### PR TITLE
Rename `float=64` SCons option to `precision=double`

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -32,11 +32,11 @@ jobs:
             proj-conv: true
             artifact: true
 
-          - name: Editor with doubles and GCC sanitizers (target=editor, tests=yes, dev_build=yes, float=64, use_asan=yes, use_ubsan=yes, linker=gold)
+          - name: Editor with doubles and GCC sanitizers (target=editor, tests=yes, dev_build=yes, precision=double, use_asan=yes, use_ubsan=yes, linker=gold)
             cache-name: linux-editor-double-sanitizers
             target: editor
             tests: true
-            sconsflags: dev_build=yes float=64 use_asan=yes use_ubsan=yes linker=gold
+            sconsflags: dev_build=yes precision=double use_asan=yes use_ubsan=yes linker=gold
             proj-test: true
             # Can be turned off for PRs that intentionally break compat with godot-cpp,
             # until both the upstream PR and the matching godot-cpp changes are merged.

--- a/SConstruct
+++ b/SConstruct
@@ -179,7 +179,7 @@ opts.Add(BoolVariable("production", "Set defaults to build Godot for use in prod
 
 # Components
 opts.Add(BoolVariable("deprecated", "Enable compatibility code for deprecated and removed features", True))
-opts.Add(EnumVariable("float", "Floating-point precision", "32", ("32", "64")))
+opts.Add(EnumVariable("precision", "Set the floating-point precision level", "single", ("single", "double")))
 opts.Add(BoolVariable("minizip", "Enable ZIP archive support using minizip", True))
 opts.Add(BoolVariable("xaudio2", "Enable the XAudio2 audio driver", False))
 opts.Add(BoolVariable("vulkan", "Enable the vulkan rendering driver", True))
@@ -442,7 +442,7 @@ if env_base["no_editor_splash"]:
 if not env_base["deprecated"]:
     env_base.Append(CPPDEFINES=["DISABLE_DEPRECATED"])
 
-if env_base["float"] == "64":
+if env_base["precision"] == "double":
     env_base.Append(CPPDEFINES=["REAL_T_IS_DOUBLE"])
 
 if selected_platform in platform_list:
@@ -747,7 +747,7 @@ if selected_platform in platform_list:
     if env.dev_build:
         suffix += ".dev"
 
-    if env_base["float"] == "64":
+    if env_base["precision"] == "double":
         suffix += ".double"
 
     suffix += "." + env["arch"]

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		2-element structure that can be used to represent positions in 2D space or any other pair of numeric values.
-		It uses floating-point coordinates. By default, these floating-point values use 32-bit precision, unlike [float] which is always 64-bit. If double precision is needed, compile the engine with the option [code]float=64[/code].
+		It uses floating-point coordinates. By default, these floating-point values use 32-bit precision, unlike [float] which is always 64-bit. If double precision is needed, compile the engine with the option [code]precision=double[/code].
 		See [Vector2i] for its integer counterpart.
 		[b]Note:[/b] In a boolean context, a Vector2 will evaluate to [code]false[/code] if it's equal to [code]Vector2(0, 0)[/code]. Otherwise, a Vector2 will always evaluate to [code]true[/code].
 	</description>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		3-element structure that can be used to represent positions in 3D space or any other triplet of numeric values.
-		It uses floating-point coordinates. By default, these floating-point values use 32-bit precision, unlike [float] which is always 64-bit. If double precision is needed, compile the engine with the option [code]float=64[/code].
+		It uses floating-point coordinates. By default, these floating-point values use 32-bit precision, unlike [float] which is always 64-bit. If double precision is needed, compile the engine with the option [code]precision=double[/code].
 		See [Vector3i] for its integer counterpart.
 		[b]Note:[/b] In a boolean context, a Vector3 will evaluate to [code]false[/code] if it's equal to [code]Vector3(0, 0, 0)[/code]. Otherwise, a Vector3 will always evaluate to [code]true[/code].
 	</description>

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		4-element structure that can be used to represent any quadruplet of numeric values.
-		It uses floating-point coordinates. By default, these floating-point values use 32-bit precision, unlike [float] which is always 64-bit. If double precision is needed, compile the engine with the option [code]float=64[/code].
+		It uses floating-point coordinates. By default, these floating-point values use 32-bit precision, unlike [float] which is always 64-bit. If double precision is needed, compile the engine with the option [code]precision=double[/code].
 		See [Vector4i] for its integer counterpart.
 		[b]Note:[/b] In a boolean context, a Vector4 will evaluate to [code]false[/code] if it's equal to [code]Vector4(0, 0, 0, 0)[/code]. Otherwise, a Vector4 will always evaluate to [code]true[/code].
 	</description>

--- a/doc/classes/float.xml
+++ b/doc/classes/float.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		The [float] built-in type is a 64-bit double-precision floating-point number, equivalent to [code]double[/code] in C++. This type has 14 reliable decimal digits of precision. The [float] type can be stored in [Variant], which is the generic type used by the engine. The maximum value of [float] is approximately [code]1.79769e308[/code], and the minimum is approximately [code]-1.79769e308[/code].
-		Many methods and properties in the engine use 32-bit single-precision floating-point numbers instead, equivalent to [code]float[/code] in C++, which have 6 reliable decimal digits of precision. For data structures such as [Vector2] and [Vector3], Godot uses 32-bit floating-point numbers by default, but it can be changed to use 64-bit doubles if Godot is compiled with the [code]float=64[/code] option.
+		Many methods and properties in the engine use 32-bit single-precision floating-point numbers instead, equivalent to [code]float[/code] in C++, which have 6 reliable decimal digits of precision. For data structures such as [Vector2] and [Vector3], Godot uses 32-bit floating-point numbers by default, but it can be changed to use 64-bit doubles if Godot is compiled with the [code]precision=double[/code] option.
 		Math done using the [float] type is not guaranteed to be exact or deterministic, and will often result in small errors. You should usually use the [method @GlobalScope.is_equal_approx] and [method @GlobalScope.is_zero_approx] methods instead of [code]==[/code] to compare [float] values for equality.
 	</description>
 	<tutorials>

--- a/methods.py
+++ b/methods.py
@@ -774,7 +774,7 @@ def generate_vs_project(env, num_jobs):
                     for platform in ModuleConfigs.PLATFORMS
                 ]
                 self.arg_dict["runfile"] += [
-                    f'bin\\godot.windows.{config}{ModuleConfigs.DEV_SUFFIX}{".double" if env["float"] == "64" else ""}.{plat_id}{f".{name}" if name else ""}.exe'
+                    f'bin\\godot.windows.{config}{ModuleConfigs.DEV_SUFFIX}{".double" if env["precision"] == "double" else ""}.{plat_id}{f".{name}" if name else ""}.exe'
                     for config in ModuleConfigs.CONFIGURATIONS
                     for plat_id in ModuleConfigs.PLATFORM_IDS
                 ]
@@ -820,8 +820,8 @@ def generate_vs_project(env, num_jobs):
                 if env["custom_modules"]:
                     common_build_postfix.append("custom_modules=%s" % env["custom_modules"])
 
-                if env["float"] == "64":
-                    common_build_postfix.append("float=64")
+                if env["precision"] == "double":
+                    common_build_postfix.append("precision=double")
 
                 result = " ^& ".join(common_build_prefix + [" ".join([commands] + common_build_postfix)])
                 return result

--- a/modules/mono/README.md
+++ b/modules/mono/README.md
@@ -46,10 +46,10 @@ C# solutions during development to avoid mistakes.
 
 # Double Precision Support (REAL_T_IS_DOUBLE)
 
-Follow the above instructions but build Godot with the float=64 argument to scons
+Follow the above instructions but build Godot with the precision=double argument to scons
 
-When building the NuGet packages, specify `--float=64` - for example:
+When building the NuGet packages, specify `--precision=double` - for example:
 ```sh
 ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir ./bin \
-    --push-nupkgs-local ~/MyLocalNugetSource --float=64
+    --push-nupkgs-local ~/MyLocalNugetSource --precision=double
 ```


### PR DESCRIPTION
This avoids confusion with the old `bits=64` option and building for 64-bit CPUs in general.

See https://github.com/godotengine/godot/pull/66178#issuecomment-1263532707 and https://github.com/godotengine/godot/issues/67308.