### PR TITLE
AnimationPlayer editor duplication: use a number instead of (copy)

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1091,9 +1091,30 @@ void AnimationPlayerEditor::_animation_duplicate() {
 		return;
 	}
 
-	String new_name = current;
-	while (player->has_animation(new_name)) {
-		new_name = new_name + " (copy)";
+	int index_digits = 0;
+	for (int i = current.length() - 1; i >= 0; i--) {
+		if (is_digit(current[i])) {
+			index_digits++;
+		} else {
+			break;
+		}
+	}
+	int64_t count = 2;
+	if (index_digits) {
+		count = current.right(index_digits).to_int();
+	}
+	String new_name = (index_digits) ? current.left(-index_digits) : current + "_";
+	while (true) {
+		String attempt = new_name;
+		if (count > 1) {
+			attempt += itos(count);
+		}
+		if (player->has_animation(attempt)) {
+			count++;
+			continue;
+		}
+		new_name = attempt;
+		break;
 	}
 
 	if (new_name.contains("/")) {


### PR DESCRIPTION
Because it's annoying to erase the 7 char long `" (copy)"` string everytime.

With this, duplicating an animation it will append a number instead of that string, just like with nodes in the scene tree.

If duplicating an animation named "NewAnim", it will create one named "NewAnim2". If "NewAnim2" already exists then it will be "NewAnim3".

~~Note however that it always takes the full anim name into consideration before appending a number, so duplicating "NewAnim2" will create "NewAnim22" instead of "NewAnim3". Still better than having multiple instances of `" (copy)"`.~~
Now it will increase number regardless.