### PR TITLE
Don't allow removing `TextEdit`'s main caret

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4380,7 +4380,7 @@ int TextEdit::add_caret(int p_line, int p_col) {
 }
 
 void TextEdit::remove_caret(int p_caret) {
-	ERR_FAIL_COND(carets.size() <= 0);
+	ERR_FAIL_COND_MSG(carets.size() <= 1, "The main caret should not be removed.");
 	ERR_FAIL_INDEX(p_caret, carets.size());
 	carets.remove_at(p_caret);
 	caret_index_edit_dirty = true;

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -3321,6 +3321,11 @@ TEST_CASE("[SceneTree][TextEdit] muiticaret") {
 		CHECK(text_edit->get_caret_count() == 1);
 		CHECK(text_edit->get_caret_line(0) == 0);
 		CHECK(text_edit->get_caret_column(0) == 1);
+
+		ERR_PRINT_OFF;
+		text_edit->remove_caret(0);
+		CHECK(text_edit->get_caret_count() == 1);
+		ERR_PRINT_ON;
 	}
 
 	SUBCASE("[TextEdit] caret index edit order") {


### PR DESCRIPTION
Fixes #67063

https://github.com/godotengine/godot/blob/bbac8198f89c0cbf0da4293201e54aa847947370/scene/gui/text_edit.h#L405-L406

Index 0 is the main caret and should not be removed. The current size check is redundant, so I believe it is a typo.