### PR TITLE
Avoid GodotSoftBody3D.reoptimize_link_order() crash if <2 nodes available.

### DIFF
--- a/servers/physics_3d/godot_soft_body_3d.cpp
+++ b/servers/physics_3d/godot_soft_body_3d.cpp
@@ -722,7 +722,14 @@ void GodotSoftBody3D::reoptimize_link_order() {
 	const int reop_not_dependent = -1;
 	const int reop_node_complete = -2;
 
-	uint32_t i, link_count = links.size(), node_count = nodes.size();
+	uint32_t link_count = links.size();
+	uint32_t node_count = nodes.size();
+
+	if (link_count < 1 || node_count < 2) {
+		return;
+	}
+
+	uint32_t i;
 	Link *lr;
 	int ar, br;
 	Node *node0 = &(nodes[0]);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #61474
