### PR TITLE
Fix default values not showing up on virtual classes

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1460,7 +1460,7 @@ Variant ClassDB::class_get_default_property_value(const StringName &p_class, con
 		if (Engine::get_singleton()->has_singleton(p_class)) {
 			c = Engine::get_singleton()->get_singleton_object(p_class);
 			cleanup_c = false;
-		} else if (ClassDB::can_instantiate(p_class) && !ClassDB::is_virtual(p_class)) {
+		} else if (ClassDB::can_instantiate(p_class)) { // Keep this condition in sync with doc_tools.cpp get_documentation_default_value.
 			c = ClassDB::instantiate(p_class);
 			cleanup_c = true;
 		}

--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -44,37 +44,38 @@
 		</method>
 	</methods>
 	<members>
-		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" enum="BaseButton.ActionMode">
+		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" enum="BaseButton.ActionMode" default="1">
 			Determines when the button is considered clicked, one of the [enum ActionMode] constants.
 		</member>
 		<member name="button_group" type="ButtonGroup" setter="set_button_group" getter="get_button_group">
 			The [ButtonGroup] associated with the button. Not to be confused with node groups.
 		</member>
-		<member name="button_mask" type="int" setter="set_button_mask" getter="get_button_mask" enum="MouseButton">
+		<member name="button_mask" type="int" setter="set_button_mask" getter="get_button_mask" enum="MouseButton" default="1">
 			Binary mask to choose which mouse buttons this button will respond to.
 			To allow both left-click and right-click, use [code]MOUSE_BUTTON_MASK_LEFT | MOUSE_BUTTON_MASK_RIGHT[/code].
 		</member>
-		<member name="button_pressed" type="bool" setter="set_pressed" getter="is_pressed">
+		<member name="button_pressed" type="bool" setter="set_pressed" getter="is_pressed" default="false">
 			If [code]true[/code], the button's state is pressed. Means the button is pressed down or toggled (if [member toggle_mode] is active). Only works if [member toggle_mode] is [code]true[/code].
 			[b]Note:[/b] Setting [member button_pressed] will result in [signal toggled] to be emitted. If you want to change the pressed state without emitting that signal, use [method set_pressed_no_signal].
 		</member>
-		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled">
+		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false">
 			If [code]true[/code], the button is in disabled state and can't be clicked or toggled.
 		</member>
-		<member name="keep_pressed_outside" type="bool" setter="set_keep_pressed_outside" getter="is_keep_pressed_outside">
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
+		<member name="keep_pressed_outside" type="bool" setter="set_keep_pressed_outside" getter="is_keep_pressed_outside" default="false">
 			If [code]true[/code], the button stays pressed when moving the cursor outside the button while pressing it.
 			[b]Note:[/b] This property only affects the button's visual appearance. Signals will be emitted at the same moment regardless of this property's value.
 		</member>
 		<member name="shortcut" type="Shortcut" setter="set_shortcut" getter="get_shortcut">
 			[Shortcut] associated to the button.
 		</member>
-		<member name="shortcut_feedback" type="bool" setter="set_shortcut_feedback" getter="is_shortcut_feedback">
+		<member name="shortcut_feedback" type="bool" setter="set_shortcut_feedback" getter="is_shortcut_feedback" default="true">
 			If [code]true[/code], the button will appear pressed when its shortcut is activated. If [code]false[/code] and [member toggle_mode] is [code]false[/code], the shortcut will activate the button without appearing to press the button.
 		</member>
-		<member name="shortcut_in_tooltip" type="bool" setter="set_shortcut_in_tooltip" getter="is_shortcut_in_tooltip_enabled">
+		<member name="shortcut_in_tooltip" type="bool" setter="set_shortcut_in_tooltip" getter="is_shortcut_in_tooltip_enabled" default="true">
 			If [code]true[/code], the button will add information about its shortcut in the tooltip.
 		</member>
-		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode">
+		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" default="false">
 			If [code]true[/code], the button is in toggle mode. Makes the button flip state between pressed and unpressed each time its area is clicked.
 		</member>
 	</members>

--- a/doc/classes/CameraAttributes.xml
+++ b/doc/classes/CameraAttributes.xml
@@ -12,19 +12,19 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="auto_exposure_enabled" type="bool" setter="set_auto_exposure_enabled" getter="is_auto_exposure_enabled">
+		<member name="auto_exposure_enabled" type="bool" setter="set_auto_exposure_enabled" getter="is_auto_exposure_enabled" default="false">
 			If [code]true[/code], enables the tonemapping auto exposure mode of the scene renderer. If [code]true[/code], the renderer will automatically determine the exposure setting to adapt to the scene's illumination and the observed light.
 		</member>
-		<member name="auto_exposure_scale" type="float" setter="set_auto_exposure_scale" getter="get_auto_exposure_scale">
+		<member name="auto_exposure_scale" type="float" setter="set_auto_exposure_scale" getter="get_auto_exposure_scale" default="0.4">
 			The scale of the auto exposure effect. Affects the intensity of auto exposure.
 		</member>
-		<member name="auto_exposure_speed" type="float" setter="set_auto_exposure_speed" getter="get_auto_exposure_speed">
+		<member name="auto_exposure_speed" type="float" setter="set_auto_exposure_speed" getter="get_auto_exposure_speed" default="0.5">
 			The speed of the auto exposure effect. Affects the time needed for the camera to perform auto exposure.
 		</member>
-		<member name="exposure_multiplier" type="float" setter="set_exposure_multiplier" getter="get_exposure_multiplier">
+		<member name="exposure_multiplier" type="float" setter="set_exposure_multiplier" getter="get_exposure_multiplier" default="1.0">
 			Multiplier for the exposure amount. A higher value results in a brighter image.
 		</member>
-		<member name="exposure_sensitivity" type="float" setter="set_exposure_sensitivity" getter="get_exposure_sensitivity">
+		<member name="exposure_sensitivity" type="float" setter="set_exposure_sensitivity" getter="get_exposure_sensitivity" default="100.0">
 			Sensitivity of camera sensors, measured in ISO. A higher sensitivity results in a brighter image. Only available when [member ProjectSettings.rendering/lights_and_shadows/use_physical_light_units] is enabled. When [member auto_exposure_enabled] this can be used as a method of exposure compensation, doubling the value will increase the exposure value (measured in EV100) by 1 stop.
 		</member>
 	</members>

--- a/doc/classes/EditorSpinSlider.xml
+++ b/doc/classes/EditorSpinSlider.xml
@@ -12,6 +12,7 @@
 		<member name="flat" type="bool" setter="set_flat" getter="is_flat" default="false">
 			If [code]true[/code], the slider will not draw background.
 		</member>
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
 		<member name="hide_slider" type="bool" setter="set_hide_slider" getter="is_hiding_slider" default="false">
 			If [code]true[/code], the slider is hidden.
 		</member>

--- a/doc/classes/GeometryInstance3D.xml
+++ b/doc/classes/GeometryInstance3D.xml
@@ -31,22 +31,22 @@
 		</method>
 	</methods>
 	<members>
-		<member name="cast_shadow" type="int" setter="set_cast_shadows_setting" getter="get_cast_shadows_setting" enum="GeometryInstance3D.ShadowCastingSetting">
+		<member name="cast_shadow" type="int" setter="set_cast_shadows_setting" getter="get_cast_shadows_setting" enum="GeometryInstance3D.ShadowCastingSetting" default="1">
 			The selected shadow casting flag. See [enum ShadowCastingSetting] for possible values.
 		</member>
-		<member name="extra_cull_margin" type="float" setter="set_extra_cull_margin" getter="get_extra_cull_margin">
+		<member name="extra_cull_margin" type="float" setter="set_extra_cull_margin" getter="get_extra_cull_margin" default="0.0">
 			The extra distance added to the GeometryInstance3D's bounding box ([AABB]) to increase its cull box.
 		</member>
-		<member name="gi_lightmap_scale" type="int" setter="set_lightmap_scale" getter="get_lightmap_scale" enum="GeometryInstance3D.LightmapScale">
+		<member name="gi_lightmap_scale" type="int" setter="set_lightmap_scale" getter="get_lightmap_scale" enum="GeometryInstance3D.LightmapScale" default="0">
 			The texel density to use for lightmapping in [LightmapGI]. Greater scale values provide higher resolution in the lightmap, which can result in sharper shadows for lights that have both direct and indirect light baked. However, greater scale values will also increase the space taken by the mesh in the lightmap texture, which increases the memory, storage, and bake time requirements. When using a single mesh at different scales, consider adjusting this value to keep the lightmap texel density consistent across meshes.
 		</member>
-		<member name="gi_mode" type="int" setter="set_gi_mode" getter="get_gi_mode" enum="GeometryInstance3D.GIMode">
+		<member name="gi_mode" type="int" setter="set_gi_mode" getter="get_gi_mode" enum="GeometryInstance3D.GIMode" default="1">
 			The global illumination mode to use for the whole geometry. To avoid inconsistent results, use a mode that matches the purpose of the mesh during gameplay (static/dynamic).
 			[b]Note:[/b] Lights' bake mode will also affect the global illumination rendering. See [member Light3D.light_bake_mode].
 		</member>
-		<member name="ignore_occlusion_culling" type="bool" setter="set_ignore_occlusion_culling" getter="is_ignoring_occlusion_culling">
+		<member name="ignore_occlusion_culling" type="bool" setter="set_ignore_occlusion_culling" getter="is_ignoring_occlusion_culling" default="false">
 		</member>
-		<member name="lod_bias" type="float" setter="set_lod_bias" getter="get_lod_bias">
+		<member name="lod_bias" type="float" setter="set_lod_bias" getter="get_lod_bias" default="1.0">
 		</member>
 		<member name="material_overlay" type="Material" setter="set_material_overlay" getter="get_material_overlay">
 			The material overlay for the whole geometry.
@@ -56,26 +56,26 @@
 			The material override for the whole geometry.
 			If a material is assigned to this property, it will be used instead of any material set in any material slot of the mesh.
 		</member>
-		<member name="transparency" type="float" setter="set_transparency" getter="get_transparency">
+		<member name="transparency" type="float" setter="set_transparency" getter="get_transparency" default="0.0">
 			The transparency applied to the whole geometry (as a multiplier of the materials' existing transparency). [code]0.0[/code] is fully opaque, while [code]1.0[/code] is fully transparent. Values greater than [code]0.0[/code] (exclusive) will force the geometry's materials to go through the transparent pipeline, which is slower to render and can exhibit rendering issues due to incorrect transparency sorting. However, unlike using a transparent material, setting [member transparency] to a value greater than [code]0.0[/code] (exclusive) will [i]not[/i] disable shadow rendering.
 			In spatial shaders, [code]1.0 - transparency[/code] is set as the default value of the [code]ALPHA[/code] built-in.
 			[b]Note:[/b] [member transparency] is clamped between [code]0.0[/code] and [code]1.0[/code], so this property cannot be used to make transparent materials more opaque than they originally are.
 		</member>
-		<member name="visibility_range_begin" type="float" setter="set_visibility_range_begin" getter="get_visibility_range_begin">
+		<member name="visibility_range_begin" type="float" setter="set_visibility_range_begin" getter="get_visibility_range_begin" default="0.0">
 			Starting distance from which the GeometryInstance3D will be visible, taking [member visibility_range_begin_margin] into account as well. The default value of 0 is used to disable the range check.
 		</member>
-		<member name="visibility_range_begin_margin" type="float" setter="set_visibility_range_begin_margin" getter="get_visibility_range_begin_margin">
+		<member name="visibility_range_begin_margin" type="float" setter="set_visibility_range_begin_margin" getter="get_visibility_range_begin_margin" default="0.0">
 			Margin for the [member visibility_range_begin] threshold. The GeometryInstance3D will only change its visibility state when it goes over or under the [member visibility_range_begin] threshold by this amount.
 			If [member visibility_range_fade_mode] is [constant VISIBILITY_RANGE_FADE_DISABLED], this acts as an hysteresis distance. If [member visibility_range_fade_mode] is [constant VISIBILITY_RANGE_FADE_SELF] or [constant VISIBILITY_RANGE_FADE_DEPENDENCIES], this acts as a fade transition distance and must be set to a value greater than [code]0.0[/code] for the effect to be noticeable.
 		</member>
-		<member name="visibility_range_end" type="float" setter="set_visibility_range_end" getter="get_visibility_range_end">
+		<member name="visibility_range_end" type="float" setter="set_visibility_range_end" getter="get_visibility_range_end" default="0.0">
 			Distance from which the GeometryInstance3D will be hidden, taking [member visibility_range_end_margin] into account as well. The default value of 0 is used to disable the range check.
 		</member>
-		<member name="visibility_range_end_margin" type="float" setter="set_visibility_range_end_margin" getter="get_visibility_range_end_margin">
+		<member name="visibility_range_end_margin" type="float" setter="set_visibility_range_end_margin" getter="get_visibility_range_end_margin" default="0.0">
 			Margin for the [member visibility_range_end] threshold. The GeometryInstance3D will only change its visibility state when it goes over or under the [member visibility_range_end] threshold by this amount.
 			If [member visibility_range_fade_mode] is [constant VISIBILITY_RANGE_FADE_DISABLED], this acts as an hysteresis distance. If [member visibility_range_fade_mode] is [constant VISIBILITY_RANGE_FADE_SELF] or [constant VISIBILITY_RANGE_FADE_DEPENDENCIES], this acts as a fade transition distance and must be set to a value greater than [code]0.0[/code] for the effect to be noticeable.
 		</member>
-		<member name="visibility_range_fade_mode" type="int" setter="set_visibility_range_fade_mode" getter="get_visibility_range_fade_mode" enum="GeometryInstance3D.VisibilityRangeFadeMode">
+		<member name="visibility_range_fade_mode" type="int" setter="set_visibility_range_fade_mode" getter="get_visibility_range_fade_mode" enum="GeometryInstance3D.VisibilityRangeFadeMode" default="0">
 			Controls which instances will be faded when approaching the limits of the visibility range. See [enum VisibilityRangeFadeMode] for possible values.
 		</member>
 	</members>

--- a/doc/classes/Label3D.xml
+++ b/doc/classes/Label3D.xml
@@ -44,6 +44,7 @@
 		<member name="billboard" type="int" setter="set_billboard_mode" getter="get_billboard_mode" enum="BaseMaterial3D.BillboardMode" default="0">
 			The billboard mode to use for the label. See [enum BaseMaterial3D.BillboardMode] for possible values.
 		</member>
+		<member name="cast_shadow" type="int" setter="set_cast_shadows_setting" getter="get_cast_shadows_setting" overrides="GeometryInstance3D" enum="GeometryInstance3D.ShadowCastingSetting" default="0" />
 		<member name="double_sided" type="bool" setter="set_draw_flag" getter="get_draw_flag" default="true">
 			If [code]true[/code], text can be seen from the back as well, if [code]false[/code], it is invisible when looking at it from behind.
 		</member>
@@ -57,6 +58,7 @@
 			Font size of the [Label3D]'s text. To make the font look more detailed when up close, increase [member font_size] while decreasing [member pixel_size] at the same time.
 			Higher font sizes require more time to render new characters, which can cause stuttering during gameplay.
 		</member>
+		<member name="gi_mode" type="int" setter="set_gi_mode" getter="get_gi_mode" overrides="GeometryInstance3D" enum="GeometryInstance3D.GIMode" default="0" />
 		<member name="horizontal_alignment" type="int" setter="set_horizontal_alignment" getter="get_horizontal_alignment" enum="HorizontalAlignment" default="1">
 			Controls the text's horizontal alignment. Supports left, center, right, and fill, or justify. Set it to one of the [enum HorizontalAlignment] constants.
 		</member>

--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -10,9 +10,11 @@
 	<tutorials>
 	</tutorials>
 	<members>
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="0" />
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
 		</member>
+		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" overrides="Control" enum="Control.CursorShape" default="2" />
 		<member name="structured_text_bidi_override" type="int" setter="set_structured_text_bidi_override" getter="get_structured_text_bidi_override" enum="TextServer.StructuredTextParser" default="0">
 			Set BiDi algorithm override for the structured text.
 		</member>

--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -176,7 +176,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="lightmap_size_hint" type="Vector2i" setter="set_lightmap_size_hint" getter="get_lightmap_size_hint">
+		<member name="lightmap_size_hint" type="Vector2i" setter="set_lightmap_size_hint" getter="get_lightmap_size_hint" default="Vector2i(0, 0)">
 			Sets a hint to be used for lightmap resolution.
 		</member>
 	</members>

--- a/doc/classes/PhysicsDirectBodyState2D.xml
+++ b/doc/classes/PhysicsDirectBodyState2D.xml
@@ -207,40 +207,40 @@
 		</method>
 	</methods>
 	<members>
-		<member name="angular_velocity" type="float" setter="set_angular_velocity" getter="get_angular_velocity">
+		<member name="angular_velocity" type="float" setter="set_angular_velocity" getter="get_angular_velocity" default="0.0">
 			The body's rotational velocity in [i]radians[/i] per second.
 		</member>
-		<member name="center_of_mass" type="Vector2" setter="" getter="get_center_of_mass">
+		<member name="center_of_mass" type="Vector2" setter="" getter="get_center_of_mass" default="Vector2(0, 0)">
 			The body's center of mass position relative to the body's center in the global coordinate system.
 		</member>
-		<member name="center_of_mass_local" type="Vector2" setter="" getter="get_center_of_mass_local">
+		<member name="center_of_mass_local" type="Vector2" setter="" getter="get_center_of_mass_local" default="Vector2(0, 0)">
 			The body's center of mass position in the body's local coordinate system.
 		</member>
-		<member name="inverse_inertia" type="float" setter="" getter="get_inverse_inertia">
+		<member name="inverse_inertia" type="float" setter="" getter="get_inverse_inertia" default="0.0">
 			The inverse of the inertia of the body.
 		</member>
-		<member name="inverse_mass" type="float" setter="" getter="get_inverse_mass">
+		<member name="inverse_mass" type="float" setter="" getter="get_inverse_mass" default="0.0">
 			The inverse of the mass of the body.
 		</member>
-		<member name="linear_velocity" type="Vector2" setter="set_linear_velocity" getter="get_linear_velocity">
+		<member name="linear_velocity" type="Vector2" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector2(0, 0)">
 			The body's linear velocity in pixels per second.
 		</member>
-		<member name="sleeping" type="bool" setter="set_sleep_state" getter="is_sleeping">
+		<member name="sleeping" type="bool" setter="set_sleep_state" getter="is_sleeping" default="false">
 			If [code]true[/code], this body is currently sleeping (not active).
 		</member>
-		<member name="step" type="float" setter="" getter="get_step">
+		<member name="step" type="float" setter="" getter="get_step" default="0.0">
 			The timestep (delta) used for the simulation.
 		</member>
-		<member name="total_angular_damp" type="float" setter="" getter="get_total_angular_damp">
+		<member name="total_angular_damp" type="float" setter="" getter="get_total_angular_damp" default="0.0">
 			The rate at which the body stops rotating, if there are not any other forces moving it.
 		</member>
-		<member name="total_gravity" type="Vector2" setter="" getter="get_total_gravity">
+		<member name="total_gravity" type="Vector2" setter="" getter="get_total_gravity" default="Vector2(0, 0)">
 			The total gravity vector being currently applied to this body.
 		</member>
-		<member name="total_linear_damp" type="float" setter="" getter="get_total_linear_damp">
+		<member name="total_linear_damp" type="float" setter="" getter="get_total_linear_damp" default="0.0">
 			The rate at which the body stops moving, if there are not any other forces moving it.
 		</member>
-		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform">
+		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform" default="Transform2D(1, 0, 0, 1, 0, 0)">
 			The body's transformation matrix.
 		</member>
 	</members>

--- a/doc/classes/PhysicsDirectBodyState3D.xml
+++ b/doc/classes/PhysicsDirectBodyState3D.xml
@@ -214,45 +214,45 @@
 		</method>
 	</methods>
 	<members>
-		<member name="angular_velocity" type="Vector3" setter="set_angular_velocity" getter="get_angular_velocity">
+		<member name="angular_velocity" type="Vector3" setter="set_angular_velocity" getter="get_angular_velocity" default="Vector3(0, 0, 0)">
 			The body's rotational velocity in [i]radians[/i] per second.
 		</member>
-		<member name="center_of_mass" type="Vector3" setter="" getter="get_center_of_mass">
+		<member name="center_of_mass" type="Vector3" setter="" getter="get_center_of_mass" default="Vector3(0, 0, 0)">
 			The body's center of mass position relative to the body's center in the global coordinate system.
 		</member>
-		<member name="center_of_mass_local" type="Vector3" setter="" getter="get_center_of_mass_local">
+		<member name="center_of_mass_local" type="Vector3" setter="" getter="get_center_of_mass_local" default="Vector3(0, 0, 0)">
 			The body's center of mass position in the body's local coordinate system.
 		</member>
-		<member name="inverse_inertia" type="Vector3" setter="" getter="get_inverse_inertia">
+		<member name="inverse_inertia" type="Vector3" setter="" getter="get_inverse_inertia" default="Vector3(0, 0, 0)">
 			The inverse of the inertia of the body.
 		</member>
-		<member name="inverse_inertia_tensor" type="Basis" setter="" getter="get_inverse_inertia_tensor">
+		<member name="inverse_inertia_tensor" type="Basis" setter="" getter="get_inverse_inertia_tensor" default="Basis(1, 0, 0, 0, 1, 0, 0, 0, 1)">
 			The inverse of the inertia tensor of the body.
 		</member>
-		<member name="inverse_mass" type="float" setter="" getter="get_inverse_mass">
+		<member name="inverse_mass" type="float" setter="" getter="get_inverse_mass" default="0.0">
 			The inverse of the mass of the body.
 		</member>
-		<member name="linear_velocity" type="Vector3" setter="set_linear_velocity" getter="get_linear_velocity">
+		<member name="linear_velocity" type="Vector3" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector3(0, 0, 0)">
 			The body's linear velocity in units per second.
 		</member>
-		<member name="principal_inertia_axes" type="Basis" setter="" getter="get_principal_inertia_axes">
+		<member name="principal_inertia_axes" type="Basis" setter="" getter="get_principal_inertia_axes" default="Basis(1, 0, 0, 0, 1, 0, 0, 0, 1)">
 		</member>
-		<member name="sleeping" type="bool" setter="set_sleep_state" getter="is_sleeping">
+		<member name="sleeping" type="bool" setter="set_sleep_state" getter="is_sleeping" default="false">
 			If [code]true[/code], this body is currently sleeping (not active).
 		</member>
-		<member name="step" type="float" setter="" getter="get_step">
+		<member name="step" type="float" setter="" getter="get_step" default="0.0">
 			The timestep (delta) used for the simulation.
 		</member>
-		<member name="total_angular_damp" type="float" setter="" getter="get_total_angular_damp">
+		<member name="total_angular_damp" type="float" setter="" getter="get_total_angular_damp" default="0.0">
 			The rate at which the body stops rotating, if there are not any other forces moving it.
 		</member>
-		<member name="total_gravity" type="Vector3" setter="" getter="get_total_gravity">
+		<member name="total_gravity" type="Vector3" setter="" getter="get_total_gravity" default="Vector3(0, 0, 0)">
 			The total gravity vector being currently applied to this body.
 		</member>
-		<member name="total_linear_damp" type="float" setter="" getter="get_total_linear_damp">
+		<member name="total_linear_damp" type="float" setter="" getter="get_total_linear_damp" default="0.0">
 			The rate at which the body stops moving, if there are not any other forces moving it.
 		</member>
-		<member name="transform" type="Transform3D" setter="set_transform" getter="get_transform">
+		<member name="transform" type="Transform3D" setter="set_transform" getter="get_transform" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 			The body's transformation matrix.
 		</member>
 	</members>

--- a/doc/classes/PrimitiveMesh.xml
+++ b/doc/classes/PrimitiveMesh.xml
@@ -34,10 +34,10 @@
 		</method>
 	</methods>
 	<members>
-		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb">
+		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb" default="AABB(0, 0, 0, 0, 0, 0)">
 			Overrides the [AABB] with one defined by user for use with frustum culling. Especially useful to avoid unexpected culling when using a shader to offset vertices.
 		</member>
-		<member name="flip_faces" type="bool" setter="set_flip_faces" getter="get_flip_faces">
+		<member name="flip_faces" type="bool" setter="set_flip_faces" getter="get_flip_faces" default="false">
 			If set, the order of the vertices in each triangle are reversed resulting in the backside of the mesh being drawn.
 			This gives the same result as using [constant BaseMaterial3D.CULL_FRONT] in [member BaseMaterial3D.cull_mode].
 		</member>

--- a/doc/classes/ProgressBar.xml
+++ b/doc/classes/ProgressBar.xml
@@ -15,6 +15,8 @@
 		<member name="show_percentage" type="bool" setter="set_show_percentage" getter="is_percentage_shown" default="true">
 			If [code]true[/code], the fill percentage is displayed on the bar.
 		</member>
+		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" default="0" />
+		<member name="step" type="float" setter="set_step" getter="get_step" overrides="Range" default="0.01" />
 	</members>
 	<constants>
 		<constant name="FILL_BEGIN_TO_END" value="0" enum="FillMode">

--- a/doc/classes/Range.xml
+++ b/doc/classes/Range.xml
@@ -38,34 +38,34 @@
 		</method>
 	</methods>
 	<members>
-		<member name="allow_greater" type="bool" setter="set_allow_greater" getter="is_greater_allowed">
+		<member name="allow_greater" type="bool" setter="set_allow_greater" getter="is_greater_allowed" default="false">
 			If [code]true[/code], [member value] may be greater than [member max_value].
 		</member>
-		<member name="allow_lesser" type="bool" setter="set_allow_lesser" getter="is_lesser_allowed">
+		<member name="allow_lesser" type="bool" setter="set_allow_lesser" getter="is_lesser_allowed" default="false">
 			If [code]true[/code], [member value] may be less than [member min_value].
 		</member>
-		<member name="exp_edit" type="bool" setter="set_exp_ratio" getter="is_ratio_exp">
+		<member name="exp_edit" type="bool" setter="set_exp_ratio" getter="is_ratio_exp" default="false">
 			If [code]true[/code], and [code]min_value[/code] is greater than 0, [code]value[/code] will be represented exponentially rather than linearly.
 		</member>
-		<member name="max_value" type="float" setter="set_max" getter="get_max">
+		<member name="max_value" type="float" setter="set_max" getter="get_max" default="100.0">
 			Maximum value. Range is clamped if [code]value[/code] is greater than [code]max_value[/code].
 		</member>
-		<member name="min_value" type="float" setter="set_min" getter="get_min">
+		<member name="min_value" type="float" setter="set_min" getter="get_min" default="0.0">
 			Minimum value. Range is clamped if [code]value[/code] is less than [code]min_value[/code].
 		</member>
-		<member name="page" type="float" setter="set_page" getter="get_page">
+		<member name="page" type="float" setter="set_page" getter="get_page" default="0.0">
 			Page size. Used mainly for [ScrollBar]. ScrollBar's length is its size multiplied by [code]page[/code] over the difference between [code]min_value[/code] and [code]max_value[/code].
 		</member>
 		<member name="ratio" type="float" setter="set_as_ratio" getter="get_as_ratio">
 			The value mapped between 0 and 1.
 		</member>
-		<member name="rounded" type="bool" setter="set_use_rounded_values" getter="is_using_rounded_values">
+		<member name="rounded" type="bool" setter="set_use_rounded_values" getter="is_using_rounded_values" default="false">
 			If [code]true[/code], [code]value[/code] will always be rounded to the nearest integer.
 		</member>
-		<member name="step" type="float" setter="set_step" getter="get_step">
+		<member name="step" type="float" setter="set_step" getter="get_step" default="1.0">
 			If greater than 0, [code]value[/code] will always be rounded to a multiple of [code]step[/code]. If [code]rounded[/code] is also [code]true[/code], [code]value[/code] will first be rounded to a multiple of [code]step[/code] then rounded to the nearest integer.
 		</member>
-		<member name="value" type="float" setter="set_value" getter="get_value">
+		<member name="value" type="float" setter="set_value" getter="get_value" default="0.0">
 			Range's current value. Changing this property (even via code) will trigger [signal value_changed] signal. Use [method set_value_no_signal] if you want to avoid it.
 		</member>
 	</members>

--- a/doc/classes/ScrollBar.xml
+++ b/doc/classes/ScrollBar.xml
@@ -12,6 +12,8 @@
 		<member name="custom_step" type="float" setter="set_custom_step" getter="get_custom_step" default="-1.0">
 			Overrides the step used when clicking increment and decrement buttons or when using arrow keys when the [ScrollBar] is focused.
 		</member>
+		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" default="0" />
+		<member name="step" type="float" setter="set_step" getter="get_step" overrides="Range" default="0.0" />
 	</members>
 	<signals>
 		<signal name="scrolling">

--- a/doc/classes/Slider.xml
+++ b/doc/classes/Slider.xml
@@ -13,9 +13,11 @@
 		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="true">
 			If [code]true[/code], the slider can be interacted with. If [code]false[/code], the value can be changed only by code.
 		</member>
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
 		<member name="scrollable" type="bool" setter="set_scrollable" getter="is_scrollable" default="true">
 			If [code]true[/code], the value can be changed using the mouse wheel.
 		</member>
+		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" default="0" />
 		<member name="tick_count" type="int" setter="set_ticks" getter="get_ticks" default="0">
 			Number of ticks displayed on the slider, including border ticks. Ticks are uniformly-distributed value markers.
 		</member>

--- a/doc/classes/StyleBox.xml
+++ b/doc/classes/StyleBox.xml
@@ -114,21 +114,21 @@
 		</method>
 	</methods>
 	<members>
-		<member name="content_margin_bottom" type="float" setter="set_default_margin" getter="get_default_margin">
+		<member name="content_margin_bottom" type="float" setter="set_default_margin" getter="get_default_margin" default="-1.0">
 			The bottom margin for the contents of this style box. Increasing this value reduces the space available to the contents from the bottom.
 			If this value is negative, it is ignored and a child-specific margin is used instead. For example for [StyleBoxFlat] the border thickness (if any) is used instead.
 			It is up to the code using this style box to decide what these contents are: for example, a [Button] respects this content margin for the textual contents of the button.
 			[method get_margin] should be used to fetch this value as consumer instead of reading these properties directly. This is because it correctly respects negative values and the fallback mentioned above.
 		</member>
-		<member name="content_margin_left" type="float" setter="set_default_margin" getter="get_default_margin">
+		<member name="content_margin_left" type="float" setter="set_default_margin" getter="get_default_margin" default="-1.0">
 			The left margin for the contents of this style box.	Increasing this value reduces the space available to the contents from the left.
 			Refer to [member content_margin_bottom] for extra considerations.
 		</member>
-		<member name="content_margin_right" type="float" setter="set_default_margin" getter="get_default_margin">
+		<member name="content_margin_right" type="float" setter="set_default_margin" getter="get_default_margin" default="-1.0">
 			The right margin for the contents of this style box. Increasing this value reduces the space available to the contents from the right.
 			Refer to [member content_margin_bottom] for extra considerations.
 		</member>
-		<member name="content_margin_top" type="float" setter="set_default_margin" getter="get_default_margin">
+		<member name="content_margin_top" type="float" setter="set_default_margin" getter="get_default_margin" default="-1.0">
 			The top margin for the contents of this style box. Increasing this value reduces the space available to the contents from the top.
 			Refer to [member content_margin_bottom] for extra considerations.
 		</member>

--- a/doc/classes/TextureProgressBar.xml
+++ b/doc/classes/TextureProgressBar.xml
@@ -27,6 +27,7 @@
 		<member name="fill_mode" type="int" setter="set_fill_mode" getter="get_fill_mode" default="0">
 			The fill direction. See [enum FillMode] for possible values.
 		</member>
+		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" overrides="Control" enum="Control.MouseFilter" default="1" />
 		<member name="nine_patch_stretch" type="bool" setter="set_nine_patch_stretch" getter="get_nine_patch_stretch" default="false">
 			If [code]true[/code], Godot treats the bar's textures like in [NinePatchRect]. Use the [code]stretch_margin_*[/code] properties like [member stretch_margin_bottom] to set up the nine patch's 3×3 grid. When using a radial [member fill_mode], this setting will enable stretching.
 		</member>

--- a/doc/classes/ViewportTexture.xml
+++ b/doc/classes/ViewportTexture.xml
@@ -15,6 +15,7 @@
 		<link title="3D Viewport Scaling Demo">https://godotengine.org/asset-library/asset/586</link>
 	</tutorials>
 	<members>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="true" />
 		<member name="viewport_path" type="NodePath" setter="set_viewport_path_in_scene" getter="get_viewport_path_in_scene" default="NodePath(&quot;&quot;)">
 			The path to the [Viewport] node to display. This is relative to the scene root, not to the node which uses the texture.
 		</member>

--- a/doc/classes/VisualInstance3D.xml
+++ b/doc/classes/VisualInstance3D.xml
@@ -56,7 +56,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="layers" type="int" setter="set_layer_mask" getter="get_layer_mask">
+		<member name="layers" type="int" setter="set_layer_mask" getter="get_layer_mask" default="1">
 			The render layer(s) this [VisualInstance3D] is drawn on.
 			This object will only be visible for [Camera3D]s whose cull mask includes the render object this [VisualInstance3D] is set to.
 			For [Light3D]s, this can be used to control which [VisualInstance3D]s are affected by a specific light. For [GPUParticles3D], this can be used to control which particles are effected by a specific attractor. For [Decal]s, this can be used to control which [VisualInstance3D]s are affected by a specific decal.

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -335,7 +335,7 @@ static Variant get_documentation_default_value(const StringName &p_class_name, c
 	Variant default_value = Variant();
 	r_default_value_valid = false;
 
-	if (ClassDB::can_instantiate(p_class_name)) {
+	if (ClassDB::can_instantiate(p_class_name)) { // Keep this condition in sync with ClassDB::class_get_default_property_value.
 		default_value = ClassDB::class_get_default_property_value(p_class_name, p_property_name, &r_default_value_valid);
 	} else {
 		// Cannot get default value of classes that can't be instantiated


### PR DESCRIPTION
Virtual classes were introduced in #58972. These are types that are technically able to be instanced by the engine so that they can be inherited in GDExtension, but before this PR, the default values in the docs were not showing up.

I noticed this issue while I was working on making CanvasItem virtual, and the default values all disappeared.