### PR TITLE
Allow release templates to store more enum info in ClassDB

### DIFF
--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -412,7 +412,7 @@ _FORCE_INLINE_ Vector<Error> errarray(P... p_args) {
 	::ClassDB::bind_integer_constant(get_class_static(), StringName(), #m_constant, m_constant);
 
 #define BIND_ENUM_CONSTANT(m_constant) \
-	::ClassDB::bind_integer_constant(get_class_static(), StringName(), #m_constant, m_constant);
+	::ClassDB::bind_integer_constant(get_class_static(), __constant_get_enum_name(m_constant, #m_constant), #m_constant, m_constant);
 
 #define BIND_BITFIELD_FLAG(m_constant) \
 	::ClassDB::bind_integer_constant(get_class_static(), StringName(), #m_constant, m_constant, true);


### PR DESCRIPTION
Fixes #69532.

This feels like a pretty big change but maybe isn't that big?

It essentially makes release builds contain as much native enum information as debug builds: specifically, it makes it so `ClassDB` keeps track of native `enum` names, not just its values. This brings it in line with debug & tool exports.

As per the linked issue, it allows release exports to run the following code:

```GDScript
func navigate(direction: TileSet.CellNeighbor): # This fails in exports as enum names are not recognized.
  pass

func _ready():
  navigate(TileSet.CELL_NEIGHBOR_LEFT_SIDE)
```

I'd argue that if GDScript typing is meant to be relatively comprehensive and useful, it feels important for enum types to be recognized at runtime.

### Possible alternatives
We could do static validation, e.g. in editor. When exporting, we could alter GDScript files so that every datatype which evaluates to `enum` gets automatically converted to `int`. But that's another layer for errors to show up in, and the exported code will be different than editor code, which might cause issues for people down the line.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
