### PR TITLE
Fix for 2D viewport not updating in the editor when the camera moves

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -39,8 +39,11 @@ void Camera2D::_update_scroll() {
 	}
 
 	if (Engine::get_singleton()->is_editor_hint()) {
-		queue_redraw(); //will just be drawn
-		return;
+		queue_redraw();
+		// Only set viewport transform when not bound to the main viewport.
+		if (get_viewport() == get_tree()->get_edited_scene_root()->get_viewport()) {
+			return;
+		}
 	}
 
 	if (!viewport) {


### PR DESCRIPTION
This fixes a problem with 2D viewports not taking the camera position into consideration when previewed in the editor.

This is based on the fix done in PR #40677 (which was never merged) with the addition of solving the problems mentioned in that review.

This will not not work for `3.x` since `queue_redraw()` has changed name. I'll open a separate PR for the backported fix.

Fixes #40441

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
