### PR TITLE
Remove unused func definition in BoneMapEditor

### DIFF
--- a/editor/plugins/bone_map_editor_plugin.h
+++ b/editor/plugins/bone_map_editor_plugin.h
@@ -206,7 +206,6 @@ class BoneMapEditor : public VBoxContainer {
 	BoneMapper *bone_mapper = nullptr;
 
 	void fetch_objects();
-	void clear_editors();
 	void create_editors();
 
 protected:


### PR DESCRIPTION
I forgot to remove it when I fixed the crashing bug before when implementing importer retarget.