### PR TITLE
Fix `test_move()` wrong collision response inside One Way Collision

### DIFF
--- a/servers/physics_2d/godot_space_2d.cpp
+++ b/servers/physics_2d/godot_space_2d.cpp
@@ -802,7 +802,8 @@ bool GodotSpace2D::test_body_motion(GodotBody2D *p_body, const PhysicsServer2D::
 				if (GodotCollisionSolver2D::solve(body_shape, body_shape_xform, Vector2(), against_shape, col_obj_shape_xform, Vector2(), nullptr, nullptr, nullptr, 0)) {
 					if (body_shape->allows_one_way_collision() && col_obj->is_shape_set_as_one_way_collision(col_shape_idx)) {
 						Vector2 direction = col_obj_shape_xform.columns[1].normalized();
-						if (motion_normal.dot(direction) < 0) {
+						real_t motion_dot = motion_normal.dot(direction);
+						if (Math::is_nan(motion_dot) || motion_dot <= 0) {
 							continue;
 						}
 					}


### PR DESCRIPTION
Fixes #60835

Really needs a review from the physics gang. A comment in the linked issue has insight that could be helpful to them.