### PR TITLE
Expose TreeItem::set_button_color

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -425,6 +425,15 @@
 				Sets the given column's button [Texture2D] at index [param button_idx] to [param button].
 			</description>
 		</method>
+		<method name="set_button_color">
+			<return type="void" />
+			<param index="0" name="column" type="int" />
+			<param index="1" name="button_idx" type="int" />
+			<param index="2" name="color" type="Color" />
+			<description>
+				Sets the given column's button color at index [param button_idx] to [param color].
+			</description>
+		</method>
 		<method name="set_button_disabled">
 			<return type="void" />
 			<param index="0" name="column" type="int" />

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1504,6 +1504,7 @@ void TreeItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_button", "column", "button_idx", "button"), &TreeItem::set_button);
 	ClassDB::bind_method(D_METHOD("erase_button", "column", "button_idx"), &TreeItem::erase_button);
 	ClassDB::bind_method(D_METHOD("set_button_disabled", "column", "button_idx", "disabled"), &TreeItem::set_button_disabled);
+	ClassDB::bind_method(D_METHOD("set_button_color", "column", "button_idx", "color"), &TreeItem::set_button_color);
 	ClassDB::bind_method(D_METHOD("is_button_disabled", "column", "button_idx"), &TreeItem::is_button_disabled);
 
 	ClassDB::bind_method(D_METHOD("set_tooltip_text", "column", "tooltip"), &TreeItem::set_tooltip_text);


### PR DESCRIPTION
I wanted to tint buttons like the node tree does for its buttons, but saw that it wasn't exposed.