### PR TITLE
Update velocity in move_and_slide_floating

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1368,11 +1368,14 @@ void CharacterBody2D::_move_and_slide_floating(double p_delta) {
 
 			if (wall_min_slide_angle != 0 && result.get_angle(-velocity.normalized()) < wall_min_slide_angle + FLOOR_ANGLE_THRESHOLD) {
 				motion = Vector2();
+				velocity = Vector2();
 			} else if (first_slide) {
 				Vector2 motion_slide_norm = result.remainder.slide(result.collision_normal).normalized();
 				motion = motion_slide_norm * (motion.length() - result.travel.length());
+				velocity = velocity.slide(result.collision_normal);
 			} else {
 				motion = result.remainder.slide(result.collision_normal);
+				velocity = velocity.slide(result.collision_normal);
 			}
 
 			if (motion.dot(velocity) <= 0.0) {

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1398,18 +1398,6 @@ void CharacterBody2D::_move_and_slide_floating(double p_delta) {
 
 		first_slide = false;
 	}
-
-	// Scales the velocity according to the wall slope.
-	if (is_on_wall() && velocity.dot(motion_results.get(0).collision_normal) < 0) {
-		// Slide the velocity against the first collision.
-		Vector2 slide_motion = velocity.slide(motion_results.get(0).collision_normal);
-		if (velocity.dot(slide_motion) < 0) {
-			// This shouldn't send us backwards.
-			velocity = Vector2();
-		} else {
-			velocity = slide_motion;
-		}
-	}
 }
 
 void CharacterBody2D::_snap_on_floor(bool p_was_on_floor, bool p_vel_dir_facing_up, bool p_wall_as_floor) {

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1344,7 +1344,6 @@ void CharacterBody2D::_move_and_slide_floating(double p_delta) {
 
 	platform_rid = RID();
 	platform_object_id = ObjectID();
-	floor_normal = Vector2();
 	platform_velocity = Vector2();
 
 	bool first_slide = true;
@@ -1361,7 +1360,7 @@ void CharacterBody2D::_move_and_slide_floating(double p_delta) {
 			motion_results.push_back(result);
 			_set_collision_direction(result);
 
-			if (wall_min_slide_angle != 0 && result.get_angle(-velocity.normalized()) < wall_min_slide_angle + FLOOR_ANGLE_THRESHOLD) {
+			if (wall_min_slide_angle != 0 && Math::acos(result.collision_normal.dot(-velocity.normalized())) < wall_min_slide_angle + FLOOR_ANGLE_THRESHOLD) {
 				// hit a wall at a sharp enough angle that we should stop
 				if (result.travel.length() <= margin + CMP_EPSILON) {
 					// Cancels the motion.

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1380,10 +1380,8 @@ void CharacterBody2D::_move_and_slide_floating(double p_delta) {
 			} else if (first_slide) {
 				Vector2 motion_slide_norm = result.remainder.slide(result.collision_normal).normalized();
 				motion = motion_slide_norm * (motion.length() - result.travel.length());
-				velocity = velocity.slide(result.collision_normal);
 			} else {
 				motion = result.remainder.slide(result.collision_normal);
-				velocity = velocity.slide(result.collision_normal);
 			}
 
 			if (motion.dot(velocity) <= 0.0) {

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -1531,9 +1531,9 @@ void CharacterBody3D::_move_and_slide_floating(double p_delta) {
 					gt.columns[2] -= result.travel;
 					set_global_transform(gt);
 				}
-				motion = Vector2();
-				last_motion = Vector2();
-				velocity = Vector2();
+				motion = Vector3();
+				last_motion = Vector3();
+				velocity = Vector3();
 				break;
 			}
 


### PR DESCRIPTION
Adjust velocity based on the collision normal when using `move_and_slide_floating()` in 2D.

Fixes #60447.

Here is a minimal test project.  In master, the CharacterBody's velocity remains fixed as it collides, resulting in it moving in unexpected ways.  Applying the commit causes it to slide off the walls correctly and stop when hitting a wall at an angle less than its `wall_min_slide_angle`.
[collisiontest.zip](https://github.com/godotengine/godot/files/9826223/collisiontest.zip)
