### PR TITLE
Emphasize the warning about special case blend for animation

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -807,10 +807,10 @@ bool AnimationTree::_update_caches(AnimationPlayer *player) {
 				track_value->is_using_angle |= anim->track_get_interpolation_type(i) == Animation::INTERPOLATION_LINEAR_ANGLE || anim->track_get_interpolation_type(i) == Animation::INTERPOLATION_CUBIC_ANGLE;
 
 				if (was_discrete != track_value->is_discrete) {
-					WARN_PRINT_ONCE("Tracks with different update modes are blended. Blending prioritizes Discrete/Trigger mode, so other update mode tracks will not be blended.");
+					ERR_PRINT_ED("Value track: " + String(path) + " with different update modes are blended. Blending prioritizes Discrete/Trigger mode, so other update mode tracks will not be blended.");
 				}
 				if (was_using_angle != track_value->is_using_angle) {
-					WARN_PRINT_ONCE("Tracks for rotation with different interpolation types are blended. Blending prioritizes angle interpolation, so the blending result uses the shortest path referenced to the initial (RESET animation) value.");
+					WARN_PRINT_ED("Value track: " + String(path) + " with different interpolation types for rotation are blended. Blending prioritizes angle interpolation, so the blending result uses the shortest path referenced to the initial (RESET animation) value.");
 				}
 			}
 


### PR DESCRIPTION
Follow up #69240.

Mixed Continuous/Discrete tracks look like a bug since the Continuous track is not played back in AnimationTree then, so it has been upgraded to an "error" instead of a "warning". But mixed Linear/LinearAngle tracks keep it as a warning since playback itself is performed as normal.

Also, I made it notify the problematic track name(path) and changed to use `ERR_PRINT_ED / WARN_PRINT_ED` instead of `WARN_PRINT_ONCE / ERR_PRINT_ONCE`. Track cache updates are not that frequent, and the notification should occur only once per update, even if it is not an ONCE macro.