### PR TITLE
Document `Array.sort()` and `sort_custom()` using unstable sorting

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -557,6 +557,7 @@
 			<return type="void" />
 			<description>
 				Sorts the array.
+				[b]Note:[/b] The sorting algorithm used is not [url=https://en.wikipedia.org/wiki/Sorting_algorithm#Stability]stable[/url]. This means that values considered equal may have their order changed when using [method sort].
 				[b]Note:[/b] Strings are sorted in alphabetical order (as opposed to natural order). This may lead to unexpected behavior when sorting an array of strings ending with a sequence of numbers. Consider the following example:
 				[codeblocks]
 				[gdscript]
@@ -581,7 +582,8 @@
 			<param index="0" name="func" type="Callable" />
 			<description>
 				Sorts the array using a custom method. The custom method receives two arguments (a pair of elements from the array) and must return either [code]true[/code] or [code]false[/code]. For two elements [code]a[/code] and [code]b[/code], if the given method returns [code]true[/code], element [code]b[/code] will be after element [code]a[/code] in the array.
-				[b]Note:[/b] You cannot randomize the return value as the heapsort algorithm expects a deterministic result. Doing so will result in unexpected behavior.
+				[b]Note:[/b] The sorting algorithm used is not [url=https://en.wikipedia.org/wiki/Sorting_algorithm#Stability]stable[/url]. This means that values considered equal may have their order changed when using [method sort_custom].
+				[b]Note:[/b] You cannot randomize the return value as the heapsort algorithm expects a deterministic result. Randomizing the return value will result in unexpected behavior.
 				[codeblocks]
 				[gdscript]
 				func sort_ascending(a, b):


### PR DESCRIPTION
I didn't add a mention to Packed\*Array's `sort()`, as I'm not sure if the algorithm being unstable has any consequences there.

This closes https://github.com/godotengine/godot-docs/issues/6278. See https://github.com/godotengine/godot-proposals/issues/5552.