### PR TITLE
[Windows] Fix GCC MinGW warnings.

### DIFF
--- a/platform/windows/joypad_windows.h
+++ b/platform/windows/joypad_windows.h
@@ -85,6 +85,8 @@ private:
 			last_pad = -1;
 			attached = false;
 			confirmed = false;
+			di_joy = nullptr;
+			guid = {};
 
 			for (int i = 0; i < MAX_JOY_BUTTONS; i++) {
 				last_buttons[i] = false;


### PR DESCRIPTION
Fixes the following MinGW / GCC 12.2.0 warnings:

```
In file included from platform/windows/joypad_windows.cpp:31:
In member function 'JoypadWindows::dinput_gamepad& JoypadWindows::dinput_gamepad::operator=(JoypadWindows::dinput_gamepad&&)',
    inlined from 'bool JoypadWindows::setup_dinput_joypad(const DIDEVICEINSTANCE*)' at platform/windows/joypad_windows.cpp:152:34:
platform/windows/joypad_windows.h:72:16: warning: '<anonymous>.JoypadWindows::dinput_gamepad::di_joy' may be used uninitialized [-Wmaybe-uninitialized]
   72 |         struct dinput_gamepad {
      |                ^~~~~~~~~~~~~~
platform/windows/joypad_windows.cpp: In member function 'bool JoypadWindows::setup_dinput_joypad(const DIDEVICEINSTANCE*)':
platform/windows/joypad_windows.cpp:152:41: note: '<anonymous>' declared here
  152 |         d_joypads[num] = dinput_gamepad();
      |                                         ^
In member function 'JoypadWindows::dinput_gamepad& JoypadWindows::dinput_gamepad::operator=(JoypadWindows::dinput_gamepad&&)',
    inlined from 'bool JoypadWindows::setup_dinput_joypad(const DIDEVICEINSTANCE*)' at platform/windows/joypad_windows.cpp:152:34:
platform/windows/joypad_windows.h:72:16: warning: '<anonymous>.JoypadWindows::dinput_gamepad::guid' may be used uninitialized [-Wmaybe-uninitialized]
   72 |         struct dinput_gamepad {
      |                ^~~~~~~~~~~~~~
platform/windows/joypad_windows.cpp: In member function 'bool JoypadWindows::setup_dinput_joypad(const DIDEVICEINSTANCE*)':
platform/windows/joypad_windows.cpp:152:41: note: '<anonymous>' declared here
  152 |         d_joypads[num] = dinput_gamepad();
      |                                         ^
```