### PR TITLE
Address Android editor crashes

### DIFF
--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -189,6 +189,7 @@ Ref<TriangleMesh> Mesh::generate_triangle_mesh() const {
 			if (primitive == PRIMITIVE_TRIANGLES) {
 				for (int j = 0; j < ic; j++) {
 					int index = ir[j];
+					ERR_FAIL_COND_V(index >= vc, Ref<TriangleMesh>());
 					facesw[widx++] = vr[index];
 				}
 			} else { // PRIMITIVE_TRIANGLE_STRIP


### PR DESCRIPTION
Add workaround for crash when resuming existing project

The crash occurs when trying to open existing vulkan mobile projects on the Godot Android editor, and seems to be caused by a mismatch between the supposed size of the `ARRAY_INDEX` and its actual size. 
The change in this PR is a workaround which allows to open the project successfully, but the underlying should be addressed.

Attached is a minimal repro project

[HelloGodotVulkan.zip](https://github.com/godotengine/godot/files/10156944/HelloGodotVulkan.zip)

To repro:
1. Build a dev version of the Android editor from the `master` branch and install it on an Android device.
2. Unzip the repro project, and push it to the Android device
3. Open the repro project on the Android device using the installed Android editor
4. Without the change in this draft PR, the editor crashes. With the change, you should see in logcat several errors. 

Fixes https://github.com/godotengine/godot/issues/70758

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
