### PR TITLE
[3.x] Implement shadowmask for DirectionalLight in BakedLightmap

### DIFF
--- a/doc/classes/BakedLightmap.xml
+++ b/doc/classes/BakedLightmap.xml
@@ -94,6 +94,10 @@
 			If [code]true[/code], stores the lightmap textures in a high dynamic range format (EXR). If [code]false[/code], stores the lightmap texture in a low dynamic range PNG image. This can be set to [code]false[/code] to reduce disk usage, but light values over 1.0 will be clamped and you may see banding caused by the reduced precision.
 			[b]Note:[/b] Setting [member use_hdr] to [code]true[/code] will decrease lightmap banding even when using the GLES2 backend or if [member ProjectSettings.rendering/quality/depth/hdr] is [code]false[/code].
 		</member>
+		<member name="use_shadowmask" type="bool" setter="set_use_shadowmask" getter="is_using_shadowmask" default="true">
+			If [code]true[/code], bakes the [DirectionalLight]s' direct light shadows into a [i]shadowmask[/i] which is stored in the lightmap textures' alpha channel. This shadowmask is used to keep static shadows visible past the DirectionalLights' [member DirectionalLight.directional_shadow_max_distance] by blending the last shadow split with the shadowmask. This in turn allows you to use a lower [member DirectionalLight.directional_shadow_max_distance] for dynamic objects. Lower real-time shadow distances improve shadow detail and performance while making shadow acne less visible.
+			[b]Note:[/b] Shadowmasking only supports one baked [DirectionalLight] at a time. If you have more than one [DirectionalLight] whose [member Light.light_bake_mode] isn't set to [constant Light.BAKE_DISABLED], the editor will print a warning when baking lightmaps. Shadowmasking doesn't work when using both [member use_hdr] is [code]true[/code] and [member use_color] is [code]false[/code]. There are known visual bugs when using the GLES2 and both [member use_hdr] is [code]false[/code] and [member use_color] is [code]true[/code].
+		</member>
 	</members>
 	<constants>
 		<constant name="BAKE_QUALITY_LOW" value="0" enum="BakeQuality">

--- a/doc/classes/Light.xml
+++ b/doc/classes/Light.xml
@@ -51,7 +51,7 @@
 		</member>
 		<member name="light_size" type="float" setter="set_param" getter="get_param" default="0.0">
 			The size of the light in Godot units. Only considered in baked lightmaps and only if [member light_bake_mode] is set to [constant BAKE_ALL]. Increasing this value will make the shadows appear blurrier. This can be used to simulate area lights to an extent.
-			[b]Note:[/b] [member light_size] is not affected by [member Spatial.scale] (the light's scale or its parent's scale).
+			[b]Note:[/b] [member light_size] is not affected by [member Spatial.scale] (the light's scale or its parent's scale). [DirectionalLight]s with their bake mode set to [constant BAKE_INDIRECT] still have an adjustable [member light_size] property, but it will only be used for the baked shadowmask (see [member BakedLightmap.use_shadowmask]). This can be used to better integrate the shadowmask with real-time shadows by making it softer and less pixelated. Values between [code]0.01[/code] and [code]0.1[/code] work well for the purposes of shadowmasking.
 		</member>
 		<member name="light_specular" type="float" setter="set_param" getter="get_param" default="0.5">
 			The intensity of the specular blob in objects affected by the light. At [code]0[/code], the light becomes a pure diffuse light. When not baking emission, this can be used to avoid unrealistic reflections when placing lights above an emissive surface.

--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -1820,12 +1820,13 @@ FRAGMENT_SHADER_CODE
 	}
 
 #ifdef USE_LIGHTMAP
-//ambient light will come entirely from lightmap is lightmap is used
 #if defined(USE_LIGHTMAP_FILTER_BICUBIC)
-	ambient_light = texture2D_bicubic(lightmap, uv2_interp).rgb * lightmap_energy;
+	vec4 lightmap_sample = texture2D_bicubic(lightmap, uv2_interp);
 #else
-	ambient_light = texture2D(lightmap, uv2_interp).rgb * lightmap_energy;
+	vec4 lightmap_sample = texture2D(lightmap, uv2_interp);
 #endif
+	//ambient light will come entirely from lightmap is lightmap is used
+	ambient_light = lightmap_sample.rgb * lightmap_energy;
 #endif
 
 #ifdef USE_LIGHTMAP_CAPTURE
@@ -1942,6 +1943,16 @@ FRAGMENT_SHADER_CODE
 #endif
 	float depth_z = -vertex.z;
 
+#ifdef USE_LIGHTMAP
+	// Take the DirectionalLight's shadow color into account for the shadowmask.
+	// This applies even if the DirectionalLight shadow is disabled, which can be
+	// done to improve performance by disabling shadows for dynamic objects only.
+	vec3 shadowmask = mix(shadow_color.rgb, vec3(1.0), lightmap_sample.a);
+#else
+	// No lightmaps, fallback to no shadows in the distance.
+	vec3 shadowmask = vec3(1.0);
+#endif
+
 #if !defined(SHADOWS_DISABLED)
 
 #ifdef USE_SHADOW
@@ -2005,7 +2016,9 @@ FRAGMENT_SHADER_CODE
 			shadow_att = mix(shadow_att, shadow_att2, pssm_blend);
 		}
 #endif
-		light_att *= mix(shadow_color.rgb, vec3(1.0), shadow_att);
+		light_att *= mix(shadow_color.rgb, shadowmask, shadow_att);
+	} else {
+		light_att *= shadowmask;
 	}
 
 #endif //LIGHT_USE_PSSM4
@@ -2045,14 +2058,16 @@ FRAGMENT_SHADER_CODE
 			shadow_att = mix(shadow_att, shadow_att2, pssm_blend);
 		}
 #endif
-		light_att *= mix(shadow_color.rgb, vec3(1.0), shadow_att);
+		light_att *= mix(shadow_color.rgb, shadowmask, shadow_att);
+	} else {
+		light_att *= shadowmask;
 	}
 
 #endif //LIGHT_USE_PSSM2
 
 #if !defined(LIGHT_USE_PSSM4) && !defined(LIGHT_USE_PSSM2)
 
-	light_att *= mix(shadow_color.rgb, vec3(1.0), sample_shadow(light_directional_shadow, shadow_coord));
+	light_att *= mix(shadow_color.rgb, shadowmask, sample_shadow(light_directional_shadow, shadow_coord));
 #endif //orthogonal
 
 #else //fragment version of pssm
@@ -2148,11 +2163,15 @@ FRAGMENT_SHADER_CODE
 			}
 #endif
 
-			light_att *= mix(shadow_color.rgb, vec3(1.0), shadow);
+			light_att *= mix(shadow_color.rgb, shadowmask, shadow);
+		} else {
+			light_att *= shadowmask;
 		}
 	}
 #endif //use vertex lighting
 
+#else
+	light_att *= shadowmask;
 #endif //use shadow
 
 #endif // SHADOWS_DISABLED

--- a/modules/denoise/denoise_wrapper.cpp
+++ b/modules/denoise/denoise_wrapper.cpp
@@ -42,8 +42,9 @@ void *oidn_denoiser_init() {
 bool oidn_denoise(void *deviceptr, float *p_floats, int p_width, int p_height) {
 	OIDNDeviceImpl *device = (OIDNDeviceImpl *)deviceptr;
 	OIDNFilter filter = oidnNewFilter(device, "RTLightmap");
-	oidnSetSharedFilterImage(filter, "color", (void *)p_floats, OIDN_FORMAT_FLOAT3, p_width, p_height, 0, 0, 0);
-	oidnSetSharedFilterImage(filter, "output", (void *)p_floats, OIDN_FORMAT_FLOAT3, p_width, p_height, 0, 0, 0);
+	// Pass 16-byte pixel stride to preserve the unmodified 32-bit alpha channel.
+	oidnSetSharedFilterImage(filter, "color", (void *)p_floats, OIDN_FORMAT_FLOAT3, p_width, p_height, 0, 16, 0);
+	oidnSetSharedFilterImage(filter, "output", (void *)p_floats, OIDN_FORMAT_FLOAT3, p_width, p_height, 0, 16, 0);
 	oidnSetFilter1b(filter, "hdr", true);
 	oidnCommitFilter(filter);
 	oidnExecuteFilter(filter);

--- a/modules/denoise/denoise_wrapper.h
+++ b/modules/denoise/denoise_wrapper.h
@@ -32,7 +32,11 @@
 #define DENOISE_WRAPPER_H
 
 void *oidn_denoiser_init();
+
+// Expects RGBAF image data. The alpha channel is configured to be ignored by OpenImageDenoise,
+// and is preserved in the output data.
 bool oidn_denoise(void *device, float *p_floats, int p_width, int p_height);
+
 void oidn_denoiser_finish(void *device);
 
 #endif // DENOISE_WRAPPER_H

--- a/modules/denoise/lightmap_denoiser.cpp
+++ b/modules/denoise/lightmap_denoiser.cpp
@@ -43,7 +43,7 @@ void LightmapDenoiserOIDN::make_default_denoiser() {
 Ref<Image> LightmapDenoiserOIDN::denoise_image(const Ref<Image> &p_image) {
 	Ref<Image> img = p_image->duplicate();
 
-	img->convert(Image::FORMAT_RGBF);
+	img->convert(Image::FORMAT_RGBAF);
 
 	PoolByteArray data = img->get_data();
 	{

--- a/modules/lightmapper_cpu/lightmapper_cpu.h
+++ b/modules/lightmapper_cpu/lightmapper_cpu.h
@@ -75,6 +75,7 @@ class LightmapperCPU : public Lightmapper {
 
 		Vector3 direct_light;
 		Vector3 output_light;
+		float shadowmask = 1.0;
 
 		float area_coverage;
 	};
@@ -160,11 +161,11 @@ class LightmapperCPU : public Lightmapper {
 
 	void _post_process(uint32_t p_idx, void *r_output);
 	void _compute_seams(const MeshInstance &p_mesh, LocalVector<UVSeam> &r_seams);
-	void _fix_seams(const LocalVector<UVSeam> &p_seams, Vector3 *r_lightmap, Vector2i p_size);
-	void _fix_seam(const Vector2 &p_pos0, const Vector2 &p_pos1, const Vector2 &p_uv0, const Vector2 &p_uv1, const Vector3 *p_read_buffer, Vector3 *r_write_buffer, const Vector2i &p_size);
-	void _dilate_lightmap(Vector3 *r_lightmap, const LocalVector<int> p_indices, Vector2i p_size, int margin);
+	void _fix_seams(const LocalVector<UVSeam> &p_seams, Color *r_lightmap, Vector2i p_size);
+	void _fix_seam(const Vector2 &p_pos0, const Vector2 &p_pos1, const Vector2 &p_uv0, const Vector2 &p_uv1, const Color *p_read_buffer, Color *r_write_buffer, const Vector2i &p_size);
+	void _dilate_lightmap(Color *r_lightmap, const LocalVector<int> p_indices, Vector2i p_size, int margin);
 
-	void _blit_lightmap(const Vector<Vector3> &p_src, const Vector2i &p_size, Ref<Image> &p_dst, int p_x, int p_y, bool p_with_padding);
+	void _blit_lightmap(const Vector<Color> &p_src, const Vector2i &p_size, Ref<Image> &p_dst, int p_x, int p_y, bool p_with_padding);
 
 public:
 	virtual void add_albedo_texture(Ref<Texture> p_texture);

--- a/scene/3d/baked_lightmap.h
+++ b/scene/3d/baked_lightmap.h
@@ -167,6 +167,7 @@ private:
 	bool use_denoiser;
 	bool use_hdr;
 	bool use_color;
+	bool use_shadowmask;
 
 	EnvironmentMode environment_mode;
 	Ref<Sky> environment_custom_sky;
@@ -264,6 +265,9 @@ public:
 
 	void set_use_color(bool p_enable);
 	bool is_using_color() const;
+
+	void set_use_shadowmask(bool p_enable);
+	bool is_using_shadowmask() const;
 
 	void set_bounces(int p_bounces);
 	int get_bounces() const;

--- a/scene/3d/light.cpp
+++ b/scene/3d/light.cpp
@@ -199,7 +199,10 @@ void Light::_validate_property(PropertyInfo &property) const {
 		property.usage = PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL;
 	}
 
-	if (bake_mode != BAKE_ALL && property.name == "light_size") {
+	// DirectionalLight can bake shadowmasks with its bake mode set to Indirect,
+	// so the light size is still relevant to display in this case.
+	const bool can_bake_shadowmask = type == VS::LIGHT_DIRECTIONAL && bake_mode == BAKE_INDIRECT;
+	if (!can_bake_shadowmask && bake_mode != BAKE_ALL && property.name == "light_size") {
 		property.usage = PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL;
 	}
 }


### PR DESCRIPTION
Finished implementing #51330.

This is my first ever PR. Please go easy on me, I'm very nervous about messing up in front of Juan senpai.

There are two known bugs that have been documented and only effect people who have shadowmasking on.
1. When using GLES2 and using shadowmasking with color and without HDR, there are visual bugs. After extensive debugging, I believe the problem is how RGBA8 images are uploaded to the graphics card in the GLES2 renderer. I feel fixing this is outside the scope of this PR because the resulting lightmap is correct and the shader appears to be bug free as well.
2. Shadowmasking doesn't work when using HDR without color because Godot doesn't support one color channel + alpha channel half float textures (RAH). Adding "Image::FORMAT_RAH" seems outside the scope of this PR. Currently a warning is printed when using HDR without color and the alpha channel is stripped, therefore removing shadowmasking but everything else still works fine.
