### PR TITLE
Fix invalid tooltip position

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1265,7 +1265,12 @@ void Viewport::_gui_show_tooltip() {
 	Rect2 r(gui.tooltip_pos + tooltip_offset, gui.tooltip_popup->get_contents_minimum_size());
 
 	Window *window = gui.tooltip_popup->get_parent_visible_window();
-	Rect2i vr = window->get_usable_parent_rect();
+	Rect2i vr;
+	if (gui.tooltip_popup->is_embedded()) {
+		vr = gui.tooltip_popup->_get_embedder()->get_visible_rect();
+	} else {
+		vr = window->get_usable_parent_rect();
+	}
 
 	if (r.size.x + r.position.x > vr.size.x + vr.position.x) {
 		// Place it in the opposite direction. If it fails, just hug the border.


### PR DESCRIPTION
Fixes #66477. Tooltips would get clipped when close to the window's right edge, instead of being pushed to the left. This also fixes tooltips not appearing at all when the window is on a monitor other than the first one (also applies to the editor when in single window mode).