### PR TITLE
[Core] Fix Resource.resource_name type.

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -436,7 +436,7 @@ void Resource::_bind_methods() {
 	ADD_GROUP("Resource", "resource_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "resource_local_to_scene"), "set_local_to_scene", "is_local_to_scene");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "resource_path", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_path", "get_path");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "resource_name"), "set_name", "get_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "resource_name"), "set_name", "get_name");
 
 	MethodInfo get_rid_bind("_get_rid");
 	get_rid_bind.return_val.type = Variant::RID;


### PR DESCRIPTION
The methods returns a String, but the Variant was bound as a StringName.

We could alternatively change the method return type but that's a breaking change which will requires code changes in other parts of the engine.