### PR TITLE
Allow easily renaming multiple nodes

### DIFF
--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -89,7 +89,6 @@ class SceneTreeEditor : public Control {
 	void _notification(int p_what);
 	void _selected_changed();
 	void _deselect_items();
-	void _rename_node(Node *p_node, const String &p_name);
 
 	void _cell_collapsed(Object *p_obj);
 
@@ -101,7 +100,8 @@ class SceneTreeEditor : public Control {
 	bool show_enabled_subscene = false;
 	bool is_scene_tree_dock = false;
 
-	void _renamed();
+	void _edited();
+	void _renamed(TreeItem *p_item, TreeItem *p_batch_item, Node *p_node = nullptr);
 
 	HashSet<Node *> marked;
 	bool marked_selectable = false;
@@ -146,6 +146,8 @@ class SceneTreeEditor : public Control {
 public:
 	// Public for use with callable_mp.
 	void _update_tree(bool p_scroll_to_selected = false);
+
+	void rename_node(Node *p_node, const String &p_name, TreeItem *p_item = nullptr);
 
 	void set_filter(const String &p_filter);
 	String get_filter() const;

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -599,8 +599,7 @@ void RenameDialog::rename() {
 				ERR_PRINT("Skipping missing node: " + to_rename[i].first.get_concatenated_subnames());
 				continue;
 			}
-
-			scene_tree_editor->call("_rename_node", n, new_name);
+			scene_tree_editor->rename_node(n, new_name);
 		}
 
 		undo_redo->commit_action();

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3370,12 +3370,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	}
 
 	if (profile_allow_editing) {
-		bool add_separator = false;
-
-		if (full_selection.size() == 1) {
-			add_separator = true;
-			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Rename")), ED_GET_SHORTCUT("scene_tree/rename"), TOOL_RENAME);
-		}
+		menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Rename")), ED_GET_SHORTCUT("scene_tree/rename"), TOOL_RENAME);
 
 		bool can_replace = true;
 		for (Node *E : selection) {
@@ -3386,14 +3381,11 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 		}
 
 		if (can_replace) {
-			add_separator = true;
 			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Reload")), ED_GET_SHORTCUT("scene_tree/change_node_type"), TOOL_REPLACE);
 		}
 
 		if (scene_tree->get_selected() != edited_scene) {
-			if (add_separator) {
-				menu->add_separator();
-			}
+			menu->add_separator();
 			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("MoveUp")), ED_GET_SHORTCUT("scene_tree/move_up"), TOOL_MOVE_UP);
 			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("MoveDown")), ED_GET_SHORTCUT("scene_tree/move_down"), TOOL_MOVE_DOWN);
 			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Duplicate")), ED_GET_SHORTCUT("scene_tree/duplicate"), TOOL_DUPLICATE);


### PR DESCRIPTION
I wanted this for a long time. The batch rename dialog is an overkill for such basic operation 😒
![](https://chat.godotengine.org/file-upload/ZRSjKwSLmfvKjTYMe/godot.windows.editor.dev.x86_64_TCKSVKFQJ5.gif)
Putting as draft, because undo is broken.