### PR TITLE
Fix Label text length mismatch after localization

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -117,7 +117,7 @@ void Label::_shape() {
 		for (int i = 0; i < TextServer::SPACING_MAX; i++) {
 			TS->shaped_text_set_spacing(text_rid, TextServer::SpacingType(i), font->get_spacing(TextServer::SpacingType(i)));
 		}
-		TS->shaped_text_set_bidi_override(text_rid, structured_text_parser(st_parser, st_args, text));
+		TS->shaped_text_set_bidi_override(text_rid, structured_text_parser(st_parser, st_args, txt));
 		dirty = false;
 		font_dirty = false;
 		lines_dirty = true;


### PR DESCRIPTION
Fixes #67081

That `text` was left un-renamed in #66808, making the label using raw text instead of the translated version when calling `structured_text_parser()`.