### PR TITLE
Added missing null checks for gl_manager in MacOS and Windows display servers

### DIFF
--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -2945,7 +2945,10 @@ int64_t DisplayServerMacOS::window_get_native_handle(HandleType p_handle_type, W
 		}
 #ifdef GLES3_ENABLED
 		case OPENGL_CONTEXT: {
-			return (int64_t)gl_manager->get_context(p_window);
+			if (gl_manager) {
+				return (int64_t)gl_manager->get_context(p_window);
+			}
+			return 0;
 		}
 #endif
 		default: {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -743,10 +743,16 @@ int64_t DisplayServerWindows::window_get_native_handle(HandleType p_handle_type,
 		}
 #if defined(GLES3_ENABLED)
 		case WINDOW_VIEW: {
-			return (int64_t)gl_manager->get_hdc(p_window);
+			if (gl_manager) {
+				return (int64_t)gl_manager->get_hdc(p_window);
+			}
+			return 0;
 		}
 		case OPENGL_CONTEXT: {
-			return (int64_t)gl_manager->get_hglrc(p_window);
+			if (gl_manager) {
+				return (int64_t)gl_manager->get_hglrc(p_window);
+			}
+			return 0;
 		}
 #endif
 		default: {


### PR DESCRIPTION
This is a follow-up to #68584 which fixes the same issue in Linux

The bug was originally added by me in #67775 :-/