### PR TITLE
Improve editor property capitalization

### DIFF
--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -64,8 +64,8 @@ String EditorPropertyNameProcessor::_capitalize_name(const String &p_name) const
 
 	Vector<String> parts = p_name.split("_", false);
 	for (int i = 0; i < parts.size(); i++) {
-		// Articles/conjunctions/prepositions which should only be capitalized if first word.
-		if (i != 0 && stop_words.find(parts[i]) != -1) {
+		// Articles/conjunctions/prepositions which should only be capitalized when not at beginning and end.
+		if (i > 0 && i + 1 < parts.size() && stop_words.find(parts[i]) != -1) {
 			continue;
 		}
 		HashMap<String, String>::ConstIterator remap = capitalize_string_remaps.find(parts[i]);
@@ -260,6 +260,8 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["yz"] = "YZ";
 
 	// Articles, conjunctions, prepositions.
+	// The following initialization is parsed in `editor/translations/extract.py` with a regex.
+	// The word definition format should be kept synced with the regex.
 	stop_words = LocalVector<String>({
 			"a",
 			"an",


### PR DESCRIPTION
Follow-up to #68455

* Captialize stop words when they are the last word. e.g. `List Script Names As`.
* Add stop words logic in `extract.py`.

