### PR TITLE
[RichTextEffect] Restore missing `relative_index` property.

### DIFF
--- a/doc/classes/CharFXTransform.xml
+++ b/doc/classes/CharFXTransform.xml
@@ -46,6 +46,9 @@
 		<member name="range" type="Vector2i" setter="set_range" getter="get_range" default="Vector2i(0, 0)">
 			Absolute character range in the string, corresponding to the glyph. Setting this property won't affect drawing.
 		</member>
+		<member name="relative_index" type="int" setter="set_relative_index" getter="get_relative_index" default="0">
+			The character offset of the glyph, relative to the current [RichTextEffect] custom block. Setting this property won't affect drawing.
+		</member>
 		<member name="visible" type="bool" setter="set_visibility" getter="is_visible" default="true">
 			If [code]true[/code], the character will be drawn. If [code]false[/code], the character will be hidden. Characters around hidden characters will reflow to take the space of hidden characters. If this is not desired, set their [member color] to [code]Color(1, 1, 1, 0)[/code] instead.
 		</member>

--- a/scene/gui/rich_text_effect.cpp
+++ b/scene/gui/rich_text_effect.cpp
@@ -88,6 +88,9 @@ void CharFXTransform::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_glyph_index"), &CharFXTransform::get_glyph_index);
 	ClassDB::bind_method(D_METHOD("set_glyph_index", "glyph_index"), &CharFXTransform::set_glyph_index);
 
+	ClassDB::bind_method(D_METHOD("get_relative_index"), &CharFXTransform::get_relative_index);
+	ClassDB::bind_method(D_METHOD("set_relative_index", "relative_index"), &CharFXTransform::set_relative_index);
+
 	ClassDB::bind_method(D_METHOD("get_glyph_count"), &CharFXTransform::get_glyph_count);
 	ClassDB::bind_method(D_METHOD("set_glyph_count", "glyph_count"), &CharFXTransform::set_glyph_count);
 
@@ -107,5 +110,6 @@ void CharFXTransform::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "glyph_index"), "set_glyph_index", "get_glyph_index");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "glyph_count"), "set_glyph_count", "get_glyph_count");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "glyph_flags"), "set_glyph_flags", "get_glyph_flags");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "relative_index"), "set_relative_index", "get_relative_index");
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "font"), "set_font", "get_font");
 }

--- a/scene/gui/rich_text_effect.h
+++ b/scene/gui/rich_text_effect.h
@@ -52,6 +52,7 @@ public:
 	uint32_t glyph_index = 0;
 	uint16_t glyph_flags = 0;
 	uint8_t glyph_count = 0;
+	int32_t relative_index = 0;
 	RID font;
 
 	CharFXTransform();
@@ -83,6 +84,9 @@ public:
 
 	uint8_t get_glyph_count() const { return glyph_count; };
 	void set_glyph_count(uint8_t p_glyph_count) { glyph_count = p_glyph_count; };
+
+	int32_t get_relative_index() const { return relative_index; };
+	void set_relative_index(int32_t p_relative_index) { relative_index = p_relative_index; };
 
 	RID get_font() const { return font; };
 	void set_font(RID p_font) { font = p_font; };

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1005,6 +1005,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 					if (!custom_effect.is_null()) {
 						charfx->elapsed_time = item_custom->elapsed_time;
 						charfx->range = Vector2i(l.char_offset + glyphs[i].start, l.char_offset + glyphs[i].end);
+						charfx->relative_index = l.char_offset + glyphs[i].start - item_fx->char_ofs;
 						charfx->visibility = txt_visible;
 						charfx->outline = true;
 						charfx->font = frid;
@@ -1222,6 +1223,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 					if (!custom_effect.is_null()) {
 						charfx->elapsed_time = item_custom->elapsed_time;
 						charfx->range = Vector2i(l.char_offset + glyphs[i].start, l.char_offset + glyphs[i].end);
+						charfx->relative_index = l.char_offset + glyphs[i].start - item_fx->char_ofs;
 						charfx->visibility = txt_visible;
 						charfx->outline = false;
 						charfx->font = frid;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/69461
