### PR TITLE
Fix typo bug in cylinder-cylinder SAT collision solver

### DIFF
--- a/servers/physics_3d/godot_collision_solver_3d_sat.cpp
+++ b/servers/physics_3d/godot_collision_solver_3d_sat.cpp
@@ -1908,7 +1908,7 @@ static void _collision_cylinder_cylinder(const GodotShape3D *p_a, const Transfor
 	}
 
 	// Cylinder B end caps.
-	if (!separator.test_axis(cylinder_A_axis.normalized())) {
+	if (!separator.test_axis(cylinder_B_axis.normalized())) {
 		return;
 	}
 


### PR DESCRIPTION
Split off from https://github.com/godotengine/godot/pull/68958 for simplicity.