### PR TITLE
[TextMesh] Fix autotranslate.

### DIFF
--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -322,6 +322,11 @@ void MeshInstance3D::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			_resolve_skeleton_path();
 		} break;
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			if (mesh.is_valid()) {
+				mesh->notification(NOTIFICATION_TRANSLATION_CHANGED);
+			}
+		} break;
 	}
 }
 


### PR DESCRIPTION
Fixes `TextMesh` not receiving locale change notification (propagate it for `MeshInstance3D`).