### PR TITLE
Add option to limit root motion to horizontal plane

### DIFF
--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -264,6 +264,7 @@ private:
 	bool started;
 
 	NodePath root_motion_track;
+	bool root_motion_horizontal;
 	Transform root_motion_transform;
 
 	friend class AnimationNode;
@@ -314,6 +315,9 @@ public:
 
 	void set_root_motion_track(const NodePath &p_track);
 	NodePath get_root_motion_track() const;
+
+	void set_root_motion_horizontal(bool p_horizontal);
+	bool get_root_motion_horizontal();
 
 	Transform get_root_motion_transform() const;
 


### PR DESCRIPTION
Very simple fix for:
https://github.com/godotengine/godot-proposals/issues/2789

Adds an option under Root Motion to enable only horizontal motion. This is needed when the skeleton doesn't have a dedicated root bone and/or the bone has other motion besides positional.
For convenience, root_motion_transform's basis gets negated as it is not needed in this case and only causes horrible chaos when using RootMotionView.

