### PR TITLE
Speed up `find_texture_pos_for_glyph()`

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -810,12 +810,12 @@ _FORCE_INLINE_ TextServerAdvanced::FontTexturePosition TextServerAdvanced::find_
 
 		ret.y = 0x7fffffff;
 		ret.x = 0;
+		const int *ct_offsets_ptr = ct.offsets.ptr();
 
 		for (int j = 0; j < ct.texture_w - mw; j++) {
 			int max_y = 0;
-
 			for (int k = j; k < j + mw; k++) {
-				int y = ct.offsets[k];
+				int y = ct_offsets_ptr[k];
 				if (y > max_y) {
 					max_y = y;
 				}

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -233,12 +233,13 @@ _FORCE_INLINE_ TextServerFallback::FontTexturePosition TextServerFallback::find_
 
 		ret.y = 0x7fffffff;
 		ret.x = 0;
+		const int *ct_offsets_ptr = ct.offsets.ptr();
 
 		for (int j = 0; j < ct.texture_w - mw; j++) {
 			int max_y = 0;
 
 			for (int k = j; k < j + mw; k++) {
-				int y = ct.offsets[k];
+				int y = ct_offsets_ptr[k];
 				if (y > max_y) {
 					max_y = y;
 				}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
See #67520 . This does NOT fix this issue, but it does help a bit. Indexing into the `ptr()` is about 4x faster than the `Vector[]` lookup.