### PR TITLE
Fix drawing of 2D primitives in OpenGL3 renderer

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1010,7 +1010,7 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, const Tran
 				_add_to_batch(r_index, r_batch_broken);
 
 				if (primitive->point_count == 4) {
-					// Reset base data
+					// Reset base data.
 					_update_transform_2d_to_mat2x3(base_transform * draw_transform, state.instance_data_array[r_index].world);
 					state.instance_data_array[r_index].color_texture_pixel_size[0] = 0.0;
 					state.instance_data_array[r_index].color_texture_pixel_size[1] = 0.0;
@@ -1018,12 +1018,13 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, const Tran
 					state.instance_data_array[r_index].flags = base_flags | (state.instance_data_array[r_index - 1].flags & (FLAGS_DEFAULT_NORMAL_MAP_USED | FLAGS_DEFAULT_SPECULAR_MAP_USED)); //reset on each command for sanity, keep canvastexture binding config
 
 					for (uint32_t j = 0; j < 3; j++) {
-						//second half of triangle
-						state.instance_data_array[r_index].points[j * 2 + 0] = primitive->points[j + 1].x;
-						state.instance_data_array[r_index].points[j * 2 + 1] = primitive->points[j + 1].y;
-						state.instance_data_array[r_index].uvs[j * 2 + 0] = primitive->uvs[j + 1].x;
-						state.instance_data_array[r_index].uvs[j * 2 + 1] = primitive->uvs[j + 1].y;
-						Color col = primitive->colors[j + 1] * base_color;
+						int offset = j == 0 ? 0 : 1;
+						// Second triangle in the quad. Uses vertices 0, 2, 3.
+						state.instance_data_array[r_index].points[j * 2 + 0] = primitive->points[j + offset].x;
+						state.instance_data_array[r_index].points[j * 2 + 1] = primitive->points[j + offset].y;
+						state.instance_data_array[r_index].uvs[j * 2 + 0] = primitive->uvs[j + offset].x;
+						state.instance_data_array[r_index].uvs[j * 2 + 1] = primitive->uvs[j + offset].y;
+						Color col = primitive->colors[j + offset] * base_color;
 						state.instance_data_array[r_index].colors[j * 2 + 0] = (uint32_t(Math::make_half_float(col.g)) << 16) | Math::make_half_float(col.r);
 						state.instance_data_array[r_index].colors[j * 2 + 1] = (uint32_t(Math::make_half_float(col.a)) << 16) | Math::make_half_float(col.b);
 					}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/67412

Previously the wrong vertices were used when assembling the second triangle of a quad.

In the RD renderer the logic looks a bit different. It loops over only j=1 to j=2. It doesn't need to run j=0 because it is writing over the same array used by the first vertex. In GLES3, since we batch draw calls, the data for all 6 vertices needs to be copied over. 