### PR TITLE
Fix child nodes still being drawn when the visible area of a control with `clip_contents` enabled is `0`

### DIFF
--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -275,12 +275,12 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 	if (ci->clip) {
 		if (p_canvas_clip != nullptr) {
 			ci->final_clip_rect = p_canvas_clip->final_clip_rect.intersection(global_rect);
-			if (ci->final_clip_rect == Rect2()) {
-				// Clip rects do not intersect, so don't draw this item.
-				return;
-			}
 		} else {
-			ci->final_clip_rect = global_rect;
+			ci->final_clip_rect = p_clip_rect.intersection(global_rect);
+		}
+		if (ci->final_clip_rect.size.width < 0.5 || ci->final_clip_rect.size.height < 0.5) {
+			// The clip rect area is 0, so don't draw the item.
+			return;
 		}
 		ci->final_clip_rect.position = ci->final_clip_rect.position.round();
 		ci->final_clip_rect.size = ci->final_clip_rect.size.round();


### PR DESCRIPTION
Fix #56579, fix #69383.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
