### PR TITLE
Quick Fix for Area2DSW dangling RID crash

### DIFF
--- a/core/rid_handle.h
+++ b/core/rid_handle.h
@@ -109,6 +109,10 @@ public:
 	bool is_valid() const { return _id != 0; }
 
 	uint32_t get_id() const { return _id ? _handle_data : 0; }
+
+	// This should not normally be used (as data pointer is somewhat random)
+	// but is added for some compatibility with the original RID.
+	uint64_t get_data() const { return _handle_data; }
 };
 
 class RID : public RID_Handle {

--- a/servers/physics_2d/area_2d_sw.h
+++ b/servers/physics_2d/area_2d_sw.h
@@ -75,7 +75,7 @@ class Area2DSW : public CollisionObject2DSW {
 					return body_shape < p_key.body_shape;
 				}
 			} else {
-				return rid < p_key.rid;
+				return rid.get_data() < p_key.rid.get_data();
 			}
 		}
 


### PR DESCRIPTION
Changes BodyKey comparison function to prevent dereferencing dangling RIDs, which would otherwise cause a crash.

Fixes #67273 (I hope! :grinning: )

I'm not super familiar with the physics. Deleting the `BodyKey` before the area is probably the tidy solution, in order to prevent a dangling RID. However that might require significant rework of the order of a few things here (@rburing might be more familiar?), and 3.x is at a stage where we may want to avoid significant rework which could open up new bugs.

I also see no obvious compelling reason why deleting a BodyKey _should require_ the `RID` to be valid in order to delete that item - it is just being used as an identifier to find the `BodyKey` within the `Map`. It should imo be able to work without a valid `RID`.

This is a quick fix that wouldn't require reverting the RID PR, a better fix would probably require a physics contributor.

## Notes
* This reverts this particular system to effectively use the same method as before #59234 (comparing data pointers in the RID).
* This is untested as I haven't been able to replicate the crash.
* It is possible that there are other similar vulnerabilities that have been exposed by #59234 .
* The addition to `rid_handle.h` is just to keep the `rid_handles` build working with this somewhat hacky approach. The actual value returned by `get_data()` doesn't seem important, just that it is unique.
* This bug would not occur in master, because in master the RID `id` is stored by value in the RID, whereas in 3.x id is read by dereferencing the data pointer to the object, and relies on the object being valid.
* This bug would not cause crashes in the `rids=handles` builds, because similarly the id did not depend on dereferencing the object, as in master.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
