### PR TITLE
[3.x] Fix RichTextLabel: BBCode [color] tags are not counting in font char spacing

### DIFF
--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -1028,6 +1028,10 @@ int DynamicFont::get_spacing(int p_type) const {
 	return 0;
 }
 
+int DynamicFont::get_spacing_char() const {
+	return spacing_char;
+}
+
 void DynamicFont::set_spacing(int p_type, int p_value) {
 	if (p_type == SPACING_TOP) {
 		spacing_top = p_value;

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -352,6 +352,8 @@ public:
 	virtual float get_ascent() const;
 	virtual float get_descent() const;
 
+	virtual int get_spacing_char() const;
+
 	virtual Size2 get_char_size(CharType p_char, CharType p_next = 0) const;
 	String get_available_chars() const;
 

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -52,6 +52,7 @@ public:
 
 	virtual float get_ascent() const = 0;
 	virtual float get_descent() const = 0;
+	virtual int get_spacing_char() const = 0;
 
 	virtual Size2 get_char_size(CharType p_char, CharType p_next = 0) const = 0;
 	Size2 get_string_size(const String &p_string) const;
@@ -179,6 +180,9 @@ public:
 	void set_ascent(float p_ascent);
 	float get_ascent() const;
 	float get_descent() const;
+	int get_spacing_char() const {
+		return 0;
+	}
 
 	void add_texture(const Ref<Texture> &p_texture);
 	void add_char(int32_t p_char, int p_texture_idx, const Rect2 &p_rect, const Size2 &p_align, float p_advance = -1);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/34130.

Each BBCode tag is drawn individually, so we have to add the character spacing manually.
Normally the character spacing is zero, but if not, the text layout is not what you would expect.

BBCode: `AA[color=red]II[/color]`, `char space = 20`
### Before
![image](https://user-images.githubusercontent.com/66004280/201493522-caee627c-da71-4269-8882-e472e775d56d.png)

### After
![image](https://user-images.githubusercontent.com/66004280/201493530-b5969d85-aedf-4bbc-8fbe-37bd4eb49d91.png)
-
Note: I have not found the `char spacing` setting in 4.x. So not sure if this is also a problem in Godot 4.