### PR TITLE
Fix the vs2017 build issue for 3.x

### DIFF
--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -63,7 +63,11 @@ private:
 
 	FileAccess::CreateFunc fa_create_func;
 
+	CharString password;
+
 public:
+	void set_password(const CharString &pass); // set or clear the zip legacy encryption password
+
 	void close_handle(unzFile p_file) const;
 	unzFile get_file_handle(String p_file) const;
 

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -34,6 +34,7 @@
 #include "core/core_string_names.h"
 #include "core/io/file_access_network.h"
 #include "core/io/file_access_pack.h"
+#include "core/io/file_access_zip.h"
 #include "core/io/marshalls.h"
 #include "core/os/dir_access.h"
 #include "core/os/file_access.h"
@@ -298,7 +299,7 @@ void ProjectSettings::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
-bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset) {
+bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset, const String &p_password) {
 	if (PackedData::get_singleton()->is_disabled()) {
 		return false;
 	}
@@ -312,6 +313,9 @@ bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_f
 	//if data.pck is found, all directory access will be from here
 	DirAccess::make_default<DirAccessPack>(DirAccess::ACCESS_RESOURCES);
 	using_datapack = true;
+
+	//set or clear ZipArchive password
+	ZipArchive::get_singleton()->set_password(p_password.utf8());
 
 	return true;
 }
@@ -1036,7 +1040,7 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("localize_path", "path"), &ProjectSettings::localize_path);
 	ClassDB::bind_method(D_METHOD("globalize_path", "path"), &ProjectSettings::globalize_path);
 	ClassDB::bind_method(D_METHOD("save"), &ProjectSettings::save);
-	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset"), &ProjectSettings::_load_resource_pack, DEFVAL(true), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset", "password"), &ProjectSettings::_load_resource_pack, DEFVAL(true), DEFVAL(0), DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("property_can_revert", "name"), &ProjectSettings::property_can_revert);
 	ClassDB::bind_method(D_METHOD("property_get_revert", "name"), &ProjectSettings::property_get_revert);
 

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -138,7 +138,7 @@ protected:
 
 	void _convert_to_last_version(int p_from_version);
 
-	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true, int p_offset = 0);
+	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true, int p_offset = 0, const String &p_password="");
 
 	void _add_property_info_bind(const Dictionary &p_info);
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -3998,6 +3998,10 @@ OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 	AudioDriverManager::add_driver(&driver_xaudio2);
 #endif
 
+	// Use the officially documented constant, https://learn.microsoft.com/en-us/windows/console/setconsolemode
+#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#endif
 	// Enable ANSI escape code support on Windows 10 v1607 (Anniversary Update) and later.
 	// This lets the engine and projects use ANSI escape codes to color text just like on macOS and Linux.
 	//

--- a/thirdparty/minizip/unzip.c
+++ b/thirdparty/minizip/unzip.c
@@ -68,10 +68,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef NOUNCRYPT
-        #define NOUNCRYPT
-#endif
-
 #include "zlib.h"
 #include "unzip.h"
 


### PR DESCRIPTION
Provide undefined constant to fix the vs2017 build issue

before this fix, build failed
![before](https://user-images.githubusercontent.com/73905273/198104643-9ef25295-e0c9-45ef-b9cf-958d98204127.png)

after this fix, build succeed
![after](https://user-images.githubusercontent.com/73905273/198104701-2cd76cf4-ae9e-4012-be84-b7ca5e3cb30b.png)

![image](https://user-images.githubusercontent.com/73905273/198105231-c0b37d97-3e09-49d3-bb47-971cd78ff9be.png)

![image](https://user-images.githubusercontent.com/73905273/198105705-c55d458e-0bb4-459c-9dd4-a1b73a9c3b41.png)


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
