### PR TITLE
Add `ShapeCast2D/3D::get_collider_rid` method

### DIFF
--- a/doc/classes/ShapeCast2D.xml
+++ b/doc/classes/ShapeCast2D.xml
@@ -58,6 +58,13 @@
 				Returns the collided [Object] of one of the multiple collisions at [param index], or [code]null[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
 			</description>
 		</method>
+		<method name="get_collider_rid" qualifiers="const">
+			<return type="RID" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns the [RID] of the collided object of one of the multiple collisions at [param index].
+			</description>
+		</method>
 		<method name="get_collider_shape" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="index" type="int" />

--- a/doc/classes/ShapeCast3D.xml
+++ b/doc/classes/ShapeCast3D.xml
@@ -58,6 +58,13 @@
 				Returns the collided [Object] of one of the multiple collisions at [param index], or [code]null[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
 			</description>
 		</method>
+		<method name="get_collider_rid" qualifiers="const">
+			<return type="RID" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns the [RID] of the collided object of one of the multiple collisions at [param index].
+			</description>
+		</method>
 		<method name="get_collider_shape" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="index" type="int" />

--- a/scene/2d/shape_cast_2d.cpp
+++ b/scene/2d/shape_cast_2d.cpp
@@ -107,6 +107,11 @@ Object *ShapeCast2D::get_collider(int p_idx) const {
 	return ObjectDB::get_instance(result[p_idx].collider_id);
 }
 
+RID ShapeCast2D::get_collider_rid(int p_idx) const {
+	ERR_FAIL_INDEX_V_MSG(p_idx, result.size(), RID(), "No collider RID found.");
+	return result[p_idx].rid;
+}
+
 int ShapeCast2D::get_collider_shape(int p_idx) const {
 	ERR_FAIL_INDEX_V_MSG(p_idx, result.size(), -1, "No collider shape found.");
 	return result[p_idx].shape;
@@ -422,6 +427,7 @@ void ShapeCast2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("force_shapecast_update"), &ShapeCast2D::force_shapecast_update);
 
 	ClassDB::bind_method(D_METHOD("get_collider", "index"), &ShapeCast2D::get_collider);
+	ClassDB::bind_method(D_METHOD("get_collider_rid", "index"), &ShapeCast2D::get_collider_rid);
 	ClassDB::bind_method(D_METHOD("get_collider_shape", "index"), &ShapeCast2D::get_collider_shape);
 	ClassDB::bind_method(D_METHOD("get_collision_point", "index"), &ShapeCast2D::get_collision_point);
 	ClassDB::bind_method(D_METHOD("get_collision_normal", "index"), &ShapeCast2D::get_collision_normal);

--- a/scene/2d/shape_cast_2d.h
+++ b/scene/2d/shape_cast_2d.h
@@ -104,6 +104,7 @@ public:
 
 	int get_collision_count() const;
 	Object *get_collider(int p_idx) const;
+	RID get_collider_rid(int p_idx) const;
 	int get_collider_shape(int p_idx) const;
 	Vector2 get_collision_point(int p_idx) const;
 	Vector2 get_collision_normal(int p_idx) const;

--- a/scene/3d/shape_cast_3d.cpp
+++ b/scene/3d/shape_cast_3d.cpp
@@ -115,6 +115,7 @@ void ShapeCast3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("force_shapecast_update"), &ShapeCast3D::force_shapecast_update);
 
 	ClassDB::bind_method(D_METHOD("get_collider", "index"), &ShapeCast3D::get_collider);
+	ClassDB::bind_method(D_METHOD("get_collider_rid", "index"), &ShapeCast3D::get_collider_rid);
 	ClassDB::bind_method(D_METHOD("get_collider_shape", "index"), &ShapeCast3D::get_collider_shape);
 	ClassDB::bind_method(D_METHOD("get_collision_point", "index"), &ShapeCast3D::get_collision_point);
 	ClassDB::bind_method(D_METHOD("get_collision_normal", "index"), &ShapeCast3D::get_collision_normal);
@@ -280,6 +281,11 @@ Object *ShapeCast3D::get_collider(int p_idx) const {
 		return nullptr;
 	}
 	return ObjectDB::get_instance(result[p_idx].collider_id);
+}
+
+RID ShapeCast3D::get_collider_rid(int p_idx) const {
+	ERR_FAIL_INDEX_V_MSG(p_idx, result.size(), RID(), "No collider RID found.");
+	return result[p_idx].rid;
 }
 
 int ShapeCast3D::get_collider_shape(int p_idx) const {

--- a/scene/3d/shape_cast_3d.h
+++ b/scene/3d/shape_cast_3d.h
@@ -120,6 +120,7 @@ public:
 
 	int get_collision_count() const;
 	Object *get_collider(int p_idx) const;
+	RID get_collider_rid(int p_idx) const;
 	int get_collider_shape(int p_idx) const;
 	Vector3 get_collision_point(int p_idx) const;
 	Vector3 get_collision_normal(int p_idx) const;


### PR DESCRIPTION
Analogous methods already exist for ray casts, probably it was simply forgotten/overlooked when adding shape casts.

Resolves https://github.com/godotengine/godot-proposals/issues/5703.