### PR TITLE
Add detail to NavigationPolygon outline error msg

### DIFF
--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -296,7 +296,9 @@ void NavigationPolygon::make_polygons_from_outlines() {
 
 	TPPLPartition tpart;
 	if (tpart.ConvexPartition_HM(&in_poly, &out_poly) == 0) { //failed!
-		ERR_PRINT("NavigationPolygon: Convex partition failed!");
+		ERR_PRINT("NavigationPolygon: Convex partition failed! Failed to convert outlines to a valid NavigationMesh."
+				  "\nNavigationPolygon outlines can not overlap vertices or edges inside same outline or with other outlines or have any intersections."
+				  "\nAdd the outmost and largest outline first. To add holes inside this outline add the smaller outlines with opposite winding order.");
 		return;
 	}
 


### PR DESCRIPTION
Adds additional information to the error msg when the convex partition fails due to invalid outline arrays created by user error.

It is a regular error that users want to treat 2D navpoly outlines like they treat e.g. procedual collision shape / mesh polygons by e.g. adding arrays with duplicated vertices that creat overlap or have edges that have intersections with other outlines among other issues.

I think the docs are already pretty clear for NavigationPolygon class doc [here](https://docs.godotengine.org/en/latest/classes/class_navigationpolygon.html) and navmesh usage doc [here](https://docs.godotengine.org/en/latest/tutorials/navigation/navigation_using_navigationmeshes.html).
Hope that by adding it to the error msg it gets more visibility.

Closes https://github.com/godotengine/godot/issues/38204
Closes https://github.com/godotengine/godot/issues/68467


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
