### PR TITLE
Added a signal connection to update buses editor on "bus_layout_changed"

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1340,6 +1340,8 @@ EditorAudioBuses::EditorAudioBuses() {
 	add_child(file_dialog);
 	file_dialog->connect("file_selected", callable_mp(this, &EditorAudioBuses::_file_dialog_callback));
 
+	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &EditorAudioBuses::_update_buses));
+
 	set_process(true);
 }
 


### PR DESCRIPTION
Hello,
This is my first PR ever so I am nervous and call for patience.

I have an issue #68056 open and discovered that I had even worse problems when deleting a bus while the audio editor tab was running.

Therefore, I changed godot source and added a connection to bus_layout_changed in the bus editor to update each time.
It works like a charm here so I would love to have some peer review about this.

And why not integrate it as my first contribution to the engine? (as soon as any relevant problem has been fixed of course)

Thank you for your work, and help,
atn

<i>Bugsquad edit:</i> Fix #68056