### PR TITLE
doc: Use `Signal.emit` instead of `emit_signal` in Object examples

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -556,7 +556,7 @@
 				While all options have the same outcome ([code]button[/code]'s [signal BaseButton.button_down] signal will be connected to [code]_on_button_down[/code]), [b]option 3[/b] offers the best validation: it will print a compile-time error if either the [code]button_down[/code] [Signal] or the [code]_on_button_down[/code] [Callable] are not defined. On the other hand, [b]option 2[/b] only relies on string names and will only be able to validate either names at runtime: it will print a runtime error if [code]"button_down"[/code] doesn't correspond to a signal, or if [code]"_on_button_down"[/code] is not a registered method in the object [code]self[/code]. The main reason for using options 1, 2, or 4 would be if you actually need to use strings (e.g. to connect signals programmatically based on strings read from a configuration file). Otherwise, option 3 is the recommended (and fastest) method.
 				[b]Binding and passing parameters:[/b]
 				The syntax to bind parameters is through [method Callable.bind], which returns a copy of the [Callable] with its parameters bound.
-				When calling [method emit_signal], the signal parameters can be also passed. The examples below show the relationship between these signal parameters and bound parameters.
+				When calling [method emit_signal] or [method Signal.emit], the signal parameters can be also passed. The examples below show the relationship between these signal parameters and bound parameters.
 				[codeblocks]
 				[gdscript]
 				func _ready():
@@ -566,7 +566,7 @@
 				    player.hit.connect(_on_player_hit.bind("sword", 100))
 
 				    # Parameters added when emitting the signal are passed first.
-				    player.emit_signal("hit", "Dark lord", 5)
+				    player.hit.emit("Dark lord", 5)
 
 				# We pass two arguments when emitting (`hit_by`, `level`),
 				# and bind two more arguments when connecting (`weapon_type`, `damage`).


### PR DESCRIPTION
Change the code and use the new method of godot4

URL:https://docs.godotengine.org/en/latest/classes/class_object.html

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
