### PR TITLE
Add source filter to TileMap editor

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -40,6 +40,7 @@
 
 #include "scene/2d/camera_2d.h"
 #include "scene/gui/center_container.h"
+#include "scene/gui/line_edit.h"
 #include "scene/gui/split_container.h"
 
 #include "core/input/input.h"
@@ -146,6 +147,8 @@ void TileMapEditorTilesPlugin::_update_tile_set_sources_list() {
 		old_source = -1;
 	}
 
+	String filter = source_filter->get_text();
+
 	List<int> source_ids = TilesEditorPlugin::get_singleton()->get_sorted_sources(tile_set);
 	for (const int &source_id : source_ids) {
 		TileSetSource *source = *tile_set->get_source(source_id);
@@ -186,6 +189,10 @@ void TileMapEditorTilesPlugin::_update_tile_set_sources_list() {
 		}
 		if (!texture.is_valid()) {
 			texture = missing_atlas_texture_icon;
+		}
+
+		if (!filter.is_empty() && !filter.is_subsequence_ofn(item_text)) {
+			continue;
 		}
 
 		sources_list->add_item(item_text, texture);
@@ -2173,7 +2180,13 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	atlas_sources_split_container->add_child(split_container_left_side);
 
 	HBoxContainer *sources_bottom_actions = memnew(HBoxContainer);
-	sources_bottom_actions->set_alignment(HBoxContainer::ALIGNMENT_END);
+
+	source_filter = memnew(LineEdit);
+	source_filter->set_placeholder(TTR("Filter Sources"));
+	source_filter->set_clear_button_enabled(true);
+	source_filter->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	source_filter->connect("text_changed", callable_mp(this, &TileMapEditorTilesPlugin::_update_tile_set_sources_list).unbind(1));
+	sources_bottom_actions->add_child(source_filter);
 
 	source_sort_button = memnew(MenuButton);
 	source_sort_button->set_flat(true);

--- a/editor/plugins/tiles/tile_map_editor.h
+++ b/editor/plugins/tiles/tile_map_editor.h
@@ -48,6 +48,7 @@
 #include "scene/gui/tree.h"
 
 class EditorUndoRedoManager;
+class LineEdit;
 
 class TileMapEditorPlugin : public Object {
 public:
@@ -156,6 +157,7 @@ private:
 	Label *invalid_source_label = nullptr;
 
 	ItemList *sources_list = nullptr;
+	LineEdit *source_filter = nullptr;
 	MenuButton *source_sort_button = nullptr;
 
 	Ref<Texture2D> missing_atlas_texture_icon;


### PR DESCRIPTION
This empty space was too tempting to not put something in there:
![godot windows editor dev x86_64_rweJiymeba](https://user-images.githubusercontent.com/2223172/202457659-63b1f482-9536-4183-b011-b6fa64fba117.gif)
Only available for TileMap view.

However there seems to be a bug where tile editor will randomly get deselected when filter changes:
![godot windows editor dev x86_64_BEfwmGegjb](https://user-images.githubusercontent.com/2223172/202457783-dc4c2c1c-6559-44a0-88d2-753321f2ccd5.gif)
No idea what causes it.

Also selection sync with TileSet seems broken, because it sends selected index instead of source id.