### PR TITLE
[Web] Add auto-formatting to HTML files.

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -1,752 +1,757 @@
 <!DOCTYPE html>
-<html xmlns="https://www.w3.org/1999/xhtml" lang="en">
-<head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no" />
-	<meta name="author" content="Godot Engine" />
-	<meta name="description" content="Use the Godot Engine editor directly in your web browser, without having to install anything." />
-	<meta name="mobile-web-app-capable" content="yes" />
-	<meta name="apple-mobile-web-app-capable" content="yes" />
-	<meta name="application-name" content="Godot" />
-	<meta name="apple-mobile-web-app-title" content="Godot" />
-	<meta name="theme-color" content="#202531" />
-	<meta name="msapplication-navbutton-color" content="#202531" />
-	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-	<meta name="msapplication-starturl" content="/latest" />
-	<meta property="og:site_name" content="Godot Engine Web Editor" />
-	<meta property="og:url" name="twitter:url" content="https://editor.godotengine.org/releases/latest/" />
-	<meta property="og:title" name="twitter:title" content="Free and open source 2D and 3D game engine" />
-	<meta property="og:description" name="twitter:description" content="Use the Godot Engine editor directly in your web browser, without having to install anything." />
-	<meta property="og:image" name="twitter:image" content="https://godotengine.org/themes/godotengine/assets/og_image.png" />
-	<meta property="og:type" content="website" />
-	<meta name="twitter:card" content="summary" />
-	<link id="-gd-engine-icon" rel="icon" type="image/png" href="favicon.png" />
-	<link rel="apple-touch-icon" type="image/png" href="favicon.png" />
-	<link rel="manifest" href="manifest.json" />
-	<title>Godot Engine Web Editor (@GODOT_VERSION@)</title>
-	<style>
-		*:focus {
-			/* More visible outline for better keyboard navigation. */
-			outline: 0.125rem solid hsl(220, 100%, 62.5%);
-			/* Make the outline always appear above other elements. */
-			/* Otherwise, one of its sides can be hidden by tabs in the Download and More layouts. */
-			position: relative;
-		}
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no">
+		<meta name="author" content="Godot Engine">
+		<meta name="description" content="Use the Godot Engine editor directly in your web browser, without having to install anything.">
+		<meta name="mobile-web-app-capable" content="yes">
+		<meta name="apple-mobile-web-app-capable" content="yes">
+		<meta name="application-name" content="Godot">
+		<meta name="apple-mobile-web-app-title" content="Godot">
+		<meta name="theme-color" content="#202531">
+		<meta name="msapplication-navbutton-color" content="#202531">
+		<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+		<meta name="msapplication-starturl" content="/latest">
+		<meta property="og:site_name" content="Godot Engine Web Editor">
+		<meta property="og:url" name="twitter:url" content="https://editor.godotengine.org/releases/latest/">
+		<meta property="og:title" name="twitter:title" content="Free and open source 2D and 3D game engine">
+		<meta property="og:description" name="twitter:description" content="Use the Godot Engine editor directly in your web browser, without having to install anything.">
+		<meta property="og:image" name="twitter:image" content="https://godotengine.org/themes/godotengine/assets/og_image.png">
+		<meta property="og:type" content="website">
+		<meta name="twitter:card" content="summary">
+		<link id="-gd-engine-icon" rel="icon" type="image/png" href="favicon.png">
+		<link rel="apple-touch-icon" type="image/png" href="favicon.png">
+		<link rel="manifest" href="manifest.json">
+		<title>Godot Engine Web Editor (@GODOT_VERSION@)</title>
+		<style>
+*:focus {
+	/* More visible outline for better keyboard navigation. */
+	outline: 0.125rem solid hsl(220, 100%, 62.5%);
+	/* Make the outline always appear above other elements. */
+	/* Otherwise, one of its sides can be hidden by tabs in the Download and More layouts. */
+	position: relative;
+}
 
-		body {
-			touch-action: none;
-			font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-			margin: 0;
-			border: 0 none;
-			padding: 0;
-			text-align: center;
-			background-color: #333b4f;
-			overflow: hidden;
-		}
+body {
+	touch-action: none;
+	font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+	margin: 0;
+	border: 0 none;
+	padding: 0;
+	text-align: center;
+	background-color: #333b4f;
+	overflow: hidden;
+}
 
-		a {
-			color: hsl(205, 100%, 75%);
-			text-decoration-color: hsla(205, 100%, 75%, 0.3);
-			text-decoration-thickness: 0.125rem;
-		}
+a {
+	color: hsl(205, 100%, 75%);
+	text-decoration-color: hsla(205, 100%, 75%, 0.3);
+	text-decoration-thickness: 0.125rem;
+}
 
-		a:hover {
-			filter: brightness(117.5%);
-		}
+a:hover {
+	filter: brightness(117.5%);
+}
 
-		a:active {
-			filter: brightness(82.5%);
-		}
+a:active {
+	filter: brightness(82.5%);
+}
 
-		.welcome-modal {
-			display: none;
- 			position: fixed;
-			z-index: 1;
-			left: 0;
-			top: 0;
-			width: 100%;
-			height: 100%;
-			overflow: auto;
-			background-color: hsla(0, 0%, 0%, 0.5);
-			text-align: left;
-		}
+.welcome-modal {
+	display: none;
+	position: fixed;
+	z-index: 1;
+	left: 0;
+	top: 0;
+	width: 100%;
+	height: 100%;
+	overflow: auto;
+	background-color: hsla(0, 0%, 0%, 0.5);
+	text-align: left;
+}
 
-		.welcome-modal-title {
-			text-align: center;
-		}
+.welcome-modal-title {
+	text-align: center;
+}
 
-		.welcome-modal-content {
-			background-color: #333b4f;
-			box-shadow: 0 0.25rem 0.25rem hsla(0, 0%, 0%, 0.5);
-			line-height: 1.5;
-			max-width: 38rem;
-			margin: 4rem auto 0 auto;
-			color: white;
-			border-radius: 0.5rem;
-			padding: 1rem 1rem 2rem 1rem;
-		}
+.welcome-modal-content {
+	background-color: #333b4f;
+	box-shadow: 0 0.25rem 0.25rem hsla(0, 0%, 0%, 0.5);
+	line-height: 1.5;
+	max-width: 38rem;
+	margin: 4rem auto 0 auto;
+	color: white;
+	border-radius: 0.5rem;
+	padding: 1rem 1rem 2rem 1rem;
+}
 
-		#tabs-buttons {
-			/* Match the default background color of the editor window for a seamless appearance. */
-			background-color: #202531;
-		}
+#tabs-buttons {
+	/* Match the default background color of the editor window for a seamless appearance. */
+	background-color: #202531;
+}
 
-		#tab-game {
-			/* Use a pure black background to better distinguish the running project */
-			/* from the editor window, and to use a more neutral background color (no tint). */
-			background-color: black;
-			/* Make the background span the entire page height. */
-			min-height: 100vh;
-		}
+#tab-game {
+	/* Use a pure black background to better distinguish the running project */
+	/* from the editor window, and to use a more neutral background color (no tint). */
+	background-color: black;
+	/* Make the background span the entire page height. */
+	min-height: 100vh;
+}
 
-		#canvas, #gameCanvas {
-			display: block;
-			margin: 0;
-			color: white;
-		}
+#canvas, #gameCanvas {
+	display: block;
+	margin: 0;
+	color: white;
+}
 
-		/* Don't show distracting focus outlines for the main tabs' contents. */
-		#tab-editor canvas:focus,
-		#tab-game canvas:focus,
-		#canvas:focus,
-		#gameCanvas:focus {
-			outline: none;
-		}
+/* Don't show distracting focus outlines for the main tabs' contents. */
+#tab-editor canvas:focus,
+#tab-game canvas:focus,
+#canvas:focus,
+#gameCanvas:focus {
+	outline: none;
+}
 
-		.godot {
-			color: #e0e0e0;
-			background-color: #3b3943;
-			background-image: linear-gradient(to bottom, #403e48, #35333c);
-			border: 1px solid #45434e;
-			box-shadow: 0 0 1px 1px #2f2d35;
-		}
+.godot {
+	color: #e0e0e0;
+	background-color: #3b3943;
+	background-image: linear-gradient(to bottom, #403e48, #35333c);
+	border: 1px solid #45434e;
+	box-shadow: 0 0 1px 1px #2f2d35;
+}
 
-		.btn {
-			appearance: none;
-			color: #e0e0e0;
-			background-color: #262c3b;
-			border: 1px solid #202531;
-			padding: 0.5rem 1rem;
-			margin: 0 0.5rem;
-		}
+.btn {
+	appearance: none;
+	color: #e0e0e0;
+	background-color: #262c3b;
+	border: 1px solid #202531;
+	padding: 0.5rem 1rem;
+	margin: 0 0.5rem;
+}
 
-		.btn:not(:disabled):hover {
-			color: #e0e1e5;
-			border-color: #666c7b;
-		}
+.btn:not(:disabled):hover {
+	color: #e0e1e5;
+	border-color: #666c7b;
+}
 
-		.btn:active {
-			border-color: #699ce8;
-			color: #699ce8;
-		}
+.btn:active {
+	border-color: #699ce8;
+	color: #699ce8;
+}
 
-		.btn:disabled {
-			color: #aaa;
-			border-color: #242937;
-		}
+.btn:disabled {
+	color: #aaa;
+	border-color: #242937;
+}
 
-		.btn.tab-btn {
-			padding: 0.3rem 1rem;
-		}
+.btn.tab-btn {
+	padding: 0.3rem 1rem;
+}
 
-		.btn.close-btn {
-			padding: 0.3rem 1rem;
-			margin-left: -0.75rem;
-			font-weight: 700;
-		}
+.btn.close-btn {
+	padding: 0.3rem 1rem;
+	margin-left: -0.75rem;
+	font-weight: 700;
+}
 
+/* Status display */
 
-		/* Status display
-		 * ============== */
+#status {
+	position: absolute;
+	left: 0;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	/* don't consume click events - make children visible explicitly */
+	visibility: hidden;
+}
 
-		#status {
-			position: absolute;
-			left: 0;
-			top: 0;
-			right: 0;
-			bottom: 0;
-			display: flex;
-			justify-content: center;
-			align-items: center;
-			/* don't consume click events - make children visible explicitly */
-			visibility: hidden;
-		}
+#status-progress {
+	width: 366px;
+	height: 7px;
+	background-color: #38363A;
+	border: 1px solid #444246;
+	padding: 1px;
+	box-shadow: 0 0 2px 1px #1B1C22;
+	border-radius: 2px;
+	visibility: visible;
+}
 
-		#status-progress {
-			width: 366px;
-			height: 7px;
-			background-color: #38363A;
-			border: 1px solid #444246;
-			padding: 1px;
-			box-shadow: 0 0 2px 1px #1B1C22;
-			border-radius: 2px;
-			visibility: visible;
-		}
+@media only screen and (orientation:portrait) {
+	#status-progress {
+		width: 61.8%;
+	}
+}
 
-		@media only screen and (orientation:portrait) {
-			#status-progress {
-				width: 61.8%;
-			}
-		}
+#status-progress-inner {
+	height: 100%;
+	width: 0;
+	box-sizing: border-box;
+	transition: width 0.5s linear;
+	background-color: #202020;
+	border: 1px solid #222223;
+	box-shadow: 0 0 1px 1px #27282E;
+	border-radius: 3px;
+}
 
-		#status-progress-inner {
-			height: 100%;
-			width: 0;
-			box-sizing: border-box;
-			transition: width 0.5s linear;
-			background-color: #202020;
-			border: 1px solid #222223;
-			box-shadow: 0 0 1px 1px #27282E;
-			border-radius: 3px;
-		}
+#status-indeterminate {
+	visibility: visible;
+	position: relative;
+}
 
-		#status-indeterminate {
-			visibility: visible;
-			position: relative;
-		}
+#status-indeterminate > div {
+	width: 4.5px;
+	height: 0;
+	border-style: solid;
+	border-width: 9px 3px 0 3px;
+	border-color: #2b2b2b transparent transparent transparent;
+	transform-origin: center 21px;
+	position: absolute;
+}
 
-		#status-indeterminate > div {
-			width: 4.5px;
-			height: 0;
-			border-style: solid;
-			border-width: 9px 3px 0 3px;
-			border-color: #2b2b2b transparent transparent transparent;
-			transform-origin: center 21px;
-			position: absolute;
-		}
+#status-indeterminate > div:nth-child(1) { transform: rotate( 22.5deg); }
+#status-indeterminate > div:nth-child(2) { transform: rotate( 67.5deg); }
+#status-indeterminate > div:nth-child(3) { transform: rotate(112.5deg); }
+#status-indeterminate > div:nth-child(4) { transform: rotate(157.5deg); }
+#status-indeterminate > div:nth-child(5) { transform: rotate(202.5deg); }
+#status-indeterminate > div:nth-child(6) { transform: rotate(247.5deg); }
+#status-indeterminate > div:nth-child(7) { transform: rotate(292.5deg); }
+#status-indeterminate > div:nth-child(8) { transform: rotate(337.5deg); }
 
-		#status-indeterminate > div:nth-child(1) { transform: rotate( 22.5deg); }
-		#status-indeterminate > div:nth-child(2) { transform: rotate( 67.5deg); }
-		#status-indeterminate > div:nth-child(3) { transform: rotate(112.5deg); }
-		#status-indeterminate > div:nth-child(4) { transform: rotate(157.5deg); }
-		#status-indeterminate > div:nth-child(5) { transform: rotate(202.5deg); }
-		#status-indeterminate > div:nth-child(6) { transform: rotate(247.5deg); }
-		#status-indeterminate > div:nth-child(7) { transform: rotate(292.5deg); }
-		#status-indeterminate > div:nth-child(8) { transform: rotate(337.5deg); }
-
-		#status-notice {
-			margin: 0 100px;
-			line-height: 1.3;
-			visibility: visible;
-			padding: 4px 6px;
-			visibility: visible;
-		}
-	</style>
-</head>
-<body>
-	<div
-		id="welcome-modal"
-		class="welcome-modal"
-		role="dialog"
-		aria-labelledby="welcome-modal-title"
-		aria-describedby="welcome-modal-description"
-		onclick="if (event.target === this) closeWelcomeModal(false)"
-	>
-		<div class="welcome-modal-content">
-			<h2 id="welcome-modal-title" class="welcome-modal-title">Important - Please read before continuing</h2>
-			<div id="welcome-modal-description">
-				<p>
-					The Godot Web Editor has some limitations compared to the native version.
-					Its main focus is education and experimentation;
-					<strong>it is not recommended for production</strong>.
-				</p>
-				<p>
-					Refer to the
-					<a
-						href="https://docs.godotengine.org/en/latest/tutorials/editor/using_the_web_editor.html"
-						target="_blank"
-						rel="noopener"
-					>Web editor documentation</a> for usage instructions and limitations.
-				</p>
-			</div>
-			<div id="welcome-modal-missing-description" style="display: none">
-				<p>
-					<strong>The following features required by the Godot Web Editor are missing:</strong>
+#status-notice {
+	margin: 0 100px;
+	line-height: 1.3;
+	visibility: visible;
+	padding: 4px 6px;
+	visibility: visible;
+}
+		</style>
+	</head>
+	<body>
+		<div
+			id="welcome-modal"
+			class="welcome-modal"
+			role="dialog"
+			aria-labelledby="welcome-modal-title"
+			aria-describedby="welcome-modal-description"
+			onclick="if (event.target === this) closeWelcomeModal(false)"
+		>
+			<div class="welcome-modal-content">
+				<h2 id="welcome-modal-title" class="welcome-modal-title">Important - Please read before continuing</h2>
+				<div id="welcome-modal-description">
+					<p>
+						The Godot Web Editor has some limitations compared to the native version.
+						Its main focus is education and experimentation;
+						<strong>it is not recommended for production</strong>.
+					</p>
+					<p>
+						Refer to the
+						<a
+							href="https://docs.godotengine.org/en/latest/tutorials/editor/using_the_web_editor.html"
+							target="_blank"
+							rel="noopener"
+						>Web editor documentation</a> for usage instructions and limitations.
+					</p>
+				</div>
+				<div id="welcome-modal-missing-description" style="display: none">
+					<p>
+						<strong>The following features required by the Godot Web Editor are missing:</strong>
+					</p>
 					<ul id="welcome-modal-missing-list">
 					</ul>
-				</p>
-				<p>
-					If you are self-hosting the web editor,
-					refer to
-					<a
-						href="https://docs.godotengine.org/en/latest/tutorials/export/exporting_for_web.html"
-						target="_blank"
-						rel="noopener"
-					>Exporting for the Web</a> for more information.
-				</p>
-			</div>
-			<div style="text-align: center">
-				<button id="welcome-modal-dismiss" class="btn" type="button" onclick="closeWelcomeModal(true)" style="margin-top: 1rem">
-					OK, don't show again
-				</button>
-			</div>
-		</div>
-	</div>
-	<div id="tabs-buttons">
-		<button id="btn-tab-loader" class="btn tab-btn" onclick="showTab('loader')">Loader</button>
-		<button id="btn-tab-editor" class="btn tab-btn" disabled="disabled" onclick="showTab('editor')">Editor</button>
-		<button id="btn-close-editor" class="btn close-btn" disabled="disabled" onclick="closeEditor()">×</button>
-		<button id="btn-tab-game" class="btn tab-btn" disabled="disabled" onclick="showTab('game')">Game</button>
-		<button id="btn-close-game" class="btn close-btn"  disabled="disabled" onclick="closeGame()">×</button>
-		<button id="btn-tab-update" class="btn tab-btn" style="display: none;">Update</button>
-	</div>
-	<div id="tabs">
-		<div id="tab-loader">
-			<div style="color: #e0e0e0;" id="persistence">
-				<br />
-				<img src="logo.svg" alt="Godot Engine logo" width="1024" height="414" style="width: auto; height: auto; max-width: min(85%, 50vh); max-height: 250px" />
-				<br />
-				@GODOT_VERSION@
-				<br />
-				<a href="releases/">Need an old version?</a>
-				<br />
-				<br />
-				<br />
-				<label for="videoMode" style="margin-right: 1rem">Video driver:</label>
-				<select id="videoMode">
-					<option value="" selected="selected">Auto</option>
-					<option value="opengl3">WebGL 2</option>
-				</select>
-				<br />
-				<br />
-				<label for="zip-file" style="margin-right: 1rem">Preload project ZIP:</label> <input id="zip-file" type="file" name="files" style="margin-bottom: 1rem"/>
-				<br />
-<a href="demo.zip">(Try this for example)</a>
-				<br />
-				<br />
-				<button id="startButton" class="btn" style="margin-bottom: 4rem; font-weight: 700">Start Godot editor</button>
-				<br />
-				<button class="btn" onclick="clearPersistence()" style="margin-bottom: 1.5rem">Clear persistent data</button>
-				<br />
-				<a href="https://docs.godotengine.org/en/latest/tutorials/editor/using_the_web_editor.html">Web editor documentation</a>
+					<p>
+						If you are self-hosting the web editor,
+						refer to
+						<a
+							href="https://docs.godotengine.org/en/latest/tutorials/export/exporting_for_web.html"
+							target="_blank"
+							rel="noopener"
+						>Exporting for the Web</a> for more information.
+					</p>
+				</div>
+				<div style="text-align: center">
+					<button id="welcome-modal-dismiss" class="btn" type="button" onclick="closeWelcomeModal(true)" style="margin-top: 1rem">
+						OK, don't show again
+					</button>
+				</div>
 			</div>
 		</div>
-		<div id="tab-editor" style="display: none;">
-			<canvas id="editor-canvas" tabindex="1">
-				HTML5 canvas appears to be unsupported in the current browser.<br />
-				Please try updating or use a different browser.
-			</canvas>
+		<div id="tabs-buttons">
+			<button id="btn-tab-loader" class="btn tab-btn" onclick="showTab('loader')">Loader</button>
+			<button id="btn-tab-editor" class="btn tab-btn" disabled="disabled" onclick="showTab('editor')">Editor</button>
+			<button id="btn-close-editor" class="btn close-btn" disabled="disabled" onclick="closeEditor()">×</button>
+			<button id="btn-tab-game" class="btn tab-btn" disabled="disabled" onclick="showTab('game')">Game</button>
+			<button id="btn-close-game" class="btn close-btn" disabled="disabled" onclick="closeGame()">×</button>
+			<button id="btn-tab-update" class="btn tab-btn" style="display: none;">Update</button>
 		</div>
-		<div id="tab-game" style="display: none;">
-			<canvas id="game-canvas" tabindex="2">
-				HTML5 canvas appears to be unsupported in the current browser.<br />
-				Please try updating or use a different browser.
-			</canvas>
-		</div>
-		<div id="tab-status" style="display: none;">
-			<div id="status-progress" style="display: none;" oncontextmenu="event.preventDefault();"><div id="status-progress-inner"></div></div>
-			<div id="status-indeterminate" style="display: none;" oncontextmenu="event.preventDefault();">
-				<div></div>
-				<div></div>
-				<div></div>
-				<div></div>
-				<div></div>
-				<div></div>
-				<div></div>
-				<div></div>
+		<div id="tabs">
+			<div id="tab-loader">
+				<div style="color: #e0e0e0;" id="persistence">
+					<br >
+					<img src="logo.svg" alt="Godot Engine logo" width="1024" height="414" style="width: auto; height: auto; max-width: min(85%, 50vh); max-height: 250px">
+					<br >
+					@GODOT_VERSION@
+					<br >
+					<a href="releases/">Need an old version?</a>
+					<br >
+					<br >
+					<br >
+					<label for="videoMode" style="margin-right: 1rem">Video driver:</label>
+					<select id="videoMode">
+						<option value="" selected="selected">Auto</option>
+						<option value="opengl3">WebGL 2</option>
+					</select>
+					<br >
+					<br >
+					<label for="zip-file" style="margin-right: 1rem">Preload project ZIP:</label>
+					<input id="zip-file" type="file" name="files" style="margin-bottom: 1rem">
+					<br >
+					<a href="demo.zip">(Try this for example)</a>
+					<br >
+					<br >
+					<button id="startButton" class="btn" style="margin-bottom: 4rem; font-weight: 700">Start Godot editor</button>
+					<br >
+					<button class="btn" onclick="clearPersistence()" style="margin-bottom: 1.5rem">Clear persistent data</button>
+					<br >
+					<a href="https://docs.godotengine.org/en/latest/tutorials/editor/using_the_web_editor.html">Web editor documentation</a>
+				</div>
 			</div>
-			<div id="status-notice" class="godot" style="display: none;"></div>
+			<div id="tab-editor" style="display: none;">
+				<canvas id="editor-canvas" tabindex="1">
+					HTML5 canvas appears to be unsupported in the current browser.<br >
+					Please try updating or use a different browser.
+				</canvas>
+			</div>
+			<div id="tab-game" style="display: none;">
+				<canvas id="game-canvas" tabindex="2">
+					HTML5 canvas appears to be unsupported in the current browser.<br >
+					Please try updating or use a different browser.
+				</canvas>
+			</div>
+			<div id="tab-status" style="display: none;">
+				<div id="status-progress" style="display: none;" oncontextmenu="event.preventDefault();">
+					<div id="status-progress-inner"></div>
+				</div>
+				<div id="status-indeterminate" style="display: none;" oncontextmenu="event.preventDefault();">
+					<div></div>
+					<div></div>
+					<div></div>
+					<div></div>
+					<div></div>
+					<div></div>
+					<div></div>
+					<div></div>
+				</div>
+				<div id="status-notice" class="godot" style="display: none;"></div>
+			</div>
 		</div>
-	</div>
-	<script>//<![CDATA[
-		window.addEventListener("load", () => {
-			function notifyUpdate(sw) {
-				const btn = document.getElementById("btn-tab-update");
-				btn.onclick = function () {
-					if (!window.confirm("Are you sure you want to update?\nClicking \"OK\" will reload all active instances!")) {
-						return;
-					}
-					sw.postMessage("update");
-					btn.innerHTML = "Updating...";
-					btn.disabled = true;
-				};
-				btn.style.display = "";
-			}
-			if ("serviceWorker" in navigator) {
-				navigator.serviceWorker.register("service.worker.js").then(function (reg) {
-					if (reg.waiting) {
-						notifyUpdate(reg.waiting);
-					}
-					reg.addEventListener("updatefound", function () {
-						const update = reg.installing;
-						update.addEventListener("statechange", function () {
-							if (update.state === "installed") {
-								// It's a new install, claim and perform aggressive caching.
-								if (!reg.active) {
-									update.postMessage("claim");
-								} else {
-									notifyUpdate(update);
-								}
-							}
-						});
-					});
-				});
-			}
-
-			const missing = Engine.getMissingFeatures();
-			if (missing.length) {
-				// Display error dialog as threading support is required for the editor.
-				setButtonEnabled('startButton', false);
-				document.getElementById("welcome-modal-description").style.display = "none";
-				document.getElementById("welcome-modal-missing-description").style.display = "block";
-				document.getElementById("welcome-modal-dismiss").style.display = "none";
-				const list = document.getElementById("welcome-modal-missing-list");
-				for (let i = 0; i < missing.length; i++) {
-					const node = document.createElement("li");
-					node.innerText = missing[i];
-					list.appendChild(node);
-				}
-			}
-
-			if (missing.length || localStorage.getItem("welcomeModalDismissed") !== 'true') {
-				document.getElementById("welcome-modal").style.display = "block";
-				document.getElementById("welcome-modal-dismiss").focus();
-			}
-		});
-
-		function closeWelcomeModal(dontShowAgain) {
-			document.getElementById("welcome-modal").style.display = "none";
-			if (dontShowAgain) {
-				localStorage.setItem("welcomeModalDismissed", 'true');
-			}
-		}
-	//]]></script>
-	<script src="godot.editor.js"></script>
-	<script>//<![CDATA[
-
-		var editor = null;
-		var game = null;
-		var setStatusMode;
-		var setStatusNotice;
-		var video_driver = "";
-
-		function clearPersistence() {
-			function deleteDB(path) {
-				return new Promise(function(resolve, reject) {
-					var req = indexedDB.deleteDatabase(path);
-					req.onsuccess = function() {
-						resolve();
-					};
-					req.onerror = function(err) {
-						reject(err);
-					};
-					req.onblocked = function(err) {
-						reject(err);
-					}
-
-				});
-			}
-			if (!window.confirm("Are you sure you want to delete all the locally stored files?\nClicking \"OK\" will permanently remove your projects and editor settings!")) {
+		<script>
+window.addEventListener('load', () => {
+	function notifyUpdate(sw) {
+		const btn = document.getElementById('btn-tab-update');
+		btn.onclick = function () {
+			if (!window.confirm('Are you sure you want to update?\nClicking "OK" will reload all active instances!')) {
 				return;
 			}
-			Promise.all([
-				deleteDB("/home/web_user"),
-			]).then(function(results) {
-				alert("Done.");
-			}).catch(function (err) {
-				alert("Error deleting local files. Please retry after reloading the page.");
-			});
-		}
-
-		function selectVideoMode() {
-			var select = document.getElementById('videoMode');
-			video_driver = select.selectedOptions[0].value;
-		}
-
-		var tabs = [
-			document.getElementById('tab-loader'),
-			document.getElementById('tab-editor'),
-			document.getElementById('tab-game')
-		]
-		function showTab(name) {
-			tabs.forEach(function (elem) {
-				if (elem.id == 'tab-' + name) {
-					elem.style.display = 'block';
-					if (name == 'editor' || name == 'game') {
-						const canvas = document.getElementById(name + '-canvas');
-						canvas.focus();
-					}
-				} else {
-					elem.style.display = 'none';
-				}
-			});
-		}
-
-		function setButtonEnabled(id, enabled) {
-			if (enabled) {
-				document.getElementById(id).disabled = "";
-			} else {
-				document.getElementById(id).disabled = "disabled";
+			sw.postMessage('update');
+			btn.innerHTML = 'Updating...';
+			btn.disabled = true;
+		};
+		btn.style.display = '';
+	}
+	if ('serviceWorker' in navigator) {
+		navigator.serviceWorker.register('service.worker.js').then(function (reg) {
+			if (reg.waiting) {
+				notifyUpdate(reg.waiting);
 			}
-		}
-
-		function setLoaderEnabled(enabled) {
-			setButtonEnabled('btn-tab-loader', enabled);
-			setButtonEnabled('btn-tab-editor', !enabled);
-			setButtonEnabled('btn-close-editor', !enabled);
-		}
-
-		function setGameTabEnabled(enabled) {
-			setButtonEnabled('btn-tab-game', enabled);
-			setButtonEnabled('btn-close-game', enabled);
-		}
-
-		function closeGame() {
-			if (game) {
-				game.requestQuit();
-			}
-		}
-
-		function closeEditor() {
-			closeGame();
-			if (editor) {
-				editor.requestQuit();
-			}
-		}
-
-		function startEditor(zip) {
-			const INDETERMINATE_STATUS_STEP_MS = 100;
-			const persistentPaths = ['/home/web_user'];
-
-			var editorCanvas = document.getElementById('editor-canvas');
-			var gameCanvas = document.getElementById('game-canvas');
-			var statusProgress = document.getElementById('status-progress');
-			var statusProgressInner = document.getElementById('status-progress-inner');
-			var statusIndeterminate = document.getElementById('status-indeterminate');
-			var statusNotice = document.getElementById('status-notice');
-			var headerDiv = document.getElementById('tabs-buttons');
-
-			var initializing = true;
-			var statusMode = 'hidden';
-
-			showTab('status');
-
-			var animationCallbacks = [];
-			function animate(time) {
-				animationCallbacks.forEach(callback => callback(time));
-				requestAnimationFrame(animate);
-			}
-			requestAnimationFrame(animate);
-
-			var lastScale = 0;
-			var lastWidth = 0;
-			var lastHeight = 0;
-			function adjustCanvasDimensions() {
-				var scale = window.devicePixelRatio || 1;
-				var headerHeight = headerDiv.offsetHeight + 1;
-				var width = window.innerWidth;
-				var height = window.innerHeight - headerHeight;
-				if (lastScale !== scale || lastWidth !== width || lastHeight !== height) {
-					editorCanvas.width = width * scale;
-					editorCanvas.height = height * scale;
-					editorCanvas.style.width = width + "px";
-					editorCanvas.style.height = height + "px";
-					lastScale = scale;
-					lastWidth = width;
-					lastHeight = height;
-				}
-			}
-			animationCallbacks.push(adjustCanvasDimensions);
-			adjustCanvasDimensions();
-
-			function replaceCanvas(from) {
-				const out = document.createElement("canvas");
-				out.id = from.id;
-				out.tabIndex = from.tabIndex;
-				from.parentNode.replaceChild(out, from);
-				lastScale = 0;
-				return out;
-			}
-
-			setStatusMode = function setStatusMode(mode) {
-				if (statusMode === mode || !initializing)
-					return;
-				[statusProgress, statusIndeterminate, statusNotice].forEach(elem => {
-					elem.style.display = 'none';
-				});
-				animationCallbacks = animationCallbacks.filter(function(value) {
-					return (value != animateStatusIndeterminate);
-				});
-				switch (mode) {
-					case 'progress':
-						statusProgress.style.display = 'block';
-						break;
-					case 'indeterminate':
-						statusIndeterminate.style.display = 'block';
-						animationCallbacks.push(animateStatusIndeterminate);
-						break;
-					case 'notice':
-						statusNotice.style.display = 'block';
-						break;
-					case 'hidden':
-						break;
-					default:
-						throw new Error('Invalid status mode');
-				}
-				statusMode = mode;
-			};
-
-			function animateStatusIndeterminate(ms) {
-				var i = Math.floor(ms / INDETERMINATE_STATUS_STEP_MS % 8);
-				if (statusIndeterminate.children[i].style.borderTopColor == '') {
-					Array.prototype.slice.call(statusIndeterminate.children).forEach(child => {
-						child.style.borderTopColor = '';
-					});
-					statusIndeterminate.children[i].style.borderTopColor = '#dfdfdf';
-				}
-			}
-
-			setStatusNotice = function setStatusNotice(text) {
-				while (statusNotice.lastChild) {
-					statusNotice.removeChild(statusNotice.lastChild);
-				}
-				var lines = text.split('\n');
-				lines.forEach((line) => {
-					statusNotice.appendChild(document.createTextNode(line));
-					statusNotice.appendChild(document.createElement('br'));
-				});
-			};
-
-			const gameConfig = {
-				'persistentPaths': persistentPaths,
-				'unloadAfterInit': false,
-				'canvas': gameCanvas,
-				'canvasResizePolicy': 1,
-				'onExit': function () {
-					gameCanvas = replaceCanvas(gameCanvas);
-					setGameTabEnabled(false);
-					showTab('editor');
-					game = null;
-				},
-			};
-
-			var OnEditorExit = function () {
-				showTab('loader');
-				setLoaderEnabled(true);
-			};
-			function Execute(args) {
-				const is_editor = args.filter(function(v) { return v == '--editor' || v == '-e' }).length != 0;
-				const is_project_manager = args.filter(function(v) { return v == '--project-manager' }).length != 0;
-				const is_game = !is_editor && !is_project_manager;
-				if (video_driver) {
-					args.push('--rendering-driver', video_driver);
-				}
-
-				if (is_game) {
-					if (game) {
-						console.error("A game is already running. Close it first");
-						return;
-					}
-					setGameTabEnabled(true);
-					game = new Engine(gameConfig);
-					showTab('game');
-					game.init().then(function() {
-						requestAnimationFrame(function() {
-							game.start({'args': args, 'canvas': gameCanvas}).then(function() {
-								gameCanvas.focus();
-							});
-						});
-					});
-				} else { // New editor instances will be run in the same canvas. We want to wait for it to exit.
-					OnEditorExit = function(code) {
-						setLoaderEnabled(true);
-						setTimeout(function() {
-							editor.init().then(function() {
-								setLoaderEnabled(false);
-								OnEditorExit = function() {
-									showTab('loader');
-									setLoaderEnabled(true);
-								};
-								editor.start({'args': args, 'persistentDrops': is_project_manager, 'canvas': editorCanvas});
-							});
-						}, 0);
-						OnEditorExit = null;
-					};
-				}
-			}
-
-			const editorConfig = {
-				'unloadAfterInit': false,
-				'onProgress': function progressFunction (current, total) {
-					if (total > 0) {
-						statusProgressInner.style.width = current/total * 100 + '%';
-						setStatusMode('progress');
-						if (current === total) {
-							// wait for progress bar animation
-							setTimeout(() => {
-								setStatusMode('indeterminate');
-							}, 100);
+			reg.addEventListener('updatefound', function () {
+				const update = reg.installing;
+				update.addEventListener('statechange', function () {
+					if (update.state === 'installed') {
+						// It's a new install, claim and perform aggressive caching.
+						if (!reg.active) {
+							update.postMessage('claim');
+						} else {
+							notifyUpdate(update);
 						}
-					} else {
+					}
+				});
+			});
+		});
+	}
+
+	const missing = Engine.getMissingFeatures();
+	if (missing.length) {
+		// Display error dialog as threading support is required for the editor.
+		document.getElementById('startButton').disabled = 'disabled';
+		document.getElementById('welcome-modal-description').style.display = 'none';
+		document.getElementById('welcome-modal-missing-description').style.display = 'block';
+		document.getElementById('welcome-modal-dismiss').style.display = 'none';
+		const list = document.getElementById('welcome-modal-missing-list');
+		for (let i = 0; i < missing.length; i++) {
+			const node = document.createElement('li');
+			node.innerText = missing[i];
+			list.appendChild(node);
+		}
+	}
+
+	if (missing.length || localStorage.getItem('welcomeModalDismissed') !== 'true') {
+		document.getElementById('welcome-modal').style.display = 'block';
+		document.getElementById('welcome-modal-dismiss').focus();
+	}
+});
+
+function closeWelcomeModal(dontShowAgain) { // eslint-disable-line no-unused-vars
+	document.getElementById('welcome-modal').style.display = 'none';
+	if (dontShowAgain) {
+		localStorage.setItem('welcomeModalDismissed', 'true');
+	}
+}
+		</script>
+		<script src="godot.editor.js"></script>
+		<script>
+let editor = null;
+let game = null;
+let setStatusMode;
+let setStatusNotice;
+let video_driver = '';
+
+function clearPersistence() { // eslint-disable-line no-unused-vars
+	function deleteDB(path) {
+		return new Promise(function (resolve, reject) {
+			const req = indexedDB.deleteDatabase(path);
+			req.onsuccess = function () {
+				resolve();
+			};
+			req.onerror = function (err) {
+				reject(err);
+			};
+			req.onblocked = function (err) {
+				reject(err);
+			};
+		});
+	}
+	if (!window.confirm('Are you sure you want to delete all the locally stored files?\nClicking "OK" will permanently remove your projects and editor settings!')) {
+		return;
+	}
+	Promise.all([
+		deleteDB('/home/web_user'),
+	]).then(function (results) {
+		alert('Done.');
+	}).catch(function (err) {
+		alert('Error deleting local files. Please retry after reloading the page.');
+	});
+}
+
+function selectVideoMode() {
+	const select = document.getElementById('videoMode');
+	video_driver = select.selectedOptions[0].value;
+}
+
+const tabs = [
+	document.getElementById('tab-loader'),
+	document.getElementById('tab-editor'),
+	document.getElementById('tab-game'),
+];
+function showTab(name) {
+	tabs.forEach(function (elem) {
+		if (elem.id === `tab-${name}`) {
+			elem.style.display = 'block';
+			if (name === 'editor' || name === 'game') {
+				const canvas = document.getElementById(`${name}-canvas`);
+				canvas.focus();
+			}
+		} else {
+			elem.style.display = 'none';
+		}
+	});
+}
+
+function setButtonEnabled(id, enabled) {
+	if (enabled) {
+		document.getElementById(id).disabled = '';
+	} else {
+		document.getElementById(id).disabled = 'disabled';
+	}
+}
+
+function setLoaderEnabled(enabled) {
+	setButtonEnabled('btn-tab-loader', enabled);
+	setButtonEnabled('btn-tab-editor', !enabled);
+	setButtonEnabled('btn-close-editor', !enabled);
+}
+
+function setGameTabEnabled(enabled) {
+	setButtonEnabled('btn-tab-game', enabled);
+	setButtonEnabled('btn-close-game', enabled);
+}
+
+function closeGame() {
+	if (game) {
+		game.requestQuit();
+	}
+}
+
+function closeEditor() { // eslint-disable-line no-unused-vars
+	closeGame();
+	if (editor) {
+		editor.requestQuit();
+	}
+}
+
+function startEditor(zip) {
+	const INDETERMINATE_STATUS_STEP_MS = 100;
+	const persistentPaths = ['/home/web_user'];
+
+	let editorCanvas = document.getElementById('editor-canvas');
+	let gameCanvas = document.getElementById('game-canvas');
+	const statusProgress = document.getElementById('status-progress');
+	const statusProgressInner = document.getElementById('status-progress-inner');
+	const statusIndeterminate = document.getElementById('status-indeterminate');
+	const statusNotice = document.getElementById('status-notice');
+	const headerDiv = document.getElementById('tabs-buttons');
+
+	let initializing = true;
+	let statusMode = 'hidden';
+
+	showTab('status');
+
+	let animationCallbacks = [];
+	function animate(time) {
+		animationCallbacks.forEach((callback) => callback(time));
+		requestAnimationFrame(animate);
+	}
+	requestAnimationFrame(animate);
+
+	let lastScale = 0;
+	let lastWidth = 0;
+	let lastHeight = 0;
+	function adjustCanvasDimensions() {
+		const scale = window.devicePixelRatio || 1;
+		const headerHeight = headerDiv.offsetHeight + 1;
+		const width = window.innerWidth;
+		const height = window.innerHeight - headerHeight;
+		if (lastScale !== scale || lastWidth !== width || lastHeight !== height) {
+			editorCanvas.width = width * scale;
+			editorCanvas.height = height * scale;
+			editorCanvas.style.width = `${width}px`;
+			editorCanvas.style.height = `${height}px`;
+			lastScale = scale;
+			lastWidth = width;
+			lastHeight = height;
+		}
+	}
+	animationCallbacks.push(adjustCanvasDimensions);
+	adjustCanvasDimensions();
+
+	function replaceCanvas(from) {
+		const out = document.createElement('canvas');
+		out.id = from.id;
+		out.tabIndex = from.tabIndex;
+		from.parentNode.replaceChild(out, from);
+		lastScale = 0;
+		return out;
+	}
+
+	function animateStatusIndeterminate(ms) {
+		const i = Math.floor((ms / INDETERMINATE_STATUS_STEP_MS) % 8);
+		if (statusIndeterminate.children[i].style.borderTopColor === '') {
+			Array.prototype.slice.call(statusIndeterminate.children).forEach((child) => {
+				child.style.borderTopColor = '';
+			});
+			statusIndeterminate.children[i].style.borderTopColor = '#dfdfdf';
+		}
+	}
+
+	setStatusMode = function (mode) {
+		if (statusMode === mode || !initializing) {
+			return;
+		}
+		[statusProgress, statusIndeterminate, statusNotice].forEach((elem) => {
+			elem.style.display = 'none';
+		});
+		animationCallbacks = animationCallbacks.filter(function (value) {
+			return (value !== animateStatusIndeterminate);
+		});
+		switch (mode) {
+		case 'progress':
+			statusProgress.style.display = 'block';
+			break;
+		case 'indeterminate':
+			statusIndeterminate.style.display = 'block';
+			animationCallbacks.push(animateStatusIndeterminate);
+			break;
+		case 'notice':
+			statusNotice.style.display = 'block';
+			break;
+		case 'hidden':
+			break;
+		default:
+			throw new Error('Invalid status mode');
+		}
+		statusMode = mode;
+	};
+
+	setStatusNotice = function (text) {
+		while (statusNotice.lastChild) {
+			statusNotice.removeChild(statusNotice.lastChild);
+		}
+		const lines = text.split('\n');
+		lines.forEach((line) => {
+			statusNotice.appendChild(document.createTextNode(line));
+			statusNotice.appendChild(document.createElement('br'));
+		});
+	};
+
+	const gameConfig = {
+		'persistentPaths': persistentPaths,
+		'unloadAfterInit': false,
+		'canvas': gameCanvas,
+		'canvasResizePolicy': 1,
+		'onExit': function () {
+			gameCanvas = replaceCanvas(gameCanvas);
+			setGameTabEnabled(false);
+			showTab('editor');
+			game = null;
+		},
+	};
+
+	let OnEditorExit = function () {
+		showTab('loader');
+		setLoaderEnabled(true);
+	};
+	function Execute(args) {
+		const is_editor = args.filter(function (v) {
+			return v === '--editor' || v === '-e';
+		}).length !== 0;
+		const is_project_manager = args.filter(function (v) {
+			return v === '--project-manager';
+		}).length !== 0;
+		const is_game = !is_editor && !is_project_manager;
+		if (video_driver) {
+			args.push('--rendering-driver', video_driver);
+		}
+
+		if (is_game) {
+			if (game) {
+				console.error('A game is already running. Close it first');
+				return;
+			}
+			setGameTabEnabled(true);
+			game = new Engine(gameConfig);
+			showTab('game');
+			game.init().then(function () {
+				requestAnimationFrame(function () {
+					game.start({ 'args': args, 'canvas': gameCanvas }).then(function () {
+						gameCanvas.focus();
+					});
+				});
+			});
+		} else { // New editor instances will be run in the same canvas. We want to wait for it to exit.
+			OnEditorExit = function (code) {
+				setLoaderEnabled(true);
+				setTimeout(function () {
+					editor.init().then(function () {
+						setLoaderEnabled(false);
+						OnEditorExit = function () {
+							showTab('loader');
+							setLoaderEnabled(true);
+						};
+						editor.start({ 'args': args, 'persistentDrops': is_project_manager, 'canvas': editorCanvas });
+					});
+				}, 0);
+				OnEditorExit = null;
+			};
+		}
+	}
+
+	const editorConfig = {
+		'unloadAfterInit': false,
+		'onProgress': function progressFunction(current, total) {
+			if (total > 0) {
+				statusProgressInner.style.width = `${(current / total) * 100}%`;
+				setStatusMode('progress');
+				if (current === total) {
+					// wait for progress bar animation
+					setTimeout(() => {
 						setStatusMode('indeterminate');
-					}
-				},
-				'canvas': editorCanvas,
-				'canvasResizePolicy': 0,
-				'onExit': function() {
-					editorCanvas = replaceCanvas(editorCanvas);
-					if (OnEditorExit) {
-						OnEditorExit();
-					}
-				},
-				'onExecute': Execute,
-				'persistentPaths': persistentPaths,
-			};
-			editor = new Engine(editorConfig);
-
-			function displayFailureNotice(err) {
-				var msg = err.message || err;
-				console.error(msg);
-				setStatusNotice(msg);
-				setStatusMode('notice');
-				initializing = false;
-			};
-
-			if (!Engine.isWebGLAvailable()) {
-				displayFailureNotice('WebGL not available');
+					}, 100);
+				}
 			} else {
 				setStatusMode('indeterminate');
-				editor.init('godot.editor').then(function() {
-					if (zip) {
-						editor.copyToFS("/tmp/preload.zip", zip);
-					}
-					try {
-						// Avoid user creating project in the persistent root folder.
-						editor.copyToFS("/home/web_user/keep", new Uint8Array());
-					} catch(e) {
-						// File exists
-					}
-					selectVideoMode();
-					showTab('editor');
-					setLoaderEnabled(false);
-					const args = ['--project-manager', '--single-window'];
-					if (video_driver) {
-						args.push('--rendering-driver', video_driver);
-					}
-					editor.start({'args': args, 'persistentDrops': true}).then(function() {
-						setStatusMode('hidden');
-						initializing = false;
-					});
-				}).catch(displayFailureNotice);
 			}
-		};
-		document.getElementById("startButton").onclick = function() {
-			preloadZip(document.getElementById('zip-file')).then(function(zip) {
-				startEditor(zip);
-			});
-		}
+		},
+		'canvas': editorCanvas,
+		'canvasResizePolicy': 0,
+		'onExit': function () {
+			editorCanvas = replaceCanvas(editorCanvas);
+			if (OnEditorExit) {
+				OnEditorExit();
+			}
+		},
+		'onExecute': Execute,
+		'persistentPaths': persistentPaths,
+	};
+	editor = new Engine(editorConfig);
 
-		function preloadZip(target) {
-			return new Promise(function(resolve, reject) {
-				if (target.files.length > 0) {
-					target.files[0].arrayBuffer().then(function(data) {
-						resolve(data);
-					});
-				} else {
-					resolve();
-				}
+	function displayFailureNotice(err) {
+		const msg = err.message || err;
+		console.error(msg);
+		setStatusNotice(msg);
+		setStatusMode('notice');
+		initializing = false;
+	}
+
+	if (!Engine.isWebGLAvailable()) {
+		displayFailureNotice('WebGL not available');
+	} else {
+		setStatusMode('indeterminate');
+		editor.init('godot.editor').then(function () {
+			if (zip) {
+				editor.copyToFS('/tmp/preload.zip', zip);
+			}
+			try {
+				// Avoid user creating project in the persistent root folder.
+				editor.copyToFS('/home/web_user/keep', new Uint8Array());
+			} catch (e) {
+				// File exists
+			}
+			selectVideoMode();
+			showTab('editor');
+			setLoaderEnabled(false);
+			const args = ['--project-manager', '--single-window'];
+			if (video_driver) {
+				args.push('--rendering-driver', video_driver);
+			}
+			editor.start({ 'args': args, 'persistentDrops': true }).then(function () {
+				setStatusMode('hidden');
+				initializing = false;
 			});
+		}).catch(displayFailureNotice);
+	}
+}
+
+function preloadZip(target) {
+	return new Promise(function (resolve, reject) {
+		if (target.files.length > 0) {
+			target.files[0].arrayBuffer().then(function (data) {
+				resolve(data);
+			});
+		} else {
+			resolve();
 		}
-	//]]></script>
-</body>
+	});
+}
+
+document.getElementById('startButton').onclick = function () {
+	preloadZip(document.getElementById('zip-file')).then(function (zip) {
+		startEditor(zip);
+	});
+};
+		</script>
+	</body>
 </html>

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -1,247 +1,245 @@
 <!DOCTYPE html>
-<html xmlns='https://www.w3.org/1999/xhtml' lang='' xml:lang=''>
-<head>
-	<meta charset='utf-8' />
-	<meta name='viewport' content='width=device-width, user-scalable=no' />
-	<title>$GODOT_PROJECT_NAME</title>
-	<style type='text/css'>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no">
+		<title>$GODOT_PROJECT_NAME</title>
+		<style>
+body {
+	touch-action: none;
+	margin: 0;
+	border: 0 none;
+	padding: 0;
+	text-align: center;
+	background-color: black;
+}
 
-		body {
-			touch-action: none;
-			margin: 0;
-			border: 0 none;
-			padding: 0;
-			text-align: center;
-			background-color: black;
-		}
+#canvas {
+	display: block;
+	margin: 0;
+	color: white;
+}
 
-		#canvas {
-			display: block;
-			margin: 0;
-			color: white;
-		}
+#canvas:focus {
+	outline: none;
+}
 
-		#canvas:focus {
-			outline: none;
-		}
+.godot {
+	font-family: 'Noto Sans', 'Droid Sans', Arial, sans-serif;
+	color: #e0e0e0;
+	background-color: #3b3943;
+	background-image: linear-gradient(to bottom, #403e48, #35333c);
+	border: 1px solid #45434e;
+	box-shadow: 0 0 1px 1px #2f2d35;
+}
 
-		.godot {
-			font-family: 'Noto Sans', 'Droid Sans', Arial, sans-serif;
-			color: #e0e0e0;
-			background-color: #3b3943;
-			background-image: linear-gradient(to bottom, #403e48, #35333c);
-			border: 1px solid #45434e;
-			box-shadow: 0 0 1px 1px #2f2d35;
-		}
+/* Status display */
 
+#status {
+	position: absolute;
+	left: 0;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	/* don't consume click events - make children visible explicitly */
+	visibility: hidden;
+}
 
-		/* Status display
-		 * ============== */
+#status-progress {
+	width: 366px;
+	height: 7px;
+	background-color: #38363A;
+	border: 1px solid #444246;
+	padding: 1px;
+	box-shadow: 0 0 2px 1px #1B1C22;
+	border-radius: 2px;
+	visibility: visible;
+}
 
-		#status {
-			position: absolute;
-			left: 0;
-			top: 0;
-			right: 0;
-			bottom: 0;
-			display: flex;
-			justify-content: center;
-			align-items: center;
-			/* don't consume click events - make children visible explicitly */
-			visibility: hidden;
-		}
+@media only screen and (orientation:portrait) {
+	#status-progress {
+		width: 61.8%;
+	}
+}
 
-		#status-progress {
-			width: 366px;
-			height: 7px;
-			background-color: #38363A;
-			border: 1px solid #444246;
-			padding: 1px;
-			box-shadow: 0 0 2px 1px #1B1C22;
-			border-radius: 2px;
-			visibility: visible;
-		}
+#status-progress-inner {
+	height: 100%;
+	width: 0;
+	box-sizing: border-box;
+	transition: width 0.5s linear;
+	background-color: #202020;
+	border: 1px solid #222223;
+	box-shadow: 0 0 1px 1px #27282E;
+	border-radius: 3px;
+}
 
-		@media only screen and (orientation:portrait) {
-			#status-progress {
-				width: 61.8%;
-			}
-		}
+#status-indeterminate {
+	height: 42px;
+	visibility: visible;
+	position: relative;
+}
 
-		#status-progress-inner {
-			height: 100%;
-			width: 0;
-			box-sizing: border-box;
-			transition: width 0.5s linear;
-			background-color: #202020;
-			border: 1px solid #222223;
-			box-shadow: 0 0 1px 1px #27282E;
-			border-radius: 3px;
-		}
+#status-indeterminate > div {
+	width: 4.5px;
+	height: 0;
+	border-style: solid;
+	border-width: 9px 3px 0 3px;
+	border-color: #2b2b2b transparent transparent transparent;
+	transform-origin: center 21px;
+	position: absolute;
+}
 
-		#status-indeterminate {
-			height: 42px;
-			visibility: visible;
-			position: relative;
-		}
+#status-indeterminate > div:nth-child(1) { transform: rotate( 22.5deg); }
+#status-indeterminate > div:nth-child(2) { transform: rotate( 67.5deg); }
+#status-indeterminate > div:nth-child(3) { transform: rotate(112.5deg); }
+#status-indeterminate > div:nth-child(4) { transform: rotate(157.5deg); }
+#status-indeterminate > div:nth-child(5) { transform: rotate(202.5deg); }
+#status-indeterminate > div:nth-child(6) { transform: rotate(247.5deg); }
+#status-indeterminate > div:nth-child(7) { transform: rotate(292.5deg); }
+#status-indeterminate > div:nth-child(8) { transform: rotate(337.5deg); }
 
-		#status-indeterminate > div {
-			width: 4.5px;
-			height: 0;
-			border-style: solid;
-			border-width: 9px 3px 0 3px;
-			border-color: #2b2b2b transparent transparent transparent;
-			transform-origin: center 21px;
-			position: absolute;
-		}
-
-		#status-indeterminate > div:nth-child(1) { transform: rotate( 22.5deg); }
-		#status-indeterminate > div:nth-child(2) { transform: rotate( 67.5deg); }
-		#status-indeterminate > div:nth-child(3) { transform: rotate(112.5deg); }
-		#status-indeterminate > div:nth-child(4) { transform: rotate(157.5deg); }
-		#status-indeterminate > div:nth-child(5) { transform: rotate(202.5deg); }
-		#status-indeterminate > div:nth-child(6) { transform: rotate(247.5deg); }
-		#status-indeterminate > div:nth-child(7) { transform: rotate(292.5deg); }
-		#status-indeterminate > div:nth-child(8) { transform: rotate(337.5deg); }
-
-		#status-notice {
-			margin: 0 100px;
-			line-height: 1.3;
-			visibility: visible;
-			padding: 4px 6px;
-			visibility: visible;
-		}
-	</style>
-$GODOT_HEAD_INCLUDE
-</head>
-<body>
-	<canvas id='canvas'>
-		HTML5 canvas appears to be unsupported in the current browser.<br />
-		Please try updating or use a different browser.
-	</canvas>
-	<div id='status'>
-		<div id='status-progress' style='display: none;' oncontextmenu='event.preventDefault();'><div id ='status-progress-inner'></div></div>
-		<div id='status-indeterminate' style='display: none;' oncontextmenu='event.preventDefault();'>
-			<div></div>
-			<div></div>
-			<div></div>
-			<div></div>
-			<div></div>
-			<div></div>
-			<div></div>
-			<div></div>
+#status-notice {
+	margin: 0 100px;
+	line-height: 1.3;
+	visibility: visible;
+	padding: 4px 6px;
+	visibility: visible;
+}
+		</style>
+		$GODOT_HEAD_INCLUDE
+	</head>
+	<body>
+		<canvas id="canvas">
+			HTML5 canvas appears to be unsupported in the current browser.<br >
+			Please try updating or use a different browser.
+		</canvas>
+		<div id="status">
+			<div id="status-progress" style="display: none;" oncontextmenu="event.preventDefault();">
+				<div id ="status-progress-inner"></div>
+			</div>
+			<div id="status-indeterminate" style="display: none;" oncontextmenu="event.preventDefault();">
+				<div></div>
+				<div></div>
+				<div></div>
+				<div></div>
+				<div></div>
+				<div></div>
+				<div></div>
+				<div></div>
+			</div>
+			<div id="status-notice" class="godot" style="display: none;"></div>
 		</div>
-		<div id='status-notice' class='godot' style='display: none;'></div>
-	</div>
 
-	<script type='text/javascript' src='$GODOT_URL'></script>
-	<script type='text/javascript'>//<![CDATA[
+		<script src="$GODOT_URL"></script>
+		<script>
+const GODOT_CONFIG = $GODOT_CONFIG;
+const engine = new Engine(GODOT_CONFIG);
 
-		const GODOT_CONFIG = $GODOT_CONFIG;
-		var engine = new Engine(GODOT_CONFIG);
+(function () {
+	const INDETERMINATE_STATUS_STEP_MS = 100;
+	const statusProgress = document.getElementById('status-progress');
+	const statusProgressInner = document.getElementById('status-progress-inner');
+	const statusIndeterminate = document.getElementById('status-indeterminate');
+	const statusNotice = document.getElementById('status-notice');
 
-		(function() {
-			const INDETERMINATE_STATUS_STEP_MS = 100;
-			var statusProgress = document.getElementById('status-progress');
-			var statusProgressInner = document.getElementById('status-progress-inner');
-			var statusIndeterminate = document.getElementById('status-indeterminate');
-			var statusNotice = document.getElementById('status-notice');
+	let initializing = true;
+	let statusMode = 'hidden';
 
-			var initializing = true;
-			var statusMode = 'hidden';
+	let animationCallbacks = [];
+	function animate(time) {
+		animationCallbacks.forEach((callback) => callback(time));
+		requestAnimationFrame(animate);
+	}
+	requestAnimationFrame(animate);
 
-			var animationCallbacks = [];
-			function animate(time) {
-				animationCallbacks.forEach(callback => callback(time));
-				requestAnimationFrame(animate);
-			}
-			requestAnimationFrame(animate);
+	function animateStatusIndeterminate(ms) {
+		const i = Math.floor((ms / INDETERMINATE_STATUS_STEP_MS) % 8);
+		if (statusIndeterminate.children[i].style.borderTopColor === '') {
+			Array.prototype.slice.call(statusIndeterminate.children).forEach((child) => {
+				child.style.borderTopColor = '';
+			});
+			statusIndeterminate.children[i].style.borderTopColor = '#dfdfdf';
+		}
+	}
 
-			function setStatusMode(mode) {
+	function setStatusMode(mode) {
+		if (statusMode === mode || !initializing) {
+			return;
+		}
+		[statusProgress, statusIndeterminate, statusNotice].forEach((elem) => {
+			elem.style.display = 'none';
+		});
+		animationCallbacks = animationCallbacks.filter(function (value) {
+			return (value !== animateStatusIndeterminate);
+		});
+		switch (mode) {
+		case 'progress':
+			statusProgress.style.display = 'block';
+			break;
+		case 'indeterminate':
+			statusIndeterminate.style.display = 'block';
+			animationCallbacks.push(animateStatusIndeterminate);
+			break;
+		case 'notice':
+			statusNotice.style.display = 'block';
+			break;
+		case 'hidden':
+			break;
+		default:
+			throw new Error('Invalid status mode');
+		}
+		statusMode = mode;
+	}
 
-				if (statusMode === mode || !initializing)
-					return;
-				[statusProgress, statusIndeterminate, statusNotice].forEach(elem => {
-					elem.style.display = 'none';
-				});
-				animationCallbacks = animationCallbacks.filter(function(value) {
-					return (value != animateStatusIndeterminate);
-				});
-				switch (mode) {
-					case 'progress':
-						statusProgress.style.display = 'block';
-						break;
-					case 'indeterminate':
-						statusIndeterminate.style.display = 'block';
-						animationCallbacks.push(animateStatusIndeterminate);
-						break;
-					case 'notice':
-						statusNotice.style.display = 'block';
-						break;
-					case 'hidden':
-						break;
-					default:
-						throw new Error('Invalid status mode');
-				}
-				statusMode = mode;
-			}
+	function setStatusNotice(text) {
+		while (statusNotice.lastChild) {
+			statusNotice.removeChild(statusNotice.lastChild);
+		}
+		const lines = text.split('\n');
+		lines.forEach((line) => {
+			statusNotice.appendChild(document.createTextNode(line));
+			statusNotice.appendChild(document.createElement('br'));
+		});
+	}
 
-			function animateStatusIndeterminate(ms) {
-				var i = Math.floor(ms / INDETERMINATE_STATUS_STEP_MS % 8);
-				if (statusIndeterminate.children[i].style.borderTopColor == '') {
-					Array.prototype.slice.call(statusIndeterminate.children).forEach(child => {
-						child.style.borderTopColor = '';
-					});
-					statusIndeterminate.children[i].style.borderTopColor = '#dfdfdf';
-				}
-			}
+	function displayFailureNotice(err) {
+		const msg = err.message || err;
+		console.error(msg);
+		setStatusNotice(msg);
+		setStatusMode('notice');
+		initializing = false;
+	}
 
-			function setStatusNotice(text) {
-				while (statusNotice.lastChild) {
-					statusNotice.removeChild(statusNotice.lastChild);
-				}
-				var lines = text.split('\n');
-				lines.forEach((line) => {
-					statusNotice.appendChild(document.createTextNode(line));
-					statusNotice.appendChild(document.createElement('br'));
-				});
-			};
-
-			function displayFailureNotice(err) {
-				var msg = err.message || err;
-				console.error(msg);
-				setStatusNotice(msg);
-				setStatusMode('notice');
-				initializing = false;
-			};
-
-			const missing = Engine.getMissingFeatures();
-			if (missing.length !== 0) {
-				const missingMsg = 'Warning!\nThe following features required to run Godot projects on the Web are missing:\n';
-				displayFailureNotice(missingMsg + missing.join("\n"));
-			} else {
-				setStatusMode('indeterminate');
-				engine.startGame({
-					'onProgress': function (current, total) {
-						if (total > 0) {
-							statusProgressInner.style.width = current/total * 100 + '%';
-							setStatusMode('progress');
-							if (current === total) {
-								// wait for progress bar animation
-								setTimeout(() => {
-									setStatusMode('indeterminate');
-								}, 500);
-							}
-						} else {
+	const missing = Engine.getMissingFeatures();
+	if (missing.length !== 0) {
+		const missingMsg = 'Warning!\nThe following features required to run Godot projects on the Web are missing:\n';
+		displayFailureNotice(missingMsg + missing.join('\n'));
+	} else {
+		setStatusMode('indeterminate');
+		engine.startGame({
+			'onProgress': function (current, total) {
+				if (total > 0) {
+					statusProgressInner.style.width = `${(current / total) * 100}%`;
+					setStatusMode('progress');
+					if (current === total) {
+						// wait for progress bar animation
+						setTimeout(() => {
 							setStatusMode('indeterminate');
-						}
-					},
-				}).then(() => {
-					setStatusMode('hidden');
-					initializing = false;
-				}, displayFailureNotice);
-			}
-		})();
-	//]]></script>
-</body>
+						}, 500);
+					}
+				} else {
+					setStatusMode('indeterminate');
+				}
+			},
+		}).then(() => {
+			setStatusMode('hidden');
+			initializing = false;
+		}, displayFailureNotice);
+	}
+}());
+		</script>
+	</body>
 </html>

--- a/misc/dist/html/offline-export.html
+++ b/misc/dist/html/offline-export.html
@@ -1,42 +1,41 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-	<meta charset="utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<title>You are offline</title>
-	<style>
-		html {
-			background-color: #000000;
-			color: #ffffff;
-		}
+	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<title>You are offline</title>
+		<style>
+html {
+	background-color: #000000;
+	color: #ffffff;
+}
 
-		body {
-			font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-			margin: 2rem;
-		}
+body {
+	font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+	margin: 2rem;
+}
 
-		p {
-			margin-block: 1rem;
-		}
+p {
+	margin-block: 1rem;
+}
 
-		button {
-			display: block;
-			padding: 1rem 2rem;
-			margin: 3rem auto 0;
-		}
-	</style>
-</head>
-<body>
-	<h1>You are offline</h1>
-	<p>This application requires an Internet connection to run for the first time.</p>
-	<p>Press the button below to try reloading:</p>
-	<button type="button">Reload</button>
-
-	<script>
-		document.querySelector("button").addEventListener("click", () => {
-			window.location.reload();
-		});
-	</script>
-</body>
+button {
+	display: block;
+	padding: 1rem 2rem;
+	margin: 3rem auto 0;
+}
+		</style>
+	</head>
+	<body>
+		<h1>You are offline</h1>
+		<p>This application requires an Internet connection to run for the first time.</p>
+		<p>Press the button below to try reloading:</p>
+		<button type="button">Reload</button>
+		<script>
+document.querySelector('button').addEventListener('click', () => {
+	window.location.reload();
+});
+		</script>
+	</body>
 </html>

--- a/misc/dist/html/offline.html
+++ b/misc/dist/html/offline.html
@@ -1,44 +1,44 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-	<meta charset="utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<meta name="theme-color" content="#202531" />
-	<meta name="msapplication-navbutton-color" content="#202531" />
-	<title>You are offline</title>
-	<style>
-		html {
-			background-color: #333b4f;
-			color: #e0e0e0;
-		}
+	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<meta name="theme-color" content="#202531">
+		<meta name="msapplication-navbutton-color" content="#202531">
+		<title>You are offline</title>
+		<style>
+html {
+	background-color: #333b4f;
+	color: #e0e0e0;
+}
 
-		body {
-			font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-			margin: 2rem;
-		}
+body {
+	font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+	margin: 2rem;
+}
 
-		p {
-			margin-block: 1rem;
-		}
+p {
+	margin-block: 1rem;
+}
 
-		button {
-			display: block;
-			padding: 1rem 2rem;
-			margin: 3rem auto 0;
-		}
-	</style>
-</head>
-<body>
-	<h1>You are offline</h1>
-	<p>This application requires an Internet connection to run for the first time.</p>
-	<p>Press the button below to try reloading:</p>
-	<button type="button">Reload</button>
+button {
+	display: block;
+	padding: 1rem 2rem;
+	margin: 3rem auto 0;
+}
+		</style>
+	</head>
+	<body>
+		<h1>You are offline</h1>
+		<p>This application requires an Internet connection to run for the first time.</p>
+		<p>Press the button below to try reloading:</p>
+		<button type="button">Reload</button>
 
-	<script>
-		document.querySelector("button").addEventListener("click", () => {
-			window.location.reload();
-		});
-	</script>
-</body>
+		<script>
+document.querySelector('button').addEventListener('click', () => {
+	window.location.reload();
+});
+		</script>
+	</body>
 </html>

--- a/platform/web/.eslintrc.html.js
+++ b/platform/web/.eslintrc.html.js
@@ -1,0 +1,19 @@
+module.exports = {
+	"plugins": [
+		"html",
+		"@html-eslint",
+	],
+	"parser": "@html-eslint/parser",
+	"extends": ["plugin:@html-eslint/recommended", "./.eslintrc.js"],
+	"rules": {
+		"no-alert": "off",
+		"no-console": "off",
+		"@html-eslint/require-closing-tags": ["error", { "selfClosing": "never" }],
+		"@html-eslint/indent": ["error", "tab"],
+	},
+	"globals": {
+		"Godot": true,
+		"Engine": true,
+		"$GODOT_CONFIG": true,
+	},
+};

--- a/platform/web/package-lock.json
+++ b/platform/web/package-lock.json
@@ -8,8 +8,13 @@
       "name": "godot",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "eslint-plugin-html": "^7.1.0"
+      },
       "devDependencies": {
-        "eslint": "^7.28.0",
+        "@html-eslint/eslint-plugin": "^0.15.0",
+        "@html-eslint/parser": "^0.15.0",
+        "eslint": "^7.32.0",
         "eslint-config-airbnb-base": "^14.2.1",
         "eslint-plugin-import": "^2.23.4",
         "jsdoc": "^3.6.7"
@@ -83,9 +88,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
-      "integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -101,6 +106,47 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/@html-eslint/eslint-plugin": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/eslint-plugin/-/eslint-plugin-0.15.0.tgz",
+      "integrity": "sha512-6DUb2ZN1PUlzlNzNj4aBhoObBp3Kl/+YbZ6CnkgFAsQSW0tSFAu7p8WwESkz9RZLZZN9gCUlcaYKJnQjTkmnDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/@html-eslint/parser": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/parser/-/parser-0.15.0.tgz",
+      "integrity": "sha512-fA+HQtWnODhOIK6j1p4XWqltINx7hM0WNNTM2RvlH/2glzeRDCcYq3vEmeQhnytvGocidu4ofTzNk80cLnnyiw==",
+      "dev": true,
+      "dependencies": {
+        "es-html-parser": "^0.0.8"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "dev": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -143,9 +189,9 @@
       }
     },
     "node_modules/acorn-jsx": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -419,9 +465,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -463,6 +509,68 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/emoji-regex": {
@@ -531,6 +639,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-html-parser": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/es-html-parser/-/es-html-parser-0.0.8.tgz",
+      "integrity": "sha512-kjMH23xhvTBw/7Ve1Dtb/7yZdFajfvwOpdsgRHmnyt8yvTsDJnkFjUgEEaMZFW+e1OhN/eoZrvF9wehq+waTGg==",
+      "dev": true
+    },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -561,13 +675,14 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.28.0.tgz",
-      "integrity": "sha512-UMfH0VSjP0G4p3EWirscJEQ/cHqnT/iuH6oNZOB94nBjWbMnhGEPxsZm1eyIW0C/9jLI0Fow4W5DXLjEI7mn1g==",
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.2",
+        "@eslint/eslintrc": "^0.4.3",
+        "@humanwhocodes/config-array": "^0.5.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -679,6 +794,14 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-html": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-7.1.0.tgz",
+      "integrity": "sha512-fNLRraV/e6j8e3XYOC9xgND4j+U7b1Rq+OygMlLcMg+wI/IpVbF+ubQa3R78EjKB9njT6TQOlcK5rFKBVVtdfg==",
+      "dependencies": {
+        "htmlparser2": "^8.0.1"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -1005,9 +1128,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
-      "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -1072,6 +1195,35 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
+      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "entities": "^4.3.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/ignore": {
       "version": "4.0.6",
@@ -2067,7 +2219,7 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "node_modules/string-width": {
@@ -2406,9 +2558,9 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
-      "integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -2421,6 +2573,38 @@
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       }
+    },
+    "@html-eslint/eslint-plugin": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/eslint-plugin/-/eslint-plugin-0.15.0.tgz",
+      "integrity": "sha512-6DUb2ZN1PUlzlNzNj4aBhoObBp3Kl/+YbZ6CnkgFAsQSW0tSFAu7p8WwESkz9RZLZZN9gCUlcaYKJnQjTkmnDA==",
+      "dev": true
+    },
+    "@html-eslint/parser": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@html-eslint/parser/-/parser-0.15.0.tgz",
+      "integrity": "sha512-fA+HQtWnODhOIK6j1p4XWqltINx7hM0WNNTM2RvlH/2glzeRDCcYq3vEmeQhnytvGocidu4ofTzNk80cLnnyiw==",
+      "dev": true,
+      "requires": {
+        "es-html-parser": "^0.0.8"
+      }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -2457,9 +2641,9 @@
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
     },
@@ -2672,9 +2856,9 @@
       }
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -2702,6 +2886,46 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "requires": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+          "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+    },
+    "domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "requires": {
+        "domelementtype": "^2.3.0"
+      }
+    },
+    "domutils": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "requires": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
       }
     },
     "emoji-regex": {
@@ -2758,6 +2982,12 @@
         "unbox-primitive": "^1.0.1"
       }
     },
+    "es-html-parser": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/es-html-parser/-/es-html-parser-0.0.8.tgz",
+      "integrity": "sha512-kjMH23xhvTBw/7Ve1Dtb/7yZdFajfvwOpdsgRHmnyt8yvTsDJnkFjUgEEaMZFW+e1OhN/eoZrvF9wehq+waTGg==",
+      "dev": true
+    },
     "es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -2776,13 +3006,14 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.28.0.tgz",
-      "integrity": "sha512-UMfH0VSjP0G4p3EWirscJEQ/cHqnT/iuH6oNZOB94nBjWbMnhGEPxsZm1eyIW0C/9jLI0Fow4W5DXLjEI7mn1g==",
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.2",
+        "@eslint/eslintrc": "^0.4.3",
+        "@humanwhocodes/config-array": "^0.5.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -2879,6 +3110,14 @@
             "ms": "^2.1.1"
           }
         }
+      }
+    },
+    "eslint-plugin-html": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-7.1.0.tgz",
+      "integrity": "sha512-fNLRraV/e6j8e3XYOC9xgND4j+U7b1Rq+OygMlLcMg+wI/IpVbF+ubQa3R78EjKB9njT6TQOlcK5rFKBVVtdfg==",
+      "requires": {
+        "htmlparser2": "^8.0.1"
       }
     },
     "eslint-plugin-import": {
@@ -3139,9 +3378,9 @@
       }
     },
     "globals": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
-      "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -3185,6 +3424,24 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
+    },
+    "htmlparser2": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
+      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+      "requires": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "entities": "^4.3.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+          "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
+        }
+      }
     },
     "ignore": {
       "version": "4.0.6",
@@ -3936,7 +4193,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "string-width": {

--- a/platform/web/package.json
+++ b/platform/web/package.json
@@ -5,23 +5,30 @@
   "description": "Development and linting setup for Godot's Web platform code",
   "scripts": {
     "docs": "jsdoc --template js/jsdoc2rst/ js/engine/engine.js js/engine/config.js js/engine/features.js --destination ''",
-    "lint": "npm run lint:engine && npm run lint:libs && npm run lint:modules && npm run lint:tools",
+    "lint": "npm run lint:engine && npm run lint:libs && npm run lint:modules && npm run lint:tools && npm run lint:html",
     "lint:engine": "eslint \"js/engine/*.js\" --no-eslintrc -c .eslintrc.engine.js",
     "lint:libs": "eslint \"js/libs/*.js\" --no-eslintrc -c .eslintrc.libs.js",
     "lint:modules": "eslint \"../../modules/**/*.js\" --no-eslintrc -c .eslintrc.libs.js",
     "lint:tools": "eslint \"js/jsdoc2rst/**/*.js\" --no-eslintrc -c .eslintrc.engine.js",
-    "format": "npm run format:engine && npm run format:libs && npm run format:modules && npm run format:tools",
+    "lint:html": "eslint \"../../misc/dist/html/*.html\" --no-eslintrc -c .eslintrc.html.js",
+    "format": "npm run format:engine && npm run format:libs && npm run format:modules && npm run format:tools && npm run format:html",
     "format:engine": "npm run lint:engine -- --fix",
     "format:libs": "npm run lint:libs -- --fix",
     "format:modules": "npm run lint:modules -- --fix",
-    "format:tools": "npm run lint:tools -- --fix"
+    "format:tools": "npm run lint:tools -- --fix",
+    "format:html": "npm run lint:html -- --fix"
   },
   "author": "Godot Engine contributors",
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^7.28.0",
+    "@html-eslint/eslint-plugin": "^0.15.0",
+    "@html-eslint/parser": "^0.15.0",
+    "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.23.4",
     "jsdoc": "^3.6.7"
+  },
+  "dependencies": {
+    "eslint-plugin-html": "^7.1.0"
   }
 }


### PR DESCRIPTION
Uses `html-eslint` for HTML file and `eslint-plugin-html` for inline JavaScript.

Use HTML5 (not XHTML), remove CDATA and trailing slashes for self closing tags.

Add format checks to CI.


Closes #66291 .

We should double-check the validity of all the HTML changes (auto-closing tags?) and the schema for the `editor.html` (xhtml doesn't seem correct.)