### PR TITLE
Improve `else` keyword completion in GDScript

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1219,7 +1219,7 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 
 	static const char *_keywords_with_space[] = {
 		"and", "not", "or", "in", "as", "class", "class_name", "extends", "is", "func", "signal", "await",
-		"const", "enum", "static", "var", "if", "elif", "else", "for", "match", "while",
+		"const", "enum", "static", "var", "if", "elif", "for", "match", "while",
 		nullptr
 	};
 
@@ -1230,6 +1230,10 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 		r_result.insert(option.display, option);
 		kws++;
 	}
+
+	ScriptLanguage::CodeCompletionOption else_option("else", ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
+	else_option.insert_text += ":";
+	r_result.insert(else_option.display, else_option);
 
 	static const char *_keywords_with_args[] = {
 		"assert", "preload",


### PR DESCRIPTION
Automatically add a colon instead of a space.

Before:

![](https://user-images.githubusercontent.com/47700418/196635097-db6a7b02-c02c-4f87-9962-57d9e9c21533.gif)

After:

![](https://user-images.githubusercontent.com/47700418/196635151-9f69b855-d5e2-475f-972e-9564c2f8c882.gif)

In the future, we should add line breaks and change the indentation level where appropriate:

```
else
====

els|<Enter>

->

else:
    |

pass, break, continue, return (void)
====================================

if true:
    pas|<Enter>

->

if true:
    pass
|

return (non-void)
=================

if true:
    return 0|<Enter>

->

if true:
    return 0
|
```