### PR TITLE
Fix bug in CylinderMesh when computing normals

### DIFF
--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -771,6 +771,7 @@ void CylinderMesh::create_mesh_array(Array &p_arr, float top_radius, float botto
 
 	thisrow = 0;
 	prevrow = 0;
+	const real_t side_normal_y = (bottom_radius - top_radius) / height;
 	for (j = 0; j <= (rings + 1); j++) {
 		v = j;
 		v /= (rings + 1);
@@ -789,7 +790,7 @@ void CylinderMesh::create_mesh_array(Array &p_arr, float top_radius, float botto
 
 			Vector3 p = Vector3(x * radius, y, z * radius);
 			points.push_back(p);
-			normals.push_back(Vector3(x, 0.0, z));
+			normals.push_back(Vector3(x, side_normal_y, z).normalized());
 			ADD_TANGENT(z, 0.0, -x, 1.0)
 			uvs.push_back(Vector2(u, v * 0.5));
 			point++;


### PR DESCRIPTION
While writing unit tests for `CylinderMesh` I realized the following bug.  When the top radius and bottom radius are different, the normal should be slanted in the `y` direction to some degree.  

However, in `primitive_meshes.cpp`, the `y` component of the normals along the side of the cylinder was always set to zero.  Essentially, the normals were being computed as if it were a right cylinder, as opposed to a sort of trapezoidal cylinder with different radii on top and bottom.
