### PR TITLE
Improve validation when setting `max`/`min`/`page` in `Range`

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -64,11 +64,6 @@ void Range::_changed_notify(const char *p_what) {
 	queue_redraw();
 }
 
-void Range::_validate_values() {
-	shared->max = MAX(shared->max, shared->min);
-	shared->page = CLAMP(shared->page, 0, shared->max - shared->min);
-}
-
 void Range::Shared::emit_changed(const char *p_what) {
 	for (Range *E : owners) {
 		Range *r = E;
@@ -111,8 +106,9 @@ void Range::set_min(double p_min) {
 	}
 
 	shared->min = p_min;
+	shared->max = MAX(shared->max, shared->min);
+	shared->page = CLAMP(shared->page, 0, shared->max - shared->min);
 	set_value(shared->val);
-	_validate_values();
 
 	shared->emit_changed("min");
 
@@ -120,13 +116,14 @@ void Range::set_min(double p_min) {
 }
 
 void Range::set_max(double p_max) {
-	if (shared->max == p_max) {
+	double max_validated = MAX(p_max, shared->min);
+	if (shared->max == max_validated) {
 		return;
 	}
 
-	shared->max = p_max;
+	shared->max = max_validated;
+	shared->page = CLAMP(shared->page, 0, shared->max - shared->min);
 	set_value(shared->val);
-	_validate_values();
 
 	shared->emit_changed("max");
 }
@@ -141,13 +138,13 @@ void Range::set_step(double p_step) {
 }
 
 void Range::set_page(double p_page) {
-	if (shared->page == p_page) {
+	double page_validated = CLAMP(p_page, 0, shared->max - shared->min);
+	if (shared->page == page_validated) {
 		return;
 	}
 
-	shared->page = p_page;
+	shared->page = page_validated;
 	set_value(shared->val);
-	_validate_values();
 
 	shared->emit_changed("page");
 }

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -59,7 +59,6 @@ class Range : public Control {
 
 	void _value_changed_notify();
 	void _changed_notify(const char *p_what = "");
-	void _validate_values();
 
 protected:
 	virtual void _value_changed(double p_value);


### PR DESCRIPTION
The incoming value is validated first and then compared.

Fix #67659.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
