### PR TITLE
Fix _unnamed_arg so that arguments defined by GDExtension show up in the editor docs.

### DIFF
--- a/core/object/method_bind.cpp
+++ b/core/object/method_bind.cpp
@@ -63,7 +63,9 @@ PropertyInfo MethodBind::get_argument_info(int p_argument) const {
 
 	PropertyInfo info = _gen_argument_type_info(p_argument);
 #ifdef DEBUG_METHODS_ENABLED
-	info.name = p_argument < arg_names.size() ? String(arg_names[p_argument]) : String("_unnamed_arg" + itos(p_argument));
+	if (info.name.is_empty()) {
+		info.name = p_argument < arg_names.size() ? String(arg_names[p_argument]) : String("_unnamed_arg" + itos(p_argument));
+	}
 #endif
 	return info;
 }


### PR DESCRIPTION
The Godot API (gdnative_interface.h) allows methods to be registered on extension classes with `classdb_register_extension_class_method`.

`GDNativeExtensionClassMethodInfo` can be provided to this function along with a `get_argument_info_func` which according to the comment indicates that argument names should be definable here.

```c
typedef struct {
	const char *name;
	void *method_userdata;
	GDNativeExtensionClassMethodCall call_func;
	GDNativeExtensionClassMethodPtrCall ptrcall_func;
	uint32_t method_flags; /* GDNativeExtensionClassMethodFlags */
	uint32_t argument_count;
	GDNativeBool has_return_value;
	GDNativeExtensionClassMethodGetArgumentType get_argument_type_func;
	GDNativeExtensionClassMethodGetArgumentInfo get_argument_info_func; /* name and hint information for the argument can be omitted in release builds. Class name should always be present if it applies. */
	GDNativeExtensionClassMethodGetArgumentMetadata get_argument_metadata_func;
	uint32_t default_argument_count;
	GDNativeVariantPtr *default_arguments;
} GDNativeExtensionClassMethodInfo;
```

Unfortunately, setting the name field in the `GDNativePropertyInfo` struct has no effect on the editor documentation, which continues to display "_unnamed_arg" for each argument.

I discovered that `MethodBind::get_argument_info` is responsible for this as it always overrides `info.name`. I've added an if condition that will only override the name when it is empty. I've tested this with my GDExtension module and I can confirm that with this commit, the argument name shows up in the builtin docs. eg. in Lookup Symbol.

*Bugsquad edit:*
- Fixes #55298