### PR TITLE
Hide text of RichTextLabel if BBCode is enabled

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1001,6 +1001,12 @@ void RichTextLabel::_update_fx(RichTextLabel::ItemFrame *p_frame, float p_delta_
 	}
 }
 
+void RichTextLabel::_validate_property(PropertyInfo &p_property) const {
+	if (use_bbcode && p_property.name == "text") {
+		p_property.usage &= ~PROPERTY_USAGE_EDITOR;
+	}
+}
+
 void RichTextLabel::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_MOUSE_EXIT: {
@@ -2726,6 +2732,7 @@ void RichTextLabel::set_use_bbcode(bool p_enable) {
 	}
 	use_bbcode = p_enable;
 	set_bbcode(bbcode);
+	property_list_changed_notify();
 }
 
 bool RichTextLabel::is_using_bbcode() const {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -414,6 +414,7 @@ private:
 	bool fit_content_height;
 
 protected:
+	virtual void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
 
 public:


### PR DESCRIPTION
On master, `text` and `bbcode_text` are merged into 1 property. But in 3.x there is a *rather big* usability problem where you enable bbcode and then set text, only to discover that you put your text in a wrong property. When bbcode is enabled, `bbcode_text` gets mirrored into `text` property, so anything you put into text gets erased.

This PR hides `text` property when BBCode is enabled.
![ezgif com-gif-maker](https://user-images.githubusercontent.com/2223172/195103888-189e94e3-f06b-444e-8c22-4a2f31f8d761.gif)
It's only hidden in the inspector, everything else works as before, so it's 100% compatible change.