### PR TITLE
Rename `set`/`get_indexed`'s "property" to "property_path"

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1468,8 +1468,8 @@ void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_class", "class"), &Object::is_class);
 	ClassDB::bind_method(D_METHOD("set", "property", "value"), &Object::_set_bind);
 	ClassDB::bind_method(D_METHOD("get", "property"), &Object::_get_bind);
-	ClassDB::bind_method(D_METHOD("set_indexed", "property", "value"), &Object::_set_indexed_bind);
-	ClassDB::bind_method(D_METHOD("get_indexed", "property"), &Object::_get_indexed_bind);
+	ClassDB::bind_method(D_METHOD("set_indexed", "property_path", "value"), &Object::_set_indexed_bind);
+	ClassDB::bind_method(D_METHOD("get_indexed", "property_path"), &Object::_get_indexed_bind);
 	ClassDB::bind_method(D_METHOD("get_property_list"), &Object::_get_property_list_bind);
 	ClassDB::bind_method(D_METHOD("get_method_list"), &Object::_get_method_list_bind);
 	ClassDB::bind_method(D_METHOD("notification", "what", "reversed"), &Object::notification, DEFVAL(false));

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -364,9 +364,9 @@
 		</method>
 		<method name="get_indexed" qualifiers="const">
 			<return type="Variant" />
-			<param index="0" name="property" type="NodePath" />
+			<param index="0" name="property_path" type="NodePath" />
 			<description>
-				Gets the object's property indexed by the given [NodePath]. The node path should be relative to the current object and can use the colon character ([code]:[/code]) to access nested properties. Examples: [code]"position:x"[/code] or [code]"material:next_pass:blend_mode"[/code].
+				Gets the object's property indexed by the given [param property_path]. The path should be a [NodePath] relative to the current object and can use the colon character ([code]:[/code]) to access nested properties. Examples: [code]"position:x"[/code] or [code]"material:next_pass:blend_mode"[/code].
 				[b]Note:[/b] Even though the method takes [NodePath] argument, it doesn't support actual paths to [Node]s in the scene tree, only colon-separated sub-property paths. For the purpose of nodes, use [method Node.get_node_and_resource] instead.
 			</description>
 		</method>
@@ -532,10 +532,10 @@
 		</method>
 		<method name="set_indexed">
 			<return type="void" />
-			<param index="0" name="property" type="NodePath" />
+			<param index="0" name="property_path" type="NodePath" />
 			<param index="1" name="value" type="Variant" />
 			<description>
-				Assigns a new value to the property identified by the [NodePath]. The node path should be relative to the current object and can use the colon character ([code]:[/code]) to access nested properties. Example:
+				Assigns a new value to the property identified by the [param property_path]. The path should be a [NodePath] relative to the current object and can use the colon character ([code]:[/code]) to access nested properties. Example:
 				[codeblocks]
 				[gdscript]
 				var node = Node2D.new()


### PR DESCRIPTION
This parameter's name is oddly misleading. The entire point of `set_indexed` and `get_indexed` is to set/get by _path_, so "property" is not actually **just** the property name. It's a whole, relative **NodePath**.

This PR renames the parameter to to "property_path", and touches up the Documentation slightly to make this clearer.

_(This minor oddity can easily be backported to 3.x)_

