### PR TITLE
Correctly deletes multi-caret selection with backspace

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -694,8 +694,8 @@ void CodeEdit::_backspace_internal(int p_caret) {
 		return;
 	}
 
-	if (has_selection()) {
-		delete_selection();
+	if (has_selection(p_caret)) {
+		delete_selection(p_caret);
 		return;
 	}
 


### PR DESCRIPTION
Fixes and closes #67992. This also fixes the same unreported bug that was present for `ui_text_delete_word`.

The correct behavior now:

https://user-images.githubusercontent.com/248383/200109879-6230e42b-e63b-4e88-8008-6045534a8519.mp4


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
