### PR TITLE
fix: emit target_reached signal after updating state

### DIFF
--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -481,8 +481,8 @@ void NavigationAgent2D::_request_repath() {
 void NavigationAgent2D::_check_distance_to_target() {
 	if (!target_reached) {
 		if (distance_to_target() < target_desired_distance) {
-			emit_signal("target_reached");
 			target_reached = true;
+			emit_signal("target_reached");
 		}
 	}
 }


### PR DESCRIPTION
Backport to 3.x for the fix in #67939, as discussed in that PR