### PR TITLE
Fix debug shape of `ShapeCast3D` not updating on `Shape` change

### DIFF
--- a/scene/3d/shape_cast_3d.h
+++ b/scene/3d/shape_cast_3d.h
@@ -77,6 +77,7 @@ class ShapeCast3D : public Node3D {
 protected:
 	void _notification(int p_what);
 	void _update_shapecast_state();
+	void _shape_changed();
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
Fixes #68304 

Added ```_shape_changed``` callback
Added ```is_editor``` check to ensure debug shape is updated while in editor