### PR TITLE
[MP] Improve network profiler.

### DIFF
--- a/modules/multiplayer/editor/editor_network_profiler.cpp
+++ b/modules/multiplayer/editor/editor_network_profiler.cpp
@@ -67,8 +67,8 @@ void EditorNetworkProfiler::_update_frame() {
 		}
 
 		node->set_text(0, E.value.node_path);
-		node->set_text(1, E.value.incoming_rpc == 0 ? "-" : itos(E.value.incoming_rpc));
-		node->set_text(2, E.value.outgoing_rpc == 0 ? "-" : itos(E.value.outgoing_rpc));
+		node->set_text(1, E.value.incoming_rpc == 0 ? "-" : vformat(TTR("%d (%s)"), E.value.incoming_rpc, String::humanize_size(E.value.incoming_size)));
+		node->set_text(2, E.value.outgoing_rpc == 0 ? "-" : vformat(TTR("%d (%s)"), E.value.outgoing_rpc, String::humanize_size(E.value.outgoing_size)));
 	}
 }
 
@@ -98,6 +98,12 @@ void EditorNetworkProfiler::add_node_frame_data(const RPCNodeInfo p_frame) {
 	} else {
 		nodes_data[p_frame.node].incoming_rpc += p_frame.incoming_rpc;
 		nodes_data[p_frame.node].outgoing_rpc += p_frame.outgoing_rpc;
+	}
+	if (p_frame.incoming_rpc) {
+		nodes_data[p_frame.node].incoming_size = p_frame.incoming_size / p_frame.incoming_rpc;
+	}
+	if (p_frame.outgoing_rpc) {
+		nodes_data[p_frame.node].outgoing_size = p_frame.outgoing_size / p_frame.outgoing_rpc;
 	}
 
 	if (frame_delay->is_stopped()) {

--- a/modules/multiplayer/editor/editor_network_profiler.h
+++ b/modules/multiplayer/editor/editor_network_profiler.h
@@ -66,7 +66,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void add_node_frame_data(const RPCNodeInfo p_frame);
+	void add_node_frame_data(RPCNodeInfo p_frame);
 	void set_bandwidth(int p_incoming, int p_outgoing);
 	bool is_profiling();
 

--- a/modules/multiplayer/multiplayer_debugger.h
+++ b/modules/multiplayer/multiplayer_debugger.h
@@ -41,7 +41,9 @@ public:
 		ObjectID node;
 		String node_path;
 		int incoming_rpc = 0;
+		int incoming_size = 0;
 		int outgoing_rpc = 0;
+		int outgoing_size = 0;
 	};
 
 	struct RPCFrame {

--- a/modules/multiplayer/scene_cache_interface.cpp
+++ b/modules/multiplayer/scene_cache_interface.cpp
@@ -99,10 +99,6 @@ void SceneCacheInterface::process_simplify_path(int p_from, const uint8_t *p_pac
 	Ref<MultiplayerPeer> multiplayer_peer = multiplayer->get_multiplayer_peer();
 	ERR_FAIL_COND(multiplayer_peer.is_null());
 
-#ifdef DEBUG_ENABLED
-	multiplayer->profile_bandwidth("out", packet.size());
-#endif
-
 	multiplayer_peer->set_transfer_channel(0);
 	multiplayer_peer->set_transfer_mode(MultiplayerPeer::TRANSFER_MODE_RELIABLE);
 	multiplayer->send_command(p_from, packet.ptr(), packet.size());
@@ -154,10 +150,6 @@ Error SceneCacheInterface::_send_confirm_path(Node *p_node, NodePath p_path, Pat
 
 	Ref<MultiplayerPeer> multiplayer_peer = multiplayer->get_multiplayer_peer();
 	ERR_FAIL_COND_V(multiplayer_peer.is_null(), ERR_BUG);
-
-#ifdef DEBUG_ENABLED
-	multiplayer->profile_bandwidth("out", packet.size() * p_peers.size());
-#endif
 
 	Error err = OK;
 	for (int peer_id : p_peers) {

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -103,6 +103,15 @@ private:
 	Ref<SceneReplicationInterface> replicator;
 	Ref<SceneRPCInterface> rpc;
 
+#ifdef DEBUG_ENABLED
+	_FORCE_INLINE_ void _profile_bandwidth(const String &p_what, int p_value);
+	_FORCE_INLINE_ Error _send(const uint8_t *p_packet, int p_packet_len); // Also profiles.
+#else
+	_FORCE_INLINE_ Error _send(const uint8_t *p_packet, int p_packet_len) {
+		return multiplayer_peer->put_packet(p_packet, p_packet_len);
+	}
+#endif
+
 protected:
 	static void _bind_methods();
 
@@ -162,10 +171,6 @@ public:
 	bool is_server_relay_enabled() const;
 
 	Ref<SceneCacheInterface> get_path_cache() { return cache; }
-
-#ifdef DEBUG_ENABLED
-	void profile_bandwidth(const String &p_inout, int p_size);
-#endif
 
 	SceneMultiplayer();
 	~SceneMultiplayer();

--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -362,12 +362,7 @@ Error SceneReplicationInterface::_update_spawn_visibility(int p_peer, const Obje
 
 Error SceneReplicationInterface::_send_raw(const uint8_t *p_buffer, int p_size, int p_peer, bool p_reliable) {
 	ERR_FAIL_COND_V(!p_buffer || p_size < 1, ERR_INVALID_PARAMETER);
-	ERR_FAIL_COND_V(!multiplayer, ERR_UNCONFIGURED);
 	ERR_FAIL_COND_V(!multiplayer->has_multiplayer_peer(), ERR_UNCONFIGURED);
-
-#ifdef DEBUG_ENABLED
-	multiplayer->profile_bandwidth("out", p_size);
-#endif
 
 	Ref<MultiplayerPeer> peer = multiplayer->get_multiplayer_peer();
 	peer->set_transfer_channel(0);

--- a/modules/multiplayer/scene_rpc_interface.h
+++ b/modules/multiplayer/scene_rpc_interface.h
@@ -81,8 +81,11 @@ private:
 
 	HashMap<ObjectID, RPCConfigCache> rpc_cache;
 
+#ifdef DEBUG_ENABLED
+	_FORCE_INLINE_ void _profile_node_data(const String &p_what, ObjectID p_id, int p_size);
+#endif
+
 protected:
-	_FORCE_INLINE_ void _profile_node_data(const String &p_what, ObjectID p_id);
 	void _process_rpc(Node *p_node, const uint16_t p_rpc_method_id, int p_from, const uint8_t *p_packet, int p_packet_len, int p_offset);
 
 	void _send_rpc(Node *p_from, int p_to, uint16_t p_rpc_id, const RPCConfig &p_config, const StringName &p_name, const Variant **p_arg, int p_argcount);


### PR DESCRIPTION
Fix RPC profiler and add average RPC size.

Improve bandwidth debugger to account for all multiplayer traffic (excluding the lower level peer transformations).

![rpc_debug](https://user-images.githubusercontent.com/1687918/202333376-0c8c4d8e-7f21-42da-a0fd-4f4639e6d47a.png)
