### PR TITLE
Fix Skeleton3D falsely assuming all physical bones will be children of their first bone

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -888,10 +888,14 @@ void _pb_start_simulation(const Skeleton3D *p_skeleton, Node *p_node, const Vect
 
 	PhysicalBone3D *pb = Object::cast_to<PhysicalBone3D>(p_node);
 	if (pb) {
-		for (int i = p_sim_bones.size() - 1; 0 <= i; --i) {
-			if (p_sim_bones[i] == pb->get_bone_id() || p_skeleton->is_bone_parent_of(pb->get_bone_id(), p_sim_bones[i])) {
-				pb->set_simulate_physics(true);
-				break;
+		if (p_sim_bones.is_empty()) { // If no bones is specified, activate ragdoll on full body.
+			pb->set_simulate_physics(true);
+		} else {
+			for (int i = p_sim_bones.size() - 1; 0 <= i; --i) {
+				if (p_sim_bones[i] == pb->get_bone_id() || p_skeleton->is_bone_parent_of(pb->get_bone_id(), p_sim_bones[i])) {
+					pb->set_simulate_physics(true);
+					break;
+				}
 			}
 		}
 	}
@@ -901,9 +905,7 @@ void Skeleton3D::physical_bones_start_simulation_on(const TypedArray<StringName>
 	set_physics_process_internal(false);
 
 	Vector<int> sim_bones;
-	if (p_bones.size() <= 0) {
-		sim_bones.push_back(0); // If no bones is specified, activate ragdoll on full body.
-	} else {
+	if (p_bones.size() > 0) {
 		sim_bones.resize(p_bones.size());
 		int c = 0;
 		for (int i = sim_bones.size() - 1; 0 <= i; --i) {


### PR DESCRIPTION
`physical_bones_start_simulation_on` was falsely assuming all physbones will be children of the first bone in their skeleton.

I've changed it so when the list of bones is empty, all physical bones start simulating, which more accurately reflects the documentation. 

This issue might also affect 3.x, I vaguely remember running into something that might have been this.