### PR TITLE
Upgrade Android gradle plugin to version 7.2.1

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,10 +1,10 @@
 ext.versions = [
-    androidGradlePlugin: '7.0.3',
+    androidGradlePlugin: '7.2.1',
     compileSdk         : 32,
-    minSdk             : 19, // Also update 'platform/android/java/lib/AndroidManifest.xml#minSdkVersion' & 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
-    targetSdk          : 32, // Also update 'platform/android/java/lib/AndroidManifest.xml#targetSdkVersion' & 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
+    minSdk             : 19, // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
+    targetSdk          : 32, // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
     buildTools         : '32.0.0',
-    kotlinVersion      : '1.6.21',
+    kotlinVersion      : '1.7.0',
     fragmentVersion    : '1.3.6',
     nexusPublishVersion: '1.1.0',
     javaVersion        : 11,

--- a/platform/android/java/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/platform/android/java/lib/AndroidManifest.xml
+++ b/platform/android/java/lib/AndroidManifest.xml
@@ -4,9 +4,6 @@
     android:versionCode="1"
     android:versionName="1.0">
 
-    <!-- Should match the mindSdk and targetSdk values in platform/android/java/app/config.gradle -->
-    <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="32" />
-
     <application>
 
         <!-- Records the version of the Godot library -->

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -176,11 +176,10 @@ android {
         }
     }
 
-    // TODO: Enable when issues with AGP 7.1+ are resolved (https://github.com/GodotVR/godot_openxr/issues/187).
-//    publishing {
-//        singleVariant("templateRelease") {
-//            withSourcesJar()
-//            withJavadocJar()
-//        }
-//    }
+    publishing {
+        singleVariant("templateRelease") {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }


### PR DESCRIPTION
The [blocking issue](https://github.com/GodotVR/godot_openxr/issues/187) was resolved in https://github.com/GodotVR/godot_openxr/pull/239.

It was caused by a change in the output directory in AGP v7.1.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
