### PR TITLE
Fix fringe issues with shortcuts not behaving as expected for multi-carets

### DIFF
--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -769,7 +769,7 @@ void FindInFilesPanel::draw_result_text(Object *item_obj, Rect2 rect) {
 
 	Rect2 match_rect = rect;
 	match_rect.position.x += font->get_string_size(item_text.left(r.begin_trimmed), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x - 1;
-	match_rect.size.x = font->get_string_size(_search_text_label->get_text(), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x + 2;
+	match_rect.size.x = font->get_string_size(_search_text_label->get_text(), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x + 1;
 	match_rect.position.y += 1 * EDSCALE;
 	match_rect.size.y -= 2 * EDSCALE;
 

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -353,7 +353,9 @@ void TextEditor::_edit_option(int p_op) {
 			code_editor->duplicate_selection();
 		} break;
 		case EDIT_TOGGLE_FOLD_LINE: {
-			tx->toggle_foldable_line(tx->get_caret_line());
+			for (int caret_idx = 0; caret_idx < tx->get_caret_count(); caret_idx++) {
+				tx->toggle_foldable_line(tx->get_caret_line(caret_idx));
+			}
 			tx->queue_redraw();
 		} break;
 		case EDIT_FOLD_ALL_LINES: {


### PR DESCRIPTION
It's smaller than it looks.

* Fixes Ctrl + Period/Comma (Breakpoint traversing) not deselecting text (same code as #68759)
* Fixes F9 (Toggle breakpoint) not working with multiple carets
* Fixes Alt+F (Toggle folding) not working with multiple carets
* Fixes Ctrl+Shift+E (Evaluate selection) misbehaving with multiple selections.

Also sneaks in a commit to shrink this rectangle's width by a pixel:

![Screenshot from 2022-12-05 13-49-35](https://user-images.githubusercontent.com/85438892/205710728-a98eef16-446f-4013-a545-ebb5e96e2504.png)