### PR TITLE
GDScript: Don't warn about RETURN_VALUE_DISCARDED by default

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -401,7 +401,7 @@
 		<member name="debug/gdscript/warnings/redundant_await" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a function that is not a coroutine is called with await.
 		</member>
-		<member name="debug/gdscript/warnings/return_value_discarded" type="int" setter="" getter="" default="1">
+		<member name="debug/gdscript/warnings/return_value_discarded" type="int" setter="" getter="" default="0">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when calling a function without using its return value (by assigning it to a variable or using it as a function argument). Such return values are sometimes used to denote possible errors using the [enum Error] enum.
 		</member>
 		<member name="debug/gdscript/warnings/shadowed_global_identifier" type="int" setter="" getter="" default="1">

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -171,6 +171,10 @@ int GDScriptWarning::get_default_value(Code p_code) {
 	if (get_name_from_code(p_code).to_lower().begins_with("unsafe_")) {
 		return WarnLevel::IGNORE;
 	}
+	// Too spammy by default on common cases (connect, Tween, etc.).
+	if (p_code == RETURN_VALUE_DISCARDED) {
+		return WarnLevel::IGNORE;
+	}
 	return WarnLevel::WARN;
 }
 


### PR DESCRIPTION
This happens too often with normal usage of the API. The warning can still be useful to find actual bugs where discarding the return value wasn't intentional, but this should stay enabled manually, at least until we either improve the API to remove false positives, or improve the warning (e.g. to only warn about unused return value on const functions).

- Supersedes (for now) #58438.
- Reduces the need for https://github.com/godotengine/godot-proposals/issues/682, but implementing that proposal or similar improvements would make it possible to re-enable this warning / improved version of it.