### PR TITLE
Add GCC problem matcher to CI

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -102,6 +102,9 @@ jobs:
         with:
           dotnet-version: '6.0.x'
 
+      - name: Setup GCC problem matcher
+        uses: ammaraskar/gcc-problem-matcher@master
+
       - name: Compilation
         uses: ./.github/actions/godot-build
         with:


### PR DESCRIPTION
Adds the GCC problem matcher action to CI so errors in C++ show inline in the `Files changed` tab of a PR.

![gcc-problem-matcher](https://user-images.githubusercontent.com/3903059/201409293-0d12b51f-0c53-45e5-a16e-6ed84480c448.png)
