### PR TITLE
Fix lua-style dictionary operator performance

### DIFF
--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1308,6 +1308,9 @@ private:
 	void reset_extents(Node *p_node, GDScriptTokenizer::Token p_token);
 	void reset_extents(Node *p_node, Node *p_from);
 
+	Node *find_previous(const Node *p_node);
+	void convert_subscript_identifier_to_literal(SubscriptNode *p_sub);
+
 	template <class T>
 	T *alloc_node() {
 		T *node = memnew(T);


### PR DESCRIPTION
Fixes #68834.

![Untitled](https://user-images.githubusercontent.com/1133892/202915002-1ad6f21d-559d-4ae1-b699-cff7df03c35b.png)

I'm having the GDScript analyzer replace an `IdentifierNode` with a `LiteralNode` so the behavior of `dict.someIndex` becomes the same as `dict["someIndex"]`.

I don't believe I can do this in the parser, because the parser does not know whether `dict` is a dictionary or not. That is something the analyzer infers.

Unfortunately, this does require us to go into `GDScriptParser`'s singly-linked list `list` and do a search for the `IdentifierNode` so we can remove it from there and replace it with the `LiteralNode`. For large scripts, this is not very efficient at all. If `GDScriptParser::Node` had a `prev` as well as a `next`, then it would become a doubly-linked list and be `O(1)` instead of `O(n)`, where `n` is the number of parse nodes in a script.

I will likely add some more documentation in the future, but technically, this is ready for review.


Quick note: I really only added `if (base_type.kind == GDScriptParser::DataType::BUILTIN && base_type.builtin_type == Variant::DICTIONARY && p_subscript->attribute->type == GDScriptParser::Node::IDENTIFIER) { ... }`. The rest of the lines are counting as added lines but only because they got indented inside the `else`.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
