### PR TITLE
Rename `is_inf` to `is_infinite`

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -151,7 +151,7 @@ public:
 #endif
 	}
 
-	static _ALWAYS_INLINE_ bool is_inf(double p_val) {
+	static _ALWAYS_INLINE_ bool is_infinite(double p_val) {
 #ifdef _MSC_VER
 		return !_finite(p_val);
 // use an inline implementation of isinf as a workaround for problematic libstdc++ versions from gcc 5.x era
@@ -168,7 +168,7 @@ public:
 #endif
 	}
 
-	static _ALWAYS_INLINE_ bool is_inf(float p_val) {
+	static _ALWAYS_INLINE_ bool is_infinite(float p_val) {
 #ifdef _MSC_VER
 		return !_finite(p_val);
 // use an inline implementation of isinf as a workaround for problematic libstdc++ versions from gcc 5.x era

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1406,7 +1406,7 @@ String String::num(double p_num, int p_decimals) {
 		return "nan";
 	}
 
-	if (Math::is_inf(p_num)) {
+	if (Math::is_infinite(p_num)) {
 		if (signbit(p_num)) {
 			return "-inf";
 		} else {
@@ -1580,7 +1580,7 @@ String String::num_scientific(double p_num) {
 		return "nan";
 	}
 
-	if (Math::is_inf(p_num)) {
+	if (Math::is_infinite(p_num)) {
 		if (signbit(p_num)) {
 			return "-inf";
 		} else {

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -298,8 +298,8 @@ struct VariantUtilityFunctions {
 		return Math::is_nan(x);
 	}
 
-	static inline bool is_inf(double x) {
-		return Math::is_inf(x);
+	static inline bool is_infinite(double x) {
+		return Math::is_infinite(x);
 	}
 
 	static inline bool is_equal_approx(double x, double y) {
@@ -1420,7 +1420,7 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(exp, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDR(is_nan, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(is_inf, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(is_infinite, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDR(is_equal_approx, sarray("a", "b"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(is_zero_approx, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -483,7 +483,7 @@
 				Returns whether [code]x[/code] is a finite value, i.e. it is not [constant @GDScript.NAN], positive infinity, or negative infinity.
 			</description>
 		</method>
-		<method name="is_inf">
+		<method name="is_infinite">
 			<return type="bool" />
 			<param index="0" name="x" type="float" />
 			<description>

--- a/tests/core/math/test_astar.h
+++ b/tests/core/math/test_astar.h
@@ -306,7 +306,7 @@ TEST_CASE("[Stress][AStar3D] Find paths") {
 		count = 0;
 		for (int u = 0; u < N; u++) {
 			for (int v = 0; v < N; v++) {
-				if (!Math::is_inf(d[u][v])) {
+				if (!Math::is_infinite(d[u][v])) {
 					count++;
 				}
 			}
@@ -319,7 +319,7 @@ TEST_CASE("[Stress][AStar3D] Find paths") {
 			for (int v = 0; v < N; v++) {
 				if (u != v) {
 					Vector<int64_t> route = a.get_id_path(u, v);
-					if (!Math::is_inf(d[u][v])) {
+					if (!Math::is_infinite(d[u][v])) {
 						// Reachable.
 						if (route.size() == 0) {
 							print_verbose(vformat("From %d to %d: A* did not find a path\n", u, v));

--- a/tests/core/math/test_expression.h
+++ b/tests/core/math/test_expression.h
@@ -410,7 +410,7 @@ TEST_CASE("[Expression] Unusual expressions") {
 			"The expression should parse successfully.");
 	ERR_PRINT_OFF;
 	CHECK_MESSAGE(
-			Math::is_inf(double(expression.execute())),
+			Math::is_infinite(double(expression.execute())),
 			"`-25.4 / 0` should return inf.");
 	ERR_PRINT_ON;
 


### PR DESCRIPTION
For consistency with `is_finite`. See https://github.com/godotengine/godot/pull/64268#issuecomment-1211836937.

Not renamed:

* `INF` constant in GDScript.
* `IsInf` method in mono, since `IsFinite` was not added, plus in C# the method is called `IsInfinity` ([link](https://learn.microsoft.com/en-us/dotnet/api/system.single.isinfinity?view=net-6.0)).
* `isinf` in Godot Shading Language and Visual Shader.