### PR TITLE
Add `hide_grabber` hint to `PROPERTY_HINT_RANGE` & replace `hide_slider` with `HideMode` in `EditorSpinSlider` to disable grabber

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -50,7 +50,7 @@ class TypedArray;
 
 enum PropertyHint {
 	PROPERTY_HINT_NONE, ///< no hint provided.
-	PROPERTY_HINT_RANGE, ///< hint_text = "min,max[,step][,or_greater][,or_less][,hide_slider][,radians][,degrees][,exp][,suffix:<keyword>] range.
+	PROPERTY_HINT_RANGE, ///< hint_text = "min,max[,step][,or_greater][,or_less][,hide_slider][,hide_grabber][,radians][,degrees][,exp][,suffix:<keyword>] range.
 	PROPERTY_HINT_ENUM, ///< hint_text= "val1,val2,val3,etc"
 	PROPERTY_HINT_ENUM_SUGGESTION, ///< hint_text= "val1,val2,val3,etc"
 	PROPERTY_HINT_EXP_EASING, /// exponential easing function (Math::ease) use "attenuation" hint string to revert (flip h), "positive_only" to exclude in-out and out-in. (ie: "attenuation,positive_only")

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2713,7 +2713,7 @@
 		<constant name="PROPERTY_HINT_RANGE" value="1" enum="PropertyHint">
 			Hints that an [int] or [float] property should be within a range specified via the hint string [code]"min,max"[/code] or [code]"min,max,step"[/code]. The hint string can optionally include [code]"or_greater"[/code] and/or [code]"or_less"[/code] to allow manual input going respectively above the max or below the min values.
 			[b]Example:[/b] [code]"-360,360,1,or_greater,or_less"[/code].
-			Additionally, other keywords can be included: [code]"exp"[/code] for exponential range editing, [code]"radians"[/code] for editing radian angles in degrees, [code]"degrees"[/code] to hint at an angle and [code]"hide_slider"[/code] to hide the slider.
+			Additionally, other keywords can be included: [code]"exp"[/code] for exponential range editing, [code]"radians"[/code] for editing radian angles in degrees, [code]"degrees"[/code] to hint at an angle, [code]"hide_slider"[/code] to hide the slider and [code]"hide_grabber"[/code] to disable the grabber.
 		</constant>
 		<constant name="PROPERTY_HINT_ENUM" value="2" enum="PropertyHint">
 			Hints that an [int], [float], or [String] property is an enumerated value to pick in a list specified via a hint string.

--- a/doc/classes/EditorSpinSlider.xml
+++ b/doc/classes/EditorSpinSlider.xml
@@ -13,8 +13,7 @@
 			If [code]true[/code], the slider will not draw background.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
-		<member name="hide_slider" type="bool" setter="set_hide_slider" getter="is_hiding_slider" default="false">
-			If [code]true[/code], the slider is hidden.
+		<member name="hide_mode" type="int" setter="set_hide_mode" getter="get_hide_mode" enum="EditorSpinSlider.HideMode" default="0">
 		</member>
 		<member name="label" type="String" setter="set_label" getter="get_label" default="&quot;&quot;">
 			The text that displays to the left of the value.
@@ -28,4 +27,15 @@
 			The suffix to display after the value (in a faded color). This should generally be a plural word. You may have to use an abbreviation if the suffix is too long to be displayed.
 		</member>
 	</members>
+	<constants>
+		<constant name="HIDE_MODE_NONE" value="0" enum="HideMode">
+			The slider is appeared.
+		</constant>
+		<constant name="HIDE_MODE_SLIDER" value="1" enum="HideMode">
+			The slider is hidden.
+		</constant>
+		<constant name="HIDE_MODE_GRABBER" value="2" enum="HideMode">
+			The slider is hidden and the grabber is disabled.
+		</constant>
+	</constants>
 </class>

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -137,7 +137,7 @@ public:
 
 			setting = true;
 			Ref<EditorUndoRedoManager> &undo_redo = EditorNode::get_undo_redo();
-			undo_redo->create_action(TTR("Anim Change Keyframe Time"), UndoRedo::MERGE_ENDS);
+			undo_redo->create_action(TTR("Anim Change Keyframe Time"));
 
 			Variant val = animation->track_get_key_value(track, key);
 			float trans = animation->track_get_key_transition(track, key);
@@ -572,9 +572,9 @@ public:
 
 		if (use_fps && animation->get_step() > 0) {
 			float max_frame = animation->get_length() / animation->get_step();
-			p_list->push_back(PropertyInfo(Variant::FLOAT, PNAME("frame"), PROPERTY_HINT_RANGE, "0," + rtos(max_frame) + ",1"));
+			p_list->push_back(PropertyInfo(Variant::FLOAT, PNAME("frame"), PROPERTY_HINT_RANGE, "0," + rtos(max_frame) + ",1,hide_grabber"));
 		} else {
-			p_list->push_back(PropertyInfo(Variant::FLOAT, PNAME("time"), PROPERTY_HINT_RANGE, "0," + rtos(animation->get_length()) + ",0.01"));
+			p_list->push_back(PropertyInfo(Variant::FLOAT, PNAME("time"), PROPERTY_HINT_RANGE, "0," + rtos(animation->get_length()) + ",0.01,hide_grabber"));
 		}
 
 		switch (animation->track_get_type(track)) {
@@ -1955,7 +1955,7 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 	length->set_step(0.001);
 	length->set_allow_greater(true);
 	length->set_custom_minimum_size(Vector2(70 * EDSCALE, 0));
-	length->set_hide_slider(true);
+	length->set_hide_mode(EditorSpinSlider::HIDE_MODE_SLIDER);
 	length->set_tooltip_text(TTR("Animation length (seconds)"));
 	length->connect("value_changed", callable_mp(this, &AnimationTimelineEdit::_anim_length_changed));
 	len_hb->add_child(length);
@@ -6674,7 +6674,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	step->set_min(0);
 	step->set_max(1000000);
 	step->set_step(0.001);
-	step->set_hide_slider(true);
+	step->set_hide_mode(EditorSpinSlider::HIDE_MODE_SLIDER);
 	step->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
 	step->set_tooltip_text(TTR("Animation step value."));
 	bottom_hb->add_child(step);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1384,10 +1384,11 @@ void EditorPropertyInteger::update_property() {
 void EditorPropertyInteger::_bind_methods() {
 }
 
-void EditorPropertyInteger::setup(int64_t p_min, int64_t p_max, int64_t p_step, bool p_allow_greater, bool p_allow_lesser, const String &p_suffix) {
+void EditorPropertyInteger::setup(int64_t p_min, int64_t p_max, int64_t p_step, EditorSpinSlider::HideMode p_hide_mode, bool p_allow_greater, bool p_allow_lesser, const String &p_suffix) {
 	spin->set_min(p_min);
 	spin->set_max(p_max);
 	spin->set_step(p_step);
+	spin->set_hide_mode(p_hide_mode);
 	spin->set_allow_greater(p_allow_greater);
 	spin->set_allow_lesser(p_allow_lesser);
 	spin->set_suffix(p_suffix);
@@ -1521,12 +1522,12 @@ void EditorPropertyFloat::update_property() {
 void EditorPropertyFloat::_bind_methods() {
 }
 
-void EditorPropertyFloat::setup(double p_min, double p_max, double p_step, bool p_hide_slider, bool p_exp_range, bool p_greater, bool p_lesser, const String &p_suffix, bool p_angle_in_radians) {
+void EditorPropertyFloat::setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, bool p_exp_range, bool p_greater, bool p_lesser, const String &p_suffix, bool p_angle_in_radians) {
 	angle_in_radians = p_angle_in_radians;
 	spin->set_min(p_min);
 	spin->set_max(p_max);
 	spin->set_step(p_step);
-	spin->set_hide_slider(p_hide_slider);
+	spin->set_hide_mode(p_hide_mode);
 	spin->set_exp_ratio(p_exp_range);
 	spin->set_allow_greater(p_greater);
 	spin->set_allow_lesser(p_lesser);
@@ -1753,7 +1754,7 @@ EditorPropertyEasing::EditorPropertyEasing() {
 	spin->set_min(-100);
 	spin->set_max(100);
 	spin->set_step(0);
-	spin->set_hide_slider(true);
+	spin->set_hide_mode(EditorSpinSlider::HIDE_MODE_SLIDER);
 	spin->set_allow_lesser(true);
 	spin->set_allow_greater(true);
 	spin->connect("value_changed", callable_mp(this, &EditorPropertyEasing::_spin_value_changed));
@@ -1829,12 +1830,12 @@ void EditorPropertyVector2::_notification(int p_what) {
 	}
 }
 
-void EditorPropertyVector2::setup(double p_min, double p_max, double p_step, bool p_hide_slider, bool p_link, const String &p_suffix) {
+void EditorPropertyVector2::setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, bool p_link, const String &p_suffix) {
 	for (int i = 0; i < 2; i++) {
 		spin[i]->set_min(p_min);
 		spin[i]->set_max(p_max);
 		spin[i]->set_step(p_step);
-		spin[i]->set_hide_slider(p_hide_slider);
+		spin[i]->set_hide_mode(p_hide_mode);
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		spin[i]->set_suffix(p_suffix);
@@ -1939,12 +1940,12 @@ void EditorPropertyRect2::_notification(int p_what) {
 void EditorPropertyRect2::_bind_methods() {
 }
 
-void EditorPropertyRect2::setup(double p_min, double p_max, double p_step, bool p_hide_slider, const String &p_suffix) {
+void EditorPropertyRect2::setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, const String &p_suffix) {
 	for (int i = 0; i < 4; i++) {
 		spin[i]->set_min(p_min);
 		spin[i]->set_max(p_max);
 		spin[i]->set_step(p_step);
-		spin[i]->set_hide_slider(p_hide_slider);
+		spin[i]->set_hide_mode(p_hide_mode);
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		spin[i]->set_suffix(p_suffix);
@@ -2110,13 +2111,13 @@ void EditorPropertyVector3::_notification(int p_what) {
 void EditorPropertyVector3::_bind_methods() {
 }
 
-void EditorPropertyVector3::setup(double p_min, double p_max, double p_step, bool p_hide_slider, bool p_link, const String &p_suffix, bool p_angle_in_radians) {
+void EditorPropertyVector3::setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, bool p_link, const String &p_suffix, bool p_angle_in_radians) {
 	angle_in_radians = p_angle_in_radians;
 	for (int i = 0; i < 3; i++) {
 		spin[i]->set_min(p_min);
 		spin[i]->set_max(p_max);
 		spin[i]->set_step(p_step);
-		spin[i]->set_hide_slider(p_hide_slider);
+		spin[i]->set_hide_mode(p_hide_mode);
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		spin[i]->set_suffix(p_suffix);
@@ -2242,12 +2243,12 @@ void EditorPropertyVector2i::_notification(int p_what) {
 	}
 }
 
-void EditorPropertyVector2i::setup(int p_min, int p_max, bool p_hide_slider, bool p_link, const String &p_suffix) {
+void EditorPropertyVector2i::setup(int p_min, int p_max, bool p_link, const String &p_suffix) {
 	for (int i = 0; i < 2; i++) {
 		spin[i]->set_min(p_min);
 		spin[i]->set_max(p_max);
 		spin[i]->set_step(1);
-		spin[i]->set_hide_slider(p_hide_slider);
+		spin[i]->set_hide_mode(EditorSpinSlider::HIDE_MODE_NONE);
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		spin[i]->set_suffix(p_suffix);
@@ -2352,12 +2353,12 @@ void EditorPropertyRect2i::_notification(int p_what) {
 void EditorPropertyRect2i::_bind_methods() {
 }
 
-void EditorPropertyRect2i::setup(int p_min, int p_max, bool p_hide_slider, const String &p_suffix) {
+void EditorPropertyRect2i::setup(int p_min, int p_max, const String &p_suffix) {
 	for (int i = 0; i < 4; i++) {
 		spin[i]->set_min(p_min);
 		spin[i]->set_max(p_max);
 		spin[i]->set_step(1);
-		spin[i]->set_hide_slider(p_hide_slider);
+		spin[i]->set_hide_mode(EditorSpinSlider::HIDE_MODE_NONE);
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		spin[i]->set_suffix(p_suffix);
@@ -2496,12 +2497,12 @@ void EditorPropertyVector3i::_notification(int p_what) {
 void EditorPropertyVector3i::_bind_methods() {
 }
 
-void EditorPropertyVector3i::setup(int p_min, int p_max, bool p_hide_slider, bool p_link, const String &p_suffix) {
+void EditorPropertyVector3i::setup(int p_min, int p_max, bool p_link, const String &p_suffix) {
 	for (int i = 0; i < 3; i++) {
 		spin[i]->set_min(p_min);
 		spin[i]->set_max(p_max);
 		spin[i]->set_step(1);
-		spin[i]->set_hide_slider(p_hide_slider);
+		spin[i]->set_hide_mode(EditorSpinSlider::HIDE_MODE_NONE);
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		spin[i]->set_suffix(p_suffix);
@@ -2605,12 +2606,12 @@ void EditorPropertyPlane::_notification(int p_what) {
 void EditorPropertyPlane::_bind_methods() {
 }
 
-void EditorPropertyPlane::setup(double p_min, double p_max, double p_step, bool p_hide_slider, const String &p_suffix) {
+void EditorPropertyPlane::setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, const String &p_suffix) {
 	for (int i = 0; i < 4; i++) {
 		spin[i]->set_min(p_min);
 		spin[i]->set_max(p_max);
 		spin[i]->set_step(p_step);
-		spin[i]->set_hide_slider(p_hide_slider);
+		spin[i]->set_hide_mode(p_hide_mode);
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 	}
@@ -2766,12 +2767,12 @@ void EditorPropertyQuaternion::_notification(int p_what) {
 void EditorPropertyQuaternion::_bind_methods() {
 }
 
-void EditorPropertyQuaternion::setup(double p_min, double p_max, double p_step, bool p_hide_slider, const String &p_suffix, bool p_hide_editor) {
+void EditorPropertyQuaternion::setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, const String &p_suffix, bool p_hide_editor) {
 	for (int i = 0; i < 4; i++) {
 		spin[i]->set_min(p_min);
 		spin[i]->set_max(p_max);
 		spin[i]->set_step(p_step);
-		spin[i]->set_hide_slider(p_hide_slider);
+		spin[i]->set_hide_mode(p_hide_mode);
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		// Quaternion is inherently unitless, however someone may want to use it as
@@ -2783,7 +2784,7 @@ void EditorPropertyQuaternion::setup(double p_min, double p_max, double p_step, 
 		euler[i]->set_min(-360);
 		euler[i]->set_max(360);
 		euler[i]->set_step(0.1);
-		euler[i]->set_hide_slider(false);
+		euler[i]->set_hide_mode(EditorSpinSlider::HIDE_MODE_NONE);
 		euler[i]->set_allow_greater(true);
 		euler[i]->set_allow_lesser(true);
 		euler[i]->set_suffix(U"\u00B0");
@@ -2914,12 +2915,12 @@ void EditorPropertyVector4::_notification(int p_what) {
 void EditorPropertyVector4::_bind_methods() {
 }
 
-void EditorPropertyVector4::setup(double p_min, double p_max, double p_step, bool p_hide_slider, const String &p_suffix) {
+void EditorPropertyVector4::setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, const String &p_suffix) {
 	for (int i = 0; i < 4; i++) {
 		spin[i]->set_min(p_min);
 		spin[i]->set_max(p_max);
 		spin[i]->set_step(p_step);
-		spin[i]->set_hide_slider(p_hide_slider);
+		spin[i]->set_hide_mode(p_hide_mode);
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		spin[i]->set_suffix(p_suffix);
@@ -3004,11 +3005,12 @@ void EditorPropertyVector4i::_notification(int p_what) {
 void EditorPropertyVector4i::_bind_methods() {
 }
 
-void EditorPropertyVector4i::setup(double p_min, double p_max, bool p_hide_slider, const String &p_suffix) {
+void EditorPropertyVector4i::setup(double p_min, double p_max, const String &p_suffix) {
 	for (int i = 0; i < 4; i++) {
 		spin[i]->set_min(p_min);
 		spin[i]->set_max(p_max);
-		spin[i]->set_hide_slider(p_hide_slider);
+		spin[i]->set_step(1);
+		spin[i]->set_hide_mode(EditorSpinSlider::HIDE_MODE_NONE);
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		spin[i]->set_suffix(p_suffix);
@@ -3099,12 +3101,12 @@ void EditorPropertyAABB::_notification(int p_what) {
 void EditorPropertyAABB::_bind_methods() {
 }
 
-void EditorPropertyAABB::setup(double p_min, double p_max, double p_step, bool p_hide_slider, const String &p_suffix) {
+void EditorPropertyAABB::setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, const String &p_suffix) {
 	for (int i = 0; i < 6; i++) {
 		spin[i]->set_min(p_min);
 		spin[i]->set_max(p_max);
 		spin[i]->set_step(p_step);
-		spin[i]->set_hide_slider(p_hide_slider);
+		spin[i]->set_hide_mode(p_hide_mode);
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		spin[i]->set_suffix(p_suffix);
@@ -3187,12 +3189,12 @@ void EditorPropertyTransform2D::_notification(int p_what) {
 void EditorPropertyTransform2D::_bind_methods() {
 }
 
-void EditorPropertyTransform2D::setup(double p_min, double p_max, double p_step, bool p_hide_slider, const String &p_suffix) {
+void EditorPropertyTransform2D::setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, const String &p_suffix) {
 	for (int i = 0; i < 6; i++) {
 		spin[i]->set_min(p_min);
 		spin[i]->set_max(p_max);
 		spin[i]->set_step(p_step);
-		spin[i]->set_hide_slider(p_hide_slider);
+		spin[i]->set_hide_mode(p_hide_mode);
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		if (i % 3 == 2) {
@@ -3279,12 +3281,12 @@ void EditorPropertyBasis::_notification(int p_what) {
 void EditorPropertyBasis::_bind_methods() {
 }
 
-void EditorPropertyBasis::setup(double p_min, double p_max, double p_step, bool p_hide_slider, const String &p_suffix) {
+void EditorPropertyBasis::setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, const String &p_suffix) {
 	for (int i = 0; i < 9; i++) {
 		spin[i]->set_min(p_min);
 		spin[i]->set_max(p_max);
 		spin[i]->set_step(p_step);
-		spin[i]->set_hide_slider(p_hide_slider);
+		spin[i]->set_hide_mode(p_hide_mode);
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		// Basis is inherently unitless, however someone may want to use it as
@@ -3377,12 +3379,12 @@ void EditorPropertyTransform3D::_notification(int p_what) {
 void EditorPropertyTransform3D::_bind_methods() {
 }
 
-void EditorPropertyTransform3D::setup(double p_min, double p_max, double p_step, bool p_hide_slider, const String &p_suffix) {
+void EditorPropertyTransform3D::setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, const String &p_suffix) {
 	for (int i = 0; i < 12; i++) {
 		spin[i]->set_min(p_min);
 		spin[i]->set_max(p_max);
 		spin[i]->set_step(p_step);
-		spin[i]->set_hide_slider(p_hide_slider);
+		spin[i]->set_hide_mode(p_hide_mode);
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		if (i % 4 == 3) {
@@ -3483,12 +3485,12 @@ void EditorPropertyProjection::_notification(int p_what) {
 void EditorPropertyProjection::_bind_methods() {
 }
 
-void EditorPropertyProjection::setup(double p_min, double p_max, double p_step, bool p_hide_slider, const String &p_suffix) {
+void EditorPropertyProjection::setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, const String &p_suffix) {
 	for (int i = 0; i < 16; i++) {
 		spin[i]->set_min(p_min);
 		spin[i]->set_max(p_max);
 		spin[i]->set_step(p_step);
-		spin[i]->set_hide_slider(p_hide_slider);
+		spin[i]->set_hide_mode(p_hide_mode);
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		if (i % 4 == 3) {
@@ -4222,7 +4224,7 @@ struct EditorPropertyRangeHint {
 	double step = 1.0;
 	String suffix;
 	bool exp_range = false;
-	bool hide_slider = true;
+	EditorSpinSlider::HideMode hide_mode = EditorSpinSlider::HIDE_MODE_SLIDER;
 	bool radians = false;
 };
 
@@ -4244,7 +4246,7 @@ static EditorPropertyRangeHint _parse_range_hint(PropertyHint p_hint, const Stri
 			// Step is optional, could be something else if not a number.
 			hint.step = slices[2].to_float();
 		}
-		hint.hide_slider = false;
+		hint.hide_mode = EditorSpinSlider::HIDE_MODE_NONE;
 		for (int i = 2; i < slices.size(); i++) {
 			String slice = slices[i].strip_edges();
 			if (slice == "or_greater") {
@@ -4252,7 +4254,9 @@ static EditorPropertyRangeHint _parse_range_hint(PropertyHint p_hint, const Stri
 			} else if (slice == "or_less") {
 				hint.or_less = true;
 			} else if (slice == "hide_slider") {
-				hint.hide_slider = true;
+				hint.hide_mode = EditorSpinSlider::HIDE_MODE_SLIDER;
+			} else if (slice == "hide_grabber") {
+				hint.hide_mode = EditorSpinSlider::HIDE_MODE_GRABBER;
 			} else if (slice == "exp") {
 				hint.exp_range = true;
 			}
@@ -4347,7 +4351,7 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				EditorPropertyInteger *editor = memnew(EditorPropertyInteger);
 
 				EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, 1);
-				editor->setup(hint.min, hint.max, hint.step, hint.or_greater, hint.or_less, hint.suffix);
+				editor->setup(hint.min, hint.max, hint.step, EditorSpinSlider::HIDE_MODE_NONE, hint.or_greater, hint.or_less, hint.suffix);
 
 				return editor;
 			}
@@ -4375,7 +4379,7 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				EditorPropertyFloat *editor = memnew(EditorPropertyFloat);
 
 				EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-				editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.exp_range, hint.or_greater, hint.or_less, hint.suffix, hint.radians);
+				editor->setup(hint.min, hint.max, hint.step, hint.hide_mode, hint.exp_range, hint.or_greater, hint.or_less, hint.suffix, hint.radians);
 
 				return editor;
 			}
@@ -4468,99 +4472,99 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 			EditorPropertyVector2 *editor = memnew(EditorPropertyVector2(p_wide));
 
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, p_hint == PROPERTY_HINT_LINK, hint.suffix);
+			editor->setup(hint.min, hint.max, hint.step, hint.hide_mode, p_hint == PROPERTY_HINT_LINK, hint.suffix);
 			return editor;
 
 		} break;
 		case Variant::VECTOR2I: {
 			EditorPropertyVector2i *editor = memnew(EditorPropertyVector2i(p_wide));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, 1);
-			editor->setup(hint.min, hint.max, hint.hide_slider, p_hint == PROPERTY_HINT_LINK, hint.suffix);
+			editor->setup(hint.min, hint.max, p_hint == PROPERTY_HINT_LINK, hint.suffix);
 			return editor;
 
 		} break;
 		case Variant::RECT2: {
 			EditorPropertyRect2 *editor = memnew(EditorPropertyRect2(p_wide));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.suffix);
+			editor->setup(hint.min, hint.max, hint.step, hint.hide_mode, hint.suffix);
 			return editor;
 		} break;
 		case Variant::RECT2I: {
 			EditorPropertyRect2i *editor = memnew(EditorPropertyRect2i(p_wide));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, 1);
-			editor->setup(hint.min, hint.max, hint.hide_slider, hint.suffix);
+			editor->setup(hint.min, hint.max, hint.suffix);
 
 			return editor;
 		} break;
 		case Variant::VECTOR3: {
 			EditorPropertyVector3 *editor = memnew(EditorPropertyVector3(p_wide));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, p_hint == PROPERTY_HINT_LINK, hint.suffix, hint.radians);
+			editor->setup(hint.min, hint.max, hint.step, hint.hide_mode, p_hint == PROPERTY_HINT_LINK, hint.suffix, hint.radians);
 			return editor;
 
 		} break;
 		case Variant::VECTOR3I: {
 			EditorPropertyVector3i *editor = memnew(EditorPropertyVector3i(p_wide));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, 1);
-			editor->setup(hint.min, hint.max, hint.hide_slider, p_hint == PROPERTY_HINT_LINK, hint.suffix);
+			editor->setup(hint.min, hint.max, p_hint == PROPERTY_HINT_LINK, hint.suffix);
 			return editor;
 
 		} break;
 		case Variant::VECTOR4: {
 			EditorPropertyVector4 *editor = memnew(EditorPropertyVector4);
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.suffix);
+			editor->setup(hint.min, hint.max, hint.step, hint.hide_mode, hint.suffix);
 			return editor;
 
 		} break;
 		case Variant::VECTOR4I: {
 			EditorPropertyVector4i *editor = memnew(EditorPropertyVector4i);
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, 1);
-			editor->setup(hint.min, hint.max, hint.hide_slider, hint.suffix);
+			editor->setup(hint.min, hint.max, hint.suffix);
 			return editor;
 
 		} break;
 		case Variant::TRANSFORM2D: {
 			EditorPropertyTransform2D *editor = memnew(EditorPropertyTransform2D);
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.suffix);
+			editor->setup(hint.min, hint.max, hint.step, hint.hide_mode, hint.suffix);
 			return editor;
 		} break;
 		case Variant::PLANE: {
 			EditorPropertyPlane *editor = memnew(EditorPropertyPlane(p_wide));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.suffix);
+			editor->setup(hint.min, hint.max, hint.step, hint.hide_mode, hint.suffix);
 			return editor;
 		} break;
 		case Variant::QUATERNION: {
 			EditorPropertyQuaternion *editor = memnew(EditorPropertyQuaternion);
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.suffix, p_hint == PROPERTY_HINT_HIDE_QUATERNION_EDIT);
+			editor->setup(hint.min, hint.max, hint.step, hint.hide_mode, hint.suffix, p_hint == PROPERTY_HINT_HIDE_QUATERNION_EDIT);
 			return editor;
 		} break;
 		case Variant::AABB: {
 			EditorPropertyAABB *editor = memnew(EditorPropertyAABB);
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.suffix);
+			editor->setup(hint.min, hint.max, hint.step, hint.hide_mode, hint.suffix);
 			return editor;
 		} break;
 		case Variant::BASIS: {
 			EditorPropertyBasis *editor = memnew(EditorPropertyBasis);
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.suffix);
+			editor->setup(hint.min, hint.max, hint.step, hint.hide_mode, hint.suffix);
 			return editor;
 		} break;
 		case Variant::TRANSFORM3D: {
 			EditorPropertyTransform3D *editor = memnew(EditorPropertyTransform3D);
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.suffix);
+			editor->setup(hint.min, hint.max, hint.step, hint.hide_mode, hint.suffix);
 			return editor;
 
 		} break;
 		case Variant::PROJECTION: {
 			EditorPropertyProjection *editor = memnew(EditorPropertyProjection);
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.suffix);
+			editor->setup(hint.min, hint.max, hint.step, hint.hide_mode, hint.suffix);
 			return editor;
 
 		} break;

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -32,6 +32,7 @@
 #define EDITOR_PROPERTIES_H
 
 #include "editor/editor_inspector.h"
+#include "editor/editor_spin_slider.h"
 
 class CheckBox;
 class ColorPickerButton;
@@ -39,7 +40,6 @@ class CreateDialog;
 class EditorFileDialog;
 class EditorLocaleDialog;
 class EditorResourcePicker;
-class EditorSpinSlider;
 class PropertySelector;
 class SceneTreeDialog;
 class TextEdit;
@@ -378,7 +378,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(int64_t p_min, int64_t p_max, int64_t p_step, bool p_allow_greater, bool p_allow_lesser, const String &p_suffix = String());
+	void setup(int64_t p_min, int64_t p_max, int64_t p_step, EditorSpinSlider::HideMode p_hide_mode, bool p_allow_greater, bool p_allow_lesser, const String &p_suffix = String());
 	EditorPropertyInteger();
 };
 
@@ -438,7 +438,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(double p_min, double p_max, double p_step, bool p_hide_slider, bool p_exp_range, bool p_greater, bool p_lesser, const String &p_suffix = String(), bool p_angle_in_radians = false);
+	void setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, bool p_exp_range, bool p_greater, bool p_lesser, const String &p_suffix = String(), bool p_angle_in_radians = false);
 	EditorPropertyFloat();
 };
 
@@ -501,7 +501,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(double p_min, double p_max, double p_step, bool p_hide_slider, bool p_link = false, const String &p_suffix = String());
+	void setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, bool p_link = false, const String &p_suffix = String());
 	EditorPropertyVector2(bool p_force_wide = false);
 };
 
@@ -518,7 +518,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(double p_min, double p_max, double p_step, bool p_hide_slider, const String &p_suffix = String());
+	void setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, const String &p_suffix = String());
 	EditorPropertyRect2(bool p_force_wide = false);
 };
 
@@ -546,7 +546,7 @@ public:
 	virtual void update_property() override;
 	virtual void update_using_vector(Vector3 p_vector);
 	virtual Vector3 get_vector();
-	void setup(double p_min, double p_max, double p_step, bool p_hide_slider, bool p_link = false, const String &p_suffix = String(), bool p_angle_in_radians = false);
+	void setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, bool p_link = false, const String &p_suffix = String(), bool p_angle_in_radians = false);
 	EditorPropertyVector3(bool p_force_wide = false);
 };
 
@@ -566,7 +566,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(int p_min, int p_max, bool p_hide_slider, bool p_link = false, const String &p_suffix = String());
+	void setup(int p_min, int p_max, bool p_link = false, const String &p_suffix = String());
 	EditorPropertyVector2i(bool p_force_wide = false);
 };
 
@@ -583,7 +583,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(int p_min, int p_max, bool p_hide_slider, const String &p_suffix = String());
+	void setup(int p_min, int p_max, const String &p_suffix = String());
 	EditorPropertyRect2i(bool p_force_wide = false);
 };
 
@@ -608,7 +608,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(int p_min, int p_max, bool p_hide_slider, bool p_link = false, const String &p_suffix = String());
+	void setup(int p_min, int p_max, bool p_link = false, const String &p_suffix = String());
 	EditorPropertyVector3i(bool p_force_wide = false);
 };
 
@@ -625,7 +625,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(double p_min, double p_max, double p_step, bool p_hide_slider, const String &p_suffix = String());
+	void setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, const String &p_suffix = String());
 	EditorPropertyPlane(bool p_force_wide = false);
 };
 
@@ -659,7 +659,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(double p_min, double p_max, double p_step, bool p_hide_slider, const String &p_suffix = String(), bool p_hide_editor = false);
+	void setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, const String &p_suffix = String(), bool p_hide_editor = false);
 	EditorPropertyQuaternion();
 };
 
@@ -676,7 +676,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(double p_min, double p_max, double p_step, bool p_hide_slider, const String &p_suffix = String());
+	void setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, const String &p_suffix = String());
 	EditorPropertyVector4();
 };
 
@@ -693,7 +693,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(double p_min, double p_max, bool p_hide_slider, const String &p_suffix = String());
+	void setup(double p_min, double p_max, const String &p_suffix = String());
 	EditorPropertyVector4i();
 };
 
@@ -710,7 +710,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(double p_min, double p_max, double p_step, bool p_hide_slider, const String &p_suffix = String());
+	void setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, const String &p_suffix = String());
 	EditorPropertyAABB();
 };
 
@@ -727,7 +727,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(double p_min, double p_max, double p_step, bool p_hide_slider, const String &p_suffix = String());
+	void setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, const String &p_suffix = String());
 	EditorPropertyTransform2D(bool p_include_origin = true);
 };
 
@@ -744,7 +744,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(double p_min, double p_max, double p_step, bool p_hide_slider, const String &p_suffix = String());
+	void setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, const String &p_suffix = String());
 	EditorPropertyBasis();
 };
 
@@ -762,7 +762,7 @@ protected:
 public:
 	virtual void update_property() override;
 	virtual void update_using_transform(Transform3D p_transform);
-	void setup(double p_min, double p_max, double p_step, bool p_hide_slider, const String &p_suffix = String());
+	void setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, const String &p_suffix = String());
 	EditorPropertyTransform3D();
 };
 
@@ -780,7 +780,7 @@ protected:
 public:
 	virtual void update_property() override;
 	virtual void update_using_transform(Projection p_transform);
-	void setup(double p_min, double p_max, double p_step, bool p_hide_slider, const String &p_suffix = String());
+	void setup(double p_min, double p_max, double p_step, EditorSpinSlider::HideMode p_hide_mode, const String &p_suffix = String());
 	EditorPropertyProjection();
 };
 

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -919,13 +919,13 @@ void EditorPropertyDictionary::update_property() {
 				} break;
 				case Variant::INT: {
 					EditorPropertyInteger *editor = memnew(EditorPropertyInteger);
-					editor->setup(-100000, 100000, 1, true, true);
+					editor->setup(-100000, 100000, 1, EditorSpinSlider::HIDE_MODE_NONE, true, true);
 					prop = editor;
 
 				} break;
 				case Variant::FLOAT: {
 					EditorPropertyFloat *editor = memnew(EditorPropertyFloat);
-					editor->setup(-100000, 100000, default_float_step, true, false, true, true);
+					editor->setup(-100000, 100000, default_float_step, EditorSpinSlider::HIDE_MODE_SLIDER, false, true, true);
 					prop = editor;
 				} break;
 				case Variant::STRING: {
@@ -936,91 +936,91 @@ void EditorPropertyDictionary::update_property() {
 				// Math types.
 				case Variant::VECTOR2: {
 					EditorPropertyVector2 *editor = memnew(EditorPropertyVector2);
-					editor->setup(-100000, 100000, default_float_step, true);
+					editor->setup(-100000, 100000, default_float_step, EditorSpinSlider::HIDE_MODE_SLIDER);
 					prop = editor;
 
 				} break;
 				case Variant::VECTOR2I: {
 					EditorPropertyVector2i *editor = memnew(EditorPropertyVector2i);
-					editor->setup(-100000, 100000, true);
+					editor->setup(-100000, 100000);
 					prop = editor;
 
 				} break;
 				case Variant::RECT2: {
 					EditorPropertyRect2 *editor = memnew(EditorPropertyRect2);
-					editor->setup(-100000, 100000, default_float_step, true);
+					editor->setup(-100000, 100000, default_float_step, EditorSpinSlider::HIDE_MODE_SLIDER);
 					prop = editor;
 
 				} break;
 				case Variant::RECT2I: {
 					EditorPropertyRect2i *editor = memnew(EditorPropertyRect2i);
-					editor->setup(-100000, 100000, true);
+					editor->setup(-100000, 100000);
 					prop = editor;
 
 				} break;
 				case Variant::VECTOR3: {
 					EditorPropertyVector3 *editor = memnew(EditorPropertyVector3);
-					editor->setup(-100000, 100000, default_float_step, true);
+					editor->setup(-100000, 100000, default_float_step, EditorSpinSlider::HIDE_MODE_SLIDER);
 					prop = editor;
 
 				} break;
 				case Variant::VECTOR3I: {
 					EditorPropertyVector3i *editor = memnew(EditorPropertyVector3i);
-					editor->setup(-100000, 100000, true);
+					editor->setup(-100000, 100000);
 					prop = editor;
 
 				} break;
 				case Variant::VECTOR4: {
 					EditorPropertyVector4 *editor = memnew(EditorPropertyVector4);
-					editor->setup(-100000, 100000, default_float_step, true);
+					editor->setup(-100000, 100000, default_float_step, EditorSpinSlider::HIDE_MODE_SLIDER);
 					prop = editor;
 
 				} break;
 				case Variant::VECTOR4I: {
 					EditorPropertyVector4i *editor = memnew(EditorPropertyVector4i);
-					editor->setup(-100000, 100000, true);
+					editor->setup(-100000, 100000);
 					prop = editor;
 
 				} break;
 				case Variant::TRANSFORM2D: {
 					EditorPropertyTransform2D *editor = memnew(EditorPropertyTransform2D);
-					editor->setup(-100000, 100000, default_float_step, true);
+					editor->setup(-100000, 100000, default_float_step, EditorSpinSlider::HIDE_MODE_SLIDER);
 					prop = editor;
 
 				} break;
 				case Variant::PLANE: {
 					EditorPropertyPlane *editor = memnew(EditorPropertyPlane);
-					editor->setup(-100000, 100000, default_float_step, true);
+					editor->setup(-100000, 100000, default_float_step, EditorSpinSlider::HIDE_MODE_SLIDER);
 					prop = editor;
 
 				} break;
 				case Variant::QUATERNION: {
 					EditorPropertyQuaternion *editor = memnew(EditorPropertyQuaternion);
-					editor->setup(-100000, 100000, default_float_step, true);
+					editor->setup(-100000, 100000, default_float_step, EditorSpinSlider::HIDE_MODE_SLIDER);
 					prop = editor;
 
 				} break;
 				case Variant::AABB: {
 					EditorPropertyAABB *editor = memnew(EditorPropertyAABB);
-					editor->setup(-100000, 100000, default_float_step, true);
+					editor->setup(-100000, 100000, default_float_step, EditorSpinSlider::HIDE_MODE_SLIDER);
 					prop = editor;
 
 				} break;
 				case Variant::BASIS: {
 					EditorPropertyBasis *editor = memnew(EditorPropertyBasis);
-					editor->setup(-100000, 100000, default_float_step, true);
+					editor->setup(-100000, 100000, default_float_step, EditorSpinSlider::HIDE_MODE_SLIDER);
 					prop = editor;
 
 				} break;
 				case Variant::TRANSFORM3D: {
 					EditorPropertyTransform3D *editor = memnew(EditorPropertyTransform3D);
-					editor->setup(-100000, 100000, default_float_step, true);
+					editor->setup(-100000, 100000, default_float_step, EditorSpinSlider::HIDE_MODE_SLIDER);
 					prop = editor;
 
 				} break;
 				case Variant::PROJECTION: {
 					EditorPropertyProjection *editor = memnew(EditorPropertyProjection);
-					editor->setup(-100000, 100000, default_float_step, true);
+					editor->setup(-100000, 100000, default_float_step, EditorSpinSlider::HIDE_MODE_SLIDER);
 					prop = editor;
 
 				} break;

--- a/editor/editor_spin_slider.h
+++ b/editor/editor_spin_slider.h
@@ -38,6 +38,14 @@
 class EditorSpinSlider : public Range {
 	GDCLASS(EditorSpinSlider, Range);
 
+public:
+	enum HideMode {
+		HIDE_MODE_NONE,
+		HIDE_MODE_SLIDER,
+		HIDE_MODE_GRABBER,
+	};
+
+private:
 	String label;
 	String suffix;
 	int updown_offset = -1;
@@ -68,7 +76,7 @@ class EditorSpinSlider : public Range {
 	bool value_input_just_closed = false;
 	bool value_input_dirty = false;
 
-	bool hide_slider = false;
+	HideMode hide_mode = HIDE_MODE_NONE;
 	bool flat = false;
 
 	void _grabber_gui_input(const Ref<InputEvent> &p_event);
@@ -101,8 +109,8 @@ public:
 	void set_suffix(const String &p_suffix);
 	String get_suffix() const;
 
-	void set_hide_slider(bool p_hide);
-	bool is_hiding_slider() const;
+	void set_hide_mode(HideMode p_hide);
+	HideMode get_hide_mode() const;
 
 	void set_read_only(bool p_enable);
 	bool is_read_only() const;
@@ -118,5 +126,7 @@ public:
 	virtual Size2 get_minimum_size() const override;
 	EditorSpinSlider();
 };
+
+VARIANT_ENUM_CAST(EditorSpinSlider::HideMode);
 
 #endif // EDITOR_SPIN_SLIDER_H

--- a/editor/plugins/font_config_plugin.cpp
+++ b/editor/plugins/font_config_plugin.cpp
@@ -483,7 +483,7 @@ void EditorPropertyOTVariation::update_property() {
 			Vector3i range = supported.get_value_at_index(i);
 
 			EditorPropertyInteger *prop = memnew(EditorPropertyInteger);
-			prop->setup(range.x, range.y, 1, false, false);
+			prop->setup(range.x, range.y, 1, EditorSpinSlider::HIDE_MODE_NONE, false, false);
 			prop->set_object_and_property(object.ptr(), "keys/" + itos(name_tag));
 
 			String name = TS->tag_to_name(name_tag);
@@ -762,7 +762,7 @@ void EditorPropertyOTFeatures::update_property() {
 					} break;
 					case Variant::INT: {
 						EditorPropertyInteger *editor = memnew(EditorPropertyInteger);
-						editor->setup(0, 255, 1, false, false);
+						editor->setup(0, 255, 1, EditorSpinSlider::HIDE_MODE_NONE, false, false);
 						prop = editor;
 					} break;
 					default: {

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -64,7 +64,7 @@ void BoneTransformEditor::create_editors() {
 
 	// Position property.
 	position_property = memnew(EditorPropertyVector3());
-	position_property->setup(-10000, 10000, 0.001f, true);
+	position_property->setup(-10000, 10000, 0.001f, EditorSpinSlider::HIDE_MODE_SLIDER);
 	position_property->set_label("Position");
 	position_property->set_selectable(false);
 	position_property->connect("property_changed", callable_mp(this, &BoneTransformEditor::_value_changed));
@@ -73,7 +73,7 @@ void BoneTransformEditor::create_editors() {
 
 	// Rotation property.
 	rotation_property = memnew(EditorPropertyQuaternion());
-	rotation_property->setup(-10000, 10000, 0.001f, true);
+	rotation_property->setup(-10000, 10000, 0.001f, EditorSpinSlider::HIDE_MODE_SLIDER);
 	rotation_property->set_label("Rotation");
 	rotation_property->set_selectable(false);
 	rotation_property->connect("property_changed", callable_mp(this, &BoneTransformEditor::_value_changed));
@@ -82,7 +82,7 @@ void BoneTransformEditor::create_editors() {
 
 	// Scale property.
 	scale_property = memnew(EditorPropertyVector3());
-	scale_property->setup(-10000, 10000, 0.001f, true);
+	scale_property->setup(-10000, 10000, 0.001f, EditorSpinSlider::HIDE_MODE_SLIDER);
 	scale_property->set_label("Scale");
 	scale_property->set_selectable(false);
 	scale_property->connect("property_changed", callable_mp(this, &BoneTransformEditor::_value_changed));
@@ -96,7 +96,7 @@ void BoneTransformEditor::create_editors() {
 
 	// Transform/Matrix property.
 	rest_matrix = memnew(EditorPropertyTransform3D());
-	rest_matrix->setup(-10000, 10000, 0.001f, true);
+	rest_matrix->setup(-10000, 10000, 0.001f, EditorSpinSlider::HIDE_MODE_SLIDER);
 	rest_matrix->set_label("Transform");
 	rest_matrix->set_selectable(false);
 	rest_section->get_vbox()->add_child(rest_matrix);

--- a/editor/plugins/tiles/tile_proxies_manager_dialog.cpp
+++ b/editor/plugins/tiles/tile_proxies_manager_dialog.cpp
@@ -398,7 +398,7 @@ TileProxiesManagerDialog::TileProxiesManagerDialog() {
 	source_from_property_editor->connect("property_changed", callable_mp(this, &TileProxiesManagerDialog::_property_changed));
 	source_from_property_editor->set_selectable(false);
 	source_from_property_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	source_from_property_editor->setup(-1, 99999, 1, true, false);
+	source_from_property_editor->setup(-1, 99999, 1, EditorSpinSlider::HIDE_MODE_NONE, true, false);
 	vboxcontainer_from->add_child(source_from_property_editor);
 
 	coords_from_property_editor = memnew(EditorPropertyVector2i);
@@ -407,7 +407,7 @@ TileProxiesManagerDialog::TileProxiesManagerDialog() {
 	coords_from_property_editor->connect("property_changed", callable_mp(this, &TileProxiesManagerDialog::_property_changed));
 	coords_from_property_editor->set_selectable(false);
 	coords_from_property_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	coords_from_property_editor->setup(-1, 99999, true);
+	coords_from_property_editor->setup(-1, 99999, EditorSpinSlider::HIDE_MODE_SLIDER);
 	coords_from_property_editor->hide();
 	vboxcontainer_from->add_child(coords_from_property_editor);
 
@@ -417,7 +417,7 @@ TileProxiesManagerDialog::TileProxiesManagerDialog() {
 	alternative_from_property_editor->connect("property_changed", callable_mp(this, &TileProxiesManagerDialog::_property_changed));
 	alternative_from_property_editor->set_selectable(false);
 	alternative_from_property_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	alternative_from_property_editor->setup(-1, 99999, 1, true, false);
+	alternative_from_property_editor->setup(-1, 99999, 1, EditorSpinSlider::HIDE_MODE_NONE, true, false);
 	alternative_from_property_editor->hide();
 	vboxcontainer_from->add_child(alternative_from_property_editor);
 
@@ -432,7 +432,7 @@ TileProxiesManagerDialog::TileProxiesManagerDialog() {
 	source_to_property_editor->connect("property_changed", callable_mp(this, &TileProxiesManagerDialog::_property_changed));
 	source_to_property_editor->set_selectable(false);
 	source_to_property_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	source_to_property_editor->setup(-1, 99999, 1, true, false);
+	source_to_property_editor->setup(-1, 99999, 1, EditorSpinSlider::HIDE_MODE_NONE, true, false);
 	vboxcontainer_to->add_child(source_to_property_editor);
 
 	coords_to_property_editor = memnew(EditorPropertyVector2i);
@@ -441,7 +441,7 @@ TileProxiesManagerDialog::TileProxiesManagerDialog() {
 	coords_to_property_editor->connect("property_changed", callable_mp(this, &TileProxiesManagerDialog::_property_changed));
 	coords_to_property_editor->set_selectable(false);
 	coords_to_property_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	coords_to_property_editor->setup(-1, 99999, true);
+	coords_to_property_editor->setup(-1, 99999, EditorSpinSlider::HIDE_MODE_SLIDER);
 	coords_to_property_editor->hide();
 	vboxcontainer_to->add_child(coords_to_property_editor);
 
@@ -451,7 +451,7 @@ TileProxiesManagerDialog::TileProxiesManagerDialog() {
 	alternative_to_property_editor->connect("property_changed", callable_mp(this, &TileProxiesManagerDialog::_property_changed));
 	alternative_to_property_editor->set_selectable(false);
 	alternative_to_property_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	alternative_to_property_editor->setup(-1, 99999, 1, true, false);
+	alternative_to_property_editor->setup(-1, 99999, 1, EditorSpinSlider::HIDE_MODE_NONE, true, false);
 	alternative_to_property_editor->hide();
 	vboxcontainer_to->add_child(alternative_to_property_editor);
 


### PR DESCRIPTION
Fixes #69529

Add `hide_grabber` hint to `PROPERTY_HINT_RANGE` & implement `HideMode` to `EditorSpinSlider`, to allow implementing a SpinSlider that doesn't have a grabber as well as a slider, but only allows numeric input.

This is a pretty naive implementation, especially as it is a work-around for the problem described in #69529. However, it is not inconvenient at all, and is better than breaking the history due to the bug by grabber/slider.