### PR TITLE
Fix parameters for hash_murmur3_one_32

### DIFF
--- a/servers/rendering/renderer_rd/framebuffer_cache_rd.h
+++ b/servers/rendering/renderer_rd/framebuffer_cache_rd.h
@@ -254,11 +254,11 @@ public:
 
 	RID get_cache_multipass(const Vector<RID> &p_textures, const Vector<RD::FramebufferPass> &p_passes, uint32_t p_views = 1) {
 		uint32_t h = hash_murmur3_one_32(p_views);
-		h = hash_murmur3_one_32(p_textures.size());
+		h = hash_murmur3_one_32(p_textures.size(), h);
 		for (int i = 0; i < p_textures.size(); i++) {
 			h = hash_murmur3_one_64(p_textures[i].get_id(), h);
 		}
-		h = hash_murmur3_one_32(p_passes.size());
+		h = hash_murmur3_one_32(p_passes.size(), h);
 		for (int i = 0; i < p_passes.size(); i++) {
 			h = _hash_pass(p_passes[i], h);
 		}


### PR DESCRIPTION
In multiple locations in the codebase `hash_murmur3_one_32` is used for generating hash values.

Whenever a sequence of multiple hash-calculation happens within a single function, the previous hash value is always used as input in the following hash-calculations. The only exception is `get_cache_multipass`, where currently the previous hash value is overridden without utilizing it.
This patch corrects that.
resolve #68028