### PR TITLE
Fix physics/3d/run_on_separate_thread race condition in WorkerThreadPool (crash).

### DIFF
--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -402,7 +402,9 @@ void WorkerThreadPool::wait_for_group_task_completion(GroupID p_group) {
 		}
 	}
 
-	groups.erase(p_group); // Threads do not access this, so safe to erase here.
+	task_mutex.lock(); // This mutex is needed when Physics 2D and/or 3D is selected to run on a separate thread.
+	groups.erase(p_group);
+	task_mutex.unlock();
 }
 
 void WorkerThreadPool::init(int p_thread_count, bool p_use_native_threads_low_priority, float p_low_priority_task_ratio) {


### PR DESCRIPTION
Fixes #67333, fixes #63671, fixes #63879
May also fix this: #61250

This mutex request fixes a race condition in `WorkerThreadPool` as far as I can tell. The race condition causes an eventual segmentation fault (crash). The comment on the `groups.erase(p_group);` is only true when `physics/3d/run_on_separate_thread` option in the project settings is disabled.

For example, add the following line next to `groups.erase(p_group);`:

```cpp
OS::get_singleton()->print("Thread id: %u\n", Thread::get_caller_id()); // Debug line
groups.erase(p_group); // Threads do not access this, so safe to erase here.
```

If you have `physics/3d/run_on_separate_thread` **disabled**, it prints only a single thread id:
```bash
...
Thread id: 3401590889
Thread id: 3401590889
Thread id: 3401590889
Thread id: 3401590889
Thread id: 3401590889
Thread id: 3401590889
...
```

If you **enable** `physics/3d/run_on_separate_thread`, it prints two thread ids:
```bash
...
Thread id: 3840933713
Thread id: 3840933713
Thread id: 1959143244
Thread id: 3840933713
Thread id: 3840933713
Thread id: 1959143244
Thread id: 3840933713
Thread id: 3840933713
...
```

The same is true if you enable the 2D thread in `physics/2d/run_on_separate_thread`. If you have separate threads enabled for both 2D and 3D, there are still only two thread ids printed.

I understand that this might not be the ideal place to fix the race condition, as the comment on the line suggests that there should not be multiple threads accessing it. However, this does fix the UI crashing in 4.0 beta 3 (or since #63354).

To test this:
1. Create empty project and enable `physics/3d/run_on_separate_thread` in the settings.
2. Save an empty scene with Control node as root.
3. Run project.
4. To speed up crashing (could be a placebo): move your mouse on and off the window. This will create internal events. Within a minute or so, your program crashes without this PR fix.

Or you can run any existing project with the `physics/3d/run_on_separate_thread` enabled and it will crash within minutes without this PR fix.

I'd really appreciate if someone else also verified this as it _works on my machine™_ .