### PR TITLE
Fixes infinite loop in ResourceFormatText when having unexpected end of file

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -511,6 +511,7 @@ Error ResourceLoaderText::load() {
 
 		if (error) {
 			_printerr();
+			return error;
 		}
 
 		resource_current++;
@@ -884,6 +885,7 @@ void ResourceLoaderText::get_dependencies(Ref<FileAccess> p_f, List<String> *p_d
 			error_text = "Unexpected end of file";
 			_printerr();
 			error = ERR_FILE_CORRUPT;
+			return;
 		}
 	}
 }


### PR DESCRIPTION
I encountered this error by trying to extend the PackedScene class. When such resource is saved to disk, it creates a wrong, truncated file (I still have to investigate why). Then editor trying to load the file in the editor would lead to an infinite stream of error.

This fixes the bug by quitting the loop when encountering the error. This is likely an oversight.

(I added the "crash" label as it hangs the editor completely and force you to quit, but it's not a crash per say)