### PR TITLE
Fix unexpected editor dependency

### DIFF
--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -220,8 +220,12 @@ void SceneDebugger::_save_node(ObjectID id, const String &p_path) {
 	Node *node = Object::cast_to<Node>(ObjectDB::get_instance(id));
 	ERR_FAIL_COND(!node);
 
+#ifdef TOOLS_ENABLED
 	HashMap<const Node *, Node *> duplimap;
 	Node *copy = node->duplicate_from_editor(duplimap);
+#else
+	Node *copy = node->duplicate();
+#endif
 
 	// Handle Unique Nodes.
 	for (int i = 0; i < copy->get_child_count(false); i++) {


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/65228#issuecomment-1338859262

`duplicate()` and `duplicate_from_editor()` are a bit different, but *hopefully* it doesn't matter that much when saving a scene. I think the only way to call `_save_node()` outside editor builds is to send a custom message to the debugger.

- Fixes #69663