### PR TITLE
Fix Thread usage in UPNP docs.

### DIFF
--- a/modules/upnp/doc_classes/UPNP.xml
+++ b/modules/upnp/doc_classes/UPNP.xml
@@ -41,7 +41,7 @@
 
 		func _ready():
 		    thread = Thread.new()
-		    thread.start(self, "_upnp_setup", SERVER_PORT)
+		    thread.start(_upnp_setup.bind(SERVER_PORT))
 
 		func _exit_tree():
 		    # Wait for thread finish here to handle game exit while the thread is running.


### PR DESCRIPTION
Fixes #65703.
The threading API has changed between Godot 3 and Godot 4 (See https://github.com/godotengine/godot-proposals/issues/4691).

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
