### PR TITLE
Move navigation server finalize before physics server

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3363,6 +3363,7 @@ void Main::cleanup(bool p_force) {
 	finalize_theme_db();
 
 	// Before deinitializing server extensions, finalize servers which may be loaded as extensions.
+	finalize_navigation_server();
 	finalize_physics();
 
 	NativeExtensionManager::get_singleton()->deinitialize_extensions(NativeExtension::INITIALIZATION_LEVEL_SERVERS);
@@ -3386,7 +3387,6 @@ void Main::cleanup(bool p_force) {
 
 	OS::get_singleton()->finalize();
 
-	finalize_navigation_server();
 	finalize_display();
 
 	if (input) {


### PR DESCRIPTION
In `Main::cleanup()`, moves `finalize_navigation_server()` just before `finalize_physics()`, as visibly, some shapes were stored by the navigation server. Uninitializing those shapes after `finalize_physics()` leads to a memory leak.

Fixes #69750 - Boxshape leaks at the end of program