### PR TITLE
Allow selecting text in shader compilation logs

### DIFF
--- a/editor/plugins/shader_file_editor_plugin.cpp
+++ b/editor/plugins/shader_file_editor_plugin.cpp
@@ -286,6 +286,7 @@ ShaderFileEditor::ShaderFileEditor() {
 
 	error_text = memnew(RichTextLabel);
 	error_text->set_v_size_flags(SIZE_EXPAND_FILL);
+	error_text->set_selection_enabled(true);
 	main_vb->add_child(error_text);
 }
 


### PR DESCRIPTION
When errors occur it was not possible to copy the relevant text. Now it is possible with selection and Ctrl+C.