### PR TITLE
Fix heap-use-after-free when removing a tile in TileSet editor

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -543,11 +543,13 @@ void TileSetAtlasSourceEditor::_update_source_inspector() {
 
 void TileSetAtlasSourceEditor::_update_fix_selected_and_hovered_tiles() {
 	// Fix selected.
-	for (RBSet<TileSelection>::Element *E = selection.front(); E; E = E->next()) {
+	for (RBSet<TileSelection>::Element *E = selection.front(); E;) {
+		RBSet<TileSelection>::Element *N = E->next();
 		TileSelection selected = E->get();
 		if (!tile_set_atlas_source->has_tile(selected.tile) || !tile_set_atlas_source->has_alternative_tile(selected.tile, selected.alternative)) {
 			selection.erase(E);
 		}
+		E = N;
 	}
 
 	// Fix hovered.


### PR DESCRIPTION
The element pointer `E` is no longer valid after calling `RBSet::erase(E)`. So calling `E->next()` is an error, crashing the sanitizer build.

<details><summary>Address Sanitizer output</summary>

```
=================================================================
==351977==ERROR: AddressSanitizer: heap-use-after-free on address 0x607003467a10 at pc 0x55e291deb8df bp 0x7ffe4bb9ff80 sp 0x7ffe4bb9ff70
READ of size 8 at 0x607003467a10 thread T0
    #0 0x55e291deb8de in RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::Element::next() core/templates/rb_set.h:66
    #1 0x55e291d98afc in TileSetAtlasSourceEditor::_update_fix_selected_and_hovered_tiles() editor/plugins/tiles/tile_set_atlas_source_editor.cpp:546
    #2 0x55e291dbb314 in TileSetAtlasSourceEditor::_menu_option(int) editor/plugins/tiles/tile_set_atlas_source_editor.cpp:1609
    #3 0x55e291e042c0 in void call_with_variant_args_helper<TileSetAtlasSourceEditor, int, 0ul>(TileSetAtlasSourceEditor*, void (TileSetAtlasSourceEditor::*)(int), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:262
    #4 0x55e291e02d3f in void call_with_variant_args<TileSetAtlasSourceEditor, int>(TileSetAtlasSourceEditor*, void (TileSetAtlasSourceEditor::*)(int), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:376
    #5 0x55e291dfe999 in CallableCustomMethodPointer<TileSetAtlasSourceEditor, int>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #6 0x55e296a41381 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #7 0x55e2971e6840 in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1046
    #8 0x55e28c881170 in Error Object::emit_signal<int>(StringName const&, int) core/object/object.h:869
    #9 0x55e292725548 in PopupMenu::activate_item(int) scene/gui/popup_menu.cpp:1718
    #10 0x55e29270add9 in PopupMenu::gui_input(Ref<InputEvent> const&) scene/gui/popup_menu.cpp:426
    #11 0x55e2927542ce in void call_with_variant_args_helper<PopupMenu, Ref<InputEvent> const&, 0ul>(PopupMenu*, void (PopupMenu::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:262
    #12 0x55e29274fa3c in void call_with_variant_args<PopupMenu, Ref<InputEvent> const&>(PopupMenu*, void (PopupMenu::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:376
    #13 0x55e29274901b in CallableCustomMethodPointer<PopupMenu, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #14 0x55e296a41381 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #15 0x55e2971e6840 in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1046
    #16 0x55e290506694 in Error Object::emit_signal<Ref<InputEvent> >(StringName const&, Ref<InputEvent>) core/object/object.h:869
    #17 0x55e29224fc2e in Window::_window_input(Ref<InputEvent> const&) scene/main/window.cpp:1087
    #18 0x55e2922b881c in void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:262
    #19 0x55e2922ad96d in void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:376
    #20 0x55e2922a169d in CallableCustomMethodPointer<Window, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #21 0x55e296a41381 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #22 0x55e28ae63000 in DisplayServerX11::_dispatch_input_event(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:3246
    #23 0x55e28ae62a2a in DisplayServerX11::_dispatch_input_events(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:3217
    #24 0x55e29695c8bc in Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) core/input/input.cpp:663
    #25 0x55e2969607dc in Input::flush_buffered_events() core/input/input.cpp:885
    #26 0x55e28ae703bf in DisplayServerX11::process_events() platform/linuxbsd/x11/display_server_x11.cpp:4244
    #27 0x55e28ae233c6 in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:795
    #28 0x55e28ae0f891 in main platform/linuxbsd/godot_linuxbsd.cpp:73
    #29 0x7f278081128f  (/usr/lib/libc.so.6+0x2328f)
    #30 0x7f2780811349 in __libc_start_main (/usr/lib/libc.so.6+0x23349)
    #31 0x55e28ae0f464 in _start ../sysdeps/x86_64/start.S:115

0x607003467a10 is located 48 bytes inside of 80-byte region [0x6070034679e0,0x607003467a30)
freed by thread T0 here:
    #0 0x7f2780cbe672 in __interceptor_free /usr/src/debug/gcc/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x55e296494f4a in Memory::free_static(void*, bool) core/os/memory.cpp:168
    #2 0x55e28ae12032 in DefaultAllocator::free(void*) core/os/memory.h:66
    #3 0x55e291df682e in void memdelete_allocator<RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::Element, DefaultAllocator>(RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::Element*) core/os/memory.h:124
    #4 0x55e291df2513 in RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::_erase(RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::Element*) core/templates/rb_set.h:532
    #5 0x55e291deb948 in RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::erase(RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::Element*) core/templates/rb_set.h:610
    #6 0x55e291d98ada in TileSetAtlasSourceEditor::_update_fix_selected_and_hovered_tiles() editor/plugins/tiles/tile_set_atlas_source_editor.cpp:549
    #7 0x55e291dbb314 in TileSetAtlasSourceEditor::_menu_option(int) editor/plugins/tiles/tile_set_atlas_source_editor.cpp:1609
    #8 0x55e291e042c0 in void call_with_variant_args_helper<TileSetAtlasSourceEditor, int, 0ul>(TileSetAtlasSourceEditor*, void (TileSetAtlasSourceEditor::*)(int), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:262
    #9 0x55e291e02d3f in void call_with_variant_args<TileSetAtlasSourceEditor, int>(TileSetAtlasSourceEditor*, void (TileSetAtlasSourceEditor::*)(int), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:376
    #10 0x55e291dfe999 in CallableCustomMethodPointer<TileSetAtlasSourceEditor, int>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #11 0x55e296a41381 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #12 0x55e2971e6840 in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1046
    #13 0x55e28c881170 in Error Object::emit_signal<int>(StringName const&, int) core/object/object.h:869
    #14 0x55e292725548 in PopupMenu::activate_item(int) scene/gui/popup_menu.cpp:1718
    #15 0x55e29270add9 in PopupMenu::gui_input(Ref<InputEvent> const&) scene/gui/popup_menu.cpp:426
    #16 0x55e2927542ce in void call_with_variant_args_helper<PopupMenu, Ref<InputEvent> const&, 0ul>(PopupMenu*, void (PopupMenu::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:262
    #17 0x55e29274fa3c in void call_with_variant_args<PopupMenu, Ref<InputEvent> const&>(PopupMenu*, void (PopupMenu::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:376
    #18 0x55e29274901b in CallableCustomMethodPointer<PopupMenu, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #19 0x55e296a41381 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #20 0x55e2971e6840 in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1046
    #21 0x55e290506694 in Error Object::emit_signal<Ref<InputEvent> >(StringName const&, Ref<InputEvent>) core/object/object.h:869
    #22 0x55e29224fc2e in Window::_window_input(Ref<InputEvent> const&) scene/main/window.cpp:1087
    #23 0x55e2922b881c in void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:262
    #24 0x55e2922ad96d in void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:376
    #25 0x55e2922a169d in CallableCustomMethodPointer<Window, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #26 0x55e296a41381 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #27 0x55e28ae63000 in DisplayServerX11::_dispatch_input_event(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:3246
    #28 0x55e28ae62a2a in DisplayServerX11::_dispatch_input_events(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:3217
    #29 0x55e29695c8bc in Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) core/input/input.cpp:663

previously allocated by thread T0 here:
    #0 0x7f2780cbfa89 in __interceptor_malloc /usr/src/debug/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x55e296494374 in Memory::alloc_static(unsigned long, bool) core/os/memory.cpp:75
    #2 0x55e28ae12013 in DefaultAllocator::alloc(unsigned long) core/os/memory.h:65
    #3 0x55e2964942b1 in operator new(unsigned long, void* (*)(unsigned long)) core/os/memory.cpp:44
    #4 0x55e291df15b3 in RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::_insert(TileSetAtlasSourceEditor::TileSelection const&) core/templates/rb_set.h:396
    #5 0x55e291deb55f in RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::insert(TileSetAtlasSourceEditor::TileSelection const&) core/templates/rb_set.h:602
    #6 0x55e291db7118 in TileSetAtlasSourceEditor::_end_dragging() editor/plugins/tiles/tile_set_atlas_source_editor.cpp:1489
    #7 0x55e291db0de5 in TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(Ref<InputEvent> const&) editor/plugins/tiles/tile_set_atlas_source_editor.cpp:1312
    #8 0x55e291e03fd2 in void call_with_variant_args_helper<TileSetAtlasSourceEditor, Ref<InputEvent> const&, 0ul>(TileSetAtlasSourceEditor*, void (TileSetAtlasSourceEditor::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:262
    #9 0x55e291e02ac0 in void call_with_variant_args<TileSetAtlasSourceEditor, Ref<InputEvent> const&>(TileSetAtlasSourceEditor*, void (TileSetAtlasSourceEditor::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:376
    #10 0x55e291dfdb31 in CallableCustomMethodPointer<TileSetAtlasSourceEditor, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #11 0x55e296a41381 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #12 0x55e2971e6840 in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1046
    #13 0x55e290506694 in Error Object::emit_signal<Ref<InputEvent> >(StringName const&, Ref<InputEvent>) core/object/object.h:869
    #14 0x55e292422c84 in Control::_call_gui_input(Ref<InputEvent> const&) scene/gui/control.cpp:1701
    #15 0x55e292193856 in Viewport::_gui_call_input(Control*, Ref<InputEvent> const&) scene/main/viewport.cpp:1326
    #16 0x55e292196d73 in Viewport::_gui_input_event(Ref<InputEvent>) scene/main/viewport.cpp:1603
    #17 0x55e2921a9135 in Viewport::push_input(Ref<InputEvent> const&, bool) scene/main/viewport.cpp:2784
    #18 0x55e29224fc6f in Window::_window_input(Ref<InputEvent> const&) scene/main/window.cpp:1089
    #19 0x55e2922b881c in void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:262
    #20 0x55e2922ad96d in void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:376
    #21 0x55e2922a169d in CallableCustomMethodPointer<Window, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #22 0x55e296a41381 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #23 0x55e28ae63000 in DisplayServerX11::_dispatch_input_event(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:3246
    #24 0x55e28ae62a2a in DisplayServerX11::_dispatch_input_events(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:3217
    #25 0x55e29695c8bc in Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) core/input/input.cpp:663
    #26 0x55e2969607dc in Input::flush_buffered_events() core/input/input.cpp:885
    #27 0x55e28ae703bf in DisplayServerX11::process_events() platform/linuxbsd/x11/display_server_x11.cpp:4244
    #28 0x55e28ae233c6 in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:795
    #29 0x55e28ae0f891 in main platform/linuxbsd/godot_linuxbsd.cpp:73

SUMMARY: AddressSanitizer: heap-use-after-free core/templates/rb_set.h:66 in RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::Element::next()
Shadow bytes around the buggy address:
  0x0c0e80684ef0: fd fa fa fa fa fa fd fd fd fd fd fd fd fd fd fd
  0x0c0e80684f00: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 fa fa
  0x0c0e80684f10: fa fa fd fd fd fd fd fd fd fd fd fa fa fa fa fa
  0x0c0e80684f20: 00 00 00 00 00 00 00 00 00 00 fa fa fa fa fd fd
  0x0c0e80684f30: fd fd fd fd fd fd fd fd fa fa fa fa fd fd fd fd
=>0x0c0e80684f40: fd fd[fd]fd fd fd fa fa fa fa 00 00 00 00 00 00
  0x0c0e80684f50: 00 00 00 00 fa fa fa fa 00 00 00 00 00 00 00 00
  0x0c0e80684f60: 00 00 fa fa fa fa 00 00 00 00 00 00 00 00 00 00
  0x0c0e80684f70: fa fa fa fa 00 00 00 00 00 00 00 00 00 fa fa fa
  0x0c0e80684f80: fa fa fd fd fd fd fd fd fd fd fd fd fa fa fa fa
  0x0c0e80684f90: fd fd fd fd fd fd fd fd fd fd fa fa fa fa fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==351977==ABORTING
```

</details>