### PR TITLE
Expose RenderingDevice::vertex_array_create to scripting

### DIFF
--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -643,6 +643,15 @@
 			<description>
 			</description>
 		</method>
+		<method name="vertex_array_create">
+			<return type="RID" />
+			<param index="0" name="vertex_count" type="int" />
+			<param index="1" name="vertex_format" type="int" />
+			<param index="2" name="src_buffers" type="RID[]" />
+			<description>
+				Creates a vertex array based on the specified buffers.
+			</description>
+		</method>
 		<method name="vertex_buffer_create">
 			<return type="RID" />
 			<param index="0" name="size_bytes" type="int" />

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -393,6 +393,7 @@ void RenderingDevice::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("vertex_buffer_create", "size_bytes", "data", "use_as_storage"), &RenderingDevice::vertex_buffer_create, DEFVAL(Vector<uint8_t>()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("vertex_format_create", "vertex_descriptions"), &RenderingDevice::_vertex_format_create);
+	ClassDB::bind_method(D_METHOD("vertex_array_create", "vertex_count", "vertex_format", "src_buffers"), &RenderingDevice::_vertex_array_create);
 
 	ClassDB::bind_method(D_METHOD("index_buffer_create", "size_indices", "format", "data", "use_restart_indices"), &RenderingDevice::index_buffer_create, DEFVAL(Vector<uint8_t>()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("index_array_create", "index_buffer", "index_offset", "index_count"), &RenderingDevice::index_array_create);


### PR DESCRIPTION
Resolves #59837

Trivial fix. Seems like just an oversight that this wasn't added to ClassDB, since the wrapper was already written.

I was able to verify that it works in a basic test:
https://github.com/pkdawson/rd_demo/blob/vertex-array/demo.gd
