### PR TITLE
[3.x] Fix for 2D viewport not updating in the editor when the camera moves

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -41,8 +41,11 @@ void Camera2D::_update_scroll() {
 	}
 
 	if (Engine::get_singleton()->is_editor_hint()) {
-		update(); //will just be drawn
-		return;
+		update();
+		// Only set viewport transform when not bound to the main viewport.
+		if (get_viewport() == get_tree()->get_edited_scene_root()->get_viewport()) {
+			return;
+		}
 	}
 
 	if (!viewport) {


### PR DESCRIPTION
This fixes a problem with 2D viewports not taking the camera position into consideration when previewed in the editor.

Backport of #69644.

Fixes #40441

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
