### PR TITLE
Remove warning when playing random no-repeat sound with only 1 sound in pool

### DIFF
--- a/doc/classes/AudioStreamRandomizer.xml
+++ b/doc/classes/AudioStreamRandomizer.xml
@@ -78,13 +78,13 @@
 	</members>
 	<constants>
 		<constant name="PLAYBACK_RANDOM_NO_REPEATS" value="0" enum="PlaybackMode">
-			Pick a stream at random according to the probability weights chosen for each stream, but avoid playing the same stream twice in a row whenever possible.
+			Pick a stream at random according to the probability weights chosen for each stream, but avoid playing the same stream twice in a row whenever possible. If only 1 sound is present in the pool, the same sound will always play, effectively allowing repeats to occur.
 		</constant>
 		<constant name="PLAYBACK_RANDOM" value="1" enum="PlaybackMode">
-			Pick a stream at random according to the probability weights chosen for each stream.
+			Pick a stream at random according to the probability weights chosen for each stream. If only 1 sound is present in the pool, the same sound will always play.
 		</constant>
 		<constant name="PLAYBACK_SEQUENTIAL" value="2" enum="PlaybackMode">
-			Play streams in the order they appear in the stream pool.
+			Play streams in the order they appear in the stream pool. If only 1 sound is present in the pool, the same sound will always play.
 		</constant>
 	</constants>
 </class>

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -555,8 +555,9 @@ Ref<AudioStreamPlayback> AudioStreamRandomizer::instance_playback_no_repeats() {
 		}
 	}
 	if (local_pool.is_empty()) {
+		// There is only one sound to choose from.
+		// Always play a random sound while allowing repeats (which always plays the same sound).
 		playback = instance_playback_random();
-		WARN_PRINT("Playback stream pool is too small to prevent repeats.");
 		return playback;
 	}
 


### PR DESCRIPTION
This makes setting up sounds for random pitch/volume faster, as you don't have to change the mode from Random (Avoid Repeats) to Random anymore if you only care about randomizing pitch/volume but want to prevent a warning message from appearing on every playback.

**Note:** Not cherry-pickable to `3.x`, as this feature isn't implemented there.