### PR TITLE
Add `set_value_no_signal()` to Range

### DIFF
--- a/doc/classes/Range.xml
+++ b/doc/classes/Range.xml
@@ -16,6 +16,13 @@
 				Called when the [Range]'s value is changed (following the same conditions as [signal value_changed]).
 			</description>
 		</method>
+		<method name="set_value_no_signal">
+			<return type="void" />
+			<param index="0" name="value" type="float" />
+			<description>
+				Sets the [Range]'s current value to the specified [param value], without emitting the [signal value_changed] signal.
+			</description>
+		</method>
 		<method name="share">
 			<return type="void" />
 			<param index="0" name="with" type="Node" />
@@ -59,7 +66,7 @@
 			If greater than 0, [code]value[/code] will always be rounded to a multiple of [code]step[/code]. If [code]rounded[/code] is also [code]true[/code], [code]value[/code] will first be rounded to a multiple of [code]step[/code] then rounded to the nearest integer.
 		</member>
 		<member name="value" type="float" setter="set_value" getter="get_value">
-			Range's current value.
+			Range's current value. Changing this property (even via code) will trigger [signal value_changed] signal. Use [method set_value_no_signal] if you want to avoid it.
 		</member>
 	</members>
 	<signals>

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -218,13 +218,12 @@ bool BaseButton::is_disabled() const {
 }
 
 void BaseButton::set_pressed(bool p_pressed) {
-	if (!toggle_mode) {
+	bool prev_pressed = status.pressed;
+	set_pressed_no_signal(p_pressed);
+
+	if (status.pressed == prev_pressed) {
 		return;
 	}
-	if (status.pressed == p_pressed) {
-		return;
-	}
-	status.pressed = p_pressed;
 
 	if (p_pressed) {
 		_unpress_group();
@@ -233,8 +232,6 @@ void BaseButton::set_pressed(bool p_pressed) {
 		}
 	}
 	_toggled(status.pressed);
-
-	queue_redraw();
 }
 
 void BaseButton::set_pressed_no_signal(bool p_pressed) {

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -80,6 +80,15 @@ void Range::Shared::emit_changed(const char *p_what) {
 }
 
 void Range::set_value(double p_val) {
+	double prev_val = shared->val;
+	set_value_no_signal(p_val);
+
+	if (shared->val != prev_val) {
+		shared->emit_value_changed();
+	}
+}
+
+void Range::set_value_no_signal(double p_val) {
 	if (shared->step > 0) {
 		p_val = Math::round(p_val / shared->step) * shared->step;
 	}
@@ -101,8 +110,6 @@ void Range::set_value(double p_val) {
 	}
 
 	shared->val = p_val;
-
-	shared->emit_value_changed();
 }
 
 void Range::set_min(double p_min) {
@@ -267,6 +274,7 @@ void Range::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_page"), &Range::get_page);
 	ClassDB::bind_method(D_METHOD("get_as_ratio"), &Range::get_as_ratio);
 	ClassDB::bind_method(D_METHOD("set_value", "value"), &Range::set_value);
+	ClassDB::bind_method(D_METHOD("set_value_no_signal", "value"), &Range::set_value_no_signal);
 	ClassDB::bind_method(D_METHOD("set_min", "minimum"), &Range::set_min);
 	ClassDB::bind_method(D_METHOD("set_max", "maximum"), &Range::set_max);
 	ClassDB::bind_method(D_METHOD("set_step", "step"), &Range::set_step);

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -72,6 +72,7 @@ protected:
 
 public:
 	void set_value(double p_val);
+	void set_value_no_signal(double p_val);
 	void set_min(double p_min);
 	void set_max(double p_max);
 	void set_step(double p_step);


### PR DESCRIPTION
This is similar to `set_pressed_no_signal()` in BaseButton. I also removed some duplicated code.
Resolves #37876

Alternatively we could make the signal not emitted in `set_value()`, but that's a very breaking change (and should also be done in BaseButton for consistency).

I think we have a few places where the new method could be useful.