### PR TITLE
Properly free Skeleton RID in RenderingServer.free()

### DIFF
--- a/drivers/gles3/storage/utilities.cpp
+++ b/drivers/gles3/storage/utilities.cpp
@@ -156,6 +156,9 @@ bool Utilities::free(RID p_rid) {
 	} else if (GLES3::ParticlesStorage::get_singleton()->owns_particles_collision_instance(p_rid)) {
 		GLES3::ParticlesStorage::get_singleton()->particles_collision_instance_free(p_rid);
 		return true;
+	} else if (GLES3::MeshStorage::get_singleton()->owns_skeleton(p_rid)) {
+		GLES3::MeshStorage::get_singleton()->skeleton_free(p_rid);
+		return true;
 	} else {
 		return false;
 	}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/69721