### PR TITLE
[3.x] Fix Array.Shuffle incorrect mono bindings

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
@@ -326,7 +326,7 @@ namespace Godot.Collections
         internal static extern Error godot_icall_Array_Resize(IntPtr ptr, int newSize);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern Error godot_icall_Array_Shuffle(IntPtr ptr);
+        internal static extern void godot_icall_Array_Shuffle(IntPtr ptr);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern void godot_icall_Array_Generic_GetElementTypeInfo(Type elemType, out int elemTypeEncoding, out IntPtr elemTypeClass);

--- a/modules/mono/glue/collections_glue.h
+++ b/modules/mono/glue/collections_glue.h
@@ -71,6 +71,8 @@ void godot_icall_Array_RemoveAt(Array *ptr, int index);
 
 int32_t godot_icall_Array_Resize(Array *ptr, int new_size);
 
+void godot_icall_Array_Shuffle(Array *ptr);
+
 void godot_icall_Array_Generic_GetElementTypeInfo(MonoReflectionType *refltype, uint32_t *type_encoding, GDMonoClass **type_class);
 
 MonoString *godot_icall_Array_ToString(Array *ptr);


### PR DESCRIPTION
Fixes #60840
