### PR TITLE
Fix focus after pressing Enter in EditorSpinSlider

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -582,6 +582,7 @@ void EditorSpinSlider::_value_focus_exited() {
 		//tab was pressed
 	} else {
 		//enter, click, esc
+		grab_focus();
 	}
 }
 


### PR DESCRIPTION
With the change from Popup to Controls for the Input-Node in #67397, it becomes necessary to adjust focus after hiding the Input-Node back to the initial Control.

resolve #69160