### PR TITLE
Keep GDScriptAnalyzer alive for whole parse()

### DIFF
--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -844,8 +844,9 @@ Error ExtendGDScriptParser::parse(const String &p_code, const String &p_path) {
 	lines = p_code.split("\n");
 
 	Error err = GDScriptParser::parse(p_code, p_path, false);
+	GDScriptAnalyzer analyzer(this);
+
 	if (err == OK) {
-		GDScriptAnalyzer analyzer(this);
 		err = analyzer.analyze();
 	}
 	update_diagnostics();


### PR DESCRIPTION
Analyzed data is allocated by Parser but kept as a reference in the cache which in turn is held by the Analyzer. If Analyzer goes away Parser is left with a tree of dangling references.

Code is analogous to all other usages of Analyzer + Parser pair.

Fixes #68049.