### PR TITLE
Allow clearing backbuffer after finishing CanvasGroup

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -300,6 +300,8 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 			}
 
 			canvas_group_owner = nullptr;
+			// Backbuffer is dirty now and needs to be re-cleared if another CanvasGroup needs it.
+			backbuffer_cleared = false;
 		}
 
 		if (backbuffer_copy) {

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1475,6 +1475,8 @@ void RendererCanvasRenderRD::canvas_render_items(RID p_to_render_target, Item *p
 			}
 
 			canvas_group_owner = nullptr;
+			// Backbuffer is dirty now and needs to be re-cleared if another CanvasGroup needs it.
+			backbuffer_cleared = false;
 		}
 
 		if (backbuffer_copy) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/60301#issuecomment-1272081786

Previously we would mark the backbuffer as having been cleared once it was cleared so we wouldn't have to clear it multiple times. But we need to clear it multiple times if we are going to reuse it for a subsequent CanvasGroup. 

This PR fixes the bug by resetting the ``backbuffer_cleared`` bool once a CanvasGroup has finished drawing flagging that the backbuffer can be cleared again if needed. 

_Before:_

![Screenshot from 2022-10-07 14-14-41](https://user-images.githubusercontent.com/16521339/194654588-aa096c5a-39ce-48a6-92db-e3279e66b316.png)


_After:_

![Screenshot from 2022-10-07 14-14-06](https://user-images.githubusercontent.com/16521339/194654595-38c730a5-370b-46ef-893b-c72525e6196f.png)

