### PR TITLE
Context aware MIDI event printing

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1722,7 +1722,27 @@ String InputEventMIDI::as_text() const {
 }
 
 String InputEventMIDI::to_string() {
-	return vformat("InputEventMIDI: channel=%d, message=%d, pitch=%d, velocity=%d, pressure=%d, controller_number=%d, controller_value=%d", channel, message, pitch, velocity, pressure, controller_number, controller_value);
+	String ret;
+	switch (message) {
+		case MIDIMessage::NOTE_ON:
+			ret = vformat("Note On: channel=%d, pitch=%d, velocity=%d", channel, pitch, velocity);
+			break;
+		case MIDIMessage::NOTE_OFF:
+			ret = vformat("Note Off: channel=%d, pitch=%d, velocity=%d", channel, pitch, velocity);
+			break;
+		case MIDIMessage::PITCH_BEND:
+			ret = vformat("Pitch Bend: channel=%d, pitch=%d", channel, pitch);
+			break;
+		case MIDIMessage::CHANNEL_PRESSURE:
+			ret = vformat("Channel Pressure: channel=%d, pressure=%d", channel, pressure);
+			break;
+		case MIDIMessage::CONTROL_CHANGE:
+			ret = vformat("Control Change: channel=%d, controller_number=%d, controller_value=%d", channel, controller_number, controller_value);
+			break;
+		default:
+			ret = vformat("channel=%d, message=%d, pitch=%d, velocity=%d, pressure=%d, controller_number=%d, controller_value=%d, instrument=%d", channel, message, pitch, velocity, pressure, controller_number, controller_value, instrument);
+	}
+	return "InputEventMIDI: " + ret;
 }
 
 void InputEventMIDI::_bind_methods() {


### PR DESCRIPTION
### What this adds
Adds Human readable MIDI event context aware printing, typical use case in GDScript:
`print(midi_event)`
output for note-on message:
`InputEventMIDI - Note On: channel=0, pitch=1, velocity=127`

I also added missing `instrument` printing. However keep in mind outputting a valid program-change is a multi-step process.

### Whats the current problem
Currently printing a MIDI event results in all InputMIDIEvent variables being listed:
`InputEventMIDI: channel=0, message=9, pitch=1, velocity=127, pressure=0, controller_number=0, controller_value=0`
However, the problem is that each MIDI event only contains specific variables. There is no controller_number in a MIDI-Note-On message.

This makes it confusing to understand the MIDI events, and clutters the output console. We are also listing the MIDI message raw number, as opposed to the enum, which is already present in Godot.
### Discussion
I have chosen to omit the `message=` as we now know _what_ the message is, and Godot already has helpful enums to deal with messages anyway:
`if event.message == MIDI_MESSAGE_NOTE_ON` etc.

Improvement in the future can occur with SYSEX printing added, along with other event types. However this PR provides the vast majority of use cases.

NOTE: Many MIDI devices use NOTE-ON with velocity 0 to signify NOTE-OFF.  As Godot's MIDI system is intended to allow developers to use MIDI in their own software we shouldn't deal with this. Rather provide the data as it comes from the MIDI input, and allow the end developer to deal with it how they choose. 

### MIDI events printed in this PR:
NOTE_ON
NOTE_OFF
PITCH_BEND
CHANNEL_PRESSURE
CONTROL_CHANGE

For all other message types this PR defaults to the old way of displaying MIDI events. This can be the topic of future PRs.

NOTE: Pitch Bend event is currently being saved in pitch, whereas it should be saved into it's own variable: pitch_bend for consistency. This will break current API, so will be subject to another PR for 4.x

See https://github.com/godotengine/godot-proposals/discussions/5805 for more info

