### PR TITLE
Fix tp_canvas_item typo in _draw_rect_region

### DIFF
--- a/doc/classes/Texture2D.xml
+++ b/doc/classes/Texture2D.xml
@@ -33,7 +33,7 @@
 		</method>
 		<method name="_draw_rect_region" qualifiers="virtual const">
 			<return type="void" />
-			<param index="0" name="tp_canvas_item" type="RID" />
+			<param index="0" name="to_canvas_item" type="RID" />
 			<param index="1" name="rect" type="Rect2" />
 			<param index="2" name="src_rect" type="Rect2" />
 			<param index="3" name="modulate" type="Color" />

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -122,7 +122,7 @@ void Texture2D::_bind_methods() {
 
 	GDVIRTUAL_BIND(_draw, "to_canvas_item", "pos", "modulate", "transpose")
 	GDVIRTUAL_BIND(_draw_rect, "to_canvas_item", "rect", "tile", "modulate", "transpose")
-	GDVIRTUAL_BIND(_draw_rect_region, "tp_canvas_item", "rect", "src_rect", "modulate", "transpose", "clip_uv");
+	GDVIRTUAL_BIND(_draw_rect_region, "to_canvas_item", "rect", "src_rect", "modulate", "transpose", "clip_uv");
 }
 
 Texture2D::Texture2D() {


### PR DESCRIPTION
Fixes a typo in `_draw_rect_region` of `Texture2D`