### PR TITLE
Add alignment options to flow container

### DIFF
--- a/doc/classes/FlowContainer.xml
+++ b/doc/classes/FlowContainer.xml
@@ -18,11 +18,25 @@
 		</method>
 	</methods>
 	<members>
+		<member name="alignment" type="int" setter="set_alignment" getter="get_alignment" enum="FlowContainer.AlignmentMode" default="0">
+			The alignment of the container's children (must be one of [constant ALIGNMENT_BEGIN], [constant ALIGNMENT_CENTER], or [constant ALIGNMENT_END]).
+		</member>
 		<member name="vertical" type="bool" setter="set_vertical" getter="is_vertical" default="false">
 			If [code]true[/code], the [FlowContainer] will arrange its children vertically, rather than horizontally.
 			Can't be changed when using [HFlowContainer] and [VFlowContainer].
 		</member>
 	</members>
+	<constants>
+		<constant name="ALIGNMENT_BEGIN" value="0" enum="AlignmentMode">
+			The child controls will be arranged at the beginning of the container, i.e. top if orientation is vertical, left if orientation is horizontal (right for RTL layout).
+		</constant>
+		<constant name="ALIGNMENT_CENTER" value="1" enum="AlignmentMode">
+			The child controls will be centered in the container.
+		</constant>
+		<constant name="ALIGNMENT_END" value="2" enum="AlignmentMode">
+			The child controls will be arranged at the end of the container, i.e. bottom if orientation is vertical, right if orientation is horizontal (left for RTL layout).
+		</constant>
+	</constants>
 	<theme_items>
 		<theme_item name="h_separation" data_type="constant" type="int" default="4">
 			The horizontal separation of children nodes.

--- a/scene/gui/flow_container.h
+++ b/scene/gui/flow_container.h
@@ -36,11 +36,19 @@
 class FlowContainer : public Container {
 	GDCLASS(FlowContainer, Container);
 
+public:
+	enum AlignmentMode {
+		ALIGNMENT_BEGIN,
+		ALIGNMENT_CENTER,
+		ALIGNMENT_END
+	};
+
 private:
 	int cached_size = 0;
 	int cached_line_count = 0;
 
 	bool vertical = false;
+	AlignmentMode alignment = ALIGNMENT_BEGIN;
 
 	struct ThemeCache {
 		int h_separation = 0;
@@ -60,6 +68,9 @@ protected:
 
 public:
 	int get_line_count() const;
+
+	void set_alignment(AlignmentMode p_alignment);
+	AlignmentMode get_alignment() const;
 
 	void set_vertical(bool p_vertical);
 	bool is_vertical() const;
@@ -87,5 +98,7 @@ public:
 	VFlowContainer() :
 			FlowContainer(true) { is_fixed = true; }
 };
+
+VARIANT_ENUM_CAST(FlowContainer::AlignmentMode);
 
 #endif // FLOW_CONTAINER_H


### PR DESCRIPTION
This PR adds an option to modify the alignment of flow containers. I have used BoxContainer as a reference for this implementation. Here is a video showcasing the results:
https://www.youtube.com/watch?v=SGOTBxSrCOw
It would solve this proposal: https://github.com/godotengine/godot-proposals/issues/4453
If this gets approved I would be glad to backport it to Godot 3.x

*Bugsquad edit:*
- Closes https://github.com/godotengine/godot-proposals/issues/4453