### PR TITLE
Fix `TileMap` collision shapes debug draw

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1297,7 +1297,7 @@ void TileMap::_rendering_draw_quadrant_debug(TileMapQuadrant *p_quadrant) {
 		return;
 	}
 
-	// Draw a placeholder for scenes needing one.
+	// Draw a placeholder for tiles needing one.
 	RenderingServer *rs = RenderingServer::get_singleton();
 	Vector2 quadrant_pos = map_to_local(p_quadrant->coords * get_effective_quadrant_size(p_quadrant->layer));
 	for (const Vector2i &E_cell : p_quadrant->cells) {
@@ -1330,9 +1330,9 @@ void TileMap::_rendering_draw_quadrant_debug(TileMapQuadrant *p_quadrant) {
 							0.8);
 
 					// Draw a placeholder tile.
-					Transform2D xform;
-					xform.set_origin(map_to_local(E_cell) - quadrant_pos);
-					rs->canvas_item_add_set_transform(p_quadrant->debug_canvas_item, xform);
+					Transform2D cell_to_quadrant;
+					cell_to_quadrant.set_origin(map_to_local(E_cell) - quadrant_pos);
+					rs->canvas_item_add_set_transform(p_quadrant->debug_canvas_item, cell_to_quadrant);
 					rs->canvas_item_add_circle(p_quadrant->debug_canvas_item, Vector2(), MIN(tile_set->get_tile_size().x, tile_set->get_tile_size().y) / 4.0, color);
 				}
 			}
@@ -1632,13 +1632,13 @@ void TileMap::_physics_draw_quadrant_debug(TileMapQuadrant *p_quadrant) {
 	color.push_back(debug_collision_color);
 
 	Vector2 quadrant_pos = map_to_local(p_quadrant->coords * get_effective_quadrant_size(p_quadrant->layer));
-	Transform2D qudrant_xform;
-	qudrant_xform.set_origin(quadrant_pos);
-	Transform2D global_transform_inv = (get_global_transform() * qudrant_xform).affine_inverse();
+	Transform2D quadrant_to_local;
+	quadrant_to_local.set_origin(quadrant_pos);
+	Transform2D global_to_quadrant = (get_global_transform() * quadrant_to_local).affine_inverse();
 
 	for (RID body : p_quadrant->bodies) {
-		Transform2D xform = Transform2D(ps->body_get_state(body, PhysicsServer2D::BODY_STATE_TRANSFORM)) * global_transform_inv;
-		rs->canvas_item_add_set_transform(p_quadrant->debug_canvas_item, xform);
+		Transform2D body_to_quadrant = global_to_quadrant * Transform2D(ps->body_get_state(body, PhysicsServer2D::BODY_STATE_TRANSFORM));
+		rs->canvas_item_add_set_transform(p_quadrant->debug_canvas_item, body_to_quadrant);
 		for (int shape_index = 0; shape_index < ps->body_get_shape_count(body); shape_index++) {
 			const RID &shape = ps->body_get_shape(body, shape_index);
 			PhysicsServer2D::ShapeType type = ps->shape_get_type(shape);
@@ -1815,9 +1815,9 @@ void TileMap::_navigation_draw_quadrant_debug(TileMapQuadrant *p_quadrant) {
 					tile_data = atlas_source->get_tile_data(c.get_atlas_coords(), c.alternative_tile);
 				}
 
-				Transform2D xform;
-				xform.set_origin(map_to_local(E_cell) - quadrant_pos);
-				rs->canvas_item_add_set_transform(p_quadrant->debug_canvas_item, xform);
+				Transform2D cell_to_quadrant;
+				cell_to_quadrant.set_origin(map_to_local(E_cell) - quadrant_pos);
+				rs->canvas_item_add_set_transform(p_quadrant->debug_canvas_item, cell_to_quadrant);
 
 				for (int layer_index = 0; layer_index < tile_set->get_navigation_layers_count(); layer_index++) {
 					Ref<NavigationPolygon> navpoly = tile_data->get_navigation_polygon(layer_index);
@@ -1956,9 +1956,9 @@ void TileMap::_scenes_draw_quadrant_debug(TileMapQuadrant *p_quadrant) {
 							0.8);
 
 					// Draw a placeholder tile.
-					Transform2D xform;
-					xform.set_origin(map_to_local(E_cell) - quadrant_pos);
-					rs->canvas_item_add_set_transform(p_quadrant->debug_canvas_item, xform);
+					Transform2D cell_to_quadrant;
+					cell_to_quadrant.set_origin(map_to_local(E_cell) - quadrant_pos);
+					rs->canvas_item_add_set_transform(p_quadrant->debug_canvas_item, cell_to_quadrant);
 					rs->canvas_item_add_circle(p_quadrant->debug_canvas_item, Vector2(), MIN(tile_set->get_tile_size().x, tile_set->get_tile_size().y) / 4.0, color);
 				}
 			}


### PR DESCRIPTION
The transform applied when drawing collision shapes for the quadrant's physics body was composed incorrectly. It was `body_to_global * global_to_quadrant` (in a right to left sense) which doesn't make much sense. Now it's `global_to_quadrant * body_to_global` which is equivalent to `body_to_quadrant`.

Fixes #67601, as it was only the debug draw which was incorrect:
|Before:|This PR|
|-|-|
|![CAiuxTmCYz](https://user-images.githubusercontent.com/9283098/197344563-85c83da3-fa35-4c6a-93e4-195d60cc2cca.gif)|![jApjnznwXd](https://user-images.githubusercontent.com/9283098/197344671-8088be08-c1c8-429e-831c-7ffaa6f3168b.gif)|