### PR TITLE
Add optional stream argument to AudioStreamRandomizer.add_stream

### DIFF
--- a/doc/classes/AudioStreamRandomizer.xml
+++ b/doc/classes/AudioStreamRandomizer.xml
@@ -12,8 +12,10 @@
 		<method name="add_stream">
 			<return type="void" />
 			<param index="0" name="index" type="int" />
+			<param index="1" name="stream" type="AudioStream" />
+			<param index="2" name="weight" type="float" default="1.0" />
 			<description>
-				Insert a stream at the specified index.
+				Insert a stream at the specified index. If the index is less than zero, the insertion occurs at the end of the underlying pool.
 			</description>
 		</method>
 		<method name="get_stream" qualifiers="const">

--- a/editor/plugins/audio_stream_randomizer_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_randomizer_editor_plugin.cpp
@@ -81,7 +81,7 @@ void AudioStreamRandomizerEditorPlugin::_move_stream_array_element(Object *p_und
 	if (p_from_index < 0) {
 		undo_redo_man->add_undo_method(randomizer, "remove_stream", p_to_pos < 0 ? randomizer->get_streams_count() : p_to_pos);
 	} else if (p_to_pos < 0) {
-		undo_redo_man->add_undo_method(randomizer, "add_stream", p_from_index);
+		undo_redo_man->add_undo_method(randomizer, "add_stream", p_from_index, Ref<AudioStream>());
 	}
 
 	List<PropertyInfo> properties;
@@ -107,7 +107,7 @@ void AudioStreamRandomizerEditorPlugin::_move_stream_array_element(Object *p_und
 #undef ADD_UNDO
 
 	if (p_from_index < 0) {
-		undo_redo_man->add_do_method(randomizer, "add_stream", p_to_pos);
+		undo_redo_man->add_do_method(randomizer, "add_stream", p_to_pos, Ref<AudioStream>());
 	} else if (p_to_pos < 0) {
 		undo_redo_man->add_do_method(randomizer, "remove_stream", p_from_index);
 	} else {

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -410,12 +410,12 @@ AudioStreamPlaybackMicrophone::AudioStreamPlaybackMicrophone() {
 
 ////////////////////////////////
 
-void AudioStreamRandomizer::add_stream(int p_index) {
+void AudioStreamRandomizer::add_stream(int p_index, Ref<AudioStream> p_stream, float p_weight) {
 	if (p_index < 0) {
 		p_index = audio_stream_pool.size();
 	}
 	ERR_FAIL_COND(p_index > audio_stream_pool.size());
-	PoolEntry entry{ nullptr, 1.0f };
+	PoolEntry entry{ p_stream, p_weight };
 	audio_stream_pool.insert(p_index, entry);
 	emit_signal(SNAME("changed"));
 	notify_property_list_changed();
@@ -709,7 +709,7 @@ void AudioStreamRandomizer::_get_property_list(List<PropertyInfo> *p_list) const
 }
 
 void AudioStreamRandomizer::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_stream", "index"), &AudioStreamRandomizer::add_stream);
+	ClassDB::bind_method(D_METHOD("add_stream", "index", "stream", "weight"), &AudioStreamRandomizer::add_stream, DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("move_stream", "index_from", "index_to"), &AudioStreamRandomizer::move_stream);
 	ClassDB::bind_method(D_METHOD("remove_stream", "index"), &AudioStreamRandomizer::remove_stream);
 

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -241,7 +241,7 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
 public:
-	void add_stream(int p_index);
+	void add_stream(int p_index, Ref<AudioStream> p_stream, float p_weight = 1.0);
 	void move_stream(int p_index_from, int p_index_to);
 	void remove_stream(int p_index);
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #67904 

This PR adds an optional stream argument to AudioStreamRandomizer.add_stream. This preserves the behavior of the inspector code to be able to insert empty elements. I'm not sure if it's worth documenting, but I also added in a note about the end insertion behavior in add_stream.

I wasn't sure, but would it make sense to also add the weight as an optional argument to add_stream as well? 
