### PR TITLE
Refactor `mouse_entered` and `mouse_exited` signals

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1094,15 +1094,15 @@
 		</signal>
 		<signal name="mouse_entered">
 			<description>
-				Emitted when the mouse enters the control's [code]Rect[/code] area, provided its [member mouse_filter] lets the event reach it.
-				[b]Note:[/b] [signal mouse_entered] will not be emitted if the mouse enters a child [Control] node before entering the parent's [code]Rect[/code] area, at least until the mouse is moved to reach the parent's [code]Rect[/code] area.
+				Emitted when the mouse cursor enters the control's visible area, that is not occluded behind other Controls or Windows, provided its [member mouse_filter] lets the event reach it and regardless if it's currently focused or not.
+				[b]Note:[/b] [member CanvasItem.z_index] doesn't affect, which Control receives the signal.
 			</description>
 		</signal>
 		<signal name="mouse_exited">
 			<description>
-				Emitted when the mouse leaves the control's [code]Rect[/code] area, provided its [member mouse_filter] lets the event reach it.
-				[b]Note:[/b] [signal mouse_exited] will be emitted if the mouse enters a child [Control] node, even if the mouse cursor is still inside the parent's [code]Rect[/code] area.
-				If you want to check whether the mouse truly left the area, ignoring any top nodes, you can use code like this:
+				Emitted when the mouse cursor leaves the control's visible area, that is not occluded behind other Controls or Windows, provided its [member mouse_filter] lets the event reach it and regardless if it's currently focused or not.
+				[b]Note:[/b] [member CanvasItem.z_index] doesn't affect, which Control receives the signal.
+				[b]Note:[/b] If you want to check whether the mouse truly left the area, ignoring any top nodes, you can use code like this:
 				[codeblock]
 				func _on_mouse_exited():
 				    if not Rect2(Vector2(), size).has_point(get_local_mouse_position()):
@@ -1140,10 +1140,12 @@
 			Sent when the node changes size. Use [member size] to get the new size.
 		</constant>
 		<constant name="NOTIFICATION_MOUSE_ENTER" value="41">
-			Sent when the mouse pointer enters the node.
+			Sent when the mouse cursor enters the control's visible area, that is not occluded behind other Controls or Windows, provided its [member mouse_filter] lets the event reach it and regardless if it's currently focused or not.
+			[b]Note:[/b] [member CanvasItem.z_index] doesn't affect, which Control receives the notification.
 		</constant>
 		<constant name="NOTIFICATION_MOUSE_EXIT" value="42">
-			Sent when the mouse pointer exits the node.
+			Sent when the mouse cursor leaves the control's visible area, that is not occluded behind other Controls or Windows, provided its [member mouse_filter] lets the event reach it and regardless if it's currently focused or not.
+			[b]Note:[/b] [member CanvasItem.z_index] doesn't affect, which Control receives the notification.
 		</constant>
 		<constant name="NOTIFICATION_FOCUS_ENTER" value="43">
 			Sent when the node grabs focus.

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -1052,10 +1052,10 @@
 			Notification received from the OS when the screen's DPI has been changed. Only implemented on macOS.
 		</constant>
 		<constant name="NOTIFICATION_VP_MOUSE_ENTER" value="1010">
-			Notification received when the mouse enters the viewport.
+			Notification received when the mouse cursor enters the [Viewport]'s visible area, that is not occluded behind other [Control]s or [Window]s, provided its [member Viewport.gui_disable_input] is [code]false[/code] and regardless if it's currently focused or not.
 		</constant>
 		<constant name="NOTIFICATION_VP_MOUSE_EXIT" value="1011">
-			Notification received when the mouse leaves the viewport.
+			Notification received when the mouse cursor leaves the [Viewport]'s visible area, that is not occluded behind other [Control]s or [Window]s, provided its [member Viewport.gui_disable_input] is [code]false[/code] and regardless if it's currently focused or not.
 		</constant>
 		<constant name="NOTIFICATION_OS_MEMORY_WARNING" value="2009">
 			Notification received from the OS when the application is exceeding its allocated memory.

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -719,12 +719,12 @@
 		</signal>
 		<signal name="mouse_entered">
 			<description>
-				Emitted when the mouse cursor enters the [Window]'s area, regardless if it's currently focused or not.
+				Emitted when the mouse cursor enters the [Window]'s visible area, that is not occluded behind other [Control]s or windows, provided its [member Viewport.gui_disable_input] is [code]false[/code] and regardless if it's currently focused or not.
 			</description>
 		</signal>
 		<signal name="mouse_exited">
 			<description>
-				Emitted when the mouse cursor exits the [Window]'s area (including when it's hovered over another window on top of this one).
+				Emitted when the mouse cursor leaves the [Window]'s visible area, that is not occluded behind other [Control]s or windows, provided its [member Viewport.gui_disable_input] is [code]false[/code] and regardless if it's currently focused or not.
 			</description>
 		</signal>
 		<signal name="theme_changed">

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -147,14 +147,6 @@ void SubViewportContainer::_notification(int p_what) {
 			}
 		} break;
 
-		case NOTIFICATION_MOUSE_ENTER: {
-			_notify_viewports(NOTIFICATION_VP_MOUSE_ENTER);
-		} break;
-
-		case NOTIFICATION_MOUSE_EXIT: {
-			_notify_viewports(NOTIFICATION_VP_MOUSE_EXIT);
-		} break;
-
 		case NOTIFICATION_FOCUS_ENTER: {
 			// If focused, send InputEvent to the SubViewport before the Gui-Input stage.
 			set_process_input(true);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -346,8 +346,6 @@ private:
 	Ref<Texture2D> vrs_texture;
 
 	struct GUI {
-		// info used when this is a window
-
 		bool forced_mouse_focus = false; //used for menu buttons
 		bool mouse_in_viewport = true;
 		bool key_event_accepted = false;
@@ -358,6 +356,8 @@ private:
 		BitField<MouseButtonMask> mouse_focus_mask;
 		Control *key_focus = nullptr;
 		Control *mouse_over = nullptr;
+		Window *subwindow_over = nullptr; // mouse_over and subwindow_over are mutually exclusive. At all times at least one of them is nullptr.
+		Window *windowmanager_window_over = nullptr; // Only used in root Viewport.
 		Control *drag_mouse_over = nullptr;
 		Vector2 drag_mouse_over_pos;
 		Control *tooltip_control = nullptr;
@@ -466,6 +466,9 @@ private:
 	bool _sub_windows_forward_input(const Ref<InputEvent> &p_event);
 	SubWindowResize _sub_window_get_resize_margin(Window *p_subwindow, const Point2 &p_point);
 
+	void _update_mouse_over();
+	void _update_mouse_over(Vector2 p_pos);
+
 	virtual bool _can_consume_input_events() const { return true; }
 	uint64_t event_count = 0;
 
@@ -477,6 +480,8 @@ protected:
 	Size2i _get_size() const;
 	Size2i _get_size_2d_override() const;
 	bool _is_size_allocated() const;
+
+	void _mouse_leave_viewport();
 
 	void _notification(int p_what);
 	void _process_picking();
@@ -665,6 +670,8 @@ public:
 	virtual Transform2D get_screen_transform_internal(bool p_absolute_position = false) const;
 	virtual Transform2D get_popup_base_transform() const { return Transform2D(); }
 	virtual bool is_directly_attached_to_screen() const { return false; };
+	virtual bool is_attached_in_viewport() const { return false; };
+	virtual bool is_sub_viewport() const { return false; };
 
 #ifndef _3D_DISABLED
 	bool use_xr = false;
@@ -797,6 +804,8 @@ public:
 	virtual Transform2D get_screen_transform_internal(bool p_absolute_position = false) const override;
 	virtual Transform2D get_popup_base_transform() const override;
 	virtual bool is_directly_attached_to_screen() const override;
+	virtual bool is_attached_in_viewport() const override;
+	virtual bool is_sub_viewport() const override { return true; };
 
 	void _validate_property(PropertyInfo &p_property) const;
 	SubViewport();

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -404,6 +404,7 @@ public:
 	virtual Transform2D get_screen_transform_internal(bool p_absolute_position = false) const override;
 	virtual Transform2D get_popup_base_transform() const override;
 	virtual bool is_directly_attached_to_screen() const override;
+	virtual bool is_attached_in_viewport() const override;
 
 	Rect2i get_parent_rect() const;
 	virtual DisplayServer::WindowID get_window_id() const override;


### PR DESCRIPTION
fix variant of #20881 where Controls are in different Viewports
fix #66293
fix no longer #57349 (that is already fixed for the case of a single Viewport)
prerequisite for #67531
prerequisite for #77781
addresses #48634 after #77933
related to #54565 (maybe supersedes it)
done: don't merge before #67903 (fix display-server differences between Windows and linuxbsd)

The current implementation for signals `mouse_entered` and `mouse_exited` have shortcomings that relate to focused windows and pressed mouse buttons. For example a `Control` can be hovered by mouse, even if it is occluded by an embedded `Window`.

This patch changes the behavior, so that `Control` and `Viewports` send their mouse-enter/exit-notifications based solely on mouse position, visible area and input restrictions and not on which window has focus or which mouse buttons are pressed. This implicitly also changes when the `mouse_entered` and `mouse_exited` signals are sent.

Rewriting a core functionality like `mouse_entered` and `mouse_exited` should be tested thoroughly. While I tested it in lots of situations and had a look at the locations where it is used in the code base, it can be, that I have missed something.

So far, tests on the following platforms were successful:
- linuxbsd
- Windows
- Web (Firefox, Chromium, Edge)

Other platforms:
- macOS: not yet tested
- Android / iOS: Not sure, if the concept of `mouse_entered` and `mouse_exited` makes sense in this context.
- Android: Signals do not trigger with touch and drag

The concept for this implementation is:
- When a mouse-event is sent from the DisplayServer to a Window, it first recursively determines mouse-over states for all Viewports and sends mouse-enter/exit notifications and signals.
- Afterwards the event handling happens just as before, without the enter/exit-notifications.
- Additional adjustments to how mouse-over-state is dropped were necessary.

MRP: [BugVisualMouseNotifications.zip](https://github.com/godotengine/godot/files/9865023/BugVisualMouseNotifications.zip) (updated 2022-10-26)

This functionality can not be implemented as a part of `Viewport::_gui_input_event`, because of its interplay with Windows and because `Viewport::_gui_input_event` is based on input and not on visibility.

https://user-images.githubusercontent.com/6299227/197390115-33c8b18d-69ff-4d87-a293-8378fe099db9.mp4

Updated 2022-11-13: Fix location of `sw->_update_mouse_over` call.
Updated 2022-11-15: Fix merge conflict with #68019
Updated 2022-11-19: Fix location of `sw->_update_mouse_over` call.
Updated 2023-01-06: Fix merge conflict with #69972
Updated 2023-01-27: Fix merge conflict with #66692
Updated 2023-02-18: Fix merge conflict with #72764
Updated 2023-06-07: Fix merge conflict with #77933
Updated 2023-06-29: Made necessary adjustments for Gui in 3D Demo
Updated 2023-07-07: Fix merge conflict with #78078
Updated 2023-07-27: Fix merge conflict with #79248