### PR TITLE
[3.x] Fix shader compiler asan out of bounds

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1680,6 +1680,9 @@ void RasterizerStorageGLES2::shader_get_param_list(RID p_shader, List<PropertyIn
 			case ShaderLanguage::TYPE_USAMPLER3D: {
 				// Not implemented in GLES2
 			} break;
+
+			default: {
+			}
 		}
 
 		p_param_list->push_back(pi);

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2460,6 +2460,8 @@ void RasterizerStorageGLES3::shader_get_param_list(RID p_shader, List<PropertyIn
 				pi.hint = PROPERTY_HINT_RESOURCE_TYPE;
 				pi.hint_string = "CubeMap";
 			} break;
+			default: {
+			}
 		};
 
 		p_param_list->push_back(pi);

--- a/drivers/gles3/shader_compiler_gles3.cpp
+++ b/drivers/gles3/shader_compiler_gles3.cpp
@@ -114,6 +114,8 @@ static int _get_datatype_size(SL::DataType p_type) {
 			return 16;
 		case SL::TYPE_STRUCT:
 			return 0;
+		default: {
+		}
 	}
 
 	ERR_FAIL_V(0);
@@ -185,6 +187,8 @@ static int _get_datatype_alignment(SL::DataType p_type) {
 			return 16;
 		case SL::TYPE_STRUCT:
 			return 0;
+		default: {
+		}
 	}
 
 	ERR_FAIL_V(0);

--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -928,6 +928,8 @@ String ShaderLanguage::get_datatype_name(DataType p_type) {
 			return "samplerExternalOES";
 		case TYPE_STRUCT:
 			return "struct";
+		default: {
+		}
 	}
 
 	return "";
@@ -2703,6 +2705,8 @@ Variant ShaderLanguage::constant_value_to_variant(const Vector<ShaderLanguage::C
 				break;
 			case ShaderLanguage::TYPE_VOID:
 				break;
+			default: {
+			}
 		}
 		return value;
 	}
@@ -2788,7 +2792,17 @@ ShaderLanguage::DataType ShaderLanguage::get_scalar_type(DataType p_type) {
 		TYPE_INT,
 		TYPE_UINT,
 		TYPE_FLOAT,
+		TYPE_INT,
+		TYPE_UINT,
+		TYPE_FLOAT,
+		TYPE_INT,
+		TYPE_UINT,
+		TYPE_FLOAT,
+		TYPE_FLOAT,
+		TYPE_VOID,
 	};
+
+	static_assert(sizeof(scalar_types) / sizeof(*scalar_types) == TYPE_MAX, "get_scalar_type must be updated if DataType is updated");
 
 	return scalar_types[p_type];
 }
@@ -2819,7 +2833,17 @@ int ShaderLanguage::get_cardinality(DataType p_type) {
 		1,
 		1,
 		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
 	};
+
+	static_assert(sizeof(cardinality_table) / sizeof(*cardinality_table) == TYPE_MAX, "get_cardinality must be updated if DataType is updated");
 
 	return cardinality_table[p_type];
 }

--- a/servers/visual/shader_language.h
+++ b/servers/visual/shader_language.h
@@ -211,6 +211,7 @@ public:
 		TYPE_SAMPLERCUBE,
 		TYPE_SAMPLEREXT,
 		TYPE_STRUCT,
+		TYPE_MAX,
 	};
 
 	enum DataPrecision {


### PR DESCRIPTION
Cherrypick of #68718 for 3.x.

Tested working with `use_ubsan=yes use_asan=yes`.

Compatible with 3.5.