### PR TITLE
Add ability for extensions to clear object instance bindings

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -855,6 +855,11 @@ static void gdextension_object_set_instance_binding(GDExtensionObjectPtr p_objec
 	o->set_instance_binding(p_token, p_binding, p_callbacks);
 }
 
+static void gdextension_object_clear_instance_binding(GDExtensionObjectPtr p_object, void *p_token) {
+	Object *o = (Object *)p_object;
+	o->clear_instance_binding(p_token);
+}
+
 static void gdextension_object_set_instance(GDExtensionObjectPtr p_object, GDExtensionConstStringNamePtr p_classname, GDExtensionClassInstancePtr p_instance) {
 	const StringName classname = *reinterpret_cast<const StringName *>(p_classname);
 	Object *o = (Object *)p_object;
@@ -1051,6 +1056,7 @@ void gdextension_setup_interface(GDExtensionInterface *p_interface) {
 	gde_interface.global_get_singleton = gdextension_global_get_singleton;
 	gde_interface.object_get_instance_binding = gdextension_object_get_instance_binding;
 	gde_interface.object_set_instance_binding = gdextension_object_set_instance_binding;
+	gde_interface.object_clear_instance_binding = gdextension_object_clear_instance_binding;
 	gde_interface.object_set_instance = gdextension_object_set_instance;
 
 	gde_interface.object_cast_to = gdextension_object_cast_to;

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -544,6 +544,7 @@ typedef struct {
 
 	void *(*object_get_instance_binding)(GDExtensionObjectPtr p_o, void *p_token, const GDExtensionInstanceBindingCallbacks *p_callbacks);
 	void (*object_set_instance_binding)(GDExtensionObjectPtr p_o, void *p_token, void *p_binding, const GDExtensionInstanceBindingCallbacks *p_callbacks);
+	void (*object_clear_instance_binding)(GDExtensionObjectPtr p_o, void *p_token);
 
 	void (*object_set_instance)(GDExtensionObjectPtr p_o, GDExtensionConstStringNamePtr p_classname, GDExtensionClassInstancePtr p_instance); /* p_classname should be a registered extension class and should extend the p_o object's class. */
 

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1744,6 +1744,18 @@ void *Object::get_instance_binding(void *p_token, const GDExtensionInstanceBindi
 	return binding;
 }
 
+void Object::clear_instance_binding(void *p_token) {
+	ERR_FAIL_COND(_instance_bindings == nullptr);
+	for (uint32_t i = 0; i < _instance_binding_count; i++) {
+		InstanceBinding &instance_binding = _instance_bindings[i];
+		if (instance_binding.token == p_token) {
+			instance_binding.free_callback(p_token, this, instance_binding.binding);
+			instance_binding = InstanceBinding();
+			break;
+		}
+	}
+}
+
 bool Object::has_instance_binding(void *p_token) {
 	bool found = false;
 	_instance_binding_mutex.lock();

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -920,6 +920,8 @@ public:
 	void *get_instance_binding(void *p_token, const GDExtensionInstanceBindingCallbacks *p_callbacks);
 	// Used on creation by binding only.
 	void set_instance_binding(void *p_token, void *p_binding, const GDExtensionInstanceBindingCallbacks *p_callbacks);
+	// Used on unloading by binding only.
+	void clear_instance_binding(void *p_token);
 	bool has_instance_binding(void *p_token);
 
 	void clear_internal_resource_paths();


### PR DESCRIPTION
Required for https://github.com/godotengine/godot-cpp/pull/892.

This change adds `Object::clear_instance_binding` which is meant to let (generated) extension code clear/unset the instance binding that gets created for engine singletons in [`Object::get_instance_binding`](https://github.com/godotengine/godot/blob/e8f9cd8ac5cf3e511e02d78a5497d204ca7e8308/core/object/object.cpp#L1723-L1737).

See https://github.com/godotengine/godot-cpp/pull/892 for more details on its usage. 