### PR TITLE
Fix type mismatch error when deselecting a 3D gizmo

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -1159,7 +1159,7 @@ int EditorNode3DGizmoPlugin::subgizmos_intersect_ray(const EditorNode3DGizmo *p_
 }
 
 Vector<int> EditorNode3DGizmoPlugin::subgizmos_intersect_frustum(const EditorNode3DGizmo *p_gizmo, const Camera3D *p_camera, const Vector<Plane> &p_frustum) const {
-	TypedArray<Transform3D> frustum;
+	TypedArray<Plane> frustum;
 	frustum.resize(p_frustum.size());
 	for (int i = 0; i < p_frustum.size(); i++) {
 		frustum[i] = p_frustum[i];


### PR DESCRIPTION
I'm not sure how to reproduce this error stably. Try deselecting a 3D node by clicking empty spaces in the 3D viewport for a few times, and you'll get this error:

> ERROR: Assignment of arrays of incompatible types.
>    at: _assign (core/variant/array.cpp:244)

I believe this mismatch is a typo :)