### PR TITLE
[WIP] Improve vertical text layout handling, move duplicate to the TextParagraph.

### DIFF
--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -49,6 +49,9 @@
 		<member name="horizontal_alignment" type="int" setter="set_horizontal_alignment" getter="get_horizontal_alignment" enum="HorizontalAlignment" default="0">
 			Controls the text's horizontal alignment. Supports left, center, right, and fill, or justify. Set it to one of the [enum HorizontalAlignment] constants.
 		</member>
+		<member name="invert_line_order" type="bool" setter="set_invert_line_order" getter="get_invert_line_order" default="false">
+			If [code]true[/code], line drawing order is inverted.
+		</member>
 		<member name="label_settings" type="LabelSettings" setter="set_label_settings" getter="get_label_settings">
 			A [LabelSettings] resource that can be shared between multiple [Label] nodes. Takes priority over theme properties.
 		</member>
@@ -62,6 +65,9 @@
 			Limits the lines of text the node shows on screen.
 		</member>
 		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" overrides="Control" enum="Control.MouseFilter" default="2" />
+		<member name="orientation" type="int" setter="set_orientation" getter="get_orientation" enum="TextServer.Orientation" default="0">
+			Text orientation.
+		</member>
 		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" default="4" />
 		<member name="structured_text_bidi_override" type="int" setter="set_structured_text_bidi_override" getter="get_structured_text_bidi_override" enum="TextServer.StructuredTextParser" default="0">
 			Set BiDi algorithm override for the structured text.
@@ -77,6 +83,9 @@
 		</member>
 		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextServer.OverrunBehavior" default="0">
 			Sets the clipping behavior when the text exceeds the node's bounding rectangle. See [enum TextServer.OverrunBehavior] for a description of all modes.
+		</member>
+		<member name="uniform_line_height" type="bool" setter="set_uniform_line_height" getter="get_uniform_line_height" default="false">
+			If [code]true[/code], heigth of every line is set to the maximum line height.
 		</member>
 		<member name="uppercase" type="bool" setter="set_uppercase" getter="is_uppercase" default="false">
 			If [code]true[/code], all the text displays as UPPERCASE.

--- a/doc/classes/Label3D.xml
+++ b/doc/classes/Label3D.xml
@@ -59,8 +59,14 @@
 			Higher font sizes require more time to render new characters, which can cause stuttering during gameplay.
 		</member>
 		<member name="gi_mode" type="int" setter="set_gi_mode" getter="get_gi_mode" overrides="GeometryInstance3D" enum="GeometryInstance3D.GIMode" default="0" />
+		<member name="height" type="float" setter="set_height" getter="get_height" default="500.0">
+			Text height (in pixels), used for alignment.
+		</member>
 		<member name="horizontal_alignment" type="int" setter="set_horizontal_alignment" getter="get_horizontal_alignment" enum="HorizontalAlignment" default="1">
 			Controls the text's horizontal alignment. Supports left, center, right, and fill, or justify. Set it to one of the [enum HorizontalAlignment] constants.
+		</member>
+		<member name="invert_line_order" type="bool" setter="set_invert_line_order" getter="get_invert_line_order" default="false">
+			If [code]true[/code], line drawing order is inverted.
 		</member>
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
@@ -76,6 +82,9 @@
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The text drawing offset (in pixels).
+		</member>
+		<member name="orientation" type="int" setter="set_orientation" getter="get_orientation" enum="TextServer.Orientation" default="0">
+			Text orientation.
 		</member>
 		<member name="outline_modulate" type="Color" setter="set_outline_modulate" getter="get_outline_modulate" default="Color(0, 0, 0, 1)">
 			The tint of text outline.
@@ -111,8 +120,14 @@
 		<member name="text_direction" type="int" setter="set_text_direction" getter="get_text_direction" enum="TextServer.Direction" default="0">
 			Base text writing direction.
 		</member>
+		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextServer.OverrunBehavior" default="0">
+			Sets the clipping behavior when the text exceeds the paragraph's set width. See [enum TextServer.OverrunBehavior] for a description of all modes.
+		</member>
 		<member name="texture_filter" type="int" setter="set_texture_filter" getter="get_texture_filter" enum="BaseMaterial3D.TextureFilter" default="3">
 			Filter flags for the texture. See [enum BaseMaterial3D.TextureFilter] for options.
+		</member>
+		<member name="uniform_line_height" type="bool" setter="set_uniform_line_height" getter="get_uniform_line_height" default="false">
+			If [code]true[/code], heigth of every line is set to the maximum line height.
 		</member>
 		<member name="uppercase" type="bool" setter="set_uppercase" getter="is_uppercase" default="false">
 			If [code]true[/code], all the text displays as UPPERCASE.
@@ -121,7 +136,7 @@
 			Controls the text's vertical alignment. Supports top, center, bottom. Set it to one of the [enum VerticalAlignment] constants.
 		</member>
 		<member name="width" type="float" setter="set_width" getter="get_width" default="500.0">
-			Text width (in pixels), used for autowrap and fill alignment.
+			Text width (in pixels), used for autowrap and alignment.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/TextLine.xml
+++ b/doc/classes/TextLine.xml
@@ -46,6 +46,17 @@
 				Draw text into a canvas item at a given position, with [param color]. [param pos] specifies the top left corner of the bounding box.
 			</description>
 		</method>
+		<method name="draw_custom" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="canvas" type="RID" />
+			<param index="1" name="pos" type="Vector2" />
+			<param index="2" name="callback" type="Callable" />
+			<description>
+				Draw text using custom glyph drawing callback.
+				The callback should have 3 arguments: [Dictionary] [code]glyph[/code], [Vector2] [code]position[/code], [RID] [code]canvas[/code].
+				The callback should return [bool], if [code]false[/code] is returned, drawing is aborted.
+			</description>
+		</method>
 		<method name="draw_outline" qualifiers="const">
 			<return type="void" />
 			<param index="0" name="canvas" type="RID" />
@@ -54,6 +65,26 @@
 			<param index="3" name="color" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
 				Draw text into a canvas item at a given position, with [param color]. [param pos] specifies the top left corner of the bounding box.
+			</description>
+		</method>
+		<method name="draw_underline_custom" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="canvas" type="RID" />
+			<param index="1" name="pos" type="Vector2" />
+			<param index="2" name="line_type" type="int" enum="TextServer.LinePosition" />
+			<param index="3" name="start" type="int" />
+			<param index="4" name="end" type="int" />
+			<param index="5" name="callback" type="Callable" />
+			<description>
+				Draw underline/overline/strikethrough for the specific range of text using custom drawing callback.
+				The callback should have 2 arguments: [Rect2] [code]rect[/code], [RID] [code]canvas[/code].
+				The callback should return [bool], if [code]false[/code] is returned, drawing is aborted.
+			</description>
+		</method>
+		<method name="get_glyph_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns number of glyphs in the line.
 			</description>
 		</method>
 		<method name="get_line_ascent" qualifiers="const">
@@ -111,6 +142,18 @@
 				Returns size of the bounding box of the text.
 			</description>
 		</method>
+		<method name="get_span_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns numbrer of text spans.
+			</description>
+		</method>
+		<method name="has_invalid_glyphs" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if line has glyphs that can't be rendered using current font.
+			</description>
+		</method>
 		<method name="hit_test" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="coords" type="float" />
@@ -143,10 +186,22 @@
 				Aligns text to the given tab-stops.
 			</description>
 		</method>
+		<method name="update_span_font">
+			<return type="void" />
+			<param index="0" name="span" type="int" />
+			<param index="1" name="font" type="Font" />
+			<param index="2" name="font_size" type="int" />
+			<description>
+				Sets font and font size of the text span (added by [method add_string]).
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="alignment" type="int" setter="set_horizontal_alignment" getter="get_horizontal_alignment" enum="HorizontalAlignment" default="0">
 			Sets text alignment within the line as if the line was horizontal.
+		</member>
+		<member name="clip" type="bool" setter="set_clip" getter="get_clip" default="true">
+			If [code]true[/code], only shows the text that fits inside its bounding rectangle and will clip text horizontally.
 		</member>
 		<member name="direction" type="int" setter="set_direction" getter="get_direction" enum="TextServer.Direction" default="0">
 			Text writing direction.

--- a/doc/classes/TextMesh.xml
+++ b/doc/classes/TextMesh.xml
@@ -26,8 +26,14 @@
 		<member name="font_size" type="int" setter="set_font_size" getter="get_font_size" default="16">
 			Font size of the [TextMesh]'s text.
 		</member>
+		<member name="height" type="float" setter="set_height" getter="get_height" default="500.0">
+			Text height (in pixels), used for alignment.
+		</member>
 		<member name="horizontal_alignment" type="int" setter="set_horizontal_alignment" getter="get_horizontal_alignment" enum="HorizontalAlignment" default="1">
 			Controls the text's horizontal alignment. Supports left, center, right, and fill, or justify. Set it to one of the [enum HorizontalAlignment] constants.
+		</member>
+		<member name="invert_line_order" type="bool" setter="set_invert_line_order" getter="get_invert_line_order" default="false">
+			If [code]true[/code], line drawing order is inverted.
 		</member>
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for text shaping algorithms, if left empty current locale is used instead.
@@ -37,6 +43,9 @@
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The text drawing offset (in pixels).
+		</member>
+		<member name="orientation" type="int" setter="set_orientation" getter="get_orientation" enum="TextServer.Orientation" default="0">
+			Text orientation.
 		</member>
 		<member name="pixel_size" type="float" setter="set_pixel_size" getter="get_pixel_size" default="0.01">
 			The size of one pixel's width on the text to scale it in 3D.
@@ -53,6 +62,9 @@
 		<member name="text_direction" type="int" setter="set_text_direction" getter="get_text_direction" enum="TextServer.Direction" default="0">
 			Base text writing direction.
 		</member>
+		<member name="uniform_line_height" type="bool" setter="set_uniform_line_height" getter="get_uniform_line_height" default="false">
+			If [code]true[/code], heigth of every line is set to the maximum line height.
+		</member>
 		<member name="uppercase" type="bool" setter="set_uppercase" getter="is_uppercase" default="false">
 			If [code]true[/code], all the text displays as UPPERCASE.
 		</member>
@@ -60,7 +72,7 @@
 			Controls the text's vertical alignment. Supports top, center, bottom. Set it to one of the [enum VerticalAlignment] constants.
 		</member>
 		<member name="width" type="float" setter="set_width" getter="get_width" default="500.0">
-			Text width (in pixels), used for fill alignment.
+			Text width (in pixels), used for autowrap and alignment.
 		</member>
 	</members>
 </class>

--- a/doc/classes/TextParagraph.xml
+++ b/doc/classes/TextParagraph.xml
@@ -53,6 +53,17 @@
 				Draw all lines of the text and drop cap into a canvas item at a given position, with [param color]. [param pos] specifies the top left corner of the bounding box.
 			</description>
 		</method>
+		<method name="draw_custom" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="canvas" type="RID" />
+			<param index="1" name="pos" type="Vector2" />
+			<param index="2" name="callback" type="Callable" />
+			<description>
+				Draw text using custom glyph drawing callback.
+				The callback should have 4 arguments: [Dictionary] [code]glyph[/code], [Vector2] [code]position[/code], [RID] [code]canvas[/code], [int] [code]line_number[/code].
+				The callback should return [bool], if [code]false[/code] is returned, drawing is aborted.
+			</description>
+		</method>
 		<method name="draw_dropcap" qualifiers="const">
 			<return type="void" />
 			<param index="0" name="canvas" type="RID" />
@@ -104,10 +115,30 @@
 				Draw outlines of all lines of the text and drop cap into a canvas item at a given position, with [param color]. [param pos] specifies the top left corner of the bounding box.
 			</description>
 		</method>
+		<method name="draw_underline_custom" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="canvas" type="RID" />
+			<param index="1" name="pos" type="Vector2" />
+			<param index="2" name="line_type" type="int" enum="TextServer.LinePosition" />
+			<param index="3" name="start" type="int" />
+			<param index="4" name="end" type="int" />
+			<param index="5" name="callback" type="Callable" />
+			<description>
+				Draw underline/overline/strikethrough for the specific range of text using custom drawing callback.
+				The callback should have 3 arguments: [Rect2] [code]rect[/code], [RID] [code]canvas[/code], [int] [code]line_number[/code].
+				The callback should return [bool], if [code]false[/code] is returned, drawing is aborted.
+			</description>
+		</method>
 		<method name="get_dropcap_lines" qualifiers="const">
 			<return type="int" />
 			<description>
 				Returns number of lines used by dropcap.
+			</description>
+		</method>
+		<method name="get_dropcap_offset" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns drawing offset of the dropcap.
 			</description>
 		</method>
 		<method name="get_dropcap_rid" qualifiers="const">
@@ -120,6 +151,12 @@
 			<return type="Vector2" />
 			<description>
 				Returns drop cap bounding box size.
+			</description>
+		</method>
+		<method name="get_glyph_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns number of glyphs in the paragraph.
 			</description>
 		</method>
 		<method name="get_line_ascent" qualifiers="const">
@@ -155,6 +192,13 @@
 			<param index="0" name="line" type="int" />
 			<description>
 				Returns array of inline objects in the line.
+			</description>
+		</method>
+		<method name="get_line_offset" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="line" type="int" />
+			<description>
+				Returnes drawing offset of the text line.
 			</description>
 		</method>
 		<method name="get_line_range" qualifiers="const">
@@ -217,6 +261,24 @@
 				Returns the size of the bounding box of the paragraph.
 			</description>
 		</method>
+		<method name="get_span_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns numbrer of text spans.
+			</description>
+		</method>
+		<method name="get_visible_line_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns visible line count.
+			</description>
+		</method>
+		<method name="has_invalid_glyphs" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if paragraph has glyphs that can't be rendered using current font.
+			</description>
+		</method>
 		<method name="hit_test" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="coords" type="Vector2" />
@@ -260,13 +322,22 @@
 				Aligns paragraph to the given tab-stops.
 			</description>
 		</method>
+		<method name="update_span_font">
+			<return type="void" />
+			<param index="0" name="span" type="int" />
+			<param index="1" name="font" type="Font" />
+			<param index="2" name="font_size" type="int" />
+			<description>
+				Sets font and font size of the text span (added by [method add_string]).
+			</description>
+		</method>
 	</methods>
 	<members>
-		<member name="alignment" type="int" setter="set_alignment" getter="get_alignment" enum="HorizontalAlignment" default="0">
-			Paragraph horizontal alignment.
-		</member>
 		<member name="break_flags" type="int" setter="set_break_flags" getter="get_break_flags" enum="TextServer.LineBreakFlag" default="3">
 			Line breaking rules. For more info see [TextServer].
+		</member>
+		<member name="clip" type="bool" setter="set_clip" getter="get_clip" default="true">
+			If [code]true[/code], only shows the text that fits inside its bounding rectangle and will clip text.
 		</member>
 		<member name="custom_punctuation" type="String" setter="set_custom_punctuation" getter="get_custom_punctuation" default="&quot;&quot;">
 			Custom punctuation character list, used for word breaking. If set to empty string, server defaults are used.
@@ -274,8 +345,23 @@
 		<member name="direction" type="int" setter="set_direction" getter="get_direction" enum="TextServer.Direction" default="0">
 			Text writing direction.
 		</member>
+		<member name="extra_line_spacing" type="float" setter="set_extra_line_spacing" getter="get_extra_line_spacing" default="0.0">
+			Extra line spacing.
+		</member>
+		<member name="height" type="float" setter="set_height" getter="get_height" default="-1.0">
+			Target height for paragraph alignment.
+		</member>
+		<member name="horizontal_alignment" type="int" setter="set_horizontal_alignment" getter="get_horizontal_alignment" enum="HorizontalAlignment" default="0">
+			Paragraph horizontal (alignment in the direction of text) alignment.
+		</member>
+		<member name="invert_line_order" type="bool" setter="set_invert_line_order" getter="get_invert_line_order" default="false">
+			If [code]true[/code], line drawing order is inverted.
+		</member>
 		<member name="justification_flags" type="int" setter="set_justification_flags" getter="get_justification_flags" enum="TextServer.JustificationFlag" default="3">
 			Line alignment rules. For more info see [TextServer].
+		</member>
+		<member name="lines_skipped" type="int" setter="set_lines_skipped" getter="get_lines_skipped" default="0">
+			Number of lines to skip.
 		</member>
 		<member name="max_lines_visible" type="int" setter="set_max_lines_visible" getter="get_max_lines_visible" default="-1">
 			Limits the lines of text shown.
@@ -292,8 +378,14 @@
 		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextServer.OverrunBehavior" default="0">
 			Sets the clipping behavior when the text exceeds the paragraph's set width. See [enum TextServer.OverrunBehavior] for a description of all modes.
 		</member>
+		<member name="uniform_line_height" type="bool" setter="set_uniform_line_height" getter="get_uniform_line_height" default="false">
+			If [code]true[/code], heigth of every line is set to the maximum line height.
+		</member>
+		<member name="vertical_alignment" type="int" setter="set_vertical_alignment" getter="get_vertical_alignment" enum="VerticalAlignment" default="0">
+			Paragraph vertical (alignment in the direction of lines) alignment.
+		</member>
 		<member name="width" type="float" setter="set_width" getter="get_width" default="-1.0">
-			Paragraph width.
+			Target width for paragraph alignment.
 		</member>
 	</members>
 </class>

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -563,6 +563,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="index" type="int" />
+			<param index="3" name="include_sideways" type="bool" default="false" />
 			<description>
 				Renders specified glyph to the font cache texture.
 			</description>
@@ -573,6 +574,7 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="start" type="int" />
 			<param index="3" name="end" type="int" />
+			<param index="4" name="include_sideways" type="bool" default="false" />
 			<description>
 				Renders the range of characters to the font cache texture.
 			</description>
@@ -1135,6 +1137,20 @@
 				Draw shaped text into a canvas item at a given position, with [param color]. [param pos] specifies the leftmost point of the baseline (for horizontal layout) or topmost point of the baseline (for vertical layout).
 			</description>
 		</method>
+		<method name="shaped_text_draw_custom" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="shaped" type="RID" />
+			<param index="1" name="canvas" type="RID" />
+			<param index="2" name="pos" type="Vector2" />
+			<param index="3" name="clip_l" type="float" />
+			<param index="4" name="clip_r" type="float" />
+			<param index="5" name="callback" type="Callable" />
+			<description>
+				Draw text using custom glyph drawing callback.
+				The callback should have 3 arguments: [Dictionary] [code]glyph[/code], [Vector2] [code]position[/code], [RID] [code]canvas[/code].
+				The callback should return [bool], if [code]false[/code] is returned, drawing is aborted.
+			</description>
+		</method>
 		<method name="shaped_text_draw_outline" qualifiers="const">
 			<return type="void" />
 			<param index="0" name="shaped" type="RID" />
@@ -1369,6 +1385,13 @@
 			<param index="0" name="shaped" type="RID" />
 			<description>
 				Returns thickness of the underline.
+			</description>
+		</method>
+		<method name="shaped_text_get_vertical_bounds" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="shaped" type="RID" />
+			<description>
+				Returned real vertical bounds of the line (like ascent/descent, but counting only space occupied by glyphs).
 			</description>
 		</method>
 		<method name="shaped_text_get_width" qualifiers="const">
@@ -1625,6 +1648,15 @@
 		</constant>
 		<constant name="FONT_LCD_SUBPIXEL_LAYOUT_MAX" value="5" enum="FontLCDSubpixelLayout">
 		</constant>
+		<constant name="UNDERLINE" value="0" enum="LinePosition">
+			Underline position.
+		</constant>
+		<constant name="OVERDERLINE" value="1" enum="LinePosition">
+			Overline position.
+		</constant>
+		<constant name="STRIKETHROUGH" value="2" enum="LinePosition">
+			Strikethrough position.
+		</constant>
 		<constant name="DIRECTION_AUTO" value="0" enum="Direction">
 			Text direction is determined based on contents and current locale.
 		</constant>
@@ -1637,9 +1669,14 @@
 		<constant name="ORIENTATION_HORIZONTAL" value="0" enum="Orientation">
 			Text is written horizontally.
 		</constant>
-		<constant name="ORIENTATION_VERTICAL" value="1" enum="Orientation">
-			Left to right text is written vertically from top to bottom.
-			Right to left text is written vertically from bottom to top.
+		<constant name="ORIENTATION_VERTICAL_UPRIGHT" value="1" enum="Orientation">
+			Text is written vertically from top to bottom (LTR) / bottom to top (RTL), all glyphs are drawn upright.
+		</constant>
+		<constant name="ORIENTATION_VERTICAL_MIXED" value="2" enum="Orientation">
+			Text is written vertically from top to bottom (LTR) / bottom to top (RTL), CJK glyphs are drawn upright, other glyphs are drawn sideways (90 deg. CW).
+		</constant>
+		<constant name="ORIENTATION_VERTICAL_SIDEWAYS" value="3" enum="Orientation">
+			Text is written vertically from top to bottom (LTR) / bottom to top (RTL), all glyphs are drawn sideways (90 deg. CW).
 		</constant>
 		<constant name="JUSTIFICATION_NONE" value="0" enum="JustificationFlag" is_bitfield="true">
 			Do not justify text.

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -485,6 +485,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="index" type="int" />
+			<param index="3" name="include_sideways" type="bool" />
 			<description>
 			</description>
 		</method>
@@ -494,6 +495,7 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="start" type="int" />
 			<param index="3" name="end" type="int" />
+			<param index="4" name="include_sideways" type="bool" />
 			<description>
 			</description>
 		</method>
@@ -1178,6 +1180,12 @@
 		</method>
 		<method name="_shaped_text_get_underline_thickness" qualifiers="virtual const">
 			<return type="float" />
+			<param index="0" name="shaped" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_shaped_text_get_vertical_bounds" qualifiers="virtual const">
+			<return type="Vector2" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
 			</description>

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -982,6 +982,7 @@ void DynamicFontImportSettings::_re_import() {
 		configurations.push_back(preload_config);
 	}
 	main_settings["preload"] = configurations;
+	main_settings["preload_sideways"] = import_settings_data->get("preload_sideways");
 	main_settings["language_support"] = import_settings_data->get("language_support");
 	main_settings["script_support"] = import_settings_data->get("script_support");
 	main_settings["opentype_features"] = import_settings_data->get("opentype_features");
@@ -1255,6 +1256,9 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::DICTIONARY, "language_support"), Dictionary()));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::DICTIONARY, "script_support"), Dictionary()));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::DICTIONARY, "opentype_features"), Dictionary()));
+
+	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::NIL, "Preload", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP), Variant()));
+	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::BOOL, "preload_sideways", PROPERTY_HINT_NONE, ""), false));
 
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::NIL, "Fallbacks", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP), Variant()));
 	options_general.push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::ARRAY, "fallbacks", PROPERTY_HINT_ARRAY_TYPE, MAKE_RESOURCE_TYPE_HINT("Font")), Array()));

--- a/editor/import/resource_importer_dynamic_font.cpp
+++ b/editor/import/resource_importer_dynamic_font.cpp
@@ -127,6 +127,7 @@ void ResourceImporterDynamicFont::get_import_options(const String &p_path, List<
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "compress"), true));
 
 	// Hide from the main UI, only for advanced import dialog.
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "preload_sideways", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::ARRAY, "preload", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), Array()));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::DICTIONARY, "language_support", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), Dictionary()));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::DICTIONARY, "script_support", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), Dictionary()));
@@ -149,6 +150,7 @@ Error ResourceImporterDynamicFont::import(const String &p_source_file, const Str
 	int px_range = p_options["msdf_pixel_range"];
 	int px_size = p_options["msdf_size"];
 	Dictionary ot_ov = p_options["opentype_features"];
+	bool preload_sideways = p_options["preload_sideways"];
 
 	bool autohinter = p_options["force_autohinter"];
 	bool allow_system_fallback = p_options["allow_system_fallback"];
@@ -209,7 +211,7 @@ Error ResourceImporterDynamicFont::import(const String &p_source_file, const Str
 		Array chars = preload_config["chars"];
 		for (int j = 0; j < chars.size(); j++) {
 			char32_t c = chars[j].operator int();
-			TS->font_render_range(conf_rid, size, c, c);
+			TS->font_render_range(conf_rid, size, c, c, preload_sideways);
 		}
 
 		Array glyphs = preload_config["glyphs"];

--- a/modules/text_server_adv/script_iterator.cpp
+++ b/modules/text_server_adv/script_iterator.cpp
@@ -65,7 +65,7 @@ ScriptIterator::ScriptIterator(const String &p_string, int p_start, int p_length
 		script_code = USCRIPT_COMMON;
 		for (script_start = script_end; script_end < p_length; script_end++) {
 			UChar32 ch = str[script_end];
-			UScriptCode sc = uscript_getScript(ch, &err);
+			UScriptCode sc = is_digit(ch) ? USCRIPT_CODE_LIMIT : uscript_getScript(ch, &err);
 			if (U_FAILURE(err)) {
 				memfree(paren_stack);
 				ERR_FAIL_MSG(u_errorName(err));
@@ -117,7 +117,7 @@ ScriptIterator::ScriptIterator(const String &p_string, int p_start, int p_length
 		}
 
 		ScriptRange rng;
-		rng.script = hb_icu_script_to_script(script_code);
+		rng.script = (script_code == USCRIPT_CODE_LIMIT) ? HB_SCRIPT_COMMON : hb_icu_script_to_script(script_code);
 		rng.start = script_start;
 		rng.end = script_end;
 

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -609,8 +609,8 @@ class TextServerAdvanced : public TextServerExtension {
 	int64_t _convert_pos(const ShapedTextDataAdvanced *p_sd, int64_t p_pos) const;
 	int64_t _convert_pos_inv(const ShapedTextDataAdvanced *p_sd, int64_t p_pos) const;
 	bool _shape_substr(ShapedTextDataAdvanced *p_new_sd, const ShapedTextDataAdvanced *p_sd, int64_t p_start, int64_t p_length) const;
-	void _shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_start, int64_t p_end, hb_script_t p_script, hb_direction_t p_direction, TypedArray<RID> p_fonts, int64_t p_span, int64_t p_fb_index, int64_t p_prev_start, int64_t p_prev_end);
-	Glyph _shape_single_glyph(ShapedTextDataAdvanced *p_sd, char32_t p_char, hb_script_t p_script, hb_direction_t p_direction, const RID &p_font, int64_t p_font_size);
+	void _shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_start, int64_t p_end, hb_script_t p_script, hb_direction_t p_direction, TypedArray<RID> p_fonts, int64_t p_span, int64_t p_fb_index, int64_t p_prev_start, int64_t p_prev_end, GlyphRotation p_rot);
+	Glyph _shape_single_glyph(ShapedTextDataAdvanced *p_sd, char32_t p_char, hb_script_t p_script, hb_direction_t p_direction, const RID &p_font, int64_t p_font_size, GlyphRotation p_rot);
 
 	_FORCE_INLINE_ void _add_featuers(const Dictionary &p_source, Vector<hb_feature_t> &r_ftrs);
 
@@ -814,8 +814,8 @@ public:
 	MODBIND2RC(bool, font_has_char, const RID &, int64_t);
 	MODBIND1RC(String, font_get_supported_chars, const RID &);
 
-	MODBIND4(font_render_range, const RID &, const Vector2i &, int64_t, int64_t);
-	MODBIND3(font_render_glyph, const RID &, const Vector2i &, int64_t);
+	MODBIND5(font_render_range, const RID &, const Vector2i &, int64_t, int64_t, bool);
+	MODBIND4(font_render_glyph, const RID &, const Vector2i &, int64_t, bool);
 
 	MODBIND6C(font_draw_glyph, const RID &, const RID &, int64_t, const Vector2 &, int64_t, const Color &);
 	MODBIND7C(font_draw_glyph_outline, const RID &, const RID &, int64_t, int64_t, const Vector2 &, int64_t, const Color &);
@@ -905,6 +905,7 @@ public:
 	MODBIND2RC(Rect2, shaped_text_get_object_rect, const RID &, const Variant &);
 
 	MODBIND1RC(Size2, shaped_text_get_size, const RID &);
+	MODBIND1RC(Size2, shaped_text_get_vertical_bounds, const RID &);
 	MODBIND1RC(double, shaped_text_get_ascent, const RID &);
 	MODBIND1RC(double, shaped_text_get_descent, const RID &);
 	MODBIND1RC(double, shaped_text_get_width, const RID &);

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -603,7 +603,7 @@ _FORCE_INLINE_ TextServerFallback::FontGlyph TextServerFallback::rasterize_bitma
 _FORCE_INLINE_ bool TextServerFallback::_ensure_glyph(FontFallback *p_font_data, const Vector2i &p_size, int32_t p_glyph) const {
 	ERR_FAIL_COND_V(!_ensure_cache_for_size(p_font_data, p_size), false);
 
-	int32_t glyph_index = p_glyph & 0xffffff; // Remove subpixel shifts.
+	int32_t glyph_index = p_glyph & 0x1fffff; // Extract glyph index.
 
 	FontForSizeFallback *fd = p_font_data->cache[p_size];
 	if (fd->glyph_map.has(p_glyph)) {
@@ -655,10 +655,10 @@ _FORCE_INLINE_ bool TextServerFallback::_ensure_glyph(FontFallback *p_font_data,
 
 		if (!p_font_data->msdf) {
 			if ((p_font_data->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (p_font_data->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && p_size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE)) {
-				FT_Pos xshift = (int)((p_glyph >> 27) & 3) << 4;
+				FT_Pos xshift = (int)((p_glyph >> 29) & 3) << 4;
 				FT_Outline_Translate(&fd->face->glyph->outline, xshift, 0);
 			} else if ((p_font_data->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (p_font_data->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && p_size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE)) {
-				FT_Pos xshift = (int)((p_glyph >> 27) & 3) << 5;
+				FT_Pos xshift = (int)((p_glyph >> 29) & 3) << 5;
 				FT_Outline_Translate(&fd->face->glyph->outline, xshift, 0);
 			}
 		}
@@ -683,7 +683,7 @@ _FORCE_INLINE_ bool TextServerFallback::_ensure_glyph(FontFallback *p_font_data,
 				aa_mode = FT_RENDER_MODE_NORMAL;
 			} break;
 			case FONT_ANTIALIASING_LCD: {
-				int aa_layout = (int)((p_glyph >> 24) & 7);
+				int aa_layout = (int)((p_glyph >> 26) & 7);
 				switch (aa_layout) {
 					case FONT_LCD_SUBPIXEL_LAYOUT_HRGB: {
 						aa_mode = FT_RENDER_MODE_LCD;
@@ -1732,7 +1732,7 @@ Vector2 TextServerFallback::_font_get_glyph_advance(const RID &p_font_rid, int64
 	if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
 		TextServer::FontLCDSubpixelLayout layout = (TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout");
 		if (layout != FONT_LCD_SUBPIXEL_LAYOUT_NONE) {
-			mod = (layout << 24);
+			mod = (layout << 26);
 		}
 	}
 
@@ -1785,7 +1785,7 @@ Vector2 TextServerFallback::_font_get_glyph_offset(const RID &p_font_rid, const 
 	if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
 		TextServer::FontLCDSubpixelLayout layout = (TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout");
 		if (layout != FONT_LCD_SUBPIXEL_LAYOUT_NONE) {
-			mod = (layout << 24);
+			mod = (layout << 26);
 		}
 	}
 
@@ -1830,7 +1830,7 @@ Vector2 TextServerFallback::_font_get_glyph_size(const RID &p_font_rid, const Ve
 	if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
 		TextServer::FontLCDSubpixelLayout layout = (TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout");
 		if (layout != FONT_LCD_SUBPIXEL_LAYOUT_NONE) {
-			mod = (layout << 24);
+			mod = (layout << 26);
 		}
 	}
 
@@ -1875,7 +1875,7 @@ Rect2 TextServerFallback::_font_get_glyph_uv_rect(const RID &p_font_rid, const V
 	if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
 		TextServer::FontLCDSubpixelLayout layout = (TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout");
 		if (layout != FONT_LCD_SUBPIXEL_LAYOUT_NONE) {
-			mod = (layout << 24);
+			mod = (layout << 26);
 		}
 	}
 
@@ -1915,7 +1915,7 @@ int64_t TextServerFallback::_font_get_glyph_texture_idx(const RID &p_font_rid, c
 	if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
 		TextServer::FontLCDSubpixelLayout layout = (TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout");
 		if (layout != FONT_LCD_SUBPIXEL_LAYOUT_NONE) {
-			mod = (layout << 24);
+			mod = (layout << 26);
 		}
 	}
 
@@ -1955,7 +1955,7 @@ RID TextServerFallback::_font_get_glyph_texture_rid(const RID &p_font_rid, const
 	if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
 		TextServer::FontLCDSubpixelLayout layout = (TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout");
 		if (layout != FONT_LCD_SUBPIXEL_LAYOUT_NONE) {
-			mod = (layout << 24);
+			mod = (layout << 26);
 		}
 	}
 
@@ -2001,7 +2001,7 @@ Size2 TextServerFallback::_font_get_glyph_texture_size(const RID &p_font_rid, co
 	if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
 		TextServer::FontLCDSubpixelLayout layout = (TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout");
 		if (layout != FONT_LCD_SUBPIXEL_LAYOUT_NONE) {
-			mod = (layout << 24);
+			mod = (layout << 26);
 		}
 	}
 
@@ -2047,7 +2047,7 @@ Dictionary TextServerFallback::_font_get_glyph_contours(const RID &p_font_rid, i
 	PackedVector3Array points;
 	PackedInt32Array contours;
 
-	int32_t index = p_index & 0xffffff; // Remove subpixel shifts.
+	int32_t index = p_index & 0x1fffff; // Extract glyph index.
 
 	int error = FT_Load_Glyph(fd->cache[size]->face, FT_Get_Char_Index(fd->cache[size]->face, index), FT_LOAD_NO_BITMAP | (fd->force_autohinter ? FT_LOAD_FORCE_AUTOHINT : 0));
 	ERR_FAIL_COND_V(error, Dictionary());
@@ -2227,7 +2227,7 @@ String TextServerFallback::_font_get_supported_chars(const RID &p_font_rid) cons
 	return chars;
 }
 
-void TextServerFallback::_font_render_range(const RID &p_font_rid, const Vector2i &p_size, int64_t p_start, int64_t p_end) {
+void TextServerFallback::_font_render_range(const RID &p_font_rid, const Vector2i &p_size, int64_t p_start, int64_t p_end, bool p_include_sideways) {
 	FontFallback *fd = font_owner.get_or_null(p_font_rid);
 	ERR_FAIL_COND(!fd);
 	ERR_FAIL_COND_MSG((p_start >= 0xd800 && p_start <= 0xdfff) || (p_start > 0x10ffff), "Unicode parsing error: Invalid unicode codepoint " + String::num_int64(p_start, 16) + ".");
@@ -2245,15 +2245,15 @@ void TextServerFallback::_font_render_range(const RID &p_font_rid, const Vector2
 			} else {
 				for (int aa = 0; aa < ((fd->antialiasing == FONT_ANTIALIASING_LCD) ? FONT_LCD_SUBPIXEL_LAYOUT_MAX : 1); aa++) {
 					if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE)) {
-						_ensure_glyph(fd, size, (int32_t)idx | (0 << 27) | (aa << 24));
-						_ensure_glyph(fd, size, (int32_t)idx | (1 << 27) | (aa << 24));
-						_ensure_glyph(fd, size, (int32_t)idx | (2 << 27) | (aa << 24));
-						_ensure_glyph(fd, size, (int32_t)idx | (3 << 27) | (aa << 24));
+						_ensure_glyph(fd, size, (int32_t)idx | (0 << 29) | (aa << 26));
+						_ensure_glyph(fd, size, (int32_t)idx | (1 << 29) | (aa << 26));
+						_ensure_glyph(fd, size, (int32_t)idx | (2 << 29) | (aa << 26));
+						_ensure_glyph(fd, size, (int32_t)idx | (3 << 29) | (aa << 26));
 					} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE)) {
-						_ensure_glyph(fd, size, (int32_t)idx | (1 << 27) | (aa << 24));
-						_ensure_glyph(fd, size, (int32_t)idx | (0 << 27) | (aa << 24));
+						_ensure_glyph(fd, size, (int32_t)idx | (1 << 29) | (aa << 26));
+						_ensure_glyph(fd, size, (int32_t)idx | (0 << 29) | (aa << 26));
 					} else {
-						_ensure_glyph(fd, size, (int32_t)idx | (aa << 24));
+						_ensure_glyph(fd, size, (int32_t)idx | (aa << 26));
 					}
 				}
 			}
@@ -2262,7 +2262,7 @@ void TextServerFallback::_font_render_range(const RID &p_font_rid, const Vector2
 	}
 }
 
-void TextServerFallback::_font_render_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_index) {
+void TextServerFallback::_font_render_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_index, bool p_include_sideways) {
 	FontFallback *fd = font_owner.get_or_null(p_font_rid);
 	ERR_FAIL_COND(!fd);
 
@@ -2270,22 +2270,22 @@ void TextServerFallback::_font_render_glyph(const RID &p_font_rid, const Vector2
 	Vector2i size = _get_size_outline(fd, p_size);
 	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
 #ifdef MODULE_FREETYPE_ENABLED
-	int32_t idx = p_index & 0xffffff; // Remove subpixel shifts.
+	int32_t idx = p_index & 0x1fffff; // Extract glyph index.
 	if (fd->cache[size]->face) {
 		if (fd->msdf) {
 			_ensure_glyph(fd, size, (int32_t)idx);
 		} else {
 			for (int aa = 0; aa < ((fd->antialiasing == FONT_ANTIALIASING_LCD) ? FONT_LCD_SUBPIXEL_LAYOUT_MAX : 1); aa++) {
 				if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE)) {
-					_ensure_glyph(fd, size, (int32_t)idx | (0 << 27) | (aa << 24));
-					_ensure_glyph(fd, size, (int32_t)idx | (1 << 27) | (aa << 24));
-					_ensure_glyph(fd, size, (int32_t)idx | (2 << 27) | (aa << 24));
-					_ensure_glyph(fd, size, (int32_t)idx | (3 << 27) | (aa << 24));
+					_ensure_glyph(fd, size, (int32_t)idx | (0 << 29) | (aa << 26));
+					_ensure_glyph(fd, size, (int32_t)idx | (1 << 29) | (aa << 26));
+					_ensure_glyph(fd, size, (int32_t)idx | (2 << 29) | (aa << 26));
+					_ensure_glyph(fd, size, (int32_t)idx | (3 << 29) | (aa << 26));
 				} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE)) {
-					_ensure_glyph(fd, size, (int32_t)idx | (1 << 27) | (aa << 24));
-					_ensure_glyph(fd, size, (int32_t)idx | (0 << 27) | (aa << 24));
+					_ensure_glyph(fd, size, (int32_t)idx | (1 << 29) | (aa << 26));
+					_ensure_glyph(fd, size, (int32_t)idx | (0 << 29) | (aa << 26));
 				} else {
-					_ensure_glyph(fd, size, (int32_t)idx | (aa << 24));
+					_ensure_glyph(fd, size, (int32_t)idx | (aa << 26));
 				}
 			}
 		}
@@ -2301,26 +2301,26 @@ void TextServerFallback::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 	Vector2i size = _get_size(fd, p_size);
 	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
 
-	int32_t index = p_index & 0xffffff; // Remove subpixel shifts.
+	int32_t index = p_index & 0x3ffffff; // Remove subpixel shifts and LCD AA data (keep rotation bits).
 	bool lcd_aa = false;
 
 #ifdef MODULE_FREETYPE_ENABLED
 	if (!fd->msdf && fd->cache[size]->face) {
-		// LCD layout, bits 24, 25, 26
+		// LCD layout, bits 26-28.
 		if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
 			TextServer::FontLCDSubpixelLayout layout = (TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout");
 			if (layout != FONT_LCD_SUBPIXEL_LAYOUT_NONE) {
 				lcd_aa = true;
-				index = index | (layout << 24);
+				index = index | (layout << 26);
 			}
 		}
-		// Subpixel X-shift, bits 27, 28
+		// Subpixel X-shift, bits 29-30.
 		if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE)) {
 			int xshift = (int)(Math::floor(4 * (p_pos.x + 0.125)) - 4 * Math::floor(p_pos.x + 0.125));
-			index = index | (xshift << 27);
+			index = index | (xshift << 29);
 		} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE)) {
 			int xshift = (int)(Math::floor(2 * (p_pos.x + 0.25)) - 2 * Math::floor(p_pos.x + 0.25));
-			index = index | (xshift << 27);
+			index = index | (xshift << 29);
 		}
 	}
 #endif
@@ -2393,26 +2393,26 @@ void TextServerFallback::_font_draw_glyph_outline(const RID &p_font_rid, const R
 	Vector2i size = _get_size_outline(fd, Vector2i(p_size, p_outline_size));
 	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
 
-	int32_t index = p_index & 0xffffff; // Remove subpixel shifts.
+	int32_t index = p_index & 0x3ffffff; // Remove subpixel shifts and LCD AA data (keep rotation bits).
 	bool lcd_aa = false;
 
 #ifdef MODULE_FREETYPE_ENABLED
 	if (!fd->msdf && fd->cache[size]->face) {
-		// LCD layout, bits 24, 25, 26
+		// LCD layout, bits 26-28.
 		if (fd->antialiasing == FONT_ANTIALIASING_LCD) {
 			TextServer::FontLCDSubpixelLayout layout = (TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout");
 			if (layout != FONT_LCD_SUBPIXEL_LAYOUT_NONE) {
 				lcd_aa = true;
-				index = index | (layout << 24);
+				index = index | (layout << 26);
 			}
 		}
-		// Subpixel X-shift, bits 27, 28
+		// Subpixel X-shift, bits 29-30.
 		if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE)) {
 			int xshift = (int)(Math::floor(4 * (p_pos.x + 0.125)) - 4 * Math::floor(p_pos.x + 0.125));
-			index = index | (xshift << 27);
+			index = index | (xshift << 29);
 		} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE)) {
 			int xshift = (int)(Math::floor(2 * (p_pos.x + 0.25)) - 2 * Math::floor(p_pos.x + 0.25));
-			index = index | (xshift << 27);
+			index = index | (xshift << 29);
 		}
 	}
 #endif
@@ -2680,7 +2680,9 @@ RID TextServerFallback::_create_shaped_text(TextServer::Direction p_direction, T
 
 	ShapedTextDataFallback *sd = memnew(ShapedTextDataFallback);
 	sd->direction = p_direction;
-	sd->orientation = p_orientation;
+	if (p_orientation == ORIENTATION_HORIZONTAL) {
+		ERR_PRINT_ONCE("Vertical layout is not supported by this text server.");
+	}
 
 	return shaped_owner.make_rid(sd);
 }
@@ -2738,13 +2740,8 @@ void TextServerFallback::_shaped_text_set_orientation(const RID &p_shaped, TextS
 	ShapedTextDataFallback *sd = shaped_owner.get_or_null(p_shaped);
 	ERR_FAIL_COND(!sd);
 
-	MutexLock lock(sd->mutex);
-	if (sd->orientation != p_orientation) {
-		if (sd->parent != RID()) {
-			full_copy(sd);
-		}
-		sd->orientation = p_orientation;
-		invalidate(sd);
+	if (p_orientation == ORIENTATION_HORIZONTAL) {
+		ERR_PRINT_ONCE("Vertical layout is not supported by this text server.");
 	}
 }
 
@@ -2753,11 +2750,7 @@ void TextServerFallback::_shaped_text_set_bidi_override(const RID &p_shaped, con
 }
 
 TextServer::Orientation TextServerFallback::_shaped_text_get_orientation(const RID &p_shaped) const {
-	const ShapedTextDataFallback *sd = shaped_owner.get_or_null(p_shaped);
-	ERR_FAIL_COND_V(!sd, TextServer::ORIENTATION_HORIZONTAL);
-
-	MutexLock lock(sd->mutex);
-	return sd->orientation;
+	return ORIENTATION_HORIZONTAL;
 }
 
 void TextServerFallback::_shaped_text_set_preserve_invalid(const RID &p_shaped, bool p_enabled) {
@@ -2979,34 +2972,19 @@ bool TextServerFallback::_shaped_text_resize_object(const RID &p_shaped, const V
 				}
 			}
 			if (key != Variant()) {
-				if (sd->orientation == ORIENTATION_HORIZONTAL) {
-					sd->objects[key].rect.position.x = sd->width;
-					sd->width += sd->objects[key].rect.size.x;
-					sd->glyphs.write[i].advance = sd->objects[key].rect.size.x;
-				} else {
-					sd->objects[key].rect.position.y = sd->width;
-					sd->width += sd->objects[key].rect.size.y;
-					sd->glyphs.write[i].advance = sd->objects[key].rect.size.y;
-				}
+				sd->objects[key].rect.position.x = sd->width;
+				sd->width += sd->objects[key].rect.size.x;
+				sd->glyphs.write[i].advance = sd->objects[key].rect.size.x;
 			} else {
 				if (gl.font_rid.is_valid()) {
-					if (sd->orientation == ORIENTATION_HORIZONTAL) {
-						sd->ascent = MAX(sd->ascent, _font_get_ascent(gl.font_rid, gl.font_size));
-						sd->descent = MAX(sd->descent, _font_get_descent(gl.font_rid, gl.font_size));
-					} else {
-						sd->ascent = MAX(sd->ascent, Math::round(_font_get_glyph_advance(gl.font_rid, gl.font_size, gl.index).x * 0.5));
-						sd->descent = MAX(sd->descent, Math::round(_font_get_glyph_advance(gl.font_rid, gl.font_size, gl.index).x * 0.5));
-					}
+					sd->ascent = MAX(sd->ascent, _font_get_ascent(gl.font_rid, gl.font_size));
+					sd->descent = MAX(sd->descent, _font_get_descent(gl.font_rid, gl.font_size));
+
 					sd->upos = MAX(sd->upos, _font_get_underline_position(gl.font_rid, gl.font_size));
 					sd->uthk = MAX(sd->uthk, _font_get_underline_thickness(gl.font_rid, gl.font_size));
 				} else if (sd->preserve_invalid || (sd->preserve_control && is_control(gl.index))) {
 					// Glyph not found, replace with hex code box.
-					if (sd->orientation == ORIENTATION_HORIZONTAL) {
-						sd->ascent = MAX(sd->ascent, get_hex_code_box_size(gl.font_size, gl.index).y);
-					} else {
-						sd->ascent = MAX(sd->ascent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5));
-						sd->descent = MAX(sd->descent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5));
-					}
+					sd->ascent = MAX(sd->ascent, get_hex_code_box_size(gl.font_size, gl.index).y);
 				}
 				sd->width += gl.advance * gl.repeat;
 			}
@@ -3022,69 +3000,36 @@ void TextServerFallback::_realign(ShapedTextDataFallback *p_sd) const {
 	double full_descent = p_sd->descent;
 	for (KeyValue<Variant, ShapedTextDataFallback::EmbeddedObject> &E : p_sd->objects) {
 		if ((E.value.pos >= p_sd->start) && (E.value.pos < p_sd->end)) {
-			if (p_sd->orientation == ORIENTATION_HORIZONTAL) {
-				switch (E.value.inline_align & INLINE_ALIGNMENT_TEXT_MASK) {
-					case INLINE_ALIGNMENT_TO_TOP: {
-						E.value.rect.position.y = -p_sd->ascent;
-					} break;
-					case INLINE_ALIGNMENT_TO_CENTER: {
-						E.value.rect.position.y = (-p_sd->ascent + p_sd->descent) / 2;
-					} break;
-					case INLINE_ALIGNMENT_TO_BASELINE: {
-						E.value.rect.position.y = 0;
-					} break;
-					case INLINE_ALIGNMENT_TO_BOTTOM: {
-						E.value.rect.position.y = p_sd->descent;
-					} break;
-				}
-				switch (E.value.inline_align & INLINE_ALIGNMENT_IMAGE_MASK) {
-					case INLINE_ALIGNMENT_BOTTOM_TO: {
-						E.value.rect.position.y -= E.value.rect.size.y;
-					} break;
-					case INLINE_ALIGNMENT_CENTER_TO: {
-						E.value.rect.position.y -= E.value.rect.size.y / 2;
-					} break;
-					case INLINE_ALIGNMENT_BASELINE_TO: {
-						E.value.rect.position.y -= E.value.baseline;
-					} break;
-					case INLINE_ALIGNMENT_TOP_TO: {
-						// NOP
-					} break;
-				}
-				full_ascent = MAX(full_ascent, -E.value.rect.position.y);
-				full_descent = MAX(full_descent, E.value.rect.position.y + E.value.rect.size.y);
-			} else {
-				switch (E.value.inline_align & INLINE_ALIGNMENT_TEXT_MASK) {
-					case INLINE_ALIGNMENT_TO_TOP: {
-						E.value.rect.position.x = -p_sd->ascent;
-					} break;
-					case INLINE_ALIGNMENT_TO_CENTER: {
-						E.value.rect.position.x = (-p_sd->ascent + p_sd->descent) / 2;
-					} break;
-					case INLINE_ALIGNMENT_TO_BASELINE: {
-						E.value.rect.position.x = 0;
-					} break;
-					case INLINE_ALIGNMENT_TO_BOTTOM: {
-						E.value.rect.position.x = p_sd->descent;
-					} break;
-				}
-				switch (E.value.inline_align & INLINE_ALIGNMENT_IMAGE_MASK) {
-					case INLINE_ALIGNMENT_BOTTOM_TO: {
-						E.value.rect.position.x -= E.value.rect.size.x;
-					} break;
-					case INLINE_ALIGNMENT_CENTER_TO: {
-						E.value.rect.position.x -= E.value.rect.size.x / 2;
-					} break;
-					case INLINE_ALIGNMENT_BASELINE_TO: {
-						E.value.rect.position.x -= E.value.baseline;
-					} break;
-					case INLINE_ALIGNMENT_TOP_TO: {
-						// NOP
-					} break;
-				}
-				full_ascent = MAX(full_ascent, -E.value.rect.position.x);
-				full_descent = MAX(full_descent, E.value.rect.position.x + E.value.rect.size.x);
+			switch (E.value.inline_align & INLINE_ALIGNMENT_TEXT_MASK) {
+				case INLINE_ALIGNMENT_TO_TOP: {
+					E.value.rect.position.y = -p_sd->ascent;
+				} break;
+				case INLINE_ALIGNMENT_TO_CENTER: {
+					E.value.rect.position.y = (-p_sd->ascent + p_sd->descent) / 2;
+				} break;
+				case INLINE_ALIGNMENT_TO_BASELINE: {
+					E.value.rect.position.y = 0;
+				} break;
+				case INLINE_ALIGNMENT_TO_BOTTOM: {
+					E.value.rect.position.y = p_sd->descent;
+				} break;
 			}
+			switch (E.value.inline_align & INLINE_ALIGNMENT_IMAGE_MASK) {
+				case INLINE_ALIGNMENT_BOTTOM_TO: {
+					E.value.rect.position.y -= E.value.rect.size.y;
+				} break;
+				case INLINE_ALIGNMENT_CENTER_TO: {
+					E.value.rect.position.y -= E.value.rect.size.y / 2;
+				} break;
+				case INLINE_ALIGNMENT_BASELINE_TO: {
+					E.value.rect.position.y -= E.value.baseline;
+				} break;
+				case INLINE_ALIGNMENT_TOP_TO: {
+					// NOP
+				} break;
+			}
+			full_ascent = MAX(full_ascent, -E.value.rect.position.y);
+			full_descent = MAX(full_descent, E.value.rect.position.y + E.value.rect.size.y);
 		}
 	}
 	p_sd->ascent = full_ascent;
@@ -3113,7 +3058,6 @@ RID TextServerFallback::_shaped_text_substr(const RID &p_shaped, int64_t p_start
 	new_sd->start = p_start;
 	new_sd->end = p_start + p_length;
 
-	new_sd->orientation = sd->orientation;
 	new_sd->direction = sd->direction;
 	new_sd->custom_punct = sd->custom_punct;
 	new_sd->para_direction = sd->para_direction;
@@ -3147,30 +3091,15 @@ RID TextServerFallback::_shaped_text_substr(const RID &p_shaped, int64_t p_start
 					}
 				}
 				if (find_embedded) {
-					if (new_sd->orientation == ORIENTATION_HORIZONTAL) {
-						new_sd->objects[key].rect.position.x = new_sd->width;
-						new_sd->width += new_sd->objects[key].rect.size.x;
-					} else {
-						new_sd->objects[key].rect.position.y = new_sd->width;
-						new_sd->width += new_sd->objects[key].rect.size.y;
-					}
+					new_sd->objects[key].rect.position.x = new_sd->width;
+					new_sd->width += new_sd->objects[key].rect.size.x;
 				} else {
 					if (gl.font_rid.is_valid()) {
-						if (new_sd->orientation == ORIENTATION_HORIZONTAL) {
-							new_sd->ascent = MAX(new_sd->ascent, _font_get_ascent(gl.font_rid, gl.font_size));
-							new_sd->descent = MAX(new_sd->descent, _font_get_descent(gl.font_rid, gl.font_size));
-						} else {
-							new_sd->ascent = MAX(new_sd->ascent, Math::round(_font_get_glyph_advance(gl.font_rid, gl.font_size, gl.index).x * 0.5));
-							new_sd->descent = MAX(new_sd->descent, Math::round(_font_get_glyph_advance(gl.font_rid, gl.font_size, gl.index).x * 0.5));
-						}
+						new_sd->ascent = MAX(new_sd->ascent, _font_get_ascent(gl.font_rid, gl.font_size));
+						new_sd->descent = MAX(new_sd->descent, _font_get_descent(gl.font_rid, gl.font_size));
 					} else if (new_sd->preserve_invalid || (new_sd->preserve_control && is_control(gl.index))) {
 						// Glyph not found, replace with hex code box.
-						if (new_sd->orientation == ORIENTATION_HORIZONTAL) {
-							new_sd->ascent = MAX(new_sd->ascent, get_hex_code_box_size(gl.font_size, gl.index).y);
-						} else {
-							new_sd->ascent = MAX(new_sd->ascent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5));
-							new_sd->descent = MAX(new_sd->descent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5));
-						}
+						new_sd->ascent = MAX(new_sd->ascent, get_hex_code_box_size(gl.font_size, gl.index).y);
 					}
 					new_sd->width += gl.advance * gl.repeat;
 				}
@@ -3650,24 +3579,16 @@ bool TextServerFallback::_shaped_text_shape(const RID &p_shaped) {
 		const ShapedTextDataFallback::Span &span = sd->spans[i];
 		if (span.embedded_key != Variant()) {
 			// Embedded object.
-			if (sd->orientation == ORIENTATION_HORIZONTAL) {
-				sd->objects[span.embedded_key].rect.position.x = sd->width;
-				sd->width += sd->objects[span.embedded_key].rect.size.x;
-			} else {
-				sd->objects[span.embedded_key].rect.position.y = sd->width;
-				sd->width += sd->objects[span.embedded_key].rect.size.y;
-			}
+			sd->objects[span.embedded_key].rect.position.x = sd->width;
+			sd->width += sd->objects[span.embedded_key].rect.size.x;
+
 			Glyph gl;
 			gl.start = span.start;
 			gl.end = span.end;
 			gl.count = 1;
 			gl.index = 0;
 			gl.flags = GRAPHEME_IS_VALID | GRAPHEME_IS_VIRTUAL;
-			if (sd->orientation == ORIENTATION_HORIZONTAL) {
-				gl.advance = sd->objects[span.embedded_key].rect.size.x;
-			} else {
-				gl.advance = sd->objects[span.embedded_key].rect.size.y;
-			}
+			gl.advance = sd->objects[span.embedded_key].rect.size.x;
 			sd->glyphs.push_back(gl);
 		} else {
 			// Text span.
@@ -3861,19 +3782,11 @@ bool TextServerFallback::_shaped_text_shape(const RID &p_shaped) {
 				if (gl.font_rid.is_valid()) {
 					bool subpos = (scale != 1.0) || (_font_get_subpixel_positioning(gl.font_rid) == SUBPIXEL_POSITIONING_ONE_HALF) || (_font_get_subpixel_positioning(gl.font_rid) == SUBPIXEL_POSITIONING_ONE_QUARTER) || (_font_get_subpixel_positioning(gl.font_rid) == SUBPIXEL_POSITIONING_AUTO && gl.font_size <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE);
 					if (sd->text[j - sd->start] != 0 && !is_linebreak(sd->text[j - sd->start])) {
-						if (sd->orientation == ORIENTATION_HORIZONTAL) {
-							gl.advance = _font_get_glyph_advance(gl.font_rid, gl.font_size, gl.index).x;
-							gl.x_off = 0;
-							gl.y_off = 0;
-							sd->ascent = MAX(sd->ascent, _font_get_ascent(gl.font_rid, gl.font_size));
-							sd->descent = MAX(sd->descent, _font_get_descent(gl.font_rid, gl.font_size));
-						} else {
-							gl.advance = _font_get_glyph_advance(gl.font_rid, gl.font_size, gl.index).y;
-							gl.x_off = -Math::round(_font_get_glyph_advance(gl.font_rid, gl.font_size, gl.index).x * 0.5);
-							gl.y_off = _font_get_ascent(gl.font_rid, gl.font_size);
-							sd->ascent = MAX(sd->ascent, Math::round(_font_get_glyph_advance(gl.font_rid, gl.font_size, gl.index).x * 0.5));
-							sd->descent = MAX(sd->descent, Math::round(_font_get_glyph_advance(gl.font_rid, gl.font_size, gl.index).x * 0.5));
-						}
+						gl.advance = _font_get_glyph_advance(gl.font_rid, gl.font_size, gl.index).x;
+						gl.x_off = 0;
+						gl.y_off = 0;
+						sd->ascent = MAX(sd->ascent, _font_get_ascent(gl.font_rid, gl.font_size));
+						sd->descent = MAX(sd->descent, _font_get_descent(gl.font_rid, gl.font_size));
 					}
 					if (j < sd->end - 1) {
 						// Do not add extra spacing to the last glyph of the string.
@@ -3890,26 +3803,16 @@ bool TextServerFallback::_shaped_text_shape(const RID &p_shaped) {
 					if (sd->glyphs.size() > 0) {
 						Glyph &prev_gl = sd->glyphs.write[sd->glyphs.size() - 1];
 						if (prev_gl.font_rid == gl.font_rid && prev_gl.font_size == gl.font_size) {
-							if (sd->orientation == ORIENTATION_HORIZONTAL) {
-								prev_gl.advance += _font_get_kerning(gl.font_rid, gl.font_size, Vector2i(prev_gl.index, gl.index)).x;
-							} else {
-								prev_gl.advance += _font_get_kerning(gl.font_rid, gl.font_size, Vector2i(prev_gl.index, gl.index)).y;
-							}
+							prev_gl.advance += _font_get_kerning(gl.font_rid, gl.font_size, Vector2i(prev_gl.index, gl.index)).x;
 						}
 					}
-					if (sd->orientation == ORIENTATION_HORIZONTAL && !subpos) {
+					if (!subpos) {
 						gl.advance = Math::round(gl.advance);
 					}
 				} else if (sd->preserve_invalid || (sd->preserve_control && is_control(gl.index))) {
 					// Glyph not found, replace with hex code box.
-					if (sd->orientation == ORIENTATION_HORIZONTAL) {
-						gl.advance = get_hex_code_box_size(gl.font_size, gl.index).x;
-						sd->ascent = MAX(sd->ascent, get_hex_code_box_size(gl.font_size, gl.index).y);
-					} else {
-						gl.advance = get_hex_code_box_size(gl.font_size, gl.index).y;
-						sd->ascent = MAX(sd->ascent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5));
-						sd->descent = MAX(sd->descent, Math::round(get_hex_code_box_size(gl.font_size, gl.index).x * 0.5));
-					}
+					gl.advance = get_hex_code_box_size(gl.font_size, gl.index).x;
+					sd->ascent = MAX(sd->ascent, get_hex_code_box_size(gl.font_size, gl.index).y);
 				}
 				sd->width += gl.advance;
 				sd->glyphs.push_back(gl);
@@ -4007,11 +3910,48 @@ Size2 TextServerFallback::_shaped_text_get_size(const RID &p_shaped) const {
 	if (!sd->valid) {
 		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
 	}
-	if (sd->orientation == TextServer::ORIENTATION_HORIZONTAL) {
-		return Size2(sd->width, sd->ascent + sd->descent + sd->extra_spacing[SPACING_TOP] + sd->extra_spacing[SPACING_BOTTOM]).ceil();
-	} else {
-		return Size2(sd->ascent + sd->descent + sd->extra_spacing[SPACING_TOP] + sd->extra_spacing[SPACING_BOTTOM], sd->width).ceil();
+	return Size2(sd->width, sd->ascent + sd->descent + sd->extra_spacing[SPACING_TOP] + sd->extra_spacing[SPACING_BOTTOM]).ceil();
+}
+
+Size2 TextServerFallback::_shaped_text_get_vertical_bounds(const RID &p_shaped) const {
+	const ShapedTextDataFallback *sd = shaped_owner.get_or_null(p_shaped);
+	ERR_FAIL_COND_V(!sd, Size2());
+
+	MutexLock lock(sd->mutex);
+	if (!sd->valid) {
+		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
 	}
+	int sd_size = sd->glyphs.size();
+	const Glyph *sd_glyphs = sd->glyphs.ptr();
+
+	float max_ascent = 0.0;
+	float max_descent = 0.0;
+
+	for (int i = 0; i < sd_size; i++) {
+		int size = sd_glyphs[i].font_size;
+		if (sd_glyphs[i].font_rid != RID() && size > 0) {
+			FontFallback *fd = font_owner.get_or_null(sd_glyphs[i].font_rid);
+			ERR_FAIL_COND_V(!fd, Size2());
+
+			int32_t index = sd_glyphs[i].index & 0x3ffffff; // Remove subpixel shifts and LCD AA data (keep rotation bits).
+			_ensure_glyph(fd, Vector2i(size, 0), index);
+			const FontGlyph &gl = fd->cache[Vector2i(size, 0)]->glyph_map[index];
+			if (gl.found) {
+				if (fd->msdf) {
+					Size2 csize = gl.rect.size * (double)size / (double)fd->msdf_source_size;
+					Point2 cpos = gl.rect.position * (double)size / (double)fd->msdf_source_size;
+					max_ascent = MAX(max_ascent, -cpos.y);
+					max_descent = MAX(max_descent, csize.y + cpos.y);
+				} else {
+					Size2 csize = gl.rect.size;
+					Point2 cpos = gl.rect.position;
+					max_ascent = MAX(max_ascent, -cpos.y);
+					max_descent = MAX(max_descent, csize.y + cpos.y);
+				}
+			}
+		}
+	}
+	return Size2(max_ascent, max_descent);
 }
 
 double TextServerFallback::_shaped_text_get_ascent(const RID &p_shaped) const {

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -396,7 +396,6 @@ class TextServerFallback : public TextServerExtension {
 		String text;
 		String custom_punct;
 		TextServer::Direction direction = DIRECTION_LTR; // Desired text direction.
-		TextServer::Orientation orientation = ORIENTATION_HORIZONTAL;
 
 		struct Span {
 			int start = -1;
@@ -689,8 +688,8 @@ public:
 	MODBIND2RC(bool, font_has_char, const RID &, int64_t);
 	MODBIND1RC(String, font_get_supported_chars, const RID &);
 
-	MODBIND4(font_render_range, const RID &, const Vector2i &, int64_t, int64_t);
-	MODBIND3(font_render_glyph, const RID &, const Vector2i &, int64_t);
+	MODBIND5(font_render_range, const RID &, const Vector2i &, int64_t, int64_t, bool);
+	MODBIND4(font_render_glyph, const RID &, const Vector2i &, int64_t, bool);
 
 	MODBIND6C(font_draw_glyph, const RID &, const RID &, int64_t, const Vector2 &, int64_t, const Color &);
 	MODBIND7C(font_draw_glyph_outline, const RID &, const RID &, int64_t, int64_t, const Vector2 &, int64_t, const Color &);
@@ -780,6 +779,7 @@ public:
 	MODBIND2RC(Rect2, shaped_text_get_object_rect, const RID &, const Variant &);
 
 	MODBIND1RC(Size2, shaped_text_get_size, const RID &);
+	MODBIND1RC(Size2, shaped_text_get_vertical_bounds, const RID &);
 	MODBIND1RC(double, shaped_text_get_ascent, const RID &);
 	MODBIND1RC(double, shaped_text_get_descent, const RID &);
 	MODBIND1RC(double, shaped_text_get_width, const RID &);

--- a/scene/3d/label_3d.h
+++ b/scene/3d/label_3d.h
@@ -33,8 +33,7 @@
 
 #include "scene/3d/visual_instance_3d.h"
 #include "scene/resources/font.h"
-
-#include "servers/text_server.h"
+#include "scene/resources/text_paragraph.h"
 
 class Label3D : public GeometryInstance3D {
 	GDCLASS(Label3D, GeometryInstance3D);
@@ -100,35 +99,30 @@ private:
 
 	HashMap<SurfaceKey, SurfaceData, SurfaceKeyHasher> surfaces;
 
-	HorizontalAlignment horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER;
-	VerticalAlignment vertical_alignment = VERTICAL_ALIGNMENT_CENTER;
 	String text;
 	String xl_text;
+	TextServer::AutowrapMode autowrap_mode = TextServer::AUTOWRAP_OFF;
 	bool uppercase = false;
 
-	TextServer::AutowrapMode autowrap_mode = TextServer::AUTOWRAP_OFF;
-	float width = 500.0;
+	bool text_set = false;
+	Ref<TextParagraph> text_para;
 
-	int font_size = 32;
+	Point2 lbl_offset;
+
 	Ref<Font> font_override;
 	mutable Ref<Font> theme_font;
+
+	int font_size = 32;
 	Color modulate = Color(1, 1, 1, 1);
-	Point2 lbl_offset;
-	int outline_render_priority = -1;
 	int render_priority = 0;
 
 	int outline_size = 12;
 	Color outline_modulate = Color(0, 0, 0, 1);
-
-	float line_spacing = 0.f;
+	int outline_render_priority = -1;
 
 	String language;
-	TextServer::Direction text_direction = TextServer::DIRECTION_AUTO;
 	TextServer::StructuredTextParser st_parser = TextServer::STRUCTURED_TEXT_DEFAULT;
 	Array st_args;
-
-	RID text_rid;
-	Vector<RID> lines_rid;
 
 	RID base_material;
 	StandardMaterial3D::BillboardMode billboard_mode = StandardMaterial3D::BILLBOARD_DISABLED;
@@ -136,28 +130,25 @@ private:
 
 	bool pending_update = false;
 
-	bool dirty_lines = true;
-	bool dirty_font = true;
-	bool dirty_text = true;
-
-	void _generate_glyph_surfaces(const Glyph &p_glyph, Vector2 &r_offset, const Color &p_modulate, int p_priority = 0, int p_outline_size = 0);
+	void _generate_glyph_surfaces(const Glyph &p_glyph, const Vector2 &p_offset, const Color &p_modulate, int p_priority = 0, int p_outline_size = 0);
+	void _update_text();
+	void _update_fonts();
+	void _invalidate_fonts();
 
 protected:
 	GDVIRTUAL2RC(Array, _structured_text_parser, Array, String)
 
 	void _notification(int p_what);
-
 	static void _bind_methods();
 
 	void _validate_property(PropertyInfo &p_property) const;
 
 	void _im_update();
-	void _font_changed();
 	void _queue_update();
 
-	void _shape();
-
 public:
+	virtual PackedStringArray get_configuration_warnings() const override;
+
 	void set_horizontal_alignment(HorizontalAlignment p_alignment);
 	HorizontalAlignment get_horizontal_alignment() const;
 
@@ -175,6 +166,15 @@ public:
 
 	void set_text_direction(TextServer::Direction p_text_direction);
 	TextServer::Direction get_text_direction() const;
+
+	void set_orientation(TextServer::Orientation p_orientation);
+	TextServer::Orientation get_orientation() const;
+
+	void set_uniform_line_height(bool p_enabled);
+	bool get_uniform_line_height() const;
+
+	void set_invert_line_order(bool p_enabled);
+	bool get_invert_line_order() const;
 
 	void set_language(const String &p_language);
 	String get_language() const;
@@ -212,6 +212,12 @@ public:
 
 	void set_width(float p_width);
 	float get_width() const;
+
+	void set_height(float p_height);
+	float get_height() const;
+
+	void set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior);
+	TextServer::OverrunBehavior get_text_overrun_behavior() const;
 
 	void set_pixel_size(real_t p_amount);
 	real_t get_pixel_size() const;

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -318,7 +318,7 @@ void Button::_notification(int p_what) {
 
 			Point2 text_ofs = (size - style->get_minimum_size() - icon_ofs - text_buf->get_size() - Point2(_internal_margin[SIDE_RIGHT] - _internal_margin[SIDE_LEFT], 0)) / 2.0;
 
-			text_buf->set_alignment(align_rtl_checked);
+			text_buf->set_horizontal_alignment(align_rtl_checked);
 			text_buf->set_width(text_width);
 			switch (align_rtl_checked) {
 				case HORIZONTAL_ALIGNMENT_FILL:

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1349,7 +1349,7 @@ void ItemList::_notification(int p_what) {
 							text_ofs.x = size.width - text_ofs.x - max_len;
 						}
 
-						items.write[i].text_buf->set_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+						items.write[i].text_buf->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 
 						if (theme_cache.font_outline_size > 0 && theme_cache.font_outline_color.a > 0) {
 							items[i].text_buf->draw_outline(get_canvas_item(), text_ofs, theme_cache.font_outline_size, theme_cache.font_outline_color);
@@ -1377,9 +1377,9 @@ void ItemList::_notification(int p_what) {
 						items.write[i].text_buf->set_width(width - text_ofs.x);
 
 						if (rtl) {
-							items.write[i].text_buf->set_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
+							items.write[i].text_buf->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 						} else {
-							items.write[i].text_buf->set_alignment(HORIZONTAL_ALIGNMENT_LEFT);
+							items.write[i].text_buf->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_LEFT);
 						}
 
 						if (theme_cache.font_outline_size > 0 && theme_cache.font_outline_color.a > 0) {

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -33,26 +33,20 @@
 
 #include "scene/gui/control.h"
 #include "scene/resources/label_settings.h"
+#include "scene/resources/text_paragraph.h"
 
 class Label : public Control {
 	GDCLASS(Label, Control);
 
 private:
-	HorizontalAlignment horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT;
-	VerticalAlignment vertical_alignment = VERTICAL_ALIGNMENT_TOP;
 	String text;
 	String xl_text;
 	TextServer::AutowrapMode autowrap_mode = TextServer::AUTOWRAP_OFF;
-	bool clip = false;
-	TextServer::OverrunBehavior overrun_behavior = TextServer::OVERRUN_NO_TRIMMING;
 	Size2 minsize;
 	bool uppercase = false;
 
-	bool lines_dirty = true;
-	bool dirty = true;
-	bool font_dirty = true;
-	RID text_rid;
-	Vector<RID> lines_rid;
+	bool text_set = false;
+	Ref<TextParagraph> text_para;
 
 	String language;
 	TextDirection text_direction = TEXT_DIRECTION_AUTO;
@@ -62,8 +56,6 @@ private:
 	TextServer::VisibleCharactersBehavior visible_chars_behavior = TextServer::VC_CHARS_BEFORE_SHAPING;
 	int visible_chars = -1;
 	float visible_ratio = 1.0;
-	int lines_skipped = 0;
-	int max_lines_visible = -1;
 
 	Ref<LabelSettings> settings;
 
@@ -82,8 +74,9 @@ private:
 	} theme_cache;
 
 	void _update_visible();
-	void _shape();
-	void _invalidate();
+	void _update_text();
+	void _update_fonts();
+	void _invalidate_fonts();
 
 protected:
 	virtual void _update_theme_item_cache() override;
@@ -109,6 +102,15 @@ public:
 
 	void set_text_direction(TextDirection p_text_direction);
 	TextDirection get_text_direction() const;
+
+	void set_orientation(TextServer::Orientation p_orientation);
+	TextServer::Orientation get_orientation() const;
+
+	void set_uniform_line_height(bool p_enabled);
+	bool get_uniform_line_height() const;
+
+	void set_invert_line_order(bool p_enabled);
+	bool get_invert_line_order() const;
 
 	void set_language(const String &p_language);
 	String get_language() const;

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -33,6 +33,7 @@
 
 #include "scene/gui/control.h"
 #include "scene/gui/popup_menu.h"
+#include "scene/resources/text_paragraph.h"
 
 class LineEdit : public Control {
 	GDCLASS(LineEdit, Control);

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -477,7 +477,7 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 	// Add indent.
 	l.offset.x = _find_margin(l.from, p_base_font, p_base_font_size);
 	l.text_buf->set_width(p_width - l.offset.x);
-	l.text_buf->set_alignment(_find_alignment(l.from));
+	l.text_buf->set_horizontal_alignment(_find_alignment(l.from));
 	l.text_buf->set_direction(_find_direction(l.from));
 
 	if (tab_size > 0) { // Align inline tabs.
@@ -835,9 +835,9 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 	int dc_lines = l.text_buf->get_dropcap_lines();
 	float h_off = l.text_buf->get_dropcap_size().x;
 	if (l.dc_ol_size > 0) {
-		l.text_buf->draw_dropcap_outline(ci, p_ofs + ((rtl) ? Vector2() : Vector2(l.offset.x, 0)), l.dc_ol_size, l.dc_ol_color);
+		l.text_buf->draw_dropcap_outline(ci, p_ofs + l.text_buf->get_dropcap_offset() + ((rtl) ? Vector2() : Vector2(l.offset.x, 0)), l.dc_ol_size, l.dc_ol_color);
 	}
-	l.text_buf->draw_dropcap(ci, p_ofs + ((rtl) ? Vector2() : Vector2(l.offset.x, 0)), l.dc_color);
+	l.text_buf->draw_dropcap(ci, p_ofs + l.text_buf->get_dropcap_offset() + ((rtl) ? Vector2() : Vector2(l.offset.x, 0)), l.dc_color);
 
 	int line_count = 0;
 	Size2 ctrl_size = get_size();
@@ -876,7 +876,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 		}
 
 		// Draw text.
-		switch (l.text_buf->get_alignment()) {
+		switch (l.text_buf->get_horizontal_alignment()) {
 			case HORIZONTAL_ALIGNMENT_FILL:
 			case HORIZONTAL_ALIGNMENT_LEFT: {
 				if (rtl) {
@@ -1454,7 +1454,7 @@ float RichTextLabel::_find_click_in_line(ItemFrame *p_frame, int p_line, const V
 			}
 		}
 
-		switch (l.text_buf->get_alignment()) {
+		switch (l.text_buf->get_horizontal_alignment()) {
 			case HORIZONTAL_ALIGNMENT_FILL:
 			case HORIZONTAL_ALIGNMENT_LEFT: {
 				if (rtl) {

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -322,7 +322,7 @@ Size2 Font::get_multiline_string_size(const String &p_text, HorizontalAlignment 
 		cache_wrap.insert(hash, lines_buffer);
 	}
 
-	lines_buffer->set_alignment(p_alignment);
+	lines_buffer->set_horizontal_alignment(p_alignment);
 	lines_buffer->set_max_lines_visible(p_max_lines);
 
 	return lines_buffer->get_size();
@@ -395,7 +395,7 @@ void Font::draw_multiline_string(RID p_canvas_item, const Point2 &p_pos, const S
 		ofs.x -= lines_buffer->get_line_ascent(0);
 	}
 
-	lines_buffer->set_alignment(p_alignment);
+	lines_buffer->set_horizontal_alignment(p_alignment);
 	lines_buffer->set_max_lines_visible(p_max_lines);
 
 	lines_buffer->draw(p_canvas_item, ofs, p_modulate);
@@ -468,7 +468,7 @@ void Font::draw_multiline_string_outline(RID p_canvas_item, const Point2 &p_pos,
 		ofs.x -= lines_buffer->get_line_ascent(0);
 	}
 
-	lines_buffer->set_alignment(p_alignment);
+	lines_buffer->set_horizontal_alignment(p_alignment);
 	lines_buffer->set_max_lines_visible(p_max_lines);
 
 	lines_buffer->draw_outline(p_canvas_item, ofs, p_size, p_modulate);

--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -33,7 +33,7 @@
 
 #include "scene/resources/font.h"
 #include "scene/resources/mesh.h"
-#include "servers/text_server.h"
+#include "scene/resources/text_paragraph.h"
 
 ///@TODO probably should change a few integers to unsigned integers...
 
@@ -581,25 +581,20 @@ private:
 	};
 	mutable HashMap<GlyphMeshKey, GlyphMeshData, GlyphMeshKeyHasher> cache;
 
-	RID text_rid;
-	mutable Vector<RID> lines_rid;
-
 	String text;
 	String xl_text;
+	TextServer::AutowrapMode autowrap_mode = TextServer::AUTOWRAP_OFF;
+	bool uppercase = false;
+
+	bool text_set = false;
+	Ref<TextParagraph> text_para;
+
+	Point2 lbl_offset;
 
 	int font_size = 16;
 	Ref<Font> font_override;
 
-	TextServer::AutowrapMode autowrap_mode = TextServer::AUTOWRAP_OFF;
-	float width = 500.0;
-	float line_spacing = 0.f;
-	Point2 lbl_offset;
-
-	HorizontalAlignment horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER;
-	VerticalAlignment vertical_alignment = VERTICAL_ALIGNMENT_CENTER;
-	bool uppercase = false;
 	String language;
-	TextServer::Direction text_direction = TextServer::DIRECTION_AUTO;
 	TextServer::StructuredTextParser st_parser = TextServer::STRUCTURED_TEXT_DEFAULT;
 	Array st_args;
 
@@ -607,13 +602,12 @@ private:
 	real_t pixel_size = 0.01;
 	real_t curve_step = 0.5;
 
-	mutable bool dirty_lines = true;
-	mutable bool dirty_text = true;
-	mutable bool dirty_font = true;
-	mutable bool dirty_cache = true;
+	mutable bool dirty_cache = true; //?????
 
 	void _generate_glyph_mesh_data(const GlyphMeshKey &p_key, const Glyph &p_glyph) const;
-	void _font_changed();
+	void _update_text();
+	void _update_fonts();
+	void _invalidate_fonts();
 
 protected:
 	static void _bind_methods();
@@ -652,6 +646,15 @@ public:
 	void set_text_direction(TextServer::Direction p_text_direction);
 	TextServer::Direction get_text_direction() const;
 
+	void set_orientation(TextServer::Orientation p_orientation);
+	TextServer::Orientation get_orientation() const;
+
+	void set_uniform_line_height(bool p_enabled);
+	bool get_uniform_line_height() const;
+
+	void set_invert_line_order(bool p_enabled);
+	bool get_invert_line_order() const;
+
 	void set_language(const String &p_language);
 	String get_language() const;
 
@@ -666,6 +669,9 @@ public:
 
 	void set_width(real_t p_width);
 	real_t get_width() const;
+
+	void set_height(float p_height);
+	float get_height() const;
 
 	void set_depth(real_t p_depth);
 	real_t get_depth() const;

--- a/scene/resources/text_line.h
+++ b/scene/resources/text_line.h
@@ -41,9 +41,9 @@ class TextLine : public RefCounted {
 
 private:
 	RID rid;
-
 	bool dirty = true;
 
+	bool clip = true;
 	float width = -1.0;
 	BitField<TextServer::JustificationFlag> flags = TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA;
 	HorizontalAlignment alignment = HORIZONTAL_ALIGNMENT_LEFT;
@@ -64,8 +64,6 @@ public:
 	void set_direction(TextServer::Direction p_direction);
 	TextServer::Direction get_direction() const;
 
-	void set_bidi_override(const Array &p_override);
-
 	void set_orientation(TextServer::Orientation p_orientation);
 	TextServer::Orientation get_orientation() const;
 
@@ -75,12 +73,20 @@ public:
 	void set_preserve_control(bool p_enabled);
 	bool get_preserve_control() const;
 
+	void set_bidi_override(const Array &p_override);
+
+	int get_span_count() const;
+	void update_span_font(int p_span, const Ref<Font> &p_font, int p_font_size);
+
 	bool add_string(const String &p_text, const Ref<Font> &p_font, int p_font_size, const String &p_language = "", const Variant &p_meta = Variant());
 	bool add_object(Variant p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER, int p_length = 1, float p_baseline = 0.0);
 	bool resize_object(Variant p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER, float p_baseline = 0.0);
 
 	void set_horizontal_alignment(HorizontalAlignment p_alignment);
 	HorizontalAlignment get_horizontal_alignment() const;
+
+	void set_clip(bool p_enabled);
+	bool get_clip() const;
 
 	void tab_align(const Vector<float> &p_tab_stops);
 
@@ -104,8 +110,16 @@ public:
 	float get_line_underline_position() const;
 	float get_line_underline_thickness() const;
 
+	bool has_invalid_glyphs() const;
+	int get_glyph_count() const;
+
 	void draw(RID p_canvas, const Vector2 &p_pos, const Color &p_color = Color(1, 1, 1)) const;
 	void draw_outline(RID p_canvas, const Vector2 &p_pos, int p_outline_size = 1, const Color &p_color = Color(1, 1, 1)) const;
+	void draw_custom(const Vector2 &p_pos, std::function<bool(const Glyph &, const Vector2 &, int)> p_draw_fn) const;
+	void _draw_custom(RID p_canvas, const Vector2 &p_pos, const Callable &p_callback) const;
+
+	void draw_underline_custom(const Vector2 &p_pos, TextServer::LinePosition p_line, int p_start, int p_end, std::function<bool(const Rect2 &)> p_draw_fn) const;
+	void _draw_underline_custom(RID p_canvas, const Vector2 &p_pos, TextServer::LinePosition p_line, int p_start, int p_end, const Callable &p_callback) const;
 
 	int hit_test(float p_coords) const;
 

--- a/scene/resources/text_paragraph.cpp
+++ b/scene/resources/text_paragraph.cpp
@@ -46,7 +46,7 @@ void TextParagraph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_orientation", "orientation"), &TextParagraph::set_orientation);
 	ClassDB::bind_method(D_METHOD("get_orientation"), &TextParagraph::get_orientation);
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "orientation", PROPERTY_HINT_ENUM, "Horizontal,Orientation"), "set_orientation", "get_orientation");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "orientation", PROPERTY_HINT_ENUM, "Horizontal,Vertical Upright,Vertical Mixed,Vertical Sideways"), "set_orientation", "get_orientation");
 
 	ClassDB::bind_method(D_METHOD("set_preserve_invalid", "enabled"), &TextParagraph::set_preserve_invalid);
 	ClassDB::bind_method(D_METHOD("get_preserve_invalid"), &TextParagraph::get_preserve_invalid);
@@ -63,14 +63,37 @@ void TextParagraph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_dropcap", "text", "font", "font_size", "dropcap_margins", "language"), &TextParagraph::set_dropcap, DEFVAL(Rect2()), DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("clear_dropcap"), &TextParagraph::clear_dropcap);
 
+	ClassDB::bind_method(D_METHOD("get_span_count"), &TextParagraph::get_span_count);
+	ClassDB::bind_method(D_METHOD("update_span_font", "span", "font", "font_size"), &TextParagraph::update_span_font);
+
 	ClassDB::bind_method(D_METHOD("add_string", "text", "font", "font_size", "language", "meta"), &TextParagraph::add_string, DEFVAL(""), DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("add_object", "key", "size", "inline_align", "length", "baseline"), &TextParagraph::add_object, DEFVAL(INLINE_ALIGNMENT_CENTER), DEFVAL(1), DEFVAL(0.0));
 	ClassDB::bind_method(D_METHOD("resize_object", "key", "size", "inline_align", "baseline"), &TextParagraph::resize_object, DEFVAL(INLINE_ALIGNMENT_CENTER), DEFVAL(0.0));
 
-	ClassDB::bind_method(D_METHOD("set_alignment", "alignment"), &TextParagraph::set_alignment);
-	ClassDB::bind_method(D_METHOD("get_alignment"), &TextParagraph::get_alignment);
+	ClassDB::bind_method(D_METHOD("set_horizontal_alignment", "horizontal_alignment"), &TextParagraph::set_horizontal_alignment);
+	ClassDB::bind_method(D_METHOD("get_horizontal_alignment"), &TextParagraph::get_horizontal_alignment);
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "alignment", PROPERTY_HINT_ENUM, "Left,Center,Right,Fill"), "set_alignment", "get_alignment");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "horizontal_alignment", PROPERTY_HINT_ENUM, "Left,Center,Right,Fill"), "set_horizontal_alignment", "get_horizontal_alignment");
+
+	ClassDB::bind_method(D_METHOD("set_vertical_alignment", "vertical_alignment"), &TextParagraph::set_vertical_alignment);
+	ClassDB::bind_method(D_METHOD("get_vertical_alignment"), &TextParagraph::get_vertical_alignment);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "vertical_alignment", PROPERTY_HINT_ENUM, "Top,Center,Bottom,Fill"), "set_vertical_alignment", "get_vertical_alignment");
+
+	ClassDB::bind_method(D_METHOD("set_uniform_line_height", "uniform_line_height"), &TextParagraph::set_uniform_line_height);
+	ClassDB::bind_method(D_METHOD("get_uniform_line_height"), &TextParagraph::get_uniform_line_height);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "uniform_line_height"), "set_uniform_line_height", "get_uniform_line_height");
+
+	ClassDB::bind_method(D_METHOD("set_invert_line_order", "invert_line_order"), &TextParagraph::set_invert_line_order);
+	ClassDB::bind_method(D_METHOD("get_invert_line_order"), &TextParagraph::get_invert_line_order);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "invert_line_order"), "set_invert_line_order", "get_invert_line_order");
+
+	ClassDB::bind_method(D_METHOD("set_clip", "clip"), &TextParagraph::set_clip);
+	ClassDB::bind_method(D_METHOD("get_clip"), &TextParagraph::get_clip);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "clip"), "set_clip", "get_clip");
 
 	ClassDB::bind_method(D_METHOD("tab_align", "tab_stops"), &TextParagraph::tab_align);
 
@@ -94,6 +117,16 @@ void TextParagraph::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "width"), "set_width", "get_width");
 
+	ClassDB::bind_method(D_METHOD("set_height", "height"), &TextParagraph::set_height);
+	ClassDB::bind_method(D_METHOD("get_height"), &TextParagraph::get_height);
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height"), "set_height", "get_height");
+
+	ClassDB::bind_method(D_METHOD("set_extra_line_spacing", "spacing"), &TextParagraph::set_extra_line_spacing);
+	ClassDB::bind_method(D_METHOD("get_extra_line_spacing"), &TextParagraph::get_extra_line_spacing);
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "extra_line_spacing"), "set_extra_line_spacing", "get_extra_line_spacing");
+
 	ClassDB::bind_method(D_METHOD("get_non_wrapped_size"), &TextParagraph::get_non_wrapped_size);
 	ClassDB::bind_method(D_METHOD("get_size"), &TextParagraph::get_size);
 
@@ -102,6 +135,12 @@ void TextParagraph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_dropcap_rid"), &TextParagraph::get_dropcap_rid);
 
 	ClassDB::bind_method(D_METHOD("get_line_count"), &TextParagraph::get_line_count);
+	ClassDB::bind_method(D_METHOD("get_visible_line_count"), &TextParagraph::get_visible_line_count);
+
+	ClassDB::bind_method(D_METHOD("set_lines_skipped", "lines_skipped"), &TextParagraph::set_lines_skipped);
+	ClassDB::bind_method(D_METHOD("get_lines_skipped"), &TextParagraph::get_lines_skipped);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "lines_skipped"), "set_lines_skipped", "get_lines_skipped");
 
 	ClassDB::bind_method(D_METHOD("set_max_lines_visible", "max_lines_visible"), &TextParagraph::set_max_lines_visible);
 	ClassDB::bind_method(D_METHOD("get_max_lines_visible"), &TextParagraph::get_max_lines_visible);
@@ -111,6 +150,7 @@ void TextParagraph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_line_objects", "line"), &TextParagraph::get_line_objects);
 	ClassDB::bind_method(D_METHOD("get_line_object_rect", "line", "key"), &TextParagraph::get_line_object_rect);
 	ClassDB::bind_method(D_METHOD("get_line_size", "line"), &TextParagraph::get_line_size);
+	ClassDB::bind_method(D_METHOD("get_line_offset", "line"), &TextParagraph::get_line_offset);
 	ClassDB::bind_method(D_METHOD("get_line_range", "line"), &TextParagraph::get_line_range);
 	ClassDB::bind_method(D_METHOD("get_line_ascent", "line"), &TextParagraph::get_line_ascent);
 	ClassDB::bind_method(D_METHOD("get_line_descent", "line"), &TextParagraph::get_line_descent);
@@ -120,9 +160,16 @@ void TextParagraph::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_dropcap_size"), &TextParagraph::get_dropcap_size);
 	ClassDB::bind_method(D_METHOD("get_dropcap_lines"), &TextParagraph::get_dropcap_lines);
+	ClassDB::bind_method(D_METHOD("get_dropcap_offset"), &TextParagraph::get_dropcap_offset);
+
+	ClassDB::bind_method(D_METHOD("has_invalid_glyphs"), &TextParagraph::has_invalid_glyphs);
+	ClassDB::bind_method(D_METHOD("get_glyph_count"), &TextParagraph::get_glyph_count);
 
 	ClassDB::bind_method(D_METHOD("draw", "canvas", "pos", "color", "dc_color"), &TextParagraph::draw, DEFVAL(Color(1, 1, 1)), DEFVAL(Color(1, 1, 1)));
 	ClassDB::bind_method(D_METHOD("draw_outline", "canvas", "pos", "outline_size", "color", "dc_color"), &TextParagraph::draw_outline, DEFVAL(1), DEFVAL(Color(1, 1, 1)), DEFVAL(Color(1, 1, 1)));
+	ClassDB::bind_method(D_METHOD("draw_custom", "canvas", "pos", "callback"), &TextParagraph::_draw_custom);
+
+	ClassDB::bind_method(D_METHOD("draw_underline_custom", "canvas", "pos", "line_type", "start", "end", "callback"), &TextParagraph::_draw_underline_custom);
 
 	ClassDB::bind_method(D_METHOD("draw_line", "canvas", "pos", "line", "color"), &TextParagraph::draw_line, DEFVAL(Color(1, 1, 1)));
 	ClassDB::bind_method(D_METHOD("draw_line_outline", "canvas", "pos", "line", "outline_size", "color"), &TextParagraph::draw_line_outline, DEFVAL(1), DEFVAL(Color(1, 1, 1)));
@@ -144,38 +191,30 @@ void TextParagraph::_shape_lines() {
 			TS->shaped_text_tab_align(rid, tab_stops);
 		}
 
-		float h_offset = 0.f;
-		float v_offset = 0.f;
 		int start = 0;
 		dropcap_lines = 0;
 
-		if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
-			h_offset = TS->shaped_text_get_size(dropcap_rid).x + dropcap_margins.size.x + dropcap_margins.position.x;
-			v_offset = TS->shaped_text_get_size(dropcap_rid).y + dropcap_margins.size.y + dropcap_margins.position.y;
-		} else {
-			h_offset = TS->shaped_text_get_size(dropcap_rid).y + dropcap_margins.size.y + dropcap_margins.position.y;
-			v_offset = TS->shaped_text_get_size(dropcap_rid).x + dropcap_margins.size.x + dropcap_margins.position.x;
-		}
+		Size2 dc_vb = TS->shaped_text_get_vertical_bounds(dropcap_rid);
+		float dc_width = TS->shaped_text_get_width(dropcap_rid) + dropcap_margins.position.x + dropcap_margins.size.x;
+		float dc_height = dc_vb.x + dc_vb.y + dropcap_margins.position.y + dropcap_margins.size.y;
 
-		if (h_offset > 0) {
+		if (dc_width > 0) {
 			// Dropcap, flow around.
-			PackedInt32Array line_breaks = TS->shaped_text_get_line_breaks(rid, width - h_offset, 0, brk_flags);
-			for (int i = 0; i < line_breaks.size(); i = i + 2) {
+			PackedInt32Array line_breaks = TS->shaped_text_get_line_breaks(rid, width - dc_width, 0, brk_flags);
+			TextServer::Orientation orientation = TS->shaped_text_get_orientation(rid);
+			for (int i = 0; i < line_breaks.size() && dc_height > 0.0; i = i + 2) {
 				RID line = TS->shaped_text_substr(rid, line_breaks[i], line_breaks[i + 1] - line_breaks[i]);
-				float h = (TS->shaped_text_get_orientation(line) == TextServer::ORIENTATION_HORIZONTAL) ? TS->shaped_text_get_size(line).y : TS->shaped_text_get_size(line).x;
-				if (v_offset < h) {
-					TS->free_rid(line);
-					break;
-				}
+				float h = (orientation == TextServer::ORIENTATION_HORIZONTAL) ? TS->shaped_text_get_size(line).y : TS->shaped_text_get_size(line).x;
 				if (!tab_stops.is_empty()) {
 					TS->shaped_text_tab_align(line, tab_stops);
 				}
 				dropcap_lines++;
-				v_offset -= h;
+				dc_height -= (h + line_spacing);
 				start = line_breaks[i + 1];
 				lines_rid.push_back(line);
 			}
 		}
+
 		// Use fixed for the rest of lines.
 		PackedInt32Array line_breaks = TS->shaped_text_get_line_breaks(rid, width, start, brk_flags);
 		for (int i = 0; i < line_breaks.size(); i = i + 2) {
@@ -219,29 +258,29 @@ void TextParagraph::_shape_lines() {
 			if (lines_hidden) {
 				overrun_flags.set_flag(TextServer::OVERRUN_ENFORCE_ELLIPSIS);
 			}
-			if (alignment == HORIZONTAL_ALIGNMENT_FILL) {
+			if (horizontal_alignment == HORIZONTAL_ALIGNMENT_FILL) {
 				for (int i = 0; i < (int)lines_rid.size(); i++) {
+					float lw = (i < dropcap_lines) ? (width - dc_width) : (width);
 					if (i < visible_lines - 1 || (int)lines_rid.size() == 1) {
-						TS->shaped_text_fit_to_width(lines_rid[i], width, jst_flags);
+						TS->shaped_text_fit_to_width(lines_rid[i], lw, jst_flags);
 					} else if (i == (visible_lines - 1)) {
-						TS->shaped_text_overrun_trim_to_width(lines_rid[visible_lines - 1], width, overrun_flags);
+						TS->shaped_text_overrun_trim_to_width(lines_rid[visible_lines - 1], lw, overrun_flags);
 					}
 				}
-
 			} else if (lines_hidden) {
 				TS->shaped_text_overrun_trim_to_width(lines_rid[visible_lines - 1], width, overrun_flags);
 			}
-
 		} else {
 			// Autowrap disabled.
 			for (int i = 0; i < (int)lines_rid.size(); i++) {
-				if (alignment == HORIZONTAL_ALIGNMENT_FILL) {
-					TS->shaped_text_fit_to_width(lines_rid[i], width, jst_flags);
+				float lw = (i < dropcap_lines) ? (width - dc_width) : (width);
+				if (horizontal_alignment == HORIZONTAL_ALIGNMENT_FILL) {
+					TS->shaped_text_fit_to_width(lines_rid[i], lw, jst_flags);
 					overrun_flags.set_flag(TextServer::OVERRUN_JUSTIFICATION_AWARE);
-					TS->shaped_text_overrun_trim_to_width(lines_rid[i], width, overrun_flags);
-					TS->shaped_text_fit_to_width(lines_rid[i], width, jst_flags | TextServer::JUSTIFICATION_CONSTRAIN_ELLIPSIS);
+					TS->shaped_text_overrun_trim_to_width(lines_rid[i], lw, overrun_flags);
+					TS->shaped_text_fit_to_width(lines_rid[i], lw, jst_flags | TextServer::JUSTIFICATION_CONSTRAIN_ELLIPSIS);
 				} else {
-					TS->shaped_text_overrun_trim_to_width(lines_rid[i], width, overrun_flags);
+					TS->shaped_text_overrun_trim_to_width(lines_rid[i], lw, overrun_flags);
 				}
 			}
 		}
@@ -282,6 +321,7 @@ void TextParagraph::set_preserve_invalid(bool p_enabled) {
 	TS->shaped_text_set_preserve_invalid(rid, p_enabled);
 	TS->shaped_text_set_preserve_invalid(dropcap_rid, p_enabled);
 	lines_dirty = true;
+	lines_offsets_dirty = true;
 }
 
 bool TextParagraph::get_preserve_invalid() const {
@@ -296,6 +336,7 @@ void TextParagraph::set_preserve_control(bool p_enabled) {
 	TS->shaped_text_set_preserve_control(rid, p_enabled);
 	TS->shaped_text_set_preserve_control(dropcap_rid, p_enabled);
 	lines_dirty = true;
+	lines_offsets_dirty = true;
 }
 
 bool TextParagraph::get_preserve_control() const {
@@ -306,10 +347,12 @@ bool TextParagraph::get_preserve_control() const {
 
 void TextParagraph::set_direction(TextServer::Direction p_direction) {
 	_THREAD_SAFE_METHOD_
+	ERR_FAIL_COND((int)p_direction < 0 || (int)p_direction > 2);
 
 	TS->shaped_text_set_direction(rid, p_direction);
 	TS->shaped_text_set_direction(dropcap_rid, p_direction);
 	lines_dirty = true;
+	lines_offsets_dirty = true;
 }
 
 TextServer::Direction TextParagraph::get_direction() const {
@@ -324,6 +367,7 @@ void TextParagraph::set_custom_punctuation(const String &p_punct) {
 
 	TS->shaped_text_set_custom_punctuation(rid, p_punct);
 	lines_dirty = true;
+	lines_offsets_dirty = true;
 }
 
 String TextParagraph::get_custom_punctuation() const {
@@ -334,10 +378,12 @@ String TextParagraph::get_custom_punctuation() const {
 
 void TextParagraph::set_orientation(TextServer::Orientation p_orientation) {
 	_THREAD_SAFE_METHOD_
+	ERR_FAIL_COND((int)p_orientation < 0 || (int)p_orientation > 3);
 
 	TS->shaped_text_set_orientation(rid, p_orientation);
 	TS->shaped_text_set_orientation(dropcap_rid, p_orientation);
 	lines_dirty = true;
+	lines_offsets_dirty = true;
 }
 
 TextServer::Orientation TextParagraph::get_orientation() const {
@@ -357,6 +403,7 @@ bool TextParagraph::set_dropcap(const String &p_text, const Ref<Font> &p_font, i
 		TS->shaped_text_set_spacing(dropcap_rid, TextServer::SpacingType(i), p_font->get_spacing(TextServer::SpacingType(i)));
 	}
 	lines_dirty = true;
+	lines_offsets_dirty = true;
 	return res;
 }
 
@@ -365,6 +412,21 @@ void TextParagraph::clear_dropcap() {
 	dropcap_margins = Rect2();
 	TS->shaped_text_clear(dropcap_rid);
 	lines_dirty = true;
+	lines_offsets_dirty = true;
+}
+
+int TextParagraph::get_span_count() const {
+	_THREAD_SAFE_METHOD_
+	return TS->shaped_get_span_count(rid);
+}
+
+void TextParagraph::update_span_font(int p_span, const Ref<Font> &p_font, int p_font_size) {
+	_THREAD_SAFE_METHOD_
+	ERR_FAIL_COND(p_font.is_null());
+
+	TS->shaped_set_span_update_font(rid, p_span, p_font->get_rids(), p_font_size, p_font->get_opentype_features());
+	lines_dirty = true;
+	lines_offsets_dirty = true;
 }
 
 bool TextParagraph::add_string(const String &p_text, const Ref<Font> &p_font, int p_font_size, const String &p_language, const Variant &p_meta) {
@@ -375,6 +437,7 @@ bool TextParagraph::add_string(const String &p_text, const Ref<Font> &p_font, in
 		TS->shaped_text_set_spacing(rid, TextServer::SpacingType(i), p_font->get_spacing(TextServer::SpacingType(i)));
 	}
 	lines_dirty = true;
+	lines_offsets_dirty = true;
 	return res;
 }
 
@@ -383,6 +446,7 @@ void TextParagraph::set_bidi_override(const Array &p_override) {
 
 	TS->shaped_text_set_bidi_override(rid, p_override);
 	lines_dirty = true;
+	lines_offsets_dirty = true;
 }
 
 bool TextParagraph::add_object(Variant p_key, const Size2 &p_size, InlineAlignment p_inline_align, int p_length, float p_baseline) {
@@ -390,6 +454,7 @@ bool TextParagraph::add_object(Variant p_key, const Size2 &p_size, InlineAlignme
 
 	bool res = TS->shaped_text_add_object(rid, p_key, p_size, p_inline_align, p_length, p_baseline);
 	lines_dirty = true;
+	lines_offsets_dirty = true;
 	return res;
 }
 
@@ -398,24 +463,75 @@ bool TextParagraph::resize_object(Variant p_key, const Size2 &p_size, InlineAlig
 
 	bool res = TS->shaped_text_resize_object(rid, p_key, p_size, p_inline_align, p_baseline);
 	lines_dirty = true;
+	lines_offsets_dirty = true;
 	return res;
 }
 
-void TextParagraph::set_alignment(HorizontalAlignment p_alignment) {
+void TextParagraph::set_horizontal_alignment(HorizontalAlignment p_alignment) {
 	_THREAD_SAFE_METHOD_
 
-	if (alignment != p_alignment) {
-		if (alignment == HORIZONTAL_ALIGNMENT_FILL || p_alignment == HORIZONTAL_ALIGNMENT_FILL) {
-			alignment = p_alignment;
+	ERR_FAIL_INDEX((int)p_alignment, 4);
+	if (horizontal_alignment != p_alignment) {
+		if (horizontal_alignment == HORIZONTAL_ALIGNMENT_FILL || p_alignment == HORIZONTAL_ALIGNMENT_FILL) {
+			horizontal_alignment = p_alignment;
 			lines_dirty = true;
 		} else {
-			alignment = p_alignment;
+			horizontal_alignment = p_alignment;
 		}
+		lines_offsets_dirty = true;
 	}
 }
 
-HorizontalAlignment TextParagraph::get_alignment() const {
-	return alignment;
+HorizontalAlignment TextParagraph::get_horizontal_alignment() const {
+	return horizontal_alignment;
+}
+
+void TextParagraph::set_vertical_alignment(VerticalAlignment p_alignment) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_INDEX((int)p_alignment, 4);
+	if (vertical_alignment != p_alignment) {
+		lines_offsets_dirty = true;
+		vertical_alignment = p_alignment;
+	}
+}
+
+VerticalAlignment TextParagraph::get_vertical_alignment() const {
+	return vertical_alignment;
+}
+
+void TextParagraph::set_uniform_line_height(bool p_enabled) {
+	_THREAD_SAFE_METHOD_
+
+	if (uniform_line_height != p_enabled) {
+		lines_offsets_dirty = true;
+		uniform_line_height = p_enabled;
+	}
+}
+
+bool TextParagraph::get_uniform_line_height() const {
+	return uniform_line_height;
+}
+
+void TextParagraph::set_invert_line_order(bool p_enabled) {
+	_THREAD_SAFE_METHOD_
+
+	if (invert_line_order != p_enabled) {
+		lines_offsets_dirty = true;
+		invert_line_order = p_enabled;
+	}
+}
+
+bool TextParagraph::get_invert_line_order() const {
+	return invert_line_order;
+}
+
+void TextParagraph::set_clip(bool p_enabled) {
+	clip = p_enabled;
+}
+
+bool TextParagraph::get_clip() const {
+	return clip;
 }
 
 void TextParagraph::tab_align(const Vector<float> &p_tab_stops) {
@@ -423,6 +539,7 @@ void TextParagraph::tab_align(const Vector<float> &p_tab_stops) {
 
 	tab_stops = p_tab_stops;
 	lines_dirty = true;
+	lines_offsets_dirty = true;
 }
 
 void TextParagraph::set_justification_flags(BitField<TextServer::JustificationFlag> p_flags) {
@@ -431,6 +548,7 @@ void TextParagraph::set_justification_flags(BitField<TextServer::JustificationFl
 	if (jst_flags != p_flags) {
 		jst_flags = p_flags;
 		lines_dirty = true;
+		lines_offsets_dirty = true;
 	}
 }
 
@@ -444,6 +562,7 @@ void TextParagraph::set_break_flags(BitField<TextServer::LineBreakFlag> p_flags)
 	if (brk_flags != p_flags) {
 		brk_flags = p_flags;
 		lines_dirty = true;
+		lines_offsets_dirty = true;
 	}
 }
 
@@ -457,6 +576,7 @@ void TextParagraph::set_text_overrun_behavior(TextServer::OverrunBehavior p_beha
 	if (overrun_behavior != p_behavior) {
 		overrun_behavior = p_behavior;
 		lines_dirty = true;
+		lines_offsets_dirty = true;
 	}
 }
 
@@ -470,11 +590,38 @@ void TextParagraph::set_width(float p_width) {
 	if (width != p_width) {
 		width = p_width;
 		lines_dirty = true;
+		lines_offsets_dirty = true;
 	}
 }
 
 float TextParagraph::get_width() const {
 	return width;
+}
+
+void TextParagraph::set_height(float p_height) {
+	_THREAD_SAFE_METHOD_
+
+	if (height != p_height) {
+		height = p_height;
+		lines_offsets_dirty = true;
+	}
+}
+
+float TextParagraph::get_height() const {
+	return height;
+}
+
+void TextParagraph::set_extra_line_spacing(float p_spacing) {
+	_THREAD_SAFE_METHOD_
+
+	if (line_spacing != p_spacing) {
+		line_spacing = p_spacing;
+		lines_offsets_dirty = true;
+	}
+}
+
+float TextParagraph::get_extra_line_spacing() const {
+	return line_spacing;
 }
 
 Size2 TextParagraph::get_non_wrapped_size() const {
@@ -494,14 +641,23 @@ Size2 TextParagraph::get_size() const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
 	Size2 size;
 	int visible_lines = (max_lines_visible >= 0) ? MIN(max_lines_visible, (int)lines_rid.size()) : (int)lines_rid.size();
-	for (int i = 0; i < visible_lines; i++) {
+	int last_line = MIN((int)lines_rid.size(), visible_lines + lines_skipped);
+	TextServer::Orientation orientation = TS->shaped_text_get_orientation(rid);
+
+	for (int i = lines_skipped; i < last_line; i++) {
 		Size2 lsize = TS->shaped_text_get_size(lines_rid[i]);
-		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
+		if (orientation == TextServer::ORIENTATION_HORIZONTAL) {
 			size.x = MAX(size.x, lsize.x);
 			size.y += lsize.y;
+			if (i < last_line - 1) {
+				size.y += line_spacing;
+			}
 		} else {
-			size.x += lsize.x;
 			size.y = MAX(size.y, lsize.y);
+			size.x += lsize.x;
+			if (i < last_line - 1) {
+				size.x += line_spacing;
+			}
 		}
 	}
 	return size;
@@ -514,17 +670,65 @@ int TextParagraph::get_line_count() const {
 	return (int)lines_rid.size();
 }
 
+int TextParagraph::get_visible_line_count() const {
+	_THREAD_SAFE_METHOD_
+
+	const_cast<TextParagraph *>(this)->_shape_lines();
+	const_cast<TextParagraph *>(this)->_update_line_offsets();
+
+	TextServer::Orientation orientation = TS->shaped_text_get_orientation(rid);
+
+	int lines_visible = (max_lines_visible >= 0) ? MIN(max_lines_visible, (int)lines_rid.size()) : (int)lines_rid.size();
+	int last_line = MIN((int)lines_rid.size(), lines_visible + lines_skipped);
+
+	if (clip) {
+		int lines_visible_clip = 0;
+		for (int i = lines_skipped; i < last_line; i++) {
+			Vector2 ofs = get_line_offset(i);
+			bool clip_line = false;
+			if (height > 0) {
+				if (orientation == TextServer::ORIENTATION_HORIZONTAL) {
+					clip_line = ((ofs.y - TS->shaped_text_get_ascent(lines_rid[i])) < 0.0 || (ofs.y + TS->shaped_text_get_descent(lines_rid[i])) > height);
+				} else {
+					clip_line = ((ofs.x - TS->shaped_text_get_descent(lines_rid[i])) < 0.0 || (ofs.x + TS->shaped_text_get_ascent(lines_rid[i])) > height);
+				}
+			}
+			if (!clip_line) {
+				lines_visible_clip++;
+			}
+		}
+		return lines_visible_clip;
+	} else {
+		return lines_visible;
+	}
+}
+
 void TextParagraph::set_max_lines_visible(int p_lines) {
 	_THREAD_SAFE_METHOD_
 
 	if (p_lines != max_lines_visible) {
 		max_lines_visible = p_lines;
 		lines_dirty = true;
+		lines_offsets_dirty = true;
 	}
 }
 
 int TextParagraph::get_max_lines_visible() const {
 	return max_lines_visible;
+}
+
+void TextParagraph::set_lines_skipped(int p_lines) {
+	_THREAD_SAFE_METHOD_
+	ERR_FAIL_COND(p_lines < 0);
+
+	if (p_lines != lines_skipped) {
+		lines_skipped = p_lines;
+		lines_offsets_dirty = true;
+	}
+}
+
+int TextParagraph::get_lines_skipped() const {
+	return lines_skipped;
 }
 
 Array TextParagraph::get_line_objects(int p_line) const {
@@ -535,91 +739,265 @@ Array TextParagraph::get_line_objects(int p_line) const {
 	return TS->shaped_text_get_objects(lines_rid[p_line]);
 }
 
+void TextParagraph::_update_line_offsets() {
+	if (lines_offsets_dirty) {
+		_shape_lines();
+
+		vsep = line_spacing;
+		line_offsets.clear();
+		line_offsets.resize(lines_rid.size());
+
+		TextServer::Orientation orientation = TS->shaped_text_get_orientation(rid);
+
+		Size2 dc_vb = TS->shaped_text_get_vertical_bounds(dropcap_rid);
+		float dc_width = TS->shaped_text_get_width(dropcap_rid) + dropcap_margins.position.x + dropcap_margins.size.x;
+
+		int visible_lines = (max_lines_visible >= 0) ? MIN(max_lines_visible, (int)lines_rid.size()) : (int)lines_rid.size();
+		int last_line = MIN((int)lines_rid.size(), visible_lines + lines_skipped);
+
+		int dc_max_line_width = 0;
+		for (int i = 0; i < dropcap_lines; i++) {
+			dc_max_line_width = MAX(dc_max_line_width, TS->shaped_text_get_width(lines_rid[i]));
+		}
+
+		int max_line_ascent = 0;
+		int max_line_descent = 0;
+		int max_line_width = dc_width + dc_max_line_width;
+		int total_h = 0;
+		for (int i = 0; i < (int)lines_rid.size(); i++) {
+			max_line_width = MAX(max_line_width, TS->shaped_text_get_width(lines_rid[i]));
+			max_line_ascent = MAX(max_line_ascent, TS->shaped_text_get_ascent(lines_rid[i]));
+			max_line_descent = MAX(max_line_descent, TS->shaped_text_get_descent(lines_rid[i]));
+			if (!uniform_line_height && i >= lines_skipped && i < last_line) {
+				total_h += TS->shaped_text_get_ascent(lines_rid[i]) + TS->shaped_text_get_descent(lines_rid[i]);
+				if (i != last_line - 1) {
+					total_h += line_spacing;
+				}
+			}
+		}
+
+		if (uniform_line_height) {
+			line_height = max_line_ascent + max_line_descent;
+			total_h = (last_line - lines_skipped) * (max_line_ascent + max_line_descent) + (last_line - lines_skipped - 1) * line_spacing;
+		} else {
+			line_height = 0.0;
+		}
+
+		Vector2 ofs;
+		if (visible_lines > 0 && height > 0) {
+			switch (vertical_alignment) {
+				case VERTICAL_ALIGNMENT_FILL: {
+					if (visible_lines > 1) {
+						vsep = (height - total_h) / (visible_lines - 1);
+					} else {
+						vsep = 0;
+					}
+				}
+					[[fallthrough]];
+				case VERTICAL_ALIGNMENT_TOP: {
+					switch (orientation) {
+						case TextServer::ORIENTATION_HORIZONTAL: {
+							if (invert_line_order) {
+								ofs.y = height;
+							} else {
+								ofs.y = 0.0;
+							}
+						} break;
+						case TextServer::ORIENTATION_VERTICAL_UPRIGHT:
+						case TextServer::ORIENTATION_VERTICAL_MIXED:
+						case TextServer::ORIENTATION_VERTICAL_SIDEWAYS: {
+							if (invert_line_order) {
+								ofs.x = 0.0;
+							} else {
+								ofs.x = height;
+							}
+						} break;
+					}
+				} break;
+				case VERTICAL_ALIGNMENT_CENTER: {
+					switch (orientation) {
+						case TextServer::ORIENTATION_HORIZONTAL: {
+							if (invert_line_order) {
+								ofs.y = (height + total_h) / 2.0;
+							} else {
+								ofs.y = (height - total_h) / 2.0;
+							}
+						} break;
+						case TextServer::ORIENTATION_VERTICAL_UPRIGHT:
+						case TextServer::ORIENTATION_VERTICAL_MIXED:
+						case TextServer::ORIENTATION_VERTICAL_SIDEWAYS: {
+							if (invert_line_order) {
+								ofs.x = (height - total_h) / 2;
+							} else {
+								ofs.x = (height + total_h) / 2;
+							}
+						} break;
+					}
+				} break;
+				case VERTICAL_ALIGNMENT_BOTTOM: {
+					switch (orientation) {
+						case TextServer::ORIENTATION_HORIZONTAL: {
+							if (invert_line_order) {
+								ofs.y = total_h;
+							} else {
+								ofs.y = height - total_h;
+							}
+						} break;
+						case TextServer::ORIENTATION_VERTICAL_UPRIGHT:
+						case TextServer::ORIENTATION_VERTICAL_MIXED:
+						case TextServer::ORIENTATION_VERTICAL_SIDEWAYS: {
+							if (invert_line_order) {
+								ofs.x = height - total_h;
+							} else {
+								ofs.x = total_h;
+							}
+						} break;
+					}
+				} break;
+			}
+		}
+		switch (orientation) {
+			case TextServer::ORIENTATION_HORIZONTAL: {
+				if (invert_line_order) {
+					dc_offset.y = ofs.y + dc_vb.y + dropcap_margins.size.y;
+				} else {
+					dc_offset.y = ofs.y + dc_vb.x + dropcap_margins.position.y;
+				}
+				if (horizontal_alignment == HORIZONTAL_ALIGNMENT_CENTER) {
+					dc_offset.x = (width - (dc_width + dc_max_line_width)) / 2.0;
+				} else if (horizontal_alignment == HORIZONTAL_ALIGNMENT_RIGHT) {
+					dc_offset.x = (width - (dc_width + dc_max_line_width));
+				}
+			} break;
+			case TextServer::ORIENTATION_VERTICAL_UPRIGHT:
+			case TextServer::ORIENTATION_VERTICAL_MIXED:
+			case TextServer::ORIENTATION_VERTICAL_SIDEWAYS: {
+				if (invert_line_order) {
+					dc_offset.x = ofs.x + dc_vb.y + dropcap_margins.size.y;
+				} else {
+					dc_offset.x = ofs.x - (dc_vb.x + dropcap_margins.position.y);
+				}
+				if (horizontal_alignment == HORIZONTAL_ALIGNMENT_CENTER) {
+					dc_offset.y = (width - (dc_width + dc_max_line_width)) / 2.0;
+				} else if (horizontal_alignment == HORIZONTAL_ALIGNMENT_RIGHT) {
+					dc_offset.y = (width - (dc_width + dc_max_line_width));
+				}
+			} break;
+		}
+
+		for (int i = lines_skipped; i < last_line; i++) {
+			if (orientation == TextServer::ORIENTATION_HORIZONTAL) {
+				if (invert_line_order) {
+					ofs.y -= (uniform_line_height) ? max_line_descent : TS->shaped_text_get_descent(lines_rid[i]);
+				} else {
+					ofs.y += (uniform_line_height) ? max_line_ascent : TS->shaped_text_get_ascent(lines_rid[i]);
+				}
+			} else {
+				if (invert_line_order) {
+					ofs.x += (uniform_line_height) ? max_line_descent : TS->shaped_text_get_descent(lines_rid[i]);
+				} else {
+					ofs.x -= (uniform_line_height) ? max_line_ascent : TS->shaped_text_get_ascent(lines_rid[i]);
+				}
+			}
+			float line_width = TS->shaped_text_get_width(lines_rid[i]);
+			float avail_width = width;
+			float start_off = 0.0;
+			if (i < dropcap_lines) {
+				avail_width = dc_max_line_width;
+				if (orientation == TextServer::ORIENTATION_HORIZONTAL) {
+					start_off = dc_offset.x + dc_width;
+				} else {
+					start_off = dc_offset.y + dc_width;
+				}
+			}
+			if (avail_width > 0) {
+				switch (horizontal_alignment) {
+					case HORIZONTAL_ALIGNMENT_FILL:
+					case HORIZONTAL_ALIGNMENT_LEFT: {
+						switch (orientation) {
+							case TextServer::ORIENTATION_HORIZONTAL: {
+								ofs.x = start_off;
+							} break;
+							case TextServer::ORIENTATION_VERTICAL_UPRIGHT:
+							case TextServer::ORIENTATION_VERTICAL_MIXED:
+							case TextServer::ORIENTATION_VERTICAL_SIDEWAYS: {
+								ofs.y = start_off;
+							} break;
+						}
+					} break;
+					case HORIZONTAL_ALIGNMENT_CENTER: {
+						switch (orientation) {
+							case TextServer::ORIENTATION_HORIZONTAL: {
+								ofs.x = start_off + (avail_width - line_width) / 2.0;
+							} break;
+							case TextServer::ORIENTATION_VERTICAL_UPRIGHT:
+							case TextServer::ORIENTATION_VERTICAL_MIXED:
+							case TextServer::ORIENTATION_VERTICAL_SIDEWAYS: {
+								ofs.y = start_off + (avail_width - line_width) / 2.0;
+							} break;
+						}
+					} break;
+					case HORIZONTAL_ALIGNMENT_RIGHT: {
+						switch (orientation) {
+							case TextServer::ORIENTATION_HORIZONTAL: {
+								ofs.x = start_off + (avail_width - line_width);
+							} break;
+							case TextServer::ORIENTATION_VERTICAL_UPRIGHT:
+							case TextServer::ORIENTATION_VERTICAL_MIXED:
+							case TextServer::ORIENTATION_VERTICAL_SIDEWAYS: {
+								ofs.y = start_off + (avail_width - line_width);
+							} break;
+						}
+					} break;
+				}
+			}
+			line_offsets.write[i] = ofs;
+			if (orientation == TextServer::ORIENTATION_HORIZONTAL) {
+				if (invert_line_order) {
+					ofs.y -= (uniform_line_height) ? (max_line_ascent + vsep) : (TS->shaped_text_get_ascent(lines_rid[i]) + vsep);
+				} else {
+					ofs.y += (uniform_line_height) ? (max_line_descent + vsep) : (TS->shaped_text_get_descent(lines_rid[i]) + vsep);
+				}
+			} else {
+				if (invert_line_order) {
+					ofs.x += (uniform_line_height) ? (max_line_ascent + vsep) : (TS->shaped_text_get_ascent(lines_rid[i]) + vsep);
+				} else {
+					ofs.x -= (uniform_line_height) ? (max_line_descent + vsep) : (TS->shaped_text_get_descent(lines_rid[i]) + vsep);
+				}
+			}
+		}
+		if (orientation == TextServer::ORIENTATION_HORIZONTAL) {
+			dc_offset.x += dropcap_margins.position.x;
+		} else {
+			dc_offset.y += dropcap_margins.position.x;
+		}
+
+		lines_offsets_dirty = false;
+	}
+}
+
+Vector2 TextParagraph::get_dropcap_offset() const {
+	_THREAD_SAFE_METHOD_
+
+	const_cast<TextParagraph *>(this)->_update_line_offsets();
+	return dc_offset;
+}
+
+Vector2 TextParagraph::get_line_offset(int p_line) const {
+	_THREAD_SAFE_METHOD_
+
+	const_cast<TextParagraph *>(this)->_update_line_offsets();
+	ERR_FAIL_COND_V(p_line < 0 || p_line >= (int)lines_rid.size(), Vector2());
+	return line_offsets[p_line];
+}
+
 Rect2 TextParagraph::get_line_object_rect(int p_line, Variant p_key) const {
 	_THREAD_SAFE_METHOD_
 
 	const_cast<TextParagraph *>(this)->_shape_lines();
 	ERR_FAIL_COND_V(p_line < 0 || p_line >= (int)lines_rid.size(), Rect2());
 
-	Vector2 ofs;
-
-	float h_offset = 0.f;
-	if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
-		h_offset = TS->shaped_text_get_size(dropcap_rid).x + dropcap_margins.size.x + dropcap_margins.position.x;
-	} else {
-		h_offset = TS->shaped_text_get_size(dropcap_rid).y + dropcap_margins.size.y + dropcap_margins.position.y;
-	}
-
-	for (int i = 0; i <= p_line; i++) {
-		float l_width = width;
-		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-			ofs.x = 0.f;
-			ofs.y += TS->shaped_text_get_ascent(lines_rid[i]);
-			if (i <= dropcap_lines) {
-				if (TS->shaped_text_get_inferred_direction(dropcap_rid) == TextServer::DIRECTION_LTR) {
-					ofs.x -= h_offset;
-				}
-				l_width -= h_offset;
-			}
-		} else {
-			ofs.y = 0.f;
-			ofs.x += TS->shaped_text_get_ascent(lines_rid[i]);
-			if (i <= dropcap_lines) {
-				if (TS->shaped_text_get_inferred_direction(dropcap_rid) == TextServer::DIRECTION_LTR) {
-					ofs.x -= h_offset;
-				}
-				l_width -= h_offset;
-			}
-		}
-		float length = TS->shaped_text_get_width(lines_rid[i]);
-		if (width > 0) {
-			switch (alignment) {
-				case HORIZONTAL_ALIGNMENT_FILL:
-					if (TS->shaped_text_get_inferred_direction(lines_rid[i]) == TextServer::DIRECTION_RTL) {
-						if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-							ofs.x += l_width - length;
-						} else {
-							ofs.y += l_width - length;
-						}
-					}
-					break;
-				case HORIZONTAL_ALIGNMENT_LEFT:
-					break;
-				case HORIZONTAL_ALIGNMENT_CENTER: {
-					if (length <= l_width) {
-						if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-							ofs.x += Math::floor((l_width - length) / 2.0);
-						} else {
-							ofs.y += Math::floor((l_width - length) / 2.0);
-						}
-					} else if (TS->shaped_text_get_inferred_direction(lines_rid[i]) == TextServer::DIRECTION_RTL) {
-						if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-							ofs.x += l_width - length;
-						} else {
-							ofs.y += l_width - length;
-						}
-					}
-				} break;
-				case HORIZONTAL_ALIGNMENT_RIGHT: {
-					if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-						ofs.x += l_width - length;
-					} else {
-						ofs.y += l_width - length;
-					}
-				} break;
-			}
-		}
-		if (i != p_line) {
-			if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-				ofs.x = 0.f;
-				ofs.y += TS->shaped_text_get_descent(lines_rid[i]);
-			} else {
-				ofs.y = 0.f;
-				ofs.x += TS->shaped_text_get_descent(lines_rid[i]);
-			}
-		}
-	}
-
+	Vector2 ofs = get_line_offset(p_line);
 	Rect2 rect = TS->shaped_text_get_object_rect(lines_rid[p_line], p_key);
 	rect.position += ofs;
 
@@ -632,9 +1010,9 @@ Size2 TextParagraph::get_line_size(int p_line) const {
 	const_cast<TextParagraph *>(this)->_shape_lines();
 	ERR_FAIL_COND_V(p_line < 0 || p_line >= (int)lines_rid.size(), Size2());
 	if (TS->shaped_text_get_orientation(lines_rid[p_line]) == TextServer::ORIENTATION_HORIZONTAL) {
-		return Size2(TS->shaped_text_get_size(lines_rid[p_line]).x, TS->shaped_text_get_size(lines_rid[p_line]).y);
+		return Size2(TS->shaped_text_get_size(lines_rid[p_line]).x, (uniform_line_height) ? line_height : TS->shaped_text_get_size(lines_rid[p_line]).y);
 	} else {
-		return Size2(TS->shaped_text_get_size(lines_rid[p_line]).x, TS->shaped_text_get_size(lines_rid[p_line]).y);
+		return Size2((uniform_line_height) ? line_height : TS->shaped_text_get_size(lines_rid[p_line]).x, TS->shaped_text_get_size(lines_rid[p_line]).y);
 	}
 }
 
@@ -696,236 +1074,233 @@ int TextParagraph::get_dropcap_lines() const {
 	return dropcap_lines;
 }
 
-void TextParagraph::draw(RID p_canvas, const Vector2 &p_pos, const Color &p_color, const Color &p_dc_color) const {
-	_THREAD_SAFE_METHOD_
-
-	const_cast<TextParagraph *>(this)->_shape_lines();
-	Vector2 ofs = p_pos;
-	float h_offset = 0.f;
-	if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
-		h_offset = TS->shaped_text_get_size(dropcap_rid).x + dropcap_margins.size.x + dropcap_margins.position.x;
-	} else {
-		h_offset = TS->shaped_text_get_size(dropcap_rid).y + dropcap_margins.size.y + dropcap_margins.position.y;
-	}
-
-	if (h_offset > 0) {
-		// Draw dropcap.
-		Vector2 dc_off = ofs;
-		if (TS->shaped_text_get_inferred_direction(dropcap_rid) == TextServer::DIRECTION_RTL) {
-			if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
-				dc_off.x += width - h_offset;
-			} else {
-				dc_off.y += width - h_offset;
-			}
+bool TextParagraph::has_invalid_glyphs() const {
+	const Glyph *glyph = TS->shaped_text_get_glyphs(dropcap_rid);
+	int64_t glyph_count = TS->shaped_text_get_glyph_count(dropcap_rid);
+	for (int64_t i = 0; i < glyph_count; i++) {
+		if (glyph[i].font_rid == RID()) {
+			return true;
 		}
-		TS->shaped_text_draw(dropcap_rid, p_canvas, dc_off + Vector2(0, TS->shaped_text_get_ascent(dropcap_rid) + dropcap_margins.size.y + dropcap_margins.position.y / 2), -1, -1, p_dc_color);
 	}
 
 	int lines_visible = (max_lines_visible >= 0) ? MIN(max_lines_visible, (int)lines_rid.size()) : (int)lines_rid.size();
-
-	for (int i = 0; i < lines_visible; i++) {
-		float l_width = width;
-		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-			ofs.x = p_pos.x;
-			ofs.y += TS->shaped_text_get_ascent(lines_rid[i]);
-			if (i <= dropcap_lines) {
-				if (TS->shaped_text_get_inferred_direction(dropcap_rid) == TextServer::DIRECTION_LTR) {
-					ofs.x -= h_offset;
-				}
-				l_width -= h_offset;
+	int last_line = MIN((int)lines_rid.size(), lines_visible + lines_skipped);
+	for (int i = lines_skipped; i < last_line; i++) {
+		glyph = TS->shaped_text_get_glyphs(lines_rid[i]);
+		glyph_count = TS->shaped_text_get_glyph_count(lines_rid[i]);
+		for (int64_t j = 0; j < glyph_count; j++) {
+			if (glyph[j].font_rid == RID()) {
+				return true;
 			}
-		} else {
-			ofs.y = p_pos.y;
-			ofs.x += TS->shaped_text_get_ascent(lines_rid[i]);
-			if (i <= dropcap_lines) {
-				if (TS->shaped_text_get_inferred_direction(dropcap_rid) == TextServer::DIRECTION_LTR) {
-					ofs.x -= h_offset;
-				}
-				l_width -= h_offset;
-			}
-		}
-		float line_width = TS->shaped_text_get_width(lines_rid[i]);
-		if (width > 0) {
-			switch (alignment) {
-				case HORIZONTAL_ALIGNMENT_FILL:
-					if (TS->shaped_text_get_inferred_direction(lines_rid[i]) == TextServer::DIRECTION_RTL) {
-						if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-							ofs.x += l_width - line_width;
-						} else {
-							ofs.y += l_width - line_width;
-						}
-					}
-					break;
-				case HORIZONTAL_ALIGNMENT_LEFT:
-					break;
-				case HORIZONTAL_ALIGNMENT_CENTER: {
-					if (line_width <= l_width) {
-						if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-							ofs.x += Math::floor((l_width - line_width) / 2.0);
-						} else {
-							ofs.y += Math::floor((l_width - line_width) / 2.0);
-						}
-					} else if (TS->shaped_text_get_inferred_direction(lines_rid[i]) == TextServer::DIRECTION_RTL) {
-						if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-							ofs.x += l_width - line_width;
-						} else {
-							ofs.y += l_width - line_width;
-						}
-					}
-				} break;
-				case HORIZONTAL_ALIGNMENT_RIGHT: {
-					if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-						ofs.x += l_width - line_width;
-					} else {
-						ofs.y += l_width - line_width;
-					}
-				} break;
-			}
-		}
-		float clip_l;
-		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-			clip_l = MAX(0, p_pos.x - ofs.x);
-		} else {
-			clip_l = MAX(0, p_pos.y - ofs.y);
-		}
-		TS->shaped_text_draw(lines_rid[i], p_canvas, ofs, clip_l, clip_l + l_width, p_color);
-		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-			ofs.x = p_pos.x;
-			ofs.y += TS->shaped_text_get_descent(lines_rid[i]);
-		} else {
-			ofs.y = p_pos.y;
-			ofs.x += TS->shaped_text_get_descent(lines_rid[i]);
 		}
 	}
+	return false;
 }
 
-void TextParagraph::draw_outline(RID p_canvas, const Vector2 &p_pos, int p_outline_size, const Color &p_color, const Color &p_dc_color) const {
+int TextParagraph::get_glyph_count() const {
+	int count = TS->shaped_text_get_glyph_count(dropcap_rid) + TS->shaped_text_get_ellipsis_glyph_count(dropcap_rid);
+
+	int lines_visible = (max_lines_visible >= 0) ? MIN(max_lines_visible, (int)lines_rid.size()) : (int)lines_rid.size();
+	int last_line = MIN((int)lines_rid.size(), lines_visible + lines_skipped);
+	for (int i = lines_skipped; i < last_line; i++) {
+		count += TS->shaped_text_get_glyph_count(lines_rid[i]) + TS->shaped_text_get_ellipsis_glyph_count(lines_rid[i]);
+	}
+
+	return count;
+}
+
+void TextParagraph::draw_underline_custom(const Vector2 &p_pos, TextServer::LinePosition p_line, int p_start, int p_end, std::function<bool(const Rect2 &, int)> p_draw_fn) const {
+	TextServer::Orientation orientation = TS->shaped_text_get_orientation(rid);
+
+	draw_custom(
+			p_pos,
+			[&](const Glyph &p_gl, const Vector2 &p_ofs, int p_line_id) {
+				if (p_gl.font_rid != RID() && p_gl.start >= p_start && p_gl.end <= p_end) {
+					float l_ofs = 0.0;
+					switch (p_line) {
+						case TextServer::UNDERLINE: {
+							l_ofs = TS->font_get_underline_position(p_gl.font_rid, p_gl.font_size);
+						} break;
+						case TextServer::OVERDERLINE: {
+							l_ofs = -TS->font_get_ascent(p_gl.font_rid, p_gl.font_size);
+						} break;
+						case TextServer::STRIKETHROUGH: {
+							l_ofs = -(TS->font_get_ascent(p_gl.font_rid, p_gl.font_size) + TS->font_get_descent(p_gl.font_rid, p_gl.font_size)) / 2.0;
+						} break;
+					}
+					float l_h = TS->font_get_underline_thickness(p_gl.font_rid, p_gl.font_size);
+					float l_w = p_gl.advance;
+					if (orientation == TextServer::ORIENTATION_HORIZONTAL) {
+						return p_draw_fn(Rect2(p_ofs + Vector2(0, l_ofs), Vector2(l_w, l_h)), p_line_id);
+					} else {
+						return p_draw_fn(Rect2(p_ofs + Vector2(-l_ofs, 0), Vector2(l_h, l_w)), p_line_id);
+					}
+				}
+				return true;
+			});
+}
+
+void TextParagraph::_draw_underline_custom(RID p_canvas, const Vector2 &p_pos, TextServer::LinePosition p_line, int p_start, int p_end, const Callable &p_callback) const {
+	draw_underline_custom(
+			p_pos,
+			p_line,
+			p_start,
+			p_end,
+			[&](const Rect2 &p_rect, int p_line_id) {
+				Variant args[] = { p_rect, p_canvas, p_line_id };
+				const Variant *args_ptr[] = { &args[0], &args[1], &args[2] };
+				Variant ret;
+				Callable::CallError ce;
+				p_callback.callp(args_ptr, 3, ret, ce);
+				if (ce.error != Callable::CallError::CALL_OK) {
+					ERR_PRINT_ONCE("Error calling glyph draw callback method " + Variant::get_callable_error_text(p_callback, args_ptr, 3, ce));
+				}
+				return ret.operator bool();
+			});
+}
+
+void TextParagraph::draw_custom(const Vector2 &p_pos, std::function<bool(const Glyph &, const Vector2 &, int)> p_draw_fn) const {
 	_THREAD_SAFE_METHOD_
 
 	const_cast<TextParagraph *>(this)->_shape_lines();
-	Vector2 ofs = p_pos;
+	const_cast<TextParagraph *>(this)->_update_line_offsets();
 
-	float h_offset = 0.f;
-	if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
-		h_offset = TS->shaped_text_get_size(dropcap_rid).x + dropcap_margins.size.x + dropcap_margins.position.x;
-	} else {
-		h_offset = TS->shaped_text_get_size(dropcap_rid).y + dropcap_margins.size.y + dropcap_margins.position.y;
-	}
+	TextServer::Orientation orientation = TS->shaped_text_get_orientation(rid);
 
-	if (h_offset > 0) {
-		// Draw dropcap.
-		Vector2 dc_off = ofs;
-		if (TS->shaped_text_get_inferred_direction(dropcap_rid) == TextServer::DIRECTION_RTL) {
-			if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
-				dc_off.x += width - h_offset;
-			} else {
-				dc_off.y += width - h_offset;
-			}
-		}
-		TS->shaped_text_draw_outline(dropcap_rid, p_canvas, dc_off + Vector2(dropcap_margins.position.x, TS->shaped_text_get_ascent(dropcap_rid) + dropcap_margins.position.y), -1, -1, p_outline_size, p_dc_color);
-	}
-
-	for (int i = 0; i < (int)lines_rid.size(); i++) {
-		float l_width = width;
-		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-			ofs.x = p_pos.x;
-			ofs.y += TS->shaped_text_get_ascent(lines_rid[i]);
-			if (i <= dropcap_lines) {
-				if (TS->shaped_text_get_inferred_direction(dropcap_rid) == TextServer::DIRECTION_LTR) {
-					ofs.x -= h_offset;
+	// Draw dropcap.
+	if (lines_skipped < dropcap_lines) {
+		Vector2 ofs = dc_offset;
+		bool clip_line = false;
+		float clip_l = -1.0;
+		float clip_r = -1.0;
+		if (clip) {
+			if (height > 0) {
+				if (orientation == TextServer::ORIENTATION_HORIZONTAL) {
+					clip_line = ((ofs.y + TS->shaped_text_get_vertical_bounds(dropcap_rid).y) < 0.0 || (ofs.y - TS->shaped_text_get_vertical_bounds(dropcap_rid).x) > height);
+				} else {
+					clip_line = ((ofs.x + TS->shaped_text_get_vertical_bounds(dropcap_rid).x) < 0.0 || (ofs.x - TS->shaped_text_get_vertical_bounds(dropcap_rid).y) > height);
 				}
-				l_width -= h_offset;
 			}
-		} else {
-			ofs.y = p_pos.y;
-			ofs.x += TS->shaped_text_get_ascent(lines_rid[i]);
-			if (i <= dropcap_lines) {
-				if (TS->shaped_text_get_inferred_direction(dropcap_rid) == TextServer::DIRECTION_LTR) {
-					ofs.x -= h_offset;
+			if (width > 0.0) {
+				if (orientation == TextServer::ORIENTATION_HORIZONTAL) {
+					clip_l = Math::floor(MAX(0.0, -ofs.x));
+					clip_r = Math::ceil(width + clip_l);
+				} else {
+					clip_l = Math::floor(MAX(0, -ofs.y));
+					clip_r = Math::ceil(width + clip_l);
 				}
-				l_width -= h_offset;
 			}
 		}
-		float length = TS->shaped_text_get_width(lines_rid[i]);
-		if (width > 0) {
-			switch (alignment) {
-				case HORIZONTAL_ALIGNMENT_FILL:
-					if (TS->shaped_text_get_inferred_direction(lines_rid[i]) == TextServer::DIRECTION_RTL) {
-						if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-							ofs.x += l_width - length;
-						} else {
-							ofs.y += l_width - length;
-						}
-					}
-					break;
-				case HORIZONTAL_ALIGNMENT_LEFT:
-					break;
-				case HORIZONTAL_ALIGNMENT_CENTER: {
-					if (length <= l_width) {
-						if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-							ofs.x += Math::floor((l_width - length) / 2.0);
-						} else {
-							ofs.y += Math::floor((l_width - length) / 2.0);
-						}
-					} else if (TS->shaped_text_get_inferred_direction(lines_rid[i]) == TextServer::DIRECTION_RTL) {
-						if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-							ofs.x += l_width - length;
-						} else {
-							ofs.y += l_width - length;
-						}
-					}
-				} break;
-				case HORIZONTAL_ALIGNMENT_RIGHT: {
-					if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-						ofs.x += l_width - length;
-					} else {
-						ofs.y += l_width - length;
-					}
-				} break;
-			}
-		}
-		float clip_l;
-		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-			clip_l = MAX(0, p_pos.x - ofs.x);
-		} else {
-			clip_l = MAX(0, p_pos.y - ofs.y);
-		}
-		TS->shaped_text_draw_outline(lines_rid[i], p_canvas, ofs, clip_l, clip_l + l_width, p_outline_size, p_color);
-		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
-			ofs.x = p_pos.x;
-			ofs.y += TS->shaped_text_get_descent(lines_rid[i]);
-		} else {
-			ofs.y = p_pos.y;
-			ofs.x += TS->shaped_text_get_descent(lines_rid[i]);
+		if (!clip_line) {
+			TS->shaped_text_draw_custom(dropcap_rid, ofs + p_pos, clip_l, clip_r, p_draw_fn, -1);
 		}
 	}
+
+	int lines_visible = (max_lines_visible >= 0) ? MIN(max_lines_visible, (int)lines_rid.size()) : (int)lines_rid.size();
+	int last_line = MIN((int)lines_rid.size(), lines_visible + lines_skipped);
+
+	for (int i = lines_skipped; i < last_line; i++) {
+		Vector2 ofs = get_line_offset(i);
+		float clip_l = -1.0;
+		float clip_r = -1.0;
+		if (clip) {
+			if (height > 0.0) {
+				if (orientation == TextServer::ORIENTATION_HORIZONTAL) {
+					if ((ofs.y + TS->shaped_text_get_descent(lines_rid[i])) < 0.0 || (ofs.y - TS->shaped_text_get_ascent(lines_rid[i])) > height) {
+						continue;
+					}
+				} else {
+					if ((ofs.x + TS->shaped_text_get_ascent(lines_rid[i])) < 0.0 || (ofs.x - TS->shaped_text_get_descent(lines_rid[i])) > height) {
+						continue;
+					}
+				}
+			}
+			if (width > 0.0) {
+				if (orientation == TextServer::ORIENTATION_HORIZONTAL) {
+					clip_l = Math::floor(MAX(0, -ofs.x));
+					clip_r = Math::ceil(width + clip_l);
+				} else {
+					clip_l = Math::floor(MAX(0, -ofs.y));
+					clip_r = Math::ceil(width + clip_l);
+				}
+			}
+		}
+		TS->shaped_text_draw_custom(lines_rid[i], ofs + p_pos, clip_l, clip_r, p_draw_fn, i);
+	}
+}
+
+void TextParagraph::_draw_custom(RID p_canvas, const Vector2 &p_pos, const Callable &p_callback) const {
+	draw_custom(
+			p_pos,
+			[&](const Glyph &p_gl, const Vector2 &p_ofs, int p_line_id) {
+				Dictionary glyph;
+
+				glyph["start"] = p_gl.start;
+				glyph["end"] = p_gl.end;
+				glyph["repeat"] = p_gl.repeat;
+				glyph["count"] = p_gl.count;
+				glyph["flags"] = p_gl.flags;
+				glyph["offset"] = Vector2(p_gl.x_off, p_gl.y_off);
+				glyph["advance"] = p_gl.advance;
+				glyph["font_rid"] = p_gl.font_rid;
+				glyph["font_size"] = p_gl.font_size;
+				glyph["index"] = p_gl.index;
+
+				Variant args[] = { glyph, p_ofs, p_canvas, p_line_id };
+				const Variant *args_ptr[] = { &args[0], &args[1], &args[2], &args[3] };
+				Variant ret;
+				Callable::CallError ce;
+				p_callback.callp(args_ptr, 4, ret, ce);
+				if (ce.error != Callable::CallError::CALL_OK) {
+					ERR_PRINT_ONCE("Error calling glyph draw callback method " + Variant::get_callable_error_text(p_callback, args_ptr, 4, ce));
+				}
+				return ret.operator bool();
+			});
+}
+
+void TextParagraph::draw(RID p_canvas, const Vector2 &p_pos, const Color &p_color, const Color &p_dc_color) const {
+	bool hex_codes = TS->shaped_text_get_preserve_control(rid) || TS->shaped_text_get_preserve_invalid(rid);
+	draw_custom(
+			p_pos,
+			[&](const Glyph &p_gl, const Vector2 &p_ofs, int p_line_id) {
+				if (p_gl.font_rid != RID()) {
+					TS->font_draw_glyph(p_gl.font_rid, p_canvas, p_gl.font_size, p_ofs, p_gl.index, (p_line_id == -1) ? p_dc_color : p_color);
+				} else if (hex_codes && ((p_gl.flags & TextServer::GRAPHEME_IS_VIRTUAL) != TextServer::GRAPHEME_IS_VIRTUAL)) {
+					TS->draw_hex_code_box(p_canvas, p_gl.font_size, p_ofs, p_gl.index, (p_line_id == -1) ? p_dc_color : p_color);
+				}
+				return true;
+			});
+}
+
+void TextParagraph::draw_outline(RID p_canvas, const Vector2 &p_pos, int p_outline_size, const Color &p_color, const Color &p_dc_color) const {
+	draw_custom(
+			p_pos,
+			[&](const Glyph &p_gl, const Vector2 &p_ofs, int p_line_id) {
+				if (p_gl.font_rid != RID()) {
+					TS->font_draw_glyph_outline(p_gl.font_rid, p_canvas, p_gl.font_size, p_outline_size, p_ofs, p_gl.index, (p_line_id == -1) ? p_dc_color : p_color);
+				}
+				return true;
+			});
 }
 
 int TextParagraph::hit_test(const Point2 &p_coords) const {
 	_THREAD_SAFE_METHOD_
 
 	const_cast<TextParagraph *>(this)->_shape_lines();
-	Vector2 ofs;
-	if (TS->shaped_text_get_orientation(rid) == TextServer::ORIENTATION_HORIZONTAL) {
-		if (ofs.y < 0) {
-			return 0;
-		}
-	} else {
-		if (ofs.x < 0) {
-			return 0;
-		}
-	}
+	const_cast<TextParagraph *>(this)->_update_line_offsets();
+
+	TextServer::Orientation orientation = TS->shaped_text_get_orientation(rid);
+
 	for (int i = 0; i < (int)lines_rid.size(); i++) {
-		if (TS->shaped_text_get_orientation(lines_rid[i]) == TextServer::ORIENTATION_HORIZONTAL) {
+		Vector2 ofs = get_line_offset(i);
+		if (orientation == TextServer::ORIENTATION_HORIZONTAL) {
 			if ((p_coords.y >= ofs.y) && (p_coords.y <= ofs.y + TS->shaped_text_get_size(lines_rid[i]).y)) {
 				return TS->shaped_text_hit_test_position(lines_rid[i], p_coords.x);
 			}
-			ofs.y += TS->shaped_text_get_size(lines_rid[i]).y;
 		} else {
 			if ((p_coords.x >= ofs.x) && (p_coords.x <= ofs.x + TS->shaped_text_get_size(lines_rid[i]).x)) {
 				return TS->shaped_text_hit_test_position(lines_rid[i], p_coords.y);
 			}
-			ofs.y += TS->shaped_text_get_size(lines_rid[i]).x;
 		}
 	}
 	return TS->shaped_text_get_range(rid).y;
@@ -934,49 +1309,17 @@ int TextParagraph::hit_test(const Point2 &p_coords) const {
 void TextParagraph::draw_dropcap(RID p_canvas, const Vector2 &p_pos, const Color &p_color) const {
 	_THREAD_SAFE_METHOD_
 
-	Vector2 ofs = p_pos;
-	float h_offset = 0.f;
-	if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
-		h_offset = TS->shaped_text_get_size(dropcap_rid).x + dropcap_margins.size.x + dropcap_margins.position.x;
-	} else {
-		h_offset = TS->shaped_text_get_size(dropcap_rid).y + dropcap_margins.size.y + dropcap_margins.position.y;
-	}
+	const_cast<TextParagraph *>(this)->_shape_lines();
 
-	if (h_offset > 0) {
-		// Draw dropcap.
-		if (TS->shaped_text_get_inferred_direction(dropcap_rid) == TextServer::DIRECTION_RTL) {
-			if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
-				ofs.x += width - h_offset;
-			} else {
-				ofs.y += width - h_offset;
-			}
-		}
-		TS->shaped_text_draw(dropcap_rid, p_canvas, ofs + Vector2(dropcap_margins.position.x, TS->shaped_text_get_ascent(dropcap_rid) + dropcap_margins.position.y), -1, -1, p_color);
-	}
+	TS->shaped_text_draw(dropcap_rid, p_canvas, p_pos, -1, -1, p_color);
 }
 
 void TextParagraph::draw_dropcap_outline(RID p_canvas, const Vector2 &p_pos, int p_outline_size, const Color &p_color) const {
 	_THREAD_SAFE_METHOD_
 
-	Vector2 ofs = p_pos;
-	float h_offset = 0.f;
-	if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
-		h_offset = TS->shaped_text_get_size(dropcap_rid).x + dropcap_margins.size.x + dropcap_margins.position.x;
-	} else {
-		h_offset = TS->shaped_text_get_size(dropcap_rid).y + dropcap_margins.size.y + dropcap_margins.position.y;
-	}
+	const_cast<TextParagraph *>(this)->_shape_lines();
 
-	if (h_offset > 0) {
-		// Draw dropcap.
-		if (TS->shaped_text_get_inferred_direction(dropcap_rid) == TextServer::DIRECTION_RTL) {
-			if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
-				ofs.x += width - h_offset;
-			} else {
-				ofs.y += width - h_offset;
-			}
-		}
-		TS->shaped_text_draw_outline(dropcap_rid, p_canvas, ofs + Vector2(dropcap_margins.position.x, TS->shaped_text_get_ascent(dropcap_rid) + dropcap_margins.position.y), -1, -1, p_outline_size, p_color);
-	}
+	TS->shaped_text_draw_outline(dropcap_rid, p_canvas, p_pos, -1, -1, p_outline_size, p_color);
 }
 
 void TextParagraph::draw_line(RID p_canvas, const Vector2 &p_pos, int p_line, const Color &p_color) const {
@@ -1010,7 +1353,7 @@ void TextParagraph::draw_line_outline(RID p_canvas, const Vector2 &p_pos, int p_
 	return TS->shaped_text_draw_outline(lines_rid[p_line], p_canvas, ofs, -1, -1, p_outline_size, p_color);
 }
 
-TextParagraph::TextParagraph(const String &p_text, const Ref<Font> &p_font, int p_font_size, const String &p_language, float p_width, TextServer::Direction p_direction, TextServer::Orientation p_orientation) {
+TextParagraph::TextParagraph(const String &p_text, const Ref<Font> &p_font, int p_font_size, const String &p_language, float p_width, float p_height, TextServer::Direction p_direction, TextServer::Orientation p_orientation) {
 	rid = TS->create_shaped_text(p_direction, p_orientation);
 	if (p_font.is_valid()) {
 		TS->shaped_text_add_string(rid, p_text, p_font->get_rids(), p_font_size, p_font->get_opentype_features(), p_language);
@@ -1019,6 +1362,7 @@ TextParagraph::TextParagraph(const String &p_text, const Ref<Font> &p_font, int 
 		}
 	}
 	width = p_width;
+	height = p_height;
 }
 
 TextParagraph::TextParagraph() {

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -182,8 +182,8 @@ void TextServerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_font_has_char, "font_rid", "char");
 	GDVIRTUAL_BIND(_font_get_supported_chars, "font_rid");
 
-	GDVIRTUAL_BIND(_font_render_range, "font_rid", "size", "start", "end");
-	GDVIRTUAL_BIND(_font_render_glyph, "font_rid", "size", "index");
+	GDVIRTUAL_BIND(_font_render_range, "font_rid", "size", "start", "end", "include_sideways");
+	GDVIRTUAL_BIND(_font_render_glyph, "font_rid", "size", "index", "include_sideways");
 
 	GDVIRTUAL_BIND(_font_draw_glyph, "font_rid", "canvas", "size", "pos", "index", "color");
 	GDVIRTUAL_BIND(_font_draw_glyph_outline, "font_rid", "canvas", "size", "outline_size", "pos", "index", "color");
@@ -280,6 +280,7 @@ void TextServerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_shaped_text_get_object_rect, "shaped", "key");
 
 	GDVIRTUAL_BIND(_shaped_text_get_size, "shaped");
+	GDVIRTUAL_BIND(_shaped_text_get_vertical_bounds, "shaped");
 	GDVIRTUAL_BIND(_shaped_text_get_ascent, "shaped");
 	GDVIRTUAL_BIND(_shaped_text_get_descent, "shaped");
 	GDVIRTUAL_BIND(_shaped_text_get_width, "shaped");
@@ -837,12 +838,12 @@ String TextServerExtension::font_get_supported_chars(const RID &p_font_rid) cons
 	return ret;
 }
 
-void TextServerExtension::font_render_range(const RID &p_font_rid, const Vector2i &p_size, int64_t p_start, int64_t p_end) {
-	GDVIRTUAL_CALL(_font_render_range, p_font_rid, p_size, p_start, p_end);
+void TextServerExtension::font_render_range(const RID &p_font_rid, const Vector2i &p_size, int64_t p_start, int64_t p_end, bool p_include_sideways) {
+	GDVIRTUAL_CALL(_font_render_range, p_font_rid, p_size, p_start, p_end, p_include_sideways);
 }
 
-void TextServerExtension::font_render_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_index) {
-	GDVIRTUAL_CALL(_font_render_glyph, p_font_rid, p_size, p_index);
+void TextServerExtension::font_render_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_index, bool p_include_sideways) {
+	GDVIRTUAL_CALL(_font_render_glyph, p_font_rid, p_size, p_index, p_include_sideways);
 }
 
 void TextServerExtension::font_draw_glyph(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const {
@@ -1208,6 +1209,12 @@ Rect2 TextServerExtension::shaped_text_get_object_rect(const RID &p_shaped, cons
 Size2 TextServerExtension::shaped_text_get_size(const RID &p_shaped) const {
 	Size2 ret;
 	GDVIRTUAL_CALL(_shaped_text_get_size, p_shaped, ret);
+	return ret;
+}
+
+Size2 TextServerExtension::shaped_text_get_vertical_bounds(const RID &p_shaped) const {
+	Size2 ret;
+	GDVIRTUAL_CALL(_shaped_text_get_vertical_bounds, p_shaped, ret);
 	return ret;
 }
 

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -299,10 +299,10 @@ public:
 	GDVIRTUAL2RC(bool, _font_has_char, RID, int64_t);
 	GDVIRTUAL1RC(String, _font_get_supported_chars, RID);
 
-	virtual void font_render_range(const RID &p_font, const Vector2i &p_size, int64_t p_start, int64_t p_end) override;
-	virtual void font_render_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_index) override;
-	GDVIRTUAL4(_font_render_range, RID, const Vector2i &, int64_t, int64_t);
-	GDVIRTUAL3(_font_render_glyph, RID, const Vector2i &, int64_t);
+	virtual void font_render_range(const RID &p_font, const Vector2i &p_size, int64_t p_start, int64_t p_end, bool p_include_sideways = false) override;
+	virtual void font_render_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_index, bool p_include_sideways = false) override;
+	GDVIRTUAL5(_font_render_range, RID, const Vector2i &, int64_t, int64_t, bool);
+	GDVIRTUAL4(_font_render_glyph, RID, const Vector2i &, int64_t, bool);
 
 	virtual void font_draw_glyph(const RID &p_font, const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color = Color(1, 1, 1)) const override;
 	virtual void font_draw_glyph_outline(const RID &p_font, const RID &p_canvas, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color = Color(1, 1, 1)) const override;
@@ -463,12 +463,14 @@ public:
 	GDVIRTUAL2RC(Rect2, _shaped_text_get_object_rect, RID, const Variant &);
 
 	virtual Size2 shaped_text_get_size(const RID &p_shaped) const override;
+	virtual Size2 shaped_text_get_vertical_bounds(const RID &p_shaped) const override;
 	virtual double shaped_text_get_ascent(const RID &p_shaped) const override;
 	virtual double shaped_text_get_descent(const RID &p_shaped) const override;
 	virtual double shaped_text_get_width(const RID &p_shaped) const override;
 	virtual double shaped_text_get_underline_position(const RID &p_shaped) const override;
 	virtual double shaped_text_get_underline_thickness(const RID &p_shaped) const override;
 	GDVIRTUAL1RC(Size2, _shaped_text_get_size, RID);
+	GDVIRTUAL1RC(Size2, _shaped_text_get_vertical_bounds, RID);
 	GDVIRTUAL1RC(double, _shaped_text_get_ascent, RID);
 	GDVIRTUAL1RC(double, _shaped_text_get_descent, RID);
 	GDVIRTUAL1RC(double, _shaped_text_get_width, RID);


### PR DESCRIPTION
- Fixes vertical text layout and few other `TextServer` bugs, and adds support for more vertical modes (upright, mixed, sideways).
- Moves duplicate code (alignment and clipping) from `Label` / `Label3D` / `TextMesh` to the `TextParagraph`.
- Adds additional options to the `TextParagraph` to ensure all lines have the same height and to invert line order (AFAIK it's only useful for   vertical Traditional Mongolian text).
- Adds functions using custom glyph drawing callback (`Callable` for scripting, `std::function` for C++ to allow using lambdas for 3D mesh generation, RTL FX, and other customize cases).
- Allows using vertical text layout in the GUI controls (currently `Label` / `Label3D` / `TextMesh` only).

<img width="687" alt="Screenshot 2022-11-11 at 12 13 42" src="https://user-images.githubusercontent.com/7645683/201635731-6c170a44-98c4-4fd4-8f61-efe87aa96d64.png">

TODO:

- [x] Check and update default values for the `Label` / `Label3D` / `TextMesh` (were not same as `TextParagraph`'s).
- [ ] Move other duplicated code (caret drawing, under/over line drawing) to the `TextParagraph`.
- [x] Update `TextLine` to reflect `TextParagrpah` changes.
- [ ] Update `LineEdit`, `TextEdit` and `RTL` to use new `TextParagraph` code and support vertical layout.
- [ ] Update documentation.

Breaking changes:
- `TextPargraph::alignment` renamed to `TextParagraph:horizontal_alignment` (unlikely it's used directly, but alias can be added).
- `TextServer::ORIENTATION_VERTICAL` is removed in favor of 3 new modes (almost certainly no one was using it, since it was extremely buggy).