### PR TITLE
Use Non-Breaking-Space in Docs' method arguments

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -327,10 +327,12 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 		class_desc->pop(); //meta
 	}
 
-	class_desc->push_color(symbol_color);
-	class_desc->add_text("(");
-	class_desc->pop();
+	const String non_breaking_space = String::chr(160);
+	const String zero_width_space = String::chr(8203);
 
+	class_desc->push_color(symbol_color);
+	class_desc->add_text("(" + zero_width_space);
+	class_desc->pop();
 	for (int j = 0; j < p_method.arguments.size(); j++) {
 		class_desc->push_color(text_color);
 		if (j > 0) {
@@ -338,14 +340,14 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 		}
 
 		_add_text(p_method.arguments[j].name);
-		class_desc->add_text(": ");
+		class_desc->add_text(":" + non_breaking_space);
 		_add_type(p_method.arguments[j].type, p_method.arguments[j].enumeration);
 		if (!p_method.arguments[j].default_value.is_empty()) {
 			class_desc->push_color(symbol_color);
-			class_desc->add_text(" = ");
+			class_desc->add_text(non_breaking_space + "=" + non_breaking_space);
 			class_desc->pop();
 			class_desc->push_color(value_color);
-			_add_text(_fix_constant(p_method.arguments[j].default_value));
+			_add_text(_fix_constant(p_method.arguments[j].default_value).replace(" ", non_breaking_space));
 			class_desc->pop();
 		}
 


### PR DESCRIPTION
This PR replaces the normal spaces within the arguments with Non-Breaking-Spaces. 
Similarly to #65248, this ensures that when the width limit is reached, the argument's name, type and default value remain on the same line, improving readability.

~Unfortunately, I am not sure of a way to separate the first parameter's name from the parenthesis. Is there a breaking character with almost 0 width out there? Not sure, probably? Either way, that'd be the theoretical solution to fix even the smaller possible width.~

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/66727710/199452254-e16df96e-9583-4d12-b469-49b025f11f58.png) | ![image](https://user-images.githubusercontent.com/66727710/199451652-19230afd-a3c6-48d0-9fb1-55568a540363.png) |
| ![image](https://user-images.githubusercontent.com/66727710/199449845-3a169eff-8665-4a8e-a42f-974107d555a0.png) | ![image](https://user-images.githubusercontent.com/66727710/199441254-84c4924a-b8fd-424b-a487-b99fd1f59258.png) |
![image](https://user-images.githubusercontent.com/66727710/199449737-f08e5238-ff07-4407-ac2a-36e3762141a4.png) |![image](https://user-images.githubusercontent.com/66727710/199448322-ed153f5b-45bf-4f92-903f-47b85e91b266.png)
