### PR TITLE
Fix C# Solution Directory Project Settings

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
@@ -12,8 +12,7 @@
     <Configurations>Debug;ExportDebug;ExportRelease</Configurations>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
 
-    <GodotProjectDir Condition=" '$(SolutionDir)' != '' ">$(SolutionDir)</GodotProjectDir>
-    <GodotProjectDir Condition=" '$(SolutionDir)' == '' ">$(MSBuildProjectDirectory)</GodotProjectDir>
+    <GodotProjectDir Condition=" '$(GodotProjectDir)' == '' ">$(MSBuildProjectDirectory)</GodotProjectDir>
     <GodotProjectDir>$([MSBuild]::EnsureTrailingSlash('$(GodotProjectDir)'))</GodotProjectDir>
 
     <!-- Custom output paths for Godot projects. In brief, 'bin\' and 'obj\' are moved to '$(GodotProjectDir)\.godot\mono\temp\'. -->

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -57,24 +57,22 @@ namespace GodotTools
             {
                 pr.Step("Generating C# project...".TTR());
 
-                string resourceDir = ProjectSettings.GlobalizePath("res://");
-
-                string path = resourceDir;
+                string csprojDir = Path.GetDirectoryName(GodotSharpDirs.ProjectCsProjPath);
+                string slnDir = Path.GetDirectoryName(GodotSharpDirs.ProjectSlnPath);
                 string name = GodotSharpDirs.ProjectAssemblyName;
-
-                string guid = CsProjOperations.GenerateGameProject(path, name);
+                string guid = CsProjOperations.GenerateGameProject(csprojDir, name);
 
                 if (guid.Length > 0)
                 {
                     var solution = new DotNetSolution(name)
                     {
-                        DirectoryPath = path
+                        DirectoryPath = slnDir
                     };
 
                     var projectInfo = new DotNetSolution.ProjectInfo
                     {
                         Guid = guid,
-                        PathRelativeToSolution = name + ".csproj",
+                        PathRelativeToSolution = Path.GetRelativePath(slnDir, GodotSharpDirs.ProjectCsProjPath),
                         Configs = new List<string> { "Debug", "ExportDebug", "ExportRelease" }
                     };
 
@@ -374,6 +372,8 @@ namespace GodotTools
         public override void _EnablePlugin()
         {
             base._EnablePlugin();
+
+            ProjectSettingsChanged += GodotSharpDirs.DetermineProjectLocation;
 
             if (Instance != null)
                 throw new InvalidOperationException();

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
@@ -52,10 +52,9 @@ namespace GodotTools.Internals
         {
             GlobalDef("dotnet/project/assembly_name", "");
             GlobalDef("dotnet/project/solution_directory", "");
-            GlobalDef("dotnet/project/c#_project_directory", "");
         }
 
-        private static void DetermineProjectLocation()
+        public static void DetermineProjectLocation()
         {
             static string DetermineProjectName()
             {
@@ -76,10 +75,11 @@ namespace GodotTools.Internals
             string slnParentDir = (string)ProjectSettings.GetSetting("dotnet/project/solution_directory");
             if (string.IsNullOrEmpty(slnParentDir))
                 slnParentDir = "res://";
+            else if (!slnParentDir.StartsWith("res://"))
+                slnParentDir = "res://" + slnParentDir;
 
-            string csprojParentDir = (string)ProjectSettings.GetSetting("dotnet/project/c#_project_directory");
-            if (string.IsNullOrEmpty(csprojParentDir))
-                csprojParentDir = "res://";
+            // The csproj should be in the same folder as project.godot.
+            string csprojParentDir = "res://";
 
             _projectSlnPath = Path.Combine(ProjectSettings.GlobalizePath(slnParentDir),
                 string.Concat(_projectAssemblyName, ".sln"));


### PR DESCRIPTION
Related Issue: #68381

he C# editor plugin would not load the change of project settings, so it always generates files in the default directory. I added a function  `RefreshProjectLocation` to force it reloading the settings.

The `dll` compiled would be generated where the `sln` file is, so the engine could not find it correctly. I added `BaseOutputPath` and `OutputPath` in the `csproj` file to re-indicate that dotnet should output results in the default place.

In the default case, a C# script would be compiled only if it is located at the same/the sub directory of the `csproj`. To make all scripts reachable, I also added`Compile Include` in `csproj`.

Since the `GodotProjectDir` in `modules\mono\editor\Godot.NET.Sdk\Godot.NET.Sdk\Sdk\Sdk.props` depends on the `sln` file's path, rather than `res://`, scripts' pathes in the `dll` file would be incorrect after the `sln` file has been moved. So I rewrote the `GodotProjectDir` in the `csproj`.

It runs well on my device. Feel free to tell me if something goes wrong or something needs to be changed. :smiley: 

*Bugsquad edit:*
- Fixes #68381