### PR TITLE
Fix get_path() error when calling get_node()

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1341,12 +1341,23 @@ Node *Node::get_node(const NodePath &p_path) const {
 	Node *node = get_node_or_null(p_path);
 
 	if (unlikely(!node)) {
+		// Try to get a clear description of this node in the error message.
+		String desc;
+		if (is_inside_tree()) {
+			desc = get_path();
+		} else {
+			desc = get_name();
+			if (desc.is_empty()) {
+				desc = get_class();
+			}
+		}
+
 		if (p_path.is_absolute()) {
 			ERR_FAIL_V_MSG(nullptr,
-					vformat(R"(Node not found: "%s" (absolute path attempted from "%s").)", p_path, get_path()));
+					vformat(R"(Node not found: "%s" (absolute path attempted from "%s").)", p_path, desc));
 		} else {
 			ERR_FAIL_V_MSG(nullptr,
-					vformat(R"(Node not found: "%s" (relative to "%s").)", p_path, get_path()));
+					vformat(R"(Node not found: "%s" (relative to "%s").)", p_path, desc));
 		}
 	}
 


### PR DESCRIPTION
When failed, `get_node()` shows the absolute path of current node by calling `get_path()`. But `get_path()` requires the node to be inside the tree. So calling `get_node("Not Exists")` on a outside-tree node produces error messages like this:

> ERROR: Cannot get path of node as it is not in a scene tree.
>    at: get_path (scene/main/node.cpp:1704)
> ERROR: Node not found: "Not Exists" (relative to "").
>    at: get_node (scene/main/node.cpp:1348)

This PR fixes the extra error message issue and avoids an empty description of the node (`relative to ""`).