### PR TITLE
Improve logic around using Ref<T> with GDExtension virtual functions

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -879,6 +879,23 @@ static GDObjectInstanceID gdextension_object_get_instance_id(GDExtensionConstObj
 	return (GDObjectInstanceID)o->get_instance_id();
 }
 
+static GDExtensionObjectPtr gdextension_ref_get_object(GDExtensionConstRefPtr p_ref) {
+	const Ref<RefCounted> *ref = (const Ref<RefCounted> *)p_ref;
+	if (ref == nullptr || ref->is_null()) {
+		return (GDExtensionObjectPtr) nullptr;
+	} else {
+		return (GDExtensionObjectPtr)ref->ptr();
+	}
+}
+
+static void gdextension_ref_set_object(GDExtensionRefPtr p_ref, GDExtensionObjectPtr p_object) {
+	Ref<RefCounted> *ref = (Ref<RefCounted> *)p_ref;
+	ERR_FAIL_NULL(ref);
+
+	Object *o = (RefCounted *)p_object;
+	ref->reference_ptr(o);
+}
+
 static GDExtensionScriptInstancePtr gdextension_script_instance_create(const GDExtensionScriptInstanceInfo *p_info, GDExtensionScriptInstanceDataPtr p_instance_data) {
 	ScriptInstanceExtension *script_instance_extension = memnew(ScriptInstanceExtension);
 	script_instance_extension->instance = p_instance_data;
@@ -1056,6 +1073,11 @@ void gdextension_setup_interface(GDExtensionInterface *p_interface) {
 	gde_interface.object_cast_to = gdextension_object_cast_to;
 	gde_interface.object_get_instance_from_id = gdextension_object_get_instance_from_id;
 	gde_interface.object_get_instance_id = gdextension_object_get_instance_id;
+
+	/* REFERENCE */
+
+	gde_interface.ref_get_object = gdextension_ref_get_object;
+	gde_interface.ref_set_object = gdextension_ref_set_object;
 
 	/* SCRIPT INSTANCE */
 

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -154,6 +154,8 @@ typedef const void *GDExtensionMethodBindPtr;
 typedef int64_t GDExtensionInt;
 typedef uint8_t GDExtensionBool;
 typedef uint64_t GDObjectInstanceID;
+typedef void *GDExtensionRefPtr;
+typedef const void *GDExtensionConstRefPtr;
 
 /* VARIANT DATA I/O */
 
@@ -550,6 +552,11 @@ typedef struct {
 	GDExtensionObjectPtr (*object_cast_to)(GDExtensionConstObjectPtr p_object, void *p_class_tag);
 	GDExtensionObjectPtr (*object_get_instance_from_id)(GDObjectInstanceID p_instance_id);
 	GDObjectInstanceID (*object_get_instance_id)(GDExtensionConstObjectPtr p_object);
+
+	/* REFERENCE */
+
+	GDExtensionObjectPtr (*ref_get_object)(GDExtensionConstRefPtr p_ref);
+	void (*ref_set_object)(GDExtensionRefPtr p_ref, GDExtensionObjectPtr p_object);
 
 	/* SCRIPT INSTANCE */
 

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -253,12 +253,14 @@ public:
 template <class T>
 struct PtrToArg<Ref<T>> {
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
+		// p_ptr points to a RefCounted object
 		return Ref<T>(const_cast<T *>(reinterpret_cast<const T *>(p_ptr)));
 	}
 
 	typedef Ref<T> EncodeT;
 
 	_FORCE_INLINE_ static void encode(Ref<T> p_val, const void *p_ptr) {
+		// p_ptr points to an EncodeT object which is a Ref<T> object.
 		*(const_cast<Ref<RefCounted> *>(reinterpret_cast<const Ref<RefCounted> *>(p_ptr))) = p_val;
 	}
 };
@@ -268,6 +270,7 @@ struct PtrToArg<const Ref<T> &> {
 	typedef Ref<T> EncodeT;
 
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
+		// p_ptr points to a RefCounted object
 		return Ref<T>((T *)p_ptr);
 	}
 };


### PR DESCRIPTION
As discussed during the GDExtension meeting, we have a problem when calling GDExtension virtual functions when `Ref<T>` is used as the data type. Unlike "normal" functions, which use `Virtual` as an intermediate which ensures refcounting is done, with virtual functions we send pointers to `Ref<T>` objects. Unfortunately GDExtension can't make heads nor tails of this and right now we assign values in a rather dangerous way as well as introducing the risk of returned objects being destroyed before Godot is able to reference them.

This PR introduces two support functions that allow us to get or set an object on a Godot side `Ref<T>` pointer. 

This PR has a companion PR on the godot-cpp side which uses these functions: https://github.com/godotengine/godot-cpp/pull/958