### PR TITLE
Fix crash caused by missing sanity checks in CodeEdit.

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -914,6 +914,10 @@ void CodeEdit::do_unindent() {
 		int cl = get_caret_line(c);
 		const String &line = get_line(cl);
 
+		if ((cc - 1) >= line.size()) {
+			continue;
+		}
+
 		if (line[cc - 1] == '\t') {
 			remove_text(cl, cc - 1, cl, cc);
 			set_caret_column(MAX(0, cc - 1), c == 0, c);


### PR DESCRIPTION
There were missing sanity checks in CodeEdit that would cause a crash when filled with garbage data. This should fix potential overflow problems.

#68154