### PR TITLE
Fix crash in 3D viewport when dragging into a scene with physics on a separate thread

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3739,14 +3739,15 @@ Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos) const 
 	Vector3 point = world_pos + world_ray * MAX_DISTANCE;
 
 	PhysicsDirectSpaceState3D *ss = get_tree()->get_root()->get_world_3d()->get_direct_space_state();
+	if (ss != nullptr) {
+		PhysicsDirectSpaceState3D::RayParameters ray_params;
+		ray_params.from = world_pos;
+		ray_params.to = point;
 
-	PhysicsDirectSpaceState3D::RayParameters ray_params;
-	ray_params.from = world_pos;
-	ray_params.to = world_pos + world_ray * MAX_DISTANCE;
-
-	PhysicsDirectSpaceState3D::RayResult result;
-	if (ss->intersect_ray(ray_params, result)) {
-		point = result.position;
+		PhysicsDirectSpaceState3D::RayResult result;
+		if (ss->intersect_ray(ray_params, result)) {
+			point = result.position;
+		}
 	}
 
 	return point;


### PR DESCRIPTION
The crash occurs because `Node3DEditorViewport::_get_instance_position` fails to check for `nullptr` on the state space before using it. Simply adding an `if` check fixed it (but it doesn't fix the physics error).
The error that ends up causing the crash only happens when `physics/3d/run_on_separate_thread` is enabled.

I was experiencing #54672, and it bugged me enough to try to fix it.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
