### PR TITLE
C# Use System.MathF on Godot.Mathf

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -242,18 +242,12 @@ public:
 	static _ALWAYS_INLINE_ float lerp(float p_from, float p_to, float p_weight) { return p_from + (p_to - p_from) * p_weight; }
 
 	static _ALWAYS_INLINE_ double cubic_interpolate(double p_from, double p_to, double p_pre, double p_post, double p_weight) {
-		return 0.5 *
-				((p_from * 2.0) +
-						(-p_pre + p_to) * p_weight +
-						(2.0 * p_pre - 5.0 * p_from + 4.0 * p_to - p_post) * (p_weight * p_weight) +
-						(-p_pre + 3.0 * p_from - 3.0 * p_to + p_post) * (p_weight * p_weight * p_weight));
+		double w2 = p_weight * p_weight;
+		return p_from + 0.5 * ((p_to - p_pre) * p_weight + (2.0 * p_pre - 5.0 * p_from + 4.0 * p_to - p_post) * w2 + (3.0 * p_from - 3.0 * p_to + p_post - p_pre) * (w2 * p_weight));
 	}
 	static _ALWAYS_INLINE_ float cubic_interpolate(float p_from, float p_to, float p_pre, float p_post, float p_weight) {
-		return 0.5f *
-				((p_from * 2.0f) +
-						(-p_pre + p_to) * p_weight +
-						(2.0f * p_pre - 5.0f * p_from + 4.0f * p_to - p_post) * (p_weight * p_weight) +
-						(-p_pre + 3.0f * p_from - 3.0f * p_to + p_post) * (p_weight * p_weight * p_weight));
+		float w2 = p_weight * p_weight;
+		return p_from + 0.5f * ((p_to - p_pre) * p_weight + (2.0f * p_pre - 5.0f * p_from + 4.0f * p_to - p_post) * w2 + (3.0f * p_from - 3.0f * p_to + p_post - p_pre) * (w2 * p_weight));
 	}
 
 	static _ALWAYS_INLINE_ double cubic_interpolate_angle(double p_from, double p_to, double p_pre, double p_post, double p_weight) {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/MathfEx.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/MathfEx.cs
@@ -1,5 +1,11 @@
 using System;
 
+#if REAL_T_IS_DOUBLE
+using MathS = System.Math;
+#else
+using MathS = System.MathF;
+#endif
+
 namespace Godot
 {
     public static partial class Mathf
@@ -9,7 +15,7 @@ namespace Godot
         /// <summary>
         /// The natural number <c>e</c>.
         /// </summary>
-        public const real_t E = (real_t)2.7182818284590452353602874714M; // 2.7182817f and 2.718281828459045
+        public const real_t E = MathS.E; // 2.7182817f and 2.718281828459045
 
         /// <summary>
         /// The square root of 2.
@@ -55,7 +61,7 @@ namespace Godot
         /// <returns>The smallest whole number that is not less than <paramref name="s"/>.</returns>
         public static int CeilToInt(real_t s)
         {
-            return (int)Math.Ceiling(s);
+            return (int)MathS.Ceiling(s);
         }
 
         /// <summary>
@@ -67,7 +73,7 @@ namespace Godot
         /// <returns>The largest whole number that is not more than <paramref name="s"/>.</returns>
         public static int FloorToInt(real_t s)
         {
-            return (int)Math.Floor(s);
+            return (int)MathS.Floor(s);
         }
 
         /// <summary>
@@ -79,7 +85,7 @@ namespace Godot
         /// <returns>The rounded number.</returns>
         public static int RoundToInt(real_t s)
         {
-            return (int)Math.Round(s);
+            return (int)MathS.Round(s);
         }
 
         /// <summary>
@@ -100,7 +106,7 @@ namespace Godot
                 return true;
             }
             // Then check for approximate equality.
-            return Abs(a - b) < tolerance;
+            return MathS.Abs(a - b) < tolerance;
         }
     }
 }


### PR DESCRIPTION
This is the solution :smile: from my PR [#5509](https://github.com/godotengine/godot-proposals/issues/5509). Where thanks to .NET 6 we finally have a float math library, so we can remove that bunch of casts on Godot.Mathf.


I also saw that some numbers that have cast where there are not necessary or make no difference so I removed them. The compiler will always convert basic operation to the bigger type. So there is no point in doing `(real_t) 1.0` (0.0 is double by default) or `floatNumber == 1`, instead of simple using float because in first case the compiler will convert the float to double and in the second case it will convert the int to float.

I also made the number formatting and function spacing consistent.