### PR TITLE
Show warning when scaling Light3D nodes

### DIFF
--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -165,6 +165,16 @@ AABB Light3D::get_aabb() const {
 	return AABB();
 }
 
+PackedStringArray Light3D::get_configuration_warnings() const {
+	PackedStringArray warnings = VisualInstance3D::get_configuration_warnings();
+
+	if (!get_scale().is_equal_approx(Vector3(1, 1, 1))) {
+		warnings.push_back(RTR("A light's scale does not affect the visual size of the light."));
+	}
+
+	return warnings;
+}
+
 void Light3D::set_bake_mode(BakeMode p_mode) {
 	bake_mode = p_mode;
 	RS::get_singleton()->light_set_bake_mode(light, RS::LightBakeMode(p_mode));
@@ -579,7 +589,7 @@ OmniLight3D::ShadowMode OmniLight3D::get_shadow_mode() const {
 }
 
 PackedStringArray OmniLight3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+	PackedStringArray warnings = Light3D::get_configuration_warnings();
 
 	if (!has_shadow() && get_projector().is_valid()) {
 		warnings.push_back(RTR("Projector texture only works with shadows active."));
@@ -609,7 +619,7 @@ OmniLight3D::OmniLight3D() :
 }
 
 PackedStringArray SpotLight3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+	PackedStringArray warnings = Light3D::get_configuration_warnings();
 
 	if (has_shadow() && get_param(PARAM_SPOT_ANGLE) >= 90.0) {
 		warnings.push_back(RTR("A SpotLight3D with an angle wider than 90 degrees cannot cast shadows."));

--- a/scene/3d/light_3d.h
+++ b/scene/3d/light_3d.h
@@ -147,6 +147,7 @@ public:
 	Color get_correlated_color() const;
 
 	virtual AABB get_aabb() const override;
+	virtual PackedStringArray get_configuration_warnings() const override;
 
 	Light3D();
 	~Light3D();


### PR DESCRIPTION
Complements #67098 

![image](https://user-images.githubusercontent.com/5117197/194869165-79794e8b-a764-4ba4-9ae9-c6935b8305b4.png)

Since Light3D has `set_disable_scale(true);`, trying to use the gizmos to scale lights will not do anything. So this warning will only show up if the user manually edits the scale in the inspector.

Not sure about where to put the `update_configuration_warnings()` call.