### PR TITLE
Fix Stutter when generating physics for objects in the "Advanced Import Settings" Window

### DIFF
--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -437,7 +437,7 @@ void SceneImportSettings::_update_view_gizmos() {
 
 		MeshInstance3D *collider_view = static_cast<MeshInstance3D *>(descendants[0].operator Object *());
 		collider_view->set_visible(generate_collider);
-		if (generate_collider) {
+		if (generate_collider && collider_view->get_mesh().is_null()) {
 			// This collider_view doesn't have a mesh so we need to generate a new one.
 
 			// Generate the mesh collider.


### PR DESCRIPTION
When generating physics for a mesh in the advanced import settings, the import window keeps lagging/stuttering. The issue seems to originate from `_update_view_gizmos()` in in scene_import_settings.cpp. The function repeatedly builds a `collider_view` for the mesh even if one already exists which causes a constant performance drop:
`if (generate_collider)`

The stutter goes away by adding a simple check - if `collider_view` already exists for the mesh, don't keep rebuilding it:
`if (generate_collider && collider_view->get_mesh().is_null())`

Fixes Stutter mentioned in Issue #67149

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
