### PR TITLE
Fix cluster_render.glsl failing on some Macs

### DIFF
--- a/servers/rendering/renderer_rd/shaders/cluster_render.glsl
+++ b/servers/rendering/renderer_rd/shaders/cluster_render.glsl
@@ -141,7 +141,11 @@ void main() {
 		}
 	}
 #else
-	if (!gl_HelperInvocation) {
+// MoltenVK/Metal fails to compile shaders using gl_HelperInvocation for some GPUs
+#ifndef MOLTENVK_USED
+	if (!gl_HelperInvocation)
+#endif
+	{
 		atomicOr(cluster_render.data[usage_write_offset], usage_write_bit);
 	}
 #endif
@@ -161,7 +165,11 @@ void main() {
 		}
 	}
 #else
-	if (!gl_HelperInvocation) {
+// MoltenVK/Metal fails to compile shaders using gl_HelperInvocation for some GPUs
+#ifndef MOLTENVK_USED
+	if (!gl_HelperInvocation)
+#endif
+	{
 		atomicOr(cluster_render.data[z_write_offset], z_write_bit);
 	}
 #endif


### PR DESCRIPTION
Some Macs encounter an internal error when compiling cluster_render.glsl caused by a likely bug in the MVK/Metal
compiler when using gl_HelperInvocation.

The fix removes a conditional that avoids atomic buffer stores when running in a helper invocation. Functionally it should be identical because atomicOr is guaranteed to not not write anything when in a helper invocation anyway, but I'm not 100% sure there aren't any performance differences. (Depends on if the atomicOr is truly a NOP when in a helper invocation or not, which the documentation doesn't really specify. It just says it has no effect on the underlying image or buffer memory.) To minimize any potential downsides I only removed the conditional when using MoltenVK.

There is a second code path in the shader that uses subgroups, and I chose to _not_ remove the conditional in that path, because I had the feeling (but no actual data) that any Mac GPUs that take this path also don't suffer from the issue. (I think it's specific to an older Intel GPU codepath.)

This PR fixes #62322
