### PR TITLE
Fix error emitted when called `inst_to_dict` on the instance of the dynamic script

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -972,6 +972,11 @@ const Variant GDScript::get_rpc_config() const {
 	return rpc_config;
 }
 
+void GDScript::set_path(const String &p_path, bool p_take_over) {
+	path = p_path;
+	Resource::set_path(p_path, p_take_over);
+}
+
 Variant GDScript::callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	GDScript *top = this;
 	while (top) {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -252,6 +252,8 @@ public:
 
 	virtual const Variant get_rpc_config() const override;
 
+	virtual void set_path(const String &p_path, bool p_take_over = false) override;
+
 #ifdef TOOLS_ENABLED
 	virtual bool is_placeholder_fallback_enabled() const override { return placeholder_fallback_enabled; }
 #endif


### PR DESCRIPTION
Fix 66673 - `path` member of derived GDScript is empty when script is instantiated in runtime (from gdscript).
Overriden function sets path=p_path and calls base Resource::set_path.

<i>Bugsquad edit:</i> Fix #66673

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
