### PR TITLE
Animation State Machine Transition : Add possible callback

### DIFF
--- a/doc/classes/AnimationNodeStateMachineTransition.xml
+++ b/doc/classes/AnimationNodeStateMachineTransition.xml
@@ -31,6 +31,12 @@
 		<member name="priority" type="int" setter="set_priority" getter="get_priority" default="1">
 			Lower priority transitions are preferred when travelling through the tree via [method AnimationNodeStateMachinePlayback.travel] or [member auto_advance].
 		</member>
+		<member name="notify_target" type="StringName" setter="set_notify_target" getter="get_notify_target" default="&quot;&quot;">
+			Target node path relative to [AnimationTree] to notify upon transition completion.
+		</member>
+		<member name="notify_target_function" type="StringName" setter="set_notify_target_function" getter="get_notify_target_function" default="&quot;&quot;">
+			Method target to notify upon transition completion.
+		</member>
 		<member name="switch_mode" type="int" setter="set_switch_mode" getter="get_switch_mode" enum="AnimationNodeStateMachineTransition.SwitchMode" default="0">
 			The transition type.
 		</member>

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -58,6 +58,10 @@ private:
 	friend class AnimationNodeStateMachinePlayback;
 	Ref<Expression> expression;
 
+	StringName notify_target;
+	NodePath notify_target_np;
+	StringName notify_target_function;
+
 protected:
 	static void _bind_methods();
 
@@ -87,6 +91,14 @@ public:
 
 	void set_priority(int p_priority);
 	int get_priority() const;
+
+	void set_notify_target(StringName target);
+	StringName get_notify_target() const;
+
+	NodePath get_notify_target_np() const;
+
+	void set_notify_target_function(StringName target_function);
+	StringName get_notify_target_function() const;
 
 	AnimationNodeStateMachineTransition();
 };


### PR DESCRIPTION
This PR is a feature/improvement proposal, it is useful for my purposes but the engine team may disagree on having it in the engine.

![image](https://user-images.githubusercontent.com/11915892/203411307-f7463ecc-9e27-49f1-9781-376958fe604e.png)

The aim is to have the transitions in a animation state machine have the possibility to call a node's function ( close to a callable ) open a completion of the transition.

This can be done directly via the animation player with a method call track, but when editing the animation player is not desired, this still allows for method to be called.

This PR adds 2 properties to the `AnimationNodeStateMachineTransition`:
```
notify_target (StringName)
notify_target_function (StringName)
```

I tried at first to make `notify_target` be a `NodePath`, but the editor was giving a global `NodePath` instead of a `NodePath` relative to the `AnimationTree`