### PR TITLE
Implement RETURN_VALUE_DISCARDED warning in GDscript

### DIFF
--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -63,7 +63,7 @@ class GDScriptAnalyzer {
 	void resolve_class_body(GDScriptParser::ClassNode *p_class);
 	void resolve_function_signature(GDScriptParser::FunctionNode *p_function);
 	void resolve_function_body(GDScriptParser::FunctionNode *p_function);
-	void resolve_node(GDScriptParser::Node *p_node);
+	void resolve_node(GDScriptParser::Node *p_node, bool p_is_root = true);
 	void resolve_suite(GDScriptParser::SuiteNode *p_suite);
 	void resolve_if(GDScriptParser::IfNode *p_if);
 	void resolve_for(GDScriptParser::ForNode *p_for);

--- a/modules/gdscript/tests/scripts/parser/features/class.gd
+++ b/modules/gdscript/tests/scripts/parser/features/class.gd
@@ -21,5 +21,5 @@ func test():
 	assert(test_sub.number == 25)  # From Test.
 	assert(test_sub.other_string == "bye")  # From TestSub.
 
-	TestConstructor.new()
-	TestConstructor.new(500)
+	var _test_constructor = TestConstructor.new()
+	_test_constructor = TestConstructor.new(500)

--- a/modules/gdscript/tests/scripts/parser/warnings/return_value_discarded.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/return_value_discarded.out
@@ -1,1 +1,5 @@
 GDTEST_OK
+>> WARNING
+>> Line: 6
+>> RETURN_VALUE_DISCARDED
+>> The function 'i_return_int()' returns a value, but this value is never used.


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/66100

RETURN_VALUE_DISCARDED wasn't implemented yet in master so no errors were printed when users called functions and ignored the return value
