### PR TITLE
Keep rendering context window size in sync when resizing

### DIFF
--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -1729,6 +1729,18 @@ void DisplayServerX11::window_set_size(const Size2i p_size, WindowID p_window) {
 
 		usleep(10000);
 	}
+
+	// Keep rendering context window size in sync
+#if defined(VULKAN_ENABLED)
+	if (context_vulkan) {
+		context_vulkan->window_resize(p_window, xwa.width, xwa.height);
+	}
+#endif
+#if defined(GLES3_ENABLED)
+	if (gl_manager) {
+		gl_manager->window_resize(p_window, xwa.width, xwa.height);
+	}
+#endif
 }
 
 Size2i DisplayServerX11::window_get_size(WindowID p_window) const {


### PR DESCRIPTION
Fixes #67280.

On X11 we rely on `ConfigureNotify` event to update rendering context window size, but we don't get such event when resizing programmatically, only when done "manually" by resizing the window etc.