### PR TITLE
Add explicit name to History dock

### DIFF
--- a/editor/history_dock.cpp
+++ b/editor/history_dock.cpp
@@ -219,6 +219,8 @@ void HistoryDock::_notification(int p_notification) {
 }
 
 HistoryDock::HistoryDock() {
+	set_name("History");
+
 	ur_manager = EditorNode::get_undo_redo();
 	ur_manager->connect("history_changed", callable_mp(this, &HistoryDock::on_history_changed));
 	ur_manager->connect("version_changed", callable_mp(this, &HistoryDock::on_version_changed));


### PR DESCRIPTION
There are 2 issues with History dock placement:
1. When opening an old project, the history dock will be first in the list. Does not happen in new projects
2. When opening the project again, the History dock position might be reset. This is because the dock was getting a garbage name like `@@7225` and the name might be different between launches

This PR fixes the latter issue.