### PR TITLE
Overhaul Object's Documentation

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -1,33 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Object" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Base class for all non-built-in types.
+		Base class for all other classes in the engine.
 	</brief_description>
 	<description>
-		Every class which is not a built-in type inherits from this class.
-		You can construct Objects from scripting languages, using [code]Object.new()[/code] in GDScript, or [code]new Object[/code] in C#.
-		Objects do not manage memory. If a class inherits from Object, you will have to delete instances of it manually. To do so, call the [method free] method from your script or delete the instance from C++.
-		Some classes that extend Object add memory management. This is the case of [RefCounted], which counts references and deletes itself automatically when no longer referenced. [Node], another fundamental type, deletes all its children when freed from memory.
-		Objects export properties, which are mainly useful for storage and editing, but not really so much in programming. Properties are exported in [method _get_property_list] and handled in [method _get] and [method _set]. However, scripting languages and C++ have simpler means to export them.
-		Property membership can be tested directly in GDScript using [code]in[/code]:
-		[codeblocks]
-		[gdscript]
-		var n = Node2D.new()
-		print("position" in n) # Prints "true".
-		print("other_property" in n) # Prints "false".
-		[/gdscript]
-		[csharp]
-		var node = new Node2D();
-		// C# has no direct equivalent to GDScript's `in` operator here, but we
-		// can achieve the same behavior by performing `Get` with a null check.
-		GD.Print(node.Get("position") != null); // Prints "true".
-		GD.Print(node.Get("other_property") != null); // Prints "false".
-		[/csharp]
-		[/codeblocks]
-		The [code]in[/code] operator will evaluate to [code]true[/code] as long as the key exists, even if the value is [code]null[/code].
-		Objects also receive notifications. Notifications are a simple way to notify the object about different events, so they can all be handled together. See [method _notification].
-		[b]Note:[/b] Unlike references to a [RefCounted], references to an Object stored in a variable can become invalid without warning. Therefore, it's recommended to use [RefCounted] for data classes instead of [Object].
-		[b]Note:[/b] The [code]script[/code] property is not exposed like most properties, but it does have a setter and getter ([code]set_script()[/code] and [code]get_script()[/code]).
+		An advanced [Variant] type. All classes in the engine inherit from Object. Each class may define new properties, methods or signals, which are available to all inheriting classes. For example, a [Sprite2D] instance is able to call [method Node.add_child] because it inherits from [Node].
+		You can create new instances, using [code]Object.new()[/code] in GDScript, or [code]new Object[/code] in C#.
+		To delete an Object instance, call [method free]. This is necessary for most classes inheriting Object, because they do not manage memory on their own, and will otherwise cause memory leaks when no longer in use. There are a few classes that perform memory management. For example, [RefCounted] (and by extension [Resource]) deletes itself when no longer referenced, and [Node] deletes its children when freed.
+		Objects can have a [Script] attached to them. Once the [Script] is instantiated, it effectively acts as an extension to the base class, allowing it to define and inherit new properties, methods and signals.
+		Inside a [Script], [method _get_property_list] may be overriden to customize properties in several ways. This allows them to be available to the editor, display as lists of options, sub-divide into groups, save on disk, etc. Scripting languages offer easier ways to customize properties, such as with the [annotation @GDScript.@export] annotation.
+		Godot is very dynamic. An object's script, and therefore its properties, methods and signals, can be changed at run-time. Because of this, there can be occasions where, for example, a property required by a method may not exist. To prevent run-time errors, see methods such as [method set], [method get], [method call], [method has_method], [method has_signal], etc. Note that these methods are [b]much[/b] slower than direct references.
+		In GDScript, you can also check if a given property, method, or signal name exists in an object with the [code]in[/code] operator:
+		[codeblock]
+		var node = Node.new()
+		print("name" in node)         # Prints true
+		print("get_parent" in node)   # Prints true
+		print("tree_entered" in node) # Prints true
+		print("unknown" in node)      # Prints false
+		[/codeblock]
+		Notifications are [int] constants commonly sent and received by objects. For example, on every rendered frame, the [SceneTree] notifies nodes inside the tree with a [constant Node.NOTIFICATION_PROCESS]. The nodes receive it and may call [method Node._process] to update. To make use of notifications, see [method notification] and [method _notification].
+		Lastly, every object can also contain metadata (data about data). [method set_meta] can be useful to store information that the object itself does not depend on. To keep your code clean, making excessive use of metadata is discouraged.
+		[b]Note:[/b] Unlike references to a [RefCounted], references to an object stored in a variable can become invalid without being set to [code]null[/code]. To check if an object has been deleted, do [i]not[/i] compare it against [code]null[/code]. Instead, use [method @GlobalScope.is_instance_valid]. It's also recommended to inherit from [RefCounted] for classes storing data instead of [Object].
+		[b]Note:[/b] The [code]script[/code] is not exposed like most properties. To set or get an object's [Script] in code, use [method set_script] and [method get_script], respectively.
 	</description>
 	<tutorials>
 		<link title="When and how to avoid using nodes for everything">$DOCS_URL/tutorials/best_practices/node_alternatives.html</link>
@@ -38,46 +32,93 @@
 			<return type="Variant" />
 			<param index="0" name="property" type="StringName" />
 			<description>
-				Virtual method which can be overridden to customize the return value of [method get].
-				Returns the given property. Returns [code]null[/code] if the [param property] does not exist.
+				Override this method to customize the behavior of [method get]. Should return the given [param property]'s value, or [code]null[/code] if the [param property] should be handled normally.
+				Combined with [method _set] and [method _get_property_list], this method allows defining custom properties, which is particularly useful for editor plugins. Note that a property must be present in [method get_property_list], otherwise this method will not be called.
+				[codeblock]
+				func _get(property):
+				    if (property == "fake_property"):
+				        print("Getting my property!")
+				        return 4
+
+				func _get_property_list():
+				    return [
+				        { "name": "fake_property", "type": TYPE_INT }
+				    ]
+				[/codeblock]
 			</description>
 		</method>
 		<method name="_get_property_list" qualifiers="virtual">
 			<return type="Dictionary[]" />
 			<description>
-				Virtual method which can be overridden to customize the return value of [method get_property_list].
-				Returns the object's property list as an [Array] of dictionaries.
-				Each property's [Dictionary] must contain at least [code]name: String[/code] and [code]type: int[/code] (see [enum Variant.Type]) entries. Optionally, it can also include [code]hint: int[/code] (see [enum PropertyHint]), [code]hint_string: String[/code], and [code]usage: int[/code] (see [enum PropertyUsageFlags]).
+				Override this method to customize how script properties should be handled by the engine.
+				Should return a property list, as an [Array] of dictionaries. The result is added to the array of [method get_property_list], and should be formatted in the same way. Each [Dictionary] must at least contain the [code]name[/code] and [code]type[/code] entries.
+				The example below displays [code]hammer_type[/code] in the Inspector dock, only if [code]holding_hammer[/code] is [code]true[/code]:
+				[codeblock]
+				@tool
+				extends Node2D
+
+				@export var holding_hammer = false:
+				    set(value):
+				        holding_hammer = value
+				        notify_property_list_changed()
+				var hammer_type = 0
+
+				func _get_property_list():
+				    # By default, `hammer_type` is not visible in the editor.
+				    var property_usage = PROPERTY_USAGE_NO_EDITOR
+
+				    if holding_hammer:
+				        property_usage = PROPERTY_USAGE_DEFAULT
+
+				    var properties = []
+				    properties.append({
+				        "name": "hammer_type",
+				        "type": TYPE_INT,
+				        "usage": property_usage, # See above assignment.
+				        "hint": PROPERTY_HINT_ENUM,
+				        "hint_string": "Wooden,Iron,Golden,Enchanted"
+				    })
+
+				    return properties
+				[/codeblock]
+				[b]Note:[/b] This method is intended for advanced purposes. For most common use cases, the scripting languages offer easier ways to handle properties. See [annotation @GDScript.@export], [annotation @GDScript.@export_enum], [annotation @GDScript.@export_group], etc.
+				[b]Note:[/b] If the object's script is not [annotation @GDScript.@tool], this method will not be called in the editor.
 			</description>
 		</method>
 		<method name="_init" qualifiers="virtual">
 			<return type="void" />
 			<description>
-				Called when the object is initialized in memory. Can be defined to take in parameters, that are passed in when constructing.
-				[b]Note:[/b] If [method _init] is defined with required parameters, then explicit construction is the only valid means of creating an Object of the class. If any other means (such as [method PackedScene.instantiate]) is used, then initialization will fail.
+				Called when the object's script is instantiated, oftentimes after the object is initialized in memory (through [code]Object.new()[/code] in GDScript, or [code]new Object[/code] in C#). It can be also defined to take in parameters. This method is similar to a constructor in most programming languages.
+				[b]Note:[/b] If [method _init] is defined with [i]required[/i] parameters, the Object with script may only be created directly. If any other means (such as [method PackedScene.instantiate] or [method Node.duplicate]) are used, the script's initialization will fail.
 			</description>
 		</method>
 		<method name="_notification" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="what" type="int" />
 			<description>
-				Called whenever the object receives a notification, which is identified in [param what] by a constant. The base [Object] has two constants [constant NOTIFICATION_POSTINITIALIZE] and [constant NOTIFICATION_PREDELETE], but subclasses such as [Node] define a lot more notifications which are also received by this method.
+				Called when the object receives a notification, which can be identified in [param what] by comparing it with a constant. See also [method notification].
+				[codeblock]
+				func _notification(what):
+				    if what == NOTIFICATION_PREDELETE:
+				        print("Goodbye!")
+				[/codeblock]
+				[b]Note:[/b] The base [Object] defines a few notifications ([constant NOTIFICATION_POSTINITIALIZE] and [constant NOTIFICATION_PREDELETE]). Inheriting classes such as [Node] define a lot more notifications, which are also received by this method.
 			</description>
 		</method>
 		<method name="_property_can_revert" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="property" type="StringName" />
 			<description>
-				Virtual methods that can be overridden to customize the property revert behavior in the editor.
-				Returns [code]true[/code] if the property identified by [code]name[/code] can be reverted to a default value. Override [method _property_get_revert] to return the actual value.
+				Override this method to customize the given [param property]'s revert behavior. Should return [code]true[/code] if the [param property] can be reverted in the Inspector dock. Use [method _property_get_revert] to specify the [param property]'s default value.
+				[b]Note:[/b] This method must return consistently, regardless of the current value of the [param property].
 			</description>
 		</method>
 		<method name="_property_get_revert" qualifiers="virtual">
 			<return type="Variant" />
 			<param index="0" name="property" type="StringName" />
 			<description>
-				Virtual methods that can be overridden to customize the property revert behavior in the editor.
-				Returns the default value of the property identified by [code]name[/code]. [method _property_can_revert] must be overridden as well for this method to be called.
+				Override this method to customize the given [param property]'s revert behavior. Should return the default value for the [param property]. If the default value differs from the [param property]'s current value, a revert icon is displayed in the Inspector dock.
+				[b]Note:[/b] [method _property_can_revert] must also be overridden for this method to be called.
 			</description>
 		</method>
 		<method name="_set" qualifiers="virtual">
@@ -85,15 +126,32 @@
 			<param index="0" name="property" type="StringName" />
 			<param index="1" name="value" type="Variant" />
 			<description>
-				Virtual method which can be overridden to customize the return value of [method set].
-				Sets a property. Returns [code]true[/code] if the [param property] exists.
+				Override this method to customize the behavior of [method set]. Should set the [param property] to [param value] and return [code]true[/code], or [code]false[/code] if the [param property] should be handled normally. The [i]exact[/i] way to set the [param property] is up to this method's implementation.
+				Combined with [method _get] and [method _get_property_list], this method allows defining custom properties, which is particularly useful for editor plugins. Note that a property [i]must[/i] be present in [method get_property_list], otherwise this method will not be called.
+				[codeblock]
+				func _set(property, value):
+				    if (property == "fake_property"):
+				        print("Setting my property to ", value)
+
+				func _get_property_list():
+				    return [
+				        { "name": "fake_property", "type": TYPE_INT }
+				    ]
+				[/codeblock]
 			</description>
 		</method>
 		<method name="_to_string" qualifiers="virtual">
 			<return type="String" />
 			<description>
-				Virtual method which can be overridden to customize the return value of [method to_string], and thus the object's representation where it is converted to a string, e.g. with [code]print(obj)[/code].
-				Returns a [String] representing the object. If not overridden, defaults to [code]"[ClassName:RID]"[/code].
+				Override this method to customize the return value of [method to_string], and therefore the object's representation as a [String].
+				[codeblock]
+				func _to_string():
+				    return "Welcome to Godot 4!"
+
+				func _init():
+				    print(self)       # Prints Welcome to Godot 4!"
+				    var a = str(self) # a is "Welcome to Godot 4!"
+				[/codeblock]
 			</description>
 		</method>
 		<method name="add_user_signal">
@@ -101,15 +159,20 @@
 			<param index="0" name="signal" type="String" />
 			<param index="1" name="arguments" type="Array" default="[]" />
 			<description>
-				Adds a user-defined [param signal]. Arguments are optional, but can be added as an [Array] of dictionaries, each containing [code]name: String[/code] and [code]type: int[/code] (see [enum Variant.Type]) entries.
+				Adds a user-defined [param signal]. Optional arguments for the signal can be added as an [Array] of dictionaries, each defining a [code]name[/code] [String] and a [code]type[/code] [int] (see [enum Variant.Type]). See also [method has_user_signal].
+				[codeblock]
+				add_user_signal("hurt", [
+				    { "name": "damage", "type": TYPE_INT },
+				    { "name": "source", "type": TYPE_OBJECT }
+				])
+				[/codeblock]
 			</description>
 		</method>
 		<method name="call" qualifiers="vararg">
 			<return type="Variant" />
 			<param index="0" name="method" type="StringName" />
 			<description>
-				Calls the [param method] on the object and returns the result. This method supports a variable number of arguments, so parameters are passed as a comma separated list.
-				[b]Example:[/b]
+				Calls the [param method] on the object and returns the result. This method supports a variable number of arguments, so parameters can be passed as a comma separated list.
 				[codeblocks]
 				[gdscript]
 				var node = Node3D.new()
@@ -120,15 +183,14 @@
 				node.Call("rotate", new Vector3(1f, 0f, 0f), 1.571f);
 				[/csharp]
 				[/codeblocks]
-				[b]Note:[/b] In C#, the method name must be specified as snake_case if it is defined by a built-in Godot node. This doesn't apply to user-defined methods where you should use the same convention as in the C# source (typically PascalCase).
+				[b]Note:[/b] In C#, [param method] must be in snake_case when referring to built-in Godot methods.
 			</description>
 		</method>
 		<method name="call_deferred" qualifiers="vararg">
 			<return type="Variant" />
 			<param index="0" name="method" type="StringName" />
 			<description>
-				Calls the [param method] on the object during idle time. This method supports a variable number of arguments, so parameters are passed as a comma separated list.
-				[b]Example:[/b]
+				Calls the [param method] on the object during idle time. This method supports a variable number of arguments, so parameters can be passed as a comma separated list.
 				[codeblocks]
 				[gdscript]
 				var node = Node3D.new()
@@ -139,7 +201,7 @@
 				node.CallDeferred("rotate", new Vector3(1f, 0f, 0f), 1.571f);
 				[/csharp]
 				[/codeblocks]
-				[b]Note:[/b] In C#, the method name must be specified as snake_case if it is defined by a built-in Godot node. This doesn't apply to user-defined methods where you should use the same convention as in the C# source (typically PascalCase).
+				[b]Note:[/b] In C#, [param method] must be in snake_case when referring to built-in Godot methods.
 			</description>
 		</method>
 		<method name="callv">
@@ -147,7 +209,7 @@
 			<param index="0" name="method" type="StringName" />
 			<param index="1" name="arg_array" type="Array" />
 			<description>
-				Calls the [param method] on the object and returns the result. Contrarily to [method call], this method does not support a variable number of arguments but expects all parameters to be via a single [Array].
+				Calls the [param method] on the object and returns the result. Unlike [method call], this method expects all parameters to be contained inside [param arg_array].
 				[codeblocks]
 				[gdscript]
 				var node = Node3D.new()
@@ -158,12 +220,13 @@
 				node.Callv("rotate", new Godot.Collections.Array { new Vector3(1f, 0f, 0f), 1.571f });
 				[/csharp]
 				[/codeblocks]
+				[b]Note:[/b] In C#, [param method] must be in snake_case when referring to built-in Godot methods.
 			</description>
 		</method>
 		<method name="can_translate_messages" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the object can translate strings. See [method set_message_translation] and [method tr].
+				Returns [code]true[/code] if the object is allowed to translate messages with [method tr] and [method tr_n]. See also [method set_message_translation].
 			</description>
 		</method>
 		<method name="connect">
@@ -172,23 +235,23 @@
 			<param index="1" name="callable" type="Callable" />
 			<param index="2" name="flags" type="int" default="0" />
 			<description>
-				Connects a [param signal] to a [param callable]. Use [param flags] to set deferred or one-shot connections. See [enum ConnectFlags] constants.
-				A signal can only be connected once to a [Callable]. It will print an error if already connected, unless the signal was connected with [constant CONNECT_REFERENCE_COUNTED]. To avoid this, first, use [method is_connected] to check for existing connections.
-				If the callable's target is destroyed in the game's lifecycle, the connection will be lost.
+				Connects a [param signal] by name to a [param callable]. Optional [param flags] can be also added to configure the connection's behavior (see [enum ConnectFlags] constants).
+				A signal can only be connected once to the same [Callable]. If the signal is already connected, this method returns [constant ERR_INVALID_PARAMETER] and pushes an error message, unless the signal is connected with [constant CONNECT_REFERENCE_COUNTED]. To prevent this, use [method is_connected] first to check for existing connections.
+				If the [param callable]'s object is freed, the connection will be lost.
 				[b]Examples with recommended syntax:[/b]
-				Connecting signals is one of the most common operations in Godot and the API gives many options to do so, which are described further down. The code block below shows the recommended approach for both GDScript and C#.
+				Connecting signals is one of the most common operations in Godot and the API gives many options to do so, which are described further down. The code block below shows the recommended approach.
 				[codeblocks]
 				[gdscript]
 				func _ready():
 				    var button = Button.new()
-				    # `button_down` here is a Signal object, and we thus call the Signal.connect() method,
-				    # not Object.connect(). See discussion below for a more in-depth overview of the API.
+				    # `button_down` here is a Signal variant type, and we thus call the Signal.connect() method, not Object.connect().
+				    # See discussion below for a more in-depth overview of the API.
 				    button.button_down.connect(_on_button_down)
 
-				    # This assumes that a `Player` class exists which defines a `hit` signal.
+				    # This assumes that a `Player` class exists, which defines a `hit` signal.
 				    var player = Player.new()
-				    # We use Signal.connect() again, and we also use the Callable.bind() method which
-				    # returns a new Callable with the parameter binds.
+				    # We use Signal.connect() again, and we also use the Callable.bind() method,
+				    # which returns a new Callable with the parameter binds.
 				    player.hit.connect(_on_player_hit.bind("sword", 100))
 
 				func _on_button_down():
@@ -204,7 +267,7 @@
 				    // C# supports passing signals as events, so we can use this idiomatic construct:
 				    button.ButtonDown += OnButtonDown;
 
-				    // This assumes that a `Player` class exists which defines a `Hit` signal.
+				    // This assumes that a `Player` class exists, which defines a `Hit` signal.
 				    var player = new Player();
 				    // Signals as events (`player.Hit += OnPlayerHit;`) do not support argument binding. You have to use:
 				    player.Hit.Connect(OnPlayerHit, new Godot.Collections.Array {"sword", 100 });
@@ -261,44 +324,41 @@
 				}
 				[/csharp]
 				[/codeblocks]
-				While all options have the same outcome ([code]button[/code]'s [signal BaseButton.button_down] signal will be connected to [code]_on_button_down[/code]), option 3 offers the best validation: it will print a compile-time error if either the [code]button_down[/code] signal or the [code]_on_button_down[/code] callable are undefined. On the other hand, option 2 only relies on string names and will only be able to validate either names at runtime: it will print a runtime error if [code]"button_down"[/code] doesn't correspond to a signal, or if [code]"_on_button_down"[/code] is not a registered method in the object [code]self[/code]. The main reason for using options 1, 2, or 4 would be if you actually need to use strings (e.g. to connect signals programmatically based on strings read from a configuration file). Otherwise, option 3 is the recommended (and fastest) method.
-				[b]Parameter bindings and passing:[/b]
-				For legacy or language-specific reasons, there are also several ways to bind parameters to signals. One can pass a [code]binds[/code] [Array] to [method Object.connect] or [method Signal.connect], or use the recommended [method Callable.bind] method to create a new callable from an existing one, with the given parameter binds.
-				One can also pass additional parameters when emitting the signal with [method emit_signal]. The examples below show the relationship between those two types of parameters.
+				While all options have the same outcome ([code]button[/code]'s [signal BaseButton.button_down] signal will be connected to [code]_on_button_down[/code]), [b]option 3[/b] offers the best validation: it will print a compile-time error if either the [code]button_down[/code] [Signal] or the [code]_on_button_down[/code] [Callable] are not defined. On the other hand, [b]option 2[/b] only relies on string names and will only be able to validate either names at runtime: it will print a runtime error if [code]"button_down"[/code] doesn't correspond to a signal, or if [code]"_on_button_down"[/code] is not a registered method in the object [code]self[/code]. The main reason for using options 1, 2, or 4 would be if you actually need to use strings (e.g. to connect signals programmatically based on strings read from a configuration file). Otherwise, option 3 is the recommended (and fastest) method.
+				[b]Binding and passing parameters:[/b]
+				The syntax to bind parameters is through [method Callable.bind], which returns a copy of the [Callable] with its parameters bound.
+				When calling [method emit_signal], the signal parameters can be also passed. The examples below show the relationship between these signal parameters and bound parameters.
 				[codeblocks]
 				[gdscript]
 				func _ready():
-				    # This assumes that a `Player` class exists which defines a `hit` signal.
+				    # This assumes that a `Player` class exists, which defines a `hit` signal.
 				    var player = Player.new()
-				    # Option 1: Using Callable.bind().
 				    player.hit.connect(_on_player_hit.bind("sword", 100))
-				    # Option 2: Using a `binds` Array in Signal.connect() (same syntax for Object.connect()).
-				    player.hit.connect(_on_player_hit, ["sword", 100])
 
 				    # Parameters added when emitting the signal are passed first.
 				    player.emit_signal("hit", "Dark lord", 5)
 
-				# Four arguments, since we pass two when emitting (hit_by, level)
-				# and two when connecting (weapon_type, damage).
+				# We pass two arguments when emitting (`hit_by`, `level`),
+				# and bind two more arguments when connecting (`weapon_type`, `damage`).
 				func _on_player_hit(hit_by, level, weapon_type, damage):
 				    print("Hit by %s (level %d) with weapon %s for %d damage." % [hit_by, level, weapon_type, damage])
 				[/gdscript]
 				[csharp]
 				public override void _Ready()
 				{
-				    // This assumes that a `Player` class exists which defines a `Hit` signal.
+				    // This assumes that a `Player` class exists, which defines a `Hit` signal.
 				    var player = new Player();
 				    // Option 1: Using Callable.Bind(). This way we can still use signals as events.
 				    player.Hit += OnPlayerHit.Bind("sword", 100);
-				    // Option 2: Using a `binds` Array in Signal.Connect() (same syntax for Object.Connect()).
+				    // Option 2: Using a `binds` Array in Signal.Connect().
 				    player.Hit.Connect(OnPlayerHit, new Godot.Collections.Array{ "sword", 100 });
 
 				    // Parameters added when emitting the signal are passed first.
 				    player.EmitSignal("hit", "Dark lord", 5);
 				}
 
-				// Four arguments, since we pass two when emitting (hitBy, level)
-				// and two when connecting (weaponType, damage).
+				// We pass two arguments when emitting (`hit_by`, `level`),
+				// and bind two more arguments when connecting (`weapon_type`, `damage`).
 				private void OnPlayerHit(string hitBy, int level, string weaponType, int damage)
 				{
 				    GD.Print(String.Format("Hit by {0} (level {1}) with weapon {2} for {3} damage.", hitBy, level, weaponType, damage));
@@ -312,16 +372,15 @@
 			<param index="0" name="signal" type="StringName" />
 			<param index="1" name="callable" type="Callable" />
 			<description>
-				Disconnects a [param signal] from a given [param callable].
-				If you try to disconnect a connection that does not exist, the method will print an error. Use [method is_connected] to ensure that the connection exists.
+				Disconnects a [param signal] by name from a given [param callable]. If the connection does not exist, generates an error. Use [method is_connected] to make sure that the connection exists.
 			</description>
 		</method>
 		<method name="emit_signal" qualifiers="vararg">
 			<return type="int" enum="Error" />
 			<param index="0" name="signal" type="StringName" />
 			<description>
-				Emits the given [param signal]. The signal must exist, so it should be a built-in signal of this class or one of its parent classes, or a user-defined signal. This method supports a variable number of arguments, so parameters are passed as a comma separated list.
-				[b]Example:[/b]
+				Emits the given [param signal] by name. The signal must exist, so it should be a built-in signal of this class or one of its inherited classes, or a user-defined signal (see [method add_user_signal]). This method supports a variable number of arguments, so parameters can be passed as a comma separated list.
+				Returns [constant ERR_UNAVAILABLE] if [param signal] does not exist or the parameters are invalid.
 				[codeblocks]
 				[gdscript]
 				emit_signal("hit", "sword", 100)
@@ -337,32 +396,43 @@
 		<method name="free">
 			<return type="void" />
 			<description>
-				Deletes the object from memory. Any pre-existing reference to the freed object will become invalid, e.g. [code]is_instance_valid(object)[/code] will return [code]false[/code].
+				Deletes the object from memory. Pre-existing references to the object become invalid, and any attempt to access them will result in a run-time error. Checking the references with [method @GlobalScope.is_instance_valid] will return [code]false[/code].
 			</description>
 		</method>
 		<method name="get" qualifiers="const">
 			<return type="Variant" />
 			<param index="0" name="property" type="StringName" />
 			<description>
-				Returns the [Variant] value of the given [param property]. If the [param property] doesn't exist, this will return [code]null[/code].
-				[b]Note:[/b] In C#, the property name must be specified as snake_case if it is defined by a built-in Godot node. This doesn't apply to user-defined properties where you should use the same convention as in the C# source (typically PascalCase).
+				Returns the [Variant] value of the given [param property]. If the [param property] does not exist, this method returns [code]null[/code].
+				[codeblocks]
+				[gdscript]
+				var node = Node2D.new()
+				node.rotation = 1.5
+				var a = node.get("rotation") # a is 1.5
+				[/gdscript]
+				[csharp]
+				var node = new Node2D();
+				node.Rotation = 1.5f;
+				var a = node.Get("rotation"); // a is 1.5
+				[/csharp]
+				[/codeblocks]
+				[b]Note:[/b] In C#, [param property] must be in snake_case when referring to built-in Godot properties.
 			</description>
 		</method>
 		<method name="get_class" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the object's class as a [String]. See also [method is_class].
-				[b]Note:[/b] [method get_class] does not take [code]class_name[/code] declarations into account. If the object has a [code]class_name[/code] defined, the base class name will be returned instead.
+				Returns the object's built-in class name, as a [String]. See also [method is_class].
+				[b]Note:[/b] This method ignores [code]class_name[/code] declarations. If this object's script has defined a [code]class_name[/code], the base, built-in class name is returned instead.
 			</description>
 		</method>
 		<method name="get_incoming_connections" qualifiers="const">
 			<return type="Dictionary[]" />
 			<description>
-				Returns an [Array] of dictionaries with information about signals that are connected to the object.
-				Each [Dictionary] contains three String entries:
-				- [code]source[/code] is a reference to the signal emitter.
-				- [code]signal_name[/code] is the name of the connected signal.
-				- [code]method_name[/code] is the name of the method to which the signal is connected.
+				Returns an [Array] of signal connections received by this object. Each connection is represented as a [Dictionary] that contains three entries:
+				- [code]signal[/code] is a reference to the [Signal];
+				- [code]callable[/code] is a reference to the [Callable];
+				- [code]flags[/code] is a combination of [enum ConnectFlags].
 			</description>
 		</method>
 		<method name="get_indexed" qualifiers="const">
@@ -371,14 +441,28 @@
 			<description>
 				Gets the object's property indexed by the given [param property_path]. The path should be a [NodePath] relative to the current object and can use the colon character ([code]:[/code]) to access nested properties.
 				[b]Examples:[/b] [code]"position:x"[/code] or [code]"material:next_pass:blend_mode"[/code].
-				[b]Note:[/b] Even though the method takes [NodePath] argument, it doesn't support actual paths to [Node]s in the scene tree, only colon-separated sub-property paths. For the purpose of nodes, use [method Node.get_node_and_resource] instead.
+				[codeblocks]
+				[gdscript]
+				var node = Node2D.new()
+				node.position = Vector2(5, -10)
+				var a = node.get_indexed("position")   # a is Vector2(5, -10)
+				var b = node.get_indexed("position:y") # b is -10
+				[/gdscript]
+				[csharp]
+				var node = new Node2D();
+				node.Position = new Vector2(5, -10);
+				var a = node.GetIndexed("position");   # a is Vector2(5, -10)
+				var b = node.GetIndexed("position:y"); # b is -10
+				[/csharp]
+				[/codeblocks]
+				[b]Note:[/b] In C#, [param property_path] must be in snake_case when referring to built-in Godot properties.
+				[b]Note:[/b] This method does not support actual paths to nodes in the [SceneTree], only sub-property paths. In the context of nodes, use [method Node.get_node_and_resource] instead.
 			</description>
 		</method>
 		<method name="get_instance_id" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the object's unique instance ID.
-				This ID can be saved in [EncodedObjectAsID], and can be used to retrieve the object instance with [method @GlobalScope.instance_from_id].
+				Returns the object's unique instance ID. This ID can be saved in [EncodedObjectAsID], and can be used to retrieve this object instance with [method @GlobalScope.instance_from_id].
 			</description>
 		</method>
 		<method name="get_meta" qualifiers="const">
@@ -386,47 +470,62 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="default" type="Variant" default="null" />
 			<description>
-				Returns the object's metadata entry for the given [param name].
-				Throws error if the entry does not exist, unless [param default] is not [code]null[/code] (in which case the default value will be returned). See also [method has_meta], [method set_meta] and [method remove_meta].
-				[b]Note:[/b] Metadata that has a [param name] starting with an underscore ([code]_[/code]) is considered editor-only. Editor-only metadata is not displayed in the Inspector and should not be edited.
+				Returns the object's metadata value for the given entry [param name]. If the entry does not exist, returns [param default]. If [param default] is [code]null[/code], an error is also generated.
+				[b]Note:[/b] Metadata that has a [param name] starting with an underscore ([code]_[/code]) is considered editor-only. Editor-only metadata is not displayed in the Inspector dock and should not be edited.
 			</description>
 		</method>
 		<method name="get_meta_list" qualifiers="const">
 			<return type="PackedStringArray" />
 			<description>
-				Returns the object's metadata as a [PackedStringArray].
+				Returns the object's metadata entry names as a [PackedStringArray].
 			</description>
 		</method>
 		<method name="get_method_list" qualifiers="const">
 			<return type="Dictionary[]" />
 			<description>
-				Returns the object's methods and their signatures as an [Array].
+				Returns this object's methods and their signatures as an [Array] of dictionaries. Each [Dictionary] contains the following entries:
+				- [code]name[/code] is the name of the method, as a [String];
+				- [code]args[/code] is an [Array] of dictionaries representing the arguments;
+				- [code]default_args[/code] is the default arguments as an [Array] of variants;
+				- [code]flags[/code] is a combination of [enum MethodFlags];
+				- [code]id[/code] is the method's internal identifier [int];
+				- [code]return[/code] is the returned value, as a [Dictionary];
+				[b]Note:[/b] The dictionaries of [code]args[/code] and [code]return[/code] are formatted identically to the results of [method get_property_list], although not all entries are used.
 			</description>
 		</method>
 		<method name="get_property_list" qualifiers="const">
 			<return type="Dictionary[]" />
 			<description>
-				Returns the object's property list as an [Array] of dictionaries.
-				Each property's [Dictionary] contain at least [code]name: String[/code] and [code]type: int[/code] (see [enum Variant.Type]) entries. Optionally, it can also include [code]hint: int[/code] (see [enum PropertyHint]), [code]hint_string: String[/code], and [code]usage: int[/code] (see [enum PropertyUsageFlags]).
+				Returns the object's property list as an [Array] of dictionaries. Each [Dictionary] contains the following entries:
+				- [code]name[/code] is the property's name, as a [String];
+				- [code]class_name[/code] is an empty [StringName], unless the property is [constant TYPE_OBJECT] and it inherits from a class;
+				- [code]type[/code] is the property's type, as an [int] (see [enum Variant.Type]);
+				- [code]hint[/code] is [i]how[/i] the property is meant to be edited (see [enum PropertyHint]);
+				- [code]hint_string[/code] depends on the hint (see [enum PropertyHint]);
+				- [code]usage[/code] is a combination of [enum PropertyUsageFlags].
 			</description>
 		</method>
 		<method name="get_script" qualifiers="const">
 			<return type="Variant" />
 			<description>
-				Returns the object's [Script] instance, or [code]null[/code] if none is assigned.
+				Returns the object's [Script] instance, or [code]null[/code] if no script is attached.
 			</description>
 		</method>
 		<method name="get_signal_connection_list" qualifiers="const">
 			<return type="Dictionary[]" />
 			<param index="0" name="signal" type="StringName" />
 			<description>
-				Returns an [Array] of connections for the given [param signal].
+				Returns an [Array] of connections for the given [param signal] name. Each connection is represented as a [Dictionary] that contains three entries:
+				- [code]signal[/code] is a reference to the [Signal];
+				- [code]callable[/code] is a reference to the [Callable];
+				- [code]flags[/code] is a combination of [enum ConnectFlags].
 			</description>
 		</method>
 		<method name="get_signal_list" qualifiers="const">
 			<return type="Dictionary[]" />
 			<description>
-				Returns the list of signals as an [Array] of dictionaries.
+				Returns the list of existing signals as an [Array] of dictionaries.
+				[b]Note:[/b] Due of the implementation, each [Dictionary] is formatted very similarly to the returned values of [method get_method_list].
 			</description>
 		</method>
 		<method name="has_meta" qualifiers="const">
@@ -434,34 +533,34 @@
 			<param index="0" name="name" type="StringName" />
 			<description>
 				Returns [code]true[/code] if a metadata entry is found with the given [param name]. See also [method get_meta], [method set_meta] and [method remove_meta].
-				[b]Note:[/b] Metadata that has a [param name] starting with an underscore ([code]_[/code]) is considered editor-only. Editor-only metadata is not displayed in the Inspector and should not be edited.
+				[b]Note:[/b] Metadata that has a [param name] starting with an underscore ([code]_[/code]) is considered editor-only. Editor-only metadata is not displayed in the Inspector and should not be edited, although it can still be found by this method.
 			</description>
 		</method>
 		<method name="has_method" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="method" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the object contains the given [param method].
+				Returns [code]true[/code] if the the given [param method] name exists in the object.
 			</description>
 		</method>
 		<method name="has_signal" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="signal" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the given [param signal] exists.
+				Returns [code]true[/code] if the given [param signal] name exists in the object.
 			</description>
 		</method>
 		<method name="has_user_signal" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="signal" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the given user-defined [param signal] exists. Only signals added using [method add_user_signal] are taken into account.
+				Returns [code]true[/code] if the given user-defined [param signal] name exists. Only signals added with [method add_user_signal] are included.
 			</description>
 		</method>
 		<method name="is_blocking_signals" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if signal emission blocking is enabled.
+				Returns [code]true[/code] if the object is blocking its signals from being emitted. See [method set_block_signals].
 			</description>
 		</method>
 		<method name="is_class" qualifiers="const">
@@ -469,7 +568,21 @@
 			<param index="0" name="class" type="String" />
 			<description>
 				Returns [code]true[/code] if the object inherits from the given [param class]. See also [method get_class].
-				[b]Note:[/b] [method is_class] does not take [code]class_name[/code] declarations into account. If the object has a [code]class_name[/code] defined, [method is_class] will return [code]false[/code] for that name.
+				[codeblocks]
+				[gdscript]
+				var sprite2d = Sprite2D.new()
+				sprite2d.is_class("Sprite2D") # Returns true
+				sprite2d.is_class("Node")     # Returns true
+				sprite2d.is_class("Node3D")   # Returns false
+				[/gdscript]
+				[csharp]
+				var sprite2d = new Sprite2D();
+				sprite2d.IsClass("Sprite2D") // Returns true
+				sprite2d.IsClass("Node")     // Returns true
+				sprite2d.IsClass("Node3D")   // Returns false
+				[/csharp]
+				[/codeblocks]
+				[b]Note:[/b] This method ignores [code]class_name[/code] declarations in the object's script.
 			</description>
 		</method>
 		<method name="is_connected" qualifiers="const">
@@ -477,7 +590,7 @@
 			<param index="0" name="signal" type="StringName" />
 			<param index="1" name="callable" type="Callable" />
 			<description>
-				Returns [code]true[/code] if a connection exists for a given [param signal] and [param callable].
+				Returns [code]true[/code] if a connection exists between the given [param signal] name and [param callable].
 			</description>
 		</method>
 		<method name="is_queued_for_deletion" qualifiers="const">
@@ -491,21 +604,31 @@
 			<param index="0" name="what" type="int" />
 			<param index="1" name="reversed" type="bool" default="false" />
 			<description>
-				Send a given notification to the object, which will also trigger a call to the [method _notification] method of all classes that the object inherits from.
-				If [param reversed] is [code]true[/code], [method _notification] is called first on the object's own class, and then up to its successive parent classes. If [param reversed] is [code]false[/code], [method _notification] is called first on the highest ancestor ([Object] itself), and then down to its successive inheriting classes.
+				Sends the given [param what] notification to all classes inherited by the object, triggering calls to [method _notification], starting from the highest ancestor (the [Object] class) and going down to the object's script.
+				If [param reversed] is [code]true[/code], the call order is reversed.
+				[codeblock]
+				var player = Node2D.new()
+				player.set_script(load("res://player.gd"))
+
+				player.notification(NOTIFICATION_ENTER_TREE)
+				# The call order is Object -&gt; Node -&gt; Node2D -&gt; player.gd.
+
+				player.notification(NOTIFICATION_ENTER_TREE, true)
+				# The call order is player.gd -&gt; Node2D -&gt; Node -&gt; Object.
+				[/codeblock]
 			</description>
 		</method>
 		<method name="notify_property_list_changed">
 			<return type="void" />
 			<description>
-				Notify the editor that the property list has changed by emitting the [signal property_list_changed] signal, so that editor plugins can take the new values into account.
+				Emits the [signal property_list_changed] signal. This is mainly used to refresh the editor, so that the Inspector and editor plugins are properly updated.
 			</description>
 		</method>
 		<method name="remove_meta">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Removes a given entry from the object's metadata. See also [method has_meta], [method get_meta] and [method set_meta].
+				Removes the given entry [param name] from the object's metadata. See also [method has_meta], [method get_meta] and [method set_meta].
 				[b]Note:[/b] Metadata that has a [param name] starting with an underscore ([code]_[/code]) is considered editor-only. Editor-only metadata is not displayed in the Inspector and should not be edited.
 			</description>
 		</method>
@@ -514,15 +637,27 @@
 			<param index="0" name="property" type="StringName" />
 			<param index="1" name="value" type="Variant" />
 			<description>
-				Assigns a new value to the given property. If the [param property] does not exist or the given value's type doesn't match, nothing will happen.
-				[b]Note:[/b] In C#, the property name must be specified as snake_case if it is defined by a built-in Godot node. This doesn't apply to user-defined properties where you should use the same convention as in the C# source (typically PascalCase).
+				Assigns [param value] to the given [param property]. If the property does not exist or the given [param value]'s type doesn't match, nothing happens.
+				[codeblocks]
+				[gdscript]
+				var node = Node2D.new()
+				node.set("global_scale", Vector2(8, 2.5))
+				print(node.global_scale) # Prints (8, 2.5)
+				[/gdscript]
+				[csharp]
+				var node = new Node2D();
+				node.Set("global_scale", new Vector2(8, 2.5));
+				GD.Print(node.GlobalScale); # Prints Vector2(8, 2.5)
+				[/csharp]
+				[/codeblocks]
+				[b]Note:[/b] In C#, [param property] must be in snake_case when referring to built-in Godot properties.
 			</description>
 		</method>
 		<method name="set_block_signals">
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
 			<description>
-				If set to [code]true[/code], signal emission is blocked.
+				If set to [code]true[/code], the object becomes unable to emit signals. As such, [method emit_signal] and signal connections will not work, until it is set to [code]false[/code].
 			</description>
 		</method>
 		<method name="set_deferred">
@@ -530,8 +665,27 @@
 			<param index="0" name="property" type="StringName" />
 			<param index="1" name="value" type="Variant" />
 			<description>
-				Assigns a new value to the given property, after the current frame's physics step. This is equivalent to calling [method set] via [method call_deferred], i.e. [code]call_deferred("set", property, value)[/code].
-				[b]Note:[/b] In C#, the property name must be specified as snake_case if it is defined by a built-in Godot node. This doesn't apply to user-defined properties where you should use the same convention as in the C# source (typically PascalCase).
+				Assigns [param value] to the given [param property], after the current frame's physics step. This is equivalent to calling [method set] through [method call_deferred].
+				[codeblocks]
+				[gdscript]
+				var node = Node2D.new()
+				add_child(node)
+
+				node.rotation = 45.0
+				node.set_deferred("rotation", 90.0)
+				print(node.rotation) # Prints 45.0
+
+				await get_tree().process_frame
+				print(node.rotation) # Prints 90.0
+				[/gdscript]
+				[csharp]
+				var node = new Node2D();
+				node.Rotation = 45f;
+				node.SetDeferred("rotation", 90f);
+				GD.Print(node.Rotation); # Prints 45f;
+				[/csharp]
+				[/codeblocks]
+				[b]Note:[/b] In C#, [param property] must be in snake_case when referring to built-in Godot properties.
 			</description>
 		</method>
 		<method name="set_indexed">
@@ -539,29 +693,29 @@
 			<param index="0" name="property_path" type="NodePath" />
 			<param index="1" name="value" type="Variant" />
 			<description>
-				Assigns a new value to the property identified by the [param property_path]. The path should be a [NodePath] relative to the current object and can use the colon character ([code]:[/code]) to access nested properties.
-				[b]Example:[/b]
+				Assigns a new [param value] to the property identified by the [param property_path]. The path should be a [NodePath] relative to this object, and can use the colon character ([code]:[/code]) to access nested properties.
 				[codeblocks]
 				[gdscript]
 				var node = Node2D.new()
 				node.set_indexed("position", Vector2(42, 0))
 				node.set_indexed("position:y", -10)
-				print(node.position) # (42, -10)
+				print(node.position) # Prints (42, -10)
 				[/gdscript]
 				[csharp]
 				var node = new Node2D();
 				node.SetIndexed("position", new Vector2(42, 0));
 				node.SetIndexed("position:y", -10);
-				GD.Print(node.Position); // (42, -10)
+				GD.Print(node.Position); // Prints (42, -10)
 				[/csharp]
 				[/codeblocks]
+				[b]Note:[/b] In C#, [param property_path] must be in snake_case when referring to built-in Godot properties.
 			</description>
 		</method>
 		<method name="set_message_translation">
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
 			<description>
-				Defines whether the object can translate strings (with calls to [method tr]). Enabled by default.
+				If set to [code]true[/code], allows the object to translate messages with [method tr] and [method tr_n]. Enabled by default. See also [method can_translate_messages].
 			</description>
 		</method>
 		<method name="set_meta">
@@ -569,24 +723,23 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="value" type="Variant" />
 			<description>
-				Adds, changes or removes a given entry in the object's metadata. Metadata are serialized and can take any [Variant] value.
-				To remove a given entry from the object's metadata, use [method remove_meta]. Metadata is also removed if its value is set to [code]null[/code]. This means you can also use [code]set_meta("name", null)[/code] to remove metadata for [code]"name"[/code]. See also [method has_meta] and [method get_meta].
-				[b]Note:[/b] Metadata that has a [param name] starting with an underscore ([code]_[/code]) is considered editor-only. Editor-only metadata is not displayed in the Inspector and should not be edited.
+				Adds or changes the entry [param name] inside the object's metadata. The metadata [param value] can be any [Variant], although some types cannot be serialised correctly.
+				If [param value] is [code]null[/code], the entry is removed. This is the equivalent of using [method remove_meta]. See also [method has_meta] and [method get_meta].
+				[b]Note:[/b] Metadata that has a [param name] starting with an underscore ([code]_[/code]) is considered editor-only. Editor-only metadata is not displayed in the Inspector dock and should not be edited.
 			</description>
 		</method>
 		<method name="set_script">
 			<return type="void" />
 			<param index="0" name="script" type="Variant" />
 			<description>
-				Assigns a script to the object. Each object can have a single script assigned to it, which are used to extend its functionality.
-				If the object already had a script, the previous script instance will be freed and its variables and state will be lost. The new script's [method _init] method will be called.
+				Attaches [param script] to the object, and instantiates it. As a result, the script's [method _init] is called. A [Script] is used to extend the object's functionality.
+				If a script already exists, its instance is detached, and its property values and state are lost. Built-in property values are still kept.
 			</description>
 		</method>
 		<method name="to_string">
 			<return type="String" />
 			<description>
-				Returns a [String] representing the object. If not overridden, defaults to [code]"[ClassName:RID]"[/code].
-				Override the method [method _to_string] to customize the [String] representation.
+				Returns a [String] representing the object. Defaults to [code]"&lt;ClassName#RID&gt;"[/code]. Override [method _to_string] to customize the string representation of the object.
 			</description>
 		</method>
 		<method name="tr" qualifiers="const">
@@ -594,9 +747,9 @@
 			<param index="0" name="message" type="StringName" />
 			<param index="1" name="context" type="StringName" default="&quot;&quot;" />
 			<description>
-				Translates a message using translation catalogs configured in the Project Settings. An additional context could be used to specify the translation context.
-				Only works if message translation is enabled (which it is by default), otherwise it returns the [param message] unchanged. See [method set_message_translation].
-				See [url=$DOCS_URL/tutorials/i18n/internationalizing_games.html]Internationalizing games[/url] for examples of the usage of this method.
+				Translates a [param message], using the translation catalogs configured in the Project Settings. Further [param context] can be specified to help with the translation.
+				If [method can_translate_messages] is [code]false[/code], or no translation is available, this method returns the [param message] without changes. See [method set_message_translation].
+				For detailed examples, see [url=$DOCS_URL/tutorials/i18n/internationalizing_games.html]Internationalizing games[/url].
 			</description>
 		</method>
 		<method name="tr_n" qualifiers="const">
@@ -606,43 +759,45 @@
 			<param index="2" name="n" type="int" />
 			<param index="3" name="context" type="StringName" default="&quot;&quot;" />
 			<description>
-				Translates a message involving plurals using translation catalogs configured in the Project Settings. An additional context could be used to specify the translation context.
-				Only works if message translation is enabled (which it is by default), otherwise it returns the [param message] or [param plural_message] unchanged. See [method set_message_translation].
-				The number [param n] is the number or quantity of the plural object. It will be used to guide the translation system to fetch the correct plural form for the selected language.
-				[b]Note:[/b] Negative and floating-point values usually represent physical entities for which singular and plural don't clearly apply. In such cases, use [method tr].
-				See [url=$DOCS_URL/tutorials/i18n/localization_using_gettext.html]Localization using gettext[/url] for examples of the usage of this method.
+				Translates a [param message] or [param plural_message], using the translation catalogs configured in the Project Settings. Further [param context] can be specified to help with the translation.
+				If [method can_translate_messages] is [code]false[/code], or no translation is available, this method returns [param message] or [param plural_message], without changes. See [method set_message_translation].
+				The [param n] is the number, or amount, of the message's subject. It is used by the translation system to fetch the correct plural form for the current language.
+				For detailed examples, see [url=$DOCS_URL/tutorials/i18n/localization_using_gettext.html]Localization using gettext[/url].
+				[b]Note:[/b] Negative and [float] numbers may not properly apply to some countable subjects. It's recommended handling these cases with [method tr].
 			</description>
 		</method>
 	</methods>
 	<signals>
 		<signal name="property_list_changed">
 			<description>
+				Emitted when [method notify_property_list_changed] is called.
 			</description>
 		</signal>
 		<signal name="script_changed">
 			<description>
-				Emitted whenever the object's script is changed.
+				Emitted when the object's script is changed.
+				[b]Note:[/b] When this signal is emitted, the new script is not initialized yet. If you need to access the new script, defer connections to this signal with [constant CONNECT_DEFERRED].
 			</description>
 		</signal>
 	</signals>
 	<constants>
 		<constant name="NOTIFICATION_POSTINITIALIZE" value="0">
-			Called right when the object is initialized. Not available in script.
+			Notification received when the object is initialized, before its script is attached. Used internally.
 		</constant>
 		<constant name="NOTIFICATION_PREDELETE" value="1">
-			Called before the object is about to be deleted.
+			Notification received when the object is about to be deleted. Can act as the deconstructor of some programming languages.
 		</constant>
 		<constant name="CONNECT_DEFERRED" value="1" enum="ConnectFlags">
-			Connects a signal in deferred mode. This way, signal emissions are stored in a queue, then set on idle time.
+			Deferred connections trigger their [Callable]s on idle time, rather than instantly.
 		</constant>
 		<constant name="CONNECT_PERSIST" value="2" enum="ConnectFlags">
-			Persisting connections are saved when the object is serialized to file.
+			Persisting connections are stored when the object is serialized (such as when using [method PackedScene.pack]). In the editor, connections created through the Node dock are always persisting.
 		</constant>
 		<constant name="CONNECT_ONE_SHOT" value="4" enum="ConnectFlags">
 			One-shot connections disconnect themselves after emission.
 		</constant>
 		<constant name="CONNECT_REFERENCE_COUNTED" value="8" enum="ConnectFlags">
-			Connect a signal as reference-counted. This means that a given signal can be connected several times to the same target, and will only be fully disconnected once no references are left.
+			Reference-counted connections can be assigned to the same [Callable] multiple times. Each disconnection decreases the internal counter. The signal fully disconnects only when the counter reaches 0.
 		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
### This PR is touchy

Closes https://github.com/godotengine/godot-docs/issues/4894
Closes https://github.com/godotengine/godot-docs/issues/5139
Closes https://github.com/godotengine/godot-docs/issues/3827 (???)
... and maybe some more?

Continuation of #67072, #67100, #67208, #67718...

Here a big list of changes which, unlike the previous PRs, is a lot more detailed. Although, I have to admit, I got tired of writing it due to repetition. 
Mainly, it's meant to represent my line of reasoning behind every change. Perhaps, someone reading this may take it as a future point of reference. Not just that, but some information deemed important by the maintainers could have been lost during the rewrite. Criticism is encouraged.

### General
- Made use of _[param]_ and several other strong references more often.
- Corrected typos.
- Stripped awkward, needlessly long sentences.
- Simplified wording where it felt necessary. For example:
   - _"Contrarily to"_ -> _"Unlike"_;
   - _"taken into account"_ -> "included"_.
-  Changed wording where technical terms (also used in the rest of the documentation) are more appropriate:
   - _"can take"_ -> _"supports"_;
- Used synonyms when words could be mistaken for another concept of Godot's API. For example:
   - _"parent classes"_ -> _"inherited classes"_;
   - _"plural object"_ -> _"message's subject"_
- Added way more examples.
- The spacing of comments in the examples has been adjusted to improve readability.
   - This is not a hard rule defined in the **ClassRef** guidelines. Although, for reasons stated above, it could totally be. However, see https://github.com/godotengine/godot-docs/issues/6328#issuecomment-1290696182.
- Tried to refer to "signal" as "signal name" sometimes.
    - This is because **Signal** can be a Variant type in Godot 4, but the API may still need to refer to them by name.

### Methods
#### 
- The leading description has been completely overhauled.
    - _"a built-in type" 
    What? Node type? Class type?_ Unclear. It's **Variant** type.
    - _"Objects do not manage memory."_, 
    Then, **literally** the next paragraph began with _"Some classes that extend Object add memory management"_.
    - _"Objects export properties, which are mainly useful for storage and editing, but not really so much in programming."_ 
  **W-what!?**
    - The `in` operator checks for properties, _methods_, and _signals_ _(try this I dare you)_.
    - Introduced basic concept of inheritance.
    - Introduced Scripts.
    - Introduced Notifications.
    - Introduced Metadata.
- Reworked **`_get_property_list`**.
    - Added important notes.
- Reworded **`_init`**.
    - Specified to be the script, not the Object.
- Reworded **`can_translate_messages`**.
    - "if the object can translate strings".
    Eh? What strings?
- Reworded **`connect`**.
    - Detail returned **Error** constant.
    - It's better to reword it for now....
    The description of this method is... so needlessly long, verbose, and incredibly horrifying to look at! Despite this, ironically, this isn't even the recommended way to connect signals anymore. This may need to be seen in another PR, it's just... ridiculous. It even explains... `emit_signal`? Why not putting the explanation there, then!? Aaah...
    - _"One can pass a binds Array to Object.connect()"_ this is just plainly false in Godot 4.
- Reworked **`emit_signal`**.
    - Detail returned error Error constant.
- Reworked **`get_incoming_connections`**.
    - It was entirely wrong and not updated from **3.x**.
- Reworked **`get_indexed`** and **`set_indexed`**.
    - Add missing note for C# about Built-in pascal_case properties.
- Reworked **`get_method_list`**.
   - Detail the returned  **Dictionary** **Array**.
     Closes https://github.com/godotengine/godot-docs/issues/4894.
- Reworked **`get_property_list`**.
    - Added more detail to the returned **Dictionary** **Array**.
- Reworked **`get_signal_list`**.
    - Added more detail to the returned **Dictionary** **Array** 
    (Which is incredibly strange by the way).
- Reworded **`notify_property_list_changed`**.
    - _"Notify the editor that the property list has changed by emitting the property_list_changed signal"_.
    These lines have been swapped, because all this method does is emitting the signal.
- Reworded **`set_script`**.
    - _"Assign script"_ -> _"Attach script"_. 
    Although both terms are correct, _"attach"_ matches the more familiar verb used in the Scene Tree Editor.
    - _"Each object can have a single script assigned to it"_.
    Very much sounded like a leftover from when Godot used to support multiple scripts.
- Reworded **`to_string`**.
    - _"defaults to "ClassName:RID""_
    This was outdated.

### Signals
- Add missing description to **`property_list_changed`**.
- Recommend deferring **`script_changed`** on some cases.
    - This is because when the signal is emitted, the new script is not yet initialized.

### Constants
- Specified that **NOTIFICATION_POSTINITIALIZE** is pretty much used internally.
    - You can't receive it from **Script**, because normally it is sent even before a **Script**'s `_init()` is even called...
- Made all **CONNECT** constant descriptions consistent.
    - They all begin like _"[adjective] connections do this thing"_. I am not sure they are the best way to word them, but it is consistent.
    
### TODO:
- [x] Finish rewriting leading description.
- [x] ~Possibly adjust `connect` to reduce... overwhelming-ness.~ Barely... May not be doable for now.
- [x] ~Document `_set` and `_get`'s _very interesting_ use cases (when it is actually called)~. Can't be done as I wished. It almost feels like the behavior is bugged.
- [x] Refine `get_property_list` and `_get_property_list`.

I recommend taking a look at the documentation by building from this PR, to read the documentation from the Editor itself. Feedback is welcome.
