### PR TITLE
Fix dependency reload triggered too early

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1414,7 +1414,7 @@ void FileSystemDock::_update_dependencies_after_move(const HashMap<String, Strin
 		Error err = ResourceLoader::rename_dependencies(file, p_renames);
 		if (err == OK) {
 			if (ResourceLoader::get_resource_type(file) == "PackedScene") {
-				EditorNode::get_singleton()->reload_scene(file);
+				callable_mp(EditorNode::get_singleton(), &EditorNode::reload_scene).bind(file).call_deferred();
 			}
 		} else {
 			EditorNode::get_singleton()->add_io_error(TTR("Unable to update dependencies:") + "\n" + remaps[i] + "\n");


### PR DESCRIPTION
Fixes #69260

The issue is odd. I could reproduce it in MRP, but not in any other project. Then I discovered that the dependency is renamed correctly, but for whatever reason the scene is reloaded too early and it fails to get the resource (maybe rename triggers some cache invalidation idk). It happens despite `rename_dependencies()` returning OK, which I assume should finish only when the scene is ready to be reloaded. Also I don't know why would it break only in the MRP, maybe it depends on the size of the project.

Anyway, when something happens too early, the solution is always putting a random `call_deferred()` somewhere ¯\\\_( •\_•)\_/¯