### PR TITLE
Toggles the `focus_mode` of the `BaseButton` when toggling its `disable` property

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -209,6 +209,9 @@ void BaseButton::set_disabled(bool p_disabled) {
 		}
 		status.press_attempt = false;
 		status.pressing_inside = false;
+		set_focus_mode(FOCUS_NONE);
+	} else {
+		set_focus_mode(FOCUS_ALL);
 	}
 	queue_redraw();
 }


### PR DESCRIPTION
Fix #68067.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
