### PR TITLE
Revert removal of GDNativeExtensionScriptInstanceInfo::get_property_type_func in GDExtension

### DIFF
--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -309,6 +309,7 @@ typedef GDNativeBool (*GDNativeExtensionScriptInstanceSet)(GDNativeExtensionScri
 typedef GDNativeBool (*GDNativeExtensionScriptInstanceGet)(GDNativeExtensionScriptInstanceDataPtr p_instance, const GDNativeStringNamePtr p_name, GDNativeVariantPtr r_ret);
 typedef const GDNativePropertyInfo *(*GDNativeExtensionScriptInstanceGetPropertyList)(GDNativeExtensionScriptInstanceDataPtr p_instance, uint32_t *r_count);
 typedef void (*GDNativeExtensionScriptInstanceFreePropertyList)(GDNativeExtensionScriptInstanceDataPtr p_instance, const GDNativePropertyInfo *p_list);
+typedef GDNativeVariantType (*GDNativeExtensionScriptInstanceGetPropertyType)(GDNativeExtensionScriptInstanceDataPtr p_instance, const GDNativeStringNamePtr p_name, GDNativeBool *r_is_valid);
 
 typedef GDNativeBool (*GDNativeExtensionScriptInstancePropertyCanRevert)(GDNativeExtensionScriptInstanceDataPtr p_instance, const GDNativeStringNamePtr p_name);
 typedef GDNativeBool (*GDNativeExtensionScriptInstancePropertyGetRevert)(GDNativeExtensionScriptInstanceDataPtr p_instance, const GDNativeStringNamePtr p_name, GDNativeVariantPtr r_ret);
@@ -354,6 +355,7 @@ typedef struct {
 
 	GDNativeExtensionScriptInstanceGetMethodList get_method_list_func;
 	GDNativeExtensionScriptInstanceFreeMethodList free_method_list_func;
+	GDNativeExtensionScriptInstanceGetPropertyType get_property_type_func;
 
 	GDNativeExtensionScriptInstanceHasMethod has_method_func;
 

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -681,21 +681,15 @@ public:
 		}
 	}
 	virtual Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid = nullptr) const override {
-		Variant::Type type = Variant::Type::NIL;
-		if (native_info->get_property_list_func) {
-			uint32_t pcount;
-			const GDNativePropertyInfo *pinfo = native_info->get_property_list_func(instance, &pcount);
-			for (uint32_t i = 0; i < pcount; i++) {
-				if (p_name == *reinterpret_cast<StringName *>(pinfo->name)) {
-					type = Variant::Type(pinfo->type);
-					break;
-				}
+		if (native_info->get_property_type_func) {
+			GDNativeBool is_valid = 0;
+			GDNativeVariantType type = native_info->get_property_type_func(instance, (const GDNativeStringNamePtr)&p_name, &is_valid);
+			if (r_is_valid) {
+				*r_is_valid = is_valid != 0;
 			}
-			if (native_info->free_property_list_func) {
-				native_info->free_property_list_func(instance, pinfo);
-			}
+			return Variant::Type(type);
 		}
-		return type;
+		return Variant::NIL;
 	}
 
 	virtual bool property_can_revert(const StringName &p_name) const override {


### PR DESCRIPTION
Reverting the change on `GDNativeExtensionScriptInstanceInfo` I made in https://github.com/godotengine/godot/pull/67750, I thought it would be simpler to have a similar interface between `GDExtension` and `GDNativeExtensionScriptInstanceInfo`, but after deeper investigation it turns out it is much better to have `GDNativeExtensionScriptInstanceInfo` being just a proxy over Godot's internal `ScriptInstance`.

Besides, by removing this function pointer, we had to do property list create/free each time we want to access type which is quadratic complexity :/ (and implementing a cache on this is complex given property [can be dynamically modified](https://github.com/godotengine/godot/pull/68479#issuecomment-1311639531))
