### PR TITLE
Use a modern font stack for system font aliases on Windows, macOS and iOS

### DIFF
--- a/platform/ios/os_ios.mm
+++ b/platform/ios/os_ios.mm
@@ -392,11 +392,11 @@ Vector<String> OS_IOS::get_system_fonts() const {
 String OS_IOS::_get_default_fontname(const String &p_font_name) const {
 	String font_name = p_font_name;
 	if (font_name.to_lower() == "sans-serif") {
-		font_name = "Helvetica";
+		font_name = "SF Pro";
 	} else if (font_name.to_lower() == "serif") {
-		font_name = "Times";
+		font_name = "New York";
 	} else if (font_name.to_lower() == "monospace") {
-		font_name = "Courier";
+		font_name = "SF Mono";
 	} else if (font_name.to_lower() == "fantasy") {
 		font_name = "Papyrus";
 	} else if (font_name.to_lower() == "cursive") {

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -391,11 +391,11 @@ Vector<String> OS_MacOS::get_system_fonts() const {
 String OS_MacOS::_get_default_fontname(const String &p_font_name) const {
 	String font_name = p_font_name;
 	if (font_name.to_lower() == "sans-serif") {
-		font_name = "Helvetica";
+		font_name = "SF Pro";
 	} else if (font_name.to_lower() == "serif") {
-		font_name = "Times";
+		font_name = "New York";
 	} else if (font_name.to_lower() == "monospace") {
-		font_name = "Courier";
+		font_name = "SF Mono";
 	} else if (font_name.to_lower() == "fantasy") {
 		font_name = "Papyrus";
 	} else if (font_name.to_lower() == "cursive") {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1048,11 +1048,11 @@ public:
 String OS_Windows::_get_default_fontname(const String &p_font_name) const {
 	String font_name = p_font_name;
 	if (font_name.to_lower() == "sans-serif") {
-		font_name = "Arial";
+		font_name = "Segoe UI";
 	} else if (font_name.to_lower() == "serif") {
-		font_name = "Times New Roman";
+		font_name = "Cambria";
 	} else if (font_name.to_lower() == "monospace") {
-		font_name = "Courier New";
+		font_name = "Consolas";
 	} else if (font_name.to_lower() == "cursive") {
 		font_name = "Comic Sans MS";
 	} else if (font_name.to_lower() == "fantasy") {


### PR DESCRIPTION
This closes https://github.com/godotengine/godot-proposals/issues/5767.

**Testing project:** [test_system_font_alias.zip](https://github.com/godotengine/godot/files/10047942/test_system_font_alias.zip)

## TODO

- [x] Test on Windows.
- [ ] Test on macOS.
- [ ] Test on iOS.
- [ ] Rewrite Linux system font alias usage to manually check for known font names, rather than relying on fontconfig for picking a (usually old-looking) font.

## Preview

*Fedora 36 (no change compared to before).*

![2022-11-19_21 49 53](https://user-images.githubusercontent.com/180032/202871455-6d6e28aa-dd6c-4b46-b25d-7ac911125e9e.png)

### Windows

#### Before

![Screenshot 2023-08-07 181002](https://github.com/godotengine/godot/assets/180032/80a1694e-a385-4459-b4c4-d1127b14c388)

#### After

![Screenshot 2023-08-07 180943](https://github.com/godotengine/godot/assets/180032/323cc9ad-17d1-4a4a-872c-7b881a3f90c6)