### PR TITLE
Improve class reference split, list variant types separately

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -29,10 +29,12 @@ MARKUP_ALLOWED_SUBSEQUENT = " -.,:;!?\\/'\")]}>"
 # write in this script (check `translate()` uses), and also hardcoded in
 # `doc/translations/extract.py` to include them in the source POT file.
 BASE_STRINGS = [
-    "Objects",
+    "All classes",
+    "Globals",
     "Nodes",
     "Resources",
-    "Globals",
+    "Other objects",
+    "Variant types",
     "Description",
     "Tutorials",
     "Properties",
@@ -71,7 +73,13 @@ CLASS_GROUPS: Dict[str, str] = {
     "global": "Globals",
     "node": "Nodes",
     "resource": "Resources",
-    "class": "Objects",
+    "object": "Other objects",
+    "variant": "Variant types",
+}
+CLASS_GROUPS_BASE: Dict[str, str] = {
+    "node": "Node",
+    "resource": "Resource",
+    "object": "Object",
 }
 
 
@@ -687,7 +695,7 @@ def get_git_branch() -> str:
 
 
 def get_class_group(class_def: ClassDef, state: State) -> str:
-    group_name = "class"
+    group_name = "variant"
     class_name = class_def.name
 
     if class_name.startswith("@"):
@@ -701,6 +709,9 @@ def get_class_group(class_def: ClassDef, state: State) -> str:
                 break
             if inherits == "Resource":
                 group_name = "resource"
+                break
+            if inherits == "Object":
+                group_name = "object"
                 break
 
             inode = state.classes[inherits].inherits
@@ -1281,6 +1292,10 @@ def make_rst_index(grouped_classes: Dict[str, List[str]], dry_run: bool, output_
 
     f.write(".. _doc_class_reference:\n\n")
 
+    main_title = translate("All classes")
+    f.write(f"{main_title}\n")
+    f.write(f"{'=' * len(main_title)}\n\n")
+
     for group_name in CLASS_GROUPS:
         if group_name in grouped_classes:
             group_title = translate(CLASS_GROUPS[group_name])
@@ -1290,8 +1305,11 @@ def make_rst_index(grouped_classes: Dict[str, List[str]], dry_run: bool, output_
 
             f.write(".. toctree::\n")
             f.write("    :maxdepth: 1\n")
-            f.write("    :name: toc-class-ref-globals\n")
+            f.write(f"    :name: toc-class-ref-{group_name}s\n")
             f.write("\n")
+
+            if group_name in CLASS_GROUPS_BASE:
+                f.write(f"    class_{CLASS_GROUPS_BASE[group_name].lower()}\n")
 
             for class_name in grouped_classes[group_name]:
                 f.write(f"    class_{class_name.lower()}\n")


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/63497 with a number of improvements based on early feedback.

* Fixes the issue with subsection references being duplicated.
* Adds a new main section to serve as a page title, "All classes", which fixes breadcrumbs (always referring to "Globals", no matter which class you were looking at).
* Splits "Objects" into "Other objects" (since nodes and resources are also objects) and "Variant types", giving the latter their own home in the class reference.
* Adds "Object", "Node", and "Resource" as a first entry to their own groups, "Other objects", "Nodes", "Resources"; they also still remain in their current groups, based on inheritance (e.g. you can find "Node" in "Other objects").

![chrome_2022-11-18_15-46-19](https://user-images.githubusercontent.com/11782833/202708976-5b4e1538-8d60-4f13-b557-3e9dbe516c19.png)

![image](https://user-images.githubusercontent.com/11782833/202708932-8df23553-9a54-4570-b17d-1ecb35ba1980.png)

PS. I can push a commit with an updated `index.rst` to the docs repo if this is accepted.