### PR TITLE
Focus EventListener when InputEventConfigurationDialog is opened.

### DIFF
--- a/editor/event_listener_line_edit.cpp
+++ b/editor/event_listener_line_edit.cpp
@@ -59,8 +59,9 @@ void EventListenerLineEdit::gui_input(const Ref<InputEvent> &p_event) {
 	// First event will be an event which is used to focus this control - i.e. a mouse click, or a tab press.
 	// Ignore the first one so that clicking into the LineEdit does not override the current event.
 	// Ignore is reset to true when the control is unfocused.
-	if (ignore) {
-		ignore = false;
+	// This class also specially handles grab_focus() calls.
+	if (ignore_next_event) {
+		ignore_next_event = false;
 		return;
 	}
 
@@ -85,7 +86,7 @@ void EventListenerLineEdit::_on_focus() {
 }
 
 void EventListenerLineEdit::_on_unfocus() {
-	ignore = true;
+	ignore_next_event = true;
 	set_placeholder(TTR("Filter by event..."));
 }
 
@@ -107,6 +108,12 @@ void EventListenerLineEdit::set_allowed_input_types(int input_types) {
 
 int EventListenerLineEdit::get_allowed_input_types() const {
 	return allowed_input_types;
+}
+
+void EventListenerLineEdit::grab_focus() {
+	// If we grab focus through code, we don't need to ignore the first event!
+	ignore_next_event = false;
+	Control::grab_focus();
 }
 
 void EventListenerLineEdit::_notification(int p_what) {

--- a/editor/event_listener_line_edit.h
+++ b/editor/event_listener_line_edit.h
@@ -44,7 +44,7 @@ class EventListenerLineEdit : public LineEdit {
 	GDCLASS(EventListenerLineEdit, LineEdit)
 
 	int allowed_input_types = INPUT_KEY | INPUT_MOUSE_BUTTON | INPUT_JOY_BUTTON | INPUT_JOY_MOTION;
-	bool ignore = true;
+	bool ignore_next_event = true;
 	bool share_keycodes = false;
 	Ref<InputEvent> event;
 
@@ -66,6 +66,8 @@ public:
 
 	void set_allowed_input_types(int input_types);
 	int get_allowed_input_types() const;
+
+	void grab_focus();
 
 public:
 	EventListenerLineEdit();

--- a/editor/input_event_configuration_dialog.cpp
+++ b/editor/input_event_configuration_dialog.cpp
@@ -533,6 +533,10 @@ String InputEventConfigurationDialog::_get_device_string(int p_device) const {
 
 void InputEventConfigurationDialog::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			event_listener->grab_focus();
+		} break;
+
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
 			input_list_search->set_right_icon(input_list_search->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));


### PR DESCRIPTION
Closes #67211

Can't just use `grab_focus` as it is, because of the way the EventListener needs to ignore the first input made to it, otherwise clicking into the line edit would override the event.

https://user-images.githubusercontent.com/41730826/195796120-73f9f1b1-c870-40d3-b828-951624435082.mp4