### PR TITLE
Load and use system emoji font in the editor.

### DIFF
--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -57,6 +57,24 @@ Ref<FontFile> load_external_font(const String &p_path, TextServer::Hinting p_hin
 	return font;
 }
 
+Ref<SystemFont> load_system_font(const PackedStringArray &p_names, TextServer::Hinting p_hinting, TextServer::FontAntialiasing p_aa, bool p_autohint, TextServer::SubpixelPositioning p_font_subpixel_positioning, bool p_msdf = false, TypedArray<Font> *r_fallbacks = nullptr) {
+	Ref<SystemFont> font;
+	font.instantiate();
+
+	font->set_font_names(p_names);
+	font->set_multichannel_signed_distance_field(p_msdf);
+	font->set_antialiasing(p_aa);
+	font->set_hinting(p_hinting);
+	font->set_force_autohinter(p_autohint);
+	font->set_subpixel_positioning(p_font_subpixel_positioning);
+
+	if (r_fallbacks != nullptr) {
+		r_fallbacks->push_back(font);
+	}
+
+	return font;
+}
+
 Ref<FontFile> load_internal_font(const uint8_t *p_data, size_t p_size, TextServer::Hinting p_hinting, TextServer::FontAntialiasing p_aa, bool p_autohint, TextServer::SubpixelPositioning p_font_subpixel_positioning, bool p_msdf = false, TypedArray<Font> *r_fallbacks = nullptr) {
 	Ref<FontFile> font;
 	font.instantiate();
@@ -166,6 +184,20 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	Ref<FontFile> thai_font_bold = load_internal_font(_font_NotoSansThaiUI_Bold, _font_NotoSansThaiUI_Bold_size, font_hinting, font_antialiasing, true, font_subpixel_positioning, false, &fallbacks_bold);
 	Ref<FontVariation> fallback_font_bold = make_bold_font(fallback_font, embolden_strength, &fallbacks_bold);
 	Ref<FontVariation> japanese_font_bold = make_bold_font(japanese_font, embolden_strength, &fallbacks_bold);
+
+	if (OS::get_singleton()->has_feature("system_fonts")) {
+		PackedStringArray emoji_font_names;
+		emoji_font_names.push_back("Apple Color Emoji");
+		emoji_font_names.push_back("Segoe UI Emoji");
+		emoji_font_names.push_back("Noto Color Emoji");
+		emoji_font_names.push_back("Twitter Color Emoji");
+		emoji_font_names.push_back("OpenMoji");
+		emoji_font_names.push_back("EmojiOne Color");
+		Ref<SystemFont> emoji_font = load_system_font(emoji_font_names, font_hinting, font_antialiasing, true, font_subpixel_positioning, false);
+		fallbacks.push_back(emoji_font);
+		fallbacks_bold.push_back(emoji_font);
+	}
+
 	default_font_bold->set_fallbacks(fallbacks_bold);
 	default_font_bold_msdf->set_fallbacks(fallbacks_bold);
 

--- a/platform/ios/os_ios.mm
+++ b/platform/ios/os_ios.mm
@@ -396,7 +396,14 @@ void OS_IOS::vibrate_handheld(int p_duration_ms) {
 }
 
 bool OS_IOS::_check_internal_feature_support(const String &p_feature) {
-	return p_feature == "mobile";
+	if (p_feature == "system_fonts") {
+		return true;
+	}
+	if (p_feature == "mobile") {
+		return true;
+	}
+
+	return false;
 }
 
 void OS_IOS::on_focus_out() {

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -481,7 +481,16 @@ Error OS_LinuxBSD::shell_open(String p_uri) {
 }
 
 bool OS_LinuxBSD::_check_internal_feature_support(const String &p_feature) {
-	return p_feature == "pc";
+#ifdef FONTCONFIG_ENABLED
+	if (p_feature == "system_fonts") {
+		return font_config_initialized;
+	}
+#endif
+	if (p_feature == "pc") {
+		return true;
+	}
+
+	return false;
 }
 
 uint64_t OS_LinuxBSD::get_embedded_pck_offset() const {

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -499,7 +499,14 @@ String OS_MacOS::get_unique_id() const {
 }
 
 bool OS_MacOS::_check_internal_feature_support(const String &p_feature) {
-	return p_feature == "pc";
+	if (p_feature == "system_fonts") {
+		return true;
+	}
+	if (p_feature == "pc") {
+		return true;
+	}
+
+	return false;
 }
 
 void OS_MacOS::disable_crash_handler() {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1181,7 +1181,14 @@ String OS_Windows::get_unique_id() const {
 }
 
 bool OS_Windows::_check_internal_feature_support(const String &p_feature) {
-	return p_feature == "pc";
+	if (p_feature == "system_fonts") {
+		return true;
+	}
+	if (p_feature == "pc") {
+		return true;
+	}
+
+	return false;
 }
 
 void OS_Windows::disable_crash_handler() {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/68026

macOS 13.0:
<img width="696" alt="Screenshot 2022-10-31 at 19 13 32" src="https://user-images.githubusercontent.com/7645683/199068182-123d349f-af9f-4121-9618-be28bebe5653.png">

Windows 11 22H2:

<img width="696" alt="Screenshot 2022-10-31 203537" src="https://user-images.githubusercontent.com/7645683/199083956-ba567454-61ae-4fab-8597-19678c35d390.png">

Pop!_OS 22.04 LTS:
<img width="696" alt="Screenshot from 2022-11-01 10-44-46" src="https://user-images.githubusercontent.com/7645683/199196829-f1070f78-3914-449d-bcf8-3caa8cbe6127.png">

Note: depending on font versions, some listed fonts require https://github.com/godotengine/godot/pull/64530 to work.