### PR TITLE
Hide Scattering label and controls within TileMap editor window when "Place Random Tile" option is disabled

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -55,7 +55,7 @@ void TileMapEditorTilesPlugin::tile_set_changed() {
 }
 
 void TileMapEditorTilesPlugin::_on_random_tile_checkbox_toggled(bool p_pressed) {
-	scatter_spinbox->set_editable(p_pressed);
+	scatter_controls_container->set_visible(p_pressed);
 }
 
 void TileMapEditorTilesPlugin::_on_scattering_spinbox_changed(double p_value) {
@@ -2124,10 +2124,12 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	tools_settings->add_child(random_tile_toggle);
 
 	// Random tile scattering.
+	scatter_controls_container = memnew(HBoxContainer);
+
 	scatter_label = memnew(Label);
 	scatter_label->set_tooltip_text(TTR("Defines the probability of painting nothing instead of a randomly selected tile."));
 	scatter_label->set_text(TTR("Scattering:"));
-	tools_settings->add_child(scatter_label);
+	scatter_controls_container->add_child(scatter_label);
 
 	scatter_spinbox = memnew(SpinBox);
 	scatter_spinbox->set_min(0.0);
@@ -2136,7 +2138,8 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	scatter_spinbox->set_tooltip_text(TTR("Defines the probability of painting nothing instead of a randomly selected tile."));
 	scatter_spinbox->get_line_edit()->add_theme_constant_override("minimum_character_width", 4);
 	scatter_spinbox->connect("value_changed", callable_mp(this, &TileMapEditorTilesPlugin::_on_scattering_spinbox_changed));
-	tools_settings->add_child(scatter_spinbox);
+	scatter_controls_container->add_child(scatter_spinbox);
+	tools_settings->add_child(scatter_controls_container);
 
 	_on_random_tile_checkbox_toggled(false);
 

--- a/editor/plugins/tiles/tile_map_editor.h
+++ b/editor/plugins/tiles/tile_map_editor.h
@@ -91,6 +91,8 @@ private:
 	VSeparator *tools_settings_vsep_2 = nullptr;
 	CheckBox *bucket_contiguous_checkbox = nullptr;
 	Button *random_tile_toggle = nullptr;
+
+	HBoxContainer *scatter_controls_container = nullptr;
 	float scattering = 0.0;
 	Label *scatter_label = nullptr;
 	SpinBox *scatter_spinbox = nullptr;


### PR DESCRIPTION
This change addresses issue #69697, which was an editor enhancement request. As stated in the title, the change hides the Scattering spinbox input within the TileMap window when "Place Random Tile" is disabled, where the current version grays out the Scattering spinbox. 
I created a new container object named ```scatter_controls_container```, with ```scatter_label``` and ```scatter_spinbox``` as child elements.  ```scatter_controls_container``` is set as a child element of the existing ```tools_setting``` container. When hiding the Scattering elements, I used ```hide()``` and ```show()``` on the ```scatter_controls_container```.
**Before:**
- Place Random Tile enabled:
![RandomToggled](https://user-images.githubusercontent.com/102765166/206885043-0e6fb6bd-7971-4e6c-867a-a9e029859f9d.jpg)
- Place Random Tile disabled: 
![RandomNotToggled](https://user-images.githubusercontent.com/102765166/206885053-9782657f-2e6e-4773-8c1a-05fbbdfd3c6a.jpg)

**After:**
- Place Random Tile enabled:
![Changed_toggle](https://user-images.githubusercontent.com/102765166/206885127-e4fc6e50-f51e-4f79-975f-a415d6aa75b8.jpg)
- Place Random Tile disabled:
![Changed_no_toggle](https://user-images.githubusercontent.com/102765166/206885130-fd806ef3-7913-47ba-956f-92f5e31a5161.jpg)

*Bugsquad edit:*
- Fixes #69697