### PR TITLE
Avoid pushing an error because reserve is decreasing the default HashMap capacity

### DIFF
--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -2274,8 +2274,7 @@ Error ConvexHullComputer::convex_hull(const Vector<Vector3> &p_points, Geometry3
 
 	// Copy the edges over. There's two "half-edges" for every edge, so we pick only one of them.
 	r_mesh.edges.resize(ch.edges.size() / 2);
-	OAHashMap<uint64_t, int32_t> edge_map;
-	edge_map.reserve(ch.edges.size() * 4); // The higher the capacity, the faster the insert
+	OAHashMap<uint64_t, int32_t> edge_map(ch.edges.size() * 4); // The higher the capacity, the faster the insert
 
 	uint32_t edges_copied = 0;
 	for (uint32_t i = 0; i < ch.edges.size(); i++) {


### PR DESCRIPTION
…ap capacity

This commit makes the reserve size passed as constructor argument, not doing this way has 2 undesired side effects when creating small convex shapes from an array of vertexes:
1. hash map will allocate more memory than really needed
2. Godot will print an error every time the reserve call is hit, the error looks like this:
```
ERROR: Condition "p_new_capacity < capacity" is true.
   at: reserve (./core/templates/oa_hash_map.h:305)
```
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

**This PR is sponsored by Prehensile Tales and Astera organization** 