### PR TITLE
Improve tooltip for CanvasLayer.layer

### DIFF
--- a/doc/classes/CanvasLayer.xml
+++ b/doc/classes/CanvasLayer.xml
@@ -44,7 +44,7 @@
 			Scales the layer when using [member follow_viewport_enabled]. Layers moving into the foreground should have increasing scales, while layers moving into the background should have decreasing scales.
 		</member>
 		<member name="layer" type="int" setter="set_layer" getter="get_layer" default="1">
-			Layer index for draw order. Lower values are drawn first.
+			Layer index for draw order. Lower values are drawn behind higher values.
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The layer's base offset.


### PR DESCRIPTION
For #69716

Improve description to make it clear that layers with a lower value are drawn **behind** layers with higher values

_Production edit: Closes https://github.com/godotengine/godot/issues/69716_
