### PR TITLE
Added extra clarification for importing fonts on `load()` method

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -146,7 +146,7 @@
 				[/codeblock]
 				[b]Important:[/b] The path must be absolute. A relative path will always return [code]null[/code].
 				This function is a simplified version of [method ResourceLoader.load], which can be used for more advanced scenarios.
-				[b]Note:[/b] Files have to be imported into the engine first to load them using this function. If you want to load [Image]s at run-time, you may use [method Image.load]. If you want to import audio files, you can use the snippet described in [member AudioStreamMP3.data].
+				[b]Note:[/b] Files have to be imported into the engine first to load them using this function. If you want to load [Image]s at run-time, you may use [method Image.load]. If you want to import audio files, you can use the snippet described in [member AudioStreamMP3.data]. If you want to load a font from the filesystem you can use [method FontFile.load_dynamic_font]
 			</description>
 		</method>
 		<method name="preload">


### PR DESCRIPTION
…paths

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Adjustment on the description for the `load()` and `preload()` functions to better identify allowed paths that can be used.  
More information on this issue https://github.com/godotengine/godot/issues/68772