### PR TITLE
Fix theme properties in doc translations

### DIFF
--- a/doc/translations/ar.po
+++ b/doc/translations/ar.po
@@ -11720,7 +11720,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -61038,7 +61038,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/ca.po
+++ b/doc/translations/ca.po
@@ -11663,7 +11663,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60861,7 +60861,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/classes.pot
+++ b/doc/translations/classes.pot
@@ -11543,7 +11543,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60738,7 +60738,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/cs.po
+++ b/doc/translations/cs.po
@@ -12059,7 +12059,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -61480,7 +61480,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/de.po
+++ b/doc/translations/de.po
@@ -15018,7 +15018,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -65021,7 +65021,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/el.po
+++ b/doc/translations/el.po
@@ -11562,7 +11562,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60862,7 +60862,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/es.po
+++ b/doc/translations/es.po
@@ -15089,7 +15089,7 @@ msgstr "Los botones planos no muestran decoración."
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -79601,10 +79601,10 @@ msgstr "El ancho, en píxeles, del minimapa."
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
-"Si [code]true[/code], se utilizará el [code]font_color_selected[/code] "
+"Si [code]true[/code], se utilizará el [code]font_selected_color[/code] "
 "personalizado para el texto seleccionado."
 
 #: doc/classes/TextEdit.xml

--- a/doc/translations/et.po
+++ b/doc/translations/et.po
@@ -11556,7 +11556,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60751,7 +60751,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/fa.po
+++ b/doc/translations/fa.po
@@ -11991,7 +11991,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -61211,7 +61211,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/fi.po
+++ b/doc/translations/fi.po
@@ -11636,7 +11636,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60950,7 +60950,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/fil.po
+++ b/doc/translations/fil.po
@@ -11559,7 +11559,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60757,7 +60757,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/fr.po
+++ b/doc/translations/fr.po
@@ -15391,14 +15391,14 @@ msgstr "Les boutons plats n’affichent pas de décoration."
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
 "L'icône du bouton, si le texte est présent, l'icône sera placée avant le "
 "texte.\n"
 "Pour modifier la marge et l'espacement de l'icône, utilisez la propriété "
-"[code]hseparation[/code] du thème pour le [Button] et les propriétés "
+"[code]h_separation[/code] du thème pour le [Button] et les propriétés "
 "[code]content_margin_*[/code] de la [StyleBox] utilisée."
 
 #: doc/classes/Button.xml
@@ -77048,10 +77048,10 @@ msgstr "La largeur, en pixels, de la mini-carte."
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
-"Si [code]true[/code], la couleur [code]font_color_selected[/code] "
+"Si [code]true[/code], la couleur [code]font_selected_color[/code] "
 "personnalisée sera utilisée pour le texte sélectionné."
 
 #: doc/classes/TextEdit.xml

--- a/doc/translations/gl.po
+++ b/doc/translations/gl.po
@@ -11551,7 +11551,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60746,7 +60746,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/hi.po
+++ b/doc/translations/hi.po
@@ -11550,7 +11550,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60745,7 +60745,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/hu.po
+++ b/doc/translations/hu.po
@@ -11570,7 +11570,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60765,7 +60765,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/id.po
+++ b/doc/translations/id.po
@@ -11961,7 +11961,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -61225,7 +61225,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/is.po
+++ b/doc/translations/is.po
@@ -11550,7 +11550,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60745,7 +60745,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/it.po
+++ b/doc/translations/it.po
@@ -12615,7 +12615,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -62164,7 +62164,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/ja.po
+++ b/doc/translations/ja.po
@@ -14501,7 +14501,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -64694,7 +64694,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/ko.po
+++ b/doc/translations/ko.po
@@ -11735,7 +11735,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -61289,7 +61289,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/lt.po
+++ b/doc/translations/lt.po
@@ -11560,7 +11560,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60755,7 +60755,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/lv.po
+++ b/doc/translations/lv.po
@@ -11565,7 +11565,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60763,7 +60763,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/mr.po
+++ b/doc/translations/mr.po
@@ -11548,7 +11548,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60743,7 +60743,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/nb.po
+++ b/doc/translations/nb.po
@@ -11560,7 +11560,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60755,7 +60755,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/ne.po
+++ b/doc/translations/ne.po
@@ -11548,7 +11548,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60743,7 +60743,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/nl.po
+++ b/doc/translations/nl.po
@@ -11618,7 +11618,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60817,7 +60817,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/pl.po
+++ b/doc/translations/pl.po
@@ -12065,7 +12065,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -61509,7 +61509,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/pt.po
+++ b/doc/translations/pt.po
@@ -12564,7 +12564,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -61988,7 +61988,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/pt_BR.po
+++ b/doc/translations/pt_BR.po
@@ -12621,7 +12621,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -62191,7 +62191,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/ro.po
+++ b/doc/translations/ro.po
@@ -11580,7 +11580,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60779,7 +60779,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/ru.po
+++ b/doc/translations/ru.po
@@ -13271,7 +13271,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -63108,7 +63108,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/sk.po
+++ b/doc/translations/sk.po
@@ -11551,7 +11551,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60749,7 +60749,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/sr_Cyrl.po
+++ b/doc/translations/sr_Cyrl.po
@@ -11562,7 +11562,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60760,7 +60760,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/sv.po
+++ b/doc/translations/sv.po
@@ -11552,7 +11552,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60747,7 +60747,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/th.po
+++ b/doc/translations/th.po
@@ -11657,7 +11657,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -61020,7 +61020,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/tl.po
+++ b/doc/translations/tl.po
@@ -11631,7 +11631,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -60871,7 +60871,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/tr.po
+++ b/doc/translations/tr.po
@@ -12337,7 +12337,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -61719,7 +61719,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/uk.po
+++ b/doc/translations/uk.po
@@ -11706,7 +11706,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -61039,7 +61039,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/vi.po
+++ b/doc/translations/vi.po
@@ -12011,7 +12011,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -61371,7 +61371,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 

--- a/doc/translations/zh_TW.po
+++ b/doc/translations/zh_TW.po
@@ -11668,7 +11668,7 @@ msgstr ""
 #: doc/classes/Button.xml
 msgid ""
 "Button's icon, if text is present the icon will be placed before the text.\n"
-"To edit margin and spacing of the icon, use [code]hseparation[/code] theme "
+"To edit margin and spacing of the icon, use [code]h_separation[/code] theme "
 "property of [Button] and [code]content_margin_*[/code] properties of the "
 "used [StyleBox]es."
 msgstr ""
@@ -61000,7 +61000,7 @@ msgstr ""
 
 #: doc/classes/TextEdit.xml
 msgid ""
-"If [code]true[/code], custom [code]font_color_selected[/code] will be used "
+"If [code]true[/code], custom [code]font_selected_color[/code] will be used "
 "for selected text."
 msgstr ""
 


### PR DESCRIPTION
Fix code property names in translation.
Respective:
- `font_color_selected` -> `font_selected_color`
- `hseparation` -> `h_separation`