### PR TITLE
C#: Add `global::` namespace to generated source

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
@@ -14,7 +14,7 @@ namespace Godot.SourceGenerators
         {
             string message =
                 "Missing partial modifier on declaration of type '" +
-                $"{symbol.FullQualifiedName()}' which is a subclass of '{GodotClasses.Object}'";
+                $"{symbol.FullQualifiedNameOmitGlobal()}' which is a subclass of '{GodotClasses.Object}'";
 
             string description = $"{message}. Subclasses of '{GodotClasses.Object}' " +
                                  "must be declared with the partial modifier.";
@@ -41,7 +41,7 @@ namespace Godot.SourceGenerators
                 .GetDeclaredSymbol(outerTypeDeclSyntax);
 
             string fullQualifiedName = outerSymbol is INamedTypeSymbol namedTypeSymbol ?
-                namedTypeSymbol.FullQualifiedName() :
+                namedTypeSymbol.FullQualifiedNameOmitGlobal() :
                 "type not found";
 
             string message =

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -149,13 +149,6 @@ namespace Godot.SourceGenerators
             };
         }
 
-        private static SymbolDisplayFormat FullyQualifiedFormatOmitGlobal { get; } =
-            SymbolDisplayFormat.FullyQualifiedFormat
-                .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted);
-
-        public static string FullQualifiedName(this ITypeSymbol symbol)
-            => symbol.ToDisplayString(NullableFlowState.NotNull, FullyQualifiedFormatOmitGlobal);
-
         public static string NameWithTypeParameters(this INamedTypeSymbol symbol)
         {
             return symbol.IsGenericType ?
@@ -163,25 +156,39 @@ namespace Godot.SourceGenerators
                 symbol.Name;
         }
 
-        public static string FullQualifiedName(this INamespaceSymbol namespaceSymbol)
+        private static SymbolDisplayFormat FullyQualifiedFormatOmitGlobal { get; } =
+            SymbolDisplayFormat.FullyQualifiedFormat
+                .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted);
+
+        private static SymbolDisplayFormat FullyQualifiedFormatIncludeGlobal { get; } =
+            SymbolDisplayFormat.FullyQualifiedFormat
+                .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Included);
+
+        public static string FullQualifiedNameOmitGlobal(this ITypeSymbol symbol)
+            => symbol.ToDisplayString(NullableFlowState.NotNull, FullyQualifiedFormatOmitGlobal);
+
+        public static string FullQualifiedNameOmitGlobal(this INamespaceSymbol namespaceSymbol)
             => namespaceSymbol.ToDisplayString(FullyQualifiedFormatOmitGlobal);
 
-        public static string FullQualifiedName(this ISymbol symbol)
-            => symbol.ToDisplayString(FullyQualifiedFormatOmitGlobal);
+        public static string FullQualifiedNameIncludeGlobal(this ITypeSymbol symbol)
+            => symbol.ToDisplayString(NullableFlowState.NotNull, FullyQualifiedFormatIncludeGlobal);
+
+        public static string FullQualifiedNameIncludeGlobal(this INamespaceSymbol namespaceSymbol)
+            => namespaceSymbol.ToDisplayString(FullyQualifiedFormatIncludeGlobal);
 
         public static string FullQualifiedSyntax(this SyntaxNode node, SemanticModel sm)
         {
             StringBuilder sb = new();
-            FullQualifiedSyntax_(node, sm, sb, true);
+            FullQualifiedSyntax(node, sm, sb, true);
             return sb.ToString();
         }
 
-        private static void FullQualifiedSyntax_(SyntaxNode node, SemanticModel sm, StringBuilder sb, bool isFirstNode)
+        private static void FullQualifiedSyntax(SyntaxNode node, SemanticModel sm, StringBuilder sb, bool isFirstNode)
         {
             if (node is NameSyntax ns && isFirstNode)
             {
                 SymbolInfo nameInfo = sm.GetSymbolInfo(ns);
-                sb.Append(nameInfo.Symbol?.FullQualifiedName() ?? ns.ToString());
+                sb.Append(nameInfo.Symbol?.ToDisplayString(FullyQualifiedFormatIncludeGlobal) ?? ns.ToString());
                 return;
             }
 
@@ -195,7 +202,7 @@ namespace Godot.SourceGenerators
 
                 if (child.IsNode)
                 {
-                    FullQualifiedSyntax_(child.AsNode()!, sm, sb, isFirstNode: innerIsFirstNode);
+                    FullQualifiedSyntax(child.AsNode()!, sm, sb, isFirstNode: innerIsFirstNode);
                     innerIsFirstNode = false;
                 }
                 else

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MarshalUtils.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MarshalUtils.cs
@@ -220,7 +220,7 @@ namespace Godot.SourceGenerators
                                         _ => null
                                     };
                                 case "Collections"
-                                    when type.ContainingNamespace?.FullQualifiedName() == "Godot.Collections":
+                                    when type.ContainingNamespace?.FullQualifiedNameOmitGlobal() == "Godot.Collections":
                                     return type switch
                                     {
                                         { Name: "Dictionary" } =>
@@ -367,7 +367,7 @@ namespace Godot.SourceGenerators
                 MarshalType.SignalInfo =>
                     source.Append(VariantUtils, ".ConvertToSignalInfo(", inputExpr, ")"),
                 MarshalType.Enum =>
-                    source.Append("(", typeSymbol.FullQualifiedName(),
+                    source.Append("(", typeSymbol.FullQualifiedNameIncludeGlobal(),
                         ")", VariantUtils, ".ConvertToInt32(", inputExpr, ")"),
                 MarshalType.ByteArray =>
                     source.Append(VariantUtils, ".ConvertAsPackedByteArrayToSystemArray(", inputExpr, ")"),
@@ -389,7 +389,7 @@ namespace Godot.SourceGenerators
                     source.Append(VariantUtils, ".ConvertAsPackedColorArrayToSystemArray(", inputExpr, ")"),
                 MarshalType.GodotObjectOrDerivedArray =>
                     source.Append(VariantUtils, ".ConvertToSystemArrayOfGodotObject<",
-                        ((IArrayTypeSymbol)typeSymbol).ElementType.FullQualifiedName(), ">(", inputExpr, ")"),
+                        ((IArrayTypeSymbol)typeSymbol).ElementType.FullQualifiedNameIncludeGlobal(), ">(", inputExpr, ")"),
                 MarshalType.SystemArrayOfStringName =>
                     source.Append(VariantUtils, ".ConvertToSystemArrayOfStringName(", inputExpr, ")"),
                 MarshalType.SystemArrayOfNodePath =>
@@ -399,7 +399,7 @@ namespace Godot.SourceGenerators
                 MarshalType.Variant =>
                     source.Append("global::Godot.Variant.CreateCopyingBorrowed(", inputExpr, ")"),
                 MarshalType.GodotObjectOrDerived =>
-                    source.Append("(", typeSymbol.FullQualifiedName(),
+                    source.Append("(", typeSymbol.FullQualifiedNameIncludeGlobal(),
                         ")", VariantUtils, ".ConvertToGodotObject(", inputExpr, ")"),
                 MarshalType.StringName =>
                     source.Append(VariantUtils, ".ConvertToStringNameObject(", inputExpr, ")"),
@@ -413,11 +413,11 @@ namespace Godot.SourceGenerators
                     source.Append(VariantUtils, ".ConvertToArrayObject(", inputExpr, ")"),
                 MarshalType.GodotGenericDictionary =>
                     source.Append(VariantUtils, ".ConvertToDictionaryObject<",
-                        ((INamedTypeSymbol)typeSymbol).TypeArguments[0].FullQualifiedName(), ", ",
-                        ((INamedTypeSymbol)typeSymbol).TypeArguments[1].FullQualifiedName(), ">(", inputExpr, ")"),
+                        ((INamedTypeSymbol)typeSymbol).TypeArguments[0].FullQualifiedNameIncludeGlobal(), ", ",
+                        ((INamedTypeSymbol)typeSymbol).TypeArguments[1].FullQualifiedNameIncludeGlobal(), ">(", inputExpr, ")"),
                 MarshalType.GodotGenericArray =>
                     source.Append(VariantUtils, ".ConvertToArrayObject<",
-                        ((INamedTypeSymbol)typeSymbol).TypeArguments[0].FullQualifiedName(), ">(", inputExpr, ")"),
+                        ((INamedTypeSymbol)typeSymbol).TypeArguments[0].FullQualifiedNameIncludeGlobal(), ">(", inputExpr, ")"),
                 _ => throw new ArgumentOutOfRangeException(nameof(marshalType), marshalType,
                     "Received unexpected marshal type")
             };
@@ -578,7 +578,7 @@ namespace Godot.SourceGenerators
                 MarshalType.Callable => source.Append(inputExpr, ".AsCallable()"),
                 MarshalType.SignalInfo => source.Append(inputExpr, ".AsSignalInfo()"),
                 MarshalType.Enum =>
-                    source.Append("(", typeSymbol.FullQualifiedName(), ")", inputExpr, ".AsInt64()"),
+                    source.Append("(", typeSymbol.FullQualifiedNameIncludeGlobal(), ")", inputExpr, ".AsInt64()"),
                 MarshalType.ByteArray => source.Append(inputExpr, ".AsByteArray()"),
                 MarshalType.Int32Array => source.Append(inputExpr, ".AsInt32Array()"),
                 MarshalType.Int64Array => source.Append(inputExpr, ".AsInt64Array()"),
@@ -589,23 +589,23 @@ namespace Godot.SourceGenerators
                 MarshalType.Vector3Array => source.Append(inputExpr, ".AsVector3Array()"),
                 MarshalType.ColorArray => source.Append(inputExpr, ".AsColorArray()"),
                 MarshalType.GodotObjectOrDerivedArray => source.Append(inputExpr, ".AsGodotObjectArray<",
-                    ((IArrayTypeSymbol)typeSymbol).ElementType.FullQualifiedName(), ">()"),
+                    ((IArrayTypeSymbol)typeSymbol).ElementType.FullQualifiedNameIncludeGlobal(), ">()"),
                 MarshalType.SystemArrayOfStringName => source.Append(inputExpr, ".AsSystemArrayOfStringName()"),
                 MarshalType.SystemArrayOfNodePath => source.Append(inputExpr, ".AsSystemArrayOfNodePath()"),
                 MarshalType.SystemArrayOfRID => source.Append(inputExpr, ".AsSystemArrayOfRID()"),
                 MarshalType.Variant => source.Append(inputExpr),
                 MarshalType.GodotObjectOrDerived => source.Append("(",
-                    typeSymbol.FullQualifiedName(), ")", inputExpr, ".AsGodotObject()"),
+                    typeSymbol.FullQualifiedNameIncludeGlobal(), ")", inputExpr, ".AsGodotObject()"),
                 MarshalType.StringName => source.Append(inputExpr, ".AsStringName()"),
                 MarshalType.NodePath => source.Append(inputExpr, ".AsNodePath()"),
                 MarshalType.RID => source.Append(inputExpr, ".AsRID()"),
                 MarshalType.GodotDictionary => source.Append(inputExpr, ".AsGodotDictionary()"),
                 MarshalType.GodotArray => source.Append(inputExpr, ".AsGodotArray()"),
                 MarshalType.GodotGenericDictionary => source.Append(inputExpr, ".AsGodotDictionary<",
-                    ((INamedTypeSymbol)typeSymbol).TypeArguments[0].FullQualifiedName(), ", ",
-                    ((INamedTypeSymbol)typeSymbol).TypeArguments[1].FullQualifiedName(), ">()"),
+                    ((INamedTypeSymbol)typeSymbol).TypeArguments[0].FullQualifiedNameIncludeGlobal(), ", ",
+                    ((INamedTypeSymbol)typeSymbol).TypeArguments[1].FullQualifiedNameIncludeGlobal(), ">()"),
                 MarshalType.GodotGenericArray => source.Append(inputExpr, ".AsGodotArray<",
-                    ((INamedTypeSymbol)typeSymbol).TypeArguments[0].FullQualifiedName(), ">()"),
+                    ((INamedTypeSymbol)typeSymbol).TypeArguments[0].FullQualifiedNameIncludeGlobal(), ">()"),
                 _ => throw new ArgumentOutOfRangeException(nameof(marshalType), marshalType,
                     "Received unexpected marshal type")
             };

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -80,13 +80,13 @@ namespace Godot.SourceGenerators
         {
             INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
             string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace ?
-                namespaceSymbol.FullQualifiedName() :
+                namespaceSymbol.FullQualifiedNameOmitGlobal() :
                 string.Empty;
             bool hasNamespace = classNs.Length != 0;
 
             bool isInnerClass = symbol.ContainingType != null;
 
-            string uniqueHint = symbol.FullQualifiedName().SanitizeQualifiedNameForUniqueHint()
+            string uniqueHint = symbol.FullQualifiedNameOmitGlobal().SanitizeQualifiedNameForUniqueHint()
                                 + "_ScriptMethods.generated";
 
             var source = new StringBuilder();
@@ -135,7 +135,7 @@ namespace Godot.SourceGenerators
 
             source.Append("#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword\n");
 
-            source.Append($"    public new class MethodName : {symbol.BaseType.FullQualifiedName()}.MethodName {{\n");
+            source.Append($"    public new class MethodName : {symbol.BaseType.FullQualifiedNameIncludeGlobal()}.MethodName {{\n");
 
             // Generate cached StringNames for methods and properties, for fast lookup
 
@@ -146,7 +146,7 @@ namespace Godot.SourceGenerators
 
             foreach (string methodName in distinctMethodNames)
             {
-                source.Append("        public new static readonly StringName ");
+                source.Append("        public new static readonly global::Godot.StringName ");
                 source.Append(methodName);
                 source.Append(" = \"");
                 source.Append(methodName);
@@ -159,7 +159,7 @@ namespace Godot.SourceGenerators
 
             if (godotClassMethods.Length > 0)
             {
-                const string listType = "System.Collections.Generic.List<global::Godot.Bridge.MethodInfo>";
+                const string listType = "global::System.Collections.Generic.List<global::Godot.Bridge.MethodInfo>";
 
                 source.Append("    internal new static ")
                     .Append(listType)
@@ -248,7 +248,7 @@ namespace Godot.SourceGenerators
 
             AppendPropertyInfo(source, methodInfo.ReturnVal);
 
-            source.Append(", flags: (Godot.MethodFlags)")
+            source.Append(", flags: (global::Godot.MethodFlags)")
                 .Append((int)methodInfo.Flags)
                 .Append(", arguments: ");
 
@@ -276,15 +276,15 @@ namespace Godot.SourceGenerators
 
         private static void AppendPropertyInfo(StringBuilder source, PropertyInfo propertyInfo)
         {
-            source.Append("new(type: (Godot.Variant.Type)")
+            source.Append("new(type: (global::Godot.Variant.Type)")
                 .Append((int)propertyInfo.Type)
                 .Append(", name: \"")
                 .Append(propertyInfo.Name)
-                .Append("\", hint: (Godot.PropertyHint)")
+                .Append("\", hint: (global::Godot.PropertyHint)")
                 .Append((int)propertyInfo.Hint)
                 .Append(", hintString: \"")
                 .Append(propertyInfo.HintString)
-                .Append("\", usage: (Godot.PropertyUsageFlags)")
+                .Append("\", usage: (global::Godot.PropertyUsageFlags)")
                 .Append((int)propertyInfo.Usage)
                 .Append(", exported: ")
                 .Append(propertyInfo.Exported ? "true" : "false")

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPathAttributeGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPathAttributeGenerator.cs
@@ -92,11 +92,11 @@ namespace Godot.SourceGenerators
 
             INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
             string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace ?
-                namespaceSymbol.FullQualifiedName() :
+                namespaceSymbol.FullQualifiedNameOmitGlobal() :
                 string.Empty;
             bool hasNamespace = classNs.Length != 0;
 
-            string uniqueHint = symbol.FullQualifiedName().SanitizeQualifiedNameForUniqueHint()
+            string uniqueHint = symbol.FullQualifiedNameOmitGlobal().SanitizeQualifiedNameForUniqueHint()
                              + "_ScriptPath.generated";
 
             var source = new StringBuilder();

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -66,13 +66,13 @@ namespace Godot.SourceGenerators
         {
             INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
             string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace ?
-                namespaceSymbol.FullQualifiedName() :
+                namespaceSymbol.FullQualifiedNameOmitGlobal() :
                 string.Empty;
             bool hasNamespace = classNs.Length != 0;
 
             bool isInnerClass = symbol.ContainingType != null;
 
-            string uniqueHint = symbol.FullQualifiedName().SanitizeQualifiedNameForUniqueHint()
+            string uniqueHint = symbol.FullQualifiedNameOmitGlobal().SanitizeQualifiedNameForUniqueHint()
                                 + "_ScriptProperties.generated";
 
             var source = new StringBuilder();
@@ -124,14 +124,14 @@ namespace Godot.SourceGenerators
 
             source.Append("#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword\n");
 
-            source.Append($"    public new class PropertyName : {symbol.BaseType.FullQualifiedName()}.PropertyName {{\n");
+            source.Append($"    public new class PropertyName : {symbol.BaseType.FullQualifiedNameIncludeGlobal()}.PropertyName {{\n");
 
             // Generate cached StringNames for methods and properties, for fast lookup
 
             foreach (var property in godotClassProperties)
             {
                 string propertyName = property.PropertySymbol.Name;
-                source.Append("        public new static readonly StringName ");
+                source.Append("        public new static readonly global::Godot.StringName ");
                 source.Append(propertyName);
                 source.Append(" = \"");
                 source.Append(propertyName);
@@ -141,7 +141,7 @@ namespace Godot.SourceGenerators
             foreach (var field in godotClassFields)
             {
                 string fieldName = field.FieldSymbol.Name;
-                source.Append("        public new static readonly StringName ");
+                source.Append("        public new static readonly global::Godot.StringName ");
                 source.Append(fieldName);
                 source.Append(" = \"");
                 source.Append(fieldName);
@@ -216,7 +216,7 @@ namespace Godot.SourceGenerators
 
                 // Generate GetGodotPropertyList
 
-                string dictionaryType = "System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo>";
+                string dictionaryType = "global::System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo>";
 
                 source.Append("    internal new static ")
                     .Append(dictionaryType)
@@ -340,15 +340,15 @@ namespace Godot.SourceGenerators
 
         private static void AppendPropertyInfo(StringBuilder source, PropertyInfo propertyInfo)
         {
-            source.Append("        properties.Add(new(type: (Godot.Variant.Type)")
+            source.Append("        properties.Add(new(type: (global::Godot.Variant.Type)")
                 .Append((int)propertyInfo.Type)
                 .Append(", name: PropertyName.")
                 .Append(propertyInfo.Name)
-                .Append(", hint: (Godot.PropertyHint)")
+                .Append(", hint: (global::Godot.PropertyHint)")
                 .Append((int)propertyInfo.Hint)
                 .Append(", hintString: \"")
                 .Append(propertyInfo.HintString)
-                .Append("\", usage: (Godot.PropertyUsageFlags)")
+                .Append("\", usage: (global::Godot.PropertyUsageFlags)")
                 .Append((int)propertyInfo.Usage)
                 .Append(", exported: ")
                 .Append(propertyInfo.Exported ? "true" : "false")

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
@@ -66,13 +66,13 @@ namespace Godot.SourceGenerators
         {
             INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
             string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace ?
-                namespaceSymbol.FullQualifiedName() :
+                namespaceSymbol.FullQualifiedNameOmitGlobal() :
                 string.Empty;
             bool hasNamespace = classNs.Length != 0;
 
             bool isInnerClass = symbol.ContainingType != null;
 
-            string uniqueHint = symbol.FullQualifiedName().SanitizeQualifiedNameForUniqueHint()
+            string uniqueHint = symbol.FullQualifiedNameOmitGlobal().SanitizeQualifiedNameForUniqueHint()
                                 + "_ScriptPropertyDefVal.generated";
 
             var source = new StringBuilder();
@@ -249,7 +249,7 @@ namespace Godot.SourceGenerators
                     string defaultValueLocalName = string.Concat("__", exportedMember.Name, "_default_value");
 
                     source.Append("        ");
-                    source.Append(exportedMember.TypeSymbol.FullQualifiedName());
+                    source.Append(exportedMember.TypeSymbol.FullQualifiedNameIncludeGlobal());
                     source.Append(" ");
                     source.Append(defaultValueLocalName);
                     source.Append(" = ");

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSerializationGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSerializationGenerator.cs
@@ -66,13 +66,13 @@ namespace Godot.SourceGenerators
         {
             INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
             string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace ?
-                namespaceSymbol.FullQualifiedName() :
+                namespaceSymbol.FullQualifiedNameOmitGlobal() :
                 string.Empty;
             bool hasNamespace = classNs.Length != 0;
 
             bool isInnerClass = symbol.ContainingType != null;
 
-            string uniqueHint = symbol.FullQualifiedName().SanitizeQualifiedNameForUniqueHint()
+            string uniqueHint = symbol.FullQualifiedNameOmitGlobal().SanitizeQualifiedNameForUniqueHint()
                                 + "_ScriptSerialization.generated";
 
             var source = new StringBuilder();
@@ -241,7 +241,7 @@ namespace Godot.SourceGenerators
             foreach (var signalDelegate in godotSignalDelegates)
             {
                 string signalName = signalDelegate.Name;
-                string signalDelegateQualifiedName = signalDelegate.DelegateSymbol.FullQualifiedName();
+                string signalDelegateQualifiedName = signalDelegate.DelegateSymbol.FullQualifiedNameIncludeGlobal();
 
                 source.Append("        if (info.TryGetSignalEventDelegate<")
                     .Append(signalDelegateQualifiedName)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -75,13 +75,13 @@ namespace Godot.SourceGenerators
         {
             INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
             string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace ?
-                namespaceSymbol.FullQualifiedName() :
+                namespaceSymbol.FullQualifiedNameOmitGlobal() :
                 string.Empty;
             bool hasNamespace = classNs.Length != 0;
 
             bool isInnerClass = symbol.ContainingType != null;
 
-            string uniqueHint = symbol.FullQualifiedName().SanitizeQualifiedNameForUniqueHint()
+            string uniqueHint = symbol.FullQualifiedNameOmitGlobal().SanitizeQualifiedNameForUniqueHint()
                                 + "_ScriptSignals.generated";
 
             var source = new StringBuilder();
@@ -176,14 +176,14 @@ namespace Godot.SourceGenerators
 
             source.Append("#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword\n");
 
-            source.Append($"    public new class SignalName : {symbol.BaseType.FullQualifiedName()}.SignalName {{\n");
+            source.Append($"    public new class SignalName : {symbol.BaseType.FullQualifiedNameIncludeGlobal()}.SignalName {{\n");
 
             // Generate cached StringNames for methods and properties, for fast lookup
 
             foreach (var signalDelegate in godotSignalDelegates)
             {
                 string signalName = signalDelegate.Name;
-                source.Append("        public new static readonly StringName ");
+                source.Append("        public new static readonly global::Godot.StringName ");
                 source.Append(signalName);
                 source.Append(" = \"");
                 source.Append(signalName);
@@ -196,7 +196,7 @@ namespace Godot.SourceGenerators
 
             if (godotSignalDelegates.Count > 0)
             {
-                const string listType = "System.Collections.Generic.List<global::Godot.Bridge.MethodInfo>";
+                const string listType = "global::System.Collections.Generic.List<global::Godot.Bridge.MethodInfo>";
 
                 source.Append("    internal new static ")
                     .Append(listType)
@@ -231,15 +231,15 @@ namespace Godot.SourceGenerators
                 // as it doesn't emit the signal, only the event delegates. This can confuse users.
                 // Maybe we should directly connect the delegates, as we do with native signals?
                 source.Append("    private ")
-                    .Append(signalDelegate.DelegateSymbol.FullQualifiedName())
+                    .Append(signalDelegate.DelegateSymbol.FullQualifiedNameIncludeGlobal())
                     .Append(" backing_")
                     .Append(signalName)
                     .Append(";\n");
 
-                source.Append($"    /// <inheritdoc cref=\"{signalDelegate.DelegateSymbol.FullQualifiedName()}\"/>\n");
+                source.Append($"    /// <inheritdoc cref=\"{signalDelegate.DelegateSymbol.FullQualifiedNameIncludeGlobal()}\"/>\n");
 
                 source.Append("    public event ")
-                    .Append(signalDelegate.DelegateSymbol.FullQualifiedName())
+                    .Append(signalDelegate.DelegateSymbol.FullQualifiedNameIncludeGlobal())
                     .Append(" ")
                     .Append(signalName)
                     .Append(" {\n")
@@ -300,7 +300,7 @@ namespace Godot.SourceGenerators
 
             AppendPropertyInfo(source, methodInfo.ReturnVal);
 
-            source.Append(", flags: (Godot.MethodFlags)")
+            source.Append(", flags: (global::Godot.MethodFlags)")
                 .Append((int)methodInfo.Flags)
                 .Append(", arguments: ");
 
@@ -328,15 +328,15 @@ namespace Godot.SourceGenerators
 
         private static void AppendPropertyInfo(StringBuilder source, PropertyInfo propertyInfo)
         {
-            source.Append("new(type: (Godot.Variant.Type)")
+            source.Append("new(type: (global::Godot.Variant.Type)")
                 .Append((int)propertyInfo.Type)
                 .Append(", name: \"")
                 .Append(propertyInfo.Name)
-                .Append("\", hint: (Godot.PropertyHint)")
+                .Append("\", hint: (global::Godot.PropertyHint)")
                 .Append((int)propertyInfo.Hint)
                 .Append(", hintString: \"")
                 .Append(propertyInfo.HintString)
-                .Append("\", usage: (Godot.PropertyUsageFlags)")
+                .Append("\", usage: (global::Godot.PropertyUsageFlags)")
                 .Append((int)propertyInfo.Usage)
                 .Append(", exported: ")
                 .Append(propertyInfo.Exported ? "true" : "false")

--- a/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/Common.cs
+++ b/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/Common.cs
@@ -12,7 +12,7 @@ internal static class Common
     {
         string message =
             "Missing partial modifier on declaration of type '" +
-            $"{symbol.FullQualifiedName()}' which has attribute '{GeneratorClasses.GenerateUnmanagedCallbacksAttr}'";
+            $"{symbol.FullQualifiedNameOmitGlobal()}' which has attribute '{GeneratorClasses.GenerateUnmanagedCallbacksAttr}'";
 
         string description = $"{message}. Classes with attribute '{GeneratorClasses.GenerateUnmanagedCallbacksAttr}' " +
                              "must be declared with the partial modifier.";
@@ -39,7 +39,7 @@ internal static class Common
             .GetDeclaredSymbol(outerTypeDeclSyntax);
 
         string fullQualifiedName = outerSymbol is INamedTypeSymbol namedTypeSymbol ?
-            namedTypeSymbol.FullQualifiedName() :
+            namedTypeSymbol.FullQualifiedNameOmitGlobal() :
             "type not found";
 
         string message =

--- a/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/ExtensionMethods.cs
+++ b/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/ExtensionMethods.cs
@@ -94,13 +94,6 @@ internal static class ExtensionMethods
         };
     }
 
-    private static SymbolDisplayFormat FullyQualifiedFormatOmitGlobal { get; } =
-        SymbolDisplayFormat.FullyQualifiedFormat
-            .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted);
-
-    public static string FullQualifiedName(this ITypeSymbol symbol)
-        => symbol.ToDisplayString(NullableFlowState.NotNull, FullyQualifiedFormatOmitGlobal);
-
     public static string NameWithTypeParameters(this INamedTypeSymbol symbol)
     {
         return symbol.IsGenericType ?
@@ -108,8 +101,25 @@ internal static class ExtensionMethods
             symbol.Name;
     }
 
-    public static string FullQualifiedName(this INamespaceSymbol symbol)
-        => symbol.ToDisplayString(FullyQualifiedFormatOmitGlobal);
+    private static SymbolDisplayFormat FullyQualifiedFormatOmitGlobal { get; } =
+        SymbolDisplayFormat.FullyQualifiedFormat
+            .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted);
+
+    private static SymbolDisplayFormat FullyQualifiedFormatIncludeGlobal { get; } =
+        SymbolDisplayFormat.FullyQualifiedFormat
+            .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Included);
+
+    public static string FullQualifiedNameOmitGlobal(this ITypeSymbol symbol)
+        => symbol.ToDisplayString(NullableFlowState.NotNull, FullyQualifiedFormatOmitGlobal);
+
+    public static string FullQualifiedNameOmitGlobal(this INamespaceSymbol namespaceSymbol)
+        => namespaceSymbol.ToDisplayString(FullyQualifiedFormatOmitGlobal);
+
+    public static string FullQualifiedNameIncludeGlobal(this ITypeSymbol symbol)
+        => symbol.ToDisplayString(NullableFlowState.NotNull, FullyQualifiedFormatIncludeGlobal);
+
+    public static string FullQualifiedNameIncludeGlobal(this INamespaceSymbol namespaceSymbol)
+        => namespaceSymbol.ToDisplayString(FullyQualifiedFormatIncludeGlobal);
 
     public static string SanitizeQualifiedNameForUniqueHint(this string qualifiedName)
         => qualifiedName

--- a/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/UnmanagedCallbacksGenerator.cs
+++ b/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/UnmanagedCallbacksGenerator.cs
@@ -96,7 +96,7 @@ internal class GenerateUnmanagedCallbacksAttribute : Attribute
 
         INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
         string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace ?
-            namespaceSymbol.FullQualifiedName() :
+            namespaceSymbol.FullQualifiedNameOmitGlobal() :
             string.Empty;
         bool hasNamespace = classNs.Length != 0;
         bool isInnerClass = symbol.ContainingType != null;
@@ -144,7 +144,7 @@ using Godot.NativeInterop;
         source.Append("[System.Runtime.CompilerServices.SkipLocalsInit]\n");
         source.Append($"unsafe partial class {symbol.Name}\n");
         source.Append("{\n");
-        source.Append($"    private static {data.FuncStructSymbol.FullQualifiedName()} _unmanagedCallbacks;\n\n");
+        source.Append($"    private static {data.FuncStructSymbol.FullQualifiedNameIncludeGlobal()} _unmanagedCallbacks;\n\n");
 
         foreach (var callback in data.Methods)
         {
@@ -159,7 +159,7 @@ using Godot.NativeInterop;
                 source.Append("static ");
 
             source.Append("partial ");
-            source.Append(callback.ReturnType.FullQualifiedName());
+            source.Append(callback.ReturnType.FullQualifiedNameIncludeGlobal());
             source.Append(' ');
             source.Append(callback.Name);
             source.Append('(');
@@ -228,7 +228,7 @@ using Godot.NativeInterop;
             if (!callback.ReturnsVoid)
             {
                 if (methodSourceAfterCall.Length != 0)
-                    source.Append($"{callback.ReturnType.FullQualifiedName()} ret = ");
+                    source.Append($"{callback.ReturnType.FullQualifiedNameIncludeGlobal()} ret = ");
                 else
                     source.Append("return ");
             }
@@ -267,7 +267,7 @@ using Godot.NativeInterop;
 
         source.Append("\n\n#pragma warning restore CA1707\n");
 
-        context.AddSource($"{data.NativeTypeSymbol.FullQualifiedName().SanitizeQualifiedNameForUniqueHint()}.generated",
+        context.AddSource($"{data.NativeTypeSymbol.FullQualifiedNameOmitGlobal().SanitizeQualifiedNameForUniqueHint()}.generated",
             SourceText.From(source.ToString(), Encoding.UTF8));
     }
 
@@ -277,7 +277,7 @@ using Godot.NativeInterop;
 
         INamespaceSymbol namespaceSymbol = symbol.ContainingNamespace;
         string classNs = namespaceSymbol != null && !namespaceSymbol.IsGlobalNamespace ?
-            namespaceSymbol.FullQualifiedName() :
+            namespaceSymbol.FullQualifiedNameOmitGlobal() :
             string.Empty;
         bool hasNamespace = classNs.Length != 0;
         bool isInnerClass = symbol.ContainingType != null;
@@ -338,18 +338,18 @@ using Godot.NativeInterop;
                         // just pass it by-ref and let it be pinned.
                         AppendRefKind(source, parameter.RefKind)
                             .Append(' ')
-                            .Append(parameter.Type.FullQualifiedName());
+                            .Append(parameter.Type.FullQualifiedNameIncludeGlobal());
                     }
                 }
                 else
                 {
-                    source.Append(parameter.Type.FullQualifiedName());
+                    source.Append(parameter.Type.FullQualifiedNameIncludeGlobal());
                 }
 
                 source.Append(", ");
             }
 
-            source.Append(callback.ReturnType.FullQualifiedName());
+            source.Append(callback.ReturnType.FullQualifiedNameIncludeGlobal());
             source.Append($"> {callback.Name};\n");
         }
 
@@ -372,12 +372,12 @@ using Godot.NativeInterop;
 
         source.Append("\n#pragma warning restore CA1707\n");
 
-        context.AddSource($"{symbol.FullQualifiedName().SanitizeQualifiedNameForUniqueHint()}.generated",
+        context.AddSource($"{symbol.FullQualifiedNameOmitGlobal().SanitizeQualifiedNameForUniqueHint()}.generated",
             SourceText.From(source.ToString(), Encoding.UTF8));
     }
 
     private static bool IsGodotInteropStruct(ITypeSymbol type) =>
-        GodotInteropStructs.Contains(type.FullQualifiedName());
+        GodotInteropStructs.Contains(type.FullQualifiedNameOmitGlobal());
 
     private static bool IsByRefParameter(IParameterSymbol parameter) =>
         parameter.RefKind is RefKind.In or RefKind.Out or RefKind.Ref;
@@ -393,7 +393,7 @@ using Godot.NativeInterop;
 
     private static void AppendPointerType(StringBuilder source, ITypeSymbol type)
     {
-        source.Append(type.FullQualifiedName());
+        source.Append(type.FullQualifiedNameIncludeGlobal());
         source.Append('*');
     }
 
@@ -426,7 +426,7 @@ using Godot.NativeInterop;
     {
         varName = $"{parameter.Name}_copy";
 
-        source.Append(parameter.Type.FullQualifiedName());
+        source.Append(parameter.Type.FullQualifiedNameIncludeGlobal());
         source.Append(' ');
         source.Append(varName);
         if (parameter.RefKind is RefKind.In or RefKind.Ref)


### PR DESCRIPTION
Adds `global::` to the fully qualified types in source generators to prevent ambiguity.

- Fixes https://github.com/godotengine/godot/issues/69038