### PR TITLE
Acknowledge that a CLASS kind of a DataType might not have an identifier

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3785,15 +3785,14 @@ bool GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node
 				}
 				break;
 			case GDScriptParser::DataType::CLASS:
-				// Can assume type is a global GDScript class.
 				if (ClassDB::is_parent_class(export_type.native_type, SNAME("Resource"))) {
 					variable->export_info.type = Variant::OBJECT;
 					variable->export_info.hint = PROPERTY_HINT_RESOURCE_TYPE;
-					variable->export_info.hint_string = export_type.class_type->identifier->name;
+					variable->export_info.hint_string = export_type.to_string();
 				} else if (ClassDB::is_parent_class(export_type.native_type, SNAME("Node"))) {
 					variable->export_info.type = Variant::OBJECT;
 					variable->export_info.hint = PROPERTY_HINT_NODE_TYPE;
-					variable->export_info.hint_string = export_type.class_type->identifier->name;
+					variable->export_info.hint_string = export_type.to_string();
 				} else {
 					push_error(R"(Export type can only be built-in, a resource, a node or an enum.)", variable);
 					return false;


### PR DESCRIPTION
In the case of a `preload()`ed Resource that will be later used for a `@export var typed_array : Array[MyRes]` identifier is `nullptr` which leads to a quick death by a segfault when trying to set the hint. Looking at the `to_string()` method it seems for a very long time we assumed that this might be the case, but we don't do it know.

Other explanation is that when `set_container_element_type()` is called a non-fully initialized `DataType` for a class is passed, for some reason.

*Bugsquad edit:*
- Fixes #69236