### PR TITLE
Fix audio track end and start offset editing

### DIFF
--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -857,18 +857,14 @@ void AnimationTrackEditTypeAudio::draw_key(int p_index, float p_pixels_sec, int 
 	float start_ofs = get_animation()->audio_track_get_key_start_offset(get_track(), p_index);
 	float end_ofs = get_animation()->audio_track_get_key_end_offset(get_track(), p_index);
 
+	int px_offset = 0;
 	if (len_resizing && p_index == len_resizing_index) {
-		float ofs_local = -len_resizing_rel / get_timeline()->get_zoom_scale();
+		float ofs_local = len_resizing_rel / get_timeline()->get_zoom_scale();
 		if (len_resizing_start) {
 			start_ofs += ofs_local;
-			if (start_ofs < 0) {
-				start_ofs = 0;
-			}
+			px_offset = ofs_local * p_pixels_sec;
 		} else {
-			end_ofs += ofs_local;
-			if (end_ofs < 0) {
-				end_ofs = 0;
-			}
+			end_ofs -= ofs_local;
 		}
 	}
 
@@ -897,8 +893,8 @@ void AnimationTrackEditTypeAudio::draw_key(int p_index, float p_pixels_sec, int 
 
 	int pixel_len = len * p_pixels_sec;
 
-	int pixel_begin = p_x;
-	int pixel_end = p_x + pixel_len;
+	int pixel_begin = px_offset + p_x;
+	int pixel_end = px_offset + p_x + pixel_len;
 
 	if (pixel_end < p_clip_left) {
 		return;
@@ -1061,9 +1057,6 @@ void AnimationTrackEditTypeAudio::gui_input(const Ref<InputEvent> &p_event) {
 
 			len -= end_ofs;
 			len -= start_ofs;
-			if (len <= 0.001) {
-				len = 0.001;
-			}
 
 			if (get_animation()->track_get_key_count(get_track()) > i + 1) {
 				len = MIN(len, get_animation()->track_get_key_time(get_track(), i + 1) - get_animation()->track_get_key_time(get_track(), i));
@@ -1078,6 +1071,13 @@ void AnimationTrackEditTypeAudio::gui_input(const Ref<InputEvent> &p_event) {
 			int end = ofs + len * get_timeline()->get_zoom_scale();
 
 			if (end >= get_timeline()->get_name_limit() && end <= get_size().width - get_timeline()->get_buttons_width() && ABS(mm->get_position().x - end) < 5 * EDSCALE) {
+				len_resizing_start = false;
+				use_hsize_cursor = true;
+				len_resizing_index = i;
+			}
+
+			if (ofs >= get_timeline()->get_name_limit() && ofs <= get_size().width - get_timeline()->get_buttons_width() && ABS(mm->get_position().x - ofs) < 5 * EDSCALE) {
+				len_resizing_start = true;
 				use_hsize_cursor = true;
 				len_resizing_index = i;
 			}
@@ -1086,8 +1086,25 @@ void AnimationTrackEditTypeAudio::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (len_resizing && mm.is_valid()) {
+		// Rezising index is some.
 		len_resizing_rel += mm->get_relative().x;
-		len_resizing_start = mm->is_shift_pressed();
+		float ofs_local = len_resizing_rel / get_timeline()->get_zoom_scale();
+		float prev_ofs_start = get_animation()->audio_track_get_key_start_offset(get_track(), len_resizing_index);
+		float prev_ofs_end = get_animation()->audio_track_get_key_end_offset(get_track(), len_resizing_index);
+		Ref<AudioStream> stream = get_animation()->audio_track_get_key_stream(get_track(), len_resizing_index);
+		float len = stream->get_length();
+		if (len == 0) {
+			Ref<AudioStreamPreview> preview = AudioStreamPreviewGenerator::get_singleton()->generate_preview(stream);
+			float preview_len = preview->get_length();
+			len = preview_len;
+		}
+
+		if (len_resizing_start) {
+			len_resizing_rel = CLAMP(ofs_local, -prev_ofs_start, len - prev_ofs_end - prev_ofs_start) * get_timeline()->get_zoom_scale();
+		} else {
+			len_resizing_rel = CLAMP(ofs_local, -(len - prev_ofs_end - prev_ofs_start), prev_ofs_end) * get_timeline()->get_zoom_scale();
+		}
+
 		queue_redraw();
 		accept_event();
 		return;
@@ -1096,7 +1113,11 @@ void AnimationTrackEditTypeAudio::gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT && over_drag_position) {
 		len_resizing = true;
-		len_resizing_start = mb->is_shift_pressed();
+		// In case if resizing index is not set yet reset the flag.
+		if (len_resizing_index < 0) {
+			len_resizing = false;
+			return;
+		}
 		len_resizing_from_px = mb->get_position().x;
 		len_resizing_rel = 0;
 		queue_redraw();
@@ -1106,23 +1127,42 @@ void AnimationTrackEditTypeAudio::gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<EditorUndoRedoManager> &undo_redo = EditorNode::get_undo_redo();
 	if (len_resizing && mb.is_valid() && !mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
-		float ofs_local = -len_resizing_rel / get_timeline()->get_zoom_scale();
-		if (len_resizing_start) {
-			float prev_ofs = get_animation()->audio_track_get_key_start_offset(get_track(), len_resizing_index);
-			undo_redo->create_action(TTR("Change Audio Track Clip Start Offset"));
-			undo_redo->add_do_method(get_animation().ptr(), "audio_track_set_key_start_offset", get_track(), len_resizing_index, prev_ofs + ofs_local);
-			undo_redo->add_undo_method(get_animation().ptr(), "audio_track_set_key_start_offset", get_track(), len_resizing_index, prev_ofs);
-			undo_redo->commit_action();
+		if (len_resizing_rel == 0 || len_resizing_index < 0) {
+			len_resizing = false;
+			return;
+		}
 
+		if (len_resizing_start) {
+			float ofs_local = len_resizing_rel / get_timeline()->get_zoom_scale();
+			float prev_ofs = get_animation()->audio_track_get_key_start_offset(get_track(), len_resizing_index);
+			float prev_time = get_animation()->track_get_key_time(get_track(), len_resizing_index);
+			float new_ofs = prev_ofs + ofs_local;
+			float new_time = prev_time + ofs_local;
+			if (prev_time != new_time) {
+				undo_redo->create_action(TTR("Change Audio Track Clip Start Offset"));
+
+				undo_redo->add_do_method(get_animation().ptr(), "track_set_key_time", get_track(), len_resizing_index, new_time);
+				undo_redo->add_undo_method(get_animation().ptr(), "track_set_key_time", get_track(), len_resizing_index, prev_time);
+
+				undo_redo->add_do_method(get_animation().ptr(), "audio_track_set_key_start_offset", get_track(), len_resizing_index, new_ofs);
+				undo_redo->add_undo_method(get_animation().ptr(), "audio_track_set_key_start_offset", get_track(), len_resizing_index, prev_ofs);
+
+				undo_redo->commit_action();
+			}
 		} else {
+			float ofs_local = -len_resizing_rel / get_timeline()->get_zoom_scale();
 			float prev_ofs = get_animation()->audio_track_get_key_end_offset(get_track(), len_resizing_index);
-			undo_redo->create_action(TTR("Change Audio Track Clip End Offset"));
-			undo_redo->add_do_method(get_animation().ptr(), "audio_track_set_key_end_offset", get_track(), len_resizing_index, prev_ofs + ofs_local);
-			undo_redo->add_undo_method(get_animation().ptr(), "audio_track_set_key_end_offset", get_track(), len_resizing_index, prev_ofs);
-			undo_redo->commit_action();
+			float new_ofs = prev_ofs + ofs_local;
+			if (prev_ofs != new_ofs) {
+				undo_redo->create_action(TTR("Change Audio Track Clip End Offset"));
+				undo_redo->add_do_method(get_animation().ptr(), "audio_track_set_key_end_offset", get_track(), len_resizing_index, new_ofs);
+				undo_redo->add_undo_method(get_animation().ptr(), "audio_track_set_key_end_offset", get_track(), len_resizing_index, prev_ofs);
+				undo_redo->commit_action();
+			}
 		}
 
 		len_resizing_index = -1;
+		len_resizing = false;
 		queue_redraw();
 		accept_event();
 		return;


### PR DESCRIPTION
Fixes #68788. Both start and end offset dragging is now possible with proper preview of the changes