### PR TITLE
Implement add custom animation nodes.

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -36,6 +36,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_plugin.h"
 #include "editor/editor_undo_redo_manager.h"
+#include "editor/plugins/animation_tree_editor_plugin.h"
 #include "editor/plugins/script_editor_plugin.h"
 #include "scene/resources/packed_scene.h"
 
@@ -462,6 +463,8 @@ void EditorData::add_custom_type(const String &p_type, const String &p_inherits,
 	}
 
 	custom_types[p_inherits].push_back(ct);
+
+	AnimationTreeEditor::get_singleton()->add_custom_type(p_type, p_script);
 }
 
 Variant EditorData::instantiate_custom_type(const String &p_type, const String &p_inherits) {
@@ -515,6 +518,10 @@ void EditorData::remove_custom_type(const String &p_type) {
 	for (KeyValue<String, Vector<CustomType>> &E : custom_types) {
 		for (int i = 0; i < E.value.size(); i++) {
 			if (E.value[i].name == p_type) {
+				Ref<Script> script = E.value[i].script;
+				// process remove custom type by script;
+				AnimationTreeEditor::get_singleton()->remove_custom_type(script);
+
 				E.value.remove_at(i);
 				if (E.value.is_empty()) {
 					custom_types.erase(E.key);

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -143,6 +143,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 				menu->add_item(vformat(TTR("Add %s"), name), idx);
 				menu->set_item_metadata(idx, E);
 			}
+			add_custom_type_for_menu(menu);
 
 			Ref<AnimationNode> clipb = EditorSettings::get_singleton()->get_resource_clipboard();
 			if (clipb.is_valid()) {
@@ -345,14 +346,31 @@ void AnimationNodeBlendSpace2DEditor::_add_menu_type(int p_index) {
 	} else if (p_index == MENU_PASTE) {
 		node = EditorSettings::get_singleton()->get_resource_clipboard();
 	} else {
-		String type = menu->get_item_metadata(p_index);
+		Variant type = menu->get_item_metadata(p_index);
+		if (type.get_type() == Variant::STRING) {
+			Object *obj = ClassDB::instantiate(type);
+			ERR_FAIL_COND(!obj);
+			AnimationNode *an = Object::cast_to<AnimationNode>(obj);
+			ERR_FAIL_COND(!an);
 
-		Object *obj = ClassDB::instantiate(type);
-		ERR_FAIL_COND(!obj);
-		AnimationNode *an = Object::cast_to<AnimationNode>(obj);
-		ERR_FAIL_COND(!an);
+			node = Ref<AnimationNode>(an);
+		} else if (type.get_type() == Variant::DICTIONARY) {
+			auto dict = type.operator Dictionary();
+			auto keys = dict.keys();
+			ERR_FAIL_COND(keys.size() != 1 || keys[0].get_type() != Variant::STRING);
+			String name = keys[0];
+			Ref<Script> custom_type_script = cast_to<Script>(dict[name]);
 
-		node = Ref<AnimationNode>(an);
+			ERR_FAIL_COND(custom_type_script.is_null());
+			ERR_FAIL_COND(!custom_type_script->can_instantiate());
+			AnimationNode *an = Object::cast_to<AnimationNode>(ClassDB::instantiate("AnimationRootNode"));
+			ERR_FAIL_COND(!an);
+
+			node = Ref<AnimationNode>(an);
+			node->set_script(custom_type_script);
+		} else {
+			ERR_FAIL();
+		}
 	}
 
 	if (!node.is_valid()) {

--- a/editor/plugins/animation_blend_tree_editor_plugin.h
+++ b/editor/plugins/animation_blend_tree_editor_plugin.h
@@ -128,6 +128,8 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	void _update_editor_settings();
 	void _update_theme();
 
+	void _setup_add_options();
+
 	EditorFileDialog *open_file = nullptr;
 	Ref<AnimationNode> file_loaded;
 	void _file_opened(const String &p_file);
@@ -142,11 +144,11 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	void add_custom_type(const String &p_name, const Ref<Script> &p_script) override;
+	void remove_custom_type(const Ref<Script> &p_script) override;
+
 public:
 	static AnimationNodeBlendTreeEditor *get_singleton() { return singleton; }
-
-	void add_custom_type(const String &p_name, const Ref<Script> &p_script);
-	void remove_custom_type(const Ref<Script> &p_script);
 
 	virtual Size2 get_minimum_size() const override;
 

--- a/editor/plugins/animation_tree_editor_plugin.h
+++ b/editor/plugins/animation_tree_editor_plugin.h
@@ -37,6 +37,7 @@
 #include "scene/gui/graph_edit.h"
 
 class EditorFileDialog;
+class AnimationTreeEditor;
 
 class AnimationTreeNodeEditorPlugin : public VBoxContainer {
 	GDCLASS(AnimationTreeNodeEditorPlugin, VBoxContainer);
@@ -44,6 +45,19 @@ class AnimationTreeNodeEditorPlugin : public VBoxContainer {
 public:
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) = 0;
 	virtual void edit(const Ref<AnimationNode> &p_node) = 0;
+
+	static bool add_custom_type_static(const String &p_name, const Ref<Script> &p_script);
+	static bool remove_custom_type_static(const Ref<Script> &p_script);
+
+protected:
+	friend class AnimationTreeEditor;
+	virtual void add_custom_type(const String &p_name, const Ref<Script> &p_script) {}
+	virtual void remove_custom_type(const Ref<Script> &p_script) {}
+
+	void add_custom_type_for_menu(PopupMenu *p_menu, bool animation_root_node_only = true);
+
+private:
+	static HashMap<String, Ref<Script>> custom_types;
 };
 
 class AnimationTreeEditor : public VBoxContainer {
@@ -79,6 +93,9 @@ public:
 	AnimationTree *get_animation_tree() { return tree; }
 	void add_plugin(AnimationTreeNodeEditorPlugin *p_editor);
 	void remove_plugin(AnimationTreeNodeEditorPlugin *p_editor);
+
+	void add_custom_type(const String &p_name, const Ref<Script> &p_script);
+	void remove_custom_type(const Ref<Script> &p_script);
 
 	String get_base_path();
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

The document descripte that allow us to create custom `AnimationNode`.

Animation Tree Editors allow to load a animation node's resource, but it is quite inconvenient.

I found that the `AnimationNodeBlendTreeEditor` has methods `add_custom_type()` and `remove_custom_type()` to handle custom `AnimationNode` which be implemented by script, but they are never used.
And I found that `AnimationNodeBlendSpace1DEditor`, `AnimationNodeBlendSpace2DEditor` and `AnimationNodeStateMachineEditor` are get avaliable `AnimationRootNode` by `ClassDB`.

So, I let `AnimationNodeBlendTreeEditor` to get `AnimationNode`s by `ClassDB`, too.
And allow using `EditorPlugin.add_custom_type()` to add custom `AnimationNode` which be implemented by script.

Now, we can add custom `AnimationNode` by using GDExtension or EditorPlugin.

![image](https://user-images.githubusercontent.com/61624558/205857939-8a45361f-6561-41cb-a90c-b69f38e0aee8.png)
![image](https://user-images.githubusercontent.com/61624558/205858315-97deca83-7a0d-4288-afe0-3887c2516935.png)

--------------------------------------------------------------
Now, it allow all types of `AnimationTreeNodeEditorPlugin` to add custom animation nodes by using EditorPlugin.

https://user-images.githubusercontent.com/61624558/213840887-5eaaa6df-2f84-4f63-aa5d-6c8f67ec7c86.mp4