### PR TITLE
Fix multiple issues with region editor

### DIFF
--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -86,6 +86,8 @@ class TextureRegionEditor : public AcceptDialog {
 	Ref<StyleBoxTexture> obj_styleBox;
 	Ref<AtlasTexture> atlas_tex;
 
+	Ref<CanvasTexture> preview_tex;
+
 	Rect2 rect;
 	Rect2 rect_prev;
 	float prev_margin = 0.0f;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -680,6 +680,7 @@ void Sprite3D::set_region_enabled(bool p_region) {
 
 	region = p_region;
 	_queue_redraw();
+	notify_property_list_changed();
 }
 
 bool Sprite3D::is_region_enabled() const {
@@ -780,6 +781,10 @@ void Sprite3D::_validate_property(PropertyInfo &p_property) const {
 
 	if (p_property.name == "frame_coords") {
 		p_property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
+	}
+
+	if (!region && (p_property.name == "region_rect")) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 }
 


### PR DESCRIPTION

Fixes https://github.com/godotengine/godot/issues/67288, fixes https://github.com/godotengine/godot/issues/65069, and the Sprite3D Edit Region button being inconsistent with the Sprite2D Edit Region button.

This PR uses a CanvasTexture for the preview so that the texture filter can be changed independently from the region editor (thanks @clayjohn for the suggestion :). The filter is determined based on what is being edited:
- For Sprite2D and NinePatchRect, the filter is set to match the node using `get_texture_filter_in_tree`
- If `get_texture_filter_in_tree` reaches the base of the tree, the filter is determined from the current default canvas texture filter setting. This is translated from Viewport::DefaultCanvasTextureFilter.
- For Sprite3D, the texture filter mode is set to match the node. It's translated from the StandardMaterial3D::TextureFilter to the corresponding CanvasItem::TextureFilter value.
- For AtlasTexture and StyleBoxTexture, nearest neighbor with mipmaps is used, since they are resources and do not have a filter setting.

Please review: What is the preferred style for casting enums like these? They aren't exactly 1 to 1. A numerical cast would be more concise but fragile if the enums are updated in the future for whatever reason (unlikely?). 

While testing I ran into [#65069](https://github.com/godotengine/godot/issues/65069) which was due to the references not being cleared correctly when editing resources. I moved the reference clearing logic to be unconditional after signals are disconnected and before new references are obtained. I also added in a fix to make the Sprite3D edit region button automatically hide like it does with Sprite2D.

Tested with both the forward+ and gl3 renderer, seems to work correctly across all the affected nodes/resources and filter modes.

~~One known issue, the filter detection does not work if all nodes in the tree are set to Inherit. It does work when you change any of the parent nodes in the tree to use a different filter. This seems to be a separate bug in `get_texture_filter_in_tree` not respecting the default filter setting, which I'll open a separate issue for.~~
EDIT: The issue was that DEFAULT_CANVAS_TEXTURE_FILTER on the editor UI nodes will always be linear (seems to be the initialized default). The default texture filter setting only applies to the scene root being edited, so I take the filter from there.