### PR TITLE
Added missing docs to built-in types float and int

### DIFF
--- a/doc/classes/float.xml
+++ b/doc/classes/float.xml
@@ -114,12 +114,17 @@
 			<return type="Vector4" />
 			<param index="0" name="right" type="Vector4" />
 			<description>
+				Multiplies each component of the [Vector4] by the given [float].
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector4" />
 			<param index="0" name="right" type="Vector4i" />
 			<description>
+				Multiplies each component of the [Vector4i] by the given [float]. Returns a [Vector4].
+				[codeblock]
+				print(0.9 * Vector4i(10, 15, 20, -10)) # Prints "(9, 13.5, 18, -9)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator *">
@@ -140,12 +145,20 @@
 			<return type="float" />
 			<param index="0" name="right" type="float" />
 			<description>
+				Raises a [float] to a power of a [float].
+				[codeblock]
+				print(39.0625**0.25) # 2.5
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator **">
 			<return type="float" />
 			<param index="0" name="right" type="int" />
 			<description>
+				Raises a [float] to a power of an [int]. The result is a [float].
+				[codeblock]
+				print(0.9**3) # 0.729
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator +">

--- a/doc/classes/int.xml
+++ b/doc/classes/int.xml
@@ -161,12 +161,14 @@
 			<return type="Vector4" />
 			<param index="0" name="right" type="Vector4" />
 			<description>
+				Multiplies each component of the [Vector4] by the given [int].
 			</description>
 		</operator>
 		<operator name="operator *">
 			<return type="Vector4i" />
 			<param index="0" name="right" type="Vector4i" />
 			<description>
+				Multiplies each component of the [Vector4i] by the given [int].
 			</description>
 		</operator>
 		<operator name="operator *">
@@ -187,12 +189,20 @@
 			<return type="float" />
 			<param index="0" name="right" type="float" />
 			<description>
+				Raises an [int] to a power of a [float]. The result is a [float].
+				[codeblock]
+				print(8**0.25) # 1.68179283050743
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator **">
 			<return type="int" />
 			<param index="0" name="right" type="int" />
 			<description>
+				Raises an [int] to a power of a [int].
+				[codeblock]
+				print(5**5) # 3125
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator +">


### PR DESCRIPTION
Added missing docs to built-in types float and int.

 - Added docs for * operator with types `Vector4` and `Vector4i`.
 - Added docs for ** operator(power).