### PR TITLE
Fix MultiMesh `visible_instance_count` being ignored after the first frame

### DIFF
--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -1502,7 +1502,7 @@ void MeshStorage::multimesh_set_visible_instances(RID p_multimesh, int p_visible
 
 	if (multimesh->data_cache.size()) {
 		//there is a data cache..
-		_multimesh_mark_all_dirty(multimesh, false, true);
+		_multimesh_mark_all_dirty(multimesh, true, true);
 	}
 
 	multimesh->visible_instances = p_visible;

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -1790,7 +1790,7 @@ void MeshStorage::multimesh_set_visible_instances(RID p_multimesh, int p_visible
 
 	if (multimesh->data_cache.size()) {
 		//there is a data cache..
-		_multimesh_mark_all_dirty(multimesh, false, true);
+		_multimesh_mark_all_dirty(multimesh, true, true);
 	}
 
 	multimesh->visible_instances = p_visible;

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -491,7 +491,9 @@ public:
 				case Dependency::DEPENDENCY_CHANGED_REFLECTION_PROBE: {
 					singleton->_instance_queue_update(instance, true, true);
 				} break;
-				case Dependency::DEPENDENCY_CHANGED_MULTIMESH_VISIBLE_INSTANCES:
+				case Dependency::DEPENDENCY_CHANGED_MULTIMESH_VISIBLE_INSTANCES: {
+					singleton->_instance_queue_update(instance, false, true);
+				} break;
 				case Dependency::DEPENDENCY_CHANGED_SKELETON_BONES: {
 					//ignored
 				} break;


### PR DESCRIPTION
This PR brings MultiMesh's `visible_instance_count` property from the non-working state to the working state.

Further optimization as suggested in https://github.com/godotengine/godot/issues/62809#issuecomment-1344778507 can be done as a follow-up by people more in-the-know (or by telling me how to do it here).

Fixes https://github.com/godotengine/godot/issues/62809