### PR TITLE
Fix GradientTexture2D's preview

### DIFF
--- a/editor/plugins/gradient_texture_2d_editor_plugin.cpp
+++ b/editor/plugins/gradient_texture_2d_editor_plugin.cpp
@@ -121,13 +121,12 @@ void GradientTexture2DEditorRect::_notification(int p_what) {
 			Size2 rect_size = get_size();
 
 			// Get the size and position to draw the texture and handles at.
-			size = Size2(texture->get_width() * rect_size.height / texture->get_height(), rect_size.height);
-			if (size.width > rect_size.width) {
-				size.width = rect_size.width;
-				size.height = texture->get_height() * size.width / texture->get_width();
-			}
-			offset = ((rect_size - size + handle_size) / 2).round();
-			size -= handle_size;
+			// Subtract handle sizes so they stay inside the preview, but keep the texture's aspect ratio.
+			Size2 available_size = rect_size - handle_size;
+			Size2 ratio = available_size / texture->get_size();
+			size = MIN(ratio.x, ratio.y) * texture->get_size();
+			offset = ((rect_size - size) / 2).round();
+
 			checkerboard->set_rect(Rect2(offset, size));
 
 			draw_set_transform(offset);
@@ -180,8 +179,9 @@ GradientTexture2DEditorRect::GradientTexture2DEditorRect() {
 
 	checkerboard = memnew(TextureRect);
 	checkerboard->set_stretch_mode(TextureRect::STRETCH_TILE);
+	checkerboard->set_ignore_texture_size(true);
 	checkerboard->set_draw_behind_parent(true);
-	add_child(checkerboard);
+	add_child(checkerboard, false, INTERNAL_MODE_FRONT);
 
 	set_custom_minimum_size(Size2(0, 250 * EDSCALE));
 }


### PR DESCRIPTION
Fixes #66661 

`handle_size` was subtracted from the texture size so the handles don't go off screen, but this usually resulted in a different aspect ratio. For example, in the edge case of a very tall/wide texture, you may get something like 4 - 16 = -12, handles are drawn off the screen and the preview is wrong completely as it represents a 4px tall texture as though it's 12px tall.

Fixes also the checkerboard showing up at small aspect ratios because it couldn't repeat less than once.