### PR TITLE
Fix crash when serializing empty delegates in C#

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
@@ -76,6 +76,11 @@ namespace Godot
 
         internal static bool TrySerializeDelegate(Delegate @delegate, Collections.Array serializedData)
         {
+            if (@delegate is null)
+            {
+                return false;
+            }
+
             if (@delegate is MulticastDelegate multicastDelegate)
             {
                 bool someDelegatesSerialized = false;


### PR DESCRIPTION
Resolves #67212

