### PR TITLE
Allow configuration warnings to refer to a property (reverted)

### DIFF
--- a/doc/classes/EditorProperty.xml
+++ b/doc/classes/EditorProperty.xml
@@ -72,6 +72,9 @@
 		<member name="checked" type="bool" setter="set_checked" getter="is_checked" default="false">
 			Used by the inspector, set to [code]true[/code] when the property is checked.
 		</member>
+		<member name="configuration_warning" type="String" setter="set_configuration_warning" getter="get_configuration_warning" default="&quot;&quot;">
+			Used by the inspector, set to show a configuration warning on the property.
+		</member>
 		<member name="deletable" type="bool" setter="set_deletable" getter="is_deletable" default="false">
 			Used by the inspector, set to [code]true[/code] when the property can be deleted by the user.
 		</member>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -37,9 +37,13 @@
 			</description>
 		</method>
 		<method name="_get_configuration_warnings" qualifiers="virtual const">
-			<return type="PackedStringArray" />
+			<return type="Array" />
 			<description>
 				The elements in the array returned from this method are displayed as warnings in the Scene dock if the script that overrides it is a [code]tool[/code] script.
+				Each array element must either be a [String] or a [Dictionary].
+				A dictionary element must contain a key [code]message[/code] of type [String] which is shown in the user interface.
+				The dictionary may optionally contain a key [code]property[/code] of type [NodePath], which also shows this warning in the inspector on the corresponding property.
+				If a string is found in the returned array, it is converted to an equivalent dictionary with the [code]message[/code] field set.
 				Returning an empty array produces no warnings.
 				Call [method update_configuration_warnings] when the warnings need to be updated for this node.
 				[codeblock]

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -214,6 +214,22 @@ void EditorProperty::_notification(int p_what) {
 						text_size -= close->get_width() + 4 * EDSCALE;
 					}
 				}
+
+				if (!configuration_warning.is_empty() && !read_only) {
+					Ref<Texture2D> warning;
+
+					warning = get_theme_icon(SNAME("NodeWarning"), SNAME("EditorIcons"));
+
+					rect.size.x -= warning->get_width() + get_theme_constant(SNAME("hseparator"), SNAME("Tree"));
+
+					if (is_layout_rtl()) {
+						rect.position.x += warning->get_width() + get_theme_constant(SNAME("hseparator"), SNAME("Tree"));
+					}
+
+					if (no_children) {
+						text_size -= warning->get_width() + 4 * EDSCALE;
+					}
+				}
 			}
 
 			//set children
@@ -398,6 +414,38 @@ void EditorProperty::_notification(int p_what) {
 				}
 			} else {
 				delete_rect = Rect2();
+			}
+
+			if (!configuration_warning.is_empty() && !read_only) {
+				Ref<Texture2D> warning;
+
+				StringName warning_icon;
+				Node *node = Object::cast_to<Node>(object);
+				if (node) {
+					const int warning_num = node->get_configuration_warnings_of_property(property_path).size();
+					warning_icon = Node::get_configuration_warning_icon(warning_num);
+				} else {
+					// This shouldn't happen, but let's not crash over an icon.
+					warning_icon = "NodeWarning";
+				}
+				warning = get_theme_icon(warning_icon, SNAME("EditorIcons"));
+
+				ofs -= warning->get_width() + get_theme_constant(SNAME("hseparator"), SNAME("Tree"));
+
+				Color color2(1, 1, 1);
+				if (configuration_warning_hover) {
+					color2.r *= 1.2;
+					color2.g *= 1.2;
+					color2.b *= 1.2;
+				}
+				configuration_warning_rect = Rect2(ofs, ((size.height - warning->get_height()) / 2), warning->get_width(), warning->get_height());
+				if (rtl) {
+					draw_texture(warning, Vector2(size.width - configuration_warning_rect.position.x - warning->get_width(), configuration_warning_rect.position.y), color2);
+				} else {
+					draw_texture(warning, configuration_warning_rect.position, color2);
+				}
+			} else {
+				configuration_warning_rect = Rect2();
 			}
 		} break;
 	}
@@ -674,6 +722,12 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 			check_hover = new_check_hover;
 			queue_redraw();
 		}
+
+		bool new_configuration_warning_hover = configuration_warning_rect.has_point(mpos) && !button_left;
+		if (new_configuration_warning_hover != configuration_warning_hover) {
+			configuration_warning_hover = new_configuration_warning_hover;
+			queue_redraw();
+		}
 	}
 
 	Ref<InputEventMouseButton> mb = p_event;
@@ -729,6 +783,16 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 			checked = !checked;
 			queue_redraw();
 			emit_signal(SNAME("property_checked"), property, checked);
+		}
+
+		if (configuration_warning_rect.has_point(mpos)) {
+			if (warning_dialog == nullptr) {
+				warning_dialog = memnew(AcceptDialog);
+				add_child(warning_dialog);
+				warning_dialog->set_title(TTR("Node Configuration Warning!"));
+			}
+			warning_dialog->set_text(configuration_warning);
+			warning_dialog->popup_centered();
 		}
 	} else if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
 		accept_event();
@@ -855,6 +919,16 @@ float EditorProperty::get_name_split_ratio() const {
 	return split_ratio;
 }
 
+void EditorProperty::set_configuration_warning(const String &p_configuration_warning) {
+	configuration_warning = p_configuration_warning;
+	queue_redraw();
+	queue_sort();
+}
+
+String EditorProperty::get_configuration_warning() const {
+	return configuration_warning;
+}
+
 void EditorProperty::set_object_and_property(Object *p_object, const StringName &p_property) {
 	object = p_object;
 	property = p_property;
@@ -908,6 +982,15 @@ void EditorProperty::_update_pin_flags() {
 				can_pin = true;
 			}
 		}
+	}
+}
+
+void EditorProperty::_update_configuration_warnings() {
+	Node *node = Object::cast_to<Node>(object);
+	if (node) {
+		const PackedStringArray warnings = node->get_configuration_warnings_as_strings(true, property_path);
+		const String warning_lines = String("\n").join(warnings);
+		set_configuration_warning(warning_lines);
 	}
 }
 
@@ -980,6 +1063,9 @@ void EditorProperty::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_deletable", "deletable"), &EditorProperty::set_deletable);
 	ClassDB::bind_method(D_METHOD("is_deletable"), &EditorProperty::is_deletable);
 
+	ClassDB::bind_method(D_METHOD("set_configuration_warning", "configuration_warning"), &EditorProperty::set_configuration_warning);
+	ClassDB::bind_method(D_METHOD("get_configuration_warning"), &EditorProperty::get_configuration_warning);
+
 	ClassDB::bind_method(D_METHOD("get_edited_property"), &EditorProperty::get_edited_property);
 	ClassDB::bind_method(D_METHOD("get_edited_object"), &EditorProperty::get_edited_object);
 
@@ -997,6 +1083,7 @@ void EditorProperty::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_warning"), "set_draw_warning", "is_draw_warning");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keying"), "set_keying", "is_keying");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deletable"), "set_deletable", "is_deletable");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "configuration_warning"), "set_configuration_warning", "get_configuration_warning");
 
 	ADD_SIGNAL(MethodInfo("property_changed", PropertyInfo(Variant::STRING_NAME, "property"), PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), PropertyInfo(Variant::STRING_NAME, "field"), PropertyInfo(Variant::BOOL, "changing")));
 	ADD_SIGNAL(MethodInfo("multiple_properties_changed", PropertyInfo(Variant::PACKED_STRING_ARRAY, "properties"), PropertyInfo(Variant::ARRAY, "value")));
@@ -3314,6 +3401,7 @@ void EditorInspector::update_tree() {
 				ep->set_keying(keying);
 				ep->set_read_only(property_read_only || all_read_only);
 				ep->set_deletable(deletable_properties || p.name.begins_with("metadata/"));
+				ep->_update_configuration_warnings();
 			}
 
 			current_vbox->add_child(editors[i].property_editor);
@@ -3960,6 +4048,12 @@ void EditorInspector::_node_removed(Node *p_node) {
 	}
 }
 
+void EditorInspector::_warning_changed(Node *p_node) {
+	if (p_node == object) {
+		update_tree_pending = true;
+	}
+}
+
 void EditorInspector::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
@@ -3971,6 +4065,7 @@ void EditorInspector::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			if (!sub_inspector) {
 				get_tree()->connect("node_removed", callable_mp(this, &EditorInspector::_node_removed));
+				get_tree()->connect("node_configuration_warning_changed", callable_mp(this, &EditorInspector::_warning_changed));
 			}
 		} break;
 
@@ -3981,6 +4076,7 @@ void EditorInspector::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			if (!sub_inspector) {
 				get_tree()->disconnect("node_removed", callable_mp(this, &EditorInspector::_node_removed));
+				get_tree()->disconnect("node_configuration_warning_changed", callable_mp(this, &EditorInspector::_warning_changed));
 			}
 			edit(nullptr);
 		} break;

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -76,6 +76,7 @@ private:
 	String doc_path;
 	bool internal = false;
 	bool has_doc_tooltip = false;
+	AcceptDialog *warning_dialog = nullptr;
 
 	int property_usage;
 
@@ -98,6 +99,8 @@ private:
 	bool check_hover = false;
 	Rect2 delete_rect;
 	bool delete_hover = false;
+	Rect2 configuration_warning_rect;
+	bool configuration_warning_hover = false;
 
 	bool can_revert = false;
 	bool can_pin = false;
@@ -121,12 +124,15 @@ private:
 	Control *bottom_editor = nullptr;
 	PopupMenu *menu = nullptr;
 
+	String configuration_warning;
+
 	HashMap<StringName, Variant> cache;
 
 	GDVIRTUAL0(_update_property)
 	GDVIRTUAL1(_set_read_only, bool)
 
 	void _update_pin_flags();
+	void _update_configuration_warnings();
 
 protected:
 	void _notification(int p_what);
@@ -202,6 +208,9 @@ public:
 
 	void set_name_split_ratio(float p_ratio);
 	float get_name_split_ratio() const;
+
+	void set_configuration_warning(const String &p_configuration_warning);
+	String get_configuration_warning() const;
 
 	void set_object_and_property(Object *p_object, const StringName &p_property);
 	virtual Control *make_custom_tooltip(const String &p_text) const override;
@@ -532,6 +541,7 @@ class EditorInspector : public ScrollContainer {
 	void _object_id_selected(const String &p_path, ObjectID p_id);
 
 	void _node_removed(Node *p_node);
+	void _warning_changed(Node *p_node);
 
 	HashMap<StringName, int> per_array_page;
 	void _page_change_request(int p_new_page, const StringName &p_array_prefix);

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -82,3 +82,10 @@ Validate extension JSON: Error: Field 'classes/GPUParticles3D/properties/process
 Validate extension JSON: Error: Field 'classes/Sky/properties/sky_material': type changed value in new API, from "ShaderMaterial,PanoramaSkyMaterial,ProceduralSkyMaterial,PhysicalSkyMaterial" to "PanoramaSkyMaterial,ProceduralSkyMaterial,PhysicalSkyMaterial,ShaderMaterial".
 
 Property hints reordered to improve editor usability. The types allowed are still the same as before. No adjustments should be necessary.
+
+
+GH-68420
+--------
+Validate extension JSON: Error: Field 'classes/Node/methods/_get_configuration_warnings/return_value': type changed value in new API, from "PackedStringArray" to "Array".
+
+Allow configuration warnings to refer to a property. Compatibility method registered.

--- a/modules/multiplayer/multiplayer_spawner.cpp
+++ b/modules/multiplayer/multiplayer_spawner.cpp
@@ -87,8 +87,8 @@ void MultiplayerSpawner::_get_property_list(List<PropertyInfo> *p_list) const {
 }
 #endif
 
-PackedStringArray MultiplayerSpawner::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array MultiplayerSpawner::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (spawn_path.is_empty() || !has_node(spawn_path)) {
 		warnings.push_back(RTR("A valid NodePath must be set in the \"Spawn Path\" property in order for MultiplayerSpawner to be able to spawn Nodes."));

--- a/modules/multiplayer/multiplayer_spawner.h
+++ b/modules/multiplayer/multiplayer_spawner.h
@@ -91,7 +91,7 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 #endif
 public:
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	Node *get_spawn_node() const {
 		return spawn_node.is_valid() ? Object::cast_to<Node>(ObjectDB::get_instance(spawn_node)) : nullptr;

--- a/modules/multiplayer/multiplayer_synchronizer.cpp
+++ b/modules/multiplayer/multiplayer_synchronizer.cpp
@@ -143,8 +143,8 @@ bool MultiplayerSynchronizer::update_inbound_sync_time(uint16_t p_network_time) 
 	return true;
 }
 
-PackedStringArray MultiplayerSynchronizer::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array MultiplayerSynchronizer::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (root_path.is_empty() || !has_node(root_path)) {
 		warnings.push_back(RTR("A valid NodePath must be set in the \"Root Path\" property in order for MultiplayerSynchronizer to be able to synchronize properties."));

--- a/modules/multiplayer/multiplayer_synchronizer.h
+++ b/modules/multiplayer/multiplayer_synchronizer.h
@@ -91,7 +91,7 @@ public:
 	bool update_outbound_sync_time(uint64_t p_usec);
 	bool update_inbound_sync_time(uint16_t p_network_time);
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	void set_replication_interval(double p_interval);
 	double get_replication_interval() const;

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -568,8 +568,8 @@ StringName AnimatedSprite2D::get_animation() const {
 	return animation;
 }
 
-PackedStringArray AnimatedSprite2D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node2D::get_configuration_warnings();
+Array AnimatedSprite2D::get_configuration_warnings() const {
+	Array warnings = Node2D::get_configuration_warnings();
 	if (frames.is_null()) {
 		warnings.push_back(RTR("A SpriteFrames resource must be created or set in the \"Frames\" property in order for AnimatedSprite2D to display frames."));
 	}

--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -125,7 +125,7 @@ public:
 	void set_flip_v(bool p_flip);
 	bool is_flipped_v() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 
 	AnimatedSprite2D();

--- a/scene/2d/canvas_modulate.cpp
+++ b/scene/2d/canvas_modulate.cpp
@@ -113,8 +113,8 @@ Color CanvasModulate::get_color() const {
 	return color;
 }
 
-PackedStringArray CanvasModulate::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array CanvasModulate::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (is_in_canvas && is_visible_in_tree()) {
 		List<Node *> nodes;

--- a/scene/2d/canvas_modulate.h
+++ b/scene/2d/canvas_modulate.h
@@ -54,7 +54,7 @@ public:
 	void set_color(const Color &p_color);
 	Color get_color() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	CanvasModulate();
 	~CanvasModulate();

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -582,8 +582,8 @@ void CollisionObject2D::_update_pickable() {
 	}
 }
 
-PackedStringArray CollisionObject2D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array CollisionObject2D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (shapes.is_empty()) {
 		warnings.push_back(RTR("This node has no shape, so it can't collide or interact with other objects.\nConsider adding a CollisionShape2D or CollisionPolygon2D as a child to define its shape."));

--- a/scene/2d/collision_object_2d.h
+++ b/scene/2d/collision_object_2d.h
@@ -166,7 +166,7 @@ public:
 	void set_pickable(bool p_enabled);
 	bool is_pickable() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	_FORCE_INLINE_ RID get_rid() const { return rid; }
 

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -232,8 +232,8 @@ bool CollisionPolygon2D::_edit_is_selected_on_click(const Point2 &p_point, doubl
 }
 #endif
 
-PackedStringArray CollisionPolygon2D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array CollisionPolygon2D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (!Object::cast_to<CollisionObject2D>(get_parent())) {
 		warnings.push_back(RTR("CollisionPolygon2D only serves to provide a collision shape to a CollisionObject2D derived node. Please only use it as a child of Area2D, StaticBody2D, RigidBody2D, CharacterBody2D, etc. to give them a shape."));

--- a/scene/2d/collision_polygon_2d.h
+++ b/scene/2d/collision_polygon_2d.h
@@ -77,7 +77,7 @@ public:
 	void set_polygon(const Vector<Point2> &p_polygon);
 	Vector<Point2> get_polygon() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	void set_disabled(bool p_disabled);
 	bool is_disabled() const;

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -173,8 +173,8 @@ bool CollisionShape2D::_edit_is_selected_on_click(const Point2 &p_point, double 
 	return shape->_edit_is_selected_on_click(p_point, p_tolerance);
 }
 
-PackedStringArray CollisionShape2D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array CollisionShape2D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	CollisionObject2D *col_object = Object::cast_to<CollisionObject2D>(get_parent());
 	if (col_object == nullptr) {

--- a/scene/2d/collision_shape_2d.h
+++ b/scene/2d/collision_shape_2d.h
@@ -80,7 +80,7 @@ public:
 	void set_debug_color(const Color &p_color);
 	Color get_debug_color() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	CollisionShape2D();
 };

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -246,8 +246,8 @@ bool CPUParticles2D::get_fractional_delta() const {
 	return fractional_delta;
 }
 
-PackedStringArray CPUParticles2D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node2D::get_configuration_warnings();
+Array CPUParticles2D::get_configuration_warnings() const {
+	Array warnings = Node2D::get_configuration_warnings();
 
 	CanvasItemMaterial *mat = Object::cast_to<CanvasItemMaterial>(get_material().ptr());
 

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -282,7 +282,7 @@ public:
 	void set_gravity(const Vector2 &p_gravity);
 	Vector2 get_gravity() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	void restart();
 

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -327,8 +327,8 @@ float GPUParticles2D::get_interp_to_end() const {
 	return interp_to_end_factor;
 }
 
-PackedStringArray GPUParticles2D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node2D::get_configuration_warnings();
+Array GPUParticles2D::get_configuration_warnings() const {
+	Array warnings = Node2D::get_configuration_warnings();
 
 	if (process_material.is_null()) {
 		warnings.push_back(RTR("A material to process the particles is not assigned, so no behavior is imprinted."));

--- a/scene/2d/gpu_particles_2d.h
+++ b/scene/2d/gpu_particles_2d.h
@@ -161,7 +161,7 @@ public:
 	void set_amount_ratio(float p_ratio);
 	float get_amount_ratio() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	void set_sub_emitter(const NodePath &p_path);
 	NodePath get_sub_emitter() const;

--- a/scene/2d/joint_2d.cpp
+++ b/scene/2d/joint_2d.cpp
@@ -212,8 +212,8 @@ bool Joint2D::get_exclude_nodes_from_collision() const {
 	return exclude_from_collision;
 }
 
-PackedStringArray Joint2D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node2D::get_configuration_warnings();
+Array Joint2D::get_configuration_warnings() const {
+	Array warnings = Node2D::get_configuration_warnings();
 
 	if (!warning.is_empty()) {
 		warnings.push_back(warning);

--- a/scene/2d/joint_2d.h
+++ b/scene/2d/joint_2d.h
@@ -62,7 +62,7 @@ protected:
 	_FORCE_INLINE_ bool is_configured() const { return configured; }
 
 public:
-	virtual PackedStringArray get_configuration_warnings() const override;
+	virtual Array get_configuration_warnings() const override;
 
 	void set_node_a(const NodePath &p_node_a);
 	NodePath get_node_a() const;

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -401,11 +401,14 @@ Vector2 PointLight2D::get_texture_offset() const {
 	return texture_offset;
 }
 
-PackedStringArray PointLight2D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array PointLight2D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (!texture.is_valid()) {
-		warnings.push_back(RTR("A texture with the shape of the light must be supplied to the \"Texture\" property."));
+		Dictionary texture_warning;
+		texture_warning["message"] = RTR("A texture with the shape of the light must be supplied.");
+		texture_warning["property"] = "texture";
+		warnings.push_back(texture_warning);
 	}
 
 	return warnings;

--- a/scene/2d/light_2d.h
+++ b/scene/2d/light_2d.h
@@ -174,7 +174,7 @@ public:
 	void set_texture_scale(real_t p_scale);
 	real_t get_texture_scale() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	PointLight2D();
 };

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -247,8 +247,8 @@ int LightOccluder2D::get_occluder_light_mask() const {
 	return mask;
 }
 
-PackedStringArray LightOccluder2D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array LightOccluder2D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (!occluder_polygon.is_valid()) {
 		warnings.push_back(RTR("An occluder polygon must be set (or drawn) for this occluder to take effect."));

--- a/scene/2d/light_occluder_2d.h
+++ b/scene/2d/light_occluder_2d.h
@@ -105,7 +105,7 @@ public:
 	void set_as_sdf_collision(bool p_enable);
 	bool is_set_as_sdf_collision() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	LightOccluder2D();
 	~LightOccluder2D();

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -624,8 +624,8 @@ void NavigationAgent2D::_avoidance_done(Vector3 p_new_velocity) {
 	emit_signal(SNAME("velocity_computed"), safe_velocity);
 }
 
-PackedStringArray NavigationAgent2D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array NavigationAgent2D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (!Object::cast_to<Node2D>(get_parent())) {
 		warnings.push_back(RTR("The NavigationAgent2D can be used only under a Node2D inheriting parent node."));

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -200,7 +200,7 @@ public:
 
 	void _avoidance_done(Vector3 p_new_velocity);
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	void set_avoidance_layers(uint32_t p_layers);
 	uint32_t get_avoidance_layers() const;

--- a/scene/2d/navigation_link_2d.cpp
+++ b/scene/2d/navigation_link_2d.cpp
@@ -337,8 +337,8 @@ void NavigationLink2D::set_travel_cost(real_t p_travel_cost) {
 	NavigationServer2D::get_singleton()->link_set_travel_cost(link, travel_cost);
 }
 
-PackedStringArray NavigationLink2D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array NavigationLink2D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (start_position.is_equal_approx(end_position)) {
 		warnings.push_back(RTR("NavigationLink2D start position should be different than the end position to be useful."));

--- a/scene/2d/navigation_link_2d.h
+++ b/scene/2d/navigation_link_2d.h
@@ -93,7 +93,7 @@ public:
 	void set_travel_cost(real_t p_travel_cost);
 	real_t get_travel_cost() const { return travel_cost; }
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	NavigationLink2D();
 	~NavigationLink2D();

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -275,8 +275,8 @@ void NavigationRegion2D::_navigation_map_changed(RID p_map) {
 }
 #endif // DEBUG_ENABLED
 
-PackedStringArray NavigationRegion2D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node2D::get_configuration_warnings();
+Array NavigationRegion2D::get_configuration_warnings() const {
+	Array warnings = Node2D::get_configuration_warnings();
 
 	if (is_visible_in_tree() && is_inside_tree()) {
 		if (!navigation_polygon.is_valid()) {

--- a/scene/2d/navigation_region_2d.h
+++ b/scene/2d/navigation_region_2d.h
@@ -113,7 +113,7 @@ public:
 	void set_avoidance_layer_value(int p_layer_number, bool p_value);
 	bool get_avoidance_layer_value(int p_layer_number) const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	void bake_navigation_polygon(bool p_on_thread);
 	void _bake_finished(Ref<NavigationPolygon> p_navigation_polygon);

--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -137,8 +137,8 @@ void ParallaxLayer::set_base_offset_and_scale(const Point2 &p_offset, real_t p_s
 	_update_mirroring();
 }
 
-PackedStringArray ParallaxLayer::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array ParallaxLayer::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (!Object::cast_to<ParallaxBackground>(get_parent())) {
 		warnings.push_back(RTR("ParallaxLayer node only works when set as child of a ParallaxBackground node."));

--- a/scene/2d/parallax_layer.h
+++ b/scene/2d/parallax_layer.h
@@ -59,7 +59,7 @@ public:
 
 	void set_base_offset_and_scale(const Point2 &p_offset, real_t p_scale);
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 	ParallaxLayer();
 };
 

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -287,8 +287,8 @@ void PathFollow2D::_validate_property(PropertyInfo &p_property) const {
 	}
 }
 
-PackedStringArray PathFollow2D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array PathFollow2D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (is_visible_in_tree() && is_inside_tree()) {
 		if (!Object::cast_to<Path2D>(get_parent())) {

--- a/scene/2d/path_2d.h
+++ b/scene/2d/path_2d.h
@@ -106,7 +106,7 @@ public:
 	void set_cubic_interpolation_enabled(bool p_enabled);
 	bool is_cubic_interpolation_enabled() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	PathFollow2D() {}
 };

--- a/scene/2d/physical_bone_2d.cpp
+++ b/scene/2d/physical_bone_2d.cpp
@@ -106,8 +106,8 @@ void PhysicalBone2D::_find_joint_child() {
 	}
 }
 
-PackedStringArray PhysicalBone2D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array PhysicalBone2D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (!parent_skeleton) {
 		warnings.push_back(RTR("A PhysicalBone2D only works with a Skeleton2D or another PhysicalBone2D as a parent node!"));

--- a/scene/2d/physical_bone_2d.h
+++ b/scene/2d/physical_bone_2d.h
@@ -79,7 +79,7 @@ public:
 	void set_follow_bone_when_simulating(bool p_follow);
 	bool get_follow_bone_when_simulating() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	PhysicalBone2D();
 	~PhysicalBone2D();

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -928,10 +928,10 @@ void RigidBody2D::_notification(int p_what) {
 #endif
 }
 
-PackedStringArray RigidBody2D::get_configuration_warnings() const {
+Array RigidBody2D::get_configuration_warnings() const {
 	Transform2D t = get_transform();
 
-	PackedStringArray warnings = CollisionObject2D::get_configuration_warnings();
+	Array warnings = CollisionObject2D::get_configuration_warnings();
 
 	if (ABS(t.columns[0].length() - 1.0) > 0.05 || ABS(t.columns[1].length() - 1.0) > 0.05) {
 		warnings.push_back(RTR("Size changes to RigidBody2D will be overridden by the physics engine when running.\nChange the size in children collision shapes instead."));

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -312,7 +312,7 @@ public:
 
 	TypedArray<Node2D> get_colliding_bodies() const; //function for script
 
-	virtual PackedStringArray get_configuration_warnings() const override;
+	virtual Array get_configuration_warnings() const override;
 
 	RigidBody2D();
 	~RigidBody2D();

--- a/scene/2d/remote_transform_2d.cpp
+++ b/scene/2d/remote_transform_2d.cpp
@@ -200,8 +200,8 @@ void RemoteTransform2D::force_update_cache() {
 	_update_cache();
 }
 
-PackedStringArray RemoteTransform2D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array RemoteTransform2D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (!has_node(remote_node) || !Object::cast_to<Node2D>(get_node(remote_node))) {
 		warnings.push_back(RTR("Path property must point to a valid Node2D node to work."));

--- a/scene/2d/remote_transform_2d.h
+++ b/scene/2d/remote_transform_2d.h
@@ -70,7 +70,7 @@ public:
 
 	void force_update_cache();
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	RemoteTransform2D();
 };

--- a/scene/2d/shape_cast_2d.cpp
+++ b/scene/2d/shape_cast_2d.cpp
@@ -402,8 +402,8 @@ Array ShapeCast2D::_get_collision_result() const {
 	return ret;
 }
 
-PackedStringArray ShapeCast2D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node2D::get_configuration_warnings();
+Array ShapeCast2D::get_configuration_warnings() const {
+	Array warnings = Node2D::get_configuration_warnings();
 
 	if (shape.is_null()) {
 		warnings.push_back(RTR("This node cannot interact with other objects unless a Shape2D is assigned."));

--- a/scene/2d/shape_cast_2d.h
+++ b/scene/2d/shape_cast_2d.h
@@ -118,7 +118,7 @@ public:
 	void remove_exception(const CollisionObject2D *p_node);
 	void clear_exceptions();
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	ShapeCast2D();
 };

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -415,8 +415,8 @@ int Bone2D::get_index_in_skeleton() const {
 	return skeleton_index;
 }
 
-PackedStringArray Bone2D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array Bone2D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 	if (!skeleton) {
 		if (parent_bone) {
 			warnings.push_back(RTR("This Bone2D chain should end at a Skeleton2D node."));

--- a/scene/2d/skeleton_2d.h
+++ b/scene/2d/skeleton_2d.h
@@ -78,7 +78,7 @@ public:
 	void apply_rest();
 	Transform2D get_skeleton_rest() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	void set_autocalculate_length_and_angle(bool p_autocalculate);
 	bool get_autocalculate_length_and_angle() const;

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1103,8 +1103,8 @@ void TileMap::draw_cells_outline(Control *p_control, const RBSet<Vector2i> &p_ce
 #undef DRAW_SIDE_IF_NEEDED
 }
 
-PackedStringArray TileMap::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array TileMap::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	// Retrieve the set of Z index values with a Y-sorted layer.
 	RBSet<int> y_sorted_z_index;

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -232,7 +232,7 @@ public:
 	GDVIRTUAL3(_tile_data_runtime_update, int, Vector2i, TileData *);
 
 	// Configuration warnings.
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	TileMap();
 	~TileMap();

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -87,8 +87,8 @@ void BoneAttachment3D::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
-PackedStringArray BoneAttachment3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node3D::get_configuration_warnings();
+Array BoneAttachment3D::get_configuration_warnings() const {
+	Array warnings = Node3D::get_configuration_warnings();
 
 	if (use_external_skeleton) {
 		if (external_skeleton_node_cache.is_null()) {

--- a/scene/3d/bone_attachment_3d.h
+++ b/scene/3d/bone_attachment_3d.h
@@ -71,7 +71,8 @@ public:
 	virtual void notify_skeleton_bones_renamed(Node *p_base_scene, Skeleton3D *p_skeleton, Dictionary p_rename_map);
 #endif // TOOLS_ENABLED
 
-	virtual PackedStringArray get_configuration_warnings() const override;
+public:
+	virtual Array get_configuration_warnings() const override;
 
 	void set_bone_name(const String &p_name);
 	String get_bone_name() const;

--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -728,8 +728,8 @@ bool CollisionObject3D::get_capture_input_on_drag() const {
 	return capture_input_on_drag;
 }
 
-PackedStringArray CollisionObject3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array CollisionObject3D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (shapes.is_empty()) {
 		warnings.push_back(RTR("This node has no shape, so it can't collide or interact with other objects.\nConsider adding a CollisionShape3D or CollisionPolygon3D as a child to define its shape."));

--- a/scene/3d/collision_object_3d.h
+++ b/scene/3d/collision_object_3d.h
@@ -173,7 +173,7 @@ public:
 
 	_FORCE_INLINE_ RID get_rid() const { return rid; }
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	CollisionObject3D();
 	~CollisionObject3D();

--- a/scene/3d/collision_polygon_3d.cpp
+++ b/scene/3d/collision_polygon_3d.cpp
@@ -168,8 +168,8 @@ void CollisionPolygon3D::set_margin(real_t p_margin) {
 	}
 }
 
-PackedStringArray CollisionPolygon3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array CollisionPolygon3D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (!Object::cast_to<CollisionObject3D>(get_parent())) {
 		warnings.push_back(RTR("CollisionPolygon3D only serves to provide a collision shape to a CollisionObject3D derived node.\nPlease only use it as a child of Area3D, StaticBody3D, RigidBody3D, CharacterBody3D, etc. to give them a shape."));

--- a/scene/3d/collision_polygon_3d.h
+++ b/scene/3d/collision_polygon_3d.h
@@ -74,7 +74,7 @@ public:
 	real_t get_margin() const;
 	void set_margin(real_t p_margin);
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	CollisionPolygon3D();
 };

--- a/scene/3d/collision_shape_3d.cpp
+++ b/scene/3d/collision_shape_3d.cpp
@@ -118,8 +118,8 @@ void CollisionShape3D::resource_changed(Ref<Resource> res) {
 }
 #endif
 
-PackedStringArray CollisionShape3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array CollisionShape3D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	CollisionObject3D *col_object = Object::cast_to<CollisionObject3D>(get_parent());
 	if (col_object == nullptr) {

--- a/scene/3d/collision_shape_3d.h
+++ b/scene/3d/collision_shape_3d.h
@@ -64,7 +64,7 @@ public:
 	void set_disabled(bool p_disabled);
 	bool is_disabled() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	CollisionShape3D();
 	~CollisionShape3D();

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -193,8 +193,8 @@ bool CPUParticles3D::get_fractional_delta() const {
 	return fractional_delta;
 }
 
-PackedStringArray CPUParticles3D::get_configuration_warnings() const {
-	PackedStringArray warnings = GeometryInstance3D::get_configuration_warnings();
+Array CPUParticles3D::get_configuration_warnings() const {
+	Array warnings = GeometryInstance3D::get_configuration_warnings();
 
 	bool mesh_found = false;
 	bool anim_material_found = false;

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -302,7 +302,7 @@ public:
 	void set_gravity(const Vector3 &p_gravity);
 	Vector3 get_gravity() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	void restart();
 

--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -162,8 +162,8 @@ void Decal::_validate_property(PropertyInfo &p_property) const {
 	}
 }
 
-PackedStringArray Decal::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array Decal::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
 		warnings.push_back(RTR("Decals are only available when using the Forward+ or Mobile rendering backends."));

--- a/scene/3d/decal.h
+++ b/scene/3d/decal.h
@@ -69,7 +69,7 @@ protected:
 #endif // DISABLE_DEPRECATED
 
 public:
-	virtual PackedStringArray get_configuration_warnings() const override;
+	virtual Array get_configuration_warnings() const override;
 
 	void set_size(const Vector3 &p_size);
 	Vector3 get_size() const;

--- a/scene/3d/fog_volume.cpp
+++ b/scene/3d/fog_volume.cpp
@@ -117,8 +117,8 @@ AABB FogVolume::get_aabb() const {
 	return AABB();
 }
 
-PackedStringArray FogVolume::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array FogVolume::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	Ref<Environment> environment = get_viewport()->find_world_3d()->get_environment();
 

--- a/scene/3d/fog_volume.h
+++ b/scene/3d/fog_volume.h
@@ -66,7 +66,7 @@ public:
 	Ref<Material> get_material() const;
 
 	virtual AABB get_aabb() const override;
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	FogVolume();
 	~FogVolume();

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -296,8 +296,8 @@ bool GPUParticles3D::get_interpolate() const {
 	return interpolate;
 }
 
-PackedStringArray GPUParticles3D::get_configuration_warnings() const {
-	PackedStringArray warnings = GeometryInstance3D::get_configuration_warnings();
+Array GPUParticles3D::get_configuration_warnings() const {
+	Array warnings = GeometryInstance3D::get_configuration_warnings();
 
 	bool meshes_found = false;
 	bool anim_material_found = false;

--- a/scene/3d/gpu_particles_3d.h
+++ b/scene/3d/gpu_particles_3d.h
@@ -164,7 +164,7 @@ public:
 	void set_draw_pass_mesh(int p_pass, const Ref<Mesh> &p_mesh);
 	Ref<Mesh> get_draw_pass_mesh(int p_pass) const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	void set_sub_emitter(const NodePath &p_path);
 	NodePath get_sub_emitter() const;

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -527,8 +527,8 @@ Ref<Image> GPUParticlesCollisionSDF3D::bake() {
 	return ret;
 }
 
-PackedStringArray GPUParticlesCollisionSDF3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array GPUParticlesCollisionSDF3D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (bake_mask == 0) {
 		warnings.push_back(RTR("The Bake Mask has no bits enabled, which means baking will not produce any collision for this GPUParticlesCollisionSDF3D.\nTo resolve this, enable at least one bit in the Bake Mask property."));

--- a/scene/3d/gpu_particles_collision_3d.h
+++ b/scene/3d/gpu_particles_collision_3d.h
@@ -170,7 +170,7 @@ protected:
 #endif // DISABLE_DEPRECATED
 
 public:
-	virtual PackedStringArray get_configuration_warnings() const override;
+	virtual Array get_configuration_warnings() const override;
 
 	void set_thickness(float p_thickness);
 	float get_thickness() const;

--- a/scene/3d/joint_3d.cpp
+++ b/scene/3d/joint_3d.cpp
@@ -198,8 +198,8 @@ bool Joint3D::get_exclude_nodes_from_collision() const {
 	return exclude_from_collision;
 }
 
-PackedStringArray Joint3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node3D::get_configuration_warnings();
+Array Joint3D::get_configuration_warnings() const {
+	Array warnings = Node3D::get_configuration_warnings();
 
 	if (!warning.is_empty()) {
 		warnings.push_back(warning);

--- a/scene/3d/joint_3d.h
+++ b/scene/3d/joint_3d.h
@@ -63,7 +63,7 @@ protected:
 	_FORCE_INLINE_ bool is_configured() const { return configured; }
 
 public:
-	virtual PackedStringArray get_configuration_warnings() const override;
+	virtual Array get_configuration_warnings() const override;
 
 	void set_node_a(const NodePath &p_node_a);
 	NodePath get_node_a() const;

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -169,8 +169,8 @@ AABB Light3D::get_aabb() const {
 	return AABB();
 }
 
-PackedStringArray Light3D::get_configuration_warnings() const {
-	PackedStringArray warnings = VisualInstance3D::get_configuration_warnings();
+Array Light3D::get_configuration_warnings() const {
+	Array warnings = VisualInstance3D::get_configuration_warnings();
 
 	if (!get_scale().is_equal_approx(Vector3(1, 1, 1))) {
 		warnings.push_back(RTR("A light's scale does not affect the visual size of the light."));
@@ -596,8 +596,8 @@ OmniLight3D::ShadowMode OmniLight3D::get_shadow_mode() const {
 	return shadow_mode;
 }
 
-PackedStringArray OmniLight3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Light3D::get_configuration_warnings();
+Array OmniLight3D::get_configuration_warnings() const {
+	Array warnings = Light3D::get_configuration_warnings();
 
 	if (!has_shadow() && get_projector().is_valid()) {
 		warnings.push_back(RTR("Projector texture only works with shadows active."));
@@ -628,8 +628,8 @@ OmniLight3D::OmniLight3D() :
 	set_shadow_mode(SHADOW_CUBE);
 }
 
-PackedStringArray SpotLight3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Light3D::get_configuration_warnings();
+Array SpotLight3D::get_configuration_warnings() const {
+	Array warnings = Light3D::get_configuration_warnings();
 
 	if (has_shadow() && get_param(PARAM_SPOT_ANGLE) >= 90.0) {
 		warnings.push_back(RTR("A SpotLight3D with an angle wider than 90 degrees cannot cast shadows."));

--- a/scene/3d/light_3d.h
+++ b/scene/3d/light_3d.h
@@ -147,7 +147,7 @@ public:
 	Color get_correlated_color() const;
 
 	virtual AABB get_aabb() const override;
-	virtual PackedStringArray get_configuration_warnings() const override;
+	virtual Array get_configuration_warnings() const override;
 
 	Light3D();
 	~Light3D();
@@ -217,7 +217,7 @@ public:
 	void set_shadow_mode(ShadowMode p_mode);
 	ShadowMode get_shadow_mode() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	OmniLight3D();
 };
@@ -231,7 +231,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	SpotLight3D();
 };

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1528,8 +1528,8 @@ Ref<CameraAttributes> LightmapGI::get_camera_attributes() const {
 	return camera_attributes;
 }
 
-PackedStringArray LightmapGI::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array LightmapGI::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
 		warnings.push_back(RTR("Lightmap can only be baked from a device that supports the RD backends. Lightmap baking may fail."));

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -302,7 +302,7 @@ public:
 
 	BakeError bake(Node *p_from_node, String p_image_data_path = "", Lightmapper::BakeStepFunc p_bake_step = nullptr, void *p_bake_userdata = nullptr);
 
-	virtual PackedStringArray get_configuration_warnings() const override;
+	virtual Array get_configuration_warnings() const override;
 
 	LightmapGI();
 };

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -690,8 +690,8 @@ void NavigationAgent3D::_avoidance_done(Vector3 p_new_velocity) {
 	emit_signal(SNAME("velocity_computed"), safe_velocity);
 }
 
-PackedStringArray NavigationAgent3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array NavigationAgent3D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (!Object::cast_to<Node3D>(get_parent())) {
 		warnings.push_back(RTR("The NavigationAgent3D can be used only under a Node3D inheriting parent node."));

--- a/scene/3d/navigation_agent_3d.h
+++ b/scene/3d/navigation_agent_3d.h
@@ -221,7 +221,7 @@ public:
 
 	void _avoidance_done(Vector3 p_new_velocity);
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	void set_avoidance_layers(uint32_t p_layers);
 	uint32_t get_avoidance_layers() const;

--- a/scene/3d/navigation_link_3d.cpp
+++ b/scene/3d/navigation_link_3d.cpp
@@ -458,8 +458,8 @@ void NavigationLink3D::set_travel_cost(real_t p_travel_cost) {
 	NavigationServer3D::get_singleton()->link_set_travel_cost(link, travel_cost);
 }
 
-PackedStringArray NavigationLink3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array NavigationLink3D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (start_position.is_equal_approx(end_position)) {
 		warnings.push_back(RTR("NavigationLink3D start position should be different than the end position to be useful."));

--- a/scene/3d/navigation_link_3d.h
+++ b/scene/3d/navigation_link_3d.h
@@ -99,7 +99,7 @@ public:
 	void set_travel_cost(real_t p_travel_cost);
 	real_t get_travel_cost() const { return travel_cost; }
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 };
 
 #endif // NAVIGATION_LINK_3D_H

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -270,8 +270,8 @@ bool NavigationRegion3D::is_baking() const {
 	return NavigationServer3D::get_singleton()->is_baking_navigation_mesh(navigation_mesh);
 }
 
-PackedStringArray NavigationRegion3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array NavigationRegion3D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (is_visible_in_tree() && is_inside_tree()) {
 		if (!navigation_mesh.is_valid()) {

--- a/scene/3d/navigation_region_3d.h
+++ b/scene/3d/navigation_region_3d.h
@@ -107,7 +107,7 @@ public:
 	void _bake_finished(Ref<NavigationMesh> p_navigation_mesh);
 	bool is_baking() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	NavigationRegion3D();
 	~NavigationRegion3D();

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -693,8 +693,8 @@ OccluderInstance3D::BakeError OccluderInstance3D::bake_scene(Node *p_from_node, 
 	return BAKE_ERROR_OK;
 }
 
-PackedStringArray OccluderInstance3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array OccluderInstance3D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (!bool(GLOBAL_GET("rendering/occlusion_culling/use_occlusion_culling"))) {
 		warnings.push_back(RTR("Occlusion culling is disabled in the Project Settings, which means occlusion culling won't be performed in the root viewport.\nTo resolve this, open the Project Settings and enable Rendering > Occlusion Culling > Use Occlusion Culling."));

--- a/scene/3d/occluder_instance_3d.h
+++ b/scene/3d/occluder_instance_3d.h
@@ -181,7 +181,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual PackedStringArray get_configuration_warnings() const override;
+	virtual Array get_configuration_warnings() const override;
 
 	enum BakeError {
 		BAKE_ERROR_OK,

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -291,8 +291,8 @@ void PathFollow3D::_validate_property(PropertyInfo &p_property) const {
 	}
 }
 
-PackedStringArray PathFollow3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array PathFollow3D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (is_visible_in_tree() && is_inside_tree()) {
 		if (!Object::cast_to<Path3D>(get_parent())) {

--- a/scene/3d/path_3d.h
+++ b/scene/3d/path_3d.h
@@ -122,7 +122,7 @@ public:
 	void set_cubic_interpolation_enabled(bool p_enabled);
 	bool is_cubic_interpolation_enabled() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	PathFollow3D() {}
 };

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -995,8 +995,8 @@ TypedArray<Node3D> RigidBody3D::get_colliding_bodies() const {
 	return ret;
 }
 
-PackedStringArray RigidBody3D::get_configuration_warnings() const {
-	PackedStringArray warnings = CollisionObject3D::get_configuration_warnings();
+Array RigidBody3D::get_configuration_warnings() const {
+	Array warnings = CollisionObject3D::get_configuration_warnings();
 
 	Vector3 scale = get_transform().get_basis().get_scale();
 	if (ABS(scale.x - 1.0) > 0.05 || ABS(scale.y - 1.0) > 0.05 || ABS(scale.z - 1.0) > 0.05) {

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -328,7 +328,7 @@ public:
 	void set_constant_torque(const Vector3 &p_torque);
 	Vector3 get_constant_torque() const;
 
-	virtual PackedStringArray get_configuration_warnings() const override;
+	virtual Array get_configuration_warnings() const override;
 
 	RigidBody3D();
 	~RigidBody3D();

--- a/scene/3d/reflection_probe.cpp
+++ b/scene/3d/reflection_probe.cpp
@@ -190,8 +190,8 @@ AABB ReflectionProbe::get_aabb() const {
 	return aabb;
 }
 
-PackedStringArray ReflectionProbe::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array ReflectionProbe::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
 		warnings.push_back(RTR("ReflectionProbes are not supported when using the GL Compatibility backend yet. Support will be added in a future release."));

--- a/scene/3d/reflection_probe.h
+++ b/scene/3d/reflection_probe.h
@@ -122,7 +122,7 @@ public:
 
 	virtual AABB get_aabb() const override;
 
-	virtual PackedStringArray get_configuration_warnings() const override;
+	virtual Array get_configuration_warnings() const override;
 
 	ReflectionProbe();
 	~ReflectionProbe();

--- a/scene/3d/remote_transform_3d.cpp
+++ b/scene/3d/remote_transform_3d.cpp
@@ -200,8 +200,8 @@ void RemoteTransform3D::force_update_cache() {
 	_update_cache();
 }
 
-PackedStringArray RemoteTransform3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array RemoteTransform3D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (!has_node(remote_node) || !Object::cast_to<Node3D>(get_node(remote_node))) {
 		warnings.push_back(RTR("The \"Remote Path\" property must point to a valid Node3D or Node3D-derived node to work."));

--- a/scene/3d/remote_transform_3d.h
+++ b/scene/3d/remote_transform_3d.h
@@ -70,7 +70,7 @@ public:
 
 	void force_update_cache();
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	RemoteTransform3D();
 };

--- a/scene/3d/shape_cast_3d.cpp
+++ b/scene/3d/shape_cast_3d.cpp
@@ -170,8 +170,8 @@ void ShapeCast3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "debug_shape_custom_color"), "set_debug_shape_custom_color", "get_debug_shape_custom_color");
 }
 
-PackedStringArray ShapeCast3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node3D::get_configuration_warnings();
+Array ShapeCast3D::get_configuration_warnings() const {
+	Array warnings = Node3D::get_configuration_warnings();
 
 	if (shape.is_null()) {
 		warnings.push_back(RTR("This node cannot interact with other objects unless a Shape3D is assigned."));

--- a/scene/3d/shape_cast_3d.h
+++ b/scene/3d/shape_cast_3d.h
@@ -140,7 +140,7 @@ public:
 	void remove_exception(const CollisionObject3D *p_node);
 	void clear_exceptions();
 
-	virtual PackedStringArray get_configuration_warnings() const override;
+	virtual Array get_configuration_warnings() const override;
 };
 
 #endif // SHAPE_CAST_3D_H

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -373,8 +373,8 @@ void SoftBody3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(DISABLE_MODE_KEEP_ACTIVE);
 }
 
-PackedStringArray SoftBody3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array SoftBody3D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (mesh.is_null()) {
 		warnings.push_back(RTR("This body will be ignored until you set a mesh."));

--- a/scene/3d/soft_body_3d.h
+++ b/scene/3d/soft_body_3d.h
@@ -126,7 +126,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 public:
 	RID get_physics_rid() const { return physics_rid; }

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1430,8 +1430,8 @@ StringName AnimatedSprite3D::get_animation() const {
 	return animation;
 }
 
-PackedStringArray AnimatedSprite3D::get_configuration_warnings() const {
-	PackedStringArray warnings = SpriteBase3D::get_configuration_warnings();
+Array AnimatedSprite3D::get_configuration_warnings() const {
+	Array warnings = SpriteBase3D::get_configuration_warnings();
 	if (frames.is_null()) {
 		warnings.push_back(RTR("A SpriteFrames resource must be created or set in the \"Frames\" property in order for AnimatedSprite3D to display frames."));
 	}

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -285,7 +285,7 @@ public:
 
 	virtual Rect2 get_item_rect() const override;
 
-	virtual PackedStringArray get_configuration_warnings() const override;
+	virtual Array get_configuration_warnings() const override;
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 
 	AnimatedSprite3D();

--- a/scene/3d/vehicle_body_3d.cpp
+++ b/scene/3d/vehicle_body_3d.cpp
@@ -105,8 +105,8 @@ void VehicleWheel3D::_notification(int p_what) {
 	}
 }
 
-PackedStringArray VehicleWheel3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array VehicleWheel3D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (!Object::cast_to<VehicleBody3D>(get_parent())) {
 		warnings.push_back(RTR("VehicleWheel3D serves to provide a wheel system to a VehicleBody3D. Please use it as a child of a VehicleBody3D."));

--- a/scene/3d/vehicle_body_3d.h
+++ b/scene/3d/vehicle_body_3d.h
@@ -147,7 +147,7 @@ public:
 	void set_steering(real_t p_steering);
 	real_t get_steering() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	VehicleWheel3D();
 };

--- a/scene/3d/visible_on_screen_notifier_3d.cpp
+++ b/scene/3d/visible_on_screen_notifier_3d.cpp
@@ -79,8 +79,8 @@ void VisibleOnScreenNotifier3D::_notification(int p_what) {
 	}
 }
 
-PackedStringArray VisibleOnScreenNotifier3D::get_configuration_warnings() const {
-	PackedStringArray warnings = VisualInstance3D::get_configuration_warnings();
+Array VisibleOnScreenNotifier3D::get_configuration_warnings() const {
+	Array warnings = VisualInstance3D::get_configuration_warnings();
 
 	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
 		warnings.push_back(RTR("VisibleOnScreenNotifier3D nodes are not supported when using the GL Compatibility backend yet. Support will be added in a future release."));

--- a/scene/3d/visible_on_screen_notifier_3d.h
+++ b/scene/3d/visible_on_screen_notifier_3d.h
@@ -57,7 +57,7 @@ public:
 	virtual AABB get_aabb() const override;
 	bool is_on_screen() const;
 
-	virtual PackedStringArray get_configuration_warnings() const override;
+	virtual Array get_configuration_warnings() const override;
 
 	VisibleOnScreenNotifier3D();
 	~VisibleOnScreenNotifier3D();

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -425,8 +425,8 @@ bool GeometryInstance3D::is_ignoring_occlusion_culling() {
 	return ignore_occlusion_culling;
 }
 
-PackedStringArray GeometryInstance3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array GeometryInstance3D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (!Math::is_zero_approx(visibility_range_end) && visibility_range_end <= visibility_range_begin) {
 		warnings.push_back(RTR("The GeometryInstance3D visibility range's End distance is set to a non-zero value, but is lower than the Begin distance.\nThis means the GeometryInstance3D will never be visible.\nTo resolve this, set the End distance to 0 or to a value greater than the Begin distance."));

--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -194,7 +194,7 @@ public:
 	void set_ignore_occlusion_culling(bool p_enabled);
 	bool is_ignoring_occlusion_culling();
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 	GeometryInstance3D();
 	virtual ~GeometryInstance3D();
 };

--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -518,8 +518,8 @@ AABB VoxelGI::get_aabb() const {
 	return AABB(-size / 2, size);
 }
 
-PackedStringArray VoxelGI::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array VoxelGI::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
 		warnings.push_back(RTR("VoxelGI nodes are not supported when using the GL Compatibility backend yet. Support will be added in a future release."));

--- a/scene/3d/voxel_gi.h
+++ b/scene/3d/voxel_gi.h
@@ -163,7 +163,7 @@ public:
 
 	virtual AABB get_aabb() const override;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	VoxelGI();
 	~VoxelGI();

--- a/scene/3d/world_environment.cpp
+++ b/scene/3d/world_environment.cpp
@@ -135,8 +135,8 @@ Ref<CameraAttributes> WorldEnvironment::get_camera_attributes() const {
 	return camera_attributes;
 }
 
-PackedStringArray WorldEnvironment::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array WorldEnvironment::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (!environment.is_valid() && !camera_attributes.is_valid()) {
 		warnings.push_back(RTR("To have any visible effect, WorldEnvironment requires its \"Environment\" property to contain an Environment, its \"Camera Attributes\" property to contain a CameraAttributes resource, or both."));

--- a/scene/3d/world_environment.h
+++ b/scene/3d/world_environment.h
@@ -55,7 +55,7 @@ public:
 	void set_camera_attributes(const Ref<CameraAttributes> &p_camera_attributes);
 	Ref<CameraAttributes> get_camera_attributes() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	WorldEnvironment();
 };

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -76,8 +76,8 @@ void XRCamera3D::_pose_changed(const Ref<XRPose> &p_pose) {
 	}
 }
 
-PackedStringArray XRCamera3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array XRCamera3D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (is_visible() && is_inside_tree()) {
 		// must be child node of XROrigin3D!
@@ -424,8 +424,8 @@ XRNode3D::~XRNode3D() {
 	xr_server->disconnect("tracker_removed", callable_mp(this, &XRNode3D::_removed_tracker));
 }
 
-PackedStringArray XRNode3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array XRNode3D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (is_visible() && is_inside_tree()) {
 		// must be child node of XROrigin!
@@ -603,8 +603,8 @@ Plane XRAnchor3D::get_plane() const {
 
 Vector<XROrigin3D *> XROrigin3D::origin_nodes;
 
-PackedStringArray XROrigin3D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array XROrigin3D::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (is_visible() && is_inside_tree()) {
 		bool has_camera = false;

--- a/scene/3d/xr_nodes.h
+++ b/scene/3d/xr_nodes.h
@@ -55,7 +55,7 @@ protected:
 	void _pose_changed(const Ref<XRPose> &p_pose);
 
 public:
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	virtual Vector3 project_local_ray_normal(const Point2 &p_pos) const override;
 	virtual Point2 unproject_position(const Vector3 &p_pos) const override;
@@ -109,7 +109,7 @@ public:
 
 	Ref<XRPose> get_pose();
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	XRNode3D();
 	~XRNode3D();
@@ -193,7 +193,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	real_t get_world_scale() const;
 	void set_world_scale(real_t p_world_scale);

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -606,8 +606,8 @@ uint64_t AnimationTree::get_last_process_pass() const {
 	return process_pass;
 }
 
-PackedStringArray AnimationTree::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array AnimationTree::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 	if (!root_animation_node.is_valid()) {
 		warnings.push_back(RTR("No root AnimationNode for the graph is set."));
 	}

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -261,7 +261,7 @@ public:
 	void set_advance_expression_base_node(const NodePath &p_path);
 	NodePath get_advance_expression_base_node() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	bool is_state_invalid() const;
 	String get_invalid_state_reason() const;

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -430,8 +430,8 @@ bool BaseButton::_was_pressed_by_mouse() const {
 	return was_mouse_pressed;
 }
 
-PackedStringArray BaseButton::get_configuration_warnings() const {
-	PackedStringArray warnings = Control::get_configuration_warnings();
+Array BaseButton::get_configuration_warnings() const {
+	Array warnings = Control::get_configuration_warnings();
 
 	if (get_button_group().is_valid() && !is_toggle_mode()) {
 		warnings.push_back(RTR("ButtonGroup is intended to be used only with buttons that have toggle_mode set to true."));

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -139,7 +139,7 @@ public:
 	void set_button_group(const Ref<ButtonGroup> &p_group);
 	Ref<ButtonGroup> get_button_group() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	BaseButton();
 	~BaseButton();

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -189,8 +189,8 @@ void Container::_notification(int p_what) {
 	}
 }
 
-PackedStringArray Container::get_configuration_warnings() const {
-	PackedStringArray warnings = Control::get_configuration_warnings();
+Array Container::get_configuration_warnings() const {
+	Array warnings = Control::get_configuration_warnings();
 
 	if (get_class() == "Container" && get_script().is_null()) {
 		warnings.push_back(RTR("Container by itself serves no purpose unless a script configures its children placement behavior.\nIf you don't intend to add a script, use a plain Control node instead."));

--- a/scene/gui/container.h
+++ b/scene/gui/container.h
@@ -63,7 +63,7 @@ public:
 	virtual Vector<int> get_allowed_size_flags_horizontal() const;
 	virtual Vector<int> get_allowed_size_flags_vertical() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	Container();
 };

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -228,9 +228,9 @@ void Control::get_argument_options(const StringName &p_function, int p_idx, List
 	}
 }
 
-PackedStringArray Control::get_configuration_warnings() const {
-	ERR_READ_THREAD_GUARD_V(PackedStringArray());
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array Control::get_configuration_warnings() const {
+	ERR_READ_THREAD_GUARD_V(Array());
+	Array warnings = Node::get_configuration_warnings();
 
 	if (data.mouse_filter == MOUSE_FILTER_IGNORE && !data.tooltip.is_empty()) {
 		warnings.push_back(RTR("The Hint Tooltip won't be displayed as the control's Mouse Filter is set to \"Ignore\". To solve this, set the Mouse Filter to \"Stop\" or \"Pass\"."));

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -408,7 +408,7 @@ public:
 	static void set_root_layout_direction(int p_root_dir);
 
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	virtual bool is_text_field() const;
 

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -251,8 +251,8 @@ Control::CursorShape GraphEdit::get_cursor_shape(const Point2 &p_pos) const {
 	return Control::get_cursor_shape(p_pos);
 }
 
-PackedStringArray GraphEdit::get_configuration_warnings() const {
-	PackedStringArray warnings = Control::get_configuration_warnings();
+Array GraphEdit::get_configuration_warnings() const {
+	Array warnings = Control::get_configuration_warnings();
 
 	warnings.push_back(RTR("Please be aware that GraphEdit and GraphNode will undergo extensive refactoring in a future 4.x version involving compatibility-breaking API changes."));
 

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -375,7 +375,7 @@ public:
 
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	Error connect_node(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);
 	bool is_node_connected(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -330,8 +330,8 @@ inline void draw_glyph_outline(const Glyph &p_gl, const RID &p_canvas, const Col
 	}
 }
 
-PackedStringArray Label::get_configuration_warnings() const {
-	PackedStringArray warnings = Control::get_configuration_warnings();
+Array Label::get_configuration_warnings() const {
+	Array warnings = Control::get_configuration_warnings();
 
 	// FIXME: This is not ideal and the sizing model should be fixed,
 	// but for now we have to warn about this impossible to resolve combination.

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -97,7 +97,7 @@ protected:
 
 public:
 	virtual Size2 get_minimum_size() const override;
-	virtual PackedStringArray get_configuration_warnings() const override;
+	virtual Array get_configuration_warnings() const override;
 
 	void set_horizontal_alignment(HorizontalAlignment p_alignment);
 	HorizontalAlignment get_horizontal_alignment() const;

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2278,8 +2278,8 @@ void LineEdit::_emit_text_change() {
 	emit_signal(SNAME("text_changed"), text);
 	text_changed_dirty = false;
 }
-PackedStringArray LineEdit::get_configuration_warnings() const {
-	PackedStringArray warnings = Control::get_configuration_warnings();
+Array LineEdit::get_configuration_warnings() const {
+	Array warnings = Control::get_configuration_warnings();
 	if (secret_character.length() > 1) {
 		warnings.push_back("Secret Character property supports only one character. Extra characters will be ignored.");
 	}

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -385,7 +385,7 @@ public:
 
 	virtual bool is_text_field() const override;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	void show_virtual_keyboard();
 

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -30,8 +30,8 @@
 
 #include "range.h"
 
-PackedStringArray Range::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array Range::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (shared->exp_ratio && shared->min <= 0) {
 		warnings.push_back(RTR("If \"Exp Edit\" is enabled, \"Min Value\" must be greater than 0."));

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -103,7 +103,7 @@ public:
 	void share(Range *p_range);
 	void unshare();
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	Range();
 	~Range();

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -537,8 +537,8 @@ void ScrollContainer::set_follow_focus(bool p_follow) {
 	follow_focus = p_follow;
 }
 
-PackedStringArray ScrollContainer::get_configuration_warnings() const {
-	PackedStringArray warnings = Container::get_configuration_warnings();
+Array ScrollContainer::get_configuration_warnings() const {
+	Array warnings = Container::get_configuration_warnings();
 
 	int found = 0;
 

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -119,7 +119,7 @@ public:
 	VScrollBar *get_v_scroll_bar();
 	void ensure_control_visible(Control *p_control);
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	ScrollContainer();
 };

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -259,8 +259,8 @@ void SubViewportContainer::remove_child_notify(Node *p_child) {
 	}
 }
 
-PackedStringArray SubViewportContainer::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array SubViewportContainer::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	bool has_viewport = false;
 	for (int i = 0; i < get_child_count(); i++) {

--- a/scene/gui/subviewport_container.h
+++ b/scene/gui/subviewport_container.h
@@ -68,7 +68,7 @@ public:
 	virtual Vector<int> get_allowed_size_flags_horizontal() const override;
 	virtual Vector<int> get_allowed_size_flags_vertical() const override;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	SubViewportContainer();
 };

--- a/scene/main/missing_node.cpp
+++ b/scene/main/missing_node.cpp
@@ -74,9 +74,9 @@ bool MissingNode::is_recording_properties() const {
 	return recording_properties;
 }
 
-PackedStringArray MissingNode::get_configuration_warnings() const {
+Array MissingNode::get_configuration_warnings() const {
 	// The mere existence of this node is warning.
-	PackedStringArray ret;
+	Array ret;
 	ret.push_back(vformat(RTR("This node was saved as class type '%s', which was no longer available when this scene was loaded."), original_class));
 	ret.push_back(RTR("Data from the original node is kept as a placeholder until this type of node is available again. It can hence be safely re-saved without risk of data loss."));
 	return ret;

--- a/scene/main/missing_node.h
+++ b/scene/main/missing_node.h
@@ -55,7 +55,7 @@ public:
 	void set_recording_properties(bool p_enable);
 	bool is_recording_properties() const;
 
-	virtual PackedStringArray get_configuration_warnings() const override;
+	virtual Array get_configuration_warnings() const override;
 
 	MissingNode();
 };

--- a/scene/main/node.compat.inc
+++ b/scene/main/node.compat.inc
@@ -1,0 +1,41 @@
+/**************************************************************************/
+/*  node.compat.inc                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+PackedStringArray Node::get_configuration_warnings_bind_compat_68420() const {
+	return PackedStringArray(get_configuration_warnings());
+}
+
+void Node::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("get_configuration_warnings"), &Node::get_configuration_warnings_bind_compat_68420);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -294,6 +294,7 @@ protected:
 
 	static void _bind_methods();
 	static String _get_name_num_separator();
+	static StringName get_configuration_warning_icon(int p_count);
 
 	friend class SceneState;
 
@@ -320,7 +321,7 @@ protected:
 	GDVIRTUAL0(_enter_tree)
 	GDVIRTUAL0(_exit_tree)
 	GDVIRTUAL0(_ready)
-	GDVIRTUAL0RC(Vector<String>, _get_configuration_warnings)
+	GDVIRTUAL0RC(Array, _get_configuration_warnings)
 
 	GDVIRTUAL1(_input, Ref<InputEvent>)
 	GDVIRTUAL1(_shortcut_input, Ref<InputEvent>)
@@ -636,7 +637,11 @@ public:
 
 	_FORCE_INLINE_ Viewport *get_viewport() const { return data.viewport; }
 
-	virtual PackedStringArray get_configuration_warnings() const;
+	virtual Array get_configuration_warnings() const;
+	Dictionary configuration_warning_to_dict(const Variant &p_warning) const;
+	Vector<Dictionary> get_configuration_warnings_as_dicts() const;
+	Vector<Dictionary> get_configuration_warnings_of_property(const String &p_property = String()) const;
+	PackedStringArray get_configuration_warnings_as_strings(bool p_wrap_lines, const String &p_property = String()) const;
 
 	void update_configuration_warnings();
 

--- a/scene/main/shader_globals_override.cpp
+++ b/scene/main/shader_globals_override.cpp
@@ -271,8 +271,8 @@ void ShaderGlobalsOverride::_notification(int p_what) {
 	}
 }
 
-PackedStringArray ShaderGlobalsOverride::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array ShaderGlobalsOverride::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (!active) {
 		warnings.push_back(RTR("ShaderGlobalsOverride is not active because another node of the same type is in the scene."));

--- a/scene/main/shader_globals_override.h
+++ b/scene/main/shader_globals_override.h
@@ -58,7 +58,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	ShaderGlobalsOverride();
 };

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -180,8 +180,8 @@ void Timer::_set_process(bool p_process, bool p_force) {
 	processing = p_process;
 }
 
-PackedStringArray Timer::get_configuration_warnings() const {
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array Timer::get_configuration_warnings() const {
+	Array warnings = Node::get_configuration_warnings();
 
 	if (wait_time < 0.05 - CMP_EPSILON) {
 		warnings.push_back(RTR("Very low timer wait times (< 0.05 seconds) may behave in significantly different ways depending on the rendered or physics frame rate.\nConsider using a script's process loop instead of relying on a Timer for very low wait times."));

--- a/scene/main/timer.h
+++ b/scene/main/timer.h
@@ -73,7 +73,7 @@ public:
 
 	double get_time_left() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	void set_timer_process_callback(TimerProcessCallback p_callback);
 	TimerProcessCallback get_timer_process_callback() const;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3500,9 +3500,9 @@ Variant Viewport::gui_get_drag_data() const {
 	return gui.drag_data;
 }
 
-PackedStringArray Viewport::get_configuration_warnings() const {
-	ERR_MAIN_THREAD_GUARD_V(PackedStringArray());
-	PackedStringArray warnings = Node::get_configuration_warnings();
+Array Viewport::get_configuration_warnings() const {
+	ERR_MAIN_THREAD_GUARD_V(Array());
+	Array warnings = Node::get_configuration_warnings();
 
 	if (size.x <= 1 || size.y <= 1) {
 		warnings.push_back(RTR("The Viewport size must be greater than or equal to 2 pixels on both dimensions to render anything."));

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -611,7 +611,7 @@ public:
 	Control *gui_get_focus_owner() const;
 	Control *gui_get_hovered_control() const;
 
-	PackedStringArray get_configuration_warnings() const override;
+	Array get_configuration_warnings() const override;
 
 	void set_debug_draw(DebugDraw p_debug_draw);
 	DebugDraw get_debug_draw() const;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/550

Configuration warnings changed from PackedStringArray to an Array that accepts a mix of Strings and Dictionaries `{ message: String, property?: String }`.
If `property` is set, then show a clickable warning icon on property in the inspector.
Strings in this array are converted to an equivalent Dictionary with `message` filled.

This PR also lays the groundwork for further configuration warning enhancements like https://github.com/godotengine/godot-proposals/issues/2519

As an example, the PointLight2D node was updated to use this system.

https://user-images.githubusercontent.com/5117197/200654466-370da225-17ea-4d90-85c5-04b5bcd7bc49.mp4

---

The PR is split into two commits for easier reviewing. The second commit only fixes the signature of the `get_configuration_warnings` method for all classes using it.

---

**TODO:**

- [x] Change warning icon based on how many warnings the property has. Probably have to move the property name filtering logic out of the `as_string` method.
- [ ] Would be nice to have a tooltip when hovering the icon, but since other icons don't have this yet, it can be done in a follow-up PR.
- [x] It seems to be necessary to introduce a compatibility method for GDExtension here.
  - [ ] No idea how to test it, so someone should verify what it's doing is correct. Especially since there's also a virtual method involved here, whose signature changed but didn't get any compat bind (I followed what was done in AnimationMixer.compat.inc)!