### PR TITLE
Fix Typed Array of Objects not accepting `null`.

### DIFF
--- a/core/variant/container_type_validate.h
+++ b/core/variant/container_type_validate.h
@@ -79,9 +79,12 @@ struct ContainerTypeValidate {
 			return true;
 		}
 
-		ERR_FAIL_COND_V_MSG(type != p_variant.get_type(), false, "Attempted to " + String(p_operation) + " a variable of type '" + Variant::get_type_name(p_variant.get_type()) + "' into a " + where + " of type '" + Variant::get_type_name(type) + "'.");
 		if (type != p_variant.get_type()) {
-			return false;
+			if (p_variant.get_type() == Variant::NIL && type == Variant::OBJECT) {
+				return true;
+			}
+
+			ERR_FAIL_V_MSG(false, "Attempted to " + String(p_operation) + " a variable of type '" + Variant::get_type_name(p_variant.get_type()) + "' into a " + where + " of type '" + Variant::get_type_name(type) + "'.");
 		}
 
 		if (type != Variant::OBJECT) {
@@ -90,7 +93,7 @@ struct ContainerTypeValidate {
 #ifdef DEBUG_ENABLED
 		ObjectID object_id = p_variant;
 		if (object_id == ObjectID()) {
-			return true; //fine its null;
+			return true; // This is fine, it's null.
 		}
 		Object *object = ObjectDB::get_instance(object_id);
 		ERR_FAIL_COND_V_MSG(object == nullptr, false, "Attempted to " + String(p_operation) + " an invalid (previously freed?) object instance into a '" + String(where) + ".");
@@ -101,7 +104,7 @@ struct ContainerTypeValidate {
 		}
 #endif
 		if (class_name == StringName()) {
-			return true; //all good, no class type requested
+			return true; // All good, no class type requested.
 		}
 
 		StringName obj_class = object->get_class_name();
@@ -110,12 +113,12 @@ struct ContainerTypeValidate {
 		}
 
 		if (script.is_null()) {
-			return true; //all good
+			return true; // All good, no script requested.
 		}
 
 		Ref<Script> other_script = object->get_script();
 
-		//check base script..
+		// Check base script..
 		ERR_FAIL_COND_V_MSG(other_script.is_null(), false, "Attempted to " + String(p_operation) + " an object into a " + String(where) + ", that does not inherit from '" + String(script->get_class_name()) + "'.");
 		ERR_FAIL_COND_V_MSG(!other_script->inherits_script(script), false, "Attempted to " + String(p_operation) + " an object into a " + String(where) + ", that does not inherit from '" + String(script->get_class_name()) + "'.");
 


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/63608.

This adds a special case specifically for Typed Arrays of **Object**s. Other Typed Arrays still do not accept null.