### PR TITLE
Fix TextEdit action and CodeEdit completion crash

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2859,7 +2859,9 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 				offset = line_height;
 			}
 
-			max_width = MAX(max_width, font->get_string_size(option.display, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).width + offset);
+			if (font.is_valid()) {
+				max_width = MAX(max_width, font->get_string_size(option.display, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).width + offset);
+			}
 			code_completion_options.push_back(option);
 		}
 
@@ -2970,7 +2972,9 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 
 		if (string_to_complete.length() == 0) {
 			code_completion_options.push_back(option);
-			max_width = MAX(max_width, font->get_string_size(option.display, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).width + offset);
+			if (font.is_valid()) {
+				max_width = MAX(max_width, font->get_string_size(option.display, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).width + offset);
+			}
 			continue;
 		}
 
@@ -3076,7 +3080,9 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 				option.matches.append_array(ssq_matches);
 				completion_options_subseq.push_back(option);
 			}
-			max_width = MAX(max_width, font->get_string_size(option.display, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).width + offset);
+			if (font.is_valid()) {
+				max_width = MAX(max_width, font->get_string_size(option.display, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).width + offset);
+			}
 		} else if (!*ssq_lower) { // Matched the whole subsequence in s_lower.
 			option.matches.clear();
 
@@ -3093,7 +3099,9 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 				option.matches.append_array(ssq_lower_matches);
 				completion_options_subseq_casei.push_back(option);
 			}
-			max_width = MAX(max_width, font->get_string_size(option.display, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).width + offset);
+			if (font.is_valid()) {
+				max_width = MAX(max_width, font->get_string_size(option.display, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).width + offset);
+			}
 		}
 	}
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3810,6 +3810,9 @@ void TextEdit::undo() {
 		return;
 	}
 
+	if (in_action) {
+		pending_action_end = true;
+	}
 	_push_current_op();
 
 	if (undo_stack_pos == nullptr) {
@@ -3871,6 +3874,9 @@ void TextEdit::redo() {
 		return;
 	}
 
+	if (in_action) {
+		pending_action_end = true;
+	}
 	_push_current_op();
 
 	if (undo_stack_pos == nullptr) {


### PR DESCRIPTION
`TextEdit` will now forcibly end current action on undo redo. Otherwise due to the complex op not completing, the caret(s) can be placed in an invalid position.

Fixed `CodeEdit` completion trying in access an invalid font.

closes #67364
closes #62199