### PR TITLE
Fix GDExtension classes derived from abstract GDExtension classes always being registered as abstract

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1661,7 +1661,15 @@ void ClassDB::register_extension_class(ObjectGDExtension *p_extension) {
 	c.name = p_extension->class_name;
 	c.is_virtual = p_extension->is_virtual;
 	if (!p_extension->is_abstract) {
-		c.creation_func = parent->creation_func;
+		// Find the closest ancestor which is either non-abstract or native (or both).
+		ClassInfo *concrete_ancestor = parent;
+		while (concrete_ancestor->creation_func == nullptr &&
+				concrete_ancestor->inherits_ptr != nullptr &&
+				concrete_ancestor->gdextension != nullptr) {
+			concrete_ancestor = concrete_ancestor->inherits_ptr;
+		}
+		ERR_FAIL_NULL_MSG(concrete_ancestor->creation_func, "Extension class " + String(p_extension->class_name) + " cannot extend native abstract class " + String(concrete_ancestor->name));
+		c.creation_func = concrete_ancestor->creation_func;
 	}
 	c.inherits = parent->name;
 	c.class_ptr = parent->class_ptr;


### PR DESCRIPTION
Fixup to https://github.com/godotengine/godot/pull/66979. In particular, this makes concrete GDExtension nodes derived from abstract GDExtension nodes show up in the Create New Node dialog, and allows such nodes to be saved/loaded in scenes.

Thanks to @aaronfranke for pointing out the issue in https://github.com/godotengine/godot-cpp/pull/883#issuecomment-1280052208.