### PR TITLE
Directly create window to desired state without post adjustment

### DIFF
--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -144,7 +144,7 @@ struct _NO_DISCARD_ Rect2 {
 		return size.x > 0.0f && size.y > 0.0f;
 	}
 
-	// Returns the instersection between two Rect2s or an empty Rect2 if there is no intersection
+	// Returns the intersection between two Rect2s or an empty Rect2 if there is no intersection
 	inline Rect2 intersection(const Rect2 &p_rect) const {
 		Rect2 new_rect = p_rect;
 

--- a/core/math/rect2i.h
+++ b/core/math/rect2i.h
@@ -87,7 +87,7 @@ struct _NO_DISCARD_ Rect2i {
 		return size.x > 0 && size.y > 0;
 	}
 
-	// Returns the instersection between two Rect2is or an empty Rect2i if there is no intersection
+	// Returns the intersection between two Rect2is or an empty Rect2i if there is no intersection
 	inline Rect2i intersection(const Rect2i &p_rect) const {
 		Rect2i new_rect = p_rect;
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -890,8 +890,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (I->get() == "-m" || I->get() == "--maximized") { // force maximized window
 
 			init_maximized = true;
-			window_mode = DisplayServer::WINDOW_MODE_MAXIMIZED;
-
 		} else if (I->get() == "-w" || I->get() == "--windowed") { // force windowed window
 
 			init_windowed = true;
@@ -1389,7 +1387,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		main_args.push_back("--editor");
 		if (!init_windowed) {
 			init_maximized = true;
-			window_mode = DisplayServer::WINDOW_MODE_MAXIMIZED;
 		}
 	}
 
@@ -1960,6 +1957,18 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		Vector2i position = init_custom_pos;
 		if (init_use_custom_pos) {
 			window_position = &position;
+		}
+
+		// Flags always take precedence over project settings.
+		if (init_windowed) {
+			window_mode = DisplayServer::WINDOW_MODE_WINDOWED;
+		} else if (init_maximized) {
+			window_mode = DisplayServer::WINDOW_MODE_MAXIMIZED;
+		} else if (init_fullscreen) {
+			window_mode = DisplayServer::WINDOW_MODE_FULLSCREEN;
+		}
+		if (init_always_on_top) {
+			window_flags |= DisplayServer::WINDOW_FLAG_ALWAYS_ON_TOP;
 		}
 
 		// rendering_driver now held in static global String in main and initialized in setup()


### PR DESCRIPTION
Fix the fullscreen and maximized options when creating window. (Related to #67790)


This PR contains a separate commit which fixes the typo of Rect. It's too small. So instead of creating a new PR, I added it to this PR.