### PR TITLE
Fix incorrect rendering of vcs dialogs

### DIFF
--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -988,7 +988,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	metadata_dialog->set_title(TTR("Create Version Control Metadata"));
 	metadata_dialog->set_min_size(Size2(200, 40));
 	metadata_dialog->get_ok_button()->connect(SNAME("pressed"), callable_mp(this, &VersionControlEditorPlugin::_create_vcs_metadata_files));
-	version_control_actions->add_child(metadata_dialog);
+	add_child(metadata_dialog);
 
 	VBoxContainer *metadata_vb = memnew(VBoxContainer);
 	metadata_dialog->add_child(metadata_vb);
@@ -1017,7 +1017,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	set_up_dialog->set_min_size(Size2(600, 100));
 	set_up_dialog->add_cancel_button("Cancel");
 	set_up_dialog->set_hide_on_ok(true);
-	version_control_actions->add_child(set_up_dialog);
+	add_child(set_up_dialog);
 
 	Button *set_up_apply_button = set_up_dialog->get_ok_button();
 	set_up_apply_button->set_text(TTR("Apply"));


### PR DESCRIPTION
I found that's glitched because window added as a child of `PopupMenu`.

Before the fix:

![image](https://user-images.githubusercontent.com/3036176/205870442-77e9c71d-e1d2-446d-9baa-3c085cae05f2.png)

After the fix:

![image](https://user-images.githubusercontent.com/3036176/205869930-e9e2042d-0cdf-4586-88a0-df91cd29565c.png)

- Fix https://github.com/godotengine/godot/issues/69509
