### PR TITLE
Use a more specific type for Mesh create_(convex|trimesh)_shape

### DIFF
--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -97,7 +97,7 @@
 			</description>
 		</method>
 		<method name="create_convex_shape" qualifiers="const">
-			<return type="Shape3D" />
+			<return type="ConvexPolygonShape3D" />
 			<param index="0" name="clean" type="bool" default="true" />
 			<param index="1" name="simplify" type="bool" default="false" />
 			<description>
@@ -115,7 +115,7 @@
 			</description>
 		</method>
 		<method name="create_trimesh_shape" qualifiers="const">
-			<return type="Shape3D" />
+			<return type="ConcavePolygonShape3D" />
 			<description>
 				Calculate a [ConcavePolygonShape3D] from the mesh.
 			</description>

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -355,7 +355,7 @@ static void _pre_gen_shape_list(Ref<ImporterMesh> &mesh, Vector<Ref<Shape3D>> &r
 	ERR_FAIL_NULL_MSG(mesh, "Cannot generate shape list with null mesh value");
 	ERR_FAIL_NULL_MSG(mesh->get_mesh(), "Cannot generate shape list with null mesh value");
 	if (!p_convex) {
-		Ref<Shape3D> shape = mesh->create_trimesh_shape();
+		Ref<ConcavePolygonShape3D> shape = mesh->create_trimesh_shape();
 		r_shape_list.push_back(shape);
 	} else {
 		Vector<Ref<Shape3D>> cd;

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -38,6 +38,8 @@
 #include "scene/3d/navigation_region_3d.h"
 #include "scene/3d/physics_body_3d.h"
 #include "scene/gui/box_container.h"
+#include "scene/resources/concave_polygon_shape_3d.h"
+#include "scene/resources/convex_polygon_shape_3d.h"
 
 void MeshInstance3DEditor::_node_removed(Node *p_node) {
 	if (p_node == node) {
@@ -66,7 +68,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 			List<Node *> selection = editor_selection->get_selected_node_list();
 
 			if (selection.is_empty()) {
-				Ref<Shape3D> shape = mesh->create_trimesh_shape();
+				Ref<ConcavePolygonShape3D> shape = mesh->create_trimesh_shape();
 				if (shape.is_null()) {
 					err_dialog->set_text(TTR("Couldn't create a Trimesh collision shape."));
 					err_dialog->popup_centered();
@@ -105,7 +107,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 					continue;
 				}
 
-				Ref<Shape3D> shape = m->create_trimesh_shape();
+				Ref<ConcavePolygonShape3D> shape = m->create_trimesh_shape();
 				if (shape.is_null()) {
 					continue;
 				}
@@ -137,7 +139,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 				return;
 			}
 
-			Ref<Shape3D> shape = mesh->create_trimesh_shape();
+			Ref<ConcavePolygonShape3D> shape = mesh->create_trimesh_shape();
 			if (shape.is_null()) {
 				return;
 			}
@@ -171,7 +173,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 
 			bool simplify = (p_option == MENU_OPTION_CREATE_SIMPLIFIED_CONVEX_COLLISION_SHAPE);
 
-			Ref<Shape3D> shape = mesh->create_convex_shape(true, simplify);
+			Ref<ConvexPolygonShape3D> shape = mesh->create_convex_shape(true, simplify);
 
 			if (shape.is_null()) {
 				err_dialog->set_text(TTR("Couldn't create a single convex collision shape."));

--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "collision_object_3d.h"
 
+#include "scene/resources/shape_3d.h"
 #include "scene/scene_string_names.h"
 
 void CollisionObject3D::_notification(int p_what) {

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -33,6 +33,8 @@
 #include "collision_shape_3d.h"
 #include "core/core_string_names.h"
 #include "physics_body_3d.h"
+#include "scene/resources/concave_polygon_shape_3d.h"
+#include "scene/resources/convex_polygon_shape_3d.h"
 
 bool MeshInstance3D::_set(const StringName &p_name, const Variant &p_value) {
 	//this is not _too_ bad performance wise, really. it only arrives here if the property was not set anywhere else.
@@ -224,7 +226,7 @@ Node *MeshInstance3D::create_trimesh_collision_node() {
 		return nullptr;
 	}
 
-	Ref<Shape3D> shape = mesh->create_trimesh_shape();
+	Ref<ConcavePolygonShape3D> shape = mesh->create_trimesh_shape();
 	if (shape.is_null()) {
 		return nullptr;
 	}
@@ -254,7 +256,7 @@ Node *MeshInstance3D::create_convex_collision_node(bool p_clean, bool p_simplify
 		return nullptr;
 	}
 
-	Ref<Shape3D> shape = mesh->create_convex_shape(p_clean, p_simplify);
+	Ref<ConvexPolygonShape3D> shape = mesh->create_convex_shape(p_clean, p_simplify);
 	if (shape.is_null()) {
 		return nullptr;
 	}

--- a/scene/3d/spring_arm_3d.cpp
+++ b/scene/3d/spring_arm_3d.cpp
@@ -31,6 +31,7 @@
 #include "spring_arm_3d.h"
 
 #include "scene/3d/camera_3d.h"
+#include "scene/resources/shape_3d.h"
 
 void SpringArm3D::_notification(int p_what) {
 	switch (p_what) {

--- a/scene/resources/importer_mesh.cpp
+++ b/scene/resources/importer_mesh.cpp
@@ -971,10 +971,10 @@ Vector<Ref<Shape3D>> ImporterMesh::convex_decompose(const Mesh::ConvexDecomposit
 	return ret;
 }
 
-Ref<Shape3D> ImporterMesh::create_trimesh_shape() const {
+Ref<ConcavePolygonShape3D> ImporterMesh::create_trimesh_shape() const {
 	Vector<Face3> faces = get_faces();
 	if (faces.size() == 0) {
-		return Ref<Shape3D>();
+		return Ref<ConcavePolygonShape3D>();
 	}
 
 	Vector<Vector3> face_points;

--- a/scene/resources/importer_mesh.h
+++ b/scene/resources/importer_mesh.h
@@ -119,7 +119,7 @@ public:
 
 	Vector<Face3> get_faces() const;
 	Vector<Ref<Shape3D>> convex_decompose(const Mesh::ConvexDecompositionSettings &p_settings) const;
-	Ref<Shape3D> create_trimesh_shape() const;
+	Ref<ConcavePolygonShape3D> create_trimesh_shape() const;
 	Ref<NavigationMesh> create_navigation_mesh();
 	Error lightmap_unwrap_cached(const Transform3D &p_base_transform, float p_texel_size, const Vector<uint8_t> &p_src_cache, Vector<uint8_t> &r_dst_cache);
 

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -388,7 +388,7 @@ Vector<Face3> Mesh::get_surface_faces(int p_surface) const {
 	return Vector<Face3>();
 }
 
-Ref<Shape3D> Mesh::create_convex_shape(bool p_clean, bool p_simplify) const {
+Ref<ConvexPolygonShape3D> Mesh::create_convex_shape(bool p_clean, bool p_simplify) const {
 	if (p_simplify) {
 		ConvexDecompositionSettings settings;
 		settings.max_convex_hulls = 1;
@@ -425,10 +425,10 @@ Ref<Shape3D> Mesh::create_convex_shape(bool p_clean, bool p_simplify) const {
 	return shape;
 }
 
-Ref<Shape3D> Mesh::create_trimesh_shape() const {
+Ref<ConcavePolygonShape3D> Mesh::create_trimesh_shape() const {
 	Vector<Face3> faces = get_faces();
 	if (faces.size() == 0) {
-		return Ref<Shape3D>();
+		return Ref<ConcavePolygonShape3D>();
 	}
 
 	Vector<Vector3> face_points;

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -35,8 +35,11 @@
 #include "core/math/face3.h"
 #include "core/math/triangle_mesh.h"
 #include "scene/resources/material.h"
-#include "scene/resources/shape_3d.h"
 #include "servers/rendering_server.h"
+
+class ConcavePolygonShape3D;
+class ConvexPolygonShape3D;
+class Shape3D;
 
 class Mesh : public Resource {
 	GDCLASS(Mesh, Resource);
@@ -211,8 +214,8 @@ public:
 	static ConvexDecompositionFunc convex_decomposition_function;
 
 	Vector<Ref<Shape3D>> convex_decompose(const ConvexDecompositionSettings &p_settings) const;
-	Ref<Shape3D> create_convex_shape(bool p_clean = true, bool p_simplify = false) const;
-	Ref<Shape3D> create_trimesh_shape() const;
+	Ref<ConvexPolygonShape3D> create_convex_shape(bool p_clean = true, bool p_simplify = false) const;
+	Ref<ConcavePolygonShape3D> create_trimesh_shape() const;
 
 	virtual int get_builtin_bind_pose_count() const;
 	virtual Transform3D get_builtin_bind_pose(int p_index) const;


### PR DESCRIPTION
* `create_convex_shape` returns `ConvexPolygonShape3D`, so change the return type to that.
* `create_trimesh_shape` returns `ConcavePolygonShape3D`, so change the return type to that.
* Use forward declarations in `mesh.h` and the full includes in the files that actually need the full definitions.