### PR TITLE
Fixes mouse click deselect for multi and single carets

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1854,6 +1854,12 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		} else {
 			if (mb->get_button_index() == MouseButton::LEFT) {
 				if (selection_drag_attempt && is_mouse_over_selection()) {
+					remove_secondary_carets();
+
+					Point2i pos = get_line_column_at_pos(get_local_mouse_pos());
+					set_caret_line(pos.y, false, true, 0, 0);
+					set_caret_column(pos.x, true, 0);
+
 					deselect();
 				}
 				dragging_minimap = false;


### PR DESCRIPTION
Fixes and closes #67993.


https://user-images.githubusercontent.com/248383/200189299-c9c45e0e-f45f-484c-8ddc-8d42489c3881.mp4

By fixing this bug I also fixed another issue that I reported in the issue itself #67993: For a selection with a single caret, after clicking to deselect the cursor should go to the clicked position, but it currently either goes to the beginning or end of the selection, which is not consistent with other text editors:

https://user-images.githubusercontent.com/248383/200189306-936c36be-b27f-4a1a-ad15-415fe117f267.mp4

It's now consistent:

https://user-images.githubusercontent.com/248383/200189310-6ce9bbaf-3e3f-48a8-9d4d-8e4e734f3c4d.mp4


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
