### PR TITLE
Update tile source icons when editor theme changes

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -472,6 +472,7 @@ void TileMapEditorTilesPlugin::_update_theme() {
 	random_tile_toggle->set_icon(tiles_bottom_panel->get_theme_icon(SNAME("RandomNumberGenerator"), SNAME("EditorIcons")));
 
 	missing_atlas_texture_icon = tiles_bottom_panel->get_theme_icon(SNAME("TileSet"), SNAME("EditorIcons"));
+	_update_tile_set_sources_list();
 }
 
 bool TileMapEditorTilesPlugin::forward_canvas_gui_input(const Ref<InputEvent> &p_event) {

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -346,6 +346,7 @@ void TileSetEditor::_notification(int p_what) {
 			source_sort_button->set_icon(get_theme_icon(SNAME("Sort"), SNAME("EditorIcons")));
 			sources_advanced_menu_button->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 			missing_texture_texture = get_theme_icon(SNAME("TileSet"), SNAME("EditorIcons"));
+			_update_sources_list();
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {


### PR DESCRIPTION
The tile source list shows editor icons for some items. It should be updated when editor theme changes (e.g. switching between dark and light themes).

![ksnip_20221208-121240](https://user-images.githubusercontent.com/372476/206354855-16f41683-c747-4f03-9421-de808e61e589.png)
