### PR TITLE
Add `PackedScene::reload_from_file()` override

### DIFF
--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -360,7 +360,6 @@ Ref<PackedScene> GDScriptCache::get_packed_scene(const String &p_path, Error &r_
 	singleton->packed_scene_cache[p_path] = scene;
 	singleton->packed_scene_dependencies[p_path].insert(p_owner);
 
-	scene->recreate_state();
 	scene->reload_from_file();
 	return scene;
 }

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -143,6 +143,7 @@ public:
 	String get_path() const;
 
 	void clear();
+	Error copy_from(const Ref<SceneState> &p_scene_state);
 
 	bool can_instantiate() const;
 	Node *instantiate(GenEditState p_edit_state) const;
@@ -234,6 +235,8 @@ public:
 
 	void recreate_state();
 	void replace_state(Ref<SceneState> p_by);
+
+	virtual void reload_from_file() override;
 
 	virtual void set_path(const String &p_path, bool p_take_over = false) override;
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
Adds a override to `Resource::reload_from_file()` in `PackedScene`. Without the override, a `PackedScene` loses it's `state`, which can create known and unknown issues, like losing reference of signal connections and the number of unbinds.

Fixes #69190 - Unbinds defined in editor will sometimes not work