### PR TITLE
Rename clear_button_color_pressed to clear_button_pressed_color

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -395,7 +395,7 @@
 		<theme_item name="clear_button_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Color used as default tint for the clear button.
 		</theme_item>
-		<theme_item name="clear_button_color_pressed" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="clear_button_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Color used for the clear button when it's pressed.
 		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1400,7 +1400,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("caret_color", "LineEdit", font_color);
 	theme->set_color("selection_color", "LineEdit", selection_color);
 	theme->set_color("clear_button_color", "LineEdit", font_color);
-	theme->set_color("clear_button_color_pressed", "LineEdit", accent_color);
+	theme->set_color("clear_button_pressed_color", "LineEdit", accent_color);
 
 	// TextEdit
 	theme->set_stylebox("normal", "TextEdit", style_line_edit);

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -728,7 +728,7 @@ void LineEdit::_update_theme_item_cache() {
 
 	theme_cache.clear_icon = get_theme_icon(SNAME("clear"));
 	theme_cache.clear_button_color = get_theme_color(SNAME("clear_button_color"));
-	theme_cache.clear_button_color_pressed = get_theme_color(SNAME("clear_button_color_pressed"));
+	theme_cache.clear_button_pressed_color = get_theme_color(SNAME("clear_button_pressed_color"));
 
 	theme_cache.base_scale = get_theme_default_base_scale();
 }
@@ -874,7 +874,7 @@ void LineEdit::_notification(int p_what) {
 				Color color_icon(1, 1, 1, !is_editable() ? .5 * .9 : .9);
 				if (display_clear_icon) {
 					if (clear_button_status.press_attempt && clear_button_status.pressing_inside) {
-						color_icon = theme_cache.clear_button_color_pressed;
+						color_icon = theme_cache.clear_button_pressed_color;
 					} else {
 						color_icon = theme_cache.clear_button_color;
 					}

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -197,7 +197,7 @@ private:
 
 		Ref<Texture2D> clear_icon;
 		Color clear_button_color;
-		Color clear_button_color_pressed;
+		Color clear_button_pressed_color;
 
 		float base_scale = 1.0;
 	} theme_cache;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -398,7 +398,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("caret_color", "LineEdit", control_font_hover_color);
 	theme->set_color("selection_color", "LineEdit", control_selection_color);
 	theme->set_color("clear_button_color", "LineEdit", control_font_color);
-	theme->set_color("clear_button_color_pressed", "LineEdit", control_font_pressed_color);
+	theme->set_color("clear_button_pressed_color", "LineEdit", control_font_pressed_color);
 
 	theme->set_constant("minimum_character_width", "LineEdit", 4);
 	theme->set_constant("outline_size", "LineEdit", 0);


### PR DESCRIPTION
This will rename the theme property `clear_button_color_pressed` to `clear_button_pressed_color` of `LineEdit` to match with all other color names.