### PR TITLE
updated example documentation for EditorScenePostImport

### DIFF
--- a/doc/classes/EditorScenePostImport.xml
+++ b/doc/classes/EditorScenePostImport.xml
@@ -28,12 +28,12 @@
 		// This sample changes all node names.
 		// Called right after the scene is imported and gets the root node.
 		[Tool]
-		public class NodeRenamer : EditorScenePostImport
+		public partial class NodeRenamer : EditorScenePostImport
 		{
-		    public override Object PostImport(Object scene)
+		    public override Object _PostImport(Node scene)
 		    {
 		        // Change all node names to "modified_[oldnodename]"
-		        Iterate(scene as Node);
+		        Iterate(scene);
 		        return scene; // Remember to return the imported scene
 		    }
 		    public void Iterate(Node node)


### PR DESCRIPTION
The code example for `EditorScenePostImport` in the documentation doesn't work in Godot 4.x due to `node.name` changing type to `StringName`. `StringName` and `String` can't concatenate so `node.name` needs to be converted first.

This is the error when you run the pre-PR example code:
`Invalid operands 'String' and 'StringName' in operator '+'.`

Kind of a dumb PR but it tripped me up (more so the renaming to `_post_import()`) and it's a good excuse for me to start contributing. I also don't know why `node.name` takes a `String` and not `StringName` but I imagine it's converting it somewhere.