### PR TITLE
Fix recurrence issue with setting current origin node

### DIFF
--- a/scene/3d/xr_nodes.h
+++ b/scene/3d/xr_nodes.h
@@ -183,6 +183,8 @@ private:
 	bool current = false;
 	static Vector<XROrigin3D *> origin_nodes; // all origin nodes in tree
 
+	void _set_current(bool p_enabled, bool p_update_others);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();


### PR DESCRIPTION
The `set_current` code for the `XROrigin3D` node when multiple `XROrigin3D` nodes are in play is designed to be called before our node has been added to the node tree, and again afterwards to fully process making the node current.

The problem with this code was that in setting a new node as current, the previous node was set as no longer current, which triggered checking the other nodes to make the first one current again, and we started ping-ponging.

This PR changes the code so the full logic is run when the property is set (or called for the second time from `NOTIFICATION_ENTER_TREE`), but when the subsequent logic turns off the previously current node, it doesn't run through the full logic but only changes the status and turns off the transform notifications. 