### PR TITLE
Fix `Shader::has_parameter` to return a correct value

### DIFF
--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -177,7 +177,7 @@ bool Shader::is_text_shader() const {
 }
 
 bool Shader::has_parameter(const StringName &p_name) const {
-	return params_cache.has("shader_parameter/" + p_name);
+	return params_cache.has(p_name);
 }
 
 void Shader::_update_shader() const {


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/68507 (shader_parameter is leftover prefix which prevents it to return a correct value).