### PR TITLE
Add note about `GROUP_CALL_UNIQUE` not considering arguments

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -308,6 +308,7 @@
 		</constant>
 		<constant name="GROUP_CALL_UNIQUE" value="4" enum="GroupCallFlags">
 			Call a group only once even if the call is executed many times.
+			[b]Note:[/b] Arguments are not taken into account when deciding whether the call is unique or not. Therefore when the same method is called with different arguments, only the first call will be performed.
 		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
When writing #69558, I realized that I mistakenly thought that `GROUP_CALL_UNIQUE` would categorize calls to the same method with different arguments as unique calls.

I think it's worth mentioning in the documentation.