### PR TITLE
Improve text line breaking performance for long lines.

### DIFF
--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -450,6 +450,7 @@ class TextServerAdvanced : public TextServerExtension {
 
 		HashMap<int, bool> jstops;
 		HashMap<int, bool> breaks;
+		int break_inserts = 0;
 		bool break_ops_valid = false;
 		bool js_ops_valid = false;
 


### PR DESCRIPTION
Depends on - https://github.com/godotengine/godot/pull/67562

Precalculate number of inserted virtual space glyphs and pre-allocate new array to avoid multiple `insert`s and reallocations.

This has any noticeable effect only with very long (> 20K chars) strings with large number of inserted spaces (CJK, Thai) and in debug mode.