### PR TITLE
Don't store `layout_mode` in scene file

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3179,7 +3179,7 @@ void Control::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "clip_contents"), "set_clip_contents", "is_clipping_contents");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "custom_minimum_size", PROPERTY_HINT_NONE, "suffix:px"), "set_custom_minimum_size", "get_custom_minimum_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "layout_direction", PROPERTY_HINT_ENUM, "Inherited,Locale,Left-to-Right,Right-to-Left"), "set_layout_direction", "get_layout_direction");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "layout_mode", PROPERTY_HINT_ENUM, "Position,Anchors,Container,Uncontrolled", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "_set_layout_mode", "_get_layout_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "layout_mode", PROPERTY_HINT_ENUM, "Position,Anchors,Container,Uncontrolled", (PROPERTY_USAGE_DEFAULT & ~PROPERTY_USAGE_STORAGE) | PROPERTY_USAGE_INTERNAL), "_set_layout_mode", "_get_layout_mode");
 	ADD_PROPERTY_DEFAULT("layout_mode", LayoutMode::LAYOUT_MODE_POSITION);
 
 	const String anchors_presets_options = "Custom:-1,PresetFullRect:15,"


### PR DESCRIPTION
Closes #67095.

As far as I understand, this property should not be stored in the scene file, but should be calculated depending on other properties and the type of the parent node.

`PROPERTY_USAGE_INTERNAL` is responsible for hiding the property in documentation, etc., but does not control the storage of the property, this is the responsibility of `PROPERTY_USAGE_STORAGE`, which is included in `PROPERTY_USAGE_DEFAULT`.

I tested and didn't find any regressions. "Layout Mode" is correctly restored after reloading the editor if a non-default "Anchors Preset" is selected.

However, I'd like to get confirmation from the feature implementer that `layout_mode` really shouldn't be saved in the scene file, since I haven't studied this code thoroughly.