### PR TITLE
[3.x] Backport moving camera and light logic to GLTF subclasses, fix ortho cameras

### DIFF
--- a/modules/gltf/doc_classes/GLTFCamera.xml
+++ b/modules/gltf/doc_classes/GLTFCamera.xml
@@ -1,22 +1,45 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GLTFCamera" inherits="Resource" version="3.6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
+		Represents a GLTF camera.
 	</brief_description>
 	<description>
+		Represents a camera as defined by the base GLTF spec.
 		[b]Note:[/b] This class is only compiled in editor builds. Run-time glTF loading and saving is [i]not[/i] available in exported projects. References to [GLTFCamera] within a script will cause an error in an exported project.
 	</description>
 	<tutorials>
+		<link title="GLTF camera detailed specification">https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#reference-camera</link>
+		<link title="GLTF camera spec and example file">https://github.com/KhronosGroup/glTF-Tutorials/blob/master/gltfTutorial/gltfTutorial_015_SimpleCameras.md</link>
 	</tutorials>
 	<methods>
+		<method name="to_dictionary" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Serializes this GLTFCamera instance into a [Dictionary].
+			</description>
+		</method>
+		<method name="to_node" qualifiers="const">
+			<return type="Camera" />
+			<description>
+				Converts this GLTFCamera instance into a Godot [Camera] node.
+			</description>
+		</method>
 	</methods>
 	<members>
-		<member name="fov_size" type="float" setter="set_fov_size" getter="get_fov_size" default="75.0">
+		<member name="fov_size" type="float" setter="set_fov_size" getter="get_fov_size" default="1.309">
+			The FOV of the camera. This class and GLTF define the camera FOV in radians, while Godot uses degrees. This maps to GLTF's [code]yfov[/code] property. This value is only used for perspective cameras, when [member perspective] is true.
 		</member>
 		<member name="perspective" type="bool" setter="set_perspective" getter="get_perspective" default="true">
+			Whether or not the camera is in perspective mode. If false, the camera is in orthographic/orthogonal mode. This maps to GLTF's camera [code]type[/code] property. See [member Camera.projection] and the GLTF spec for more information.
+		</member>
+		<member name="size_mag" type="float" setter="set_size_mag" getter="get_size_mag" default="0.5">
+			The size of the camera. This class and GLTF define the camera size magnitude as a radius in meters, while Godot defines it as a diameter in meters. This maps to GLTF's [code]ymag[/code] property. This value is only used for orthographic/orthogonal cameras, when [member perspective] is false.
 		</member>
 		<member name="zfar" type="float" setter="set_zfar" getter="get_zfar" default="4000.0">
+			The distance to the far culling boundary for this camera relative to its local Z axis, in meters. This maps to GLTF's [code]zfar[/code] property.
 		</member>
 		<member name="znear" type="float" setter="set_znear" getter="get_znear" default="0.05">
+			The distance to the near culling boundary for this camera relative to its local Z axis, in meters. This maps to GLTF's [code]znear[/code] property.
 		</member>
 	</members>
 	<constants>

--- a/modules/gltf/doc_classes/GLTFLight.xml
+++ b/modules/gltf/doc_classes/GLTFLight.xml
@@ -1,13 +1,28 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GLTFLight" inherits="Resource" version="3.6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
+		Represents a GLTF light.
 	</brief_description>
 	<description>
+		Represents a light as defined by the [code]KHR_lights_punctual[/code] GLTF extension.
 		[b]Note:[/b] This class is only compiled in editor builds. Run-time glTF loading and saving is [i]not[/i] available in exported projects. References to [GLTFLight] within a script will cause an error in an exported project.
 	</description>
 	<tutorials>
+		<link title="KHR_lights_punctual GLTF extension spec">https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_lights_punctual</link>
 	</tutorials>
 	<methods>
+		<method name="to_dictionary" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Serializes this GLTFLight instance into a [Dictionary].
+			</description>
+		</method>
+		<method name="to_node" qualifiers="const">
+			<return type="Light" />
+			<description>
+				Converts this GLTFLight instance into a Godot [Light] node.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color( 1, 1, 1, 1 )">

--- a/modules/gltf/extensions/gltf_light.cpp
+++ b/modules/gltf/extensions/gltf_light.cpp
@@ -30,7 +30,12 @@
 
 #include "gltf_light.h"
 
+#include "scene/3d/light.h"
+
 void GLTFLight::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("to_node"), &GLTFLight::to_node);
+	ClassDB::bind_method(D_METHOD("to_dictionary"), &GLTFLight::to_dictionary);
+
 	ClassDB::bind_method(D_METHOD("get_color"), &GLTFLight::get_color);
 	ClassDB::bind_method(D_METHOD("set_color", "color"), &GLTFLight::set_color);
 	ClassDB::bind_method(D_METHOD("get_intensity"), &GLTFLight::get_intensity);
@@ -98,4 +103,117 @@ float GLTFLight::get_outer_cone_angle() {
 
 void GLTFLight::set_outer_cone_angle(float p_outer_cone_angle) {
 	outer_cone_angle = p_outer_cone_angle;
+}
+
+Ref<GLTFLight> GLTFLight::from_node(const Light *p_light) {
+	Ref<GLTFLight> l;
+	l.instance();
+	ERR_FAIL_COND_V_MSG(!p_light, l, "Tried to create a GLTFLight from a Light node, but the given node was null.");
+	l->color = p_light->get_color();
+	if (cast_to<const DirectionalLight>(p_light)) {
+		l->type = "directional";
+		const DirectionalLight *light = cast_to<const DirectionalLight>(p_light);
+		l->intensity = light->get_param(DirectionalLight::PARAM_ENERGY);
+		l->range = FLT_MAX; // Range for directional lights is infinite in Godot.
+	} else if (cast_to<const OmniLight>(p_light)) {
+		l->type = "point";
+		const OmniLight *light = cast_to<const OmniLight>(p_light);
+		l->range = light->get_param(OmniLight::PARAM_RANGE);
+		l->intensity = light->get_param(OmniLight::PARAM_ENERGY);
+	} else if (cast_to<const SpotLight>(p_light)) {
+		l->type = "spot";
+		const SpotLight *light = cast_to<const SpotLight>(p_light);
+		l->range = light->get_param(SpotLight::PARAM_RANGE);
+		l->intensity = light->get_param(SpotLight::PARAM_ENERGY);
+		l->outer_cone_angle = Math::deg2rad(light->get_param(SpotLight::PARAM_SPOT_ANGLE));
+		// This equation is the inverse of the import equation (which has a desmos link).
+		float angle_ratio = 1 - (0.2 / (0.1 + light->get_param(SpotLight::PARAM_SPOT_ATTENUATION)));
+		angle_ratio = MAX(0, angle_ratio);
+		l->inner_cone_angle = l->outer_cone_angle * angle_ratio;
+	}
+	return l;
+}
+
+Light *GLTFLight::to_node() const {
+	if (type == "directional") {
+		DirectionalLight *light = memnew(DirectionalLight);
+		light->set_param(Light::PARAM_ENERGY, intensity);
+		light->set_color(color);
+		return light;
+	}
+	if (type == "point") {
+		OmniLight *light = memnew(OmniLight);
+		light->set_param(OmniLight::PARAM_ENERGY, intensity);
+		light->set_param(OmniLight::PARAM_RANGE, CLAMP(range, 0, 4096));
+		light->set_color(color);
+		return light;
+	}
+	if (type == "spot") {
+		SpotLight *light = memnew(SpotLight);
+		light->set_param(SpotLight::PARAM_ENERGY, intensity);
+		light->set_param(SpotLight::PARAM_RANGE, CLAMP(range, 0, 4096));
+		light->set_param(SpotLight::PARAM_SPOT_ANGLE, Math::rad2deg(outer_cone_angle));
+		light->set_color(color);
+		// Line of best fit derived from guessing, see https://www.desmos.com/calculator/biiflubp8b
+		// The points in desmos are not exact, except for (1, infinity).
+		float angle_ratio = inner_cone_angle / outer_cone_angle;
+		float angle_attenuation = 0.2 / (1 - angle_ratio) - 0.1;
+		light->set_param(SpotLight::PARAM_SPOT_ATTENUATION, angle_attenuation);
+		return light;
+	}
+	return memnew(Light);
+}
+
+Ref<GLTFLight> GLTFLight::from_dictionary(const Dictionary p_dictionary) {
+	ERR_FAIL_COND_V_MSG(!p_dictionary.has("type"), Ref<GLTFLight>(), "Failed to parse GLTF light, missing required field 'type'.");
+	Ref<GLTFLight> light;
+	light.instance();
+	const String &type = p_dictionary["type"];
+	light->type = type;
+
+	if (p_dictionary.has("color")) {
+		const Array &arr = p_dictionary["color"];
+		if (arr.size() == 3) {
+			light->color = Color(arr[0], arr[1], arr[2]).to_srgb();
+		} else {
+			ERR_PRINT("Error parsing GLTF light: The color must have exactly 3 numbers.");
+		}
+	}
+	if (p_dictionary.has("intensity")) {
+		light->intensity = p_dictionary["intensity"];
+	}
+	if (p_dictionary.has("range")) {
+		light->range = p_dictionary["range"];
+	}
+	if (type == "spot") {
+		const Dictionary &spot = p_dictionary["spot"];
+		light->inner_cone_angle = spot["innerConeAngle"];
+		light->outer_cone_angle = spot["outerConeAngle"];
+		if (light->inner_cone_angle >= light->outer_cone_angle) {
+			ERR_PRINT("Error parsing GLTF light: The inner angle must be smaller than the outer angle.");
+		}
+	} else if (type != "point" && type != "directional") {
+		ERR_PRINT("Error parsing GLTF light: Light type '" + type + "' is unknown.");
+	}
+	return light;
+}
+
+Dictionary GLTFLight::to_dictionary() const {
+	Dictionary d;
+	Array color_array;
+	color_array.resize(3);
+	color_array[0] = color.r;
+	color_array[1] = color.g;
+	color_array[2] = color.b;
+	d["color"] = color_array;
+	d["type"] = type;
+	if (type == "spot") {
+		Dictionary spot_dict;
+		spot_dict["innerConeAngle"] = inner_cone_angle;
+		spot_dict["outerConeAngle"] = outer_cone_angle;
+		d["spot"] = spot_dict;
+	}
+	d["intensity"] = intensity;
+	d["range"] = range;
+	return d;
 }

--- a/modules/gltf/extensions/gltf_light.h
+++ b/modules/gltf/extensions/gltf_light.h
@@ -34,6 +34,10 @@
 #include "../gltf_defines.h"
 #include "core/resource.h"
 
+class Light;
+
+// https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_lights_punctual
+
 class GLTFLight : public Resource {
 	GDCLASS(GLTFLight, Resource)
 	friend class GLTFDocument;
@@ -67,6 +71,12 @@ public:
 
 	float get_outer_cone_angle();
 	void set_outer_cone_angle(float p_outer_cone_angle);
+
+	static Ref<GLTFLight> from_node(const Light *p_light);
+	Light *to_node() const;
+
+	static Ref<GLTFLight> from_dictionary(const Dictionary p_dictionary);
+	Dictionary to_dictionary() const;
 };
 
 #endif // GLTF_LIGHT_H

--- a/modules/gltf/structures/gltf_camera.h
+++ b/modules/gltf/structures/gltf_camera.h
@@ -33,14 +33,22 @@
 
 #include "core/resource.h"
 
+class Camera;
+
+// Reference and test file:
+// https://github.com/KhronosGroup/glTF-Tutorials/blob/master/gltfTutorial/gltfTutorial_015_SimpleCameras.md
+
 class GLTFCamera : public Resource {
 	GDCLASS(GLTFCamera, Resource);
 
 private:
+	// GLTF has no default camera values, they should always be specified in
+	// the GLTF file. Here we default to Godot's default camera settings.
 	bool perspective = true;
-	float fov_size = 75.0;
-	float zfar = 4000.0;
-	float znear = 0.05;
+	real_t fov = Math::deg2rad(75.0);
+	real_t size_mag = 0.5;
+	real_t zfar = 4000.0;
+	real_t znear = 0.05;
 
 protected:
 	static void _bind_methods();
@@ -48,12 +56,20 @@ protected:
 public:
 	bool get_perspective() const { return perspective; }
 	void set_perspective(bool p_val) { perspective = p_val; }
-	float get_fov_size() const { return fov_size; }
-	void set_fov_size(float p_val) { fov_size = p_val; }
-	float get_zfar() const { return zfar; }
-	void set_zfar(float p_val) { zfar = p_val; }
-	float get_znear() const { return znear; }
-	void set_znear(float p_val) { znear = p_val; }
+	real_t get_fov_size() const { return fov; }
+	void set_fov_size(real_t p_val) { fov = p_val; }
+	real_t get_size_mag() const { return size_mag; }
+	void set_size_mag(real_t p_val) { size_mag = p_val; }
+	real_t get_zfar() const { return zfar; }
+	void set_zfar(real_t p_val) { zfar = p_val; }
+	real_t get_znear() const { return znear; }
+	void set_znear(real_t p_val) { znear = p_val; }
+
+	static Ref<GLTFCamera> from_node(const Camera *p_camera);
+	Camera *to_node() const;
+
+	static Ref<GLTFCamera> from_dictionary(const Dictionary p_dictionary);
+	Dictionary to_dictionary() const;
 };
 
 #endif // GLTF_CAMERA_H


### PR DESCRIPTION
This PR backports #64977, #64400, and #65327 to Godot 3.x. It moves the GLTF camera and light logic to the GLTF subclasses and fixes the import and export of orthographic cameras. I tested this PR on some test files with lights and cameras and they import and export correctly. I also backported the documentation improvements for these classes.

This PR does not break API compatibility, but it does change behavior. The API differences from master are that `light_type` is `type` here, and `fov` is `fov_size` here (was intended to store either perspective FOV or orthographic size, but only ever worked for FOV in 3.x, so this PR just uses this for FOV only and adds a new `size_mag` for the orthographic size to mirror master). The units of the numbers in GLTFCamera are now the same as in GLTF and in master.

Also, note that due to the lack of static methods in 3.x, the `from_` methods are not exposed. I'm not too worried about this, it's not a big deal to be missing them. If there is a desire in the future, we could expose in another way.