### PR TITLE
Make Camera3D gizmo the same aspect ratio as its viewport

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.h
+++ b/editor/plugins/node_3d_editor_gizmos.h
@@ -264,6 +264,9 @@ public:
 class Camera3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(Camera3DGizmoPlugin, EditorNode3DGizmoPlugin);
 
+private:
+	static Size2i _get_viewport_size(Camera3D *p_camera);
+
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
 	String get_gizmo_name() const override;

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7248,6 +7248,8 @@ void Node3DEditor::_notification(int p_what) {
 
 			sun_state->set_custom_minimum_size(sun_vb->get_combined_minimum_size());
 			environ_state->set_custom_minimum_size(environ_vb->get_combined_minimum_size());
+
+			EditorNode::get_singleton()->connect("project_settings_changed", callable_mp(this, &Node3DEditor::update_all_gizmos).bind(Variant()));
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -112,6 +112,12 @@ void Camera3D::_notification(int p_what) {
 			if (current || first_camera) {
 				viewport->_camera_3d_set(this);
 			}
+
+#ifdef TOOLS_ENABLED
+			if (Engine::get_singleton()->is_editor_hint()) {
+				viewport->connect(SNAME("size_changed"), callable_mp((Node3D *)this, &Camera3D::update_gizmos));
+			}
+#endif
 		} break;
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
@@ -133,6 +139,11 @@ void Camera3D::_notification(int p_what) {
 			}
 
 			if (viewport) {
+#ifdef TOOLS_ENABLED
+				if (Engine::get_singleton()->is_editor_hint()) {
+					viewport->disconnect(SNAME("size_changed"), callable_mp((Node3D *)this, &Camera3D::update_gizmos));
+				}
+#endif
 				viewport->_camera_3d_remove(this);
 				viewport = nullptr;
 			}


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/discussions/5781

https://user-images.githubusercontent.com/372476/201876771-aa651a51-3089-4789-8e6b-762f5cdfbf4a.mp4

In the editor, a Camera3D's viewport can be three different things:

* Window ancestor
* SubViewport ancestor
* The main Viewport (size specified in project settings)

---

All Node3D gizmos are now redrawn when project settings changes. There are two reasons:

* To updating the Camera3D gizmo size when size of the main viewport changes.
* Avoid including `editor/editor_node.h` in `godot/scene/3d/camera_3d.cpp`.

https://github.com/godotengine/godot/blob/5b02173d5e2ec1abb4fdf624957b12f1a54810c1/editor/plugins/node_3d_editor_plugin.cpp#L7252

https://github.com/godotengine/godot/blob/5b02173d5e2ec1abb4fdf624957b12f1a54810c1/scene/3d/camera_3d.cpp#L116-L120