### PR TITLE
Avoid memory corruption when GodotConvexPolygonShape3D is setup more than once

### DIFF
--- a/servers/physics_3d/godot_shape_3d.cpp
+++ b/servers/physics_3d/godot_shape_3d.cpp
@@ -1085,6 +1085,8 @@ void GodotConvexPolygonShape3D::_setup(const Vector<Vector3> &p_vertices) {
 	if (err != OK) {
 		ERR_PRINT("Failed to build convex hull");
 	}
+	extreme_vertices.resize(0);
+	vertex_neighbors.resize(0);
 
 	AABB _aabb;
 


### PR DESCRIPTION
…than once

I have been suffering random crashes when using World3D.intersect_shape, and the reason seems to happen because of some memory corruption.
This assumption is because the code in GodotConvexPolygonShape3D is referencing vertexes that does not exists in the mesh.

The assumption is that _setup is called again when `points` property changes, and this provokes undesired results when intending to intersect_shape.

In some cases the game crashes here because of the old data pointing to a now unexisting vertex
```
	_FORCE_INLINE_ const T &operator[](U p_index) const {
		CRASH_BAD_UNSIGNED_INDEX(p_index, count);
		return data[p_index];
	}
```
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
**This PR is sponsored by Prehensile Tales and Astera organization**