### PR TITLE
Area3D: declare "_validate_property" as protected

### DIFF
--- a/scene/3d/area_3d.h
+++ b/scene/3d/area_3d.h
@@ -141,13 +141,12 @@ private:
 	float reverb_amount = 0.0;
 	float reverb_uniformity = 0.0;
 
-	void _validate_property(PropertyInfo &p_property) const;
-
 	void _initialize_wind();
 
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_gravity_space_override_mode(SpaceOverride p_mode);


### PR DESCRIPTION
In other classes, the function _validate_property is declared as protected (in the case of Area2D), but in Area3D it's declared as private, which causes compile errors when trying to extend the class in a C++ module for example.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
