### PR TITLE
Fix incorrect mouse event position while hovering different window

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2910,11 +2910,10 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			old_x = mm->get_position().x;
 			old_y = mm->get_position().y;
 
-			if (!windows[receiving_window_id].window_has_focus) {
-				// In case of unfocused Popups, adjust event position.
-				Point2i pos = mm->get_position() - window_get_position(receiving_window_id) + window_get_position(window_id);
-				mm->set_position(pos);
-				mm->set_global_position(pos);
+			if (receiving_window_id != window_id) {
+				// Adjust event position relative to window distance when event is sent to a different window.
+				mm->set_position(mm->get_position() - window_get_position(receiving_window_id) + window_get_position(window_id));
+				mm->set_global_position(mm->get_position());
 			}
 			Input::get_singleton()->parse_input_event(mm);
 


### PR DESCRIPTION
resolve #69368
follow up to #68099 and generalizes this approach to all other windows
made sure, that this doesn't reintroduce #68084
