### PR TITLE
Fix case where mutex is never unlocked

### DIFF
--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -66,7 +66,9 @@ void TilesEditorPlugin::_thread() {
 		pattern_preview_sem.wait();
 
 		pattern_preview_mutex.lock();
-		if (pattern_preview_queue.size()) {
+		if (pattern_preview_queue.size() == 0) {
+			pattern_preview_mutex.unlock();
+		} else {
 			QueueItem item = pattern_preview_queue.front()->get();
 			pattern_preview_queue.pop_front();
 			pattern_preview_mutex.unlock();
@@ -130,8 +132,6 @@ void TilesEditorPlugin::_thread() {
 				item.callback.callp(args_ptr, 2, r, error);
 
 				viewport->queue_delete();
-			} else {
-				pattern_preview_mutex.unlock();
 			}
 		}
 	}


### PR DESCRIPTION
`pattern_preview_mutex` guards `pattern_preview_queue`, but due to how the code was written, it could remain locked even after the thread exits.

I found this while compiling Godot on Windows with `/MTd`, which enables standard library debug checks and uses the debug runtime library. However by default Godot always uses `/MT`, so errors like this easily fly under the radar. (more info here  https://github.com/godotengine/godot/issues/31608)