### PR TITLE
Ability to change a resource UID from API

### DIFF
--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -170,6 +170,7 @@ public:
 		RESERVED_FIELDS = 11
 	};
 	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	Error set_uid(const String &p_path, ResourceUID::ID p_uid);
 	static void write_variant(Ref<FileAccess> f, const Variant &p_property, HashMap<Ref<Resource>, int> &resource_map, HashMap<Ref<Resource>, int> &external_resources, HashMap<StringName, int> &string_map, const PropertyInfo &p_hint = PropertyInfo());
 };
 
@@ -177,6 +178,7 @@ class ResourceFormatSaverBinary : public ResourceFormatSaver {
 public:
 	static ResourceFormatSaverBinary *singleton;
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
+	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -31,6 +31,7 @@
 #include "resource_importer.h"
 
 #include "core/config/project_settings.h"
+#include "core/io/config_file.h"
 #include "core/os/os.h"
 #include "core/variant/variant_parser.h"
 
@@ -483,4 +484,19 @@ void ResourceFormatImporter::add_importer(const Ref<ResourceImporter> &p_importe
 	} else {
 		importers.push_back(p_importer);
 	}
+}
+
+/////
+
+Error ResourceFormatImporterSaver::set_uid(const String &p_path, ResourceUID::ID p_uid) {
+	Ref<ConfigFile> cf;
+	cf.instantiate();
+	Error err = cf->load(p_path + ".import");
+	if (err != OK) {
+		return err;
+	}
+	cf->set_value("remap", "uid", ResourceUID::get_singleton()->id_to_text(p_uid));
+	cf->save(p_path + ".import");
+
+	return OK;
 }

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -32,6 +32,7 @@
 #define RESOURCE_IMPORTER_H
 
 #include "core/io/resource_loader.h"
+#include "core/io/resource_saver.h"
 
 class ResourceImporter;
 
@@ -148,5 +149,12 @@ public:
 };
 
 VARIANT_ENUM_CAST(ResourceImporter::ImportOrder);
+
+class ResourceFormatImporterSaver : public ResourceFormatSaver {
+	GDCLASS(ResourceFormatImporterSaver, ResourceFormatSaver)
+
+public:
+	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;
+};
 
 #endif // RESOURCE_IMPORTER_H

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -47,6 +47,12 @@ Error ResourceFormatSaver::save(const Ref<Resource> &p_resource, const String &p
 	return (Error)res;
 }
 
+Error ResourceFormatSaver::set_uid(const String &p_path, ResourceUID::ID p_uid) {
+	Error err = ERR_FILE_UNRECOGNIZED;
+	GDVIRTUAL_CALL(_set_uid, p_path, p_uid, err);
+	return err;
+}
+
 bool ResourceFormatSaver::recognize(const Ref<Resource> &p_resource) const {
 	bool success = false;
 	GDVIRTUAL_CALL(_recognize, p_resource, success);
@@ -85,6 +91,7 @@ bool ResourceFormatSaver::recognize_path(const Ref<Resource> &p_resource, const 
 
 void ResourceFormatSaver::_bind_methods() {
 	GDVIRTUAL_BIND(_save, "resource", "path", "flags");
+	GDVIRTUAL_BIND(_set_uid, "path", "uid");
 	GDVIRTUAL_BIND(_recognize, "resource");
 	GDVIRTUAL_BIND(_get_recognized_extensions, "resource");
 	GDVIRTUAL_BIND(_recognize_path, "resource", "path");
@@ -140,6 +147,23 @@ Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path,
 			}
 
 			return OK;
+		}
+	}
+
+	return err;
+}
+
+Error ResourceSaver::set_uid(const String &p_path, ResourceUID::ID p_uid) {
+	String path = p_path;
+
+	ERR_FAIL_COND_V_MSG(path.is_empty(), ERR_INVALID_PARAMETER, "Can't update UID to empty path. Provide non-empty path.");
+
+	Error err = ERR_FILE_UNRECOGNIZED;
+
+	for (int i = 0; i < saver_count; i++) {
+		err = saver[i]->set_uid(path, p_uid);
+		if (err == OK) {
+			break;
 		}
 	}
 

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -42,12 +42,14 @@ protected:
 	static void _bind_methods();
 
 	GDVIRTUAL3R(int64_t, _save, Ref<Resource>, String, uint32_t)
+	GDVIRTUAL2R(Error, _set_uid, String, ResourceUID::ID)
 	GDVIRTUAL1RC(bool, _recognize, Ref<Resource>)
 	GDVIRTUAL1RC(Vector<String>, _get_recognized_extensions, Ref<Resource>)
 	GDVIRTUAL2RC(bool, _recognize_path, Ref<Resource>, String)
 
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
+	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 	virtual bool recognize_path(const Ref<Resource> &p_resource, const String &p_path) const;
@@ -87,6 +89,8 @@ public:
 	static void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions);
 	static void add_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver, bool p_at_front = false);
 	static void remove_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver);
+
+	static Error set_uid(const String &p_path, ResourceUID::ID p_uid);
 
 	static void set_timestamp_on_save(bool p_timestamp) { timestamp_on_save = p_timestamp; }
 	static bool get_timestamp_on_save() { return timestamp_on_save; }

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -84,6 +84,7 @@
 static Ref<ResourceFormatSaverBinary> resource_saver_binary;
 static Ref<ResourceFormatLoaderBinary> resource_loader_binary;
 static Ref<ResourceFormatImporter> resource_format_importer;
+static Ref<ResourceFormatImporterSaver> resource_format_importer_saver;
 static Ref<ResourceFormatLoaderImage> resource_format_image;
 static Ref<TranslationLoaderPO> resource_format_po;
 static Ref<ResourceFormatSaverCrypto> resource_format_saver_crypto;
@@ -143,6 +144,9 @@ void register_core_types() {
 
 	resource_format_importer.instantiate();
 	ResourceLoader::add_resource_format_loader(resource_format_importer);
+
+	resource_format_importer_saver.instantiate();
+	ResourceSaver::add_resource_format_saver(resource_format_importer_saver);
 
 	resource_format_image.instantiate();
 	ResourceLoader::add_resource_format_loader(resource_format_image);
@@ -388,6 +392,9 @@ void unregister_core_types() {
 
 	ResourceLoader::remove_resource_format_loader(resource_format_importer);
 	resource_format_importer.unref();
+
+	ResourceSaver::remove_resource_format_saver(resource_format_importer_saver);
+	resource_format_importer_saver.unref();
 
 	ResourceLoader::remove_resource_format_loader(resource_format_po);
 	resource_format_po.unref();

--- a/doc/classes/ResourceFormatSaver.xml
+++ b/doc/classes/ResourceFormatSaver.xml
@@ -43,5 +43,13 @@
 				Returns [constant OK] on success, or an [enum Error] constant in case of failure.
 			</description>
 		</method>
+		<method name="_set_uid" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="uid" type="int" />
+			<description>
+				Sets a new UID for the resource at the given [param path]. Returns [constant OK] on success, or an [enum Error] constant in case of failure.
+			</description>
+		</method>
 	</methods>
 </class>

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -433,7 +433,7 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 	}
 
 	if (!found_uid) {
-		return true; //UUID not found, old format, reimport.
+		return true; //UID not found, old format, reimport.
 	}
 
 	Ref<ResourceImporter> importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(importer_name);
@@ -868,7 +868,7 @@ void EditorFileSystem::_scan_new_dir(EditorFileSystemDirectory *p_dir, Ref<DirAc
 				}
 
 				if (fc->uid == ResourceUID::INVALID_ID) {
-					// imported files should always have a UUID, so attempt to fetch it.
+					// imported files should always have a UID, so attempt to fetch it.
 					fi->uid = ResourceLoader::get_resource_uid(path);
 				}
 
@@ -2319,14 +2319,14 @@ ResourceUID::ID EditorFileSystem::_resource_saver_get_resource_id_for_path(const
 		}
 
 		if (p_generate) {
-			return ResourceUID::get_singleton()->create_id(); // Just create a new one, we will be notified of save anyway and fetch the right UUID at that time, to keep things simple.
+			return ResourceUID::get_singleton()->create_id(); // Just create a new one, we will be notified of save anyway and fetch the right UID at that time, to keep things simple.
 		} else {
 			return ResourceUID::INVALID_ID;
 		}
 	} else if (fs->files[cpos]->uid != ResourceUID::INVALID_ID) {
 		return fs->files[cpos]->uid;
 	} else if (p_generate) {
-		return ResourceUID::get_singleton()->create_id(); // Just create a new one, we will be notified of save anyway and fetch the right UUID at that time, to keep things simple.
+		return ResourceUID::get_singleton()->create_id(); // Just create a new one, we will be notified of save anyway and fetch the right UID at that time, to keep things simple.
 	} else {
 		return ResourceUID::INVALID_ID;
 	}

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -106,6 +106,7 @@ class ResourceLoaderText {
 	VariantParser::ResourceParser rp;
 
 	friend class ResourceFormatLoaderText;
+	friend class ResourceFormatSaverText;
 
 	Error error = OK;
 
@@ -117,6 +118,7 @@ public:
 	void set_local_path(const String &p_local_path);
 	Ref<Resource> get_resource();
 	Error load();
+	Error set_uid(Ref<FileAccess> p_f, ResourceUID::ID p_uid);
 	int get_stage() const;
 	int get_stage_count() const;
 	void set_translation_remapped(bool p_remapped);
@@ -195,6 +197,7 @@ class ResourceFormatSaverText : public ResourceFormatSaver {
 public:
 	static ResourceFormatSaverText *singleton;
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
+	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 


### PR DESCRIPTION
* Works for text, binary and imported resources
* Allows better clean up of duplicate files.

TODO (future PRs):

* Use this API for assigning new UIDs to copied files in FS dock instead of current (kind of hackish) code.
* Use this API for UID conflict on FS scanning (if more than one file has the same UID, the newer one(s) should get assigned a different UID).

This API can be used together with:
```c++
ResourceUID::get_singleton()->create_id()
// To assign new UID to a file:
ResourceSaver::set_uid( "<filepath>", ResourceUID::get_singleton()->create_id() );
```
to assign new Unique IDs to files.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
