### PR TITLE
Fix autocomplete on functions returning variants

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2272,6 +2272,11 @@ static bool _guess_method_return_type_from_base(GDScriptParser::CompletionContex
 				if (base_type.class_type->has_function(p_method)) {
 					const GDScriptParser::FunctionNode *method = base_type.class_type->get_member(p_method).function;
 					if (!is_static || method->is_static) {
+						if (method->get_datatype().is_set() && !method->get_datatype().is_variant()) {
+							r_type.type = method->get_datatype();
+							return true;
+						}
+
 						int last_return_line = -1;
 						const GDScriptParser::ExpressionNode *last_returned_value = nullptr;
 						GDScriptParser::CompletionContext c = p_context;
@@ -2283,10 +2288,6 @@ static bool _guess_method_return_type_from_base(GDScriptParser::CompletionContex
 						if (last_returned_value) {
 							c.current_line = c.current_suite->end_line;
 							if (_guess_expression_type(c, last_returned_value, r_type)) {
-								return true;
-							}
-							if (method->get_datatype().is_set() && !method->get_datatype().is_variant()) {
-								r_type.type = method->get_datatype();
 								return true;
 							}
 						}


### PR DESCRIPTION
Fixes #69837 

When reducing method return type, the current logic attempts to guess the return type from the last return value _before_ checking type hints. Hence if the last return value is a resolved type, it uses that value for auto-complete. If a type hint is present, it should probably be used rather than guessing the return type, so I just re-ordered the checks.

This also fixes auto-complete on a variable that is inferring datatype from a method return type.

## Demo
[Screencast from 2022-12-11 14-25-19.webm](https://user-images.githubusercontent.com/74857873/206891434-a270fbf0-14a8-42d5-a84d-8ae27d08eae9.webm)


