### PR TITLE
Add shortcut to instantiate scripts

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -109,6 +109,8 @@ void SceneTreeDock::shortcut_input(const Ref<InputEvent> &p_event) {
 		_tool_selected(TOOL_NEW);
 	} else if (ED_IS_SHORTCUT("scene_tree/instantiate_scene", p_event)) {
 		_tool_selected(TOOL_INSTANTIATE);
+	} else if (ED_IS_SHORTCUT("scene_tree/instantiate_script", p_event)) {
+		_tool_selected(TOOL_INSTANTIATE_SCRIPT);
 	} else if (ED_IS_SHORTCUT("scene_tree/expand_collapse_all", p_event)) {
 		_tool_selected(TOOL_EXPAND_COLLAPSE);
 	} else if (ED_IS_SHORTCUT("scene_tree/cut_node", p_event)) {
@@ -467,8 +469,19 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			quick_open->popup_dialog("PackedScene,Script", true);
+			quick_open->popup_dialog("PackedScene", true);
 			quick_open->set_title(TTR("Instantiate Child Scene"));
+			if (!p_confirm_override) {
+				emit_signal(SNAME("add_node_used"));
+			}
+		} break;
+		case TOOL_INSTANTIATE_SCRIPT: {
+			if (!profile_allow_editing) {
+				break;
+			}
+
+			quick_open->popup_dialog("Script", true);
+			quick_open->set_title(TTR("Instantiate Script"));
 			if (!p_confirm_override) {
 				emit_signal(SNAME("add_node_used"));
 			}
@@ -2750,6 +2763,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 		if (profile_allow_editing) {
 			menu->add_icon_shortcut(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/add_child_node"), TOOL_NEW);
 			menu->add_icon_shortcut(get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/instantiate_scene"), TOOL_INSTANTIATE);
+			menu->add_icon_shortcut(get_theme_icon(SNAME("Script"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/instantiate_script"), TOOL_INSTANTIATE_SCRIPT);
 		}
 
 		menu->reset_size();
@@ -2783,6 +2797,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 
 			menu->add_icon_shortcut(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/add_child_node"), TOOL_NEW);
 			menu->add_icon_shortcut(get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/instantiate_scene"), TOOL_INSTANTIATE);
+			menu->add_icon_shortcut(get_theme_icon(SNAME("Script"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/instantiate_script"), TOOL_INSTANTIATE_SCRIPT);
 		}
 		menu->add_icon_shortcut(get_theme_icon(SNAME("Collapse"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/expand_collapse_all"), TOOL_EXPAND_COLLAPSE);
 		menu->add_separator();
@@ -3509,6 +3524,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 
 	ED_SHORTCUT("scene_tree/add_child_node", TTR("Add Child Node"), KeyModifierMask::CMD_OR_CTRL | Key::A);
 	ED_SHORTCUT("scene_tree/instantiate_scene", TTR("Instantiate Child Scene"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::A);
+	ED_SHORTCUT("scene_tree/instantiate_script", TTR("Instantiate Script"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT | Key::A);
 	ED_SHORTCUT("scene_tree/expand_collapse_all", TTR("Expand/Collapse Branch"));
 	ED_SHORTCUT("scene_tree/cut_node", TTR("Cut"), KeyModifierMask::CMD_OR_CTRL | Key::X);
 	ED_SHORTCUT("scene_tree/copy_node", TTR("Copy"), KeyModifierMask::CMD_OR_CTRL | Key::C);

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -61,6 +61,7 @@ class SceneTreeDock : public VBoxContainer {
 	enum Tool {
 		TOOL_NEW,
 		TOOL_INSTANTIATE,
+		TOOL_INSTANTIATE_SCRIPT,
 		TOOL_EXPAND_COLLAPSE,
 		TOOL_CUT,
 		TOOL_COPY,


### PR DESCRIPTION
This PR adds support for scripts in Instantiate Child Scene dialog, and in another commit it splits it into 2 options.
![image](https://user-images.githubusercontent.com/2223172/203386360-e53375bd-ef58-4ae2-9a27-b3122a233f11.png)

Splits and depends on #68648