### PR TITLE
Fix exporting with export template binaries over 2.0 GiB

### DIFF
--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -351,7 +351,7 @@ Error DirAccess::copy(String p_from, String p_to, int p_chmod_flags) {
 		const size_t copy_buffer_limit = 65536; // 64 KB
 
 		fsrc->seek_end(0);
-		int size = fsrc->get_position();
+		uint64_t size = fsrc->get_position();
 		fsrc->seek(0);
 		err = OK;
 		size_t buffer_size = MIN(size * sizeof(uint8_t), copy_buffer_limit);

--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -169,8 +169,10 @@ static bool _collect_inheritance_chain(const Ref<SceneState> &p_state, const Nod
 		state = state->get_base_scene_state();
 	}
 
-	for (int i = inheritance_states.size() - 1; i >= 0; --i) {
-		r_states_stack.push_back(inheritance_states[i]);
+	if (inheritance_states.size() > 0) {
+		for (int i = inheritance_states.size() - 1; i >= 0; --i) {
+			r_states_stack.push_back(inheritance_states[i]);
+		}
 	}
 
 	return found;
@@ -214,10 +216,12 @@ Vector<SceneState::PackState> PropertyUtils::get_node_states_stack(const Node *p
 	{
 		states_stack_ret.resize(states_stack.size());
 		_FastPackState *ps = states_stack.ptr();
-		for (int i = states_stack.size() - 1; i >= 0; --i) {
-			states_stack_ret.write[i].state.reference_ptr(ps->state);
-			states_stack_ret.write[i].node = ps->node;
-			++ps;
+		if (states_stack.size() > 0) {
+			for (int i = states_stack.size() - 1; i >= 0; --i) {
+				states_stack_ret.write[i].state.reference_ptr(ps->state);
+				states_stack_ret.write[i].node = ps->node;
+				++ps;
+			}
 		}
 	}
 	return states_stack_ret;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/67572

Also silences some overflows/undeflows which are visible under llvm sanitizers