### PR TITLE
[WebSocket] Fix TCP connection being closed while connecting.

### DIFF
--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -104,6 +104,8 @@ void WSLPeer::Resolver::try_next_candidate(Ref<StreamPeerTCP> &p_tcp) {
 			p_tcp->set_no_delay(true);
 			ip_candidates.clear();
 			return;
+		} else if (status == StreamPeerTCP::STATUS_CONNECTING) {
+			return; // Keep connecting.
 		} else {
 			p_tcp->disconnect_from_host();
 		}


### PR DESCRIPTION
Fix a bug causing the WebSocketPeer to fail connecting to a remote server when the TCP 3-way handshake took more than a few milliseconds.

Fixup after #66594 
