### PR TITLE
Fix cyclic reference base being loaded but not valid (which is ok)

### DIFF
--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -260,7 +260,7 @@ Ref<GDScript> GDScriptCache::get_full_script(const String &p_path, Error &r_erro
 	Ref<GDScript> script;
 	r_error = OK;
 	if (singleton->full_gdscript_cache.has(p_path)) {
-		script = Ref<GDScript>(singleton->full_gdscript_cache[p_path]);
+		script = singleton->full_gdscript_cache[p_path];
 		if (!p_update_from_disk) {
 			return script;
 		}

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2284,7 +2284,7 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 					_set_error(vformat(R"(Could not find class "%s" in "%s".)", base->fully_qualified_name, base->path), nullptr);
 					return ERR_COMPILATION_FAILED;
 				}
-				ERR_FAIL_COND_V(!base->is_valid(), ERR_BUG);
+				ERR_FAIL_COND_V(!base->is_valid() && !base->reloading, ERR_BUG);
 			}
 
 			p_script->base = base;


### PR DESCRIPTION
In some cases, a script from `GDScriptCache::get_full_script()` can be not null, but invalid. In the context of cyclic references and while populating class members (`GDScriptCompiler::_populate_class_members()`), the test was too strict and was issuing an error even if the script itself is usable.

This was breaking seemingly valid code that was working in previous betas.

Making the tests more lax seems to be the right thing to do.

Fixes #69213