### PR TITLE
Make Marker3D gizmo resizable

### DIFF
--- a/doc/classes/Marker3D.xml
+++ b/doc/classes/Marker3D.xml
@@ -8,4 +8,9 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<members>
+		<member name="gizmo_extents" type="float" setter="set_gizmo_extents" getter="get_gizmo_extents" default="0.25">
+			Size of the gizmo cross that appears in the editor.
+		</member>
+	</members>
 </class>

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -2296,10 +2296,10 @@ void Label3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 Marker3DGizmoPlugin::Marker3DGizmoPlugin() {
 	pos3d_mesh = Ref<ArrayMesh>(memnew(ArrayMesh));
-	cursor_points = Vector<Vector3>();
 
+	Vector<Vector3> cursor_points;
 	Vector<Color> cursor_colors;
-	const float cs = 0.25;
+	const float cs = 1.0;
 	// Add more points to create a "hard stop" in the color gradient.
 	cursor_points.push_back(Vector3(+cs, 0, 0));
 	cursor_points.push_back(Vector3());
@@ -2367,9 +2367,22 @@ int Marker3DGizmoPlugin::get_priority() const {
 }
 
 void Marker3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
+	const Marker3D *marker = Object::cast_to<Marker3D>(p_gizmo->get_node_3d());
+	const real_t extents = marker->get_gizmo_extents();
+	const Transform3D xform(Basis::from_scale(Vector3(extents, extents, extents)));
+
 	p_gizmo->clear();
-	p_gizmo->add_mesh(pos3d_mesh);
-	p_gizmo->add_collision_segments(cursor_points);
+	p_gizmo->add_mesh(pos3d_mesh, Ref<Material>(), xform);
+
+	const Vector<Vector3> points = {
+		Vector3(-extents, 0, 0),
+		Vector3(+extents, 0, 0),
+		Vector3(0, -extents, 0),
+		Vector3(0, +extents, 0),
+		Vector3(0, 0, -extents),
+		Vector3(0, 0, +extents),
+	};
+	p_gizmo->add_collision_segments(points);
 }
 
 ////

--- a/editor/plugins/node_3d_editor_gizmos.h
+++ b/editor/plugins/node_3d_editor_gizmos.h
@@ -338,7 +338,6 @@ class Marker3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(Marker3DGizmoPlugin, EditorNode3DGizmoPlugin);
 
 	Ref<ArrayMesh> pos3d_mesh;
-	Vector<Vector3> cursor_points;
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;

--- a/scene/3d/marker_3d.cpp
+++ b/scene/3d/marker_3d.cpp
@@ -30,5 +30,24 @@
 
 #include "marker_3d.h"
 
+void Marker3D::set_gizmo_extents(real_t p_extents) {
+	if (Math::is_equal_approx(gizmo_extents, p_extents)) {
+		return;
+	}
+	gizmo_extents = p_extents;
+	update_gizmos();
+}
+
+real_t Marker3D::get_gizmo_extents() const {
+	return gizmo_extents;
+}
+
+void Marker3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_gizmo_extents", "extents"), &Marker3D::set_gizmo_extents);
+	ClassDB::bind_method(D_METHOD("get_gizmo_extents"), &Marker3D::get_gizmo_extents);
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "gizmo_extents", PROPERTY_HINT_RANGE, "0,10,0.01,or_greater,suffix:m"), "set_gizmo_extents", "get_gizmo_extents");
+}
+
 Marker3D::Marker3D() {
 }

--- a/scene/3d/marker_3d.h
+++ b/scene/3d/marker_3d.h
@@ -36,7 +36,15 @@
 class Marker3D : public Node3D {
 	GDCLASS(Marker3D, Node3D);
 
+	real_t gizmo_extents = 0.25;
+
+protected:
+	static void _bind_methods();
+
 public:
+	void set_gizmo_extents(real_t p_extents);
+	real_t get_gizmo_extents() const;
+
 	Marker3D();
 };
 


### PR DESCRIPTION
This PR adds a `gizmo_extents` property to `Marker3D`. It works the same as its `Marker2D` counterpart.