### PR TITLE
Manually load glXSwapInterval function pointers

### DIFF
--- a/platform/linuxbsd/x11/gl_manager_x11.cpp
+++ b/platform/linuxbsd/x11/gl_manager_x11.cpp
@@ -330,6 +330,7 @@ Error GLManager_X11::initialize() {
 }
 
 void GLManager_X11::set_use_vsync(bool p_use) {
+	static bool setup = false;
 	static PFNGLXSWAPINTERVALEXTPROC glXSwapIntervalEXT = nullptr;
 	static PFNGLXSWAPINTERVALSGIPROC glXSwapIntervalMESA = nullptr;
 	static PFNGLXSWAPINTERVALSGIPROC glXSwapIntervalSGI = nullptr;
@@ -344,7 +345,22 @@ void GLManager_X11::set_use_vsync(bool p_use) {
 	if (!_current_window) {
 		return;
 	}
+
 	const GLDisplay &disp = get_current_display();
+
+	if (!setup) {
+		setup = true;
+		String extensions = glXQueryExtensionsString(disp.x11_display, DefaultScreen(disp.x11_display));
+		if (extensions.find("GLX_EXT_swap_control") != -1) {
+			glXSwapIntervalEXT = (PFNGLXSWAPINTERVALEXTPROC)glXGetProcAddressARB((const GLubyte *)"glXSwapIntervalEXT");
+		}
+		if (extensions.find("GLX_MESA_swap_control") != -1) {
+			glXSwapIntervalMESA = (PFNGLXSWAPINTERVALSGIPROC)glXGetProcAddressARB((const GLubyte *)"glXSwapIntervalMESA");
+		}
+		if (extensions.find("GLX_SGI_swap_control") != -1) {
+			glXSwapIntervalSGI = (PFNGLXSWAPINTERVALSGIPROC)glXGetProcAddressARB((const GLubyte *)"glXSwapIntervalSGI");
+		}
+	}
 
 	int val = p_use ? 1 : 0;
 	if (GLAD_GLX_MESA_swap_control) {


### PR DESCRIPTION
Fixes issue reported in https://github.com/godotengine/godot/pull/68700#issuecomment-1316112686

This copies the code from 3.x for initializing the swap interval function with GLX. By actually calling the vsync code I had exposed an issue that has been around since the early GLES3 port. For some reason the old code was working fine on my system (intel iGPU) My guess is my system was able to pull the MESA version while the NVidia drivers crashed in one of the latter two options. 

This works fine on my system, but my system wasn't crashing before. Will need testing from someone who can reproduce.

cc @lateasusual

- Fixes #68722