### PR TITLE
Add missing String & StringName operator descriptions

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -27,14 +27,14 @@
 			<return type="String" />
 			<param index="0" name="from" type="NodePath" />
 			<description>
-				Constructs a new String from the given [NodePath].
+				Constructs a new [String] from the given [NodePath].
 			</description>
 		</constructor>
 		<constructor name="String">
 			<return type="String" />
 			<param index="0" name="from" type="StringName" />
 			<description>
-				Constructs a new String from the given [StringName].
+				Constructs a new [String] from the given [StringName].
 			</description>
 		</constructor>
 	</constructors>
@@ -51,7 +51,7 @@
 			<description>
 				Returns an array containing the bigrams (pairs of consecutive letters) of this string.
 				[codeblock]
-				print("Bigrams".bigrams()) # Prints "[Bi, ig, gr, ra, am, ms]"
+				print("Bigrams".bigrams()) # Prints ["Bi", "ig", "gr", "ra", "am", "ms"]
 				[/codeblock]
 			</description>
 		</method>
@@ -920,66 +920,88 @@
 			<return type="bool" />
 			<param index="0" name="right" type="String" />
 			<description>
+				Returns [code]true[/code] if both strings do not contain the same sequence of characters.
 			</description>
 		</operator>
 		<operator name="operator !=">
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
 			<description>
+				Returns [code]true[/code] if this [String] is not equivalent to the given [StringName].
 			</description>
 		</operator>
 		<operator name="operator %">
 			<return type="String" />
 			<param index="0" name="right" type="Variant" />
 			<description>
+				Formats the [String], replacing the placeholders with one or more parameters.
+				To pass multiple parameters, [param right] needs to be an [Array].
+				[codeblock]
+				print("I caught %d fishes!" % 2) # Prints "I caught 2 fishes!"
+
+				var my_message = "Travelling to %s, at %2.2f per second."
+				var location = "Deep Valley"
+				var speed = 40.3485
+				print(my_message % [location, speed]) # Prints "Travelling to Deep Valley, at 40.35 km/h."
+				[/codeblock]
+				In C#, there is no direct equivalent to this operator. Use the [method format] method, instead.
+				For more information, see the [url=$DOCS_URL/tutorials/scripting/gdscript/gdscript_format_string.html]GDScript format strings[/url] tutorial.
 			</description>
 		</operator>
 		<operator name="operator +">
 			<return type="String" />
 			<param index="0" name="right" type="String" />
 			<description>
+				Appends [param right] at the end of this [String], also known as a string concatenation.
 			</description>
 		</operator>
 		<operator name="operator &lt;">
 			<return type="bool" />
 			<param index="0" name="right" type="String" />
 			<description>
+				Returns [code]true[/code] if the left [String] comes before [param right] in [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode order[/url], which roughly matches the alphabetical order. Useful for sorting.
 			</description>
 		</operator>
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="String" />
 			<description>
+				Returns [code]true[/code] if the left [String] comes before [param right] in [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode order[/url], which roughly matches the alphabetical order, or if both are equal.
 			</description>
 		</operator>
 		<operator name="operator ==">
 			<return type="bool" />
 			<param index="0" name="right" type="String" />
 			<description>
+				Returns [code]true[/code] if both strings contain the same sequence of characters.
 			</description>
 		</operator>
 		<operator name="operator ==">
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
 			<description>
+				Returns [code]true[/code] if this [String] is equivalent to the given [StringName].
 			</description>
 		</operator>
 		<operator name="operator &gt;">
 			<return type="bool" />
 			<param index="0" name="right" type="String" />
 			<description>
+				Returns [code]true[/code] if the left [String] comes after [param right] in [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode order[/url], which roughly matches the alphabetical order. Useful for sorting.
 			</description>
 		</operator>
 		<operator name="operator &gt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="String" />
 			<description>
+				Returns [code]true[/code] if the left [String] comes after [param right] in [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode order[/url], which roughly matches the alphabetical order, or if both are equal.
 			</description>
 		</operator>
 		<operator name="operator []">
 			<return type="String" />
 			<param index="0" name="index" type="int" />
 			<description>
+				Returns a new [String] that only contains the character at [param index]. Indices start from [code]0[/code]. If [param index] is greater or equal to [code]0[/code], the character is fetched starting from the beginning of the string. If [param index] is a negative value, it is fetched starting from the end. Accessing a string out-of-bounds will cause a run-time error, pausing the project execution if run from the editor.
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		[StringName]s are immutable strings designed for general-purpose representation of unique names (also called "string interning"). [StringName] ensures that only one instance of a given name exists (so two [StringName]s with the same value are the same object). Comparing them is much faster than with regular [String]s, because only the pointers are compared, not the whole strings.
-		You will usually just pass a [String] to methods expecting a [StringName] and it will be automatically converted, but you may occasionally want to construct a [StringName] ahead of time with [StringName] or the literal syntax [code]&amp;"example"[/code].
+		You will usually just pass a [String] to methods expecting a [StringName] and it will be automatically converted, but you may occasionally want to construct a [StringName] ahead of time with [StringName] or, in GDScript, the literal syntax [code]&amp;"example"[/code].
 		See also [NodePath], which is a similar concept specifically designed to store pre-parsed node paths.
 	</description>
 	<tutorials>
@@ -28,7 +28,7 @@
 			<return type="StringName" />
 			<param index="0" name="from" type="String" />
 			<description>
-				Creates a new [StringName] from the given [String]. [code]StringName("example")[/code] is equivalent to [code]&amp;"example"[/code].
+				Creates a new [StringName] from the given [String]. In GDScript, [code]StringName("example")[/code] is equivalent to [code]&amp;"example"[/code].
 			</description>
 		</constructor>
 	</constructors>
@@ -45,48 +45,56 @@
 			<return type="bool" />
 			<param index="0" name="right" type="String" />
 			<description>
+				Returns [code]true[/code] if this [StringName] is not equivalent to the given [String].
 			</description>
 		</operator>
 		<operator name="operator !=">
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
 			<description>
+				Returns [code]true[/code] if the [StringName] and [param right] do not refer to the same name. Comparisons between [StringName]s are much faster than regular [String] comparisons.
 			</description>
 		</operator>
 		<operator name="operator &lt;">
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
 			<description>
+				Returns [code]true[/code] if the left [String] comes before [param right] in [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode order[/url], which roughly matches the alphabetical order. Useful for sorting.
 			</description>
 		</operator>
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
 			<description>
+				Returns [code]true[/code] if the left [String] comes before [param right] in [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode order[/url], which roughly matches the alphabetical order, or if both are equal.
 			</description>
 		</operator>
 		<operator name="operator ==">
 			<return type="bool" />
 			<param index="0" name="right" type="String" />
 			<description>
+				Returns [code]true[/code] if this [StringName] is equivalent to the given [String].
 			</description>
 		</operator>
 		<operator name="operator ==">
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
 			<description>
+				Returns [code]true[/code] if the [StringName] and [param right] refer to the same name. Comparisons between [StringName]s are much faster than regular [String] comparisons.
 			</description>
 		</operator>
 		<operator name="operator &gt;">
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
 			<description>
+				Returns [code]true[/code] if the left [StringName] comes after [param right] in [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode order[/url], which roughly matches the alphabetical order. Useful for sorting.
 			</description>
 		</operator>
 		<operator name="operator &gt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
 			<description>
+				Returns [code]true[/code] if the left [StringName] comes after [param right] in [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode order[/url], which roughly matches the alphabetical order, or if both are equal.
 			</description>
 		</operator>
 	</operators>


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/68838.

Adds missing descriptions to the **String** and **StringName** operators in the Class Reference. Most notably, a decently detailed one to the "**%**" operator pointing to the String formatting tutorial.

Also corrects `String.bigram()`'s print value because I glanced at it, it technically was outdated.