### PR TITLE
Move engine version printout to top

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1932,6 +1932,9 @@ error:
 }
 
 Error Main::setup2(Thread::ID p_main_tid_override) {
+	// Print engine name and version
+	print_line(String(VERSION_NAME) + " v" + get_full_version_string() + " - " + String(VERSION_WEBSITE));
+
 	engine->startup_benchmark_begin_measure("servers");
 
 	tsman = memnew(TextServerManager);
@@ -1948,9 +1951,6 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	register_server_types();
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
 	NativeExtensionManager::get_singleton()->initialize_extensions(NativeExtension::INITIALIZATION_LEVEL_SERVERS);
-
-	// Print engine name and version
-	print_line(String(VERSION_NAME) + " v" + get_full_version_string() + " - " + String(VERSION_WEBSITE));
 
 	if (p_main_tid_override) {
 		Thread::main_thread_id = p_main_tid_override;


### PR DESCRIPTION
The engine name and version line should be the first thing printed during startup, but when running the engine with `--verbose`, the first line printed is from TextServer. This PR moves the version print to the top of Main::setup2.

Old output:
```
TextServer: Added interface "Dummy"
TextServer: Added interface "ICU / HarfBuzz / Graphite (Built-in)"
Godot Engine v4.0.beta.custom_build.89a33d28f - https://godotengine.org
XInput: Refreshing devices.
XInput: No touch devices found.
Detecting GPUs, set DRI_PRIME in the environment to override GPU detection logic.
```

Output with this PR:
```
Godot Engine v4.0.beta.custom_build.772d11d34 - https://godotengine.org
TextServer: Added interface "Dummy"
TextServer: Added interface "ICU / HarfBuzz / Graphite (Built-in)"
XInput: Refreshing devices.
XInput: No touch devices found.
Detecting GPUs, set DRI_PRIME in the environment to override GPU detection logic.
```

Not an issue in 3.x.