### PR TITLE
Static analysis: remove "break" after "return"

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -487,7 +487,7 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 				euler.z = 0.0f;
 			}
 			return euler;
-		} break;
+		}
 		case EulerOrder::XZY: {
 			// Euler angles in XZY convention.
 			// See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
@@ -516,7 +516,7 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 				euler.z = -Math_PI / 2.0f;
 			}
 			return euler;
-		} break;
+		}
 		case EulerOrder::YXZ: {
 			// Euler angles in YXZ convention.
 			// See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
@@ -554,7 +554,7 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 			}
 
 			return euler;
-		} break;
+		}
 		case EulerOrder::YZX: {
 			// Euler angles in YZX convention.
 			// See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
@@ -639,7 +639,7 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 				euler.z = -Math::atan2(rows[0][1], rows[1][1]);
 			}
 			return euler;
-		} break;
+		}
 		default: {
 			ERR_FAIL_V_MSG(Vector3(), "Invalid parameter for get_euler(order)");
 		}

--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -181,7 +181,7 @@ Plane Projection::get_projection_plane(Planes p_plane) const {
 			new_plane.normal = -new_plane.normal;
 			new_plane.normalize();
 			return new_plane;
-		} break;
+		}
 		case PLANE_FAR: {
 			Plane new_plane = Plane(matrix[3] - matrix[2],
 					matrix[7] - matrix[6],
@@ -191,7 +191,7 @@ Plane Projection::get_projection_plane(Planes p_plane) const {
 			new_plane.normal = -new_plane.normal;
 			new_plane.normalize();
 			return new_plane;
-		} break;
+		}
 		case PLANE_LEFT: {
 			Plane new_plane = Plane(matrix[3] + matrix[0],
 					matrix[7] + matrix[4],
@@ -201,7 +201,7 @@ Plane Projection::get_projection_plane(Planes p_plane) const {
 			new_plane.normal = -new_plane.normal;
 			new_plane.normalize();
 			return new_plane;
-		} break;
+		}
 		case PLANE_TOP: {
 			Plane new_plane = Plane(matrix[3] - matrix[1],
 					matrix[7] - matrix[5],
@@ -211,7 +211,7 @@ Plane Projection::get_projection_plane(Planes p_plane) const {
 			new_plane.normal = -new_plane.normal;
 			new_plane.normalize();
 			return new_plane;
-		} break;
+		}
 		case PLANE_RIGHT: {
 			Plane new_plane = Plane(matrix[3] - matrix[0],
 					matrix[7] - matrix[4],
@@ -221,7 +221,7 @@ Plane Projection::get_projection_plane(Planes p_plane) const {
 			new_plane.normal = -new_plane.normal;
 			new_plane.normalize();
 			return new_plane;
-		} break;
+		}
 		case PLANE_BOTTOM: {
 			Plane new_plane = Plane(matrix[3] + matrix[1],
 					matrix[7] + matrix[5],
@@ -231,7 +231,7 @@ Plane Projection::get_projection_plane(Planes p_plane) const {
 			new_plane.normal = -new_plane.normal;
 			new_plane.normalize();
 			return new_plane;
-		} break;
+		}
 	}
 
 	return Plane();


### PR DESCRIPTION
Changes as requested to keep in sync with godotengine/godot-cpp#929
