### PR TITLE
GDScript: Rework type and member resolution

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -123,7 +123,7 @@ Vector<String> EditorFileSystemDirectory::get_file_deps(int p_idx) const {
 
 	for (int i = 0; i < files[p_idx]->deps.size(); i++) {
 		String dep = files[p_idx]->deps[i];
-		int sep_idx = dep.find("::"); //may contain type information, unwanted
+		int sep_idx = dep.find(":|:"); //may contain type information, unwanted
 		if (sep_idx != -1) {
 			dep = dep.substr(0, sep_idx);
 		}
@@ -247,15 +247,15 @@ void EditorFileSystem::_scan_filesystem() {
 					continue;
 				}
 
-				if (l.begins_with("::")) {
-					Vector<String> split = l.split("::");
+				if (l.begins_with(":|:")) {
+					Vector<String> split = l.split(":|:");
 					ERR_CONTINUE(split.size() != 3);
 					String name = split[1];
 
 					cpath = name;
 
 				} else {
-					Vector<String> split = l.split("::");
+					Vector<String> split = l.split(":|:");
 					ERR_CONTINUE(split.size() != 9);
 					String name = split[0];
 					String file;
@@ -1267,14 +1267,14 @@ void EditorFileSystem::_save_filesystem_cache(EditorFileSystemDirectory *p_dir, 
 	if (!p_dir) {
 		return; //none
 	}
-	p_file->store_line("::" + p_dir->get_path() + "::" + String::num(p_dir->modified_time));
+	p_file->store_line(":|:" + p_dir->get_path() + ":|:" + String::num(p_dir->modified_time));
 
 	for (int i = 0; i < p_dir->files.size(); i++) {
 		if (!p_dir->files[i]->import_group_file.is_empty()) {
 			group_file_cache.insert(p_dir->files[i]->import_group_file);
 		}
-		String s = p_dir->files[i]->file + "::" + p_dir->files[i]->type + "::" + itos(p_dir->files[i]->uid) + "::" + itos(p_dir->files[i]->modified_time) + "::" + itos(p_dir->files[i]->import_modified_time) + "::" + itos(p_dir->files[i]->import_valid) + "::" + p_dir->files[i]->import_group_file + "::" + p_dir->files[i]->script_class_name + "<>" + p_dir->files[i]->script_class_extends + "<>" + p_dir->files[i]->script_class_icon_path;
-		s += "::";
+		String s = p_dir->files[i]->file + ":|:" + p_dir->files[i]->type + ":|:" + itos(p_dir->files[i]->uid) + ":|:" + itos(p_dir->files[i]->modified_time) + ":|:" + itos(p_dir->files[i]->import_modified_time) + ":|:" + itos(p_dir->files[i]->import_valid) + ":|:" + p_dir->files[i]->import_group_file + ":|:" + p_dir->files[i]->script_class_name + "<>" + p_dir->files[i]->script_class_extends + "<>" + p_dir->files[i]->script_class_icon_path;
+		s += ":|:";
 		for (int j = 0; j < p_dir->files[i]->deps.size(); j++) {
 			if (j > 0) {
 				s += "<>";

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -50,17 +50,16 @@ class GDScriptAnalyzer {
 	Error check_native_member_name_conflict(const StringName &p_member_name, const GDScriptParser::Node *p_member_node, const StringName &p_native_type_string);
 	Error check_class_member_name_conflict(const GDScriptParser::ClassNode *p_class_node, const StringName &p_member_name, const GDScriptParser::Node *p_member_node);
 
-	Error resolve_inheritance(GDScriptParser::ClassNode *p_class, bool p_recursive = true);
+	Error resolve_class_inheritance(GDScriptParser::ClassNode *p_class, bool p_recursive = false);
 	GDScriptParser::DataType resolve_datatype(GDScriptParser::TypeNode *p_type);
+	GDScriptParser::DataType resolve_type_id_from_base(GDScriptParser::IdentifierNode *p_identifier, GDScriptParser::DataType *p_base = nullptr);
 
 	void decide_suite_type(GDScriptParser::Node *p_suite, GDScriptParser::Node *p_statement);
 
-	// This traverses the tree to resolve all TypeNodes.
-	Error resolve_program();
-
 	void resolve_annotation(GDScriptParser::AnnotationNode *p_annotation);
-	void resolve_class_interface(GDScriptParser::ClassNode *p_class);
-	void resolve_class_body(GDScriptParser::ClassNode *p_class);
+	void resolve_class_member(GDScriptParser::ClassNode *p_class, GDScriptParser::ClassNode::Member &p_member);
+	void resolve_class_interface(GDScriptParser::ClassNode *p_class, bool p_recursive = false);
+	void resolve_class_body(GDScriptParser::ClassNode *p_class, bool p_recursive = false);
 	void resolve_function_signature(GDScriptParser::FunctionNode *p_function);
 	void resolve_function_body(GDScriptParser::FunctionNode *p_function);
 	void resolve_node(GDScriptParser::Node *p_node, bool p_is_root = true);
@@ -104,7 +103,7 @@ class GDScriptAnalyzer {
 	GDScriptParser::DataType type_from_variant(const Variant &p_value, const GDScriptParser::Node *p_source);
 	GDScriptParser::DataType type_from_metatype(const GDScriptParser::DataType &p_meta_type) const;
 	GDScriptParser::DataType type_from_property(const PropertyInfo &p_property) const;
-	GDScriptParser::DataType make_global_class_meta_type(const StringName &p_class_name, const GDScriptParser::Node *p_source);
+	GDScriptParser::DataType make_script_class_type(const String &p_path, const GDScriptParser::Node *p_source, bool p_meta = false);
 	bool get_function_signature(GDScriptParser::Node *p_source, bool p_is_constructor, GDScriptParser::DataType base_type, const StringName &p_function, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, bool &r_static, bool &r_vararg);
 	bool function_signature_from_info(const MethodInfo &p_info, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, bool &r_static, bool &r_vararg);
 	bool validate_call_arg(const List<GDScriptParser::DataType> &p_par_types, int p_default_args_count, bool p_is_vararg, const GDScriptParser::CallNode *p_call);
@@ -117,7 +116,7 @@ class GDScriptAnalyzer {
 	void mark_node_unsafe(const GDScriptParser::Node *p_node);
 	void mark_lambda_use_self();
 	bool class_exists(const StringName &p_class) const;
-	Ref<GDScriptParserRef> get_parser_for(const String &p_path);
+	Ref<GDScriptParserRef> get_parser_for(const String &p_path, GDScriptParserRef::Status p_status, Error &r_error);
 #ifdef DEBUG_ENABLED
 	bool is_shadowing(GDScriptParser::IdentifierNode *p_local, const String &p_context);
 #endif

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2862,7 +2862,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 
 			for (int i = 0; i < completion_context.current_argument; i++) {
 				GDScriptCompletionIdentifier ci;
-				if (!_guess_identifier_type_from_base(completion_context, base, type->type_chain[i]->name, ci)) {
+				if (!_guess_identifier_type_from_base(completion_context, base, type->subtypes[i]->name, ci)) {
 					found = false;
 					break;
 				}
@@ -3287,17 +3287,6 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 	analyzer.analyze();
 
 	GDScriptParser::CompletionContext context = parser.get_completion_context();
-
-	if (context.current_class && context.current_class->extends.size() > 0) {
-		bool success = false;
-		ClassDB::get_integer_constant(context.current_class->extends[0], p_symbol, &success);
-		if (success) {
-			r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
-			r_result.class_name = context.current_class->extends[0];
-			r_result.class_member = p_symbol;
-			return OK;
-		}
-	}
 
 	bool is_function = false;
 

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -463,7 +463,7 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 	// Create script.
 	Ref<GDScript> script;
 	script.instantiate();
-	script->set_path(source_file);
+	script->set_path(source_file, true);
 	err = script->load_source_code(source_file);
 	if (err != OK) {
 		enable_stdout();

--- a/modules/gdscript/tests/scripts/analyzer/errors/class_name_shadows_builtin_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/class_name_shadows_builtin_type.out
@@ -1,2 +1,2 @@
 GDTEST_ANALYZER_ERROR
-The member "Vector2" cannot have the same name as a builtin type.
+Class "Vector2" hides a built-in type.


### PR DESCRIPTION
allows true out of order member resolution
`resolve_datatype()` uses `reduce_identifier_from_base()` to reduce duplicated code and improve errors.
parser uses `TypeNode` when parsing extends, to reduce duplicated code and improve errors.
changed filesystem cache separator, because it clashes with GDScript inner class separators "::" > ":|:" (maybe it should be changed to json or something)