### PR TITLE
Fix crashing when editing the `TileSet` field

### DIFF
--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -268,8 +268,8 @@ List<int> TilesEditorPlugin::get_sorted_sources(const Ref<TileSet> p_tile_set) c
 	SourceNameComparator::tile_set = p_tile_set;
 	List<int> source_ids;
 
-	for (int i = 0; i < tile_set->get_source_count(); i++) {
-		source_ids.push_back(tile_set->get_source_id(i));
+	for (int i = 0; i < p_tile_set->get_source_count(); i++) {
+		source_ids.push_back(p_tile_set->get_source_id(i));
 	}
 
 	switch (source_sort) {

--- a/editor/plugins/tiles/tiles_editor_plugin.h
+++ b/editor/plugins/tiles/tiles_editor_plugin.h
@@ -122,7 +122,7 @@ public:
 
 	// Sorting.
 	void set_sorting_option(int p_option);
-	List<int> get_sorted_sources(const Ref<TileSet> tile_set) const;
+	List<int> get_sorted_sources(const Ref<TileSet> p_tile_set) const;
 
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #67049. Which regressed by #66808
