### PR TITLE
add ability to pick random value from array

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -38,6 +38,7 @@
 #include "core/templates/vector.h"
 #include "core/variant/callable.h"
 #include "core/variant/variant.h"
+#include "core/math/math_funcs.h"
 
 class ArrayPrivate {
 public:
@@ -297,6 +298,11 @@ Variant Array::front() const {
 Variant Array::back() const {
 	ERR_FAIL_COND_V_MSG(_p->array.size() == 0, Variant(), "Can't take value from empty array.");
 	return operator[](_p->array.size() - 1);
+}
+
+Variant Array::pick_random() const {
+	ERR_FAIL_COND_V_MSG(_p->array.size() == 0, Variant(), "Can't take value from empty array.");
+	return operator[](Math::rand() % _p->array.size());
 }
 
 int Array::find(const Variant &p_value, int p_from) const {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -79,6 +79,7 @@ public:
 
 	Variant front() const;
 	Variant back() const;
+	Variant pick_random() const;
 
 	void sort();
 	void sort_custom(const Callable &p_callable);

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2053,6 +2053,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Array, erase, sarray("value"), varray());
 	bind_method(Array, front, sarray(), varray());
 	bind_method(Array, back, sarray(), varray());
+	bind_method(Array, pick_random, sarray(), varray());
 	bind_method(Array, find, sarray("what", "from"), varray(0));
 	bind_method(Array, rfind, sarray("what", "from"), varray(-1));
 	bind_method(Array, find_last, sarray("value"), varray());

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -205,6 +205,16 @@
 				[b]Note:[/b] Calling this function is not the same as writing [code]array[-1][/code]. If the array is empty, accessing by index will pause project execution when running from the editor.
 			</description>
 		</method>
+		<method name="pick_random" qualifiers="const">
+			<return type="Variant" />
+			<description>
+				Returns a random value from the target array.
+				[codeblock]
+				var array: Array[int] = [1, 2, 3, 4]
+				print(array.pick_random())  # Prints either of the four numbers.
+				[/codeblock]
+			</description>
+		</method>
 		<method name="bsearch">
 			<return type="int" />
 			<param index="0" name="value" type="Variant" />


### PR DESCRIPTION
Returns a random value from the target array.
```
var array: Array[int] = [1, 2, 3, 4]
print(array.pick_random())  # Prints either of the four numbers.
```	

Implements: https://github.com/godotengine/godot-proposals/issues/3454


IMPORTANT:
First merge https://github.com/godotengine/godot/pull/54940 before this one, to avoid https://github.com/godotengine/godot/issues/54939

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

supersedes 
