### PR TITLE
Fix TreeItem::set_as_cursor check

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1018,7 +1018,7 @@ void TreeItem::set_as_cursor(int p_column) {
 	if (tree->select_mode != Tree::SELECT_MULTI) {
 		return;
 	}
-	if (tree->selected_col == p_column) {
+	if (tree->selected_item == this && tree->selected_col == p_column) {
 		return;
 	}
 	tree->selected_item = this;


### PR DESCRIPTION
Fixes #69513
Regression from #59226

(Note the mentioned issue of `expand_to_selected` is not addressed here)
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
