### PR TITLE
Add global constants for integer limits

### DIFF
--- a/core/core_constants.cpp
+++ b/core/core_constants.cpp
@@ -67,6 +67,9 @@ static Vector<_CoreConstant> _global_constants;
 #define BIND_CORE_CONSTANT(m_constant) \
 	_global_constants.push_back(_CoreConstant(StringName(), #m_constant, m_constant));
 
+#define BIND_CORE_CONSTANT_CUSTOM(m_custom_name, m_constant) \
+	_global_constants.push_back(_CoreConstant(StringName(), m_custom_name, m_constant));
+
 #define BIND_CORE_ENUM_CONSTANT(m_constant) \
 	_global_constants.push_back(_CoreConstant(__constant_get_enum_name(m_constant, #m_constant), #m_constant, m_constant));
 
@@ -96,6 +99,9 @@ static Vector<_CoreConstant> _global_constants;
 
 #define BIND_CORE_CONSTANT(m_constant) \
 	_global_constants.push_back(_CoreConstant(#m_constant, m_constant));
+
+#define BIND_CORE_CONSTANT_CUSTOM(m_custom_name, m_constant) \
+	_global_constants.push_back(_CoreConstant(m_custom_name, m_constant));
 
 #define BIND_CORE_ENUM_CONSTANT(m_constant) \
 	_global_constants.push_back(_CoreConstant(#m_constant, m_constant));
@@ -738,6 +744,22 @@ void register_global_constants() {
 	//containment
 	BIND_CORE_ENUM_CONSTANT_CUSTOM("OP_IN", Variant::OP_IN);
 	BIND_CORE_ENUM_CONSTANT_CUSTOM("OP_MAX", Variant::OP_MAX);
+
+	// Data type limits.
+	BIND_CORE_CONSTANT(UINT8_MAX);
+	BIND_CORE_CONSTANT(UINT16_MAX);
+	BIND_CORE_CONSTANT(UINT32_MAX);
+	BIND_CORE_CONSTANT(UINT64_MAX);
+	BIND_CORE_CONSTANT(INT8_MIN);
+	BIND_CORE_CONSTANT(INT8_MAX);
+	BIND_CORE_CONSTANT(INT16_MIN);
+	BIND_CORE_CONSTANT(INT16_MAX);
+	BIND_CORE_CONSTANT(INT32_MIN);
+	BIND_CORE_CONSTANT(INT32_MAX);
+	BIND_CORE_CONSTANT(INT64_MIN);
+	BIND_CORE_CONSTANT(INT64_MAX);
+	BIND_CORE_CONSTANT_CUSTOM("INT_MIN", INT64_MIN);
+	BIND_CORE_CONSTANT_CUSTOM("INT_MAX", INT64_MAX);
 }
 
 void unregister_global_constants() {

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -3098,5 +3098,47 @@
 		<constant name="OP_MAX" value="25" enum="Variant.Operator">
 			Represents the size of the [enum Variant.Operator] enum.
 		</constant>
+		<constant name="UINT8_MAX" value="255">
+			Maximum value of a 8-bit unsigned integer.
+		</constant>
+		<constant name="UINT16_MAX" value="65535">
+			Maximum value of a 16-bit unsigned integer.
+		</constant>
+		<constant name="UINT32_MAX" value="4294967295">
+			Maximum value of a 32-bit unsigned integer.
+		</constant>
+		<constant name="UINT64_MAX" value="-1">
+			Maximum value of a 64-bit unsigned integer.
+		</constant>
+		<constant name="INT8_MIN" value="-128">
+			Minimum value of a 8-bit signed integer.
+		</constant>
+		<constant name="INT8_MAX" value="127">
+			Maximum value of a 8-bit signed integer.
+		</constant>
+		<constant name="INT16_MIN" value="-32768">
+			Minimum value of a 16-bit signed integer.
+		</constant>
+		<constant name="INT16_MAX" value="32767">
+			Maximum value of a 16-bit signed integer.
+		</constant>
+		<constant name="INT32_MIN" value="-2147483648">
+			Minimum value of a 32-bit signed integer.
+		</constant>
+		<constant name="INT32_MAX" value="2147483647">
+			Maximum value of a 32-bit signed integer.
+		</constant>
+		<constant name="INT64_MIN" value="-9223372036854775808">
+			Minimum value of a 64-bit signed integer.
+		</constant>
+		<constant name="INT64_MAX" value="9223372036854775807">
+			Maximum value of a 64-bit signed integer.
+		</constant>
+		<constant name="INT_MIN" value="-9223372036854775808">
+			Minimum value of [int], which is a 64-bit signed integer (so equivalent to [constant INT64_MIN]).
+		</constant>
+		<constant name="INT_MAX" value="9223372036854775807">
+			Maximum value of [int], which is a 64-bit signed integer (so equivalent to [constant INT64_MAX]).
+		</constant>
 	</constants>
 </class>

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -32,6 +32,7 @@
 #include "../gdscript.h"
 #include "../gdscript_tokenizer.h"
 #include "core/config/project_settings.h"
+#include "core/core_constants.h"
 #include "editor/editor_settings.h"
 
 Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_line) {
@@ -338,6 +339,8 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 						col = global_function_color;
 					}
 				}
+			} else if (global_constants.has(word)) {
+				col = symbol_color;
 			} else if (class_names.has(word)) {
 				col = class_names[word];
 			} else if (reserved_keywords.has(word)) {
@@ -569,6 +572,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	reserved_keywords.clear();
 	member_keywords.clear();
 	global_functions.clear();
+	global_constants.clear();
 	color_regions.clear();
 	color_region_cache.clear();
 
@@ -634,6 +638,12 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	global_functions.insert(SNAME("preload"));
 	for (const StringName &E : global_function_list) {
 		global_functions.insert(E);
+	}
+
+	/* Global constants. */
+	const int global_constant_count = CoreConstants::get_global_constant_count();
+	for (int i = 0; i < global_constant_count; i++) {
+		global_constants.insert(CoreConstants::get_global_constant_name(i));
 	}
 
 	/* Comments */

--- a/modules/gdscript/editor/gdscript_highlighter.h
+++ b/modules/gdscript/editor/gdscript_highlighter.h
@@ -51,6 +51,7 @@ private:
 	HashMap<StringName, Color> reserved_keywords;
 	HashMap<StringName, Color> member_keywords;
 	HashSet<StringName> global_functions;
+	HashSet<StringName> global_constants;
 
 	enum Type {
 		NONE,


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/2411

* Adds `INT{bits}_MIN`, `INT{bits}_MAX`, and `UINT{bits}_MAX` constants.
    * This is mainly for data (de)serialization related use cases.
* Adds `INT_MIN` and `INT_MAX` constants.
    * This is for variant `int` limits. They are the same as `INT64_*` since `int` is a 64-bit signed integer.
* GDScript syntax highlighter did not highlight global constants before. I set the color to be the same as a plain symbol (`text_editor/theme/highlighting/symbol_color`).

Currently waiting for https://github.com/godotengine/godot-cpp/pull/935 to be merged first, so CI won't complain here.