### PR TITLE
[TileMap] Fix alternative tile issues.

### DIFF
--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -153,7 +153,14 @@ void GenericTilePolygonEditor::_base_control_draw() {
 
 	// Draw the background.
 	if (background_texture.is_valid()) {
-		base_control->draw_texture_rect_region(background_texture, Rect2(-background_region.size / 2 - background_offset, background_region.size), background_region, background_modulate, background_transpose);
+		Size2 region_size = background_region.size;
+		if (background_h_flip) {
+			region_size.x = -region_size.x;
+		}
+		if (background_v_flip) {
+			region_size.y = -region_size.y;
+		}
+		base_control->draw_texture_rect_region(background_texture, Rect2(-background_region.size / 2 - background_offset, region_size), background_region, background_modulate, background_transpose);
 	}
 
 	// Draw the polygons.

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -4363,6 +4363,7 @@ int TileSetAtlasSource::create_alternative_tile(const Vector2i p_atlas_coords, i
 	tiles[p_atlas_coords].alternatives[new_alternative_id] = memnew(TileData);
 	tiles[p_atlas_coords].alternatives[new_alternative_id]->set_tile_set(tile_set);
 	tiles[p_atlas_coords].alternatives[new_alternative_id]->set_allow_transform(true);
+	tiles[p_atlas_coords].alternatives[new_alternative_id]->connect("changed", callable_mp((Resource *)this, &TileSetAtlasSource::emit_changed));
 	tiles[p_atlas_coords].alternatives[new_alternative_id]->notify_property_list_changed();
 	tiles[p_atlas_coords].alternatives_ids.append(new_alternative_id);
 	tiles[p_atlas_coords].alternatives_ids.sort();


### PR DESCRIPTION
Fix #69099
Fix #69095

1. When `TileSet` creates `TileData` for alternative tiles, it didn't connect `changed` signal, so `TileMap` won't refresh.
2. Fix flipping for drawing background in `GenericTilePolygonEditor`.

Preview:
![fix_alternative_tile](https://user-images.githubusercontent.com/12966814/203835585-1d3ad753-2321-45a8-a1c5-59a0411f78a3.gif)
