### PR TITLE
Add creation_time_interval in editor settings to prevent debug instance from crashing

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -643,6 +643,9 @@
 		<member name="run/output/font_size" type="int" setter="" getter="">
 			The size of the font in the [b]Output[/b] panel at the bottom of the editor. This setting does not impact the font size of the script editor (see [member interface/editor/code_font_size]).
 		</member>
+		<member name="run/window_placement/creation_time_interval" type="int" setter="" getter="">
+			The interval in milliseconds of running multiple debug instances. When you found that actually created debug instances is less than your demands, increase this interval until all debug instances are created properly.
+		</member>
 		<member name="run/window_placement/rect" type="int" setter="" getter="">
 			The window mode to use to display the project when starting the project from the editor.
 		</member>

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -270,7 +270,12 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 	printf("\n");
 
 	int instances = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_instances", 1);
+	int creation_time_interval = EditorSettings::get_singleton()->get("run/window_placement/creation_time_interval");
 	for (int i = 0; i < instances; i++) {
+		if (i > 0 && creation_time_interval > 0) {
+			// Let previous instance has some time to initialize.
+			OS::get_singleton()->delay_usec(creation_time_interval * 1000);
+		}
 		OS::ProcessID pid = 0;
 		Error err = OS::get_singleton()->create_instance(args, &pid);
 		ERR_FAIL_COND_V(err, err);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -695,6 +695,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	/* Run */
 
 	// Window placement
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "run/window_placement/creation_time_interval", 0, "0,10000,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "run/window_placement/rect", 1, "Top Left,Centered,Custom Position,Force Maximized,Force Fullscreen")
 	String screen_hints = "Same as Editor,Previous Monitor,Next Monitor";
 	for (int i = 0; i < DisplayServer::get_singleton()->get_screen_count(); i++) {


### PR DESCRIPTION
For Issue https://github.com/godotengine/godot/issues/67499

Add an editor setting `run/window_placement/creation_time_interval`. The setting controls the interval in milliseconds of creating debug instances.


I recorded a vedio to show the problem and the behavior of creation_time_interval.

- 00:00 ~ 00:42，Reproduced the problem that debug instances crashed.
- 00:42 ~ 00:52，Change creation_time_interval to 100ms
- 00:52 ~ 01:30，Re-run debug instances about 10 times and they do not crash anymore.

https://user-images.githubusercontent.com/13895988/196465519-cd817c01-15e0-4acf-8a4c-4767ca0bc621.mp4


