### PR TITLE
Give files with an empty file type an ImportFail icon

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -221,7 +221,7 @@ Ref<Texture2D> FileSystemDock::_get_tree_item_icon(bool p_is_valid, const String
 		}
 	}
 
-	if (!p_is_valid) {
+	if (!p_is_valid || p_file_type.is_empty()) {
 		return get_editor_theme_icon(SNAME("ImportFail"));
 	} else if (has_theme_icon(p_file_type, EditorStringName(EditorIcons))) {
 		return get_editor_theme_icon(p_file_type);


### PR DESCRIPTION
This PR adds a check in the file system dock for when a file type is an 'empty' String.

If files are created in convoluted ways (eg. create a text file, save, rename extension to .tres), the 'type' of the file is empty and the file is un-openable. This will typically open a warning dialog saying the file is of an unrecognized type, but changing the icon will make it clear the file is broken without needing to make an attempt to open it.