### PR TITLE
Fix unwanted popup closing by mouse-move while holding mouse-button down

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -3414,7 +3414,7 @@ bool DisplayServerX11::mouse_process_popups() {
 			XWindowAttributes root_attrs;
 			XGetWindowAttributes(x11_display, root, &root_attrs);
 			Vector2i pos = Vector2i(root_attrs.x + root_x, root_attrs.y + root_y);
-			if ((pos != last_mouse_monitor_pos) || (mask != last_mouse_monitor_mask)) {
+			if (mask != last_mouse_monitor_mask) {
 				if (((mask & Button1Mask) || (mask & Button2Mask) || (mask & Button3Mask) || (mask & Button4Mask) || (mask & Button5Mask))) {
 					List<WindowID>::Element *C = nullptr;
 					List<WindowID>::Element *E = popup_list.back();
@@ -3440,7 +3440,6 @@ bool DisplayServerX11::mouse_process_popups() {
 				}
 			}
 			last_mouse_monitor_mask = mask;
-			last_mouse_monitor_pos = pos;
 		}
 	}
 	return closed;

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -169,7 +169,6 @@ class DisplayServerX11 : public DisplayServer {
 	HashMap<WindowID, WindowData> windows;
 
 	unsigned int last_mouse_monitor_mask = 0;
-	Vector2i last_mouse_monitor_pos;
 	uint64_t time_since_popup = 0;
 
 	List<WindowID> popup_list;


### PR DESCRIPTION
fix #66622

This patch disables, that popups get closed on linuxbsd, when mouse is moved outside of the popup, while a mouse-button is being kept held down.

Updated 2022-11-03: Fix merge conflict