### PR TITLE
Fix problems with `tab_changed` signal when removing multiple tabs at once

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -345,7 +345,7 @@ Vector<Control *> TabContainer::_get_tab_controls() const {
 	Vector<Control *> controls;
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *control = Object::cast_to<Control>(get_child(i));
-		if (!control || control->is_set_as_top_level() || control == tab_bar || control == child_removing) {
+		if (!control || control->is_set_as_top_level() || control == tab_bar || children_removing.has(control)) {
 			continue;
 		}
 
@@ -584,10 +584,10 @@ void TabContainer::remove_child_notify(Node *p_child) {
 
 	int idx = get_tab_idx_from_control(c);
 
-	// Before this, the tab control has not changed; after this, the tab control has changed.
-	child_removing = p_child;
+	// As the child hasn't been removed yet, keep track of it so when the "tab_changed" signal is fired it can be ignored.
+	children_removing.push_back(c);
 	tab_bar->remove_tab(idx);
-	child_removing = nullptr;
+	children_removing.erase(c);
 
 	_update_margins();
 	if (get_tab_count() == 0) {

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -46,7 +46,7 @@ class TabContainer : public Container {
 	bool drag_to_rearrange_enabled = false;
 	bool use_hidden_tabs_for_min_size = false;
 	bool theme_changing = false;
-	Node *child_removing = nullptr;
+	Vector<Control *> children_removing;
 
 	struct ThemeCache {
 		int side_margin = 0;


### PR DESCRIPTION
This PR makes possible to keep track of multiple removed children in a `TabContainer`, avoiding problems when doing so from the `tab_changed` signal.

This PR is an alternative to #63176.