### PR TITLE
Strip ERR_FAIL from `Node.remove_from_group()`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -606,7 +606,7 @@
 			<return type="void" />
 			<param index="0" name="group" type="StringName" />
 			<description>
-				Removes a node from a group. See notes in the description, and the group methods in [SceneTree].
+				Removes a node from the [param group]. Does nothing if the node is not in the [param group]. See notes in the description, and the group methods in [SceneTree].
 			</description>
 		</method>
 		<method name="replace_by">

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1759,11 +1759,11 @@ void Node::add_to_group(const StringName &p_identifier, bool p_persistent) {
 }
 
 void Node::remove_from_group(const StringName &p_identifier) {
-	ERR_FAIL_COND(!data.grouped.has(p_identifier));
-
 	HashMap<StringName, GroupData>::Iterator E = data.grouped.find(p_identifier);
 
-	ERR_FAIL_COND(!E);
+	if (!E) {
+		return;
+	}
 
 	if (data.tree) {
 		data.tree->remove_from_group(E->key, this);


### PR DESCRIPTION
See [RocketChat conversation](https://chat.godotengine.org/channel/core?msg=CGMFMsiPSWzjDGzcB).

`Node.remove_from_group()` generates an error if the node has not been added to the given group in the first place, but `Node.add_to_group()` simply does nothing if the node has already been added to the given group...

This PR just strips away the error of `Node.remove_from_group()` for consistency, and also removes an unnecessary `!data.grouped.has`. The erroring behavior wasn't even documented.