### PR TITLE
Delete Android godot-lib with the old naming scheme

### DIFF
--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -276,6 +276,11 @@ task generateDevTemplate {
     finalizedBy 'zipCustomBuild'
 }
 
+task clean(type: Delete) {
+    dependsOn 'cleanGodotEditor'
+    dependsOn 'cleanGodotTemplates'
+}
+
 /**
  * Clean the generated editor artifacts.
  */
@@ -292,8 +297,6 @@ task cleanGodotEditor(type: Delete) {
     // Delete the Godot editor apks in the Godot bin directory
     delete("$binDir/android_editor.apk")
     delete("$binDir/android_editor_dev.apk")
-
-    finalizedBy getTasksByName("clean", true)
 }
 
 /**
@@ -321,5 +324,8 @@ task cleanGodotTemplates(type: Delete) {
     delete("$binDir/godot-lib.template_debug.dev.aar")
     delete("$binDir/godot-lib.template_release.aar")
 
-    finalizedBy getTasksByName("clean", true)
+    // Cover deletion for the libs using the previous naming scheme
+    delete("$binDir/godot-lib.debug.aar")
+    delete("$binDir/godot-lib.dev.aar")
+    delete("$binDir/godot-lib.release.aar")
 }


### PR DESCRIPTION
Addresses #67378

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
