### PR TITLE
Fixes inability to assign script after clearing

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -409,7 +409,9 @@ bool PlaceHolderScriptInstance::set(const StringName &p_name, const Variant &p_v
 	if (values.has(p_name)) {
 		Variant defval;
 		if (script->get_property_default_value(p_name, defval)) {
-			if (defval == p_value) {
+			// The evaluate function ensures that a NIL variant is equal to e.g. an empty Resource.
+			// Simply doing defval == p_value does not do this.
+			if (Variant::evaluate(Variant::OP_EQUAL, defval, p_value)) {
 				values.erase(p_name);
 				return true;
 			}
@@ -419,7 +421,7 @@ bool PlaceHolderScriptInstance::set(const StringName &p_name, const Variant &p_v
 	} else {
 		Variant defval;
 		if (script->get_property_default_value(p_name, defval)) {
-			if (defval != p_value) {
+			if (Variant::evaluate(Variant::OP_NOT_EQUAL, defval, p_value)) {
 				values[p_name] = p_value;
 			}
 			return true;

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -31,6 +31,7 @@
 #include "editor_properties.h"
 
 #include "core/config/project_settings.h"
+#include "core/core_string_names.h"
 #include "editor/editor_file_dialog.h"
 #include "editor/editor_node.h"
 #include "editor/editor_properties_array_dict.h"
@@ -3844,8 +3845,11 @@ void EditorPropertyResource::_resource_selected(const Ref<Resource> &p_resource,
 void EditorPropertyResource::_resource_changed(const Ref<Resource> &p_resource) {
 	// Make visual script the correct type.
 	Ref<Script> s = p_resource;
+
+	// The bool is_script applies only to an object's main script.
+	// Changing the value of Script-type exported variables of the main script should not trigger saving/reloading properties.
 	bool is_script = false;
-	if (get_edited_object() && s.is_valid()) {
+	if (get_edited_object() && s.is_valid() && get_edited_property() == CoreStringNames::get_singleton()->_script) {
 		is_script = true;
 		InspectorDock::get_singleton()->store_script_properties(get_edited_object());
 		s->call("set_instance_base_type", get_edited_object()->get_class());


### PR DESCRIPTION
Fixes #67938 in two different ways. Either would work in isolation, but both of them reflect more desirable behavior.

### Problem 1

When an object's script is changed/updated, the `InspectorDock` temporarily stores non-default values of its exported values, then reloads those values into the variables of the new/updated script. When we assign some script to an exported variable, that behavior is triggered. It shouldn't, since exported variables effectively only in an object's main script - not the scripts assigned to its exported variables.

When you clear a script, variable, you assign a null value to that exported variable. That gets stored. Then the variable is updated (as desired), but then that update is overwritten by the undesired restoring of exported variable values (the null value).

To fix this, we simply ensure that the storing/restoring of exported variables is only triggered assigning to an object's main script, i.e. the `script` property.

Note that it is currently possible to define exported variables called `script`, which is a bug. See #68430.

### Problem 2

`PlaceHolderScript` keeps track of exported variables that have been assigned to in the `values` hashmap. If there is a non-default value stored in `values`, that gets set when script properties are restored.

If they are ever assigned their default value, then that key disappears from `values` (it has reverted to its original state, so no need to keep track).

But often, the default type may slightly differ to what is possible to assign to it.

- The default type for a `Resource` (or `Script`), is a `NIL` Variant.
- The `edited_resource` provided by `ResourcePicker`'s `Clear` option is an empty `Ref<Resource>`, which is implicitly converted to an empty `OBJECT` variant.

Right now, comparing the two with `defval == p_value` (are these the same objects) returns false because the types are different. Semantically, what we want is _are these equivalent variants_. This fix uses the more comprehensive variant comparison operators in `variant_op.h/cpp`, which make empty `OBJECT` variants equal to `NIL` variants.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
