### PR TITLE
`SceneTree` Fix storing removed nodes to be skipped by the group calls (reverted)

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -123,6 +123,9 @@ void SceneTree::tree_changed() {
 
 void SceneTree::node_added(Node *p_node) {
 	emit_signal(node_added_name, p_node);
+	if (call_lock > 0) {
+		call_skip.erase(p_node->get_instance_id());
+	}
 }
 
 void SceneTree::node_removed(Node *p_node) {
@@ -131,7 +134,7 @@ void SceneTree::node_removed(Node *p_node) {
 	}
 	emit_signal(node_removed_name, p_node);
 	if (call_lock > 0) {
-		call_skip.insert(p_node);
+		call_skip.insert(p_node->get_instance_id());
 	}
 }
 
@@ -261,7 +264,7 @@ void SceneTree::call_group_flagsp(uint32_t p_call_flags, const StringName &p_gro
 
 	if (p_call_flags & GROUP_CALL_REVERSE) {
 		for (int i = gr_node_count - 1; i >= 0; i--) {
-			if (call_lock && call_skip.has(gr_nodes[i])) {
+			if (call_lock && call_skip.has(gr_nodes[i]->get_instance_id())) {
 				continue;
 			}
 
@@ -275,7 +278,7 @@ void SceneTree::call_group_flagsp(uint32_t p_call_flags, const StringName &p_gro
 
 	} else {
 		for (int i = 0; i < gr_node_count; i++) {
-			if (call_lock && call_skip.has(gr_nodes[i])) {
+			if (call_lock && call_skip.has(gr_nodes[i]->get_instance_id())) {
 				continue;
 			}
 
@@ -314,7 +317,7 @@ void SceneTree::notify_group_flags(uint32_t p_call_flags, const StringName &p_gr
 
 	if (p_call_flags & GROUP_CALL_REVERSE) {
 		for (int i = gr_node_count - 1; i >= 0; i--) {
-			if (call_lock && call_skip.has(gr_nodes[i])) {
+			if (call_lock && call_skip.has(gr_nodes[i]->get_instance_id())) {
 				continue;
 			}
 
@@ -327,7 +330,7 @@ void SceneTree::notify_group_flags(uint32_t p_call_flags, const StringName &p_gr
 
 	} else {
 		for (int i = 0; i < gr_node_count; i++) {
-			if (call_lock && call_skip.has(gr_nodes[i])) {
+			if (call_lock && call_skip.has(gr_nodes[i]->get_instance_id())) {
 				continue;
 			}
 
@@ -365,7 +368,7 @@ void SceneTree::set_group_flags(uint32_t p_call_flags, const StringName &p_group
 
 	if (p_call_flags & GROUP_CALL_REVERSE) {
 		for (int i = gr_node_count - 1; i >= 0; i--) {
-			if (call_lock && call_skip.has(gr_nodes[i])) {
+			if (call_lock && call_skip.has(gr_nodes[i]->get_instance_id())) {
 				continue;
 			}
 
@@ -378,7 +381,7 @@ void SceneTree::set_group_flags(uint32_t p_call_flags, const StringName &p_group
 
 	} else {
 		for (int i = 0; i < gr_node_count; i++) {
-			if (call_lock && call_skip.has(gr_nodes[i])) {
+			if (call_lock && call_skip.has(gr_nodes[i]->get_instance_id())) {
 				continue;
 			}
 
@@ -854,7 +857,7 @@ void SceneTree::_notify_group_pause(const StringName &p_group, int p_notificatio
 
 	for (int i = 0; i < gr_node_count; i++) {
 		Node *n = gr_nodes[i];
-		if (call_lock && call_skip.has(n)) {
+		if (call_lock && call_skip.has(n->get_instance_id())) {
 			continue;
 		}
 
@@ -904,7 +907,7 @@ void SceneTree::_call_input_pause(const StringName &p_group, CallInputType p_cal
 		}
 
 		Node *n = gr_nodes[i];
-		if (call_lock && call_skip.has(n)) {
+		if (call_lock && call_skip.has(n->get_instance_id())) {
 			continue;
 		}
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -135,7 +135,7 @@ private:
 
 	// Safety for when a node is deleted while a group is being called.
 	int call_lock = 0;
-	HashSet<Node *> call_skip; // Skip erased nodes.
+	HashSet<ObjectID> call_skip; // Skip erased nodes. Store ID instead of pointer to avoid false positives when node is freed and a new node is allocated at the pointed address.
 
 	List<ObjectID> delete_queue;
 


### PR DESCRIPTION
Nodes removed from the `SceneTree` are meant to be skipped by the group calls, hence such nodes are stored for each relevant "call lock". The issue was they were stored as pointers. Such stored node can be freed and possibly a new node can be allocated at exact same memory address. When all this happened during the same "call lock" then such newly added node would be incorrectly skipped in a group call (during the same "call lock") because of the by-pointer checks. This PR avoids such false positives by storing the nodes to be skipped as `ObjectID`s (which should be unique) instead of pointers.

Note that when making changes like `node` to `node->get_instance_id()` I haven't added sanity null checks for `node` as in most changed places such `node` is already being dereferenced in the subsequent lines, hence they're probably never supposed to be null in there? :thinking:

Fixes #67819.

---

Besides the above there was another issue: if node would be removed from the `SceneTree` and readded to it during the same "call lock" then such node would still be skipped in the group calls because it would still be in the nodes-to-skip set. Now when node is added to the tree during the "call lock" it checks if such node is in the nodes-to-skip set and if so, it's removed from it.

Fixes #44765.
