### PR TITLE
Don't allow instancing virtual node types in the Create New Node dialog

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -31,6 +31,7 @@
 #include "class_db.h"
 
 #include "core/config/engine.h"
+#include "core/object/script_language.h"
 #include "core/os/mutex.h"
 #include "core/version.h"
 
@@ -376,7 +377,12 @@ bool ClassDB::is_virtual(const StringName &p_class) {
 	OBJTYPE_RLOCK;
 
 	ClassInfo *ti = classes.getptr(p_class);
-	ERR_FAIL_COND_V_MSG(!ti, false, "Cannot get class '" + String(p_class) + "'.");
+	if (!ti) {
+		if (!ScriptServer::is_global_class(p_class)) {
+			ERR_FAIL_V_MSG(false, "Cannot get class '" + String(p_class) + "'.");
+		}
+		return false;
+	}
 #ifdef TOOLS_ENABLED
 	if (ti->api == API_EDITOR && !Engine::get_singleton()->is_editor_hint()) {
 		return false;

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -284,12 +284,12 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String 
 	bool can_instantiate = (p_type_category == TypeCategory::CPP_TYPE && ClassDB::can_instantiate(p_type)) ||
 			p_type_category == TypeCategory::OTHER_TYPE;
 
-	if (!can_instantiate) {
-		r_item->set_custom_color(0, search_options->get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
-		r_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, "NodeDisabled"));
-		r_item->set_selectable(0, false);
-	} else {
+	if (can_instantiate && !ClassDB::is_virtual(p_type)) {
 		r_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, icon_fallback));
+	} else {
+		r_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, "NodeDisabled"));
+		r_item->set_custom_color(0, search_options->get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
+		r_item->set_selectable(0, false);
 	}
 
 	bool is_deprecated = EditorHelp::get_doc_data()->class_list[p_type].is_deprecated;

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -570,13 +570,17 @@ void EditorResourcePicker::_get_allowed_types(bool p_with_convert, HashSet<Strin
 
 	for (int i = 0; i < size; i++) {
 		String base = allowed_types[i].strip_edges();
-		p_vector->insert(base);
+		if (!ClassDB::is_virtual(base)) {
+			p_vector->insert(base);
+		}
 
 		// If we hit a familiar base type, take all the data from cache.
 		if (allowed_types_cache.has(base)) {
 			List<StringName> allowed_subtypes = allowed_types_cache[base];
 			for (const StringName &subtype_name : allowed_subtypes) {
-				p_vector->insert(subtype_name);
+				if (!ClassDB::is_virtual(subtype_name)) {
+					p_vector->insert(subtype_name);
+				}
 			}
 		} else {
 			List<StringName> allowed_subtypes;
@@ -586,13 +590,17 @@ void EditorResourcePicker::_get_allowed_types(bool p_with_convert, HashSet<Strin
 				ClassDB::get_inheriters_from_class(base, &inheriters);
 			}
 			for (const StringName &subtype_name : inheriters) {
-				p_vector->insert(subtype_name);
+				if (!ClassDB::is_virtual(subtype_name)) {
+					p_vector->insert(subtype_name);
+				}
 				allowed_subtypes.push_back(subtype_name);
 			}
 
 			for (const StringName &subtype_name : global_classes) {
 				if (EditorNode::get_editor_data().script_class_is_parent(subtype_name, base)) {
-					p_vector->insert(subtype_name);
+					if (!ClassDB::is_virtual(subtype_name)) {
+						p_vector->insert(subtype_name);
+					}
 					allowed_subtypes.push_back(subtype_name);
 				}
 			}


### PR DESCRIPTION
Virtual classes were introduced in #58972. These are types that are technically able to be instanced by the engine so that they can be inherited in GDExtension, but they are not intended to be used directly like abstract classes.

Given the above reasoning, plus how #58972 says "they can't be instantiated from the editor", it was a mistake that the node creation dialog allowed this until now.

Before (it's not intended to be able to instance VisualInstance3D and GeometryInstance3D directly)

<img width="446" alt="Screen Shot 2022-10-21 at 5 48 12 PM" src="https://user-images.githubusercontent.com/1646875/197300144-42a8a2cf-040c-4a4b-b68e-b401f19bfcd8.png">

After:

<img width="446" alt="Screen Shot 2022-10-21 at 5 47 02 PM" src="https://user-images.githubusercontent.com/1646875/197300126-7ed45313-c566-45d2-9f78-d9b25d2ae5af.png">

EDIT: Updated the PR with a second commit that fixes this in the resource picker dialog.

<img width="258" alt="Screen Shot 2022-10-21 at 4 14 52 PM" src="https://user-images.githubusercontent.com/1646875/197299118-e27a10c4-9723-4824-a266-7d0b28487063.png">

In the above example MyMesh extends PrimitiveMesh. With this PR it looks like the above. In the current master, PrimitiveMesh also shows up in this menu, which is undesired because it's a virtual class.

EDIT 2: Updated to not error when the project contains custom classes defined with `class_name`. Note: This PR makes `ClassDB` depend on `ScriptServer`, so that `ClassDB::is_virtual` can be the master authority on whether a type is virtual (if it's a custom class, return false). Also, note that `ClassDB::class_exists` will still return false. I don't know what's the best design for this API, feedback welcome.