### PR TITLE
Clarify that the FPS displayed in the 3D editor viewport is estimated

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2825,7 +2825,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 								Math::remap(gpu_time, 0, 30, 0, 1)));
 
 				const double fps = 1000.0 / gpu_time;
-				fps_label->set_text(vformat(TTR("FPS: %d"), fps));
+				fps_label->set_text(vformat(TTR("FPS: ~%d"), fps));
 				// Middle point is at 60 FPS.
 				fps_label->add_theme_color_override(
 						"font_color",


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/69218.

It may be a good idea to implement CPU/GPU utilization queries in Godot, so we can display the CPU/GPU usage percentage in this panel as well. This way, you can see whether your CPU/GPU are being fully utilized or not.