### PR TITLE
Fade out SSR with roughness so that it doesn't show at high roughness amounts

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
@@ -212,6 +212,9 @@ void main() {
 		float grad = (steps_taken + 1.0) / float(params.num_steps);
 		float initial_fade = params.curve_fade_in == 0.0 ? 1.0 : pow(clamp(grad, 0.0, 1.0), params.curve_fade_in);
 		float fade = pow(clamp(1.0 - grad, 0.0, 1.0), params.distance_fade) * initial_fade;
+		// This is an ad-hoc term to fade out the SSR as roughness increases. Values used
+		// are meant to match the visual appearance of a ReflectionProbe.
+		float roughness_fade = smoothstep(0.4, 0.7, 1.0 - normal_roughness.w);
 		final_pos = pos;
 
 		vec4 final_color;
@@ -246,7 +249,7 @@ void main() {
 
 #endif // MODE_ROUGH
 
-		final_color = vec4(imageLoad(source_diffuse, ivec2(final_pos - 0.5)).rgb, fade * margin_blend);
+		final_color = vec4(imageLoad(source_diffuse, ivec2(final_pos - 0.5)).rgb, fade * margin_blend * roughness_fade);
 
 		// Schlick term.
 		float metallic = texelFetch(source_metallic, ssC << 1, 0).w;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/66285

This is an ad hoc change to visually match the output of ReflectionProbes, SDFGI, and VoxelGI.

<details>
  <summary>Roughness: 1</summary>
  
_Before:_

![Screenshot from 2022-12-09 12-57-55](https://user-images.githubusercontent.com/16521339/206797174-b8c0c9b9-7dd8-4de4-9dc4-9872fb4d0826.png)

_After:_

![Screenshot from 2022-12-09 13-20-11](https://user-images.githubusercontent.com/16521339/206797869-f3cb3eda-b934-4e4a-a199-0e5d68c1f284.png)

</details>

<details>
  <summary>Roughness: 0.5</summary>
  
You'll notice at 0.5 roughness SSR now starts to fade out

_Before:_

![Screenshot from 2022-12-09 12-57-50](https://user-images.githubusercontent.com/16521339/206797177-1853d570-f975-4cde-817a-707bd0a24ea1.png)

_After:_

![Screenshot from 2022-12-09 13-20-05](https://user-images.githubusercontent.com/16521339/206797875-30dff572-8f66-4bf1-84b0-24cd3df4e633.png)

</details>

<details>
  <summary>Roughness: 0.0 (no change)</summary>
  
_Before:_

![Screenshot from 2022-12-09 12-57-45](https://user-images.githubusercontent.com/16521339/206797182-fb46618d-5cdf-4257-8ee6-8859ffeddf6a.png)

_After:_

![Screenshot from 2022-12-09 13-20-00](https://user-images.githubusercontent.com/16521339/206797881-af32df10-d6db-4171-9b82-0a631a5286c7.png)

</details>
