### PR TITLE
Implement snappedi, snappedf, and Vector[2/3/4]i.snapped

### DIFF
--- a/core/math/vector2i.cpp
+++ b/core/math/vector2i.cpp
@@ -39,6 +39,12 @@ Vector2i Vector2i::clamp(const Vector2i &p_min, const Vector2i &p_max) const {
 			CLAMP(y, p_min.y, p_max.y));
 }
 
+Vector2i Vector2i::snapped(const Vector2i &p_step) const {
+	return Vector2i(
+			Math::snapped(x, p_step.x),
+			Math::snapped(y, p_step.y));
+}
+
 int64_t Vector2i::length_squared() const {
 	return x * (int64_t)x + y * (int64_t)y;
 }

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -119,6 +119,7 @@ struct _NO_DISCARD_ Vector2i {
 	Vector2i sign() const { return Vector2i(SIGN(x), SIGN(y)); }
 	Vector2i abs() const { return Vector2i(Math::abs(x), Math::abs(y)); }
 	Vector2i clamp(const Vector2i &p_min, const Vector2i &p_max) const;
+	Vector2i snapped(const Vector2i &p_step) const;
 
 	operator String() const;
 	operator Vector2() const;

--- a/core/math/vector3i.cpp
+++ b/core/math/vector3i.cpp
@@ -48,6 +48,13 @@ Vector3i Vector3i::clamp(const Vector3i &p_min, const Vector3i &p_max) const {
 			CLAMP(z, p_min.z, p_max.z));
 }
 
+Vector3i Vector3i::snapped(const Vector3i &p_step) const {
+	return Vector3i(
+			Math::snapped(x, p_step.x),
+			Math::snapped(y, p_step.y),
+			Math::snapped(z, p_step.z));
+}
+
 Vector3i::operator String() const {
 	return "(" + itos(x) + ", " + itos(y) + ", " + itos(z) + ")";
 }

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -77,6 +77,7 @@ struct _NO_DISCARD_ Vector3i {
 	_FORCE_INLINE_ Vector3i abs() const;
 	_FORCE_INLINE_ Vector3i sign() const;
 	Vector3i clamp(const Vector3i &p_min, const Vector3i &p_max) const;
+	Vector3i snapped(const Vector3i &p_step) const;
 
 	/* Operators */
 

--- a/core/math/vector4i.cpp
+++ b/core/math/vector4i.cpp
@@ -65,6 +65,14 @@ Vector4i Vector4i::clamp(const Vector4i &p_min, const Vector4i &p_max) const {
 			CLAMP(w, p_min.w, p_max.w));
 }
 
+Vector4i Vector4i::snapped(const Vector4i &p_step) const {
+	return Vector4i(
+			Math::snapped(x, p_step.x),
+			Math::snapped(y, p_step.y),
+			Math::snapped(z, p_step.z),
+			Math::snapped(w, p_step.w));
+}
+
 Vector4i::operator String() const {
 	return "(" + itos(x) + ", " + itos(y) + ", " + itos(z) + ", " + itos(w) + ")";
 }

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -79,6 +79,7 @@ struct _NO_DISCARD_ Vector4i {
 	_FORCE_INLINE_ Vector4i abs() const;
 	_FORCE_INLINE_ Vector4i sign() const;
 	Vector4i clamp(const Vector4i &p_min, const Vector4i &p_max) const;
+	Vector4i snapped(const Vector4i &p_step) const;
 
 	/* Operators */
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1646,6 +1646,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector2i, sign, sarray(), varray());
 	bind_method(Vector2i, abs, sarray(), varray());
 	bind_method(Vector2i, clamp, sarray("min", "max"), varray());
+	bind_method(Vector2i, snapped, sarray("step"), varray());
 
 	/* Rect2 */
 
@@ -1734,6 +1735,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector3i, sign, sarray(), varray());
 	bind_method(Vector3i, abs, sarray(), varray());
 	bind_method(Vector3i, clamp, sarray("min", "max"), varray());
+	bind_method(Vector3i, snapped, sarray("step"), varray());
 
 	/* Vector4 */
 
@@ -1773,6 +1775,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector4i, sign, sarray(), varray());
 	bind_method(Vector4i, abs, sarray(), varray());
 	bind_method(Vector4i, clamp, sarray("min", "max"), varray());
+	bind_method(Vector4i, snapped, sarray("step"), varray());
 
 	/* Plane */
 

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -16,7 +16,7 @@
 			<return type="Variant" />
 			<param index="0" name="x" type="Variant" />
 			<description>
-				Returns the absolute value of a [Variant] parameter [param x] (i.e. non-negative value). Variant types [int], [float], [Vector2], [Vector2i], [Vector3] and [Vector3i] are supported.
+				Returns the absolute value of a [Variant] parameter [param x] (i.e. non-negative value). Supported types: [int], [float], [Vector2], [Vector2i], [Vector3], [Vector3i], [Vector4], [Vector4i].
 				[codeblock]
 				var a = abs(-1)
 				# a is 1
@@ -36,6 +36,7 @@
 				var f = abs(Vector3i(-7, -8, -9))
 				# f is (7, 8, 9)
 				[/codeblock]
+				[b]Note:[/b] For better type safety, use [method absf], [method absi], [method Vector2.abs], [method Vector2i.abs], [method Vector3.abs], [method Vector3i.abs], [method Vector4.abs], or [method Vector4i.abs].
 			</description>
 		</method>
 		<method name="absf">
@@ -143,7 +144,7 @@
 				i = ceil(1.001)    # i is 2.0
 				[/codeblock]
 				See also [method floor], [method round], and [method snapped].
-				[b]Note:[/b] For better type safety, see [method ceilf], [method ceili], [method Vector2.ceil], [method Vector3.ceil] and [method Vector4.ceil].
+				[b]Note:[/b] For better type safety, use [method ceilf], [method ceili], [method Vector2.ceil], [method Vector3.ceil], or [method Vector4.ceil].
 			</description>
 		</method>
 		<method name="ceilf">
@@ -168,7 +169,7 @@
 			<param index="1" name="min" type="Variant" />
 			<param index="2" name="max" type="Variant" />
 			<description>
-				Clamps the [param value], returning a [Variant] not less than [param min] and not more than [param max]. Variant types [int], [float], [Vector2], [Vector2i], [Vector3] and [Vector3i] are supported.
+				Clamps the [param value], returning a [Variant] not less than [param min] and not more than [param max]. Supported types: [int], [float], [Vector2], [Vector2i], [Vector3], [Vector3i], [Vector4], [Vector4i].
 				[codeblock]
 				var a = clamp(-10, -1, 5)
 				# a is -1
@@ -188,6 +189,7 @@
 				var f = clamp(Vector3i(-7, -8, -9), Vector3i(-1, 2, 3), Vector3i(-4, -5, -6))
 				# f is (-4, -5, -6)
 				[/codeblock]
+				[b]Note:[/b] For better type safety, use [method clampf], [method clampi], [method Vector2.clamp], [method Vector2i.clamp], [method Vector3.clamp], [method Vector3i.clamp], [method Vector4.clamp], or [method Vector4i.clamp].
 			</description>
 		</method>
 		<method name="clampf">
@@ -367,7 +369,7 @@
 				a = floor(-2.99)    # a is -3.0
 				[/codeblock]
 				See also [method ceil], [method round], and [method snapped].
-				[b]Note:[/b] For better type safety, see [method floorf], [method floori], [method Vector2.floor], [method Vector3.floor] and [method Vector4.floor].
+				[b]Note:[/b] For better type safety, use [method floorf], [method floori], [method Vector2.floor], [method Vector3.floor], or [method Vector4.floor].
 			</description>
 		</method>
 		<method name="floorf">
@@ -950,7 +952,7 @@
 				round(2.6) # Returns 3
 				[/codeblock]
 				See also [method floor], [method ceil], and [method snapped].
-				[b]Note:[/b] For better type safety, use [method roundf], [method roundi], [method Vector2.round], [method Vector3.round] or [method Vector4.round], instead.
+				[b]Note:[/b] For better type safety, use [method roundf], [method roundi], [method Vector2.round], [method Vector3.round], or [method Vector4.round].
 			</description>
 		</method>
 		<method name="roundf">
@@ -987,21 +989,22 @@
 			<return type="Variant" />
 			<param index="0" name="x" type="Variant" />
 			<description>
-				Returns the sign of [param x] as same type of [Variant] as [param x] with each component being -1, 0 and 1 for each negative, zero and positive values respectively. Variant types [int], [float], [Vector2], [Vector2i], [Vector3] and [Vector3i] are supported.
+				Returns the same type of [Variant] as [param x], with [code]-1[/code] for negative values, [code]1[/code] for positive values, and [code]0[/code] for zeros. Supported types: [int], [float], [Vector2], [Vector2i], [Vector3], [Vector3i], [Vector4], [Vector4i].
 				[codeblock]
 				sign(-6.0) # Returns -1
 				sign(0.0)  # Returns 0
 				sign(6.0)  # Returns 1
 
-				sign(Vector3(-6.0, 0.0, 6.0) # Returns (-1, 0, 1)
+				sign(Vector3(-6.0, 0.0, 6.0)) # Returns (-1, 0, 1)
 				[/codeblock]
+				[b]Note:[/b] For better type safety, use [method signf], [method signi], [method Vector2.sign], [method Vector2i.sign], [method Vector3.sign], [method Vector3i.sign], [method Vector4.sign], or [method Vector4i.sign].
 			</description>
 		</method>
 		<method name="signf">
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns the sign of [param x] as a [float]: -1.0 or 1.0. Returns 0.0 if [param x] is 0.0.
+				Returns [code]-1.0[/code] if [param x] is negative, [code]1.0[/code] if [param x] is positive, and [code]0.0[/code] if if [param x] is zero.
 				[codeblock]
 				sign(-6.5) # Returns -1.0
 				sign(0.0)  # Returns 0.0
@@ -1013,7 +1016,7 @@
 			<return type="int" />
 			<param index="0" name="x" type="int" />
 			<description>
-				Returns the sign of [param x] as an [int]: -1 or 1. Returns 0 if [param x] is 0.
+				Returns [code]-1[/code] if [param x] is negative, [code]1[/code] if [param x] is positive, and [code]0[/code] if if [param x] is zero.
 				[codeblock]
 				sign(-6) # Returns -1
 				sign(0)  # Returns 0
@@ -1063,16 +1066,46 @@
 			</description>
 		</method>
 		<method name="snapped">
+			<return type="Variant" />
+			<param index="0" name="x" type="Variant" />
+			<param index="1" name="step" type="Variant" />
+			<description>
+				Returns the multiple of [param step] that is the closest to [param x]. This can also be used to round a floating point number to an arbitrary number of decimals.
+				The returned value is the same type of [Variant] as [param step]. Supported types: [int], [float], [Vector2], [Vector2i], [Vector3], [Vector3i], [Vector4], [Vector4i].
+				[codeblock]
+				snapped(100, 32)  # Returns 96
+				snapped(3.14159, 0.01)  # Returns 3.14
+
+				snapped(Vector2(34, 70), Vector2(8, 8))  # Returns (32, 72)
+				[/codeblock]
+				See also [method ceil], [method floor], and [method round].
+				[b]Note:[/b] For better type safety, use [method snappedf], [method snappedi], [method Vector2.snapped], [method Vector2i.snapped], [method Vector3.snapped], [method Vector3i.snapped], [method Vector4.snapped], or [method Vector4i.snapped].
+			</description>
+		</method>
+		<method name="snappedf">
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<param index="1" name="step" type="float" />
 			<description>
-				Snaps the float value [param x] to a given [param step]. This can also be used to round a floating point number to an arbitrary number of decimals.
+				Returns the multiple of [param step] that is the closest to [param x]. This can also be used to round a floating point number to an arbitrary number of decimals.
+				A type-safe version of [method snapped], returning a [float].
 				[codeblock]
-				snapped(100, 32) # Returns 96
-				snapped(3.14159, 0.01) # Returns 3.14
+				snapped(32.0, 2.5)  # Returns 32.5
+				snapped(3.14159, 0.01)  # Returns 3.14
 				[/codeblock]
-				See also [method ceil], [method floor], and [method round].
+			</description>
+		</method>
+		<method name="snappedi">
+			<return type="int" />
+			<param index="0" name="x" type="float" />
+			<param index="1" name="step" type="int" />
+			<description>
+				Returns the multiple of [param step] that is the closest to [param x].
+				A type-safe version of [method snapped], returning an [int].
+				[codeblock]
+				snapped(53, 16)  # Returns 48
+				snapped(4096, 100)  # Returns 4100
+				[/codeblock]
 			</description>
 		</method>
 		<method name="sqrt">

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -99,7 +99,7 @@
 			<return type="Vector2" />
 			<param index="0" name="n" type="Vector2" />
 			<description>
-				Returns the vector "bounced off" from a plane defined by the given normal.
+				Returns a new vector "bounced off" from a plane defined by the given normal.
 			</description>
 		</method>
 		<method name="ceil" qualifiers="const">
@@ -276,7 +276,7 @@
 		<method name="normalized" qualifiers="const">
 			<return type="Vector2" />
 			<description>
-				Returns the vector scaled to unit length. Equivalent to [code]v / v.length()[/code].
+				Returns a new vector scaled to unit length. Equivalent to [code]v / v.length()[/code].
 			</description>
 		</method>
 		<method name="orthogonal" qualifiers="const">
@@ -303,21 +303,21 @@
 			<return type="Vector2" />
 			<param index="0" name="b" type="Vector2" />
 			<description>
-				Returns this vector projected onto the vector [code]b[/code].
+				Returns the result of projecting the vector onto the given vector [param b].
 			</description>
 		</method>
 		<method name="reflect" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="n" type="Vector2" />
 			<description>
-				Returns the vector reflected (i.e. mirrored, or symmetric) over a line defined by the given direction vector [param n].
+				Returns the result of reflecting the vector from a line defined by the given direction vector [param n].
 			</description>
 		</method>
 		<method name="rotated" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="angle" type="float" />
 			<description>
-				Returns the vector rotated by [param angle] (in radians). See also [method @GlobalScope.deg_to_rad].
+				Returns the result of rotating this vector by [param angle] (in radians). See also [method @GlobalScope.deg_to_rad].
 			</description>
 		</method>
 		<method name="round" qualifiers="const">
@@ -329,7 +329,7 @@
 		<method name="sign" qualifiers="const">
 			<return type="Vector2" />
 			<description>
-				Returns a new vector with each component set to one or negative one, depending on the signs of the components, or zero if the component is zero, by calling [method @GlobalScope.sign] on each component.
+				Returns a new vector with each component set to [code]1.0[/code] if it's positive, [code]-1.0[/code] if it's negative, and [code]0.0[/code] if it's zero. The result is identical to calling [method @GlobalScope.sign] on each component.
 			</description>
 		</method>
 		<method name="slerp" qualifiers="const">
@@ -345,14 +345,14 @@
 			<return type="Vector2" />
 			<param index="0" name="n" type="Vector2" />
 			<description>
-				Returns this vector slid along a plane defined by the given normal.
+				Returns the result of sliding the vector along a plane defined by the given normal.
 			</description>
 		</method>
 		<method name="snapped" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="step" type="Vector2" />
 			<description>
-				Returns this vector with each component snapped to the nearest multiple of [param step]. This can also be used to round to an arbitrary number of decimals.
+				Returns a new vector with each component snapped to the nearest multiple of the corresponding component in [param step]. This can also be used to round the components to an arbitrary number of decimals.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -92,7 +92,14 @@
 		<method name="sign" qualifiers="const">
 			<return type="Vector2i" />
 			<description>
-				Returns a new vector with each component set to one or negative one, depending on the signs of the components, or zero if the component is zero, by calling [method @GlobalScope.sign] on each component.
+				Returns a new vector with each component set to [code]1[/code] if it's positive, [code]-1[/code] if it's negative, and [code]0[/code] if it's zero. The result is identical to calling [method @GlobalScope.sign] on each component.
+			</description>
+		</method>
+		<method name="snapped" qualifiers="const">
+			<return type="Vector2i" />
+			<param index="0" name="step" type="Vector2i" />
+			<description>
+				Returns a new vector with each component snapped to the closest multiple of the corresponding component in [param step].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -287,14 +287,14 @@
 			<return type="Vector3" />
 			<param index="0" name="b" type="Vector3" />
 			<description>
-				Returns this vector projected onto the vector [param b].
+				Returns the result of projecting the vector onto the given vector [param b].
 			</description>
 		</method>
 		<method name="reflect" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="n" type="Vector3" />
 			<description>
-				Returns this vector reflected from a plane defined by the given normal.
+				Returns the result of reflecting the vector from a plane defined by the given normal [param n].
 			</description>
 		</method>
 		<method name="rotated" qualifiers="const">
@@ -302,7 +302,7 @@
 			<param index="0" name="axis" type="Vector3" />
 			<param index="1" name="angle" type="float" />
 			<description>
-				Rotates this vector around a given axis by [param angle] (in radians). The axis must be a normalized vector.
+				Returns the result of rotating this vector around a given axis by [param angle] (in radians). The axis must be a normalized vector. See also [method @GlobalScope.deg_to_rad].
 			</description>
 		</method>
 		<method name="round" qualifiers="const">
@@ -314,7 +314,7 @@
 		<method name="sign" qualifiers="const">
 			<return type="Vector3" />
 			<description>
-				Returns a new vector with each component set to one or negative one, depending on the signs of the components, or zero if the component is zero, by calling [method @GlobalScope.sign] on each component.
+				Returns a new vector with each component set to [code]1.0[/code] if it's positive, [code]-1.0[/code] if it's negative, and [code]0.0[/code] if it's zero. The result is identical to calling [method @GlobalScope.sign] on each component.
 			</description>
 		</method>
 		<method name="signed_angle_to" qualifiers="const">
@@ -338,14 +338,14 @@
 			<return type="Vector3" />
 			<param index="0" name="n" type="Vector3" />
 			<description>
-				Returns this vector slid along a plane defined by the given normal.
+				Returns a new vector slid along a plane defined by the given normal.
 			</description>
 		</method>
 		<method name="snapped" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="step" type="Vector3" />
 			<description>
-				Returns this vector with each component snapped to the nearest multiple of [param step]. This can also be used to round to an arbitrary number of decimals.
+				Returns a new vector with each component snapped to the nearest multiple of the corresponding component in [param step]. This can also be used to round the components to an arbitrary number of decimals.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -87,7 +87,14 @@
 		<method name="sign" qualifiers="const">
 			<return type="Vector3i" />
 			<description>
-				Returns the vector with each component set to one or negative one, depending on the signs of the components.
+				Returns a new vector with each component set to [code]1[/code] if it's positive, [code]-1[/code] if it's negative, and [code]0[/code] if it's zero. The result is identical to calling [method @GlobalScope.sign] on each component.
+			</description>
+		</method>
+		<method name="snapped" qualifiers="const">
+			<return type="Vector3i" />
+			<param index="0" name="step" type="Vector3i" />
+			<description>
+				Returns a new vector with each component snapped to the closest multiple of the corresponding component in [param step].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -189,21 +189,21 @@
 		<method name="normalized" qualifiers="const">
 			<return type="Vector4" />
 			<description>
-				Returns the vector scaled to unit length. Equivalent to [code]v / v.length()[/code].
+				Returns the result of scaling the vector to unit length. Equivalent to [code]v / v.length()[/code].
 			</description>
 		</method>
 		<method name="posmod" qualifiers="const">
 			<return type="Vector4" />
 			<param index="0" name="mod" type="float" />
 			<description>
-				Returns a vector composed of the [method @GlobalScope.fposmod] of this vector's components and [param mod].
+				Returns a new vector composed of the [method @GlobalScope.fposmod] of this vector's components and [param mod].
 			</description>
 		</method>
 		<method name="posmodv" qualifiers="const">
 			<return type="Vector4" />
 			<param index="0" name="modv" type="Vector4" />
 			<description>
-				Returns a vector composed of the [method @GlobalScope.fposmod] of this vector's components and [param modv]'s components.
+				Returns a new vector composed of the [method @GlobalScope.fposmod] of this vector's components and [param modv]'s components.
 			</description>
 		</method>
 		<method name="round" qualifiers="const">
@@ -215,14 +215,14 @@
 		<method name="sign" qualifiers="const">
 			<return type="Vector4" />
 			<description>
-				Returns a new vector with each component set to one or negative one, depending on the signs of the components, or zero if the component is zero, by calling [method @GlobalScope.sign] on each component.
+				Returns a new vector with each component set to [code]1.0[/code] if it's positive, [code]-1.0[/code] if it's negative, and [code]0.0[/code] if it's zero. The result is identical to calling [method @GlobalScope.sign] on each component.
 			</description>
 		</method>
 		<method name="snapped" qualifiers="const">
 			<return type="Vector4" />
 			<param index="0" name="step" type="Vector4" />
 			<description>
-				Returns this vector with each component snapped to the nearest multiple of [param step]. This can also be used to round to an arbitrary number of decimals.
+				Returns a new vector with each component snapped to the nearest multiple of the corresponding component in [param step]. This can also be used to round the components to an arbitrary number of decimals.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Vector4i.xml
+++ b/doc/classes/Vector4i.xml
@@ -83,7 +83,14 @@
 		<method name="sign" qualifiers="const">
 			<return type="Vector4i" />
 			<description>
-				Returns a new vector with each component set to one or negative one, depending on the signs of the components, or zero if the component is zero, by calling [method @GlobalScope.sign] on each component.
+				Returns a new vector with each component set to [code]1[/code] if it's positive, [code]-1[/code] if it's negative, and [code]0[/code] if it's zero. The result is identical to calling [method @GlobalScope.sign] on each component.
+			</description>
+		</method>
+		<method name="snapped" qualifiers="const">
+			<return type="Vector4i" />
+			<param index="0" name="step" type="Vector4i" />
+			<description>
+				Returns a new vector with each component snapped to the closest multiple of the corresponding component in [param step].
 			</description>
 		</method>
 	</methods>

--- a/tests/core/math/test_vector2i.h
+++ b/tests/core/math/test_vector2i.h
@@ -131,12 +131,16 @@ TEST_CASE("[Vector2i] Other methods") {
 			"Vector2i aspect should work as expected.");
 
 	CHECK_MESSAGE(
-			Vector2i(1, 2) == vector.min(Vector2i(3, 2)),
+			vector.min(Vector2i(3, 2)) == Vector2i(1, 2),
 			"Vector2i min should return expected value.");
 
 	CHECK_MESSAGE(
-			Vector2i(5, 3) == vector.max(Vector2i(5, 2)),
+			vector.max(Vector2i(5, 2)) == Vector2i(5, 3),
 			"Vector2i max should return expected value.");
+
+	CHECK_MESSAGE(
+			vector.snapped(Vector2i(4, 2)) == Vector2i(0, 4),
+			"Vector2i snapped should work as expected.");
 }
 
 TEST_CASE("[Vector2i] Abs and sign methods") {

--- a/tests/core/math/test_vector3i.h
+++ b/tests/core/math/test_vector3i.h
@@ -127,6 +127,14 @@ TEST_CASE("[Vector3i] Operators") {
 			"Vector3i constructed from Vector3 should work as expected.");
 }
 
+TEST_CASE("[Vector3i] Other methods") {
+	const Vector3i vector = Vector3i(1, 3, -7);
+
+	CHECK_MESSAGE(
+			vector.snapped(Vector3i(4, 2, 5)) == Vector3i(0, 4, -5),
+			"Vector3i snapped should work as expected.");
+}
+
 TEST_CASE("[Vector3i] Abs and sign methods") {
 	const Vector3i vector1 = Vector3i(1, 3, 5);
 	const Vector3i vector2 = Vector3i(1, -3, -5);

--- a/tests/core/math/test_vector4i.h
+++ b/tests/core/math/test_vector4i.h
@@ -130,6 +130,14 @@ TEST_CASE("[Vector4i] Operators") {
 			"Vector4i constructed from Vector4 should work as expected.");
 }
 
+TEST_CASE("[Vector3i] Other methods") {
+	const Vector4i vector = Vector4i(1, 3, -7, 13);
+
+	CHECK_MESSAGE(
+			vector.snapped(Vector4i(4, 2, 5, 8)) == Vector4i(0, 4, -5, 16),
+			"Vector4i snapped should work as expected.");
+}
+
 TEST_CASE("[Vector4i] Abs and sign methods") {
 	const Vector4i vector1 = Vector4i(1, 3, 5, 7);
 	const Vector4i vector2 = Vector4i(1, -3, -5, 7);


### PR DESCRIPTION
Finishes an "incomplete effort" to make such functions type-safe in 4.0. I think this is the only remaining GlobalScope function that makes sense for this. In my statically-typed project I'd personally find them super useful.

- Implements `snappedi(float, int)` and `snappedf(float, float)` in `@GlobalScope`.
- Modifies `snapped(float)` into `snapped(Variant)` that accepts `int`, `float`, and vector types.
- Implements `Vector2i.snapped()`, `Vector3i.snapped()`, `Vector4i.snapped()`
- Also improved a little bit of strange or incorrect documentation in GlobalScope and Vector methods I noticed while doing this.

Quite straightforward, here's examples:
```gdscript
snapped(Vector3(31, 41, 59), Vector3(5, 8, 13))  # (30, 40, 65)
snappedi(65.4, 25)  # 75
snappedf(-27, 12.8)  # -25.6
Vector3i(30, 6, 21).snapped(Vector3i(8, 4, 4))  # (32, 8, 20)
```