### PR TITLE
Change all WEBP strings and comments to WebP

### DIFF
--- a/doc/classes/PortableCompressedTexture2D.xml
+++ b/doc/classes/PortableCompressedTexture2D.xml
@@ -22,7 +22,7 @@
 			<description>
 				Initializes the compressed texture from a base image. The compression mode must be provided.
 				If this image will be used as a normal map, the "normal map" flag is recommended, to ensure optimum quality.
-				If lossy compression is requested, the quality setting can optionally be provided. This maps to Lossy WEBP compression quality.
+				If lossy compression is requested, the quality setting can optionally be provided. This maps to Lossy WebP compression quality.
 			</description>
 		</method>
 		<method name="get_compression_mode" qualifiers="const">

--- a/modules/webp/resource_saver_webp.cpp
+++ b/modules/webp/resource_saver_webp.cpp
@@ -38,8 +38,8 @@
 Error ResourceSaverWebP::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
 	Ref<ImageTexture> texture = p_resource;
 
-	ERR_FAIL_COND_V_MSG(!texture.is_valid(), ERR_INVALID_PARAMETER, "Can't save invalid texture as WEBP.");
-	ERR_FAIL_COND_V_MSG(!texture->get_width(), ERR_INVALID_PARAMETER, "Can't save empty texture as WEBP.");
+	ERR_FAIL_COND_V_MSG(!texture.is_valid(), ERR_INVALID_PARAMETER, "Can't save invalid texture as WebP.");
+	ERR_FAIL_COND_V_MSG(!texture->get_width(), ERR_INVALID_PARAMETER, "Can't save empty texture as WebP.");
 
 	Ref<Image> img = texture->get_image();
 
@@ -52,7 +52,7 @@ Error ResourceSaverWebP::save_image(const String &p_path, const Ref<Image> &p_im
 	Vector<uint8_t> buffer = save_image_to_buffer(p_img, p_lossy, p_quality);
 	Error err;
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
-	ERR_FAIL_COND_V_MSG(err, err, vformat("Can't save WEBP at path: '%s'.", p_path));
+	ERR_FAIL_COND_V_MSG(err, err, vformat("Can't save WebP at path: '%s'.", p_path));
 
 	const uint8_t *reader = buffer.ptr();
 

--- a/modules/webp/webp_common.cpp
+++ b/modules/webp/webp_common.cpp
@@ -139,7 +139,7 @@ Ref<Image> _webp_unpack(const Vector<uint8_t> &p_buffer) {
 	ERR_FAIL_COND_V(r[0] != 'R' || r[1] != 'I' || r[2] != 'F' || r[3] != 'F' || r[8] != 'W' || r[9] != 'E' || r[10] != 'B' || r[11] != 'P', Ref<Image>());
 	WebPBitstreamFeatures features;
 	if (WebPGetFeatures(r, size, &features) != VP8_STATUS_OK) {
-		ERR_FAIL_V_MSG(Ref<Image>(), "Error unpacking WEBP image.");
+		ERR_FAIL_V_MSG(Ref<Image>(), "Error unpacking WebP image.");
 	}
 
 	Vector<uint8_t> dst_image;

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -653,7 +653,7 @@ Ref<Image> CompressedTexture2D::load_image_from_file(Ref<FileAccess> f, int p_si
 	Image::Format format = Image::Format(f->get_32());
 
 	if (data_format == DATA_FORMAT_PNG || data_format == DATA_FORMAT_WEBP || data_format == DATA_FORMAT_BASIS_UNIVERSAL) {
-		//look for a PNG or WEBP file inside
+		//look for a PNG or WebP file inside
 
 		int sw = w;
 		int sh = h;

--- a/tests/core/io/test_image.h
+++ b/tests/core/io/test_image.h
@@ -124,7 +124,7 @@ TEST_CASE("[Image] Saving and loading") {
 			image_jpg->load_jpg_from_buffer(data_jpg) == OK,
 			"The JPG image should load successfully.");
 
-	// Load WEBP
+	// Load WebP
 	Ref<Image> image_webp = memnew(Image());
 	Ref<FileAccess> f_webp = FileAccess::open(TestUtils::get_data_path("images/icon.webp"), FileAccess::READ, &err);
 	PackedByteArray data_webp;
@@ -132,7 +132,7 @@ TEST_CASE("[Image] Saving and loading") {
 	f_webp->get_buffer(data_webp.ptrw(), f_webp->get_length());
 	CHECK_MESSAGE(
 			image_webp->load_webp_from_buffer(data_webp) == OK,
-			"The WEBP image should load successfully.");
+			"The WebP image should load successfully.");
 
 	// Load PNG
 	Ref<Image> image_png = memnew(Image());


### PR DESCRIPTION
`endif`s were carefully avoided.