### PR TITLE
GLAD: don't look for OpenGL if it has been already loaded

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -199,12 +199,16 @@ void RasterizerGLES3::finalize() {
 
 RasterizerGLES3::RasterizerGLES3() {
 #ifdef GLAD_ENABLED
-	if (!gladLoaderLoadGL()) {
-		ERR_PRINT("Error initializing GLAD");
-		// FIXME this is an early return from a constructor.  Any other code using this instance will crash or the finalizer will crash, because none of
-		// the members of this instance are initialized, so this just makes debugging harder.  It should either crash here intentionally,
-		// or we need to actually test for this situation before constructing this.
-		return;
+	if (!GLAD_GL_VERSION_3_3) {
+		if (!gladLoaderLoadGL()) {
+			ERR_PRINT("Error initializing GLAD");
+			// FIXME this is an early return from a constructor.  Any other code using this instance will crash or the finalizer will crash, because none of
+			// the members of this instance are initialized, so this just makes debugging harder.  It should either crash here intentionally,
+			// or we need to actually test for this situation before constructing this.
+			return;
+		}
+	} else {
+		print_verbose("OpenGL 3.3 already initialized, skipping automatic GLAD loading.");
 	}
 #endif
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4911,21 +4911,13 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 		gl_manager = memnew(GLManager_X11(p_resolution, opengl_api_type));
 
 		if (gl_manager->initialize() != OK) {
+			ERR_PRINT("Can't load GLX.");
 			memdelete(gl_manager);
 			gl_manager = nullptr;
 			r_error = ERR_UNAVAILABLE;
 			return;
 		}
 		driver_found = true;
-
-		if (true) {
-			RasterizerGLES3::make_current();
-		} else {
-			memdelete(gl_manager);
-			gl_manager = nullptr;
-			r_error = ERR_UNAVAILABLE;
-			return;
-		}
 	}
 #endif
 	if (!driver_found) {
@@ -4954,6 +4946,16 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 	show_window(main_window);
 	XSync(x11_display, False);
 	_validate_mode_on_map(main_window);
+
+#ifdef GLES3_ENABLED
+	if (rendering_driver == "opengl3") {
+		if (gl_manager->load_gl() != OK) {
+			ERR_FAIL_MSG("Can't load OpenGL.");
+		}
+
+		RasterizerGLES3::make_current();
+	}
+#endif
 
 #if defined(VULKAN_ENABLED)
 	if (rendering_driver == "vulkan") {

--- a/platform/linuxbsd/x11/gl_manager_x11.cpp
+++ b/platform/linuxbsd/x11/gl_manager_x11.cpp
@@ -37,6 +37,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include "thirdparty/glad/glad/gl.h"
 #include "thirdparty/glad/glad/glx.h"
 
 #define GLX_CONTEXT_MAJOR_VERSION_ARB 0x2091
@@ -323,7 +324,15 @@ void GLManager_X11::swap_buffers() {
 
 Error GLManager_X11::initialize() {
 	if (!gladLoaderLoadGLX(nullptr, 0)) {
-		return ERR_CANT_CREATE;
+		return ERR_UNAVAILABLE;
+	}
+
+	return OK;
+}
+
+Error GLManager_X11::load_gl() {
+	if (!gladLoadGL((GLADloadfunc)glXGetProcAddress)) {
+		return ERR_UNAVAILABLE;
 	}
 
 	return OK;

--- a/platform/linuxbsd/x11/gl_manager_x11.h
+++ b/platform/linuxbsd/x11/gl_manager_x11.h
@@ -112,6 +112,7 @@ public:
 	void window_make_current(DisplayServer::WindowID p_window_id);
 
 	Error initialize();
+	Error load_gl();
 
 	void set_use_vsync(bool p_use);
 	bool is_using_vsync() const;


### PR DESCRIPTION
This allows platforms and whatnot to load OpenGL as they please while still providing an automatic fallback for platforms that don't have specific needs.

This also moves the loading to `GLManager_X11` to both show this mechanism in action (run the binary with `--verbose` to see it) and to prepare it for EGL support.