### PR TITLE
Resize project dialog only when necessary

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -143,7 +143,11 @@ private:
 			install_status_rect->set_texture(new_icon);
 		}
 
-		set_size(Size2(500, 0) * EDSCALE);
+		Size2i window_size = get_size();
+		Size2 contents_min_size = get_contents_minimum_size();
+		if (window_size.x < contents_min_size.x || window_size.y < contents_min_size.y) {
+			set_size(window_size.max(contents_min_size));
+		}
 	}
 
 	String _test_path() {

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -651,9 +651,9 @@ void Window::_update_window_size() {
 			DisplayServer::get_singleton()->window_set_min_size(Size2i(), window_id);
 		}
 
-		DisplayServer::get_singleton()->window_set_size(size, window_id);
 		DisplayServer::get_singleton()->window_set_max_size(max_size_valid ? max_size : Size2i(), window_id);
 		DisplayServer::get_singleton()->window_set_min_size(size_limit, window_id);
+		DisplayServer::get_singleton()->window_set_size(size, window_id);
 	}
 
 	//update the viewport


### PR DESCRIPTION
Fixes #66620.

To improve both performance and user experience, we should not resize the dialog on every message change. Rather we resize it only if the content wouldn't fit into the current window size.

The other thing encountered while fixing this is that (at least) on X11 resizing window can fail if the requested size does not fall into current min and max range. Therefore, we should first change the min and max values and only then set the new size value.