### PR TITLE
[3.x] Fix docks to be reset to first tab when switching main tab

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4535,7 +4535,7 @@ void EditorNode::_load_docks() {
 	editor_data.set_plugin_window_layout(config);
 }
 
-void EditorNode::_update_dock_slots_visibility() {
+void EditorNode::_update_dock_slots_visibility(bool p_keep_selected_tabs) {
 	if (!docks_visible) {
 		for (int i = 0; i < DOCK_SLOT_MAX; i++) {
 			dock_slot[i]->hide();
@@ -4570,9 +4570,11 @@ void EditorNode::_update_dock_slots_visibility() {
 			}
 		}
 
-		for (int i = 0; i < DOCK_SLOT_MAX; i++) {
-			if (dock_slot[i]->is_visible() && dock_slot[i]->get_tab_count()) {
-				dock_slot[i]->set_current_tab(0);
+		if (!p_keep_selected_tabs) {
+			for (int i = 0; i < DOCK_SLOT_MAX; i++) {
+				if (dock_slot[i]->is_visible() && dock_slot[i]->get_tab_count()) {
+					dock_slot[i]->set_current_tab(0);
+				}
 			}
 		}
 
@@ -5173,7 +5175,7 @@ void EditorNode::_bottom_panel_switch(bool p_enable, int p_idx) {
 
 void EditorNode::set_docks_visible(bool p_show) {
 	docks_visible = p_show;
-	_update_dock_slots_visibility();
+	_update_dock_slots_visibility(true);
 }
 
 bool EditorNode::get_docks_visible() const {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -616,7 +616,7 @@ private:
 	void _load_docks();
 	void _save_docks_to_config(Ref<ConfigFile> p_layout, const String &p_section);
 	void _load_docks_from_config(Ref<ConfigFile> p_layout, const String &p_section);
-	void _update_dock_slots_visibility();
+	void _update_dock_slots_visibility(bool p_keep_selected_tabs = false);
 	void _dock_tab_changed(int p_tab);
 
 	bool restoring_scenes;


### PR DESCRIPTION
Fix #56227 in 3.x branch.

Backport of #58049

Issue was still occur in 3.x branch

### Issue description
When switching distraction mode on / off, seleted tabs in docks are reset to first tab.

Also, with separate_distraction_mode activated, each switch to 2D / 3D / Script / AssetLib screen reset the selected tabs in docks.

### Identified cause
Those situations call ``EditorNode::_update_dock_slots_visibility()``
In this function, selected docks tabs are reset to first one.

### Fix proposal
Add a bool parameter to keep docks selected tabs to ``EditorNode::_update_dock_slots_visibility()`` -> ``EditorNode::_update_dock_slots_visibility(bool p_keep_selected_tabs = false)``.

When this function is called via ``EditorNode::set_docks_visible()`` there is no need to reset tab selection cause tabs are unchanged.
The default value of this new parameter is false because other call to ``EditorNode::_update_dock_slots_visibility()`` elsewhere in code may need selected tab to be reset.

### Before
![bug](https://user-images.githubusercontent.com/3649998/199721849-7469f23a-75c4-4223-9c45-833e7aae43d4.gif)


### After
![fix](https://user-images.githubusercontent.com/3649998/199721873-48a5e145-9ffd-4545-81b8-34ad29cf534d.gif)
