### PR TITLE
Fixes engine crashes caused by the user failing to initialize PCKPacker with pck_start()

### DIFF
--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -107,6 +107,8 @@ Error PCKPacker::pck_start(const String &p_file, int p_alignment, const String &
 }
 
 Error PCKPacker::add_file(const String &p_file, const String &p_src, bool p_encrypt) {
+	ERR_FAIL_COND_V_MSG(file.is_null(), ERR_INVALID_PARAMETER, "File must be opened before use.");
+
 	Ref<FileAccess> f = FileAccess::open(p_src, FileAccess::READ);
 	if (f.is_null()) {
 		return ERR_FILE_CANT_OPEN;


### PR DESCRIPTION
Fixes engine crashes caused by the user failing to initialize PCKPacker with pck_start()
Fixes: #67613