### PR TITLE
Allow black metallic materials to reflect IBL

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1162,7 +1162,7 @@ void main() {
 
 		float a004 = min(r.x * r.x, exp2(-9.28 * ndotv)) * r.x + r.y;
 		vec2 env = vec2(-1.04, 1.04) * a004 + r.zw;
-		specular_light *= env.x * f0 + env.y * clamp(50.0 * f0.g, 0.0, 1.0);
+		specular_light *= env.x * f0 + env.y * clamp(50.0 * f0.g, metallic, 1.0);
 #endif
 	}
 

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1484,7 +1484,7 @@ void fragment_shader(in SceneData scene_data) {
 		float a004 = min(r.x * r.x, exp2(-9.28 * ndotv)) * r.x + r.y;
 		vec2 env = vec2(-1.04, 1.04) * a004 + r.zw;
 
-		specular_light *= env.x * f0 + env.y * clamp(50.0 * f0.g, 0.0, 1.0);
+		specular_light *= env.x * f0 + env.y * clamp(50.0 * f0.g, metallic, 1.0);
 #endif
 	}
 

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1205,7 +1205,7 @@ void main() {
 		float a004 = min(r.x * r.x, exp2(-9.28 * ndotv)) * r.x + r.y;
 		vec2 env = vec2(-1.04, 1.04) * a004 + r.zw;
 
-		specular_light *= env.x * f0 + env.y;
+		specular_light *= env.x * f0 + env.y * clamp(50.0 * f0.g, metallic, 1.0);
 #endif
 	}
 

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -202,7 +202,7 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, float atte
 		float cLdotH5 = SchlickFresnel(cLdotH);
 		// Calculate Fresnel using specular occlusion term from Filament:
 		// https://google.github.io/filament/Filament.html#lighting/occlusion/specularocclusion
-		float f90 = clamp(dot(f0, vec3(50.0 * 0.33)), 0.0, 1.0);
+		float f90 = clamp(dot(f0, vec3(50.0 * 0.33)), metallic, 1.0);
 		vec3 F = f0 + (f90 - f0) * cLdotH5;
 
 		vec3 specular_brdf_NL = cNdotL * D * F * G;


### PR DESCRIPTION
Fixes the other half of https://github.com/godotengine/godot/issues/69476

@fracteed and I have been discussing this change at length today. This PR restores a behaviour that was present in Godot 3.x and was only removed this year in https://github.com/godotengine/godot/pull/63587 (in response to https://github.com/godotengine/godot/issues/40753 and https://github.com/godotengine/godot-proposals/issues/4818).

## Background

In Godot 3.x there was no way to disable specular reflections. Many users requested the ability, often pointing out that in other engines specular reflections can be disabled in dieletric materials by setting ``specular`` to ``0.0`` (in Godot this only adjusted the specular lobe of lights). In response, I implemented https://github.com/godotengine/godot/pull/63587 which relies on a hack that Filament calls ["Pre-baked Specular Occlusion"](https://google.github.io/filament/Filament.html#lighting/occlusion/specularocclusion). The idea is basically that no materially can have a specular value of less than 0.02, so we can treat a specular value of less than 0.02 as a signal to shut off specular reflections entirely. In other words, we can treat a specular of less than 0.02 as a form of baked occlusion. This hack is used in Filament, Unreal Engine, and Frostbite to my knowledge. 

Trouble arises when we consider metallic materials. For metals, their specular value comes directly from their albedo, the ``specular`` property isn't used. Therefore, metals with an albedo of (0,0,0) were subject to this change as well. In effect any metal with an albedo of (0,0,0) became a perfectly black absorbing material.

This created two inconsistencies:
1. Metals aren't supposed to absorb light, so it is odd that they would be absorbing light in this case but only with an albedo of exactly (0,0,0)
2. Dielectrics which _do_ absorb light still have a reflection when their albedo is (0,0,0), they only totally lose their reflection when ``specular`` is also ``0.0``

Further, as pointed out in https://github.com/godotengine/godot/issues/69476 it can be desirable to have a metal material with an albedo of (0,0,0) still have some fresnel reflectance, but this was made impossible by https://github.com/godotengine/godot/pull/63587

Finally, the reason I have had difficulty with this is that we have two knowledgeable users at odds over what the behaviour should be.

In https://github.com/godotengine/godot-proposals/issues/4818 @mindinsomnia specifically pointed out that albedo metals should have no reflection in order to match the behaviour in Unreal Engine, unity, and Eevee (note, it only actually matches the behaviour in Unreal Engine).

In https://github.com/godotengine/godot/issues/69476 @fracteed has requested that the behaviour be changed back (only for black albedo metals) in order to be consistent with Eevee, Substance, and Unity.

Part of what makes this tricky is that Eevee used to disable reflections for black albedo metals. But in newer versions has changed to the behaviour in this PR where specular reflections are partially enabled. 

Underpinning all this discussion is the fact that metals with an albedo of less than 0.66 don't exist in nature, so there is no solid PBR theory underpinning the difference between the two behaviours (which is why I consistently refer to this and https://github.com/godotengine/godot/pull/63587 as hacks)

## Implementation

The specular occlusion trick works by expanding the 0.02 range of the ``specular`` parameter to 0-1 (essentially a multiplication by 50) then clamping to the 0-1 range. We exploit that by replacing the 0 with metallic, so the range becomes metallic-1. For metallic materials, this nullifies specular occlusion entirely, but allows it to gradually fade in if metallic is used to blend between a metal and dialectric. In theory this should not create any extra shader instructions and so should be essentially free.

## Reasoning

The reason I think this change is worth making is twofold:
1. It enables a material behaviour that cannot be created any other way (contrast that to the current behaviour which allows for many ways to get a totally black non-specular material)
4. It makes sense to enforce the fact that metals do not absorb light (previously I explained that anytime albedo is (0,0,0) it should be assumed that all light is absorbed, but that doesn't actually make sense for metallic materials which do not absorb light)

The following examples use:
``metallic = 1.0``
``specular = 0.5``
``albedo = (0,0,0)``
``roughness = 0.0``

_Before:_
![Screenshot (308)](https://user-images.githubusercontent.com/16521339/205421729-7c61b696-ab9d-453c-9a8b-02dfae407044.png)

_After_
![Screenshot (307)](https://user-images.githubusercontent.com/16521339/205421731-7aae1ba2-bde0-4ed0-a1fd-19f4a2287680.png)
_Note that the center is dark, but the reflection increases strength as it approaches the edge._
