### PR TITLE
Fix error in Web builds that resulting in 2D objects not drawing in the GLES3 backend

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -130,7 +130,10 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 		if (syncStatus == GL_UNSIGNALED) {
 			// If older than 2 frames, wait for sync OpenGL can have up to 3 frames in flight, any more and we need to sync anyway.
 			if (state.canvas_instance_data_buffers[state.current_buffer].last_frame_used < RSG::rasterizer->get_frame_number() - 2) {
+#ifndef WEB_ENABLED
+				// On web, we do nothing as the glSubBufferData will force a sync anyway and WebGL does not like waiting.
 				glClientWaitSync(state.canvas_instance_data_buffers[state.current_buffer].fence, 0, 100000000); // wait for up to 100ms
+#endif
 			} else {
 				// Used in last frame or frame before that. OpenGL can get up to two frames behind, so these buffers may still be in use
 				// Allocate a new buffer and use that.

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -211,7 +211,9 @@ void main() {
 #include "canvas_uniforms_inc.glsl"
 #include "stdlib_inc.glsl"
 
+#ifndef DISABLE_LIGHTING
 uniform sampler2D atlas_texture; //texunit:-2
+#endif // DISABLE_LIGHTING
 //uniform sampler2D shadow_atlas_texture; //texunit:-3
 uniform sampler2D screen_texture; //texunit:-4
 uniform sampler2D sdf_texture; //texunit:-5

--- a/drivers/gles3/shaders/canvas_uniforms_inc.glsl
+++ b/drivers/gles3/shaders/canvas_uniforms_inc.glsl
@@ -82,6 +82,7 @@ layout(std140) uniform CanvasData { //ubo:0
 	uint pad2;
 };
 
+#ifndef DISABLE_LIGHTING
 #define LIGHT_FLAGS_BLEND_MASK uint(3 << 16)
 #define LIGHT_FLAGS_BLEND_MODE_ADD uint(0 << 16)
 #define LIGHT_FLAGS_BLEND_MODE_SUB uint(1 << 16)
@@ -114,7 +115,7 @@ struct Light {
 layout(std140) uniform LightData { //ubo:2
 	Light light_array[MAX_LIGHTS];
 };
-
+#endif // DISABLE_LIGHTING
 layout(std140) uniform DrawDataInstances { //ubo:3
 
 	DrawData draw_data[MAX_DRAW_DATA_INSTANCES];


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/67392

The issue came from not binding a light UBO when using the DISABLE_LIGHTING code path

I also removed the glClientWaitSync call as it was resulting in an error as well.
