### PR TITLE
[3.x] Fix wrong owner for editor plugin created nodes in instanced scene

### DIFF
--- a/editor/plugins/mesh_instance_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_editor_plugin.cpp
@@ -76,7 +76,7 @@ void MeshInstanceEditor::_menu_option(int p_option) {
 				StaticBody *body = memnew(StaticBody);
 				body->add_child(cshape);
 
-				Node *owner = node == get_tree()->get_edited_scene_root() ? node : node->get_owner();
+				Node *owner = get_tree()->get_edited_scene_root();
 
 				ur->create_action(TTR("Create Static Trimesh Body"));
 				ur->add_do_method(node, "add_child", body);
@@ -111,7 +111,7 @@ void MeshInstanceEditor::_menu_option(int p_option) {
 				StaticBody *body = memnew(StaticBody);
 				body->add_child(cshape);
 
-				Node *owner = instance == get_tree()->get_edited_scene_root() ? instance : instance->get_owner();
+				Node *owner = get_tree()->get_edited_scene_root();
 
 				ur->add_do_method(instance, "add_child", body);
 				ur->add_do_method(body, "set_owner", owner);
@@ -140,7 +140,7 @@ void MeshInstanceEditor::_menu_option(int p_option) {
 			cshape->set_shape(shape);
 			cshape->set_transform(node->get_transform());
 
-			Node *owner = node->get_owner();
+			Node *owner = get_tree()->get_edited_scene_root();
 
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 
@@ -183,7 +183,7 @@ void MeshInstanceEditor::_menu_option(int p_option) {
 			cshape->set_shape(shape);
 			cshape->set_transform(node->get_transform());
 
-			Node *owner = node->get_owner();
+			Node *owner = get_tree()->get_edited_scene_root();
 
 			ur->add_do_method(node->get_parent(), "add_child", cshape);
 			ur->add_do_method(node->get_parent(), "move_child", cshape, node->get_index() + 1);
@@ -218,7 +218,7 @@ void MeshInstanceEditor::_menu_option(int p_option) {
 				cshape->set_shape(shapes[i]);
 				cshape->set_transform(node->get_transform());
 
-				Node *owner = node->get_owner();
+				Node *owner = get_tree()->get_edited_scene_root();
 
 				ur->add_do_method(node->get_parent(), "add_child", cshape);
 				ur->add_do_method(node->get_parent(), "move_child", cshape, node->get_index() + 1);
@@ -241,7 +241,7 @@ void MeshInstanceEditor::_menu_option(int p_option) {
 			NavigationMeshInstance *nmi = memnew(NavigationMeshInstance);
 			nmi->set_navigation_mesh(nmesh);
 
-			Node *owner = node == get_tree()->get_edited_scene_root() ? node : node->get_owner();
+			Node *owner = get_tree()->get_edited_scene_root();
 
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 			ur->create_action(TTR("Create Navigation Mesh"));
@@ -419,10 +419,7 @@ void MeshInstanceEditor::_create_outline_mesh() {
 
 	MeshInstance *mi = memnew(MeshInstance);
 	mi->set_mesh(mesho);
-	Node *owner = node->get_owner();
-	if (get_tree()->get_edited_scene_root() == node) {
-		owner = node;
-	}
+	Node *owner = get_tree()->get_edited_scene_root();
 
 	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 

--- a/editor/plugins/skeleton_editor_plugin.cpp
+++ b/editor/plugins/skeleton_editor_plugin.cpp
@@ -51,7 +51,7 @@ void SkeletonEditor::_on_click_option(int p_option) {
 
 void SkeletonEditor::create_physical_skeleton() {
 	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
-	Node *owner = skeleton == get_tree()->get_edited_scene_root() ? skeleton : skeleton->get_owner();
+	Node *owner = get_tree()->get_edited_scene_root();
 
 	const int bc = skeleton->get_bone_count();
 


### PR DESCRIPTION
I instanced a `.gltf` scene, and turned on Editable Children in order to create physical bones for the Skeleton inside. When using Create Physical Skeleton in the Skeleton menu, the created Physical Bones have their owner wrong (greyed out, as if they are part of the original scene).

Other operations like generating colliders also have this issue. This does not happen on master.