### PR TITLE
Fix incorrect base class when using extends `Class.Subclass`

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2275,6 +2275,18 @@ Error GDScriptCompiler::_parse_class_level(GDScript *p_script, const GDScriptPar
 		} break;
 		case GDScriptDataType::GDSCRIPT: {
 			Ref<GDScript> base = Ref<GDScript>(base_type.script_type);
+			if (base.is_valid()) {
+				Error err = OK;
+				GDScriptCache::get_full_script(base->get_path(), err, main_script->path);
+				if (err != OK)
+					return err;
+				if (p_class->extends.size() > 1) {
+					for (int i = 1; i < p_class->extends.size(); i++) {
+						StringName extend = p_class->extends.get(i);
+						base = base->constants[extend];
+					}
+				}
+			}
 			p_script->base = base;
 			p_script->_base = base.ptr();
 
@@ -2290,15 +2302,6 @@ Error GDScriptCompiler::_parse_class_level(GDScript *p_script, const GDScriptPar
 						if (err) {
 							return err;
 						}
-					}
-				} else {
-					Error err = OK;
-					base = GDScriptCache::get_full_script(p_class->base_type.script_path, err, main_script->path);
-					if (err) {
-						return err;
-					}
-					if (base.is_null() || !base->is_valid()) {
-						return ERR_COMPILATION_FAILED;
 					}
 				}
 			}


### PR DESCRIPTION
## Issue
When parsing class level, the code loads the correct script file, but not the actual subclass extending the parsed class.

## How it resolves it
This PR does what the code did, but not at the right place. It forces the full script load of the base script file, then it adds a new part: it loops through the `Vector<StringName> extends` of the class node to go down each subclass of the base script file. It should even go through the subclasses' subclasses.

## Fixes
Fixes #65953