### PR TITLE
Correctly set number of particle dispatches when setting view axis

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1220,7 +1220,9 @@ void ParticlesStorage::particles_set_view_axis(RID p_particles, const Vector3 &p
 		RendererCompositorRD::singleton->get_effects()->sort_buffer(particles->particles_sort_uniform_set, particles->amount);
 	}
 
-	copy_push_constant.total_particles *= copy_push_constant.total_particles;
+	if (particles->trails_enabled && particles->trail_bind_poses.size() > 1) {
+		copy_push_constant.total_particles *= particles->trail_bind_poses.size();
+	}
 
 	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
 	uint32_t copy_pipeline = do_sort ? ParticlesShader::COPY_MODE_FILL_INSTANCES_WITH_SORT_BUFFER : ParticlesShader::COPY_MODE_FILL_INSTANCES;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/67717

The issue was that we were sending a number of dispatches equal to amount * amount which quickly became way too many. With this PR we only send as many dispatches as we need. 

The multiplier I use here matches the multiplier used for the other copy operation:
https://github.com/godotengine/godot/blob/2b505b74b9b0a7005586ecaa9aa1236e86b18437/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp#L1462-L1464