### PR TITLE
Web: Fix side module build with Embree

### DIFF
--- a/thirdparty/embree/common/sys/sysinfo.cpp
+++ b/thirdparty/embree/common/sys/sysinfo.cpp
@@ -640,6 +640,12 @@ namespace embree
 
 #if defined(__EMSCRIPTEN__)
 #include <emscripten.h>
+
+// -- GODOT start --
+extern "C" {
+extern int godot_js_os_hw_concurrency_get();
+}
+// -- GODOT end --
 #endif
 
 namespace embree
@@ -653,21 +659,9 @@ namespace embree
     nThreads = sysconf(_SC_NPROCESSORS_ONLN); // does not work in Linux LXC container
     assert(nThreads);
 #elif defined(__EMSCRIPTEN__)
-    // WebAssembly supports pthreads, but not pthread_getaffinity_np. Get the number of logical
-    // threads from the browser or Node.js using JavaScript.
-    nThreads = MAIN_THREAD_EM_ASM_INT({
-        const isBrowser = typeof window !== 'undefined';
-        const isNode = typeof process !== 'undefined' && process.versions != null &&
-            process.versions.node != null;
-        if (isBrowser) {
-            // Return 1 if the browser does not expose hardwareConcurrency.
-            return window.navigator.hardwareConcurrency || 1;
-        } else if (isNode) {
-            return require('os').cpus().length;
-        } else {
-            return 1;
-        }
-    });
+    // -- GODOT start --
+    nThreads = godot_js_os_hw_concurrency_get();
+    // -- GODOT end --
 #else
     cpu_set_t set;
     if (pthread_getaffinity_np(pthread_self(), sizeof(set), &set) == 0)

--- a/thirdparty/embree/patches/emscripten-nthreads.patch
+++ b/thirdparty/embree/patches/emscripten-nthreads.patch
@@ -1,0 +1,42 @@
+diff --git a/thirdparty/embree/common/sys/sysinfo.cpp b/thirdparty/embree/common/sys/sysinfo.cpp
+index c98f61fa53..7f7a009a1e 100644
+--- a/thirdparty/embree/common/sys/sysinfo.cpp
++++ b/thirdparty/embree/common/sys/sysinfo.cpp
+@@ -640,6 +640,12 @@ namespace embree
+ 
+ #if defined(__EMSCRIPTEN__)
+ #include <emscripten.h>
++
++// -- GODOT start --
++extern "C" {
++extern int godot_js_os_hw_concurrency_get();
++}
++// -- GODOT end --
+ #endif
+ 
+ namespace embree
+@@ -653,21 +659,9 @@ namespace embree
+     nThreads = sysconf(_SC_NPROCESSORS_ONLN); // does not work in Linux LXC container
+     assert(nThreads);
+ #elif defined(__EMSCRIPTEN__)
+-    // WebAssembly supports pthreads, but not pthread_getaffinity_np. Get the number of logical
+-    // threads from the browser or Node.js using JavaScript.
+-    nThreads = MAIN_THREAD_EM_ASM_INT({
+-        const isBrowser = typeof window !== 'undefined';
+-        const isNode = typeof process !== 'undefined' && process.versions != null &&
+-            process.versions.node != null;
+-        if (isBrowser) {
+-            // Return 1 if the browser does not expose hardwareConcurrency.
+-            return window.navigator.hardwareConcurrency || 1;
+-        } else if (isNode) {
+-            return require('os').cpus().length;
+-        } else {
+-            return 1;
+-        }
+-    });
++    // -- GODOT start --
++    nThreads = godot_js_os_hw_concurrency_get();
++    // -- GODOT end --
+ #else
+     cpu_set_t set;
+     if (pthread_getaffinity_np(pthread_self(), sizeof(set), &set) == 0)


### PR DESCRIPTION
Using `EM_ASM` here would cause this error in `dlink_enabled=yes` template builds:
```
EM_ASM is not supported in side modules
```
We use our own method for this since it already handles this properly.

This became necessary after #69169.