### PR TITLE
Mark shader built-ins as used when passed to functions as out parameter

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -9717,6 +9717,25 @@ String ShaderLanguage::get_shader_type(const String &p_code) {
 	return String();
 }
 
+bool ShaderLanguage::is_builtin_func_out_parameter(const String &p_name, int p_param) {
+	int i = 0;
+	while (builtin_func_out_args[i].name) {
+		if (p_name == builtin_func_out_args[i].name) {
+			for (int j = 0; j < BuiltinFuncOutArgs::MAX_ARGS; j++) {
+				int arg = builtin_func_out_args[i].arguments[j];
+				if (arg == p_param) {
+					return true;
+				}
+				if (arg < 0) {
+					return false;
+				}
+			}
+		}
+		i++;
+	}
+	return false;
+}
+
 #ifdef DEBUG_ENABLED
 void ShaderLanguage::_check_warning_accums() {
 	for (const KeyValue<ShaderWarning::Code, HashMap<StringName, HashMap<StringName, Usage>> *> &E : warnings_check_map2) {

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -1119,6 +1119,7 @@ public:
 	void clear();
 
 	static String get_shader_type(const String &p_code);
+	static bool is_builtin_func_out_parameter(const String &p_name, int p_param);
 
 	struct ShaderCompileInfo {
 		HashMap<StringName, FunctionInfo> functions;


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/68378 by marking the built-in as used when it passed to function as `out` or `inout` parameter (we cannot guarantee that it will not be modified inside it anyway). Fixes the cases like:

```
void test(inout vec3 vertex) {
 vertex.y = 10.0;
}

void vertex() {
	test(VERTEX);
}
```

or

```
void test(inout float component) {
	component = 10.0f;
}

void vertex() {
	test(VERTEX.y);
}
```

and also for built-in functions:

```
void vertex() {
	modf(1.0, VERTEX.y);
}
```