### PR TITLE
[3.x] Fix ERROR: Can't resize PoolVector if locked.

### DIFF
--- a/core/pool_vector.h
+++ b/core/pool_vector.h
@@ -581,6 +581,7 @@ Error PoolVector<T>::resize(int p_size) {
 		MemoryPool::allocs_used++;
 
 		//cleanup the alloc
+		alloc->lock.set(0);
 		alloc->size = 0;
 		alloc->refcount.init();
 		alloc->pool_id = POOL_ALLOCATOR_INVALID_ID;


### PR DESCRIPTION
When resizing a new `PoolVector`, and no allocator has been assigned one is pulled from the `MemoryPool`. Since the memory may be reused, the values are reset. However, currently, the lock value is not. This PR sets the lock value to 0 during this value reset step.

Fixes #69727 