### PR TITLE
Make InputEventAction as_text() return the text of the first valid event for the action.

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1408,7 +1408,18 @@ bool InputEventAction::action_match(const Ref<InputEvent> &p_event, bool p_exact
 }
 
 String InputEventAction::as_text() const {
-	return vformat(RTR("Input Action %s was %s"), action, pressed ? "pressed" : "released");
+	const List<Ref<InputEvent>> *events = InputMap::get_singleton()->action_get_events(action);
+	if (!events) {
+		return String();
+	}
+
+	for (const Ref<InputEvent> &E : *events) {
+		if (E.is_valid()) {
+			return E->as_text();
+		}
+	}
+
+	return String();
 }
 
 String InputEventAction::to_string() {


### PR DESCRIPTION
Fixes #67715

![image](https://user-images.githubusercontent.com/41730826/197379172-bbbbe16d-7af5-4f9c-bd1e-c77130ad42b7.png)

Not sure if `to_string()` should get the same treatment.