### PR TITLE
Use `.generated` suffix for generated C# code

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotPluginsInitializerGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotPluginsInitializerGenerator.cs
@@ -56,7 +56,7 @@ namespace GodotPlugins.Game
 }
 ";
 
-            context.AddSource("GodotPlugins.Game_Generated",
+            context.AddSource("GodotPlugins.Game.generated",
                 SourceText.From(source, Encoding.UTF8));
         }
     }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -87,7 +87,7 @@ namespace Godot.SourceGenerators
             bool isInnerClass = symbol.ContainingType != null;
 
             string uniqueHint = symbol.FullQualifiedName().SanitizeQualifiedNameForUniqueHint()
-                                + "_ScriptMethods_Generated";
+                                + "_ScriptMethods.generated";
 
             var source = new StringBuilder();
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPathAttributeGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPathAttributeGenerator.cs
@@ -96,8 +96,8 @@ namespace Godot.SourceGenerators
                 string.Empty;
             bool hasNamespace = classNs.Length != 0;
 
-            var uniqueHint = symbol.FullQualifiedName().SanitizeQualifiedNameForUniqueHint()
-                             + "_ScriptPath_Generated";
+            string uniqueHint = symbol.FullQualifiedName().SanitizeQualifiedNameForUniqueHint()
+                             + "_ScriptPath.generated";
 
             var source = new StringBuilder();
 
@@ -126,7 +126,7 @@ namespace Godot.SourceGenerators
                 source.Append("\n}\n");
             }
 
-            context.AddSource(uniqueHint.ToString(), SourceText.From(source.ToString(), Encoding.UTF8));
+            context.AddSource(uniqueHint, SourceText.From(source.ToString(), Encoding.UTF8));
         }
 
         private static void AddScriptTypesAssemblyAttr(GeneratorExecutionContext context,
@@ -157,7 +157,7 @@ namespace Godot.SourceGenerators
 
             sourceBuilder.Append("})]\n");
 
-            context.AddSource("AssemblyScriptTypes_Generated",
+            context.AddSource("AssemblyScriptTypes.generated",
                 SourceText.From(sourceBuilder.ToString(), Encoding.UTF8));
         }
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -73,7 +73,7 @@ namespace Godot.SourceGenerators
             bool isInnerClass = symbol.ContainingType != null;
 
             string uniqueHint = symbol.FullQualifiedName().SanitizeQualifiedNameForUniqueHint()
-                                + "_ScriptProperties_Generated";
+                                + "_ScriptProperties.generated";
 
             var source = new StringBuilder();
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
@@ -73,7 +73,7 @@ namespace Godot.SourceGenerators
             bool isInnerClass = symbol.ContainingType != null;
 
             string uniqueHint = symbol.FullQualifiedName().SanitizeQualifiedNameForUniqueHint()
-                                + "_ScriptPropertyDefVal_Generated";
+                                + "_ScriptPropertyDefVal.generated";
 
             var source = new StringBuilder();
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSerializationGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSerializationGenerator.cs
@@ -73,7 +73,7 @@ namespace Godot.SourceGenerators
             bool isInnerClass = symbol.ContainingType != null;
 
             string uniqueHint = symbol.FullQualifiedName().SanitizeQualifiedNameForUniqueHint()
-                                + "_ScriptSerialization_Generated";
+                                + "_ScriptSerialization.generated";
 
             var source = new StringBuilder();
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -82,7 +82,7 @@ namespace Godot.SourceGenerators
             bool isInnerClass = symbol.ContainingType != null;
 
             string uniqueHint = symbol.FullQualifiedName().SanitizeQualifiedNameForUniqueHint()
-                                + "_ScriptSignals_Generated";
+                                + "_ScriptSignals.generated";
 
             var source = new StringBuilder();
 


### PR DESCRIPTION
Use the `.generated` suffix instead of `_Generated` so .NET marks C# file generated by Godot source generators as generated code.

- Fixes https://github.com/godotengine/godot/issues/67758