### PR TITLE
Tweak Callable's documentation

### DIFF
--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Callable" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		An object representing a method in a certain object that can be called.
+		Built-in type representing a method in an object instance or a standalone function.
 	</brief_description>
 	<description>
-		[Callable] is a first class object which can be held in variables and passed to functions. It represents a given method in an [Object], and is typically used for signal callbacks.
+		[Callable] is a built-in [Variant] type that represents a function. It can either be a method within an [Object] instance, or a standalone function not related to any object, like a lambda function. Like all [Variant] types, it can be stored in variables and passed to other functions. It is most commonly used for signal callbacks.
 		[b]Example:[/b]
 		[codeblocks]
 		[gdscript]
@@ -32,6 +32,18 @@
 		}
 		[/csharp]
 		[/codeblocks]
+		In GDScript, it's possible to create lambda functions within a method. Lambda functions are custom callables that are not associated with an [Object] instance. Optionally, lambda functions can also be named. The name will be displayed in the debugger, or when calling [method get_method].
+		[codeblock]
+		func _init():
+		    var my_lambda = func (message):
+		        print(message)
+
+		    # Prints Hello everyone!
+		    my_lambda.call("Hello everyone!")
+
+		    # Prints "Attack!", when the button_pressed signal is emitted.
+		    button_pressed.connect(func(): print("Attack!"))
+		[/codeblock]
 	</description>
 	<tutorials>
 	</tutorials>
@@ -39,7 +51,7 @@
 		<constructor name="Callable">
 			<return type="Callable" />
 			<description>
-				Constructs a null [Callable] with no object nor method bound.
+				Constructs an empty [Callable], with no object nor method bound.
 			</description>
 		</constructor>
 		<constructor name="Callable">
@@ -54,7 +66,7 @@
 			<param index="0" name="object" type="Object" />
 			<param index="1" name="method" type="StringName" />
 			<description>
-				Creates a new [Callable] for the method called [param method] in the specified [param object].
+				Creates a new [Callable] for the method named [param method] in the specified [param object].
 			</description>
 		</constructor>
 	</constructors>
@@ -62,7 +74,7 @@
 		<method name="bind" qualifiers="vararg const">
 			<return type="Callable" />
 			<description>
-				Returns a copy of this [Callable] with the arguments bound. Bound arguments are passed after the arguments supplied by [method call].
+				Returns a copy of this [Callable] with one or more arguments bound. When called, the bound arguments are passed [i]after[/i] the arguments supplied by [method call].
 			</description>
 		</method>
 		<method name="call" qualifiers="vararg const">
@@ -85,13 +97,13 @@
 			<return type="Variant" />
 			<param index="0" name="arguments" type="Array" />
 			<description>
-				Calls the method represented by this [Callable]. Contrary to [method call], this method does not take a variable number of arguments but expects all arguments to be passed via a single [Array].
+				Calls the method represented by this [Callable]. Unlike [method call], this method expects all arguments to be contained inside the [param arguments] [Array].
 			</description>
 		</method>
 		<method name="get_method" qualifiers="const">
 			<return type="StringName" />
 			<description>
-				Returns the name of the method represented by this [Callable].
+				Returns the name of the method represented by this [Callable]. If the callable is a lambda function, returns the function's name.
 			</description>
 		</method>
 		<method name="get_object" qualifiers="const">
@@ -116,7 +128,7 @@
 		<method name="is_custom" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if this [Callable] is a custom callable whose behavior differs based on implementation details. Custom callables are used in the engine for various reasons. If [code]true[/code], you can't use [method get_method].
+				Returns [code]true[/code] if this [Callable] is a custom callable. Custom callables are created from [method bind] or [method unbind]. In GDScript, lambda functions are also custom callables.
 			</description>
 		</method>
 		<method name="is_null" qualifiers="const">
@@ -128,33 +140,33 @@
 		<method name="is_standard" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if this [Callable] is a standard callable, referencing an object and a method using a [StringName].
+				Returns [code]true[/code] if this [Callable] is a standard callable. This method is the opposite of [method is_custom]. Returns [code]false[/code] if this callable is a lambda function.
 			</description>
 		</method>
 		<method name="is_valid" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the object exists and has a valid function assigned, or is a custom callable.
+				Returns [code]true[/code] if the callable's object exists and has a valid method name assigned, or is a custom callable.
 			</description>
 		</method>
 		<method name="rpc" qualifiers="vararg const">
 			<return type="void" />
 			<description>
-				Perform an RPC (Remote Procedure Call). This is used for multiplayer and is normally not available unless the function being called has been marked as [i]RPC[/i]. Calling it on unsupported functions will result in an error.
+				Perform an RPC (Remote Procedure Call). This is used for multiplayer and is normally not available, unless the function being called has been marked as [i]RPC[/i]. Calling this method on unsupported functions will result in an error.
 			</description>
 		</method>
 		<method name="rpc_id" qualifiers="vararg const">
 			<return type="void" />
 			<param index="0" name="peer_id" type="int" />
 			<description>
-				Perform an RPC (Remote Procedure Call) on a specific peer ID (see multiplayer documentation for reference). This is used for multiplayer and is normally not available unless the function being called has been marked as [i]RPC[/i]. Calling it on unsupported functions will result in an error.
+				Perform an RPC (Remote Procedure Call) on a specific peer ID (see multiplayer documentation for reference). This is used for multiplayer and is normally not available unless the function being called has been marked as [i]RPC[/i]. Calling this method on unsupported functions will result in an error.
 			</description>
 		</method>
 		<method name="unbind" qualifiers="const">
 			<return type="Callable" />
 			<param index="0" name="argcount" type="int" />
 			<description>
-				Returns a copy of this [Callable] with the arguments unbound. Calling the returned [Callable] will call the method without the extra arguments that are supplied in the [Callable] on which you are calling this method.
+				Returns a copy of this [Callable] with the arguments unbound, as defined by [param argcount]. Calling the returned [Callable] will call the method without the extra arguments that are supplied in the [Callable] on which you are calling this method.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Follow up to many of my documentation PRs, this one is unfortunately not as detailed, as I hoped it to be. 
I do not have enough knowledge of **Callable** to document it with confidence for the time being. Still, some outdated and misleading terms have been removed, so that's an upgrade. Wish I could've done something more with the verbosity that make **Callable** look more complicated than it actually is, but it is what it is for now.

- Clarify that **Callable** is a Variant type, not an Object.
- Add GDScript lambda function example.
- Update outdated description of `is_custom` and `is_valid`.
- Some tweaks all around. 

If you find some more misleading or very confusing terminology, as always, you may use this PR as a "catch-all" to propose further suggestions before it gets merged.
