### PR TITLE
Fix code editor search match inconsistencies

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -377,10 +377,12 @@ void FindReplaceBar::_update_results_count() {
 
 			if (is_whole_words()) {
 				if (col_pos > 0 && !is_symbol(line_text[col_pos - 1])) {
-					break;
+					col_pos += searched.length();
+					continue;
 				}
-				if (col_pos + line_text.length() < line_text.length() && !is_symbol(line_text[col_pos + searched.length()])) {
-					break;
+				if (col_pos + searched.length() < line_text.length() && !is_symbol(line_text[col_pos + searched.length()])) {
+					col_pos += searched.length();
+					continue;
 				}
 			}
 


### PR DESCRIPTION
Closes #68650

Fixes code editor's search match inconsistencies which display an incorrect number of matches while filtering for “Whole Words”, with the following:
- Continue searching line for whole word matches on mismatch
- Using searched text length to offset

Results of custom editor build with fixes using provided example project of #68650 :
![image](https://user-images.githubusercontent.com/17155529/201664270-cc11836c-310f-4c0f-9c84-9bf66394a91e.png)
![image](https://user-images.githubusercontent.com/17155529/201664451-9d5abace-f14f-4fc9-9d0a-055e59844c26.png)