### PR TITLE
Fix Variant StringName `is_zero` being inverted

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -940,7 +940,7 @@ bool Variant::is_zero() const {
 			return reinterpret_cast<const Signal *>(_data._mem)->is_null();
 		}
 		case STRING_NAME: {
-			return *reinterpret_cast<const StringName *>(_data._mem) != StringName();
+			return *reinterpret_cast<const StringName *>(_data._mem) == StringName();
 		}
 		case NODE_PATH: {
 			return reinterpret_cast<const NodePath *>(_data._mem)->is_empty();


### PR DESCRIPTION
Test code:

```
	if &"test":
		print("true")
	else:
		print("false")

	if &"":
		print("true")
	else:
		print("false")
```

Before, this would print false, then true. Now, it prints true, then false.