### PR TITLE
Add "dedicated server" export mode which can strip unneeded visual resources (superseded)

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -438,6 +438,15 @@ void Resource::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "resource_path", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_path", "get_path");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "resource_name"), "set_name", "get_name");
 
+#ifdef TOOLS_ENABLED
+	ClassDB::bind_method(D_METHOD("set_dedicated_server_export_type", "server_export_type"), &Resource::set_dedicated_server_export_type);
+	ClassDB::bind_method(D_METHOD("get_dedicated_server_export_type"), &Resource::get_dedicated_server_export_type);
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "resource_dedicated_server_export_type", PROPERTY_HINT_ENUM, "Strip,Keep"), "set_dedicated_server_export_type", "get_dedicated_server_export_type");
+
+	BIND_ENUM_CONSTANT(DEDICATED_SERVER_EXPORT_STRIP);
+	BIND_ENUM_CONSTANT(DEDICATED_SERVER_EXPORT_KEEP);
+#endif
+
 	MethodInfo get_rid_bind("_get_rid");
 	get_rid_bind.return_val.type = Variant::RID;
 

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -53,6 +53,13 @@ public:
 	static void register_custom_data_to_otdb() { ClassDB::add_resource_base_extension("res", get_class_static()); }
 	virtual String get_base_extension() const { return "res"; }
 
+#ifdef TOOLS_ENABLED
+	enum DedicatedServerExportType {
+		DEDICATED_SERVER_EXPORT_STRIP,
+		DEDICATED_SERVER_EXPORT_KEEP,
+	};
+#endif
+
 private:
 	HashSet<ObjectID> owners;
 
@@ -67,6 +74,7 @@ private:
 	uint64_t last_modified_time = 0;
 	uint64_t import_last_modified_time = 0;
 	String import_path;
+	DedicatedServerExportType dedicated_server_export_type = DEDICATED_SERVER_EXPORT_STRIP;
 #endif
 
 	bool local_to_scene = false;
@@ -133,6 +141,12 @@ public:
 	void set_import_path(const String &p_path) { import_path = p_path; }
 	String get_import_path() const { return import_path; }
 
+	void set_dedicated_server_export_type(DedicatedServerExportType p_server_export_type) {
+		dedicated_server_export_type = p_server_export_type;
+		emit_changed();
+	}
+	DedicatedServerExportType get_dedicated_server_export_type() const { return dedicated_server_export_type; }
+
 #endif
 
 	void set_as_translation_remapped(bool p_remapped);
@@ -149,6 +163,10 @@ public:
 	Resource();
 	~Resource();
 };
+
+#ifdef TOOLS_ENABLED
+VARIANT_ENUM_CAST(Resource::DedicatedServerExportType);
+#endif
 
 class ResourceCache {
 	friend class Resource;

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -43,6 +43,9 @@ class ResourceFormatImporter : public ResourceFormatLoader {
 		String group_file;
 		Variant metadata;
 		uint64_t uid = ResourceUID::INVALID_ID;
+#ifdef TOOLS_ENABLED
+		Resource::DedicatedServerExportType dedicated_server_export_type;
+#endif
 	};
 
 	Error _get_path_and_type(const String &p_path, PathAndType &r_path_and_type, bool *r_valid = nullptr) const;
@@ -145,6 +148,10 @@ public:
 	virtual Error import_group_file(const String &p_group_file, const HashMap<String, HashMap<StringName, Variant>> &p_source_file_options, const HashMap<String, String> &p_base_paths) { return ERR_UNAVAILABLE; }
 	virtual bool are_import_settings_valid(const String &p_path) const { return true; }
 	virtual String get_import_settings_string() const { return String(); }
+
+#ifdef TOOLS_ENABLED
+	void get_editor_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0);
+#endif
 };
 
 VARIANT_ENUM_CAST(ResourceImporter::ImportOrder);

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -82,6 +82,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="resource_dedicated_server_export_type" type="int" setter="set_dedicated_server_export_type" getter="get_dedicated_server_export_type" enum="Resource.DedicatedServerExportType" default="0">
+			Controls how this resource should be handled in a dedicated server export.
+		</member>
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" default="false">
 			If [code]true[/code], the resource is duplicated for each instance of all scenes using it. At run-time, the resource can be modified in one scene without affecting other instances (see [method PackedScene.instantiate]).
 			[b]Note:[/b] Changing this property at run-time has no effect on already created duplicate resources.
@@ -107,4 +110,12 @@
 			</description>
 		</signal>
 	</signals>
+	<constants>
+		<constant name="DEDICATED_SERVER_EXPORT_STRIP" value="0" enum="DedicatedServerExportType">
+			Replace this resource with a placeholder (if available) in a dedicated server export.
+		</constant>
+		<constant name="DEDICATED_SERVER_EXPORT_KEEP" value="1" enum="DedicatedServerExportType">
+			Keep this resource in a dedicated server export.
+		</constant>
+	</constants>
 </class>

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -432,7 +432,7 @@ void DocTools::generate(bool p_basic_types) {
 				Variant default_value;
 
 				if (name == "EditorSettings") {
-					if (E.name == "resource_local_to_scene" || E.name == "resource_name" || E.name == "resource_path" || E.name == "script") {
+					if (E.name == "resource_local_to_scene" || E.name == "resource_name" || E.name == "resource_path" || E.name == "resource_dedicated_server_export_type" || E.name == "script") {
 						// Don't include spurious properties in the generated EditorSettings class reference.
 						continue;
 					}

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1667,7 +1667,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		Ref<ResourceImporter> importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(importer_name);
 		ERR_FAIL_COND_V(!importer.is_valid(), ERR_FILE_CORRUPT);
 		List<ResourceImporter::ImportOption> options;
-		importer->get_import_options(p_files[i], &options);
+		importer->get_editor_import_options(p_files[i], &options);
 		//set default values
 		for (const ResourceImporter::ImportOption &E : options) {
 			source_file_options[p_files[i]][E.option.name] = E.default_value;
@@ -1748,7 +1748,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 			//store options in provided order, to avoid file changing. Order is also important because first match is accepted first.
 
 			List<ResourceImporter::ImportOption> options;
-			importer->get_import_options(file, &options);
+			importer->get_editor_import_options(file, &options);
 			//set default values
 			for (const ResourceImporter::ImportOption &F : options) {
 				String base = F.option.name;
@@ -1885,7 +1885,7 @@ void EditorFileSystem::_reimport_file(const String &p_file, const HashMap<String
 	//mix with default params, in case a parameter is missing
 
 	List<ResourceImporter::ImportOption> opts;
-	importer->get_import_options(p_file, &opts);
+	importer->get_editor_import_options(p_file, &opts);
 	for (const ResourceImporter::ImportOption &E : opts) {
 		if (!params.has(E.option.name)) { //this one is not present
 			params[E.option.name] = E.default_value;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -123,6 +123,7 @@
 #include "editor/plugins/asset_library_editor_plugin.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
 #include "editor/plugins/debugger_editor_plugin.h"
+#include "editor/plugins/dedicated_server_export_plugin.h"
 #include "editor/plugins/editor_preview_plugins.h"
 #include "editor/plugins/editor_resource_conversion_plugin.h"
 #include "editor/plugins/gdextension_export_plugin.h"
@@ -7331,6 +7332,11 @@ EditorNode::EditorNode() {
 	gdextension_export_plugin.instantiate();
 
 	EditorExport::get_singleton()->add_export_plugin(gdextension_export_plugin);
+
+	Ref<DedicatedServerExportPlugin> dedicated_server_export_plugin;
+	dedicated_server_export_plugin.instantiate();
+
+	EditorExport::get_singleton()->add_export_plugin(dedicated_server_export_plugin);
 
 	Ref<PackedSceneEditorTranslationParserPlugin> packed_scene_translation_parser_plugin;
 	packed_scene_translation_parser_plugin.instantiate();

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -95,7 +95,7 @@ class SectionedInspectorFilter : public Object {
 		for (PropertyInfo &pi : pinfo) {
 			int sp = pi.name.find("/");
 
-			if (pi.name == "resource_path" || pi.name == "resource_name" || pi.name == "resource_local_to_scene" || pi.name.begins_with("script/") || pi.name.begins_with("_global_script")) { //skip resource stuff
+			if (pi.name == "resource_path" || pi.name == "resource_name" || pi.name == "resource_local_to_scene" || pi.name == "resource_dedicated_server_export_type" || pi.name.begins_with("script/") || pi.name.begins_with("_global_script")) { //skip resource stuff
 				continue;
 			}
 
@@ -243,7 +243,7 @@ void SectionedInspector::update_category_list() {
 			continue;
 		}
 
-		if (pi.name.contains(":") || pi.name == "script" || pi.name == "resource_name" || pi.name == "resource_path" || pi.name == "resource_local_to_scene" || pi.name.begins_with("_global_script")) {
+		if (pi.name.contains(":") || pi.name == "script" || pi.name == "resource_name" || pi.name == "resource_path" || pi.name == "resource_local_to_scene" || pi.name == "resource_dedicated_server_export_type" || pi.name.begins_with("_global_script")) {
 			continue;
 		}
 

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -103,6 +103,7 @@ private:
 
 	struct FileExportCache {
 		uint64_t source_modified_time = 0;
+		uint64_t import_modified_time = 0;
 		String source_md5;
 		String saved_path;
 		bool used = false;

--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -31,6 +31,7 @@
 #include "editor_export_platform_pc.h"
 
 #include "core/config/project_settings.h"
+#include "editor/plugins/dedicated_server_export_plugin.h"
 
 void EditorExportPlatformPC::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
 	if (p_preset->get("texture_format/s3tc")) {
@@ -61,6 +62,8 @@ void EditorExportPlatformPC::get_export_options(List<ExportOption> *r_options) {
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/etc"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/etc2"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/no_bptc_fallbacks"), true));
+
+	DedicatedServerExportPlugin::add_export_options(r_options);
 }
 
 String EditorExportPlatformPC::get_name() const {

--- a/editor/export/editor_export_plugin.cpp
+++ b/editor/export/editor_export_plugin.cpp
@@ -184,6 +184,12 @@ String EditorExportPlugin::_get_name() const {
 	return ret;
 }
 
+PackedStringArray EditorExportPlugin::_get_export_features(const Ref<EditorExportPlatform> &p_platform, bool p_debug) const {
+	PackedStringArray ret;
+	GDVIRTUAL_CALL(_get_export_features, p_platform, p_debug, ret);
+	return ret;
+}
+
 void EditorExportPlugin::_export_file(const String &p_path, const String &p_type, const HashSet<String> &p_features) {
 }
 

--- a/editor/export/editor_export_plugin.h
+++ b/editor/export/editor_export_plugin.h
@@ -120,18 +120,22 @@ protected:
 	GDVIRTUAL0(_end_customize_scenes)
 	GDVIRTUAL0(_end_customize_resources)
 
+	GDVIRTUAL2RC(PackedStringArray, _get_export_features, const Ref<EditorExportPlatform> &, bool);
+
 	GDVIRTUAL0RC(String, _get_name)
 
-	bool _begin_customize_resources(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) const; // Return true if this plugin does property export customization
-	Ref<Resource> _customize_resource(const Ref<Resource> &p_resource, const String &p_path); // If nothing is returned, it means do not touch (nothing changed). If something is returned (either the same or a different resource) it means changes are made.
+	virtual bool _begin_customize_resources(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) const; // Return true if this plugin does property export customization
+	virtual Ref<Resource> _customize_resource(const Ref<Resource> &p_resource, const String &p_path); // If nothing is returned, it means do not touch (nothing changed). If something is returned (either the same or a different resource) it means changes are made.
 
-	bool _begin_customize_scenes(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) const; // Return true if this plugin does property export customization
-	Node *_customize_scene(Node *p_root, const String &p_path); // Return true if a change was made
+	virtual bool _begin_customize_scenes(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) const; // Return true if this plugin does property export customization
+	virtual Node *_customize_scene(Node *p_root, const String &p_path); // Return true if a change was made
 
-	uint64_t _get_customization_configuration_hash() const; // Hash used for caching customized resources and scenes.
+	virtual uint64_t _get_customization_configuration_hash() const; // Hash used for caching customized resources and scenes.
 
-	void _end_customize_scenes();
-	void _end_customize_resources();
+	virtual void _end_customize_scenes();
+	virtual void _end_customize_resources();
+
+	virtual PackedStringArray _get_export_features(const Ref<EditorExportPlatform> &p_export_platform, bool p_debug) const;
 
 	virtual String _get_name() const;
 

--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -137,7 +137,7 @@ void ImportDefaultsEditor::_update_importer() {
 
 	if (importer.is_valid()) {
 		List<ResourceImporter::ImportOption> options;
-		importer->get_import_options("", &options);
+		importer->get_editor_import_options("", &options);
 		Dictionary d;
 		if (ProjectSettings::get_singleton()->has_setting("importer_defaults/" + importer->get_importer_name())) {
 			d = GLOBAL_GET("importer_defaults/" + importer->get_importer_name());

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -160,7 +160,7 @@ void ImportDock::_update_options(const String &p_path, const Ref<ConfigFile> &p_
 	List<ResourceImporter::ImportOption> options;
 
 	if (params->importer.is_valid()) {
-		params->importer->get_import_options(p_path, &options);
+		params->importer->get_editor_import_options(p_path, &options);
 	}
 
 	params->properties.clear();
@@ -241,7 +241,7 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 		base_path = p_paths[0];
 	}
 	List<ResourceImporter::ImportOption> options;
-	params->importer->get_import_options(base_path, &options);
+	params->importer->get_editor_import_options(base_path, &options);
 
 	params->properties.clear();
 	params->values.clear();
@@ -407,7 +407,7 @@ void ImportDock::_preset_selected(int p_idx) {
 		default: {
 			List<ResourceImporter::ImportOption> options;
 
-			params->importer->get_import_options(params->base_options_path, &options, p_idx);
+			params->importer->get_editor_import_options(params->base_options_path, &options, p_idx);
 
 			if (params->checking) {
 				params->checked.clear();

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -2144,7 +2144,7 @@ void EditorAnimationMultiTransitionEdit::_get_property_list(List<PropertyInfo> *
 		p_list->push_back(prop_transition_path);
 
 		for (List<PropertyInfo>::Element *F = plist.front(); F; F = F->next()) {
-			if (F->get().name == "script" || F->get().name == "resource_name" || F->get().name == "resource_path" || F->get().name == "resource_local_to_scene") {
+			if (F->get().name == "script" || F->get().name == "resource_name" || F->get().name == "resource_path" || F->get().name == "resource_local_to_scene" || F->get().name == "resource_dedicated_server_export_type") {
 				continue;
 			}
 

--- a/editor/plugins/dedicated_server_export_plugin.cpp
+++ b/editor/plugins/dedicated_server_export_plugin.cpp
@@ -1,0 +1,126 @@
+/*************************************************************************/
+/*  dedicated_server_export_plugin.cpp                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "dedicated_server_export_plugin.h"
+
+#define EXPORT_OPTION_IS_DEDICATED_SERVER "dedicated_server/is_server"
+
+void DedicatedServerExportPlugin::add_export_options(List<EditorExportPlatform::ExportOption> *r_options) {
+	r_options->push_back(EditorExportPlatform::ExportOption(PropertyInfo(Variant::BOOL, EXPORT_OPTION_IS_DEDICATED_SERVER), false));
+}
+
+bool DedicatedServerExportPlugin::is_dedicated_server() const {
+	Ref<EditorExportPreset> preset = get_export_preset();
+	ERR_FAIL_COND_V(preset.is_null(), false);
+
+	bool valid_prop = false;
+	bool is_server = preset->get(EXPORT_OPTION_IS_DEDICATED_SERVER, &valid_prop);
+
+	if (valid_prop) {
+		return is_server;
+	}
+
+	return false;
+}
+
+PackedStringArray DedicatedServerExportPlugin::_get_export_features(const Ref<EditorExportPlatform> &p_platform, bool p_debug) const {
+	PackedStringArray ret;
+	if (is_dedicated_server()) {
+		ret.append("dedicated_server");
+	}
+	return ret;
+}
+
+uint64_t DedicatedServerExportPlugin::_get_customization_configuration_hash() const {
+	return (uint64_t)is_dedicated_server();
+}
+
+bool DedicatedServerExportPlugin::_begin_customize_resources(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) const {
+	return is_dedicated_server();
+}
+
+Ref<Resource> DedicatedServerExportPlugin::_customize_resource(const Ref<Resource> &p_resource, const String &p_path) {
+	if (p_resource->get_dedicated_server_export_type() == Resource::DEDICATED_SERVER_EXPORT_KEEP) {
+		return Ref<Resource>();
+	}
+
+	if (const Texture2D *texture = Object::cast_to<Texture2D>(p_resource.ptr())) {
+		Ref<PlaceholderTexture2D> placeholder;
+		placeholder.instantiate();
+		placeholder->set_size(texture->get_size());
+		return placeholder;
+	}
+
+	if (const Texture2DArray *texture = Object::cast_to<Texture2DArray>(p_resource.ptr())) {
+		Ref<PlaceholderTexture2DArray> placeholder;
+		placeholder.instantiate();
+		placeholder->set_size(Size2i(texture->get_width(), texture->get_height()));
+		placeholder->set_layers(texture->get_layers());
+		return placeholder;
+	}
+
+	if (const Texture3D *texture = Object::cast_to<Texture3D>(p_resource.ptr())) {
+		Ref<PlaceholderTexture3D> placeholder;
+		placeholder.instantiate();
+		placeholder->set_size(Vector3i(texture->get_width(), texture->get_height(), texture->get_depth()));
+		return placeholder;
+	}
+
+	if (const Cubemap *cubemap = Object::cast_to<Cubemap>(p_resource.ptr())) {
+		Ref<PlaceholderCubemap> placeholder;
+		placeholder.instantiate();
+		placeholder->set_size(Size2i(cubemap->get_width(), cubemap->get_height()));
+		placeholder->set_layers(cubemap->get_layers());
+		return placeholder;
+	}
+
+	if (const CubemapArray *cubemap = Object::cast_to<CubemapArray>(p_resource.ptr())) {
+		Ref<PlaceholderCubemapArray> placeholder;
+		placeholder.instantiate();
+		placeholder->set_size(Size2i(cubemap->get_width(), cubemap->get_height()));
+		placeholder->set_layers(cubemap->get_layers());
+		return placeholder;
+	}
+
+	if (Object::cast_to<Material>(p_resource.ptr()) != nullptr) {
+		Ref<PlaceholderMaterial> placeholder;
+		placeholder.instantiate();
+		return placeholder;
+	}
+
+	if (const Mesh *mesh = Object::cast_to<Mesh>(p_resource.ptr())) {
+		Ref<PlaceholderMesh> placeholder;
+		placeholder.instantiate();
+		placeholder->set_aabb(mesh->get_aabb());
+		return placeholder;
+	}
+
+	return Ref<Resource>();
+}

--- a/editor/plugins/dedicated_server_export_plugin.h
+++ b/editor/plugins/dedicated_server_export_plugin.h
@@ -1,0 +1,51 @@
+/*************************************************************************/
+/*  dedicated_server_export_plugin.h                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef DEDICATED_SERVER_EXPORT_PLUGIN_H
+#define DEDICATED_SERVER_EXPORT_PLUGIN_H
+
+#include "editor/export/editor_export.h"
+
+class DedicatedServerExportPlugin : public EditorExportPlugin {
+protected:
+	String _get_name() const override { return "DedicatedServer"; }
+	PackedStringArray _get_export_features(const Ref<EditorExportPlatform> &p_platform, bool p_debug) const override;
+	uint64_t _get_customization_configuration_hash() const override;
+
+	bool _begin_customize_resources(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) const override;
+	Ref<Resource> _customize_resource(const Ref<Resource> &p_resource, const String &p_path) override;
+
+	bool is_dedicated_server() const;
+
+public:
+	static void add_export_options(List<EditorExportPlatform::ExportOption> *r_options);
+};
+
+#endif // DEDICATED_SERVER_EXPORT_PLUGIN_H

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1351,6 +1351,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	ResourceUID::get_singleton()->load_from_cache(); // load UUIDs from cache.
 
+	if (ProjectSettings::get_singleton()->has_custom_feature("dedicated_server")) {
+		audio_driver = "Dummy";
+		display_driver = "headless";
+	}
+
 	ProjectSettings::get_singleton()->set_custom_property_info("memory/limits/multithreaded_server/rid_pool_prealloc",
 			PropertyInfo(Variant::INT,
 					"memory/limits/multithreaded_server/rid_pool_prealloc",


### PR DESCRIPTION
This implements a little more of https://github.com/godotengine/godot-proposals/issues/2756 (but not all of it - this will take a few PRs), including:

- There is an "Is server" option that you can enable when configuring a Windows, MacOS or Linux export preset
- A "dedicated_server" feature tag will be set when running one of those exports!
  - So, you'd detect that you are a dedicated server via `OS.has_feature("dedicated_server")`.
  - This is different than the proposal, which proposes `Engine.is_dedicated_server()`, but I think a feature tag is better, because then you can override project settings using the tag (ie. using "setting.dedicated_server"), and features are commonly used to identify things about the platform. If others feel strongly, though, I can add `Engine.is_dedicated_server()` as well.
- When running an export with "Is server" enabled, headless mode is forced (so, the equivalent of `--headless` on the CLI)
- Resources get a "Dedicated Server Export Type" which can be set to "Keep" or "Strip"
  - For imported resources, this is set on the import options:
    ![Selection_436](https://user-images.githubusercontent.com/191561/205466275-66592e78-685e-437a-9dd3-f8d94b7a696b.png)
  - For embedded resources, you can set it under the expandable "Resource" group in the inspector:
    ![Selection_437](https://user-images.githubusercontent.com/191561/205466268-aaf0626a-53ff-42cf-80cc-efd942798bbb.png)
  - "Remove" and "RemoveOnClient" from the proposal aren't implemented yet. We can add those in a future PR.
- When exporting on a preset with "Is server" enabled, resources set to "Strip" will be replaced with their placeholder versions from #60583.
  - "Strip" is the default, but it doesn't do anything on resources that don't have a placeholder version. We'll probably be adding more placeholder resources in future PRs.
- Random note: Overall, I tried to keep the extra code added for this feature as editor-only, so that it doesn't have an impact on the exported games.

This is was marked as a draft (although, no longer is) because:

- ~~There is an issue with the "file export cache" that I haven't solved yet. If you change the "Dedicated Server Export Type" on an imported asset, re-import and then export, it will export it as-if it still had the previous setting. However, if I delete `.godot/exported/*/file_cache` and then re-export, it gets picked up fine.~~
- I'm unsure that using an `EditorExportPlugin` is the right choice? A lot of the code for this is scattered all over the place (because it has to be), and so `dedicated_server_export_plugin.cpp` is actually pretty small. So, the plugin seems not totally worth it.
- I wasn't previously very familiar with the code I'm changing here, so I welcome feedback from more experienced folks! It's very likely I didn't choose the best approach for some or all of this :-)
