### PR TITLE
[3.x] Rename `set_indexed` & `get_child`'s params to be clearer

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1670,8 +1670,8 @@ void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_class", "class"), &Object::is_class);
 	ClassDB::bind_method(D_METHOD("set", "property", "value"), &Object::_set_bind);
 	ClassDB::bind_method(D_METHOD("get", "property"), &Object::_get_bind);
-	ClassDB::bind_method(D_METHOD("set_indexed", "property", "value"), &Object::_set_indexed_bind);
-	ClassDB::bind_method(D_METHOD("get_indexed", "property"), &Object::_get_indexed_bind);
+	ClassDB::bind_method(D_METHOD("set_indexed", "property_path", "value"), &Object::_set_indexed_bind);
+	ClassDB::bind_method(D_METHOD("get_indexed", "property_path"), &Object::_get_indexed_bind);
 	ClassDB::bind_method(D_METHOD("get_property_list"), &Object::_get_property_list_bind);
 	ClassDB::bind_method(D_METHOD("get_method_list"), &Object::_get_method_list_bind);
 	ClassDB::bind_method(D_METHOD("notification", "what", "reversed"), &Object::notification, DEFVAL(false));

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -108,10 +108,10 @@
 		<method name="add_child">
 			<return type="void" />
 			<argument index="0" name="node" type="Node" />
-			<argument index="1" name="legible_unique_name" type="bool" default="false" />
+			<argument index="1" name="force_readable_name" type="bool" default="false" />
 			<description>
 				Adds a child node. Nodes can have any number of children, but every child must have a unique name. Child nodes are automatically deleted when the parent node is deleted, so an entire scene can be removed by deleting its topmost node.
-				If [code]legible_unique_name[/code] is [code]true[/code], the child node will have a human-readable name based on the name of the node being instanced instead of its type.
+				If [code]force_readable_name[/code] is [code]true[/code], improves the readability of the added node. If not named, the node is renamed to its type, and if it shares [member name] with a sibling, a number is suffixed more appropriately. This operation is very slow. As such, it is recommended leaving this to [code]false[/code], which assigns a dummy name featuring [code]@[/code] in both situations.
 				[b]Note:[/b] If the child node already has a parent, the function will fail. Use [method remove_child] first to remove the node from its current parent. For example:
 				[codeblock]
 				if child_node.get_parent():
@@ -125,10 +125,10 @@
 			<return type="void" />
 			<argument index="0" name="node" type="Node" />
 			<argument index="1" name="child_node" type="Node" />
-			<argument index="2" name="legible_unique_name" type="bool" default="false" />
+			<argument index="2" name="force_readable_name" type="bool" default="false" />
 			<description>
 				Adds [code]child_node[/code] as a child. The child is placed below the given [code]node[/code] in the list of children.
-				If [code]legible_unique_name[/code] is [code]true[/code], the child node will have a human-readable name based on the name of the node being instanced instead of its type.
+				If [code]force_readable_name[/code] is [code]true[/code], improves the readability of the added node. If not named, the node is renamed to its type, and if it shares [member name] with a sibling, a number is suffixed more appropriately. This operation is very slow. As such, it is recommended leaving this to [code]false[/code], which assigns a dummy name featuring [code]@[/code] in both situations.
 			</description>
 		</method>
 		<method name="add_to_group">

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -199,9 +199,9 @@
 		</method>
 		<method name="get_indexed" qualifiers="const">
 			<return type="Variant" />
-			<argument index="0" name="property" type="NodePath" />
+			<argument index="0" name="property_path" type="NodePath" />
 			<description>
-				Gets the object's property indexed by the given [NodePath]. The node path should be relative to the current object and can use the colon character ([code]:[/code]) to access nested properties. Examples: [code]"position:x"[/code] or [code]"material:next_pass:blend_mode"[/code].
+				Gets the object's property indexed by the given [code]property_path[/code]. The path should be a [NodePath] relative to the current object and can use the colon character ([code]:[/code]) to access nested properties. Examples: [code]"position:x"[/code] or [code]"material:next_pass:blend_mode"[/code].
 				[b]Note:[/b] Even though the method takes [NodePath] argument, it doesn't support actual paths to [Node]s in the scene tree, only colon-separated sub-property paths. For the purpose of nodes, use [method Node.get_node_and_resource] instead.
 			</description>
 		</method>
@@ -365,10 +365,10 @@
 		</method>
 		<method name="set_indexed">
 			<return type="void" />
-			<argument index="0" name="property" type="NodePath" />
+			<argument index="0" name="property_path" type="NodePath" />
 			<argument index="1" name="value" type="Variant" />
 			<description>
-				Assigns a new value to the property identified by the [NodePath]. The node path should be relative to the current object and can use the colon character ([code]:[/code]) to access nested properties. Example:
+				Assigns a new value to the property identified by the [code]property_path[/code]. The path should be a [NodePath] relative to the current object and can use the colon character ([code]:[/code]) to access nested properties. Example:
 				[codeblock]
 				set_indexed("position", Vector2(42, 0))
 				set_indexed("position:y", -10)

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1284,7 +1284,7 @@ void Node::_add_child_nocheck(Node *p_child, const StringName &p_name) {
 	}
 }
 
-void Node::add_child(Node *p_child, bool p_legible_unique_name) {
+void Node::add_child(Node *p_child, bool p_force_readable_name) {
 	ERR_FAIL_NULL(p_child);
 	ERR_FAIL_COND_MSG(p_child == this, vformat("Can't add child '%s' to itself.", p_child->get_name())); // adding to itself!
 	ERR_FAIL_COND_MSG(p_child->data.parent, vformat("Can't add child '%s' to '%s', already has a parent '%s'.", p_child->get_name(), get_name(), p_child->data.parent->get_name())); //Fail if node has a parent
@@ -1294,16 +1294,16 @@ void Node::add_child(Node *p_child, bool p_legible_unique_name) {
 	ERR_FAIL_COND_MSG(data.blocked > 0, "Parent node is busy setting up children, add_node() failed. Consider using call_deferred(\"add_child\", child) instead.");
 
 	/* Validate name */
-	_validate_child_name(p_child, p_legible_unique_name);
+	_validate_child_name(p_child, p_force_readable_name);
 
 	_add_child_nocheck(p_child, p_child->data.name);
 }
 
-void Node::add_child_below_node(Node *p_node, Node *p_child, bool p_legible_unique_name) {
+void Node::add_child_below_node(Node *p_node, Node *p_child, bool p_force_readable_name) {
 	ERR_FAIL_NULL(p_node);
 	ERR_FAIL_NULL(p_child);
 
-	add_child(p_child, p_legible_unique_name);
+	add_child(p_child, p_force_readable_name);
 
 	if (p_node->data.parent == this) {
 		move_child(p_child, p_node->get_position_in_parent() + 1);
@@ -2981,11 +2981,11 @@ void Node::_bind_methods() {
 	GLOBAL_DEF("node/name_casing", NAME_CASING_PASCAL_CASE);
 	ProjectSettings::get_singleton()->set_custom_property_info("node/name_casing", PropertyInfo(Variant::INT, "node/name_casing", PROPERTY_HINT_ENUM, "PascalCase,camelCase,snake_case"));
 
-	ClassDB::bind_method(D_METHOD("add_child_below_node", "node", "child_node", "legible_unique_name"), &Node::add_child_below_node, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("add_child_below_node", "node", "child_node", "force_readable_name"), &Node::add_child_below_node, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("set_name", "name"), &Node::set_name);
 	ClassDB::bind_method(D_METHOD("get_name"), &Node::get_name);
-	ClassDB::bind_method(D_METHOD("add_child", "node", "legible_unique_name"), &Node::add_child, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("add_child", "node", "force_readable_name"), &Node::add_child, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_child", "node"), &Node::remove_child);
 	ClassDB::bind_method(D_METHOD("get_child_count"), &Node::get_child_count);
 	ClassDB::bind_method(D_METHOD("get_children"), &Node::_get_children);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -304,8 +304,8 @@ public:
 	StringName get_name() const;
 	void set_name(const String &p_name);
 
-	void add_child(Node *p_child, bool p_legible_unique_name = false);
-	void add_child_below_node(Node *p_node, Node *p_child, bool p_legible_unique_name = false);
+	void add_child(Node *p_child, bool p_force_readable_name = false);
+	void add_child_below_node(Node *p_node, Node *p_child, bool p_force_readable_name = false);
 	void remove_child(Node *p_child);
 
 	int get_child_count() const;


### PR DESCRIPTION
3.x backport of both #67300 and #64463 in one tight package.