### PR TITLE
[iOS] Fix getting Unicode executable path, fix error spam on start.

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -565,7 +565,7 @@ String OS_Unix::get_executable_path() const {
 		WARN_PRINT("MAXPATHLEN is too small");
 	}
 
-	String path(resolved_path);
+	String path = String::utf8(resolved_path);
 	delete[] resolved_path;
 
 	return path;

--- a/platform/ios/os_ios.h
+++ b/platform/ios/os_ios.h
@@ -106,7 +106,6 @@ public:
 
 	virtual Error shell_open(String p_uri) override;
 
-	void set_user_data_dir(String p_dir);
 	virtual String get_user_data_dir() const override;
 
 	virtual String get_cache_path() const override;

--- a/platform/ios/os_ios.mm
+++ b/platform/ios/os_ios.mm
@@ -130,8 +130,6 @@ void OS_IOS::alert(const String &p_alert, const String &p_title) {
 
 void OS_IOS::initialize_core() {
 	OS_Unix::initialize_core();
-
-	set_user_data_dir(user_data_dir);
 }
 
 void OS_IOS::initialize() {
@@ -273,13 +271,16 @@ Error OS_IOS::shell_open(String p_uri) {
 	return OK;
 }
 
-void OS_IOS::set_user_data_dir(String p_dir) {
-	Ref<DirAccess> da = DirAccess::open(p_dir);
-	user_data_dir = da->get_current_dir();
-	printf("setting data dir to %s from %s\n", user_data_dir.utf8().get_data(), p_dir.utf8().get_data());
-}
-
 String OS_IOS::get_user_data_dir() const {
+	static bool user_data_dir_set = false;
+	if (user_data_dir_set) {
+		String old_dir = user_data_dir;
+		Ref<DirAccess> da = DirAccess::open(old_dir);
+		const_cast<OS_IOS *>(this)->user_data_dir = da->get_current_dir();
+		user_data_dir_set = true;
+
+		printf("setting data dir to %s from %s\n", user_data_dir.utf8().get_data(), old_dir.utf8().get_data());
+	}
 	return user_data_dir;
 }
 


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/68723
- Fixes `!configured` and `!classes.has(ti.inherits)` error spam due to `Ref<DirAccess>` created before core type initialization.
