### PR TITLE
embree: Enable raycast module build for Web and Windows x86_32

### DIFF
--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -67,7 +67,7 @@ if env["builtin_embree"]:
     env_raycast.AppendUnique(CPPDEFINES=["NDEBUG"])  # No assert() even in debug builds.
 
     if not env.msvc:
-        if env["arch"] == "x86_64":
+        if env["arch"] in ["x86_64", "x86_32"]:
             env_raycast.Append(CPPFLAGS=["-msse2", "-mxsave"])
 
         if env["platform"] == "windows":
@@ -87,9 +87,12 @@ if env["builtin_embree"]:
     env_thirdparty.disable_warnings()
     env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
 
-    if env["arch"] == "arm64" or env.msvc:
+    if env["arch"] != "x86_64" or env.msvc:
         # Embree needs those, it will automatically use SSE2NEON in ARM
         env_thirdparty.Append(CPPDEFINES=["__SSE2__", "__SSE__"])
+
+    if env["platform"] == "web":
+        env_thirdparty.Append(CPPFLAGS=["-msimd128"])
 
     if not env.msvc:
         env_thirdparty.Append(

--- a/modules/raycast/config.py
+++ b/modules/raycast/config.py
@@ -1,9 +1,13 @@
 def can_build(env, platform):
-    # Depends on Embree library, which only supports x86_64 and arm64.
-    if platform == "windows":
-        return env["arch"] == "x86_64"  # TODO build for Windows on ARM
-
-    return env["arch"] in ["x86_64", "arm64"]
+    # Supported architectures depend on the Embree library.
+    # No ARM32 support planned.
+    if env["arch"] == "arm32":
+        return False
+    # x86_32 only seems supported on Windows for now.
+    if env["arch"] == "x86_32" and platform != "windows":
+        return False
+    # The rest works, even wasm32!
+    return True
 
 
 def configure(env):


### PR DESCRIPTION
Follow-up to #69144.

Embree initially only supported x86_64, then got arm64 support added. Now it seems to be possible to build it with Emscripten (wasm32) and on x86_32 Windows.

Linux and Android x86_32 don't seem to build.

Windows arm64 still untested - I've removed the code that prevents trying it, but it's not guaranteed that it will work (it works for macOS, iOS, Linux and Android though).

Building the raycast module and embree will make the Web template even bigger - but @JFonS confirmed that these would be usable on Web for occlusion culling. We can decide later if we want to disable this module by default to keep templates smaller, or have the template full featured and maybe provide a set of leaner templates with less features.

The lightmapper that uses embree still isn't supported on the Web of course as it depends on RenderingDevice. We currently still compile it, some work should be done here to exclude features that can't actually be used on Web (so anything that depends on RenderingDevice, including possibly the whole RendererRD folder and drivers).