### PR TITLE
[TextServer] Do not clean up font texture cache when setting `allow_system_fallback` property.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -2151,10 +2151,7 @@ void TextServerAdvanced::_font_set_allow_system_fallback(const RID &p_font_rid, 
 	ERR_FAIL_COND(!fd);
 
 	MutexLock lock(fd->mutex);
-	if (fd->allow_system_fallback != p_allow_system_fallback) {
-		_font_clear_cache(fd);
-		fd->allow_system_fallback = p_allow_system_fallback;
-	}
+	fd->allow_system_fallback = p_allow_system_fallback;
 }
 
 bool TextServerAdvanced::_font_is_allow_system_fallback(const RID &p_font_rid) const {

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -1246,10 +1246,7 @@ void TextServerFallback::_font_set_allow_system_fallback(const RID &p_font_rid, 
 	ERR_FAIL_COND(!fd);
 
 	MutexLock lock(fd->mutex);
-	if (fd->allow_system_fallback != p_allow_system_fallback) {
-		_font_clear_cache(fd);
-		fd->allow_system_fallback = p_allow_system_fallback;
-	}
+	fd->allow_system_fallback = p_allow_system_fallback;
 }
 
 bool TextServerFallback::_font_is_allow_system_fallback(const RID &p_font_rid) const {


### PR DESCRIPTION
Remove incorrectly copy-pasted `_font_clear_cache` calls added during system font fallback implementation.

Fixes https://github.com/godotengine/godot/issues/69849