### PR TITLE
Fix event propagation to child after set_as_toplevel

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -679,6 +679,12 @@ Transform2D Control::get_transform() const {
 	return xform;
 }
 
+void Control::_toplevel_changed_on_parent() {
+	// Update root control status.
+	_notification(NOTIFICATION_EXIT_CANVAS);
+	_notification(NOTIFICATION_ENTER_CANVAS);
+}
+
 /// Anchors and offsets.
 
 void Control::_set_anchor(Side p_side, real_t p_anchor) {

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -288,6 +288,9 @@ private:
 	void _update_minimum_size();
 	void _size_changed();
 
+	void _toplevel_changed() override{}; // Controls don't need to do anything, only other CanvasItems.
+	void _toplevel_changed_on_parent() override;
+
 	void _clear_size_warning();
 
 	// Input events.

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -401,9 +401,26 @@ void CanvasItem::set_as_top_level(bool p_top_level) {
 
 	_exit_canvas();
 	top_level = p_top_level;
+	_toplevel_changed();
 	_enter_canvas();
 
 	_notify_transform();
+}
+
+void CanvasItem::_toplevel_changed() {
+	// Inform children that toplevel status has changed on a parent.
+	int childs = get_child_count();
+	for (int i = 0; i < childs; i++) {
+		CanvasItem *child = Object::cast_to<CanvasItem>(get_child(i));
+		if (child) {
+			child->_toplevel_changed_on_parent();
+		}
+	}
+}
+
+void CanvasItem::_toplevel_changed_on_parent() {
+	// Inform children that toplevel status has changed on a parent.
+	_toplevel_changed();
 }
 
 bool CanvasItem::is_set_as_top_level() const {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -110,6 +110,9 @@ private:
 	void _propagate_visibility_changed(bool p_parent_visible_in_tree);
 	void _handle_visibility_change(bool p_visible);
 
+	virtual void _toplevel_changed();
+	virtual void _toplevel_changed_on_parent();
+
 	void _redraw_callback();
 
 	void _enter_canvas();


### PR DESCRIPTION
In certain conditions events did not get propagated to `Control`-childs of `Node2D`-nodes when setting a parent of the `Node2D` to toplevel because the Controls did not get added as root-control-nodes in the Viewport.
fix #42822

Analysis of the problem is available here: https://github.com/godotengine/godot/issues/42822#issuecomment-711554138

This patch makes sure that such Control nodes become root-control-nodes in the Viewport.

This is done by propagating the info that toplevel status has changed on a parent to all descendant `CanvasItems` passing through `Node2D` nodes and executing the code of `NOTIFICATION_EXIT_CANVAS` and `NOTIFICATION_ENTER_CANVAS` on all first reached `Control` nodes.