### PR TITLE
Unexpose broken `Array.set_typed`

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2079,7 +2079,6 @@ static void _register_variant_builtin_methods() {
 	bind_method(Array, max, sarray(), varray());
 	bind_method(Array, min, sarray(), varray());
 	bind_method(Array, typed_assign, sarray("array"), varray());
-	bind_method(Array, set_typed, sarray("type", "class_name", "script"), varray());
 	bind_method(Array, is_typed, sarray(), varray());
 	bind_method(Array, get_typed_builtin, sarray(), varray());
 	bind_method(Array, get_typed_class_name, sarray(), varray());

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -58,7 +58,8 @@
 			<param index="2" name="class_name" type="StringName" />
 			<param index="3" name="script" type="Variant" />
 			<description>
-				Creates a typed array from the [param base] array. The base array can't be already typed. See [method set_typed] for more details.
+				Creates a typed array from the [param base] array. The base array can't be already typed.Makes the [Array] typed.
+				The [param type] should be one of the [enum Variant.Type] constants. [param class_name] is optional and can only be provided for [constant TYPE_OBJECT]. [param script] can only be provided if [param class_name] is not empty.
 			</description>
 		</constructor>
 		<constructor name="Array">
@@ -527,16 +528,6 @@
 			<param index="0" name="enable" type="bool" />
 			<description>
 				Makes the [Array] read-only, i.e. disabled modifying of the array's elements. Does not apply to nested content, e.g. content of nested arrays.
-			</description>
-		</method>
-		<method name="set_typed">
-			<return type="void" />
-			<param index="0" name="type" type="int" />
-			<param index="1" name="class_name" type="StringName" />
-			<param index="2" name="script" type="Variant" />
-			<description>
-				Makes the [Array] typed. The [param type] should be one of the [enum Variant.Type] constants. [param class_name] is optional and can only be provided for [constant TYPE_OBJECT]. [param script] can only be provided if [param class_name] is not empty.
-				The method fails if an array is already typed.
 			</description>
 		</method>
 		<method name="shuffle">


### PR DESCRIPTION
<img width=500 src="https://user-images.githubusercontent.com/66727710/205048134-6b9b31ef-4d57-471d-afc3-3b33e625e7a4.png">

- This method just does not work, look above.
- If it were to work, it would only work if the array is **empty**, is only referenced **once**, and is **not already typed** (which cannot be undone).
- At that point, you may as well either use the Typed Array constructor, or GDScript's static typing syntax.


