### PR TITLE
Expose `custom_data` per cell in GridMap

### DIFF
--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -62,6 +62,13 @@
 				Returns the basis that gives the specified cell its orientation.
 			</description>
 		</method>
+		<method name="get_cell_item_custom_data" qualifiers="const">
+			<return type="Color" />
+			<param index="0" name="position" type="Vector3i" />
+			<description>
+				Returns the custom data that has been set for a specific cell.
+			</description>
+		</method>
 		<method name="get_cell_item_orientation" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="position" type="Vector3i" />
@@ -161,6 +168,16 @@
 				Sets the mesh index for the cell referenced by its grid coordinates.
 				A negative item index such as [constant INVALID_CELL_ITEM] will clear the cell.
 				Optionally, the item's orientation can be passed. For valid orientation values, see [method get_orthogonal_index_from_basis].
+			</description>
+		</method>
+		<method name="set_cell_item_custom_data">
+			<return type="void" />
+			<param index="0" name="position" type="Vector3i" />
+			<param index="1" name="custom_data" type="Color" />
+			<description>
+				Sets custom data for a specific cell. Although [Color] is used, it is just a container for 4 floating point numbers.
+				If custom data is set for at least one cell, [member MultiMesh.use_custom_data] will be set to [code]true[/code] on the [MultiMesh] instances.
+				This custom instance data has to be manually accessed in your custom shader using [code]INSTANCE_CUSTOM[/code].
 			</description>
 		</method>
 		<method name="set_collision_layer_value">

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -416,7 +416,24 @@ void GridMap::set_cell_item(const Vector3i &p_position, int p_item, int p_rot) {
 
 	cell_map[key] = c;
 }
+void GridMap::set_cell_item_custom_data(const Vector3i &p_position, const Color &p_custom_data) {
+	if (baked_meshes.size() && !recreating_octants) {
+		//if you set a cell item, baked meshes go good bye
+		clear_baked_meshes();
+		_recreate_octant_data();
+	}
 
+	ERR_FAIL_INDEX(ABS(p_position.x), 1 << 20);
+	ERR_FAIL_INDEX(ABS(p_position.y), 1 << 20);
+	ERR_FAIL_INDEX(ABS(p_position.z), 1 << 20);
+
+	IndexKey key;
+	key.x = p_position.x;
+	key.y = p_position.y;
+	key.z = p_position.z;
+	cell_data_map[key] = p_custom_data;
+	return;
+}
 int GridMap::get_cell_item(const Vector3i &p_position) const {
 	ERR_FAIL_INDEX_V(ABS(p_position.x), 1 << 20, INVALID_CELL_ITEM);
 	ERR_FAIL_INDEX_V(ABS(p_position.y), 1 << 20, INVALID_CELL_ITEM);
@@ -433,6 +450,22 @@ int GridMap::get_cell_item(const Vector3i &p_position) const {
 	return cell_map[key].item;
 }
 
+Color GridMap::get_cell_item_custom_data(const Vector3i &p_position) const {
+	ERR_FAIL_INDEX_V(ABS(p_position.x), 1 << 20, Color());
+	ERR_FAIL_INDEX_V(ABS(p_position.y), 1 << 20, Color());
+	ERR_FAIL_INDEX_V(ABS(p_position.z), 1 << 20, Color());
+
+	IndexKey key;
+	key.x = p_position.x;
+	key.y = p_position.y;
+	key.z = p_position.z;
+
+	if (!cell_data_map.has(key)) {
+		return Color();
+	}
+	return cell_data_map[key];
+}
+
 int GridMap::get_cell_item_orientation(const Vector3i &p_position) const {
 	ERR_FAIL_INDEX_V(ABS(p_position.x), 1 << 20, -1);
 	ERR_FAIL_INDEX_V(ABS(p_position.y), 1 << 20, -1);
@@ -444,7 +477,7 @@ int GridMap::get_cell_item_orientation(const Vector3i &p_position) const {
 	key.z = p_position.z;
 
 	if (!cell_map.has(key)) {
-		return -1;
+		return INVALID_CELL_ITEM;
 	}
 	return cell_map[key].rot;
 }
@@ -700,12 +733,15 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 			Octant::MultimeshInstance mmi;
 
 			RID mm = RS::get_singleton()->multimesh_create();
-			RS::get_singleton()->multimesh_allocate_data(mm, E.value.size(), RS::MULTIMESH_TRANSFORM_3D);
+			RS::get_singleton()->multimesh_allocate_data(mm, E.value.size(), RS::MULTIMESH_TRANSFORM_3D, false, !this->cell_data_map.is_empty());
 			RS::get_singleton()->multimesh_set_mesh(mm, mesh_library->get_item_mesh(E.key)->get_rid());
 
 			int idx = 0;
 			for (const Pair<Transform3D, IndexKey> &F : E.value) {
 				RS::get_singleton()->multimesh_instance_set_transform(mm, idx, F.first);
+				if (this->cell_data_map.has(F.second)) {
+					RS::get_singleton()->multimesh_instance_set_custom_data(mm, idx, this->cell_data_map[F.second]);
+				}
 #ifdef TOOLS_ENABLED
 
 				Octant::MultimeshInstance::Item it;
@@ -1073,7 +1109,9 @@ void GridMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_octant_size"), &GridMap::get_octant_size);
 
 	ClassDB::bind_method(D_METHOD("set_cell_item", "position", "item", "orientation"), &GridMap::set_cell_item, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("set_cell_item_custom_data", "position", "custom_data"), &GridMap::set_cell_item_custom_data);
 	ClassDB::bind_method(D_METHOD("get_cell_item", "position"), &GridMap::get_cell_item);
+	ClassDB::bind_method(D_METHOD("get_cell_item_custom_data", "position"), &GridMap::get_cell_item_custom_data);
 	ClassDB::bind_method(D_METHOD("get_cell_item_orientation", "position"), &GridMap::get_cell_item_orientation);
 	ClassDB::bind_method(D_METHOD("get_cell_item_basis", "position"), &GridMap::get_cell_item_basis);
 	ClassDB::bind_method(D_METHOD("get_basis_with_orthogonal_index", "index"), &GridMap::get_basis_with_orthogonal_index);

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -171,6 +171,7 @@ class GridMap : public Node3D {
 
 	HashMap<OctantKey, Octant *, OctantKey> octant_map;
 	HashMap<IndexKey, Cell, IndexKey> cell_map;
+	HashMap<IndexKey, Color> cell_data_map;
 
 	void _recreate_octant_data();
 
@@ -274,7 +275,9 @@ public:
 	bool get_center_z() const;
 
 	void set_cell_item(const Vector3i &p_position, int p_item, int p_rot = 0);
+	void set_cell_item_custom_data(const Vector3i &p_position, const Color &p_custom_data);
 	int get_cell_item(const Vector3i &p_position) const;
+	Color get_cell_item_custom_data(const Vector3i &p_position) const;
 	int get_cell_item_orientation(const Vector3i &p_position) const;
 	Basis get_cell_item_basis(const Vector3i &p_position) const;
 	Basis get_basis_with_orthogonal_index(int p_index) const;


### PR DESCRIPTION
Expose `custom_data` per cell the same way than it's exposed at the MultiMesh level.
This is only doable in code for now, designing a UI for that would need a lot of change in UX of GridMap.