### PR TITLE
Fix material overlay overriding shadow casting logic

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3862,7 +3862,7 @@ void RendererSceneCull::_update_dirty_instance(Instance *p_instance) {
 			}
 
 			if (p_instance->material_overlay.is_valid()) {
-				can_cast_shadows = can_cast_shadows || RSG::material_storage->material_casts_shadows(p_instance->material_overlay);
+				can_cast_shadows = can_cast_shadows && RSG::material_storage->material_casts_shadows(p_instance->material_overlay);
 				is_animated = is_animated || RSG::material_storage->material_is_animated(p_instance->material_overlay);
 				_update_instance_shader_uniforms_from_material(isparams, p_instance->instance_shader_uniforms, p_instance->material_overlay);
 			}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/67014

Material overlay should only cast a shadow if it can cast a shadow and the instance can cast a shadow

The old logic essentially override ``can_cast_shadows`` so the visual instance cast shadows even when it was disabled on the instance level. ``material_casts_shadows()`` is supposed to return true if a material _can_ cast shadows, it shouldn't be used to force shadows on an object that has them disabled. 

Going through this code I notice some significant other problems with the logic that I will improve in a later PR. For example, ``material_casts_shadows()`` always returns true so most of the ``can_cast_shadow`` logic gets ignored.