### PR TITLE
Clean up specialization constants in OpenGL scene renderer

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -392,10 +392,10 @@ private:
 		GeometryInstanceSurface **elements = nullptr;
 		int element_count = 0;
 		bool reverse_cull = false;
-		uint32_t spec_constant_base_flags = 0;
+		uint64_t spec_constant_base_flags = 0;
 		bool force_wireframe = false;
 
-		RenderListParameters(GeometryInstanceSurface **p_elements, int p_element_count, bool p_reverse_cull, uint32_t p_spec_constant_base_flags, bool p_force_wireframe = false) {
+		RenderListParameters(GeometryInstanceSurface **p_elements, int p_element_count, bool p_reverse_cull, uint64_t p_spec_constant_base_flags, bool p_force_wireframe = false) {
 			elements = p_elements;
 			element_count = p_element_count;
 			reverse_cull = p_reverse_cull;

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -41,8 +41,6 @@ layout(std140) uniform MaterialUniforms{ //ubo:4
 #include "canvas_uniforms_inc.glsl"
 #include "stdlib_inc.glsl"
 
-uniform sampler2D transforms_texture; //texunit:-1
-
 out vec2 uv_interp;
 out vec4 color_interp;
 out vec2 vertex_interp;

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -779,7 +779,7 @@ float get_omni_attenuation(float distance, float inv_range, float decay) {
 	nd *= nd; // nd^2
 	return nd * pow(max(distance, 0.0001), -decay);
 }
-
+#ifndef DISABLE_LIGHT_OMNI
 void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 f0, float roughness, float metallic, float shadow, vec3 albedo, inout float alpha,
 #ifdef LIGHT_BACKLIGHT_USED
 		vec3 backlight,
@@ -821,7 +821,9 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 f
 			diffuse_light,
 			specular_light);
 }
+#endif // !DISABLE_LIGHT_OMNI
 
+#ifndef DISABLE_LIGHT_SPOT
 void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 f0, float roughness, float metallic, float shadow, vec3 albedo, inout float alpha,
 #ifdef LIGHT_BACKLIGHT_USED
 		vec3 backlight,
@@ -869,6 +871,7 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 f
 #endif
 			diffuse_light, specular_light);
 }
+#endif // !DISABLE_LIGHT_SPOT
 #endif // !defined(DISABLE_LIGHT_DIRECTIONAL) || !defined(DISABLE_LIGHT_OMNI) && !defined(DISABLE_LIGHT_SPOT)
 
 #ifndef MODE_RENDER_DEPTH


### PR DESCRIPTION
Also add support for disabling omni and spot lights when not used.

This doesn't fix a bug, but it does avoid a future one. I plan to have many specialization constants in the future possible more than 32 (in 3.x we had more than 32). Since the specialization constant mask is 64 bits anyway we should use the full 64 bits here.

Also this should slightly improve performance for objects that aren't affected by omni lights and/or spot lights