### PR TITLE
Fix newlines not honored in Windows console

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1147,11 +1147,8 @@ OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 	//
 	// NOTE: The engine does not use ANSI escape codes to color error/warning messages; it uses Windows API calls instead.
 	// Therefore, error/warning messages are still colored on Windows versions older than 10.
-	HANDLE stdoutHandle;
-	stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-	DWORD outMode = 0;
-	outMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-
+	HANDLE stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+	DWORD outMode = ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 	if (!SetConsoleMode(stdoutHandle, outMode)) {
 		// Windows 8.1 or below, or Windows 10 prior to Anniversary Update.
 		print_verbose("Can't set the ENABLE_VIRTUAL_TERMINAL_PROCESSING Windows console mode. `print_rich()` will not work as expected.");


### PR DESCRIPTION
This is relevant when building with `windows_subsystem=console`.

Before:
![image](https://user-images.githubusercontent.com/11797174/195035020-fd02411d-b524-4a4f-9ffa-2e94c8ed4a1c.png)

After:
![image](https://user-images.githubusercontent.com/11797174/195035066-c2b9b759-d1b4-44e0-8585-b6bceb6042e5.png)

Additionally smoke tested in some run-from-console scenarios (run from `cmd`, PowerShell, both directly and from VS Code's terminal pane).