### PR TITLE
Prevent stack overflow when setting a shader global value

### DIFF
--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -111,7 +111,7 @@ protected:
 		undo_redo->add_do_method(this, "_var_changed");
 		undo_redo->add_undo_method(this, "_var_changed");
 		block_update = true;
-		undo_redo->commit_action();
+		undo_redo->commit_action(false);
 		block_update = false;
 
 		return true;


### PR DESCRIPTION
Should fix https://github.com/godotengine/godot/issues/68791. It's a regression of https://github.com/godotengine/godot/pull/59564, causes stack overflow (infinite recursion call of commit_action between `UndoRedo`/`EditorUndoRedoManager` classes). There is still a bit buggy cuz it generates two Set calls (instead of one) and pushes them to history, but this prevents crashing at least.
