### PR TITLE
fix conversion of csharp attributes in code blocks

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -1565,7 +1565,7 @@ def format_text_block(
         escape_post = False
 
         # Tag is a reference to a class.
-        if tag_text in state.classes:
+        if tag_text in state.classes and not inside_code:
             if tag_text == state.current_class:
                 # Don't create a link to the same class, format it as strong emphasis.
                 tag_text = f"**{tag_text}**"


### PR DESCRIPTION
Fixes the conversion of c# attributes like `[Signal]` to bold in code blocks.
Before:
![Screenshot 2022-12-05 224138](https://user-images.githubusercontent.com/48352564/205751590-8c31d2fa-5dff-4246-971d-f81596de5842.png)
After:
![Screenshot 2022-12-05 224041](https://user-images.githubusercontent.com/48352564/205751614-806d6a74-c8cd-4942-93cd-f4dccc390aa0.png)
