### PR TITLE
Add texture reading code to OpenGL3 renderer for web and mobile

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -587,6 +587,13 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 		_record_item_commands(ci, p_canvas_transform_inverse, current_clip, blend_mode, p_lights, index, batch_broken);
 	}
 
+	if (r_last_index >= index) {
+		// Nothing to render, just return.
+		state.current_batch_index = 0;
+		state.canvas_instance_batches.clear();
+		return;
+	}
+
 	// Copy over all data needed for rendering.
 	glBindBuffer(GL_UNIFORM_BUFFER, state.canvas_instance_data_buffers[state.current_buffer].ubo);
 #ifdef WEB_ENABLED

--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -1004,7 +1004,7 @@ void MeshStorage::multimesh_set_mesh(RID p_multimesh, RID p_mesh) {
 #define MULTIMESH_DIRTY_REGION_SIZE 512
 
 void MeshStorage::_multimesh_make_local(MultiMesh *multimesh) const {
-	if (multimesh->data_cache.size() > 0) {
+	if (multimesh->data_cache.size() > 0 || multimesh->instances == 0) {
 		return; //already local
 	}
 	ERR_FAIL_COND(multimesh->data_cache.size() > 0);
@@ -1421,7 +1421,7 @@ Vector<float> MeshStorage::multimesh_get_buffer(RID p_multimesh) const {
 	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
 	ERR_FAIL_COND_V(!multimesh, Vector<float>());
 	Vector<float> ret;
-	if (multimesh->buffer == 0) {
+	if (multimesh->buffer == 0 || multimesh->instances == 0) {
 		return Vector<float>();
 	} else if (multimesh->data_cache.size()) {
 		ret = multimesh->data_cache;

--- a/drivers/gles3/storage/utilities.cpp
+++ b/drivers/gles3/storage/utilities.cpp
@@ -71,6 +71,11 @@ Utilities::~Utilities() {
 
 Vector<uint8_t> Utilities::buffer_get_data(GLenum p_target, GLuint p_buffer, uint32_t p_buffer_size) {
 	Vector<uint8_t> ret;
+
+	if (p_buffer_size == 0) {
+		return ret;
+	}
+
 	ret.resize(p_buffer_size);
 	glBindBuffer(p_target, p_buffer);
 


### PR DESCRIPTION
This allows using texture_2d_get on all platforms which is needed for the get_image function

This commit also fixes some OpenGL warnings on the Web platform that came from attempting to map a buffer with zero length

Fixes: https://github.com/godotengine/godot/issues/68116