### PR TITLE
Don't update EditorSettings dialog unnecessarily

### DIFF
--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -312,7 +312,9 @@ void SectionedInspector::_search_changed(const String &p_what) {
 void SectionedInspector::_notification(int p_what) {
 	switch (p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			inspector->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/localize_settings")) {
+				inspector->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
+			}
 		} break;
 	}
 }

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -152,7 +152,9 @@ void EditorSettingsDialog::_notification(int p_what) {
 				_update_shortcuts();
 			}
 
-			inspector->update_category_list();
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/localize_settings")) {
+				inspector->update_category_list();
+			}
 		} break;
 	}
 }


### PR DESCRIPTION
Fixes regression from #59426

The PR made the inspector update unconditionally, restoring the old bug where changing interface color would reload everything 🙄

(this would've fixed #59798 if it wasn't closed already)