### PR TITLE
Strip unnecessary break on switches returning early in Variant

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -47,146 +47,126 @@ String Variant::get_type_name(Variant::Type p_type) {
 	switch (p_type) {
 		case NIL: {
 			return "Nil";
-		} break;
+		}
 
-		// atomic types
+		// Atomic types.
 		case BOOL: {
 			return "bool";
-		} break;
+		}
 		case INT: {
 			return "int";
-
-		} break;
+		}
 		case FLOAT: {
 			return "float";
-
-		} break;
+		}
 		case STRING: {
 			return "String";
-		} break;
+		}
 
-		// math types
+		// Math types.
 		case VECTOR2: {
 			return "Vector2";
-		} break;
+		}
 		case VECTOR2I: {
 			return "Vector2i";
-		} break;
+		}
 		case RECT2: {
 			return "Rect2";
-		} break;
+		}
 		case RECT2I: {
 			return "Rect2i";
-		} break;
+		}
 		case TRANSFORM2D: {
 			return "Transform2D";
-		} break;
+		}
 		case VECTOR3: {
 			return "Vector3";
-		} break;
+		}
 		case VECTOR3I: {
 			return "Vector3i";
-		} break;
+		}
 		case VECTOR4: {
 			return "Vector4";
-		} break;
+		}
 		case VECTOR4I: {
 			return "Vector4i";
-		} break;
+		}
 		case PLANE: {
 			return "Plane";
-
-		} break;
+		}
 		case AABB: {
 			return "AABB";
-		} break;
+		}
 		case QUATERNION: {
 			return "Quaternion";
-
-		} break;
+		}
 		case BASIS: {
 			return "Basis";
-
-		} break;
+		}
 		case TRANSFORM3D: {
 			return "Transform3D";
-
-		} break;
+		}
 		case PROJECTION: {
 			return "Projection";
+		}
 
-		} break;
-
-		// misc types
+		// Miscellaneous types.
 		case COLOR: {
 			return "Color";
-
-		} break;
+		}
 		case RID: {
 			return "RID";
-		} break;
+		}
 		case OBJECT: {
 			return "Object";
-		} break;
+		}
 		case CALLABLE: {
 			return "Callable";
-		} break;
+		}
 		case SIGNAL: {
 			return "Signal";
-		} break;
+		}
 		case STRING_NAME: {
 			return "StringName";
-
-		} break;
+		}
 		case NODE_PATH: {
 			return "NodePath";
-
-		} break;
+		}
 		case DICTIONARY: {
 			return "Dictionary";
-
-		} break;
+		}
 		case ARRAY: {
 			return "Array";
+		}
 
-		} break;
-
-		// arrays
+		// Arrays.
 		case PACKED_BYTE_ARRAY: {
 			return "PackedByteArray";
-
-		} break;
+		}
 		case PACKED_INT32_ARRAY: {
 			return "PackedInt32Array";
-
-		} break;
+		}
 		case PACKED_INT64_ARRAY: {
 			return "PackedInt64Array";
-
-		} break;
+		}
 		case PACKED_FLOAT32_ARRAY: {
 			return "PackedFloat32Array";
-
-		} break;
+		}
 		case PACKED_FLOAT64_ARRAY: {
 			return "PackedFloat64Array";
-
-		} break;
+		}
 		case PACKED_STRING_ARRAY: {
 			return "PackedStringArray";
-		} break;
+		}
 		case PACKED_VECTOR2_ARRAY: {
 			return "PackedVector2Array";
-
-		} break;
+		}
 		case PACKED_VECTOR3_ARRAY: {
 			return "PackedVector3Array";
-
-		} break;
+		}
 		case PACKED_COLOR_ARRAY: {
 			return "PackedColorArray";
-
-		} break;
+		}
 		default: {
 		}
 	}
@@ -880,157 +860,126 @@ bool Variant::is_zero() const {
 	switch (type) {
 		case NIL: {
 			return true;
-		} break;
+		}
 
-		// atomic types
+		// Atomic types.
 		case BOOL: {
 			return !(_data._bool);
-		} break;
+		}
 		case INT: {
 			return _data._int == 0;
-
-		} break;
+		}
 		case FLOAT: {
 			return _data._float == 0;
-
-		} break;
+		}
 		case STRING: {
 			return *reinterpret_cast<const String *>(_data._mem) == String();
+		}
 
-		} break;
-
-		// math types
+		// Math types.
 		case VECTOR2: {
 			return *reinterpret_cast<const Vector2 *>(_data._mem) == Vector2();
-
-		} break;
+		}
 		case VECTOR2I: {
 			return *reinterpret_cast<const Vector2i *>(_data._mem) == Vector2i();
-
-		} break;
+		}
 		case RECT2: {
 			return *reinterpret_cast<const Rect2 *>(_data._mem) == Rect2();
-
-		} break;
+		}
 		case RECT2I: {
 			return *reinterpret_cast<const Rect2i *>(_data._mem) == Rect2i();
-
-		} break;
+		}
 		case TRANSFORM2D: {
 			return *_data._transform2d == Transform2D();
-
-		} break;
+		}
 		case VECTOR3: {
 			return *reinterpret_cast<const Vector3 *>(_data._mem) == Vector3();
-
-		} break;
+		}
 		case VECTOR3I: {
 			return *reinterpret_cast<const Vector3i *>(_data._mem) == Vector3i();
-
-		} break;
+		}
 		case VECTOR4: {
 			return *reinterpret_cast<const Vector4 *>(_data._mem) == Vector4();
-
-		} break;
+		}
 		case VECTOR4I: {
 			return *reinterpret_cast<const Vector4i *>(_data._mem) == Vector4i();
-
-		} break;
+		}
 		case PLANE: {
 			return *reinterpret_cast<const Plane *>(_data._mem) == Plane();
-
-		} break;
+		}
 		case AABB: {
 			return *_data._aabb == ::AABB();
-		} break;
+		}
 		case QUATERNION: {
 			return *reinterpret_cast<const Quaternion *>(_data._mem) == Quaternion();
-
-		} break;
+		}
 		case BASIS: {
 			return *_data._basis == Basis();
-
-		} break;
+		}
 		case TRANSFORM3D: {
 			return *_data._transform3d == Transform3D();
-
-		} break;
+		}
 		case PROJECTION: {
 			return *_data._projection == Projection();
+		}
 
-		} break;
-
-		// misc types
+		// Miscellaneous types.
 		case COLOR: {
 			return *reinterpret_cast<const Color *>(_data._mem) == Color();
-
-		} break;
+		}
 		case RID: {
 			return *reinterpret_cast<const ::RID *>(_data._mem) == ::RID();
-		} break;
+		}
 		case OBJECT: {
 			return _get_obj().obj == nullptr;
-		} break;
+		}
 		case CALLABLE: {
 			return reinterpret_cast<const Callable *>(_data._mem)->is_null();
-		} break;
+		}
 		case SIGNAL: {
 			return reinterpret_cast<const Signal *>(_data._mem)->is_null();
-		} break;
+		}
 		case STRING_NAME: {
 			return *reinterpret_cast<const StringName *>(_data._mem) != StringName();
-
-		} break;
+		}
 		case NODE_PATH: {
 			return reinterpret_cast<const NodePath *>(_data._mem)->is_empty();
-
-		} break;
+		}
 		case DICTIONARY: {
 			return reinterpret_cast<const Dictionary *>(_data._mem)->is_empty();
-
-		} break;
+		}
 		case ARRAY: {
 			return reinterpret_cast<const Array *>(_data._mem)->is_empty();
+		}
 
-		} break;
-
-		// arrays
+		// Arrays.
 		case PACKED_BYTE_ARRAY: {
 			return PackedArrayRef<uint8_t>::get_array(_data.packed_array).size() == 0;
-
-		} break;
+		}
 		case PACKED_INT32_ARRAY: {
 			return PackedArrayRef<int32_t>::get_array(_data.packed_array).size() == 0;
-
-		} break;
+		}
 		case PACKED_INT64_ARRAY: {
 			return PackedArrayRef<int64_t>::get_array(_data.packed_array).size() == 0;
-
-		} break;
+		}
 		case PACKED_FLOAT32_ARRAY: {
 			return PackedArrayRef<float>::get_array(_data.packed_array).size() == 0;
-
-		} break;
+		}
 		case PACKED_FLOAT64_ARRAY: {
 			return PackedArrayRef<double>::get_array(_data.packed_array).size() == 0;
-
-		} break;
+		}
 		case PACKED_STRING_ARRAY: {
 			return PackedArrayRef<String>::get_array(_data.packed_array).size() == 0;
-
-		} break;
+		}
 		case PACKED_VECTOR2_ARRAY: {
 			return PackedArrayRef<Vector2>::get_array(_data.packed_array).size() == 0;
-
-		} break;
+		}
 		case PACKED_VECTOR3_ARRAY: {
 			return PackedArrayRef<Vector3>::get_array(_data.packed_array).size() == 0;
-
-		} break;
+		}
 		case PACKED_COLOR_ARRAY: {
 			return PackedArrayRef<Color>::get_array(_data.packed_array).size() == 0;
-
-		} break;
+		}
 		default: {
 		}
 	}
@@ -1042,60 +991,49 @@ bool Variant::is_one() const {
 	switch (type) {
 		case NIL: {
 			return true;
-		} break;
+		}
 
-		// atomic types
 		case BOOL: {
 			return _data._bool;
-		} break;
+		}
 		case INT: {
 			return _data._int == 1;
-
-		} break;
+		}
 		case FLOAT: {
 			return _data._float == 1;
+		}
 
-		} break;
 		case VECTOR2: {
 			return *reinterpret_cast<const Vector2 *>(_data._mem) == Vector2(1, 1);
-
-		} break;
+		}
 		case VECTOR2I: {
 			return *reinterpret_cast<const Vector2i *>(_data._mem) == Vector2i(1, 1);
-
-		} break;
+		}
 		case RECT2: {
 			return *reinterpret_cast<const Rect2 *>(_data._mem) == Rect2(1, 1, 1, 1);
-
-		} break;
+		}
 		case RECT2I: {
 			return *reinterpret_cast<const Rect2i *>(_data._mem) == Rect2i(1, 1, 1, 1);
-
-		} break;
+		}
 		case VECTOR3: {
 			return *reinterpret_cast<const Vector3 *>(_data._mem) == Vector3(1, 1, 1);
-
-		} break;
+		}
 		case VECTOR3I: {
 			return *reinterpret_cast<const Vector3i *>(_data._mem) == Vector3i(1, 1, 1);
-
-		} break;
+		}
 		case VECTOR4: {
 			return *reinterpret_cast<const Vector4 *>(_data._mem) == Vector4(1, 1, 1, 1);
-
-		} break;
+		}
 		case VECTOR4I: {
 			return *reinterpret_cast<const Vector4i *>(_data._mem) == Vector4i(1, 1, 1, 1);
-
-		} break;
+		}
 		case PLANE: {
 			return *reinterpret_cast<const Plane *>(_data._mem) == Plane(1, 1, 1, 1);
+		}
 
-		} break;
 		case COLOR: {
 			return *reinterpret_cast<const Color *>(_data._mem) == Color(1, 1, 1, 1);
-
-		} break;
+		}
 
 		default: {
 			return !is_zero();
@@ -1133,10 +1071,10 @@ void Variant::reference(const Variant &p_variant) {
 
 	switch (p_variant.type) {
 		case NIL: {
-			// none
+			// None.
 		} break;
 
-		// atomic types
+		// Atomic types.
 		case BOOL: {
 			_data._bool = p_variant._data._bool;
 		} break;
@@ -1150,7 +1088,7 @@ void Variant::reference(const Variant &p_variant) {
 			memnew_placement(_data._mem, String(*reinterpret_cast<const String *>(p_variant._data._mem)));
 		} break;
 
-		// math types
+		// Math types.
 		case VECTOR2: {
 			memnew_placement(_data._mem, Vector2(*reinterpret_cast<const Vector2 *>(p_variant._data._mem)));
 		} break;
@@ -1202,10 +1140,9 @@ void Variant::reference(const Variant &p_variant) {
 			memnew_placement(_data._projection, Projection(*p_variant._data._projection));
 		} break;
 
-		// misc types
+		// Miscellaneous types.
 		case COLOR: {
 			memnew_placement(_data._mem, Color(*reinterpret_cast<const Color *>(p_variant._data._mem)));
-
 		} break;
 		case RID: {
 			memnew_placement(_data._mem, ::RID(*reinterpret_cast<const ::RID *>(p_variant._data._mem)));
@@ -1224,7 +1161,6 @@ void Variant::reference(const Variant &p_variant) {
 
 			_get_obj().obj = const_cast<Object *>(p_variant._get_obj().obj);
 			_get_obj().id = p_variant._get_obj().id;
-
 		} break;
 		case CALLABLE: {
 			memnew_placement(_data._mem, Callable(*reinterpret_cast<const Callable *>(p_variant._data._mem)));
@@ -1234,84 +1170,71 @@ void Variant::reference(const Variant &p_variant) {
 		} break;
 		case STRING_NAME: {
 			memnew_placement(_data._mem, StringName(*reinterpret_cast<const StringName *>(p_variant._data._mem)));
-
 		} break;
 		case NODE_PATH: {
 			memnew_placement(_data._mem, NodePath(*reinterpret_cast<const NodePath *>(p_variant._data._mem)));
-
 		} break;
 		case DICTIONARY: {
 			memnew_placement(_data._mem, Dictionary(*reinterpret_cast<const Dictionary *>(p_variant._data._mem)));
-
 		} break;
 		case ARRAY: {
 			memnew_placement(_data._mem, Array(*reinterpret_cast<const Array *>(p_variant._data._mem)));
-
 		} break;
 
-		// arrays
+		// Arrays.
 		case PACKED_BYTE_ARRAY: {
 			_data.packed_array = static_cast<PackedArrayRef<uint8_t> *>(p_variant._data.packed_array)->reference();
 			if (!_data.packed_array) {
 				_data.packed_array = PackedArrayRef<uint8_t>::create();
 			}
-
 		} break;
 		case PACKED_INT32_ARRAY: {
 			_data.packed_array = static_cast<PackedArrayRef<int32_t> *>(p_variant._data.packed_array)->reference();
 			if (!_data.packed_array) {
 				_data.packed_array = PackedArrayRef<int32_t>::create();
 			}
-
 		} break;
 		case PACKED_INT64_ARRAY: {
 			_data.packed_array = static_cast<PackedArrayRef<int64_t> *>(p_variant._data.packed_array)->reference();
 			if (!_data.packed_array) {
 				_data.packed_array = PackedArrayRef<int64_t>::create();
 			}
-
 		} break;
 		case PACKED_FLOAT32_ARRAY: {
 			_data.packed_array = static_cast<PackedArrayRef<float> *>(p_variant._data.packed_array)->reference();
 			if (!_data.packed_array) {
 				_data.packed_array = PackedArrayRef<float>::create();
 			}
-
 		} break;
 		case PACKED_FLOAT64_ARRAY: {
 			_data.packed_array = static_cast<PackedArrayRef<double> *>(p_variant._data.packed_array)->reference();
 			if (!_data.packed_array) {
 				_data.packed_array = PackedArrayRef<double>::create();
 			}
-
 		} break;
 		case PACKED_STRING_ARRAY: {
 			_data.packed_array = static_cast<PackedArrayRef<String> *>(p_variant._data.packed_array)->reference();
 			if (!_data.packed_array) {
 				_data.packed_array = PackedArrayRef<String>::create();
 			}
-
 		} break;
 		case PACKED_VECTOR2_ARRAY: {
 			_data.packed_array = static_cast<PackedArrayRef<Vector2> *>(p_variant._data.packed_array)->reference();
 			if (!_data.packed_array) {
 				_data.packed_array = PackedArrayRef<Vector2>::create();
 			}
-
 		} break;
 		case PACKED_VECTOR3_ARRAY: {
 			_data.packed_array = static_cast<PackedArrayRef<Vector3> *>(p_variant._data.packed_array)->reference();
 			if (!_data.packed_array) {
 				_data.packed_array = PackedArrayRef<Vector3>::create();
 			}
-
 		} break;
 		case PACKED_COLOR_ARRAY: {
 			_data.packed_array = static_cast<PackedArrayRef<Color> *>(p_variant._data.packed_array)->reference();
 			if (!_data.packed_array) {
 				_data.packed_array = PackedArrayRef<Color>::create();
 			}
-
 		} break;
 		default: {
 		}
@@ -1331,6 +1254,7 @@ void Variant::zero() {
 		case FLOAT:
 			this->_data._float = 0;
 			break;
+
 		case VECTOR2:
 			*reinterpret_cast<Vector2 *>(this->_data._mem) = Vector2();
 			break;
@@ -1361,9 +1285,11 @@ void Variant::zero() {
 		case QUATERNION:
 			*reinterpret_cast<Quaternion *>(this->_data._mem) = Quaternion();
 			break;
+
 		case COLOR:
 			*reinterpret_cast<Color *>(this->_data._mem) = Color();
 			break;
+
 		default:
 			this->clear();
 			break;
@@ -1375,15 +1301,8 @@ void Variant::_clear_internal() {
 		case STRING: {
 			reinterpret_cast<String *>(_data._mem)->~String();
 		} break;
-		/*
-		// no point, they don't allocate memory
-		VECTOR3,
-		PLANE,
-		QUATERNION,
-		COLOR,
-		VECTOR2,
-		RECT2
-		*/
+
+		// Math types.
 		case TRANSFORM2D: {
 			if (_data._transform2d) {
 				_data._transform2d->~Transform2D();
@@ -1419,7 +1338,8 @@ void Variant::_clear_internal() {
 				_data._projection = nullptr;
 			}
 		} break;
-			// misc types
+
+		// Miscellaneous types.
 		case STRING_NAME: {
 			reinterpret_cast<StringName *>(_data._mem)->~StringName();
 		} break;
@@ -1428,7 +1348,7 @@ void Variant::_clear_internal() {
 		} break;
 		case OBJECT: {
 			if (_get_obj().id.is_ref_counted()) {
-				//we are safe that there is a reference here
+				// We are safe that there is a reference here.
 				RefCounted *ref_counted = static_cast<RefCounted *>(_get_obj().obj);
 				if (ref_counted->unreference()) {
 					memdelete(ref_counted);
@@ -1438,8 +1358,8 @@ void Variant::_clear_internal() {
 			_get_obj().id = ObjectID();
 		} break;
 		case RID: {
-			// not much need probably
-			// Can't seem to use destructor + scoping operator, so hack.
+			// Not much need probably.
+			// HACK: Can't seem to use destructor + scoping operator, so hack.
 			typedef ::RID RID_Class;
 			reinterpret_cast<RID_Class *>(_data._mem)->~RID_Class();
 		} break;
@@ -1455,7 +1375,8 @@ void Variant::_clear_internal() {
 		case ARRAY: {
 			reinterpret_cast<Array *>(_data._mem)->~Array();
 		} break;
-		// arrays
+
+		// Arrays.
 		case PACKED_BYTE_ARRAY: {
 			PackedArrayRefBase::destroy(_data.packed_array);
 		} break;
@@ -1484,7 +1405,9 @@ void Variant::_clear_internal() {
 			PackedArrayRefBase::destroy(_data.packed_array);
 		} break;
 		default: {
-		} /* not needed */
+			// Not needed, there is no point. The following do not allocate memory:
+			// VECTOR2, VECTOR3, RECT2, PLANE, QUATERNION, COLOR.
+		}
 	}
 }
 
@@ -1863,34 +1786,34 @@ String Variant::stringify(int recursion_count) const {
 			str += " }";
 
 			return str;
-		} break;
+		}
 		case PACKED_VECTOR2_ARRAY: {
 			return stringify_vector(operator Vector<Vector2>(), recursion_count);
-		} break;
+		}
 		case PACKED_VECTOR3_ARRAY: {
 			return stringify_vector(operator Vector<Vector3>(), recursion_count);
-		} break;
+		}
 		case PACKED_COLOR_ARRAY: {
 			return stringify_vector(operator Vector<Color>(), recursion_count);
-		} break;
+		}
 		case PACKED_STRING_ARRAY: {
 			return stringify_vector(operator Vector<String>(), recursion_count);
-		} break;
+		}
 		case PACKED_BYTE_ARRAY: {
 			return stringify_vector(operator Vector<uint8_t>(), recursion_count);
-		} break;
+		}
 		case PACKED_INT32_ARRAY: {
 			return stringify_vector(operator Vector<int32_t>(), recursion_count);
-		} break;
+		}
 		case PACKED_INT64_ARRAY: {
 			return stringify_vector(operator Vector<int64_t>(), recursion_count);
-		} break;
+		}
 		case PACKED_FLOAT32_ARRAY: {
 			return stringify_vector(operator Vector<float>(), recursion_count);
-		} break;
+		}
 		case PACKED_FLOAT64_ARRAY: {
 			return stringify_vector(operator Vector<double>(), recursion_count);
-		} break;
+		}
 		case ARRAY: {
 			Array arr = operator Array();
 			if (recursion_count > MAX_RECURSION) {
@@ -1899,8 +1822,7 @@ String Variant::stringify(int recursion_count) const {
 			}
 
 			return stringify_vector(arr, recursion_count);
-
-		} break;
+		}
 		case OBJECT: {
 			if (_get_obj().obj) {
 				if (!_get_obj().id.is_ref_counted() && ObjectDB::get_instance(_get_obj().id) == nullptr) {
@@ -1911,20 +1833,19 @@ String Variant::stringify(int recursion_count) const {
 			} else {
 				return "<Object#null>";
 			}
-
-		} break;
+		}
 		case CALLABLE: {
 			const Callable &c = *reinterpret_cast<const Callable *>(_data._mem);
 			return c;
-		} break;
+		}
 		case SIGNAL: {
 			const Signal &s = *reinterpret_cast<const Signal *>(_data._mem);
 			return s;
-		} break;
+		}
 		case RID: {
 			const ::RID &s = *reinterpret_cast<const ::RID *>(_data._mem);
 			return "RID(" + itos(s.get_id()) + ")";
-		} break;
+		}
 		default: {
 			return "<" + get_type_name(type) + ">";
 		}


### PR DESCRIPTION
I noticed that in most of the codebase (even within `variant.cpp`) switches that always contain a `return` statement do not write a trailing `break`.