### PR TITLE
[Editor] Add button to keep the debug server open.

### DIFF
--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -63,7 +63,6 @@ private:
 		DEBUG_STEP,
 		DEBUG_BREAK,
 		DEBUG_CONTINUE,
-		DEBUG_KEEP_DEBUGGER_OPEN,
 		DEBUG_WITH_EXTERNAL_EDITOR,
 	};
 
@@ -110,7 +109,9 @@ private:
 	float remote_scene_tree_timeout = 0.0;
 	bool auto_switch_remote_scene_tree = false;
 	bool debug_with_external_editor = false;
-	bool hide_on_stop = true;
+	bool keep_open = false;
+	String current_uri;
+
 	CameraOverride camera_override = OVERRIDE_NONE;
 	HashMap<Breakpoint, bool, Breakpoint> breakpoints;
 
@@ -203,8 +204,9 @@ public:
 
 	String get_server_uri() const;
 
+	void set_keep_open(bool p_keep_open);
 	Error start(const String &p_uri = "tcp://");
-	void stop();
+	void stop(bool p_force = false);
 
 	bool plugins_capture(ScriptEditorDebugger *p_debugger, const String &p_message, const Array &p_data);
 	void add_debugger_plugin(const Ref<EditorDebuggerPlugin> &p_plugin);

--- a/editor/plugins/debugger_editor_plugin.h
+++ b/editor/plugins/debugger_editor_plugin.h
@@ -53,6 +53,7 @@ private:
 		RUN_DEBUG_NAVIGATION,
 		RUN_DEPLOY_REMOTE_DEBUG,
 		RUN_RELOAD_SCRIPTS,
+		SERVER_KEEP_OPEN,
 	};
 
 	void _update_debug_options();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2952,6 +2952,7 @@ bool Main::start() {
 				DisplayServer::get_singleton()->set_context(DisplayServer::CONTEXT_EDITOR);
 				if (!debug_server_uri.is_empty()) {
 					EditorDebuggerNode::get_singleton()->start(debug_server_uri);
+					EditorDebuggerNode::get_singleton()->set_keep_open(true);
 				}
 			}
 #endif


### PR DESCRIPTION
The setting is stored in the project editor metadata, and the server is automatically started/stopped when the option change (only stopped if no session is currently active).

The CLI option `--debug-server` now also forces the server to stay open (without saving the state, unlike the menu option).

This commit also removes the "Keep debugger open" option in the script editor "debug" menu. That option was really confusing, it used to hide the bottom panel if and only if the debugger pane was selected, so if you had your output log open instead (default when pressing play) it would effectively do nothing. Having an option to save a click in such a very specific case seems very overkill.

Closes https://github.com/godotengine/godot-proposals/issues/2608

![keep_open](https://user-images.githubusercontent.com/1687918/203957180-bfc7c4d4-171b-4d2c-acd2-e83328e250c6.png)
