### PR TITLE
Enable mipmaps in cubemap roughness shader

### DIFF
--- a/servers/rendering/renderer_rd/effects/copy_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/copy_effects.cpp
@@ -1122,8 +1122,8 @@ void CopyEffects::cubemap_roughness_raster(RID p_source_rd_texture, RID p_dest_f
 	roughness.push_constant.use_direct_write = p_roughness == 0.0;
 	roughness.push_constant.face_size = p_size;
 
-	// setup our uniforms
-	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
+	// Setup our uniforms.
+	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
 	RD::Uniform u_source_rd_texture(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_rd_texture }));
 


### PR DESCRIPTION
This PR fixes the appearance of radiance maps in the mobile renderer and should improve performance slightly. The shader always reads from a mipmapped cubemap, so the sampler always needs to include mipmaps. 

_Before:_

![Screenshot from 2022-11-10 23-40-46](https://user-images.githubusercontent.com/16521339/201290977-c57ce65d-8b11-49c9-bdb1-5f3f4087c06d.png)


_After:_

![Screenshot from 2022-11-10 23-38-39](https://user-images.githubusercontent.com/16521339/201290979-674324a7-e1ad-4d57-af9f-804632e2362b.png)