### PR TITLE
Add handles to control Curve3D tilt

### DIFF
--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -39,14 +39,14 @@
 #include "node_3d_editor_plugin.h"
 #include "scene/resources/curve.h"
 
-static Vector3 _get_curve_point_up_vector(const Ref<Curve3D> & c, int index, bool tilt) {
+static Vector3 _get_curve_point_up_vector(const Ref<Curve3D> &c, int index, bool tilt) {
 	// TODO: Get offset in a cleaner, more direct way.
 	Vector3 pos = c->get_point_position(index);
 	real_t t = c->get_closest_offset(pos);
 	return c->sample_baked_up_vector(t, tilt);
 }
 
-static Vector3 _get_curve_point_tangent(const Ref<Curve3D> & c, int index) {
+static Vector3 _get_curve_point_tangent(const Ref<Curve3D> &c, int index) {
 	Vector3 pos = c->get_point_position(index);
 	real_t t = c->get_closest_offset(pos);
 
@@ -375,8 +375,7 @@ void Path3DGizmo::redraw() {
 
 		// Put the tilt related handles first to massively simplify handle identification in
 		// {get,set,commit}_handle().
-		if (c->is_up_vector_enabled())
-		{
+		if (c->is_up_vector_enabled()) {
 			for (int i = 0; i < c->get_point_count(); i++) {
 				Vector3 p = c->get_point_position(i);
 				Vector3 up = _get_curve_point_up_vector(c, i, true);


### PR DESCRIPTION
First PR, please be gentle, I tried to read the relevant contributing guides but I'm happy to correct anything I've missed.


This change allows interactive modification of the tilt values of a Curve3D.

Because the up vector is difficult to predict ahead of time, and changes in ways that are unintuitive (at least to me!) it was difficult to make good use of them. There's at least two of us who think this :wink: See #47445 

This change allows for a more intuitive way to edit tilts and affect the up vector along the path. The handles point in the direction of the up vector, with tilt applied, and only appear when up vectors are enabled on the underlying curve.

![2022-11-18-224955_1916x989_scrot](https://user-images.githubusercontent.com/18740/202834770-3170cc43-0da7-4024-aa4c-2ae1ef0745f0.png)
![2022-11-18-225017_1916x989_scrot](https://user-images.githubusercontent.com/18740/202834771-4c137853-937e-4f02-83d3-a86ca464bfe6.png)

I think its usefullness is more apparent with a CSGPolygon3D that uses the tilt values (cherry pick the tip of https://github.com/Ademan/godot/tree/wip_csg_use_up_vector and you'll get something more exciting like this:

![2022-11-18-224450_1916x989_scrot](https://user-images.githubusercontent.com/18740/202834617-b9abef62-c183-4e1c-a441-ae32aedd7745.png)

The major drawbacks of this change are

1. More handles create more clutter
2. These handles aren't visually distinguished from in/out handles
3. The way this code calculates offset into the curve is prone to some inaccuracy, but it's been acceptable in my experience.