### PR TITLE
Defer `EditorInspector::update_tree` to the process stage to improve performance

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2597,7 +2597,7 @@ bool EditorInspector::_is_property_disabled_by_feature_profile(const StringName 
 	return false;
 }
 
-void EditorInspector::update_tree() {
+void EditorInspector::_update_tree() {
 	//to update properly if all is refreshed
 	StringName current_selected = property_selected;
 	int current_focusable = -1;
@@ -3316,6 +3316,10 @@ void EditorInspector::update_tree() {
 	}
 }
 
+void EditorInspector::update_tree() {
+	update_tree_pending = true;
+}
+
 void EditorInspector::update_property(const String &p_prop) {
 	if (!editor_property_map.has(p_prop)) {
 		return;
@@ -3910,10 +3914,9 @@ void EditorInspector::_notification(int p_what) {
 			changing++;
 
 			if (update_tree_pending) {
-				update_tree();
 				update_tree_pending = false;
 				pending.clear();
-
+				_update_tree();
 			} else {
 				while (pending.size()) {
 					StringName prop = *pending.begin();

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -540,6 +540,8 @@ class EditorInspector : public ScrollContainer {
 	void _show_add_meta_dialog();
 	void _check_meta_name(const String &p_name);
 
+	void _update_tree();
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);


### PR DESCRIPTION
`EditorInspector::update_tree` is expensive, so defer the call to the process phase to prevent multiple calls in a single frame (when switching scene tabs).

Improve the experience when using `Ctrl + D` to copy nodes.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
