### PR TITLE
Fix shader compiler asan out of bounds

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -4309,7 +4309,17 @@ ShaderLanguage::DataType ShaderLanguage::get_scalar_type(DataType p_type) {
 		TYPE_INT,
 		TYPE_UINT,
 		TYPE_FLOAT,
+		TYPE_INT,
+		TYPE_UINT,
+		TYPE_FLOAT,
+		TYPE_INT,
+		TYPE_UINT,
+		TYPE_FLOAT,
+		TYPE_FLOAT,
+		TYPE_VOID,
 	};
+
+	static_assert(sizeof(scalar_types) / sizeof(*scalar_types) == TYPE_MAX);
 
 	return scalar_types[p_type];
 }
@@ -4340,7 +4350,17 @@ int ShaderLanguage::get_cardinality(DataType p_type) {
 		1,
 		1,
 		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
 	};
+
+	static_assert(sizeof(cardinality_table) / sizeof(*cardinality_table) == TYPE_MAX);
 
 	return cardinality_table[p_type];
 }


### PR DESCRIPTION
Fixes #68623

`ShaderLanguage::get_scalar_type` and `ShaderLanguage::get_cardinality` index into an array, but as new elements were added to `enum DataType` these arrays have not been updated.
An UB out of bounds read occurs if any type > `TYPE_SAMPLER2DARRAY` is passed as arguments to a function, including *Sampler2DArray, *Sampler3D, SamplerCube(Array), and Struct.

Examples of shaders producing this bug (4.0 and 3.x):
```glsl
shader_type spatial;

uniform sampler3D tex;

void fragment() {
    ALBEDO = texture(tex, vec3(0.0)).rgb;
}
```
```glsl
shader_type spatial;

struct Foo {
        float bar;
};

float get_bar(Foo foo) {
        return foo.bar;
}

void fragment() {
        Foo foo = Foo(0.5);
        ALBEDO = vec3(get_bar(foo));
}
```

The fix is to add the missing values, and add a check to ensure that the length of the array matches the number of types. I tried to match the values, but as far as I can tell from how `get_scalar_type` and `get_cardinality` are used, if the type doesn't have a constructor then the exact values don't matter, as long as `get_scalar_type(type) != type`.

This PR is compatible with 3.x, once `TYPE_MAX` is added to `enum DataType`.