### PR TITLE
Check if Vulkan context for the window exists before resizing it to avoid unnecessary error messages.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3087,7 +3087,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 					rect_changed = true;
 				}
 #if defined(VULKAN_ENABLED)
-				if (context_vulkan && window_created) {
+				if (context_vulkan && window.context_created) {
 					// Note: Trigger resize event to update swapchains when window is minimized/restored, even if size is not changed.
 					context_vulkan->window_resize(window_id, window.width, window.height);
 				}
@@ -3547,6 +3547,7 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 				windows.erase(id);
 				ERR_FAIL_V_MSG(INVALID_WINDOW_ID, "Failed to create Vulkan Window.");
 			}
+			wd.context_created = true;
 		}
 #endif
 

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -369,6 +369,7 @@ class DisplayServerWindows : public DisplayServer {
 		bool no_focus = false;
 		bool window_has_focus = false;
 		bool exclusive = false;
+		bool context_created = false;
 
 		// Used to transfer data between events using timer.
 		WPARAM saved_wparam;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/67408, resize event can be triggered during window creation (before Vulkan context for a window is initialized).