### PR TITLE
Restrict MSAA attachment usage to the strictly needed set

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -2461,6 +2461,7 @@ void TextureStorage::_update_render_target(RenderTarget *rt) {
 			RD::TEXTURE_SAMPLES_8,
 		};
 		rd_color_multisample_format.samples = texture_samples[rt->msaa];
+		rd_color_multisample_format.usage_bits = RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
 		RD::TextureView rd_view_multisample;
 		rd_color_multisample_format.is_resolve_buffer = false;
 		rt->color_multisample = RD::get_singleton()->texture_create(rd_color_multisample_format, rd_view_multisample);


### PR DESCRIPTION
In D3D12 it's not cool to ask for an UAV (storage) with MSAA. It's recently supported. Nonetheless, it's a good practice to pass only the usage flags really needed. In this case, the MSAA target doesn't need to be used as storage or be able to be copied from; in short, it just needs to support the role of a color attachment.