### PR TITLE
Extend the generated gitignore.

### DIFF
--- a/editor/version_control/editor_vcs_interface.cpp
+++ b/editor/version_control/editor_vcs_interface.cpp
@@ -367,6 +367,7 @@ void EditorVCSInterface::create_vcs_metadata_files(VCSMetadata p_vcs_metadata_ty
 		} else {
 			f->store_line("# Godot 4+ specific ignores");
 			f->store_line(".godot/");
+			f->store_line("*.translation");
 			f->store_line("/android/");
 		}
 		f = FileAccess::open(p_dir.path_join(".gitattributes"), FileAccess::WRITE);


### PR DESCRIPTION
To match the ignore file described in the [docs](https://docs.godotengine.org/en/latest/tutorials/best_practices/version_control_systems.html).

As #42392 was not merged `.translation` files still need to be ignored.

I am not using the Mono version but as far as I can tell from source code the `.mono` folder is now located inside `.godot` so there is no need to ignore it. If someone could confirm this I can change the documentation as well.
