### PR TITLE
[3.x] SurfaceTool - efficiency improvements

### DIFF
--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1373,10 +1373,20 @@ Error ArrayMesh::lightmap_unwrap_cached(int *&r_cache_data, unsigned int &r_cach
 				surfaces_tools[surface]->add_tangent(t);
 			}
 			if (lightmap_surfaces[surface].format & ARRAY_FORMAT_BONES) {
-				surfaces_tools[surface]->add_bones(v.bones);
+				Vector<int> bones;
+				bones.resize(v.num_bones);
+				for (int n = 0; n < v.num_bones; n++) {
+					bones.set(n, v.bones[n]);
+				}
+				surfaces_tools[surface]->add_bones(bones);
 			}
 			if (lightmap_surfaces[surface].format & ARRAY_FORMAT_WEIGHTS) {
-				surfaces_tools[surface]->add_weights(v.weights);
+				Vector<float> weights;
+				weights.resize(v.num_bones);
+				for (int n = 0; n < v.num_bones; n++) {
+					weights.set(n, v.weights[n]);
+				}
+				surfaces_tools[surface]->add_weights(weights);
 			}
 
 			Vector2 uv2(gen_uvs[gen_indices[i + j] * 2 + 0], gen_uvs[gen_indices[i + j] * 2 + 1]);

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -40,6 +40,8 @@ class SurfaceTool : public Reference {
 
 public:
 	struct Vertex {
+		enum { MAX_BONES = 4 };
+
 		Vector3 vertex;
 		Color color;
 		Vector3 normal; // normal, binormal, tangent
@@ -47,8 +49,10 @@ public:
 		Vector3 tangent;
 		Vector2 uv;
 		Vector2 uv2;
-		Vector<int> bones;
-		Vector<float> weights;
+
+		int16_t bones[MAX_BONES];
+		float weights[MAX_BONES];
+		int32_t num_bones = 0;
 
 		bool operator==(const Vertex &p_vertex) const;
 
@@ -71,11 +75,13 @@ private:
 	bool begun;
 	bool first;
 	Mesh::PrimitiveType primitive;
-	int format;
+	uint32_t format;
 	Ref<Material> material;
+
 	//arrays
-	List<Vertex> vertex_array;
-	List<int> index_array;
+	LocalVector<Vertex> vertex_array;
+	LocalVector<int> index_array;
+
 	Map<int, bool> smooth_groups;
 
 	//memory
@@ -87,8 +93,13 @@ private:
 	Vector<float> last_weights;
 	Plane last_tangent;
 
-	void _create_list_from_arrays(Array arr, List<Vertex> *r_vertex, List<int> *r_index, int &lformat);
-	void _create_list(const Ref<Mesh> &p_existing, int p_surface, List<Vertex> *r_vertex, List<int> *r_index, int &lformat);
+	void _create_list_from_arrays(Array arr, LocalVector<Vertex> *r_vertex, LocalVector<int> *r_index, uint32_t &lformat);
+	void _create_list(const Ref<Mesh> &p_existing, int p_surface, LocalVector<Vertex> *r_vertex, LocalVector<int> *r_index, uint32_t &lformat);
+	void _apply_smoothing_group(HashMap<Vertex, Vector3, VertexHasher> &r_vertex_hash, uint32_t p_from, uint32_t p_to, bool &r_smooth);
+	void _mask_format_flags(uint32_t p_mask) { format &= p_mask; }
+	bool _sanitize_last_bones_and_weights();
+
+	uint32_t get_num_draw_vertices() const { return index_array.size() ? index_array.size() : vertex_array.size(); }
 
 	//mikktspace callbacks
 	static int mikktGetNumFaces(const SMikkTSpaceContext *pContext);
@@ -128,7 +139,7 @@ public:
 
 	void clear();
 
-	List<Vertex> &get_vertex_array() { return vertex_array; }
+	LocalVector<Vertex> &get_vertex_array() { return vertex_array; }
 
 	void create_from_triangle_arrays(const Array &p_arrays);
 	static Vector<Vertex> create_vertex_array_from_triangle_arrays(const Array &p_arrays);


### PR DESCRIPTION
Changed to use LocalVector rather than linked lists.

This is actually part of #61568 but has been separated for easier review.

## Notes
* This is much faster than the previous code (and speed is critical for merging).
* Conversion of `SurfaceTool` to use vectors rather than linked lists has already been done in master.

## Areas of interest
* `Vertex` now has fixed arrays for bones and weights, this allows more efficient access / movement within `LocalVector`s, and we don't support more than 4 bones in 3.x anyway.
* Smoothing groups implementation is slightly altered but the end result should be the same.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
