### PR TITLE
Expose emulated *Unorm4x8 glsl functions in non-android builds

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -288,11 +288,9 @@ vec3 light_normal_compute(vec3 light_vec, vec3 normal, vec3 base_color, vec3 lig
 
 #endif
 
-#define SHADOW_TEST(m_uv)                              \
-	{                                                  \
-		highp float sd = SHADOW_DEPTH(m_uv);           \
-		shadow += step(sd, shadow_uv.z / shadow_uv.w); \
-	}
+/* clang-format off */
+#define SHADOW_TEST(m_uv) { highp float sd = SHADOW_DEPTH(m_uv); shadow += step(sd, shadow_uv.z / shadow_uv.w); }
+/* clang-format on */
 
 //float distance = length(shadow_pos);
 vec4 light_shadow_compute(uint light_base, vec4 light_color, vec4 shadow_uv
@@ -332,7 +330,7 @@ vec4 light_shadow_compute(uint light_base, vec4 light_color, vec4 shadow_uv
 		shadow /= 13.0;
 	}
 
-	vec4 shadow_color = unpackUnorm4x8(light_array[light_base].shadow_color);
+	vec4 shadow_color = godot_unpackUnorm4x8(light_array[light_base].shadow_color);
 #ifdef LIGHT_CODE_USED
 	shadow_color.rgb *= shadow_modulate;
 #endif
@@ -499,7 +497,7 @@ void main() {
 
 	if (specular_shininess_used || (using_light && normal_used && bool(draw_data[draw_data_instance].flags & FLAGS_DEFAULT_SPECULAR_MAP_USED))) {
 		specular_shininess = texture(specular_texture, uv);
-		specular_shininess *= unpackUnorm4x8(draw_data[draw_data_instance].specular_shininess);
+		specular_shininess *= godot_unpackUnorm4x8(draw_data[draw_data_instance].specular_shininess);
 		specular_shininess_used = true;
 	} else {
 		specular_shininess = vec4(1.0);

--- a/drivers/gles3/shaders/stdlib_inc.glsl
+++ b/drivers/gles3/shaders/stdlib_inc.glsl
@@ -39,23 +39,32 @@ vec2 unpackSnorm2x16(uint p) {
 	return clamp((v - 32767.0) * vec2(0.00003051851), vec2(-1.0), vec2(1.0));
 }
 
-uint packUnorm4x8(vec4 v) {
+#endif
+
+// Compatibility renames. These are exposed with the "godot_" prefix
+// to work around an Adreno bug which was exposing these ES310 functions
+// in ES300 shaders. Internally, we must use the "godot_" prefix, but user shaders
+// will be mapped automatically.
+uint godot_packUnorm4x8(vec4 v) {
 	uvec4 uv = uvec4(round(clamp(v, vec4(0.0), vec4(1.0)) * 255.0));
 	return uv.x | (uv.y << uint(8)) | (uv.z << uint(16)) | (uv.w << uint(24));
 }
 
-vec4 unpackUnorm4x8(uint p) {
+vec4 godot_unpackUnorm4x8(uint p) {
 	return vec4(float(p & uint(0xff)), float((p >> uint(8)) & uint(0xff)), float((p >> uint(16)) & uint(0xff)), float(p >> uint(24))) * 0.00392156862; // 1.0 / 255.0
 }
 
-uint packSnorm4x8(vec4 v) {
+uint godot_packSnorm4x8(vec4 v) {
 	uvec4 uv = uvec4(round(clamp(v, vec4(-1.0), vec4(1.0)) * 127.0) + 127.0);
 	return uv.x | uv.y << uint(8) | uv.z << uint(16) | uv.w << uint(24);
 }
 
-vec4 unpackSnorm4x8(uint p) {
+vec4 godot_unpackSnorm4x8(uint p) {
 	vec4 v = vec4(float(p & uint(0xff)), float((p >> uint(8)) & uint(0xff)), float((p >> uint(16)) & uint(0xff)), float(p >> uint(24)));
 	return clamp((v - vec4(127.0)) * vec4(0.00787401574), vec4(-1.0), vec4(1.0));
 }
 
-#endif
+#define packUnorm4x8 godot_packUnorm4x8
+#define unpackUnorm4x8 godot_unpackUnorm4x8
+#define packSnorm4x8 godot_packSnorm4x8
+#define unpackSnorm4x8 godot_unpackSnorm4x8


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/69489

Originally these functions were exposed on all GLSL ES 300 devices. However, that causes a build error as Android devices expose the *Unorm4x8 functions despite them not being in the ES 300 spec.

This is a pretty painful hack. In theory these functions shouldn't be exposed at all when targeting ES 300 so there should be no redefinition error. 

I am a bit worried that this may be an Adreno-specific error. But I don't have any non-Adreno devices handy to test with so I can't confirm. We should merge this on the assumption that this is an Android specific issue. If we get the same issues on iOS devices we can expand to that. Or if this causes issues on Android non-Adreno devices, we can limit this to Adreno devices.

