### PR TITLE
[GDScript] Fix type mismatch in optimized single arg `range`

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1377,7 +1377,7 @@ void GDScriptAnalyzer::resolve_for(GDScriptParser::ForNode *p_for) {
 					if (all_is_constant) {
 						switch (args.size()) {
 							case 1:
-								reduced = args[0];
+								reduced = (int32_t)args[0];
 								break;
 							case 2:
 								reduced = Vector2i(args[0], args[1]);

--- a/modules/gdscript/tests/scripts/runtime/features/range_optimized_in_for_has_int_iterator.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/range_optimized_in_for_has_int_iterator.gd
@@ -1,0 +1,60 @@
+func test():
+	# All combinations of 1/2/3 arguments, each being int/float.
+
+	for number in range(5):
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	for number in range(5.2):
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+
+	for number in range(1, 5):
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	for number in range(1, 5.2):
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	for number in range(1.2, 5):
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	for number in range(1.2, 5.2):
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+
+	for number in range(1, 5, 2):
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	for number in range(1, 5, 2.2):
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	for number in range(1, 5.2, 2):
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	for number in range(1, 5.2, 2.2):
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	for number in range(1.2, 5, 2):
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	for number in range(1.2, 5.2, 2):
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	for number in range(1.2, 5, 2.2):
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	for number in range(1.2, 5.2, 2.2):
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")

--- a/modules/gdscript/tests/scripts/runtime/features/range_optimized_in_for_has_int_iterator.out
+++ b/modules/gdscript/tests/scripts/runtime/features/range_optimized_in_for_has_int_iterator.out
@@ -1,0 +1,1 @@
+GDTEST_OK

--- a/modules/gdscript/tests/scripts/runtime/features/range_returns_ints.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/range_returns_ints.gd
@@ -1,0 +1,77 @@
+func test():
+	# All combinations of 1/2/3 arguments, each being int/float.
+	# Store result in variable to ensure actual array is created (avoid `for` + `range` optimization).
+
+	var result
+
+	result = range(5)
+	for number in result:
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	result = range(5.2)
+	for number in result:
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+
+	result = range(1, 5)
+	for number in result:
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	result = range(1, 5.2)
+	for number in result:
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	result = range(1.2, 5)
+	for number in result:
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	result = range(1.2, 5.2)
+	for number in result:
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+
+	result = range(1, 5, 2)
+	for number in result:
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	result = range(1, 5, 2.2)
+	for number in result:
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	result = range(1, 5.2, 2)
+	for number in result:
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	result = range(1, 5.2, 2.2)
+	for number in result:
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	result = range(1.2, 5, 2)
+	for number in result:
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	result = range(1.2, 5.2, 2)
+	for number in result:
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	result = range(1.2, 5, 2.2)
+	for number in result:
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")
+
+	result = range(1.2, 5.2, 2.2)
+	for number in result:
+		if typeof(number) != TYPE_INT:
+			print("Number returned from `range` was not an int!")

--- a/modules/gdscript/tests/scripts/runtime/features/range_returns_ints.out
+++ b/modules/gdscript/tests/scripts/runtime/features/range_returns_ints.out
@@ -1,0 +1,1 @@
+GDTEST_OK


### PR DESCRIPTION
Fixes #68093.

When `range` is used in a `for` loop and when all of its 1/2/3 arguments are constants (`int` or `float` each) then it's being optimized to generate a loop directly without generating an actual array. In such case `list->reduced_value` of the relevant `GDScriptParser::ForNode` should be set to `int`/`Vector2i`/`Vector3i` according to the argument count. The problem was in case of a single argument the argument was not casted to `int`, meaning in case the original argument was a `float` the `reduced_value` would end up being a `float` as well.

This PR solves it by adding the missing cast. I'm casting to `int32_t` to make it consistent with 2/3 arguments cases as `Vector2i`/`Vector3i` used in there are capable of storing only 32-bit signed integers. Making the `range` work properly with 64-bit integers (including the optimized `for` case) is for another PR (I've already done it partially in #67025, without the optimized `for` part).

Note that if `range` is optimized then `for`'s variable is already annotated to be an `int` (including the bugged single argument case):
https://github.com/godotengine/godot/blob/e6751549cf7247965d1744b8c464f5e901006f21/modules/gdscript/gdscript_analyzer.cpp#L1408-L1412
so when the actual assigment during looping is happening the conversion should happen even from a `float`. Meaning the inconsistency fixed in this PR was not the solely reason of the bug in #68093. But the no-conversion bug is likely to be the cause of e.g. #62650 which might be fixed by #62674/#62688 so it's not like it will be left unfixed.