### PR TITLE
Fix OpenXR on the Meta Quest: XR_KHR_loader_init_android is not reported as available (but it works anyway)

### DIFF
--- a/modules/openxr/extensions/openxr_android_extension.cpp
+++ b/modules/openxr/extensions/openxr_android_extension.cpp
@@ -47,11 +47,15 @@ OpenXRAndroidExtension *OpenXRAndroidExtension::get_singleton() {
 OpenXRAndroidExtension::OpenXRAndroidExtension(OpenXRAPI *p_openxr_api) :
 		OpenXRExtensionWrapper(p_openxr_api) {
 	singleton = this;
-	request_extensions[XR_KHR_LOADER_INIT_ANDROID_EXTENSION_NAME] = nullptr; // must be available
+	request_extensions[XR_KHR_LOADER_INIT_ANDROID_EXTENSION_NAME] = &loader_init_extension_available;
 	request_extensions[XR_KHR_ANDROID_CREATE_INSTANCE_EXTENSION_NAME] = &create_instance_extension_available;
 }
 
 void OpenXRAndroidExtension::on_before_instance_created() {
+	if (!loader_init_extension_available) {
+		print_line("OpenXR: XR_KHR_loader_init_android is not reported as available - trying to initialize anyway...");
+	}
+
 	EXT_INIT_XR_FUNC(xrInitializeLoaderKHR);
 
 	JNIEnv *env = get_jni_env();

--- a/modules/openxr/extensions/openxr_android_extension.h
+++ b/modules/openxr/extensions/openxr_android_extension.h
@@ -48,6 +48,7 @@ public:
 private:
 	static OpenXRAndroidExtension *singleton;
 
+	bool loader_init_extension_available = false;
 	bool create_instance_extension_available = false;
 
 	// Initialize the loader


### PR DESCRIPTION
At the moment, OpenXR isn't working for me on the Meta Quest 2 - I get the error:

> OpenXR Runtime does not support XR_KHR_loader_init_android extension!

According to the spec, you MUST load that extension in order to use the `XrLoaderInitInfoAndroidKHR` structure to initialize the OpenXR loader:

https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrLoaderInitInfoAndroidKHR.html

However, the Meta Quest doesn't report that extension as supported, however, you can use the structure just fine anyway, and everything works.

So, this PR will attempt to load the extension (for platforms that require it, like the Pico 4 apparently - it was PR #68023 that made this extension required), but even if it doesn't load, it'll try to initialize the loader as if it were available anyway.