### PR TITLE
Remove debug macro for GDScriptLanguage script_list assignment

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1351,13 +1351,11 @@ void GDScript::_get_dependencies(RBSet<GDScript *> &p_dependencies, const GDScri
 
 GDScript::GDScript() :
 		script_list(this) {
-#ifdef DEBUG_ENABLED
 	{
 		MutexLock lock(GDScriptLanguage::get_singleton()->mutex);
 
 		GDScriptLanguage::get_singleton()->script_list.add(&script_list);
 	}
-#endif
 }
 
 void GDScript::_save_orphaned_subclasses() {
@@ -1491,13 +1489,11 @@ GDScript::~GDScript() {
 		}
 	}
 
-#ifdef DEBUG_ENABLED
 	{
 		MutexLock lock(GDScriptLanguage::get_singleton()->mutex);
 
 		GDScriptLanguage::get_singleton()->script_list.remove(&script_list);
 	}
-#endif
 
 	if (GDScriptCache::singleton) { // Cache may have been already destroyed at engine shutdown.
 		GDScriptCache::remove_script(get_path());


### PR DESCRIPTION
I realized that the memory safety net of [modules/gdscript/gdscript.cpp:2537](https://github.com/godotengine/godot/blob/fa270c2456df5ad12f51584c4ff891e2cf728cec/modules/gdscript/gdscript.cpp#L2537) could not work in release mode, as the assignment of `script_list` was done if `DEBUG_ENABLED`.

To be sure that no script is leaking, it is necessary to populate `GDScriptLanguage::script_list` with every script.