### PR TITLE
Fix -Wtype-limits warning in openxr_interface.cpp

### DIFF
--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -666,7 +666,7 @@ Transform3D OpenXRInterface::get_camera_transform() {
 Transform3D OpenXRInterface::get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) {
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL_V(xr_server, Transform3D());
-	ERR_FAIL_INDEX_V_MSG(p_view, get_view_count(), Transform3D(), "View index outside bounds.");
+	ERR_FAIL_UNSIGNED_INDEX_V_MSG(p_view, get_view_count(), Transform3D(), "View index outside bounds.");
 
 	Transform3D t;
 	if (openxr_api && openxr_api->get_view_transform(p_view, t)) {
@@ -686,7 +686,7 @@ Transform3D OpenXRInterface::get_transform_for_view(uint32_t p_view, const Trans
 
 Projection OpenXRInterface::get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) {
 	Projection cm;
-	ERR_FAIL_INDEX_V_MSG(p_view, get_view_count(), cm, "View index outside bounds.");
+	ERR_FAIL_UNSIGNED_INDEX_V_MSG(p_view, get_view_count(), cm, "View index outside bounds.");
 
 	if (openxr_api) {
 		if (openxr_api->get_view_projection(p_view, p_z_near, p_z_far, cm)) {


### PR DESCRIPTION
Fixes this compilation failure due to `-Wtype-limits` in GCC 11+ when building with `warnings=extra werror=yes`:
```
In file included from ./core/error/error_macros.h:34,
                 from ./core/math/vector3.h:34,
                 from ./core/math/projection.h:34,
                 from ./servers/xr/xr_interface.h:34,
                 from modules/openxr/openxr_interface.h:34,
                 from modules/openxr/openxr_interface.cpp:31:
modules/openxr/openxr_interface.cpp: In member function 'virtual Transform3D OpenXRInterface::get_transform_for_view(uint32_t, const Transform3D&)':
./core/error/error_macros.h:168:32: error: comparison of unsigned expression in '< 0' is always false [-Werror=type-limits]
  168 |         if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
      |                      ~~~~~~~~~~^~~
./core/typedefs.h:271:41: note: in definition of macro 'unlikely'
  271 | #define unlikely(x) __builtin_expect(!!(x), 0)
      |                                         ^
modules/openxr/openxr_interface.cpp:669:9: note: in expansion of macro 'ERR_FAIL_INDEX_V_MSG'
  669 |         ERR_FAIL_INDEX_V_MSG(p_view, get_view_count(), Transform3D(), "View index outside bounds.");
      |         ^~~~~~~~~~~~~~~~~~~~
modules/openxr/openxr_interface.cpp: In member function 'virtual Projection OpenXRInterface::get_projection_for_view(uint32_t, double, double, double)':
./core/error/error_macros.h:168:32: error: comparison of unsigned expression in '< 0' is always false [-Werror=type-limits]
  168 |         if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
      |                      ~~~~~~~~~~^~~
./core/typedefs.h:271:41: note: in definition of macro 'unlikely'
  271 | #define unlikely(x) __builtin_expect(!!(x), 0)
      |                                         ^
modules/openxr/openxr_interface.cpp:689:9: note: in expansion of macro 'ERR_FAIL_INDEX_V_MSG'
  689 |         ERR_FAIL_INDEX_V_MSG(p_view, get_view_count(), cm, "View index outside bounds.");
      |         ^~~~~~~~~~~~~~~~~~~~
```