### PR TITLE
Have the Rename Node action use the targeted Node for undo/redo context

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1016,7 +1016,7 @@ void SceneTreeEditor::_renamed() {
 		emit_signal(SNAME("node_renamed"));
 	} else {
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-		undo_redo->create_action(TTR("Rename Node"));
+		undo_redo->create_action(TTR("Rename Node"), UndoRedo::MERGE_DISABLE, n);
 		emit_signal(SNAME("node_prerename"), n, new_name);
 		undo_redo->add_do_method(this, "_rename_node", n->get_instance_id(), new_name);
 		undo_redo->add_undo_method(this, "_rename_node", n->get_instance_id(), n->get_name());


### PR DESCRIPTION
Formerly, we deduced context implicitly, but this failed and always used the global context instead of the context of the scene containing the Node.

This happened because the first argument to `add_do_method`, the SceneTreeEditor, is a descendant of Node and outside the current game scene's tree (it's part of the editor instead). This led the code in `EditorUndoRedoManager::get_history_id_for_object` to choose global context.

My solution is to explicitly use the renamed Node to deduce our context because it will always be in the current scene in this situation.

Fixes #67276

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
