### PR TITLE
[3.x] Fix "<" on Arrays not working as intended

### DIFF
--- a/core/array.cpp
+++ b/core/array.cpp
@@ -116,6 +116,31 @@ bool Array::operator==(const Array &p_array) const {
 	return _p == p_array._p;
 }
 
+bool Array::operator!=(const Array &p_array) const {
+	return !operator==(p_array);
+}
+
+bool Array::operator<(const Array &p_array) const {
+	int a_len = size();
+	int b_len = p_array.size();
+
+	int min_cmp = MIN(a_len, b_len);
+
+	for (int i = 0; i < min_cmp; i++) {
+		if (operator[](i) < p_array[i]) {
+			return true;
+		} else if (p_array[i] < operator[](i)) {
+			return false;
+		}
+	}
+
+	return a_len < b_len;
+}
+
+bool Array::operator>(const Array &p_array) const {
+	return p_array < *this;
+}
+
 uint32_t Array::hash() const {
 	uint32_t h = hash_djb2_one_32(0);
 

--- a/core/array.h
+++ b/core/array.h
@@ -58,6 +58,7 @@ public:
 
 	bool deep_equal(const Array &p_array, int p_recursion_count = 0) const;
 	bool operator==(const Array &p_array) const;
+	bool operator!=(const Array &p_array) const;
 
 	uint32_t hash() const;
 	void operator=(const Array &p_array);
@@ -97,6 +98,9 @@ public:
 	Array duplicate(bool p_deep = false) const;
 
 	Array slice(int p_begin, int p_end, int p_step = 1, bool p_deep = false) const;
+
+	bool operator<(const Array &p_array) const;
+	bool operator>(const Array &p_array) const;
 
 	Variant min() const;
 	Variant max() const;

--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -457,24 +457,13 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 			}
 
 			CASE_TYPE(math, OP_EQUAL, ARRAY) {
-				if (p_b.type != ARRAY) {
-					if (p_b.type == NIL)
-						_RETURN(false);
+				if (p_b.type != ARRAY)
 					_RETURN_FAIL;
-				}
+
 				const Array *arr_a = reinterpret_cast<const Array *>(p_a._data._mem);
 				const Array *arr_b = reinterpret_cast<const Array *>(p_b._data._mem);
 
-				int l = arr_a->size();
-				if (arr_b->size() != l)
-					_RETURN(false);
-				for (int i = 0; i < l; i++) {
-					if (!((*arr_a)[i] == (*arr_b)[i])) {
-						_RETURN(false);
-					}
-				}
-
-				_RETURN(true);
+				_RETURN(*arr_a == *arr_b);
 			}
 
 			DEFAULT_OP_NUM_NULL(math, OP_EQUAL, INT, ==, _int);
@@ -546,26 +535,13 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 			}
 
 			CASE_TYPE(math, OP_NOT_EQUAL, ARRAY) {
-				if (p_b.type != ARRAY) {
-					if (p_b.type == NIL)
-						_RETURN(true);
-
+				if (p_b.type != ARRAY)
 					_RETURN_FAIL;
-				}
 
 				const Array *arr_a = reinterpret_cast<const Array *>(p_a._data._mem);
 				const Array *arr_b = reinterpret_cast<const Array *>(p_b._data._mem);
 
-				int l = arr_a->size();
-				if (arr_b->size() != l)
-					_RETURN(true);
-				for (int i = 0; i < l; i++) {
-					if (((*arr_a)[i] != (*arr_b)[i])) {
-						_RETURN(true);
-					}
-				}
-
-				_RETURN(false);
+				_RETURN(*arr_a != *arr_b);
 			}
 
 			DEFAULT_OP_NUM_NULL(math, OP_NOT_EQUAL, INT, !=, _int);
@@ -620,16 +596,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 				const Array *arr_a = reinterpret_cast<const Array *>(p_a._data._mem);
 				const Array *arr_b = reinterpret_cast<const Array *>(p_b._data._mem);
 
-				int l = arr_a->size();
-				if (arr_b->size() < l)
-					_RETURN(false);
-				for (int i = 0; i < l; i++) {
-					if (!((*arr_a)[i] < (*arr_b)[i])) {
-						_RETURN(true);
-					}
-				}
-
-				_RETURN(false);
+				_RETURN(*arr_a < *arr_b);
 			}
 
 			DEFAULT_OP_NUM(math, OP_LESS, INT, <, _int);
@@ -724,16 +691,7 @@ void Variant::evaluate(const Operator &p_op, const Variant &p_a,
 				const Array *arr_a = reinterpret_cast<const Array *>(p_a._data._mem);
 				const Array *arr_b = reinterpret_cast<const Array *>(p_b._data._mem);
 
-				int l = arr_a->size();
-				if (arr_b->size() > l)
-					_RETURN(false);
-				for (int i = 0; i < l; i++) {
-					if (((*arr_a)[i] < (*arr_b)[i])) {
-						_RETURN(false);
-					}
-				}
-
-				_RETURN(true);
+				_RETURN(*arr_a > *arr_b);
 			}
 
 			DEFAULT_OP_NUM(math, OP_GREATER, INT, >, _int);


### PR DESCRIPTION
Fixes #39299, #43395.

Turns out, in **3.x**, comparisons between two Arrays have never worked as they should've, due of a flaw in implementation for "**<**".

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/66727710/195662643-48dfd1ac-10b0-49ef-873f-568d26eb4b8c.png) | ![image](https://user-images.githubusercontent.com/66727710/195661308-33f3a0cd-8cbf-42ad-83bd-937bfa4079e0.png) |

This PR addresses this. It backports some code from **4.0**, the one introduced in https://github.com/godotengine/godot/pull/43323, cleaning everything up in the process, too.

~Do note that "**>=**" and "**<=**" cannot be backported, because "**==**" in Godot 3 compares by reference, so they wouldn't make much sense.~

Note: I honestly thought I needed to use the code in https://github.com/godotengine/godot/pull/44344 to fix this, but for some reason I can't fathom, there doesn't seem to be a need to.