### PR TITLE
C#: Generate strongly-typed method to raise signal events and fix event accessibility

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/EventSignals_ScriptSignals.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/EventSignals_ScriptSignals.generated.cs
@@ -32,6 +32,10 @@ partial class EventSignals
         add => backing_MySignal += value;
         remove => backing_MySignal -= value;
 }
+    protected void OnMySignal(string str, int num)
+    {
+        EmitSignal(SignalName.MySignal, str, num);
+    }
     /// <inheritdoc/>
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     protected override void RaiseGodotClassSignalCallbacks(in godot_string_name signal, NativeVariantPtrArgs args)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -155,6 +155,32 @@ namespace Godot.SourceGenerators
             };
         }
 
+        public static string GetAccessibilityKeyword(this INamedTypeSymbol namedTypeSymbol)
+        {
+            if (namedTypeSymbol.DeclaredAccessibility == Accessibility.NotApplicable)
+            {
+                // Accessibility not specified. Get the default accessibility.
+                return namedTypeSymbol.ContainingSymbol switch
+                {
+                    null or INamespaceSymbol => "internal",
+                    ITypeSymbol { TypeKind: TypeKind.Class or TypeKind.Struct } => "private",
+                    ITypeSymbol { TypeKind: TypeKind.Interface } => "public",
+                    _ => "",
+                };
+            }
+
+            return namedTypeSymbol.DeclaredAccessibility switch
+            {
+                Accessibility.Private => "private",
+                Accessibility.Protected => "protected",
+                Accessibility.Internal => "internal",
+                Accessibility.ProtectedAndInternal => "private",
+                Accessibility.ProtectedOrInternal => "private",
+                Accessibility.Public => "public",
+                _ => "",
+            };
+        }
+
         public static string NameWithTypeParameters(this INamedTypeSymbol symbol)
         {
             return symbol.IsGenericType ?

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -276,7 +276,7 @@ namespace Godot.SourceGenerators
                 source.Append(
                     $"    /// <inheritdoc cref=\"{signalDelegate.DelegateSymbol.FullQualifiedNameIncludeGlobal()}\"/>\n");
 
-                source.Append("    public event ")
+                source.Append($"    {signalDelegate.DelegateSymbol.GetAccessibilityKeyword()} event ")
                     .Append(signalDelegate.DelegateSymbol.FullQualifiedNameIncludeGlobal())
                     .Append(" @")
                     .Append(signalName)

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -3104,6 +3104,46 @@ Error BindingsGenerator::_generate_cs_signal(const BindingsGenerator::TypeInterf
 		}
 
 		p_output.append(CLOSE_BLOCK_L1);
+
+		// Generate On{EventName} method to raise the event.
+		if (!p_itype.is_singleton) {
+			p_output.append(MEMBER_BEGIN "protected void ");
+			p_output << "On" << p_isignal.proxy_name;
+			if (is_parameterless) {
+				p_output.append("()\n" OPEN_BLOCK_L1 INDENT2);
+				p_output << "EmitSignal(SignalName." << p_isignal.proxy_name << ");\n";
+				p_output.append(CLOSE_BLOCK_L1);
+			} else {
+				p_output.append("(");
+
+				StringBuilder cs_emitsignal_params;
+
+				int idx = 0;
+				for (const ArgumentInterface &iarg : p_isignal.arguments) {
+					const TypeInterface *arg_type = _get_type_or_null(iarg.type);
+					ERR_FAIL_NULL_V_MSG(arg_type, ERR_BUG, "Argument type '" + iarg.type.cname + "' was not found.");
+
+					if (idx != 0) {
+						p_output << ", ";
+						cs_emitsignal_params << ", ";
+					}
+
+					p_output << arg_type->cs_type << " " << iarg.name;
+
+					if (arg_type->is_enum) {
+						cs_emitsignal_params << "(long)";
+					}
+
+					cs_emitsignal_params << iarg.name;
+
+					idx++;
+				}
+
+				p_output.append(")\n" OPEN_BLOCK_L1 INDENT2);
+				p_output << "EmitSignal(SignalName." << p_isignal.proxy_name << ", " << cs_emitsignal_params << ");\n";
+				p_output.append(CLOSE_BLOCK_L1);
+			}
+		}
 	}
 
 	return OK;


### PR DESCRIPTION
- Generate signal event with the same accessibility as the delegate
	- Before this, if a user class declares a signal delegate with less accessibility than `public` it resulted in a compiler error because the delegate had less accessibility than the generated event which was always generated as `public`, with this PR the event is generated with the same accessibility that the delegate was declared with.
	- I can't find an issue about this but I'm pretty sure I saw someone affected by this, maybe it was outside of GitHub.
- Generate `On{EventName}` method to raise signal events
	- Closes https://github.com/godotengine/godot/issues/66533
	- Closes https://github.com/godotengine/godot/issues/67549
	- Follows .NET naming conventions but I can change it to `Emit{EventName}` if that's preferred.
	- Method is `protected virtual` unless the class is sealed in which case it's `private`, this follows the .NET event guidelines.
	- Enums are converted to the underlying type so they can be used as Variant in `EmitSignal`.

Sample:

```csharp
// User-defined signal
[Signal]
delegate void MySignalEventHandler(int a, float b, Node c, MyEnum d);

// Method generated by the source generator
protected void OnMySignal(int a, float b, Node c, MyEnum d)
{
    EmitSignal(SignalName.MySignal, a, b, c, (int)d);
}
```