### PR TITLE
Fallback to IAudioClient when IAudioClient3 is not available in a more robust way

### DIFF
--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -79,19 +79,17 @@ class AudioDriverWASAPI : public AudioDriver {
 
 	SafeFlag exit_thread;
 
-	static bool is_running_on_wine();
-
 	static _FORCE_INLINE_ void write_sample(WORD format_tag, int bits_per_sample, BYTE *buffer, int i, int32_t sample);
 	static _FORCE_INLINE_ int32_t read_sample(WORD format_tag, int bits_per_sample, BYTE *buffer, int i);
 	static void thread_func(void *p_udata);
 
-	Error init_render_device(bool reinit = false);
-	Error init_capture_device(bool reinit = false);
+	Error init_render_device(bool p_reinit = false);
+	Error init_capture_device(bool p_reinit = false);
 
 	Error finish_render_device();
 	Error finish_capture_device();
 
-	Error audio_device_init(AudioDeviceWASAPI *p_device, bool p_capture, bool reinit);
+	Error audio_device_init(AudioDeviceWASAPI *p_device, bool p_capture, bool p_reinit, bool p_no_audio_client_3 = false);
 	Error audio_device_finish(AudioDeviceWASAPI *p_device);
 	PackedStringArray audio_device_get_list(bool p_capture);
 


### PR DESCRIPTION
Changes work from #67381 to behave in a more robust way without needing to detect if we are running inside Wine, this mechanism seems to be the way to go since miniaudio (which IMO is THE reference modern audio library) does it this this way and works fine.

This also makes it so that spoofing whether or not we are running on wine won't break audio.