### PR TITLE
Update cvtt to GIT 2022

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -51,7 +51,7 @@ Files extracted from upstream source:
 ## cvtt
 
 - Upstream: https://github.com/elasota/ConvectionKernels
-- Version: git (dc2dbbe0ae2cf2be06ef56d1021e2222a56c7fe2, 2021)
+- Version: git (350416daa4e98f1c17ffc273b134d0120a2ef230, 2022)
 - License: MIT
 
 Files extracted from upstream source:

--- a/thirdparty/cvtt/ConvectionKernels_BC67.cpp
+++ b/thirdparty/cvtt/ConvectionKernels_BC67.cpp
@@ -726,10 +726,10 @@ namespace cvtt
                 if (carry)
                 {
                     uint32_t bitMask = (1 << carry) - 1;
-                    for (int i = 0; i < 4; i++)
+                    for (int i = 0; i < entriesRemaining; i++)
                     {
                         m_vector[i] >>= carry;
-                        if (i != 3)
+                        if (i != entriesRemaining - 1)
                             m_vector[i] |= (m_vector[i + 1] & bitMask) << (32 - carry);
                     }
                 }
@@ -3058,14 +3058,11 @@ void cvtt::Internal::BC6HComputer::SignExtendSingle(int &v, int bits)
 
 void cvtt::Internal::BC6HComputer::UnpackOne(PixelBlockF16 &output, const uint8_t *pBC, bool isSigned)
 {
-    UnpackingVector pv;
-    pv.Init(pBC);
-
     int numModeBits = 2;
-    int modeBits = pv.Unpack(2);
+    int modeBits = pBC[0] & 0x3;
     if (modeBits != 0 && modeBits != 1)
     {
-        modeBits |= pv.Unpack(3) << 2;
+        modeBits = pBC[0] & 0x1f;
         numModeBits += 3;
     }
 
@@ -3101,6 +3098,9 @@ void cvtt::Internal::BC6HComputer::UnpackOne(PixelBlockF16 &output, const uint8_
         for (int epi = 0; epi < 2; epi++)
             for (int ch = 0; ch < 3; ch++)
                 eps[subset][epi][ch] = 0;
+
+    UnpackingVector pv;
+    pv.Init(pBC);
 
     {
         uint32_t header[3];


### PR DESCRIPTION
Another third-party library update mentioned on that tracker.

I wonder if this deserves its own commit, since the update on GIT is a single commit that updates a single file.

Maybe it's important since it claims to fix a bug.