### PR TITLE
[openxr] Remove unnecessary fallbacks for native handles on X11

### DIFF
--- a/modules/openxr/extensions/openxr_opengl_extension.cpp
+++ b/modules/openxr/extensions/openxr_opengl_extension.cpp
@@ -151,19 +151,6 @@ void *OpenXROpenGLExtension::set_session_create_and_get_next_pointer(void *p_nex
 	graphics_binding_gl.glxContext = (GLXContext)glxcontext_handle;
 	graphics_binding_gl.glxDrawable = (GLXDrawable)glxdrawable_handle;
 
-	if (graphics_binding_gl.xDisplay == nullptr) {
-		print_line("OpenXR Failed to get xDisplay from Godot, using XOpenDisplay(nullptr)");
-		graphics_binding_gl.xDisplay = XOpenDisplay(nullptr);
-	}
-	if (graphics_binding_gl.glxContext == nullptr) {
-		print_line("OpenXR Failed to get glxContext from Godot, using glXGetCurrentContext()");
-		graphics_binding_gl.glxContext = glXGetCurrentContext();
-	}
-	if (graphics_binding_gl.glxDrawable == 0) {
-		print_line("OpenXR Failed to get glxDrawable from Godot, using glXGetCurrentDrawable()");
-		graphics_binding_gl.glxDrawable = glXGetCurrentDrawable();
-	}
-
 	// spec says to use proper values but runtimes don't care
 	graphics_binding_gl.visualid = 0;
 	graphics_binding_gl.glxFBConfig = 0;


### PR DESCRIPTION
This removes some unnecessary fallbacks for the native X11 handles.

This code was originally copied from the OpenXR plugin for Godot 3. The fallbacks were there for older versions of Godot that didn't have the `OS::get_native_handle()` method. But now in Godot 4, we can rely on `DisplayServer::window_get_native_handle()` and don't need the fallbacks.

@Riteo pointed this out on https://github.com/godotengine/godot/pull/67775 where this code was just added