### PR TITLE
Allow changing imported AnimationLibrary names in AnimationPlayer in the editor

### DIFF
--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -668,7 +668,7 @@ void AnimationLibraryEditor::update_tree() {
 			}
 		}
 
-		libitem->set_editable(0, !animation_library_is_foreign);
+		libitem->set_editable(0, true);
 		libitem->set_metadata(0, K);
 		libitem->set_icon(0, get_editor_theme_icon("AnimationLibrary"));
 


### PR DESCRIPTION
Fixes #65625. Doesn't make anything else editable.