### PR TITLE
Make submitting depth buffer in OpenXR optional

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2299,6 +2299,9 @@
 		<member name="xr/openxr/reference_space" type="int" setter="" getter="" default="&quot;1&quot;">
 			Specify the default reference space.
 		</member>
+		<member name="xr/openxr/submit_depth_buffer" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], OpenXR will manage the depth buffer and use the depth buffer for advanced reprojection provided this is supported by the XR runtime. Note that some rendering features in Godot can't be used with this feature.
+		</member>
 		<member name="xr/openxr/view_configuration" type="int" setter="" getter="" default="&quot;1&quot;">
 			Specify the view configuration with which to configure OpenXR setting up either Mono or Stereo rendering.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1862,6 +1862,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF_BASIC("xr/openxr/reference_space", "1");
 	ProjectSettings::get_singleton()->set_custom_property_info("xr/openxr/reference_space", PropertyInfo(Variant::INT, "xr/openxr/reference_space", PROPERTY_HINT_ENUM, "Local,Stage"));
 
+	GLOBAL_DEF_BASIC("xr/openxr/submit_depth_buffer", false);
+
 #ifdef TOOLS_ENABLED
 	// Disabled for now, using XR inside of the editor we'll be working on during the coming months.
 

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -104,6 +104,7 @@ private:
 	XrViewConfigurationType view_configuration = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
 	XrReferenceSpaceType reference_space = XR_REFERENCE_SPACE_TYPE_STAGE;
 	// XrEnvironmentBlendMode environment_blend_mode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+	bool submit_depth_buffer = false; // if set to true we submit depth buffers to OpenXR if a suitable extension is enabled.
 
 	// state
 	XrInstance instance = XR_NULL_HANDLE;
@@ -311,6 +312,18 @@ public:
 
 	void set_xr_interface(OpenXRInterface *p_xr_interface);
 	void register_extension_wrapper(OpenXRExtensionWrapper *p_extension_wrapper);
+
+	void set_form_factor(XrFormFactor p_form_factor);
+	XrFormFactor get_form_factor() const { return form_factor; }
+
+	void set_view_configuration(XrViewConfigurationType p_view_configuration);
+	XrViewConfigurationType get_view_configuration() const { return view_configuration; }
+
+	void set_reference_space(XrReferenceSpaceType p_reference_space);
+	XrReferenceSpaceType get_reference_space() const { return reference_space; }
+
+	void set_submit_depth_buffer(bool p_submit_depth_buffer);
+	bool get_submit_depth_buffer() const { return submit_depth_buffer; }
 
 	bool is_initialized();
 	bool is_running();


### PR DESCRIPTION
OpenXR has various implementations where we can submit depth buffers for improved re-projection logic however this also results in OpenXR providing us with the depth buffer we need to render into.

As we are limited in the configuration of these depth buffers there are certain situations where we run into problems. We're missing the ability to resolve the MSAA depth buffer in the mobile renderer when subpasses are used, and we have a number of systems (like GI) in the clustered renderer which requires the storage bit to be set on the depth buffer (which OpenXR does not allow).

Also reprojection is only required when you're not hitting your frame rates and you still get basic reprojection even without the depth buffer.

As a result we've made this feature optional with a setting in project settings to turn it off (as it currently can't be switched after OpenXR has been initialized).