### PR TITLE
Fix `GDScriptCache` to not remove scripts/scenes individually when clearing

### DIFF
--- a/modules/gdscript/gdscript_cache.h
+++ b/modules/gdscript/gdscript_cache.h
@@ -87,7 +87,7 @@ class GDScriptCache {
 
 	static GDScriptCache *singleton;
 
-	bool destructing = false;
+	bool cleared = false;
 
 	Mutex mutex;
 
@@ -103,13 +103,6 @@ public:
 
 	static Ref<PackedScene> get_packed_scene(const String &p_path, Error &r_error, const String &p_owner = "");
 	static void clear_unreferenced_packed_scenes();
-
-	static bool is_destructing() {
-		if (singleton == nullptr) {
-			return true;
-		}
-		return singleton->destructing;
-	};
 
 	static void clear();
 


### PR DESCRIPTION
Split PR from #69587 for everything about `GDScriptCache`.

Should prevent `GDScript::~GDScript()` instances to call `GDScriptCache::remove_script()` when the `GDScript` was destructed because `GDScriptCache::clear()` erased the hashmap. Otherwise, `GDScriptCache::remove_script()` will call `erase()` on the hashmap, causing a crash or a `heap-use-after-free` error.

Fixes #69183 (Crash on exit in the GDScript module when debugging Godot) (hopefully)