### PR TITLE
Fix Editor crash when vertex count is 65536

### DIFF
--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -219,7 +219,7 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 	}
 
 	if (p_surface.index_count) {
-		bool is_index_16 = p_surface.vertex_count <= 65536 && p_surface.vertex_count > 0;
+		bool is_index_16 = p_surface.vertex_count < 65536 && p_surface.vertex_count > 0;
 		glGenBuffers(1, &s->index_buffer);
 		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, s->index_buffer);
 		glBufferData(GL_ELEMENT_ARRAY_BUFFER, p_surface.index_data.size(), p_surface.index_data.ptr(), GL_STATIC_DRAW);

--- a/drivers/gles3/storage/mesh_storage.h
+++ b/drivers/gles3/storage/mesh_storage.h
@@ -360,7 +360,7 @@ public:
 	_FORCE_INLINE_ GLenum mesh_surface_get_index_type(void *p_surface) const {
 		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
 
-		return (s->vertex_count <= 65536 && s->vertex_count > 0) ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT;
+		return (s->vertex_count < 65536 && s->vertex_count > 0) ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT;
 	}
 
 	// Use this to cache Vertex Array Objects so they are only generated once

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -366,7 +366,7 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 	}
 
 	if (p_surface.index_count) {
-		bool is_index_16 = p_surface.vertex_count <= 65536 && p_surface.vertex_count > 0;
+		bool is_index_16 = p_surface.vertex_count < 65536 && p_surface.vertex_count > 0;
 
 		s->index_buffer = RD::get_singleton()->index_buffer_create(p_surface.index_count, is_index_16 ? RD::INDEX_BUFFER_FORMAT_UINT16 : RD::INDEX_BUFFER_FORMAT_UINT32, p_surface.index_data, false);
 		s->index_count = p_surface.index_count;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1007,7 +1007,7 @@ Error RenderingServer::mesh_create_surface_data_from_arrays(SurfaceData *r_surfa
 			const int *r = indices.ptr();
 
 			Vector<uint8_t> data;
-			if (array_len <= 65536) {
+			if (array_len < 65536) {
 				// 16 bits indices
 				data.resize(indices.size() * 2);
 				uint8_t *w = data.ptrw();
@@ -1319,7 +1319,7 @@ Dictionary RenderingServer::mesh_surface_get_lods(RID p_mesh, int p_surface) con
 
 	for (int i = 0; i < sd.lods.size(); i++) {
 		Vector<int> lods;
-		if (sd.vertex_count <= 65536) {
+		if (sd.vertex_count < 65536) {
 			uint32_t lc = sd.lods[i].index_data.size() / 2;
 			lods.resize(lc);
 			const uint8_t *r = sd.lods[i].index_data.ptr();


### PR DESCRIPTION
Fix #68923

Not sure if this is best fix since @ueshita came up with another fix in https://github.com/ueshita/godot/commit/454116716e7934f6bd80d7040a2c06a7c18d4c64.