### PR TITLE
Fix inserting tabs in TextEdit

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2192,8 +2192,17 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			return;
 		}
 
-		// Handle Unicode (if no modifiers active). Tab	has a value of 0x09.
-		if (allow_unicode_handling && editable && (k->get_unicode() >= 32 || k->get_keycode() == Key::TAB)) {
+		// Handle tab as it has no set unicode value.
+		if (k->is_action("ui_text_indent", true)) {
+			if (editable) {
+				insert_text_at_caret("\t");
+			}
+			accept_event();
+			return;
+		}
+
+		// Handle Unicode (if no modifiers active).
+		if (allow_unicode_handling && editable && k->get_unicode() >= 32) {
 			handle_unicode_input(k->get_unicode());
 			accept_event();
 			return;

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -2944,6 +2944,18 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			text_edit->set_overtype_mode_enabled(false);
 			CHECK_FALSE(text_edit->is_overtype_mode_enabled());
+
+			lines_edited_args.remove_at(0);
+			lines_edited_args.remove_at(1);
+
+			SEND_GUI_KEY_EVENT(text_edit, Key::TAB);
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_text() == "A\tB\nA\tB");
+			CHECK(text_edit->get_caret_column() == 2);
+			CHECK(text_edit->get_caret_column(1) == 2);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 		}
 
 		SIGNAL_UNWATCH(text_edit, "text_set");


### PR DESCRIPTION
`TextEdit` will now handle the `ui_text_indent` action to insert tabs.

supersedes #63054

closes #63052
closes #59021