### PR TITLE
Use ObjectID as argument when referred-calling `_request_gizmo`

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7639,6 +7639,13 @@ void Node3DEditor::_request_gizmo(Object *p_obj) {
 	}
 }
 
+void Node3DEditor::_request_gizmo_for_id(ObjectID p_id) {
+	Node3D *node = Object::cast_to<Node3D>(ObjectDB::get_instance(p_id));
+	if (node) {
+		_request_gizmo(node);
+	}
+}
+
 void Node3DEditor::_set_subgizmo_selection(Object *p_obj, Ref<Node3DGizmo> p_gizmo, int p_id, Transform3D p_transform) {
 	if (p_id == -1) {
 		_clear_subgizmo_selection(p_obj);
@@ -7819,6 +7826,7 @@ void Node3DEditor::_register_all_gizmos() {
 void Node3DEditor::_bind_methods() {
 	ClassDB::bind_method("_get_editor_data", &Node3DEditor::_get_editor_data);
 	ClassDB::bind_method("_request_gizmo", &Node3DEditor::_request_gizmo);
+	ClassDB::bind_method("_request_gizmo_for_id", &Node3DEditor::_request_gizmo_for_id);
 	ClassDB::bind_method("_set_subgizmo_selection", &Node3DEditor::_set_subgizmo_selection);
 	ClassDB::bind_method("_clear_subgizmo_selection", &Node3DEditor::_clear_subgizmo_selection);
 	ClassDB::bind_method("_refresh_menu_icons", &Node3DEditor::_refresh_menu_icons);

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -716,6 +716,7 @@ private:
 	Node3D *selected = nullptr;
 
 	void _request_gizmo(Object *p_obj);
+	void _request_gizmo_for_id(ObjectID p_id);
 	void _set_subgizmo_selection(Object *p_obj, Ref<Node3DGizmo> p_gizmo, int p_id, Transform3D p_transform = Transform3D());
 	void _clear_subgizmo_selection(Object *p_obj = nullptr);
 

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -188,7 +188,7 @@ void Node3D::_notification(int p_what) {
 
 #ifdef TOOLS_ENABLED
 			if (Engine::get_singleton()->is_editor_hint() && get_tree()->is_node_being_edited(this)) {
-				get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, SceneStringNames::get_singleton()->_spatial_editor_group, SceneStringNames::get_singleton()->_request_gizmo, this);
+				get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, SceneStringNames::get_singleton()->_spatial_editor_group, SNAME("_request_gizmo_for_id"), get_instance_id());
 			}
 #endif
 		} break;
@@ -482,7 +482,7 @@ void Node3D::update_gizmos() {
 	}
 
 	if (data.gizmos.is_empty()) {
-		get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, SceneStringNames::get_singleton()->_spatial_editor_group, SceneStringNames::get_singleton()->_request_gizmo, this);
+		get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, SceneStringNames::get_singleton()->_spatial_editor_group, SNAME("_request_gizmo_for_id"), get_instance_id());
 		return;
 	}
 	if (data.gizmos_dirty) {


### PR DESCRIPTION
Fixes #69827

Explanation of the crash is here: https://github.com/godotengine/godot/issues/69827#issuecomment-1344991143

It's unsafe to use raw object pointer as argument of a deferred call. Because that object might already be gone when the call is executed. There's no way to detect the problem since the pointer becomes a wild pointer.

This PR adds a dedicated `_request_gizmo_for_id()` for deferred calls.

*Bugsquad edit:*
- Fixes #69459