### PR TITLE
Fix static object destructors being called on gpu selection with X11

### DIFF
--- a/platform/linuxbsd/x11/detect_prime_x11.cpp
+++ b/platform/linuxbsd/x11/detect_prime_x11.cpp
@@ -208,7 +208,10 @@ int detect_prime() {
 				print_verbose("Couldn't write vendor/renderer string.");
 			}
 			close(fdset[1]);
-			exit(0);
+
+			// The function quick_exit() is used because exit() will call destructors on static objects copied by fork().
+			// These objects will be freed anyway when the process finishes execution.
+			quick_exit(0);
 		}
 	}
 


### PR DESCRIPTION
Resolves #68322 

There is no need to call static object destructors on a child process that is used purely for determining the best GPU to use.