### PR TITLE
Make SurfaceTool.generate_normals() behave consistently with smoothing groups

### DIFF
--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -133,7 +133,7 @@
 			<description>
 				Generates normals from vertices so you do not have to do it manually. If [param flip] is [code]true[/code], the resulting normals will be inverted. [method generate_normals] should be called [i]after[/i] generating geometry and [i]before[/i] committing the mesh using [method commit] or [method commit_to_arrays]. For correct display of normal-mapped surfaces, you will also have to generate tangents using [method generate_tangents].
 				[b]Note:[/b] [method generate_normals] only works if the primitive type to be set to [constant Mesh.PRIMITIVE_TRIANGLES].
-				[b]Note:[/b] [method generate_normals] takes smooth groups into account. If you don't specify any smooth group for each vertex, [method generate_normals] will smooth normals for you.
+				[b]Note:[/b] [method generate_normals] takes smooth groups into account. To generate smooth normals, set the smooth group to a value greater than or equal to [code]0[/code] using [method set_smooth_group] or leave the smooth group at the default of [code]0[/code]. To generate flat normals, set the smooth group to [code]-1[/code] using [method set_smooth_group] prior to adding vertices.
 			</description>
 		</method>
 		<method name="generate_tangents">
@@ -241,7 +241,7 @@
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Specifies whether the current vertex (if using only vertex arrays) or current index (if also using index arrays) should use smooth normals for normal calculation.
+				Specifies the smooth group to use for the [i]next[/i] vertex. If this is never called, all vertices will have the default smooth group of [code]0[/code] and will be smoothed with adjacent vertices of the same group. To produce a mesh with flat normals, set the smooth group to [code]-1[/code].
 			</description>
 		</method>
 		<method name="set_tangent">

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -97,6 +97,21 @@ private:
 		static _FORCE_INLINE_ uint32_t hash(const Vertex &p_vtx);
 	};
 
+	struct SmoothGroupVertex {
+		Vector3 vertex;
+		uint32_t smooth_group = 0;
+		bool operator==(const SmoothGroupVertex &p_vertex) const;
+
+		SmoothGroupVertex(const Vertex &p_vertex) {
+			vertex = p_vertex.vertex;
+			smooth_group = p_vertex.smooth_group;
+		};
+	};
+
+	struct SmoothGroupVertexHasher {
+		static _FORCE_INLINE_ uint32_t hash(const SmoothGroupVertex &p_vtx);
+	};
+
 	struct TriangleHasher {
 		static _FORCE_INLINE_ uint32_t hash(const int *p_triangle);
 		static _FORCE_INLINE_ bool compare(const int *p_lhs, const int *p_rhs);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
I'm not entirely sure how smooth groups is *supposed* to work within SurfaceTool since it seems to be undocumented, but I think this relatively small change makes the behavior easier to reason about and produce results in a consistent manner. 

This change addresses a couple problems(?) with `generate_normals()`. The first issue is that vertices are binned using a hash map which takes into account the *entire* vertex (including uvs, colors, bones, etc.). To address this issue, this PR introduces a `SmoothGroupVertex` struct and accompanying `SmoothGroupVertexHasher` which only takes vertex position and smooth group into account. This means that vertices of adjacent faces sharing the same smooth group will *contribute to* and *receive* smoothed normals regardless of other vertex attributes.

The other potential issue that some other tickets (see below) bring up is that for a user to generate normals for a mesh with flat faces it would be necessary to use different smooth groups for each face (or at least ensuring that no adjacent vertices share smooth groups) which seems to me like an unnecessary burden for the user. This PR also includes changes which imply that surface group `0` is meant to be flat shaded. If a user wishes to create a smooth shaded mesh, a single call to `surface_tool.set_smooth_group(1)` would mean the entire mesh will be smooth. This behavior makes sense to me, but I defer to the group :grin: .

Here's a screenshot of the output of the attached example project (adapted from a related issue below):
![generate_normals_changes](https://user-images.githubusercontent.com/9374/198852167-e4375ad2-f1fd-495b-96ee-d7c407750ec7.png)
Example:
[SurfaceToolSmoothShading4.zip](https://github.com/godotengine/godot/files/9894596/SurfaceToolSmoothShading4.zip)

Related issues:
 - #6146 - (2.x and 3.x) describes an issue where smoothing is not performed when vertices of adjacent faces don't share UV coordinates (binning issue)
 - #65076 - (4.0) - claims 3.x works fine, but the example consists of flat sided cubes which masks the issue, while the problem is clearly visible in the 4.x screenshot (also a binning issue)
 - #65104 - (3.5) - identifies part of the vertex binning issue, but 3.x's `add_smooth_group()` has a slightly unrelated bug in addition to the binning.

Although this PR is not applicable to 3.x, I think similar behavior can be implemented with the old `add_smooth_group(bool)` method.

Hopefully this is a welcome contribution, any feedback is greatly appreciated!

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/6146
- Fixes https://github.com/godotengine/godot/issues/65076
- Fixes https://github.com/godotengine/godot/issues/65104
- Fixes https://github.com/godotengine/godot/issues/66765