### PR TITLE
Fix heap-use-after-free when changing alternative tile ID

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -152,7 +152,7 @@ bool TileSetAtlasSourceEditor::AtlasTileProxyObject::_set(const StringName &p_na
 
 	// ID and size related properties.
 	if (tiles.size() == 1) {
-		const Vector2i &coords = tiles.front()->get().tile;
+		const Vector2i coords = tiles.front()->get().tile;
 		const int &alternative = tiles.front()->get().alternative;
 
 		if (alternative == 0) {


### PR DESCRIPTION
`coords` was a reference to an element inside the container. The element no longer exists after `clear()`, so accessing `coords` is then undefined behavior, crashing a sanitizer build.

https://github.com/godotengine/godot/blob/5826e960143fd416e0d02cf8f672d778f56da9ea/editor/plugins/tiles/tile_set_atlas_source_editor.cpp#L155

https://github.com/godotengine/godot/blob/5826e960143fd416e0d02cf8f672d778f56da9ea/editor/plugins/tiles/tile_set_atlas_source_editor.cpp#L196-L197

<details><summary>Address Sanitizer output</summary>

```
=================================================================
==492221==ERROR: AddressSanitizer: heap-use-after-free on address 0x6070029ebb50 at pc 0x557fb99e9c59 bp 0x7ffc053bbed0 sp 0x7ffc053bbec0
READ of size 8 at 0x6070029ebb50 thread T0
    #0 0x557fb99e9c58 in TileSetAtlasSourceEditor::AtlasTileProxyObject::_set(StringName const&, Variant const&) editor/plugins/tiles/tile_set_atlas_source_editor.cpp:197
    #1 0x557fb9a41c7d in TileSetAtlasSourceEditor::AtlasTileProxyObject::_setv(StringName const&, Variant const&) editor/plugins/tiles/tile_set_atlas_source_editor.h:88
    #2 0x557fbee3708e in Object::set(StringName const&, Variant const&, bool*) core/object/object.cpp:293
    #3 0x557fbeec4482 in UndoRedo::_process_operation_list(List<UndoRedo::Operation, DefaultAllocator>::Element*) core/object/undo_redo.cpp:351
    #4 0x557fbeec01cc in UndoRedo::_redo(bool) core/object/undo_redo.cpp:75
    #5 0x557fbeec3502 in UndoRedo::commit_action(bool) core/object/undo_redo.cpp:297
    #6 0x557fb8107731 in EditorUndoRedoManager::commit_action(bool) editor/editor_undo_redo_manager.cpp:234
    #7 0x557fb7b70050 in EditorInspector::_edit_set(String const&, Variant const&, bool, String const&) editor/editor_inspector.cpp:3665
    #8 0x557fb7b70f8d in EditorInspector::_property_changed(String const&, Variant const&, String const&, bool, bool) editor/editor_inspector.cpp:3682
    #9 0x557fb7bdf885 in void call_with_variant_args_helper<EditorInspector, String const&, Variant const&, String const&, bool, bool, 0ul, 1ul, 2ul, 3ul, 4ul>(EditorInspector*, void (EditorInspector::*)(String const&, Variant const&, String const&, bool, bool), Variant const**, Callable::CallError&, IndexSequence<0ul, 1ul, 2ul, 3ul, 4ul>) core/variant/binder_common.h:262
    #10 0x557fb7bd784d in void call_with_variant_args<EditorInspector, String const&, Variant const&, String const&, bool, bool>(EditorInspector*, void (EditorInspector::*)(String const&, Variant const&, String const&, bool, bool), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:376
    #11 0x557fb7bc7ac1 in CallableCustomMethodPointer<EditorInspector, String const&, Variant const&, String const&, bool, bool>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #12 0x557fbe69bc41 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #13 0x557fbe6a3639 in CallableCustomBind::call(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable_bind.cpp:99
    #14 0x557fbe69bc41 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #15 0x557fbee41100 in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1046
    #16 0x557fb7b0afb3 in EditorProperty::emit_changed(StringName const&, Variant const&, StringName const&, bool) editor/editor_inspector.cpp:120
    #17 0x557fb7e03ee2 in EditorPropertyInteger::_value_changed(long) editor/editor_properties.cpp:1368
    #18 0x557fb7edfc1f in void call_with_variant_args_helper<EditorPropertyInteger, long, 0ul>(EditorPropertyInteger*, void (EditorPropertyInteger::*)(long), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:262
    #19 0x557fb7ed4d6c in void call_with_variant_args<EditorPropertyInteger, long>(EditorPropertyInteger*, void (EditorPropertyInteger::*)(long), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:376
    #20 0x557fb7ebb48f in CallableCustomMethodPointer<EditorPropertyInteger, long>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #21 0x557fbe69bc41 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #22 0x557fbee41100 in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1046
    #23 0x557fb769e94e in Error Object::emit_signal<double>(StringName const&, double) core/object/object.h:869
    #24 0x557fba3b6dec in Range::_value_changed_notify() scene/gui/range.cpp:48
    #25 0x557fba3b6ff5 in Range::Shared::emit_value_changed() scene/gui/range.cpp:58
    #26 0x557fba3b77b9 in Range::set_value(double) scene/gui/range.cpp:87
    #27 0x557fb804d3c4 in EditorSpinSlider::gui_input(Ref<InputEvent> const&) editor/editor_spin_slider.cpp:68
    #28 0x557fba07d6c3 in Control::_call_gui_input(Ref<InputEvent> const&) scene/gui/control.cpp:1709
    #29 0x557fb9dee120 in Viewport::_gui_call_input(Control*, Ref<InputEvent> const&) scene/main/viewport.cpp:1326
    #30 0x557fb9df0fc9 in Viewport::_gui_input_event(Ref<InputEvent>) scene/main/viewport.cpp:1559
    #31 0x557fb9e039ff in Viewport::push_input(Ref<InputEvent> const&, bool) scene/main/viewport.cpp:2784
    #32 0x557fb9eaa539 in Window::_window_input(Ref<InputEvent> const&) scene/main/window.cpp:1089
    #33 0x557fb9f130e6 in void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:262
    #34 0x557fb9f08237 in void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:376
    #35 0x557fb9efbf67 in CallableCustomMethodPointer<Window, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #36 0x557fbe69bc41 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #37 0x557fb2abc140 in DisplayServerX11::_dispatch_input_event(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:3246
    #38 0x557fb2abbb6a in DisplayServerX11::_dispatch_input_events(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:3217
    #39 0x557fbe5b717c in Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) core/input/input.cpp:663
    #40 0x557fbe5bb09c in Input::flush_buffered_events() core/input/input.cpp:885
    #41 0x557fb2ac94ff in DisplayServerX11::process_events() platform/linuxbsd/x11/display_server_x11.cpp:4244
    #42 0x557fb2a7c506 in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:795
    #43 0x557fb2a689d1 in main platform/linuxbsd/godot_linuxbsd.cpp:73
    #44 0x7fa0de21128f  (/usr/lib/libc.so.6+0x2328f)
    #45 0x7fa0de211349 in __libc_start_main (/usr/lib/libc.so.6+0x23349)
    #46 0x557fb2a685a4 in _start ../sysdeps/x86_64/start.S:115

0x6070029ebb50 is located 64 bytes inside of 80-byte region [0x6070029ebb10,0x6070029ebb60)
freed by thread T0 here:
    #0 0x7fa0de6be672 in __interceptor_free /usr/src/debug/gcc/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x557fbe0ef80a in Memory::free_static(void*, bool) core/os/memory.cpp:168
    #2 0x557fb2a6b172 in DefaultAllocator::free(void*) core/os/memory.h:66
    #3 0x557fb9a510f8 in void memdelete_allocator<RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::Element, DefaultAllocator>(RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::Element*) core/os/memory.h:124
    #4 0x557fb9a4ba38 in RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::_cleanup_tree(RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::Element*) core/templates/rb_set.h:557
    #5 0x557fb9a45d02 in RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::clear() core/templates/rb_set.h:690
    #6 0x557fb99e9ba1 in TileSetAtlasSourceEditor::AtlasTileProxyObject::_set(StringName const&, Variant const&) editor/plugins/tiles/tile_set_atlas_source_editor.cpp:196
    #7 0x557fb9a41c7d in TileSetAtlasSourceEditor::AtlasTileProxyObject::_setv(StringName const&, Variant const&) editor/plugins/tiles/tile_set_atlas_source_editor.h:88
    #8 0x557fbee3708e in Object::set(StringName const&, Variant const&, bool*) core/object/object.cpp:293
    #9 0x557fbeec4482 in UndoRedo::_process_operation_list(List<UndoRedo::Operation, DefaultAllocator>::Element*) core/object/undo_redo.cpp:351
    #10 0x557fbeec01cc in UndoRedo::_redo(bool) core/object/undo_redo.cpp:75
    #11 0x557fbeec3502 in UndoRedo::commit_action(bool) core/object/undo_redo.cpp:297
    #12 0x557fb8107731 in EditorUndoRedoManager::commit_action(bool) editor/editor_undo_redo_manager.cpp:234
    #13 0x557fb7b70050 in EditorInspector::_edit_set(String const&, Variant const&, bool, String const&) editor/editor_inspector.cpp:3665
    #14 0x557fb7b70f8d in EditorInspector::_property_changed(String const&, Variant const&, String const&, bool, bool) editor/editor_inspector.cpp:3682
    #15 0x557fb7bdf885 in void call_with_variant_args_helper<EditorInspector, String const&, Variant const&, String const&, bool, bool, 0ul, 1ul, 2ul, 3ul, 4ul>(EditorInspector*, void (EditorInspector::*)(String const&, Variant const&, String const&, bool, bool), Variant const**, Callable::CallError&, IndexSequence<0ul, 1ul, 2ul, 3ul, 4ul>) core/variant/binder_common.h:262
    #16 0x557fb7bd784d in void call_with_variant_args<EditorInspector, String const&, Variant const&, String const&, bool, bool>(EditorInspector*, void (EditorInspector::*)(String const&, Variant const&, String const&, bool, bool), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:376
    #17 0x557fb7bc7ac1 in CallableCustomMethodPointer<EditorInspector, String const&, Variant const&, String const&, bool, bool>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #18 0x557fbe69bc41 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #19 0x557fbe6a3639 in CallableCustomBind::call(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable_bind.cpp:99
    #20 0x557fbe69bc41 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #21 0x557fbee41100 in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1046
    #22 0x557fb7b0afb3 in EditorProperty::emit_changed(StringName const&, Variant const&, StringName const&, bool) editor/editor_inspector.cpp:120
    #23 0x557fb7e03ee2 in EditorPropertyInteger::_value_changed(long) editor/editor_properties.cpp:1368
    #24 0x557fb7edfc1f in void call_with_variant_args_helper<EditorPropertyInteger, long, 0ul>(EditorPropertyInteger*, void (EditorPropertyInteger::*)(long), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:262
    #25 0x557fb7ed4d6c in void call_with_variant_args<EditorPropertyInteger, long>(EditorPropertyInteger*, void (EditorPropertyInteger::*)(long), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:376
    #26 0x557fb7ebb48f in CallableCustomMethodPointer<EditorPropertyInteger, long>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #27 0x557fbe69bc41 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #28 0x557fbee41100 in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1046
    #29 0x557fb769e94e in Error Object::emit_signal<double>(StringName const&, double) core/object/object.h:869

previously allocated by thread T0 here:
    #0 0x7fa0de6bfa89 in __interceptor_malloc /usr/src/debug/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x557fbe0eec34 in Memory::alloc_static(unsigned long, bool) core/os/memory.cpp:75
    #2 0x557fb2a6b153 in DefaultAllocator::alloc(unsigned long) core/os/memory.h:65
    #3 0x557fbe0eeb71 in operator new(unsigned long, void* (*)(unsigned long)) core/os/memory.cpp:44
    #4 0x557fb9a4be7d in RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::_insert(TileSetAtlasSourceEditor::TileSelection const&) core/templates/rb_set.h:396
    #5 0x557fb9a45e29 in RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::insert(TileSetAtlasSourceEditor::TileSelection const&) core/templates/rb_set.h:602
    #6 0x557fb9a4b247 in RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::_copy_from(RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator> const&) core/templates/rb_set.h:564
    #7 0x557fb9a46174 in RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>::operator=(RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator> const&) core/templates/rb_set.h:697
    #8 0x557fb99f19e8 in TileSetAtlasSourceEditor::AtlasTileProxyObject::edit(TileSetAtlasSource*, RBSet<TileSetAtlasSourceEditor::TileSelection, Comparator<TileSetAtlasSourceEditor::TileSelection>, DefaultAllocator>) editor/plugins/tiles/tile_set_atlas_source_editor.cpp:500
    #9 0x557fb99f3c74 in TileSetAtlasSourceEditor::_update_tile_inspector() editor/plugins/tiles/tile_set_atlas_source_editor.cpp:577
    #10 0x557fb9a1f6ce in TileSetAtlasSourceEditor::_tile_alternatives_control_gui_input(Ref<InputEvent> const&) editor/plugins/tiles/tile_set_atlas_source_editor.cpp:1930
    #11 0x557fb9a5e89c in void call_with_variant_args_helper<TileSetAtlasSourceEditor, Ref<InputEvent> const&, 0ul>(TileSetAtlasSourceEditor*, void (TileSetAtlasSourceEditor::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:262
    #12 0x557fb9a5d38a in void call_with_variant_args<TileSetAtlasSourceEditor, Ref<InputEvent> const&>(TileSetAtlasSourceEditor*, void (TileSetAtlasSourceEditor::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:376
    #13 0x557fb9a583fb in CallableCustomMethodPointer<TileSetAtlasSourceEditor, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #14 0x557fbe69bc41 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #15 0x557fbee41100 in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1046
    #16 0x557fb81606c0 in Error Object::emit_signal<Ref<InputEvent> >(StringName const&, Ref<InputEvent>) core/object/object.h:869
    #17 0x557fba07d54e in Control::_call_gui_input(Ref<InputEvent> const&) scene/gui/control.cpp:1701
    #18 0x557fb9dee120 in Viewport::_gui_call_input(Control*, Ref<InputEvent> const&) scene/main/viewport.cpp:1326
    #19 0x557fb9df0fc9 in Viewport::_gui_input_event(Ref<InputEvent>) scene/main/viewport.cpp:1559
    #20 0x557fb9e039ff in Viewport::push_input(Ref<InputEvent> const&, bool) scene/main/viewport.cpp:2784
    #21 0x557fb9eaa539 in Window::_window_input(Ref<InputEvent> const&) scene/main/window.cpp:1089
    #22 0x557fb9f130e6 in void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:262
    #23 0x557fb9f08237 in void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:376
    #24 0x557fb9efbf67 in CallableCustomMethodPointer<Window, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #25 0x557fbe69bc41 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #26 0x557fb2abc140 in DisplayServerX11::_dispatch_input_event(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:3246
    #27 0x557fb2abbb6a in DisplayServerX11::_dispatch_input_events(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:3217
    #28 0x557fbe5b717c in Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) core/input/input.cpp:663
    #29 0x557fbe5bb09c in Input::flush_buffered_events() core/input/input.cpp:885

SUMMARY: AddressSanitizer: heap-use-after-free editor/plugins/tiles/tile_set_atlas_source_editor.cpp:197 in TileSetAtlasSourceEditor::AtlasTileProxyObject::_set(StringName const&, Variant const&)
Shadow bytes around the buggy address:
  0x0c0e80535710: fd fd fd fd fd fd fd fd fa fa fa fa fd fd fd fd
  0x0c0e80535720: fd fd fd fd fd fd fa fa fa fa fd fd fd fd fd fd
  0x0c0e80535730: fd fd fd fd fa fa fa fa 00 00 00 00 00 00 00 00
  0x0c0e80535740: 00 00 fa fa fa fa fd fd fd fd fd fd fd fd fd fd
  0x0c0e80535750: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 fa fa
=>0x0c0e80535760: fa fa fd fd fd fd fd fd fd fd[fd]fd fa fa fa fa
  0x0c0e80535770: fd fd fd fd fd fd fd fd fd fd fa fa fa fa fd fd
  0x0c0e80535780: fd fd fd fd fd fd fd fd fa fa fa fa fd fd fd fd
  0x0c0e80535790: fd fd fd fd fd fa fa fa fa fa fd fd fd fd fd fd
  0x0c0e805357a0: fd fd fd fd fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c0e805357b0: fd fd fa fa fa fa 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==492221==ABORTING
```
</details>