### PR TITLE
Add Caret Insert Below and Above shortcuts to TextEdit

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -331,6 +331,10 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
     { "ui_text_caret_document_start.macos",            TTRC("Caret Document Start") },
     { "ui_text_caret_document_end",                    TTRC("Caret Document End") },
     { "ui_text_caret_document_end.macos",              TTRC("Caret Document End") },
+    { "ui_text_caret_add_below",                       TTRC("Caret Add Below") },
+    { "ui_text_caret_add_below.macos",                 TTRC("Caret Add Below") },
+    { "ui_text_caret_add_above",                       TTRC("Caret Add Above") },
+    { "ui_text_caret_add_above.macos",                 TTRC("Caret Add Above") },
     { "ui_text_scroll_up",                             TTRC("Scroll Up") },
     { "ui_text_scroll_up.macos",                       TTRC("Scroll Up") },
     { "ui_text_scroll_down",                           TTRC("Scroll Down") },
@@ -615,6 +619,24 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::DOWN | KeyModifierMask::CMD_OR_CTRL));
 	default_builtin_cache.insert("ui_text_caret_document_end.macos", inputs);
+
+	// Text Caret Addition Below/Above
+
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::DOWN | KeyModifierMask::SHIFT | KeyModifierMask::CMD_OR_CTRL));
+	default_builtin_cache.insert("ui_text_caret_add_below", inputs);
+
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::L | KeyModifierMask::SHIFT | KeyModifierMask::CMD_OR_CTRL));
+	default_builtin_cache.insert("ui_text_caret_add_below.macos", inputs);
+
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::UP | KeyModifierMask::SHIFT | KeyModifierMask::CMD_OR_CTRL));
+	default_builtin_cache.insert("ui_text_caret_add_above", inputs);
+
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::O | KeyModifierMask::SHIFT | KeyModifierMask::CMD_OR_CTRL));
+	default_builtin_cache.insert("ui_text_caret_add_above.macos", inputs);
 
 	// Text Scrolling
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -838,6 +838,18 @@
 		<member name="input/ui_text_backspace_word.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to delete a word.
 		</member>
+		<member name="input/ui_text_caret_add_above" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to add an additional caret above every caret of a text
+		</member>
+		<member name="input/ui_text_caret_add_above.macos" type="Dictionary" setter="" getter="">
+			macOS specific override for the shortcut to add a caret above every caret
+		</member>
+		<member name="input/ui_text_caret_add_below" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to add an additional caret below every caret of a text
+		</member>
+		<member name="input/ui_text_caret_add_below.macos" type="Dictionary" setter="" getter="">
+			macOS specific override for the shortcut to add a caret below every caret
+		</member>
 		<member name="input/ui_text_caret_document_end" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to move the text cursor the the end of the text.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -63,6 +63,13 @@
 				Adds a new caret at the given location. Returns the index of the new caret, or [code]-1[/code] if the location is invalid.
 			</description>
 		</method>
+		<method name="add_caret_at_carets">
+			<return type="void" />
+			<param index="0" name="below" type="bool" />
+			<description>
+				Adds an additional caret above or below every caret. If [param below] is true the new caret will be added below and above otherwise.
+			</description>
+		</method>
 		<method name="add_gutter">
 			<return type="void" />
 			<param index="0" name="at" type="int" default="-1" />

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -598,6 +598,9 @@ private:
 	void _move_caret_document_start(bool p_select);
 	void _move_caret_document_end(bool p_select);
 
+	// Used in add_caret_at_carets
+	void _get_above_below_caret_line_column(int p_old_line, int p_old_wrap_index, int p_old_column, bool p_below, int &p_new_line, int &p_new_column, int p_last_fit_x = -1) const;
+
 protected:
 	void _notification(int p_what);
 
@@ -816,6 +819,7 @@ public:
 	void remove_secondary_carets();
 	void merge_overlapping_carets();
 	int get_caret_count() const;
+	void add_caret_at_carets(bool p_below);
 
 	Vector<int> get_caret_index_edit_order();
 	void adjust_carets_after_edit(int p_caret, int p_from_line, int p_from_col, int p_to_line, int p_to_col);

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -3313,7 +3313,7 @@ TEST_CASE("[SceneTree][TextEdit] caret") {
 	memdelete(text_edit);
 }
 
-TEST_CASE("[SceneTree][TextEdit] muiticaret") {
+TEST_CASE("[SceneTree][TextEdit] multicaret") {
 	TextEdit *text_edit = memnew(TextEdit);
 	SceneTree::get_singleton()->get_root()->add_child(text_edit);
 	text_edit->set_multiple_carets_enabled(true);
@@ -3401,6 +3401,43 @@ TEST_CASE("[SceneTree][TextEdit] muiticaret") {
 		caret_index_get_order.write[0] = 0;
 		caret_index_get_order.write[1] = 1;
 		CHECK(text_edit->get_caret_index_edit_order() == caret_index_get_order);
+	}
+
+	SUBCASE("[TextEdit] add caret at carets") {
+		text_edit->remove_secondary_carets();
+		text_edit->set_caret_line(1);
+		text_edit->set_caret_column(9);
+
+		text_edit->add_caret_at_carets(true);
+		CHECK(text_edit->get_caret_count() == 2);
+		CHECK(text_edit->get_caret_line(1) == 2);
+		CHECK(text_edit->get_caret_column(1) == 4);
+
+		text_edit->add_caret_at_carets(true);
+		CHECK(text_edit->get_caret_count() == 2);
+
+		text_edit->add_caret_at_carets(false);
+		CHECK(text_edit->get_caret_count() == 3);
+		CHECK(text_edit->get_caret_line(2) == 0);
+		CHECK(text_edit->get_caret_column(2) == 7);
+
+		text_edit->remove_secondary_carets();
+		text_edit->set_caret_line(0);
+		text_edit->set_caret_column(4);
+		text_edit->select(0, 0, 0, 4);
+		text_edit->add_caret_at_carets(true);
+		CHECK(text_edit->get_caret_count() == 2);
+		CHECK(text_edit->get_selection_from_line(1) == 1);
+		CHECK(text_edit->get_selection_to_line(1) == 1);
+		CHECK(text_edit->get_selection_from_column(1) == 0);
+		CHECK(text_edit->get_selection_to_column(1) == 3);
+
+		text_edit->add_caret_at_carets(true);
+		CHECK(text_edit->get_caret_count() == 3);
+		CHECK(text_edit->get_selection_from_line(2) == 2);
+		CHECK(text_edit->get_selection_to_line(2) == 2);
+		CHECK(text_edit->get_selection_from_column(2) == 0);
+		CHECK(text_edit->get_selection_to_column(2) == 4);
 	}
 
 	memdelete(text_edit);


### PR DESCRIPTION
This PR is an enhancement of the multi caret support (#61902). This adds the shortcuts `ui_text_caret_add_below` and `ui_text_caret_add_above`. The default keys are `Ctrl+Shift+Down` and `Ctrl+Shift+Up`. On macOS the default keys are `Ctrl+Shift+L` and `Ctrl+Shift+O`. These shortcuts allow the user to quickly insert multiple carets without using the mouse.

+ [x] Handle selections
+ [x] Handle Wrap
+ [x] Handle RTL

![insert_caret_at_carets](https://user-images.githubusercontent.com/25499721/195212719-5c2a509b-0459-4bf9-8ed6-b1a6e605d4a3.gif)

