### PR TITLE
Add JetBrains Fleet folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,7 @@ gmon.out
 
 # Jetbrains IDEs
 .idea/
+.fleet/
 
 # Kate
 *.kate-swp


### PR DESCRIPTION
I tried JetBrains Fleet now that it's in public preview. It doesn't use the `.idea/` folder like the other IDEs.