### PR TITLE
Enable Drag and Drop between SubViewports and Windows

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -151,7 +151,7 @@
 		<method name="gui_is_dragging" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the viewport is currently performing a drag operation.
+				Returns [code]true[/code] if a drag operation is currently ongoing and where the drop action could happen in this viewport.
 				Alternative to [constant Node.NOTIFICATION_DRAG_BEGIN] and [constant Node.NOTIFICATION_DRAG_END] when you prefer polling the value.
 			</description>
 		</method>

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -1787,12 +1787,6 @@ void DisplayServerX11::delete_sub_window(WindowID p_id) {
 		_send_window_event(windows[p_id], WINDOW_EVENT_MOUSE_EXIT);
 	}
 
-	window_set_rect_changed_callback(Callable(), p_id);
-	window_set_window_event_callback(Callable(), p_id);
-	window_set_input_event_callback(Callable(), p_id);
-	window_set_input_text_callback(Callable(), p_id);
-	window_set_drop_files_callback(Callable(), p_id);
-
 	while (wd.transient_children.size()) {
 		window_set_transient(*wd.transient_children.begin(), INVALID_WINDOW_ID);
 	}
@@ -1835,6 +1829,12 @@ void DisplayServerX11::delete_sub_window(WindowID p_id) {
 
 	XUnmapWindow(x11_display, wd.x11_window);
 	XDestroyWindow(x11_display, wd.x11_window);
+
+	window_set_rect_changed_callback(Callable(), p_id);
+	window_set_window_event_callback(Callable(), p_id);
+	window_set_input_event_callback(Callable(), p_id);
+	window_set_input_text_callback(Callable(), p_id);
+	window_set_drop_files_callback(Callable(), p_id);
 
 	windows.erase(p_id);
 }

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -281,7 +281,7 @@ private:
 
 	bool disable_3d = false;
 
-	void _propagate_viewport_notification(Node *p_node, int p_what);
+	static void _propagate_drag_notification(Node *p_node, int p_what);
 
 	void _update_global_transform();
 
@@ -362,7 +362,6 @@ private:
 		Window *subwindow_over = nullptr; // mouse_over and subwindow_over are mutually exclusive. At all times at least one of them is nullptr.
 		Window *windowmanager_window_over = nullptr; // Only used in root Viewport.
 		Control *drag_mouse_over = nullptr;
-		Vector2 drag_mouse_over_pos;
 		Control *tooltip_control = nullptr;
 		Window *tooltip_popup = nullptr;
 		Label *tooltip_label = nullptr;
@@ -371,7 +370,7 @@ private:
 		Point2 last_mouse_pos;
 		Point2 drag_accum;
 		bool drag_attempted = false;
-		Variant drag_data;
+		Variant drag_data; // Only used in root-Viewport and SubViewports, that are not children of a SubViewportContainer.
 		ObjectID drag_preview_id;
 		Ref<SceneTreeTimer> tooltip_timer;
 		double tooltip_delay = 0.0;
@@ -379,8 +378,10 @@ private:
 		List<Control *> roots;
 		HashSet<ObjectID> canvas_parents_with_dirty_order;
 		int canvas_sort_index = 0; //for sorting items with canvas as root
-		bool dragging = false;
+		bool dragging = false; // Is true in the viewport in which dragging started while dragging is active.
+		bool global_dragging = false; // Is true while dragging is active. Only used in root-Viewport and SubViewports that are not children of a SubViewportContainer.
 		bool drag_successful = false;
+		Control *target_control = nullptr; // Control that the mouse is over in the innermost nested Viewport. Only used in root-Viewport and SubViewports, that are not children of a SubViewportContainer.
 		bool embed_subwindows_hint = false;
 
 		Window *subwindow_focused = nullptr;
@@ -408,7 +409,7 @@ private:
 	Control *_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_global, const Transform2D &p_xform);
 
 	void _gui_input_event(Ref<InputEvent> p_event);
-	void _perform_drop(Control *p_control = nullptr, Point2 p_pos = Point2());
+	void _perform_drop(Control *p_control = nullptr);
 	void _gui_cleanup_internal_state(Ref<InputEvent> p_event);
 
 	void _push_unhandled_input_internal(const Ref<InputEvent> &p_event);
@@ -672,9 +673,9 @@ public:
 	Transform2D get_screen_transform() const;
 	virtual Transform2D get_screen_transform_internal(bool p_absolute_position = false) const;
 	virtual Transform2D get_popup_base_transform() const { return Transform2D(); }
-	virtual bool is_directly_attached_to_screen() const { return false; };
-	virtual bool is_attached_in_viewport() const { return false; };
-	virtual bool is_sub_viewport() const { return false; };
+	virtual Viewport *get_section_root_viewport() const { return nullptr; }
+	virtual bool is_attached_in_viewport() const { return false; }
+	virtual bool is_sub_viewport() const { return false; }
 
 private:
 	// 2D audio, camera, and physics. (don't put World2D here because World2D is needed for Control nodes).
@@ -836,9 +837,9 @@ public:
 
 	virtual Transform2D get_screen_transform_internal(bool p_absolute_position = false) const override;
 	virtual Transform2D get_popup_base_transform() const override;
-	virtual bool is_directly_attached_to_screen() const override;
+	virtual Viewport *get_section_root_viewport() const override;
 	virtual bool is_attached_in_viewport() const override;
-	virtual bool is_sub_viewport() const override { return true; };
+	virtual bool is_sub_viewport() const override { return true; }
 
 	void _validate_property(PropertyInfo &p_property) const;
 	SubViewport();

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2755,12 +2755,16 @@ Transform2D Window::get_popup_base_transform() const {
 	return popup_base_transform;
 }
 
-bool Window::is_directly_attached_to_screen() const {
+Viewport *Window::get_section_root_viewport() const {
 	if (get_embedder()) {
-		return get_embedder()->is_directly_attached_to_screen();
+		return get_embedder()->get_section_root_viewport();
 	}
-	// Distinguish between the case that this is a native Window and not inside the tree.
-	return is_inside_tree();
+	if (is_inside_tree()) {
+		// Native window.
+		return SceneTree::get_singleton()->get_root();
+	}
+	Window *vp = const_cast<Window *>(this);
+	return vp;
 }
 
 bool Window::is_attached_in_viewport() const {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -469,7 +469,7 @@ public:
 	virtual Transform2D get_final_transform() const override;
 	virtual Transform2D get_screen_transform_internal(bool p_absolute_position = false) const override;
 	virtual Transform2D get_popup_base_transform() const override;
-	virtual bool is_directly_attached_to_screen() const override;
+	virtual Viewport *get_section_root_viewport() const override;
 	virtual bool is_attached_in_viewport() const override;
 
 	Rect2i get_parent_rect() const;


### PR DESCRIPTION
Make Drag and Drop an application-wide operation.
This allows to drop on Controls in other Viewports/Windows.

Also now all nodes in the SceneTree are notified about the Drag and Drop operation, with the exception of SubViewports that are not child-nodes of SubViewportContainers. This distinction seemed prudent, because these SubViewports need to be displayed manually and this requires manual setup also for Drag and Drop.

Unit-tests for Drag and Drop in different Windows & SubViewports are also added.

In order to achieve this, the following changes were made:
- `Viewport::_update_mouse_over` from #67791 is used to identify the drop-target (even within nested viewports)
- This Control is used as a basis for the Drop-operation, which replaces the previous algorithm, that was only aware of topmost Viewports.
- In order to handle DnD within non-default SubViewports (see for an example https://github.com/godotengine/godot-demo-projects/pull/925), it becomes necessary to track drag-operations in each (for the lack of a better name) section in the scene-tree.
- `is_directly_attached_to_screen` is replaced by `get_section_rootviewport`. which is of the same complexity, but additionally returns the topmost Viewport within the section
- `_propagate_viewport_notification` had to be adjusted to account for sections
- `DisplayServerX11::delete_sub_window` needed to be adjusted similar to #80142, since the event-callback is also needed on linuxbsd during Window-deletion

Relations:
- alternative to #71509 and has a broader scope
- fix #28522
- fix #44390
- fix #59622
- fix #77665
- fix no longer (will be done separately) #67186 
- fix duplicate #62384
- fix duplicate #68063
- was previously blocked by #71972
- utilizes #67791
- follow-up to #80142
- related to #64949
- related to #20881

MRP: [BugDragNDrop.zip](https://github.com/godotengine/godot/files/10468628/BugDragNDrop.zip) (updated 2023-01-20)

The Drag-Preview in the following Video is outdated, because that will be done in a different PR.

https://user-images.githubusercontent.com/6299227/196206434-2b8cba24-5993-40d2-a8dc-22749b7ccd27.mp4

Updated 2023-01-28: Fix merge conflict
Updated 2023-03-20: Fix merge conflict
Updated 2023-05-30: Linked another bug-report, that this PR fixes. Resolve problematic testcases. Fix merge conflict.
Updated 2023-06-07: Fix merge conflict
Updated 2023-06-08: Fix issue with docks
Updated 2023-06-19: Fix issue with simultaneous drag starts
Updated 2023-07-06: Fix issue with Gui in 3D Demo, Add Unit-tests
Updated 2023-07-19: Fix merge conflict
Updated 2023-08-02: Fix merge conflict with #67791 and #79805
Updated 2023-08-12: Fix merge conflict
Updated 2023-09-18: Fix merge conflict with #81551
Updated 2024-01-03: Fix merge conflict with #86511 and verified that #86493 doesn't get reintroduced.
Updated 2024-05-03: Rebased after #91425 and verified that #91387 doesn't get reintroduced.
Updated 2024-09-15: Rebased after 4.3-release for good measure and verified the functionality in the MRP.