### PR TITLE
expose XRInterface::get_transform_for_view to gdscript

### DIFF
--- a/doc/classes/XRInterface.xml
+++ b/doc/classes/XRInterface.xml
@@ -35,6 +35,16 @@
 				Returns an array of vectors that denotes the physical play area mapped to the virtual space around the [XROrigin3D] point. The points form a convex polygon that can be used to react to or visualize the play area. This returns an empty array if this feature is not supported or if the information is not yet available.
 			</description>
 		</method>
+		<method name="get_projection_for_view">
+			<return type="Projection" />
+			<param index="0" name="view" type="int" />
+			<param index="1" name="aspect" type="float" />
+			<param index="2" name="near" type="float" />
+			<param index="3" name="far" type="float" />
+			<description>
+				Returns the projection matrix for a view/eye.
+			</description>
+		</method>
 		<method name="get_render_target_size">
 			<return type="Vector2" />
 			<description>
@@ -45,6 +55,16 @@
 			<return type="int" enum="XRInterface.TrackingStatus" />
 			<description>
 				If supported, returns the status of our tracking. This will allow you to provide feedback to the user whether there are issues with positional tracking.
+			</description>
+		</method>
+		<method name="get_transform_for_view">
+			<return type="Transform3D" />
+			<param index="0" name="view" type="int" />
+			<param index="1" name="cam_transform" type="Transform3D" />
+			<description>
+				Returns the transform for a view/eye.
+				[param view] is the view/eye index.
+				[param cam_transform] is the transform that maps device coordinates to scene coordinates, typically the global_transform of the current XROrigin3D.
 			</description>
 		</method>
 		<method name="get_view_count">

--- a/servers/xr/xr_interface.cpp
+++ b/servers/xr/xr_interface.cpp
@@ -72,6 +72,8 @@ void XRInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_passthrough_enabled"), &XRInterface::is_passthrough_enabled);
 	ClassDB::bind_method(D_METHOD("start_passthrough"), &XRInterface::start_passthrough);
 	ClassDB::bind_method(D_METHOD("stop_passthrough"), &XRInterface::stop_passthrough);
+	ClassDB::bind_method(D_METHOD("get_transform_for_view", "view", "cam_transform"), &XRInterface::get_transform_for_view);
+	ClassDB::bind_method(D_METHOD("get_projection_for_view", "view", "aspect", "near", "far"), &XRInterface::get_projection_for_view);
 
 	ADD_GROUP("AR", "ar_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ar_is_anchor_detection_enabled"), "set_anchor_detection_is_enabled", "get_anchor_detection_is_enabled");


### PR DESCRIPTION
Hello again

By exposing  XRInterface::get_transform_for_view, it's possible to implement true stereoscopic mirrors and portals in VR previously impossible in godot.

Previously i made a [PR](https://github.com/godotengine/godot/pull/68384) for 3.x only since viewport textures seemed to be not working on godot 4 but I found the workaround was to set the viewport size to something different than the default 512, it's now working.

I made a demo for godot 4 using the method to render stereoscopic mirrors in VR, it can be found here:
https://github.com/cheece/godot-vr-mirror-test-g4

![20221107191406_1_vr](https://user-images.githubusercontent.com/9534017/200430193-0df93543-e702-4a5c-8f04-cb84eef178e7.jpg)
