### PR TITLE
Fix sorting issue in Project Manager.

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1306,6 +1306,8 @@ void ProjectList::load_projects() {
 		create_project_item_control(i);
 	}
 
+	sort_projects();
+
 	set_v_scroll(0);
 
 	update_icons_async();


### PR DESCRIPTION
It happens when scanning or dropping projects. The manager reloads projects but not sort them again.

Reproduction:
![sorting_issue](https://user-images.githubusercontent.com/12966814/196127000-1d479a61-656e-429c-b9ae-2e4efd42fcd4.gif)
(for `Last Edited` option, A-C-B-D is expected.)