### PR TITLE
Make `Node::get_children()` public

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1269,6 +1269,17 @@ Node *Node::get_child(int p_index, bool p_include_internal) const {
 	}
 }
 
+TypedArray<Node> Node::get_children(bool p_include_internal) const {
+	TypedArray<Node> arr;
+	int cc = get_child_count(p_include_internal);
+	arr.resize(cc);
+	for (int i = 0; i < cc; i++) {
+		arr[i] = get_child(i, p_include_internal);
+	}
+
+	return arr;
+}
+
 Node *Node::_get_child_by_name(const StringName &p_name) const {
 	const Node *const *node = data.children.getptr(p_name);
 	if (node) {
@@ -2687,17 +2698,6 @@ void Node::queue_free() {
 	}
 }
 
-TypedArray<Node> Node::_get_children(bool p_include_internal) const {
-	TypedArray<Node> arr;
-	int cc = get_child_count(p_include_internal);
-	arr.resize(cc);
-	for (int i = 0; i < cc; i++) {
-		arr[i] = get_child(i, p_include_internal);
-	}
-
-	return arr;
-}
-
 void Node::set_import_path(const NodePath &p_import_path) {
 #ifdef TOOLS_ENABLED
 	data.import_path = p_import_path;
@@ -2847,7 +2847,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_child", "node"), &Node::remove_child);
 	ClassDB::bind_method(D_METHOD("reparent", "new_parent", "keep_global_transform"), &Node::reparent, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("get_child_count", "include_internal"), &Node::get_child_count, DEFVAL(false)); // Note that the default value bound for include_internal is false, while the method is declared with true. This is because internal nodes are irrelevant for GDSCript.
-	ClassDB::bind_method(D_METHOD("get_children", "include_internal"), &Node::_get_children, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_children", "include_internal"), &Node::get_children, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_child", "idx", "include_internal"), &Node::get_child, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("has_node", "path"), &Node::has_node);
 	ClassDB::bind_method(D_METHOD("get_node", "path"), &Node::get_node);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -196,7 +196,6 @@ private:
 	void _duplicate_signals(const Node *p_original, Node *p_copy) const;
 	Node *_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap = nullptr) const;
 
-	TypedArray<Node> _get_children(bool p_include_internal = true) const;
 	TypedArray<StringName> _get_groups() const;
 
 	Error _rpc_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
@@ -331,6 +330,7 @@ public:
 
 	int get_child_count(bool p_include_internal = true) const;
 	Node *get_child(int p_index, bool p_include_internal = true) const;
+	TypedArray<Node> get_children(bool p_include_internal = true) const;
 	bool has_node(const NodePath &p_path) const;
 	Node *get_node(const NodePath &p_path) const;
 	Node *get_node_or_null(const NodePath &p_path) const;


### PR DESCRIPTION
This method is exposed to GDScript, there's no reason to prevent using it internally. Similar methods are already public.