### PR TITLE
Expose editor viewports in EditorInterface

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -116,6 +116,19 @@
 				[b]Note:[/b] When creating custom editor UI, prefer accessing theme items directly from your GUI nodes using the [code]get_theme_*[/code] methods.
 			</description>
 		</method>
+		<method name="get_editor_viewport_2d" qualifiers="const">
+			<return type="SubViewport" />
+			<description>
+				Returns the 2D editor [SubViewport]. It does not have a camera. Instead, the view transforms are done directly and can be accessed with [member Viewport.global_canvas_transform].
+			</description>
+		</method>
+		<method name="get_editor_viewport_3d" qualifiers="const">
+			<return type="SubViewport" />
+			<param index="0" name="idx" type="int" default="0" />
+			<description>
+				Returns the specified 3D editor [SubViewport], from [code]0[/code] to [code]3[/code]. The viewport can be used to access the active editor cameras with [method Viewport.get_camera_3d].
+			</description>
+		</method>
 		<method name="get_file_system_dock" qualifiers="const">
 			<return type="FileSystemDock" />
 			<description>

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -41,6 +41,7 @@
 #include "editor/filesystem_dock.h"
 #include "editor/gui/editor_run_bar.h"
 #include "editor/inspector_dock.h"
+#include "editor/plugins/node_3d_editor_plugin.h"
 #include "main/main.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/control.h"
@@ -211,6 +212,15 @@ VBoxContainer *EditorInterface::get_editor_main_screen() const {
 
 ScriptEditor *EditorInterface::get_script_editor() const {
 	return ScriptEditor::get_singleton();
+}
+
+SubViewport *EditorInterface::get_editor_viewport_2d() const {
+	return EditorNode::get_singleton()->get_scene_root();
+}
+
+SubViewport *EditorInterface::get_editor_viewport_3d(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, static_cast<int>(Node3DEditor::VIEWPORTS_COUNT), nullptr);
+	return Node3DEditor::get_singleton()->get_editor_viewport(p_idx)->get_viewport_node();
 }
 
 void EditorInterface::set_main_screen_editor(const String &p_name) {
@@ -414,6 +424,8 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_base_control"), &EditorInterface::get_base_control);
 	ClassDB::bind_method(D_METHOD("get_editor_main_screen"), &EditorInterface::get_editor_main_screen);
 	ClassDB::bind_method(D_METHOD("get_script_editor"), &EditorInterface::get_script_editor);
+	ClassDB::bind_method(D_METHOD("get_editor_viewport_2d"), &EditorInterface::get_editor_viewport_2d);
+	ClassDB::bind_method(D_METHOD("get_editor_viewport_3d", "idx"), &EditorInterface::get_editor_viewport_3d, DEFVAL(0));
 
 	ClassDB::bind_method(D_METHOD("set_main_screen_editor", "name"), &EditorInterface::set_main_screen_editor);
 	ClassDB::bind_method(D_METHOD("set_distraction_free_mode", "enter"), &EditorInterface::set_distraction_free_mode);

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -49,6 +49,7 @@ class FileSystemDock;
 class Mesh;
 class Node;
 class ScriptEditor;
+class SubViewport;
 class Texture2D;
 class Theme;
 class VBoxContainer;
@@ -92,6 +93,8 @@ public:
 	Control *get_base_control() const;
 	VBoxContainer *get_editor_main_screen() const;
 	ScriptEditor *get_script_editor() const;
+	SubViewport *get_editor_viewport_2d() const;
+	SubViewport *get_editor_viewport_3d(int p_idx = 0) const;
 
 	void set_main_screen_editor(const String &p_name);
 	void set_distraction_free_mode(bool p_enter);


### PR DESCRIPTION
This PR grants gdscript access to the editor viewports, which grant access to the cameras, as discussed in https://github.com/godotengine/godot-proposals/issues/1302.


### For 3D Viewports
`EditorInterface.get_editor_viewport_3d(p_index) -> SubViewport` provides access to the 3d editor viewports. 

The cameras can already be accessed with `Viewport.get_camera_3d()` (no change).

### For 2D Viewports
`EditorInterface.get_editor_viewport_2d() -> SubViewport` provides access to the 2D viewport.

There is no 2D editor camera per @KoBeWi, as view transforms are done directly. The viewport transform can be accessed as shown in the example below.


### Example Usage
This script shows accessing the 2D viewport and all 4 3D cameras. The positions are printed to the console as the 2D or any of the 4 3D viewport cameras are moved around.

```
@tool
extends Node

var editor_cameras: Array[Camera3D]
var editor_2dvp: SubViewport


func _ready():
	if Engine.is_editor_hint():
		editor_2dvp = EditorInterface.get_editor_viewport_2d()

		for i in 4:
			var vp = EditorInterface.get_editor_viewport_3d(i)
			var cam = vp.get_camera_3d()
			editor_cameras.push_back(cam)
		
		var timer := Timer.new()
		add_child(timer)
		timer.start(1)
		timer.timeout.connect(Callable(self, "_on_timeout"))


func _on_timeout():
	print("----------")
	print("2D Viewport: ", editor_2dvp.global_canvas_transform)
	
	for i in editor_cameras.size():
		print("3D Editor camera%d pos: %.2v" % [ i, editor_cameras[i].global_position])

```

Output
```
----------
2D Viewport: [X: (0.561231, 0), Y: (0, 0.561231), O: (122.801, 209.8038)]
3D Editor camera0 pos: (-0.26, 2.74, 1.12)
3D Editor camera1 pos: (3.51, 0.86, -1.22)
3D Editor camera2 pos: (-4.29, 1.56, -1.15)
3D Editor camera3 pos: (-1.66, 1.56, -3.97)
```

------
Update: This PR has been updated post #75694
