### PR TITLE
Fix unable to disconnect signal in Editor once created

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -556,6 +556,7 @@ public:
 		CONNECT_PERSIST = 2, // hint for scene to save this connection
 		CONNECT_ONE_SHOT = 4,
 		CONNECT_REFERENCE_COUNTED = 8,
+		CONNECT_INHERITED = 16, // Used in editor builds.
 	};
 
 	struct Connection {

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -788,23 +788,7 @@ bool ConnectionsDock::_is_item_signal(TreeItem &p_item) {
 }
 
 bool ConnectionsDock::_is_connection_inherited(Connection &p_connection) {
-	Node *scene_root = EditorNode::get_singleton()->get_edited_scene();
-	Ref<PackedScene> scn = ResourceLoader::load(scene_root->get_scene_file_path());
-	ERR_FAIL_NULL_V(scn, false);
-
-	Ref<SceneState> state = scn->get_state();
-	ERR_FAIL_NULL_V(state, false);
-
-	Node *source = Object::cast_to<Node>(p_connection.signal.get_object());
-	Node *target = Object::cast_to<Node>(p_connection.callable.get_object());
-
-	const NodePath source_path = scene_root->get_path_to(source);
-	const NodePath target_path = scene_root->get_path_to(target);
-	const StringName signal_name = p_connection.signal.get_name();
-	const StringName method_name = p_connection.callable.get_method();
-
-	// If it cannot be found in PackedScene, this connection was inherited.
-	return !state->has_connection(source_path, signal_name, target_path, method_name, true);
+	return bool(p_connection.flags & CONNECT_INHERITED);
 }
 
 /*

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -450,7 +450,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 			callable = callable.bindp(argptrs, binds.size());
 		}
 
-		cfrom->connect(snames[c.signal], callable, CONNECT_PERSIST | c.flags);
+		cfrom->connect(snames[c.signal], callable, CONNECT_PERSIST | c.flags | (p_edit_state == GEN_EDIT_STATE_MAIN ? 0 : CONNECT_INHERITED));
 	}
 
 	//Node *s = ret_nodes[0];


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/69348.

https://github.com/godotengine/godot/pull/66665's implementation was a bit too stupid and didn't account all cases. Most importantly, signals that had yet to be saved.

To solve this in the least chaotic, slow and intrusive way, I basically gave up. This PR adds a **CONNECT_INHERITED** flag to connections, only available in editor builds. This flag denotes that the signal has been inherited from a previous Scene in the instancing hierarchy. Signals deemed to be inherited cannot be edited or deleted in the editor.
