### PR TITLE
Fix `Curve3D::get_closest_point()` broken

### DIFF
--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -64,7 +64,7 @@
 			<return type="Vector3" />
 			<param index="0" name="to_point" type="Vector3" />
 			<description>
-				Returns the closest baked point (in curve's local space) to [param to_point].
+				Returns the closest point on baked segments (in curve's local space) to [param to_point].
 				[param to_point] must be in this curve's local space.
 			</description>
 		</method>


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/69220

The problem is caused by calling adaptive tessellation baking function by mistake, which produce too few points for straight lines. Calling the even length tessellation fix the problem. The code for `get_closest_point()` and `get_closest_offset()` are also updated. They used to assume bake interval to be exact, which is no longer true.

The out dated document for `get_closest_point()` is also updated.

Fix https://github.com/godotengine/godot/issues/69507 as a by product, which is caused by a typo. (`size_t` instead of `real_t`)

All fixes have been applied to the Curve2D counterpart https://github.com/godotengine/godot/pull/69115.