### PR TITLE
Revert "`SceneTree` Fix storing removed nodes to be skipped by the group calls"

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -123,9 +123,6 @@ void SceneTree::tree_changed() {
 
 void SceneTree::node_added(Node *p_node) {
 	emit_signal(node_added_name, p_node);
-	if (call_lock > 0) {
-		call_skip.erase(p_node->get_instance_id());
-	}
 }
 
 void SceneTree::node_removed(Node *p_node) {
@@ -134,7 +131,7 @@ void SceneTree::node_removed(Node *p_node) {
 	}
 	emit_signal(node_removed_name, p_node);
 	if (call_lock > 0) {
-		call_skip.insert(p_node->get_instance_id());
+		call_skip.insert(p_node);
 	}
 }
 
@@ -264,7 +261,7 @@ void SceneTree::call_group_flagsp(uint32_t p_call_flags, const StringName &p_gro
 
 	if (p_call_flags & GROUP_CALL_REVERSE) {
 		for (int i = gr_node_count - 1; i >= 0; i--) {
-			if (call_lock && call_skip.has(gr_nodes[i]->get_instance_id())) {
+			if (call_lock && call_skip.has(gr_nodes[i])) {
 				continue;
 			}
 
@@ -278,7 +275,7 @@ void SceneTree::call_group_flagsp(uint32_t p_call_flags, const StringName &p_gro
 
 	} else {
 		for (int i = 0; i < gr_node_count; i++) {
-			if (call_lock && call_skip.has(gr_nodes[i]->get_instance_id())) {
+			if (call_lock && call_skip.has(gr_nodes[i])) {
 				continue;
 			}
 
@@ -317,7 +314,7 @@ void SceneTree::notify_group_flags(uint32_t p_call_flags, const StringName &p_gr
 
 	if (p_call_flags & GROUP_CALL_REVERSE) {
 		for (int i = gr_node_count - 1; i >= 0; i--) {
-			if (call_lock && call_skip.has(gr_nodes[i]->get_instance_id())) {
+			if (call_lock && call_skip.has(gr_nodes[i])) {
 				continue;
 			}
 
@@ -330,7 +327,7 @@ void SceneTree::notify_group_flags(uint32_t p_call_flags, const StringName &p_gr
 
 	} else {
 		for (int i = 0; i < gr_node_count; i++) {
-			if (call_lock && call_skip.has(gr_nodes[i]->get_instance_id())) {
+			if (call_lock && call_skip.has(gr_nodes[i])) {
 				continue;
 			}
 
@@ -368,7 +365,7 @@ void SceneTree::set_group_flags(uint32_t p_call_flags, const StringName &p_group
 
 	if (p_call_flags & GROUP_CALL_REVERSE) {
 		for (int i = gr_node_count - 1; i >= 0; i--) {
-			if (call_lock && call_skip.has(gr_nodes[i]->get_instance_id())) {
+			if (call_lock && call_skip.has(gr_nodes[i])) {
 				continue;
 			}
 
@@ -381,7 +378,7 @@ void SceneTree::set_group_flags(uint32_t p_call_flags, const StringName &p_group
 
 	} else {
 		for (int i = 0; i < gr_node_count; i++) {
-			if (call_lock && call_skip.has(gr_nodes[i]->get_instance_id())) {
+			if (call_lock && call_skip.has(gr_nodes[i])) {
 				continue;
 			}
 
@@ -857,7 +854,7 @@ void SceneTree::_notify_group_pause(const StringName &p_group, int p_notificatio
 
 	for (int i = 0; i < gr_node_count; i++) {
 		Node *n = gr_nodes[i];
-		if (call_lock && call_skip.has(n->get_instance_id())) {
+		if (call_lock && call_skip.has(n)) {
 			continue;
 		}
 
@@ -907,7 +904,7 @@ void SceneTree::_call_input_pause(const StringName &p_group, CallInputType p_cal
 		}
 
 		Node *n = gr_nodes[i];
-		if (call_lock && call_skip.has(n->get_instance_id())) {
+		if (call_lock && call_skip.has(n)) {
 			continue;
 		}
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -135,7 +135,7 @@ private:
 
 	// Safety for when a node is deleted while a group is being called.
 	int call_lock = 0;
-	HashSet<ObjectID> call_skip; // Skip erased nodes. Store ID instead of pointer to avoid false positives when node is freed and a new node is allocated at the pointed address.
+	HashSet<Node *> call_skip; // Skip erased nodes.
 
 	List<ObjectID> delete_queue;
 


### PR DESCRIPTION
Reverts godotengine/godot#67831

- Fixed #69159
- Reopens #67819
- Reopens #44765