### PR TITLE
Fix TileMap redrawing itself twice on creation

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -995,9 +995,11 @@ void TileMap::_recompute_rect_cache() {
 		}
 	}
 
+	bool changed = rect_cache != r_total;
+
 	rect_cache = r_total;
 
-	item_rect_changed();
+	item_rect_changed(changed);
 
 	rect_cache_dirty = false;
 #endif


### PR DESCRIPTION
Adds a check before calling `item_rect_changed()` in `_recompute_rect_cache()` of `scene/2d/tile_map.cpp`. Makes sure TileMap is only redrawn if the rect is actually changed. Fixes #69754

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
