### PR TITLE
Fix drawing of 2D skeletons in the RD renderer.

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -153,48 +153,6 @@ void main() {
 		uv += 1e-5;
 	}
 
-#ifdef USE_ATTRIBUTES
-#if 0
-	if (bool(draw_data[draw_data_instance].flags & FLAGS_USE_SKELETON) && bone_weights != vec4(0.0)) { //must be a valid bone
-		//skeleton transform
-		ivec4 bone_indicesi = ivec4(bone_indices);
-
-		uvec2 tex_ofs = bone_indicesi.x * 2;
-
-		mat2x4 m;
-		m = mat2x4(
-					texelFetch(skeleton_buffer, tex_ofs + 0),
-					texelFetch(skeleton_buffer, tex_ofs + 1)) *
-			bone_weights.x;
-
-		tex_ofs = bone_indicesi.y * 2;
-
-		m += mat2x4(
-					 texelFetch(skeleton_buffer, tex_ofs + 0),
-					 texelFetch(skeleton_buffer, tex_ofs + 1)) *
-			 bone_weights.y;
-
-		tex_ofs = bone_indicesi.z * 2;
-
-		m += mat2x4(
-					 texelFetch(skeleton_buffer, tex_ofs + 0),
-					 texelFetch(skeleton_buffer, tex_ofs + 1)) *
-			 bone_weights.z;
-
-		tex_ofs = bone_indicesi.w * 2;
-
-		m += mat2x4(
-					 texelFetch(skeleton_buffer, tex_ofs + 0),
-					 texelFetch(skeleton_buffer, tex_ofs + 1)) *
-			 bone_weights.w;
-
-		mat4 bone_matrix = skeleton_data.skeleton_transform * transpose(mat4(m[0], m[1], vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0))) * skeleton_data.skeleton_transform_inverse;
-
-		//outvec = bone_matrix * outvec;
-	}
-#endif
-#endif
-
 	vertex = (canvas_transform * vec4(vertex, 0.0, 1.0)).xy;
 
 	vertex_interp = vertex;

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -114,7 +114,7 @@ void Polygon2D::_notification(int p_what) {
 
 			ObjectID new_skeleton_id;
 
-			if (skeleton_node) {
+			if (skeleton_node && !invert && bone_weights.size()) {
 				RS::get_singleton()->canvas_item_attach_skeleton(get_canvas_item(), skeleton_node->get_skeleton());
 				new_skeleton_id = skeleton_node->get_instance_id();
 			} else {

--- a/servers/rendering/renderer_canvas_render.cpp
+++ b/servers/rendering/renderer_canvas_render.cpp
@@ -32,7 +32,7 @@
 #include "servers/rendering/rendering_server_globals.h"
 
 const Rect2 &RendererCanvasRender::Item::get_rect() const {
-	if (custom_rect || (!rect_dirty && !update_when_visible)) {
+	if (custom_rect || (!rect_dirty && !update_when_visible && skeleton == RID())) {
 		return rect;
 	}
 
@@ -80,7 +80,7 @@ const Rect2 &RendererCanvasRender::Item::get_rect() const {
 			} break;
 			case Item::Command::TYPE_MESH: {
 				const Item::CommandMesh *mesh = static_cast<const Item::CommandMesh *>(c);
-				AABB aabb = RSG::mesh_storage->mesh_get_aabb(mesh->mesh, RID());
+				AABB aabb = RSG::mesh_storage->mesh_get_aabb(mesh->mesh, skeleton);
 
 				r = Rect2(aabb.position.x, aabb.position.y, aabb.size.x, aabb.size.y);
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2681,16 +2681,6 @@ RendererCanvasRenderRD::RendererCanvasRenderRD() {
 		primitive_arrays.index_array[3] = shader.quad_index_array = RD::get_singleton()->index_array_create(shader.quad_index_buffer, 0, 6);
 	}
 
-	{ //default skeleton buffer
-
-		shader.default_skeleton_uniform_buffer = RD::get_singleton()->uniform_buffer_create(sizeof(SkeletonUniform));
-		SkeletonUniform su;
-		_update_transform_2d_to_mat4(Transform2D(), su.skeleton_inverse);
-		_update_transform_2d_to_mat4(Transform2D(), su.skeleton_transform);
-		RD::get_singleton()->buffer_update(shader.default_skeleton_uniform_buffer, 0, sizeof(SkeletonUniform), &su);
-
-		shader.default_skeleton_texture_buffer = RD::get_singleton()->texture_buffer_create(32, RD::DATA_FORMAT_R32G32B32A32_SFLOAT);
-	}
 	{
 		//default shadow texture to keep uniform set happy
 		RD::TextureFormat tf;
@@ -2834,8 +2824,6 @@ RendererCanvasRenderRD::~RendererCanvasRenderRD() {
 
 		memdelete_arr(state.light_uniforms);
 		RD::get_singleton()->free(state.lights_uniform_buffer);
-		RD::get_singleton()->free(shader.default_skeleton_uniform_buffer);
-		RD::get_singleton()->free(shader.default_skeleton_texture_buffer);
 	}
 
 	//shadow rendering

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -144,10 +144,6 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		RID quad_index_array;
 		PipelineVariants pipeline_variants;
 
-		// default_skeleton uniform set
-		RID default_skeleton_uniform_buffer;
-		RID default_skeleton_texture_buffer;
-
 		ShaderCompiler compiler;
 	} shader;
 
@@ -407,11 +403,6 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		};
 		float color_texture_pixel_size[2];
 		uint32_t lights[4];
-	};
-
-	struct SkeletonUniform {
-		float skeleton_transform[16];
-		float skeleton_inverse[16];
 	};
 
 	Item *items[MAX_RENDER_ITEMS];

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -191,48 +191,6 @@ void main() {
 		uv += 1e-5;
 	}
 
-#ifdef USE_ATTRIBUTES
-#if 0
-	if (bool(draw_data.flags & FLAGS_USE_SKELETON) && bone_weights != vec4(0.0)) { //must be a valid bone
-		//skeleton transform
-		ivec4 bone_indicesi = ivec4(bone_indices);
-
-		uvec2 tex_ofs = bone_indicesi.x * 2;
-
-		mat2x4 m;
-		m = mat2x4(
-					texelFetch(skeleton_buffer, tex_ofs + 0),
-					texelFetch(skeleton_buffer, tex_ofs + 1)) *
-			bone_weights.x;
-
-		tex_ofs = bone_indicesi.y * 2;
-
-		m += mat2x4(
-					 texelFetch(skeleton_buffer, tex_ofs + 0),
-					 texelFetch(skeleton_buffer, tex_ofs + 1)) *
-			 bone_weights.y;
-
-		tex_ofs = bone_indicesi.z * 2;
-
-		m += mat2x4(
-					 texelFetch(skeleton_buffer, tex_ofs + 0),
-					 texelFetch(skeleton_buffer, tex_ofs + 1)) *
-			 bone_weights.z;
-
-		tex_ofs = bone_indicesi.w * 2;
-
-		m += mat2x4(
-					 texelFetch(skeleton_buffer, tex_ofs + 0),
-					 texelFetch(skeleton_buffer, tex_ofs + 1)) *
-			 bone_weights.w;
-
-		mat4 bone_matrix = skeleton_data.skeleton_transform * transpose(mat4(m[0], m[1], vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0))) * skeleton_data.skeleton_transform_inverse;
-
-		//outvec = bone_matrix * outvec;
-	}
-#endif
-#endif
-
 	vertex = (canvas_data.canvas_transform * vec4(vertex, 0.0, 1.0)).xy;
 
 	vertex_interp = vertex;

--- a/servers/rendering/renderer_rd/shaders/skeleton.glsl
+++ b/servers/rendering/renderer_rd/shaders/skeleton.glsl
@@ -143,8 +143,8 @@ void main() {
 		uint skin_offset = params.skin_stride * index;
 
 		uvec2 bones = uvec2(src_bone_weights.data[skin_offset + 0], src_bone_weights.data[skin_offset + 1]);
-		uvec2 bones_01 = uvec2(bones.x & 0xFFFF, bones.x >> 16) * 3; //pre-add xform offset
-		uvec2 bones_23 = uvec2(bones.y & 0xFFFF, bones.y >> 16) * 3;
+		uvec2 bones_01 = uvec2(bones.x & 0xFFFF, bones.x >> 16) * 2; //pre-add xform offset
+		uvec2 bones_23 = uvec2(bones.y & 0xFFFF, bones.y >> 16) * 2;
 
 		skin_offset += params.skin_weight_offset;
 
@@ -161,6 +161,13 @@ void main() {
 		//reverse order because its transposed
 		vertex = (vec4(vertex, 0.0, 1.0) * m).xy;
 	}
+
+	uint dst_offset = index * params.vertex_stride;
+
+	uvec2 uvertex = floatBitsToUint(vertex);
+	dst_vertices.data[dst_offset + 0] = uvertex.x;
+	dst_vertices.data[dst_offset + 1] = uvertex.y;
+
 #else
 	vec3 vertex;
 	vec3 normal;

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -616,7 +616,7 @@ AABB MeshStorage::mesh_get_aabb(RID p_mesh, RID p_skeleton) {
 
 	Skeleton *skeleton = skeleton_owner.get_or_null(p_skeleton);
 
-	if (!skeleton || skeleton->size == 0) {
+	if (!skeleton || skeleton->size == 0 || mesh->skeleton_aabb_version == skeleton->version) {
 		return mesh->aabb;
 	}
 
@@ -708,6 +708,7 @@ AABB MeshStorage::mesh_get_aabb(RID p_mesh, RID p_skeleton) {
 		}
 	}
 
+	mesh->skeleton_aabb_version = skeleton->version;
 	return aabb;
 }
 

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
@@ -144,6 +144,7 @@ private:
 
 		AABB aabb;
 		AABB custom_aabb;
+		uint64_t skeleton_aabb_version = 0;
 
 		Vector<RID> material_cache;
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/59451
Fixes: https://github.com/godotengine/godot/issues/35726

There were multiple issues:
1. The renderer expects bones if a mesh uses a Skeleton. So if we don't have any bones assigned yet, do not register the skeleton with the RenderingServer (thats the change in polygon_2d.cpp)
2. The skeleton shader wasn't writing any values out at the end (simply add a write to the destination vertex buffer)
3. The skeleton shader erroneously had some values copied from the 3D version (change stride from 3 to 2)
4. Skeletons were culled if the rest pose went outside of the viewport

To solve the culling issue we do 2 things:
1. When a canvas item has a skeleton we always request the AABB from the rendering server
2. In the rendering server we check if the skeleton has changed since the last time the AABB was generated. If it has changed, we regenerate the AABB. This fix is similar to https://github.com/godotengine/godot/pull/63071 except in 4.0 we can keep the logic close to where the mesh and skeleton are updated

The first two problems stopped Skeletons from working at all. After I solved those I discovered the other problems and slowly added to this PR. 

The rest of the code is removing dead code that hasn't been doing anything. I'm doing this in preparation for fixing up some other lingering problems with 2D skeletons and adding skeletons to GLES3. Now that Skeletons are working well in the RD renderer I can add Skeletons to the GLES3 renderer

