### PR TITLE
[macOS] Fix window button position and title bar size when editor scale do not match OS UI scale.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1116,10 +1116,10 @@
 			</description>
 		</method>
 		<method name="window_get_safe_title_margins" qualifiers="const">
-			<return type="Vector2i" />
+			<return type="Vector3i" />
 			<param index="0" name="window_id" type="int" default="0" />
 			<description>
-				Returns left and right margins of the title that are safe to use (contains no buttons or other elements) when [constant WINDOW_FLAG_EXTEND_TO_TITLE] flag is set.
+				Returns left margins ([code]x[/code]), right margins ([code]y[/code]) adn height ([code]z[/code]) of the title that are safe to use (contains no buttons or other elements) when [constant WINDOW_FLAG_EXTEND_TO_TITLE] flag is set.
 			</description>
 		</method>
 		<method name="window_get_size" qualifiers="const">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1181,7 +1181,8 @@ void EditorNode::_vp_resized() {
 }
 
 void EditorNode::_titlebar_resized() {
-	const Size2 &margin = DisplayServer::get_singleton()->window_get_safe_title_margins(DisplayServer::MAIN_WINDOW_ID);
+	DisplayServer::get_singleton()->window_set_window_buttons_offset(Vector2i(menu_hb->get_global_position().y + menu_hb->get_size().y / 2, menu_hb->get_global_position().y + menu_hb->get_size().y / 2), DisplayServer::MAIN_WINDOW_ID);
+	const Vector3i &margin = DisplayServer::get_singleton()->window_get_safe_title_margins(DisplayServer::MAIN_WINDOW_ID);
 	if (left_menu_spacer) {
 		int w = (gui_base->is_layout_rtl()) ? margin.y : margin.x;
 		left_menu_spacer->set_custom_minimum_size(Size2(w, 0));
@@ -1189,6 +1190,9 @@ void EditorNode::_titlebar_resized() {
 	if (right_menu_spacer) {
 		int w = (gui_base->is_layout_rtl()) ? margin.x : margin.y;
 		right_menu_spacer->set_custom_minimum_size(Size2(w, 0));
+	}
+	if (menu_hb) {
+		menu_hb->set_custom_minimum_size(Size2(0, margin.z - menu_hb->get_global_position().y));
 	}
 }
 
@@ -7560,7 +7564,6 @@ EditorNode::EditorNode() {
 
 	// Extend menu bar to window title.
 	if (can_expand) {
-		DisplayServer::get_singleton()->window_set_window_buttons_offset(Vector2i(menu_hb->get_minimum_size().y / 2, menu_hb->get_minimum_size().y / 2), DisplayServer::MAIN_WINDOW_ID);
 		DisplayServer::get_singleton()->window_set_flag(DisplayServer::WINDOW_FLAG_EXTEND_TO_TITLE, true, DisplayServer::MAIN_WINDOW_ID);
 		menu_hb->set_can_move_window(true);
 	}

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -401,7 +401,7 @@ public:
 	virtual bool window_minimize_on_title_dbl_click() const override;
 
 	virtual void window_set_window_buttons_offset(const Vector2i &p_offset, WindowID p_window = MAIN_WINDOW_ID) override;
-	virtual Vector2i window_get_safe_title_margins(WindowID p_window = MAIN_WINDOW_ID) const override;
+	virtual Vector3i window_get_safe_title_margins(WindowID p_window = MAIN_WINDOW_ID) const override;
 
 	virtual Point2i ime_get_selection() const override;
 	virtual String ime_get_text() const override;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -2655,25 +2655,33 @@ void DisplayServerMacOS::window_set_window_buttons_offset(const Vector2i &p_offs
 
 	ERR_FAIL_COND(!windows.has(p_window));
 	WindowData &wd = windows[p_window];
-	wd.wb_offset = p_offset;
+	float scale = screen_get_max_scale();
+	wd.wb_offset = p_offset / scale;
+	wd.wb_offset.x = MAX(wd.wb_offset.x, 12);
+	wd.wb_offset.y = MAX(wd.wb_offset.y, 12);
+	if (wd.window_button_view) {
+		[wd.window_button_view setOffset:NSMakePoint(wd.wb_offset.x, wd.wb_offset.y)];
+	}
 }
 
-Vector2i DisplayServerMacOS::window_get_safe_title_margins(WindowID p_window) const {
+Vector3i DisplayServerMacOS::window_get_safe_title_margins(WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 
-	ERR_FAIL_COND_V(!windows.has(p_window), Vector2i());
+	ERR_FAIL_COND_V(!windows.has(p_window), Vector3i());
 	const WindowData &wd = windows[p_window];
 
 	if (!wd.window_button_view) {
-		return Vector2i();
+		return Vector3i();
 	}
 
-	float max_x = wd.wb_offset.x + [wd.window_button_view frame].size.width;
+	float scale = screen_get_max_scale();
+	float max_x = [wd.window_button_view getOffset].x + [wd.window_button_view frame].size.width;
+	float max_y = [wd.window_button_view getOffset].y + [wd.window_button_view frame].size.height;
 
 	if ([wd.window_object windowTitlebarLayoutDirection] == NSUserInterfaceLayoutDirectionRightToLeft) {
-		return Vector2i(0, max_x * screen_get_max_scale());
+		return Vector3i(0, max_x * scale, max_y * scale);
 	} else {
-		return Vector2i(max_x * screen_get_max_scale(), 0);
+		return Vector3i(max_x * scale, 0, max_y * scale);
 	}
 }
 

--- a/platform/macos/godot_button_view.h
+++ b/platform/macos/godot_button_view.h
@@ -42,10 +42,15 @@
 	CGFloat spacing;
 	bool mouse_in_group;
 	bool rtl;
+	NSButton *close_button;
+	NSButton *miniaturize_button;
+	NSButton *zoom_button;
 }
 
 - (void)initButtons:(CGFloat)button_spacing offset:(NSPoint)button_offset rtl:(bool)is_rtl;
 - (void)displayButtons;
+- (void)setOffset:(NSPoint)button_offset;
+- (NSPoint)getOffset;
 
 @end
 

--- a/platform/macos/godot_button_view.mm
+++ b/platform/macos/godot_button_view.mm
@@ -40,6 +40,9 @@
 	spacing = 20;
 	mouse_in_group = false;
 	rtl = false;
+	close_button = nullptr;
+	miniaturize_button = nullptr;
+	zoom_button = nullptr;
 
 	return self;
 }
@@ -48,15 +51,15 @@
 	spacing = button_spacing;
 	rtl = is_rtl;
 
-	NSButton *close_button = [NSWindow standardWindowButton:NSWindowCloseButton forStyleMask:NSWindowStyleMaskTitled];
+	close_button = [NSWindow standardWindowButton:NSWindowCloseButton forStyleMask:NSWindowStyleMaskTitled];
 	[close_button setFrameOrigin:NSMakePoint(rtl ? spacing * 2 : 0, 0)];
 	[self addSubview:close_button];
 
-	NSButton *miniaturize_button = [NSWindow standardWindowButton:NSWindowMiniaturizeButton forStyleMask:NSWindowStyleMaskTitled];
+	miniaturize_button = [NSWindow standardWindowButton:NSWindowMiniaturizeButton forStyleMask:NSWindowStyleMaskTitled];
 	[miniaturize_button setFrameOrigin:NSMakePoint(spacing, 0)];
 	[self addSubview:miniaturize_button];
 
-	NSButton *zoom_button = [NSWindow standardWindowButton:NSWindowZoomButton forStyleMask:NSWindowStyleMaskTitled];
+	zoom_button = [NSWindow standardWindowButton:NSWindowZoomButton forStyleMask:NSWindowStyleMaskTitled];
 	[zoom_button setFrameOrigin:NSMakePoint(rtl ? 0 : spacing * 2, 0)];
 	[self addSubview:zoom_button];
 
@@ -69,6 +72,19 @@
 		[self setFrameSize:NSMakeSize(zoom_button.frame.origin.x + zoom_button.frame.size.width, zoom_button.frame.size.height)];
 	}
 	[self displayButtons];
+}
+
+- (void)setOffset:(NSPoint)button_offset {
+	if (zoom_button) {
+		offset.y = button_offset.y - zoom_button.frame.size.height / 2;
+		offset.x = button_offset.x - zoom_button.frame.size.width / 2;
+
+		[self viewDidMoveToWindow];
+	}
+}
+
+- (NSPoint)getOffset {
+	return offset;
 }
 
 - (void)viewDidMoveToWindow {

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -382,7 +382,7 @@ public:
 	virtual void window_move_to_foreground(WindowID p_window = MAIN_WINDOW_ID) = 0;
 
 	virtual void window_set_window_buttons_offset(const Vector2i &p_offset, WindowID p_window = MAIN_WINDOW_ID) {}
-	virtual Vector2i window_get_safe_title_margins(WindowID p_window = MAIN_WINDOW_ID) const { return Vector2i(); }
+	virtual Vector3i window_get_safe_title_margins(WindowID p_window = MAIN_WINDOW_ID) const { return Vector3i(); }
 
 	virtual bool window_can_draw(WindowID p_window = MAIN_WINDOW_ID) const = 0;
 


### PR DESCRIPTION
Fix window button position and title bar size when editor scale is set manually do not match OS UI scale.