### PR TITLE
[Font] Add an import option to pre-render all glyphs required for the translation.

### DIFF
--- a/core/string/optimized_translation.h
+++ b/core/string/optimized_translation.h
@@ -81,6 +81,7 @@ protected:
 public:
 	virtual StringName get_message(const StringName &p_src_text, const StringName &p_context = "") const override; //overridable for other implementations
 	virtual StringName get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context = "") const override;
+	virtual Vector<String> get_translated_message_list() const override;
 	void generate(const Ref<Translation> &p_from);
 
 	OptimizedTranslation() {}

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -59,6 +59,18 @@ Vector<String> Translation::_get_message_list() const {
 	return msgs;
 }
 
+Vector<String> Translation::get_translated_message_list() const {
+	Vector<String> msgs;
+	msgs.resize(translation_map.size());
+	int idx = 0;
+	for (const KeyValue<StringName, StringName> &E : translation_map) {
+		msgs.set(idx, E.value);
+		idx += 1;
+	}
+
+	return msgs;
+}
+
 void Translation::_set_messages(const Dictionary &p_messages) {
 	List<Variant> keys;
 	p_messages.get_key_list(&keys);
@@ -140,6 +152,7 @@ void Translation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_plural_message", "src_message", "src_plural_message", "n", "context"), &Translation::get_plural_message, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("erase_message", "src_message", "context"), &Translation::erase_message, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("get_message_list"), &Translation::_get_message_list);
+	ClassDB::bind_method(D_METHOD("get_translated_message_list"), &Translation::get_translated_message_list);
 	ClassDB::bind_method(D_METHOD("get_message_count"), &Translation::get_message_count);
 	ClassDB::bind_method(D_METHOD("_set_messages", "messages"), &Translation::_set_messages);
 	ClassDB::bind_method(D_METHOD("_get_messages"), &Translation::_get_messages);

--- a/core/string/translation.h
+++ b/core/string/translation.h
@@ -64,6 +64,7 @@ public:
 	virtual void erase_message(const StringName &p_src_text, const StringName &p_context = "");
 	virtual void get_message_list(List<StringName> *r_messages) const;
 	virtual int get_message_count() const;
+	virtual Vector<String> get_translated_message_list() const;
 
 	Translation() {}
 };

--- a/core/string/translation_po.cpp
+++ b/core/string/translation_po.cpp
@@ -103,6 +103,23 @@ void TranslationPO::_set_messages(const Dictionary &p_messages) {
 	}
 }
 
+Vector<String> TranslationPO::get_translated_message_list() const {
+	Vector<String> msgs;
+	for (const KeyValue<StringName, HashMap<StringName, Vector<StringName>>> &E : translation_map) {
+		if (E.key != StringName()) {
+			continue;
+		}
+
+		for (const KeyValue<StringName, Vector<StringName>> &E2 : E.value) {
+			for (const StringName &E3 : E2.value) {
+				msgs.push_back(E3);
+			}
+		}
+	}
+
+	return msgs;
+}
+
 Vector<String> TranslationPO::_get_message_list() const {
 	// Return all keys in translation_map.
 

--- a/core/string/translation_po.h
+++ b/core/string/translation_po.h
@@ -70,6 +70,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	Vector<String> get_translated_message_list() const override;
 	void get_message_list(List<StringName> *r_messages) const override;
 	int get_message_count() const override;
 	void add_message(const StringName &p_src_text, const StringName &p_xlated_text, const StringName &p_context = "") override;

--- a/doc/classes/Translation.xml
+++ b/doc/classes/Translation.xml
@@ -88,6 +88,12 @@
 				The number [param n] is the number or quantity of the plural object. It will be used to guide the translation system to fetch the correct plural form for the selected language.
 			</description>
 		</method>
+		<method name="get_translated_message_list" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Returns all the messages (translated text).
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="locale" type="String" setter="set_locale" getter="get_locale" default="&quot;en&quot;">

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -293,6 +293,14 @@
 				Sets language code of column title used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
 			</description>
 		</method>
+		<method name="set_selected">
+			<return type="void" />
+			<param index="0" name="item" type="TreeItem" />
+			<param index="1" name="column" type="int" />
+			<description>
+				Selects the specified [TreeItem] and column.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="allow_reselect" type="bool" setter="set_allow_reselect" getter="get_allow_reselect" default="false">

--- a/editor/import/dynamic_font_import_settings.h
+++ b/editor/import/dynamic_font_import_settings.h
@@ -118,18 +118,30 @@ class DynamicFontImportSettings : public ConfirmationDialog {
 
 	TabContainer *preload_pages = nullptr;
 
+	Label *label_glyphs = nullptr;
+	void _glyph_clear();
+	void _glyph_update_lbl();
+
+	// Page 2.0 layout: Translations
+	Label *page2_0_description = nullptr;
+	Tree *locale_tree = nullptr;
+	TreeItem *locale_root = nullptr;
+	Button *btn_fill_locales = nullptr;
+
+	void _locale_edited();
+	void _process_locales();
+
 	// Page 2.1 layout: Text to select glyphs
 	Label *page2_1_description = nullptr;
-	Label *label_glyphs = nullptr;
 	TextEdit *text_edit = nullptr;
 	EditorInspector *inspector_text = nullptr;
+	Button *btn_fill = nullptr;
 
 	List<ResourceImporter::ImportOption> options_text;
 	Ref<DynamicFontImportSettingsData> text_settings_data;
 
 	void _change_text_opts();
 	void _glyph_text_selected();
-	void _glyph_clear();
 
 	// Page 2.2 layout: Character map
 	Label *page2_2_description = nullptr;

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4338,6 +4338,12 @@ TreeItem *Tree::get_selected() const {
 	return selected_item;
 }
 
+void Tree::set_selected(TreeItem *p_item, int p_column) {
+	ERR_FAIL_INDEX(p_column, columns.size());
+	ERR_FAIL_COND(!p_item);
+	select_single_item(p_item, get_root(), p_column);
+}
+
 int Tree::get_selected_column() const {
 	return selected_col;
 }
@@ -5156,6 +5162,7 @@ void Tree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_root_hidden"), &Tree::is_root_hidden);
 	ClassDB::bind_method(D_METHOD("get_next_selected", "from"), &Tree::get_next_selected);
 	ClassDB::bind_method(D_METHOD("get_selected"), &Tree::get_selected);
+	ClassDB::bind_method(D_METHOD("set_selected", "item", "column"), &Tree::set_selected);
 	ClassDB::bind_method(D_METHOD("get_selected_column"), &Tree::get_selected_column);
 	ClassDB::bind_method(D_METHOD("get_pressed_button"), &Tree::get_pressed_button);
 	ClassDB::bind_method(D_METHOD("set_select_mode", "mode"), &Tree::set_select_mode);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -666,6 +666,7 @@ public:
 	bool is_root_hidden() const;
 	TreeItem *get_next_selected(TreeItem *p_item);
 	TreeItem *get_selected() const;
+	void set_selected(TreeItem *p_item, int p_column = 0);
 	int get_selected_column() const;
 	int get_pressed_button() const;
 	void set_select_mode(SelectMode p_mode);


### PR DESCRIPTION
Adds a new page to the advanced import dialog, as well as a few other improvements to the import dialog:

<img width="1352" alt="Screenshot 2022-11-09 at 14 48 13" src="https://user-images.githubusercontent.com/7645683/200834609-368e9dd5-8f4d-4672-a93a-b4176c8f7510.png">

- Adds advanced import dialog page to pre-prender all glyph required for the translation.
    - Adds method to get list of translated strings.
- Auto add default font configuration if none are in the list when opening dialog.
- Disable "Add Glyphs" buttons if there are no selected configuration.
- Auto select first configuration and glyph range when opening dialog.
    - Adds method to select item in the `Tree`.
- Display total number of pre-rendered glyphs from all sources (instead of glyphs from the only).
