### PR TITLE
Make Camera3D gizmo clickable

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -1937,6 +1937,7 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 #undef ADD_QUAD
 
 	p_gizmo->add_lines(lines, material);
+	p_gizmo->add_collision_segments(lines);
 	p_gizmo->add_handles(handles, get_material("handles"));
 }
 


### PR DESCRIPTION
There's currently no way to select the camera in 3D viewport.

This PR makes the gizmo lines clickable.

![Peek 2022-10-29 14-01](https://user-images.githubusercontent.com/372476/198816502-d224c6f5-add9-4d9c-ba6d-285779a04d91.gif)
