### PR TITLE
Cancels the code complete timer when the caret moves to another line

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -873,6 +873,10 @@ void CodeTextEditor::_reset_zoom() {
 }
 
 void CodeTextEditor::_line_col_changed() {
+	if (!code_complete_timer->is_stopped() && code_complete_timer_line != text_editor->get_caret_line()) {
+		code_complete_timer->stop();
+	}
+
 	String line = text_editor->get_line(text_editor->get_caret_line());
 
 	int positional_column = 0;
@@ -902,6 +906,7 @@ void CodeTextEditor::_line_col_changed() {
 
 void CodeTextEditor::_text_changed() {
 	if (text_editor->is_insert_text_operation()) {
+		code_complete_timer_line = text_editor->get_caret_line();
 		code_complete_timer->start();
 	}
 

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -158,6 +158,7 @@ class CodeTextEditor : public VBoxContainer {
 	Label *info = nullptr;
 	Timer *idle = nullptr;
 	Timer *code_complete_timer = nullptr;
+	int code_complete_timer_line = 0;
 
 	Timer *font_resize_timer = nullptr;
 	int font_resize_val;


### PR DESCRIPTION
Fixes and closes #68961

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
