### PR TITLE
Check anonymous scripts in resource exports.

### DIFF
--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -95,6 +95,7 @@ class EditorResourcePicker : public HBoxContainer {
 	void _get_allowed_types(bool p_with_convert, HashSet<String> *p_vector) const;
 	bool _is_drop_valid(const Dictionary &p_drag_data) const;
 	bool _is_type_valid(const String p_type_name, HashSet<String> p_allowed_types) const;
+	bool _is_object_valid(const Ref<Resource> &p_resource, HashSet<String> p_allowed_types, String *r_res_type = nullptr) const;
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;


### PR DESCRIPTION
Closes #66987.

Adjusts `EditorResourcePicker` so that it uses its cache-based `HashMap` lookups for all typename queries rather than just a subset (I'm not sure why it wasn't doing that to begin with). Then, in cases where we are evaluating an actual object and not just a name, it now supplements those queries with an additional *manual* script inheritance check if and only if...

1. all preceding name checks fail
2. the resource in question has a valid script attached
3. the currently evaluated `base` is the name of a global script class

Also, if someone could please evaluate and confirm the correct usage of `p_with_convert` in the calls to `_get_allowed_types()` as I'm not entirely sure when the convertible types should be included in the gathered type list, i.e. I may have passed the wrong boolean value in when I called the method.