### PR TITLE
Fix invalid argument error in vararg methods

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2425,10 +2425,15 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 
 				switch (err.error) {
 					case Callable::CallError::CALL_ERROR_INVALID_ARGUMENT: {
-						PropertyInfo wrong_arg = function_info.arguments[err.argument];
-						push_error(vformat(R"*(Invalid argument for "%s()" function: argument %d should be %s but is %s.)*", function_name, err.argument + 1,
-										   type_from_property(wrong_arg).to_string(), p_call->arguments[err.argument]->get_datatype().to_string()),
-								p_call->arguments[err.argument]);
+						if (err.argument < function_info.arguments.size()) {
+							PropertyInfo wrong_arg = function_info.arguments[err.argument];
+							push_error(vformat(R"*(Invalid argument for "%s()" function: argument %d should be %s but is %s.)*", function_name, err.argument + 1,
+											type_from_property(wrong_arg).to_string(), p_call->arguments[err.argument]->get_datatype().to_string()),
+									p_call->arguments[err.argument]);
+						} else { // Might happen in vararg function.
+							push_error(vformat(R"*(Invalid argument for "%s()" function: argument %d is %s.)*", function_name, err.argument + 1,
+											p_call->arguments[err.argument]->get_datatype().to_string()), p_call->arguments[err.argument]);
+						}
 					} break;
 					case Callable::CallError::CALL_ERROR_INVALID_METHOD:
 						push_error(vformat(R"(Invalid call for function "%s".)", function_name), p_call);


### PR DESCRIPTION
Fixes #68062
```GDScript
min(1, null)
```
![image](https://user-images.githubusercontent.com/2223172/198903445-f026b72f-ff10-4bb8-a49c-fe9ce5379bbd.png)

The crash happened because the error message tried to display expected argument type, but there was no necessary info, because the function was vararg.