### PR TITLE
Fix Quick Open window to use EDSCALE and save the size between popups

### DIFF
--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -171,7 +171,13 @@ void EditorCommandPalette::_confirmed() {
 }
 
 void EditorCommandPalette::open_popup() {
-	popup_centered_clamped(Size2i(600, 440), 0.8f);
+	static bool was_showed = false;
+	if (!was_showed) {
+		was_showed = true;
+		popup_centered_clamped(Size2(600, 440) * EDSCALE, 0.8f);
+	} else {
+		show();
+	}
 
 	command_search_box->clear();
 	command_search_box->grab_focus();

--- a/editor/editor_quick_open.cpp
+++ b/editor/editor_quick_open.cpp
@@ -32,12 +32,20 @@
 
 #include "core/os/keyboard.h"
 #include "editor/editor_node.h"
+#include "editor/editor_scale.h"
 
 void EditorQuickOpen::popup_dialog(const String &p_base, bool p_enable_multi, bool p_dontclear) {
 	base_type = p_base;
 	allow_multi_select = p_enable_multi;
 	search_options->set_select_mode(allow_multi_select ? Tree::SELECT_MULTI : Tree::SELECT_SINGLE);
-	popup_centered_clamped(Size2i(600, 440), 0.8f);
+
+	static bool was_showed = false;
+	if (!was_showed) {
+		was_showed = true;
+		popup_centered_clamped(Size2(600, 440) * EDSCALE, 0.8f);
+	} else {
+		show();
+	}
 
 	EditorFileSystemDirectory *efsd = EditorFileSystem::get_singleton()->get_filesystem();
 	_build_search_cache(efsd);


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/68363
