### PR TITLE
Document known issues with CylinderShape (3.x)

### DIFF
--- a/doc/classes/CylinderShape.xml
+++ b/doc/classes/CylinderShape.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Cylinder shape for collisions.
+		[b]Note:[/b] When using GodotPhysics instead of the default Bullet physics engine, there are several known bugs with cylinder collision shapes. Using [CapsuleShape] or [BoxShape] instead is recommended.
 	</description>
 	<tutorials>
 		<link title="Third Person Shooter Demo">https://godotengine.org/asset-library/asset/678</link>


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/67648.

See https://github.com/godotengine/godot/issues/57048.