### PR TITLE
Fix the conditions for firing 'No such file or directory' error on Linux `move_to_trash`

### DIFF
--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -622,32 +622,41 @@ Error OS_LinuxBSD::move_to_trash(const String &p_path) {
 	args.push_back(path);
 	args.push_front("trash"); // The command is `gio trash <file_name>` so we need to add it to args.
 	Error result = execute("gio", args, nullptr, &err_code); // For GNOME based machines.
-	if (result == OK && !err_code) {
-		return OK;
-	} else if (err_code == 2) {
-		return ERR_FILE_NOT_FOUND;
+	if (result == OK) { // The `execute` function has done its job without errors.
+		if (!err_code) { // The shell command has been executed without errors.
+			return OK;
+		} else if (err_code == 1) {
+			ERR_PRINT("move_to_trash: No such file or directory as " + path + ".");
+			return ERR_FILE_NOT_FOUND;
+		}
 	}
 
 	args.pop_front();
 	args.push_front("move");
 	args.push_back("trash:/"); // The command is `kioclient5 move <file_name> trash:/`.
 	result = execute("kioclient5", args, nullptr, &err_code); // For KDE based machines.
-	if (result == OK && !err_code) {
-		return OK;
-	} else if (err_code == 2) {
-		return ERR_FILE_NOT_FOUND;
+	if (result == OK) { // The `execute` function has done its job without errors.
+		if (!err_code) { // The shell command has been executed without errors.
+			return OK;
+		} else if (err_code == 1) {
+			ERR_PRINT("move_to_trash: No such file or directory as " + path + ".");
+			return ERR_FILE_NOT_FOUND;
+		}
 	}
 
 	args.pop_front();
 	args.pop_back();
 	result = execute("gvfs-trash", args, nullptr, &err_code); // For older Linux machines.
-	if (result == OK && !err_code) {
-		return OK;
-	} else if (err_code == 2) {
-		return ERR_FILE_NOT_FOUND;
+	if (result == OK) { // The `execute` function has done its job without errors.
+		if (!err_code) { // The shell command has been executed without errors.
+			return OK;
+		} else if (err_code == 1) {
+			ERR_PRINT("move_to_trash: No such file or directory as " + path + ".");
+			return ERR_FILE_NOT_FOUND;
+		}
 	}
 
-	// If the commands `kioclient5`, `gio` or `gvfs-trash` don't exist on the system we do it manually.
+	// If the commands `kioclient5`, `gio` or `gvfs-trash` don't work on the system we do it manually.
 	String trash_path = "";
 	String mnt = get_mountpoint(path);
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #67157