### PR TITLE
[Export] Use image loader directly to avoid "resource as image file" errors.

### DIFF
--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -666,7 +666,7 @@ Error EditorExportPlatformIOS::_export_loading_screen_file(const Ref<EditorExpor
 		Ref<Image> image;
 		String image_path = p_dest_dir.path_join("splash@2x.png");
 		image.instantiate();
-		Error err = image->load(custom_launch_image_2x);
+		Error err = ImageLoader::load_image(custom_launch_image_2x, image);
 
 		if (err) {
 			image.unref();
@@ -680,7 +680,7 @@ Error EditorExportPlatformIOS::_export_loading_screen_file(const Ref<EditorExpor
 		image.unref();
 		image_path = p_dest_dir.path_join("splash@3x.png");
 		image.instantiate();
-		err = image->load(custom_launch_image_3x);
+		err = ImageLoader::load_image(custom_launch_image_3x, image);
 
 		if (err) {
 			image.unref();
@@ -697,7 +697,7 @@ Error EditorExportPlatformIOS::_export_loading_screen_file(const Ref<EditorExpor
 
 		if (!splash_path.is_empty()) {
 			splash.instantiate();
-			const Error err = splash->load(splash_path);
+			const Error err = ImageLoader::load_image(splash_path, splash);
 			if (err) {
 				splash.unref();
 			}

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -34,6 +34,7 @@
 #include "lipo.h"
 #include "macho.h"
 
+#include "core/io/image_loader.h"
 #include "core/string/translation.h"
 #include "editor/editor_node.h"
 #include "editor/editor_paths.h"
@@ -1269,8 +1270,10 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 						icon->get_buffer(&data.write[0], icon->get_length());
 					}
 				} else {
-					Ref<Image> icon = Image::load_from_file(iconpath);
-					if (icon.is_valid() && !icon->is_empty()) {
+					Ref<Image> icon;
+					icon.instantiate();
+					err = ImageLoader::load_image(iconpath, icon);
+					if (err == OK && !icon->is_empty()) {
 						_make_icon(p_preset, icon, data);
 					}
 				}

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -31,6 +31,7 @@
 #include "export_plugin.h"
 
 #include "core/config/project_settings.h"
+#include "core/io/image_loader.h"
 #include "editor/editor_node.h"
 #include "editor/editor_paths.h"
 
@@ -84,8 +85,10 @@ Error EditorExportPlatformWindows::_process_icon(const Ref<EditorExportPreset> &
 			f->seek(prev_offset);
 		}
 	} else {
-		Ref<Image> src_image = Image::load_from_file(p_src_path);
-		ERR_FAIL_COND_V(src_image.is_null() || src_image->is_empty(), ERR_CANT_OPEN);
+		Ref<Image> src_image;
+		src_image.instantiate();
+		err = ImageLoader::load_image(p_src_path, src_image);
+		ERR_FAIL_COND_V(err != OK || src_image->is_empty(), ERR_CANT_OPEN);
 		for (size_t i = 0; i < sizeof(icon_size) / sizeof(icon_size[0]); ++i) {
 			int size = (icon_size[i] == 0) ? 256 : icon_size[i];
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/68915