### PR TITLE
Fix transparent color fading when enable `clip_children`

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -2665,8 +2665,7 @@ void fragment() {
 shader_type canvas_item;
 
 void fragment() {
-	vec4 c = textureLod(SCREEN_TEXTURE, SCREEN_UV, 0.0);
-	COLOR.rgb = c.rgb;
+	COLOR = textureLod(SCREEN_TEXTURE, SCREEN_UV, 0.0);
 }
 )");
 		default_clip_children_material = material_storage->material_allocate();

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2747,8 +2747,7 @@ void fragment() {
 shader_type canvas_item;
 
 void fragment() {
-	vec4 c = textureLod(SCREEN_TEXTURE, SCREEN_UV, 0.0);
-	COLOR.rgb = c.rgb;
+	COLOR = textureLod(SCREEN_TEXTURE, SCREEN_UV, 0.0);
 }
 )");
 		default_clip_children_material = material_storage->material_allocate();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

| Before | After | Mode |
| :-------: | :------: | :-----: |
| ![0](https://user-images.githubusercontent.com/30386067/204138231-9e45886b-2916-411d-9bb3-22e891a72276.png) | ![1](https://user-images.githubusercontent.com/30386067/204138232-e991adf4-2f63-49a6-bf34-a2ed00f819ad.png) |  `CLIP_CHILDREN_AND_DRAW` |
| ![2](https://user-images.githubusercontent.com/30386067/204138526-1f4d2058-f699-4ea3-976d-6946b756da14.png) | ![3](https://user-images.githubusercontent.com/30386067/204138529-7024991b-b7df-4252-bf94-07f6520e15b6.png) | `CLIP_CHILDREN_ONLY` |






[clip-children-transparent-fading.zip](https://github.com/godotengine/godot/files/10098426/clip-children-transparent-fading.zip)

