### PR TITLE
Improve code flow in `ScriptServer::init_languages()`

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -184,23 +184,23 @@ void ScriptServer::unregister_language(const ScriptLanguage *p_language) {
 }
 
 void ScriptServer::init_languages() {
-	{ //load global classes
-		global_classes_clear();
-		if (ProjectSettings::get_singleton()->has_setting("_global_script_classes")) {
-			Array script_classes = ProjectSettings::get_singleton()->get("_global_script_classes");
-
-			for (int i = 0; i < script_classes.size(); i++) {
-				Dictionary c = script_classes[i];
-				if (!c.has("class") || !c.has("language") || !c.has("path") || !c.has("base")) {
-					continue;
-				}
-				add_global_class(c["class"], c["base"], c["language"], c["path"]);
-			}
-		}
-	}
+	global_classes_clear();
 
 	for (int i = 0; i < _language_count; i++) {
 		_languages[i]->init();
+	}
+
+	if (!ProjectSettings::get_singleton()->has_setting("_global_script_classes")) {
+		return;
+	}
+
+	Array script_classes = ProjectSettings::get_singleton()->get("_global_script_classes");
+	for (int i = 0; i < script_classes.size(); i++) {
+		Dictionary c = script_classes[i];
+		if (!c.has("class") || !c.has("language") || !c.has("path") || !c.has("base")) {
+			continue;
+		}
+		add_global_class(c["class"], c["base"], c["language"], c["path"]);
 	}
 }
 


### PR DESCRIPTION
This PR improves code flow in `ScriptServer::init_languages()` by removing two unnecessary scopes.
The execution order has changed, languages are now initialized before global script classes are added.

I tested this change by creating a scene with two nodes, one with a C# script and the other with a GDScript script.
This did not generate any error, warning or unintended behaviour on latest commit of master branch `040f49ed6e`.

The values of `_language_count` and `_languages` are unaffected by this change, and the only other side-effect apart from the initialization of the languages is the function call `add_global_class()` at `script_language.cpp:203`, which only affects the variable `ScriptServer::global_classes`. Neither C# or GDScript's `init()` methods access any `ScriptServer` variables or methods.