### PR TITLE
Fix that mouse-button-up event is parsed twice for drag-and-drop

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -3947,7 +3947,6 @@ void DisplayServerX11::process_events() {
 									mb->set_window_id(window_id_other);
 									mb->set_position(Vector2(x, y));
 									mb->set_global_position(mb->get_position());
-									Input::get_singleton()->parse_input_event(mb);
 								}
 								break;
 							}


### PR DESCRIPTION
Currently `Input::get_singleton()->parse_input_event(mb);` is called twice for mouse-button-up events when dropping in a different window on linuxbsd.
I would expect, that an event is parsed only once.

This PR removes the first location where this happens. The second location, which is also used for mouse-button-down events appears a few lines later:
https://github.com/godotengine/godot/blob/f3e6750a7e4702918e05f42b1376e30e652f2f90/platform/linuxbsd/x11/display_server_x11.cpp#L3958