### PR TITLE
Mention .godot folder in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,4 +53,4 @@ body:
     label: Minimal reproduction project
     description: |
       A small Godot project which reproduces the issue. Highly recommended to speed up troubleshooting.
-      Drag and drop a ZIP archive to upload it.
+      Drag and drop a ZIP archive to upload it. Be sure to not include the ".godot" folder in the archive.


### PR DESCRIPTION
I'm constantly annoyed by 6MB+ minimal reproduction project, where 99% is useless shader cache.

Maybe if it's mentioned in the template, *some* people *might* read it and there will be less of these. Although it could be worded better probably.