### PR TITLE
Remove error condition from get_global_transform()

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -416,7 +416,7 @@
 		<method name="get_global_transform" qualifiers="const">
 			<return type="Transform2D" />
 			<description>
-				Returns the global transform matrix of this item.
+				Returns the global transform matrix of this item, i.e. the combined transform up to the topmost [CanvasItem] node. The topmost item is a [CanvasItem] that either has no parent, has non-[CanvasItem] parent or it has [member top_level] enabled.
 			</description>
 		</method>
 		<method name="get_global_transform_with_canvas" qualifiers="const">

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -168,9 +168,6 @@ Transform2D CanvasItem::get_screen_transform() const {
 }
 
 Transform2D CanvasItem::get_global_transform() const {
-#ifdef DEBUG_ENABLED
-	ERR_FAIL_COND_V(!is_inside_tree(), get_transform());
-#endif
 	if (global_invalid) {
 		const CanvasItem *pi = get_parent_item();
 		if (pi) {


### PR DESCRIPTION
Removes the arbitrary error in `get_global_transform()` method.

The error makes no sense for a couple of reasons:
- it only triggers in debug build, which means the method works differently in release build
- even with the error, the transform may not be truly "global", because `Node` ancestors stop transform propagation
  - if node is not inside tree, it has `null` parent, which is effectively the same as having `Node` parent

Closes #30445