### PR TITLE
Fix polygon generation in BitMap

### DIFF
--- a/scene/resources/bit_map.h
+++ b/scene/resources/bit_map.h
@@ -46,7 +46,7 @@ class BitMap : public Resource {
 	int width = 0;
 	int height = 0;
 
-	Vector<Vector2> _march_square(const Rect2i &p_rect, const Point2i &p_start) const;
+	Vector<Vector<Vector2>> _march_square(const Rect2i &p_rect, const Point2i &p_start) const;
 
 	TypedArray<PackedVector2Array> _opaque_to_polygons_bind(const Rect2i &p_rect, float p_epsilon) const;
 

--- a/tests/scene/test_bit_map.h
+++ b/tests/scene/test_bit_map.h
@@ -434,6 +434,37 @@ TEST_CASE("[BitMap] Clip to polygon") {
 	polygons = bit_map.clip_opaque_to_polygons(Rect2i(0, 0, 128, 128));
 	CHECK_MESSAGE(polygons.size() == 1, "We should have exactly 1 polygon");
 	CHECK_MESSAGE(polygons[0].size() == 6, "The polygon should have exactly 6 points");
+
+	reset_bit_map(bit_map);
+	bit_map.set_bit_rect(Rect2i(0, 0, 64, 64), true);
+	bit_map.set_bit_rect(Rect2i(64, 64, 64, 64), true);
+	bit_map.set_bit_rect(Rect2i(192, 128, 64, 64), true);
+	bit_map.set_bit_rect(Rect2i(128, 192, 64, 64), true);
+	polygons = bit_map.clip_opaque_to_polygons(Rect2i(0, 0, 256, 256));
+	CHECK_MESSAGE(polygons.size() == 4, "We should have exactly 4 polygons");
+	CHECK_MESSAGE(polygons[0].size() == 4, "The polygon should have exactly 4 points");
+	CHECK_MESSAGE(polygons[1].size() == 4, "The polygon should have exactly 4 points");
+	CHECK_MESSAGE(polygons[2].size() == 4, "The polygon should have exactly 4 points");
+	CHECK_MESSAGE(polygons[3].size() == 4, "The polygon should have exactly 4 points");
+
+	reset_bit_map(bit_map);
+	bit_map.set_bit(0, 0, true);
+	bit_map.set_bit(2, 0, true);
+	bit_map.set_bit_rect(Rect2i(1, 1, 1, 2), true);
+	polygons = bit_map.clip_opaque_to_polygons(Rect2i(0, 0, 3, 3));
+	CHECK_MESSAGE(polygons.size() == 3, "We should have exactly 3 polygons");
+	CHECK_MESSAGE(polygons[0].size() == 4, "The polygon should have exactly 4 points");
+	CHECK_MESSAGE(polygons[1].size() == 4, "The polygon should have exactly 4 points");
+	CHECK_MESSAGE(polygons[2].size() == 4, "The polygon should have exactly 4 points");
+
+	reset_bit_map(bit_map);
+	bit_map.set_bit_rect(Rect2i(0, 0, 2, 1), true);
+	bit_map.set_bit_rect(Rect2i(0, 2, 3, 1), true);
+	bit_map.set_bit(0, 1, true);
+	bit_map.set_bit(2, 1, true);
+	polygons = bit_map.clip_opaque_to_polygons(Rect2i(0, 0, 4, 4));
+	CHECK_MESSAGE(polygons.size() == 1, "We should have exactly 1 polygon");
+	CHECK_MESSAGE(polygons[0].size() == 6, "The polygon should have exactly 6 points");
 }
 
 } // namespace TestBitmap


### PR DESCRIPTION
While working on #68380 some issues with the way BitMap does polygon generation showed up, I have tried to solve them here

There are a few things that have been changed:
* An oversight in `fill_bits` that caused connected pixels to not be filled, causing duplicate polygons being generated
* The procedure for traversing the bits and generating the polygon in `_march_squares`

For the `fill_bits` you could have a the following, starting at x and the red square would not be filled, causing in some cases overlapping polygons as the function would start over in the red square and create a polygon overlapping with the white area:
![image](https://user-images.githubusercontent.com/96648715/202193227-2fe940e5-6817-46e3-aa8e-2cfbf83a66cc.png)

There were some issues with the traversing the squares to generate the polygon as well, causing entire areas to be ignored:
![image](https://user-images.githubusercontent.com/96648715/202194327-ea1ffdfd-1052-47be-831c-0643b9b3f8f8.png)

There were also cases where the polygon would get self intersections, like this:
![image](https://user-images.githubusercontent.com/96648715/202195448-a4f722ec-842d-4a4e-900e-0a68bbbd2d16.png)
Which break the triangulation

When the number of points is greater than the pixels in the BitMap it now returns an empty result rather than the points so far, I don't see how a result in that case is valid and shouldn't be returned

So my solution is this:
* Fix the popping in the `fill_bits`, it seems to have been an oversight as the code says "The next loop over j must start normally." which I take to mean subtracting one, and from what I can see it doesn't cause any problems
* Fix the behavior in diagonal cases:
![image](https://user-images.githubusercontent.com/96648715/202196070-b9d19938-1b55-4c74-ae46-9e71eef9fdd8.png)
Where traversal didn't take into account the direction we are coming from, as the direction to go is (as far as I can figure out) based on the direction as we traverse it counter-clockwise
* Fix cases of self-overlap caused by my fix as well as other cases original to the code, this splits polygons at points where it reaches the same point again, which in some cases breaks triangulation (as it uses ear-clipping)

I had a few other approaches but this approach avoids filling in any bits that weren't filled, making assumptions or decisions on where should be included to solve the degenerate cases, at the cost of splitting polygons at these self overlap points

There might still be some issues in the `reduce` function that I haven't identified but it seems that it now generates valid polygons for general cases

For testing purposes here is a project where you can play around with a bitmap and see the different results:
[BitPR.zip](https://github.com/godotengine/godot/files/10022270/BitPR.zip)
Instructions:
* Left mouse fills square
* Right mouse clears square
* Space gets polygons
* Tab inverts bits
* Escape clears

Fixes #31675