### PR TITLE
Fix viewport doesn't auto-resize on Web.

### DIFF
--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -54,7 +54,15 @@ DisplayServerWeb *DisplayServerWeb::get_singleton() {
 
 // Window (canvas)
 bool DisplayServerWeb::check_size_force_redraw() {
-	return godot_js_display_size_update() != 0;
+	bool size_changed = godot_js_display_size_update() != 0;
+	if (size_changed && !rect_changed_callback.is_null()) {
+		Variant size = Rect2i(Point2i(), window_get_size()); // TODO use window_get_position if implemented.
+		Variant *vp = &size;
+		Variant ret;
+		Callable::CallError ce;
+		rect_changed_callback.callp((const Variant **)&vp, 1, ret, ce);
+	}
+	return size_changed;
 }
 
 void DisplayServerWeb::fullscreen_change_callback(int p_fullscreen) {
@@ -903,7 +911,7 @@ ObjectID DisplayServerWeb::window_get_attached_instance_id(WindowID p_window) co
 }
 
 void DisplayServerWeb::window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window) {
-	// Not supported.
+	rect_changed_callback = p_callable;
 }
 
 void DisplayServerWeb::window_set_window_event_callback(const Callable &p_callable, WindowID p_window) {

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -60,6 +60,7 @@ private:
 	WindowMode window_mode = WINDOW_MODE_WINDOWED;
 	ObjectID window_attached_instance_id = {};
 
+	Callable rect_changed_callback;
 	Callable window_event_callback;
 	Callable input_event_callback;
 	Callable input_text_callback;


### PR DESCRIPTION
Fixes #66899.
Fixes #67087.

Implemented `DisplayServerWeb::window_set_rect_changed_callback` and call when canvas' size changed in `check_size_force_redraw`. 

cc @Faless 

Preview:
![preview2](https://user-images.githubusercontent.com/12966814/200545108-cf2f8c6a-efc2-4ab1-a3b4-7d0e20c362aa.gif)
