### PR TITLE
Unified shortcut to clear carets and selections from TextEdit

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -342,7 +342,7 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
     { "ui_text_select_all",                            TTRC("Select All") },
     { "ui_text_select_word_under_caret",               TTRC("Select Word Under Caret") },
     { "ui_text_add_selection_for_next_occurrence",     TTRC("Add Selection for Next Occurrence") },
-    { "ui_text_remove_secondary_carets",               TTRC("Remove Secondary Carets") },
+    { "ui_text_clear_carets_and_selection",            TTRC("Clear Carets and Selection") },
     { "ui_text_toggle_insert_mode",                    TTRC("Toggle Insert Mode") },
     { "ui_text_submit",                                TTRC("Text Submitted") },
     { "ui_graph_duplicate",                            TTRC("Duplicate Nodes") },
@@ -674,7 +674,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::ESCAPE));
-	default_builtin_cache.insert("ui_text_remove_secondary_carets", inputs);
+	default_builtin_cache.insert("ui_text_clear_carets_and_selection", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::INSERT));

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -937,6 +937,11 @@
 		<member name="input/ui_text_caret_word_right.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to move the text cursor forward one word.
 		</member>
+		<member name="input/ui_text_clear_carets_and_selection" type="Dictionary" setter="" getter="">
+			If there's only one caret active and with a selection, clears the selection.
+			In case there's more than one caret active, removes the secondary carets and clears their selections.
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
 		<member name="input/ui_text_completion_accept" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to accept an autocompetion hint.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
@@ -985,10 +990,6 @@
 		</member>
 		<member name="input/ui_text_newline_blank" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to insert a new line after the current one.
-			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
-		</member>
-		<member name="input/ui_text_remove_secondary_carets" type="Dictionary" setter="" getter="">
-			If multiple carets are currently active, clear additional carets and keep just one caret.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
 		<member name="input/ui_text_scroll_down" type="Dictionary" setter="" getter="">

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2051,7 +2051,8 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		}
 
 		if (is_shortcut_keys_enabled()) {
-			// SELECT ALL, SELECT WORD UNDER CARET, ADD SELECTION FOR NEXT OCCURRENCE, CUT, COPY, PASTE.
+			// SELECT ALL, SELECT WORD UNDER CARET, ADD SELECTION FOR NEXT OCCURRENCE,
+			// CLEAR CARETS AND SELECTIONS, CUT, COPY, PASTE.
 			if (k->is_action("ui_text_select_all", true)) {
 				select_all();
 				accept_event();
@@ -2067,10 +2068,12 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				accept_event();
 				return;
 			}
-			if (k->is_action("ui_text_remove_secondary_carets", true) && _should_remove_secondary_carets()) {
-				remove_secondary_carets();
-				accept_event();
-				return;
+			if (k->is_action("ui_text_clear_carets_and_selection", true)) {
+				// Since the default shortcut is ESC, accepts the event only if it's actually performed.
+				if (_clear_carets_and_selection()) {
+					accept_event();
+					return;
+				}
 			}
 			if (k->is_action("ui_cut", true)) {
 				cut();
@@ -2824,8 +2827,18 @@ void TextEdit::_move_caret_document_end(bool p_select) {
 	}
 }
 
-bool TextEdit::_should_remove_secondary_carets() {
-	return carets.size() > 1;
+bool TextEdit::_clear_carets_and_selection() {
+	if (get_caret_count() > 1) {
+		remove_secondary_carets();
+		return true;
+	}
+
+	if (has_selection()) {
+		deselect();
+		return true;
+	}
+
+	return false;
 }
 
 void TextEdit::_get_above_below_caret_line_column(int p_old_line, int p_old_wrap_index, int p_old_column, bool p_below, int &p_new_line, int &p_new_column, int p_last_fit_x) const {

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -597,7 +597,7 @@ private:
 	void _delete(bool p_word = false, bool p_all_to_right = false);
 	void _move_caret_document_start(bool p_select);
 	void _move_caret_document_end(bool p_select);
-	bool _should_remove_secondary_carets();
+	bool _clear_carets_and_selection();
 
 	// Used in add_caret_at_carets
 	void _get_above_below_caret_line_column(int p_old_line, int p_old_wrap_index, int p_old_column, bool p_below, int &p_new_line, int &p_new_column, int p_last_fit_x = -1) const;


### PR DESCRIPTION
Refactors`ui_text_remove_secondary_carets` from https://github.com/godotengine/godot/pull/68089 as `ui_text_clear_carets_and_selection`, with extra behaviour:

- If there's only one active caret active with a selection, clears the selection.
- In case there's more than one caret active, removes the secondary carets and clears selections.

With this change, `TextEdit` then imitates the behaviour of VSCode for clearing carets and selections.


## Showcase
Pressing ESC two times in...

VSCode:

https://user-images.githubusercontent.com/248383/199546143-8a8d28e8-3d76-482c-8a69-d254457050c8.mp4

And Godot:

https://user-images.githubusercontent.com/248383/199546179-3b196387-164a-4a72-b7f7-3a5a230fc80f.mp4

But works by pressing ESC a single time as well if you have only a single caret + selection.

<!--




Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
