### PR TITLE
Added support for 16-bit BMP files

### DIFF
--- a/modules/bmp/image_loader_bmp.h
+++ b/modules/bmp/image_loader_bmp.h
@@ -74,6 +74,15 @@ protected:
 			uint32_t bmp_colors_used = 0;
 			uint32_t bmp_important_colors = 0;
 		} bmp_info_header;
+
+		struct bmp_bitfield_s {
+			uint16_t red_mask = 0x7C00;
+			uint16_t green_mask = 0x03E0;
+			uint16_t blue_mask = 0x001F;
+			uint16_t red_mask_width = 5;
+			uint16_t green_mask_width = 5;
+			uint16_t blue_mask_width = 5;
+		} bmp_bitfield;
 	};
 
 	static Error convert_to_image(Ref<Image> p_image,


### PR DESCRIPTION
I request more people to test this.
Testing with 16-bit bitmap files outside project will be best suited for this.

Added support for 16-bit BMP files.
If compression flag is BI_BITFIELDS, it should support RGB565, RGB555 or any other RGB mask. Defaults to 555 if no BI_BITFIELDS,

**Usecase:**
I needed them for my own project where I need to show a Windows 8/10/11 user's profile picture but unfortunately the only copy available was a 16-bit 5-6-5 bmp file in Temp folder(`OS.get_environment("LOCALAPPDATA") + "\\Temp\\" + username + ".bmp"`).

**Sample:**
I made a tiny sample Godot project to show different 16-bit bmp files beside their png version(tooltips have filename).
[BMP_Test.zip](https://github.com/godotengine/godot/files/9846758/BMP_Test.zip) (I tried deleting .godot and .import so there might be UUID warnings).

Source: http://entropymine.com/jason/bmpsuite/bmpsuite/html/bmpsuite.html.

**Screenshot:**
![image](https://user-images.githubusercontent.com/11459028/197396200-6c277453-7185-4fb1-bea2-09957a143e6e.png)

