### PR TITLE
Actually set the execinfo flag on non-glibc systems

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -367,6 +367,7 @@ def configure(env: "Environment"):
         # The default crash handler depends on glibc, so if the host uses
         # a different libc (BSD libc, musl), fall back to libexecinfo.
         print("Note: Using `execinfo=yes` for the crash handler as required on platforms where glibc is missing.")
+        env["execinfo"] = True
 
     if env["execinfo"]:
         env.Append(LIBS=["execinfo"])


### PR DESCRIPTION
For some reason the condition only printed that it would set the flag, without actually setting it.

I tested it on a pretty standard KISS Linux installation using musl by cherry picking this commit on my Wayland branch. It's also trivial enough to make me confident enough that it will work. Still, testing is always appreciated.

*Bugsquad edit:* Fixup to #63983.