### PR TITLE
Move detecting disabled features in engine build profile to above `detect.configure(env)`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -514,6 +514,26 @@ if selected_platform in platform_list:
         # LTO "auto" means we handle the preferred option in each platform detect.py.
         env["lto"] = ARGUMENTS.get("lto", "auto")
 
+    disabled_classes = []
+
+    if env["build_feature_profile"] != "":
+        print("Using build feature profile: " + env["build_feature_profile"])
+        import json
+
+        try:
+            ft = json.load(open(env["build_feature_profile"]))
+            if "disabled_classes" in ft:
+                disabled_classes = ft["disabled_classes"]
+            if "disabled_build_options" in ft:
+                dbo = ft["disabled_build_options"]
+                for c in dbo:
+                    env[c] = dbo[c]
+        except:
+            print("Error opening feature build profile: " + env["build_feature_profile"])
+            Exit(255)
+
+    methods.write_disabled_classes(disabled_classes)
+
     # Must happen after the flags' definition, as configure is when most flags
     # are actually handled to change compile options, etc.
     detect.configure(env)
@@ -807,26 +827,6 @@ if selected_platform in platform_list:
         env["LIBSUFFIXES"] += [env["LIBSUFFIX"], env["SHLIBSUFFIX"]]
     env["LIBSUFFIX"] = suffix + env["LIBSUFFIX"]
     env["SHLIBSUFFIX"] = suffix + env["SHLIBSUFFIX"]
-
-    disabled_classes = []
-
-    if env["build_feature_profile"] != "":
-        print("Using build feature profile: " + env["build_feature_profile"])
-        import json
-
-        try:
-            ft = json.load(open(env["build_feature_profile"]))
-            if "disabled_classes" in ft:
-                disabled_classes = ft["disabled_classes"]
-            if "disabled_build_options" in ft:
-                dbo = ft["disabled_build_options"]
-                for c in dbo:
-                    env[c] = dbo[c]
-        except:
-            print("Error opening feature build profile: " + env["build_feature_profile"])
-            Exit(255)
-
-    methods.write_disabled_classes(disabled_classes)
 
     if env["disable_3d"]:
         if env.editor_build:


### PR DESCRIPTION
This PR moves the code for detecting disabled features from a specified engine build profile above `detect.configure(env)` where these flags are used.

I am unsure if there is any other unexpected behavior as a result of this change as I am unfamiliar with the build environment and would like for this to be further looked into.

Fixes #68142