### PR TITLE
[3.x] Bullet: Revert "Fixed gravity scale"

### DIFF
--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -857,8 +857,7 @@ void SpaceBullet::check_body_collision() {
 void SpaceBullet::update_gravity() {
 	btVector3 btGravity;
 	G_TO_B(gravityDirection * gravityMagnitude, btGravity);
-	//dynamicsWorld->setGravity(btGravity);
-	dynamicsWorld->setGravity(btVector3(0, 0, 0));
+	dynamicsWorld->setGravity(btGravity);
 	if (soft_body_world_info) {
 		soft_body_world_info->m_gravity = btGravity;
 	}


### PR DESCRIPTION
This reverts commit d250ade37b1e74dd11c870be279318ba01a8ba70 which appears to have been made in error? (Looks suspicious, commented out line followed by a line which ignores the parameters in favor of a hard-coded zero vector).

Aside from ensuring the gravity vector is normalized (since it gets multiplied by `gravityMagnitude`), I don't see how reverting this would cause any issues.

Fixes #32196

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
