### PR TITLE
Scene tab closing refactor

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -546,7 +546,7 @@
 			If [code]true[/code], the mouse's additional side buttons will be usable to navigate in the script editor's file history. Set this to [code]false[/code] if you're using the side buttons for other purposes (such as a push-to-talk button in a VoIP program).
 		</member>
 		<member name="interface/editor/save_each_scene_on_quit" type="bool" setter="" getter="">
-			If [code]true[/code], the editor will save all scenes when confirming the [b]Save[/b] action when quitting the editor or quitting to the project list. If [code]false[/code], the editor will ask to save each scene individually.
+			If [code]false[/code], the editor will save all scenes when confirming the [b]Save[/b] action when quitting the editor or quitting to the project list. If [code]true[/code], the editor will ask to save each scene individually.
 		</member>
 		<member name="interface/editor/separate_distraction_mode" type="bool" setter="" getter="">
 			If [code]true[/code], the editor's Script tab will have a separate distraction mode setting from the 2D/3D/AssetLib tabs. If [code]false[/code], the distraction-free mode toggle is shared between all tabs.

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -177,9 +177,6 @@ private:
 		FILE_CLOSE_OTHERS,
 		FILE_CLOSE_RIGHT,
 		FILE_CLOSE_ALL,
-		FILE_CLOSE_ALL_AND_QUIT,
-		FILE_CLOSE_ALL_AND_RUN_PROJECT_MANAGER,
-		FILE_CLOSE_ALL_AND_RELOAD_CURRENT_PROJECT,
 		FILE_QUIT,
 		FILE_EXTERNAL_OPEN_SCENE,
 		EDIT_UNDO,
@@ -329,7 +326,10 @@ private:
 	PopupMenu *scene_tabs_context_menu = nullptr;
 	Panel *tab_preview_panel = nullptr;
 	TextureRect *tab_preview = nullptr;
+
 	int tab_closing_idx = 0;
+	List<String> tabs_to_close;
+	int tab_closing_menu_option = -1;
 
 	bool exiting = false;
 	bool dimmed = false;
@@ -652,7 +652,9 @@ private:
 	void _dock_floating_close_request(Control *p_control);
 	void _dock_make_float();
 	void _scene_tab_changed(int p_tab);
-	void _scene_tab_closed(int p_tab, int option = SCENE_TAB_CLOSE);
+	void _proceed_closing_scene_tabs();
+	bool _is_closing_editor() const;
+	void _scene_tab_closed(int p_tab, int p_option = SCENE_TAB_CLOSE);
 	void _scene_tab_hovered(int p_tab);
 	void _scene_tab_exit();
 	void _scene_tab_input(const Ref<InputEvent> &p_input);


### PR DESCRIPTION
Closes #40539
I went a bit further actually and refactored how editor closing works. The refactoring went so far that I'm surprised it all still works 🤪
Needs testing though.

Summary of changes:
- added `_proceed_closing_scene_tabs()` method and `tabs_to_close` list
  - the idea is that you put tab paths into `tabs_to_close` and then call `_proceed_closing_scene_tabs()`
  - `_proceed_closing_scene_tabs()` will keep getting called until the list is cleared
- `FILE_CLOSE_ALL_AND_QUIT`, `FILE_CLOSE_ALL_AND_RUN_PROJECT_MANAGER` and `FILE_CLOSE_ALL_AND_RELOAD_CURRENT_PROJECT` are gone ~~reduced to atoms~~
  - editor exit is now simply CLOSE_ALL + the new `tab_closing_menu_option` variable
- removed the -2 hack (https://github.com/godotengine/godot/pull/65504/files#r965571959)
- when exiting the editor, the scene tabs are no longer closed
  - this allowed to remove the hack where a scene was reopened after discarding for the purpose of `restore_scenes_on_load`, which makes closing the editor faster under specific circumstances

This should make the code much cleaner, but there is still room for improvements. I opened this PR because I might be needing it for another thing I have planned.