### PR TITLE
C#: Expose attribute properties and add documentation

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/AssemblyHasScriptsAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/AssemblyHasScriptsAttribute.cs
@@ -1,20 +1,32 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 #nullable enable
 
 namespace Godot
 {
     /// <summary>
-    /// An attribute that determines if an assembly has scripts. If so, what types of scripts the assembly has.
+    /// Attribute that determines that the assembly contains Godot scripts and, optionally, the
+    /// collection of types that implement scripts; otherwise, retrieving the types requires lookup.
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly)]
     public class AssemblyHasScriptsAttribute : Attribute
     {
+        /// <summary>
+        /// If the Godot scripts contained in the assembly require lookup
+        /// and can't rely on <see cref="ScriptTypes"/>.
+        /// </summary>
+        [MemberNotNullWhen(false, nameof(ScriptTypes))]
         public bool RequiresLookup { get; }
+
+        /// <summary>
+        /// The collection of types that implement a Godot script.
+        /// </summary>
         public Type[]? ScriptTypes { get; }
 
         /// <summary>
-        /// Constructs a new AssemblyHasScriptsAttribute instance.
+        /// Constructs a new AssemblyHasScriptsAttribute instance
+        /// that requires lookup to get the Godot scripts.
         /// </summary>
         public AssemblyHasScriptsAttribute()
         {
@@ -23,9 +35,10 @@ namespace Godot
         }
 
         /// <summary>
-        /// Constructs a new AssemblyHasScriptsAttribute instance.
+        /// Constructs a new AssemblyHasScriptsAttribute instance
+        /// that includes the Godot script types and requires no lookup.
         /// </summary>
-        /// <param name="scriptTypes">The specified type(s) of scripts.</param>
+        /// <param name="scriptTypes">The collection of types that implement a Godot script.</param>
         public AssemblyHasScriptsAttribute(Type[] scriptTypes)
         {
             RequiresLookup = false;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportAttribute.cs
@@ -3,23 +3,30 @@ using System;
 namespace Godot
 {
     /// <summary>
-    /// An attribute used to export objects.
+    /// Exports the annotated member as a property of the Godot Object.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
     public sealed class ExportAttribute : Attribute
     {
-        private PropertyHint hint;
-        private string hintString;
+        /// <summary>
+        /// Optional hint that determines how the property should be handled by the editor.
+        /// </summary>
+        public PropertyHint Hint { get; }
+
+        /// <summary>
+        /// Optional string that can contain additional metadata for the <see cref="Hint"/>.
+        /// </summary>
+        public string HintString { get; }
 
         /// <summary>
         /// Constructs a new ExportAttribute Instance.
         /// </summary>
-        /// <param name="hint">A hint to the exported object.</param>
-        /// <param name="hintString">A string representing the exported object.</param>
+        /// <param name="hint">The hint for the exported property.</param>
+        /// <param name="hintString">A string that may contain additional metadata for the hint.</param>
         public ExportAttribute(PropertyHint hint = PropertyHint.None, string hintString = "")
         {
-            this.hint = hint;
-            this.hintString = hintString;
+            Hint = hint;
+            HintString = hintString;
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportCategoryAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportCategoryAttribute.cs
@@ -8,7 +8,10 @@ namespace Godot
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
     public sealed class ExportCategoryAttribute : Attribute
     {
-        private string name;
+        /// <summary>
+        /// Name of the category.
+        /// </summary>
+        public string Name { get; }
 
         /// <summary>
         /// Define a new category for the following exported properties.
@@ -16,7 +19,7 @@ namespace Godot
         /// <param name="name">The name of the category.</param>
         public ExportCategoryAttribute(string name)
         {
-            this.name = name;
+            Name = name;
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportGroupAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportGroupAttribute.cs
@@ -1,5 +1,7 @@
 using System;
 
+#nullable enable
+
 namespace Godot
 {
     /// <summary>
@@ -8,8 +10,15 @@ namespace Godot
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
     public sealed class ExportGroupAttribute : Attribute
     {
-        private string name;
-        private string prefix;
+        /// <summary>
+        /// Name of the group.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// If provided, the prefix that all properties must have to be considered part of the group.
+        /// </summary>
+        public string? Prefix { get; }
 
         /// <summary>
         /// Define a new group for the following exported properties.
@@ -18,8 +27,8 @@ namespace Godot
         /// <param name="prefix">If provided, the group would make group to only consider properties that have this prefix.</param>
         public ExportGroupAttribute(string name, string prefix = "")
         {
-            this.name = name;
-            this.prefix = prefix;
+            Name = name;
+            Prefix = prefix;
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportSubgroupAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportSubgroupAttribute.cs
@@ -1,5 +1,7 @@
 using System;
 
+#nullable enable
+
 namespace Godot
 {
     /// <summary>
@@ -8,8 +10,15 @@ namespace Godot
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
     public sealed class ExportSubgroupAttribute : Attribute
     {
-        private string name;
-        private string prefix;
+        /// <summary>
+        /// Name of the subgroup.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// If provided, the prefix that all properties must have to be considered part of the subgroup.
+        /// </summary>
+        public string? Prefix { get; }
 
         /// <summary>
         /// Define a new subgroup for the following exported properties. This helps to organize properties in the Inspector dock.
@@ -18,8 +27,8 @@ namespace Godot
         /// <param name="prefix">If provided, the subgroup would make group to only consider properties that have this prefix.</param>
         public ExportSubgroupAttribute(string name, string prefix = "")
         {
-            this.name = name;
-            this.prefix = prefix;
+            Name = name;
+            Prefix = prefix;
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/RPCAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/RPCAttribute.cs
@@ -19,17 +19,17 @@ namespace Godot
         /// <summary>
         /// If the method will also be called locally; otherwise, it is only called remotely.
         /// </summary>
-        public bool CallLocal { get; set; } = false;
+        public bool CallLocal { get; init; } = false;
 
         /// <summary>
         /// Transfer mode for the annotated method.
         /// </summary>
-        public MultiplayerPeer.TransferModeEnum TransferMode { get; set; } = MultiplayerPeer.TransferModeEnum.Reliable;
+        public MultiplayerPeer.TransferModeEnum TransferMode { get; init; } = MultiplayerPeer.TransferModeEnum.Reliable;
 
         /// <summary>
         /// Transfer channel for the annotated mode.
         /// </summary>
-        public int TransferChannel { get; set; } = 0;
+        public int TransferChannel { get; init; } = 0;
 
         /// <summary>
         /// Constructs a <see cref="RPCAttribute"/> instance.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ScriptPathAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ScriptPathAttribute.cs
@@ -8,6 +8,9 @@ namespace Godot
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public class ScriptPathAttribute : Attribute
     {
+        /// <summary>
+        /// File path to the script.
+        /// </summary>
         public string Path { get; }
 
         /// <summary>


### PR DESCRIPTION
- Exposes the properties of C# attribute so they can be accessed from reflection[^1], renaming them to PascalCase to follow .NET conventions.
- Added some documentation to the newly exposed members.
- Made attribute properties readonly to avoid giving the impression that they could be modified.
	- This breaks compatibility with previous betas but I don't think anyone would be setting the members of a `RPCAttribute` instance and doing so would have no effect anyway.

[^1]: I mean using reflection to retrieve the attribute since accessibility doesn't matter when retrieving members, but if the members are public once you have the attribute instance you can easily access those members and it gives the guarantees that it's a stable API since it's exposed as public API.