### PR TITLE
Fix autocomplete crash as it would infinite loop

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1612,7 +1612,7 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 						}
 					}
 
-					if (!found) {
+					if (!found && base.value.get_type() != Variant::NIL) {
 						found = _guess_method_return_type_from_base(c, base, call->function_name, r_type);
 					}
 				}


### PR DESCRIPTION
Adds a check before calling `_guess_method_return_type_from_base()` inside `_guess_expression_type()` of `modules/gdscript/gdscript_editor.cpp`. Assures that the `base.value` variant is not `nil`. Otherwise, it can lead to an infinite loop if `_guess_method_return_type_from_base()` calls back `_guess_expression_type()`­.

Will need to be tested to know if there's not side effects to this added test.

Fixes #69779 - Editor Crashes On Autocomplete With Custom Classes In Some Circumstances