### PR TITLE
Rename `Object.notification` to `notify`

### DIFF
--- a/core/core_string_names.cpp
+++ b/core/core_string_names.cpp
@@ -75,6 +75,6 @@ CoreStringNames::CoreStringNames() :
 		bind(StaticCString::create("bind")),
 		unbind(StaticCString::create("unbind")),
 		emit(StaticCString::create("emit")),
-		notification(StaticCString::create("notification")),
+		notify(StaticCString::create("notify")),
 		property_list_changed(StaticCString::create("property_list_changed")) {
 }

--- a/core/core_string_names.h
+++ b/core/core_string_names.h
@@ -94,7 +94,7 @@ public:
 	StringName bind;
 	StringName unbind;
 	StringName emit;
-	StringName notification;
+	StringName notify;
 	StringName property_list_changed;
 };
 

--- a/core/extension/native_extension.cpp
+++ b/core/extension/native_extension.cpp
@@ -178,7 +178,7 @@ void NativeExtension::_register_extension_class(const GDNativeExtensionClassLibr
 	extension->native_extension.free_property_list = p_extension_funcs->free_property_list_func;
 	extension->native_extension.property_can_revert = p_extension_funcs->property_can_revert_func;
 	extension->native_extension.property_get_revert = p_extension_funcs->property_get_revert_func;
-	extension->native_extension.notification = p_extension_funcs->notification_func;
+	extension->native_extension.notify = p_extension_funcs->notification_func;
 	extension->native_extension.to_string = p_extension_funcs->to_string_func;
 	extension->native_extension.reference = p_extension_funcs->reference_func;
 	extension->native_extension.unreference = p_extension_funcs->unreference_func;

--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -90,7 +90,7 @@ Error MessageQueue::push_notification(ObjectID p_id, int p_notification) {
 	Message *msg = memnew_placement(&buffer[buffer_end], Message);
 
 	msg->type = TYPE_NOTIFICATION;
-	msg->callable = Callable(p_id, CoreStringNames::get_singleton()->notification); //name is meaningless but callable needs it
+	msg->callable = Callable(p_id, CoreStringNames::get_singleton()->notify); //name is meaningless but callable needs it
 	//msg->target;
 	msg->notification = p_notification;
 
@@ -277,7 +277,7 @@ void MessageQueue::flush() {
 				} break;
 				case TYPE_NOTIFICATION: {
 					// messages don't expect a return value
-					target->notification(message->notification);
+					target->notify(message->notification);
 
 				} break;
 				case TYPE_SET: {

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -193,7 +193,7 @@ Object::Connection::Connection(const Variant &p_variant) {
 
 bool Object::_predelete() {
 	_predelete_ok = 1;
-	notification(NOTIFICATION_PREDELETE, true);
+	notify(NOTIFICATION_PREDELETE, true);
 	if (_predelete_ok) {
 		_class_ptr = nullptr; //must restore so destructors can access class ptr correctly
 	}
@@ -203,7 +203,7 @@ bool Object::_predelete() {
 void Object::_postinitialize() {
 	_class_ptr = _get_class_namev();
 	_initialize_classv();
-	notification(NOTIFICATION_POSTINITIALIZE);
+	notify(NOTIFICATION_POSTINITIALIZE);
 }
 
 void Object::get_valid_parents_static(List<String> *p_parents) {
@@ -786,15 +786,15 @@ Variant Object::call_const(const StringName &p_method, const Variant **p_args, i
 	return ret;
 }
 
-void Object::notification(int p_notification, bool p_reversed) {
+void Object::notify(int p_notification, bool p_reversed) {
 	_notificationv(p_notification, p_reversed);
 
 	if (script_instance) {
-		script_instance->notification(p_notification);
+		script_instance->notify(p_notification);
 	}
 
-	if (_extension && _extension->notification) {
-		_extension->notification(_extension_instance, p_notification);
+	if (_extension && _extension->notify) {
+		_extension->notify(_extension_instance, p_notification);
 	}
 }
 
@@ -1473,7 +1473,7 @@ void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_indexed", "property_path"), &Object::_get_indexed_bind);
 	ClassDB::bind_method(D_METHOD("get_property_list"), &Object::_get_property_list_bind);
 	ClassDB::bind_method(D_METHOD("get_method_list"), &Object::_get_method_list_bind);
-	ClassDB::bind_method(D_METHOD("notification", "what", "reversed"), &Object::notification, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("notify", "what", "reversed"), &Object::notify, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("to_string"), &Object::to_string);
 	ClassDB::bind_method(D_METHOD("get_instance_id"), &Object::get_instance_id);
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -315,7 +315,7 @@ struct ObjectNativeExtension {
 	GDNativeExtensionClassFreePropertyList free_property_list;
 	GDNativeExtensionClassPropertyCanRevert property_can_revert;
 	GDNativeExtensionClassPropertyGetRevert property_get_revert;
-	GDNativeExtensionClassNotification notification;
+	GDNativeExtensionClassNotification notify;
 	GDNativeExtensionClassToString to_string;
 	GDNativeExtensionClassReference reference;
 	GDNativeExtensionClassReference unreference;
@@ -822,7 +822,7 @@ public:
 		return callp(p_method, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args), cerr);
 	}
 
-	void notification(int p_notification, bool p_reversed = false);
+	void notify(int p_notification, bool p_reversed = false);
 	virtual String to_string();
 
 	// Used mainly by script, get and set all INCLUDING string.

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -196,7 +196,7 @@ public:
 	}
 
 	virtual Variant call_const(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error); // implement if language supports const functions
-	virtual void notification(int p_notification) = 0;
+	virtual void notify(int p_notification) = 0;
 	virtual String to_string(bool *r_valid) {
 		if (r_valid) {
 			*r_valid = false;
@@ -462,7 +462,7 @@ public:
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
 		return Variant();
 	}
-	virtual void notification(int p_notification) override {}
+	virtual void notify(int p_notification) override {}
 
 	virtual Ref<Script> get_script() const override { return script; }
 

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -752,7 +752,7 @@ public:
 		return ret;
 	}
 
-	virtual void notification(int p_notification) override {
+	virtual void notify(int p_notification) override {
 		if (native_info->notification_func) {
 			native_info->notification_func(instance, p_notification);
 		}

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -83,7 +83,7 @@ void Translation::set_locale(const String &p_locale) {
 	locale = TranslationServer::get_singleton()->standardize_locale(p_locale);
 
 	if (OS::get_singleton()->get_main_loop() && TranslationServer::get_singleton()->get_loaded_locales().has(get_locale())) {
-		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_TRANSLATION_CHANGED);
+		OS::get_singleton()->get_main_loop()->notify(MainLoop::NOTIFICATION_TRANSLATION_CHANGED);
 	}
 }
 
@@ -512,7 +512,7 @@ void TranslationServer::set_locale(const String &p_locale) {
 	locale = standardize_locale(p_locale);
 
 	if (OS::get_singleton()->get_main_loop()) {
-		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_TRANSLATION_CHANGED);
+		OS::get_singleton()->get_main_loop()->notify(MainLoop::NOTIFICATION_TRANSLATION_CHANGED);
 	}
 
 	ResourceLoader::reload_translation_remaps();
@@ -776,7 +776,7 @@ void TranslationServer::set_pseudolocalization_enabled(bool p_enabled) {
 	pseudolocalization_enabled = p_enabled;
 
 	if (OS::get_singleton()->get_main_loop()) {
-		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_TRANSLATION_CHANGED);
+		OS::get_singleton()->get_main_loop()->notify(MainLoop::NOTIFICATION_TRANSLATION_CHANGED);
 	}
 	ResourceLoader::reload_translation_remaps();
 }
@@ -796,7 +796,7 @@ void TranslationServer::reload_pseudolocalization() {
 	pseudolocalization_skip_placeholders_enabled = GLOBAL_GET("internationalization/pseudolocalization/skip_placeholders");
 
 	if (OS::get_singleton()->get_main_loop()) {
-		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_TRANSLATION_CHANGED);
+		OS::get_singleton()->get_main_loop()->notify(MainLoop::NOTIFICATION_TRANSLATION_CHANGED);
 	}
 	ResourceLoader::reload_translation_remaps();
 }

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -585,7 +585,7 @@
 			<return type="void" />
 			<param index="0" name="what" type="int" />
 			<description>
-				Notifies the current node and all its children recursively by calling [method Object.notification] on all of them.
+				Notifies the current node and all its children recursively by calling [method Object.notify] on all of them.
 			</description>
 		</method>
 		<method name="queue_free">

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -18,7 +18,7 @@
 		print("tree_entered" in node) # Prints true
 		print("unknown" in node)      # Prints false
 		[/codeblock]
-		Notifications are [int] constants commonly sent and received by objects. For example, on every rendered frame, the [SceneTree] notifies nodes inside the tree with a [constant Node.NOTIFICATION_PROCESS]. The nodes receive it and may call [method Node._process] to update. To make use of notifications, see [method notification] and [method _notification].
+		Notifications are [int] constants commonly sent and received by objects. For example, on every rendered frame, the [SceneTree] notifies nodes inside the tree with a [constant Node.NOTIFICATION_PROCESS]. The nodes receive it and may call [method Node._process] to update. To make use of notifications, see [method notify] and [method _notification].
 		Lastly, every object can also contain metadata (data about data). [method set_meta] can be useful to store information that the object itself does not depend on. To keep your code clean, making excessive use of metadata is discouraged.
 		[b]Note:[/b] Unlike references to a [RefCounted], references to an object stored in a variable can become invalid without being set to [code]null[/code]. To check if an object has been deleted, do [i]not[/i] compare it against [code]null[/code]. Instead, use [method @GlobalScope.is_instance_valid]. It's also recommended to inherit from [RefCounted] for classes storing data instead of [Object].
 		[b]Note:[/b] The [code]script[/code] is not exposed like most properties. To set or get an object's [Script] in code, use [method set_script] and [method get_script], respectively.
@@ -96,7 +96,7 @@
 			<return type="void" />
 			<param index="0" name="what" type="int" />
 			<description>
-				Called when the object receives a notification, which can be identified in [param what] by comparing it with a constant. See also [method notification].
+				Called when the object receives a notification, which can be identified in [param what] by comparing it with a constant. See also [method notify].
 				[codeblock]
 				func _notification(what):
 				    if what == NOTIFICATION_PREDELETE:
@@ -599,7 +599,7 @@
 				Returns [code]true[/code] if the [method Node.queue_free] method was called for the object.
 			</description>
 		</method>
-		<method name="notification">
+		<method name="notify">
 			<return type="void" />
 			<param index="0" name="what" type="int" />
 			<param index="1" name="reversed" type="bool" default="false" />
@@ -610,10 +610,10 @@
 				var player = Node2D.new()
 				player.set_script(load("res://player.gd"))
 
-				player.notification(NOTIFICATION_ENTER_TREE)
+				player.notify(NOTIFICATION_ENTER_TREE)
 				# The call order is Object -&gt; Node -&gt; Node2D -&gt; player.gd.
 
-				player.notification(NOTIFICATION_ENTER_TREE, true)
+				player.notify(NOTIFICATION_ENTER_TREE, true)
 				# The call order is player.gd -&gt; Node2D -&gt; Node -&gt; Object.
 				[/codeblock]
 			</description>

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2369,7 +2369,7 @@ void Node3DEditorPlugin::edited_scene_changed() {
 	for (uint32_t i = 0; i < Node3DEditor::VIEWPORTS_COUNT; i++) {
 		Node3DEditorViewport *viewport = Node3DEditor::get_singleton()->get_editor_viewport(i);
 		if (viewport->is_visible()) {
-			viewport->notification(Control::NOTIFICATION_VISIBILITY_CHANGED);
+			viewport->notify(Control::NOTIFICATION_VISIBILITY_CHANGED);
 		}
 	}
 }

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -54,7 +54,7 @@ void ThemeEditorPreview::add_preview_overlay(Control *p_overlay) {
 }
 
 void ThemeEditorPreview::_propagate_redraw(Control *p_at) {
-	p_at->notification(NOTIFICATION_THEME_CHANGED);
+	p_at->notify(NOTIFICATION_THEME_CHANGED);
 	p_at->update_minimum_size();
 	p_at->queue_redraw();
 	for (int i = 0; i < p_at->get_child_count(); i++) {

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -456,6 +456,7 @@ static const char *gdscript_function_renames[][2] = {
 	{ "move_to_top", "move_before" }, // Skeleton3D
 	{ "multimesh_allocate", "multimesh_allocate_data" }, // RenderingServer
 	{ "normalmap_to_xy", "normal_map_to_xy" }, // Image
+	{ "notification", "notify" }, // Object
 	{ "offset_polygon_2d", "offset_polygon" }, // Geometry2D
 	{ "offset_polyline_2d", "offset_polyline" }, // Geometry2D
 	{ "percent_decode", "uri_decode" }, // String
@@ -897,6 +898,7 @@ static const char *csharp_function_renames[][2] = {
 	{ "MoveToTop", "MoveBefore" }, // Skeleton3D
 	{ "MultimeshAllocate", "MultimeshAllocateData" }, // RenderingServer
 	{ "NormalmapToXy", "NormalMapToXy" }, // Image
+	{ "Notification", "Notify" }, // Object
 	{ "OffsetPolygon2d", "OffsetPolygon" }, // Geometry2D
 	{ "OffsetPolyline2d", "OffsetPolyline" }, // Geometry2D
 	{ "PercentDecode", "UriDecode" }, // String

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1832,8 +1832,8 @@ Variant GDScriptInstance::callp(const StringName &p_method, const Variant **p_ar
 	return Variant();
 }
 
-void GDScriptInstance::notification(int p_notification) {
-	//notification is not virtual, it gets called at ALL levels just like in C.
+void GDScriptInstance::notify(int p_notification) {
+	//notify is not virtual, it gets called at ALL levels just like in C.
 	Variant value = p_notification;
 	const Variant *args[1] = { &value };
 
@@ -1844,7 +1844,7 @@ void GDScriptInstance::notification(int p_notification) {
 			Callable::CallError err;
 			E->value->call(this, args, 1, err);
 			if (err.error != Callable::CallError::CALL_OK) {
-				//print error about notification call
+				//print error about notify call
 			}
 		}
 		sptr = sptr->_base;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -314,7 +314,7 @@ public:
 
 	Variant debug_get_member_by_index(int p_idx) const { return members[p_idx]; }
 
-	virtual void notification(int p_notification);
+	virtual void notify(int p_notification);
 	String to_string(bool *r_valid);
 
 	virtual Ref<Script> get_script() const;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1883,7 +1883,7 @@ const Variant CSharpInstance::get_rpc_config() const {
 	return script->get_rpc_config();
 }
 
-void CSharpInstance::notification(int p_notification) {
+void CSharpInstance::notify(int p_notification) {
 	if (p_notification == Object::NOTIFICATION_PREDELETE) {
 		// When NOTIFICATION_PREDELETE is sent, we also take the chance to call Dispose().
 		// It's safe to call Dispose() multiple times and NOTIFICATION_PREDELETE is guaranteed

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -274,7 +274,7 @@ public:
 
 	const Variant get_rpc_config() const override;
 
-	void notification(int p_notification) override;
+	void notify(int p_notification) override;
 	void _call_notification(int p_notification);
 
 	String to_string(bool *r_valid) override;

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -504,7 +504,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onRendererResumed(JNI
 	// We force redraw to ensure we render at least once when resuming the app.
 	Main::force_redraw();
 	if (os_android->get_main_loop()) {
-		os_android->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_RESUMED);
+		os_android->get_main_loop()->notify(MainLoop::NOTIFICATION_APPLICATION_RESUMED);
 	}
 }
 
@@ -514,7 +514,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onRendererPaused(JNIE
 	}
 
 	if (os_android->get_main_loop()) {
-		os_android->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_PAUSED);
+		os_android->get_main_loop()->notify(MainLoop::NOTIFICATION_APPLICATION_PAUSED);
 	}
 }
 }

--- a/platform/ios/app_delegate.mm
+++ b/platform/ios/app_delegate.mm
@@ -116,7 +116,7 @@ static ViewController *mainViewController = nil;
 
 - (void)applicationDidReceiveMemoryWarning:(UIApplication *)application {
 	if (OS::get_singleton()->get_main_loop()) {
-		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_OS_MEMORY_WARNING);
+		OS::get_singleton()->get_main_loop()->notify(MainLoop::NOTIFICATION_OS_MEMORY_WARNING);
 	}
 }
 

--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -64,7 +64,7 @@ static void handle_crash(int sig) {
 
 	// Tell MainLoop about the crash. This can be handled by users too in Node.
 	if (OS::get_singleton()->get_main_loop()) {
-		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_CRASH);
+		OS::get_singleton()->get_main_loop()->notify(MainLoop::NOTIFICATION_CRASH);
 	}
 
 	// Dump the backtrace to stderr with a message to the user

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -3488,7 +3488,7 @@ void DisplayServerX11::process_events() {
 				//X11 can go between windows and have no focus for a while, when creating them or something else. Use this as safety to avoid unnecessary focus in/outs.
 				if (OS::get_singleton()->get_main_loop()) {
 					DEBUG_LOG_X11("All focus lost, triggering NOTIFICATION_APPLICATION_FOCUS_OUT\n");
-					OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_OUT);
+					OS::get_singleton()->get_main_loop()->notify(MainLoop::NOTIFICATION_APPLICATION_FOCUS_OUT);
 				}
 				app_focused = false;
 			}
@@ -3804,7 +3804,7 @@ void DisplayServerX11::process_events() {
 
 				if (!app_focused) {
 					if (OS::get_singleton()->get_main_loop()) {
-						OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_IN);
+						OS::get_singleton()->get_main_loop()->notify(MainLoop::NOTIFICATION_APPLICATION_FOCUS_IN);
 					}
 					app_focused = true;
 				}

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -88,7 +88,7 @@ static void handle_crash(int sig) {
 
 	// Tell MainLoop about the crash. This can be handled by users too in Node.
 	if (OS::get_singleton()->get_main_loop()) {
-		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_CRASH);
+		OS::get_singleton()->get_main_loop()->notify(MainLoop::NOTIFICATION_CRASH);
 	}
 
 	// Dump the backtrace to stderr with a message to the user

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -648,7 +648,7 @@ void DisplayServerMacOS::update_im_text(const Point2i &p_selection, const String
 	im_selection = p_selection;
 	im_text = p_text;
 
-	OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_OS_IME_UPDATE);
+	OS::get_singleton()->get_main_loop()->notify(MainLoop::NOTIFICATION_OS_IME_UPDATE);
 }
 
 void DisplayServerMacOS::set_last_focused_window(WindowID p_window) {

--- a/platform/macos/godot_application_delegate.mm
+++ b/platform/macos/godot_application_delegate.mm
@@ -121,13 +121,13 @@
 		ds->mouse_process_popups(true);
 	}
 	if (OS::get_singleton()->get_main_loop()) {
-		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_OUT);
+		OS::get_singleton()->get_main_loop()->notify(MainLoop::NOTIFICATION_APPLICATION_FOCUS_OUT);
 	}
 }
 
 - (void)applicationDidBecomeActive:(NSNotification *)notification {
 	if (OS::get_singleton()->get_main_loop()) {
-		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_IN);
+		OS::get_singleton()->get_main_loop()->notify(MainLoop::NOTIFICATION_APPLICATION_FOCUS_IN);
 	}
 }
 
@@ -158,7 +158,7 @@
 - (void)showAbout:(id)sender {
 	OS_MacOS *os = (OS_MacOS *)OS::get_singleton();
 	if (os && os->get_main_loop()) {
-		os->get_main_loop()->notification(MainLoop::NOTIFICATION_WM_ABOUT);
+		os->get_main_loop()->notify(MainLoop::NOTIFICATION_WM_ABOUT);
 	}
 }
 

--- a/platform/windows/crash_handler_windows.cpp
+++ b/platform/windows/crash_handler_windows.cpp
@@ -138,7 +138,7 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 
 	// Tell MainLoop about the crash. This can be handled by users too in Node.
 	if (OS::get_singleton()->get_main_loop()) {
-		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_CRASH);
+		OS::get_singleton()->get_main_loop()->notify(MainLoop::NOTIFICATION_CRASH);
 	}
 
 	print_error("\n================================================================");

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2365,7 +2365,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 			if (!app_focused) {
 				if (OS::get_singleton()->get_main_loop()) {
-					OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_IN);
+					OS::get_singleton()->get_main_loop()->notify(MainLoop::NOTIFICATION_APPLICATION_FOCUS_IN);
 				}
 				app_focused = true;
 			}
@@ -2391,7 +2391,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 			if (!self_steal) {
 				if (OS::get_singleton()->get_main_loop()) {
-					OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_OUT);
+					OS::get_singleton()->get_main_loop()->notify(MainLoop::NOTIFICATION_APPLICATION_FOCUS_OUT);
 				}
 				app_focused = false;
 			}

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -121,7 +121,7 @@ void NavigationAgent2D::_notification(int p_what) {
 		case NOTIFICATION_PARENTED: {
 			if (is_inside_tree() && (get_parent() != agent_parent)) {
 				// only react to PARENTED notifications when already inside_tree and parent changed, e.g. users switch nodes around
-				// PARENTED notification fires also when Node is added in scripts to a parent
+				// PARENTED notify fires also when Node is added in scripts to a parent
 				// this would spam transforms fails and world fails while Node is outside SceneTree
 				// when node gets reparented when joining the tree POST_ENTER_TREE takes care of this
 				set_agent_parent(get_parent());

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -153,12 +153,12 @@ void Node3D::_notification(int p_what) {
 			data.dirty |= DIRTY_GLOBAL_TRANSFORM; // Global is always dirty upon entering a scene.
 			_notify_dirty();
 
-			notification(NOTIFICATION_ENTER_WORLD);
+			notify(NOTIFICATION_ENTER_WORLD);
 			_update_visibility_parent(true);
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			notification(NOTIFICATION_EXIT_WORLD, true);
+			notify(NOTIFICATION_EXIT_WORLD, true);
 			if (xform_change.in_list()) {
 				get_tree()->xform_change_list.remove(&xform_change);
 			}
@@ -233,7 +233,7 @@ void Node3D::set_quaternion(const Quaternion &p_quaternion) {
 
 	_propagate_transform_changed(this);
 	if (data.notify_local_transform) {
-		notification(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
+		notify(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
 	}
 }
 
@@ -263,7 +263,7 @@ void Node3D::set_transform(const Transform3D &p_transform) {
 
 	_propagate_transform_changed(this);
 	if (data.notify_local_transform) {
-		notification(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
+		notify(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
 	}
 }
 
@@ -354,7 +354,7 @@ void Node3D::set_position(const Vector3 &p_position) {
 	data.local_transform.origin = p_position;
 	_propagate_transform_changed(this);
 	if (data.notify_local_transform) {
-		notification(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
+		notify(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
 	}
 }
 
@@ -381,7 +381,7 @@ void Node3D::set_rotation_edit_mode(RotationEditMode p_mode) {
 	if (transform_changed) {
 		_propagate_transform_changed(this);
 		if (data.notify_local_transform) {
-			notification(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
+			notify(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
 		}
 	}
 
@@ -415,7 +415,7 @@ void Node3D::set_rotation_order(EulerOrder p_order) {
 	if (transform_changed) {
 		_propagate_transform_changed(this);
 		if (data.notify_local_transform) {
-			notification(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
+			notify(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
 		}
 	}
 	notify_property_list_changed(); // Will change the rotation property.
@@ -436,7 +436,7 @@ void Node3D::set_rotation(const Vector3 &p_euler_rad) {
 	data.dirty = DIRTY_LOCAL_TRANSFORM;
 	_propagate_transform_changed(this);
 	if (data.notify_local_transform) {
-		notification(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
+		notify(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
 	}
 }
 
@@ -451,7 +451,7 @@ void Node3D::set_scale(const Vector3 &p_scale) {
 	data.dirty = DIRTY_LOCAL_TRANSFORM;
 	_propagate_transform_changed(this);
 	if (data.notify_local_transform) {
-		notification(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
+		notify(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
 	}
 }
 
@@ -641,7 +641,7 @@ Ref<World3D> Node3D::get_world_3d() const {
 }
 
 void Node3D::_propagate_visibility_changed() {
-	notification(NOTIFICATION_VISIBILITY_CHANGED);
+	notify(NOTIFICATION_VISIBILITY_CHANGED);
 	emit_signal(SceneStringNames::get_singleton()->visibility_changed);
 
 #ifdef TOOLS_ENABLED
@@ -829,7 +829,7 @@ void Node3D::force_update_transform() {
 	}
 	get_tree()->xform_change_list.remove(&xform_change);
 
-	notification(NOTIFICATION_TRANSFORM_CHANGED);
+	notify(NOTIFICATION_TRANSFORM_CHANGED);
 }
 
 void Node3D::_update_visibility_parent(bool p_update_root) {

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -381,7 +381,7 @@ Transform3D Skeleton3D::get_bone_global_pose(int p_bone) const {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX_V(p_bone, bone_size, Transform3D());
 	if (dirty) {
-		const_cast<Skeleton3D *>(this)->notification(NOTIFICATION_UPDATE_SKELETON);
+		const_cast<Skeleton3D *>(this)->notify(NOTIFICATION_UPDATE_SKELETON);
 	}
 	return bones[p_bone].pose_global;
 }
@@ -390,7 +390,7 @@ Transform3D Skeleton3D::get_bone_global_pose_no_override(int p_bone) const {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX_V(p_bone, bone_size, Transform3D());
 	if (dirty) {
-		const_cast<Skeleton3D *>(this)->notification(NOTIFICATION_UPDATE_SKELETON);
+		const_cast<Skeleton3D *>(this)->notify(NOTIFICATION_UPDATE_SKELETON);
 	}
 	return bones[p_bone].pose_global_no_override;
 }
@@ -640,7 +640,7 @@ Transform3D Skeleton3D::get_bone_global_rest(int p_bone) const {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX_V(p_bone, bone_size, Transform3D());
 	if (rest_dirty) {
-		const_cast<Skeleton3D *>(this)->notification(NOTIFICATION_UPDATE_SKELETON);
+		const_cast<Skeleton3D *>(this)->notify(NOTIFICATION_UPDATE_SKELETON);
 	}
 	return bones[p_bone].global_rest;
 }
@@ -1017,7 +1017,7 @@ Ref<SkinReference> Skeleton3D::register_skin(const Ref<Skin> &p_skin) {
 
 void Skeleton3D::force_update_all_dirty_bones() {
 	if (dirty) {
-		const_cast<Skeleton3D *>(this)->notification(NOTIFICATION_UPDATE_SKELETON);
+		const_cast<Skeleton3D *>(this)->notify(NOTIFICATION_UPDATE_SKELETON);
 	}
 }
 

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -717,7 +717,7 @@ void XROrigin3D::_notification(int p_what) {
 		for (int i = 0; i < xr_server->get_interface_count(); i++) {
 			Ref<XRInterface> interface = xr_server->get_interface(i);
 			if (interface.is_valid() && interface->is_initialized()) {
-				interface->notification(p_what);
+				interface->notify(p_what);
 			}
 		}
 	}

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -44,7 +44,7 @@ void AnimatedValuesBackup::update_skeletons() {
 	for (int i = 0; i < entries.size(); i++) {
 		if (entries[i].bone_idx != -1) {
 			// 3D bone
-			Object::cast_to<Skeleton3D>(entries[i].object)->notification(Skeleton3D::NOTIFICATION_UPDATE_SKELETON);
+			Object::cast_to<Skeleton3D>(entries[i].object)->notify(Skeleton3D::NOTIFICATION_UPDATE_SKELETON);
 		} else {
 			Bone2D *bone = Object::cast_to<Bone2D>(entries[i].object);
 			if (bone && bone->skeleton) {

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -88,10 +88,10 @@ void Container::_sort_children() {
 		return;
 	}
 
-	notification(NOTIFICATION_PRE_SORT_CHILDREN);
+	notify(NOTIFICATION_PRE_SORT_CHILDREN);
 	emit_signal(SceneStringNames::get_singleton()->pre_sort_children);
 
-	notification(NOTIFICATION_SORT_CHILDREN);
+	notify(NOTIFICATION_SORT_CHILDREN);
 	emit_signal(SceneStringNames::get_singleton()->sort_children);
 	pending_sort = false;
 }

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1639,7 +1639,7 @@ void Control::_size_changed() {
 
 	if (is_inside_tree()) {
 		if (size_changed) {
-			notification(NOTIFICATION_RESIZED);
+			notify(NOTIFICATION_RESIZED);
 		}
 		if (pos_changed || size_changed) {
 			item_rect_changed(size_changed);
@@ -2296,7 +2296,7 @@ void Control::_theme_changed() {
 
 void Control::_notify_theme_override_changed() {
 	if (!data.bulk_theme_override && is_inside_tree()) {
-		notification(NOTIFICATION_THEME_CHANGED);
+		notify(NOTIFICATION_THEME_CHANGED);
 	}
 }
 
@@ -2365,7 +2365,7 @@ void Control::set_theme_type_variation(const StringName &p_theme_type) {
 	}
 	data.theme_type_variation = p_theme_type;
 	if (is_inside_tree()) {
-		notification(NOTIFICATION_THEME_CHANGED);
+		notify(NOTIFICATION_THEME_CHANGED);
 	}
 }
 
@@ -2780,7 +2780,7 @@ void Control::set_localize_numeral_system(bool p_enable) {
 
 	data.localize_numeral_system = p_enable;
 
-	notification(MainLoop::NOTIFICATION_TRANSLATION_CHANGED);
+	notify(MainLoop::NOTIFICATION_TRANSLATION_CHANGED);
 }
 
 bool Control::is_localizing_numeral_system() const {
@@ -2794,7 +2794,7 @@ void Control::set_auto_translate(bool p_enable) {
 
 	data.auto_translate = p_enable;
 
-	notification(MainLoop::NOTIFICATION_TRANSLATION_CHANGED);
+	notify(MainLoop::NOTIFICATION_TRANSLATION_CHANGED);
 }
 
 bool Control::is_auto_translating() const {
@@ -2840,7 +2840,7 @@ void Control::_notification(int p_notification) {
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
-			notification(NOTIFICATION_THEME_CHANGED);
+			notify(NOTIFICATION_THEME_CHANGED);
 		} break;
 
 		case NOTIFICATION_POST_ENTER_TREE: {

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -169,7 +169,7 @@ void SubViewportContainer::_notify_viewports(int p_notification) {
 		if (!c) {
 			continue;
 		}
-		c->notification(p_notification);
+		c->notify(p_notification);
 	}
 }
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1875,7 +1875,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			}
 
 			// Notify to show soft keyboard.
-			notification(NOTIFICATION_FOCUS_ENTER);
+			notify(NOTIFICATION_FOCUS_ENTER);
 		}
 	}
 

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -76,7 +76,7 @@ void CanvasItem::set_visible(bool p_visible) {
 	visible = p_visible;
 
 	if (!parent_visible_in_tree) {
-		notification(NOTIFICATION_VISIBILITY_CHANGED);
+		notify(NOTIFICATION_VISIBILITY_CHANGED);
 		return;
 	}
 
@@ -85,7 +85,7 @@ void CanvasItem::set_visible(bool p_visible) {
 
 void CanvasItem::_handle_visibility_change(bool p_visible) {
 	RenderingServer::get_singleton()->canvas_item_set_visible(canvas_item, p_visible);
-	notification(NOTIFICATION_VISIBILITY_CHANGED);
+	notify(NOTIFICATION_VISIBILITY_CHANGED);
 
 	if (p_visible) {
 		queue_redraw();
@@ -132,7 +132,7 @@ void CanvasItem::_redraw_callback() {
 	if (is_visible_in_tree()) {
 		drawing = true;
 		current_item_drawn = this;
-		notification(NOTIFICATION_DRAW);
+		notify(NOTIFICATION_DRAW);
 		emit_signal(SceneStringNames::get_singleton()->draw);
 		GDVIRTUAL_CALL(_draw);
 		current_item_drawn = nullptr;
@@ -243,11 +243,11 @@ void CanvasItem::_enter_canvas() {
 	pending_update = false;
 	queue_redraw();
 
-	notification(NOTIFICATION_ENTER_CANVAS);
+	notify(NOTIFICATION_ENTER_CANVAS);
 }
 
 void CanvasItem::_exit_canvas() {
-	notification(NOTIFICATION_EXIT_CANVAS, true); //reverse the notification
+	notify(NOTIFICATION_EXIT_CANVAS, true); //reverse the notification
 	RenderingServer::get_singleton()->canvas_item_set_parent(canvas_item, RID());
 	canvas_layer = nullptr;
 	if (canvas_group != StringName()) {
@@ -300,7 +300,7 @@ void CanvasItem::_notification(int p_what) {
 
 			RenderingServer::get_singleton()->canvas_item_set_visible(canvas_item, is_visible_in_tree()); // The visibility of the parent may change.
 			if (is_visible_in_tree()) {
-				notification(NOTIFICATION_VISIBILITY_CHANGED); // Considered invisible until entered.
+				notify(NOTIFICATION_VISIBILITY_CHANGED); // Considered invisible until entered.
 			}
 			_enter_canvas();
 
@@ -869,7 +869,7 @@ void CanvasItem::force_update_transform() {
 
 	get_tree()->xform_change_list.remove(&xform_change);
 
-	notification(NOTIFICATION_TRANSFORM_CHANGED);
+	notify(NOTIFICATION_TRANSFORM_CHANGED);
 }
 
 void CanvasItem::_bind_methods() {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -143,7 +143,7 @@ protected:
 		}
 		_notify_transform(this);
 		if (!block_transform_notify && notify_local_transform) {
-			notification(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
+			notify(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);
 		}
 	}
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -180,11 +180,11 @@ void Node::_propagate_ready() {
 	}
 	data.blocked--;
 
-	notification(NOTIFICATION_POST_ENTER_TREE);
+	notify(NOTIFICATION_POST_ENTER_TREE);
 
 	if (data.ready_first) {
 		data.ready_first = false;
-		notification(NOTIFICATION_READY);
+		notify(NOTIFICATION_READY);
 		emit_signal(SceneStringNames::get_singleton()->ready);
 	}
 }
@@ -210,7 +210,7 @@ void Node::_propagate_enter_tree() {
 		E.value.group = data.tree->add_to_group(E.key, this);
 	}
 
-	notification(NOTIFICATION_ENTER_TREE);
+	notify(NOTIFICATION_ENTER_TREE);
 
 	GDVIRTUAL_CALL(_enter_tree);
 
@@ -292,7 +292,7 @@ void Node::_propagate_exit_tree() {
 
 	emit_signal(SceneStringNames::get_singleton()->tree_exiting);
 
-	notification(NOTIFICATION_EXIT_TREE, true);
+	notify(NOTIFICATION_EXIT_TREE, true);
 	if (data.tree) {
 		data.tree->node_removed(this);
 	}
@@ -391,7 +391,7 @@ void Node::_move_child(Node *p_child, int p_index, bool p_ignore_end) {
 	// notification second
 	move_child_notify(p_child);
 	for (int i = motion_from; i <= motion_to; i++) {
-		data.children[i]->notification(NOTIFICATION_MOVED_IN_PARENT);
+		data.children[i]->notify(NOTIFICATION_MOVED_IN_PARENT);
 	}
 	p_child->_propagate_groups_dirty();
 
@@ -521,9 +521,9 @@ void Node::_propagate_pause_notification(bool p_enable) {
 	bool next_can_process = _can_process(p_enable);
 
 	if (prev_can_process && !next_can_process) {
-		notification(NOTIFICATION_PAUSED);
+		notify(NOTIFICATION_PAUSED);
 	} else if (!prev_can_process && next_can_process) {
-		notification(NOTIFICATION_UNPAUSED);
+		notify(NOTIFICATION_UNPAUSED);
 	}
 
 	for (int i = 0; i < data.children.size(); i++) {
@@ -539,11 +539,11 @@ void Node::_propagate_process_owner(Node *p_owner, int p_pause_notification, int
 	data.process_owner = p_owner;
 
 	if (p_pause_notification != 0) {
-		notification(p_pause_notification);
+		notify(p_pause_notification);
 	}
 
 	if (p_enabled_notification != 0) {
-		notification(p_enabled_notification);
+		notify(p_enabled_notification);
 	}
 
 	for (int i = 0; i < data.children.size(); i++) {
@@ -1111,7 +1111,7 @@ void Node::_add_child_nocheck(Node *p_child, const StringName &p_name) {
 	if (data.internal_children_back > 0) {
 		_move_child(p_child, data.children.size() - data.internal_children_back - 1);
 	}
-	p_child->notification(NOTIFICATION_PARENTED);
+	p_child->notify(NOTIFICATION_PARENTED);
 
 	if (data.tree) {
 		p_child->_set_tree(data.tree);
@@ -1200,7 +1200,7 @@ void Node::remove_child(Node *p_child) {
 	//}
 
 	remove_child_notify(p_child);
-	p_child->notification(NOTIFICATION_UNPARENTED);
+	p_child->notify(NOTIFICATION_UNPARENTED);
 
 	data.children.remove_at(idx);
 
@@ -1210,7 +1210,7 @@ void Node::remove_child(Node *p_child) {
 
 	for (int i = idx; i < child_count; i++) {
 		children[i]->data.index = i;
-		children[i]->notification(NOTIFICATION_MOVED_IN_PARENT);
+		children[i]->notify(NOTIFICATION_MOVED_IN_PARENT);
 	}
 
 	p_child->data.parent = nullptr;
@@ -1834,7 +1834,7 @@ void Node::_propagate_reverse_notification(int p_notification) {
 		data.children[i]->_propagate_reverse_notification(p_notification);
 	}
 
-	notification(p_notification, true);
+	notify(p_notification, true);
 	data.blocked--;
 }
 
@@ -1860,7 +1860,7 @@ void Node::_propagate_deferred_notification(int p_notification, bool p_reverse) 
 
 void Node::propagate_notification(int p_notification) {
 	data.blocked++;
-	notification(p_notification);
+	notify(p_notification);
 
 	for (int i = 0; i < data.children.size(); i++) {
 		data.children[i]->propagate_notification(p_notification);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -179,7 +179,7 @@ void SceneTree::flush_transform_notifications() {
 		SelfList<Node> *nx = n->next();
 		xform_change_list.remove(n);
 		n = nx;
-		node->notification(NOTIFICATION_TRANSFORM_CHANGED);
+		node->notify(NOTIFICATION_TRANSFORM_CHANGED);
 	}
 }
 
@@ -322,7 +322,7 @@ void SceneTree::notify_group_flags(uint32_t p_call_flags, const StringName &p_gr
 			}
 
 			if (!(p_call_flags & GROUP_CALL_DEFERRED)) {
-				gr_nodes[i]->notification(p_notification);
+				gr_nodes[i]->notify(p_notification);
 			} else {
 				MessageQueue::get_singleton()->push_notification(gr_nodes[i], p_notification);
 			}
@@ -335,7 +335,7 @@ void SceneTree::notify_group_flags(uint32_t p_call_flags, const StringName &p_gr
 			}
 
 			if (!(p_call_flags & GROUP_CALL_DEFERRED)) {
-				gr_nodes[i]->notification(p_notification);
+				gr_nodes[i]->notify(p_notification);
 			} else {
 				MessageQueue::get_singleton()->push_notification(gr_nodes[i], p_notification);
 			}
@@ -868,7 +868,7 @@ void SceneTree::_notify_group_pause(const StringName &p_group, int p_notificatio
 			continue;
 		}
 
-		n->notification(p_notification);
+		n->notify(p_notification);
 		//ERR_FAIL_COND(gr_node_count != g.nodes.size());
 	}
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1025,7 +1025,7 @@ Ref<World2D> Viewport::find_world_2d() const {
 }
 
 void Viewport::_propagate_viewport_notification(Node *p_node, int p_what) {
-	p_node->notification(p_what);
+	p_node->notify(p_what);
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		Node *c = p_node->get_child(i);
 		if (Object::cast_to<Viewport>(c)) {
@@ -1355,7 +1355,7 @@ void Viewport::_gui_call_notification(Control *p_control, int p_what) {
 		Control *control = Object::cast_to<Control>(ci);
 		if (control) {
 			if (control->data.mouse_filter != Control::MOUSE_FILTER_IGNORE) {
-				control->notification(p_what);
+				control->notify(p_what);
 			}
 
 			if (!control->is_inside_tree()) {
@@ -2226,7 +2226,7 @@ void Viewport::_gui_control_grab_focus(Control *p_control) {
 	get_tree()->call_group("_viewports", "_gui_remove_focus_for_window", (Node *)get_base_window());
 	gui.key_focus = p_control;
 	emit_signal(SNAME("gui_focus_changed"), p_control);
-	p_control->notification(Control::NOTIFICATION_FOCUS_ENTER);
+	p_control->notify(Control::NOTIFICATION_FOCUS_ENTER);
 	p_control->queue_redraw();
 }
 
@@ -2904,7 +2904,7 @@ void Viewport::gui_release_focus() {
 	if (gui.key_focus) {
 		Control *f = gui.key_focus;
 		gui.key_focus = nullptr;
-		f->notification(Control::NOTIFICATION_FOCUS_EXIT, true);
+		f->notify(Control::NOTIFICATION_FOCUS_EXIT, true);
 		f->queue_redraw();
 	}
 }
@@ -3378,7 +3378,7 @@ void Viewport::_camera_3d_set(Camera3D *p_camera) {
 	}
 
 	if (camera_3d) {
-		camera_3d->notification(Camera3D::NOTIFICATION_LOST_CURRENT);
+		camera_3d->notify(Camera3D::NOTIFICATION_LOST_CURRENT);
 	}
 
 	camera_3d = p_camera;
@@ -3392,7 +3392,7 @@ void Viewport::_camera_3d_set(Camera3D *p_camera) {
 	}
 
 	if (camera_3d) {
-		camera_3d->notification(Camera3D::NOTIFICATION_BECAME_CURRENT);
+		camera_3d->notify(Camera3D::NOTIFICATION_BECAME_CURRENT);
 	}
 
 	_update_audio_listener_3d();
@@ -3407,7 +3407,7 @@ bool Viewport::_camera_3d_add(Camera3D *p_camera) {
 void Viewport::_camera_3d_remove(Camera3D *p_camera) {
 	camera_3d_set.erase(p_camera);
 	if (camera_3d == p_camera) {
-		camera_3d->notification(Camera3D::NOTIFICATION_LOST_CURRENT);
+		camera_3d->notify(Camera3D::NOTIFICATION_LOST_CURRENT);
 		camera_3d = nullptr;
 	}
 }
@@ -3626,7 +3626,7 @@ void Viewport::_propagate_enter_world_3d(Node *p_node) {
 		}
 
 		if (Object::cast_to<Node3D>(p_node) || Object::cast_to<WorldEnvironment>(p_node)) {
-			p_node->notification(Node3D::NOTIFICATION_ENTER_WORLD);
+			p_node->notify(Node3D::NOTIFICATION_ENTER_WORLD);
 		} else {
 			Viewport *v = Object::cast_to<Viewport>(p_node);
 			if (v) {
@@ -3649,7 +3649,7 @@ void Viewport::_propagate_exit_world_3d(Node *p_node) {
 		}
 
 		if (Object::cast_to<Node3D>(p_node) || Object::cast_to<WorldEnvironment>(p_node)) {
-			p_node->notification(Node3D::NOTIFICATION_EXIT_WORLD);
+			p_node->notify(Node3D::NOTIFICATION_EXIT_WORLD);
 		} else {
 			Viewport *v = Object::cast_to<Viewport>(p_node);
 			if (v) {

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -333,7 +333,7 @@ void Window::_rect_changed_callback(const Rect2i &p_callback) {
 }
 
 void Window::_propagate_window_notification(Node *p_node, int p_notification) {
-	p_node->notification(p_notification);
+	p_node->notify(p_notification);
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		Node *child = p_node->get_child(i);
 		Window *window = Object::cast_to<Window>(child);
@@ -349,13 +349,13 @@ void Window::_event_callback(DisplayServer::WindowEvent p_event) {
 		case DisplayServer::WINDOW_EVENT_MOUSE_ENTER: {
 			_propagate_window_notification(this, NOTIFICATION_WM_MOUSE_ENTER);
 			emit_signal(SNAME("mouse_entered"));
-			notification(NOTIFICATION_VP_MOUSE_ENTER);
+			notify(NOTIFICATION_VP_MOUSE_ENTER);
 			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CURSOR_SHAPE)) {
 				DisplayServer::get_singleton()->cursor_set_shape(DisplayServer::CURSOR_ARROW); //restore cursor shape
 			}
 		} break;
 		case DisplayServer::WINDOW_EVENT_MOUSE_EXIT: {
-			notification(NOTIFICATION_VP_MOUSE_EXIT);
+			notify(NOTIFICATION_VP_MOUSE_EXIT);
 			_propagate_window_notification(this, NOTIFICATION_WM_MOUSE_EXIT);
 			emit_signal(SNAME("mouse_exited"));
 		} break;
@@ -454,7 +454,7 @@ void Window::set_visible(bool p_visible) {
 	if (!visible) {
 		focused = false;
 	}
-	notification(NOTIFICATION_VISIBILITY_CHANGED);
+	notify(NOTIFICATION_VISIBILITY_CHANGED);
 	emit_signal(SceneStringNames::get_singleton()->visibility_changed);
 
 	RS::get_singleton()->viewport_set_active(get_viewport_rid(), visible);
@@ -774,7 +774,7 @@ void Window::_update_viewport_size() {
 		}
 	}
 
-	notification(NOTIFICATION_WM_SIZE_CHANGED);
+	notify(NOTIFICATION_WM_SIZE_CHANGED);
 
 	if (embedder) {
 		embedder->_sub_window_update(this);
@@ -868,12 +868,12 @@ void Window::_notification(int p_what) {
 				_make_transient();
 			}
 			if (visible) {
-				notification(NOTIFICATION_VISIBILITY_CHANGED);
+				notify(NOTIFICATION_VISIBILITY_CHANGED);
 				emit_signal(SceneStringNames::get_singleton()->visibility_changed);
 				RS::get_singleton()->viewport_set_active(get_viewport_rid(), true);
 			}
 
-			notification(NOTIFICATION_THEME_CHANGED);
+			notify(NOTIFICATION_THEME_CHANGED);
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
@@ -1270,7 +1270,7 @@ void Window::popup(const Rect2i &p_screen_rect) {
 	}
 
 	_post_popup();
-	notification(NOTIFICATION_POST_POPUP);
+	notify(NOTIFICATION_POST_POPUP);
 }
 
 Size2 Window::get_contents_minimum_size() const {
@@ -1384,7 +1384,7 @@ void Window::_update_theme_item_cache() {
 void Window::set_theme_type_variation(const StringName &p_theme_type) {
 	theme_type_variation = p_theme_type;
 	if (is_inside_tree()) {
-		notification(NOTIFICATION_THEME_CHANGED);
+		notify(NOTIFICATION_THEME_CHANGED);
 	}
 }
 
@@ -1597,7 +1597,7 @@ void Window::set_auto_translate(bool p_enable) {
 
 	auto_translate = p_enable;
 
-	notification(MainLoop::NOTIFICATION_TRANSLATION_CHANGED);
+	notify(MainLoop::NOTIFICATION_TRANSLATION_CHANGED);
 }
 
 bool Window::is_auto_translating() const {

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1759,7 +1759,7 @@ Node *PackedScene::instantiate(GenEditState p_edit_state) const {
 		s->set_scene_file_path(get_path());
 	}
 
-	s->notification(Node::NOTIFICATION_SCENE_INSTANTIATED);
+	s->notify(Node::NOTIFICATION_SCENE_INSTANTIATED);
 
 	return s;
 }

--- a/scene/resources/skeleton_modification_2d_ccdik.cpp
+++ b/scene/resources/skeleton_modification_2d_ccdik.cpp
@@ -231,7 +231,7 @@ void SkeletonModification2DCCDIK::_execute_ccdik_joint(int p_joint_idx, Node2D *
 	// Set the local pose override, and to make sure child bones are also updated, set the transform of the bone.
 	stack->skeleton->set_bone_local_pose_override(ccdik_data.bone_idx, operation_transform, stack->strength, true);
 	operation_bone->set_transform(operation_transform);
-	operation_bone->notification(operation_bone->NOTIFICATION_TRANSFORM_CHANGED);
+	operation_bone->notify(operation_bone->NOTIFICATION_TRANSFORM_CHANGED);
 }
 
 void SkeletonModification2DCCDIK::_setup_modification(SkeletonModificationStack2D *p_stack) {

--- a/scene/theme/theme_owner.cpp
+++ b/scene/theme/theme_owner.cpp
@@ -129,7 +129,7 @@ void ThemeOwner::propagate_theme_changed(Node *p_to_node, Node *p_owner_node, bo
 		}
 
 		if (p_notify) {
-			c->notification(Control::NOTIFICATION_THEME_CHANGED);
+			c->notify(Control::NOTIFICATION_THEME_CHANGED);
 		}
 	} else if (w) {
 		if (w != p_owner_node && w->get_theme().is_valid()) {
@@ -142,7 +142,7 @@ void ThemeOwner::propagate_theme_changed(Node *p_to_node, Node *p_owner_node, bo
 		}
 
 		if (p_notify) {
-			w->notification(Window::NOTIFICATION_THEME_CHANGED);
+			w->notify(Window::NOTIFICATION_THEME_CHANGED);
 		}
 	}
 

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -128,7 +128,7 @@ void TextServerManager::set_primary_interface(const Ref<TextServer> &p_primary_i
 		print_verbose("TextServer: Primary interface set to: \"" + primary_interface->get_name() + "\".");
 
 		if (OS::get_singleton()->get_main_loop()) {
-			OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_TEXT_SERVER_CHANGED);
+			OS::get_singleton()->get_main_loop()->notify(MainLoop::NOTIFICATION_TEXT_SERVER_CHANGED);
 		}
 	}
 }

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -96,7 +96,7 @@ public:
 	Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override {
 		return Variant();
 	}
-	void notification(int p_notification) override {
+	void notify(int p_notification) override {
 	}
 	Ref<Script> get_script() const override {
 		return Ref<Script>();

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -3870,19 +3870,19 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 
 	v_scroll = text_edit->get_v_scroll();
 	SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, Point2i(10, 10), MouseButton::WHEEL_DOWN, MouseButton::WHEEL_DOWN, Key::NONE);
-	text_edit->notification(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
+	text_edit->notify(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 	CHECK(text_edit->get_v_scroll() >= v_scroll);
 	SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, Point2i(10, 10), MouseButton::WHEEL_UP, MouseButton::WHEEL_UP, Key::NONE);
-	text_edit->notification(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
+	text_edit->notify(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 	CHECK(text_edit->get_v_scroll() == v_scroll);
 
 	v_scroll = text_edit->get_v_scroll();
 	text_edit->set_v_scroll_speed(10000);
 	SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, Point2i(10, 10), MouseButton::WHEEL_DOWN, MouseButton::WHEEL_DOWN, Key::NONE);
-	text_edit->notification(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
+	text_edit->notify(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 	CHECK(text_edit->get_v_scroll() >= v_scroll);
 	SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, Point2i(10, 10), MouseButton::WHEEL_UP, MouseButton::WHEEL_UP, Key::NONE);
-	text_edit->notification(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
+	text_edit->notify(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 	CHECK(text_edit->get_v_scroll() == v_scroll);
 
 	ERR_PRINT_OFF;


### PR DESCRIPTION
## DO NOT EXPECT THIS PR TO BE MERGED BEFORE STABLE 4.0.
#### This was mostly a proof of test.

Closes https://github.com/godotengine/godot-proposals/issues/5668

See https://github.com/godotengine/godot-proposals/issues/5668 for reasoning. To make it brief, `Object.notification()` and `Object._notification()` is outstandingly confusing and makes the whole ordeal seem more complicated than it actually is. It doesn't help that the class reference sometimes refers to it as "notify", and there exist methods such as `SceneTree.notify_group()`, yet at the same time the documentation is discouraged from calling it _"notify"_ because that's not how the original method is called.

This PR renames `Object.notification()` to `notify()`, across the _whoooole_ codebase.

![image](https://user-images.githubusercontent.com/66727710/201521999-d4321e60-a50e-4523-8785-f364b6867a15.png)



I do not expect this to make the cut, but it is worth a shot. It would really improve user accessibility for notifications and make the explanation of **EVERY** other notification in the engine so much less confusing.