### PR TITLE
Fix `CanvasItem` draw_primitive vertex order incorrect for quads

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1017,13 +1017,23 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, const Tran
 
 					state.instance_data_array[r_index].flags = base_flags | (state.instance_data_array[r_index - 1].flags & (FLAGS_DEFAULT_NORMAL_MAP_USED | FLAGS_DEFAULT_SPECULAR_MAP_USED)); //reset on each command for sanity, keep canvastexture binding config
 
-					for (uint32_t j = 0; j < 3; j++) {
+
+					// re-use first vertex of primitive for second half
+					state.instance_data_array[r_index].points[0] = primitive->points[0].x;
+					state.instance_data_array[r_index].points[1] = primitive->points[0].y;
+					state.instance_data_array[r_index].uvs[0] = primitive->uvs[0].x;
+					state.instance_data_array[r_index].uvs[1] = primitive->uvs[0].y;
+					Color col = primitive->colors[0] * base_color;
+					state.instance_data_array[r_index].colors[0] = (uint32_t(Math::make_half_float(col.g)) << 16) | Math::make_half_float(col.r);
+					state.instance_data_array[r_index].colors[1] = (uint32_t(Math::make_half_float(col.a)) << 16) | Math::make_half_float(col.b);
+
+					for (uint32_t j = 1; j < 3; j++) {
 						//second half of triangle
 						state.instance_data_array[r_index].points[j * 2 + 0] = primitive->points[j + 1].x;
 						state.instance_data_array[r_index].points[j * 2 + 1] = primitive->points[j + 1].y;
 						state.instance_data_array[r_index].uvs[j * 2 + 0] = primitive->uvs[j + 1].x;
 						state.instance_data_array[r_index].uvs[j * 2 + 1] = primitive->uvs[j + 1].y;
-						Color col = primitive->colors[j + 1] * base_color;
+						col = primitive->colors[j + 1] * base_color;
 						state.instance_data_array[r_index].colors[j * 2 + 0] = (uint32_t(Math::make_half_float(col.g)) << 16) | Math::make_half_float(col.r);
 						state.instance_data_array[r_index].colors[j * 2 + 1] = (uint32_t(Math::make_half_float(col.a)) << 16) | Math::make_half_float(col.b);
 					}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes https://github.com/godotengine/godot/issues/67412

The root cause of this issue was how the batches were being constructed for CommandPrimitive in the GLES3 renderer.

When comparing the code used by the Vulkan/forward+ renderer, 
https://github.com/godotengine/godot/blob/39534a7aecc4ca4215af67244b23dda09ea339f8/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp#L725-L727

The Vulkan renderer re-uses the point data in `push_constant` and loops across the last two vertices of the primitive so that the first, third, and fourth vertices are used to construct the second triangle half.

The GLES3 renderer is similar except the loop starts at zero and iterates across the 2nd, 3rd, and 4th vertices (resulting in the bad second half). 

To fix this, I adjusted the loop to iterate across the 3rd and 4th to match the Vulkan code, and manually set up the first vertex. Because the call to `_add_to_batch` increments r_index, I can't re-use `instance_data_array` to get the first vertex for free. I think this could be replaced with a line like
```c++
state.instance_data_array[r_index] = state.instance_data_array[r_index-1]
```
but `_add_to_batch` is capable of returning without incrementing `r_index`, so I don't know if doing that is safe in all cases. 

