### PR TITLE
Allow GDExtension to register unexposed classes.

### DIFF
--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -248,6 +248,7 @@ typedef GDNativeExtensionClassCallVirtual (*GDNativeExtensionClassGetVirtual)(vo
 typedef struct {
 	GDNativeBool is_virtual;
 	GDNativeBool is_abstract;
+	GDNativeBool is_exposed;
 	GDNativeExtensionClassSet set_func;
 	GDNativeExtensionClassGet get_func;
 	GDNativeExtensionClassGetPropertyList get_property_list_func;

--- a/core/extension/native_extension.cpp
+++ b/core/extension/native_extension.cpp
@@ -172,6 +172,7 @@ void NativeExtension::_register_extension_class(GDNativeExtensionClassLibraryPtr
 	extension->native_extension.editor_class = self->level_initialized == INITIALIZATION_LEVEL_EDITOR;
 	extension->native_extension.is_virtual = p_extension_funcs->is_virtual;
 	extension->native_extension.is_abstract = p_extension_funcs->is_abstract;
+	extension->native_extension.is_exposed = p_extension_funcs->is_exposed;
 	extension->native_extension.set = p_extension_funcs->set_func;
 	extension->native_extension.get = p_extension_funcs->get_func;
 	extension->native_extension.get_property_list = p_extension_funcs->get_property_list_func;

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1541,7 +1541,11 @@ void ClassDB::register_extension_class(ObjectNativeExtension *p_extension) {
 	c.inherits = parent->name;
 	c.class_ptr = parent->class_ptr;
 	c.inherits_ptr = parent;
-	c.exposed = true;
+	c.exposed = p_extension->is_exposed;
+	if (c.exposed) {
+		// The parent classes should be exposed if has a exposed child class.
+		parent->exposed = true;
+	}
 
 	classes[p_extension->class_name] = c;
 }

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -178,13 +178,13 @@ public:
 	}
 
 	template <class T>
-	static void register_class(bool p_virtual = false) {
+	static void register_class(bool p_virtual = false, bool p_exposed = true) {
 		GLOBAL_LOCK_FUNCTION;
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_COND(!t);
 		t->creation_func = &creator<T>;
-		t->exposed = true;
+		t->exposed = p_exposed;
 		t->is_virtual = p_virtual;
 		t->class_ptr = T::get_class_ptr_static();
 		t->api = current_api;
@@ -192,15 +192,43 @@ public:
 	}
 
 	template <class T>
-	static void register_abstract_class() {
+	static void register_abstract_class(bool p_exposed = true) {
 		GLOBAL_LOCK_FUNCTION;
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_COND(!t);
-		t->exposed = true;
+		t->exposed = p_exposed;
 		t->class_ptr = T::get_class_ptr_static();
 		t->api = current_api;
 		//nothing
+	}
+
+	template <class T>
+	static void register_virtual_class(bool p_exposed = true) {
+		GLOBAL_LOCK_FUNCTION;
+		T::initialize_class();
+		ClassInfo *t = classes.getptr(T::get_class_static());
+		ERR_FAIL_COND(!t);
+		t->creation_func = &creator<T>;
+		t->exposed = p_exposed;
+		t->is_virtual = true;
+		t->class_ptr = T::get_class_ptr_static();
+		t->api = current_api;
+		T::register_custom_data_to_otdb();
+	}
+
+	template <class T>
+	static void register_internal_class(bool p_virtual = false) {
+		GLOBAL_LOCK_FUNCTION;
+		T::initialize_class();
+		ClassInfo *t = classes.getptr(T::get_class_static());
+		ERR_FAIL_COND(!t);
+		t->creation_func = &creator<T>;
+		t->exposed = false;
+		t->is_virtual = false;
+		t->class_ptr = T::get_class_ptr_static();
+		t->api = current_api;
+		T::register_custom_data_to_otdb();
 	}
 
 	static void register_extension_class(ObjectNativeExtension *p_extension);

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -312,6 +312,7 @@ struct ObjectNativeExtension {
 	bool editor_class = false;
 	bool is_virtual = false;
 	bool is_abstract = false;
+	bool is_exposed = true;
 	GDNativeExtensionClassSet set;
 	GDNativeExtensionClassGet get;
 	GDNativeExtensionClassGetPropertyList get_property_list;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Relate to [#951](https://github.com/godotengine/godot-cpp/pull/951).

It seems that some register methods are redundant. I am not sure about that, these new register methods just for making style consistent.