### PR TITLE
[3.x] Use high precision for sky UV calculations on mobile

### DIFF
--- a/drivers/gles3/shaders/copy.glsl
+++ b/drivers/gles3/shaders/copy.glsl
@@ -68,7 +68,7 @@ precision mediump float;
 #endif
 
 #if defined(USE_CUBEMAP) || defined(USE_PANORAMA)
-in vec3 cube_interp;
+in highp vec3 cube_interp;
 #else
 in vec2 uv_interp;
 #endif
@@ -119,7 +119,7 @@ uniform float multiplier;
 uniform highp mat4 sky_transform;
 
 vec4 texturePanorama(vec3 normal, sampler2D pano) {
-	vec2 st = vec2(
+	highp vec2 st = vec2(
 			atan(normal.x, normal.z),
 			acos(normal.y));
 
@@ -156,7 +156,7 @@ void main() {
 
 #ifdef USE_PANORAMA
 
-	vec3 cube_normal = normalize(cube_interp);
+	highp vec3 cube_normal = normalize(cube_interp);
 	cube_normal.z = -cube_normal.z;
 	cube_normal = mat3(sky_transform) * cube_normal;
 	cube_normal.z = -cube_normal.z;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/68950

Mobile devices were showing significant rendering artifacts in the background sky. These artifacts come from using medium precision for the UV calculations and (on GLES2) from reading from empty mipmaps. 

This change increases precision for the UV calculations because they always need high precision, so it should be enabled without users having to force high precision on all calculations. 

_Before:_
![Screenshot_20221121-133602](https://user-images.githubusercontent.com/16521339/203163916-7b0453f2-6119-4260-81f4-67ad81b6604e.jpg)

_After:_
![Screenshot_20221121-133516](https://user-images.githubusercontent.com/16521339/203163920-975cc2a5-4c26-4c54-a7d4-6ccfd1fe9dac.jpg)
