### PR TITLE
Fix `heap-use-after-free` error in `TileMap::~TileMap()`

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -4072,5 +4072,9 @@ TileMap::TileMap() {
 }
 
 TileMap::~TileMap() {
+	if (tile_set.is_valid()) {
+		tile_set->disconnect("changed", callable_mp(this, &TileMap::_tile_set_changed));
+	}
+
 	_clear_internals();
 }


### PR DESCRIPTION
Makes sure that `TileMap::tile_set` is disposed first when `TileMap::~TileMap()` is called, otherwise [it can lead to a `heap-use-after-free` error.
](https://github.com/godotengine/godot/issues/69918#issuecomment-1345620226)
Fixes #69918 - Crash due to heap corruption after `change_scene_to_file`