### PR TITLE
[3.x] Canvas item hierarchical culling

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1437,6 +1437,10 @@
 			[b]Experimental.[/b] If set to on, uses the [code]GL_STREAM_DRAW[/code] flag for legacy buffer uploads. If off, uses the [code]GL_DYNAMIC_DRAW[/code] flag.
 			[b]Note:[/b] Use with care. You are advised to leave this as default for exports. A non-default setting that works better on your machine may adversely affect performance for end users.
 		</member>
+		<member name="rendering/2d/options/culling_mode" type="int" setter="" getter="" default="1">
+			The culling mode determines the method used for rejecting canvas items that are outside a viewport. The visual result should be identical, but some modes may be faster for a particular project.
+			You can either cull items individually ([code]Item mode[/code]), or use hierarchical culling ([code]Node mode[/code]) which has a little more housekeeping but can increase performance by culling large numbers of items at once.
+		</member>
 		<member name="rendering/2d/options/ninepatch_mode" type="int" setter="" getter="" default="1">
 			Choose between fixed mode where corner scalings are preserved matching the artwork, and scaling mode.
 			Not available in GLES3 when [member rendering/batching/options/use_batching] is off.

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -484,6 +484,7 @@ public:
 	void skeleton_bone_set_transform_2d(RID p_skeleton, int p_bone, const Transform2D &p_transform) {}
 	Transform2D skeleton_bone_get_transform_2d(RID p_skeleton, int p_bone) const { return Transform2D(); }
 	uint32_t skeleton_get_revision(RID p_skeleton) const { return 0; }
+	void skeleton_attach_canvas_item(RID p_skeleton, RID p_canvas_item, bool p_attach) {}
 
 	/* Light API */
 

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -903,6 +903,7 @@ public:
 		Set<RasterizerScene::InstanceBase *> instances;
 
 		Transform2D base_transform_2d;
+		LocalVector<RID> linked_canvas_items;
 
 		Skeleton() :
 				use_2d(false),
@@ -928,6 +929,7 @@ public:
 	virtual Transform2D skeleton_bone_get_transform_2d(RID p_skeleton, int p_bone) const;
 	virtual void skeleton_set_base_transform_2d(RID p_skeleton, const Transform2D &p_base_transform);
 	virtual uint32_t skeleton_get_revision(RID p_skeleton) const;
+	virtual void skeleton_attach_canvas_item(RID p_skeleton, RID p_canvas_item, bool p_attach);
 
 	void _update_skeleton_transform_buffer(const PoolVector<float> &p_data, size_t p_size);
 

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -926,7 +926,9 @@ public:
 		GLuint texture;
 		SelfList<Skeleton> update_list;
 		Set<RasterizerScene::InstanceBase *> instances; //instances using skeleton
+
 		Transform2D base_transform_2d;
+		LocalVector<RID> linked_canvas_items;
 
 		Skeleton() :
 				use_2d(false),
@@ -952,6 +954,7 @@ public:
 	virtual Transform2D skeleton_bone_get_transform_2d(RID p_skeleton, int p_bone) const;
 	virtual void skeleton_set_base_transform_2d(RID p_skeleton, const Transform2D &p_base_transform);
 	virtual uint32_t skeleton_get_revision(RID p_skeleton) const;
+	virtual void skeleton_attach_canvas_item(RID p_skeleton, RID p_canvas_item, bool p_attach);
 
 	/* Light API */
 

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -39,6 +39,7 @@
 #include "scene/resources/style_box.h"
 #include "scene/resources/texture.h"
 #include "scene/scene_string_names.h"
+#include "servers/visual/visual_server_constants.h"
 #include "servers/visual/visual_server_raster.h"
 #include "servers/visual_server.h"
 
@@ -612,6 +613,17 @@ void CanvasItem::_notification(int p_what) {
 		} break;
 	}
 }
+
+#ifdef DEV_ENABLED
+void CanvasItem::_name_changed_notify() {
+	// Even in DEV builds, there is no point in calling this unless we are debugging
+	// canvas item names. Even calling the stub function will be expensive, as there
+	// are a lot of canvas items.
+#ifdef VISUAL_SERVER_CANVAS_DEBUG_ITEM_NAMES
+	VisualServer::get_singleton()->canvas_item_set_name(canvas_item, get_name());
+#endif
+}
+#endif
 
 void CanvasItem::update() {
 	if (!is_inside_tree()) {

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -240,6 +240,10 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+#ifdef DEV_ENABLED
+	virtual void _name_changed_notify();
+#endif
+
 public:
 	enum {
 		NOTIFICATION_TRANSFORM_CHANGED = SceneTree::NOTIFICATION_TRANSFORM_CHANGED, //unique

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -96,6 +96,15 @@ void Polygon2D::_skeleton_bone_setup_changed() {
 
 void Polygon2D::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			// Must re-establish any existing links with skeletons on re-entering the tree.
+			update();
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			// Always detach skeleton when exiting the tree, so skeletons don't inform
+			// Polygon2Ds outside the tree that they have moved (this would be useless work).
+			VS::get_singleton()->canvas_item_attach_skeleton(get_canvas_item(), RID());
+		} break;
 		case NOTIFICATION_DRAW: {
 			if (polygon.size() < 3) {
 				return;
@@ -664,4 +673,12 @@ Polygon2D::Polygon2D() {
 	rect_cache_dirty = true;
 	internal_vertices = 0;
 	current_skeleton_id = 0;
+}
+
+Polygon2D::~Polygon2D() {
+	// Most definitely don't want to leave references to this deleted canvas item
+	// in the skeleton.
+	if (get_canvas_item().is_valid()) {
+		VS::get_singleton()->canvas_item_attach_skeleton(get_canvas_item(), RID());
+	}
 }

--- a/scene/2d/polygon_2d.h
+++ b/scene/2d/polygon_2d.h
@@ -147,6 +147,7 @@ public:
 	NodePath get_skeleton() const;
 
 	Polygon2D();
+	virtual ~Polygon2D();
 };
 
 #endif // POLYGON_2D_H

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1051,7 +1051,15 @@ StringName Node::get_name() const {
 
 void Node::_set_name_nocheck(const StringName &p_name) {
 	data.name = p_name;
+#ifdef DEV_ENABLED
+	_name_changed_notify();
+#endif
 }
+
+#ifdef DEV_ENABLED
+void Node::_name_changed_notify() {
+}
+#endif
 
 void Node::set_name(const String &p_name) {
 	String name = p_name.validate_node_name();
@@ -1078,6 +1086,10 @@ void Node::set_name(const String &p_name) {
 		get_tree()->node_renamed(this);
 		get_tree()->tree_changed();
 	}
+
+#ifdef DEV_ENABLED
+	_name_changed_notify();
+#endif
 }
 
 static bool node_hrcr = false;
@@ -1262,7 +1274,7 @@ void Node::_generate_serial_child_name(const Node *p_child, StringName &name) co
 void Node::_add_child_nocheck(Node *p_child, const StringName &p_name) {
 	//add a child node quickly, without name validation
 
-	p_child->data.name = p_name;
+	p_child->_set_name_nocheck(p_name);
 	p_child->data.pos = data.children.size();
 	data.children.push_back(p_child);
 	p_child->data.parent = this;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -238,6 +238,9 @@ protected:
 	virtual void remove_child_notify(Node *p_child);
 	virtual void move_child_notify(Node *p_child);
 	virtual void owner_changed_notify();
+#ifdef DEV_ENABLED
+	virtual void _name_changed_notify();
+#endif
 
 	virtual void _physics_interpolated_changed();
 

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -449,6 +449,7 @@ public:
 	virtual Transform2D skeleton_bone_get_transform_2d(RID p_skeleton, int p_bone) const = 0;
 	virtual void skeleton_set_base_transform_2d(RID p_skeleton, const Transform2D &p_base_transform) = 0;
 	virtual uint32_t skeleton_get_revision(RID p_skeleton) const = 0;
+	virtual void skeleton_attach_canvas_item(RID p_skeleton, RID p_canvas_item, bool p_attach) = 0;
 
 	/* Light API */
 
@@ -985,6 +986,7 @@ public:
 		bool light_masked : 1;
 		mutable bool custom_rect : 1;
 		mutable bool rect_dirty : 1;
+		mutable bool bound_dirty : 1;
 
 		Vector<Command *> commands;
 		mutable Rect2 rect;
@@ -1024,6 +1026,10 @@ public:
 		void precalculate_polygon_bone_bounds(const Item::CommandPolygon &p_polygon) const;
 
 	public:
+		// the rect containing this item and all children,
+		// in local space.
+		Rect2 local_bound;
+
 		const Rect2 &get_rect() const {
 			if (custom_rect) {
 				return rect;
@@ -1201,6 +1207,7 @@ public:
 			final_modulate = Color(1, 1, 1, 1);
 			visible = true;
 			rect_dirty = true;
+			bound_dirty = true;
 			custom_rect = false;
 			behind = false;
 			material_owner = nullptr;

--- a/servers/visual/visual_server_constants.h
+++ b/servers/visual/visual_server_constants.h
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/*  visual_server_constants.h                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef VISUAL_SERVER_CONSTANTS_H
+#define VISUAL_SERVER_CONSTANTS_H
+
+// Use for constants etc that need not be included as often as VisualServer.h
+// to reduce dependencies and prevent slow compilation.
+
+// This is a "cheap" include, and can be used from scene side code as well as servers.
+
+// Uncomment to provide comparison of node culling versus item culling
+// #define VISUAL_SERVER_CANVAS_TIME_NODE_CULLING
+
+// N.B. ONLY allow these defined in DEV_ENABLED builds, they will slow
+// performance, and are only necessary to use for debugging.
+#ifdef DEV_ENABLED
+
+// Uncomment this define to store canvas item names in VisualServerCanvas.
+// This is relatively expensive, but is invaluable for debugging the canvas scene tree
+// especially using _print_tree() in VisualServerCanvas.
+// #define VISUAL_SERVER_CANVAS_DEBUG_ITEM_NAMES
+
+// Uncomment this define to verify local bounds of canvas items,
+// to check that the hierarchical culling is working correctly.
+// This is expensive.
+// #define VISUAL_SERVER_CANVAS_CHECK_BOUNDS
+
+#endif // DEV_ENABLED
+
+#endif // VISUAL_SERVER_CONSTANTS_H

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -682,6 +682,7 @@ public:
 
 	BIND0R(RID, canvas_item_create)
 	BIND2(canvas_item_set_parent, RID, RID)
+	BIND2(canvas_item_set_name, RID, String)
 
 	BIND2(canvas_item_set_visible, RID, bool)
 	BIND2(canvas_item_set_light_mask, RID, int)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -583,6 +583,7 @@ public:
 
 	FUNCRID(canvas_item)
 	FUNC2(canvas_item_set_parent, RID, RID)
+	FUNC2(canvas_item_set_name, RID, String)
 
 	FUNC2(canvas_item_set_visible, RID, bool)
 	FUNC2(canvas_item_set_light_mask, RID, int)

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -1009,6 +1009,7 @@ public:
 
 	virtual RID canvas_item_create() = 0;
 	virtual void canvas_item_set_parent(RID p_item, RID p_parent) = 0;
+	virtual void canvas_item_set_name(RID p_item, String p_name) = 0;
 
 	virtual void canvas_item_set_visible(RID p_item, bool p_visible) = 0;
 	virtual void canvas_item_set_light_mask(RID p_item, int p_mask) = 0;


### PR DESCRIPTION
Adds optional hierarchical culling to the 2D rendering (within VisualServer).

Each canvas item maintains a bound in local space of the item itself and all child / grandchild items. This allows branches to be culled at once when they don't intersect a viewport.

## Background
* @BimDav noticed in #63193 that culling in 2D is incredibly inefficient, in fact, it still does a lot of work for each item that is off screen.
* I noted in that PR that in addition to fixing the `VisibilityEnabler` to work with this, it might be possible to add some kind of automatic hierarchical culling, for instance using the scene graph, or a spatial partitioning structure such as BVH or similar.
* It turns out that unlike in 3D, for 2D, the hierarchical structure of the scene tree is stored in `VisualServer`, allowing the possibility for using this directly as spatial partitioning.

## How it works
* It stores one extra (non negligible) piece of data on each `Item` - the local bound. This is a `Rect2` indicating the bound in local space of the `Item` and all its non-hidden children and grandchildren.
* Additionally a dirty flag is stored to indicate whether the bound is dirty. This uses 1 bit and will combine with the other bitflags, so not using more memory.

### Housekeeping and Rendering
1) When changing the transform, or almost anything, about an `Item`, the bound of the item itself must be marked dirty (to be calculated next time). Additionally, the bounds of all parent items are marked dirty, as they may be modified.
2) During rendering, if a local bound is up to date (not dirty), it can be used for an intersection test with the viewport. If the bound is completely outside, all of the children can be culled. If the bound is _completely_ inside the viewport, none of the children need be tested, as they are all inside the viewport. If there is a partial intersection, the rendering proceeds as normal.
3) During rendering, any dirty local bounds are recalculated.

## Costs and Benefits
There is thus a small housekeeping cost to the technique - probably around 2% (of the time taken by the preparation / culling code). In return the wins are quite significant. Overall the preparation phase is typically 4-10x faster.

In cases where a lot is off screen (and can thus be culled) the gains can be large. In @BimDav 's test project with 300,000 canvas items, the preparation code runs in the region of 16,000x faster, with a similar huge improvement to frame rate.

In the editor there are also speed improvements to the preparation / culling.

However, note that the preparation / culling is not always a major bottleneck, so even though there are huge improvements in the efficiency of preparation code, the overall boosts to frame rate are usually more modest.

Testing in `jetpaca`, I was typically getting increases from around 350 to 400fps, so about 15%.

## Special cases
Most canvas items are only altered by calling functions in `VisualServer`, and these are thus easy to flag the bounds as dirty when such a change occurs. There are exceptions though for "dynamic" items, where changes are "pulled" rather than "pushed" to the server.

#### Skinned 2D Polygons
Skinned polygons pull their vertex transforms from a `Skeleton` each time the `Skeleton` changes. But there is a chicken and egg problem: In order to know whether the skeleton has changed, we need to call `get_rect()` on the `Polygon2D`, and this only occurs immediately prior to rendering, well after the time we expect to mass reject the `Polygon2D` using hierarchical culling.

The solution used here is instead of having a one way relationship where `Polygon2D` has a dependency to the `Skeleton`, the RID of the linked `Polygon2D` is now stored on the skeleton. Whenever the skeleton moves, the dependent polygons are informed, and their bounds made dirty.

This should always work, but is not ideal efficiency wise - it is advisable to use `VisibilityEnabler2D` for each skinned character, which will prevent animation when off screen, and thus the bound will not need updating.

#### Particles
Particle bounds are not actually currently dynamic in 3.x. Turns out GLES2 returns `Rect2()`, and GLES3 can only return a custom rect. So they should work as is without modification for hierarchical culling.

#### Vertex Shaders (that move verts)
These would probably need the user to make a custom rect or apply expansion margin.

## Notes
* As this is something that could potentially have regressions (particularly in y sorting), I have added it as an optional extra, and included the legacy path. This are now switchable in `project_settings/rendering/2d/options/cull_mode`, between `Item` mode (old style) and `Node` mode (which is now the default).
* There are some extra debugging functionality added. In particular, you can now switch a define to pass `canvas_item` names to the `VisualServer`, which enables you to identify nodes when printing the tree. This is normally switched off to save memory and performance. This can also be helpful for general 2D debugging in the `VisualServerCanvas`.

## Optional defines (in `visual_server_constants.h`)
* `VISUAL_SERVER_CANVAS_TIME_NODE_CULLING` - every 100 frames it runs both `Item` culling and `Node` culling, timing both, and displaying the timings using `print_line`. This enables direct comparison in different projects / scenes, and can be used in release.
* `VISUAL_SERVER_CANVAS_DEBUG_ITEM_NAMES` - pass canvas item names to VisualServer for debugging.
* `VISUAL_SERVER_CANVAS_CHECK_BOUNDS` - performs verification checks on all bounds to make sure they are correct and up to date, in order to detect bugs.
