### PR TITLE
Fix GPUParticles not rendering in doubles build of the engine.

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -97,7 +97,7 @@ private:
 			uint32_t type;
 
 			uint32_t texture_index; //texture index for vector field
-			real_t scale;
+			float scale;
 			uint32_t pad[2];
 		};
 
@@ -106,8 +106,8 @@ private:
 		float prev_system_phase;
 		uint32_t cycle;
 
-		real_t explosiveness;
-		real_t randomness;
+		float explosiveness;
+		float randomness;
 		float time;
 		float delta;
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/67545

May help: https://github.com/godotengine/godot/issues/58333

``real_t`` was mistakenly used in uniform structs causing a mismatch between the GPU uniform and the CPU uniform. On the GPU side these are all floats, so they should be floats here too. 
