### PR TITLE
[MP] Add peer authentication support to the default MultiplayerAPI.

### DIFF
--- a/doc/classes/MultiplayerPeer.xml
+++ b/doc/classes/MultiplayerPeer.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="MultiplayerPeer" inherits="PacketPeer" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A high-level network interface to simplify multiplayer interactions.
+		Abstract class for specialized [PacketPeer]s used by the [MultiplayerAPI].
 	</brief_description>
 	<description>
-		Manages the connection to multiplayer peers. Assigns unique IDs to each client connected to the server. See also [MultiplayerAPI].
-		[b]Note:[/b] The high-level multiplayer API protocol is an implementation detail and isn't meant to be used by non-Godot servers. It may change without notice.
+		Manages the connection with one or more remote peers acting as server or client and assigning unique IDs to each of them. See also [MultiplayerAPI].
+		[b]Note:[/b] The [MultiplayerAPI] protocol is an implementation detail and isn't meant to be used by non-Godot servers. It may change without notice.
 		[b]Note:[/b] When exporting to Android, make sure to enable the [code]INTERNET[/code] permission in the Android export preset before exporting the project or using one-click deploy. Otherwise, network communication of any kind will be blocked by Android.
 	</description>
 	<tutorials>
@@ -97,49 +97,34 @@
 		</member>
 	</members>
 	<signals>
-		<signal name="connection_failed">
-			<description>
-				Emitted when a connection attempt fails.
-			</description>
-		</signal>
-		<signal name="connection_succeeded">
-			<description>
-				Emitted when a connection attempt succeeds.
-			</description>
-		</signal>
 		<signal name="peer_connected">
 			<param index="0" name="id" type="int" />
 			<description>
-				Emitted by the server when a client connects.
+				Emitted when a remote peer connects.
 			</description>
 		</signal>
 		<signal name="peer_disconnected">
 			<param index="0" name="id" type="int" />
 			<description>
-				Emitted by the server when a client disconnects.
-			</description>
-		</signal>
-		<signal name="server_disconnected">
-			<description>
-				Emitted by clients when the server disconnects.
+				Emitted when a remote peer has disconnected.
 			</description>
 		</signal>
 	</signals>
 	<constants>
 		<constant name="CONNECTION_DISCONNECTED" value="0" enum="ConnectionStatus">
-			The ongoing connection disconnected.
+			The MultiplayerPeer is disconnected.
 		</constant>
 		<constant name="CONNECTION_CONNECTING" value="1" enum="ConnectionStatus">
-			A connection attempt is ongoing.
+			The MultiplayerPeer is currently connecting to a server.
 		</constant>
 		<constant name="CONNECTION_CONNECTED" value="2" enum="ConnectionStatus">
-			The connection attempt succeeded.
+			This MultiplayerPeer is connected.
 		</constant>
 		<constant name="TARGET_PEER_BROADCAST" value="0">
-			Packets are sent to the server and then redistributed to other peers.
+			Packets are sent to all connected peers.
 		</constant>
 		<constant name="TARGET_PEER_SERVER" value="1">
-			Packets are sent to the server alone.
+			Packets are sent to the remote peer acting as server.
 		</constant>
 		<constant name="TRANSFER_MODE_UNRELIABLE" value="0" enum="TransferMode">
 			Packets are not acknowledged, no resend attempts are made for lost packets. Packets may arrive in any order. Potentially faster than [constant TRANSFER_MODE_UNRELIABLE_ORDERED]. Use for non-critical data, and always consider whether the order matters.

--- a/modules/enet/enet_multiplayer_peer.cpp
+++ b/modules/enet/enet_multiplayer_peer.cpp
@@ -159,10 +159,7 @@ void ENetMultiplayerPeer::_disconnect_inactive_peers() {
 		if (hosts.has(P)) {
 			hosts.erase(P);
 		}
-		if (active_mode == MODE_CLIENT) {
-			ERR_CONTINUE(P != TARGET_PEER_SERVER);
-			emit_signal(SNAME("server_disconnected"));
-		}
+		ERR_CONTINUE(active_mode == MODE_CLIENT && P != TARGET_PEER_SERVER);
 		emit_signal(SNAME("peer_disconnected"), P);
 	}
 }
@@ -186,14 +183,10 @@ void ENetMultiplayerPeer::poll() {
 				if (ret == ENetConnection::EVENT_CONNECT) {
 					connection_status = CONNECTION_CONNECTED;
 					emit_signal(SNAME("peer_connected"), 1);
-					emit_signal(SNAME("connection_succeeded"));
 				} else if (ret == ENetConnection::EVENT_DISCONNECT) {
 					if (connection_status == CONNECTION_CONNECTED) {
 						// Client just disconnected from server.
-						emit_signal(SNAME("server_disconnected"));
 						emit_signal(SNAME("peer_disconnected"), 1);
-					} else {
-						emit_signal(SNAME("connection_failed"));
 					}
 					close();
 				} else if (ret == ENetConnection::EVENT_RECEIVE) {

--- a/modules/multiplayer/doc_classes/SceneMultiplayer.xml
+++ b/modules/multiplayer/doc_classes/SceneMultiplayer.xml
@@ -19,6 +19,35 @@
 				Clears the current SceneMultiplayer network state (you shouldn't call this unless you know what you are doing).
 			</description>
 		</method>
+		<method name="complete_auth">
+			<return type="int" enum="Error" />
+			<param index="0" name="id" type="int" />
+			<description>
+				Mark the authentication step as completed for the remote peer identified by [param id]. The [signal MultiplayerAPI.peer_connected] signal will be emitted for this peer once the remote side also completes the authentication. No further authentication messages are expected to be received from this peer.
+				If a peer disconnects before completing authentication, either due to a network issue, the [member auth_timeout] expiring, or manually calling [method disconnect_peer], the [signal peer_authentication_failed] signal will be emitted instead of [signal MultiplayerAPI.peer_disconnected].
+			</description>
+		</method>
+		<method name="disconnect_peer">
+			<return type="void" />
+			<param index="0" name="id" type="int" />
+			<description>
+				Disconnects the peer identified by [param id], removing it from the list of connected peers, and closing the underlying connection with it.
+			</description>
+		</method>
+		<method name="get_authenticating_peers">
+			<return type="PackedInt32Array" />
+			<description>
+				Returns the IDs of the peers currently trying to authenticate with this [MultiplayerAPI].
+			</description>
+		</method>
+		<method name="send_auth">
+			<return type="int" enum="Error" />
+			<param index="0" name="id" type="int" />
+			<param index="1" name="data" type="PackedByteArray" />
+			<description>
+				Sends the specified [param data] to the remote peer identified by [param id] as part of an authentication message. This can be used to authenticate peers, and control when [signal MultiplayerAPI.peer_connected] is emitted (and the remote peer accepted as one of the connected peers).
+			</description>
+		</method>
 		<method name="send_bytes">
 			<return type="int" enum="Error" />
 			<param index="0" name="bytes" type="PackedByteArray" />
@@ -35,6 +64,12 @@
 			If [code]true[/code], the MultiplayerAPI will allow encoding and decoding of object during RPCs.
 			[b]Warning:[/b] Deserialized objects can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threat such as remote code execution.
 		</member>
+		<member name="auth_callback" type="Callable" setter="set_auth_callback" getter="get_auth_callback">
+			The callback to execute when when receiving authentication data sent via [method send_auth]. If the [Callable] is empty (default), peers will be automatically accepted as soon as they connect.
+		</member>
+		<member name="auth_timeout" type="float" setter="set_auth_timeout" getter="get_auth_timeout" default="3.0">
+			If set to a value greater than [code]0.0[/code], the maximum amount of time peers can stay in the authenticating state, after which the authentication will automatically fail. See the [signal peer_authenticating] and [signal peer_authentication_failed] signals.
+		</member>
 		<member name="refuse_new_connections" type="bool" setter="set_refuse_new_connections" getter="is_refusing_new_connections" default="false">
 			If [code]true[/code], the MultiplayerAPI's [member MultiplayerAPI.multiplayer_peer] refuses new incoming connections.
 		</member>
@@ -48,6 +83,18 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="peer_authenticating">
+			<param index="0" name="id" type="int" />
+			<description>
+				Emitted when this MultiplayerAPI's [member MultiplayerAPI.multiplayer_peer] connects to a new peer and a valid [member auth_callback] is set. In this case, the [signal MultiplayerAPI.peer_connected] will not be emitted until [method complete_auth] is called with given peer [param id]. While in this state, the peer will not be included in the list returned by [method MultiplayerAPI.get_peers] (but in the one returned by [method get_authenticating_peers]), and only authentication data will be sent or received. See [method send_auth] for sending authentication data.
+			</description>
+		</signal>
+		<signal name="peer_authentication_failed">
+			<param index="0" name="id" type="int" />
+			<description>
+				Emitted when this MultiplayerAPI's [member MultiplayerAPI.multiplayer_peer] disconnects from a peer for which authentication had not yet completed. See [signal peer_authenticating].
+			</description>
+		</signal>
 		<signal name="peer_packet">
 			<param index="0" name="id" type="int" />
 			<param index="1" name="packet" type="PackedByteArray" />

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -113,9 +113,6 @@ protected:
 	void _add_peer(int p_id);
 	void _admit_peer(int p_id);
 	void _del_peer(int p_id);
-	void _connected_to_server();
-	void _connection_failed();
-	void _server_disconnected();
 	void _update_status();
 
 public:

--- a/modules/webrtc/doc_classes/WebRTCMultiplayerPeer.xml
+++ b/modules/webrtc/doc_classes/WebRTCMultiplayerPeer.xml
@@ -6,7 +6,7 @@
 	<description>
 		This class constructs a full mesh of [WebRTCPeerConnection] (one connection for each peer) that can be used as a [member MultiplayerAPI.multiplayer_peer].
 		You can add each [WebRTCPeerConnection] via [method add_peer] or remove them via [method remove_peer]. Peers must be added in [constant WebRTCPeerConnection.STATE_NEW] state to allow it to create the appropriate channels. This class will not create offers nor set descriptions, it will only poll them, and notify connections and disconnections.
-		[signal MultiplayerPeer.connection_succeeded] and [signal MultiplayerPeer.server_disconnected] will not be emitted unless the peer is created using [method create_client]. Beside that data transfer works like in a [MultiplayerPeer].
+		When creating the peer via [method create_client] or [method create_server] the [method MultiplayerPeer.is_server_relay_supported] method will return [code]true[/code] enabling peer exchange and packet relaying when supported by the [MultiplayerAPI] implementation.
 		[b]Note:[/b] When exporting to Android, make sure to enable the [code]INTERNET[/code] permission in the Android export preset before exporting the project or using one-click deploy. Otherwise, network communication of any kind will be blocked by Android.
 	</description>
 	<tutorials>

--- a/modules/webrtc/webrtc_multiplayer_peer.cpp
+++ b/modules/webrtc/webrtc_multiplayer_peer.cpp
@@ -341,11 +341,6 @@ void WebRTCMultiplayerPeer::remove_peer(int p_peer_id) {
 		peer->connected = false;
 		emit_signal(SNAME("peer_disconnected"), p_peer_id);
 		if (network_mode == MODE_CLIENT && p_peer_id == TARGET_PEER_SERVER) {
-			if (connection_status == CONNECTION_CONNECTING) {
-				emit_signal(SNAME("connection_failed"));
-			} else {
-				emit_signal(SNAME("server_disconnected"));
-			}
 			connection_status = CONNECTION_DISCONNECTED;
 		}
 	}

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -264,9 +264,7 @@ void WebSocketMultiplayerPeer::_poll_client() {
 		}
 	} else if (peer->get_ready_state() == WebSocketPeer::STATE_CLOSED) {
 		if (connection_status == CONNECTION_CONNECTED) {
-			emit_signal(SNAME("server_disconnected"));
-		} else {
-			emit_signal(SNAME("connection_failed"));
+			emit_signal(SNAME("peer_disconnected"), 1);
 		}
 		_clear();
 		return;
@@ -276,7 +274,6 @@ void WebSocketMultiplayerPeer::_poll_client() {
 		ERR_FAIL_COND(!pending_peers.has(1)); // Bug.
 		if (OS::get_singleton()->get_ticks_msec() - pending_peers[1].time > handshake_timeout) {
 			print_verbose(vformat("WebSocket handshake timed out after %.3f seconds.", handshake_timeout * 0.001));
-			emit_signal(SNAME("connection_failed"));
 			_clear();
 			return;
 		}

--- a/scene/main/multiplayer_peer.cpp
+++ b/scene/main/multiplayer_peer.cpp
@@ -123,9 +123,6 @@ void MultiplayerPeer::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("peer_connected", PropertyInfo(Variant::INT, "id")));
 	ADD_SIGNAL(MethodInfo("peer_disconnected", PropertyInfo(Variant::INT, "id")));
-	ADD_SIGNAL(MethodInfo("server_disconnected"));
-	ADD_SIGNAL(MethodInfo("connection_succeeded"));
-	ADD_SIGNAL(MethodInfo("connection_failed"));
 }
 
 /*************/


### PR DESCRIPTION
This PR adds support for pre-authenticating peers in `SceneMultiplayer` before letting them join the multiplayer session (i.e. before RPCs and replication starts).

Workflow explanation:

- Use `set_auth_callback(callback)` to enable the authentication features.
  The callback must be a `Callable` that accepts an `int` (the peer ID), and a `PackedByteArray` of data which will be called when authentication data is received.
- The `peer_authenticating(id)` signal will be emitted instead of  `peer_connected` when a new peer connects.
- Use `send_auth(id: int, data: PackedByteArray)` to send authentication data.
- Call `complete_auth(id: int)` when the authentication process is complete and you expect to start receiving game data.
- The `peer_connected` signal will be emitted as soon as both parties complete the authentication.
- Use `disconnect_peer(id)` to disconnect a connected peer.
- If the `peer_connected` signal didn't fire for that peer (i.e. it was still in the authentication phase), the `peer_auth_failed` signal will be emitted instead of `peer_disconnected`.

Closes https://github.com/godotengine/godot-proposals/issues/548

[Here a demo](https://github.com/Faless/gd-mp-password-auth) using it to implement 

Draft status:
- [x] ~Based on https://github.com/godotengine/godot/pull/67094~
- [x] ~Maybe `get_pending_peers` method, and `authentication_timeout = 3.0`.~ Done
- [x] Need few ENet/WebSocket fixes also present in `master`, which ~may be~ have been splitted into their own PR, along with `MultiplayerPeer.disconnect_peer` and `MultiplayerPeer.close`. https://github.com/godotengine/godot/pull/67982