### PR TITLE
Expose Viewport::get_screen_transform to GDScript

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -71,6 +71,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_screen_transform" qualifiers="const">
+			<return type="Transform2D" />
+			<description>
+				Returns the transform from the Viewport's coordinates to the screen coordinates of the containing window manager window.
+			</description>
+		</method>
 		<method name="get_texture" qualifiers="const">
 			<return type="ViewportTexture" />
 			<description>

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3729,6 +3729,7 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_global_canvas_transform", "xform"), &Viewport::set_global_canvas_transform);
 	ClassDB::bind_method(D_METHOD("get_global_canvas_transform"), &Viewport::get_global_canvas_transform);
 	ClassDB::bind_method(D_METHOD("get_final_transform"), &Viewport::get_final_transform);
+	ClassDB::bind_method(D_METHOD("get_screen_transform"), &Viewport::get_screen_transform);
 
 	ClassDB::bind_method(D_METHOD("get_visible_rect"), &Viewport::get_visible_rect);
 	ClassDB::bind_method(D_METHOD("set_transparent_background", "enable"), &Viewport::set_transparent_background);


### PR DESCRIPTION
While working on the ["Feeding Custom Input Events" section of the 2D Transforms tutorial](https://docs.godotengine.org/en/latest/tutorials/2d/2d_transforms.html#feeding-custom-input-events) I noticed, that there is currently no globally reliable method for feeding custom input events, that contain a position, from GDScript when embedded windows / subviewports are used.

This PR exposes `Viewport::get_screen_transform` which enables the transformation of local coordinates to the form, that `Input.parse_input_event()` requires.