### PR TITLE
Deprecate `Resource.setup_local_to_scene`

### DIFF
--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -55,23 +55,11 @@
 				Returns the [RID] of this resource (or an empty RID). Many resources (such as [Texture2D], [Mesh], and so on) are high-level abstractions of resources stored in a specialized server ([DisplayServer], [RenderingServer], etc.), so this function will return the original [RID].
 			</description>
 		</method>
-		<method name="setup_local_to_scene">
+		<method name="setup_local_to_scene" is_deprecated="true">
 			<return type="void" />
 			<description>
 				Emits the [signal setup_local_to_scene_requested] signal. If [member resource_local_to_scene] is set to [code]true[/code], this method is called from [method PackedScene.instantiate] by the newly duplicated resource within the scene instance.
 				For most resources, this method performs no logic of its own. Custom behavior can be defined by connecting [signal setup_local_to_scene_requested] from a script, [b]not[/b] by overriding this method.
-				[b]Example:[/b] Assign a random value to [code]health[/code] for every duplicated Resource from an instantiated scene, excluding the original.
-				[codeblock]
-				extends Resource
-
-				var health = 0
-
-				func _init():
-				    setup_local_to_scene_requested.connect(randomize_health)
-
-				func randomize_health():
-				    health = randi_range(10, 40)
-				[/codeblock]
 			</description>
 		</method>
 		<method name="take_over_path">
@@ -104,7 +92,7 @@
 		</signal>
 		<signal name="setup_local_to_scene_requested">
 			<description>
-				Emitted when [method setup_local_to_scene] is called, usually by a newly duplicated resource with [member resource_local_to_scene] set to [code]true[/code]. Custom behavior can be defined by connecting this signal.
+				Emitted by the newly duplicated resource with [member resource_local_to_scene] set to [code]true[/code], when the scene is instantiated. Custom behavior can be defined by connecting this signal.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/ViewportTexture.xml
+++ b/doc/classes/ViewportTexture.xml
@@ -6,7 +6,7 @@
 	<description>
 		Provides the content of a [Viewport] as a dynamic [Texture2D]. This can be used to mix controls, 2D game objects, and 3D game objects in the same scene.
 		To create a [ViewportTexture] in code, use the [method Viewport.get_texture] method on the target viewport.
-		[b]Note:[/b] When local to scene, this texture uses [method Resource.setup_local_to_scene] to set the proxy texture and flags in the local viewport. Local to scene [ViewportTexture]s will return incorrect data until the scene root is ready (see [signal Node.ready]).
+		[b]Note:[/b] A [ViewportTexture] is always local to its scene (see [member Resource.resource_local_to_scene]). If the scene root is not ready, it may return incorrect data (see [signal Node.ready]).
 	</description>
 	<tutorials>
 		<link title="GUI in 3D Demo">https://godotengine.org/asset-library/asset/127</link>


### PR DESCRIPTION
This PR has been updated to deprecate instead of removing. Compatibility is no longer broken because the method still works, but use is discouraged.

Continuation of https://github.com/godotengine/godot/pull/67080 and in a way, https://github.com/godotengine/godot/pull/67072.

To quote myself from Godot's [RocketChat](https://chat.godotengine.org/channel/devel?msg=sY5KFfnZHNPQ7DB49):
> What? Why? I can't even find the reasoning as to why [this](https://github.com/godotengine/godot/pull/67080) happened, nor the reasoning as to why `setup_local_to_scene` is exposed to users in the first place! It was so difficult to explain in my [documentation tweak](https://github.com/godotengine/godot/pull/67072). It does not feel right. Custom resources that would need this are expected to run their own specialised logic, their own functions, written by the more advanced user that knows what they're doing.

Above, I mentioned that it was a struggle to explain properly. And that is because it currently does something really trivial: emit the `setup_local_to_scene_requested` to potentially perform custom user logic. But internally, it is **expected to be called only once** during `PackedScene.instantiate()`. 

Because the user may **also** call it whenever they want, they need to understand the occasion the engine *expects* it to be called. Specifically, deserialization of a `local_to_scene` resource. But again, if the user is writing custom serialization for a Resource for whatever reason, they will write their own methods to do it, without ever calling `setup_local_to_scene`!

~~In conclusion, good riddance, please!~~ ... See you in Godot 5...!
