### PR TITLE
Fix click location bug/reorganize code in `RichTextLabel`

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1505,7 +1505,7 @@ float RichTextLabel::_find_click_in_line(ItemFrame *p_frame, int p_line, const V
 		}
 
 		if (p_click.y >= rect.position.y && p_click.y <= rect.position.y + rect.size.y) {
-			if ((!rtl && p_click.x >= rect.position.x) || (rtl && p_click.x <= rect.position.x + rect.size.x)) {
+            if ((!rtl && p_click.x >= rect.position.x) || ((rtl || l.text_buf->get_alignment() != HORIZONTAL_ALIGNMENT_LEFT) && p_click.x <= rect.position.x + rect.size.x)) {
 				if (p_meta) {
 					int64_t glyph_idx = TS->shaped_text_hit_test_grapheme(rid, p_click.x - rect.position.x);
 					if (glyph_idx >= 0) {
@@ -5496,10 +5496,10 @@ int RichTextLabel::get_character_line(int p_char) {
 	int to_line = main->first_invalid_line.load();
 	for (int i = 0; i < to_line; i++) {
 		MutexLock lock(main->lines[i].text_buf->get_mutex());
-		if (main->lines[i].char_offset < p_char && p_char <= main->lines[i].char_offset + main->lines[i].char_count) {
+        if (main->lines[i].char_offset <= p_char && p_char <= main->lines[i].char_offset + main->lines[i].char_count) {
 			for (int j = 0; j < main->lines[i].text_buf->get_line_count(); j++) {
 				Vector2i range = main->lines[i].text_buf->get_line_range(j);
-				if (main->lines[i].char_offset + range.x < p_char && p_char <= main->lines[i].char_offset + range.y) {
+                if (main->lines[i].char_offset + range.x <= p_char && p_char <= main->lines[i].char_offset + range.y) {
 					return line_count;
 				}
 				line_count++;

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1505,7 +1505,7 @@ float RichTextLabel::_find_click_in_line(ItemFrame *p_frame, int p_line, const V
 		}
 
 		if (p_click.y >= rect.position.y && p_click.y <= rect.position.y + rect.size.y) {
-            if ((!rtl && p_click.x >= rect.position.x) || ((rtl || l.text_buf->get_alignment() != HORIZONTAL_ALIGNMENT_LEFT) && p_click.x <= rect.position.x + rect.size.x)) {
+			if ((!rtl && p_click.x >= rect.position.x) || ((rtl || l.text_buf->get_alignment() != HORIZONTAL_ALIGNMENT_LEFT) && p_click.x <= rect.position.x + rect.size.x)) {
 				if (p_meta) {
 					int64_t glyph_idx = TS->shaped_text_hit_test_grapheme(rid, p_click.x - rect.position.x);
 					if (glyph_idx >= 0) {
@@ -5496,10 +5496,10 @@ int RichTextLabel::get_character_line(int p_char) {
 	int to_line = main->first_invalid_line.load();
 	for (int i = 0; i < to_line; i++) {
 		MutexLock lock(main->lines[i].text_buf->get_mutex());
-        if (main->lines[i].char_offset <= p_char && p_char <= main->lines[i].char_offset + main->lines[i].char_count) {
+		if (main->lines[i].char_offset <= p_char && p_char <= main->lines[i].char_offset + main->lines[i].char_count) {
 			for (int j = 0; j < main->lines[i].text_buf->get_line_count(); j++) {
 				Vector2i range = main->lines[i].text_buf->get_line_range(j);
-                if (main->lines[i].char_offset + range.x <= p_char && p_char <= main->lines[i].char_offset + range.y) {
+				if (main->lines[i].char_offset + range.x <= p_char && p_char <= main->lines[i].char_offset + range.y) {
 					return line_count;
 				}
 				line_count++;

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -5517,7 +5517,7 @@ int RichTextLabel::get_character_paragraph(int p_char) {
 	int para_count = 0;
 	int to_line = main->first_invalid_line.load();
 	for (int i = 0; i < to_line; i++) {
-		if (main->lines[i].char_offset < p_char && p_char <= main->lines[i].char_offset + main->lines[i].char_count) {
+		if (main->lines[i].char_offset <= p_char && p_char < main->lines[i].char_offset + main->lines[i].char_count) {
 			return para_count;
 		} else {
 			para_count++;

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -643,18 +643,19 @@ public:
 
 	bool search(const String &p_string, bool p_from_selection = false, bool p_search_previous = false);
 
-	void scroll_to_paragraph(int p_paragraph);
-	int get_paragraph_count() const;
-	int get_visible_paragraph_count() const;
+    void scroll_to_paragraph(int p_paragraph);
+    int get_paragraph_count() const;
+    int get_visible_paragraph_count() const;
+    float get_paragraph_offset(int p_paragraph); // y offset.
+    int get_character_paragraph(int p_char); // Paragraph (Line type) index, not document total lines index.
 
-	float get_line_offset(int p_line);
-	float get_paragraph_offset(int p_paragraph);
+    void scroll_to_line(int p_line); // Document total lines index.
+    int get_line_count() const; // Document total lines.
+    int get_visible_line_count() const; // From total document lines.
+    float get_line_offset(int p_line); // y offset of a document line index.
+    int get_character_line(int p_char); // Document total lines index from document total chars index.
 
-	void scroll_to_line(int p_line);
-	int get_line_count() const;
-	int get_visible_line_count() const;
-
-	int get_content_height() const;
+    int get_content_height() const;
 	int get_content_width() const;
 
 	VScrollBar *get_v_scroll_bar() { return vscroll; }
@@ -711,13 +712,11 @@ public:
 
 	void set_visible_characters(int p_visible);
 	int get_visible_characters() const;
-	int get_character_line(int p_char);
-	int get_character_paragraph(int p_char);
 	int get_total_character_count() const;
 	int get_total_glyph_count() const;
-
-	void set_visible_ratio(float p_ratio);
-	float get_visible_ratio() const;
+    
+    void set_visible_ratio(float p_ratio);
+    float get_visible_ratio() const;
 
 	TextServer::VisibleCharactersBehavior get_visible_characters_behavior() const;
 	void set_visible_characters_behavior(TextServer::VisibleCharactersBehavior p_behavior);

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -643,19 +643,19 @@ public:
 
 	bool search(const String &p_string, bool p_from_selection = false, bool p_search_previous = false);
 
-    void scroll_to_paragraph(int p_paragraph);
-    int get_paragraph_count() const;
-    int get_visible_paragraph_count() const;
-    float get_paragraph_offset(int p_paragraph); // y offset.
-    int get_character_paragraph(int p_char); // Paragraph (Line type) index, not document total lines index.
+	void scroll_to_paragraph(int p_paragraph);
+	int get_paragraph_count() const;
+	int get_visible_paragraph_count() const;
+	float get_paragraph_offset(int p_paragraph); // y offset.
+	int get_character_paragraph(int p_char); // Paragraph (Line type) index, not document total lines index.
 
-    void scroll_to_line(int p_line); // Document total lines index.
-    int get_line_count() const; // Document total lines.
-    int get_visible_line_count() const; // From total document lines.
-    float get_line_offset(int p_line); // y offset of a document line index.
-    int get_character_line(int p_char); // Document total lines index from document total chars index.
+	void scroll_to_line(int p_line); // Document total lines index.
+	int get_line_count() const; // Document total lines.
+	int get_visible_line_count() const; // From total document lines.
+	float get_line_offset(int p_line); // y offset of a document line index.
+	int get_character_line(int p_char); // Document total lines index from document total chars index.
 
-    int get_content_height() const;
+	int get_content_height() const;
 	int get_content_width() const;
 
 	VScrollBar *get_v_scroll_bar() { return vscroll; }
@@ -714,9 +714,9 @@ public:
 	int get_visible_characters() const;
 	int get_total_character_count() const;
 	int get_total_glyph_count() const;
-    
-    void set_visible_ratio(float p_ratio);
-    float get_visible_ratio() const;
+
+	void set_visible_ratio(float p_ratio);
+	float get_visible_ratio() const;
 
 	TextServer::VisibleCharactersBehavior get_visible_characters_behavior() const;
 	void set_visible_characters_behavior(TextServer::VisibleCharactersBehavior p_behavior);


### PR DESCRIPTION
Fixed click location bug for last line of center and right aligned paragraphs; fixed get_character_line() failure to return the line start char index; minor reorganization and comments in header for clarity.

These minor fixes are essential for any future cursor/caret implementation, which I have almost completed on a separate branch. That branch adds multi-selection and a cursor API compatible with TextEdit.

Issues fixed:
If you try to begin a selection by clicking in the left margin of the last line of a paragraph with center or right alignment, it will not commence.

get_character_line() fails to return the start char of a paragraph line (line range).

The header cosmetic/comment changes are intended to assist with code reasoning. RTL has three distinct "lines" interspersed throughout, each completely different, which makes learning the class confusing: the Line type is equivalent to a "paragraph"; a document "line" is a rendered discrete line from all the lines visible in the document; and a paragraph "line" is a wrapped line within the paragraph whereas index 0 is the first line of the paragraph. 