### PR TITLE
Add track validator to AnimationPlayerEditor to detect tracks which have error

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -212,6 +212,8 @@ class AnimationPlayerEditor : public VBoxContainer {
 	void _start_onion_skinning();
 	void _stop_onion_skinning();
 
+	bool _validate_tracks(const Ref<Animation> p_anim);
+
 	void _pin_pressed();
 	String _get_current() const;
 


### PR DESCRIPTION
Fixes #64340

Unnormalized quaternion keys will cause problems in playing back animations, but it is hard to know which track has the problem just from the error `The start/end quaternion must be normalized`.

However, checking for error tracks at runtime will reduce the performance, so to notify us the problematic track, the validation is run only at the moment the animation playback button is pressed in the editor.

![image](https://user-images.githubusercontent.com/61938263/202373335-5f3dd9d8-d44e-43be-bd55-8361aedb5bea.png)
