### PR TITLE
Uncomment drag forwarding in CreateDialog

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -752,8 +752,7 @@ CreateDialog::CreateDialog() {
 	favorites->connect("cell_selected", callable_mp(this, &CreateDialog::_favorite_selected));
 	favorites->connect("item_activated", callable_mp(this, &CreateDialog::_favorite_activated));
 	favorites->add_theme_constant_override("draw_guides", 1);
-	// Cannot forward drag data to a non control, must be fixed.
-	//favorites->set_drag_forwarding(this);
+	favorites->set_drag_forwarding(this);
 	fav_vb->add_margin_child(TTR("Favorites:"), favorites, true);
 
 	VBoxContainer *rec_vb = memnew(VBoxContainer);


### PR DESCRIPTION
Part of #67190

The comment was added when converting dialogs to windows, but it's wrong. Drag forwarding takes any Object. Uncommenting it restores a completely functional drag and drop:
![godot windows editor dev x86_64_hdte47usS6](https://user-images.githubusercontent.com/2223172/197396004-a4123368-fdff-4a9a-ae94-2a4203a7cbd0.gif)

It's technically a regression, but no one seem to have reported it.