### PR TITLE
Fix Path2D fish bone direction

### DIFF
--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -120,7 +120,7 @@ void Path2D::_notification(int p_what) {
 					Transform2D *w = frames.ptrw();
 
 					for (int i = 0; i < sample_count; i++) {
-						w[i] = curve->sample_baked_with_rotation(i * interval, true);
+						w[i] = curve->sample_baked_with_rotation(i * interval, false);
 					}
 				}
 

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -941,7 +941,7 @@ Transform2D Curve2D::_sample_posture(Interval p_interval) const {
 	const Vector2 forward = forward_begin.slerp(forward_end, frac).normalized();
 	const Vector2 side = Vector2(-forward.y, forward.x);
 
-	return Transform2D(forward, side, Vector2(0.0, 0.0));
+	return Transform2D(side, forward, Vector2(0.0, 0.0));
 }
 
 Vector2 Curve2D::sample_baked(real_t p_offset, bool p_cubic) const {


### PR DESCRIPTION
The forward and side vector are swap, and rotate arrow head 90 degree.

Fix this
![image](https://user-images.githubusercontent.com/6020486/205923811-6d95f1d8-c847-4930-970a-04c890c91321.png)
