### PR TITLE
Expose near lossless WebP encoding

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2922,7 +2922,7 @@ void (*Image::_image_decompress_bptc)(Image *) = nullptr;
 void (*Image::_image_decompress_etc1)(Image *) = nullptr;
 void (*Image::_image_decompress_etc2)(Image *) = nullptr;
 
-Vector<uint8_t> (*Image::webp_lossy_packer)(const Ref<Image> &, float) = nullptr;
+Vector<uint8_t> (*Image::webp_lossy_packer)(const Ref<Image> &, float, bool) = nullptr;
 Vector<uint8_t> (*Image::webp_lossless_packer)(const Ref<Image> &) = nullptr;
 Ref<Image> (*Image::webp_unpacker)(const Vector<uint8_t> &) = nullptr;
 Vector<uint8_t> (*Image::png_packer)(const Ref<Image> &) = nullptr;

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -150,7 +150,7 @@ public:
 	static void (*_image_decompress_etc1)(Image *);
 	static void (*_image_decompress_etc2)(Image *);
 
-	static Vector<uint8_t> (*webp_lossy_packer)(const Ref<Image> &p_image, float p_quality);
+	static Vector<uint8_t> (*webp_lossy_packer)(const Ref<Image> &p_image, float p_quality, bool p_near_lossless);
 	static Vector<uint8_t> (*webp_lossless_packer)(const Ref<Image> &p_image);
 	static Ref<Image> (*webp_unpacker)(const Vector<uint8_t> &p_buffer);
 	static Vector<uint8_t> (*png_packer)(const Ref<Image> &p_image);

--- a/doc/classes/PortableCompressedTexture2D.xml
+++ b/doc/classes/PortableCompressedTexture2D.xml
@@ -19,10 +19,12 @@
 			<param index="1" name="compression_mode" type="int" enum="PortableCompressedTexture2D.CompressionMode" />
 			<param index="2" name="normal_map" type="bool" default="false" />
 			<param index="3" name="lossy_quality" type="float" default="0.8" />
+			<param index="4" name="near_lossless" type="bool" default="false" />
 			<description>
 				Initializes the compressed texture from a base image. The compression mode must be provided.
-				If this image will be used as a normal map, the "normal map" flag is recommended, to ensure optimum quality.
+				[param normal_map] is recommended to ensure optimum quality if this image will be used as a normal map.
 				If lossy compression is requested, the quality setting can optionally be provided. This maps to Lossy WEBP compression quality.
+				Additionally, you may trigger near lossless compression with [param near_lossless].
 			</description>
 		</method>
 		<method name="get_compression_mode" qualifiers="const">

--- a/editor/import/resource_importer_layered_texture.h
+++ b/editor/import/resource_importer_layered_texture.h
@@ -50,6 +50,7 @@ public:
 	Vector<Ref<Image>> *slices = nullptr;
 	int compress_mode = 0;
 	float lossy = 1.0;
+	bool near_lossless = false;
 	int hdr_compression = 0;
 	int bptc_ldr = 0;
 	bool mipmaps = true;
@@ -110,7 +111,7 @@ public:
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 
-	void _save_tex(Vector<Ref<Image>> p_images, const String &p_to_path, int p_compress_mode, float p_lossy, Image::CompressMode p_vram_compression, Image::CompressSource p_csource, Image::UsedChannels used_channels, bool p_mipmaps, bool p_force_po2);
+	void _save_tex(Vector<Ref<Image>> p_images, const String &p_to_path, int p_compress_mode, float p_lossy, bool p_near_lossless, Image::CompressMode p_vram_compression, Image::CompressSource p_csource, Image::UsedChannels used_channels, bool p_mipmaps, bool p_force_po2);
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -74,10 +74,10 @@ protected:
 	static ResourceImporterTexture *singleton;
 	static const char *compression_formats[];
 
-	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel);
+	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, bool p_near_lossless, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel);
 
 public:
-	static void save_to_ctex_format(Ref<FileAccess> f, const Ref<Image> &p_image, CompressMode p_compress_mode, Image::UsedChannels p_channels, Image::CompressMode p_compress_format, float p_lossy_quality);
+	static void save_to_ctex_format(Ref<FileAccess> f, const Ref<Image> &p_image, CompressMode p_compress_mode, Image::UsedChannels p_channels, Image::CompressMode p_compress_format, float p_lossy_quality, bool p_near_lossless);
 
 	static ResourceImporterTexture *get_singleton() { return singleton; }
 	virtual String get_importer_name() const override;

--- a/modules/webp/resource_saver_webp.cpp
+++ b/modules/webp/resource_saver_webp.cpp
@@ -67,7 +67,7 @@ Error ResourceSaverWebP::save_image(const String &p_path, const Ref<Image> &p_im
 Vector<uint8_t> ResourceSaverWebP::save_image_to_buffer(const Ref<Image> &p_img, const bool p_lossy, const float p_quality) {
 	Vector<uint8_t> buffer;
 	if (p_lossy) {
-		buffer = WebPCommon::_webp_lossy_pack(p_img, p_quality);
+		buffer = WebPCommon::_webp_lossy_pack(p_img, p_quality, false);
 	} else {
 		buffer = WebPCommon::_webp_lossless_pack(p_img);
 	}

--- a/modules/webp/webp_common.h
+++ b/modules/webp/webp_common.h
@@ -35,8 +35,10 @@
 
 namespace WebPCommon {
 // Given an image, pack this data into a WebP file.
-Vector<uint8_t> _webp_lossy_pack(const Ref<Image> &p_image, float p_quality);
+Vector<uint8_t> _webp_lossy_pack(const Ref<Image> &p_image, float p_quality, bool p_near_lossless);
 Vector<uint8_t> _webp_lossless_pack(const Ref<Image> &p_image);
+// Helper function for those above.
+Vector<uint8_t> _webp_lossless_helper(const Ref<Image> &p_image, int p_near_lossless_quality = 100);
 // Given a WebP file, unpack it into an image.
 Ref<Image> _webp_unpack(const Vector<uint8_t> &p_buffer);
 Error webp_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p_buffer_len);

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -422,7 +422,7 @@ Vector<uint8_t> PortableCompressedTexture2D::_get_data() const {
 	return compressed_buffer;
 }
 
-void PortableCompressedTexture2D::create_from_image(const Ref<Image> &p_image, CompressionMode p_compression_mode, bool p_normal_map, float p_lossy_quality) {
+void PortableCompressedTexture2D::create_from_image(const Ref<Image> &p_image, CompressionMode p_compression_mode, bool p_normal_map, float p_lossy_quality, bool p_near_lossless) {
 	ERR_FAIL_COND(p_image.is_null() || p_image->is_empty());
 
 	Vector<uint8_t> buffer;
@@ -440,7 +440,7 @@ void PortableCompressedTexture2D::create_from_image(const Ref<Image> &p_image, C
 			for (int i = 0; i < p_image->get_mipmap_count() + 1; i++) {
 				Vector<uint8_t> data;
 				if (p_compression_mode == COMPRESSION_MODE_LOSSY) {
-					data = Image::webp_lossy_packer(p_image->get_image_from_mipmap(i), p_lossy_quality);
+					data = Image::webp_lossy_packer(p_image->get_image_from_mipmap(i), p_lossy_quality, p_near_lossless);
 				} else {
 					data = Image::webp_lossless_packer(p_image->get_image_from_mipmap(i));
 				}
@@ -607,7 +607,7 @@ bool PortableCompressedTexture2D::is_keeping_compressed_buffer() const {
 }
 
 void PortableCompressedTexture2D::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("create_from_image", "image", "compression_mode", "normal_map", "lossy_quality"), &PortableCompressedTexture2D::create_from_image, DEFVAL(false), DEFVAL(0.8));
+	ClassDB::bind_method(D_METHOD("create_from_image", "image", "compression_mode", "normal_map", "lossy_quality", "near_lossless"), &PortableCompressedTexture2D::create_from_image, DEFVAL(false), DEFVAL(0.8), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_format"), &PortableCompressedTexture2D::get_format);
 	ClassDB::bind_method(D_METHOD("get_compression_mode"), &PortableCompressedTexture2D::get_compression_mode);
 

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -174,7 +174,7 @@ protected:
 
 public:
 	CompressionMode get_compression_mode() const;
-	void create_from_image(const Ref<Image> &p_image, CompressionMode p_compression_mode, bool p_normal_map = false, float p_lossy_quality = 0.8);
+	void create_from_image(const Ref<Image> &p_image, CompressionMode p_compression_mode, bool p_normal_map = false, float p_lossy_quality = 0.8, bool p_near_lossless = false);
 
 	Image::Format get_format() const;
 


### PR DESCRIPTION
**Bugsquad edit removed, as it is now invalid.**
**I still intend to use this PR for the implementation, so I ask to keep it open.**

Adds a checkable option to texture importers called Near Lossless, when Mode is set to Lossy:

![image](https://user-images.githubusercontent.com/60024671/198288912-af4faff6-d109-404c-8619-0cdedff8acc7.png)

It also affects other Lossy importers:

![image](https://user-images.githubusercontent.com/60024671/198290186-7e616afb-6a02-44ec-9de3-aea945c83d18.png)

When checked, importing will use the same workflow as Lossless, but the value of Lossy Quality will be passed to `config.near_lossless`, which decreases image quality in order to reduce its size (while keeping RGB(A) color space instead of using lossy's YUV(A)420) when below 100. This is a built-in feature in libwebp.

A few things to note:
- WebP Compression Level project setting will affect images imported as Near Lossless. #67948 kinda solves this.
- The image will be imported as true lossless if Lossy Quality is set to 1.0 (`config.near_lossless`' default is 100) or the image being imported is too simple.