### PR TITLE
More refactor AnimationPlayer process for Method track which change animation with Immediate mode

### DIFF
--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -255,7 +255,6 @@ private:
 
 	List<StringName> queued;
 
-	bool is_just_played = false;
 	bool end_reached = false;
 	bool end_notify = false;
 


### PR DESCRIPTION
Follow up #69685.

- Changed initialization timing of cache_update_size.
- Implemented checking for animation equality by comparing pointers instead of a bool value `is_just_played`.

It is not recommended, but I think it can support advance() in method track with Immediate mode.

cc @LakshayaG73