### PR TITLE
Fix `MultiMeshInstance2D` aabb not up-to-date after instances transformed

### DIFF
--- a/scene/2d/multimesh_instance_2d.cpp
+++ b/scene/2d/multimesh_instance_2d.cpp
@@ -63,12 +63,12 @@ void MultiMeshInstance2D::_bind_methods() {
 void MultiMeshInstance2D::set_multimesh(const Ref<MultiMesh> &p_multimesh) {
 	// Cleanup previous connection if any.
 	if (multimesh.is_valid()) {
-		multimesh->disconnect(&CoreStringNames::get_singleton()->changed, callable_mp(this, &CanvasItem::queue_redraw));
+		multimesh->disconnect(&CoreStringNames::get_singleton()->changed, callable_mp(this, &CanvasItem::queue_redraw()));
 	}
 	multimesh = p_multimesh;
 	// Connect to the multimesh so the AABB can update when instance transforms are changed.
 	if (multimesh.is_valid()) {
-		multimesh->connect(&CoreStringNames::get_singleton()->changed, callable_mp(this, &CanvasItem::queue_redraw));
+		multimesh->connect(&CoreStringNames::get_singleton()->changed, callable_mp(this, &CanvasItem::queue_redraw()));
 	}
 	queue_redraw();
 }

--- a/scene/2d/multimesh_instance_2d.cpp
+++ b/scene/2d/multimesh_instance_2d.cpp
@@ -63,12 +63,12 @@ void MultiMeshInstance2D::_bind_methods() {
 void MultiMeshInstance2D::set_multimesh(const Ref<MultiMesh> &p_multimesh) {
 	// Cleanup previous connection if any.
 	if (multimesh.is_valid()) {
-		multimesh->disconnect("update", callable_mp(this, &CoreStringNames::get_singleton()->changed));
+		multimesh->disconnect(&CoreStringNames::get_singleton()->changed, callable_mp(this, &CanvasItem::queue_redraw));
 	}
 	multimesh = p_multimesh;
 	// Connect to the multimesh so the AABB can update when instance transforms are changed.
 	if (multimesh.is_valid()) {
-		multimesh->connect("update", callable_mp(this, &CoreStringNames::get_singleton()->changed));
+		multimesh->connect(&CoreStringNames::get_singleton()->changed, callable_mp(this, &CanvasItem::queue_redraw));
 	}
 	queue_redraw();
 }

--- a/scene/2d/multimesh_instance_2d.cpp
+++ b/scene/2d/multimesh_instance_2d.cpp
@@ -30,6 +30,7 @@
 
 #include "multimesh_instance_2d.h"
 
+#include "core/core_string_names.h"
 #include "scene/scene_string_names.h"
 
 void MultiMeshInstance2D::_notification(int p_what) {
@@ -60,7 +61,15 @@ void MultiMeshInstance2D::_bind_methods() {
 }
 
 void MultiMeshInstance2D::set_multimesh(const Ref<MultiMesh> &p_multimesh) {
+	// Cleanup previous connection if any.
+	if (multimesh.is_valid()) {
+		multimesh->disconnect(CoreStringNames::get_singleton()->changed, this, "update");
+	}
 	multimesh = p_multimesh;
+	// Connect to the multimesh so the AABB can update when instance transforms are changed.
+	if (multimesh.is_valid()) {
+		multimesh->connect(CoreStringNames::get_singleton()->changed, this, "update");
+	}
 	queue_redraw();
 }
 

--- a/scene/2d/multimesh_instance_2d.cpp
+++ b/scene/2d/multimesh_instance_2d.cpp
@@ -63,12 +63,12 @@ void MultiMeshInstance2D::_bind_methods() {
 void MultiMeshInstance2D::set_multimesh(const Ref<MultiMesh> &p_multimesh) {
 	// Cleanup previous connection if any.
 	if (multimesh.is_valid()) {
-		multimesh->disconnect(CoreStringNames::get_singleton()->changed, this, "update");
+		multimesh->disconnect("update", callable_mp(this, &CoreStringNames::get_singleton()->changed));
 	}
 	multimesh = p_multimesh;
 	// Connect to the multimesh so the AABB can update when instance transforms are changed.
 	if (multimesh.is_valid()) {
-		multimesh->connect(CoreStringNames::get_singleton()->changed, this, "update");
+		multimesh->connect("update", callable_mp(this, &CoreStringNames::get_singleton()->changed));
 	}
 	queue_redraw();
 }

--- a/scene/resources/multimesh.cpp
+++ b/scene/resources/multimesh.cpp
@@ -242,6 +242,7 @@ void MultiMesh::set_instance_transform(int p_instance, const Transform3D &p_tran
 
 void MultiMesh::set_instance_transform_2d(int p_instance, const Transform2D &p_transform) {
 	RenderingServer::get_singleton()->multimesh_instance_set_transform_2d(multimesh, p_instance, p_transform);
+	emit_changed();
 }
 
 Transform3D MultiMesh::get_instance_transform(int p_instance) const {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

- Fixes #66849

## What I Did

The code was adjusted to get the `CanvasItem` to update whenever the AABB is recalculated for the `MultiMesh`!