### PR TITLE
Default to Opengl3 driver when using the project manager

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1530,6 +1530,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	if (default_renderer_mobile.is_empty()) {
 		default_renderer_mobile = "gl_compatibility";
 	}
+	// Default to Compatibility when using the project manager.
+	if (rendering_driver.is_empty() && rendering_method.is_empty() && project_manager) {
+		rendering_driver = "opengl3";
+		rendering_method = "gl_compatibility";
+	}
 #endif
 	if (renderer_hints.is_empty()) {
 		ERR_PRINT("No renderers available.");


### PR DESCRIPTION
This only applies when starting the project manager without command line args and only applies if OpenGL3 support is compiled in to the binary (i.e. when ``GLES3_ENABLED`` is defined).

The main rationale for this change is performance. On certain systems initializing Vulkan can be quite slow. Since there is no need to use Vulkan in the ProjectManager, it is better to use OpenGL and just have it open quicker for everyone. 

In the coming weeks we will update the project selection dialogue to include the OpenGL 3 backend.

### Performance

Here is a basic performance comparison table showing the difference on both debug vs release and opening on a system with only an integrated CPU and one with both and integrated CPU and a GPU. 

|         | CPU - Debug | GPU - Debug | CPU - Release | GPU - Release |
|---------|-------------|-------------|---------------|---------------|
| OpenGL3 | 4.305       | 4.349       | 2.856  | 2.896     |
| Vulkan  | 14.490      | 4.700       | 13.078   | 2.956     |

Based on the table it appears something is going wrong with the CPU-only system and it is having a poor interaction with Vulkan so take the results with a grain of salt, they may not represent the experience of a typical user.

#### Details

<details>
  <summary>Opening with Intel Integrated graphics only (dedicated GPU disabled) - Debug</summary>

```
hyperfine -iw1 "./godot.linuxbsd.editor.dev.x86_64.llvm --quit" "./godot.linuxbsd.editor.dev.x86_64.llvm --rendering-driver vulkan --quit"
Benchmark 1: ./godot.linuxbsd.editor.dev.x86_64.llvm --quit
  Time (mean ± σ):      4.305 s ±  0.065 s    [User: 3.084 s, System: 0.339 s]
  Range (min … max):    4.230 s …  4.426 s    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 2: ./godot.linuxbsd.editor.dev.x86_64.llvm --rendering-driver vulkan --quit
  Time (mean ± σ):     14.490 s ±  0.361 s    [User: 3.258 s, System: 0.483 s]
  Range (min … max):   14.065 s … 14.946 s    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Summary
  './godot.linuxbsd.editor.dev.x86_64.llvm --quit' ran
    3.37 ± 0.10 times faster than './godot.linuxbsd.editor.dev.x86_64.llvm --rendering-driver vulkan --quit'
```
</details>

<details>
  <summary>Opening with dedicated GPU - Debug</summary>

```
hyperfine -iw1 "./godot.linuxbsd.editor.dev.x86_64.llvm --quit" "./godot.linuxbsd.editor.dev.x86_64.llvm --rendering-driver vulkan --quit"
Benchmark 1: ./godot.linuxbsd.editor.dev.x86_64.llvm --quit
  Time (mean ± σ):      4.349 s ±  0.102 s    [User: 3.122 s, System: 0.326 s]
  Range (min … max):    4.198 s …  4.503 s    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 2: ./godot.linuxbsd.editor.dev.x86_64.llvm --rendering-driver vulkan --quit
  Time (mean ± σ):      4.700 s ±  0.050 s    [User: 3.443 s, System: 0.355 s]
  Range (min … max):    4.611 s …  4.774 s    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Summary
  './godot.linuxbsd.editor.dev.x86_64.llvm --quit' ran
    1.08 ± 0.03 times faster than './godot.linuxbsd.editor.dev.x86_64.llvm --rendering-driver vulkan --quit'
```
  
</details>

<details>
  <summary>Opening with Intel Integrated graphics only (dedicated GPU disabled) - Release</summary>
  
```
hyperfine -iw1 "./godot.linuxbsd.editor.x86_64.llvm --quit" "./godot.linuxbsd.editor.x86_64.llvm --rendering-driver vulkan --quit"
Benchmark 1: ./godot.linuxbsd.editor.x86_64.llvm --quit
  Time (mean ± σ):      2.856 s ±  0.162 s    [User: 1.618 s, System: 0.297 s]
  Range (min … max):    2.637 s …  3.040 s    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 2: ./godot.linuxbsd.editor.x86_64.llvm --rendering-driver vulkan --quit
  Time (mean ± σ):     13.078 s ±  0.483 s    [User: 1.741 s, System: 0.491 s]
  Range (min … max):   12.056 s … 13.546 s    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Summary
  './godot.linuxbsd.editor.x86_64.llvm --quit' ran
    4.58 ± 0.31 times faster than './godot.linuxbsd.editor.x86_64.llvm --rendering-driver vulkan --quit'
```

</details>

<details>
  <summary>Opening with dedicated GPU - Release</summary>
  
```
hyperfine -iw1 "./godot.linuxbsd.editor.x86_64.llvm --quit" "./godot.linuxbsd.editor.x86_64.llvm --rendering-driver vulkan --quit"
Benchmark 1: ./godot.linuxbsd.editor.x86_64.llvm --quit
  Time (mean ± σ):      2.896 s ±  0.043 s    [User: 1.635 s, System: 0.338 s]
  Range (min … max):    2.805 s …  2.949 s    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 2: ./godot.linuxbsd.editor.x86_64.llvm --rendering-driver vulkan --quit
  Time (mean ± σ):      2.956 s ±  0.038 s    [User: 1.647 s, System: 0.371 s]
  Range (min … max):    2.896 s …  3.006 s    10 runs
 
  Warning: Ignoring non-zero exit code.
 
Summary
  './godot.linuxbsd.editor.x86_64.llvm --quit' ran
    1.02 ± 0.02 times faster than './godot.linuxbsd.editor.x86_64.llvm --rendering-driver vulkan --quit'
```
</details>

**Notes:**
Users will notice a new error upon started:
```
ERROR: BUG: Unreferenced static string to 0: interface_added
   at: unref (core/string/string_name.cpp:131)
```
 I don't know if it comes from the TextServer or the XRServer, but it appears to be a harmless error
