### PR TITLE
GDScript: Fix wrong marking of some lines related to Variant as unsafe

### DIFF
--- a/modules/gdscript/tests/scripts/analyzer/features/hard_variants.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/hard_variants.gd
@@ -1,0 +1,32 @@
+func variant() -> Variant: return null
+
+var member_weak = variant()
+var member_typed: Variant = variant()
+var member_inferred := variant()
+
+func param_weak(param = variant()) -> void: print(param)
+func param_typed(param: Variant = variant()) -> void: print(param)
+func param_inferred(param := variant()) -> void: print(param)
+
+func return_untyped(): return variant()
+func return_typed() -> Variant: return variant()
+
+@warning_ignore(unused_variable)
+func test() -> void:
+	var weak = variant()
+	var typed: Variant = variant()
+	var inferred := variant()
+
+	weak = variant()
+	typed = variant()
+	inferred = variant()
+
+	param_weak(typed)
+	param_typed(typed)
+	param_inferred(typed)
+
+	if typed == null: pass
+	if typed != null: pass
+	if typed is Node: pass
+
+	print('ok')

--- a/modules/gdscript/tests/scripts/analyzer/features/hard_variants.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/hard_variants.out
@@ -1,0 +1,5 @@
+GDTEST_OK
+<null>
+<null>
+<null>
+ok


### PR DESCRIPTION
I think most of the things were implemented in other PRs. Here is what remains in this one:

```gdscript
func variant() -> Variant: return null

func as_return() -> Variant:
  return variant() # safe now

func as_argument(arg: Variant): pass
  
func _ready():
  var mystery := variant()
  
  as_argument(mystery) # safe now
  
  if mystery == null: pass # safe now
  if mystery != null: pass # safe now
  if mystery is Node: pass # safe now
  
```

Those will be safe for variant - returning or passing as an argument with explicitly specified Variant type, comparing to null, type checking.