### PR TITLE
C#: Always convert float Variants to System.Double

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Variant.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Variant.cs
@@ -114,11 +114,7 @@ public partial struct Variant : IDisposable
         {
             Type.Bool => AsBool(),
             Type.Int => AsInt64(),
-#if REAL_T_IS_DOUBLE
             Type.Float => AsDouble(),
-#else
-            Type.Float => AsSingle(),
-#endif
             Type.String => AsString(),
             Type.Vector2 => AsVector2(),
             Type.Vector2i => AsVector2i(),


### PR DESCRIPTION
Godot floats are always 64-bit. The real_t feature only affects vectors, not scalars.

Follow up to https://github.com/godotengine/godot/pull/69428#discussion_r1037675342.
