### PR TITLE
[3.x] Add alignment options to flow container

### DIFF
--- a/doc/classes/FlowContainer.xml
+++ b/doc/classes/FlowContainer.xml
@@ -17,6 +17,20 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="alignment" type="int" setter="set_alignment" getter="get_alignment" enum="FlowContainer.AlignMode" default="0">
+			The alignment of the container's children (must be one of [constant ALIGN_BEGIN], [constant ALIGN_CENTER] or [constant ALIGN_END]).
+		</member>
+	</members>
 	<constants>
+		<constant name="ALIGN_BEGIN" value="0" enum="AlignMode">
+			Aligns children with the beginning of the container.
+		</constant>
+		<constant name="ALIGN_CENTER" value="1" enum="AlignMode">
+			Aligns children with the center of the container.
+		</constant>
+		<constant name="ALIGN_END" value="2" enum="AlignMode">
+			Aligns children with the end of the container.
+		</constant>
 	</constants>
 </class>

--- a/scene/gui/flow_container.h
+++ b/scene/gui/flow_container.h
@@ -36,11 +36,19 @@
 class FlowContainer : public Container {
 	GDCLASS(FlowContainer, Container);
 
+public:
+	enum AlignMode {
+		ALIGN_BEGIN,
+		ALIGN_CENTER,
+		ALIGN_END
+	};
+
 private:
 	int cached_size;
 	int cached_line_count;
 
 	bool vertical;
+	AlignMode align;
 
 	void _resort();
 
@@ -55,6 +63,9 @@ public:
 	virtual Size2 get_minimum_size() const;
 
 	FlowContainer(bool p_vertical = false);
+
+	void set_alignment(AlignMode p_align);
+	AlignMode get_alignment() const;
 };
 
 class HFlowContainer : public FlowContainer {
@@ -72,5 +83,7 @@ public:
 	VFlowContainer() :
 			FlowContainer(true) {}
 };
+
+VARIANT_ENUM_CAST(FlowContainer::AlignMode);
 
 #endif // FLOW_CONTAINER_H


### PR DESCRIPTION
This is a backport to Godot 3.x of the following PR https://github.com/godotengine/godot/pull/67788.
The implementation looks a bit different in order to align it better (haha get it?) to Godot 3.x's BoxContainer align implementation. I have also checked `project_converter_3_to_4` and, from my understanding, it is already prepared to rename the enums to the Godot 4 version, as it would use the same logic as for the BoxContainer part. So no changes would be needed in that depart.

Please let me know if there is anything else that could be done to improve this feature.