### PR TITLE
Stop NavigationAgents without a target from moving to world origin

### DIFF
--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -161,7 +161,7 @@ void NavigationAgent2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
-			if (agent_parent) {
+			if (agent_parent && target_position_submitted) {
 				if (avoidance_enabled) {
 					// agent_position on NavigationServer is avoidance only and has nothing to do with pathfinding
 					// no point in flooding NavigationServer queue with agent position updates that get send to the void if avoidance is not used
@@ -314,6 +314,7 @@ real_t NavigationAgent2D::get_path_max_distance() {
 
 void NavigationAgent2D::set_target_location(Vector2 p_location) {
 	target_location = p_location;
+	target_position_submitted = true;
 	_request_repath();
 }
 
@@ -402,6 +403,9 @@ void NavigationAgent2D::update_navigation() {
 	if (!agent_parent->is_inside_tree()) {
 		return;
 	}
+	if (!target_position_submitted) {
+		return;
+	}
 	if (update_frame_id == Engine::get_singleton()->get_physics_frames()) {
 		return;
 	}
@@ -463,6 +467,7 @@ void NavigationAgent2D::update_navigation() {
 				_check_distance_to_target();
 				nav_path_index -= 1;
 				navigation_finished = true;
+				target_position_submitted = false;
 				emit_signal(SNAME("navigation_finished"));
 				break;
 			}

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -60,6 +60,7 @@ class NavigationAgent2D : public Node {
 	real_t path_max_distance = 3.0;
 
 	Vector2 target_location;
+	bool target_position_submitted = false;
 	Ref<NavigationPathQueryParameters2D> navigation_query;
 	Ref<NavigationPathQueryResult2D> navigation_result;
 	int nav_path_index = 0;

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -167,7 +167,7 @@ void NavigationAgent3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
-			if (agent_parent) {
+			if (agent_parent && target_position_submitted) {
 				if (avoidance_enabled) {
 					// agent_position on NavigationServer is avoidance only and has nothing to do with pathfinding
 					// no point in flooding NavigationServer queue with agent position updates that get send to the void if avoidance is not used
@@ -330,6 +330,7 @@ real_t NavigationAgent3D::get_path_max_distance() {
 
 void NavigationAgent3D::set_target_location(Vector3 p_location) {
 	target_location = p_location;
+	target_position_submitted = true;
 	_request_repath();
 }
 
@@ -417,6 +418,9 @@ void NavigationAgent3D::update_navigation() {
 	if (!agent_parent->is_inside_tree()) {
 		return;
 	}
+	if (!target_position_submitted) {
+		return;
+	}
 	if (update_frame_id == Engine::get_singleton()->get_physics_frames()) {
 		return;
 	}
@@ -480,6 +484,7 @@ void NavigationAgent3D::update_navigation() {
 				_check_distance_to_target();
 				nav_path_index -= 1;
 				navigation_finished = true;
+				target_position_submitted = false;
 				emit_signal(SNAME("navigation_finished"));
 				break;
 			}

--- a/scene/3d/navigation_agent_3d.h
+++ b/scene/3d/navigation_agent_3d.h
@@ -62,6 +62,7 @@ class NavigationAgent3D : public Node {
 	real_t path_max_distance = 3.0;
 
 	Vector3 target_location;
+	bool target_position_submitted = false;
 	Ref<NavigationPathQueryParameters3D> navigation_query;
 	Ref<NavigationPathQueryResult3D> navigation_result;
 	int nav_path_index = 0;


### PR DESCRIPTION
Stops NavigationAgents moving to the world origin without anyone telling them to do so.

Fixes #65472

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
