### PR TITLE
Fix shortcut buttons generating mouse exited signal on selected collider.

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3043,8 +3043,11 @@ bool Viewport::gui_is_drag_successful() const {
 void Viewport::set_input_as_handled() {
 	const Ref<InputEventMouseMotion> mm = last_event;
 	if (mm.is_valid()) {
+		// Option 1:
 		// physics_picking_events.push_back(mm);
 		// _process_picking();
+
+		// Option 2:
 		_drop_physics_mouseover();
 	}
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2755,6 +2755,8 @@ void Viewport::push_input(const Ref<InputEvent> &p_event, bool p_local_coords) {
 		ev = p_event;
 	}
 
+	last_event = ev;
+
 	if (is_embedding_subwindows() && _sub_windows_forward_input(ev)) {
 		set_input_as_handled();
 		return;
@@ -2797,6 +2799,8 @@ void Viewport::push_unhandled_input(const Ref<InputEvent> &p_event, bool p_local
 	} else {
 		ev = p_event;
 	}
+
+	last_event = ev;
 
 	// Shortcut Input.
 	if (Object::cast_to<InputEventKey>(*ev) != nullptr || Object::cast_to<InputEventShortcut>(*ev) != nullptr) {
@@ -3037,7 +3041,11 @@ bool Viewport::gui_is_drag_successful() const {
 }
 
 void Viewport::set_input_as_handled() {
-	_drop_physics_mouseover();
+	const Ref<InputEventMouseMotion> mm = last_event;
+	if (mm.is_valid()) {
+		physics_picking_events.push_back(mm);
+		_process_picking();
+	}
 
 	if (!handle_input_locally) {
 		ERR_FAIL_COND(!is_inside_tree());

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3043,8 +3043,9 @@ bool Viewport::gui_is_drag_successful() const {
 void Viewport::set_input_as_handled() {
 	const Ref<InputEventMouseMotion> mm = last_event;
 	if (mm.is_valid()) {
-		physics_picking_events.push_back(mm);
-		_process_picking();
+		// physics_picking_events.push_back(mm);
+		// _process_picking();
+		_drop_physics_mouseover();
 	}
 
 	if (!handle_input_locally) {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -474,7 +474,7 @@ protected:
 	Size2i _get_size() const;
 	Size2i _get_size_2d_override() const;
 	bool _is_size_allocated() const;
-
+	Ref<InputEvent> last_event;
 	void _notification(int p_what);
 	void _process_picking();
 	static void _bind_methods();


### PR DESCRIPTION
Fixes #61924 while trying to keep fix from #29575

Basically, cache last event which was pushed, and when marking that event as handled, check if it was mouse motion before dropping mouseover or doing picking. Might need to add joypad motion too in case that was being used for mouse movement I guess? not sure

**Option 1:** Continue physics picking _through_ controls when input is handled.

https://user-images.githubusercontent.com/41730826/193043339-e762cf6c-8f41-49a4-a851-32ecdb5afbd3.mp4

**Option 2:** Drop physics picking _only_ on mouse motion events which are handled.

https://user-images.githubusercontent.com/41730826/193046475-02987d19-94fa-4b4e-92f5-457fa4191db4.mp4

The are probably other ways to handle it too.

CC @Chaosus