### PR TITLE
[3.x] GLTF: Move shared defines into a file and only list used extensions

### DIFF
--- a/modules/gltf/gltf_accessor.cpp
+++ b/modules/gltf/gltf_accessor.cpp
@@ -65,7 +65,7 @@ void GLTFAccessor::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "component_type"), "set_component_type", "get_component_type"); // int
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "normalized"), "set_normalized", "get_normalized"); // bool
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "count"), "set_count", "get_count"); // int
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "type"), "set_type", "get_type"); // GLTFDocument::GLTFType
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "type"), "set_type", "get_type"); // GLTFType
 	ADD_PROPERTY(PropertyInfo(Variant::POOL_REAL_ARRAY, "min"), "set_min", "get_min"); // Vector<real_t>
 	ADD_PROPERTY(PropertyInfo(Variant::POOL_REAL_ARRAY, "max"), "set_max", "get_max"); // Vector<real_t>
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sparse_count"), "set_sparse_count", "get_sparse_count"); // int
@@ -121,7 +121,7 @@ int GLTFAccessor::get_type() {
 }
 
 void GLTFAccessor::set_type(int p_type) {
-	type = (GLTFDocument::GLTFType)p_type; // TODO: Register enum
+	type = (GLTFType)p_type; // TODO: Register enum
 }
 
 PoolVector<float> GLTFAccessor::get_min() {

--- a/modules/gltf/gltf_accessor.h
+++ b/modules/gltf/gltf_accessor.h
@@ -32,8 +32,7 @@
 #define GLTF_ACCESSOR_H
 
 #include "core/resource.h"
-
-#include "gltf_document.h"
+#include "gltf_defines.h"
 
 struct GLTFAccessor : public Resource {
 	GDCLASS(GLTFAccessor, Resource);
@@ -45,7 +44,7 @@ private:
 	int component_type = 0;
 	bool normalized = false;
 	int count = 0;
-	GLTFDocument::GLTFType type = GLTFDocument::TYPE_SCALAR;
+	GLTFType type = GLTFType::TYPE_SCALAR;
 	PoolVector<float> min;
 	PoolVector<float> max;
 	int sparse_count = 0;

--- a/modules/gltf/gltf_buffer_view.h
+++ b/modules/gltf/gltf_buffer_view.h
@@ -32,8 +32,7 @@
 #define GLTF_BUFFER_VIEW_H
 
 #include "core/resource.h"
-
-#include "gltf_document.h"
+#include "gltf_defines.h"
 
 class GLTFBufferView : public Resource {
 	GDCLASS(GLTFBufferView, Resource);

--- a/modules/gltf/gltf_defines.h
+++ b/modules/gltf/gltf_defines.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  gltf_skeleton.h                                                      */
+/*  gltf_defines.h                                                       */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,55 +28,63 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GLTF_SKELETON_H
-#define GLTF_SKELETON_H
+#ifndef GLTF_DEFINES_H
+#define GLTF_DEFINES_H
 
-#include "core/resource.h"
-#include "gltf_defines.h"
+// This file should only be included by other headers.
 
-class GLTFSkeleton : public Resource {
-	GDCLASS(GLTFSkeleton, Resource);
-	friend class GLTFDocument;
+// Godot classes used by GLTF headers.
+class AnimationPlayer;
+class BoneAttachment;
+class CSGShape;
+class DirectionalLight;
+class GridMap;
+class Light;
+class MultiMeshInstance;
+class Skeleton;
+class Skin;
 
-private:
-	// The *synthesized* skeletons joints
-	PoolVector<GLTFNodeIndex> joints;
+// GLTF classes.
+struct GLTFAccessor;
+class GLTFAnimation;
+class GLTFBufferView;
+class GLTFCamera;
+class GLTFDocument;
+class GLTFLight;
+class GLTFMesh;
+class GLTFNode;
+class GLTFSkeleton;
+class GLTFSkin;
+class GLTFSpecGloss;
+class GLTFState;
+class GLTFTexture;
+class GLTFTextureSampler;
+class PackedSceneGLTF;
 
-	// The roots of the skeleton. If there are multiple, each root must have the
-	// same parent (ie roots are siblings)
-	PoolVector<GLTFNodeIndex> roots;
+// GLTF index aliases.
+using GLTFAccessorIndex = int;
+using GLTFAnimationIndex = int;
+using GLTFBufferIndex = int;
+using GLTFBufferViewIndex = int;
+using GLTFCameraIndex = int;
+using GLTFImageIndex = int;
+using GLTFLightIndex = int;
+using GLTFMaterialIndex = int;
+using GLTFMeshIndex = int;
+using GLTFNodeIndex = int;
+using GLTFSkeletonIndex = int;
+using GLTFSkinIndex = int;
+using GLTFTextureIndex = int;
+using GLTFTextureSamplerIndex = int;
 
-	// The created Skeleton for the scene
-	Skeleton *godot_skeleton = nullptr;
-
-	// Set of unique bone names for the skeleton
-	Set<String> unique_names;
-
-	Map<int32_t, GLTFNodeIndex> godot_bone_node;
-
-	PoolVector<BoneAttachment *> bone_attachments;
-
-protected:
-	static void _bind_methods();
-
-public:
-	PoolVector<GLTFNodeIndex> get_joints();
-	void set_joints(PoolVector<GLTFNodeIndex> p_joints);
-
-	PoolVector<GLTFNodeIndex> get_roots();
-	void set_roots(PoolVector<GLTFNodeIndex> p_roots);
-
-	Skeleton *get_godot_skeleton();
-
-	Array get_unique_names();
-	void set_unique_names(Array p_unique_names);
-
-	Dictionary get_godot_bone_node();
-	void set_godot_bone_node(Dictionary p_indict);
-
-	BoneAttachment *get_bone_attachment(int idx);
-
-	int32_t get_bone_attachment_count();
+enum GLTFType {
+	TYPE_SCALAR,
+	TYPE_VEC2,
+	TYPE_VEC3,
+	TYPE_VEC4,
+	TYPE_MAT2,
+	TYPE_MAT3,
+	TYPE_MAT4,
 };
 
-#endif // GLTF_SKELETON_H
+#endif // GLTF_DEFINES_H

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -30,17 +30,8 @@
 
 #include "gltf_document.h"
 
-#include "gltf_accessor.h"
-#include "gltf_animation.h"
-#include "gltf_camera.h"
-#include "gltf_light.h"
-#include "gltf_mesh.h"
-#include "gltf_node.h"
-#include "gltf_skeleton.h"
-#include "gltf_skin.h"
 #include "gltf_spec_gloss.h"
 #include "gltf_state.h"
-#include "gltf_texture.h"
 
 #include "core/bind/core_bind.h" // FIXME: Shouldn't use _Directory but DirAccess.
 #include "core/crypto/crypto_core.h"
@@ -979,58 +970,58 @@ Error GLTFDocument::_encode_accessors(Ref<GLTFState> state) {
 	return OK;
 }
 
-String GLTFDocument::_get_accessor_type_name(const GLTFDocument::GLTFType p_type) {
-	if (p_type == GLTFDocument::TYPE_SCALAR) {
+String GLTFDocument::_get_accessor_type_name(const GLTFType p_type) {
+	if (p_type == GLTFType::TYPE_SCALAR) {
 		return "SCALAR";
 	}
-	if (p_type == GLTFDocument::TYPE_VEC2) {
+	if (p_type == GLTFType::TYPE_VEC2) {
 		return "VEC2";
 	}
-	if (p_type == GLTFDocument::TYPE_VEC3) {
+	if (p_type == GLTFType::TYPE_VEC3) {
 		return "VEC3";
 	}
-	if (p_type == GLTFDocument::TYPE_VEC4) {
+	if (p_type == GLTFType::TYPE_VEC4) {
 		return "VEC4";
 	}
 
-	if (p_type == GLTFDocument::TYPE_MAT2) {
+	if (p_type == GLTFType::TYPE_MAT2) {
 		return "MAT2";
 	}
-	if (p_type == GLTFDocument::TYPE_MAT3) {
+	if (p_type == GLTFType::TYPE_MAT3) {
 		return "MAT3";
 	}
-	if (p_type == GLTFDocument::TYPE_MAT4) {
+	if (p_type == GLTFType::TYPE_MAT4) {
 		return "MAT4";
 	}
 	ERR_FAIL_V("SCALAR");
 }
 
-GLTFDocument::GLTFType GLTFDocument::_get_type_from_str(const String &p_string) {
+GLTFType GLTFDocument::_get_type_from_str(const String &p_string) {
 	if (p_string == "SCALAR") {
-		return GLTFDocument::TYPE_SCALAR;
+		return GLTFType::TYPE_SCALAR;
 	}
 
 	if (p_string == "VEC2") {
-		return GLTFDocument::TYPE_VEC2;
+		return GLTFType::TYPE_VEC2;
 	}
 	if (p_string == "VEC3") {
-		return GLTFDocument::TYPE_VEC3;
+		return GLTFType::TYPE_VEC3;
 	}
 	if (p_string == "VEC4") {
-		return GLTFDocument::TYPE_VEC4;
+		return GLTFType::TYPE_VEC4;
 	}
 
 	if (p_string == "MAT2") {
-		return GLTFDocument::TYPE_MAT2;
+		return GLTFType::TYPE_MAT2;
 	}
 	if (p_string == "MAT3") {
-		return GLTFDocument::TYPE_MAT3;
+		return GLTFType::TYPE_MAT3;
 	}
 	if (p_string == "MAT4") {
-		return GLTFDocument::TYPE_MAT4;
+		return GLTFType::TYPE_MAT4;
 	}
 
-	ERR_FAIL_V(GLTFDocument::TYPE_SCALAR);
+	ERR_FAIL_V(GLTFType::TYPE_SCALAR);
 }
 
 Error GLTFDocument::_parse_accessors(Ref<GLTFState> state) {
@@ -1591,7 +1582,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_ints(Ref<GLTFState> state, c
 	accessor.instance();
 	GLTFBufferIndex buffer_view_i;
 	int64_t size = state->buffers[0].size();
-	const GLTFDocument::GLTFType type = GLTFDocument::TYPE_SCALAR;
+	const GLTFType type = GLTFType::TYPE_SCALAR;
 	const int component_type = GLTFDocument::COMPONENT_TYPE_INT;
 
 	PoolVector<float> max;
@@ -1687,7 +1678,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_vec2(Ref<GLTFState> state, c
 	accessor.instance();
 	GLTFBufferIndex buffer_view_i;
 	int64_t size = state->buffers[0].size();
-	const GLTFDocument::GLTFType type = GLTFDocument::TYPE_VEC2;
+	const GLTFType type = GLTFType::TYPE_VEC2;
 	const int component_type = GLTFDocument::COMPONENT_TYPE_FLOAT;
 
 	PoolVector<float> max;
@@ -1748,7 +1739,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_color(Ref<GLTFState> state, 
 	accessor.instance();
 	GLTFBufferIndex buffer_view_i;
 	int64_t size = state->buffers[0].size();
-	const GLTFDocument::GLTFType type = GLTFDocument::TYPE_VEC4;
+	const GLTFType type = GLTFType::TYPE_VEC4;
 	const int component_type = GLTFDocument::COMPONENT_TYPE_FLOAT;
 	PoolVector<float> max;
 	max.resize(type_max.size());
@@ -1824,7 +1815,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_weights(Ref<GLTFState> state
 	accessor.instance();
 	GLTFBufferIndex buffer_view_i;
 	int64_t size = state->buffers[0].size();
-	const GLTFDocument::GLTFType type = GLTFDocument::TYPE_VEC4;
+	const GLTFType type = GLTFType::TYPE_VEC4;
 	const int component_type = GLTFDocument::COMPONENT_TYPE_FLOAT;
 
 	PoolVector<float> max;
@@ -1883,7 +1874,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_joints(Ref<GLTFState> state,
 	accessor.instance();
 	GLTFBufferIndex buffer_view_i;
 	int64_t size = state->buffers[0].size();
-	const GLTFDocument::GLTFType type = GLTFDocument::TYPE_VEC4;
+	const GLTFType type = GLTFType::TYPE_VEC4;
 	const int component_type = GLTFDocument::COMPONENT_TYPE_UNSIGNED_SHORT;
 
 	PoolVector<float> max;
@@ -1944,7 +1935,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_quats(Ref<GLTFState> state, 
 	accessor.instance();
 	GLTFBufferIndex buffer_view_i;
 	int64_t size = state->buffers[0].size();
-	const GLTFDocument::GLTFType type = GLTFDocument::TYPE_VEC4;
+	const GLTFType type = GLTFType::TYPE_VEC4;
 	const int component_type = GLTFDocument::COMPONENT_TYPE_FLOAT;
 
 	PoolVector<float> max;
@@ -2021,7 +2012,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_floats(Ref<GLTFState> state,
 	accessor.instance();
 	GLTFBufferIndex buffer_view_i;
 	int64_t size = state->buffers[0].size();
-	const GLTFDocument::GLTFType type = GLTFDocument::TYPE_SCALAR;
+	const GLTFType type = GLTFType::TYPE_SCALAR;
 	const int component_type = GLTFDocument::COMPONENT_TYPE_FLOAT;
 
 	PoolVector<float> max;
@@ -2079,7 +2070,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_vec3(Ref<GLTFState> state, c
 	accessor.instance();
 	GLTFBufferIndex buffer_view_i;
 	int64_t size = state->buffers[0].size();
-	const GLTFDocument::GLTFType type = GLTFDocument::TYPE_VEC3;
+	const GLTFType type = GLTFType::TYPE_VEC3;
 	const int component_type = GLTFDocument::COMPONENT_TYPE_FLOAT;
 
 	PoolVector<float> max;
@@ -2159,7 +2150,7 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_xform(Ref<GLTFState> state, 
 	accessor.instance();
 	GLTFBufferIndex buffer_view_i;
 	int64_t size = state->buffers[0].size();
-	const GLTFDocument::GLTFType type = GLTFDocument::TYPE_MAT4;
+	const GLTFType type = GLTFType::TYPE_MAT4;
 	const int component_type = GLTFDocument::COMPONENT_TYPE_FLOAT;
 
 	PoolVector<float> max;

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -31,6 +31,8 @@
 #ifndef GLTF_DOCUMENT_H
 #define GLTF_DOCUMENT_H
 
+#include "gltf_defines.h"
+
 #include "scene/3d/bone_attachment.h"
 #include "scene/3d/camera.h"
 #include "scene/3d/light.h"
@@ -45,14 +47,6 @@
 
 #include "modules/modules_enabled.gen.h" // For csg, gridmap.
 
-class GLTFState;
-class GLTFSkin;
-class GLTFNode;
-class GLTFSpecGloss;
-class GLTFSkeleton;
-class GLTFTextureSampler;
-class MultiMeshInstance;
-
 #ifdef MODULE_CSG_ENABLED
 class CSGShape;
 #endif // MODULE_CSG_ENABLED
@@ -60,41 +54,14 @@ class CSGShape;
 class GridMap;
 #endif // MODULE_GRIDMAP_ENABLED
 
-using GLTFAccessorIndex = int;
-using GLTFAnimationIndex = int;
-using GLTFBufferIndex = int;
-using GLTFBufferViewIndex = int;
-using GLTFCameraIndex = int;
-using GLTFImageIndex = int;
-using GLTFMaterialIndex = int;
-using GLTFMeshIndex = int;
-using GLTFLightIndex = int;
-using GLTFNodeIndex = int;
-using GLTFSkeletonIndex = int;
-using GLTFSkinIndex = int;
-using GLTFTextureIndex = int;
-using GLTFTextureSamplerIndex = int;
-
 class GLTFDocument : public Resource {
 	GDCLASS(GLTFDocument, Resource);
-	friend class GLTFState;
-	friend class GLTFSkin;
-	friend class GLTFSkeleton;
 
 private:
 	const float BAKE_FPS = 30.0f;
 
 public:
 	const int32_t JOINT_GROUP_SIZE = 4;
-	enum GLTFType {
-		TYPE_SCALAR,
-		TYPE_VEC2,
-		TYPE_VEC3,
-		TYPE_VEC4,
-		TYPE_MAT2,
-		TYPE_MAT3,
-		TYPE_MAT4,
-	};
 
 	enum {
 		ARRAY_BUFFER = 34962,
@@ -116,65 +83,13 @@ public:
 	};
 
 private:
-	template <class T>
-	static Array to_array(const Vector<T> &p_inp) {
-		Array ret;
-		for (int i = 0; i < p_inp.size(); i++) {
-			ret.push_back(p_inp[i]);
-		}
-		return ret;
-	}
-
-	template <class T>
-	static Array to_array(const Set<T> &p_inp) {
-		Array ret;
-		typename Set<T>::Element *elem = p_inp.front();
-		while (elem) {
-			ret.push_back(elem->get());
-			elem = elem->next();
-		}
-		return ret;
-	}
-
-	template <class T>
-	static void set_from_array(Vector<T> &r_out, const Array &p_inp) {
-		r_out.clear();
-		for (int i = 0; i < p_inp.size(); i++) {
-			r_out.push_back(p_inp[i]);
-		}
-	}
-
-	template <class T>
-	static void set_from_array(Set<T> &r_out, const Array &p_inp) {
-		r_out.clear();
-		for (int i = 0; i < p_inp.size(); i++) {
-			r_out.insert(p_inp[i]);
-		}
-	}
-	template <class K, class V>
-	static Dictionary to_dict(const Map<K, V> &p_inp) {
-		Dictionary ret;
-		for (typename Map<K, V>::Element *E = p_inp.front(); E; E = E->next()) {
-			ret[E->key()] = E->value();
-		}
-		return ret;
-	}
-
-	template <class K, class V>
-	static void set_from_dict(Map<K, V> &r_out, const Dictionary &p_inp) {
-		r_out.clear();
-		Array keys = p_inp.keys();
-		for (int i = 0; i < keys.size(); i++) {
-			r_out[keys[i]] = p_inp[keys[i]];
-		}
-	}
 	double _filter_number(double p_float);
 	String _get_component_type_name(const uint32_t p_component);
 	int _get_component_type_size(const int component_type);
 	Error _parse_scenes(Ref<GLTFState> state);
 	Error _parse_nodes(Ref<GLTFState> state);
 	String _get_type_name(const GLTFType p_component);
-	String _get_accessor_type_name(const GLTFDocument::GLTFType p_type);
+	String _get_accessor_type_name(const GLTFType p_type);
 	String _gen_unique_name(Ref<GLTFState> state, const String &p_name);
 	String _sanitize_animation_name(const String &name);
 	String _gen_unique_animation_name(Ref<GLTFState> state, const String &p_name);

--- a/modules/gltf/gltf_node.h
+++ b/modules/gltf/gltf_node.h
@@ -32,8 +32,7 @@
 #define GLTF_NODE_H
 
 #include "core/resource.h"
-
-#include "gltf_document.h"
+#include "gltf_defines.h"
 
 class GLTFNode : public Resource {
 	GDCLASS(GLTFNode, Resource);

--- a/modules/gltf/gltf_skeleton.cpp
+++ b/modules/gltf/gltf_skeleton.cpp
@@ -30,6 +30,9 @@
 
 #include "gltf_skeleton.h"
 
+#include "gltf_template_convert.h"
+#include "scene/3d/bone_attachment.h"
+
 void GLTFSkeleton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_joints"), &GLTFSkeleton::get_joints);
 	ClassDB::bind_method(D_METHOD("set_joints", "joints"), &GLTFSkeleton::set_joints);
@@ -70,19 +73,19 @@ Skeleton *GLTFSkeleton::get_godot_skeleton() {
 }
 
 Array GLTFSkeleton::get_unique_names() {
-	return GLTFDocument::to_array(unique_names);
+	return GLTFTemplateConvert::to_array(unique_names);
 }
 
 void GLTFSkeleton::set_unique_names(Array p_unique_names) {
-	GLTFDocument::set_from_array(unique_names, p_unique_names);
+	GLTFTemplateConvert::set_from_array(unique_names, p_unique_names);
 }
 
 Dictionary GLTFSkeleton::get_godot_bone_node() {
-	return GLTFDocument::to_dict(godot_bone_node);
+	return GLTFTemplateConvert::to_dict(godot_bone_node);
 }
 
 void GLTFSkeleton::set_godot_bone_node(Dictionary p_indict) {
-	GLTFDocument::set_from_dict(godot_bone_node, p_indict);
+	GLTFTemplateConvert::set_from_dict(godot_bone_node, p_indict);
 }
 
 BoneAttachment *GLTFSkeleton::get_bone_attachment(int idx) {

--- a/modules/gltf/gltf_skin.cpp
+++ b/modules/gltf/gltf_skin.cpp
@@ -30,6 +30,9 @@
 
 #include "gltf_skin.h"
 
+#include "gltf_template_convert.h"
+#include "scene/resources/skin.h"
+
 void GLTFSkin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_skin_root"), &GLTFSkin::get_skin_root);
 	ClassDB::bind_method(D_METHOD("set_skin_root", "skin_root"), &GLTFSkin::set_skin_root);
@@ -81,11 +84,11 @@ void GLTFSkin::set_joints_original(Vector<GLTFNodeIndex> p_joints_original) {
 }
 
 Array GLTFSkin::get_inverse_binds() {
-	return GLTFDocument::to_array(inverse_binds);
+	return GLTFTemplateConvert::to_array(inverse_binds);
 }
 
 void GLTFSkin::set_inverse_binds(Array p_inverse_binds) {
-	GLTFDocument::set_from_array(inverse_binds, p_inverse_binds);
+	GLTFTemplateConvert::set_from_array(inverse_binds, p_inverse_binds);
 }
 
 Vector<GLTFNodeIndex> GLTFSkin::get_joints() {
@@ -121,11 +124,11 @@ void GLTFSkin::set_skeleton(int p_skeleton) {
 }
 
 Dictionary GLTFSkin::get_joint_i_to_bone_i() {
-	return GLTFDocument::to_dict(joint_i_to_bone_i);
+	return GLTFTemplateConvert::to_dict(joint_i_to_bone_i);
 }
 
 void GLTFSkin::set_joint_i_to_bone_i(Dictionary p_joint_i_to_bone_i) {
-	GLTFDocument::set_from_dict(joint_i_to_bone_i, p_joint_i_to_bone_i);
+	GLTFTemplateConvert::set_from_dict(joint_i_to_bone_i, p_joint_i_to_bone_i);
 }
 
 Dictionary GLTFSkin::get_joint_i_to_name() {

--- a/modules/gltf/gltf_skin.h
+++ b/modules/gltf/gltf_skin.h
@@ -32,8 +32,7 @@
 #define GLTF_SKIN_H
 
 #include "core/resource.h"
-
-#include "gltf_document.h"
+#include "gltf_defines.h"
 
 class GLTFSkin : public Resource {
 	GDCLASS(GLTFSkin, Resource);

--- a/modules/gltf/gltf_state.cpp
+++ b/modules/gltf/gltf_state.cpp
@@ -30,6 +30,8 @@
 
 #include "gltf_state.h"
 
+#include "scene/animation/animation_player.h"
+
 void GLTFState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_json"), &GLTFState::get_json);
 	ClassDB::bind_method(D_METHOD("set_json", "json"), &GLTFState::set_json);
@@ -150,51 +152,51 @@ void GLTFState::set_use_named_skin_binds(bool p_use_named_skin_binds) {
 }
 
 Array GLTFState::get_nodes() {
-	return GLTFDocument::to_array(nodes);
+	return GLTFTemplateConvert::to_array(nodes);
 }
 
 void GLTFState::set_nodes(Array p_nodes) {
-	GLTFDocument::set_from_array(nodes, p_nodes);
+	GLTFTemplateConvert::set_from_array(nodes, p_nodes);
 }
 
 Array GLTFState::get_buffers() {
-	return GLTFDocument::to_array(buffers);
+	return GLTFTemplateConvert::to_array(buffers);
 }
 
 void GLTFState::set_buffers(Array p_buffers) {
-	GLTFDocument::set_from_array(buffers, p_buffers);
+	GLTFTemplateConvert::set_from_array(buffers, p_buffers);
 }
 
 Array GLTFState::get_buffer_views() {
-	return GLTFDocument::to_array(buffer_views);
+	return GLTFTemplateConvert::to_array(buffer_views);
 }
 
 void GLTFState::set_buffer_views(Array p_buffer_views) {
-	GLTFDocument::set_from_array(buffer_views, p_buffer_views);
+	GLTFTemplateConvert::set_from_array(buffer_views, p_buffer_views);
 }
 
 Array GLTFState::get_accessors() {
-	return GLTFDocument::to_array(accessors);
+	return GLTFTemplateConvert::to_array(accessors);
 }
 
 void GLTFState::set_accessors(Array p_accessors) {
-	GLTFDocument::set_from_array(accessors, p_accessors);
+	GLTFTemplateConvert::set_from_array(accessors, p_accessors);
 }
 
 Array GLTFState::get_meshes() {
-	return GLTFDocument::to_array(meshes);
+	return GLTFTemplateConvert::to_array(meshes);
 }
 
 void GLTFState::set_meshes(Array p_meshes) {
-	GLTFDocument::set_from_array(meshes, p_meshes);
+	GLTFTemplateConvert::set_from_array(meshes, p_meshes);
 }
 
 Array GLTFState::get_materials() {
-	return GLTFDocument::to_array(materials);
+	return GLTFTemplateConvert::to_array(materials);
 }
 
 void GLTFState::set_materials(Array p_materials) {
-	GLTFDocument::set_from_array(materials, p_materials);
+	GLTFTemplateConvert::set_from_array(materials, p_materials);
 }
 
 String GLTFState::get_scene_name() {
@@ -206,99 +208,99 @@ void GLTFState::set_scene_name(String p_scene_name) {
 }
 
 Array GLTFState::get_root_nodes() {
-	return GLTFDocument::to_array(root_nodes);
+	return GLTFTemplateConvert::to_array(root_nodes);
 }
 
 void GLTFState::set_root_nodes(Array p_root_nodes) {
-	GLTFDocument::set_from_array(root_nodes, p_root_nodes);
+	GLTFTemplateConvert::set_from_array(root_nodes, p_root_nodes);
 }
 
 Array GLTFState::get_textures() {
-	return GLTFDocument::to_array(textures);
+	return GLTFTemplateConvert::to_array(textures);
 }
 
 void GLTFState::set_textures(Array p_textures) {
-	GLTFDocument::set_from_array(textures, p_textures);
+	GLTFTemplateConvert::set_from_array(textures, p_textures);
 }
 
 Array GLTFState::get_texture_samplers() {
-	return GLTFDocument::to_array(texture_samplers);
+	return GLTFTemplateConvert::to_array(texture_samplers);
 }
 
 void GLTFState::set_texture_samplers(Array p_texture_samplers) {
-	GLTFDocument::set_from_array(texture_samplers, p_texture_samplers);
+	GLTFTemplateConvert::set_from_array(texture_samplers, p_texture_samplers);
 }
 
 Array GLTFState::get_images() {
-	return GLTFDocument::to_array(images);
+	return GLTFTemplateConvert::to_array(images);
 }
 
 void GLTFState::set_images(Array p_images) {
-	GLTFDocument::set_from_array(images, p_images);
+	GLTFTemplateConvert::set_from_array(images, p_images);
 }
 
 Array GLTFState::get_skins() {
-	return GLTFDocument::to_array(skins);
+	return GLTFTemplateConvert::to_array(skins);
 }
 
 void GLTFState::set_skins(Array p_skins) {
-	GLTFDocument::set_from_array(skins, p_skins);
+	GLTFTemplateConvert::set_from_array(skins, p_skins);
 }
 
 Array GLTFState::get_cameras() {
-	return GLTFDocument::to_array(cameras);
+	return GLTFTemplateConvert::to_array(cameras);
 }
 
 void GLTFState::set_cameras(Array p_cameras) {
-	GLTFDocument::set_from_array(cameras, p_cameras);
+	GLTFTemplateConvert::set_from_array(cameras, p_cameras);
 }
 
 Array GLTFState::get_lights() {
-	return GLTFDocument::to_array(lights);
+	return GLTFTemplateConvert::to_array(lights);
 }
 
 void GLTFState::set_lights(Array p_lights) {
-	GLTFDocument::set_from_array(lights, p_lights);
+	GLTFTemplateConvert::set_from_array(lights, p_lights);
 }
 
 Array GLTFState::get_unique_names() {
-	return GLTFDocument::to_array(unique_names);
+	return GLTFTemplateConvert::to_array(unique_names);
 }
 
 void GLTFState::set_unique_names(Array p_unique_names) {
-	GLTFDocument::set_from_array(unique_names, p_unique_names);
+	GLTFTemplateConvert::set_from_array(unique_names, p_unique_names);
 }
 
 Array GLTFState::get_unique_animation_names() {
-	return GLTFDocument::to_array(unique_animation_names);
+	return GLTFTemplateConvert::to_array(unique_animation_names);
 }
 
 void GLTFState::set_unique_animation_names(Array p_unique_animation_names) {
-	GLTFDocument::set_from_array(unique_animation_names, p_unique_animation_names);
+	GLTFTemplateConvert::set_from_array(unique_animation_names, p_unique_animation_names);
 }
 
 Array GLTFState::get_skeletons() {
-	return GLTFDocument::to_array(skeletons);
+	return GLTFTemplateConvert::to_array(skeletons);
 }
 
 void GLTFState::set_skeletons(Array p_skeletons) {
-	GLTFDocument::set_from_array(skeletons, p_skeletons);
+	GLTFTemplateConvert::set_from_array(skeletons, p_skeletons);
 }
 
 Dictionary GLTFState::get_skeleton_to_node() {
-	return GLTFDocument::to_dict(skeleton_to_node);
+	return GLTFTemplateConvert::to_dict(skeleton_to_node);
 }
 
 void GLTFState::set_skeleton_to_node(Dictionary p_skeleton_to_node) {
-	GLTFDocument::set_from_dict(skeleton_to_node, p_skeleton_to_node);
+	GLTFTemplateConvert::set_from_dict(skeleton_to_node, p_skeleton_to_node);
 }
 
 Array GLTFState::get_animations() {
-	return GLTFDocument::to_array(animations);
+	return GLTFTemplateConvert::to_array(animations);
 }
 
 void GLTFState::set_animations(Array p_animations) {
-	GLTFDocument::set_from_array(animations, p_animations);
+	GLTFTemplateConvert::set_from_array(animations, p_animations);
 }
 
 Node *GLTFState::get_scene_node(GLTFNodeIndex idx) {

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -31,26 +31,18 @@
 #ifndef GLTF_STATE_H
 #define GLTF_STATE_H
 
-#include "core/map.h"
-#include "core/resource.h"
-#include "core/vector.h"
-#include "scene/animation/animation_player.h"
-#include "scene/resources/texture.h"
-
 #include "gltf_accessor.h"
 #include "gltf_animation.h"
 #include "gltf_buffer_view.h"
 #include "gltf_camera.h"
-#include "gltf_document.h"
 #include "gltf_light.h"
 #include "gltf_mesh.h"
 #include "gltf_node.h"
 #include "gltf_skeleton.h"
 #include "gltf_skin.h"
+#include "gltf_template_convert.h"
 #include "gltf_texture.h"
 #include "gltf_texture_sampler.h"
-#include "scene/animation/animation_player.h"
-#include "scene/resources/texture.h"
 
 class GLTFState : public Resource {
 	GDCLASS(GLTFState, Resource);

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -64,6 +64,7 @@ class GLTFState : public Resource {
 	Vector<uint8_t> glb_data;
 
 	bool use_named_skin_binds = false;
+	bool use_khr_texture_transform = false;
 	bool use_legacy_names = false;
 	uint32_t compress_flags = 0;
 

--- a/modules/gltf/gltf_template_convert.h
+++ b/modules/gltf/gltf_template_convert.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  gltf_skeleton.h                                                      */
+/*  gltf_template_convert.h                                              */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,55 +28,67 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GLTF_SKELETON_H
-#define GLTF_SKELETON_H
+#ifndef GLTF_TEMPLATE_CONVERT_H
+#define GLTF_TEMPLATE_CONVERT_H
 
-#include "core/resource.h"
-#include "gltf_defines.h"
+#include "core/array.h"
+#include "core/dictionary.h"
+#include "core/set.h"
 
-class GLTFSkeleton : public Resource {
-	GDCLASS(GLTFSkeleton, Resource);
-	friend class GLTFDocument;
+namespace GLTFTemplateConvert {
+template <class T>
+static Array to_array(const Vector<T> &p_inp) {
+	Array ret;
+	for (int i = 0; i < p_inp.size(); i++) {
+		ret.push_back(p_inp[i]);
+	}
+	return ret;
+}
 
-private:
-	// The *synthesized* skeletons joints
-	PoolVector<GLTFNodeIndex> joints;
+template <class T>
+static Array to_array(const Set<T> &p_inp) {
+	Array ret;
+	typename Set<T>::Element *elem = p_inp.front();
+	while (elem) {
+		ret.push_back(elem->get());
+		elem = elem->next();
+	}
+	return ret;
+}
 
-	// The roots of the skeleton. If there are multiple, each root must have the
-	// same parent (ie roots are siblings)
-	PoolVector<GLTFNodeIndex> roots;
+template <class T>
+static void set_from_array(Vector<T> &r_out, const Array &p_inp) {
+	r_out.clear();
+	for (int i = 0; i < p_inp.size(); i++) {
+		r_out.push_back(p_inp[i]);
+	}
+}
 
-	// The created Skeleton for the scene
-	Skeleton *godot_skeleton = nullptr;
+template <class T>
+static void set_from_array(Set<T> &r_out, const Array &p_inp) {
+	r_out.clear();
+	for (int i = 0; i < p_inp.size(); i++) {
+		r_out.insert(p_inp[i]);
+	}
+}
 
-	// Set of unique bone names for the skeleton
-	Set<String> unique_names;
+template <class K, class V>
+static Dictionary to_dict(const Map<K, V> &p_inp) {
+	Dictionary ret;
+	for (typename Map<K, V>::Element *E = p_inp.front(); E; E = E->next()) {
+		ret[E->key()] = E->value();
+	}
+	return ret;
+}
 
-	Map<int32_t, GLTFNodeIndex> godot_bone_node;
+template <class K, class V>
+static void set_from_dict(Map<K, V> &r_out, const Dictionary &p_inp) {
+	r_out.clear();
+	Array keys = p_inp.keys();
+	for (int i = 0; i < keys.size(); i++) {
+		r_out[keys[i]] = p_inp[keys[i]];
+	}
+}
+} //namespace GLTFTemplateConvert
 
-	PoolVector<BoneAttachment *> bone_attachments;
-
-protected:
-	static void _bind_methods();
-
-public:
-	PoolVector<GLTFNodeIndex> get_joints();
-	void set_joints(PoolVector<GLTFNodeIndex> p_joints);
-
-	PoolVector<GLTFNodeIndex> get_roots();
-	void set_roots(PoolVector<GLTFNodeIndex> p_roots);
-
-	Skeleton *get_godot_skeleton();
-
-	Array get_unique_names();
-	void set_unique_names(Array p_unique_names);
-
-	Dictionary get_godot_bone_node();
-	void set_godot_bone_node(Dictionary p_indict);
-
-	BoneAttachment *get_bone_attachment(int idx);
-
-	int32_t get_bone_attachment_count();
-};
-
-#endif // GLTF_SKELETON_H
+#endif // GLTF_TEMPLATE_CONVERT_H

--- a/modules/gltf/gltf_texture.h
+++ b/modules/gltf/gltf_texture.h
@@ -32,8 +32,7 @@
 #define GLTF_TEXTURE_H
 
 #include "core/resource.h"
-
-#include "gltf_document.h"
+#include "gltf_defines.h"
 
 class GLTFTexture : public Resource {
 	GDCLASS(GLTFTexture, Resource);

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -32,20 +32,8 @@
 
 #include "register_types.h"
 
-#include "gltf_accessor.h"
-#include "gltf_animation.h"
-#include "gltf_buffer_view.h"
-#include "gltf_camera.h"
-#include "gltf_document.h"
-#include "gltf_light.h"
-#include "gltf_mesh.h"
-#include "gltf_node.h"
-#include "gltf_skeleton.h"
-#include "gltf_skin.h"
 #include "gltf_spec_gloss.h"
 #include "gltf_state.h"
-#include "gltf_texture.h"
-#include "packed_scene_gltf.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_node.h"


### PR DESCRIPTION
This PR backports #63373 and #63399 to Godot 3.x. Does not break compat.

I am planning to backport the entire GLTF module similarly to what #49120 did, but it's a lot safer and easier to review if I do it in small chunks. So here's the first small chunk which backports two PRs. And yes, I tested it.