### PR TITLE
Improve logic for detecting and tracking extensions

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -161,6 +161,18 @@ bool CharString::operator<(const CharString &p_right) const {
 	return is_str_less(get_data(), p_right.get_data());
 }
 
+bool CharString::operator==(const CharString &p_right) const {
+	if (length() == 0) {
+		// True if both have length 0, false if only p_right has a length
+		return p_right.length() == 0;
+	} else if (p_right.length() == 0) {
+		// False due to unequal length
+		return false;
+	}
+
+	return strcmp(ptr(), p_right.ptr()) == 0;
+}
+
 CharString &CharString::operator+=(char p_char) {
 	const int lhs_len = length();
 	resize(lhs_len + 2);

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -156,6 +156,7 @@ public:
 
 	void operator=(const char *p_cstr);
 	bool operator<(const CharString &p_right) const;
+	bool operator==(const CharString &p_right) const;
 	CharString &operator+=(char p_char);
 	int length() const { return size() ? size() - 1 : 0; }
 	const char *get_data() const;

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -310,6 +310,7 @@ struct HashMapHasherDefault {
 	static _FORCE_INLINE_ uint32_t hash(const char16_t p_uchar) { return hash_fmix32(p_uchar); }
 	static _FORCE_INLINE_ uint32_t hash(const char32_t p_uchar) { return hash_fmix32(p_uchar); }
 	static _FORCE_INLINE_ uint32_t hash(const RID &p_rid) { return hash_one_uint64(p_rid.get_id()); }
+	static _FORCE_INLINE_ uint32_t hash(const CharString &p_char_string) { return hash_djb2(p_char_string.ptr()); }
 	static _FORCE_INLINE_ uint32_t hash(const StringName &p_string_name) { return p_string_name.hash(); }
 	static _FORCE_INLINE_ uint32_t hash(const NodePath &p_path) { return p_path.hash(); }
 	static _FORCE_INLINE_ uint32_t hash(const ObjectID &p_id) { return hash_one_uint64(p_id); }

--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -34,6 +34,7 @@
 #include "core/error/error_list.h"
 #include "core/os/mutex.h"
 #include "core/string/ustring.h"
+#include "core/templates/hash_map.h"
 #include "core/templates/rb_map.h"
 #include "core/templates/rid_owner.h"
 #include "servers/display_server.h"
@@ -184,19 +185,15 @@ private:
 	int command_buffer_count = 1;
 
 	// Extensions.
+	static bool instance_extensions_initialized;
+	static HashMap<CharString, bool> requested_instance_extensions;
+	HashSet<CharString> enabled_instance_extension_names;
 
+	static bool device_extensions_initialized;
+	static HashMap<CharString, bool> requested_device_extensions;
+	HashSet<CharString> enabled_device_extension_names;
 	bool VK_KHR_incremental_present_enabled = true;
 	bool VK_GOOGLE_display_timing_enabled = true;
-	uint32_t enabled_extension_count = 0;
-	const char *extension_names[MAX_EXTENSIONS];
-	bool enabled_debug_utils = false;
-	bool has_renderpass2_ext = false;
-
-	/**
-	 * True if VK_EXT_debug_report extension is used. VK_EXT_debug_report is deprecated but it is
-	 * still used if VK_EXT_debug_utils is not available.
-	 */
-	bool enabled_debug_report = false;
 
 	PFN_vkCreateDebugUtilsMessengerEXT CreateDebugUtilsMessengerEXT = nullptr;
 	PFN_vkDestroyDebugUtilsMessengerEXT DestroyDebugUtilsMessengerEXT = nullptr;
@@ -225,7 +222,8 @@ private:
 	VkDebugReportCallbackEXT dbg_debug_report = VK_NULL_HANDLE;
 
 	Error _obtain_vulkan_version();
-	Error _initialize_extensions();
+	Error _initialize_instance_extensions();
+	Error _initialize_device_extensions();
 	Error _check_capabilities();
 
 	VkBool32 _check_layers(uint32_t check_count, const char *const *check_names, uint32_t layer_count, VkLayerProperties *layers);
@@ -275,7 +273,7 @@ protected:
 
 public:
 	// Extension calls.
-	bool supports_renderpass2() const { return has_renderpass2_ext; }
+	bool supports_renderpass2() const { return is_device_extension_enabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME); }
 	VkResult vkCreateRenderPass2KHR(VkDevice p_device, const VkRenderPassCreateInfo2 *p_create_info, const VkAllocationCallbacks *p_allocator, VkRenderPass *p_render_pass);
 
 	uint32_t get_vulkan_major() const { return vulkan_major; };
@@ -294,6 +292,16 @@ public:
 	uint32_t get_graphics_queue_family_index() const;
 
 	static void set_vulkan_hooks(VulkanHooks *p_vulkan_hooks) { vulkan_hooks = p_vulkan_hooks; };
+
+	static void register_requested_instance_extension(const CharString &extension_name, bool p_required);
+	bool is_instance_extension_enabled(const CharString &extension_name) const {
+		return enabled_instance_extension_names.has(extension_name);
+	}
+
+	static void register_requested_device_extension(const CharString &extension_name, bool p_required);
+	bool is_device_extension_enabled(const CharString &extension_name) const {
+		return enabled_device_extension_names.has(extension_name);
+	}
 
 	void window_resize(DisplayServer::WindowID p_window_id, int p_width, int p_height);
 	int window_get_width(DisplayServer::WindowID p_window = 0);

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -226,6 +226,12 @@ TEST_CASE("[String] Comparisons (equal)") {
 	CHECK(s == U"Test Compare");
 	CHECK(s == L"Test Compare");
 	CHECK(s == String("Test Compare"));
+
+	CharString empty = "";
+	CharString cs = "Test Compare";
+	CHECK(!(empty == cs));
+	CHECK(!(cs == empty));
+	CHECK(cs == CharString("Test Compare"));
 }
 
 TEST_CASE("[String] Comparisons (not equal)") {


### PR DESCRIPTION
This PR brings some much needed structure to how we handle extensions in our Vulkan driver. The design is taken from how we handle extensions in OpenXR, but with a few things still left out.

## Instance and device extensions
We're now nicely naming instance and device extensions, often there was confusion which was being used as we re-used the same buffers.

## Required extensions
Second, we now define a set called `requested_instance_extensions`, and `requested_device_extensions` (**WIP**), as static variables. These can be populated with the extensions we wish to enable. To register these we call `register_requested_instance_extension` and `register_requested_device_extension` respectively. By making these static modules can request additional extensions.
We will add our default extensions in `_initialize_instance_extensions` and `_initialize_device_extensions` respectively.

In those last two functions we also check our requested extensions against the extensions available in the system. We enable any we find, we error out if we couldn't find required extensions. 

This allows us to more cleanly check in various places whether an extension was enabled.

## Checking for enabled extensions

The code previously either didn't check things consistently or maintained an ever growing set of boolean variables. We're removing those and instead have introduced `is_instance_extension_enabled` and `is_device_extension_enabled` (**WIP**).
