### PR TITLE
Add iOS UI Options

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -565,6 +565,13 @@
 		<member name="display/window/ios/hide_home_indicator" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], the home indicator is hidden automatically. This only affects iOS devices without a physical home button.
 		</member>
+		<member name="display/window/ios/hide_status_bar" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], the status bar is hidden while the app is running.
+		</member>
+		<member name="display/window/ios/suppress_ui_gesture" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], it will require two swipes to access iOS UI that uses gestures.
+			[b]Note:[/b] This setting has no effect on the home indicator if [code]hide_home_indicator[/code] is [code]true[/code].
+		</member>
 		<member name="display/window/per_pixel_transparency/allowed" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], allows per-pixel transparency for the window background. This affects performance, so leave it on [code]false[/code] unless you need it. See also [member display/window/size/transparent] and [member rendering/transparent_background].
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1808,6 +1808,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 					"0,33200,1,or_greater")); // No negative numbers
 
 	GLOBAL_DEF("display/window/ios/hide_home_indicator", true);
+	GLOBAL_DEF("display/window/ios/hide_status_bar", true);
+	GLOBAL_DEF("display/window/ios/suppress_ui_gesture", true);
 	GLOBAL_DEF("input_devices/pointing/ios/touch_delay", 0.15);
 	ProjectSettings::get_singleton()->set_custom_property_info("input_devices/pointing/ios/touch_delay",
 			PropertyInfo(Variant::FLOAT,

--- a/platform/ios/view_controller.mm
+++ b/platform/ios/view_controller.mm
@@ -164,7 +164,11 @@
 // MARK: Orientation
 
 - (UIRectEdge)preferredScreenEdgesDeferringSystemGestures {
-	return UIRectEdgeAll;
+	if (GLOBAL_GET("display/window/ios/suppress_ui_gesture")) {
+		return UIRectEdgeAll;
+	} else {
+		return UIRectEdgeNone;
+	}
 }
 
 - (BOOL)shouldAutorotate {
@@ -206,7 +210,11 @@
 }
 
 - (BOOL)prefersStatusBarHidden {
-	return YES;
+	if (GLOBAL_GET("display/window/ios/hide_status_bar")) {
+		return YES;
+	} else {
+		return NO;
+	}
 }
 
 - (BOOL)prefersHomeIndicatorAutoHidden {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5573.

Adds settings to allow the Status Bar to be visible on iOS exports while in portrait mode on iPhone, and disable system gesture suppression (to access Notification Center, Control Center, Home, and App Switcher).