### PR TITLE
Fix private properties appearing in custom class doc Property Descriptions

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1489,6 +1489,10 @@ void EditorHelp::_update_doc() {
 			if (cd.properties[i].overridden) {
 				continue;
 			}
+			// Ignore undocumented private.
+			if (cd.properties[i].name.begins_with("_") && cd.properties[i].description.strip_edges().is_empty()) {
+				continue;
+			}
 
 			property_line[cd.properties[i].name] = class_desc->get_paragraph_count() - 2;
 


### PR DESCRIPTION
This fixes one of the issues mentioned in #67704, namely private properties appearing in Property Descriptions.
I just copy-pasted this from the part of the code that updates the Properties list, which does work, but it might be a better idea to filter properties in the same way methods are filtered in `_update_method_descriptions`.

*Bugsquad edit:*
- Fixes #72705