### PR TITLE
Ensure class name is printed in STATIC_CALLED_ON_INSTANCE warning

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2563,8 +2563,14 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 			parser->push_warning(p_call, GDScriptWarning::RETURN_VALUE_DISCARDED, p_call->function_name);
 		}
 
-		if (is_static && !base_type.is_meta_type && !(callee_type != GDScriptParser::Node::SUBSCRIPT && parser->current_function != nullptr && parser->current_function->is_static)) {
-			parser->push_warning(p_call, GDScriptWarning::STATIC_CALLED_ON_INSTANCE, p_call->function_name, base_type.to_string());
+		if (is_static && !base_type.is_meta_type && !(is_self && parser->current_function != nullptr && parser->current_function->is_static)) {
+			String caller_type = String(base_type.native_type);
+
+			if (caller_type.is_empty()) {
+				caller_type = base_type.to_string();
+			}
+
+			parser->push_warning(p_call, GDScriptWarning::STATIC_CALLED_ON_INSTANCE, p_call->function_name, caller_type);
 		}
 #endif // DEBUG_ENABLED
 


### PR DESCRIPTION
Follow up to: https://github.com/godotengine/godot/pull/68566

Mickeon noticed that calling ``print_orphan_nodes`` on its own lead to the following warning:
```
 The function 'print_orphan_nodes()' is a static function but was called from an instance. Instead, it should be directly called from the type: 'res://inheritance/cool.gd.print_orphan_nodes()`
```
Note that the user is directed to call ``res://inheritance/cool.gd.print_orphan_nodes()`` which is not valid. 

Instead the warning should direct the user to call ``Node.print_orphan_nodes()``. 

Instead of calling ``base_type.to_string()`` we first check to see if the ``base_type`` has registered a ``native_type`` if it has we use that instead. 

My understanding of native type is that it refers to the "proper" class name rather than the unique name. In this case it refers to "``Node``" instead of the name of the individual script. 

One quirk with this is that it grabs the closest class name. For example if a user has a GDScript like follows:
```
extends Control

func _ready():
	print_orphan_nodes()

```
The warning will suggest calling ``Control.print_orphan_nodes()`` Which I think is fine. 
