### PR TITLE
Fix inconsistency between vector field texture and world space directions

### DIFF
--- a/servers/rendering/renderer_rd/shaders/particles.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles.glsl
@@ -462,7 +462,7 @@ void main() {
 					if (any(lessThan(uvw_pos, vec3(0.0))) || any(greaterThan(uvw_pos, vec3(1.0)))) {
 						continue;
 					}
-					vec3 s = texture(sampler3D(sdf_vec_textures[FRAME.attractors[i].texture_index], material_samplers[SAMPLER_LINEAR_CLAMP]), uvw_pos).xyz * 2.0 - 1.0;
+					vec3 s = texture(sampler3D(sdf_vec_textures[FRAME.attractors[i].texture_index], material_samplers[SAMPLER_LINEAR_CLAMP]), uvw_pos).xyz * -2.0 + 1.0;
 					dir = mat3(FRAME.attractors[i].transform) * safe_normalize(s); //revert direction
 					amount = length(s);
 


### PR DESCRIPTION
This is a follow-up to #63627

When I pushed that PR I didn't think to check whether vectors in the game world matched their corresponding color in the texture, i.e. whether a red pixel in the vector field texture with a value greater than 0.5 corresponds to movement along positive X in the world.

Now that I arrived at that point in writing the [documentation for the particle system](https://github.com/godotengine/godot-docs/pull/5535), I had to make sure and it turns out I got the directions flipped. So positive movement along X in the texture turns into negative movement in the shader; the same with Y and Z.

The fix is fairly simple and makes vector field attractors more predictable and easier to reason about.
