### PR TITLE
Fix built-in script path of GDScript to prevent crash

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1050,6 +1050,11 @@ Error GDScript::load_byte_code(const String &p_path) {
 	return ERR_COMPILATION_FAILED;
 }
 
+void GDScript::set_path(const String &p_path, bool p_take_over) {
+	Script::set_path(p_path, p_take_over);
+	this->path = p_path;
+}
+
 Error GDScript::load_source_code(const String &p_path) {
 	Vector<uint8_t> sourcef;
 	Error err;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -222,6 +222,7 @@ public:
 
 	virtual Error reload(bool p_keep_state = false) override;
 
+	virtual void set_path(const String &p_path, bool p_take_over = false) override;
 	void set_script_path(const String &p_path) { path = p_path; } //because subclasses need a path too...
 	Error load_source_code(const String &p_path);
 	Error load_byte_code(const String &p_path);


### PR DESCRIPTION
Fix #67779

_bugsquad edit: Fixes https://github.com/godotengine/godot/issues/51538_