### PR TITLE
Clarified reason why a resource cannot be preload()'ed

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3226,7 +3226,13 @@ void GDScriptAnalyzer::reduce_preload(GDScriptParser::PreloadNode *p_preload) {
 		}
 		p_preload->resolved_path = p_preload->resolved_path.simplify_path();
 		if (!ResourceLoader::exists(p_preload->resolved_path)) {
-			push_error(vformat(R"(Preload file "%s" does not exist.)", p_preload->resolved_path), p_preload->path);
+			Ref<FileAccess> file_check = FileAccess::create(FileAccess::ACCESS_RESOURCES);
+
+			if (file_check->file_exists(p_preload->resolved_path)) {
+				push_error(vformat(R"(Preload file "%s" has no resource loaders (unrecognized file extension).)", p_preload->resolved_path), p_preload->path);
+			} else {
+				push_error(vformat(R"(Preload file "%s" does not exist.)", p_preload->resolved_path), p_preload->path);
+			}
 		} else {
 			// TODO: Don't load if validating: use completion cache.
 			p_preload->resource = ResourceLoader::load(p_preload->resolved_path);


### PR DESCRIPTION
_**Issue**_

When attempting to preload a resource file that Godot does not recognize, the error message is that the file does not exist, even if the file does exist.

![Untitled](https://user-images.githubusercontent.com/1133892/196016545-bd248701-f614-41a4-a1ab-40b33f803a50.png)

This might lead tiny innocent poor Godot contributor-wannabes on many hours of bug hunting thinking there is a significant issue with their other PR (#67314), when in fact there is simply no resource loader for .txt files ;)

_**To replicate**_

Create new Godot project. Create an empty text file. Create a new script and attempt to preload the text file. You will get the error message above.

_**Proposed fix in this PR**_

To simply change the error message to warn users that the reason they are not able to preload a resource might also be because there is no resource loader capable of handling that file extension. If custom resource loaders are at play, this should help Godot users pinpoint the source of the issue more rapidly (an incorrectly installed/configured resource loader, rather than an issue with the file system).

A better fix would be possible if ResourceLoader::exists() returned an int/enum instead of a boolean. This would make it possible to indicate exactly what type of error had occurred: 1) file not found or 2) extension not supported.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
