### PR TITLE
Fix burning CPU with udev disabled on Flatpak

### DIFF
--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -218,8 +218,8 @@ void JoypadLinux::monitor_joypads() {
 			}
 		}
 		closedir(input_directory);
+		usleep(1000000); // 1s
 	}
-	usleep(1000000); // 1s
 }
 
 void JoypadLinux::close_joypads() {


### PR DESCRIPTION
Fixes #67355.
Should be cherry-picked to 3.5.

Note that I haven't tested this fix locally. I'd be happy if someone were to make a no-udev or Flatpak build of 3.5 or master, then test on their machine, and/or publish a Flatpak package (perhaps https://docs.flatpak.org/en/latest/single-file-bundles.html?) so I can test CPU burning (unsure about controllers) my side.

- [x] Verify CPU burning is fixed
- [x] Verify startup controllers work
- [x] Verify controller hotplug works
- [x] Verify unplugging controllers works(???)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
