### PR TITLE
Allow readonly and writeonly C# properties to be accessed from GDScript

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/OneWayProperties/AllReadOnly.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/OneWayProperties/AllReadOnly.cs
@@ -1,0 +1,10 @@
+namespace Godot.SourceGenerators.Sample
+{
+    public partial class AllReadOnly : GodotObject
+    {
+        public readonly string readonly_field = "foo";
+        public string readonly_auto_property { get; } = "foo";
+        public string readonly_property { get => "foo"; }
+        public string initonly_auto_property { get; init; }
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/OneWayProperties/AllWriteOnly.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/OneWayProperties/AllWriteOnly.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Godot.SourceGenerators.Sample
+{
+    public partial class AllWriteOnly : GodotObject
+    {
+        bool writeonly_backing_field = false;
+        public bool writeonly_property { set => writeonly_backing_field = value; }
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/OneWayProperties/MixedReadOnlyWriteOnly.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/OneWayProperties/MixedReadOnlyWriteOnly.cs
@@ -1,0 +1,13 @@
+namespace Godot.SourceGenerators.Sample
+{
+    public partial class MixedReadonlyWriteOnly : GodotObject
+    {
+        public readonly string readonly_field = "foo";
+        public string readonly_auto_property { get; } = "foo";
+        public string readonly_property { get => "foo"; }
+        public string initonly_auto_property { get; init; }
+
+        bool writeonly_backing_field = false;
+        public bool writeonly_property { set => writeonly_backing_field = value; }
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -303,11 +303,6 @@ namespace Godot.SourceGenerators
         {
             foreach (var property in properties)
             {
-                // TODO: We should still restore read-only properties after reloading assembly. Two possible ways: reflection or turn RestoreGodotObjectData into a constructor overload.
-                // Ignore properties without a getter, without a setter or with an init-only setter. Godot properties must be both readable and writable.
-                if (property.IsWriteOnly || property.IsReadOnly || property.SetMethod!.IsInitOnly)
-                    continue;
-
                 var marshalType = MarshalUtils.ConvertManagedTypeToMarshalType(property.Type, typeCache);
 
                 if (marshalType == null)
@@ -325,10 +320,6 @@ namespace Godot.SourceGenerators
             foreach (var field in fields)
             {
                 // TODO: We should still restore read-only fields after reloading assembly. Two possible ways: reflection or turn RestoreGodotObjectData into a constructor overload.
-                // Ignore properties without a getter or without a setter. Godot properties must be both readable and writable.
-                if (field.IsReadOnly)
-                    continue;
-
                 var marshalType = MarshalUtils.ConvertManagedTypeToMarshalType(field.Type, typeCache);
 
                 if (marshalType == null)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -212,31 +212,37 @@ namespace Godot.SourceGenerators
                 }
 
                 // Generate GetGodotClassPropertyValue
+                bool allPropertiesAreWriteOnly = godotClassFields.Length == 0 && godotClassProperties.All(pi => pi.PropertySymbol.IsWriteOnly);
 
-                source.Append("    /// <inheritdoc/>\n");
-                source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
-                source.Append("    protected override bool GetGodotClassPropertyValue(in godot_string_name name, ");
-                source.Append("out godot_variant value)\n    {\n");
-
-                isFirstEntry = true;
-                foreach (var property in godotClassProperties)
+                if (!allPropertiesAreWriteOnly)
                 {
-                    GeneratePropertyGetter(property.PropertySymbol.Name,
-                        property.PropertySymbol.Type, property.Type, source, isFirstEntry);
-                    isFirstEntry = false;
+                    source.Append("    /// <inheritdoc/>\n");
+                    source.Append("    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n");
+                    source.Append("    protected override bool GetGodotClassPropertyValue(in godot_string_name name, ");
+                    source.Append("out godot_variant value)\n    {\n");
+
+                    isFirstEntry = true;
+                    foreach (var property in godotClassProperties)
+                    {
+                        if (property.PropertySymbol.IsWriteOnly)
+                            continue;
+
+                        GeneratePropertyGetter(property.PropertySymbol.Name,
+                            property.PropertySymbol.Type, property.Type, source, isFirstEntry);
+                        isFirstEntry = false;
+                    }
+
+                    foreach (var field in godotClassFields)
+                    {
+                        GeneratePropertyGetter(field.FieldSymbol.Name,
+                            field.FieldSymbol.Type, field.Type, source, isFirstEntry);
+                        isFirstEntry = false;
+                    }
+
+                    source.Append("        return base.GetGodotClassPropertyValue(name, out value);\n");
+
+                    source.Append("    }\n");
                 }
-
-                foreach (var field in godotClassFields)
-                {
-                    GeneratePropertyGetter(field.FieldSymbol.Name,
-                        field.FieldSymbol.Type, field.Type, source, isFirstEntry);
-                    isFirstEntry = false;
-                }
-
-                source.Append("        return base.GetGodotClassPropertyValue(name, out value);\n");
-
-                source.Append("    }\n");
-
                 // Generate GetGodotPropertyList
 
                 const string dictionaryType = "global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo>";

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSerializationGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSerializationGenerator.cs
@@ -119,8 +119,14 @@ namespace Godot.SourceGenerators
                 .Where(s => !s.IsStatic && s.Kind == SymbolKind.Field && !s.IsImplicitlyDeclared)
                 .Cast<IFieldSymbol>();
 
-            var godotClassProperties = propertySymbols.WhereIsGodotCompatibleType(typeCache).ToArray();
-            var godotClassFields = fieldSymbols.WhereIsGodotCompatibleType(typeCache).ToArray();
+            // TODO: We should still restore read-only properties after reloading assembly. Two possible ways: reflection or turn RestoreGodotObjectData into a constructor overload.
+            // Ignore properties without a getter, without a setter or with an init-only setter. Godot properties must be both readable and writable.
+            var godotClassProperties = propertySymbols.Where(property => !(property.IsReadOnly || property.IsWriteOnly || property.SetMethod!.IsInitOnly))
+                .WhereIsGodotCompatibleType(typeCache)
+                .ToArray();
+            var godotClassFields = fieldSymbols.Where(property => !property.IsReadOnly)
+                .WhereIsGodotCompatibleType(typeCache)
+                .ToArray();
 
             var signalDelegateSymbols = members
                 .Where(s => s.Kind == SymbolKind.NamedType)


### PR DESCRIPTION
A potential fix for #67167

As mentioned on the issue, I'm new to the codebase and may be _way_ off. Skepticism and feedback welcome. :)

The goal is to allow GDScript to access readonly and writeonly properties on C# objects, like the str2 property of the C# class in the cross-language scripting tutorial: https://docs.godotengine.org/en/latest/tutorials/scripting/cross_language_scripting.html

As far as I can tell, this functionality is intended- ScriptPropertiesGenerator.cs even has a check to skip over generating setters for readonly properties and fields- but the code never gets there because WhereIsGodotScriptSerializable filters out readonly and writeonly properties, and readonly fields. As far as I can tell on that, it's because they're not appropriate for script serialization, not because they shouldn't be accessible via the generated GetGodotClassPropertyValue and SetGodotClassPropertyValue methods.

So, the goal of this PR is to separate those criteria into two methods- one for the type compatibility check and one for the serializability check so that ScriptSerializationGenerator.cs can call both and keep the same output it has today, while ScriptPropertiesGenerator.cs calls just the type check and generates all applicable getters and setters.

*Bugsquad edit:*
- Fixes #67167