### PR TITLE
Fix leaks of `Shape2D` and `Shape3D`

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3336,11 +3336,11 @@ void Main::cleanup(bool p_force) {
 	finalize_theme_db();
 
 	// Before deinitializing server extensions, finalize servers which may be loaded as extensions.
-	finalize_physics();
-
 	NativeExtensionManager::get_singleton()->deinitialize_extensions(NativeExtension::INITIALIZATION_LEVEL_SERVERS);
 	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
 	unregister_server_types();
+
+	finalize_physics();
 
 	EngineDebugger::deinitialize();
 

--- a/scene/resources/shape_2d.cpp
+++ b/scene/resources/shape_2d.cpp
@@ -124,7 +124,5 @@ Shape2D::Shape2D(const RID &p_rid) {
 }
 
 Shape2D::~Shape2D() {
-	if (PhysicsServer2D::get_singleton() != nullptr) {
-		PhysicsServer2D::get_singleton()->free(shape);
-	}
+	PhysicsServer2D::get_singleton()->free(shape);
 }

--- a/scene/resources/shape_3d.cpp
+++ b/scene/resources/shape_3d.cpp
@@ -128,7 +128,5 @@ Shape3D::Shape3D(RID p_shape) :
 		shape(p_shape) {}
 
 Shape3D::~Shape3D() {
-	if (PhysicsServer3D::get_singleton() != nullptr) {
-		PhysicsServer3D::get_singleton()->free(shape);
-	}
+	PhysicsServer3D::get_singleton()->free(shape);
 }


### PR DESCRIPTION
Moves `finalize_physics()` after `unregister_server_types()` in `main.cpp` which assures that `GDScript` instances will be disposed of before removing physics servers.

Fixes #68973

Will need testing as I don't know if there's side effects delaying the clearing of physics servers after modules and other server types.