### PR TITLE
Make the root motion track candidates all the bones of the Skeleton existing in the tracks

### DIFF
--- a/editor/plugins/animation_tree_editor_plugin.h
+++ b/editor/plugins/animation_tree_editor_plugin.h
@@ -35,8 +35,6 @@
 #include "scene/animation/animation_tree.h"
 #include "scene/gui/button.h"
 #include "scene/gui/graph_edit.h"
-#include "scene/gui/popup.h"
-#include "scene/gui/tree.h"
 
 class EditorFileDialog;
 


### PR DESCRIPTION
Fixes #66190

In the current implementation, only bones that exist on the track and their parent bones were candidates.

Now, by AnimationLibrary and Retarget, it is easier to share animations. So by this PR, it would be fine to have all the child bones of the skeleton existing in the track as candidates.

![image](https://user-images.githubusercontent.com/61938263/202662209-c0c8a8d9-cdcc-4d45-b26b-2ea83e97844e.png)

Also, fixed a strange display of the inspector when setting a unique path (in `EditorPropertyRootMotion::update_property()`).