### PR TITLE
Move `finalize_display()` before servers uninit

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3365,6 +3365,7 @@ void Main::cleanup(bool p_force) {
 	// Before deinitializing server extensions, finalize servers which may be loaded as extensions.
 	finalize_navigation_server();
 	finalize_physics();
+	finalize_display();
 
 	NativeExtensionManager::get_singleton()->deinitialize_extensions(NativeExtension::INITIALIZATION_LEVEL_SERVERS);
 	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
@@ -3386,8 +3387,6 @@ void Main::cleanup(bool p_force) {
 	}
 
 	OS::get_singleton()->finalize();
-
-	finalize_display();
 
 	if (input) {
 		memdelete(input);


### PR DESCRIPTION
Move `finalize_display()` before servers uninit as if `RenderingServer` RID leaks exist, the destructors of these leaks objects will try to free the RIDs, but as the `RenderingServer` singleton is already disposed, it crashes.

Fixes #69910 