### PR TITLE
To avoid gdscript crash, match the defines checks to "debug/gdscript/…

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -494,6 +494,7 @@ void ScriptTextEditor::_update_warnings() {
 
 	bool has_connections_table = false;
 	// Add missing connections.
+#ifdef DEBUG_ENABLED
 	if (GLOBAL_GET("debug/gdscript/warnings/enable").booleanize()) {
 		Node *base = get_tree()->get_edited_scene_root();
 		if (base && missing_connections.size() > 0) {
@@ -515,6 +516,7 @@ void ScriptTextEditor::_update_warnings() {
 			warning_nb += missing_connections.size();
 		}
 	}
+#endif
 
 	code_editor->set_warning_count(warning_nb);
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -148,7 +148,9 @@ GDScriptParser::GDScriptParser() {
 	// Networking.
 	register_annotation(MethodInfo("@rpc", PropertyInfo(Variant::STRING, "mode"), PropertyInfo(Variant::STRING, "sync"), PropertyInfo(Variant::STRING, "transfer_mode"), PropertyInfo(Variant::INT, "transfer_channel")), AnnotationInfo::FUNCTION, &GDScriptParser::rpc_annotation, varray("", "", "", 0), true);
 
+#ifdef DEBUG_ENABLED
 	is_ignoring_warnings = !(bool)GLOBAL_GET("debug/gdscript/warnings/enable");
+#endif
 }
 
 GDScriptParser::~GDScriptParser() {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/69094