### PR TITLE
Add `Color.get_named_colors()`

### DIFF
--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -34,6 +34,7 @@
 #include "core/math/math_funcs.h"
 #include "core/string/ustring.h"
 #include "core/templates/rb_map.h"
+#include "core/variant/variant.h"
 
 #include "thirdparty/misc/ok_color.h"
 
@@ -451,6 +452,17 @@ String Color::get_named_color_name(int p_idx) {
 Color Color::get_named_color(int p_idx) {
 	ERR_FAIL_INDEX_V(p_idx, get_named_color_count(), Color());
 	return named_colors[p_idx].color;
+}
+
+Dictionary Color::get_named_colors() {
+	Dictionary dict;
+	for (int idx = 0; named_colors[idx].name != nullptr; idx++) {
+		NamedColor named = named_colors[idx];
+
+		const String name = String(named.name);
+		dict[Variant(name)] = Variant(named.color);
+	}
+	return dict;
 }
 
 // For a version that errors on invalid values instead of returning

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -32,6 +32,7 @@
 #define COLOR_H
 
 #include "core/math/math_funcs.h"
+#include "core/variant/dictionary.h"
 
 class String;
 
@@ -198,6 +199,7 @@ struct _NO_DISCARD_ Color {
 	static int get_named_color_count();
 	static String get_named_color_name(int p_idx);
 	static Color get_named_color(int p_idx);
+	static Dictionary get_named_colors();
 	static Color from_string(const String &p_string, const Color &p_default);
 	static Color from_hsv(float p_h, float p_s, float p_v, float p_alpha = 1.0f);
 	static Color from_ok_hsl(float p_h, float p_s, float p_l, float p_alpha = 1.0f);

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1839,6 +1839,7 @@ static void _register_variant_builtin_methods() {
 	bind_static_method(Color, get_named_color_count, sarray(), varray());
 	bind_static_method(Color, get_named_color_name, sarray("idx"), varray());
 	bind_static_method(Color, get_named_color, sarray("idx"), varray());
+	bind_static_method(Color, get_named_colors, sarray(), varray());
 	bind_static_method(Color, from_string, sarray("str", "default"), varray());
 	bind_static_method(Color, from_hsv, sarray("h", "s", "v", "alpha"), varray(1.0));
 	bind_static_method(Color, from_ok_hsl, sarray("h", "s", "l", "alpha"), varray(1.0));

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -231,6 +231,12 @@
 				Returns the name of a color with the given index. You can get the index from [method find_named_color] or iteratively from [method get_named_color_count].
 			</description>
 		</method>
+		<method name="get_named_colors" qualifiers="static">
+			<return type="Dictionary" />
+			<description>
+				Returns all of the available color constants, as a [Dictionary]. Each key is an uppercase name corresponding to the color.
+			</description>
+		</method>
 		<method name="hex" qualifiers="static">
 			<return type="Color" />
 			<param index="0" name="hex" type="int" />


### PR DESCRIPTION
See also #64830.

This PR implements the static method `Color.get_named_colors()`. It returns a **Dictionary**, where each key is a name corresponds to a **Color** from the exposed engine API.

The idea is that using the **Dictionary** over `find_named_color()`, `get_named_color_count()`, `get_named_color_name()`, `get_named_color` is favourable. 
The advantage is that it is much more accessible, because unlike them, no **integer** index is required or returned. It also opens up the door for more interesting manipulation. It needs to be said, however, that not everything can be replicated. Namely, `find_named_color()` does some string manipulation to be case-insensitive and support spaces _(the `Color(String)` constructor does the same thing)_... 
###### However, `find_named_color()` also returns a numerical index! And `Color.from_string()` is the better equivalent, just returning the Color directly! Bah... Look at #64830.

If an user, for some reason, needs an integer index, it's worth reminding that Dictionaries remember the insertion order. Therefore:
```GDScript
	var named_colors = Color.get_named_colors()
	
	# Color.get_named_color_count() -> int
	var count = named_colors.size()
	
	# Color.get_named_color_name(1) -> String
	var color_name = named_colors.keys()[1]
	
	# Color.get_named_color(1) -> Color
	var colour_from_idx = named_colors[color_name]
```