### PR TITLE
Add an exception for thirdparty subdirectories in file_format.sh

### DIFF
--- a/misc/scripts/file_format.sh
+++ b/misc/scripts/file_format.sh
@@ -31,7 +31,9 @@ while IFS= read -rd '' f; do
         continue
     elif [[ "$f" == *"po" ]]; then
         continue
-    elif [[ "$f" == "thirdparty"* ]]; then
+    elif [[ "$f" == "thirdparty/"* ]]; then
+        continue
+    elif [[ "$f" == *"/thirdparty/"* ]]; then
         continue
     elif [[ "$f" == "platform/android/java/lib/src/com/google"* ]]; then
         continue


### PR DESCRIPTION
This exception is also present in clang_format.sh and is needed in some cases.

I stumbled upon this while working on #68586, as a platform-specific third party header had more sense to stay there and clang_format.sh already ignored it.