### PR TITLE
Viewport cancels existing tooltip when window looses focus

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -491,6 +491,7 @@ void Viewport::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_WM_WINDOW_FOCUS_OUT: {
+			_gui_cancel_tooltip();
 			_drop_physics_mouseover();
 			if (gui.mouse_focus && !gui.forced_mouse_focus) {
 				_drop_mouse_focus();


### PR DESCRIPTION
this is to fix #68197 

This should be less likely to cause regressions then the last one.

when NOTIFICATION_WM_WINDOW_FOCUS_OUT is received by a viewport it will now call _gui_cancel_tooltip() to avoid it hanging around after the mouse events stop coming in.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
