### PR TITLE
Fix scrolling behavior with zero/low page value

### DIFF
--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -55,12 +55,14 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 		accept_event();
 
 		if (b->get_button_index() == MouseButton::WHEEL_DOWN && b->is_pressed()) {
-			set_value(get_value() + get_page() / 4.0);
+			double change = get_page() != 0.0 ? get_page() / 4.0 : (get_max() - get_min()) / 16.0;
+			set_value(get_value() + MAX(change, get_step()));
 			accept_event();
 		}
 
 		if (b->get_button_index() == MouseButton::WHEEL_UP && b->is_pressed()) {
-			set_value(get_value() - get_page() / 4.0);
+			double change = get_page() != 0.0 ? get_page() / 4.0 : (get_max() - get_min()) / 16.0;
+			set_value(get_value() - MAX(change, get_step()));
 			accept_event();
 		}
 
@@ -99,7 +101,8 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 				if (scrolling) {
 					target_scroll = CLAMP(target_scroll - get_page(), get_min(), get_max() - get_page());
 				} else {
-					target_scroll = CLAMP(get_value() - get_page(), get_min(), get_max() - get_page());
+					double change = get_page() != 0.0 ? get_page() : (get_max() - get_min()) / 16.0;
+					target_scroll = CLAMP(get_value() - change, get_min(), get_max() - get_page());
 				}
 
 				if (smooth_scroll_enabled) {
@@ -122,7 +125,8 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 				if (scrolling) {
 					target_scroll = CLAMP(target_scroll + get_page(), get_min(), get_max() - get_page());
 				} else {
-					target_scroll = CLAMP(get_value() + get_page(), get_min(), get_max() - get_page());
+					double change = get_page() != 0.0 ? get_page() : (get_max() - get_min()) / 16.0;
+					target_scroll = CLAMP(get_value() + change, get_min(), get_max() - get_page());
 				}
 
 				if (smooth_scroll_enabled) {


### PR DESCRIPTION
ScrollBar with page set to 0 ignores mouse wheel events and clicks. Only dragging can change its value. Also combination of small page value and big step can produce unpredicted results.

I think it's not the best behaviour and **probably disabling mouse input by setting page to 0 is not intentional**.
I propose to **change value by some percent for mouse events when page is set to default 0**.

Scrolling before and afer:
![scrollbarchange](https://user-images.githubusercontent.com/19764492/198099428-1905608f-8250-44ce-82d7-2223f0e76f4f.gif)

Test project:
[scrollbarchange.zip](https://github.com/godotengine/godot/files/9872383/scrollbarchange.zip)
