### PR TITLE
Fix crash on old glTF scene reimport 

### DIFF
--- a/modules/gltf/editor/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor/editor_scene_importer_gltf.cpp
@@ -63,7 +63,12 @@ Node *EditorSceneFormatImporterGLTF::import_scene(const String &p_path, uint32_t
 	if (p_options.has("animation/import")) {
 		state->set_create_animations(bool(p_options["animation/import"]));
 	}
-	return doc->generate_scene(state, (float)p_options["animation/fps"], (bool)p_options["animation/trimming"]);
+
+	if (p_options.has("animation/trimming")) {
+		return doc->generate_scene(state, (float)p_options["animation/fps"], (bool)p_options["animation/trimming"]);
+	} else {
+		return doc->generate_scene(state, (float)p_options["animation/fps"], false);
+	}
 }
 
 #endif // TOOLS_ENABLED


### PR DESCRIPTION
Fix for #69625. modules/gltf/editor/editor_scene_importer_gltf.cpp:66 tries to access nonexistent "animation/trimming" parameter from cube.glb.import. Not sure if this flag is added by default but it seems like it breaks compatibility. @TokageItLab 

*Bugsquad edit:*
- Fixes #69604
