### PR TITLE
C#: Add implicit conversion from arrays to Variant

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Variant.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Variant.cs
@@ -766,6 +766,58 @@ public partial struct Variant : IDisposable
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromSignalInfo(from));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Variant(byte[] from) =>
+        (Variant)from.AsSpan();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Variant(int[] from) =>
+        (Variant)from.AsSpan();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Variant(long[] from) =>
+        (Variant)from.AsSpan();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Variant(float[] from) =>
+        (Variant)from.AsSpan();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Variant(double[] from) =>
+        (Variant)from.AsSpan();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Variant(string[] from) =>
+        (Variant)from.AsSpan();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Variant(Vector2[] from) =>
+        (Variant)from.AsSpan();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Variant(Vector3[] from) =>
+        (Variant)from.AsSpan();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Variant(Color[] from) =>
+        (Variant)from.AsSpan();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Variant(Godot.Object[] from) =>
+        CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromSystemArrayOfGodotObject(from));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Variant(StringName[] from) =>
+        (Variant)from.AsSpan();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Variant(NodePath[] from) =>
+        (Variant)from.AsSpan();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Variant(RID[] from) =>
+        (Variant)from.AsSpan();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Span<byte> from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromPackedByteArray(from));
 
@@ -800,10 +852,6 @@ public partial struct Variant : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Span<Color> from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromPackedColorArray(from));
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator Variant(Godot.Object[] from) =>
-        CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromSystemArrayOfGodotObject(from));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Span<StringName> from) =>


### PR DESCRIPTION
This is needed for arrays to be implicitly converted to Variant. Arrays can be implicitly converted to Span and Span can be implicitly converted to Variant, but since arrays didn't have an implicit conversion to Variant directly the conversion between array and Variant can't be done implicitly.

```csharp
void MyMethod(Variant v)
{
	// Do something with v.
}

int[] numbers = { 1, 2, 3 };

// This works because Variant.CreateFrom takes Span<int> and int[] can be implicitly converted to it.
MyMethod(Variant.CreateFrom(numbers));

// This works because int[].AsSpan returns Span<int> and it can be implicitly converted to Variant.
MyMethod(numbers.AsSpan());

// This didn't work before this PR but now it does.
MyMethod(numbers);
```