### PR TITLE
Fix not enough arguments error when validating 3to4 conversion

### DIFF
--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -2172,7 +2172,7 @@ int ProjectConverter3To4::validate_conversion() {
 				lines.append(line);
 			}
 		}
-		print_line(vformat("Checking for conversion - %d/%d file - \"%s\" with size - %d KB"), i + 1, collected_files.size(), file_name.trim_prefix("res://"), file_size / 1024);
+		print_line(vformat("Checking for conversion - %d/%d file - \"%s\" with size - %d KB", i + 1, collected_files.size(), file_name.trim_prefix("res://"), file_size / 1024));
 
 		Vector<String> changed_elements;
 		Vector<String> reason;


### PR DESCRIPTION
There were errors when executing `--validate-conversion-3to4`:

```
ERROR: not enough arguments for format string
   at: vformat (./core/variant/variant.h:820)
```

It's a result of misplaced parenthesis.