### PR TITLE
Add Skeletons and Blend Shapes to the OpenGL renderer

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -106,6 +106,7 @@ void RasterizerCanvasGLES3::_update_transform_to_mat4(const Transform3D &p_trans
 void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_light_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used) {
 	GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();
 	GLES3::MaterialStorage *material_storage = GLES3::MaterialStorage::get_singleton();
+	GLES3::MeshStorage *mesh_storage = GLES3::MeshStorage::get_singleton();
 
 	Transform2D canvas_transform_inverse = p_canvas_transform.affine_inverse();
 
@@ -384,6 +385,7 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 	Rect2 back_buffer_rect;
 	bool backbuffer_copy = false;
 	bool backbuffer_gen_mipmaps = false;
+	bool update_skeletons = false;
 
 	Item *ci = p_item_list;
 	Item *canvas_group_owner = nullptr;
@@ -425,8 +427,27 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 			}
 		}
 
+		if (ci->skeleton.is_valid()) {
+			const Item::Command *c = ci->commands;
+
+			while (c) {
+				if (c->type == Item::Command::TYPE_MESH) {
+					const Item::CommandMesh *cm = static_cast<const Item::CommandMesh *>(c);
+					if (cm->mesh_instance.is_valid()) {
+						mesh_storage->mesh_instance_check_for_update(cm->mesh_instance);
+						update_skeletons = true;
+					}
+				}
+				c = c->next;
+			}
+		}
+
 		if (ci->canvas_group_owner != nullptr) {
 			if (canvas_group_owner == nullptr) {
+				if (update_skeletons) {
+					mesh_storage->update_mesh_instances();
+					update_skeletons = false;
+				}
 				// Canvas group begins here, render until before this item
 				_render_items(p_to_render_target, item_count, canvas_transform_inverse, p_light_list, starting_index, false);
 				item_count = 0;
@@ -455,6 +476,10 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 		}
 
 		if (ci == canvas_group_owner) {
+			if (update_skeletons) {
+				mesh_storage->update_mesh_instances();
+				update_skeletons = false;
+			}
 			_render_items(p_to_render_target, item_count, canvas_transform_inverse, p_light_list, starting_index, true);
 			item_count = 0;
 
@@ -468,6 +493,10 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 		}
 
 		if (backbuffer_copy) {
+			if (update_skeletons) {
+				mesh_storage->update_mesh_instances();
+				update_skeletons = false;
+			}
 			//render anything pending, including clearing if no items
 
 			_render_items(p_to_render_target, item_count, canvas_transform_inverse, p_light_list, starting_index, false);
@@ -492,6 +521,10 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 		items[item_count++] = ci;
 
 		if (!ci->next || item_count == MAX_RENDER_ITEMS - 1) {
+			if (update_skeletons) {
+				mesh_storage->update_mesh_instances();
+				update_skeletons = false;
+			}
 			_render_items(p_to_render_target, item_count, canvas_transform_inverse, p_light_list, starting_index, false);
 			//then reset
 			item_count = 0;

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -420,6 +420,11 @@ void RasterizerSceneGLES3::_geometry_instance_update(RenderGeometryInstance *p_g
 		}
 
 	} else if (ginstance->data->base_type == RS::INSTANCE_MESH) {
+		if (mesh_storage->skeleton_is_valid(ginstance->data->skeleton)) {
+			if (ginstance->data->dirty_dependencies) {
+				mesh_storage->skeleton_update_dependency(ginstance->data->skeleton, &ginstance->data->dependency_tracker);
+			}
+		}
 	}
 
 	ginstance->store_transform_cache = store_transform;

--- a/drivers/gles3/shaders/SCsub
+++ b/drivers/gles3/shaders/SCsub
@@ -21,3 +21,4 @@ if "GLES3_GLSL" in env["BUILDERS"]:
     env.GLES3_GLSL("canvas_sdf.glsl")
     env.GLES3_GLSL("particles.glsl")
     env.GLES3_GLSL("particles_copy.glsl")
+    env.GLES3_GLSL("skeleton.glsl")

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -19,9 +19,6 @@ layout(location = 0) in vec2 vertex_attrib;
 layout(location = 3) in vec4 color_attrib;
 layout(location = 4) in vec2 uv_attrib;
 
-layout(location = 10) in uvec4 bone_attrib;
-layout(location = 11) in vec4 weight_attrib;
-
 #ifdef USE_INSTANCING
 
 layout(location = 1) in highp vec4 instance_xform0;
@@ -81,8 +78,6 @@ void main() {
 		uv = draw_data[draw_data_instance].uv_c;
 		color = vec4(unpackHalf2x16(draw_data[draw_data_instance].color_c_rg), unpackHalf2x16(draw_data[draw_data_instance].color_c_ba));
 	}
-	uvec4 bones = uvec4(0, 0, 0, 0);
-	vec4 bone_weights = vec4(0.0);
 
 #elif defined(USE_ATTRIBUTES)
 	draw_data_instance = gl_InstanceID;
@@ -92,9 +87,6 @@ void main() {
 	vec2 vertex = vertex_attrib;
 	vec4 color = color_attrib * draw_data[draw_data_instance].modulation;
 	vec2 uv = uv_attrib;
-
-	uvec4 bones = bone_attrib;
-	vec4 bone_weights = weight_attrib;
 
 #ifdef USE_INSTANCING
 	vec4 instance_color = vec4(unpackHalf2x16(instance_color_custom_data.x), unpackHalf2x16(instance_color_custom_data.y));
@@ -110,7 +102,6 @@ void main() {
 	vec2 uv = draw_data[draw_data_instance].src_rect.xy + abs(draw_data[draw_data_instance].src_rect.zw) * ((draw_data[draw_data_instance].flags & FLAGS_TRANSPOSE_RECT) != uint(0) ? vertex_base.yx : vertex_base.xy);
 	vec4 color = draw_data[draw_data_instance].modulation;
 	vec2 vertex = draw_data[draw_data_instance].dst_rect.xy + abs(draw_data[draw_data_instance].dst_rect.zw) * mix(vertex_base, vec2(1.0, 1.0) - vertex_base, lessThan(draw_data[draw_data_instance].src_rect.zw, vec2(0.0, 0.0)));
-	uvec4 bones = uvec4(0, 0, 0, 0);
 
 #endif
 

--- a/drivers/gles3/shaders/skeleton.glsl
+++ b/drivers/gles3/shaders/skeleton.glsl
@@ -1,0 +1,269 @@
+/* clang-format off */
+#[modes]
+
+mode_base_pass =
+mode_blend_pass = #define MODE_BLEND_PASS
+
+#[specializations]
+
+MODE_2D = true
+USE_BLEND_SHAPES = false
+USE_SKELETON = false
+USE_NORMAL = false
+USE_TANGENT = false
+FINAL_PASS = false
+USE_EIGHT_WEIGHTS = false
+
+#[vertex]
+
+#include "stdlib_inc.glsl"
+
+#ifdef MODE_2D
+#define VFORMAT vec2
+#else
+#define VFORMAT vec3
+#endif
+
+#ifdef FINAL_PASS
+#define OFORMAT vec2
+#else
+#define OFORMAT uvec2
+#endif
+
+// These come from the source mesh and the output from previous passes.
+layout(location = 0) in highp VFORMAT in_vertex;
+#ifdef MODE_BLEND_PASS
+#ifdef USE_NORMAL
+layout(location = 1) in highp uvec2 in_normal;
+#endif
+#ifdef USE_TANGENT
+layout(location = 2) in highp uvec2 in_tangent;
+#endif
+#else // MODE_BLEND_PASS
+#ifdef USE_NORMAL
+layout(location = 1) in highp vec2 in_normal;
+#endif
+#ifdef USE_TANGENT
+layout(location = 2) in highp vec2 in_tangent;
+#endif
+#endif // MODE_BLEND_PASS
+
+#ifdef USE_SKELETON
+#ifdef USE_EIGHT_WEIGHTS
+layout(location = 10) in highp uvec4 in_bone_attrib;
+layout(location = 11) in highp uvec4 in_bone_attrib2;
+layout(location = 12) in mediump vec4 in_weight_attrib;
+layout(location = 13) in mediump vec4 in_weight_attrib2;
+#else
+layout(location = 10) in highp uvec4 in_bone_attrib;
+layout(location = 11) in mediump vec4 in_weight_attrib;
+#endif
+
+uniform mediump sampler2D skeleton_texture; // texunit:0
+#endif
+
+/* clang-format on */
+#ifdef MODE_BLEND_PASS
+layout(location = 3) in highp VFORMAT blend_vertex;
+#ifdef USE_NORMAL
+layout(location = 4) in highp vec2 blend_normal;
+#endif
+#ifdef USE_TANGENT
+layout(location = 5) in highp vec2 blend_tangent;
+#endif
+#endif // MODE_BLEND_PASS
+
+out highp VFORMAT out_vertex; //tfb:
+
+#ifdef USE_NORMAL
+flat out highp OFORMAT out_normal; //tfb:USE_NORMAL
+#endif
+#ifdef USE_TANGENT
+flat out highp OFORMAT out_tangent; //tfb:USE_TANGENT
+#endif
+
+#ifdef USE_BLEND_SHAPES
+uniform highp float blend_weight;
+uniform lowp float blend_shape_count;
+#endif
+
+vec2 signNotZero(vec2 v) {
+	return mix(vec2(-1.0), vec2(1.0), greaterThanEqual(v.xy, vec2(0.0)));
+}
+
+vec3 oct_to_vec3(vec2 oct) {
+	oct = oct * 2.0 - 1.0;
+	vec3 v = vec3(oct.xy, 1.0 - abs(oct.x) - abs(oct.y));
+	if (v.z < 0.0) {
+		v.xy = (1.0 - abs(v.yx)) * signNotZero(v.xy);
+	}
+	return normalize(v);
+}
+
+vec2 vec3_to_oct(vec3 e) {
+	e /= abs(e.x) + abs(e.y) + abs(e.z);
+	vec2 oct = e.z >= 0.0f ? e.xy : (vec2(1.0f) - abs(e.yx)) * signNotZero(e.xy);
+	return oct * 0.5f + 0.5f;
+}
+
+vec4 oct_to_tang(vec2 oct_sign_encoded) {
+	// Binormal sign encoded in y component
+	vec2 oct = vec2(oct_sign_encoded.x, abs(oct_sign_encoded.y) * 2.0 - 1.0);
+	return vec4(oct_to_vec3(oct), sign(oct_sign_encoded.y));
+}
+
+vec2 tang_to_oct(vec4 base) {
+	vec2 oct = vec3_to_oct(base.xyz);
+	// Encode binormal sign in y component
+	oct.y = oct.y * 0.5f + 0.5f;
+	oct.y = base.w >= 0.0f ? oct.y : 1.0 - oct.y;
+	return oct;
+}
+
+// Our original input for normals and tangents is 2 16-bit floats.
+// Transform Feedback has to write out 32-bits per channel.
+// Octahedral compression requires normalized vectors, but we need to store
+// non-normalized vectors until the very end.
+// Therefore, we will compress our normals into 16 bits using signed-normalized
+// fixed point precision. This works well, because we know that each normal
+// is no larger than |1| so we can normalize by dividing by the number of blend
+// shapes.
+uvec2 vec4_to_vec2(vec4 p_vec) {
+	return uvec2(packSnorm2x16(p_vec.xy), packSnorm2x16(p_vec.zw));
+}
+
+vec4 vec2_to_vec4(uvec2 p_vec) {
+	return vec4(unpackSnorm2x16(p_vec.x), unpackSnorm2x16(p_vec.y));
+}
+
+void main() {
+#ifdef MODE_2D
+	out_vertex = in_vertex;
+
+#ifdef USE_BLEND_SHAPES
+#ifdef MODE_BLEND_PASS
+	out_vertex = in_vertex + blend_vertex * blend_weight;
+#else
+	out_vertex = in_vertex * blend_weight;
+#endif
+#ifdef FINAL_PASS
+	out_vertex = normalize(out_vertex);
+#endif
+#endif // USE_BLEND_SHAPES
+
+#ifdef USE_SKELETON
+
+#define TEX(m) texelFetch(skeleton_texture, ivec2(m % 256u, m / 256u), 0)
+#define GET_BONE_MATRIX(a, b, w) mat2x4(TEX(a), TEX(b)) * w
+
+	uvec4 bones = in_bone_attrib * uvec4(2u);
+	uvec4 bones_a = bones + uvec4(1u);
+
+	highp mat2x4 m = GET_BONE_MATRIX(bones.x, bones_a.x, in_weight_attrib.x);
+	m += GET_BONE_MATRIX(bones.y, bones_a.y, in_weight_attrib.y);
+	m += GET_BONE_MATRIX(bones.z, bones_a.z, in_weight_attrib.z);
+	m += GET_BONE_MATRIX(bones.w, bones_a.w, in_weight_attrib.w);
+
+	mat4 bone_matrix = mat4(m[0], m[1], vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0));
+
+	//reverse order because its transposed
+	out_vertex = (vec4(out_vertex, 0.0, 1.0) * bone_matrix).xy;
+#endif // USE_SKELETON
+
+#else // MODE_2D
+
+#ifdef USE_BLEND_SHAPES
+#ifdef MODE_BLEND_PASS
+	out_vertex = in_vertex + blend_vertex * blend_weight;
+
+#ifdef USE_NORMAL
+	vec3 normal = vec2_to_vec4(in_normal).xyz * blend_shape_count;
+	vec3 normal_blend = oct_to_vec3(blend_normal) * blend_weight;
+#ifdef FINAL_PASS
+	out_normal = vec3_to_oct(normalize(normal + normal_blend));
+#else
+	out_normal = vec4_to_vec2(vec4(normal + normal_blend, 0.0) / blend_shape_count);
+#endif
+#endif // USE_NORMAL
+
+#ifdef USE_TANGENT
+	vec4 tangent = vec2_to_vec4(in_tangent) * blend_shape_count;
+	vec4 tangent_blend = oct_to_tang(blend_tangent) * blend_weight;
+#ifdef FINAL_PASS
+	out_tangent = tang_to_oct(vec4(normalize(tangent.xyz + tangent_blend.xyz), tangent.w));
+#else
+	out_tangent = vec4_to_vec2(vec4((tangent.xyz + tangent_blend.xyz) / blend_shape_count, tangent.w));
+#endif
+#endif // USE_TANGENT
+
+#else // MODE_BLEND_PASS
+	out_vertex = in_vertex * blend_weight;
+
+#ifdef USE_NORMAL
+	vec3 normal = oct_to_vec3(in_normal);
+	out_normal = vec4_to_vec2(vec4(normal * blend_weight / blend_shape_count, 0.0));
+#endif
+#ifdef USE_TANGENT
+	vec4 tangent = oct_to_tang(in_tangent);
+	out_tangent = vec4_to_vec2(vec4(tangent.rgb * blend_weight / blend_shape_count, tangent.w));
+#endif
+#endif // MODE_BLEND_PASS
+#else // USE_BLEND_SHAPES
+
+	// Make attributes available to the skeleton shader if not written by blend shapes.
+	out_vertex = in_vertex;
+#ifdef USE_NORMAL
+	out_normal = in_normal;
+#endif
+#ifdef USE_TANGENT
+	out_tangent = in_tangent;
+#endif
+#endif // USE_BLEND_SHAPES
+
+#ifdef USE_SKELETON
+
+#define TEX(m) texelFetch(skeleton_texture, ivec2(m % 256u, m / 256u), 0)
+#define GET_BONE_MATRIX(a, b, c, w) mat4(TEX(a), TEX(b), TEX(c), vec4(0.0, 0.0, 0.0, 1.0)) * w
+
+	uvec4 bones = in_bone_attrib * uvec4(3);
+	uvec4 bones_a = bones + uvec4(1);
+	uvec4 bones_b = bones + uvec4(2);
+
+	highp mat4 m;
+	m = GET_BONE_MATRIX(bones.x, bones_a.x, bones_b.x, in_weight_attrib.x);
+	m += GET_BONE_MATRIX(bones.y, bones_a.y, bones_b.y, in_weight_attrib.y);
+	m += GET_BONE_MATRIX(bones.z, bones_a.z, bones_b.z, in_weight_attrib.z);
+	m += GET_BONE_MATRIX(bones.w, bones_a.w, bones_b.w, in_weight_attrib.w);
+
+#ifdef USE_EIGHT_WEIGHTS
+	bones = in_bone_attrib2 * uvec4(3);
+	bones_a = bones + uvec4(1);
+	bones_b = bones + uvec4(2);
+
+	m += GET_BONE_MATRIX(bones.x, bones_a.x, bones_b.x, in_weight_attrib2.x);
+	m += GET_BONE_MATRIX(bones.y, bones_a.y, bones_b.y, in_weight_attrib2.y);
+	m += GET_BONE_MATRIX(bones.z, bones_a.z, bones_b.z, in_weight_attrib2.z);
+	m += GET_BONE_MATRIX(bones.w, bones_a.w, bones_b.w, in_weight_attrib2.w);
+#endif
+
+	// Reverse order because its transposed.
+	out_vertex = (vec4(out_vertex, 1.0) * m).xyz;
+#ifdef USE_NORMAL
+	vec3 vertex_normal = oct_to_vec3(out_normal);
+	out_normal = vec3_to_oct(normalize((vec4(vertex_normal, 0.0) * m).xyz));
+#endif // USE_NORMAL
+#ifdef USE_TANGENT
+	vec4 vertex_tangent = oct_to_tang(out_tangent);
+	out_tangent = tang_to_oct(vec4(normalize((vec4(vertex_tangent.xyz, 0.0) * m).xyz), vertex_tangent.w));
+#endif // USE_TANGENT
+#endif // USE_SKELETON
+#endif // MODE_2D
+}
+
+/* clang-format off */
+#[fragment]
+
+void main() {
+
+}
+/* clang-format on */

--- a/drivers/gles3/storage/mesh_storage.h
+++ b/drivers/gles3/storage/mesh_storage.h
@@ -33,6 +33,7 @@
 
 #ifdef GLES3_ENABLED
 
+#include "../shaders/skeleton.glsl.gen.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/rid_owner.h"
 #include "core/templates/self_list.h"
@@ -102,7 +103,13 @@ struct Mesh {
 
 		Vector<AABB> bone_aabbs;
 
-		GLuint blend_shape_buffer = 0;
+		struct BlendShape {
+			GLuint vertex_buffer = 0;
+			GLuint vertex_array = 0;
+		};
+
+		BlendShape *blend_shapes = nullptr;
+		GLuint skeleton_vertex_array = 0;
 
 		RID material;
 	};
@@ -136,7 +143,14 @@ struct MeshInstance {
 	Mesh *mesh = nullptr;
 	RID skeleton;
 	struct Surface {
+		GLuint vertex_buffers[2] = { 0, 0 };
+		GLuint vertex_arrays[2] = { 0, 0 };
 		GLuint vertex_buffer = 0;
+		int vertex_stride_cache = 0;
+		int vertex_size_cache = 0;
+		int vertex_normal_offset_cache = 0;
+		int vertex_tangent_offset_cache = 0;
+		uint32_t format_cache = 0;
 
 		Mesh::Surface::Version *versions = nullptr; //allocated on demand
 		uint32_t version_count = 0;
@@ -144,7 +158,6 @@ struct MeshInstance {
 	LocalVector<Surface> surfaces;
 	LocalVector<float> blend_weights;
 
-	GLuint blend_weights_buffer = 0;
 	List<MeshInstance *>::Element *I = nullptr; //used to erase itself
 	uint64_t skeleton_version = 0;
 	bool dirty = false;
@@ -186,12 +199,14 @@ struct MultiMesh {
 struct Skeleton {
 	bool use_2d = false;
 	int size = 0;
+	int height = 0;
 	Vector<float> data;
-	GLuint buffer = 0;
 
 	bool dirty = false;
 	Skeleton *dirty_list = nullptr;
 	Transform2D base_transform_2d;
+
+	GLuint transforms_texture = 0;
 
 	uint64_t version = 1;
 
@@ -201,6 +216,11 @@ struct Skeleton {
 class MeshStorage : public RendererMeshStorage {
 private:
 	static MeshStorage *singleton;
+
+	struct {
+		SkeletonShaderGLES3 shader;
+		RID shader_version;
+	} skeleton_shader;
 
 	/* Mesh */
 
@@ -214,6 +234,7 @@ private:
 
 	void _mesh_instance_clear(MeshInstance *mi);
 	void _mesh_instance_add_surface(MeshInstance *mi, Mesh *mesh, uint32_t p_surface);
+	void _blend_shape_bind_mesh_instance_buffer(MeshInstance *p_mi, uint32_t p_surface);
 	SelfList<MeshInstance>::List dirty_mesh_instance_weights;
 	SelfList<MeshInstance>::List dirty_mesh_instance_arrays;
 
@@ -232,9 +253,10 @@ private:
 
 	mutable RID_Owner<Skeleton, true> skeleton_owner;
 
-	Skeleton *skeleton_dirty_list = nullptr;
-
 	_FORCE_INLINE_ void _skeleton_make_dirty(Skeleton *skeleton);
+	void _compute_skeleton(MeshInstance *p_mi, Skeleton *p_sk, uint32_t p_surface);
+
+	Skeleton *skeleton_dirty_list = nullptr;
 
 public:
 	static MeshStorage *get_singleton();
@@ -534,9 +556,11 @@ public:
 
 	virtual void skeleton_update_dependency(RID p_base, DependencyTracker *p_instance) override;
 
-	/* OCCLUDER */
+	void _update_dirty_skeletons();
 
-	void occluder_set_mesh(RID p_occluder, const PackedVector3Array &p_vertices, const PackedInt32Array &p_indices);
+	_FORCE_INLINE_ bool skeleton_is_valid(RID p_skeleton) {
+		return skeleton_owner.get_or_null(p_skeleton) != nullptr;
+	}
 };
 
 } // namespace GLES3

--- a/drivers/gles3/storage/utilities.cpp
+++ b/drivers/gles3/storage/utilities.cpp
@@ -281,7 +281,7 @@ String Utilities::get_captured_timestamp_name(uint32_t p_index) const {
 void Utilities::update_dirty_resources() {
 	MaterialStorage::get_singleton()->_update_global_shader_uniforms();
 	MaterialStorage::get_singleton()->_update_queued_materials();
-	//MeshStorage::get_singleton()->_update_dirty_skeletons();
+	MeshStorage::get_singleton()->_update_dirty_skeletons();
 	MeshStorage::get_singleton()->_update_dirty_multimeshes();
 	TextureStorage::get_singleton()->update_texture_atlas();
 }

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
@@ -665,7 +665,6 @@ public:
 
 	virtual void skeleton_allocate_data(RID p_skeleton, int p_bones, bool p_2d_skeleton = false) override;
 	virtual void skeleton_set_base_transform_2d(RID p_skeleton, const Transform2D &p_base_transform) override;
-	void skeleton_set_world_transform(RID p_skeleton, bool p_enable, const Transform3D &p_world_transform);
 	virtual int skeleton_get_bone_count(RID p_skeleton) const override;
 	virtual void skeleton_bone_set_transform(RID p_skeleton, int p_bone, const Transform3D &p_transform) override;
 	virtual Transform3D skeleton_bone_get_transform(RID p_skeleton, int p_bone) const override;


### PR DESCRIPTION
This uses a similar multipass approach to blend shapes as Godot 3.x, the major difference here is that we need to convert the normals and tangents to octahedral for rendering.

Skeletons work the same as the Vulkan renderer except the bones are stored in a texture as they were in 3.x.

Performance in my testing is very good on newer hardware. I expect performance will be not amazing on older hardware and on Apple devices due to the use of transform feedback. The plan is to use ANGLE to improve performance on Windows and on Apple devices. 

This is the last big 2D feature remaining for the OpenGL renderer. Hooray!
