### PR TITLE
Fix connection of animation "changed" signal in AnimationTrackEditor

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -568,13 +568,6 @@
 			The animation step value.
 		</member>
 	</members>
-	<signals>
-		<signal name="tracks_changed">
-			<description>
-				Emitted when there's a change in the list of tracks, e.g. tracks are added, moved or have changed paths.
-			</description>
-		</signal>
-	</signals>
 	<constants>
 		<constant name="TYPE_VALUE" value="0" enum="TrackType">
 			Value tracks set values in node properties, but only those which can be interpolated. For 3D position/rotation/scale, using the dedicated [constant TYPE_POSITION_3D], [constant TYPE_ROTATION_3D] and [constant TYPE_SCALE_3D] track types instead of [constant TYPE_VALUE] is recommended for performance reasons.

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3446,8 +3446,7 @@ void AnimationTrackEditor::set_animation(const Ref<Animation> &p_anim, bool p_re
 		track_edits[_get_track_selected()]->release_focus();
 	}
 	if (animation.is_valid()) {
-		animation->disconnect("tracks_changed", callable_mp(this, &AnimationTrackEditor::_animation_changed));
-		animation->disconnect("changed", callable_mp(this, &AnimationTrackEditor::_sync_animation_change));
+		animation->disconnect("changed", callable_mp(this, &AnimationTrackEditor::_animation_changed));
 		_clear_selection();
 	}
 	animation = p_anim;
@@ -3458,8 +3457,7 @@ void AnimationTrackEditor::set_animation(const Ref<Animation> &p_anim, bool p_re
 	_update_tracks();
 
 	if (animation.is_valid()) {
-		animation->connect("tracks_changed", callable_mp(this, &AnimationTrackEditor::_animation_changed), CONNECT_DEFERRED);
-		animation->connect("changed", callable_mp(this, &AnimationTrackEditor::_sync_animation_change), CONNECT_DEFERRED);
+		animation->connect("changed", callable_mp(this, &AnimationTrackEditor::_animation_changed), CONNECT_DEFERRED);
 
 		hscroll->show();
 		edit->set_disabled(read_only);
@@ -4648,10 +4646,6 @@ void AnimationTrackEditor::_redraw_groups() {
 	for (int i = 0; i < groups.size(); i++) {
 		groups[i]->queue_redraw();
 	}
-}
-
-void AnimationTrackEditor::_sync_animation_change() {
-	bezier_edit->queue_redraw();
 }
 
 void AnimationTrackEditor::_animation_changed() {

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -328,7 +328,6 @@ class AnimationTrackEditor : public VBoxContainer {
 	bool animation_changing_awaiting_update = false;
 	void _animation_update(); // Updated by AnimationTrackEditor(this)
 	int _get_track_selected();
-	void _sync_animation_change();
 	void _animation_changed();
 	void _update_tracks();
 	void _redraw_tracks();

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1442,11 +1442,11 @@ void AnimationPlayer::remove_animation_library(const StringName &p_name) {
 }
 
 void AnimationPlayer::_ref_anim(const Ref<Animation> &p_anim) {
-	Ref<Animation>(p_anim)->connect(SceneStringNames::get_singleton()->tracks_changed, callable_mp(this, &AnimationPlayer::_animation_changed), CONNECT_REFERENCE_COUNTED);
+	Ref<Animation>(p_anim)->connect("changed", callable_mp(this, &AnimationPlayer::_animation_changed), CONNECT_REFERENCE_COUNTED);
 }
 
 void AnimationPlayer::_unref_anim(const Ref<Animation> &p_anim) {
-	Ref<Animation>(p_anim)->disconnect(SceneStringNames::get_singleton()->tracks_changed, callable_mp(this, &AnimationPlayer::_animation_changed));
+	Ref<Animation>(p_anim)->disconnect("changed", callable_mp(this, &AnimationPlayer::_animation_changed));
 }
 
 void AnimationPlayer::rename_animation_library(const StringName &p_name, const StringName &p_new_name) {

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -888,7 +888,6 @@ int Animation::add_track(TrackType p_type, int p_at_pos) {
 		}
 	}
 	emit_changed();
-	emit_signal(SceneStringNames::get_singleton()->tracks_changed);
 	return p_at_pos;
 }
 
@@ -951,7 +950,6 @@ void Animation::remove_track(int p_track) {
 	memdelete(t);
 	tracks.remove_at(p_track);
 	emit_changed();
-	emit_signal(SceneStringNames::get_singleton()->tracks_changed);
 }
 
 int Animation::get_track_count() const {
@@ -967,7 +965,6 @@ void Animation::track_set_path(int p_track, const NodePath &p_path) {
 	ERR_FAIL_INDEX(p_track, tracks.size());
 	tracks[p_track]->path = p_path;
 	emit_changed();
-	emit_signal(SceneStringNames::get_singleton()->tracks_changed);
 }
 
 NodePath Animation::track_get_path(int p_track) const {
@@ -3834,7 +3831,6 @@ void Animation::track_move_up(int p_track) {
 	}
 
 	emit_changed();
-	emit_signal(SceneStringNames::get_singleton()->tracks_changed);
 }
 
 void Animation::track_move_down(int p_track) {
@@ -3843,7 +3839,6 @@ void Animation::track_move_down(int p_track) {
 	}
 
 	emit_changed();
-	emit_signal(SceneStringNames::get_singleton()->tracks_changed);
 }
 
 void Animation::track_move_to(int p_track, int p_to_index) {
@@ -3859,7 +3854,6 @@ void Animation::track_move_to(int p_track, int p_to_index) {
 	tracks.insert(p_to_index > p_track ? p_to_index - 1 : p_to_index, track);
 
 	emit_changed();
-	emit_signal(SceneStringNames::get_singleton()->tracks_changed);
 }
 
 void Animation::track_swap(int p_track, int p_with_track) {
@@ -3871,7 +3865,6 @@ void Animation::track_swap(int p_track, int p_with_track) {
 	SWAP(tracks.write[p_track], tracks.write[p_with_track]);
 
 	emit_changed();
-	emit_signal(SceneStringNames::get_singleton()->tracks_changed);
 }
 
 void Animation::set_step(real_t p_step) {
@@ -4001,8 +3994,6 @@ void Animation::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "loop_mode", PROPERTY_HINT_ENUM, "None,Linear,Ping-Pong"), "set_loop_mode", "get_loop_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "step", PROPERTY_HINT_RANGE, "0,4096,0.001,suffix:s"), "set_step", "get_step");
 
-	ADD_SIGNAL(MethodInfo("tracks_changed"));
-
 	BIND_ENUM_CONSTANT(TYPE_VALUE);
 	BIND_ENUM_CONSTANT(TYPE_POSITION_3D);
 	BIND_ENUM_CONSTANT(TYPE_ROTATION_3D);
@@ -4041,7 +4032,6 @@ void Animation::clear() {
 	compression.pages.clear();
 	compression.fps = 120;
 	emit_changed();
-	emit_signal(SceneStringNames::get_singleton()->tracks_changed);
 }
 
 bool Animation::_float_track_optimize_key(const TKey<float> t0, const TKey<float> t1, const TKey<float> t2, real_t p_allowed_velocity_err, real_t p_allowed_precision_error) {

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -206,8 +206,6 @@ SceneStringNames::SceneStringNames() {
 	theme_changed = StaticCString::create("theme_changed");
 	parameters_base_path = "parameters/";
 
-	tracks_changed = "tracks_changed";
-
 	shader_overrides_group = StaticCString::create("_shader_overrides_group_");
 	shader_overrides_group_active = StaticCString::create("_shader_overrides_group_active_");
 

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -209,8 +209,6 @@ public:
 
 	StringName parameters_base_path;
 
-	StringName tracks_changed;
-
 	StringName _window_group;
 	StringName _window_input;
 	StringName _window_unhandled_input;


### PR DESCRIPTION
Follow up #64647.

Since the signal connection method was unwillingly changed, there is a bug in the GUI update. This PR fix that.

Before:

https://user-images.githubusercontent.com/61938263/202873025-f8182d65-67c4-4c55-9fad-891332bbe407.mp4

After fix:

https://user-images.githubusercontent.com/61938263/202873031-f83f89f9-5a19-481f-8fd0-c1e2ddeb4d64.mp4

Also, the signal `"tracks_changed"` is almost equivalent to `"changed"`, and there is no reason to exist it separately, so I remove that signal.