### PR TITLE
Fix `dotnet format`

### DIFF
--- a/misc/scripts/dotnet_format.sh
+++ b/misc/scripts/dotnet_format.sh
@@ -5,6 +5,13 @@
 
 set -uo pipefail
 
+# Create dummy generated files.
+echo "<Project />" > modules/mono/SdkPackageVersions.props
+mkdir -p modules/mono/glue/GodotSharp/GodotSharp/Generated
+echo "<Project />" > modules/mono/glue/GodotSharp/GodotSharp/Generated/GeneratedIncludes.props
+mkdir -p modules/mono/glue/GodotSharp/GodotSharpEditor/Generated
+echo "<Project />" > modules/mono/glue/GodotSharp/GodotSharpEditor/Generated/GeneratedIncludes.props
+
 # Loops through all C# projects tracked by Git.
 git ls-files -- '*.csproj' \
                 ':!:.git/*' ':!:thirdparty/*' ':!:platform/android/java/lib/src/com/google/*' ':!:*-so_wrap.*' |


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/64956

Noticed that in https://github.com/godotengine/godot/pull/67216 CI was not complaining about mixing tabs and spaces.

It seems `dotnet format` fails to analyze projects when it encounters issues such as the csproj referencing non-existent or invalid `.props` files, since we generate some of those and the static checks CI won't have those generated I create some dummy files so that `dotnet format` can at least check the style and whitespace rules properly.