### PR TITLE
Fix BackBufferCopy `rect` property appearing when not relevant in inspector (3.x)

### DIFF
--- a/doc/classes/BackBufferCopy.xml
+++ b/doc/classes/BackBufferCopy.xml
@@ -4,8 +4,8 @@
 		Copies a region of the screen (or the whole screen) to a buffer so it can be accessed in your shader scripts through the [code]texture(SCREEN_TEXTURE, ...)[/code] function.
 	</brief_description>
 	<description>
-		Node for back-buffering the currently-displayed screen. The region defined in the BackBufferCopy node is buffered with the content of the screen it covers, or the entire screen according to the copy mode set. Use the [code]texture(SCREEN_TEXTURE, ...)[/code] function in your shader scripts to access the buffer.
-		[b]Note:[/b] Since this node inherits from [Node2D] (and not [Control]), anchors and margins won't apply to child [Control]-derived nodes. This can be problematic when resizing the window. To avoid this, add [Control]-derived nodes as [i]siblings[/i] to the BackBufferCopy node instead of adding them as children.
+		Node for back-buffering the currently-displayed screen. The region defined in the [BackBufferCopy] node is buffered with the content of the screen it covers, or the entire screen according to the copy mode set. Use the [code]texture(SCREEN_TEXTURE, ...)[/code] function in your shader scripts to access the buffer.
+		[b]Note:[/b] Since this node inherits from [Node2D] (and not [Control]), anchors and margins won't apply to child [Control]-derived nodes. This can be problematic when resizing the window. To avoid this, add [Control]-derived nodes as [i]siblings[/i] to the [BackBufferCopy] node instead of adding them as children.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -16,18 +16,18 @@
 			Buffer mode. See [enum CopyMode] constants.
 		</member>
 		<member name="rect" type="Rect2" setter="set_rect" getter="get_rect" default="Rect2( -100, -100, 200, 200 )">
-			The area covered by the BackBufferCopy. Only used if [member copy_mode] is [constant COPY_MODE_RECT].
+			The area covered by the [BackBufferCopy]. Only used if [member copy_mode] is [constant COPY_MODE_RECT].
 		</member>
 	</members>
 	<constants>
 		<constant name="COPY_MODE_DISABLED" value="0" enum="CopyMode">
-			Disables the buffering mode. This means the BackBufferCopy node will directly use the portion of screen it covers.
+			Disables the buffering mode. This means the [BackBufferCopy] node will directly use the portion of screen it covers.
 		</constant>
 		<constant name="COPY_MODE_RECT" value="1" enum="CopyMode">
-			BackBufferCopy buffers a rectangular region.
+			[BackBufferCopy] buffers a rectangular region.
 		</constant>
 		<constant name="COPY_MODE_VIEWPORT" value="2" enum="CopyMode">
-			BackBufferCopy buffers the entire screen.
+			[BackBufferCopy] buffers the entire screen.
 		</constant>
 	</constants>
 </class>

--- a/scene/2d/back_buffer_copy.cpp
+++ b/scene/2d/back_buffer_copy.cpp
@@ -71,9 +71,17 @@ Rect2 BackBufferCopy::get_rect() const {
 void BackBufferCopy::set_copy_mode(CopyMode p_mode) {
 	copy_mode = p_mode;
 	_update_copy_mode();
+	_change_notify();
 }
+
 BackBufferCopy::CopyMode BackBufferCopy::get_copy_mode() const {
 	return copy_mode;
+}
+
+void BackBufferCopy::_validate_property(PropertyInfo &p_property) const {
+	if (copy_mode != COPY_MODE_RECT && p_property.name == "rect") {
+		p_property.usage = PROPERTY_USAGE_NOEDITOR;
+	}
 }
 
 void BackBufferCopy::_bind_methods() {

--- a/scene/2d/back_buffer_copy.h
+++ b/scene/2d/back_buffer_copy.h
@@ -51,6 +51,7 @@ private:
 
 protected:
 	static void _bind_methods();
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/69774.

The `rect` property is only effective if `copy_mode` is Rect.

This closes https://github.com/godotengine/godot/issues/69772