### PR TITLE
Fix broken root motion scale & Refactor API & Add sample codes in documentation

### DIFF
--- a/doc/classes/AnimationTree.xml
+++ b/doc/classes/AnimationTree.xml
@@ -19,10 +19,66 @@
 				Manually advance the animations by the specified time (in seconds).
 			</description>
 		</method>
-		<method name="get_root_motion_transform" qualifiers="const">
-			<return type="Transform3D" />
+		<method name="get_root_motion_position" qualifiers="const">
+			<return type="Vector3" />
 			<description>
-				Retrieve the motion of the [member root_motion_track] as a [Transform3D] that can be used elsewhere. If [member root_motion_track] is not a path to a track of type [constant Animation.TYPE_POSITION_3D], [constant Animation.TYPE_SCALE_3D] or [constant Animation.TYPE_ROTATION_3D], returns an identity transformation. See also [member root_motion_track] and [RootMotionView].
+				Retrieve the motion of position with the [member root_motion_track] as a [Vector3] that can be used elsewhere.
+				If [member root_motion_track] is not a path to a track of type [constant Animation.TYPE_POSITION_3D], returns [code]Vector3(0, 0, 0)[/code].
+				See also [member root_motion_track] and [RootMotionView].
+				The most basic example is applying position to [CharacterBody3D]:
+				[codeblocks]
+				[gdscript]
+				var current_rotation: Quaternion
+
+				func _process(delta):
+				    if Input.is_action_just_pressed("animate"):
+				        current_rotation = get_quaternion()
+				        state_machine.travel("Animate")
+				    var velocity: Vector3 = current_rotation * animation_tree.get_root_motion_position() / delta
+				    set_velocity(velocity)
+				    move_and_slide()
+				[/gdscript]
+				[/codeblocks]
+			</description>
+		</method>
+		<method name="get_root_motion_rotation" qualifiers="const">
+			<return type="Quaternion" />
+			<description>
+				Retrieve the motion of rotation with the [member root_motion_track] as a [Quaternion] that can be used elsewhere.
+				If [member root_motion_track] is not a path to a track of type [constant Animation.TYPE_ROTATION_3D], returns [code]Quaternion(0, 0, 0, 1)[/code].
+				See also [member root_motion_track] and [RootMotionView].
+				The most basic example is applying rotation to [CharacterBody3D]:
+				[codeblocks]
+				[gdscript]
+				func _process(delta):
+				    if Input.is_action_just_pressed("animate"):
+				        state_machine.travel("Animate")
+				    set_quaternion(get_quaternion() * animation_tree.get_root_motion_rotation())
+				[/gdscript]
+				[/codeblocks]
+			</description>
+		</method>
+		<method name="get_root_motion_scale" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Retrieve the motion of scale with the [member root_motion_track] as a [Vector3] that can be used elsewhere.
+				If [member root_motion_track] is not a path to a track of type [constant Animation.TYPE_SCALE_3D], returns [code]Vector3(0, 0, 0)[/code].
+				See also [member root_motion_track] and [RootMotionView].
+				The most basic example is applying scale to [CharacterBody3D]:
+				[codeblocks]
+				[gdscript]
+				var current_scale: Vector3 = Vector3(1, 1, 1)
+				var scale_accum: Vector3 = Vector3(1, 1, 1)
+
+				func _process(delta):
+				    if Input.is_action_just_pressed("animate"):
+				        current_scale = get_scale()
+				        scale_accum = Vector3(1, 1, 1)
+				        state_machine.travel("Animate")
+				    scale_accum += animation_tree.get_root_motion_scale()
+				    set_scale(current_scale * scale_accum)
+				[/gdscript]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="rename_parameter">
@@ -48,7 +104,7 @@
 		</member>
 		<member name="root_motion_track" type="NodePath" setter="set_root_motion_track" getter="get_root_motion_track" default="NodePath(&quot;&quot;)">
 			The path to the Animation track used for root motion. Paths must be valid scene-tree paths to a node, and must be specified starting from the parent node of the node that will reproduce the animation. To specify a track that controls properties or bones, append its name after the path, separated by [code]":"[/code]. For example, [code]"character/skeleton:ankle"[/code] or [code]"character/mesh:transform/local"[/code].
-			If the track has type [constant Animation.TYPE_POSITION_3D], [constant Animation.TYPE_ROTATION_3D] or [constant Animation.TYPE_SCALE_3D] the transformation will be cancelled visually, and the animation will appear to stay in place. See also [method get_root_motion_transform] and [RootMotionView].
+			If the track has type [constant Animation.TYPE_POSITION_3D], [constant Animation.TYPE_ROTATION_3D] or [constant Animation.TYPE_SCALE_3D] the transformation will be cancelled visually, and the animation will appear to stay in place. See also [method get_root_motion_position], [method get_root_motion_rotation], [method get_root_motion_scale] and [RootMotionView].
 		</member>
 		<member name="tree_root" type="AnimationNode" setter="set_tree_root" getter="get_tree_root">
 			The root animation node of this [AnimationTree]. See [AnimationNode].

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -294,7 +294,9 @@ private:
 	bool started = true;
 
 	NodePath root_motion_track;
-	Transform3D root_motion_transform;
+	Vector3 root_motion_position = Vector3(0, 0, 0);
+	Quaternion root_motion_rotation = Quaternion(0, 0, 0, 1);
+	Vector3 root_motion_scale = Vector3(0, 0, 0);
 
 	friend class AnimationNode;
 	bool properties_dirty = true;
@@ -350,7 +352,9 @@ public:
 	void set_root_motion_track(const NodePath &p_track);
 	NodePath get_root_motion_track() const;
 
-	Transform3D get_root_motion_transform() const;
+	Vector3 get_root_motion_position() const;
+	Quaternion get_root_motion_rotation() const;
+	Vector3 get_root_motion_scale() const;
 
 	real_t get_connection_activity(const StringName &p_path, int p_connection) const;
 	void advance(double p_time);

--- a/scene/animation/root_motion_view.cpp
+++ b/scene/animation/root_motion_view.cpp
@@ -103,7 +103,8 @@ void RootMotionView::_notification(int p_what) {
 						set_physics_process_internal(false);
 					}
 
-					transform = tree->get_root_motion_transform();
+					transform.origin = tree->get_root_motion_position();
+					transform.basis = tree->get_root_motion_rotation(); // Scale is meaningless.
 				}
 			}
 
@@ -113,9 +114,8 @@ void RootMotionView::_notification(int p_what) {
 
 			first = false;
 
-			transform.orthonormalize(); //don't want scale, too imprecise
-
-			accumulated = accumulated * transform;
+			accumulated.origin += transform.origin;
+			accumulated.basis *= transform.basis;
 			accumulated.origin.x = Math::fposmod(accumulated.origin.x, cell_size);
 			if (zero_y) {
 				accumulated.origin.y = 0;


### PR DESCRIPTION
Fixes #58061

1. Fix root motion scale
The current root motion scale is completely broken due to incorrect initial values and application process. This PR fix the initial value and the application process, and make the returned  root motion scale to be able to used by the accumulator[^1].

Before with `transform.basis *= root_motion_transform.basis`:

https://user-images.githubusercontent.com/61938263/204078985-7c652d3f-10ce-4eeb-8754-d1a6efe8d53f.mp4

After with accumulator:

https://user-images.githubusercontent.com/61938263/204079001-f90908c8-e7ac-4059-9da2-2dde63210dae.mp4

[rootmotiondemo.zip](https://github.com/godotengine/godot/files/10096515/rootmotiondemo.zip)

2. Match motion in RootMotionView and AnimationPlayer
The apply order of the root motion position and root motion rotation differs between AnimationPlayer and RootMotionView. Considering the order in which Bone Pose is applied, the root motion position shuold not affected by the root motion rotation, so the current motion in RootMotionView is incorrect, fixed.

3. Add sample code to document for apply root motion
In above case, the root motion rotation must respect the object's orientation at the start of the animation. So I added the sample code in the documentation. Also, the scale needs to respect the object's value and accumulator at the start of the animation as well. I added it in the documentation too.

4. Change API `get_root_motion_transform()` to `get_root_motion_position/rotation/scale()`
For these reasons, it makes more sense to separate them as TRS than to take the root motion out as Transform3D.

[^1]: For example, if you animate 4 times and want the Scale to transition like `1` -> `3` -> `5` -> `7`, you do not need to use the accumulator, but If you want to do Scale transitions like `1` -> `3` -> `9` -> `27`, you need accumulator.