### PR TITLE
Adjust position and size for dropping texture in canvas editor.

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5596,7 +5596,7 @@ void CanvasItemEditorViewport::_create_nodes(Node *parent, Node *child, String &
 	// make visible for certain node type
 	if (Object::cast_to<Control>(child)) {
 		Size2 texture_size = texture->get_size();
-		undo_redo->add_do_property(child, "rect_size", texture_size);
+		undo_redo->add_do_property(child, "size", texture_size);
 	} else if (Object::cast_to<Polygon2D>(child)) {
 		Size2 texture_size = texture->get_size();
 		Vector<Vector2> list = {
@@ -5611,6 +5611,11 @@ void CanvasItemEditorViewport::_create_nodes(Node *parent, Node *child, String &
 	// Compute the global position
 	Transform2D xform = canvas_item_editor->get_canvas_transform();
 	Point2 target_position = xform.affine_inverse().xform(p_point);
+
+	// Adjust position for Control and TouchScreenButton
+	if (Object::cast_to<Control>(child) || Object::cast_to<TouchScreenButton>(child)) {
+		target_position -= texture->get_size() / 2;
+	}
 
 	// there's nothing to be used as source position so snapping will work as absolute if enabled
 	target_position = canvas_item_editor->snap_point(target_position);


### PR DESCRIPTION
1. Fix incorrect size when creating `NinePatchTexture`;
2. Adjust Control and TouchScreenButton's position.

Before:
![before_nine_patch](https://user-images.githubusercontent.com/12966814/204746703-13cbb377-5c86-49c6-92f5-50a495e1d8c6.gif)
![before_control](https://user-images.githubusercontent.com/12966814/204746716-c582b38e-c682-44e7-89f3-412f03b0922d.gif)




After:
![after](https://user-images.githubusercontent.com/12966814/204746753-17691c77-18e3-49d3-958c-3c1e56b2d9e2.gif)
