### PR TITLE
Partial support for Pico 4

### DIFF
--- a/modules/openxr/extensions/openxr_android_extension.h
+++ b/modules/openxr/extensions/openxr_android_extension.h
@@ -41,11 +41,14 @@ public:
 	OpenXRAndroidExtension(OpenXRAPI *p_openxr_api);
 
 	virtual void on_before_instance_created() override;
+	virtual void *set_instance_create_info_and_get_next_pointer(void *p_next_pointer) override;
 
 	virtual ~OpenXRAndroidExtension() override;
 
 private:
 	static OpenXRAndroidExtension *singleton;
+
+	bool create_instance_extension_available = false;
 
 	// Initialize the loader
 	EXT_PROTO_XRRESULT_FUNC1(xrInitializeLoaderKHR, (const XrLoaderInitInfoBaseHeaderKHR *), loaderInitInfo)

--- a/modules/openxr/extensions/openxr_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper.h
@@ -65,6 +65,7 @@ public:
 	virtual void *set_system_properties_and_get_next_pointer(void *p_next_pointer) { return p_next_pointer; }
 	virtual void *set_session_create_and_get_next_pointer(void *p_next_pointer) { return p_next_pointer; }
 	virtual void *set_swapchain_create_info_and_get_next_pointer(void *p_next_pointer) { return p_next_pointer; }
+	virtual void *set_instance_create_info_and_get_next_pointer(void *p_next_pointer) { return p_next_pointer; }
 
 	virtual void on_before_instance_created() {}
 	virtual void on_instance_created(const XrInstance p_instance) {}

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -269,9 +269,17 @@ bool OpenXRAPI::create_instance() {
 		XR_CURRENT_API_VERSION // apiVersion
 	};
 
+	void *next_pointer = nullptr;
+	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
+		void *np = wrapper->set_instance_create_info_and_get_next_pointer(next_pointer);
+		if (np != nullptr) {
+			next_pointer = np;
+		}
+	}
+
 	XrInstanceCreateInfo instance_create_info = {
 		XR_TYPE_INSTANCE_CREATE_INFO, // type
-		nullptr, // next
+		next_pointer, // next
 		0, // createFlags
 		application_info, // applicationInfo
 		0, // enabledApiLayerCount, need to find out if we need support for this?


### PR DESCRIPTION
I attempted to port Godot 4 to the Pico 4, but so far did not succeed to get the whole engine up and running. This PR adds support for the necessary OpenXR extension and injects necessary metadata to permit the engine to start in VR mode.

**With this PR, only extremely simple scenes will render properly** (with the mobile renderer). I  tested this with a scene with the usual XR nodes (origin, camera, controllers) and a world environment with sky shader and unshaded, untextured geometry, on a Pico 4 with Pico OS 5.1. As far as I see, the remaining issues are likely to reside either on the Vulkan side or in the OpenXR-Vulkan interactions.

I hope this PR helps people with more Vulkan / OpenXR / godot core experience to either complete the port or point me in the right direction so I can get further. I'll post a comment on this PR shortly with information about the issues I identified so far and some information about what I tried already. That said, it might be reasonable to merge it as-is and in the meantime and continue the discussion for full Pico 4 support elsewhere, as the two commits in this PR are self-contained.

_Similar to Meta/Oculus Quest, Pico devices support OpenXR through a proprietary loader included in their [OpenXR SDK download](https://developer-global.pico-interactive.com/sdk?deviceId=1&platformId=3&itemId=11). To test this code in a crude way, it is sufficient to copy the 64-bit libopenxr_loader.so file to platform/android/java/app/libs/dev/arm64-v8a and rebuild the Android export template._