### PR TITLE
SCons: Strip symbol table for builds with `debug_symbols=no`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -544,6 +544,12 @@ if selected_platform in platform_list:
                 env.Append(CCFLAGS=["-g3"])
             else:
                 env.Append(CCFLAGS=["-g2"])
+        else:
+            if methods.using_clang(env) and not methods.is_vanilla_clang(env):
+                # Apple Clang, its linker doesn't like -s.
+                env.Append(LINKFLAGS=["-Wl,-S", "-Wl,-x", "-Wl,-dead_strip"])
+            else:
+                env.Append(LINKFLAGS=["-s"])
 
         if env["optimize"] == "speed":
             env.Append(CCFLAGS=["-O3"])


### PR DESCRIPTION
This is equivalent to calling `strip` on the resulting binary, which is what we do for official builds.

This applies for GCC/Clang.
For MSVC `/DEBUG:NONE` should already be the default.

See https://github.com/godotengine/godot/issues/69470#issuecomment-1335075070 for context.