### PR TITLE
Add history dock to default editor layout, and prevent signal connecting multiple times

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7035,7 +7035,7 @@ EditorNode::EditorNode() {
 	// Dock numbers are based on DockSlot enum value + 1.
 	default_layout->set_value(docks_section, "dock_3", "Scene,Import");
 	default_layout->set_value(docks_section, "dock_4", "FileSystem");
-	default_layout->set_value(docks_section, "dock_5", "Inspector,Node");
+	default_layout->set_value(docks_section, "dock_5", "Inspector,Node,History");
 
 	for (int i = 0; i < vsplits.size(); i++) {
 		default_layout->set_value(docks_section, "dock_split_" + itos(i + 1), 0);

--- a/editor/history_dock.cpp
+++ b/editor/history_dock.cpp
@@ -206,7 +206,7 @@ void HistoryDock::seek_history(int p_index) {
 
 void HistoryDock::_notification(int p_notification) {
 	switch (p_notification) {
-		case NOTIFICATION_ENTER_TREE: {
+		case NOTIFICATION_READY: {
 			EditorNode::get_singleton()->connect("scene_changed", callable_mp(this, &HistoryDock::on_history_changed));
 		} break;
 


### PR DESCRIPTION
Fixes: #69069, possibly #68882

### **Changes:**
- Change enter tree notification to ready notification to ensure the `HistoryDock::on_history_changed` signal only attempts to connect once (as the enter tree notification is fired whenever the dock is moved in the editor layout, see discussion).
- Add the history dock to the default editor layout; using Editor -> Editor Layout -> Default will no longer make the history dock disappear.