### PR TITLE
Fix Array & Dictionary copy constructor

### DIFF
--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -197,10 +197,10 @@ void Variant::_register_variant_constructors() {
 	add_constructor<VariantConstructorSignalArgs>(sarray("object", "signal"));
 
 	add_constructor<VariantConstructNoArgs<Dictionary>>(sarray());
-	add_constructor<VariantConstructor<Dictionary, Dictionary>>(sarray("from"));
+	add_constructor<VariantConstructorDictionaryDuplicate>(sarray("from"));
 
 	add_constructor<VariantConstructNoArgs<Array>>(sarray());
-	add_constructor<VariantConstructor<Array, Array>>(sarray("from"));
+	add_constructor<VariantConstructorArrayDuplicate>(sarray("from"));
 	add_constructor<VariantConstructorTypedArray>(sarray("base", "type", "class_name", "script"));
 	add_constructor<VariantConstructorToArray<PackedByteArray>>(sarray("from"));
 	add_constructor<VariantConstructorToArray<PackedInt32Array>>(sarray("from"));

--- a/core/variant/variant_construct.h
+++ b/core/variant/variant_construct.h
@@ -394,6 +394,84 @@ public:
 	}
 };
 
+class VariantConstructorDictionaryDuplicate {
+public:
+	static void construct(Variant &r_ret, const Variant **p_args, Callable::CallError &r_error) {
+		if (p_args[0]->get_type() != Variant::ARRAY) {
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+			r_error.argument = 0;
+			r_error.expected = Variant::DICTIONARY;
+			return;
+		}
+
+		const Dictionary &src_dict = *VariantGetInternalPtr<Dictionary>::get_ptr(p_args[0]);
+		r_ret = src_dict.duplicate();
+	}
+
+	static inline void validated_construct(Variant *r_ret, const Variant **p_args) {
+		const Dictionary &src_dict = *VariantGetInternalPtr<Dictionary>::get_ptr(p_args[0]);
+		*r_ret = src_dict.duplicate();
+	}
+
+	static void ptr_construct(void *base, const void **p_args) {
+		const Dictionary &src_dict = PtrToArg<Dictionary>::convert(p_args[0]);
+		Dictionary dst_dict = src_dict.duplicate();
+
+		PtrConstruct<Dictionary>::construct(dst_dict, base);
+	}
+
+	static int get_argument_count() {
+		return 1;
+	}
+
+	static Variant::Type get_argument_type(int p_arg) {
+		return Variant::DICTIONARY;
+	}
+
+	static Variant::Type get_base_type() {
+		return Variant::DICTIONARY;
+	}
+};
+
+class VariantConstructorArrayDuplicate {
+public:
+	static void construct(Variant &r_ret, const Variant **p_args, Callable::CallError &r_error) {
+		if (p_args[0]->get_type() != Variant::ARRAY) {
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+			r_error.argument = 0;
+			r_error.expected = Variant::ARRAY;
+			return;
+		}
+
+		const Array &src_arr = *VariantGetInternalPtr<Array>::get_ptr(p_args[0]);
+		r_ret = src_arr.duplicate();
+	}
+
+	static inline void validated_construct(Variant *r_ret, const Variant **p_args) {
+		const Array &src_arr = *VariantGetInternalPtr<Array>::get_ptr(p_args[0]);
+		*r_ret = src_arr.duplicate();
+	}
+
+	static void ptr_construct(void *base, const void **p_args) {
+		const Array &src_arr = PtrToArg<Array>::convert(p_args[0]);
+		Array dst_arr = src_arr.duplicate();
+
+		PtrConstruct<Array>::construct(dst_arr, base);
+	}
+
+	static int get_argument_count() {
+		return 1;
+	}
+
+	static Variant::Type get_argument_type(int p_arg) {
+		return Variant::ARRAY;
+	}
+
+	static Variant::Type get_base_type() {
+		return Variant::ARRAY;
+	}
+};
+
 class VariantConstructorTypedArray {
 public:
 	static void construct(Variant &r_ret, const Variant **p_args, Callable::CallError &r_error) {

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -66,7 +66,7 @@
 			<return type="Array" />
 			<param index="0" name="from" type="Array" />
 			<description>
-				Returns the same array as [param from]. If you need a copy of the array, use [method duplicate].
+				Constructs an [Array] as a [i]shallow[/i] copy of the given [Array], similarly to [method duplicate].
 			</description>
 		</constructor>
 		<constructor name="Array">

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -153,7 +153,7 @@
 			<return type="Dictionary" />
 			<param index="0" name="from" type="Dictionary" />
 			<description>
-				Returns the same dictionary as [param from]. If you need a copy of the dictionary, use [method duplicate].
+				Constructs a [Dictionary] as a [i]shallow[/i] copy of the given [Dictionary], similarly to [method duplicate].
 			</description>
 		</constructor>
 	</constructors>


### PR DESCRIPTION
The description states:
> Constructs an Array as a copy of the given Array.

Case and point:
![image](https://user-images.githubusercontent.com/66727710/203819476-18f71c0d-3469-4a55-bf9e-752d6b1c1c0d.png)

And if you do want a copy, `Array.duplicate` exists already and it is more explicit.

###### ~This PR removes the constructor~

This PR fixes the Array and Dictionary constructor, that was probably meant for consistency with the Packed Arrays (whose constructor equivalent works completely fine).