### PR TITLE
Fix crash when selecting a new `ScriptExtension` for a `NativeExtension` resource

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2185,6 +2185,9 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 	}
 
 	Ref<Script> scr = p_resource;
+	if (scr->get_language() == nullptr) {
+		return false;
+	}
 
 	// Don't open dominant script if using an external editor.
 	bool use_external_editor =


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
This fixes issue #67267 it was fairly simple once i got a stack trace.

I don't know how the engine got a plain Script object but i am fairly certain it shouldn't be possible, in my opinion Script should be made a abstract class so that it is impossible but i certainly won't use my time doing that, 

besides that as a script language i have only gdscript as an option. no one has responded to my issue so if you can't replicate try doing it without any GDExtension installed.