### PR TITLE
Expose the logic to recognize a save path in ResourceSaver

### DIFF
--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -69,10 +69,31 @@ void ResourceFormatSaver::get_recognized_extensions(const Ref<Resource> &p_resou
 	}
 }
 
+bool ResourceFormatSaver::recognize_path(const Ref<Resource> &p_resource, const String &p_path) const {
+	bool ret = false;
+	if (GDVIRTUAL_CALL(_recognize_path, p_resource, p_path, ret)) {
+		return ret;
+	}
+
+	String extension = p_path.get_extension();
+
+	List<String> extensions;
+	get_recognized_extensions(p_resource, &extensions);
+
+	for (const String &E : extensions) {
+		if (E.nocasecmp_to(extension) == 0) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 void ResourceFormatSaver::_bind_methods() {
 	GDVIRTUAL_BIND(_save, "resource", "path", "flags");
 	GDVIRTUAL_BIND(_recognize, "resource");
 	GDVIRTUAL_BIND(_get_recognized_extensions, "resource");
+	GDVIRTUAL_BIND(_recognize_path, "resource", "path");
 }
 
 Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
@@ -90,17 +111,7 @@ Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path,
 			continue;
 		}
 
-		List<String> extensions;
-		bool recognized = false;
-		saver[i]->get_recognized_extensions(p_resource, &extensions);
-
-		for (const String &E : extensions) {
-			if (E.nocasecmp_to(extension) == 0) {
-				recognized = true;
-			}
-		}
-
-		if (!recognized) {
+		if (!saver[i]->recognize_path(p_resource, path)) {
 			continue;
 		}
 

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -44,11 +44,13 @@ protected:
 	GDVIRTUAL3R(int64_t, _save, Ref<Resource>, String, uint32_t)
 	GDVIRTUAL1RC(bool, _recognize, Ref<Resource>)
 	GDVIRTUAL1RC(Vector<String>, _get_recognized_extensions, Ref<Resource>)
+	GDVIRTUAL2RC(bool, _recognize_path, Ref<Resource>, String)
 
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
+	virtual bool recognize_path(const Ref<Resource> &p_resource, const String &p_path) const;
 
 	virtual ~ResourceFormatSaver() {}
 };

--- a/doc/classes/ResourceFormatSaver.xml
+++ b/doc/classes/ResourceFormatSaver.xml
@@ -24,6 +24,15 @@
 				Returns whether the given resource object can be saved by this saver.
 			</description>
 		</method>
+		<method name="_recognize_path" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="resource" type="Resource" />
+			<param index="1" name="path" type="String" />
+			<description>
+				Returns [code]true[/code] if this saver handles a given save path and [code]false[/code] otherwise.
+				If this method is not implemented, the default behavior returns whether the path's extension is within the ones provided by [method _get_recognized_extensions].
+			</description>
+		</method>
 		<method name="_save" qualifiers="virtual">
 			<return type="int" />
 			<param index="0" name="resource" type="Resource" />


### PR DESCRIPTION
In the same vein as https://github.com/godotengine/godot/pull/67241, this exposes the logic to check whether or not path can be 
handled to save a given resource. 
This allows me to make a ResourceFormatSaver check for the prefix instead of the extension to save resources (in my case, I want to save the resource on a distant server so I need to check the resource path prefix for a protocol identifier and host).

I wondered if I should have merged `recognize` and `recognize_path` together (since they are called one after the other and both need the resource argument), but that would have meant breaking compatibility and would have required users to re-implement the extension check too even when they only could check the resource type instead. Thus I went with this implementation instead.