### PR TITLE
Allow to escape closing brackets in ConfigFile tags

### DIFF
--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -208,7 +208,7 @@ Error ConfigFile::_internal_save(Ref<FileAccess> file) {
 			file->store_string("\n");
 		}
 		if (!E.key.is_empty()) {
-			file->store_string("[" + E.key + "]\n\n");
+			file->store_string("[" + E.key.replace("]", "\\]") + "]\n\n");
 		}
 
 		for (const KeyValue<String, Variant> &F : E.value) {
@@ -308,7 +308,7 @@ Error ConfigFile::_parse(const String &p_path, VariantParser::Stream *p_stream) 
 		if (!assign.is_empty()) {
 			set_value(section, assign, value);
 		} else if (!next_tag.name.is_empty()) {
-			section = next_tag.name;
+			section = next_tag.name.replace("\\]", "]");
 		}
 	}
 

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1304,6 +1304,7 @@ Error VariantParser::_parse_tag(Token &token, Stream *p_stream, int &line, Strin
 	if (p_simple_tag) {
 		r_tag.name = "";
 		r_tag.fields.clear();
+		bool escaping = false;
 
 		if (p_stream->is_utf8()) {
 			CharString cs;
@@ -1314,7 +1315,15 @@ Error VariantParser::_parse_tag(Token &token, Stream *p_stream, int &line, Strin
 					return ERR_PARSE_ERROR;
 				}
 				if (c == ']') {
-					break;
+					if (escaping) {
+						escaping = false;
+					} else {
+						break;
+					}
+				} else if (c == '\\') {
+					escaping = true;
+				} else {
+					escaping = false;
 				}
 				cs += c;
 			}
@@ -1327,7 +1336,15 @@ Error VariantParser::_parse_tag(Token &token, Stream *p_stream, int &line, Strin
 					return ERR_PARSE_ERROR;
 				}
 				if (c == ']') {
-					break;
+					if (escaping) {
+						escaping = false;
+					} else {
+						break;
+					}
+				} else if (c == '\\') {
+					escaping = true;
+				} else {
+					escaping = false;
 				}
 				r_tag.name += String::chr(c);
 			}

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1223,7 +1223,7 @@ ProjectList::Item ProjectList::load_project_data(const String &p_path, bool p_fa
 	PackedStringArray unsupported_features = ProjectSettings::get_unsupported_features(project_features);
 
 	uint64_t last_edited = 0;
-	if (FileAccess::exists(conf)) {
+	if (cf_err == OK) {
 		// The modification date marks the date the project was last edited.
 		// This is because the `project.godot` file will always be modified
 		// when editing a project (but not when running it).


### PR DESCRIPTION
Closes #68444
**EDIT**: Also closes #66053

The problem was that `]` in name caused early tag termination and the loaded name was invalid.

A simpler solution would be changing how paths are stored (e.g. use generic "project 1", "project 2", etc. tags and make `path` a key), but I realized that after implementing this. Maybe it's useful though.