### PR TITLE
Remove editor dependencies from ColorPicker

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3747,11 +3747,12 @@ void EditorNode::set_current_scene(int p_idx) {
 	call_deferred(SNAME("_set_main_scene_state"), state, get_edited_scene()); // Do after everything else is done setting up.
 }
 
-void EditorNode::setup_color_picker(ColorPicker *picker) {
+void EditorNode::setup_color_picker(ColorPicker *p_picker) {
+	p_picker->set_editor_settings(EditorSettings::get_singleton());
 	int default_color_mode = EDITOR_GET("interface/inspector/default_color_picker_mode");
 	int picker_shape = EDITOR_GET("interface/inspector/default_color_picker_shape");
-	picker->set_color_mode((ColorPicker::ColorModeType)default_color_mode);
-	picker->set_picker_shape((ColorPicker::PickerShapeType)picker_shape);
+	p_picker->set_color_mode((ColorPicker::ColorModeType)default_color_mode);
+	p_picker->set_picker_shape((ColorPicker::PickerShapeType)picker_shape);
 }
 
 bool EditorNode::is_scene_open(const String &p_path) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -809,7 +809,7 @@ public:
 
 	void set_current_scene(int p_idx);
 
-	void setup_color_picker(ColorPicker *picker);
+	void setup_color_picker(ColorPicker *p_picker);
 
 	void request_instance_scene(const String &p_path);
 	void request_instantiate_scenes(const Vector<String> &p_files);

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -35,11 +35,6 @@
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 #include "scene/gui/color_mode.h"
-
-#ifdef TOOLS_ENABLED
-#include "editor/editor_settings.h"
-#endif
-
 #include "thirdparty/misc/ok_color.h"
 #include "thirdparty/misc/ok_color_shader.h"
 
@@ -50,31 +45,6 @@ void ColorPicker::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			_update_color();
-#ifdef TOOLS_ENABLED
-			if (Engine::get_singleton()->is_editor_hint()) {
-				if (preset_cache.is_empty()) {
-					PackedColorArray saved_presets = EditorSettings::get_singleton()->get_project_metadata("color_picker", "presets", PackedColorArray());
-					for (int i = 0; i < saved_presets.size(); i++) {
-						preset_cache.push_back(saved_presets[i]);
-					}
-				}
-
-				for (int i = 0; i < preset_cache.size(); i++) {
-					presets.push_back(preset_cache[i]);
-				}
-
-				if (recent_preset_cache.is_empty()) {
-					PackedColorArray saved_recent_presets = EditorSettings::get_singleton()->get_project_metadata("color_picker", "recent_presets", PackedColorArray());
-					for (int i = 0; i < saved_recent_presets.size(); i++) {
-						recent_preset_cache.push_back(saved_recent_presets[i]);
-					}
-				}
-
-				for (int i = 0; i < recent_preset_cache.size(); i++) {
-					recent_presets.push_back(recent_preset_cache[i]);
-				}
-			}
-#endif
 			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
@@ -396,6 +366,40 @@ void ColorPicker::create_slider(GridContainer *gc, int idx) {
 	}
 }
 
+#ifdef TOOLS_ENABLED
+void ColorPicker::set_editor_settings(Object *p_editor_settings) {
+	if (editor_settings) {
+		return;
+	}
+	editor_settings = p_editor_settings;
+
+	if (preset_cache.is_empty()) {
+		PackedColorArray saved_presets = editor_settings->call(SNAME("get_project_metadata"), "color_picker", "presets", PackedColorArray());
+		for (int i = 0; i < saved_presets.size(); i++) {
+			preset_cache.push_back(saved_presets[i]);
+		}
+	}
+
+	for (int i = 0; i < preset_cache.size(); i++) {
+		presets.push_back(preset_cache[i]);
+	}
+
+	if (recent_preset_cache.is_empty()) {
+		PackedColorArray saved_recent_presets = editor_settings->call(SNAME("get_project_metadata"), "color_picker", "recent_presets", PackedColorArray());
+		for (int i = 0; i < saved_recent_presets.size(); i++) {
+			recent_preset_cache.push_back(saved_recent_presets[i]);
+		}
+	}
+
+	for (int i = 0; i < recent_preset_cache.size(); i++) {
+		recent_presets.push_back(recent_preset_cache[i]);
+	}
+
+	_update_presets();
+	_update_recent_presets();
+}
+#endif
+
 HSlider *ColorPicker::get_slider(int p_idx) {
 	if (p_idx < SLIDER_COUNT) {
 		return sliders[p_idx];
@@ -545,7 +549,7 @@ void ColorPicker::_update_presets() {
 	}
 
 #ifdef TOOLS_ENABLED
-	if (Engine::get_singleton()->is_editor_hint()) {
+	if (editor_settings) {
 		// Only load preset buttons when the only child is the add-preset button.
 		if (preset_container->get_child_count() == 1) {
 			for (int i = 0; i < preset_cache.size(); i++) {
@@ -559,7 +563,7 @@ void ColorPicker::_update_presets() {
 
 void ColorPicker::_update_recent_presets() {
 #ifdef TOOLS_ENABLED
-	if (Engine::get_singleton()->is_editor_hint()) {
+	if (editor_settings) {
 		int recent_preset_count = recent_preset_hbc->get_child_count();
 		for (int i = 0; i < recent_preset_count; i++) {
 			memdelete(recent_preset_hbc->get_child(0));
@@ -732,9 +736,9 @@ void ColorPicker::add_preset(const Color &p_color) {
 	}
 
 #ifdef TOOLS_ENABLED
-	if (Engine::get_singleton()->is_editor_hint()) {
+	if (editor_settings) {
 		PackedColorArray arr_to_save = get_presets();
-		EditorSettings::get_singleton()->set_project_metadata("color_picker", "presets", arr_to_save);
+		editor_settings->call(SNAME("set_project_metadata"), "color_picker", "presets", arr_to_save);
 	}
 #endif
 }
@@ -753,9 +757,9 @@ void ColorPicker::add_recent_preset(const Color &p_color) {
 	_select_from_preset_container(p_color);
 
 #ifdef TOOLS_ENABLED
-	if (Engine::get_singleton()->is_editor_hint()) {
+	if (editor_settings) {
 		PackedColorArray arr_to_save = get_recent_presets();
-		EditorSettings::get_singleton()->set_project_metadata("color_picker", "recent_presets", arr_to_save);
+		editor_settings->call(SNAME("set_project_metadata"), "color_picker", "recent_presets", arr_to_save);
 	}
 #endif
 }
@@ -776,9 +780,9 @@ void ColorPicker::erase_preset(const Color &p_color) {
 		}
 
 #ifdef TOOLS_ENABLED
-		if (Engine::get_singleton()->is_editor_hint()) {
+		if (editor_settings) {
 			PackedColorArray arr_to_save = get_presets();
-			EditorSettings::get_singleton()->set_project_metadata("color_picker", "presets", arr_to_save);
+			editor_settings->call(SNAME("set_project_metadata"), "color_picker", "presets", arr_to_save);
 		}
 #endif
 	}
@@ -800,9 +804,9 @@ void ColorPicker::erase_recent_preset(const Color &p_color) {
 		}
 
 #ifdef TOOLS_ENABLED
-		if (Engine::get_singleton()->is_editor_hint()) {
+		if (editor_settings) {
 			PackedColorArray arr_to_save = get_recent_presets();
-			EditorSettings::get_singleton()->set_project_metadata("color_picker", "recent_presets", arr_to_save);
+			editor_settings->call(SNAME("set_project_metadata"), "color_picker", "recent_presets", arr_to_save);
 		}
 #endif
 	}

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -99,6 +99,10 @@ private:
 	static List<Color> preset_cache;
 	static List<Color> recent_preset_cache;
 
+#ifdef TOOLS_ENABLED
+	Object *editor_settings = nullptr;
+#endif
+
 	int current_slider_count = SLIDER_COUNT;
 	static const int MODE_BUTTON_COUNT = 3;
 
@@ -224,6 +228,10 @@ protected:
 	static void _bind_methods();
 
 public:
+#ifdef TOOLS_ENABLED
+	void set_editor_settings(Object *p_editor_settings);
+#endif
+
 	HSlider *get_slider(int idx);
 	Vector<float> get_active_slider_values();
 


### PR DESCRIPTION
Part of https://github.com/godotengine/godot/issues/53295#issuecomment-932203107

I added an `editor_settings` property to ColorPicker, which is simple `Object *` and settings are accessed using `call()`. I moved initialization code from ENTER_TREE to a new `set_editor_settings()` method, which is called for each ColorPicker.

If we exposed this function, users could provide a fake editor settings object to store their presets 🤔