### PR TITLE
Use a bold font for section titles in the editor performance monitor

### DIFF
--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -234,6 +234,7 @@ TreeItem *EditorPerformanceProfiler::_get_monitor_base(const StringName &p_base_
 	base->set_editable(0, false);
 	base->set_selectable(0, false);
 	base->set_expand_right(0, true);
+	base->set_custom_font(0, get_theme_font(SNAME("bold"), SNAME("EditorFonts")));
 	base_map.insert(p_base_name, base);
 	return base;
 }


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/68536.

This is consistent with styling used in the Project/Editor Settings dialogs and the inspector.