### PR TITLE
Allow `++` as an alternative separator to `--` for user CLI arguments

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -182,10 +182,12 @@
 		<method name="get_cmdline_user_args">
 			<return type="PackedStringArray" />
 			<description>
-				Similar to [method get_cmdline_args], but this returns the user arguments (any argument passed after the double dash [code]--[/code] argument). These are left untouched by Godot for the user.
+				Similar to [method get_cmdline_args], but this returns the user arguments (any argument passed after the double dash [code]--[/code] or double plus [code]++[/code] argument). These are left untouched by Godot for the user. [code]++[/code] can be used in situations where [code]--[/code] is intercepted by another program (such as [code]startx[/code]).
 				For example, in the command line below, [code]--fullscreen[/code] will not be returned in [method get_cmdline_user_args] and [code]--level 1[/code] will only be returned in [method get_cmdline_user_args]:
 				[codeblock]
 				godot --fullscreen -- --level 1
+				# Or:
+				godot --fullscreen ++ --level 1
 				[/codeblock]
 			</description>
 		</method>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -316,7 +316,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("\n");
 
 	OS::get_singleton()->print("Run options:\n");
-	OS::get_singleton()->print("  --                                           Separator for user-provided arguments. Following arguments are not used by the engine, but can be read from `OS.get_cmdline_user_args()`.\n");
+	OS::get_singleton()->print("  --, ++                                       Separator for user-provided arguments. Following arguments are not used by the engine, but can be read from `OS.get_cmdline_user_args()`.\n");
 #ifdef TOOLS_ENABLED
 	OS::get_singleton()->print("  -e, --editor                                 Start the editor instead of running the scene.\n");
 	OS::get_singleton()->print("  -p, --project-manager                        Start the project manager, even if a project is auto-detected.\n");
@@ -1286,7 +1286,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 
-		} else if (I->get() == "--") {
+		} else if (I->get() == "--" || I->get() == "++") {
 			adding_user_args = true;
 		} else {
 			main_args.push_back(I->get());


### PR DESCRIPTION
This is required when using `startx` to start a Godot project, as `--` is used by `startx` for its own arguments (and there is no way to escape it). This is specifically needed by https://github.com/godotengine/godot-benchmarks for automation purposes.

**Testing project:** [test_cli_separator_double_slash.zip](https://github.com/godotengine/godot/files/9992358/test_cli_separator_double_slash.zip)
