### PR TITLE
Make texture preview filter setting content aware

### DIFF
--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -958,6 +958,7 @@ EditorResourcePicker::EditorResourcePicker(bool p_hide_assign_button_controls) {
 		preview_rect->set_offset(SIDE_TOP, 1);
 		preview_rect->set_offset(SIDE_BOTTOM, -1);
 		preview_rect->set_offset(SIDE_RIGHT, -1);
+		preview_rect->set_texture_filter(TEXTURE_FILTER_NEAREST_WITH_MIPMAPS);
 		assign_button->add_child(preview_rect);
 	}
 

--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -29,7 +29,6 @@
 /*************************************************************************/
 
 #include "texture_editor_plugin.h"
-
 #include "editor/editor_scale.h"
 
 TextureRect *TexturePreview::get_texture_display() {
@@ -123,6 +122,7 @@ TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
 	add_child(checkerboard);
 
 	texture_display = memnew(TextureRect);
+	texture_display->set_texture_filter(TEXTURE_FILTER_NEAREST_WITH_MIPMAPS);
 	texture_display->set_texture(p_texture);
 	texture_display->set_anchors_preset(TextureRect::PRESET_FULL_RECT);
 	texture_display->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes https://github.com/godotengine/godot/issues/60150

This PR implements content aware filtering of the texture preview based on Calinou's suggestion [here](https://github.com/godotengine/godot/issues/60150#issuecomment-1095473546). I really like the idea since it's pragmatic and easy to implement.

This implementation works by comparing the size of the texture being displayed to the size of the preview. When the scale factor exceeds 4.0, nearest filtering is used. Otherwise, linear filtering is used. This way, pixel art (where the ratio is high) is crisp and high resolution art (where the ratio is low) is not jagged or harsh. In my testing using the minimum between the width ratio and height ratio behaved nicely. Without it, it was possible to take pixel art and make it blurry simply by expanding the inspector too far.

I did my best to test across a handful of different resolutions and image scales but my native resolution is high. 4.0 is a pretty good threshold but may need tweaking. It is possible to end up with images whose resolution is right on the borderline between the two modes (e.g. large spritesheets). I'm not sure if there's a silver bullet way to handle them any differently from smaller high-rez assets. As a catch-all backup, I added an editor setting to Editor > Inspector, "Texture Preview Filter Mode" which allows the user to use the detection algorithm or to always use one of the two. Maybe the wording could be adjusted since it could be misleading
![image](https://user-images.githubusercontent.com/1747505/195966333-7f9b18e1-64ba-4234-9741-8c90bb733d78.png)



