### PR TITLE
Fix error emitting when clicking on end line in `TextEdit`

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4758,8 +4758,7 @@ void TextEdit::set_selection_mode(SelectionMode p_mode, int p_line, int p_column
 	}
 	if (p_column >= 0) {
 		ERR_FAIL_INDEX(carets[p_caret].selection.selecting_line, text.size());
-		ERR_FAIL_INDEX(p_column, text[carets[p_caret].selection.selecting_line].length() + 1);
-		carets.write[p_caret].selection.selecting_column = p_column;
+		carets.write[p_caret].selection.selecting_column = CLAMP(p_column, 0, text[carets[p_caret].selection.selecting_line].length());
 	}
 }
 


### PR DESCRIPTION
Fix the following bug:
![bug2](https://user-images.githubusercontent.com/3036176/197142861-6d80953a-6f08-45f3-93c2-3a3a1333b046.gif)

Fix https://github.com/godotengine/godot/issues/67828
