### PR TITLE
Properly initialize use_aabb_center in visual server

### DIFF
--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -374,7 +374,7 @@ public:
 
 			custom_aabb = nullptr;
 			sorting_offset = 0.0f;
-			use_aabb_center = false;
+			use_aabb_center = true;
 		}
 
 		~Instance() {


### PR DESCRIPTION
Fixes an unreported bug which made the renderer silently default to sorting based on AABB origin

In visual_instance.cpp ``use_aabb_center`` is initialized to ``true``:
https://github.com/godotengine/godot/blob/3c39bc365fbfeda805aa87687422e9c9092c809b/scene/3d/visual_instance.cpp#L237

But in visual_server_scene.h it is initialized to ``false``:
https://github.com/godotengine/godot/blob/3c39bc365fbfeda805aa87687422e9c9092c809b/servers/visual/visual_server_scene.h#L377

Accordingly, the default behaviour will be to sort based on the AABB origin while the default setting exposed to users and to the editor will say that it is set to sort based on the AABB center. 

This issue is only present in the 3.x branch