### PR TITLE
Fix color picker mode buttons

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1591,9 +1591,6 @@ ColorPicker::ColorPicker() :
 		mode_hbc->add_child(mode_btns[i]);
 		mode_btns[i]->set_focus_mode(FOCUS_NONE);
 		mode_btns[i]->set_h_size_flags(SIZE_EXPAND_FILL);
-		mode_btns[i]->add_theme_style_override("pressed", get_theme_stylebox("tab_selected", "TabContainer"));
-		mode_btns[i]->add_theme_style_override("normal", get_theme_stylebox("tab_unselected", "TabContainer"));
-		mode_btns[i]->add_theme_style_override("hover", get_theme_stylebox("tab_selected", "TabContainer"));
 		mode_btns[i]->set_toggle_mode(true);
 		mode_btns[i]->set_text(modes[i]->get_name());
 		mode_btns[i]->set_button_group(mode_group);


### PR DESCRIPTION
These three buttons have been an eyesore for me for the last couple of weeks.
The changes are trivial, and theme override for these buttons seem unnecessary in any case (they aren't really attached to a tab container), not to mention that it makes them look barely readable in the light mode (yes, I'm using it wherever I can because of eyesight reasons).

**EDIT:** That icon on the shape popup button? Yes, dark/light mode icons are already broken in various places, so it needs to be fixed globally, not just in the color picker.

### Before
Light | Dark
------|------
![Godot Color Picker Before](https://user-images.githubusercontent.com/5585984/198499660-3901b5cf-82f5-4231-9224-37503f01e1f8.png) | ![Godot Color Picker Dark Before](https://user-images.githubusercontent.com/5585984/198499665-97c308e2-58bf-4e6c-ba3c-77005e7a0f34.png)

### After
Light | Dark
------|------
![Godot Color Picker After](https://user-images.githubusercontent.com/5585984/198499691-35661827-2bb0-47e5-adaa-32d095ed9fa0.png) | ![Godot Color Picker Dark After](https://user-images.githubusercontent.com/5585984/198499696-d8d009fe-b648-4392-9e8e-ba0a808ddb28.png)
