### PR TITLE
Remove "?" from String.c_escape()

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3899,7 +3899,6 @@ String String::c_unescape() const {
 	escaped = escaped.replace("\\v", "\v");
 	escaped = escaped.replace("\\'", "\'");
 	escaped = escaped.replace("\\\"", "\"");
-	escaped = escaped.replace("\\?", "\?");
 	escaped = escaped.replace("\\\\", "\\");
 
 	return escaped;
@@ -3916,7 +3915,6 @@ String String::c_escape() const {
 	escaped = escaped.replace("\t", "\\t");
 	escaped = escaped.replace("\v", "\\v");
 	escaped = escaped.replace("\'", "\\'");
-	escaped = escaped.replace("\?", "\\?");
 	escaped = escaped.replace("\"", "\\\"");
 
 	return escaped;

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -80,7 +80,7 @@
 		<method name="c_unescape" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns a copy of the string with escaped characters replaced by their meanings. Supported escape sequences are [code]\'[/code], [code]\"[/code], [code]\?[/code], [code]\\[/code], [code]\a[/code], [code]\b[/code], [code]\f[/code], [code]\n[/code], [code]\r[/code], [code]\t[/code], [code]\v[/code].
+				Returns a copy of the string with escaped characters replaced by their meanings. Supported escape sequences are [code]\'[/code], [code]\"[/code], [code]\\[/code], [code]\a[/code], [code]\b[/code], [code]\f[/code], [code]\n[/code], [code]\r[/code], [code]\t[/code], [code]\v[/code].
 				[b]Note:[/b] Unlike the GDScript parser, this method doesn't support the [code]\uXXXX[/code] escape sequence.
 			</description>
 		</method>


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/64520.

Honestly this error should suffice as a justification for this PR all on its own, but I suppose explaining myself does not hurt.
![image](https://user-images.githubusercontent.com/66727710/199809460-b2f9b5a1-94f6-4ccc-9ec9-e9031210f4d2.png)

Indeed, `?` _can_ be a valid escape character in C and C++ [(1)](https://stackoverflow.com/questions/19374878/why-is-an-escape-sequence-in-c-c) [(2)](https://stackoverflow.com/questions/18155056/what-does-the-backslash-question-mark-escape-sequence-mean) [(3)](https://stackoverflow.com/questions/1586834/escape-sequence-for-in-c)...
They allow writing a [trigraph](http://en.wikipedia.org/wiki/Digraphs_and_trigraphs). These trigraphs were one past solution for the limited keyboard sets that may not feature important, special characters. By writing `??`, followed by a character, the compiler will interpret it differently. For example, writing `??(` is the equivalent of `[`, and `??!` is the same as `|`. To prevent this, the question mark needs to be escaped `\?`.
 
The `String.c_escape()` and `String.unescape()` has been kind of flawed for a while. What starts a trigraph is not one, but two question marks, and not every combination of characters is a valid. The replacement logic is too simplistic, and because of it, the "_?_" present in common sentences is unescaped for no discernible reason.

Nowadays, the concept is essentially deprecated, and use is discouraged. I am not sure if it's worth even writing special logic to escape them, as by [C stardard](https://en.wikipedia.org/wiki/Digraphs_and_trigraphs#C).