### PR TITLE
Fix RichTextLabel crash with out of bound exception

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2375,7 +2375,7 @@ int RichTextLabel::_find_list(Item *p_item, Vector<int> &r_index, Vector<ItemLis
 
 			int index = 1;
 			if (frame != nullptr) {
-				for (int i = list->line + 1; i <= prev_item->line; i++) {
+				for (int i = list->line + 1; i <= prev_item->line && i < (int)frame->lines.size(); i++) {
 					if (_find_list_item(frame->lines[i].from) == list) {
 						index++;
 					}


### PR DESCRIPTION
Fixes #68242.

I am not completely sure how the `_find_list` method works :sweat_smile:  This check will stop the error from happening, but perhaps the iteration itself is not valid now. We are iterating over `list` and `prev_item` and then using the index to access `frame->lines`, and I'm not sure if that process is correct. If this fix should be implemented differently, please let me know :smile: 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
