### PR TITLE
Update XRServer with starting position of (new) current XROrigin3D

### DIFF
--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -644,6 +644,12 @@ void XROrigin3D::set_current(bool p_enabled) {
 				origin_nodes[i]->set_current(false);
 			}
 		}
+
+		// update XRServer with our current position
+		XRServer *xr_server = XRServer::get_singleton();
+		ERR_FAIL_NULL(xr_server);
+
+		xr_server->set_world_origin(get_global_transform());
 	} else {
 		bool found = false;
 		// We no longer have a current origin so find the first one we can make current


### PR DESCRIPTION
With the recent change to `XROrigin3D` we're now only informing the `XRServer` of our new transform when our transform changes and we are the current node.

When we become the current `XROrigin3D` node, we aren't providing the `XRServer` with our starting location. This PR fixes that omission. 

I believe this fixes #68312
