### PR TITLE
Fetch cached scene if it exists in `GDScriptCache::get_packed_scene()`

### DIFF
--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -342,7 +342,12 @@ Ref<PackedScene> GDScriptCache::get_packed_scene(const String &p_path, Error &r_
 		return singleton->packed_scene_cache[p_path];
 	}
 
-	Ref<PackedScene> scene;
+	Ref<PackedScene> scene = ResourceCache::get_ref(p_path);
+	if (scene.is_valid()) {
+		singleton->packed_scene_cache[p_path] = scene;
+		singleton->packed_scene_dependencies[p_path].insert(p_owner);
+		return scene;
+	}
 	scene.instantiate();
 
 	r_error = OK;


### PR DESCRIPTION
If the scene exists in `ResourceCache`, `GDScriptCache` now fetches it before instantiating a new scene that can clash with the cached one later.

The change is not compatible with 3.x

Fixes #68971 - GDScript 2.0: Can't instantiate scene if another resource is loaded from the same path