### PR TITLE
Fixes and improvements to Gradient preview

### DIFF
--- a/editor/plugins/gradient_editor.h
+++ b/editor/plugins/gradient_editor.h
@@ -53,10 +53,10 @@ class GradientEditor : public Control {
 
 	// Make sure to use the scaled value below.
 	const int BASE_SPACING = 3;
-	const int BASE_POINT_WIDTH = 8;
+	const int BASE_HANDLE_WIDTH = 8;
 
 	int draw_spacing = BASE_SPACING;
-	int draw_point_width = BASE_POINT_WIDTH;
+	int handle_width = BASE_HANDLE_WIDTH;
 
 	void _gradient_changed();
 	void _ramp_changed();


### PR DESCRIPTION
This PR takes the handles' width into consideration when drawing color ramps, so they don't collide with other elements or get outside of the preview.

Before:

![image](https://user-images.githubusercontent.com/85438892/203119897-f6972466-b2e7-4582-b9c3-6c4aac84094e.png)

After:

![image](https://user-images.githubusercontent.com/85438892/203119862-0e01a5e1-50f8-4fc6-be33-08ebb7b2a217.png)

---

It also draws the focus rect earlier, making it not overlap the handles.

Before:

![image](https://user-images.githubusercontent.com/85438892/203129955-e5d991ff-b142-4b2d-8324-befa333df062.png)

After:

![image](https://user-images.githubusercontent.com/85438892/203131133-be9145ae-6cc3-4d77-bf27-05f3501fe25b.png)