### PR TITLE
Remove sorting since the lods are generated from closest to furthest.

### DIFF
--- a/scene/resources/importer_mesh.cpp
+++ b/scene/resources/importer_mesh.cpp
@@ -645,7 +645,6 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, float p_normal_spli
 		}
 
 		surfaces.write[i].split_normals(split_vertex_indices, split_vertex_normals);
-		surfaces.write[i].lods.sort_custom<Surface::LODComparator>();
 
 		for (int j = 0; j < surfaces.write[i].lods.size(); j++) {
 			Surface::LOD &lod = surfaces.write[i].lods.write[j];

--- a/scene/resources/importer_mesh.h
+++ b/scene/resources/importer_mesh.h
@@ -63,12 +63,6 @@ class ImporterMesh : public Resource {
 		String name;
 		uint32_t flags = 0;
 
-		struct LODComparator {
-			_FORCE_INLINE_ bool operator()(const LOD &l, const LOD &r) const {
-				return l.distance < r.distance;
-			}
-		};
-
 		void split_normals(const LocalVector<int> &p_indices, const LocalVector<Vector3> &p_normals);
 		static void _split_normals(Array &r_arrays, const LocalVector<int> &p_indices, const LocalVector<Vector3> &p_normals);
 	};


### PR DESCRIPTION
1. Multiple bugs show the wrong lod level. The lods seem to be decimated too quickly
1. Neither the distance or the index comparator make sense to sort lods. 
1. They're generated from most detail to the least detail already. The only operation I can see is maybe a reverse list and definitely not a sort in any other order.
1. If this is an optimization it should have no visible lod effect. So the removal is valid because it has an unexpected visual effect.

Discussed with Detox on the discord server.

Fixes: https://github.com/godotengine/godot/issues/67891