### PR TITLE
Fix Window::popup_centered not working with non-default canvas transform

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -25,7 +25,7 @@
 		<method name="get_contents_minimum_size" qualifiers="const">
 			<return type="Vector2" />
 			<description>
-				Returns the combined minimum size from the child [Control] nodes of the window. Use [method child_controls_changed] to update it when children nodes have changed.
+				Returns the combined minimum size from the child [Control] nodes of the window in the Viewport coordinate system. Use [method child_controls_changed] to update it when children nodes have changed.
 			</description>
 		</method>
 		<method name="get_flag" qualifiers="const">

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -276,6 +276,9 @@ Size2 AcceptDialog::_get_contents_minimum_size() const {
 	// Plus there is a separation size added on top.
 	content_minsize.y += theme_cache.buttons_separation;
 
+	// Now adjust according to the viewport scale.
+	content_minsize = get_canvas_transform().get_scale() * content_minsize;
+
 	// Last, we make sure that we aren't below the minimum window size.
 	Size2 window_minsize = get_min_size();
 	content_minsize.x = MAX(window_minsize.x, content_minsize.x);

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -227,7 +227,7 @@ Size2 PopupPanel::_get_contents_minimum_size() const {
 		ms.y = MAX(cms.y, ms.y);
 	}
 
-	return ms + theme_cache.panel_style->get_minimum_size();
+	return get_canvas_transform().get_scale() * (ms + theme_cache.panel_style->get_minimum_size());
 }
 
 void PopupPanel::_update_child_rects() {

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -95,6 +95,8 @@ Size2 PopupMenu::_get_contents_minimum_size() const {
 		minsize.width += check_w;
 	}
 
+	minsize = get_canvas_transform().get_scale() * minsize;
+
 	if (is_inside_tree()) {
 		int height_limit = get_usable_parent_rect().size.height;
 		if (minsize.height > height_limit) {

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1021,7 +1021,7 @@ Size2 Window::_get_contents_minimum_size() const {
 		}
 	}
 
-	return max;
+	return get_canvas_transform().get_scale() * max;
 }
 
 void Window::_update_child_controls() {


### PR DESCRIPTION
`popup_centered` relies on `Window::_get_contents_minimum_size` to get the minimal content size of a window, but `_get_contents_minimum_size` doesn't consider the windows `canvas_transform` scaling, so the sizing doesn't match the content.
This PR makes `_get_contents_minimum_size` aware of the `canvas_transform`.

This also fixes the windows-resizing of embedded Windows with flag `wrap_controls = true`.

MRP: [BugPopupCentered.zip](https://github.com/godotengine/godot/files/10096041/BugPopupCentered.zip)

Before & After with the MRP, where the Window has a `canvas_transform` of scaling `Vector(0.5, 0.5)`:
![image](https://user-images.githubusercontent.com/6299227/204083664-0dfbfacd-5c8a-4266-a186-5b72c69d64b8.png)
![image](https://user-images.githubusercontent.com/6299227/204083692-a51b1b96-dd39-4e5c-8fd9-089b944dbfc1.png)
