### PR TITLE
Rename SceneTree group methods to begin with "group"

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -13,29 +13,6 @@
 		<link title="Multiple resolutions">$DOCS_URL/tutorials/rendering/multiple_resolutions.html</link>
 	</tutorials>
 	<methods>
-		<method name="call_group" qualifiers="vararg">
-			<return type="void" />
-			<param index="0" name="group" type="StringName" />
-			<param index="1" name="method" type="StringName" />
-			<description>
-				Calls [param method] on each member of the given group. You can pass arguments to [param method] by specifying them at the end of the method call. If a node doesn't have the given method or the argument list does not match (either in count or in types), it will be skipped.
-				[b]Note:[/b] [method call_group] will call methods immediately on all members at once, which can cause stuttering if an expensive method is called on lots of members. To wait for one frame after [method call_group] was called, use [method call_group_flags] with the [constant GROUP_CALL_DEFERRED] flag.
-			</description>
-		</method>
-		<method name="call_group_flags" qualifiers="vararg">
-			<return type="void" />
-			<param index="0" name="flags" type="int" />
-			<param index="1" name="group" type="StringName" />
-			<param index="2" name="method" type="StringName" />
-			<description>
-				Calls [param method] on each member of the given group, respecting the given [enum GroupCallFlags]. You can pass arguments to [param method] by specifying them at the end of the method call. If a node doesn't have the given method or the argument list does not match (either in count or in types), it will be skipped.
-				[codeblock]
-				# Call the method in a deferred manner and in reverse order.
-				get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFERRED | SceneTree.GROUP_CALL_REVERSE)
-				[/codeblock]
-				[b]Note:[/b] Group call flags are used to control the method calling behavior. By default, methods will be called immediately in a way similar to [method call_group]. However, if the [constant GROUP_CALL_DEFERRED] flag is present in the [param flags] argument, methods will be called with a one-frame delay in a way similar to [method Object.set_deferred].
-			</description>
-		</method>
 		<method name="change_scene_to_file">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
@@ -130,30 +107,74 @@
 				Returns an array of currently existing [Tween]s in the [SceneTree] (both running and paused).
 			</description>
 		</method>
-		<method name="has_group" qualifiers="const">
-			<return type="bool" />
-			<param index="0" name="name" type="StringName" />
+		<method name="group_call" qualifiers="vararg">
+			<return type="void" />
+			<param index="0" name="group" type="StringName" />
+			<param index="1" name="method" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the given group exists.
+				Calls [param method] on each member of the given group. You can pass arguments to [param method] by specifying them at the end of the method call. If a node doesn't have the given method or the argument list does not match (either in count or in types), it will be skipped.
+				[b]Note:[/b] [method group_call] will call methods immediately on all members at once, which can cause stuttering if an expensive method is called on lots of members. To wait for one frame after [method group_call] was called, use [method group_call_flags] with the [constant GROUP_CALL_DEFERRED] flag.
 			</description>
 		</method>
-		<method name="notify_group">
+		<method name="group_call_flags" qualifiers="vararg">
+			<return type="void" />
+			<param index="0" name="flags" type="int" />
+			<param index="1" name="group" type="StringName" />
+			<param index="2" name="method" type="StringName" />
+			<description>
+				Calls [param method] on each member of the given group, respecting the given [enum GroupCallFlags]. You can pass arguments to [param method] by specifying them at the end of the method call. If a node doesn't have the given method or the argument list does not match (either in count or in types), it will be skipped.
+				[codeblock]
+				# Call the method in a deferred manner and in reverse order.
+				get_tree().group_call_flags(SceneTree.GROUP_CALL_DEFERRED | SceneTree.GROUP_CALL_REVERSE)
+				[/codeblock]
+				[b]Note:[/b] Group call flags are used to control the method calling behavior. By default, methods will be called immediately in a way similar to [method group_call]. However, if the [constant GROUP_CALL_DEFERRED] flag is present in the [param flags] argument, methods will be called with a one-frame delay in a way similar to [method Object.set_deferred].
+			</description>
+		</method>
+		<method name="group_notify">
 			<return type="void" />
 			<param index="0" name="group" type="StringName" />
 			<param index="1" name="notification" type="int" />
 			<description>
 				Sends the given notification to all members of the [param group].
-				[b]Note:[/b] [method notify_group] will immediately notify all members at once, which can cause stuttering if an expensive method is called as a result of sending the notification lots of members. To wait for one frame, use [method notify_group_flags] with the [constant GROUP_CALL_DEFERRED] flag.
+				[b]Note:[/b] [method group_notify] will immediately notify all members at once, which can cause stuttering if an expensive method is called as a result of sending the notification lots of members. To wait for one frame, use [method group_notify_flags] with the [constant GROUP_CALL_DEFERRED] flag.
 			</description>
 		</method>
-		<method name="notify_group_flags">
+		<method name="group_notify_flags">
 			<return type="void" />
-			<param index="0" name="call_flags" type="int" />
+			<param index="0" name="flags" type="int" />
 			<param index="1" name="group" type="StringName" />
 			<param index="2" name="notification" type="int" />
 			<description>
 				Sends the given notification to all members of the [param group], respecting the given [enum GroupCallFlags].
-				[b]Note:[/b] Group call flags are used to control the notification sending behavior. By default, notifications will be sent immediately in a way similar to [method notify_group]. However, if the [constant GROUP_CALL_DEFERRED] flag is present in the [param call_flags] argument, notifications will be sent with a one-frame delay in a way similar to using [code]Object.call_deferred("notification", ...)[/code].
+				[b]Note:[/b] Group call flags are used to control the notification sending behavior. By default, notifications will be sent immediately in a way similar to [method group_notify]. However, if the [constant GROUP_CALL_DEFERRED] flag is present in the [param flags] argument, notifications will be sent with a one-frame delay in a way similar to using [code]Object.call_deferred("notification", ...)[/code].
+			</description>
+		</method>
+		<method name="group_set">
+			<return type="void" />
+			<param index="0" name="group" type="StringName" />
+			<param index="1" name="property" type="String" />
+			<param index="2" name="value" type="Variant" />
+			<description>
+				Sets the given [param property] to [param value] on all members of the given group.
+				[b]Note:[/b] [method group_set] will set the property immediately on all members at once, which can cause stuttering if a property with an expensive setter is set on lots of members. To wait for one frame, use [method group_set_flags] with the [constant GROUP_CALL_DEFERRED] flag.
+			</description>
+		</method>
+		<method name="group_set_flags">
+			<return type="void" />
+			<param index="0" name="flags" type="int" />
+			<param index="1" name="group" type="StringName" />
+			<param index="2" name="property" type="String" />
+			<param index="3" name="value" type="Variant" />
+			<description>
+				Sets the given [param property] to [param value] on all members of the given group, respecting the given [enum GroupCallFlags].
+				[b]Note:[/b] Group call flags are used to control the property setting behavior. By default, properties will be set immediately in a way similar to [method group_set]. However, if the [constant GROUP_CALL_DEFERRED] flag is present in the [param flags] argument, properties will be set with a one-frame delay in a way similar to [method Object.call_deferred].
+			</description>
+		</method>
+		<method name="has_group" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Returns [code]true[/code] if the given group exists.
 			</description>
 		</method>
 		<method name="queue_delete">
@@ -178,27 +199,6 @@
 			<description>
 				Reloads the currently active scene.
 				Returns [constant OK] on success, [constant ERR_UNCONFIGURED] if no [member current_scene] was defined yet, [constant ERR_CANT_OPEN] if [member current_scene] cannot be loaded into a [PackedScene], or [constant ERR_CANT_CREATE] if the scene cannot be instantiated.
-			</description>
-		</method>
-		<method name="set_group">
-			<return type="void" />
-			<param index="0" name="group" type="StringName" />
-			<param index="1" name="property" type="String" />
-			<param index="2" name="value" type="Variant" />
-			<description>
-				Sets the given [param property] to [param value] on all members of the given group.
-				[b]Note:[/b] [method set_group] will set the property immediately on all members at once, which can cause stuttering if a property with an expensive setter is set on lots of members. To wait for one frame, use [method set_group_flags] with the [constant GROUP_CALL_DEFERRED] flag.
-			</description>
-		</method>
-		<method name="set_group_flags">
-			<return type="void" />
-			<param index="0" name="call_flags" type="int" />
-			<param index="1" name="group" type="StringName" />
-			<param index="2" name="property" type="String" />
-			<param index="3" name="value" type="Variant" />
-			<description>
-				Sets the given [param property] to [param value] on all members of the given group, respecting the given [enum GroupCallFlags].
-				[b]Note:[/b] Group call flags are used to control the property setting behavior. By default, properties will be set immediately in a way similar to [method set_group]. However, if the [constant GROUP_CALL_DEFERRED] flag is present in the [param call_flags] argument, properties will be set with a one-frame delay in a way similar to [method Object.call_deferred].
 			</description>
 		</method>
 		<method name="set_multiplayer">

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -238,6 +238,8 @@ static const char *gdscript_function_renames[][2] = {
 	{ "body_add_force", "body_apply_force" }, // PhysicsServer2D
 	{ "body_add_torque", "body_apply_torque" }, // PhysicsServer2D
 	{ "bumpmap_to_normalmap", "bump_map_to_normal_map" }, // Image
+	{ "call_group", "group_call" }, // SceneTree
+	{ "call_group_flags", "group_call_flags" }, // SceneTree
 	{ "can_be_hidden", "_can_be_hidden" }, // EditorNode3DGizmoPlugin
 	{ "can_drop_data_fw", "_can_drop_data_fw" }, // ScriptEditor
 	{ "can_generate_small_preview", "_can_generate_small_preview" }, // EditorResourcePreviewGenerator
@@ -454,6 +456,8 @@ static const char *gdscript_function_renames[][2] = {
 	{ "move_to_bottom", "move_after" }, // Skeleton3D
 	{ "move_to_top", "move_before" }, // Skeleton3D
 	{ "multimesh_allocate", "multimesh_allocate_data" }, // RenderingServer
+	{ "notify_group", "group_notify" }, // SceneTree
+	{ "notify_group_flags", "group_notify_flags" }, // SceneTree
 	{ "normalmap_to_xy", "normal_map_to_xy" }, // Image
 	{ "offset_polygon_2d", "offset_polygon" }, // Geometry2D
 	{ "offset_polyline_2d", "offset_polyline" }, // Geometry2D
@@ -513,6 +517,8 @@ static const char *gdscript_function_renames[][2] = {
 	{ "set_global_rate_scale", "set_playback_speed_scale" }, // AudioServer
 	{ "set_gravity_distance_scale", "set_gravity_point_distance_scale" }, // Area2D
 	{ "set_gravity_vector", "set_gravity_direction" }, // Area2D
+	{ "set_group", "group_set" }, // SceneTree
+	{ "set_group_flags", "group_set_flags" }, // SceneTree
 	{ "set_h_drag_enabled", "set_drag_horizontal_enabled" }, // Camera2D
 	{ "set_icon_align", "set_icon_alignment" }, // Button
 	{ "set_interior_ambient", "set_ambient_color" }, // ReflectionProbe
@@ -690,6 +696,8 @@ static const char *csharp_function_renames[][2] = {
 	{ "AgentSetNeighborDist", "AgentSetNeighborDistance" }, // NavigationServer2D, NavigationServer3D
 	{ "BindChildNodeToBone", "SetBoneChildren" }, // Skeleton3D
 	{ "BumpmapToNormalmap", "BumpMapToNormalMap" }, // Image
+	{ "CallGroup", "GroupCallNotify" }, // SceneTree
+	{ "CallGroupFlags", "GroupCallFlags" }, // SceneTree
 	{ "CanBeHidden", "_CanBeHidden" }, // EditorNode3DGizmoPlugin
 	{ "CanDropDataFw", "_CanDropDataFw" }, // ScriptEditor
 	{ "CanGenerateSmallPreview", "_CanGenerateSmallPreview" }, // EditorResourcePreviewGenerator
@@ -894,6 +902,8 @@ static const char *csharp_function_renames[][2] = {
 	{ "MoveToBottom", "MoveAfter" }, // Skeleton3D
 	{ "MoveToTop", "MoveBefore" }, // Skeleton3D
 	{ "MultimeshAllocate", "MultimeshAllocateData" }, // RenderingServer
+	{ "NotifyGroup", "GroupNotify" }, // SceneTree
+	{ "NotifyGroupFlags", "GroupNotifyFlags" }, // SceneTree
 	{ "NormalmapToXy", "NormalMapToXy" }, // Image
 	{ "OffsetPolygon2d", "OffsetPolygon" }, // Geometry2D
 	{ "OffsetPolyline2d", "OffsetPolyline" }, // Geometry2D
@@ -950,6 +960,8 @@ static const char *csharp_function_renames[][2] = {
 	{ "SetGlobalRateScale", "SetPlaybackSpeedScale" }, // AudioServer
 	{ "SetGravityDistanceScale", "SetGravityPointDistanceScale" }, // Area2D
 	{ "SetGravityVector", "SetGravityDirection" }, // Area2D
+	{ "SetGroup", "GroupSet" }, // SceneTree
+	{ "SetGroupFlags", "GroupSetFlags" }, // SceneTree
 	{ "SetHDragEnabled", "SetDragHorizontalEnabled" }, // Camera2D
 	{ "SetIconAlign", "SetIconAlignment" }, // Button
 	{ "SetInteriorAmbient", "SetAmbientColor" }, // ReflectionProbe

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1258,25 +1258,25 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("queue_delete", "obj"), &SceneTree::queue_delete);
 
 	MethodInfo mi;
-	mi.name = "call_group_flags";
+	mi.name = "group_call_flags";
 	mi.arguments.push_back(PropertyInfo(Variant::INT, "flags"));
 	mi.arguments.push_back(PropertyInfo(Variant::STRING_NAME, "group"));
 	mi.arguments.push_back(PropertyInfo(Variant::STRING_NAME, "method"));
 
-	ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "call_group_flags", &SceneTree::_call_group_flags, mi);
+	ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "group_call_flags", &SceneTree::_call_group_flags, mi);
 
-	ClassDB::bind_method(D_METHOD("notify_group_flags", "call_flags", "group", "notification"), &SceneTree::notify_group_flags);
-	ClassDB::bind_method(D_METHOD("set_group_flags", "call_flags", "group", "property", "value"), &SceneTree::set_group_flags);
+	ClassDB::bind_method(D_METHOD("group_notify_flags", "flags", "group", "notification"), &SceneTree::notify_group_flags);
+	ClassDB::bind_method(D_METHOD("group_set_flags", "flags", "group", "property", "value"), &SceneTree::set_group_flags);
 
 	MethodInfo mi2;
-	mi2.name = "call_group";
+	mi2.name = "group_call";
 	mi2.arguments.push_back(PropertyInfo(Variant::STRING_NAME, "group"));
 	mi2.arguments.push_back(PropertyInfo(Variant::STRING_NAME, "method"));
 
-	ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "call_group", &SceneTree::_call_group, mi2);
+	ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "group_call", &SceneTree::_call_group, mi2);
 
-	ClassDB::bind_method(D_METHOD("notify_group", "group", "notification"), &SceneTree::notify_group);
-	ClassDB::bind_method(D_METHOD("set_group", "group", "property", "value"), &SceneTree::set_group);
+	ClassDB::bind_method(D_METHOD("group_notify", "group", "notification"), &SceneTree::notify_group);
+	ClassDB::bind_method(D_METHOD("group_set", "group", "property", "value"), &SceneTree::set_group);
 
 	ClassDB::bind_method(D_METHOD("get_nodes_in_group", "group"), &SceneTree::_get_nodes_in_group);
 	ClassDB::bind_method(D_METHOD("get_first_node_in_group", "group"), &SceneTree::get_first_node_in_group);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5772.

One problem I've noticed while making https://github.com/godotengine/godot/pull/68560 is that explaining the group methods was irritating and confusing. Groups are heavily used by the **SceneTree**, but the SceneTree's methods are... somewhat chaotic to find, despite them all being part of the same "group" feature _(`set_group?` Are we setting a group or setting for every group or...? Can groups be notified? What exactly is being notified?)_.

This PR attempts to address that.

`call_group` -> `group_call`
`call_group_flags` -> `group_call_flags`
`notify_group` -> `group_notify`
`notify_group_flags` -> `group_notify_flags`
`set_group` ->`group_set`
`set_group_flags` ->`group_set_flags`

These new names also happen to look tidier, even when the methods are not sorted alphabetically.

![image](https://user-images.githubusercontent.com/66727710/201520278-f3afaea5-671e-4d7c-8cba-b1c4dd6bb291.png)
![image](https://user-images.githubusercontent.com/66727710/201520595-b09ea1bf-8d32-4dc2-a1fa-021f3d139902.png)

This PR doesn't rename the methods internally, only the exposed methods. It would be ideal to first see the reception of this PR before further working on it. As of the time of writing this, we're in Beta 4 and renames are **really** out of the question, but this feels necessary.