### PR TITLE
[3.x] Prevent [unsaved] tabs on move

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1149,10 +1149,13 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 		}
 
 		// Update scene if it is open.
+		int current_tab = editor->get_current_tab();
 		for (int i = 0; i < file_changed_paths.size(); ++i) {
 			String new_item_path = p_item.is_file ? new_path : file_changed_paths[i].replace_first(old_path, new_path);
-			if (ResourceLoader::get_resource_type(new_item_path) == "PackedScene" && editor->is_scene_open(file_changed_paths[i])) {
-				EditorData *ed = &editor->get_editor_data();
+			String resource_type = ResourceLoader::get_resource_type(new_item_path);
+			EditorData *ed = &editor->get_editor_data();
+
+			if (resource_type == "PackedScene" && editor->is_scene_open(file_changed_paths[i])) {
 				for (int j = 0; j < ed->get_edited_scene_count(); j++) {
 					if (ed->get_scene_path(j) == file_changed_paths[i]) {
 						ed->get_edited_scene_root(j)->set_filename(new_item_path);
@@ -1160,6 +1163,8 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 						break;
 					}
 				}
+			} else if (resource_type == "GDScript") {
+				ScriptEditor::get_singleton()->resolve_edited_scene_move(current_tab, old_path, new_path);
 			}
 		}
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3570,6 +3570,49 @@ ScriptEditor::~ScriptEditor() {
 	memdelete(completion_cache);
 }
 
+void ScriptEditor::resolve_edited_scene_move(int p_scene_tab, const String &p_old_path, const String &p_new_path) {
+	EditorData *ed = &editor->get_editor_data();
+
+	Ref<Script> root_script = ed->get_scene_root_script(p_scene_tab);
+	String root_script_path = root_script.is_valid() ? root_script->get_path() : String();
+
+	Node *root = ed->get_edited_scene_root(p_scene_tab);
+	String found_path;
+	for (int i = 0; i < root->get_child_count(); ++i) {
+		Ref<Script> child_script = root->get_child(i)->get_script();
+		if (child_script.is_null()) {
+			continue;
+		}
+
+		String child_script_path = child_script->get_path();
+		if (child_script_path == p_old_path) {
+			found_path = child_script_path;
+			break;
+		}
+	}
+
+	if (!found_path.size() && root_script_path != p_old_path) {
+		return;
+	}
+
+	for (int i = 0; i < tab_container->get_child_count(); ++i) {
+		ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
+		if (!seb) {
+			continue;
+		}
+		String seb_path = seb->get_edited_resource()->get_path();
+
+		if (seb_path == root_script_path && root_script_path == p_old_path) {
+			_close_tab(i, false, false);
+			return;
+		} else if (found_path == seb_path) {
+			_close_tab(i, false, false);
+			_open_script_request(p_new_path);
+			return;
+		}
+	}
+}
+
 void ScriptEditorPlugin::edit(Object *p_object) {
 	if (Object::cast_to<Script>(p_object)) {
 		Script *p_script = Object::cast_to<Script>(p_object);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -435,6 +435,7 @@ public:
 
 	void save_current_script();
 	void save_all_scripts();
+	void resolve_edited_scene_move(int p_scene_tab, const String &p_old_path, const String &p_new_path);
 
 	void set_window_layout(Ref<ConfigFile> p_layout);
 	void get_window_layout(Ref<ConfigFile> p_layout);


### PR DESCRIPTION
*First PR, sorry if I've done something horrific*

When moving a script attached to a node of the current scene tab, if they are open in the script editor, the old tab is replaced with a new one with the identical source of the moved script. 

https://user-images.githubusercontent.com/57271984/203875236-348c4339-fc52-405c-8aef-9c6c45af796a.mp4

This handles that move with a new method: `ScriptEditor::resolve_edited_scene_move`, that closes the original tabs, and sends requests to reopen the moved scripts.

https://user-images.githubusercontent.com/57271984/203875456-0b56f6d1-40b3-4bcf-97ac-c8604eddfdec.mp4

