### PR TITLE
Fix lost input events with popups and multiple windows on linuxbsd

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -315,7 +315,7 @@ protected:
 	void _window_changed(XEvent *event);
 
 public:
-	bool mouse_process_popups();
+	bool mouse_process_popups(WindowID p_window);
 	void popup_open(WindowID p_window);
 	void popup_close(WindowID p_window);
 


### PR DESCRIPTION
fix linuxbsd variant of #66016

In the following setting
- Root Window (don't embed windows)
  - Popup
  - Secondary Window

Mouse-Button-Down events in the Secondary Window were lost, because they were used for trying to close the Popup.

This PR makes `DisplayServerX11::mouse_process_popups` aware of multiple windows and tries to close them only if no other window was targeted.

Please review with care, because I am touching areas, I am not familiar with.