### PR TITLE
Remove unnecessary namespaces in generated PropertyDefVal files.

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
@@ -78,10 +78,6 @@ namespace Godot.SourceGenerators
 
             var source = new StringBuilder();
 
-            source.Append("using Godot;\n");
-            source.Append("using Godot.NativeInterop;\n");
-            source.Append("\n");
-
             if (hasNamespace)
             {
                 source.Append("namespace ");
@@ -281,7 +277,7 @@ namespace Godot.SourceGenerators
             {
                 source.Append("#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword\n");
 
-                string dictionaryType = "System.Collections.Generic.Dictionary<StringName, object>";
+                string dictionaryType = "System.Collections.Generic.Dictionary<Godot.StringName, object>";
 
                 source.Append("#if TOOLS\n");
                 source.Append("    internal new static ");


### PR DESCRIPTION
These namespaces are no longer needed after #68580 was merged.