### PR TITLE
Fix collision detection for degenerate capsules

### DIFF
--- a/servers/physics_2d/godot_shape_2d.cpp
+++ b/servers/physics_2d/godot_shape_2d.cpp
@@ -369,8 +369,9 @@ void GodotCapsuleShape2D::get_supports(const Vector2 &p_normal, Vector2 *r_suppo
 	Vector2 n = p_normal;
 
 	real_t d = n.y;
+	real_t h = height * 0.5 - radius; // half-height of the rectangle part
 
-	if (Math::abs(d) < (1.0 - _SEGMENT_IS_VALID_SUPPORT_THRESHOLD)) {
+	if (h > 0 && Math::abs(d) < (1.0 - _SEGMENT_IS_VALID_SUPPORT_THRESHOLD)) {
 		// make it flat
 		n.y = 0.0;
 		n.normalize();
@@ -378,13 +379,10 @@ void GodotCapsuleShape2D::get_supports(const Vector2 &p_normal, Vector2 *r_suppo
 
 		r_amount = 2;
 		r_supports[0] = n;
-		r_supports[0].y += height * 0.5 - radius;
+		r_supports[0].y += h;
 		r_supports[1] = n;
-		r_supports[1].y -= height * 0.5 - radius;
-
+		r_supports[1].y -= h;
 	} else {
-		real_t h = height * 0.5 - radius;
-
 		n *= radius;
 		n.y += (d > 0) ? h : -h;
 		r_amount = 1;

--- a/servers/physics_3d/godot_shape_3d.cpp
+++ b/servers/physics_3d/godot_shape_3d.cpp
@@ -521,8 +521,9 @@ void GodotCapsuleShape3D::get_supports(const Vector3 &p_normal, int p_max, Vecto
 	Vector3 n = p_normal;
 
 	real_t d = n.y;
+	real_t h = height * 0.5 - radius; // half-height of the cylinder part
 
-	if (Math::abs(d) < edge_support_threshold) {
+	if (h > 0 && Math::abs(d) < edge_support_threshold) {
 		// make it flat
 		n.y = 0.0;
 		n.normalize();
@@ -531,13 +532,10 @@ void GodotCapsuleShape3D::get_supports(const Vector3 &p_normal, int p_max, Vecto
 		r_amount = 2;
 		r_type = FEATURE_EDGE;
 		r_supports[0] = n;
-		r_supports[0].y += height * 0.5 - radius;
+		r_supports[0].y += h;
 		r_supports[1] = n;
-		r_supports[1].y -= height * 0.5 - radius;
-
+		r_supports[1].y -= h;
 	} else {
-		real_t h = height * 0.5 - radius;
-
 		n *= radius;
 		n.y += (d > 0) ? h : -h;
 		r_amount = 1;


### PR DESCRIPTION
In `GodotCapsuleShape3D::get_supports` and `GodotCapsuleShape2D::get_supports`, return a point instead of an edge of length zero in case the capsule degenerates to a sphere or circle.

Fixes https://github.com/godotengine/godot/issues/59632