### PR TITLE
`Curve3D` bake refactor continue

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -364,6 +364,26 @@ public:
 		return p_start * omt3 + p_control_1 * omt2 * p_t * 3.0f + p_control_2 * omt * t2 * 3.0f + p_end * t3;
 	}
 
+	static _ALWAYS_INLINE_ double bezier_derivative(double p_start, double p_control_1, double p_control_2, double p_end, double p_t) {
+		/* Formula from Wikipedia article on Bezier curves. */
+		double omt = (1.0 - p_t);
+		double omt2 = omt * omt;
+		double t2 = p_t * p_t;
+
+		double d = (p_control_1 - p_start) * 3.0 * omt2 + (p_control_2 - p_control_1) * 6.0 * omt * p_t + (p_end - p_control_2) * 3.0 * t2;
+		return d;
+	}
+
+	static _ALWAYS_INLINE_ float bezier_derivative(float p_start, float p_control_1, float p_control_2, float p_end, float p_t) {
+		/* Formula from Wikipedia article on Bezier curves. */
+		float omt = (1.0f - p_t);
+		float omt2 = omt * omt;
+		float t2 = p_t * p_t;
+
+		float d = (p_control_1 - p_start) * 3.0f * omt2 + (p_control_2 - p_control_1) * 6.0f * omt * p_t + (p_end - p_control_2) * 3.0f * t2;
+		return d;
+	}
+
 	static _ALWAYS_INLINE_ double lerp_angle(double p_from, double p_to, double p_weight) {
 		double difference = fmod(p_to - p_from, Math_TAU);
 		double distance = fmod(2.0 * difference, Math_TAU) - difference;

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -112,6 +112,7 @@ struct _NO_DISCARD_ Vector2 {
 	_FORCE_INLINE_ Vector2 cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, const real_t p_weight) const;
 	_FORCE_INLINE_ Vector2 cubic_interpolate_in_time(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, const real_t p_weight, const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const;
 	_FORCE_INLINE_ Vector2 bezier_interpolate(const Vector2 &p_control_1, const Vector2 &p_control_2, const Vector2 &p_end, const real_t p_t) const;
+	_FORCE_INLINE_ Vector2 bezier_derivative(const Vector2 &p_control_1, const Vector2 &p_control_2, const Vector2 &p_end, const real_t p_t) const;
 
 	Vector2 move_toward(const Vector2 &p_to, const real_t p_delta) const;
 
@@ -287,6 +288,18 @@ Vector2 Vector2::bezier_interpolate(const Vector2 &p_control_1, const Vector2 &p
 	real_t t3 = t2 * p_t;
 
 	return res * omt3 + p_control_1 * omt2 * p_t * 3.0 + p_control_2 * omt * t2 * 3.0 + p_end * t3;
+}
+
+Vector2 Vector2::bezier_derivative(const Vector2 &p_control_1, const Vector2 &p_control_2, const Vector2 &p_end, const real_t p_t) const {
+	Vector2 res = *this;
+
+	/* Formula from Wikipedia article on Bezier curves. */
+	real_t omt = (1.0 - p_t);
+	real_t omt2 = omt * omt;
+	real_t t2 = p_t * p_t;
+
+	Vector2 d = (p_control_1 - res) * 3.0 * omt2 + (p_control_2 - p_control_1) * 6.0 * omt * p_t + (p_end - p_control_2) * 3.0 * t2;
+	return d;
 }
 
 Vector2 Vector2::direction_to(const Vector2 &p_to) const {

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -100,6 +100,7 @@ struct _NO_DISCARD_ Vector3 {
 	_FORCE_INLINE_ Vector3 cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, const real_t p_weight) const;
 	_FORCE_INLINE_ Vector3 cubic_interpolate_in_time(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, const real_t p_weight, const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const;
 	_FORCE_INLINE_ Vector3 bezier_interpolate(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, const real_t p_t) const;
+	_FORCE_INLINE_ Vector3 bezier_derivative(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, const real_t p_t) const;
 
 	Vector3 move_toward(const Vector3 &p_to, const real_t p_delta) const;
 
@@ -263,6 +264,18 @@ Vector3 Vector3::bezier_interpolate(const Vector3 &p_control_1, const Vector3 &p
 	real_t t3 = t2 * p_t;
 
 	return res * omt3 + p_control_1 * omt2 * p_t * 3.0 + p_control_2 * omt * t2 * 3.0 + p_end * t3;
+}
+
+Vector3 Vector3::bezier_derivative(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, const real_t p_t) const {
+	Vector3 res = *this;
+
+	/* Formula from Wikipedia article on Bezier curves. */
+	real_t omt = (1.0 - p_t);
+	real_t omt2 = omt * omt;
+	real_t t2 = p_t * p_t;
+
+	Vector3 d = (p_control_1 - res) * 3.0 * omt2 + (p_control_2 - p_control_1) * 6.0 * omt * p_t + (p_end - p_control_2) * 3.0 * t2;
+	return d;
 }
 
 real_t Vector3::distance_to(const Vector3 &p_to) const {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1615,6 +1615,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector2, cubic_interpolate, sarray("b", "pre_a", "post_b", "weight"), varray());
 	bind_method(Vector2, cubic_interpolate_in_time, sarray("b", "pre_a", "post_b", "weight", "b_t", "pre_a_t", "post_b_t"), varray());
 	bind_method(Vector2, bezier_interpolate, sarray("control_1", "control_2", "end", "t"), varray());
+	bind_method(Vector2, bezier_derivative, sarray("control_1", "control_2", "end", "t"), varray());
 	bind_method(Vector2, max_axis_index, sarray(), varray());
 	bind_method(Vector2, min_axis_index, sarray(), varray());
 	bind_method(Vector2, move_toward, sarray("to", "delta"), varray());
@@ -1707,6 +1708,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector3, cubic_interpolate, sarray("b", "pre_a", "post_b", "weight"), varray());
 	bind_method(Vector3, cubic_interpolate_in_time, sarray("b", "pre_a", "post_b", "weight", "b_t", "pre_a_t", "post_b_t"), varray());
 	bind_method(Vector3, bezier_interpolate, sarray("control_1", "control_2", "end", "t"), varray());
+	bind_method(Vector3, bezier_derivative, sarray("control_1", "control_2", "end", "t"), varray());
 	bind_method(Vector3, move_toward, sarray("to", "delta"), varray());
 	bind_method(Vector3, dot, sarray("with"), varray());
 	bind_method(Vector3, cross, sarray("with"), varray());

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -392,6 +392,10 @@ struct VariantUtilityFunctions {
 		return Math::bezier_interpolate(p_start, p_control_1, p_control_2, p_end, p_t);
 	}
 
+	static inline double bezier_derivative(double p_start, double p_control_1, double p_control_2, double p_end, double p_t) {
+		return Math::bezier_derivative(p_start, p_control_1, p_control_2, p_end, p_t);
+	}
+
 	static inline double lerp_angle(double from, double to, double weight) {
 		return Math::lerp_angle(from, to, weight);
 	}
@@ -1440,6 +1444,7 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(cubic_interpolate_in_time, sarray("from", "to", "pre", "post", "weight", "to_t", "pre_t", "post_t"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(cubic_interpolate_angle_in_time, sarray("from", "to", "pre", "post", "weight", "to_t", "pre_t", "post_t"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(bezier_interpolate, sarray("start", "control_1", "control_2", "end", "t"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(bezier_derivative, sarray("start", "control_1", "control_2", "end", "t"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(lerp_angle, sarray("from", "to", "weight"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(inverse_lerp, sarray("from", "to", "weight"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(remap, sarray("value", "istart", "istop", "ostart", "ostop"), Variant::UTILITY_FUNC_TYPE_MATH);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -106,6 +106,17 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="bezier_derivative">
+			<return type="float" />
+			<param index="0" name="start" type="float" />
+			<param index="1" name="control_1" type="float" />
+			<param index="2" name="control_2" type="float" />
+			<param index="3" name="end" type="float" />
+			<param index="4" name="t" type="float" />
+			<description>
+				Returns the derivative at the given [param t] on a one-dimensional [url=https://en.wikipedia.org/wiki/B%C3%A9zier_curve]Bezier curve[/url] defined by the given [param control_1], [param control_2], and [param end] points.
+			</description>
+		</method>
 		<method name="bezier_interpolate">
 			<return type="float" />
 			<param index="0" name="start" type="float" />

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -192,6 +192,15 @@
 				[param tolerance_degrees] controls how many degrees the midpoint of a segment may deviate from the real curve, before the segment has to be subdivided.
 			</description>
 		</method>
+		<method name="tessellate_even_length" qualifiers="const">
+			<return type="PackedVector3Array" />
+			<param index="0" name="max_stages" type="int" default="5" />
+			<param index="1" name="tolerance_length" type="float" default="0.2" />
+			<description>
+				Returns a list of points along the curve, with almost uniform density. [param max_stages] controls how many subdivisions a curve segment may face before it is considered approximate enough. Each subdivision splits the segment in half, so the default 5 stages may mean up to 32 subdivisions per curve segment. Increase with care!
+				[param tolerance_length] controls the maximal distance between two neighbouring points, before the segment has to be subdivided.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="bake_interval" type="float" setter="set_bake_interval" getter="get_bake_interval" default="0.2">

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -86,6 +86,16 @@
 				Returns the aspect ratio of this vector, the ratio of [member x] to [member y].
 			</description>
 		</method>
+		<method name="bezier_derivative" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="control_1" type="Vector2" />
+			<param index="1" name="control_2" type="Vector2" />
+			<param index="2" name="end" type="Vector2" />
+			<param index="3" name="t" type="float" />
+			<description>
+				Returns the derivative at the given [param t] on the [url=https://en.wikipedia.org/wiki/B%C3%A9zier_curve]Bezier curve[/url] defined by this vector and the given [param control_1], [param control_2], and [param end] points.
+			</description>
+		</method>
 		<method name="bezier_interpolate" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="control_1" type="Vector2" />

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -62,6 +62,16 @@
 				Returns the unsigned minimum angle to the given vector, in radians.
 			</description>
 		</method>
+		<method name="bezier_derivative" qualifiers="const">
+			<return type="Vector3" />
+			<param index="0" name="control_1" type="Vector3" />
+			<param index="1" name="control_2" type="Vector3" />
+			<param index="2" name="end" type="Vector3" />
+			<param index="3" name="t" type="float" />
+			<description>
+				Returns the derivative at the given [param t] on the [url=https://en.wikipedia.org/wiki/B%C3%A9zier_curve]Bezier curve[/url] defined by this vector and the given [param control_1], [param control_2], and [param end] points.
+			</description>
+		</method>
 		<method name="bezier_interpolate" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="control_1" type="Vector3" />

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -242,6 +242,7 @@ class Curve3D : public Resource {
 	mutable PackedVector3Array baked_point_cache;
 	mutable Vector<real_t> baked_tilt_cache;
 	mutable PackedVector3Array baked_up_vector_cache;
+	mutable PackedVector3Array baked_forward_vector_cache;
 	mutable Vector<real_t> baked_dist_cache;
 	mutable real_t baked_max_ofs = 0.0;
 
@@ -262,6 +263,7 @@ class Curve3D : public Resource {
 	bool up_vector_enabled = true;
 
 	void _bake_segment3d(RBMap<real_t, Vector3> &r_bake, real_t p_begin, real_t p_end, const Vector3 &p_a, const Vector3 &p_out, const Vector3 &p_b, const Vector3 &p_in, int p_depth, int p_max_depth, real_t p_tol) const;
+	void _bake_segment3d_even_length(RBMap<real_t, Vector3> &r_bake, real_t p_begin, real_t p_end, const Vector3 &p_a, const Vector3 &p_out, const Vector3 &p_b, const Vector3 &p_in, int p_depth, int p_max_depth, real_t p_length) const;
 	Dictionary _get_data() const;
 	void _set_data(const Dictionary &p_data);
 
@@ -271,6 +273,8 @@ class Curve3D : public Resource {
 
 	void _add_point(const Vector3 &p_position, const Vector3 &p_in = Vector3(), const Vector3 &p_out = Vector3(), int p_atpos = -1);
 	void _remove_point(int p_index);
+
+	Vector<RBMap<real_t, Vector3>> _tessellate_even_length(int p_max_stages = 5, real_t p_length = 0.2) const;
 
 protected:
 	static void _bind_methods();
@@ -309,7 +313,8 @@ public:
 	Vector3 get_closest_point(const Vector3 &p_to_point) const;
 	real_t get_closest_offset(const Vector3 &p_to_point) const;
 
-	PackedVector3Array tessellate(int p_max_stages = 5, real_t p_tolerance = 4) const; //useful for display
+	PackedVector3Array tessellate(int p_max_stages = 5, real_t p_tolerance = 4) const; // Useful for display.
+	PackedVector3Array tessellate_even_length(int p_max_stages = 5, real_t p_length = 0.2) const; // Useful for baking.
 
 	Curve3D();
 };


### PR DESCRIPTION
This PR follows https://github.com/godotengine/godot/pull/64212, further refactoring the bake code of `Curve3D`. 

The main change is to calculate tangent directly from bezier curve, without going
through discretized polyline.

This is mathematically correct method has the following benefits:
1. More accurate transform frames sampling along the curve; 
2. Path3DFollow movement is completely smooth, fixing https://github.com/godotengine/godot/pull/64212#discussion_r1020716713;
3. Initial up vector is not influenced by baking interval, fixing https://github.com/godotengine/godot/issues/68893
4. Adhoc checks and fixes become unnecessary, leading to simpler and more performant code.

The same refactor can be applied to `Curve2D` in a seperate PR.

_Production edit: Fixes https://github.com/godotengine/godot/issues/68893_