### PR TITLE
Fix signature for `folder_moved` signal of `FileSystemDock`

### DIFF
--- a/doc/classes/FileSystemDock.xml
+++ b/doc/classes/FileSystemDock.xml
@@ -32,7 +32,7 @@
 		</signal>
 		<signal name="folder_moved">
 			<param index="0" name="old_folder" type="String" />
-			<param index="1" name="new_file" type="String" />
+			<param index="1" name="new_folder" type="String" />
 			<description>
 			</description>
 		</signal>

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2994,7 +2994,7 @@ void FileSystemDock::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("file_removed", PropertyInfo(Variant::STRING, "file")));
 	ADD_SIGNAL(MethodInfo("folder_removed", PropertyInfo(Variant::STRING, "folder")));
 	ADD_SIGNAL(MethodInfo("files_moved", PropertyInfo(Variant::STRING, "old_file"), PropertyInfo(Variant::STRING, "new_file")));
-	ADD_SIGNAL(MethodInfo("folder_moved", PropertyInfo(Variant::STRING, "old_folder"), PropertyInfo(Variant::STRING, "new_file")));
+	ADD_SIGNAL(MethodInfo("folder_moved", PropertyInfo(Variant::STRING, "old_folder"), PropertyInfo(Variant::STRING, "new_folder")));
 
 	ADD_SIGNAL(MethodInfo("display_mode_changed"));
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Issue #66990

## What I Did

Changed the signature for `folder_moved` signal in [`editor/filesystem_dock.cpp`](https://github.com/godotengine/godot/compare/master...mateuseap:godot:master#diff-5cfc95a5fb43c0bf71052045ddce94275819d0173bc0c2c7fcd667ffe2568ce2) file;
Updated the [`doc/classes/FileSystemDock.xml`](https://github.com/godotengine/godot/compare/master...mateuseap:godot:master#diff-bdfabbd7769e2d1b79416778c2bba9e7c100de97375653fd6da16321d12863e7) file to match the new signature for `folder_moved`.

*Bugsquad edit:*
- Fixes #66990.