### PR TITLE
Add project settting for allowing StringName keys

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1310,6 +1310,8 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("rendering/rendering_device/staging_buffer/texture_upload_region_size_px", 64);
 	GLOBAL_DEF("rendering/rendering_device/vulkan/max_descriptors_per_pool", 64);
 
+	GLOBAL_DEF("core/data/variant/force_string_in_dictionary", true);
+
 	// These properties will not show up in the dialog nor in the documentation. If you want to exclude whole groups, see _get_property_list() method.
 	GLOBAL_DEF_INTERNAL("application/config/features", PackedStringArray());
 	GLOBAL_DEF_INTERNAL("internationalization/locale/translation_remaps", PackedStringArray());

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -39,6 +39,8 @@
 #include "core/variant/type_info.h"
 #include "core/variant/variant_internal.h"
 
+bool Dictionary::force_string_in_dictionary = true;
+
 struct DictionaryPrivate {
 	SafeRefCount refcount;
 	Variant *read_only = nullptr; // If enabled, a pointer is used to a temporary value that is used to return read-only values.
@@ -81,7 +83,7 @@ Variant Dictionary::get_value_at_index(int p_index) const {
 
 Variant &Dictionary::operator[](const Variant &p_key) {
 	if (unlikely(_p->read_only)) {
-		if (p_key.get_type() == Variant::STRING_NAME) {
+		if (force_string_in_dictionary && p_key.get_type() == Variant::STRING_NAME) {
 			const StringName *sn = VariantInternal::get_string_name(&p_key);
 			*_p->read_only = _p->variant_map[sn->operator String()];
 		} else {
@@ -90,7 +92,7 @@ Variant &Dictionary::operator[](const Variant &p_key) {
 
 		return *_p->read_only;
 	} else {
-		if (p_key.get_type() == Variant::STRING_NAME) {
+		if (force_string_in_dictionary && p_key.get_type() == Variant::STRING_NAME) {
 			const StringName *sn = VariantInternal::get_string_name(&p_key);
 			return _p->variant_map[sn->operator String()];
 		} else {

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -46,6 +46,8 @@ class Dictionary {
 	void _unref() const;
 
 public:
+	static bool force_string_in_dictionary;
+
 	void get_key_list(List<Variant> *p_keys) const;
 	Variant get_key_at_index(int p_index) const;
 	Variant get_value_at_index(int p_index) const;

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -344,6 +344,9 @@
 		<member name="compression/formats/zstd/window_log_size" type="int" setter="" getter="" default="27">
 			Largest size limit (in power of 2) allowed when compressing using long-distance matching with Zstandard. Higher values can result in better compression, but will require more memory when compressing and decompressing.
 		</member>
+		<member name="core/data/variant/force_string_in_dictionary" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], [Dictionary] will automatically convert [StringName] keys to [String], both for read and write. Disabling it will improve performance of [StringName] keys, at the cost of usability.
+		</member>
 		<member name="debug/disable_touch" type="bool" setter="" getter="" default="false">
 			Disable touch input. Only has effect on iOS.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1354,6 +1354,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	// Initialize user data dir.
 	OS::get_singleton()->ensure_user_data_dir();
 
+	Dictionary::force_string_in_dictionary = GLOBAL_GET("core/data/variant/force_string_in_dictionary");
+
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
 	register_core_extensions(); // core extensions must be registered after globals setup and before display
 


### PR DESCRIPTION
Fixes #68834

Pretty sure it's not an acceptable solution. Taking aside that this PR adds a project setting that affects core class via some global static variable, the gained performance doesn't make much difference in practice. The benchmarks in the issue are done with 1000000 operations; in my case I do at most ~20 StringName operations per frame, so the gain is non-existent xd

But I just had this idea, so I opened a PR 🤷‍♂️ It *does* solve the issue at least.