### PR TITLE
Add rendering team as GLES3 CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,7 @@ doc_classes/*                       @godotengine/documentation
 
 ## Rendering
 /drivers/dummy/                     @godotengine/rendering
+/drivers/gles3/                     @godotengine/rendering
 /drivers/spirv-reflect/             @godotengine/rendering
 /drivers/vulkan/                    @godotengine/rendering
 


### PR DESCRIPTION
I noticed that the rendering team wasn't getting reviews requested if the changes were wholly in the GLES3 folder. 