### PR TITLE
Bounds fixes in `TextureAtlas` import

### DIFF
--- a/editor/editor_atlas_packer.cpp
+++ b/editor/editor_atlas_packer.cpp
@@ -59,7 +59,7 @@ void EditorAtlasPacker::chart_pack(Vector<Chart> &charts, int &r_width, int &r_h
 
 		Ref<BitMap> src_bitmap;
 		src_bitmap.instantiate();
-		src_bitmap->create(aabb.size / divide_by);
+		src_bitmap->create((aabb.size + Vector2(divide_by - 1, divide_by - 1)) / divide_by);
 
 		int w = src_bitmap->get_size().width;
 		int h = src_bitmap->get_size().height;


### PR DESCRIPTION
Fixes Importing of TextureAtlas in Mesh2D mode, adding settings for the generation of the triangulation which was not optimal, using the same options as used in Sprite2D editor

There is still a problem with gaps in the texture (see #68350) and if I find a way to solve that I will add that here but otherwise I will leave that for someone else I currently cannot see a solution.

Currently not fixing the errors in rasterisation, will investigate further later or let someone else solve that (added a note about this).

* Fixes #68350 (partially)
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
