### PR TITLE
Pass GLTFState to the export_preflight method

### DIFF
--- a/modules/gltf/doc_classes/GLTFDocumentExtension.xml
+++ b/modules/gltf/doc_classes/GLTFDocumentExtension.xml
@@ -42,7 +42,8 @@
 		</method>
 		<method name="_export_preflight" qualifiers="virtual">
 			<return type="int" />
-			<param index="0" name="root" type="Node" />
+			<param index="0" name="state" type="GLTFState" />
+			<param index="1" name="root" type="Node" />
 			<description>
 				Part of the export process. This method is run first, before all other parts of the export process.
 				The return value is used to determine if this [GLTFDocumentExtension] instance should be used for exporting a given GLTF file. If [constant OK], the export will use this [GLTFDocumentExtension] instance. If not overridden, [constant OK] is returned.

--- a/modules/gltf/extensions/gltf_document_extension.cpp
+++ b/modules/gltf/extensions/gltf_document_extension.cpp
@@ -40,7 +40,7 @@ void GLTFDocumentExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_import_node, "state", "gltf_node", "json", "node");
 	GDVIRTUAL_BIND(_import_post, "state", "root");
 	// Export process.
-	GDVIRTUAL_BIND(_export_preflight, "root");
+	GDVIRTUAL_BIND(_export_preflight, "state", "root");
 	GDVIRTUAL_BIND(_convert_scene_node, "state", "gltf_node", "scene_node");
 	GDVIRTUAL_BIND(_export_node, "state", "gltf_node", "json", "node");
 	GDVIRTUAL_BIND(_export_post, "state");
@@ -102,10 +102,10 @@ Error GLTFDocumentExtension::import_post(Ref<GLTFState> p_state, Node *p_root) {
 }
 
 // Export process.
-Error GLTFDocumentExtension::export_preflight(Node *p_root) {
+Error GLTFDocumentExtension::export_preflight(Ref<GLTFState> p_state, Node *p_root) {
 	ERR_FAIL_NULL_V(p_root, ERR_INVALID_PARAMETER);
 	int err = OK;
-	GDVIRTUAL_CALL(_export_preflight, p_root, err);
+	GDVIRTUAL_CALL(_export_preflight, p_state, p_root, err);
 	return Error(err);
 }
 

--- a/modules/gltf/extensions/gltf_document_extension.h
+++ b/modules/gltf/extensions/gltf_document_extension.h
@@ -49,7 +49,7 @@ public:
 	virtual Error import_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_json, Node *p_node);
 	virtual Error import_post(Ref<GLTFState> p_state, Node *p_node);
 	// Export process.
-	virtual Error export_preflight(Node *p_state);
+	virtual Error export_preflight(Ref<GLTFState> p_state, Node *p_root);
 	virtual void convert_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_node);
 	virtual Error export_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_json, Node *p_node);
 	virtual Error export_post(Ref<GLTFState> p_state);
@@ -63,7 +63,7 @@ public:
 	GDVIRTUAL4R(int, _import_node, Ref<GLTFState>, Ref<GLTFNode>, Dictionary, Node *);
 	GDVIRTUAL2R(int, _import_post, Ref<GLTFState>, Node *);
 	// Export process.
-	GDVIRTUAL1R(int, _export_preflight, Node *);
+	GDVIRTUAL2R(int, _export_preflight, Ref<GLTFState>, Node *);
 	GDVIRTUAL3(_convert_scene_node, Ref<GLTFState>, Ref<GLTFNode>, Node *);
 	GDVIRTUAL4R(int, _export_node, Ref<GLTFState>, Ref<GLTFNode>, Dictionary, Node *);
 	GDVIRTUAL1R(int, _export_post, Ref<GLTFState>);

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6930,7 +6930,7 @@ Error GLTFDocument::append_from_scene(Node *p_node, Ref<GLTFState> p_state, uint
 	document_extensions.clear();
 	for (Ref<GLTFDocumentExtension> ext : all_document_extensions) {
 		ERR_CONTINUE(ext.is_null());
-		Error err = ext->export_preflight(p_node);
+		Error err = ext->export_preflight(p_state, p_node);
 		if (err == OK) {
 			document_extensions.push_back(ext);
 		}


### PR DESCRIPTION
I don't have a specific use case in mind for this, but it's for consistency with most of the other methods, and in general it makes sense to allow a GLTFDocumentExtension class to interact with the state at this stage.

This technically breaks compat, but only for things using this recently-introduced API (no breakage coming from 3.x).