### PR TITLE
Add feature tags to signify engine float precision

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -374,6 +374,16 @@ bool OS::has_feature(const String &p_feature) {
 #endif // DEBUG_ENABLED
 #endif // TOOLS_ENABLED
 
+#ifdef REAL_T_IS_DOUBLE
+	if (p_feature == "double") {
+		return true;
+	}
+#else
+	if (p_feature == "single") {
+		return true;
+	}
+#endif // REAL_T_IS_DOUBLE
+
 	if (sizeof(void *) == 8 && p_feature == "64") {
 		return true;
 	}

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -280,6 +280,8 @@ void ProjectSettingsEditor::_add_feature_overrides() {
 	presets.insert("debug");
 	presets.insert("release");
 	presets.insert("template");
+	presets.insert("double");
+	presets.insert("single");
 	presets.insert("32");
 	presets.insert("64");
 	presets.insert("movie");


### PR DESCRIPTION
This adds `double` (edit: and `single`) as a "feature tag" to `OS::has_feature` to signify whether an engine was built with double-precision, also known as `float=64` or `REAL_T_IS_DOUBLE`.

This allows, for example, the engine to load different extension libraries (see [here](https://github.com/godotengine/godot/blob/daf168f4c821980a6a06fde67057f6a14d9e20c6/core/extension/native_extension.cpp#L429)) depending on if the engine was built with `float=32` or `float=64`, allowing extension authors to bundle libraries for both precision types.

Without this ability to differentiate between `float=32` and `float=64` the engine will crash when loading an extension with a mismatching precision type.