### PR TITLE
Fix debug line drawing with tiny convex hull mesh colliders

### DIFF
--- a/editor/plugins/gizmos/collision_shape_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/collision_shape_3d_gizmo_plugin.cpp
@@ -538,20 +538,19 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	if (Object::cast_to<ConvexPolygonShape3D>(*s)) {
 		Vector<Vector3> points = Object::cast_to<ConvexPolygonShape3D>(*s)->get_points();
 
-		if (points.size() > 3) {
+		if (points.size() > 1) { // Need at least 2 points for a line.
 			Vector<Vector3> varr = Variant(points);
 			Geometry3D::MeshData md;
 			Error err = ConvexHullComputer::convex_hull(varr, md);
 			if (err == OK) {
-				Vector<Vector3> points2;
-				points2.resize(md.edges.size() * 2);
+				Vector<Vector3> lines;
+				lines.resize(md.edges.size() * 2);
 				for (uint32_t i = 0; i < md.edges.size(); i++) {
-					points2.write[i * 2 + 0] = md.vertices[md.edges[i].vertex_a];
-					points2.write[i * 2 + 1] = md.vertices[md.edges[i].vertex_b];
+					lines.write[i * 2 + 0] = md.vertices[md.edges[i].vertex_a];
+					lines.write[i * 2 + 1] = md.vertices[md.edges[i].vertex_b];
 				}
-
-				p_gizmo->add_lines(points2, material);
-				p_gizmo->add_collision_segments(points2);
+				p_gizmo->add_lines(lines, material);
+				p_gizmo->add_collision_segments(lines);
 			}
 		}
 	}

--- a/scene/resources/3d/convex_polygon_shape_3d.cpp
+++ b/scene/resources/3d/convex_polygon_shape_3d.cpp
@@ -35,7 +35,7 @@
 Vector<Vector3> ConvexPolygonShape3D::get_debug_mesh_lines() const {
 	Vector<Vector3> poly_points = get_points();
 
-	if (poly_points.size() > 3) {
+	if (poly_points.size() > 1) { // Need at least 2 points for a line.
 		Vector<Vector3> varr = Variant(poly_points);
 		Geometry3D::MeshData md;
 		Error err = ConvexHullComputer::convex_hull(varr, md);


### PR DESCRIPTION
Godot's convex hulls support lines and planes, but the code to draw debug lines currently disables itself if there are fewer than 4 points. This means that the debug lines are not able to draw valid convex hulls with 2 or 3 points, even though there is no reason the code couldn't do that.