### PR TITLE
Fix Tooltips do not work properly when selecting multiple nodes (MultiNodeEdit)

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1655,7 +1655,10 @@ void EditorInspector::update_tree() {
 			StringName classname = object->get_class_name();
 			if (object_class != String()) {
 				classname = object_class;
+			} else if (Object::cast_to<MultiNodeEdit>(object)) {
+				classname = Object::cast_to<MultiNodeEdit>(object)->get_edited_class_name();
 			}
+
 			StringName propname = property_prefix + p.name;
 			String descr;
 			bool found = false;

--- a/editor/multi_node_edit.h
+++ b/editor/multi_node_edit.h
@@ -55,6 +55,7 @@ public:
 
 	int get_node_count() const;
 	NodePath get_node(int p_index) const;
+	StringName get_edited_class_name() const;
 
 	void set_property_field(const StringName &p_property, const Variant &p_value, const String &p_field);
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/68533

The editor inspector will now get the edited class name from the MultiNodeEdit when it is used. The name of the selected nodes is searched in the scene and if not found in the parent class(es).

This is a mostly clean backport from Godot 4.0.

Edit: The commit that fixed this in Godot 4.0: a914dc0c