### PR TITLE
Document PopupMenu "id_pressed" behavior

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -533,6 +533,8 @@
 			<param index="0" name="id" type="int" />
 			<description>
 				Emitted when an item of some [param id] is pressed or its accelerator is activated.
+
+				[b]Note:[/b] If [param id] is negative (either explicitly or due to overflow), this will return the correponding index instead.
 			</description>
 		</signal>
 		<signal name="index_pressed">


### PR DESCRIPTION
Fixes #53423

This documents the check done in code that changes the ID if it isn't valid (negative or overflow):
https://github.com/godotengine/godot/blob/a8c805be2947b211ee8b881d7a8bab7cdc86e170/scene/gui/popup_menu.cpp#L1671

Not sure if I should add a warning in code though, as this behavior isn't consistent; for example `id_focused` does not handle this.