### PR TITLE
Show Light3D's scale warning immediately when a user edits the property.

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -907,9 +907,7 @@ void RigidBody2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
-			if (Engine::get_singleton()->is_editor_hint()) {
-				update_configuration_warnings();
-			}
+			update_configuration_warnings();
 		} break;
 	}
 #endif

--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -83,13 +83,9 @@ void CollisionObject3D::_notification(int p_what) {
 			_update_pickable();
 		} break;
 
-#ifdef TOOLS_ENABLED
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
-			if (Engine::get_singleton()->is_editor_hint()) {
-				update_configuration_warnings();
-			}
+			update_configuration_warnings();
 		} break;
-#endif
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (only_update_transform_changes) {

--- a/scene/3d/collision_polygon_3d.cpp
+++ b/scene/3d/collision_polygon_3d.cpp
@@ -104,11 +104,7 @@ void CollisionPolygon3D::_notification(int p_what) {
 			if (parent) {
 				_update_in_shape_owner(true);
 			}
-#ifdef TOOLS_ENABLED
-			if (Engine::get_singleton()->is_editor_hint()) {
-				update_configuration_warnings();
-			}
-#endif
+			update_configuration_warnings();
 		} break;
 
 		case NOTIFICATION_UNPARENTED: {

--- a/scene/3d/collision_shape_3d.cpp
+++ b/scene/3d/collision_shape_3d.cpp
@@ -99,11 +99,7 @@ void CollisionShape3D::_notification(int p_what) {
 			if (parent) {
 				_update_in_shape_owner(true);
 			}
-#ifdef TOOLS_ENABLED
-			if (Engine::get_singleton()->is_editor_hint()) {
-				update_configuration_warnings();
-			}
-#endif
+			update_configuration_warnings();
 		} break;
 
 		case NOTIFICATION_UNPARENTED: {

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -284,6 +284,9 @@ void Light3D::_update_visibility() {
 
 void Light3D::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_TRANSFORM_CHANGED: {
+			update_configuration_warnings();
+		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED:
 		case NOTIFICATION_ENTER_TREE: {
 			_update_visibility();

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -599,9 +599,7 @@ void RigidBody3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
-			if (Engine::get_singleton()->is_editor_hint()) {
-				update_configuration_warnings();
-			}
+			update_configuration_warnings();
 		} break;
 	}
 #endif


### PR DESCRIPTION
Oversight I noticed in https://github.com/godotengine/godot/pull/67192