### PR TITLE
GDScript 2.0: Fix shift due to skip of non-constant default argument values

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1163,6 +1163,8 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 
 			if (p_function->parameters[i]->default_value->is_constant) {
 				p_function->default_arg_values.push_back(p_function->parameters[i]->default_value->reduced_value);
+			} else {
+				p_function->default_arg_values.push_back(Variant()); // Prevent shift.
 			}
 		}
 #endif // TOOLS_ENABLED


### PR DESCRIPTION
I noticed this while working on #68454.

![](https://user-images.githubusercontent.com/47700418/201150681-5144a8d2-1e2c-488f-b9d4-8403f8f2e000.png)

It should not be `null`, but `<unknown>` (as in the signature hint format), but this is problematic to do, since `MethodInfo`/`PropertyInfo` does not provide this option (we can use some `PROPERTY_USAGE_` flag or add a new one).

![](https://user-images.githubusercontent.com/47700418/201154144-2b202790-3e1f-46ac-8f67-f889695c2427.png)