### PR TITLE
Ensure that mesh instance is properly freed when freeing Polygon2D

### DIFF
--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -663,5 +663,7 @@ Polygon2D::Polygon2D() {
 }
 
 Polygon2D::~Polygon2D() {
+	// This will free the internally-allocated mesh instance, if allocated.
+	RS::get_singleton()->canvas_item_attach_skeleton(get_canvas_item(), RID());
 	RS::get_singleton()->free(mesh);
 }


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/69092

This PR fixes the error in https://github.com/godotengine/godot/issues/69092, but I can't reproduce the crash so I don't know if it helps the crash as well.

cc @h0lley Could you test this out and see if it helps with the crash?