### PR TITLE
Windows icon export improvements.

### DIFF
--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -137,6 +137,9 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/short_version"), "1.0"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/version"), "1.0"));
 
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/icon_interpolation", PROPERTY_HINT_ENUM, "Nearest neighbor,Bilinear,Cubic,Trilinear,Lanczos"), 4));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/launch_screens_interpolation", PROPERTY_HINT_ENUM, "Nearest neighbor,Bilinear,Cubic,Trilinear,Lanczos"), 4));
+
 	Vector<PluginConfigIOS> found_plugins = get_plugins();
 	for (int i = 0; i < found_plugins.size(); i++) {
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, vformat("%s/%s", PNAME("plugins"), found_plugins[i].name)), false));
@@ -589,13 +592,13 @@ Error EditorExportPlatformIOS::_export_icons(const Ref<EditorExportPreset> &p_pr
 				return ERR_UNCONFIGURED;
 			} else if (info.force_opaque && img->detect_alpha() != Image::ALPHA_NONE) {
 				add_message(EXPORT_MESSAGE_WARNING, TTR("Export Icons"), vformat("Icon (%s) must be opaque.", info.preset_key));
-				img->resize(side_size, side_size);
+				img->resize(side_size, side_size, (Image::Interpolation)(p_preset->get("application/icon_interpolation").operator int()));
 				Ref<Image> new_img = Image::create_empty(side_size, side_size, false, Image::FORMAT_RGBA8);
 				new_img->fill(boot_bg_color);
 				_blend_and_rotate(new_img, img, false);
 				err = new_img->save_png(p_iconset_dir + info.export_name);
 			} else {
-				img->resize(side_size, side_size);
+				img->resize(side_size, side_size, (Image::Interpolation)(p_preset->get("application/icon_interpolation").operator int()));
 				err = img->save_png(p_iconset_dir + info.export_name);
 			}
 			if (err) {
@@ -611,14 +614,14 @@ Error EditorExportPlatformIOS::_export_icons(const Ref<EditorExportPreset> &p_pr
 				return ERR_UNCONFIGURED;
 			} else if (info.force_opaque && img->detect_alpha() != Image::ALPHA_NONE) {
 				add_message(EXPORT_MESSAGE_WARNING, TTR("Export Icons"), vformat("Icon (%s) must be opaque.", info.preset_key));
-				img->resize(side_size, side_size);
+				img->resize(side_size, side_size, (Image::Interpolation)(p_preset->get("application/icon_interpolation").operator int()));
 				Ref<Image> new_img = Image::create_empty(side_size, side_size, false, Image::FORMAT_RGBA8);
 				new_img->fill(boot_bg_color);
 				_blend_and_rotate(new_img, img, false);
 				err = new_img->save_png(p_iconset_dir + info.export_name);
 			} else if (img->get_width() != side_size || img->get_height() != side_size) {
 				add_message(EXPORT_MESSAGE_WARNING, TTR("Export Icons"), vformat("Icon (%s): '%s' has incorrect size %s and was automatically resized to %s.", info.preset_key, icon_path, img->get_size(), Vector2i(side_size, side_size)));
-				img->resize(side_size, side_size);
+				img->resize(side_size, side_size, (Image::Interpolation)(p_preset->get("application/icon_interpolation").operator int()));
 				err = img->save_png(p_iconset_dir + info.export_name);
 			} else {
 				err = da->copy(icon_path, p_iconset_dir + info.export_name);
@@ -748,9 +751,9 @@ Error EditorExportPlatformIOS::_export_loading_screen_images(const Ref<EditorExp
 				float aspect_ratio = (float)img->get_width() / (float)img->get_height();
 				if (boot_logo_scale) {
 					if (info.height * aspect_ratio <= info.width) {
-						img->resize(info.height * aspect_ratio, info.height);
+						img->resize(info.height * aspect_ratio, info.height, (Image::Interpolation)(p_preset->get("application/launch_screens_interpolation").operator int()));
 					} else {
-						img->resize(info.width, info.width / aspect_ratio);
+						img->resize(info.width, info.width / aspect_ratio, (Image::Interpolation)(p_preset->get("application/launch_screens_interpolation").operator int()));
 					}
 				}
 				Ref<Image> new_img = Image::create_empty(info.width, info.height, false, Image::FORMAT_RGBA8);
@@ -784,17 +787,17 @@ Error EditorExportPlatformIOS::_export_loading_screen_images(const Ref<EditorExp
 				if (info.rotate) {
 					if (boot_logo_scale) {
 						if (info.width * aspect_ratio <= info.height) {
-							img_bs->resize(info.width * aspect_ratio, info.width);
+							img_bs->resize(info.width * aspect_ratio, info.width, (Image::Interpolation)(p_preset->get("application/launch_screens_interpolation").operator int()));
 						} else {
-							img_bs->resize(info.height, info.height / aspect_ratio);
+							img_bs->resize(info.height, info.height / aspect_ratio, (Image::Interpolation)(p_preset->get("application/launch_screens_interpolation").operator int()));
 						}
 					}
 				} else {
 					if (boot_logo_scale) {
 						if (info.height * aspect_ratio <= info.width) {
-							img_bs->resize(info.height * aspect_ratio, info.height);
+							img_bs->resize(info.height * aspect_ratio, info.height, (Image::Interpolation)(p_preset->get("application/launch_screens_interpolation").operator int()));
 						} else {
-							img_bs->resize(info.width, info.width / aspect_ratio);
+							img_bs->resize(info.width, info.width / aspect_ratio, (Image::Interpolation)(p_preset->get("application/launch_screens_interpolation").operator int()));
 						}
 					}
 				}

--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -53,7 +53,7 @@ class EditorExportPlatformMacOS : public EditorExportPlatform {
 	Ref<ImageTexture> logo;
 
 	void _fix_plist(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &plist, const String &p_binary);
-	void _make_icon(const Ref<Image> &p_icon, Vector<uint8_t> &p_data);
+	void _make_icon(const Ref<EditorExportPreset> &p_preset, const Ref<Image> &p_icon, Vector<uint8_t> &p_data);
 
 	Error _notarize(const Ref<EditorExportPreset> &p_preset, const String &p_path);
 	Error _code_sign(const Ref<EditorExportPreset> &p_preset, const String &p_path, const String &p_ent_path, bool p_warn = true);

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -32,6 +32,118 @@
 
 #include "core/config/project_settings.h"
 #include "editor/editor_node.h"
+#include "editor/editor_paths.h"
+
+Error EditorExportPlatformWindows::_process_icon(const Ref<EditorExportPreset> &p_preset, const String &p_src_path, const String &p_dst_path) {
+	static const uint8_t icon_size[] = { 16, 32, 48, 64, 128, 0 /*256*/ };
+
+	struct IconData {
+		Vector<uint8_t> data;
+		uint8_t pal_colors = 0;
+		uint16_t planes = 0;
+		uint16_t bpp = 32;
+	};
+
+	HashMap<uint8_t, IconData> images;
+	Error err;
+
+	if (p_src_path.get_extension() == "ico") {
+		Ref<FileAccess> f = FileAccess::open(p_src_path, FileAccess::READ, &err);
+		if (err != OK) {
+			return err;
+		}
+
+		// Read ICONDIR.
+		f->get_16(); // Reserved.
+		uint16_t icon_type = f->get_16(); // Image type: 1 - ICO.
+		uint16_t icon_count = f->get_16(); // Number of images.
+		ERR_FAIL_COND_V(icon_type != 1, ERR_CANT_OPEN);
+
+		for (uint16_t i = 0; i < icon_count; i++) {
+			// Read ICONDIRENTRY.
+			uint16_t w = f->get_8(); // Width in pixels.
+			uint16_t h = f->get_8(); // Height in pixels.
+			uint8_t pal_colors = f->get_8(); // Number of colors in the palette (0 - no palette).
+			f->get_8(); // Reserved.
+			uint16_t planes = f->get_16(); // Number of color planes.
+			uint16_t bpp = f->get_16(); // Bits per pixel.
+			uint32_t img_size = f->get_32(); // Image data size in bytes.
+			uint32_t img_offset = f->get_32(); // Image data offset.
+			if (w != h) {
+				continue;
+			}
+
+			// Read image data.
+			uint64_t prev_offset = f->get_position();
+			images[w].pal_colors = pal_colors;
+			images[w].planes = planes;
+			images[w].bpp = bpp;
+			images[w].data.resize(img_size);
+			f->seek(img_offset);
+			f->get_buffer(images[w].data.ptrw(), img_size);
+			f->seek(prev_offset);
+		}
+	} else {
+		Ref<Image> src_image = Image::load_from_file(p_src_path);
+		ERR_FAIL_COND_V(src_image.is_null() || src_image->is_empty(), ERR_CANT_OPEN);
+		for (size_t i = 0; i < sizeof(icon_size) / sizeof(icon_size[0]); ++i) {
+			int size = (icon_size[i] == 0) ? 256 : icon_size[i];
+
+			Ref<Image> res_image = src_image->duplicate();
+			ERR_FAIL_COND_V(res_image.is_null() || res_image->is_empty(), ERR_CANT_OPEN);
+			res_image->resize(size, size, (Image::Interpolation)(p_preset->get("application/icon_interpolation").operator int()));
+			images[icon_size[i]].data = res_image->save_png_to_buffer();
+		}
+	}
+
+	uint16_t valid_icon_count = 0;
+	for (size_t i = 0; i < sizeof(icon_size) / sizeof(icon_size[0]); ++i) {
+		if (images.has(icon_size[i])) {
+			valid_icon_count++;
+		} else {
+			int size = (icon_size[i] == 0) ? 256 : icon_size[i];
+			add_message(EXPORT_MESSAGE_WARNING, TTR("Resources Modification"), vformat(TTR("Icon size \"%d\" is missing."), size));
+		}
+	}
+	ERR_FAIL_COND_V(valid_icon_count == 0, ERR_CANT_OPEN);
+
+	Ref<FileAccess> fw = FileAccess::open(p_dst_path, FileAccess::WRITE, &err);
+	if (err != OK) {
+		return err;
+	}
+
+	// Write ICONDIR.
+	fw->store_16(0); // Reserved.
+	fw->store_16(1); // Image type: 1 - ICO.
+	fw->store_16(valid_icon_count); // Number of images.
+
+	// Write ICONDIRENTRY.
+	uint32_t img_offset = 6 + 16 * valid_icon_count;
+	for (size_t i = 0; i < sizeof(icon_size) / sizeof(icon_size[0]); ++i) {
+		if (images.has(icon_size[i])) {
+			const IconData &di = images[icon_size[i]];
+			fw->store_8(icon_size[i]); // Width in pixels.
+			fw->store_8(icon_size[i]); // Height in pixels.
+			fw->store_8(di.pal_colors); // Number of colors in the palette (0 - no palette).
+			fw->store_8(0); // Reserved.
+			fw->store_16(di.planes); // Number of color planes.
+			fw->store_16(di.bpp); // Bits per pixel.
+			fw->store_32(di.data.size()); // Image data size in bytes.
+			fw->store_32(img_offset); // Image data offset.
+
+			img_offset += di.data.size();
+		}
+	}
+
+	// Write image data.
+	for (size_t i = 0; i < sizeof(icon_size) / sizeof(icon_size[0]); ++i) {
+		if (images.has(icon_size[i])) {
+			const IconData &di = images[icon_size[i]];
+			fw->store_buffer(di.data.ptr(), di.data.size());
+		}
+	}
+	return OK;
+}
 
 Error EditorExportPlatformWindows::sign_shared_object(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path) {
 	if (p_preset->get("codesign/enable")) {
@@ -110,8 +222,9 @@ void EditorExportPlatformWindows::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::PACKED_STRING_ARRAY, "codesign/custom_options"), PackedStringArray()));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "application/modify_resources"), true));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/icon", PROPERTY_HINT_FILE, "*.ico"), ""));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/console_wrapper_icon", PROPERTY_HINT_FILE, "*.ico"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/icon", PROPERTY_HINT_FILE, "*.ico,*.png,*.webp,*.svg"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/console_wrapper_icon", PROPERTY_HINT_FILE, "*.ico.*.png,*.webp,*.svg"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/icon_interpolation", PROPERTY_HINT_ENUM, "Nearest neighbor,Bilinear,Cubic,Trilinear,Lanczos"), 4));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/file_version", PROPERTY_HINT_PLACEHOLDER_TEXT, "1.0.0.0"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/product_version", PROPERTY_HINT_PLACEHOLDER_TEXT, "1.0.0.0"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/company_name", PROPERTY_HINT_PLACEHOLDER_TEXT, "Company Name"), ""));
@@ -154,6 +267,15 @@ Error EditorExportPlatformWindows::_rcedit_add_data(const Ref<EditorExportPreset
 			icon_path = console_icon_path;
 		}
 	}
+
+	String tmp_icon_path = EditorPaths::get_singleton()->get_cache_dir().path_join("_rcedit.ico");
+	if (!icon_path.is_empty()) {
+		if (_process_icon(p_preset, icon_path, tmp_icon_path) != OK) {
+			add_message(EXPORT_MESSAGE_WARNING, TTR("Resources Modification"), vformat(TTR("Invalid icon file \"%s\"."), icon_path));
+			icon_path = String();
+		}
+	}
+
 	String file_verion = p_preset->get("application/file_version");
 	String product_version = p_preset->get("application/product_version");
 	String company_name = p_preset->get("application/company_name");
@@ -167,7 +289,7 @@ Error EditorExportPlatformWindows::_rcedit_add_data(const Ref<EditorExportPreset
 	args.push_back(p_path);
 	if (!icon_path.is_empty()) {
 		args.push_back("--set-icon");
-		args.push_back(icon_path);
+		args.push_back(tmp_icon_path);
 	}
 	if (!file_verion.is_empty()) {
 		args.push_back("--set-file-version");
@@ -211,6 +333,11 @@ Error EditorExportPlatformWindows::_rcedit_add_data(const Ref<EditorExportPreset
 
 	String str;
 	Error err = OS::get_singleton()->execute(rcedit_path, args, &str, nullptr, true);
+
+	if (FileAccess::exists(tmp_icon_path)) {
+		DirAccess::remove_file_or_error(tmp_icon_path);
+	}
+
 	if (err != OK || (str.find("not found") != -1) || (str.find("not recognized") != -1)) {
 		add_message(EXPORT_MESSAGE_WARNING, TTR("Resources Modification"), TTR("Could not start rcedit executable. Configure rcedit path in the Editor Settings (Export > Windows > rcedit), or disable \"Application > Modify Resources\" in the export preset."));
 		return err;

--- a/platform/windows/export/export_plugin.h
+++ b/platform/windows/export/export_plugin.h
@@ -38,6 +38,7 @@
 #include "platform/windows/logo.gen.h"
 
 class EditorExportPlatformWindows : public EditorExportPlatformPC {
+	Error _process_icon(const Ref<EditorExportPreset> &p_preset, const String &p_src_path, const String &p_dst_path);
 	Error _rcedit_add_data(const Ref<EditorExportPreset> &p_preset, const String &p_path, bool p_console_icon);
 	Error _code_sign(const Ref<EditorExportPreset> &p_preset, const String &p_path);
 


### PR DESCRIPTION
- Regenerate Windows icon on export to ensure correct icon size order.
- Add support for using PNG/WebP/SVG files as an icon for Windows exports.
- Allow using WebP/SVG files as icon for macOS exports.
- Add option to select generated icons interpolation, and set default interpolation to Lanczos.

Fixes #64073

Now icons won't be blurry regardless of size order in the icon, exporter will reorder it, remove unnecessary sizes and warn is some are missing.
It's also possible to auto generate icon from any `Image` (also added WebP / SVG for macOS exported, since it should be able to generate icon from any `Image` as well).

Note: Order of the sizes in the default icon used by the export template must always match order in the `static const uint8_t icon_size[]` array, if the default icon is updated (e.g., reverted to compressed version), this array should be updated as well.