### PR TITLE
Fix memory leak in `EditorSettingsDialog`

### DIFF
--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -487,6 +487,7 @@ void EditorSettingsDialog::_update_shortcuts() {
 		TreeItem *section = E.value;
 		if (section->get_first_child() == nullptr) {
 			root->remove_child(section);
+			memdelete(section);
 		}
 	}
 }


### PR DESCRIPTION
Delete `TreeItem`s that are not in `Tree`, `TreeItem` needs to be deleted manually.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
