### PR TITLE
Fix several render issues found while debugging XR

### DIFF
--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -273,6 +273,7 @@ protected:
 
 public:
 	// Extension calls.
+	bool supports_renderpass2() const { return has_renderpass2_ext; }
 	VkResult vkCreateRenderPass2KHR(VkDevice p_device, const VkRenderPassCreateInfo2 *p_create_info, const VkAllocationCallbacks *p_allocator, VkRenderPass *p_render_pass);
 
 	uint32_t get_vulkan_major() const { return vulkan_major; };

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -691,7 +691,7 @@ bool OpenXRAPI::create_swapchains() {
 			print_verbose(String("Using color swap chain format:") + get_swapchain_format_name(swapchain_format_to_use));
 		}
 
-		if (!create_swapchain(XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT, swapchain_format_to_use, recommended_size.width, recommended_size.height, view_configuration_views[0].recommendedSwapchainSampleCount, view_count, swapchains[OPENXR_SWAPCHAIN_COLOR].swapchain, &swapchains[OPENXR_SWAPCHAIN_COLOR].swapchain_graphics_data)) {
+		if (!create_swapchain(XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_MUTABLE_FORMAT_BIT, swapchain_format_to_use, recommended_size.width, recommended_size.height, view_configuration_views[0].recommendedSwapchainSampleCount, view_count, swapchains[OPENXR_SWAPCHAIN_COLOR].swapchain, &swapchains[OPENXR_SWAPCHAIN_COLOR].swapchain_graphics_data)) {
 			return false;
 		}
 	}


### PR DESCRIPTION
This PR fixes various issues reported by `--gpu-validation` found by @rsjtdrjgfuzkfg

> [ VUID-VkImageSubresourceRange-levelCount-01720 ] | vkCreateImageView: pCreateInfo->subresourceRange.levelCount is 0. The Vulkan spec states: If levelCount is not VK_REMAINING_MIP_LEVELS, it must be greater than 0 (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkImageSubresourceRange-levelCount-01720)

External textures were setting mipmap levels to 0, not 1. 

> [ VUID-VkImageViewCreateInfo-image-01762 ] | vkCreateImageView() format VK_FORMAT_R8G8B8A8_UNORM differs from VkImage [...] format VK_FORMAT_R8G8B8A8_SRGB. Formats MUST be IDENTICAL unless VK_IMAGE_CREATE_MUTABLE_FORMAT BIT was set on image creation. The Vulkan spec states: If image was not created with the VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT flag, or if the format of the image is a multi-planar format and if subresourceRange.aspectMask is VK_IMAGE_ASPECT_COLOR_BIT, format must be identical to the format used to create image (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkImageViewCreateInfo-image-01762)

When multiple formats are used, `VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT` must be set, we do this for normal swap chains but in OpenXR this requires adding `XR_SWAPCHAIN_USAGE_MUTABLE_FORMAT_BIT` when we create the swap chain

> [ VUID-VkImageMemoryBarrier-newLayout-parameter ] | vkCmdPipelineBarrier: value of pImageMemoryBarriers[0].newLayout ([...]) does not fall within the begin..end range of the core VkImageLayout enumeration tokens and is not an extension added token. The Vulkan spec states: newLayout must be a valid VkImageLayout value (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkImageMemoryBarrier-newLayout-parameter)

Our external texture logic was not setting the image layout value at all.

> [ VUID-VkRenderPassCreateInfo2-pNext-pNext ] | vkCreateRenderPass2KHR: pCreateInfo->pNext chain includes a structure with unexpected VkStructureType VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO; Allowed structures are [VkRenderPassCreationControlEXT, VkRenderPassCreationFeedbackCreateInfoEXT, VkRenderPassFragmentDensityMapCreateInfoEXT]. This error is based on the Valid Usage documentation for version 224 of the Vulkan header. It is possible that you are using a struct from a private extension or an extension that was added to a later version of the Vulkan header, in which case the use of pCreateInfo->pNext is undefined and may not work correctly with validation enabled The Vulkan spec states: Each pNext member of any structure (including this one) in the pNext chain must be either [message is cut here]

When we originally implemented multiview we did so for `vkCreateRenderPass` which requires inclusion of this struct.
Now that we use `vkCreateRenderPass2KHR` the information is already provided and the additional multiview struct is no longer needed.
This took a bit of trickery because we implemented a fallback solution to have `vkCreateRenderPass2KHR` fall back to `vkCreateRenderPass`. I'm not including this struct only if we expect to fallback on `vkCreateRenderPass`.

> [ VUID-VkRenderPassCreateInfo2-attachment-02525 ] | vkCreateRenderPass2KHR(): Using format (VK_FORMAT_A2B10G10R10_UNORM_PACK32) with aspect flags (VK_IMAGE_ASPECT_NONE) but color image formats must have the VK_IMAGE_ASPECT_COLOR_BIT set. The Vulkan spec states: If the attachment member of any element of the pInputAttachments member of any element of pSubpasses is not VK_ATTACHMENT_UNUSED, the aspectMask member of that element of pInputAttachments must only include aspects that are present in images of the format specified by the element of pAttachments specified by attachment (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkRenderPassCreateInfo2-attachment-02525)

Since switching to `vkCreateRenderPass2KHR` we now also need to supply the `aspectMask`, this was not implemented properly. I'm very surprised this was not reported earlier as it would also effect desktop rendering. My best guess is that many Vulkan drivers ignore this mask in `vkCreateRenderPass2KHR`. 
Anyway, this should set them properly.

> [ VUID-VkSubpassDescription2-attachment-02800 ] | vkCreateRenderPass2KHR(): Input attachment pSubpasses[3].pInputAttachments[0] aspect mask must not be 0. The Vulkan spec states: If the attachment member of any element of pInputAttachments is not VK_ATTACHMENT_UNUSED, then the aspectMask member must not be 0 (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkSubpassDescription2-attachment-02800)

I suspect this is fixed by the above fix, but I may still have overlooked something. Since I'm not getting these validation errors I can't verify.