### PR TITLE
Filter out HTC OpenXR paths based on extension

### DIFF
--- a/modules/openxr/extensions/openxr_htc_vive_tracker_extension.cpp
+++ b/modules/openxr/extensions/openxr_htc_vive_tracker_extension.cpp
@@ -69,6 +69,34 @@ bool OpenXRHTCViveTrackerExtension::on_event_polled(const XrEventDataBuffer &eve
 bool OpenXRHTCViveTrackerExtension::is_path_supported(const String &p_path) {
 	if (p_path == "/interaction_profiles/htc/vive_tracker_htcx") {
 		return available;
+	} else if (p_path == "/user/vive_tracker_htcx/role/handheld_object") {
+		return available;
+	} else if (p_path == "/user/vive_tracker_htcx/role/left_foot") {
+		return available;
+	} else if (p_path == "/user/vive_tracker_htcx/role/right_foot") {
+		return available;
+	} else if (p_path == "/user/vive_tracker_htcx/role/left_shoulder") {
+		return available;
+	} else if (p_path == "/user/vive_tracker_htcx/role/right_shoulder") {
+		return available;
+	} else if (p_path == "/user/vive_tracker_htcx/role/left_elbow") {
+		return available;
+	} else if (p_path == "/user/vive_tracker_htcx/role/right_elbow") {
+		return available;
+	} else if (p_path == "/user/vive_tracker_htcx/role/left_knee") {
+		return available;
+	} else if (p_path == "/user/vive_tracker_htcx/role/right_knee") {
+		return available;
+	} else if (p_path == "/user/vive_tracker_htcx/role/waist") {
+		return available;
+	} else if (p_path == "/user/vive_tracker_htcx/role/chest") {
+		return available;
+	} else if (p_path == "/user/vive_tracker_htcx/role/chest") {
+		return available;
+	} else if (p_path == "/user/vive_tracker_htcx/role/camera") {
+		return available;
+	} else if (p_path == "/user/vive_tracker_htcx/role/keyboard") {
+		return available;
 	}
 
 	// Not a path under this extensions control, so we return true;

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -84,8 +84,6 @@ private:
 	bool ext_vive_focus3_available = false;
 	bool ext_huawei_controller_available = false;
 
-	bool is_path_supported(const String &p_path);
-
 	// composition layer providers
 	Vector<OpenXRCompositionLayerProvider *> composition_layer_providers;
 
@@ -302,6 +300,7 @@ public:
 	void parse_velocities(const XrSpaceVelocity &p_velocity, Vector3 &r_linear_velocity, Vector3 &r_angular_velocity);
 
 	bool xr_result(XrResult result, const char *format, Array args = Array()) const;
+	bool is_path_supported(const String &p_path);
 
 	static bool openxr_is_enabled(bool p_check_run_in_editor = true);
 	static OpenXRAPI *get_singleton();

--- a/modules/openxr/openxr_interface.h
+++ b/modules/openxr/openxr_interface.h
@@ -91,7 +91,6 @@ private:
 	void free_actions(ActionSet *p_action_set);
 
 	Tracker *find_tracker(const String &p_tracker_name, bool p_create = false);
-	void link_action_to_tracker(Tracker *p_tracker, Action *p_action);
 	void handle_tracker(Tracker *p_tracker);
 	void free_trackers();
 


### PR DESCRIPTION
We're having issues with the OpenXR action map that contains entries for the HTC trackers. While previously we did a PR that filters out the interaction profiles if the extension is not available, we weren't filtering out the extensions paths when registering actions.

I can't test this as the extension is installed for me however this should fix #65395

