### PR TITLE
Fix alpha hash by correcting typos and doing calculations in object space

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -826,7 +826,8 @@ void fragment_shader(in SceneData scene_data) {
 
 // alpha hash can be used in unison with alpha antialiasing
 #ifdef ALPHA_HASH_USED
-	if (alpha < compute_alpha_hash_threshold(vertex, alpha_hash_scale)) {
+	vec3 object_pos = (inverse(read_model_matrix) * inv_view_matrix * vec4(vertex, 1.0)).xyz;
+	if (alpha < compute_alpha_hash_threshold(object_pos, alpha_hash_scale)) {
 		discard;
 	}
 #endif // ALPHA_HASH_USED

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -779,7 +779,8 @@ void main() {
 
 // alpha hash can be used in unison with alpha antialiasing
 #ifdef ALPHA_HASH_USED
-	if (alpha < compute_alpha_hash_threshold(vertex, alpha_hash_scale)) {
+	vec3 object_pos = (inverse(read_model_matrix) * inv_view_matrix * vec4(vertex, 1.0)).xyz;
+	if (alpha < compute_alpha_hash_threshold(object_pos, alpha_hash_scale)) {
 		discard;
 	}
 #endif // ALPHA_HASH_USED

--- a/servers/rendering/renderer_rd/shaders/scene_forward_aa_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_aa_inc.glsl
@@ -11,7 +11,8 @@ float hash_3d(vec3 p) {
 
 float compute_alpha_hash_threshold(vec3 pos, float hash_scale) {
 	vec3 dx = dFdx(pos);
-	vec3 dy = dFdx(pos);
+	vec3 dy = dFdy(pos);
+
 	float delta_max_sqr = max(length(dx), length(dy));
 	float pix_scale = 1.0 / (hash_scale * delta_max_sqr);
 
@@ -32,9 +33,9 @@ float compute_alpha_hash_threshold(vec3 pos, float hash_scale) {
 			1.0 - ((1.0 - a_interp) * (1.0 - a_interp) / (2.0 * min_lerp * (1.0 - min_lerp))));
 
 	float alpha_hash_threshold =
-			(lerp_factor < (1.0 - min_lerp)) ? ((lerp_factor < min_lerp) ? cases.x : cases.y) : cases.z;
+			(a_interp < (1.0 - min_lerp)) ? ((a_interp < min_lerp) ? cases.x : cases.y) : cases.z;
 
-	return clamp(alpha_hash_threshold, 0.0, 1.0);
+	return clamp(alpha_hash_threshold, 0.00001, 1.0);
 }
 
 #endif // ALPHA_HASH_USED


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/64500
Supersedes: https://github.com/godotengine/godot/pull/61880

This PR corrects a few places where we had differed from the source (https://casual-effects.com/research/Wyman2017Hashed/Wyman2017Hashed.pdf) 

Notably:
1. We do calculations in object space instead of view space
2. ``dFdx`` -> ``dFdy`` (clear typo)
3. Typo resulting in using ``lerp_factor`` instead of alpha threshold
4. Final value should be clamped above 0 so that alpha values of 0.0 are always clamped. 

This makes 

_Before_
![Screenshot from 2022-11-14 18-00-21](https://user-images.githubusercontent.com/16521339/201808085-11e70293-0b55-4078-9458-1d6ad31fbc25.png)

_After_
![Screenshot from 2022-11-14 17-58-57](https://user-images.githubusercontent.com/16521339/201808088-6383ba5a-b198-49d9-b30a-8c6d601f8746.png)

The results in motion are much better too. 
