### PR TITLE
Fix error when right clicking proxy list in TileProxiesManagerDialog

### DIFF
--- a/editor/plugins/tiles/tile_proxies_manager_dialog.cpp
+++ b/editor/plugins/tiles/tile_proxies_manager_dialog.cpp
@@ -36,7 +36,7 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "scene/gui/separator.h"
 
-void TileProxiesManagerDialog::_right_clicked(int p_item, Vector2 p_local_mouse_pos, Object *p_item_list, MouseButton p_mouse_button_index) {
+void TileProxiesManagerDialog::_right_clicked(int p_item, Vector2 p_local_mouse_pos, MouseButton p_mouse_button_index, Object *p_item_list) {
 	if (p_mouse_button_index != MouseButton::RIGHT) {
 		return;
 	}

--- a/editor/plugins/tiles/tile_proxies_manager_dialog.h
+++ b/editor/plugins/tiles/tile_proxies_manager_dialog.h
@@ -61,7 +61,7 @@ private:
 	EditorPropertyInteger *alternative_to_property_editor = nullptr;
 
 	PopupMenu *popup_menu = nullptr;
-	void _right_clicked(int p_item, Vector2 p_local_mouse_pos, Object *p_item_list, MouseButton p_mouse_button_index);
+	void _right_clicked(int p_item, Vector2 p_local_mouse_pos, MouseButton p_mouse_button_index, Object *p_item_list);
 	void _menu_id_pressed(int p_id);
 	void _delete_selected_bindings();
 	void _update_lists();


### PR DESCRIPTION
This PR moves the additional parameter to the end of the signal parameters.

```
ERROR: Error calling from signal 'item_clicked' to callable: 'TileProxiesManagerDialog::TileProxiesManagerDialog::_right_clicked': Cannot convert argument 3 from int to Object.
   at: emit_signalp (core/object/object.cpp:1058)
```