### PR TITLE
Check for method in attached scripts for Thread.start

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2832,8 +2832,19 @@ void _Thread::_start_func(void *ud) {
 Error _Thread::start(Object *p_instance, const StringName &p_method, const Variant &p_userdata, Priority p_priority) {
 	ERR_FAIL_COND_V_MSG(is_active(), ERR_ALREADY_IN_USE, "Thread already started.");
 	ERR_FAIL_COND_V(!p_instance, ERR_INVALID_PARAMETER);
-	ERR_FAIL_COND_V(p_method == StringName() || !p_instance->has_method(p_method), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_method == StringName(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_INDEX_V(p_priority, PRIORITY_MAX, ERR_INVALID_PARAMETER);
+
+	Ref<Script> script = p_instance->get_script();
+	while (script.is_valid()) {
+		if (script->has_method(p_method)) {
+			break;
+		}
+		script = script->get_base_script();
+	}
+	if (script.is_null()) {
+		ERR_FAIL_COND_V(!p_instance->has_method(p_method), ERR_INVALID_PARAMETER);
+	}
 
 	ret = Variant();
 	target_method = p_method;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Fix #67088 
