### PR TITLE
Fix crash caused by non-deferred signal connection for `_property_keyed`

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -661,9 +661,10 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (keying_rect.has_point(mpos)) {
 			accept_event();
-			emit_signal(SNAME("property_keyed"), property, use_keying_next());
+			const bool l_keying_next = use_keying_next();
+			emit_signal(SNAME("property_keyed"), property, l_keying_next);
 
-			if (use_keying_next()) {
+			if (l_keying_next) {
 				if (property == "frame_coords" && (object->is_class("Sprite2D") || object->is_class("Sprite3D"))) {
 					Vector2i new_coords = object->get(property);
 					new_coords.x++;
@@ -2528,7 +2529,7 @@ void EditorInspector::_parse_added_editors(VBoxContainer *current_vbox, EditorIn
 		if (ep) {
 			ep->object = object;
 			ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed).bind(false));
-			ep->connect("property_keyed", callable_mp(this, &EditorInspector::_property_keyed));
+			ep->connect("property_keyed", callable_mp(this, &EditorInspector::_property_keyed), CONNECT_DEFERRED);
 			ep->connect("property_deleted", callable_mp(this, &EditorInspector::_property_deleted), CONNECT_DEFERRED);
 			ep->connect("property_keyed_with_value", callable_mp(this, &EditorInspector::_property_keyed_with_value));
 			ep->connect("property_checked", callable_mp(this, &EditorInspector::_property_checked));


### PR DESCRIPTION
This is likely an oversight since we're also doing this for `_property_deleted` . 

I might recommend we add a DEV_ASSERT to `object.cpp::1800` so that we can track these types of rug-pulling situations. I'm not confident that the story ends here as I noticed that a backtrace when using breakpoints for that error message comes from `editor_node.cpp:2302` . I missed capturing the entire call stack, but I can try again later to see if I can get a sense of whether there's anything dangerous going on. 

Anyway, having tested with this fix, there hasn't been any crashes and I haven't noticed any regressions. I'll get the user who posted to test out the changes on his end if he can. 

Closes #69829