### PR TITLE
Use `GDREGISTER_CLASS` macro for SkeletonModification classes

### DIFF
--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -827,14 +827,14 @@ void register_scene_types() {
 	GDREGISTER_CLASS(ConvexPolygonShape3D);
 	GDREGISTER_CLASS(ConcavePolygonShape3D);
 
-	ClassDB::register_class<SkeletonModificationStack3D>();
-	ClassDB::register_class<SkeletonModification3D>();
-	ClassDB::register_class<SkeletonModification3DLookAt>();
-	ClassDB::register_class<SkeletonModification3DCCDIK>();
-	ClassDB::register_class<SkeletonModification3DFABRIK>();
-	ClassDB::register_class<SkeletonModification3DJiggle>();
-	ClassDB::register_class<SkeletonModification3DTwoBoneIK>();
-	ClassDB::register_class<SkeletonModification3DStackHolder>();
+	GDREGISTER_CLASS(SkeletonModificationStack3D);
+	GDREGISTER_CLASS(SkeletonModification3D);
+	GDREGISTER_CLASS(SkeletonModification3DLookAt);
+	GDREGISTER_CLASS(SkeletonModification3DCCDIK);
+	GDREGISTER_CLASS(SkeletonModification3DFABRIK);
+	GDREGISTER_CLASS(SkeletonModification3DJiggle);
+	GDREGISTER_CLASS(SkeletonModification3DTwoBoneIK);
+	GDREGISTER_CLASS(SkeletonModification3DStackHolder);
 
 	OS::get_singleton()->yield(); // may take time to init
 #endif // _3D_DISABLED


### PR DESCRIPTION
This was likely an oversight from merging this PR after `GDREGISTER_CLASS` was introduced. It's equivalent, unless the class is actually disabled.