### PR TITLE
fix typo in ZIPReader doc

### DIFF
--- a/modules/zip/doc_classes/ZIPReader.xml
+++ b/modules/zip/doc_classes/ZIPReader.xml
@@ -9,7 +9,7 @@
 		func read_zip_file():
 		    var reader := ZIPReader.new()
 		    var err := reader.open("user://archive.zip")
-		    if err == OK:
+		    if err != OK:
 		        return PackedByteArray()
 		    var res := reader.read_file("hello.txt")
 		    reader.close()


### PR DESCRIPTION
Fix to the minor typo in ZIPReader from the issue: https://github.com/godotengine/godot-docs/issues/6370

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot-docs/issues/6370