### PR TITLE
Fix issue around incorrect Vulkan version

### DIFF
--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -110,10 +110,7 @@ private:
 	bool device_initialized = false;
 	bool inst_initialized = false;
 
-	// Vulkan 1.0 doesn't return version info so we assume this by default until we know otherwise.
-	uint32_t vulkan_major = 1;
-	uint32_t vulkan_minor = 0;
-	uint32_t vulkan_patch = 0;
+	uint32_t instance_api_version = VK_API_VERSION_1_0;
 	SubgroupCapabilities subgroup_capabilities;
 	MultiviewCapabilities multiview_capabilities;
 	VRSCapabilities vrs_capabilities;
@@ -276,8 +273,8 @@ public:
 	bool supports_renderpass2() const { return is_device_extension_enabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME); }
 	VkResult vkCreateRenderPass2KHR(VkDevice p_device, const VkRenderPassCreateInfo2 *p_create_info, const VkAllocationCallbacks *p_allocator, VkRenderPass *p_render_pass);
 
-	uint32_t get_vulkan_major() const { return vulkan_major; };
-	uint32_t get_vulkan_minor() const { return vulkan_minor; };
+	uint32_t get_vulkan_major() const { return VK_API_VERSION_MAJOR(device_api_version); };
+	uint32_t get_vulkan_minor() const { return VK_API_VERSION_MINOR(device_api_version); };
 	const SubgroupCapabilities &get_subgroup_capabilities() const { return subgroup_capabilities; };
 	const MultiviewCapabilities &get_multiview_capabilities() const { return multiview_capabilities; };
 	const VRSCapabilities &get_vrs_capabilities() const { return vrs_capabilities; };


### PR DESCRIPTION
With Vulkan we are dealing with two different version numbers (well 3 actually for completeness)

1) The version of the instance, which is the version of the Vulkan runtime installed on the OS
2) The version of the device, which is the version the selected GPU drivers supports
3) The version of the SDK we're compiling against

We were purely retrieving the instance version and checking capabilities against that however often the GPU may be an older device with older drivers that do not support the Vulkan version the OS supports and thus we were enabling things that shouldn't be enabled.

This PR cleans up the version checks and now tracks both instance and device versions and checks the device version where applicable. The device version is also what we expose to the rest of the application.

Note that when creating our instance we tell Vulkan what API we're developing against. We set this to the instance API version but cap it to the version of the Vulkan header we include. Note that Vulkan **only** uses this version for validation checking. If we tell it we only support Vulkan 1.1, and we use Vulkan 1.2 functions, fool on us I guess :)