### PR TITLE
Fix !tile_set.is_valid() error on startup

### DIFF
--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -120,7 +120,9 @@ bool TileSetEditor::_can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 }
 
 void TileSetEditor::_update_sources_list(int force_selected_id) {
-	ERR_FAIL_COND(!tile_set.is_valid());
+	if (tile_set.is_null()) {
+		return;
+	}
 
 	// Get the previously selected id.
 	int old_selected = TileSet::INVALID_SOURCE;


### PR DESCRIPTION
Fixes #69841

In #69747, `_update_sources_list()` is called when the editor enters the tree and when theme changes in order to update list icons. At this point, `tile_set` should have no value assigned, so we should return silently.