### PR TITLE
[3.x] Store Bullet total gravity, linear damp and angular damp calculations

### DIFF
--- a/modules/bullet/rigid_body_bullet.h
+++ b/modules/bullet/rigid_body_bullet.h
@@ -168,6 +168,9 @@ private:
 	real_t gravity_scale;
 	real_t linearDamp;
 	real_t angularDamp;
+	Vector3 total_gravity;
+	real_t total_linear_damp;
+	real_t total_angular_damp;
 	bool can_sleep;
 	bool omit_forces_integration;
 	bool can_integrate_forces;


### PR DESCRIPTION
Stores Bullet's total gravity, linear damp and angular damp calculations. This is required so the values can be retrieved from `PhysicsDirectBodyState` when using the Custom Integrator.

Fixes #65773

Bullet has been removed from master; so this is a 3.x PR only.