### PR TITLE
Fix internal editor not updating when using external editor via LSP

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2528,7 +2528,7 @@ void ScriptEditor::reload_scripts(bool p_refresh_only) {
 			}
 
 			Ref<Script> scr = edited_res;
-			if (scr != nullptr) {
+			if (scr.is_valid()) {
 				Ref<Script> rel_scr = ResourceLoader::load(scr->get_path(), scr->get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
 				ERR_CONTINUE(!rel_scr.is_valid());
 				scr->set_source_code(rel_scr->get_source_code());
@@ -2537,12 +2537,8 @@ void ScriptEditor::reload_scripts(bool p_refresh_only) {
 			}
 
 			Ref<TextFile> text_file = edited_res;
-			if (text_file != nullptr) {
-				Error err;
-				Ref<TextFile> rel_text_file = _load_text_file(text_file->get_path(), &err);
-				ERR_CONTINUE(!rel_text_file.is_valid());
-				text_file->set_text(rel_text_file->get_text());
-				text_file->set_last_modified_time(rel_text_file->get_last_modified_time());
+			if (text_file.is_valid()) {
+				text_file->reload_from_file();
 			}
 		}
 

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -108,6 +108,7 @@ void GDScriptTextDocument::didSave(const Variant &p_param) {
 			scr->reload(true);
 		}
 		scr->update_exports();
+		ScriptEditor::get_singleton()->reload_scripts(true);
 		ScriptEditor::get_singleton()->update_docs_from_script(scr);
 	}
 }

--- a/scene/resources/text_file.cpp
+++ b/scene/resources/text_file.cpp
@@ -67,5 +67,10 @@ Error TextFile::load_text(const String &p_path) {
 	ERR_FAIL_COND_V_MSG(s.parse_utf8((const char *)w) != OK, ERR_INVALID_DATA, "Script '" + p_path + "' contains invalid unicode (UTF-8), so it was not loaded. Please ensure that scripts are saved in valid UTF-8 unicode.");
 	text = s;
 	path = p_path;
+#ifdef TOOLS_ENABLED
+	if (ResourceLoader::get_timestamp_on_load()) {
+		set_last_modified_time(FileAccess::get_modified_time(path));
+	}
+#endif // TOOLS_ENABLED
 	return OK;
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Fix #69485, fix #59115.

In addition, `update_exports` was called in `ScriptTextEditor` before, which may require script to be open in a  `ScriptTextEditor` to update the export variable.

Fix external modification of text files causing tabs opened in the internal editor to lose their names.



#66658, #66916, #66880 seem to have missed the best time.