### PR TITLE
Add GDScript implicit type conversion for member variables with initializers

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -701,6 +701,7 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 						Variant default_value;
 						if (member.variable->initializer && member.variable->initializer->is_constant) {
 							default_value = member.variable->initializer->reduced_value;
+							GDScriptCompiler::convert_to_initializer_type(default_value, member.variable);
 						}
 						member_default_values_cache[member.variable->identifier->name] = default_value;
 					} break;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2389,6 +2389,7 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 #ifdef TOOLS_ENABLED
 				if (variable->initializer != nullptr && variable->initializer->is_constant) {
 					p_script->member_default_values[name] = variable->initializer->reduced_value;
+					GDScriptCompiler::convert_to_initializer_type(p_script->member_default_values[name], variable);
 				} else {
 					p_script->member_default_values.erase(name);
 				}
@@ -2644,6 +2645,20 @@ Error GDScriptCompiler::_compile_class(GDScript *p_script, const GDScriptParser:
 
 	p_script->valid = true;
 	return OK;
+}
+
+void GDScriptCompiler::convert_to_initializer_type(Variant &p_variant, const GDScriptParser::VariableNode *p_node) {
+	// Set p_variant to the value of p_node's initializer, with the type of p_node's variable.
+	GDScriptParser::DataType member_t = p_node->datatype;
+	GDScriptParser::DataType init_t = p_node->initializer->datatype;
+	if (member_t.is_hard_type() && init_t.is_hard_type() &&
+			member_t.kind == GDScriptParser::DataType::BUILTIN && init_t.kind == GDScriptParser::DataType::BUILTIN) {
+		if (Variant::can_convert_strict(init_t.builtin_type, member_t.builtin_type)) {
+			Variant *v = &p_node->initializer->reduced_value;
+			Callable::CallError ce;
+			Variant::construct(member_t.builtin_type, p_variant, const_cast<const Variant **>(&v), 1, ce);
+		}
+	}
 }
 
 void GDScriptCompiler::make_scripts(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state) {

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -140,6 +140,7 @@ class GDScriptCompiler {
 	bool within_await = false;
 
 public:
+	static void convert_to_initializer_type(Variant &p_variant, const GDScriptParser::VariableNode *p_node);
 	static void make_scripts(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state);
 	Error compile(const GDScriptParser *p_parser, GDScript *p_script, bool p_keep_state = false);
 


### PR DESCRIPTION
Fixes #69361.

Before,

`@export something: NodePath = ""`

This would save the default value as a `String`, since that was its type. This would have awkward consequences in comparisons with default values later.

When possible, this PR changes it so that the type is implicitly converted to whatever the explicit type of the variable is. With this PR if it is possible to convert from `String` to `NodePath`, which it is, then the default value is saved with that type. That way, when comparisons are made to default values, at least they have a matching type and are more likely to behave as desired.

There might be some more consequences for types that can be converted into one another (thinking `String` and `StringName`, for example), but I'd argue that this PR makes this behave as expected.

The auxiliary function was added to `GDScriptCompiler` because it was the place that required the least amount of extra includes...

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
