### PR TITLE
Remove auto selecting the first file for FileDialog with Save mode

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -632,8 +632,11 @@ void FileDialog::update_file_list() {
 		files.pop_front();
 	}
 
-	if (tree->get_root() && tree->get_root()->get_first_child() && tree->get_selected() == nullptr) {
-		tree->get_root()->get_first_child()->select(0);
+	if (mode != FILE_MODE_SAVE_FILE) {
+		// Select the first file from list if nothing is selected.
+		if (tree->get_root() && tree->get_root()->get_first_child() && tree->get_selected() == nullptr) {
+			tree->get_root()->get_first_child()->select(0);
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Resolves #62890. As suggested in the issue with changes from this PR the FileDialog with Save mode selected will no longer pick the first file as default one.

