### PR TITLE
Fix editor crash on audio preview

### DIFF
--- a/editor/audio_stream_preview.cpp
+++ b/editor/audio_stream_preview.cpp
@@ -42,6 +42,10 @@ float AudioStreamPreview::get_max(float p_time, float p_time_next) const {
 	}
 
 	int max = preview.size() / 2;
+	if (max == 0) {
+		return 0;
+	}
+
 	int time_from = p_time / length * max;
 	int time_to = p_time_next / length * max;
 	time_from = CLAMP(time_from, 0, max - 1);
@@ -69,6 +73,10 @@ float AudioStreamPreview::get_min(float p_time, float p_time_next) const {
 	}
 
 	int max = preview.size() / 2;
+	if (max == 0) {
+		return 0;
+	}
+	
 	int time_from = p_time / length * max;
 	int time_to = p_time_next / length * max;
 	time_from = CLAMP(time_from, 0, max - 1);


### PR DESCRIPTION
- Crash was due to getting -1 values when clamping [0, -1].
- This was happening due to 'max' being zero.
- If 'max' is zero we should return zero, as it can never be any other value.

<i>Bugsquad edit:</I>
- Fix https://github.com/godotengine/godot/issues/66928

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
