### PR TITLE
Fix crash when deleting an alternative-level tile proxy

### DIFF
--- a/editor/plugins/tiles/tile_proxies_manager_dialog.cpp
+++ b/editor/plugins/tiles/tile_proxies_manager_dialog.cpp
@@ -77,7 +77,7 @@ void TileProxiesManagerDialog::_delete_selected_bindings() {
 	Vector<int> alternative_level_selected = alternative_level_list->get_selected_items();
 	for (int i = 0; i < alternative_level_selected.size(); i++) {
 		Array key = alternative_level_list->get_item_metadata(alternative_level_selected[i]);
-		Array val = tile_set->get_coords_level_tile_proxy(key[0], key[1]);
+		Array val = tile_set->get_alternative_level_tile_proxy(key[0], key[1], key[2]);
 		undo_redo->add_do_method(*tile_set, "remove_alternative_level_tile_proxy", key[0], key[1], key[2]);
 		undo_redo->add_undo_method(*tile_set, "set_alternative_level_tile_proxy", key[0], key[1], key[2], val[0], val[1], val[2]);
 	}


### PR DESCRIPTION
Using `get_coords_level_tile_proxy()` here is a typo I believe, so the `val` array contains less elements than expected.