### PR TITLE
Add remote history to EditorUndoRedoManager

### DIFF
--- a/doc/classes/EditorUndoRedoManager.xml
+++ b/doc/classes/EditorUndoRedoManager.xml
@@ -123,6 +123,9 @@
 		<constant name="GLOBAL_HISTORY" value="0" enum="SpecialHistory">
 			Global history not associated with any scene, but with external resources etc.
 		</constant>
+		<constant name="REMOTE_HISTORY" value="-9" enum="SpecialHistory">
+			History associated with remote inspector. Used when live editing a running project.
+		</constant>
 		<constant name="INVALID_HISTORY" value="-99" enum="SpecialHistory">
 			Invalid "null" history. It's a special value, not associated with any object.
 		</constant>

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -36,6 +36,7 @@
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
+#include "editor/editor_undo_redo_manager.h"
 #include "editor/inspector_dock.h"
 #include "editor/plugins/editor_debugger_plugin.h"
 #include "editor/plugins/script_editor_plugin.h"
@@ -274,6 +275,7 @@ void EditorDebuggerNode::stop(bool p_force) {
 	});
 	_break_state_changed();
 	breakpoints.clear();
+	EditorNode::get_undo_redo()->clear_history(false, EditorUndoRedoManager::REMOTE_HISTORY);
 	set_process(false);
 }
 

--- a/editor/editor_undo_redo_manager.h
+++ b/editor/editor_undo_redo_manager.h
@@ -41,6 +41,7 @@ class EditorUndoRedoManager : public RefCounted {
 public:
 	enum SpecialHistory {
 		GLOBAL_HISTORY = 0,
+		REMOTE_HISTORY = -9,
 		INVALID_HISTORY = -99,
 	};
 


### PR DESCRIPTION
This PR improves how editing objects in remote inspector is handled:
- editing remote objects stores actions in a separate undo history
- remote edits no longer mark the project as unsaved
- remote history is cleared when project is stopped, so you no longer get empty undo actions
- remote actions don't appear in History dock (I could change this if desired)