### PR TITLE
Exit editor with non-zero return code if --build-solutions fails

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3227,10 +3227,12 @@ bool Main::iteration() {
 		auto_build_solutions = false;
 		// Only relevant when running the editor.
 		if (!editor) {
+			OS::get_singleton()->set_exit_code(EXIT_FAILURE);
 			ERR_FAIL_V_MSG(true,
 					"Command line option --build-solutions was passed, but no project is being edited. Aborting.");
 		}
 		if (!EditorNode::get_singleton()->call_build()) {
+			OS::get_singleton()->set_exit_code(EXIT_FAILURE);
 			ERR_FAIL_V_MSG(true,
 					"Command line option --build-solutions was passed, but the build callback failed. Aborting.");
 		}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
While writing some automation for building my C#-based game with Godot Mono, I noticed that when using --build-solutions via CLI,  failed C# builds don't affect the exit code. So this reduces the ability to automate the build process of a game, because to know if the game failed, you would have to try to search for failure messages in the output.

I have another version of this change for 3.x which I tested using the builds from GitHub Actions. The change is identical in the two branches.

Where godot-mono is the official release of 3.5.1:
```bash
godot-mono  --build-solutions --no-window --verbose --path ~/Desktop/MyGame/ || echo "failed with code $?"
# [...]
ERROR: An EditorPlugin build callback failed.
   at: call_build (editor/editor_node.cpp:5532)
ERROR: Command line option --build-solutions was passed, but the build callback failed. Aborting.
# [...]
Orphan StringName: SplashScreenFinish
Orphan StringName: Invoke
StringName: 4 unclaimed string names at exit.
# it did not print 'failed with code' 
```

And this is  my 3.x branch build 
```bash 
./godot.x11.opt.tools.64.mono  --build-solutions --no-window --verbose --path ~/Desktop/MyGame/ || echo "failed with code $?"
# [...]
ERROR: An EditorPlugin build callback failed.
   at: call_build (editor/editor_node.cpp:5532)
ERROR: Command line option --build-solutions was passed, but the build callback failed. Aborting.
# [...]
Orphan StringName: Invoke
StringName: 4 unclaimed string names at exit.
failed with code 1
# exit code was set to 1 
```
I wanted to also fail --export and --export debug commands if this is thrown in ExportPlugin.cs
`throw new InvalidOperationException("Failed to build project.");` 

Since that also exits 0 for me. But I wonder if any exception thrown in that file should be failing the build? Not sure where to influence the return code during --export if ExportPlugin.cs fails.   

Thanks to Calinou in the contributors chat for the tips
Edit: force pushed to get rid of merge commit