### PR TITLE
Fix error in curve editor multiline string draw

### DIFF
--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -755,10 +755,10 @@ void CurveEditor::_draw() {
 	float width = view_size.x - 60 * EDSCALE;
 	if (_selected_point > 0 && _selected_point + 1 < curve.get_point_count()) {
 		text_color.a *= 0.4;
-		draw_multiline_string(font, Vector2(50 * EDSCALE, font_height), TTR("Hold Shift to edit tangents individually"), HORIZONTAL_ALIGNMENT_LEFT, width, -1, font_size, text_color);
+		draw_multiline_string(font, Vector2(50 * EDSCALE, font_height), TTR("Hold Shift to edit tangents individually"), HORIZONTAL_ALIGNMENT_LEFT, width, font_size, -1, text_color);
 	} else if (curve.get_point_count() == 0) {
 		text_color.a *= 0.4;
-		draw_multiline_string(font, Vector2(50 * EDSCALE, font_height), TTR("Right click to add point"), HORIZONTAL_ALIGNMENT_LEFT, width, -1, font_size, text_color);
+		draw_multiline_string(font, Vector2(50 * EDSCALE, font_height), TTR("Right click to add point"), HORIZONTAL_ALIGNMENT_LEFT, width, font_size, -1, text_color);
 	}
 }
 


### PR DESCRIPTION
Didn't bother with an Issue since this was so small and had an easy fix.

### Problem

The two "tooltips" using `draw_multiline_string` in the `CurveEditor` have two switched parameters. This leads to an error whenever that text attempts to be drawn the first time (the error appears once for each `draw_multiline_string` call).

To reproduce:

1. Create a new Curve resource
2. Select it

OR

1. Create new Curve resource
2. Add 3 points
3. Select the middle point, causing the tangent lines to appear

In either case, you should get the following error.

`modules\text_server_adv\text_server_adv.cpp:3815 - Condition "p_size <= 0" is true. Returning: false`

### Fix

Reorder the relevant parameters!

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
