### PR TITLE
Expose functionalities of `CanvasItemEditor` to GDScript, through `EditorInterface` 

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -34,11 +34,23 @@
 				Edits the given [Script]. The line and column on which to open the script can also be specified. The script will be open with the user-configured editor for the script's language which may be an external editor.
 			</description>
 		</method>
+		<method name="focus_canvas_item_editor_to_selection">
+			<return type="void" />
+			<description>
+				Focus the canvas item editor viewport to the selected object(s).
+			</description>
+		</method>
 		<method name="get_base_control">
 			<return type="Control" />
 			<description>
 				Returns the main container of Godot editor's window. For example, you can use it to retrieve the size of the container and place your controls accordingly.
 				[b]Warning:[/b] Removing and freeing this node will render the editor useless and may cause a crash.
+			</description>
+		</method>
+		<method name="get_canvas_item_editor_transform" qualifiers="const">
+			<return type="Transform2D" />
+			<description>
+				Return the transform of the canvas item editor viewport, from global space to viewport space.
 			</description>
 		</method>
 		<method name="get_command_palette" qualifiers="const">
@@ -272,6 +284,12 @@
 			<return type="void" />
 			<description>
 				Stops the scene that is currently playing.
+			</description>
+		</method>
+		<method name="update_canvas_item_editor_viewport">
+			<return type="void" />
+			<description>
+				Update the canvas item editor viewport and the surranding sliders.
 			</description>
 		</method>
 	</methods>

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -345,6 +345,18 @@ EditorCommandPalette *EditorInterface::get_command_palette() const {
 	return EditorCommandPalette::get_singleton();
 }
 
+Transform2D EditorInterface::get_canvas_item_editor_transform() const {
+	return CanvasItemEditor::get_singleton()->get_canvas_transform();
+}
+
+void EditorInterface::update_canvas_item_editor_viewport() {
+	CanvasItemEditor::get_singleton()->update_viewport();
+}
+
+void EditorInterface::focus_canvas_item_editor_to_selection() {
+	CanvasItemEditor::get_singleton()->focus_selection();
+}
+
 EditorInterface *EditorInterface::singleton = nullptr;
 
 void EditorInterface::_bind_methods() {
@@ -394,6 +406,10 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_main_screen_editor", "name"), &EditorInterface::set_main_screen_editor);
 	ClassDB::bind_method(D_METHOD("set_distraction_free_mode", "enter"), &EditorInterface::set_distraction_free_mode);
 	ClassDB::bind_method(D_METHOD("is_distraction_free_mode_enabled"), &EditorInterface::is_distraction_free_mode_enabled);
+
+	ClassDB::bind_method(D_METHOD("get_canvas_item_editor_transform"), &EditorInterface::get_canvas_item_editor_transform);
+	ClassDB::bind_method(D_METHOD("update_canvas_item_editor_viewport"), &EditorInterface::update_canvas_item_editor_viewport);
+	ClassDB::bind_method(D_METHOD("focus_canvas_item_editor_to_selection"), &EditorInterface::focus_canvas_item_editor_to_selection);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "distraction_free_mode"), "set_distraction_free_mode", "is_distraction_free_mode_enabled");
 }

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -56,6 +56,7 @@ class EditorSettings;
 class EditorToolAddons;
 class EditorTranslationParserPlugin;
 class EditorUndoRedoManager;
+class CanvasItemEditor;
 class FileSystemDock;
 class ScriptCreateDialog;
 class ScriptEditor;
@@ -129,6 +130,11 @@ public:
 	void set_main_screen_editor(const String &p_name);
 	void set_distraction_free_mode(bool p_enter);
 	bool is_distraction_free_mode_enabled() const;
+
+	// Expose selected functionalities from `CanvasItemEditor` for 2D Plugin writers
+	Transform2D get_canvas_item_editor_transform() const;
+	void update_canvas_item_editor_viewport();
+	void focus_canvas_item_editor_to_selection();
 
 	EditorInterface();
 };

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4711,12 +4711,17 @@ void CanvasItemEditor::_reset_drag() {
 }
 
 void CanvasItemEditor::_bind_methods() {
-	ClassDB::bind_method("_get_editor_data", &CanvasItemEditor::_get_editor_data);
+	//ClassDB::bind_method("_get_editor_data", &CanvasItemEditor::_get_editor_data);
 
-	ClassDB::bind_method(D_METHOD("set_state"), &CanvasItemEditor::set_state);
+	ClassDB::bind_method(D_METHOD("set_state", "p_state"), &CanvasItemEditor::set_state);
+	ClassDB::bind_method(D_METHOD("get_state"), &CanvasItemEditor::get_state);
 	ClassDB::bind_method(D_METHOD("update_viewport"), &CanvasItemEditor::update_viewport);
+	ClassDB::bind_method(D_METHOD("get_viewport_control"), &CanvasItemEditor::get_viewport_control);
+	ClassDB::bind_method(D_METHOD("get_editor_transform"), &CanvasItemEditor::get_canvas_transform); // Avoid conflict with CanvasItem::get_canvas_transform
+	ClassDB::bind_method(D_METHOD("focus_selection"), &CanvasItemEditor::focus_selection);
 
-	ClassDB::bind_method("_set_owner_for_node_and_children", &CanvasItemEditor::_set_owner_for_node_and_children);
+	//ClassDB::bind_method("_set_owner_for_node_and_children", &CanvasItemEditor::_set_owner_for_node_and_children);
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "state"), "set_state", "get_state");
 
 	ADD_SIGNAL(MethodInfo("item_lock_status_changed"));
 	ADD_SIGNAL(MethodInfo("item_group_status_changed"));


### PR DESCRIPTION
Writing 2D editor plugins in GDScript use some [hacky work around](https://github.com/godotengine/godot/issues/3992) to interact with `CanvasItemEditor`. ~This PR exposes `CanvasItemEditor` directly~, This PR exposes some functionalities of `CanvasItemEditor` through `EditorInterface`, in order to make life of 2D plugin writer easier.  

Currently only methods that are essential for 2D editor plugin are exposed. More functionalities (such as snapping and tool state) can be exposed if there is demand. See https://github.com/godotengine/godot-proposals/issues/1302 for discussion.


Another [PR](https://github.com/godotengine/godot/pull/68696) address the same problem with different ways. I am not familiar with Godot enough to tell which is the better way. Hope reviewer could shed some light.