### PR TITLE
Add `center_grabber` theme property to Slider

### DIFF
--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -141,6 +141,9 @@
 		</constant>
 	</constants>
 	<theme_items>
+		<theme_item name="center_slider_grabbers" data_type="constant" type="int" default="1">
+			Overrides the [theme_item HSlider.center_grabber] theme property of the sliders.
+		</theme_item>
 		<theme_item name="h_width" data_type="constant" type="int" default="30">
 			The width of the hue selection slider.
 		</theme_item>

--- a/doc/classes/HSlider.xml
+++ b/doc/classes/HSlider.xml
@@ -10,6 +10,9 @@
 	<tutorials>
 	</tutorials>
 	<theme_items>
+		<theme_item name="center_grabber" data_type="constant" type="int" default="0">
+			Boolean constant. If [code]1[/code], the grabber texture size will be ignored and it will fit within slider's bounds based only on its center position.
+		</theme_item>
 		<theme_item name="grabber_offset" data_type="constant" type="int" default="0">
 			Vertical offset of the grabber.
 		</theme_item>

--- a/doc/classes/VSlider.xml
+++ b/doc/classes/VSlider.xml
@@ -14,6 +14,9 @@
 		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" enum="Control.SizeFlags" default="1" />
 	</members>
 	<theme_items>
+		<theme_item name="center_grabber" data_type="constant" type="int" default="0">
+			Boolean constant. If [code]1[/code], the grabber texture size will be ignored and it will fit within slider's bounds based only on its center position.
+		</theme_item>
 		<theme_item name="grabber_offset" data_type="constant" type="int" default="0">
 			Horizontal offset of the grabber.
 		</theme_item>

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1594,6 +1594,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("slider", "HSlider", make_flat_stylebox(dark_color_3, 0, default_margin_size / 2, 0, default_margin_size / 2, corner_width));
 	theme->set_stylebox("grabber_area", "HSlider", make_flat_stylebox(contrast_color_1, 0, default_margin_size / 2, 0, default_margin_size / 2, corner_width));
 	theme->set_stylebox("grabber_area_highlight", "HSlider", make_flat_stylebox(contrast_color_1, 0, default_margin_size / 2, 0, default_margin_size / 2));
+	theme->set_constant("center_grabber", "HSlider", 0);
 	theme->set_constant("grabber_offset", "HSlider", 0);
 
 	// VSlider
@@ -1602,6 +1603,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("slider", "VSlider", make_flat_stylebox(dark_color_3, default_margin_size / 2, 0, default_margin_size / 2, 0, corner_width));
 	theme->set_stylebox("grabber_area", "VSlider", make_flat_stylebox(contrast_color_1, default_margin_size / 2, 0, default_margin_size / 2, 0, corner_width));
 	theme->set_stylebox("grabber_area_highlight", "VSlider", make_flat_stylebox(contrast_color_1, default_margin_size / 2, 0, default_margin_size / 2, 0));
+	theme->set_constant("center_grabber", "VSlider", 0);
 	theme->set_constant("grabber_offset", "VSlider", 0);
 
 	// RichTextLabel
@@ -1858,6 +1860,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_constant("sv_height", "ColorPicker", 256 * EDSCALE);
 	theme->set_constant("h_width", "ColorPicker", 30 * EDSCALE);
 	theme->set_constant("label_width", "ColorPicker", 10 * EDSCALE);
+	theme->set_constant("center_slider_grabbers", "ColorPicker", 1);
 	theme->set_icon("screen_picker", "ColorPicker", theme->get_icon(SNAME("ColorPick"), SNAME("EditorIcons")));
 	theme->set_icon("shape_circle", "ColorPicker", theme->get_icon(SNAME("PickerShapeCircle"), SNAME("EditorIcons")));
 	theme->set_icon("shape_rect", "ColorPicker", theme->get_icon(SNAME("PickerShapeRectangle"), SNAME("EditorIcons")));

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -67,9 +67,11 @@ void ColorPicker::_notification(int p_what) {
 
 			for (int i = 0; i < SLIDER_COUNT; i++) {
 				labels[i]->set_custom_minimum_size(Size2(theme_cache.label_width, 0));
+				sliders[i]->add_theme_constant_override(SNAME("center_grabber"), theme_cache.center_slider_grabbers);
 				set_offset((Side)i, get_offset((Side)i) + theme_cache.content_margin);
 			}
 			alpha_label->set_custom_minimum_size(Size2(theme_cache.label_width, 0));
+			alpha_label->add_theme_constant_override(SNAME("center_grabber"), theme_cache.center_slider_grabbers);
 			set_offset((Side)0, get_offset((Side)0) + theme_cache.content_margin);
 
 			for (int i = 0; i < MODE_BUTTON_COUNT; i++) {
@@ -121,6 +123,8 @@ void ColorPicker::_update_theme_item_cache() {
 	theme_cache.sv_width = get_theme_constant(SNAME("sv_width"));
 	theme_cache.sv_height = get_theme_constant(SNAME("sv_height"));
 	theme_cache.h_width = get_theme_constant(SNAME("h_width"));
+
+	theme_cache.center_slider_grabbers = get_theme_constant(SNAME("center_slider_grabbers"));
 
 	theme_cache.screen_picker = get_theme_icon(SNAME("screen_picker"));
 	theme_cache.expanded_arrow = get_theme_icon(SNAME("expanded_arrow"));

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -213,6 +213,8 @@ private:
 		int sv_width = 0;
 		int h_width = 0;
 
+		bool center_slider_grabbers = true;
+
 		Ref<Texture2D> screen_picker;
 		Ref<Texture2D> expanded_arrow;
 		Ref<Texture2D> folded_arrow;

--- a/scene/gui/slider.h
+++ b/scene/gui/slider.h
@@ -58,6 +58,9 @@ class Slider : public Range {
 		Ref<Texture2D> grabber_hl_icon;
 		Ref<Texture2D> grabber_disabled_icon;
 		Ref<Texture2D> tick_icon;
+
+		bool center_grabber = false;
+		int grabber_offset = 0;
 	} theme_cache;
 
 protected:

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -565,6 +565,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_icon("grabber_disabled", "HSlider", icons["slider_grabber_disabled"]);
 	theme->set_icon("tick", "HSlider", icons["hslider_tick"]);
 
+	theme->set_constant("center_grabber", "HSlider", 0);
 	theme->set_constant("grabber_offset", "HSlider", 0);
 
 	// VSlider
@@ -578,6 +579,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_icon("grabber_disabled", "VSlider", icons["slider_grabber_disabled"]);
 	theme->set_icon("tick", "VSlider", icons["vslider_tick"]);
 
+	theme->set_constant("center_grabber", "VSlider", 0);
 	theme->set_constant("grabber_offset", "VSlider", 0);
 
 	// SpinBox
@@ -903,6 +905,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("sv_height", "ColorPicker", 256 * scale);
 	theme->set_constant("h_width", "ColorPicker", 30 * scale);
 	theme->set_constant("label_width", "ColorPicker", 10 * scale);
+	theme->set_constant("center_slider_grabbers", "ColorPicker", 1);
 
 	theme->set_icon("folded_arrow", "ColorPicker", icons["arrow_right"]);
 	theme->set_icon("expanded_arrow", "ColorPicker", icons["arrow_down"]);


### PR DESCRIPTION
This PR adds a property to Slider that makes the grabber centered at its position, which makes part of the grabber stick out when its at edges:
![image](https://user-images.githubusercontent.com/2223172/203564911-187bf574-3b3f-4596-b098-8f8dbf0d4feb.png)

It's enabled for ColorPicker sliders, which allows for greater precision:
![godot windows editor dev x86_64_GMNB0mWt59](https://user-images.githubusercontent.com/2223172/203565050-e66b9f99-ab2e-4f78-a664-9894e3cc2a88.gif)

Although I wonder if it shouldn't be a theme property instead 🤔

Closes https://github.com/godotengine/godot-proposals/issues/5830

I also included some minor style changes.