### PR TITLE
Use internal texture name when setting texture uniform location in OpenGL renderer

### DIFF
--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -36,6 +36,11 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 
+static String _mkid(const String &p_id) {
+	String id = "m_" + p_id.replace("__", "_dus_");
+	return id.replace("__", "_dus_"); //doubleunderscore is reserved in glsl
+}
+
 void ShaderGLES3::_add_stage(const char *p_code, StageType p_stage_type) {
 	Vector<String> lines = String(p_code).split("\n");
 
@@ -425,7 +430,7 @@ void ShaderGLES3::_compile_specialization(Version::Specialization &spec, uint32_
 	}
 	// textures
 	for (int i = 0; i < p_version->texture_uniforms.size(); i++) {
-		String native_uniform_name = p_version->texture_uniforms[i];
+		String native_uniform_name = _mkid(p_version->texture_uniforms[i]);
 		GLint location = glGetUniformLocation(spec.id, (native_uniform_name).ascii().get_data());
 		glUniform1i(location, i + base_texture_index);
 	}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/69481

OpenGL requires the string passed in to obtain the uniform's location be the exact same as the string in the shader itself. In the shader compiler we use ``_mkid()`` to alter user shaders and avoid name conflicts. 

I do the rename here as everywhere else in the pipeline expects the name to be the original name as entered by the user (except the shader code that is). 

_Before:_
![Screenshot (315)](https://user-images.githubusercontent.com/16521339/205792012-3b09d76d-8342-4ec9-b5d4-a44446cb08d0.png)

_After:_

![Screenshot (316)](https://user-images.githubusercontent.com/16521339/205792014-40fc9d23-6519-42b1-b762-3ae322fc9719.png)