### PR TITLE
Fix Editor crash when MeshLibrary gets replaced while used in an open Scene

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -561,10 +561,12 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 				NavigationServer::get_singleton()->region_set_navigation_layers(region, navigation_layers);
 				NavigationServer::get_singleton()->region_set_navmesh(region, navmesh);
 				NavigationServer::get_singleton()->region_set_transform(region, get_global_transform() * nm.xform);
-				if (navigation) {
-					NavigationServer::get_singleton()->region_set_map(region, navigation->get_rid());
-				} else {
-					NavigationServer::get_singleton()->region_set_map(region, get_world()->get_navigation_map());
+				if (is_inside_tree()) {
+					if (navigation) {
+						NavigationServer::get_singleton()->region_set_map(region, navigation->get_rid());
+					} else {
+						NavigationServer::get_singleton()->region_set_map(region, get_world()->get_navigation_map());
+					}
 				}
 				nm.region = region;
 


### PR DESCRIPTION
Fixes #64393

Some functions are intended to be called inside the SceneTree so get_global_transform() and get_world() can work but this is not always the case when the scene is loaded in e.g. an Editor background tab. The MeshLibrary replacement is triggering a lot of them and while transform fails only polluted the error log the call to get_world() was a fatal error that crashed the Editor.

In Godot 4.x this is already guarded / handled slightly differently.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
