### PR TITLE
Hiding the Scatter Label and Scatter Spinbox when scattering and rand…

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -56,6 +56,12 @@ void TileMapEditorTilesPlugin::tile_set_changed() {
 
 void TileMapEditorTilesPlugin::_on_random_tile_checkbox_toggled(bool p_pressed) {
 	scatter_spinbox->set_editable(p_pressed);
+	//If we're making the spinbox uneditable, then we want to hide the Scatter Label and the Spinbox.
+	if(p_pressed == false){
+		//Index 6 and 7 represents the Scatter Label and Scatter Spinbox
+		Object::cast_to<CanvasItem>(tools_settings->get_child(6))->hide();
+		Object::cast_to<CanvasItem>(tools_settings->get_child(7))->hide();
+	}
 }
 
 void TileMapEditorTilesPlugin::_on_scattering_spinbox_changed(double p_value) {

--- a/editor/plugins/tiles/tile_map_test.txt
+++ b/editor/plugins/tiles/tile_map_test.txt
@@ -1,0 +1,34 @@
+/*
+#include "tile_map_editor.h"
+
+#include "tiles_editor_plugin.h"
+
+#include "editor/editor_node.h"
+#include "editor/editor_resource_preview.h"
+#include "editor/editor_scale.h"
+#include "editor/editor_settings.h"
+#include "editor/editor_undo_redo_manager.h"
+#include "editor/plugins/canvas_item_editor_plugin.h"
+
+#include "scene/2d/camera_2d.h"
+#include "scene/gui/center_container.h"
+#include "scene/gui/split_container.h"
+
+#include "core/input/input.h"
+#include "core/math/geometry_2d.h"
+#include "core/os/keyboard.h"
+
+void TileMapEditorTilesPlugin::_on_random_tile_checkbox_toggled(bool p_pressed) {
+	if(p_pressed == false){
+        try
+        {
+            Object::cast_to<CanvasItem>(tools_settings->get_child(6))->hide();
+            Object::cast_to<CanvasItem>(tools_settings->get_child(7))->hide();
+        }
+        catch(const std::exception& e)
+        {
+            assert(false);
+        }
+	}
+}
+*/


### PR DESCRIPTION
When set_editable is passed in false, we hide the Scatter Label and Scatter Spinbox

Fixes #69697: Cannot modify Scattering value when Place Random Tile is deselected