### PR TITLE
[3.x] Add built-in action toggle in Input Map settings

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -110,8 +110,6 @@ void ProjectSettingsEditor::_notification(int p_what) {
 			search_box->set_right_icon(get_icon("Search", "EditorIcons"));
 			search_box->set_clear_button_enabled(true);
 
-			action_add_error->add_color_override("font_color", get_color("error_color", "Editor"));
-
 			translation_list->connect("button_pressed", this, "_translation_delete");
 			_update_actions();
 
@@ -161,7 +159,6 @@ void ProjectSettingsEditor::_notification(int p_what) {
 			search_button->set_icon(get_icon("Search", "EditorIcons"));
 			search_box->set_right_icon(get_icon("Search", "EditorIcons"));
 			search_box->set_clear_button_enabled(true);
-			action_add_error->add_color_override("font_color", get_color("error_color", "Editor"));
 			popup_add->set_item_icon(popup_add->get_item_index(INPUT_KEY_PHYSICAL), get_icon("KeyboardPhysical", "EditorIcons"));
 			popup_add->set_item_icon(popup_add->get_item_index(INPUT_KEY), get_icon("Keyboard", "EditorIcons"));
 			popup_add->set_item_icon(popup_add->get_item_index(INPUT_JOY_BUTTON), get_icon("JoyButton", "EditorIcons"));
@@ -197,6 +194,16 @@ void ProjectSettingsEditor::_action_selected() {
 	edit_idx = -1;
 }
 
+String _check_new_action_name(const String &p_name) {
+	if (p_name.empty() || !_validate_action_name(p_name)) {
+		return TTR("Invalid action name. It cannot be empty nor contain '/', ':', '=', '\\' or '\"'.");
+	}
+	if (ProjectSettings::get_singleton()->has_setting("input/" + p_name)) {
+		return vformat(TTR("An action with the name '%s' already exists."), p_name);
+	}
+	return String();
+}
+
 void ProjectSettingsEditor::_action_edited() {
 	TreeItem *ti = input_editor->get_selected();
 	if (!ti) {
@@ -211,25 +218,17 @@ void ProjectSettingsEditor::_action_edited() {
 			return;
 		}
 
-		if (new_name == "" || !_validate_action_name(new_name)) {
+		const String error = _check_new_action_name(new_name);
+		if (!error.empty()) {
 			ti->set_text(0, old_name);
 			add_at = "input/" + old_name;
 
-			message->set_text(TTR("Invalid action name. It cannot be empty nor contain '/', ':', '=', '\\' or '\"'"));
+			message->set_text(error);
 			message->popup_centered(Size2(300, 100) * EDSCALE);
 			return;
 		}
 
 		String action_prop = "input/" + new_name;
-
-		if (ProjectSettings::get_singleton()->has_setting(action_prop)) {
-			ti->set_text(0, old_name);
-			add_at = "input/" + old_name;
-
-			message->set_text(vformat(TTR("An action with the name '%s' already exists."), new_name));
-			message->popup_centered(Size2(300, 100) * EDSCALE);
-			return;
-		}
 
 		int order = ProjectSettings::get_singleton()->get_order(add_at);
 		Dictionary action = ProjectSettings::get_singleton()->get(add_at);
@@ -743,6 +742,11 @@ void ProjectSettingsEditor::_update_actions() {
 			continue;
 		}
 
+		const bool is_builtin = ProjectSettings::get_singleton()->get_input_presets().find(pi.name) != nullptr;
+		if (is_builtin && !show_builtin_actions) {
+			continue;
+		}
+
 		Dictionary action = ProjectSettings::get_singleton()->get(pi.name);
 		Array events = action["events"];
 
@@ -760,7 +764,7 @@ void ProjectSettingsEditor::_update_actions() {
 		item->set_custom_bg_color(1, get_color("prop_subsection", "Editor"));
 
 		item->add_button(2, get_icon("Add", "EditorIcons"), 1, false, TTR("Add Event"));
-		if (!ProjectSettings::get_singleton()->get_input_presets().find(pi.name)) {
+		if (!is_builtin) {
 			item->add_button(2, get_icon("Remove", "EditorIcons"), 2, false, TTR("Remove"));
 			item->set_editable(0, true);
 		}
@@ -957,26 +961,9 @@ void ProjectSettingsEditor::_item_del() {
 }
 
 void ProjectSettingsEditor::_action_check(String p_action) {
-	if (p_action == "") {
-		action_add->set_disabled(true);
-	} else {
-		if (!_validate_action_name(p_action)) {
-			action_add_error->set_text(TTR("Invalid action name. It cannot be empty nor contain '/', ':', '=', '\\' or '\"'."));
-			action_add_error->show();
-			action_add->set_disabled(true);
-			return;
-		}
-		if (ProjectSettings::get_singleton()->has_setting("input/" + p_action)) {
-			action_add_error->set_text(vformat(TTR("An action with the name '%s' already exists."), p_action));
-			action_add_error->show();
-			action_add->set_disabled(true);
-			return;
-		}
-
-		action_add->set_disabled(false);
-	}
-
-	action_add_error->hide();
+	String error = _check_new_action_name(p_action);
+	action_add->set_tooltip(error);
+	action_add->set_disabled(!error.empty());
 }
 
 void ProjectSettingsEditor::_action_adds(String) {
@@ -1014,8 +1001,12 @@ void ProjectSettingsEditor::_action_add() {
 
 	r->select(0);
 	input_editor->ensure_cursor_is_visible();
-	action_add_error->hide();
 	action_name->clear();
+}
+
+void ProjectSettingsEditor::_set_show_builtin_actions(bool p_show) {
+	show_builtin_actions = p_show;
+	_update_actions();
 }
 
 void ProjectSettingsEditor::_item_checked(const String &p_item, bool p_check) {
@@ -1605,6 +1596,7 @@ void ProjectSettingsEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_action_edited"), &ProjectSettingsEditor::_action_edited);
 	ClassDB::bind_method(D_METHOD("_action_activated"), &ProjectSettingsEditor::_action_activated);
 	ClassDB::bind_method(D_METHOD("_action_button_pressed"), &ProjectSettingsEditor::_action_button_pressed);
+	ClassDB::bind_method(D_METHOD("_set_show_builtin_actions"), &ProjectSettingsEditor::_set_show_builtin_actions);
 	ClassDB::bind_method(D_METHOD("_update_actions"), &ProjectSettingsEditor::_update_actions);
 	ClassDB::bind_method(D_METHOD("_wait_for_key"), &ProjectSettingsEditor::_wait_for_key);
 	ClassDB::bind_method(D_METHOD("_add_item"), &ProjectSettingsEditor::_add_item, DEFVAL(Variant()));
@@ -1780,14 +1772,11 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	l->set_text(TTR("Action:"));
 
 	action_name = memnew(LineEdit);
+	action_name->set_clear_button_enabled(true);
 	action_name->set_h_size_flags(SIZE_EXPAND_FILL);
 	hbc->add_child(action_name);
 	action_name->connect("text_entered", this, "_action_adds");
 	action_name->connect("text_changed", this, "_action_check");
-
-	action_add_error = memnew(Label);
-	hbc->add_child(action_add_error);
-	action_add_error->hide();
 
 	add = memnew(Button);
 	hbc->add_child(add);
@@ -1795,6 +1784,12 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	add->set_disabled(true);
 	add->connect("pressed", this, "_action_add");
 	action_add = add;
+
+	show_builtin_actions_checkbutton = memnew(CheckButton);
+	hbc->add_child(show_builtin_actions_checkbutton);
+	show_builtin_actions_checkbutton->set_text(TTR("Show Built-in Actions"));
+	show_builtin_actions_checkbutton->set_pressed(false);
+	show_builtin_actions_checkbutton->connect("toggled", this, "_set_show_builtin_actions");
 
 	input_editor = memnew(Tree);
 	vbc->add_child(input_editor);
@@ -1984,4 +1979,5 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	add_child(timer);
 
 	updating_translations = false;
+	show_builtin_actions = false;
 }

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -84,10 +84,11 @@ class ProjectSettingsEditor : public AcceptDialog {
 
 	LineEdit *action_name;
 	Button *action_add;
-	Label *action_add_error;
+	CheckButton *show_builtin_actions_checkbutton;
 	Tree *input_editor;
 	bool setting;
 	bool updating_translations;
+	bool show_builtin_actions;
 
 	Ref<InputEventKey> last_wait_for_key;
 
@@ -118,6 +119,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _action_adds(String);
 	void _action_add();
 	void _device_input_add();
+	void _set_show_builtin_actions(bool p_show);
 
 	void _item_checked(const String &p_item, bool p_check);
 	void _action_selected();


### PR DESCRIPTION
Like in 4.0:

* Adds a "Show Built-in Actions" toggle.
* Display name error in the tooltip of the disabled Add button, so that controls won't exceed dialog boundary in some cases.

![Peek 2022-11-29 16-53](https://user-images.githubusercontent.com/372476/204484207-722c5a66-f175-4e33-b32a-759f13caf5db.gif)

This is a reimplementation instead of a backport since the action map editor changed quite a lot in 4.0. But the new functions / variables still use the same name as their 4.0 counterpart.