### PR TITLE
[3.x] Allow extending virtual nodes

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -531,6 +531,13 @@ bool ClassDB::can_instance(const StringName &p_class) {
 #endif
 	return (!ti->disabled && ti->creation_func != nullptr);
 }
+bool ClassDB::is_virtual_node(const StringName &p_class) {
+	OBJTYPE_RLOCK;
+
+	ClassInfo *ti = classes.getptr(p_class);
+	ERR_FAIL_COND_V_MSG(!ti, false, "Cannot get class '" + String(p_class) + "'.");
+	return (ti->virtual_node);
+}
 
 void ClassDB::_add_class2(const StringName &p_class, const StringName &p_inherits) {
 	OBJTYPE_WLOCK;

--- a/core/class_db.h
+++ b/core/class_db.h
@@ -127,6 +127,7 @@ public:
 		StringName name;
 		bool disabled;
 		bool exposed;
+		bool virtual_node;
 		Object *(*creation_func)();
 		ClassInfo();
 		~ClassInfo();
@@ -191,6 +192,20 @@ public:
 	}
 
 	template <class T>
+	static void register_virtual_node() {
+		GLOBAL_LOCK_FUNCTION;
+		T::initialize_class();
+		ClassInfo *t = classes.getptr(T::get_class_static());
+		ERR_FAIL_COND(!t);
+		t->creation_func = &creator<T>;
+		t->exposed = true;
+		t->class_ptr = T::get_class_ptr_static();
+		T::register_custom_data_to_otdb();
+		t->virtual_node = true;
+		//nothing
+	}
+
+	template <class T>
 	static Object *_create_ptr_func() {
 		return T::create();
 	}
@@ -215,6 +230,7 @@ public:
 	static bool class_exists(const StringName &p_class);
 	static bool is_parent_class(const StringName &p_class, const StringName &p_inherits);
 	static bool can_instance(const StringName &p_class);
+	static bool is_virtual_node(const StringName &p_class);
 	static Object *instance(const StringName &p_class);
 	static APIType get_api_type(const StringName &p_class);
 

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -179,7 +179,7 @@ void CreateDialog::add_type(const String &p_type, HashMap<String, TreeItem *> &p
 		}
 	}
 
-	bool can_instance = (cpp_type && ClassDB::can_instance(p_type)) || ScriptServer::is_global_class(p_type);
+	bool can_instance = (cpp_type && ClassDB::can_instance(p_type) && !ClassDB::is_virtual_node(p_type)) || ScriptServer::is_global_class(p_type);
 
 	TreeItem *item = search_options->create_item(parent);
 	if (cpp_type) {

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -451,6 +451,8 @@ EditorPlugin *EditorData::get_editor_plugin(int p_idx) {
 
 void EditorData::add_custom_type(const String &p_type, const String &p_inherits, const Ref<Script> &p_script, const Ref<Texture> &p_icon) {
 	ERR_FAIL_COND_MSG(p_script.is_null(), "It's not a reference to a valid Script object.");
+	ERR_FAIL_COND_MSG(!ClassDB::class_exists(p_inherits), "class" + p_inherits + " does not exist");
+	ERR_FAIL_COND_MSG(!ClassDB::can_instance(p_inherits), p_inherits + " can not be inherited for custom type");
 	CustomType ct;
 	ct.name = p_type;
 	ct.icon = p_icon;

--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -183,6 +183,10 @@ void Joint2D::_notification(int p_what) {
 	}
 }
 
+RID Joint2D::_configure_joint(PhysicsBody2D *body_a, PhysicsBody2D *body_b) {
+	return RID();
+}
+
 void Joint2D::set_bias(real_t p_bias) {
 	bias = p_bias;
 	if (joint.is_valid()) {

--- a/scene/2d/joints_2d.h
+++ b/scene/2d/joints_2d.h
@@ -54,7 +54,7 @@ protected:
 	void _update_joint(bool p_only_free = false);
 
 	void _notification(int p_what);
-	virtual RID _configure_joint(PhysicsBody2D *body_a, PhysicsBody2D *body_b) = 0;
+	virtual RID _configure_joint(PhysicsBody2D *body_a, PhysicsBody2D *body_b);
 
 	static void _bind_methods();
 

--- a/scene/3d/cull_instance.h
+++ b/scene/3d/cull_instance.h
@@ -60,7 +60,7 @@ public:
 	CullInstance();
 
 protected:
-	virtual void _refresh_portal_mode() = 0;
+	virtual void _refresh_portal_mode(){};
 
 	static void _bind_methods();
 

--- a/scene/3d/physics_joint.cpp
+++ b/scene/3d/physics_joint.cpp
@@ -193,6 +193,10 @@ void Joint::_notification(int p_what) {
 	}
 }
 
+RID Joint::_configure_joint(PhysicsBody *body_a, PhysicsBody *body_b) {
+	return RID();
+}
+
 void Joint::set_exclude_nodes_from_collision(bool p_enable) {
 	if (exclude_from_collision == p_enable) {
 		return;

--- a/scene/3d/physics_joint.h
+++ b/scene/3d/physics_joint.h
@@ -55,7 +55,7 @@ protected:
 
 	void _notification(int p_what);
 
-	virtual RID _configure_joint(PhysicsBody *body_a, PhysicsBody *body_b) = 0;
+	virtual RID _configure_joint(PhysicsBody *body_a, PhysicsBody *body_b);
 
 	static void _bind_methods();
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -438,6 +438,10 @@ SpatialMaterial::BillboardMode SpriteBase3D::get_billboard_mode() const {
 	return billboard_mode;
 }
 
+Rect2 SpriteBase3D::get_item_rect() const {
+	return Rect2();
+}
+
 void SpriteBase3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_centered", "centered"), &SpriteBase3D::set_centered);
 	ClassDB::bind_method(D_METHOD("is_centered"), &SpriteBase3D::is_centered);

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -93,7 +93,7 @@ protected:
 	Color _get_color_accum();
 	void _notification(int p_what);
 	static void _bind_methods();
-	virtual void _draw() = 0;
+	virtual void _draw(){};
 	void draw_texture_rect(Ref<Texture> p_texture, Rect2 p_dst_rect, Rect2 p_src_rect);
 	_FORCE_INLINE_ void set_aabb(const AABB &p_aabb) { aabb = p_aabb; }
 	_FORCE_INLINE_ RID &get_mesh() { return mesh; }
@@ -142,7 +142,7 @@ public:
 	void set_billboard_mode(SpatialMaterial::BillboardMode p_mode);
 	SpatialMaterial::BillboardMode get_billboard_mode() const;
 
-	virtual Rect2 get_item_rect() const = 0;
+	virtual Rect2 get_item_rect() const;
 
 	virtual AABB get_aabb() const;
 	virtual PoolVector<Face3> get_faces(uint32_t p_usage_flags) const;

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -34,6 +34,14 @@
 #include "servers/visual_server.h"
 #include "skeleton.h"
 
+AABB VisualInstance::get_aabb() const {
+	return AABB();
+}
+
+PoolVector<Face3> VisualInstance::get_faces(uint32_t p_usage_flags) const {
+	return PoolVector<Face3>();
+}
+
 AABB VisualInstance::get_transformed_aabb() const {
 	return get_global_transform().xform(get_aabb());
 }

--- a/scene/3d/visual_instance.h
+++ b/scene/3d/visual_instance.h
@@ -65,8 +65,8 @@ public:
 	};
 
 	RID get_instance() const;
-	virtual AABB get_aabb() const = 0;
-	virtual PoolVector<Face3> get_faces(uint32_t p_usage_flags) const = 0;
+	virtual AABB get_aabb() const;
+	virtual PoolVector<Face3> get_faces(uint32_t p_usage_flags) const;
 
 	virtual AABB get_transformed_aabb() const; // helper
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -295,7 +295,7 @@ void register_scene_types() {
 
 	/* REGISTER GUI */
 	ClassDB::register_class<ButtonGroup>();
-	ClassDB::register_virtual_class<BaseButton>();
+	ClassDB::register_virtual_node<BaseButton>();
 
 	OS::get_singleton()->yield(); //may take time to init
 
@@ -303,11 +303,11 @@ void register_scene_types() {
 	ClassDB::register_class<Control>();
 	ClassDB::register_class<Button>();
 	ClassDB::register_class<Label>();
-	ClassDB::register_virtual_class<ScrollBar>();
+	ClassDB::register_virtual_node<ScrollBar>();
 	ClassDB::register_class<HScrollBar>();
 	ClassDB::register_class<VScrollBar>();
 	ClassDB::register_class<ProgressBar>();
-	ClassDB::register_virtual_class<Slider>();
+	ClassDB::register_virtual_node<Slider>();
 	ClassDB::register_class<HSlider>();
 	ClassDB::register_class<VSlider>();
 	ClassDB::register_class<Popup>();
@@ -318,7 +318,7 @@ void register_scene_types() {
 	ClassDB::register_class<ToolButton>();
 	ClassDB::register_class<LinkButton>();
 	ClassDB::register_class<Panel>();
-	ClassDB::register_virtual_class<Range>();
+	ClassDB::register_virtual_node<Range>();
 
 	OS::get_singleton()->yield(); //may take time to init
 
@@ -329,19 +329,19 @@ void register_scene_types() {
 	ClassDB::register_class<AspectRatioContainer>();
 	ClassDB::register_class<TabContainer>();
 	ClassDB::register_class<Tabs>();
-	ClassDB::register_virtual_class<Separator>();
+	ClassDB::register_virtual_node<Separator>();
 	ClassDB::register_class<HSeparator>();
 	ClassDB::register_class<VSeparator>();
 	ClassDB::register_class<TextureButton>();
 	ClassDB::register_class<Container>();
-	ClassDB::register_virtual_class<BoxContainer>();
+	ClassDB::register_virtual_node<BoxContainer>();
 	ClassDB::register_class<HBoxContainer>();
 	ClassDB::register_class<VBoxContainer>();
 	ClassDB::register_class<GridContainer>();
 	ClassDB::register_class<CenterContainer>();
 	ClassDB::register_class<ScrollContainer>();
 	ClassDB::register_class<PanelContainer>();
-	ClassDB::register_virtual_class<FlowContainer>();
+	ClassDB::register_virtual_node<FlowContainer>();
 	ClassDB::register_class<HFlowContainer>();
 	ClassDB::register_class<VFlowContainer>();
 
@@ -376,7 +376,7 @@ void register_scene_types() {
 	ClassDB::register_class<ConfirmationDialog>();
 	ClassDB::register_class<MarginContainer>();
 	ClassDB::register_class<ViewportContainer>();
-	ClassDB::register_virtual_class<SplitContainer>();
+	ClassDB::register_virtual_node<SplitContainer>();
 	ClassDB::register_class<HSplitContainer>();
 	ClassDB::register_class<VSplitContainer>();
 	ClassDB::register_class<GraphNode>();
@@ -428,9 +428,9 @@ void register_scene_types() {
 	OS::get_singleton()->yield(); //may take time to init
 
 #ifndef _3D_DISABLED
-	ClassDB::register_virtual_class<VisualInstance>();
-	ClassDB::register_virtual_class<CullInstance>();
-	ClassDB::register_virtual_class<GeometryInstance>();
+	ClassDB::register_virtual_node<VisualInstance>();
+	ClassDB::register_virtual_node<CullInstance>();
+	ClassDB::register_virtual_node<GeometryInstance>();
 	ClassDB::register_class<Camera>();
 	ClassDB::register_class<ClippedCamera>();
 	ClassDB::register_class<Listener>();
@@ -441,7 +441,7 @@ void register_scene_types() {
 	ClassDB::register_class<InterpolatedCamera>();
 	ClassDB::register_class<MeshInstance>();
 	ClassDB::register_class<ImmediateGeometry>();
-	ClassDB::register_virtual_class<SpriteBase3D>();
+	ClassDB::register_virtual_node<SpriteBase3D>();
 	ClassDB::register_class<Sprite3D>();
 	ClassDB::register_class<AnimatedSprite3D>();
 	ClassDB::register_class<Label3D>();
@@ -503,7 +503,7 @@ void register_scene_types() {
 	ClassDB::register_class<WorldEnvironment>();
 	ClassDB::register_class<RemoteTransform>();
 
-	ClassDB::register_virtual_class<Joint>();
+	ClassDB::register_virtual_node<Joint>();
 	ClassDB::register_class<PinJoint>();
 	ClassDB::register_class<HingeJoint>();
 	ClassDB::register_class<SliderJoint>();
@@ -629,7 +629,7 @@ void register_scene_types() {
 
 	ClassDB::register_class<Camera2D>();
 	ClassDB::register_class<Listener2D>();
-	ClassDB::register_virtual_class<Joint2D>();
+	ClassDB::register_virtual_node<Joint2D>();
 	ClassDB::register_class<PinJoint2D>();
 	ClassDB::register_class<GrooveJoint2D>();
 	ClassDB::register_class<DampedSpringJoint2D>();


### PR DESCRIPTION
Allow plugins to extend most of the virtual node classes for custom types
Allow editor create dialog to list custom types of virtual nodes

3.X since the class handling changed a lot and my need was for 3.X projects and its editor which will stay relevant for a long time to come; can look into doing similar for 4 at a later time if there is interest

| Name | Exposed(Y/N) |
| ---- | ------------ |
| CanvasItem | N |
| BoxContainer | Y |
| FlowContainer | Y |
| SplitContainer | Y |
| BaseButton | Y |
| Range | Y |
| ScrollBar | Y |
| Slider | Y |
| Seperator | Y |
| CollisionObject2D | N? |
| Joint2D | Y |
| CullInstance | Y |
| VisualInstance | Y |
| GeometryInstance | Y |
| SpriteBase3D | Y |
| CSGShape | N |
| CSGPrimitive | N |
| Light | N? |
| CollisionObject | N? |
| PhysicsBody | N |
| Joint | Y |

Note: the N? are because they are not currently exposed but I think it would be possible if someone else wanted to dive deeper into the code to allow them

Closes https://github.com/godotengine/godot-proposals/issues/5644