### PR TITLE
[DisplayServer] Hide internal window creation/deletion methods and expose some missing methods.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -44,16 +44,6 @@
 				[b]Note:[/b] This method is only implemented on Linux (X11).
 			</description>
 		</method>
-		<method name="create_sub_window">
-			<return type="int" />
-			<param index="0" name="mode" type="int" enum="DisplayServer.WindowMode" />
-			<param index="1" name="vsync_mode" type="int" enum="DisplayServer.VSyncMode" />
-			<param index="2" name="flags" type="int" />
-			<param index="3" name="rect" type="Rect2i" default="Rect2i(0, 0, 0, 0)" />
-			<description>
-				Create a new subwindow (a [Window] whose presence is linked to another window). This window will appear to be embedded within the main window if [member Viewport.gui_embed_subwindows] is [code]true[/code]. Otherwise, the window will appear to be a separate window which can be dragged outside the main window. [code]vsync_mode[/code] is ignored if [member Viewport.gui_embed_subwindows] is [code]true[/code], as the subwindow will be drawn at the same time as the main window in this case.
-			</description>
-		</method>
 		<method name="cursor_get_shape" qualifiers="const">
 			<return type="int" enum="DisplayServer.CursorShape" />
 			<description>
@@ -74,13 +64,6 @@
 			<param index="0" name="shape" type="int" enum="DisplayServer.CursorShape" />
 			<description>
 				Sets the default mouse cursor shape. The cursor's appearance will vary depending on the user's operating system and mouse cursor theme. See also [method cursor_get_shape] and [method cursor_set_custom_image].
-			</description>
-		</method>
-		<method name="delete_sub_window">
-			<return type="void" />
-			<param index="0" name="window_id" type="int" />
-			<description>
-				Removes the subwindow specified by [param window_id].
 			</description>
 		</method>
 		<method name="dialog_input_text">
@@ -391,6 +374,14 @@
 			<param index="1" name="idx" type="int" />
 			<description>
 				Returns the callback of the item at index [param idx].
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
+		<method name="global_menu_get_item_count" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="menu_root" type="String" />
+			<description>
+				Returns number of items in the global menu with ID [param menu_root].
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -1089,14 +1080,6 @@
 				Sets the mouse cursor position to the given [param position] relative to an origin at the upper left corner of the currently focused game Window Manager window.
 			</description>
 		</method>
-		<method name="window_attach_instance_id">
-			<return type="void" />
-			<param index="0" name="instance_id" type="int" />
-			<param index="1" name="window_id" type="int" default="0" />
-			<description>
-				Sets the [Window] instance ID ([method Object.get_instance_id]) the [param window_id] should be attached to. See also [method window_get_attached_instance_id].
-			</description>
-		</method>
 		<method name="window_can_draw" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="window_id" type="int" default="0" />
@@ -1202,6 +1185,13 @@
 			<param index="0" name="window_id" type="int" default="0" />
 			<description>
 				Returns the V-Sync mode of the given window.
+			</description>
+		</method>
+		<method name="window_is_maximize_allowed" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="window_id" type="int" default="0" />
+			<description>
+				Returns [code]true[/code] if the given window can be maximized (the maximize button is enabled).
 			</description>
 		</method>
 		<method name="window_maximize_on_title_dbl_click" qualifiers="const">

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -581,6 +581,8 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("global_menu_set_item_icon", "menu_root", "idx", "icon"), &DisplayServer::global_menu_set_item_icon);
 	ClassDB::bind_method(D_METHOD("global_menu_set_item_indentation_level", "menu_root", "idx", "level"), &DisplayServer::global_menu_set_item_indentation_level);
 
+	ClassDB::bind_method(D_METHOD("global_menu_get_item_count", "menu_root"), &DisplayServer::global_menu_get_item_count);
+
 	ClassDB::bind_method(D_METHOD("global_menu_remove_item", "menu_root", "idx"), &DisplayServer::global_menu_remove_item);
 	ClassDB::bind_method(D_METHOD("global_menu_clear", "menu_root"), &DisplayServer::global_menu_clear);
 
@@ -636,9 +638,6 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_window_list"), &DisplayServer::get_window_list);
 	ClassDB::bind_method(D_METHOD("get_window_at_screen_position", "position"), &DisplayServer::get_window_at_screen_position);
 
-	ClassDB::bind_method(D_METHOD("create_sub_window", "mode", "vsync_mode", "flags", "rect"), &DisplayServer::create_sub_window, DEFVAL(Rect2i()));
-	ClassDB::bind_method(D_METHOD("delete_sub_window", "window_id"), &DisplayServer::delete_sub_window);
-
 	ClassDB::bind_method(D_METHOD("window_get_native_handle", "handle_type", "window_id"), &DisplayServer::window_get_native_handle, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_get_active_popup"), &DisplayServer::window_get_active_popup);
 	ClassDB::bind_method(D_METHOD("window_set_popup_safe_rect", "window", "rect"), &DisplayServer::window_set_popup_safe_rect);
@@ -661,7 +660,6 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("window_set_input_text_callback", "callback", "window_id"), &DisplayServer::window_set_input_text_callback, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_set_drop_files_callback", "callback", "window_id"), &DisplayServer::window_set_drop_files_callback, DEFVAL(MAIN_WINDOW_ID));
 
-	ClassDB::bind_method(D_METHOD("window_attach_instance_id", "instance_id", "window_id"), &DisplayServer::window_attach_instance_id, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_get_attached_instance_id", "window_id"), &DisplayServer::window_get_attached_instance_id, DEFVAL(MAIN_WINDOW_ID));
 
 	ClassDB::bind_method(D_METHOD("window_get_max_size", "window_id"), &DisplayServer::window_get_max_size, DEFVAL(MAIN_WINDOW_ID));
@@ -695,6 +693,7 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("window_set_vsync_mode", "vsync_mode", "window_id"), &DisplayServer::window_set_vsync_mode, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_get_vsync_mode", "window_id"), &DisplayServer::window_get_vsync_mode, DEFVAL(MAIN_WINDOW_ID));
 
+	ClassDB::bind_method(D_METHOD("window_is_maximize_allowed", "window_id"), &DisplayServer::window_is_maximize_allowed, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_maximize_on_title_dbl_click"), &DisplayServer::window_maximize_on_title_dbl_click);
 	ClassDB::bind_method(D_METHOD("window_minimize_on_title_dbl_click"), &DisplayServer::window_minimize_on_title_dbl_click);
 


### PR DESCRIPTION
- Hides `create_sub_window`/`delete_sub_window`/`window_attach_instance_id` methods are intended to be used by `Window` class, and using them directly will result in unusable, hidden window without `Viewport` (or broken `Window` if native window deleted or reattached).
- Exposes missing `global_menu_get_item_count` and `window_is_maximize_allowed` methods.