### PR TITLE
[WebSocket] Fix Web write mode, debugger.

### DIFF
--- a/modules/websocket/editor/editor_debugger_server_websocket.cpp
+++ b/modules/websocket/editor/editor_debugger_server_websocket.cpp
@@ -40,7 +40,13 @@
 
 void EditorDebuggerServerWebSocket::poll() {
 	if (pending_peer.is_null() && tcp_server->is_connection_available()) {
-		Ref<WebSocketPeer> peer;
+		Ref<WebSocketPeer> peer = Ref<WebSocketPeer>(WebSocketPeer::create());
+		ERR_FAIL_COND(peer.is_null()); // Bug.
+
+		Vector<String> ws_protocols;
+		ws_protocols.push_back("binary"); // Compatibility for emscripten TCP-to-WebSocket.
+		peer->set_supported_protocols(ws_protocols);
+
 		Error err = peer->accept_stream(tcp_server->take_connection());
 		if (err == OK) {
 			pending_timer = OS::get_singleton()->get_ticks_msec();

--- a/modules/websocket/emws_peer.cpp
+++ b/modules/websocket/emws_peer.cpp
@@ -120,7 +120,7 @@ Error EMWSPeer::_send(const uint8_t *p_buffer, int p_buffer_size, bool p_binary)
 }
 
 Error EMWSPeer::send(const uint8_t *p_buffer, int p_buffer_size, WriteMode p_mode) {
-	return _send(p_buffer, p_buffer_size, p_mode == WRITE_MODE_TEXT);
+	return _send(p_buffer, p_buffer_size, p_mode == WRITE_MODE_BINARY);
 }
 
 Error EMWSPeer::put_packet(const uint8_t *p_buffer, int p_buffer_size) {

--- a/modules/websocket/register_types.cpp
+++ b/modules/websocket/register_types.cpp
@@ -31,10 +31,13 @@
 #include "register_types.h"
 
 #include "core/config/project_settings.h"
+#include "core/debugger/engine_debugger.h"
 #include "core/error/error_macros.h"
 
 #include "websocket_multiplayer_peer.h"
 #include "websocket_peer.h"
+
+#include "remote_debugger_peer_websocket.h"
 
 #ifdef WEB_ENABLED
 #include "emws_peer.h"
@@ -55,7 +58,7 @@ static void _editor_init_callback() {
 #endif
 
 void initialize_websocket_module(ModuleInitializationLevel p_level) {
-	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_CORE) {
 #ifdef WEB_ENABLED
 		EMWSPeer::initialize();
 #else
@@ -64,6 +67,9 @@ void initialize_websocket_module(ModuleInitializationLevel p_level) {
 
 		GDREGISTER_CLASS(WebSocketMultiplayerPeer);
 		ClassDB::register_custom_instance_class<WebSocketPeer>();
+
+		EngineDebugger::register_uri_handler("ws://", RemoteDebuggerPeerWebSocket::create);
+		EngineDebugger::register_uri_handler("wss://", RemoteDebuggerPeerWebSocket::create);
 	}
 
 #ifdef TOOLS_ENABLED
@@ -74,7 +80,7 @@ void initialize_websocket_module(ModuleInitializationLevel p_level) {
 }
 
 void uninitialize_websocket_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_CORE) {
 		return;
 	}
 #ifndef WEB_ENABLED

--- a/modules/websocket/remote_debugger_peer_websocket.cpp
+++ b/modules/websocket/remote_debugger_peer_websocket.cpp
@@ -33,12 +33,13 @@
 #include "core/config/project_settings.h"
 
 Error RemoteDebuggerPeerWebSocket::connect_to_host(const String &p_uri) {
+	ws_peer = Ref<WebSocketPeer>(WebSocketPeer::create());
+	ERR_FAIL_COND_V(ws_peer.is_null(), ERR_BUG);
+
 	Vector<String> protocols;
 	protocols.push_back("binary"); // Compatibility for emscripten TCP-to-WebSocket.
 
-	ws_peer = Ref<WebSocketPeer>(WebSocketPeer::create());
 	ws_peer->set_supported_protocols(protocols);
-
 	ws_peer->set_max_queued_packets(max_queued_messages);
 	ws_peer->set_inbound_buffer_size((1 << 23) - 1);
 	ws_peer->set_outbound_buffer_size((1 << 23) - 1);
@@ -81,6 +82,7 @@ void RemoteDebuggerPeerWebSocket::poll() {
 }
 
 int RemoteDebuggerPeerWebSocket::get_max_message_size() const {
+	ERR_FAIL_COND_V(ws_peer.is_null(), 0);
 	return ws_peer->get_max_packet_size();
 }
 

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -37,9 +37,6 @@
 #include "platform/web/display_server_web.h"
 
 #include "modules/modules_enabled.gen.h" // For websocket.
-#ifdef MODULE_WEBSOCKET_ENABLED
-#include "modules/websocket/remote_debugger_peer_websocket.h"
-#endif
 
 #include <dlfcn.h>
 #include <emscripten.h>
@@ -56,11 +53,6 @@ void OS_Web::alert(const String &p_alert, const String &p_title) {
 void OS_Web::initialize() {
 	OS_Unix::initialize_core();
 	DisplayServerWeb::register_web_driver();
-
-#ifdef MODULE_WEBSOCKET_ENABLED
-	EngineDebugger::register_uri_handler("ws://", RemoteDebuggerPeerWebSocket::create);
-	EngineDebugger::register_uri_handler("wss://", RemoteDebuggerPeerWebSocket::create);
-#endif
 }
 
 void OS_Web::resume_audio() {


### PR DESCRIPTION
In this PR:

- Fix Web write mode. (was incorrectly using text for binary and binary for text).
- Fix debugger implementation (now also registers itself without the need for the platform to do it),