### PR TITLE
Add a tutorial link to `BoneMap` and `SkeletonProfile`

### DIFF
--- a/doc/classes/BoneMap.xml
+++ b/doc/classes/BoneMap.xml
@@ -8,6 +8,7 @@
 		By assigning the actual [Skeleton3D] bone name as the key value, it maps the [Skeleton3D] to the [SkeletonProfile].
 	</description>
 	<tutorials>
+		<link title="Retargeting 3D Skeletons">$DOCS_URL/tutorials/assets_pipeline/retargeting_3d_skeletons.html</link>
 	</tutorials>
 	<methods>
 		<method name="find_profile_bone_name" qualifiers="const">

--- a/doc/classes/SkeletonProfile.xml
+++ b/doc/classes/SkeletonProfile.xml
@@ -7,6 +7,7 @@
 		This resource is used in [EditorScenePostImport]. Some parameters are referring to bones in [Skeleton3D], [Skin], [Animation], and some other nodes are rewritten based on the parameters of [SkeletonProfile].
 	</description>
 	<tutorials>
+		<link title="Retargeting 3D Skeletons">$DOCS_URL/tutorials/assets_pipeline/retargeting_3d_skeletons.html</link>
 	</tutorials>
 	<methods>
 		<method name="find_bone" qualifiers="const">

--- a/doc/classes/SkeletonProfileHumanoid.xml
+++ b/doc/classes/SkeletonProfileHumanoid.xml
@@ -6,6 +6,7 @@
 		A [SkeletonProfile] as a preset that is optimized for the human form. This exists for standardization, so all parameters are read-only.
 	</description>
 	<tutorials>
+		<link title="Retargeting 3D Skeletons">$DOCS_URL/tutorials/assets_pipeline/retargeting_3d_skeletons.html</link>
 	</tutorials>
 	<members>
 		<member name="bone_size" type="int" setter="set_bone_size" getter="get_bone_size" overrides="SkeletonProfile" default="56" />

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -6204,7 +6204,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 				if (do_bake && !animation->track_is_compressed(i)) {
 					Animation::InterpolationType it = animation->track_get_interpolation_type(i);
 					if (it == Animation::INTERPOLATION_NEAREST) {
-						continue; // Nearest and Angle interpolation cannot be baked.
+						continue; // Nearest interpolation cannot be baked.
 					}
 
 					// Special case for angle interpolation.


### PR DESCRIPTION
Add a tutorial link written by https://github.com/godotengine/godot-docs/pull/6322 to Retarget Classes (`BoneMap`, `SkeletonProfile`).

Containing minor fix for comment of animation track editor.