### PR TITLE
New SampleRate audio effect

### DIFF
--- a/doc/classes/AudioEffectSampleRate.xml
+++ b/doc/classes/AudioEffectSampleRate.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AudioEffectSampleRate" inherits="AudioEffect" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Adds a sample rate audio effect to an Audio bus.
+	</brief_description>
+	<description>
+		Reduces the input audio's sample rate, without interpolating the output. Also known as "sample &amp; hold", or a type of "bitcrush".
+		[b]Note:[/b] To reduce an audio signal's bit depth, use the "LoFi" mode in [AudioEffectDistortion].
+	</description>
+	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
+	</tutorials>
+	<members>
+		<member name="mix" type="float" setter="set_mix" getter="get_mix" default="1.0">
+			Linear fade between dry/wet signals. Value can range from 0 to 1.
+		</member>
+		<member name="rate" type="float" setter="set_rate" getter="get_rate" default="11025.0">
+			Sample rate (in Hz) that input audio will be resampled to. Value must be at least 1, and should be less than [method AudioServer.get_mix_rate] to result in any audible effect.
+		</member>
+	</members>
+</class>

--- a/servers/audio/effects/audio_effect_sample_rate.cpp
+++ b/servers/audio/effects/audio_effect_sample_rate.cpp
@@ -1,0 +1,86 @@
+/*************************************************************************/
+/*  audio_effect_sample_rate.cpp                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "audio_effect_sample_rate.h"
+#include "core/math/math_funcs.h"
+#include "servers/audio_server.h"
+
+void AudioEffectSampleRateInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
+	float frames_until_next_sample = AudioServer::get_singleton()->get_mix_rate() / base->rate;
+
+	for (int i = 0; i < p_frame_count; i++) {
+		if (processed_frames >= frames_until_next_sample) {
+			last_sampled_frame = p_src_frames[i]; // sample a new frame
+			processed_frames = Math::fmod(processed_frames - frames_until_next_sample, 1.0f);
+		}
+
+		// output dry/wet signal based on the `mix` control
+		p_dst_frames[i] = last_sampled_frame * base->mix + p_src_frames[i] * (1.0f - base->mix);
+
+		processed_frames++;
+	}
+}
+
+Ref<AudioEffectInstance> AudioEffectSampleRate::instantiate() {
+	Ref<AudioEffectSampleRateInstance> ins;
+	ins.instantiate();
+	ins->base = Ref<AudioEffectSampleRate>(this);
+	return ins;
+}
+
+void AudioEffectSampleRate::set_rate(float p_rate) {
+	rate = MAX(p_rate, 1.0f);
+}
+float AudioEffectSampleRate::get_rate() const {
+	return rate;
+}
+
+void AudioEffectSampleRate::set_mix(float p_mix) {
+	mix = CLAMP(p_mix, 0.0f, 1.0f);
+}
+float AudioEffectSampleRate::get_mix() const {
+	return mix;
+}
+
+void AudioEffectSampleRate::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_rate", "rate"), &AudioEffectSampleRate::set_rate);
+	ClassDB::bind_method(D_METHOD("get_rate"), &AudioEffectSampleRate::get_rate);
+
+	ClassDB::bind_method(D_METHOD("set_mix", "mix"), &AudioEffectSampleRate::set_mix);
+	ClassDB::bind_method(D_METHOD("get_mix"), &AudioEffectSampleRate::get_mix);
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rate", PROPERTY_HINT_RANGE, "1.0,22050.0,1.0,or_greater,hide_slider,suffix:Hz"), "set_rate", "get_rate");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "mix", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_mix", "get_mix");
+}
+
+AudioEffectSampleRate::AudioEffectSampleRate() {
+	rate = 11025.0f;
+	mix = 1.0f;
+}

--- a/servers/audio/effects/audio_effect_sample_rate.h
+++ b/servers/audio/effects/audio_effect_sample_rate.h
@@ -1,0 +1,71 @@
+/*************************************************************************/
+/*  audio_effect_sample_rate.h                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef AUDIO_EFFECT_SAMPLE_RATE_H
+#define AUDIO_EFFECT_SAMPLE_RATE_H
+
+#include "servers/audio/audio_effect.h"
+
+class AudioEffectSampleRate;
+
+class AudioEffectSampleRateInstance : public AudioEffectInstance {
+	GDCLASS(AudioEffectSampleRateInstance, AudioEffectInstance);
+	friend class AudioEffectSampleRate;
+	Ref<AudioEffectSampleRate> base;
+
+	float processed_frames = 0;
+	AudioFrame last_sampled_frame;
+
+public:
+	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) override;
+};
+
+class AudioEffectSampleRate : public AudioEffect {
+	GDCLASS(AudioEffectSampleRate, AudioEffect);
+
+	friend class AudioEffectSampleRateInstance;
+
+protected:
+	static void _bind_methods();
+
+public:
+	float rate;
+	float mix;
+
+	Ref<AudioEffectInstance> instantiate() override;
+	void set_rate(float p_rate);
+	float get_rate() const;
+	void set_mix(float p_mix);
+	float get_mix() const;
+
+	AudioEffectSampleRate();
+};
+
+#endif // AUDIO_EFFECT_SAMPLE_RATE_H

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -49,6 +49,7 @@
 #include "audio/effects/audio_effect_pitch_shift.h"
 #include "audio/effects/audio_effect_record.h"
 #include "audio/effects/audio_effect_reverb.h"
+#include "audio/effects/audio_effect_sample_rate.h"
 #include "audio/effects/audio_effect_spectrum_analyzer.h"
 #include "audio/effects/audio_effect_stereo_enhance.h"
 #include "audio/effects/audio_stream_generator.h"
@@ -211,6 +212,8 @@ void register_server_types() {
 		GDREGISTER_CLASS(AudioEffectEQ21);
 
 		GDREGISTER_CLASS(AudioEffectDistortion);
+
+		GDREGISTER_CLASS(AudioEffectSampleRate);
 
 		GDREGISTER_CLASS(AudioEffectStereoEnhance);
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Implements a new audio effect, which lowers the sample rate of the input audio by using a [Sample & Hold algorithm](https://en.wikipedia.org/wiki/Sample_and_hold).

This is a common tool in sound design; especially for things like chiptune, but it's also used as a creative effect in modern hi-fi audio productions as well.

The "LoFi" mode in the Distortion audio effect reduces bit depth, but not sample rate. With the addition of the SampleRate audio effect, users will have control over both the vertical, and horizontal resolution of audio buses.

Here is an example project, with the SampleRate effect on the Master audio bus. The scene provides some controls to get a quick idea of the effect's sound.

[AudioEffectSampleRate-example.zip](https://github.com/godotengine/godot/files/10028073/AudioEffectSampleRate-example.zip)

I have the appropriate edits prepared for the [Audio Effects](https://docs.godotengine.org/en/latest/tutorials/audio/audio_effects.html) page in the Godot Docs as well, if you'd like me to open a pull request in the godot-docs repo and link it here.

-----------------------------------------
### Proposal / Pull Requests

**Proposal** at https://github.com/godotengine/godot-proposals/issues/5810
**Pull request for 3.x branch** at #70085

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/5810*