### PR TITLE
Fix typo in physics step: contraint -> constraint

### DIFF
--- a/servers/physics_2d/godot_step_2d.cpp
+++ b/servers/physics_2d/godot_step_2d.cpp
@@ -71,7 +71,7 @@ void GodotStep2D::_populate_island(GodotBody2D *p_body, LocalVector<GodotBody2D 
 	}
 }
 
-void GodotStep2D::_setup_contraint(uint32_t p_constraint_index, void *p_userdata) {
+void GodotStep2D::_setup_constraint(uint32_t p_constraint_index, void *p_userdata) {
 	GodotConstraint2D *constraint = all_constraints[p_constraint_index];
 	constraint->setup(delta);
 }
@@ -238,8 +238,8 @@ void GodotStep2D::step(GodotSpace2D *p_space, real_t p_delta) {
 
 	/* SETUP CONSTRAINTS / PROCESS COLLISIONS */
 
-	uint32_t total_contraint_count = all_constraints.size();
-	WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &GodotStep2D::_setup_contraint, nullptr, total_contraint_count, -1, true, SNAME("Physics2DConstraintSetup"));
+	uint32_t total_constraint_count = all_constraints.size();
+	WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &GodotStep2D::_setup_constraint, nullptr, total_constraint_count, -1, true, SNAME("Physics2DConstraintSetup"));
 	WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
 
 	{ //profile

--- a/servers/physics_2d/godot_step_2d.h
+++ b/servers/physics_2d/godot_step_2d.h
@@ -47,7 +47,7 @@ class GodotStep2D {
 	LocalVector<GodotConstraint2D *> all_constraints;
 
 	void _populate_island(GodotBody2D *p_body, LocalVector<GodotBody2D *> &p_body_island, LocalVector<GodotConstraint2D *> &p_constraint_island);
-	void _setup_contraint(uint32_t p_constraint_index, void *p_userdata = nullptr);
+	void _setup_constraint(uint32_t p_constraint_index, void *p_userdata = nullptr);
 	void _pre_solve_island(LocalVector<GodotConstraint2D *> &p_constraint_island) const;
 	void _solve_island(uint32_t p_island_index, void *p_userdata = nullptr) const;
 	void _check_suspend(LocalVector<GodotBody2D *> &p_body_island) const;

--- a/servers/physics_3d/godot_step_3d.cpp
+++ b/servers/physics_3d/godot_step_3d.cpp
@@ -111,7 +111,7 @@ void GodotStep3D::_populate_island_soft_body(GodotSoftBody3D *p_soft_body, Local
 	}
 }
 
-void GodotStep3D::_setup_contraint(uint32_t p_constraint_index, void *p_userdata) {
+void GodotStep3D::_setup_constraint(uint32_t p_constraint_index, void *p_userdata) {
 	GodotConstraint3D *constraint = all_constraints[p_constraint_index];
 	constraint->setup(delta);
 }
@@ -342,8 +342,8 @@ void GodotStep3D::step(GodotSpace3D *p_space, real_t p_delta) {
 
 	/* SETUP CONSTRAINTS / PROCESS COLLISIONS */
 
-	uint32_t total_contraint_count = all_constraints.size();
-	WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &GodotStep3D::_setup_contraint, nullptr, total_contraint_count, -1, true, SNAME("Physics3DConstraintSetup"));
+	uint32_t total_constraint_count = all_constraints.size();
+	WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &GodotStep3D::_setup_constraint, nullptr, total_constraint_count, -1, true, SNAME("Physics3DConstraintSetup"));
 	WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
 
 	{ //profile

--- a/servers/physics_3d/godot_step_3d.h
+++ b/servers/physics_3d/godot_step_3d.h
@@ -48,7 +48,7 @@ class GodotStep3D {
 
 	void _populate_island(GodotBody3D *p_body, LocalVector<GodotBody3D *> &p_body_island, LocalVector<GodotConstraint3D *> &p_constraint_island);
 	void _populate_island_soft_body(GodotSoftBody3D *p_soft_body, LocalVector<GodotBody3D *> &p_body_island, LocalVector<GodotConstraint3D *> &p_constraint_island);
-	void _setup_contraint(uint32_t p_constraint_index, void *p_userdata = nullptr);
+	void _setup_constraint(uint32_t p_constraint_index, void *p_userdata = nullptr);
 	void _pre_solve_island(LocalVector<GodotConstraint3D *> &p_constraint_island) const;
 	void _solve_island(uint32_t p_island_index, void *p_userdata = nullptr);
 	void _check_suspend(const LocalVector<GodotBody3D *> &p_body_island) const;


### PR DESCRIPTION
This misspelled name was only used internally and this PR doesn't fix any bug, but it will improve the experience of anyone searching for "constraint" or using their eyes to look at this code.