### PR TITLE
Comment not to remove `data` structs in some Nodes

### DIFF
--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -96,6 +96,7 @@ private:
 
 	mutable SelfList<Node> xform_change;
 
+	// This Data struct is to avoid namespace pollution in derived classes.
 	struct Data {
 		mutable Transform3D global_transform;
 		mutable Transform3D local_transform;

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -159,6 +159,7 @@ private:
 		}
 	};
 
+	// This Data struct is to avoid namespace pollution in derived classes.
 	struct Data {
 		// Global relations.
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -91,6 +91,7 @@ private:
 		SceneTree::Group *group = nullptr;
 	};
 
+	// This Data struct is to avoid namespace pollution in derived classes.
 	struct Data {
 		String scene_file_path;
 		Ref<SceneState> instance_state;


### PR DESCRIPTION
Salvages https://github.com/godotengine/godot/pull/62795, and does its exact opposite.

This PR just writes a comment regurgitating https://github.com/godotengine/godot/pull/62795#issuecomment-1207941864 near the `data` struct of **Node**, **Node3D**, **Control**.