### PR TITLE
Fix animation blending for value track `UPDATE_DISCRETE` and `UPDATE_TRIGGER` mode

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -589,6 +589,7 @@ bool AnimationTree::_update_caches(AnimationPlayer *player) {
 							track_value->object = child;
 						}
 
+						track_value->is_discrete = anim->value_track_get_update_mode(i) == Animation::UPDATE_DISCRETE || anim->value_track_get_update_mode(i) == Animation::UPDATE_TRIGGER;
 						track_value->is_using_angle = anim->track_get_interpolation_type(i) == Animation::INTERPOLATION_LINEAR_ANGLE || anim->track_get_interpolation_type(i) == Animation::INTERPOLATION_CUBIC_ANGLE;
 
 						track_value->subpath = leftover_path;
@@ -796,6 +797,7 @@ bool AnimationTree::_update_caches(AnimationPlayer *player) {
 			} else if (track_cache_type == Animation::TYPE_VALUE) {
 				// If it has at least one angle interpolation, it also uses angle interpolation for blending.
 				TrackCacheValue *track_value = memnew(TrackCacheValue);
+				track_value->is_discrete |= anim->value_track_get_update_mode(i) == Animation::UPDATE_DISCRETE || anim->value_track_get_update_mode(i) == Animation::UPDATE_TRIGGER;
 				track_value->is_using_angle |= anim->track_get_interpolation_type(i) == Animation::INTERPOLATION_LINEAR_ANGLE || anim->track_get_interpolation_type(i) == Animation::INTERPOLATION_CUBIC_ANGLE;
 			}
 
@@ -1690,6 +1692,10 @@ void AnimationTree::_process_graph(double p_delta) {
 				} break;
 				case Animation::TYPE_VALUE: {
 					TrackCacheValue *t = static_cast<TrackCacheValue *>(track);
+
+					if (t->is_discrete) {
+						break; // Don't overwrite the value set by UPDATE_DISCRETE or UPDATE_TRIGGER.
+					}
 
 					if (t->init_value.get_type() == Variant::BOOL) {
 						t->object->set_indexed(t->subpath, t->value.operator real_t() >= 0.5);

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -233,6 +233,7 @@ private:
 		Variant init_value;
 		Variant value;
 		Vector<StringName> subpath;
+		bool is_discrete = false;
 		bool is_using_angle = false;
 		TrackCacheValue() { type = Animation::TYPE_VALUE; }
 	};


### PR DESCRIPTION
Fixes #68261.

`UPDATE_DISCRETE` and `UPDATE_TRIGGER` do not blend values, but set values to objects on the fly, but this will be overwritten by the blended values.

This PR prevents overwriting by skipping the normal process of applying blend values if the blend contains `UPDATE_DISCRETE` or `UPDATE_TRIGGER` tracks. For blending, `INTERPOLATION_NEAREST` should be used instead. I will update the documentation about the blending later.