### PR TITLE
Make CanvasItemEditor work without Node2D::set_scale hack

### DIFF
--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -172,6 +172,10 @@ bool Transform2D::is_finite() const {
 	return columns[0].is_finite() && columns[1].is_finite() && columns[2].is_finite();
 }
 
+bool Transform2D::is_invertible() const {
+	return basis_determinant() != 0;
+}
+
 Transform2D Transform2D::looking_at(const Vector2 &p_target) const {
 	Transform2D return_trans = Transform2D(get_rotation(), get_origin());
 	Vector2 target_position = affine_inverse().xform(p_target);

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -99,6 +99,7 @@ struct _NO_DISCARD_ Transform2D {
 	Transform2D orthonormalized() const;
 	bool is_equal_approx(const Transform2D &p_transform) const;
 	bool is_finite() const;
+	bool is_invertible() const;
 
 	Transform2D looking_at(const Vector2 &p_target) const;
 

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -152,6 +152,13 @@ Transform2D CanvasItem::get_global_transform_with_canvas() const {
 	}
 }
 
+Transform2D CanvasItem::get_parent_transform_to_viewport() const {
+	if (!get_parent_item()) {
+		return Transform2D();
+	}
+	return get_parent_item()->get_global_transform_with_canvas();
+}
+
 Transform2D CanvasItem::get_screen_transform() const {
 	ERR_FAIL_COND_V(!is_inside_tree(), Transform2D());
 	Transform2D xform = get_global_transform_with_canvas();

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -284,6 +284,7 @@ public:
 
 	virtual Transform2D get_global_transform() const;
 	virtual Transform2D get_global_transform_with_canvas() const;
+	virtual Transform2D get_parent_transform_to_viewport() const;
 	virtual Transform2D get_screen_transform() const;
 
 	CanvasItem *get_top_level() const;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1410,8 +1410,8 @@ Control *Viewport::_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_
 	}
 
 	Transform2D matrix = p_xform * p_node->get_transform();
-	// matrix.basis_determinant() == 0.0f implies that node does not exist on scene
-	if (matrix.basis_determinant() == 0.0f) {
+	// !matrix.is_invertible() implies that node does not exist on scene.
+	if (!matrix.is_invertible()) {
 		return nullptr;
 	}
 


### PR DESCRIPTION
Add several checks to CanvasItemEditor so that it works without the `Node2D::set_scale` hack, that prevents a determinant of zero in `Node2D` transforms. This covers all places in CanvasItemEditor, that are problematic, with the exception of `CanvasItemEditor::_gui_input_resize` (and the according `_draw`-section), that requires a more complex solution, which is available in #68826.

part of #35081

At multiple locations, where it was possible, `affine_inverse`-calculations were replaced by `CanvasItem::get_parent_transform_to_viewport`, which doesn't use `affine_inverse`.

Added a utility function `Transform2D::is_invertible` to check, if it is possible to calculate the `affine_inverse`. At multiple locations, this test was enough to circumvent problematic areas.

This PR makes the following assumptions:
The transforms of the follwing nodes are invertible:
- CanvasItemEditor
- CanvasItemEditor.viewport_scrollable
- CanvasItemEditor.viewport
- CanvasItemEditor.target_node

The follwing transform is invertible:
- CanvasItemEditor.canvas_item_editor->get_canvas_transform()

In order to test this PR, the following patch should be applied (but it also works without that patch in current master):
``` diff
diff --git a/core/math/transform_2d.cpp b/core/math/transform_2d.cpp
index 548a82d254..53e489de65 100644
--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -47,6 +47,7 @@ Transform2D Transform2D::inverse() const {
 
 void Transform2D::affine_invert() {
 	real_t det = basis_determinant();
+	CRASH_COND(Math::is_zero_approx(det));
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND(det == 0);
 #endif
diff --git a/scene/2d/node_2d.cpp b/scene/2d/node_2d.cpp
index 2518069b78..3d6535a31d 100644
--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -161,12 +161,14 @@ void Node2D::set_scale(const Size2 &p_scale) {
 	}
 	scale = p_scale;
 	// Avoid having 0 scale values, can lead to errors in physics and rendering.
+#if 0
 	if (Math::is_zero_approx(scale.x)) {
 		scale.x = CMP_EPSILON;
 	}
 	if (Math::is_zero_approx(scale.y)) {
 		scale.y = CMP_EPSILON;
 	}
+#endif // 0
 	_update_transform();
 }
 
@@ -440,7 +442,7 @@ void Node2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position", PROPERTY_HINT_RANGE, "-99999,99999,0.001,or_less,or_greater,hide_slider,suffix:px"), "set_position", "get_position");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rotation", PROPERTY_HINT_RANGE, "-360,360,0.1,or_less,or_greater,radians"), "set_rotation", "get_rotation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "scale", PROPERTY_HINT_LINK), "set_scale", "get_scale");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "skew", PROPERTY_HINT_RANGE, "-89.9,89.9,0.1,radians"), "set_skew", "get_skew");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "skew", PROPERTY_HINT_RANGE, "-90.0,90.0,0.1,radians"), "set_skew", "get_skew");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "transform", PROPERTY_HINT_NONE, "suffix:px", PROPERTY_USAGE_NONE), "set_transform", "get_transform");
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "global_position", PROPERTY_HINT_NONE, "suffix:px", PROPERTY_USAGE_NONE), "set_global_position", "get_global_position");
```