### PR TITLE
Add missing packed scene cache clear inside `GDScriptCache::clear()`

### DIFF
--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -398,6 +398,11 @@ void GDScriptCache::clear() {
 			E->clear();
 	}
 
+	for (KeyValue<String, HashSet<String>> &E : singleton->packed_scene_dependencies) {
+		singleton->packed_scene_dependencies.erase(E.key);
+		singleton->packed_scene_cache.erase(E.key);
+	}
+
 	parser_map_refs.clear();
 	singleton->parser_map.clear();
 	singleton->shallow_gdscript_cache.clear();


### PR DESCRIPTION
Split #69679 `GDScriptCache::clear()` part inside this PR.
Does what the title say.

This is essentially the continuation of #69506.