### PR TITLE
Ensure user shader is used in depth pass when point size is used

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -3349,7 +3349,7 @@ void RenderForwardClustered::_geometry_instance_add_surface_with_material(Geomet
 
 	SceneShaderForwardClustered::MaterialData *material_shadow = nullptr;
 	void *surface_shadow = nullptr;
-	if (!p_material->shader_data->uses_particle_trails && !p_material->shader_data->writes_modelview_or_projection && !p_material->shader_data->uses_vertex && !p_material->shader_data->uses_position && !p_material->shader_data->uses_discard && !p_material->shader_data->uses_depth_pre_pass && !p_material->shader_data->uses_alpha_clip && p_material->shader_data->cull_mode == SceneShaderForwardClustered::ShaderData::CULL_BACK) {
+	if (!p_material->shader_data->uses_particle_trails && !p_material->shader_data->writes_modelview_or_projection && !p_material->shader_data->uses_vertex && !p_material->shader_data->uses_position && !p_material->shader_data->uses_discard && !p_material->shader_data->uses_depth_pre_pass && !p_material->shader_data->uses_alpha_clip && p_material->shader_data->cull_mode == SceneShaderForwardClustered::ShaderData::CULL_BACK && !p_material->shader_data->uses_point_size) {
 		flags |= GeometryInstanceSurfaceDataCache::FLAG_USES_SHARED_SHADOW_MATERIAL;
 		material_shadow = static_cast<SceneShaderForwardClustered::MaterialData *>(RendererRD::MaterialStorage::get_singleton()->material_get_data(scene_shader.default_material, RendererRD::MaterialStorage::SHADER_TYPE_3D));
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/61178

This was a fascinating problem with a simple solution. 

When point_size is used by a shader, we ensure that all pipelines for that shader are compiled for the POINTS primitive (i.e. the primitive is always overridden to be POINTS). That ensures that, no matter the underlying geometry, the points primitive is always used. However, in certain situations we use a default shadow shader for depth prepass. Accordingly we use the pipelines for the default shadow shadow which respect the meshes chosen primitive (unlike our shader pipeline which overrides the primitive).

In the usual case this works fine, however in #61178 the user was using a mesh set to use the TRIANGLES primitive and a shader set to us POINTS. So during the depth prepass the TRIANGLES primitive was being used. 

The solution is to add ``uses_point_size`` to our list of conditions that disallow using the default shadow shader. 