### PR TITLE
Fix `ResourceLoader::thread_load_tasks` crash

### DIFF
--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -219,6 +219,8 @@ public:
 	static void load_translation_remaps();
 	static void clear_translation_remaps();
 
+	static void clear_thread_load_tasks();
+
 	static void set_load_callback(ResourceLoadedCallback p_callback);
 	static ResourceLoaderImport import;
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3328,6 +3328,8 @@ void Main::cleanup(bool p_force) {
 	ResourceLoader::clear_translation_remaps();
 	ResourceLoader::clear_path_remaps();
 
+	ResourceLoader::clear_thread_load_tasks();
+
 	ScriptServer::finish_languages();
 
 	// Sync pending commands that may have been queued from a different thread during ScriptServer finalization


### PR DESCRIPTION
This PR adds a new method: `ResourceLoader::clear_thread_load_tasks()`. This is called now just after clearing scripting languages, but before the modules and servers uninitialization. Otherwise, some resources would exist until `unregister_core_types()`, and crash the engine when trying to access servers in the resources destructors.

This PR also adds the clearing of scene references inside `GDScriptCache` in `GDScriptCache::clear()`.

Fixes #69652