### PR TITLE
Fix double hint paste in EditorResourcePicker

### DIFF
--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -256,7 +256,7 @@ void EditorResourcePicker::_update_menu_items() {
 
 				paste_valid = ClassDB::is_parent_class(res_type, base) || EditorNode::get_editor_data().script_class_is_parent(res_type, base);
 
-				if (!paste_valid) {
+				if (paste_valid) {
 					break;
 				}
 			}


### PR DESCRIPTION
Fixes not being able to paste process material between particles:
![godot_Uiqc0a16gY](https://user-images.githubusercontent.com/2223172/196820931-d2b594b3-45c7-4500-9e82-531b5a1dfdcd.gif)
The property has this double hint `ShaderMaterial,ParticleProcessMaterial` and it wasn't handled properly.

EDIT:
Fixes #67641