### PR TITLE
[Windows] Fix joypad crash

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3919,6 +3919,8 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 	WindowID main_window = _create_window(p_mode, p_vsync_mode, 0, Rect2i(window_position, p_resolution));
 	ERR_FAIL_COND_MSG(main_window == INVALID_WINDOW_ID, "Failed to create main window.");
 
+	joypad = new JoypadWindows(&windows[MAIN_WINDOW_ID].hWnd);
+
 	for (int i = 0; i < WINDOW_FLAG_MAX; i++) {
 		if (p_flags & (1 << i)) {
 			window_set_flag(WindowFlags(i), true, main_window);
@@ -3957,8 +3959,6 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 	cursor_shape = CURSOR_ARROW;
 
 	_update_real_mouse_position(MAIN_WINDOW_ID);
-
-	joypad = new JoypadWindows(&windows[MAIN_WINDOW_ID].hWnd);
 
 	r_error = OK;
 


### PR DESCRIPTION
Fixes #69275

The bug report didn't have Windows symbols loaded, but it looks like `ShowWindow` can cause messages to be processed in the `WNDPROC` callback.

Since Godot's window callback may use `joypad`, it should be constructed before that can happen.