### PR TITLE
Fix animation signal `caches_cleared` firing timing

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1800,7 +1800,6 @@ double AnimationPlayer::get_current_animation_length() const {
 
 void AnimationPlayer::_animation_changed() {
 	clear_caches();
-	emit_signal(SNAME("caches_cleared"));
 	if (is_playing()) {
 		playback.seeked = true; //need to restart stuff, like audio
 	}
@@ -1839,6 +1838,8 @@ void AnimationPlayer::clear_caches() {
 	cache_update_size = 0;
 	cache_update_prop_size = 0;
 	cache_update_bezier_size = 0;
+
+	emit_signal(SNAME("caches_cleared"));
 }
 
 void AnimationPlayer::set_active(bool p_active) {

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -859,7 +859,6 @@ void AnimationTree::_clear_caches() {
 		memdelete(K.value);
 	}
 	playing_caches.clear();
-
 	track_cache.clear();
 	cache_valid = false;
 }


### PR DESCRIPTION
Fixes #39926
Fixes #59549

The `caches_cleared` signal should be fired in the `clear_caches()`.

[animation tree bug.zip](https://github.com/godotengine/godot/files/10138512/animation.tree.bug.zip) (fixed MRP by #59549)

