### PR TITLE
GDExtension: Ensure newline at EOF

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "extension_api_dump.h"
+
 #include "core/config/engine.h"
 #include "core/core_constants.h"
 #include "core/io/file_access.h"
@@ -938,9 +939,9 @@ void NativeExtensionAPIDump::generate_extension_json_file(const String &p_path) 
 	Ref<JSON> json;
 	json.instantiate();
 
-	String text = json->stringify(api, "\t", false);
+	String text = json->stringify(api, "\t", false) + "\n";
 	Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::WRITE);
-	CharString cs = text.ascii();
-	fa->store_buffer((const uint8_t *)cs.ptr(), cs.length());
+	fa->store_string(text);
 }
-#endif
+
+#endif // TOOLS_ENABLED


### PR DESCRIPTION
I seem to recall that there used to be a newline in the generated json, but since a few weeks it's no longer there.

Maybe `JSON::stringify` changed? Should we make it so that `JSON::stringify` always includes a trailing newline, or keep it as is?