### PR TITLE
RichTextLabel: decouple meta cursor from underline

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1854,10 +1854,6 @@ void RichTextLabel::_notification(int p_what) {
 }
 
 Control::CursorShape RichTextLabel::get_cursor_shape(const Point2 &p_pos) const {
-	if (!underline_meta) {
-		return get_default_cursor_shape();
-	}
-
 	if (selection.click_item) {
 		return CURSOR_IBEAM;
 	}


### PR DESCRIPTION
This commit decouples the type of cursor used when the underline of meta tag is set to False. Previous to this commit setting the meta underline to false in the RichTextLabel would also make it show the arrow cursor instead of the hand cursor.

Making the meta tag with no underline should not have any effect on the type of cursor, since the text will still be clickable it should be expected to have a hand cursor.

The same behavior is seen in other languages, like HTML+CSS, where the setting "text-decoration" to "none" for the links, disables the underline but maintains the clickable cursor.

Fixes godotengine/godot-proposals#3193