### PR TITLE
[3.x] Fix CanvasLayer visibility toggle can only run once per frame

### DIFF
--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -55,7 +55,7 @@ void CanvasLayer::set_visible(bool p_visible) {
 	// For CanvasItems that is explicitly top level or has non-CanvasItem parents.
 	if (is_inside_tree()) {
 		const String group = "root_canvas" + itos(canvas.get_id());
-		get_tree()->call_group_flags(SceneTree::GROUP_CALL_UNIQUE, group, "_toplevel_visibility_changed", p_visible);
+		get_tree()->call_group(group, "_toplevel_visibility_changed", p_visible);
 	}
 }
 


### PR DESCRIPTION
Fixes #69556

The `GROUP_CALL_UNIQUE` flag was copied from `CanvasItem` code.

https://github.com/godotengine/godot/blob/01574a566ff1f1a7270bd986b226c1bd351f894e/scene/2d/canvas_item.cpp#L539

I thought calling the same method with different arguments are considered unique calls, but it turns out I'm wrong :(