### PR TITLE
Fix `GDScriptCache::clear()` crash when clearing packed scenes

### DIFF
--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -415,10 +415,8 @@ void GDScriptCache::clear() {
 			E->clear();
 	}
 
-	for (KeyValue<String, HashSet<String>> &E : singleton->packed_scene_dependencies) {
-		singleton->packed_scene_dependencies.erase(E.key);
-		singleton->packed_scene_cache.erase(E.key);
-	}
+	singleton->packed_scene_dependencies.clear();
+	singleton->packed_scene_cache.clear();
 
 	parser_map_refs.clear();
 	singleton->parser_map.clear();


### PR DESCRIPTION
Fixes issues when clearing packed scenes inside `GDScriptCache::clear()`.

Fixes #69872 - [4.0 Beta 8] Game crashes (heap use after free) on quit during GDScriptCache::Clear()