### PR TITLE
[3.x] Rename `BACK` constant to `BACKWARD` in Vector3

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -2238,7 +2238,7 @@ void register_variant_methods() {
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "UP", Vector3(0, 1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "DOWN", Vector3(0, -1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "FORWARD", Vector3(0, 0, -1));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "BACK", Vector3(0, 0, 1));
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "BACKWARD", Vector3(0, 0, 1));
 
 	_VariantCall::add_constant(Variant::VECTOR2, "AXIS_X", Vector2::AXIS_X);
 	_VariantCall::add_constant(Variant::VECTOR2, "AXIS_Y", Vector2::AXIS_Y);

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -318,8 +318,8 @@
 		<constant name="FORWARD" value="Vector3( 0, 0, -1 )">
 			Forward unit vector. Represents the local direction of forward, and the global direction of north.
 		</constant>
-		<constant name="BACK" value="Vector3( 0, 0, 1 )">
-			Back unit vector. Represents the local direction of back, and the global direction of south.
+		<constant name="BACKWARD" value="Vector3( 0, 0, 1 )">
+			Backward unit vector. Represents the local direction of back, and the global direction of south.
 		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
3.x version of #67265.
