### PR TITLE
Emphasize the importance of uploading a minimal reproduction project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -52,5 +52,8 @@ body:
   attributes:
     label: Minimal reproduction project
     description: |
-      A small Godot project which reproduces the issue. Highly recommended to speed up troubleshooting.
-      Drag and drop a ZIP archive to upload it. Be sure to not include the ".godot" folder in the archive.
+      A small Godot project which reproduces the issue, with no unnecessary files included. Be sure to not include the `.godot` folder in the archive (but keep `project.godot`).
+      Required, unless the reproduction steps are trivial and don't require any project files to be followed. In this case, write "N/A" in the field.
+      Drag and drop a ZIP archive to upload it. **Do not select another field until the project is done uploading.**
+  validations:
+    required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,8 @@ understand that:
 - What happens to you may not happen to other users.
 - We can't take the time to look at your project, understand how it is set up
   and then figure out why it's failing.
+- On the contributors' end, recreating a test project from scratch takes valuable
+  time that can be saved by uploading a *minimal* project.
 
 To speed up our work, **please upload a minimal project** that isolates
 and reproduces the issue. This is always the **best way for us to fix it**.
@@ -74,7 +76,7 @@ if your ZIP file isn't accepted by GitHub because it's too large.
 We recommend always attaching a minimal reproduction project, even if the issue
 may seem simple to reproduce manually.
 
-**Note for C# users:** If your issue is not .NET-specific, please upload a
+**Note for C# users:** If your issue is *not* .NET-specific, please upload a
 minimal reproduction project written in GDScript.
 This will make it easier for contributors to reproduce the issue
 locally as not everyone has a .NET setup available.


### PR DESCRIPTION
The field is now required, but "N/A" can be manually entered if the reproduction steps are trivial and don't require any project files to be followed.