### PR TITLE
RichTextLabel Cell Option "bg" - add possibility to use only one color

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3860,6 +3860,10 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 							Color color2 = Color::from_string(subtag_b[1], fallback_color);
 							set_cell_row_background_color(color1, color2);
 						}
+						if (subtag_b.size() == 1) {
+							Color color1 = Color::from_string(subtag_a[1], fallback_color);
+							set_cell_row_background_color(color1, color1);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
According to the [Cell Options Docs](https://docs.godotengine.org/en/latest/tutorials/ui/bbcode_in_richtextlabel.html#doc-bbcode-in-richtextlabel-cell-options) you can use `[cell bg=color]` to style the cell, however it is not possible without using the split character `,`.

This change applies a single color to both odd and even.