### PR TITLE
Use capitalized ID in the doc

### DIFF
--- a/doc/classes/CollisionObject2D.xml
+++ b/doc/classes/CollisionObject2D.xml
@@ -157,7 +157,7 @@
 			<param index="0" name="owner_id" type="int" />
 			<param index="1" name="shape_id" type="int" />
 			<description>
-				Returns the [Shape2D] with the given id from the given shape owner.
+				Returns the [Shape2D] with the given ID from the given shape owner.
 			</description>
 		</method>
 		<method name="shape_owner_get_shape_count" qualifiers="const">
@@ -172,7 +172,7 @@
 			<param index="0" name="owner_id" type="int" />
 			<param index="1" name="shape_id" type="int" />
 			<description>
-				Returns the child index of the [Shape2D] with the given id from the given shape owner.
+				Returns the child index of the [Shape2D] with the given ID from the given shape owner.
 			</description>
 		</method>
 		<method name="shape_owner_get_transform" qualifiers="const">

--- a/doc/classes/CollisionObject3D.xml
+++ b/doc/classes/CollisionObject3D.xml
@@ -130,7 +130,7 @@
 			<param index="0" name="owner_id" type="int" />
 			<param index="1" name="shape_id" type="int" />
 			<description>
-				Returns the [Shape3D] with the given id from the given shape owner.
+				Returns the [Shape3D] with the given ID from the given shape owner.
 			</description>
 		</method>
 		<method name="shape_owner_get_shape_count" qualifiers="const">
@@ -145,7 +145,7 @@
 			<param index="0" name="owner_id" type="int" />
 			<param index="1" name="shape_id" type="int" />
 			<description>
-				Returns the child index of the [Shape3D] with the given id from the given shape owner.
+				Returns the child index of the [Shape3D] with the given ID from the given shape owner.
 			</description>
 		</method>
 		<method name="shape_owner_get_transform" qualifiers="const">

--- a/doc/classes/PhysicsPointQueryParameters2D.xml
+++ b/doc/classes/PhysicsPointQueryParameters2D.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="canvas_instance_id" type="int" setter="set_canvas_instance_id" getter="get_canvas_instance_id" default="0">
-			If different from [code]0[/code], restricts the query to a specific canvas layer specified by its instance id. See [method Object.get_instance_id].
+			If different from [code]0[/code], restricts the query to a specific canvas layer specified by its instance ID. See [method Object.get_instance_id].
 		</member>
 		<member name="collide_with_areas" type="bool" setter="set_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">
 			If [code]true[/code], the query will take [Area2D]s into account.

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -206,7 +206,7 @@
 			<return type="int" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the id of the item at the given [param index]. [code]id[/code] can be manually assigned, while index can not.
+				Returns the ID of the item at the given [param index]. [code]id[/code] can be manually assigned, while index can not.
 			</description>
 		</method>
 		<method name="get_item_indent" qualifiers="const">

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1295,13 +1295,13 @@
 		<method name="get_test_cube">
 			<return type="RID" />
 			<description>
-				Returns the id of the test cube. Creates one if none exists.
+				Returns the ID of the test cube. Creates one if none exists.
 			</description>
 		</method>
 		<method name="get_test_texture">
 			<return type="RID" />
 			<description>
-				Returns the id of the test texture. Creates one if none exists.
+				Returns the ID of the test texture. Creates one if none exists.
 			</description>
 		</method>
 		<method name="get_video_adapter_api_version" qualifiers="const">
@@ -1335,7 +1335,7 @@
 		<method name="get_white_texture">
 			<return type="RID" />
 			<description>
-				Returns the id of a white texture. Creates one if none exists.
+				Returns the ID of a white texture. Creates one if none exists.
 			</description>
 		</method>
 		<method name="gi_set_use_half_resolution">

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -235,7 +235,7 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<description>
-				Returns resource id of the cache texture containing the glyph.
+				Returns resource ID of the cache texture containing the glyph.
 				[b]Note:[/b] If there are pending glyphs to render, calling this function might trigger the texture cache update.
 			</description>
 		</method>

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -70,7 +70,7 @@
 			<return type="int" />
 			<param index="0" name="position" type="Vector2" />
 			<description>
-				Returns the button id at [param position], or -1 if no button is there.
+				Returns the button ID at [param position], or -1 if no button is there.
 			</description>
 		</method>
 		<method name="get_column_at_position" qualifiers="const">

--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -78,7 +78,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="id" type="int" />
 			<description>
-				Returns the button index if there is a button with id [param id] in column [param column], otherwise returns -1.
+				Returns the button index if there is a button with ID [param id] in column [param column], otherwise returns -1.
 			</description>
 		</method>
 		<method name="get_button_count" qualifiers="const">
@@ -93,7 +93,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="button_idx" type="int" />
 			<description>
-				Returns the id for the button at index [param button_idx] in column [param column].
+				Returns the ID for the button at index [param button_idx] in column [param column].
 			</description>
 		</method>
 		<method name="get_button_tooltip_text" qualifiers="const">

--- a/doc/classes/XRInterfaceExtension.xml
+++ b/doc/classes/XRInterfaceExtension.xml
@@ -24,7 +24,7 @@
 		<method name="_get_camera_feed_id" qualifiers="virtual const">
 			<return type="int" />
 			<description>
-				Returns the camera feed id for the [CameraFeed] registered with the [CameraServer] that should be presented as the background on an AR capable device (if applicable).
+				Returns the camera feed ID for the [CameraFeed] registered with the [CameraServer] that should be presented as the background on an AR capable device (if applicable).
 			</description>
 		</method>
 		<method name="_get_camera_transform" qualifiers="virtual">

--- a/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
+++ b/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
@@ -17,7 +17,7 @@
 			<param index="0" name="filter" type="Callable" />
 			<description>
 				Adds a peer visibility filter for this synchronizer.
-				[code]filter[/code] should take a peer id [int] and return a [bool].
+				[code]filter[/code] should take a peer ID [int] and return a [bool].
 			</description>
 		</method>
 		<method name="get_visibility_for" qualifiers="const">

--- a/modules/webrtc/doc_classes/WebRTCDataChannel.xml
+++ b/modules/webrtc/doc_classes/WebRTCDataChannel.xml
@@ -22,8 +22,8 @@
 		<method name="get_id" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the id assigned to this channel during creation (or auto-assigned during negotiation).
-				If the channel is not negotiated out-of-band the id will only be available after the connection is established (will return [code]65535[/code] until then).
+				Returns the ID assigned to this channel during creation (or auto-assigned during negotiation).
+				If the channel is not negotiated out-of-band the ID will only be available after the connection is established (will return [code]65535[/code] until then).
 			</description>
 		</method>
 		<method name="get_label" qualifiers="const">


### PR DESCRIPTION
As per https://github.com/godotengine/godot/pull/69695#pullrequestreview-1208020708

The remaining lowercase `id`s in the documentation are part of the sample code.