### PR TITLE
Document (Omni/Spot)Light ignoring Spatial's scale property (3.x)

### DIFF
--- a/doc/classes/Light.xml
+++ b/doc/classes/Light.xml
@@ -51,6 +51,7 @@
 		</member>
 		<member name="light_size" type="float" setter="set_param" getter="get_param" default="0.0">
 			The size of the light in Godot units. Only considered in baked lightmaps and only if [member light_bake_mode] is set to [constant BAKE_ALL]. Increasing this value will make the shadows appear blurrier. This can be used to simulate area lights to an extent.
+			[b]Note:[/b] [member light_size] is not affected by [member Spatial.scale] (the light's scale or its parent's scale).
 		</member>
 		<member name="light_specular" type="float" setter="set_param" getter="get_param" default="0.5">
 			The intensity of the specular blob in objects affected by the light. At [code]0[/code], the light becomes a pure diffuse light. When not baking emission, this can be used to avoid unrealistic reflections when placing lights above an emissive surface.

--- a/doc/classes/OmniLight.xml
+++ b/doc/classes/OmniLight.xml
@@ -18,6 +18,7 @@
 		</member>
 		<member name="omni_range" type="float" setter="set_param" getter="get_param" default="5.0">
 			The light's radius. Note that the effectively lit area may appear to be smaller depending on the [member omni_attenuation] in use. No matter the [member omni_attenuation] in use, the light will never reach anything outside this radius.
+			[b]Note:[/b] [member omni_range] is not affected by [member Spatial.scale] (the light's scale or its parent's scale).
 		</member>
 		<member name="omni_shadow_detail" type="int" setter="set_shadow_detail" getter="get_shadow_detail" enum="OmniLight.ShadowDetail" default="1">
 			See [enum ShadowDetail].

--- a/doc/classes/Spatial.xml
+++ b/doc/classes/Spatial.xml
@@ -273,6 +273,7 @@
 		<member name="scale" type="Vector3" setter="set_scale" getter="get_scale" default="Vector3( 1, 1, 1 )">
 			Scale part of the local transformation.
 			[b]Note:[/b] Mixed negative scales in 3D are not decomposable from the transformation matrix. Due to the way scale is represented with transformation matrices in Godot, the scale values will either be all positive or all negative.
+			[b]Note:[/b] Not all nodes are visually scaled by the [member scale] property. For example, [Light]s are not visually affected by [member scale].
 		</member>
 		<member name="transform" type="Transform" setter="set_transform" getter="get_transform" default="Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
 			Local space [Transform] of this node, with respect to the parent node.

--- a/doc/classes/SpotLight.xml
+++ b/doc/classes/SpotLight.xml
@@ -16,6 +16,7 @@
 	<members>
 		<member name="spot_angle" type="float" setter="set_param" getter="get_param" default="45.0">
 			The spotlight's angle in degrees.
+			[b]Note:[/b] [member spot_angle] is not affected by [member Spatial.scale] (the light's scale or its parent's scale).
 		</member>
 		<member name="spot_angle_attenuation" type="float" setter="set_param" getter="get_param" default="1.0">
 			The spotlight's angular attenuation curve.
@@ -25,6 +26,7 @@
 		</member>
 		<member name="spot_range" type="float" setter="set_param" getter="get_param" default="5.0">
 			The maximal range that can be reached by the spotlight. Note that the effectively lit area may appear to be smaller depending on the [member spot_attenuation] in use. No matter the [member spot_attenuation] in use, the light will never reach anything outside this range.
+			[b]Note:[/b] [member spot_range] is not affected by [member Spatial.scale] (the light's scale or its parent's scale).
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/67098.

This closes https://github.com/godotengine/godot/issues/67058.