### PR TITLE
[MP] Add MultiplayerPeer disconnect_peer, close.

### DIFF
--- a/doc/classes/MultiplayerPeer.xml
+++ b/doc/classes/MultiplayerPeer.xml
@@ -13,6 +13,20 @@
 		<link title="WebRTC Signaling Demo">https://godotengine.org/asset-library/asset/537</link>
 	</tutorials>
 	<methods>
+		<method name="close">
+			<return type="void" />
+			<description>
+				Immediately close the multiplayer peer returning to the state [constant CONNECTION_DISCONNECTED]. Connected peers will be dropped without emitting [signal peer_disconnected].
+			</description>
+		</method>
+		<method name="disconnect_peer">
+			<return type="void" />
+			<param index="0" name="peer" type="int" />
+			<param index="1" name="force" type="bool" default="false" />
+			<description>
+				Disconnects the given [param peer] from this host. If [param force] is [code]true[/code] the [signal peer_disconnected] signal will not be emitted for this peer.
+			</description>
+		</method>
 		<method name="generate_unique_id" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -79,7 +93,7 @@
 			[b]Note:[/b] The default channel ([code]0[/code]) actually works as 3 separate channels (one for each [enum TransferMode]) so that [constant TRANSFER_MODE_RELIABLE] and [constant TRANSFER_MODE_UNRELIABLE_ORDERED] does not interact with each other by default. Refer to the specific network API documentation (e.g. ENet or WebRTC) to learn how to set up channels correctly.
 		</member>
 		<member name="transfer_mode" type="int" setter="set_transfer_mode" getter="get_transfer_mode" enum="MultiplayerPeer.TransferMode" default="2">
-			The manner in which to send packets to the [code]target_peer[/code]. See [enum TransferMode].
+			The manner in which to send packets to the target peer. See [enum TransferMode], and the [method set_target_peer] method.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/MultiplayerPeerExtension.xml
+++ b/doc/classes/MultiplayerPeerExtension.xml
@@ -9,6 +9,20 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_close" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the multiplayer peer should be immediately closed (see [method MultiplayerPeer.close]).
+			</description>
+		</method>
+		<method name="_disconnect_peer" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="p_peer" type="int" />
+			<param index="1" name="p_force" type="bool" />
+			<description>
+				Called when the connected [param p_peer] should be forcibly disconnected (see [method MultiplayerPeer.disconnect_peer]).
+			</description>
+		</method>
 		<method name="_get_available_packet_count" qualifiers="virtual const">
 			<return type="int" />
 			<description>

--- a/modules/enet/doc_classes/ENetMultiplayerPeer.xml
+++ b/modules/enet/doc_classes/ENetMultiplayerPeer.xml
@@ -21,13 +21,6 @@
 				[b]Note:[/b] The [code]host[/code] must have exactly one peer in the [constant ENetPacketPeer.STATE_CONNECTED] state.
 			</description>
 		</method>
-		<method name="close_connection">
-			<return type="void" />
-			<param index="0" name="wait_usec" type="int" default="100" />
-			<description>
-				Closes the connection. Ignored if no connection is currently established. If this is a server it tries to notify all clients before forcibly disconnecting them. If this is a client it simply closes the connection to the server.
-			</description>
-		</method>
 		<method name="create_client">
 			<return type="int" enum="Error" />
 			<param index="0" name="address" type="String" />
@@ -37,7 +30,7 @@
 			<param index="4" name="out_bandwidth" type="int" default="0" />
 			<param index="5" name="local_port" type="int" default="0" />
 			<description>
-				Create client that connects to a server at [code]address[/code] using specified [code]port[/code]. The given address needs to be either a fully qualified domain name (e.g. [code]"www.example.com"[/code]) or an IP address in IPv4 or IPv6 format (e.g. [code]"192.168.1.1"[/code]). The [code]port[/code] is the port the server is listening on. The [code]channel_count[/code] parameter can be used to specify the number of ENet channels allocated for the connection. The [code]in_bandwidth[/code] and [code]out_bandwidth[/code] parameters can be used to limit the incoming and outgoing bandwidth to the given number of bytes per second. The default of 0 means unlimited bandwidth. Note that ENet will strategically drop packets on specific sides of a connection between peers to ensure the peer's bandwidth is not overwhelmed. The bandwidth parameters also determine the window size of a connection which limits the amount of reliable packets that may be in transit at any given time. Returns [constant OK] if a client was created, [constant ERR_ALREADY_IN_USE] if this ENetMultiplayerPeer instance already has an open connection (in which case you need to call [method close_connection] first) or [constant ERR_CANT_CREATE] if the client could not be created. If [code]local_port[/code] is specified, the client will also listen to the given port; this is useful for some NAT traversal techniques.
+				Create client that connects to a server at [code]address[/code] using specified [code]port[/code]. The given address needs to be either a fully qualified domain name (e.g. [code]"www.example.com"[/code]) or an IP address in IPv4 or IPv6 format (e.g. [code]"192.168.1.1"[/code]). The [code]port[/code] is the port the server is listening on. The [code]channel_count[/code] parameter can be used to specify the number of ENet channels allocated for the connection. The [code]in_bandwidth[/code] and [code]out_bandwidth[/code] parameters can be used to limit the incoming and outgoing bandwidth to the given number of bytes per second. The default of 0 means unlimited bandwidth. Note that ENet will strategically drop packets on specific sides of a connection between peers to ensure the peer's bandwidth is not overwhelmed. The bandwidth parameters also determine the window size of a connection which limits the amount of reliable packets that may be in transit at any given time. Returns [constant OK] if a client was created, [constant ERR_ALREADY_IN_USE] if this ENetMultiplayerPeer instance already has an open connection (in which case you need to call [method MultiplayerPeer.close] first) or [constant ERR_CANT_CREATE] if the client could not be created. If [code]local_port[/code] is specified, the client will also listen to the given port; this is useful for some NAT traversal techniques.
 			</description>
 		</method>
 		<method name="create_mesh">
@@ -55,7 +48,7 @@
 			<param index="3" name="in_bandwidth" type="int" default="0" />
 			<param index="4" name="out_bandwidth" type="int" default="0" />
 			<description>
-				Create server that listens to connections via [code]port[/code]. The port needs to be an available, unused port between 0 and 65535. Note that ports below 1024 are privileged and may require elevated permissions depending on the platform. To change the interface the server listens on, use [method set_bind_ip]. The default IP is the wildcard [code]"*"[/code], which listens on all available interfaces. [code]max_clients[/code] is the maximum number of clients that are allowed at once, any number up to 4095 may be used, although the achievable number of simultaneous clients may be far lower and depends on the application. For additional details on the bandwidth parameters, see [method create_client]. Returns [constant OK] if a server was created, [constant ERR_ALREADY_IN_USE] if this ENetMultiplayerPeer instance already has an open connection (in which case you need to call [method close_connection] first) or [constant ERR_CANT_CREATE] if the server could not be created.
+				Create server that listens to connections via [code]port[/code]. The port needs to be an available, unused port between 0 and 65535. Note that ports below 1024 are privileged and may require elevated permissions depending on the platform. To change the interface the server listens on, use [method set_bind_ip]. The default IP is the wildcard [code]"*"[/code], which listens on all available interfaces. [code]max_clients[/code] is the maximum number of clients that are allowed at once, any number up to 4095 may be used, although the achievable number of simultaneous clients may be far lower and depends on the application. For additional details on the bandwidth parameters, see [method create_client]. Returns [constant OK] if a server was created, [constant ERR_ALREADY_IN_USE] if this ENetMultiplayerPeer instance already has an open connection (in which case you need to call [method MultiplayerPeer.close] first) or [constant ERR_CANT_CREATE] if the server could not be created.
 			</description>
 		</method>
 		<method name="get_peer" qualifiers="const">

--- a/modules/enet/enet_multiplayer_peer.h
+++ b/modules/enet/enet_multiplayer_peer.h
@@ -83,9 +83,7 @@ private:
 
 	void _store_packet(int32_t p_source, ENetConnection::Event &p_event);
 	void _pop_current_packet();
-	bool _parse_server_event(ENetConnection::EventType p_event_type, ENetConnection::Event &p_event);
-	bool _parse_client_event(ENetConnection::EventType p_event_type, ENetConnection::Event &p_event);
-	bool _parse_mesh_event(ENetConnection::EventType p_event_type, ENetConnection::Event &p_event, int p_peer_id);
+	void _disconnect_inactive_peers();
 	void _destroy_unused(ENetPacket *p_packet);
 	_FORCE_INLINE_ bool _is_active() const { return active_mode != MODE_NONE; }
 
@@ -102,6 +100,9 @@ public:
 	virtual int get_packet_channel() const override;
 
 	virtual void poll() override;
+	virtual void close() override;
+	virtual void disconnect_peer(int p_peer, bool p_force = false) override;
+
 	virtual bool is_server() const override;
 	virtual bool is_server_relay_supported() const override;
 
@@ -121,10 +122,6 @@ public:
 	Error create_client(const String &p_address, int p_port, int p_channel_count = 0, int p_in_bandwidth = 0, int p_out_bandwidth = 0, int p_local_port = 0);
 	Error create_mesh(int p_id);
 	Error add_mesh_peer(int p_id, Ref<ENetConnection> p_host);
-
-	void close_connection(uint32_t wait_usec = 100);
-
-	void disconnect_peer(int p_peer, bool now = false);
 
 	void set_bind_ip(const IPAddress &p_ip);
 

--- a/modules/webrtc/doc_classes/WebRTCMultiplayerPeer.xml
+++ b/modules/webrtc/doc_classes/WebRTCMultiplayerPeer.xml
@@ -22,12 +22,6 @@
 				Three channels will be created for reliable, unreliable, and ordered transport. The value of [code]unreliable_lifetime[/code] will be passed to the [code]maxPacketLifetime[/code] option when creating unreliable and ordered channels (see [method WebRTCPeerConnection.create_data_channel]).
 			</description>
 		</method>
-		<method name="close">
-			<return type="void" />
-			<description>
-				Close all the add peer connections and channels, freeing all resources.
-			</description>
-		</method>
 		<method name="create_client">
 			<return type="int" enum="Error" />
 			<param index="0" name="peer_id" type="int" />

--- a/modules/webrtc/webrtc_multiplayer_peer.cpp
+++ b/modules/webrtc/webrtc_multiplayer_peer.cpp
@@ -42,7 +42,6 @@ void WebRTCMultiplayerPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_peer", "peer_id"), &WebRTCMultiplayerPeer::has_peer);
 	ClassDB::bind_method(D_METHOD("get_peer", "peer_id"), &WebRTCMultiplayerPeer::get_peer);
 	ClassDB::bind_method(D_METHOD("get_peers"), &WebRTCMultiplayerPeer::get_peers);
-	ClassDB::bind_method(D_METHOD("close"), &WebRTCMultiplayerPeer::close);
 }
 
 void WebRTCMultiplayerPeer::set_target_peer(int p_peer_id) {
@@ -349,6 +348,18 @@ void WebRTCMultiplayerPeer::remove_peer(int p_peer_id) {
 			}
 			connection_status = CONNECTION_DISCONNECTED;
 		}
+	}
+}
+
+void WebRTCMultiplayerPeer::disconnect_peer(int p_peer_id, bool p_force) {
+	ERR_FAIL_COND(!peer_map.has(p_peer_id));
+	if (p_force) {
+		peer_map.erase(p_peer_id);
+		if (network_mode == MODE_CLIENT && p_peer_id == TARGET_PEER_SERVER) {
+			connection_status = CONNECTION_DISCONNECTED;
+		}
+	} else {
+		peer_map[p_peer_id]->connection->close(); // Will be removed during next poll.
 	}
 }
 

--- a/modules/webrtc/webrtc_multiplayer_peer.h
+++ b/modules/webrtc/webrtc_multiplayer_peer.h
@@ -98,28 +98,29 @@ public:
 	bool has_peer(int p_peer_id);
 	Dictionary get_peer(int p_peer_id);
 	Dictionary get_peers();
-	void close();
 
 	// PacketPeer
-	Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override; ///< buffer is GONE after next get_packet
-	Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
-	int get_available_packet_count() const override;
-	int get_max_packet_size() const override;
+	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override; ///< buffer is GONE after next get_packet
+	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
+	virtual int get_available_packet_count() const override;
+	virtual int get_max_packet_size() const override;
 
 	// MultiplayerPeer
-	void set_target_peer(int p_peer_id) override;
+	virtual void set_target_peer(int p_peer_id) override;
 
-	int get_unique_id() const override;
-	int get_packet_peer() const override;
-	int get_packet_channel() const override;
-	TransferMode get_packet_mode() const override;
+	virtual int get_unique_id() const override;
+	virtual int get_packet_peer() const override;
+	virtual int get_packet_channel() const override;
+	virtual TransferMode get_packet_mode() const override;
 
-	bool is_server() const override;
-	bool is_server_relay_supported() const override;
+	virtual bool is_server() const override;
+	virtual bool is_server_relay_supported() const override;
 
-	void poll() override;
+	virtual void poll() override;
+	virtual void close() override;
+	virtual void disconnect_peer(int p_peer_id, bool p_force = false) override;
 
-	ConnectionStatus get_connection_status() const override;
+	virtual ConnectionStatus get_connection_status() const override;
 };
 
 #endif // WEBRTC_MULTIPLAYER_PEER_H

--- a/modules/websocket/doc_classes/WebSocketMultiplayerPeer.xml
+++ b/modules/websocket/doc_classes/WebSocketMultiplayerPeer.xml
@@ -10,13 +10,6 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="close">
-			<return type="void" />
-			<description>
-				Closes this [MultiplayerPeer], resetting the state to [constant MultiplayerPeer.CONNECTION_CONNECTED].
-				[b]Note:[/b] To make sure remote peers receive a clean close prefer disconnecting clients via [method disconnect_peer].
-			</description>
-		</method>
 		<method name="create_client">
 			<return type="int" enum="Error" />
 			<param index="0" name="url" type="String" />
@@ -35,15 +28,6 @@
 			<param index="3" name="tls_certificate" type="X509Certificate" default="null" />
 			<description>
 				Starts a new multiplayer server listening on the given [param port]. You can optionally specify a [param bind_address], and provide a [param tls_key] and [param tls_certificate] to use TLS.
-			</description>
-		</method>
-		<method name="disconnect_peer">
-			<return type="void" />
-			<param index="0" name="id" type="int" />
-			<param index="1" name="code" type="int" default="1000" />
-			<param index="2" name="reason" type="String" default="&quot;&quot;" />
-			<description>
-				Disconnects the peer identified by [code]id[/code] from the server. See [method WebSocketPeer.close] for more information.
 			</description>
 		</method>
 		<method name="get_peer" qualifiers="const">

--- a/modules/websocket/websocket_multiplayer_peer.h
+++ b/modules/websocket/websocket_multiplayer_peer.h
@@ -102,6 +102,9 @@ public:
 	virtual int get_max_packet_size() const override;
 	virtual bool is_server() const override;
 	virtual void poll() override;
+	virtual void close() override;
+	virtual void disconnect_peer(int p_peer_id, bool p_force = false) override;
+
 	virtual ConnectionStatus get_connection_status() const override;
 
 	/* PacketPeer */
@@ -132,8 +135,6 @@ public:
 
 	IPAddress get_peer_address(int p_peer_id) const;
 	int get_peer_port(int p_peer_id) const;
-	void disconnect_peer(int p_peer_id, int p_code = 1000, String p_reason = "");
-	void close();
 
 	void set_max_queued_packets(int p_max_queued_packets);
 	int get_max_queued_packets() const;

--- a/scene/main/multiplayer_peer.cpp
+++ b/scene/main/multiplayer_peer.cpp
@@ -94,6 +94,8 @@ void MultiplayerPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_packet_mode"), &MultiplayerPeer::get_packet_mode);
 
 	ClassDB::bind_method(D_METHOD("poll"), &MultiplayerPeer::poll);
+	ClassDB::bind_method(D_METHOD("close"), &MultiplayerPeer::close);
+	ClassDB::bind_method(D_METHOD("disconnect_peer", "peer", "force"), &MultiplayerPeer::disconnect_peer, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("get_connection_status"), &MultiplayerPeer::get_connection_status);
 	ClassDB::bind_method(D_METHOD("get_unique_id"), &MultiplayerPeer::get_unique_id);
@@ -213,6 +215,8 @@ void MultiplayerPeerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_packet_peer);
 	GDVIRTUAL_BIND(_is_server);
 	GDVIRTUAL_BIND(_poll);
+	GDVIRTUAL_BIND(_close);
+	GDVIRTUAL_BIND(_disconnect_peer, "p_peer", "p_force");
 	GDVIRTUAL_BIND(_get_unique_id);
 	GDVIRTUAL_BIND(_set_refuse_new_connections, "p_enable");
 	GDVIRTUAL_BIND(_is_refusing_new_connections);

--- a/scene/main/multiplayer_peer.h
+++ b/scene/main/multiplayer_peer.h
@@ -82,9 +82,12 @@ public:
 	virtual TransferMode get_packet_mode() const = 0;
 	virtual int get_packet_channel() const = 0;
 
+	virtual void disconnect_peer(int p_peer, bool p_force = false) = 0;
+
 	virtual bool is_server() const = 0;
 
 	virtual void poll() = 0;
+	virtual void close() = 0;
 
 	virtual int get_unique_id() const = 0;
 
@@ -139,6 +142,8 @@ public:
 	EXBIND0RC(int, get_packet_channel);
 	EXBIND0RC(bool, is_server);
 	EXBIND0(poll);
+	EXBIND0(close);
+	EXBIND2(disconnect_peer, int, bool);
 	EXBIND0RC(int, get_unique_id);
 	EXBIND0RC(ConnectionStatus, get_connection_status);
 };


### PR DESCRIPTION
Update ENet, WebRTC, and WebSocket to support peer disconnection and unify the close function.

Includes some refactoring to ENet to simplify the code and avoid crash in some cases.

I think the ENet mesh configuration deserves some more improvements (including API side), but I've left them for a separate PR (since it might involve some more discussion).