### PR TITLE
Fix type testing with typed arrays

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2102,6 +2102,8 @@ void GDScriptAnalyzer::reduce_binary_op(GDScriptParser::BinaryOpNode *p_binary_o
 
 	if (p_binary_op->operation == GDScriptParser::BinaryOpNode::OP_TYPE_TEST && p_binary_op->right_operand && p_binary_op->right_operand->type == GDScriptParser::Node::IDENTIFIER) {
 		reduce_identifier(static_cast<GDScriptParser::IdentifierNode *>(p_binary_op->right_operand), true);
+	} else if (p_binary_op->operation == GDScriptParser::BinaryOpNode::OP_TYPE_TEST && p_binary_op->right_operand && p_binary_op->right_operand->type == GDScriptParser::Node::SUBSCRIPT) {
+		reduce_subscript(static_cast<GDScriptParser::SubscriptNode *>(p_binary_op->right_operand));
 	} else {
 		reduce_expression(p_binary_op->right_operand);
 	}
@@ -3300,7 +3302,11 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 		if (p_subscript->index == nullptr) {
 			return;
 		}
-		reduce_expression(p_subscript->index);
+		if (p_subscript->index->type == GDScriptParser::Node::IDENTIFIER) {
+			reduce_identifier(static_cast<GDScriptParser::IdentifierNode *>(p_subscript->index), true);
+		} else {
+			reduce_expression(p_subscript->index);
+		}
 
 		if (p_subscript->base->is_constant && p_subscript->index->is_constant) {
 			// Just try to get it.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fix #54312
My biggest PR yet so if you find any regression let me know
Small GDScript test:
```
	var a = [1.0,2.0,3.0,4.0]
	print(a is int)#false
	print(a is Array[float])#true
	var b = 1
	print(b is Array[int])#false
	
	var c = [Node3D.new(),Node3D.new()]
	print(c is Array[Node2D])#false
	print(c is Array[Node])#true
	
	var d = [1.0,2.0,3,4.0]
	print(d is Array[int])#false
	print(d is Array[float])#false
	print(d is Array)#true
	
	print([1.0,2.0,3.0,4.0] is Array[float])#true
	print([1.0,2,3.0,4.0] is Array[float])#false
```