### PR TITLE
Fix gl_manager nullptr crash

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -1319,7 +1319,10 @@ int64_t DisplayServerX11::window_get_native_handle(HandleType p_handle_type, Win
 		}
 #ifdef GLES3_ENABLED
 		case OPENGL_CONTEXT: {
-			return (int64_t)gl_manager->get_glx_context(p_window);
+			if (gl_manager) {
+				return (int64_t)gl_manager->get_glx_context(p_window);
+			}
+			return 0;
 		}
 #endif
 		default: {


### PR DESCRIPTION
Add a nullptr-check, before accessing `gl_manager`
resolve #68525