### PR TITLE
Don't free instanced scenes when recreating tiles

### DIFF
--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -236,6 +236,8 @@ private:
 	void _clear_layer_internals(int p_layer);
 	void _clear_internals();
 
+	HashSet<Vector3i> instantiated_scenes;
+
 	// Rect caching.
 	void _recompute_rect_cache();
 


### PR DESCRIPTION
Fixes #58034
Fixes #68347

Scenes are no longer re-instantiated when quadrant is recreated, including when setting cells and changing layer properties (modulate etc). Only modifying TileSet will recreate the scenes (although there's high chance they'll just get unlinked at that point...).

To me it's rather weird that the scenes are re-instanced at all. The purpose of scene collections is to put objects on your level. At no point you want them freed and recreated by the TileMap.

That said, not sure if my solution is good. Probably not 🙃