### PR TITLE
Rename `BACK` constant to `BACKWARD` in Vector3 and Vector3i

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2364,7 +2364,7 @@ static void _register_variant_builtin_methods() {
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "UP", Vector3(0, 1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "DOWN", Vector3(0, -1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "FORWARD", Vector3(0, 0, -1));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "BACK", Vector3(0, 0, 1));
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "BACKWARD", Vector3(0, 0, 1));
 
 	_VariantCall::add_constant(Variant::VECTOR4, "AXIS_X", Vector4::AXIS_X);
 	_VariantCall::add_constant(Variant::VECTOR4, "AXIS_Y", Vector4::AXIS_Y);
@@ -2407,7 +2407,7 @@ static void _register_variant_builtin_methods() {
 	_VariantCall::add_variant_constant(Variant::VECTOR3I, "UP", Vector3i(0, 1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3I, "DOWN", Vector3i(0, -1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3I, "FORWARD", Vector3i(0, 0, -1));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "BACK", Vector3i(0, 0, 1));
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "BACKWARD", Vector3i(0, 0, 1));
 
 	_VariantCall::add_constant(Variant::VECTOR2, "AXIS_X", Vector2::AXIS_X);
 	_VariantCall::add_constant(Variant::VECTOR2, "AXIS_Y", Vector2::AXIS_Y);

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -390,8 +390,8 @@
 		<constant name="FORWARD" value="Vector3(0, 0, -1)">
 			Forward unit vector. Represents the local direction of forward, and the global direction of north.
 		</constant>
-		<constant name="BACK" value="Vector3(0, 0, 1)">
-			Back unit vector. Represents the local direction of back, and the global direction of south.
+		<constant name="BACKWARD" value="Vector3(0, 0, 1)">
+			Backward unit vector. Represents the local direction of back, and the global direction of south.
 		</constant>
 	</constants>
 	<operators>

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -133,8 +133,8 @@
 		<constant name="FORWARD" value="Vector3i(0, 0, -1)">
 			Forward unit vector. Represents the local direction of forward, and the global direction of north.
 		</constant>
-		<constant name="BACK" value="Vector3i(0, 0, 1)">
-			Back unit vector. Represents the local direction of back, and the global direction of south.
+		<constant name="BACKWARD" value="Vector3i(0, 0, 1)">
+			Backward unit vector. Represents the local direction of back, and the global direction of south.
 		</constant>
 	</constants>
 	<operators>


### PR DESCRIPTION
`BACKWARD` makes more sense in the context of unit vectors, since it implies a direction, in contrast to `BACK`, which implies a fixed point. This also makes the naming more consistent with `Vector3.FORWARD`.

Fixes #67229.