### PR TITLE
Refactor `get_event_text` to a static method, remove high deadzone from event configuration

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -443,7 +443,7 @@ void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_info
 			TreeItem *event_item = action_tree->create_item(action_item);
 
 			// First Column - Text
-			event_item->set_text(0, event_config_dialog->get_event_text(event, true));
+			event_item->set_text(0, EventListenerLineEdit::get_event_text(event, true));
 			event_item->set_meta("__event", event);
 			event_item->set_meta("__index", evnt_idx);
 

--- a/editor/event_listener_line_edit.h
+++ b/editor/event_listener_line_edit.h
@@ -61,6 +61,9 @@ protected:
 	static void _bind_methods();
 
 public:
+	static String get_event_text(const Ref<InputEvent> &p_event, bool p_include_device);
+	static String get_device_string(int p_device);
+
 	Ref<InputEvent> get_event() const;
 	void clear_event();
 

--- a/editor/input_event_configuration_dialog.h
+++ b/editor/input_event_configuration_dialog.h
@@ -105,7 +105,6 @@ private:
 	void _device_selection_changed(int p_option_button_index);
 	void _set_current_device(int p_device);
 	int _get_current_device() const;
-	String _get_device_string(int p_device) const;
 
 protected:
 	void _notification(int p_what);
@@ -114,7 +113,6 @@ public:
 	// Pass an existing event to configure it. Alternatively, pass no event to start with a blank configuration.
 	void popup_and_configure(const Ref<InputEvent> &p_event = Ref<InputEvent>());
 	Ref<InputEvent> get_event() const;
-	String get_event_text(const Ref<InputEvent> &p_event, bool p_include_device) const;
 
 	void set_allowed_input_types(int p_type_masks);
 


### PR DESCRIPTION
* `get_event_text` and `get_device_string` are now static methods (they always could have been)
* Applied 90% deadzone on joypad motion inputs in the configurator had the effect of ignoring most joypad motion inputs. Low ones do not need to be filtered out as JoypadMotion is only considered 'pressed' if it as above 50% strength - and that works well.

Fixes #68617

Not sure if static method on `EventListenerLineEdit` is the best - but it is the "lowest common denominator" for where these methods are used, and it seems overkill to create a new class just to house them.
