### PR TITLE
[3.x] Clarify the difference between Vector2/3's `reflect()` and `bounce()`

### DIFF
--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -65,7 +65,8 @@
 			<return type="Vector2" />
 			<argument index="0" name="n" type="Vector2" />
 			<description>
-				Returns the vector "bounced off" from a plane defined by the given normal.
+				Returns the vector "bounced off" from a plane defined by the given normal [code]n[/code].
+				[b]Note:[/b] [method bounce] performs [i]physical[/i] reflection, as opposed to [method reflect] which performs [i]mathematical[/i] reflection. Double-check which method you actually need to use, as other engines may use these terms differently.
 			</description>
 		</method>
 		<method name="ceil">
@@ -220,6 +221,7 @@
 			<argument index="0" name="n" type="Vector2" />
 			<description>
 				Returns the vector reflected (i.e. mirrored, or symmetric) over a line defined by the given direction vector [code]n[/code].
+				[b]Note:[/b] [method reflect] performs [i]mathematical[/i] reflection, as opposed to [method bounce] which performs [i]physical[/i] reflection. Double-check which method you actually need to use, as other engines may use these terms differently.
 			</description>
 		</method>
 		<method name="rotated">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -42,7 +42,8 @@
 			<return type="Vector3" />
 			<argument index="0" name="n" type="Vector3" />
 			<description>
-				Returns the vector "bounced off" from a plane defined by the given normal.
+				Returns the vector "bounced off" from a plane defined by the given normal [code]n[/code].
+				[b]Note:[/b] [method bounce] performs [i]physical[/i] reflection, as opposed to [method reflect] which performs [i]mathematical[/i] reflection.
 			</description>
 		</method>
 		<method name="ceil">
@@ -211,7 +212,8 @@
 			<return type="Vector3" />
 			<argument index="0" name="n" type="Vector3" />
 			<description>
-				Returns this vector reflected from a plane defined by the given normal.
+				Returns the vector reflected (i.e. mirrored, or symmetric) over a plane defined by the given direction vector [code]n[/code].
+				[b]Note:[/b] [method reflect] performs [i]mathematical[/i] reflection, as opposed to [method bounce] which performs [i]physical[/i] reflection. Double-check which method you actually need to use, as other engines may use these terms differently.
 			</description>
 		</method>
 		<method name="rotated">


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/68392.

This closes https://github.com/godotengine/godot/issues/11678.