### PR TITLE
Change is_valid_identifier() in ustring to be similar to is_valid_identifier() in text_server.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3861,8 +3861,12 @@ bool String::is_valid_identifier() const {
 
 	const char32_t *str = &operator[](0);
 
-	for (int i = 0; i < len; i++) {
-		if (!_is_valid_identifier_bit(i, str[i])) {
+	if (!is_unicode_identifier_start(str[0])) {
+		return false;
+	}
+
+	for (int i = 1; i < len; i++) {
+		if (!is_unicode_identifier_continue(str[i])) {
 			return false;
 		}
 	}


### PR DESCRIPTION
Make it possible to use UTF in places like in the image below.

![image](https://user-images.githubusercontent.com/14800320/204287034-2d495e4f-f39a-4890-8949-61de63be71c4.png)
