### PR TITLE
fixed holding alt while zooming zooms in by 2 increments.

### DIFF
--- a/scene/gui/view_panner.cpp
+++ b/scene/gui/view_panner.cpp
@@ -38,7 +38,9 @@ bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid()) {
 		Vector2 scroll_vec = Vector2((mb->get_button_index() == MouseButton::WHEEL_RIGHT) - (mb->get_button_index() == MouseButton::WHEEL_LEFT), (mb->get_button_index() == MouseButton::WHEEL_DOWN) - (mb->get_button_index() == MouseButton::WHEEL_UP));
-		if (scroll_vec != Vector2()) {
+		// Moving the scroll wheel sends two events: one with pressed as true,
+		// and one with pressed as false. Make sure we only process one of them.
+		if (scroll_vec != Vector2() && mb->is_pressed()) {
 			if (control_scheme == SCROLL_PANS) {
 				if (mb->is_ctrl_pressed()) {
 					scroll_vec.y *= mb->get_factor();


### PR DESCRIPTION
When scrolling, Godot is generating two events:
`InputEventMouseButton: button_index=4, mods=Alt, pressed=true, position=((807, 754)), button_mask=8, double_click=false`
`InputEventMouseButton: button_index=4, mods=Alt, pressed=false, position=((807, 754)), button_mask=0, double_click=false`

Added an if statement to check if the mouse button is pressed so that only one of the events is processed.
Not sure if Godot generating two scroll events is intended but regardless this should solve the issue. (also not sure how to fix that)

Resolves #67221