### PR TITLE
X11: Don't override glxSwapInterval function pointers loaded by GLAD

### DIFF
--- a/platform/linuxbsd/x11/gl_manager_x11.cpp
+++ b/platform/linuxbsd/x11/gl_manager_x11.cpp
@@ -330,10 +330,6 @@ Error GLManager_X11::initialize() {
 }
 
 void GLManager_X11::set_use_vsync(bool p_use) {
-	static PFNGLXSWAPINTERVALEXTPROC glXSwapIntervalEXT = nullptr;
-	static PFNGLXSWAPINTERVALSGIPROC glXSwapIntervalMESA = nullptr;
-	static PFNGLXSWAPINTERVALSGIPROC glXSwapIntervalSGI = nullptr;
-
 	// force vsync in the editor for now, as a safety measure
 	bool is_editor = Engine::get_singleton()->is_editor_hint();
 	if (is_editor) {


### PR DESCRIPTION
- Fixes #68722.
- Supersedes #68714.

Co-authored-by: @alcomposer 

Tested on Intel HD 630 and AMD Radeon Vega M with Mesa 22.2.3.
And @alcomposer tested the same patch with Nvidia driver 520.56.06.

---

BTW there's more stuff in this file that could likely be cleaned up now that we use GLAD2's glx wrapper.
E.g. these overrides seem to duplicate what's already in `glad/glx.h`:
```
#define GLX_CONTEXT_MAJOR_VERSION_ARB 0x2091
#define GLX_CONTEXT_MINOR_VERSION_ARB 0x2092
```