### PR TITLE
[TextServer] Fix hex code box positions in vertical text layout.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -5072,6 +5072,8 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_star
 					p_sd->ascent = MAX(p_sd->ascent, get_hex_code_box_size(fs, gl.index).y);
 				} else {
 					gl.advance = get_hex_code_box_size(fs, gl.index).y;
+					gl.y_off = get_hex_code_box_size(fs, gl.index).y;
+					gl.x_off = -Math::round(get_hex_code_box_size(fs, gl.index).x * 0.5);
 					p_sd->ascent = MAX(p_sd->ascent, Math::round(get_hex_code_box_size(fs, gl.index).x * 0.5));
 					p_sd->descent = MAX(p_sd->descent, Math::round(get_hex_code_box_size(fs, gl.index).x * 0.5));
 				}


### PR DESCRIPTION
Fixes invalid character replacement box position in the vertical text.

| Before | After |
|--|--|
| <img width="52" alt="Screenshot 2022-11-01 at 11 52 02" src="https://user-images.githubusercontent.com/7645683/199207287-7637b6e1-e736-42c8-8e40-97dffdc1e8b7.png"> | <img width="52" alt="Screenshot 2022-11-01 at 11 49 55" src="https://user-images.githubusercontent.com/7645683/199207281-0339ebb9-09bf-476d-84e7-771d85147f61.png"> |

