### PR TITLE
Add `GDScriptCache::move_script` check before executing logic

### DIFF
--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -122,7 +122,7 @@ GDScriptParserRef::~GDScriptParserRef() {
 GDScriptCache *GDScriptCache::singleton = nullptr;
 
 void GDScriptCache::move_script(const String &p_from, const String &p_to) {
-	if (singleton == nullptr) {
+	if (singleton == nullptr || p_from == p_to) {
 		return;
 	}
 


### PR DESCRIPTION
Without this check, `move_script` would be executed and somehow, references would be lost. Later, errors like `Trying to assign value of type ''  to a variable of type 'X'` could pop up, as two GDScript instances could point to the same script file, but not being the same.

Fix a regression introduced by #67714