### PR TITLE
Fix two typos in tracker names and a bug in OpenXR haptic feedback

### DIFF
--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -447,9 +447,18 @@ void OpenXRInterface::handle_tracker(Tracker *p_tracker) {
 
 void OpenXRInterface::trigger_haptic_pulse(const String &p_action_name, const StringName &p_tracker_name, double p_frequency, double p_amplitude, double p_duration_sec, double p_delay_sec) {
 	ERR_FAIL_NULL(openxr_api);
+
 	Action *action = find_action(p_action_name);
 	ERR_FAIL_NULL(action);
-	Tracker *tracker = find_tracker(p_tracker_name);
+
+	// We need to map our tracker name to our OpenXR name for our inbuild names.
+	String tracker_name = p_tracker_name;
+	if (tracker_name == "left_hand") {
+		tracker_name = "/user/hand/left";
+	} else if (tracker_name == "right_hand") {
+		tracker_name = "/user/hand/right";
+	}
+	Tracker *tracker = find_tracker(tracker_name);
 	ERR_FAIL_NULL(tracker);
 
 	// TODO OpenXR does not support delay, so we may need to add support for that somehow...

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -363,7 +363,7 @@ void XRNode3D::_unbind_tracker() {
 }
 
 void XRNode3D::_changed_tracker(const StringName p_tracker_name, int p_tracker_type) {
-	if (p_tracker_name == p_tracker_name) {
+	if (tracker_name == p_tracker_name) {
 		// just in case unref our current tracker
 		_unbind_tracker();
 
@@ -373,7 +373,7 @@ void XRNode3D::_changed_tracker(const StringName p_tracker_name, int p_tracker_t
 }
 
 void XRNode3D::_removed_tracker(const StringName p_tracker_name, int p_tracker_type) {
-	if (p_tracker_name == p_tracker_name) {
+	if (tracker_name == p_tracker_name) {
 		// unref our tracker, it's no longer available
 		_unbind_tracker();
 	}


### PR DESCRIPTION
Found two dumb typos and added a fix in mapping internal tracker names to their OpenXR counter parts when our haptic feedback function is called. 
