### PR TITLE
Fix autoload scenes implicit types

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3120,6 +3120,18 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 						result = type_from_metatype(singl_parser->get_parser()->head->get_datatype());
 					}
 				}
+			} else if (ResourceLoader::get_resource_type(autoload.path) == "PackedScene") {
+				Error err = OK;
+				Ref<GDScript> scr = GDScriptCache::get_packed_scene_script(autoload.path, err);
+				if (err == OK && scr.is_valid()) {
+					Ref<GDScriptParserRef> singl_parser = get_parser_for(scr->get_path());
+					if (singl_parser.is_valid()) {
+						err = singl_parser->raise_status(GDScriptParserRef::INTERFACE_SOLVED);
+						if (err == OK) {
+							result = type_from_metatype(singl_parser->get_parser()->head->get_datatype());
+						}
+					}
+				}
 			}
 			result.is_constant = true;
 			p_identifier->set_datatype(result);

--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -360,6 +360,31 @@ Ref<PackedScene> GDScriptCache::get_packed_scene(const String &p_path, Error &r_
 	return scene;
 }
 
+Ref<GDScript> GDScriptCache::get_packed_scene_script(const String &p_path, Error &r_error) {
+	r_error = OK;
+	Ref<PackedScene> scene = get_packed_scene(p_path, r_error);
+
+	if (r_error != OK) {
+		return Ref<GDScript>();
+	}
+
+	int node_count = scene->get_state()->get_node_count();
+	if (node_count == 0) {
+		return Ref<GDScript>();
+	}
+
+	const int ROOT_NODE = 0;
+	for (int i = 0; i < scene->get_state()->get_node_property_count(ROOT_NODE); i++) {
+		if (scene->get_state()->get_node_property_name(ROOT_NODE, i) != SNAME("script")) {
+			continue;
+		}
+
+		return scene->get_state()->get_node_property_value(ROOT_NODE, i);
+	}
+
+	return Ref<GDScript>();
+}
+
 void GDScriptCache::clear_unreferenced_packed_scenes() {
 	if (singleton == nullptr) {
 		return;

--- a/modules/gdscript/gdscript_cache.h
+++ b/modules/gdscript/gdscript_cache.h
@@ -102,6 +102,7 @@ public:
 	static Error finish_compiling(const String &p_owner);
 
 	static Ref<PackedScene> get_packed_scene(const String &p_path, Error &r_error, const String &p_owner = "");
+	static Ref<GDScript> get_packed_scene_script(const String &p_path, Error &r_error);
 	static void clear_unreferenced_packed_scenes();
 
 	static bool is_destructing() {


### PR DESCRIPTION
## Important
Merge #68972 "Fetch cached scene if it exists in `GDScriptCache::get_packed_scene()`" first.

## Summary
Sorta reverts #68872 "Remove fix leftover that caused cyclic load issues", but cleans up the code.

Needs testing before merge to make sure the revert does not bring back the issues the removal fixed. Volunteers needed.

## Fixes
Fixes #61386 - [4.x regression] AutoLoad scenes (not scripts) do not support implicit types