### PR TITLE
[Web] Add the "serve" and "run" scons targets.

### DIFF
--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -2,6 +2,20 @@
 
 Import("env")
 
+# The HTTP server "targets". Run with "scons p=web serve", or "scons p=web run"
+if "serve" in COMMAND_LINE_TARGETS or "run" in COMMAND_LINE_TARGETS:
+    from serve import serve
+    import os
+
+    port = os.environ.get("GODOT_WEB_TEST_PORT", 8060)
+    try:
+        port = int(port)
+    except Exception:
+        print("GODOT_WEB_TEST_PORT must be a valid integer")
+        sys.exit(255)
+    serve(env.Dir("#bin/.web_zip").abspath, port, "run" in COMMAND_LINE_TARGETS)
+    sys.exit(0)
+
 web_files = [
     "audio_driver_web.cpp",
     "display_server_web.cpp",

--- a/platform/web/serve.py
+++ b/platform/web/serve.py
@@ -24,6 +24,17 @@ def shell_open(url):
         subprocess.call([opener, url])
 
 
+def serve(root, port, run_browser):
+    os.chdir(root)
+
+    if run_browser:
+        # Open the served page in the user's default browser.
+        print("Opening the served URL in the default browser (use `--no-browser` or `-n` to disable this).")
+        shell_open(f"http://127.0.0.1:{port}")
+
+    test(CORSRequestHandler, HTTPServer, port=port)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--port", help="port to listen on", default=8060, type=int)
@@ -41,12 +52,4 @@ if __name__ == "__main__":
     # so that the script can be run from any location.
     os.chdir(Path(__file__).resolve().parent)
 
-    if args.root:
-        os.chdir(args.root)
-
-    if args.browser:
-        # Open the served page in the user's default browser.
-        print("Opening the served URL in the default browser (use `--no-browser` or `-n` to disable this).")
-        shell_open(f"http://127.0.0.1:{args.port}")
-
-    test(CORSRequestHandler, HTTPServer, port=args.port)
+    serve(args.root, args.port, args.browser)


### PR DESCRIPTION
You can now run the test HTTP server by calling:
```
scons p=web serve
```
If you also wish to run the browser, call instead:
```
scons p=web run
```
The default listen port is 8060, but can be overriden via the env variable `GODOT_WEB_TEST_PORT` which must be a valid integer.

Follow up on #64886