### PR TITLE
[3.x] Fix spatial gizmo still active when node is deselected

### DIFF
--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -752,6 +752,7 @@ private:
 
 	bool is_any_freelook_active() const;
 
+	void _selection_changed();
 	void _refresh_menu_icons();
 
 protected:


### PR DESCRIPTION
Fixes #51059

This PR hides a spatial gizmo when:

* No node is selected.
* Multiple nodes are selected.
* A non-Spatial node is selected.

This is how Node3D gizmos are hidden on `master`.