### PR TITLE
Identify debug instances with window title

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1739,6 +1739,10 @@ bool EngineDebugger::has_capture(const StringName &p_name) {
 	return ::EngineDebugger::has_capture(p_name);
 }
 
+int EngineDebugger::get_session_id() {
+	return ::EngineDebugger::get_singleton()->get_session_id();
+}
+
 void EngineDebugger::send_message(const String &p_msg, const Array &p_data) {
 	ERR_FAIL_COND_MSG(!::EngineDebugger::is_active(), "Can't send message. No active debugger");
 	::EngineDebugger::get_singleton()->send_message(p_msg, p_data);
@@ -1784,6 +1788,8 @@ void EngineDebugger::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("register_message_capture", "name", "callable"), &EngineDebugger::register_message_capture);
 	ClassDB::bind_method(D_METHOD("unregister_message_capture", "name"), &EngineDebugger::unregister_message_capture);
 	ClassDB::bind_method(D_METHOD("has_capture", "name"), &EngineDebugger::has_capture);
+
+	ClassDB::bind_method(D_METHOD("get_session_id"), &EngineDebugger::get_session_id);
 
 	ClassDB::bind_method(D_METHOD("send_message", "message", "data"), &EngineDebugger::send_message);
 }

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -563,6 +563,8 @@ public:
 	void unregister_message_capture(const StringName &p_name);
 	bool has_capture(const StringName &p_name);
 
+	int get_session_id();
+
 	void send_message(const String &p_msg, const Array &p_data);
 
 	static Error call_capture(void *p_user, const String &p_cmd, const Array &p_data, bool &r_captured);

--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -180,6 +180,14 @@ void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, Ve
 	allow_focus_steal_fn = p_allow_focus_steal_fn;
 }
 
+void EngineDebugger::set_session_id(int p_session_id) {
+	session_id = p_session_id;
+}
+
+int EngineDebugger::get_session_id() {
+	return session_id;
+}
+
 void EngineDebugger::deinitialize() {
 	if (singleton) {
 		// Stop all profilers

--- a/core/debugger/engine_debugger.h
+++ b/core/debugger/engine_debugger.h
@@ -85,6 +85,8 @@ public:
 	};
 
 private:
+	int session_id = -1;
+
 	double frame_time = 0.0;
 	double process_time = 0.0;
 	double physics_time = 0.0;
@@ -127,6 +129,9 @@ public:
 	Error capture_parse(const StringName &p_name, const String &p_msg, const Array &p_args, bool &r_captured);
 
 	void line_poll();
+
+	void set_session_id(int p_session_id);
+	int get_session_id();
 
 	virtual void poll_events(bool p_is_idle) {}
 	virtual void send_message(const String &p_msg, const Array &p_data) = 0;

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -632,6 +632,8 @@ Error RemoteDebugger::_core_capture(const String &p_cmd, const Array &p_data, bo
 		script_debugger->set_skip_breakpoints(p_data[0]);
 	} else if (p_cmd == "break") {
 		script_debugger->debug(script_debugger->get_break_language());
+	} else if (p_cmd == "set_session_id") {
+		set_session_id(p_data[0]);
 	} else {
 		r_captured = false;
 	}

--- a/doc/classes/EngineDebugger.xml
+++ b/doc/classes/EngineDebugger.xml
@@ -9,6 +9,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_session_id">
+			<return type="int" />
+			<description>
+				Returns session id of this instance. If the value is negative, the session is invalid.
+			</description>
+		</method>
 		<method name="has_capture">
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -111,7 +111,8 @@ ScriptEditorDebugger *EditorDebuggerNode::_add_debugger() {
 
 	tabs->add_child(node);
 
-	node->set_name("Session " + itos(tabs->get_tab_count()));
+	node->session_id = tabs->get_tab_count();
+	node->set_name("Session " + itos(node->session_id));
 	if (tabs->get_tab_count() > 1) {
 		node->clear_style();
 		tabs->set_tabs_visible(true);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -930,6 +930,11 @@ void ScriptEditorDebugger::start(Ref<RemoteDebuggerPeer> p_peer) {
 	tabs->set_current_tab(0);
 	_set_reason_text(TTR("Debug session started."), MESSAGE_SUCCESS);
 	_update_buttons_state();
+
+	Array msg;
+	msg.push_back(session_id);
+	_put_msg("set_session_id", msg);
+
 	emit_signal(SNAME("started"));
 }
 

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -111,6 +111,7 @@ private:
 	};
 	FileDialogPurpose file_dialog_purpose;
 
+	int session_id = -1;
 	int error_count;
 	int warning_count;
 


### PR DESCRIPTION
Related to [#3357](https://github.com/godotengine/godot-proposals/issues/3357), #64913


This PR passes session id via debug message instead of cmd args. It is always correct even if the debug instances are not connected to debug server in order.