### PR TITLE
Fix warnings in class ref

### DIFF
--- a/doc/classes/Popup.xml
+++ b/doc/classes/Popup.xml
@@ -4,7 +4,7 @@
 		Popup is a base window container for popup-like subwindows.
 	</brief_description>
 	<description>
-		Popup is a base window container for popup-like subwindows. It's a modal by default (see [member popup_window]) and has helpers for custom popup behavior.
+		Popup is a base window container for popup-like subwindows. It's a modal by default (see [member Window.popup_window]) and has helpers for custom popup behavior.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -82,9 +82,9 @@
 				var rect2 = rect.expand(Vector2(0, -1))
 				[/gdscript]
 				[csharp]
-				# position (-3, 2), size (1, 1)
+				// position (-3, 2), size (1, 1)
 				var rect = new Rect2(new Vector2(-3, 2), new Vector2(1, 1));
-				# position (-3, -1), size (3, 4), so we fit both rect and Vector2(0, -1)
+				// position (-3, -1), size (3, 4), so we fit both rect and Vector2(0, -1)
 				var rect2 = rect.Expand(new Vector2(0, -1));
 				[/csharp]
 				[/codeblocks]

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -79,9 +79,9 @@
 				var rect2 = rect.expand(Vector2i(0, -1))
 				[/gdscript]
 				[csharp]
-				# position (-3, 2), size (1, 1)
+				// position (-3, 2), size (1, 1)
 				var rect = new Rect2i(new Vector2i(-3, 2), new Vector2i(1, 1));
-				# position (-3, -1), size (3, 4), so we fit both rect and Vector2i(0, -1)
+				// position (-3, -1), size (3, 4), so we fit both rect and Vector2i(0, -1)
 				var rect2 = rect.Expand(new Vector2i(0, -1));
 				[/csharp]
 				[/codeblocks]

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -1057,12 +1057,11 @@ def make_rst_class(class_def: ClassDef, state: State, dry_run: bool, output_dir:
             for i, m in enumerate(method_list):
                 if index != 0:
                     f.write("----\n\n")
-
-                if i == 0:
-                    f.write(
-                        f".. _class_{class_name}_operator_{sanitize_operator_name(m.name, state)}_{m.return_type.type_name}:\n\n"
-                    )
-
+                out = f".. _class_{class_name}_operator_{sanitize_operator_name(m.name, state)}"
+                for parameter in m.parameters:
+                    out += f"_{parameter.type_name.type_name}"
+                out += f":\n\n"
+                f.write(out)
                 ret_type, signature = make_method_signature(class_def, m, "", state)
                 f.write(f"- {ret_type} {signature}\n\n")
 
@@ -1168,7 +1167,10 @@ def make_method_signature(
     if isinstance(definition, MethodDef) and ref_type != "":
         if ref_type == "operator":
             op_name = definition.name.replace("<", "\\<")  # So operator "<" gets correctly displayed.
-            out += f":ref:`{op_name}<class_{class_def.name}_{ref_type}_{sanitize_operator_name(definition.name, state)}_{definition.return_type.type_name}>` "
+            out += f":ref:`{op_name}<class_{class_def.name}_{ref_type}_{sanitize_operator_name(definition.name, state)}"
+            for parameter in definition.parameters:
+                out += f"_{parameter.type_name.type_name}"
+            out += f">` "
         else:
             out += f":ref:`{definition.name}<class_{class_def.name}_{ref_type}_{definition.name}>` "
     else:


### PR DESCRIPTION
Fix: `WARNING: Could not lex literal_block as "csharp". Highlighting skipped`
(invalid comment character # instead of //)

Fix: `WARNING: undefined label: class_popup_property_popup_window`
the referenced member needs to reference the parent class

Fix: `WARNING: undefined label: class_basis_operator_mul_vector3`, ...
Operators with the same name didn't create the class ref in the operator description section.

This fix results in: `WARNING: Duplicate explicit target name`
Operators can have the same name and return type, which are used to create the ref identifier, resulting in duplicates.
example: class_float with `vector2` and `vector2i` both returning `vector2`

This change will instead include parameter types and not return types in the identifier, but this can break external links to the operator description.
Internal should all be updated by this change. (I hope...)