### PR TITLE
Fix missing tooltips caused by export_category

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2723,6 +2723,16 @@ void EditorInspector::update_tree() {
 			section_depth = 0;
 
 			if (!show_categories) {
+				// Find the class name to retrieve information about the following properties. (The category name does not always work.)
+				if (doc_name == "" && !EditorNode::get_editor_data().is_type_recognized(p.name) && p.hint_string.length() && FileAccess::exists(p.hint_string)) {
+					Ref<Script> scr = ResourceLoader::load(p.hint_string, "Script");
+					if (scr.is_valid()) {
+						Vector<DocData::ClassDoc> docs = scr->get_documentation();
+						if (!docs.is_empty()) {
+							doc_name = docs[0].name;
+						}
+					}
+				}
 				continue;
 			}
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3853,6 +3853,7 @@ bool GDScriptParser::export_group_annotations(const AnnotationNode *p_annotation
 	switch (t_usage) {
 		case PROPERTY_USAGE_CATEGORY: {
 			annotation->export_info.usage = t_usage;
+			annotation->export_info.hint_string = script_path;
 		} break;
 
 		case PROPERTY_USAGE_GROUP: {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
This pull request attempts to fix the issues mentioned by #64432 and #68520.

Problems found:
1. The EditorInspector::update_tree function did not update the doc_name variable when skipping a category, which happened when show_categories was set to false and caused the following properties could not be identified (editor_inspector.cpp, line 2725).
2. In the same function, the name of an export_category was treated as a class name as if it were a script.

Solutions:
1. Find out the name of class a skipped category belongs to and update doc_name with it.
2. Add the corresponding script path to hint_string of an export_category, which allows the function to find out the corresponding class.

<i>Bugsquad edit:</i> 
- Fix #64432
- Fix #68520