### PR TITLE
Fix error emitting when double-clicking on JSON files in FileSystem tab

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1244,10 +1244,11 @@ Error EditorNode::load_resource(const String &p_resource, bool p_ignore_broken_d
 	Error err;
 
 	Ref<Resource> res;
-	if (ResourceLoader::exists(p_resource, "")) {
-		res = ResourceLoader::load(p_resource, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
-	} else if (textfile_extensions.has(p_resource.get_extension())) {
+	if (textfile_extensions.has(p_resource.get_extension())) {
 		res = ScriptEditor::get_singleton()->open_file(p_resource);
+	}
+	else if (ResourceLoader::exists(p_resource, "")) {
+		res = ResourceLoader::load(p_resource, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
 	}
 	ERR_FAIL_COND_V(!res.is_valid(), ERR_CANT_OPEN);
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1246,8 +1246,7 @@ Error EditorNode::load_resource(const String &p_resource, bool p_ignore_broken_d
 	Ref<Resource> res;
 	if (textfile_extensions.has(p_resource.get_extension())) {
 		res = ScriptEditor::get_singleton()->open_file(p_resource);
-	}
-	else if (ResourceLoader::exists(p_resource, "")) {
+	} else if (ResourceLoader::exists(p_resource, "")) {
 		res = ResourceLoader::load(p_resource, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
 	}
 	ERR_FAIL_COND_V(!res.is_valid(), ERR_CANT_OPEN);


### PR DESCRIPTION
Fixes error thrown when clicking on a json file in the file dock

<i>Bugsquad edit:</i> Fix #66820

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
