### PR TITLE
Code simplifications

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1367,7 +1367,7 @@ void ColorPicker::_screen_input(const Ref<InputEvent> &p_event) {
 
 		Ref<Image> img = r->get_texture()->get_image();
 		if (img.is_valid() && !img->is_empty()) {
-			Vector2 ofs = mev->get_global_position() - r->get_visible_rect().get_position();
+			Vector2 ofs = mev->get_global_position();
 			Color c = img->get_pixel(ofs.x, ofs.y);
 
 			set_pick_color(c);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1436,13 +1436,6 @@ Rect2 Control::get_screen_rect() const {
 	return r;
 }
 
-Rect2 Control::get_window_rect() const {
-	ERR_FAIL_COND_V(!is_inside_tree(), Rect2());
-	Rect2 gr = get_global_rect();
-	gr.position += get_viewport()->get_visible_rect().position;
-	return gr;
-}
-
 Rect2 Control::get_anchorable_rect() const {
 	return Rect2(Point2(), get_size());
 }

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -445,7 +445,6 @@ public:
 	Rect2 get_rect() const;
 	Rect2 get_global_rect() const;
 	Rect2 get_screen_rect() const;
-	Rect2 get_window_rect() const; ///< use with care, as it blocks waiting for the rendering server
 	Rect2 get_anchorable_rect() const override;
 
 	void set_scale(const Vector2 &p_scale);

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -338,7 +338,7 @@ void ScrollBar::_notification(int p_what) {
 			if (scrolling) {
 				if (get_value() != target_scroll) {
 					double target = target_scroll - get_value();
-					double dist = sqrt(target * target);
+					double dist = abs(target);
 					double vel = ((target / dist) * 500) * get_physics_process_delta_time();
 
 					if (Math::abs(vel) >= dist) {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -464,7 +464,7 @@ void TextEdit::_notification(int p_what) {
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (scrolling && get_v_scroll() != target_v_scroll) {
 				double target_y = target_v_scroll - get_v_scroll();
-				double dist = sqrt(target_y * target_y);
+				double dist = abs(target_y);
 				// To ensure minimap is responsive override the speed setting.
 				double vel = ((target_y / dist) * ((minimap_clicked) ? 3000 : v_scroll_speed)) * get_physics_process_delta_time();
 

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -2866,7 +2866,8 @@ void GI::VoxelGIInstance::update(bool p_update_light_instances, const Vector<RID
 
 		{
 			Transform3D to_cell = gi->voxel_gi_get_to_cell_xform(probe);
-			Transform3D to_probe_xform = (transform * to_cell.affine_inverse()).affine_inverse();
+			Transform3D to_probe_xform = to_cell * transform.affine_inverse();
+
 			//update lights
 
 			for (uint32_t i = 0; i < light_count; i++) {

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -655,20 +655,7 @@ void main() {
 		if (i >= light_count) {
 			break;
 		}
-		uint light_base;
-		if (i < 8) {
-			if (i < 4) {
-				light_base = draw_data.lights[0];
-			} else {
-				light_base = draw_data.lights[1];
-			}
-		} else {
-			if (i < 12) {
-				light_base = draw_data.lights[2];
-			} else {
-				light_base = draw_data.lights[3];
-			}
-		}
+		uint light_base = draw_data.lights[i >> 2];
 		light_base >>= (i & 3) * 8;
 		light_base &= 0xFF;
 


### PR DESCRIPTION
1. `Viewport::get_visible_rect().position` is always zero. So `Control::get_window_rect` is identical to `Control::get_global_rect`. Remove `Control::get_window_rect` since it is not used in the source code.

2. `sqrt(a * a)` = `abs(a)` for doubles

3. Simplify `affine_inverse` combination

4. Simplify calculation in shaders
