### PR TITLE
Remove AnimationTree implicit volume overwrite AudioStreamPlayer

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1539,8 +1539,6 @@ void AnimationTree::_process_graph(double p_delta) {
 							}
 						}
 
-						real_t db = Math::linear_to_db(MAX(blend, 0.00001));
-						t->object->call(SNAME("set_volume_db"), db);
 					} break;
 					case Animation::TYPE_ANIMATION: {
 						TrackCacheAnimation *t = static_cast<TrackCacheAnimation *>(track);


### PR DESCRIPTION
Fixes #69746, #65750.

Since AnimationTree AudioTrack overwrite the volume of AudioStreamPlayer implicitly when blending, there is no way to work around this, and it is very inconvenient.

I have approached to solve this issue many times #65750 #49099 in the past, but all have been rejected because @reduz decides that it needs to be fixed at a much lower layer.

For now, I simply remove this "implicit overwrite" to make AudioTrack usable.

If the same functionality is needed, it can be reproduced by setting the linear_to_db() interface as a exported property in extended AudioStreamPlayer and setting the value in ValueTrack on the user side.

So, I believe removing this feature should not be a problem to make AudioTrack usable. And the fundamental improvements mentioned by reduz should be able to be added later.

<i>Bugsquad edit:</i> Fix #65750