### PR TITLE
[3.x] Fix error when having BoneAttachment before PhysicalBone

### DIFF
--- a/scene/3d/skeleton.cpp
+++ b/scene/3d/skeleton.cpp
@@ -140,8 +140,9 @@ bool Skeleton::_get(const StringName &p_path, Variant &r_ret) const {
 	} else if (what == "bound_children") {
 		Array children;
 
-		for (const List<uint32_t>::Element *E = bones[which].nodes_bound.front(); E; E = E->next()) {
-			Object *obj = ObjectDB::get_instance(E->get());
+		const LocalVectori<uint32_t> &nodes = bones[which].nodes_bound;
+		for (int i = 0; i < nodes.size(); i++) {
+			Object *obj = ObjectDB::get_instance(nodes[i]);
 			ERR_CONTINUE(!obj);
 			Node *node = Object::cast_to<Node>(obj);
 			ERR_CONTINUE(!node);
@@ -290,8 +291,9 @@ void Skeleton::_notification(int p_what) {
 					b.global_pose_override_amount = 0.0;
 				}
 
-				for (List<uint32_t>::Element *E = b.nodes_bound.front(); E; E = E->next()) {
-					Object *obj = ObjectDB::get_instance(E->get());
+				const LocalVectori<uint32_t> &nodes = b.nodes_bound;
+				for (int j = 0; j < nodes.size(); j++) {
+					Object *obj = ObjectDB::get_instance(nodes[j]);
 					ERR_CONTINUE(!obj);
 					Spatial *sp = Object::cast_to<Spatial>(obj);
 					ERR_CONTINUE(!sp);
@@ -525,10 +527,8 @@ void Skeleton::bind_child_node_to_bone(int p_bone, Node *p_node) {
 
 	uint32_t id = p_node->get_instance_id();
 
-	for (const List<uint32_t>::Element *E = bones[p_bone].nodes_bound.front(); E; E = E->next()) {
-		if (E->get() == id) {
-			return; // already here
-		}
+	if (bones[p_bone].nodes_bound.find(id) != -1) {
+		return; // Already here.
 	}
 
 	bones.write[p_bone].nodes_bound.push_back(id);
@@ -538,13 +538,20 @@ void Skeleton::unbind_child_node_from_bone(int p_bone, Node *p_node) {
 	ERR_FAIL_INDEX(p_bone, bones.size());
 
 	uint32_t id = p_node->get_instance_id();
-	bones.write[p_bone].nodes_bound.erase(id);
+
+	int index = bones[p_bone].nodes_bound.find(id);
+	if (index == -1) {
+		return; // Doesn't exist in the first place.
+	}
+
+	bones.write[p_bone].nodes_bound.remove(index);
 }
 void Skeleton::get_bound_child_nodes_to_bone(int p_bone, List<Node *> *p_bound) const {
 	ERR_FAIL_INDEX(p_bone, bones.size());
 
-	for (const List<uint32_t>::Element *E = bones[p_bone].nodes_bound.front(); E; E = E->next()) {
-		Object *obj = ObjectDB::get_instance(E->get());
+	const LocalVectori<uint32_t> &nodes = bones[p_bone].nodes_bound;
+	for (int i = 0; i < nodes.size(); i++) {
+		Object *obj = ObjectDB::get_instance(nodes[i]);
 		ERR_CONTINUE(!obj);
 		p_bound->push_back(Object::cast_to<Node>(obj));
 	}

--- a/scene/3d/skeleton.h
+++ b/scene/3d/skeleton.h
@@ -102,7 +102,7 @@ private:
 		PhysicalBone *cache_parent_physical_bone;
 #endif // _3D_DISABLED
 
-		List<uint32_t> nodes_bound;
+		LocalVectori<uint32_t> nodes_bound;
 
 		Bone() {
 			parent = -1;


### PR DESCRIPTION
Fixes #42010

`bind_child_node_to_bone()` allows re-adding an existing bind. But `unbind_child_node_from_bone()` does not have extra checks for unbinding a non-existing bindings. So `List::erase()` complains about erasing something that does not exist.

There's no error when no `BoneAttachment` node comes before a `PhysicalBone`. This is because calling `List::erase()` on an empty list won't print an error. (Bone attachments are also bind to bones, so when there's a bone attachment node before the physical bone, the bind node list is not empty when it enters tree.)

It's inconsistent that `List::erase()` behaves differently when empty and non-empty. But I think fixing this on `Skeleton` level is acceptable since we prefer local solutions :stuck_out_tongue: 

There're no such methods on `master`.