### PR TITLE
GDScript compiler inner class bugfixes

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -137,7 +137,6 @@ class GDScript : public Script {
 	void _super_implicit_constructor(GDScript *p_script, GDScriptInstance *p_instance, Callable::CallError &r_error);
 	GDScriptInstance *_create_instance(const Variant **p_args, int p_argcount, Object *p_owner, bool p_is_ref_counted, Callable::CallError &r_error);
 
-	void _set_subclass_path(Ref<GDScript> &p_sc, const String &p_path);
 	String _get_debug_path() const;
 
 #ifdef TOOLS_ENABLED
@@ -178,6 +177,11 @@ public:
 
 	bool inherits_script(const Ref<Script> &p_script) const override;
 
+	GDScript *find_class(const String &p_qualified_name);
+	bool is_subclass(const GDScript *p_script);
+	GDScript *get_root_script();
+	bool is_root_script() const { return _owner == nullptr; }
+	String get_fully_qualified_name() const { return fully_qualified_name; }
 	const HashMap<StringName, Ref<GDScript>> &get_subclasses() const { return subclasses; }
 	const HashMap<StringName, Variant> &get_constants() const { return constants; }
 	const HashSet<StringName> &get_members() const { return members; }
@@ -223,7 +227,6 @@ public:
 	virtual Error reload(bool p_keep_state = false) override;
 
 	virtual void set_path(const String &p_path, bool p_take_over = false) override;
-	void set_script_path(const String &p_path) { path = p_path; } //because subclasses need a path too...
 	Error load_source_code(const String &p_path);
 	Error load_byte_code(const String &p_path);
 

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -213,16 +213,6 @@ Error GDScriptAnalyzer::resolve_inheritance(GDScriptParser::ClassNode *p_class, 
 		return OK;
 	}
 
-	if (p_class == parser->head) {
-		if (p_class->identifier) {
-			p_class->fqcn = p_class->identifier->name;
-		} else {
-			p_class->fqcn = parser->script_path;
-		}
-	} else {
-		p_class->fqcn = p_class->outer->fqcn + "::" + String(p_class->identifier->name);
-	}
-
 	if (p_class->identifier) {
 		StringName class_name = p_class->identifier->name;
 		if (class_exists(class_name)) {

--- a/modules/gdscript/gdscript_cache.h
+++ b/modules/gdscript/gdscript_cache.h
@@ -87,8 +87,9 @@ class GDScriptCache {
 public:
 	static Ref<GDScriptParserRef> get_parser(const String &p_path, GDScriptParserRef::Status status, Error &r_error, const String &p_owner = String());
 	static String get_source_code(const String &p_path);
-	static Ref<GDScript> get_shallow_script(const String &p_path, const String &p_owner = String());
+	static Ref<GDScript> get_shallow_script(const String &p_path, Error &r_error, const String &p_owner = String());
 	static Ref<GDScript> get_full_script(const String &p_path, Error &r_error, const String &p_owner = String(), bool p_update_from_disk = false);
+	static Ref<GDScript> get_cached_script(const String &p_path);
 	static Error finish_compiling(const String &p_owner);
 
 	GDScriptCache();

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -121,7 +121,7 @@ class GDScriptCompiler {
 	Error _create_binary_operator(CodeGen &codegen, const GDScriptParser::BinaryOpNode *on, Variant::Operator op, bool p_initializer = false, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
 	Error _create_binary_operator(CodeGen &codegen, const GDScriptParser::ExpressionNode *p_left_operand, const GDScriptParser::ExpressionNode *p_right_operand, Variant::Operator op, bool p_initializer = false, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
 
-	GDScriptDataType _gdtype_from_datatype(const GDScriptParser::DataType &p_datatype, GDScript *p_owner = nullptr) const;
+	GDScriptDataType _gdtype_from_datatype(const GDScriptParser::DataType &p_datatype, GDScript *p_owner);
 
 	GDScriptCodeGenerator::Address _parse_assign_right_expression(CodeGen &codegen, Error &r_error, const GDScriptParser::AssignmentNode *p_assignmentint, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
 	GDScriptCodeGenerator::Address _parse_expression(CodeGen &codegen, Error &r_error, const GDScriptParser::ExpressionNode *p_expression, bool p_root = false, bool p_initializer = false, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
@@ -130,9 +130,8 @@ class GDScriptCompiler {
 	Error _parse_block(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block, bool p_add_locals = true);
 	GDScriptFunction *_parse_function(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::FunctionNode *p_func, bool p_for_ready = false, bool p_for_lambda = false);
 	Error _parse_setter_getter(GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::VariableNode *p_variable, bool p_is_setter);
-	Error _parse_class_level(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state);
-	Error _parse_class_blocks(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state);
-	void _make_scripts(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state);
+	Error _populate_class_members(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state);
+	Error _compile_class(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state);
 	int err_line = 0;
 	int err_column = 0;
 	StringName source;
@@ -140,6 +139,7 @@ class GDScriptCompiler {
 	bool within_await = false;
 
 public:
+	static void make_scripts(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state);
 	Error compile(const GDScriptParser *p_parser, GDScript *p_script, bool p_keep_state = false);
 
 	String get_error() const;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3051,8 +3051,9 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 						r_result.type = ScriptLanguage::LOOKUP_RESULT_SCRIPT_LOCATION;
 						r_result.location = base_type.class_type->get_member(p_symbol).get_line();
 						r_result.class_path = base_type.script_path;
-						r_result.script = GDScriptCache::get_shallow_script(r_result.class_path);
-						return OK;
+						Error err = OK;
+						r_result.script = GDScriptCache::get_shallow_script(r_result.class_path, err);
+						return err;
 					}
 					base_type = base_type.class_type->base_type;
 				}

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -534,6 +534,7 @@ void GDScriptParser::end_statement(const String &p_context) {
 
 void GDScriptParser::parse_program() {
 	head = alloc_node<ClassNode>();
+	head->fqcn = script_path;
 	current_class = head;
 
 	// If we happen to parse an annotation before extends or class_name keywords, track it.
@@ -646,6 +647,9 @@ GDScriptParser::ClassNode *GDScriptParser::parse_class() {
 
 	if (consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected identifier for the class name after "class".)")) {
 		n_class->identifier = parse_identifier();
+		if (n_class->outer) {
+			n_class->fqcn = n_class->outer->fqcn + "::" + n_class->identifier->name;
+		}
 	}
 
 	if (match(GDScriptTokenizer::Token::EXTENDS)) {
@@ -684,6 +688,7 @@ GDScriptParser::ClassNode *GDScriptParser::parse_class() {
 void GDScriptParser::parse_class_name() {
 	if (consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected identifier for the global class name after "class_name".)")) {
 		current_class->identifier = parse_identifier();
+		current_class->fqcn = String(current_class->identifier->name);
 	}
 
 	if (match(GDScriptTokenizer::Token::EXTENDS)) {

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -461,7 +461,6 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 	Ref<GDScript> script;
 	script.instantiate();
 	script->set_path(source_file);
-	script->set_script_path(source_file);
 	err = script->load_source_code(source_file);
 	if (err != OK) {
 		enable_stdout();

--- a/modules/gdscript/tests/scripts/analyzer/features/external_inner_base.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/external_inner_base.gd
@@ -1,0 +1,4 @@
+extends "inner_base.gd".InnerA.InnerAB
+
+func test():
+	super.test()

--- a/modules/gdscript/tests/scripts/analyzer/features/external_inner_base.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/external_inner_base.out
@@ -1,0 +1,3 @@
+GDTEST_OK
+InnerA.InnerAB.test
+InnerB.test

--- a/modules/gdscript/tests/scripts/analyzer/features/inner_base.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/inner_base.gd
@@ -1,0 +1,18 @@
+extends InnerA
+
+func test():
+	super.test()
+
+class InnerA extends InnerAB:
+	func test():
+		print("InnerA.test")
+		super.test()
+
+	class InnerAB extends InnerB:
+		func test():
+			print("InnerA.InnerAB.test")
+			super.test()
+
+class InnerB:
+	func test():
+		print("InnerB.test")

--- a/modules/gdscript/tests/scripts/analyzer/features/inner_base.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/inner_base.out
@@ -1,0 +1,4 @@
+GDTEST_OK
+InnerA.test
+InnerA.InnerAB.test
+InnerB.test


### PR DESCRIPTION
Replaces some important outdated code about subclasses.
rpc properties correctly apply to subclasses.
subclasses of subclasses now have docs populated.
shallow scripts have their subclass scripts populated and name and id set.
various other fixes.

- Fixes #65953
- Fixes #68291
- Fixes #68561
- Fixes #64915
- Fixes #61848
- Fixes #61268
- Fixes #67977
- Fixes #62982
- Fixes #67753
- Fixes #67547
- Fixes #67163