### PR TITLE
Generic math function tests: Test float and double variants

### DIFF
--- a/tests/core/math/test_math_funcs.h
+++ b/tests/core/math/test_math_funcs.h
@@ -88,290 +88,280 @@ TEST_CASE("[Math] Power of two functions") {
 	CHECK(nearest_shift(65535) == 16);
 }
 
-TEST_CASE("[Math] abs") {
-	// int
-	CHECK(Math::abs(-1) == 1);
-	CHECK(Math::abs(0) == 0);
-	CHECK(Math::abs(1) == 1);
-
-	// double
-	CHECK(Math::abs(-0.1) == 0.1);
-	CHECK(Math::abs(0.0) == 0.0);
-	CHECK(Math::abs(0.1) == 0.1);
-
-	// float
-	CHECK(Math::abs(-0.1f) == 0.1f);
-	CHECK(Math::abs(0.0f) == 0.0f);
-	CHECK(Math::abs(0.1f) == 0.1f);
+TEST_CASE_TEMPLATE("[Math] abs", T, int, float, double) {
+	CHECK(Math::abs((T)-1) == (T)1);
+	CHECK(Math::abs((T)0) == (T)0);
+	CHECK(Math::abs((T)1) == (T)1);
+	CHECK(Math::abs((T)0.1) == (T)0.1);
 }
 
-TEST_CASE("[Math] round/floor/ceil") {
-	CHECK(Math::round(1.5) == 2.0);
-	CHECK(Math::round(1.6) == 2.0);
-	CHECK(Math::round(-1.5) == -2.0);
-	CHECK(Math::round(-1.1) == -1.0);
+TEST_CASE_TEMPLATE("[Math] round/floor/ceil", T, float, double) {
+	CHECK(Math::round((T)1.5) == (T)2.0);
+	CHECK(Math::round((T)1.6) == (T)2.0);
+	CHECK(Math::round((T)-1.5) == (T)-2.0);
+	CHECK(Math::round((T)-1.1) == (T)-1.0);
 
-	CHECK(Math::floor(1.5) == 1.0);
-	CHECK(Math::floor(-1.5) == -2.0);
+	CHECK(Math::floor((T)1.5) == (T)1.0);
+	CHECK(Math::floor((T)-1.5) == (T)-2.0);
 
-	CHECK(Math::ceil(1.5) == 2.0);
-	CHECK(Math::ceil(-1.9) == -1.0);
+	CHECK(Math::ceil((T)1.5) == (T)2.0);
+	CHECK(Math::ceil((T)-1.9) == (T)-1.0);
 }
 
-TEST_CASE("[Math] sin/cos/tan") {
-	CHECK(Math::sin(-0.1) == doctest::Approx(-0.0998334166));
-	CHECK(Math::sin(0.1) == doctest::Approx(0.0998334166));
-	CHECK(Math::sin(0.5) == doctest::Approx(0.4794255386));
-	CHECK(Math::sin(1.0) == doctest::Approx(0.8414709848));
-	CHECK(Math::sin(1.5) == doctest::Approx(0.9974949866));
-	CHECK(Math::sin(450.0) == doctest::Approx(-0.683283725));
+TEST_CASE_TEMPLATE("[Math] sin/cos/tan", T, float, double) {
+	CHECK(Math::sin((T)-0.1) == doctest::Approx((T)-0.0998334166));
+	CHECK(Math::sin((T)0.1) == doctest::Approx((T)0.0998334166));
+	CHECK(Math::sin((T)0.5) == doctest::Approx((T)0.4794255386));
+	CHECK(Math::sin((T)1.0) == doctest::Approx((T)0.8414709848));
+	CHECK(Math::sin((T)1.5) == doctest::Approx((T)0.9974949866));
+	CHECK(Math::sin((T)450.0) == doctest::Approx((T)-0.683283725));
 
-	CHECK(Math::cos(-0.1) == doctest::Approx(0.99500416530));
-	CHECK(Math::cos(0.1) == doctest::Approx(0.9950041653));
-	CHECK(Math::cos(0.5) == doctest::Approx(0.8775825619));
-	CHECK(Math::cos(1.0) == doctest::Approx(0.5403023059));
-	CHECK(Math::cos(1.5) == doctest::Approx(0.0707372017));
-	CHECK(Math::cos(450.0) == doctest::Approx(-0.7301529642));
+	CHECK(Math::cos((T)-0.1) == doctest::Approx((T)0.99500416530));
+	CHECK(Math::cos((T)0.1) == doctest::Approx((T)0.9950041653));
+	CHECK(Math::cos((T)0.5) == doctest::Approx((T)0.8775825619));
+	CHECK(Math::cos((T)1.0) == doctest::Approx((T)0.5403023059));
+	CHECK(Math::cos((T)1.5) == doctest::Approx((T)0.0707372017));
+	CHECK(Math::cos((T)450.0) == doctest::Approx((T)-0.7301529642));
 
-	CHECK(Math::tan(-0.1) == doctest::Approx(-0.1003346721));
-	CHECK(Math::tan(0.1) == doctest::Approx(0.1003346721));
-	CHECK(Math::tan(0.5) == doctest::Approx(0.5463024898));
-	CHECK(Math::tan(1.0) == doctest::Approx(1.5574077247));
-	CHECK(Math::tan(1.5) == doctest::Approx(14.1014199472));
-	CHECK(Math::tan(450.0) == doctest::Approx(0.9358090134));
+	CHECK(Math::tan((T)-0.1) == doctest::Approx((T)-0.1003346721));
+	CHECK(Math::tan((T)0.1) == doctest::Approx((T)0.1003346721));
+	CHECK(Math::tan((T)0.5) == doctest::Approx((T)0.5463024898));
+	CHECK(Math::tan((T)1.0) == doctest::Approx((T)1.5574077247));
+	CHECK(Math::tan((T)1.5) == doctest::Approx((T)14.1014199472));
+	CHECK(Math::tan((T)450.0) == doctest::Approx((T)0.9358090134));
 }
 
-TEST_CASE("[Math] sinh/cosh/tanh") {
-	CHECK(Math::sinh(-0.1) == doctest::Approx(-0.10016675));
-	CHECK(Math::sinh(0.1) == doctest::Approx(0.10016675));
-	CHECK(Math::sinh(0.5) == doctest::Approx(0.5210953055));
-	CHECK(Math::sinh(1.0) == doctest::Approx(1.1752011936));
-	CHECK(Math::sinh(1.5) == doctest::Approx(2.1292794551));
+TEST_CASE_TEMPLATE("[Math] sinh/cosh/tanh", T, float, double) {
+	CHECK(Math::sinh((T)-0.1) == doctest::Approx((T)-0.10016675));
+	CHECK(Math::sinh((T)0.1) == doctest::Approx((T)0.10016675));
+	CHECK(Math::sinh((T)0.5) == doctest::Approx((T)0.5210953055));
+	CHECK(Math::sinh((T)1.0) == doctest::Approx((T)1.1752011936));
+	CHECK(Math::sinh((T)1.5) == doctest::Approx((T)2.1292794551));
 
-	CHECK(Math::cosh(-0.1) == doctest::Approx(1.0050041681));
-	CHECK(Math::cosh(0.1) == doctest::Approx(1.0050041681));
-	CHECK(Math::cosh(0.5) == doctest::Approx(1.1276259652));
-	CHECK(Math::cosh(1.0) == doctest::Approx(1.5430806348));
-	CHECK(Math::cosh(1.5) == doctest::Approx(2.3524096152));
+	CHECK(Math::cosh((T)-0.1) == doctest::Approx((T)1.0050041681));
+	CHECK(Math::cosh((T)0.1) == doctest::Approx((T)1.0050041681));
+	CHECK(Math::cosh((T)0.5) == doctest::Approx((T)1.1276259652));
+	CHECK(Math::cosh((T)1.0) == doctest::Approx((T)1.5430806348));
+	CHECK(Math::cosh((T)1.5) == doctest::Approx((T)2.3524096152));
 
-	CHECK(Math::tanh(-0.1) == doctest::Approx(-0.0996679946));
-	CHECK(Math::tanh(0.1) == doctest::Approx(0.0996679946));
-	CHECK(Math::tanh(0.5) == doctest::Approx(0.4621171573));
-	CHECK(Math::tanh(1.0) == doctest::Approx(0.761594156));
-	CHECK(Math::tanh(1.5) == doctest::Approx(0.9051482536));
-	CHECK(Math::tanh(450.0) == doctest::Approx(1.0));
+	CHECK(Math::tanh((T)-0.1) == doctest::Approx((T)-0.0996679946));
+	CHECK(Math::tanh((T)0.1) == doctest::Approx((T)0.0996679946));
+	CHECK(Math::tanh((T)0.5) == doctest::Approx((T)0.4621171573));
+	CHECK(Math::tanh((T)1.0) == doctest::Approx((T)0.761594156));
+	CHECK(Math::tanh((T)1.5) == doctest::Approx((T)0.9051482536));
+	CHECK(Math::tanh((T)450.0) == doctest::Approx((T)1.0));
 }
 
-TEST_CASE("[Math] asin/acos/atan") {
-	CHECK(Math::asin(-0.1) == doctest::Approx(-0.1001674212));
-	CHECK(Math::asin(0.1) == doctest::Approx(0.1001674212));
-	CHECK(Math::asin(0.5) == doctest::Approx(0.5235987756));
-	CHECK(Math::asin(1.0) == doctest::Approx(1.5707963268));
-	CHECK(Math::is_nan(Math::asin(1.5)));
-	CHECK(Math::is_nan(Math::asin(450.0)));
+TEST_CASE_TEMPLATE("[Math] asin/acos/atan", T, float, double) {
+	CHECK(Math::asin((T)-0.1) == doctest::Approx((T)-0.1001674212));
+	CHECK(Math::asin((T)0.1) == doctest::Approx((T)0.1001674212));
+	CHECK(Math::asin((T)0.5) == doctest::Approx((T)0.5235987756));
+	CHECK(Math::asin((T)1.0) == doctest::Approx((T)1.5707963268));
+	CHECK(Math::is_nan(Math::asin((T)1.5)));
+	CHECK(Math::is_nan(Math::asin((T)450.0)));
 
-	CHECK(Math::acos(-0.1) == doctest::Approx(1.670963748));
-	CHECK(Math::acos(0.1) == doctest::Approx(1.4706289056));
-	CHECK(Math::acos(0.5) == doctest::Approx(1.0471975512));
-	CHECK(Math::acos(1.0) == doctest::Approx(0.0));
-	CHECK(Math::is_nan(Math::acos(1.5)));
-	CHECK(Math::is_nan(Math::acos(450.0)));
+	CHECK(Math::acos((T)-0.1) == doctest::Approx((T)1.670963748));
+	CHECK(Math::acos((T)0.1) == doctest::Approx((T)1.4706289056));
+	CHECK(Math::acos((T)0.5) == doctest::Approx((T)1.0471975512));
+	CHECK(Math::acos((T)1.0) == doctest::Approx((T)0.0));
+	CHECK(Math::is_nan(Math::acos((T)1.5)));
+	CHECK(Math::is_nan(Math::acos((T)450.0)));
 
-	CHECK(Math::atan(-0.1) == doctest::Approx(-0.0996686525));
-	CHECK(Math::atan(0.1) == doctest::Approx(0.0996686525));
-	CHECK(Math::atan(0.5) == doctest::Approx(0.463647609));
-	CHECK(Math::atan(1.0) == doctest::Approx(0.7853981634));
-	CHECK(Math::atan(1.5) == doctest::Approx(0.9827937232));
-	CHECK(Math::atan(450.0) == doctest::Approx(1.5685741082));
+	CHECK(Math::atan((T)-0.1) == doctest::Approx((T)-0.0996686525));
+	CHECK(Math::atan((T)0.1) == doctest::Approx((T)0.0996686525));
+	CHECK(Math::atan((T)0.5) == doctest::Approx((T)0.463647609));
+	CHECK(Math::atan((T)1.0) == doctest::Approx((T)0.7853981634));
+	CHECK(Math::atan((T)1.5) == doctest::Approx((T)0.9827937232));
+	CHECK(Math::atan((T)450.0) == doctest::Approx((T)1.5685741082));
 }
 
-TEST_CASE("[Math] sinc/sincn/atan2") {
-	CHECK(Math::sinc(-0.1) == doctest::Approx(0.9983341665));
-	CHECK(Math::sinc(0.1) == doctest::Approx(0.9983341665));
-	CHECK(Math::sinc(0.5) == doctest::Approx(0.9588510772));
-	CHECK(Math::sinc(1.0) == doctest::Approx(0.8414709848));
-	CHECK(Math::sinc(1.5) == doctest::Approx(0.6649966577));
-	CHECK(Math::sinc(450.0) == doctest::Approx(-0.0015184083));
+TEST_CASE_TEMPLATE("[Math] sinc/sincn/atan2", T, float, double) {
+	CHECK(Math::sinc((T)-0.1) == doctest::Approx((T)0.9983341665));
+	CHECK(Math::sinc((T)0.1) == doctest::Approx((T)0.9983341665));
+	CHECK(Math::sinc((T)0.5) == doctest::Approx((T)0.9588510772));
+	CHECK(Math::sinc((T)1.0) == doctest::Approx((T)0.8414709848));
+	CHECK(Math::sinc((T)1.5) == doctest::Approx((T)0.6649966577));
+	CHECK(Math::sinc((T)450.0) == doctest::Approx((T)-0.0015184083));
 
-	CHECK(Math::sincn(-0.1) == doctest::Approx(0.9836316431));
-	CHECK(Math::sincn(0.1) == doctest::Approx(0.9836316431));
-	CHECK(Math::sincn(0.5) == doctest::Approx(0.6366197724));
-	CHECK(Math::sincn(1.0) == doctest::Approx(0.0));
-	CHECK(Math::sincn(1.5) == doctest::Approx(-0.2122065908));
-	CHECK(Math::sincn(450.0) == doctest::Approx(0.0));
+	CHECK(Math::sincn((T)-0.1) == doctest::Approx((T)0.9836316431));
+	CHECK(Math::sincn((T)0.1) == doctest::Approx((T)0.9836316431));
+	CHECK(Math::sincn((T)0.5) == doctest::Approx((T)0.6366197724));
+	CHECK(Math::sincn((T)1.0) == doctest::Approx((T)0.0));
+	CHECK(Math::sincn((T)1.5) == doctest::Approx((T)-0.2122065908));
+	CHECK(Math::sincn((T)450.0) == doctest::Approx((T)0.0));
 
-	CHECK(Math::atan2(-0.1, 0.5) == doctest::Approx(-0.1973955598));
-	CHECK(Math::atan2(0.1, -0.5) == doctest::Approx(2.9441970937));
-	CHECK(Math::atan2(0.5, 1.5) == doctest::Approx(0.3217505544));
-	CHECK(Math::atan2(1.0, 2.5) == doctest::Approx(0.3805063771));
-	CHECK(Math::atan2(1.5, 1.0) == doctest::Approx(0.9827937232));
-	CHECK(Math::atan2(450.0, 1.0) == doctest::Approx(1.5685741082));
+	CHECK(Math::atan2((T)-0.1, (T)0.5) == doctest::Approx((T)-0.1973955598));
+	CHECK(Math::atan2((T)0.1, (T)-0.5) == doctest::Approx((T)2.9441970937));
+	CHECK(Math::atan2((T)0.5, (T)1.5) == doctest::Approx((T)0.3217505544));
+	CHECK(Math::atan2((T)1.0, (T)2.5) == doctest::Approx((T)0.3805063771));
+	CHECK(Math::atan2((T)1.5, (T)1.0) == doctest::Approx((T)0.9827937232));
+	CHECK(Math::atan2((T)450.0, (T)1.0) == doctest::Approx((T)1.5685741082));
 }
 
-TEST_CASE("[Math] pow/log/log2/exp/sqrt") {
-	CHECK(Math::pow(-0.1, 2.0) == doctest::Approx(0.01));
-	CHECK(Math::pow(0.1, 2.5) == doctest::Approx(0.0031622777));
-	CHECK(Math::pow(0.5, 0.5) == doctest::Approx(0.7071067812));
-	CHECK(Math::pow(1.0, 1.0) == doctest::Approx(1.0));
-	CHECK(Math::pow(1.5, -1.0) == doctest::Approx(0.6666666667));
-	CHECK(Math::pow(450.0, -2.0) == doctest::Approx(0.0000049383));
-	CHECK(Math::pow(450.0, 0.0) == doctest::Approx(1.0));
+TEST_CASE_TEMPLATE("[Math] pow/log/log2/exp/sqrt", T, float, double) {
+	CHECK(Math::pow((T)-0.1, (T)2.0) == doctest::Approx((T)0.01));
+	CHECK(Math::pow((T)0.1, (T)2.5) == doctest::Approx((T)0.0031622777));
+	CHECK(Math::pow((T)0.5, (T)0.5) == doctest::Approx((T)0.7071067812));
+	CHECK(Math::pow((T)1.0, (T)1.0) == doctest::Approx((T)1.0));
+	CHECK(Math::pow((T)1.5, (T)-1.0) == doctest::Approx((T)0.6666666667));
+	CHECK(Math::pow((T)450.0, (T)-2.0) == doctest::Approx((T)0.0000049383));
+	CHECK(Math::pow((T)450.0, (T)0.0) == doctest::Approx((T)1.0));
 
-	CHECK(Math::is_nan(Math::log(-0.1)));
-	CHECK(Math::log(0.1) == doctest::Approx(-2.302585093));
-	CHECK(Math::log(0.5) == doctest::Approx(-0.6931471806));
-	CHECK(Math::log(1.0) == doctest::Approx(0.0));
-	CHECK(Math::log(1.5) == doctest::Approx(0.4054651081));
-	CHECK(Math::log(450.0) == doctest::Approx(6.1092475828));
+	CHECK(Math::is_nan(Math::log((T)-0.1)));
+	CHECK(Math::log((T)0.1) == doctest::Approx((T)-2.302585093));
+	CHECK(Math::log((T)0.5) == doctest::Approx((T)-0.6931471806));
+	CHECK(Math::log((T)1.0) == doctest::Approx((T)0.0));
+	CHECK(Math::log((T)1.5) == doctest::Approx((T)0.4054651081));
+	CHECK(Math::log((T)450.0) == doctest::Approx((T)6.1092475828));
 
-	CHECK(Math::is_nan(Math::log2(-0.1)));
-	CHECK(Math::log2(0.1) == doctest::Approx(-3.3219280949));
-	CHECK(Math::log2(0.5) == doctest::Approx(-1.0));
-	CHECK(Math::log2(1.0) == doctest::Approx(0.0));
-	CHECK(Math::log2(1.5) == doctest::Approx(0.5849625007));
-	CHECK(Math::log2(450.0) == doctest::Approx(8.8137811912));
+	CHECK(Math::is_nan(Math::log2((T)-0.1)));
+	CHECK(Math::log2((T)0.1) == doctest::Approx((T)-3.3219280949));
+	CHECK(Math::log2((T)0.5) == doctest::Approx((T)-1.0));
+	CHECK(Math::log2((T)1.0) == doctest::Approx((T)0.0));
+	CHECK(Math::log2((T)1.5) == doctest::Approx((T)0.5849625007));
+	CHECK(Math::log2((T)450.0) == doctest::Approx((T)8.8137811912));
 
-	CHECK(Math::exp(-0.1) == doctest::Approx(0.904837418));
-	CHECK(Math::exp(0.1) == doctest::Approx(1.1051709181));
-	CHECK(Math::exp(0.5) == doctest::Approx(1.6487212707));
-	CHECK(Math::exp(1.0) == doctest::Approx(2.7182818285));
-	CHECK(Math::exp(1.5) == doctest::Approx(4.4816890703));
+	CHECK(Math::exp((T)-0.1) == doctest::Approx((T)0.904837418));
+	CHECK(Math::exp((T)0.1) == doctest::Approx((T)1.1051709181));
+	CHECK(Math::exp((T)0.5) == doctest::Approx((T)1.6487212707));
+	CHECK(Math::exp((T)1.0) == doctest::Approx((T)2.7182818285));
+	CHECK(Math::exp((T)1.5) == doctest::Approx((T)4.4816890703));
 
-	CHECK(Math::is_nan(Math::sqrt(-0.1)));
-	CHECK(Math::sqrt(0.1) == doctest::Approx(0.316228));
-	CHECK(Math::sqrt(0.5) == doctest::Approx(0.707107));
-	CHECK(Math::sqrt(1.0) == doctest::Approx(1.0));
-	CHECK(Math::sqrt(1.5) == doctest::Approx(1.224745));
+	CHECK(Math::is_nan(Math::sqrt((T)-0.1)));
+	CHECK(Math::sqrt((T)0.1) == doctest::Approx((T)0.316228));
+	CHECK(Math::sqrt((T)0.5) == doctest::Approx((T)0.707107));
+	CHECK(Math::sqrt((T)1.0) == doctest::Approx((T)1.0));
+	CHECK(Math::sqrt((T)1.5) == doctest::Approx((T)1.224745));
 }
 
-TEST_CASE("[Math] is_nan/is_inf") {
-	CHECK(!Math::is_nan(0.0));
-	CHECK(Math::is_nan(NAN));
+TEST_CASE_TEMPLATE("[Math] is_nan/is_inf", T, float, double) {
+	CHECK(!Math::is_nan((T)0.0));
+	CHECK(Math::is_nan((T)NAN));
 
-	CHECK(!Math::is_inf(0.0));
-	CHECK(Math::is_inf(INFINITY));
+	CHECK(!Math::is_inf((T)0.0));
+	CHECK(Math::is_inf((T)INFINITY));
 }
 
-TEST_CASE("[Math] linear_to_db") {
-	CHECK(Math::linear_to_db(1.0) == doctest::Approx(0.0));
-	CHECK(Math::linear_to_db(20.0) == doctest::Approx(26.0206));
-	CHECK(Math::is_inf(Math::linear_to_db(0.0)));
-	CHECK(Math::is_nan(Math::linear_to_db(-20.0)));
+TEST_CASE_TEMPLATE("[Math] linear_to_db", T, float, double) {
+	CHECK(Math::linear_to_db((T)1.0) == doctest::Approx((T)0.0));
+	CHECK(Math::linear_to_db((T)20.0) == doctest::Approx((T)26.0206));
+	CHECK(Math::is_inf(Math::linear_to_db((T)0.0)));
+	CHECK(Math::is_nan(Math::linear_to_db((T)-20.0)));
 }
 
-TEST_CASE("[Math] db_to_linear") {
-	CHECK(Math::db_to_linear(0.0) == doctest::Approx(1.0));
-	CHECK(Math::db_to_linear(1.0) == doctest::Approx(1.122018));
-	CHECK(Math::db_to_linear(20.0) == doctest::Approx(10.0));
-	CHECK(Math::db_to_linear(-20.0) == doctest::Approx(0.1));
+TEST_CASE_TEMPLATE("[Math] db_to_linear", T, float, double) {
+	CHECK(Math::db_to_linear((T)0.0) == doctest::Approx((T)1.0));
+	CHECK(Math::db_to_linear((T)1.0) == doctest::Approx((T)1.122018));
+	CHECK(Math::db_to_linear((T)20.0) == doctest::Approx((T)10.0));
+	CHECK(Math::db_to_linear((T)-20.0) == doctest::Approx((T)0.1));
 }
 
-TEST_CASE("[Math] step_decimals") {
-	CHECK(Math::step_decimals(-0.5) == 1);
-	CHECK(Math::step_decimals(0) == 0);
-	CHECK(Math::step_decimals(1) == 0);
-	CHECK(Math::step_decimals(0.1) == 1);
-	CHECK(Math::step_decimals(0.01) == 2);
-	CHECK(Math::step_decimals(0.001) == 3);
-	CHECK(Math::step_decimals(0.0001) == 4);
-	CHECK(Math::step_decimals(0.00001) == 5);
-	CHECK(Math::step_decimals(0.000001) == 6);
-	CHECK(Math::step_decimals(0.0000001) == 7);
-	CHECK(Math::step_decimals(0.00000001) == 8);
-	CHECK(Math::step_decimals(0.000000001) == 9);
+TEST_CASE_TEMPLATE("[Math] step_decimals", T, float, double) {
+	CHECK(Math::step_decimals((T)-0.5) == 1);
+	CHECK(Math::step_decimals((T)0) == 0);
+	CHECK(Math::step_decimals((T)1) == 0);
+	CHECK(Math::step_decimals((T)0.1) == 1);
+	CHECK(Math::step_decimals((T)0.01) == 2);
+	CHECK(Math::step_decimals((T)0.001) == 3);
+	CHECK(Math::step_decimals((T)0.0001) == 4);
+	CHECK(Math::step_decimals((T)0.00001) == 5);
+	CHECK(Math::step_decimals((T)0.000001) == 6);
+	CHECK(Math::step_decimals((T)0.0000001) == 7);
+	CHECK(Math::step_decimals((T)0.00000001) == 8);
+	CHECK(Math::step_decimals((T)0.000000001) == 9);
 	// Too many decimals to handle.
-	CHECK(Math::step_decimals(0.0000000001) == 0);
+	CHECK(Math::step_decimals((T)0.0000000001) == 0);
 }
 
-TEST_CASE("[Math] range_step_decimals") {
-	CHECK(Math::range_step_decimals(0.000000001) == 9);
+TEST_CASE_TEMPLATE("[Math] range_step_decimals", T, float, double) {
+	CHECK(Math::range_step_decimals((T)0.000000001) == 9);
 	// Too many decimals to handle.
-	CHECK(Math::range_step_decimals(0.0000000001) == 0);
+	CHECK(Math::range_step_decimals((T)0.0000000001) == 0);
 	// Should be treated as a step of 0 for use by the editor.
-	CHECK(Math::range_step_decimals(0.0) == 16);
-	CHECK(Math::range_step_decimals(-0.5) == 16);
+	CHECK(Math::range_step_decimals((T)0.0) == 16);
+	CHECK(Math::range_step_decimals((T)-0.5) == 16);
 }
 
-TEST_CASE("[Math] lerp") {
-	CHECK(Math::lerp(2.0, 5.0, -0.1) == doctest::Approx(1.7));
-	CHECK(Math::lerp(2.0, 5.0, 0.0) == doctest::Approx(2.0));
-	CHECK(Math::lerp(2.0, 5.0, 0.1) == doctest::Approx(2.3));
-	CHECK(Math::lerp(2.0, 5.0, 1.0) == doctest::Approx(5.0));
-	CHECK(Math::lerp(2.0, 5.0, 2.0) == doctest::Approx(8.0));
+TEST_CASE_TEMPLATE("[Math] lerp", T, float, double) {
+	CHECK(Math::lerp((T)2.0, (T)5.0, (T)-0.1) == doctest::Approx((T)1.7));
+	CHECK(Math::lerp((T)2.0, (T)5.0, (T)0.0) == doctest::Approx((T)2.0));
+	CHECK(Math::lerp((T)2.0, (T)5.0, (T)0.1) == doctest::Approx((T)2.3));
+	CHECK(Math::lerp((T)2.0, (T)5.0, (T)1.0) == doctest::Approx((T)5.0));
+	CHECK(Math::lerp((T)2.0, (T)5.0, (T)2.0) == doctest::Approx((T)8.0));
 
-	CHECK(Math::lerp(-2.0, -5.0, -0.1) == doctest::Approx(-1.7));
-	CHECK(Math::lerp(-2.0, -5.0, 0.0) == doctest::Approx(-2.0));
-	CHECK(Math::lerp(-2.0, -5.0, 0.1) == doctest::Approx(-2.3));
-	CHECK(Math::lerp(-2.0, -5.0, 1.0) == doctest::Approx(-5.0));
-	CHECK(Math::lerp(-2.0, -5.0, 2.0) == doctest::Approx(-8.0));
+	CHECK(Math::lerp((T)-2.0, (T)-5.0, (T)-0.1) == doctest::Approx((T)-1.7));
+	CHECK(Math::lerp((T)-2.0, (T)-5.0, (T)0.0) == doctest::Approx((T)-2.0));
+	CHECK(Math::lerp((T)-2.0, (T)-5.0, (T)0.1) == doctest::Approx((T)-2.3));
+	CHECK(Math::lerp((T)-2.0, (T)-5.0, (T)1.0) == doctest::Approx((T)-5.0));
+	CHECK(Math::lerp((T)-2.0, (T)-5.0, (T)2.0) == doctest::Approx((T)-8.0));
 }
 
-TEST_CASE("[Math] inverse_lerp") {
-	CHECK(Math::inverse_lerp(2.0, 5.0, 1.7) == doctest::Approx(-0.1));
-	CHECK(Math::inverse_lerp(2.0, 5.0, 2.0) == doctest::Approx(0.0));
-	CHECK(Math::inverse_lerp(2.0, 5.0, 2.3) == doctest::Approx(0.1));
-	CHECK(Math::inverse_lerp(2.0, 5.0, 5.0) == doctest::Approx(1.0));
-	CHECK(Math::inverse_lerp(2.0, 5.0, 8.0) == doctest::Approx(2.0));
+TEST_CASE_TEMPLATE("[Math] inverse_lerp", T, float, double) {
+	CHECK(Math::inverse_lerp((T)2.0, (T)5.0, (T)1.7) == doctest::Approx((T)-0.1));
+	CHECK(Math::inverse_lerp((T)2.0, (T)5.0, (T)2.0) == doctest::Approx((T)0.0));
+	CHECK(Math::inverse_lerp((T)2.0, (T)5.0, (T)2.3) == doctest::Approx((T)0.1));
+	CHECK(Math::inverse_lerp((T)2.0, (T)5.0, (T)5.0) == doctest::Approx((T)1.0));
+	CHECK(Math::inverse_lerp((T)2.0, (T)5.0, (T)8.0) == doctest::Approx((T)2.0));
 
-	CHECK(Math::inverse_lerp(-2.0, -5.0, -1.7) == doctest::Approx(-0.1));
-	CHECK(Math::inverse_lerp(-2.0, -5.0, -2.0) == doctest::Approx(0.0));
-	CHECK(Math::inverse_lerp(-2.0, -5.0, -2.3) == doctest::Approx(0.1));
-	CHECK(Math::inverse_lerp(-2.0, -5.0, -5.0) == doctest::Approx(1.0));
-	CHECK(Math::inverse_lerp(-2.0, -5.0, -8.0) == doctest::Approx(2.0));
+	CHECK(Math::inverse_lerp((T)-2.0, (T)-5.0, (T)-1.7) == doctest::Approx((T)-0.1));
+	CHECK(Math::inverse_lerp((T)-2.0, (T)-5.0, (T)-2.0) == doctest::Approx((T)0.0));
+	CHECK(Math::inverse_lerp((T)-2.0, (T)-5.0, (T)-2.3) == doctest::Approx((T)0.1));
+	CHECK(Math::inverse_lerp((T)-2.0, (T)-5.0, (T)-5.0) == doctest::Approx((T)1.0));
+	CHECK(Math::inverse_lerp((T)-2.0, (T)-5.0, (T)-8.0) == doctest::Approx((T)2.0));
 }
 
-TEST_CASE("[Math] remap") {
-	CHECK(Math::remap(50.0, 100.0, 200.0, 0.0, 1000.0) == doctest::Approx(-500.0));
-	CHECK(Math::remap(100.0, 100.0, 200.0, 0.0, 1000.0) == doctest::Approx(0.0));
-	CHECK(Math::remap(200.0, 100.0, 200.0, 0.0, 1000.0) == doctest::Approx(1000.0));
-	CHECK(Math::remap(250.0, 100.0, 200.0, 0.0, 1000.0) == doctest::Approx(1500.0));
+TEST_CASE_TEMPLATE("[Math] remap", T, float, double) {
+	CHECK(Math::remap((T)50.0, (T)100.0, (T)200.0, (T)0.0, (T)1000.0) == doctest::Approx((T)-500.0));
+	CHECK(Math::remap((T)100.0, (T)100.0, (T)200.0, (T)0.0, (T)1000.0) == doctest::Approx((T)0.0));
+	CHECK(Math::remap((T)200.0, (T)100.0, (T)200.0, (T)0.0, (T)1000.0) == doctest::Approx((T)1000.0));
+	CHECK(Math::remap((T)250.0, (T)100.0, (T)200.0, (T)0.0, (T)1000.0) == doctest::Approx((T)1500.0));
 
-	CHECK(Math::remap(-50.0, -100.0, -200.0, 0.0, 1000.0) == doctest::Approx(-500.0));
-	CHECK(Math::remap(-100.0, -100.0, -200.0, 0.0, 1000.0) == doctest::Approx(0.0));
-	CHECK(Math::remap(-200.0, -100.0, -200.0, 0.0, 1000.0) == doctest::Approx(1000.0));
-	CHECK(Math::remap(-250.0, -100.0, -200.0, 0.0, 1000.0) == doctest::Approx(1500.0));
+	CHECK(Math::remap((T)-50.0, (T)-100.0, (T)-200.0, (T)0.0, (T)1000.0) == doctest::Approx((T)-500.0));
+	CHECK(Math::remap((T)-100.0, (T)-100.0, (T)-200.0, (T)0.0, (T)1000.0) == doctest::Approx((T)0.0));
+	CHECK(Math::remap((T)-200.0, (T)-100.0, (T)-200.0, (T)0.0, (T)1000.0) == doctest::Approx((T)1000.0));
+	CHECK(Math::remap((T)-250.0, (T)-100.0, (T)-200.0, (T)0.0, (T)1000.0) == doctest::Approx((T)1500.0));
 
-	CHECK(Math::remap(-50.0, -100.0, -200.0, 0.0, -1000.0) == doctest::Approx(500.0));
-	CHECK(Math::remap(-100.0, -100.0, -200.0, 0.0, -1000.0) == doctest::Approx(0.0));
-	CHECK(Math::remap(-200.0, -100.0, -200.0, 0.0, -1000.0) == doctest::Approx(-1000.0));
-	CHECK(Math::remap(-250.0, -100.0, -200.0, 0.0, -1000.0) == doctest::Approx(-1500.0));
+	CHECK(Math::remap((T)-50.0, (T)-100.0, (T)-200.0, (T)0.0, (T)-1000.0) == doctest::Approx((T)500.0));
+	CHECK(Math::remap((T)-100.0, (T)-100.0, (T)-200.0, (T)0.0, (T)-1000.0) == doctest::Approx((T)0.0));
+	CHECK(Math::remap((T)-200.0, (T)-100.0, (T)-200.0, (T)0.0, (T)-1000.0) == doctest::Approx((T)-1000.0));
+	CHECK(Math::remap((T)-250.0, (T)-100.0, (T)-200.0, (T)0.0, (T)-1000.0) == doctest::Approx((T)-1500.0));
 }
 
-TEST_CASE("[Math] lerp_angle") {
+TEST_CASE_TEMPLATE("[Math] lerp_angle", T, float, double) {
 	// Counter-clockwise rotation.
-	CHECK(Math::lerp_angle(0.24 * Math_TAU, 0.75 * Math_TAU, 0.5) == doctest::Approx(-0.005 * Math_TAU));
+	CHECK(Math::lerp_angle((T)0.24 * Math_TAU, 0.75 * Math_TAU, 0.5) == doctest::Approx((T)-0.005 * Math_TAU));
 	// Counter-clockwise rotation.
-	CHECK(Math::lerp_angle(0.25 * Math_TAU, 0.75 * Math_TAU, 0.5) == doctest::Approx(0.0));
+	CHECK(Math::lerp_angle((T)0.25 * Math_TAU, 0.75 * Math_TAU, 0.5) == doctest::Approx((T)0.0));
 	// Clockwise rotation.
-	CHECK(Math::lerp_angle(0.26 * Math_TAU, 0.75 * Math_TAU, 0.5) == doctest::Approx(0.505 * Math_TAU));
+	CHECK(Math::lerp_angle((T)0.26 * Math_TAU, 0.75 * Math_TAU, 0.5) == doctest::Approx((T)0.505 * Math_TAU));
 
-	CHECK(Math::lerp_angle(-0.25 * Math_TAU, 1.25 * Math_TAU, 0.5) == doctest::Approx(-0.5 * Math_TAU));
-	CHECK(Math::lerp_angle(0.72 * Math_TAU, 1.44 * Math_TAU, 0.96) == doctest::Approx(0.4512 * Math_TAU));
-	CHECK(Math::lerp_angle(0.72 * Math_TAU, 1.44 * Math_TAU, 1.04) == doctest::Approx(0.4288 * Math_TAU));
+	CHECK(Math::lerp_angle((T)-0.25 * Math_TAU, 1.25 * Math_TAU, 0.5) == doctest::Approx((T)-0.5 * Math_TAU));
+	CHECK(Math::lerp_angle((T)0.72 * Math_TAU, 1.44 * Math_TAU, 0.96) == doctest::Approx((T)0.4512 * Math_TAU));
+	CHECK(Math::lerp_angle((T)0.72 * Math_TAU, 1.44 * Math_TAU, 1.04) == doctest::Approx((T)0.4288 * Math_TAU));
 
 	// Initial and final angles are effectively identical, so the value returned
 	// should always be the same regardless of the `weight` parameter.
-	CHECK(Math::lerp_angle(-4 * Math_TAU, 4 * Math_TAU, -1.0) == doctest::Approx(-4.0 * Math_TAU));
-	CHECK(Math::lerp_angle(-4 * Math_TAU, 4 * Math_TAU, 0.0) == doctest::Approx(-4.0 * Math_TAU));
-	CHECK(Math::lerp_angle(-4 * Math_TAU, 4 * Math_TAU, 0.5) == doctest::Approx(-4.0 * Math_TAU));
-	CHECK(Math::lerp_angle(-4 * Math_TAU, 4 * Math_TAU, 1.0) == doctest::Approx(-4.0 * Math_TAU));
-	CHECK(Math::lerp_angle(-4 * Math_TAU, 4 * Math_TAU, 500.0) == doctest::Approx(-4.0 * Math_TAU));
+	CHECK(Math::lerp_angle((T)-4 * Math_TAU, 4 * Math_TAU, -1.0) == doctest::Approx((T)-4.0 * Math_TAU));
+	CHECK(Math::lerp_angle((T)-4 * Math_TAU, 4 * Math_TAU, 0.0) == doctest::Approx((T)-4.0 * Math_TAU));
+	CHECK(Math::lerp_angle((T)-4 * Math_TAU, 4 * Math_TAU, 0.5) == doctest::Approx((T)-4.0 * Math_TAU));
+	CHECK(Math::lerp_angle((T)-4 * Math_TAU, 4 * Math_TAU, 1.0) == doctest::Approx((T)-4.0 * Math_TAU));
+	CHECK(Math::lerp_angle((T)-4 * Math_TAU, 4 * Math_TAU, 500.0) == doctest::Approx((T)-4.0 * Math_TAU));
 }
 
-TEST_CASE("[Math] move_toward") {
-	CHECK(Math::move_toward(2.0, 5.0, -1.0) == doctest::Approx(1.0));
-	CHECK(Math::move_toward(2.0, 5.0, 2.5) == doctest::Approx(4.5));
-	CHECK(Math::move_toward(2.0, 5.0, 4.0) == doctest::Approx(5.0));
-	CHECK(Math::move_toward(-2.0, -5.0, -1.0) == doctest::Approx(-1.0));
-	CHECK(Math::move_toward(-2.0, -5.0, 2.5) == doctest::Approx(-4.5));
-	CHECK(Math::move_toward(-2.0, -5.0, 4.0) == doctest::Approx(-5.0));
+TEST_CASE_TEMPLATE("[Math] move_toward", T, float, double) {
+	CHECK(Math::move_toward(2.0, 5.0, -1.0) == doctest::Approx((T)1.0));
+	CHECK(Math::move_toward(2.0, 5.0, 2.5) == doctest::Approx((T)4.5));
+	CHECK(Math::move_toward(2.0, 5.0, 4.0) == doctest::Approx((T)5.0));
+	CHECK(Math::move_toward(-2.0, -5.0, -1.0) == doctest::Approx((T)-1.0));
+	CHECK(Math::move_toward(-2.0, -5.0, 2.5) == doctest::Approx((T)-4.5));
+	CHECK(Math::move_toward(-2.0, -5.0, 4.0) == doctest::Approx((T)-5.0));
 }
 
-TEST_CASE("[Math] smoothstep") {
-	CHECK(Math::smoothstep(0.0, 2.0, -5.0) == doctest::Approx(0.0));
-	CHECK(Math::smoothstep(0.0, 2.0, 0.5) == doctest::Approx(0.15625));
-	CHECK(Math::smoothstep(0.0, 2.0, 1.0) == doctest::Approx(0.5));
-	CHECK(Math::smoothstep(0.0, 2.0, 2.0) == doctest::Approx(1.0));
+TEST_CASE_TEMPLATE("[Math] smoothstep", T, float, double) {
+	CHECK(Math::smoothstep((T)0.0, (T)2.0, (T)-5.0) == doctest::Approx((T)0.0));
+	CHECK(Math::smoothstep((T)0.0, (T)2.0, (T)0.5) == doctest::Approx((T)0.15625));
+	CHECK(Math::smoothstep((T)0.0, (T)2.0, (T)1.0) == doctest::Approx((T)0.5));
+	CHECK(Math::smoothstep((T)0.0, (T)2.0, (T)2.0) == doctest::Approx((T)1.0));
 }
 
 TEST_CASE("[Math] ease") {
@@ -429,34 +419,34 @@ TEST_CASE("[Math] larger_prime") {
 	ERR_PRINT_ON;
 }
 
-TEST_CASE("[Math] fmod") {
-	CHECK(Math::fmod(-2.0, 0.3) == doctest::Approx(-0.2));
-	CHECK(Math::fmod(0.0, 0.3) == doctest::Approx(0.0));
-	CHECK(Math::fmod(2.0, 0.3) == doctest::Approx(0.2));
+TEST_CASE_TEMPLATE("[Math] fmod", T, float, double) {
+	CHECK(Math::fmod((T)-2.0, (T)0.3) == doctest::Approx((T)-0.2));
+	CHECK(Math::fmod((T)0.0, (T)0.3) == doctest::Approx((T)0.0));
+	CHECK(Math::fmod((T)2.0, (T)0.3) == doctest::Approx((T)0.2));
 
-	CHECK(Math::fmod(-2.0, -0.3) == doctest::Approx(-0.2));
-	CHECK(Math::fmod(0.0, -0.3) == doctest::Approx(0.0));
-	CHECK(Math::fmod(2.0, -0.3) == doctest::Approx(0.2));
+	CHECK(Math::fmod((T)-2.0, (T)-0.3) == doctest::Approx((T)-0.2));
+	CHECK(Math::fmod((T)0.0, (T)-0.3) == doctest::Approx((T)0.0));
+	CHECK(Math::fmod((T)2.0, (T)-0.3) == doctest::Approx((T)0.2));
 }
 
-TEST_CASE("[Math] fposmod") {
-	CHECK(Math::fposmod(-2.0, 0.3) == doctest::Approx(0.1));
-	CHECK(Math::fposmod(0.0, 0.3) == doctest::Approx(0.0));
-	CHECK(Math::fposmod(2.0, 0.3) == doctest::Approx(0.2));
+TEST_CASE_TEMPLATE("[Math] fposmod", T, float, double) {
+	CHECK(Math::fposmod((T)-2.0, (T)0.3) == doctest::Approx((T)0.1));
+	CHECK(Math::fposmod((T)0.0, (T)0.3) == doctest::Approx((T)0.0));
+	CHECK(Math::fposmod((T)2.0, (T)0.3) == doctest::Approx((T)0.2));
 
-	CHECK(Math::fposmod(-2.0, -0.3) == doctest::Approx(-0.2));
-	CHECK(Math::fposmod(0.0, -0.3) == doctest::Approx(0.0));
-	CHECK(Math::fposmod(2.0, -0.3) == doctest::Approx(-0.1));
+	CHECK(Math::fposmod((T)-2.0, (T)-0.3) == doctest::Approx((T)-0.2));
+	CHECK(Math::fposmod((T)0.0, (T)-0.3) == doctest::Approx((T)0.0));
+	CHECK(Math::fposmod((T)2.0, (T)-0.3) == doctest::Approx((T)-0.1));
 }
 
-TEST_CASE("[Math] fposmodp") {
-	CHECK(Math::fposmodp(-2.0, 0.3) == doctest::Approx(0.1));
-	CHECK(Math::fposmodp(0.0, 0.3) == doctest::Approx(0.0));
-	CHECK(Math::fposmodp(2.0, 0.3) == doctest::Approx(0.2));
+TEST_CASE_TEMPLATE("[Math] fposmodp", T, float, double) {
+	CHECK(Math::fposmodp((T)-2.0, (T)0.3) == doctest::Approx((T)0.1));
+	CHECK(Math::fposmodp((T)0.0, (T)0.3) == doctest::Approx((T)0.0));
+	CHECK(Math::fposmodp((T)2.0, (T)0.3) == doctest::Approx((T)0.2));
 
-	CHECK(Math::fposmodp(-2.0, -0.3) == doctest::Approx(-0.5));
-	CHECK(Math::fposmodp(0.0, -0.3) == doctest::Approx(0.0));
-	CHECK(Math::fposmodp(2.0, -0.3) == doctest::Approx(0.2));
+	CHECK(Math::fposmodp((T)-2.0, (T)-0.3) == doctest::Approx((T)-0.5));
+	CHECK(Math::fposmodp((T)0.0, (T)-0.3) == doctest::Approx((T)0.0));
+	CHECK(Math::fposmodp((T)2.0, (T)-0.3) == doctest::Approx((T)0.2));
 }
 
 TEST_CASE("[Math] posmod") {
@@ -475,80 +465,83 @@ TEST_CASE("[Math] wrapi") {
 	CHECK(Math::wrapi(300'000'000'000, -20, 160) == 120);
 }
 
-TEST_CASE("[Math] wrapf") {
-	CHECK(Math::wrapf(-30.0, -20.0, 160.0) == doctest::Approx(150.0));
-	CHECK(Math::wrapf(30.0, -2.0, 160.0) == doctest::Approx(30.0));
-	CHECK(Math::wrapf(300.0, -20.0, 160.0) == doctest::Approx(120.0));
-	CHECK(Math::wrapf(300'000'000'000.0, -20.0, 160.0) == doctest::Approx(120.0));
+TEST_CASE_TEMPLATE("[Math] wrapf", T, float, double) {
+	CHECK(Math::wrapf((T)-30.0, (T)-20.0, (T)160.0) == doctest::Approx((T)150.0));
+	CHECK(Math::wrapf((T)30.0, (T)-2.0, (T)160.0) == doctest::Approx((T)30.0));
+	CHECK(Math::wrapf((T)300.0, (T)-20.0, (T)160.0) == doctest::Approx((T)120.0));
+
+	CHECK(Math::wrapf(300'000'000'000.0, -20.0, 160.0) == doctest::Approx((T)120.0));
+	// float's precision is too low for 300'000'000'000.0, so we reduce it by a factor of 1000.
+	CHECK(Math::wrapf((float)300'000'000.0, (float)-20.0, (float)160.0) == doctest::Approx((T)128.0));
 }
 
-TEST_CASE("[Math] fract") {
-	CHECK(Math::fract(1.0) == doctest::Approx(0.0));
-	CHECK(Math::fract(77.8) == doctest::Approx(0.8));
-	CHECK(Math::fract(-10.1) == doctest::Approx(0.9));
+TEST_CASE_TEMPLATE("[Math] fract", T, float, double) {
+	CHECK(Math::fract((T)1.0) == doctest::Approx((T)0.0));
+	CHECK(Math::fract((T)77.8) == doctest::Approx((T)0.8));
+	CHECK(Math::fract((T)-10.1) == doctest::Approx((T)0.9));
 }
 
-TEST_CASE("[Math] pingpong") {
-	CHECK(Math::pingpong(0.0, 0.0) == doctest::Approx(0.0));
-	CHECK(Math::pingpong(1.0, 1.0) == doctest::Approx(1.0));
-	CHECK(Math::pingpong(0.5, 2.0) == doctest::Approx(0.5));
-	CHECK(Math::pingpong(3.5, 2.0) == doctest::Approx(0.5));
-	CHECK(Math::pingpong(11.5, 2.0) == doctest::Approx(0.5));
-	CHECK(Math::pingpong(-2.5, 2.0) == doctest::Approx(1.5));
+TEST_CASE_TEMPLATE("[Math] pingpong", T, float, double) {
+	CHECK(Math::pingpong((T)0.0, (T)0.0) == doctest::Approx((T)0.0));
+	CHECK(Math::pingpong((T)1.0, (T)1.0) == doctest::Approx((T)1.0));
+	CHECK(Math::pingpong((T)0.5, (T)2.0) == doctest::Approx((T)0.5));
+	CHECK(Math::pingpong((T)3.5, (T)2.0) == doctest::Approx((T)0.5));
+	CHECK(Math::pingpong((T)11.5, (T)2.0) == doctest::Approx((T)0.5));
+	CHECK(Math::pingpong((T)-2.5, (T)2.0) == doctest::Approx((T)1.5));
 }
 
-TEST_CASE("[Math] deg_to_rad/rad_to_deg") {
-	CHECK(Math::deg_to_rad(180.0) == doctest::Approx(Math_PI));
-	CHECK(Math::deg_to_rad(-27.0) == doctest::Approx(-0.471239));
+TEST_CASE_TEMPLATE("[Math] deg_to_rad/rad_to_deg", T, float, double) {
+	CHECK(Math::deg_to_rad((T)180.0) == doctest::Approx((T)Math_PI));
+	CHECK(Math::deg_to_rad((T)-27.0) == doctest::Approx((T)-0.471239));
 
-	CHECK(Math::rad_to_deg(Math_PI) == doctest::Approx(180.0));
-	CHECK(Math::rad_to_deg(-1.5) == doctest::Approx(-85.94366927));
+	CHECK(Math::rad_to_deg((T)Math_PI) == doctest::Approx((T)180.0));
+	CHECK(Math::rad_to_deg((T)-1.5) == doctest::Approx((T)-85.94366927));
 }
 
-TEST_CASE("[Math] cubic_interpolate") {
-	CHECK(Math::cubic_interpolate(0.2, 0.8, 0.0, 1.0, 0.0) == doctest::Approx(0.2));
-	CHECK(Math::cubic_interpolate(0.2, 0.8, 0.0, 1.0, 0.25) == doctest::Approx(0.33125));
-	CHECK(Math::cubic_interpolate(0.2, 0.8, 0.0, 1.0, 0.5) == doctest::Approx(0.5));
-	CHECK(Math::cubic_interpolate(0.2, 0.8, 0.0, 1.0, 0.75) == doctest::Approx(0.66875));
-	CHECK(Math::cubic_interpolate(0.2, 0.8, 0.0, 1.0, 1.0) == doctest::Approx(0.8));
+TEST_CASE_TEMPLATE("[Math] cubic_interpolate", T, float, double) {
+	CHECK(Math::cubic_interpolate((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.0) == doctest::Approx((T)0.2));
+	CHECK(Math::cubic_interpolate((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.25) == doctest::Approx((T)0.33125));
+	CHECK(Math::cubic_interpolate((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.5) == doctest::Approx((T)0.5));
+	CHECK(Math::cubic_interpolate((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.75) == doctest::Approx((T)0.66875));
+	CHECK(Math::cubic_interpolate((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)1.0) == doctest::Approx((T)0.8));
 
-	CHECK(Math::cubic_interpolate(20.2, 30.1, -100.0, 32.0, -50.0) == doctest::Approx(-6662732.3));
-	CHECK(Math::cubic_interpolate(20.2, 30.1, -100.0, 32.0, -5.0) == doctest::Approx(-9356.3));
-	CHECK(Math::cubic_interpolate(20.2, 30.1, -100.0, 32.0, 0.0) == doctest::Approx(20.2));
-	CHECK(Math::cubic_interpolate(20.2, 30.1, -100.0, 32.0, 1.0) == doctest::Approx(30.1));
-	CHECK(Math::cubic_interpolate(20.2, 30.1, -100.0, 32.0, 4.0) == doctest::Approx(1853.2));
+	CHECK(Math::cubic_interpolate((T)20.2, (T)30.1, (T)-100.0, (T)32.0, (T)-50.0) == doctest::Approx((T)-6662732.3));
+	CHECK(Math::cubic_interpolate((T)20.2, (T)30.1, (T)-100.0, (T)32.0, (T)-5.0) == doctest::Approx((T)-9356.3));
+	CHECK(Math::cubic_interpolate((T)20.2, (T)30.1, (T)-100.0, (T)32.0, (T)0.0) == doctest::Approx((T)20.2));
+	CHECK(Math::cubic_interpolate((T)20.2, (T)30.1, (T)-100.0, (T)32.0, (T)1.0) == doctest::Approx((T)30.1));
+	CHECK(Math::cubic_interpolate((T)20.2, (T)30.1, (T)-100.0, (T)32.0, (T)4.0) == doctest::Approx((T)1853.2));
 }
 
-TEST_CASE("[Math] cubic_interpolate_angle") {
-	CHECK(Math::cubic_interpolate_angle(Math_PI * (1.0 / 6.0), Math_PI * (5.0 / 6.0), 0.0, Math_PI, 0.0) == doctest::Approx(Math_PI * (1.0 / 6.0)));
-	CHECK(Math::cubic_interpolate_angle(Math_PI * (1.0 / 6.0), Math_PI * (5.0 / 6.0), 0.0, Math_PI, 0.25) == doctest::Approx(0.973566));
-	CHECK(Math::cubic_interpolate_angle(Math_PI * (1.0 / 6.0), Math_PI * (5.0 / 6.0), 0.0, Math_PI, 0.5) == doctest::Approx(Math_PI / 2.0));
-	CHECK(Math::cubic_interpolate_angle(Math_PI * (1.0 / 6.0), Math_PI * (5.0 / 6.0), 0.0, Math_PI, 0.75) == doctest::Approx(2.16803));
-	CHECK(Math::cubic_interpolate_angle(Math_PI * (1.0 / 6.0), Math_PI * (5.0 / 6.0), 0.0, Math_PI, 1.0) == doctest::Approx(Math_PI * (5.0 / 6.0)));
+TEST_CASE_TEMPLATE("[Math] cubic_interpolate_angle", T, float, double) {
+	CHECK(Math::cubic_interpolate_angle((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)0.0) == doctest::Approx((T)Math_PI * (1.0 / 6.0)));
+	CHECK(Math::cubic_interpolate_angle((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)0.25) == doctest::Approx((T)0.973566));
+	CHECK(Math::cubic_interpolate_angle((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)0.5) == doctest::Approx((T)Math_PI / 2.0));
+	CHECK(Math::cubic_interpolate_angle((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)0.75) == doctest::Approx((T)2.16803));
+	CHECK(Math::cubic_interpolate_angle((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)1.0) == doctest::Approx((T)Math_PI * (5.0 / 6.0)));
 }
 
-TEST_CASE("[Math] cubic_interpolate_in_time") {
-	CHECK(Math::cubic_interpolate_in_time(0.2, 0.8, 0.0, 1.0, 0.0, 0.5, 0.0, 1.0) == doctest::Approx(0.0));
-	CHECK(Math::cubic_interpolate_in_time(0.2, 0.8, 0.0, 1.0, 0.25, 0.5, 0.0, 1.0) == doctest::Approx(0.1625));
-	CHECK(Math::cubic_interpolate_in_time(0.2, 0.8, 0.0, 1.0, 0.5, 0.5, 0.0, 1.0) == doctest::Approx(0.4));
-	CHECK(Math::cubic_interpolate_in_time(0.2, 0.8, 0.0, 1.0, 0.75, 0.5, 0.0, 1.0) == doctest::Approx(0.6375));
-	CHECK(Math::cubic_interpolate_in_time(0.2, 0.8, 0.0, 1.0, 1.0, 0.5, 0.0, 1.0) == doctest::Approx(0.8));
+TEST_CASE_TEMPLATE("[Math] cubic_interpolate_in_time", T, float, double) {
+	CHECK(Math::cubic_interpolate_in_time((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.0, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)0.0));
+	CHECK(Math::cubic_interpolate_in_time((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.25, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)0.1625));
+	CHECK(Math::cubic_interpolate_in_time((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.5, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)0.4));
+	CHECK(Math::cubic_interpolate_in_time((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)0.75, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)0.6375));
+	CHECK(Math::cubic_interpolate_in_time((T)0.2, (T)0.8, (T)0.0, (T)1.0, (T)1.0, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)0.8));
 }
 
-TEST_CASE("[Math] cubic_interpolate_angle_in_time") {
-	CHECK(Math::cubic_interpolate_angle_in_time(Math_PI * (1.0 / 6.0), Math_PI * (5.0 / 6.0), 0.0, Math_PI, 0.0, 0.5, 0.0, 1.0) == doctest::Approx(0.0));
-	CHECK(Math::cubic_interpolate_angle_in_time(Math_PI * (1.0 / 6.0), Math_PI * (5.0 / 6.0), 0.0, Math_PI, 0.25, 0.5, 0.0, 1.0) == doctest::Approx(0.494964));
-	CHECK(Math::cubic_interpolate_angle_in_time(Math_PI * (1.0 / 6.0), Math_PI * (5.0 / 6.0), 0.0, Math_PI, 0.5, 0.5, 0.0, 1.0) == doctest::Approx(1.27627));
-	CHECK(Math::cubic_interpolate_angle_in_time(Math_PI * (1.0 / 6.0), Math_PI * (5.0 / 6.0), 0.0, Math_PI, 0.75, 0.5, 0.0, 1.0) == doctest::Approx(2.07394));
-	CHECK(Math::cubic_interpolate_angle_in_time(Math_PI * (1.0 / 6.0), Math_PI * (5.0 / 6.0), 0.0, Math_PI, 1.0, 0.5, 0.0, 1.0) == doctest::Approx(Math_PI * (5.0 / 6.0)));
+TEST_CASE_TEMPLATE("[Math] cubic_interpolate_angle_in_time", T, float, double) {
+	CHECK(Math::cubic_interpolate_angle_in_time((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)0.0, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)0.0));
+	CHECK(Math::cubic_interpolate_angle_in_time((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)0.25, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)0.494964));
+	CHECK(Math::cubic_interpolate_angle_in_time((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)0.5, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)1.27627));
+	CHECK(Math::cubic_interpolate_angle_in_time((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)0.75, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)2.07394));
+	CHECK(Math::cubic_interpolate_angle_in_time((T)(Math_PI * (1.0 / 6.0)), (T)(Math_PI * (5.0 / 6.0)), (T)0.0, (T)Math_PI, (T)1.0, (T)0.5, (T)0.0, (T)1.0) == doctest::Approx((T)Math_PI * (5.0 / 6.0)));
 }
 
-TEST_CASE("[Math] bezier_interpolate") {
-	CHECK(Math::bezier_interpolate(0.0, 0.2, 0.8, 1.0, 0.0) == doctest::Approx(0.0));
-	CHECK(Math::bezier_interpolate(0.0, 0.2, 0.8, 1.0, 0.25) == doctest::Approx(0.2125));
-	CHECK(Math::bezier_interpolate(0.0, 0.2, 0.8, 1.0, 0.5) == doctest::Approx(0.5));
-	CHECK(Math::bezier_interpolate(0.0, 0.2, 0.8, 1.0, 0.75) == doctest::Approx(0.7875));
-	CHECK(Math::bezier_interpolate(0.0, 0.2, 0.8, 1.0, 1.0) == doctest::Approx(1.0));
+TEST_CASE_TEMPLATE("[Math] bezier_interpolate", T, float, double) {
+	CHECK(Math::bezier_interpolate((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)0.0) == doctest::Approx((T)0.0));
+	CHECK(Math::bezier_interpolate((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)0.25) == doctest::Approx((T)0.2125));
+	CHECK(Math::bezier_interpolate((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)0.5) == doctest::Approx((T)0.5));
+	CHECK(Math::bezier_interpolate((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)0.75) == doctest::Approx((T)0.7875));
+	CHECK(Math::bezier_interpolate((T)0.0, (T)0.2, (T)0.8, (T)1.0, (T)1.0) == doctest::Approx((T)1.0));
 }
 
 } // namespace TestMath


### PR DESCRIPTION
Since we have a float and double variant of almost all math functions (which are basically just duplicated in most cases) we should test both of them, but currently we use simple float literals (e.g. 1.41) which evaluate to double. This PR changes the corresponding test cases to use doctest's convenient TEST_CASE_TEMPLATE macro. 
Example of a failed test using the float variant of Math::tan, the type is displayed in pointy braces behind the test case's name:
```
===============================================================================
[...]core/math/test_math_funcs.h(111):
TEST CASE:  [Math] sin/cos/tan<float>

[...]core/math/test_math_funcs.h(126): ERROR: CHECK( Math::tan((T)-0.1) == doctest::Approx((T)-1.1003346721) ) is NOT correct!
  values: CHECK( -0.100335 == Approx( -1.10033 ) )
```