### PR TITLE
fix exporting Android APPLICATION_ATTRIBS (3.X)

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2577,8 +2577,8 @@ void EditorExportPlatformAndroid::_update_custom_build_project() {
 							append_line = true;
 						} else {
 							String base = l.substr(0, last_tag_pos + last_tag.length());
-							if (manifest_sections.has("application_attribs")) {
-								for (List<String>::Element *E = manifest_sections["application_attribs"].front(); E; E = E->next()) {
+							if (manifest_sections.has("APPLICATION_ATTRIBS")) {
+								for (List<String>::Element *E = manifest_sections["APPLICATION_ATTRIBS"].front(); E; E = E->next()) {
 									String to_add = E->get().strip_edges();
 									base += " " + to_add + " ";
 								}


### PR DESCRIPTION
I needed to add a tag to the inside of <application ...>   in AndroidManifest.xml
I noticed that  godot\platform\android\export\export_plugin.cpp   did appear to support adding a [application_attribs]   section to AndroidManfiest.conf.  Which should then get inserted into <application ...>  in AndroidManifest.xml

But it didn't work.  The reason why is when export_plugin.cpp parses AndroidManifest.conf   it upper cases the section names: "APPLICATION_ATTRIBS", but then later it was looking up using lower case "application_attribs"

So the simple fix was to upper case "APPLICATION_ATTRIBS" in code

Submitting pull request only against version 3.x  because export_plugin.cpp in Master appears to be significantly different.