### PR TITLE
[3.x] Fix PCKPacker error spam

### DIFF
--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -86,6 +86,8 @@ Error PCKPacker::pck_start(const String &p_file, int p_alignment) {
 };
 
 Error PCKPacker::add_file(const String &p_file, const String &p_src) {
+	ERR_FAIL_COND_V_MSG(!file, ERR_INVALID_PARAMETER, "File must be opened before use.");
+
 	FileAccess *f = FileAccess::open(p_src, FileAccess::READ);
 	if (!f) {
 		return ERR_FILE_CANT_OPEN;
@@ -165,6 +167,9 @@ Error PCKPacker::flush(bool p_verbose) {
 	}
 
 	file->close();
+	memdelete(file);
+	file = nullptr;
+
 	memdelete_arr(buf);
 
 	return OK;


### PR DESCRIPTION
After `PCKPacker.flush()`, the file is closed and it is invalid to call `flush()` or `add_file()`, but the closed file isn't properly detected because the FileAccess remains nonnull and `add_file()` doesn't check for a closed file, causing `flush()` to spam error messages and `add_file()` to miss the error. This PR fixes that.

With this script:
```gdscript
extends Node

func _ready():
        var packer = PCKPacker.new()
        packer.pck_start("res://out.pck")
        packer.flush()
        packer.flush()
        print()

        packer.add_file("", "icon.png")
```

Error messages before:
```
ERROR: File must be opened before use.
   at: store_8 (drivers/unix/file_access_unix.cpp:261)
ERROR: File must be opened before use.
   at: store_8 (drivers/unix/file_access_unix.cpp:261)
ERROR: File must be opened before use.
   at: store_8 (drivers/unix/file_access_unix.cpp:261)
ERROR: File must be opened before use.
   at: store_8 (drivers/unix/file_access_unix.cpp:261)
ERROR: File must be opened before use.
   at: get_position (drivers/unix/file_access_unix.cpp:205)
ERROR: File must be opened before use.
   at: get_position (drivers/unix/file_access_unix.cpp:205)
```

Error messages after:
```
ERROR: File must be opened before use.
   at: flush (core/io/pck_packer.cpp:111)

ERROR: File must be opened before use.
   at: add_file (core/io/pck_packer.cpp:89)
```

Compatible with 3.5.