### PR TITLE
Improve error reporting of Mono builds and the code structure of hostfxr and Godot plugin initializations

### DIFF
--- a/modules/mono/build_scripts/build_assemblies.py
+++ b/modules/mono/build_scripts/build_assemblies.py
@@ -342,6 +342,13 @@ def build_all(msbuild_tool, module_dir, output_dir, godot_platform, dev_debug, p
 def main():
     import argparse
     import sys
+    import os.path
+
+    if not os.path.exists("modules/mono/glue/GodotSharp/GodotSharp/Generated/"):
+        print(
+            "WARNING: Mono glue not found.\nConsider running the command `<godot_binary> --generate-mono-glue ./modules/mono/glue` from the Godot source root.\n",
+            file=sys.stderr,
+        )
 
     parser = argparse.ArgumentParser(description="Builds all Godot .NET solutions")
     parser.add_argument("--godot-output-dir", type=str, required=True)


### PR DESCRIPTION
## Issues
### Error reporting
After compiling a Mono build with option `module_mono_enabled=yes`, these errors are printed during execution.
This is an end-user issue caused by not generating Mono Glue as described in `modules/mono/README.md`.
Those errors provide no troubleshooting steps and no useful debugging information.
```
The specified runtimeconfig.json [/home/roland/Git/godot/bin/GodotSharp/Api/Debug/GodotPlugins.runtimeconfig.json] does not exist
ERROR: hostfxr_initialize_for_runtime_config failed with code: -2147450733
   at: initialize_hostfxr_for_config (modules/mono/mono_gd/gd_mono.cpp:201)
ERROR: Parameter "load_assembly_and_get_function_pointer" is null.
   at: initialize_hostfxr_and_godot_plugins (modules/mono/mono_gd/gd_mono.cpp:274)
ERROR: Parameter "godot_plugins_initialize" is null.
   at: initialize (modules/mono/mono_gd/gd_mono.cpp:403)
```
### `initialize_hostfxr_and_godot_plugins(bool &)`
This function, as the name suggests, initializes both hostfxr and Godot plugins, the latter depending on the former.
There are no good reasons for those two functions to be merged together into one, as it violates the "do one thing" principle.
## Resolution
### Error reporting
In the same situation as before, these errors are now generated.
They provide clear troubleshooting steps, and useful debugging information.
```
WARNING: Mono glue not found. Consider running the next commands from the Godot source root and recompiling using `mono_glue=yes`:
<godot_binary> --generate-mono-glue ./modules/mono/glue
./modules/mono/build_scripts/build_assemblies.py --godot-output-dir ./bin
     at: initialize_hostfxr (modules/mono/mono_gd/gd_mono.cpp:267)
ERROR: Could not initialize hostfxr.
   at: initialize_hostfxr (modules/mono/mono_gd/gd_mono.cpp:270)
ERROR: Could not initialize Godot plugins due to hostfxr being uninitialized.
   at: initialize_godot_plugins (modules/mono/mono_gd/gd_mono.cpp:284)
ERROR: Could not initialize GDMono due to Godot plugins being uninitialized.
   at: initialize (modules/mono/mono_gd/gd_mono.cpp:410)
```
Another issue that was faced by some is the accidental reversal of the two commands needed to generate Mono Glue.
For this reason, a warning to `modules/mono/build_scripts/build_assemblies.py` has been added.
```
WARNING: Mono glue not found.
Consider running the command `<godot_binary> --generate-mono-glue ./modules/mono/glue` from the Godot source root and recompiling using `mono_glue=yes`.
```
### `initialize_hostfxr_and_godot_plugins(bool &)`
The function has been divided into `initialize_hostfxr(bool &)` and `initialize_godot_plugins(load_assembly_and_get_function_pointer_fn)`.
The latter depends on the input of the former, the resulting behaviour remaining intact.
The original function supported both tools enabled and disabled, so do those new functions.
Some names have been changed to reduce redundancy while maintaining clarity.