### PR TITLE
Fix GUI update timing when AnimationEditor changes FPS

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1678,6 +1678,7 @@ void AnimationTimelineEdit::_notification(int p_what) {
 			}
 
 			draw_line(Vector2(0, get_size().height), get_size(), linecolor, Math::round(EDSCALE));
+			update_values();
 		} break;
 	}
 }
@@ -1700,7 +1701,6 @@ void AnimationTimelineEdit::set_animation(const Ref<Animation> &p_animation, boo
 		play_position->hide();
 	}
 	queue_redraw();
-	update_values();
 }
 
 Size2 AnimationTimelineEdit::get_minimum_size() const {
@@ -1749,6 +1749,7 @@ void AnimationTimelineEdit::update_values() {
 		length->set_step(1);
 		length->set_tooltip_text(TTR("Animation length (frames)"));
 		time_icon->set_tooltip_text(TTR("Animation length (frames)"));
+		track_edit->editor->_update_key_edit();
 	} else {
 		length->set_value(animation->get_length());
 		length->set_step(0.001);
@@ -1893,7 +1894,6 @@ void AnimationTimelineEdit::_zoom_callback(Vector2 p_scroll_vec, Vector2 p_origi
 
 void AnimationTimelineEdit::set_use_fps(bool p_use_fps) {
 	use_fps = p_use_fps;
-	update_values();
 	queue_redraw();
 }
 
@@ -4793,6 +4793,7 @@ void AnimationTrackEditor::_update_step(double p_new_step) {
 		if (step_value != 0.0) {
 			step_value = 1.0 / step_value;
 		}
+		timeline->queue_redraw();
 	}
 	undo_redo->add_do_method(animation.ptr(), "set_step", step_value);
 	undo_redo->add_undo_method(animation.ptr(), "set_step", animation->get_step());

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -135,6 +135,7 @@ class AnimationTrackEditor;
 
 class AnimationTrackEdit : public Control {
 	GDCLASS(AnimationTrackEdit, Control);
+	friend class AnimationTimelineEdit;
 
 	enum {
 		MENU_CALL_MODE_CONTINUOUS,
@@ -293,6 +294,7 @@ public:
 
 class AnimationTrackEditor : public VBoxContainer {
 	GDCLASS(AnimationTrackEditor, VBoxContainer);
+	friend class AnimationTimelineEdit;
 
 	Ref<Animation> animation;
 	bool read_only = false;


### PR DESCRIPTION
Fixes #59784

When the AnimationEditor's snap value was in FPS mode, most update timings of the Editor GUI were delayed. This PR fixes that.

Before:

https://user-images.githubusercontent.com/61938263/202349925-57584d36-97fd-4e3e-8ef4-a5004c885137.mp4

After:

https://user-images.githubusercontent.com/61938263/202349951-75ddd785-6279-47b5-8184-c8ae943f1028.mp4
