### PR TITLE
Properly remap roughness when reading from radiance map

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1100,7 +1100,7 @@ void main() {
 		ref_vec = mix(ref_vec, normal, roughness * roughness);
 		float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
 		ref_vec = scene_data.radiance_inverse_xform * ref_vec;
-		specular_light = textureLod(radiance_map, ref_vec, roughness * RADIANCE_MAX_LOD).rgb;
+		specular_light = textureLod(radiance_map, ref_vec, sqrt(roughness) * RADIANCE_MAX_LOD).rgb;
 		specular_light = srgb_to_linear(specular_light);
 		specular_light *= horizon * horizon;
 		specular_light *= scene_data.ambient_light_color_energy.a;

--- a/servers/rendering/renderer_rd/effects/copy_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/copy_effects.cpp
@@ -1153,7 +1153,8 @@ void CopyEffects::cubemap_roughness(RID p_source_rd_texture, RID p_dest_texture,
 	memset(&roughness.push_constant, 0, sizeof(CubemapRoughnessPushConstant));
 
 	roughness.push_constant.face_id = p_face_id > 9 ? 0 : p_face_id;
-	roughness.push_constant.roughness = p_roughness * p_roughness; // Shader expects roughness, not perceptual roughness, so multiply before passing in.
+	// Remap to perceptual-roughness^2 to create more detail in lower mips and match the mapping of cubemap_filter.
+	roughness.push_constant.roughness = p_roughness * p_roughness;
 	roughness.push_constant.sample_count = p_sample_count;
 	roughness.push_constant.use_direct_write = p_roughness == 0.0;
 	roughness.push_constant.face_size = p_size;

--- a/servers/rendering/renderer_rd/shaders/effects/cubemap_roughness_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/cubemap_roughness_inc.glsl
@@ -70,17 +70,6 @@ float DistributionGGX(float NdotH, float roughness4) {
 	return roughness4 / denom;
 }
 
-// https://graphicrants.blogspot.com.au/2013/08/specular-brdf-reference.html
-float GGX(float NdotV, float a) {
-	float k = a / 2.0;
-	return NdotV / (NdotV * (1.0 - k) + k);
-}
-
-// https://graphicrants.blogspot.com.au/2013/08/specular-brdf-reference.html
-float G_Smith(float a, float nDotV, float nDotL) {
-	return GGX(nDotL, a * a) * GGX(nDotV, a * a);
-}
-
 float radicalInverse_VdC(uint bits) {
 	bits = (bits << 16u) | (bits >> 16u);
 	bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1084,12 +1084,13 @@ void fragment_shader(in SceneData scene_data) {
 #ifdef USE_RADIANCE_CUBEMAP_ARRAY
 
 		float lod, blend;
-		blend = modf(roughness * MAX_ROUGHNESS_LOD, lod);
+
+		blend = modf(sqrt(roughness) * MAX_ROUGHNESS_LOD, lod);
 		specular_light = texture(samplerCubeArray(radiance_cubemap, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), vec4(ref_vec, lod)).rgb;
 		specular_light = mix(specular_light, texture(samplerCubeArray(radiance_cubemap, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), vec4(ref_vec, lod + 1)).rgb, blend);
 
 #else
-		specular_light = textureLod(samplerCube(radiance_cubemap, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), ref_vec, roughness * MAX_ROUGHNESS_LOD).rgb;
+		specular_light = textureLod(samplerCube(radiance_cubemap, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), ref_vec, sqrt(roughness) * MAX_ROUGHNESS_LOD).rgb;
 
 #endif //USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light *= scene_data.IBL_exposure_normalization;
@@ -1137,7 +1138,7 @@ void fragment_shader(in SceneData scene_data) {
 		ref_vec = mix(ref_vec, n, clearcoat_roughness * clearcoat_roughness);
 		float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
 		ref_vec = scene_data.radiance_inverse_xform * ref_vec;
-		float roughness_lod = mix(0.001, 0.1, clearcoat_roughness) * MAX_ROUGHNESS_LOD;
+		float roughness_lod = mix(0.001, 0.1, sqrt(clearcoat_roughness)) * MAX_ROUGHNESS_LOD;
 #ifdef USE_RADIANCE_CUBEMAP_ARRAY
 
 		float lod, blend;

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -987,12 +987,12 @@ void main() {
 #ifdef USE_RADIANCE_CUBEMAP_ARRAY
 
 		float lod, blend;
-		blend = modf(roughness * MAX_ROUGHNESS_LOD, lod);
+		blend = modf(sqrt(roughness) * MAX_ROUGHNESS_LOD, lod);
 		specular_light = texture(samplerCubeArray(radiance_cubemap, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), vec4(ref_vec, lod)).rgb;
 		specular_light = mix(specular_light, texture(samplerCubeArray(radiance_cubemap, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), vec4(ref_vec, lod + 1)).rgb, blend);
 
 #else // USE_RADIANCE_CUBEMAP_ARRAY
-		specular_light = textureLod(samplerCube(radiance_cubemap, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), ref_vec, roughness * MAX_ROUGHNESS_LOD).rgb;
+		specular_light = textureLod(samplerCube(radiance_cubemap, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), ref_vec, sqrt(roughness) * MAX_ROUGHNESS_LOD).rgb;
 
 #endif //USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light *= sc_luminance_multiplier;
@@ -1042,7 +1042,7 @@ void main() {
 
 		float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
 		ref_vec = scene_data.radiance_inverse_xform * ref_vec;
-		float roughness_lod = mix(0.001, 0.1, clearcoat_roughness) * MAX_ROUGHNESS_LOD;
+		float roughness_lod = mix(0.001, 0.1, sqrt(clearcoat_roughness)) * MAX_ROUGHNESS_LOD;
 #ifdef USE_RADIANCE_CUBEMAP_ARRAY
 
 		float lod, blend;


### PR DESCRIPTION
This ensures that we consistently use perceptual roughness which matches the behaviour of most other PBR renderers like Blender, Ue4 and Godot 3

Fixes one of the reported issues in https://github.com/godotengine/godot/issues/69476

This issue was a regression from https://github.com/godotengine/godot/pull/58418. I didn't notice at the time, but the fast filtering path used a non-linear mapping between cubemap mipmap and roughness. I mistakenly thought that the high quality roughness shader took linear roughness as a parameter (linear roughness is perceptual_roughness^2). In fact the high quality roughness shader takes perceptual roughness as a parameter. What I did was square perceptual roughness before passing it in, thus I also created a non-linear mapping between radiance mip maps and roughness. And by chance, a simple square remapping is very close to what is used by the fast filtering algorithm. 

The problem is that when reading from the radiance map, we uniformly map perceptual radiance to the radiance map mipmaps. So we end up reading from a much more reflective mipmap than we mean to. The solution is to take the sqrt of perceptual roughness so it uses the same non-linear mapping as the high quality roughness shader. 

Before:
![Screenshot (301)](https://user-images.githubusercontent.com/16521339/205410825-c3498b1a-ea17-48e8-883f-e9f2474b59c2.png)

After:

![Screenshot (298)-godot](https://user-images.githubusercontent.com/16521339/205410848-f09440d6-2cdb-42ce-83f5-b4e025b48683.png)

Blender:

![Screenshot (299)-blender](https://user-images.githubusercontent.com/16521339/205410853-0d140821-8394-4206-848b-2d687cb64939.png)

Ue4:

![Screenshot (297)ue4](https://user-images.githubusercontent.com/16521339/205410859-dd00905a-82b8-4fba-9a81-18baf7a58bb9.png)

### Implementation details

Getting to this conclusion took a lot of work as I had some mistaken assumptions:
1. I thought the high quality roughness shader took linear roughness as input (it takes perceptual roughness)
2. I thought the fast filtering algorithm used a linear mapping of roughness to mipmaps (it doesn't)

In Godot 3.x we linearly map perceptual roughness to mipmap. In other words roughness of 0.5 corresponds to the mip level halfway between 0 and the max mip level. A linear mapping is not an efficient use of resources as above a perceptual roughness of 0.5 there is not a very big difference in each level. While between 0 and 0.25, there is a huge difference. This relationship has been studied by [others](https://s3.amazonaws.com/docs.knaldtech.com/knald/1.0.0/lys_power_drops.html) and various mapping schemes have been proposed (for example, see [here](https://github.com/google/filament/pull/1981) for the mapping used by filament).

The fast filtering algorithm bakes the roughness to mipmap mapping into the precalculated coefficients. So we are kind of stuck with [their mapping](https://www.activision.com/cdn/research/spec_params_for_mip.txt). However, if you take a look at their mapping and the current square mapping we use, you can see they are quite close. 

_Blue is linear, purple is sqrt(x), red is our square mapping, and black is the fast filtering baked mapping_
![Screenshot (303)](https://user-images.githubusercontent.com/16521339/205411383-11f65779-ba74-4418-b7dd-06eb1aa3bc30.png)
https://www.desmos.com/calculator/nuh7yakzuq

Notice how the purple and red are a mirror image of each other? Red is what we use to bake the radiance map, and then purple is what we use to read from it. Since red and black are fairly close, it makes sense to treat them both the same. 

In a perfect world, we would bake the high quality radiance map using the same mapping function as the fast filter radiance map, however it would be very costly to do required unmapping from that function at run time. So I have opted to just use square as it is pretty close.

With this PR, there is still a small difference between high-quality and fast filter radiance, but they are very close. There is also a small difference between Godot, Blender, and Ue4, but Godot now looks much closer to Blender than Ue4 does, so I think it is within an acceptable range. 


