### PR TITLE
ci: require content of description and brief_description in classes doc

### DIFF
--- a/doc/class.xsd
+++ b/doc/class.xsd
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:simpleType name="mandatoryString">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="10"/>
+		</xs:restriction>
+	</xs:simpleType>
 	<xs:element name="class">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element type="xs:string" name="brief_description" />
-				<xs:element type="xs:string" name="description" />
+				<xs:element type="mandatoryString" name="brief_description" />
+				<xs:element type="mandatoryString" name="description" />
 				<xs:element name="tutorials">
 					<xs:complexType>
 						<xs:sequence>
@@ -47,7 +52,7 @@
 												<xs:attribute type="xs:string" name="default" use="optional" />
 											</xs:complexType>
 										</xs:element>
-										<xs:element type="xs:string" name="description" />
+										<xs:element type="mandatoryString" name="description" />
 									</xs:sequence>
 									<xs:attribute type="xs:string" name="name" use="optional" />
 									<xs:attribute type="xs:string" name="qualifiers" use="optional" />
@@ -91,7 +96,7 @@
 												<xs:attribute type="xs:string" name="default" use="optional" />
 											</xs:complexType>
 										</xs:element>
-										<xs:element type="xs:string" name="description" />
+										<xs:element type="mandatoryString" name="description" />
 									</xs:sequence>
 									<xs:attribute type="xs:string" name="name" use="optional" />
 									<xs:attribute type="xs:string" name="qualifiers" use="optional" />
@@ -141,7 +146,7 @@
 												<xs:attribute type="xs:string" name="type" />
 											</xs:complexType>
 										</xs:element>
-										<xs:element type="xs:string" name="description" />
+										<xs:element type="mandatoryString" name="description" />
 									</xs:sequence>
 									<xs:attribute type="xs:string" name="name" use="optional" />
 								</xs:complexType>
@@ -196,7 +201,7 @@
 												<xs:attribute type="xs:string" name="default" use="optional" />
 											</xs:complexType>
 										</xs:element>
-										<xs:element type="xs:string" name="description" />
+										<xs:element type="mandatoryString" name="description" />
 									</xs:sequence>
 									<xs:attribute type="xs:string" name="name" use="optional" />
 									<xs:attribute type="xs:string" name="qualifiers" use="optional" />
@@ -250,7 +255,7 @@
 												<xs:attribute type="xs:string" name="default" use="optional" />
 											</xs:complexType>
 										</xs:element>
-										<xs:element type="xs:string" name="description" />
+										<xs:element type="mandatoryString" name="description" />
 									</xs:sequence>
 									<xs:attribute type="xs:string" name="name" use="optional" />
 									<xs:attribute type="xs:string" name="qualifiers" use="optional" />

--- a/doc/classes/AnimationNodeOutput.xml
+++ b/doc/classes/AnimationNodeOutput.xml
@@ -3,7 +3,7 @@
 	<brief_description>
 		Generic output node to be added to [AnimationNodeBlendTree].
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 		<link title="AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>

--- a/doc/classes/AnimationNodeStateMachine.xml
+++ b/doc/classes/AnimationNodeStateMachine.xml
@@ -142,7 +142,7 @@
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="node" type="AnimationNode" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_graph_offset">

--- a/doc/classes/AnimationNodeStateMachinePlayback.xml
+++ b/doc/classes/AnimationNodeStateMachinePlayback.xml
@@ -23,7 +23,7 @@
 	<methods>
 		<method name="get_current_length" qualifiers="const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_current_node" qualifiers="const">

--- a/doc/classes/AnimationNodeStateMachineTransition.xml
+++ b/doc/classes/AnimationNodeStateMachineTransition.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimationNodeStateMachineTransition" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 		<link title="AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>

--- a/doc/classes/AnimationNodeSync.xml
+++ b/doc/classes/AnimationNodeSync.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimationNodeSync" inherits="AnimationNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/AnimationNodeTransition.xml
+++ b/doc/classes/AnimationNodeTransition.xml
@@ -15,27 +15,27 @@
 		<method name="get_input_caption" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="input" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="is_input_set_as_auto_advance" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="input" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_input_as_auto_advance">
 			<return type="void" />
 			<param index="0" name="input" type="int" />
 			<param index="1" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_input_caption">
 			<return type="void" />
 			<param index="0" name="input" type="int" />
 			<param index="1" name="caption" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AnimationRootNode.xml
+++ b/doc/classes/AnimationRootNode.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimationRootNode" inherits="AnimationNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/AnimationTrackEditPlugin.xml
+++ b/doc/classes/AnimationTrackEditPlugin.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimationTrackEditPlugin" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/AnimationTree.xml
+++ b/doc/classes/AnimationTree.xml
@@ -29,7 +29,7 @@
 			<return type="void" />
 			<param index="0" name="old_name" type="String" />
 			<param index="1" name="new_name" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -174,7 +174,7 @@
 			<param index="0" name="surf_idx" type="int" />
 			<param index="1" name="offset" type="int" />
 			<param index="2" name="data" type="PackedByteArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="surface_update_skin_region">
@@ -182,7 +182,7 @@
 			<param index="0" name="surf_idx" type="int" />
 			<param index="1" name="offset" type="int" />
 			<param index="2" name="data" type="PackedByteArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="surface_update_vertex_region">
@@ -190,7 +190,7 @@
 			<param index="0" name="surf_idx" type="int" />
 			<param index="1" name="offset" type="int" />
 			<param index="2" name="data" type="PackedByteArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ArrayOccluder3D.xml
+++ b/doc/classes/ArrayOccluder3D.xml
@@ -14,7 +14,7 @@
 			<return type="void" />
 			<param index="0" name="vertices" type="PackedVector3Array" />
 			<param index="1" name="indices" type="PackedInt32Array" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AudioEffect.xml
+++ b/doc/classes/AudioEffect.xml
@@ -12,7 +12,7 @@
 	<methods>
 		<method name="_instantiate" qualifiers="virtual">
 			<return type="AudioEffectInstance" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AudioEffectChorus.xml
+++ b/doc/classes/AudioEffectChorus.xml
@@ -13,79 +13,79 @@
 		<method name="get_voice_cutoff_hz" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="voice_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_voice_delay_ms" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="voice_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_voice_depth_ms" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="voice_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_voice_level_db" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="voice_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_voice_pan" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="voice_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_voice_rate_hz" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="voice_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_voice_cutoff_hz">
 			<return type="void" />
 			<param index="0" name="voice_idx" type="int" />
 			<param index="1" name="cutoff_hz" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_voice_delay_ms">
 			<return type="void" />
 			<param index="0" name="voice_idx" type="int" />
 			<param index="1" name="delay_ms" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_voice_depth_ms">
 			<return type="void" />
 			<param index="0" name="voice_idx" type="int" />
 			<param index="1" name="depth_ms" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_voice_level_db">
 			<return type="void" />
 			<param index="0" name="voice_idx" type="int" />
 			<param index="1" name="level_db" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_voice_pan">
 			<return type="void" />
 			<param index="0" name="voice_idx" type="int" />
 			<param index="1" name="pan" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_voice_rate_hz">
 			<return type="void" />
 			<param index="0" name="voice_idx" type="int" />
 			<param index="1" name="rate_hz" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AudioEffectInstance.xml
+++ b/doc/classes/AudioEffectInstance.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectInstance" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -12,12 +12,12 @@
 			<param index="0" name="src_buffer" type="const void*" />
 			<param index="1" name="dst_buffer" type="AudioFrame*" />
 			<param index="2" name="frame_count" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_process_silence" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AudioEffectSpectrumAnalyzerInstance.xml
+++ b/doc/classes/AudioEffectSpectrumAnalyzerInstance.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectSpectrumAnalyzerInstance" inherits="AudioEffectInstance" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -12,7 +12,7 @@
 			<param index="0" name="from_hz" type="float" />
 			<param index="1" name="to_hz" type="float" />
 			<param index="2" name="mode" type="int" enum="AudioEffectSpectrumAnalyzerInstance.MagnitudeMode" default="1" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -279,7 +279,7 @@
 		<method name="set_enable_tagging_used_audio_streams">
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="swap_bus_effects">

--- a/doc/classes/AudioStream.xml
+++ b/doc/classes/AudioStream.xml
@@ -15,32 +15,32 @@
 	<methods>
 		<method name="_get_beat_count" qualifiers="virtual const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_bpm" qualifiers="virtual const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_length" qualifiers="virtual const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_stream_name" qualifiers="virtual const">
 			<return type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_instantiate_playback" qualifiers="virtual const">
 			<return type="AudioStreamPlayback" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_is_monophonic" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_length" qualifiers="const">

--- a/doc/classes/AudioStreamGeneratorPlayback.xml
+++ b/doc/classes/AudioStreamGeneratorPlayback.xml
@@ -32,7 +32,7 @@
 		</method>
 		<method name="get_skips" qualifiers="const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="push_buffer">

--- a/doc/classes/AudioStreamPlayback.xml
+++ b/doc/classes/AudioStreamPlayback.xml
@@ -12,17 +12,17 @@
 	<methods>
 		<method name="_get_loop_count" qualifiers="virtual const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_playback_position" qualifiers="virtual const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_is_playing" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_mix" qualifiers="virtual">
@@ -30,29 +30,29 @@
 			<param index="0" name="buffer" type="AudioFrame*" />
 			<param index="1" name="rate_scale" type="float" />
 			<param index="2" name="frames" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_seek" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="position" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_start" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="from_pos" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_stop" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_tag_used_streams" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AudioStreamPlaybackResampled.xml
+++ b/doc/classes/AudioStreamPlaybackResampled.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioStreamPlaybackResampled" inherits="AudioStreamPlayback" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
 		<method name="_get_stream_sampling_rate" qualifiers="virtual const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_mix_resampled" qualifiers="virtual">
 			<return type="int" />
 			<param index="0" name="dst_buffer" type="AudioFrame*" />
 			<param index="1" name="frame_count" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="begin_resample">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ConeTwistJoint3D.xml
+++ b/doc/classes/ConeTwistJoint3D.xml
@@ -14,14 +14,14 @@
 		<method name="get_param" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="param" type="int" enum="ConeTwistJoint3D.Param" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_param">
 			<return type="void" />
 			<param index="0" name="param" type="int" enum="ConeTwistJoint3D.Param" />
 			<param index="1" name="value" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/EditorExportPlatform.xml
+++ b/doc/classes/EditorExportPlatform.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="EditorExportPlatform" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/EditorResourceConversionPlugin.xml
+++ b/doc/classes/EditorResourceConversionPlugin.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="EditorResourceConversionPlugin" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,18 +10,18 @@
 		<method name="_convert" qualifiers="virtual const">
 			<return type="Resource" />
 			<param index="0" name="resource" type="Resource" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_converts_to" qualifiers="virtual const">
 			<return type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_handles" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="resource" type="Resource" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/EditorSceneFormatImporter.xml
+++ b/doc/classes/EditorSceneFormatImporter.xml
@@ -12,18 +12,18 @@
 	<methods>
 		<method name="_get_extensions" qualifiers="virtual const">
 			<return type="PackedStringArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_import_flags" qualifiers="virtual const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_import_options" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="path" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_option_visibility" qualifiers="virtual const">
@@ -31,7 +31,7 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="for_animation" type="bool" />
 			<param index="2" name="option" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_import_scene" qualifiers="virtual">
@@ -40,7 +40,7 @@
 			<param index="1" name="flags" type="int" />
 			<param index="2" name="options" type="Dictionary" />
 			<param index="3" name="bake_fps" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/FileSystemDock.xml
+++ b/doc/classes/FileSystemDock.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="FileSystemDock" inherits="VBoxContainer" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,45 +10,45 @@
 		<method name="navigate_to_path">
 			<return type="void" />
 			<param index="0" name="path" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>
 	<signals>
 		<signal name="display_mode_changed">
-			<description>
+			<description>          
 			</description>
 		</signal>
 		<signal name="file_removed">
 			<param index="0" name="file" type="String" />
-			<description>
+			<description>          
 			</description>
 		</signal>
 		<signal name="files_moved">
 			<param index="0" name="old_file" type="String" />
 			<param index="1" name="new_file" type="String" />
-			<description>
+			<description>          
 			</description>
 		</signal>
 		<signal name="folder_moved">
 			<param index="0" name="old_folder" type="String" />
 			<param index="1" name="new_folder" type="String" />
-			<description>
+			<description>          
 			</description>
 		</signal>
 		<signal name="folder_removed">
 			<param index="0" name="folder" type="String" />
-			<description>
+			<description>          
 			</description>
 		</signal>
 		<signal name="inherit">
 			<param index="0" name="file" type="String" />
-			<description>
+			<description>          
 			</description>
 		</signal>
 		<signal name="instantiate">
 			<param index="0" name="files" type="PackedStringArray" />
-			<description>
+			<description>          
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/FontFile.xml
+++ b/doc/classes/FontFile.xml
@@ -87,28 +87,28 @@
 			<return type="float" />
 			<param index="0" name="cache_index" type="int" />
 			<param index="1" name="size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_cache_scale" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="cache_index" type="int" />
 			<param index="1" name="size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_cache_underline_position" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="cache_index" type="int" />
 			<param index="1" name="size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_cache_underline_thickness" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="cache_index" type="int" />
 			<param index="1" name="size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_embolden" qualifiers="const">
@@ -376,7 +376,7 @@
 			<param index="0" name="cache_index" type="int" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="ascent" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_cache_descent">
@@ -384,7 +384,7 @@
 			<param index="0" name="cache_index" type="int" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="descent" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_cache_scale">
@@ -392,7 +392,7 @@
 			<param index="0" name="cache_index" type="int" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="scale" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_cache_underline_position">
@@ -400,7 +400,7 @@
 			<param index="0" name="cache_index" type="int" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="underline_position" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_cache_underline_thickness">
@@ -408,7 +408,7 @@
 			<param index="0" name="cache_index" type="int" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="underline_thickness" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_embolden">

--- a/doc/classes/Generic6DOFJoint3D.xml
+++ b/doc/classes/Generic6DOFJoint3D.xml
@@ -12,79 +12,79 @@
 		<method name="get_flag_x" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="flag" type="int" enum="Generic6DOFJoint3D.Flag" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_flag_y" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="flag" type="int" enum="Generic6DOFJoint3D.Flag" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_flag_z" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="flag" type="int" enum="Generic6DOFJoint3D.Flag" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_param_x" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="param" type="int" enum="Generic6DOFJoint3D.Param" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_param_y" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="param" type="int" enum="Generic6DOFJoint3D.Param" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_param_z" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="param" type="int" enum="Generic6DOFJoint3D.Param" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_flag_x">
 			<return type="void" />
 			<param index="0" name="flag" type="int" enum="Generic6DOFJoint3D.Flag" />
 			<param index="1" name="value" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_flag_y">
 			<return type="void" />
 			<param index="0" name="flag" type="int" enum="Generic6DOFJoint3D.Flag" />
 			<param index="1" name="value" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_flag_z">
 			<return type="void" />
 			<param index="0" name="flag" type="int" enum="Generic6DOFJoint3D.Flag" />
 			<param index="1" name="value" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_param_x">
 			<return type="void" />
 			<param index="0" name="param" type="int" enum="Generic6DOFJoint3D.Param" />
 			<param index="1" name="value" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_param_y">
 			<return type="void" />
 			<param index="0" name="param" type="int" enum="Generic6DOFJoint3D.Param" />
 			<param index="1" name="value" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_param_z">
 			<return type="void" />
 			<param index="0" name="param" type="int" enum="Generic6DOFJoint3D.Param" />
 			<param index="1" name="value" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -355,7 +355,7 @@
 		</signal>
 		<signal name="node_deselected">
 			<param index="0" name="node" type="Node" />
-			<description>
+			<description>          
 			</description>
 		</signal>
 		<signal name="node_selected">

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -17,7 +17,7 @@
 			<param index="0" name="brightness" type="float" />
 			<param index="1" name="contrast" type="float" />
 			<param index="2" name="saturation" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="blend_rect">
@@ -85,7 +85,7 @@
 			<param index="0" name="mode" type="int" enum="Image.CompressMode" />
 			<param index="1" name="channels" type="int" enum="Image.UsedChannels" />
 			<param index="2" name="lossy_quality" type="float" default="0.7" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="compute_image_metrics">
@@ -156,7 +156,7 @@
 		<method name="detect_used_channels" qualifiers="const">
 			<return type="int" enum="Image.UsedChannels" />
 			<param index="0" name="source" type="int" enum="Image.CompressSource" default="0" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="fill">

--- a/doc/classes/ImporterMeshInstance3D.xml
+++ b/doc/classes/ImporterMeshInstance3D.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ImporterMeshInstance3D" inherits="Node3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/InputEventFromWindow.xml
+++ b/doc/classes/InputEventFromWindow.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventFromWindow" inherits="InputEvent" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/InputEventGesture.xml
+++ b/doc/classes/InputEventGesture.xml
@@ -3,7 +3,7 @@
 	<brief_description>
 		Base class for touch control gestures.
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/InputEventMagnifyGesture.xml
+++ b/doc/classes/InputEventMagnifyGesture.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventMagnifyGesture" inherits="InputEventGesture" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/InputEventPanGesture.xml
+++ b/doc/classes/InputEventPanGesture.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventPanGesture" inherits="InputEventGesture" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/InputEventShortcut.xml
+++ b/doc/classes/InputEventShortcut.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventShortcut" inherits="InputEvent" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/JSONRPC.xml
+++ b/doc/classes/JSONRPC.xml
@@ -66,14 +66,14 @@
 		<method name="process_string">
 			<return type="String" />
 			<param index="0" name="action" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_scope">
 			<return type="void" />
 			<param index="0" name="scope" type="String" />
 			<param index="1" name="target" type="Object" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/JavaClass.xml
+++ b/doc/classes/JavaClass.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="JavaClass" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/JavaClassWrapper.xml
+++ b/doc/classes/JavaClassWrapper.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="JavaClassWrapper" inherits="Object" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,7 +10,7 @@
 		<method name="wrap">
 			<return type="JavaClass" />
 			<param index="0" name="name" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Light2D.xml
+++ b/doc/classes/Light2D.xml
@@ -13,13 +13,13 @@
 	<methods>
 		<method name="get_height" qualifiers="const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_height">
 			<return type="void" />
 			<param index="0" name="height" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Material.xml
+++ b/doc/classes/Material.xml
@@ -13,27 +13,27 @@
 	<methods>
 		<method name="_can_do_next_pass" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_can_use_render_priority" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_shader_mode" qualifiers="virtual const">
 			<return type="int" enum="Shader.Mode" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_shader_rid" qualifiers="virtual const">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="inspect_native_shader_code">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -15,85 +15,85 @@
 	<methods>
 		<method name="_get_aabb" qualifiers="virtual const">
 			<return type="AABB" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_blend_shape_count" qualifiers="virtual const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_blend_shape_name" qualifiers="virtual const">
 			<return type="StringName" />
 			<param index="0" name="index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_surface_count" qualifiers="virtual const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_blend_shape_name" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<param index="1" name="name" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_surface_get_array_index_len" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_surface_get_array_len" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_surface_get_arrays" qualifiers="virtual const">
 			<return type="Array" />
 			<param index="0" name="index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_surface_get_blend_shape_arrays" qualifiers="virtual const">
 			<return type="Array[]" />
 			<param index="0" name="index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_surface_get_format" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_surface_get_lods" qualifiers="virtual const">
 			<return type="Dictionary" />
 			<param index="0" name="index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_surface_get_material" qualifiers="virtual const">
 			<return type="Material" />
 			<param index="0" name="index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_surface_get_primitive_type" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_surface_set_material" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<param index="1" name="material" type="Material" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="create_convex_shape" qualifiers="const">

--- a/doc/classes/MeshInstance3D.xml
+++ b/doc/classes/MeshInstance3D.xml
@@ -44,7 +44,7 @@
 		<method name="find_blend_shape_by_name">
 			<return type="int" />
 			<param index="0" name="name" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_active_material" qualifiers="const">
@@ -56,13 +56,13 @@
 		</method>
 		<method name="get_blend_shape_count" qualifiers="const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_blend_shape_value" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="blend_shape_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_surface_override_material" qualifiers="const">
@@ -82,7 +82,7 @@
 			<return type="void" />
 			<param index="0" name="blend_shape_idx" type="int" />
 			<param index="1" name="value" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_surface_override_material">

--- a/doc/classes/NativeExtension.xml
+++ b/doc/classes/NativeExtension.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="NativeExtension" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
 		<method name="close_library">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_minimum_library_initialization_level" qualifiers="const">
 			<return type="int" enum="NativeExtension.InitializationLevel" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="initialize_library">
 			<return type="void" />
 			<param index="0" name="level" type="int" enum="NativeExtension.InitializationLevel" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="is_library_open" qualifiers="const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="open_library">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="entry_symbol" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/NativeExtensionManager.xml
+++ b/doc/classes/NativeExtensionManager.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="NativeExtensionManager" inherits="Object" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,36 +10,36 @@
 		<method name="get_extension">
 			<return type="NativeExtension" />
 			<param index="0" name="path" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_loaded_extensions" qualifiers="const">
 			<return type="PackedStringArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="is_extension_loaded" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="path" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="load_extension">
 			<return type="int" enum="NativeExtensionManager.LoadStatus" />
 			<param index="0" name="path" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="reload_extension">
 			<return type="int" enum="NativeExtensionManager.LoadStatus" />
 			<param index="0" name="path" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="unload_extension">
 			<return type="int" enum="NativeExtensionManager.LoadStatus" />
 			<param index="0" name="path" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Node3DGizmo.xml
+++ b/doc/classes/Node3DGizmo.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Node3DGizmo" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -616,7 +616,7 @@
 	</methods>
 	<signals>
 		<signal name="property_list_changed">
-			<description>
+			<description>          
 			</description>
 		</signal>
 		<signal name="script_changed">

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -93,7 +93,7 @@
 		<method name="get_selectable_item" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="from_last" type="bool" default="false" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_selected_id" qualifiers="const">
@@ -110,7 +110,7 @@
 		</method>
 		<method name="has_selectable_items" qualifiers="const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="is_item_disabled" qualifiers="const">
@@ -123,7 +123,7 @@
 		<method name="is_item_separator" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="remove_item">

--- a/doc/classes/PackedDataContainer.xml
+++ b/doc/classes/PackedDataContainer.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PackedDataContainer" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,12 +10,12 @@
 		<method name="pack">
 			<return type="int" enum="Error" />
 			<param index="0" name="value" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="size" qualifiers="const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PackedDataContainerRef.xml
+++ b/doc/classes/PackedDataContainerRef.xml
@@ -3,14 +3,14 @@
 	<brief_description>
 		Reference-counted version of [PackedDataContainer].
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
 		<method name="size" qualifiers="const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PacketPeerExtension.xml
+++ b/doc/classes/PacketPeerExtension.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PacketPeerExtension" inherits="PacketPeer" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
 		<method name="_get_available_packet_count" qualifiers="virtual const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_max_packet_size" qualifiers="virtual const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_packet" qualifiers="virtual">
 			<return type="int" enum="Error" />
 			<param index="0" name="r_buffer" type="const uint8_t **" />
 			<param index="1" name="r_buffer_size" type="int32_t*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_put_packet" qualifiers="virtual">
 			<return type="int" enum="Error" />
 			<param index="0" name="p_buffer" type="const uint8_t*" />
 			<param index="1" name="p_buffer_size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicalBone3D.xml
+++ b/doc/classes/PhysicalBone3D.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PhysicalBone3D" inherits="PhysicsBody3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -17,29 +17,29 @@
 		<method name="apply_central_impulse">
 			<return type="void" />
 			<param index="0" name="impulse" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="apply_impulse">
 			<return type="void" />
 			<param index="0" name="impulse" type="Vector3" />
 			<param index="1" name="position" type="Vector3" default="Vector3(0, 0, 0)" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_bone_id" qualifiers="const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_simulate_physics">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="is_simulating_physics">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicsDirectBodyState2DExtension.xml
+++ b/doc/classes/PhysicsDirectBodyState2DExtension.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PhysicsDirectBodyState2DExtension" inherits="PhysicsDirectBodyState2D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,239 +10,239 @@
 		<method name="_add_constant_central_force" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="force" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_add_constant_force" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="force" type="Vector2" />
 			<param index="1" name="position" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_add_constant_torque" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="torque" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_apply_central_force" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="force" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_apply_central_impulse" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="impulse" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_apply_force" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="force" type="Vector2" />
 			<param index="1" name="position" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_apply_impulse" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="impulse" type="Vector2" />
 			<param index="1" name="position" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_apply_torque" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="torque" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_apply_torque_impulse" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="impulse" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_angular_velocity" qualifiers="virtual const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_center_of_mass" qualifiers="virtual const">
 			<return type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_center_of_mass_local" qualifiers="virtual const">
 			<return type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_constant_force" qualifiers="virtual const">
 			<return type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_constant_torque" qualifiers="virtual const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_collider" qualifiers="virtual const">
 			<return type="RID" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_collider_id" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_collider_object" qualifiers="virtual const">
 			<return type="Object" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_collider_position" qualifiers="virtual const">
 			<return type="Vector2" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_collider_shape" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_collider_velocity_at_position" qualifiers="virtual const">
 			<return type="Vector2" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_count" qualifiers="virtual const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_local_normal" qualifiers="virtual const">
 			<return type="Vector2" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_local_position" qualifiers="virtual const">
 			<return type="Vector2" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_local_shape" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_inverse_inertia" qualifiers="virtual const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_inverse_mass" qualifiers="virtual const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_linear_velocity" qualifiers="virtual const">
 			<return type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_space_state" qualifiers="virtual">
 			<return type="PhysicsDirectSpaceState2D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_step" qualifiers="virtual const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_total_angular_damp" qualifiers="virtual const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_total_gravity" qualifiers="virtual const">
 			<return type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_total_linear_damp" qualifiers="virtual const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_transform" qualifiers="virtual const">
 			<return type="Transform2D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_velocity_at_local_position" qualifiers="virtual const">
 			<return type="Vector2" />
 			<param index="0" name="local_position" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_integrate_forces" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_is_sleeping" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_angular_velocity" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="velocity" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_constant_force" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="force" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_constant_torque" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="torque" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_linear_velocity" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="velocity" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_sleep_state" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="enabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_transform" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="transform" type="Transform2D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicsDirectBodyState3DExtension.xml
+++ b/doc/classes/PhysicsDirectBodyState3DExtension.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PhysicsDirectBodyState3DExtension" inherits="PhysicsDirectBodyState3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,255 +10,255 @@
 		<method name="_add_constant_central_force" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="force" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_add_constant_force" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="force" type="Vector3" />
 			<param index="1" name="position" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_add_constant_torque" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="torque" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_apply_central_force" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="force" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_apply_central_impulse" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="impulse" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_apply_force" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="force" type="Vector3" />
 			<param index="1" name="position" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_apply_impulse" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="impulse" type="Vector3" />
 			<param index="1" name="position" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_apply_torque" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="torque" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_apply_torque_impulse" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="impulse" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_angular_velocity" qualifiers="virtual const">
 			<return type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_center_of_mass" qualifiers="virtual const">
 			<return type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_center_of_mass_local" qualifiers="virtual const">
 			<return type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_constant_force" qualifiers="virtual const">
 			<return type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_constant_torque" qualifiers="virtual const">
 			<return type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_collider" qualifiers="virtual const">
 			<return type="RID" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_collider_id" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_collider_object" qualifiers="virtual const">
 			<return type="Object" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_collider_position" qualifiers="virtual const">
 			<return type="Vector3" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_collider_shape" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_collider_velocity_at_position" qualifiers="virtual const">
 			<return type="Vector3" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_count" qualifiers="virtual const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_impulse" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_local_normal" qualifiers="virtual const">
 			<return type="Vector3" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_local_position" qualifiers="virtual const">
 			<return type="Vector3" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_contact_local_shape" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="contact_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_inverse_inertia" qualifiers="virtual const">
 			<return type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_inverse_inertia_tensor" qualifiers="virtual const">
 			<return type="Basis" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_inverse_mass" qualifiers="virtual const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_linear_velocity" qualifiers="virtual const">
 			<return type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_principal_inertia_axes" qualifiers="virtual const">
 			<return type="Basis" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_space_state" qualifiers="virtual">
 			<return type="PhysicsDirectSpaceState3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_step" qualifiers="virtual const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_total_angular_damp" qualifiers="virtual const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_total_gravity" qualifiers="virtual const">
 			<return type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_total_linear_damp" qualifiers="virtual const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_transform" qualifiers="virtual const">
 			<return type="Transform3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_velocity_at_local_position" qualifiers="virtual const">
 			<return type="Vector3" />
 			<param index="0" name="local_position" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_integrate_forces" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_is_sleeping" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_angular_velocity" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="velocity" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_constant_force" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="force" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_constant_torque" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="torque" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_linear_velocity" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="velocity" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_sleep_state" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="enabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_transform" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="transform" type="Transform3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicsDirectSpaceState2DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState2DExtension.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PhysicsDirectSpaceState2DExtension" inherits="PhysicsDirectSpaceState2D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -18,7 +18,7 @@
 			<param index="6" name="collide_with_areas" type="bool" />
 			<param index="7" name="closest_safe" type="float*" />
 			<param index="8" name="closest_unsafe" type="float*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_collide_shape" qualifiers="virtual">
@@ -33,7 +33,7 @@
 			<param index="7" name="results" type="void*" />
 			<param index="8" name="max_results" type="int" />
 			<param index="9" name="result_count" type="int32_t*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_intersect_point" qualifiers="virtual">
@@ -45,7 +45,7 @@
 			<param index="4" name="collide_with_areas" type="bool" />
 			<param index="5" name="results" type="PhysicsServer2DExtensionShapeResult*" />
 			<param index="6" name="max_results" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_intersect_ray" qualifiers="virtual">
@@ -57,7 +57,7 @@
 			<param index="4" name="collide_with_areas" type="bool" />
 			<param index="5" name="hit_from_inside" type="bool" />
 			<param index="6" name="result" type="PhysicsServer2DExtensionRayResult*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_intersect_shape" qualifiers="virtual">
@@ -71,7 +71,7 @@
 			<param index="6" name="collide_with_areas" type="bool" />
 			<param index="7" name="result" type="PhysicsServer2DExtensionShapeResult*" />
 			<param index="8" name="max_results" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_rest_info" qualifiers="virtual">
@@ -84,7 +84,7 @@
 			<param index="5" name="collide_with_bodies" type="bool" />
 			<param index="6" name="collide_with_areas" type="bool" />
 			<param index="7" name="rest_info" type="PhysicsServer2DExtensionShapeRestInfo*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicsDirectSpaceState3DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState3DExtension.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PhysicsDirectSpaceState3DExtension" inherits="PhysicsDirectSpaceState3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -19,7 +19,7 @@
 			<param index="7" name="closest_safe" type="float*" />
 			<param index="8" name="closest_unsafe" type="float*" />
 			<param index="9" name="info" type="PhysicsServer3DExtensionShapeRestInfo*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_collide_shape" qualifiers="virtual">
@@ -34,14 +34,14 @@
 			<param index="7" name="results" type="void*" />
 			<param index="8" name="max_results" type="int" />
 			<param index="9" name="result_count" type="int32_t*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_closest_point_to_object_volume" qualifiers="virtual const">
 			<return type="Vector3" />
 			<param index="0" name="object" type="RID" />
 			<param index="1" name="point" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_intersect_point" qualifiers="virtual">
@@ -52,7 +52,7 @@
 			<param index="3" name="collide_with_areas" type="bool" />
 			<param index="4" name="results" type="PhysicsServer3DExtensionShapeResult*" />
 			<param index="5" name="max_results" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_intersect_ray" qualifiers="virtual">
@@ -65,7 +65,7 @@
 			<param index="5" name="hit_from_inside" type="bool" />
 			<param index="6" name="hit_back_faces" type="bool" />
 			<param index="7" name="result" type="PhysicsServer3DExtensionRayResult*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_intersect_shape" qualifiers="virtual">
@@ -79,7 +79,7 @@
 			<param index="6" name="collide_with_areas" type="bool" />
 			<param index="7" name="result_count" type="PhysicsServer3DExtensionShapeResult*" />
 			<param index="8" name="max_results" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_rest_info" qualifiers="virtual">
@@ -92,7 +92,7 @@
 			<param index="5" name="collide_with_bodies" type="bool" />
 			<param index="6" name="collide_with_areas" type="bool" />
 			<param index="7" name="rest_info" type="PhysicsServer3DExtensionShapeRestInfo*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -23,7 +23,7 @@
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="id" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="area_attach_object_instance_id">
@@ -50,7 +50,7 @@
 		<method name="area_get_canvas_instance_id" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="area_get_collision_layer" qualifiers="const">
@@ -131,7 +131,7 @@
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="callback" type="Callable" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="area_set_collision_layer">
@@ -167,7 +167,7 @@
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="monitorable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="area_set_param">
@@ -328,7 +328,7 @@
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="id" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="body_attach_object_instance_id">
@@ -355,7 +355,7 @@
 		<method name="body_get_canvas_instance_id" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="body_get_collision_layer" qualifiers="const">
@@ -676,22 +676,22 @@
 		</method>
 		<method name="capsule_shape_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="circle_shape_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="concave_polygon_shape_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="convex_polygon_shape_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="damped_spring_joint_get_param" qualifiers="const">
@@ -728,12 +728,12 @@
 		<method name="joint_clear">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="joint_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="joint_get_param" qualifiers="const">
@@ -758,7 +758,7 @@
 			<param index="2" name="anchor_b" type="Vector2" />
 			<param index="3" name="body_a" type="RID" />
 			<param index="4" name="body_b" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="joint_make_groove">
@@ -769,7 +769,7 @@
 			<param index="3" name="anchor_b" type="Vector2" />
 			<param index="4" name="body_a" type="RID" />
 			<param index="5" name="body_b" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="joint_make_pin">
@@ -778,7 +778,7 @@
 			<param index="1" name="anchor" type="Vector2" />
 			<param index="2" name="body_a" type="RID" />
 			<param index="3" name="body_b" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="joint_set_param">
@@ -792,17 +792,17 @@
 		</method>
 		<method name="rectangle_shape_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="segment_shape_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="separation_ray_shape_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_active">
@@ -881,7 +881,7 @@
 		</method>
 		<method name="world_boundary_shape_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PhysicsServer2DExtension" inherits="PhysicsServer2D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -13,137 +13,137 @@
 			<param index="1" name="shape" type="RID" />
 			<param index="2" name="transform" type="Transform2D" />
 			<param index="3" name="disabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_attach_canvas_instance_id" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="id" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_attach_object_instance_id" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="id" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_clear_shapes" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_canvas_instance_id" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_collision_layer" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_collision_mask" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_object_instance_id" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_param" qualifiers="virtual const">
 			<return type="Variant" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.AreaParameter" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_shape" qualifiers="virtual const">
 			<return type="RID" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_shape_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_shape_transform" qualifiers="virtual const">
 			<return type="Transform2D" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_space" qualifiers="virtual const">
 			<return type="RID" />
 			<param index="0" name="area" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_transform" qualifiers="virtual const">
 			<return type="Transform2D" />
 			<param index="0" name="area" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_remove_shape" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_area_monitor_callback" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="callback" type="Callable" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_collision_layer" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="layer" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_collision_mask" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="mask" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_monitor_callback" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="callback" type="Callable" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_monitorable" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="monitorable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_param" qualifiers="virtual">
@@ -151,14 +151,14 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.AreaParameter" />
 			<param index="2" name="value" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_pickable" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="pickable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_shape" qualifiers="virtual">
@@ -166,7 +166,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="shape" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_shape_disabled" qualifiers="virtual">
@@ -174,7 +174,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="disabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_shape_transform" qualifiers="virtual">
@@ -182,35 +182,35 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="transform" type="Transform2D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_space" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="space" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_transform" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="transform" type="Transform2D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_add_collision_exception" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="excepted_body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_add_constant_central_force" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_add_constant_force" qualifiers="virtual">
@@ -218,14 +218,14 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector2" />
 			<param index="2" name="position" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_add_constant_torque" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="torque" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_add_shape" qualifiers="virtual">
@@ -234,21 +234,21 @@
 			<param index="1" name="shape" type="RID" />
 			<param index="2" name="transform" type="Transform2D" />
 			<param index="3" name="disabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_apply_central_force" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_apply_central_impulse" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="impulse" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_apply_force" qualifiers="virtual">
@@ -256,7 +256,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector2" />
 			<param index="2" name="position" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_apply_impulse" qualifiers="virtual">
@@ -264,41 +264,41 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="impulse" type="Vector2" />
 			<param index="2" name="position" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_apply_torque" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="torque" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_apply_torque_impulse" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="impulse" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_attach_canvas_instance_id" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="id" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_attach_object_instance_id" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="id" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_clear_shapes" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_collide_shape" qualifiers="virtual">
@@ -311,212 +311,212 @@
 			<param index="5" name="results" type="void*" />
 			<param index="6" name="result_max" type="int" />
 			<param index="7" name="result_count" type="int32_t*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_canvas_instance_id" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_collision_exceptions" qualifiers="virtual const">
 			<return type="RID[]" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_collision_layer" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_collision_mask" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_collision_priority" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_constant_force" qualifiers="virtual const">
 			<return type="Vector2" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_constant_torque" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_contacts_reported_depth_threshold" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_continuous_collision_detection_mode" qualifiers="virtual const">
 			<return type="int" enum="PhysicsServer2D.CCDMode" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_direct_state" qualifiers="virtual">
 			<return type="PhysicsDirectBodyState2D" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_max_contacts_reported" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_mode" qualifiers="virtual const">
 			<return type="int" enum="PhysicsServer2D.BodyMode" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_object_instance_id" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_param" qualifiers="virtual const">
 			<return type="Variant" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.BodyParameter" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_shape" qualifiers="virtual const">
 			<return type="RID" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_shape_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_shape_transform" qualifiers="virtual const">
 			<return type="Transform2D" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_space" qualifiers="virtual const">
 			<return type="RID" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_state" qualifiers="virtual const">
 			<return type="Variant" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer2D.BodyState" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_is_omitting_force_integration" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_remove_collision_exception" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="excepted_body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_remove_shape" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_reset_mass_properties" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_axis_velocity" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="axis_velocity" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_collision_layer" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="layer" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_collision_mask" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mask" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_collision_priority" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="priority" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_constant_force" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_constant_torque" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="torque" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_contacts_reported_depth_threshold" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="threshold" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_continuous_collision_detection_mode" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mode" type="int" enum="PhysicsServer2D.CCDMode" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_force_integration_callback" qualifiers="virtual">
@@ -524,28 +524,28 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="callable" type="Callable" />
 			<param index="2" name="userdata" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_max_contacts_reported" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="amount" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_mode" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mode" type="int" enum="PhysicsServer2D.BodyMode" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_omit_force_integration" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_param" qualifiers="virtual">
@@ -553,14 +553,14 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.BodyParameter" />
 			<param index="2" name="value" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_pickable" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="pickable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_shape" qualifiers="virtual">
@@ -568,7 +568,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="shape" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_shape_as_one_way_collision" qualifiers="virtual">
@@ -577,7 +577,7 @@
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="enable" type="bool" />
 			<param index="3" name="margin" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_shape_disabled" qualifiers="virtual">
@@ -585,7 +585,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="disabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_shape_transform" qualifiers="virtual">
@@ -593,14 +593,14 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="transform" type="Transform2D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_space" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="space" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_state" qualifiers="virtual">
@@ -608,14 +608,14 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer2D.BodyState" />
 			<param index="2" name="value" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_state_sync_callback" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="callable" type="Callable" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_test_motion" qualifiers="virtual const">
@@ -627,34 +627,34 @@
 			<param index="4" name="collide_separation_ray" type="bool" />
 			<param index="5" name="recovery_as_collision" type="bool" />
 			<param index="6" name="result" type="PhysicsServer2DExtensionMotionResult*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_capsule_shape_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_circle_shape_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_concave_polygon_shape_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_convex_polygon_shape_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_damped_spring_joint_get_param" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.DampedSpringParam" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_damped_spring_joint_set_param" qualifiers="virtual">
@@ -662,81 +662,81 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.DampedSpringParam" />
 			<param index="2" name="value" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_end_sync" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_finish" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_flush_queries" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_free_rid" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_process_info" qualifiers="virtual">
 			<return type="int" />
 			<param index="0" name="process_info" type="int" enum="PhysicsServer2D.ProcessInfo" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_init" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_is_flushing_queries" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_clear" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_disable_collisions_between_bodies" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="disable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_get_param" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.JointParam" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_get_type" qualifiers="virtual const">
 			<return type="int" enum="PhysicsServer2D.JointType" />
 			<param index="0" name="joint" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_is_disabled_collisions_between_bodies" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="joint" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_make_damped_spring" qualifiers="virtual">
@@ -746,7 +746,7 @@
 			<param index="2" name="anchor_b" type="Vector2" />
 			<param index="3" name="body_a" type="RID" />
 			<param index="4" name="body_b" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_make_groove" qualifiers="virtual">
@@ -757,7 +757,7 @@
 			<param index="3" name="b_anchor" type="Vector2" />
 			<param index="4" name="body_a" type="RID" />
 			<param index="5" name="body_b" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_make_pin" qualifiers="virtual">
@@ -766,7 +766,7 @@
 			<param index="1" name="anchor" type="Vector2" />
 			<param index="2" name="body_a" type="RID" />
 			<param index="3" name="body_b" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_set_param" qualifiers="virtual">
@@ -774,14 +774,14 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.JointParam" />
 			<param index="2" name="value" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_pin_joint_get_param" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.PinJointParam" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_pin_joint_set_param" qualifiers="virtual">
@@ -789,28 +789,28 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.PinJointParam" />
 			<param index="2" name="value" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_rectangle_shape_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_segment_shape_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_separation_ray_shape_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_active" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="active" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shape_collide" qualifiers="virtual">
@@ -824,89 +824,89 @@
 			<param index="6" name="results" type="void*" />
 			<param index="7" name="result_max" type="int" />
 			<param index="8" name="result_count" type="int32_t*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shape_get_custom_solver_bias" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="shape" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shape_get_data" qualifiers="virtual const">
 			<return type="Variant" />
 			<param index="0" name="shape" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shape_get_type" qualifiers="virtual const">
 			<return type="int" enum="PhysicsServer2D.ShapeType" />
 			<param index="0" name="shape" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shape_set_custom_solver_bias" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="shape" type="RID" />
 			<param index="1" name="bias" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shape_set_data" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="shape" type="RID" />
 			<param index="1" name="data" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_space_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_space_get_contact_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="space" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_space_get_contacts" qualifiers="virtual const">
 			<return type="PackedVector2Array" />
 			<param index="0" name="space" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_space_get_direct_state" qualifiers="virtual">
 			<return type="PhysicsDirectSpaceState2D" />
 			<param index="0" name="space" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_space_get_param" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.SpaceParameter" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_space_is_active" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="space" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_space_set_active" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="active" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_space_set_debug_contacts" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="max_contacts" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_space_set_param" qualifiers="virtual">
@@ -914,23 +914,23 @@
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.SpaceParameter" />
 			<param index="2" name="value" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_step" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="step" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_sync" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_world_boundary_shape_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -118,7 +118,7 @@
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="callback" type="Callable" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="area_set_collision_layer">
@@ -154,7 +154,7 @@
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="monitorable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="area_set_param">
@@ -188,7 +188,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="disabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="area_set_shape_transform">
@@ -335,7 +335,7 @@
 		</method>
 		<method name="body_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="body_get_collision_layer" qualifiers="const">
@@ -453,7 +453,7 @@
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="axis" type="int" enum="PhysicsServer3D.BodyAxis" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="body_is_continuous_collision_detection_enabled" qualifiers="const">
@@ -499,7 +499,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="axis" type="int" enum="PhysicsServer3D.BodyAxis" />
 			<param index="2" name="lock" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="body_set_axis_velocity">
@@ -628,7 +628,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="disabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="body_set_shape_transform">
@@ -668,17 +668,17 @@
 		</method>
 		<method name="box_shape_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="capsule_shape_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="concave_polygon_shape_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="cone_twist_joint_get_param" qualifiers="const">
@@ -700,17 +700,17 @@
 		</method>
 		<method name="convex_polygon_shape_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="custom_shape_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="cylinder_shape_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="free_rid">
@@ -767,7 +767,7 @@
 		</method>
 		<method name="heightmap_shape_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="hinge_joint_get_flag" qualifiers="const">
@@ -807,12 +807,12 @@
 		<method name="joint_clear">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="joint_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="joint_get_solver_priority" qualifiers="const">
@@ -836,7 +836,7 @@
 			<param index="2" name="local_ref_A" type="Transform3D" />
 			<param index="3" name="body_B" type="RID" />
 			<param index="4" name="local_ref_B" type="Transform3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="joint_make_generic_6dof">
@@ -846,7 +846,7 @@
 			<param index="2" name="local_ref_A" type="Transform3D" />
 			<param index="3" name="body_B" type="RID" />
 			<param index="4" name="local_ref_B" type="Transform3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="joint_make_hinge">
@@ -856,7 +856,7 @@
 			<param index="2" name="hinge_A" type="Transform3D" />
 			<param index="3" name="body_B" type="RID" />
 			<param index="4" name="hinge_B" type="Transform3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="joint_make_pin">
@@ -866,7 +866,7 @@
 			<param index="2" name="local_A" type="Vector3" />
 			<param index="3" name="body_B" type="RID" />
 			<param index="4" name="local_B" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="joint_make_slider">
@@ -876,7 +876,7 @@
 			<param index="2" name="local_ref_A" type="Transform3D" />
 			<param index="3" name="body_B" type="RID" />
 			<param index="4" name="local_ref_B" type="Transform3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="joint_set_solver_priority">
@@ -936,7 +936,7 @@
 		</method>
 		<method name="separation_ray_shape_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_active">
@@ -988,7 +988,7 @@
 		<method name="soft_body_get_bounds" qualifiers="const">
 			<return type="AABB" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="space_create">
@@ -1038,12 +1038,12 @@
 		</method>
 		<method name="sphere_shape_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="world_boundary_shape_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PhysicsServer3DExtension" inherits="PhysicsServer3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -13,124 +13,124 @@
 			<param index="1" name="shape" type="RID" />
 			<param index="2" name="transform" type="Transform3D" />
 			<param index="3" name="disabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_attach_object_instance_id" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="id" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_clear_shapes" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_collision_layer" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_collision_mask" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_object_instance_id" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_param" qualifiers="virtual const">
 			<return type="Variant" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.AreaParameter" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_shape" qualifiers="virtual const">
 			<return type="RID" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_shape_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_shape_transform" qualifiers="virtual const">
 			<return type="Transform3D" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_space" qualifiers="virtual const">
 			<return type="RID" />
 			<param index="0" name="area" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_get_transform" qualifiers="virtual const">
 			<return type="Transform3D" />
 			<param index="0" name="area" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_remove_shape" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_area_monitor_callback" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="callback" type="Callable" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_collision_layer" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="layer" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_collision_mask" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="mask" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_monitor_callback" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="callback" type="Callable" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_monitorable" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="monitorable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_param" qualifiers="virtual">
@@ -138,14 +138,14 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.AreaParameter" />
 			<param index="2" name="value" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_ray_pickable" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_shape" qualifiers="virtual">
@@ -153,7 +153,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="shape" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_shape_disabled" qualifiers="virtual">
@@ -161,7 +161,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="disabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_shape_transform" qualifiers="virtual">
@@ -169,35 +169,35 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="transform" type="Transform3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_space" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="space" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_area_set_transform" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="transform" type="Transform3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_add_collision_exception" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="excepted_body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_add_constant_central_force" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_add_constant_force" qualifiers="virtual">
@@ -205,14 +205,14 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector3" />
 			<param index="2" name="position" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_add_constant_torque" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="torque" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_add_shape" qualifiers="virtual">
@@ -221,21 +221,21 @@
 			<param index="1" name="shape" type="RID" />
 			<param index="2" name="transform" type="Transform3D" />
 			<param index="3" name="disabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_apply_central_force" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_apply_central_impulse" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="impulse" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_apply_force" qualifiers="virtual">
@@ -243,7 +243,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector3" />
 			<param index="2" name="position" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_apply_impulse" qualifiers="virtual">
@@ -251,190 +251,190 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="impulse" type="Vector3" />
 			<param index="2" name="position" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_apply_torque" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="torque" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_apply_torque_impulse" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="impulse" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_attach_object_instance_id" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="id" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_clear_shapes" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_collision_exceptions" qualifiers="virtual const">
 			<return type="RID[]" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_collision_layer" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_collision_mask" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_collision_priority" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_constant_force" qualifiers="virtual const">
 			<return type="Vector3" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_constant_torque" qualifiers="virtual const">
 			<return type="Vector3" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_contacts_reported_depth_threshold" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_direct_state" qualifiers="virtual">
 			<return type="PhysicsDirectBodyState3D" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_max_contacts_reported" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_mode" qualifiers="virtual const">
 			<return type="int" enum="PhysicsServer3D.BodyMode" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_object_instance_id" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_param" qualifiers="virtual const">
 			<return type="Variant" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.BodyParameter" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_shape" qualifiers="virtual const">
 			<return type="RID" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_shape_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_shape_transform" qualifiers="virtual const">
 			<return type="Transform3D" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_space" qualifiers="virtual const">
 			<return type="RID" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_state" qualifiers="virtual const">
 			<return type="Variant" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_get_user_flags" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_is_axis_locked" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="axis" type="int" enum="PhysicsServer3D.BodyAxis" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_is_continuous_collision_detection_enabled" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_is_omitting_force_integration" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_remove_collision_exception" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="excepted_body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_remove_shape" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_reset_mass_properties" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_axis_lock" qualifiers="virtual">
@@ -442,63 +442,63 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="axis" type="int" enum="PhysicsServer3D.BodyAxis" />
 			<param index="2" name="lock" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_axis_velocity" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="axis_velocity" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_collision_layer" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="layer" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_collision_mask" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mask" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_collision_priority" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="priority" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_constant_force" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_constant_torque" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="torque" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_contacts_reported_depth_threshold" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="threshold" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_enable_continuous_collision_detection" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_force_integration_callback" qualifiers="virtual">
@@ -506,28 +506,28 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="callable" type="Callable" />
 			<param index="2" name="userdata" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_max_contacts_reported" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="amount" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_mode" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mode" type="int" enum="PhysicsServer3D.BodyMode" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_omit_force_integration" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_param" qualifiers="virtual">
@@ -535,14 +535,14 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.BodyParameter" />
 			<param index="2" name="value" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_ray_pickable" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_shape" qualifiers="virtual">
@@ -550,7 +550,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="shape" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_shape_disabled" qualifiers="virtual">
@@ -558,7 +558,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="disabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_shape_transform" qualifiers="virtual">
@@ -566,14 +566,14 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="transform" type="Transform3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_space" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="space" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_state" qualifiers="virtual">
@@ -581,21 +581,21 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
 			<param index="2" name="value" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_state_sync_callback" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="callable" type="Callable" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_set_user_flags" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="flags" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_body_test_motion" qualifiers="virtual const">
@@ -607,29 +607,29 @@
 			<param index="4" name="max_collisions" type="int" />
 			<param index="5" name="collide_separation_ray" type="bool" />
 			<param index="6" name="result" type="PhysicsServer3DExtensionMotionResult*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_box_shape_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_capsule_shape_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_concave_polygon_shape_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_cone_twist_joint_get_param" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.ConeTwistJointParam" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_cone_twist_joint_set_param" qualifiers="virtual">
@@ -637,43 +637,43 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.ConeTwistJointParam" />
 			<param index="2" name="value" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_convex_polygon_shape_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_custom_shape_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_cylinder_shape_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_end_sync" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_finish" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_flush_queries" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_free_rid" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_generic_6dof_joint_get_flag" qualifiers="virtual const">
@@ -681,7 +681,7 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
 			<param index="2" name="flag" type="int" enum="PhysicsServer3D.G6DOFJointAxisFlag" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_generic_6dof_joint_get_param" qualifiers="virtual const">
@@ -689,7 +689,7 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
 			<param index="2" name="param" type="int" enum="PhysicsServer3D.G6DOFJointAxisParam" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_generic_6dof_joint_set_flag" qualifiers="virtual">
@@ -698,7 +698,7 @@
 			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
 			<param index="2" name="flag" type="int" enum="PhysicsServer3D.G6DOFJointAxisFlag" />
 			<param index="3" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_generic_6dof_joint_set_param" qualifiers="virtual">
@@ -707,32 +707,32 @@
 			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
 			<param index="2" name="param" type="int" enum="PhysicsServer3D.G6DOFJointAxisParam" />
 			<param index="3" name="value" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_process_info" qualifiers="virtual">
 			<return type="int" />
 			<param index="0" name="process_info" type="int" enum="PhysicsServer3D.ProcessInfo" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_heightmap_shape_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_hinge_joint_get_flag" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="flag" type="int" enum="PhysicsServer3D.HingeJointFlag" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_hinge_joint_get_param" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.HingeJointParam" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_hinge_joint_set_flag" qualifiers="virtual">
@@ -740,7 +740,7 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="flag" type="int" enum="PhysicsServer3D.HingeJointFlag" />
 			<param index="2" name="enabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_hinge_joint_set_param" qualifiers="virtual">
@@ -748,40 +748,40 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.HingeJointParam" />
 			<param index="2" name="value" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_init" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_is_flushing_queries" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_clear" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_get_solver_priority" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="joint" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_get_type" qualifiers="virtual const">
 			<return type="int" enum="PhysicsServer3D.JointType" />
 			<param index="0" name="joint" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_make_cone_twist" qualifiers="virtual">
@@ -791,7 +791,7 @@
 			<param index="2" name="local_ref_A" type="Transform3D" />
 			<param index="3" name="body_B" type="RID" />
 			<param index="4" name="local_ref_B" type="Transform3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_make_generic_6dof" qualifiers="virtual">
@@ -801,7 +801,7 @@
 			<param index="2" name="local_ref_A" type="Transform3D" />
 			<param index="3" name="body_B" type="RID" />
 			<param index="4" name="local_ref_B" type="Transform3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_make_hinge" qualifiers="virtual">
@@ -811,7 +811,7 @@
 			<param index="2" name="hinge_A" type="Transform3D" />
 			<param index="3" name="body_B" type="RID" />
 			<param index="4" name="hinge_B" type="Transform3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_make_hinge_simple" qualifiers="virtual">
@@ -823,7 +823,7 @@
 			<param index="4" name="body_B" type="RID" />
 			<param index="5" name="pivot_B" type="Vector3" />
 			<param index="6" name="axis_B" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_make_pin" qualifiers="virtual">
@@ -833,7 +833,7 @@
 			<param index="2" name="local_A" type="Vector3" />
 			<param index="3" name="body_B" type="RID" />
 			<param index="4" name="local_B" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_make_slider" qualifiers="virtual">
@@ -843,47 +843,47 @@
 			<param index="2" name="local_ref_A" type="Transform3D" />
 			<param index="3" name="body_B" type="RID" />
 			<param index="4" name="local_ref_B" type="Transform3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_joint_set_solver_priority" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="priority" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_pin_joint_get_local_a" qualifiers="virtual const">
 			<return type="Vector3" />
 			<param index="0" name="joint" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_pin_joint_get_local_b" qualifiers="virtual const">
 			<return type="Vector3" />
 			<param index="0" name="joint" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_pin_joint_get_param" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.PinJointParam" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_pin_joint_set_local_a" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="local_A" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_pin_joint_set_local_b" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="local_B" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_pin_joint_set_param" qualifiers="virtual">
@@ -891,70 +891,70 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.PinJointParam" />
 			<param index="2" name="value" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_separation_ray_shape_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_active" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="active" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shape_get_custom_solver_bias" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="shape" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shape_get_data" qualifiers="virtual const">
 			<return type="Variant" />
 			<param index="0" name="shape" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shape_get_margin" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="shape" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shape_get_type" qualifiers="virtual const">
 			<return type="int" enum="PhysicsServer3D.ShapeType" />
 			<param index="0" name="shape" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shape_set_custom_solver_bias" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="shape" type="RID" />
 			<param index="1" name="bias" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shape_set_data" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="shape" type="RID" />
 			<param index="1" name="data" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shape_set_margin" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="shape" type="RID" />
 			<param index="1" name="margin" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_slider_joint_get_param" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.SliderJointParam" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_slider_joint_set_param" qualifiers="virtual">
@@ -962,106 +962,106 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.SliderJointParam" />
 			<param index="2" name="value" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_add_collision_exception" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="body_b" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_get_bounds" qualifiers="virtual const">
 			<return type="AABB" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_get_collision_exceptions" qualifiers="virtual const">
 			<return type="RID[]" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_get_collision_layer" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_get_collision_mask" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_get_damping_coefficient" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_get_drag_coefficient" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_get_linear_stiffness" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_get_point_global_position" qualifiers="virtual const">
 			<return type="Vector3" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="point_index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_get_pressure_coefficient" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_get_simulation_precision" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_get_space" qualifiers="virtual const">
 			<return type="RID" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_get_state" qualifiers="virtual const">
 			<return type="Variant" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_get_total_mass" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_is_point_pinned" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="point_index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_move_point" qualifiers="virtual">
@@ -1069,7 +1069,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="point_index" type="int" />
 			<param index="2" name="global_position" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_pin_point" qualifiers="virtual">
@@ -1077,90 +1077,90 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="point_index" type="int" />
 			<param index="2" name="pin" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_remove_all_pinned_points" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_remove_collision_exception" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="body_b" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_set_collision_layer" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="layer" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_set_collision_mask" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mask" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_set_damping_coefficient" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="damping_coefficient" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_set_drag_coefficient" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="drag_coefficient" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_set_linear_stiffness" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="linear_stiffness" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_set_mesh" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mesh" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_set_pressure_coefficient" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="pressure_coefficient" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_set_ray_pickable" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_set_simulation_precision" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="simulation_precision" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_set_space" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="space" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_set_state" qualifiers="virtual">
@@ -1168,78 +1168,78 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
 			<param index="2" name="variant" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_set_total_mass" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="total_mass" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_set_transform" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="transform" type="Transform3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_soft_body_update_rendering_server" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="rendering_server_handler" type="PhysicsServer3DRenderingServerHandler" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_space_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_space_get_contact_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="space" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_space_get_contacts" qualifiers="virtual const">
 			<return type="PackedVector3Array" />
 			<param index="0" name="space" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_space_get_direct_state" qualifiers="virtual">
 			<return type="PhysicsDirectSpaceState3D" />
 			<param index="0" name="space" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_space_get_param" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.SpaceParameter" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_space_is_active" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="space" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_space_set_active" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="active" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_space_set_debug_contacts" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="max_contacts" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_space_set_param" qualifiers="virtual">
@@ -1247,28 +1247,28 @@
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.SpaceParameter" />
 			<param index="2" name="value" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_sphere_shape_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_step" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="step" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_sync" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_world_boundary_shape_create" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicsServer3DRenderingServerHandler.xml
+++ b/doc/classes/PhysicsServer3DRenderingServerHandler.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PhysicsServer3DRenderingServerHandler" inherits="Object" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,21 +10,21 @@
 		<method name="_set_aabb" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="aabb" type="AABB" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_normal" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="vertex_id" type="int" />
 			<param index="1" name="normals" type="const void*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_vertex" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="vertex_id" type="int" />
 			<param index="1" name="vertices" type="const void*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PointLight2D.xml
+++ b/doc/classes/PointLight2D.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PointLight2D" inherits="Light2D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PolygonPathFinder.xml
+++ b/doc/classes/PolygonPathFinder.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PolygonPathFinder" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -11,51 +11,51 @@
 			<return type="PackedVector2Array" />
 			<param index="0" name="from" type="Vector2" />
 			<param index="1" name="to" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_bounds" qualifiers="const">
 			<return type="Rect2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_closest_point" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="point" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_intersections" qualifiers="const">
 			<return type="PackedVector2Array" />
 			<param index="0" name="from" type="Vector2" />
 			<param index="1" name="to" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_point_penalty" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="is_point_inside" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="point" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_point_penalty">
 			<return type="void" />
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="penalty" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="setup">
 			<return type="void" />
 			<param index="0" name="points" type="PackedVector2Array" />
 			<param index="1" name="connections" type="PackedInt32Array" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PrimitiveMesh.xml
+++ b/doc/classes/PrimitiveMesh.xml
@@ -11,7 +11,7 @@
 	<methods>
 		<method name="_create_mesh_array" qualifiers="virtual const">
 			<return type="Array" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_mesh_arrays" qualifiers="const">

--- a/doc/classes/Quaternion.xml
+++ b/doc/classes/Quaternion.xml
@@ -30,7 +30,7 @@
 			<return type="Quaternion" />
 			<param index="0" name="arc_from" type="Vector3" />
 			<param index="1" name="arc_to" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</constructor>
 		<constructor name="Quaternion">
@@ -77,7 +77,7 @@
 		</method>
 		<method name="exp" qualifiers="const">
 			<return type="Quaternion" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="from_euler" qualifiers="static">
@@ -89,12 +89,12 @@
 		</method>
 		<method name="get_angle" qualifiers="const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_axis" qualifiers="const">
 			<return type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_euler" qualifiers="const">
@@ -143,7 +143,7 @@
 		</method>
 		<method name="log" qualifiers="const">
 			<return type="Quaternion" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="normalized" qualifiers="const">

--- a/doc/classes/RDAttachmentFormat.xml
+++ b/doc/classes/RDAttachmentFormat.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RDAttachmentFormat" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RDPipelineColorBlendState.xml
+++ b/doc/classes/RDPipelineColorBlendState.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RDPipelineColorBlendState" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RDPipelineColorBlendStateAttachment.xml
+++ b/doc/classes/RDPipelineColorBlendStateAttachment.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RDPipelineColorBlendStateAttachment" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
 		<method name="set_as_mix">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/RDPipelineDepthStencilState.xml
+++ b/doc/classes/RDPipelineDepthStencilState.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RDPipelineDepthStencilState" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RDPipelineMultisampleState.xml
+++ b/doc/classes/RDPipelineMultisampleState.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RDPipelineMultisampleState" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RDPipelineRasterizationState.xml
+++ b/doc/classes/RDPipelineRasterizationState.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RDPipelineRasterizationState" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RDPipelineSpecializationConstant.xml
+++ b/doc/classes/RDPipelineSpecializationConstant.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RDPipelineSpecializationConstant" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RDSamplerState.xml
+++ b/doc/classes/RDSamplerState.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RDSamplerState" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RDShaderFile.xml
+++ b/doc/classes/RDShaderFile.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RDShaderFile" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,19 +10,19 @@
 		<method name="get_spirv" qualifiers="const">
 			<return type="RDShaderSPIRV" />
 			<param index="0" name="version" type="StringName" default="&amp;&quot;&quot;" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_version_list" qualifiers="const">
 			<return type="PackedStringArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_bytecode">
 			<return type="void" />
 			<param index="0" name="bytecode" type="RDShaderSPIRV" />
 			<param index="1" name="version" type="StringName" default="&amp;&quot;&quot;" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/RDShaderSPIRV.xml
+++ b/doc/classes/RDShaderSPIRV.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RDShaderSPIRV" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,27 +10,27 @@
 		<method name="get_stage_bytecode" qualifiers="const">
 			<return type="PackedByteArray" />
 			<param index="0" name="stage" type="int" enum="RenderingDevice.ShaderStage" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_stage_compile_error" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="stage" type="int" enum="RenderingDevice.ShaderStage" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_stage_bytecode">
 			<return type="void" />
 			<param index="0" name="stage" type="int" enum="RenderingDevice.ShaderStage" />
 			<param index="1" name="bytecode" type="PackedByteArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_stage_compile_error">
 			<return type="void" />
 			<param index="0" name="stage" type="int" enum="RenderingDevice.ShaderStage" />
 			<param index="1" name="compile_error" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/RDShaderSource.xml
+++ b/doc/classes/RDShaderSource.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RDShaderSource" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,14 +10,14 @@
 		<method name="get_stage_source" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="stage" type="int" enum="RenderingDevice.ShaderStage" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_stage_source">
 			<return type="void" />
 			<param index="0" name="stage" type="int" enum="RenderingDevice.ShaderStage" />
 			<param index="1" name="source" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/RDTextureFormat.xml
+++ b/doc/classes/RDTextureFormat.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RDTextureFormat" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,13 +10,13 @@
 		<method name="add_shareable_format">
 			<return type="void" />
 			<param index="0" name="format" type="int" enum="RenderingDevice.DataFormat" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="remove_shareable_format">
 			<return type="void" />
 			<param index="0" name="format" type="int" enum="RenderingDevice.DataFormat" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/RDTextureView.xml
+++ b/doc/classes/RDTextureView.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RDTextureView" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RDUniform.xml
+++ b/doc/classes/RDUniform.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RDUniform" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,17 +10,17 @@
 		<method name="add_id">
 			<return type="void" />
 			<param index="0" name="id" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="clear_ids">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_ids" qualifiers="const">
 			<return type="RID[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/RDVertexAttribute.xml
+++ b/doc/classes/RDVertexAttribute.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RDVertexAttribute" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RID.xml
+++ b/doc/classes/RID.xml
@@ -41,37 +41,37 @@
 		<operator name="operator !=">
 			<return type="bool" />
 			<param index="0" name="right" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator &lt;">
 			<return type="bool" />
 			<param index="0" name="right" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator ==">
 			<return type="bool" />
 			<param index="0" name="right" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator &gt;">
 			<return type="bool" />
 			<param index="0" name="right" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator &gt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RenderingDevice" inherits="Object" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -11,7 +11,7 @@
 			<return type="void" />
 			<param index="0" name="from" type="int" enum="RenderingDevice.BarrierMask" default="7" />
 			<param index="1" name="to" type="int" enum="RenderingDevice.BarrierMask" default="7" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="buffer_clear">
@@ -20,13 +20,13 @@
 			<param index="1" name="offset" type="int" />
 			<param index="2" name="size_bytes" type="int" />
 			<param index="3" name="post_barrier" type="int" enum="RenderingDevice.BarrierMask" default="7" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="buffer_get_data">
 			<return type="PackedByteArray" />
 			<param index="0" name="buffer" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="buffer_update">
@@ -36,32 +36,32 @@
 			<param index="2" name="size_bytes" type="int" />
 			<param index="3" name="data" type="PackedByteArray" />
 			<param index="4" name="post_barrier" type="int" enum="RenderingDevice.BarrierMask" default="7" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="capture_timestamp">
 			<return type="void" />
 			<param index="0" name="name" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="compute_list_add_barrier">
 			<return type="void" />
 			<param index="0" name="compute_list" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="compute_list_begin">
 			<return type="int" />
 			<param index="0" name="allow_draw_overlap" type="bool" default="false" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="compute_list_bind_compute_pipeline">
 			<return type="void" />
 			<param index="0" name="compute_list" type="int" />
 			<param index="1" name="compute_pipeline" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="compute_list_bind_uniform_set">
@@ -69,7 +69,7 @@
 			<param index="0" name="compute_list" type="int" />
 			<param index="1" name="uniform_set" type="RID" />
 			<param index="2" name="set_index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="compute_list_dispatch">
@@ -78,13 +78,13 @@
 			<param index="1" name="x_groups" type="int" />
 			<param index="2" name="y_groups" type="int" />
 			<param index="3" name="z_groups" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="compute_list_end">
 			<return type="void" />
 			<param index="0" name="post_barrier" type="int" enum="RenderingDevice.BarrierMask" default="7" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="compute_list_set_push_constant">
@@ -92,44 +92,44 @@
 			<param index="0" name="compute_list" type="int" />
 			<param index="1" name="buffer" type="PackedByteArray" />
 			<param index="2" name="size_bytes" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="compute_pipeline_create">
 			<return type="RID" />
 			<param index="0" name="shader" type="RID" />
 			<param index="1" name="specialization_constants" type="RDPipelineSpecializationConstant[]" default="[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="compute_pipeline_is_valid">
 			<return type="bool" />
 			<param index="0" name="compute_pieline" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="create_local_device">
 			<return type="RenderingDevice" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="draw_command_begin_label">
 			<return type="void" />
 			<param index="0" name="name" type="String" />
 			<param index="1" name="color" type="Color" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="draw_command_end_label">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="draw_command_insert_label">
 			<return type="void" />
 			<param index="0" name="name" type="String" />
 			<param index="1" name="color" type="Color" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="draw_list_begin">
@@ -144,14 +144,14 @@
 			<param index="7" name="clear_stencil" type="int" default="0" />
 			<param index="8" name="region" type="Rect2" default="Rect2(0, 0, 0, 0)" />
 			<param index="9" name="storage_textures" type="Array" default="[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="draw_list_begin_for_screen">
 			<return type="int" />
 			<param index="0" name="screen" type="int" default="0" />
 			<param index="1" name="clear_color" type="Color" default="Color(0, 0, 0, 1)" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="draw_list_begin_split">
@@ -167,21 +167,21 @@
 			<param index="8" name="clear_stencil" type="int" default="0" />
 			<param index="9" name="region" type="Rect2" default="Rect2(0, 0, 0, 0)" />
 			<param index="10" name="storage_textures" type="RID[]" default="[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="draw_list_bind_index_array">
 			<return type="void" />
 			<param index="0" name="draw_list" type="int" />
 			<param index="1" name="index_array" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="draw_list_bind_render_pipeline">
 			<return type="void" />
 			<param index="0" name="draw_list" type="int" />
 			<param index="1" name="render_pipeline" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="draw_list_bind_uniform_set">
@@ -189,20 +189,20 @@
 			<param index="0" name="draw_list" type="int" />
 			<param index="1" name="uniform_set" type="RID" />
 			<param index="2" name="set_index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="draw_list_bind_vertex_array">
 			<return type="void" />
 			<param index="0" name="draw_list" type="int" />
 			<param index="1" name="vertex_array" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="draw_list_disable_scissor">
 			<return type="void" />
 			<param index="0" name="draw_list" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="draw_list_draw">
@@ -211,20 +211,20 @@
 			<param index="1" name="use_indices" type="bool" />
 			<param index="2" name="instances" type="int" />
 			<param index="3" name="procedural_vertex_count" type="int" default="0" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="draw_list_enable_scissor">
 			<return type="void" />
 			<param index="0" name="draw_list" type="int" />
 			<param index="1" name="rect" type="Rect2" default="Rect2(0, 0, 0, 0)" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="draw_list_end">
 			<return type="void" />
 			<param index="0" name="post_barrier" type="int" enum="RenderingDevice.BarrierMask" default="7" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="draw_list_set_blend_constants">
@@ -240,18 +240,18 @@
 			<param index="0" name="draw_list" type="int" />
 			<param index="1" name="buffer" type="PackedByteArray" />
 			<param index="2" name="size_bytes" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="draw_list_switch_to_next_pass">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="draw_list_switch_to_next_pass_split">
 			<return type="PackedInt64Array" />
 			<param index="0" name="splits" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="framebuffer_create">
@@ -259,7 +259,7 @@
 			<param index="0" name="textures" type="RID[]" />
 			<param index="1" name="validate_with_format" type="int" default="-1" />
 			<param index="2" name="view_count" type="int" default="1" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="framebuffer_create_empty">
@@ -267,7 +267,7 @@
 			<param index="0" name="size" type="Vector2i" />
 			<param index="1" name="samples" type="int" enum="RenderingDevice.TextureSamples" default="0" />
 			<param index="2" name="validate_with_format" type="int" default="-1" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="framebuffer_create_multipass">
@@ -276,20 +276,20 @@
 			<param index="1" name="passes" type="RDFramebufferPass[]" />
 			<param index="2" name="validate_with_format" type="int" default="-1" />
 			<param index="3" name="view_count" type="int" default="1" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="framebuffer_format_create">
 			<return type="int" />
 			<param index="0" name="attachments" type="RDAttachmentFormat[]" />
 			<param index="1" name="view_count" type="int" default="1" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="framebuffer_format_create_empty">
 			<return type="int" />
 			<param index="0" name="samples" type="int" enum="RenderingDevice.TextureSamples" default="0" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="framebuffer_format_create_multipass">
@@ -297,80 +297,80 @@
 			<param index="0" name="attachments" type="RDAttachmentFormat[]" />
 			<param index="1" name="passes" type="RDFramebufferPass[]" />
 			<param index="2" name="view_count" type="int" default="1" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="framebuffer_format_get_texture_samples">
 			<return type="int" enum="RenderingDevice.TextureSamples" />
 			<param index="0" name="format" type="int" />
 			<param index="1" name="render_pass" type="int" default="0" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="framebuffer_get_format">
 			<return type="int" />
 			<param index="0" name="framebuffer" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="framebuffer_is_valid" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="framebuffer" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="free_rid">
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="full_barrier">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_captured_timestamp_cpu_time" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_captured_timestamp_gpu_time" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_captured_timestamp_name" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_captured_timestamps_count" qualifiers="const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_captured_timestamps_frame" qualifiers="const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_device_name" qualifiers="const">
 			<return type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_device_pipeline_cache_uuid" qualifiers="const">
 			<return type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_device_vendor_name" qualifiers="const">
 			<return type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_driver_resource">
@@ -378,18 +378,18 @@
 			<param index="0" name="resource" type="int" enum="RenderingDevice.DriverResource" />
 			<param index="1" name="rid" type="RID" />
 			<param index="2" name="index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_frame_delay" qualifiers="const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_memory_usage" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="type" type="int" enum="RenderingDevice.MemoryType" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="index_array_create">
@@ -397,7 +397,7 @@
 			<param index="0" name="index_buffer" type="RID" />
 			<param index="1" name="index_offset" type="int" />
 			<param index="2" name="index_count" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="index_buffer_create">
@@ -406,13 +406,13 @@
 			<param index="1" name="format" type="int" enum="RenderingDevice.IndexBufferFormat" />
 			<param index="2" name="data" type="PackedByteArray" default="PackedByteArray()" />
 			<param index="3" name="use_restart_indices" type="bool" default="false" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="limit_get" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="limit" type="int" enum="RenderingDevice.Limit" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="render_pipeline_create">
@@ -428,76 +428,76 @@
 			<param index="8" name="dynamic_state_flags" type="int" default="0" />
 			<param index="9" name="for_render_pass" type="int" default="0" />
 			<param index="10" name="specialization_constants" type="RDPipelineSpecializationConstant[]" default="[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="render_pipeline_is_valid">
 			<return type="bool" />
 			<param index="0" name="render_pipeline" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="sampler_create">
 			<return type="RID" />
 			<param index="0" name="state" type="RDSamplerState" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="screen_get_framebuffer_format" qualifiers="const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="screen_get_height" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="screen" type="int" default="0" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="screen_get_width" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="screen" type="int" default="0" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_resource_name">
 			<return type="void" />
 			<param index="0" name="id" type="RID" />
 			<param index="1" name="name" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="shader_compile_binary_from_spirv">
 			<return type="PackedByteArray" />
 			<param index="0" name="spirv_data" type="RDShaderSPIRV" />
 			<param index="1" name="name" type="String" default="&quot;&quot;" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="shader_compile_spirv_from_source">
 			<return type="RDShaderSPIRV" />
 			<param index="0" name="shader_source" type="RDShaderSource" />
 			<param index="1" name="allow_cache" type="bool" default="true" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="shader_create_from_bytecode">
 			<return type="RID" />
 			<param index="0" name="binary_data" type="PackedByteArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="shader_create_from_spirv">
 			<return type="RID" />
 			<param index="0" name="spirv_data" type="RDShaderSPIRV" />
 			<param index="1" name="name" type="String" default="&quot;&quot;" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="shader_get_vertex_input_attribute_mask">
 			<return type="int" />
 			<param index="0" name="shader" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="storage_buffer_create">
@@ -505,17 +505,17 @@
 			<param index="0" name="size_bytes" type="int" />
 			<param index="1" name="data" type="PackedByteArray" default="PackedByteArray()" />
 			<param index="2" name="usage" type="int" default="0" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="submit">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="sync">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_buffer_create">
@@ -523,7 +523,7 @@
 			<param index="0" name="size_bytes" type="int" />
 			<param index="1" name="format" type="int" enum="RenderingDevice.DataFormat" />
 			<param index="2" name="data" type="PackedByteArray" default="PackedByteArray()" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_clear">
@@ -535,7 +535,7 @@
 			<param index="4" name="base_layer" type="int" />
 			<param index="5" name="layer_count" type="int" />
 			<param index="6" name="post_barrier" type="int" enum="RenderingDevice.BarrierMask" default="7" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_copy">
@@ -550,7 +550,7 @@
 			<param index="7" name="src_layer" type="int" />
 			<param index="8" name="dst_layer" type="int" />
 			<param index="9" name="post_barrier" type="int" enum="RenderingDevice.BarrierMask" default="7" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_create">
@@ -558,14 +558,14 @@
 			<param index="0" name="format" type="RDTextureFormat" />
 			<param index="1" name="view" type="RDTextureView" />
 			<param index="2" name="data" type="PackedByteArray[]" default="[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_create_shared">
 			<return type="RID" />
 			<param index="0" name="view" type="RDTextureView" />
 			<param index="1" name="with_texture" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_create_shared_from_slice">
@@ -576,33 +576,33 @@
 			<param index="3" name="mipmap" type="int" />
 			<param index="4" name="mipmaps" type="int" default="1" />
 			<param index="5" name="slice_type" type="int" enum="RenderingDevice.TextureSliceType" default="0" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_get_data">
 			<return type="PackedByteArray" />
 			<param index="0" name="texture" type="RID" />
 			<param index="1" name="layer" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_is_format_supported_for_usage" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="format" type="int" enum="RenderingDevice.DataFormat" />
 			<param index="1" name="usage_flags" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_is_shared">
 			<return type="bool" />
 			<param index="0" name="texture" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_is_valid">
 			<return type="bool" />
 			<param index="0" name="texture" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_resolve_multisample">
@@ -610,7 +610,7 @@
 			<param index="0" name="from_texture" type="RID" />
 			<param index="1" name="to_texture" type="RID" />
 			<param index="2" name="post_barrier" type="int" enum="RenderingDevice.BarrierMask" default="7" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_update">
@@ -619,14 +619,14 @@
 			<param index="1" name="layer" type="int" />
 			<param index="2" name="data" type="PackedByteArray" />
 			<param index="3" name="post_barrier" type="int" enum="RenderingDevice.BarrierMask" default="7" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="uniform_buffer_create">
 			<return type="RID" />
 			<param index="0" name="size_bytes" type="int" />
 			<param index="1" name="data" type="PackedByteArray" default="PackedByteArray()" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="uniform_set_create">
@@ -634,13 +634,13 @@
 			<param index="0" name="uniforms" type="RDUniform[]" />
 			<param index="1" name="shader" type="RID" />
 			<param index="2" name="shader_set" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="uniform_set_is_valid">
 			<return type="bool" />
 			<param index="0" name="uniform_set" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="vertex_array_create">
@@ -658,13 +658,13 @@
 			<param index="0" name="size_bytes" type="int" />
 			<param index="1" name="data" type="PackedByteArray" default="PackedByteArray()" />
 			<param index="2" name="use_as_storage" type="bool" default="false" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="vertex_format_create">
 			<return type="int" />
 			<param index="0" name="vertex_descriptions" type="RDVertexAttribute[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -24,7 +24,7 @@
 			<param index="0" name="base" type="RID" />
 			<param index="1" name="material_overrides" type="RID[]" />
 			<param index="2" name="image_size" type="Vector2i" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="camera_attributes_create">
@@ -42,7 +42,7 @@
 			<param index="3" name="max_sensitivity" type="float" />
 			<param index="4" name="speed" type="float" />
 			<param index="5" name="scale" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="camera_attributes_set_dof_blur">
@@ -55,20 +55,20 @@
 			<param index="5" name="near_distance" type="float" />
 			<param index="6" name="near_transition" type="float" />
 			<param index="7" name="amount" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="camera_attributes_set_dof_blur_bokeh_shape">
 			<return type="void" />
 			<param index="0" name="shape" type="int" enum="RenderingServer.DOFBokehShape" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="camera_attributes_set_dof_blur_quality">
 			<return type="void" />
 			<param index="0" name="quality" type="int" enum="RenderingServer.DOFBlurQuality" />
 			<param index="1" name="use_jitter" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="camera_attributes_set_exposure">
@@ -101,7 +101,7 @@
 			<return type="void" />
 			<param index="0" name="camera" type="RID" />
 			<param index="1" name="effects" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="camera_set_cull_mask">
@@ -191,14 +191,14 @@
 			<param index="1" name="pos" type="Vector2" />
 			<param index="2" name="radius" type="float" />
 			<param index="3" name="color" type="Color" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_add_clip_ignore">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="ignore" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_add_lcd_texture_rect_region">
@@ -208,7 +208,7 @@
 			<param index="2" name="texture" type="RID" />
 			<param index="3" name="src_rect" type="Rect2" />
 			<param index="4" name="modulate" type="Color" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_add_line">
@@ -219,7 +219,7 @@
 			<param index="3" name="color" type="Color" />
 			<param index="4" name="width" type="float" default="1.0" />
 			<param index="5" name="antialiased" type="bool" default="false" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_add_mesh">
@@ -229,7 +229,7 @@
 			<param index="2" name="transform" type="Transform2D" default="Transform2D(1, 0, 0, 1, 0, 0)" />
 			<param index="3" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
 			<param index="4" name="texture" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_add_msdf_texture_rect_region">
@@ -241,7 +241,7 @@
 			<param index="4" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
 			<param index="5" name="outline_size" type="int" default="0" />
 			<param index="6" name="px_range" type="float" default="1.0" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_add_multimesh">
@@ -249,7 +249,7 @@
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="mesh" type="RID" />
 			<param index="2" name="texture" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_add_nine_patch">
@@ -264,7 +264,7 @@
 			<param index="7" name="y_axis_mode" type="int" enum="RenderingServer.NinePatchAxisMode" default="0" />
 			<param index="8" name="draw_center" type="bool" default="true" />
 			<param index="9" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_add_particles">
@@ -272,7 +272,7 @@
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="particles" type="RID" />
 			<param index="2" name="texture" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_add_polygon">
@@ -282,7 +282,7 @@
 			<param index="2" name="colors" type="PackedColorArray" />
 			<param index="3" name="uvs" type="PackedVector2Array" default="PackedVector2Array()" />
 			<param index="4" name="texture" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_add_polyline">
@@ -292,7 +292,7 @@
 			<param index="2" name="colors" type="PackedColorArray" />
 			<param index="3" name="width" type="float" default="1.0" />
 			<param index="4" name="antialiased" type="bool" default="false" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_add_primitive">
@@ -303,7 +303,7 @@
 			<param index="3" name="uvs" type="PackedVector2Array" />
 			<param index="4" name="texture" type="RID" />
 			<param index="5" name="width" type="float" default="1.0" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_add_rect">
@@ -311,14 +311,14 @@
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="rect" type="Rect2" />
 			<param index="2" name="color" type="Color" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_add_set_transform">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="transform" type="Transform2D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_add_texture_rect">
@@ -329,7 +329,7 @@
 			<param index="3" name="tile" type="bool" default="false" />
 			<param index="4" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
 			<param index="5" name="transpose" type="bool" default="false" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_add_texture_rect_region">
@@ -341,7 +341,7 @@
 			<param index="4" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
 			<param index="5" name="transpose" type="bool" default="false" />
 			<param index="6" name="clip_uv" type="bool" default="true" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_add_triangle_array">
@@ -355,7 +355,7 @@
 			<param index="6" name="weights" type="PackedFloat32Array" default="PackedFloat32Array()" />
 			<param index="7" name="texture" type="RID" />
 			<param index="8" name="count" type="int" default="-1" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_clear">
@@ -367,7 +367,7 @@
 		</method>
 		<method name="canvas_item_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_set_canvas_group_mode">
@@ -378,14 +378,14 @@
 			<param index="3" name="fit_empty" type="bool" default="false" />
 			<param index="4" name="fit_margin" type="float" default="0.0" />
 			<param index="5" name="blur_mipmaps" type="bool" default="false" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_set_clip">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="clip" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_set_copy_to_backbuffer">
@@ -402,35 +402,35 @@
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="use_custom_rect" type="bool" />
 			<param index="2" name="rect" type="Rect2" default="Rect2(0, 0, 0, 0)" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_set_default_texture_filter">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="filter" type="int" enum="RenderingServer.CanvasItemTextureFilter" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_set_default_texture_repeat">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="repeat" type="int" enum="RenderingServer.CanvasItemTextureRepeat" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_set_distance_field_mode">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="enabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_set_draw_behind_parent">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="enabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_set_draw_index">
@@ -445,7 +445,7 @@
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="mask" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_set_material">
@@ -460,35 +460,35 @@
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="color" type="Color" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_set_parent">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="parent" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_set_self_modulate">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="color" type="Color" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_set_sort_children_by_y">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="enabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_set_transform">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="transform" type="Transform2D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_set_use_parent_material">
@@ -514,14 +514,14 @@
 			<param index="2" name="area" type="Rect2" />
 			<param index="3" name="enter_callable" type="Callable" />
 			<param index="4" name="exit_callable" type="Callable" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_set_visible">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="visible" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_item_set_z_as_relative_to_parent">
@@ -574,7 +574,7 @@
 			<return type="void" />
 			<param index="0" name="occluder" type="RID" />
 			<param index="1" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_light_occluder_set_enabled">
@@ -774,7 +774,7 @@
 		<method name="canvas_set_disable_scale">
 			<return type="void" />
 			<param index="0" name="disable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_set_item_mirroring">
@@ -797,12 +797,12 @@
 		<method name="canvas_set_shadow_texture_size">
 			<return type="void" />
 			<param index="0" name="size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_texture_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_texture_set_channel">
@@ -810,7 +810,7 @@
 			<param index="0" name="canvas_texture" type="RID" />
 			<param index="1" name="channel" type="int" enum="RenderingServer.CanvasTextureChannel" />
 			<param index="2" name="texture" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_texture_set_shading_parameters">
@@ -818,21 +818,21 @@
 			<param index="0" name="canvas_texture" type="RID" />
 			<param index="1" name="base_color" type="Color" />
 			<param index="2" name="shininess" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_texture_set_texture_filter">
 			<return type="void" />
 			<param index="0" name="canvas_texture" type="RID" />
 			<param index="1" name="filter" type="int" enum="RenderingServer.CanvasItemTextureFilter" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="canvas_texture_set_texture_repeat">
 			<return type="void" />
 			<param index="0" name="canvas_texture" type="RID" />
 			<param index="1" name="repeat" type="int" enum="RenderingServer.CanvasItemTextureRepeat" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="create_local_rendering_device" qualifiers="const">
@@ -844,21 +844,21 @@
 		</method>
 		<method name="decal_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="decal_set_albedo_mix">
 			<return type="void" />
 			<param index="0" name="decal" type="RID" />
 			<param index="1" name="albedo_mix" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="decal_set_cull_mask">
 			<return type="void" />
 			<param index="0" name="decal" type="RID" />
 			<param index="1" name="mask" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="decal_set_distance_fade">
@@ -867,21 +867,21 @@
 			<param index="1" name="enabled" type="bool" />
 			<param index="2" name="begin" type="float" />
 			<param index="3" name="length" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="decal_set_emission_energy">
 			<return type="void" />
 			<param index="0" name="decal" type="RID" />
 			<param index="1" name="energy" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="decal_set_extents">
 			<return type="void" />
 			<param index="0" name="decal" type="RID" />
 			<param index="1" name="extents" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="decal_set_fade">
@@ -889,21 +889,21 @@
 			<param index="0" name="decal" type="RID" />
 			<param index="1" name="above" type="float" />
 			<param index="2" name="below" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="decal_set_modulate">
 			<return type="void" />
 			<param index="0" name="decal" type="RID" />
 			<param index="1" name="color" type="Color" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="decal_set_normal_fade">
 			<return type="void" />
 			<param index="0" name="decal" type="RID" />
 			<param index="1" name="fade" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="decal_set_texture">
@@ -911,13 +911,13 @@
 			<param index="0" name="decal" type="RID" />
 			<param index="1" name="type" type="int" enum="RenderingServer.DecalTexture" />
 			<param index="2" name="texture" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="decals_set_filter">
 			<return type="void" />
 			<param index="0" name="filter" type="int" enum="RenderingServer.DecalFilter" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="directional_light_create">
@@ -932,13 +932,13 @@
 			<return type="void" />
 			<param index="0" name="size" type="int" />
 			<param index="1" name="is_16bits" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="directional_soft_shadow_filter_set_quality">
 			<return type="void" />
 			<param index="0" name="quality" type="int" enum="RenderingServer.ShadowQuality" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="environment_bake_panorama">
@@ -946,7 +946,7 @@
 			<param index="0" name="environment" type="RID" />
 			<param index="1" name="bake_irradiance" type="bool" />
 			<param index="2" name="size" type="Vector2i" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="environment_create">
@@ -959,13 +959,13 @@
 		<method name="environment_glow_set_use_bicubic_upscale">
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="environment_glow_set_use_high_quality">
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="environment_set_adjustment">
@@ -989,7 +989,7 @@
 			<param index="3" name="energy" type="float" default="1.0" />
 			<param index="4" name="sky_contibution" type="float" default="0.0" />
 			<param index="5" name="reflection_source" type="int" enum="RenderingServer.EnvironmentReflectionSource" default="0" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="environment_set_background">
@@ -1037,7 +1037,7 @@
 			<param index="7" name="height_density" type="float" />
 			<param index="8" name="aerial_perspective" type="float" />
 			<param index="9" name="sky_affect" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="environment_set_glow">
@@ -1055,7 +1055,7 @@
 			<param index="10" name="hdr_luminance_cap" type="float" />
 			<param index="11" name="glow_map_strength" type="float" />
 			<param index="12" name="glow_map" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="environment_set_sdfgi">
@@ -1071,25 +1071,25 @@
 			<param index="8" name="energy" type="float" />
 			<param index="9" name="normal_bias" type="float" />
 			<param index="10" name="probe_bias" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="environment_set_sdfgi_frames_to_converge">
 			<return type="void" />
 			<param index="0" name="frames" type="int" enum="RenderingServer.EnvironmentSDFGIFramesToConverge" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="environment_set_sdfgi_frames_to_update_light">
 			<return type="void" />
 			<param index="0" name="frames" type="int" enum="RenderingServer.EnvironmentSDFGIFramesToUpdateLight" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="environment_set_sdfgi_ray_count">
 			<return type="void" />
 			<param index="0" name="ray_count" type="int" enum="RenderingServer.EnvironmentSDFGIRayCount" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="environment_set_sky">
@@ -1171,7 +1171,7 @@
 		<method name="environment_set_ssr_roughness_quality">
 			<return type="void" />
 			<param index="0" name="quality" type="int" enum="RenderingServer.EnvironmentSSRRoughnessQuality" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="environment_set_tonemap">
@@ -1200,7 +1200,7 @@
 			<param index="11" name="temporal_reprojection_amount" type="float" />
 			<param index="12" name="ambient_inject" type="float" />
 			<param index="13" name="sky_affect" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="environment_set_volumetric_fog_filter_active">
@@ -1252,12 +1252,12 @@
 			<return type="void" />
 			<param index="0" name="swap_buffers" type="bool" default="true" />
 			<param index="1" name="frame_step" type="float" default="0.0" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="force_sync">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="free_rid">
@@ -1269,7 +1269,7 @@
 		</method>
 		<method name="get_frame_setup_time_cpu" qualifiers="const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_rendering_device" qualifiers="const">
@@ -1282,7 +1282,7 @@
 		<method name="get_rendering_info">
 			<return type="int" />
 			<param index="0" name="info" type="int" enum="RenderingServer.RenderingInfo" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_shader_parameter_list" qualifiers="const">
@@ -1350,44 +1350,44 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="type" type="int" enum="RenderingServer.GlobalShaderParameterType" />
 			<param index="2" name="default_value" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="global_shader_parameter_get" qualifiers="const">
 			<return type="Variant" />
 			<param index="0" name="name" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="global_shader_parameter_get_list" qualifiers="const">
 			<return type="PackedStringArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="global_shader_parameter_get_type" qualifiers="const">
 			<return type="int" enum="RenderingServer.GlobalShaderParameterType" />
 			<param index="0" name="name" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="global_shader_parameter_remove">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="global_shader_parameter_set">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="value" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="global_shader_parameter_set_override">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="value" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="has_changed" qualifiers="const">
@@ -1447,20 +1447,20 @@
 			<return type="Variant" />
 			<param index="0" name="instance" type="RID" />
 			<param index="1" name="parameter" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="instance_geometry_get_shader_parameter_default_value" qualifiers="const">
 			<return type="Variant" />
 			<param index="0" name="instance" type="RID" />
 			<param index="1" name="parameter" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="instance_geometry_get_shader_parameter_list" qualifiers="const">
 			<return type="Dictionary[]" />
 			<param index="0" name="instance" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="instance_geometry_set_cast_shadows_setting">
@@ -1486,14 +1486,14 @@
 			<param index="1" name="lightmap" type="RID" />
 			<param index="2" name="lightmap_uv_scale" type="Rect2" />
 			<param index="3" name="lightmap_slice" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="instance_geometry_set_lod_bias">
 			<return type="void" />
 			<param index="0" name="instance" type="RID" />
 			<param index="1" name="lod_bias" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="instance_geometry_set_material_overlay">
@@ -1517,7 +1517,7 @@
 			<param index="0" name="instance" type="RID" />
 			<param index="1" name="parameter" type="StringName" />
 			<param index="2" name="value" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="instance_geometry_set_transparency">
@@ -1580,7 +1580,7 @@
 			<return type="void" />
 			<param index="0" name="instance" type="RID" />
 			<param index="1" name="enabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="instance_set_layer_mask">
@@ -1695,14 +1695,14 @@
 		<method name="light_projectors_set_filter">
 			<return type="void" />
 			<param index="0" name="filter" type="int" enum="RenderingServer.LightProjectorFilter" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="light_set_bake_mode">
 			<return type="void" />
 			<param index="0" name="light" type="RID" />
 			<param index="1" name="bake_mode" type="int" enum="RenderingServer.LightBakeMode" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="light_set_color">
@@ -1736,7 +1736,7 @@
 			<return type="void" />
 			<param index="0" name="light" type="RID" />
 			<param index="1" name="cascade" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="light_set_negative">
@@ -1782,31 +1782,31 @@
 		</method>
 		<method name="lightmap_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="lightmap_get_probe_capture_bsp_tree" qualifiers="const">
 			<return type="PackedInt32Array" />
 			<param index="0" name="lightmap" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="lightmap_get_probe_capture_points" qualifiers="const">
 			<return type="PackedVector3Array" />
 			<param index="0" name="lightmap" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="lightmap_get_probe_capture_sh" qualifiers="const">
 			<return type="PackedColorArray" />
 			<param index="0" name="lightmap" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="lightmap_get_probe_capture_tetrahedra" qualifiers="const">
 			<return type="PackedInt32Array" />
 			<param index="0" name="lightmap" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="lightmap_set_baked_exposure_normalization">
@@ -1821,7 +1821,7 @@
 			<return type="void" />
 			<param index="0" name="lightmap" type="RID" />
 			<param index="1" name="bounds" type="AABB" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="lightmap_set_probe_capture_data">
@@ -1831,20 +1831,20 @@
 			<param index="2" name="point_sh" type="PackedColorArray" />
 			<param index="3" name="tetrahedra" type="PackedInt32Array" />
 			<param index="4" name="bsp_tree" type="PackedInt32Array" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="lightmap_set_probe_capture_update_speed">
 			<return type="void" />
 			<param index="0" name="speed" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="lightmap_set_probe_interior">
 			<return type="void" />
 			<param index="0" name="lightmap" type="RID" />
 			<param index="1" name="interior" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="lightmap_set_textures">
@@ -1852,7 +1852,7 @@
 			<param index="0" name="lightmap" type="RID" />
 			<param index="1" name="light" type="RID" />
 			<param index="2" name="uses_sh" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="make_sphere_mesh">
@@ -1916,7 +1916,7 @@
 			<return type="void" />
 			<param index="0" name="mesh" type="RID" />
 			<param index="1" name="surface" type="Dictionary" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="mesh_add_surface_from_arrays">
@@ -1927,7 +1927,7 @@
 			<param index="3" name="blend_shapes" type="Array" default="[]" />
 			<param index="4" name="lods" type="Dictionary" default="{}" />
 			<param index="5" name="compress_format" type="int" default="0" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="mesh_clear">
@@ -1949,7 +1949,7 @@
 			<return type="RID" />
 			<param index="0" name="surfaces" type="Dictionary[]" />
 			<param index="1" name="blend_shape_count" type="int" default="0" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="mesh_get_blend_shape_count" qualifiers="const">
@@ -1977,7 +1977,7 @@
 			<return type="Dictionary" />
 			<param index="0" name="mesh" type="RID" />
 			<param index="1" name="surface" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="mesh_get_surface_count" qualifiers="const">
@@ -2007,7 +2007,7 @@
 			<return type="void" />
 			<param index="0" name="mesh" type="RID" />
 			<param index="1" name="shadow_mesh" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="mesh_surface_get_arrays" qualifiers="const">
@@ -2030,7 +2030,7 @@
 			<return type="int" />
 			<param index="0" name="format" type="int" />
 			<param index="1" name="vertex_count" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="mesh_surface_get_format_offset" qualifiers="const">
@@ -2038,21 +2038,21 @@
 			<param index="0" name="format" type="int" />
 			<param index="1" name="vertex_count" type="int" />
 			<param index="2" name="array_index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="mesh_surface_get_format_skin_stride" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="format" type="int" />
 			<param index="1" name="vertex_count" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="mesh_surface_get_format_vertex_stride" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="format" type="int" />
 			<param index="1" name="vertex_count" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="mesh_surface_get_material" qualifiers="const">
@@ -2078,7 +2078,7 @@
 			<param index="1" name="surface" type="int" />
 			<param index="2" name="offset" type="int" />
 			<param index="3" name="data" type="PackedByteArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="mesh_surface_update_skin_region">
@@ -2087,7 +2087,7 @@
 			<param index="1" name="surface" type="int" />
 			<param index="2" name="offset" type="int" />
 			<param index="3" name="data" type="PackedByteArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="mesh_surface_update_vertex_region">
@@ -2096,7 +2096,7 @@
 			<param index="1" name="surface" type="int" />
 			<param index="2" name="offset" type="int" />
 			<param index="3" name="data" type="PackedByteArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="multimesh_allocate_data">
@@ -2106,7 +2106,7 @@
 			<param index="2" name="transform_format" type="int" enum="RenderingServer.MultimeshTransformFormat" />
 			<param index="3" name="color_format" type="bool" default="false" />
 			<param index="4" name="custom_data_format" type="bool" default="false" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="multimesh_create">
@@ -2127,7 +2127,7 @@
 		<method name="multimesh_get_buffer" qualifiers="const">
 			<return type="PackedFloat32Array" />
 			<param index="0" name="multimesh" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="multimesh_get_instance_count" qualifiers="const">
@@ -2223,7 +2223,7 @@
 			<return type="void" />
 			<param index="0" name="multimesh" type="RID" />
 			<param index="1" name="buffer" type="PackedFloat32Array" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="multimesh_set_mesh">
@@ -2244,7 +2244,7 @@
 		</method>
 		<method name="occluder_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="occluder_set_mesh">
@@ -2252,7 +2252,7 @@
 			<param index="0" name="occluder" type="RID" />
 			<param index="1" name="vertices" type="PackedVector3Array" />
 			<param index="2" name="indices" type="PackedInt32Array" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="omni_light_create">
@@ -2265,76 +2265,76 @@
 		</method>
 		<method name="particles_collision_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_collision_height_field_update">
 			<return type="void" />
 			<param index="0" name="particles_collision" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_collision_set_attractor_attenuation">
 			<return type="void" />
 			<param index="0" name="particles_collision" type="RID" />
 			<param index="1" name="curve" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_collision_set_attractor_directionality">
 			<return type="void" />
 			<param index="0" name="particles_collision" type="RID" />
 			<param index="1" name="amount" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_collision_set_attractor_strength">
 			<return type="void" />
 			<param index="0" name="particles_collision" type="RID" />
 			<param index="1" name="setrngth" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_collision_set_box_extents">
 			<return type="void" />
 			<param index="0" name="particles_collision" type="RID" />
 			<param index="1" name="extents" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_collision_set_collision_type">
 			<return type="void" />
 			<param index="0" name="particles_collision" type="RID" />
 			<param index="1" name="type" type="int" enum="RenderingServer.ParticlesCollisionType" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_collision_set_cull_mask">
 			<return type="void" />
 			<param index="0" name="particles_collision" type="RID" />
 			<param index="1" name="mask" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_collision_set_field_texture">
 			<return type="void" />
 			<param index="0" name="particles_collision" type="RID" />
 			<param index="1" name="texture" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_collision_set_height_field_resolution">
 			<return type="void" />
 			<param index="0" name="particles_collision" type="RID" />
 			<param index="1" name="resolution" type="int" enum="RenderingServer.ParticlesCollisionHeightfieldResolution" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_collision_set_sphere_radius">
 			<return type="void" />
 			<param index="0" name="particles_collision" type="RID" />
 			<param index="1" name="radius" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_create">
@@ -2353,7 +2353,7 @@
 			<param index="3" name="color" type="Color" />
 			<param index="4" name="custom" type="Color" />
 			<param index="5" name="emit_flags" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_get_current_aabb">
@@ -2403,7 +2403,7 @@
 			<return type="void" />
 			<param index="0" name="particles" type="RID" />
 			<param index="1" name="size" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_set_custom_aabb">
@@ -2483,7 +2483,7 @@
 			<return type="void" />
 			<param index="0" name="particles" type="RID" />
 			<param index="1" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_set_lifetime">
@@ -2498,7 +2498,7 @@
 			<return type="void" />
 			<param index="0" name="particles" type="RID" />
 			<param index="1" name="mode" type="int" enum="RenderingServer.ParticlesMode" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_set_one_shot">
@@ -2546,14 +2546,14 @@
 			<return type="void" />
 			<param index="0" name="particles" type="RID" />
 			<param index="1" name="subemitter_particles" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_set_trail_bind_poses">
 			<return type="void" />
 			<param index="0" name="particles" type="RID" />
 			<param index="1" name="bind_poses" type="Transform3D[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_set_trails">
@@ -2561,14 +2561,14 @@
 			<param index="0" name="particles" type="RID" />
 			<param index="1" name="enable" type="bool" />
 			<param index="2" name="length_sec" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_set_transform_align">
 			<return type="void" />
 			<param index="0" name="particles" type="RID" />
 			<param index="1" name="align" type="int" enum="RenderingServer.ParticlesTransformAlign" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="particles_set_use_local_coordinates">
@@ -2582,7 +2582,7 @@
 		<method name="positional_soft_shadow_filter_set_quality">
 			<return type="void" />
 			<param index="0" name="quality" type="int" enum="RenderingServer.ShadowQuality" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="reflection_probe_create">
@@ -2597,21 +2597,21 @@
 			<return type="void" />
 			<param index="0" name="probe" type="RID" />
 			<param index="1" name="color" type="Color" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="reflection_probe_set_ambient_energy">
 			<return type="void" />
 			<param index="0" name="probe" type="RID" />
 			<param index="1" name="energy" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="reflection_probe_set_ambient_mode">
 			<return type="void" />
 			<param index="0" name="probe" type="RID" />
 			<param index="1" name="mode" type="int" enum="RenderingServer.ReflectionProbeAmbientMode" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="reflection_probe_set_as_interior">
@@ -2674,7 +2674,7 @@
 			<return type="void" />
 			<param index="0" name="probe" type="RID" />
 			<param index="1" name="pixels" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="reflection_probe_set_origin_offset">
@@ -2689,7 +2689,7 @@
 			<return type="void" />
 			<param index="0" name="probe" type="RID" />
 			<param index="1" name="resolution" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="reflection_probe_set_update_mode">
@@ -2719,7 +2719,7 @@
 			<return type="void" />
 			<param index="0" name="scenario" type="RID" />
 			<param index="1" name="effects" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="scenario_set_environment">
@@ -2743,7 +2743,7 @@
 			<param index="0" name="enable" type="bool" />
 			<param index="1" name="amount" type="float" />
 			<param index="2" name="limit" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_boot_image">
@@ -2798,14 +2798,14 @@
 			<return type="Variant" />
 			<param index="0" name="shader" type="RID" />
 			<param index="1" name="name" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="shader_set_code">
 			<return type="void" />
 			<param index="0" name="shader" type="RID" />
 			<param index="1" name="code" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="shader_set_default_texture_parameter">
@@ -2823,7 +2823,7 @@
 			<return type="void" />
 			<param index="0" name="shader" type="RID" />
 			<param index="1" name="path" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="skeleton_allocate_data">
@@ -2831,7 +2831,7 @@
 			<param index="0" name="skeleton" type="RID" />
 			<param index="1" name="bones" type="int" />
 			<param index="2" name="is_2d_skeleton" type="bool" default="false" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="skeleton_bone_get_transform" qualifiers="const">
@@ -2886,7 +2886,7 @@
 			<return type="void" />
 			<param index="0" name="skeleton" type="RID" />
 			<param index="1" name="base_transform" type="Transform2D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="sky_bake_panorama">
@@ -2895,7 +2895,7 @@
 			<param index="1" name="energy" type="float" />
 			<param index="2" name="bake_irradiance" type="bool" />
 			<param index="3" name="size" type="Vector2i" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="sky_create">
@@ -2917,14 +2917,14 @@
 			<return type="void" />
 			<param index="0" name="sky" type="RID" />
 			<param index="1" name="mode" type="int" enum="RenderingServer.SkyMode" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="sky_set_radiance_size">
 			<return type="void" />
 			<param index="0" name="sky" type="RID" />
 			<param index="1" name="radiance_size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="spot_light_create">
@@ -2938,51 +2938,51 @@
 		<method name="sub_surface_scattering_set_quality">
 			<return type="void" />
 			<param index="0" name="quality" type="int" enum="RenderingServer.SubSurfaceScatteringQuality" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="sub_surface_scattering_set_scale">
 			<return type="void" />
 			<param index="0" name="scale" type="float" />
 			<param index="1" name="depth_scale" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_2d_create">
 			<return type="RID" />
 			<param index="0" name="image" type="Image" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_2d_get" qualifiers="const">
 			<return type="Image" />
 			<param index="0" name="texture" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_2d_layer_get" qualifiers="const">
 			<return type="Image" />
 			<param index="0" name="texture" type="RID" />
 			<param index="1" name="layer" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_2d_layered_create">
 			<return type="RID" />
 			<param index="0" name="layers" type="Image[]" />
 			<param index="1" name="layered_type" type="int" enum="RenderingServer.TextureLayeredType" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_2d_layered_placeholder_create">
 			<return type="RID" />
 			<param index="0" name="layered_type" type="int" enum="RenderingServer.TextureLayeredType" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_2d_placeholder_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_2d_update">
@@ -2990,7 +2990,7 @@
 			<param index="0" name="texture" type="RID" />
 			<param index="1" name="image" type="Image" />
 			<param index="2" name="layer" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_3d_create">
@@ -3001,31 +3001,31 @@
 			<param index="3" name="depth" type="int" />
 			<param index="4" name="mipmaps" type="bool" />
 			<param index="5" name="data" type="Image[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_3d_get" qualifiers="const">
 			<return type="Image[]" />
 			<param index="0" name="texture" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_3d_placeholder_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_3d_update">
 			<return type="void" />
 			<param index="0" name="texture" type="RID" />
 			<param index="1" name="data" type="Image[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_get_path" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="texture" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_get_rd_texture" qualifiers="const">
@@ -3039,35 +3039,35 @@
 		<method name="texture_proxy_create">
 			<return type="RID" />
 			<param index="0" name="base" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_proxy_update">
 			<return type="void" />
 			<param index="0" name="texture" type="RID" />
 			<param index="1" name="proxy_to" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_replace">
 			<return type="void" />
 			<param index="0" name="texture" type="RID" />
 			<param index="1" name="by_texture" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_set_force_redraw_if_visible">
 			<return type="void" />
 			<param index="0" name="texture" type="RID" />
 			<param index="1" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_set_path">
 			<return type="void" />
 			<param index="0" name="texture" type="RID" />
 			<param index="1" name="path" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="texture_set_size_override">
@@ -3075,7 +3075,7 @@
 			<param index="0" name="texture" type="RID" />
 			<param index="1" name="width" type="int" />
 			<param index="2" name="height" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="viewport_attach_camera">
@@ -3123,13 +3123,13 @@
 		<method name="viewport_get_measured_render_time_cpu" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="viewport" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="viewport_get_measured_render_time_gpu" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="viewport" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="viewport_get_render_info">
@@ -3137,7 +3137,7 @@
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="type" type="int" enum="RenderingServer.ViewportRenderInfoType" />
 			<param index="2" name="info" type="int" enum="RenderingServer.ViewportRenderInfo" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="viewport_get_texture" qualifiers="const">
@@ -3211,14 +3211,14 @@
 			<return type="void" />
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="filter" type="int" enum="RenderingServer.CanvasItemTextureFilter" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="viewport_set_default_canvas_item_texture_repeat">
 			<return type="void" />
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="repeat" type="int" enum="RenderingServer.CanvasItemTextureRepeat" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="viewport_set_disable_2d">
@@ -3233,7 +3233,7 @@
 			<return type="void" />
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="disable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="viewport_set_disable_environment">
@@ -3264,7 +3264,7 @@
 			<return type="void" />
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="viewport_set_msaa_2d">
@@ -3286,13 +3286,13 @@
 		<method name="viewport_set_occlusion_culling_build_quality">
 			<return type="void" />
 			<param index="0" name="quality" type="int" enum="RenderingServer.ViewportOcclusionCullingBuildQuality" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="viewport_set_occlusion_rays_per_thread">
 			<return type="void" />
 			<param index="0" name="rays_per_thread" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="viewport_set_parent_viewport">
@@ -3360,7 +3360,7 @@
 			<return type="void" />
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="mode" type="int" enum="RenderingServer.ViewportScreenSpaceAA" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="viewport_set_sdf_oversize_and_scale">
@@ -3368,7 +3368,7 @@
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="oversize" type="int" enum="RenderingServer.ViewportSDFOversize" />
 			<param index="2" name="scale" type="int" enum="RenderingServer.ViewportSDFScale" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="viewport_set_size">
@@ -3384,14 +3384,14 @@
 			<return type="void" />
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="enabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="viewport_set_snap_2d_vertices_to_pixel">
 			<return type="void" />
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="enabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="viewport_set_texture_mipmap_bias">
@@ -3423,14 +3423,14 @@
 			<return type="void" />
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="viewport_set_use_occlusion_culling">
 			<return type="void" />
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="viewport_set_use_taa">
@@ -3467,14 +3467,14 @@
 		</method>
 		<method name="visibility_notifier_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="visibility_notifier_set_aabb">
 			<return type="void" />
 			<param index="0" name="notifier" type="RID" />
 			<param index="1" name="aabb" type="AABB" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="visibility_notifier_set_callbacks">
@@ -3482,7 +3482,7 @@
 			<param index="0" name="notifier" type="RID" />
 			<param index="1" name="enter_callable" type="Callable" />
 			<param index="2" name="exit_callable" type="Callable" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="voxel_gi_allocate_data">
@@ -3495,48 +3495,48 @@
 			<param index="5" name="data_cells" type="PackedByteArray" />
 			<param index="6" name="distance_field" type="PackedByteArray" />
 			<param index="7" name="level_counts" type="PackedInt32Array" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="voxel_gi_create">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="voxel_gi_get_data_cells" qualifiers="const">
 			<return type="PackedByteArray" />
 			<param index="0" name="voxel_gi" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="voxel_gi_get_distance_field" qualifiers="const">
 			<return type="PackedByteArray" />
 			<param index="0" name="voxel_gi" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="voxel_gi_get_level_counts" qualifiers="const">
 			<return type="PackedInt32Array" />
 			<param index="0" name="voxel_gi" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="voxel_gi_get_octree_cells" qualifiers="const">
 			<return type="PackedByteArray" />
 			<param index="0" name="voxel_gi" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="voxel_gi_get_octree_size" qualifiers="const">
 			<return type="Vector3i" />
 			<param index="0" name="voxel_gi" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="voxel_gi_get_to_cell_xform" qualifiers="const">
 			<return type="Transform3D" />
 			<param index="0" name="voxel_gi" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="voxel_gi_set_baked_exposure_normalization">
@@ -3551,55 +3551,55 @@
 			<return type="void" />
 			<param index="0" name="voxel_gi" type="RID" />
 			<param index="1" name="bias" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="voxel_gi_set_dynamic_range">
 			<return type="void" />
 			<param index="0" name="voxel_gi" type="RID" />
 			<param index="1" name="range" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="voxel_gi_set_energy">
 			<return type="void" />
 			<param index="0" name="voxel_gi" type="RID" />
 			<param index="1" name="energy" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="voxel_gi_set_interior">
 			<return type="void" />
 			<param index="0" name="voxel_gi" type="RID" />
 			<param index="1" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="voxel_gi_set_normal_bias">
 			<return type="void" />
 			<param index="0" name="voxel_gi" type="RID" />
 			<param index="1" name="bias" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="voxel_gi_set_propagation">
 			<return type="void" />
 			<param index="0" name="voxel_gi" type="RID" />
 			<param index="1" name="amount" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="voxel_gi_set_quality">
 			<return type="void" />
 			<param index="0" name="quality" type="int" enum="RenderingServer.VoxelGIQuality" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="voxel_gi_set_use_two_bounces">
 			<return type="void" />
 			<param index="0" name="voxel_gi" type="RID" />
 			<param index="1" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ResourceFormatLoader.xml
+++ b/doc/classes/ResourceFormatLoader.xml
@@ -14,13 +14,13 @@
 		<method name="_exists" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="path" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_classes_used" qualifiers="virtual const">
 			<return type="PackedStringArray" />
 			<param index="0" name="path" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_dependencies" qualifiers="virtual const">
@@ -49,7 +49,7 @@
 		<method name="_get_resource_uid" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="path" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_handles_type" qualifiers="virtual const">

--- a/doc/classes/RibbonTrailMesh.xml
+++ b/doc/classes/RibbonTrailMesh.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RibbonTrailMesh" inherits="PrimitiveMesh" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -282,7 +282,7 @@
 		<method name="push_font_size">
 			<return type="void" />
 			<param index="0" name="font_size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="push_hint">

--- a/doc/classes/ScriptExtension.xml
+++ b/doc/classes/ScriptExtension.xml
@@ -1,178 +1,178 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ScriptExtension" inherits="Script" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
 		<method name="_can_instantiate" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_editor_can_reload_from_file" qualifiers="virtual">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_base_script" qualifiers="virtual const">
 			<return type="Script" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_constants" qualifiers="virtual const">
 			<return type="Dictionary" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_documentation" qualifiers="virtual const">
 			<return type="Dictionary[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_instance_base_type" qualifiers="virtual const">
 			<return type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_language" qualifiers="virtual const">
 			<return type="ScriptLanguage" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_member_line" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="member" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_members" qualifiers="virtual const">
 			<return type="StringName[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_method_info" qualifiers="virtual const">
 			<return type="Dictionary" />
 			<param index="0" name="method" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_property_default_value" qualifiers="virtual const">
 			<return type="Variant" />
 			<param index="0" name="property" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_rpc_config" qualifiers="virtual const">
 			<return type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_script_method_list" qualifiers="virtual const">
 			<return type="Dictionary[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_script_property_list" qualifiers="virtual const">
 			<return type="Dictionary[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_script_signal_list" qualifiers="virtual const">
 			<return type="Dictionary[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_source_code" qualifiers="virtual const">
 			<return type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_has_method" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="method" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_has_property_default_value" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="property" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_has_script_signal" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="signal" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_has_source_code" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_inherits_script" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="script" type="Script" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_instance_create" qualifiers="virtual const">
 			<return type="void*" />
 			<param index="0" name="for_object" type="Object" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_instance_has" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="object" type="Object" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_is_placeholder_fallback_enabled" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_is_tool" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_is_valid" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_placeholder_erased" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="placeholder" type="void*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_placeholder_instance_create" qualifiers="virtual const">
 			<return type="void*" />
 			<param index="0" name="for_object" type="Object" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_reload" qualifiers="virtual">
 			<return type="int" enum="Error" />
 			<param index="0" name="keep_state" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_source_code" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="code" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_update_exports" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ScriptLanguage.xml
+++ b/doc/classes/ScriptLanguage.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ScriptLanguage" inherits="Object" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/ScriptLanguageExtension.xml
+++ b/doc/classes/ScriptLanguageExtension.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ScriptLanguageExtension" inherits="ScriptLanguage" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -11,20 +11,20 @@
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="value" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_add_named_global_constant" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="value" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_alloc_instance_binding_data" qualifiers="virtual">
 			<return type="void*" />
 			<param index="0" name="object" type="Object" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_auto_indent_code" qualifiers="virtual const">
@@ -32,12 +32,12 @@
 			<param index="0" name="code" type="String" />
 			<param index="1" name="from_line" type="int" />
 			<param index="2" name="to_line" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_can_inherit_from_file" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_complete_code" qualifiers="virtual const">
@@ -45,52 +45,52 @@
 			<param index="0" name="code" type="String" />
 			<param index="1" name="path" type="String" />
 			<param index="2" name="owner" type="Object" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_create_script" qualifiers="virtual const">
 			<return type="Object" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_debug_get_current_stack_info" qualifiers="virtual">
 			<return type="Dictionary[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_debug_get_error" qualifiers="virtual const">
 			<return type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_debug_get_globals" qualifiers="virtual">
 			<return type="Dictionary" />
 			<param index="0" name="max_subitems" type="int" />
 			<param index="1" name="max_depth" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_debug_get_stack_level_count" qualifiers="virtual const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_debug_get_stack_level_function" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="level" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_debug_get_stack_level_instance" qualifiers="virtual">
 			<return type="void*" />
 			<param index="0" name="level" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_debug_get_stack_level_line" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="level" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_debug_get_stack_level_locals" qualifiers="virtual">
@@ -98,7 +98,7 @@
 			<param index="0" name="level" type="int" />
 			<param index="1" name="max_subitems" type="int" />
 			<param index="2" name="max_depth" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_debug_get_stack_level_members" qualifiers="virtual">
@@ -106,7 +106,7 @@
 			<param index="0" name="level" type="int" />
 			<param index="1" name="max_subitems" type="int" />
 			<param index="2" name="max_depth" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_debug_parse_stack_level_expression" qualifiers="virtual">
@@ -115,125 +115,125 @@
 			<param index="1" name="expression" type="String" />
 			<param index="2" name="max_subitems" type="int" />
 			<param index="3" name="max_depth" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_execute_file" qualifiers="virtual">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_find_function" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="class_name" type="String" />
 			<param index="1" name="function_name" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_finish" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_frame" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_free_instance_binding_data" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="data" type="void*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_built_in_templates" qualifiers="virtual const">
 			<return type="Dictionary[]" />
 			<param index="0" name="object" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_comment_delimiters" qualifiers="virtual const">
 			<return type="PackedStringArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_extension" qualifiers="virtual const">
 			<return type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_global_class_name" qualifiers="virtual const">
 			<return type="Dictionary" />
 			<param index="0" name="path" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_name" qualifiers="virtual const">
 			<return type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_public_annotations" qualifiers="virtual const">
 			<return type="Dictionary[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_public_constants" qualifiers="virtual const">
 			<return type="Dictionary" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_public_functions" qualifiers="virtual const">
 			<return type="Dictionary[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_recognized_extensions" qualifiers="virtual const">
 			<return type="PackedStringArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_reserved_words" qualifiers="virtual const">
 			<return type="PackedStringArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_string_delimiters" qualifiers="virtual const">
 			<return type="PackedStringArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_type" qualifiers="virtual const">
 			<return type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_handles_global_class_type" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="type" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_has_named_classes" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_init" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_is_control_flow_keyword" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="keyword" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_is_using_templates" qualifiers="virtual">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_lookup_code" qualifiers="virtual const">
@@ -242,7 +242,7 @@
 			<param index="1" name="symbol" type="String" />
 			<param index="2" name="path" type="String" />
 			<param index="3" name="owner" type="Object" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_make_function" qualifiers="virtual const">
@@ -250,7 +250,7 @@
 			<param index="0" name="class_name" type="String" />
 			<param index="1" name="function_name" type="String" />
 			<param index="2" name="function_args" type="PackedStringArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_make_template" qualifiers="virtual const">
@@ -258,7 +258,7 @@
 			<param index="0" name="template" type="String" />
 			<param index="1" name="class_name" type="String" />
 			<param index="2" name="base_class_name" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_open_in_external_editor" qualifiers="virtual">
@@ -266,86 +266,86 @@
 			<param index="0" name="script" type="Script" />
 			<param index="1" name="line" type="int" />
 			<param index="2" name="column" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_overrides_external_editor" qualifiers="virtual">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_profiling_get_accumulated_data" qualifiers="virtual">
 			<return type="int" />
 			<param index="0" name="info_array" type="ScriptLanguageExtensionProfilingInfo*" />
 			<param index="1" name="info_max" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_profiling_get_frame_data" qualifiers="virtual">
 			<return type="int" />
 			<param index="0" name="info_array" type="ScriptLanguageExtensionProfilingInfo*" />
 			<param index="1" name="info_max" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_profiling_start" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_profiling_stop" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_refcount_decremented_instance_binding" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="object" type="Object" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_refcount_incremented_instance_binding" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="object" type="Object" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_reload_all_scripts" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_reload_tool_script" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="script" type="Script" />
 			<param index="1" name="soft_reload" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_remove_named_global_constant" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_supports_builtin_mode" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_supports_documentation" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_thread_enter" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_thread_exit" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_validate" qualifiers="virtual const">
@@ -356,13 +356,13 @@
 			<param index="3" name="validate_errors" type="bool" />
 			<param index="4" name="validate_warnings" type="bool" />
 			<param index="5" name="validate_safe_lines" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_validate_path" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="path" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ShaderGlobalsOverride.xml
+++ b/doc/classes/ShaderGlobalsOverride.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ShaderGlobalsOverride" inherits="Node" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/ShaderInclude.xml
+++ b/doc/classes/ShaderInclude.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ShaderInclude" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -41,7 +41,7 @@
 		</method>
 		<method name="create_skin_from_rest_transforms">
 			<return type="Skin" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="execute_modifications" is_deprecated="true">
@@ -145,19 +145,19 @@
 		<method name="get_bone_pose_position" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="bone_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_bone_pose_rotation" qualifiers="const">
 			<return type="Quaternion" />
 			<param index="0" name="bone_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_bone_pose_scale" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="bone_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_bone_rest" qualifiers="const">
@@ -315,7 +315,7 @@
 			<return type="void" />
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="name" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_bone_parent">
@@ -331,21 +331,21 @@
 			<return type="void" />
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="position" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_bone_pose_rotation">
 			<return type="void" />
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="rotation" type="Quaternion" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_bone_pose_scale">
 			<return type="void" />
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="scale" type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_bone_rest">
@@ -393,7 +393,7 @@
 	<signals>
 		<signal name="bone_enabled_changed">
 			<param index="0" name="bone_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</signal>
 		<signal name="bone_pose_changed">
@@ -403,11 +403,11 @@
 			</description>
 		</signal>
 		<signal name="pose_updated">
-			<description>
+			<description>          
 			</description>
 		</signal>
 		<signal name="show_rest_only_changed">
-			<description>
+			<description>          
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/SkeletonModification3DLookAt.xml
+++ b/doc/classes/SkeletonModification3DLookAt.xml
@@ -37,7 +37,7 @@
 		<method name="set_lock_rotation_plane">
 			<return type="void" />
 			<param index="0" name="plane" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_lock_rotation_to_plane">

--- a/doc/classes/SkeletonProfileHumanoid.xml
+++ b/doc/classes/SkeletonProfileHumanoid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="SkeletonProfileHumanoid" inherits="SkeletonProfile" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
 	<description>
 		A [SkeletonProfile] as a preset that is optimized for the human form. This exists for standardization, so all parameters are read-only.

--- a/doc/classes/Skin.xml
+++ b/doc/classes/Skin.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Skin" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -11,69 +11,69 @@
 			<return type="void" />
 			<param index="0" name="bone" type="int" />
 			<param index="1" name="pose" type="Transform3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="add_named_bind">
 			<return type="void" />
 			<param index="0" name="name" type="String" />
 			<param index="1" name="pose" type="Transform3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="clear_binds">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_bind_bone" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="bind_index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_bind_count" qualifiers="const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_bind_name" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="bind_index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_bind_pose" qualifiers="const">
 			<return type="Transform3D" />
 			<param index="0" name="bind_index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_bind_bone">
 			<return type="void" />
 			<param index="0" name="bind_index" type="int" />
 			<param index="1" name="bone" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_bind_count">
 			<return type="void" />
 			<param index="0" name="bind_count" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_bind_name">
 			<return type="void" />
 			<param index="0" name="bind_index" type="int" />
 			<param index="1" name="name" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_bind_pose">
 			<return type="void" />
 			<param index="0" name="bind_index" type="int" />
 			<param index="1" name="pose" type="Transform3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/SkinReference.xml
+++ b/doc/classes/SkinReference.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="SkinReference" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
 		<method name="get_skeleton" qualifiers="const">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_skin" qualifiers="const">
 			<return type="Skin" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/SliderJoint3D.xml
+++ b/doc/classes/SliderJoint3D.xml
@@ -12,14 +12,14 @@
 		<method name="get_param" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="param" type="int" enum="SliderJoint3D.Param" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_param">
 			<return type="void" />
 			<param index="0" name="param" type="int" enum="SliderJoint3D.Param" />
 			<param index="1" name="value" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/SoftBody3D.xml
+++ b/doc/classes/SoftBody3D.xml
@@ -40,7 +40,7 @@
 		</method>
 		<method name="get_physics_rid" qualifiers="const">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_point_transform">

--- a/doc/classes/StreamPeerExtension.xml
+++ b/doc/classes/StreamPeerExtension.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="StreamPeerExtension" inherits="StreamPeer" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
 		<method name="_get_available_bytes" qualifiers="virtual const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_data" qualifiers="virtual">
@@ -17,7 +17,7 @@
 			<param index="0" name="r_buffer" type="uint8_t*" />
 			<param index="1" name="r_bytes" type="int" />
 			<param index="2" name="r_received" type="int32_t*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_partial_data" qualifiers="virtual">
@@ -25,7 +25,7 @@
 			<param index="0" name="r_buffer" type="uint8_t*" />
 			<param index="1" name="r_bytes" type="int" />
 			<param index="2" name="r_received" type="int32_t*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_put_data" qualifiers="virtual">
@@ -33,7 +33,7 @@
 			<param index="0" name="p_data" type="const uint8_t*" />
 			<param index="1" name="p_bytes" type="int" />
 			<param index="2" name="r_sent" type="int32_t*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_put_partial_data" qualifiers="virtual">
@@ -41,7 +41,7 @@
 			<param index="0" name="p_data" type="const uint8_t*" />
 			<param index="1" name="p_bytes" type="int" />
 			<param index="2" name="r_sent" type="int32_t*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -540,7 +540,7 @@
 		<method name="num_scientific" qualifiers="static">
 			<return type="String" />
 			<param index="0" name="number" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="num_uint64" qualifiers="static">
@@ -919,67 +919,67 @@
 		<operator name="operator !=">
 			<return type="bool" />
 			<param index="0" name="right" type="String" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator !=">
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator %">
 			<return type="String" />
 			<param index="0" name="right" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator +">
 			<return type="String" />
 			<param index="0" name="right" type="String" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator &lt;">
 			<return type="bool" />
 			<param index="0" name="right" type="String" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="String" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator ==">
 			<return type="bool" />
 			<param index="0" name="right" type="String" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator ==">
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator &gt;">
 			<return type="bool" />
 			<param index="0" name="right" type="String" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator &gt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="String" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator []">
 			<return type="String" />
 			<param index="0" name="index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -44,49 +44,49 @@
 		<operator name="operator !=">
 			<return type="bool" />
 			<param index="0" name="right" type="String" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator !=">
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator &lt;">
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator ==">
 			<return type="bool" />
 			<param index="0" name="right" type="String" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator ==">
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator &gt;">
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 		<operator name="operator &gt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
-			<description>
+			<description>          
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/StyleBox.xml
+++ b/doc/classes/StyleBox.xml
@@ -14,31 +14,31 @@
 			<return type="void" />
 			<param index="0" name="to_canvas_item" type="RID" />
 			<param index="1" name="rect" type="Rect2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_center_size" qualifiers="virtual const">
 			<return type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_draw_rect" qualifiers="virtual const">
 			<return type="Rect2" />
 			<param index="0" name="rect" type="Rect2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_style_margin" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="side" type="int" enum="Side" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_test_mask" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="point" type="Vector2" />
 			<param index="1" name="rect" type="Rect2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="draw" qualifiers="const">

--- a/doc/classes/TextServerDummy.xml
+++ b/doc/classes/TextServerDummy.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="TextServerDummy" inherits="TextServerExtension" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -11,14 +11,14 @@
 	<methods>
 		<method name="_create_font" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_create_shaped_text" qualifiers="virtual">
 			<return type="RID" />
 			<param index="0" name="direction" type="int" enum="TextServer.Direction" />
 			<param index="1" name="orientation" type="int" enum="TextServer.Orientation" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_draw_hex_code_box" qualifiers="virtual const">
@@ -28,34 +28,34 @@
 			<param index="2" name="pos" type="Vector2" />
 			<param index="3" name="index" type="int" />
 			<param index="4" name="color" type="Color" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_clear_glyphs" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_clear_kerning_map" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_clear_size_cache" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_clear_textures" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_draw_glyph" qualifiers="virtual const">
@@ -66,7 +66,7 @@
 			<param index="3" name="pos" type="Vector2" />
 			<param index="4" name="index" type="int" />
 			<param index="5" name="color" type="Color" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_draw_glyph_outline" qualifiers="virtual const">
@@ -78,62 +78,62 @@
 			<param index="4" name="pos" type="Vector2" />
 			<param index="5" name="index" type="int" />
 			<param index="6" name="color" type="Color" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_antialiasing" qualifiers="virtual const">
 			<return type="int" enum="TextServer.FontAntialiasing" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_ascent" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_descent" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_embolden" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_face_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_face_index" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_fixed_size" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_generate_mipmaps" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_global_oversampling" qualifiers="virtual const">
 			<return type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_glyph_advance" qualifiers="virtual const">
@@ -141,7 +141,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="glyph" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_glyph_contours" qualifiers="virtual const">
@@ -149,7 +149,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_glyph_index" qualifiers="virtual const">
@@ -158,14 +158,14 @@
 			<param index="1" name="size" type="int" />
 			<param index="2" name="char" type="int" />
 			<param index="3" name="variation_selector" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_glyph_list" qualifiers="virtual const">
 			<return type="PackedInt32Array" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_glyph_offset" qualifiers="virtual const">
@@ -173,7 +173,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_glyph_size" qualifiers="virtual const">
@@ -181,7 +181,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_glyph_texture_idx" qualifiers="virtual const">
@@ -189,7 +189,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_glyph_texture_rid" qualifiers="virtual const">
@@ -197,7 +197,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_glyph_texture_size" qualifiers="virtual const">
@@ -205,7 +205,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_glyph_uv_rect" qualifiers="virtual const">
@@ -213,13 +213,13 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_hinting" qualifiers="virtual const">
 			<return type="int" enum="TextServer.Hinting" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_kerning" qualifiers="virtual const">
@@ -227,114 +227,114 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="glyph_pair" type="Vector2i" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_kerning_list" qualifiers="virtual const">
 			<return type="Vector2i[]" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_language_support_override" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="language" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_language_support_overrides" qualifiers="virtual">
 			<return type="PackedStringArray" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_msdf_pixel_range" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_msdf_size" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_name" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_opentype_feature_overrides" qualifiers="virtual const">
 			<return type="Dictionary" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_oversampling" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_scale" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_script_support_override" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="script" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_script_support_overrides" qualifiers="virtual">
 			<return type="PackedStringArray" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_size_cache_list" qualifiers="virtual const">
 			<return type="Vector2i[]" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_style" qualifiers="virtual const">
 			<return type="int" enum="TextServer.FontStyle" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_style_name" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_subpixel_positioning" qualifiers="virtual const">
 			<return type="int" enum="TextServer.SubpixelPositioning" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_supported_chars" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_texture_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_texture_image" qualifiers="virtual const">
@@ -342,7 +342,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="texture_index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_texture_offsets" qualifiers="virtual const">
@@ -350,66 +350,66 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="texture_index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_transform" qualifiers="virtual const">
 			<return type="Transform2D" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_underline_position" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_underline_thickness" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_get_variation_coordinates" qualifiers="virtual const">
 			<return type="Dictionary" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_has_char" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="char" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_is_force_autohinter" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_is_language_supported" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="language" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_is_multichannel_signed_distance_field" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_is_script_supported" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="script" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_remove_glyph" qualifiers="virtual">
@@ -417,7 +417,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_remove_kerning" qualifiers="virtual">
@@ -425,28 +425,28 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="glyph_pair" type="Vector2i" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_remove_language_support_override" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="language" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_remove_script_support_override" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="script" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_remove_size_cache" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_remove_texture" qualifiers="virtual">
@@ -454,7 +454,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="texture_index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_render_glyph" qualifiers="virtual">
@@ -462,7 +462,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_render_range" qualifiers="virtual">
@@ -471,14 +471,14 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="start" type="int" />
 			<param index="3" name="end" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_antialiasing" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="antialiasing" type="int" enum="TextServer.FontAntialiasing" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_ascent" qualifiers="virtual">
@@ -486,14 +486,14 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="ascent" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_data" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="data" type="PackedByteArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_data_ptr" qualifiers="virtual">
@@ -501,7 +501,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="data_ptr" type="const uint8_t*" />
 			<param index="2" name="data_size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_descent" qualifiers="virtual">
@@ -509,48 +509,48 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="descent" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_embolden" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="strength" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_face_index" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="face_index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_fixed_size" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="fixed_size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_force_autohinter" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="force_autohinter" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_generate_mipmaps" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="generate_mipmaps" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_global_oversampling" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="oversampling" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_glyph_advance" qualifiers="virtual">
@@ -559,7 +559,7 @@
 			<param index="1" name="size" type="int" />
 			<param index="2" name="glyph" type="int" />
 			<param index="3" name="advance" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_glyph_offset" qualifiers="virtual">
@@ -568,7 +568,7 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<param index="3" name="offset" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_glyph_size" qualifiers="virtual">
@@ -577,7 +577,7 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<param index="3" name="gl_size" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_glyph_texture_idx" qualifiers="virtual">
@@ -586,7 +586,7 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<param index="3" name="texture_idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_glyph_uv_rect" qualifiers="virtual">
@@ -595,14 +595,14 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<param index="3" name="uv_rect" type="Rect2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_hinting" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="hinting" type="int" enum="TextServer.Hinting" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_kerning" qualifiers="virtual">
@@ -611,7 +611,7 @@
 			<param index="1" name="size" type="int" />
 			<param index="2" name="glyph_pair" type="Vector2i" />
 			<param index="3" name="kerning" type="Vector2" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_language_support_override" qualifiers="virtual">
@@ -619,49 +619,49 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="language" type="String" />
 			<param index="2" name="supported" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_msdf_pixel_range" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="msdf_pixel_range" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_msdf_size" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="msdf_size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_multichannel_signed_distance_field" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="msdf" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_name" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="name" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_opentype_feature_overrides" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="overrides" type="Dictionary" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_oversampling" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="oversampling" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_scale" qualifiers="virtual">
@@ -669,7 +669,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="scale" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_script_support_override" qualifiers="virtual">
@@ -677,28 +677,28 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="script" type="String" />
 			<param index="2" name="supported" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_style" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="style" type="int" enum="TextServer.FontStyle" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_style_name" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="name_style" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_subpixel_positioning" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="subpixel_positioning" type="int" enum="TextServer.SubpixelPositioning" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_texture_image" qualifiers="virtual">
@@ -707,7 +707,7 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="texture_index" type="int" />
 			<param index="3" name="image" type="Image" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_texture_offsets" qualifiers="virtual">
@@ -716,14 +716,14 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="texture_index" type="int" />
 			<param index="3" name="offset" type="PackedInt32Array" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_transform" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="transform" type="Transform2D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_underline_position" qualifiers="virtual">
@@ -731,7 +731,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="underline_position" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_underline_thickness" qualifiers="virtual">
@@ -739,116 +739,116 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="underline_thickness" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_set_variation_coordinates" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="variation_coordinates" type="Dictionary" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_supported_feature_list" qualifiers="virtual const">
 			<return type="Dictionary" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_font_supported_variation_list" qualifiers="virtual const">
 			<return type="Dictionary" />
 			<param index="0" name="font_rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_format_number" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="string" type="String" />
 			<param index="1" name="language" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_free_rid" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_features" qualifiers="virtual const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_hex_code_box_size" qualifiers="virtual const">
 			<return type="Vector2" />
 			<param index="0" name="size" type="int" />
 			<param index="1" name="index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_name" qualifiers="virtual const">
 			<return type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_support_data_filename" qualifiers="virtual const">
 			<return type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_support_data_info" qualifiers="virtual const">
 			<return type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_has" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="rid" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_has_feature" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="feature" type="int" enum="TextServer.Feature" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_is_confusable" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="string" type="String" />
 			<param index="1" name="dict" type="PackedStringArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_is_locale_right_to_left" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="locale" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_is_valid_identifier" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="string" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_load_support_data" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="filename" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_name_to_tag" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="name" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_parse_number" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="string" type="String" />
 			<param index="1" name="language" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_parse_structured_text" qualifiers="virtual const">
@@ -856,32 +856,32 @@
 			<param index="0" name="parser_type" type="int" enum="TextServer.StructuredTextParser" />
 			<param index="1" name="args" type="Array" />
 			<param index="2" name="text" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_percent_sign" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="language" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_save_support_data" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="filename" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_get_span_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_get_span_meta" qualifiers="virtual const">
 			<return type="Variant" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="index" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_set_span_update_font" qualifiers="virtual">
@@ -891,7 +891,7 @@
 			<param index="2" name="fonts" type="RID[]" />
 			<param index="3" name="size" type="int" />
 			<param index="4" name="opentype_features" type="Dictionary" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_add_object" qualifiers="virtual">
@@ -901,7 +901,7 @@
 			<param index="2" name="size" type="Vector2" />
 			<param index="3" name="inline_align" type="int" enum="InlineAlignment" />
 			<param index="4" name="length" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_add_string" qualifiers="virtual">
@@ -913,13 +913,13 @@
 			<param index="4" name="opentype_features" type="Dictionary" />
 			<param index="5" name="language" type="String" />
 			<param index="6" name="meta" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_clear" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_draw" qualifiers="virtual const">
@@ -930,7 +930,7 @@
 			<param index="3" name="clip_l" type="float" />
 			<param index="4" name="clip_r" type="float" />
 			<param index="5" name="color" type="Color" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_draw_outline" qualifiers="virtual const">
@@ -942,7 +942,7 @@
 			<param index="4" name="clip_r" type="float" />
 			<param index="5" name="outline_size" type="int" />
 			<param index="6" name="color" type="Color" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_fit_to_width" qualifiers="virtual">
@@ -950,13 +950,13 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="width" type="float" />
 			<param index="2" name="jst_flags" type="int" enum="TextServer.JustificationFlag" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_ascent" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_carets" qualifiers="virtual const">
@@ -964,25 +964,25 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="position" type="int" />
 			<param index="2" name="caret" type="CaretInfo*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_custom_punctuation" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_descent" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_direction" qualifiers="virtual const">
 			<return type="int" enum="TextServer.Direction" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_dominant_direction_in_range" qualifiers="virtual const">
@@ -990,50 +990,50 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="start" type="int" />
 			<param index="2" name="end" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_ellipsis_glyph_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_ellipsis_glyphs" qualifiers="virtual const">
 			<return type="const Glyph*" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_ellipsis_pos" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_glyph_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_glyphs" qualifiers="virtual const">
 			<return type="const Glyph*" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_grapheme_bounds" qualifiers="virtual const">
 			<return type="Vector2" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_inferred_direction" qualifiers="virtual const">
 			<return type="int" enum="TextServer.Direction" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_line_breaks" qualifiers="virtual const">
@@ -1042,7 +1042,7 @@
 			<param index="1" name="width" type="float" />
 			<param index="2" name="start" type="int" />
 			<param index="3" name="break_flags" type="int" enum="TextServer.LineBreakFlag" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_line_breaks_adv" qualifiers="virtual const">
@@ -1052,50 +1052,50 @@
 			<param index="2" name="start" type="int" />
 			<param index="3" name="once" type="bool" />
 			<param index="4" name="break_flags" type="int" enum="TextServer.LineBreakFlag" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_object_rect" qualifiers="virtual const">
 			<return type="Rect2" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="key" type="Variant" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_objects" qualifiers="virtual const">
 			<return type="Array" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_orientation" qualifiers="virtual const">
 			<return type="int" enum="TextServer.Orientation" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_parent" qualifiers="virtual const">
 			<return type="RID" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_preserve_control" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_preserve_invalid" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_range" qualifiers="virtual const">
 			<return type="Vector2i" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_selection" qualifiers="virtual const">
@@ -1103,78 +1103,78 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="start" type="int" />
 			<param index="2" name="end" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_size" qualifiers="virtual const">
 			<return type="Vector2" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_spacing" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="spacing" type="int" enum="TextServer.SpacingType" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_trim_pos" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_underline_position" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_underline_thickness" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_width" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_get_word_breaks" qualifiers="virtual const">
 			<return type="PackedInt32Array" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="grapheme_flags" type="int" enum="TextServer.GraphemeFlag" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_hit_test_grapheme" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="coord" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_hit_test_position" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="coord" type="float" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_is_ready" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_next_grapheme_pos" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_overrun_trim_to_width" qualifiers="virtual">
@@ -1182,14 +1182,14 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="width" type="float" />
 			<param index="2" name="trim_flags" type="int" enum="TextServer.TextOverrunFlag" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_prev_grapheme_pos" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_resize_object" qualifiers="virtual">
@@ -1198,49 +1198,49 @@
 			<param index="1" name="key" type="Variant" />
 			<param index="2" name="size" type="Vector2" />
 			<param index="3" name="inline_align" type="int" enum="InlineAlignment" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_set_bidi_override" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="override" type="Array" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_set_custom_punctuation" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="punct" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_set_direction" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="direction" type="int" enum="TextServer.Direction" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_set_orientation" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="orientation" type="int" enum="TextServer.Orientation" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_set_preserve_control" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="enabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_set_preserve_invalid" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="enabled" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_set_spacing" qualifiers="virtual">
@@ -1248,19 +1248,19 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<param index="2" name="value" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_shape" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_sort_logical" qualifiers="virtual">
 			<return type="const Glyph*" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_substr" qualifiers="virtual const">
@@ -1268,65 +1268,65 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="start" type="int" />
 			<param index="2" name="length" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_tab_align" qualifiers="virtual">
 			<return type="float" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="tab_stops" type="PackedFloat32Array" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_update_breaks" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_shaped_text_update_justification_ops" qualifiers="virtual">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_spoof_check" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="string" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_string_get_word_breaks" qualifiers="virtual const">
 			<return type="PackedInt32Array" />
 			<param index="0" name="string" type="String" />
 			<param index="1" name="language" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_string_to_lower" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="string" type="String" />
 			<param index="1" name="language" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_string_to_upper" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="string" type="String" />
 			<param index="1" name="language" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_strip_diacritics" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="string" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_tag_to_name" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="tag" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -40,7 +40,7 @@
 		<constructor name="Transform3D">
 			<return type="Transform3D" />
 			<param index="0" name="from" type="Projection" />
-			<description>
+			<description>          
 			</description>
 		</constructor>
 		<constructor name="Transform3D">

--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -271,13 +271,13 @@
 		<method name="get_structured_text_bidi_override" qualifiers="const">
 			<return type="int" enum="TextServer.StructuredTextParser" />
 			<param index="0" name="column" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_structured_text_bidi_override_options" qualifiers="const">
 			<return type="Array" />
 			<param index="0" name="column" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_suffix" qualifiers="const">
@@ -347,7 +347,7 @@
 		<method name="is_custom_set_as_button" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="column" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="is_editable">
@@ -470,7 +470,7 @@
 			<return type="void" />
 			<param index="0" name="column" type="int" />
 			<param index="1" name="enable" type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_custom_bg_color">
@@ -621,14 +621,14 @@
 			<return type="void" />
 			<param index="0" name="column" type="int" />
 			<param index="1" name="parser" type="int" enum="TextServer.StructuredTextParser" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_structured_text_bidi_override_options">
 			<return type="void" />
 			<param index="0" name="column" type="int" />
 			<param index="1" name="args" type="Array" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_suffix">
@@ -673,7 +673,7 @@
 		</method>
 		<method name="uncollapse_tree">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/TubeTrailMesh.xml
+++ b/doc/classes/TubeTrailMesh.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="TubeTrailMesh" inherits="PrimitiveMesh" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -75,7 +75,7 @@
 			<return type="int" />
 			<param index="0" name="type" type="int" enum="Viewport.RenderInfoType" />
 			<param index="1" name="info" type="int" enum="Viewport.RenderInfo" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_screen_transform" qualifiers="const">
@@ -164,7 +164,7 @@
 		<method name="push_text_input">
 			<return type="void" />
 			<param index="0" name="text" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="push_unhandled_input">

--- a/doc/classes/VisualInstance3D.xml
+++ b/doc/classes/VisualInstance3D.xml
@@ -11,7 +11,7 @@
 	<methods>
 		<method name="_get_aabb" qualifiers="virtual const">
 			<return type="AABB" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_aabb" qualifiers="const">

--- a/doc/classes/VisualShader.xml
+++ b/doc/classes/VisualShader.xml
@@ -25,7 +25,7 @@
 			<param index="0" name="name" type="String" />
 			<param index="1" name="mode" type="int" enum="VisualShader.VaryingMode" />
 			<param index="2" name="type" type="int" enum="VisualShader.VaryingType" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="can_connect_nodes" qualifiers="const">
@@ -105,13 +105,13 @@
 		<method name="get_valid_node_id" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="type" type="int" enum="VisualShader.Type" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="has_varying" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="name" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="is_node_connection" qualifiers="const">
@@ -136,7 +136,7 @@
 		<method name="remove_varying">
 			<return type="void" />
 			<param index="0" name="name" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="replace_node">

--- a/doc/classes/VisualShaderNodeConstant.xml
+++ b/doc/classes/VisualShaderNodeConstant.xml
@@ -3,7 +3,7 @@
 	<brief_description>
 		A base type for the constants within the visual shader graph.
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeDistanceFade.xml
+++ b/doc/classes/VisualShaderNodeDistanceFade.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeDistanceFade" inherits="VisualShaderNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeIntParameter.xml
+++ b/doc/classes/VisualShaderNodeIntParameter.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeIntParameter" inherits="VisualShaderNodeParameter" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeLinearSceneDepth.xml
+++ b/doc/classes/VisualShaderNodeLinearSceneDepth.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeLinearSceneDepth" inherits="VisualShaderNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeParticleAccelerator.xml
+++ b/doc/classes/VisualShaderNodeParticleAccelerator.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeParticleAccelerator" inherits="VisualShaderNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeParticleBoxEmitter.xml
+++ b/doc/classes/VisualShaderNodeParticleBoxEmitter.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeParticleBoxEmitter" inherits="VisualShaderNodeParticleEmitter" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeParticleConeVelocity.xml
+++ b/doc/classes/VisualShaderNodeParticleConeVelocity.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeParticleConeVelocity" inherits="VisualShaderNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeParticleEmit.xml
+++ b/doc/classes/VisualShaderNodeParticleEmit.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeParticleEmit" inherits="VisualShaderNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeParticleEmitter.xml
+++ b/doc/classes/VisualShaderNodeParticleEmitter.xml
@@ -3,7 +3,7 @@
 	<brief_description>
 		A base class for particle emitters.
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeParticleMeshEmitter.xml
+++ b/doc/classes/VisualShaderNodeParticleMeshEmitter.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeParticleMeshEmitter" inherits="VisualShaderNodeParticleEmitter" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeParticleMultiplyByAxisAngle.xml
+++ b/doc/classes/VisualShaderNodeParticleMultiplyByAxisAngle.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeParticleMultiplyByAxisAngle" inherits="VisualShaderNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeParticleOutput.xml
+++ b/doc/classes/VisualShaderNodeParticleOutput.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeParticleOutput" inherits="VisualShaderNodeOutput" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeParticleRandomness.xml
+++ b/doc/classes/VisualShaderNodeParticleRandomness.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeParticleRandomness" inherits="VisualShaderNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeParticleRingEmitter.xml
+++ b/doc/classes/VisualShaderNodeParticleRingEmitter.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeParticleRingEmitter" inherits="VisualShaderNodeParticleEmitter" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeParticleSphereEmitter.xml
+++ b/doc/classes/VisualShaderNodeParticleSphereEmitter.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeParticleSphereEmitter" inherits="VisualShaderNodeParticleEmitter" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeProximityFade.xml
+++ b/doc/classes/VisualShaderNodeProximityFade.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeProximityFade" inherits="VisualShaderNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeRandomRange.xml
+++ b/doc/classes/VisualShaderNodeRandomRange.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeRandomRange" inherits="VisualShaderNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeRemap.xml
+++ b/doc/classes/VisualShaderNodeRemap.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeRemap" inherits="VisualShaderNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeTexture2DArrayParameter.xml
+++ b/doc/classes/VisualShaderNodeTexture2DArrayParameter.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeTexture2DArrayParameter" inherits="VisualShaderNodeTextureParameter" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeUVFunc.xml
+++ b/doc/classes/VisualShaderNodeUVFunc.xml
@@ -3,7 +3,7 @@
 	<brief_description>
 		Contains functions to modify texture coordinates ([code]uv[/code]) to be used within the visual shader graph.
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeUVPolarCoord.xml
+++ b/doc/classes/VisualShaderNodeUVPolarCoord.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeUVPolarCoord" inherits="VisualShaderNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeVarying.xml
+++ b/doc/classes/VisualShaderNodeVarying.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVarying" inherits="VisualShaderNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeVaryingGetter.xml
+++ b/doc/classes/VisualShaderNodeVaryingGetter.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVaryingGetter" inherits="VisualShaderNodeVarying" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeVaryingSetter.xml
+++ b/doc/classes/VisualShaderNodeVaryingSetter.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="VisualShaderNodeVaryingSetter" inherits="VisualShaderNodeVarying" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VisualShaderNodeVectorBase.xml
+++ b/doc/classes/VisualShaderNodeVectorBase.xml
@@ -3,7 +3,7 @@
 	<brief_description>
 		A base type for the nodes using different vector types within the visual shader graph.
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VoxelGIData.xml
+++ b/doc/classes/VoxelGIData.xml
@@ -20,7 +20,7 @@
 			<param index="4" name="data_cells" type="PackedByteArray" />
 			<param index="5" name="distance_field" type="PackedByteArray" />
 			<param index="6" name="level_counts" type="PackedInt32Array" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_bounds" qualifiers="const">
@@ -32,27 +32,27 @@
 		</method>
 		<method name="get_data_cells" qualifiers="const">
 			<return type="PackedByteArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_level_counts" qualifiers="const">
 			<return type="PackedInt32Array" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_octree_cells" qualifiers="const">
 			<return type="PackedByteArray" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_octree_size" qualifiers="const">
 			<return type="Vector3" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_to_cell_xform" qualifiers="const">
 			<return type="Transform3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/WorkerThreadPool.xml
+++ b/doc/classes/WorkerThreadPool.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="WorkerThreadPool" inherits="Object" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -14,7 +14,7 @@
 			<param index="2" name="tasks_needed" type="int" default="-1" />
 			<param index="3" name="high_priority" type="bool" default="false" />
 			<param index="4" name="description" type="String" default="&quot;&quot;" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="add_task">
@@ -22,37 +22,37 @@
 			<param index="0" name="action" type="Callable" />
 			<param index="1" name="high_priority" type="bool" default="false" />
 			<param index="2" name="description" type="String" default="&quot;&quot;" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_group_processed_element_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="group_id" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="is_group_task_completed" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="group_id" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="is_task_completed" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="task_id" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="wait_for_group_task_completion">
 			<return type="void" />
 			<param index="0" name="group_id" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="wait_for_task_completion">
 			<return type="void" />
 			<param index="0" name="task_id" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/XRInterfaceExtension.xml
+++ b/doc/classes/XRInterfaceExtension.xml
@@ -126,7 +126,7 @@
 		</method>
 		<method name="_get_vrs_texture" qualifiers="virtual">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_initialize" qualifiers="virtual">
@@ -226,12 +226,12 @@
 		</method>
 		<method name="get_color_texture">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_depth_texture">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_render_target_texture">
@@ -243,7 +243,7 @@
 		</method>
 		<method name="get_velocity_texture">
 			<return type="RID" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/modules/gltf/doc_classes/EditorSceneFormatImporterGLTF.xml
+++ b/modules/gltf/doc_classes/EditorSceneFormatImporterGLTF.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="EditorSceneFormatImporterGLTF" inherits="EditorSceneFormatImporter" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/gltf/doc_classes/GLTFAccessor.xml
+++ b/modules/gltf/doc_classes/GLTFAccessor.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GLTFAccessor" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/gltf/doc_classes/GLTFAnimation.xml
+++ b/modules/gltf/doc_classes/GLTFAnimation.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GLTFAnimation" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/gltf/doc_classes/GLTFBufferView.xml
+++ b/modules/gltf/doc_classes/GLTFBufferView.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GLTFBufferView" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/gltf/doc_classes/GLTFDocument.xml
+++ b/modules/gltf/doc_classes/GLTFDocument.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GLTFDocument" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
 	<description>
 		Append a glTF2 3d format from a file, buffer or scene and then write to the filesystem, buffer or scene.

--- a/modules/gltf/doc_classes/GLTFDocumentExtensionConvertImporterMesh.xml
+++ b/modules/gltf/doc_classes/GLTFDocumentExtensionConvertImporterMesh.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GLTFDocumentExtensionConvertImporterMesh" inherits="GLTFDocumentExtension" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/gltf/doc_classes/GLTFMesh.xml
+++ b/modules/gltf/doc_classes/GLTFMesh.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GLTFMesh" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/gltf/doc_classes/GLTFSkeleton.xml
+++ b/modules/gltf/doc_classes/GLTFSkeleton.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GLTFSkeleton" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,39 +10,39 @@
 		<method name="get_bone_attachment">
 			<return type="BoneAttachment3D" />
 			<param index="0" name="idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_bone_attachment_count">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_godot_bone_node">
 			<return type="Dictionary" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_godot_skeleton">
 			<return type="Skeleton3D" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_unique_names">
 			<return type="String[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_godot_bone_node">
 			<return type="void" />
 			<param index="0" name="godot_bone_node" type="Dictionary" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_unique_names">
 			<return type="void" />
 			<param index="0" name="unique_names" type="String[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/modules/gltf/doc_classes/GLTFSkin.xml
+++ b/modules/gltf/doc_classes/GLTFSkin.xml
@@ -1,43 +1,43 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GLTFSkin" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
 		<method name="get_inverse_binds">
 			<return type="Transform3D[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_joint_i_to_bone_i">
 			<return type="Dictionary" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_joint_i_to_name">
 			<return type="Dictionary" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_inverse_binds">
 			<return type="void" />
 			<param index="0" name="inverse_binds" type="Transform3D[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_joint_i_to_bone_i">
 			<return type="void" />
 			<param index="0" name="joint_i_to_bone_i" type="Dictionary" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_joint_i_to_name">
 			<return type="void" />
 			<param index="0" name="joint_i_to_name" type="Dictionary" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/modules/gltf/doc_classes/GLTFState.xml
+++ b/modules/gltf/doc_classes/GLTFState.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GLTFState" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -17,7 +17,7 @@
 		</method>
 		<method name="get_accessors">
 			<return type="GLTFAccessor[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_additional_data">
@@ -31,74 +31,74 @@
 		<method name="get_animation_player">
 			<return type="AnimationPlayer" />
 			<param index="0" name="idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_animation_players_count">
 			<return type="int" />
 			<param index="0" name="idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_animations">
 			<return type="GLTFAnimation[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_buffer_views">
 			<return type="GLTFBufferView[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_cameras">
 			<return type="GLTFCamera[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_images">
 			<return type="Texture2D[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_lights">
 			<return type="GLTFLight[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_materials">
 			<return type="BaseMaterial3D[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_meshes">
 			<return type="GLTFMesh[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_nodes">
 			<return type="GLTFNode[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_scene_node">
 			<return type="Node" />
 			<param index="0" name="idx" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_skeleton_to_node">
 			<return type="Dictionary" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_skeletons">
 			<return type="GLTFSkeleton[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_skins">
 			<return type="GLTFSkin[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_texture_samplers">
@@ -109,23 +109,23 @@
 		</method>
 		<method name="get_textures">
 			<return type="GLTFTexture[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_unique_animation_names">
 			<return type="String[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="get_unique_names">
 			<return type="String[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_accessors">
 			<return type="void" />
 			<param index="0" name="accessors" type="GLTFAccessor[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_additional_data">
@@ -140,67 +140,67 @@
 		<method name="set_animations">
 			<return type="void" />
 			<param index="0" name="animations" type="GLTFAnimation[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_buffer_views">
 			<return type="void" />
 			<param index="0" name="buffer_views" type="GLTFBufferView[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_cameras">
 			<return type="void" />
 			<param index="0" name="cameras" type="GLTFCamera[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_images">
 			<return type="void" />
 			<param index="0" name="images" type="Texture2D[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_lights">
 			<return type="void" />
 			<param index="0" name="lights" type="GLTFLight[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_materials">
 			<return type="void" />
 			<param index="0" name="materials" type="BaseMaterial3D[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_meshes">
 			<return type="void" />
 			<param index="0" name="meshes" type="GLTFMesh[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_nodes">
 			<return type="void" />
 			<param index="0" name="nodes" type="GLTFNode[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_skeleton_to_node">
 			<return type="void" />
 			<param index="0" name="skeleton_to_node" type="Dictionary" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_skeletons">
 			<return type="void" />
 			<param index="0" name="skeletons" type="GLTFSkeleton[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_skins">
 			<return type="void" />
 			<param index="0" name="skins" type="GLTFSkin[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_texture_samplers">
@@ -213,19 +213,19 @@
 		<method name="set_textures">
 			<return type="void" />
 			<param index="0" name="textures" type="GLTFTexture[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_unique_animation_names">
 			<return type="void" />
 			<param index="0" name="unique_animation_names" type="String[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="set_unique_names">
 			<return type="void" />
 			<param index="0" name="unique_names" type="String[]" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/modules/gltf/doc_classes/GLTFTexture.xml
+++ b/modules/gltf/doc_classes/GLTFTexture.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GLTFTexture" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/multiplayer/doc_classes/SceneReplicationConfig.xml
+++ b/modules/multiplayer/doc_classes/SceneReplicationConfig.xml
@@ -3,7 +3,7 @@
 	<brief_description>
 		Configuration for properties to synchronize with a [MultiplayerSynchronizer].
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/ogg/doc_classes/OggPacketSequencePlayback.xml
+++ b/modules/ogg/doc_classes/OggPacketSequencePlayback.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="OggPacketSequencePlayback" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/text_server_adv/doc_classes/TextServerAdvanced.xml
+++ b/modules/text_server_adv/doc_classes/TextServerAdvanced.xml
@@ -3,7 +3,7 @@
 	<brief_description>
 		Text Server using HarfBuzz, ICU and SIL Graphite to support BiDi, complex text layouts and contextual OpenType features.
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/text_server_fb/doc_classes/TextServerFallback.xml
+++ b/modules/text_server_fb/doc_classes/TextServerFallback.xml
@@ -3,7 +3,7 @@
 	<brief_description>
 		Fallback implementation of the Text Server, without BiDi and complex text layout support.
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/vorbis/doc_classes/AudioStreamOggVorbis.xml
+++ b/modules/vorbis/doc_classes/AudioStreamOggVorbis.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioStreamOggVorbis" inherits="AudioStream" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/vorbis/doc_classes/AudioStreamPlaybackOggVorbis.xml
+++ b/modules/vorbis/doc_classes/AudioStreamPlaybackOggVorbis.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioStreamPlaybackOggVorbis" inherits="AudioStreamPlaybackResampled" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/webrtc/doc_classes/WebRTCDataChannel.xml
+++ b/modules/webrtc/doc_classes/WebRTCDataChannel.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="WebRTCDataChannel" inherits="PacketPeer" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/webrtc/doc_classes/WebRTCDataChannelExtension.xml
+++ b/modules/webrtc/doc_classes/WebRTCDataChannelExtension.xml
@@ -1,105 +1,105 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="WebRTCDataChannelExtension" inherits="WebRTCDataChannel" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
 		<method name="_close" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_available_packet_count" qualifiers="virtual const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_buffered_amount" qualifiers="virtual const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_id" qualifiers="virtual const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_label" qualifiers="virtual const">
 			<return type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_max_packet_life_time" qualifiers="virtual const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_max_packet_size" qualifiers="virtual const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_max_retransmits" qualifiers="virtual const">
 			<return type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_packet" qualifiers="virtual">
 			<return type="int" enum="Error" />
 			<param index="0" name="r_buffer" type="const uint8_t **" />
 			<param index="1" name="r_buffer_size" type="int32_t*" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_protocol" qualifiers="virtual const">
 			<return type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_ready_state" qualifiers="virtual const">
 			<return type="int" enum="WebRTCDataChannel.ChannelState" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_write_mode" qualifiers="virtual const">
 			<return type="int" enum="WebRTCDataChannel.WriteMode" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_is_negotiated" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_is_ordered" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_poll" qualifiers="virtual">
 			<return type="int" enum="Error" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_put_packet" qualifiers="virtual">
 			<return type="int" enum="Error" />
 			<param index="0" name="p_buffer" type="const uint8_t*" />
 			<param index="1" name="p_buffer_size" type="int" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_write_mode" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="p_write_mode" type="int" enum="WebRTCDataChannel.WriteMode" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_was_string_packet" qualifiers="virtual const">
 			<return type="bool" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>

--- a/modules/webrtc/doc_classes/WebRTCPeerConnectionExtension.xml
+++ b/modules/webrtc/doc_classes/WebRTCPeerConnectionExtension.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="WebRTCPeerConnectionExtension" inherits="WebRTCPeerConnection" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
-	<brief_description>
+	<brief_description>          
 	</brief_description>
-	<description>
+	<description>          
 	</description>
 	<tutorials>
 	</tutorials>
@@ -12,64 +12,64 @@
 			<param index="0" name="p_sdp_mid_name" type="String" />
 			<param index="1" name="p_sdp_mline_index" type="int" />
 			<param index="2" name="p_sdp_name" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_close" qualifiers="virtual">
 			<return type="void" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_create_data_channel" qualifiers="virtual">
 			<return type="Object" />
 			<param index="0" name="p_label" type="String" />
 			<param index="1" name="p_config" type="Dictionary" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_create_offer" qualifiers="virtual">
 			<return type="int" enum="Error" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_connection_state" qualifiers="virtual const">
 			<return type="int" enum="WebRTCPeerConnection.ConnectionState" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_gathering_state" qualifiers="virtual const">
 			<return type="int" enum="WebRTCPeerConnection.GatheringState" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_get_signaling_state" qualifiers="virtual const">
 			<return type="int" enum="WebRTCPeerConnection.SignalingState" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_initialize" qualifiers="virtual">
 			<return type="int" enum="Error" />
 			<param index="0" name="p_config" type="Dictionary" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_poll" qualifiers="virtual">
 			<return type="int" enum="Error" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_local_description" qualifiers="virtual">
 			<return type="int" enum="Error" />
 			<param index="0" name="p_type" type="String" />
 			<param index="1" name="p_sdp" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 		<method name="_set_remote_description" qualifiers="virtual">
 			<return type="int" enum="Error" />
 			<param index="0" name="p_type" type="String" />
 			<param index="1" name="p_sdp" type="String" />
-			<description>
+			<description>          
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
inspired by @KoBeWi's comment in #68948
> tbh it's irritating when someone adds a feature, but doesn't bother to fill the description.

This PR changes type of `<description>` and `<brief_description>`to string with a min length of 10, which is then checked via `xmllint` in CI pipeline. Error looks like this:

> doc/classes/WorkerThreadPool.xml:3: element brief_description: Schemas validity error : Element 'brief_description': [facet 'minLength'] The value has a length of '2'; this underruns the allowed minimum length of '10'.

Unfortunately there is over 600 empty `<description>` in the existing code already, so to make the pipeline pass I had to either regularly fill them (which feels quite overwhelming) or fill them up with just blank spaces. Not the best solution, but this could help to stop the problem getting worse over time.