### PR TITLE
Fix constants scope in extended or inner GDScript classes

### DIFF
--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -50,6 +50,8 @@ class GDScriptAnalyzer {
 	Error check_native_member_name_conflict(const StringName &p_member_name, const GDScriptParser::Node *p_member_node, const StringName &p_native_type_string);
 	Error check_class_member_name_conflict(const GDScriptParser::ClassNode *p_class_node, const StringName &p_member_name, const GDScriptParser::Node *p_member_node);
 
+	void get_class_node_current_scope_classes(GDScriptParser::ClassNode *p_node, List<GDScriptParser::ClassNode *> *p_list);
+
 	Error resolve_inheritance(GDScriptParser::ClassNode *p_class, bool p_recursive = true);
 	GDScriptParser::DataType resolve_datatype(GDScriptParser::TypeNode *p_type);
 

--- a/modules/gdscript/tests/scripts/analyzer/features/base_outer_resolution.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/base_outer_resolution.gd
@@ -1,0 +1,14 @@
+const A: = preload("base_outer_resolution_a.notest.gd")
+const B: = preload("base_outer_resolution_b.notest.gd")
+const C: = preload("base_outer_resolution_c.notest.gd")
+
+const Extend: = preload("base_outer_resolution_extend.notest.gd")
+
+func test() -> void:
+	Extend.test_a(A.new())
+	Extend.test_b(B.new())
+	Extend.InnerClass.test_c(C.new())
+	Extend.InnerClass.InnerInnerClass.test_a_b_c(A.new(), B.new(), C.new())
+	Extend.InnerClass.InnerInnerClass.test_enum(C.TestEnum.HELLO_WORLD)
+	Extend.InnerClass.InnerInnerClass.test_a_prime(A.APrime.new())
+

--- a/modules/gdscript/tests/scripts/analyzer/features/base_outer_resolution.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/base_outer_resolution.out
@@ -1,0 +1,7 @@
+GDTEST_OK
+true
+true
+true
+true
+true
+true

--- a/modules/gdscript/tests/scripts/analyzer/features/base_outer_resolution_a.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/base_outer_resolution_a.notest.gd
@@ -1,0 +1,2 @@
+class APrime:
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/features/base_outer_resolution_base.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/base_outer_resolution_base.notest.gd
@@ -1,0 +1,4 @@
+const A: = preload("base_outer_resolution_a.notest.gd")
+
+class InnerClassInBase:
+	const C: = preload("base_outer_resolution_c.notest.gd")

--- a/modules/gdscript/tests/scripts/analyzer/features/base_outer_resolution_c.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/base_outer_resolution_c.notest.gd
@@ -1,0 +1,3 @@
+enum TestEnum {
+	HELLO_WORLD
+}

--- a/modules/gdscript/tests/scripts/analyzer/features/base_outer_resolution_extend.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/base_outer_resolution_extend.notest.gd
@@ -1,0 +1,23 @@
+extends "base_outer_resolution_base.notest.gd"
+
+const B: = preload("base_outer_resolution_b.notest.gd")
+
+static func test_a(a: A) -> void:
+	print(a is A)
+
+static func test_b(b: B) -> void:
+	print(b is B)
+
+class InnerClass extends InnerClassInBase:
+	static func test_c(c: C) -> void:
+		print(c is C)
+
+	class InnerInnerClass:
+		static func test_a_b_c(a: A, b: B, c: C) -> void:
+			print(a is A and b is B and c is C)
+
+		static func test_enum(test_enum: C.TestEnum) -> void:
+			print(test_enum == C.TestEnum.HELLO_WORLD)
+
+		static func test_a_prime(a_prime: A.APrime) -> void:
+			print(a_prime is A.APrime)


### PR DESCRIPTION
**~~This PR depends on #69865~~ Merged, thanks**

Especially when checking the typing, the gdscript parser doesn't seem to pass through the code to set the right `script_class->outer` value for a given `GDScriptParser::ClassNode`. It is available though inside `script_class->base_type.class_type` in `GDScriptAnalyzer::resolve_datatype()`.

~~So this PR uses `script_class->base_type.class_type` if the `script_class->outer` is a `nullptr`.~~

Edit: I updated the logic! It now checks for outer classes and their extended classes, without the need of adding one more loop. I prioritized the outer classes first, as this was the logic as for now.

This code now works:

```gdscript
# `base.gd` declares `A`
extends "base.gd"

const OuterDeclared: = "OuterDeclared"

static func test(a: A) -> void:
	print(A)  # prints <GDScript #...>

# `base_inner.gd` declares `B`
class InnerBaseClass extends "base_inner.gd":
	static func test_a(a: A) -> void:
		print(OuterDeclared)  # prints "OuterDeclared"
		print(A)  # prints <GDScript #...>

	static func test_b(b: B) -> void:
		print(B)  # prints <GDScript #...>
```

It makes the constants of base class available as typing inside the extended classes.

Fixes #69586