### PR TITLE
Move GDScript uninitialization to `GDScriptLanguage::finish()`

### DIFF
--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -381,15 +381,15 @@ void GDScriptCache::clear_unreferenced_packed_scenes() {
 	}
 }
 
-GDScriptCache::GDScriptCache() {
-	singleton = this;
-}
+void GDScriptCache::clear() {
+	if (singleton == nullptr) {
+		return;
+	}
 
-GDScriptCache::~GDScriptCache() {
-	destructing = true;
+	MutexLock lock(singleton->mutex);
 
 	RBSet<Ref<GDScriptParserRef>> parser_map_refs;
-	for (KeyValue<String, GDScriptParserRef *> &E : parser_map) {
+	for (KeyValue<String, GDScriptParserRef *> &E : singleton->parser_map) {
 		parser_map_refs.insert(E.value);
 	}
 
@@ -399,12 +399,20 @@ GDScriptCache::~GDScriptCache() {
 	}
 
 	parser_map_refs.clear();
-	parser_map.clear();
-	shallow_gdscript_cache.clear();
-	full_gdscript_cache.clear();
+	singleton->parser_map.clear();
+	singleton->shallow_gdscript_cache.clear();
+	singleton->full_gdscript_cache.clear();
 
-	packed_scene_cache.clear();
-	packed_scene_dependencies.clear();
+	singleton->packed_scene_cache.clear();
+	singleton->packed_scene_dependencies.clear();
+}
 
+GDScriptCache::GDScriptCache() {
+	singleton = this;
+}
+
+GDScriptCache::~GDScriptCache() {
+	destructing = true;
+	clear();
 	singleton = nullptr;
 }

--- a/modules/gdscript/gdscript_cache.h
+++ b/modules/gdscript/gdscript_cache.h
@@ -111,6 +111,8 @@ public:
 		return singleton->destructing;
 	};
 
+	static void clear();
+
 	GDScriptCache();
 	~GDScriptCache();
 };

--- a/scene/resources/shape_2d.cpp
+++ b/scene/resources/shape_2d.cpp
@@ -124,7 +124,6 @@ Shape2D::Shape2D(const RID &p_rid) {
 }
 
 Shape2D::~Shape2D() {
-	if (PhysicsServer2D::get_singleton() != nullptr) {
-		PhysicsServer2D::get_singleton()->free(shape);
-	}
+	ERR_FAIL_NULL(PhysicsServer2D::get_singleton());
+	PhysicsServer2D::get_singleton()->free(shape);
 }

--- a/scene/resources/shape_3d.cpp
+++ b/scene/resources/shape_3d.cpp
@@ -128,7 +128,6 @@ Shape3D::Shape3D(RID p_shape) :
 		shape(p_shape) {}
 
 Shape3D::~Shape3D() {
-	if (PhysicsServer3D::get_singleton() != nullptr) {
-		PhysicsServer3D::get_singleton()->free(shape);
-	}
+	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
+	PhysicsServer3D::get_singleton()->free(shape);
 }


### PR DESCRIPTION
`GDScriptLanguage::finish()` was empty. So I moved the uninitialization of GDScriptLanguage originally in `GDScriptLanguage::~GDScriptLanguage()` inside it, calling too a new `GDScriptCache::clear()` to clear the cache sooner than the destructor. And `finish_languages` is called before the servers uninit.

As cyclic references didn't exist, there wasn't any GDScript instance that could live after the removal of the root script, so it wasn't a problem until cyclic references (which could make it so that instances could live beyond the root script).

The problem existed when ~~cyclic~~ cached scripts would hold RID past the uninitialization of the servers.

Fixes #68973
Would be interesting to merge with #69077