### PR TITLE
Add case for Variant::INT in lerp variant switch

### DIFF
--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -335,6 +335,9 @@ struct VariantUtilityFunctions {
 		}
 
 		switch (from.get_type()) {
+			case Variant::INT: {
+				return lerpf(VariantInternalAccessor<int64_t>::get(&from), to, weight);
+			} break;
 			case Variant::FLOAT: {
 				return lerpf(VariantInternalAccessor<double>::get(&from), to, weight);
 			} break;

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -527,7 +527,7 @@
 			<param index="2" name="weight" type="Variant" />
 			<description>
 				Linearly interpolates between two values by the factor defined in [param weight]. To perform interpolation, [param weight] should be between [code]0.0[/code] and [code]1.0[/code] (inclusive). However, values outside this range are allowed and can be used to perform [i]extrapolation[/i]. If this is not desired, use [method clamp] on the result of this function.
-				Both [param from] and [param to] must be the same type. Supported types: [float], [Vector2], [Vector3], [Vector4], [Color], [Quaternion], [Basis].
+				Both [param from] and [param to] must be the same type. Supported types: [int], [float], [Vector2], [Vector3], [Vector4], [Color], [Quaternion], [Basis].
 				[codeblock]
 				lerp(0, 4, 0.75) # Returns 3.0
 				[/codeblock]


### PR DESCRIPTION
A typing problem with variants was causing difficult-to-read errors when people called lerp on ints instead of lerpf. Since lerp already has a fallthrough to lerpf for doubles, I added one for integers.

Closes #66307
