### PR TITLE
Add missing public `property_*_revert` getters

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1473,6 +1473,8 @@ void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_indexed", "property_path"), &Object::_get_indexed_bind);
 	ClassDB::bind_method(D_METHOD("get_property_list"), &Object::_get_property_list_bind);
 	ClassDB::bind_method(D_METHOD("get_method_list"), &Object::_get_method_list_bind);
+	ClassDB::bind_method(D_METHOD("property_can_revert", "property"), &Object::property_can_revert);
+	ClassDB::bind_method(D_METHOD("property_get_revert", "property"), &Object::property_get_revert);
 	ClassDB::bind_method(D_METHOD("notification", "what", "reversed"), &Object::notification, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("to_string"), &Object::to_string);
 	ClassDB::bind_method(D_METHOD("get_instance_id"), &Object::get_instance_id);

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -764,6 +764,22 @@
 				Emits the [signal property_list_changed] signal. This is mainly used to refresh the editor, so that the Inspector and editor plugins are properly updated.
 			</description>
 		</method>
+		<method name="property_can_revert" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="property" type="StringName" />
+			<description>
+				Returns [code]true[/code] if the given [param property] has a custom default value. Use [method property_get_revert] to get the [param property]'s default value.
+				[b]Note:[/b] This method is used by the Inspector dock to display a revert icon. The object must implement [method _property_can_revert] to customize the default value. If [method _property_can_revert] is not implemented, this method returns [code]false[/code].
+			</description>
+		</method>
+		<method name="property_get_revert" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="property" type="StringName" />
+			<description>
+				Returns the custom default value of the given [param property]. Use [method property_can_revert] to check if the [param property] has a custom default value.
+				[b]Note:[/b] This method is used by the Inspector dock to display a revert icon. The object must implement [method _property_get_revert] to customize the default value. If [method _property_get_revert] is not implemented, this method returns [code]null[/code].
+			</description>
+		</method>
 		<method name="remove_meta">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/69335. In my initial implementation moving these methods to virtual calls I missed the possible need for users to fetch the values. So this PR adds the missing public counterparts of the virtual methods, the same way they exist for other such methods.

Based on the report, here's how you're supposed to use it. The virtual method is prefixed, the public getter is not.

```gdscript

func _property_get_revert(property : StringName):
	if str(property).begins_with("mat_"):
		var param_name = str(property).replace("mat_", "")
		
		var revert_value = _material.property_get_revert(str("shader_param/", param_name))
		
		return revert_value
```

cc @Mickeon I'd appreciate a look at the docs from you <3