### PR TITLE
Update TileSet preview when paint custom data changes

### DIFF
--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -851,6 +851,7 @@ GenericTilePolygonEditor::GenericTilePolygonEditor() {
 void TileDataDefaultEditor::_property_value_changed(StringName p_property, Variant p_value, StringName p_field) {
 	ERR_FAIL_COND(!dummy_object);
 	dummy_object->set(p_property, p_value);
+	emit_signal(SNAME("needs_redraw"));
 }
 
 Variant TileDataDefaultEditor::_get_painted_value() {


### PR DESCRIPTION
When editing a TileSet, the paint tool can paint custom data onto tiles. In the preview area, each tile draws the current value of that custom data.

Values matching the current selected value is drawn using a different color. But currently the preview is only redrawn when the mouse moves onto that area. This PR makes it redrawn when as soon as that value updates.

<table>
<tr><th>Before</th><td>
You have to move the mouse onto the preview area to trigger the update.

![before](https://user-images.githubusercontent.com/372476/204131290-5af0d453-43a9-4145-b50e-943c8c17e60c.gif)
</td></tr>
<tr><th>After</th><td>
Preview updates as soon as the value updates.

![after](https://user-images.githubusercontent.com/372476/204131291-70f2d5dc-19b2-4d7b-92fd-a42dee71199b.gif)
</td></tr>
</table>

p.s. This also applies when painting other properties, since it's an `TileDataDefaultEditor` update.