### PR TITLE
Ignore ResourceCache when loading a resource while analyzing preload

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3235,9 +3235,10 @@ void GDScriptAnalyzer::reduce_preload(GDScriptParser::PreloadNode *p_preload) {
 			}
 		} else {
 			// TODO: Don't load if validating: use completion cache.
-			p_preload->resource = ResourceLoader::load(p_preload->resolved_path);
+			Error load_error;
+			p_preload->resource = ResourceLoader::load(p_preload->resolved_path, "", ResourceFormatLoader::CACHE_MODE_IGNORE, &load_error);
 			if (p_preload->resource.is_null()) {
-				push_error(vformat(R"(Could not preload resource file "%s".)", p_preload->resolved_path), p_preload->path);
+				push_error(vformat(R"(Could not preload resource file "%s": %s.)", p_preload->resolved_path, error_names[load_error]), p_preload->path);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #67515

This PR uses `CACHE_MODE_IGNORE` when loading resources for the `GDScriptAnalyzer` in `reduce_preload`. I think it makes senses, that the cache is ignored when analyzing the preload, because it needs to mimic the behaviour of the script in a standalone application. If the cache is not ignored it behaves differently depending on what is currently loaded in the editor.

Also `load_error` is added so that the user gets a little more information on why the preload failed. This PR also correctly displays an error if files like JSON, which do have a `ResourceFormatLoader`, but can not be loaded, are loaded.
