### PR TITLE
Make script annotations be placed before `class_name` and `extends`

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -540,43 +540,28 @@ void GDScriptParser::parse_program() {
 	head = alloc_node<ClassNode>();
 	head->fqcn = script_path;
 	current_class = head;
+	bool can_have_class_or_extends = true;
 
-	// If we happen to parse an annotation before extends or class_name keywords, track it.
-	// @tool is allowed, but others should fail.
-	AnnotationNode *premature_annotation = nullptr;
-
-	if (match(GDScriptTokenizer::Token::ANNOTATION)) {
-		// Check for @tool, script-level, or standalone annotation.
+	while (match(GDScriptTokenizer::Token::ANNOTATION)) {
 		AnnotationNode *annotation = parse_annotation(AnnotationInfo::SCRIPT | AnnotationInfo::STANDALONE | AnnotationInfo::CLASS_LEVEL);
 		if (annotation != nullptr) {
-			if (annotation->name == SNAME("@tool")) {
-				// TODO: don't allow @tool anywhere else. (Should all script annotations be the first thing?).
-				_is_tool = true;
-				if (previous.type != GDScriptTokenizer::Token::NEWLINE) {
-					push_error(R"(Expected newline after "@tool" annotation.)");
-				}
-				// @tool annotation has no specific target.
-				annotation->apply(this, nullptr);
-			} else if (annotation->applies_to(AnnotationInfo::SCRIPT | AnnotationInfo::STANDALONE)) {
-				premature_annotation = annotation;
-				if (previous.type != GDScriptTokenizer::Token::NEWLINE) {
-					push_error(R"(Expected newline after a standalone annotation.)");
-				}
+			if (annotation->applies_to(AnnotationInfo::SCRIPT)) {
 				annotation->apply(this, head);
 			} else {
-				premature_annotation = annotation;
 				annotation_stack.push_back(annotation);
+				// This annotation must appear after script-level annotations
+				// and class_name/extends (ex: could be @onready or @export),
+				// so we stop looking for script-level stuff.
+				can_have_class_or_extends = false;
+				break;
 			}
 		}
 	}
 
-	for (bool should_break = false; !should_break;) {
+	while (can_have_class_or_extends) {
 		// Order here doesn't matter, but there should be only one of each at most.
 		switch (current.type) {
 			case GDScriptTokenizer::Token::CLASS_NAME:
-				if (premature_annotation != nullptr) {
-					push_error(R"("class_name" should be used before annotations (except @tool).)");
-				}
 				advance();
 				if (head->identifier != nullptr) {
 					push_error(R"("class_name" can only be used once.)");
@@ -585,9 +570,6 @@ void GDScriptParser::parse_program() {
 				}
 				break;
 			case GDScriptTokenizer::Token::EXTENDS:
-				if (premature_annotation != nullptr) {
-					push_error(R"("extends" should be used before annotations (except @tool).)");
-				}
 				advance();
 				if (head->extends_used) {
 					push_error(R"("extends" can only be used once.)");
@@ -597,27 +579,13 @@ void GDScriptParser::parse_program() {
 				}
 				break;
 			default:
-				should_break = true;
+				// No tokens are allowed between script annotations and class/extends.
+				can_have_class_or_extends = false;
 				break;
 		}
 
 		if (panic_mode) {
 			synchronize();
-		}
-	}
-
-	if (match(GDScriptTokenizer::Token::ANNOTATION)) {
-		// Check for a script-level, or standalone annotation.
-		AnnotationNode *annotation = parse_annotation(AnnotationInfo::SCRIPT | AnnotationInfo::STANDALONE | AnnotationInfo::CLASS_LEVEL);
-		if (annotation != nullptr) {
-			if (annotation->applies_to(AnnotationInfo::SCRIPT | AnnotationInfo::STANDALONE)) {
-				if (previous.type != GDScriptTokenizer::Token::NEWLINE) {
-					push_error(R"(Expected newline after a standalone annotation.)");
-				}
-				annotation->apply(this, head);
-			} else {
-				annotation_stack.push_back(annotation);
-			}
 		}
 	}
 

--- a/modules/gdscript/tests/scripts/parser/errors/class_name_after_annotation.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/class_name_after_annotation.gd
@@ -1,6 +1,6 @@
-# Error here. `class_name` should be used *before* annotations, not after (except @tool).
-@icon("res://path/to/optional/icon.svg")
+# Error here. Annotations should be used before `class_name`, not after.
 class_name HelloWorld
+@icon("res://path/to/optional/icon.svg")
 
 func test():
     pass

--- a/modules/gdscript/tests/scripts/parser/errors/class_name_after_annotation.out
+++ b/modules/gdscript/tests/scripts/parser/errors/class_name_after_annotation.out
@@ -1,2 +1,2 @@
 GDTEST_PARSER_ERROR
-"class_name" should be used before annotations (except @tool).
+Annotation "@icon" is not allowed in this level.

--- a/modules/gdscript/tests/scripts/parser/features/class_name.gd
+++ b/modules/gdscript/tests/scripts/parser/features/class_name.gd
@@ -1,5 +1,5 @@
-class_name HelloWorld
 @icon("res://path/to/optional/icon.svg")
+class_name HelloWorld
 
 func test():
 	pass


### PR DESCRIPTION
[Before](https://github.com/godotengine/godot/blob/4546986d21e862cd11d9d541f6e8347483fd7f69/modules/gdscript/gdscript_parser.cpp#L543) (current master):

```gdscript
@tool
class_name MyClass extends Node
@icon("res://icon.png")

@onready var x = $X

@rpc
func my_func():
	pass
```

Almost all annotations come before the thing they are annotating. The only exception is `@icon`. This PR proposes to change this, so that the correct way to write the above now looks like this:

[After](https://github.com/aaronfranke/godot/blob/script-annotations/modules/gdscript/gdscript_parser.cpp#L540) (this PR):
```gdscript
@tool
@icon("res://icon.png")
class_name MyClass extends Node

@onready var x = $X

@rpc
func my_func():
	pass
```

This PR also fixes a limitation where only `@tool` and one other annotation was allowed on scripts, because it was just two `if` statements instead of a `while` loop. This is the reason that I looked into this code, later I want to add an `@abstract` annotation but with the current code it's not possible to have both `@icon` and `@abstract`.