### PR TITLE
Gdextension declarative property

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -191,7 +191,8 @@ jobs:
         if: ${{ matrix.godot-cpp-test }}
         uses: actions/checkout@v3
         with:
-          repository: godotengine/godot-cpp
+          repository: touilleMan/godot-cpp
+          ref: gdextension-declarative-property
           submodules: 'recursive'
           path: 'godot-cpp'
 

--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -309,6 +309,7 @@ typedef GDNativeBool (*GDNativeExtensionScriptInstanceSet)(GDNativeExtensionScri
 typedef GDNativeBool (*GDNativeExtensionScriptInstanceGet)(GDNativeExtensionScriptInstanceDataPtr p_instance, const GDNativeStringNamePtr p_name, GDNativeVariantPtr r_ret);
 typedef const GDNativePropertyInfo *(*GDNativeExtensionScriptInstanceGetPropertyList)(GDNativeExtensionScriptInstanceDataPtr p_instance, uint32_t *r_count);
 typedef void (*GDNativeExtensionScriptInstanceFreePropertyList)(GDNativeExtensionScriptInstanceDataPtr p_instance, const GDNativePropertyInfo *p_list);
+typedef GDNativeVariantType (*GDNativeExtensionScriptInstanceGetPropertyType)(GDNativeExtensionScriptInstanceDataPtr p_instance, const GDNativeStringNamePtr p_name, GDNativeBool *r_is_valid);
 
 typedef GDNativeBool (*GDNativeExtensionScriptInstancePropertyCanRevert)(GDNativeExtensionScriptInstanceDataPtr p_instance, const GDNativeStringNamePtr p_name);
 typedef GDNativeBool (*GDNativeExtensionScriptInstancePropertyGetRevert)(GDNativeExtensionScriptInstanceDataPtr p_instance, const GDNativeStringNamePtr p_name, GDNativeVariantPtr r_ret);
@@ -354,6 +355,7 @@ typedef struct {
 
 	GDNativeExtensionScriptInstanceGetMethodList get_method_list_func;
 	GDNativeExtensionScriptInstanceFreeMethodList free_method_list_func;
+	GDNativeExtensionScriptInstanceGetPropertyType get_property_type_func;
 
 	GDNativeExtensionScriptInstanceHasMethod has_method_func;
 

--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -238,10 +238,10 @@ typedef struct {
 	GDNativeBool is_abstract;
 	GDNativeExtensionClassSet set_func;
 	GDNativeExtensionClassGet get_func;
-	GDNativeExtensionClassGetPropertyList get_property_list_func;
-	GDNativeExtensionClassFreePropertyList free_property_list_func;
-	GDNativeExtensionClassPropertyCanRevert property_can_revert_func;
-	GDNativeExtensionClassPropertyGetRevert property_get_revert_func;
+	uint32_t property_count;
+	GDNativePropertyInfo *properties_info; // array of `property_count` size
+	// array of `property_count` size, properties that can't be reverted are set to NULL
+	GDNativeVariantPtr *properties_revert_value;
 	GDNativeExtensionClassNotification notification_func;
 	GDNativeExtensionClassToString to_string_func;
 	GDNativeExtensionClassReference reference_func;

--- a/core/extension/native_extension.cpp
+++ b/core/extension/native_extension.cpp
@@ -174,10 +174,17 @@ void NativeExtension::_register_extension_class(const GDNativeExtensionClassLibr
 	extension->native_extension.is_abstract = p_extension_funcs->is_abstract;
 	extension->native_extension.set = p_extension_funcs->set_func;
 	extension->native_extension.get = p_extension_funcs->get_func;
-	extension->native_extension.get_property_list = p_extension_funcs->get_property_list_func;
-	extension->native_extension.free_property_list = p_extension_funcs->free_property_list_func;
-	extension->native_extension.property_can_revert = p_extension_funcs->property_can_revert_func;
-	extension->native_extension.property_get_revert = p_extension_funcs->property_get_revert_func;
+
+	for (uint32_t i = 0; i < p_extension_funcs->property_count; i++) {
+		GDNativePropertyInfo *prop = reinterpret_cast<GDNativePropertyInfo *>(&p_extension_funcs->properties_info[i]);
+		extension->native_extension.properties.push_back(PropertyInfo(*prop));
+		Variant *revert_value = reinterpret_cast<Variant *>(p_extension_funcs->properties_revert_value[i]);
+		if (revert_value != NULL) {
+			StringName *prop_name = reinterpret_cast<StringName *>(prop->name);
+			extension->native_extension.properties_revert_value[*prop_name] = revert_value->duplicate(true);
+		}
+	}
+
 	extension->native_extension.notification = p_extension_funcs->notification_func;
 	extension->native_extension.to_string = p_extension_funcs->to_string_func;
 	extension->native_extension.reference = p_extension_funcs->reference_func;

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -313,10 +313,8 @@ struct ObjectNativeExtension {
 	bool is_abstract = false;
 	GDNativeExtensionClassSet set;
 	GDNativeExtensionClassGet get;
-	GDNativeExtensionClassGetPropertyList get_property_list;
-	GDNativeExtensionClassFreePropertyList free_property_list;
-	GDNativeExtensionClassPropertyCanRevert property_can_revert;
-	GDNativeExtensionClassPropertyGetRevert property_get_revert;
+	List<PropertyInfo> properties;
+	HashMap<StringName, Variant> properties_revert_value;
 	GDNativeExtensionClassNotification notification;
 	GDNativeExtensionClassToString to_string;
 	GDNativeExtensionClassReference reference;

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -681,21 +681,15 @@ public:
 		}
 	}
 	virtual Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid = nullptr) const override {
-		Variant::Type type = Variant::Type::NIL;
-		if (native_info->get_property_list_func) {
-			uint32_t pcount;
-			const GDNativePropertyInfo *pinfo = native_info->get_property_list_func(instance, &pcount);
-			for (uint32_t i = 0; i < pcount; i++) {
-				if (p_name == *reinterpret_cast<StringName *>(pinfo->name)) {
-					type = Variant::Type(pinfo->type);
-					break;
-				}
+		if (native_info->get_property_type_func) {
+			GDNativeBool is_valid = 0;
+			GDNativeVariantType type = native_info->get_property_type_func(instance, (const GDNativeStringNamePtr)&p_name, &is_valid);
+			if (r_is_valid) {
+				*r_is_valid = is_valid != 0;
 			}
-			if (native_info->free_property_list_func) {
-				native_info->free_property_list_func(instance, pinfo);
-			}
+			return Variant::Type(type);
 		}
-		return type;
+		return Variant::NIL;
 	}
 
 	virtual bool property_can_revert(const StringName &p_name) const override {


### PR DESCRIPTION
See https://github.com/godot-rust/gdextension/issues/19#issuecomment-1308038369

ping @Bromeon 

On top of that, I've reverted the change on `GDNativeExtensionScriptInstanceInfo` I made in https://github.com/godotengine/godot/pull/67750, I thought it would be simpler to have a similar interface between GDExtension and GDNativeExtensionScriptInstanceInfo, but after deeper investigation it turns out it is much better to have `GDNativeExtensionScriptInstanceInfo` being just a proxy over Godot's internal `ScriptInstance`