### PR TITLE
Allow canceling Drag and Drop with the Escape-Key

### DIFF
--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -405,6 +405,7 @@ private:
 	Control *_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_global, const Transform2D &p_xform, Transform2D &r_inv_xform);
 
 	void _gui_input_event(Ref<InputEvent> p_event);
+	void _perform_drop(Control *p_control = nullptr, Point2 p_pos = Point2());
 	void _gui_cleanup_internal_state(Ref<InputEvent> p_event);
 
 	_FORCE_INLINE_ Transform2D _get_input_pre_xform() const;


### PR DESCRIPTION
This patch implements the functionality to cancel Drag and Drop by using the escape key or more general, the `ui_cancel` action.
implement and resolve godotengine/godot-proposals#4679

Since this would be the third location, where the finalization of Drag and Drop would have to be implemented, that functionality was put into the new private function `_perform_drop`.

Simplified `gui.drag_data.get_type() != Variant::NIL` to `gui.dragging` because they are equivalent.
