### PR TITLE
[MP] New default multiplayer_peer acting as server.

### DIFF
--- a/doc/classes/OfflineMultiplayerPeer.xml
+++ b/doc/classes/OfflineMultiplayerPeer.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OfflineMultiplayerPeer" inherits="MultiplayerPeer" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A [MultiplayerPeer] which is always connected and acts as a server.
+	</brief_description>
+	<description>
+		This is the default [member MultiplayerAPI.multiplayer_peer] for the [member Node.multiplayer]. It mimics the behavior of a server with no peers connected.
+		This means that the [SceneTree] will act as the multiplayer authority by default. Calls to [method MultiplayerAPI.is_server] will return [code]true[/code], and calls to [method MultiplayerAPI.get_unique_id] will return [constant MultiplayerPeer.TARGET_PEER_SERVER].
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/modules/multiplayer/register_types.cpp
+++ b/modules/multiplayer/register_types.cpp
@@ -47,6 +47,7 @@ void initialize_multiplayer_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(SceneReplicationConfig);
 		GDREGISTER_CLASS(MultiplayerSpawner);
 		GDREGISTER_CLASS(MultiplayerSynchronizer);
+		GDREGISTER_CLASS(OfflineMultiplayerPeer);
 		GDREGISTER_CLASS(SceneMultiplayer);
 		MultiplayerAPI::set_default_interface("SceneMultiplayer");
 		MultiplayerDebugger::initialize();

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -661,6 +661,7 @@ SceneMultiplayer::SceneMultiplayer() {
 	replicator = Ref<SceneReplicationInterface>(memnew(SceneReplicationInterface(this)));
 	rpc = Ref<SceneRPCInterface>(memnew(SceneRPCInterface(this)));
 	cache = Ref<SceneCacheInterface>(memnew(SceneCacheInterface(this)));
+	set_multiplayer_peer(Ref<OfflineMultiplayerPeer>(memnew(OfflineMultiplayerPeer)));
 }
 
 SceneMultiplayer::~SceneMultiplayer() {

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -37,6 +37,31 @@
 #include "scene_replication_interface.h"
 #include "scene_rpc_interface.h"
 
+class OfflineMultiplayerPeer : public MultiplayerPeer {
+	GDCLASS(OfflineMultiplayerPeer, MultiplayerPeer);
+
+public:
+	virtual int get_available_packet_count() const override { return 0; }
+	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override {
+		*r_buffer = nullptr;
+		r_buffer_size = 0;
+		return OK;
+	}
+	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override { return OK; }
+	virtual int get_max_packet_size() const override { return 0; }
+
+	virtual void set_target_peer(int p_peer_id) override {}
+	virtual int get_packet_peer() const override { return 0; }
+	virtual TransferMode get_packet_mode() const override { return TRANSFER_MODE_RELIABLE; };
+	virtual int get_packet_channel() const override { return 0; }
+	virtual void disconnect_peer(int p_peer, bool p_force = false) override {}
+	virtual bool is_server() const override { return true; }
+	virtual void poll() override {}
+	virtual void close() override {}
+	virtual int get_unique_id() const override { return TARGET_PEER_SERVER; }
+	virtual ConnectionStatus get_connection_status() const override { return CONNECTION_CONNECTED; };
+};
+
 class SceneMultiplayer : public MultiplayerAPI {
 	GDCLASS(SceneMultiplayer, MultiplayerAPI);
 


### PR DESCRIPTION
Adds a `OfflineMultiplayerPeer` class which behaves like a server with no connected peers.

Use `OfflineMultiplayerPeer` as default for `SceneMultiplayer`.

This means that the `SceneTree` will act as the multiplayer authority by default.
Calls to `is_server` will return `true`, and calls to `get_unique_id` will return `TARGET_PEER_SERVER`.

Closes #22892 .