### PR TITLE
Some fixes for instance shader parameters

### DIFF
--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -40,8 +40,6 @@ class VisualInstance3D : public Node3D {
 	RID instance;
 	uint32_t layers = 1;
 
-	RID _get_visual_instance_rid() const;
-
 protected:
 	void _update_visibility();
 
@@ -119,8 +117,8 @@ private:
 
 	float lod_bias = 1.0;
 
-	mutable HashMap<StringName, Variant> instance_uniforms;
-	mutable HashMap<StringName, StringName> instance_uniform_property_remap;
+	mutable HashMap<StringName, Variant> instance_shader_parameters;
+	mutable HashMap<StringName, StringName> instance_shader_parameter_property_remap;
 
 	float extra_cull_margin = 0.0;
 	LightmapScale lightmap_scale = LIGHTMAP_SCALE_1X;

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -8178,6 +8178,10 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					}
 				}
 #endif // DEBUG_ENABLED
+				if (String(shader_type_identifier) != "spatial") {
+					_set_error(vformat(RTR("Uniform instances are not yet implemented for '%s' shaders."), shader_type_identifier));
+					return ERR_PARSE_ERROR;
+				}
 				if (uniform_scope == ShaderNode::Uniform::SCOPE_LOCAL) {
 					tk = _get_token();
 					if (tk.type != TK_UNIFORM) {


### PR DESCRIPTION
This PR removes the unused method, renamed `Shader Uniforms` group to `Instance Shader Parameters`, and restrict using the instance uniforms where it's not possible now by providing an error.
