### PR TITLE
Document the ENetPacketPeer class

### DIFF
--- a/modules/enet/doc_classes/ENetPacketPeer.xml
+++ b/modules/enet/doc_classes/ENetPacketPeer.xml
@@ -80,7 +80,7 @@
 			<return type="void" />
 			<param index="0" name="ping_interval" type="int" />
 			<description>
-				Sets the [code]ping_interval[/code] in milliseconds at which pings will be sent to a peer. Pings are used both to monitor the liveness of the connection and also to dynamically adjust the throttle during periods of low traffic so that the throttle has reasonable responsiveness during traffic spikes.
+				Sets the [code]ping_interval[/code] in milliseconds at which pings will be sent to a peer. Pings are used both to monitor the liveness of the connection and also to dynamically adjust the throttle during periods of low traffic so that the throttle has reasonable responsiveness during traffic spikes. The default ping interval is [code]500[/code] milliseconds.
 			</description>
 		</method>
 		<method name="reset">
@@ -115,33 +115,43 @@
 			<param index="2" name="deceleration" type="int" />
 			<description>
 				Configures throttle parameter for a peer.
-				Unreliable packets are dropped by ENet in response to the varying conditions of the Internet connection to the peer. The throttle represents a probability that an unreliable packet should not be dropped and thus sent by ENet to the peer. By measuring fluctuations in round trip times of reliable packets over the specified [code]interval[/code], ENet will either increase the probably by the amount specified in the [code]acceleration[/code] parameter, or decrease it by the amount specified in the [code]deceleration[/code] parameter (both are ratios to [constant PACKET_THROTTLE_SCALE]).
+				Unreliable packets are dropped by ENet in response to the varying conditions of the Internet connection to the peer. The throttle represents a probability that an unreliable packet should not be dropped and thus sent by ENet to the peer. By measuring fluctuations in round trip times of reliable packets over the specified [code]interval[/code], ENet will either increase the probability by the amount specified in the [code]acceleration[/code] parameter, or decrease it by the amount specified in the [code]deceleration[/code] parameter (both are ratios to [constant PACKET_THROTTLE_SCALE]).
 				When the throttle has a value of [constant PACKET_THROTTLE_SCALE], no unreliable packets are dropped by ENet, and so 100% of all unreliable packets will be sent.
-				When the throttle has a value of 0, all unreliable packets are dropped by ENet, and so 0% of all unreliable packets will be sent.
+				When the throttle has a value of [code]0[/code], all unreliable packets are dropped by ENet, and so 0% of all unreliable packets will be sent.
 				Intermediate values for the throttle represent intermediate probabilities between 0% and 100% of unreliable packets being sent. The bandwidth limits of the local and foreign hosts are taken into account to determine a sensible limit for the throttle probability above which it should not raise even in the best of conditions.
 			</description>
 		</method>
 	</methods>
 	<constants>
 		<constant name="STATE_DISCONNECTED" value="0" enum="PeerState">
+			The peer is disconnected.
 		</constant>
 		<constant name="STATE_CONNECTING" value="1" enum="PeerState">
+			The peer is currently attempting to connect.
 		</constant>
 		<constant name="STATE_ACKNOWLEDGING_CONNECT" value="2" enum="PeerState">
+			The peer has acknowledged the connection request.
 		</constant>
 		<constant name="STATE_CONNECTION_PENDING" value="3" enum="PeerState">
+			The peer is currently connecting.
 		</constant>
 		<constant name="STATE_CONNECTION_SUCCEEDED" value="4" enum="PeerState">
+			The peer has successfully connected, but is not ready to communicate with yet ([constant STATE_CONNECTED]).
 		</constant>
 		<constant name="STATE_CONNECTED" value="5" enum="PeerState">
+			The peer is currently connected and ready to communicate with.
 		</constant>
 		<constant name="STATE_DISCONNECT_LATER" value="6" enum="PeerState">
+			The peer is slated to disconnect after it has no more outgoing packets to send.
 		</constant>
 		<constant name="STATE_DISCONNECTING" value="7" enum="PeerState">
+			The peer is currently disconnecting.
 		</constant>
 		<constant name="STATE_ACKNOWLEDGING_DISCONNECT" value="8" enum="PeerState">
+			The peer has acknowledged the disconnection request.
 		</constant>
 		<constant name="STATE_ZOMBIE" value="9" enum="PeerState">
+			The peer has lost connection, but is not considered truly disconnected (as the peer didn't acknowledge the disconnection request).
 		</constant>
 		<constant name="PEER_PACKET_LOSS" value="0" enum="PeerStatistic">
 			Mean packet loss of reliable packets as a ratio with respect to the [constant PACKET_LOSS_SCALE].
@@ -150,6 +160,7 @@
 			Packet loss variance.
 		</constant>
 		<constant name="PEER_PACKET_LOSS_EPOCH" value="2" enum="PeerStatistic">
+			The time at which packet loss statistics were last updated (in milliseconds since the connection started). The interval for packet loss statistics updates is 10 seconds, and at least one packet must have been sent since the last statistics update.
 		</constant>
 		<constant name="PEER_ROUND_TRIP_TIME" value="3" enum="PeerStatistic">
 			Mean packet round trip time for reliable packets.
@@ -164,24 +175,31 @@
 			Variance of the last trip time recorded.
 		</constant>
 		<constant name="PEER_PACKET_THROTTLE" value="7" enum="PeerStatistic">
+			The peer's current throttle status.
 		</constant>
 		<constant name="PEER_PACKET_THROTTLE_LIMIT" value="8" enum="PeerStatistic">
+			The maximum number of unreliable packets that should not be dropped. This value is always greater than or equal to [code]1[/code]. The initial value is equal to [constant PACKET_THROTTLE_SCALE].
 		</constant>
 		<constant name="PEER_PACKET_THROTTLE_COUNTER" value="9" enum="PeerStatistic">
+			Internal value used to increment the packet throttle counter. The value is hardcoded to [code]7[/code] and cannot be changed. You probably want to look at [constant PEER_PACKET_THROTTLE_ACCELERATION] instead.
 		</constant>
 		<constant name="PEER_PACKET_THROTTLE_EPOCH" value="10" enum="PeerStatistic">
+			The time at which throttle statistics were last updated (in milliseconds since the connection started). The interval for throttle statistics updates is [constant PEER_PACKET_THROTTLE_INTERVAL].
 		</constant>
 		<constant name="PEER_PACKET_THROTTLE_ACCELERATION" value="11" enum="PeerStatistic">
+			The throttle's acceleration factor. Higher values will make ENet adapt to fluctuating network conditions faster, causing unrelaible packets to be sent [i]more[/i] often. The default value is [code]2[/code].
 		</constant>
 		<constant name="PEER_PACKET_THROTTLE_DECELERATION" value="12" enum="PeerStatistic">
+			The throttle's deceleration factor. Higher values will make ENet adapt to fluctuating network conditions faster, causing unrelaible packets to be sent [i]less[/i] often. The default value is [code]2[/code].
 		</constant>
 		<constant name="PEER_PACKET_THROTTLE_INTERVAL" value="13" enum="PeerStatistic">
+			The interval over which the lowest mean round trip time should be measured for use by the throttle mechanism (in milliseconds). The default value is [code]5000[/code].
 		</constant>
 		<constant name="PACKET_LOSS_SCALE" value="65536">
 			The reference scale for packet loss. See [method get_statistic] and [constant PEER_PACKET_LOSS].
 		</constant>
 		<constant name="PACKET_THROTTLE_SCALE" value="32">
-			The reference value for throttle configuration. See [method throttle_configure].
+			The reference value for throttle configuration. The default value is [code]32[/code]. See [method throttle_configure].
 		</constant>
 		<constant name="FLAG_RELIABLE" value="1">
 			Mark the packet to be sent as reliable.


### PR DESCRIPTION
This makes the ENetPacketPeer class 100% documented.

@lsalzman If you have time, please give this a review – I've had to look at ENet source code to document most of the constants.