### PR TITLE
Fix clicking in gradient editor

### DIFF
--- a/editor/plugins/gradient_editor.cpp
+++ b/editor/plugins/gradient_editor.cpp
@@ -203,6 +203,7 @@ void GradientEditor::gui_input(const Ref<InputEvent> &p_event) {
 		grabbed = _get_point_from_pos(mb->get_position().x);
 		_show_color_picker();
 		accept_event();
+		return;
 	}
 
 	// Delete point on right click.


### PR DESCRIPTION
- When double-clicking on the gradient we should open the colour picker and create a colour key.
- Instead, we were also evaluating the click further down producing the colour key to move around.

<i>Bugsquad edit:</i>
- Fix #67235

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
