### PR TITLE
Fix const qualifier for parameters in GDExtension api functions

### DIFF
--- a/core/extension/gdnative_interface.cpp
+++ b/core/extension/gdnative_interface.cpp
@@ -61,15 +61,15 @@ static void gdnative_print_script_error(const char *p_description, const char *p
 	_err_print_error(p_function, p_file, p_line, p_description, false, ERR_HANDLER_SCRIPT);
 }
 
-uint64_t gdnative_get_native_struct_size(const GDNativeStringNamePtr p_name) {
+uint64_t gdnative_get_native_struct_size(GDNativeConstStringNamePtr p_name) {
 	const StringName name = *reinterpret_cast<const StringName *>(p_name);
 	return ClassDB::get_native_struct_size(name);
 }
 
 // Variant functions
 
-static void gdnative_variant_new_copy(GDNativeVariantPtr r_dest, const GDNativeVariantPtr p_src) {
-	memnew_placement(reinterpret_cast<Variant *>(r_dest), Variant(*reinterpret_cast<Variant *>(p_src)));
+static void gdnative_variant_new_copy(GDNativeVariantPtr r_dest, GDNativeConstVariantPtr p_src) {
+	memnew_placement(reinterpret_cast<Variant *>(r_dest), Variant(*reinterpret_cast<const Variant *>(p_src)));
 }
 static void gdnative_variant_new_nil(GDNativeVariantPtr r_dest) {
 	memnew_placement(reinterpret_cast<Variant *>(r_dest), Variant);
@@ -80,7 +80,7 @@ static void gdnative_variant_destroy(GDNativeVariantPtr p_self) {
 
 // variant type
 
-static void gdnative_variant_call(GDNativeVariantPtr p_self, const GDNativeStringNamePtr p_method, const GDNativeVariantPtr *p_args, const GDNativeInt p_argcount, GDNativeVariantPtr r_return, GDNativeCallError *r_error) {
+static void gdnative_variant_call(GDNativeVariantPtr p_self, GDNativeConstStringNamePtr p_method, GDNativeConstVariantPtr *p_args, GDNativeInt p_argcount, GDNativeVariantPtr r_return, GDNativeCallError *r_error) {
 	Variant *self = (Variant *)p_self;
 	const StringName method = *reinterpret_cast<const StringName *>(p_method);
 	const Variant **args = (const Variant **)p_args;
@@ -96,7 +96,7 @@ static void gdnative_variant_call(GDNativeVariantPtr p_self, const GDNativeStrin
 	}
 }
 
-static void gdnative_variant_call_static(GDNativeVariantType p_type, const GDNativeStringNamePtr p_method, const GDNativeVariantPtr *p_args, const GDNativeInt p_argcount, GDNativeVariantPtr r_return, GDNativeCallError *r_error) {
+static void gdnative_variant_call_static(GDNativeVariantType p_type, GDNativeConstStringNamePtr p_method, GDNativeConstVariantPtr *p_args, GDNativeInt p_argcount, GDNativeVariantPtr r_return, GDNativeCallError *r_error) {
 	Variant::Type type = (Variant::Type)p_type;
 	const StringName method = *reinterpret_cast<const StringName *>(p_method);
 	const Variant **args = (const Variant **)p_args;
@@ -112,7 +112,7 @@ static void gdnative_variant_call_static(GDNativeVariantType p_type, const GDNat
 	}
 }
 
-static void gdnative_variant_evaluate(GDNativeVariantOperator p_op, const GDNativeVariantPtr p_a, const GDNativeVariantPtr p_b, GDNativeVariantPtr r_return, GDNativeBool *r_valid) {
+static void gdnative_variant_evaluate(GDNativeVariantOperator p_op, GDNativeConstVariantPtr p_a, GDNativeConstVariantPtr p_b, GDNativeVariantPtr r_return, GDNativeBool *r_valid) {
 	Variant::Operator op = (Variant::Operator)p_op;
 	const Variant *a = (const Variant *)p_a;
 	const Variant *b = (const Variant *)p_b;
@@ -122,7 +122,7 @@ static void gdnative_variant_evaluate(GDNativeVariantOperator p_op, const GDNati
 	*r_valid = valid;
 }
 
-static void gdnative_variant_set(GDNativeVariantPtr p_self, const GDNativeVariantPtr p_key, const GDNativeVariantPtr p_value, GDNativeBool *r_valid) {
+static void gdnative_variant_set(GDNativeVariantPtr p_self, GDNativeConstVariantPtr p_key, GDNativeConstVariantPtr p_value, GDNativeBool *r_valid) {
 	Variant *self = (Variant *)p_self;
 	const Variant *key = (const Variant *)p_key;
 	const Variant *value = (const Variant *)p_value;
@@ -132,7 +132,7 @@ static void gdnative_variant_set(GDNativeVariantPtr p_self, const GDNativeVarian
 	*r_valid = valid;
 }
 
-static void gdnative_variant_set_named(GDNativeVariantPtr p_self, const GDNativeStringNamePtr p_key, const GDNativeVariantPtr p_value, GDNativeBool *r_valid) {
+static void gdnative_variant_set_named(GDNativeVariantPtr p_self, GDNativeConstStringNamePtr p_key, GDNativeConstVariantPtr p_value, GDNativeBool *r_valid) {
 	Variant *self = (Variant *)p_self;
 	const StringName *key = (const StringName *)p_key;
 	const Variant *value = (const Variant *)p_value;
@@ -142,7 +142,7 @@ static void gdnative_variant_set_named(GDNativeVariantPtr p_self, const GDNative
 	*r_valid = valid;
 }
 
-static void gdnative_variant_set_keyed(GDNativeVariantPtr p_self, const GDNativeVariantPtr p_key, const GDNativeVariantPtr p_value, GDNativeBool *r_valid) {
+static void gdnative_variant_set_keyed(GDNativeVariantPtr p_self, GDNativeConstVariantPtr p_key, GDNativeConstVariantPtr p_value, GDNativeBool *r_valid) {
 	Variant *self = (Variant *)p_self;
 	const Variant *key = (const Variant *)p_key;
 	const Variant *value = (const Variant *)p_value;
@@ -152,7 +152,7 @@ static void gdnative_variant_set_keyed(GDNativeVariantPtr p_self, const GDNative
 	*r_valid = valid;
 }
 
-static void gdnative_variant_set_indexed(GDNativeVariantPtr p_self, GDNativeInt p_index, const GDNativeVariantPtr p_value, GDNativeBool *r_valid, GDNativeBool *r_oob) {
+static void gdnative_variant_set_indexed(GDNativeVariantPtr p_self, GDNativeInt p_index, GDNativeConstVariantPtr p_value, GDNativeBool *r_valid, GDNativeBool *r_oob) {
 	Variant *self = (Variant *)p_self;
 	const Variant *value = (const Variant *)p_value;
 
@@ -163,7 +163,7 @@ static void gdnative_variant_set_indexed(GDNativeVariantPtr p_self, GDNativeInt 
 	*r_oob = oob;
 }
 
-static void gdnative_variant_get(const GDNativeVariantPtr p_self, const GDNativeVariantPtr p_key, GDNativeVariantPtr r_ret, GDNativeBool *r_valid) {
+static void gdnative_variant_get(GDNativeConstVariantPtr p_self, GDNativeConstVariantPtr p_key, GDNativeVariantPtr r_ret, GDNativeBool *r_valid) {
 	const Variant *self = (const Variant *)p_self;
 	const Variant *key = (const Variant *)p_key;
 
@@ -172,7 +172,7 @@ static void gdnative_variant_get(const GDNativeVariantPtr p_self, const GDNative
 	*r_valid = valid;
 }
 
-static void gdnative_variant_get_named(const GDNativeVariantPtr p_self, const GDNativeStringNamePtr p_key, GDNativeVariantPtr r_ret, GDNativeBool *r_valid) {
+static void gdnative_variant_get_named(GDNativeConstVariantPtr p_self, GDNativeConstStringNamePtr p_key, GDNativeVariantPtr r_ret, GDNativeBool *r_valid) {
 	const Variant *self = (const Variant *)p_self;
 	const StringName *key = (const StringName *)p_key;
 
@@ -181,7 +181,7 @@ static void gdnative_variant_get_named(const GDNativeVariantPtr p_self, const GD
 	*r_valid = valid;
 }
 
-static void gdnative_variant_get_keyed(const GDNativeVariantPtr p_self, const GDNativeVariantPtr p_key, GDNativeVariantPtr r_ret, GDNativeBool *r_valid) {
+static void gdnative_variant_get_keyed(GDNativeConstVariantPtr p_self, GDNativeConstVariantPtr p_key, GDNativeVariantPtr r_ret, GDNativeBool *r_valid) {
 	const Variant *self = (const Variant *)p_self;
 	const Variant *key = (const Variant *)p_key;
 
@@ -190,7 +190,7 @@ static void gdnative_variant_get_keyed(const GDNativeVariantPtr p_self, const GD
 	*r_valid = valid;
 }
 
-static void gdnative_variant_get_indexed(const GDNativeVariantPtr p_self, GDNativeInt p_index, GDNativeVariantPtr r_ret, GDNativeBool *r_valid, GDNativeBool *r_oob) {
+static void gdnative_variant_get_indexed(GDNativeConstVariantPtr p_self, GDNativeInt p_index, GDNativeVariantPtr r_ret, GDNativeBool *r_valid, GDNativeBool *r_oob) {
 	const Variant *self = (const Variant *)p_self;
 
 	bool valid;
@@ -201,7 +201,7 @@ static void gdnative_variant_get_indexed(const GDNativeVariantPtr p_self, GDNati
 }
 
 /// Iteration.
-static GDNativeBool gdnative_variant_iter_init(const GDNativeVariantPtr p_self, GDNativeVariantPtr r_iter, GDNativeBool *r_valid) {
+static GDNativeBool gdnative_variant_iter_init(GDNativeConstVariantPtr p_self, GDNativeVariantPtr r_iter, GDNativeBool *r_valid) {
 	const Variant *self = (const Variant *)p_self;
 	Variant *iter = (Variant *)r_iter;
 
@@ -211,7 +211,7 @@ static GDNativeBool gdnative_variant_iter_init(const GDNativeVariantPtr p_self, 
 	return ret;
 }
 
-static GDNativeBool gdnative_variant_iter_next(const GDNativeVariantPtr p_self, GDNativeVariantPtr r_iter, GDNativeBool *r_valid) {
+static GDNativeBool gdnative_variant_iter_next(GDNativeConstVariantPtr p_self, GDNativeVariantPtr r_iter, GDNativeBool *r_valid) {
 	const Variant *self = (const Variant *)p_self;
 	Variant *iter = (Variant *)r_iter;
 
@@ -221,7 +221,7 @@ static GDNativeBool gdnative_variant_iter_next(const GDNativeVariantPtr p_self, 
 	return ret;
 }
 
-static void gdnative_variant_iter_get(const GDNativeVariantPtr p_self, GDNativeVariantPtr r_iter, GDNativeVariantPtr r_ret, GDNativeBool *r_valid) {
+static void gdnative_variant_iter_get(GDNativeConstVariantPtr p_self, GDNativeVariantPtr r_iter, GDNativeVariantPtr r_ret, GDNativeBool *r_valid) {
 	const Variant *self = (const Variant *)p_self;
 	Variant *iter = (Variant *)r_iter;
 
@@ -231,53 +231,53 @@ static void gdnative_variant_iter_get(const GDNativeVariantPtr p_self, GDNativeV
 }
 
 /// Variant functions.
-static GDNativeInt gdnative_variant_hash(const GDNativeVariantPtr p_self) {
+static GDNativeInt gdnative_variant_hash(GDNativeConstVariantPtr p_self) {
 	const Variant *self = (const Variant *)p_self;
 	return self->hash();
 }
 
-static GDNativeInt gdnative_variant_recursive_hash(const GDNativeVariantPtr p_self, GDNativeInt p_recursion_count) {
+static GDNativeInt gdnative_variant_recursive_hash(GDNativeConstVariantPtr p_self, GDNativeInt p_recursion_count) {
 	const Variant *self = (const Variant *)p_self;
 	return self->recursive_hash(p_recursion_count);
 }
 
-static GDNativeBool gdnative_variant_hash_compare(const GDNativeVariantPtr p_self, const GDNativeVariantPtr p_other) {
+static GDNativeBool gdnative_variant_hash_compare(GDNativeConstVariantPtr p_self, GDNativeConstVariantPtr p_other) {
 	const Variant *self = (const Variant *)p_self;
 	const Variant *other = (const Variant *)p_other;
 	return self->hash_compare(*other);
 }
 
-static GDNativeBool gdnative_variant_booleanize(const GDNativeVariantPtr p_self) {
+static GDNativeBool gdnative_variant_booleanize(GDNativeConstVariantPtr p_self) {
 	const Variant *self = (const Variant *)p_self;
 	return self->booleanize();
 }
 
-static void gdnative_variant_duplicate(const GDNativeVariantPtr p_self, GDNativeVariantPtr r_ret, GDNativeBool p_deep) {
+static void gdnative_variant_duplicate(GDNativeConstVariantPtr p_self, GDNativeVariantPtr r_ret, GDNativeBool p_deep) {
 	const Variant *self = (const Variant *)p_self;
 	memnew_placement(r_ret, Variant(self->duplicate(p_deep)));
 }
 
-static void gdnative_variant_stringify(const GDNativeVariantPtr p_self, GDNativeStringPtr r_ret) {
+static void gdnative_variant_stringify(GDNativeConstVariantPtr p_self, GDNativeStringPtr r_ret) {
 	const Variant *self = (const Variant *)p_self;
 	memnew_placement(r_ret, String(*self));
 }
 
-static GDNativeVariantType gdnative_variant_get_type(const GDNativeVariantPtr p_self) {
+static GDNativeVariantType gdnative_variant_get_type(GDNativeConstVariantPtr p_self) {
 	const Variant *self = (const Variant *)p_self;
 	return (GDNativeVariantType)self->get_type();
 }
 
-static GDNativeBool gdnative_variant_has_method(const GDNativeVariantPtr p_self, const GDNativeStringNamePtr p_method) {
+static GDNativeBool gdnative_variant_has_method(GDNativeConstVariantPtr p_self, GDNativeConstStringNamePtr p_method) {
 	const Variant *self = (const Variant *)p_self;
 	const StringName *method = (const StringName *)p_method;
 	return self->has_method(*method);
 }
 
-static GDNativeBool gdnative_variant_has_member(GDNativeVariantType p_type, const GDNativeStringNamePtr p_member) {
+static GDNativeBool gdnative_variant_has_member(GDNativeVariantType p_type, GDNativeConstStringNamePtr p_member) {
 	return Variant::has_member((Variant::Type)p_type, *((const StringName *)p_member));
 }
 
-static GDNativeBool gdnative_variant_has_key(const GDNativeVariantPtr p_self, const GDNativeVariantPtr p_key, GDNativeBool *r_valid) {
+static GDNativeBool gdnative_variant_has_key(GDNativeConstVariantPtr p_self, GDNativeConstVariantPtr p_key, GDNativeBool *r_valid) {
 	const Variant *self = (const Variant *)p_self;
 	const Variant *key = (const Variant *)p_key;
 	bool valid;
@@ -470,7 +470,7 @@ static GDNativeTypeFromVariantConstructorFunc gdnative_get_type_from_variant_con
 static GDNativePtrOperatorEvaluator gdnative_variant_get_ptr_operator_evaluator(GDNativeVariantOperator p_operator, GDNativeVariantType p_type_a, GDNativeVariantType p_type_b) {
 	return (GDNativePtrOperatorEvaluator)Variant::get_ptr_operator_evaluator(Variant::Operator(p_operator), Variant::Type(p_type_a), Variant::Type(p_type_b));
 }
-static GDNativePtrBuiltInMethod gdnative_variant_get_ptr_builtin_method(GDNativeVariantType p_type, const GDNativeStringNamePtr p_method, GDNativeInt p_hash) {
+static GDNativePtrBuiltInMethod gdnative_variant_get_ptr_builtin_method(GDNativeVariantType p_type, GDNativeConstStringNamePtr p_method, GDNativeInt p_hash) {
 	const StringName method = *reinterpret_cast<const StringName *>(p_method);
 	uint32_t hash = Variant::get_builtin_method_hash(Variant::Type(p_type), method);
 	if (hash != p_hash) {
@@ -486,7 +486,7 @@ static GDNativePtrConstructor gdnative_variant_get_ptr_constructor(GDNativeVaria
 static GDNativePtrDestructor gdnative_variant_get_ptr_destructor(GDNativeVariantType p_type) {
 	return (GDNativePtrDestructor)Variant::get_ptr_destructor(Variant::Type(p_type));
 }
-static void gdnative_variant_construct(GDNativeVariantType p_type, GDNativeVariantPtr p_base, const GDNativeVariantPtr *p_args, int32_t p_argument_count, GDNativeCallError *r_error) {
+static void gdnative_variant_construct(GDNativeVariantType p_type, GDNativeVariantPtr p_base, GDNativeConstVariantPtr *p_args, int32_t p_argument_count, GDNativeCallError *r_error) {
 	memnew_placement(p_base, Variant);
 
 	Callable::CallError error;
@@ -498,11 +498,11 @@ static void gdnative_variant_construct(GDNativeVariantType p_type, GDNativeVaria
 		r_error->expected = error.expected;
 	}
 }
-static GDNativePtrSetter gdnative_variant_get_ptr_setter(GDNativeVariantType p_type, const GDNativeStringNamePtr p_member) {
+static GDNativePtrSetter gdnative_variant_get_ptr_setter(GDNativeVariantType p_type, GDNativeConstStringNamePtr p_member) {
 	const StringName member = *reinterpret_cast<const StringName *>(p_member);
 	return (GDNativePtrSetter)Variant::get_member_ptr_setter(Variant::Type(p_type), member);
 }
-static GDNativePtrGetter gdnative_variant_get_ptr_getter(GDNativeVariantType p_type, const GDNativeStringNamePtr p_member) {
+static GDNativePtrGetter gdnative_variant_get_ptr_getter(GDNativeVariantType p_type, GDNativeConstStringNamePtr p_member) {
 	const StringName member = *reinterpret_cast<const StringName *>(p_member);
 	return (GDNativePtrGetter)Variant::get_member_ptr_getter(Variant::Type(p_type), member);
 }
@@ -521,11 +521,11 @@ static GDNativePtrKeyedGetter gdnative_variant_get_ptr_keyed_getter(GDNativeVari
 static GDNativePtrKeyedChecker gdnative_variant_get_ptr_keyed_checker(GDNativeVariantType p_type) {
 	return (GDNativePtrKeyedChecker)Variant::get_member_ptr_keyed_checker(Variant::Type(p_type));
 }
-static void gdnative_variant_get_constant_value(GDNativeVariantType p_type, const GDNativeStringNamePtr p_constant, GDNativeVariantPtr r_ret) {
+static void gdnative_variant_get_constant_value(GDNativeVariantType p_type, GDNativeConstStringNamePtr p_constant, GDNativeVariantPtr r_ret) {
 	StringName constant = *reinterpret_cast<const StringName *>(p_constant);
 	memnew_placement(r_ret, Variant(Variant::get_constant_value(Variant::Type(p_type), constant)));
 }
-static GDNativePtrUtilityFunction gdnative_variant_get_ptr_utility_function(const GDNativeStringNamePtr p_function, GDNativeInt p_hash) {
+static GDNativePtrUtilityFunction gdnative_variant_get_ptr_utility_function(GDNativeConstStringNamePtr p_function, GDNativeInt p_hash) {
 	StringName function = *reinterpret_cast<const StringName *>(p_function);
 	uint32_t hash = Variant::get_utility_function_hash(function);
 	if (hash != p_hash) {
@@ -574,31 +574,31 @@ static void gdnative_string_new_with_wide_chars(GDNativeStringPtr r_dest, const 
 	}
 }
 
-static void gdnative_string_new_with_latin1_chars_and_len(GDNativeStringPtr r_dest, const char *p_contents, const GDNativeInt p_size) {
+static void gdnative_string_new_with_latin1_chars_and_len(GDNativeStringPtr r_dest, const char *p_contents, GDNativeInt p_size) {
 	String *dest = (String *)r_dest;
 	memnew_placement(dest, String);
 	*dest = String(p_contents, p_size);
 }
 
-static void gdnative_string_new_with_utf8_chars_and_len(GDNativeStringPtr r_dest, const char *p_contents, const GDNativeInt p_size) {
+static void gdnative_string_new_with_utf8_chars_and_len(GDNativeStringPtr r_dest, const char *p_contents, GDNativeInt p_size) {
 	String *dest = (String *)r_dest;
 	memnew_placement(dest, String);
 	dest->parse_utf8(p_contents, p_size);
 }
 
-static void gdnative_string_new_with_utf16_chars_and_len(GDNativeStringPtr r_dest, const char16_t *p_contents, const GDNativeInt p_size) {
+static void gdnative_string_new_with_utf16_chars_and_len(GDNativeStringPtr r_dest, const char16_t *p_contents, GDNativeInt p_size) {
 	String *dest = (String *)r_dest;
 	memnew_placement(dest, String);
 	dest->parse_utf16(p_contents, p_size);
 }
 
-static void gdnative_string_new_with_utf32_chars_and_len(GDNativeStringPtr r_dest, const char32_t *p_contents, const GDNativeInt p_size) {
+static void gdnative_string_new_with_utf32_chars_and_len(GDNativeStringPtr r_dest, const char32_t *p_contents, GDNativeInt p_size) {
 	String *dest = (String *)r_dest;
 	memnew_placement(dest, String);
 	*dest = String((const char32_t *)p_contents, p_size);
 }
 
-static void gdnative_string_new_with_wide_chars_and_len(GDNativeStringPtr r_dest, const wchar_t *p_contents, const GDNativeInt p_size) {
+static void gdnative_string_new_with_wide_chars_and_len(GDNativeStringPtr r_dest, const wchar_t *p_contents, GDNativeInt p_size) {
 	String *dest = (String *)r_dest;
 	if constexpr (sizeof(wchar_t) == 2) {
 		// wchar_t is 16 bit, parse.
@@ -611,7 +611,7 @@ static void gdnative_string_new_with_wide_chars_and_len(GDNativeStringPtr r_dest
 	}
 }
 
-static GDNativeInt gdnative_string_to_latin1_chars(const GDNativeStringPtr p_self, char *r_text, GDNativeInt p_max_write_length) {
+static GDNativeInt gdnative_string_to_latin1_chars(GDNativeConstStringPtr p_self, char *r_text, GDNativeInt p_max_write_length) {
 	String *self = (String *)p_self;
 	CharString cs = self->ascii(true);
 	GDNativeInt len = cs.length();
@@ -623,7 +623,7 @@ static GDNativeInt gdnative_string_to_latin1_chars(const GDNativeStringPtr p_sel
 	}
 	return len;
 }
-static GDNativeInt gdnative_string_to_utf8_chars(const GDNativeStringPtr p_self, char *r_text, GDNativeInt p_max_write_length) {
+static GDNativeInt gdnative_string_to_utf8_chars(GDNativeConstStringPtr p_self, char *r_text, GDNativeInt p_max_write_length) {
 	String *self = (String *)p_self;
 	CharString cs = self->utf8();
 	GDNativeInt len = cs.length();
@@ -635,7 +635,7 @@ static GDNativeInt gdnative_string_to_utf8_chars(const GDNativeStringPtr p_self,
 	}
 	return len;
 }
-static GDNativeInt gdnative_string_to_utf16_chars(const GDNativeStringPtr p_self, char16_t *r_text, GDNativeInt p_max_write_length) {
+static GDNativeInt gdnative_string_to_utf16_chars(GDNativeConstStringPtr p_self, char16_t *r_text, GDNativeInt p_max_write_length) {
 	String *self = (String *)p_self;
 	Char16String cs = self->utf16();
 	GDNativeInt len = cs.length();
@@ -647,7 +647,7 @@ static GDNativeInt gdnative_string_to_utf16_chars(const GDNativeStringPtr p_self
 	}
 	return len;
 }
-static GDNativeInt gdnative_string_to_utf32_chars(const GDNativeStringPtr p_self, char32_t *r_text, GDNativeInt p_max_write_length) {
+static GDNativeInt gdnative_string_to_utf32_chars(GDNativeConstStringPtr p_self, char32_t *r_text, GDNativeInt p_max_write_length) {
 	String *self = (String *)p_self;
 	GDNativeInt len = self->length();
 	if (r_text) {
@@ -658,7 +658,7 @@ static GDNativeInt gdnative_string_to_utf32_chars(const GDNativeStringPtr p_self
 	}
 	return len;
 }
-static GDNativeInt gdnative_string_to_wide_chars(const GDNativeStringPtr p_self, wchar_t *r_text, GDNativeInt p_max_write_length) {
+static GDNativeInt gdnative_string_to_wide_chars(GDNativeConstStringPtr p_self, wchar_t *r_text, GDNativeInt p_max_write_length) {
 	if constexpr (sizeof(wchar_t) == 4) {
 		return gdnative_string_to_utf32_chars(p_self, (char32_t *)r_text, p_max_write_length);
 	} else {
@@ -672,7 +672,7 @@ static char32_t *gdnative_string_operator_index(GDNativeStringPtr p_self, GDNati
 	return &self->ptrw()[p_index];
 }
 
-static const char32_t *gdnative_string_operator_index_const(const GDNativeStringPtr p_self, GDNativeInt p_index) {
+static const char32_t *gdnative_string_operator_index_const(GDNativeConstStringPtr p_self, GDNativeInt p_index) {
 	const String *self = (const String *)p_self;
 	ERR_FAIL_INDEX_V(p_index, self->length() + 1, nullptr);
 	return &self->ptr()[p_index];
@@ -686,7 +686,7 @@ static uint8_t *gdnative_packed_byte_array_operator_index(GDNativeTypePtr p_self
 	return &self->ptrw()[p_index];
 }
 
-static const uint8_t *gdnative_packed_byte_array_operator_index_const(const GDNativeTypePtr p_self, GDNativeInt p_index) {
+static const uint8_t *gdnative_packed_byte_array_operator_index_const(GDNativeConstTypePtr p_self, GDNativeInt p_index) {
 	const PackedByteArray *self = (const PackedByteArray *)p_self;
 	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
 	return &self->ptr()[p_index];
@@ -698,7 +698,7 @@ static GDNativeTypePtr gdnative_packed_color_array_operator_index(GDNativeTypePt
 	return (GDNativeTypePtr)&self->ptrw()[p_index];
 }
 
-static GDNativeTypePtr gdnative_packed_color_array_operator_index_const(const GDNativeTypePtr p_self, GDNativeInt p_index) {
+static GDNativeTypePtr gdnative_packed_color_array_operator_index_const(GDNativeConstTypePtr p_self, GDNativeInt p_index) {
 	const PackedColorArray *self = (const PackedColorArray *)p_self;
 	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
 	return (GDNativeTypePtr)&self->ptr()[p_index];
@@ -710,7 +710,7 @@ static float *gdnative_packed_float32_array_operator_index(GDNativeTypePtr p_sel
 	return &self->ptrw()[p_index];
 }
 
-static const float *gdnative_packed_float32_array_operator_index_const(const GDNativeTypePtr p_self, GDNativeInt p_index) {
+static const float *gdnative_packed_float32_array_operator_index_const(GDNativeConstTypePtr p_self, GDNativeInt p_index) {
 	const PackedFloat32Array *self = (const PackedFloat32Array *)p_self;
 	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
 	return &self->ptr()[p_index];
@@ -722,7 +722,7 @@ static double *gdnative_packed_float64_array_operator_index(GDNativeTypePtr p_se
 	return &self->ptrw()[p_index];
 }
 
-static const double *gdnative_packed_float64_array_operator_index_const(const GDNativeTypePtr p_self, GDNativeInt p_index) {
+static const double *gdnative_packed_float64_array_operator_index_const(GDNativeConstTypePtr p_self, GDNativeInt p_index) {
 	const PackedFloat64Array *self = (const PackedFloat64Array *)p_self;
 	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
 	return &self->ptr()[p_index];
@@ -734,7 +734,7 @@ static int32_t *gdnative_packed_int32_array_operator_index(GDNativeTypePtr p_sel
 	return &self->ptrw()[p_index];
 }
 
-static const int32_t *gdnative_packed_int32_array_operator_index_const(const GDNativeTypePtr p_self, GDNativeInt p_index) {
+static const int32_t *gdnative_packed_int32_array_operator_index_const(GDNativeConstTypePtr p_self, GDNativeInt p_index) {
 	const PackedInt32Array *self = (const PackedInt32Array *)p_self;
 	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
 	return &self->ptr()[p_index];
@@ -746,7 +746,7 @@ static int64_t *gdnative_packed_int64_array_operator_index(GDNativeTypePtr p_sel
 	return &self->ptrw()[p_index];
 }
 
-static const int64_t *gdnative_packed_int64_array_operator_index_const(const GDNativeTypePtr p_self, GDNativeInt p_index) {
+static const int64_t *gdnative_packed_int64_array_operator_index_const(GDNativeConstTypePtr p_self, GDNativeInt p_index) {
 	const PackedInt64Array *self = (const PackedInt64Array *)p_self;
 	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
 	return &self->ptr()[p_index];
@@ -758,7 +758,7 @@ static GDNativeStringPtr gdnative_packed_string_array_operator_index(GDNativeTyp
 	return (GDNativeStringPtr)&self->ptrw()[p_index];
 }
 
-static GDNativeStringPtr gdnative_packed_string_array_operator_index_const(const GDNativeTypePtr p_self, GDNativeInt p_index) {
+static GDNativeStringPtr gdnative_packed_string_array_operator_index_const(GDNativeConstTypePtr p_self, GDNativeInt p_index) {
 	const PackedStringArray *self = (const PackedStringArray *)p_self;
 	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
 	return (GDNativeStringPtr)&self->ptr()[p_index];
@@ -770,7 +770,7 @@ static GDNativeTypePtr gdnative_packed_vector2_array_operator_index(GDNativeType
 	return (GDNativeTypePtr)&self->ptrw()[p_index];
 }
 
-static GDNativeTypePtr gdnative_packed_vector2_array_operator_index_const(const GDNativeTypePtr p_self, GDNativeInt p_index) {
+static GDNativeTypePtr gdnative_packed_vector2_array_operator_index_const(GDNativeConstTypePtr p_self, GDNativeInt p_index) {
 	const PackedVector2Array *self = (const PackedVector2Array *)p_self;
 	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
 	return (GDNativeTypePtr)&self->ptr()[p_index];
@@ -782,7 +782,7 @@ static GDNativeTypePtr gdnative_packed_vector3_array_operator_index(GDNativeType
 	return (GDNativeTypePtr)&self->ptrw()[p_index];
 }
 
-static GDNativeTypePtr gdnative_packed_vector3_array_operator_index_const(const GDNativeTypePtr p_self, GDNativeInt p_index) {
+static GDNativeTypePtr gdnative_packed_vector3_array_operator_index_const(GDNativeConstTypePtr p_self, GDNativeInt p_index) {
 	const PackedVector3Array *self = (const PackedVector3Array *)p_self;
 	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
 	return (GDNativeTypePtr)&self->ptr()[p_index];
@@ -794,7 +794,7 @@ static GDNativeVariantPtr gdnative_array_operator_index(GDNativeTypePtr p_self, 
 	return (GDNativeVariantPtr)&self->operator[](p_index);
 }
 
-static GDNativeVariantPtr gdnative_array_operator_index_const(const GDNativeTypePtr p_self, GDNativeInt p_index) {
+static GDNativeVariantPtr gdnative_array_operator_index_const(GDNativeConstTypePtr p_self, GDNativeInt p_index) {
 	const Array *self = (const Array *)p_self;
 	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
 	return (GDNativeVariantPtr)&self->operator[](p_index);
@@ -802,20 +802,20 @@ static GDNativeVariantPtr gdnative_array_operator_index_const(const GDNativeType
 
 /* Dictionary functions */
 
-static GDNativeVariantPtr gdnative_dictionary_operator_index(GDNativeTypePtr p_self, const GDNativeVariantPtr p_key) {
+static GDNativeVariantPtr gdnative_dictionary_operator_index(GDNativeTypePtr p_self, GDNativeConstVariantPtr p_key) {
 	Dictionary *self = (Dictionary *)p_self;
 	return (GDNativeVariantPtr)&self->operator[](*(const Variant *)p_key);
 }
 
-static GDNativeVariantPtr gdnative_dictionary_operator_index_const(const GDNativeTypePtr p_self, const GDNativeVariantPtr p_key) {
+static GDNativeVariantPtr gdnative_dictionary_operator_index_const(GDNativeConstTypePtr p_self, GDNativeConstVariantPtr p_key) {
 	const Dictionary *self = (const Dictionary *)p_self;
 	return (GDNativeVariantPtr)&self->operator[](*(const Variant *)p_key);
 }
 
 /* OBJECT API */
 
-static void gdnative_object_method_bind_call(const GDNativeMethodBindPtr p_method_bind, GDNativeObjectPtr p_instance, const GDNativeVariantPtr *p_args, GDNativeInt p_arg_count, GDNativeVariantPtr r_return, GDNativeCallError *r_error) {
-	MethodBind *mb = (MethodBind *)p_method_bind;
+static void gdnative_object_method_bind_call(GDNativeMethodBindPtr p_method_bind, GDNativeObjectPtr p_instance, GDNativeConstVariantPtr *p_args, GDNativeInt p_arg_count, GDNativeVariantPtr r_return, GDNativeCallError *r_error) {
+	const MethodBind *mb = reinterpret_cast<const MethodBind *>(p_method_bind);
 	Object *o = (Object *)p_instance;
 	const Variant **args = (const Variant **)p_args;
 	Callable::CallError error;
@@ -830,8 +830,8 @@ static void gdnative_object_method_bind_call(const GDNativeMethodBindPtr p_metho
 	}
 }
 
-static void gdnative_object_method_bind_ptrcall(const GDNativeMethodBindPtr p_method_bind, GDNativeObjectPtr p_instance, const GDNativeTypePtr *p_args, GDNativeTypePtr p_ret) {
-	MethodBind *mb = (MethodBind *)p_method_bind;
+static void gdnative_object_method_bind_ptrcall(GDNativeMethodBindPtr p_method_bind, GDNativeObjectPtr p_instance, GDNativeConstTypePtr *p_args, GDNativeTypePtr p_ret) {
+	const MethodBind *mb = reinterpret_cast<const MethodBind *>(p_method_bind);
 	Object *o = (Object *)p_instance;
 	mb->ptrcall(o, (const void **)p_args, p_ret);
 }
@@ -840,7 +840,7 @@ static void gdnative_object_destroy(GDNativeObjectPtr p_o) {
 	memdelete((Object *)p_o);
 }
 
-static GDNativeObjectPtr gdnative_global_get_singleton(const GDNativeStringNamePtr p_name) {
+static GDNativeObjectPtr gdnative_global_get_singleton(GDNativeConstStringNamePtr p_name) {
 	const StringName name = *reinterpret_cast<const StringName *>(p_name);
 	return (GDNativeObjectPtr)Engine::get_singleton()->get_singleton_object(name);
 }
@@ -855,7 +855,7 @@ static void gdnative_object_set_instance_binding(GDNativeObjectPtr p_object, voi
 	o->set_instance_binding(p_token, p_binding, p_callbacks);
 }
 
-static void gdnative_object_set_instance(GDNativeObjectPtr p_object, const GDNativeStringNamePtr p_classname, GDExtensionClassInstancePtr p_instance) {
+static void gdnative_object_set_instance(GDNativeObjectPtr p_object, GDNativeConstStringNamePtr p_classname, GDExtensionClassInstancePtr p_instance) {
 	const StringName classname = *reinterpret_cast<const StringName *>(p_classname);
 	Object *o = (Object *)p_object;
 	ClassDB::set_object_extension_instance(o, classname, p_instance);
@@ -865,7 +865,7 @@ static GDNativeObjectPtr gdnative_object_get_instance_from_id(GDObjectInstanceID
 	return (GDNativeObjectPtr)ObjectDB::get_instance(ObjectID(p_instance_id));
 }
 
-static GDNativeObjectPtr gdnative_object_cast_to(const GDNativeObjectPtr p_object, void *p_class_tag) {
+static GDNativeObjectPtr gdnative_object_cast_to(GDNativeConstObjectPtr p_object, void *p_class_tag) {
 	if (!p_object) {
 		return nullptr;
 	}
@@ -874,7 +874,7 @@ static GDNativeObjectPtr gdnative_object_cast_to(const GDNativeObjectPtr p_objec
 	return o->is_class_ptr(p_class_tag) ? (GDNativeObjectPtr)o : (GDNativeObjectPtr) nullptr;
 }
 
-static GDObjectInstanceID gdnative_object_get_instance_id(const GDNativeObjectPtr p_object) {
+static GDObjectInstanceID gdnative_object_get_instance_id(GDNativeConstObjectPtr p_object) {
 	const Object *o = (const Object *)p_object;
 	return (GDObjectInstanceID)o->get_instance_id();
 }
@@ -886,7 +886,7 @@ static GDNativeScriptInstancePtr gdnative_script_instance_create(const GDNativeE
 	return reinterpret_cast<GDNativeScriptInstancePtr>(script_instance_extension);
 }
 
-static GDNativeMethodBindPtr gdnative_classdb_get_method_bind(const GDNativeStringNamePtr p_classname, const GDNativeStringNamePtr p_methodname, GDNativeInt p_hash) {
+static GDNativeMethodBindPtr gdnative_classdb_get_method_bind(GDNativeConstStringNamePtr p_classname, GDNativeConstStringNamePtr p_methodname, GDNativeInt p_hash) {
 	const StringName classname = *reinterpret_cast<const StringName *>(p_classname);
 	const StringName methodname = *reinterpret_cast<const StringName *>(p_methodname);
 	MethodBind *mb = ClassDB::get_method(classname, methodname);
@@ -898,12 +898,12 @@ static GDNativeMethodBindPtr gdnative_classdb_get_method_bind(const GDNativeStri
 	return (GDNativeMethodBindPtr)mb;
 }
 
-static GDNativeObjectPtr gdnative_classdb_construct_object(const GDNativeStringNamePtr p_classname) {
+static GDNativeObjectPtr gdnative_classdb_construct_object(GDNativeConstStringNamePtr p_classname) {
 	const StringName classname = *reinterpret_cast<const StringName *>(p_classname);
 	return (GDNativeObjectPtr)ClassDB::instantiate(classname);
 }
 
-static void *gdnative_classdb_get_class_tag(const GDNativeStringNamePtr p_classname) {
+static void *gdnative_classdb_get_class_tag(GDNativeConstStringNamePtr p_classname) {
 	const StringName classname = *reinterpret_cast<const StringName *>(p_classname);
 	ClassDB::ClassInfo *class_info = ClassDB::classes.getptr(classname);
 	return class_info ? class_info->class_ptr : nullptr;

--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -141,12 +141,16 @@ typedef enum {
 } GDNativeVariantOperator;
 
 typedef void *GDNativeVariantPtr;
+typedef const void *GDNativeConstVariantPtr;
 typedef void *GDNativeStringNamePtr;
+typedef const void *GDNativeConstStringNamePtr;
 typedef void *GDNativeStringPtr;
+typedef const void *GDNativeConstStringPtr;
 typedef void *GDNativeObjectPtr;
+typedef const void *GDNativeConstObjectPtr;
 typedef void *GDNativeTypePtr;
-typedef void *GDNativeExtensionPtr;
-typedef void *GDNativeMethodBindPtr;
+typedef const void *GDNativeConstTypePtr;
+typedef const void *GDNativeMethodBindPtr;
 typedef int64_t GDNativeInt;
 typedef uint8_t GDNativeBool;
 typedef uint64_t GDObjectInstanceID;
@@ -171,18 +175,18 @@ typedef struct {
 
 typedef void (*GDNativeVariantFromTypeConstructorFunc)(GDNativeVariantPtr, GDNativeTypePtr);
 typedef void (*GDNativeTypeFromVariantConstructorFunc)(GDNativeTypePtr, GDNativeVariantPtr);
-typedef void (*GDNativePtrOperatorEvaluator)(const GDNativeTypePtr p_left, const GDNativeTypePtr p_right, GDNativeTypePtr r_result);
-typedef void (*GDNativePtrBuiltInMethod)(GDNativeTypePtr p_base, const GDNativeTypePtr *p_args, GDNativeTypePtr r_return, int p_argument_count);
-typedef void (*GDNativePtrConstructor)(GDNativeTypePtr p_base, const GDNativeTypePtr *p_args);
+typedef void (*GDNativePtrOperatorEvaluator)(GDNativeConstTypePtr p_left, GDNativeConstTypePtr p_right, GDNativeTypePtr r_result);
+typedef void (*GDNativePtrBuiltInMethod)(GDNativeTypePtr p_base, GDNativeConstTypePtr *p_args, GDNativeTypePtr r_return, int p_argument_count);
+typedef void (*GDNativePtrConstructor)(GDNativeTypePtr p_base, GDNativeConstTypePtr *p_args);
 typedef void (*GDNativePtrDestructor)(GDNativeTypePtr p_base);
-typedef void (*GDNativePtrSetter)(GDNativeTypePtr p_base, const GDNativeTypePtr p_value);
-typedef void (*GDNativePtrGetter)(const GDNativeTypePtr p_base, GDNativeTypePtr r_value);
-typedef void (*GDNativePtrIndexedSetter)(GDNativeTypePtr p_base, GDNativeInt p_index, const GDNativeTypePtr p_value);
-typedef void (*GDNativePtrIndexedGetter)(const GDNativeTypePtr p_base, GDNativeInt p_index, GDNativeTypePtr r_value);
-typedef void (*GDNativePtrKeyedSetter)(GDNativeTypePtr p_base, const GDNativeTypePtr p_key, const GDNativeTypePtr p_value);
-typedef void (*GDNativePtrKeyedGetter)(const GDNativeTypePtr p_base, const GDNativeTypePtr p_key, GDNativeTypePtr r_value);
-typedef uint32_t (*GDNativePtrKeyedChecker)(const GDNativeVariantPtr p_base, const GDNativeVariantPtr p_key);
-typedef void (*GDNativePtrUtilityFunction)(GDNativeTypePtr r_return, const GDNativeTypePtr *p_arguments, int p_argument_count);
+typedef void (*GDNativePtrSetter)(GDNativeTypePtr p_base, GDNativeConstTypePtr p_value);
+typedef void (*GDNativePtrGetter)(GDNativeConstTypePtr p_base, GDNativeTypePtr r_value);
+typedef void (*GDNativePtrIndexedSetter)(GDNativeTypePtr p_base, GDNativeInt p_index, GDNativeConstTypePtr p_value);
+typedef void (*GDNativePtrIndexedGetter)(GDNativeConstTypePtr p_base, GDNativeInt p_index, GDNativeTypePtr r_value);
+typedef void (*GDNativePtrKeyedSetter)(GDNativeTypePtr p_base, GDNativeConstTypePtr p_key, GDNativeConstTypePtr p_value);
+typedef void (*GDNativePtrKeyedGetter)(GDNativeConstTypePtr p_base, GDNativeConstTypePtr p_key, GDNativeTypePtr r_value);
+typedef uint32_t (*GDNativePtrKeyedChecker)(GDNativeConstVariantPtr p_base, GDNativeConstVariantPtr p_key);
+typedef void (*GDNativePtrUtilityFunction)(GDNativeTypePtr r_return, GDNativeConstTypePtr *p_arguments, int p_argument_count);
 
 typedef GDNativeObjectPtr (*GDNativeClassConstructor)();
 
@@ -200,8 +204,8 @@ typedef struct {
 
 typedef void *GDExtensionClassInstancePtr;
 
-typedef GDNativeBool (*GDNativeExtensionClassSet)(GDExtensionClassInstancePtr p_instance, const GDNativeStringNamePtr p_name, const GDNativeVariantPtr p_value);
-typedef GDNativeBool (*GDNativeExtensionClassGet)(GDExtensionClassInstancePtr p_instance, const GDNativeStringNamePtr p_name, GDNativeVariantPtr r_ret);
+typedef GDNativeBool (*GDNativeExtensionClassSet)(GDExtensionClassInstancePtr p_instance, GDNativeConstStringNamePtr p_name, GDNativeConstVariantPtr p_value);
+typedef GDNativeBool (*GDNativeExtensionClassGet)(GDExtensionClassInstancePtr p_instance, GDNativeConstStringNamePtr p_name, GDNativeVariantPtr r_ret);
 typedef uint64_t (*GDNativeExtensionClassGetRID)(GDExtensionClassInstancePtr p_instance);
 
 typedef struct {
@@ -230,16 +234,16 @@ typedef struct {
 
 typedef const GDNativePropertyInfo *(*GDNativeExtensionClassGetPropertyList)(GDExtensionClassInstancePtr p_instance, uint32_t *r_count);
 typedef void (*GDNativeExtensionClassFreePropertyList)(GDExtensionClassInstancePtr p_instance, const GDNativePropertyInfo *p_list);
-typedef GDNativeBool (*GDNativeExtensionClassPropertyCanRevert)(GDExtensionClassInstancePtr p_instance, const GDNativeStringNamePtr p_name);
-typedef GDNativeBool (*GDNativeExtensionClassPropertyGetRevert)(GDExtensionClassInstancePtr p_instance, const GDNativeStringNamePtr p_name, GDNativeVariantPtr r_ret);
+typedef GDNativeBool (*GDNativeExtensionClassPropertyCanRevert)(GDExtensionClassInstancePtr p_instance, GDNativeConstStringNamePtr p_name);
+typedef GDNativeBool (*GDNativeExtensionClassPropertyGetRevert)(GDExtensionClassInstancePtr p_instance, GDNativeConstStringNamePtr p_name, GDNativeVariantPtr r_ret);
 typedef void (*GDNativeExtensionClassNotification)(GDExtensionClassInstancePtr p_instance, int32_t p_what);
 typedef void (*GDNativeExtensionClassToString)(GDExtensionClassInstancePtr p_instance, GDNativeBool *r_is_valid, GDNativeStringPtr p_out);
 typedef void (*GDNativeExtensionClassReference)(GDExtensionClassInstancePtr p_instance);
 typedef void (*GDNativeExtensionClassUnreference)(GDExtensionClassInstancePtr p_instance);
-typedef void (*GDNativeExtensionClassCallVirtual)(GDExtensionClassInstancePtr p_instance, const GDNativeTypePtr *p_args, GDNativeTypePtr r_ret);
+typedef void (*GDNativeExtensionClassCallVirtual)(GDExtensionClassInstancePtr p_instance, GDNativeConstTypePtr *p_args, GDNativeTypePtr r_ret);
 typedef GDNativeObjectPtr (*GDNativeExtensionClassCreateInstance)(void *p_userdata);
 typedef void (*GDNativeExtensionClassFreeInstance)(void *p_userdata, GDExtensionClassInstancePtr p_instance);
-typedef GDNativeExtensionClassCallVirtual (*GDNativeExtensionClassGetVirtual)(void *p_userdata, const GDNativeStringNamePtr p_name);
+typedef GDNativeExtensionClassCallVirtual (*GDNativeExtensionClassGetVirtual)(void *p_userdata, GDNativeConstStringNamePtr p_name);
 
 typedef struct {
 	GDNativeBool is_virtual;
@@ -289,8 +293,8 @@ typedef enum {
 	GDNATIVE_EXTENSION_METHOD_ARGUMENT_METADATA_REAL_IS_DOUBLE
 } GDNativeExtensionClassMethodArgumentMetadata;
 
-typedef void (*GDNativeExtensionClassMethodCall)(void *method_userdata, GDExtensionClassInstancePtr p_instance, const GDNativeVariantPtr *p_args, const GDNativeInt p_argument_count, GDNativeVariantPtr r_return, GDNativeCallError *r_error);
-typedef void (*GDNativeExtensionClassMethodPtrCall)(void *method_userdata, GDExtensionClassInstancePtr p_instance, const GDNativeTypePtr *p_args, GDNativeTypePtr r_ret);
+typedef void (*GDNativeExtensionClassMethodCall)(void *method_userdata, GDExtensionClassInstancePtr p_instance, GDNativeConstVariantPtr *p_args, GDNativeInt p_argument_count, GDNativeVariantPtr r_return, GDNativeCallError *r_error);
+typedef void (*GDNativeExtensionClassMethodPtrCall)(void *method_userdata, GDExtensionClassInstancePtr p_instance, GDNativeConstTypePtr *p_args, GDNativeTypePtr r_ret);
 
 typedef struct {
 	GDNativeStringNamePtr name;
@@ -320,25 +324,25 @@ typedef struct {
 
 typedef void *GDNativeExtensionScriptInstanceDataPtr; // Pointer to custom ScriptInstance native implementation.
 
-typedef GDNativeBool (*GDNativeExtensionScriptInstanceSet)(GDNativeExtensionScriptInstanceDataPtr p_instance, const GDNativeStringNamePtr p_name, const GDNativeVariantPtr p_value);
-typedef GDNativeBool (*GDNativeExtensionScriptInstanceGet)(GDNativeExtensionScriptInstanceDataPtr p_instance, const GDNativeStringNamePtr p_name, GDNativeVariantPtr r_ret);
+typedef GDNativeBool (*GDNativeExtensionScriptInstanceSet)(GDNativeExtensionScriptInstanceDataPtr p_instance, GDNativeConstStringNamePtr p_name, GDNativeConstVariantPtr p_value);
+typedef GDNativeBool (*GDNativeExtensionScriptInstanceGet)(GDNativeExtensionScriptInstanceDataPtr p_instance, GDNativeConstStringNamePtr p_name, GDNativeVariantPtr r_ret);
 typedef const GDNativePropertyInfo *(*GDNativeExtensionScriptInstanceGetPropertyList)(GDNativeExtensionScriptInstanceDataPtr p_instance, uint32_t *r_count);
 typedef void (*GDNativeExtensionScriptInstanceFreePropertyList)(GDNativeExtensionScriptInstanceDataPtr p_instance, const GDNativePropertyInfo *p_list);
-typedef GDNativeVariantType (*GDNativeExtensionScriptInstanceGetPropertyType)(GDNativeExtensionScriptInstanceDataPtr p_instance, const GDNativeStringNamePtr p_name, GDNativeBool *r_is_valid);
+typedef GDNativeVariantType (*GDNativeExtensionScriptInstanceGetPropertyType)(GDNativeExtensionScriptInstanceDataPtr p_instance, GDNativeConstStringNamePtr p_name, GDNativeBool *r_is_valid);
 
-typedef GDNativeBool (*GDNativeExtensionScriptInstancePropertyCanRevert)(GDNativeExtensionScriptInstanceDataPtr p_instance, const GDNativeStringNamePtr p_name);
-typedef GDNativeBool (*GDNativeExtensionScriptInstancePropertyGetRevert)(GDNativeExtensionScriptInstanceDataPtr p_instance, const GDNativeStringNamePtr p_name, GDNativeVariantPtr r_ret);
+typedef GDNativeBool (*GDNativeExtensionScriptInstancePropertyCanRevert)(GDNativeExtensionScriptInstanceDataPtr p_instance, GDNativeConstStringNamePtr p_name);
+typedef GDNativeBool (*GDNativeExtensionScriptInstancePropertyGetRevert)(GDNativeExtensionScriptInstanceDataPtr p_instance, GDNativeConstStringNamePtr p_name, GDNativeVariantPtr r_ret);
 
 typedef GDNativeObjectPtr (*GDNativeExtensionScriptInstanceGetOwner)(GDNativeExtensionScriptInstanceDataPtr p_instance);
-typedef void (*GDNativeExtensionScriptInstancePropertyStateAdd)(const GDNativeStringNamePtr p_name, const GDNativeVariantPtr p_value, void *p_userdata);
+typedef void (*GDNativeExtensionScriptInstancePropertyStateAdd)(GDNativeConstStringNamePtr p_name, GDNativeConstVariantPtr p_value, void *p_userdata);
 typedef void (*GDNativeExtensionScriptInstanceGetPropertyState)(GDNativeExtensionScriptInstanceDataPtr p_instance, GDNativeExtensionScriptInstancePropertyStateAdd p_add_func, void *p_userdata);
 
 typedef const GDNativeMethodInfo *(*GDNativeExtensionScriptInstanceGetMethodList)(GDNativeExtensionScriptInstanceDataPtr p_instance, uint32_t *r_count);
 typedef void (*GDNativeExtensionScriptInstanceFreeMethodList)(GDNativeExtensionScriptInstanceDataPtr p_instance, const GDNativeMethodInfo *p_list);
 
-typedef GDNativeBool (*GDNativeExtensionScriptInstanceHasMethod)(GDNativeExtensionScriptInstanceDataPtr p_instance, const GDNativeStringNamePtr p_name);
+typedef GDNativeBool (*GDNativeExtensionScriptInstanceHasMethod)(GDNativeExtensionScriptInstanceDataPtr p_instance, GDNativeConstStringNamePtr p_name);
 
-typedef void (*GDNativeExtensionScriptInstanceCall)(GDNativeExtensionScriptInstanceDataPtr p_self, const GDNativeStringNamePtr p_method, const GDNativeVariantPtr *p_args, const GDNativeInt p_argument_count, GDNativeVariantPtr r_return, GDNativeCallError *r_error);
+typedef void (*GDNativeExtensionScriptInstanceCall)(GDNativeExtensionScriptInstanceDataPtr p_self, GDNativeConstStringNamePtr p_method, GDNativeConstVariantPtr *p_args, GDNativeInt p_argument_count, GDNativeVariantPtr r_return, GDNativeCallError *r_error);
 typedef void (*GDNativeExtensionScriptInstanceNotification)(GDNativeExtensionScriptInstanceDataPtr p_instance, int32_t p_what);
 typedef void (*GDNativeExtensionScriptInstanceToString)(GDNativeExtensionScriptInstanceDataPtr p_instance, GDNativeBool *r_is_valid, GDNativeStringPtr r_out);
 
@@ -413,41 +417,41 @@ typedef struct {
 	void (*print_warning)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line);
 	void (*print_script_error)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line);
 
-	uint64_t (*get_native_struct_size)(const GDNativeStringNamePtr p_name);
+	uint64_t (*get_native_struct_size)(GDNativeConstStringNamePtr p_name);
 
 	/* GODOT VARIANT */
 
 	/* variant general */
-	void (*variant_new_copy)(GDNativeVariantPtr r_dest, const GDNativeVariantPtr p_src);
+	void (*variant_new_copy)(GDNativeVariantPtr r_dest, GDNativeConstVariantPtr p_src);
 	void (*variant_new_nil)(GDNativeVariantPtr r_dest);
 	void (*variant_destroy)(GDNativeVariantPtr p_self);
 
 	/* variant type */
-	void (*variant_call)(GDNativeVariantPtr p_self, const GDNativeStringNamePtr p_method, const GDNativeVariantPtr *p_args, const GDNativeInt p_argument_count, GDNativeVariantPtr r_return, GDNativeCallError *r_error);
-	void (*variant_call_static)(GDNativeVariantType p_type, const GDNativeStringNamePtr p_method, const GDNativeVariantPtr *p_args, const GDNativeInt p_argument_count, GDNativeVariantPtr r_return, GDNativeCallError *r_error);
-	void (*variant_evaluate)(GDNativeVariantOperator p_op, const GDNativeVariantPtr p_a, const GDNativeVariantPtr p_b, GDNativeVariantPtr r_return, GDNativeBool *r_valid);
-	void (*variant_set)(GDNativeVariantPtr p_self, const GDNativeVariantPtr p_key, const GDNativeVariantPtr p_value, GDNativeBool *r_valid);
-	void (*variant_set_named)(GDNativeVariantPtr p_self, const GDNativeStringNamePtr p_key, const GDNativeVariantPtr p_value, GDNativeBool *r_valid);
-	void (*variant_set_keyed)(GDNativeVariantPtr p_self, const GDNativeVariantPtr p_key, const GDNativeVariantPtr p_value, GDNativeBool *r_valid);
-	void (*variant_set_indexed)(GDNativeVariantPtr p_self, GDNativeInt p_index, const GDNativeVariantPtr p_value, GDNativeBool *r_valid, GDNativeBool *r_oob);
-	void (*variant_get)(const GDNativeVariantPtr p_self, const GDNativeVariantPtr p_key, GDNativeVariantPtr r_ret, GDNativeBool *r_valid);
-	void (*variant_get_named)(const GDNativeVariantPtr p_self, const GDNativeStringNamePtr p_key, GDNativeVariantPtr r_ret, GDNativeBool *r_valid);
-	void (*variant_get_keyed)(const GDNativeVariantPtr p_self, const GDNativeVariantPtr p_key, GDNativeVariantPtr r_ret, GDNativeBool *r_valid);
-	void (*variant_get_indexed)(const GDNativeVariantPtr p_self, GDNativeInt p_index, GDNativeVariantPtr r_ret, GDNativeBool *r_valid, GDNativeBool *r_oob);
-	GDNativeBool (*variant_iter_init)(const GDNativeVariantPtr p_self, GDNativeVariantPtr r_iter, GDNativeBool *r_valid);
-	GDNativeBool (*variant_iter_next)(const GDNativeVariantPtr p_self, GDNativeVariantPtr r_iter, GDNativeBool *r_valid);
-	void (*variant_iter_get)(const GDNativeVariantPtr p_self, GDNativeVariantPtr r_iter, GDNativeVariantPtr r_ret, GDNativeBool *r_valid);
-	GDNativeInt (*variant_hash)(const GDNativeVariantPtr p_self);
-	GDNativeInt (*variant_recursive_hash)(const GDNativeVariantPtr p_self, GDNativeInt p_recursion_count);
-	GDNativeBool (*variant_hash_compare)(const GDNativeVariantPtr p_self, const GDNativeVariantPtr p_other);
-	GDNativeBool (*variant_booleanize)(const GDNativeVariantPtr p_self);
-	void (*variant_duplicate)(const GDNativeVariantPtr p_self, GDNativeVariantPtr r_ret, GDNativeBool p_deep);
-	void (*variant_stringify)(const GDNativeVariantPtr p_self, GDNativeStringPtr r_ret);
+	void (*variant_call)(GDNativeVariantPtr p_self, GDNativeConstStringNamePtr p_method, GDNativeConstVariantPtr *p_args, GDNativeInt p_argument_count, GDNativeVariantPtr r_return, GDNativeCallError *r_error);
+	void (*variant_call_static)(GDNativeVariantType p_type, GDNativeConstStringNamePtr p_method, GDNativeConstVariantPtr *p_args, GDNativeInt p_argument_count, GDNativeVariantPtr r_return, GDNativeCallError *r_error);
+	void (*variant_evaluate)(GDNativeVariantOperator p_op, GDNativeConstVariantPtr p_a, GDNativeConstVariantPtr p_b, GDNativeVariantPtr r_return, GDNativeBool *r_valid);
+	void (*variant_set)(GDNativeVariantPtr p_self, GDNativeConstVariantPtr p_key, GDNativeConstVariantPtr p_value, GDNativeBool *r_valid);
+	void (*variant_set_named)(GDNativeVariantPtr p_self, GDNativeConstStringNamePtr p_key, GDNativeConstVariantPtr p_value, GDNativeBool *r_valid);
+	void (*variant_set_keyed)(GDNativeVariantPtr p_self, GDNativeConstVariantPtr p_key, GDNativeConstVariantPtr p_value, GDNativeBool *r_valid);
+	void (*variant_set_indexed)(GDNativeVariantPtr p_self, GDNativeInt p_index, GDNativeConstVariantPtr p_value, GDNativeBool *r_valid, GDNativeBool *r_oob);
+	void (*variant_get)(GDNativeConstVariantPtr p_self, GDNativeConstVariantPtr p_key, GDNativeVariantPtr r_ret, GDNativeBool *r_valid);
+	void (*variant_get_named)(GDNativeConstVariantPtr p_self, GDNativeConstStringNamePtr p_key, GDNativeVariantPtr r_ret, GDNativeBool *r_valid);
+	void (*variant_get_keyed)(GDNativeConstVariantPtr p_self, GDNativeConstVariantPtr p_key, GDNativeVariantPtr r_ret, GDNativeBool *r_valid);
+	void (*variant_get_indexed)(GDNativeConstVariantPtr p_self, GDNativeInt p_index, GDNativeVariantPtr r_ret, GDNativeBool *r_valid, GDNativeBool *r_oob);
+	GDNativeBool (*variant_iter_init)(GDNativeConstVariantPtr p_self, GDNativeVariantPtr r_iter, GDNativeBool *r_valid);
+	GDNativeBool (*variant_iter_next)(GDNativeConstVariantPtr p_self, GDNativeVariantPtr r_iter, GDNativeBool *r_valid);
+	void (*variant_iter_get)(GDNativeConstVariantPtr p_self, GDNativeVariantPtr r_iter, GDNativeVariantPtr r_ret, GDNativeBool *r_valid);
+	GDNativeInt (*variant_hash)(GDNativeConstVariantPtr p_self);
+	GDNativeInt (*variant_recursive_hash)(GDNativeConstVariantPtr p_self, GDNativeInt p_recursion_count);
+	GDNativeBool (*variant_hash_compare)(GDNativeConstVariantPtr p_self, GDNativeConstVariantPtr p_other);
+	GDNativeBool (*variant_booleanize)(GDNativeConstVariantPtr p_self);
+	void (*variant_duplicate)(GDNativeConstVariantPtr p_self, GDNativeVariantPtr r_ret, GDNativeBool p_deep);
+	void (*variant_stringify)(GDNativeConstVariantPtr p_self, GDNativeStringPtr r_ret);
 
-	GDNativeVariantType (*variant_get_type)(const GDNativeVariantPtr p_self);
-	GDNativeBool (*variant_has_method)(const GDNativeVariantPtr p_self, const GDNativeStringNamePtr p_method);
-	GDNativeBool (*variant_has_member)(GDNativeVariantType p_type, const GDNativeStringNamePtr p_member);
-	GDNativeBool (*variant_has_key)(const GDNativeVariantPtr p_self, const GDNativeVariantPtr p_key, GDNativeBool *r_valid);
+	GDNativeVariantType (*variant_get_type)(GDNativeConstVariantPtr p_self);
+	GDNativeBool (*variant_has_method)(GDNativeConstVariantPtr p_self, GDNativeConstStringNamePtr p_method);
+	GDNativeBool (*variant_has_member)(GDNativeVariantType p_type, GDNativeConstStringNamePtr p_member);
+	GDNativeBool (*variant_has_key)(GDNativeConstVariantPtr p_self, GDNativeConstVariantPtr p_key, GDNativeBool *r_valid);
 	void (*variant_get_type_name)(GDNativeVariantType p_type, GDNativeStringPtr r_name);
 	GDNativeBool (*variant_can_convert)(GDNativeVariantType p_from, GDNativeVariantType p_to);
 	GDNativeBool (*variant_can_convert_strict)(GDNativeVariantType p_from, GDNativeVariantType p_to);
@@ -456,19 +460,19 @@ typedef struct {
 	GDNativeVariantFromTypeConstructorFunc (*get_variant_from_type_constructor)(GDNativeVariantType p_type);
 	GDNativeTypeFromVariantConstructorFunc (*get_variant_to_type_constructor)(GDNativeVariantType p_type);
 	GDNativePtrOperatorEvaluator (*variant_get_ptr_operator_evaluator)(GDNativeVariantOperator p_operator, GDNativeVariantType p_type_a, GDNativeVariantType p_type_b);
-	GDNativePtrBuiltInMethod (*variant_get_ptr_builtin_method)(GDNativeVariantType p_type, const GDNativeStringNamePtr p_method, GDNativeInt p_hash);
+	GDNativePtrBuiltInMethod (*variant_get_ptr_builtin_method)(GDNativeVariantType p_type, GDNativeConstStringNamePtr p_method, GDNativeInt p_hash);
 	GDNativePtrConstructor (*variant_get_ptr_constructor)(GDNativeVariantType p_type, int32_t p_constructor);
 	GDNativePtrDestructor (*variant_get_ptr_destructor)(GDNativeVariantType p_type);
-	void (*variant_construct)(GDNativeVariantType p_type, GDNativeVariantPtr p_base, const GDNativeVariantPtr *p_args, int32_t p_argument_count, GDNativeCallError *r_error);
-	GDNativePtrSetter (*variant_get_ptr_setter)(GDNativeVariantType p_type, const GDNativeStringNamePtr p_member);
-	GDNativePtrGetter (*variant_get_ptr_getter)(GDNativeVariantType p_type, const GDNativeStringNamePtr p_member);
+	void (*variant_construct)(GDNativeVariantType p_type, GDNativeVariantPtr p_base, GDNativeConstVariantPtr *p_args, int32_t p_argument_count, GDNativeCallError *r_error);
+	GDNativePtrSetter (*variant_get_ptr_setter)(GDNativeVariantType p_type, GDNativeConstStringNamePtr p_member);
+	GDNativePtrGetter (*variant_get_ptr_getter)(GDNativeVariantType p_type, GDNativeConstStringNamePtr p_member);
 	GDNativePtrIndexedSetter (*variant_get_ptr_indexed_setter)(GDNativeVariantType p_type);
 	GDNativePtrIndexedGetter (*variant_get_ptr_indexed_getter)(GDNativeVariantType p_type);
 	GDNativePtrKeyedSetter (*variant_get_ptr_keyed_setter)(GDNativeVariantType p_type);
 	GDNativePtrKeyedGetter (*variant_get_ptr_keyed_getter)(GDNativeVariantType p_type);
 	GDNativePtrKeyedChecker (*variant_get_ptr_keyed_checker)(GDNativeVariantType p_type);
-	void (*variant_get_constant_value)(GDNativeVariantType p_type, const GDNativeStringNamePtr p_constant, GDNativeVariantPtr r_ret);
-	GDNativePtrUtilityFunction (*variant_get_ptr_utility_function)(const GDNativeStringNamePtr p_function, GDNativeInt p_hash);
+	void (*variant_get_constant_value)(GDNativeVariantType p_type, GDNativeConstStringNamePtr p_constant, GDNativeVariantPtr r_ret);
+	GDNativePtrUtilityFunction (*variant_get_ptr_utility_function)(GDNativeConstStringNamePtr p_function, GDNativeInt p_hash);
 
 	/*  extra utilities */
 	void (*string_new_with_latin1_chars)(GDNativeStringPtr r_dest, const char *p_contents);
@@ -476,12 +480,11 @@ typedef struct {
 	void (*string_new_with_utf16_chars)(GDNativeStringPtr r_dest, const char16_t *p_contents);
 	void (*string_new_with_utf32_chars)(GDNativeStringPtr r_dest, const char32_t *p_contents);
 	void (*string_new_with_wide_chars)(GDNativeStringPtr r_dest, const wchar_t *p_contents);
-	void (*string_new_with_latin1_chars_and_len)(GDNativeStringPtr r_dest, const char *p_contents, const GDNativeInt p_size);
-	void (*string_new_with_utf8_chars_and_len)(GDNativeStringPtr r_dest, const char *p_contents, const GDNativeInt p_size);
-	void (*string_new_with_utf16_chars_and_len)(GDNativeStringPtr r_dest, const char16_t *p_contents, const GDNativeInt p_size);
-	void (*string_new_with_utf32_chars_and_len)(GDNativeStringPtr r_dest, const char32_t *p_contents, const GDNativeInt p_size);
-	void (*string_new_with_wide_chars_and_len)(GDNativeStringPtr r_dest, const wchar_t *p_contents, const GDNativeInt p_size);
-
+	void (*string_new_with_latin1_chars_and_len)(GDNativeStringPtr r_dest, const char *p_contents, GDNativeInt p_size);
+	void (*string_new_with_utf8_chars_and_len)(GDNativeStringPtr r_dest, const char *p_contents, GDNativeInt p_size);
+	void (*string_new_with_utf16_chars_and_len)(GDNativeStringPtr r_dest, const char16_t *p_contents, GDNativeInt p_size);
+	void (*string_new_with_utf32_chars_and_len)(GDNativeStringPtr r_dest, const char32_t *p_contents, GDNativeInt p_size);
+	void (*string_new_with_wide_chars_and_len)(GDNativeStringPtr r_dest, const wchar_t *p_contents, GDNativeInt p_size);
 	/* Information about the following functions:
 	 * - The return value is the resulting encoded string length.
 	 * - The length returned is in characters, not in bytes. It also does not include a trailing zero.
@@ -490,63 +493,63 @@ typedef struct {
 	 * - p_max_write_length argument is in characters, not bytes. It will be ignored if r_text is NULL.
 	 * - p_max_write_length argument does not affect the return value, it's only to cap write length.
 	 */
-	GDNativeInt (*string_to_latin1_chars)(const GDNativeStringPtr p_self, char *r_text, GDNativeInt p_max_write_length);
-	GDNativeInt (*string_to_utf8_chars)(const GDNativeStringPtr p_self, char *r_text, GDNativeInt p_max_write_length);
-	GDNativeInt (*string_to_utf16_chars)(const GDNativeStringPtr p_self, char16_t *r_text, GDNativeInt p_max_write_length);
-	GDNativeInt (*string_to_utf32_chars)(const GDNativeStringPtr p_self, char32_t *r_text, GDNativeInt p_max_write_length);
-	GDNativeInt (*string_to_wide_chars)(const GDNativeStringPtr p_self, wchar_t *r_text, GDNativeInt p_max_write_length);
+	GDNativeInt (*string_to_latin1_chars)(GDNativeConstStringPtr p_self, char *r_text, GDNativeInt p_max_write_length);
+	GDNativeInt (*string_to_utf8_chars)(GDNativeConstStringPtr p_self, char *r_text, GDNativeInt p_max_write_length);
+	GDNativeInt (*string_to_utf16_chars)(GDNativeConstStringPtr p_self, char16_t *r_text, GDNativeInt p_max_write_length);
+	GDNativeInt (*string_to_utf32_chars)(GDNativeConstStringPtr p_self, char32_t *r_text, GDNativeInt p_max_write_length);
+	GDNativeInt (*string_to_wide_chars)(GDNativeConstStringPtr p_self, wchar_t *r_text, GDNativeInt p_max_write_length);
 	char32_t *(*string_operator_index)(GDNativeStringPtr p_self, GDNativeInt p_index);
-	const char32_t *(*string_operator_index_const)(const GDNativeStringPtr p_self, GDNativeInt p_index);
+	const char32_t *(*string_operator_index_const)(GDNativeConstStringPtr p_self, GDNativeInt p_index);
 
 	/* Packed array functions */
 
 	uint8_t *(*packed_byte_array_operator_index)(GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedByteArray
-	const uint8_t *(*packed_byte_array_operator_index_const)(const GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedByteArray
+	const uint8_t *(*packed_byte_array_operator_index_const)(GDNativeConstTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedByteArray
 
 	GDNativeTypePtr (*packed_color_array_operator_index)(GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedColorArray, returns Color ptr
-	GDNativeTypePtr (*packed_color_array_operator_index_const)(const GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedColorArray, returns Color ptr
+	GDNativeTypePtr (*packed_color_array_operator_index_const)(GDNativeConstTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedColorArray, returns Color ptr
 
 	float *(*packed_float32_array_operator_index)(GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedFloat32Array
-	const float *(*packed_float32_array_operator_index_const)(const GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedFloat32Array
+	const float *(*packed_float32_array_operator_index_const)(GDNativeConstTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedFloat32Array
 	double *(*packed_float64_array_operator_index)(GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedFloat64Array
-	const double *(*packed_float64_array_operator_index_const)(const GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedFloat64Array
+	const double *(*packed_float64_array_operator_index_const)(GDNativeConstTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedFloat64Array
 
 	int32_t *(*packed_int32_array_operator_index)(GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedInt32Array
-	const int32_t *(*packed_int32_array_operator_index_const)(const GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedInt32Array
+	const int32_t *(*packed_int32_array_operator_index_const)(GDNativeConstTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedInt32Array
 	int64_t *(*packed_int64_array_operator_index)(GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedInt32Array
-	const int64_t *(*packed_int64_array_operator_index_const)(const GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedInt32Array
+	const int64_t *(*packed_int64_array_operator_index_const)(GDNativeConstTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedInt32Array
 
 	GDNativeStringPtr (*packed_string_array_operator_index)(GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedStringArray
-	GDNativeStringPtr (*packed_string_array_operator_index_const)(const GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedStringArray
+	GDNativeStringPtr (*packed_string_array_operator_index_const)(GDNativeConstTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedStringArray
 
 	GDNativeTypePtr (*packed_vector2_array_operator_index)(GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedVector2Array, returns Vector2 ptr
-	GDNativeTypePtr (*packed_vector2_array_operator_index_const)(const GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedVector2Array, returns Vector2 ptr
+	GDNativeTypePtr (*packed_vector2_array_operator_index_const)(GDNativeConstTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedVector2Array, returns Vector2 ptr
 	GDNativeTypePtr (*packed_vector3_array_operator_index)(GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedVector3Array, returns Vector3 ptr
-	GDNativeTypePtr (*packed_vector3_array_operator_index_const)(const GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedVector3Array, returns Vector3 ptr
+	GDNativeTypePtr (*packed_vector3_array_operator_index_const)(GDNativeConstTypePtr p_self, GDNativeInt p_index); // p_self should be a PackedVector3Array, returns Vector3 ptr
 
 	GDNativeVariantPtr (*array_operator_index)(GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be an Array ptr
-	GDNativeVariantPtr (*array_operator_index_const)(const GDNativeTypePtr p_self, GDNativeInt p_index); // p_self should be an Array ptr
+	GDNativeVariantPtr (*array_operator_index_const)(GDNativeConstTypePtr p_self, GDNativeInt p_index); // p_self should be an Array ptr
 
 	/* Dictionary functions */
 
-	GDNativeVariantPtr (*dictionary_operator_index)(GDNativeTypePtr p_self, const GDNativeVariantPtr p_key); // p_self should be an Dictionary ptr
-	GDNativeVariantPtr (*dictionary_operator_index_const)(const GDNativeTypePtr p_self, const GDNativeVariantPtr p_key); // p_self should be an Dictionary ptr
+	GDNativeVariantPtr (*dictionary_operator_index)(GDNativeTypePtr p_self, GDNativeConstVariantPtr p_key); // p_self should be an Dictionary ptr
+	GDNativeVariantPtr (*dictionary_operator_index_const)(GDNativeConstTypePtr p_self, GDNativeConstVariantPtr p_key); // p_self should be an Dictionary ptr
 
 	/* OBJECT */
 
-	void (*object_method_bind_call)(const GDNativeMethodBindPtr p_method_bind, GDNativeObjectPtr p_instance, const GDNativeVariantPtr *p_args, GDNativeInt p_arg_count, GDNativeVariantPtr r_ret, GDNativeCallError *r_error);
-	void (*object_method_bind_ptrcall)(const GDNativeMethodBindPtr p_method_bind, GDNativeObjectPtr p_instance, const GDNativeTypePtr *p_args, GDNativeTypePtr r_ret);
+	void (*object_method_bind_call)(GDNativeMethodBindPtr p_method_bind, GDNativeObjectPtr p_instance, GDNativeConstVariantPtr *p_args, GDNativeInt p_arg_count, GDNativeVariantPtr r_ret, GDNativeCallError *r_error);
+	void (*object_method_bind_ptrcall)(GDNativeMethodBindPtr p_method_bind, GDNativeObjectPtr p_instance, GDNativeConstTypePtr *p_args, GDNativeTypePtr r_ret);
 	void (*object_destroy)(GDNativeObjectPtr p_o);
-	GDNativeObjectPtr (*global_get_singleton)(const GDNativeStringNamePtr p_name);
+	GDNativeObjectPtr (*global_get_singleton)(GDNativeConstStringNamePtr p_name);
 
 	void *(*object_get_instance_binding)(GDNativeObjectPtr p_o, void *p_token, const GDNativeInstanceBindingCallbacks *p_callbacks);
 	void (*object_set_instance_binding)(GDNativeObjectPtr p_o, void *p_token, void *p_binding, const GDNativeInstanceBindingCallbacks *p_callbacks);
 
-	void (*object_set_instance)(GDNativeObjectPtr p_o, const GDNativeStringNamePtr p_classname, GDExtensionClassInstancePtr p_instance); /* p_classname should be a registered extension class and should extend the p_o object's class. */
+	void (*object_set_instance)(GDNativeObjectPtr p_o, GDNativeConstStringNamePtr p_classname, GDExtensionClassInstancePtr p_instance); /* p_classname should be a registered extension class and should extend the p_o object's class. */
 
-	GDNativeObjectPtr (*object_cast_to)(const GDNativeObjectPtr p_object, void *p_class_tag);
+	GDNativeObjectPtr (*object_cast_to)(GDNativeConstObjectPtr p_object, void *p_class_tag);
 	GDNativeObjectPtr (*object_get_instance_from_id)(GDObjectInstanceID p_instance_id);
-	GDObjectInstanceID (*object_get_instance_id)(const GDNativeObjectPtr p_object);
+	GDObjectInstanceID (*object_get_instance_id)(GDNativeConstObjectPtr p_object);
 
 	/* SCRIPT INSTANCE */
 
@@ -554,23 +557,23 @@ typedef struct {
 
 	/* CLASSDB */
 
-	GDNativeObjectPtr (*classdb_construct_object)(const GDNativeStringNamePtr p_classname); /* The passed class must be a built-in godot class, or an already-registered extension class. In both case, object_set_instance should be called to fully initialize the object. */
-	GDNativeMethodBindPtr (*classdb_get_method_bind)(const GDNativeStringNamePtr p_classname, const GDNativeStringNamePtr p_methodname, GDNativeInt p_hash);
-	void *(*classdb_get_class_tag)(const GDNativeStringNamePtr p_classname);
+	GDNativeObjectPtr (*classdb_construct_object)(GDNativeConstStringNamePtr p_classname); /* The passed class must be a built-in godot class, or an already-registered extension class. In both case, object_set_instance should be called to fully initialize the object. */
+	GDNativeMethodBindPtr (*classdb_get_method_bind)(GDNativeConstStringNamePtr p_classname, GDNativeConstStringNamePtr p_methodname, GDNativeInt p_hash);
+	void *(*classdb_get_class_tag)(GDNativeConstStringNamePtr p_classname);
 
 	/* CLASSDB EXTENSION */
 
 	/* Provided parameters for `classdb_register_extension_*` can be safely freed once the function returns. */
-	void (*classdb_register_extension_class)(const GDNativeExtensionClassLibraryPtr p_library, const GDNativeStringNamePtr p_class_name, const GDNativeStringNamePtr p_parent_class_name, const GDNativeExtensionClassCreationInfo *p_extension_funcs);
-	void (*classdb_register_extension_class_method)(const GDNativeExtensionClassLibraryPtr p_library, const GDNativeStringNamePtr p_class_name, const GDNativeExtensionClassMethodInfo *p_method_info);
-	void (*classdb_register_extension_class_integer_constant)(const GDNativeExtensionClassLibraryPtr p_library, const GDNativeStringNamePtr p_class_name, const GDNativeStringNamePtr p_enum_name, const GDNativeStringNamePtr p_constant_name, GDNativeInt p_constant_value, GDNativeBool p_is_bitfield);
-	void (*classdb_register_extension_class_property)(const GDNativeExtensionClassLibraryPtr p_library, const GDNativeStringNamePtr p_class_name, const GDNativePropertyInfo *p_info, const GDNativeStringNamePtr p_setter, const GDNativeStringNamePtr p_getter);
-	void (*classdb_register_extension_class_property_group)(const GDNativeExtensionClassLibraryPtr p_library, const GDNativeStringNamePtr p_class_name, const GDNativeStringPtr p_group_name, const GDNativeStringPtr p_prefix);
-	void (*classdb_register_extension_class_property_subgroup)(const GDNativeExtensionClassLibraryPtr p_library, const GDNativeStringNamePtr p_class_name, const GDNativeStringPtr p_subgroup_name, const GDNativeStringPtr p_prefix);
-	void (*classdb_register_extension_class_signal)(const GDNativeExtensionClassLibraryPtr p_library, const GDNativeStringNamePtr p_class_name, const GDNativeStringNamePtr p_signal_name, const GDNativePropertyInfo *p_argument_info, GDNativeInt p_argument_count);
-	void (*classdb_unregister_extension_class)(const GDNativeExtensionClassLibraryPtr p_library, const GDNativeStringNamePtr p_class_name); /* Unregistering a parent class before a class that inherits it will result in failure. Inheritors must be unregistered first. */
+	void (*classdb_register_extension_class)(GDNativeExtensionClassLibraryPtr p_library, GDNativeConstStringNamePtr p_class_name, GDNativeConstStringNamePtr p_parent_class_name, const GDNativeExtensionClassCreationInfo *p_extension_funcs);
+	void (*classdb_register_extension_class_method)(GDNativeExtensionClassLibraryPtr p_library, GDNativeConstStringNamePtr p_class_name, const GDNativeExtensionClassMethodInfo *p_method_info);
+	void (*classdb_register_extension_class_integer_constant)(GDNativeExtensionClassLibraryPtr p_library, GDNativeConstStringNamePtr p_class_name, GDNativeConstStringNamePtr p_enum_name, GDNativeConstStringNamePtr p_constant_name, GDNativeInt p_constant_value, GDNativeBool p_is_bitfield);
+	void (*classdb_register_extension_class_property)(GDNativeExtensionClassLibraryPtr p_library, GDNativeConstStringNamePtr p_class_name, const GDNativePropertyInfo *p_info, GDNativeConstStringNamePtr p_setter, GDNativeConstStringNamePtr p_getter);
+	void (*classdb_register_extension_class_property_group)(GDNativeExtensionClassLibraryPtr p_library, GDNativeConstStringNamePtr p_class_name, GDNativeConstStringPtr p_group_name, GDNativeConstStringPtr p_prefix);
+	void (*classdb_register_extension_class_property_subgroup)(GDNativeExtensionClassLibraryPtr p_library, GDNativeConstStringNamePtr p_class_name, GDNativeConstStringPtr p_subgroup_name, GDNativeConstStringPtr p_prefix);
+	void (*classdb_register_extension_class_signal)(GDNativeExtensionClassLibraryPtr p_library, GDNativeConstStringNamePtr p_class_name, GDNativeConstStringNamePtr p_signal_name, const GDNativePropertyInfo *p_argument_info, GDNativeInt p_argument_count);
+	void (*classdb_unregister_extension_class)(GDNativeExtensionClassLibraryPtr p_library, GDNativeConstStringNamePtr p_class_name); /* Unregistering a parent class before a class that inherits it will result in failure. Inheritors must be unregistered first. */
 
-	void (*get_library_path)(const GDNativeExtensionClassLibraryPtr p_library, GDNativeStringPtr r_path);
+	void (*get_library_path)(GDNativeExtensionClassLibraryPtr p_library, GDNativeStringPtr r_path);
 
 } GDNativeInterface;
 
@@ -600,7 +603,7 @@ typedef struct {
  * It can be used to set up different init levels, which are called during various stages of initialization/shutdown.
  * The function name must be a unique one specified in the .gdextension config file.
  */
-typedef GDNativeBool (*GDNativeInitializationFunction)(const GDNativeInterface *p_interface, const GDNativeExtensionClassLibraryPtr p_library, GDNativeInitialization *r_initialization);
+typedef GDNativeBool (*GDNativeInitializationFunction)(const GDNativeInterface *p_interface, GDNativeExtensionClassLibraryPtr p_library, GDNativeInitialization *r_initialization);
 
 #ifdef __cplusplus
 }

--- a/core/extension/native_extension.h
+++ b/core/extension/native_extension.h
@@ -47,15 +47,15 @@ class NativeExtension : public Resource {
 
 	HashMap<StringName, Extension> extension_classes;
 
-	static void _register_extension_class(const GDNativeExtensionClassLibraryPtr p_library, const GDNativeStringNamePtr p_class_name, const GDNativeStringNamePtr p_parent_class_name, const GDNativeExtensionClassCreationInfo *p_extension_funcs);
-	static void _register_extension_class_method(const GDNativeExtensionClassLibraryPtr p_library, const GDNativeStringNamePtr p_class_name, const GDNativeExtensionClassMethodInfo *p_method_info);
-	static void _register_extension_class_integer_constant(const GDNativeExtensionClassLibraryPtr p_library, const GDNativeStringNamePtr p_class_name, const GDNativeStringNamePtr p_enum_name, const GDNativeStringNamePtr p_constant_name, GDNativeInt p_constant_value, GDNativeBool p_is_bitfield);
-	static void _register_extension_class_property(const GDNativeExtensionClassLibraryPtr p_library, const GDNativeStringNamePtr p_class_name, const GDNativePropertyInfo *p_info, const GDNativeStringNamePtr p_setter, const GDNativeStringNamePtr p_getter);
-	static void _register_extension_class_property_group(const GDNativeExtensionClassLibraryPtr p_library, const GDNativeStringNamePtr p_class_name, const GDNativeStringNamePtr p_group_name, const GDNativeStringNamePtr p_prefix);
-	static void _register_extension_class_property_subgroup(const GDNativeExtensionClassLibraryPtr p_library, const GDNativeStringNamePtr p_class_name, const GDNativeStringNamePtr p_subgroup_name, const GDNativeStringNamePtr p_prefix);
-	static void _register_extension_class_signal(const GDNativeExtensionClassLibraryPtr p_library, const GDNativeStringNamePtr p_class_name, const GDNativeStringNamePtr p_signal_name, const GDNativePropertyInfo *p_argument_info, GDNativeInt p_argument_count);
-	static void _unregister_extension_class(const GDNativeExtensionClassLibraryPtr p_library, const GDNativeStringNamePtr p_class_name);
-	static void _get_library_path(const GDNativeExtensionClassLibraryPtr p_library, GDNativeStringPtr r_path);
+	static void _register_extension_class(GDNativeExtensionClassLibraryPtr p_library, GDNativeConstStringNamePtr p_class_name, GDNativeConstStringNamePtr p_parent_class_name, const GDNativeExtensionClassCreationInfo *p_extension_funcs);
+	static void _register_extension_class_method(GDNativeExtensionClassLibraryPtr p_library, GDNativeConstStringNamePtr p_class_name, const GDNativeExtensionClassMethodInfo *p_method_info);
+	static void _register_extension_class_integer_constant(GDNativeExtensionClassLibraryPtr p_library, GDNativeConstStringNamePtr p_class_name, GDNativeConstStringNamePtr p_enum_name, GDNativeConstStringNamePtr p_constant_name, GDNativeInt p_constant_value, GDNativeBool p_is_bitfield);
+	static void _register_extension_class_property(GDNativeExtensionClassLibraryPtr p_library, GDNativeConstStringNamePtr p_class_name, const GDNativePropertyInfo *p_info, GDNativeConstStringNamePtr p_setter, GDNativeConstStringNamePtr p_getter);
+	static void _register_extension_class_property_group(GDNativeExtensionClassLibraryPtr p_library, GDNativeConstStringNamePtr p_class_name, GDNativeConstStringNamePtr p_group_name, GDNativeConstStringNamePtr p_prefix);
+	static void _register_extension_class_property_subgroup(GDNativeExtensionClassLibraryPtr p_library, GDNativeConstStringNamePtr p_class_name, GDNativeConstStringNamePtr p_subgroup_name, GDNativeConstStringNamePtr p_prefix);
+	static void _register_extension_class_signal(GDNativeExtensionClassLibraryPtr p_library, GDNativeConstStringNamePtr p_class_name, GDNativeConstStringNamePtr p_signal_name, const GDNativePropertyInfo *p_argument_info, GDNativeInt p_argument_count);
+	static void _unregister_extension_class(GDNativeExtensionClassLibraryPtr p_library, GDNativeConstStringNamePtr p_class_name);
+	static void _get_library_path(GDNativeExtensionClassLibraryPtr p_library, GDNativeStringPtr r_path);
 
 	GDNativeInitialization initialization;
 	int32_t level_initialized = -1;

--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -94,7 +94,7 @@ def generate_version(argcount, const=False, returns=False):
         argtext += ", "
         callsiargs = "Variant vargs[" + str(argcount) + "]={"
         callsiargptrs = "\t\tconst Variant *vargptrs[" + str(argcount) + "]={"
-        callptrargsptr = "\t\tconst GDNativeTypePtr argptrs[" + str(argcount) + "]={"
+        callptrargsptr = "\t\tGDNativeConstTypePtr argptrs[" + str(argcount) + "]={"
     callptrargs = ""
     for i in range(argcount):
         if i > 0:
@@ -121,7 +121,7 @@ def generate_version(argcount, const=False, returns=False):
         s = s.replace("$CALLSIARGPASS", "(const Variant **)vargptrs," + str(argcount))
         callptrargsptr += "};\\\n"
         s = s.replace("$CALLPTRARGS", callptrargs + callptrargsptr)
-        s = s.replace("$CALLPTRARGPASS", "(const GDNativeTypePtr*)argptrs")
+        s = s.replace("$CALLPTRARGPASS", "reinterpret_cast<GDNativeConstTypePtr*>(argptrs)")
     else:
         s = s.replace("$CALLSIARGS", "")
         s = s.replace("$CALLSIARGPASS", "nullptr, 0")

--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -110,8 +110,8 @@ public:
 
 	_FORCE_INLINE_ int get_argument_count() const { return argument_count; };
 
-	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) = 0;
-	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) = 0;
+	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const = 0;
+	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) const = 0;
 
 	StringName get_name() const;
 	void set_name(const StringName &p_name);
@@ -158,7 +158,7 @@ public:
 	}
 #endif
 
-	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) override {
+	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) const override {
 		ERR_FAIL(); // Can't call.
 	}
 
@@ -210,7 +210,7 @@ class MethodBindVarArgT : public MethodBindVarArgBase<MethodBindVarArgT<T>, T, v
 	friend class MethodBindVarArgBase<MethodBindVarArgT<T>, T, void, false>;
 
 public:
-	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) override {
+	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
 		(static_cast<T *>(p_object)->*MethodBindVarArgBase<MethodBindVarArgT<T>, T, void, false>::method)(p_args, p_arg_count, r_error);
 		return {};
 	}
@@ -246,7 +246,7 @@ public:
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
-	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) override {
+	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
 		return (static_cast<T *>(p_object)->*MethodBindVarArgBase<MethodBindVarArgTR<T, R>, T, R, true>::method)(p_args, p_arg_count, r_error);
 	}
 #if defined(SANITIZERS_ENABLED) && defined(__GNUC__) && !defined(__clang__)
@@ -313,7 +313,7 @@ public:
 	}
 
 #endif
-	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) override {
+	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
 #ifdef TYPED_METHOD_BIND
 		call_with_variant_args_dv(static_cast<T *>(p_object), method, p_args, p_arg_count, r_error, get_default_arguments());
 #else
@@ -322,7 +322,7 @@ public:
 		return Variant();
 	}
 
-	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) override {
+	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) const override {
 #ifdef TYPED_METHOD_BIND
 		call_with_ptr_args<T, P...>(static_cast<T *>(p_object), method, p_args);
 #else
@@ -380,7 +380,7 @@ public:
 	}
 
 #endif
-	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) override {
+	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
 #ifdef TYPED_METHOD_BIND
 		call_with_variant_argsc_dv(static_cast<T *>(p_object), method, p_args, p_arg_count, r_error, get_default_arguments());
 #else
@@ -389,7 +389,7 @@ public:
 		return Variant();
 	}
 
-	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) override {
+	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) const override {
 #ifdef TYPED_METHOD_BIND
 		call_with_ptr_argsc<T, P...>(static_cast<T *>(p_object), method, p_args);
 #else
@@ -457,7 +457,7 @@ public:
 	}
 #endif
 
-	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) override {
+	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
 		Variant ret;
 #ifdef TYPED_METHOD_BIND
 		call_with_variant_args_ret_dv(static_cast<T *>(p_object), method, p_args, p_arg_count, ret, r_error, get_default_arguments());
@@ -467,7 +467,7 @@ public:
 		return ret;
 	}
 
-	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) override {
+	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) const override {
 #ifdef TYPED_METHOD_BIND
 		call_with_ptr_args_ret<T, R, P...>(static_cast<T *>(p_object), method, p_args, r_ret);
 #else
@@ -536,7 +536,7 @@ public:
 	}
 #endif
 
-	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) override {
+	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
 		Variant ret;
 #ifdef TYPED_METHOD_BIND
 		call_with_variant_args_retc_dv(static_cast<T *>(p_object), method, p_args, p_arg_count, ret, r_error, get_default_arguments());
@@ -546,7 +546,7 @@ public:
 		return ret;
 	}
 
-	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) override {
+	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) const override {
 #ifdef TYPED_METHOD_BIND
 		call_with_ptr_args_retc<T, R, P...>(static_cast<T *>(p_object), method, p_args, r_ret);
 #else
@@ -604,13 +604,13 @@ public:
 	}
 
 #endif
-	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) override {
+	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
 		(void)p_object; // unused
 		call_with_variant_args_static_dv(function, p_args, p_arg_count, r_error, get_default_arguments());
 		return Variant();
 	}
 
-	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) override {
+	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) const override {
 		(void)p_object;
 		(void)r_ret;
 		call_with_ptr_args_static_method(function, p_args);
@@ -667,13 +667,13 @@ public:
 	}
 
 #endif
-	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) override {
+	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
 		Variant ret;
 		call_with_variant_args_static_ret_dv(function, p_args, p_arg_count, ret, r_error, get_default_arguments());
 		return ret;
 	}
 
-	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) override {
+	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) const override {
 		(void)p_object;
 		call_with_ptr_args_static_method_ret(function, p_args, r_ret);
 	}

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -650,13 +650,13 @@ public:
 
 	virtual bool set(const StringName &p_name, const Variant &p_value) override {
 		if (native_info->set_func) {
-			return native_info->set_func(instance, (const GDNativeStringNamePtr)&p_name, (const GDNativeVariantPtr)&p_value);
+			return native_info->set_func(instance, (GDNativeConstStringNamePtr)&p_name, (GDNativeConstVariantPtr)&p_value);
 		}
 		return false;
 	}
 	virtual bool get(const StringName &p_name, Variant &r_ret) const override {
 		if (native_info->get_func) {
-			return native_info->get_func(instance, (const GDNativeStringNamePtr)&p_name, (GDNativeVariantPtr)&r_ret);
+			return native_info->get_func(instance, (GDNativeConstStringNamePtr)&p_name, (GDNativeVariantPtr)&r_ret);
 		}
 		return false;
 	}
@@ -683,7 +683,7 @@ public:
 	virtual Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid = nullptr) const override {
 		if (native_info->get_property_type_func) {
 			GDNativeBool is_valid = 0;
-			GDNativeVariantType type = native_info->get_property_type_func(instance, (const GDNativeStringNamePtr)&p_name, &is_valid);
+			GDNativeVariantType type = native_info->get_property_type_func(instance, (GDNativeConstStringNamePtr)&p_name, &is_valid);
 			if (r_is_valid) {
 				*r_is_valid = is_valid != 0;
 			}
@@ -694,13 +694,13 @@ public:
 
 	virtual bool property_can_revert(const StringName &p_name) const override {
 		if (native_info->property_can_revert_func) {
-			return native_info->property_can_revert_func(instance, (const GDNativeStringNamePtr)&p_name);
+			return native_info->property_can_revert_func(instance, (GDNativeConstStringNamePtr)&p_name);
 		}
 		return false;
 	}
 	virtual bool property_get_revert(const StringName &p_name, Variant &r_ret) const override {
 		if (native_info->property_get_revert_func) {
-			return native_info->property_get_revert_func(instance, (const GDNativeStringNamePtr)&p_name, (GDNativeVariantPtr)&r_ret);
+			return native_info->property_get_revert_func(instance, (GDNativeConstStringNamePtr)&p_name, (GDNativeVariantPtr)&r_ret);
 		}
 		return false;
 	}
@@ -711,7 +711,7 @@ public:
 		}
 		return nullptr;
 	}
-	static void _add_property_with_state(const GDNativeStringNamePtr p_name, const GDNativeVariantPtr p_value, void *p_userdata) {
+	static void _add_property_with_state(GDNativeConstStringNamePtr p_name, GDNativeConstVariantPtr p_value, void *p_userdata) {
 		List<Pair<StringName, Variant>> *state = (List<Pair<StringName, Variant>> *)p_userdata;
 		state->push_back(Pair<StringName, Variant>(*(const StringName *)p_name, *(const Variant *)p_value));
 	}
@@ -744,7 +744,7 @@ public:
 		Variant ret;
 		if (native_info->call_func) {
 			GDNativeCallError ce;
-			native_info->call_func(instance, (const GDNativeStringNamePtr)&p_method, (const GDNativeVariantPtr *)p_args, p_argcount, (GDNativeVariantPtr)&ret, &ce);
+			native_info->call_func(instance, (GDNativeConstStringNamePtr)&p_method, (GDNativeConstVariantPtr *)p_args, p_argcount, (GDNativeVariantPtr)&ret, &ce);
 			r_error.error = Callable::CallError::Error(ce.error);
 			r_error.argument = ce.argument;
 			r_error.expected = ce.expected;
@@ -799,7 +799,7 @@ public:
 
 	virtual void property_set_fallback(const StringName &p_name, const Variant &p_value, bool *r_valid) override {
 		if (native_info->set_fallback_func) {
-			bool ret = native_info->set_fallback_func(instance, (const GDNativeStringNamePtr)&p_name, (const GDNativeVariantPtr)&p_value);
+			bool ret = native_info->set_fallback_func(instance, (GDNativeConstStringNamePtr)&p_name, (GDNativeConstVariantPtr)&p_value);
 			if (r_valid) {
 				*r_valid = ret;
 			}
@@ -808,7 +808,7 @@ public:
 	virtual Variant property_get_fallback(const StringName &p_name, bool *r_valid) override {
 		Variant ret;
 		if (native_info->get_fallback_func) {
-			bool valid = native_info->get_fallback_func(instance, (const GDNativeStringNamePtr)&p_name, (GDNativeVariantPtr)&ret);
+			bool valid = native_info->get_fallback_func(instance, (GDNativeConstStringNamePtr)&p_name, (GDNativeVariantPtr)&ret);
 			if (r_valid) {
 				*r_valid = valid;
 			}


### PR DESCRIPTION
see the related Godot-CPP PR: https://github.com/godotengine/godot-cpp/pull/897

The GDExtension contains code like this:
```cpp
typedef void *FooPtr;
void do_something(const FooPtr foo);
```

What we'd like to have is `foo` being typed as `const void*` (i.e. a pointer on a constant structure), however what it is actually typed is `void *const` (i.e. a constant pointer on a modifiable structure)

This PR fix this by introducing const types, e.g.:
```cpp
typedef void *FooPtr;
typedef const void*ConstFooPtr;
void do_something(ConstFooPtr foo);
```
