### PR TITLE
Bring back `Engine.editor_hint` as a read-only property

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1996,6 +1996,7 @@ void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_print_error_messages", "enabled"), &Engine::set_print_error_messages);
 	ClassDB::bind_method(D_METHOD("is_printing_error_messages"), &Engine::is_printing_error_messages);
 
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editor_hint"), "", "is_editor_hint");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "print_error_messages"), "set_print_error_messages", "is_printing_error_messages");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "print_to_stdout"), "set_print_to_stdout", "is_printing_to_stdout");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "physics_ticks_per_second"), "set_physics_ticks_per_second", "get_physics_ticks_per_second");

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -218,28 +218,6 @@
 				[b]Note:[/b] Global singletons are not the same as autoloaded nodes, which are configurable in the project settings.
 			</description>
 		</method>
-		<method name="is_editor_hint" qualifiers="const">
-			<return type="bool" />
-			<description>
-				Returns [code]true[/code] if the script is currently running inside the editor, otherwise returns [code]false[/code]. This is useful for [code]@tool[/code] scripts to conditionally draw editor helpers, or prevent accidentally running "game" code that would affect the scene state while in the editor:
-				[codeblocks]
-				[gdscript]
-				if Engine.is_editor_hint():
-				    draw_gizmos()
-				else:
-				    simulate_physics()
-				[/gdscript]
-				[csharp]
-				if (Engine.IsEditorHint())
-				    DrawGizmos();
-				else
-				    SimulatePhysics();
-				[/csharp]
-				[/codeblocks]
-				See [url=$DOCS_URL/tutorials/plugins/running_code_in_the_editor.html]Running code in the editor[/url] in the documentation for more information.
-				[b]Note:[/b] To detect whether the script is running on an editor [i]build[/i] (such as when pressing [kbd]F5[/kbd]), use [method OS.has_feature] with the [code]"editor"[/code] argument instead. [code]OS.has_feature("editor")[/code] evaluate to [code]true[/code] both when the script is running in the editor and when running the project from the editor, but returns [code]false[/code] when run from an exported project.
-			</description>
-		</method>
 		<method name="is_embedded_in_editor" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -302,6 +280,25 @@
 		</method>
 	</methods>
 	<members>
+		<member name="editor_hint" type="bool" setter="" getter="is_editor_hint" default="true">
+			If [code]true[/code], the script is currently running inside the editor, otherwise it is [code]false[/code]. This property cannot be modified, and is useful for [annotation @GDScript.@tool] scripts to conditionally draw editor helpers, or prevent accidentally running "game" code that would affect the scene state while in the editor:
+			[codeblocks]
+			[gdscript]
+			if Engine.editor_hint:
+			    draw_gizmos()
+			else:
+			    simulate_physics()
+			[/gdscript]
+			[csharp]
+			if (Engine.editorHint)
+			    DrawGizmos();
+			else
+			    SimulatePhysics();
+			[/csharp]
+			[/codeblocks]
+			See [url=$DOCS_URL/tutorials/plugins/running_code_in_the_editor.html]Running code in the editor[/url] in the documentation for more information.
+			[b]Note:[/b] To detect whether the script is run from an editor [i]build[/i] (such as when pressing [kbd]F5[/kbd]), use [method OS.has_feature] with the [code]"editor"[/code] argument instead. [code]OS.has_feature("editor")[/code] returns [code]true[/code] both when the code is running in the editor and when running the project from the editor, but returns [code]false[/code] when the code is run from an exported project.
+		</member>
 		<member name="max_fps" type="int" setter="set_max_fps" getter="get_max_fps" default="0">
 			The maximum number of frames that can be rendered every second (FPS). A value of [code]0[/code] means the framerate is uncapped.
 			Limiting the FPS can be useful to reduce the host machine's power consumption, which reduces heat, noise emissions, and improves battery life.


### PR DESCRIPTION
When I was reading around code, I noticed something interesting. The **SceneTree**'s `root` is a property that can be accessed, but it cannot be set, at all. It features no setter.
![image](https://user-images.githubusercontent.com/66727710/203750106-8bd1d8cd-842b-4f1f-87f8-c43017132362.png)

This made me think, that perhaps `editor_hint` disappearance during the transition between 3.x and 4.0 didn't have to be necessary. I mean, I totally understand why, but the concept of read-only properties is not exactly new. Granted, `root` may be an exception to the rule but... I don't know, personally? I like not having to see the "_is_" for this particularly special property.

This PR brings back **Engine**'s `editor_hint` as a read-only property. It also updates the description slightly to make it clear that it cannot be modified.
Do note that users that already are using `Engine.is_editor_hint()` would be entirely unaffected by this, but people that are going to port their projects to 4.0 would appreciate this.