### PR TITLE
Expose model_matrix in GLES3 scene fragment shader

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -920,6 +920,7 @@ void main() {
 #else
 	vec3 view = -normalize(vertex_interp);
 #endif
+	highp mat4 model_matrix = world_transform;
 	vec3 albedo = vec3(1.0);
 	vec3 backlight = vec3(0.0);
 	vec4 transmittance_color = vec4(0.0, 0.0, 0.0, 1.0);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/67894

This was just missing from the initial port to GLES3
