### PR TITLE
Drop physics mouseover as soon as the mouse moves over a Control

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1669,6 +1669,9 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			_gui_cancel_tooltip();
 
 			if (over) {
+				if (!gui.mouse_over) {
+					_drop_physics_mouseover();
+				}
 				_gui_call_notification(over, Control::NOTIFICATION_MOUSE_ENTER);
 				gui.mouse_over = over;
 			}
@@ -3039,8 +3042,6 @@ bool Viewport::gui_is_drag_successful() const {
 }
 
 void Viewport::set_input_as_handled() {
-	_drop_physics_mouseover();
-
 	if (!handle_input_locally) {
 		ERR_FAIL_COND(!is_inside_tree());
 		Viewport *vp = this;


### PR DESCRIPTION
fix #61924
alternative to #68018

`_drop_physics_mouseover()` was added into `set_input_as_handled` as a fix for #29575 to drop physics mouseover when the mouse is over a control.
The current implementation however doesn't check, if the mouse is actually over a Control, which leads to #61924, where physics-mouseover is dropped even if the mouse is not over a Control.
~This patch changes the behavior, so that it is verified that the mouse is actually over a Control, before dropping physics mouseover.~
This patch doesn't call `_drop_physics_mouseover()` in `set_input_as_handled` but as soon as the mouse enters the area of a `Control`.