### PR TITLE
Setting surface AABBs for mesh surfaces in headless mode.

### DIFF
--- a/servers/rendering/dummy/storage/mesh_storage.h
+++ b/servers/rendering/dummy/storage/mesh_storage.h
@@ -81,6 +81,7 @@ public:
 		s->vertex_count = p_surface.vertex_count;
 		s->index_data = p_surface.index_data;
 		s->index_count = p_surface.index_count;
+		s->aabb = p_surface.aabb;
 		s->skin_data = p_surface.skin_data;
 	}
 


### PR DESCRIPTION
This PR fixes the setting of bounding box data of surfaces in the dummy mesh storage, required for correct mesh creation when Godot is started in headless mode.

Sponsored by Migeran (https://migeran.com)
