### PR TITLE
Return typed arrays from `range`, `get_stack` utility functions

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -80,7 +80,7 @@
 			</description>
 		</method>
 		<method name="get_stack">
-			<return type="Array" />
+			<return type="Dictionary[]" />
 			<description>
 				Returns an array of dictionaries representing the current call stack. See also [method print_stack].
 				[codeblock]
@@ -187,7 +187,7 @@
 			</description>
 		</method>
 		<method name="range" qualifiers="vararg">
-			<return type="Array" />
+			<return type="int[]" />
 			<description>
 				Returns an array with the given range. [method range] can be called in three ways:
 				[code]range(n: int)[/code]: Starts from 0, increases by steps of 1, and stops [i]before[/i] [code]n[/code]. The argument [code]n[/code] is [b]exclusive[/b].

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -122,7 +122,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 			} break;
 			case 1: {
 				VALIDATE_ARG_NUM(0);
-				Array arr;
+				TypedArray<int64_t> arr;
 				int64_t count = *p_args[0];
 				if (count <= 0) {
 					*r_ret = arr;
@@ -153,7 +153,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 				int64_t from = *p_args[0];
 				int64_t to = *p_args[1];
 
-				Array arr;
+				TypedArray<int64_t> arr;
 				if (from >= to) {
 					*r_ret = arr;
 					return;
@@ -188,7 +188,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 					return;
 				}
 
-				Array arr;
+				TypedArray<int64_t> arr;
 				if (from >= to && incr > 0) {
 					*r_ret = arr;
 					return;
@@ -564,58 +564,38 @@ static void _register_function(const String &p_name, const MethodInfo &p_method_
 
 #define REGISTER_FUNC(m_func, m_is_const, m_return_type, ...)                                    \
 	{                                                                                            \
-		String name(#m_func);                                                                    \
-		if (name.begins_with("_")) {                                                             \
-			name = name.substr(1, name.length() - 1);                                            \
-		}                                                                                        \
-		MethodInfo info = MethodInfo(name, __VA_ARGS__);                                         \
-		info.return_val.type = m_return_type;                                                    \
+		String name = String(#m_func).trim_prefix("_");                                          \
+		MethodInfo info = MethodInfo(m_return_type, name, __VA_ARGS__);                          \
 		_register_function(name, info, GDScriptUtilityFunctionsDefinitions::m_func, m_is_const); \
 	}
 
 #define REGISTER_FUNC_NO_ARGS(m_func, m_is_const, m_return_type)                                 \
 	{                                                                                            \
-		String name(#m_func);                                                                    \
-		if (name.begins_with("_")) {                                                             \
-			name = name.substr(1, name.length() - 1);                                            \
-		}                                                                                        \
-		MethodInfo info = MethodInfo(name);                                                      \
-		info.return_val.type = m_return_type;                                                    \
+		String name = String(#m_func).trim_prefix("_");                                          \
+		MethodInfo info = MethodInfo(m_return_type, name);                                       \
 		_register_function(name, info, GDScriptUtilityFunctionsDefinitions::m_func, m_is_const); \
 	}
 
 #define REGISTER_VARARG_FUNC(m_func, m_is_const, m_return_type)                                  \
 	{                                                                                            \
-		String name(#m_func);                                                                    \
-		if (name.begins_with("_")) {                                                             \
-			name = name.substr(1, name.length() - 1);                                            \
-		}                                                                                        \
-		MethodInfo info = MethodInfo(name);                                                      \
-		info.return_val.type = m_return_type;                                                    \
+		String name = String(#m_func).trim_prefix("_");                                          \
+		MethodInfo info = MethodInfo(m_return_type, name);                                       \
 		info.flags |= METHOD_FLAG_VARARG;                                                        \
 		_register_function(name, info, GDScriptUtilityFunctionsDefinitions::m_func, m_is_const); \
 	}
 
 #define REGISTER_VARIANT_FUNC(m_func, m_is_const, ...)                                           \
 	{                                                                                            \
-		String name(#m_func);                                                                    \
-		if (name.begins_with("_")) {                                                             \
-			name = name.substr(1, name.length() - 1);                                            \
-		}                                                                                        \
-		MethodInfo info = MethodInfo(name, __VA_ARGS__);                                         \
-		info.return_val.type = Variant::NIL;                                                     \
+		String name = String(#m_func).trim_prefix("_");                                          \
+		MethodInfo info = MethodInfo(Variant::NIL, name, __VA_ARGS__);                           \
 		info.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;                                  \
 		_register_function(name, info, GDScriptUtilityFunctionsDefinitions::m_func, m_is_const); \
 	}
 
 #define REGISTER_CLASS_FUNC(m_func, m_is_const, m_return_type, ...)                              \
 	{                                                                                            \
-		String name(#m_func);                                                                    \
-		if (name.begins_with("_")) {                                                             \
-			name = name.substr(1, name.length() - 1);                                            \
-		}                                                                                        \
-		MethodInfo info = MethodInfo(name, __VA_ARGS__);                                         \
-		info.return_val.type = Variant::OBJECT;                                                  \
+		String name = String(#m_func).trim_prefix("_");                                          \
+		MethodInfo info = MethodInfo(Variant::OBJECT, name, __VA_ARGS__);                        \
 		info.return_val.hint = PROPERTY_HINT_RESOURCE_TYPE;                                      \
 		info.return_val.class_name = m_return_type;                                              \
 		_register_function(name, info, GDScriptUtilityFunctionsDefinitions::m_func, m_is_const); \
@@ -623,12 +603,8 @@ static void _register_function(const String &p_name, const MethodInfo &p_method_
 
 #define REGISTER_FUNC_DEF(m_func, m_is_const, m_default, m_return_type, ...)                     \
 	{                                                                                            \
-		String name(#m_func);                                                                    \
-		if (name.begins_with("_")) {                                                             \
-			name = name.substr(1, name.length() - 1);                                            \
-		}                                                                                        \
-		MethodInfo info = MethodInfo(name, __VA_ARGS__);                                         \
-		info.return_val.type = m_return_type;                                                    \
+		String name = String(#m_func).trim_prefix("_");                                          \
+		MethodInfo info = MethodInfo(m_return_type, name, __VA_ARGS__);                          \
 		info.default_arguments.push_back(m_default);                                             \
 		_register_function(name, info, GDScriptUtilityFunctionsDefinitions::m_func, m_is_const); \
 	}
@@ -643,14 +619,14 @@ void GDScriptUtilityFunctions::register_functions() {
 	REGISTER_VARIANT_FUNC(convert, true, VARARG("what"), ARG("type", Variant::INT));
 	REGISTER_FUNC(type_exists, true, Variant::BOOL, ARG("type", Variant::STRING_NAME));
 	REGISTER_FUNC(_char, true, Variant::STRING, ARG("char", Variant::INT));
-	REGISTER_VARARG_FUNC(range, false, Variant::ARRAY);
+	REGISTER_VARARG_FUNC(range, false, GetTypeInfo<TypedArray<int64_t>>::get_class_info());
 	REGISTER_CLASS_FUNC(load, false, "Resource", ARG("path", Variant::STRING));
 	REGISTER_FUNC(inst_to_dict, false, Variant::DICTIONARY, ARG("instance", Variant::OBJECT));
 	REGISTER_FUNC(dict_to_inst, false, Variant::OBJECT, ARG("dictionary", Variant::DICTIONARY));
 	REGISTER_FUNC_DEF(Color8, true, 255, Variant::COLOR, ARG("r8", Variant::INT), ARG("g8", Variant::INT), ARG("b8", Variant::INT), ARG("a8", Variant::INT));
 	REGISTER_VARARG_FUNC(print_debug, false, Variant::NIL);
 	REGISTER_FUNC_NO_ARGS(print_stack, false, Variant::NIL);
-	REGISTER_FUNC_NO_ARGS(get_stack, false, Variant::ARRAY);
+	REGISTER_FUNC_NO_ARGS(get_stack, false, GetTypeInfo<TypedArray<Dictionary>>::get_class_info());
 	REGISTER_FUNC(len, true, Variant::INT, VARARG("var"));
 }
 

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -122,21 +122,26 @@ struct GDScriptUtilityFunctionsDefinitions {
 			} break;
 			case 1: {
 				VALIDATE_ARG_NUM(0);
-				int count = *p_args[0];
 				Array arr;
+				int64_t count = *p_args[0];
 				if (count <= 0) {
 					*r_ret = arr;
 					return;
 				}
-				Error err = arr.resize(count);
+				if (count > (int64_t)std::numeric_limits<int>::max()) {
+					r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+					*r_ret = RTR("The given range has too many elements!");
+					return;
+				}
+				Error err = arr.resize((int)count);
 				if (err != OK) {
 					r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
-					*r_ret = Variant();
+					*r_ret = RTR("Failed to resize the array!");
 					return;
 				}
 
-				for (int i = 0; i < count; i++) {
-					arr[i] = i;
+				for (int64_t i = 0; i < count; i++) {
+					arr[(int)i] = i;
 				}
 
 				*r_ret = arr;
@@ -145,22 +150,27 @@ struct GDScriptUtilityFunctionsDefinitions {
 				VALIDATE_ARG_NUM(0);
 				VALIDATE_ARG_NUM(1);
 
-				int from = *p_args[0];
-				int to = *p_args[1];
+				int64_t from = *p_args[0];
+				int64_t to = *p_args[1];
 
 				Array arr;
 				if (from >= to) {
 					*r_ret = arr;
 					return;
 				}
-				Error err = arr.resize(to - from);
-				if (err != OK) {
+				if (to - from > (int64_t)std::numeric_limits<int>::max()) {
 					r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
-					*r_ret = Variant();
+					*r_ret = RTR("The given range has too many elements!");
 					return;
 				}
-				for (int i = from; i < to; i++) {
-					arr[i - from] = i;
+				Error err = arr.resize((int)(to - from));
+				if (err != OK) {
+					r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+					*r_ret = RTR("Failed to resize the array!");
+					return;
+				}
+				for (int64_t i = from; i < to; i++) {
+					arr[int(i - from)] = i;
 				}
 				*r_ret = arr;
 			} break;
@@ -169,9 +179,9 @@ struct GDScriptUtilityFunctionsDefinitions {
 				VALIDATE_ARG_NUM(1);
 				VALIDATE_ARG_NUM(2);
 
-				int from = *p_args[0];
-				int to = *p_args[1];
-				int incr = *p_args[2];
+				int64_t from = *p_args[0];
+				int64_t to = *p_args[1];
+				int64_t incr = *p_args[2];
 				if (incr == 0) {
 					*r_ret = RTR("Step argument is zero!");
 					r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
@@ -189,29 +199,33 @@ struct GDScriptUtilityFunctionsDefinitions {
 				}
 
 				// Calculate how many.
-				int count = 0;
+				int64_t count = 0;
 				if (incr > 0) {
 					count = ((to - from - 1) / incr) + 1;
 				} else {
 					count = ((from - to - 1) / -incr) + 1;
 				}
+				if (count > (int64_t)std::numeric_limits<int>::max()) {
+					*r_ret = arr;
+					*r_ret = RTR("The given range has too many elements!");
+					return;
+				}
 
-				Error err = arr.resize(count);
-
+				Error err = arr.resize((int)count);
 				if (err != OK) {
 					r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
-					*r_ret = Variant();
+					*r_ret = RTR("Failed to resize the array!");
 					return;
 				}
 
 				if (incr > 0) {
 					int idx = 0;
-					for (int i = from; i < to; i += incr) {
+					for (int64_t i = from; i < to; i += incr) {
 						arr[idx++] = i;
 					}
 				} else {
 					int idx = 0;
-					for (int i = from; i > to; i += incr) {
+					for (int64_t i = from; i > to; i += incr) {
 						arr[idx++] = i;
 					}
 				}


### PR DESCRIPTION
|Before (v4.0.beta2.official [f8745f2f7])|After (this PR)
|-|-|
|![CXzvmluavt](https://user-images.githubusercontent.com/9283098/194544243-be977337-5743-45f7-a207-4f9ad0b38582.png)|![godot windows editor x86_64_ZdLl6ZRLH2](https://user-images.githubusercontent.com/9283098/216684556-795b7574-6c06-48e2-a426-ff5b0a51d79c.png)|

---

The first commit ensures `range` actually works with 64-bit integers as previously it would truncate such intputs to `int`s. Of course `Array`'s (and thus `TypedArray`'s too) `resize` and `operator []` take in `int` since it's reasonable to not create arrays with 2^32 elements and more. But still, even with `range(1 << 32)` instead of truncating the input by casting to `int` it makes more sense to make it fail if it exceeds `int`'s range. In such case ~an empty array will be returned now (I haven't added any warning in such case, can be added if desired)~ _edit: I've actually made it error while rebasing but **not sure if that's wanted**_. So for example:
```gdscript
var v: int = 1 << 32
print(range(v, v + 3))
print(range(v, v + 3, 2))
print(range(v))
```
Outputs:
|Before (v4.0.beta17.official [c40020513])|After (this PR)
|-|-|
|`[0, 1, 2]`<br>`[0, 2]`<br>`[]`|<br>`[4294967296, 4294967297, 4294967298]`<br>`[4294967296, 4294967298]`<br>Error calling GDScript utility function '\<unknown function\>': The given range has too many elements!|

The last one is empty (before) because it's truncated to `int` and thus equivalent to `range(0)`.

### Known issues:

- When `range` is used in a `for` loop and `range`'s arguments are constant it's being optimized to not generate an actual array (just loop directly). In case of such optimization arguments are truncated/casted to 32-bit integers. Meaning:
```gdscript
print(range(1 << 32, (1 << 32) + 3, 2))
for i in range(1 << 32, (1 << 32) + 3, 2):
	print(i)
```
would print:
```
[4294967296, 4294967298]
0
2
```

---

The second commit actually changes the return types to typed arrays. I've simplified some already existing macros by using the fact that `MethodInfo` already has a bunch of constructors among which many differ only in the first argument being either `Variant::Type` or `const PropertyInfo&`. This argument tells what the return type is. These macros were used by passing a variant type for the return type, now the passed in return type can also be a `PropertyInfo`. And relevant `PropertyInfo` can be obtained for `TypedArray<T>` from `GetTypeInfo<TypedArray<T>>::get_class_info()`.

* _Production edit:_ Closes #72762
* _Bugsquad edit:_ Closes godotengine/godot-proposals#9277