### PR TITLE
Fix default values on virtual classes causing errors in projects

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1460,7 +1460,7 @@ Variant ClassDB::class_get_default_property_value(const StringName &p_class, con
 		if (Engine::get_singleton()->has_singleton(p_class)) {
 			c = Engine::get_singleton()->get_singleton_object(p_class);
 			cleanup_c = false;
-		} else if (ClassDB::can_instantiate(p_class)) { // Keep this condition in sync with doc_tools.cpp get_documentation_default_value.
+		} else if (ClassDB::can_instantiate(p_class) && !ClassDB::is_virtual(p_class)) { // Keep this condition in sync with doc_tools.cpp get_documentation_default_value.
 			c = ClassDB::instantiate(p_class);
 			cleanup_c = true;
 		}

--- a/doc/classes/AnimatedTexture.xml
+++ b/doc/classes/AnimatedTexture.xml
@@ -57,6 +57,7 @@
 		<member name="pause" type="bool" setter="set_pause" getter="get_pause" default="false">
 			If [code]true[/code], the animation will pause where it currently is (i.e. at [member current_frame]). The animation will continue from where it was paused when changing this property to [code]false[/code].
 		</member>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 		<member name="speed_scale" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
 			The animation speed is multiplied by this value. If set to a negative value, the animation is played in reverse.
 		</member>

--- a/doc/classes/AtlasTexture.xml
+++ b/doc/classes/AtlasTexture.xml
@@ -23,5 +23,6 @@
 		<member name="region" type="Rect2" setter="set_region" getter="get_region" default="Rect2(0, 0, 0, 0)">
 			The region used to draw the [member atlas].
 		</member>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 	</members>
 </class>

--- a/doc/classes/CameraTexture.xml
+++ b/doc/classes/CameraTexture.xml
@@ -16,6 +16,7 @@
 		<member name="camera_is_active" type="bool" setter="set_camera_active" getter="get_camera_active" default="false">
 			Convenience property that gives access to the active property of the [CameraFeed].
 		</member>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 		<member name="which_feed" type="int" setter="set_which_feed" getter="get_which_feed" enum="CameraServer.FeedImage" default="0">
 			Which image within the [CameraFeed] we want access to, important if the camera image is split in a Y and CbCr component.
 		</member>

--- a/doc/classes/CanvasTexture.xml
+++ b/doc/classes/CanvasTexture.xml
@@ -17,6 +17,7 @@
 			The normal map texture to use. Only has a visible effect if [Light2D]s are affecting this [CanvasTexture].
 			[b]Note:[/b] Godot expects the normal map to use X+, Y+, and Z+ coordinates. See [url=http://wiki.polycount.com/wiki/Normal_Map_Technical_Details#Common_Swizzle_Coordinates]this page[/url] for a comparison of normal map coordinates expected by popular engines.
 		</member>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 		<member name="specular_color" type="Color" setter="set_specular_color" getter="get_specular_color" default="Color(1, 1, 1, 1)">
 			The multiplier for specular reflection colors. The [Light2D]'s color is also taken into account when determining the reflection color. Only has a visible effect if [Light2D]s are affecting this [CanvasTexture].
 		</member>

--- a/doc/classes/CompressedTexture2D.xml
+++ b/doc/classes/CompressedTexture2D.xml
@@ -21,5 +21,6 @@
 		<member name="load_path" type="String" setter="load" getter="get_load_path" default="&quot;&quot;">
 			The CompressedTexture's file path to a [code].ctex[/code] file.
 		</member>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 	</members>
 </class>

--- a/doc/classes/CurveTexture.xml
+++ b/doc/classes/CurveTexture.xml
@@ -13,6 +13,7 @@
 		<member name="curve" type="Curve" setter="set_curve" getter="get_curve">
 			The [Curve] that is rendered onto the texture.
 		</member>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 		<member name="texture_mode" type="int" setter="set_texture_mode" getter="get_texture_mode" enum="CurveTexture.TextureMode" default="0">
 			The format the texture should be generated with. When passing a CurveTexture as a input to a [Shader], this may need to be adjusted.
 		</member>

--- a/doc/classes/CurveXYZTexture.xml
+++ b/doc/classes/CurveXYZTexture.xml
@@ -19,6 +19,7 @@
 		<member name="curve_z" type="Curve" setter="set_curve_z" getter="get_curve_z">
 			The [Curve] that is rendered onto the texture's blue channel.
 		</member>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 		<member name="width" type="int" setter="set_width" getter="get_width" default="256">
 			The width of the texture (in pixels). Higher values make it possible to represent high-frequency data better (such as sudden direction changes), at the cost of increased generation time and memory usage.
 		</member>

--- a/doc/classes/EditorSpinSlider.xml
+++ b/doc/classes/EditorSpinSlider.xml
@@ -22,6 +22,8 @@
 		<member name="read_only" type="bool" setter="set_read_only" getter="is_read_only" default="false">
 			If [code]true[/code], the slider can't be interacted with.
 		</member>
+		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" default="1" />
+		<member name="step" type="float" setter="set_step" getter="get_step" overrides="Range" default="1.0" />
 		<member name="suffix" type="String" setter="set_suffix" getter="get_suffix" default="&quot;&quot;">
 			The suffix to display after the value (in a faded color). This should generally be a plural word. You may have to use an abbreviation if the suffix is too long to be displayed.
 		</member>

--- a/doc/classes/GradientTexture1D.xml
+++ b/doc/classes/GradientTexture1D.xml
@@ -12,6 +12,7 @@
 		<member name="gradient" type="Gradient" setter="set_gradient" getter="get_gradient">
 			The [Gradient] that will be used to fill the texture.
 		</member>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 		<member name="use_hdr" type="bool" setter="set_use_hdr" getter="is_using_hdr" default="false">
 			If [code]true[/code], the generated texture will support high dynamic range ([constant Image.FORMAT_RGBAF] format). This allows for glow effects to work if [member Environment.glow_enabled] is [code]true[/code]. If [code]false[/code], the generated texture will use low dynamic range; overbright colors will be clamped ([constant Image.FORMAT_RGBA8] format).
 		</member>

--- a/doc/classes/GradientTexture2D.xml
+++ b/doc/classes/GradientTexture2D.xml
@@ -27,6 +27,7 @@
 		<member name="repeat" type="int" setter="set_repeat" getter="get_repeat" enum="GradientTexture2D.Repeat" default="0">
 			The gradient repeat type, one of the [enum Repeat] values. The texture is filled starting from [member fill_from] to [member fill_to] offsets by default, but the gradient fill can be repeated to cover the entire texture.
 		</member>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 		<member name="use_hdr" type="bool" setter="set_use_hdr" getter="is_using_hdr" default="false">
 			If [code]true[/code], the generated texture will support high dynamic range ([constant Image.FORMAT_RGBAF] format). This allows for glow effects to work if [member Environment.glow_enabled] is [code]true[/code]. If [code]false[/code], the generated texture will use low dynamic range; overbright colors will be clamped ([constant Image.FORMAT_RGBA8] format).
 		</member>

--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -67,4 +67,7 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
+	</members>
 </class>

--- a/doc/classes/MeshTexture.xml
+++ b/doc/classes/MeshTexture.xml
@@ -18,5 +18,6 @@
 		<member name="mesh" type="Mesh" setter="set_mesh" getter="get_mesh">
 			Sets the mesh used to draw. It must be a mesh using 2D vertices.
 		</member>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 	</members>
 </class>

--- a/doc/classes/PhysicsDirectBodyState2D.xml
+++ b/doc/classes/PhysicsDirectBodyState2D.xml
@@ -209,40 +209,40 @@
 		</method>
 	</methods>
 	<members>
-		<member name="angular_velocity" type="float" setter="set_angular_velocity" getter="get_angular_velocity" default="0.0">
+		<member name="angular_velocity" type="float" setter="set_angular_velocity" getter="get_angular_velocity">
 			The body's rotational velocity in [i]radians[/i] per second.
 		</member>
-		<member name="center_of_mass" type="Vector2" setter="" getter="get_center_of_mass" default="Vector2(0, 0)">
+		<member name="center_of_mass" type="Vector2" setter="" getter="get_center_of_mass">
 			The body's center of mass position relative to the body's center in the global coordinate system.
 		</member>
-		<member name="center_of_mass_local" type="Vector2" setter="" getter="get_center_of_mass_local" default="Vector2(0, 0)">
+		<member name="center_of_mass_local" type="Vector2" setter="" getter="get_center_of_mass_local">
 			The body's center of mass position in the body's local coordinate system.
 		</member>
-		<member name="inverse_inertia" type="float" setter="" getter="get_inverse_inertia" default="0.0">
+		<member name="inverse_inertia" type="float" setter="" getter="get_inverse_inertia">
 			The inverse of the inertia of the body.
 		</member>
-		<member name="inverse_mass" type="float" setter="" getter="get_inverse_mass" default="0.0">
+		<member name="inverse_mass" type="float" setter="" getter="get_inverse_mass">
 			The inverse of the mass of the body.
 		</member>
-		<member name="linear_velocity" type="Vector2" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector2(0, 0)">
+		<member name="linear_velocity" type="Vector2" setter="set_linear_velocity" getter="get_linear_velocity">
 			The body's linear velocity in pixels per second.
 		</member>
-		<member name="sleeping" type="bool" setter="set_sleep_state" getter="is_sleeping" default="false">
+		<member name="sleeping" type="bool" setter="set_sleep_state" getter="is_sleeping">
 			If [code]true[/code], this body is currently sleeping (not active).
 		</member>
-		<member name="step" type="float" setter="" getter="get_step" default="0.0">
+		<member name="step" type="float" setter="" getter="get_step">
 			The timestep (delta) used for the simulation.
 		</member>
-		<member name="total_angular_damp" type="float" setter="" getter="get_total_angular_damp" default="0.0">
+		<member name="total_angular_damp" type="float" setter="" getter="get_total_angular_damp">
 			The rate at which the body stops rotating, if there are not any other forces moving it.
 		</member>
-		<member name="total_gravity" type="Vector2" setter="" getter="get_total_gravity" default="Vector2(0, 0)">
+		<member name="total_gravity" type="Vector2" setter="" getter="get_total_gravity">
 			The total gravity vector being currently applied to this body.
 		</member>
-		<member name="total_linear_damp" type="float" setter="" getter="get_total_linear_damp" default="0.0">
+		<member name="total_linear_damp" type="float" setter="" getter="get_total_linear_damp">
 			The rate at which the body stops moving, if there are not any other forces moving it.
 		</member>
-		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform" default="Transform2D(1, 0, 0, 1, 0, 0)">
+		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform">
 			The body's transformation matrix.
 		</member>
 	</members>

--- a/doc/classes/PhysicsDirectBodyState3D.xml
+++ b/doc/classes/PhysicsDirectBodyState3D.xml
@@ -216,45 +216,45 @@
 		</method>
 	</methods>
 	<members>
-		<member name="angular_velocity" type="Vector3" setter="set_angular_velocity" getter="get_angular_velocity" default="Vector3(0, 0, 0)">
+		<member name="angular_velocity" type="Vector3" setter="set_angular_velocity" getter="get_angular_velocity">
 			The body's rotational velocity in [i]radians[/i] per second.
 		</member>
-		<member name="center_of_mass" type="Vector3" setter="" getter="get_center_of_mass" default="Vector3(0, 0, 0)">
+		<member name="center_of_mass" type="Vector3" setter="" getter="get_center_of_mass">
 			The body's center of mass position relative to the body's center in the global coordinate system.
 		</member>
-		<member name="center_of_mass_local" type="Vector3" setter="" getter="get_center_of_mass_local" default="Vector3(0, 0, 0)">
+		<member name="center_of_mass_local" type="Vector3" setter="" getter="get_center_of_mass_local">
 			The body's center of mass position in the body's local coordinate system.
 		</member>
-		<member name="inverse_inertia" type="Vector3" setter="" getter="get_inverse_inertia" default="Vector3(0, 0, 0)">
+		<member name="inverse_inertia" type="Vector3" setter="" getter="get_inverse_inertia">
 			The inverse of the inertia of the body.
 		</member>
-		<member name="inverse_inertia_tensor" type="Basis" setter="" getter="get_inverse_inertia_tensor" default="Basis(1, 0, 0, 0, 1, 0, 0, 0, 1)">
+		<member name="inverse_inertia_tensor" type="Basis" setter="" getter="get_inverse_inertia_tensor">
 			The inverse of the inertia tensor of the body.
 		</member>
-		<member name="inverse_mass" type="float" setter="" getter="get_inverse_mass" default="0.0">
+		<member name="inverse_mass" type="float" setter="" getter="get_inverse_mass">
 			The inverse of the mass of the body.
 		</member>
-		<member name="linear_velocity" type="Vector3" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector3(0, 0, 0)">
+		<member name="linear_velocity" type="Vector3" setter="set_linear_velocity" getter="get_linear_velocity">
 			The body's linear velocity in units per second.
 		</member>
-		<member name="principal_inertia_axes" type="Basis" setter="" getter="get_principal_inertia_axes" default="Basis(1, 0, 0, 0, 1, 0, 0, 0, 1)">
+		<member name="principal_inertia_axes" type="Basis" setter="" getter="get_principal_inertia_axes">
 		</member>
-		<member name="sleeping" type="bool" setter="set_sleep_state" getter="is_sleeping" default="false">
+		<member name="sleeping" type="bool" setter="set_sleep_state" getter="is_sleeping">
 			If [code]true[/code], this body is currently sleeping (not active).
 		</member>
-		<member name="step" type="float" setter="" getter="get_step" default="0.0">
+		<member name="step" type="float" setter="" getter="get_step">
 			The timestep (delta) used for the simulation.
 		</member>
-		<member name="total_angular_damp" type="float" setter="" getter="get_total_angular_damp" default="0.0">
+		<member name="total_angular_damp" type="float" setter="" getter="get_total_angular_damp">
 			The rate at which the body stops rotating, if there are not any other forces moving it.
 		</member>
-		<member name="total_gravity" type="Vector3" setter="" getter="get_total_gravity" default="Vector3(0, 0, 0)">
+		<member name="total_gravity" type="Vector3" setter="" getter="get_total_gravity">
 			The total gravity vector being currently applied to this body.
 		</member>
-		<member name="total_linear_damp" type="float" setter="" getter="get_total_linear_damp" default="0.0">
+		<member name="total_linear_damp" type="float" setter="" getter="get_total_linear_damp">
 			The rate at which the body stops moving, if there are not any other forces moving it.
 		</member>
-		<member name="transform" type="Transform3D" setter="set_transform" getter="get_transform" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
+		<member name="transform" type="Transform3D" setter="set_transform" getter="get_transform">
 			The body's transformation matrix.
 		</member>
 	</members>

--- a/doc/classes/PlaceholderTexture2D.xml
+++ b/doc/classes/PlaceholderTexture2D.xml
@@ -7,6 +7,7 @@
 	<tutorials>
 	</tutorials>
 	<members>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2(1, 1)">
 		</member>
 	</members>

--- a/doc/classes/PortableCompressedTexture2D.xml
+++ b/doc/classes/PortableCompressedTexture2D.xml
@@ -58,6 +58,7 @@
 			When running on the editor, this class will keep the source compressed data in memory. Otherwise, the source compressed data is lost after loading and the resource can't be re saved.
 			This flag allows to keep the compressed data in memory if you intend it to persist after loading.
 		</member>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 		<member name="size_override" type="Vector2" setter="set_size_override" getter="get_size_override" default="Vector2(0, 0)">
 			Allow overriding the texture size (for 2D only).
 		</member>

--- a/doc/classes/ProgressBar.xml
+++ b/doc/classes/ProgressBar.xml
@@ -15,8 +15,6 @@
 		<member name="show_percentage" type="bool" setter="set_show_percentage" getter="is_percentage_shown" default="true">
 			If [code]true[/code], the fill percentage is displayed on the bar.
 		</member>
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" default="0" />
-		<member name="step" type="float" setter="set_step" getter="get_step" overrides="Range" default="0.01" />
 	</members>
 	<constants>
 		<constant name="FILL_BEGIN_TO_END" value="0" enum="FillMode">

--- a/doc/classes/Range.xml
+++ b/doc/classes/Range.xml
@@ -62,7 +62,8 @@
 		<member name="rounded" type="bool" setter="set_use_rounded_values" getter="is_using_rounded_values" default="false">
 			If [code]true[/code], [code]value[/code] will always be rounded to the nearest integer.
 		</member>
-		<member name="step" type="float" setter="set_step" getter="get_step" default="1.0">
+		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" default="0" />
+		<member name="step" type="float" setter="set_step" getter="get_step" default="0.01">
 			If greater than 0, [code]value[/code] will always be rounded to a multiple of [code]step[/code]. If [code]rounded[/code] is also [code]true[/code], [code]value[/code] will first be rounded to a multiple of [code]step[/code] then rounded to the nearest integer.
 		</member>
 		<member name="value" type="float" setter="set_value" getter="get_value" default="0.0">

--- a/doc/classes/ScrollBar.xml
+++ b/doc/classes/ScrollBar.xml
@@ -12,7 +12,6 @@
 		<member name="custom_step" type="float" setter="set_custom_step" getter="get_custom_step" default="-1.0">
 			Overrides the step used when clicking increment and decrement buttons or when using arrow keys when the [ScrollBar] is focused.
 		</member>
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" default="0" />
 		<member name="step" type="float" setter="set_step" getter="get_step" overrides="Range" default="0.0" />
 	</members>
 	<signals>

--- a/doc/classes/Slider.xml
+++ b/doc/classes/Slider.xml
@@ -17,7 +17,7 @@
 		<member name="scrollable" type="bool" setter="set_scrollable" getter="is_scrollable" default="true">
 			If [code]true[/code], the value can be changed using the mouse wheel.
 		</member>
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" default="0" />
+		<member name="step" type="float" setter="set_step" getter="get_step" overrides="Range" default="1.0" />
 		<member name="tick_count" type="int" setter="set_ticks" getter="get_ticks" default="0">
 			Number of ticks displayed on the slider, including border ticks. Ticks are uniformly-distributed value markers.
 		</member>

--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -59,6 +59,8 @@
 		<member name="select_all_on_focus" type="bool" setter="set_select_all_on_focus" getter="is_select_all_on_focus" default="false">
 			If [code]true[/code], the [SpinBox] will select the whole text when the [LineEdit] gains focus. Clicking the up and down arrows won't trigger this behavior.
 		</member>
+		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" default="1" />
+		<member name="step" type="float" setter="set_step" getter="get_step" overrides="Range" default="1.0" />
 		<member name="suffix" type="String" setter="set_suffix" getter="get_suffix" default="&quot;&quot;">
 			Adds the specified [code]suffix[/code] string after the numerical value of the [SpinBox].
 		</member>

--- a/doc/classes/TextureProgressBar.xml
+++ b/doc/classes/TextureProgressBar.xml
@@ -41,6 +41,8 @@
 		<member name="radial_initial_angle" type="float" setter="set_radial_initial_angle" getter="get_radial_initial_angle" default="0.0">
 			Starting angle for the fill of [member texture_progress] if [member fill_mode] is [constant FILL_CLOCKWISE] or [constant FILL_COUNTER_CLOCKWISE]. When the node's [code]value[/code] is equal to its [code]min_value[/code], the texture doesn't show up at all. When the [code]value[/code] increases, the texture fills and tends towards [member radial_fill_degrees].
 		</member>
+		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" default="1" />
+		<member name="step" type="float" setter="set_step" getter="get_step" overrides="Range" default="1.0" />
 		<member name="stretch_margin_bottom" type="int" setter="set_stretch_margin" getter="get_stretch_margin" default="0">
 			The height of the 9-patch's bottom row. A margin of 16 means the 9-slice's bottom corners and side will have a height of 16 pixels. You can set all 4 margin values individually to create panels with non-uniform borders.
 		</member>

--- a/doc/classes/ViewportTexture.xml
+++ b/doc/classes/ViewportTexture.xml
@@ -15,7 +15,6 @@
 		<link title="3D Viewport Scaling Demo">https://godotengine.org/asset-library/asset/586</link>
 	</tutorials>
 	<members>
-		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="true" />
 		<member name="viewport_path" type="NodePath" setter="set_viewport_path_in_scene" getter="get_viewport_path_in_scene" default="NodePath(&quot;&quot;)">
 			The path to the [Viewport] node to display. This is relative to the scene root, not to the node which uses the texture.
 		</member>

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -335,7 +335,7 @@ static Variant get_documentation_default_value(const StringName &p_class_name, c
 	Variant default_value = Variant();
 	r_default_value_valid = false;
 
-	if (ClassDB::can_instantiate(p_class_name)) { // Keep this condition in sync with ClassDB::class_get_default_property_value.
+	if (ClassDB::can_instantiate(p_class_name) && !ClassDB::is_virtual(p_class_name)) { // Keep this condition in sync with ClassDB::class_get_default_property_value.
 		default_value = ClassDB::class_get_default_property_value(p_class_name, p_property_name, &r_default_value_valid);
 	} else {
 		// Cannot get default value of classes that can't be instantiated

--- a/modules/noise/doc_classes/NoiseTexture2D.xml
+++ b/modules/noise/doc_classes/NoiseTexture2D.xml
@@ -44,6 +44,7 @@
 		<member name="noise" type="Noise" setter="set_noise" getter="get_noise">
 			The instance of the [Noise] object.
 		</member>
+		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 		<member name="seamless" type="bool" setter="set_seamless" getter="get_seamless" default="false">
 			If [code]true[/code], a seamless texture is requested from the [Noise] resource.
 			[b]Note:[/b] Seamless noise textures may take longer to generate and/or can have a lower contrast compared to non-seamless noise depending on the used [Noise] resource. This is because some implementations use higher dimensions for generating seamless noise.


### PR DESCRIPTION
Fixes #68437, regression from #68344. This does result in the physics extension classes not having default values listed. I don't know what the perfect solution would be in this case.