### PR TITLE
Don't use a const reference for the enum constructor in Variant

### DIFF
--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -488,7 +488,7 @@ public:
 	Variant(const IPAddress &p_address);
 
 #define VARIANT_ENUM_CLASS_CONSTRUCTOR(m_enum) \
-	Variant(const m_enum &p_value) {           \
+	Variant(m_enum p_value) {                  \
 		type = INT;                            \
 		_data._int = (int64_t)p_value;         \
 	}


### PR DESCRIPTION
This was a copy-paste mistake I made when creating this constructor macro. Copying an enum's value will be at least as cheap as grabbing a pointer (reference), so it should not be a const reference.