### PR TITLE
C#: Cleaner signal emission

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -227,23 +227,32 @@ namespace Godot.SourceGenerators
             foreach (var signalDelegate in godotSignalDelegates)
             {
                 string signalName = signalDelegate.Name;
-
-                var paramsSb = new StringBuilder();
                 var parameters = signalDelegate.InvokeMethodData.Method.Parameters;
+                string @params = "";
+                string paramsCall = "";
 
-                for (int i = 0; i < parameters.Length; i++)
+                if (parameters.Length > 0)
                 {
-                    paramsSb.Append(parameters[i].ToString())
-                            .Append(" ")
-                            .Append(parameters[i].Name.ToString());
+                    paramsCall += ", ";
 
-                    if (i != parameters.Length - 1)
-                        paramsSb.Append(", ");
+                    for (int i = 0; i < parameters.Length; i++)
+                    {
+                        @params += parameters[i].ToString()
+                                + " "
+                                + parameters[i].Name.ToString();
+
+                        paramsCall += parameters[i].Name.ToString();
+
+                        if (i != parameters.Length - 1)
+                            @params += ", ";
+                        paramsCall += ", ";
+                    }
                 }
+
                 source.AppendLine($"        /// <inheritdoc cref=\"{signalDelegate.DelegateSymbol.FullQualifiedName()}\"/>");
 
-                source.Append($"        public void {signalName}({paramsSb.ToString()})")
-                        .AppendLine($" => bound.EmitSignal({symbol.NameWithTypeParameters()}.SignalName.{signalName});");
+                source.Append($"        public void {signalName}({@params})")
+                        .AppendLine($" => bound.EmitSignal({symbol.NameWithTypeParameters()}.SignalName.{signalName}{paramsCall});");
             }
 
             source.AppendLine("    }");

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -244,8 +244,10 @@ namespace Godot.SourceGenerators
                         paramsCall += parameters[i].Name.ToString();
 
                         if (i != parameters.Length - 1)
+                        {
                             @params += ", ";
-                        paramsCall += ", ";
+                            paramsCall += ", ";
+                        }
                     }
                 }
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -260,7 +260,7 @@ namespace Godot.SourceGenerators
             source.AppendLine("    }");
 
             // Generate the Emit property
-            source.AppendLine("    private new SignalEmit _emit;")
+            source.AppendLine("    private SignalEmit _emit;")
                 .AppendLine("    /// <summary>A helper to quickly and safely emit signals.</summary>")
                 .AppendLine("    public new SignalEmit Emit => _emit ??= new(this);");
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -228,7 +228,7 @@ namespace Godot.SourceGenerators
             {
                 string signalName = signalDelegate.Name;
 
-                var paramsSb = new StringBuilder("");
+                var paramsSb = new StringBuilder();
                 var parameters = signalDelegate.InvokeMethodData.Method.Parameters;
 
                 for (int i = 0; i < parameters.Length; i++)

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -1809,7 +1809,7 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 
 			output << MEMBER_BEGIN INDENT1 "/// <summary>\n"
 				   << INDENT2 "/// "
-				   << "Fires the"
+				   << "Raises the"
 				   << "<see cref=\"" BINDINGS_NAMESPACE "." + itype.proxy_name + "." + isignal.proxy_name + "\"/>"
 				   << " signal.\n"
 				   << INDENT2 "/// </summary>\n";

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -1542,7 +1542,7 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 		output.append("\";\n");
 
 		// Add Emit property
-		output << MEMBER_BEGIN "private new SignalEmit _emit;\n"
+		output << MEMBER_BEGIN "private SignalEmit _emit;\n"
 			   << MEMBER_BEGIN "/// <summary>A helper to quickly and safely emit signals.</summary>\n"
 			   << MEMBER_BEGIN "public new SignalEmit Emit => _emit \?\?= new(this);\n";
 

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -1544,7 +1544,7 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 		// Add Emit property
 		output << MEMBER_BEGIN "private new SignalEmit _emit;\n"
 			   << MEMBER_BEGIN "/// <summary>A helper to quickly and safely emit signals.</summary>\n"
-			   << MEMBER_BEGIN "public new SignalEmit Emit => _emit ??= new(this);\n";
+			   << MEMBER_BEGIN "public new SignalEmit Emit => _emit \?\?= new(this);\n";
 
 		if (itype.is_instantiable) {
 			// Add native constructor static field

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -1544,7 +1544,7 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 		// Add Emit property
 		output << MEMBER_BEGIN "private new SignalEmit _emit;\n"
 			   << MEMBER_BEGIN "/// <summary>A helper to quickly and safely emit signals.</summary>\n"
-			   << MEMBER_BEGIN "public new SignalEmit Emit => new(this);\n";
+			   << MEMBER_BEGIN "public new SignalEmit Emit => _emit ??= new(this);\n";
 
 		if (itype.is_instantiable) {
 			// Add native constructor static field


### PR DESCRIPTION
I'd thought that emitting signals from c# does have some problems and could be a lot better.
So i made them better :)

Currently when you want to emit a signal from c# it would look something like this:
```c#
// From the class itself
EmitSignal(SignalName.SomethingHappened, arg1, arg2);
// From an other object (you don't usually do that)
obj.EmitSignal(ObjNamespace.ObjType.SignalEmit.SomethingHappened, arg1, arg2);
```
I think that this looks a bit clunky, however with this PR a property named `Emit` will be generated it is of the newly generated type called `SignalEmit`.
The `SignalEmit` type works a bit like the `SignalName` type and it will contain functions to quickly emit all available signals.
```c#
// From the class itself
Emit.SomethingHappened(arg1, arg2);
// From an other object
obj.Emit.SomethingHappened(arg1, arg2);
```
This already looks better and is a lot more readable in my opinion.
But there is another big advantage, the parameters will match the types and the names that the signal EventHandler uses.
So when you for example add an argument or change the type of an argument from the signal EventHandler, you will instantly get error syntax highlighting and the compilation won't even accept signal emissions that would not work and break the game.