### PR TITLE
Avoid error spamming in animation_tree when path is not found

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1031,7 +1031,9 @@ void AnimationTree::_process_graph(double p_delta) {
 				}
 
 				NodePath path = a->track_get_path(i);
-				ERR_CONTINUE(!track_cache.has(path));
+				if (!track_cache.has(path)) {
+					continue; // No path, but avoid error spamming.
+				}
 				TrackCache *track = track_cache[path];
 
 				ERR_CONTINUE(!state.track_map.has(path));


### PR DESCRIPTION
For this issue: https://github.com/godotengine/godot/issues/65608

Error spamming was bringing Godot (and eventually the whole system) to a crawl by spamming an error message when there was an error finding a path.

I fixed this by skipping the error message (the error is also logged somewhere else outside of the loop)

<i>Bugsquad edit:</i>
- Fix #65608