### PR TITLE
Remove unneeded calc in root motion

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1630,7 +1630,7 @@ void AnimationTree::_process_graph(double p_delta) {
 					TrackCacheTransform *t = static_cast<TrackCacheTransform *>(track);
 
 					if (t->root_motion) {
-						root_motion_position = root_motion_rotation.xform_inv(t->loc);
+						root_motion_position = t->loc;
 						root_motion_rotation = t->rot;
 						root_motion_scale = t->scale - Vector3(1, 1, 1);
 


### PR DESCRIPTION
Follow up #69199

Sorry, I had mistakenly pushed a method that was not needed. This code does not appear to actually do anything, but there is a bit misalignment.