### PR TITLE
Check custom directory for csproj

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -150,6 +150,14 @@ const PackedStringArray ProjectSettings::_trim_to_supported_features(const Packe
 	features.sort();
 	return features;
 }
+
+String ProjectSettings::get_csproj_path() const {
+	String project_dir = get_resource_path();
+	if (has_setting("dotnet/project/c#_project_directory")) {
+		project_dir = project_dir.path_join(get_setting("dotnet/project/c#_project_directory"));
+	}
+	return project_dir.path_join(get_safe_project_name() + ".csproj");
+}
 #endif // TOOLS_ENABLED
 
 String ProjectSettings::localize_path(const String &p_path) const {
@@ -941,7 +949,7 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 		}
 	}
 	// Check for the existence of a csproj file.
-	if (FileAccess::exists(get_resource_path().path_join(get_safe_project_name() + ".csproj"))) {
+	if (FileAccess::exists(get_csproj_path())) {
 		// If there is a csproj file, add the C# feature if it doesn't already exist.
 		if (!project_features.has("C#")) {
 			project_features.append("C#");

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -122,6 +122,8 @@ protected:
 #ifdef TOOLS_ENABLED
 	const static PackedStringArray _get_supported_features();
 	const static PackedStringArray _trim_to_supported_features(const PackedStringArray &p_project_features);
+
+	String get_csproj_path() const;
 #endif // TOOLS_ENABLED
 
 	void _convert_to_last_version(int p_from_version);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #69045.

Setting `c#_project_directory` would previously cause the `C#` feature to be dropped from ProjectSettings.