### PR TITLE
Windows: Link MSVC dynamic debug CRT for debug builds

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -339,10 +339,14 @@ def configure_msvc(env, vcvars_msvc_config):
 
     ## Compile/link flags
 
-    if env["use_static_cpp"]:
-        env.AppendUnique(CCFLAGS=["/MT"])
+    if env["optimize"] in ["debug", "none"]:
+        # Always use dynamic runtime, static debug CRT breaks thread_local.
+        env.AppendUnique(CCFLAGS=["/MDd"])
     else:
-        env.AppendUnique(CCFLAGS=["/MD"])
+        if env["use_static_cpp"]:
+            env.AppendUnique(CCFLAGS=["/MT"])
+        else:
+            env.AppendUnique(CCFLAGS=["/MD"])
 
     if env["arch"] == "x86_32":
         env["x86_libtheora_opt_vc"] = True


### PR DESCRIPTION
Fixes #31608.

*Edit:* See #69609, it's now opt-in behind the `debug_crt=yes` option.

Didn't test, please confirm if this works as expected.

See https://github.com/godotengine/godot-cpp/pull/932 for a similar change in godot-cpp (CC @Faless).

And https://developercommunity.visualstudio.com/t/race-condition-on-g-tss-mutex-with-static-crt/672664 for a reference on the MSVC static CRT bug. Might be worth testing with newer MSVC to see if it's still broken.