### PR TITLE
[Tests] Replace Math::is_equal_approx with == and doctest::Approx

### DIFF
--- a/tests/core/io/test_json.h
+++ b/tests/core/io/test_json.h
@@ -83,7 +83,7 @@ TEST_CASE("[JSON] Parsing single data types") {
 			json.get_error_line() == 0,
 			"Parsing a floating-point number as JSON should parse successfully.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(double(json.get_data()), 0.123456),
+			double(json.get_data()) == doctest::Approx(0.123456),
 			"Parsing a floating-point number as JSON should return the expected value.");
 
 	json.parse("\"hello\"");

--- a/tests/core/math/test_aabb.h
+++ b/tests/core/math/test_aabb.h
@@ -91,7 +91,7 @@ TEST_CASE("[AABB] Basic setters") {
 TEST_CASE("[AABB] Volume getters") {
 	AABB aabb = AABB(Vector3(-1.5, 2, -2.5), Vector3(4, 5, 6));
 	CHECK_MESSAGE(
-			Math::is_equal_approx(aabb.get_volume(), 120),
+			aabb.get_volume() == doctest::Approx(120),
 			"get_volume() should return the expected value with positive size.");
 	CHECK_MESSAGE(
 			aabb.has_volume(),
@@ -99,17 +99,17 @@ TEST_CASE("[AABB] Volume getters") {
 
 	aabb = AABB(Vector3(-1.5, 2, -2.5), Vector3(-4, 5, 6));
 	CHECK_MESSAGE(
-			Math::is_equal_approx(aabb.get_volume(), -120),
+			aabb.get_volume() == doctest::Approx(-120),
 			"get_volume() should return the expected value with negative size (1 component).");
 
 	aabb = AABB(Vector3(-1.5, 2, -2.5), Vector3(-4, -5, 6));
 	CHECK_MESSAGE(
-			Math::is_equal_approx(aabb.get_volume(), 120),
+			aabb.get_volume() == doctest::Approx(120),
 			"get_volume() should return the expected value with negative size (2 components).");
 
 	aabb = AABB(Vector3(-1.5, 2, -2.5), Vector3(-4, -5, -6));
 	CHECK_MESSAGE(
-			Math::is_equal_approx(aabb.get_volume(), -120),
+			aabb.get_volume() == doctest::Approx(-120),
 			"get_volume() should return the expected value with negative size (3 components).");
 
 	aabb = AABB(Vector3(-1.5, 2, -2.5), Vector3(4, 0, 6));

--- a/tests/core/math/test_basis.h
+++ b/tests/core/math/test_basis.h
@@ -223,7 +223,7 @@ TEST_CASE("[Basis] Set axis angle") {
 	// Testing the singularity when the angle is 180°.
 	Basis singularityPi(-1, 0, 0, 0, 1, 0, 0, 0, -1);
 	singularityPi.get_axis_angle(axis, angle);
-	CHECK(Math::is_equal_approx(angle, pi));
+	CHECK(angle == doctest::Approx(pi));
 
 	// Testing reversing the an axis (of an 30° angle).
 	float cos30deg = Math::cos(Math::deg_to_rad((real_t)30.0));
@@ -231,17 +231,17 @@ TEST_CASE("[Basis] Set axis angle") {
 	Basis z_negative(cos30deg, 0.5, 0, -0.5, cos30deg, 0, 0, 0, 1);
 
 	z_positive.get_axis_angle(axis, angle);
-	CHECK(Math::is_equal_approx(angle, Math::deg_to_rad((real_t)30.0)));
+	CHECK(angle == doctest::Approx(Math::deg_to_rad((real_t)30.0)));
 	CHECK(axis == Vector3(0, 0, 1));
 
 	z_negative.get_axis_angle(axis, angle);
-	CHECK(Math::is_equal_approx(angle, Math::deg_to_rad((real_t)30.0)));
+	CHECK(angle == doctest::Approx(Math::deg_to_rad((real_t)30.0)));
 	CHECK(axis == Vector3(0, 0, -1));
 
 	// Testing a rotation of 90° on x-y-z.
 	Basis x90deg(1, 0, 0, 0, 0, -1, 0, 1, 0);
 	x90deg.get_axis_angle(axis, angle);
-	CHECK(Math::is_equal_approx(angle, pi / (real_t)2));
+	CHECK(angle == doctest::Approx(pi / (real_t)2));
 	CHECK(axis == Vector3(1, 0, 0));
 
 	Basis y90deg(0, 0, 1, 0, 1, 0, -1, 0, 0);
@@ -255,7 +255,7 @@ TEST_CASE("[Basis] Set axis angle") {
 	// Regression test: checks that the method returns a small angle (not 0).
 	Basis tiny(1, 0, 0, 0, 0.9999995, -0.001, 0, 001, 0.9999995); // The min angle possible with float is 0.001rad.
 	tiny.get_axis_angle(axis, angle);
-	CHECK(Math::is_equal_approx(angle, (real_t)0.001, (real_t)0.0001));
+	CHECK(angle == doctest::Approx(0.001).epsilon(0.0001));
 
 	// Regression test: checks that the method returns an angle which is a number (not NaN)
 	Basis bugNan(1.00000024, 0, 0.000100001693, 0, 1, 0, -0.000100009143, 0, 1.00000024);

--- a/tests/core/math/test_color.h
+++ b/tests/core/math/test_color.h
@@ -101,13 +101,13 @@ TEST_CASE("[Color] Reading methods") {
 	const Color dark_blue = Color(0, 0, 0.5, 0.4);
 
 	CHECK_MESSAGE(
-			Math::is_equal_approx(dark_blue.get_h(), 240.0f / 360.0f),
+			dark_blue.get_h() == doctest::Approx(240.0f / 360.0f),
 			"The returned HSV hue should match the expected value.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(dark_blue.get_s(), 1.0f),
+			dark_blue.get_s() == doctest::Approx(1.0f),
 			"The returned HSV saturation should match the expected value.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(dark_blue.get_v(), 0.5f),
+			dark_blue.get_v() == doctest::Approx(0.5f),
 			"The returned HSV value should match the expected value.");
 }
 

--- a/tests/core/math/test_expression.h
+++ b/tests/core/math/test_expression.h
@@ -83,42 +83,42 @@ TEST_CASE("[Expression] Floating-point arithmetic") {
 			expression.parse("-123.456") == OK,
 			"Float identity should parse successfully.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(double(expression.execute()), -123.456),
+			double(expression.execute()) == doctest::Approx(-123.456),
 			"Float identity should return the expected result.");
 
 	CHECK_MESSAGE(
 			expression.parse("2.0 + 3.0") == OK,
 			"Float addition should parse successfully.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(double(expression.execute()), 5),
+			double(expression.execute()) == doctest::Approx(5),
 			"Float addition should return the expected result.");
 
 	CHECK_MESSAGE(
 			expression.parse("3.0 / 10") == OK,
 			"Float / integer division should parse successfully.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(double(expression.execute()), 0.3),
+			double(expression.execute()) == doctest::Approx(0.3),
 			"Float / integer division should return the expected result.");
 
 	CHECK_MESSAGE(
 			expression.parse("3 / 10.0") == OK,
 			"Basic integer / float division should parse successfully.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(double(expression.execute()), 0.3),
+			double(expression.execute()) == doctest::Approx(0.3),
 			"Basic integer / float division should return the expected result.");
 
 	CHECK_MESSAGE(
 			expression.parse("3.0 / 10.0") == OK,
 			"Float / float division should parse successfully.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(double(expression.execute()), 0.3),
+			double(expression.execute()) == doctest::Approx(0.3),
 			"Float / float division should return the expected result.");
 
 	CHECK_MESSAGE(
 			expression.parse("2.5 * (6.0 + 14.25) / 2.0 - 5.12345") == OK,
 			"Float multiplication-addition-subtraction-division should parse successfully.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(double(expression.execute()), 20.18905),
+			double(expression.execute()) == doctest::Approx(20.18905),
 			"Float multiplication-addition-subtraction-division should return the expected result.");
 }
 
@@ -129,7 +129,7 @@ TEST_CASE("[Expression] Scientific notation") {
 			expression.parse("2.e5") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(double(expression.execute()), 200'000),
+			double(expression.execute()) == doctest::Approx(200'000),
 			"The expression should return the expected result.");
 
 	// The middle "e" is ignored here.
@@ -137,14 +137,14 @@ TEST_CASE("[Expression] Scientific notation") {
 			expression.parse("2e5") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(double(expression.execute()), 2e5),
+			double(expression.execute()) == doctest::Approx(2e5),
 			"The expression should return the expected result.");
 
 	CHECK_MESSAGE(
 			expression.parse("2e.5") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(double(expression.execute()), 2),
+			double(expression.execute()) == doctest::Approx(2),
 			"The expression should return the expected result.");
 }
 
@@ -176,7 +176,7 @@ TEST_CASE("[Expression] Built-in functions") {
 			expression.parse("snapped(sin(0.5), 0.01)") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(double(expression.execute()), 0.48),
+			double(expression.execute()) == doctest::Approx(0.48),
 			"`snapped(sin(0.5), 0.01)` should return the expected result.");
 
 	CHECK_MESSAGE(

--- a/tests/core/math/test_geometry_2d.h
+++ b/tests/core/math/test_geometry_2d.h
@@ -171,43 +171,43 @@ TEST_CASE("[Geometry2D] Segment intersection with circle") {
 	real_t one = 1.0;
 
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Geometry2D::segment_intersects_circle(Vector2(0, 0), Vector2(4, 0), Vector2(0, 0), 1.0), one_quarter),
+			Geometry2D::segment_intersects_circle(Vector2(0, 0), Vector2(4, 0), Vector2(0, 0), 1.0) == doctest::Approx(one_quarter),
 			"Segment from inside to outside of circle should intersect it.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Geometry2D::segment_intersects_circle(Vector2(4, 0), Vector2(0, 0), Vector2(0, 0), 1.0), three_quarters),
+			Geometry2D::segment_intersects_circle(Vector2(4, 0), Vector2(0, 0), Vector2(0, 0), 1.0) == doctest::Approx(three_quarters),
 			"Segment from outside to inside of circle should intersect it.");
 
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Geometry2D::segment_intersects_circle(Vector2(-2, 0), Vector2(2, 0), Vector2(0, 0), 1.0), one_quarter),
+			Geometry2D::segment_intersects_circle(Vector2(-2, 0), Vector2(2, 0), Vector2(0, 0), 1.0) == doctest::Approx(one_quarter),
 			"Segment running through circle should intersect it.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Geometry2D::segment_intersects_circle(Vector2(2, 0), Vector2(-2, 0), Vector2(0, 0), 1.0), one_quarter),
+			Geometry2D::segment_intersects_circle(Vector2(2, 0), Vector2(-2, 0), Vector2(0, 0), 1.0) == doctest::Approx(one_quarter),
 			"Segment running through circle should intersect it.");
 
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Geometry2D::segment_intersects_circle(Vector2(0, 0), Vector2(1, 0), Vector2(0, 0), 1.0), one),
+			Geometry2D::segment_intersects_circle(Vector2(0, 0), Vector2(1, 0), Vector2(0, 0), 1.0) == doctest::Approx(one),
 			"Segment starting inside the circle and ending on the circle should intersect it");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Geometry2D::segment_intersects_circle(Vector2(1, 0), Vector2(0, 0), Vector2(0, 0), 1.0), zero),
+			Geometry2D::segment_intersects_circle(Vector2(1, 0), Vector2(0, 0), Vector2(0, 0), 1.0) == doctest::Approx(zero),
 			"Segment starting on the circle and going inwards should intersect it");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Geometry2D::segment_intersects_circle(Vector2(1, 0), Vector2(2, 0), Vector2(0, 0), 1.0), zero),
+			Geometry2D::segment_intersects_circle(Vector2(1, 0), Vector2(2, 0), Vector2(0, 0), 1.0) == doctest::Approx(zero),
 			"Segment starting on the circle and going outwards should intersect it");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Geometry2D::segment_intersects_circle(Vector2(2, 0), Vector2(1, 0), Vector2(0, 0), 1.0), one),
+			Geometry2D::segment_intersects_circle(Vector2(2, 0), Vector2(1, 0), Vector2(0, 0), 1.0) == doctest::Approx(one),
 			"Segment starting outside the circle and ending on the circle intersect it");
 
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Geometry2D::segment_intersects_circle(Vector2(-1, 0), Vector2(1, 0), Vector2(0, 0), 2.0), minus_one),
+			Geometry2D::segment_intersects_circle(Vector2(-1, 0), Vector2(1, 0), Vector2(0, 0), 2.0) == doctest::Approx(minus_one),
 			"Segment completely within the circle should not intersect it");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Geometry2D::segment_intersects_circle(Vector2(1, 0), Vector2(-1, 0), Vector2(0, 0), 2.0), minus_one),
+			Geometry2D::segment_intersects_circle(Vector2(1, 0), Vector2(-1, 0), Vector2(0, 0), 2.0) == doctest::Approx(minus_one),
 			"Segment completely within the circle should not intersect it");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Geometry2D::segment_intersects_circle(Vector2(2, 0), Vector2(3, 0), Vector2(0, 0), 1.0), minus_one),
+			Geometry2D::segment_intersects_circle(Vector2(2, 0), Vector2(3, 0), Vector2(0, 0), 1.0) == doctest::Approx(minus_one),
 			"Segment completely outside the circle should not intersect it");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Geometry2D::segment_intersects_circle(Vector2(3, 0), Vector2(2, 0), Vector2(0, 0), 1.0), minus_one),
+			Geometry2D::segment_intersects_circle(Vector2(3, 0), Vector2(2, 0), Vector2(0, 0), 1.0) == doctest::Approx(minus_one),
 			"Segment completely outside the circle should not intersect it");
 }
 

--- a/tests/core/math/test_rect2.h
+++ b/tests/core/math/test_rect2.h
@@ -102,16 +102,16 @@ TEST_CASE("[Rect2] Basic setters") {
 
 TEST_CASE("[Rect2] Area getters") {
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Rect2(0, 100, 1280, 720).get_area(), 921'600),
+			Rect2(0, 100, 1280, 720).get_area() == doctest::Approx(921'600),
 			"get_area() should return the expected value.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Rect2(0, 100, -1280, -720).get_area(), 921'600),
+			Rect2(0, 100, -1280, -720).get_area() == doctest::Approx(921'600),
 			"get_area() should return the expected value.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Rect2(0, 100, 1280, -720).get_area(), -921'600),
+			Rect2(0, 100, 1280, -720).get_area() == doctest::Approx(-921'600),
 			"get_area() should return the expected value.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Rect2(0, 100, -1280, 720).get_area(), -921'600),
+			Rect2(0, 100, -1280, 720).get_area() == doctest::Approx(-921'600),
 			"get_area() should return the expected value.");
 	CHECK_MESSAGE(
 			Math::is_zero_approx(Rect2(0, 100, 0, 720).get_area()),

--- a/tests/core/math/test_vector2.h
+++ b/tests/core/math/test_vector2.h
@@ -49,16 +49,16 @@ TEST_CASE("[Vector2] Angle methods") {
 	const Vector2 vector_x = Vector2(1, 0);
 	const Vector2 vector_y = Vector2(0, 1);
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector_x.angle_to(vector_y), (real_t)Math_TAU / 4),
+			vector_x.angle_to(vector_y) == doctest::Approx((real_t)Math_TAU / 4),
 			"Vector2 angle_to should work as expected.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector_y.angle_to(vector_x), (real_t)-Math_TAU / 4),
+			vector_y.angle_to(vector_x) == doctest::Approx((real_t)-Math_TAU / 4),
 			"Vector2 angle_to should work as expected.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector_x.angle_to_point(vector_y), (real_t)Math_TAU * 3 / 8),
+			vector_x.angle_to_point(vector_y) == doctest::Approx((real_t)Math_TAU * 3 / 8),
 			"Vector2 angle_to_point should work as expected.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector_y.angle_to_point(vector_x), (real_t)-Math_TAU / 8),
+			vector_y.angle_to_point(vector_x) == doctest::Approx((real_t)-Math_TAU / 8),
 			"Vector2 angle_to_point should work as expected.");
 }
 
@@ -113,10 +113,10 @@ TEST_CASE("[Vector2] Interpolation methods") {
 			Vector2(4, 6).slerp(Vector2(8, 10), 0.5).is_equal_approx(Vector2(5.9076470794008017626, 8.07918879020090480697)),
 			"Vector2 slerp should work as expected.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector1.slerp(vector2, 0.5).length(), (real_t)4.31959610746631919),
+			vector1.slerp(vector2, 0.5).length() == doctest::Approx((real_t)4.31959610746631919),
 			"Vector2 slerp with different length input should return a vector with an interpolated length.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector1.angle_to(vector1.slerp(vector2, 0.5)) * 2, vector1.angle_to(vector2)),
+			vector1.angle_to(vector1.slerp(vector2, 0.5)) * 2 == doctest::Approx(vector1.angle_to(vector2)),
 			"Vector2 slerp with different length input should return a vector with an interpolated angle.");
 	CHECK_MESSAGE(
 			vector1.cubic_interpolate(vector2, Vector2(), Vector2(7, 7), 0.5) == Vector2(2.375, 3.5),
@@ -136,19 +136,19 @@ TEST_CASE("[Vector2] Length methods") {
 			vector1.length_squared() == 200,
 			"Vector2 length_squared should work as expected and return exact result.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector1.length(), 10 * (real_t)Math_SQRT2),
+			vector1.length() == doctest::Approx(10 * (real_t)Math_SQRT2),
 			"Vector2 length should work as expected.");
 	CHECK_MESSAGE(
 			vector2.length_squared() == 1300,
 			"Vector2 length_squared should work as expected and return exact result.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector2.length(), (real_t)36.05551275463989293119),
+			vector2.length() == doctest::Approx((real_t)36.05551275463989293119),
 			"Vector2 length should work as expected.");
 	CHECK_MESSAGE(
 			vector1.distance_squared_to(vector2) == 500,
 			"Vector2 distance_squared_to should work as expected and return exact result.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector1.distance_to(vector2), (real_t)22.36067977499789696409),
+			vector1.distance_to(vector2) == doctest::Approx((real_t)22.36067977499789696409),
 			"Vector2 distance_to should work as expected.");
 }
 
@@ -294,7 +294,7 @@ TEST_CASE("[Vector2] Operators") {
 TEST_CASE("[Vector2] Other methods") {
 	const Vector2 vector = Vector2(1.2, 3.4);
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector.aspect(), (real_t)1.2 / (real_t)3.4),
+			vector.aspect() == doctest::Approx((real_t)1.2 / (real_t)3.4),
 			"Vector2 aspect should work as expected.");
 
 	CHECK_MESSAGE(
@@ -443,10 +443,10 @@ TEST_CASE("[Vector2] Linear algebra methods") {
 			vector_y.cross(vector_x) == -1,
 			"Vector2 cross product of Y and X should give negative 1.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(a.cross(b), (real_t)-28.1),
+			a.cross(b) == doctest::Approx((real_t)-28.1),
 			"Vector2 cross should return expected value.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Vector2(-a.x, a.y).cross(Vector2(b.x, -b.y)), (real_t)-28.1),
+			Vector2(-a.x, a.y).cross(Vector2(b.x, -b.y)) == doctest::Approx((real_t)-28.1),
 			"Vector2 cross should return expected value.");
 
 	CHECK_MESSAGE(
@@ -459,10 +459,10 @@ TEST_CASE("[Vector2] Linear algebra methods") {
 			(vector_x * 10).dot(vector_x * 10) == 100.0,
 			"Vector2 dot product of same direction vectors should behave as expected.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(a.dot(b), (real_t)57.3),
+			a.dot(b) == doctest::Approx((real_t)57.3),
 			"Vector2 dot should return expected value.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Vector2(-a.x, a.y).dot(Vector2(b.x, -b.y)), (real_t)-57.3),
+			Vector2(-a.x, a.y).dot(Vector2(b.x, -b.y)) == doctest::Approx((real_t)-57.3),
 			"Vector2 dot should return expected value.");
 }
 

--- a/tests/core/math/test_vector2i.h
+++ b/tests/core/math/test_vector2i.h
@@ -79,13 +79,13 @@ TEST_CASE("[Vector2i] Length methods") {
 			vector1.length_squared() == 200,
 			"Vector2i length_squared should work as expected and return exact result.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector1.length(), 10 * Math_SQRT2),
+			vector1.length() == doctest::Approx(10 * Math_SQRT2),
 			"Vector2i length should work as expected.");
 	CHECK_MESSAGE(
 			vector2.length_squared() == 1300,
 			"Vector2i length_squared should work as expected and return exact result.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector2.length(), 36.05551275463989293119),
+			vector2.length() == doctest::Approx(36.05551275463989293119),
 			"Vector2i length should work as expected.");
 }
 
@@ -127,7 +127,7 @@ TEST_CASE("[Vector2i] Operators") {
 TEST_CASE("[Vector2i] Other methods") {
 	const Vector2i vector = Vector2i(1, 3);
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector.aspect(), (real_t)1.0 / (real_t)3.0),
+			vector.aspect() == doctest::Approx((real_t)1.0 / (real_t)3.0),
 			"Vector2i aspect should work as expected.");
 
 	CHECK_MESSAGE(

--- a/tests/core/math/test_vector3.h
+++ b/tests/core/math/test_vector3.h
@@ -52,26 +52,26 @@ TEST_CASE("[Vector3] Angle methods") {
 	const Vector3 vector_y = Vector3(0, 1, 0);
 	const Vector3 vector_yz = Vector3(0, 1, 1);
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector_x.angle_to(vector_y), (real_t)Math_TAU / 4),
+			vector_x.angle_to(vector_y) == doctest::Approx((real_t)Math_TAU / 4),
 			"Vector3 angle_to should work as expected.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector_x.angle_to(vector_yz), (real_t)Math_TAU / 4),
+			vector_x.angle_to(vector_yz) == doctest::Approx((real_t)Math_TAU / 4),
 			"Vector3 angle_to should work as expected.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector_yz.angle_to(vector_x), (real_t)Math_TAU / 4),
+			vector_yz.angle_to(vector_x) == doctest::Approx((real_t)Math_TAU / 4),
 			"Vector3 angle_to should work as expected.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector_y.angle_to(vector_yz), (real_t)Math_TAU / 8),
+			vector_y.angle_to(vector_yz) == doctest::Approx((real_t)Math_TAU / 8),
 			"Vector3 angle_to should work as expected.");
 
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector_x.signed_angle_to(vector_y, vector_y), (real_t)Math_TAU / 4),
+			vector_x.signed_angle_to(vector_y, vector_y) == doctest::Approx((real_t)Math_TAU / 4),
 			"Vector3 signed_angle_to edge case should be positive.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector_x.signed_angle_to(vector_yz, vector_y), (real_t)Math_TAU / -4),
+			vector_x.signed_angle_to(vector_yz, vector_y) == doctest::Approx((real_t)Math_TAU / -4),
 			"Vector3 signed_angle_to should work as expected.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector_yz.signed_angle_to(vector_x, vector_y), (real_t)Math_TAU / 4),
+			vector_yz.signed_angle_to(vector_x, vector_y) == doctest::Approx((real_t)Math_TAU / 4),
 			"Vector3 signed_angle_to should work as expected.");
 }
 
@@ -130,10 +130,10 @@ TEST_CASE("[Vector3] Interpolation methods") {
 			Vector3(4, 6, 2).slerp(Vector3(8, 10, 3), 0.5).is_equal_approx(Vector3(5.90194219811429941053, 8.06758688849378394534, 2.558307894718317120038)),
 			"Vector3 slerp should work as expected.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector1.slerp(vector2, 0.5).length(), (real_t)6.25831088708303172),
+			vector1.slerp(vector2, 0.5).length() == doctest::Approx((real_t)6.25831088708303172),
 			"Vector3 slerp with different length input should return a vector with an interpolated length.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector1.angle_to(vector1.slerp(vector2, 0.5)) * 2, vector1.angle_to(vector2)),
+			vector1.angle_to(vector1.slerp(vector2, 0.5)) * 2 == doctest::Approx(vector1.angle_to(vector2)),
 			"Vector3 slerp with different length input should return a vector with an interpolated angle.");
 	CHECK_MESSAGE(
 			vector1.cubic_interpolate(vector2, Vector3(), Vector3(7, 7, 7), 0.5) == Vector3(2.375, 3.5, 4.625),
@@ -153,19 +153,19 @@ TEST_CASE("[Vector3] Length methods") {
 			vector1.length_squared() == 300,
 			"Vector3 length_squared should work as expected and return exact result.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector1.length(), 10 * (real_t)Math_SQRT3),
+			vector1.length() == doctest::Approx(10 * (real_t)Math_SQRT3),
 			"Vector3 length should work as expected.");
 	CHECK_MESSAGE(
 			vector2.length_squared() == 2900,
 			"Vector3 length_squared should work as expected and return exact result.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector2.length(), (real_t)53.8516480713450403125),
+			vector2.length() == doctest::Approx((real_t)53.8516480713450403125),
 			"Vector3 length should work as expected.");
 	CHECK_MESSAGE(
 			vector1.distance_squared_to(vector2) == 1400,
 			"Vector3 distance_squared_to should work as expected and return exact result.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector1.distance_to(vector2), (real_t)37.41657386773941385584),
+			vector1.distance_to(vector2) == doctest::Approx((real_t)37.41657386773941385584),
 			"Vector3 distance_to should work as expected.");
 }
 
@@ -473,10 +473,10 @@ TEST_CASE("[Vector3] Linear algebra methods") {
 			(vector_x * 10).dot(vector_x * 10) == 100.0,
 			"Vector3 dot product of same direction vectors should behave as expected.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(a.dot(b), (real_t)75.24),
+			a.dot(b) == doctest::Approx((real_t)75.24),
 			"Vector3 dot should return expected value.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(Vector3(-a.x, a.y, -a.z).dot(Vector3(b.x, -b.y, b.z)), (real_t)-75.24),
+			Vector3(-a.x, a.y, -a.z).dot(Vector3(b.x, -b.y, b.z)) == doctest::Approx((real_t)-75.24),
 			"Vector3 dot should return expected value.");
 }
 

--- a/tests/core/math/test_vector3i.h
+++ b/tests/core/math/test_vector3i.h
@@ -82,13 +82,13 @@ TEST_CASE("[Vector3i] Length methods") {
 			vector1.length_squared() == 300,
 			"Vector3i length_squared should work as expected and return exact result.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector1.length(), 10 * Math_SQRT3),
+			vector1.length() == doctest::Approx(10 * Math_SQRT3),
 			"Vector3i length should work as expected.");
 	CHECK_MESSAGE(
 			vector2.length_squared() == 2900,
 			"Vector3i length_squared should work as expected and return exact result.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector2.length(), 53.8516480713450403125),
+			vector2.length() == doctest::Approx(53.8516480713450403125),
 			"Vector3i length should work as expected.");
 }
 

--- a/tests/core/math/test_vector4.h
+++ b/tests/core/math/test_vector4.h
@@ -91,19 +91,19 @@ TEST_CASE("[Vector4] Length methods") {
 			vector1.length_squared() == 400,
 			"Vector4 length_squared should work as expected and return exact result.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector1.length(), 20),
+			vector1.length() == doctest::Approx(20),
 			"Vector4 length should work as expected.");
 	CHECK_MESSAGE(
 			vector2.length_squared() == 5400,
 			"Vector4 length_squared should work as expected and return exact result.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector2.length(), (real_t)73.484692283495),
+			vector2.length() == doctest::Approx((real_t)73.484692283495),
 			"Vector4 length should work as expected.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector1.distance_to(vector2), (real_t)54.772255750517),
+			vector1.distance_to(vector2) == doctest::Approx((real_t)54.772255750517),
 			"Vector4 distance_to should work as expected.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector1.distance_squared_to(vector2), 3000),
+			vector1.distance_squared_to(vector2) == doctest::Approx(3000),
 			"Vector4 distance_squared_to should work as expected.");
 }
 
@@ -311,7 +311,7 @@ TEST_CASE("[Vector4] Linear algebra methods") {
 			(vector_x * 10).dot(vector_x * 10) == 100.0,
 			"Vector4 dot product of same direction vectors should behave as expected.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx((vector1 * 2).dot(vector2 * 4), (real_t)-25.9 * 8),
+			(vector1 * 2).dot(vector2 * 4) == doctest::Approx((real_t)-25.9 * 8),
 			"Vector4 dot product should work as expected.");
 }
 

--- a/tests/core/math/test_vector4i.h
+++ b/tests/core/math/test_vector4i.h
@@ -82,13 +82,13 @@ TEST_CASE("[Vector4i] Length methods") {
 			vector1.length_squared() == 400,
 			"Vector4i length_squared should work as expected and return exact result.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector1.length(), 20),
+			vector1.length() == doctest::Approx(20),
 			"Vector4i length should work as expected.");
 	CHECK_MESSAGE(
 			vector2.length_squared() == 5400,
 			"Vector4i length_squared should work as expected and return exact result.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(vector2.length(), 73.4846922835),
+			vector2.length() == doctest::Approx(73.4846922835),
 			"Vector4i length should work as expected.");
 }
 

--- a/tests/scene/test_animation.h
+++ b/tests/scene/test_animation.h
@@ -40,8 +40,8 @@ namespace TestAnimation {
 TEST_CASE("[Animation] Empty animation getters") {
 	const Ref<Animation> animation = memnew(Animation);
 
-	CHECK(Math::is_equal_approx(animation->get_length(), real_t(1.0)));
-	CHECK(Math::is_equal_approx(animation->get_step(), real_t(0.1)));
+	CHECK(animation->get_length() == doctest::Approx(real_t(1.0)));
+	CHECK(animation->get_step() == doctest::Approx(real_t(0.1)));
 }
 
 TEST_CASE("[Animation] Create value track") {
@@ -59,33 +59,33 @@ TEST_CASE("[Animation] Create value track") {
 	CHECK(int(animation->track_get_key_value(0, 0)) == 0);
 	CHECK(int(animation->track_get_key_value(0, 1)) == 100);
 
-	CHECK(Math::is_equal_approx(animation->value_track_interpolate(0, -0.2), 0.0));
-	CHECK(Math::is_equal_approx(animation->value_track_interpolate(0, 0.0), 0.0));
-	CHECK(Math::is_equal_approx(animation->value_track_interpolate(0, 0.2), 40.0));
-	CHECK(Math::is_equal_approx(animation->value_track_interpolate(0, 0.4), 80.0));
-	CHECK(Math::is_equal_approx(animation->value_track_interpolate(0, 0.5), 100.0));
-	CHECK(Math::is_equal_approx(animation->value_track_interpolate(0, 0.6), 100.0));
+	CHECK(animation->value_track_interpolate(0, -0.2) == doctest::Approx(0.0));
+	CHECK(animation->value_track_interpolate(0, 0.0) == doctest::Approx(0.0));
+	CHECK(animation->value_track_interpolate(0, 0.2) == doctest::Approx(40.0));
+	CHECK(animation->value_track_interpolate(0, 0.4) == doctest::Approx(80.0));
+	CHECK(animation->value_track_interpolate(0, 0.5) == doctest::Approx(100.0));
+	CHECK(animation->value_track_interpolate(0, 0.6) == doctest::Approx(100.0));
 
-	CHECK(Math::is_equal_approx(animation->track_get_key_transition(0, 0), real_t(1.0)));
-	CHECK(Math::is_equal_approx(animation->track_get_key_transition(0, 1), real_t(1.0)));
+	CHECK(animation->track_get_key_transition(0, 0) == doctest::Approx(real_t(1.0)));
+	CHECK(animation->track_get_key_transition(0, 1) == doctest::Approx(real_t(1.0)));
 
 	ERR_PRINT_OFF;
 	// Nonexistent keys.
 	CHECK(animation->track_get_key_value(0, 2).is_null());
 	CHECK(animation->track_get_key_value(0, -1).is_null());
-	CHECK(Math::is_equal_approx(animation->track_get_key_transition(0, 2), real_t(-1.0)));
+	CHECK(animation->track_get_key_transition(0, 2) == doctest::Approx(real_t(-1.0)));
 	// Nonexistent track (and keys).
 	CHECK(animation->track_get_key_value(1, 0).is_null());
 	CHECK(animation->track_get_key_value(1, 1).is_null());
 	CHECK(animation->track_get_key_value(1, 2).is_null());
 	CHECK(animation->track_get_key_value(1, -1).is_null());
-	CHECK(Math::is_equal_approx(animation->track_get_key_transition(1, 0), real_t(-1.0)));
+	CHECK(animation->track_get_key_transition(1, 0) == doctest::Approx(real_t(-1.0)));
 
 	// This is a value track, so the methods below should return errors.
 	CHECK(animation->position_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
 	CHECK(animation->rotation_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
 	CHECK(animation->scale_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
-	CHECK(Math::is_zero_approx(animation->bezier_track_interpolate(0, 0.0)));
+	CHECK(animation->bezier_track_interpolate(0, 0.0) == doctest::Approx(0.0));
 	CHECK(animation->blend_shape_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
 	ERR_PRINT_ON;
 }
@@ -123,15 +123,15 @@ TEST_CASE("[Animation] Create 3D position track") {
 	CHECK(r_interpolation.is_equal_approx(Vector3(3.5, 4, 5)));
 
 	// 3D position tracks always use linear interpolation for performance reasons.
-	CHECK(Math::is_equal_approx(animation->track_get_key_transition(0, 0), real_t(1.0)));
-	CHECK(Math::is_equal_approx(animation->track_get_key_transition(0, 1), real_t(1.0)));
+	CHECK(animation->track_get_key_transition(0, 0) == doctest::Approx(real_t(1.0)));
+	CHECK(animation->track_get_key_transition(0, 1) == doctest::Approx(real_t(1.0)));
 
 	// This is a 3D position track, so the methods below should return errors.
 	ERR_PRINT_OFF;
 	CHECK(animation->value_track_interpolate(0, 0.0).is_null());
 	CHECK(animation->rotation_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
 	CHECK(animation->scale_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
-	CHECK(Math::is_zero_approx(animation->bezier_track_interpolate(0, 0.0)));
+	CHECK(animation->bezier_track_interpolate(0, 0.0) == doctest::Approx(0.0));
 	CHECK(animation->blend_shape_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
 	ERR_PRINT_ON;
 }
@@ -169,15 +169,15 @@ TEST_CASE("[Animation] Create 3D rotation track") {
 	CHECK(r_interpolation.is_equal_approx(Quaternion(0.231055, 0.374912, 0.761204, 0.476048)));
 
 	// 3D rotation tracks always use linear interpolation for performance reasons.
-	CHECK(Math::is_equal_approx(animation->track_get_key_transition(0, 0), real_t(1.0)));
-	CHECK(Math::is_equal_approx(animation->track_get_key_transition(0, 1), real_t(1.0)));
+	CHECK(animation->track_get_key_transition(0, 0) == doctest::Approx(real_t(1.0)));
+	CHECK(animation->track_get_key_transition(0, 1) == doctest::Approx(real_t(1.0)));
 
 	// This is a 3D rotation track, so the methods below should return errors.
 	ERR_PRINT_OFF;
 	CHECK(animation->value_track_interpolate(0, 0.0).is_null());
 	CHECK(animation->position_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
 	CHECK(animation->scale_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
-	CHECK(Math::is_zero_approx(animation->bezier_track_interpolate(0, 0.0)));
+	CHECK(animation->bezier_track_interpolate(0, 0.0) == doctest::Approx(real_t(0.0)));
 	CHECK(animation->blend_shape_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
 	ERR_PRINT_ON;
 }
@@ -215,15 +215,15 @@ TEST_CASE("[Animation] Create 3D scale track") {
 	CHECK(r_interpolation.is_equal_approx(Vector3(3.5, 4, 5)));
 
 	// 3D scale tracks always use linear interpolation for performance reasons.
-	CHECK(Math::is_equal_approx(animation->track_get_key_transition(0, 0), real_t(1.0)));
-	CHECK(Math::is_equal_approx(animation->track_get_key_transition(0, 1), real_t(1.0)));
+	CHECK(animation->track_get_key_transition(0, 0) == doctest::Approx(1.0));
+	CHECK(animation->track_get_key_transition(0, 1) == doctest::Approx(1.0));
 
 	// This is a 3D scale track, so the methods below should return errors.
 	ERR_PRINT_OFF;
 	CHECK(animation->value_track_interpolate(0, 0.0).is_null());
 	CHECK(animation->position_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
 	CHECK(animation->rotation_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
-	CHECK(Math::is_zero_approx(animation->bezier_track_interpolate(0, 0.0)));
+	CHECK(animation->bezier_track_interpolate(0, 0.0) == doctest::Approx(0.0));
 	CHECK(animation->blend_shape_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
 	ERR_PRINT_ON;
 }
@@ -242,32 +242,32 @@ TEST_CASE("[Animation] Create blend shape track") {
 	float r_blend = 0.0f;
 
 	CHECK(animation->blend_shape_track_get_key(0, 0, &r_blend) == OK);
-	CHECK(Math::is_equal_approx(r_blend, -1.0f));
+	CHECK(r_blend == doctest::Approx(-1.0f));
 
 	CHECK(animation->blend_shape_track_get_key(0, 1, &r_blend) == OK);
-	CHECK(Math::is_equal_approx(r_blend, 1.0f));
+	CHECK(r_blend == doctest::Approx(1.0f));
 
 	CHECK(animation->blend_shape_track_interpolate(0, -0.2, &r_blend) == OK);
-	CHECK(Math::is_equal_approx(r_blend, -1.0f));
+	CHECK(r_blend == doctest::Approx(-1.0f));
 
 	CHECK(animation->blend_shape_track_interpolate(0, 0.0, &r_blend) == OK);
-	CHECK(Math::is_equal_approx(r_blend, -1.0f));
+	CHECK(r_blend == doctest::Approx(-1.0f));
 
 	CHECK(animation->blend_shape_track_interpolate(0, 0.2, &r_blend) == OK);
-	CHECK(Math::is_equal_approx(r_blend, -0.2f));
+	CHECK(r_blend == doctest::Approx(-0.2f));
 
 	CHECK(animation->blend_shape_track_interpolate(0, 0.4, &r_blend) == OK);
-	CHECK(Math::is_equal_approx(r_blend, 0.6f));
+	CHECK(r_blend == doctest::Approx(0.6f));
 
 	CHECK(animation->blend_shape_track_interpolate(0, 0.5, &r_blend) == OK);
-	CHECK(Math::is_equal_approx(r_blend, 1.0f));
+	CHECK(r_blend == doctest::Approx(1.0f));
 
 	CHECK(animation->blend_shape_track_interpolate(0, 0.6, &r_blend) == OK);
-	CHECK(Math::is_equal_approx(r_blend, 1.0f));
+	CHECK(r_blend == doctest::Approx(1.0f));
 
 	// Blend shape tracks always use linear interpolation for performance reasons.
-	CHECK(Math::is_equal_approx(animation->track_get_key_transition(0, 0), real_t(1.0)));
-	CHECK(Math::is_equal_approx(animation->track_get_key_transition(0, 1), real_t(1.0)));
+	CHECK(animation->track_get_key_transition(0, 0) == doctest::Approx(real_t(1.0)));
+	CHECK(animation->track_get_key_transition(0, 1) == doctest::Approx(real_t(1.0)));
 
 	// This is a blend shape track, so the methods below should return errors.
 	ERR_PRINT_OFF;
@@ -275,7 +275,7 @@ TEST_CASE("[Animation] Create blend shape track") {
 	CHECK(animation->position_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
 	CHECK(animation->rotation_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
 	CHECK(animation->scale_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
-	CHECK(Math::is_zero_approx(animation->bezier_track_interpolate(0, 0.0)));
+	CHECK(animation->bezier_track_interpolate(0, 0.0) == doctest::Approx(0.0));
 	ERR_PRINT_ON;
 }
 
@@ -289,15 +289,15 @@ TEST_CASE("[Animation] Create Bezier track") {
 	CHECK(animation->get_track_count() == 1);
 	CHECK(!animation->track_is_compressed(0));
 
-	CHECK(Math::is_equal_approx(animation->bezier_track_get_key_value(0, 0), real_t(-1.0)));
-	CHECK(Math::is_equal_approx(animation->bezier_track_get_key_value(0, 1), real_t(1.0)));
+	CHECK(animation->bezier_track_get_key_value(0, 0) == doctest::Approx(real_t(-1.0)));
+	CHECK(animation->bezier_track_get_key_value(0, 1) == doctest::Approx(real_t(1.0)));
 
-	CHECK(Math::is_equal_approx(animation->bezier_track_interpolate(0, -0.2), real_t(-1.0)));
-	CHECK(Math::is_equal_approx(animation->bezier_track_interpolate(0, 0.0), real_t(-1.0)));
-	CHECK(Math::is_equal_approx(animation->bezier_track_interpolate(0, 0.2), real_t(-0.76057207584381)));
-	CHECK(Math::is_equal_approx(animation->bezier_track_interpolate(0, 0.4), real_t(-0.39975279569626)));
-	CHECK(Math::is_equal_approx(animation->bezier_track_interpolate(0, 0.5), real_t(1.0)));
-	CHECK(Math::is_equal_approx(animation->bezier_track_interpolate(0, 0.6), real_t(1.0)));
+	CHECK(animation->bezier_track_interpolate(0, -0.2) == doctest::Approx(real_t(-1.0)));
+	CHECK(animation->bezier_track_interpolate(0, 0.0) == doctest::Approx(real_t(-1.0)));
+	CHECK(animation->bezier_track_interpolate(0, 0.2) == doctest::Approx(real_t(-0.76057207584381)));
+	CHECK(animation->bezier_track_interpolate(0, 0.4) == doctest::Approx(real_t(-0.39975279569626)));
+	CHECK(animation->bezier_track_interpolate(0, 0.5) == doctest::Approx(real_t(1.0)));
+	CHECK(animation->bezier_track_interpolate(0, 0.6) == doctest::Approx(real_t(1.0)));
 
 	// This is a bezier track, so the methods below should return errors.
 	ERR_PRINT_OFF;

--- a/tests/scene/test_audio_stream_wav.h
+++ b/tests/scene/test_audio_stream_wav.h
@@ -138,7 +138,7 @@ void run_test(String file_name, AudioStreamWAV::Format data_format, bool stereo,
 	CHECK(stream->get_data() == test_data);
 
 	SUBCASE("Stream length is computed properly") {
-		CHECK(Math::is_equal_approx(stream->get_length(), double(wav_count / wav_rate)));
+		CHECK(stream->get_length() == doctest::Approx(double(wav_count / wav_rate)));
 	}
 
 	SUBCASE("Stream can be saved as .wav") {

--- a/tests/scene/test_curve.h
+++ b/tests/scene/test_curve.h
@@ -83,54 +83,54 @@ TEST_CASE("[Curve] Custom curve with free tangents") {
 			Math::is_zero_approx(curve->sample(-0.1)),
 			"Custom free curve should return the expected value at offset 0.1.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample(0.1), (real_t)0.352),
+			curve->sample(0.1) == doctest::Approx((real_t)0.352),
 			"Custom free curve should return the expected value at offset 0.1.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample(0.4), (real_t)0.352),
+			curve->sample(0.4) == doctest::Approx((real_t)0.352),
 			"Custom free curve should return the expected value at offset 0.1.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample(0.7), (real_t)0.896),
+			curve->sample(0.7) == doctest::Approx((real_t)0.896),
 			"Custom free curve should return the expected value at offset 0.1.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample(1), 1),
+			curve->sample(1) == doctest::Approx(1),
 			"Custom free curve should return the expected value at offset 0.1.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample(2), 1),
+			curve->sample(2) == doctest::Approx(1),
 			"Custom free curve should return the expected value at offset 0.1.");
 
 	CHECK_MESSAGE(
 			Math::is_zero_approx(curve->sample_baked(-0.1)),
 			"Custom free curve should return the expected baked value at offset 0.1.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample_baked(0.1), (real_t)0.352),
+			curve->sample_baked(0.1) == doctest::Approx((real_t)0.352),
 			"Custom free curve should return the expected baked value at offset 0.1.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample_baked(0.4), (real_t)0.352),
+			curve->sample_baked(0.4) == doctest::Approx((real_t)0.352),
 			"Custom free curve should return the expected baked value at offset 0.1.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample_baked(0.7), (real_t)0.896),
+			curve->sample_baked(0.7) == doctest::Approx((real_t)0.896),
 			"Custom free curve should return the expected baked value at offset 0.1.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample_baked(1), 1),
+			curve->sample_baked(1) == doctest::Approx(1),
 			"Custom free curve should return the expected baked value at offset 0.1.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample_baked(2), 1),
+			curve->sample_baked(2) == doctest::Approx(1),
 			"Custom free curve should return the expected baked value at offset 0.1.");
 
 	curve->remove_point(1);
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample(0.1), 0),
+			curve->sample(0.1) == doctest::Approx(0),
 			"Custom free curve should return the expected value at offset 0.1 after removing point at index 1.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample_baked(0.1), 0),
+			curve->sample_baked(0.1) == doctest::Approx(0),
 			"Custom free curve should return the expected baked value at offset 0.1 after removing point at index 1.");
 
 	curve->clear_points();
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample(0.6), 0),
+			curve->sample(0.6) == doctest::Approx(0),
 			"Custom free curve should return the expected value at offset 0.6 after clearing all points.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample_baked(0.6), 0),
+			curve->sample_baked(0.6) == doctest::Approx(0),
 			"Custom free curve should return the expected baked value at offset 0.6 after clearing all points.");
 }
 
@@ -143,7 +143,7 @@ TEST_CASE("[Curve] Custom curve with linear tangents") {
 	curve->add_point(Vector2(0.75, 1), 0, 0, Curve::TangentMode::TANGENT_LINEAR, Curve::TangentMode::TANGENT_LINEAR);
 
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->get_point_left_tangent(3), 4),
+			curve->get_point_left_tangent(3) == doctest::Approx(4),
 			"get_point_left_tangent() should return the expected value for point index 3.");
 	CHECK_MESSAGE(
 			Math::is_zero_approx(curve->get_point_right_tangent(3)),
@@ -172,48 +172,48 @@ TEST_CASE("[Curve] Custom curve with linear tangents") {
 			Math::is_zero_approx(curve->sample(-0.1)),
 			"Custom linear curve should return the expected value at offset -0.1.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample(0.1), (real_t)0.4),
+			curve->sample(0.1) == doctest::Approx((real_t)0.4),
 			"Custom linear curve should return the expected value at offset 0.1.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample(0.4), (real_t)0.4),
+			curve->sample(0.4) == doctest::Approx((real_t)0.4),
 			"Custom linear curve should return the expected value at offset 0.4.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample(0.7), (real_t)0.8),
+			curve->sample(0.7) == doctest::Approx((real_t)0.8),
 			"Custom linear curve should return the expected value at offset 0.7.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample(1), 1),
+			curve->sample(1) == doctest::Approx(1),
 			"Custom linear curve should return the expected value at offset 1.0.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample(2), 1),
+			curve->sample(2) == doctest::Approx(1),
 			"Custom linear curve should return the expected value at offset 2.0.");
 
 	CHECK_MESSAGE(
 			Math::is_zero_approx(curve->sample_baked(-0.1)),
 			"Custom linear curve should return the expected baked value at offset -0.1.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample_baked(0.1), (real_t)0.4),
+			curve->sample_baked(0.1) == doctest::Approx((real_t)0.4),
 			"Custom linear curve should return the expected baked value at offset 0.1.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample_baked(0.4), (real_t)0.4),
+			curve->sample_baked(0.4) == doctest::Approx((real_t)0.4),
 			"Custom linear curve should return the expected baked value at offset 0.4.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample_baked(0.7), (real_t)0.8),
+			curve->sample_baked(0.7) == doctest::Approx((real_t)0.8),
 			"Custom linear curve should return the expected baked value at offset 0.7.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample_baked(1), 1),
+			curve->sample_baked(1) == doctest::Approx(1),
 			"Custom linear curve should return the expected baked value at offset 1.0.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample_baked(2), 1),
+			curve->sample_baked(2) == doctest::Approx(1),
 			"Custom linear curve should return the expected baked value at offset 2.0.");
 
 	ERR_PRINT_OFF;
 	curve->remove_point(10);
 	ERR_PRINT_ON;
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample(0.7), (real_t)0.8),
+			curve->sample(0.7) == doctest::Approx((real_t)0.8),
 			"Custom free curve should return the expected value at offset 0.7 after removing point at invalid index 10.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(curve->sample_baked(0.7), (real_t)0.8),
+			curve->sample_baked(0.7) == doctest::Approx((real_t)0.8),
 			"Custom free curve should return the expected baked value at offset 0.7 after removing point at invalid index 10.");
 }
 

--- a/tests/scene/test_primitives.h
+++ b/tests/scene/test_primitives.h
@@ -57,9 +57,9 @@ TEST_CASE("[SceneTree][Primitive][Capsule] Capsule Primitive") {
 		capsule->set_radial_segments(16);
 		capsule->set_rings(32);
 
-		CHECK_MESSAGE(Math::is_equal_approx(capsule->get_radius(), 1.3f),
+		CHECK_MESSAGE(capsule->get_radius() == doctest::Approx(1.3f),
 				"Get/Set radius work with one set.");
-		CHECK_MESSAGE(Math::is_equal_approx(capsule->get_height(), 7.1f),
+		CHECK_MESSAGE(capsule->get_height() == doctest::Approx(7.1f),
 				"Get/Set radius work with one set.");
 		CHECK_MESSAGE(capsule->get_radial_segments() == 16,
 				"Get/Set radius work with one set.");
@@ -129,7 +129,7 @@ TEST_CASE("[SceneTree][Primitive][Capsule] Capsule Primitive") {
 				if (normals[ii].y == 0.f) {
 					float mag_of_normal = Math::sqrt(normals[ii].x * normals[ii].x + normals[ii].z * normals[ii].z);
 					Vector3 normalized_normal = normals[ii] / mag_of_normal;
-					CHECK_MESSAGE(Math::is_equal_approx(point_dist_from_yaxis, radius),
+					CHECK_MESSAGE(point_dist_from_yaxis == doctest::Approx(radius),
 							"Points on the tube of the capsule are radius away from y-axis.");
 					CHECK_MESSAGE(normalized_normal.is_equal_approx(yaxis_to_point),
 							"Normal points orthogonal from mid cylinder.");
@@ -244,9 +244,9 @@ TEST_CASE("[SceneTree][Primitive][Cylinder] Cylinder Primitive") {
 		cylinder->set_cap_top(false);
 		cylinder->set_cap_bottom(false);
 
-		CHECK(Math::is_equal_approx(cylinder->get_top_radius(), 4.3f));
-		CHECK(Math::is_equal_approx(cylinder->get_bottom_radius(), 1.2f));
-		CHECK(Math::is_equal_approx(cylinder->get_height(), 9.77f));
+		CHECK(cylinder->get_top_radius() == doctest::Approx(4.3f));
+		CHECK(cylinder->get_bottom_radius() == doctest::Approx(1.2f));
+		CHECK(cylinder->get_height() == doctest::Approx(9.77f));
 		CHECK(cylinder->get_radial_segments() == 12);
 		CHECK(cylinder->get_rings() == 16);
 		CHECK(!cylinder->is_cap_top());
@@ -478,7 +478,7 @@ TEST_CASE("[SceneTree][Primitive][Prism] Prism Primitive") {
 		prism->set_subdivide_height(5);
 		prism->set_subdivide_depth(64);
 
-		CHECK(Math::is_equal_approx(prism->get_left_to_right(), 3.4f));
+		CHECK(prism->get_left_to_right() == doctest::Approx(3.4f));
 		CHECK(prism->get_size().is_equal_approx(size));
 		CHECK(prism->get_subdivide_width() == 36);
 		CHECK(prism->get_subdivide_height() == 5);
@@ -513,8 +513,8 @@ TEST_CASE("[SceneTree][Primitive][Sphere] Sphere Primitive") {
 		sphere->set_rings(5);
 		sphere->set_is_hemisphere(true);
 
-		CHECK(Math::is_equal_approx(sphere->get_radius(), 3.4f));
-		CHECK(Math::is_equal_approx(sphere->get_height(), 2.2f));
+		CHECK(sphere->get_radius() == doctest::Approx(3.4f));
+		CHECK(sphere->get_height() == doctest::Approx(2.2f));
 		CHECK(sphere->get_radial_segments() == 36);
 		CHECK(sphere->get_rings() == 5);
 		CHECK(sphere->get_is_hemisphere());
@@ -581,8 +581,8 @@ TEST_CASE("[SceneTree][Primitive][Torus] Torus Primitive") {
 		torus->set_rings(19);
 		torus->set_ring_segments(43);
 
-		CHECK(Math::is_equal_approx(torus->get_inner_radius(), 3.2f));
-		CHECK(Math::is_equal_approx(torus->get_outer_radius(), 9.5f));
+		CHECK(torus->get_inner_radius() == doctest::Approx(3.2f));
+		CHECK(torus->get_outer_radius() == doctest::Approx(9.5f));
 		CHECK(torus->get_rings() == 19);
 		CHECK(torus->get_ring_segments() == 43);
 	}
@@ -610,8 +610,8 @@ TEST_CASE("[SceneTree][Primitive][TubeTrail] TubeTrail Primitive") {
 		Ref<Curve> curve = memnew(Curve);
 		tube->set_curve(curve);
 
-		CHECK(Math::is_equal_approx(tube->get_radius(), 7.2f));
-		CHECK(Math::is_equal_approx(tube->get_section_length(), 5.5f));
+		CHECK(tube->get_radius() == doctest::Approx(7.2f));
+		CHECK(tube->get_section_length() == doctest::Approx(5.5f));
 		CHECK(tube->get_radial_steps() == 9);
 		CHECK(tube->get_sections() == 33);
 		CHECK(tube->get_section_rings() == 12);
@@ -670,8 +670,8 @@ TEST_CASE("[SceneTree][Primitive][RibbonTrail] RibbonTrail Primitive") {
 		ribbon->set_section_segments(9);
 		ribbon->set_curve(curve);
 
-		CHECK(Math::is_equal_approx(ribbon->get_size(), 4.3f));
-		CHECK(Math::is_equal_approx(ribbon->get_section_length(), 1.3f));
+		CHECK(ribbon->get_size() == doctest::Approx(4.3f));
+		CHECK(ribbon->get_section_length() == doctest::Approx(1.3f));
 		CHECK(ribbon->get_sections() == 16);
 		CHECK(ribbon->get_section_segments() == 9);
 		CHECK(ribbon->get_curve() == curve);
@@ -781,11 +781,11 @@ TEST_CASE("[SceneTree][Primitive][Text] Text Primitive") {
 		CHECK(text->get_structured_text_bidi_override_options() == options);
 		CHECK(text->is_uppercase() == true);
 		CHECK(text->get_offset() == offset);
-		CHECK(Math::is_equal_approx(text->get_line_spacing(), 1.7f));
-		CHECK(Math::is_equal_approx(text->get_width(), width));
-		CHECK(Math::is_equal_approx(text->get_depth(), depth));
-		CHECK(Math::is_equal_approx(text->get_curve_step(), curve_step));
-		CHECK(Math::is_equal_approx(text->get_pixel_size(), pixel_size));
+		CHECK(text->get_line_spacing() == doctest::Approx(1.7f));
+		CHECK(text->get_width() == doctest::Approx(width));
+		CHECK(text->get_depth() == doctest::Approx(depth));
+		CHECK(text->get_curve_step() == doctest::Approx(curve_step));
+		CHECK(text->get_pixel_size() == doctest::Approx(pixel_size));
 	}
 
 	SUBCASE("[Primitive][Text] Set objects multiple times.") {


### PR DESCRIPTION
Replaces all occurrences of `Math::is_equal_approx` in in our test suites (only within the `CHECK` macro) with == and `doctest::Approx`, so that the actual values are printed if a test fails. This makes debugging much easier as it is no longer needed to add a print statement to find out the actual value a function returned, resulting in much more fluent TDD.