### PR TITLE
C#: Reflection-less delegate callables and nested generic Godot collections

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -188,14 +188,14 @@ namespace Godot.SourceGenerators
             if (godotClassMethods.Length > 0)
             {
                 source.Append("    protected override bool InvokeGodotClassMethod(in godot_string_name method, ");
-                source.Append("NativeVariantPtrArgs args, int argCount, out godot_variant ret)\n    {\n");
+                source.Append("NativeVariantPtrArgs args, out godot_variant ret)\n    {\n");
 
                 foreach (var method in godotClassMethods)
                 {
                     GenerateMethodInvoker(method, source);
                 }
 
-                source.Append("        return base.InvokeGodotClassMethod(method, args, argCount, out ret);\n");
+                source.Append("        return base.InvokeGodotClassMethod(method, args, out ret);\n");
 
                 source.Append("    }\n");
             }
@@ -364,7 +364,7 @@ namespace Godot.SourceGenerators
 
             source.Append("        if (method == MethodName.");
             source.Append(methodName);
-            source.Append(" && argCount == ");
+            source.Append(" && args.Count == ");
             source.Append(method.ParamTypes.Length);
             source.Append(") {\n");
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -167,6 +167,7 @@ namespace Godot.SourceGenerators
                             Common.ReportSignalDelegateSignatureMustReturnVoid(context, signalDelegateSymbol);
                         }
                     }
+
                     continue;
                 }
 
@@ -257,14 +258,14 @@ namespace Godot.SourceGenerators
             {
                 source.Append(
                     "    protected override void RaiseGodotClassSignalCallbacks(in godot_string_name signal, ");
-                source.Append("NativeVariantPtrArgs args, int argCount)\n    {\n");
+                source.Append("NativeVariantPtrArgs args)\n    {\n");
 
                 foreach (var signal in godotSignalDelegates)
                 {
                     GenerateSignalEventInvoker(signal, source);
                 }
 
-                source.Append("        base.RaiseGodotClassSignalCallbacks(signal, args, argCount);\n");
+                source.Append("        base.RaiseGodotClassSignalCallbacks(signal, args);\n");
 
                 source.Append("    }\n");
             }
@@ -404,7 +405,7 @@ namespace Godot.SourceGenerators
 
             source.Append("        if (signal == SignalName.");
             source.Append(signalName);
-            source.Append(" && argCount == ");
+            source.Append(" && args.Count == ");
             source.Append(invokeMethodData.ParamTypes.Length);
             source.Append(") {\n");
             source.Append("            backing_");

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/CSharpInstanceBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/CSharpInstanceBridge.cs
@@ -22,8 +22,7 @@ namespace Godot.Bridge
                 }
 
                 bool methodInvoked = godotObject.InvokeGodotClassMethod(CustomUnsafe.AsRef(method),
-                    new NativeVariantPtrArgs(args),
-                    argCount, out godot_variant retValue);
+                    new NativeVariantPtrArgs(args, argCount), out godot_variant retValue);
 
                 if (!methodInvoked)
                 {
@@ -102,7 +101,7 @@ namespace Godot.Bridge
                     return godot_bool.False;
                 }
 
-                *outRet = Marshaling.ConvertManagedObjectToVariant(ret);
+                *outRet = ret.CopyNativeVariant();
                 return godot_bool.True;
             }
             catch (Exception e)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
@@ -9,7 +9,7 @@ namespace Godot.Bridge
     {
         // @formatter:off
         public delegate* unmanaged<IntPtr, godot_variant**, int, godot_bool*, void> SignalAwaiter_SignalCallback;
-        public delegate* unmanaged<IntPtr, godot_variant**, uint, godot_variant*, void> DelegateUtils_InvokeWithVariantArgs;
+        public delegate* unmanaged<IntPtr, void*, godot_variant**, int, godot_variant*, void> DelegateUtils_InvokeWithVariantArgs;
         public delegate* unmanaged<IntPtr, IntPtr, godot_bool> DelegateUtils_DelegateEquals;
         public delegate* unmanaged<IntPtr, godot_array*, godot_bool> DelegateUtils_TrySerializeDelegateWithGCHandle;
         public delegate* unmanaged<godot_array*, IntPtr*, godot_bool> DelegateUtils_TryDeserializeDelegateWithGCHandle;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -339,7 +339,7 @@ namespace Godot.Bridge
                 *outOwnerIsNull = godot_bool.False;
 
                 owner.RaiseGodotClassSignalCallbacks(CustomUnsafe.AsRef(eventSignalName),
-                    new NativeVariantPtrArgs(args), argCount);
+                    new NativeVariantPtrArgs(args, argCount));
             }
             catch (Exception e)
             {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Callable.generics.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Callable.generics.cs
@@ -1,0 +1,480 @@
+using System;
+using System.Runtime.CompilerServices;
+using Godot.NativeInterop;
+
+namespace Godot;
+
+#nullable enable
+
+public readonly partial struct Callable
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfArgCountMismatch(NativeVariantPtrArgs args, int countExpected,
+        [CallerArgumentExpression("args")] string? paramName = null)
+    {
+        if (countExpected != args.Count)
+            ThrowArgCountMismatch(countExpected, args.Count, paramName);
+
+        static void ThrowArgCountMismatch(int countExpected, int countReceived, string? paramName)
+        {
+            throw new ArgumentException(
+                "Invalid argument count for invoking callable." +
+                $" Expected {countExpected} arguments, received {countReceived}.",
+                paramName);
+        }
+    }
+
+    /// <summary>
+    /// Constructs a new <see cref="Callable"/> for the given <paramref name="action"/>.
+    /// </summary>
+    /// <param name="action">Action method that will be called.</param>
+    public static unsafe Callable From(
+        Action action
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 0);
+
+            ((Action)delegateObj)();
+
+            ret = default;
+        }
+
+        return CreateWithUnsafeTrampoline(action, &Trampoline);
+    }
+
+    /// <inheritdoc cref="From(Action)"/>
+    public static unsafe Callable From<T0>(
+        Action<T0> action
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 1);
+
+            ((Action<T0>)delegateObj)(
+                VariantConversionCallbacks.GetToManagedCallback<T0>()(args[0])
+            );
+
+            ret = default;
+        }
+
+        return CreateWithUnsafeTrampoline(action, &Trampoline);
+    }
+
+    /// <inheritdoc cref="From(Action)"/>
+    public static unsafe Callable From<T0, T1>(
+        Action<T0, T1> action
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 2);
+
+            ((Action<T0, T1>)delegateObj)(
+                VariantConversionCallbacks.GetToManagedCallback<T0>()(args[0]),
+                VariantConversionCallbacks.GetToManagedCallback<T1>()(args[1])
+            );
+
+            ret = default;
+        }
+
+        return CreateWithUnsafeTrampoline(action, &Trampoline);
+    }
+
+    /// <inheritdoc cref="From(Action)"/>
+    public static unsafe Callable From<T0, T1, T2>(
+        Action<T0, T1, T2> action
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 3);
+
+            ((Action<T0, T1, T2>)delegateObj)(
+                VariantConversionCallbacks.GetToManagedCallback<T0>()(args[0]),
+                VariantConversionCallbacks.GetToManagedCallback<T1>()(args[1]),
+                VariantConversionCallbacks.GetToManagedCallback<T2>()(args[2])
+            );
+
+            ret = default;
+        }
+
+        return CreateWithUnsafeTrampoline(action, &Trampoline);
+    }
+
+    /// <inheritdoc cref="From(Action)"/>
+    public static unsafe Callable From<T0, T1, T2, T3>(
+        Action<T0, T1, T2, T3> action
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 4);
+
+            ((Action<T0, T1, T2, T3>)delegateObj)(
+                VariantConversionCallbacks.GetToManagedCallback<T0>()(args[0]),
+                VariantConversionCallbacks.GetToManagedCallback<T1>()(args[1]),
+                VariantConversionCallbacks.GetToManagedCallback<T2>()(args[2]),
+                VariantConversionCallbacks.GetToManagedCallback<T3>()(args[3])
+            );
+
+            ret = default;
+        }
+
+        return CreateWithUnsafeTrampoline(action, &Trampoline);
+    }
+
+    /// <inheritdoc cref="From(Action)"/>
+    public static unsafe Callable From<T0, T1, T2, T3, T4>(
+        Action<T0, T1, T2, T3, T4> action
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 5);
+
+            ((Action<T0, T1, T2, T3, T4>)delegateObj)(
+                VariantConversionCallbacks.GetToManagedCallback<T0>()(args[0]),
+                VariantConversionCallbacks.GetToManagedCallback<T1>()(args[1]),
+                VariantConversionCallbacks.GetToManagedCallback<T2>()(args[2]),
+                VariantConversionCallbacks.GetToManagedCallback<T3>()(args[3]),
+                VariantConversionCallbacks.GetToManagedCallback<T4>()(args[4])
+            );
+
+            ret = default;
+        }
+
+        return CreateWithUnsafeTrampoline(action, &Trampoline);
+    }
+
+    /// <inheritdoc cref="From(Action)"/>
+    public static unsafe Callable From<T0, T1, T2, T3, T4, T5>(
+        Action<T0, T1, T2, T3, T4, T5> action
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 6);
+
+            ((Action<T0, T1, T2, T3, T4, T5>)delegateObj)(
+                VariantConversionCallbacks.GetToManagedCallback<T0>()(args[0]),
+                VariantConversionCallbacks.GetToManagedCallback<T1>()(args[1]),
+                VariantConversionCallbacks.GetToManagedCallback<T2>()(args[2]),
+                VariantConversionCallbacks.GetToManagedCallback<T3>()(args[3]),
+                VariantConversionCallbacks.GetToManagedCallback<T4>()(args[4]),
+                VariantConversionCallbacks.GetToManagedCallback<T5>()(args[5])
+            );
+
+            ret = default;
+        }
+
+        return CreateWithUnsafeTrampoline(action, &Trampoline);
+    }
+
+    /// <inheritdoc cref="From(Action)"/>
+    public static unsafe Callable From<T0, T1, T2, T3, T4, T5, T6>(
+        Action<T0, T1, T2, T3, T4, T5, T6> action
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 7);
+
+            ((Action<T0, T1, T2, T3, T4, T5, T6>)delegateObj)(
+                VariantConversionCallbacks.GetToManagedCallback<T0>()(args[0]),
+                VariantConversionCallbacks.GetToManagedCallback<T1>()(args[1]),
+                VariantConversionCallbacks.GetToManagedCallback<T2>()(args[2]),
+                VariantConversionCallbacks.GetToManagedCallback<T3>()(args[3]),
+                VariantConversionCallbacks.GetToManagedCallback<T4>()(args[4]),
+                VariantConversionCallbacks.GetToManagedCallback<T5>()(args[5]),
+                VariantConversionCallbacks.GetToManagedCallback<T6>()(args[6])
+            );
+
+            ret = default;
+        }
+
+        return CreateWithUnsafeTrampoline(action, &Trampoline);
+    }
+
+    /// <inheritdoc cref="From(Action)"/>
+    public static unsafe Callable From<T0, T1, T2, T3, T4, T5, T6, T7>(
+        Action<T0, T1, T2, T3, T4, T5, T6, T7> action
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 8);
+
+            ((Action<T0, T1, T2, T3, T4, T5, T6, T7>)delegateObj)(
+                VariantConversionCallbacks.GetToManagedCallback<T0>()(args[0]),
+                VariantConversionCallbacks.GetToManagedCallback<T1>()(args[1]),
+                VariantConversionCallbacks.GetToManagedCallback<T2>()(args[2]),
+                VariantConversionCallbacks.GetToManagedCallback<T3>()(args[3]),
+                VariantConversionCallbacks.GetToManagedCallback<T4>()(args[4]),
+                VariantConversionCallbacks.GetToManagedCallback<T5>()(args[5]),
+                VariantConversionCallbacks.GetToManagedCallback<T6>()(args[6]),
+                VariantConversionCallbacks.GetToManagedCallback<T7>()(args[7])
+            );
+
+            ret = default;
+        }
+
+        return CreateWithUnsafeTrampoline(action, &Trampoline);
+    }
+
+    /// <inheritdoc cref="From(Action)"/>
+    public static unsafe Callable From<T0, T1, T2, T3, T4, T5, T6, T7, T8>(
+        Action<T0, T1, T2, T3, T4, T5, T6, T7, T8> action
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 9);
+
+            ((Action<T0, T1, T2, T3, T4, T5, T6, T7, T8>)delegateObj)(
+                VariantConversionCallbacks.GetToManagedCallback<T0>()(args[0]),
+                VariantConversionCallbacks.GetToManagedCallback<T1>()(args[1]),
+                VariantConversionCallbacks.GetToManagedCallback<T2>()(args[2]),
+                VariantConversionCallbacks.GetToManagedCallback<T3>()(args[3]),
+                VariantConversionCallbacks.GetToManagedCallback<T4>()(args[4]),
+                VariantConversionCallbacks.GetToManagedCallback<T5>()(args[5]),
+                VariantConversionCallbacks.GetToManagedCallback<T6>()(args[6]),
+                VariantConversionCallbacks.GetToManagedCallback<T7>()(args[7]),
+                VariantConversionCallbacks.GetToManagedCallback<T8>()(args[8])
+            );
+
+            ret = default;
+        }
+
+        return CreateWithUnsafeTrampoline(action, &Trampoline);
+    }
+
+    /// <summary>
+    /// Constructs a new <see cref="Callable"/> for the given <paramref name="func"/>.
+    /// </summary>
+    /// <param name="func">Action method that will be called.</param>
+    public static unsafe Callable From<TResult>(
+        Func<TResult> func
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 0);
+
+            TResult res = ((Func<TResult>)delegateObj)();
+
+            ret = VariantConversionCallbacks.GetToVariantCallback<TResult>()(res);
+        }
+
+        return CreateWithUnsafeTrampoline(func, &Trampoline);
+    }
+
+    /// <inheritdoc cref="From{TResult}(Func{TResult})"/>
+    public static unsafe Callable From<T0, TResult>(
+        Func<T0, TResult> func
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 1);
+
+            TResult res = ((Func<T0, TResult>)delegateObj)(
+                VariantConversionCallbacks.GetToManagedCallback<T0>()(args[0])
+            );
+
+            ret = VariantConversionCallbacks.GetToVariantCallback<TResult>()(res);
+        }
+
+        return CreateWithUnsafeTrampoline(func, &Trampoline);
+    }
+
+    /// <inheritdoc cref="From{TResult}(Func{TResult})"/>
+    public static unsafe Callable From<T0, T1, TResult>(
+        Func<T0, T1, TResult> func
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 2);
+
+            TResult res = ((Func<T0, T1, TResult>)delegateObj)(
+                VariantConversionCallbacks.GetToManagedCallback<T0>()(args[0]),
+                VariantConversionCallbacks.GetToManagedCallback<T1>()(args[1])
+            );
+
+            ret = VariantConversionCallbacks.GetToVariantCallback<TResult>()(res);
+        }
+
+        return CreateWithUnsafeTrampoline(func, &Trampoline);
+    }
+
+    /// <inheritdoc cref="From{TResult}(Func{TResult})"/>
+    public static unsafe Callable From<T0, T1, T2, TResult>(
+        Func<T0, T1, T2, TResult> func
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 3);
+
+            TResult res = ((Func<T0, T1, T2, TResult>)delegateObj)(
+                VariantConversionCallbacks.GetToManagedCallback<T0>()(args[0]),
+                VariantConversionCallbacks.GetToManagedCallback<T1>()(args[1]),
+                VariantConversionCallbacks.GetToManagedCallback<T2>()(args[2])
+            );
+
+            ret = VariantConversionCallbacks.GetToVariantCallback<TResult>()(res);
+        }
+
+        return CreateWithUnsafeTrampoline(func, &Trampoline);
+    }
+
+    /// <inheritdoc cref="From{TResult}(Func{TResult})"/>
+    public static unsafe Callable From<T0, T1, T2, T3, TResult>(
+        Func<T0, T1, T2, T3, TResult> func
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 4);
+
+            TResult res = ((Func<T0, T1, T2, T3, TResult>)delegateObj)(
+                VariantConversionCallbacks.GetToManagedCallback<T0>()(args[0]),
+                VariantConversionCallbacks.GetToManagedCallback<T1>()(args[1]),
+                VariantConversionCallbacks.GetToManagedCallback<T2>()(args[2]),
+                VariantConversionCallbacks.GetToManagedCallback<T3>()(args[3])
+            );
+
+            ret = VariantConversionCallbacks.GetToVariantCallback<TResult>()(res);
+        }
+
+        return CreateWithUnsafeTrampoline(func, &Trampoline);
+    }
+
+    /// <inheritdoc cref="From{TResult}(Func{TResult})"/>
+    public static unsafe Callable From<T0, T1, T2, T3, T4, TResult>(
+        Func<T0, T1, T2, T3, T4, TResult> func
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 5);
+
+            TResult res = ((Func<T0, T1, T2, T3, T4, TResult>)delegateObj)(
+                VariantConversionCallbacks.GetToManagedCallback<T0>()(args[0]),
+                VariantConversionCallbacks.GetToManagedCallback<T1>()(args[1]),
+                VariantConversionCallbacks.GetToManagedCallback<T2>()(args[2]),
+                VariantConversionCallbacks.GetToManagedCallback<T3>()(args[3]),
+                VariantConversionCallbacks.GetToManagedCallback<T4>()(args[4])
+            );
+
+            ret = VariantConversionCallbacks.GetToVariantCallback<TResult>()(res);
+        }
+
+        return CreateWithUnsafeTrampoline(func, &Trampoline);
+    }
+
+    /// <inheritdoc cref="From{TResult}(Func{TResult})"/>
+    public static unsafe Callable From<T0, T1, T2, T3, T4, T5, TResult>(
+        Func<T0, T1, T2, T3, T4, T5, TResult> func
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 6);
+
+            TResult res = ((Func<T0, T1, T2, T3, T4, T5, TResult>)delegateObj)(
+                VariantConversionCallbacks.GetToManagedCallback<T0>()(args[0]),
+                VariantConversionCallbacks.GetToManagedCallback<T1>()(args[1]),
+                VariantConversionCallbacks.GetToManagedCallback<T2>()(args[2]),
+                VariantConversionCallbacks.GetToManagedCallback<T3>()(args[3]),
+                VariantConversionCallbacks.GetToManagedCallback<T4>()(args[4]),
+                VariantConversionCallbacks.GetToManagedCallback<T5>()(args[5])
+            );
+
+            ret = VariantConversionCallbacks.GetToVariantCallback<TResult>()(res);
+        }
+
+        return CreateWithUnsafeTrampoline(func, &Trampoline);
+    }
+
+    /// <inheritdoc cref="From{TResult}(Func{TResult})"/>
+    public static unsafe Callable From<T0, T1, T2, T3, T4, T5, T6, TResult>(
+        Func<T0, T1, T2, T3, T4, T5, T6, TResult> func
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 7);
+
+            TResult res = ((Func<T0, T1, T2, T3, T4, T5, T6, TResult>)delegateObj)(
+                VariantConversionCallbacks.GetToManagedCallback<T0>()(args[0]),
+                VariantConversionCallbacks.GetToManagedCallback<T1>()(args[1]),
+                VariantConversionCallbacks.GetToManagedCallback<T2>()(args[2]),
+                VariantConversionCallbacks.GetToManagedCallback<T3>()(args[3]),
+                VariantConversionCallbacks.GetToManagedCallback<T4>()(args[4]),
+                VariantConversionCallbacks.GetToManagedCallback<T5>()(args[5]),
+                VariantConversionCallbacks.GetToManagedCallback<T6>()(args[6])
+            );
+
+            ret = VariantConversionCallbacks.GetToVariantCallback<TResult>()(res);
+        }
+
+        return CreateWithUnsafeTrampoline(func, &Trampoline);
+    }
+
+    /// <inheritdoc cref="From{TResult}(Func{TResult})"/>
+    public static unsafe Callable From<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(
+        Func<T0, T1, T2, T3, T4, T5, T6, T7, TResult> func
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 8);
+
+            TResult res = ((Func<T0, T1, T2, T3, T4, T5, T6, T7, TResult>)delegateObj)(
+                VariantConversionCallbacks.GetToManagedCallback<T0>()(args[0]),
+                VariantConversionCallbacks.GetToManagedCallback<T1>()(args[1]),
+                VariantConversionCallbacks.GetToManagedCallback<T2>()(args[2]),
+                VariantConversionCallbacks.GetToManagedCallback<T3>()(args[3]),
+                VariantConversionCallbacks.GetToManagedCallback<T4>()(args[4]),
+                VariantConversionCallbacks.GetToManagedCallback<T5>()(args[5]),
+                VariantConversionCallbacks.GetToManagedCallback<T6>()(args[6]),
+                VariantConversionCallbacks.GetToManagedCallback<T7>()(args[7])
+            );
+
+            ret = VariantConversionCallbacks.GetToVariantCallback<TResult>()(res);
+        }
+
+        return CreateWithUnsafeTrampoline(func, &Trampoline);
+    }
+
+    /// <inheritdoc cref="From{TResult}(Func{TResult})"/>
+    public static unsafe Callable From<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(
+        Func<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult> func
+    )
+    {
+        static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+        {
+            ThrowIfArgCountMismatch(args, 9);
+
+            TResult res = ((Func<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>)delegateObj)(
+                VariantConversionCallbacks.GetToManagedCallback<T0>()(args[0]),
+                VariantConversionCallbacks.GetToManagedCallback<T1>()(args[1]),
+                VariantConversionCallbacks.GetToManagedCallback<T2>()(args[2]),
+                VariantConversionCallbacks.GetToManagedCallback<T3>()(args[3]),
+                VariantConversionCallbacks.GetToManagedCallback<T4>()(args[4]),
+                VariantConversionCallbacks.GetToManagedCallback<T5>()(args[5]),
+                VariantConversionCallbacks.GetToManagedCallback<T6>()(args[6]),
+                VariantConversionCallbacks.GetToManagedCallback<T7>()(args[7]),
+                VariantConversionCallbacks.GetToManagedCallback<T8>()(args[8])
+            );
+
+            ret = VariantConversionCallbacks.GetToVariantCallback<TResult>()(res);
+        }
+
+        return CreateWithUnsafeTrampoline(func, &Trampoline);
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -141,11 +141,11 @@ namespace Godot.NativeInterop
         public static partial void godotsharp_packed_string_array_add(ref godot_packed_string_array r_dest,
             in godot_string p_element);
 
-        public static partial void godotsharp_callable_new_with_delegate(IntPtr p_delegate_handle, IntPtr p_object,
-            out godot_callable r_callable);
+        public static partial void godotsharp_callable_new_with_delegate(IntPtr p_delegate_handle, IntPtr p_trampoline,
+            IntPtr p_object, out godot_callable r_callable);
 
         internal static partial godot_bool godotsharp_callable_get_data_for_marshalling(in godot_callable p_callable,
-            out IntPtr r_delegate_handle, out IntPtr r_object, out godot_string_name r_name);
+            out IntPtr r_delegate_handle, out IntPtr r_trampoline, out IntPtr r_object, out godot_string_name r_name);
 
         internal static partial godot_variant godotsharp_callable_call(in godot_callable p_callable,
             godot_variant** p_args, int p_arg_count, out godot_variant_call_error p_call_error);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeVariantPtrArgs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeVariantPtrArgs.cs
@@ -8,8 +8,22 @@ namespace Godot.NativeInterop
     public unsafe ref struct NativeVariantPtrArgs
     {
         private godot_variant** _args;
+        private int _argc;
 
-        internal NativeVariantPtrArgs(godot_variant** args) => _args = args;
+        internal NativeVariantPtrArgs(godot_variant** args, int argc)
+        {
+            _args = args;
+            _argc = argc;
+        }
+
+        /// <summary>
+        /// Returns the number of arguments.
+        /// </summary>
+        public int Count
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _argc;
+        }
 
         public ref godot_variant this[int index]
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantConversionCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantConversionCallbacks.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Godot.NativeInterop;
 
+// TODO: Change VariantConversionCallbacks<T>. Store the callback in a static field for quick repeated access, instead of checking every time.
 internal static unsafe class VariantConversionCallbacks
 {
     [SuppressMessage("ReSharper", "RedundantNameQualifier")]

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Object.base.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Object.base.cs
@@ -202,7 +202,7 @@ namespace Godot
 
         // ReSharper disable once VirtualMemberNeverOverridden.Global
         protected internal virtual void RaiseGodotClassSignalCallbacks(in godot_string_name signal,
-            NativeVariantPtrArgs args, int argCount)
+            NativeVariantPtrArgs args)
         {
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Core\AABB.cs" />
     <Compile Include="Core\Bridge\GodotSerializationInfo.cs" />
     <Compile Include="Core\Bridge\MethodInfo.cs" />
+    <Compile Include="Core\Callable.generics.cs" />
     <Compile Include="Core\CustomGCHandle.cs" />
     <Compile Include="Core\Array.cs" />
     <Compile Include="Core\Attributes\AssemblyHasScriptsAttribute.cs" />

--- a/modules/mono/managed_callable.cpp
+++ b/modules/mono/managed_callable.cpp
@@ -92,7 +92,7 @@ void ManagedCallable::call(const Variant **p_arguments, int p_argcount, Variant 
 	ERR_FAIL_COND(delegate_handle.value == nullptr);
 
 	GDMonoCache::managed_callbacks.DelegateUtils_InvokeWithVariantArgs(
-			delegate_handle, p_arguments, p_argcount, &r_return_value);
+			delegate_handle, trampoline, p_arguments, p_argcount, &r_return_value);
 
 	r_call_error.error = Callable::CallError::CALL_OK;
 }
@@ -106,7 +106,8 @@ void ManagedCallable::release_delegate_handle() {
 
 // Why you do this clang-format...
 /* clang-format off */
-ManagedCallable::ManagedCallable(GCHandleIntPtr p_delegate_handle, ObjectID p_object_id) : delegate_handle(p_delegate_handle), object_id(p_object_id) {
+ManagedCallable::ManagedCallable(GCHandleIntPtr p_delegate_handle, void *p_trampoline, ObjectID p_object_id) :
+		delegate_handle(p_delegate_handle), trampoline(p_trampoline), object_id(p_object_id) {
 #ifdef GD_MONO_HOT_RELOAD
 	{
 		MutexLock lock(instances_mutex);

--- a/modules/mono/managed_callable.h
+++ b/modules/mono/managed_callable.h
@@ -40,6 +40,7 @@
 class ManagedCallable : public CallableCustom {
 	friend class CSharpLanguage;
 	GCHandleIntPtr delegate_handle;
+	void *trampoline = nullptr;
 	ObjectID object_id;
 
 #ifdef GD_MONO_HOT_RELOAD
@@ -58,6 +59,7 @@ public:
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
 	_FORCE_INLINE_ GCHandleIntPtr get_delegate() const { return delegate_handle; }
+	_FORCE_INLINE_ void *get_trampoline() const { return trampoline; }
 
 	static bool compare_equal(const CallableCustom *p_a, const CallableCustom *p_b);
 	static bool compare_less(const CallableCustom *p_a, const CallableCustom *p_b);
@@ -67,7 +69,7 @@ public:
 
 	void release_delegate_handle();
 
-	ManagedCallable(GCHandleIntPtr p_delegate_handle, ObjectID p_object_id);
+	ManagedCallable(GCHandleIntPtr p_delegate_handle, void *p_trampoline, ObjectID p_object_id);
 	~ManagedCallable();
 };
 

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -74,7 +74,7 @@ struct ManagedCallbacks {
 	using Callback_ScriptManagerBridge_GetPropertyDefaultValues_Add = void(GD_CLR_STDCALL *)(CSharpScript *p_script, void *p_def_vals, int32_t p_count);
 
 	using FuncSignalAwaiter_SignalCallback = void(GD_CLR_STDCALL *)(GCHandleIntPtr, const Variant **, int32_t, bool *);
-	using FuncDelegateUtils_InvokeWithVariantArgs = void(GD_CLR_STDCALL *)(GCHandleIntPtr, const Variant **, uint32_t, const Variant *);
+	using FuncDelegateUtils_InvokeWithVariantArgs = void(GD_CLR_STDCALL *)(GCHandleIntPtr, void *, const Variant **, int32_t, const Variant *);
 	using FuncDelegateUtils_DelegateEquals = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, GCHandleIntPtr);
 	using FuncDelegateUtils_TrySerializeDelegateWithGCHandle = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, const Array *);
 	using FuncDelegateUtils_TryDeserializeDelegateWithGCHandle = bool(GD_CLR_STDCALL *)(const Array *, GCHandleIntPtr *);


### PR DESCRIPTION
- Removed need for reflection to invoking delegate callables (see details below)
- Added Variant conversion callbacks for generic Godot collections. This brings support for:
  - Nested generic Godot collections: `Dictionary<string, Array<Vector3>>`.
  - Generic Godot collections as parameter or return types of callable delegates.


### Reflection-less delegate callables

We aim to make the C# API reflection-free, mainly for concerns about performance, and to be able to target NativeAOT in refletion-free mode, which reduces the binary size.

One of the main usages of reflection still left was the dynamic invokation of callable delegates, and for some time I wasn't sure I would find an alternative solution that I'd be happy with.

The new solution uses trampoline functions to invoke the delegates:

```cs
static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
{
    if (args.Count != 1)
        throw new ArgumentException($"Callable expected 1 arguments but received {args.Count}.");

    string res = ((Func<int, string>)delegateObj)(
        VariantConversionCallbacks.GetToManagedCallback<int>()(args[0])
    );

    ret = VariantConversionCallbacks.GetToVariantCallback<string>()(res);
}

Callable.CreateWithUnsafeTrampoline((int num) => "Foo" + num, &Trampoline);
```

Of course, this is too much boilerplate for user code. To improve this, the `Callable.From` methods were added. These are overloads that take `Action` and `Func` delegates, which covers the most common use cases: lambdas and method groups:

```cs
// Lambda
Callable.From((int num) => "Foo" + num);

// Method group
string AppendNum(int num) => "Foo" + num;
Callable.From(AppendNum);
```

Unfortunately, due to limitations in the C# language, implicit conversions from delegates to `Callable` are not supported.

`Callable.From` does not support custom delegates. These should be uncommon, but the Godot C# API actually uses them for event signals. As such, the bindings generator was updated to generate trampoline functions for event signals. It was also optimized to use `Action` instead of a custom delegate for parameterless signals, which removes the need for the trampoline functions for those signals.

The change to reflection-free invokation removes one of the last needs for `ConvertVariantToManagedObjectOfType`. The only remaining usage is from calling script constructors with parameters from the engine (`CreateManagedForGodotObjectScriptInstance`). Once that one is made reflection-free, `ConvertVariantToManagedObjectOfType` can be removed.
