### PR TITLE
Fix bug in setting custom cursor on web

### DIFF
--- a/platform/web/js/libs/library_godot_display.js
+++ b/platform/web/js/libs/library_godot_display.js
@@ -174,7 +174,7 @@ const GodotDisplayCursor = {
 	$GodotDisplayCursor__deps: ['$GodotOS', '$GodotConfig'],
 	$GodotDisplayCursor__postset: 'GodotOS.atexit(function(resolve, reject) { GodotDisplayCursor.clear(); resolve(); });',
 	$GodotDisplayCursor: {
-		shape: 'auto',
+		shape: 'default',
 		visible: true,
 		cursors: {},
 		set_style: function (style) {
@@ -185,7 +185,7 @@ const GodotDisplayCursor = {
 			let css = shape;
 			if (shape in GodotDisplayCursor.cursors) {
 				const c = GodotDisplayCursor.cursors[shape];
-				css = `url("${c.url}") ${c.x} ${c.y}, auto`;
+				css = `url("${c.url}") ${c.x} ${c.y}, default`;
 			}
 			if (GodotDisplayCursor.visible) {
 				GodotDisplayCursor.set_style(css);
@@ -193,7 +193,7 @@ const GodotDisplayCursor = {
 		},
 		clear: function () {
 			GodotDisplayCursor.set_style('');
-			GodotDisplayCursor.shape = 'auto';
+			GodotDisplayCursor.shape = 'default';
 			GodotDisplayCursor.visible = true;
 			Object.keys(GodotDisplayCursor.cursors).forEach(function (key) {
 				URL.revokeObjectURL(GodotDisplayCursor.cursors[key]);


### PR DESCRIPTION
This [commit](https://github.com/godotengine/godot/commit/7e43fb6ad28dbd3d1c79acc02f43112bf56534b3) introduced a regression where the cursor wouldnt update until it was set to something different than the default.

Change auto to default in cursor css settings.

3.x version: https://github.com/godotengine/godot/pull/67044