### PR TITLE
Fix minor inheritance errors

### DIFF
--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -45,7 +45,7 @@ class GDScriptAnalyzer {
 	List<GDScriptParser::LambdaNode *> lambda_stack;
 
 	// Tests for detecting invalid overloading of script members
-	static _FORCE_INLINE_ bool has_member_name_conflict_in_script_class(const StringName &p_name, const GDScriptParser::ClassNode *p_current_class_node);
+	static _FORCE_INLINE_ bool has_member_name_conflict_in_script_class(const StringName &p_name, const GDScriptParser::ClassNode *p_current_class_node, const GDScriptParser::Node *p_member);
 	static _FORCE_INLINE_ bool has_member_name_conflict_in_native_type(const StringName &p_name, const StringName &p_native_type_string);
 	Error check_native_member_name_conflict(const StringName &p_member_name, const GDScriptParser::Node *p_member_node, const StringName &p_native_type_string);
 	Error check_class_member_name_conflict(const GDScriptParser::ClassNode *p_class_node, const StringName &p_member_name, const GDScriptParser::Node *p_member_node);

--- a/modules/gdscript/tests/scripts/analyzer/errors/overload_script_variable.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/overload_script_variable.gd
@@ -1,0 +1,6 @@
+extends Node
+
+var script: int
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/overload_script_variable.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/overload_script_variable.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Member "script" redefined (original in native class 'Node')

--- a/modules/gdscript/tests/scripts/analyzer/errors/variable_overloads_superclass_function.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/variable_overloads_superclass_function.gd
@@ -1,0 +1,9 @@
+func test():
+	pass
+
+class A:
+	func overload_me():
+		pass
+
+class B extends A:
+	var overload_me

--- a/modules/gdscript/tests/scripts/analyzer/errors/variable_overloads_superclass_function.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/variable_overloads_superclass_function.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+The member "overload_me" already exists in parent class A.


### PR DESCRIPTION
Fixes #68355, and variables overloading functions of the base class.

### Fix one

There are only a couple of minor changes added to this fix. Since neither `Node` nor `Object` export the `script` variable through `ClassDB`, I hacked in the property for native classes in `has_member_name_conflict_in_native_type`. It would be more elegant to declare `script` as a property through `ClassDB`, but I figure that's a big decision with far reaching consequences.

### Fix two

Problem:

```
class_name A

func test():
	pass
```

```
extends A

var test : int

func _ready():
	test()
```

There will be an error when calling `test()`, since it is overloaded by the local variable. This is fixed by only allowing overloading of functions if the thing being declared in the subclass is also a function.


Ultimately, functions should only allow overloading if their signatures match.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
