### PR TITLE
Add VS's enc_temp_folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -318,6 +318,7 @@ _ReSharper*/
 
 # Others
 ClientBin/
+enc_temp_folder/
 ~$*
 *.dbmdl
 *.dbproj.schemaview


### PR DESCRIPTION
Visual Studio 2022 occasionally adds an `enc_temp_folder` folder to the main directory. This adds it to `.gitignore`.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
