### PR TITLE
Fix c# Array.Shuffle incorrect mono bindings

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -374,7 +374,7 @@ namespace Godot.NativeInterop
 
         public static partial Error godotsharp_array_resize(ref godot_array p_self, int p_new_size);
 
-        public static partial Error godotsharp_array_shuffle(ref godot_array p_self);
+        public static partial void godotsharp_array_shuffle(ref godot_array p_self);
 
         public static partial void godotsharp_array_to_string(ref godot_array p_self, out godot_string r_str);
 


### PR DESCRIPTION
This does not fix any bug, but it fixes an inconsistency I found on #68252. The function is defined as void.