### PR TITLE
Fix for glDrawElements crash on GLES3

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2210,10 +2210,13 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 				glBindVertexArray(vertex_array_gl);
 			}
 			prev_vertex_array_gl = vertex_array_gl;
+
+			// Invalidate the previous index array
+			prev_index_array_gl = 0;
 		}
 
 		bool use_index_buffer = index_array_gl != 0;
-		if (prev_index_array_gl != index_array_gl || prev_vertex_array_gl != vertex_array_gl) {
+		if (prev_index_array_gl != index_array_gl) {
 			if (index_array_gl != 0) {
 				// Bind index each time so we can use LODs
 				glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, index_array_gl);


### PR DESCRIPTION
This pull request fixes issue #69836 by clearing prev_index_array_gl after calling glBindVertexArray. This is required because the call to glBindVertexArray clears the GL_ELEMEMT_ARRAY_BUFFER when changing the state. The code must take this into account to decide when to bind the index array.

The broken ```prev_vertex_array_gl != vertex_array_gl``` test was removed from the second if. The clearing of the prev_index_array_gl is enough to trigger the second if when binding is required.

*Bugsquad edit:*
- Fixes #69836