### PR TITLE
[3.x] Fix TreeItem.remove_child not updating Tree immediately

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -430,14 +430,14 @@ void TreeItem::remove_child(TreeItem *p_item) {
 			*c = (*c)->next;
 
 			aux->parent = nullptr;
+
+			if (tree) {
+				tree->update();
+			}
 			return;
 		}
 
 		c = &(*c)->next;
-	}
-
-	if (tree) {
-		tree->update();
 	}
 
 	ERR_FAIL();


### PR DESCRIPTION
Fixes #69553

Previously, the `tree->update()` call won't be reached when the function succeeds.