### PR TITLE
Fix wrong `AnimationTrackKeyEdit` update timing

### DIFF
--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -427,7 +427,6 @@ class AnimationTrackEditor : public VBoxContainer {
 	AnimationTrackKeyEdit *key_edit = nullptr;
 	AnimationMultiTrackKeyEdit *multi_key_edit = nullptr;
 	void _update_key_edit();
-
 	void _clear_key_edit();
 
 	Control *box_selection = nullptr;


### PR DESCRIPTION
Fixed #69154, regression by #68902.

Updating KeyEdit should be avoided while KeyEdit is being edited.
