### PR TITLE
Support to customize launching position for every debug instance

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -646,8 +646,8 @@
 		<member name="run/window_placement/rect" type="int" setter="" getter="">
 			The window mode to use to display the project when starting the project from the editor.
 		</member>
-		<member name="run/window_placement/rect_custom_position" type="Vector2" setter="" getter="">
-			The custom position to use when starting the project from the editor (in pixels from the top-left corner). Only effective if [member run/window_placement/rect] is set to [b]Custom Position[/b].
+		<member name="run/window_placement/rect_custom_position" type="PackedVector2Array" setter="" getter="">
+			The custom position to use when starting the project from the editor (in pixels from the top-left corner). Only effective if [member run/window_placement/rect] is set to [b]Custom Position[/b]. You can specify 1 or more positions of debug instances. If the count of debug instances is more than the count of positions, then remaining instances will use the last position.
 		</member>
 		<member name="run/window_placement/screen" type="int" setter="" getter="">
 			The monitor to display the project on when starting the project from the editor.

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -115,6 +115,7 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 	screen_rect.size = DisplayServer::get_singleton()->screen_get_size(screen);
 
 	int window_placement = EDITOR_GET("run/window_placement/rect");
+	Vector<Vector2> instance_positions = Vector<Vector2>();
 	if (screen_rect != Rect2()) {
 		Size2 window_size;
 		window_size.x = GLOBAL_GET("display/window/size/viewport_width");
@@ -150,30 +151,23 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 
 		switch (window_placement) {
 			case 0: { // top left
-				args.push_back("--position");
-				args.push_back(itos(screen_rect.position.x) + "," + itos(screen_rect.position.y));
+				instance_positions.push_back(Vector2());
 			} break;
 			case 1: { // centered
-				Vector2 pos = (screen_rect.position) + ((screen_rect.size - window_size) / 2).floor();
-				args.push_back("--position");
-				args.push_back(itos(pos.x) + "," + itos(pos.y));
+				instance_positions.push_back(((screen_rect.size - window_size) / 2).floor());
 			} break;
 			case 2: { // custom pos
-				Vector2 pos = EDITOR_GET("run/window_placement/rect_custom_position");
-				pos += screen_rect.position;
-				args.push_back("--position");
-				args.push_back(itos(pos.x) + "," + itos(pos.y));
+				instance_positions = EDITOR_GET("run/window_placement/rect_custom_position");
+				if (instance_positions.size() <= 0) {
+					instance_positions.push_back(Vector2());
+				}
 			} break;
 			case 3: { // force maximized
-				Vector2 pos = screen_rect.position;
-				args.push_back("--position");
-				args.push_back(itos(pos.x) + "," + itos(pos.y));
+				instance_positions.push_back(Vector2());
 				args.push_back("--maximized");
 			} break;
 			case 4: { // force fullscreen
-				Vector2 pos = screen_rect.position;
-				args.push_back("--position");
-				args.push_back(itos(pos.x) + "," + itos(pos.y));
+				instance_positions.push_back(Vector2());
 				args.push_back("--fullscreen");
 			} break;
 		}
@@ -271,8 +265,22 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 
 	int instances = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_instances", 1);
 	for (int i = 0; i < instances; i++) {
+		// Specify the position for current instance.
+		List<String> instance_args = args;
+		if (instance_positions.size() > 0) {
+			Vector2 pos = Vector2();
+			if (i < instance_positions.size()) {
+				pos = instance_positions[i];
+			} else {
+				pos = instance_positions[instance_positions.size() - 1];
+			}
+			pos += screen_rect.position;
+			instance_args.push_back("--position");
+			instance_args.push_back(itos(pos.x) + "," + itos(pos.y));
+		}
+
 		OS::ProcessID pid = 0;
-		Error err = OS::get_singleton()->create_instance(args, &pid);
+		Error err = OS::get_singleton()->create_instance(instance_args, &pid);
 		ERR_FAIL_COND_V(err, err);
 		pids.push_back(pid);
 	}

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -700,7 +700,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	for (int i = 0; i < DisplayServer::get_singleton()->get_screen_count(); i++) {
 		screen_hints += ",Monitor " + itos(i + 1);
 	}
-	_initial_set("run/window_placement/rect_custom_position", Vector2());
+	_initial_set("run/window_placement/rect_custom_position", Vector<Vector2>());
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "run/window_placement/screen", 0, screen_hints)
 
 	// Auto save


### PR DESCRIPTION
Change `run/window_placement/rect_custom_position` to an array to support specify position of every debug instance.


Now I can debug multiplayer instances without `Run & moving window & moving window & moving window & moving window`.


Snapshot:
![image](https://user-images.githubusercontent.com/13895988/196484583-da81682f-35de-4198-bf10-e8af8237d4f1.png)


