### PR TITLE
Add warning for missing characters in label font

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -288,6 +288,36 @@ void Label::_update_theme_item_cache() {
 	theme_cache.font_shadow_outline_size = get_theme_constant(SNAME("shadow_outline_size"));
 }
 
+PackedStringArray Label::get_configuration_warnings() const {
+	PackedStringArray warnings = Control::get_configuration_warnings();
+
+	// Ensure that the font can render all of the required glyphs.
+	Ref<Font> font;
+	if (settings.is_valid()) {
+		font = settings->get_font();
+	}
+	if (font.is_null()) {
+		font = theme_cache.font;
+	}
+
+	if (font.is_valid()) {
+		if (dirty || font_dirty || lines_dirty) {
+			const_cast<Label *>(this)->_shape();
+		}
+
+		const Glyph *glyph = TS->shaped_text_get_glyphs(text_rid);
+		int64_t glyph_count = TS->shaped_text_get_glyph_count(text_rid);
+		for (int64_t i = 0; i < glyph_count; i++) {
+			if (glyph[i].font_rid == RID()) {
+				warnings.push_back(RTR("The current font does not support rendering one or more characters used in this Label's text."));
+				break;
+			}
+		}
+	}
+
+	return warnings;
+}
+
 void Label::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
@@ -302,6 +332,7 @@ void Label::_notification(int p_what) {
 			dirty = true;
 
 			queue_redraw();
+			update_configuration_warnings();
 		} break;
 
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
@@ -674,6 +705,7 @@ void Label::set_text(const String &p_string) {
 	}
 	queue_redraw();
 	update_minimum_size();
+	update_configuration_warnings();
 }
 
 void Label::_invalidate() {

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -93,6 +93,7 @@ protected:
 
 public:
 	virtual Size2 get_minimum_size() const override;
+	virtual PackedStringArray get_configuration_warnings() const override;
 
 	void set_horizontal_alignment(HorizontalAlignment p_alignment);
 	HorizontalAlignment get_horizontal_alignment() const;


### PR DESCRIPTION
Fix #66966

Show a configuration warning if any character of the Label's text does not exist in the font.

![image](https://user-images.githubusercontent.com/5117197/194711180-dfed54d6-f12a-43a4-8859-cdcde9c91fbc.png)

Haven't tested this in combination with translations, languages that combine characters, or font fallbacks, so I'd appreciate a good look at the code.

This could possibly be implemented on a lower level, so all Controls that show text (such as Button or RichTextLabel) could automatically benefit from this. Just not sure how this could be done easily or if it's worth going for.
