### PR TITLE
Collapse three seperate texture storage methods into render_target_set_override()

### DIFF
--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -593,11 +593,9 @@ public:
 	virtual void render_target_set_vrs_texture(RID p_render_target, RID p_texture) override {}
 	virtual RID render_target_get_vrs_texture(RID p_render_target) const override { return RID(); }
 
-	virtual void render_target_set_override_color(RID p_render_target, RID p_texture) override {}
+	virtual void render_target_set_override(RID p_render_target, RID p_color_texture, RID p_depth_texture, RID p_velocity_texture) override {}
 	virtual RID render_target_get_override_color(RID p_render_target) const override { return RID(); }
-	virtual void render_target_set_override_depth(RID p_render_target, RID p_texture) override {}
 	virtual RID render_target_get_override_depth(RID p_render_target) const override { return RID(); }
-	virtual void render_target_set_override_velocity(RID p_render_target, RID p_texture) override {}
 	virtual RID render_target_get_override_velocity(RID p_render_target) const override { return RID(); }
 
 	virtual RID render_target_get_texture(RID p_render_target) override;

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -184,11 +184,9 @@ public:
 	virtual void render_target_set_vrs_texture(RID p_render_target, RID p_texture) override {}
 	virtual RID render_target_get_vrs_texture(RID p_render_target) const override { return RID(); }
 
-	virtual void render_target_set_override_color(RID p_render_target, RID p_texture) override {}
+	virtual void render_target_set_override(RID p_render_target, RID p_color_texture, RID p_depth_texture, RID p_velocity_texture) override {}
 	virtual RID render_target_get_override_color(RID p_render_target) const override { return RID(); }
-	virtual void render_target_set_override_depth(RID p_render_target, RID p_texture) override {}
 	virtual RID render_target_get_override_depth(RID p_render_target) const override { return RID(); }
-	virtual void render_target_set_override_velocity(RID p_render_target, RID p_texture) override {}
 	virtual RID render_target_get_override_velocity(RID p_render_target) const override { return RID(); }
 
 	virtual RID render_target_get_texture(RID p_render_target) override { return RID(); }

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -2594,11 +2594,13 @@ RID TextureStorage::render_target_get_texture(RID p_render_target) {
 	return rt->texture;
 }
 
-void TextureStorage::render_target_set_override_color(RID p_render_target, RID p_texture) {
+void TextureStorage::render_target_set_override(RID p_render_target, RID p_color_texture, RID p_depth_texture, RID p_velocity_texture) {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_COND(!rt);
 
-	rt->overridden.color = p_texture;
+	rt->overridden.color = p_color_texture;
+	rt->overridden.depth = p_depth_texture;
+	rt->overridden.velocity = p_velocity_texture;
 }
 
 RID TextureStorage::render_target_get_override_color(RID p_render_target) const {
@@ -2606,13 +2608,6 @@ RID TextureStorage::render_target_get_override_color(RID p_render_target) const 
 	ERR_FAIL_COND_V(!rt, RID());
 
 	return rt->overridden.color;
-}
-
-void TextureStorage::render_target_set_override_depth(RID p_render_target, RID p_texture) {
-	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
-	ERR_FAIL_COND(!rt);
-
-	rt->overridden.depth = p_texture;
 }
 
 RID TextureStorage::render_target_get_override_depth(RID p_render_target) const {
@@ -2639,13 +2634,6 @@ RID TextureStorage::render_target_get_override_depth_slice(RID p_render_target, 
 
 		return rt->overridden.cached_slices[key];
 	}
-}
-
-void TextureStorage::render_target_set_override_velocity(RID p_render_target, RID p_texture) {
-	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
-	ERR_FAIL_COND(!rt);
-
-	rt->overridden.velocity = p_texture;
 }
 
 RID TextureStorage::render_target_get_override_velocity(RID p_render_target) const {

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -718,12 +718,10 @@ public:
 	virtual void render_target_set_vrs_texture(RID p_render_target, RID p_texture) override;
 	virtual RID render_target_get_vrs_texture(RID p_render_target) const override;
 
-	virtual void render_target_set_override_color(RID p_render_target, RID p_texture) override;
+	virtual void render_target_set_override(RID p_render_target, RID p_color_texture, RID p_depth_texture, RID p_velocity_texture) override;
 	virtual RID render_target_get_override_color(RID p_render_target) const override;
-	virtual void render_target_set_override_depth(RID p_render_target, RID p_texture) override;
 	virtual RID render_target_get_override_depth(RID p_render_target) const override;
 	RID render_target_get_override_depth_slice(RID p_render_target, const uint32_t p_layer) const;
-	virtual void render_target_set_override_velocity(RID p_render_target, RID p_texture) override;
 	virtual RID render_target_get_override_velocity(RID p_render_target) const override;
 	RID render_target_get_override_velocity_slice(RID p_render_target, const uint32_t p_layer) const;
 

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -669,9 +669,10 @@ void RendererViewport::draw_viewports() {
 			// This usually is a result of the player taking off their headset and OpenXR telling us to skip
 			// rendering frames.
 			if (xr_interface->pre_draw_viewport(vp->render_target)) {
-				RSG::texture_storage->render_target_set_override_color(vp->render_target, xr_interface->get_color_texture());
-				RSG::texture_storage->render_target_set_override_depth(vp->render_target, xr_interface->get_depth_texture());
-				RSG::texture_storage->render_target_set_override_velocity(vp->render_target, xr_interface->get_velocity_texture());
+				RSG::texture_storage->render_target_set_override(vp->render_target,
+						xr_interface->get_color_texture(),
+						xr_interface->get_depth_texture(),
+						xr_interface->get_velocity_texture());
 
 				// render...
 				RSG::scene->set_debug_draw_mode(vp->debug_draw);
@@ -699,9 +700,7 @@ void RendererViewport::draw_viewports() {
 				}
 			}
 		} else {
-			RSG::texture_storage->render_target_set_override_color(vp->render_target, RID()); // TODO if fullscreen output, we can set this to our texture chain
-			RSG::texture_storage->render_target_set_override_depth(vp->render_target, RID());
-			RSG::texture_storage->render_target_set_override_velocity(vp->render_target, RID());
+			RSG::texture_storage->render_target_set_override(vp->render_target, RID(), RID(), RID());
 
 			RSG::scene->set_debug_draw_mode(vp->debug_draw);
 

--- a/servers/rendering/storage/texture_storage.h
+++ b/servers/rendering/storage/texture_storage.h
@@ -160,11 +160,9 @@ public:
 	virtual RID render_target_get_vrs_texture(RID p_render_target) const = 0;
 
 	// override color, depth and velocity buffers (depth and velocity only for 3D)
-	virtual void render_target_set_override_color(RID p_render_target, RID p_texture) = 0;
+	virtual void render_target_set_override(RID p_render_target, RID p_color_texture, RID p_depth_texture, RID p_velocity_texture) = 0;
 	virtual RID render_target_get_override_color(RID p_render_target) const = 0;
-	virtual void render_target_set_override_depth(RID p_render_target, RID p_texture) = 0;
 	virtual RID render_target_get_override_depth(RID p_render_target) const = 0;
-	virtual void render_target_set_override_velocity(RID p_render_target, RID p_texture) = 0;
 	virtual RID render_target_get_override_velocity(RID p_render_target) const = 0;
 
 	// get textures


### PR DESCRIPTION
Currently, there's three separate methods to override the textures on a render target (added recently in #65227):

- `render_target_set_override_color(RID p_render_target, RID p_texture)`
- `render_target_set_override_depth(RID p_render_target, RID p_texture)`
- `render_target_set_override_velocity(RID p_render_target, RID p_texture)`

This PR collapses them into a single method:

- `render_target_set_override(RID p_render_target, RID p_color_texture, RID p_depth_texture, RID p_velocity_texture)`

You'll really only ever want to set all of the override textures on the render target at the same time, and doing it in a single method call makes it *much* easier to cache the framebuffer that is created as a result.

The Vulkan renderer already has a sophisticated caching mechanism, so it has no problem. But I'd like to implement caching of these overridden framebuffers for OpenGL (in #67775), where we don't have any caching yet. In XR, this caching is particularly important, because the overridden textures will be swapped every frame.

I already discussed this with @BastiaanOlij on RocketChat and he seemed open to this change!