### PR TITLE
Check if class exists before checking if it's virtual in Create New Node dialog

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -284,8 +284,9 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String 
 
 	bool can_instantiate = (p_type_category == TypeCategory::CPP_TYPE && ClassDB::can_instantiate(p_type)) ||
 			p_type_category == TypeCategory::OTHER_TYPE;
+	bool is_virtual = ClassDB::class_exists(p_type) && ClassDB::is_virtual(p_type);
 
-	if (can_instantiate && !ClassDB::is_virtual(p_type)) {
+	if (can_instantiate && !is_virtual) {
 		r_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, icon_fallback));
 	} else {
 		r_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, "NodeDisabled"));


### PR DESCRIPTION
Fixes #69889. This PR adds the fixed proposed by @raulsntos [here](https://github.com/godotengine/godot/issues/69889#issuecomment-1345617029). The fix ended up being simpler than I expected.

Merging this PR will not affect the discussion of the fate of `add_custom_type`, this fix is likely a good improvement to the Create New Node dialog code anyway since it just adds a safety check.