### PR TITLE
Ensure buffer is allocated (if necesary) before setting the buffer values

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -1728,6 +1728,17 @@ void MeshStorage::multimesh_set_buffer(RID p_multimesh, const Vector<float> &p_b
 	ERR_FAIL_COND(!multimesh);
 	ERR_FAIL_COND(p_buffer.size() != (multimesh->instances * (int)multimesh->stride_cache));
 
+	if (!multimesh->buffer.is_valid()) {
+		uint32_t buffer_size = multimesh->instances * multimesh->stride_cache * sizeof(float);
+		if (multimesh->motion_vectors_enabled) {
+			buffer_size *= 2;
+		}
+		if (buffer_size == 0) {
+			return;
+		}
+		multimesh->buffer = RD::get_singleton()->storage_buffer_create(buffer_size);
+	}
+
 	if (multimesh->motion_vectors_enabled) {
 		uint32_t frame = RSG::rasterizer->get_frame_number();
 


### PR DESCRIPTION
Multimesh buffer is not created when the node still does not contain any instance, this causes the engine to throw a bunch of annoying and repetitive errors whenever operating with the multimesh.
This change will ensure the buffer is initialized with the right size before setting it's content, but also doing an early return if the buffer is fully empty.

![image](https://user-images.githubusercontent.com/1776044/202299676-01f5343c-ff6e-4adc-971e-bc2fa8a361ec.png)

**This PR is sponsored by Prehensile Tales and Astera organization**
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
