### PR TITLE
set X11 window focus to false in Window data struct

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -155,7 +155,7 @@ class DisplayServerX11 : public DisplayServer {
 		bool borderless = false;
 		bool resize_disabled = false;
 		Vector2i last_position_before_fs;
-		bool focused = true;
+		bool focused = false;
 		bool minimized = false;
 		bool maximized = false;
 		bool is_popup = false;


### PR DESCRIPTION
It might be important to note this is my first PR for this project so I apologise if there are any teething issues.

this is to fix issue [#68197](https://github.com/godotengine/godot/issues/68197)

undoes ac1e7e10. This doesn't seem to cause any changes other then the desired one of ensuring that editor tooltips don't hover above newly created game windows (ie: when running the currect scene).

This change isn't needed prior to changes made in the v4.0 beta

edit: I don't have a windows system so I can't locate (or test fixes for) the bug in windows as per the original issues stated OS 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
