### PR TITLE
GDScript: Cache scripts after parse error

### DIFF
--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -242,11 +242,9 @@ Ref<GDScript> GDScriptCache::get_shallow_script(const String &p_path, Error &r_e
 	script->load_source_code(p_path);
 
 	Ref<GDScriptParserRef> parser_ref = get_parser(p_path, GDScriptParserRef::PARSED, r_error);
-	if (r_error != OK) {
-		return script;
+	if (r_error == OK) {
+		GDScriptCompiler::make_scripts(script.ptr(), parser_ref->get_parser()->get_tree(), true);
 	}
-
-	GDScriptCompiler::make_scripts(script.ptr(), parser_ref->get_parser()->get_tree(), true);
 
 	singleton->shallow_gdscript_cache[p_path] = script;
 	return script;


### PR DESCRIPTION
@Rindbee pointed out that #68374 doesn't cache scripts after parsing errors like the previous logic did. This fixes that
not a functionality regression as far as i can tell, but it's incorrect as-is