### PR TITLE
Remove `zf != NULL` check from `ZIPPacker::start_file`

### DIFF
--- a/modules/zip/zip_packer.cpp
+++ b/modules/zip/zip_packer.cpp
@@ -50,7 +50,6 @@ Error ZIPPacker::close() {
 }
 
 Error ZIPPacker::start_file(String p_path) {
-	ERR_FAIL_COND_V_MSG(zf != NULL, FAILED, "ZIPPacker is already in use.");
 	ERR_FAIL_COND_V_MSG(fa.is_null(), FAILED, "ZIPPacker must be opened before use.");
 
 	zip_fileinfo zipfi;


### PR DESCRIPTION
This check was removed because it introduces a bug which prevents ZIPPacker from actually adding any files, since it must be opened before adding any files (and therefore shouldn't be NULL at the start of `start_file`).

Fixes #68130 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
