### PR TITLE
Index override surface name starting from 1 to match surface name

### DIFF
--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -57,6 +57,7 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	bool old_surface_index = false;
 
 	void _notification(int p_what);
 	static void _bind_methods();


### PR DESCRIPTION
I hate to be making a compatibility breaking PR, but this has been a concern of mine for awhile and I unfortunately didn't realize it would be compatibility breaking until I made the PR. 

The issue is that Mesh surfaces index starting from 1 while MeshInstance3D surfaces start indexing from 0. Leading to this:

![Screenshot (310)](https://user-images.githubusercontent.com/16521339/205430052-879c09a7-91ad-4c7b-b8a1-7db03105c581.png)

Surface override 1 corresponds to surface 2. This isn't such a big deal for simple meshes like this as you can see all the surfaces in one screen. It becomes a big deal when using larger meshes. For example, the Sponza scene I use has over 40 surfaces, it becomes really annoying to set a material on a specific surface and it is easy to forget to account for the off-by-one error

You can plainly see the issue, in Mesh we add 1 to each index:
https://github.com/godotengine/godot/blob/30800d20f452015c054dc7d1d7cfd38362fe28ff/scene/resources/mesh.cpp#L1521-L1528

In MeshInstance3D we dont:
https://github.com/godotengine/godot/blob/30800d20f452015c054dc7d1d7cfd38362fe28ff/scene/3d/mesh_instance_3d.cpp#L101-L103

The real trouble lies in the fact that these are not just labels assigned to the meshes. The surfaces are serialized based on these names. So if we change the numbering for either one, we will break the surfaces that have already been saved. For example, with this PR, if I had filled all three surface override slots, then I would lose the material in override_surface 0, the material that was in override_surface 1 would still be called override_surface 1, but it would match up with surface 1 instead of surface 2 etc. Accordingly, this is clearly a breaking change and will impact any users who use override surfaces. 

It may be too late for this change as we are late into the beta cycle. But It may be worth discussing. 

With this change the above screenshot becomes:
![Screenshot (309)](https://user-images.githubusercontent.com/16521339/205430051-dc61aa25-aed5-4d79-a286-9e40a03d79a1.png)