### PR TITLE
First attempt at fully qualifying the default values of C# properties.

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ExportedFields.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ExportedFields.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 #pragma warning disable CS0169
@@ -83,6 +84,10 @@ namespace Godot.SourceGenerators.Sample
         [Export] private StringName[] field_StringNameArray = { "foo", "bar" };
         [Export] private NodePath[] field_NodePathArray = { "foo", "bar" };
         [Export] private RID[] field_RIDArray = { default, default, default };
+        // Note we use Array and not System.Array. This tests the generated namespace qualification.
+        [Export] private Int32[] field_empty_Int32Array = Array.Empty<Int32>();
+        // Note we use List and not System.Collections.Generic.
+        [Export] private int[] field_array_from_list = new List<int>(Array.Empty<int>()).ToArray();
 
         // Variant
         [Export] private Variant field_Variant = "foo";

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/MoreExportedFields.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/MoreExportedFields.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+#pragma warning disable CS0169
+#pragma warning disable CS0414
+
+namespace Godot.SourceGenerators.Sample
+{
+    [SuppressMessage("ReSharper", "BuiltInTypeReferenceStyle")]
+    [SuppressMessage("ReSharper", "RedundantNameQualifier")]
+    [SuppressMessage("ReSharper", "ArrangeObjectCreationWhenTypeEvident")]
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    // We split the definition of ExportedFields to verify properties work across multiple files.
+    public partial class ExportedFields : Godot.Object
+    {
+        // Note we use Array and not System.Array. This tests the generated namespace qualification.
+        [Export] private Int64[] field_empty_Int64Array = Array.Empty<Int64>();
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
@@ -170,7 +170,13 @@ namespace Godot.SourceGenerators
                     .Select(s => s?.Initializer ?? null)
                     .FirstOrDefault();
 
-                string? value = initializer?.Value.ToString();
+                // Fully qualify the value to avoid issues with namespaces.
+                string? value = null;
+                if (initializer != null)
+                {
+                    var sm = context.Compilation.GetSemanticModel(initializer.SyntaxTree);
+                    value = initializer.Value.FullQualifiedSyntax(sm);
+                }
 
                 exportedMembers.Add(new ExportedPropertyMetadata(
                     property.Name, marshalType.Value, propertyType, value));
@@ -207,7 +213,13 @@ namespace Godot.SourceGenerators
                     .Select(s => s.Initializer)
                     .FirstOrDefault(i => i != null);
 
-                string? value = initializer?.Value.ToString();
+                // This needs to be fully qualified to avoid issues with namespaces.
+                string? value = null;
+                if (initializer != null)
+                {
+                    var sm = context.Compilation.GetSemanticModel(initializer.SyntaxTree);
+                    value = initializer.Value.FullQualifiedSyntax(sm);
+                }
 
                 exportedMembers.Add(new ExportedPropertyMetadata(
                     field.Name, marshalType.Value, fieldType, value));


### PR DESCRIPTION
I believe this fixes #66523.

This is my first time working with C# source generation so it's very possible I've missed something. I'm not particularly happy 
with how the spacing looks after SyntaxToQualifiedString, but it compiles fine.

I think this handles the issue better than #65907, but my PR doesn't handle the "this." part.

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/65938.
- Fixes https://github.com/godotengine/godot/issues/66523.