### PR TITLE
Calculate the mouse focus inverse transform only when needed

### DIFF
--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -374,7 +374,6 @@ private:
 		ObjectID drag_preview_id;
 		Ref<SceneTreeTimer> tooltip_timer;
 		double tooltip_delay = 0.0;
-		Transform2D focus_inv_xform;
 		bool roots_order_dirty = false;
 		List<Control *> roots;
 		int canvas_sort_index = 0; //for sorting items with canvas as root
@@ -403,7 +402,7 @@ private:
 	void _gui_call_notification(Control *p_control, int p_what);
 
 	void _gui_sort_roots();
-	Control *_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_global, const Transform2D &p_xform, Transform2D &r_inv_xform);
+	Control *_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_global, const Transform2D &p_xform);
 
 	void _gui_input_event(Ref<InputEvent> p_event);
 	void _perform_drop(Control *p_control = nullptr, Point2 p_pos = Point2());


### PR DESCRIPTION
Revival of #49158
Supersedes #49158
fix #69593
Co-authored-by: Marcel Admiraal <madmiraal@users.noreply.github.com>

madmiraal did the heavy lifting, I just fixed merge conflicts.

Orignal description:

Currently, `gui.focus_inv_xform` is used to determine the location of an event within a `Control`. `Viewport::_gui_find_control()` has the side-effect of updating `gui.focus_inv_xform`. This would be fine `if _gui_find_control()` was just used to assign `gui.mouse_focus`, but it's not. The result is, when a mouse button release event happens, sometimes `gui.focus_inv_xform` does not provide the location of the event inside the Control where the mouse button press event happened.

Instead of calculating the `mouse_focus`'s `Control`'s inverse transform every time `_gui_find_control()` is called and storing the result for later use, this PR calculates the required inverse transform only when it is needed. This will not only prevent the wrong inverse transform sometimes being used, but should result in better performance too.

Edited 2023-01-09: Fix merge conflict