### PR TITLE
Reimplement Resource.`_setup_local_to_scene` & deprecate signal

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -379,8 +379,8 @@ Node *Resource::get_local_scene() const {
 }
 
 void Resource::setup_local_to_scene() {
-	// Can't use GDVIRTUAL in Resource, so this will have to be done with a signal
 	emit_signal(SNAME("setup_local_to_scene_requested"));
+	GDVIRTUAL_CALL(_setup_local_to_scene);
 }
 
 void Resource::reset_local_to_scene() {
@@ -460,6 +460,7 @@ void Resource::_bind_methods() {
 	get_rid_bind.return_val.type = Variant::RID;
 
 	::ClassDB::add_virtual_method(get_class_static(), get_rid_bind, true, Vector<String>(), true);
+	GDVIRTUAL_BIND(_setup_local_to_scene);
 }
 
 Resource::Resource() :

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -33,6 +33,7 @@
 
 #include "core/io/resource_uid.h"
 #include "core/object/class_db.h"
+#include "core/object/gdvirtual.gen.inc"
 #include "core/object/ref_counted.h"
 #include "core/templates/safe_refcount.h"
 #include "core/templates/self_list.h"
@@ -81,6 +82,7 @@ protected:
 	void _take_over_path(const String &p_path);
 
 	virtual void reset_local_to_scene();
+	GDVIRTUAL0(_setup_local_to_scene);
 
 public:
 	static Node *(*_get_local_scene_func)(); //used by editor

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -19,6 +19,21 @@
 				Override this method to return a custom [RID] when [method get_rid] is called.
 			</description>
 		</method>
+		<method name="_setup_local_to_scene" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Override this method to customize the newly duplicated resource created from [method PackedScene.instantiate], if the original's [member resource_local_to_scene] is set to [code]true[/code].
+				[b]Example:[/b] Set a random [code]damage[/code] value to every local resource from an instantiated scene.
+				[codeblock]
+				extends Resource
+
+				var damage = 0
+
+				func _setup_local_to_scene():
+				    damage = randi_range(10, 40)
+				[/codeblock]
+			</description>
+		</method>
 		<method name="duplicate" qualifiers="const">
 			<return type="Resource" />
 			<param index="0" name="subresources" type="bool" default="false" />
@@ -58,8 +73,8 @@
 		<method name="setup_local_to_scene" is_deprecated="true">
 			<return type="void" />
 			<description>
-				Emits the [signal setup_local_to_scene_requested] signal. If [member resource_local_to_scene] is set to [code]true[/code], this method is called from [method PackedScene.instantiate] by the newly duplicated resource within the scene instance.
-				For most resources, this method performs no logic of its own. Custom behavior can be defined by connecting [signal setup_local_to_scene_requested] from a script, [b]not[/b] by overriding this method.
+				Calls [method _setup_local_to_scene]. If [member resource_local_to_scene] is set to [code]true[/code], this method is automatically called from [method PackedScene.instantiate] by the newly duplicated resource within the scene instance.
+				[i]Deprecated.[/i] This method should only be called internally. Override [method _setup_local_to_scene] instead.
 			</description>
 		</method>
 		<method name="take_over_path">
@@ -90,9 +105,10 @@
 				[b]Note:[/b] This signal is not emitted automatically for properties of custom resources. If necessary, a setter needs to be created to emit the signal.
 			</description>
 		</signal>
-		<signal name="setup_local_to_scene_requested">
+		<signal name="setup_local_to_scene_requested" is_deprecated="true">
 			<description>
-				Emitted by the newly duplicated resource with [member resource_local_to_scene] set to [code]true[/code], when the scene is instantiated. Custom behavior can be defined by connecting this signal.
+				Emitted by a newly duplicated resource with [member resource_local_to_scene] set to [code]true[/code]. 
+				[i]Deprecated.[/i] This signal is only emitted when the resource is created. Override [method _setup_local_to_scene] instead.
 			</description>
 		</signal>
 	</signals>


### PR DESCRIPTION
Requires https://github.com/godotengine/godot/pull/81388.

This PR reimplements the virtual method `Resource._setup_local_to_scene`, that has been lost since #51970. It also gives it a much, **much** better description compared to 3.x:

Finally, deprecates the now redundant `setup_local_to_scene_requested` signal. 
This signal can only be useful when connecting it in the custom Resource's own `_init`. It _can_ be called manually with `setup_local_to_scene`. However, whether or not `setup_local_to_scene` should be exposed to the user in the first place is very up to debate to me (see my struggles attempting to update the description in https://github.com/godotengine/godot/pull/67072 and https://github.com/godotengine/godot/pull/67082.

##### I wish I could just remove it, to be honest. Only like, one or two people in the universe may be using it.