### PR TITLE
Add ability to pick random value from array

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -31,6 +31,7 @@
 #include "array.h"
 
 #include "container_type_validate.h"
+#include "core/math/math_funcs.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "core/templates/hashfuncs.h"
@@ -297,6 +298,11 @@ Variant Array::front() const {
 Variant Array::back() const {
 	ERR_FAIL_COND_V_MSG(_p->array.size() == 0, Variant(), "Can't take value from empty array.");
 	return operator[](_p->array.size() - 1);
+}
+
+Variant Array::pick_random() const {
+	ERR_FAIL_COND_V_MSG(_p->array.size() == 0, Variant(), "Can't take value from empty array.");
+	return operator[](Math::rand() % _p->array.size());
 }
 
 int Array::find(const Variant &p_value, int p_from) const {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -79,6 +79,7 @@ public:
 
 	Variant front() const;
 	Variant back() const;
+	Variant pick_random() const;
 
 	void sort();
 	void sort_custom(const Callable &p_callable);

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2053,6 +2053,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Array, erase, sarray("value"), varray());
 	bind_method(Array, front, sarray(), varray());
 	bind_method(Array, back, sarray(), varray());
+	bind_method(Array, pick_random, sarray(), varray());
 	bind_method(Array, find, sarray("what", "from"), varray(0));
 	bind_method(Array, rfind, sarray("what", "from"), varray(-1));
 	bind_method(Array, find_last, sarray("value"), varray());

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -429,6 +429,16 @@
 				Returns the minimum value contained in the array if all elements are of comparable types. If the elements can't be compared, [code]null[/code] is returned.
 			</description>
 		</method>
+		<method name="pick_random" qualifiers="const">
+			<return type="Variant" />
+			<description>
+				Returns a random value from the target array.
+				[codeblock]
+				var array: Array[int] = [1, 2, 3, 4]
+				print(array.pick_random())  # Prints either of the four numbers.
+				[/codeblock]
+			</description>
+		</method>
 		<method name="pop_at">
 			<return type="Variant" />
 			<param index="0" name="position" type="int" />


### PR DESCRIPTION
Returns a random value from the target array.
```
var array: Array[int] = [1, 2, 3, 4]
print(array.pick_random())  # Prints either of the four numbers.
```	

Implements: https://github.com/godotengine/godot-proposals/issues/3454
