### PR TITLE
Support to remove, edit and store user defined signals

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -149,6 +149,8 @@ enum PropertyUsageFlags {
 #define ADD_ARRAY_COUNT_WITH_USAGE_FLAGS(m_label, m_count_property, m_count_property_setter, m_count_property_getter, m_prefix, m_property_usage_flags) ClassDB::add_property_array_count(get_class_static(), m_label, m_count_property, _scs_create(m_count_property_setter), _scs_create(m_count_property_getter), m_prefix, m_property_usage_flags)
 #define ADD_ARRAY(m_array_path, m_prefix) ClassDB::add_property_array(get_class_static(), m_array_path, m_prefix)
 
+#define META_USER_SIGNALS "_user_signals"
+
 // Helper macro to use with PROPERTY_HINT_ARRAY_TYPE for arrays of specific resources:
 // PropertyInfo(Variant::ARRAY, "fallbacks", PROPERTY_HINT_ARRAY_TYPE, MAKE_RESOURCE_TYPE_HINT("Font")
 #define MAKE_RESOURCE_TYPE_HINT(m_type) vformat("%s/%s:%s", Variant::OBJECT, PROPERTY_HINT_RESOURCE_TYPE, m_type)
@@ -617,7 +619,8 @@ private:
 	mutable StringName _class_name;
 	mutable const StringName *_class_ptr = nullptr;
 
-	void _add_user_signal(const String &p_name, const Array &p_args = Array());
+	void _add_user_signal(const String &p_name, const Array &p_args = Array(), const bool &p_persistent = false);
+	void _remove_user_signal(const String &p_name);
 	bool _has_user_signal(const StringName &p_name) const;
 	Error _emit_signal(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 	TypedArray<Dictionary> _get_signal_list() const;

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -265,8 +265,9 @@
 			<return type="void" />
 			<param index="0" name="signal" type="String" />
 			<param index="1" name="arguments" type="Array" default="[]" />
+			<param index="2" name="persistent" type="bool" default="false" />
 			<description>
-				Adds a user-defined [param signal]. Optional arguments for the signal can be added as an [Array] of dictionaries, each defining a [code]name[/code] [String] and a [code]type[/code] [int] (see [enum Variant.Type]). See also [method has_user_signal].
+				Adds a new user-defined [param signal] or overrides existing. Optional arguments for the signal can be added as an [Array] of dictionaries, each defining a [code]name[/code] [String] and [code]type[/code] [int] (see [enum Variant.Type]), and optionally [code]hint[/code] [int] (see [enum PropertyHint]) and [code]hint_string[/code] [String].
 				[codeblocks]
 				[gdscript]
 				add_user_signal("hurt", [
@@ -290,6 +291,7 @@
 				});
 				[/csharp]
 				[/codeblocks]
+				To store the signal persistently and automatically declare it when instantiating the scene, set the third argument [code]persistent[/code] to [code]true[/code]. If not set or [code]false[/code] makes an existing signal non-persistent. See also [method has_user_signal] and [method remove_user_signal].
 			</description>
 		</method>
 		<method name="call" qualifiers="vararg">
@@ -770,6 +772,13 @@
 			<description>
 				Removes the given entry [param name] from the object's metadata. See also [method has_meta], [method get_meta] and [method set_meta].
 				[b]Note:[/b] Metadata that has a [param name] starting with an underscore ([code]_[/code]) is considered editor-only. Editor-only metadata is not displayed in the Inspector and should not be edited.
+			</description>
+		</method>
+		<method name="remove_user_signal">
+			<return type="void" />
+			<param index="0" name="signal" type="String" />
+			<description>
+				Removes the previously added user-defined [param signal], if it exists. Only removes signals added with [method add_user_signal].
 			</description>
 		</method>
 		<method name="set">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

## Feature (updated)
Adds support to:
1. Override a previously added user signal. 
2. Support to add full `PropertyInfo` for user signal arguments - not only picking `name` and `type`.
3. Remove an existing user signal by `remove_user_signal(name)` method.
4. Also adds support to add the signal persistently (using `_user_signals` meta data) and auto-declare the signal when the scene is instatiated. This is done via optional 3rd argument in the `add_user_signal(name, args=[], persistent=false)` method.

## GDScript examples
Feature 1: Allow to modify existing user signals.

    add_user_signal("my_signal")
    add_user_signal("my_signal", [ { name = "first_arg", type = TYPE_INT } ])

Feature 2: Full support for property infos.

     add_user_signal("my_signal", [ { name = "mode", type = TYPE_INT, hint = PROPERTY_HINT_ENUM, hint_string = "one,two" }])
    
Feature 3: Allow to remove an existing signal.

    remove_user_signal("my_signal")

Feature 4: Store the signal persistently.

    add_user_signal("my_signal", [], true)

## Implementation
The implementation for 1-3 is very straight forward:
1. Just removed the check that prevented re-adding the signal into `signal_map` hashmap. If wants to prevent adding an already existing signal, should use `has_user_signal(name)` before.
2. Changed the manual picking of name and type to using `PropertyInfo::from_dict()` method.
3. Added a method to remove the user signal from the `signal_map`.

The feature for persistent user signals (4) is implemented by:
- Storing the signal using `_user_signals` meta data, which is an array of dictionaries: `[ { name, args }, ... ]`.
- When a packed scene is instantiated, checks if has meta data and if so loops the array and declares all the signals. This part is done after adds to groups and before corrects the naming.

Also modified the docs (in Object.xml) accordingly.

## Why
The purpose of this commit is to allow better setting up of dynamic (=user declared) signals when preparing scenes in the editor. The user may modify the signal arguments (= override) or rename the signal (remove + add) while developing the game scene (eg. using some tool using these methods), and then to use the newly generated signals to hook up to more things in the scene.

Note. In general terms, the user signals feature (= scriptless signals) is very useful, for example, for cases where several different game objects share the same root script (eg. using a common modular node structure), but want to provide custom signals that are emitted from somewhere within (eg. by features of one of those modules). For example, a helpless creature with a custom "panic" signal. (In this sense user signals are a bit like meta data - independent of the script.) So this commit aims to enhance / complete the existing feature set.

## Further thoughts

(feature 5:) To totally complete this idea of "user signals" feature, the editor could provide a way to edit the user signals manually - just like it provides a way to edit persistent group names and meta data.

But at minimum, I'd at least like to change 1. `add_user_signal` to override the earlier signal, 2. add suppor for hint etc., and 3. to add `remove_user_signal`. If the 4. concept of persistent is "not worth it" (in larger context), or the implementation not good (eg. maybe meta data not the cleanest way(?)), then I'd like to reduce this PR to those three main aspects. (But I believe making signals as editor-editable as groups and meta data enhances flexibility of the Godot architecture.)