### PR TITLE
Add GDExtension support for OpenXR extension wrappers

### DIFF
--- a/doc/classes/OpenXRAPIExtension.xml
+++ b/doc/classes/OpenXRAPIExtension.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRAPIExtension" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Makes the OpenXR API available for GDExtension.
+	</brief_description>
+	<description>
+		[OpenXRAPIExtension] makes OpenXR available for GDExtension. It provides the OpenXR API to GDExtension through the [method get_instance_proc_addr] method, and the OpenXR instance through [method get_instance].
+		It also provides methods for querying the status of OpenXR initialization, and helper methods for ease of use of the API with GDExtension.
+	</description>
+	<tutorials>
+		<link title="XrResult documentation">https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrResult.html</link>
+		<link title="XrInstance documentation">https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrInstance.html</link>
+		<link title="XrSpace documentation">https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrSpace.html</link>
+		<link title="XrSession documentation">https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrSession.html</link>
+		<link title="XrSystemId documentation">https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrSystemId.html</link>
+		<link title="xrBeginSession documentation">https://registry.khronos.org/OpenXR/specs/1.0/man/html/xrBeginSession.html</link>
+		<link title="XrPosef documentation">https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrPosef.html</link>
+	</tutorials>
+	<methods>
+		<method name="can_render">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if OpenXR is initialized for rendering with an XR viewport.
+			</description>
+		</method>
+		<method name="get_error_string">
+			<return type="String" />
+			<param index="0" name="result" type="int" />
+			<description>
+				Returns an error string for the given [url=https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrResult.html]XrResult[/url].
+			</description>
+		</method>
+		<method name="get_instance">
+			<return type="int" />
+			<description>
+				Returns the [url=https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrInstance.html]XrInstance[/url] created during the initialization of the OpenXR API.
+			</description>
+		</method>
+		<method name="get_instance_proc_addr">
+			<return type="int" />
+			<param index="0" name="name" type="String" />
+			<description>
+				Returns the function pointer of the OpenXR function with the specified name, cast to an integer. If the function with the given name does not exist, the method returns [code]0[/code].
+				[b]Note:[/b] [code]openxr/util.h[/code] contains utility macros for acquiring OpenXR functions, e.g. [code]GDEXTENSION_INIT_XR_FUNC_V(xrCreateAction)[/code].
+			</description>
+		</method>
+		<method name="get_next_frame_time">
+			<return type="int" />
+			<description>
+				Returns the timing for the next frame.
+			</description>
+		</method>
+		<method name="get_play_space">
+			<return type="int" />
+			<description>
+				Returns the play space, which is an [url=https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrSpace.html]XrSpace[/url] cast to an integer.
+			</description>
+		</method>
+		<method name="get_session">
+			<return type="int" />
+			<description>
+				Returns the OpenXR session, which is an [url=https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrSession.html]XrSession[/url] cast to an integer.
+			</description>
+		</method>
+		<method name="get_swapchain_format_name">
+			<return type="String" />
+			<param index="0" name="swapchain_format" type="int" />
+			<description>
+				Returns the name of the specified swapchain format.
+			</description>
+		</method>
+		<method name="get_system_id">
+			<return type="int" />
+			<description>
+				Returns the id of the system, which is a [url=https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrSystemId.html]XrSystemId[/url] cast to an integer.
+			</description>
+		</method>
+		<method name="is_initialized">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if OpenXR is initialized.
+			</description>
+		</method>
+		<method name="is_running">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if OpenXR is running ([url=https://registry.khronos.org/OpenXR/specs/1.0/man/html/xrBeginSession.html]xrBeginSession[/url] was successfully called and the swapchains were created).
+			</description>
+		</method>
+		<method name="openxr_is_enabled" qualifiers="static">
+			<return type="bool" />
+			<param index="0" name="check_run_in_editor" type="bool" />
+			<description>
+				Returns [code]true[/code] if OpenXR is enabled.
+			</description>
+		</method>
+		<method name="transform_from_pose">
+			<return type="Transform3D" />
+			<param index="0" name="pose" type="const void*" />
+			<description>
+				Creates a [Transform3D] from an [url=https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrPosef.html]XrPosef[/url].
+			</description>
+		</method>
+		<method name="xr_result">
+			<return type="bool" />
+			<param index="0" name="result" type="int" />
+			<param index="1" name="format" type="String" />
+			<param index="2" name="args" type="Array" />
+			<description>
+				Returns [code]true[/code] if the provided [url=https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrResult.html]XrResult[/url] (cast to an integer) is successful. Otherwise returns [code]false[/code] and prints the [url=https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrResult.html]XrResult[/url] converted to a string, with the specified additional information.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/OpenXRExtensionWrapperExtension.xml
+++ b/doc/classes/OpenXRExtensionWrapperExtension.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRExtensionWrapperExtension" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Allows clients to implement OpenXR extensions with GDExtension.
+	</brief_description>
+	<description>
+		[OpenXRExtensionWrapperExtension] allows clients to implement OpenXR extensions with GDExtension. The extension should be registered with [method register_extension_wrapper].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_get_requested_extensions" qualifiers="virtual">
+			<return type="Dictionary" />
+			<description>
+				Returns a [Dictionary] of OpenXR extensions related to this extension. The [Dictionary] should contain the name of the extension, mapped to a [code]bool *[/code] cast to an integer:
+				- If the [code]bool *[/code] is a [code]nullptr[/code] this extension is mandatory.
+				- If the [code]bool *[/code] points to a boolean, the boolean will be updated to [code]true[/code] if the extension is enabled.
+			</description>
+		</method>
+		<method name="_on_before_instance_created" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called before the OpenXR instance is created.
+			</description>
+		</method>
+		<method name="_on_event_polled" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="event" type="const void*" />
+			<description>
+				Called when there is an OpenXR event to process. When implementing, return [code]true[/code] if the event was handled, return [code]false[/code] otherwise.
+			</description>
+		</method>
+		<method name="_on_instance_created" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="instance" type="int" />
+			<description>
+				Called right after the OpenXR instance is created.
+			</description>
+		</method>
+		<method name="_on_instance_destroyed" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called right before the OpenXR instance is destroyed.
+			</description>
+		</method>
+		<method name="_on_pre_render" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called right before the XR viewports begin their rendering step.
+			</description>
+		</method>
+		<method name="_on_process" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called as part of the OpenXR process handling. This happens right before general and physics processing steps of the main loop. During this step controller data is queried and made available to game logic.
+			</description>
+		</method>
+		<method name="_on_register_metadata" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Allows extensions to register additional controller metadata. This function is called even when the OpenXR API is not constructed as the metadata needs to be available to the editor.
+				Extensions should also provide metadata regardless of whether they are supported on the host system. The controller data is used to setup action maps for users who may have access to the relevant hardware.
+			</description>
+		</method>
+		<method name="_on_session_created" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="session" type="int" />
+			<description>
+				Called right after the OpenXR session is created.
+			</description>
+		</method>
+		<method name="_on_session_destroyed" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called right before the OpenXR session is destroyed.
+			</description>
+		</method>
+		<method name="_on_state_exiting" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the OpenXR session state is changed to exiting.
+			</description>
+		</method>
+		<method name="_on_state_focused" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the OpenXR session state is changed to focused. This state is the active state when the game runs.
+			</description>
+		</method>
+		<method name="_on_state_idle" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the OpenXR session state is changed to idle.
+			</description>
+		</method>
+		<method name="_on_state_loss_pending" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the OpenXR session state is changed to loss pending.
+			</description>
+		</method>
+		<method name="_on_state_ready" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the OpenXR session state is changed to ready. This means OpenXR is ready to set up the session.
+			</description>
+		</method>
+		<method name="_on_state_stopping" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the OpenXR session state is changed to stopping.
+			</description>
+		</method>
+		<method name="_on_state_synchronized" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the OpenXR session state is changed to synchronized. OpenXR also returns to this state when the application loses focus.
+			</description>
+		</method>
+		<method name="_on_state_visible" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the OpenXR session state is changed to visible. This means OpenXR is now ready to receive frames.
+			</description>
+		</method>
+		<method name="_set_instance_create_info_and_get_next_pointer" qualifiers="virtual">
+			<return type="int" />
+			<param index="0" name="next_pointer" type="void*" />
+			<description>
+				Adds additional data structures when the OpenXR instance is created.
+			</description>
+		</method>
+		<method name="_set_session_create_and_get_next_pointer" qualifiers="virtual">
+			<return type="int" />
+			<param index="0" name="next_pointer" type="void*" />
+			<description>
+				Adds additional data structures when the OpenXR session is created.
+			</description>
+		</method>
+		<method name="_set_swapchain_create_info_and_get_next_pointer" qualifiers="virtual">
+			<return type="int" />
+			<param index="0" name="next_pointer" type="void*" />
+			<description>
+				Adds additional data structures when creating OpenXR swapchains.
+			</description>
+		</method>
+		<method name="_set_system_properties_and_get_next_pointer" qualifiers="virtual">
+			<return type="int" />
+			<param index="0" name="next_pointer" type="void*" />
+			<description>
+				Adds additional data structures when interogating OpenXR system abilities.
+			</description>
+		</method>
+		<method name="get_openxr_api">
+			<return type="OpenXRAPIExtension" />
+			<description>
+				Returns the created [OpenXRAPIExtension], which can be used to access the OpenXR API.
+			</description>
+		</method>
+		<method name="register_extension_wrapper">
+			<return type="void" />
+			<description>
+				Registers the extension. This should happen at core module initialization level.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -104,6 +104,8 @@ env_openxr.add_source_files(module_obj, "extensions/openxr_fb_display_refresh_ra
 env_openxr.add_source_files(module_obj, "extensions/openxr_pico_controller_extension.cpp")
 env_openxr.add_source_files(module_obj, "extensions/openxr_wmr_controller_extension.cpp")
 env_openxr.add_source_files(module_obj, "extensions/openxr_ml2_controller_extension.cpp")
+env_openxr.add_source_files(module_obj, "extensions/openxr_extension_wrapper_extension.cpp")
+env_openxr.add_source_files(module_obj, "extensions/openxr_api_extension.cpp")
 
 env.modules_sources += module_obj
 

--- a/modules/openxr/extensions/openxr_android_extension.cpp
+++ b/modules/openxr/extensions/openxr_android_extension.cpp
@@ -53,6 +53,7 @@ OpenXRAndroidExtension::OpenXRAndroidExtension() {
 HashMap<String, bool *> OpenXRAndroidExtension::get_requested_extensions() {
 	HashMap<String, bool *> request_extensions;
 
+	request_extensions[XR_KHR_LOADER_INIT_ANDROID_EXTENSION_NAME] = &loader_init_extension_available;
 	request_extensions[XR_KHR_ANDROID_CREATE_INSTANCE_EXTENSION_NAME] = &create_instance_extension_available;
 
 	return request_extensions;

--- a/modules/openxr/extensions/openxr_extension_wrapper_extension.cpp
+++ b/modules/openxr/extensions/openxr_extension_wrapper_extension.cpp
@@ -1,0 +1,207 @@
+/**************************************************************************/
+/*  openxr_extension_wrapper_extension.cpp                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "openxr_extension_wrapper_extension.h"
+
+#include "../openxr_api.h"
+
+void OpenXRExtensionWrapperExtension::_bind_methods() {
+	GDVIRTUAL_BIND(_get_requested_extensions);
+	GDVIRTUAL_BIND(_set_system_properties_and_get_next_pointer, "next_pointer");
+	GDVIRTUAL_BIND(_set_instance_create_info_and_get_next_pointer, "next_pointer");
+	GDVIRTUAL_BIND(_set_session_create_and_get_next_pointer, "next_pointer");
+	GDVIRTUAL_BIND(_set_swapchain_create_info_and_get_next_pointer, "next_pointer");
+	GDVIRTUAL_BIND(_on_register_metadata);
+	GDVIRTUAL_BIND(_on_before_instance_created);
+	GDVIRTUAL_BIND(_on_instance_created, "instance");
+	GDVIRTUAL_BIND(_on_instance_destroyed);
+	GDVIRTUAL_BIND(_on_session_created, "session");
+	GDVIRTUAL_BIND(_on_process);
+	GDVIRTUAL_BIND(_on_pre_render);
+	GDVIRTUAL_BIND(_on_session_destroyed);
+	GDVIRTUAL_BIND(_on_state_idle);
+	GDVIRTUAL_BIND(_on_state_ready);
+	GDVIRTUAL_BIND(_on_state_synchronized);
+	GDVIRTUAL_BIND(_on_state_visible);
+	GDVIRTUAL_BIND(_on_state_focused);
+	GDVIRTUAL_BIND(_on_state_stopping);
+	GDVIRTUAL_BIND(_on_state_loss_pending);
+	GDVIRTUAL_BIND(_on_state_exiting);
+	GDVIRTUAL_BIND(_on_event_polled, "event");
+
+	ClassDB::bind_method(D_METHOD("get_openxr_api"), &OpenXRExtensionWrapperExtension::get_openxr_api);
+	ClassDB::bind_method(D_METHOD("register_extension_wrapper"), &OpenXRExtensionWrapperExtension::register_extension_wrapper);
+}
+
+HashMap<String, bool *> OpenXRExtensionWrapperExtension::get_requested_extensions() {
+	Dictionary request_extension;
+
+	if (GDVIRTUAL_CALL(_get_requested_extensions, request_extension)) {
+		HashMap<String, bool *> result;
+		Array keys = request_extension.keys();
+		for (int i = 0; i < keys.size(); i++) {
+			String key = keys.get(i);
+			GDExtensionPtr<bool> value = VariantCaster<GDExtensionPtr<bool>>::cast(request_extension.get(key, GDExtensionPtr<bool>(nullptr)));
+			result.insert(key, value);
+		}
+		return result;
+	}
+
+	return HashMap<String, bool *>();
+}
+
+void *OpenXRExtensionWrapperExtension::set_system_properties_and_get_next_pointer(void *p_next_pointer) {
+	uint64_t pointer;
+
+	if (GDVIRTUAL_CALL(_set_system_properties_and_get_next_pointer, GDExtensionPtr<void>(p_next_pointer), pointer)) {
+		return reinterpret_cast<void *>(pointer);
+	}
+
+	return nullptr;
+}
+
+void *OpenXRExtensionWrapperExtension::set_instance_create_info_and_get_next_pointer(void *p_next_pointer) {
+	uint64_t pointer;
+
+	if (GDVIRTUAL_CALL(_set_instance_create_info_and_get_next_pointer, GDExtensionPtr<void>(p_next_pointer), pointer)) {
+		return reinterpret_cast<void *>(pointer);
+	}
+
+	return nullptr;
+}
+
+void *OpenXRExtensionWrapperExtension::set_session_create_and_get_next_pointer(void *p_next_pointer) {
+	uint64_t pointer;
+
+	if (GDVIRTUAL_CALL(_set_session_create_and_get_next_pointer, GDExtensionPtr<void>(p_next_pointer), pointer)) {
+		return reinterpret_cast<void *>(pointer);
+	}
+
+	return nullptr;
+}
+
+void *OpenXRExtensionWrapperExtension::set_swapchain_create_info_and_get_next_pointer(void *p_next_pointer) {
+	uint64_t pointer;
+
+	if (GDVIRTUAL_CALL(_set_swapchain_create_info_and_get_next_pointer, GDExtensionPtr<void>(p_next_pointer), pointer)) {
+		return reinterpret_cast<void *>(pointer);
+	}
+
+	return nullptr;
+}
+
+void OpenXRExtensionWrapperExtension::on_register_metadata() {
+	GDVIRTUAL_CALL(_on_register_metadata);
+}
+
+void OpenXRExtensionWrapperExtension::on_before_instance_created() {
+	GDVIRTUAL_CALL(_on_before_instance_created);
+}
+
+void OpenXRExtensionWrapperExtension::on_instance_created(const XrInstance p_instance) {
+	uint64_t instance = reinterpret_cast<uint64_t>(p_instance);
+	GDVIRTUAL_CALL(_on_instance_created, instance);
+}
+
+void OpenXRExtensionWrapperExtension::on_instance_destroyed() {
+	GDVIRTUAL_CALL(_on_instance_destroyed);
+}
+
+void OpenXRExtensionWrapperExtension::on_session_created(const XrSession p_session) {
+	uint64_t session = reinterpret_cast<uint64_t>(p_session);
+	GDVIRTUAL_CALL(_on_session_created, session);
+}
+
+void OpenXRExtensionWrapperExtension::on_process() {
+	GDVIRTUAL_CALL(_on_process);
+}
+
+void OpenXRExtensionWrapperExtension::on_pre_render() {
+	GDVIRTUAL_CALL(_on_pre_render);
+}
+
+void OpenXRExtensionWrapperExtension::on_session_destroyed() {
+	GDVIRTUAL_CALL(_on_session_destroyed);
+}
+
+void OpenXRExtensionWrapperExtension::on_state_idle() {
+	GDVIRTUAL_CALL(_on_state_idle);
+}
+
+void OpenXRExtensionWrapperExtension::on_state_ready() {
+	GDVIRTUAL_CALL(_on_state_ready);
+}
+
+void OpenXRExtensionWrapperExtension::on_state_synchronized() {
+	GDVIRTUAL_CALL(_on_state_synchronized);
+}
+
+void OpenXRExtensionWrapperExtension::on_state_visible() {
+	GDVIRTUAL_CALL(_on_state_visible);
+}
+
+void OpenXRExtensionWrapperExtension::on_state_focused() {
+	GDVIRTUAL_CALL(_on_state_focused);
+}
+
+void OpenXRExtensionWrapperExtension::on_state_stopping() {
+	GDVIRTUAL_CALL(_on_state_stopping);
+}
+
+void OpenXRExtensionWrapperExtension::on_state_loss_pending() {
+	GDVIRTUAL_CALL(_on_state_loss_pending);
+}
+
+void OpenXRExtensionWrapperExtension::on_state_exiting() {
+	GDVIRTUAL_CALL(_on_state_exiting);
+}
+
+bool OpenXRExtensionWrapperExtension::on_event_polled(const XrEventDataBuffer &p_event) {
+	bool event_polled;
+
+	if (GDVIRTUAL_CALL(_on_event_polled, GDExtensionConstPtr<void>(&p_event), event_polled)) {
+		return event_polled;
+	}
+
+	return false;
+}
+
+Ref<OpenXRAPIExtension> OpenXRExtensionWrapperExtension::get_openxr_api() {
+	return openxr_api;
+}
+
+void OpenXRExtensionWrapperExtension::register_extension_wrapper() {
+	OpenXRAPI::register_extension_wrapper(this);
+}
+
+OpenXRExtensionWrapperExtension::OpenXRExtensionWrapperExtension() :
+		Object(), OpenXRExtensionWrapper() {
+	openxr_api.instantiate();
+}

--- a/modules/openxr/extensions/openxr_extension_wrapper_extension.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper_extension.h
@@ -1,0 +1,115 @@
+/**************************************************************************/
+/*  openxr_extension_wrapper_extension.h                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef OPENXR_EXTENSION_WRAPPER_EXTENSION_H
+#define OPENXR_EXTENSION_WRAPPER_EXTENSION_H
+
+#include "../openxr_api_extension.h"
+#include "openxr_extension_wrapper.h"
+
+#include "core/object/ref_counted.h"
+#include "core/os/os.h"
+#include "core/os/thread_safe.h"
+#include "core/variant/native_ptr.h"
+
+class OpenXRExtensionWrapperExtension : public Object, OpenXRExtensionWrapper {
+	GDCLASS(OpenXRExtensionWrapperExtension, Object);
+
+protected:
+	_THREAD_SAFE_CLASS_
+
+	static void _bind_methods();
+
+	Ref<OpenXRAPIExtension> openxr_api;
+
+public:
+	virtual HashMap<String, bool *> get_requested_extensions() override;
+
+	GDVIRTUAL0R(Dictionary, _get_requested_extensions);
+
+	virtual void *set_system_properties_and_get_next_pointer(void *p_next_pointer) override;
+	virtual void *set_instance_create_info_and_get_next_pointer(void *p_next_pointer) override;
+	virtual void *set_session_create_and_get_next_pointer(void *p_next_pointer) override;
+	virtual void *set_swapchain_create_info_and_get_next_pointer(void *p_next_pointer) override;
+
+	//TODO workaround as GDExtensionPtr<void> return type results in build error in godot-cpp
+	GDVIRTUAL1R(uint64_t, _set_system_properties_and_get_next_pointer, GDExtensionPtr<void>);
+	GDVIRTUAL1R(uint64_t, _set_instance_create_info_and_get_next_pointer, GDExtensionPtr<void>);
+	GDVIRTUAL1R(uint64_t, _set_session_create_and_get_next_pointer, GDExtensionPtr<void>);
+	GDVIRTUAL1R(uint64_t, _set_swapchain_create_info_and_get_next_pointer, GDExtensionPtr<void>);
+
+	virtual void on_register_metadata() override;
+	virtual void on_before_instance_created() override;
+	virtual void on_instance_created(const XrInstance p_instance) override;
+	virtual void on_instance_destroyed() override;
+	virtual void on_session_created(const XrSession p_session) override;
+	virtual void on_process() override;
+	virtual void on_pre_render() override;
+	virtual void on_session_destroyed() override;
+
+	GDVIRTUAL0(_on_register_metadata);
+	GDVIRTUAL0(_on_before_instance_created);
+	GDVIRTUAL1(_on_instance_created, uint64_t);
+	GDVIRTUAL0(_on_instance_destroyed);
+	GDVIRTUAL1(_on_session_created, uint64_t);
+	GDVIRTUAL0(_on_process);
+	GDVIRTUAL0(_on_pre_render);
+	GDVIRTUAL0(_on_session_destroyed);
+
+	virtual void on_state_idle() override;
+	virtual void on_state_ready() override;
+	virtual void on_state_synchronized() override;
+	virtual void on_state_visible() override;
+	virtual void on_state_focused() override;
+	virtual void on_state_stopping() override;
+	virtual void on_state_loss_pending() override;
+	virtual void on_state_exiting() override;
+
+	GDVIRTUAL0(_on_state_idle);
+	GDVIRTUAL0(_on_state_ready);
+	GDVIRTUAL0(_on_state_synchronized);
+	GDVIRTUAL0(_on_state_visible);
+	GDVIRTUAL0(_on_state_focused);
+	GDVIRTUAL0(_on_state_stopping);
+	GDVIRTUAL0(_on_state_loss_pending);
+	GDVIRTUAL0(_on_state_exiting);
+
+	virtual bool on_event_polled(const XrEventDataBuffer &p_event) override;
+
+	GDVIRTUAL1R(bool, _on_event_polled, GDExtensionConstPtr<void>);
+
+	Ref<OpenXRAPIExtension> get_openxr_api();
+
+	void register_extension_wrapper();
+
+	OpenXRExtensionWrapperExtension();
+};
+
+#endif // OPENXR_EXTENSION_WRAPPER_EXTENSION_H

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -30,6 +30,7 @@
 
 #include "openxr_api.h"
 
+#include "extensions/openxr_extension_wrapper_extension.h"
 #include "openxr_interface.h"
 #include "openxr_util.h"
 

--- a/modules/openxr/openxr_api_extension.cpp
+++ b/modules/openxr/openxr_api_extension.cpp
@@ -1,0 +1,130 @@
+/**************************************************************************/
+/*  openxr_api_extension.cpp                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "openxr_api_extension.h"
+
+void OpenXRAPIExtension::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_instance"), &OpenXRAPIExtension::get_instance);
+	ClassDB::bind_method(D_METHOD("get_system_id"), &OpenXRAPIExtension::get_system_id);
+	ClassDB::bind_method(D_METHOD("get_session"), &OpenXRAPIExtension::get_session);
+
+	ClassDB::bind_method(D_METHOD("transform_from_pose", "pose"), &OpenXRAPIExtension::transform_from_pose);
+	ClassDB::bind_method(D_METHOD("xr_result", "result", "format", "args"), &OpenXRAPIExtension::xr_result);
+	ClassDB::bind_static_method("OpenXRAPIExtension", D_METHOD("openxr_is_enabled", "check_run_in_editor"), &OpenXRAPIExtension::openxr_is_enabled);
+	ClassDB::bind_method(D_METHOD("get_instance_proc_addr", "name"), &OpenXRAPIExtension::get_instance_proc_addr);
+	ClassDB::bind_method(D_METHOD("get_error_string", "result"), &OpenXRAPIExtension::get_error_string);
+	ClassDB::bind_method(D_METHOD("get_swapchain_format_name", "swapchain_format"), &OpenXRAPIExtension::get_swapchain_format_name);
+
+	ClassDB::bind_method(D_METHOD("is_initialized"), &OpenXRAPIExtension::is_initialized);
+	ClassDB::bind_method(D_METHOD("is_running"), &OpenXRAPIExtension::is_running);
+
+	ClassDB::bind_method(D_METHOD("get_play_space"), &OpenXRAPIExtension::get_play_space);
+	ClassDB::bind_method(D_METHOD("get_next_frame_time"), &OpenXRAPIExtension::get_next_frame_time);
+	ClassDB::bind_method(D_METHOD("can_render"), &OpenXRAPIExtension::can_render);
+}
+
+uint64_t OpenXRAPIExtension::get_instance() {
+	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), 0);
+	return (uint64_t)OpenXRAPI::get_singleton()->get_instance();
+}
+
+uint64_t OpenXRAPIExtension::get_system_id() {
+	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), 0);
+	return (uint64_t)OpenXRAPI::get_singleton()->get_system_id();
+}
+
+uint64_t OpenXRAPIExtension::get_session() {
+	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), 0);
+	return (uint64_t)OpenXRAPI::get_singleton()->get_session();
+}
+
+Transform3D OpenXRAPIExtension::transform_from_pose(GDExtensionConstPtr<const void> p_pose) {
+	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), Transform3D());
+	return OpenXRAPI::get_singleton()->transform_from_pose(*(XrPosef *)p_pose.data);
+}
+
+bool OpenXRAPIExtension::xr_result(uint64_t result, String format, Array args) {
+	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), false);
+	return OpenXRAPI::get_singleton()->xr_result((XrResult)result, format.utf8().get_data(), args);
+}
+
+bool OpenXRAPIExtension::openxr_is_enabled(bool p_check_run_in_editor) {
+	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), false);
+	return OpenXRAPI::openxr_is_enabled(p_check_run_in_editor);
+}
+
+uint64_t OpenXRAPIExtension::get_instance_proc_addr(String p_name) {
+	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), 0);
+	CharString str = p_name.utf8();
+	PFN_xrVoidFunction addr = nullptr;
+	XrResult result = OpenXRAPI::get_singleton()->get_instance_proc_addr(str.get_data(), &addr);
+	if (result != XR_SUCCESS) {
+		return 0;
+	}
+	return reinterpret_cast<uint64_t>(addr);
+}
+
+String OpenXRAPIExtension::get_error_string(uint64_t result) {
+	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), String());
+	return OpenXRAPI::get_singleton()->get_error_string((XrResult)result);
+}
+
+String OpenXRAPIExtension::get_swapchain_format_name(int64_t p_swapchain_format) {
+	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), String());
+	return OpenXRAPI::get_singleton()->get_swapchain_format_name(p_swapchain_format);
+}
+
+bool OpenXRAPIExtension::is_initialized() {
+	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), false);
+	return OpenXRAPI::get_singleton()->is_initialized();
+}
+
+bool OpenXRAPIExtension::is_running() {
+	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), false);
+	return OpenXRAPI::get_singleton()->is_running();
+}
+
+uint64_t OpenXRAPIExtension::get_play_space() {
+	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), 0);
+	return (uint64_t)OpenXRAPI::get_singleton()->get_play_space();
+}
+
+int64_t OpenXRAPIExtension::get_next_frame_time() {
+	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), 0);
+	return (XrTime)OpenXRAPI::get_singleton()->get_next_frame_time();
+}
+
+bool OpenXRAPIExtension::can_render() {
+	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), false);
+	return OpenXRAPI::get_singleton()->can_render();
+}
+
+OpenXRAPIExtension::OpenXRAPIExtension() {
+}

--- a/modules/openxr/openxr_api_extension.h
+++ b/modules/openxr/openxr_api_extension.h
@@ -1,0 +1,76 @@
+/**************************************************************************/
+/*  openxr_api_extension.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef OPENXR_API_EXTENSION_H
+#define OPENXR_API_EXTENSION_H
+
+#include "openxr_api.h"
+
+#include "core/object/ref_counted.h"
+#include "core/os/os.h"
+#include "core/os/thread_safe.h"
+#include "core/variant/native_ptr.h"
+
+class OpenXRAPIExtension : public RefCounted {
+	GDCLASS(OpenXRAPIExtension, RefCounted);
+
+protected:
+	_THREAD_SAFE_CLASS_
+
+	static void _bind_methods();
+
+public:
+	uint64_t get_instance();
+	uint64_t get_system_id();
+	uint64_t get_session();
+
+	// Helper method to convert an XrPosef to a Transform3D.
+	Transform3D transform_from_pose(GDExtensionConstPtr<const void> p_pose);
+
+	bool xr_result(uint64_t result, String format, Array args = Array());
+
+	static bool openxr_is_enabled(bool p_check_run_in_editor = true);
+
+	//TODO workaround as GDExtensionPtr<void> return type results in build error in godot-cpp
+	uint64_t get_instance_proc_addr(String p_name);
+	String get_error_string(uint64_t result);
+	String get_swapchain_format_name(int64_t p_swapchain_format);
+
+	bool is_initialized();
+	bool is_running();
+
+	uint64_t get_play_space();
+	int64_t get_next_frame_time();
+	bool can_render();
+
+	OpenXRAPIExtension();
+};
+
+#endif // OPENXR_API_EXTENSION_H

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -36,6 +36,9 @@
 #include "action_map/openxr_interaction_profile.h"
 #include "action_map/openxr_interaction_profile_meta_data.h"
 #include "openxr_interface.h"
+
+#include "extensions/openxr_extension_wrapper_extension.h"
+
 #include "scene/openxr_hand.h"
 
 #include "extensions/openxr_composition_layer_depth_extension.h"
@@ -87,6 +90,11 @@ static void _editor_init() {
 #endif
 
 void initialize_openxr_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_CORE) {
+		GDREGISTER_CLASS(OpenXRExtensionWrapperExtension);
+		GDREGISTER_CLASS(OpenXRAPIExtension);
+	}
+
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SERVERS) {
 		if (OpenXRAPI::openxr_is_enabled(false)) {
 			// Always register our extension wrappers even if we don't initialize OpenXR.

--- a/modules/openxr/util.h
+++ b/modules/openxr/util.h
@@ -58,6 +58,17 @@
 
 #define EXT_TRY_INIT_XR_FUNC(name) TRY_INIT_XR_FUNC(OpenXRAPI::get_singleton(), name)
 #define OPENXR_TRY_API_INIT_XR_FUNC(name) TRY_INIT_XR_FUNC(this, name)
+#define GDEXTENSION_INIT_XR_FUNC(name)                                                              \
+	do {                                                                                            \
+		name##_ptr = reinterpret_cast<PFN_##name>(get_openxr_api()->get_instance_proc_addr(#name)); \
+		ERR_FAIL_COND(name##_ptr == nullptr);                                                       \
+	} while (0)
+
+#define GDEXTENSION_INIT_XR_FUNC_V(name)                                                            \
+	do {                                                                                            \
+		name##_ptr = reinterpret_cast<PFN_##name>(get_openxr_api()->get_instance_proc_addr(#name)); \
+		ERR_FAIL_COND_V(name##_ptr == nullptr, false);                                              \
+	} while (0)
 
 #define EXT_PROTO_XRRESULT_FUNC1(func_name, arg1_type, arg1)                    \
 	PFN_##func_name func_name##_ptr = nullptr;                                  \


### PR DESCRIPTION
This commit adds the classes `OpenXRExtensionWrapperExtension` and `OpenXRAPIExtension` that can be used in GDExtensions to define OpenXR extension wrappers. It modifies extension wrapper registration so that they can be registered before `OpenXRAPI` instantiation (e.g. in core level initialization of GDExtensions).

As `OpenXRAPI` requires all extension wrappers to be registered upon initialization, the construction order of `OpenXRAPI` and the extension wrappers has been swapped, and extension wrappers now do not acquire the `OpenXRAPI` instance as a constructor parameter, but it is passed to them upon `OpenXRAPI` initialization through the `OpenXRExtensionWrapper::initialize()` method. This - along with making `registered_extension_wrappers` a static member of `OpenXRAPI` - allows us to register extension wrappers before `OpenXRAPI` construction.

Regarding the timing of extension wrapper registration, in the current design this needs to happen in core level extension initialization. The reason for this is that `OpenXRAPI` is currently instantiated and initialized at server level module initialization, which precedes server level extension initialization, so unless the Godot core is extended with an additional initialization level for OpenXR extension wrappers, they need to be initialized at core level.

OpenXR types are mapped to Godot's type system in the following way: XR handles (e.g. `XrSession`) are mapped to `uint64_t`. The same is true for enums such as `XrResult`. For structs such as `XrEventDataBuffer`, these are passed as pointers with `GDNativePtr`/`GDNativeConstPtr` instances. Currently there is an issue with the binding generator that results in a build error when `GDNativePtr`/`GDNativeConstPtr` is used as return type, so for these cases (e.g. `get_instance_proc_addr`) the current workaround is to pass the pointer as a 64-bit unsigned integer.

An issue that came up with GDExtensions in Godot 4.x is that library resources do not get properly globalized on Android: GDExtension libraries [can only be specified with resource paths](https://github.com/godotengine/godot/blob/master/editor/plugins/gdextension_export_plugin.h#L76), and the libraries get properly placed in the lib folder of the apk, but when loading the library, Godot tries to find it relative to the given resource path. To solve this issue, I modified `ProjectSettings::globalize_path()` so that on Android, libraries are loaded without their path specified. This fixes the issue of loading GDExtension libraries, although this might be considered a workaround, and further discussion might be needed on better ways to solve this issue.
```
+#ifdef ANDROID_ENABLED
+               if (p_path.ends_with(".so")) {
+                       return p_path.get_file();
+               }
+#endif
```

The PR also adds a new `"xr_features/use_anchor_api"` export setting, which is required for the implementation of extension wrappers for FB spatial anchors and scene capture.

Developed by [Migeran](https://migeran.com)