### PR TITLE
[macOS] Fit OS::alert to the text width for better readability.

### DIFF
--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -148,9 +148,11 @@ void OS_MacOS::alert(const String &p_alert, const String &p_title) {
 	NSString *ns_title = [NSString stringWithUTF8String:p_title.utf8().get_data()];
 	NSString *ns_alert = [NSString stringWithUTF8String:p_alert.utf8().get_data()];
 
+	NSTextField *text_field = [NSTextField labelWithString:ns_alert];
+	[text_field setAlignment:NSTextAlignmentCenter];
 	[window addButtonWithTitle:@"OK"];
 	[window setMessageText:ns_title];
-	[window setInformativeText:ns_alert];
+	[window setAccessoryView:text_field];
 	[window setAlertStyle:NSAlertStyleWarning];
 
 	id key_window = [[NSApplication sharedApplication] keyWindow];


### PR DESCRIPTION
Improves readability of the long messages like: https://github.com/godotengine/godot/pull/67546

Before:
<img width="293" alt="Screenshot 2022-10-17 at 23 14 48" src="https://user-images.githubusercontent.com/7645683/196274453-6034ac95-ff4a-40c0-8845-17690e7c1c58.png">

After:
<img width="681" alt="Screenshot 2022-10-18 at 12 04 08" src="https://user-images.githubusercontent.com/7645683/196388961-4db68bc1-854e-4129-84a2-817e1f9cdfe3.png">
