### PR TITLE
[Windows] Fix more GCC MinGW warnings.

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -331,8 +331,10 @@ Vector<String> OS_Windows::get_video_adapter_driver_info() const {
 	if (hr != S_OK) {
 		return Vector<String>();
 	}
+	BSTR resource_name = SysAllocString(L"root\\CIMV2");
+	hr = wbemLocator->ConnectServer(resource_name, NULL, NULL, NULL, 0, NULL, NULL, &wbemServices);
+	SysFreeString(resource_name);
 
-	hr = wbemLocator->ConnectServer(L"root\\CIMV2", NULL, NULL, 0, NULL, 0, 0, &wbemServices);
 	SAFE_RELEASE(wbemLocator) // from now on, use `wbemServices`
 	if (hr != S_OK) {
 		SAFE_RELEASE(wbemServices)


### PR DESCRIPTION
Fixes the following MinGW / GCC 12.2.0 warnings added by a recent changes:

```
platform/windows/os_windows.cpp: In member function 'virtual Vector<String> OS_Windows::get_video_adapter_driver_info() const':
platform/windows/os_windows.cpp:335:41: warning: ISO C++ forbids converting a string constant to 'BSTR' {aka 'wchar_t*'} [-Wwrite-strings]
  335 |         hr = wbemLocator->ConnectServer(L"root\\CIMV2", NULL, NULL, 0, NULL, 0, 0, &wbemServices);
      |                                         ^~~~~~~~~~~~~~
platform/windows/os_windows.cpp:335:72: warning: passing NULL to non-pointer argument 5 of 'virtual HRESULT IWbemLocator::ConnectServer(BSTR, BSTR, BSTR, BSTR, LONG, BSTR, IWbemContext*, IWbemServices**)' [-Wconversion-null]
  335 |         hr = wbemLocator->ConnectServer(L"root\\CIMV2", NULL, NULL, 0, NULL, 0, 0, &wbemServices);
      |                                                                        ^~~~
In file included from platform/windows/os_windows.cpp:56:
/opt/homebrew/Cellar/mingw-w64/10.0.0_3/toolchain-x86_64/x86_64-w64-mingw32/include/wbemcli.h:1538:14: note:   declared here
 1538 |         LONG lSecurityFlags,
      |         ~~~~~^~~~~~~~~~~~~~
```