### PR TITLE
Improve TileSetAtlasSourceEditor UI

### DIFF
--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -1207,8 +1207,6 @@ TileDataDefaultEditor::TileDataDefaultEditor() {
 	label->set_theme_type_variation("HeaderSmall");
 	add_child(label);
 
-	toolbar->add_child(memnew(VSeparator));
-
 	picker_button = memnew(Button);
 	picker_button->set_flat(true);
 	picker_button->set_toggle_mode(true);
@@ -2659,8 +2657,6 @@ TileDataTerrainsEditor::TileDataTerrainsEditor() {
 	add_child(label);
 
 	// Toolbar
-	toolbar->add_child(memnew(VSeparator));
-
 	picker_button = memnew(Button);
 	picker_button->set_flat(true);
 	picker_button->set_toggle_mode(true);

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -42,8 +42,8 @@ class TileSet;
 class Tree;
 class VSeparator;
 
-class TileSetAtlasSourceEditor : public HBoxContainer {
-	GDCLASS(TileSetAtlasSourceEditor, HBoxContainer);
+class TileSetAtlasSourceEditor : public HSplitContainer {
+	GDCLASS(TileSetAtlasSourceEditor, HSplitContainer);
 
 public:
 	// A class to store which tiles are selected.
@@ -77,7 +77,7 @@ public:
 
 	public:
 		void set_id(int p_id);
-		int get_id();
+		int get_id() const;
 
 		void edit(Ref<TileSet> p_tile_set, TileSetAtlasSource *p_tile_set_atlas_source, int p_source_id);
 		TileSetAtlasSource *get_edited() { return tile_set_atlas_source; };
@@ -137,19 +137,15 @@ private:
 
 	// -- Inspector --
 	AtlasTileProxyObject *tile_proxy_object = nullptr;
-	Label *tile_inspector_label = nullptr;
 	EditorInspector *tile_inspector = nullptr;
 	Label *tile_inspector_no_tile_selected_label = nullptr;
 	String selected_property;
 	void _inspector_property_selected(String p_property);
 
 	TileSetAtlasSourceProxyObject *atlas_source_proxy_object = nullptr;
-	Label *atlas_source_inspector_label = nullptr;
 	EditorInspector *atlas_source_inspector = nullptr;
 
 	// -- Atlas view --
-	HBoxContainer *toolbox = nullptr;
-	Label *tile_atlas_view_missing_source_label = nullptr;
 	TileAtlasView *tile_atlas_view = nullptr;
 
 	// Dragging
@@ -210,7 +206,6 @@ private:
 
 	// Tool settings.
 	HBoxContainer *tool_settings = nullptr;
-	VSeparator *tool_settings_vsep = nullptr;
 	HBoxContainer *tool_settings_tile_data_toolbar_container = nullptr;
 	Button *tools_settings_erase_button = nullptr;
 	MenuButton *tool_advanced_menu_buttom = nullptr;


### PR DESCRIPTION
Based on my mockup posted on RocketChat: https://chat.godotengine.org/channel/editor?msg=DAb8wAnQ4z3LkyDnE

* The three mode buttons are moved to the top and texts are added. This makes it easier to know what you can do / what you are doing.
* Uses inspector category instead of a Label to show what's being edited. This also allows better scrolling behavior.

<table>
<tr><th>Before</th><td>

![before](https://user-images.githubusercontent.com/372476/204284780-23e134a9-c0c5-4ebd-afec-3501ad080730.gif)
</td></tr>
<tr><th>After</th><td>

![after](https://user-images.githubusercontent.com/372476/206606821-a3fda008-f12f-4004-a8e5-9bfba5c74896.gif)
</td></tr>
</table>

---

The subtle vertical movement of main area when one tile is selected/deselected is caused by the top right tile info label showing / hiding. It's an issue that existed before this PR. I tried to fix it in this PR, but there does not seem to be a nice approach.