### PR TITLE
Disable `display_folded` and `editable_instance` in release builds

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2595,6 +2595,7 @@ String Node::get_editor_description() const {
 	return data.editor_description;
 }
 
+#ifdef DEBUG_ENABLED
 void Node::set_editable_instance(Node *p_node, bool p_editable) {
 	ERR_THREAD_GUARD
 	ERR_FAIL_NULL(p_node);
@@ -2618,6 +2619,7 @@ bool Node::is_editable_instance(const Node *p_node) const {
 	ERR_FAIL_COND_V(!is_ancestor_of(p_node), false);
 	return p_node->data.editable_instance;
 }
+#endif // DEBUG_ENABLED
 
 Node *Node::get_deepest_editable_node(Node *p_start_node) const {
 	ERR_THREAD_GUARD_V(nullptr);
@@ -2773,7 +2775,9 @@ Node *Node::_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap) c
 
 	if (!get_scene_file_path().is_empty()) { //an instance
 		node->set_scene_file_path(get_scene_file_path());
+#ifdef DEBUG_ENABLED
 		node->data.editable_instance = data.editable_instance;
+#endif
 	}
 
 	List<const Node *> hidden_roots;
@@ -3430,6 +3434,7 @@ void Node::update_configuration_warnings() {
 #endif
 }
 
+#ifdef DEBUG_ENABLED
 void Node::set_display_folded(bool p_folded) {
 	ERR_THREAD_GUARD
 	data.display_folded = p_folded;
@@ -3438,6 +3443,7 @@ void Node::set_display_folded(bool p_folded) {
 bool Node::is_displayed_folded() const {
 	return data.display_folded;
 }
+#endif // DEBUG_ENABLED
 
 bool Node::is_ready() const {
 	return !data.ready_first;
@@ -3947,8 +3953,10 @@ Node::Node() {
 
 	data.use_placeholder = false;
 
+#ifdef DEBUG_ENABLED
 	data.display_folded = false;
 	data.editable_instance = false;
+#endif
 
 	data.inside_tree = false;
 	data.ready_notified = false; // This is a small hack, so if a node is added during _ready() to the tree, it correctly gets the _ready() notification.

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -240,8 +240,10 @@ private:
 
 		bool use_placeholder : 1;
 
+#ifdef DEBUG_ENABLED
 		bool display_folded : 1;
 		bool editable_instance : 1;
+#endif
 
 		bool inside_tree : 1;
 		bool ready_notified : 1;
@@ -554,8 +556,13 @@ public:
 	void set_editor_description(const String &p_editor_description);
 	String get_editor_description() const;
 
+#ifdef DEBUG_ENABLED
 	void set_editable_instance(Node *p_node, bool p_editable);
 	bool is_editable_instance(const Node *p_node) const;
+#else
+	void set_editable_instance(Node *p_node, bool p_editable) {}
+	bool is_editable_instance(const Node *p_node) const { return false; }
+#endif
 	Node *get_deepest_editable_node(Node *p_start_node) const;
 
 #ifdef TOOLS_ENABLED
@@ -717,8 +724,13 @@ public:
 
 	void update_configuration_warnings();
 
+#ifdef DEBUG_ENABLED
 	void set_display_folded(bool p_folded);
 	bool is_displayed_folded() const;
+#else
+	void set_display_folded(bool p_folded) {}
+	bool is_displayed_folded() const { return false; }
+#endif
 
 	/* NETWORK */
 


### PR DESCRIPTION
See also https://github.com/godotengine/godot/pull/68560.

This PR dummies out `is_displayed_folded()`, `set_display_folded()`, `is_editable_instance()`, `set_editable_instance()` of **Node** to do nothing on release builds. In the editor and in debug builds, they work completely fine still, as they're intended to.

I do not expect anyone to have ever used these in release builds, and if they do... I'm not sure why? This is technically compatibility breaking, but in practice you shouldn't use these methods outside of an editor context, nor you probably have ever tried to, because the documentation heavily implies they're not intended to be.