### PR TITLE
Fold code sections back after being searched over

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -204,7 +204,10 @@ bool FindReplaceBar::_search(uint32_t p_flags, int p_from_line, int p_from_col) 
 
 	if (pos.x != -1) {
 		if (!preserve_cursor && !is_selection_only()) {
-			text_editor->unfold_line(pos.y);
+			_temp_unfold_line(pos.y);
+			text_editor->set_caret_line(pos.y, false);
+			text_editor->set_caret_column(pos.x + text.length(), false);
+			text_editor->center_viewport_to_caret(0);
 			text_editor->select(pos.y, pos.x, pos.y, pos.x + text.length());
 			text_editor->center_viewport_to_caret(0);
 			text_editor->set_code_hint("");
@@ -500,6 +503,34 @@ void FindReplaceBar::_update_matches_display() {
 	replace_all->set_disabled(search_text->get_text().is_empty());
 }
 
+void FindReplaceBar::_temp_unfold_line(int p_line) {
+	// Unfold p_line, then walk back to find which was the first line that had to be unfolded so p_line can be shown.
+	// Mark that line as temporarily unfolded, so it's folded back on the next temporarily unfolding - unless the user for example edits the text.
+	if (temp_unfolded_line != -1) {
+		text_editor->fold_line(temp_unfolded_line);
+	}
+
+	if (!text_editor->is_line_folded(p_line)) {
+		temp_unfolded_line = p_line;
+		while (temp_unfolded_line >= 0) {
+			if (text_editor->is_line_folded(temp_unfolded_line)) {
+				break;
+			} else {
+				String line_text = text_editor->get_line(temp_unfolded_line);
+				// If at the start of a lowest-level foldable block, don't backtrack further.
+				// TODO This should likely be refined in its own CodeEdit function, but when this was written such a function didn't exist.
+				if (text_editor->can_fold_line(temp_unfolded_line) && !is_whitespace(line_text[0]) && text_editor->is_in_comment(temp_unfolded_line, 0) == -1 && text_editor->is_in_string(temp_unfolded_line, 0) == -1) {
+					temp_unfolded_line = -1;
+					break;
+				}
+			}
+			temp_unfolded_line--;
+		}
+
+		text_editor->unfold_line(p_line);
+	}
+}
+
 bool FindReplaceBar::search_current() {
 	_update_flags(false);
 
@@ -568,6 +599,7 @@ void FindReplaceBar::_hide_bar() {
 	}
 
 	text_editor->set_search_text("");
+	temp_unfolded_line = -1;
 	result_line = -1;
 	result_col = -1;
 	hide();
@@ -650,6 +682,7 @@ void FindReplaceBar::_search_options_changed(bool p_pressed) {
 }
 
 void FindReplaceBar::_editor_text_changed() {
+	temp_unfolded_line = -1;
 	results_count = -1;
 	results_count_to_current = -1;
 	needs_to_count_results = true;

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -95,6 +95,7 @@ class FindReplaceBar : public HBoxContainer {
 
 	uint32_t flags = 0;
 
+	int temp_unfolded_line = -1;
 	int result_line = 0;
 	int result_col = 0;
 	int results_count = -1;
@@ -108,6 +109,7 @@ class FindReplaceBar : public HBoxContainer {
 	void _get_search_from(int &r_line, int &r_col, SearchMode p_search_mode);
 	void _update_results_count();
 	void _update_matches_display();
+	void _temp_unfold_line(int p_line);
 
 	void _show_search(bool p_with_replace, bool p_show_only);
 	void _hide_bar();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5361

When you have a big script where most functions are folded, the Find&Replace bar becomes a wrecking ball if you're searching for something far down in the script.

https://user-images.githubusercontent.com/85438892/188762548-1ab5692e-ef9a-4d77-bb08-d51d684b3fe6.mp4

This PR makes it so until you close the bar or change the script, Find&Replace will only temporarily unfold lines, like a small peek inside the current search result:

https://user-images.githubusercontent.com/85438892/196509512-fba7d570-990b-4888-ab4d-326c5e0ebbc8.mp4