### PR TITLE
Simplify GDVIRTUAL_CALL calls

### DIFF
--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -52,10 +52,8 @@ bool ImageFormatLoader::recognize(const String &p_extension) const {
 
 Error ImageFormatLoaderExtension::load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
 	Error err = ERR_UNAVAILABLE;
-	if (GDVIRTUAL_CALL(_load_image, p_image, p_fileaccess, p_flags, p_scale, err)) {
-		return err;
-	}
-	return ERR_UNAVAILABLE;
+	GDVIRTUAL_CALL(_load_image, p_image, p_fileaccess, p_flags, p_scale, err);
+	return err;
 }
 
 void ImageFormatLoaderExtension::get_recognized_extensions(List<String> *p_extension) const {

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -74,11 +74,8 @@ bool ResourceFormatLoader::recognize_path(const String &p_path, const String &p_
 
 bool ResourceFormatLoader::handles_type(const String &p_type) const {
 	bool success = false;
-	if (GDVIRTUAL_CALL(_handles_type, p_type, success)) {
-		return success;
-	}
-
-	return false;
+	GDVIRTUAL_CALL(_handles_type, p_type, success);
+	return success;
 }
 
 void ResourceFormatLoader::get_classes_used(const String &p_path, HashSet<StringName> *r_classes) {
@@ -98,21 +95,14 @@ void ResourceFormatLoader::get_classes_used(const String &p_path, HashSet<String
 
 String ResourceFormatLoader::get_resource_type(const String &p_path) const {
 	String ret;
-
-	if (GDVIRTUAL_CALL(_get_resource_type, p_path, ret)) {
-		return ret;
-	}
-
-	return "";
+	GDVIRTUAL_CALL(_get_resource_type, p_path, ret);
+	return ret;
 }
 
 ResourceUID::ID ResourceFormatLoader::get_resource_uid(const String &p_path) const {
 	int64_t uid = ResourceUID::INVALID_ID;
-	if (GDVIRTUAL_CALL(_get_resource_uid, p_path, uid)) {
-		return uid;
-	}
-
-	return ResourceUID::INVALID_ID;
+	GDVIRTUAL_CALL(_get_resource_uid, p_path, uid);
+	return uid;
 }
 
 void ResourceFormatLoader::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const {
@@ -132,7 +122,7 @@ bool ResourceFormatLoader::exists(const String &p_path) const {
 	if (GDVIRTUAL_CALL(_exists, p_path, success)) {
 		return success;
 	}
-	return FileAccess::exists(p_path); //by default just check file
+	return FileAccess::exists(p_path); // By default just check file.
 }
 
 void ResourceFormatLoader::get_recognized_extensions(List<String> *p_extensions) const {
@@ -181,11 +171,8 @@ Error ResourceFormatLoader::rename_dependencies(const String &p_path, const Hash
 	}
 
 	int64_t err = OK;
-	if (GDVIRTUAL_CALL(_rename_dependencies, p_path, deps_dict, err)) {
-		return (Error)err;
-	}
-
-	return OK;
+	GDVIRTUAL_CALL(_rename_dependencies, p_path, deps_dict, err);
+	return (Error)err;
 }
 
 void ResourceFormatLoader::_bind_methods() {

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -43,20 +43,14 @@ ResourceSaverGetResourceIDForPath ResourceSaver::save_get_id_for_path = nullptr;
 
 Error ResourceFormatSaver::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
 	int64_t res = ERR_METHOD_NOT_FOUND;
-	if (GDVIRTUAL_CALL(_save, p_resource, p_path, p_flags, res)) {
-		return (Error)res;
-	}
-
-	return ERR_METHOD_NOT_FOUND;
+	GDVIRTUAL_CALL(_save, p_resource, p_path, p_flags, res);
+	return (Error)res;
 }
 
 bool ResourceFormatSaver::recognize(const Ref<Resource> &p_resource) const {
 	bool success = false;
-	if (GDVIRTUAL_CALL(_recognize, p_resource, success)) {
-		return success;
-	}
-
-	return false;
+	GDVIRTUAL_CALL(_recognize, p_resource, success);
+	return success;
 }
 
 void ResourceFormatSaver::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {

--- a/core/os/main_loop.cpp
+++ b/core/os/main_loop.cpp
@@ -65,21 +65,15 @@ void MainLoop::initialize() {
 }
 
 bool MainLoop::physics_process(double p_time) {
-	bool quit;
-	if (GDVIRTUAL_CALL(_physics_process, p_time, quit)) {
-		return quit;
-	}
-
-	return false;
+	bool quit = false;
+	GDVIRTUAL_CALL(_physics_process, p_time, quit);
+	return quit;
 }
 
 bool MainLoop::process(double p_time) {
-	bool quit;
-	if (GDVIRTUAL_CALL(_process, p_time, quit)) {
-		return quit;
-	}
-
-	return false;
+	bool quit = false;
+	GDVIRTUAL_CALL(_process, p_time, quit);
+	return quit;
 }
 
 void MainLoop::finalize() {

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1062,10 +1062,8 @@ void EditorInspectorPlugin::add_property_editor_for_multiple_properties(const St
 
 bool EditorInspectorPlugin::can_handle(Object *p_object) {
 	bool success = false;
-	if (GDVIRTUAL_CALL(_can_handle, p_object, success)) {
-		return success;
-	}
-	return false;
+	GDVIRTUAL_CALL(_can_handle, p_object, success);
+	return success;
 }
 
 void EditorInspectorPlugin::parse_begin(Object *p_object) {
@@ -1082,10 +1080,8 @@ void EditorInspectorPlugin::parse_group(Object *p_object, const String &p_group)
 
 bool EditorInspectorPlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide) {
 	bool ret = false;
-	if (GDVIRTUAL_CALL(_parse_property, p_object, p_type, p_path, p_hint, p_hint_text, p_usage, p_wide, ret)) {
-		return ret;
-	}
-	return false;
+	GDVIRTUAL_CALL(_parse_property, p_object, p_type, p_path, p_hint, p_hint_text, p_usage, p_wide, ret);
+	return ret;
 }
 
 void EditorInspectorPlugin::parse_end(Object *p_object) {

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -571,10 +571,8 @@ void EditorPlugin::notify_resource_saved(const Ref<Resource> &p_resource) {
 
 bool EditorPlugin::forward_canvas_gui_input(const Ref<InputEvent> &p_event) {
 	bool success = false;
-	if (GDVIRTUAL_CALL(_forward_canvas_gui_input, p_event, success)) {
-		return success;
-	}
-	return false;
+	GDVIRTUAL_CALL(_forward_canvas_gui_input, p_event, success);
+	return success;
 }
 
 void EditorPlugin::forward_canvas_draw_over_viewport(Control *p_overlay) {
@@ -606,12 +604,8 @@ int EditorPlugin::update_overlays() const {
 
 EditorPlugin::AfterGUIInput EditorPlugin::forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) {
 	int success = EditorPlugin::AFTER_GUI_INPUT_PASS;
-
-	if (GDVIRTUAL_CALL(_forward_3d_gui_input, p_camera, p_event, success)) {
-		return static_cast<EditorPlugin::AfterGUIInput>(success);
-	}
-
-	return EditorPlugin::AFTER_GUI_INPUT_PASS;
+	GDVIRTUAL_CALL(_forward_3d_gui_input, p_camera, p_event, success);
+	return static_cast<EditorPlugin::AfterGUIInput>(success);
 }
 
 void EditorPlugin::forward_3d_draw_over_viewport(Control *p_overlay) {
@@ -624,29 +618,20 @@ void EditorPlugin::forward_3d_force_draw_over_viewport(Control *p_overlay) {
 
 String EditorPlugin::get_name() const {
 	String name;
-	if (GDVIRTUAL_CALL(_get_plugin_name, name)) {
-		return name;
-	}
-
-	return String();
+	GDVIRTUAL_CALL(_get_plugin_name, name);
+	return name;
 }
 
 const Ref<Texture2D> EditorPlugin::get_icon() const {
 	Ref<Texture2D> icon;
-	if (GDVIRTUAL_CALL(_get_plugin_icon, icon)) {
-		return icon;
-	}
-
-	return Ref<Texture2D>();
+	GDVIRTUAL_CALL(_get_plugin_icon, icon);
+	return icon;
 }
 
 bool EditorPlugin::has_main_screen() const {
-	bool success;
-	if (GDVIRTUAL_CALL(_has_main_screen, success)) {
-		return success;
-	}
-
-	return false;
+	bool success = false;
+	GDVIRTUAL_CALL(_has_main_screen, success);
+	return success;
 }
 
 void EditorPlugin::make_visible(bool p_visible) {
@@ -663,20 +648,14 @@ void EditorPlugin::edit(Object *p_object) {
 
 bool EditorPlugin::handles(Object *p_object) const {
 	bool success = false;
-	if (GDVIRTUAL_CALL(_handles, p_object, success)) {
-		return success;
-	}
-
-	return false;
+	GDVIRTUAL_CALL(_handles, p_object, success);
+	return success;
 }
 
 Dictionary EditorPlugin::get_state() const {
 	Dictionary state;
-	if (GDVIRTUAL_CALL(_get_state, state)) {
-		return state;
-	}
-
-	return Dictionary();
+	GDVIRTUAL_CALL(_get_state, state);
+	return state;
 }
 
 void EditorPlugin::set_state(const Dictionary &p_state) {
@@ -822,11 +801,9 @@ void EditorPlugin::get_window_layout(Ref<ConfigFile> p_layout) {
 }
 
 bool EditorPlugin::build() {
-	bool success;
-	if (GDVIRTUAL_CALL(_build, success)) {
-		return success;
-	}
-	return true;
+	bool success = true;
+	GDVIRTUAL_CALL(_build, success);
+	return success;
 }
 
 void EditorPlugin::queue_save_layout() {

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -512,12 +512,9 @@ void EditorResourcePicker::set_create_options(Object *p_menu_node) {
 }
 
 bool EditorResourcePicker::handle_menu_selected(int p_which) {
-	bool success;
-	if (GDVIRTUAL_CALL(_handle_menu_selected, p_which, success)) {
-		return success;
-	}
-
-	return false;
+	bool success = false;
+	GDVIRTUAL_CALL(_handle_menu_selected, p_which, success);
+	return success;
 }
 
 void EditorResourcePicker::_button_draw() {

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -71,20 +71,14 @@ Ref<Texture2D> EditorResourcePreviewGenerator::generate_from_path(const String &
 
 bool EditorResourcePreviewGenerator::generate_small_preview_automatically() const {
 	bool success = false;
-	if (GDVIRTUAL_CALL(_generate_small_preview_automatically, success)) {
-		return success;
-	}
-
-	return false;
+	GDVIRTUAL_CALL(_generate_small_preview_automatically, success);
+	return success;
 }
 
 bool EditorResourcePreviewGenerator::can_generate_small_preview() const {
 	bool success = false;
-	if (GDVIRTUAL_CALL(_can_generate_small_preview, success)) {
-		return success;
-	}
-
-	return false;
+	GDVIRTUAL_CALL(_can_generate_small_preview, success);
+	return success;
 }
 
 void EditorResourcePreviewGenerator::_bind_methods() {

--- a/editor/export/editor_export_plugin.cpp
+++ b/editor/export/editor_export_plugin.cpp
@@ -142,10 +142,8 @@ void EditorExportPlugin::_export_end_script() {
 
 bool EditorExportPlugin::_begin_customize_resources(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) const {
 	bool ret = false;
-	if (GDVIRTUAL_CALL(_begin_customize_resources, p_platform, p_features, ret)) {
-		return ret;
-	}
-	return false;
+	GDVIRTUAL_CALL(_begin_customize_resources, p_platform, p_features, ret);
+	return ret;
 }
 
 Ref<Resource> EditorExportPlugin::_customize_resource(const Ref<Resource> &p_resource, const String &p_path) {
@@ -158,10 +156,8 @@ Ref<Resource> EditorExportPlugin::_customize_resource(const Ref<Resource> &p_res
 
 bool EditorExportPlugin::_begin_customize_scenes(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) const {
 	bool ret = false;
-	if (GDVIRTUAL_CALL(_begin_customize_scenes, p_platform, p_features, ret)) {
-		return ret;
-	}
-	return false;
+	GDVIRTUAL_CALL(_begin_customize_scenes, p_platform, p_features, ret);
+	return ret;
 }
 
 Node *EditorExportPlugin::_customize_scene(Node *p_root, const String &p_path) {

--- a/editor/plugins/editor_resource_conversion_plugin.cpp
+++ b/editor/plugins/editor_resource_conversion_plugin.cpp
@@ -38,27 +38,18 @@ void EditorResourceConversionPlugin::_bind_methods() {
 
 String EditorResourceConversionPlugin::converts_to() const {
 	String ret;
-	if (GDVIRTUAL_CALL(_converts_to, ret)) {
-		return ret;
-	}
-
-	return "";
+	GDVIRTUAL_CALL(_converts_to, ret);
+	return ret;
 }
 
 bool EditorResourceConversionPlugin::handles(const Ref<Resource> &p_resource) const {
 	bool ret = false;
-	if (GDVIRTUAL_CALL(_handles, p_resource, ret)) {
-		return ret;
-	}
-
-	return false;
+	GDVIRTUAL_CALL(_handles, p_resource, ret);
+	return ret;
 }
 
 Ref<Resource> EditorResourceConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<Resource> ret;
-	if (GDVIRTUAL_CALL(_convert, p_resource, ret)) {
-		return ret;
-	}
-
-	return Ref<Resource>();
+	GDVIRTUAL_CALL(_convert, p_resource, ret);
+	return ret;
 }

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -1078,11 +1078,9 @@ void EditorNode3DGizmoPlugin::_bind_methods() {
 }
 
 bool EditorNode3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
-	bool success;
-	if (GDVIRTUAL_CALL(_has_gizmo, p_spatial, success)) {
-		return success;
-	}
-	return false;
+	bool success = false;
+	GDVIRTUAL_CALL(_has_gizmo, p_spatial, success);
+	return success;
 }
 
 Ref<EditorNode3DGizmo> EditorNode3DGizmoPlugin::create_gizmo(Node3D *p_spatial) {
@@ -1099,19 +1097,15 @@ Ref<EditorNode3DGizmo> EditorNode3DGizmoPlugin::create_gizmo(Node3D *p_spatial) 
 }
 
 bool EditorNode3DGizmoPlugin::can_be_hidden() const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_can_be_hidden, ret)) {
-		return ret;
-	}
-	return true;
+	bool ret = true;
+	GDVIRTUAL_CALL(_can_be_hidden, ret);
+	return ret;
 }
 
 bool EditorNode3DGizmoPlugin::is_selectable_when_hidden() const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_is_selectable_when_hidden, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_is_selectable_when_hidden, ret);
+	return ret;
 }
 
 void EditorNode3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
@@ -1120,26 +1114,20 @@ void EditorNode3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 bool EditorNode3DGizmoPlugin::is_handle_highlighted(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const {
 	bool ret = false;
-	if (GDVIRTUAL_CALL(_is_handle_highlighted, Ref<EditorNode3DGizmo>(p_gizmo), p_id, p_secondary, ret)) {
-		return ret;
-	}
-	return false;
+	GDVIRTUAL_CALL(_is_handle_highlighted, Ref<EditorNode3DGizmo>(p_gizmo), p_id, p_secondary, ret);
+	return ret;
 }
 
 String EditorNode3DGizmoPlugin::get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const {
 	String ret;
-	if (GDVIRTUAL_CALL(_get_handle_name, Ref<EditorNode3DGizmo>(p_gizmo), p_id, p_secondary, ret)) {
-		return ret;
-	}
-	return "";
+	GDVIRTUAL_CALL(_get_handle_name, Ref<EditorNode3DGizmo>(p_gizmo), p_id, p_secondary, ret);
+	return ret;
 }
 
 Variant EditorNode3DGizmoPlugin::get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const {
 	Variant ret;
-	if (GDVIRTUAL_CALL(_get_handle_value, Ref<EditorNode3DGizmo>(p_gizmo), p_id, p_secondary, ret)) {
-		return ret;
-	}
-	return Variant();
+	GDVIRTUAL_CALL(_get_handle_value, Ref<EditorNode3DGizmo>(p_gizmo), p_id, p_secondary, ret);
+	return ret;
 }
 
 void EditorNode3DGizmoPlugin::set_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, Camera3D *p_camera, const Point2 &p_point) {
@@ -1152,10 +1140,8 @@ void EditorNode3DGizmoPlugin::commit_handle(const EditorNode3DGizmo *p_gizmo, in
 
 int EditorNode3DGizmoPlugin::subgizmos_intersect_ray(const EditorNode3DGizmo *p_gizmo, Camera3D *p_camera, const Vector2 &p_point) const {
 	int ret = -1;
-	if (GDVIRTUAL_CALL(_subgizmos_intersect_ray, Ref<EditorNode3DGizmo>(p_gizmo), p_camera, p_point, ret)) {
-		return ret;
-	}
-	return -1;
+	GDVIRTUAL_CALL(_subgizmos_intersect_ray, Ref<EditorNode3DGizmo>(p_gizmo), p_camera, p_point, ret);
+	return ret;
 }
 
 Vector<int> EditorNode3DGizmoPlugin::subgizmos_intersect_frustum(const EditorNode3DGizmo *p_gizmo, const Camera3D *p_camera, const Vector<Plane> &p_frustum) const {
@@ -1165,20 +1151,14 @@ Vector<int> EditorNode3DGizmoPlugin::subgizmos_intersect_frustum(const EditorNod
 		frustum[i] = p_frustum[i];
 	}
 	Vector<int> ret;
-	if (GDVIRTUAL_CALL(_subgizmos_intersect_frustum, Ref<EditorNode3DGizmo>(p_gizmo), p_camera, frustum, ret)) {
-		return ret;
-	}
-
-	return Vector<int>();
+	GDVIRTUAL_CALL(_subgizmos_intersect_frustum, Ref<EditorNode3DGizmo>(p_gizmo), p_camera, frustum, ret);
+	return ret;
 }
 
 Transform3D EditorNode3DGizmoPlugin::get_subgizmo_transform(const EditorNode3DGizmo *p_gizmo, int p_id) const {
 	Transform3D ret;
-	if (GDVIRTUAL_CALL(_get_subgizmo_transform, Ref<EditorNode3DGizmo>(p_gizmo), p_id, ret)) {
-		return ret;
-	}
-
-	return Transform3D();
+	GDVIRTUAL_CALL(_get_subgizmo_transform, Ref<EditorNode3DGizmo>(p_gizmo), p_id, ret);
+	return ret;
 }
 
 void EditorNode3DGizmoPlugin::set_subgizmo_transform(const EditorNode3DGizmo *p_gizmo, int p_id, Transform3D p_transform) {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -59,19 +59,15 @@
 /*** SYNTAX HIGHLIGHTER ****/
 
 String EditorSyntaxHighlighter::_get_name() const {
-	String ret;
-	if (GDVIRTUAL_CALL(_get_name, ret)) {
-		return ret;
-	}
-	return "Unnamed";
+	String ret = "Unnamed";
+	GDVIRTUAL_CALL(_get_name, ret);
+	return ret;
 }
 
 PackedStringArray EditorSyntaxHighlighter::_get_supported_languages() const {
 	PackedStringArray ret;
-	if (GDVIRTUAL_CALL(_get_supported_languages, ret)) {
-		return ret;
-	}
-	return PackedStringArray();
+	GDVIRTUAL_CALL(_get_supported_languages, ret);
+	return ret;
 }
 
 Ref<EditorSyntaxHighlighter> EditorSyntaxHighlighter::_create() const {

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -87,10 +87,8 @@ void VisualShaderNodePlugin::set_editor(VisualShaderEditor *p_editor) {
 
 Control *VisualShaderNodePlugin::create_editor(const Ref<Resource> &p_parent_resource, const Ref<VisualShaderNode> &p_node) {
 	Object *ret = nullptr;
-	if (GDVIRTUAL_CALL(_create_editor, p_parent_resource, p_node, ret)) {
-		return Object::cast_to<Control>(ret);
-	}
-	return nullptr;
+	GDVIRTUAL_CALL(_create_editor, p_parent_resource, p_node, ret);
+	return Object::cast_to<Control>(ret);
 }
 
 void VisualShaderNodePlugin::_bind_methods() {

--- a/modules/gltf/gltf_document_extension.cpp
+++ b/modules/gltf/gltf_document_extension.cpp
@@ -51,45 +51,35 @@ Error GLTFDocumentExtension::import_post(Ref<GLTFState> p_state, Node *p_root) {
 	ERR_FAIL_NULL_V(p_root, ERR_INVALID_PARAMETER);
 	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
 	int err = OK;
-	if (GDVIRTUAL_CALL(_import_post, p_state, p_root, err)) {
-		return Error(err);
-	}
-	return OK;
+	GDVIRTUAL_CALL(_import_post, p_state, p_root, err);
+	return Error(err);
 }
 
 Error GLTFDocumentExtension::import_preflight(Ref<GLTFState> p_state) {
 	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
 	int err = OK;
-	if (GDVIRTUAL_CALL(_import_preflight, p_state, err)) {
-		return Error(err);
-	}
-	return OK;
+	GDVIRTUAL_CALL(_import_preflight, p_state, err);
+	return Error(err);
 }
 
 Error GLTFDocumentExtension::import_post_parse(Ref<GLTFState> p_state) {
 	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
 	int err = OK;
-	if (GDVIRTUAL_CALL(_import_post_parse, p_state, err)) {
-		return Error(err);
-	}
-	return OK;
+	GDVIRTUAL_CALL(_import_post_parse, p_state, err);
+	return Error(err);
 }
 
 Error GLTFDocumentExtension::export_post(Ref<GLTFState> p_state) {
 	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
 	int err = OK;
-	if (GDVIRTUAL_CALL(_export_post, p_state, err)) {
-		return Error(err);
-	}
-	return OK;
+	GDVIRTUAL_CALL(_export_post, p_state, err);
+	return Error(err);
 }
 Error GLTFDocumentExtension::export_preflight(Node *p_root) {
 	ERR_FAIL_NULL_V(p_root, ERR_INVALID_PARAMETER);
 	int err = OK;
-	if (GDVIRTUAL_CALL(_export_preflight, p_root, err)) {
-		return Error(err);
-	}
-	return OK;
+	GDVIRTUAL_CALL(_export_preflight, p_root, err);
+	return Error(err);
 }
 
 Error GLTFDocumentExtension::import_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_dict, Node *p_node) {
@@ -97,10 +87,8 @@ Error GLTFDocumentExtension::import_node(Ref<GLTFState> p_state, Ref<GLTFNode> p
 	ERR_FAIL_NULL_V(p_gltf_node, ERR_INVALID_PARAMETER);
 	ERR_FAIL_NULL_V(p_node, ERR_INVALID_PARAMETER);
 	int err = OK;
-	if (GDVIRTUAL_CALL(_import_node, p_state, p_gltf_node, r_dict, p_node, err)) {
-		return Error(err);
-	}
-	return OK;
+	GDVIRTUAL_CALL(_import_node, p_state, p_gltf_node, r_dict, p_node, err);
+	return Error(err);
 }
 
 Error GLTFDocumentExtension::export_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_dict, Node *p_node) {
@@ -108,8 +96,6 @@ Error GLTFDocumentExtension::export_node(Ref<GLTFState> p_state, Ref<GLTFNode> p
 	ERR_FAIL_NULL_V(p_gltf_node, ERR_INVALID_PARAMETER);
 	ERR_FAIL_NULL_V(p_node, ERR_INVALID_PARAMETER);
 	int err = OK;
-	if (GDVIRTUAL_CALL(_export_node, p_state, p_gltf_node, r_dict, p_node, err)) {
-		return Error(err);
-	}
-	return OK;
+	GDVIRTUAL_CALL(_export_node, p_state, p_gltf_node, r_dict, p_node, err);
+	return Error(err);
 }

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -34,10 +34,8 @@
 
 AABB VisualInstance3D::get_aabb() const {
 	AABB ret;
-	if (GDVIRTUAL_CALL(_get_aabb, ret)) {
-		return ret;
-	}
-	return AABB();
+	GDVIRTUAL_CALL(_get_aabb, ret);
+	return ret;
 }
 
 AABB VisualInstance3D::get_transformed_aabb() const {

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -50,10 +50,8 @@ void AnimationNode::get_parameter_list(List<PropertyInfo> *r_list) const {
 
 Variant AnimationNode::get_parameter_default_value(const StringName &p_parameter) const {
 	Variant ret;
-	if (GDVIRTUAL_CALL(_get_parameter_default_value, p_parameter, ret)) {
-		return ret;
-	}
-	return Variant();
+	GDVIRTUAL_CALL(_get_parameter_default_value, p_parameter, ret);
+	return ret;
 }
 
 void AnimationNode::set_parameter(const StringName &p_name, const Variant &p_value) {
@@ -312,12 +310,9 @@ String AnimationNode::get_input_name(int p_input) {
 }
 
 String AnimationNode::get_caption() const {
-	String ret;
-	if (GDVIRTUAL_CALL(_get_caption, ret)) {
-		return ret;
-	}
-
-	return "Node";
+	String ret = "Node";
+	GDVIRTUAL_CALL(_get_caption, ret);
+	return ret;
 }
 
 void AnimationNode::add_input(const String &p_name) {
@@ -344,12 +339,9 @@ void AnimationNode::remove_input(int p_index) {
 }
 
 double AnimationNode::process(double p_time, bool p_seek, bool p_seek_root) {
-	double ret;
-	if (GDVIRTUAL_CALL(_process, p_time, p_seek, p_seek_root, ret)) {
-		return ret;
-	}
-
-	return 0;
+	double ret = 0;
+	GDVIRTUAL_CALL(_process, p_time, p_seek, p_seek_root, ret);
+	return ret;
 }
 
 void AnimationNode::set_filter_path(const NodePath &p_path, bool p_enable) {
@@ -373,12 +365,9 @@ bool AnimationNode::is_path_filtered(const NodePath &p_path) const {
 }
 
 bool AnimationNode::has_filter() const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_has_filter, ret)) {
-		return ret;
-	}
-
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_has_filter, ret);
+	return ret;
 }
 
 Array AnimationNode::_get_filters() const {
@@ -407,10 +396,8 @@ void AnimationNode::_validate_property(PropertyInfo &p_property) const {
 
 Ref<AnimationNode> AnimationNode::get_child_by_name(const StringName &p_name) {
 	Ref<AnimationNode> ret;
-	if (GDVIRTUAL_CALL(_get_child_by_name, p_name, ret)) {
-		return ret;
-	}
-	return Ref<AnimationNode>();
+	GDVIRTUAL_CALL(_get_child_by_name, p_name, ret);
+	return ret;
 }
 
 void AnimationNode::_bind_methods() {

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1558,10 +1558,8 @@ bool Control::is_minimum_size_adjust_blocked() const {
 
 Size2 Control::get_minimum_size() const {
 	Vector2 ms;
-	if (GDVIRTUAL_CALL(_get_minimum_size, ms)) {
-		return ms;
-	}
-	return Vector2();
+	GDVIRTUAL_CALL(_get_minimum_size, ms);
+	return ms;
 }
 
 void Control::set_custom_minimum_size(const Size2i &p_custom) {
@@ -1806,11 +1804,8 @@ Variant Control::get_drag_data(const Point2 &p_point) {
 	}
 
 	Variant dd;
-	if (GDVIRTUAL_CALL(_get_drag_data, p_point, dd)) {
-		return dd;
-	}
-
-	return Variant();
+	GDVIRTUAL_CALL(_get_drag_data, p_point, dd);
+	return dd;
 }
 
 bool Control::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
@@ -1822,10 +1817,8 @@ bool Control::can_drop_data(const Point2 &p_point, const Variant &p_data) const 
 	}
 
 	bool ret = false;
-	if (GDVIRTUAL_CALL(_can_drop_data, p_point, p_data, ret)) {
-		return ret;
-	}
-	return false;
+	GDVIRTUAL_CALL(_can_drop_data, p_point, p_data, ret);
+	return ret;
 }
 
 void Control::drop_data(const Point2 &p_point, const Variant &p_data) {
@@ -2732,11 +2725,8 @@ void Control::end_bulk_theme_override() {
 TypedArray<Vector2i> Control::structured_text_parser(TextServer::StructuredTextParser p_parser_type, const Array &p_args, const String &p_text) const {
 	if (p_parser_type == TextServer::STRUCTURED_TEXT_CUSTOM) {
 		TypedArray<Vector2i> ret;
-		if (GDVIRTUAL_CALL(_structured_text_parser, p_args, p_text, ret)) {
-			return ret;
-		} else {
-			return TypedArray<Vector2i>();
-		}
+		GDVIRTUAL_CALL(_structured_text_parser, p_args, p_text, ret);
+		return ret;
 	} else {
 		return TS->parse_structured_text(p_parser_type, p_args, p_text);
 	}
@@ -2821,10 +2811,8 @@ String Control::get_tooltip(const Point2 &p_pos) const {
 
 Control *Control::make_custom_tooltip(const String &p_text) const {
 	Object *ret = nullptr;
-	if (GDVIRTUAL_CALL(_make_custom_tooltip, p_text, ret)) {
-		return Object::cast_to<Control>(ret);
-	}
-	return nullptr;
+	GDVIRTUAL_CALL(_make_custom_tooltip, p_text, ret);
+	return Object::cast_to<Control>(ret);
 }
 
 // Base object overrides.

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1475,11 +1475,9 @@ void GraphEdit::force_connection_drag_end() {
 }
 
 bool GraphEdit::is_node_hover_valid(const StringName &p_from, const int p_from_port, const StringName &p_to, const int p_to_port) {
-	bool valid = false;
-	if (GDVIRTUAL_CALL(_is_node_hover_valid, p_from, p_from_port, p_to, p_to_port, valid)) {
-		return valid;
-	}
-	return true;
+	bool valid = true;
+	GDVIRTUAL_CALL(_is_node_hover_valid, p_from, p_from_port, p_to, p_to_port, valid);
+	return valid;
 }
 
 void GraphEdit::set_panning_scheme(PanningScheme p_scheme) {

--- a/scene/gui/rich_text_effect.cpp
+++ b/scene/gui/rich_text_effect.cpp
@@ -56,10 +56,8 @@ Variant RichTextEffect::get_bbcode() const {
 
 bool RichTextEffect::_process_effect_impl(Ref<CharFXTransform> p_cfx) {
 	bool return_value = false;
-	if (GDVIRTUAL_CALL(_process_custom_fx, p_cfx, return_value)) {
-		return return_value;
-	}
-	return false;
+	GDVIRTUAL_CALL(_process_custom_fx, p_cfx, return_value);
+	return return_value;
 }
 
 RichTextEffect::RichTextEffect() {

--- a/scene/main/multiplayer_api.cpp
+++ b/scene/main/multiplayer_api.cpp
@@ -329,11 +329,9 @@ void MultiplayerAPI::_bind_methods() {
 /// MultiplayerAPIExtension
 
 Error MultiplayerAPIExtension::poll() {
-	int err;
-	if (GDVIRTUAL_CALL(_poll, err)) {
-		return (Error)err;
-	}
-	return OK;
+	int err = OK;
+	GDVIRTUAL_CALL(_poll, err);
+	return (Error)err;
 }
 
 void MultiplayerAPIExtension::set_multiplayer_peer(const Ref<MultiplayerPeer> &p_peer) {
@@ -342,26 +340,20 @@ void MultiplayerAPIExtension::set_multiplayer_peer(const Ref<MultiplayerPeer> &p
 
 Ref<MultiplayerPeer> MultiplayerAPIExtension::get_multiplayer_peer() {
 	Ref<MultiplayerPeer> peer;
-	if (GDVIRTUAL_CALL(_get_multiplayer_peer, peer)) {
-		return peer;
-	}
-	return nullptr;
+	GDVIRTUAL_CALL(_get_multiplayer_peer, peer);
+	return peer;
 }
 
 int MultiplayerAPIExtension::get_unique_id() {
-	int id;
-	if (GDVIRTUAL_CALL(_get_unique_id, id)) {
-		return id;
-	}
-	return 1;
+	int id = 1;
+	GDVIRTUAL_CALL(_get_unique_id, id);
+	return id;
 }
 
 Vector<int> MultiplayerAPIExtension::get_peer_ids() {
 	Vector<int> ids;
-	if (GDVIRTUAL_CALL(_get_peer_ids, ids)) {
-		return ids;
-	}
-	return Vector<int>();
+	GDVIRTUAL_CALL(_get_peer_ids, ids);
+	return ids;
 }
 
 Error MultiplayerAPIExtension::rpcp(Object *p_obj, int p_peer_id, const StringName &p_method, const Variant **p_arg, int p_argcount) {
@@ -373,34 +365,26 @@ Error MultiplayerAPIExtension::rpcp(Object *p_obj, int p_peer_id, const StringNa
 		args.push_back(*p_arg[i]);
 	}
 	int ret = FAILED;
-	if (GDVIRTUAL_CALL(_rpc, p_peer_id, p_obj, p_method, args, ret)) {
-		return (Error)ret;
-	}
-	return FAILED;
+	GDVIRTUAL_CALL(_rpc, p_peer_id, p_obj, p_method, args, ret);
+	return (Error)ret;
 }
 
 int MultiplayerAPIExtension::get_remote_sender_id() {
 	int id = 0;
-	if (GDVIRTUAL_CALL(_get_remote_sender_id, id)) {
-		return id;
-	}
-	return 0;
+	GDVIRTUAL_CALL(_get_remote_sender_id, id);
+	return id;
 }
 
 Error MultiplayerAPIExtension::object_configuration_add(Object *p_object, Variant p_config) {
 	int err = ERR_UNAVAILABLE;
-	if (GDVIRTUAL_CALL(_object_configuration_add, p_object, p_config, err)) {
-		return (Error)err;
-	}
-	return ERR_UNAVAILABLE;
+	GDVIRTUAL_CALL(_object_configuration_add, p_object, p_config, err);
+	return (Error)err;
 }
 
 Error MultiplayerAPIExtension::object_configuration_remove(Object *p_object, Variant p_config) {
 	int err = ERR_UNAVAILABLE;
-	if (GDVIRTUAL_CALL(_object_configuration_remove, p_object, p_config, err)) {
-		return (Error)err;
-	}
-	return ERR_UNAVAILABLE;
+	GDVIRTUAL_CALL(_object_configuration_remove, p_object, p_config, err);
+	return (Error)err;
 }
 
 void MultiplayerAPIExtension::_bind_methods() {

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -107,18 +107,15 @@ Shader::Mode Material::get_shader_mode() const {
 }
 
 bool Material::_can_do_next_pass() const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_can_do_next_pass, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_can_do_next_pass, ret);
+	return ret;
 }
+
 bool Material::_can_use_render_priority() const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_can_use_render_priority, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_can_use_render_priority, ret);
+	return ret;
 }
 
 void Material::_bind_methods() {

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -43,12 +43,9 @@ float StyleBox::get_style_margin(Side p_side) const {
 }
 
 bool StyleBox::test_mask(const Point2 &p_point, const Rect2 &p_rect) const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_test_mask, p_point, p_rect, ret)) {
-		return ret;
-	}
-
-	return true;
+	bool ret = true;
+	GDVIRTUAL_CALL(_test_mask, p_point, p_rect, ret);
+	return ret;
 }
 
 void StyleBox::draw(RID p_canvas_item, const Rect2 &p_rect) const {
@@ -109,11 +106,8 @@ Point2 StyleBox::get_offset() const {
 
 Size2 StyleBox::get_center_size() const {
 	Size2 ret;
-	if (GDVIRTUAL_CALL(_get_center_size, ret)) {
-		return ret;
-	}
-
-	return Size2();
+	GDVIRTUAL_CALL(_get_center_size, ret);
+	return ret;
 }
 
 Rect2 StyleBox::get_draw_rect(const Rect2 &p_rect) const {

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -60,20 +60,14 @@ Size2 Texture2D::get_size() const {
 }
 
 bool Texture2D::is_pixel_opaque(int p_x, int p_y) const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_is_pixel_opaque, p_x, p_y, ret)) {
-		return ret;
-	}
-
-	return true;
+	bool ret = true;
+	GDVIRTUAL_CALL(_is_pixel_opaque, p_x, p_y, ret);
+	return ret;
 }
 bool Texture2D::has_alpha() const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_has_alpha, ret)) {
-		return ret;
-	}
-
-	return true;
+	bool ret = true;
+	GDVIRTUAL_CALL(_has_alpha, ret);
+	return ret;
 }
 
 void Texture2D::draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate, bool p_transpose) const {

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -456,11 +456,9 @@ void VisualShaderNodeCustom::update_ports() {
 }
 
 String VisualShaderNodeCustom::get_caption() const {
-	String ret;
-	if (GDVIRTUAL_CALL(_get_name, ret)) {
-		return ret;
-	}
-	return "Unnamed";
+	String ret = "Unnamed";
+	GDVIRTUAL_CALL(_get_name, ret);
+	return ret;
 }
 
 int VisualShaderNodeCustom::get_input_port_count() const {
@@ -559,11 +557,9 @@ String VisualShaderNodeCustom::generate_global_per_func(Shader::Mode p_mode, Vis
 }
 
 bool VisualShaderNodeCustom::is_available(Shader::Mode p_mode, VisualShader::Type p_type) const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_is_available, p_mode, p_type, ret)) {
-		return ret;
-	}
-	return true;
+	bool ret = true;
+	GDVIRTUAL_CALL(_is_available, p_mode, p_type, ret);
+	return ret;
 }
 
 void VisualShaderNodeCustom::set_input_port_default_value(int p_port, const Variant &p_value, const Variant &p_prev_value) {

--- a/servers/audio/audio_effect.cpp
+++ b/servers/audio/audio_effect.cpp
@@ -36,11 +36,9 @@ void AudioEffectInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_
 	}
 }
 bool AudioEffectInstance::process_silence() const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_process_silence, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_process_silence, ret);
+	return ret;
 }
 
 void AudioEffectInstance::_bind_methods() {

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -54,11 +54,9 @@ bool AudioStreamPlayback::is_playing() const {
 }
 
 int AudioStreamPlayback::get_loop_count() const {
-	int ret;
-	if (GDVIRTUAL_CALL(_get_loop_count, ret)) {
-		return ret;
-	}
-	return 0;
+	int ret = 0;
+	GDVIRTUAL_CALL(_get_loop_count, ret);
+	return ret;
 }
 
 double AudioStreamPlayback::get_playback_position() const {
@@ -69,9 +67,7 @@ double AudioStreamPlayback::get_playback_position() const {
 	ERR_FAIL_V_MSG(0, "AudioStreamPlayback::get_playback_position unimplemented!");
 }
 void AudioStreamPlayback::seek(double p_time) {
-	if (GDVIRTUAL_CALL(_seek, p_time)) {
-		return;
-	}
+	GDVIRTUAL_CALL(_seek, p_time);
 }
 
 int AudioStreamPlayback::mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) {
@@ -201,58 +197,44 @@ Ref<AudioStreamPlayback> AudioStream::instantiate_playback() {
 }
 String AudioStream::get_stream_name() const {
 	String ret;
-	if (GDVIRTUAL_CALL(_get_stream_name, ret)) {
-		return ret;
-	}
-	return String();
+	GDVIRTUAL_CALL(_get_stream_name, ret);
+	return ret;
 }
 
 double AudioStream::get_length() const {
-	double ret;
-	if (GDVIRTUAL_CALL(_get_length, ret)) {
-		return ret;
-	}
-	return 0;
+	double ret = 0;
+	GDVIRTUAL_CALL(_get_length, ret);
+	return ret;
 }
 
 bool AudioStream::is_monophonic() const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_is_monophonic, ret)) {
-		return ret;
-	}
-	return true;
+	bool ret = true;
+	GDVIRTUAL_CALL(_is_monophonic, ret);
+	return ret;
 }
 
 double AudioStream::get_bpm() const {
 	double ret = 0;
-	if (GDVIRTUAL_CALL(_get_bpm, ret)) {
-		return ret;
-	}
-	return 0;
+	GDVIRTUAL_CALL(_get_bpm, ret);
+	return ret;
 }
 
 bool AudioStream::has_loop() const {
 	bool ret = 0;
-	if (GDVIRTUAL_CALL(_has_loop, ret)) {
-		return ret;
-	}
-	return 0;
+	GDVIRTUAL_CALL(_has_loop, ret);
+	return ret;
 }
 
 int AudioStream::get_bar_beats() const {
 	int ret = 0;
-	if (GDVIRTUAL_CALL(_get_bar_beats, ret)) {
-		return ret;
-	}
-	return 0;
+	GDVIRTUAL_CALL(_get_bar_beats, ret);
+	return ret;
 }
 
 int AudioStream::get_beat_count() const {
 	int ret = 0;
-	if (GDVIRTUAL_CALL(_get_beat_count, ret)) {
-		return ret;
-	}
-	return 0;
+	GDVIRTUAL_CALL(_get_beat_count, ret);
+	return ret;
 }
 
 void AudioStream::tag_used(float p_offset) {

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -311,27 +311,21 @@ void TextServerExtension::_bind_methods() {
 }
 
 bool TextServerExtension::has_feature(Feature p_feature) const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_has_feature, p_feature, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_has_feature, p_feature, ret);
+	return ret;
 }
 
 String TextServerExtension::get_name() const {
-	String ret;
-	if (GDVIRTUAL_CALL(_get_name, ret)) {
-		return ret;
-	}
-	return "Unknown";
+	String ret = "Unknown";
+	GDVIRTUAL_CALL(_get_name, ret);
+	return ret;
 }
 
 int64_t TextServerExtension::get_features() const {
-	int64_t ret;
-	if (GDVIRTUAL_CALL(_get_features, ret)) {
-		return ret;
-	}
-	return 0;
+	int64_t ret = 0;
+	GDVIRTUAL_CALL(_get_features, ret);
+	return ret;
 }
 
 void TextServerExtension::free_rid(const RID &p_rid) {
@@ -339,67 +333,51 @@ void TextServerExtension::free_rid(const RID &p_rid) {
 }
 
 bool TextServerExtension::has(const RID &p_rid) {
-	bool ret;
-	if (GDVIRTUAL_CALL(_has, p_rid, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_has, p_rid, ret);
+	return ret;
 }
 
 bool TextServerExtension::load_support_data(const String &p_filename) {
-	bool ret;
-	if (GDVIRTUAL_CALL(_load_support_data, p_filename, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_load_support_data, p_filename, ret);
+	return ret;
 }
 
 String TextServerExtension::get_support_data_filename() const {
 	String ret;
-	if (GDVIRTUAL_CALL(_get_support_data_filename, ret)) {
-		return ret;
-	}
-	return String();
+	GDVIRTUAL_CALL(_get_support_data_filename, ret);
+	return ret;
 }
 
 String TextServerExtension::get_support_data_info() const {
 	String ret;
-	if (GDVIRTUAL_CALL(_get_support_data_info, ret)) {
-		return ret;
-	}
-	return String();
+	GDVIRTUAL_CALL(_get_support_data_info, ret);
+	return ret;
 }
 
 bool TextServerExtension::save_support_data(const String &p_filename) const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_save_support_data, p_filename, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_save_support_data, p_filename, ret);
+	return ret;
 }
 
 bool TextServerExtension::is_locale_right_to_left(const String &p_locale) const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_is_locale_right_to_left, p_locale, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_is_locale_right_to_left, p_locale, ret);
+	return ret;
 }
 
 int64_t TextServerExtension::name_to_tag(const String &p_name) const {
-	int64_t ret;
-	if (GDVIRTUAL_CALL(_name_to_tag, p_name, ret)) {
-		return ret;
-	}
-	return 0;
+	int64_t ret = 0;
+	GDVIRTUAL_CALL(_name_to_tag, p_name, ret);
+	return ret;
 }
 
 String TextServerExtension::tag_to_name(int64_t p_tag) const {
 	String ret;
-	if (GDVIRTUAL_CALL(_tag_to_name, p_tag, ret)) {
-		return ret;
-	}
-	return "";
+	GDVIRTUAL_CALL(_tag_to_name, p_tag, ret);
+	return ret;
 }
 
 /*************************************************************************/
@@ -408,10 +386,8 @@ String TextServerExtension::tag_to_name(int64_t p_tag) const {
 
 RID TextServerExtension::create_font() {
 	RID ret;
-	if (GDVIRTUAL_CALL(_create_font, ret)) {
-		return ret;
-	}
-	return RID();
+	GDVIRTUAL_CALL(_create_font, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_data(const RID &p_font_rid, const PackedByteArray &p_data) {
@@ -427,19 +403,15 @@ void TextServerExtension::font_set_face_index(const RID &p_font_rid, int64_t p_i
 }
 
 int64_t TextServerExtension::font_get_face_index(const RID &p_font_rid) const {
-	int64_t ret;
-	if (GDVIRTUAL_CALL(_font_get_face_index, p_font_rid, ret)) {
-		return ret;
-	}
-	return 0;
+	int64_t ret = 0;
+	GDVIRTUAL_CALL(_font_get_face_index, p_font_rid, ret);
+	return ret;
 }
 
 int64_t TextServerExtension::font_get_face_count(const RID &p_font_rid) const {
-	int64_t ret;
-	if (GDVIRTUAL_CALL(_font_get_face_count, p_font_rid, ret)) {
-		return ret;
-	}
-	return 0;
+	int64_t ret = 0;
+	GDVIRTUAL_CALL(_font_get_face_count, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_style(const RID &p_font_rid, BitField<TextServer::FontStyle> p_style) {
@@ -448,10 +420,8 @@ void TextServerExtension::font_set_style(const RID &p_font_rid, BitField<TextSer
 
 BitField<TextServer::FontStyle> TextServerExtension::font_get_style(const RID &p_font_rid) const {
 	BitField<TextServer::FontStyle> ret = 0;
-	if (GDVIRTUAL_CALL(_font_get_style, p_font_rid, ret)) {
-		return ret;
-	}
-	return 0;
+	GDVIRTUAL_CALL(_font_get_style, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_style_name(const RID &p_font_rid, const String &p_name) {
@@ -460,10 +430,8 @@ void TextServerExtension::font_set_style_name(const RID &p_font_rid, const Strin
 
 String TextServerExtension::font_get_style_name(const RID &p_font_rid) const {
 	String ret;
-	if (GDVIRTUAL_CALL(_font_get_style_name, p_font_rid, ret)) {
-		return ret;
-	}
-	return String();
+	GDVIRTUAL_CALL(_font_get_style_name, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_name(const RID &p_font_rid, const String &p_name) {
@@ -472,10 +440,8 @@ void TextServerExtension::font_set_name(const RID &p_font_rid, const String &p_n
 
 String TextServerExtension::font_get_name(const RID &p_font_rid) const {
 	String ret;
-	if (GDVIRTUAL_CALL(_font_get_name, p_font_rid, ret)) {
-		return ret;
-	}
-	return String();
+	GDVIRTUAL_CALL(_font_get_name, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_antialiasing(const RID &p_font_rid, TextServer::FontAntialiasing p_antialiasing) {
@@ -483,11 +449,9 @@ void TextServerExtension::font_set_antialiasing(const RID &p_font_rid, TextServe
 }
 
 TextServer::FontAntialiasing TextServerExtension::font_get_antialiasing(const RID &p_font_rid) const {
-	TextServer::FontAntialiasing ret;
-	if (GDVIRTUAL_CALL(_font_get_antialiasing, p_font_rid, ret)) {
-		return ret;
-	}
-	return TextServer::FONT_ANTIALIASING_NONE;
+	TextServer::FontAntialiasing ret = TextServer::FONT_ANTIALIASING_NONE;
+	GDVIRTUAL_CALL(_font_get_antialiasing, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_generate_mipmaps(const RID &p_font_rid, bool p_generate_mipmaps) {
@@ -495,11 +459,9 @@ void TextServerExtension::font_set_generate_mipmaps(const RID &p_font_rid, bool 
 }
 
 bool TextServerExtension::font_get_generate_mipmaps(const RID &p_font_rid) const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_font_get_generate_mipmaps, p_font_rid, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_font_get_generate_mipmaps, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_multichannel_signed_distance_field(const RID &p_font_rid, bool p_msdf) {
@@ -507,11 +469,9 @@ void TextServerExtension::font_set_multichannel_signed_distance_field(const RID 
 }
 
 bool TextServerExtension::font_is_multichannel_signed_distance_field(const RID &p_font_rid) const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_font_is_multichannel_signed_distance_field, p_font_rid, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_font_is_multichannel_signed_distance_field, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_msdf_pixel_range(const RID &p_font_rid, int64_t p_msdf_pixel_range) {
@@ -519,11 +479,9 @@ void TextServerExtension::font_set_msdf_pixel_range(const RID &p_font_rid, int64
 }
 
 int64_t TextServerExtension::font_get_msdf_pixel_range(const RID &p_font_rid) const {
-	int64_t ret;
-	if (GDVIRTUAL_CALL(_font_get_msdf_pixel_range, p_font_rid, ret)) {
-		return ret;
-	}
-	return 0;
+	int64_t ret = 0;
+	GDVIRTUAL_CALL(_font_get_msdf_pixel_range, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_msdf_size(const RID &p_font_rid, int64_t p_msdf_size) {
@@ -531,11 +489,9 @@ void TextServerExtension::font_set_msdf_size(const RID &p_font_rid, int64_t p_ms
 }
 
 int64_t TextServerExtension::font_get_msdf_size(const RID &p_font_rid) const {
-	int64_t ret;
-	if (GDVIRTUAL_CALL(_font_get_msdf_size, p_font_rid, ret)) {
-		return ret;
-	}
-	return 0;
+	int64_t ret = 0;
+	GDVIRTUAL_CALL(_font_get_msdf_size, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_fixed_size(const RID &p_font_rid, int64_t p_fixed_size) {
@@ -543,11 +499,9 @@ void TextServerExtension::font_set_fixed_size(const RID &p_font_rid, int64_t p_f
 }
 
 int64_t TextServerExtension::font_get_fixed_size(const RID &p_font_rid) const {
-	int64_t ret;
-	if (GDVIRTUAL_CALL(_font_get_fixed_size, p_font_rid, ret)) {
-		return ret;
-	}
-	return 0;
+	int64_t ret = 0;
+	GDVIRTUAL_CALL(_font_get_fixed_size, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_force_autohinter(const RID &p_font_rid, bool p_force_autohinter) {
@@ -555,11 +509,9 @@ void TextServerExtension::font_set_force_autohinter(const RID &p_font_rid, bool 
 }
 
 bool TextServerExtension::font_is_force_autohinter(const RID &p_font_rid) const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_font_is_force_autohinter, p_font_rid, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_font_is_force_autohinter, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_hinting(const RID &p_font_rid, TextServer::Hinting p_hinting) {
@@ -567,11 +519,9 @@ void TextServerExtension::font_set_hinting(const RID &p_font_rid, TextServer::Hi
 }
 
 TextServer::Hinting TextServerExtension::font_get_hinting(const RID &p_font_rid) const {
-	TextServer::Hinting ret;
-	if (GDVIRTUAL_CALL(_font_get_hinting, p_font_rid, ret)) {
-		return (TextServer::Hinting)ret;
-	}
-	return TextServer::Hinting::HINTING_NONE;
+	TextServer::Hinting ret = TextServer::HINTING_NONE;
+	GDVIRTUAL_CALL(_font_get_hinting, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_subpixel_positioning(const RID &p_font_rid, TextServer::SubpixelPositioning p_subpixel) {
@@ -579,11 +529,9 @@ void TextServerExtension::font_set_subpixel_positioning(const RID &p_font_rid, T
 }
 
 TextServer::SubpixelPositioning TextServerExtension::font_get_subpixel_positioning(const RID &p_font_rid) const {
-	TextServer::SubpixelPositioning ret;
-	if (GDVIRTUAL_CALL(_font_get_subpixel_positioning, p_font_rid, ret)) {
-		return (TextServer::SubpixelPositioning)ret;
-	}
-	return TextServer::SubpixelPositioning::SUBPIXEL_POSITIONING_DISABLED;
+	TextServer::SubpixelPositioning ret = TextServer::SUBPIXEL_POSITIONING_DISABLED;
+	GDVIRTUAL_CALL(_font_get_subpixel_positioning, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_embolden(const RID &p_font_rid, double p_strength) {
@@ -591,11 +539,9 @@ void TextServerExtension::font_set_embolden(const RID &p_font_rid, double p_stre
 }
 
 double TextServerExtension::font_get_embolden(const RID &p_font_rid) const {
-	double ret;
-	if (GDVIRTUAL_CALL(_font_get_embolden, p_font_rid, ret)) {
-		return ret;
-	}
-	return 0.0;
+	double ret = 0;
+	GDVIRTUAL_CALL(_font_get_embolden, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_transform(const RID &p_font_rid, const Transform2D &p_transform) {
@@ -604,10 +550,8 @@ void TextServerExtension::font_set_transform(const RID &p_font_rid, const Transf
 
 Transform2D TextServerExtension::font_get_transform(const RID &p_font_rid) const {
 	Transform2D ret;
-	if (GDVIRTUAL_CALL(_font_get_transform, p_font_rid, ret)) {
-		return ret;
-	}
-	return Transform2D();
+	GDVIRTUAL_CALL(_font_get_transform, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_variation_coordinates(const RID &p_font_rid, const Dictionary &p_variation_coordinates) {
@@ -616,10 +560,8 @@ void TextServerExtension::font_set_variation_coordinates(const RID &p_font_rid, 
 
 Dictionary TextServerExtension::font_get_variation_coordinates(const RID &p_font_rid) const {
 	Dictionary ret;
-	if (GDVIRTUAL_CALL(_font_get_variation_coordinates, p_font_rid, ret)) {
-		return ret;
-	}
-	return Dictionary();
+	GDVIRTUAL_CALL(_font_get_variation_coordinates, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_oversampling(const RID &p_font_rid, double p_oversampling) {
@@ -627,19 +569,15 @@ void TextServerExtension::font_set_oversampling(const RID &p_font_rid, double p_
 }
 
 double TextServerExtension::font_get_oversampling(const RID &p_font_rid) const {
-	double ret;
-	if (GDVIRTUAL_CALL(_font_get_oversampling, p_font_rid, ret)) {
-		return ret;
-	}
-	return 0.0;
+	double ret = 0;
+	GDVIRTUAL_CALL(_font_get_oversampling, p_font_rid, ret);
+	return ret;
 }
 
 TypedArray<Vector2i> TextServerExtension::font_get_size_cache_list(const RID &p_font_rid) const {
 	TypedArray<Vector2i> ret;
-	if (GDVIRTUAL_CALL(_font_get_size_cache_list, p_font_rid, ret)) {
-		return ret;
-	}
-	return TypedArray<Vector2i>();
+	GDVIRTUAL_CALL(_font_get_size_cache_list, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_clear_size_cache(const RID &p_font_rid) {
@@ -655,11 +593,9 @@ void TextServerExtension::font_set_ascent(const RID &p_font_rid, int64_t p_size,
 }
 
 double TextServerExtension::font_get_ascent(const RID &p_font_rid, int64_t p_size) const {
-	double ret;
-	if (GDVIRTUAL_CALL(_font_get_ascent, p_font_rid, p_size, ret)) {
-		return ret;
-	}
-	return 0.0;
+	double ret = 0;
+	GDVIRTUAL_CALL(_font_get_ascent, p_font_rid, p_size, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_descent(const RID &p_font_rid, int64_t p_size, double p_descent) {
@@ -667,11 +603,9 @@ void TextServerExtension::font_set_descent(const RID &p_font_rid, int64_t p_size
 }
 
 double TextServerExtension::font_get_descent(const RID &p_font_rid, int64_t p_size) const {
-	double ret;
-	if (GDVIRTUAL_CALL(_font_get_descent, p_font_rid, p_size, ret)) {
-		return ret;
-	}
-	return 0.0;
+	double ret = 0;
+	GDVIRTUAL_CALL(_font_get_descent, p_font_rid, p_size, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_underline_position(const RID &p_font_rid, int64_t p_size, double p_underline_position) {
@@ -679,11 +613,9 @@ void TextServerExtension::font_set_underline_position(const RID &p_font_rid, int
 }
 
 double TextServerExtension::font_get_underline_position(const RID &p_font_rid, int64_t p_size) const {
-	double ret;
-	if (GDVIRTUAL_CALL(_font_get_underline_position, p_font_rid, p_size, ret)) {
-		return ret;
-	}
-	return 0.0;
+	double ret = 0;
+	GDVIRTUAL_CALL(_font_get_underline_position, p_font_rid, p_size, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_underline_thickness(const RID &p_font_rid, int64_t p_size, double p_underline_thickness) {
@@ -691,11 +623,9 @@ void TextServerExtension::font_set_underline_thickness(const RID &p_font_rid, in
 }
 
 double TextServerExtension::font_get_underline_thickness(const RID &p_font_rid, int64_t p_size) const {
-	double ret;
-	if (GDVIRTUAL_CALL(_font_get_underline_thickness, p_font_rid, p_size, ret)) {
-		return ret;
-	}
-	return 0.0;
+	double ret = 0;
+	GDVIRTUAL_CALL(_font_get_underline_thickness, p_font_rid, p_size, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_scale(const RID &p_font_rid, int64_t p_size, double p_scale) {
@@ -703,19 +633,15 @@ void TextServerExtension::font_set_scale(const RID &p_font_rid, int64_t p_size, 
 }
 
 double TextServerExtension::font_get_scale(const RID &p_font_rid, int64_t p_size) const {
-	double ret;
-	if (GDVIRTUAL_CALL(_font_get_scale, p_font_rid, p_size, ret)) {
-		return ret;
-	}
-	return 0.0;
+	double ret = 0;
+	GDVIRTUAL_CALL(_font_get_scale, p_font_rid, p_size, ret);
+	return ret;
 }
 
 int64_t TextServerExtension::font_get_texture_count(const RID &p_font_rid, const Vector2i &p_size) const {
-	int64_t ret;
-	if (GDVIRTUAL_CALL(_font_get_texture_count, p_font_rid, p_size, ret)) {
-		return ret;
-	}
-	return 0;
+	int64_t ret = 0;
+	GDVIRTUAL_CALL(_font_get_texture_count, p_font_rid, p_size, ret);
+	return ret;
 }
 
 void TextServerExtension::font_clear_textures(const RID &p_font_rid, const Vector2i &p_size) {
@@ -732,10 +658,8 @@ void TextServerExtension::font_set_texture_image(const RID &p_font_rid, const Ve
 
 Ref<Image> TextServerExtension::font_get_texture_image(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) const {
 	Ref<Image> ret;
-	if (GDVIRTUAL_CALL(_font_get_texture_image, p_font_rid, p_size, p_texture_index, ret)) {
-		return ret;
-	}
-	return Ref<Image>();
+	GDVIRTUAL_CALL(_font_get_texture_image, p_font_rid, p_size, p_texture_index, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_texture_offsets(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index, const PackedInt32Array &p_offset) {
@@ -744,18 +668,14 @@ void TextServerExtension::font_set_texture_offsets(const RID &p_font_rid, const 
 
 PackedInt32Array TextServerExtension::font_get_texture_offsets(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) const {
 	PackedInt32Array ret;
-	if (GDVIRTUAL_CALL(_font_get_texture_offsets, p_font_rid, p_size, p_texture_index, ret)) {
-		return ret;
-	}
-	return PackedInt32Array();
+	GDVIRTUAL_CALL(_font_get_texture_offsets, p_font_rid, p_size, p_texture_index, ret);
+	return ret;
 }
 
 PackedInt32Array TextServerExtension::font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const {
 	PackedInt32Array ret;
-	if (GDVIRTUAL_CALL(_font_get_glyph_list, p_font_rid, p_size, ret)) {
-		return ret;
-	}
-	return PackedInt32Array();
+	GDVIRTUAL_CALL(_font_get_glyph_list, p_font_rid, p_size, ret);
+	return ret;
 }
 
 void TextServerExtension::font_clear_glyphs(const RID &p_font_rid, const Vector2i &p_size) {
@@ -768,10 +688,8 @@ void TextServerExtension::font_remove_glyph(const RID &p_font_rid, const Vector2
 
 Vector2 TextServerExtension::font_get_glyph_advance(const RID &p_font_rid, int64_t p_size, int64_t p_glyph) const {
 	Vector2 ret;
-	if (GDVIRTUAL_CALL(_font_get_glyph_advance, p_font_rid, p_size, p_glyph, ret)) {
-		return ret;
-	}
-	return Vector2();
+	GDVIRTUAL_CALL(_font_get_glyph_advance, p_font_rid, p_size, p_glyph, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_glyph_advance(const RID &p_font_rid, int64_t p_size, int64_t p_glyph, const Vector2 &p_advance) {
@@ -780,10 +698,8 @@ void TextServerExtension::font_set_glyph_advance(const RID &p_font_rid, int64_t 
 
 Vector2 TextServerExtension::font_get_glyph_offset(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
 	Vector2 ret;
-	if (GDVIRTUAL_CALL(_font_get_glyph_offset, p_font_rid, p_size, p_glyph, ret)) {
-		return ret;
-	}
-	return Vector2();
+	GDVIRTUAL_CALL(_font_get_glyph_offset, p_font_rid, p_size, p_glyph, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_glyph_offset(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Vector2 &p_offset) {
@@ -792,10 +708,8 @@ void TextServerExtension::font_set_glyph_offset(const RID &p_font_rid, const Vec
 
 Vector2 TextServerExtension::font_get_glyph_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
 	Vector2 ret;
-	if (GDVIRTUAL_CALL(_font_get_glyph_size, p_font_rid, p_size, p_glyph, ret)) {
-		return ret;
-	}
-	return Vector2();
+	GDVIRTUAL_CALL(_font_get_glyph_size, p_font_rid, p_size, p_glyph, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_glyph_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Vector2 &p_gl_size) {
@@ -804,10 +718,8 @@ void TextServerExtension::font_set_glyph_size(const RID &p_font_rid, const Vecto
 
 Rect2 TextServerExtension::font_get_glyph_uv_rect(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
 	Rect2 ret;
-	if (GDVIRTUAL_CALL(_font_get_glyph_uv_rect, p_font_rid, p_size, p_glyph, ret)) {
-		return ret;
-	}
-	return Rect2();
+	GDVIRTUAL_CALL(_font_get_glyph_uv_rect, p_font_rid, p_size, p_glyph, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_glyph_uv_rect(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Rect2 &p_uv_rect) {
@@ -815,11 +727,9 @@ void TextServerExtension::font_set_glyph_uv_rect(const RID &p_font_rid, const Ve
 }
 
 int64_t TextServerExtension::font_get_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
-	int64_t ret;
-	if (GDVIRTUAL_CALL(_font_get_glyph_texture_idx, p_font_rid, p_size, p_glyph, ret)) {
-		return ret;
-	}
-	return 0;
+	int64_t ret = 0;
+	GDVIRTUAL_CALL(_font_get_glyph_texture_idx, p_font_rid, p_size, p_glyph, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, int64_t p_texture_idx) {
@@ -828,34 +738,26 @@ void TextServerExtension::font_set_glyph_texture_idx(const RID &p_font_rid, cons
 
 RID TextServerExtension::font_get_glyph_texture_rid(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
 	RID ret;
-	if (GDVIRTUAL_CALL(_font_get_glyph_texture_rid, p_font_rid, p_size, p_glyph, ret)) {
-		return ret;
-	}
-	return RID();
+	GDVIRTUAL_CALL(_font_get_glyph_texture_rid, p_font_rid, p_size, p_glyph, ret);
+	return ret;
 }
 
 Size2 TextServerExtension::font_get_glyph_texture_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
 	Size2 ret;
-	if (GDVIRTUAL_CALL(_font_get_glyph_texture_size, p_font_rid, p_size, p_glyph, ret)) {
-		return ret;
-	}
-	return Size2();
+	GDVIRTUAL_CALL(_font_get_glyph_texture_size, p_font_rid, p_size, p_glyph, ret);
+	return ret;
 }
 
 Dictionary TextServerExtension::font_get_glyph_contours(const RID &p_font_rid, int64_t p_size, int64_t p_index) const {
 	Dictionary ret;
-	if (GDVIRTUAL_CALL(_font_get_glyph_contours, p_font_rid, p_size, p_index, ret)) {
-		return ret;
-	}
-	return Dictionary();
+	GDVIRTUAL_CALL(_font_get_glyph_contours, p_font_rid, p_size, p_index, ret);
+	return ret;
 }
 
 TypedArray<Vector2i> TextServerExtension::font_get_kerning_list(const RID &p_font_rid, int64_t p_size) const {
 	TypedArray<Vector2i> ret;
-	if (GDVIRTUAL_CALL(_font_get_kerning_list, p_font_rid, p_size, ret)) {
-		return ret;
-	}
-	return TypedArray<Vector2i>();
+	GDVIRTUAL_CALL(_font_get_kerning_list, p_font_rid, p_size, ret);
+	return ret;
 }
 
 void TextServerExtension::font_clear_kerning_map(const RID &p_font_rid, int64_t p_size) {
@@ -872,34 +774,26 @@ void TextServerExtension::font_set_kerning(const RID &p_font_rid, int64_t p_size
 
 Vector2 TextServerExtension::font_get_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair) const {
 	Vector2 ret;
-	if (GDVIRTUAL_CALL(_font_get_kerning, p_font_rid, p_size, p_glyph_pair, ret)) {
-		return ret;
-	}
-	return Vector2();
+	GDVIRTUAL_CALL(_font_get_kerning, p_font_rid, p_size, p_glyph_pair, ret);
+	return ret;
 }
 
 int64_t TextServerExtension::font_get_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_char, int64_t p_variation_selector) const {
-	int64_t ret;
-	if (GDVIRTUAL_CALL(_font_get_glyph_index, p_font_rid, p_size, p_char, p_variation_selector, ret)) {
-		return ret;
-	}
-	return 0;
+	int64_t ret = 0;
+	GDVIRTUAL_CALL(_font_get_glyph_index, p_font_rid, p_size, p_char, p_variation_selector, ret);
+	return ret;
 }
 
 bool TextServerExtension::font_has_char(const RID &p_font_rid, int64_t p_char) const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_font_has_char, p_font_rid, p_char, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_font_has_char, p_font_rid, p_char, ret);
+	return ret;
 }
 
 String TextServerExtension::font_get_supported_chars(const RID &p_font_rid) const {
 	String ret;
-	if (GDVIRTUAL_CALL(_font_get_supported_chars, p_font_rid, ret)) {
-		return ret;
-	}
-	return String();
+	GDVIRTUAL_CALL(_font_get_supported_chars, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_render_range(const RID &p_font_rid, const Vector2i &p_size, int64_t p_start, int64_t p_end) {
@@ -919,11 +813,9 @@ void TextServerExtension::font_draw_glyph_outline(const RID &p_font_rid, const R
 }
 
 bool TextServerExtension::font_is_language_supported(const RID &p_font_rid, const String &p_language) const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_font_is_language_supported, p_font_rid, p_language, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_font_is_language_supported, p_font_rid, p_language, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_language_support_override(const RID &p_font_rid, const String &p_language, bool p_supported) {
@@ -931,11 +823,9 @@ void TextServerExtension::font_set_language_support_override(const RID &p_font_r
 }
 
 bool TextServerExtension::font_get_language_support_override(const RID &p_font_rid, const String &p_language) {
-	bool ret;
-	if (GDVIRTUAL_CALL(_font_get_language_support_override, p_font_rid, p_language, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_font_get_language_support_override, p_font_rid, p_language, ret);
+	return ret;
 }
 
 void TextServerExtension::font_remove_language_support_override(const RID &p_font_rid, const String &p_language) {
@@ -944,18 +834,14 @@ void TextServerExtension::font_remove_language_support_override(const RID &p_fon
 
 PackedStringArray TextServerExtension::font_get_language_support_overrides(const RID &p_font_rid) {
 	PackedStringArray ret;
-	if (GDVIRTUAL_CALL(_font_get_language_support_overrides, p_font_rid, ret)) {
-		return ret;
-	}
-	return PackedStringArray();
+	GDVIRTUAL_CALL(_font_get_language_support_overrides, p_font_rid, ret);
+	return ret;
 }
 
 bool TextServerExtension::font_is_script_supported(const RID &p_font_rid, const String &p_script) const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_font_is_script_supported, p_font_rid, p_script, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_font_is_script_supported, p_font_rid, p_script, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_script_support_override(const RID &p_font_rid, const String &p_script, bool p_supported) {
@@ -963,11 +849,9 @@ void TextServerExtension::font_set_script_support_override(const RID &p_font_rid
 }
 
 bool TextServerExtension::font_get_script_support_override(const RID &p_font_rid, const String &p_script) {
-	bool ret;
-	if (GDVIRTUAL_CALL(_font_get_script_support_override, p_font_rid, p_script, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_font_get_script_support_override, p_font_rid, p_script, ret);
+	return ret;
 }
 
 void TextServerExtension::font_remove_script_support_override(const RID &p_font_rid, const String &p_script) {
@@ -976,10 +860,8 @@ void TextServerExtension::font_remove_script_support_override(const RID &p_font_
 
 PackedStringArray TextServerExtension::font_get_script_support_overrides(const RID &p_font_rid) {
 	PackedStringArray ret;
-	if (GDVIRTUAL_CALL(_font_get_script_support_overrides, p_font_rid, ret)) {
-		return ret;
-	}
-	return PackedStringArray();
+	GDVIRTUAL_CALL(_font_get_script_support_overrides, p_font_rid, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_opentype_feature_overrides(const RID &p_font_rid, const Dictionary &p_overrides) {
@@ -988,34 +870,26 @@ void TextServerExtension::font_set_opentype_feature_overrides(const RID &p_font_
 
 Dictionary TextServerExtension::font_get_opentype_feature_overrides(const RID &p_font_rid) const {
 	Dictionary ret;
-	if (GDVIRTUAL_CALL(_font_get_opentype_feature_overrides, p_font_rid, ret)) {
-		return ret;
-	}
-	return Dictionary();
+	GDVIRTUAL_CALL(_font_get_opentype_feature_overrides, p_font_rid, ret);
+	return ret;
 }
 
 Dictionary TextServerExtension::font_supported_feature_list(const RID &p_font_rid) const {
 	Dictionary ret;
-	if (GDVIRTUAL_CALL(_font_supported_feature_list, p_font_rid, ret)) {
-		return ret;
-	}
-	return Dictionary();
+	GDVIRTUAL_CALL(_font_supported_feature_list, p_font_rid, ret);
+	return ret;
 }
 
 Dictionary TextServerExtension::font_supported_variation_list(const RID &p_font_rid) const {
 	Dictionary ret;
-	if (GDVIRTUAL_CALL(_font_supported_variation_list, p_font_rid, ret)) {
-		return ret;
-	}
-	return Dictionary();
+	GDVIRTUAL_CALL(_font_supported_variation_list, p_font_rid, ret);
+	return ret;
 }
 
 double TextServerExtension::font_get_global_oversampling() const {
-	double ret;
-	if (GDVIRTUAL_CALL(_font_get_global_oversampling, ret)) {
-		return ret;
-	}
-	return 0.0;
+	double ret = 0;
+	GDVIRTUAL_CALL(_font_get_global_oversampling, ret);
+	return ret;
 }
 
 void TextServerExtension::font_set_global_oversampling(double p_oversampling) {
@@ -1042,10 +916,8 @@ void TextServerExtension::draw_hex_code_box(const RID &p_canvas, int64_t p_size,
 
 RID TextServerExtension::create_shaped_text(TextServer::Direction p_direction, TextServer::Orientation p_orientation) {
 	RID ret;
-	if (GDVIRTUAL_CALL(_create_shaped_text, p_direction, p_orientation, ret)) {
-		return ret;
-	}
-	return RID();
+	GDVIRTUAL_CALL(_create_shaped_text, p_direction, p_orientation, ret);
+	return ret;
 }
 
 void TextServerExtension::shaped_text_clear(const RID &p_shaped) {
@@ -1057,19 +929,15 @@ void TextServerExtension::shaped_text_set_direction(const RID &p_shaped, TextSer
 }
 
 TextServer::Direction TextServerExtension::shaped_text_get_direction(const RID &p_shaped) const {
-	TextServer::Direction ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_direction, p_shaped, ret)) {
-		return (TextServer::Direction)ret;
-	}
-	return TextServer::Direction::DIRECTION_AUTO;
+	TextServer::Direction ret = TextServer::DIRECTION_AUTO;
+	GDVIRTUAL_CALL(_shaped_text_get_direction, p_shaped, ret);
+	return ret;
 }
 
 TextServer::Direction TextServerExtension::shaped_text_get_inferred_direction(const RID &p_shaped) const {
-	TextServer::Direction ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_inferred_direction, p_shaped, ret)) {
-		return (TextServer::Direction)ret;
-	}
-	return TextServer::Direction::DIRECTION_LTR;
+	TextServer::Direction ret = TextServer::DIRECTION_LTR;
+	GDVIRTUAL_CALL(_shaped_text_get_inferred_direction, p_shaped, ret);
+	return ret;
 }
 
 void TextServerExtension::shaped_text_set_orientation(const RID &p_shaped, TextServer::Orientation p_orientation) {
@@ -1077,11 +945,9 @@ void TextServerExtension::shaped_text_set_orientation(const RID &p_shaped, TextS
 }
 
 TextServer::Orientation TextServerExtension::shaped_text_get_orientation(const RID &p_shaped) const {
-	TextServer::Orientation ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_orientation, p_shaped, ret)) {
-		return (TextServer::Orientation)ret;
-	}
-	return TextServer::Orientation::ORIENTATION_HORIZONTAL;
+	TextServer::Orientation ret = TextServer::ORIENTATION_HORIZONTAL;
+	GDVIRTUAL_CALL(_shaped_text_get_orientation, p_shaped, ret);
+	return ret;
 }
 
 void TextServerExtension::shaped_text_set_bidi_override(const RID &p_shaped, const Array &p_override) {
@@ -1094,10 +960,8 @@ void TextServerExtension::shaped_text_set_custom_punctuation(const RID &p_shaped
 
 String TextServerExtension::shaped_text_get_custom_punctuation(const RID &p_shaped) const {
 	String ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_custom_punctuation, p_shaped, ret)) {
-		return ret;
-	}
-	return String();
+	GDVIRTUAL_CALL(_shaped_text_get_custom_punctuation, p_shaped, ret);
+	return ret;
 }
 
 void TextServerExtension::shaped_text_set_preserve_invalid(const RID &p_shaped, bool p_enabled) {
@@ -1105,11 +969,9 @@ void TextServerExtension::shaped_text_set_preserve_invalid(const RID &p_shaped, 
 }
 
 bool TextServerExtension::shaped_text_get_preserve_invalid(const RID &p_shaped) const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_preserve_invalid, p_shaped, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_shaped_text_get_preserve_invalid, p_shaped, ret);
+	return ret;
 }
 
 void TextServerExtension::shaped_text_set_preserve_control(const RID &p_shaped, bool p_enabled) {
@@ -1117,11 +979,9 @@ void TextServerExtension::shaped_text_set_preserve_control(const RID &p_shaped, 
 }
 
 bool TextServerExtension::shaped_text_get_preserve_control(const RID &p_shaped) const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_preserve_control, p_shaped, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_shaped_text_get_preserve_control, p_shaped, ret);
+	return ret;
 }
 
 void TextServerExtension::shaped_text_set_spacing(const RID &p_shaped, TextServer::SpacingType p_spacing, int64_t p_value) {
@@ -1129,51 +989,39 @@ void TextServerExtension::shaped_text_set_spacing(const RID &p_shaped, TextServe
 }
 
 int64_t TextServerExtension::shaped_text_get_spacing(const RID &p_shaped, TextServer::SpacingType p_spacing) const {
-	int64_t ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_spacing, p_shaped, p_spacing, ret)) {
-		return ret;
-	}
-	return 0;
+	int64_t ret = 0;
+	GDVIRTUAL_CALL(_shaped_text_get_spacing, p_shaped, p_spacing, ret);
+	return ret;
 }
 
 bool TextServerExtension::shaped_text_add_string(const RID &p_shaped, const String &p_text, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features, const String &p_language, const Variant &p_meta) {
-	bool ret;
-	if (GDVIRTUAL_CALL(_shaped_text_add_string, p_shaped, p_text, p_fonts, p_size, p_opentype_features, p_language, p_meta, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_shaped_text_add_string, p_shaped, p_text, p_fonts, p_size, p_opentype_features, p_language, p_meta, ret);
+	return ret;
 }
 
 bool TextServerExtension::shaped_text_add_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align, int64_t p_length) {
-	bool ret;
-	if (GDVIRTUAL_CALL(_shaped_text_add_object, p_shaped, p_key, p_size, p_inline_align, p_length, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_shaped_text_add_object, p_shaped, p_key, p_size, p_inline_align, p_length, ret);
+	return ret;
 }
 
 bool TextServerExtension::shaped_text_resize_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align) {
-	bool ret;
-	if (GDVIRTUAL_CALL(_shaped_text_resize_object, p_shaped, p_key, p_size, p_inline_align, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_shaped_text_resize_object, p_shaped, p_key, p_size, p_inline_align, ret);
+	return ret;
 }
 
 int64_t TextServerExtension::shaped_get_span_count(const RID &p_shaped) const {
-	int64_t ret;
-	if (GDVIRTUAL_CALL(_shaped_get_span_count, p_shaped, ret)) {
-		return ret;
-	}
-	return 0;
+	int64_t ret = 0;
+	GDVIRTUAL_CALL(_shaped_get_span_count, p_shaped, ret);
+	return ret;
 }
 
 Variant TextServerExtension::shaped_get_span_meta(const RID &p_shaped, int64_t p_index) const {
-	Variant ret;
-	if (GDVIRTUAL_CALL(_shaped_get_span_meta, p_shaped, p_index, ret)) {
-		return ret;
-	}
-	return false;
+	Variant ret = false;
+	GDVIRTUAL_CALL(_shaped_get_span_meta, p_shaped, p_index, ret);
+	return ret;
 }
 
 void TextServerExtension::shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features) {
@@ -1182,98 +1030,74 @@ void TextServerExtension::shaped_set_span_update_font(const RID &p_shaped, int64
 
 RID TextServerExtension::shaped_text_substr(const RID &p_shaped, int64_t p_start, int64_t p_length) const {
 	RID ret;
-	if (GDVIRTUAL_CALL(_shaped_text_substr, p_shaped, p_start, p_length, ret)) {
-		return ret;
-	}
-	return RID();
+	GDVIRTUAL_CALL(_shaped_text_substr, p_shaped, p_start, p_length, ret);
+	return ret;
 }
 
 RID TextServerExtension::shaped_text_get_parent(const RID &p_shaped) const {
 	RID ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_parent, p_shaped, ret)) {
-		return ret;
-	}
-	return RID();
+	GDVIRTUAL_CALL(_shaped_text_get_parent, p_shaped, ret);
+	return ret;
 }
 
 double TextServerExtension::shaped_text_fit_to_width(const RID &p_shaped, double p_width, BitField<TextServer::JustificationFlag> p_jst_flags) {
-	double ret;
-	if (GDVIRTUAL_CALL(_shaped_text_fit_to_width, p_shaped, p_width, p_jst_flags, ret)) {
-		return ret;
-	}
-	return 0.0;
+	double ret = 0;
+	GDVIRTUAL_CALL(_shaped_text_fit_to_width, p_shaped, p_width, p_jst_flags, ret);
+	return ret;
 }
 
 double TextServerExtension::shaped_text_tab_align(const RID &p_shaped, const PackedFloat32Array &p_tab_stops) {
-	double ret;
-	if (GDVIRTUAL_CALL(_shaped_text_tab_align, p_shaped, p_tab_stops, ret)) {
-		return ret;
-	}
-	return 0.0;
+	double ret = 0;
+	GDVIRTUAL_CALL(_shaped_text_tab_align, p_shaped, p_tab_stops, ret);
+	return ret;
 }
 
 bool TextServerExtension::shaped_text_shape(const RID &p_shaped) {
-	bool ret;
-	if (GDVIRTUAL_CALL(_shaped_text_shape, p_shaped, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_shaped_text_shape, p_shaped, ret);
+	return ret;
 }
 
 bool TextServerExtension::shaped_text_update_breaks(const RID &p_shaped) {
-	bool ret;
-	if (GDVIRTUAL_CALL(_shaped_text_update_breaks, p_shaped, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_shaped_text_update_breaks, p_shaped, ret);
+	return ret;
 }
 
 bool TextServerExtension::shaped_text_update_justification_ops(const RID &p_shaped) {
-	bool ret;
-	if (GDVIRTUAL_CALL(_shaped_text_update_justification_ops, p_shaped, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_shaped_text_update_justification_ops, p_shaped, ret);
+	return ret;
 }
 
 bool TextServerExtension::shaped_text_is_ready(const RID &p_shaped) const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_shaped_text_is_ready, p_shaped, ret)) {
-		return ret;
-	}
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_shaped_text_is_ready, p_shaped, ret);
+	return ret;
 }
 
 const Glyph *TextServerExtension::shaped_text_get_glyphs(const RID &p_shaped) const {
 	GDNativeConstPtr<const Glyph> ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_glyphs, p_shaped, ret)) {
-		return ret;
-	}
-	return nullptr;
+	GDVIRTUAL_CALL(_shaped_text_get_glyphs, p_shaped, ret);
+	return ret;
 }
 
 const Glyph *TextServerExtension::shaped_text_sort_logical(const RID &p_shaped) {
 	GDNativeConstPtr<const Glyph> ret;
-	if (GDVIRTUAL_CALL(_shaped_text_sort_logical, p_shaped, ret)) {
-		return ret;
-	}
-	return nullptr;
+	GDVIRTUAL_CALL(_shaped_text_sort_logical, p_shaped, ret);
+	return ret;
 }
 
 int64_t TextServerExtension::shaped_text_get_glyph_count(const RID &p_shaped) const {
-	int64_t ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_glyph_count, p_shaped, ret)) {
-		return ret;
-	}
-	return 0;
+	int64_t ret = 0;
+	GDVIRTUAL_CALL(_shaped_text_get_glyph_count, p_shaped, ret);
+	return ret;
 }
 
 Vector2i TextServerExtension::shaped_text_get_range(const RID &p_shaped) const {
 	Vector2i ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_range, p_shaped, ret)) {
-		return ret;
-	}
-	return Vector2i();
+	GDVIRTUAL_CALL(_shaped_text_get_range, p_shaped, ret);
+	return ret;
 }
 
 PackedInt32Array TextServerExtension::shaped_text_get_line_breaks_adv(const RID &p_shaped, const PackedFloat32Array &p_width, int64_t p_start, bool p_once, BitField<TextServer::LineBreakFlag> p_break_flags) const {
@@ -1301,35 +1125,27 @@ PackedInt32Array TextServerExtension::shaped_text_get_word_breaks(const RID &p_s
 }
 
 int64_t TextServerExtension::shaped_text_get_trim_pos(const RID &p_shaped) const {
-	int64_t ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_trim_pos, p_shaped, ret)) {
-		return ret;
-	}
-	return -1;
+	int64_t ret = -1;
+	GDVIRTUAL_CALL(_shaped_text_get_trim_pos, p_shaped, ret);
+	return ret;
 }
 
 int64_t TextServerExtension::shaped_text_get_ellipsis_pos(const RID &p_shaped) const {
-	int64_t ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_ellipsis_pos, p_shaped, ret)) {
-		return ret;
-	}
-	return -1;
+	int64_t ret = -1;
+	GDVIRTUAL_CALL(_shaped_text_get_ellipsis_pos, p_shaped, ret);
+	return ret;
 }
 
 const Glyph *TextServerExtension::shaped_text_get_ellipsis_glyphs(const RID &p_shaped) const {
 	GDNativeConstPtr<const Glyph> ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_ellipsis_glyphs, p_shaped, ret)) {
-		return ret;
-	}
-	return nullptr;
+	GDVIRTUAL_CALL(_shaped_text_get_ellipsis_glyphs, p_shaped, ret);
+	return ret;
 }
 
 int64_t TextServerExtension::shaped_text_get_ellipsis_glyph_count(const RID &p_shaped) const {
-	int64_t ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_ellipsis_glyph_count, p_shaped, ret)) {
-		return ret;
-	}
-	return -1;
+	int64_t ret = -1;
+	GDVIRTUAL_CALL(_shaped_text_get_ellipsis_glyph_count, p_shaped, ret);
+	return ret;
 }
 
 void TextServerExtension::shaped_text_overrun_trim_to_width(const RID &p_shaped_line, double p_width, BitField<TextServer::TextOverrunFlag> p_trim_flags) {
@@ -1338,66 +1154,50 @@ void TextServerExtension::shaped_text_overrun_trim_to_width(const RID &p_shaped_
 
 Array TextServerExtension::shaped_text_get_objects(const RID &p_shaped) const {
 	Array ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_objects, p_shaped, ret)) {
-		return ret;
-	}
-	return Array();
+	GDVIRTUAL_CALL(_shaped_text_get_objects, p_shaped, ret);
+	return ret;
 }
 
 Rect2 TextServerExtension::shaped_text_get_object_rect(const RID &p_shaped, const Variant &p_key) const {
 	Rect2 ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_object_rect, p_shaped, p_key, ret)) {
-		return ret;
-	}
-	return Rect2();
+	GDVIRTUAL_CALL(_shaped_text_get_object_rect, p_shaped, p_key, ret);
+	return ret;
 }
 
 Size2 TextServerExtension::shaped_text_get_size(const RID &p_shaped) const {
 	Size2 ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_size, p_shaped, ret)) {
-		return ret;
-	}
-	return Size2();
+	GDVIRTUAL_CALL(_shaped_text_get_size, p_shaped, ret);
+	return ret;
 }
 
 double TextServerExtension::shaped_text_get_ascent(const RID &p_shaped) const {
-	double ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_ascent, p_shaped, ret)) {
-		return ret;
-	}
-	return 0.0;
+	double ret = 0;
+	GDVIRTUAL_CALL(_shaped_text_get_ascent, p_shaped, ret);
+	return ret;
 }
 
 double TextServerExtension::shaped_text_get_descent(const RID &p_shaped) const {
-	double ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_descent, p_shaped, ret)) {
-		return ret;
-	}
-	return 0.0;
+	double ret = 0;
+	GDVIRTUAL_CALL(_shaped_text_get_descent, p_shaped, ret);
+	return ret;
 }
 
 double TextServerExtension::shaped_text_get_width(const RID &p_shaped) const {
-	double ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_width, p_shaped, ret)) {
-		return ret;
-	}
-	return 0.0;
+	double ret = 0;
+	GDVIRTUAL_CALL(_shaped_text_get_width, p_shaped, ret);
+	return ret;
 }
 
 double TextServerExtension::shaped_text_get_underline_position(const RID &p_shaped) const {
-	double ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_underline_position, p_shaped, ret)) {
-		return ret;
-	}
-	return 0.0;
+	double ret = 0;
+	GDVIRTUAL_CALL(_shaped_text_get_underline_position, p_shaped, ret);
+	return ret;
 }
 
 double TextServerExtension::shaped_text_get_underline_thickness(const RID &p_shaped) const {
-	double ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_underline_thickness, p_shaped, ret)) {
-		return ret;
-	}
-	return 0.0;
+	double ret = 0;
+	GDVIRTUAL_CALL(_shaped_text_get_underline_thickness, p_shaped, ret);
+	return ret;
 }
 
 TextServer::Direction TextServerExtension::shaped_text_get_dominant_direction_in_range(const RID &p_shaped, int64_t p_start, int64_t p_end) const {
@@ -1495,11 +1295,9 @@ String TextServerExtension::parse_number(const String &p_string, const String &p
 }
 
 String TextServerExtension::percent_sign(const String &p_language) const {
-	String ret;
-	if (GDVIRTUAL_CALL(_percent_sign, p_language, ret)) {
-		return ret;
-	}
-	return "%";
+	String ret = "%";
+	GDVIRTUAL_CALL(_percent_sign, p_language, ret);
+	return ret;
 }
 
 bool TextServerExtension::is_valid_identifier(const String &p_string) const {
@@ -1536,18 +1334,14 @@ String TextServerExtension::string_to_lower(const String &p_string, const String
 
 TypedArray<Vector2i> TextServerExtension::parse_structured_text(StructuredTextParser p_parser_type, const Array &p_args, const String &p_text) const {
 	TypedArray<Vector2i> ret;
-	if (GDVIRTUAL_CALL(_parse_structured_text, p_parser_type, p_args, p_text, ret)) {
-		return ret;
-	}
-	return TypedArray<Vector2i>();
+	GDVIRTUAL_CALL(_parse_structured_text, p_parser_type, p_args, p_text, ret);
+	return ret;
 }
 
 PackedInt32Array TextServerExtension::string_get_word_breaks(const String &p_string, const String &p_language) const {
 	PackedInt32Array ret;
-	if (GDVIRTUAL_CALL(_string_get_word_breaks, p_string, p_language, ret)) {
-		return ret;
-	}
-	return PackedInt32Array();
+	GDVIRTUAL_CALL(_string_get_word_breaks, p_string, p_language, ret);
+	return ret;
 }
 
 int64_t TextServerExtension::is_confusable(const String &p_string, const PackedStringArray &p_dict) const {

--- a/servers/xr/xr_interface_extension.cpp
+++ b/servers/xr/xr_interface_extension.cpp
@@ -100,33 +100,21 @@ StringName XRInterfaceExtension::get_name() const {
 }
 
 uint32_t XRInterfaceExtension::get_capabilities() const {
-	uint32_t capabilities;
-
-	if (GDVIRTUAL_CALL(_get_capabilities, capabilities)) {
-		return capabilities;
-	}
-
-	return 0;
+	uint32_t capabilities = 0;
+	GDVIRTUAL_CALL(_get_capabilities, capabilities);
+	return capabilities;
 }
 
 bool XRInterfaceExtension::is_initialized() const {
 	bool initialised = false;
-
-	if (GDVIRTUAL_CALL(_is_initialized, initialised)) {
-		return initialised;
-	}
-
-	return false;
+	GDVIRTUAL_CALL(_is_initialized, initialised);
+	return initialised;
 }
 
 bool XRInterfaceExtension::initialize() {
 	bool initialised = false;
-
-	if (GDVIRTUAL_CALL(_initialize, initialised)) {
-		return initialised;
-	}
-
-	return false;
+	GDVIRTUAL_CALL(_initialize, initialised);
+	return initialised;
 }
 
 void XRInterfaceExtension::uninitialize() {
@@ -150,13 +138,9 @@ PackedStringArray XRInterfaceExtension::get_suggested_pose_names(const StringNam
 }
 
 XRInterface::TrackingStatus XRInterfaceExtension::get_tracking_status() const {
-	uint32_t status;
-
-	if (GDVIRTUAL_CALL(_get_tracking_status, status)) {
-		return TrackingStatus(status);
-	}
-
-	return XR_UNKNOWN_TRACKING;
+	uint32_t status = XR_UNKNOWN_TRACKING;
+	GDVIRTUAL_CALL(_get_tracking_status, status);
+	return TrackingStatus(status);
 }
 
 void XRInterfaceExtension::trigger_haptic_pulse(const String &p_action_name, const StringName &p_tracker_name, double p_frequency, double p_amplitude, double p_duration_sec, double p_delay_sec) {
@@ -164,52 +148,34 @@ void XRInterfaceExtension::trigger_haptic_pulse(const String &p_action_name, con
 }
 
 bool XRInterfaceExtension::supports_play_area_mode(XRInterface::PlayAreaMode p_mode) {
-	bool is_supported;
-
-	if (GDVIRTUAL_CALL(_supports_play_area_mode, p_mode, is_supported)) {
-		return is_supported;
-	}
-
-	return false;
+	bool is_supported = false;
+	GDVIRTUAL_CALL(_supports_play_area_mode, p_mode, is_supported);
+	return is_supported;
 }
 
 XRInterface::PlayAreaMode XRInterfaceExtension::get_play_area_mode() const {
-	uint32_t mode;
-
-	if (GDVIRTUAL_CALL(_get_play_area_mode, mode)) {
-		return XRInterface::PlayAreaMode(mode);
-	}
-
-	return XRInterface::XR_PLAY_AREA_UNKNOWN;
+	uint32_t mode = XR_PLAY_AREA_UNKNOWN;
+	GDVIRTUAL_CALL(_get_play_area_mode, mode);
+	return XRInterface::PlayAreaMode(mode);
 }
 
 bool XRInterfaceExtension::set_play_area_mode(XRInterface::PlayAreaMode p_mode) {
-	bool success;
-
-	if (GDVIRTUAL_CALL(_set_play_area_mode, p_mode, success)) {
-		return success;
-	}
-
-	return false;
+	bool success = false;
+	GDVIRTUAL_CALL(_set_play_area_mode, p_mode, success);
+	return success;
 }
 
 PackedVector3Array XRInterfaceExtension::get_play_area() const {
 	PackedVector3Array arr;
-
 	GDVIRTUAL_CALL(_get_play_area, arr);
-
 	return arr;
 }
 
 /** these will only be implemented on AR interfaces, so we want dummies for VR **/
 bool XRInterfaceExtension::get_anchor_detection_is_enabled() const {
-	bool enabled;
-
-	if (GDVIRTUAL_CALL(_get_anchor_detection_is_enabled, enabled)) {
-		return enabled;
-	}
-
-	return false;
+	bool enabled = false;
+	GDVIRTUAL_CALL(_get_anchor_detection_is_enabled, enabled);
+	return enabled;
 }
 
 void XRInterfaceExtension::set_anchor_detection_is_enabled(bool p_enable) {
@@ -218,53 +184,33 @@ void XRInterfaceExtension::set_anchor_detection_is_enabled(bool p_enable) {
 }
 
 int XRInterfaceExtension::get_camera_feed_id() {
-	int feed_id;
-
-	if (GDVIRTUAL_CALL(_get_camera_feed_id, feed_id)) {
-		return feed_id;
-	}
-
-	return 0;
+	int feed_id = 0;
+	GDVIRTUAL_CALL(_get_camera_feed_id, feed_id);
+	return feed_id;
 }
 
 Size2 XRInterfaceExtension::get_render_target_size() {
 	Size2 size;
-
-	if (GDVIRTUAL_CALL(_get_render_target_size, size)) {
-		return size;
-	}
-
-	return Size2(0, 0);
+	GDVIRTUAL_CALL(_get_render_target_size, size);
+	return size;
 }
 
 uint32_t XRInterfaceExtension::get_view_count() {
-	uint32_t view_count;
-
-	if (GDVIRTUAL_CALL(_get_view_count, view_count)) {
-		return view_count;
-	}
-
-	return 1;
+	uint32_t view_count = 1;
+	GDVIRTUAL_CALL(_get_view_count, view_count);
+	return view_count;
 }
 
 Transform3D XRInterfaceExtension::get_camera_transform() {
 	Transform3D transform;
-
-	if (GDVIRTUAL_CALL(_get_camera_transform, transform)) {
-		return transform;
-	}
-
-	return Transform3D();
+	GDVIRTUAL_CALL(_get_camera_transform, transform);
+	return transform;
 }
 
 Transform3D XRInterfaceExtension::get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) {
 	Transform3D transform;
-
-	if (GDVIRTUAL_CALL(_get_transform_for_view, p_view, p_cam_transform, transform)) {
-		return transform;
-	}
-
-	return Transform3D();
+	GDVIRTUAL_CALL(_get_transform_for_view, p_view, p_cam_transform, transform);
+	return transform;
 }
 
 Projection XRInterfaceExtension::get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) {
@@ -294,29 +240,20 @@ RID XRInterfaceExtension::get_vrs_texture() {
 
 RID XRInterfaceExtension::get_color_texture() {
 	RID texture;
-	if (GDVIRTUAL_CALL(_get_color_texture, texture)) {
-		return texture;
-	} else {
-		return RID();
-	}
+	GDVIRTUAL_CALL(_get_color_texture, texture);
+	return texture;
 }
 
 RID XRInterfaceExtension::get_depth_texture() {
 	RID texture;
-	if (GDVIRTUAL_CALL(_get_depth_texture, texture)) {
-		return texture;
-	} else {
-		return RID();
-	}
+	GDVIRTUAL_CALL(_get_depth_texture, texture);
+	return texture;
 }
 
 RID XRInterfaceExtension::get_velocity_texture() {
 	RID texture;
-	if (GDVIRTUAL_CALL(_get_velocity_texture, texture)) {
-		return texture;
-	} else {
-		return RID();
-	}
+	GDVIRTUAL_CALL(_get_velocity_texture, texture);
+	return texture;
 }
 
 void XRInterfaceExtension::add_blit(RID p_render_target, Rect2 p_src_rect, Rect2i p_dst_rect, bool p_use_layer, uint32_t p_layer, bool p_apply_lens_distortion, Vector2 p_eye_center, double p_k1, double p_k2, double p_upscale, double p_aspect_ratio) {
@@ -351,13 +288,8 @@ void XRInterfaceExtension::pre_render() {
 
 bool XRInterfaceExtension::pre_draw_viewport(RID p_render_target) {
 	bool do_render = true;
-
-	if (GDVIRTUAL_CALL(_pre_draw_viewport, p_render_target, do_render)) {
-		return do_render;
-	} else {
-		// if not implemented we're returning true
-		return true;
-	}
+	GDVIRTUAL_CALL(_pre_draw_viewport, p_render_target, do_render);
+	return do_render; // If not implemented we're returning true.
 }
 
 Vector<BlitToScreen> XRInterfaceExtension::post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) {


### PR DESCRIPTION
The premise of this PR is that
```C++
bool success = false;
if (GDVIRTUAL_CALL(_handles_type, p_type, success)) {
	return success;
}

return false;
```
is the same as
```C++
bool success = false;
GDVIRTUAL_CALL(_handles_type, p_type, success);
return success;
```
I went over all `if (GDVIRTUAL_CALL)` conditions and simplified them like this.