### PR TITLE
Fixed scene name can be saved as extension only

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -472,6 +472,14 @@ void EditorFileDialog::_action_pressed() {
 			}
 		}
 
+		// First check we're not having an empty name.
+		String file_name = file_text.strip_edges().get_file();
+		if (file_name.is_empty()) {
+			error_dialog->set_text(TTR("Cannot save file with an empty filename."));
+			error_dialog->popup_centered(Size2(250, 80) * EDSCALE);
+			return;
+		}
+
 		// Add first extension of filter if no valid extension is found.
 		if (!valid) {
 			int idx = filter->get_selected();
@@ -480,9 +488,15 @@ void EditorFileDialog::_action_pressed() {
 			f += "." + ext;
 		}
 
+		if (file_name.begins_with(".")) { // Could still happen if typed manually.
+			error_dialog->set_text(TTR("Cannot save file with a name starting with a dot."));
+			error_dialog->popup_centered(Size2(250, 80) * EDSCALE);
+			return;
+		}
+
 		if (dir_access->file_exists(f) && !disable_overwrite_warning) {
-			confirm_save->set_text(TTR("File exists, overwrite?"));
-			confirm_save->popup_centered(Size2(200, 80));
+			confirm_save->set_text(vformat(TTR("File \"%s\" already exists.\nDo you want to overwrite it?"), f));
+			confirm_save->popup_centered(Size2(250, 80) * EDSCALE);
 		} else {
 			_save_to_recent();
 			hide();

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -347,14 +347,15 @@ void FileDialog::_action_pressed() {
 			}
 		}
 
-		if (!valid) {
+		String file_name = file_text.strip_edges().get_file();
+		if (!valid || file_name.is_empty()) {
 			exterr->popup_centered(Size2(250, 80));
 			return;
 		}
 
 		if (dir_access->file_exists(f)) {
-			confirm_save->set_text(RTR("File exists, overwrite?"));
-			confirm_save->popup_centered(Size2(200, 80));
+			confirm_save->set_text(vformat(RTR("File \"%s\" already exists.\nDo you want to overwrite it?"), f));
+			confirm_save->popup_centered(Size2(250, 80));
 		} else {
 			emit_signal(SNAME("file_selected"), f);
 			hide();
@@ -1136,7 +1137,7 @@ FileDialog::FileDialog() {
 	add_child(mkdirerr, false, INTERNAL_MODE_FRONT);
 
 	exterr = memnew(AcceptDialog);
-	exterr->set_text(RTR("Must use a valid extension."));
+	exterr->set_text(RTR("Invalid extension, or empty filename."));
 	add_child(exterr, false, INTERNAL_MODE_FRONT);
 
 	update_filters();


### PR DESCRIPTION
Fixes: #69768

This is a bug. In the Windows system, the filename cannot be empty.

Also, the Windows system does not allow filenames to contain only space characters or start with space characters. But these restrictions do not apply to the "New Scene" dialog.