### PR TITLE
[WIP] Implement Process wrapper class to allow more control over running processes.

### DIFF
--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -173,7 +173,8 @@ public:
 	String get_system_font_path(const String &p_font_name, bool p_bold = false, bool p_italic = false) const;
 	String get_executable_path() const;
 	String read_string_from_stdin(bool p_block = true);
-	int execute(const String &p_path, const Vector<String> &p_arguments, Array r_output = Array(), bool p_read_stderr = false, bool p_open_console = false);
+	int execute(const String &p_path, const Vector<String> &p_arguments, Array r_output = Array(), bool p_read_stderr = false);
+	void execute_async(const String &p_path, const Vector<String> &p_arguments, Callable p_callback, bool p_read_stderr = false);
 	int create_process(const String &p_path, const Vector<String> &p_arguments, bool p_open_console = false);
 	int create_instance(const Vector<String> &p_arguments);
 	Error kill(int p_pid);
@@ -260,6 +261,39 @@ public:
 	static OS *get_singleton() { return singleton; }
 
 	OS() { singleton = this; }
+};
+
+class Process : public Object {
+	GDCLASS(Process, Object);
+
+	String path;
+	List<String> args;
+	bool read_stdout = false;
+	bool read_stderr = false;
+	bool open_console = false;
+
+	String output;
+	int exitcode = 0;
+	::OS::ProcessID pid = 0;
+
+	::Thread execute_output_thread;
+	::Mutex execute_output_mutex;
+	SafeFlag done;
+
+protected:
+	static void _bind_methods();
+	static void _execute_thread(void *p_ud);
+
+public:
+	void start(const String &p_path, const Vector<String> &p_arguments, bool p_read_stdout = true, bool p_read_stderr = false, bool p_open_console = false);
+	void kill();
+
+	String get_output() const;
+	int get_exitcode() const;
+	int get_pid() const;
+	bool is_done() const;
+
+	~Process();
 };
 
 class Geometry2D : public Object {

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -152,7 +152,7 @@ public:
 	virtual Vector<String> get_system_fonts() const { return Vector<String>(); };
 	virtual String get_system_font_path(const String &p_font_name, bool p_bold = false, bool p_italic = false) const { return String(); };
 	virtual String get_executable_path() const;
-	virtual Error execute(const String &p_path, const List<String> &p_arguments, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr, bool p_open_console = false) = 0;
+	virtual Error execute(const String &p_path, const List<String> &p_arguments, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr, bool p_open_console = false, ProcessID *r_child_id = nullptr) = 0;
 	virtual Error create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id = nullptr, bool p_open_console = false) = 0;
 	virtual Error create_instance(const List<String> &p_arguments, ProcessID *r_child_id = nullptr) { return create_process(get_executable_path(), p_arguments, r_child_id); };
 	virtual Error kill(const ProcessID &p_pid) = 0;

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -322,6 +322,7 @@ void register_core_singletons() {
 	GDREGISTER_CLASS(core_bind::Engine);
 	GDREGISTER_CLASS(core_bind::special::ClassDB);
 	GDREGISTER_CLASS(core_bind::Marshalls);
+	GDREGISTER_CLASS(core_bind::Process);
 	GDREGISTER_CLASS(TranslationServer);
 	GDREGISTER_ABSTRACT_CLASS(Input);
 	GDREGISTER_CLASS(InputMap);

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -89,10 +89,8 @@
 			<param index="1" name="arguments" type="PackedStringArray" />
 			<param index="2" name="output" type="Array" default="[]" />
 			<param index="3" name="read_stderr" type="bool" default="false" />
-			<param index="4" name="open_console" type="bool" default="false" />
 			<description>
 				Executes a command. The file specified in [param path] must exist and be executable. Platform path resolution will be used. The [param arguments] are used in the given order and separated by a space. If an [param output] [Array] is provided, the complete shell output of the process will be appended as a single [String] element in [param output]. If [param read_stderr] is [code]true[/code], the output to the standard error stream will be included too.
-				On Windows, if [param open_console] is [code]true[/code] and the process is a console app, a new terminal window will be opened. This is ignored on other platforms.
 				If the command is successfully executed, the method will return the exit code of the command, or [code]-1[/code] if it fails.
 				[b]Note:[/b] The Godot thread will pause its execution until the executed command terminates. Use [Thread] to create a separate thread that will not pause the Godot thread, or use [method create_process] to create a completely independent process.
 				For example, to retrieve a list of the working directory's contents:

--- a/doc/classes/Process.xml
+++ b/doc/classes/Process.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Process" inherits="Object" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+		Class to start and control extenal processes.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_exitcode" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns process exit code, or [code]255[/code] if it is still running or not started.
+			</description>
+		</method>
+		<method name="get_output" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns current process shell output, if output capture is enabled by [method start].
+			</description>
+		</method>
+		<method name="get_pid" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns process PID, or [code]0[/code] if process is not running.
+			</description>
+		</method>
+		<method name="is_done" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if process is finished (or not started).
+			</description>
+		</method>
+		<method name="kill">
+			<return type="void" />
+			<description>
+				Kill (terminate) the process.
+			</description>
+		</method>
+		<method name="start">
+			<return type="void" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="arguments" type="PackedStringArray" />
+			<param index="2" name="read_stdout" type="bool" default="true" />
+			<param index="3" name="read_stderr" type="bool" default="false" />
+			<param index="4" name="open_console" type="bool" default="false" />
+			<description>
+				Executes a command. The file specified in [param path] must exist and be executable. Platform path resolution will be used. The [param arguments] are used in the given order and separated by a space. If an [param read_stdout] is [code]true[/code], the shell output of the process will be captured. If [param read_stderr] is [code]true[/code], the output to the standard error stream will be captured too.
+				If process is already started, old instance is automatically killed.
+				On Windows, if [param open_console] is [code]true[/code], [param read_stdout] is [code]false[/code] and the process is a console app, a new terminal window will be opened. This is ignored on other platforms.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -75,7 +75,7 @@ public:
 	virtual void delay_usec(uint32_t p_usec) const override;
 	virtual uint64_t get_ticks_usec() const override;
 
-	virtual Error execute(const String &p_path, const List<String> &p_arguments, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr, bool p_open_console = false) override;
+	virtual Error execute(const String &p_path, const List<String> &p_arguments, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr, bool p_open_console = false, ProcessID *r_child_id = nullptr) override;
 	virtual Error create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id = nullptr, bool p_open_console = false) override;
 	virtual Error kill(const ProcessID &p_pid) override;
 	virtual int get_process_id() const override;

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -493,11 +493,11 @@ OS_Android::OS_Android(GodotJavaWrapper *p_godot_java, GodotIOJavaWrapper *p_god
 	DisplayServerAndroid::register_android_driver();
 }
 
-Error OS_Android::execute(const String &p_path, const List<String> &p_arguments, String *r_pipe, int *r_exitcode, bool read_stderr, Mutex *p_pipe_mutex, bool p_open_console) {
+Error OS_Android::execute(const String &p_path, const List<String> &p_arguments, String *r_pipe, int *r_exitcode, bool read_stderr, Mutex *p_pipe_mutex, bool p_open_console, ProcessID *r_child_id) {
 	if (p_path == ANDROID_EXEC_PATH) {
 		return create_instance(p_arguments);
 	} else {
-		return OS_Unix::execute(p_path, p_arguments, r_pipe, r_exitcode, read_stderr, p_pipe_mutex, p_open_console);
+		return OS_Unix::execute(p_path, p_arguments, r_pipe, r_exitcode, read_stderr, p_pipe_mutex, p_open_console, r_child_id);
 	}
 }
 

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -132,7 +132,7 @@ public:
 
 	virtual String get_config_path() const override;
 
-	virtual Error execute(const String &p_path, const List<String> &p_arguments, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr, bool p_open_console = false) override;
+	virtual Error execute(const String &p_path, const List<String> &p_arguments, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr, bool p_open_console = false, ProcessID *r_child_id = nullptr) override;
 	virtual Error create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id = nullptr, bool p_open_console = false) override;
 	virtual Error create_instance(const List<String> &p_arguments, ProcessID *r_child_id = nullptr) override;
 

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -641,7 +641,7 @@ void OS_UWP::set_custom_mouse_cursor(const Ref<Resource> &p_cursor, CursorShape 
 	// TODO
 }
 
-Error OS_UWP::execute(const String &p_path, const List<String> &p_arguments, String *r_pipe, int *r_exitcode, bool read_stderr, Mutex *p_pipe_mutex, bool p_open_console) {
+Error OS_UWP::execute(const String &p_path, const List<String> &p_arguments, String *r_pipe, int *r_exitcode, bool read_stderr, Mutex *p_pipe_mutex, bool p_open_console, ProcessID *r_child_id) {
 	return FAILED;
 }
 

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -195,7 +195,7 @@ public:
 	virtual void delay_usec(uint32_t p_usec) const;
 	virtual uint64_t get_ticks_usec() const;
 
-	virtual Error execute(const String &p_path, const List<String> &p_arguments, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr, bool p_open_console = false);
+	virtual Error execute(const String &p_path, const List<String> &p_arguments, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr, bool p_open_console = false, ProcessID *r_child_id = nullptr);
 	virtual Error create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id = nullptr, bool p_open_console = false);
 	virtual Error kill(const ProcessID &p_pid);
 	virtual bool is_process_running(const ProcessID &p_pid) const;

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -100,7 +100,7 @@ void OS_Web::finalize() {
 
 // Miscellaneous
 
-Error OS_Web::execute(const String &p_path, const List<String> &p_arguments, String *r_pipe, int *r_exitcode, bool read_stderr, Mutex *p_pipe_mutex, bool p_open_console) {
+Error OS_Web::execute(const String &p_path, const List<String> &p_arguments, String *r_pipe, int *r_exitcode, bool read_stderr, Mutex *p_pipe_mutex, bool p_open_console, ProcessID *r_child_id) {
 	return create_process(p_path, p_arguments);
 }
 

--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -75,7 +75,7 @@ public:
 	MainLoop *get_main_loop() const override;
 	bool main_loop_iterate();
 
-	Error execute(const String &p_path, const List<String> &p_arguments, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr, bool p_open_console = false) override;
+	Error execute(const String &p_path, const List<String> &p_arguments, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr, bool p_open_console = false, ProcessID *r_child_id = nullptr) override;
 	Error create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id = nullptr, bool p_open_console = false) override;
 	Error kill(const ProcessID &p_pid) override;
 	int get_process_id() const override;

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -161,7 +161,7 @@ public:
 	virtual void delay_usec(uint32_t p_usec) const override;
 	virtual uint64_t get_ticks_usec() const override;
 
-	virtual Error execute(const String &p_path, const List<String> &p_arguments, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr, bool p_open_console = false) override;
+	virtual Error execute(const String &p_path, const List<String> &p_arguments, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr, bool p_open_console = false, ProcessID *r_child_id = nullptr) override;
 	virtual Error create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id = nullptr, bool p_open_console = false) override;
 	virtual Error kill(const ProcessID &p_pid) override;
 	virtual int get_process_id() const override;


### PR DESCRIPTION
- Removes `open_console` parameter from the `core_bind::OS::execute`, due to the way GDScript wrapper is implemented, it's always piping output and opened console will not show anything or be interactive. It's also impossible to read partial output, since GDScript wrapper is waiting for the process and returning all output as a single string.
- Implements `core_bind::Process` class to allow:
  - Asynchronously monitor, read output and kill running process using GDScript.
  - Wait for the interactive process running with opened console.

See https://github.com/godotengine/godot/pull/26674#issuecomment-1315272838

https://user-images.githubusercontent.com/7645683/202197673-4f3a79f1-4f3f-42f1-9acc-42f10a00e036.mp4

