### PR TITLE
Unify Node3D RotationOrder with global EulerOrder

### DIFF
--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -490,6 +490,7 @@ public:
 	}
 
 	// Only enum classes that need to be bound need this to be defined.
+	VARIANT_ENUM_CLASS_CONSTRUCTOR(EulerOrder)
 	VARIANT_ENUM_CLASS_CONSTRUCTOR(JoyAxis)
 	VARIANT_ENUM_CLASS_CONSTRUCTOR(JoyButton)
 	VARIANT_ENUM_CLASS_CONSTRUCTOR(Key)

--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -290,7 +290,7 @@
 		<member name="rotation_edit_mode" type="int" setter="set_rotation_edit_mode" getter="get_rotation_edit_mode" enum="Node3D.RotationEditMode" default="0">
 			Specify how rotation (and scale) will be presented in the editor.
 		</member>
-		<member name="rotation_order" type="int" setter="set_rotation_order" getter="get_rotation_order" enum="Node3D.RotationOrder" default="2">
+		<member name="rotation_order" type="int" setter="set_rotation_order" getter="get_rotation_order" enum="EulerOrder" default="2">
 			Specify the axis rotation order of the [member rotation] property. The final orientation is constructed by rotating the Euler angles in the order specified by this property.
 		</member>
 		<member name="scale" type="Vector3" setter="set_scale" getter="get_scale" default="Vector3(1, 1, 1)">
@@ -341,18 +341,6 @@
 		<constant name="ROTATION_EDIT_MODE_QUATERNION" value="1" enum="RotationEditMode">
 		</constant>
 		<constant name="ROTATION_EDIT_MODE_BASIS" value="2" enum="RotationEditMode">
-		</constant>
-		<constant name="ROTATION_ORDER_XYZ" value="0" enum="RotationOrder">
-		</constant>
-		<constant name="ROTATION_ORDER_XZY" value="1" enum="RotationOrder">
-		</constant>
-		<constant name="ROTATION_ORDER_YXZ" value="2" enum="RotationOrder">
-		</constant>
-		<constant name="ROTATION_ORDER_YZX" value="3" enum="RotationOrder">
-		</constant>
-		<constant name="ROTATION_ORDER_ZXY" value="4" enum="RotationOrder">
-		</constant>
-		<constant name="ROTATION_ORDER_ZYX" value="5" enum="RotationOrder">
 		</constant>
 	</constants>
 </class>

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -392,27 +392,25 @@ Node3D::RotationEditMode Node3D::get_rotation_edit_mode() const {
 	return data.rotation_edit_mode;
 }
 
-void Node3D::set_rotation_order(RotationOrder p_order) {
-	EulerOrder order = EulerOrder(p_order);
-
-	if (data.euler_rotation_order == order) {
+void Node3D::set_rotation_order(EulerOrder p_order) {
+	if (data.euler_rotation_order == p_order) {
 		return;
 	}
 
-	ERR_FAIL_INDEX(int32_t(order), 6);
+	ERR_FAIL_INDEX(int32_t(p_order), 6);
 	bool transform_changed = false;
 
 	if (data.dirty & DIRTY_EULER_ROTATION_AND_SCALE) {
 		_update_rotation_and_scale();
 	} else if (data.dirty & DIRTY_LOCAL_TRANSFORM) {
-		data.euler_rotation = Basis::from_euler(data.euler_rotation, data.euler_rotation_order).get_euler_normalized(order);
+		data.euler_rotation = Basis::from_euler(data.euler_rotation, data.euler_rotation_order).get_euler_normalized(p_order);
 		transform_changed = true;
 	} else {
 		data.dirty |= DIRTY_LOCAL_TRANSFORM;
 		transform_changed = true;
 	}
 
-	data.euler_rotation_order = order;
+	data.euler_rotation_order = p_order;
 
 	if (transform_changed) {
 		_propagate_transform_changed(this);
@@ -423,8 +421,8 @@ void Node3D::set_rotation_order(RotationOrder p_order) {
 	notify_property_list_changed(); // Will change the rotation property.
 }
 
-Node3D::RotationOrder Node3D::get_rotation_order() const {
-	return RotationOrder(data.euler_rotation_order);
+EulerOrder Node3D::get_rotation_order() const {
+	return data.euler_rotation_order;
 }
 
 void Node3D::set_rotation(const Vector3 &p_euler_rad) {
@@ -1041,13 +1039,6 @@ void Node3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(ROTATION_EDIT_MODE_EULER);
 	BIND_ENUM_CONSTANT(ROTATION_EDIT_MODE_QUATERNION);
 	BIND_ENUM_CONSTANT(ROTATION_EDIT_MODE_BASIS);
-
-	BIND_ENUM_CONSTANT(ROTATION_ORDER_XYZ);
-	BIND_ENUM_CONSTANT(ROTATION_ORDER_XZY);
-	BIND_ENUM_CONSTANT(ROTATION_ORDER_YXZ);
-	BIND_ENUM_CONSTANT(ROTATION_ORDER_YZX);
-	BIND_ENUM_CONSTANT(ROTATION_ORDER_ZXY);
-	BIND_ENUM_CONSTANT(ROTATION_ORDER_ZYX);
 
 	ADD_GROUP("Transform", "");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM3D, "transform", PROPERTY_HINT_NONE, "suffix:m", PROPERTY_USAGE_NO_EDITOR), "set_transform", "get_transform");

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -61,15 +61,6 @@ public:
 		ROTATION_EDIT_MODE_BASIS,
 	};
 
-	enum RotationOrder {
-		ROTATION_ORDER_XYZ,
-		ROTATION_ORDER_XZY,
-		ROTATION_ORDER_YXZ,
-		ROTATION_ORDER_YZX,
-		ROTATION_ORDER_ZXY,
-		ROTATION_ORDER_ZYX
-	};
-
 private:
 	// For the sake of ease of use, Node3D can operate with Transforms (Basis+Origin), Quaternion/Scale and Euler Rotation/Scale.
 	// Transform and Quaternion are stored in data.local_transform Basis (so quaternion is not really stored, but converted back/forth from 3x3 matrix on demand).
@@ -179,7 +170,7 @@ public:
 	void set_rotation_edit_mode(RotationEditMode p_mode);
 	RotationEditMode get_rotation_edit_mode() const;
 
-	void set_rotation_order(RotationOrder p_order);
+	void set_rotation_order(EulerOrder p_order);
 	void set_rotation(const Vector3 &p_euler_rad);
 	void set_scale(const Vector3 &p_scale);
 
@@ -188,7 +179,7 @@ public:
 
 	Vector3 get_position() const;
 
-	RotationOrder get_rotation_order() const;
+	EulerOrder get_rotation_order() const;
 	Vector3 get_rotation() const;
 	Vector3 get_scale() const;
 
@@ -277,6 +268,5 @@ public:
 };
 
 VARIANT_ENUM_CAST(Node3D::RotationEditMode)
-VARIANT_ENUM_CAST(Node3D::RotationOrder)
 
 #endif // NODE_3D_H


### PR DESCRIPTION
This PR removes a duplicate enum in Node3D that represented the Euler rotation order for the editor UI.