### PR TITLE
expose ARVRInterface::get_transform_for_eye to gdscript

### DIFF
--- a/doc/classes/ARVRInterface.xml
+++ b/doc/classes/ARVRInterface.xml
@@ -41,6 +41,14 @@
 				If supported, returns the status of our tracking. This will allow you to provide feedback to the user whether there are issues with positional tracking.
 			</description>
 		</method>
+		<method name="get_transform_for_eye">
+			<return type="Transform" />
+			<argument index="0" name="eye" type="int" enum="ARVRInterface.Eyes" />
+			<argument index="1" name="transform" type="Transform" />
+			<description>
+				Returns the transform for an eye multiplied by [code]transform[/code]. The usual value for [code]transform[/code] is the global_transform of the current ARVROrigin.
+			</description>
+		</method>
 		<method name="initialize">
 			<return type="bool" />
 			<description>

--- a/servers/arvr/arvr_interface.cpp
+++ b/servers/arvr/arvr_interface.cpp
@@ -46,6 +46,7 @@ void ARVRInterface::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_render_targetsize"), &ARVRInterface::get_render_targetsize);
 	ClassDB::bind_method(D_METHOD("is_stereo"), &ARVRInterface::is_stereo);
+	ClassDB::bind_method(D_METHOD("get_transform_for_eye", "eye", "transform"), &ARVRInterface::get_transform_for_eye);
 
 	ADD_GROUP("Interface", "interface_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "interface_is_primary"), "set_is_primary", "is_primary");


### PR DESCRIPTION
Hello

By exposing ARVRInterface::get_transform_for_eye, it's possible to implement true stereoscopic mirrors and portals in VR previously impossible in godot. 

I made this specifically for 3.x since viewport textures seem to be not working on godot 4 with openxr yet and I couldn't make it work, but it 's rather easy to port (it would be get_transform_for_view instead) 
 
I made a demo using the method to render stereoscopic mirrors in VR, it can be found here: 
https://github.com/cheece/godot-vr-mirror-test

![20221107152938_1_vr](https://user-images.githubusercontent.com/9534017/200389622-08598ce7-df1e-4c66-a733-ca036737780b.jpg)

update:

I found a workaround about the viewports not rendering in godot 4 and I got it working finally, so I made a PR to master too #68390

