### PR TITLE
Fixed the canvas group owner not setting canvas_group_owner when no visible child nodes

### DIFF
--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -212,6 +212,11 @@ void RendererCanvasCull::_attach_canvas_item_for_draw(RendererCanvasCull::Item *
 			ci->next = nullptr;
 		}
 
+		// The canvas group owner has not set canvas_group_owner.
+		if (ci->canvas_group != nullptr && ci->canvas_group_owner == nullptr) {
+			ci->canvas_group_owner = ci;
+		}
+
 		if (ci->visibility_notifier) {
 			if (!ci->visibility_notifier->visible_element.in_list()) {
 				visibility_notifier_list.add(&ci->visibility_notifier->visible_element);


### PR DESCRIPTION
Fixes #69179.
This is a quick fix, there might be a better solution.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
| Before | After |
| :------: | :------: |
|![1](https://user-images.githubusercontent.com/30386067/204133166-21c0a863-ea7b-4970-b5d0-37cc844b2f16.png) | ![0](https://user-images.githubusercontent.com/30386067/204133172-7af0be19-7306-4b1f-a4e4-461cb7ec3d6d.png) |



[clip-children-test.zip](https://github.com/godotengine/godot/files/10098185/clip-children-test.zip)

