### PR TITLE
Double the default size of the quick open menu

### DIFF
--- a/editor/editor_quick_open.cpp
+++ b/editor/editor_quick_open.cpp
@@ -37,7 +37,7 @@ void EditorQuickOpen::popup_dialog(const StringName &p_base, bool p_enable_multi
 	base_type = p_base;
 	allow_multi_select = p_enable_multi;
 	search_options->set_select_mode(allow_multi_select ? Tree::SELECT_MULTI : Tree::SELECT_SINGLE);
-	popup_centered_clamped(Size2i(600, 440), 0.8f);
+	popup_centered_clamped(Size2i(1200, 880), 0.8f);
 
 	EditorFileSystemDirectory *efsd = EditorFileSystem::get_singleton()->get_filesystem();
 	_build_search_cache(efsd);


### PR DESCRIPTION
Currently the default size for this is too small IMO, any moderately long paths get cut off and you can't see what you're selecting without resizing the window.
I have a project with some pretty long file paths, and having to resize the window every time I used quick open was not very quick and it was driving me crazy, so I widened it. The fallback ratio is still 0.8 so it won't go off screen or anything.