### PR TITLE
Clarify what happens when return value is discarded in GDScript warning text

### DIFF
--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -96,7 +96,7 @@ String GDScriptWarning::get_message() const {
 		} break;
 		case RETURN_VALUE_DISCARDED: {
 			CHECK_SYMBOLS(1);
-			return "The function '" + symbols[0] + "()' returns a value, but this value is never used.";
+			return "The function '" + symbols[0] + "()' returns a value that will be discarded if not used.";
 		} break;
 		case PROPERTY_USED_AS_FUNCTION: {
 			CHECK_SYMBOLS(2);

--- a/modules/gdscript/tests/scripts/parser/warnings/return_value_discarded.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/return_value_discarded.out
@@ -2,4 +2,4 @@ GDTEST_OK
 >> WARNING
 >> Line: 6
 >> RETURN_VALUE_DISCARDED
->> The function 'i_return_int()' returns a value, but this value is never used.
+>> The function 'i_return_int()' returns a value that will be discarded if not used.


### PR DESCRIPTION
Fixes #68896.

Improve `RETURN_VALUE_DISCARDED` warning text by clarifying that the return value of a function isn't just unused, but discarded.

This change makes the warning more consistent with the language of similar 'discarded' warnings, such as `INTEGER_DIVISION` (see below). This will also make it easier for users to find "Return Value Discarded" in Project Settings -> Debug -> GDScript, as the previous warning text implied it would be found with the prefix "Unused."

### **Before:**
![before-warning](https://user-images.githubusercontent.com/89402588/202881365-6cb27ac2-d07a-485c-9fde-e6718514790c.png)

### **After:**
![update_after](https://user-images.githubusercontent.com/89402588/202919425-6a589aaa-6d86-499e-a03d-4ea3b34e2ef8.png)
