### PR TITLE
[WIP] Fix JSON file not loaded

### DIFF
--- a/core/io/json.h
+++ b/core/io/json.h
@@ -36,8 +36,8 @@
 #include "core/io/resource_saver.h"
 #include "core/variant/variant.h"
 
-class JSON : public RefCounted {
-	GDCLASS(JSON, RefCounted);
+class JSON : public Resource {
+	GDCLASS(JSON, Resource);
 
 	enum TokenType {
 		TK_CURLY_BRACKET_OPEN,


### PR DESCRIPTION
Fixes #67630.

The problem is that currently the inheritance tree looks like this:
```
Object
└── RefCounted
    ├── Resource
    └── JSON
```

This means that `JSON` cannot be loaded using `ResourceLoader`, because it's not actually a `Resource`.

One solution would be to make `JSON` a `Resource`, as in this PR. I'm not sure about this, seeing how `FileAccess` is also not a resource, and is a similar type. Possibly we would have to move several types around.

Another solution is to make the `ResourceLoader.load` method return `Ref<RefCounted>`, which also seems like a huge change.

I will wait for the feedback from the maintainers ;)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
