### PR TITLE
Don't try to import unknown dependency from scan

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -619,7 +619,12 @@ bool EditorFileSystem::_update_scan_actions() {
 				if (_test_for_reimport(full_path, false)) {
 					//must reimport
 					reimports.push_back(full_path);
-					reimports.append_array(_get_dependencies(full_path));
+					Vector<String> dependencies = _get_dependencies(full_path);
+					for (const String &dependency_path : dependencies) {
+						if (import_extensions.has(dependency_path.get_extension())) {
+							reimports.push_back(dependency_path);
+						}
+					}
 				} else {
 					//must not reimport, all was good
 					//update modified times, to avoid reimport


### PR DESCRIPTION
Only import dependency we know how to import, since custom resource may have .gd in dependency list which doesn't have an importer

I was encountering `BUG: File queued for import, but can't be imported, importer for type '' not found.` when I modified my resource file that has custom importer addon. The code was trying to reimport script file (".gd") of my resource, which can't be imported.

After seeing similar issues ( https://github.com/godotengine/godot/issues/45524 , https://github.com/godotengine/godot/issues/46288 and https://github.com/godotengine/godot/issues/51816 ), I think this is the right thing to do?

Should fix #46288

*Bugsquad edit:*
- Fixes error messages in #45524
- Fixes #46288
- Fixes #51816