### PR TITLE
Add "Trimming" option to cut un-keyed timeline before first key in glTF animation

### DIFF
--- a/doc/classes/EditorSceneFormatImporter.xml
+++ b/doc/classes/EditorSceneFormatImporter.xml
@@ -39,7 +39,6 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="flags" type="int" />
 			<param index="2" name="options" type="Dictionary" />
-			<param index="3" name="bake_fps" type="int" />
 			<description>
 			</description>
 		</method>

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -65,7 +65,7 @@ struct ColladaImport {
 	bool force_make_tangents = false;
 	bool apply_mesh_xform_to_vertices = true;
 	bool use_mesh_builtin_materials = false;
-	float bake_fps = 15;
+	float bake_fps = 30;
 
 	HashMap<String, NodeMap> node_map; //map from collada node to engine node
 	HashMap<String, String> node_name_map; //map from collada node to engine node
@@ -1760,7 +1760,7 @@ void EditorSceneFormatImporterCollada::get_extensions(List<String> *r_extensions
 	r_extensions->push_back("dae");
 }
 
-Node *EditorSceneFormatImporterCollada::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, int p_bake_fps, List<String> *r_missing_deps, Error *r_err) {
+Node *EditorSceneFormatImporterCollada::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err) {
 	if (r_err) {
 		*r_err = OK;
 	}
@@ -1771,7 +1771,7 @@ Node *EditorSceneFormatImporterCollada::import_scene(const String &p_path, uint3
 	}
 
 	state.use_mesh_builtin_materials = true;
-	state.bake_fps = p_bake_fps;
+	state.bake_fps = (float)p_options["animation/fps"];
 
 	Error err = state.load(p_path, flags, p_flags & EditorSceneFormatImporter::IMPORT_GENERATE_TANGENT_ARRAYS, false);
 

--- a/editor/import/editor_import_collada.h
+++ b/editor/import/editor_import_collada.h
@@ -39,7 +39,7 @@ class EditorSceneFormatImporterCollada : public EditorSceneFormatImporter {
 public:
 	virtual uint32_t get_import_flags() const override;
 	virtual void get_extensions(List<String> *r_extensions) const override;
-	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, int p_bake_fps, List<String> *r_missing_deps = nullptr, Error *r_err = nullptr) override;
+	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps = nullptr, Error *r_err = nullptr) override;
 
 	EditorSceneFormatImporterCollada();
 };

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -422,7 +422,7 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 	return OK;
 }
 
-Node *EditorOBJImporter::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, int p_bake_fps, List<String> *r_missing_deps, Error *r_err) {
+Node *EditorOBJImporter::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err) {
 	List<Ref<Mesh>> meshes;
 
 	Error err = _parse_obj(p_path, meshes, false, p_flags & IMPORT_GENERATE_TANGENT_ARRAYS, false, Vector3(1, 1, 1), Vector3(0, 0, 0), r_missing_deps);

--- a/editor/import/resource_importer_obj.h
+++ b/editor/import/resource_importer_obj.h
@@ -39,7 +39,7 @@ class EditorOBJImporter : public EditorSceneFormatImporter {
 public:
 	virtual uint32_t get_import_flags() const override;
 	virtual void get_extensions(List<String> *r_extensions) const override;
-	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, int p_bake_fps, List<String> *r_missing_deps, Error *r_err = nullptr) override;
+	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr) override;
 
 	EditorOBJImporter();
 };

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -53,12 +53,12 @@ class EditorSceneFormatImporter : public RefCounted {
 protected:
 	static void _bind_methods();
 
-	Node *import_scene_wrapper(const String &p_path, uint32_t p_flags, Dictionary p_options, int p_bake_fps);
-	Ref<Animation> import_animation_wrapper(const String &p_path, uint32_t p_flags, Dictionary p_options, int p_bake_fps);
+	Node *import_scene_wrapper(const String &p_path, uint32_t p_flags, Dictionary p_options);
+	Ref<Animation> import_animation_wrapper(const String &p_path, uint32_t p_flags, Dictionary p_options);
 
 	GDVIRTUAL0RC(int, _get_import_flags)
 	GDVIRTUAL0RC(Vector<String>, _get_extensions)
-	GDVIRTUAL4R(Object *, _import_scene, String, uint32_t, Dictionary, uint32_t)
+	GDVIRTUAL3R(Object *, _import_scene, String, uint32_t, Dictionary)
 	GDVIRTUAL1(_get_import_options, String)
 	GDVIRTUAL3RC(Variant, _get_option_visibility, String, bool, String)
 
@@ -74,7 +74,7 @@ public:
 
 	virtual uint32_t get_import_flags() const;
 	virtual void get_extensions(List<String> *r_extensions) const;
-	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, int p_bake_fps, List<String> *r_missing_deps, Error *r_err = nullptr);
+	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr);
 	virtual void get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options);
 	virtual Variant get_option_visibility(const String &p_path, bool p_for_animation, const String &p_option, const HashMap<StringName, Variant> &p_options);
 
@@ -310,7 +310,7 @@ class EditorSceneFormatImporterESCN : public EditorSceneFormatImporter {
 public:
 	virtual uint32_t get_import_flags() const override;
 	virtual void get_extensions(List<String> *r_extensions) const override;
-	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, int p_bake_fps, List<String> *r_missing_deps, Error *r_err = nullptr) override;
+	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr) override;
 };
 
 template <class M>

--- a/modules/gltf/doc_classes/GLTFDocument.xml
+++ b/modules/gltf/doc_classes/GLTFDocument.xml
@@ -14,7 +14,6 @@
 			<param index="1" name="base_path" type="String" />
 			<param index="2" name="state" type="GLTFState" />
 			<param index="3" name="flags" type="int" default="0" />
-			<param index="4" name="bake_fps" type="int" default="30" />
 			<description>
 			</description>
 		</method>
@@ -23,8 +22,7 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="state" type="GLTFState" />
 			<param index="2" name="flags" type="int" default="0" />
-			<param index="3" name="bake_fps" type="int" default="30" />
-			<param index="4" name="base_path" type="String" default="&quot;&quot;" />
+			<param index="3" name="base_path" type="String" default="&quot;&quot;" />
 			<description>
 			</description>
 		</method>
@@ -33,7 +31,6 @@
 			<param index="0" name="node" type="Node" />
 			<param index="1" name="state" type="GLTFState" />
 			<param index="2" name="flags" type="int" default="0" />
-			<param index="3" name="bake_fps" type="int" default="30" />
 			<description>
 			</description>
 		</method>
@@ -46,7 +43,8 @@
 		<method name="generate_scene">
 			<return type="Node" />
 			<param index="0" name="state" type="GLTFState" />
-			<param index="1" name="bake_fps" type="int" default="30" />
+			<param index="1" name="bake_fps" type="float" default="30" />
+			<param index="2" name="trimming" type="bool" default="false" />
 			<description>
 			</description>
 		</method>

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
@@ -85,7 +85,7 @@ void SceneExporterGLTFPlugin::_gltf2_dialog_action(String p_file) {
 	state.instantiate();
 	int32_t flags = 0;
 	flags |= EditorSceneFormatImporter::IMPORT_USE_NAMED_SKIN_BINDS;
-	Error err = doc->append_from_scene(root, state, flags, 30.0f);
+	Error err = doc->append_from_scene(root, state, flags);
 	if (err != OK) {
 		ERR_PRINT(vformat("glTF2 save scene error %s.", itos(err)));
 	}

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -58,7 +58,7 @@ void EditorSceneFormatImporterBlend::get_extensions(List<String> *r_extensions) 
 }
 
 Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_t p_flags,
-		const HashMap<StringName, Variant> &p_options, int p_bake_fps,
+		const HashMap<StringName, Variant> &p_options,
 		List<String> *r_missing_deps, Error *r_err) {
 	// Get global paths for source and sink.
 
@@ -227,14 +227,14 @@ Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_
 	if (p_options.has(SNAME("blender/materials/unpack_enabled")) && p_options[SNAME("blender/materials/unpack_enabled")]) {
 		base_dir = sink.get_base_dir();
 	}
-	Error err = gltf->append_from_file(sink.get_basename() + ".gltf", state, p_flags, p_bake_fps, base_dir);
+	Error err = gltf->append_from_file(sink.get_basename() + ".gltf", state, p_flags, base_dir);
 	if (err != OK) {
 		if (r_err) {
 			*r_err = FAILED;
 		}
 		return nullptr;
 	}
-	return gltf->generate_scene(state, p_bake_fps);
+	return gltf->generate_scene(state, (float)p_options["animation/fps"], (bool)p_options["animation/trimming"]);
 }
 
 Variant EditorSceneFormatImporterBlend::get_option_visibility(const String &p_path, bool p_for_animation, const String &p_option,

--- a/modules/gltf/editor/editor_scene_importer_blend.h
+++ b/modules/gltf/editor/editor_scene_importer_blend.h
@@ -66,7 +66,7 @@ public:
 	virtual uint32_t get_import_flags() const override;
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
-			const HashMap<StringName, Variant> &p_options, int p_bake_fps,
+			const HashMap<StringName, Variant> &p_options,
 			List<String> *r_missing_deps, Error *r_err = nullptr) override;
 	virtual void get_import_options(const String &p_path,
 			List<ResourceImporter::ImportOption> *r_options) override;

--- a/modules/gltf/editor/editor_scene_importer_fbx.cpp
+++ b/modules/gltf/editor/editor_scene_importer_fbx.cpp
@@ -49,7 +49,7 @@ void EditorSceneFormatImporterFBX::get_extensions(List<String> *r_extensions) co
 }
 
 Node *EditorSceneFormatImporterFBX::import_scene(const String &p_path, uint32_t p_flags,
-		const HashMap<StringName, Variant> &p_options, int p_bake_fps,
+		const HashMap<StringName, Variant> &p_options,
 		List<String> *r_missing_deps, Error *r_err) {
 	// Get global paths for source and sink.
 
@@ -95,14 +95,14 @@ Node *EditorSceneFormatImporterFBX::import_scene(const String &p_path, uint32_t 
 	Ref<GLTFState> state;
 	state.instantiate();
 	print_verbose(vformat("glTF path: %s", sink));
-	Error err = gltf->append_from_file(sink, state, p_flags, p_bake_fps);
+	Error err = gltf->append_from_file(sink, state, p_flags);
 	if (err != OK) {
 		if (r_err) {
 			*r_err = FAILED;
 		}
 		return nullptr;
 	}
-	return gltf->generate_scene(state, p_bake_fps);
+	return gltf->generate_scene(state, (float)p_options["animation/fps"], (bool)p_options["animation/trimming"]);
 }
 
 Variant EditorSceneFormatImporterFBX::get_option_visibility(const String &p_path, bool p_for_animation,

--- a/modules/gltf/editor/editor_scene_importer_fbx.h
+++ b/modules/gltf/editor/editor_scene_importer_fbx.h
@@ -45,7 +45,7 @@ public:
 	virtual uint32_t get_import_flags() const override;
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
-			const HashMap<StringName, Variant> &p_options, int p_bake_fps,
+			const HashMap<StringName, Variant> &p_options,
 			List<String> *r_missing_deps, Error *r_err = nullptr) override;
 	virtual void get_import_options(const String &p_path,
 			List<ResourceImporter::ImportOption> *r_options) override;

--- a/modules/gltf/editor/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor/editor_scene_importer_gltf.cpp
@@ -47,13 +47,13 @@ void EditorSceneFormatImporterGLTF::get_extensions(List<String> *r_extensions) c
 }
 
 Node *EditorSceneFormatImporterGLTF::import_scene(const String &p_path, uint32_t p_flags,
-		const HashMap<StringName, Variant> &p_options, int p_bake_fps,
+		const HashMap<StringName, Variant> &p_options,
 		List<String> *r_missing_deps, Error *r_err) {
 	Ref<GLTFDocument> doc;
 	doc.instantiate();
 	Ref<GLTFState> state;
 	state.instantiate();
-	Error err = doc->append_from_file(p_path, state, p_flags, p_bake_fps);
+	Error err = doc->append_from_file(p_path, state, p_flags);
 	if (err != OK) {
 		if (r_err) {
 			*r_err = err;
@@ -63,7 +63,7 @@ Node *EditorSceneFormatImporterGLTF::import_scene(const String &p_path, uint32_t
 	if (p_options.has("animation/import")) {
 		state->set_create_animations(bool(p_options["animation/import"]));
 	}
-	return doc->generate_scene(state, p_bake_fps);
+	return doc->generate_scene(state, (float)p_options["animation/fps"], (bool)p_options["animation/trimming"]);
 }
 
 #endif // TOOLS_ENABLED

--- a/modules/gltf/editor/editor_scene_importer_gltf.h
+++ b/modules/gltf/editor/editor_scene_importer_gltf.h
@@ -48,7 +48,7 @@ public:
 	virtual uint32_t get_import_flags() const override;
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
-			const HashMap<StringName, Variant> &p_options, int p_bake_fps,
+			const HashMap<StringName, Variant> &p_options,
 			List<String> *r_missing_deps, Error *r_err = nullptr) override;
 };
 

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5819,7 +5819,7 @@ T GLTFDocument::_interpolate_track(const Vector<real_t> &p_times, const Vector<T
 	ERR_FAIL_V(p_values[0]);
 }
 
-void GLTFDocument::_import_animation(Ref<GLTFState> state, AnimationPlayer *ap, const GLTFAnimationIndex index, const int bake_fps) {
+void GLTFDocument::_import_animation(Ref<GLTFState> state, AnimationPlayer *ap, const GLTFAnimationIndex index, const float bake_fps, const bool trimming) {
 	Ref<GLTFAnimation> anim = state->animations[index];
 
 	String anim_name = anim->get_name();
@@ -5836,7 +5836,8 @@ void GLTFDocument::_import_animation(Ref<GLTFState> state, AnimationPlayer *ap, 
 		animation->set_loop_mode(Animation::LOOP_LINEAR);
 	}
 
-	float length = 0.0;
+	double anim_start = trimming ? INFINITY : 0.0;
+	double anim_end = 0.0;
 
 	for (const KeyValue<int, GLTFAnimation::Track> &track_i : anim->get_tracks()) {
 		const GLTFAnimation::Track &track = track_i.value;
@@ -5866,19 +5867,40 @@ void GLTFDocument::_import_animation(Ref<GLTFState> state, AnimationPlayer *ap, 
 			transform_node_path = node_path;
 		}
 
-		for (int i = 0; i < track.rotation_track.times.size(); i++) {
-			length = MAX(length, track.rotation_track.times[i]);
-		}
-		for (int i = 0; i < track.position_track.times.size(); i++) {
-			length = MAX(length, track.position_track.times[i]);
-		}
-		for (int i = 0; i < track.scale_track.times.size(); i++) {
-			length = MAX(length, track.scale_track.times[i]);
-		}
-
-		for (int i = 0; i < track.weight_tracks.size(); i++) {
-			for (int j = 0; j < track.weight_tracks[i].times.size(); j++) {
-				length = MAX(length, track.weight_tracks[i].times[j]);
+		if (trimming) {
+			for (int i = 0; i < track.rotation_track.times.size(); i++) {
+				anim_start = MIN(anim_start, track.rotation_track.times[i]);
+				anim_end = MAX(anim_end, track.rotation_track.times[i]);
+			}
+			for (int i = 0; i < track.position_track.times.size(); i++) {
+				anim_start = MIN(anim_start, track.position_track.times[i]);
+				anim_end = MAX(anim_end, track.position_track.times[i]);
+			}
+			for (int i = 0; i < track.scale_track.times.size(); i++) {
+				anim_start = MIN(anim_start, track.scale_track.times[i]);
+				anim_end = MAX(anim_end, track.scale_track.times[i]);
+			}
+			for (int i = 0; i < track.weight_tracks.size(); i++) {
+				for (int j = 0; j < track.weight_tracks[i].times.size(); j++) {
+					anim_start = MIN(anim_start, track.weight_tracks[i].times[j]);
+					anim_end = MAX(anim_end, track.weight_tracks[i].times[j]);
+				}
+			}
+		} else {
+			// If you don't use trimming and the first key time is not at 0.0, fake keys will be inserted.
+			for (int i = 0; i < track.rotation_track.times.size(); i++) {
+				anim_end = MAX(anim_end, track.rotation_track.times[i]);
+			}
+			for (int i = 0; i < track.position_track.times.size(); i++) {
+				anim_end = MAX(anim_end, track.position_track.times[i]);
+			}
+			for (int i = 0; i < track.scale_track.times.size(); i++) {
+				anim_end = MAX(anim_end, track.scale_track.times[i]);
+			}
+			for (int i = 0; i < track.weight_tracks.size(); i++) {
+				for (int j = 0; j < track.weight_tracks[i].times.size(); j++) {
+					anim_end = MAX(anim_end, track.weight_tracks[i].times[j]);
+				}
 			}
 		}
 
@@ -5947,10 +5969,8 @@ void GLTFDocument::_import_animation(Ref<GLTFState> state, AnimationPlayer *ap, 
 				}
 			}
 
-			//first determine animation length
-
 			const double increment = 1.0 / bake_fps;
-			double time = 0.0;
+			double time = anim_start;
 
 			Vector3 base_pos;
 			Quaternion base_rot;
@@ -5976,26 +5996,26 @@ void GLTFDocument::_import_animation(Ref<GLTFState> state, AnimationPlayer *ap, 
 
 				if (position_idx >= 0) {
 					pos = _interpolate_track<Vector3>(track.position_track.times, track.position_track.values, time, track.position_track.interpolation);
-					animation->position_track_insert_key(position_idx, time, pos);
+					animation->position_track_insert_key(position_idx, time - anim_start, pos);
 				}
 
 				if (rotation_idx >= 0) {
 					rot = _interpolate_track<Quaternion>(track.rotation_track.times, track.rotation_track.values, time, track.rotation_track.interpolation);
-					animation->rotation_track_insert_key(rotation_idx, time, rot);
+					animation->rotation_track_insert_key(rotation_idx, time - anim_start, rot);
 				}
 
 				if (scale_idx >= 0) {
 					scale = _interpolate_track<Vector3>(track.scale_track.times, track.scale_track.values, time, track.scale_track.interpolation);
-					animation->scale_track_insert_key(scale_idx, time, scale);
+					animation->scale_track_insert_key(scale_idx, time - anim_start, scale);
 				}
 
 				if (last) {
 					break;
 				}
 				time += increment;
-				if (time >= length) {
+				if (time >= anim_end) {
 					last = true;
-					time = length;
+					time = anim_end;
 				}
 			}
 		}
@@ -6030,21 +6050,21 @@ void GLTFDocument::_import_animation(Ref<GLTFState> state, AnimationPlayer *ap, 
 				bool last = false;
 				while (true) {
 					real_t blend = _interpolate_track<real_t>(track.weight_tracks[i].times, track.weight_tracks[i].values, time, gltf_interp);
-					animation->blend_shape_track_insert_key(track_idx, time, blend);
+					animation->blend_shape_track_insert_key(track_idx, time - anim_start, blend);
 					if (last) {
 						break;
 					}
 					time += increment;
-					if (time >= length) {
+					if (time >= anim_end) {
 						last = true;
-						time = length;
+						time = anim_end;
 					}
 				}
 			}
 		}
 	}
 
-	animation->set_length(length);
+	animation->set_length(anim_end - anim_start);
 
 	Ref<AnimationLibrary> library;
 	if (!ap->has_animation_library("")) {
@@ -6544,7 +6564,7 @@ void GLTFDocument::_convert_animation(Ref<GLTFState> state, AnimationPlayer *ap,
 	}
 }
 
-Error GLTFDocument::_parse(Ref<GLTFState> state, String p_path, Ref<FileAccess> f, int p_bake_fps) {
+Error GLTFDocument::_parse(Ref<GLTFState> state, String p_path, Ref<FileAccess> f) {
 	Error err;
 	if (f.is_null()) {
 		return FAILED;
@@ -6593,7 +6613,7 @@ Error GLTFDocument::_parse(Ref<GLTFState> state, String p_path, Ref<FileAccess> 
 		ERR_FAIL_COND_V(err != OK, err);
 	}
 
-	err = _parse_gltf_state(state, p_path, p_bake_fps);
+	err = _parse_gltf_state(state, p_path);
 	ERR_FAIL_COND_V(err != OK, err);
 
 	return OK;
@@ -6715,14 +6735,14 @@ Error GLTFDocument::_serialize_file(Ref<GLTFState> state, const String p_path) {
 }
 
 void GLTFDocument::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("append_from_file", "path", "state", "flags", "bake_fps", "base_path"),
-			&GLTFDocument::append_from_file, DEFVAL(0), DEFVAL(30), DEFVAL(String()));
-	ClassDB::bind_method(D_METHOD("append_from_buffer", "bytes", "base_path", "state", "flags", "bake_fps"),
-			&GLTFDocument::append_from_buffer, DEFVAL(0), DEFVAL(30));
-	ClassDB::bind_method(D_METHOD("append_from_scene", "node", "state", "flags", "bake_fps"),
-			&GLTFDocument::append_from_scene, DEFVAL(0), DEFVAL(30));
-	ClassDB::bind_method(D_METHOD("generate_scene", "state", "bake_fps"),
-			&GLTFDocument::generate_scene, DEFVAL(30));
+	ClassDB::bind_method(D_METHOD("append_from_file", "path", "state", "flags", "base_path"),
+			&GLTFDocument::append_from_file, DEFVAL(0), DEFVAL(String()));
+	ClassDB::bind_method(D_METHOD("append_from_buffer", "bytes", "base_path", "state", "flags"),
+			&GLTFDocument::append_from_buffer, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("append_from_scene", "node", "state", "flags"),
+			&GLTFDocument::append_from_scene, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("generate_scene", "state", "bake_fps", "trimming"),
+			&GLTFDocument::generate_scene, DEFVAL(30), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("generate_buffer", "state"),
 			&GLTFDocument::generate_buffer);
 	ClassDB::bind_method(D_METHOD("write_to_filesystem", "state", "path"),
@@ -6833,7 +6853,7 @@ Error GLTFDocument::write_to_filesystem(Ref<GLTFState> state, const String &p_pa
 	return OK;
 }
 
-Node *GLTFDocument::generate_scene(Ref<GLTFState> state, int32_t p_bake_fps) {
+Node *GLTFDocument::generate_scene(Ref<GLTFState> state, float p_bake_fps, bool p_trimming) {
 	ERR_FAIL_NULL_V(state, nullptr);
 	ERR_FAIL_INDEX_V(0, state->root_nodes.size(), nullptr);
 	Error err = OK;
@@ -6847,7 +6867,7 @@ Node *GLTFDocument::generate_scene(Ref<GLTFState> state, int32_t p_bake_fps) {
 		root->add_child(ap, true);
 		ap->set_owner(root);
 		for (int i = 0; i < state->animations.size(); i++) {
-			_import_animation(state, ap, i, p_bake_fps);
+			_import_animation(state, ap, i, p_bake_fps, p_trimming);
 		}
 	}
 	for (KeyValue<GLTFNodeIndex, Node *> E : state->scene_nodes) {
@@ -6875,7 +6895,7 @@ Node *GLTFDocument::generate_scene(Ref<GLTFState> state, int32_t p_bake_fps) {
 	return root;
 }
 
-Error GLTFDocument::append_from_scene(Node *p_node, Ref<GLTFState> state, uint32_t p_flags, int32_t p_bake_fps) {
+Error GLTFDocument::append_from_scene(Node *p_node, Ref<GLTFState> state, uint32_t p_flags) {
 	ERR_FAIL_COND_V(state.is_null(), FAILED);
 	state->use_named_skin_binds = p_flags & GLTF_IMPORT_USE_NAMED_SKIN_BINDS;
 	state->discard_meshes_and_materials = p_flags & GLTF_IMPORT_DISCARD_MESHES_AND_MATERIALS;
@@ -6893,7 +6913,7 @@ Error GLTFDocument::append_from_scene(Node *p_node, Ref<GLTFState> state, uint32
 	return OK;
 }
 
-Error GLTFDocument::append_from_buffer(PackedByteArray p_bytes, String p_base_path, Ref<GLTFState> state, uint32_t p_flags, int32_t p_bake_fps) {
+Error GLTFDocument::append_from_buffer(PackedByteArray p_bytes, String p_base_path, Ref<GLTFState> state, uint32_t p_flags) {
 	ERR_FAIL_COND_V(state.is_null(), FAILED);
 	// TODO Add missing texture and missing .bin file paths to r_missing_deps 2021-09-10 fire
 	Error err = FAILED;
@@ -6904,7 +6924,7 @@ Error GLTFDocument::append_from_buffer(PackedByteArray p_bytes, String p_base_pa
 	file_access.instantiate();
 	file_access->open_custom(p_bytes.ptr(), p_bytes.size());
 	state->base_path = p_base_path.get_base_dir();
-	err = _parse(state, state->base_path, file_access, p_bake_fps);
+	err = _parse(state, state->base_path, file_access);
 	ERR_FAIL_COND_V(err != OK, err);
 	for (int32_t ext_i = 0; ext_i < document_extensions.size(); ext_i++) {
 		Ref<GLTFDocumentExtension> ext = document_extensions[ext_i];
@@ -6915,7 +6935,7 @@ Error GLTFDocument::append_from_buffer(PackedByteArray p_bytes, String p_base_pa
 	return OK;
 }
 
-Error GLTFDocument::_parse_gltf_state(Ref<GLTFState> state, const String &p_search_path, float p_bake_fps) {
+Error GLTFDocument::_parse_gltf_state(Ref<GLTFState> state, const String &p_search_path) {
 	Error err;
 
 	/* PARSE EXTENSIONS */
@@ -7011,7 +7031,7 @@ Error GLTFDocument::_parse_gltf_state(Ref<GLTFState> state, const String &p_sear
 	return OK;
 }
 
-Error GLTFDocument::append_from_file(String p_path, Ref<GLTFState> r_state, uint32_t p_flags, int32_t p_bake_fps, String p_base_path) {
+Error GLTFDocument::append_from_file(String p_path, Ref<GLTFState> r_state, uint32_t p_flags, String p_base_path) {
 	// TODO Add missing texture and missing .bin file paths to r_missing_deps 2021-09-10 fire
 	if (r_state == Ref<GLTFState>()) {
 		r_state.instantiate();
@@ -7028,7 +7048,7 @@ Error GLTFDocument::append_from_file(String p_path, Ref<GLTFState> r_state, uint
 		base_path = p_path.get_base_dir();
 	}
 	r_state->base_path = base_path;
-	err = _parse(r_state, base_path, f, p_bake_fps);
+	err = _parse(r_state, base_path, f);
 	ERR_FAIL_COND_V(err != OK, err);
 	for (int32_t ext_i = 0; ext_i < document_extensions.size(); ext_i++) {
 		Ref<GLTFDocumentExtension> ext = document_extensions[ext_i];

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -291,17 +291,17 @@ private:
 	static float get_max_component(const Color &p_color);
 
 public:
-	Error append_from_file(String p_path, Ref<GLTFState> r_state, uint32_t p_flags = 0, int32_t p_bake_fps = 30, String p_base_path = String());
-	Error append_from_buffer(PackedByteArray p_bytes, String p_base_path, Ref<GLTFState> r_state, uint32_t p_flags = 0, int32_t p_bake_fps = 30);
-	Error append_from_scene(Node *p_node, Ref<GLTFState> r_state, uint32_t p_flags = 0, int32_t p_bake_fps = 30);
+	Error append_from_file(String p_path, Ref<GLTFState> r_state, uint32_t p_flags = 0, String p_base_path = String());
+	Error append_from_buffer(PackedByteArray p_bytes, String p_base_path, Ref<GLTFState> r_state, uint32_t p_flags = 0);
+	Error append_from_scene(Node *p_node, Ref<GLTFState> r_state, uint32_t p_flags = 0);
 
 public:
-	Node *generate_scene(Ref<GLTFState> state, int32_t p_bake_fps = 30.0f);
+	Node *generate_scene(Ref<GLTFState> state, float p_bake_fps = 30.0f, bool p_trimming = false);
 	PackedByteArray generate_buffer(Ref<GLTFState> state);
 	Error write_to_filesystem(Ref<GLTFState> state, const String &p_path);
 
 public:
-	Error _parse_gltf_state(Ref<GLTFState> state, const String &p_search_path, float p_bake_fps);
+	Error _parse_gltf_state(Ref<GLTFState> state, const String &p_search_path);
 	Error _parse_gltf_extensions(Ref<GLTFState> state);
 	void _process_mesh_instances(Ref<GLTFState> state, Node *scene_root);
 	void _generate_scene_node(Ref<GLTFState> state, Node *scene_parent,
@@ -309,7 +309,7 @@ public:
 			const GLTFNodeIndex node_index);
 	void _generate_skeleton_bone_node(Ref<GLTFState> state, Node *scene_parent, Node3D *scene_root, const GLTFNodeIndex node_index);
 	void _import_animation(Ref<GLTFState> state, AnimationPlayer *ap,
-			const GLTFAnimationIndex index, const int bake_fps);
+			const GLTFAnimationIndex index, const float bake_fps, const bool trimming);
 	void _convert_mesh_instances(Ref<GLTFState> state);
 	GLTFCameraIndex _convert_camera(Ref<GLTFState> state, Camera3D *p_camera);
 	void _convert_light_to_gltf(Light3D *light, Ref<GLTFState> state, Ref<GLTFNode> gltf_node);
@@ -367,7 +367,7 @@ public:
 	void _convert_animation(Ref<GLTFState> state, AnimationPlayer *ap,
 			String p_animation_track_name);
 	Error _serialize(Ref<GLTFState> state, const String &p_path);
-	Error _parse(Ref<GLTFState> state, String p_path, Ref<FileAccess> f, int p_bake_fps);
+	Error _parse(Ref<GLTFState> state, String p_path, Ref<FileAccess> f);
 };
 
 #endif // GLTF_DOCUMENT_H


### PR DESCRIPTION
Fixes #65513

If the first key frame of the animation stored in the glTF is not at position 0 on the timeline, Godot's glTF importer will insert a fake key at position 0.  This option addresses problem #65513 by removing the timeline before the first keyframe.

![image](https://user-images.githubusercontent.com/61938263/201764021-d009e259-0baf-4c3e-aa34-38eb756eebbf.png)

However, I am not sure if this option should be enabled by default. There is a problem when this option is enabled.

For example, if you have a timeline in Blender that is `start: 0 end: 60` and the animation starts at frame 30, the length from the first 0 to frame 30 is ignored.

Blender's timeline starting from 1 is certainly an abnormality in the animation industry. But I think trimming is more the role of Blender's glTF exporter than Godot's importer.

How do you think about the Blender's glTF exporter behavior of recording time of 30th frame in the first key of glTF when there is a timeline of length `start: 30 end: 60` in Blender and the animation starts at frame 30? @julienduroure CC @fire 

For now, we solve #65513 by implementing this as an importer option, it is disabled by default. This PR includes a refactoring to clean up unnecessary arguments.