### PR TITLE
Fix `VariantUtils.UnsupportedType` method throwing

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
@@ -6,7 +6,7 @@ namespace Godot.NativeInterop;
 
 public partial class VariantUtils
 {
-    private static Exception UnsupportedType<T>() => throw new InvalidOperationException(
+    private static Exception UnsupportedType<T>() => new InvalidOperationException(
         $"The type is not supported for conversion to/from Variant: '{typeof(T).FullName}'");
 
     internal static class GenericConversion<T>


### PR DESCRIPTION
This method was not supposed to throw, just return the new constructed exception so it can be thrown by the caller.

- Follow-up to https://github.com/godotengine/godot/pull/68310
