### PR TITLE
[ArrayOccluder3D Docs] Add descriptions for `set_arrays`, `indices`, and `vertices`

### DIFF
--- a/doc/classes/ArrayOccluder3D.xml
+++ b/doc/classes/ArrayOccluder3D.xml
@@ -15,13 +15,16 @@
 			<param index="0" name="vertices" type="PackedVector3Array" />
 			<param index="1" name="indices" type="PackedInt32Array" />
 			<description>
+				Sets the occluder's [member vertices] to the [code]vertices[/code] array and the [member indices] to the [code]indices[/code] array.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="indices" type="PackedInt32Array" setter="set_indices" getter="get_indices" default="PackedInt32Array()">
+			The [PackedInt32Array] that contains the occluder's vertex indices.
 		</member>
 		<member name="vertices" type="PackedVector3Array" setter="set_vertices" getter="get_vertices" default="PackedVector3Array()">
+			The [PackedVector3Array] that contains the occluder's vertices.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
Adds the property and method descriptions for `set_arrays`, `indices`, and `vertices`.
This completes the `ArrayOccluder3D` documentation.

I struggled a bit on the description of `set_arrays` so any feedback on missing detail, bad phrasing, etc, is welcome.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
