### PR TITLE
Rename `Node.propagate_notification` to `propagate_notify`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -581,7 +581,7 @@
 				Calls the given method (if present) with the arguments given in [param args] on this node and recursively on all its children. If the [param parent_first] argument is [code]true[/code], the method will be called on the current node first, then on all its children. If [param parent_first] is [code]false[/code], the children will be called first.
 			</description>
 		</method>
-		<method name="propagate_notification">
+		<method name="propagate_notify">
 			<return type="void" />
 			<param index="0" name="what" type="int" />
 			<description>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1767,7 +1767,7 @@ void EditorNode::_save_scene(String p_file, int idx) {
 		return;
 	}
 
-	scene->propagate_notification(NOTIFICATION_EDITOR_PRE_SAVE);
+	scene->propagate_notify(NOTIFICATION_EDITOR_PRE_SAVE);
 
 	editor_data.apply_changes_in_editors();
 	List<Ref<AnimatedValuesBackup>> anim_backups;
@@ -1830,7 +1830,7 @@ void EditorNode::_save_scene(String p_file, int idx) {
 		_dialog_display_save_error(p_file, err);
 	}
 
-	scene->propagate_notification(NOTIFICATION_EDITOR_POST_SAVE);
+	scene->propagate_notify(NOTIFICATION_EDITOR_POST_SAVE);
 }
 
 void EditorNode::save_all_scenes() {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1622,7 +1622,7 @@ void EditorSettings::notify_changes() {
 	if (!root) {
 		return;
 	}
-	root->propagate_notification(NOTIFICATION_EDITOR_SETTINGS_CHANGED);
+	root->propagate_notify(NOTIFICATION_EDITOR_SETTINGS_CHANGED);
 }
 
 void EditorSettings::_bind_methods() {

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -463,6 +463,7 @@ static const char *gdscript_function_renames[][2] = {
 	{ "popup_centered_minsize", "popup_centered_clamped" }, // Window
 	{ "post_import", "_post_import" }, // EditorScenePostImport
 	{ "print_stray_nodes", "print_orphan_nodes" }, // Node
+	{ "propagate_notification", "propagate_notify" }, // Node
 	{ "property_list_changed_notify", "notify_property_list_changed" }, // Object
 	{ "recognize", "_recognize" }, // ResourceFormatLoader
 	{ "regen_normalmaps", "regen_normal_maps" }, // ArrayMesh
@@ -903,6 +904,7 @@ static const char *csharp_function_renames[][2] = {
 	{ "PopupCenteredMinsize", "PopupCenteredClamped" }, // Window
 	{ "PostImport", "_PostImport" }, // EditorScenePostImport
 	{ "PrintStrayNodes", "PrintOrphanNodes" }, // Node
+	{ "PropagateNotification", "PropagateNotify" }, // Node
 	{ "PropertyListChangedNotify", "NotifyPropertyListChanged" }, // Object
 	{ "Recognize", "_Recognize" }, // ResourceFormatLoader
 	{ "RegenNormalmaps", "RegenNormalMaps" }, // ArrayMesh

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2734,7 +2734,7 @@ void Control::set_layout_direction(Control::LayoutDirection p_direction) {
 	data.layout_dir = p_direction;
 	data.is_rtl_dirty = true;
 
-	propagate_notification(NOTIFICATION_LAYOUT_DIRECTION_CHANGED);
+	propagate_notify(NOTIFICATION_LAYOUT_DIRECTION_CHANGED);
 }
 
 Control::LayoutDirection Control::get_layout_direction() const {

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -97,7 +97,7 @@ void ScrollContainer::_cancel_drag() {
 
 	if (beyond_deadzone) {
 		emit_signal(SNAME("scroll_ended"));
-		propagate_notification(NOTIFICATION_SCROLL_END);
+		propagate_notify(NOTIFICATION_SCROLL_END);
 		beyond_deadzone = false;
 	}
 }
@@ -210,7 +210,7 @@ void ScrollContainer::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 			if (beyond_deadzone || (h_scroll_enabled && Math::abs(drag_accum.x) > deadzone) || (v_scroll_enabled && Math::abs(drag_accum.y) > deadzone)) {
 				if (!beyond_deadzone) {
-					propagate_notification(NOTIFICATION_SCROLL_BEGIN);
+					propagate_notify(NOTIFICATION_SCROLL_BEGIN);
 					emit_signal(SNAME("scroll_started"));
 
 					beyond_deadzone = true;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -919,7 +919,7 @@ void Node::set_name(const String &p_name) {
 		_acquire_unique_name_in_owner();
 	}
 
-	propagate_notification(NOTIFICATION_PATH_RENAMED);
+	propagate_notify(NOTIFICATION_PATH_RENAMED);
 
 	if (is_inside_tree()) {
 		emit_signal(SNAME("renamed"));
@@ -1858,12 +1858,12 @@ void Node::_propagate_deferred_notification(int p_notification, bool p_reverse) 
 	data.blocked--;
 }
 
-void Node::propagate_notification(int p_notification) {
+void Node::propagate_notify(int p_notification) {
 	data.blocked++;
 	notification(p_notification);
 
 	for (int i = 0; i < data.children.size(); i++) {
-		data.children[i]->propagate_notification(p_notification);
+		data.children[i]->propagate_notify(p_notification);
 	}
 	data.blocked--;
 }
@@ -2777,7 +2777,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("print_tree_pretty"), &Node::print_tree_pretty);
 	ClassDB::bind_method(D_METHOD("set_scene_file_path", "scene_file_path"), &Node::set_scene_file_path);
 	ClassDB::bind_method(D_METHOD("get_scene_file_path"), &Node::get_scene_file_path);
-	ClassDB::bind_method(D_METHOD("propagate_notification", "what"), &Node::propagate_notification);
+	ClassDB::bind_method(D_METHOD("propagate_notify", "what"), &Node::propagate_notify);
 	ClassDB::bind_method(D_METHOD("propagate_call", "method", "args", "parent_first"), &Node::propagate_call, DEFVAL(Array()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("set_physics_process", "enable"), &Node::set_physics_process);
 	ClassDB::bind_method(D_METHOD("get_physics_process_delta_time"), &Node::get_physics_process_delta_time);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -385,7 +385,7 @@ public:
 
 	/* NOTIFICATIONS */
 
-	void propagate_notification(int p_notification);
+	void propagate_notify(int p_notification);
 
 	void propagate_call(const StringName &p_method, const Array &p_args = Array(), const bool p_parent_first = false);
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -624,7 +624,7 @@ void SceneTree::_notification(int p_notification) {
 	switch (p_notification) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			if (!Engine::get_singleton()->is_editor_hint()) {
-				get_root()->propagate_notification(p_notification);
+				get_root()->propagate_notify(p_notification);
 			}
 		} break;
 
@@ -637,7 +637,7 @@ void SceneTree::_notification(int p_notification) {
 		case NOTIFICATION_APPLICATION_FOCUS_IN:
 		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
 			// Pass these to nodes, since they are mirrored.
-			get_root()->propagate_notification(p_notification);
+			get_root()->propagate_notify(p_notification);
 		} break;
 	}
 }

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1560,7 +1560,7 @@ void Window::set_layout_direction(Window::LayoutDirection p_direction) {
 	ERR_FAIL_INDEX((int)p_direction, 4);
 
 	layout_dir = p_direction;
-	propagate_notification(Control::NOTIFICATION_LAYOUT_DIRECTION_CHANGED);
+	propagate_notify(Control::NOTIFICATION_LAYOUT_DIRECTION_CHANGED);
 }
 
 Window::LayoutDirection Window::get_layout_direction() const {


### PR DESCRIPTION
- See https://github.com/godotengine/godot/pull/68605 for reasoning.

This PR renames `Node.propagate_notification()` to `propagate_notify()` for consistency with https://github.com/godotengine/godot/pull/68605. It wouldn't be a big deal if it remains as is, however.