### PR TITLE
Fix Viewport visibility after entering/leaving scene-tree

### DIFF
--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -227,6 +227,18 @@ void SubViewportContainer::unhandled_input(const Ref<InputEvent> &p_event) {
 	}
 }
 
+void SubViewportContainer::add_child_notify(Node *p_child) {
+	if (Object::cast_to<SubViewport>(p_child)) {
+		queue_redraw();
+	}
+}
+
+void SubViewportContainer::remove_child_notify(Node *p_child) {
+	if (Object::cast_to<SubViewport>(p_child)) {
+		queue_redraw();
+	}
+}
+
 PackedStringArray SubViewportContainer::get_configuration_warnings() const {
 	PackedStringArray warnings = Node::get_configuration_warnings();
 

--- a/scene/gui/subviewport_container.h
+++ b/scene/gui/subviewport_container.h
@@ -44,6 +44,9 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	virtual void add_child_notify(Node *p_child) override;
+	virtual void remove_child_notify(Node *p_child) override;
+
 public:
 	void set_stretch(bool p_enable);
 	bool is_stretch_enabled() const;


### PR DESCRIPTION
When a `SubViewport` leaves the tree, it is still displayed in its parent `SubViewportContainer` until the next redraw.
This PR makes sure, that the parent gets redrawn immediately.

This also fixes the visibility problem when a `SubViewport` is added as child of a `SubViewportContainer`.

MRP: [BugViewportExit.zip](https://github.com/godotengine/godot/files/10075772/BugViewportExit.zip)
