### PR TITLE
Fix blending with negative blend weights

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -221,7 +221,7 @@ double AnimationNode::_blend_node(const StringName &p_subpath, const Vector<Stri
 					}
 
 					blendw[i] = blendr[i] * p_blend;
-					if (blendw[i] > CMP_EPSILON) {
+					if (!Math::is_zero_approx(blendw[i])) {
 						any_valid = true;
 					}
 				}
@@ -236,7 +236,7 @@ double AnimationNode::_blend_node(const StringName &p_subpath, const Vector<Stri
 					}
 
 					blendw[i] = blendr[i] * p_blend;
-					if (blendw[i] > CMP_EPSILON) {
+					if (!Math::is_zero_approx(blendw[i])) {
 						any_valid = true;
 					}
 				}
@@ -252,7 +252,7 @@ double AnimationNode::_blend_node(const StringName &p_subpath, const Vector<Stri
 						blendw[i] = blendr[i]; //not filtered, do not blend
 					}
 
-					if (blendw[i] > CMP_EPSILON) {
+					if (!Math::is_zero_approx(blendw[i])) {
 						any_valid = true;
 					}
 				}
@@ -263,7 +263,7 @@ double AnimationNode::_blend_node(const StringName &p_subpath, const Vector<Stri
 		for (int i = 0; i < blend_count; i++) {
 			//regular blend
 			blendw[i] = blendr[i] * p_blend;
-			if (blendw[i] > CMP_EPSILON) {
+			if (!Math::is_zero_approx(blendw[i])) {
 				any_valid = true;
 			}
 		}
@@ -1025,7 +1025,7 @@ void AnimationTree::_process_graph(double p_delta) {
 				int blend_idx = state.track_map[path];
 				ERR_CONTINUE(blend_idx < 0 || blend_idx >= state.track_count);
 				real_t blend = (*as.track_blends)[blend_idx] * weight;
-				if (blend < CMP_EPSILON) {
+				if (Math::is_zero_approx(blend)) {
 					continue; // Nothing to blend.
 				}
 


### PR DESCRIPTION
Fixes a regression introduced in #68593.

Negative blend wrights are possible and are needed for some effects. I'm using them for dynamic animation exaggeration:

```gdscript
# exaggeration is applied to the base animations blend weight
blend_weight *= exaggeration_factor

# and a reference pose (the "center" of the animation, ie: crossing pose of walk cycle) is blended with
reference_blend_weight = 1.0 - blend_weight
```

If `exaggeration_factor` is greater than `1.0` then it could be the case that `reference_blend_weight` is less than `0.0`, which is correct and necessary for this type of additive blending.