### PR TITLE
Fix unordered values of PROPERTY_HINT_INT_IS_POINTER & ARRAY_TYPE

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -89,8 +89,8 @@ enum PropertyHint {
 	PROPERTY_HINT_SAVE_FILE, ///< a file path must be passed, hint_text (optionally) is a filter "*.png,*.wav,*.doc,". This opens a save dialog
 	PROPERTY_HINT_GLOBAL_SAVE_FILE, ///< a file path must be passed, hint_text (optionally) is a filter "*.png,*.wav,*.doc,". This opens a save dialog
 	PROPERTY_HINT_INT_IS_OBJECTID,
-	PROPERTY_HINT_ARRAY_TYPE,
 	PROPERTY_HINT_INT_IS_POINTER,
+	PROPERTY_HINT_ARRAY_TYPE,
 	PROPERTY_HINT_LOCALE_ID,
 	PROPERTY_HINT_LOCALIZABLE_STRING,
 	PROPERTY_HINT_NODE_TYPE, ///< a node object type

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2756,9 +2756,9 @@
 		</constant>
 		<constant name="PROPERTY_HINT_INT_IS_OBJECTID" value="39" enum="PropertyHint">
 		</constant>
-		<constant name="PROPERTY_HINT_INT_IS_POINTER" value="41" enum="PropertyHint">
+		<constant name="PROPERTY_HINT_INT_IS_POINTER" value="40" enum="PropertyHint">
 		</constant>
-		<constant name="PROPERTY_HINT_ARRAY_TYPE" value="40" enum="PropertyHint">
+		<constant name="PROPERTY_HINT_ARRAY_TYPE" value="41" enum="PropertyHint">
 		</constant>
 		<constant name="PROPERTY_HINT_LOCALE_ID" value="42" enum="PropertyHint">
 			Hints that a string property is a locale code. Editing it will show a locale dialog for picking language and country.


### PR DESCRIPTION
See comment https://github.com/godotengine/godot/pull/67688#issuecomment-1286205941,

Switches **PROPERTY_HINT_INT_IS_POINTER** and **PROPERTY_HINT_ARRAY_TYPE** around, so that 40 comes before 41 . 

Note that the alternative solution could've been to instead switch the BIND_CONSTANTs, but the order it used feels slightly more appropriate. I'm aware that one day of beta could be used to order the enum constants, however.