### PR TITLE
TouchScreenButton: Fix screen capability check

### DIFF
--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -100,7 +100,7 @@ void TouchScreenButton::_notification(int p_what) {
 			if (!is_inside_tree()) {
 				return;
 			}
-			if (!Engine::get_singleton()->is_editor_hint() && !!DisplayServer::get_singleton()->is_touchscreen_available() && visibility == VISIBILITY_TOUCHSCREEN_ONLY) {
+			if (!Engine::get_singleton()->is_editor_hint() && !DisplayServer::get_singleton()->is_touchscreen_available() && visibility == VISIBILITY_TOUCHSCREEN_ONLY) {
 				return;
 			}
 
@@ -137,7 +137,7 @@ void TouchScreenButton::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
-			if (!Engine::get_singleton()->is_editor_hint() && !!DisplayServer::get_singleton()->is_touchscreen_available() && visibility == VISIBILITY_TOUCHSCREEN_ONLY) {
+			if (!Engine::get_singleton()->is_editor_hint() && !DisplayServer::get_singleton()->is_touchscreen_available() && visibility == VISIBILITY_TOUCHSCREEN_ONLY) {
 				return;
 			}
 			queue_redraw();


### PR DESCRIPTION
Fixes #69572.

Thanks @spatker for identifying the issue and the likely fix.

I haven't tested the change but it seems clear that the previous logic was wrong.
The code in `3.x` is correct and matches what this PR restores:
```cpp
if (!Engine::get_singleton()->is_editor_hint() && !OS::get_singleton()->has_touchscreen_ui_hint() && visibility == VISIBILITY_TOUCHSCREEN_ONLY)
```