### PR TITLE
dampen -> damp, attenuate in audio and physics class docs

### DIFF
--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -4,7 +4,7 @@
 		Plays positional sound in 2D space.
 	</brief_description>
 	<description>
-		Plays audio that dampens with distance from a given position.
+		Plays audio that is attenuated with distance to the listener.
 		By default, audio is heard from the screen center. This can be changed by adding an [AudioListener2D] node to the scene and enabling it by calling [method AudioListener2D.make_current] on it.
 		See also [AudioStreamPlayer] to play a sound non-positionally.
 		[b]Note:[/b] Hiding an [AudioStreamPlayer2D] node does not disable its audio output. To temporarily disable an [AudioStreamPlayer2D]'s audio output, set [member volume_db] to a very low value like [code]-100[/code] (which isn't audible to human hearing).
@@ -57,7 +57,7 @@
 			Determines which [Area2D] layers affect the sound for reverb and audio bus effects. Areas can be used to redirect [AudioStream]s so that they play in a certain audio bus. An example of how you might use this is making a "water" area so that sounds played in the water are redirected through an audio bus to make them sound like they are being played underwater.
 		</member>
 		<member name="attenuation" type="float" setter="set_attenuation" getter="get_attenuation" default="1.0">
-			Dampens audio over distance with this as an exponent.
+			The volume is attenuated over distance with this as an exponent.
 		</member>
 		<member name="autoplay" type="bool" setter="set_autoplay" getter="is_autoplay_enabled" default="false">
 			If [code]true[/code], audio plays when added to scene tree.
@@ -88,7 +88,7 @@
 			If [code]true[/code], the playback is paused. You can resume it by setting [code]stream_paused[/code] to [code]false[/code].
 		</member>
 		<member name="volume_db" type="float" setter="set_volume_db" getter="get_volume_db" default="0.0">
-			Base volume without dampening.
+			Base volume before attenuation.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -4,7 +4,7 @@
 		Plays positional sound in 3D space.
 	</brief_description>
 	<description>
-		Plays a sound effect with directed sound effects, dampens with distance if needed, generates effect of hearable position in space. For greater realism, a low-pass filter is automatically applied to distant sounds. This can be disabled by setting [member attenuation_filter_cutoff_hz] to [code]20500[/code].
+		Plays audio with positional sound effects, based on the relative position of the audio listener. Positional effects include distance attenuation, directionality, and the Doppler effect. For greater realism, a low-pass filter is applied to distant sounds. This can be disabled by setting [member attenuation_filter_cutoff_hz] to [code]20500[/code].
 		By default, audio is heard from the camera position. This can be changed by adding an [AudioListener3D] node to the scene and enabling it by calling [method AudioListener3D.make_current] on it.
 		See also [AudioStreamPlayer] to play a sound non-positionally.
 		[b]Note:[/b] Hiding an [AudioStreamPlayer3D] node does not disable its audio output. To temporarily disable an [AudioStreamPlayer3D]'s audio output, set [member volume_db] to a very low value like [code]-100[/code] (which isn't audible to human hearing).
@@ -57,7 +57,7 @@
 			Determines which [Area3D] layers affect the sound for reverb and audio bus effects. Areas can be used to redirect [AudioStream]s so that they play in a certain audio bus. An example of how you might use this is making a "water" area so that sounds played in the water are redirected through an audio bus to make them sound like they are being played underwater.
 		</member>
 		<member name="attenuation_filter_cutoff_hz" type="float" setter="set_attenuation_filter_cutoff_hz" getter="get_attenuation_filter_cutoff_hz" default="5000.0">
-			Dampens audio using a low-pass filter above this frequency, in Hz. To disable the dampening effect entirely, set this to [code]20500[/code] as this frequency is above the human hearing limit.
+			The cutoff frequency of the attenuation low-pass filter, in Hz. A sound above this frequency is attenuated more than a sound below this frequency. To disable this effect, set this to [code]20500[/code] as this frequency is above the human hearing limit.
 		</member>
 		<member name="attenuation_filter_db" type="float" setter="set_attenuation_filter_db" getter="get_attenuation_filter_db" default="-24.0">
 			Amount how much the filter affects the loudness, in decibels.
@@ -76,13 +76,13 @@
 			Decides in which step the Doppler effect should be calculated.
 		</member>
 		<member name="emission_angle_degrees" type="float" setter="set_emission_angle" getter="get_emission_angle" default="45.0">
-			The angle in which the audio reaches cameras undampened.
+			The angle in which the audio reaches a listener unattenuated.
 		</member>
 		<member name="emission_angle_enabled" type="bool" setter="set_emission_angle_enabled" getter="is_emission_angle_enabled" default="false">
-			If [code]true[/code], the audio should be dampened according to the direction of the sound.
+			If [code]true[/code], the audio should be attenuated according to the direction of the sound.
 		</member>
 		<member name="emission_angle_filter_attenuation_db" type="float" setter="set_emission_angle_filter_attenuation_db" getter="get_emission_angle_filter_attenuation_db" default="-12.0">
-			Dampens audio if camera is outside of [member emission_angle_degrees] and [member emission_angle_enabled] is set by this factor, in decibels.
+			Attenuation factor used if listener is outside of [member emission_angle_degrees] and [member emission_angle_enabled] is set, in decibels.
 		</member>
 		<member name="max_db" type="float" setter="set_max_db" getter="get_max_db" default="3.0">
 			Sets the absolute maximum of the soundlevel, in decibels.
@@ -112,7 +112,7 @@
 			The factor for the attenuation effect. Higher values make the sound audible over a larger distance.
 		</member>
 		<member name="volume_db" type="float" setter="set_volume_db" getter="get_volume_db" default="0.0">
-			The base sound level unaffected by dampening, in decibels.
+			The base sound level before attenuation, in decibels.
 		</member>
 	</members>
 	<signals>
@@ -124,16 +124,16 @@
 	</signals>
 	<constants>
 		<constant name="ATTENUATION_INVERSE_DISTANCE" value="0" enum="AttenuationModel">
-			Linear dampening of loudness according to distance.
+			Attenuation of loudness according to linear distance.
 		</constant>
 		<constant name="ATTENUATION_INVERSE_SQUARE_DISTANCE" value="1" enum="AttenuationModel">
-			Squared dampening of loudness according to distance.
+			Attenuation of loudness according to squared distance.
 		</constant>
 		<constant name="ATTENUATION_LOGARITHMIC" value="2" enum="AttenuationModel">
-			Logarithmic dampening of loudness according to distance.
+			Attenuation of loudness according to logarithmic distance.
 		</constant>
 		<constant name="ATTENUATION_DISABLED" value="3" enum="AttenuationModel">
-			No dampening of loudness according to distance. The sound will still be heard positionally, unlike an [AudioStreamPlayer]. [constant ATTENUATION_DISABLED] can be combined with a [member max_distance] value greater than [code]0.0[/code] to achieve linear attenuation clamped to a sphere of a defined size.
+			No attenuation of loudness according to distance. The sound will still be heard positionally, unlike an [AudioStreamPlayer]. [constant ATTENUATION_DISABLED] can be combined with a [member max_distance] value greater than [code]0.0[/code] to achieve linear attenuation clamped to a sphere of a defined size.
 		</constant>
 		<constant name="DOPPLER_TRACKING_DISABLED" value="0" enum="DopplerTracking">
 			Disables doppler tracking.

--- a/doc/classes/Generic6DOFJoint3D.xml
+++ b/doc/classes/Generic6DOFJoint3D.xml
@@ -115,7 +115,7 @@
 			The minimum rotation in positive direction to break loose and rotate around the X axis.
 		</member>
 		<member name="angular_limit_y/damping" type="float" setter="set_param_y" getter="get_param_y" default="1.0">
-			The amount of rotational damping across the Y axis. The lower, the more dampening occurs.
+			The amount of rotational damping across the Y axis. The lower, the more damping occurs.
 		</member>
 		<member name="angular_limit_y/enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="true">
 			If [code]true[/code], rotation across the Y axis is limited.
@@ -139,7 +139,7 @@
 			The minimum rotation in positive direction to break loose and rotate around the Y axis.
 		</member>
 		<member name="angular_limit_z/damping" type="float" setter="set_param_z" getter="get_param_z" default="1.0">
-			The amount of rotational damping across the Z axis. The lower, the more dampening occurs.
+			The amount of rotational damping across the Z axis. The lower, the more damping occurs.
 		</member>
 		<member name="angular_limit_z/enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="true">
 			If [code]true[/code], rotation across the Z axis is limited.
@@ -357,7 +357,7 @@
 			The speed of all rotations across the axes.
 		</constant>
 		<constant name="PARAM_ANGULAR_DAMPING" value="13" enum="Param">
-			The amount of rotational damping across the axes. The lower, the more dampening occurs.
+			The amount of rotational damping across the axes. The lower, the more damping occurs.
 		</constant>
 		<constant name="PARAM_ANGULAR_RESTITUTION" value="14" enum="Param">
 			The amount of rotational restitution across the axes. The lower, the more restitution occurs.

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -1049,16 +1049,16 @@
 			Constant to set/get a body's gravity multiplier.
 		</constant>
 		<constant name="BODY_PARAM_LINEAR_DAMP_MODE" value="6" enum="BodyParameter">
-			Constant to set/get a body's linear dampening mode. See [enum BodyDampMode] for possible values.
+			Constant to set/get a body's linear damping mode. See [enum BodyDampMode] for possible values.
 		</constant>
 		<constant name="BODY_PARAM_ANGULAR_DAMP_MODE" value="7" enum="BodyParameter">
-			Constant to set/get a body's angular dampening mode. See [enum BodyDampMode] for possible values.
+			Constant to set/get a body's angular damping mode. See [enum BodyDampMode] for possible values.
 		</constant>
 		<constant name="BODY_PARAM_LINEAR_DAMP" value="8" enum="BodyParameter">
-			Constant to set/get a body's linear dampening factor.
+			Constant to set/get a body's linear damping factor.
 		</constant>
 		<constant name="BODY_PARAM_ANGULAR_DAMP" value="9" enum="BodyParameter">
-			Constant to set/get a body's angular dampening factor.
+			Constant to set/get a body's angular damping factor.
 		</constant>
 		<constant name="BODY_PARAM_MAX" value="10" enum="BodyParameter">
 			Represents the size of the [enum BodyParameter] enum.

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -1241,7 +1241,7 @@
 			A factor that gets multiplied onto all rotations across the axes.
 		</constant>
 		<constant name="G6DOF_JOINT_ANGULAR_DAMPING" value="13" enum="G6DOFJointAxisParam">
-			The amount of rotational damping across the axes. The lower, the more dampening occurs.
+			The amount of rotational damping across the axes. The lower, the more damping occurs.
 		</constant>
 		<constant name="G6DOF_JOINT_ANGULAR_RESTITUTION" value="14" enum="G6DOFJointAxisParam">
 			The amount of rotational restitution across the axes. The lower, the more restitution occurs.
@@ -1392,16 +1392,16 @@
 			Constant to set/get a body's gravity multiplier.
 		</constant>
 		<constant name="BODY_PARAM_LINEAR_DAMP_MODE" value="6" enum="BodyParameter">
-			Constant to set/get a body's linear dampening mode. See [enum BodyDampMode] for possible values.
+			Constant to set/get a body's linear damping mode. See [enum BodyDampMode] for possible values.
 		</constant>
 		<constant name="BODY_PARAM_ANGULAR_DAMP_MODE" value="7" enum="BodyParameter">
-			Constant to set/get a body's angular dampening mode. See [enum BodyDampMode] for possible values.
+			Constant to set/get a body's angular damping mode. See [enum BodyDampMode] for possible values.
 		</constant>
 		<constant name="BODY_PARAM_LINEAR_DAMP" value="8" enum="BodyParameter">
-			Constant to set/get a body's linear dampening factor.
+			Constant to set/get a body's linear damping factor.
 		</constant>
 		<constant name="BODY_PARAM_ANGULAR_DAMP" value="9" enum="BodyParameter">
-			Constant to set/get a body's angular dampening factor.
+			Constant to set/get a body's angular damping factor.
 		</constant>
 		<constant name="BODY_PARAM_MAX" value="10" enum="BodyParameter">
 			Represents the size of the [enum BodyParameter] enum.

--- a/doc/classes/SkeletonModification2DJiggle.xml
+++ b/doc/classes/SkeletonModification2DJiggle.xml
@@ -107,7 +107,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="damping" type="float" />
 			<description>
-				Sets the amount of dampening of the Jiggle joint at [param joint_idx].
+				Sets the amount of damping of the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_jiggle_joint_gravity">
@@ -160,7 +160,7 @@
 	</methods>
 	<members>
 		<member name="damping" type="float" setter="set_damping" getter="get_damping" default="0.75">
-			The default amount of dampening applied to the Jiggle joints, if they are not overridden. Higher values lead to more of the calculated velocity being applied.
+			The default amount of damping applied to the Jiggle joints, if they are not overridden. Higher values lead to more of the calculated velocity being applied.
 		</member>
 		<member name="gravity" type="Vector2" setter="set_gravity" getter="get_gravity" default="Vector2(0, 6)">
 			The default amount of gravity applied to the Jiggle joints, if they are not overridden.


### PR DESCRIPTION
Fixing instances of the word `dampen(ed|ing)` being used in place of `damp(ed|ing)`.

In the audio classes some surrounding changes needed to be made. I elected to use 'attenuate' instead, which is consistent with the code and other parts of the docs.

The physics classes were a case of simple substitution.