### PR TITLE
Fixed Issue #68194 involving ColorPicker being allowed to align horizontally when it shouldn't

### DIFF
--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="ColorPicker" inherits="BoxContainer" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="ColorPicker" inherits="VBoxContainer" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Color picker control.
 	</brief_description>
@@ -76,7 +76,6 @@
 		<member name="presets_visible" type="bool" setter="set_presets_visible" getter="are_presets_visible" default="true">
 			If [code]true[/code], saved color presets are visible.
 		</member>
-		<member name="vertical" type="bool" setter="set_vertical" getter="is_vertical" overrides="BoxContainer" default="true" />
 	</members>
 	<signals>
 		<signal name="color_changed">

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1529,8 +1529,7 @@ void ColorPicker::_bind_methods() {
 	BIND_ENUM_CONSTANT(SHAPE_OKHSL_CIRCLE);
 }
 
-ColorPicker::ColorPicker() :
-		BoxContainer(true) {
+ColorPicker::ColorPicker() {
 	HBoxContainer *hb_edit = memnew(HBoxContainer);
 	add_child(hb_edit, false, INTERNAL_MODE_FRONT);
 	hb_edit->set_v_size_flags(SIZE_SHRINK_BEGIN);

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -68,8 +68,8 @@ public:
 	~ColorPresetButton();
 };
 
-class ColorPicker : public BoxContainer {
-	GDCLASS(ColorPicker, BoxContainer);
+class ColorPicker : public VBoxContainer {
+	GDCLASS(ColorPicker, VBoxContainer);
 
 public:
 	enum ColorModeType {


### PR DESCRIPTION
Fixed the ColorPicker class to disallow the vertical checkbox option in the editor and be set to vertical by default.

This fix was implemented by making the `ColorPicker` class a subclass of `VBoxContainer` and initializing with the `VBoxContainer` constructor.

*Bugsquad edit:* Fixes #68194
