### PR TITLE
Fixed signal connection examples to use new callable syntax in the docs

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -11,7 +11,7 @@
 		func _ready():
 		    var button = Button.new()
 		    button.text = "Click me"
-		    button.connect("pressed", self, "_button_pressed")
+		    button.pressed.connect(self._button_pressed)
 		    add_child(button)
 
 		func _button_pressed():
@@ -22,7 +22,7 @@
 		{
 		    var button = new Button();
 		    button.Text = "Click me";
-		    button.Connect("pressed", this, nameof(ButtonPressed));
+		    button.Pressed += ButtonPressed;
 		    AddChild(button);
 		}
 

--- a/doc/classes/ConfirmationDialog.xml
+++ b/doc/classes/ConfirmationDialog.xml
@@ -8,10 +8,10 @@
 		To get cancel action, you can use:
 		[codeblocks]
 		[gdscript]
-		get_cancel().connect("pressed", self, "cancelled")
+		get_cancel_button().pressed.connect(self.cancelled)
 		[/gdscript]
 		[csharp]
-		GetCancel().Connect("pressed", this, nameof(Cancelled));
+		GetCancelButton().Pressed += Cancelled;
 		[/csharp]
 		[/codeblocks]
 	</description>

--- a/doc/classes/Expression.xml
+++ b/doc/classes/Expression.xml
@@ -12,7 +12,7 @@
 		var expression = Expression.new()
 
 		func _ready():
-		    $LineEdit.connect("text_submitted", self, "_on_text_submitted")
+		    $LineEdit.text_submitted.connect(self._on_text_submitted)
 
 		func _on_text_submitted(command):
 		    var error = expression.parse(command)
@@ -28,7 +28,7 @@
 
 		public override void _Ready()
 		{
-		    GetNode("LineEdit").Connect("text_submitted", this, nameof(OnTextEntered));
+		    GetNode("LineEdit").TextSubmitted += OnTextEntered;
 		}
 
 		private void OnTextEntered(string command)

--- a/modules/webxr/doc_classes/WebXRInterface.xml
+++ b/modules/webxr/doc_classes/WebXRInterface.xml
@@ -18,16 +18,16 @@
 		func _ready():
 		    # We assume this node has a button as a child.
 		    # This button is for the user to consent to entering immersive VR mode.
-		    $Button.connect("pressed", self, "_on_Button_pressed")
+		    $Button.pressed.connect(self._on_Button_pressed)
 
 		    webxr_interface = XRServer.find_interface("WebXR")
 		    if webxr_interface:
 		        # WebXR uses a lot of asynchronous callbacks, so we connect to various
 		        # signals in order to receive them.
-		        webxr_interface.connect("session_supported", self, "_webxr_session_supported")
-		        webxr_interface.connect("session_started", self, "_webxr_session_started")
-		        webxr_interface.connect("session_ended", self, "_webxr_session_ended")
-		        webxr_interface.connect("session_failed", self, "_webxr_session_failed")
+		        webxr_interface.session_supported.connect(self._webxr_session_supported)
+		        webxr_interface.session_started.connect(self._webxr_session_started)
+		        webxr_interface.session_ended.connect(self._webxr_session_ended)
+		        webxr_interface.session_failed.connect(self._webxr_session_failed)
 
 		        # This returns immediately - our _webxr_session_supported() method
 		        # (which we connected to the "session_supported" signal above) will


### PR DESCRIPTION
Fixed signal connection examples to use new callable syntax in the docs.

- Button
- ConfirmationDialog
- Expression
- WebXRInterface

This list was found by global searching the repo for `.connect` in *.xml files. Not sure if there are more signal examples in the class APIs.