### PR TITLE
Fix VRS object being created even when not supported

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1419,10 +1419,13 @@ void RendererSceneRenderRD::init() {
 	cull_argument.set_page_pool(&cull_argument_pool);
 
 	bool can_use_storage = _render_buffers_can_be_storage();
+	bool can_use_vrs = is_vrs_supported();
 	bokeh_dof = memnew(RendererRD::BokehDOF(!can_use_storage));
 	copy_effects = memnew(RendererRD::CopyEffects(!can_use_storage));
 	tone_mapper = memnew(RendererRD::ToneMapper);
-	vrs = memnew(RendererRD::VRS);
+	if (can_use_vrs) {
+		vrs = memnew(RendererRD::VRS);
+	}
 	if (can_use_storage) {
 		fsr = memnew(RendererRD::FSR);
 	}


### PR DESCRIPTION
Fix for when a project has OpenXR enabled and no HMD is detected, the texel size will return zero and cause a division by zero crash.