### PR TITLE
Fix typo in OpenXR depth buffer submission

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -796,7 +796,7 @@ bool OpenXRAPI::create_swapchains() {
 			depth_views[i].type = XR_TYPE_COMPOSITION_LAYER_DEPTH_INFO_KHR;
 			depth_views[i].next = nullptr;
 			depth_views[i].subImage.swapchain = swapchains[OPENXR_SWAPCHAIN_DEPTH].swapchain;
-			depth_views[i].subImage.imageArrayIndex = 0;
+			depth_views[i].subImage.imageArrayIndex = i;
 			depth_views[i].subImage.imageRect.offset.x = 0;
 			depth_views[i].subImage.imageRect.offset.y = 0;
 			depth_views[i].subImage.imageRect.extent.width = recommended_size.width;


### PR DESCRIPTION
This typo resulted in the left eye depth buffer being submitted for the right eye causing weird visual glitches in reprojections