### PR TITLE
Fix crash of `queue_free()` when main loop is not SceneTree

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2581,10 +2581,14 @@ void Node::print_orphan_nodes() {
 }
 
 void Node::queue_free() {
+	// There are users which instantiate multiple scene trees for their games.
+	// Use the node's own tree to handle its deletion when relevant.
 	if (is_inside_tree()) {
 		get_tree()->queue_delete(this);
 	} else {
-		SceneTree::get_singleton()->queue_delete(this);
+		SceneTree *tree = SceneTree::get_singleton();
+		ERR_FAIL_NULL_MSG(tree, "Can't queue free a node when no SceneTree is available.");
+		tree->queue_delete(this);
 	}
 }
 


### PR DESCRIPTION
Run this snippet with `godot -s script.gd` crashes:

```gdscript
extends MainLoop

func _process(delta: float) -> bool:
	Node.new().queue_free()
	return true  # exit loop
```

<details><summary>Backtrace</summary>

```
================================================================
handle_crash: Program crashed with signal 11
Engine version: Godot Engine v4.0.beta.custom_build (c51a42778df3239fa3e9ef23e701146675985f3c)
Dumping the backtrace. Please include this when reporting the bug on: https://github.com/godotengine/godot/issues
[1] bin/godot.linuxbsd.editor.dev.x86_64.san(+0x7f67b00) [0x5601ba3b5b00] (??:0)
[2] /usr/lib/libc.so.6(+0x38a00) [0x7f4f1f826a00] (??:0)
[3] /usr/lib/libc.so.6(pthread_mutex_lock+0x4) [0x7f4f1f877b04] (??:0)
[4] bin/godot.linuxbsd.editor.dev.x86_64.san(+0x7f8bf8b) [0x5601ba3d9f8b] (??:0)
[5] bin/godot.linuxbsd.editor.dev.x86_64.san(+0x7f8bfdb) [0x5601ba3d9fdb] (??:0)
[6] std::recursive_mutex::lock() (??:0)
[7] SceneTree::queue_delete(Object*) (??:0)
[8] Node::queue_delete() (??:0)
[9] void call_with_ptr_args_helper<__UnexistingClass>(__UnexistingClass*, void (__UnexistingClass::*)(), void const**, IndexSequence<>) (??:0)
[10] void call_with_ptr_args<__UnexistingClass>(__UnexistingClass*, void (__UnexistingClass::*)(), void const**) (??:0)
[11] MethodBindT<>::ptrcall(Object*, void const**, void*) (??:0)
[12] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) (??:0)
[13] GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) (??:0)
[14] bool MainLoop::_gdvirtual__process_call<false>(double, bool&) (??:0)
[15] MainLoop::process(double) (??:0)
[16] Main::iteration() (??:0)
[17] OS_LinuxBSD::run() (??:0)
[18] bin/godot.linuxbsd.editor.dev.x86_64.san(main+0x339) [0x5601ba3b4c72] (??:0)
[19] /usr/lib/libc.so.6(+0x23290) [0x7f4f1f811290] (??:0)
[20] /usr/lib/libc.so.6(__libc_start_main+0x8a) [0x7f4f1f81134a] (??:0)
[21] bin/godot.linuxbsd.editor.dev.x86_64.san(_start+0x25) [0x5601ba3b4865] (??:0)
-- END OF BACKTRACE --
================================================================
```
</details>

This PR adds a null check for the SceneTree singleton and merges the `queue_delete()` calls.