### PR TITLE
Draw fish bones for Path3D and Path2D in the Editor

### DIFF
--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -106,18 +106,57 @@ void Path2D::_notification(int p_what) {
 #else
 			const real_t line_width = get_tree()->get_debug_paths_width();
 #endif
-			_cached_draw_pts.resize(curve->get_point_count() * 8);
-			int count = 0;
+			real_t interval = 10;
+			const real_t length = curve->get_baked_length();
 
-			for (int i = 0; i < curve->get_point_count(); i++) {
-				for (int j = 0; j < 8; j++) {
-					real_t frac = j * (1.0 / 8.0);
-					Vector2 p = curve->sample(i, frac);
-					_cached_draw_pts.set(count++, p);
+			if (length > CMP_EPSILON) {
+				const int sample_count = int(length / interval) + 2;
+				interval = length / (sample_count - 1); // Recalculate real interval length.
+
+				Vector<Transform2D> frames;
+				frames.resize(sample_count);
+
+				{
+					Transform2D *w = frames.ptrw();
+
+					for (int i = 0; i < sample_count; i++) {
+						w[i] = curve->sample_baked_with_rotation(i * interval, true, true);
+					}
+				}
+
+				const Transform2D *r = frames.ptr();
+				// Draw curve segments
+				{
+					PackedVector2Array v2p;
+					v2p.resize(sample_count);
+					Vector2 *w = v2p.ptrw();
+
+					for (int i = 0; i < sample_count; i++) {
+						w[i] = r[i].get_origin();
+					}
+					draw_polyline(v2p, get_tree()->get_debug_paths_color(), line_width, false);
+				}
+
+				// Draw fish bones
+				{
+					PackedVector2Array v2p;
+					v2p.resize(3);
+					Vector2 *w = v2p.ptrw();
+
+					for (int i = 0; i < sample_count; i++) {
+						const Vector2 p = r[i].get_origin();
+						const Vector2 side = r[i].columns[0];
+						const Vector2 forward = r[i].columns[1];
+
+						// Fish Bone.
+						w[0] = p + (side - forward) * 5;
+						w[1] = p;
+						w[2] = p + (-side - forward) * 5;
+
+						draw_polyline(v2p, get_tree()->get_debug_paths_color(), line_width * 0.5, false);
+					}
 				}
 			}
-
-			draw_polyline(_cached_draw_pts, get_tree()->get_debug_paths_color(), line_width, true);
 		} break;
 	}
 }

--- a/scene/2d/path_2d.h
+++ b/scene/2d/path_2d.h
@@ -38,7 +38,6 @@ class Path2D : public Node2D {
 	GDCLASS(Path2D, Node2D);
 
 	Ref<Curve2D> curve;
-	Vector<Vector2> _cached_draw_pts;
 
 	void _curve_changed();
 

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -1075,18 +1075,36 @@ void RendererCanvasCull::canvas_item_add_polyline(RID p_item, const Vector<Point
 
 void RendererCanvasCull::canvas_item_add_multiline(RID p_item, const Vector<Point2> &p_points, const Vector<Color> &p_colors, float p_width) {
 	ERR_FAIL_COND(p_points.size() < 2);
-	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
-	ERR_FAIL_COND(!canvas_item);
 
-	Item::CommandPolygon *pline = canvas_item->alloc_command<Item::CommandPolygon>();
-	ERR_FAIL_COND(!pline);
+	// TODO: `canvas_item_add_line`(`multiline`, `polyline`) share logic, should factor out.
+	if (p_width <= 1) {
+		Item *canvas_item = canvas_item_owner.get_or_null(p_item);
+		ERR_FAIL_COND(!canvas_item);
 
-	if (true || p_width <= 1) {
-#define TODO make thick lines possible
-
+		Item::CommandPolygon *pline = canvas_item->alloc_command<Item::CommandPolygon>();
+		ERR_FAIL_COND(!pline);
 		pline->primitive = RS::PRIMITIVE_LINES;
 		pline->polygon.create(Vector<int>(), p_points, p_colors);
 	} else {
+		if (p_colors.size() == 1) {
+			Color color = p_colors[0];
+			for (int i = 0; i < p_points.size() >> 1; i++) {
+				Vector2 from = p_points[i * 2 + 0];
+				Vector2 to = p_points[i * 2 + 1];
+
+				canvas_item_add_line(p_item, from, to, color, p_width);
+			}
+		} else if (p_colors.size() == p_points.size() >> 1) {
+			for (int i = 0; i < p_points.size() >> 1; i++) {
+				Color color = p_colors[i];
+				Vector2 from = p_points[i * 2 + 0];
+				Vector2 to = p_points[i * 2 + 1];
+
+				canvas_item_add_line(p_item, from, to, color, p_width);
+			}
+		} else {
+			ERR_FAIL_MSG("Length of p_colors is invalid.");
+		}
 	}
 }
 


### PR DESCRIPTION
Visualize `Path3D` direction and tilt with the so called `fish bones`.

![image](https://user-images.githubusercontent.com/6020486/201499263-b256a6d2-3611-464d-8557-6faafacff5b6.png)

For `Path2D`

<img width="704" alt="Screenshot 2022-11-19 at 15 21 47" src="https://user-images.githubusercontent.com/6020486/202839862-14b97664-76c1-47b6-bfc4-302517dd4a47.png">

For more details, see  https://github.com/godotengine/godot-proposals/issues/5716 and https://github.com/godotengine/godot-proposals/issues/5811