### PR TITLE
Fix stretch transform when resizing SubViewports

### DIFF
--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -471,7 +471,7 @@ private:
 	uint64_t event_count = 0;
 
 protected:
-	void _set_size(const Size2i &p_size, const Size2i &p_size_2d_override, const Rect2i &p_to_screen_rect, const Transform2D &p_stretch_transform, bool p_allocated);
+	void _set_size(const Size2i &p_size, const Size2i &p_size_2d_override, const Rect2i &p_to_screen_rect, bool p_allocated);
 
 	Size2i _get_size() const;
 	Size2i _get_size_2d_override() const;
@@ -649,6 +649,8 @@ public:
 	void set_canvas_cull_mask_bit(uint32_t p_layer, bool p_enable);
 	bool get_canvas_cull_mask_bit(uint32_t p_layer) const;
 
+	virtual bool is_size_2d_override_stretch_enabled() const { return true; }
+
 	virtual Transform2D get_screen_transform() const;
 	virtual Transform2D get_popup_base_transform() const { return Transform2D(); }
 
@@ -759,7 +761,6 @@ private:
 protected:
 	static void _bind_methods();
 	virtual DisplayServer::WindowID get_window_id() const override;
-	Transform2D _stretch_transform();
 	void _notification(int p_what);
 
 public:
@@ -771,7 +772,7 @@ public:
 	Size2i get_size_2d_override() const;
 
 	void set_size_2d_override_stretch(bool p_enable);
-	bool is_size_2d_override_stretch_enabled() const;
+	bool is_size_2d_override_stretch_enabled() const override;
 
 	void set_update_mode(UpdateMode p_mode);
 	UpdateMode get_update_mode() const;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -905,7 +905,6 @@ void Window::_update_viewport_size() {
 	Size2i final_size;
 	Size2i final_size_override;
 	Rect2i attach_to_screen_rect(Point2i(), size);
-	Transform2D stretch_transform_new;
 	float font_oversampling = 1.0;
 	window_transform = Transform2D();
 
@@ -913,9 +912,6 @@ void Window::_update_viewport_size() {
 		font_oversampling = content_scale_factor;
 		final_size = size;
 		final_size_override = Size2(size) / content_scale_factor;
-
-		stretch_transform_new = Transform2D();
-		stretch_transform_new.scale(Size2(content_scale_factor, content_scale_factor));
 	} else {
 		//actual screen video mode
 		Size2 video_mode = size;
@@ -991,9 +987,6 @@ void Window::_update_viewport_size() {
 				attach_to_screen_rect = Rect2(margin, screen_size);
 				font_oversampling = (screen_size.x / viewport_size.x) * content_scale_factor;
 
-				Size2 scale = Vector2(screen_size) / Vector2(final_size_override);
-				stretch_transform_new.scale(scale);
-
 				window_transform.translate_local(margin);
 			} break;
 			case CONTENT_SCALE_MODE_VIEWPORT: {
@@ -1011,7 +1004,7 @@ void Window::_update_viewport_size() {
 	}
 
 	bool allocate = is_inside_tree() && visible && (window_id != DisplayServer::INVALID_WINDOW_ID || embedder != nullptr);
-	_set_size(final_size, final_size_override, attach_to_screen_rect, stretch_transform_new, allocate);
+	_set_size(final_size, final_size_override, attach_to_screen_rect, allocate);
 
 	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
 		RenderingServer::get_singleton()->viewport_attach_to_screen(get_viewport_rid(), attach_to_screen_rect, window_id);


### PR DESCRIPTION
resolve #67329
resolve #68871

In `SubViewport::set_size` the following function is called:
https://github.com/godotengine/godot/blob/895428c8058ce97abb02a6a3500e463f72a4f9c9/scene/main/viewport.cpp#L4112

The problem is, that currently `_stretch_transform()` is based on the previous size of the `SubViewport` instead of the new `p_size`.

This PR changes the code, so that stretch transform is now calculated inside of `Viewport::_set_size`, where the new `size` and `size_2d_override` are available.

Updated 2022-11-19: Fix merge conflict
Updated 2023-01-27: Fix merge conflict
Updated 2023-02-01: Fix merge conflict with #66906