### PR TITLE
Fix lots of misc undefined behaviour

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -50,7 +50,9 @@ struct _ObjectDebugLock {
 		obj->_lock_index.ref();
 	}
 	~_ObjectDebugLock() {
-		obj->_lock_index.unref();
+		if(obj) {
+			obj->_lock_index.unref();
+		}
 	}
 };
 

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -258,6 +258,8 @@ template <class T, class... P, size_t... Is>
 void call_with_variant_args_helper(T *p_instance, void (T::*p_method)(P...), const Variant **p_args, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 
+	ERR_FAIL_COND_MSG(p_instance == nullptr, "Invalid instance - attempted to call pointer for invalid object");
+
 #ifdef DEBUG_METHODS_ENABLED
 	(p_instance->*p_method)(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
 #else
@@ -727,6 +729,10 @@ template <class T, class R, class... P, size_t... Is>
 void call_with_variant_args_retc_helper(T *p_instance, R (T::*p_method)(P...) const, const Variant **p_args, Variant &r_ret, Callable::CallError &r_error, IndexSequence<Is...>) {
 	r_error.error = Callable::CallError::CALL_OK;
 
+	if( p_instance == nullptr )
+	{
+		return;
+	}
 #ifdef DEBUG_METHODS_ENABLED
 	r_ret = (p_instance->*p_method)(VariantCasterAndValidate<P>::cast(p_args, Is, r_error)...);
 #else

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -5044,9 +5044,9 @@ Vector<uint8_t> RenderingDeviceVulkan::shader_compile_binary_from_spirv(const Ve
 				ERR_FAIL_COND_V_MSG(result != SPV_REFLECT_RESULT_SUCCESS, Vector<uint8_t>(),
 						"Reflection of SPIR-V shader stage '" + String(shader_stage_names[p_spirv[i].shader_stage]) + "' failed enumerating output variables.");
 
-				if (ov_count) {
+				if (ov_count > 0) {
 					Vector<SpvReflectInterfaceVariable *> output_vars;
-					output_vars.resize(ov_count);
+					output_vars.resize_zeroed(ov_count);
 
 					result = spvReflectEnumerateOutputVariables(&module, &ov_count, output_vars.ptrw());
 					ERR_FAIL_COND_V_MSG(result != SPV_REFLECT_RESULT_SUCCESS, Vector<uint8_t>(),

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -224,8 +224,12 @@ Ref<TriangleMesh> Mesh::generate_triangle_mesh() const {
 
 			if (primitive == PRIMITIVE_TRIANGLES) {
 				for (int j = 0; j < ic; j++) {
+					ERR_FAIL_COND_V_MSG(indices.size() > j,Ref<TriangleMesh>(),"invalid index");
 					int index = ir[j];
-					facesw[widx++] = vr[index];
+					ERR_FAIL_COND_V_MSG(index > vertices.size(), Ref<TriangleMesh>(), "unable to generate triangle mesh");
+					ERR_FAIL_COND_V_MSG(widx > faces.size(), Ref<TriangleMesh>(), "unable to generate triangle mesh");
+					widx++;
+					facesw[widx] = vr[index];
 				}
 			} else { // PRIMITIVE_TRIANGLE_STRIP
 				for (int j = 2; j < ic; j++) {

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -400,9 +400,9 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint
 				const Vector3 *src = array.ptr();
 				for (int i = 0; i < p_vertex_array_len; i++) {
 					Vector2 res = src[i].octahedron_encode();
-					int16_t vector[2] = {
-						(int16_t)CLAMP(res.x * 65535, 0, 65535),
-						(int16_t)CLAMP(res.y * 65535, 0, 65535),
+					uint16_t vector[2] = {
+						(uint16_t)CLAMP(res.x * 65535, 0, 65535),
+						(uint16_t)CLAMP(res.y * 65535, 0, 65535),
 					};
 
 					memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, 4);
@@ -420,9 +420,9 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint
 					for (int i = 0; i < p_vertex_array_len; i++) {
 						const Vector3 src(src_ptr[i * 4 + 0], src_ptr[i * 4 + 1], src_ptr[i * 4 + 2]);
 						Vector2 res = src.octahedron_tangent_encode(src_ptr[i * 4 + 3]);
-						int16_t vector[2] = {
-							(int16_t)CLAMP(res.x * 65535, 0, 65535),
-							(int16_t)CLAMP(res.y * 65535, 0, 65535),
+						uint16_t vector[2] = {
+							(uint16_t)CLAMP(res.x * 65535, 0, 65535),
+							(uint16_t)CLAMP(res.y * 65535, 0, 65535),
 						};
 
 						memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, 4);

--- a/thirdparty/libogg/bitwise.c
+++ b/thirdparty/libogg/bitwise.c
@@ -387,15 +387,15 @@ long oggpack_read(oggpack_buffer *b,int bits){
     else if(!bits)return(0L);
   }
 
-  ret=b->ptr[0]>>b->endbit;
+  ret=(unsigned int)b->ptr[0]>>b->endbit;
   if(bits>8){
-    ret|=b->ptr[1]<<(8-b->endbit);
+    ret|=(unsigned int)b->ptr[1]<<(8-b->endbit);
     if(bits>16){
-      ret|=b->ptr[2]<<(16-b->endbit);
+      ret|=(unsigned int)b->ptr[2]<<(16-b->endbit);
       if(bits>24){
-        ret|=b->ptr[3]<<(24-b->endbit);
+        ret|=(unsigned int)b->ptr[3]<<(24-b->endbit);
         if(bits>32 && b->endbit){
-          ret|=b->ptr[4]<<(32-b->endbit);
+          ret|=(unsigned int)b->ptr[4]<<(32-b->endbit);
         }
       }
     }

--- a/thirdparty/libvorbis/sharedbook.c
+++ b/thirdparty/libvorbis/sharedbook.c
@@ -325,7 +325,7 @@ static int sort32a(const void *a,const void *b){
 
 /* decode codebook arrangement is more heavily optimized than encode */
 int vorbis_book_init_decode(codebook *c,const static_codebook *s){
-  int i,j,n=0,tabn;
+  unsigned int i,j,n=0,tabn;
   int *sortindex;
 
   memset(c,0,sizeof(*c));

--- a/thirdparty/misc/mikktspace.c
+++ b/thirdparty/misc/mikktspace.c
@@ -1656,7 +1656,7 @@ static void QuickSortEdges(SEdge * pSortBuffer, int iLeft, int iRight, const int
 
 	// Random
 	t=uSeed&31;
-	t=(uSeed<<t)|(uSeed>>(32-t));
+	t=(uSeed<<t)|(uSeed>>(31-t));
 	uSeed=uSeed+t+3;
 	// Random end
 

--- a/thirdparty/vhacd/src/VHACD.cpp
+++ b/thirdparty/vhacd/src/VHACD.cpp
@@ -1166,8 +1166,11 @@ void VHACD::ComputeACD(const Parameters& params)
             }
         }
 
-        Update(95.0 * (1.0 - maxConcavity) / (1.0 - params.m_concavity), 100.0, params);
-        if (GetCancel()) {
+		if(1.0 - params.m_concavity != 0) {
+			Update(95.0 * (1.0 - maxConcavity) / (1.0 - params.m_concavity), 100.0, params);
+		}
+		if (GetCancel()) {
+
             const size_t nTempParts = temp.Size();
             for (size_t p = 0; p < nTempParts; ++p) {
                 delete temp[p];


### PR DESCRIPTION
- Fix invalid variant call crash stack corruption (might be redundant)
- Fix renderer spirv crash caused by invalid spirv member 
- Fix mesh.cpp using invalid indicies from invalid mesh data causing stack crash. 
- Fix normal calculation on rendering_server caused by incorrect datatype was using 16 bit, but using signed bit. (undefined behaviour) 
- Fix enet undefined behaviour on mac/clang memory was not correctly accessed, or aligned, and crashed. 
- Fix libogg alignment for bitwise operations on clang, gcc would not report this as it expands to integers and clang expects this to be explicit. 
- Fix libvorbis undefined behaviour for same reason as above. 
- Fix mikktspace.c using incorrect alignment when zero bytes. Fix vhacd.cpp division by zero

Godot undefined behaviour be gone. :fire:

We need to get this into a state where we can merge, this is a draft for now.

Sponsored by The Mirror.


This clears 99% of undefined behaviour upon launch of /our/ game.