### PR TITLE
Shortcut and Bind to Remove Secondary Carets

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -342,6 +342,7 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
     { "ui_text_select_all",                            TTRC("Select All") },
     { "ui_text_select_word_under_caret",               TTRC("Select Word Under Caret") },
     { "ui_text_add_selection_for_next_occurrence",     TTRC("Add Selection for Next Occurrence") },
+    { "ui_text_remove_secondary_carets",               TTRC("Remove Secondary Carets") },
     { "ui_text_toggle_insert_mode",                    TTRC("Toggle Insert Mode") },
     { "ui_text_submit",                                TTRC("Text Submitted") },
     { "ui_graph_duplicate",                            TTRC("Duplicate Nodes") },
@@ -670,6 +671,10 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::D | KeyModifierMask::CMD_OR_CTRL));
 	default_builtin_cache.insert("ui_text_add_selection_for_next_occurrence", inputs);
+
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::ESCAPE));
+	default_builtin_cache.insert("ui_text_remove_secondary_carets", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::INSERT));

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -984,6 +984,10 @@
 			Default [InputEventAction] to insert a new line after the current one.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
+		<member name="input/ui_text_remove_secondary_carets" type="Dictionary" setter="" getter="">
+			If multiple carets are currently active, clear additional carets and keep just one caret.
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
 		<member name="input/ui_text_scroll_down" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to scroll down one line of text.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2067,6 +2067,11 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				accept_event();
 				return;
 			}
+			if (k->is_action("ui_text_remove_secondary_carets", true) && _should_remove_secondary_carets()) {
+				remove_secondary_carets();
+				accept_event();
+				return;
+			}
 			if (k->is_action("ui_cut", true)) {
 				cut();
 				accept_event();
@@ -2817,6 +2822,10 @@ void TextEdit::_move_caret_document_end(bool p_select) {
 	if (p_select) {
 		_post_shift_selection(0);
 	}
+}
+
+bool TextEdit::_should_remove_secondary_carets() {
+	return carets.size() > 1;
 }
 
 void TextEdit::_get_above_below_caret_line_column(int p_old_line, int p_old_wrap_index, int p_old_column, bool p_below, int &p_new_line, int &p_new_column, int p_last_fit_x) const {

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -597,6 +597,7 @@ private:
 	void _delete(bool p_word = false, bool p_all_to_right = false);
 	void _move_caret_document_start(bool p_select);
 	void _move_caret_document_end(bool p_select);
+	bool _should_remove_secondary_carets();
 
 	// Used in add_caret_at_carets
 	void _get_above_below_caret_line_column(int p_old_line, int p_old_wrap_index, int p_old_column, bool p_below, int &p_new_line, int &p_new_column, int p_last_fit_x = -1) const;


### PR DESCRIPTION
Adds the bind `ui_text_remove_secondary_carets` to TextEdit, with `ESC` as the default shortcut.

When the bind is performed, if the TextEdit has multiple carets, `remove_secondary_carets` is called and secondary carets are removed.

This is useful when multiple selects are performed with `add_selection_for_next_occurrence` #67644 or when multiple multiple carets are manually added, then it's possible to go back to a single caret with a shortcut.

Implements and Closes #67991.

https://user-images.githubusercontent.com/248383/199062074-4f999c25-b72c-4853-819b-00c6b8f38ec1.mp4

From the scenarios I tested, I couldn't see any conflicts for `ESC`, as the bind is only consumed IF there are more than one carets inside the TextEdit.

![image](https://user-images.githubusercontent.com/248383/199061559-3f51866b-4e9d-4b7c-aca1-e9a155e932d0.png)


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
