### PR TITLE
Add ProMotion/High Refresh Rate Support to iOS Exports

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -565,6 +565,9 @@
 			The default screen orientation to use on mobile devices. See [enum DisplayServer.ScreenOrientation] for possible values.
 			[b]Note:[/b] When set to a portrait orientation, this project setting does not flip the project resolution's width and height automatically. Instead, you have to set [member display/window/size/viewport_width] and [member display/window/size/viewport_height] accordingly.
 		</member>
+		<member name="display/window/ios/allow_high_refresh_rate" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], iOS devices that support high refresh rate/"ProMotion" will be allowed to render at up to 120 frames per second.
+		</member>
 		<member name="display/window/ios/hide_home_indicator" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], the home indicator is hidden automatically. This only affects iOS devices without a physical home button.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1820,6 +1820,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 					PROPERTY_HINT_RANGE,
 					"0,33200,1,or_greater")); // No negative numbers
 
+	GLOBAL_DEF("display/window/ios/allow_high_refresh_rate", true);
 	GLOBAL_DEF("display/window/ios/hide_home_indicator", true);
 	GLOBAL_DEF("display/window/ios/hide_status_bar", true);
 	GLOBAL_DEF("display/window/ios/suppress_ui_gesture", true);

--- a/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
+++ b/misc/dist/ios_xcode/godot_ios/godot_ios-Info.plist
@@ -58,5 +58,6 @@
 	</array>
 	$additional_plist_content
 	$plist_launch_screen_name
+	<key>CADisableMinimumFrameDurationOnPhone</key><true/>
 </dict>
 </plist>

--- a/platform/ios/godot_view.mm
+++ b/platform/ios/godot_view.mm
@@ -30,6 +30,7 @@
 
 #import "godot_view.h"
 
+#include "core/config/project_settings.h"
 #include "core/os/keyboard.h"
 #include "core/string/ustring.h"
 #import "display_layer.h"
@@ -205,16 +206,16 @@ static const float earth_gravity = 9.80665;
 	if (self.useCADisplayLink) {
 		self.displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(drawView)];
 
-		// Approximate frame rate
-		// assumes device refreshes at 60 fps
-		int displayFPS = (NSInteger)(1.0 / self.renderingInterval);
-
-		self.displayLink.preferredFramesPerSecond = displayFPS;
+		if (GLOBAL_GET("display/window/ios/allow_high_refresh_rate")) {
+			self.displayLink.preferredFramesPerSecond = 120;
+		} else {
+			self.displayLink.preferredFramesPerSecond = 60;
+		}
 
 		// Setup DisplayLink in main thread
 		[self.displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
 	} else {
-		self.animationTimer = [NSTimer scheduledTimerWithTimeInterval:self.renderingInterval target:self selector:@selector(drawView) userInfo:nil repeats:YES];
+		self.animationTimer = [NSTimer scheduledTimerWithTimeInterval:(1.0 / 60) target:self selector:@selector(drawView) userInfo:nil repeats:YES];
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5676

Adds ability for iOS exports to take advantage of "ProMotion" which is Apple's branding for panels with a refresh rate above 60Hz. This should affect the following devices, allowing them to reach up to 120Hz if the setting is left enabled:

-iPad Pro 2018 or later
-iPhone 13 Pro/Pro Max
-iPhone 14 Pro/Pro Max (or later)

How this affects VSync depends on the device, more info can be seen [here](https://developer.apple.com/documentation/quartzcore/optimizing_promotion_refresh_rates_for_iphone_13_pro_and_ipad_pro#Enable_faster_ProMotion_refresh_rates) in the "Understand refresh rates" header.

Note: `<key>CADisableMinimumFrameDurationOnPhone</key><true/>` has no visible effect if the Godot project setting is set to off, so it probably doesn't need any kind of special toggle.