### PR TITLE
Fix `DisplayServer.has_feature()` claiming X11 has native icon support

### DIFF
--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -126,7 +126,7 @@ bool DisplayServerX11::has_feature(Feature p_feature) const {
 		case FEATURE_WINDOW_TRANSPARENCY:
 		//case FEATURE_HIDPI:
 		case FEATURE_ICON:
-		case FEATURE_NATIVE_ICON:
+		//case FEATURE_NATIVE_ICON:
 		case FEATURE_SWAP_BUFFERS:
 #ifdef DBUS_ENABLED
 		case FEATURE_KEEP_SCREEN_ON:


### PR DESCRIPTION
[Native icons are not supported by the X11 DisplayServer](https://github.com/godotengine/godot/blob/2b505b74b9b0a7005586ecaa9aa1236e86b18437/platform/linuxbsd/display_server_x11.cpp#L4303-L4305), unlike Windows and macOS.

I'm not sure how much work would be required to add native icon support to X11, or even if there is such a concept in the first place. I assume an XPM image would need to be given to X11 for this to work?