### PR TITLE
Use `Packed*Array` over `Vector<T>` in Variant

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1793,31 +1793,31 @@ String Variant::stringify(int recursion_count) const {
 		}
 		// Packed arrays cannot contain recursive structures, the recursion_count increment is not needed.
 		case PACKED_VECTOR2_ARRAY: {
-			return stringify_vector(operator Vector<Vector2>(), recursion_count);
+			return stringify_vector(operator PackedVector2Array(), recursion_count);
 		}
 		case PACKED_VECTOR3_ARRAY: {
-			return stringify_vector(operator Vector<Vector3>(), recursion_count);
+			return stringify_vector(operator PackedVector3Array(), recursion_count);
 		}
 		case PACKED_COLOR_ARRAY: {
-			return stringify_vector(operator Vector<Color>(), recursion_count);
+			return stringify_vector(operator PackedColorArray(), recursion_count);
 		}
 		case PACKED_STRING_ARRAY: {
-			return stringify_vector(operator Vector<String>(), recursion_count);
+			return stringify_vector(operator PackedStringArray(), recursion_count);
 		}
 		case PACKED_BYTE_ARRAY: {
-			return stringify_vector(operator Vector<uint8_t>(), recursion_count);
+			return stringify_vector(operator PackedByteArray(), recursion_count);
 		}
 		case PACKED_INT32_ARRAY: {
-			return stringify_vector(operator Vector<int32_t>(), recursion_count);
+			return stringify_vector(operator PackedInt32Array(), recursion_count);
 		}
 		case PACKED_INT64_ARRAY: {
-			return stringify_vector(operator Vector<int64_t>(), recursion_count);
+			return stringify_vector(operator PackedInt64Array(), recursion_count);
 		}
 		case PACKED_FLOAT32_ARRAY: {
-			return stringify_vector(operator Vector<float>(), recursion_count);
+			return stringify_vector(operator PackedFloat32Array(), recursion_count);
 		}
 		case PACKED_FLOAT64_ARRAY: {
-			return stringify_vector(operator Vector<double>(), recursion_count);
+			return stringify_vector(operator PackedFloat64Array(), recursion_count);
 		}
 		case ARRAY: {
 			ERR_FAIL_COND_V_MSG(recursion_count > MAX_RECURSION, "[...]", "Maximum array recursion reached!");
@@ -2207,31 +2207,31 @@ inline DA _convert_array_from_variant(const Variant &p_variant) {
 			return _convert_array<DA, Array>(p_variant.operator Array());
 		}
 		case Variant::PACKED_BYTE_ARRAY: {
-			return _convert_array<DA, Vector<uint8_t>>(p_variant.operator Vector<uint8_t>());
+			return _convert_array<DA, PackedByteArray>(p_variant.operator PackedByteArray());
 		}
 		case Variant::PACKED_INT32_ARRAY: {
-			return _convert_array<DA, Vector<int32_t>>(p_variant.operator Vector<int32_t>());
+			return _convert_array<DA, PackedInt32Array>(p_variant.operator PackedInt32Array());
 		}
 		case Variant::PACKED_INT64_ARRAY: {
-			return _convert_array<DA, Vector<int64_t>>(p_variant.operator Vector<int64_t>());
+			return _convert_array<DA, PackedInt64Array>(p_variant.operator PackedInt64Array());
 		}
 		case Variant::PACKED_FLOAT32_ARRAY: {
-			return _convert_array<DA, Vector<float>>(p_variant.operator Vector<float>());
+			return _convert_array<DA, PackedFloat32Array>(p_variant.operator PackedFloat32Array());
 		}
 		case Variant::PACKED_FLOAT64_ARRAY: {
-			return _convert_array<DA, Vector<double>>(p_variant.operator Vector<double>());
+			return _convert_array<DA, PackedFloat64Array>(p_variant.operator PackedFloat64Array());
 		}
 		case Variant::PACKED_STRING_ARRAY: {
-			return _convert_array<DA, Vector<String>>(p_variant.operator Vector<String>());
+			return _convert_array<DA, PackedStringArray>(p_variant.operator PackedStringArray());
 		}
 		case Variant::PACKED_VECTOR2_ARRAY: {
-			return _convert_array<DA, Vector<Vector2>>(p_variant.operator Vector<Vector2>());
+			return _convert_array<DA, PackedVector2Array>(p_variant.operator PackedVector2Array());
 		}
 		case Variant::PACKED_VECTOR3_ARRAY: {
-			return _convert_array<DA, Vector<Vector3>>(p_variant.operator Vector<Vector3>());
+			return _convert_array<DA, PackedVector3Array>(p_variant.operator PackedVector3Array());
 		}
 		case Variant::PACKED_COLOR_ARRAY: {
-			return _convert_array<DA, Vector<Color>>(p_variant.operator Vector<Color>());
+			return _convert_array<DA, PackedColorArray>(p_variant.operator PackedColorArray());
 		}
 		default: {
 			return DA();
@@ -2247,75 +2247,75 @@ Variant::operator Array() const {
 	}
 }
 
-Variant::operator Vector<uint8_t>() const {
+Variant::operator PackedByteArray() const {
 	if (type == PACKED_BYTE_ARRAY) {
 		return static_cast<PackedArrayRef<uint8_t> *>(_data.packed_array)->array;
 	} else {
-		return _convert_array_from_variant<Vector<uint8_t>>(*this);
+		return _convert_array_from_variant<PackedByteArray>(*this);
 	}
 }
 
-Variant::operator Vector<int32_t>() const {
+Variant::operator PackedInt32Array() const {
 	if (type == PACKED_INT32_ARRAY) {
 		return static_cast<PackedArrayRef<int32_t> *>(_data.packed_array)->array;
 	} else {
-		return _convert_array_from_variant<Vector<int>>(*this);
+		return _convert_array_from_variant<PackedInt32Array>(*this);
 	}
 }
 
-Variant::operator Vector<int64_t>() const {
+Variant::operator PackedInt64Array() const {
 	if (type == PACKED_INT64_ARRAY) {
 		return static_cast<PackedArrayRef<int64_t> *>(_data.packed_array)->array;
 	} else {
-		return _convert_array_from_variant<Vector<int64_t>>(*this);
+		return _convert_array_from_variant<PackedInt64Array>(*this);
 	}
 }
 
-Variant::operator Vector<float>() const {
+Variant::operator PackedFloat32Array() const {
 	if (type == PACKED_FLOAT32_ARRAY) {
 		return static_cast<PackedArrayRef<float> *>(_data.packed_array)->array;
 	} else {
-		return _convert_array_from_variant<Vector<float>>(*this);
+		return _convert_array_from_variant<PackedFloat32Array>(*this);
 	}
 }
 
-Variant::operator Vector<double>() const {
+Variant::operator PackedFloat64Array() const {
 	if (type == PACKED_FLOAT64_ARRAY) {
 		return static_cast<PackedArrayRef<double> *>(_data.packed_array)->array;
 	} else {
-		return _convert_array_from_variant<Vector<double>>(*this);
+		return _convert_array_from_variant<PackedFloat64Array>(*this);
 	}
 }
 
-Variant::operator Vector<String>() const {
+Variant::operator PackedStringArray() const {
 	if (type == PACKED_STRING_ARRAY) {
 		return static_cast<PackedArrayRef<String> *>(_data.packed_array)->array;
 	} else {
-		return _convert_array_from_variant<Vector<String>>(*this);
+		return _convert_array_from_variant<PackedStringArray>(*this);
 	}
 }
 
-Variant::operator Vector<Vector3>() const {
-	if (type == PACKED_VECTOR3_ARRAY) {
-		return static_cast<PackedArrayRef<Vector3> *>(_data.packed_array)->array;
-	} else {
-		return _convert_array_from_variant<Vector<Vector3>>(*this);
-	}
-}
-
-Variant::operator Vector<Vector2>() const {
+Variant::operator PackedVector2Array() const {
 	if (type == PACKED_VECTOR2_ARRAY) {
 		return static_cast<PackedArrayRef<Vector2> *>(_data.packed_array)->array;
 	} else {
-		return _convert_array_from_variant<Vector<Vector2>>(*this);
+		return _convert_array_from_variant<PackedVector2Array>(*this);
 	}
 }
 
-Variant::operator Vector<Color>() const {
+Variant::operator PackedVector3Array() const {
+	if (type == PACKED_VECTOR3_ARRAY) {
+		return static_cast<PackedArrayRef<Vector3> *>(_data.packed_array)->array;
+	} else {
+		return _convert_array_from_variant<PackedVector3Array>(*this);
+	}
+}
+
+Variant::operator PackedColorArray() const {
 	if (type == PACKED_COLOR_ARRAY) {
 		return static_cast<PackedArrayRef<Color> *>(_data.packed_array)->array;
 	} else {
-		return _convert_array_from_variant<Vector<Color>>(*this);
+		return _convert_array_from_variant<PackedColorArray>(*this);
 	}
 }
 
@@ -2350,7 +2350,7 @@ Variant::operator Vector<Plane>() const {
 }
 
 Variant::operator Vector<Face3>() const {
-	Vector<Vector3> va = operator Vector<Vector3>();
+	PackedVector3Array va = operator PackedVector3Array();
 	Vector<Face3> faces;
 	int va_size = va.size();
 	if (va_size == 0) {
@@ -2386,7 +2386,7 @@ Variant::operator Vector<Variant>() const {
 }
 
 Variant::operator Vector<StringName>() const {
-	Vector<String> from = operator Vector<String>();
+	PackedStringArray from = operator PackedStringArray();
 	Vector<StringName> to;
 	int len = from.size();
 	to.resize(len);
@@ -2646,18 +2646,53 @@ Variant::Variant(const Array &p_array) {
 	memnew_placement(_data._mem, Array(p_array));
 }
 
-Variant::Variant(const Vector<Plane> &p_array) {
-	type = ARRAY;
+Variant::Variant(const PackedByteArray &p_byte_array) {
+	type = PACKED_BYTE_ARRAY;
 
-	Array *plane_array = memnew_placement(_data._mem, Array);
-
-	plane_array->resize(p_array.size());
-
-	for (int i = 0; i < p_array.size(); i++) {
-		plane_array->operator[](i) = Variant(p_array[i]);
-	}
+	_data.packed_array = PackedArrayRef<uint8_t>::create(p_byte_array);
 }
 
+Variant::Variant(const PackedInt32Array &p_int32_array) {
+	type = PACKED_INT32_ARRAY;
+	_data.packed_array = PackedArrayRef<int32_t>::create(p_int32_array);
+}
+
+Variant::Variant(const PackedInt64Array &p_int64_array) {
+	type = PACKED_INT64_ARRAY;
+	_data.packed_array = PackedArrayRef<int64_t>::create(p_int64_array);
+}
+
+Variant::Variant(const PackedFloat32Array &p_float32_array) {
+	type = PACKED_FLOAT32_ARRAY;
+	_data.packed_array = PackedArrayRef<float>::create(p_float32_array);
+}
+
+Variant::Variant(const PackedFloat64Array &p_float64_array) {
+	type = PACKED_FLOAT64_ARRAY;
+	_data.packed_array = PackedArrayRef<double>::create(p_float64_array);
+}
+
+Variant::Variant(const PackedStringArray &p_string_array) {
+	type = PACKED_STRING_ARRAY;
+	_data.packed_array = PackedArrayRef<String>::create(p_string_array);
+}
+
+Variant::Variant(const PackedVector2Array &p_vector2_array) {
+	type = PACKED_VECTOR2_ARRAY;
+	_data.packed_array = PackedArrayRef<Vector2>::create(p_vector2_array);
+}
+
+Variant::Variant(const PackedVector3Array &p_vector3_array) {
+	type = PACKED_VECTOR3_ARRAY;
+	_data.packed_array = PackedArrayRef<Vector3>::create(p_vector3_array);
+}
+
+Variant::Variant(const PackedColorArray &p_color_array) {
+	type = PACKED_COLOR_ARRAY;
+	_data.packed_array = PackedArrayRef<Color>::create(p_color_array);
+}
+
+/* helpers */
 Variant::Variant(const Vector<::RID> &p_array) {
 	type = ARRAY;
 
@@ -2670,54 +2705,20 @@ Variant::Variant(const Vector<::RID> &p_array) {
 	}
 }
 
-Variant::Variant(const Vector<uint8_t> &p_byte_array) {
-	type = PACKED_BYTE_ARRAY;
+Variant::Variant(const Vector<Plane> &p_array) {
+	type = ARRAY;
 
-	_data.packed_array = PackedArrayRef<uint8_t>::create(p_byte_array);
-}
+	Array *plane_array = memnew_placement(_data._mem, Array);
 
-Variant::Variant(const Vector<int32_t> &p_int32_array) {
-	type = PACKED_INT32_ARRAY;
-	_data.packed_array = PackedArrayRef<int32_t>::create(p_int32_array);
-}
+	plane_array->resize(p_array.size());
 
-Variant::Variant(const Vector<int64_t> &p_int64_array) {
-	type = PACKED_INT64_ARRAY;
-	_data.packed_array = PackedArrayRef<int64_t>::create(p_int64_array);
-}
-
-Variant::Variant(const Vector<float> &p_float32_array) {
-	type = PACKED_FLOAT32_ARRAY;
-	_data.packed_array = PackedArrayRef<float>::create(p_float32_array);
-}
-
-Variant::Variant(const Vector<double> &p_float64_array) {
-	type = PACKED_FLOAT64_ARRAY;
-	_data.packed_array = PackedArrayRef<double>::create(p_float64_array);
-}
-
-Variant::Variant(const Vector<String> &p_string_array) {
-	type = PACKED_STRING_ARRAY;
-	_data.packed_array = PackedArrayRef<String>::create(p_string_array);
-}
-
-Variant::Variant(const Vector<Vector3> &p_vector3_array) {
-	type = PACKED_VECTOR3_ARRAY;
-	_data.packed_array = PackedArrayRef<Vector3>::create(p_vector3_array);
-}
-
-Variant::Variant(const Vector<Vector2> &p_vector2_array) {
-	type = PACKED_VECTOR2_ARRAY;
-	_data.packed_array = PackedArrayRef<Vector2>::create(p_vector2_array);
-}
-
-Variant::Variant(const Vector<Color> &p_color_array) {
-	type = PACKED_COLOR_ARRAY;
-	_data.packed_array = PackedArrayRef<Color>::create(p_color_array);
+	for (int i = 0; i < p_array.size(); i++) {
+		plane_array->operator[](i) = Variant(p_array[i]);
+	}
 }
 
 Variant::Variant(const Vector<Face3> &p_face_array) {
-	Vector<Vector3> vertices;
+	PackedVector3Array vertices;
 	int face_count = p_face_array.size();
 	vertices.resize(face_count * 3);
 
@@ -2737,7 +2738,6 @@ Variant::Variant(const Vector<Face3> &p_face_array) {
 	*this = vertices;
 }
 
-/* helpers */
 Variant::Variant(const Vector<Variant> &p_array) {
 	type = NIL;
 	Array arr;
@@ -2750,7 +2750,7 @@ Variant::Variant(const Vector<Variant> &p_array) {
 
 Variant::Variant(const Vector<StringName> &p_array) {
 	type = NIL;
-	Vector<String> v;
+	PackedStringArray v;
 	int len = p_array.size();
 	v.resize(len);
 	for (int i = 0; i < len; i++) {
@@ -3100,7 +3100,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 
 		} break;
 		case PACKED_BYTE_ARRAY: {
-			const Vector<uint8_t> &arr = PackedArrayRef<uint8_t>::get_array(_data.packed_array);
+			const PackedByteArray &arr = PackedArrayRef<uint8_t>::get_array(_data.packed_array);
 			int len = arr.size();
 			if (likely(len)) {
 				const uint8_t *r = arr.ptr();
@@ -3111,7 +3111,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 
 		} break;
 		case PACKED_INT32_ARRAY: {
-			const Vector<int32_t> &arr = PackedArrayRef<int32_t>::get_array(_data.packed_array);
+			const PackedInt32Array &arr = PackedArrayRef<int32_t>::get_array(_data.packed_array);
 			int len = arr.size();
 			if (likely(len)) {
 				const int32_t *r = arr.ptr();
@@ -3122,7 +3122,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 
 		} break;
 		case PACKED_INT64_ARRAY: {
-			const Vector<int64_t> &arr = PackedArrayRef<int64_t>::get_array(_data.packed_array);
+			const PackedInt64Array &arr = PackedArrayRef<int64_t>::get_array(_data.packed_array);
 			int len = arr.size();
 			if (likely(len)) {
 				const int64_t *r = arr.ptr();
@@ -3133,7 +3133,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 
 		} break;
 		case PACKED_FLOAT32_ARRAY: {
-			const Vector<float> &arr = PackedArrayRef<float>::get_array(_data.packed_array);
+			const PackedFloat32Array &arr = PackedArrayRef<float>::get_array(_data.packed_array);
 			int len = arr.size();
 
 			if (likely(len)) {
@@ -3149,7 +3149,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 
 		} break;
 		case PACKED_FLOAT64_ARRAY: {
-			const Vector<double> &arr = PackedArrayRef<double>::get_array(_data.packed_array);
+			const PackedFloat64Array &arr = PackedArrayRef<double>::get_array(_data.packed_array);
 			int len = arr.size();
 
 			if (likely(len)) {
@@ -3166,7 +3166,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 		} break;
 		case PACKED_STRING_ARRAY: {
 			uint32_t hash = HASH_MURMUR3_SEED;
-			const Vector<String> &arr = PackedArrayRef<String>::get_array(_data.packed_array);
+			const PackedStringArray &arr = PackedArrayRef<String>::get_array(_data.packed_array);
 			int len = arr.size();
 
 			if (likely(len)) {
@@ -3182,7 +3182,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 		} break;
 		case PACKED_VECTOR2_ARRAY: {
 			uint32_t hash = HASH_MURMUR3_SEED;
-			const Vector<Vector2> &arr = PackedArrayRef<Vector2>::get_array(_data.packed_array);
+			const PackedVector2Array &arr = PackedArrayRef<Vector2>::get_array(_data.packed_array);
 			int len = arr.size();
 
 			if (likely(len)) {
@@ -3199,7 +3199,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 		} break;
 		case PACKED_VECTOR3_ARRAY: {
 			uint32_t hash = HASH_MURMUR3_SEED;
-			const Vector<Vector3> &arr = PackedArrayRef<Vector3>::get_array(_data.packed_array);
+			const PackedVector3Array &arr = PackedArrayRef<Vector3>::get_array(_data.packed_array);
 			int len = arr.size();
 
 			if (likely(len)) {
@@ -3217,7 +3217,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 		} break;
 		case PACKED_COLOR_ARRAY: {
 			uint32_t hash = HASH_MURMUR3_SEED;
-			const Vector<Color> &arr = PackedArrayRef<Color>::get_array(_data.packed_array);
+			const PackedColorArray &arr = PackedArrayRef<Color>::get_array(_data.packed_array);
 			int len = arr.size();
 
 			if (likely(len)) {

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -404,21 +404,21 @@ public:
 	operator Dictionary() const;
 	operator Array() const;
 
-	operator Vector<uint8_t>() const;
-	operator Vector<int32_t>() const;
-	operator Vector<int64_t>() const;
-	operator Vector<float>() const;
-	operator Vector<double>() const;
-	operator Vector<String>() const;
-	operator Vector<Vector3>() const;
-	operator Vector<Color>() const;
+	operator PackedByteArray() const;
+	operator PackedInt32Array() const;
+	operator PackedInt64Array() const;
+	operator PackedFloat32Array() const;
+	operator PackedFloat64Array() const;
+	operator PackedStringArray() const;
+	operator PackedVector3Array() const;
+	operator PackedVector2Array() const;
+	operator PackedColorArray() const;
+
+	operator Vector<::RID>() const;
 	operator Vector<Plane>() const;
 	operator Vector<Face3>() const;
-
 	operator Vector<Variant>() const;
 	operator Vector<StringName>() const;
-	operator Vector<::RID>() const;
-	operator Vector<Vector2>() const;
 
 	// some core type enums to convert to
 	operator Side() const;
@@ -473,21 +473,21 @@ public:
 	Variant(const Dictionary &p_dictionary);
 
 	Variant(const Array &p_array);
-	Variant(const Vector<Plane> &p_array); // helper
-	Variant(const Vector<uint8_t> &p_byte_array);
-	Variant(const Vector<int32_t> &p_int32_array);
-	Variant(const Vector<int64_t> &p_int64_array);
-	Variant(const Vector<float> &p_float32_array);
-	Variant(const Vector<double> &p_float64_array);
-	Variant(const Vector<String> &p_string_array);
-	Variant(const Vector<Vector3> &p_vector3_array);
-	Variant(const Vector<Color> &p_color_array);
-	Variant(const Vector<Face3> &p_face_array);
+	Variant(const PackedByteArray &p_byte_array);
+	Variant(const PackedInt32Array &p_int32_array);
+	Variant(const PackedInt64Array &p_int64_array);
+	Variant(const PackedFloat32Array &p_float32_array);
+	Variant(const PackedFloat64Array &p_float64_array);
+	Variant(const PackedStringArray &p_string_array);
+	Variant(const PackedVector2Array &p_vector2_array);
+	Variant(const PackedVector3Array &p_vector3_array);
+	Variant(const PackedColorArray &p_color_array);
 
+	Variant(const Vector<::RID> &p_array); // helper
+	Variant(const Vector<Plane> &p_array); // helper
+	Variant(const Vector<Face3> &p_face_array);
 	Variant(const Vector<Variant> &p_array);
 	Variant(const Vector<StringName> &p_array);
-	Variant(const Vector<::RID> &p_array); // helper
-	Variant(const Vector<Vector2> &p_array); // helper
 
 	Variant(const IPAddress &p_address);
 


### PR DESCRIPTION
Also shuffles some method definitions and declarations to be more consistent with the way the Variant types are ordered across the codebase.

~~... Also removes an unnecessary JSON assign (`JSON::stringify` can now be accessed statically).~~