### PR TITLE
Adds 16bpp support for BMP File Format

### DIFF
--- a/modules/bmp/image_loader_bmp.h
+++ b/modules/bmp/image_loader_bmp.h
@@ -74,6 +74,25 @@ protected:
 			uint32_t bmp_colors_used = 0;
 			uint32_t bmp_important_colors = 0;
 		} bmp_info_header;
+
+		struct bmp_bitfield_s {
+			uint16_t alpha_mask = 0x8000;
+			uint16_t red_mask = 0x7C00;
+			uint16_t green_mask = 0x03E0;
+			uint16_t blue_mask = 0x001F;
+			uint16_t alpha_mask_width = 1u;
+			uint16_t red_mask_width = 5u;
+			uint16_t green_mask_width = 5u;
+			uint16_t blue_mask_width = 5u;
+			uint8_t alpha_offset = 15u; // Used for bit shifting.
+			uint8_t red_offset = 10u; // Used for bit shifting.
+			uint8_t green_offset = 5u; // Used for bit shifting.
+			//uint8_t blue_offset = 0u; // Always LSB aligned no shifting needed.
+			//uint8_t alpha_max = 1u; // Always boolean or on, so no scaling needed.
+			uint8_t red_max = 32u; // Used for color space scaling.
+			uint8_t green_max = 32u; // Used for color space scaling.
+			uint8_t blue_max = 32u; // Used for color space scaling.
+		} bmp_bitfield;
 	};
 
 	static Error convert_to_image(Ref<Image> p_image,


### PR DESCRIPTION
This commit adds some basic 16bpp support for BMP File Format.

Doesn't support R5G6B5 pixel format yet as I haven't figured out how to detect it's usage seperatly from the A1R5G5B5/X1R5G5B5 pixel formats from the available header information. Should be easy to add support for it though once that's nailed down.

Doesn't support Alpha bit yet. This is because while it seems to still have it's transparency correct when I open test images in Gimp, I have no such luck in Godot and I'm not sure why. I think some relevant information maybe being stored in the colorspace or the V5 BMP header that I'm either ignorant of or have missed.

Edit: Added spacing and line breaks for legability.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
