### PR TITLE
Fix cyclic references in GDScript 2.0

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -39,6 +39,7 @@
 #include "core/templates/hash_map.h"
 #include "gdscript.h"
 #include "gdscript_utility_functions.h"
+#include "scene/resources/packed_scene.h"
 
 static MethodInfo info_from_utility_func(const StringName &p_function) {
 	ERR_FAIL_COND_V(!Variant::has_utility_function(p_function), MethodInfo());
@@ -3103,12 +3104,40 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 			GDScriptParser::DataType result;
 			result.kind = GDScriptParser::DataType::NATIVE;
 			result.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;
-			if (autoload.path.to_lower().ends_with(GDScriptLanguage::get_singleton()->get_extension())) {
+			if (ResourceLoader::get_resource_type(autoload.path) == "GDScript") {
 				Ref<GDScriptParserRef> singl_parser = get_parser_for(autoload.path);
 				if (singl_parser.is_valid()) {
 					Error err = singl_parser->raise_status(GDScriptParserRef::INTERFACE_SOLVED);
 					if (err == OK) {
 						result = type_from_metatype(singl_parser->get_parser()->head->get_datatype());
+					}
+				}
+			} else if (ResourceLoader::get_resource_type(autoload.path) == "PackedScene") {
+				Error err = OK;
+				Ref<PackedScene> scene = GDScriptCache::get_packed_scene(autoload.path, err);
+				if (err == OK && scene->get_state().is_valid()) {
+					Ref<SceneState> state = scene->get_state();
+					if (state->get_node_count() > 0) {
+						const int ROOT_NODE = 0;
+						for (int i = 0; i < state->get_node_property_count(ROOT_NODE); i++) {
+							if (state->get_node_property_name(ROOT_NODE, i) != SNAME("script")) {
+								continue;
+							}
+
+							Ref<GDScript> scr = state->get_node_property_value(ROOT_NODE, i);
+							if (scr.is_null()) {
+								continue;
+							}
+
+							Ref<GDScriptParserRef> singl_parser = get_parser_for(scr->get_path());
+							if (singl_parser.is_valid()) {
+								err = singl_parser->raise_status(GDScriptParserRef::INTERFACE_SOLVED);
+								if (err == OK) {
+									result = type_from_metatype(singl_parser->get_parser()->head->get_datatype());
+								}
+							}
+							break;
+						}
 					}
 				}
 			}
@@ -3236,9 +3265,28 @@ void GDScriptAnalyzer::reduce_preload(GDScriptParser::PreloadNode *p_preload) {
 			}
 		} else {
 			// TODO: Don't load if validating: use completion cache.
-			p_preload->resource = ResourceLoader::load(p_preload->resolved_path);
-			if (p_preload->resource.is_null()) {
-				push_error(vformat(R"(Could not preload resource file "%s".)", p_preload->resolved_path), p_preload->path);
+
+			// Must load GDScript and PackedScenes separately to permit cyclic references
+			// as ResourceLoader::load() detect and reject those.
+			if (ResourceLoader::get_resource_type(p_preload->resolved_path) == "GDScript") {
+				Error err = OK;
+				Ref<GDScript> res = GDScriptCache::get_shallow_script(p_preload->resolved_path, err, parser->script_path);
+				p_preload->resource = res;
+				if (err != OK) {
+					push_error(vformat(R"(Could not preload resource script "%s".)", p_preload->resolved_path), p_preload->path);
+				}
+			} else if (ResourceLoader::get_resource_type(p_preload->resolved_path) == "PackedScene") {
+				Error err = OK;
+				Ref<PackedScene> res = GDScriptCache::get_packed_scene(p_preload->resolved_path, err, parser->script_path);
+				p_preload->resource = res;
+				if (err != OK) {
+					push_error(vformat(R"(Could not preload resource scene "%s".)", p_preload->resolved_path), p_preload->path);
+				}
+			} else {
+				p_preload->resource = ResourceLoader::load(p_preload->resolved_path);
+				if (p_preload->resource.is_null()) {
+					push_error(vformat(R"(Could not preload resource file "%s".)", p_preload->resolved_path), p_preload->path);
+				}
 			}
 		}
 	}
@@ -3280,6 +3328,17 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 			// Just try to get it.
 			bool valid = false;
 			Variant value = p_subscript->base->reduced_value.get_named(p_subscript->attribute->name, valid);
+
+			// If it's a GDScript instance, try to get the full script. Maybe it's not still completely loaded.
+			Ref<GDScript> gdscr = Ref<GDScript>(p_subscript->base->reduced_value);
+			if (!valid && gdscr.is_valid()) {
+				Error err = OK;
+				GDScriptCache::get_full_script(gdscr->get_path(), err);
+				if (err == OK) {
+					value = p_subscript->base->reduced_value.get_named(p_subscript->attribute->name, valid);
+				}
+			}
+
 			if (!valid) {
 				push_error(vformat(R"(Cannot get member "%s" from "%s".)", p_subscript->attribute->name, p_subscript->base->reduced_value), p_subscript->index);
 				result_type.kind = GDScriptParser::DataType::VARIANT;
@@ -3662,50 +3721,43 @@ GDScriptParser::DataType GDScriptAnalyzer::type_from_variant(const Variant &p_va
 			scr = obj->get_script();
 		}
 		if (scr.is_valid()) {
-			if (scr->is_valid()) {
-				result.script_type = scr;
-				result.script_path = scr->get_path();
-				Ref<GDScript> gds = scr;
-				if (gds.is_valid()) {
-					result.kind = GDScriptParser::DataType::CLASS;
-					// This might be an inner class, so we want to get the parser for the root.
-					// But still get the inner class from that tree.
-					GDScript *current = gds.ptr();
-					List<StringName> class_chain;
-					while (current->_owner) {
-						// Push to front so it's in reverse.
-						class_chain.push_front(current->name);
-						current = current->_owner;
-					}
-
-					Ref<GDScriptParserRef> ref = get_parser_for(current->get_path());
-					if (ref.is_null()) {
-						push_error("Could not find script in path.", p_source);
-						GDScriptParser::DataType error_type;
-						error_type.kind = GDScriptParser::DataType::VARIANT;
-						return error_type;
-					}
-					ref->raise_status(GDScriptParserRef::INTERFACE_SOLVED);
-
-					GDScriptParser::ClassNode *found = ref->get_parser()->head;
-
-					// It should be okay to assume this exists, since we have a complete script already.
-					for (const StringName &E : class_chain) {
-						found = found->get_member(E).m_class;
-					}
-
-					result.class_type = found;
-					result.script_path = ref->get_parser()->script_path;
-				} else {
-					result.kind = GDScriptParser::DataType::SCRIPT;
+			result.script_type = scr;
+			result.script_path = scr->get_path();
+			Ref<GDScript> gds = scr;
+			if (gds.is_valid()) {
+				result.kind = GDScriptParser::DataType::CLASS;
+				// This might be an inner class, so we want to get the parser for the root.
+				// But still get the inner class from that tree.
+				GDScript *current = gds.ptr();
+				List<StringName> class_chain;
+				while (current->_owner) {
+					// Push to front so it's in reverse.
+					class_chain.push_front(current->name);
+					current = current->_owner;
 				}
-				result.native_type = scr->get_instance_base_type();
+
+				Ref<GDScriptParserRef> ref = get_parser_for(current->get_path());
+				if (ref.is_null()) {
+					push_error("Could not find script in path.", p_source);
+					GDScriptParser::DataType error_type;
+					error_type.kind = GDScriptParser::DataType::VARIANT;
+					return error_type;
+				}
+				ref->raise_status(GDScriptParserRef::INTERFACE_SOLVED);
+
+				GDScriptParser::ClassNode *found = ref->get_parser()->head;
+
+				// It should be okay to assume this exists, since we have a complete script already.
+				for (const StringName &E : class_chain) {
+					found = found->get_member(E).m_class;
+				}
+
+				result.class_type = found;
+				result.script_path = ref->get_parser()->script_path;
 			} else {
-				push_error(vformat(R"(Constant value uses script from "%s" which is loaded but not compiled.)", scr->get_path()), p_source);
-				result.kind = GDScriptParser::DataType::VARIANT;
-				result.type_source = GDScriptParser::DataType::UNDETECTED;
-				result.is_meta_type = false;
+				result.kind = GDScriptParser::DataType::SCRIPT;
 			}
+			result.native_type = scr->get_instance_base_type();
 		} else {
 			result.kind = GDScriptParser::DataType::NATIVE;
 			if (result.native_type == GDScriptNativeClass::get_class_static()) {

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -149,9 +149,16 @@ GDScriptFunction::GDScriptFunction() {
 }
 
 GDScriptFunction::~GDScriptFunction() {
+	get_script()->member_functions.erase(name);
+
 	for (int i = 0; i < lambdas.size(); i++) {
 		memdelete(lambdas[i]);
 	}
+
+	for (int i = 0; i < argument_types.size(); i++) {
+		argument_types.write[i].script_type_ref = Ref<Script>();
+	}
+	return_type.script_type_ref = Ref<Script>();
 
 #ifdef DEBUG_ENABLED
 

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -430,6 +430,7 @@ public:
 	};
 
 private:
+	friend class GDScript;
 	friend class GDScriptCompiler;
 	friend class GDScriptByteCodeGenerator;
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -648,7 +648,13 @@ GDScriptParser::ClassNode *GDScriptParser::parse_class() {
 	if (consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected identifier for the class name after "class".)")) {
 		n_class->identifier = parse_identifier();
 		if (n_class->outer) {
-			n_class->fqcn = n_class->outer->fqcn + "::" + n_class->identifier->name;
+			String fqcn = n_class->outer->fqcn;
+			if (fqcn.is_empty()) {
+				fqcn = script_path;
+			}
+			n_class->fqcn = fqcn + "::" + n_class->identifier->name;
+		} else {
+			n_class->fqcn = n_class->identifier->name;
 		}
 	}
 

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -251,7 +251,10 @@ bool GDScriptTestRunner::make_tests_for_dir(const String &p_dir) {
 				return false;
 			}
 		} else {
-			if (next.get_extension().to_lower() == "gd") {
+			if (next.ends_with(".notest.gd")) {
+				next = dir->get_next();
+				continue;
+			} else if (next.get_extension().to_lower() == "gd") {
 #ifndef DEBUG_ENABLED
 				// On release builds, skip tests marked as debug only.
 				Error open_err = OK;
@@ -597,6 +600,9 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 	}
 
 	enable_stdout();
+
+	GDScriptCache::remove_script(script->get_path());
+
 	return result;
 }
 

--- a/modules/gdscript/tests/scripts/analyzer/features/gdscript_to_preload.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/gdscript_to_preload.notest.gd
@@ -1,7 +1,4 @@
 const A := 42
 
-func test():
-	pass
-
 func something():
 	return "OK"

--- a/modules/gdscript/tests/scripts/analyzer/features/preload_constant_types_are_inferred.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/preload_constant_types_are_inferred.gd
@@ -1,4 +1,4 @@
-const Constants = preload("gdscript_to_preload.gd")
+const Constants = preload("gdscript_to_preload.notest.gd")
 
 func test():
 	var a := Constants.A

--- a/modules/gdscript/tests/scripts/analyzer/features/preload_cyclic_reference.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/preload_cyclic_reference.gd
@@ -1,0 +1,4 @@
+const A = preload("preload_cyclic_reference_a.notest.gd")
+
+func test():
+	A.test_cyclic_reference()

--- a/modules/gdscript/tests/scripts/analyzer/features/preload_cyclic_reference.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/preload_cyclic_reference.out
@@ -1,1 +1,2 @@
 GDTEST_OK
+godot

--- a/modules/gdscript/tests/scripts/analyzer/features/preload_cyclic_reference_a.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/preload_cyclic_reference_a.notest.gd
@@ -1,0 +1,12 @@
+const B = preload("preload_cyclic_reference_b.notest.gd")
+
+const WAITING_FOR = "godot"
+
+static func test_cyclic_reference():
+	B.test_cyclic_reference()
+
+static func test_cyclic_reference_2():
+	B.test_cyclic_reference_2()
+
+static func test_cyclic_reference_3():
+	B.test_cyclic_reference_3()

--- a/modules/gdscript/tests/scripts/analyzer/features/preload_cyclic_reference_b.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/preload_cyclic_reference_b.notest.gd
@@ -1,0 +1,10 @@
+const A = preload("preload_cyclic_reference_a.notest.gd")
+
+static func test_cyclic_reference():
+	A.test_cyclic_reference_2()
+
+static func test_cyclic_reference_2():
+	A.test_cyclic_reference_3()
+
+static func test_cyclic_reference_3():
+	print(A.WAITING_FOR)

--- a/modules/gdscript/tests/scripts/analyzer/features/use_preload_script_as_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/use_preload_script_as_type.gd
@@ -1,4 +1,4 @@
-const preloaded : GDScript = preload("gdscript_to_preload.gd")
+const preloaded : GDScript = preload("gdscript_to_preload.notest.gd")
 
 func test():
 	var preloaded_instance: preloaded = preloaded.new()

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -601,9 +601,13 @@ Error ResourceLoaderText::load() {
 		resource_current++;
 
 		int_resources[id] = res; //always assign int resources
-		if (do_assign && cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
-			res->set_path(path, cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE);
-			res->set_scene_unique_id(id);
+		if (do_assign) {
+			if (cache_mode == ResourceFormatLoader::CACHE_MODE_IGNORE) {
+				res->set_path(path);
+			} else {
+				res->set_path(path, cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE);
+				res->set_scene_unique_id(id);
+			}
 		}
 
 		Dictionary missing_resource_properties;

--- a/scene/resources/shape_2d.cpp
+++ b/scene/resources/shape_2d.cpp
@@ -124,5 +124,7 @@ Shape2D::Shape2D(const RID &p_rid) {
 }
 
 Shape2D::~Shape2D() {
-	PhysicsServer2D::get_singleton()->free(shape);
+	if (PhysicsServer2D::get_singleton() != nullptr) {
+		PhysicsServer2D::get_singleton()->free(shape);
+	}
 }

--- a/scene/resources/shape_3d.cpp
+++ b/scene/resources/shape_3d.cpp
@@ -128,5 +128,7 @@ Shape3D::Shape3D(RID p_shape) :
 		shape(p_shape) {}
 
 Shape3D::~Shape3D() {
-	PhysicsServer3D::get_singleton()->free(shape);
+	if (PhysicsServer3D::get_singleton() != nullptr) {
+		PhysicsServer3D::get_singleton()->free(shape);
+	}
 }


### PR DESCRIPTION
# TL;DR
This PR makes possible to use cyclic references in GDScript 2.0, i.e. preload class (or use by class name) `A` in `B` and `B` in `A`, preload cyclic scenes, use typing in addons.

# Summary
This PR tweaks the engine to accept and support cyclic references.

# What it tries to solve
The current GDScript engine blocks cyclic references as this would normally lead to memory leaks. Why? Because cyclic references artificially increase the refcount of gdscripts.

## Standard case
Let's say `Main` loads `A` that loads `B`.

Here, `Main` reference count is 1 (referenced by the engine), `A` is 1 (referenced by `Main`) and `B` is 1 (referenced by `A`).

When the engine unloads, `Main` reference count will be decremented by 1 and will be deleted, because its reference count will hit 0. `A` and `B` will also be deleted because `A` lost his reference from `Main` and `B` will lose its reference from `A` later.

## Current cyclic reference issue
Currently, the engine makes it so that using cyclic references is impossible. Why, you say?

Let's bring back our example, but with a cyclic reference. Let's say `Main` loads `A` that loads `B` that loads back `A`.

Here, `Main` reference count is 1 (referenced by the engine), `A` is 2 (referenced by `Main` and `B`) and `B` is 1 (referenced by `A`).

Do you see the issue? When `Main` will be deleted, there will be no way to delete `A` and `B`. `A` will lose its reference to `Main` and will decrement, but it will not be deleted as `A` reference count is now 1. `B` is not deleted because it didn't lose its reference to `A`.

So, the answer is: the engine makes cyclic references impossible due to memory leaks concerns. That explains errors thrown by the parser or the analyzer like `Constant value uses script from "res://b.gd" which is loaded but not compiled`.

# Proposed solution
## Cyclic dependency detection
There is no way to use the reference count as a mean to know if a cyclic `Ref<RefCounted>` needs to be disposed of. If `A` and `B` refers to themselves a number of times, the reference count will skyrocket and it would not be easy to track down the exact number of times the count has been incremented.

If, someday or someone, comes up with a reliable way to detect these, it would be the ideal solution.

Meanwhile, to fix this issue, I propose to use the existing `SelfList<GDScript> script_list` found in the `GDScript` class. This list holds each `GDScript` instance.

Take this table as basis for my following example:

| Script list | Script constants |
|-|-|
| `Main` | `A`, `B`, `X` |
| `A` | |
| `B` | `C` |
| `C` | `D`, `E` |
| `D` | |
| `E` | `F` |
| `F` | `E` |
| `X` | `Y` |
| `Y` | `F`, `Z` |
| `Z` | |

On the left column, each script contained in `script_list` and on the right one, each script referenced, contained in its constants (script constants, function constants, ...).

In the example, if `B` is disposed, `C` and `D` will be too, but not `E` and `F`. How to make sure they are disposed correctly? And how to make sure to not dispose any script that can be legitimately used by another one?

When we dispose of `B`, we can check the dependencies of its dependencies. After all, there's a good chance that those will be disposed of with `B`. So, `B` will check its `get_must_clear_dependencies()`.

### "Must clear" dependencies
`GDScript::get_must_clear_dependencies()` is called in `GDScript::clear()` to know which dependencies must be forcibly cleared.

The process may seem complicated, but it's quite simple. Let's say `Main` runs `get_must_clear_dependencies()`.

1. Get a dependencies set. These dependencies includes all the dependencies of the script dependencies;
2. Get the inverted dependencies of each dependency of set 1;
3. For each dependency of set 1, if one their inverted dependencies (step 2) is outside of the dependencies of step 1, add the dependency (and it's dependencies) to a "can't clear" set;
4. Filter out each dependency that appears in the "can't clear" set of step 3;
5. Return the set of step 4.

With this, we know for a fact that each dependency in the "must_clear" set can be deleted without impacting the rest of the scripts, even if their reference count is high. That means that it's high only because of cyclic references.

By clearing each of those scripts (`GDScript::clear()` clears all the constants holding scripts), their reference count will necessarily drop to zero, so they will be disposed without any need of hacks.

#### Example

![cyclic-dependency-detection-Page-2 drawio](https://user-images.githubusercontent.com/270928/198340022-1d6764ff-c07c-4465-88b1-a2598dc2f0e7.png)

##### Must clear dependencies of `Main`
Must clear dependencies of `Main` is quite simple. It's every `GDScript` because every script comes from `Main`.

###### Step 1
> Get a dependencies set. These dependencies includes all the dependencies of the script dependencies;

The direct dependencies of `Main` are `A`, `B` and `X`, but as it includes all the dependencies of the dependencies, it includes every class in the diagram.

###### Step 2
> Get the inverted dependencies of each dependency of set 1;

| Class | Inverted dependencies |
|-|-|
| `A` | `Main` |
| `B` | `Main` |
| `C` | `B` |
| `D` | `C` |
| `E` | `C`, `F` |
| `F` | `E`, `Y` |
| `X` | `Main` |
| `Y` | `X` |
| `Z` | `Y` |

###### Step 3
> For each dependency of set 1, if one their inverted dependencies (step 2) is outside of the dependencies of step 1, add the dependency (and it's dependencies) to a "can't clear" set;

As every class is a dependency of `Main`, "can't clear" set is empty.

###### Step 4
> Filter out each dependency that appears in the "can't clear" set of step 3;

As "can't clear" is empty, the dependencies stay the same.

###### Step 5
> 5. Return the set of step 4.

It returns every classes.

##### Must clear dependencies of `B`
This is where `must_clear_dependencies` shine, because it doesn't clear everything this time. Based on the algorithm, only `C` and `D` can be cleared without any consequences, as `E` and `F` are used by `Y`.

###### Step 1
> Get a dependencies set. These dependencies includes all the dependencies of the script dependencies;

| Class | Dependencies |
|-|-|
| `B` | `C`, `D`, `E`, `F` |

The direct dependency of `B` is `C`, but as it includes all the dependencies of the dependencies, it includes `D`, `E` and `F`.

###### Step 2
> Get the inverted dependencies of each dependency of set 1;

| Class | Inverted dependencies |
|-|-|
| `C` | `B` |
| `D` | `C` |
| `E` | `C`, `F` |
| `F` | `E`, `Y` |

###### Step 3
> For each dependency of set 1, if one their inverted dependencies (step 2) is outside of the dependencies of step 1, add the dependency (and it's dependencies) to a "can't clear" set;

`Y` is outside of `B` (itself), `C`, `D`, `E` and `F`. So, we add `F`, `E` and `Y` to the "can't clear" set.

###### Step 4
> Filter out each dependency that appears in the "can't clear" set of step 3;

We remove `F` and `E` from the dependencies.

###### Step 5
> 5. Return the set of step 4.

It returns `C` and `D`.

## Backup
If, for some reason, a script was able to slip out of the process, it still has a reference to `script_list`. Then, we can call `clear()` in the loop found in `GDScriptLanguage::~GDScriptLanguage()` for script instances still left. This adds the ability to force the clear of internal variables of a script, which can trigger the reference count decrement of other scripts.

# Known issues
- ✔️ ~~Code completion isn't working for cyclic references~~ 
  - Bug present in 4.0beta2 for in-game scripts. The method list does not update at all until a refresh. Code completion for this PR does not show issues other than current ones;
- ✔️ ~~The code works, but the cleaning isn't optimal. I found a reliable way to calculate cyclic references (see `GDScript::get_cyclic_references_count()`), but my efforts to clear dynamically the script failed. It seems the `unreference()` function is somewhat unreliable.~~ 
  - Implemented with success, clearing GDScript with `GDScript::clear()` and `GDScript::get_must_clear_dependencies()`;
- ❌ For some reason, GDScript instances can still hold `Shape2D` references, even if `PhysicsServer2D` singleton was destructed, which leads to memory leaks.
- ❌ Same thing for `Shape3D`

# Code example
So, this code works with this PR, which returns this error on `master`: `Constant value uses script from "res://b.gd" which is loaded but not compiled.`:
```gdscript
# main.gd
const A = preload("res://a.gd")

func _ready() -> void:
	A.test()  # The console will print: "A.HELLO_WORLD: hello, world!"
```
```gdscript
# a.gd
extends Node

const B = preload("res://b.gd")

const HELLO_WORLD: = "hello, world!"

static func test() -> void:
	B.test()

	# Test cyclic `is` keyword
	var b_instance: = B.new()
	if b_instance is B:
		prints("b_instance is B")  # The console will print: "b_instance is B"
	b_instance.queue_free()
```
```gdscript
# b.gd
extends Node

const A = preload("res://a.gd")

static func test() -> void:
	prints("A.HELLO_WORLD:", A.HELLO_WORLD)

	# Test cyclic `is` keyword
	var a_instance: = A.new()
	if a_instance is A:
		prints("a_instance is A")  # The console will print: "a_instance is A"
	a_instance.queue_free()
```

# Minimal reproduction project:
[cyclic3.zip](https://github.com/godotengine/godot/files/9543713/cyclic3.zip)

# Fixes
Fixes #21461 - Some usages of `class_name` can produce cyclic errors unexpectedly
Fixes #32165 - Cyclic Errors After Autoload of Imported Asset
Fixes #41027 - Cyclic reference error in GDScript 2.0
Fixes #58551 - Can't preload a scene in AutoLoad script when the scene's script references the AutoLoad
Fixes #58181 - GDScript 2.0: Cannot preload cyclic const script references
Fixes #58871 - Cyclic Autoload Singleton Plugin Bug
Fixes #61043 - New cyclic reference error with autoload and preloaded script
Fixes #65263 - GDScript reload generates error when created dynamically (no backing script)
Fixes #68211 - Can't preload a scene in autoload if that scene uses the autoload

# Does not fix (yet)
#61386 - [4.x regression] AutoLoad scenes (not scripts) do not support implicit types

# Notes
This PR follows up #65752.