### PR TITLE
Bind `AnimationTrackEditor::_redraw_tracks` for UndoRedo

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -6458,6 +6458,7 @@ void AnimationTrackEditor::_select_all_tracks_for_copy() {
 void AnimationTrackEditor::_bind_methods() {
 	ClassDB::bind_method("_animation_update", &AnimationTrackEditor::_animation_update);
 	ClassDB::bind_method("_track_grab_focus", &AnimationTrackEditor::_track_grab_focus);
+	ClassDB::bind_method("_redraw_tracks", &AnimationTrackEditor::_redraw_tracks);
 	ClassDB::bind_method("_clear_selection_for_anim", &AnimationTrackEditor::_clear_selection_for_anim);
 	ClassDB::bind_method("_select_at_anim", &AnimationTrackEditor::_select_at_anim);
 	ClassDB::bind_method("_clear_selection", &AnimationTrackEditor::_clear_selection);


### PR DESCRIPTION
Fixes #67064

The method was mistakenly unbind in #44143