### PR TITLE
Vulkan Clustered: Fix culling of negatively-scaled objects

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -754,7 +754,7 @@ void RenderForwardClustered::_fill_instance_data(RenderListType p_render_list, i
 
 		bool cant_repeat = instance_data.flags & INSTANCE_DATA_FLAG_MULTIMESH || inst->mesh_instance.is_valid();
 
-		if (prev_surface != nullptr && !cant_repeat && prev_surface->sort.sort_key1 == surface->sort.sort_key1 && prev_surface->sort.sort_key2 == surface->sort.sort_key2 && repeats < RenderElementInfo::MAX_REPEATS) {
+		if (prev_surface != nullptr && !cant_repeat && prev_surface->sort.sort_key1 == surface->sort.sort_key1 && prev_surface->sort.sort_key2 == surface->sort.sort_key2 && inst->mirror == prev_surface->owner->mirror && repeats < RenderElementInfo::MAX_REPEATS) {
 			//this element is the same as the previous one, count repeats to draw it using instancing
 			repeats++;
 		} else {


### PR DESCRIPTION
Negatively scaled objects should be mirrored. This is already implemented, but it breaks when mirrored and non-mirrored instances of the same object are visible together.

It turns out that the code that skips-over repeats in `RenderForwardClustered::_render_list_template` also skips the code that accounts for the culling mode of mirrored objects.

The solution here is to consider the `mirror` flag when determining repeats. This might result in more draw commands than necessary since a mirrored object can split a group of non-mirrored instances in two. Maybe we can optimize that later? I don't expect mirrored objects to be common.

This problem doesn't appear in the mobile renderer because the repeat optimization isn't implemented there yet.

The problem still appears in MultiMeshInstance3D in *all* renderers.

Fixes #62879 and fixes #58546.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
