### PR TITLE
Fix localize_path with custom protocol identifiers

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -153,8 +153,23 @@ const PackedStringArray ProjectSettings::_trim_to_supported_features(const Packe
 #endif // TOOLS_ENABLED
 
 String ProjectSettings::localize_path(const String &p_path) const {
-	if (resource_path.is_empty() || p_path.begins_with("res://") || p_path.begins_with("user://") ||
-			(p_path.is_absolute_path() && !p_path.begins_with(resource_path))) {
+	if (resource_path.is_empty() || (p_path.is_absolute_path() && !p_path.begins_with(resource_path))) {
+		return p_path.simplify_path();
+	}
+
+	// Check if we have a special path (like res://) or a protocol identifier.
+	int p = p_path.find("://");
+	bool found = false;
+	if (p > 0) {
+		found = true;
+		for (int i = 0; i < p; i++) {
+			if (!is_ascii_alphanumeric_char(p_path[i])) {
+				found = false;
+				break;
+			}
+		}
+	}
+	if (found) {
 		return p_path.simplify_path();
 	}
 

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3675,7 +3675,7 @@ String String::simplify_path() const {
 	if (p > 0) {
 		bool only_chars = true;
 		for (int i = 0; i < p; i++) {
-			if (!is_ascii_char(s[i])) {
+			if (!is_ascii_alphanumeric_char(s[i])) {
 				only_chars = false;
 				break;
 			}


### PR DESCRIPTION
This is a follow-up PR to https://github.com/godotengine/godot/pull/67251. `simplify_path` is now fixed, but the same issue was caused by `ProjectSettings::localize_path` when it was called from `ResourceLoader.load("test://")`.