### PR TITLE
Add empty state to enum properties

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -760,8 +760,13 @@ void EditorPropertyEnum::_option_selected(int p_which) {
 }
 
 void EditorPropertyEnum::update_property() {
-	int64_t which = get_edited_object()->get(get_edited_property());
+	Variant current = get_edited_object()->get(get_edited_property());
+	if (current.get_type() == Variant::NIL) {
+		options->select(-1);
+		return;
+	}
 
+	int64_t which = current;
 	for (int i = 0; i < options->get_item_count(); i++) {
 		if (which == (int64_t)options->get_item_metadata(i)) {
 			options->select(i);


### PR DESCRIPTION
Fixes #33914
![godot windows editor dev x86_64_Mn2bbWJVXC](https://user-images.githubusercontent.com/2223172/195580530-d70a4e05-85d0-4d29-99f4-2ab57e8a9dc8.gif)
