### PR TITLE
[3.x] GDScript: Fix `get_method_list` for custom functions

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -223,11 +223,15 @@ void GDScript::get_script_method_list(List<MethodInfo> *p_list) const {
 			GDScriptFunction *func = E->get();
 			MethodInfo mi;
 			mi.name = E->key();
-			for (int i = 0; i < func->get_argument_count(); i++) {
-				mi.arguments.push_back(func->get_argument_type(i));
-			}
-
 			mi.return_val = func->get_return_type();
+			for (int i = 0; i < func->get_argument_count(); i++) {
+				PropertyInfo arginfo = func->get_argument_type(i);
+				arginfo.name = func->get_argument_name(i);
+				mi.arguments.push_back(arginfo);
+			}
+			for (int i = 0; i < func->get_default_argument_count(); i++) {
+				mi.default_arguments.push_back(func->get_default_argument_value(i));
+			}
 			p_list->push_back(mi);
 		}
 
@@ -276,11 +280,15 @@ MethodInfo GDScript::get_method_info(const StringName &p_method) const {
 	GDScriptFunction *func = E->get();
 	MethodInfo mi;
 	mi.name = E->key();
-	for (int i = 0; i < func->get_argument_count(); i++) {
-		mi.arguments.push_back(func->get_argument_type(i));
-	}
-
 	mi.return_val = func->get_return_type();
+	for (int i = 0; i < func->get_argument_count(); i++) {
+		PropertyInfo arginfo = func->get_argument_type(i);
+		arginfo.name = func->get_argument_name(i);
+		mi.arguments.push_back(arginfo);
+	}
+	for (int i = 0; i < func->get_default_argument_count(); i++) {
+		mi.default_arguments.push_back(func->get_default_argument_value(i));
+	}
 	return mi;
 }
 
@@ -1166,11 +1174,18 @@ void GDScriptInstance::get_method_list(List<MethodInfo> *p_list) const {
 	const GDScript *sptr = script.ptr();
 	while (sptr) {
 		for (Map<StringName, GDScriptFunction *>::Element *E = sptr->member_functions.front(); E; E = E->next()) {
+			GDScriptFunction *func = E->get();
 			MethodInfo mi;
 			mi.name = E->key();
+			mi.return_val = func->get_return_type();
 			mi.flags |= METHOD_FLAG_FROM_SCRIPT;
 			for (int i = 0; i < E->get()->get_argument_count(); i++) {
-				mi.arguments.push_back(PropertyInfo(Variant::NIL, "arg" + itos(i)));
+				PropertyInfo arginfo = func->get_argument_type(i);
+				arginfo.name = func->get_argument_name(i);
+				mi.arguments.push_back(arginfo);
+			}
+			for (int i = 0; i < func->get_default_argument_count(); i++) {
+				mi.default_arguments.push_back(func->get_default_argument_value(i));
 			}
 			p_list->push_back(mi);
 		}

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -264,6 +264,7 @@ private:
 
 #ifdef TOOLS_ENABLED
 	Vector<StringName> arg_names;
+	Vector<Variant> default_arg_values;
 #endif
 
 	List<StackDebug> stack_debug;
@@ -336,12 +337,16 @@ public:
 		ERR_FAIL_INDEX_V(p_idx, arg_names.size(), StringName());
 		return arg_names[p_idx];
 #else
-		return StringName();
+		return StringName("arg" + itos(p_idx));
 #endif
 	}
-	Variant get_default_argument(int p_idx) const {
-		ERR_FAIL_INDEX_V(p_idx, default_arguments.size(), Variant());
-		return default_arguments[p_idx];
+	Variant get_default_argument_value(int p_idx) const {
+#ifdef TOOLS_ENABLED
+		ERR_FAIL_INDEX_V(p_idx, default_arg_values.size(), Variant());
+		return default_arg_values[p_idx];
+#else
+		return Variant();
+#endif
 	}
 
 	Variant call(GDScriptInstance *p_instance, const Variant **p_args, int p_argcount, Variant::CallError &r_err, CallState *p_state = nullptr);


### PR DESCRIPTION
Closes #33624 for 3.x.

3.x version of #50425, resurrection of #34226, highly desirable for #68449.

The main problem is getting the default values of the arguments. See [the comment](https://github.com/godotengine/godot/pull/34226/files#r356836011).