### PR TITLE
[macOS] Dynamically attach and detach transient windows to allow them to stay on top of parent and be moved to another screen.

### DIFF
--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -233,6 +233,7 @@ public:
 	void popup_close(WindowID p_window);
 	void set_is_resizing(bool p_is_resizing);
 	bool get_is_resizing() const;
+	void reparent_check(WindowID p_window);
 
 	void window_update(WindowID p_window);
 	void window_destroy(WindowID p_window);

--- a/platform/macos/godot_window_delegate.mm
+++ b/platform/macos/godot_window_delegate.mm
@@ -256,6 +256,15 @@
 	}
 }
 
+- (void)windowDidChangeScreen:(NSNotification *)notification {
+	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
+	if (!ds || !ds->has_window(window_id)) {
+		return;
+	}
+
+	ds->reparent_check(window_id);
+}
+
 - (void)windowDidMove:(NSNotification *)notification {
 	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
 	if (!ds || !ds->has_window(window_id)) {


### PR DESCRIPTION
By default, child windows macOS (which stay on top of parent and moved when parent is moved) can't be moved to another screen (will end up off-screen and unusable).

This PR dynamically attach and detach the transient window to ensure it is a child window only when it is on the same screen as its transient parent. This will make floating editor windows stay on top of the main window, like it does on the other platforms.