### PR TITLE
Allow extending CanvasItem in GDExtension

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -22,6 +22,12 @@
 				Corresponds to the [constant NOTIFICATION_DRAW] notification in [method Object._notification].
 			</description>
 		</method>
+		<method name="_get_transform" qualifiers="virtual const">
+			<return type="Transform2D" />
+			<description>
+				Callback used to implement custom [CanvasItem] nodes in GDExtension. This method is called by [method get_transform]. This callback method is not used with [Control] and [Node2D], which implement their own [method get_transform].
+			</description>
+		</method>
 		<method name="draw_animation_slice">
 			<return type="void" />
 			<param index="0" name="animation_length" type="float" />

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1205,6 +1205,7 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_clip_children_mode"), &CanvasItem::get_clip_children_mode);
 
 	GDVIRTUAL_BIND(_draw);
+	GDVIRTUAL_BIND(_get_transform);
 
 	ADD_GROUP("Visibility", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "visible"), "set_visible", "is_visible");
@@ -1262,6 +1263,12 @@ void CanvasItem::_bind_methods() {
 	BIND_ENUM_CONSTANT(CLIP_CHILDREN_ONLY);
 	BIND_ENUM_CONSTANT(CLIP_CHILDREN_AND_DRAW);
 	BIND_ENUM_CONSTANT(CLIP_CHILDREN_MAX);
+}
+
+Transform2D CanvasItem::get_transform() const {
+	Transform2D ret = Transform2D();
+	GDVIRTUAL_CALL(_get_transform, ret);
+	return ret;
 }
 
 Transform2D CanvasItem::get_canvas_transform() const {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -166,6 +166,7 @@ protected:
 	_FORCE_INLINE_ void set_hide_clip_children(bool p_value) { hide_clip_children = p_value; }
 
 	GDVIRTUAL0(_draw)
+	GDVIRTUAL0RC(Transform2D, _get_transform)
 
 public:
 	enum {
@@ -188,12 +189,12 @@ public:
 	virtual Dictionary _edit_get_state() const { return Dictionary(); }
 
 	// Used to move the node
-	virtual void _edit_set_position(const Point2 &p_position) = 0;
-	virtual Point2 _edit_get_position() const = 0;
+	virtual void _edit_set_position(const Point2 &p_position) {}
+	virtual Point2 _edit_get_position() const { return get_transform().get_origin(); }
 
 	// Used to scale the node
-	virtual void _edit_set_scale(const Size2 &p_scale) = 0;
-	virtual Size2 _edit_get_scale() const = 0;
+	virtual void _edit_set_scale(const Size2 &p_scale) {}
+	virtual Size2 _edit_get_scale() const { return get_transform().get_scale(); }
 
 	// Used to rotate the node
 	virtual bool _edit_use_rotation() const { return false; };
@@ -308,7 +309,7 @@ public:
 
 	CanvasItem *get_parent_item() const;
 
-	virtual Transform2D get_transform() const = 0;
+	virtual Transform2D get_transform() const;
 
 	virtual Transform2D get_global_transform() const;
 	virtual Transform2D get_global_transform_with_canvas() const;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -733,7 +733,7 @@ void register_scene_types() {
 	GDREGISTER_VIRTUAL_CLASS(Material);
 	GDREGISTER_CLASS(PlaceholderMaterial);
 	GDREGISTER_CLASS(ShaderMaterial);
-	GDREGISTER_ABSTRACT_CLASS(CanvasItem);
+	GDREGISTER_VIRTUAL_CLASS(CanvasItem);
 	GDREGISTER_CLASS(CanvasTexture);
 	GDREGISTER_CLASS(CanvasItemMaterial);
 	SceneTree::add_idle_callback(CanvasItemMaterial::flush_changes);


### PR DESCRIPTION
This PR allows extending CanvasItem and overriding its `get_transform` method in GDExtension by defining a method called `_get_transform`. This will not affect Control or Node2D because both of those classes override their own `get_transform`. The `_get_transform` method is therefore only used when implementing a custom CanvasItem.