### PR TITLE
Fix mouseleave event after drag and drop in different windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2449,6 +2449,10 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				window_mouseover_id = INVALID_WINDOW_ID;
 
 				_send_window_event(windows[window_id], WINDOW_EVENT_MOUSE_EXIT);
+			} else if (window_mouseover_id != INVALID_WINDOW_ID) {
+				// This is reached during drag and drop, after dropping in a different window.
+				// Once-off notification, must call again.
+				track_mouse_leave_event(windows[window_mouseover_id].hWnd);
 			}
 
 		} break;


### PR DESCRIPTION
When dropping in a different window, it is necessary to start tracking the `WM_MOUSELEAVE` event again.

Regression from #67903.

This fixes the bug, that after drag and drop, mouse-leave-events were no longer sent for the window, that was dropped in.

This bug would show in the following way on the windows-platform:
1. Drag from one window
2. Drop in a different window
3. Move mouse cursor on the window-border of the dropped window so that the mouse-cursor changes to "resize"
4. Move the mouse cursor back into the window
After the last step, the mouse cursor is still "resize"