### PR TITLE
ETCPAK expects BGRA data for ETC

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3798,6 +3798,19 @@ void Image::convert_ra_rgba8_to_rg() {
 	}
 }
 
+void Image::convert_rgba8_to_bgra8() {
+	ERR_FAIL_COND(format != FORMAT_RGBA8);
+	ERR_FAIL_COND(!data.size());
+
+	int s = data.size();
+	uint8_t *w = data.ptrw();
+	for (int i = 0; i < s; i += 4) {
+		uint8_t r = w[i];
+		w[i] = w[i + 2]; // Swap R to B
+		w[i + 2] = r; // Swap B to R
+	}
+}
+
 Error Image::_load_from_buffer(const Vector<uint8_t> &p_array, ImageMemLoadFunc p_loader) {
 	int buffer_size = p_array.size();
 

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -391,6 +391,7 @@ public:
 
 	void convert_rg_to_ra_rgba8();
 	void convert_ra_rgba8_to_rg();
+	void convert_rgba8_to_bgra8();
 
 	Image(const uint8_t *p_mem_png_jpg, int p_len = -1);
 	Image(const char **p_xpm);

--- a/modules/etcpak/image_compress_etcpak.cpp
+++ b/modules/etcpak/image_compress_etcpak.cpp
@@ -111,13 +111,16 @@ void _compress_etcpak(EtcpakType p_compresstype, Image *r_img, float p_lossy_qua
 	Image::Format target_format = Image::FORMAT_RGBA8;
 	if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC1) {
 		target_format = Image::FORMAT_ETC;
+		r_img->convert_rgba8_to_bgra8(); // It's badly documented but ETCPAK seems to be expected BGRA8 for ETC.
 	} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC2) {
 		target_format = Image::FORMAT_ETC2_RGB8;
+		r_img->convert_rgba8_to_bgra8(); // It's badly documented but ETCPAK seems to be expected BGRA8 for ETC.
 	} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC2_RA_AS_RG) {
 		target_format = Image::FORMAT_ETC2_RA_AS_RG;
 		r_img->convert_rg_to_ra_rgba8();
 	} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC2_ALPHA) {
 		target_format = Image::FORMAT_ETC2_RGBA8;
+		r_img->convert_rgba8_to_bgra8(); // It's badly documented but ETCPAK seems to be expected BGRA8 for ETC.
 	} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_DXT1) {
 		target_format = Image::FORMAT_DXT1;
 	} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_DXT5_RA_AS_RG) {


### PR DESCRIPTION
This one is weird and mostly based on the end result and a vague remark in the PYPI library that implements ETCPAK.
I've asked a question on ETCPAKs github issue page to confirm our findings: https://github.com/wolfpld/etcpak/issues/32

Anyway, this fixes #65127 by converting our image data from `RGBA` to `BGRA`. Inspecting the textures with renderdoc they seem to be loaded into memory correctly after this fix.

I am not sure if DXT images should be converted as well, I might test this as some textures still look weird but we went from this on my Pixel 6:
![image](https://user-images.githubusercontent.com/1945449/205080528-e52538d5-37d8-4f6c-8fc3-38737447cc2b.png)

To this:
![image](https://user-images.githubusercontent.com/1945449/205080677-e8b18672-0d9f-4322-9ead-a1f38da71f17.png)

For comparison, running this on Windows:
![image](https://user-images.githubusercontent.com/1945449/205080828-a01e3f84-25a1-4f20-a5a0-44b5059f8aa5.png)
