### PR TITLE
Prevent inputs to spin slider while popup is visible

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -54,7 +54,7 @@ String EditorSpinSlider::get_text_value() const {
 void EditorSpinSlider::gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
-	if (read_only) {
+	if (read_only || value_input_focused) {
 		return;
 	}
 
@@ -560,6 +560,7 @@ void EditorSpinSlider::_value_input_submitted(const String &p_text) {
 void EditorSpinSlider::_value_input_closed() {
 	_evaluate_input_text();
 	value_input_just_closed = true;
+	value_input_focused = false;
 }
 
 //focus_exited signal
@@ -618,6 +619,8 @@ bool EditorSpinSlider::is_grabbing() const {
 }
 
 void EditorSpinSlider::_focus_entered() {
+	value_input_focused = true;
+
 	_ensure_input_popup();
 	Rect2 gr = get_screen_rect();
 	value_input->set_text(get_text_value());

--- a/editor/editor_spin_slider.h
+++ b/editor/editor_spin_slider.h
@@ -65,6 +65,7 @@ class EditorSpinSlider : public Range {
 
 	Popup *value_input_popup = nullptr;
 	LineEdit *value_input = nullptr;
+	bool value_input_focused = false;
 	bool value_input_just_closed = false;
 	bool value_input_dirty = false;
 


### PR DESCRIPTION
Fixes #66909. Once we decide to enter focus on the popup, we can ignore any further input events until the popup is closed. This seems to prevent the bug where a stray mouse button pressed event causes the mouse to get stuck in captured mode.

I am a noob! If a GUI or editor expert could review this I would really appreciate it. There may be smarter or more elegant ways to fix this, but this is nice and simple and at least for me, it fixes #66909.