### PR TITLE
Fix Updating New Node Dialog Description of Custom Nodes

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -275,7 +275,8 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String 
 		r_item->set_text(0, "\"" + p_type + "\"");
 	} else if (script_type) {
 		r_item->set_metadata(0, p_type);
-		r_item->set_text(0, p_type + " (" + ScriptServer::get_global_class_path(p_type).get_file() + ")");
+		r_item->set_text(0, p_type);
+		r_item->set_suffix(0, "(" + ScriptServer::get_global_class_path(p_type).get_file() + ")");
 	} else {
 		r_item->set_metadata(0, custom_type_parents[p_type]);
 		r_item->set_text(0, p_type);


### PR DESCRIPTION
The text of the first column in the selection Tree is used to compare Node names.
Since this text contains for custom nodes additionally the path to the file, it doesn't match anything.

This patch separates the path and adds it as suffix.

resolve #67535