### PR TITLE
Add option `throw_error_with_invalid_path` to Project Setting and remove cache error from `AnimationTree`

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1245,6 +1245,9 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("display/window/energy_saving/keep_screen_on", true);
 	GLOBAL_DEF("display/window/energy_saving/keep_screen_on.editor", false);
 
+	GLOBAL_DEF("animation/animation_player/warnings/ignore_invalid_paths", true);
+	GLOBAL_DEF("animation/animation_tree/warnings/ignore_invalid_paths", true);
+
 	GLOBAL_DEF_BASIC("audio/buses/default_bus_layout", "res://default_bus_layout.tres");
 	custom_prop_info["audio/buses/default_bus_layout"] = PropertyInfo(Variant::STRING, "audio/buses/default_bus_layout", PROPERTY_HINT_FILE, "*.tres");
 	GLOBAL_DEF_RST("audio/general/2d_panning_strength", 0.5f);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -188,6 +188,12 @@
 		</method>
 	</methods>
 	<members>
+		<member name="animation/animation_player/warnings/ignore_invalid_paths" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], [AnimationPlayer] silences the error of no matching object of the track path in the scene.
+		</member>
+		<member name="animation/animation_tree/warnings/ignore_invalid_paths" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], [AnimationTree] silences the error of no matching object of the track path in the scene.
+		</member>
 		<member name="application/boot_splash/bg_color" type="Color" setter="" getter="" default="Color(0.14, 0.14, 0.14, 1)">
 			Background color for the boot splash.
 		</member>


### PR DESCRIPTION
Fixes #65608
Supersedes #68998

There are two reasons for the #65608 spamming:

First, when caching tracks, if they contain invalid paths, they throw an error and are not cached. The iterating is done on the list of tracks, not on the list of caches. If the cache is not found when iterating on a track, AnimationTree throws that error every frame.

#68998 tried to remove that error, but I didn't really think that was a good way. However, after I looked into AnimationPlayer, it doesn't throw errors in the same case, so it seems to be acceptable, I apologize for that.

However, there is another cause for spamming. If a large number of animations and a large number of track paths cannot be resolved, a large number of errors can occur during caching. This means that this can happen frequently with 3D skeletal animations.

Considering the existence of retargeting and duck typing recommendations, it might be fine that not to throw errors even for invalid paths. So I added an option to Project Setting to disable checking for paths in AnimationPlayer/AnimationTree.

![image](https://user-images.githubusercontent.com/61938263/205253273-f7744d1a-34de-4622-b7ce-651e4601f6e9.png)
