### PR TITLE
Rewrite most of Resource's documentation

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2803,6 +2803,7 @@
 		<constant name="PROPERTY_USAGE_INTERNAL" value="524288" enum="PropertyUsageFlags">
 		</constant>
 		<constant name="PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE" value="1048576" enum="PropertyUsageFlags">
+			If the property is a [Resource], a new copy of it is always created when calling [method Node.duplicate] or [method Resource.duplicate].
 		</constant>
 		<constant name="PROPERTY_USAGE_HIGH_END_GFX" value="2097152" enum="PropertyUsageFlags">
 		</constant>

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -4,7 +4,8 @@
 		Base class for all resources.
 	</brief_description>
 	<description>
-		Resource is the base class for all Godot-specific resource types, serving primarily as data containers. Since they inherit from [RefCounted], resources are reference-counted and freed when no longer in use. They are also cached once loaded from disk, so that any further attempts to load a resource from a given path will return the same reference (all this in contrast to a [Node], which is not reference-counted and can be instantiated from disk as many times as desired). Resources can be saved externally on disk or bundled into another object, such as a [Node] or another resource.
+		Resource is the base class for all Godot-specific resource types, serving primarily as data containers. Since they inherit from [RefCounted], resources are reference-counted and freed when no longer in use. They can also be nested within other resources, and saved on disk. Once loaded from disk, further attempts to load a resource by [member resource_path] returns the same reference. [PackedScene], one of the most common [Object]s in a Godot project, is also a resource, uniquely capable of storing and instantiating the [Node]s it contains as many times as desired.
+		In GDScript, resources can loaded from disk by their [member resource_path] using [method @GDScript.load] or [method @GDScript.preload].
 		[b]Note:[/b] In C#, resources will not be freed instantly after they are no longer in use. Instead, garbage collection will run periodically and will free resources that are no longer in use. This means that unused resources will linger on for a while before being removed.
 	</description>
 	<tutorials>
@@ -15,77 +16,94 @@
 		<method name="_get_rid" qualifiers="virtual">
 			<return type="RID" />
 			<description>
+				Override this method to return a custom [RID] when [method get_rid] is called.
 			</description>
 		</method>
 		<method name="duplicate" qualifiers="const">
 			<return type="Resource" />
 			<param index="0" name="subresources" type="bool" default="false" />
 			<description>
-				Duplicates the resource, returning a new resource with the exported members copied. [b]Note:[/b] To duplicate the resource the constructor is called without arguments. This method will error when the constructor doesn't have default values.
-				By default, sub-resources are shared between resource copies for efficiency. This can be changed by passing [code]true[/code] to the [param subresources] argument which will copy the subresources.
-				[b]Note:[/b] If [param subresources] is [code]true[/code], this method will only perform a shallow copy. Nested resources within subresources will not be duplicated and will still be shared.
-				[b]Note:[/b] When duplicating a resource, only [code]export[/code]ed properties are copied. Other properties will be set to their default value in the new resource.
+				Duplicates this resource, returning a new resource with its [code]export[/code]ed or [constant PROPERTY_USAGE_STORAGE] properties copied from the original.
+				If [param subresources] is [code]false[/code], a shallow copy is returned. Nested resources within subresources are not duplicated and are shared from the original resource. This behavior can be overriden by the [constant PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE] flag.
+				[b]Note:[/b] For custom resources, this method will fail if [method Object._init] has been defined with required parameters.
 			</description>
 		</method>
 		<method name="emit_changed">
 			<return type="void" />
 			<description>
-				Emits the [signal changed] signal.
-				If external objects which depend on this resource should be updated, this method must be called manually whenever the state of this resource has changed (such as modification of properties).
-				The method is equivalent to:
+				Emits the [signal changed] signal. This method is called automatically for built-in resources.
+				[b]Note:[/b] For custom resources, it's recommended to call this method whenever a meaningful change occurs, such as a modified property. This ensures that custom [Object]s depending on the resource are properly updated.
 				[codeblock]
-				emit_signal("changed")
+				var damage:
+				    set(new_value):
+				        if damage != new_value:
+				            damage = new_value
+				            emit_changed()
 				[/codeblock]
-				[b]Note:[/b] This method is called automatically for built-in resources.
 			</description>
 		</method>
 		<method name="get_local_scene" qualifiers="const">
 			<return type="Node" />
 			<description>
-				If [member resource_local_to_scene] is enabled and the resource was loaded from a [PackedScene] instantiation, returns the local scene where this resource's unique copy is in use. Otherwise, returns [code]null[/code].
+				If [member resource_local_to_scene] is set to [code]true[/code] and the resource has been loaded from a [PackedScene] instantiation, returns the root [Node] of the scene where this resource is used. Otherwise, returns [code]null[/code].
 			</description>
 		</method>
 		<method name="get_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the RID of the resource (or an empty RID). Many resources (such as [Texture2D], [Mesh], etc) are high-level abstractions of resources stored in a server, so this function will return the original RID.
+				Returns the [RID] of this resource (or an empty RID). Many resources (such as [Texture2D], [Mesh], and so on) are high-level abstractions of resources stored in a specialised server ([DisplayServer], [RenderingServer], etc.), so this function will return the original [RID].
 			</description>
 		</method>
 		<method name="setup_local_to_scene">
 			<return type="void" />
 			<description>
-				This method is called when a resource with [member resource_local_to_scene] enabled is loaded from a [PackedScene] instantiation. Its behavior can be customized by connecting [signal setup_local_to_scene_requested] from script.
-				For most resources, this method performs no base logic. [ViewportTexture] performs custom logic to properly set the proxy texture and flags in the local viewport.
+				Emits the [signal setup_local_to_scene_requested] signal. If [member resource_local_to_scene] is set to [code]true[/code], this method is called from [method PackedScene.instantiate] by the newly duplicated resource within the scene instance.
+				For most resources, this method performs no logic of its own. Custom behavior can be defined by connecting [signal setup_local_to_scene_requested] from a script, [b]not[/b] by overriding this method.
+				[b]Example:[/b] Assign a random value to [code]health[/code] for every duplicated Resource from an instantiated scene, excluding the original.
+				[codeblock]
+				extends Resource
+
+				var health = 0
+
+				func _init():
+				    setup_local_to_scene_requested.connect(randomize_health)
+
+				func randomize_health():
+				    health = randi_range(10, 40)
+				[/codeblock]
 			</description>
 		</method>
 		<method name="take_over_path">
 			<return type="void" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Sets the path of the resource, potentially overriding an existing cache entry for this path. This differs from setting [member resource_path], as the latter would error out if another resource was already cached for the given path.
+				Sets the [member resource_path] to [param path], potentially overriding an existing cache entry for this path. Further attempts to load an overridden resource by path will instead return this resource.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" default="false">
-			If [code]true[/code], the resource will be made unique in each instance of its local scene. It can thus be modified in a scene instance without impacting other instances of that same scene.
+			If [code]true[/code], the resource is duplicated for each instance of all scenes using it. At run-time, the resource can be modified in one scene without affecting other instances (see [method PackedScene.instantiate]).
+			[b]Note:[/b] Changing this property at run-time has no effect on already created duplicate resources.
 		</member>
 		<member name="resource_name" type="String" setter="set_name" getter="get_name" default="&quot;&quot;">
-			The name of the resource. This is an optional identifier. If [member resource_name] is not empty, its value will be displayed to represent the current resource in the editor inspector. For built-in scripts, the [member resource_name] will be displayed as the tab name in the script editor.
+			An optional name for this resource. When defined, its value is displayed to represent the resource in the Inspector dock. For built-in scripts, the name is displayed as part of the tab name in the script editor.
 		</member>
 		<member name="resource_path" type="String" setter="set_path" getter="get_path" default="&quot;&quot;">
-			The path to the resource. In case it has its own file, it will return its filepath. If it's tied to the scene, it will return the scene's path, followed by the resource's index.
+			The unique path to this resource. If it has been saved to disk, the value will be its filepath. If the resource is exclusively contained within a scene, the value will be the [PackedScene]'s filepath, followed by an unique identifier.
+			[b]Note:[/b] Setting this property manually may fail if a resource with the same path has already been previously loaded. If necessary, use [method take_over_path].
 		</member>
 	</members>
 	<signals>
 		<signal name="changed">
 			<description>
-				Emitted whenever the resource changes.
-				[b]Note:[/b] This signal is not emitted automatically for custom resources, which means that you need to create a setter and emit the signal yourself.
+				Emitted when the resource changes, usually when one of its properties is modified. See also [method emit_changed].
+				[b]Note:[/b] This signal is not emitted automatically for properties of custom resources. If necessary, a setter needs to be created to emit the signal.
 			</description>
 		</signal>
 		<signal name="setup_local_to_scene_requested">
 			<description>
+				Emitted when [method setup_local_to_scene] is called, usually by a newly duplicated resource with [member resource_local_to_scene] set to [code]true[/code]. Custom behavior can be defined by connecting this signal.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/ViewportTexture.xml
+++ b/doc/classes/ViewportTexture.xml
@@ -6,6 +6,7 @@
 	<description>
 		Displays the content of a [Viewport] node as a dynamic [Texture2D]. This can be used to mix controls, 2D, and 3D elements in the same scene.
 		To create a ViewportTexture in code, use the [method Viewport.get_texture] method on the target viewport.
+		[b]Note:[/b] When local to scene, this texture uses [method Resource.setup_local_to_scene] to set the proxy texture and flags in the local viewport.
 	</description>
 	<tutorials>
 		<link title="GUI in 3D Demo">https://godotengine.org/asset-library/asset/127</link>


### PR DESCRIPTION
I swear, I *totally* didn't spend 2 days on this PR, which touches up a lot of **Resource**'s documentation. Despite being a very important class, it was smelling **very** old, at least to me. And I was angry.

The documentation has been "modernised", based on the way other classes are written (especially **Node**). I personally verified many concepts extensively, by looking at the source code and through testing. The changes are so numerous that it's difficult to summarise them all without calling them "improvements".

##### Do note that whenever I say "_user_" or "_users_", I do mean the average, possibly a bit inexperienced person, learning the engine.

### The most notable changes and their reasoning include:
- `duplicate` has been shortened and corrected. 
    - Despite being such a simple concept, the description felt compelled to convolute the basic functionality of the very vague parameter name. So much, in fact, that [it may have been entirely wrong](https://github.com/godotengine/godot/pull/65374#issuecomment-1269960135).

- Point out that `resource_local_to_scene` duplicates the original resource at run-time. 
   - This is what happens behind the _s c e n e s_. Let's not pretend it's not the case by attempting to introduce a "local"/"global" concept to it. Otherwise, users may think that changing the original **Resource** also affects the "local" **Resource**s at run-time.
- Added a more accurate explanation to `setup_local_to_scene` and given an example. 

   - I don't know why this method is exposed, but it was very vague before. When was the method called by the engine? What resource called the method _(original Resource or its duplicate)_? It probably could be shortened, but it needs to be more accurate and verbose, because the user is also able to call it. As simple as it is, they need to know what it does. 
    - Honestly, this is the method I spent the most hours on, attempting so many iterations to explain the same concept, and that is not a good sign to me. https://github.com/godotengine/godot/pull/67082
    
- Moved that one note of what **ViewportTexture** does in `setup_local_to_scene` to **ViewportTexture** itself. 
   - Most users do not care about this, nor they need to. In fact, I would've removed it outright, but because the method is exposed, users _need to know_ it is happening.
   
- Added more details and a simple example for using `emit_changed`.
   - It was missing, despite being part of the common workflow.


I'm aware this is touchy. Feedback is very, very welcome. 