### PR TITLE
Fix buffer over-read and memory leaks when using long filepaths in minizip API

### DIFF
--- a/core/io/zip_io.h
+++ b/core/io/zip_io.h
@@ -39,6 +39,13 @@
 #include "thirdparty/minizip/unzip.h"
 #include "thirdparty/minizip/zip.h"
 
+// Get the current file info and safely convert the full filepath to a String.
+int godot_unzip_get_current_file_info(unzFile p_zip_file, unz_file_info64 &r_file_info, String &r_filepath);
+// Try to locate the file in the archive specified by the filepath (works with large paths and Unicode).
+int godot_unzip_locate_file(unzFile p_zip_file, String p_filepath, bool p_case_sensitive = true);
+
+//
+
 void *zipio_open(voidpf opaque, const char *p_fname, int mode);
 uLong zipio_read(voidpf opaque, voidpf stream, void *buf, uLong size);
 uLong zipio_write(voidpf opaque, voidpf stream, const void *buf, uLong size);

--- a/modules/zip/doc_classes/ZIPPacker.xml
+++ b/modules/zip/doc_classes/ZIPPacker.xml
@@ -63,10 +63,13 @@
 	</methods>
 	<constants>
 		<constant name="APPEND_CREATE" value="0" enum="ZipAppend">
+			Create a new zip archive at the given path.
 		</constant>
 		<constant name="APPEND_CREATEAFTER" value="1" enum="ZipAppend">
+			Append a new zip archive to the end of the already existing file at the given path.
 		</constant>
 		<constant name="APPEND_ADDINZIP" value="2" enum="ZipAppend">
+			Add new files to the existing zip archive at the given path.
 		</constant>
 	</constants>
 </class>

--- a/modules/zip/zip_packer.cpp
+++ b/modules/zip/zip_packer.cpp
@@ -39,17 +39,19 @@ Error ZIPPacker::open(String p_path, ZipAppend p_append) {
 	}
 
 	zlib_filefunc_def io = zipio_create_io(&fa);
-	zf = zipOpen2(p_path.utf8().get_data(), p_append, NULL, &io);
-	return zf != NULL ? OK : FAILED;
+	zf = zipOpen2(p_path.utf8().get_data(), p_append, nullptr, &io);
+	return zf != nullptr ? OK : FAILED;
 }
 
 Error ZIPPacker::close() {
 	ERR_FAIL_COND_V_MSG(fa.is_null(), FAILED, "ZIPPacker cannot be closed because it is not open.");
 
-	Error err = zipClose(zf, NULL) == ZIP_OK ? OK : FAILED;
+	Error err = zipClose(zf, nullptr) == ZIP_OK ? OK : FAILED;
 	if (err == OK) {
-		zf = NULL;
+		DEV_ASSERT(fa == nullptr);
+		zf = nullptr;
 	}
+
 	return err;
 }
 
@@ -60,18 +62,18 @@ Error ZIPPacker::start_file(String p_path) {
 
 	OS::DateTime time = OS::get_singleton()->get_datetime();
 
+	zipfi.tmz_date.tm_sec = time.second;
+	zipfi.tmz_date.tm_min = time.minute;
 	zipfi.tmz_date.tm_hour = time.hour;
 	zipfi.tmz_date.tm_mday = time.day;
-	zipfi.tmz_date.tm_min = time.minute;
 	zipfi.tmz_date.tm_mon = time.month - 1;
-	zipfi.tmz_date.tm_sec = time.second;
 	zipfi.tmz_date.tm_year = time.year;
 	zipfi.dosDate = 0;
-	zipfi.external_fa = 0;
 	zipfi.internal_fa = 0;
+	zipfi.external_fa = 0;
 
-	int ret = zipOpenNewFileInZip(zf, p_path.utf8().get_data(), &zipfi, NULL, 0, NULL, 0, NULL, Z_DEFLATED, Z_DEFAULT_COMPRESSION);
-	return ret == ZIP_OK ? OK : FAILED;
+	int err = zipOpenNewFileInZip(zf, p_path.utf8().get_data(), &zipfi, nullptr, 0, nullptr, 0, nullptr, Z_DEFLATED, Z_DEFAULT_COMPRESSION);
+	return err == ZIP_OK ? OK : FAILED;
 }
 
 Error ZIPPacker::write_file(Vector<uint8_t> p_data) {

--- a/modules/zip/zip_packer.h
+++ b/modules/zip/zip_packer.h
@@ -40,7 +40,7 @@ class ZIPPacker : public RefCounted {
 	GDCLASS(ZIPPacker, RefCounted);
 
 	Ref<FileAccess> fa;
-	zipFile zf;
+	zipFile zf = nullptr;
 
 protected:
 	static void _bind_methods();

--- a/modules/zip/zip_reader.h
+++ b/modules/zip/zip_reader.h
@@ -40,7 +40,7 @@ class ZIPReader : public RefCounted {
 	GDCLASS(ZIPReader, RefCounted)
 
 	Ref<FileAccess> fa;
-	unzFile uzf;
+	unzFile uzf = nullptr;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
- Fixed a buffer over-read when building a `List<String>` of filepaths due to implicit `String(c_str)` constructor use.
- Fixed a memory leak when using long filepaths (>256 characters) in `ZIPReader::get_files()`.
- Added a new `unzGetCurrentFileInfo` replacement method, `godot_unzip_get_current_file_info`, that safely gets the file information and filepath as a `String` without exposing/leaking dangerous C strings.
- Added a new `unzLocateFile` replacement method, `godot_unzip_locate_file`, that handles long filepaths as the default `unzLocateFile` doesn't handle paths >256 characters at all (it could if it wanted to...). This method also uses Godot's `String` class for comparison in order to support Unicode case-comparison.
- Improved the robustness of `ZIPReader::read_file`, it should now safely handle uncompressed blobs of up to 2gb and verify each action it takes before returning data.
- Added documentation for `ZipAppend` enum.