### PR TITLE
Fix "View Owners" dialog not acknowledging that some resources aren't scenes

### DIFF
--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -286,10 +286,23 @@ void DependencyEditorOwners::_list_rmb_clicked(int p_item, const Vector2 &p_pos,
 	file_options->clear();
 	file_options->reset_size();
 	if (p_item >= 0) {
-		if (owners->get_selected_items().size() == 1) {
-			file_options->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Open Scene"), FILE_OPEN);
+		PackedInt32Array selected_items = owners->get_selected_items();
+		bool only_scenes_selected = true;
+
+		for (int i = 0; i < selected_items.size(); i++) {
+			int item_idx = selected_items[i];
+			if (ResourceLoader::get_resource_type(owners->get_item_text(item_idx)) != "PackedScene") {
+				only_scenes_selected = false;
+				break;
+			}
+		}
+
+		if (only_scenes_selected) {
+			file_options->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTRN("Open Scene", "Open Scenes", selected_items.size()), FILE_OPEN);
+		} else if (selected_items.size() == 1) {
+			file_options->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Open"), FILE_OPEN);
 		} else {
-			file_options->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Open Scenes"), FILE_OPEN);
+			return;
 		}
 	}
 
@@ -303,9 +316,19 @@ void DependencyEditorOwners::_select_file(int p_idx) {
 
 	if (ResourceLoader::get_resource_type(fpath) == "PackedScene") {
 		EditorNode::get_singleton()->open_request(fpath);
-		hide();
-		emit_signal(SNAME("confirmed"));
+	} else {
+		EditorNode::get_singleton()->load_resource(fpath);
 	}
+	hide();
+	emit_signal(SNAME("confirmed"));
+}
+
+void DependencyEditorOwners::_empty_clicked(const Vector2 &p_pos, MouseButton p_mouse_button_index) {
+	if (p_mouse_button_index != MouseButton::LEFT) {
+		return;
+	}
+
+	owners->deselect_all();
 }
 
 void DependencyEditorOwners::_file_option(int p_option) {
@@ -372,6 +395,7 @@ DependencyEditorOwners::DependencyEditorOwners() {
 	owners->set_select_mode(ItemList::SELECT_MULTI);
 	owners->connect("item_clicked", callable_mp(this, &DependencyEditorOwners::_list_rmb_clicked));
 	owners->connect("item_activated", callable_mp(this, &DependencyEditorOwners::_select_file));
+	owners->connect("empty_clicked", callable_mp(this, &DependencyEditorOwners::_empty_clicked));
 	owners->set_allow_rmb_select(true);
 	add_child(owners);
 }

--- a/editor/dependency_editor.h
+++ b/editor/dependency_editor.h
@@ -80,6 +80,7 @@ class DependencyEditorOwners : public AcceptDialog {
 	static void _bind_methods();
 	void _list_rmb_clicked(int p_item, const Vector2 &p_pos, MouseButton p_mouse_button_index);
 	void _select_file(int p_idx);
+	void _empty_clicked(const Vector2 &p_pos, MouseButton p_mouse_button_index);
 	void _file_option(int p_option);
 
 private:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/85438892/202024537-05c894c1-9a15-43ae-8c01-c237a6b46931.png)
Silly dialog!

- Fixes resources not being openable in this dialog
- No popup if multiple resources are selected, or if a mix of scenes and other resources is selected.
- Misc enhancement: Deselects all items when you click on empty space, as one would expect.

This behavior matches the FileSystem dock. The whole dialog could use a glow up, but this fixes its bugs for now.