### PR TITLE
[MP] Initial Replication profiler.

### DIFF
--- a/modules/multiplayer/editor/editor_network_profiler.cpp
+++ b/modules/multiplayer/editor/editor_network_profiler.cpp
@@ -36,13 +36,19 @@
 
 void EditorNetworkProfiler::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("enable_profiling", PropertyInfo(Variant::BOOL, "enable")));
+	ADD_SIGNAL(MethodInfo("open_request", PropertyInfo(Variant::STRING, "path")));
 }
 
 void EditorNetworkProfiler::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
+			node_icon = get_theme_icon(SNAME("Node"), SNAME("EditorIcons"));
+			if (activate->is_pressed()) {
+				activate->set_icon(get_theme_icon(SNAME("Stop"), SNAME("EditorIcons")));
+			} else {
+				activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
+			}
 			clear_button->set_icon(get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")));
 			incoming_bandwidth_text->set_right_icon(get_theme_icon(SNAME("ArrowDown"), SNAME("EditorIcons")));
 			outgoing_bandwidth_text->set_right_icon(get_theme_icon(SNAME("ArrowUp"), SNAME("EditorIcons")));
@@ -54,15 +60,25 @@ void EditorNetworkProfiler::_notification(int p_what) {
 	}
 }
 
-void EditorNetworkProfiler::_update_frame() {
+void EditorNetworkProfiler::_refresh() {
+	if (!dirty) {
+		return;
+	}
+	dirty = false;
+	refresh_rpc_data();
+	refresh_replication_data();
+}
+
+void EditorNetworkProfiler::refresh_rpc_data() {
 	counters_display->clear();
 
 	TreeItem *root = counters_display->create_item();
+	int cols = counters_display->get_columns();
 
-	for (const KeyValue<ObjectID, RPCNodeInfo> &E : nodes_data) {
+	for (const KeyValue<ObjectID, RPCNodeInfo> &E : rpc_data) {
 		TreeItem *node = counters_display->create_item(root);
 
-		for (int j = 0; j < counters_display->get_columns(); ++j) {
+		for (int j = 0; j < cols; ++j) {
 			node->set_text_alignment(j, j > 0 ? HORIZONTAL_ALIGNMENT_RIGHT : HORIZONTAL_ALIGNMENT_LEFT);
 		}
 
@@ -72,11 +88,76 @@ void EditorNetworkProfiler::_update_frame() {
 	}
 }
 
+void EditorNetworkProfiler::refresh_replication_data() {
+	replication_display->clear();
+
+	TreeItem *root = replication_display->create_item();
+
+	for (const KeyValue<ObjectID, SyncInfo> &E : sync_data) {
+		// Ensure the nodes have at least a temporary cache.
+		ObjectID ids[3] = { E.value.synchronizer, E.value.config, E.value.root_node };
+		for (uint32_t i = 0; i < 3; i++) {
+			const ObjectID &id = ids[i];
+			if (!node_data.has(id)) {
+				missing_node_data.insert(id);
+				node_data[id] = NodeInfo(id);
+			}
+		}
+
+		TreeItem *node = replication_display->create_item(root);
+
+		const NodeInfo &root_info = node_data[E.value.root_node];
+		const NodeInfo &sync_info = node_data[E.value.synchronizer];
+		const NodeInfo &cfg_info = node_data[E.value.config];
+
+		node->set_text(0, root_info.path.get_file());
+		node->set_icon(0, has_theme_icon(root_info.type, SNAME("EditorIcons")) ? get_theme_icon(root_info.type, SNAME("EditorIcons")) : node_icon);
+		node->set_tooltip_text(0, root_info.path);
+
+		node->set_text(1, sync_info.path.get_file());
+		node->set_icon(1, get_theme_icon("MultiplayerSynchronizer", SNAME("EditorIcons")));
+		node->set_tooltip_text(1, sync_info.path);
+
+		int cfg_idx = cfg_info.path.find("::");
+		if (cfg_info.path.begins_with("res://") && ResourceLoader::exists(cfg_info.path) && cfg_idx > 0) {
+			String res_idstr = cfg_info.path.substr(cfg_idx + 2).replace("SceneReplicationConfig_", "");
+			String scene_path = cfg_info.path.substr(0, cfg_idx);
+			node->set_text(2, vformat("%s (%s)", res_idstr, scene_path.get_file()));
+			node->add_button(2, get_theme_icon(SNAME("InstanceOptions"), SNAME("EditorIcons")));
+			node->set_tooltip_text(2, cfg_info.path);
+			node->set_metadata(2, scene_path);
+		} else {
+			node->set_text(2, cfg_info.path);
+			node->set_metadata(2, "");
+		}
+
+		node->set_text(3, vformat("%d - %d", E.value.incoming_syncs, E.value.outgoing_syncs));
+		node->set_text(4, vformat("%d - %d", E.value.incoming_size, E.value.outgoing_size));
+	}
+}
+
+Array EditorNetworkProfiler::pop_missing_node_data() {
+	Array out;
+	for (const ObjectID &id : missing_node_data) {
+		out.push_back(id);
+	}
+	missing_node_data.clear();
+	return out;
+}
+
+void EditorNetworkProfiler::add_node_data(const NodeInfo &p_info) {
+	ERR_FAIL_COND(!node_data.has(p_info.id));
+	node_data[p_info.id] = p_info;
+	dirty = true;
+}
+
 void EditorNetworkProfiler::_activate_pressed() {
 	if (activate->is_pressed()) {
+		refresh_timer->start();
 		activate->set_icon(get_theme_icon(SNAME("Stop"), SNAME("EditorIcons")));
 		activate->set_text(TTR("Stop"));
 	} else {
+		refresh_timer->stop();
 		activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
 		activate->set_text(TTR("Start"));
 	}
@@ -84,31 +165,55 @@ void EditorNetworkProfiler::_activate_pressed() {
 }
 
 void EditorNetworkProfiler::_clear_pressed() {
-	nodes_data.clear();
+	rpc_data.clear();
+	sync_data.clear();
+	node_data.clear();
+	missing_node_data.clear();
 	set_bandwidth(0, 0);
-	if (frame_delay->is_stopped()) {
-		frame_delay->set_wait_time(0.1);
-		frame_delay->start();
+	refresh_rpc_data();
+	refresh_replication_data();
+}
+
+void EditorNetworkProfiler::_replication_button_clicked(TreeItem *p_item, int p_column, int p_idx, MouseButton p_button) {
+	if (!p_item) {
+		return;
+	}
+	String meta = p_item->get_metadata(p_column);
+	if (meta.size() && ResourceLoader::exists(meta)) {
+		emit_signal("open_request", meta);
 	}
 }
 
-void EditorNetworkProfiler::add_node_frame_data(const RPCNodeInfo p_frame) {
-	if (!nodes_data.has(p_frame.node)) {
-		nodes_data.insert(p_frame.node, p_frame);
+void EditorNetworkProfiler::add_rpc_frame_data(const RPCNodeInfo &p_frame) {
+	dirty = true;
+	if (!rpc_data.has(p_frame.node)) {
+		rpc_data.insert(p_frame.node, p_frame);
 	} else {
-		nodes_data[p_frame.node].incoming_rpc += p_frame.incoming_rpc;
-		nodes_data[p_frame.node].outgoing_rpc += p_frame.outgoing_rpc;
+		rpc_data[p_frame.node].incoming_rpc += p_frame.incoming_rpc;
+		rpc_data[p_frame.node].outgoing_rpc += p_frame.outgoing_rpc;
 	}
 	if (p_frame.incoming_rpc) {
-		nodes_data[p_frame.node].incoming_size = p_frame.incoming_size / p_frame.incoming_rpc;
+		rpc_data[p_frame.node].incoming_size = p_frame.incoming_size / p_frame.incoming_rpc;
 	}
 	if (p_frame.outgoing_rpc) {
-		nodes_data[p_frame.node].outgoing_size = p_frame.outgoing_size / p_frame.outgoing_rpc;
+		rpc_data[p_frame.node].outgoing_size = p_frame.outgoing_size / p_frame.outgoing_rpc;
 	}
+}
 
-	if (frame_delay->is_stopped()) {
-		frame_delay->set_wait_time(0.1);
-		frame_delay->start();
+void EditorNetworkProfiler::add_sync_frame_data(const SyncInfo &p_frame) {
+	dirty = true;
+	if (!sync_data.has(p_frame.synchronizer)) {
+		sync_data[p_frame.synchronizer] = p_frame;
+	} else {
+		sync_data[p_frame.synchronizer].incoming_syncs += p_frame.incoming_syncs;
+		sync_data[p_frame.synchronizer].outgoing_syncs += p_frame.outgoing_syncs;
+	}
+	SyncInfo &info = sync_data[p_frame.synchronizer];
+	if (info.incoming_syncs) {
+		info.incoming_size = p_frame.incoming_size / p_frame.incoming_syncs;
+	}
+	if (info.outgoing_syncs) {
+		info.outgoing_size = p_frame.outgoing_size / p_frame.outgoing_syncs;
 	}
 }
 
@@ -174,9 +279,17 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	// Set initial texts in the incoming/outgoing bandwidth labels
 	set_bandwidth(0, 0);
 
+	HSplitContainer *sc = memnew(HSplitContainer);
+	add_child(sc);
+	sc->set_v_size_flags(SIZE_EXPAND_FILL);
+	sc->set_h_size_flags(SIZE_EXPAND_FILL);
+	sc->set_split_offset(100 * EDSCALE);
+
+	// RPC
 	counters_display = memnew(Tree);
-	counters_display->set_custom_minimum_size(Size2(300, 0) * EDSCALE);
+	counters_display->set_custom_minimum_size(Size2(320, 0) * EDSCALE);
 	counters_display->set_v_size_flags(SIZE_EXPAND_FILL);
+	counters_display->set_h_size_flags(SIZE_EXPAND_FILL);
 	counters_display->set_hide_folding(true);
 	counters_display->set_hide_root(true);
 	counters_display->set_columns(3);
@@ -193,11 +306,42 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	counters_display->set_column_expand(2, false);
 	counters_display->set_column_clip_content(2, true);
 	counters_display->set_column_custom_minimum_width(2, 120 * EDSCALE);
-	add_child(counters_display);
+	sc->add_child(counters_display);
 
-	frame_delay = memnew(Timer);
-	frame_delay->set_wait_time(0.1);
-	frame_delay->set_one_shot(true);
-	add_child(frame_delay);
-	frame_delay->connect("timeout", callable_mp(this, &EditorNetworkProfiler::_update_frame));
+	// Replication
+	replication_display = memnew(Tree);
+	replication_display->set_custom_minimum_size(Size2(320, 0) * EDSCALE);
+	replication_display->set_v_size_flags(SIZE_EXPAND_FILL);
+	replication_display->set_h_size_flags(SIZE_EXPAND_FILL);
+	replication_display->set_hide_folding(true);
+	replication_display->set_hide_root(true);
+	replication_display->set_columns(5);
+	replication_display->set_column_titles_visible(true);
+	replication_display->set_column_title(0, TTR("Root"));
+	replication_display->set_column_expand(0, true);
+	replication_display->set_column_clip_content(0, true);
+	replication_display->set_column_custom_minimum_width(0, 80 * EDSCALE);
+	replication_display->set_column_title(1, TTR("Synchronizer"));
+	replication_display->set_column_expand(1, true);
+	replication_display->set_column_clip_content(1, true);
+	replication_display->set_column_custom_minimum_width(1, 80 * EDSCALE);
+	replication_display->set_column_title(2, TTR("Config"));
+	replication_display->set_column_expand(2, true);
+	replication_display->set_column_clip_content(2, true);
+	replication_display->set_column_custom_minimum_width(2, 80 * EDSCALE);
+	replication_display->set_column_title(3, TTR("Count"));
+	replication_display->set_column_expand(3, false);
+	replication_display->set_column_clip_content(3, true);
+	replication_display->set_column_custom_minimum_width(3, 80 * EDSCALE);
+	replication_display->set_column_title(4, TTR("Size"));
+	replication_display->set_column_expand(4, false);
+	replication_display->set_column_clip_content(4, true);
+	replication_display->set_column_custom_minimum_width(4, 80 * EDSCALE);
+	replication_display->connect("button_clicked", callable_mp(this, &EditorNetworkProfiler::_replication_button_clicked));
+	sc->add_child(replication_display);
+
+	refresh_timer = memnew(Timer);
+	refresh_timer->set_wait_time(0.5);
+	refresh_timer->connect("timeout", callable_mp(this, &EditorNetworkProfiler::_refresh));
+	add_child(refresh_timer);
 }

--- a/modules/multiplayer/editor/editor_network_profiler.h
+++ b/modules/multiplayer/editor/editor_network_profiler.h
@@ -43,30 +43,55 @@
 class EditorNetworkProfiler : public VBoxContainer {
 	GDCLASS(EditorNetworkProfiler, VBoxContainer)
 
+public:
+	struct NodeInfo {
+		ObjectID id;
+		String type;
+		String path;
+
+		NodeInfo() {}
+		NodeInfo(const ObjectID &p_id) {
+			id = p_id;
+			path = String::num_int64(p_id);
+		}
+	};
+
 private:
 	using RPCNodeInfo = MultiplayerDebugger::RPCNodeInfo;
+	using SyncInfo = MultiplayerDebugger::SyncInfo;
 
+	bool dirty = false;
+	Timer *refresh_timer = nullptr;
 	Button *activate = nullptr;
 	Button *clear_button = nullptr;
 	Tree *counters_display = nullptr;
 	LineEdit *incoming_bandwidth_text = nullptr;
 	LineEdit *outgoing_bandwidth_text = nullptr;
+	Tree *replication_display = nullptr;
 
-	Timer *frame_delay = nullptr;
-
-	HashMap<ObjectID, RPCNodeInfo> nodes_data;
-
-	void _update_frame();
+	HashMap<ObjectID, RPCNodeInfo> rpc_data;
+	HashMap<ObjectID, SyncInfo> sync_data;
+	HashMap<ObjectID, NodeInfo> node_data;
+	HashSet<ObjectID> missing_node_data;
+	Ref<Texture2D> node_icon;
 
 	void _activate_pressed();
 	void _clear_pressed();
+	void _refresh();
+	void _replication_button_clicked(TreeItem *p_item, int p_column, int p_idx, MouseButton p_button);
 
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
 public:
-	void add_node_frame_data(RPCNodeInfo p_frame);
+	void refresh_rpc_data();
+	void refresh_replication_data();
+
+	Array pop_missing_node_data();
+	void add_node_data(const NodeInfo &p_info);
+	void add_rpc_frame_data(const RPCNodeInfo &p_frame);
+	void add_sync_frame_data(const SyncInfo &p_frame);
 	void set_bandwidth(int p_incoming, int p_outgoing);
 	bool is_profiling();
 

--- a/modules/multiplayer/editor/multiplayer_editor_plugin.h
+++ b/modules/multiplayer/editor/multiplayer_editor_plugin.h
@@ -42,7 +42,11 @@ class MultiplayerEditorDebugger : public EditorDebuggerPlugin {
 private:
 	HashMap<int, EditorNetworkProfiler *> profilers;
 
+	void _open_request(const String &p_path);
 	void _profiler_activate(bool p_enable, int p_session_id);
+
+protected:
+	static void _bind_methods();
 
 public:
 	virtual bool has_capture(const String &p_capture) const override;
@@ -62,6 +66,7 @@ private:
 	ReplicationEditor *repl_editor = nullptr;
 	Ref<MultiplayerEditorDebugger> debugger;
 
+	void _open_request(const String &p_path);
 	void _node_removed(Node *p_node);
 
 	void _pinned();
@@ -75,7 +80,6 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	MultiplayerEditorPlugin();
-	~MultiplayerEditorPlugin();
 };
 
 #endif // MULTIPLAYER_EDITOR_PLUGIN_H

--- a/modules/multiplayer/multiplayer_debugger.h
+++ b/modules/multiplayer/multiplayer_debugger.h
@@ -35,6 +35,8 @@
 
 #include "core/os/os.h"
 
+class MultiplayerSynchronizer;
+
 class MultiplayerDebugger {
 public:
 	struct RPCNodeInfo {
@@ -48,6 +50,29 @@ public:
 
 	struct RPCFrame {
 		Vector<RPCNodeInfo> infos;
+
+		Array serialize();
+		bool deserialize(const Array &p_arr);
+	};
+
+	struct SyncInfo {
+		ObjectID synchronizer;
+		ObjectID config;
+		ObjectID root_node;
+		int incoming_syncs = 0;
+		int incoming_size = 0;
+		int outgoing_syncs = 0;
+		int outgoing_size = 0;
+
+		void write_to_array(Array &r_arr) const;
+		bool read_from_array(const Array &p_arr, int p_offset);
+
+		SyncInfo() {}
+		SyncInfo(MultiplayerSynchronizer *p_sync);
+	};
+
+	struct ReplicationFrame {
+		HashMap<ObjectID, SyncInfo> infos;
 
 		Array serialize();
 		bool deserialize(const Array &p_arr);
@@ -76,7 +101,6 @@ private:
 	};
 
 	class RPCProfiler : public EngineProfiler {
-	public:
 	private:
 		HashMap<ObjectID, RPCNodeInfo> rpc_node_data;
 		uint64_t last_profile_time = 0;
@@ -88,6 +112,19 @@ private:
 		void add(const Array &p_data);
 		void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time);
 	};
+
+	class ReplicationProfiler : public EngineProfiler {
+	private:
+		HashMap<ObjectID, SyncInfo> sync_data;
+		uint64_t last_profile_time = 0;
+
+	public:
+		void toggle(bool p_enable, const Array &p_opts);
+		void add(const Array &p_data);
+		void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time);
+	};
+
+	static Error _capture(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured);
 
 public:
 	static void initialize();

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -41,12 +41,12 @@
 
 #ifdef DEBUG_ENABLED
 _FORCE_INLINE_ void SceneMultiplayer::_profile_bandwidth(const String &p_what, int p_value) {
-	if (EngineDebugger::is_profiling("multiplayer")) {
+	if (EngineDebugger::is_profiling("multiplayer:bandwidth")) {
 		Array values;
 		values.push_back(p_what);
 		values.push_back(OS::get_singleton()->get_ticks_msec());
 		values.push_back(p_value);
-		EngineDebugger::profiler_add_frame_data("multiplayer", values);
+		EngineDebugger::profiler_add_frame_data("multiplayer:bandwidth", values);
 	}
 }
 #endif

--- a/modules/multiplayer/scene_replication_interface.h
+++ b/modules/multiplayer/scene_replication_interface.h
@@ -105,6 +105,10 @@ private:
 		return p_id.is_valid() ? Object::cast_to<T>(ObjectDB::get_instance(p_id)) : nullptr;
 	}
 
+#ifdef DEBUG_ENABLED
+	_FORCE_INLINE_ void _profile_node_data(const String &p_what, ObjectID p_id, int p_size);
+#endif
+
 public:
 	static void make_default();
 

--- a/modules/multiplayer/scene_rpc_interface.cpp
+++ b/modules/multiplayer/scene_rpc_interface.cpp
@@ -53,12 +53,12 @@
 
 #ifdef DEBUG_ENABLED
 _FORCE_INLINE_ void SceneRPCInterface::_profile_node_data(const String &p_what, ObjectID p_id, int p_size) {
-	if (EngineDebugger::is_profiling("rpc")) {
+	if (EngineDebugger::is_profiling("multiplayer:rpc")) {
 		Array values;
 		values.push_back(p_what);
 		values.push_back(p_id);
 		values.push_back(p_size);
-		EngineDebugger::profiler_add_frame_data("rpc", values);
+		EngineDebugger::profiler_add_frame_data("multiplayer:rpc", values);
 	}
 }
 #endif


### PR DESCRIPTION
Part of the current network profiler stack.
Tracks synchronizers, incoming/outgoing state sizes, and their bandwidth usage.

![icons](https://user-images.githubusercontent.com/1687918/202718184-a8bb172b-0a36-48ab-a1c7-7b99afbe811c.png)

(hovering the node name shows full path in tree).

Draft status:
- [x] #68758 (could probably be squashed together).
- [x] Reintroduce refresh delay with a global timer and a dirty flag.