### PR TITLE
[3.x] Improve Scene Tree Dock's Node filter (Allow multiple terms & more)

### DIFF
--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -156,7 +156,13 @@ class SceneTreeDock : public VBoxContainer {
 	EditorSubScene *import_subscene_dialog;
 	EditorFileDialog *new_scene_from_dialog;
 
+	enum FilterMenuItems {
+		FILTER_BY_TYPE = 64, // Used in the same menus as the Tool enum.
+		FILTER_BY_GROUP,
+	};
+
 	LineEdit *filter;
+	PopupMenu *filter_quick_menu;
 	TextureRect *filter_icon;
 
 	PopupMenu *menu;
@@ -240,8 +246,12 @@ class SceneTreeDock : public VBoxContainer {
 	void _quick_open();
 
 	void _tree_rmb(const Vector2 &p_menu_pos);
+	void _update_filter_menu();
 
 	void _filter_changed(const String &p_filter);
+	void _filter_gui_input(const Ref<InputEvent> &p_event);
+	void _filter_option_selected(int option);
+	void _append_filter_options_to(PopupMenu *p_menu, bool p_include_separator = true);
 
 	void _perform_instance_scenes(const Vector<String> &p_files, Node *parent, int p_pos);
 	void _replace_with_branch_scene(const String &p_file, Node *base);

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -61,6 +61,7 @@ class SceneTreeEditor : public Control {
 	ObjectID instance_node;
 
 	String filter;
+	String filter_term_warning;
 
 	AcceptDialog *error;
 	AcceptDialog *warning;
@@ -72,9 +73,11 @@ class SceneTreeEditor : public Control {
 
 	void _compute_hash(Node *p_node, uint64_t &hash);
 
-	bool _add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll_to_selected = false);
+	void _add_nodes(Node *p_node, TreeItem *p_parent);
 	void _test_update_tree();
 	void _update_tree(bool p_scroll_to_selected = false);
+	bool _update_filter(TreeItem *p_parent = nullptr, bool p_scroll_to_selected = false);
+	bool _item_matches_all_terms(TreeItem *p_item, Vector<String> p_terms);
 	void _tree_changed();
 	void _node_removed(Node *p_node);
 	void _node_renamed(Node *p_node);
@@ -134,6 +137,7 @@ class SceneTreeEditor : public Control {
 public:
 	void set_filter(const String &p_filter);
 	String get_filter() const;
+	String get_filter_term_warning() const;
 
 	void set_undo_redo(UndoRedo *p_undo_redo) { undo_redo = p_undo_redo; };
 	void set_display_foreign_nodes(bool p_display);


### PR DESCRIPTION
Backport of #65352, #65932 and #65939, as well as some other filtering behavioral changes.

For the onlookers perhaps seeing this on a patch-note, here's the summary of what this PR features:


| Multiple filter terms & more | Special filters
| --- | --- |
| ![Gif2](https://i.gyazo.com/65710daa20dfbd2390f34347fedcdd43.gif) | ![Gif1](https://i.gyazo.com/0e3cf058bedfaa858aa616e250c71152.gif)
| Spaces divide each search term. <br>Only Nodes matching **all** terms are displayed. <br>Parent Nodes with children matching the search are **darkened**. | A few special filters are available to narrow down the search: <br> - **Filter by Type** (accounts for inheritance); <br>- **Filter by Group**.

If you do not remember the special filters, or want to discover this feature, they are quickly available by:
| Right click | Middle click | Top-right menu |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/66727710/195595894-e4f4d5ee-0e5f-4524-94d0-1714066b283f.png)| ![middle Click](https://user-images.githubusercontent.com/66727710/195593113-1c57e802-3306-43f0-bae2-9d39e4113c69.png) | No, wait, this one is not in Godot 3... <br>What do I do?


| Warning | Tooltip |
| --- | --- |
| ![Warning](https://user-images.githubusercontent.com/66727710/195457873-49b400f1-bcc6-4341-a088-b64d16d7e225.png) | ![Tooltip](https://user-images.githubusercontent.com/66727710/195458024-d0e4294a-1bab-4e90-afc5-4adfbe40eb0a.png) |
| A warning is available as a tooltip when the special filter is not recognised. | A short description can be seen by hovering over the "Filter by" options |

Lastly, you may have noticed dark yellow-coloured names:
| | |
|--- | --- |
| ![image](https://user-images.githubusercontent.com/66727710/195542838-d1410545-2ab0-44ae-acf9-792ae4b410a6.png) | ![image](https://user-images.githubusercontent.com/66727710/195543879-af7c6ada-1590-431d-a1b9-c5f4c2a8e122.png)

~~Out of necessity, in this PR, this is the color of inherited children. 
Do note that this is actually **unlike** Godot 4.0, which uses a purely unfiltered warning yellow colour. However, I personally felt like that was too alienating to returning users.~~