### PR TITLE
Add user-facing C# unhandled exception reporting.

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Logging.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Logging.cs
@@ -1,0 +1,19 @@
+
+using System;
+
+#nullable enable
+
+namespace Godot;
+
+/// <summary>
+/// Functionality to intercept and handle engine log messages.
+/// </summary>
+public static class Logging
+{
+    public static event Action<Exception>? UnhandledExceptionReporter;
+
+    internal static void InvokeUnhandledExceptionReporter(Exception e)
+    {
+        UnhandledExceptionReporter?.Invoke(e);
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
@@ -99,10 +99,41 @@ namespace Godot.NativeInterop
             }
         }
 
+        private static void InvokeUserUnhandledExceptionReporter(Exception e)
+        {
+            try
+            {
+                Godot.Logging.InvokeUnhandledExceptionReporter(e);
+            }
+            catch (Exception refailure)
+            {
+                // We try again, just in the hopes that we can attempt to report a failure in their callback system.
+                try
+                {
+                    Godot.Logging.InvokeUnhandledExceptionReporter(refailure);
+                }
+                catch (Exception)
+                {
+                    // Well, that's probably not going to work. Sorry.
+                    // Try to report something anyway.
+                    try
+                    {
+                        GD.PushError("User exception handler threw an exception, giving up");
+                    }
+                    catch (Exception)
+                    {
+                        // fine, never mind
+                    }
+                }
+            }
+        }
+
         public static void LogException(Exception e)
         {
             try
             {
+                InvokeUserUnhandledExceptionReporter(e);
+
                 if (NativeFuncs.godotsharp_internal_script_debugger_is_active())
                 {
                     SendToScriptDebugger(e);
@@ -122,6 +153,8 @@ namespace Godot.NativeInterop
         {
             try
             {
+                InvokeUserUnhandledExceptionReporter(e);
+
                 if (NativeFuncs.godotsharp_internal_script_debugger_is_active())
                 {
                     SendToScriptDebugger(e);

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Core\Interfaces\IAwaitable.cs" />
     <Compile Include="Core\Interfaces\IAwaiter.cs" />
     <Compile Include="Core\Interfaces\ISerializationListener.cs" />
+    <Compile Include="Core\Logging.cs" />
     <Compile Include="Core\Mathf.cs" />
     <Compile Include="Core\MathfEx.cs" />
     <Compile Include="Core\NativeInterop\CustomUnsafe.cs" />


### PR DESCRIPTION
I wanted a way to catch unhandled exceptions, because I want to display those in-game and also be able to report them to online bug reporting services. This does part of the job! It doesn't do all the job; this is more of a proof-of-concept that I am happy to parlay into good code.

This allows me to do this during my startup:

```cs
Godot.Logging.UnhandledExceptionReporter += (e) =>
{
    ErrorCollector.GatherEx(e);
};
```

and it works great for my current needs.

It is not perfect.

* This catches C# exceptions. It does not catch engine warnings or errors. I'm going to do that too eventually, just not today.
* This does not provide any mechanism by which errors (or warnings) can be suppressed. Sometimes that's useful!
* It's unclear how to extend this API to provide those; most likely the interface will need significant changes to add those, and, well, breaking changes kinda suck.

I am, to reiterate, happy to work on this more if there's specific guidance on how it should be designed; I'm also happy to put together engine-error and engine-warning reporting too. Let me know if this is interesting and if it's worth continuing!