### PR TITLE
Add a special case for importing bitmap fonts designed for Godot 3.

### DIFF
--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -1788,7 +1788,10 @@ Error FontFile::load_bitmap_font(const String &p_path) {
 								ERR_FAIL_V_MSG(ERR_CANT_CREATE, RTR("Unsupported BMFont texture format."));
 							}
 						} else {
-							if ((ch[0] == 0) && (ch[1] == 0) && (ch[2] == 0) && (ch[3] == 0)) { // RGBA8 color, no outline
+							if ((ch[3] == 0) && (ch[0] == 4) && (ch[1] == 4) && (ch[2] == 4) && img->get_format() == Image::FORMAT_RGBA8) { // might be RGBA8 color, no outline (color part of the image should be sold white, but some apps designed for Godot 3 generate color fonts with this config)
+								outline = 0;
+								set_texture_image(0, Vector2i(base_size, 0), page, img);
+							} else if ((ch[0] == 0) && (ch[1] == 0) && (ch[2] == 0) && (ch[3] == 0)) { // RGBA8 color, no outline
 								outline = 0;
 								ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8, ERR_FILE_CANT_READ, RTR("Unsupported BMFont texture format."));
 								set_texture_image(0, Vector2i(base_size, 0), page, img);


### PR DESCRIPTION
Add a special case for importing bitmap fonts designed for Godot 3 with invalid channel data (or fonts with manually edited image). It will not interfere with correctly formatted fonts, since it should have solid white color channels, so the result will be the same as reading only alpha.

Fixes https://github.com/godotengine/godot/issues/68458