### PR TITLE
Fix peer visiblity in SceneReplicationInterface._update_sync_visibility

### DIFF
--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -261,11 +261,11 @@ Error SceneReplicationInterface::_update_sync_visibility(int p_peer, Multiplayer
 	if (p_peer == 0) {
 		for (KeyValue<int, PeerInfo> &E : peers_info) {
 			// Might be visible to this specific peer.
-			is_visible = is_visible || p_sync->is_visible_to(E.key);
-			if (is_visible == E.value.sync_nodes.has(sid)) {
+			bool is_visible_to_peer = is_visible || p_sync->is_visible_to(E.key);
+			if (is_visible_to_peer == E.value.sync_nodes.has(sid)) {
 				continue;
 			}
-			if (is_visible) {
+			if (is_visible_to_peer) {
 				E.value.sync_nodes.insert(sid);
 			} else {
 				E.value.sync_nodes.erase(sid);


### PR DESCRIPTION
If there are 2 or more peers and the synchronizer is visible to the first peer, then the second peer won't be check. Because the local variable `is_visible` has changed by first peer.