### PR TITLE
Fix crash caused by invalid `mix_rate` assignment due to bogus project settings.

### DIFF
--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -44,7 +44,8 @@ extern int initialize_pulse(int verbose);
 #endif
 
 Error AudioDriverALSA::init_output_device() {
-	mix_rate = GLOBAL_GET("audio/driver/mix_rate");
+	mix_rate = _get_configured_mix_rate();
+
 	speaker_mode = SPEAKER_MODE_STEREO;
 	channels = 2;
 

--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -116,7 +116,7 @@ Error AudioDriverCoreAudio::init() {
 			break;
 	}
 
-	mix_rate = GLOBAL_GET("audio/driver/mix_rate");
+	mix_rate = _get_configured_mix_rate();
 
 	memset(&strdesc, 0, sizeof(strdesc));
 	strdesc.mFormatID = kAudioFormatLinearPCM;
@@ -405,7 +405,7 @@ Error AudioDriverCoreAudio::init_input_device() {
 			break;
 	}
 
-	mix_rate = GLOBAL_GET("audio/driver/mix_rate");
+	mix_rate = _get_configured_mix_rate();
 
 	memset(&strdesc, 0, sizeof(strdesc));
 	strdesc.mFormatID = kAudioFormatLinearPCM;

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -293,7 +293,7 @@ Error AudioDriverPulseAudio::init() {
 	active.clear();
 	exit_thread.clear();
 
-	mix_rate = GLOBAL_GET("audio/driver/mix_rate");
+	mix_rate = _get_configured_mix_rate();
 
 	pa_ml = pa_mainloop_new();
 	ERR_FAIL_COND_V(pa_ml == nullptr, ERR_CANT_OPEN);

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -547,7 +547,7 @@ Error AudioDriverWASAPI::finish_input_device() {
 }
 
 Error AudioDriverWASAPI::init() {
-	mix_rate = GLOBAL_GET("audio/driver/mix_rate");
+	mix_rate = _get_configured_mix_rate();
 
 	target_latency_ms = GLOBAL_GET("audio/driver/output_latency");
 

--- a/drivers/xaudio2/audio_driver_xaudio2.cpp
+++ b/drivers/xaudio2/audio_driver_xaudio2.cpp
@@ -39,7 +39,8 @@ Error AudioDriverXAudio2::init() {
 	pcm_open = false;
 	samples_in = nullptr;
 
-	mix_rate = GLOBAL_GET("audio/driver/mix_rate");
+	mix_rate = _get_configured_mix_rate();
+
 	// FIXME: speaker_mode seems unused in the Xaudio2 driver so far
 	speaker_mode = SPEAKER_MODE_STEREO;
 	channels = 2;

--- a/platform/web/audio_driver_web.cpp
+++ b/platform/web/audio_driver_web.cpp
@@ -103,7 +103,7 @@ void AudioDriverWeb::_audio_driver_capture(int p_from, int p_samples) {
 Error AudioDriverWeb::init() {
 	int latency = GLOBAL_GET("audio/driver/output_latency");
 	if (!audio_context.inited) {
-		audio_context.mix_rate = GLOBAL_GET("audio/driver/mix_rate");
+		audio_context.mix_rate = _get_configured_mix_rate();
 		audio_context.channel_count = godot_audio_init(&audio_context.mix_rate, latency, &_state_change_callback, &_latency_update_callback);
 		audio_context.inited = true;
 	}

--- a/servers/audio/audio_driver_dummy.cpp
+++ b/servers/audio/audio_driver_dummy.cpp
@@ -41,7 +41,7 @@ Error AudioDriverDummy::init() {
 	samples_in = nullptr;
 
 	if (mix_rate == -1) {
-		mix_rate = GLOBAL_GET("audio/driver/mix_rate");
+		mix_rate = _get_configured_mix_rate();
 	}
 
 	channels = get_channels();

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -115,6 +115,20 @@ void AudioDriver::input_buffer_write(int32_t sample) {
 	}
 }
 
+int AudioDriver::_get_configured_mix_rate() {
+	StringName audio_driver_setting = "audio/driver/mix_rate";
+	int mix_rate = GLOBAL_GET(audio_driver_setting);
+
+	// In the case of invalid mix rate, let's default to a sensible value..
+	if (mix_rate <= 0) {
+		WARN_PRINT(vformat("Invalid mix rate of %d, consider reassigning setting \'%s\'. \nDefaulting mix rate to value %d.",
+				mix_rate, audio_driver_setting, AudioDriverManager::DEFAULT_MIX_RATE));
+		mix_rate = AudioDriverManager::DEFAULT_MIX_RATE;
+	}
+
+	return mix_rate;
+}
+
 AudioDriver::SpeakerMode AudioDriver::get_speaker_mode_by_total_channels(int p_channels) const {
 	switch (p_channels) {
 		case 4:

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -66,6 +66,8 @@ protected:
 	void input_buffer_init(int driver_buffer_frames);
 	void input_buffer_write(int32_t sample);
 
+	int _get_configured_mix_rate();
+
 #ifdef DEBUG_ENABLED
 	_FORCE_INLINE_ void start_counting_ticks() { prof_ticks = OS::get_singleton()->get_ticks_usec(); }
 	_FORCE_INLINE_ void stop_counting_ticks() { prof_time += OS::get_singleton()->get_ticks_usec() - prof_ticks; }
@@ -136,7 +138,6 @@ class AudioDriverManager {
 		MAX_DRIVERS = 10
 	};
 
-	static const int DEFAULT_MIX_RATE = 44100;
 	static const int DEFAULT_OUTPUT_LATENCY = 15;
 
 	static AudioDriver *drivers[MAX_DRIVERS];
@@ -145,6 +146,8 @@ class AudioDriverManager {
 	static AudioDriverDummy dummy_driver;
 
 public:
+	static const int DEFAULT_MIX_RATE = 44100;
+
 	static void add_driver(AudioDriver *p_driver);
 	static void initialize(int p_driver);
 	static int get_driver_count();


### PR DESCRIPTION
I noticed this bug come in that was related to code I was already looking over for other reasons, so I decided to fix it.

We'll just default to a sensible value in the case that a user has somehow managed to modify the configuration file incorrectly. 44100hz feels like the appropriate default, but if there's a constant somewhere defined let me know and I'll change it to that. Otherwise, I'll change the code to use a constant so the fallback makes sense on a system-by-system basis and is easy to change.

It seems like, to me, there shouldn't be a case where we're loading the audio driver at all with an improper `mix_rate`, but I could be wrong. In which case, we will simply make exceptions for the `divide by zero` error. 

Closes #69819
