### PR TITLE
Print warning when custom class icon size exceeds 32x32, update docs mentioning recommended size

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4144,6 +4144,9 @@ Ref<ImageTexture> EditorNode::_load_custom_class_icon(const String &p_path) cons
 		Ref<Image> img = memnew(Image);
 		Error err = ImageLoader::load_image(p_path, img);
 		if (err == OK) {
+			if (img->get_size() > Size2(32, 32)) {
+				WARN_PRINT_ONCE("The class icon '" + p_path + "' is larger than the recommended size of 32x32. This can cause performance issues.");
+			}
 			img->resize(16 * EDSCALE, 16 * EDSCALE, Image::INTERPOLATE_LANCZOS);
 			return ImageTexture::create_from_image(img);
 		}

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -551,7 +551,7 @@
 				[codeblock]
 				@icon("res://path/to/class/icon.svg")
 				[/codeblock]
-				[b]Note:[/b] Only the script can have a custom icon. Inner classes are not supported.
+				[b]Note:[/b] Only the script can have a custom icon. Inner classes are not supported. The recommended icon size is 32x32, as this resolution looks good on hiDPI displays (but higher resolutions can cause performance issues).
 			</description>
 		</annotation>
 		<annotation name="@onready">


### PR DESCRIPTION
Implements https://github.com/godotengine/godot/issues/68962#issuecomment-1322459485.

Prints a warning when a custom class icon is greater than the recommended size of 32x32. Also updates the docs to mention that 32x32 is the recommended size as it looks good on hiDPI displays.

**Ex.**
![warning](https://user-images.githubusercontent.com/89402588/203647623-e262991b-17e4-44c5-80a4-8fe9c97416ce.png)