### PR TITLE
Fix AABB merge failing

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -442,10 +442,17 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 			// Each surface may affect different numbers of bones.
 			mesh->bone_aabbs.resize(p_surface.bone_aabbs.size());
 		}
+
 		for (int i = 0; i < p_surface.bone_aabbs.size(); i++) {
 			const AABB &bone = p_surface.bone_aabbs[i];
-			if (bone.has_volume()) {
+			if (!bone.has_volume()) {
+				continue;
+			}
+
+			if (mesh->bone_aabbs[i].has_volume()) {
 				mesh->bone_aabbs.write[i].merge_with(bone);
+			} else {
+				mesh->bone_aabbs.write[i] = bone;
 			}
 		}
 		mesh->aabb.merge_with(p_surface.aabb);


### PR DESCRIPTION
This now merges when it's possible only and assigns in the case where only one of the AABB's is valid.

Previous behaviour was the merge would fail when assignment could be done instead, and it would repeatedly spam the user.