### PR TITLE
Add `_get_unsaved_status()` method to EditorPlugin and implement it for script and shader editors

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -280,6 +280,22 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="_get_unsaved_status" qualifiers="virtual const">
+			<return type="String" />
+			<description>
+				Override this method to provide a custom message that lists unsaved changes. The editor will call this method on exit and display it in a confirmation dialog. Return empty string if the plugin has no unsaved changes.
+				If the user confirms saving, [method _save_external_data] will be called, before closing the editor.
+				[codeblock]
+				func _get_unsaved_status():
+				    if unsaved:
+				        return "Save changes in MyCustomPlugin before closing?"
+				    return ""
+				
+				func _save_external_data():
+				    unsaved = false
+				[/codeblock]
+			</description>
+		</method>
 		<method name="_get_window_layout" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="configuration" type="ConfigFile" />

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -282,17 +282,29 @@
 		</method>
 		<method name="_get_unsaved_status" qualifiers="virtual const">
 			<return type="String" />
+			<param index="0" name="for_scene" type="String" />
 			<description>
-				Override this method to provide a custom message that lists unsaved changes. The editor will call this method on exit and display it in a confirmation dialog. Return empty string if the plugin has no unsaved changes.
+				Override this method to provide a custom message that lists unsaved changes. The editor will call this method when exiting or when closing a scene, and display the returned string in a confirmation dialog. Return empty string if the plugin has no unsaved changes.
+				When closing a scene, [param for_scene] is the path to the scene being closed. You can use it to handle built-in resources in that scene.
 				If the user confirms saving, [method _save_external_data] will be called, before closing the editor.
 				[codeblock]
-				func _get_unsaved_status():
-				    if unsaved:
+				func _get_unsaved_status(for_scene):
+				    if not unsaved:
+				        return ""
+
+				    if for_scene.is_empty():
 				        return "Save changes in MyCustomPlugin before closing?"
-				    return ""
-				
+				    else:
+				        return "Scene %s has changes from MyCustomPlugin. Save before closing?" % for_scene.get_file()
+
 				func _save_external_data():
 				    unsaved = false
+				[/codeblock]
+				If the plugin has no scene-specific changes, you can ignore the calls when closing scenes:
+				[codeblock]
+				func _get_unsaved_status(for_scene):
+				    if not for_scene.is_empty():
+				        return ""
 				[/codeblock]
 			</description>
 		</method>

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -382,6 +382,7 @@ private:
 	AcceptDialog *save_accept = nullptr;
 	EditorAbout *about = nullptr;
 	AcceptDialog *warning = nullptr;
+	EditorPlugin *plugin_to_save = nullptr;
 
 	int overridden_default_layout = -1;
 	Ref<ConfigFile> default_layout;

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -341,9 +341,9 @@ void EditorPlugin::clear() {
 	GDVIRTUAL_CALL(_clear);
 }
 
-String EditorPlugin::get_unsaved_status() const {
+String EditorPlugin::get_unsaved_status(const String &p_for_scene) const {
 	String ret;
-	GDVIRTUAL_CALL(_get_unsaved_status, ret);
+	GDVIRTUAL_CALL(_get_unsaved_status, p_for_scene, ret);
 	return ret;
 }
 
@@ -599,7 +599,7 @@ void EditorPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_get_state);
 	GDVIRTUAL_BIND(_set_state, "state");
 	GDVIRTUAL_BIND(_clear);
-	GDVIRTUAL_BIND(_get_unsaved_status);
+	GDVIRTUAL_BIND(_get_unsaved_status, "for_scene");
 	GDVIRTUAL_BIND(_save_external_data);
 	GDVIRTUAL_BIND(_apply_changes);
 	GDVIRTUAL_BIND(_get_breakpoints);

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -341,7 +341,12 @@ void EditorPlugin::clear() {
 	GDVIRTUAL_CALL(_clear);
 }
 
-// if editor references external resources/scenes, save them
+String EditorPlugin::get_unsaved_status() const {
+	String ret;
+	GDVIRTUAL_CALL(_get_unsaved_status, ret);
+	return ret;
+}
+
 void EditorPlugin::save_external_data() {
 	GDVIRTUAL_CALL(_save_external_data);
 }
@@ -594,6 +599,7 @@ void EditorPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_get_state);
 	GDVIRTUAL_BIND(_set_state, "state");
 	GDVIRTUAL_BIND(_clear);
+	GDVIRTUAL_BIND(_get_unsaved_status);
 	GDVIRTUAL_BIND(_save_external_data);
 	GDVIRTUAL_BIND(_apply_changes);
 	GDVIRTUAL_BIND(_get_breakpoints);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -88,6 +88,7 @@ protected:
 	GDVIRTUAL0RC(Dictionary, _get_state)
 	GDVIRTUAL1(_set_state, Dictionary)
 	GDVIRTUAL0(_clear)
+	GDVIRTUAL0RC(String, _get_unsaved_status)
 	GDVIRTUAL0(_save_external_data)
 	GDVIRTUAL0(_apply_changes)
 	GDVIRTUAL0RC(Vector<String>, _get_breakpoints)
@@ -175,6 +176,7 @@ public:
 	virtual Dictionary get_state() const; //save editor state so it can't be reloaded when reloading scene
 	virtual void set_state(const Dictionary &p_state); //restore editor state (likely was saved with the scene)
 	virtual void clear(); // clear any temporary data in the editor, reset it (likely new scene or load another scene)
+	virtual String get_unsaved_status() const;
 	virtual void save_external_data(); // if editor references external resources/scenes, save them
 	virtual void apply_changes(); // if changes are pending in editor, apply them
 	virtual void get_breakpoints(List<String> *p_breakpoints);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -88,7 +88,7 @@ protected:
 	GDVIRTUAL0RC(Dictionary, _get_state)
 	GDVIRTUAL1(_set_state, Dictionary)
 	GDVIRTUAL0(_clear)
-	GDVIRTUAL0RC(String, _get_unsaved_status)
+	GDVIRTUAL1RC(String, _get_unsaved_status, String)
 	GDVIRTUAL0(_save_external_data)
 	GDVIRTUAL0(_apply_changes)
 	GDVIRTUAL0RC(Vector<String>, _get_breakpoints)
@@ -176,7 +176,7 @@ public:
 	virtual Dictionary get_state() const; //save editor state so it can't be reloaded when reloading scene
 	virtual void set_state(const Dictionary &p_state); //restore editor state (likely was saved with the scene)
 	virtual void clear(); // clear any temporary data in the editor, reset it (likely new scene or load another scene)
-	virtual String get_unsaved_status() const;
+	virtual String get_unsaved_status(const String &p_for_scene = "") const;
 	virtual void save_external_data(); // if editor references external resources/scenes, save them
 	virtual void apply_changes(); // if changes are pending in editor, apply them
 	virtual void get_breakpoints(List<String> *p_breakpoints);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2435,6 +2435,18 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 	return true;
 }
 
+PackedStringArray ScriptEditor::get_unsaved_scripts() const {
+	PackedStringArray unsaved_list;
+
+	for (int i = 0; i < tab_container->get_tab_count(); i++) {
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
+		if (se->is_unsaved()) {
+			unsaved_list.append(se->get_name());
+		}
+	}
+	return unsaved_list;
+}
+
 void ScriptEditor::save_current_script() {
 	ScriptEditorBase *current = _get_current_editor();
 	if (!current || _test_script_times_on_disk()) {
@@ -4205,6 +4217,24 @@ void ScriptEditorPlugin::make_visible(bool p_visible) {
 void ScriptEditorPlugin::selected_notify() {
 	script_editor->ensure_select_current();
 	_focus_another_editor();
+}
+
+String ScriptEditorPlugin::get_unsaved_status() const {
+	const PackedStringArray unsaved_scripts = script_editor->get_unsaved_scripts();
+	if (unsaved_scripts.is_empty()) {
+		return String();
+	}
+
+	PackedStringArray message;
+	message.resize(unsaved_scripts.size() + 1);
+	message.write[0] = "Save changes to the following script(s) before quitting?";
+
+	int i = 1;
+	for (const String &E : unsaved_scripts) {
+		message.write[i] = E.trim_suffix("(*)");
+		i++;
+	}
+	return String("\n").join(message);
 }
 
 void ScriptEditorPlugin::save_external_data() {

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -573,7 +573,7 @@ public:
 	virtual void make_visible(bool p_visible) override;
 	virtual void selected_notify() override;
 
-	virtual String get_unsaved_status() const override;
+	virtual String get_unsaved_status(const String &p_for_scene) const override;
 	virtual void save_external_data() override;
 	virtual void apply_changes() override;
 

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -512,6 +512,7 @@ public:
 
 	void get_breakpoints(List<String> *p_breakpoints);
 
+	PackedStringArray get_unsaved_scripts() const;
 	void save_current_script();
 	void save_all_scripts();
 
@@ -572,6 +573,7 @@ public:
 	virtual void make_visible(bool p_visible) override;
 	virtual void selected_notify() override;
 
+	virtual String get_unsaved_status() const override;
 	virtual void save_external_data() override;
 	virtual void apply_changes() override;
 

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -287,6 +287,22 @@ void ShaderEditorPlugin::get_window_layout(Ref<ConfigFile> p_layout) {
 	p_layout->set_value("ShaderEditor", "selected_shader", selected_shader);
 }
 
+String ShaderEditorPlugin::get_unsaved_status() const {
+	// TODO: This should also include visual shaders and shader includes, but save_external_data() doesn't seem to save them...
+	PackedStringArray unsaved_shaders;
+	for (uint32_t i = 0; i < edited_shaders.size(); i++) {
+		if (edited_shaders[i].shader_editor) {
+			if (edited_shaders[i].shader_editor->is_unsaved()) {
+				if (unsaved_shaders.is_empty()) {
+					unsaved_shaders.append("Save changes to the following shaders(s) before quitting?");
+				}
+				unsaved_shaders.append(edited_shaders[i].shader_editor->get_name());
+			}
+		}
+	}
+	return String("\n").join(unsaved_shaders);
+}
+
 void ShaderEditorPlugin::save_external_data() {
 	for (EditedShader &edited_shader : edited_shaders) {
 		if (edited_shader.shader_editor) {

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -287,14 +287,19 @@ void ShaderEditorPlugin::get_window_layout(Ref<ConfigFile> p_layout) {
 	p_layout->set_value("ShaderEditor", "selected_shader", selected_shader);
 }
 
-String ShaderEditorPlugin::get_unsaved_status() const {
+String ShaderEditorPlugin::get_unsaved_status(const String &p_for_scene) const {
+	if (!p_for_scene.is_empty()) {
+		// TODO: handle built-in shaders.
+		return String();
+	}
+
 	// TODO: This should also include visual shaders and shader includes, but save_external_data() doesn't seem to save them...
 	PackedStringArray unsaved_shaders;
 	for (uint32_t i = 0; i < edited_shaders.size(); i++) {
 		if (edited_shaders[i].shader_editor) {
 			if (edited_shaders[i].shader_editor->is_unsaved()) {
 				if (unsaved_shaders.is_empty()) {
-					unsaved_shaders.append("Save changes to the following shaders(s) before quitting?");
+					unsaved_shaders.append(TTR("Save changes to the following shaders(s) before quitting?"));
 				}
 				unsaved_shaders.append(edited_shaders[i].shader_editor->get_name());
 			}

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -115,6 +115,7 @@ public:
 	virtual void set_window_layout(Ref<ConfigFile> p_layout) override;
 	virtual void get_window_layout(Ref<ConfigFile> p_layout) override;
 
+	virtual String get_unsaved_status() const override;
 	virtual void save_external_data() override;
 	virtual void apply_changes() override;
 

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -115,7 +115,7 @@ public:
 	virtual void set_window_layout(Ref<ConfigFile> p_layout) override;
 	virtual void get_window_layout(Ref<ConfigFile> p_layout) override;
 
-	virtual String get_unsaved_status() const override;
+	virtual String get_unsaved_status(const String &p_for_scene) const override;
 	virtual void save_external_data() override;
 	virtual void apply_changes() override;
 


### PR DESCRIPTION
This PR adds `_get_unsaved_status()`. When editor is being closed, it calls this method on every plugin. The method returns a string. If the string is not empty, its content will be displayed in save confirmation dialog and the user can normally choose to save or discard. If the returned string is empty, the editor will close normally.

I implemented this method for script editor and shader editor, so unsaved scripts will now prompt on editor exit. Unfortunately you can't discard them due to #18010

Fixes #55026
Fixes https://github.com/godotengine/godot/issues/36281
Supersedes #55586