### PR TITLE
Avoid simplifying mesh lods that shouldn't be.

### DIFF
--- a/scene/resources/importer_mesh.h
+++ b/scene/resources/importer_mesh.h
@@ -65,7 +65,7 @@ class ImporterMesh : public Resource {
 
 		struct LODComparator {
 			_FORCE_INLINE_ bool operator()(const LOD &l, const LOD &r) const {
-				return l.distance < r.distance;
+				return l.distance < r.distance && l.indices.size() < r.indices.size();
 			}
 		};
 


### PR DESCRIPTION
**Work in progress.**

Testing with https://github.com/godotengine/godot/files/9865899/basketball.zip and https://sketchfab.com/3d-models/subd-minitutorial-8ee637a4afa44d95836749c994270dd3

I tried using sorting and distance to push the "bad lods further back"

Discussion with DETOX says that this is not a uv seam (discontinuity) but a uv mirroring.

~~Try with 1% error from the documentation https://github.com/zeux/meshoptimizer#simplification~~

~~The basketball is tested with 128 LOD level and 1% error. The black areas are still there.~~

~~I think the problem is lod values don't care about the maximum error.~~

Fixes: https://github.com/godotengine/godot/issues/67891