### PR TITLE
check for empty string TextServer _string_to_upper

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -6196,6 +6196,9 @@ String TextServerAdvanced::_strip_diacritics(const String &p_string) const {
 }
 
 String TextServerAdvanced::_string_to_upper(const String &p_string, const String &p_language) const {
+	if (p_string.is_empty()) {
+		return p_string;
+	}
 	const String lang = (p_language.is_empty()) ? TranslationServer::get_singleton()->get_tool_locale() : p_language;
 
 	// Convert to UTF-16.
@@ -6215,6 +6218,9 @@ String TextServerAdvanced::_string_to_upper(const String &p_string, const String
 }
 
 String TextServerAdvanced::_string_to_lower(const String &p_string, const String &p_language) const {
+	if (p_string.is_empty()) {
+		return p_string;
+	}
 	const String lang = (p_language.is_empty()) ? TranslationServer::get_singleton()->get_tool_locale() : p_language;
 	// Convert to UTF-16.
 	Char16String utf16 = p_string.utf16();


### PR DESCRIPTION
Adds a check to TextServerAdvanced.::_string_to_upper
Now properly does nothing when the string is empty.

Closes #69888