### PR TITLE
Clean up DisplayServerAndroid::window_get_native_handle() with the GLES3 renderer

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1715,6 +1715,7 @@
 		<constant name="DISPLAY_HANDLE" value="0" enum="HandleType">
 			Display handle:
 			- Linux (X11): [code]X11::Display*[/code] for the display.
+			- Android: [code]EGLDisplay[/code] for the display.
 		</constant>
 		<constant name="WINDOW_HANDLE" value="1" enum="HandleType">
 			Window handle:

--- a/modules/openxr/extensions/openxr_opengl_extension.cpp
+++ b/modules/openxr/extensions/openxr_opengl_extension.cpp
@@ -136,7 +136,7 @@ void *OpenXROpenGLExtension::set_session_create_and_get_next_pointer(void *p_nex
 	graphics_binding_gl.type = XR_TYPE_GRAPHICS_BINDING_OPENGL_ES_ANDROID_KHR;
 	graphics_binding_gl.next = p_next_pointer;
 
-	graphics_binding_gl.display = eglGetCurrentDisplay();
+	graphics_binding_gl.display = (void *)display_server->window_get_native_handle(DisplayServer::DISPLAY_HANDLE);
 	graphics_binding_gl.config = (EGLConfig)0; // https://github.com/KhronosGroup/OpenXR-SDK-Source/blob/master/src/tests/hello_xr/graphicsplugin_opengles.cpp#L122
 	graphics_binding_gl.context = (void *)display_server->window_get_native_handle(DisplayServer::OPENGL_CONTEXT);
 #else

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -316,9 +316,6 @@ DisplayServer::WindowID DisplayServerAndroid::get_window_at_screen_position(cons
 int64_t DisplayServerAndroid::window_get_native_handle(HandleType p_handle_type, WindowID p_window) const {
 	ERR_FAIL_COND_V(p_window != MAIN_WINDOW_ID, 0);
 	switch (p_handle_type) {
-		case DISPLAY_HANDLE: {
-			return 0; // Not supported.
-		}
 		case WINDOW_HANDLE: {
 			return reinterpret_cast<int64_t>(static_cast<OS_Android *>(OS::get_singleton())->get_godot_java()->get_activity());
 		}
@@ -326,8 +323,17 @@ int64_t DisplayServerAndroid::window_get_native_handle(HandleType p_handle_type,
 			return 0; // Not supported.
 		}
 #ifdef GLES3_ENABLED
+		case DISPLAY_HANDLE: {
+			if (rendering_driver == "opengl3") {
+				return reinterpret_cast<int64_t>(eglGetCurrentDisplay());
+			}
+			return 0;
+		}
 		case OPENGL_CONTEXT: {
-			return reinterpret_cast<int64_t>(eglGetCurrentContext());
+			if (rendering_driver == "opengl3") {
+				return reinterpret_cast<int64_t>(eglGetCurrentContext());
+			}
+			return 0;
 		}
 #endif
 		default: {


### PR DESCRIPTION
This is a small cleanup for `DisplayServer::window_get_native_handle()` on Android.

This is a bug, because without these changes, calling `window_get_native_handle(DisplayServer::OPENGL_CONTEXT)` will do something unpredictable if we're using Vulkan, and `window_get_native_handle(DisplayServer::DISPLAY_HANDLE)` will always return 0.

This also updates openxr_opengl_extension.cpp to use this to get the EGLDisplay, rather than interacting with EGL directly.
