### PR TITLE
Extend Curve to allow for domains outside of `[0, 1]`.

### DIFF
--- a/doc/classes/AnimationNodeOneShot.xml
+++ b/doc/classes/AnimationNodeOneShot.xml
@@ -70,14 +70,14 @@
 			If [code]true[/code], breaks the loop at the end of the loop cycle for transition, even if the animation is looping.
 		</member>
 		<member name="fadein_curve" type="Curve" setter="set_fadein_curve" getter="get_fadein_curve">
-			Determines how cross-fading between animations is eased. If empty, the transition will be linear.
+			Determines how cross-fading between animations is eased. If empty, the transition will be linear. Should be a unit [Curve].
 		</member>
 		<member name="fadein_time" type="float" setter="set_fadein_time" getter="get_fadein_time" default="0.0">
 			The fade-in duration. For example, setting this to [code]1.0[/code] for a 5 second length animation will produce a cross-fade that starts at 0 second and ends at 1 second during the animation.
 			[b]Note:[/b] [AnimationNodeOneShot] transitions the current state after the end of the fading. When [AnimationNodeOutput] is considered as the most upstream, so the [member fadein_time] is scaled depending on the downstream delta. For example, if this value is set to [code]1.0[/code] and a [AnimationNodeTimeScale] with a value of [code]2.0[/code] is chained downstream, the actual processing time will be 0.5 second.
 		</member>
 		<member name="fadeout_curve" type="Curve" setter="set_fadeout_curve" getter="get_fadeout_curve">
-			Determines how cross-fading between animations is eased. If empty, the transition will be linear.
+			Determines how cross-fading between animations is eased. If empty, the transition will be linear. Should be a unit [Curve].
 		</member>
 		<member name="fadeout_time" type="float" setter="set_fadeout_time" getter="get_fadeout_time" default="0.0">
 			The fade-out duration. For example, setting this to [code]1.0[/code] for a 5 second length animation will produce a cross-fade that starts at 4 second and ends at 5 second during the animation.

--- a/doc/classes/AnimationNodeStateMachineTransition.xml
+++ b/doc/classes/AnimationNodeStateMachineTransition.xml
@@ -41,7 +41,7 @@
 			The transition type.
 		</member>
 		<member name="xfade_curve" type="Curve" setter="set_xfade_curve" getter="get_xfade_curve">
-			Ease curve for better control over cross-fade between this state and the next.
+			Ease curve for better control over cross-fade between this state and the next. Should be a unit [Curve].
 		</member>
 		<member name="xfade_time" type="float" setter="set_xfade_time" getter="get_xfade_time" default="0.0">
 			The time to cross-fade between this state and the next.

--- a/doc/classes/AnimationNodeTransition.xml
+++ b/doc/classes/AnimationNodeTransition.xml
@@ -96,7 +96,7 @@
 			The number of enabled input ports for this animation node.
 		</member>
 		<member name="xfade_curve" type="Curve" setter="set_xfade_curve" getter="get_xfade_curve">
-			Determines how cross-fading between animations is eased. If empty, the transition will be linear.
+			Determines how cross-fading between animations is eased. If empty, the transition will be linear. Should be a unit [Curve].
 		</member>
 		<member name="xfade_time" type="float" setter="set_xfade_time" getter="get_xfade_time" default="0.0">
 			Cross-fading time (in seconds) between each animation connected to the inputs.

--- a/doc/classes/CPUParticles2D.xml
+++ b/doc/classes/CPUParticles2D.xml
@@ -57,7 +57,7 @@
 			<param index="0" name="param" type="int" enum="CPUParticles2D.Parameter" />
 			<param index="1" name="curve" type="Curve" />
 			<description>
-				Sets the [Curve] of the parameter specified by [enum Parameter].
+				Sets the [Curve] of the parameter specified by [enum Parameter]. Should be a unit [Curve].
 			</description>
 		</method>
 		<method name="set_param_max">
@@ -90,7 +90,7 @@
 			Number of particles emitted in one emission cycle.
 		</member>
 		<member name="angle_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's rotation will be animated along this [Curve].
+			Each particle's rotation will be animated along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="angle_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum initial rotation applied to each particle, in degrees.
@@ -99,7 +99,7 @@
 			Minimum equivalent of [member angle_max].
 		</member>
 		<member name="angular_velocity_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's angular velocity will vary along this [Curve].
+			Each particle's angular velocity will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="angular_velocity_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum initial angular velocity (rotation speed) applied to each particle in [i]degrees[/i] per second.
@@ -108,7 +108,7 @@
 			Minimum equivalent of [member angular_velocity_max].
 		</member>
 		<member name="anim_offset_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's animation offset will vary along this [Curve].
+			Each particle's animation offset will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="anim_offset_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum animation offset that corresponds to frame index in the texture. [code]0[/code] is the first frame, [code]1[/code] is the last one. See [member CanvasItemMaterial.particles_animation].
@@ -117,7 +117,7 @@
 			Minimum equivalent of [member anim_offset_max].
 		</member>
 		<member name="anim_speed_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's animation speed will vary along this [Curve].
+			Each particle's animation speed will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="anim_speed_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum particle animation speed. Animation speed of [code]1[/code] means that the particles will make full [code]0[/code] to [code]1[/code] offset cycle during lifetime, [code]2[/code] means [code]2[/code] cycles etc.
@@ -136,7 +136,7 @@
 			Each particle's color will vary along this [Gradient] (multiplied with [member color]).
 		</member>
 		<member name="damping_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Damping will vary along this [Curve].
+			Damping will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="damping_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			The maximum rate at which particles lose velocity. For example value of [code]100[/code] means that the particle will go from [code]100[/code] velocity to [code]0[/code] in [code]1[/code] second.
@@ -184,7 +184,7 @@
 			Gravity applied to every particle.
 		</member>
 		<member name="hue_variation_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's hue will vary along this [Curve].
+			Each particle's hue will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="hue_variation_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum initial hue variation applied to each particle. It will shift the particle color's hue.
@@ -205,7 +205,7 @@
 			Particle lifetime randomness ratio.
 		</member>
 		<member name="linear_accel_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's linear acceleration will vary along this [Curve].
+			Each particle's linear acceleration will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="linear_accel_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum linear acceleration applied to each particle in the direction of motion.
@@ -220,7 +220,7 @@
 			If [code]true[/code], only one emission cycle occurs. If set [code]true[/code] during a cycle, emission will stop at the cycle's end.
 		</member>
 		<member name="orbit_velocity_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's orbital velocity will vary along this [Curve].
+			Each particle's orbital velocity will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="orbit_velocity_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum orbital velocity applied to each particle. Makes the particles circle around origin. Specified in number of full rotations around origin per second.
@@ -235,7 +235,7 @@
 			Particle system starts as if it had already run for this many seconds.
 		</member>
 		<member name="radial_accel_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's radial acceleration will vary along this [Curve].
+			Each particle's radial acceleration will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="radial_accel_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum radial acceleration applied to each particle. Makes particle accelerate away from the origin or towards it if negative.
@@ -247,7 +247,7 @@
 			Emission lifetime randomness ratio.
 		</member>
 		<member name="scale_amount_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's scale will vary along this [Curve].
+			Each particle's scale will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="scale_amount_max" type="float" setter="set_param_max" getter="get_param_max" default="1.0">
 			Maximum initial scale applied to each particle.
@@ -256,11 +256,11 @@
 			Minimum equivalent of [member scale_amount_max].
 		</member>
 		<member name="scale_curve_x" type="Curve" setter="set_scale_curve_x" getter="get_scale_curve_x">
-			Each particle's horizontal scale will vary along this [Curve].
+			Each particle's horizontal scale will vary along this [Curve]. Should be a unit [Curve].
 			[member split_scale] must be enabled.
 		</member>
 		<member name="scale_curve_y" type="Curve" setter="set_scale_curve_y" getter="get_scale_curve_y">
-			Each particle's vertical scale will vary along this [Curve].
+			Each particle's vertical scale will vary along this [Curve]. Should be a unit [Curve].
 			[member split_scale] must be enabled.
 		</member>
 		<member name="speed_scale" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
@@ -273,7 +273,7 @@
 			Each particle's initial direction range from [code]+spread[/code] to [code]-spread[/code] degrees.
 		</member>
 		<member name="tangential_accel_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's tangential acceleration will vary along this [Curve].
+			Each particle's tangential acceleration will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="tangential_accel_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum tangential acceleration applied to each particle. Tangential acceleration is perpendicular to the particle's velocity giving the particles a swirling motion.

--- a/doc/classes/CPUParticles3D.xml
+++ b/doc/classes/CPUParticles3D.xml
@@ -63,7 +63,7 @@
 			<param index="0" name="param" type="int" enum="CPUParticles3D.Parameter" />
 			<param index="1" name="curve" type="Curve" />
 			<description>
-				Sets the [Curve] of the parameter specified by [enum Parameter].
+				Sets the [Curve] of the parameter specified by [enum Parameter]. Should be a unit [Curve].
 			</description>
 		</method>
 		<method name="set_param_max">
@@ -96,7 +96,7 @@
 			Number of particles emitted in one emission cycle.
 		</member>
 		<member name="angle_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's rotation will be animated along this [Curve].
+			Each particle's rotation will be animated along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="angle_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum angle.
@@ -105,7 +105,7 @@
 			Minimum angle.
 		</member>
 		<member name="angular_velocity_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's angular velocity (rotation speed) will vary along this [Curve] over its lifetime.
+			Each particle's angular velocity (rotation speed) will vary along this [Curve] over its lifetime. Should be a unit [Curve].
 		</member>
 		<member name="angular_velocity_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum initial angular velocity (rotation speed) applied to each particle in [i]degrees[/i] per second.
@@ -114,7 +114,7 @@
 			Minimum initial angular velocity (rotation speed) applied to each particle in [i]degrees[/i] per second.
 		</member>
 		<member name="anim_offset_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's animation offset will vary along this [Curve].
+			Each particle's animation offset will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="anim_offset_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum animation offset.
@@ -123,7 +123,7 @@
 			Minimum animation offset.
 		</member>
 		<member name="anim_speed_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's animation speed will vary along this [Curve].
+			Each particle's animation speed will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="anim_speed_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum particle animation speed.
@@ -144,7 +144,7 @@
 			[b]Note:[/b] [member color_ramp] multiplies the particle mesh's vertex colors. To have a visible effect on a [BaseMaterial3D], [member BaseMaterial3D.vertex_color_use_as_albedo] [i]must[/i] be [code]true[/code]. For a [ShaderMaterial], [code]ALBEDO *= COLOR.rgb;[/code] must be inserted in the shader's [code]fragment()[/code] function. Otherwise, [member color_ramp] will have no visible effect.
 		</member>
 		<member name="damping_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Damping will vary along this [Curve].
+			Damping will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="damping_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum damping.
@@ -212,7 +212,7 @@
 			Gravity applied to every particle.
 		</member>
 		<member name="hue_variation_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's hue will vary along this [Curve].
+			Each particle's hue will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="hue_variation_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum hue variation.
@@ -233,7 +233,7 @@
 			Particle lifetime randomness ratio.
 		</member>
 		<member name="linear_accel_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's linear acceleration will vary along this [Curve].
+			Each particle's linear acceleration will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="linear_accel_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum linear acceleration.
@@ -251,7 +251,7 @@
 			If [code]true[/code], only one emission cycle occurs. If set [code]true[/code] during a cycle, emission will stop at the cycle's end.
 		</member>
 		<member name="orbit_velocity_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's orbital velocity will vary along this [Curve].
+			Each particle's orbital velocity will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="orbit_velocity_max" type="float" setter="set_param_max" getter="get_param_max">
 			Maximum orbit velocity.
@@ -272,7 +272,7 @@
 			Particle system starts as if it had already run for this many seconds.
 		</member>
 		<member name="radial_accel_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's radial acceleration will vary along this [Curve].
+			Each particle's radial acceleration will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="radial_accel_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum radial acceleration.
@@ -284,7 +284,7 @@
 			Emission lifetime randomness ratio.
 		</member>
 		<member name="scale_amount_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's scale will vary along this [Curve].
+			Each particle's scale will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="scale_amount_max" type="float" setter="set_param_max" getter="get_param_max" default="1.0">
 			Maximum scale.
@@ -311,7 +311,7 @@
 			Each particle's initial direction range from [code]+spread[/code] to [code]-spread[/code] degrees. Applied to X/Z plane and Y/Z planes.
 		</member>
 		<member name="tangential_accel_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
-			Each particle's tangential acceleration will vary along this [Curve].
+			Each particle's tangential acceleration will vary along this [Curve]. Should be a unit [Curve].
 		</member>
 		<member name="tangential_accel_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum tangent acceleration.

--- a/doc/classes/Curve.xml
+++ b/doc/classes/Curve.xml
@@ -4,8 +4,8 @@
 		A mathematical curve.
 	</brief_description>
 	<description>
-		This resource describes a mathematical curve by defining a set of points and tangents at each point. By default, it ranges between [code]0[/code] and [code]1[/code] on the Y axis and positions points relative to the [code]0.5[/code] Y position.
-		See also [Gradient] which is designed for color interpolation. See also [Curve2D] and [Curve3D].
+		This resource describes a mathematical curve by defining a set of points and tangents at each point. By default, it ranges between [code]0[/code] and [code]1[/code] on the X and Y axes, but these ranges can be changed.
+		Please note that many resources and nodes assume they are given [i]unit curves[/i]. A unit curve is a curve whose domain (the X axis) is between [code]0[/code] and [code]1[/code]. Some examples of unit curve usage are [member CPUParticles2D.angle_curve] and [member Line2D.width_curve].
 	</description>
 	<tutorials>
 	</tutorials>
@@ -37,6 +37,12 @@
 			<return type="void" />
 			<description>
 				Removes all points from the curve.
+			</description>
+		</method>
+		<method name="get_domain_range" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the difference between [member min_domain] and [member max_domain].
 			</description>
 		</method>
 		<method name="get_point_left_mode" qualifiers="const">
@@ -72,6 +78,12 @@
 			<param index="0" name="index" type="int" />
 			<description>
 				Returns the right tangent angle (in degrees) for the point at [param index].
+			</description>
+		</method>
+		<method name="get_value_range" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the difference between [member min_value] and [member max_value].
 			</description>
 		</method>
 		<method name="remove_point">
@@ -148,17 +160,28 @@
 		<member name="bake_resolution" type="int" setter="set_bake_resolution" getter="get_bake_resolution" default="100">
 			The number of points to include in the baked (i.e. cached) curve data.
 		</member>
+		<member name="max_domain" type="float" setter="set_max_domain" getter="get_max_domain" default="1.0">
+			The maximum domain (x-coordinate) that points can have.
+		</member>
 		<member name="max_value" type="float" setter="set_max_value" getter="get_max_value" default="1.0">
-			The maximum value the curve can reach.
+			The maximum value (y-coordinate) that points can have. Tangents can cause higher values between points.
+		</member>
+		<member name="min_domain" type="float" setter="set_min_domain" getter="get_min_domain" default="0.0">
+			The minimum domain (x-coordinate) that points can have.
 		</member>
 		<member name="min_value" type="float" setter="set_min_value" getter="get_min_value" default="0.0">
-			The minimum value the curve can reach.
+			The minimum value (y-coordinate) that points can have. Tangents can cause lower values between points.
 		</member>
 		<member name="point_count" type="int" setter="set_point_count" getter="get_point_count" default="0">
 			The number of points describing the curve.
 		</member>
 	</members>
 	<signals>
+		<signal name="domain_changed">
+			<description>
+				Emitted when [member max_domain] or [member min_domain] is changed.
+			</description>
+		</signal>
 		<signal name="range_changed">
 			<description>
 				Emitted when [member max_value] or [member min_value] is changed.

--- a/doc/classes/CurveTexture.xml
+++ b/doc/classes/CurveTexture.xml
@@ -4,14 +4,14 @@
 		A 1D texture where pixel brightness corresponds to points on a curve.
 	</brief_description>
 	<description>
-		A 1D texture where pixel brightness corresponds to points on a [Curve] resource, either in grayscale or in red. This visual representation simplifies the task of saving curves as image files.
+		A 1D texture where pixel brightness corresponds to points on a unit [Curve] resource, either in grayscale or in red. This visual representation simplifies the task of saving curves as image files.
 		If you need to store up to 3 curves within a single texture, use [CurveXYZTexture] instead. See also [GradientTexture1D] and [GradientTexture2D].
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
 		<member name="curve" type="Curve" setter="set_curve" getter="get_curve">
-			The [Curve] that is rendered onto the texture.
+			The [Curve] that is rendered onto the texture. Should be a unit [Curve].
 		</member>
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 		<member name="texture_mode" type="int" setter="set_texture_mode" getter="get_texture_mode" enum="CurveTexture.TextureMode" default="0">

--- a/doc/classes/CurveXYZTexture.xml
+++ b/doc/classes/CurveXYZTexture.xml
@@ -4,20 +4,20 @@
 		A 1D texture where the red, green, and blue color channels correspond to points on 3 curves.
 	</brief_description>
 	<description>
-		A 1D texture where the red, green, and blue color channels correspond to points on 3 [Curve] resources. Compared to using separate [CurveTexture]s, this further simplifies the task of saving curves as image files.
+		A 1D texture where the red, green, and blue color channels correspond to points on 3 unit [Curve] resources. Compared to using separate [CurveTexture]s, this further simplifies the task of saving curves as image files.
 		If you only need to store one curve within a single texture, use [CurveTexture] instead. See also [GradientTexture1D] and [GradientTexture2D].
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
 		<member name="curve_x" type="Curve" setter="set_curve_x" getter="get_curve_x">
-			The [Curve] that is rendered onto the texture's red channel.
+			The [Curve] that is rendered onto the texture's red channel. Should be a unit [Curve].
 		</member>
 		<member name="curve_y" type="Curve" setter="set_curve_y" getter="get_curve_y">
-			The [Curve] that is rendered onto the texture's green channel.
+			The [Curve] that is rendered onto the texture's green channel. Should be a unit [Curve].
 		</member>
 		<member name="curve_z" type="Curve" setter="set_curve_z" getter="get_curve_z">
-			The [Curve] that is rendered onto the texture's blue channel.
+			The [Curve] that is rendered onto the texture's blue channel. Should be a unit [Curve].
 		</member>
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 		<member name="width" type="int" setter="set_width" getter="get_width" default="256">

--- a/doc/classes/Line2D.xml
+++ b/doc/classes/Line2D.xml
@@ -101,7 +101,7 @@
 			The polyline's width.
 		</member>
 		<member name="width_curve" type="Curve" setter="set_curve" getter="get_curve">
-			The polyline's width curve. The width of the polyline over its length will be equivalent to the value of the width curve over its domain.
+			The polyline's width curve. The width of the polyline over its length will be equivalent to the value of the width curve over its domain. The width curve should be a unit [Curve].
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/RibbonTrailMesh.xml
+++ b/doc/classes/RibbonTrailMesh.xml
@@ -13,7 +13,7 @@
 	</tutorials>
 	<members>
 		<member name="curve" type="Curve" setter="set_curve" getter="get_curve">
-			Determines the size of the ribbon along its length. The size of a particular section segment is obtained by multiplying the baseline [member size] by the value of this curve at the given distance. For values smaller than [code]0[/code], the faces will be inverted.
+			Determines the size of the ribbon along its length. The size of a particular section segment is obtained by multiplying the baseline [member size] by the value of this curve at the given distance. For values smaller than [code]0[/code], the faces will be inverted. Should be a unit [Curve].
 		</member>
 		<member name="section_length" type="float" setter="set_section_length" getter="get_section_length" default="0.2">
 			The length of a section of the ribbon.

--- a/doc/classes/TubeTrailMesh.xml
+++ b/doc/classes/TubeTrailMesh.xml
@@ -19,7 +19,7 @@
 			If [code]true[/code], generates a cap at the top of the tube. This can be set to [code]false[/code] to speed up generation and rendering when the cap is never seen by the camera.
 		</member>
 		<member name="curve" type="Curve" setter="set_curve" getter="get_curve">
-			Determines the radius of the tube along its length. The radius of a particular section ring is obtained by multiplying the baseline [member radius] by the value of this curve at the given distance. For values smaller than [code]0[/code], the faces will be inverted.
+			Determines the radius of the tube along its length. The radius of a particular section ring is obtained by multiplying the baseline [member radius] by the value of this curve at the given distance. For values smaller than [code]0[/code], the faces will be inverted. Should be a unit [Curve].
 		</member>
 		<member name="radial_steps" type="int" setter="set_radial_steps" getter="get_radial_steps" default="8">
 			The number of sides on the tube. For example, a value of [code]5[/code] means the tube will be pentagonal. Higher values result in a more detailed tube at the cost of performance.

--- a/editor/plugins/curve_editor_plugin.h
+++ b/editor/plugins/curve_editor_plugin.h
@@ -78,14 +78,14 @@ private:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	void _curve_changed();
 
-	int get_point_at(Vector2 p_pos) const;
-	TangentIndex get_tangent_at(Vector2 p_pos) const;
+	int get_point_at(const Vector2 &p_pos) const;
+	TangentIndex get_tangent_at(const Vector2 &p_pos) const;
 
 	float get_offset_without_collision(int p_current_index, float p_offset, bool p_prioritize_right = true);
 
-	void add_point(Vector2 p_pos);
+	void add_point(const Vector2 &p_pos);
 	void remove_point(int p_index);
-	void set_point_position(int p_index, Vector2 p_pos);
+	void set_point_position(int p_index, const Vector2 &p_pos);
 
 	void set_point_tangents(int p_index, float p_left, float p_right);
 	void set_point_left_tangent(int p_index, float p_tangent);
@@ -94,17 +94,20 @@ private:
 
 	void update_view_transform();
 
+	void plot_curve_accurate(float p_step, const Color &p_line_color, const Color &p_edge_line_color);
+
 	void set_selected_index(int p_index);
-	void set_selected_tangent_index(TangentIndex p_tangent);
 
 	Vector2 get_tangent_view_pos(int p_index, TangentIndex p_tangent) const;
-	Vector2 get_view_pos(Vector2 p_world_pos) const;
-	Vector2 get_world_pos(Vector2 p_view_pos) const;
+	Vector2 get_view_pos(const Vector2 &p_world_pos) const;
+	Vector2 get_world_pos(const Vector2 &p_view_pos) const;
 
 	void _redraw();
 
 private:
 	const float ASPECT_RATIO = 6.f / 13.f;
+	const float LINE_WIDTH = 0.5f;
+	const int STEP_SIZE = 2; // Number of pixels between plot points.
 
 	Transform2D _world_to_view;
 
@@ -136,9 +139,9 @@ private:
 	};
 	GrabMode grabbing = GRAB_NONE;
 	Vector2 initial_grab_pos;
-	int initial_grab_index;
-	float initial_grab_left_tangent;
-	float initial_grab_right_tangent;
+	int initial_grab_index = -1;
+	float initial_grab_left_tangent = 0;
+	float initial_grab_right_tangent = 0;
 
 	bool snap_enabled = false;
 	int snap_count = 10;

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -38,10 +38,8 @@ class Curve : public Resource {
 	GDCLASS(Curve, Resource);
 
 public:
-	static const int MIN_X = 0.f;
-	static const int MAX_X = 1.f;
-
 	static const char *SIGNAL_RANGE_CHANGED;
+	static const char *SIGNAL_DOMAIN_CHANGED;
 
 	enum TangentMode {
 		TANGENT_FREE = 0,
@@ -101,11 +99,18 @@ public:
 
 	real_t get_min_value() const { return _min_value; }
 	void set_min_value(real_t p_min);
-
 	real_t get_max_value() const { return _max_value; }
 	void set_max_value(real_t p_max);
+	real_t get_value_range() const { return _max_value - _min_value; }
 
-	real_t get_range() const { return _max_value - _min_value; }
+	real_t get_min_domain() const { return _min_domain; }
+	void set_min_domain(real_t p_min);
+	real_t get_max_domain() const { return _max_domain; }
+	void set_max_domain(real_t p_max);
+	real_t get_domain_range() const { return _max_domain - _min_domain; }
+
+	Array get_limits() const;
+	void set_limits(const Array &p_input);
 
 	real_t sample(real_t p_offset) const;
 	real_t sample_local_nocheck(int p_index, real_t p_local_offset) const;
@@ -156,7 +161,8 @@ private:
 	int _bake_resolution = 100;
 	real_t _min_value = 0.0;
 	real_t _max_value = 1.0;
-	int _minmax_set_once = 0b00; // Encodes whether min and max have been set a first time, first bit for min and second for max.
+	real_t _min_domain = 0.0;
+	real_t _max_domain = 1.0;
 };
 
 VARIANT_ENUM_CAST(Curve::TangentMode)

--- a/tests/scene/test_curve.h
+++ b/tests/scene/test_curve.h
@@ -55,7 +55,7 @@ TEST_CASE("[Curve] Default curve") {
 			"Default curve should return the expected value at offset 1.0.");
 }
 
-TEST_CASE("[Curve] Custom curve with free tangents") {
+TEST_CASE("[Curve] Custom unit curve with free tangents") {
 	Ref<Curve> curve = memnew(Curve);
 	// "Sawtooth" curve with an open ending towards the 1.0 offset.
 	curve->add_point(Vector2(0, 0));
@@ -136,7 +136,90 @@ TEST_CASE("[Curve] Custom curve with free tangents") {
 			"Custom free curve should return the expected baked value at offset 0.6 after clearing all points.");
 }
 
-TEST_CASE("[Curve] Custom curve with linear tangents") {
+TEST_CASE("[Curve] Custom non-unit curve with free tangents") {
+	Ref<Curve> curve = memnew(Curve);
+	curve->set_min_domain(-100.0);
+	curve->set_max_domain(100.0);
+	// "Sawtooth" curve with an open ending towards the 100 offset.
+	curve->add_point(Vector2(-100, 0));
+	curve->add_point(Vector2(-50, 1));
+	curve->add_point(Vector2(0, 0));
+	curve->add_point(Vector2(50, 1));
+	curve->set_bake_resolution(11);
+
+	CHECK_MESSAGE(
+			Math::is_zero_approx(curve->get_point_left_tangent(0)),
+			"get_point_left_tangent() should return the expected value for point index 0.");
+	CHECK_MESSAGE(
+			Math::is_zero_approx(curve->get_point_right_tangent(0)),
+			"get_point_right_tangent() should return the expected value for point index 0.");
+	CHECK_MESSAGE(
+			curve->get_point_left_mode(0) == Curve::TangentMode::TANGENT_FREE,
+			"get_point_left_mode() should return the expected value for point index 0.");
+	CHECK_MESSAGE(
+			curve->get_point_right_mode(0) == Curve::TangentMode::TANGENT_FREE,
+			"get_point_right_mode() should return the expected value for point index 0.");
+
+	CHECK_MESSAGE(
+			curve->get_point_count() == 4,
+			"Custom free curve should contain the expected number of points.");
+
+	CHECK_MESSAGE(
+			Math::is_zero_approx(curve->sample(-200)),
+			"Custom free curve should return the expected value at offset -200.");
+	CHECK_MESSAGE(
+			curve->sample(0.1 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx((real_t)0.352),
+			"Custom free curve should return the expected value at offset equivalent to a unit curve's 0.1.");
+	CHECK_MESSAGE(
+			curve->sample(0.4 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx((real_t)0.352),
+			"Custom free curve should return the expected value at offset equivalent to a unit curve's 0.4.");
+	CHECK_MESSAGE(
+			curve->sample(0.7 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx((real_t)0.896),
+			"Custom free curve should return the expected value at offset equivalent to a unit curve's 0.7.");
+	CHECK_MESSAGE(
+			curve->sample(1 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx(1),
+			"Custom free curve should return the expected value at offset equivalent to a unit curve's 1.");
+	CHECK_MESSAGE(
+			curve->sample(2 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx(1),
+			"Custom free curve should return the expected value at offset equivalent to a unit curve's 2.");
+
+	CHECK_MESSAGE(
+			Math::is_zero_approx(curve->sample_baked(-200)),
+			"Custom free curve should return the expected baked value at offset equivalent to a unit curve's -0.1.");
+	CHECK_MESSAGE(
+			curve->sample_baked(0.1 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx((real_t)0.352),
+			"Custom free curve should return the expected baked value at offset equivalent to a unit curve's 0.1.");
+	CHECK_MESSAGE(
+			curve->sample_baked(0.4 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx((real_t)0.352),
+			"Custom free curve should return the expected baked value at offset equivalent to a unit curve's 0.4.");
+	CHECK_MESSAGE(
+			curve->sample_baked(0.7 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx((real_t)0.896),
+			"Custom free curve should return the expected baked value at offset equivalent to a unit curve's 0.7.");
+	CHECK_MESSAGE(
+			curve->sample_baked(1 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx(1),
+			"Custom free curve should return the expected baked value at offset equivalent to a unit curve's 1.");
+	CHECK_MESSAGE(
+			curve->sample_baked(2 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx(1),
+			"Custom free curve should return the expected baked value at offset equivalent to a unit curve's 2.");
+
+	curve->remove_point(1);
+	CHECK_MESSAGE(
+			curve->sample(0.1 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx(0),
+			"Custom free curve should return the expected value at offset equivalent to a unit curve's 0.1 after removing point at index 1.");
+	CHECK_MESSAGE(
+			curve->sample_baked(0.1 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx(0),
+			"Custom free curve should return the expected baked value at offset equivalent to a unit curve's 0.1 after removing point at index 1.");
+
+	curve->clear_points();
+	CHECK_MESSAGE(
+			curve->sample(0.6 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx(0),
+			"Custom free curve should return the expected value at offset 0.6 after clearing all points.");
+	CHECK_MESSAGE(
+			curve->sample_baked(0.6 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx(0),
+			"Custom free curve should return the expected baked value at offset 0.6 after clearing all points.");
+}
+
+TEST_CASE("[Curve] Custom unit curve with linear tangents") {
 	Ref<Curve> curve = memnew(Curve);
 	// "Sawtooth" curve with an open ending towards the 1.0 offset.
 	curve->add_point(Vector2(0, 0), 0, 0, Curve::TangentMode::TANGENT_LINEAR, Curve::TangentMode::TANGENT_LINEAR);
@@ -217,6 +300,91 @@ TEST_CASE("[Curve] Custom curve with linear tangents") {
 	CHECK_MESSAGE(
 			curve->sample_baked(0.7) == doctest::Approx((real_t)0.8),
 			"Custom free curve should return the expected baked value at offset 0.7 after removing point at invalid index 10.");
+}
+
+TEST_CASE("[Curve] Custom non-unit curve with linear tangents") {
+	Ref<Curve> curve = memnew(Curve);
+	curve->set_min_domain(-100.0);
+	curve->set_max_domain(100.0);
+	// "Sawtooth" curve with an open ending towards the 100 offset.
+	curve->add_point(Vector2(-100, 0), 0, 0, Curve::TangentMode::TANGENT_LINEAR, Curve::TangentMode::TANGENT_LINEAR);
+	curve->add_point(Vector2(-50, 1), 0, 0, Curve::TangentMode::TANGENT_LINEAR, Curve::TangentMode::TANGENT_LINEAR);
+	curve->add_point(Vector2(0, 0), 0, 0, Curve::TangentMode::TANGENT_LINEAR, Curve::TangentMode::TANGENT_LINEAR);
+	curve->add_point(Vector2(50, 1), 0, 0, Curve::TangentMode::TANGENT_LINEAR, Curve::TangentMode::TANGENT_LINEAR);
+
+	CHECK_MESSAGE(
+			curve->get_point_left_tangent(3) == doctest::Approx(1.f / 50),
+			"get_point_left_tangent() should return the expected value for point index 3.");
+	CHECK_MESSAGE(
+			Math::is_zero_approx(curve->get_point_right_tangent(3)),
+			"get_point_right_tangent() should return the expected value for point index 3.");
+	CHECK_MESSAGE(
+			curve->get_point_left_mode(3) == Curve::TangentMode::TANGENT_LINEAR,
+			"get_point_left_mode() should return the expected value for point index 3.");
+	CHECK_MESSAGE(
+			curve->get_point_right_mode(3) == Curve::TangentMode::TANGENT_LINEAR,
+			"get_point_right_mode() should return the expected value for point index 3.");
+
+	ERR_PRINT_OFF;
+	CHECK_MESSAGE(
+			Math::is_zero_approx(curve->get_point_right_tangent(300)),
+			"get_point_right_tangent() should return the expected value for invalid point index 300.");
+	CHECK_MESSAGE(
+			curve->get_point_left_mode(-12345) == Curve::TangentMode::TANGENT_FREE,
+			"get_point_left_mode() should return the expected value for invalid point index -12345.");
+	ERR_PRINT_ON;
+
+	CHECK_MESSAGE(
+			curve->get_point_count() == 4,
+			"Custom linear unit curve should contain the expected number of points.");
+
+	CHECK_MESSAGE(
+			Math::is_zero_approx(curve->sample(-0.1 * curve->get_domain_range() + curve->get_min_domain())),
+			"Custom linear curve should return the expected value at offset equivalent to a unit curve's -0.1.");
+	CHECK_MESSAGE(
+			curve->sample(0.1 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx((real_t)0.4),
+			"Custom linear curve should return the expected value at offset equivalent to a unit curve's 0.1.");
+	CHECK_MESSAGE(
+			curve->sample(0.4 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx((real_t)0.4),
+			"Custom linear curve should return the expected value at offset equivalent to a unit curve's 0.4.");
+	CHECK_MESSAGE(
+			curve->sample(0.7 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx((real_t)0.8),
+			"Custom linear curve should return the expected value at offset equivalent to a unit curve's 0.7.");
+	CHECK_MESSAGE(
+			curve->sample(1 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx(1),
+			"Custom linear curve should return the expected value at offset equivalent to a unit curve's 1.0.");
+	CHECK_MESSAGE(
+			curve->sample(2 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx(1),
+			"Custom linear curve should return the expected value at offset equivalent to a unit curve's 2.0.");
+
+	CHECK_MESSAGE(
+			Math::is_zero_approx(curve->sample_baked(-0.1 * curve->get_domain_range() + curve->get_min_domain())),
+			"Custom linear curve should return the expected baked value at offset equivalent to a unit curve's -0.1.");
+	CHECK_MESSAGE(
+			curve->sample_baked(0.1 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx((real_t)0.4),
+			"Custom linear curve should return the expected baked value at offset equivalent to a unit curve's 0.1.");
+	CHECK_MESSAGE(
+			curve->sample_baked(0.4 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx((real_t)0.4),
+			"Custom linear curve should return the expected baked value at offset equivalent to a unit curve's 0.4.");
+	CHECK_MESSAGE(
+			curve->sample_baked(0.7 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx((real_t)0.8),
+			"Custom linear curve should return the expected baked value at offset equivalent to a unit curve's 0.7.");
+	CHECK_MESSAGE(
+			curve->sample_baked(1 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx(1),
+			"Custom linear curve should return the expected baked value at offset equivalent to a unit curve's 1.0.");
+	CHECK_MESSAGE(
+			curve->sample_baked(2 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx(1),
+			"Custom linear curve should return the expected baked value at offset equivalent to a unit curve's 2.0.");
+
+	ERR_PRINT_OFF;
+	curve->remove_point(10);
+	ERR_PRINT_ON;
+	CHECK_MESSAGE(
+			curve->sample(0.7 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx((real_t)0.8),
+			"Custom free curve should return the expected value at offset equivalent to a unit curve's 0.7 after removing point at invalid index 10.");
+	CHECK_MESSAGE(
+			curve->sample_baked(0.7 * curve->get_domain_range() + curve->get_min_domain()) == doctest::Approx((real_t)0.8),
+			"Custom free curve should return the expected baked value at offset equivalent to a unit curve's 0.7 after removing point at invalid index 10.");
 }
 
 TEST_CASE("[Curve] Straight line offset test") {


### PR DESCRIPTION
This PR allows users to make curves in whatever app/game-specific domain they wish 📈 Previously, curves were restricted to a domain of [0,1]. Implements proposal, closes [#5607](https://github.com/godotengine/godot-proposals/issues/5607).

Depends on #78931 and #77622, whose commits have been cherry-picked in this PR. Can rebase/remove those commits when/if they get merged. I can also squash them into this PR if preferred. Let me know 🥰 

https://github.com/godotengine/godot/assets/1133892/a0e957fc-b914-4e44-8b4f-b3bb27687ca0

⚠️ This PR also enforces previously unenforced value ranges for points in the curve ⚠️ I tested this and it should _not_ alter existing curve's points when they are loaded ⚠️ Instead, this happens, then is corrected when limits are changed:

![image](https://github.com/godotengine/godot/assets/1133892/84b722df-677d-4da5-b623-f367cd236a5e)


### Things accounted for

- Curve editor supports extended curves
- Preview generates correctly
- Baking works correctly
- Presets are set correctly in new domains
- Duplicated unit curve test cases adapted to a domain of [-100, 100]
- Documented that other uses of Curve in the engine require unit curves

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
