### PR TITLE
Fix libtheora source code being mistakenly `.gitignore`d

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,6 +242,8 @@ xcuserdata/
 [Rr]eleases/
 x64/
 x86/
+# Not build results, this is Theora source code.
+!thirdparty/libtheora/x86/
 [Ww][Ii][Nn]32/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/


### PR DESCRIPTION
To test this change locally, rename `thirdparty/libtheora/x86/` to `thirdparty/libtheora/x87/` and rename both `x86/` and `!thirdparty/libtheora/x86/` to refer to `x87` instead, then use `git status`.

This closes https://github.com/godotengine/godot/issues/69729.