### PR TITLE
Fixed crash when renaming node in animation blend tree editor

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -119,8 +119,17 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 	graph->clear_connections();
 	//erase all nodes
 	for (int i = 0; i < graph->get_child_count(); i++) {
-		if (Object::cast_to<GraphNode>(graph->get_child(i))) {
-			memdelete(graph->get_child(i));
+		GraphNode *graph_node = Object::cast_to<GraphNode>(graph->get_child(i));
+		if (graph_node) {
+			Ref<AnimationNode> agnode = blend_tree->get_node(graph_node->get_name());
+			for (int j = 0; j < graph_node->get_child_count(); j++) {
+				LineEdit *le = Object::cast_to<LineEdit>(graph_node->get_child(j));
+
+				if (le) {
+					le->disconnect("focus_exited", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_renamed_focus_out).bind(le, agnode));
+				}
+			}
+			memdelete(graph_node);
 			i--;
 		}
 	}


### PR DESCRIPTION
Related to #67941

This fix removes the issue and crash for me, my only problem is why does it remove it.
As i understand it, shouldn't deleting the graph_node also delete the line_edit and it's signals?

I checked and LineEdit is indeed deleted when graphnode is deleted, but the signal is still present?
Weird

Also, should we delete the other signals, should not be needed.