### PR TITLE
Fix changing of visual shader mode

### DIFF
--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -96,6 +96,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual String get_name() const override { return "Shader"; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;


### PR DESCRIPTION
Currently, changing the mode on visual shader resource has no effect:

![bug](https://user-images.githubusercontent.com/3036176/206654348-322af249-3158-40c9-ad83-d758cefddf10.gif)
