### PR TITLE
Check for a Vulkan extension before checking its features

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -687,21 +687,43 @@ Error VulkanContext::_check_capabilities() {
 
 		vkGetPhysicalDeviceFeatures2_func(gpu, &device_features);
 
-		vrs_capabilities.pipeline_vrs_supported = vrs_features.pipelineFragmentShadingRate;
-		vrs_capabilities.primitive_vrs_supported = vrs_features.primitiveFragmentShadingRate;
-		vrs_capabilities.attachment_vrs_supported = vrs_features.attachmentFragmentShadingRate;
+		// We must check that the relative extension is present before assuming a
+		// feature as enabled. Actually, according to the spec we shouldn't add the
+		// structs in pNext at all, but this works fine.
+		// See also: https://github.com/godotengine/godot/issues/65409
+		for (uint32_t i = 0; i < enabled_extension_count; ++i) {
+			if (!strcmp(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME, extension_names[i])) {
+				vrs_capabilities.pipeline_vrs_supported = vrs_features.pipelineFragmentShadingRate;
+				vrs_capabilities.primitive_vrs_supported = vrs_features.primitiveFragmentShadingRate;
+				vrs_capabilities.attachment_vrs_supported = vrs_features.attachmentFragmentShadingRate;
 
-		multiview_capabilities.is_supported = multiview_features.multiview;
-		multiview_capabilities.geometry_shader_is_supported = multiview_features.multiviewGeometryShader;
-		multiview_capabilities.tessellation_shader_is_supported = multiview_features.multiviewTessellationShader;
+				continue;
+			}
 
-		shader_capabilities.shader_float16_is_supported = shader_features.shaderFloat16;
-		shader_capabilities.shader_int8_is_supported = shader_features.shaderInt8;
+			if (!strcmp(VK_KHR_MULTIVIEW_EXTENSION_NAME, extension_names[i])) {
+				multiview_capabilities.is_supported = multiview_features.multiview;
+				multiview_capabilities.geometry_shader_is_supported = multiview_features.multiviewGeometryShader;
+				multiview_capabilities.tessellation_shader_is_supported = multiview_features.multiviewTessellationShader;
 
-		storage_buffer_capabilities.storage_buffer_16_bit_access_is_supported = storage_feature.storageBuffer16BitAccess;
-		storage_buffer_capabilities.uniform_and_storage_buffer_16_bit_access_is_supported = storage_feature.uniformAndStorageBuffer16BitAccess;
-		storage_buffer_capabilities.storage_push_constant_16_is_supported = storage_feature.storagePushConstant16;
-		storage_buffer_capabilities.storage_input_output_16 = storage_feature.storageInputOutput16;
+				continue;
+			}
+
+			if (!strcmp(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME, extension_names[i])) {
+				shader_capabilities.shader_float16_is_supported = shader_features.shaderFloat16;
+				shader_capabilities.shader_int8_is_supported = shader_features.shaderInt8;
+
+				continue;
+			}
+
+			if (!strcmp(VK_KHR_16BIT_STORAGE_EXTENSION_NAME, extension_names[i])) {
+				storage_buffer_capabilities.storage_buffer_16_bit_access_is_supported = storage_feature.storageBuffer16BitAccess;
+				storage_buffer_capabilities.uniform_and_storage_buffer_16_bit_access_is_supported = storage_feature.uniformAndStorageBuffer16BitAccess;
+				storage_buffer_capabilities.storage_push_constant_16_is_supported = storage_feature.storagePushConstant16;
+				storage_buffer_capabilities.storage_input_output_16 = storage_feature.storageInputOutput16;
+
+				continue;
+			}
+		}
 	}
 
 	// Check extended properties.


### PR DESCRIPTION
For some reason AFAICT mesa reports a feature as enabled even when its extension isn't supported. The Vulkan specification says nothing aboutd this so this is technically more of a workaround, but it works.

I think that this oddity has always been present in mesa but we just got lucky by targeting features supported by all GPUs, up until variable rate shading.

Fixes #65409.

Note that this approach technically still uses `vkGetPhysicalDeviceFeatures2` in an invalid way (passing disabled extension feature structs in `pNext`), but a proper solution would require a more convoluted approach and this works fine.