### PR TITLE
Use the consistent stream

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -930,18 +930,25 @@ Error ResourceLoaderText::rename_dependencies(Ref<FileAccess> p_f, const String 
 				String type = next_tag.fields["type"];
 				fw->store_line("[sub_resource type=\"" + type + "\" id=\"" + id + "\"]");
 			} else if (next_tag.name == "node") {
-				if (!next_tag.fields.has("name") || !next_tag.fields.has("type") || next_tag.fields.has("parent")) {
+				if (!next_tag.fields.has("name") || (next_tag.fields.has("type") == next_tag.fields.has("instance")) || next_tag.fields.has("parent")) {
 					error = ERR_FILE_CORRUPT;
 					ERR_FAIL_V(error);
 				}
 				fw->store_line(String());
 				String name = next_tag.fields["name"];
-				String type = next_tag.fields["type"];
-
-				String s = "[node name=\"" + name + "\" type=\"" + type + "\"";
+				String s = "[node name=\"" + name + "\"";
+				if (next_tag.fields.has("type")) {
+					String type = next_tag.fields["type"];
+					s += " type=\"" + type + "\"";
+				}
 				if (next_tag.fields.has("groups")) {
 					String groups = next_tag.fields["groups"];
 					s += " groups=" + groups;
+				}
+				if (next_tag.fields.has("instance")) {
+					Variant instance = next_tag.fields["instance"];
+					ERR_FAIL_COND_V_EDMSG(!instance.is_null(), ERR_PARSE_ERROR, instance);
+					s += " instance=" + stringify_variants(instance);
 				}
 				s += "]";
 				fw->store_line(s);


### PR DESCRIPTION
Fix #69794.

`stream` uses a buffer to read the file, so the position information of `f` is unreliable.

When the `next_tag` is parsed, the position of the stream is moved to the end of the line, so the `next_tag` information needs to be saved in `fw`, and then copied.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
