### PR TITLE
[3.x] Try loading the path specified in a preload(..) method call with the ResourceLoader if the script code completion cache is not yet available

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -527,6 +527,8 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 						return nullptr;
 					} else if (ScriptCodeCompletionCache::get_singleton()) {
 						res = ScriptCodeCompletionCache::get_singleton()->get_cached_resource(path);
+					} else {
+						res = ResourceLoader::load(path);
 					}
 				}
 				if (!res.is_valid()) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/69360
Fixes: https://github.com/godotengine/godot/issues/78475
Maybe related to: https://github.com/godotengine/godot/issues/35248 (Not sure as I didn't used an external editor, but the issue there sounds very similar)

This fixes the problem that autoloaded nodes could not be loaded because they (or there children) preload other nodes in their script. 
This only happened at the start of Godot. When the autoloaded nodes will be resolved, there is no `ScriptCodeCompletionCache` yet.

This scenario is also handled above, so we may as well handle it here in the same way.
https://github.com/godotengine/godot/blob/7cfd984e73d6d7d5b29f4079ea7f0e34bf67420b/modules/gdscript/gdscript_parser.cpp#L522

Why exactly is the `ScriptCodeCompletionCache` not yet resolved?
In editor_node:
- Line 6348: `ProjectSettingsEditor` is instantiated -> `EditorAutoloadSettings` -> Autoloaded scenes will be created
- Line 6985: `ScriptEditorPlugin` is instantiated -> `ScriptCodeCompletionCache` will be instantiated

----
ANOTHER POSSIBLE FIX

Initialize the `ScriptCodeCompletionCache` (`ScriptCodeCompletionCache::get_singleton()`) before resolving the autoloaded scenes.
Then the `ScriptCodeCompletionCache` cache can be reused. (Order needs be changed in `editor_node`)

Moving down the `ProjectSettingsEditor` in the instantiation order (after `ScriptEditorPlugin`) does work and everything looks normal. And the `ScriptCodeCompletionCache` is created before the autoloaded nodes are created. But this is a much more risky change.

**Note: This bug does not happen in Godot 4.0**