### PR TITLE
[QoL]: Add an 'import files' button to filesystem right-click menu

### DIFF
--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -93,6 +93,7 @@ private:
 		FILE_NEW_FOLDER,
 		FILE_NEW_SCRIPT,
 		FILE_NEW_SCENE,
+		FILE_IMPORT,
 		FILE_SHOW_IN_EXPLORER,
 		FILE_COPY_PATH,
 		FILE_COPY_UID,
@@ -154,6 +155,8 @@ private:
 	ScriptCreateDialog *make_script_dialog = nullptr;
 	ShaderCreateDialog *make_shader_dialog = nullptr;
 	CreateDialog *new_resource_dialog = nullptr;
+	EditorFileDialog *import_files_dialog = nullptr;
+	ConfirmationDialog *import_overwrite_dialog = nullptr;
 
 	bool always_show_folders = false;
 
@@ -237,6 +240,9 @@ private:
 	void _move_with_overwrite();
 	Vector<String> _check_existing();
 	void _move_operation_confirm(const String &p_to_path, bool p_overwrite = false);
+	void _import_files_with_overwrite();
+	void _import_files_selected(const PackedStringArray &p_file);
+	void _import_files(bool p_overwrite = false);
 
 	void _tree_rmb_option(int p_option);
 	void _file_list_rmb_option(int p_option);


### PR DESCRIPTION
Adds the ability to import multiple files into res:// or any subfolders from a file selection dialog. The button is located above "Show In File Manager", if the position should be changed let me know. The icon in the context menu is the same as "Copy File Path" but if an icon needs to be made / a better one is available, it can be changed. Currently doesn't filter the file extension, if that's necessarily let me know.

Tested on Windows 10 and Linux

![GodotImportFilesDialog](https://user-images.githubusercontent.com/24617621/198746437-3dcb0944-9d81-4821-9679-31cb47ff9ba2.gif)
