### PR TITLE
Fix Image::bump_map_to_normal_map incorrectly keeping mipmap flag

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3524,6 +3524,7 @@ Ref<Image> Image::get_image_from_mipmap(int p_mipamp) const {
 
 void Image::bump_map_to_normal_map(float bump_scale) {
 	ERR_FAIL_COND(!_can_modify(format));
+	clear_mipmaps();
 	convert(Image::FORMAT_RF);
 
 	Vector<uint8_t> result_image; //rgba output


### PR DESCRIPTION
Fixes #68061

Image::bump_map_to_normal_map replaces the image data with a new non-mipmapped image, but doesn't clear the mipmap flag. This causes later code to assume the size is larger than allocated and read out of bounds.

To fix, either always clear mipmaps, or regenerate mipmaps at the end if needed.

Compatible with 3.x