### PR TITLE
  Fix differences between Windows and linuxbsd Display Server

### DIFF
--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -323,6 +323,8 @@ class DisplayServerWindows : public DisplayServer {
 		LPARAM lParam;
 	};
 
+	WindowID window_mouseover_id = INVALID_WINDOW_ID;
+
 	KeyEvent key_event_buffer[KEY_EVENT_BUFFER_SIZE];
 	int key_event_pos;
 
@@ -398,7 +400,6 @@ class DisplayServerWindows : public DisplayServer {
 
 		Size2 window_rect;
 		Point2 last_pos;
-		bool mouse_outside = true;
 
 		ObjectID instance_id;
 


### PR DESCRIPTION
Make adjustments to `DisplayServerWindows` to reduce the differences to `DisplayServerX11`.
Prerequisite for  #67791

Fix that Windows receive `WINDOW_EVENT_MOUSE_EXIT` on startup. (fix #67898)

When moving the mouse cursor from one window to a different one, make sure that the first window receives the `WINDOW_EVENT_MOUSE_EXIT` event before the second window receives the `WINDOW_EVENT_MOUSE_ENTER` event.

Send Mouse-Move events also for Windows, that are currently not focused.

For determining the currently hovered window, consider not just the currently focused window, but also other windows.

Send mouse move events to focused window instead of hovered window.

Update 2022-10-28: Code cleanup