### PR TITLE
Add unregister for `GLTFDocumentExtension`

### DIFF
--- a/modules/gltf/doc_classes/GLTFDocument.xml
+++ b/modules/gltf/doc_classes/GLTFDocument.xml
@@ -62,8 +62,15 @@
 			<param index="0" name="extension" type="GLTFDocumentExtension" />
 			<param index="1" name="first_priority" type="bool" default="false" />
 			<description>
-				Registers this GLTFDocumentExtension instance with GLTFDocument. If [param first_priority] is true, this extension will be ran first. Otherwise, it will be ran last.
+				Registers the given [GLTFDocumentExtension] instance with GLTFDocument. If [param first_priority] is true, this extension will be run first. Otherwise, it will be run last.
 				[b]Note:[/b] Like GLTFDocument itself, all GLTFDocumentExtension classes must be stateless in order to function properly. If you need to store data, use the [code]set_additional_data[/code] and [code]get_additional_data[/code] methods in [GLTFState] or [GLTFNode].
+			</description>
+		</method>
+		<method name="unregister_gltf_document_extension" qualifiers="static">
+			<return type="void" />
+			<param index="0" name="extension" type="GLTFDocumentExtension" />
+			<description>
+				Unregisters the given [GLTFDocumentExtension] instance.
 			</description>
 		</method>
 		<method name="write_to_filesystem">

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6761,6 +6761,8 @@ void GLTFDocument::_bind_methods() {
 
 	ClassDB::bind_static_method("GLTFDocument", D_METHOD("register_gltf_document_extension", "extension", "first_priority"),
 			&GLTFDocument::register_gltf_document_extension, DEFVAL(false));
+	ClassDB::bind_static_method("GLTFDocument", D_METHOD("unregister_gltf_document_extension", "extension"),
+			&GLTFDocument::unregister_gltf_document_extension);
 }
 
 void GLTFDocument::_build_parent_hierachy(Ref<GLTFState> state) {
@@ -6787,6 +6789,10 @@ void GLTFDocument::register_gltf_document_extension(Ref<GLTFDocumentExtension> p
 			all_document_extensions.push_back(p_extension);
 		}
 	}
+}
+
+void GLTFDocument::unregister_gltf_document_extension(Ref<GLTFDocumentExtension> p_extension) {
+	all_document_extensions.erase(p_extension);
 }
 
 void GLTFDocument::unregister_all_gltf_document_extensions() {

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -77,6 +77,7 @@ protected:
 
 public:
 	static void register_gltf_document_extension(Ref<GLTFDocumentExtension> p_extension, bool p_first_priority = false);
+	static void unregister_gltf_document_extension(Ref<GLTFDocumentExtension> p_extension);
 	static void unregister_all_gltf_document_extensions();
 
 private:


### PR DESCRIPTION
When using `GLTFDocumentExtension` in a tool script, you will need to unregister it when the plugin is disabled.