### PR TITLE
AudioEffectDistortion docs & inspector edits

### DIFF
--- a/doc/classes/AudioEffectDistortion.xml
+++ b/doc/classes/AudioEffectDistortion.xml
@@ -2,11 +2,11 @@
 <class name="AudioEffectDistortion" inherits="AudioEffect" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Adds a distortion audio effect to an Audio bus.
-		Modify the sound to make it distorted.
+		Modifies the sound to make it distorted.
 	</brief_description>
 	<description>
 		Different types are available: clip, tan, lo-fi (bit crushing), overdrive, or waveshape.
-		By distorting the waveform the frequency content change, which will often make the sound "crunchy" or "abrasive". For games, it can simulate sound coming from some saturated device or speaker very efficiently.
+		By distorting the waveform the frequency content changes, which will often make the sound "crunchy" or "abrasive". For games, it can simulate sound coming from some saturated device or speaker very efficiently.
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
@@ -22,10 +22,10 @@
 			Distortion type.
 		</member>
 		<member name="post_gain" type="float" setter="set_post_gain" getter="get_post_gain" default="0.0">
-			Increases or decreases the volume after the effect. Value can range from -80 to 24.
+			Increases or decreases the volume after the effect, in decibels. Value can range from -80 to 24.
 		</member>
 		<member name="pre_gain" type="float" setter="set_pre_gain" getter="get_pre_gain" default="0.0">
-			Increases or decreases the volume before the effect. Value can range from -60 to 60.
+			Increases or decreases the volume before the effect, in decibels. Value can range from -60 to 60.
 		</member>
 	</members>
 	<constants>
@@ -35,10 +35,10 @@
 		<constant name="MODE_ATAN" value="1" enum="Mode">
 		</constant>
 		<constant name="MODE_LOFI" value="2" enum="Mode">
-			Low-resolution digital distortion effect. You can use it to emulate the sound of early digital audio devices.
+			Low-resolution digital distortion effect (bit depth reduction). You can use it to emulate the sound of early digital audio devices.
 		</constant>
 		<constant name="MODE_OVERDRIVE" value="3" enum="Mode">
-			Emulates the warm distortion produced by a field effect transistor, which is commonly used in solid-state musical instrument amplifiers.
+			Emulates the warm distortion produced by a field effect transistor, which is commonly used in solid-state musical instrument amplifiers. The [member drive] property has no effect in this mode.
 		</constant>
 		<constant name="MODE_WAVESHAPE" value="4" enum="Mode">
 			Waveshaper distortions are used mainly by electronic musicians to achieve an extra-abrasive sound.

--- a/servers/audio/effects/audio_effect_distortion.cpp
+++ b/servers/audio/effects/audio_effect_distortion.cpp
@@ -160,10 +160,10 @@ void AudioEffectDistortion::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_post_gain"), &AudioEffectDistortion::get_post_gain);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, "Clip,ATan,LoFi,Overdrive,Wave Shape"), "set_mode", "get_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pre_gain", PROPERTY_HINT_RANGE, "-60,60,0.01"), "set_pre_gain", "get_pre_gain");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pre_gain", PROPERTY_HINT_RANGE, "-60,60,0.01,suffix:dB"), "set_pre_gain", "get_pre_gain");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "keep_hf_hz", PROPERTY_HINT_RANGE, "1,20500,1,suffix:Hz"), "set_keep_hf_hz", "get_keep_hf_hz");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "drive", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_drive", "get_drive");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "post_gain", PROPERTY_HINT_RANGE, "-80,24,0.01"), "set_post_gain", "get_post_gain");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "post_gain", PROPERTY_HINT_RANGE, "-80,24,0.01,suffix:dB"), "set_post_gain", "get_post_gain");
 
 	BIND_ENUM_CONSTANT(MODE_CLIP);
 	BIND_ENUM_CONSTANT(MODE_ATAN);


### PR DESCRIPTION
Fixing a few typos in the AudioEffectDistortion docs, making a few things clearer, etc

Also adding the decibel (dB) suffix to the pre/post gain properties in the inspector.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
