### PR TITLE
Fix routing of InputEventScreenDrag events to Control nodes

### DIFF
--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -354,6 +354,7 @@ private:
 		bool forced_mouse_focus = false; //used for menu buttons
 		bool mouse_in_viewport = true;
 		bool key_event_accepted = false;
+		HashMap<int, ObjectID> touch_focus;
 		Control *mouse_focus = nullptr;
 		Control *last_mouse_focus = nullptr;
 		Control *mouse_click_grabber = nullptr;


### PR DESCRIPTION
Multitouch support enables multiple concurrent `InputEventScreenTouch` and `InputEventScreenDrag` events each differentiated by their `index` property.

An `InputEventScreenDrag` event typically follows another `InputEventScreenDrag` or `InputEventScreenTouch` event and thus should be routed to the target that last matched the previous touch event. 
Prior to this fix, in a multitouch scenario only the target of the first touch event was tracked, causing all subsequent multitouch drag events to be routed to that invalid target. The PR tracks the touch targets using the touch event's `index` property, and use that data to properly route drag events based on their matching `index` property.

[3.x version](https://github.com/godotengine/godot/pull/68630)

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/29525
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
