### PR TITLE
Fix Godot exiting with unexpected failure code

### DIFF
--- a/platform/linuxbsd/godot_linuxbsd.cpp
+++ b/platform/linuxbsd/godot_linuxbsd.cpp
@@ -69,6 +69,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	if (Main::start()) {
+		os.set_exit_code(EXIT_SUCCESS);
 		os.run(); // it is actually the OS that decides how to run
 	}
 	Main::cleanup();


### PR DESCRIPTION
The exit code is initialized as `EXIT_FAILURE` to indicate failures during startup. Closing the Game window via the window manager does not change the exit code, so the program exits with `EXIT_FAILURE`.

This PR sets the exit code to `EXIT_SUCCESS` when initialization was successful just before starting the main loop.

resolve #62898