### PR TITLE
Expose String::split_ints to GDScript

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1512,6 +1512,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(String, split, sarray("delimiter", "allow_empty", "maxsplit"), varray(true, 0));
 	bind_method(String, rsplit, sarray("delimiter", "allow_empty", "maxsplit"), varray(true, 0));
 	bind_method(String, split_floats, sarray("delimiter", "allow_empty"), varray(true));
+	bind_method(String, split_ints, sarray("delimiter", "allow_empty"), varray(true));
 	bind_method(String, join, sarray("parts"), varray());
 
 	bind_method(String, to_upper, sarray(), varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -747,6 +747,16 @@
 				If [param allow_empty] is [code]true[/code], and there are two adjacent delimiters in the string, it will add an empty string to the array of substrings at this position.
 			</description>
 		</method>
+		<method name="split_ints" qualifiers="const">
+			<return type="PackedInt32Array" />
+			<param index="0" name="delimiter" type="String" />
+			<param index="1" name="allow_empty" type="bool" default="true" />
+			<description>
+				Splits the string in ints by using a delimiter string and returns an array of the substrings.
+				For example, [code]"1,2,3"[/code] will return [code][1,2,3][/code] if split by [code]","[/code].
+				If [param allow_empty] is [code]true[/code], and there are two adjacent delimiters in the string, it will add an empty string to the array of substrings at this position.
+			</description>
+		</method>
 		<method name="strip_edges" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="left" type="bool" default="true" />


### PR DESCRIPTION
Makes `String::split_ints` exposed to GDScript, additionally to `String::split_floats`.
Can be useful, considerring the difference in types conversion