### PR TITLE
Fix AnimationPlayer play backward doesn't process just current key & AnimationPlaybackTrack seeking for preview

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -216,8 +216,8 @@ void AnimationPlayerEditor::_play_from_pressed() {
 			player->stop(); //so it won't blend with itself
 		}
 		ERR_FAIL_COND_EDMSG(!_validate_tracks(player->get_animation(current)), "Animation tracks may have any invalid key, abort playing.");
-		player->play(current);
 		player->seek(time);
+		player->play(current);
 	}
 
 	//unstop
@@ -254,8 +254,8 @@ void AnimationPlayerEditor::_play_bw_from_pressed() {
 			player->stop(); //so it won't blend with itself
 		}
 		ERR_FAIL_COND_EDMSG(!_validate_tracks(player->get_animation(current)), "Animation tracks may have any invalid key, abort playing.");
-		player->play(current, -1, -1, true);
 		player->seek(time);
+		player->play(current, -1, -1, true);
 	}
 
 	//unstop

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -955,7 +955,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double
 							break;
 					}
 
-					if (player->is_playing() || p_seeked) {
+					if (player->is_playing()) {
 						player->play(anim_name);
 						player->seek(at_anim_pos);
 						nc->animation_playing = true;


### PR DESCRIPTION
To process the key at the moment of playback, it must be seeked prior to playback. Follow up #69336. 
Also, Sub-AnimationPlayer should not play when seeking while stopped. Follow up #69357. 