### PR TITLE
Curve2D and Curve3D get_closest_point non-baked versions

### DIFF
--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -993,7 +993,7 @@ real_t Curve2D::get_bake_interval() const {
 	return bake_interval;
 }
 
-Vector2 Curve2D::get_closest_point(const Vector2 &p_to_point) const {
+Vector2 Curve2D::get_baked_closest_point(const Vector2 &p_to_point) const {
 	// Brute force method.
 
 	if (baked_cache_dirty) {
@@ -1024,6 +1024,34 @@ Vector2 Curve2D::get_closest_point(const Vector2 &p_to_point) const {
 
 		if (nearest_dist < 0.0f || dist < nearest_dist) {
 			nearest = proj;
+			nearest_dist = dist;
+		}
+	}
+
+	return nearest;
+}
+
+Vector2 Curve2D::get_closest_point(const Vector2 &p_to_point) const {
+	// Brute force method.
+
+	// Validate: Curve may not have baked points.
+	int pc = points.size();
+	ERR_FAIL_COND_V_MSG(pc == 0, Vector2(), "No points in Curve2D.");
+
+	if (pc == 1) {
+		return points.get(0).position;
+	}
+
+	Vector2 nearest;
+	real_t nearest_dist = -1.0f;
+
+	for (int i = 0; i < pc - 1; i++) {
+		Vector2 origin = points[i].position;
+
+		real_t dist = origin.distance_squared_to(p_to_point);
+
+		if (nearest_dist < 0.0f || dist < nearest_dist) {
+			nearest = origin;
 			nearest_dist = dist;
 		}
 	}
@@ -1226,6 +1254,7 @@ void Curve2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("sample_baked", "offset", "cubic"), &Curve2D::sample_baked, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("sample_baked_with_rotation", "offset", "cubic", "loop", "lookahead"), &Curve2D::sample_baked_with_rotation, DEFVAL(false), DEFVAL(true), DEFVAL(4.0));
 	ClassDB::bind_method(D_METHOD("get_baked_points"), &Curve2D::get_baked_points);
+	ClassDB::bind_method(D_METHOD("get_baked_closest_point", "to_point"), &Curve2D::get_baked_closest_point);
 	ClassDB::bind_method(D_METHOD("get_closest_point", "to_point"), &Curve2D::get_closest_point);
 	ClassDB::bind_method(D_METHOD("get_closest_offset", "to_point"), &Curve2D::get_closest_offset);
 	ClassDB::bind_method(D_METHOD("tessellate", "max_stages", "tolerance_degrees"), &Curve2D::tessellate, DEFVAL(5), DEFVAL(4));
@@ -1764,7 +1793,7 @@ PackedVector3Array Curve3D::get_baked_up_vectors() const {
 	return baked_up_vector_cache;
 }
 
-Vector3 Curve3D::get_closest_point(const Vector3 &p_to_point) const {
+Vector3 Curve3D::get_baked_closest_point(const Vector3 &p_to_point) const {
 	// Brute force method.
 
 	if (baked_cache_dirty) {
@@ -1795,6 +1824,34 @@ Vector3 Curve3D::get_closest_point(const Vector3 &p_to_point) const {
 
 		if (nearest_dist < 0.0f || dist < nearest_dist) {
 			nearest = proj;
+			nearest_dist = dist;
+		}
+	}
+
+	return nearest;
+}
+
+Vector3 Curve3D::get_closest_point(const Vector3 &p_to_point) const {
+	// Brute force method.
+
+	// Validate: Curve may not have baked points.
+	int pc = points.size();
+	ERR_FAIL_COND_V_MSG(pc == 0, Vector3(), "No points in Curve3D.");
+
+	if (pc == 1) {
+		return points.get(0).position;
+	}
+
+	Vector3 nearest;
+	real_t nearest_dist = -1.0f;
+
+	for (int i = 0; i < pc - 1; i++) {
+		Vector3 origin = points[i].position;
+
+		real_t dist = origin.distance_squared_to(p_to_point);
+
+		if (nearest_dist < 0.0f || dist < nearest_dist) {
+			nearest = origin;
 			nearest_dist = dist;
 		}
 	}
@@ -2038,6 +2095,7 @@ void Curve3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_baked_points"), &Curve3D::get_baked_points);
 	ClassDB::bind_method(D_METHOD("get_baked_tilts"), &Curve3D::get_baked_tilts);
 	ClassDB::bind_method(D_METHOD("get_baked_up_vectors"), &Curve3D::get_baked_up_vectors);
+	ClassDB::bind_method(D_METHOD("get_baked_closest_point", "to_point"), &Curve3D::get_baked_closest_point);
 	ClassDB::bind_method(D_METHOD("get_closest_point", "to_point"), &Curve3D::get_closest_point);
 	ClassDB::bind_method(D_METHOD("get_closest_offset", "to_point"), &Curve3D::get_closest_offset);
 	ClassDB::bind_method(D_METHOD("tessellate", "max_stages", "tolerance_degrees"), &Curve3D::tessellate, DEFVAL(5), DEFVAL(4));

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -218,6 +218,7 @@ public:
 	Vector2 sample_baked(real_t p_offset, bool p_cubic = false) const;
 	Transform2D sample_baked_with_rotation(real_t p_offset, bool p_cubic = false, bool p_loop = true, real_t p_lookahead = 4.0) const;
 	PackedVector2Array get_baked_points() const; //useful for going through
+	Vector2 get_baked_closest_point(const Vector2 &p_to_point) const;
 	Vector2 get_closest_point(const Vector2 &p_to_point) const;
 	real_t get_closest_offset(const Vector2 &p_to_point) const;
 
@@ -301,6 +302,7 @@ public:
 	PackedVector3Array get_baked_points() const; //useful for going through
 	Vector<real_t> get_baked_tilts() const; //useful for going through
 	PackedVector3Array get_baked_up_vectors() const;
+	Vector3 get_baked_closest_point(const Vector3 &p_to_point) const;
 	Vector3 get_closest_point(const Vector3 &p_to_point) const;
 	real_t get_closest_offset(const Vector3 &p_to_point) const;
 


### PR DESCRIPTION
Today, Curve2D and Curve3D implements the method
`VectorX get_closest_point(const VectorX &p_to_point) const;`
Which return the closest point from **baked points cache**.

Based on the fact that methods using the baked cache have the **get_baked_xxx** wording, i thought that we should rename the current method **get_baked_closest_point**, which leaves us with no actual method to get the "true" closest point from the curve user-created points.

I therefore implemented this behaviour in functions borrowing the name from the previously "wrongly" named get_closest_point.

**Reflexion on the topic:**
A second thought would be to implement **get_closest_point_index** instead of my implementation of **get_closest_point** returning the actual index of the closest point, allowing the user to gather more data from the point such as **in/out** while still being able to get pos by calling **get_point_position** with the queried index. This also benefits from the fact that the name will not collide with a currently existing API method.