### PR TITLE
Fix crash AnimationTimelineEdit when switch FPS mode without track

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1754,7 +1754,9 @@ void AnimationTimelineEdit::update_values() {
 		length->set_step(1);
 		length->set_tooltip_text(TTR("Animation length (frames)"));
 		time_icon->set_tooltip_text(TTR("Animation length (frames)"));
-		track_edit->editor->_update_key_edit();
+		if (track_edit) {
+			track_edit->editor->_update_key_edit();
+		}
 	} else {
 		length->set_value(animation->get_length());
 		length->set_step(0.001);


### PR DESCRIPTION
Fixes #69340.

AnimationTrackKeyEdit does not exist if AnimationTrackEdit has not yet been created. Added nullptr check.