### PR TITLE
Fix Screen-Transform missing in Button Size in OptionButton::show_popup

### DIFF
--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -491,9 +491,11 @@ void OptionButton::show_popup() {
 		return;
 	}
 
-	Size2 button_size = get_global_transform_with_canvas().get_scale() * get_size();
-	popup->set_position(get_screen_position() + Size2(0, button_size.height));
-	popup->set_size(Size2i(button_size.width, 0));
+	Rect2 rect = get_screen_rect();
+	rect.position.y += rect.size.height;
+	rect.size.height = 0;
+	popup->set_position(rect.position);
+	popup->set_size(rect.size);
 
 	// If not triggered by the mouse, start the popup with the checked item (or the first enabled one) focused.
 	if (current != NONE_SELECTED && !popup->is_item_disabled(current)) {


### PR DESCRIPTION
The button size is affected by the screen transform, which was previously not taken into consideration.

This resulted in the following situation for an `OptionButton` within a `SubViewportContainer`.
When the `SubViewportContainer` had a non-identity-transform (like a scale of 2 in the picture), the PopupMenu was positioned without including the scale for its position:
![image](https://user-images.githubusercontent.com/6299227/204054524-97c28cf4-31f1-4257-8c87-047811e206ed.png)

fix part of #69171 (PopupMenu appears at wrong position)
follow up to #68573

Updated 2023-02-06: Rebase to master in order to include dependencies