### PR TITLE
Document that `Vector#` types are 32-bit by default and `Vector#i` are always 32-bit

### DIFF
--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -5,7 +5,8 @@
 	</brief_description>
 	<description>
 		2-element structure that can be used to represent positions in 2D space or any other pair of numeric values.
-		It uses floating-point coordinates. See [Vector2i] for its integer counterpart.
+		It uses floating-point coordinates. By default, these floating-point values use 32-bit precision, unlike [float] which is always 64-bit. If double precision is needed, compile the engine with the option [code]float=64[/code].
+		See [Vector2i] for its integer counterpart.
 		[b]Note:[/b] In a boolean context, a Vector2 will evaluate to [code]false[/code] if it's equal to [code]Vector2(0, 0)[/code]. Otherwise, a Vector2 will always evaluate to [code]true[/code].
 	</description>
 	<tutorials>

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		2-element structure that can be used to represent positions in 2D space or any other pair of numeric values.
-		It uses integer coordinates and is therefore preferable to [Vector2] when exact precision is required.
+		It uses integer coordinates and is therefore preferable to [Vector2] when exact precision is required. Note that the values are limited to 32 bits, and unlike [Vector2] this cannot be configured with an engine build option. Use [int] or [PackedInt64Array] if 64-bit values are needed.
 		[b]Note:[/b] In a boolean context, a Vector2i will evaluate to [code]false[/code] if it's equal to [code]Vector2i(0, 0)[/code]. Otherwise, a Vector2i will always evaluate to [code]true[/code].
 	</description>
 	<tutorials>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -5,7 +5,8 @@
 	</brief_description>
 	<description>
 		3-element structure that can be used to represent positions in 3D space or any other triplet of numeric values.
-		It uses floating-point coordinates. See [Vector3i] for its integer counterpart.
+		It uses floating-point coordinates. By default, these floating-point values use 32-bit precision, unlike [float] which is always 64-bit. If double precision is needed, compile the engine with the option [code]float=64[/code].
+		See [Vector3i] for its integer counterpart.
 		[b]Note:[/b] In a boolean context, a Vector3 will evaluate to [code]false[/code] if it's equal to [code]Vector3(0, 0, 0)[/code]. Otherwise, a Vector3 will always evaluate to [code]true[/code].
 	</description>
 	<tutorials>

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		3-element structure that can be used to represent positions in 3D space or any other triplet of numeric values.
-		It uses integer coordinates and is therefore preferable to [Vector3] when exact precision is required.
+		It uses integer coordinates and is therefore preferable to [Vector3] when exact precision is required. Note that the values are limited to 32 bits, and unlike [Vector3] this cannot be configured with an engine build option. Use [int] or [PackedInt64Array] if 64-bit values are needed.
 		[b]Note:[/b] In a boolean context, a Vector3i will evaluate to [code]false[/code] if it's equal to [code]Vector3i(0, 0, 0)[/code]. Otherwise, a Vector3i will always evaluate to [code]true[/code].
 	</description>
 	<tutorials>

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -5,7 +5,8 @@
 	</brief_description>
 	<description>
 		4-element structure that can be used to represent any quadruplet of numeric values.
-		It uses floating-point coordinates. See [Vector4i] for its integer counterpart.
+		It uses floating-point coordinates. By default, these floating-point values use 32-bit precision, unlike [float] which is always 64-bit. If double precision is needed, compile the engine with the option [code]float=64[/code].
+		See [Vector4i] for its integer counterpart.
 		[b]Note:[/b] In a boolean context, a Vector4 will evaluate to [code]false[/code] if it's equal to [code]Vector4(0, 0, 0, 0)[/code]. Otherwise, a Vector4 will always evaluate to [code]true[/code].
 	</description>
 	<tutorials>

--- a/doc/classes/Vector4i.xml
+++ b/doc/classes/Vector4i.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		4-element structure that can be used to represent 4D grid coordinates or sets of integers.
-		It uses integer coordinates. See [Vector4] for its floating-point counterpart.
+		It uses integer coordinates and is therefore preferable to [Vector4] when exact precision is required. Note that the values are limited to 32 bits, and unlike [Vector4] this cannot be configured with an engine build option. Use [int] or [PackedInt64Array] if 64-bit values are needed.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Add a mention in the class descriptions that `Vector2`, `3`, and `4` are 32-bit by default and can be changed with the `float=64` build option.
Also mention that `Vector2i`, `3i`, and `4i` are also 32-bit and can _not_ be made 64-bit.
Closes #67308.