### PR TITLE
Add `animation_selected` signal to AnimationPlayerEditor to subscribe changed animation

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -302,6 +302,8 @@ void AnimationPlayerEditor::_animation_selected(int p_which) {
 
 	AnimationPlayerEditor::get_singleton()->get_track_editor()->update_keying();
 	_animation_key_editor_seek(timeline_position, false);
+
+	emit_signal("animation_selected", current);
 }
 
 void AnimationPlayerEditor::_animation_new() {
@@ -1552,6 +1554,8 @@ void AnimationPlayerEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_prepare_onion_layers_2"), &AnimationPlayerEditor::_prepare_onion_layers_2);
 	ClassDB::bind_method(D_METHOD("_start_onion_skinning"), &AnimationPlayerEditor::_start_onion_skinning);
 	ClassDB::bind_method(D_METHOD("_stop_onion_skinning"), &AnimationPlayerEditor::_stop_onion_skinning);
+
+	ADD_SIGNAL(MethodInfo("animation_selected", PropertyInfo(Variant::STRING, "name")));
 }
 
 AnimationPlayerEditor *AnimationPlayerEditor::singleton = nullptr;


### PR DESCRIPTION
Supersedes #67113.

I am creating an add-on to display data added to Animation, but it is impractical to extend AnimationPlayerEditor directly, so a new EditorPlugin must be added separately.

However, it is blocked because AnimationPlayerEditor does not notify that the Animation has been changed.

This PR adds the animation_changed signal to AnimationPlayerEditor, allowing the creation of a plugin that displays information about the Animation separately from AnimationPlayerEditor.

![image](https://user-images.githubusercontent.com/61938263/194821490-734b0855-0f6a-420e-96ff-4bbf187ca010.png)

---
#### Test model

Blender Chan! / CC by [SearKitchen](https://sketchfab.com/searkitchen)
https://sketchfab.com/3d-models/blender-chan-6835f0d60e0c4813812c0247e3b73da7