### PR TITLE
Add tooltip to method qualifiers in Documentation Help

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -368,8 +368,29 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 	class_desc->pop();
 	if (!p_method.qualifiers.is_empty()) {
 		class_desc->push_color(qualifier_color);
-		class_desc->add_text(" ");
-		_add_text(p_method.qualifiers);
+
+		PackedStringArray qualifiers = p_method.qualifiers.split_spaces();
+		for (const String &qualifier : qualifiers) {
+			String hint;
+			if (qualifier == "vararg") {
+				hint = TTR("This method supports a variable number of arguments.");
+			} else if (qualifier == "virtual") {
+				hint = TTR("This method is called by the engine.\nIt can be overriden to customise built-in behavior.");
+			} else if (qualifier == "const") {
+				hint = TTR("This method has no side effects.\nIt does not modify the object in any way.");
+			} else if (qualifier == "static") {
+				hint = TTR("This method does not need an instance to be called.\nIt can be called directly using the class name.");
+			}
+
+			class_desc->add_text(" ");
+			if (!hint.is_empty()) {
+				class_desc->push_hint(hint);
+				class_desc->add_text(qualifier);
+				class_desc->pop();
+			} else {
+				class_desc->add_text(qualifier);
+			}
+		}
 		class_desc->pop();
 	}
 


### PR DESCRIPTION
Quoting https://github.com/godotengine/godot-proposals/issues/1285:
> In https://github.com/godotengine/godot/pull/40872, I added tooltips to `virtual`, `const` and `vararg` method qualifiers in the online class reference. I'd like to do the same in the editor documentation. However, there's no way to _specify_ a tooltip for a specific part of the text in a RichTextLabel.

Then hints were implemented in https://github.com/godotengine/godot/pull/58394, but not used for this purpose.

This PR adds the forgotten tooltips to the qualifiers. The tooltips are worded similarly to the online documentation, but are not perfectly identical, and contain newlines to improve readability.
![image](https://user-images.githubusercontent.com/66727710/198987751-64e3c2cd-a2a9-44fb-80a8-bfe9a6d6b235.png)

Also, an amusing note: the previous function to add the qualifiers was `_add_text()`, not `class_desc->add_text()`. The former is used for each individual description and is much, **much** slower. I believe that by replacing this there is a notable performance boost in the text generation.
