### PR TITLE
Make CanvasItem-resizing in Editor work without Node2D::set_scale hack

### DIFF
--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -172,6 +172,10 @@ bool Transform2D::is_finite() const {
 	return columns[0].is_finite() && columns[1].is_finite() && columns[2].is_finite();
 }
 
+bool Transform2D::is_invertible() const {
+	return basis_determinant() != 0;
+}
+
 Transform2D Transform2D::looking_at(const Vector2 &p_target) const {
 	Transform2D return_trans = Transform2D(get_rotation(), get_origin());
 	Vector2 target_position = affine_inverse().xform(p_target);

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -99,6 +99,7 @@ struct _NO_DISCARD_ Transform2D {
 	Transform2D orthonormalized() const;
 	bool is_equal_approx(const Transform2D &p_transform) const;
 	bool is_finite() const;
+	bool is_invertible() const;
 
 	Transform2D looking_at(const Vector2 &p_target) const;
 

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -343,6 +343,10 @@ private:
 	Point2 drag_to;
 	Point2 drag_rotation_center;
 	List<CanvasItem *> drag_selection;
+	Size2 drag_ci_scale;
+	real_t drag_ci_aspect_ratio = 0;
+	bool drag_uniform;
+	bool drag_symmetric;
 	int dragged_guide_index = -1;
 	Point2 dragged_guide_pos;
 	bool is_hovering_h_guide = false;
@@ -500,6 +504,7 @@ private:
 
 protected:
 	void _notification(int p_what);
+	virtual void unhandled_key_input(const Ref<InputEvent> &p_event) override;
 
 	static void _bind_methods();
 

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -79,36 +79,12 @@ bool Node2D::_edit_use_rotation() const {
 	return true;
 }
 
-void Node2D::_edit_set_rect(const Rect2 &p_edit_rect) {
-	ERR_FAIL_COND(!_edit_use_rect());
-
-	Rect2 r = _edit_get_rect();
-
-	Vector2 zero_offset;
-	Size2 new_scale(1, 1);
-
-	if (r.size.x != 0) {
-		zero_offset.x = -r.position.x / r.size.x;
-		new_scale.x = p_edit_rect.size.x / r.size.x;
-	}
-
-	if (r.size.y != 0) {
-		zero_offset.y = -r.position.y / r.size.y;
-		new_scale.y = p_edit_rect.size.y / r.size.y;
-	}
-
-	Point2 new_pos = p_edit_rect.position + p_edit_rect.size * zero_offset;
-
-	Transform2D postxf;
-	postxf.set_rotation_scale_and_skew(rotation, scale, skew);
-	new_pos = postxf.xform(new_pos);
-
-	position += new_pos;
-	scale *= new_scale;
-
-	_update_transform();
+void Node2D::_edit_set_scale_with_fixpoint(Size2 p_new_scale, const Point2 p_local_fixpoint) {
+	Transform2D new_xform = Transform2D(get_rotation(), p_new_scale, get_skew(), Vector2());
+	position = get_transform().xform(p_local_fixpoint) - new_xform.xform(p_local_fixpoint);
+	set_scale(p_new_scale);
 }
-#endif
+#endif // TOOLS_ENABLED
 
 void Node2D::_update_xform_values() {
 	position = transform.columns[2];

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -70,7 +70,7 @@ public:
 	virtual real_t _edit_get_rotation() const override;
 	virtual bool _edit_use_rotation() const override;
 
-	virtual void _edit_set_rect(const Rect2 &p_edit_rect) override;
+	virtual void _edit_set_scale_with_fixpoint(Size2 p_new_scale, const Point2 p_local_fixpoint) override;
 #endif
 
 	void set_position(const Point2 &p_pos);

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -152,6 +152,13 @@ Transform2D CanvasItem::get_global_transform_with_canvas() const {
 	}
 }
 
+Transform2D CanvasItem::get_parent_transform_to_viewport() const {
+	if (!get_parent_item()) {
+		return Transform2D();
+	}
+	return get_parent_item()->get_global_transform_with_canvas();
+}
+
 Transform2D CanvasItem::get_screen_transform() const {
 	ERR_FAIL_COND_V(!is_inside_tree(), Transform2D());
 	Transform2D xform = get_global_transform_with_canvas();

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -190,8 +190,9 @@ public:
 	// Used to resize/move the node
 	virtual bool _edit_use_rect() const { return false; }; // MAYBE REPLACE BY A _edit_get_editmode()
 	virtual void _edit_set_rect(const Rect2 &p_rect) {}
+	virtual void _edit_set_scale_with_fixpoint(Size2 p_new_scale, const Point2 p_local_fixpoint) {}
 	virtual Rect2 _edit_get_rect() const { return Rect2(0, 0, 0, 0); };
-	virtual Size2 _edit_get_minimum_size() const { return Size2(-1, -1); }; // LOOKS WEIRD
+	virtual Size2 _edit_get_minimum_size() const { return Size2(); };
 
 	// Used to set a pivot
 	virtual bool _edit_use_pivot() const { return false; };
@@ -284,6 +285,7 @@ public:
 
 	virtual Transform2D get_global_transform() const;
 	virtual Transform2D get_global_transform_with_canvas() const;
+	virtual Transform2D get_parent_transform_to_viewport() const;
 	virtual Transform2D get_screen_transform() const;
 
 	CanvasItem *get_top_level() const;


### PR DESCRIPTION
part of #35081
related to #68755

`Node2D::_edit_set_rect` depends on the assumption, that `Node2D::scale` is never `0` in the following line:
https://github.com/godotengine/godot/blob/3bd74cd67bfc5484b3f5d4b47da66c55457474c7/scene/2d/node_2d.cpp#L107

This line makes the `Node2D::set_scale`-hack necessary, which doesn't allow components of `scale` to be `0`.

Replace `Node2D::_edit_set_rect` by `Node2D::_edit_set_scale_with_fixpoint` which doesn't depend on this restriction. This new function takes as arguments:
- the new scale
- A fixpoint, that stays on the same location before and after the change

In order to achieve this, `CanvasItemEditor::_gui_input_resize` had to be adjusted with necessary changes.

`CanvasItemEditor::_draw_selection` also needed adjustments because `(endpoints[i] - endpoints[prev]).normalized()` no longer works reliably in all cases, because the two endpoints can be at the same location.
https://github.com/godotengine/godot/blob/3bd74cd67bfc5484b3f5d4b47da66c55457474c7/editor/plugins/canvas_item_editor_plugin.cpp#L3404

In order to properly account for `Ctrl`- and `Alt`-Keys these two now get processed in `CanvasItemEditor::unhandled_key_input`.

`CanvasItem::_edit_get_minimum_size` no longer looks weird (but previously it was necessary that way).

A Mockup for this new algorithm is available in GDScript: [BugZeroDet.zip](https://github.com/godotengine/godot/files/10040112/BugZeroDet.zip)



In order to test this PR, the following patch should be applied and also #68755. This PR also works without the following patch and without #68755 in current master.
``` diff
diff --git a/core/math/transform_2d.cpp b/core/math/transform_2d.cpp
index 548a82d254..53e489de65 100644
--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -47,6 +47,7 @@ Transform2D Transform2D::inverse() const {
 
 void Transform2D::affine_invert() {
 	real_t det = basis_determinant();
+	CRASH_COND(Math::is_zero_approx(det));
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND(det == 0);
 #endif
diff --git a/scene/2d/node_2d.cpp b/scene/2d/node_2d.cpp
index 2518069b78..3d6535a31d 100644
--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -161,12 +161,14 @@ void Node2D::set_scale(const Size2 &p_scale) {
 	}
 	scale = p_scale;
 	// Avoid having 0 scale values, can lead to errors in physics and rendering.
+#if 0
 	if (Math::is_zero_approx(scale.x)) {
 		scale.x = CMP_EPSILON;
 	}
 	if (Math::is_zero_approx(scale.y)) {
 		scale.y = CMP_EPSILON;
 	}
+#endif // 0
 	_update_transform();
 }
 
@@ -440,7 +442,7 @@ void Node2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position", PROPERTY_HINT_RANGE, "-99999,99999,0.001,or_less,or_greater,hide_slider,suffix:px"), "set_position", "get_position");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rotation", PROPERTY_HINT_RANGE, "-360,360,0.1,or_less,or_greater,radians"), "set_rotation", "get_rotation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "scale", PROPERTY_HINT_LINK), "set_scale", "get_scale");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "skew", PROPERTY_HINT_RANGE, "-89.9,89.9,0.1,radians"), "set_skew", "get_skew");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "skew", PROPERTY_HINT_RANGE, "-90.0,90.0,0.1,radians"), "set_skew", "get_skew");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "transform", PROPERTY_HINT_NONE, "suffix:px", PROPERTY_USAGE_NONE), "set_transform", "get_transform");
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "global_position", PROPERTY_HINT_NONE, "suffix:px", PROPERTY_USAGE_NONE), "set_global_position", "get_global_position");
```