### PR TITLE
Rename references to audio device, capture_device to output_device, input_device respectively

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -29,13 +29,6 @@
 				Adds an [AudioEffect] effect to the bus [param bus_idx] at [param at_position].
 			</description>
 		</method>
-		<method name="capture_get_device_list">
-			<return type="PackedStringArray" />
-			<description>
-				Returns the names of all audio input devices detected on the system.
-				[b]Note:[/b] [member ProjectSettings.audio/driver/enable_input] must be [code]true[/code] for audio input to work. See also that setting's description for caveats related to permissions and operating system privacy settings.
-			</description>
-		</method>
 		<method name="generate_bus_layout" qualifiers="const">
 			<return type="AudioBusLayout" />
 			<description>
@@ -117,16 +110,23 @@
 				Returns the volume of the bus at index [param bus_idx] in dB.
 			</description>
 		</method>
-		<method name="get_device_list">
+		<method name="get_input_device_list">
 			<return type="PackedStringArray" />
 			<description>
-				Returns the names of all audio devices detected on the system.
+				Returns the names of all audio input devices detected on the system.
+				[b]Note:[/b] [member ProjectSettings.audio/driver/enable_input] must be [code]true[/code] for audio input to work. See also that setting's description for caveats related to permissions and operating system privacy settings.
 			</description>
 		</method>
 		<method name="get_mix_rate" qualifiers="const">
 			<return type="float" />
 			<description>
 				Returns the sample rate at the output of the [AudioServer].
+			</description>
+		</method>
+		<method name="get_output_device_list">
+			<return type="PackedStringArray" />
+			<description>
+				Returns the names of all audio output devices detected on the system.
 			</description>
 		</method>
 		<method name="get_output_latency" qualifiers="const">
@@ -302,12 +302,12 @@
 		<member name="bus_count" type="int" setter="set_bus_count" getter="get_bus_count" default="1">
 			Number of available audio buses.
 		</member>
-		<member name="capture_device" type="String" setter="capture_set_device" getter="capture_get_device" default="&quot;Default&quot;">
-			Name of the current device for audio input (see [method capture_get_device_list]). On systems with multiple audio inputs (such as analog, USB and HDMI audio), this can be used to select the audio input device. The value [code]"Default"[/code] will record audio on the system-wide default audio input. If an invalid device name is set, the value will be reverted back to [code]"Default"[/code].
+		<member name="input_device" type="String" setter="set_input_device" getter="get_input_device" default="&quot;Default&quot;">
+			Name of the current device for audio input (see [method get_input_device_list]). On systems with multiple audio inputs (such as analog, USB and HDMI audio), this can be used to select the audio input device. The value [code]"Default"[/code] will record audio on the system-wide default audio input. If an invalid device name is set, the value will be reverted back to [code]"Default"[/code].
 			[b]Note:[/b] [member ProjectSettings.audio/driver/enable_input] must be [code]true[/code] for audio input to work. See also that setting's description for caveats related to permissions and operating system privacy settings.
 		</member>
-		<member name="device" type="String" setter="set_device" getter="get_device" default="&quot;Default&quot;">
-			Name of the current device for audio output (see [method get_device_list]). On systems with multiple audio outputs (such as analog, USB and HDMI audio), this can be used to select the audio output device. The value [code]"Default"[/code] will play audio on the system-wide default audio output. If an invalid device name is set, the value will be reverted back to [code]"Default"[/code].
+		<member name="output_device" type="String" setter="set_output_device" getter="get_output_device" default="&quot;Default&quot;">
+			Name of the current device for audio output (see [method get_output_device_list]). On systems with multiple audio outputs (such as analog, USB and HDMI audio), this can be used to select the audio output device. The value [code]"Default"[/code] will play audio on the system-wide default audio output. If an invalid device name is set, the value will be reverted back to [code]"Default"[/code].
 		</member>
 		<member name="playback_speed_scale" type="float" setter="set_playback_speed_scale" getter="get_playback_speed_scale" default="1.0">
 			Scales the rate at which audio is played (i.e. setting it to [code]0.5[/code] will make the audio be played at half its speed).

--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -47,8 +47,8 @@ class AudioDriverCoreAudio : public AudioDriver {
 	bool active = false;
 	Mutex mutex;
 
-	String device_name = "Default";
-	String capture_device_name = "Default";
+	String output_device_name = "Default";
+	String input_device_name = "Default";
 
 	int mix_rate = 0;
 	unsigned int channels = 2;
@@ -60,7 +60,7 @@ class AudioDriverCoreAudio : public AudioDriver {
 
 #ifdef MACOS_ENABLED
 	PackedStringArray _get_device_list(bool capture = false);
-	void _set_device(const String &device, bool capture = false);
+	void _set_device(const String &output_device, bool capture = false);
 
 	static OSStatus input_device_address_cb(AudioObjectID inObjectID,
 			UInt32 inNumberAddresses, const AudioObjectPropertyAddress *inAddresses,
@@ -107,13 +107,13 @@ public:
 	void stop();
 
 #ifdef MACOS_ENABLED
-	virtual PackedStringArray get_device_list();
-	virtual String get_device();
-	virtual void set_device(String device);
+	virtual PackedStringArray get_output_device_list();
+	virtual String get_output_device();
+	virtual void set_output_device(String output_device);
 
-	virtual PackedStringArray capture_get_device_list();
-	virtual void capture_set_device(const String &p_name);
-	virtual String capture_get_device();
+	virtual PackedStringArray get_input_device_list();
+	virtual void set_input_device(const String &p_name);
+	virtual String get_input_device();
 #endif
 
 	AudioDriverCoreAudio();

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -106,15 +106,15 @@ void AudioDriverPulseAudio::pa_server_info_cb(pa_context *c, const pa_server_inf
 	ERR_FAIL_COND_MSG(!i, "PulseAudio server info is null.");
 	AudioDriverPulseAudio *ad = static_cast<AudioDriverPulseAudio *>(userdata);
 
-	ad->capture_default_device = i->default_source_name;
-	ad->default_device = i->default_sink_name;
+	ad->default_input_device = i->default_source_name;
+	ad->default_output_device = i->default_sink_name;
 	ad->pa_status++;
 }
 
-Error AudioDriverPulseAudio::detect_channels(bool capture) {
-	pa_channel_map_init_stereo(capture ? &pa_rec_map : &pa_map);
+Error AudioDriverPulseAudio::detect_channels(bool input) {
+	pa_channel_map_init_stereo(input ? &pa_rec_map : &pa_map);
 
-	String device = capture ? capture_device_name : device_name;
+	String device = input ? input_device_name : output_device_name;
 	if (device == "Default") {
 		// Get the default output device name
 		pa_status = 0;
@@ -136,7 +136,7 @@ Error AudioDriverPulseAudio::detect_channels(bool capture) {
 
 	char dev[1024];
 	if (device == "Default") {
-		strcpy(dev, capture ? capture_default_device.utf8().get_data() : default_device.utf8().get_data());
+		strcpy(dev, input ? default_input_device.utf8().get_data() : default_output_device.utf8().get_data());
 	} else {
 		strcpy(dev, device.utf8().get_data());
 	}
@@ -145,7 +145,7 @@ Error AudioDriverPulseAudio::detect_channels(bool capture) {
 	// Now using the device name get the amount of channels
 	pa_status = 0;
 	pa_operation *pa_op;
-	if (capture) {
+	if (input) {
 		pa_op = pa_context_get_source_info_by_name(pa_ctx, dev, &AudioDriverPulseAudio::pa_source_info_cb, (void *)this);
 	} else {
 		pa_op = pa_context_get_sink_info_by_name(pa_ctx, dev, &AudioDriverPulseAudio::pa_sink_info_cb, (void *)this);
@@ -165,7 +165,7 @@ Error AudioDriverPulseAudio::detect_channels(bool capture) {
 			return FAILED;
 		}
 	} else {
-		if (capture) {
+		if (input) {
 			ERR_PRINT("pa_context_get_source_info_by_name error");
 		} else {
 			ERR_PRINT("pa_context_get_sink_info_by_name error");
@@ -175,13 +175,13 @@ Error AudioDriverPulseAudio::detect_channels(bool capture) {
 	return OK;
 }
 
-Error AudioDriverPulseAudio::init_device() {
-	// If there is a specified device check that it is really present
-	if (device_name != "Default") {
-		PackedStringArray list = get_device_list();
-		if (list.find(device_name) == -1) {
-			device_name = "Default";
-			new_device = "Default";
+Error AudioDriverPulseAudio::init_output_device() {
+	// If there is a specified output device, check that it is really present
+	if (output_device_name != "Default") {
+		PackedStringArray list = get_output_device_list();
+		if (list.find(output_device_name) == -1) {
+			output_device_name = "Default";
+			new_output_device = "Default";
 		}
 	}
 
@@ -192,7 +192,7 @@ Error AudioDriverPulseAudio::init_device() {
 	Error err = detect_channels();
 	if (err != OK) {
 		// This most likely means there are no sinks.
-		ERR_PRINT("PulseAudio: init device failed to detect number of output channels");
+		ERR_PRINT("PulseAudio: init_output_device failed to detect number of output channels");
 		return err;
 	}
 
@@ -256,7 +256,7 @@ Error AudioDriverPulseAudio::init_device() {
 	attr.maxlength = (uint32_t)-1;
 	attr.minreq = (uint32_t)-1;
 
-	const char *dev = device_name == "Default" ? nullptr : device_name.utf8().get_data();
+	const char *dev = output_device_name == "Default" ? nullptr : output_device_name.utf8().get_data();
 	pa_stream_flags flags = pa_stream_flags(PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_ADJUST_LATENCY | PA_STREAM_AUTO_TIMING_UPDATE);
 	int error_code = pa_stream_connect_playback(pa_str, dev, &attr, flags, nullptr, nullptr);
 	ERR_FAIL_COND_V(error_code < 0, ERR_CANT_OPEN);
@@ -346,7 +346,7 @@ Error AudioDriverPulseAudio::init() {
 		return ERR_CANT_OPEN;
 	}
 
-	init_device();
+	init_output_device();
 	thread.start(AudioDriverPulseAudio::thread_func, this);
 
 	return OK;
@@ -448,18 +448,18 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 			}
 		}
 
-		// User selected a new device, finish the current one so we'll init the new device
-		if (ad->device_name != ad->new_device) {
-			ad->device_name = ad->new_device;
-			ad->finish_device();
+		// User selected a new output device, finish the current one so we'll init the new output device
+		if (ad->output_device_name != ad->new_output_device) {
+			ad->output_device_name = ad->new_output_device;
+			ad->finish_output_device();
 
-			Error err = ad->init_device();
+			Error err = ad->init_output_device();
 			if (err != OK) {
-				ERR_PRINT("PulseAudio: init_device error");
-				ad->device_name = "Default";
-				ad->new_device = "Default";
+				ERR_PRINT("PulseAudio: init_output_device error");
+				ad->output_device_name = "Default";
+				ad->new_output_device = "Default";
 
-				err = ad->init_device();
+				err = ad->init_output_device();
 				if (err != OK) {
 					ad->active.clear();
 					ad->exit_thread.set();
@@ -471,11 +471,11 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 			write_ofs = 0;
 		}
 
-		// If we're using the default device check that the current device is still the default
-		if (ad->device_name == "Default") {
+		// If we're using the default output device, check that the current output device is still the default
+		if (ad->output_device_name == "Default") {
 			uint64_t msec = OS::get_singleton()->get_ticks_msec();
 			if (msec > (default_device_msec + 1000)) {
-				String old_default_device = ad->default_device;
+				String old_default_device = ad->default_output_device;
 
 				default_device_msec = msec;
 
@@ -494,12 +494,12 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 					ERR_PRINT("pa_context_get_server_info error: " + String(pa_strerror(pa_context_errno(ad->pa_ctx))));
 				}
 
-				if (old_default_device != ad->default_device) {
-					ad->finish_device();
+				if (old_default_device != ad->default_output_device) {
+					ad->finish_output_device();
 
-					Error err = ad->init_device();
+					Error err = ad->init_output_device();
 					if (err != OK) {
-						ERR_PRINT("PulseAudio: init_device error");
+						ERR_PRINT("PulseAudio: init_output_device error");
 						ad->active.clear();
 						ad->exit_thread.set();
 						break;
@@ -541,18 +541,18 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 				}
 			}
 
-			// User selected a new device, finish the current one so we'll init the new device
-			if (ad->capture_device_name != ad->capture_new_device) {
-				ad->capture_device_name = ad->capture_new_device;
-				ad->capture_finish_device();
+			// User selected a new input device, finish the current one so we'll init the new input device
+			if (ad->input_device_name != ad->new_input_device) {
+				ad->input_device_name = ad->new_input_device;
+				ad->finish_input_device();
 
-				Error err = ad->capture_init_device();
+				Error err = ad->init_input_device();
 				if (err != OK) {
-					ERR_PRINT("PulseAudio: capture_init_device error");
-					ad->capture_device_name = "Default";
-					ad->capture_new_device = "Default";
+					ERR_PRINT("PulseAudio: init_input_device error");
+					ad->input_device_name = "Default";
+					ad->new_input_device = "Default";
 
-					err = ad->capture_init_device();
+					err = ad->init_input_device();
 					if (err != OK) {
 						ad->active.clear();
 						ad->exit_thread.set();
@@ -596,7 +596,7 @@ void AudioDriverPulseAudio::pa_sinklist_cb(pa_context *c, const pa_sink_info *l,
 	ad->pa_status++;
 }
 
-PackedStringArray AudioDriverPulseAudio::get_device_list() {
+PackedStringArray AudioDriverPulseAudio::get_output_device_list() {
 	pa_devices.clear();
 	pa_devices.push_back("Default");
 
@@ -606,7 +606,7 @@ PackedStringArray AudioDriverPulseAudio::get_device_list() {
 
 	lock();
 
-	// Get the device list
+	// Get the output device list
 	pa_status = 0;
 	pa_operation *pa_op = pa_context_get_sink_info_list(pa_ctx, pa_sinklist_cb, (void *)this);
 	if (pa_op) {
@@ -627,13 +627,13 @@ PackedStringArray AudioDriverPulseAudio::get_device_list() {
 	return pa_devices;
 }
 
-String AudioDriverPulseAudio::get_device() {
-	return device_name;
+String AudioDriverPulseAudio::get_output_device() {
+	return output_device_name;
 }
 
-void AudioDriverPulseAudio::set_device(String device) {
+void AudioDriverPulseAudio::set_output_device(String output_device) {
 	lock();
-	new_device = device;
+	new_output_device = output_device;
 	unlock();
 }
 
@@ -645,7 +645,7 @@ void AudioDriverPulseAudio::unlock() {
 	mutex.unlock();
 }
 
-void AudioDriverPulseAudio::finish_device() {
+void AudioDriverPulseAudio::finish_output_device() {
 	if (pa_str) {
 		pa_stream_disconnect(pa_str);
 		pa_stream_unref(pa_str);
@@ -661,7 +661,7 @@ void AudioDriverPulseAudio::finish() {
 	exit_thread.set();
 	thread.wait_to_finish();
 
-	finish_device();
+	finish_output_device();
 
 	if (pa_ctx) {
 		pa_context_disconnect(pa_ctx);
@@ -675,13 +675,13 @@ void AudioDriverPulseAudio::finish() {
 	}
 }
 
-Error AudioDriverPulseAudio::capture_init_device() {
-	// If there is a specified device check that it is really present
-	if (capture_device_name != "Default") {
-		PackedStringArray list = capture_get_device_list();
-		if (list.find(capture_device_name) == -1) {
-			capture_device_name = "Default";
-			capture_new_device = "Default";
+Error AudioDriverPulseAudio::init_input_device() {
+	// If there is a specified input device, check that it is really present
+	if (input_device_name != "Default") {
+		PackedStringArray list = get_input_device_list();
+		if (list.find(input_device_name) == -1) {
+			input_device_name = "Default";
+			new_input_device = "Default";
 		}
 	}
 
@@ -718,7 +718,7 @@ Error AudioDriverPulseAudio::capture_init_device() {
 		ERR_FAIL_V(ERR_CANT_OPEN);
 	}
 
-	const char *dev = capture_device_name == "Default" ? nullptr : capture_device_name.utf8().get_data();
+	const char *dev = input_device_name == "Default" ? nullptr : input_device_name.utf8().get_data();
 	pa_stream_flags flags = pa_stream_flags(PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_ADJUST_LATENCY | PA_STREAM_AUTO_TIMING_UPDATE);
 	int error_code = pa_stream_connect_record(pa_rec_str, dev, &attr, flags);
 	if (error_code < 0) {
@@ -734,7 +734,7 @@ Error AudioDriverPulseAudio::capture_init_device() {
 	return OK;
 }
 
-void AudioDriverPulseAudio::capture_finish_device() {
+void AudioDriverPulseAudio::finish_input_device() {
 	if (pa_rec_str) {
 		int ret = pa_stream_disconnect(pa_rec_str);
 		if (ret != 0) {
@@ -745,25 +745,25 @@ void AudioDriverPulseAudio::capture_finish_device() {
 	}
 }
 
-Error AudioDriverPulseAudio::capture_start() {
+Error AudioDriverPulseAudio::input_start() {
 	lock();
-	Error err = capture_init_device();
+	Error err = init_input_device();
 	unlock();
 
 	return err;
 }
 
-Error AudioDriverPulseAudio::capture_stop() {
+Error AudioDriverPulseAudio::input_stop() {
 	lock();
-	capture_finish_device();
+	finish_input_device();
 	unlock();
 
 	return OK;
 }
 
-void AudioDriverPulseAudio::capture_set_device(const String &p_name) {
+void AudioDriverPulseAudio::set_input_device(const String &p_name) {
 	lock();
-	capture_new_device = p_name;
+	new_input_device = p_name;
 	unlock();
 }
 
@@ -782,7 +782,7 @@ void AudioDriverPulseAudio::pa_sourcelist_cb(pa_context *c, const pa_source_info
 	ad->pa_status++;
 }
 
-PackedStringArray AudioDriverPulseAudio::capture_get_device_list() {
+PackedStringArray AudioDriverPulseAudio::get_input_device_list() {
 	pa_rec_devices.clear();
 	pa_rec_devices.push_back("Default");
 
@@ -813,9 +813,9 @@ PackedStringArray AudioDriverPulseAudio::capture_get_device_list() {
 	return pa_rec_devices;
 }
 
-String AudioDriverPulseAudio::capture_get_device() {
+String AudioDriverPulseAudio::get_input_device() {
 	lock();
-	String name = capture_device_name;
+	String name = input_device_name;
 	unlock();
 
 	return name;

--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -51,13 +51,13 @@ class AudioDriverPulseAudio : public AudioDriver {
 	pa_channel_map pa_map = {};
 	pa_channel_map pa_rec_map = {};
 
-	String device_name = "Default";
-	String new_device = "Default";
-	String default_device;
+	String output_device_name = "Default";
+	String new_output_device = "Default";
+	String default_output_device;
 
-	String capture_device_name;
-	String capture_new_device;
-	String capture_default_device;
+	String input_device_name;
+	String new_input_device;
+	String default_input_device;
 
 	Vector<int32_t> samples_in;
 	Vector<int16_t> samples_out;
@@ -83,11 +83,11 @@ class AudioDriverPulseAudio : public AudioDriver {
 	static void pa_sinklist_cb(pa_context *c, const pa_sink_info *l, int eol, void *userdata);
 	static void pa_sourcelist_cb(pa_context *c, const pa_source_info *l, int eol, void *userdata);
 
-	Error init_device();
-	void finish_device();
+	Error init_output_device();
+	void finish_output_device();
 
-	Error capture_init_device();
-	void capture_finish_device();
+	Error init_input_device();
+	void finish_input_device();
 
 	Error detect_channels(bool capture = false);
 
@@ -103,13 +103,13 @@ public:
 	virtual int get_mix_rate() const;
 	virtual SpeakerMode get_speaker_mode() const;
 
-	virtual PackedStringArray get_device_list();
-	virtual String get_device();
-	virtual void set_device(String device);
+	virtual PackedStringArray get_output_device_list();
+	virtual String get_output_device();
+	virtual void set_output_device(String output_device);
 
-	virtual PackedStringArray capture_get_device_list();
-	virtual void capture_set_device(const String &p_name);
-	virtual String capture_get_device();
+	virtual PackedStringArray get_input_device_list();
+	virtual void set_input_device(const String &p_name);
+	virtual String get_input_device();
 
 	virtual void lock();
 	virtual void unlock();
@@ -117,8 +117,8 @@ public:
 
 	virtual float get_latency();
 
-	virtual Error capture_start();
-	virtual Error capture_stop();
+	virtual Error input_start();
+	virtual Error input_stop();
 
 	AudioDriverPulseAudio();
 	~AudioDriverPulseAudio() {}

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -47,8 +47,8 @@ class AudioDriverWASAPI : public AudioDriver {
 	class AudioDeviceWASAPI {
 	public:
 		IAudioClient *audio_client = nullptr;
-		IAudioRenderClient *render_client = nullptr;
-		IAudioCaptureClient *capture_client = nullptr;
+		IAudioRenderClient *render_client = nullptr; // Output
+		IAudioCaptureClient *capture_client = nullptr; // Input
 		SafeFlag active;
 
 		WORD format_tag = 0;
@@ -56,8 +56,8 @@ class AudioDriverWASAPI : public AudioDriver {
 		unsigned int channels = 0;
 		unsigned int frame_size = 0;
 
-		String device_name = "Default";
-		String new_device = "Default";
+		String device_name = "Default"; // Output OR Input
+		String new_device = "Default"; // Output OR Input
 
 		AudioDeviceWASAPI() {}
 	};
@@ -83,15 +83,15 @@ class AudioDriverWASAPI : public AudioDriver {
 	static _FORCE_INLINE_ int32_t read_sample(WORD format_tag, int bits_per_sample, BYTE *buffer, int i);
 	static void thread_func(void *p_udata);
 
-	Error init_render_device(bool p_reinit = false);
-	Error init_capture_device(bool p_reinit = false);
+	Error init_output_device(bool p_reinit = false);
+	Error init_input_device(bool p_reinit = false);
 
-	Error finish_render_device();
-	Error finish_capture_device();
+	Error finish_output_device();
+	Error finish_input_device();
 
-	Error audio_device_init(AudioDeviceWASAPI *p_device, bool p_capture, bool p_reinit, bool p_no_audio_client_3 = false);
+	Error audio_device_init(AudioDeviceWASAPI *p_device, bool p_input, bool p_reinit, bool p_no_audio_client_3 = false);
 	Error audio_device_finish(AudioDeviceWASAPI *p_device);
-	PackedStringArray audio_device_get_list(bool p_capture);
+	PackedStringArray audio_device_get_list(bool p_input);
 
 public:
 	virtual const char *get_name() const {
@@ -103,18 +103,18 @@ public:
 	virtual int get_mix_rate() const;
 	virtual float get_latency();
 	virtual SpeakerMode get_speaker_mode() const;
-	virtual PackedStringArray get_device_list();
-	virtual String get_device();
-	virtual void set_device(String device);
+	virtual PackedStringArray get_output_device_list();
+	virtual String get_output_device();
+	virtual void set_output_device(String output_device);
 	virtual void lock();
 	virtual void unlock();
 	virtual void finish();
 
-	virtual Error capture_start();
-	virtual Error capture_stop();
-	virtual PackedStringArray capture_get_device_list();
-	virtual void capture_set_device(const String &p_name);
-	virtual String capture_get_device();
+	virtual Error input_start();
+	virtual Error input_stop();
+	virtual PackedStringArray get_input_device_list();
+	virtual void set_input_device(const String &p_name);
+	virtual String get_input_device();
 
 	AudioDriverWASAPI();
 };

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -241,6 +241,9 @@ const char *ProjectConverter3To4::gdscript_function_renames[][2] = {
 	{ "can_generate_small_preview", "_can_generate_small_preview" }, // EditorResourcePreviewGenerator
 	{ "can_instance", "can_instantiate" }, // PackedScene, Script
 	{ "canvas_light_set_scale", "canvas_light_set_texture_scale" }, // RenderingServer
+	{ "capture_get_device", "get_input_device" }, // AudioServer
+	{ "capture_get_device_list", "get_input_device_list" }, // AudioServer
+	{ "capture_set_device", "set_input_device" }, // AudioServer
 	{ "center_viewport_to_cursor", "center_viewport_to_caret" }, // TextEdit
 	{ "change_scene", "change_scene_to_file" }, // SceneTree
 	{ "change_scene_to", "change_scene_to_packed" }, // SceneTree
@@ -301,6 +304,8 @@ const char *ProjectConverter3To4::gdscript_function_renames[][2] = {
 	{ "get_cursor_position", "get_caret_column" }, // LineEdit
 	{ "get_d", "get_distance" }, // LineShape2D
 	{ "get_depth_bias_enable", "get_depth_bias_enabled" }, // RDPipelineRasterizationState
+	{ "get_device", "get_output_device" }, // AudioServer
+	{ "get_device_list", "get_output_device_list" }, // AudioServer
 	{ "get_drag_data", "_get_drag_data" }, // Control
 	{ "get_editor_viewport", "get_editor_main_screen" }, // EditorPlugin
 	{ "get_enabled_focus_mode", "get_focus_mode" }, // BaseButton
@@ -499,6 +504,7 @@ const char *ProjectConverter3To4::gdscript_function_renames[][2] = {
 	{ "set_cursor_position", "set_caret_column" }, // LineEdit
 	{ "set_d", "set_distance" }, // WorldMarginShape2D
 	{ "set_depth_bias_enable", "set_depth_bias_enabled" }, // RDPipelineRasterizationState
+	{ "set_device", "set_output_device" }, // AudioServer
 	{ "set_doubleclick", "set_double_click" }, // InputEventMouseButton
 	{ "set_draw_red", "set_draw_warning" }, // EditorProperty
 	{ "set_enable_follow_smoothing", "set_position_smoothing_enabled" }, // Camera2D
@@ -697,6 +703,9 @@ const char *ProjectConverter3To4::csharp_function_renames[][2] = {
 	{ "CanGenerateSmallPreview", "_CanGenerateSmallPreview" }, // EditorResourcePreviewGenerator
 	{ "CanInstance", "CanInstantiate" }, // PackedScene, Script
 	{ "CanvasLightSetScale", "CanvasLightSetTextureScale" }, // RenderingServer
+	{ "CaptureGetDevice", "GetInputDevice" }, // AudioServer
+	{ "CaptureGetDeviceList", "GetInputDeviceList" }, // AudioServer
+	{ "CaptureSetDevice", "SetInputDevice" }, // AudioServer
 	{ "CenterViewportToCursor", "CenterViewportToCaret" }, // TextEdit
 	{ "ChangeScene", "ChangeSceneToFile" }, // SceneTree
 	{ "ChangeSceneTo", "ChangeSceneToPacked" }, // SceneTree
@@ -754,6 +763,8 @@ const char *ProjectConverter3To4::csharp_function_renames[][2] = {
 	{ "GetCursorPosition", "GetCaretColumn" }, // LineEdit
 	{ "GetD", "GetDistance" }, // LineShape2D
 	{ "GetDepthBiasEnable", "GetDepthBiasEnabled" }, // RDPipelineRasterizationState
+	{ "GetDevice", "GetOutputDevice" }, // AudioServer
+	{ "GetDeviceList", "GetOutputDeviceList" }, // AudioServer
 	{ "GetDragDataFw", "_GetDragDataFw" }, // ScriptEditor
 	{ "GetEditorViewport", "GetViewport" }, // EditorPlugin
 	{ "GetEnabledFocusMode", "GetFocusMode" }, // BaseButton
@@ -942,6 +953,7 @@ const char *ProjectConverter3To4::csharp_function_renames[][2] = {
 	{ "SetCursorPosition", "SetCaretColumn" }, // LineEdit
 	{ "SetD", "SetDistance" }, // WorldMarginShape2D
 	{ "SetDepthBiasEnable", "SetDepthBiasEnabled" }, // RDPipelineRasterizationState
+	{ "SetDevice", "SetOutputDevice" }, // AudioServer
 	{ "SetDoubleclick", "SetDoubleClick" }, // InputEventMouseButton
 	{ "SetEnableFollowSmoothing", "SetFollowSmoothingEnabled" }, // Camera2D
 	{ "SetEnabledFocusMode", "SetFocusMode" }, // BaseButton
@@ -1070,6 +1082,7 @@ const char *ProjectConverter3To4::gdscript_properties_renames[][2] = {
 	//	// {"shift","shift_pressed"},// This may broke a lot of comments and user variables
 	//	{ "autowrap", "autowrap_mode" }, // Label
 	//	{ "cast_to", "target_position" }, // RayCast2D, RayCast3D
+	//	{ "device", "output_device"}, // AudioServer - Too vague, most likely breaks comments & variables
 	//	{ "doubleclick", "double_click" }, // InputEventMouseButton
 	//	{ "group", "button_group" }, // BaseButton
 	//	{ "process_mode", "process_callback" }, // AnimationTree, Camera2D
@@ -1085,6 +1098,7 @@ const char *ProjectConverter3To4::gdscript_properties_renames[][2] = {
 	{ "bbcode_text", "text" }, // RichTextLabel
 	{ "bg", "panel" }, // Theme
 	{ "bg_focus", "focus" }, // Theme
+	{ "capture_device", "input_device" }, // AudioServer
 	{ "caret_blink_speed", "caret_blink_interval" }, // TextEdit, LineEdit
 	{ "caret_moving_by_right_click", "caret_move_on_right_click" }, // TextEdit
 	{ "caret_position", "caret_column" }, // LineEdit

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -144,7 +144,7 @@ int AudioDriver::get_total_channels_by_speaker_mode(AudioDriver::SpeakerMode p_m
 	ERR_FAIL_V(2);
 }
 
-PackedStringArray AudioDriver::get_device_list() {
+PackedStringArray AudioDriver::get_output_device_list() {
 	PackedStringArray list;
 
 	list.push_back("Default");
@@ -152,11 +152,11 @@ PackedStringArray AudioDriver::get_device_list() {
 	return list;
 }
 
-String AudioDriver::get_device() {
+String AudioDriver::get_output_device() {
 	return "Default";
 }
 
-PackedStringArray AudioDriver::capture_get_device_list() {
+PackedStringArray AudioDriver::get_input_device_list() {
 	PackedStringArray list;
 
 	list.push_back("Default");
@@ -238,7 +238,7 @@ void AudioServer::_driver_process(int p_frames, int32_t *p_buffer) {
 #endif
 
 	if (channel_count != get_channel_count()) {
-		// Amount of channels changed due to a device change
+		// Amount of channels changed due to a output_device change
 		// reinitialize the buses channels and buffers
 		init_channels_and_buffers();
 	}
@@ -1632,28 +1632,28 @@ Ref<AudioBusLayout> AudioServer::generate_bus_layout() const {
 	return state;
 }
 
-PackedStringArray AudioServer::get_device_list() {
-	return AudioDriver::get_singleton()->get_device_list();
+PackedStringArray AudioServer::get_output_device_list() {
+	return AudioDriver::get_singleton()->get_output_device_list();
 }
 
-String AudioServer::get_device() {
-	return AudioDriver::get_singleton()->get_device();
+String AudioServer::get_output_device() {
+	return AudioDriver::get_singleton()->get_output_device();
 }
 
-void AudioServer::set_device(String device) {
-	AudioDriver::get_singleton()->set_device(device);
+void AudioServer::set_output_device(String output_device) {
+	AudioDriver::get_singleton()->set_output_device(output_device);
 }
 
-PackedStringArray AudioServer::capture_get_device_list() {
-	return AudioDriver::get_singleton()->capture_get_device_list();
+PackedStringArray AudioServer::get_input_device_list() {
+	return AudioDriver::get_singleton()->get_input_device_list();
 }
 
-String AudioServer::capture_get_device() {
-	return AudioDriver::get_singleton()->capture_get_device();
+String AudioServer::get_input_device() {
+	return AudioDriver::get_singleton()->get_input_device();
 }
 
-void AudioServer::capture_set_device(const String &p_name) {
-	AudioDriver::get_singleton()->capture_set_device(p_name);
+void AudioServer::set_input_device(const String &p_name) {
+	AudioDriver::get_singleton()->set_input_device(p_name);
 }
 
 void AudioServer::set_enable_tagging_used_audio_streams(bool p_enable) {
@@ -1711,17 +1711,17 @@ void AudioServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_speaker_mode"), &AudioServer::get_speaker_mode);
 	ClassDB::bind_method(D_METHOD("get_mix_rate"), &AudioServer::get_mix_rate);
-	ClassDB::bind_method(D_METHOD("get_device_list"), &AudioServer::get_device_list);
-	ClassDB::bind_method(D_METHOD("get_device"), &AudioServer::get_device);
-	ClassDB::bind_method(D_METHOD("set_device", "device"), &AudioServer::set_device);
+	ClassDB::bind_method(D_METHOD("get_output_device_list"), &AudioServer::get_output_device_list);
+	ClassDB::bind_method(D_METHOD("get_output_device"), &AudioServer::get_output_device);
+	ClassDB::bind_method(D_METHOD("set_output_device", "output_device"), &AudioServer::set_output_device);
 
 	ClassDB::bind_method(D_METHOD("get_time_to_next_mix"), &AudioServer::get_time_to_next_mix);
 	ClassDB::bind_method(D_METHOD("get_time_since_last_mix"), &AudioServer::get_time_since_last_mix);
 	ClassDB::bind_method(D_METHOD("get_output_latency"), &AudioServer::get_output_latency);
 
-	ClassDB::bind_method(D_METHOD("capture_get_device_list"), &AudioServer::capture_get_device_list);
-	ClassDB::bind_method(D_METHOD("capture_get_device"), &AudioServer::capture_get_device);
-	ClassDB::bind_method(D_METHOD("capture_set_device", "name"), &AudioServer::capture_set_device);
+	ClassDB::bind_method(D_METHOD("get_input_device_list"), &AudioServer::get_input_device_list);
+	ClassDB::bind_method(D_METHOD("get_input_device"), &AudioServer::get_input_device);
+	ClassDB::bind_method(D_METHOD("set_input_device", "name"), &AudioServer::set_input_device);
 
 	ClassDB::bind_method(D_METHOD("set_bus_layout", "bus_layout"), &AudioServer::set_bus_layout);
 	ClassDB::bind_method(D_METHOD("generate_bus_layout"), &AudioServer::generate_bus_layout);
@@ -1729,11 +1729,11 @@ void AudioServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_enable_tagging_used_audio_streams", "enable"), &AudioServer::set_enable_tagging_used_audio_streams);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bus_count"), "set_bus_count", "get_bus_count");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "device"), "set_device", "get_device");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "capture_device"), "capture_set_device", "capture_get_device");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "output_device"), "set_output_device", "get_output_device");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "input_device"), "set_input_device", "get_input_device");
 	// The default value may be set to an empty string by the platform-specific audio driver.
 	// Override for class reference generation purposes.
-	ADD_PROPERTY_DEFAULT("capture_device", "Default");
+	ADD_PROPERTY_DEFAULT("input_device", "Default");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "playback_speed_scale"), "set_playback_speed_scale", "get_playback_speed_scale");
 
 	ADD_SIGNAL(MethodInfo("bus_layout_changed"));

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -94,18 +94,18 @@ public:
 	virtual void start() = 0;
 	virtual int get_mix_rate() const = 0;
 	virtual SpeakerMode get_speaker_mode() const = 0;
-	virtual PackedStringArray get_device_list();
-	virtual String get_device();
-	virtual void set_device(String device) {}
+	virtual PackedStringArray get_output_device_list();
+	virtual String get_output_device();
+	virtual void set_output_device(String output_device) {}
 	virtual void lock() = 0;
 	virtual void unlock() = 0;
 	virtual void finish() = 0;
 
 	virtual Error capture_start() { return FAILED; }
 	virtual Error capture_stop() { return FAILED; }
-	virtual void capture_set_device(const String &p_name) {}
-	virtual String capture_get_device() { return "Default"; }
-	virtual PackedStringArray capture_get_device_list();
+	virtual void set_input_device(const String &p_name) {}
+	virtual String get_input_device() { return "Default"; }
+	virtual PackedStringArray get_input_device_list();
 
 	virtual float get_latency() { return 0; }
 
@@ -419,13 +419,13 @@ public:
 	void set_bus_layout(const Ref<AudioBusLayout> &p_bus_layout);
 	Ref<AudioBusLayout> generate_bus_layout() const;
 
-	PackedStringArray get_device_list();
-	String get_device();
-	void set_device(String device);
+	PackedStringArray get_output_device_list();
+	String get_output_device();
+	void set_output_device(String output_device);
 
-	PackedStringArray capture_get_device_list();
-	String capture_get_device();
-	void capture_set_device(const String &p_name);
+	PackedStringArray get_input_device_list();
+	String get_input_device();
+	void set_input_device(const String &p_name);
 
 	void set_enable_tagging_used_audio_streams(bool p_enable);
 


### PR DESCRIPTION
Implements: [#5893](https://github.com/godotengine/godot-proposals/issues/5839).

This PR changes many audio properties and methods so that they better reflect their purpose (a 'device' is an audio output device, while a 'capture device' is an audio input device). 

---

### AudioServer

Properties:
- device > **output_device**
- capture_device > **input_device**

Methods:
- set_device(value) > **set_output_device(value)**
- get_device() > **get_output_device()**
- get_device_list() > **get_output_device_list()**
- capture_set_device(value) > **set_input_device(value)**
- capture_get_device() > **get_input_device()**
- capture_get_device_list() > **get_input_device_list()**

---

In addition to the changes above, the 3-to-4 converter will convert instances of the old names to the new names (one exception: 'device' was left out since the name is too vague and may replace user variables).

Most references in the audio drivers have been changed to maintain consistency as well; the only exceptions are drivers that use 'device' interchangeably at times (WASAPI, ALSA), and certain internal references in WASAPI, including `eRender` and `eCapture` that are out of scope for this PR.

This is a change that breaks compatibility for this particular feature if used in previous betas.