### PR TITLE
[Linux/BSD] Fix build without fontconfig.

### DIFF
--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -616,6 +616,7 @@ Vector<String> OS_LinuxBSD::get_system_fonts() const {
 #endif
 }
 
+#ifdef FONTCONFIG_ENABLED
 int OS_LinuxBSD::_weight_to_fc(int p_weight) const {
 	if (p_weight < 150) {
 		return FC_WEIGHT_THIN;
@@ -665,6 +666,7 @@ int OS_LinuxBSD::_stretch_to_fc(int p_stretch) const {
 		return FC_WIDTH_ULTRAEXPANDED;
 	}
 }
+#endif // FONTCONFIG_ENABLED
 
 Vector<String> OS_LinuxBSD::get_system_font_path_for_text(const String &p_font_name, const String &p_text, const String &p_locale, const String &p_script, int p_weight, int p_stretch, bool p_italic) const {
 #ifdef FONTCONFIG_ENABLED

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -51,6 +51,9 @@ class OS_LinuxBSD : public OS_Unix {
 	bool font_config_initialized = false;
 	FcConfig *config = nullptr;
 	FcObjectSet *object_set = nullptr;
+
+	int _weight_to_fc(int p_weight) const;
+	int _stretch_to_fc(int p_stretch) const;
 #endif
 
 #ifdef JOYDEV_ENABLED
@@ -72,9 +75,6 @@ class OS_LinuxBSD : public OS_Unix {
 	CrashHandler crash_handler;
 
 	MainLoop *main_loop = nullptr;
-
-	int _weight_to_fc(int p_weight) const;
-	int _stretch_to_fc(int p_stretch) const;
 
 	String get_systemd_os_release_info_value(const String &key) const;
 


### PR DESCRIPTION
Adds missing `ifdef` from https://github.com/godotengine/godot/pull/68995