### PR TITLE
[NavigationAgent2D/3D]: target_reached signal is emitted before internal state is updated

### DIFF
--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -478,8 +478,8 @@ void NavigationAgent2D::_request_repath() {
 void NavigationAgent2D::_check_distance_to_target() {
 	if (!target_reached) {
 		if (distance_to_target() < target_desired_distance) {
-			emit_signal(SNAME("target_reached"));
 			target_reached = true;
+			emit_signal(SNAME("target_reached"));
 		}
 	}
 }

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -495,8 +495,8 @@ void NavigationAgent3D::_request_repath() {
 void NavigationAgent3D::_check_distance_to_target() {
 	if (!target_reached) {
 		if (distance_to_target() < target_desired_distance) {
-			emit_signal(SNAME("target_reached"));
 			target_reached = true;
+			emit_signal(SNAME("target_reached"));
 		}
 	}
 }


### PR DESCRIPTION
When using a `NavigationAgent2D` or `NavigationAgent3D` the signal that gets emitted once the agent has reached its target (`target_reached`) is sent before the internal state is properly updated. 

Namely, the `target_reached` property of the agent will be overridden once the signal has been processed. When listereners to the signal try to issue a new target, as in:

```gdscript
# agent is a NavigationAgent2D or NavigationAgent3D
...
func on_target_reached() -> void:
    agent.set_target_location(some_new_location)
```
its internal state is (correctly) reset, but directly thereafter the `target_reached` property is set to `true` again. This `true` is based on the old target, not the new one, and thus the agent enters a corrupt state where it thinks it reached it's target but it actually hasn't.

The solution is to delay the emission of the signal until the internal state has been changed. Which also makes sense since the actual reaching of the target should only complete once the internal representation is reflecting that.

I don't see any downsides to delaying the emission of the signal, and since all the tests still pass I assume this change can be safely made. I've attached a minimal reproduction project and two gifs from its execution before and after the change

[minimal_repro_project](https://github.com/godotengine/godot/files/9879027/NavAgentReached.zip)

[before_change.webm](https://user-images.githubusercontent.com/298829/198250770-18e51267-b673-463e-880d-412b3fb05423.webm)

[after_change.webm](https://user-images.githubusercontent.com/298829/198251097-40fc4614-c464-44ce-be95-16027ca89708.webm)
