### PR TITLE
Changed `animation_changed` signal to fire even when not using queue in `AnimationPlayer`

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -257,8 +257,8 @@
 			<param index="0" name="old_name" type="StringName" />
 			<param index="1" name="new_name" type="StringName" />
 			<description>
-				Emitted when a queued animation plays after the previous animation finished. See [method queue].
-				[b]Note:[/b] The signal is not emitted when the animation is changed via [method play] or by an [AnimationTree].
+				Emitted when an assigned animation changed.
+				[b]Note:[/b] The signal is not emitted when the animation is changed by an [AnimationTree].
 			</description>
 		</signal>
 		<signal name="animation_finished">

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1193,9 +1193,6 @@ void AnimationPlayer::_animation_process(double p_delta) {
 				play(queued.front()->get());
 				String new_name = playback.assigned;
 				queued.pop_front();
-				if (end_notify) {
-					emit_signal(SceneStringNames::get_singleton()->animation_changed, old, new_name);
-				}
 			} else {
 				playing = false;
 				_set_process(false);
@@ -1640,10 +1637,15 @@ void AnimationPlayer::play(const StringName &p_name, double p_custom_blend, floa
 		}
 	}
 
+	String old_name = c.assigned;
+	String new_name = name;
 	c.current.speed_scale = p_custom_scale;
 	c.assigned = name;
 	c.seeked = false;
 	c.started = true;
+	if (old_name != new_name) {
+		emit_signal(SceneStringNames::get_singleton()->animation_changed, old_name, new_name);
+	}
 
 	if (!end_reached) {
 		queued.clear();
@@ -1686,9 +1688,14 @@ void AnimationPlayer::set_assigned_animation(const String &p_anim) {
 		play(p_anim);
 	} else {
 		ERR_FAIL_COND_MSG(!animation_set.has(p_anim), vformat("Animation not found: %s.", p_anim));
+		String old_name = playback.assigned;
+		String new_name = p_anim;
 		playback.current.pos = 0;
 		playback.current.from = &animation_set[p_anim];
 		playback.assigned = p_anim;
+		if (old_name != new_name) {
+			emit_signal(SceneStringNames::get_singleton()->animation_changed, old_name, new_name);
+		}
 	}
 }
 


### PR DESCRIPTION
The current `animation_changed` signal only fires when queue is used in `AnimationPlayer`.

This is inconvenient when you want to monitor `AnimationPlayer` from the outside. As a actual use case, I am developing an add-on for `AnimationPlayer` that does not conflict with built-in `AnimationPlayerEditor`, but this limitation blocks it.

I felt that at least the current signal `animation_changed` should be changed to a signal named `animation_queue_processed`. Nevertheless, all cases can be covered by firing the `animation_changed` signal even when queue is not used.

In this PR, I make it simple to fire the `animation_changed` signal even in cases where queue is not used. And I think there is no sense in limiting this unless there is a specific reason for the signal to be valid only when queue is used in previous implementations.

Test project:
[animation_player_signal_test.zip](https://github.com/godotengine/godot/files/9740889/animation_player_signal_test.zip)
