### PR TITLE
Add optional UV2 logic for lightmapping to primitive shapes

### DIFF
--- a/doc/classes/PrimitiveMesh.xml
+++ b/doc/classes/PrimitiveMesh.xml
@@ -34,6 +34,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="add_uv2" type="bool" setter="set_add_uv2" getter="get_add_uv2" default="false">
+			If set, generates UV2 UV coordinates applying a padding using the [member uv2_padding] setting. UV2 is needed for lightmapping.
+		</member>
 		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb" default="AABB(0, 0, 0, 0, 0, 0)">
 			Overrides the [AABB] with one defined by user for use with frustum culling. Especially useful to avoid unexpected culling when using a shader to offset vertices.
 		</member>
@@ -43,6 +46,9 @@
 		</member>
 		<member name="material" type="Material" setter="set_material" getter="get_material">
 			The current [Material] of the primitive mesh.
+		</member>
+		<member name="uv2_padding" type="float" setter="set_uv2_padding" getter="get_uv2_padding" default="2.0">
+			If [member add_uv2] is set, specifies the padding in pixels applied along seams of the mesh. If at generation the size of the lightmap texture can't be determined, the UVs are calculated assuming a texture size of 1024x1024.
 		</member>
 	</members>
 </class>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2016,6 +2016,9 @@
 		<member name="rendering/lightmapping/bake_quality/ultra_quality_ray_count" type="int" setter="" getter="" default="1024">
 			The number of rays to use for baking lightmaps with [LightmapGI] when [member LightmapGI.quality] is [constant LightmapGI.BAKE_QUALITY_ULTRA].
 		</member>
+		<member name="rendering/lightmapping/primitive_meshes/texel_size" type="float" setter="" getter="" default="0.2">
+			The texel_size that is used to calculate the [member Mesh.lightmap_size_hint] on [PrimitiveMesh] resources if [member PrimitiveMesh.add_uv2] is enabled.
+		</member>
 		<member name="rendering/lightmapping/probe_capture/update_speed" type="float" setter="" getter="" default="15">
 			The framerate-independent update speed when representing dynamic object lighting from [LightmapProbe]s. Higher values make dynamic object lighting update faster. Higher values can prevent fast-moving objects from having "outdated" indirect lighting displayed on them, at the cost of possible flickering when an object moves from a bright area to a shaded area.
 		</member>

--- a/modules/lightmapper_rd/register_types.cpp
+++ b/modules/lightmapper_rd/register_types.cpp
@@ -57,6 +57,7 @@ void initialize_lightmapper_rd_module(ModuleInitializationLevel p_level) {
 	GLOBAL_DEF("rendering/lightmapping/bake_quality/high_quality_probe_ray_count", 512);
 	GLOBAL_DEF("rendering/lightmapping/bake_quality/ultra_quality_probe_ray_count", 2048);
 	GLOBAL_DEF("rendering/lightmapping/bake_performance/max_rays_per_probe_pass", 64);
+	GLOBAL_DEF("rendering/lightmapping/primitive_meshes/texel_size", 0.2);
 #ifndef _3D_DISABLED
 	GDREGISTER_CLASS(LightmapperRD);
 	Lightmapper::create_gpu = create_lightmapper_rd;

--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -56,6 +56,9 @@ private:
 	Ref<Material> material;
 	bool flip_faces = false;
 
+	bool add_uv2 = false;
+	float uv2_padding = 2.0;
+
 	// make sure we do an update after we've finished constructing our object
 	mutable bool pending_request = true;
 	void _update() const;
@@ -69,6 +72,10 @@ protected:
 	virtual void _create_mesh_array(Array &p_arr) const {}
 	void _request_update();
 	GDVIRTUAL0RC(Array, _create_mesh_array)
+
+	Vector2 get_uv2_scale(Vector2 p_margin_scale = Vector2(1.0, 1.0)) const;
+	float get_lightmap_texel_size() const;
+	virtual void _update_lightmap_size(){};
 
 public:
 	virtual int get_surface_count() const override;
@@ -98,6 +105,12 @@ public:
 	void set_flip_faces(bool p_enable);
 	bool get_flip_faces() const;
 
+	void set_add_uv2(bool p_enable);
+	bool get_add_uv2() const { return add_uv2; }
+
+	void set_uv2_padding(float p_padding);
+	float get_uv2_padding() const { return uv2_padding; }
+
 	PrimitiveMesh();
 	~PrimitiveMesh();
 };
@@ -118,8 +131,10 @@ protected:
 	static void _bind_methods();
 	virtual void _create_mesh_array(Array &p_arr) const override;
 
+	virtual void _update_lightmap_size() override;
+
 public:
-	static void create_mesh_array(Array &p_arr, float radius, float height, int radial_segments = 64, int rings = 8);
+	static void create_mesh_array(Array &p_arr, float radius, float height, int radial_segments = 64, int rings = 8, bool p_add_uv2 = false, const float p_uv2_padding = 1.0);
 
 	void set_radius(const float p_radius);
 	float get_radius() const;
@@ -152,8 +167,10 @@ protected:
 	static void _bind_methods();
 	virtual void _create_mesh_array(Array &p_arr) const override;
 
+	virtual void _update_lightmap_size() override;
+
 public:
-	static void create_mesh_array(Array &p_arr, Vector3 size, int subdivide_w = 0, int subdivide_h = 0, int subdivide_d = 0);
+	static void create_mesh_array(Array &p_arr, Vector3 size, int subdivide_w = 0, int subdivide_h = 0, int subdivide_d = 0, bool p_add_uv2 = false, const float p_uv2_padding = 1.0);
 
 	void set_size(const Vector3 &p_size);
 	Vector3 get_size() const;
@@ -190,8 +207,10 @@ protected:
 	static void _bind_methods();
 	virtual void _create_mesh_array(Array &p_arr) const override;
 
+	virtual void _update_lightmap_size() override;
+
 public:
-	static void create_mesh_array(Array &p_arr, float top_radius, float bottom_radius, float height, int radial_segments = 64, int rings = 4, bool cap_top = true, bool cap_bottom = true);
+	static void create_mesh_array(Array &p_arr, float top_radius, float bottom_radius, float height, int radial_segments = 64, int rings = 4, bool cap_top = true, bool cap_bottom = true, bool p_add_uv2 = false, const float p_uv2_padding = 1.0);
 
 	void set_top_radius(const float p_radius);
 	float get_top_radius() const;
@@ -240,6 +259,8 @@ private:
 protected:
 	static void _bind_methods();
 	virtual void _create_mesh_array(Array &p_arr) const override;
+
+	virtual void _update_lightmap_size() override;
 
 public:
 	void set_size(const Size2 &p_size);
@@ -292,6 +313,8 @@ protected:
 	static void _bind_methods();
 	virtual void _create_mesh_array(Array &p_arr) const override;
 
+	virtual void _update_lightmap_size() override;
+
 public:
 	void set_left_to_right(const float p_left_to_right);
 	float get_left_to_right() const;
@@ -328,8 +351,10 @@ protected:
 	static void _bind_methods();
 	virtual void _create_mesh_array(Array &p_arr) const override;
 
+	virtual void _update_lightmap_size() override;
+
 public:
-	static void create_mesh_array(Array &p_arr, float radius, float height, int radial_segments = 64, int rings = 32, bool is_hemisphere = false);
+	static void create_mesh_array(Array &p_arr, float radius, float height, int radial_segments = 64, int rings = 32, bool is_hemisphere = false, bool p_add_uv2 = false, const float p_uv2_padding = 1.0);
 
 	void set_radius(const float p_radius);
 	float get_radius() const;
@@ -364,6 +389,8 @@ private:
 protected:
 	static void _bind_methods();
 	virtual void _create_mesh_array(Array &p_arr) const override;
+
+	virtual void _update_lightmap_size() override;
 
 public:
 	void set_inner_radius(const float p_inner_radius);


### PR DESCRIPTION
This PR introduces optionally adding UV2 texture coordinates to primitive shapes including support for padding along the seams of the mesh. It will also set the `lightmap size hint` based on a texel size that can be configured in project settings:

![image](https://user-images.githubusercontent.com/1945449/199367239-a3f71c07-1f49-4f60-a053-c1ce1060ff1b.png)

The default values of this is `0.2`.

The Primitive Meshes related to particles have not been changed. 

This PR supersedes #49932 