### PR TITLE
RendererDummy - Fix buffer overflow due to stale mesh_get_surface

### DIFF
--- a/servers/rendering/dummy/storage/mesh_storage.cpp
+++ b/servers/rendering/dummy/storage/mesh_storage.cpp
@@ -56,3 +56,10 @@ void MeshStorage::mesh_free(RID p_rid) {
 
 	mesh_owner.free(p_rid);
 }
+
+void MeshStorage::mesh_clear(RID p_mesh) {
+	DummyMesh *m = mesh_owner.get_or_null(p_mesh);
+	ERR_FAIL_COND(!m);
+
+	m->surfaces.clear();
+}

--- a/servers/rendering/dummy/storage/mesh_storage.h
+++ b/servers/rendering/dummy/storage/mesh_storage.h
@@ -116,7 +116,7 @@ public:
 
 	virtual AABB mesh_get_aabb(RID p_mesh, RID p_skeleton = RID()) override { return AABB(); }
 	virtual void mesh_set_shadow_mesh(RID p_mesh, RID p_shadow_mesh) override {}
-	virtual void mesh_clear(RID p_mesh) override {}
+	virtual void mesh_clear(RID p_mesh) override;
 
 	/* MESH INSTANCE */
 


### PR DESCRIPTION
Fixes #66699

Failing to clear the surfaces vector causes `RendererDummy::mesh_get_surface` and `mesh_get_surface_count` to return stale data, which can cause a buffer overflow in the caller if the replacement surface has longer arrays.

```gdscript
func make_arrays(n):
	var vertices = PackedVector3Array()
	vertices.resize(n)

	var arrays = []
	arrays.resize(Mesh.ARRAY_MAX)
	arrays[Mesh.ARRAY_VERTEX] = vertices

	return arrays

func _ready():
	var mesh = ArrayMesh.new()

	mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, make_arrays(3))
	print(mesh._get_surfaces()[0]["vertex_data"].size() / 12)  # supposed to print 3
	
	mesh.clear_surfaces()
	mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, make_arrays(100))
	print(mesh._get_surfaces()[0]["vertex_data"].size() / 12)  # supposed to print 100
	# on headless, the first surface was never cleared, so it prints 3
	# if the caller is expecting 100, this causes a buffer overflow
```