### PR TITLE
Fix SubViewport with default size being pink

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4231,6 +4231,8 @@ void SubViewport::_bind_methods() {
 	BIND_ENUM_CONSTANT(UPDATE_ALWAYS);
 }
 
-SubViewport::SubViewport() {}
+SubViewport::SubViewport() {
+	RS::get_singleton()->viewport_set_size(get_viewport_rid(), get_size().width, get_size().height);
+}
 
 SubViewport::~SubViewport() {}


### PR DESCRIPTION
A SubViewport with default-size doesn't display its content, but shows pink color, until it is resized.
This patch makes sure, that the size gets set during initialization.
resolve #66483