### PR TITLE
Use proper types for converting Java float/double arrays in Android code

### DIFF
--- a/platform/android/jni_utils.cpp
+++ b/platform/android/jni_utils.cpp
@@ -265,33 +265,33 @@ Variant _jobject_to_variant(JNIEnv *env, jobject obj) {
 	if (name == "[D") {
 		jdoubleArray arr = (jdoubleArray)obj;
 		int fCount = env->GetArrayLength(arr);
-		PackedFloat32Array sarr;
-		sarr.resize(fCount);
+		PackedFloat64Array packed_array;
+		packed_array.resize(fCount);
 
-		real_t *w = sarr.ptrw();
+		double *w = packed_array.ptrw();
 
 		for (int i = 0; i < fCount; i++) {
 			double n;
 			env->GetDoubleArrayRegion(arr, i, 1, &n);
 			w[i] = n;
 		}
-		return sarr;
+		return packed_array;
 	}
 
 	if (name == "[F") {
 		jfloatArray arr = (jfloatArray)obj;
 		int fCount = env->GetArrayLength(arr);
-		PackedFloat32Array sarr;
-		sarr.resize(fCount);
+		PackedFloat32Array packed_array;
+		packed_array.resize(fCount);
 
-		real_t *w = sarr.ptrw();
+		float *w = packed_array.ptrw();
 
 		for (int i = 0; i < fCount; i++) {
 			float n;
 			env->GetFloatArrayRegion(arr, i, 1, &n);
 			w[i] = n;
 		}
-		return sarr;
+		return packed_array;
 	}
 
 	if (name == "[Ljava.lang.Object;") {


### PR DESCRIPTION
Fixes #67574. Now converting a `double` array from Java uses `double` and `PackedFloat64Array`. I assume that the old code here was a holdover from when we had `PoolRealArray`.