### PR TITLE
Use raster versions of copy effects for 2D operations when using the mobile renderer

### DIFF
--- a/servers/rendering/renderer_rd/effects/copy_effects.h
+++ b/servers/rendering/renderer_rd/effects/copy_effects.h
@@ -63,6 +63,8 @@ private:
 		BLUR_MODE_GAUSSIAN_GLOW_AUTO_EXPOSURE,
 		BLUR_MODE_COPY,
 
+		BLUR_MODE_SET_COLOR,
+
 		BLUR_MODE_MAX
 	};
 
@@ -174,6 +176,8 @@ private:
 
 		COPY_TO_FB_MULTIVIEW,
 		COPY_TO_FB_MULTIVIEW_WITH_DEPTH,
+
+		COPY_TO_FB_SET_COLOR,
 		COPY_TO_FB_MAX,
 	};
 
@@ -186,7 +190,9 @@ private:
 		uint32_t force_luminance;
 		uint32_t alpha_to_zero;
 		uint32_t srgb;
-		uint32_t pad;
+		uint32_t alpha_to_one;
+
+		float set_color[4];
 	};
 
 	struct CopyToFb {
@@ -316,11 +322,12 @@ public:
 	void copy_cubemap_to_panorama(RID p_source_cube, RID p_dest_panorama, const Size2i &p_panorama_size, float p_lod, bool p_is_array);
 	void copy_depth_to_rect(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2i &p_rect, bool p_flip_y = false);
 	void copy_depth_to_rect_and_linearize(RID p_source_rd_texture, RID p_dest_texture, const Rect2i &p_rect, bool p_flip_y, float p_z_near, float p_z_far);
-	void copy_to_fb_rect(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2i &p_rect, bool p_flip_y = false, bool p_force_luminance = false, bool p_alpha_to_zero = false, bool p_srgb = false, RID p_secondary = RID(), bool p_multiview = false);
+	void copy_to_fb_rect(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2i &p_rect, bool p_flip_y = false, bool p_force_luminance = false, bool p_alpha_to_zero = false, bool p_srgb = false, RID p_secondary = RID(), bool p_multiview = false, bool alpha_to_one = false);
 	void copy_to_atlas_fb(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2 &p_uv_rect, RD::DrawListID p_draw_list, bool p_flip_y = false, bool p_panorama = false);
 	void copy_raster(RID p_source_texture, RID p_dest_framebuffer);
 
 	void gaussian_blur(RID p_source_rd_texture, RID p_texture, const Rect2i &p_region, bool p_8bit_dst = false);
+	void gaussian_blur_raster(RID p_source_rd_texture, RID p_dest_texture, const Rect2i &p_region, const Size2i &p_size);
 	void gaussian_glow(RID p_source_rd_texture, RID p_back_texture, const Size2i &p_size, float p_strength = 1.0, bool p_high_quality = false, bool p_first_pass = false, float p_luminance_cap = 16.0, float p_exposure = 1.0, float p_bloom = 0.0, float p_hdr_bleed_threshold = 1.0, float p_hdr_bleed_scale = 1.0, RID p_auto_exposure = RID(), float p_auto_exposure_scale = 1.0);
 	void gaussian_glow_raster(RID p_source_rd_texture, RID p_half_texture, RID p_dest_texture, float p_luminance_multiplier, const Size2i &p_size, float p_strength = 1.0, bool p_high_quality = false, bool p_first_pass = false, float p_luminance_cap = 16.0, float p_exposure = 1.0, float p_bloom = 0.0, float p_hdr_bleed_threshold = 1.0, float p_hdr_bleed_scale = 1.0, RID p_auto_exposure = RID(), float p_auto_exposure_scale = 1.0);
 
@@ -328,6 +335,7 @@ public:
 	void make_mipmap_raster(RID p_source_rd_texture, RID p_dest_texture, const Size2i &p_size);
 
 	void set_color(RID p_dest_texture, const Color &p_color, const Rect2i &p_region, bool p_8bit_dst = false);
+	void set_color_raster(RID p_dest_texture, const Color &p_color, const Rect2i &p_region);
 
 	void copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dst_framebuffer, const Rect2 &p_rect, const Vector2 &p_dst_size, float p_z_near, float p_z_far, bool p_dp_flip);
 	void cubemap_downsample(RID p_source_cubemap, RID p_dest_cubemap, const Size2i &p_size);

--- a/servers/rendering/renderer_rd/shaders/effects/blur_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/blur_raster.glsl
@@ -53,30 +53,31 @@ void main() {
 
 #ifdef MODE_GAUSSIAN_BLUR
 
-	// Simpler blur uses SIGMA2 for the gaussian kernel for a stronger effect
+	// For Gaussian Blur we use 13 taps in a single pass instead of 12 taps over 2 passes.
+	// This minimizes the number of times we change framebuffers which is very important for mobile.
+	// Source: http://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare
+	vec4 A = texture(source_color, uv_interp + blur.pixel_size * vec2(-1.0, -1.0));
+	vec4 B = texture(source_color, uv_interp + blur.pixel_size * vec2(0.0, -1.0));
+	vec4 C = texture(source_color, uv_interp + blur.pixel_size * vec2(1.0, -1.0));
+	vec4 D = texture(source_color, uv_interp + blur.pixel_size * vec2(-0.5, -0.5));
+	vec4 E = texture(source_color, uv_interp + blur.pixel_size * vec2(0.5, -0.5));
+	vec4 F = texture(source_color, uv_interp + blur.pixel_size * vec2(-1.0, 0.0));
+	vec4 G = texture(source_color, uv_interp);
+	vec4 H = texture(source_color, uv_interp + blur.pixel_size * vec2(1.0, 0.0));
+	vec4 I = texture(source_color, uv_interp + blur.pixel_size * vec2(-0.5, 0.5));
+	vec4 J = texture(source_color, uv_interp + blur.pixel_size * vec2(0.5, 0.5));
+	vec4 K = texture(source_color, uv_interp + blur.pixel_size * vec2(-1.0, 1.0));
+	vec4 L = texture(source_color, uv_interp + blur.pixel_size * vec2(0.0, 1.0));
+	vec4 M = texture(source_color, uv_interp + blur.pixel_size * vec2(1.0, 1.0));
 
-	// note, for blur blur.luminance_multiplier is irrelavant, we would be multiplying and then dividing by this amount.
+	float base_weight = 0.5 / 4.0;
+	float lesser_weight = 0.125 / 4.0;
 
-	if (bool(blur.flags & FLAG_HORIZONTAL)) {
-		vec2 pix_size = blur.pixel_size;
-		pix_size *= 0.5; //reading from larger buffer, so use more samples
-		vec4 color = texture(source_color, uv_interp + vec2(0.0, 0.0) * pix_size) * 0.214607;
-		color += texture(source_color, uv_interp + vec2(1.0, 0.0) * pix_size) * 0.189879;
-		color += texture(source_color, uv_interp + vec2(2.0, 0.0) * pix_size) * 0.131514;
-		color += texture(source_color, uv_interp + vec2(3.0, 0.0) * pix_size) * 0.071303;
-		color += texture(source_color, uv_interp + vec2(-1.0, 0.0) * pix_size) * 0.189879;
-		color += texture(source_color, uv_interp + vec2(-2.0, 0.0) * pix_size) * 0.131514;
-		color += texture(source_color, uv_interp + vec2(-3.0, 0.0) * pix_size) * 0.071303;
-		frag_color = color;
-	} else {
-		vec2 pix_size = blur.pixel_size;
-		vec4 color = texture(source_color, uv_interp + vec2(0.0, 0.0) * pix_size) * 0.38774;
-		color += texture(source_color, uv_interp + vec2(0.0, 1.0) * pix_size) * 0.24477;
-		color += texture(source_color, uv_interp + vec2(0.0, 2.0) * pix_size) * 0.06136;
-		color += texture(source_color, uv_interp + vec2(0.0, -1.0) * pix_size) * 0.24477;
-		color += texture(source_color, uv_interp + vec2(0.0, -2.0) * pix_size) * 0.06136;
-		frag_color = color;
-	}
+	frag_color = (D + E + I + J) * base_weight;
+	frag_color += (A + B + G + F) * lesser_weight;
+	frag_color += (B + C + H + G) * lesser_weight;
+	frag_color += (F + G + L + K) * lesser_weight;
+	frag_color += (G + H + M + L) * lesser_weight;
 #endif
 
 #ifdef MODE_GAUSSIAN_GLOW

--- a/servers/rendering/renderer_rd/shaders/effects/copy.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/copy.glsl
@@ -194,10 +194,10 @@ void main() {
 
 		color = min(color * feedback, vec4(params.glow_luminance_cap));
 	}
-#endif
+#endif // MODE_GLOW
 	imageStore(dest_buffer, pos + params.target, color);
 
-#endif
+#endif // MODE_GAUSSIAN_BLUR
 
 #ifdef MODE_SIMPLE_COPY
 
@@ -227,7 +227,7 @@ void main() {
 
 	imageStore(dest_buffer, pos + params.target, color);
 
-#endif
+#endif // MODE_SIMPLE_COPY
 
 #ifdef MODE_SIMPLE_COPY_DEPTH
 
@@ -239,7 +239,7 @@ void main() {
 
 	imageStore(dest_buffer, pos + params.target, vec4(color.r));
 
-#endif
+#endif // MODE_SIMPLE_COPY_DEPTH
 
 #ifdef MODE_LINEARIZE_DEPTH_COPY
 
@@ -253,7 +253,7 @@ void main() {
 	}
 
 	imageStore(dest_buffer, pos + params.target, color);
-#endif
+#endif // MODE_LINEARIZE_DEPTH_COPY
 
 #if defined(MODE_CUBEMAP_TO_PANORAMA) || defined(MODE_CUBEMAP_ARRAY_TO_PANORAMA)
 
@@ -276,7 +276,7 @@ void main() {
 	vec4 color = textureLod(source_color, vec4(normal, params.camera_z_far), 0.0); //the biggest the lod the least the acne
 #endif
 	imageStore(dest_buffer, pos + params.target, color);
-#endif
+#endif // defined(MODE_CUBEMAP_TO_PANORAMA) || defined(MODE_CUBEMAP_ARRAY_TO_PANORAMA)
 
 #ifdef MODE_SET_COLOR
 	imageStore(dest_buffer, pos + params.target, params.set_color);

--- a/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl
@@ -26,7 +26,11 @@ layout(push_constant, std430) uniform Params {
 	bool use_section;
 
 	bool force_luminance;
-	uint pad[3];
+	bool alpha_to_zero;
+	bool srgb;
+	bool alpha_to_one;
+
+	vec4 color;
 }
 params;
 
@@ -72,7 +76,9 @@ layout(push_constant, std430) uniform Params {
 	bool force_luminance;
 	bool alpha_to_zero;
 	bool srgb;
-	uint pad;
+	bool alpha_to_one;
+
+	vec4 color;
 }
 params;
 
@@ -105,6 +111,10 @@ vec3 linear_to_srgb(vec3 color) {
 }
 
 void main() {
+#ifdef MODE_SET_COLOR
+	frag_color = params.color;
+#else
+
 #ifdef MULTIVIEW
 	vec3 uv = uv_interp;
 #else
@@ -164,6 +174,10 @@ void main() {
 	if (params.srgb) {
 		color.rgb = linear_to_srgb(color.rgb);
 	}
+	if (params.alpha_to_one) {
+		color.a = 1.0;
+	}
 
 	frag_color = color;
+#endif // MODE_SET_COLOR
 }


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/67160
Fixes: https://github.com/godotengine/godot/issues/68465

This PR also implements a few basic copy operations in raster that weren't available before.

Previously the raster version of guassian blur wasn't used at all. I have updated it to use a single pass downsample instead of the multipass like what is used for Gaussian Glow. Not only is the code much simpler, it is also much more efficient for mobile hardware. Instead of taking 12 samples over two passes (7 samples then 5 samples), it only does one pass but takes 13 samples. The results are slightly less smooth, but are still comparable in quality. On Mobile the cost of changing framebuffers is very high and should be avoided as much as possible. 

In the future, we need to optimize glow similarly and we need to optimize both the gaussian blur and gaussian glow with subpasses (and on compute just do one pass)