### PR TITLE
Expose unregister language & improve usability with GDExtension

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1590,8 +1590,12 @@ Vector<String> Engine::get_singleton_list() const {
 	return ret;
 }
 
-void Engine::register_script_language(ScriptLanguage *p_language) {
-	ScriptServer::register_language(p_language);
+Error Engine::register_script_language(ScriptLanguage *p_language) {
+	return ScriptServer::register_language(p_language);
+}
+
+Error Engine::unregister_script_language(const ScriptLanguage *p_language) {
+	return ScriptServer::unregister_language(p_language);
 }
 
 int Engine::get_script_language_count() {
@@ -1662,6 +1666,7 @@ void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_singleton_list"), &Engine::get_singleton_list);
 
 	ClassDB::bind_method(D_METHOD("register_script_language", "language"), &Engine::register_script_language);
+	ClassDB::bind_method(D_METHOD("unregister_script_language", "language"), &Engine::unregister_script_language);
 	ClassDB::bind_method(D_METHOD("get_script_language_count"), &Engine::get_script_language_count);
 	ClassDB::bind_method(D_METHOD("get_script_language", "index"), &Engine::get_script_language);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -499,7 +499,8 @@ public:
 	void unregister_singleton(const StringName &p_name);
 	Vector<String> get_singleton_list() const;
 
-	void register_script_language(ScriptLanguage *p_language);
+	Error register_script_language(ScriptLanguage *p_language);
+	Error unregister_script_language(const ScriptLanguage *p_language);
 	int get_script_language_count();
 	ScriptLanguage *get_script_language(int p_index) const;
 

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -165,22 +165,30 @@ ScriptLanguage *ScriptServer::get_language(int p_idx) {
 	return _languages[p_idx];
 }
 
-void ScriptServer::register_language(ScriptLanguage *p_language) {
-	ERR_FAIL_NULL(p_language);
-	ERR_FAIL_COND(_language_count >= MAX_LANGUAGES);
+Error ScriptServer::register_language(ScriptLanguage *p_language) {
+	ERR_FAIL_NULL_V(p_language, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V_MSG(_language_count >= MAX_LANGUAGES, ERR_UNAVAILABLE, "Script languages limit has been reach, cannot register more.");
+	for (int i = 0; i < _language_count; i++) {
+		const ScriptLanguage *other_language = _languages[i];
+		ERR_FAIL_COND_V_MSG(other_language->get_extension() == p_language->get_extension(), ERR_ALREADY_EXISTS, "A script language with extension '" + p_language->get_extension() + "' is already registered.");
+		ERR_FAIL_COND_V_MSG(other_language->get_name() == p_language->get_name(), ERR_ALREADY_EXISTS, "A script language with name '" + p_language->get_name() + "' is already registered.");
+		ERR_FAIL_COND_V_MSG(other_language->get_type() == p_language->get_type(), ERR_ALREADY_EXISTS, "A script language with type '" + p_language->get_type() + "' is already registered.");
+	}
 	_languages[_language_count++] = p_language;
+	return OK;
 }
 
-void ScriptServer::unregister_language(const ScriptLanguage *p_language) {
+Error ScriptServer::unregister_language(const ScriptLanguage *p_language) {
 	for (int i = 0; i < _language_count; i++) {
 		if (_languages[i] == p_language) {
 			_language_count--;
 			if (i < _language_count) {
 				SWAP(_languages[i], _languages[_language_count]);
 			}
-			return;
+			return OK;
 		}
 	}
+	return ERR_DOES_NOT_EXIST;
 }
 
 void ScriptServer::init_languages() {

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -70,8 +70,8 @@ public:
 	static bool is_scripting_enabled();
 	_FORCE_INLINE_ static int get_language_count() { return _language_count; }
 	static ScriptLanguage *get_language(int p_idx);
-	static void register_language(ScriptLanguage *p_language);
-	static void unregister_language(const ScriptLanguage *p_language);
+	static Error register_language(ScriptLanguage *p_language);
+	static Error unregister_language(const ScriptLanguage *p_language);
 
 	static void set_reload_scripts_on_save(bool p_enable);
 	static bool is_reload_scripts_on_save_enabled();

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -244,10 +244,14 @@
 			</description>
 		</method>
 		<method name="register_script_language">
-			<return type="void" />
+			<return type="int" enum="Error" />
 			<param index="0" name="language" type="ScriptLanguage" />
 			<description>
 				Registers a [ScriptLanguage] instance to be available with [code]ScriptServer[/code].
+				Returns:
+				- [constant OK] on success
+				- [constant ERR_UNAVAILABLE] if [code]ScriptServer[/code] has reached it limit and cannot register any new language
+				- [constant ERR_ALREADY_EXISTS] if [code]ScriptServer[/code] already contains a language with similar extension/name/type
 			</description>
 		</method>
 		<method name="register_singleton">
@@ -256,6 +260,16 @@
 			<param index="1" name="instance" type="Object" />
 			<description>
 				Registers the given object as a singleton, globally available under [param name].
+			</description>
+		</method>
+		<method name="unregister_script_language">
+			<return type="int" enum="Error" />
+			<param index="0" name="language" type="ScriptLanguage" />
+			<description>
+				Unregisters the [ScriptLanguage] instance from [code]ScriptServer[/code].
+				Returns:
+				- [constant OK] on success
+				- [constant ERR_DOES_NOT_EXIST] if the language is already not registered in [code]ScriptServer[/code]
 			</description>
 		</method>
 		<method name="unregister_singleton">


### PR DESCRIPTION
This PR is separated into 3 commits:
- first add `Engine::unregister_script` (currently only `Engine::register_script` is present), this is needed by GDExtension when the asked is torndown
- second modify `Engine::register_script`&`Engine::unregister_script` to return a boolean indicating the operation succeeded, this is required to know if the `ScriptLanguageExtension` instance passed in parameter can be safely freed (currently we have the choice between memory leak or segfault 😄 )
- last one add sanity checks to `Engine::register_script` to ensure we don't end up with multiple script languages using the same extension/name/type.

Of course I can remove some of the commits if you think it is not needed ;-)