### PR TITLE
Fix enum type to use int64_t instead of int in GDScript

### DIFF
--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -469,7 +469,7 @@ public:
 			EnumNode *parent_enum = nullptr;
 			int index = -1;
 			bool resolved = false;
-			int value = 0;
+			int64_t value = 0;
 			int line = 0;
 			int leftmost_column = 0;
 			int rightmost_column = 0;


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/67824
