### PR TITLE
Fixed Physical bone joints set_param error

### DIFF
--- a/servers/physics_3d/godot_physics_server_3d.cpp
+++ b/servers/physics_3d/godot_physics_server_3d.cpp
@@ -1247,7 +1247,7 @@ void GodotPhysicsServer3D::joint_make_pin(RID p_joint, RID p_body_A, const Vecto
 void GodotPhysicsServer3D::pin_joint_set_param(RID p_joint, PinJointParam p_param, real_t p_value) {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_COND(!joint);
-	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_PIN);
+	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_PIN && joint->get_type() != JOINT_TYPE_MAX);
 	GodotPinJoint3D *pin_joint = static_cast<GodotPinJoint3D *>(joint);
 	pin_joint->set_param(p_param, p_value);
 }
@@ -1343,7 +1343,7 @@ void GodotPhysicsServer3D::joint_make_hinge_simple(RID p_joint, RID p_body_A, co
 void GodotPhysicsServer3D::hinge_joint_set_param(RID p_joint, HingeJointParam p_param, real_t p_value) {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_COND(!joint);
-	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_HINGE);
+	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_HINGE && joint->get_type() != JOINT_TYPE_MAX);
 	GodotHingeJoint3D *hinge_joint = static_cast<GodotHingeJoint3D *>(joint);
 	hinge_joint->set_param(p_param, p_value);
 }
@@ -1444,7 +1444,7 @@ void GodotPhysicsServer3D::joint_make_slider(RID p_joint, RID p_body_A, const Tr
 void GodotPhysicsServer3D::slider_joint_set_param(RID p_joint, SliderJointParam p_param, real_t p_value) {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_COND(!joint);
-	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_SLIDER);
+	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_SLIDER && joint->get_type() != JOINT_TYPE_MAX);
 	GodotSliderJoint3D *slider_joint = static_cast<GodotSliderJoint3D *>(joint);
 	slider_joint->set_param(p_param, p_value);
 }
@@ -1484,7 +1484,7 @@ void GodotPhysicsServer3D::joint_make_cone_twist(RID p_joint, RID p_body_A, cons
 void GodotPhysicsServer3D::cone_twist_joint_set_param(RID p_joint, ConeTwistJointParam p_param, real_t p_value) {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_COND(!joint);
-	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_CONE_TWIST);
+	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_CONE_TWIST && joint->get_type() != JOINT_TYPE_MAX);
 	GodotConeTwistJoint3D *cone_twist_joint = static_cast<GodotConeTwistJoint3D *>(joint);
 	cone_twist_joint->set_param(p_param, p_value);
 }
@@ -1524,7 +1524,7 @@ void GodotPhysicsServer3D::joint_make_generic_6dof(RID p_joint, RID p_body_A, co
 void GodotPhysicsServer3D::generic_6dof_joint_set_param(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisParam p_param, real_t p_value) {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_COND(!joint);
-	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_6DOF);
+	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_6DOF && joint->get_type() != JOINT_TYPE_MAX);
 	GodotGeneric6DOFJoint3D *generic_6dof_joint = static_cast<GodotGeneric6DOFJoint3D *>(joint);
 	generic_6dof_joint->set_param(p_axis, p_param, p_value);
 }

--- a/servers/physics_3d/joints/godot_cone_twist_joint_3d.cpp
+++ b/servers/physics_3d/joints/godot_cone_twist_joint_3d.cpp
@@ -96,6 +96,8 @@ GodotConeTwistJoint3D::GodotConeTwistJoint3D(GodotBody3D *rbA, GodotBody3D *rbB,
 	B->add_constraint(this, 1);
 }
 
+PhysicsServer3D::JointType GodotConeTwistJoint3D::get_type() const { return PhysicsServer3D::JOINT_TYPE_CONE_TWIST; }
+
 bool GodotConeTwistJoint3D::setup(real_t p_timestep) {
 	dynamic_A = (A->get_mode() > PhysicsServer3D::BODY_MODE_KINEMATIC);
 	dynamic_B = (B->get_mode() > PhysicsServer3D::BODY_MODE_KINEMATIC);

--- a/servers/physics_3d/joints/godot_cone_twist_joint_3d.h
+++ b/servers/physics_3d/joints/godot_cone_twist_joint_3d.h
@@ -102,7 +102,7 @@ public:
 	bool m_solveSwingLimit = false;
 
 public:
-	virtual PhysicsServer3D::JointType get_type() const override { return PhysicsServer3D::JOINT_TYPE_CONE_TWIST; }
+	virtual PhysicsServer3D::JointType get_type() const override;
 
 	virtual bool setup(real_t p_step) override;
 	virtual void solve(real_t p_step) override;

--- a/servers/physics_3d/joints/godot_generic_6dof_joint_3d.cpp
+++ b/servers/physics_3d/joints/godot_generic_6dof_joint_3d.cpp
@@ -313,6 +313,8 @@ bool GodotGeneric6DOFJoint3D::testAngularLimitMotor(int axis_index) {
 	return m_angularLimits[axis_index].needApplyTorques();
 }
 
+PhysicsServer3D::JointType GodotGeneric6DOFJoint3D::get_type() const { return PhysicsServer3D::JOINT_TYPE_6DOF; }
+
 bool GodotGeneric6DOFJoint3D::setup(real_t p_timestep) {
 	dynamic_A = (A->get_mode() > PhysicsServer3D::BODY_MODE_KINEMATIC);
 	dynamic_B = (B->get_mode() > PhysicsServer3D::BODY_MODE_KINEMATIC);

--- a/servers/physics_3d/joints/godot_generic_6dof_joint_3d.h
+++ b/servers/physics_3d/joints/godot_generic_6dof_joint_3d.h
@@ -202,7 +202,7 @@ protected:
 public:
 	GodotGeneric6DOFJoint3D(GodotBody3D *rbA, GodotBody3D *rbB, const Transform3D &frameInA, const Transform3D &frameInB, bool useLinearReferenceFrameA);
 
-	virtual PhysicsServer3D::JointType get_type() const override { return PhysicsServer3D::JOINT_TYPE_6DOF; }
+	virtual PhysicsServer3D::JointType get_type() const override;
 
 	virtual bool setup(real_t p_step) override;
 	virtual void solve(real_t p_step) override;

--- a/servers/physics_3d/joints/godot_hinge_joint_3d.cpp
+++ b/servers/physics_3d/joints/godot_hinge_joint_3d.cpp
@@ -124,6 +124,8 @@ GodotHingeJoint3D::GodotHingeJoint3D(GodotBody3D *rbA, GodotBody3D *rbB, const V
 	B->add_constraint(this, 1);
 }
 
+PhysicsServer3D::JointType GodotHingeJoint3D::get_type() const { return PhysicsServer3D::JOINT_TYPE_HINGE; }
+
 bool GodotHingeJoint3D::setup(real_t p_step) {
 	dynamic_A = (A->get_mode() > PhysicsServer3D::BODY_MODE_KINEMATIC);
 	dynamic_B = (B->get_mode() > PhysicsServer3D::BODY_MODE_KINEMATIC);

--- a/servers/physics_3d/joints/godot_hinge_joint_3d.h
+++ b/servers/physics_3d/joints/godot_hinge_joint_3d.h
@@ -96,7 +96,7 @@ class GodotHingeJoint3D : public GodotJoint3D {
 	real_t m_appliedImpulse = 0.0;
 
 public:
-	virtual PhysicsServer3D::JointType get_type() const override { return PhysicsServer3D::JOINT_TYPE_HINGE; }
+	virtual PhysicsServer3D::JointType get_type() const override;
 
 	virtual bool setup(real_t p_step) override;
 	virtual void solve(real_t p_step) override;

--- a/servers/physics_3d/joints/godot_pin_joint_3d.cpp
+++ b/servers/physics_3d/joints/godot_pin_joint_3d.cpp
@@ -49,6 +49,8 @@ subject to the following restrictions:
 
 #include "godot_pin_joint_3d.h"
 
+PhysicsServer3D::JointType GodotPinJoint3D::get_type() const { return PhysicsServer3D::JOINT_TYPE_PIN; }
+
 bool GodotPinJoint3D::setup(real_t p_step) {
 	dynamic_A = (A->get_mode() > PhysicsServer3D::BODY_MODE_KINEMATIC);
 	dynamic_B = (B->get_mode() > PhysicsServer3D::BODY_MODE_KINEMATIC);

--- a/servers/physics_3d/joints/godot_pin_joint_3d.h
+++ b/servers/physics_3d/joints/godot_pin_joint_3d.h
@@ -74,7 +74,7 @@ class GodotPinJoint3D : public GodotJoint3D {
 	Vector3 m_pivotInB;
 
 public:
-	virtual PhysicsServer3D::JointType get_type() const override { return PhysicsServer3D::JOINT_TYPE_PIN; }
+	virtual PhysicsServer3D::JointType get_type() const override;
 
 	virtual bool setup(real_t p_step) override;
 	virtual void solve(real_t p_step) override;

--- a/servers/physics_3d/joints/godot_slider_joint_3d.cpp
+++ b/servers/physics_3d/joints/godot_slider_joint_3d.cpp
@@ -151,6 +151,7 @@ bool GodotSliderJoint3D::setup(real_t p_step) {
 }
 
 //-----------------------------------------------------------------------------
+PhysicsServer3D::JointType GodotSliderJoint3D::get_type() const { return PhysicsServer3D::JOINT_TYPE_SLIDER; }
 
 void GodotSliderJoint3D::solve(real_t p_step) {
 	int i;

--- a/servers/physics_3d/joints/godot_slider_joint_3d.h
+++ b/servers/physics_3d/joints/godot_slider_joint_3d.h
@@ -237,10 +237,10 @@ public:
 	void set_param(PhysicsServer3D::SliderJointParam p_param, real_t p_value);
 	real_t get_param(PhysicsServer3D::SliderJointParam p_param) const;
 
+	virtual PhysicsServer3D::JointType get_type() const override;
+
 	virtual bool setup(real_t p_step) override;
 	virtual void solve(real_t p_step) override;
-
-	virtual PhysicsServer3D::JointType get_type() const override { return PhysicsServer3D::JOINT_TYPE_SLIDER; }
 };
 
 #endif // GODOT_SLIDER_JOINT_3D_H

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -630,7 +630,6 @@ public:
 		JOINT_TYPE_CONE_TWIST,
 		JOINT_TYPE_6DOF,
 		JOINT_TYPE_MAX,
-
 	};
 
 	virtual RID joint_create() = 0;


### PR DESCRIPTION

Fixes #66645 

I'm a new contributor so I'm sorry if I'm missing anything. Code compiles and unit tests are passing.

The issue was that when Godot first starts, for some reason joints begin as JOINT_TYPE_MAX and then change to their assigned type. 