### PR TITLE
Add `type_string()` utility

### DIFF
--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -875,6 +875,11 @@ String VariantUtilityFunctions::error_string(Error error) {
 	return String(error_names[error]);
 }
 
+String VariantUtilityFunctions::type_string(Variant::Type p_type) {
+	ERR_FAIL_INDEX_V_MSG((int)p_type, (int)Variant::VARIANT_MAX, "<invalid type>", "Invalid type argument to type_string(), use the TYPE_* constants.");
+	return Variant::get_type_name(p_type);
+}
+
 void VariantUtilityFunctions::print(const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
 	String s;
 	for (int i = 0; i < p_arg_count; i++) {
@@ -1713,6 +1718,7 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(type_convert, sarray("variant", "type"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGS(str, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDR(error_string, sarray("error"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(type_string, sarray("type"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(print, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(print_rich, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(printerr, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -130,6 +130,7 @@ struct VariantUtilityFunctions {
 	static Variant type_convert(const Variant &p_variant, const Variant::Type p_type);
 	static String str(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
 	static String error_string(Error error);
+	static String type_string(Variant::Type p_type);
 	static void print(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
 	static void print_rich(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
 #undef print_verbose

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1403,6 +1403,19 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="type_string">
+			<return type="String" />
+			<param index="0" name="type" type="int" />
+			<description>
+				Returns a human-readable name of the given [param type], using the [enum Variant.Type] values.
+				[codeblock]
+				print(TYPE_INT) # Prints 2.
+				print(type_string(TYPE_INT)) # Prints "int".
+				print(type_string(TYPE_STRING)) # Prints "String".
+				[/codeblock]
+				See also [method typeof].
+			</description>
+		</method>
 		<method name="typeof">
 			<return type="int" />
 			<param index="0" name="variable" type="Variant" />
@@ -1417,6 +1430,7 @@
 				else:
 				    print("Unexpected result")
 				[/codeblock]
+				See also [method type_string].
 			</description>
 		</method>
 		<method name="var_to_bytes">

--- a/modules/gdscript/tests/scripts/utils.notest.gd
+++ b/modules/gdscript/tests/scripts/utils.notest.gd
@@ -17,7 +17,7 @@ static func get_type(property: Dictionary, is_return: bool = false) -> String:
 		TYPE_OBJECT:
 			if not str(property.class_name).is_empty():
 				return property.class_name
-	return variant_get_type_name(property.type)
+	return type_string(property.type)
 
 
 static func get_property_signature(property: Dictionary, is_static: bool = false) -> String:
@@ -64,88 +64,6 @@ static func get_method_signature(method: Dictionary, is_signal: bool = false) ->
 	else:
 		result += " -> " + get_type(method.return, true)
 	return result
-
-
-static func variant_get_type_name(type: Variant.Type) -> String:
-	match type:
-		TYPE_NIL:
-			return "Nil" # `Nil` in core, `null` in GDScript.
-		TYPE_BOOL:
-			return "bool"
-		TYPE_INT:
-			return "int"
-		TYPE_FLOAT:
-			return "float"
-		TYPE_STRING:
-			return "String"
-		TYPE_VECTOR2:
-			return "Vector2"
-		TYPE_VECTOR2I:
-			return "Vector2i"
-		TYPE_RECT2:
-			return "Rect2"
-		TYPE_RECT2I:
-			return "Rect2i"
-		TYPE_VECTOR3:
-			return "Vector3"
-		TYPE_VECTOR3I:
-			return "Vector3i"
-		TYPE_TRANSFORM2D:
-			return "Transform2D"
-		TYPE_VECTOR4:
-			return "Vector4"
-		TYPE_VECTOR4I:
-			return "Vector4i"
-		TYPE_PLANE:
-			return "Plane"
-		TYPE_QUATERNION:
-			return "Quaternion"
-		TYPE_AABB:
-			return "AABB"
-		TYPE_BASIS:
-			return "Basis"
-		TYPE_TRANSFORM3D:
-			return "Transform3D"
-		TYPE_PROJECTION:
-			return "Projection"
-		TYPE_COLOR:
-			return "Color"
-		TYPE_STRING_NAME:
-			return "StringName"
-		TYPE_NODE_PATH:
-			return "NodePath"
-		TYPE_RID:
-			return "RID"
-		TYPE_OBJECT:
-			return "Object"
-		TYPE_CALLABLE:
-			return "Callable"
-		TYPE_SIGNAL:
-			return "Signal"
-		TYPE_DICTIONARY:
-			return "Dictionary"
-		TYPE_ARRAY:
-			return "Array"
-		TYPE_PACKED_BYTE_ARRAY:
-			return "PackedByteArray"
-		TYPE_PACKED_INT32_ARRAY:
-			return "PackedInt32Array"
-		TYPE_PACKED_INT64_ARRAY:
-			return "PackedInt64Array"
-		TYPE_PACKED_FLOAT32_ARRAY:
-			return "PackedFloat32Array"
-		TYPE_PACKED_FLOAT64_ARRAY:
-			return "PackedFloat64Array"
-		TYPE_PACKED_STRING_ARRAY:
-			return "PackedStringArray"
-		TYPE_PACKED_VECTOR2_ARRAY:
-			return "PackedVector2Array"
-		TYPE_PACKED_VECTOR3_ARRAY:
-			return "PackedVector3Array"
-		TYPE_PACKED_COLOR_ARRAY:
-			return "PackedColorArray"
-	push_error("Argument `type` is invalid. Use `TYPE_*` constants.")
-	return "<invalid type>"
 
 
 static func get_property_hint_name(hint: PropertyHint) -> String:


### PR DESCRIPTION
Closes [#1860](https://github.com/godotengine/godot-proposals/issues/1860)

Adds `typeof_string()` method, using `Variant::get_type_name()` effectively just exposing this method to GDScript.

This method goes hand in hand with the already implemented `error_string()` utility. Both of these methods are extremely useful for plugin development where user interaction is expected.

The proposal describes a method that prints the name of the variable directly without the `typeof()` step between. But I believe that this makes this function more versatile and a method like that can be simply made like this:
```gdscript
func typeofname(x):
    return type_string(typeof(x))
```
