### PR TITLE
Optimize animation blend tree process

### DIFF
--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -309,8 +309,8 @@ double AnimationNodeBlendSpace1D::process(double p_time, bool p_seek, bool p_see
 		if (i == point_lower || i == point_higher) {
 			double remaining = blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_seek_root, weights[i], FILTER_IGNORE, true);
 			max_time_remaining = MAX(max_time_remaining, remaining);
-		} else {
-			blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_seek_root, 0, FILTER_IGNORE, sync);
+		} else if (sync) {
+			blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_seek_root, 0, FILTER_IGNORE, true);
 		}
 	}
 

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -512,8 +512,8 @@ double AnimationNodeBlendSpace2D::process(double p_time, bool p_seek, bool p_see
 				}
 			}
 
-			if (!found) {
-				blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_seek_root, 0, FILTER_IGNORE, sync);
+			if (sync && !found) {
+				blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_seek_root, 0, FILTER_IGNORE, true);
 			}
 		}
 	} else {
@@ -550,9 +550,11 @@ double AnimationNodeBlendSpace2D::process(double p_time, bool p_seek, bool p_see
 			mind = blend_node(blend_points[cur_closest].name, blend_points[cur_closest].node, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE, true);
 		}
 
-		for (int i = 0; i < blend_points_used; i++) {
-			if (i != cur_closest) {
-				blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_seek_root, 0, FILTER_IGNORE, sync);
+		if (sync) {
+			for (int i = 0; i < blend_points_used; i++) {
+				if (i != cur_closest) {
+					blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_seek_root, 0, FILTER_IGNORE, true);
+				}
 			}
 		}
 	}

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -726,9 +726,11 @@ double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_seek_
 
 	double rem = 0.0;
 
-	for (int i = 0; i < enabled_inputs; i++) {
-		if (i != cur_current && i != cur_prev) {
-			blend_input(i, p_time, p_seek, p_seek_root, 0, FILTER_IGNORE, sync);
+	if (sync) {
+		for (int i = 0; i < enabled_inputs; i++) {
+			if (i != cur_current && i != cur_prev) {
+				blend_input(i, p_time, p_seek, p_seek_root, 0, FILTER_IGNORE, true);
+			}
 		}
 	}
 

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -190,7 +190,6 @@ private:
 	struct TrackCache {
 		bool root_motion = false;
 		uint64_t setup_pass = 0;
-		uint64_t process_pass = 0;
 		Animation::TrackType type = Animation::TrackType::TYPE_ANIMATION;
 		Object *object = nullptr;
 		ObjectID object_id;


### PR DESCRIPTION
Optimize animation blend tree process.

Fixes #65199 (Partially)

In #57675 and #62623, for blending result consistency, it was necessary to blend animations even if the blend amount is 0 or don't have sync option.

The fundamental reason of this is that the blend values are initialized only on the track that will be blended in the only one frame that is just played.

Consistent blending by correct initialization:

https://user-images.githubusercontent.com/61938263/201505301-54ed7bd6-b2c6-4922-ace5-32c5464a43b8.mp4

Inconsistent blending due to lack of initialization on certain tracks:

https://user-images.githubusercontent.com/61938263/201505307-6861b234-792b-42f4-9288-86fdede7dfaf.mp4

This PR separates the initialization process and iterates through the TrackCache instead of the track that will be blended at that frame. This greatly reduces calculation cost while keeping the blending consistency. Well, this is just a re-implementation of the optimization that #57675 removed.

I confirmed that this would increase the FPS of the https://github.com/godotengine/godot/issues/65199#issuecomment-1247090562 project at running by about 1.5 times.

Before:
![image](https://user-images.githubusercontent.com/61938263/201505396-aa43b886-b7fc-4478-b36d-3d3ee9ce9135.png)

After:
![image](https://user-images.githubusercontent.com/61938263/201505400-466208e5-9623-4c12-ae0d-d9739df04bca.png)

Also, these are the projects to check whether this PR will not change the behavior:
[animation_blend_test.zip](https://github.com/godotengine/godot/files/10009529/animation_blend_test.zip)
[character_controller_3d_sample.zip](https://github.com/godotengine/godot/files/9996495/character_controller_3d_sample.zip)

As far as I have checked, this PR should not change the behavior of the blending, but I welcome anyone who is interested to test it. This is mention to people I remember talking about optimization before: @JoanPotatoes2021 @and-rad 

This process optimization was the biggest issue, so I think we can now close #65199 for now. If this does not solve the problem of frame rate dropping with panning viewport, then perhaps it is a problem other than blending.