### PR TITLE
Hide axis gizmo after translating 3D nodes

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1650,12 +1650,12 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 							}
 
 							se->gizmo->commit_subgizmos(ids, restore, false);
-							spatial_editor->update_transform_gizmo();
 						} else {
 							commit_transform();
 						}
 						_edit.mode = TRANSFORM_NONE;
 						set_message("");
+						spatial_editor->update_transform_gizmo();
 					}
 					surface->queue_redraw();
 				}


### PR DESCRIPTION
<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

![Peek 2022-10-29 16-14](https://user-images.githubusercontent.com/372476/198821489-ccfec67a-a27d-49b7-bb98-fe3277d86edf.gif)
</td>
<td>

![Peek 2022-10-29 16-21](https://user-images.githubusercontent.com/372476/198821713-92cd1dc5-1ca2-45e2-9386-3056f545324f.gif)
</td>
</tr>
</table>