### PR TITLE
Use CameraAttributesPractical in the editor default environment

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -767,7 +767,7 @@ private:
 	WorldEnvironment *preview_environment = nullptr;
 	bool preview_env_dangling = false;
 	Ref<Environment> environment;
-	Ref<CameraAttributesPhysical> camera_attributes;
+	Ref<CameraAttributesPractical> camera_attributes;
 	Ref<ProceduralSkyMaterial> sky_material;
 
 	bool sun_environ_updating = false;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/67542

This avoids forcing DoF in the editor when physical light units are enabled.

