### PR TITLE
C#: Cleanup and sync StringExtensions with core

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -414,21 +414,6 @@ namespace Godot.NativeInterop
 
         // StringExtensions
 
-        public static partial void godotsharp_string_md5_buffer(in godot_string p_self,
-            out godot_packed_byte_array r_md5_buffer);
-
-        public static partial void godotsharp_string_md5_text(in godot_string p_self, out godot_string r_md5_text);
-
-        public static partial int godotsharp_string_rfind(in godot_string p_self, in godot_string p_what, int p_from);
-
-        public static partial int godotsharp_string_rfindn(in godot_string p_self, in godot_string p_what, int p_from);
-
-        public static partial void godotsharp_string_sha256_buffer(in godot_string p_self,
-            out godot_packed_byte_array r_sha256_buffer);
-
-        public static partial void godotsharp_string_sha256_text(in godot_string p_self,
-            out godot_string r_sha256_text);
-
         public static partial void godotsharp_string_simplify_path(in godot_string p_self,
             out godot_string r_simplified_path);
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -75,6 +75,7 @@ namespace Godot
         /// <param name="instance">The string to check.</param>
         /// <param name="text">The beginning string.</param>
         /// <returns>If the string begins with the given string.</returns>
+        [Obsolete("Use string.StartsWith instead.")]
         public static bool BeginsWith(this string instance, string text)
         {
             return instance.StartsWith(text);
@@ -500,18 +501,6 @@ namespace Godot
                     toIndex++;
                 }
             }
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the strings ends
-        /// with the given string <paramref name="text"/>.
-        /// </summary>
-        /// <param name="instance">The string to check.</param>
-        /// <param name="text">The ending string.</param>
-        /// <returns>If the string ends with the given string.</returns>
-        public static bool EndsWith(this string instance, string text)
-        {
-            return instance.EndsWith(text);
         }
 
         /// <summary>
@@ -1210,19 +1199,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Formats a string to be at least <paramref name="minLength"/> long by
-        /// adding <paramref name="character"/>s to the left of the string.
-        /// </summary>
-        /// <param name="instance">String that will be padded.</param>
-        /// <param name="minLength">Minimum length that the resulting string must have.</param>
-        /// <param name="character">Character to add to the left of the string.</param>
-        /// <returns>String padded with the specified character.</returns>
-        public static string LPad(this string instance, int minLength, char character = ' ')
-        {
-            return instance.PadLeft(minLength, character);
-        }
-
-        /// <summary>
         /// Returns a copy of the string with characters removed from the left.
         /// The <paramref name="chars"/> argument is a string specifying the set of characters
         /// to be removed.
@@ -1233,6 +1209,7 @@ namespace Godot
         /// <param name="instance">The string to remove characters from.</param>
         /// <param name="chars">The characters to be removed.</param>
         /// <returns>A copy of the string with characters removed from the left.</returns>
+        [Obsolete("Use string.TrimStart instead.")]
         public static string LStrip(this string instance, string chars)
         {
             return instance.TrimStart(chars.ToCharArray());
@@ -1527,19 +1504,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Formats a string to be at least <paramref name="minLength"/> long by
-        /// adding <paramref name="character"/>s to the right of the string.
-        /// </summary>
-        /// <param name="instance">String that will be padded.</param>
-        /// <param name="minLength">Minimum length that the resulting string must have.</param>
-        /// <param name="character">Character to add to the right of the string.</param>
-        /// <returns>String padded with the specified character.</returns>
-        public static string RPad(this string instance, int minLength, char character = ' ')
-        {
-            return instance.PadRight(minLength, character);
-        }
-
-        /// <summary>
         /// Returns a copy of the string with characters removed from the right.
         /// The <paramref name="chars"/> argument is a string specifying the set of characters
         /// to be removed.
@@ -1550,6 +1514,7 @@ namespace Godot
         /// <param name="instance">The string to remove characters from.</param>
         /// <param name="chars">The characters to be removed.</param>
         /// <returns>A copy of the string with characters removed from the right.</returns>
+        [Obsolete("Use string.TrimEnd instead.")]
         public static string RStrip(this string instance, string chars)
         {
             return instance.TrimEnd(chars.ToCharArray());
@@ -1883,17 +1848,6 @@ namespace Godot
                 return instance.Substring(0, instance.Length - suffix.Length);
 
             return instance;
-        }
-
-        /// <summary>
-        /// Returns the character code at position <paramref name="at"/>.
-        /// </summary>
-        /// <param name="instance">The string to check.</param>
-        /// <param name="at">The position int the string for the character to check.</param>
-        /// <returns>The character code.</returns>
-        public static int UnicodeAt(this string instance, int at)
-        {
-            return instance[at];
         }
 
         /// <summary>

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -1067,30 +1067,6 @@ void godotsharp_dictionary_to_string(const Dictionary *p_self, String *r_str) {
 	*r_str = Variant(*p_self).operator String();
 }
 
-void godotsharp_string_md5_buffer(const String *p_self, PackedByteArray *r_md5_buffer) {
-	memnew_placement(r_md5_buffer, PackedByteArray(p_self->md5_buffer()));
-}
-
-void godotsharp_string_md5_text(const String *p_self, String *r_md5_text) {
-	memnew_placement(r_md5_text, String(p_self->md5_text()));
-}
-
-int32_t godotsharp_string_rfind(const String *p_self, const String *p_what, int32_t p_from) {
-	return p_self->rfind(*p_what, p_from);
-}
-
-int32_t godotsharp_string_rfindn(const String *p_self, const String *p_what, int32_t p_from) {
-	return p_self->rfindn(*p_what, p_from);
-}
-
-void godotsharp_string_sha256_buffer(const String *p_self, PackedByteArray *r_sha256_buffer) {
-	memnew_placement(r_sha256_buffer, PackedByteArray(p_self->sha256_buffer()));
-}
-
-void godotsharp_string_sha256_text(const String *p_self, String *r_sha256_text) {
-	memnew_placement(r_sha256_text, String(p_self->sha256_text()));
-}
-
 void godotsharp_string_simplify_path(const String *p_self, String *r_simplified_path) {
 	memnew_placement(r_simplified_path, String(p_self->simplify_path()));
 }
@@ -1473,12 +1449,6 @@ static const void *unmanaged_callbacks[]{
 	(void *)godotsharp_dictionary_duplicate,
 	(void *)godotsharp_dictionary_remove_key,
 	(void *)godotsharp_dictionary_to_string,
-	(void *)godotsharp_string_md5_buffer,
-	(void *)godotsharp_string_md5_text,
-	(void *)godotsharp_string_rfind,
-	(void *)godotsharp_string_rfindn,
-	(void *)godotsharp_string_sha256_buffer,
-	(void *)godotsharp_string_sha256_text,
 	(void *)godotsharp_string_simplify_path,
 	(void *)godotsharp_string_to_camel_case,
 	(void *)godotsharp_string_to_pascal_case,


### PR DESCRIPTION
I started with the intention of creating separate commits and maybe creating separate PRs but I kind of gave up half way because all of these changes end up being related to each other in one way or another and I don't think it was useful to keep them separated but I can extract some of the simpler less-controversial changes into smaller PRs if that's preferred.

## Changes

- Moved `GetBaseName` to keep methods alphabetically sorted.
- Removed `Length`, users should just use the Length property.
- Removed `Insert`, string already has a method with the same signature that takes precedence.
- Removed `ToLower` and `ToUpper`, string already has methods with the same signature that take precedence.
- Deprecated `BeginsWith` in favor of `string.StartsWith`.
- Removed `EndsWith`, string already has a method with the same signature that take precedence.
- Removed `FindLast` in favor of `RFind` (https://github.com/godotengine/godot/pull/40092).
- Replaced `RFind` and `RFindN` implementation with a call to `string.LastIndexOf` to avoid marshaling (this fixes a bug caused by using the wrong parameter in the NativeFuncs call).
- ~~Added `LPad` and `RPad` (https://github.com/godotengine/godot/pull/40999)~~.
- Added `StripEscapes` (https://github.com/godotengine/godot/pull/29347).
- Replaced `LStrip` and `RStrip` implementation with a call to `string.TrimStart` and `string.TrimEnd`.
- Deprecated `LStrip` and `RStrip` in favor of `string.TrimStart` and `string.TrimEnd`.
- Added `TrimPrefix` and `TrimSuffix` (https://github.com/godotengine/godot/pull/18176).
- Removed `Erase` (https://github.com/godotengine/godot/pull/54869 and https://github.com/godotengine/godot/pull/64714).
- ~~Renamed `OrdAt` to `UnicodeAt` (https://github.com/godotengine/godot/pull/43790)~~.
- Removes `OrdAt`/`UnicodeAt` in favor of the string indexer.
- Added `IsValidFileName` (https://github.com/godotengine/godot/commit/a20235aeb02c0c9e5ce58c0236f88a19865d571c).
- Added `IsValidHexNumber` (https://github.com/godotengine/godot/pull/24586).
- Renamed `IsValidInteger` to `IsValidInt` (https://github.com/godotengine/godot/pull/49659).
- Added support for IPv6 to `IsValidIPAddress` (https://github.com/godotengine/godot/pull/6925).
- Added `ValidateNodeName` (https://github.com/godotengine/godot/pull/45545).
- Updated the documentation of the `IsValid*` methods.
- Replaced `MD5Buffer`, `MD5Text`, `SHA256Buffer` and `SHA256Text` implementation to use the `System.Security.Cryptography` classes and avoid marshaling.
- Added `SHA1Buffer` and `SHA1Text` (https://github.com/godotengine/godot/pull/30263).
- Renamed `ToUTF8` to `ToUTF8Buffer` (https://github.com/godotengine/godot/pull/42780).
- Renamed `ToAscii` to `ToASCIIBuffer` (https://github.com/godotengine/godot/pull/42780).
- Added `ToUTF16Buffer` and `ToUTF32Buffer` (https://github.com/godotengine/godot/pull/40999 and https://github.com/godotengine/godot/pull/42780).
- Added `GetStringFromUTF16` and `GetStringFromUTF32` (https://github.com/godotengine/godot/pull/40999).
- Added `Dedent` (https://github.com/godotengine/godot/pull/12025).
- Added `Indent` (https://github.com/godotengine/godot/pull/55930).
- Added `CountN` (also moved the `caseSensitive` parameter in `Count` to follow the same pattern used by other methods that have an alt `N` method where the `caseSensitive` parameter is at the end) (https://github.com/godotengine/godot/pull/25090).
    - All methods that end with `N` could be removed since their "overloads" that don't end with `N` already have an optional `caseSensitive` parameter (this seems to be @neikeq's preference as well, see https://github.com/godotengine/godot/pull/25090#discussion_r272846351) but since we already have many methods with an `N` "overload" I decided to follow the established pattern.

## Methods to consider removing

Adding extension methods can pollute the type so we should consider if the methods we add are really useful or necessary. Many of the existing methods don't add much and their behavior can be achieved with a similar one-liner using the methods provided by the BCL. Often we add methods that already exist in the BCL with a different name, this means IntelliSense will show multiple methods with very similar names and that can be confusing to users. I think it would be better to avoid providing those methods and instead recommend users to use the existing APIs which would also benefit from existing analyzers provided by Microsoft or third-party libraries that understand the existing BCL APIs and can warn users of potential incorrect or non-optimal usage.

- `UnicodeAt` since it's just a wrapper over the indexer `string[int index]`.
- `BeginsWith` and `EndsWith` since they're just a wrapper over `string.StartsWith` and `string.EndsWith`.
    - It can be confusing for users when there are multiple methods with a very similar name.
    - Also, `EndsWith` has the same signature as `string.EndsWith` and the instance method takes precedence so it's already unused.
- `Split` since it's just a wrapper over `string.Split`.
- `Substr` since it's just a wrapper over `string.Substring`.
- `Hash` since users should probably use `string.GetHashCode` instead.
- `Find`, `FindN`, `RFind` and `RFindN` since they're just wrappers over `string.IndexOf` and `string.LastIndexOf`.
- `CasecmpTo`, `NocasecmpTo` and `CompareTo`, users should probably use `string.Equals` and `string.Compare` both of which take a `StringComparison` parameter that allows specifying the culture and case sensitivity.
- `LPad` and `RPad` since they are just wrappers over `string.PadLeft` and `string.PadRight`.
- `LStrip` and `RStrip` since they are just wrappers over `string.TrimStart` and `string.TrimEnd`.
- `TrimPrefix` and `TrimSuffix` in a future .NET version where `RemovePrefix` and `RemoveSuffix` may be added (https://github.com/dotnet/runtime/issues/14386).
- `IsValidFloat` and `IsValidInt` since they're just wrappers over `float.TryParse` and `int.TryParse`.
- `ToUTF8Buffer`, `ToUTF16Buffer`, `ToUTF32Buffer`, `ToASCIIBuffer`, `GetStringFromUTF8`, `GetStringFromUTF16`, `GetStringFromUTF32` and `GetStringFromASCII` since they are just wrappers over `System.Text.Encoding`.
- `SHA1Buffer`, `SHA1Text`, `SHA256Buffer`, `SHA256Text`, `MD5Buffer` and `MD5Text` since they are just wrappers over `System.Security.Cryptography` classes (and using our methods hides [CA5350](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca5350) and [CA5351](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca5351)).

## Methods not added

These methods are exposed in GDScript but don't currently exist in StringExtensions and haven't been added/exposed in this PR, we could add them in a future PR if we consider them useful.

- `humanize_size` because it's a static method and it takes an int. (https://github.com/godotengine/godot/pull/32546).
- `get_slice`, `get_slice_count` and `get_slicec`.
    - `GetSliceCount` is already implemented because it's used in `Capitalize` but not exposed.
    - `GetSliceCharacter` implements `get_slicec` because it's used in `Capitalize` but it's not exposed.
- `num`, `num_int64`, `num_scientific` and `num_uint64` because users should use `ToString` and/or `IFormattable`.
- `naturalnocasecmp_to`
- `rsplit` because we also don't really implement `split` with the same behavior as GDScript.
- `repeat` because users should probably use the string constructor or StringBuilder.