### PR TITLE
Fix Navigation API abbreviations inconsistency

### DIFF
--- a/doc/classes/MeshLibrary.xml
+++ b/doc/classes/MeshLibrary.xml
@@ -59,14 +59,14 @@
 				Returns the item's name.
 			</description>
 		</method>
-		<method name="get_item_navmesh" qualifiers="const">
+		<method name="get_item_navigation_mesh" qualifiers="const">
 			<return type="NavigationMesh" />
 			<param index="0" name="id" type="int" />
 			<description>
 				Returns the item's navigation mesh.
 			</description>
 		</method>
-		<method name="get_item_navmesh_transform" qualifiers="const">
+		<method name="get_item_navigation_mesh_transform" qualifiers="const">
 			<return type="Transform3D" />
 			<param index="0" name="id" type="int" />
 			<description>
@@ -126,18 +126,18 @@
 				This name is shown in the editor. It can also be used to look up the item later using [method find_item_by_name].
 			</description>
 		</method>
-		<method name="set_item_navmesh">
+		<method name="set_item_navigation_mesh">
 			<return type="void" />
 			<param index="0" name="id" type="int" />
-			<param index="1" name="navmesh" type="NavigationMesh" />
+			<param index="1" name="navigation_mesh" type="NavigationMesh" />
 			<description>
 				Sets the item's navigation mesh.
 			</description>
 		</method>
-		<method name="set_item_navmesh_transform">
+		<method name="set_item_navigation_mesh_transform">
 			<return type="void" />
 			<param index="0" name="id" type="int" />
-			<param index="1" name="navmesh" type="Transform3D" />
+			<param index="1" name="navigation_mesh" type="Transform3D" />
 			<description>
 				Sets the transform to apply to the item's navigation mesh.
 			</description>

--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -16,22 +16,22 @@
 				Returns the distance to the target location, using the agent's global position. The user must set [member target_location] in order for this to be accurate.
 			</description>
 		</method>
-		<method name="get_final_location">
-			<return type="Vector2" />
-			<description>
-				Returns the reachable final location in global coordinates. This can change if the navigation path is altered in any way. Because of this, it would be best to check this each frame.
-			</description>
-		</method>
-		<method name="get_nav_path" qualifiers="const">
+		<method name="get_current_navigation_path" qualifiers="const">
 			<return type="PackedVector2Array" />
 			<description>
 				Returns this agent's current path from start to finish in global coordinates. The path only updates when the target location is changed or the agent requires a repath. The path array is not intended to be used in direct path movement as the agent has its own internal path logic that would get corrupted by changing the path array manually. Use the intended [method get_next_location] once every physics frame to receive the next path point for the agents movement as this function also updates the internal path logic.
 			</description>
 		</method>
-		<method name="get_nav_path_index" qualifiers="const">
+		<method name="get_current_navigation_path_index" qualifiers="const">
 			<return type="int" />
 			<description>
 				Returns which index the agent is currently on in the navigation path's [PackedVector2Array].
+			</description>
+		</method>
+		<method name="get_final_location">
+			<return type="Vector2" />
+			<description>
+				Returns the reachable final location in global coordinates. This can change if the navigation path is altered in any way. Because of this, it would be best to check this each frame.
 			</description>
 		</method>
 		<method name="get_navigation_layer_value" qualifiers="const">

--- a/doc/classes/NavigationAgent3D.xml
+++ b/doc/classes/NavigationAgent3D.xml
@@ -16,22 +16,22 @@
 				Returns the distance to the target location, using the agent's global position. The user must set [member target_location] in order for this to be accurate.
 			</description>
 		</method>
-		<method name="get_final_location">
-			<return type="Vector3" />
-			<description>
-				Returns the reachable final location in global coordinates. This can change if the navigation path is altered in any way. Because of this, it would be best to check this each frame.
-			</description>
-		</method>
-		<method name="get_nav_path" qualifiers="const">
+		<method name="get_current_navigation_path" qualifiers="const">
 			<return type="PackedVector3Array" />
 			<description>
 				Returns this agent's current path from start to finish in global coordinates. The path only updates when the target location is changed or the agent requires a repath. The path array is not intended to be used in direct path movement as the agent has its own internal path logic that would get corrupted by changing the path array manually. Use the intended [method get_next_location] once every physics frame to receive the next path point for the agents movement as this function also updates the internal path logic.
 			</description>
 		</method>
-		<method name="get_nav_path_index" qualifiers="const">
+		<method name="get_current_navigation_path_index" qualifiers="const">
 			<return type="int" />
 			<description>
 				Returns which index the agent is currently on in the navigation path's [PackedVector3Array].
+			</description>
+		</method>
+		<method name="get_final_location">
+			<return type="Vector3" />
+			<description>
+				Returns the reachable final location in global coordinates. This can change if the navigation path is altered in any way. Because of this, it would be best to check this each frame.
 			</description>
 		</method>
 		<method name="get_navigation_layer_value" qualifiers="const">

--- a/doc/classes/NavigationLink2D.xml
+++ b/doc/classes/NavigationLink2D.xml
@@ -38,7 +38,7 @@
 			The distance the link will search is controlled by [method NavigationServer2D.map_set_link_connection_radius].
 		</member>
 		<member name="enter_cost" type="float" setter="set_enter_cost" getter="get_enter_cost" default="0.0">
-			When pathfinding enters this link from another regions navmesh the [code]enter_cost[/code] value is added to the path distance for determining the shortest path.
+			When pathfinding enters this link from another regions navigation mesh the [code]enter_cost[/code] value is added to the path distance for determining the shortest path.
 		</member>
 		<member name="navigation_layers" type="int" setter="set_navigation_layers" getter="get_navigation_layers" default="1">
 			A bitfield determining all navigation layers the link belongs to. These navigation layers will be checked when requesting a path with [method NavigationServer2D.map_get_path].

--- a/doc/classes/NavigationLink3D.xml
+++ b/doc/classes/NavigationLink3D.xml
@@ -38,7 +38,7 @@
 			The distance the link will search is controlled by [method NavigationServer3D.map_set_link_connection_radius].
 		</member>
 		<member name="enter_cost" type="float" setter="set_enter_cost" getter="get_enter_cost" default="0.0">
-			When pathfinding enters this link from another regions navmesh the [code]enter_cost[/code] value is added to the path distance for determining the shortest path.
+			When pathfinding enters this link from another regions navigation mesh the [code]enter_cost[/code] value is added to the path distance for determining the shortest path.
 		</member>
 		<member name="navigation_layers" type="int" setter="set_navigation_layers" getter="get_navigation_layers" default="1">
 			A bitfield determining all navigation layers the link belongs to. These navigation layers will be checked when requesting a path with [method NavigationServer3D.map_get_path].

--- a/doc/classes/NavigationMesh.xml
+++ b/doc/classes/NavigationMesh.xml
@@ -133,11 +133,11 @@
 		<member name="geometry_source_geometry_mode" type="int" setter="set_source_geometry_mode" getter="get_source_geometry_mode" enum="NavigationMesh.SourceGeometryMode" default="0">
 			The source of the geometry used when baking. See [enum SourceGeometryMode] for possible values.
 		</member>
-		<member name="geometry_source_group_name" type="StringName" setter="set_source_group_name" getter="get_source_group_name" default="&amp;&quot;navmesh&quot;">
+		<member name="geometry_source_group_name" type="StringName" setter="set_source_group_name" getter="get_source_group_name" default="&amp;&quot;navigation_mesh_source_group&quot;">
 			The name of the group to scan for geometry.
 			Only used when [member geometry_source_geometry_mode] is [constant SOURCE_GEOMETRY_GROUPS_WITH_CHILDREN] or [constant SOURCE_GEOMETRY_GROUPS_EXPLICIT].
 		</member>
-		<member name="polygon_verts_per_poly" type="float" setter="set_verts_per_poly" getter="get_verts_per_poly" default="6.0">
+		<member name="polygon_vertices_per_polyon" type="float" setter="set_vertices_per_polyon" getter="get_vertices_per_polyon" default="6.0">
 			The maximum number of vertices allowed for polygons generated during the contour to polygon conversion process.
 		</member>
 		<member name="region_merge_size" type="float" setter="set_region_merge_size" getter="get_region_merge_size" default="20.0">
@@ -177,8 +177,8 @@
 		<constant name="PARSED_GEOMETRY_MAX" value="3" enum="ParsedGeometryType">
 			Represents the size of the [enum ParsedGeometryType] enum.
 		</constant>
-		<constant name="SOURCE_GEOMETRY_NAVMESH_CHILDREN" value="0" enum="SourceGeometryMode">
-			Scans the child nodes of [NavigationRegion3D] recursively for geometry.
+		<constant name="SOURCE_GEOMETRY_ROOT_NODE_CHILDREN" value="0" enum="SourceGeometryMode">
+			Scans the child nodes of the root node recursively for geometry.
 		</constant>
 		<constant name="SOURCE_GEOMETRY_GROUPS_WITH_CHILDREN" value="1" enum="SourceGeometryMode">
 			Scans nodes in a group and their child nodes recursively for geometry. The group is specified by [member geometry_source_group_name].

--- a/doc/classes/NavigationMeshGenerator.xml
+++ b/doc/classes/NavigationMeshGenerator.xml
@@ -15,17 +15,17 @@
 	<methods>
 		<method name="bake">
 			<return type="void" />
-			<param index="0" name="nav_mesh" type="NavigationMesh" />
+			<param index="0" name="navigation_mesh" type="NavigationMesh" />
 			<param index="1" name="root_node" type="Node" />
 			<description>
-				Bakes navigation data to the provided [param nav_mesh] by parsing child nodes under the provided [param root_node] or a specific group of nodes for potential source geometry. The parse behavior can be controlled with the [member NavigationMesh.geometry_parsed_geometry_type] and [member NavigationMesh.geometry_source_geometry_mode] properties on the [NavigationMesh] resource.
+				Bakes navigation data to the provided [param navigation_mesh] by parsing child nodes under the provided [param root_node] or a specific group of nodes for potential source geometry. The parse behavior can be controlled with the [member NavigationMesh.geometry_parsed_geometry_type] and [member NavigationMesh.geometry_source_geometry_mode] properties on the [NavigationMesh] resource.
 			</description>
 		</method>
 		<method name="clear">
 			<return type="void" />
-			<param index="0" name="nav_mesh" type="NavigationMesh" />
+			<param index="0" name="navigation_mesh" type="NavigationMesh" />
 			<description>
-				Removes all polygons and vertices from the provided [param nav_mesh] resource.
+				Removes all polygons and vertices from the provided [param navigation_mesh] resource.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/NavigationPathQueryParameters2D.xml
+++ b/doc/classes/NavigationPathQueryParameters2D.xml
@@ -33,10 +33,10 @@
 			The path query uses the default A* pathfinding algorithm.
 		</constant>
 		<constant name="PATH_POSTPROCESSING_CORRIDORFUNNEL" value="0" enum="PathPostProcessing">
-			Applies a funnel algorithm to the raw path corridor found by the pathfinding algorithm. This will result in the shortest path possible inside the path corridor. This postprocessing very much depends on the navmesh polygon layout and the created corridor. Especially tile- or gridbased layouts can face artificial corners with diagonal movement due to a jagged path corridor imposed by the cell shapes.
+			Applies a funnel algorithm to the raw path corridor found by the pathfinding algorithm. This will result in the shortest path possible inside the path corridor. This postprocessing very much depends on the navigation mesh polygon layout and the created corridor. Especially tile- or gridbased layouts can face artificial corners with diagonal movement due to a jagged path corridor imposed by the cell shapes.
 		</constant>
 		<constant name="PATH_POSTPROCESSING_EDGECENTERED" value="1" enum="PathPostProcessing">
-			Centers every path position in the middle of the traveled navmesh polygon edge. This creates better paths for tile- or gridbased layouts that restrict the movement to the cells center.
+			Centers every path position in the middle of the traveled navigation mesh polygon edge. This creates better paths for tile- or gridbased layouts that restrict the movement to the cells center.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/NavigationPathQueryParameters3D.xml
+++ b/doc/classes/NavigationPathQueryParameters3D.xml
@@ -33,10 +33,10 @@
 			The path query uses the default A* pathfinding algorithm.
 		</constant>
 		<constant name="PATH_POSTPROCESSING_CORRIDORFUNNEL" value="0" enum="PathPostProcessing">
-			Applies a funnel algorithm to the raw path corridor found by the pathfinding algorithm. This will result in the shortest path possible inside the path corridor. This postprocessing very much depends on the navmesh polygon layout and the created corridor. Especially tile- or gridbased layouts can face artificial corners with diagonal movement due to a jagged path corridor imposed by the cell shapes.
+			Applies a funnel algorithm to the raw path corridor found by the pathfinding algorithm. This will result in the shortest path possible inside the path corridor. This postprocessing very much depends on the navigation mesh polygon layout and the created corridor. Especially tile- or gridbased layouts can face artificial corners with diagonal movement due to a jagged path corridor imposed by the cell shapes.
 		</constant>
 		<constant name="PATH_POSTPROCESSING_EDGECENTERED" value="1" enum="PathPostProcessing">
-			Centers every path position in the middle of the traveled navmesh polygon edge. This creates better paths for tile- or gridbased layouts that restrict the movement to the cells center.
+			Centers every path position in the middle of the traveled navigation mesh polygon edge. This creates better paths for tile- or gridbased layouts that restrict the movement to the cells center.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/NavigationPolygon.xml
+++ b/doc/classes/NavigationPolygon.xml
@@ -12,14 +12,14 @@
 		var outline = PackedVector2Array([Vector2(0, 0), Vector2(0, 50), Vector2(50, 50), Vector2(50, 0)])
 		polygon.add_outline(outline)
 		polygon.make_polygons_from_outlines()
-		$NavigationRegion2D.navpoly = polygon
+		$NavigationRegion2D.navigation_polygon = polygon
 		[/gdscript]
 		[csharp]
 		var polygon = new NavigationPolygon();
 		var outline = new Vector2[] { new Vector2(0, 0), new Vector2(0, 50), new Vector2(50, 50), new Vector2(50, 0) };
 		polygon.AddOutline(outline);
 		polygon.MakePolygonsFromOutlines();
-		GetNode&lt;NavigationRegion2D&gt;("NavigationRegion2D").Navpoly = polygon;
+		GetNode&lt;NavigationRegion2D&gt;("NavigationRegion2D").NavigationPolygon = polygon;
 		[/csharp]
 		[/codeblocks]
 		Using [method add_polygon] and indices of the vertices array.
@@ -30,7 +30,7 @@
 		polygon.vertices = vertices
 		var indices = PackedInt32Array([0, 1, 2, 3])
 		polygon.add_polygon(indices)
-		$NavigationRegion2D.navpoly = polygon
+		$NavigationRegion2D.navigation_polygon = polygon
 		[/gdscript]
 		[csharp]
 		var polygon = new NavigationPolygon();
@@ -38,7 +38,7 @@
 		polygon.Vertices = vertices;
 		var indices = new int[] { 0, 1, 2, 3 };
 		polygon.AddPolygon(indices);
-		GetNode&lt;NavigationRegion2D&gt;("NavigationRegion2D").Navpoly = polygon;
+		GetNode&lt;NavigationRegion2D&gt;("NavigationRegion2D").NavigationPolygon = polygon;
 		[/csharp]
 		[/codeblocks]
 	</description>
@@ -80,10 +80,10 @@
 				Clears the array of polygons, but it doesn't clear the array of outlines and vertices.
 			</description>
 		</method>
-		<method name="get_mesh">
+		<method name="get_navigation_mesh">
 			<return type="NavigationMesh" />
 			<description>
-				Returns the [NavigationMesh] resulting from this navigation polygon. This navmesh can be used to update the navmesh of a region with the [method NavigationServer3D.region_set_navmesh] API directly (as 2D uses the 3D server behind the scene).
+				Returns the [NavigationMesh] resulting from this navigation polygon. This navigation mesh can be used to update the navigation mesh of a region with the [method NavigationServer3D.region_set_navigation_mesh] API directly (as 2D uses the 3D server behind the scene).
 			</description>
 		</method>
 		<method name="get_outline" qualifiers="const">

--- a/doc/classes/NavigationRegion2D.xml
+++ b/doc/classes/NavigationRegion2D.xml
@@ -6,7 +6,7 @@
 	<description>
 		A region of the navigation map. It tells the [NavigationServer2D] what can be navigated and what cannot, based on its [NavigationPolygon] resource.
 		Two regions can be connected to each other if they share a similar edge. You can set the minimum distance between two vertices required to connect two edges by using [method NavigationServer2D.map_set_edge_connection_margin].
-		[b]Note:[/b] Overlapping two regions' polygons is not enough for connecting two regions. They must share a similar edge.
+		[b]Note:[/b] Overlapping two regions' navigation polygons is not enough for connecting two regions. They must share a similar edge.
 		The pathfinding cost of entering this region from another region can be controlled with the [member enter_cost] value.
 		[b]Note:[/b] This value is not added to the path cost when the start position is already inside this region.
 		The pathfinding cost of traveling distances inside this region can be controlled with the [member travel_cost] multiplier.
@@ -42,16 +42,16 @@
 			Determines if the [NavigationRegion2D] is enabled or disabled.
 		</member>
 		<member name="enter_cost" type="float" setter="set_enter_cost" getter="get_enter_cost" default="0.0">
-			When pathfinding enters this region's navmesh from another regions navmesh the [code]enter_cost[/code] value is added to the path distance for determining the shortest path.
+			When pathfinding enters this region's navigation mesh from another regions navigation mesh the [code]enter_cost[/code] value is added to the path distance for determining the shortest path.
 		</member>
 		<member name="navigation_layers" type="int" setter="set_navigation_layers" getter="get_navigation_layers" default="1">
 			A bitfield determining all navigation layers the region belongs to. These navigation layers can be checked upon when requesting a path with [method NavigationServer2D.map_get_path].
 		</member>
-		<member name="navpoly" type="NavigationPolygon" setter="set_navigation_polygon" getter="get_navigation_polygon">
+		<member name="navigation_polygon" type="NavigationPolygon" setter="set_navigation_polygon" getter="get_navigation_polygon">
 			The [NavigationPolygon] resource to use.
 		</member>
 		<member name="travel_cost" type="float" setter="set_travel_cost" getter="get_travel_cost" default="1.0">
-			When pathfinding moves inside this region's navmesh the traveled distances are multiplied with [code]travel_cost[/code] for determining the shortest path.
+			When pathfinding moves inside this region's navigation mesh the traveled distances are multiplied with [code]travel_cost[/code] for determining the shortest path.
 		</member>
 	</members>
 </class>

--- a/doc/classes/NavigationRegion3D.xml
+++ b/doc/classes/NavigationRegion3D.xml
@@ -6,7 +6,7 @@
 	<description>
 		A region of the navigation map. It tells the [NavigationServer3D] what can be navigated and what cannot, based on its [NavigationMesh] resource.
 		Two regions can be connected to each other if they share a similar edge. You can set the minimum distance between two vertices required to connect two edges by using [method NavigationServer3D.map_set_edge_connection_margin].
-		[b]Note:[/b] Overlapping two regions' navmeshes is not enough for connecting two regions. They must share a similar edge.
+		[b]Note:[/b] Overlapping two regions' navigation meshes is not enough for connecting two regions. They must share a similar edge.
 		The cost of entering this region from another region can be controlled with the [member enter_cost] value.
 		[b]Note:[/b] This value is not added to the path cost when the start position is already inside this region.
 		The cost of traveling distances inside this region can be controlled with the [member travel_cost] multiplier.
@@ -49,16 +49,16 @@
 			Determines if the [NavigationRegion3D] is enabled or disabled.
 		</member>
 		<member name="enter_cost" type="float" setter="set_enter_cost" getter="get_enter_cost" default="0.0">
-			When pathfinding enters this region's navmesh from another regions navmesh the [code]enter_cost[/code] value is added to the path distance for determining the shortest path.
+			When pathfinding enters this region's navigation mesh from another regions navigation mesh the [code]enter_cost[/code] value is added to the path distance for determining the shortest path.
 		</member>
 		<member name="navigation_layers" type="int" setter="set_navigation_layers" getter="get_navigation_layers" default="1">
 			A bitfield determining all navigation layers the region belongs to. These navigation layers can be checked upon when requesting a path with [method NavigationServer3D.map_get_path].
 		</member>
-		<member name="navmesh" type="NavigationMesh" setter="set_navigation_mesh" getter="get_navigation_mesh">
+		<member name="navigation_mesh" type="NavigationMesh" setter="set_navigation_mesh" getter="get_navigation_mesh">
 			The [NavigationMesh] resource to use.
 		</member>
 		<member name="travel_cost" type="float" setter="set_travel_cost" getter="get_travel_cost" default="1.0">
-			When pathfinding moves inside this region's navmesh the traveled distances are multiplied with [code]travel_cost[/code] for determining the shortest path.
+			When pathfinding moves inside this region's navigation mesh the traveled distances are multiplied with [code]travel_cost[/code] for determining the shortest path.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -489,12 +489,12 @@
 				Set the region's navigation layers. This allows selecting regions from a path request (when using [method NavigationServer2D.map_get_path]).
 			</description>
 		</method>
-		<method name="region_set_navpoly" qualifiers="const">
+		<method name="region_set_navigation_polygon" qualifiers="const">
 			<return type="void" />
 			<param index="0" name="region" type="RID" />
-			<param index="1" name="nav_poly" type="NavigationPolygon" />
+			<param index="1" name="navigation_polygon" type="NavigationPolygon" />
 			<description>
-				Sets the navigation mesh for the region.
+				Sets the [param navigation_polygon] for the region.
 			</description>
 		</method>
 		<method name="region_set_owner_id" qualifiers="const">

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -433,12 +433,12 @@
 				Queries a path in a given navigation map. Start and target position and other parameters are defined through [NavigationPathQueryParameters3D]. Updates the provided [NavigationPathQueryResult3D] result object with the path among other results requested by the query.
 			</description>
 		</method>
-		<method name="region_bake_navmesh" qualifiers="const">
+		<method name="region_bake_navigation_mesh" qualifiers="const">
 			<return type="void" />
-			<param index="0" name="mesh" type="NavigationMesh" />
-			<param index="1" name="node" type="Node" />
+			<param index="0" name="navigation_mesh" type="NavigationMesh" />
+			<param index="1" name="root_node" type="Node" />
 			<description>
-				Bakes the navigation mesh.
+				Bakes the [param navigation_mesh] with bake source geometry collected starting from the [param root_node].
 			</description>
 		</method>
 		<method name="region_create" qualifiers="const">
@@ -539,10 +539,10 @@
 				Set the region's navigation layers. This allows selecting regions from a path request (when using [method NavigationServer3D.map_get_path]).
 			</description>
 		</method>
-		<method name="region_set_navmesh" qualifiers="const">
+		<method name="region_set_navigation_mesh" qualifiers="const">
 			<return type="void" />
 			<param index="0" name="region" type="RID" />
-			<param index="1" name="nav_mesh" type="NavigationMesh" />
+			<param index="1" name="navigation_mesh" type="NavigationMesh" />
 			<description>
 				Sets the navigation mesh for the region.
 			</description>

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -160,23 +160,23 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 
 		p_library->set_item_shapes(id, collisions);
 
-		Ref<NavigationMesh> navmesh;
-		Transform3D navmesh_transform;
+		Ref<NavigationMesh> navigation_mesh;
+		Transform3D navigation_mesh_transform;
 		for (int j = 0; j < mi->get_child_count(); j++) {
 			Node *child2 = mi->get_child(j);
 			if (!Object::cast_to<NavigationRegion3D>(child2)) {
 				continue;
 			}
 			NavigationRegion3D *sb = Object::cast_to<NavigationRegion3D>(child2);
-			navmesh = sb->get_navigation_mesh();
-			navmesh_transform = sb->get_transform();
-			if (!navmesh.is_null()) {
+			navigation_mesh = sb->get_navigation_mesh();
+			navigation_mesh_transform = sb->get_transform();
+			if (!navigation_mesh.is_null()) {
 				break;
 			}
 		}
-		if (!navmesh.is_null()) {
-			p_library->set_item_navmesh(id, navmesh);
-			p_library->set_item_navmesh_transform(id, navmesh_transform);
+		if (!navigation_mesh.is_null()) {
+			p_library->set_item_navigation_mesh(id, navigation_mesh);
+			p_library->set_item_navigation_mesh_transform(id, navigation_mesh_transform);
 		}
 	}
 

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -95,10 +95,10 @@ class GridMap : public Node3D {
 	 * A GridMap can have multiple Octants.
 	 */
 	struct Octant {
-		struct NavMesh {
+		struct NavigationCell {
 			RID region;
 			Transform3D xform;
-			RID navmesh_debug_instance;
+			RID navigation_mesh_debug_instance;
 		};
 
 		struct MultimeshInstance {
@@ -124,7 +124,7 @@ class GridMap : public Node3D {
 
 		bool dirty = false;
 		RID static_body;
-		HashMap<IndexKey, NavMesh> navmesh_ids;
+		HashMap<IndexKey, NavigationCell> navigation_cell_ids;
 	};
 
 	union OctantKey {

--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -421,20 +421,20 @@ uint32_t GodotNavigationServer::region_get_navigation_layers(RID p_region) const
 	return region->get_navigation_layers();
 }
 
-COMMAND_2(region_set_navmesh, RID, p_region, Ref<NavigationMesh>, p_nav_mesh) {
+COMMAND_2(region_set_navigation_mesh, RID, p_region, Ref<NavigationMesh>, p_navigation_mesh) {
 	NavRegion *region = region_owner.get_or_null(p_region);
 	ERR_FAIL_COND(region == nullptr);
 
-	region->set_mesh(p_nav_mesh);
+	region->set_mesh(p_navigation_mesh);
 }
 
-void GodotNavigationServer::region_bake_navmesh(Ref<NavigationMesh> r_mesh, Node *p_node) const {
-	ERR_FAIL_COND(r_mesh.is_null());
-	ERR_FAIL_COND(p_node == nullptr);
+void GodotNavigationServer::region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) const {
+	ERR_FAIL_COND(p_navigation_mesh.is_null());
+	ERR_FAIL_COND(p_root_node == nullptr);
 
 #ifndef _3D_DISABLED
-	NavigationMeshGenerator::get_singleton()->clear(r_mesh);
-	NavigationMeshGenerator::get_singleton()->bake(r_mesh, p_node);
+	NavigationMeshGenerator::get_singleton()->clear(p_navigation_mesh);
+	NavigationMeshGenerator::get_singleton()->bake(p_navigation_mesh, p_root_node);
 #endif
 }
 

--- a/modules/navigation/godot_navigation_server.h
+++ b/modules/navigation/godot_navigation_server.h
@@ -135,8 +135,8 @@ public:
 	COMMAND_2(region_set_navigation_layers, RID, p_region, uint32_t, p_navigation_layers);
 	virtual uint32_t region_get_navigation_layers(RID p_region) const override;
 	COMMAND_2(region_set_transform, RID, p_region, Transform3D, p_transform);
-	COMMAND_2(region_set_navmesh, RID, p_region, Ref<NavigationMesh>, p_nav_mesh);
-	virtual void region_bake_navmesh(Ref<NavigationMesh> r_mesh, Node *p_node) const override;
+	COMMAND_2(region_set_navigation_mesh, RID, p_region, Ref<NavigationMesh>, p_navigation_mesh);
+	virtual void region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) const override;
 	virtual int region_get_connections_count(RID p_region) const override;
 	virtual Vector3 region_get_connection_pathway_start(RID p_region, int p_connection_id) const override;
 	virtual Vector3 region_get_connection_pathway_end(RID p_region, int p_connection_id) const override;

--- a/modules/navigation/navigation_mesh_generator.cpp
+++ b/modules/navigation/navigation_mesh_generator.cpp
@@ -470,14 +470,14 @@ void NavigationMeshGenerator::_parse_geometry(const Transform3D &p_navmesh_trans
 	}
 }
 
-void NavigationMeshGenerator::_convert_detail_mesh_to_native_navigation_mesh(const rcPolyMeshDetail *p_detail_mesh, Ref<NavigationMesh> p_nav_mesh) {
+void NavigationMeshGenerator::_convert_detail_mesh_to_native_navigation_mesh(const rcPolyMeshDetail *p_detail_mesh, Ref<NavigationMesh> p_navigation_mesh) {
 	Vector<Vector3> nav_vertices;
 
 	for (int i = 0; i < p_detail_mesh->nverts; i++) {
 		const float *v = &p_detail_mesh->verts[i * 3];
 		nav_vertices.push_back(Vector3(v[0], v[1], v[2]));
 	}
-	p_nav_mesh->set_vertices(nav_vertices);
+	p_navigation_mesh->set_vertices(nav_vertices);
 
 	for (int i = 0; i < p_detail_mesh->nmeshes; i++) {
 		const unsigned int *m = &p_detail_mesh->meshes[i * 4];
@@ -492,13 +492,13 @@ void NavigationMeshGenerator::_convert_detail_mesh_to_native_navigation_mesh(con
 			nav_indices.write[0] = ((int)(bverts + tris[j * 4 + 0]));
 			nav_indices.write[1] = ((int)(bverts + tris[j * 4 + 2]));
 			nav_indices.write[2] = ((int)(bverts + tris[j * 4 + 1]));
-			p_nav_mesh->add_polygon(nav_indices);
+			p_navigation_mesh->add_polygon(nav_indices);
 		}
 	}
 }
 
 void NavigationMeshGenerator::_build_recast_navigation_mesh(
-		Ref<NavigationMesh> p_nav_mesh,
+		Ref<NavigationMesh> p_navigation_mesh,
 #ifdef TOOLS_ENABLED
 		EditorProgress *ep,
 #endif
@@ -528,42 +528,42 @@ void NavigationMeshGenerator::_build_recast_navigation_mesh(
 	rcConfig cfg;
 	memset(&cfg, 0, sizeof(cfg));
 
-	cfg.cs = p_nav_mesh->get_cell_size();
-	cfg.ch = p_nav_mesh->get_cell_height();
-	cfg.walkableSlopeAngle = p_nav_mesh->get_agent_max_slope();
-	cfg.walkableHeight = (int)Math::ceil(p_nav_mesh->get_agent_height() / cfg.ch);
-	cfg.walkableClimb = (int)Math::floor(p_nav_mesh->get_agent_max_climb() / cfg.ch);
-	cfg.walkableRadius = (int)Math::ceil(p_nav_mesh->get_agent_radius() / cfg.cs);
-	cfg.maxEdgeLen = (int)(p_nav_mesh->get_edge_max_length() / p_nav_mesh->get_cell_size());
-	cfg.maxSimplificationError = p_nav_mesh->get_edge_max_error();
-	cfg.minRegionArea = (int)(p_nav_mesh->get_region_min_size() * p_nav_mesh->get_region_min_size());
-	cfg.mergeRegionArea = (int)(p_nav_mesh->get_region_merge_size() * p_nav_mesh->get_region_merge_size());
-	cfg.maxVertsPerPoly = (int)p_nav_mesh->get_verts_per_poly();
-	cfg.detailSampleDist = MAX(p_nav_mesh->get_cell_size() * p_nav_mesh->get_detail_sample_distance(), 0.1f);
-	cfg.detailSampleMaxError = p_nav_mesh->get_cell_height() * p_nav_mesh->get_detail_sample_max_error();
+	cfg.cs = p_navigation_mesh->get_cell_size();
+	cfg.ch = p_navigation_mesh->get_cell_height();
+	cfg.walkableSlopeAngle = p_navigation_mesh->get_agent_max_slope();
+	cfg.walkableHeight = (int)Math::ceil(p_navigation_mesh->get_agent_height() / cfg.ch);
+	cfg.walkableClimb = (int)Math::floor(p_navigation_mesh->get_agent_max_climb() / cfg.ch);
+	cfg.walkableRadius = (int)Math::ceil(p_navigation_mesh->get_agent_radius() / cfg.cs);
+	cfg.maxEdgeLen = (int)(p_navigation_mesh->get_edge_max_length() / p_navigation_mesh->get_cell_size());
+	cfg.maxSimplificationError = p_navigation_mesh->get_edge_max_error();
+	cfg.minRegionArea = (int)(p_navigation_mesh->get_region_min_size() * p_navigation_mesh->get_region_min_size());
+	cfg.mergeRegionArea = (int)(p_navigation_mesh->get_region_merge_size() * p_navigation_mesh->get_region_merge_size());
+	cfg.maxVertsPerPoly = (int)p_navigation_mesh->get_vertices_per_polyon();
+	cfg.detailSampleDist = MAX(p_navigation_mesh->get_cell_size() * p_navigation_mesh->get_detail_sample_distance(), 0.1f);
+	cfg.detailSampleMaxError = p_navigation_mesh->get_cell_height() * p_navigation_mesh->get_detail_sample_max_error();
 
-	if (!Math::is_equal_approx((float)cfg.walkableHeight * cfg.ch, p_nav_mesh->get_agent_height())) {
+	if (!Math::is_equal_approx((float)cfg.walkableHeight * cfg.ch, p_navigation_mesh->get_agent_height())) {
 		WARN_PRINT("Property agent_height is ceiled to cell_height voxel units and loses precision.");
 	}
-	if (!Math::is_equal_approx((float)cfg.walkableClimb * cfg.ch, p_nav_mesh->get_agent_max_climb())) {
+	if (!Math::is_equal_approx((float)cfg.walkableClimb * cfg.ch, p_navigation_mesh->get_agent_max_climb())) {
 		WARN_PRINT("Property agent_max_climb is floored to cell_height voxel units and loses precision.");
 	}
-	if (!Math::is_equal_approx((float)cfg.walkableRadius * cfg.cs, p_nav_mesh->get_agent_radius())) {
+	if (!Math::is_equal_approx((float)cfg.walkableRadius * cfg.cs, p_navigation_mesh->get_agent_radius())) {
 		WARN_PRINT("Property agent_radius is ceiled to cell_size voxel units and loses precision.");
 	}
-	if (!Math::is_equal_approx((float)cfg.maxEdgeLen * cfg.cs, p_nav_mesh->get_edge_max_length())) {
+	if (!Math::is_equal_approx((float)cfg.maxEdgeLen * cfg.cs, p_navigation_mesh->get_edge_max_length())) {
 		WARN_PRINT("Property edge_max_length is rounded to cell_size voxel units and loses precision.");
 	}
-	if (!Math::is_equal_approx((float)cfg.minRegionArea, p_nav_mesh->get_region_min_size() * p_nav_mesh->get_region_min_size())) {
+	if (!Math::is_equal_approx((float)cfg.minRegionArea, p_navigation_mesh->get_region_min_size() * p_navigation_mesh->get_region_min_size())) {
 		WARN_PRINT("Property region_min_size is converted to int and loses precision.");
 	}
-	if (!Math::is_equal_approx((float)cfg.mergeRegionArea, p_nav_mesh->get_region_merge_size() * p_nav_mesh->get_region_merge_size())) {
+	if (!Math::is_equal_approx((float)cfg.mergeRegionArea, p_navigation_mesh->get_region_merge_size() * p_navigation_mesh->get_region_merge_size())) {
 		WARN_PRINT("Property region_merge_size is converted to int and loses precision.");
 	}
-	if (!Math::is_equal_approx((float)cfg.maxVertsPerPoly, p_nav_mesh->get_verts_per_poly())) {
-		WARN_PRINT("Property verts_per_poly is converted to int and loses precision.");
+	if (!Math::is_equal_approx((float)cfg.maxVertsPerPoly, p_navigation_mesh->get_vertices_per_polyon())) {
+		WARN_PRINT("Property vertices_per_polyon is converted to int and loses precision.");
 	}
-	if (p_nav_mesh->get_cell_size() * p_nav_mesh->get_detail_sample_distance() < 0.1f) {
+	if (p_navigation_mesh->get_cell_size() * p_navigation_mesh->get_detail_sample_distance() < 0.1f) {
 		WARN_PRINT("Property detail_sample_distance is clamped to 0.1 world units as the resulting value from multiplying with cell_size is too low.");
 	}
 
@@ -574,9 +574,9 @@ void NavigationMeshGenerator::_build_recast_navigation_mesh(
 	cfg.bmax[1] = bmax[1];
 	cfg.bmax[2] = bmax[2];
 
-	AABB baking_aabb = p_nav_mesh->get_filter_baking_aabb();
+	AABB baking_aabb = p_navigation_mesh->get_filter_baking_aabb();
 	if (baking_aabb.has_volume()) {
-		Vector3 baking_aabb_offset = p_nav_mesh->get_filter_baking_aabb_offset();
+		Vector3 baking_aabb_offset = p_navigation_mesh->get_filter_baking_aabb_offset();
 		cfg.bmin[0] = baking_aabb.position[0] + baking_aabb_offset.x;
 		cfg.bmin[1] = baking_aabb.position[1] + baking_aabb_offset.y;
 		cfg.bmin[2] = baking_aabb.position[2] + baking_aabb_offset.z;
@@ -627,13 +627,13 @@ void NavigationMeshGenerator::_build_recast_navigation_mesh(
 		ERR_FAIL_COND(!rcRasterizeTriangles(&ctx, verts, nverts, tris, tri_areas.ptr(), ntris, *hf, cfg.walkableClimb));
 	}
 
-	if (p_nav_mesh->get_filter_low_hanging_obstacles()) {
+	if (p_navigation_mesh->get_filter_low_hanging_obstacles()) {
 		rcFilterLowHangingWalkableObstacles(&ctx, cfg.walkableClimb, *hf);
 	}
-	if (p_nav_mesh->get_filter_ledge_spans()) {
+	if (p_navigation_mesh->get_filter_ledge_spans()) {
 		rcFilterLedgeSpans(&ctx, cfg.walkableHeight, cfg.walkableClimb, *hf);
 	}
-	if (p_nav_mesh->get_filter_walkable_low_height_spans()) {
+	if (p_navigation_mesh->get_filter_walkable_low_height_spans()) {
 		rcFilterWalkableLowHeightSpans(&ctx, cfg.walkableHeight, *hf);
 	}
 
@@ -665,10 +665,10 @@ void NavigationMeshGenerator::_build_recast_navigation_mesh(
 	}
 #endif
 
-	if (p_nav_mesh->get_sample_partition_type() == NavigationMesh::SAMPLE_PARTITION_WATERSHED) {
+	if (p_navigation_mesh->get_sample_partition_type() == NavigationMesh::SAMPLE_PARTITION_WATERSHED) {
 		ERR_FAIL_COND(!rcBuildDistanceField(&ctx, *chf));
 		ERR_FAIL_COND(!rcBuildRegions(&ctx, *chf, 0, cfg.minRegionArea, cfg.mergeRegionArea));
-	} else if (p_nav_mesh->get_sample_partition_type() == NavigationMesh::SAMPLE_PARTITION_MONOTONE) {
+	} else if (p_navigation_mesh->get_sample_partition_type() == NavigationMesh::SAMPLE_PARTITION_MONOTONE) {
 		ERR_FAIL_COND(!rcBuildRegionsMonotone(&ctx, *chf, 0, cfg.minRegionArea, cfg.mergeRegionArea));
 	} else {
 		ERR_FAIL_COND(!rcBuildLayerRegions(&ctx, *chf, 0, cfg.minRegionArea));
@@ -710,7 +710,7 @@ void NavigationMeshGenerator::_build_recast_navigation_mesh(
 	}
 #endif
 
-	_convert_detail_mesh_to_native_navigation_mesh(detail_mesh, p_nav_mesh);
+	_convert_detail_mesh_to_native_navigation_mesh(detail_mesh, p_navigation_mesh);
 
 	rcFreePolyMesh(poly_mesh);
 	poly_mesh = nullptr;
@@ -729,8 +729,8 @@ NavigationMeshGenerator::NavigationMeshGenerator() {
 NavigationMeshGenerator::~NavigationMeshGenerator() {
 }
 
-void NavigationMeshGenerator::bake(Ref<NavigationMesh> p_nav_mesh, Node *p_node) {
-	ERR_FAIL_COND_MSG(!p_nav_mesh.is_valid(), "Invalid navigation mesh.");
+void NavigationMeshGenerator::bake(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) {
+	ERR_FAIL_COND_MSG(!p_navigation_mesh.is_valid(), "Invalid navigation mesh.");
 
 #ifdef TOOLS_ENABLED
 	EditorProgress *ep(nullptr);
@@ -755,17 +755,17 @@ void NavigationMeshGenerator::bake(Ref<NavigationMesh> p_nav_mesh, Node *p_node)
 
 	List<Node *> parse_nodes;
 
-	if (p_nav_mesh->get_source_geometry_mode() == NavigationMesh::SOURCE_GEOMETRY_NAVMESH_CHILDREN) {
-		parse_nodes.push_back(p_node);
+	if (p_navigation_mesh->get_source_geometry_mode() == NavigationMesh::SOURCE_GEOMETRY_ROOT_NODE_CHILDREN) {
+		parse_nodes.push_back(p_root_node);
 	} else {
-		p_node->get_tree()->get_nodes_in_group(p_nav_mesh->get_source_group_name(), &parse_nodes);
+		p_root_node->get_tree()->get_nodes_in_group(p_navigation_mesh->get_source_group_name(), &parse_nodes);
 	}
 
-	Transform3D navmesh_xform = Object::cast_to<Node3D>(p_node)->get_global_transform().affine_inverse();
+	Transform3D navmesh_xform = Object::cast_to<Node3D>(p_root_node)->get_global_transform().affine_inverse();
 	for (Node *E : parse_nodes) {
-		NavigationMesh::ParsedGeometryType geometry_type = p_nav_mesh->get_parsed_geometry_type();
-		uint32_t collision_mask = p_nav_mesh->get_collision_mask();
-		bool recurse_children = p_nav_mesh->get_source_geometry_mode() != NavigationMesh::SOURCE_GEOMETRY_GROUPS_EXPLICIT;
+		NavigationMesh::ParsedGeometryType geometry_type = p_navigation_mesh->get_parsed_geometry_type();
+		uint32_t collision_mask = p_navigation_mesh->get_collision_mask();
+		bool recurse_children = p_navigation_mesh->get_source_geometry_mode() != NavigationMesh::SOURCE_GEOMETRY_GROUPS_EXPLICIT;
 		_parse_geometry(navmesh_xform, E, vertices, indices, geometry_type, collision_mask, recurse_children);
 	}
 
@@ -777,7 +777,7 @@ void NavigationMeshGenerator::bake(Ref<NavigationMesh> p_nav_mesh, Node *p_node)
 		rcPolyMeshDetail *detail_mesh = nullptr;
 
 		_build_recast_navigation_mesh(
-				p_nav_mesh,
+				p_navigation_mesh,
 #ifdef TOOLS_ENABLED
 				ep,
 #endif
@@ -816,16 +816,16 @@ void NavigationMeshGenerator::bake(Ref<NavigationMesh> p_nav_mesh, Node *p_node)
 #endif
 }
 
-void NavigationMeshGenerator::clear(Ref<NavigationMesh> p_nav_mesh) {
-	if (p_nav_mesh.is_valid()) {
-		p_nav_mesh->clear_polygons();
-		p_nav_mesh->set_vertices(Vector<Vector3>());
+void NavigationMeshGenerator::clear(Ref<NavigationMesh> p_navigation_mesh) {
+	if (p_navigation_mesh.is_valid()) {
+		p_navigation_mesh->clear_polygons();
+		p_navigation_mesh->set_vertices(Vector<Vector3>());
 	}
 }
 
 void NavigationMeshGenerator::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("bake", "nav_mesh", "root_node"), &NavigationMeshGenerator::bake);
-	ClassDB::bind_method(D_METHOD("clear", "nav_mesh"), &NavigationMeshGenerator::clear);
+	ClassDB::bind_method(D_METHOD("bake", "navigation_mesh", "root_node"), &NavigationMeshGenerator::bake);
+	ClassDB::bind_method(D_METHOD("clear", "navigation_mesh"), &NavigationMeshGenerator::clear);
 }
 
 #endif

--- a/modules/navigation/navigation_mesh_generator.h
+++ b/modules/navigation/navigation_mesh_generator.h
@@ -55,9 +55,9 @@ protected:
 	static void _add_faces(const PackedVector3Array &p_faces, const Transform3D &p_xform, Vector<float> &p_vertices, Vector<int> &p_indices);
 	static void _parse_geometry(const Transform3D &p_navmesh_transform, Node *p_node, Vector<float> &p_vertices, Vector<int> &p_indices, NavigationMesh::ParsedGeometryType p_generate_from, uint32_t p_collision_mask, bool p_recurse_children);
 
-	static void _convert_detail_mesh_to_native_navigation_mesh(const rcPolyMeshDetail *p_detail_mesh, Ref<NavigationMesh> p_nav_mesh);
+	static void _convert_detail_mesh_to_native_navigation_mesh(const rcPolyMeshDetail *p_detail_mesh, Ref<NavigationMesh> p_navigation_mesh);
 	static void _build_recast_navigation_mesh(
-			Ref<NavigationMesh> p_nav_mesh,
+			Ref<NavigationMesh> p_navigation_mesh,
 #ifdef TOOLS_ENABLED
 			EditorProgress *ep,
 #endif
@@ -75,8 +75,8 @@ public:
 	NavigationMeshGenerator();
 	~NavigationMeshGenerator();
 
-	void bake(Ref<NavigationMesh> p_nav_mesh, Node *p_node);
-	void clear(Ref<NavigationMesh> p_nav_mesh);
+	void bake(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node);
+	void clear(Ref<NavigationMesh> p_navigation_mesh);
 };
 
 #endif

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -79,8 +79,8 @@ void NavigationAgent2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_next_location"), &NavigationAgent2D::get_next_location);
 	ClassDB::bind_method(D_METHOD("distance_to_target"), &NavigationAgent2D::distance_to_target);
 	ClassDB::bind_method(D_METHOD("set_velocity", "velocity"), &NavigationAgent2D::set_velocity);
-	ClassDB::bind_method(D_METHOD("get_nav_path"), &NavigationAgent2D::get_nav_path);
-	ClassDB::bind_method(D_METHOD("get_nav_path_index"), &NavigationAgent2D::get_nav_path_index);
+	ClassDB::bind_method(D_METHOD("get_current_navigation_path"), &NavigationAgent2D::get_current_navigation_path);
+	ClassDB::bind_method(D_METHOD("get_current_navigation_path_index"), &NavigationAgent2D::get_current_navigation_path_index);
 	ClassDB::bind_method(D_METHOD("is_target_reached"), &NavigationAgent2D::is_target_reached);
 	ClassDB::bind_method(D_METHOD("is_target_reachable"), &NavigationAgent2D::is_target_reachable);
 	ClassDB::bind_method(D_METHOD("is_navigation_finished"), &NavigationAgent2D::is_navigation_finished);
@@ -329,11 +329,11 @@ Vector2 NavigationAgent2D::get_next_location() {
 		ERR_FAIL_COND_V_MSG(agent_parent == nullptr, Vector2(), "The agent has no parent.");
 		return agent_parent->get_global_position();
 	} else {
-		return navigation_path[nav_path_index];
+		return navigation_path[navigation_path_index];
 	}
 }
 
-const Vector<Vector2> &NavigationAgent2D::get_nav_path() const {
+const Vector<Vector2> &NavigationAgent2D::get_current_navigation_path() const {
 	return navigation_result->get_path();
 }
 
@@ -418,12 +418,12 @@ void NavigationAgent2D::update_navigation() {
 		reload_path = true;
 	} else {
 		// Check if too far from the navigation path
-		if (nav_path_index > 0) {
+		if (navigation_path_index > 0) {
 			const Vector<Vector2> &navigation_path = navigation_result->get_path();
 
 			Vector2 segment[2];
-			segment[0] = navigation_path[nav_path_index - 1];
-			segment[1] = navigation_path[nav_path_index];
+			segment[0] = navigation_path[navigation_path_index - 1];
+			segment[1] = navigation_path[navigation_path_index];
 			Vector2 p = Geometry2D::get_closest_point_to_segment(origin, segment);
 			if (origin.distance_to(p) >= path_max_distance) {
 				// To faraway, reload path
@@ -445,7 +445,7 @@ void NavigationAgent2D::update_navigation() {
 
 		NavigationServer2D::get_singleton()->query_path(navigation_query, navigation_result);
 		navigation_finished = false;
-		nav_path_index = 0;
+		navigation_path_index = 0;
 		emit_signal(SNAME("path_changed"));
 	}
 
@@ -457,11 +457,11 @@ void NavigationAgent2D::update_navigation() {
 	if (navigation_finished == false) {
 		// Advances to the next far away location.
 		const Vector<Vector2> &navigation_path = navigation_result->get_path();
-		while (origin.distance_to(navigation_path[nav_path_index]) < path_desired_distance) {
-			nav_path_index += 1;
-			if (nav_path_index == navigation_path.size()) {
+		while (origin.distance_to(navigation_path[navigation_path_index]) < path_desired_distance) {
+			navigation_path_index += 1;
+			if (navigation_path_index == navigation_path.size()) {
 				_check_distance_to_target();
-				nav_path_index -= 1;
+				navigation_path_index -= 1;
 				navigation_finished = true;
 				emit_signal(SNAME("navigation_finished"));
 				break;

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -62,7 +62,7 @@ class NavigationAgent2D : public Node {
 	Vector2 target_location;
 	Ref<NavigationPathQueryParameters2D> navigation_query;
 	Ref<NavigationPathQueryResult2D> navigation_result;
-	int nav_path_index = 0;
+	int navigation_path_index = 0;
 	bool velocity_submitted = false;
 	Vector2 prev_safe_velocity;
 	/// The submitted target velocity
@@ -141,10 +141,10 @@ public:
 
 	Vector2 get_next_location();
 
-	const Vector<Vector2> &get_nav_path() const;
+	const Vector<Vector2> &get_current_navigation_path() const;
 
-	int get_nav_path_index() const {
-		return nav_path_index;
+	int get_current_navigation_path_index() const {
+		return navigation_path_index;
 	}
 
 	real_t distance_to_target() const;

--- a/scene/2d/navigation_region_2d.h
+++ b/scene/2d/navigation_region_2d.h
@@ -41,9 +41,9 @@ class NavigationRegion2D : public Node2D {
 	uint32_t navigation_layers = 1;
 	real_t enter_cost = 0.0;
 	real_t travel_cost = 1.0;
-	Ref<NavigationPolygon> navpoly;
+	Ref<NavigationPolygon> navigation_polygon;
 
-	void _navpoly_changed();
+	void _navigation_polygon_changed();
 	void _map_changed(RID p_RID);
 
 protected:
@@ -73,7 +73,7 @@ public:
 	void set_travel_cost(real_t p_travel_cost);
 	real_t get_travel_cost() const;
 
-	void set_navigation_polygon(const Ref<NavigationPolygon> &p_navpoly);
+	void set_navigation_polygon(const Ref<NavigationPolygon> &p_navigation_polygon);
 	Ref<NavigationPolygon> get_navigation_polygon() const;
 
 	PackedStringArray get_configuration_warnings() const override;

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1728,10 +1728,10 @@ void TileMap::_navigation_update_dirty_quadrants(SelfList<TileMapQuadrant>::List
 					q.navigation_regions[E_cell].resize(tile_set->get_navigation_layers_count());
 
 					for (int layer_index = 0; layer_index < tile_set->get_navigation_layers_count(); layer_index++) {
-						Ref<NavigationPolygon> navpoly;
-						navpoly = tile_data->get_navigation_polygon(layer_index);
+						Ref<NavigationPolygon> navigation_polygon;
+						navigation_polygon = tile_data->get_navigation_polygon(layer_index);
 
-						if (navpoly.is_valid()) {
+						if (navigation_polygon.is_valid()) {
 							Transform2D tile_transform;
 							tile_transform.set_origin(map_to_local(E_cell));
 
@@ -1739,7 +1739,7 @@ void TileMap::_navigation_update_dirty_quadrants(SelfList<TileMapQuadrant>::List
 							NavigationServer2D::get_singleton()->region_set_owner_id(region, get_instance_id());
 							NavigationServer2D::get_singleton()->region_set_map(region, get_world_2d()->get_navigation_map());
 							NavigationServer2D::get_singleton()->region_set_transform(region, tilemap_xform * tile_transform);
-							NavigationServer2D::get_singleton()->region_set_navpoly(region, navpoly);
+							NavigationServer2D::get_singleton()->region_set_navigation_polygon(region, navigation_polygon);
 							q.navigation_regions[E_cell].write[layer_index] = region;
 						}
 					}

--- a/scene/3d/navigation_agent_3d.h
+++ b/scene/3d/navigation_agent_3d.h
@@ -64,7 +64,7 @@ class NavigationAgent3D : public Node {
 	Vector3 target_location;
 	Ref<NavigationPathQueryParameters3D> navigation_query;
 	Ref<NavigationPathQueryResult3D> navigation_result;
-	int nav_path_index = 0;
+	int navigation_path_index = 0;
 	bool velocity_submitted = false;
 	Vector3 prev_safe_velocity;
 	/// The submitted target velocity
@@ -153,10 +153,10 @@ public:
 
 	Vector3 get_next_location();
 
-	const Vector<Vector3> &get_nav_path() const;
+	const Vector<Vector3> &get_current_navigation_path() const;
 
-	int get_nav_path_index() const {
-		return nav_path_index;
+	int get_current_navigation_path_index() const {
+		return navigation_path_index;
 	}
 
 	real_t distance_to_target() const;

--- a/scene/3d/navigation_region_3d.h
+++ b/scene/3d/navigation_region_3d.h
@@ -42,7 +42,7 @@ class NavigationRegion3D : public Node3D {
 	uint32_t navigation_layers = 1;
 	real_t enter_cost = 0.0;
 	real_t travel_cost = 1.0;
-	Ref<NavigationMesh> navmesh;
+	Ref<NavigationMesh> navigation_mesh;
 
 	Thread bake_thread;
 
@@ -82,13 +82,13 @@ public:
 	void set_travel_cost(real_t p_travel_cost);
 	real_t get_travel_cost() const;
 
-	void set_navigation_mesh(const Ref<NavigationMesh> &p_navmesh);
+	void set_navigation_mesh(const Ref<NavigationMesh> &p_navigation_mesh);
 	Ref<NavigationMesh> get_navigation_mesh() const;
 
 	/// Bakes the navigation mesh; once done, automatically
 	/// sets the new navigation mesh and emits a signal
 	void bake_navigation_mesh(bool p_on_thread);
-	void _bake_finished(Ref<NavigationMesh> p_nav_mesh);
+	void _bake_finished(Ref<NavigationMesh> p_navigation_mesh);
 
 	PackedStringArray get_configuration_warnings() const override;
 

--- a/scene/resources/mesh_library.cpp
+++ b/scene/resources/mesh_library.cpp
@@ -57,10 +57,10 @@ bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
 			_set_item_shapes(idx, p_value);
 		} else if (what == "preview") {
 			set_item_preview(idx, p_value);
-		} else if (what == "navmesh") {
-			set_item_navmesh(idx, p_value);
-		} else if (what == "navmesh_transform") {
-			set_item_navmesh_transform(idx, p_value);
+		} else if (what == "navigation_mesh") {
+			set_item_navigation_mesh(idx, p_value);
+		} else if (what == "navigation_mesh_transform") {
+			set_item_navigation_mesh_transform(idx, p_value);
 		} else {
 			return false;
 		}
@@ -85,10 +85,10 @@ bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
 		r_ret = get_item_mesh_transform(idx);
 	} else if (what == "shapes") {
 		r_ret = _get_item_shapes(idx);
-	} else if (what == "navmesh") {
-		r_ret = get_item_navmesh(idx);
-	} else if (what == "navmesh_transform") {
-		r_ret = get_item_navmesh_transform(idx);
+	} else if (what == "navigation_mesh") {
+		r_ret = get_item_navigation_mesh(idx);
+	} else if (what == "navigation_mesh_transform") {
+		r_ret = get_item_navigation_mesh_transform(idx);
 	} else if (what == "preview") {
 		r_ret = get_item_preview(idx);
 	} else {
@@ -105,8 +105,8 @@ void MeshLibrary::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("mesh"), PROPERTY_HINT_RESOURCE_TYPE, "Mesh"));
 		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, prop_name + PNAME("mesh_transform"), PROPERTY_HINT_NONE, "suffix:m"));
 		p_list->push_back(PropertyInfo(Variant::ARRAY, prop_name + PNAME("shapes")));
-		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("navmesh"), PROPERTY_HINT_RESOURCE_TYPE, "NavigationMesh"));
-		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, prop_name + PNAME("navmesh_transform"), PROPERTY_HINT_NONE, "suffix:m"));
+		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("navigation_mesh"), PROPERTY_HINT_RESOURCE_TYPE, "NavigationMesh"));
+		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, prop_name + PNAME("navigation_mesh_transform"), PROPERTY_HINT_NONE, "suffix:m"));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("preview"), PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", PROPERTY_USAGE_DEFAULT));
 	}
 }
@@ -150,18 +150,18 @@ void MeshLibrary::set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes)
 	notify_property_list_changed();
 }
 
-void MeshLibrary::set_item_navmesh(int p_item, const Ref<NavigationMesh> &p_navmesh) {
+void MeshLibrary::set_item_navigation_mesh(int p_item, const Ref<NavigationMesh> &p_navigation_mesh) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
-	item_map[p_item].navmesh = p_navmesh;
+	item_map[p_item].navigation_mesh = p_navigation_mesh;
 	notify_property_list_changed();
 	notify_change_to_owners();
 	emit_changed();
 	notify_property_list_changed();
 }
 
-void MeshLibrary::set_item_navmesh_transform(int p_item, const Transform3D &p_transform) {
+void MeshLibrary::set_item_navigation_mesh_transform(int p_item, const Transform3D &p_transform) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
-	item_map[p_item].navmesh_transform = p_transform;
+	item_map[p_item].navigation_mesh_transform = p_transform;
 	notify_change_to_owners();
 	emit_changed();
 	notify_property_list_changed();
@@ -194,14 +194,14 @@ Vector<MeshLibrary::ShapeData> MeshLibrary::get_item_shapes(int p_item) const {
 	return item_map[p_item].shapes;
 }
 
-Ref<NavigationMesh> MeshLibrary::get_item_navmesh(int p_item) const {
+Ref<NavigationMesh> MeshLibrary::get_item_navigation_mesh(int p_item) const {
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Ref<NavigationMesh>(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
-	return item_map[p_item].navmesh;
+	return item_map[p_item].navigation_mesh;
 }
 
-Transform3D MeshLibrary::get_item_navmesh_transform(int p_item) const {
+Transform3D MeshLibrary::get_item_navigation_mesh_transform(int p_item) const {
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Transform3D(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
-	return item_map[p_item].navmesh_transform;
+	return item_map[p_item].navigation_mesh_transform;
 }
 
 Ref<Texture2D> MeshLibrary::get_item_preview(int p_item) const {
@@ -314,15 +314,15 @@ void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_item_name", "id", "name"), &MeshLibrary::set_item_name);
 	ClassDB::bind_method(D_METHOD("set_item_mesh", "id", "mesh"), &MeshLibrary::set_item_mesh);
 	ClassDB::bind_method(D_METHOD("set_item_mesh_transform", "id", "mesh_transform"), &MeshLibrary::set_item_mesh_transform);
-	ClassDB::bind_method(D_METHOD("set_item_navmesh", "id", "navmesh"), &MeshLibrary::set_item_navmesh);
-	ClassDB::bind_method(D_METHOD("set_item_navmesh_transform", "id", "navmesh"), &MeshLibrary::set_item_navmesh_transform);
+	ClassDB::bind_method(D_METHOD("set_item_navigation_mesh", "id", "navigation_mesh"), &MeshLibrary::set_item_navigation_mesh);
+	ClassDB::bind_method(D_METHOD("set_item_navigation_mesh_transform", "id", "navigation_mesh"), &MeshLibrary::set_item_navigation_mesh_transform);
 	ClassDB::bind_method(D_METHOD("set_item_shapes", "id", "shapes"), &MeshLibrary::_set_item_shapes);
 	ClassDB::bind_method(D_METHOD("set_item_preview", "id", "texture"), &MeshLibrary::set_item_preview);
 	ClassDB::bind_method(D_METHOD("get_item_name", "id"), &MeshLibrary::get_item_name);
 	ClassDB::bind_method(D_METHOD("get_item_mesh", "id"), &MeshLibrary::get_item_mesh);
 	ClassDB::bind_method(D_METHOD("get_item_mesh_transform", "id"), &MeshLibrary::get_item_mesh_transform);
-	ClassDB::bind_method(D_METHOD("get_item_navmesh", "id"), &MeshLibrary::get_item_navmesh);
-	ClassDB::bind_method(D_METHOD("get_item_navmesh_transform", "id"), &MeshLibrary::get_item_navmesh_transform);
+	ClassDB::bind_method(D_METHOD("get_item_navigation_mesh", "id"), &MeshLibrary::get_item_navigation_mesh);
+	ClassDB::bind_method(D_METHOD("get_item_navigation_mesh_transform", "id"), &MeshLibrary::get_item_navigation_mesh_transform);
 	ClassDB::bind_method(D_METHOD("get_item_shapes", "id"), &MeshLibrary::_get_item_shapes);
 	ClassDB::bind_method(D_METHOD("get_item_preview", "id"), &MeshLibrary::get_item_preview);
 	ClassDB::bind_method(D_METHOD("remove_item", "id"), &MeshLibrary::remove_item);

--- a/scene/resources/mesh_library.h
+++ b/scene/resources/mesh_library.h
@@ -49,11 +49,11 @@ public:
 	struct Item {
 		String name;
 		Ref<Mesh> mesh;
+		Transform3D mesh_transform;
 		Vector<ShapeData> shapes;
 		Ref<Texture2D> preview;
-		Transform3D navmesh_transform;
-		Transform3D mesh_transform;
-		Ref<NavigationMesh> navmesh;
+		Ref<NavigationMesh> navigation_mesh;
+		Transform3D navigation_mesh_transform;
 	};
 
 	RBMap<int, Item> item_map;
@@ -74,15 +74,15 @@ public:
 	void set_item_name(int p_item, const String &p_name);
 	void set_item_mesh(int p_item, const Ref<Mesh> &p_mesh);
 	void set_item_mesh_transform(int p_item, const Transform3D &p_transform);
-	void set_item_navmesh(int p_item, const Ref<NavigationMesh> &p_navmesh);
-	void set_item_navmesh_transform(int p_item, const Transform3D &p_transform);
+	void set_item_navigation_mesh(int p_item, const Ref<NavigationMesh> &p_navigation_mesh);
+	void set_item_navigation_mesh_transform(int p_item, const Transform3D &p_transform);
 	void set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes);
 	void set_item_preview(int p_item, const Ref<Texture2D> &p_preview);
 	String get_item_name(int p_item) const;
 	Ref<Mesh> get_item_mesh(int p_item) const;
 	Transform3D get_item_mesh_transform(int p_item) const;
-	Ref<NavigationMesh> get_item_navmesh(int p_item) const;
-	Transform3D get_item_navmesh_transform(int p_item) const;
+	Ref<NavigationMesh> get_item_navigation_mesh(int p_item) const;
+	Transform3D get_item_navigation_mesh_transform(int p_item) const;
 	Vector<ShapeData> get_item_shapes(int p_item) const;
 	Ref<Texture2D> get_item_preview(int p_item) const;
 

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -225,13 +225,13 @@ float NavigationMesh::get_edge_max_error() const {
 	return edge_max_error;
 }
 
-void NavigationMesh::set_verts_per_poly(float p_value) {
+void NavigationMesh::set_vertices_per_polyon(float p_value) {
 	ERR_FAIL_COND(p_value < 3);
-	verts_per_poly = p_value;
+	vertices_per_polyon = p_value;
 }
 
-float NavigationMesh::get_verts_per_poly() const {
-	return verts_per_poly;
+float NavigationMesh::get_vertices_per_polyon() const {
+	return vertices_per_polyon;
 }
 
 void NavigationMesh::set_detail_sample_distance(float p_value) {
@@ -483,8 +483,8 @@ void NavigationMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_edge_max_error", "edge_max_error"), &NavigationMesh::set_edge_max_error);
 	ClassDB::bind_method(D_METHOD("get_edge_max_error"), &NavigationMesh::get_edge_max_error);
 
-	ClassDB::bind_method(D_METHOD("set_verts_per_poly", "verts_per_poly"), &NavigationMesh::set_verts_per_poly);
-	ClassDB::bind_method(D_METHOD("get_verts_per_poly"), &NavigationMesh::get_verts_per_poly);
+	ClassDB::bind_method(D_METHOD("set_vertices_per_polyon", "vertices_per_polyon"), &NavigationMesh::set_vertices_per_polyon);
+	ClassDB::bind_method(D_METHOD("get_vertices_per_polyon"), &NavigationMesh::get_vertices_per_polyon);
 
 	ClassDB::bind_method(D_METHOD("set_detail_sample_distance", "detail_sample_dist"), &NavigationMesh::set_detail_sample_distance);
 	ClassDB::bind_method(D_METHOD("get_detail_sample_distance"), &NavigationMesh::get_detail_sample_distance);
@@ -527,9 +527,9 @@ void NavigationMesh::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "geometry_parsed_geometry_type", PROPERTY_HINT_ENUM, "Mesh Instances,Static Colliders,Both"), "set_parsed_geometry_type", "get_parsed_geometry_type");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "geometry_collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY_DEFAULT("geometry_collision_mask", 0xFFFFFFFF);
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "geometry_source_geometry_mode", PROPERTY_HINT_ENUM, "NavMesh Children,Group With Children,Group Explicit"), "set_source_geometry_mode", "get_source_geometry_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "geometry_source_geometry_mode", PROPERTY_HINT_ENUM, "Root Node Children,Group With Children,Group Explicit"), "set_source_geometry_mode", "get_source_geometry_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "geometry_source_group_name"), "set_source_group_name", "get_source_group_name");
-	ADD_PROPERTY_DEFAULT("geometry_source_group_name", StringName("navmesh"));
+	ADD_PROPERTY_DEFAULT("geometry_source_group_name", StringName("navigation_mesh_source_group"));
 	ADD_GROUP("Cells", "cell_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cell_size", PROPERTY_HINT_RANGE, "0.01,500.0,0.01,or_greater,suffix:m"), "set_cell_size", "get_cell_size");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cell_height", PROPERTY_HINT_RANGE, "0.01,500.0,0.01,or_greater,suffix:m"), "set_cell_height", "get_cell_height");
@@ -545,7 +545,7 @@ void NavigationMesh::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "edge_max_length", PROPERTY_HINT_RANGE, "0.0,50.0,0.01,or_greater,suffix:m"), "set_edge_max_length", "get_edge_max_length");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "edge_max_error", PROPERTY_HINT_RANGE, "0.1,3.0,0.01,or_greater,suffix:m"), "set_edge_max_error", "get_edge_max_error");
 	ADD_GROUP("Polygons", "polygon_");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "polygon_verts_per_poly", PROPERTY_HINT_RANGE, "3.0,12.0,1.0,or_greater"), "set_verts_per_poly", "get_verts_per_poly");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "polygon_vertices_per_polyon", PROPERTY_HINT_RANGE, "3.0,12.0,1.0,or_greater"), "set_vertices_per_polyon", "get_vertices_per_polyon");
 	ADD_GROUP("Details", "detail_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "detail_sample_distance", PROPERTY_HINT_RANGE, "0.1,16.0,0.01,or_greater,suffix:m"), "set_detail_sample_distance", "get_detail_sample_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "detail_sample_max_error", PROPERTY_HINT_RANGE, "0.0,16.0,0.01,or_greater,suffix:m"), "set_detail_sample_max_error", "get_detail_sample_max_error");
@@ -566,7 +566,7 @@ void NavigationMesh::_bind_methods() {
 	BIND_ENUM_CONSTANT(PARSED_GEOMETRY_BOTH);
 	BIND_ENUM_CONSTANT(PARSED_GEOMETRY_MAX);
 
-	BIND_ENUM_CONSTANT(SOURCE_GEOMETRY_NAVMESH_CHILDREN);
+	BIND_ENUM_CONSTANT(SOURCE_GEOMETRY_ROOT_NODE_CHILDREN);
 	BIND_ENUM_CONSTANT(SOURCE_GEOMETRY_GROUPS_WITH_CHILDREN);
 	BIND_ENUM_CONSTANT(SOURCE_GEOMETRY_GROUPS_EXPLICIT);
 	BIND_ENUM_CONSTANT(SOURCE_GEOMETRY_MAX);
@@ -581,7 +581,7 @@ void NavigationMesh::_validate_property(PropertyInfo &p_property) const {
 	}
 
 	if (p_property.name == "geometry_source_group_name") {
-		if (source_geometry_mode == SOURCE_GEOMETRY_NAVMESH_CHILDREN) {
+		if (source_geometry_mode == SOURCE_GEOMETRY_ROOT_NODE_CHILDREN) {
 			p_property.usage = PROPERTY_USAGE_NONE;
 			return;
 		}

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -84,7 +84,7 @@ public:
 	};
 
 	enum SourceGeometryMode {
-		SOURCE_GEOMETRY_NAVMESH_CHILDREN = 0,
+		SOURCE_GEOMETRY_ROOT_NODE_CHILDREN = 0,
 		SOURCE_GEOMETRY_GROUPS_WITH_CHILDREN,
 		SOURCE_GEOMETRY_GROUPS_EXPLICIT,
 		SOURCE_GEOMETRY_MAX
@@ -101,7 +101,7 @@ protected:
 	float region_merge_size = 20.0f;
 	float edge_max_length = 12.0f;
 	float edge_max_error = 1.3f;
-	float verts_per_poly = 6.0f;
+	float vertices_per_polyon = 6.0f;
 	float detail_sample_distance = 6.0f;
 	float detail_sample_max_error = 1.0f;
 
@@ -109,8 +109,8 @@ protected:
 	ParsedGeometryType parsed_geometry_type = PARSED_GEOMETRY_MESH_INSTANCES;
 	uint32_t collision_mask = 0xFFFFFFFF;
 
-	SourceGeometryMode source_geometry_mode = SOURCE_GEOMETRY_NAVMESH_CHILDREN;
-	StringName source_group_name = "navmesh";
+	SourceGeometryMode source_geometry_mode = SOURCE_GEOMETRY_ROOT_NODE_CHILDREN;
+	StringName source_group_name = "navigation_mesh_source_group";
 
 	bool filter_low_hanging_obstacles = false;
 	bool filter_ledge_spans = false;
@@ -168,8 +168,8 @@ public:
 	void set_edge_max_error(float p_value);
 	float get_edge_max_error() const;
 
-	void set_verts_per_poly(float p_value);
-	float get_verts_per_poly() const;
+	void set_vertices_per_polyon(float p_value);
+	float get_vertices_per_polyon() const;
 
 	void set_detail_sample_distance(float p_value);
 	float get_detail_sample_distance() const;

--- a/scene/resources/navigation_polygon.cpp
+++ b/scene/resources/navigation_polygon.cpp
@@ -81,8 +81,8 @@ bool NavigationPolygon::_edit_is_selected_on_click(const Point2 &p_point, double
 
 void NavigationPolygon::set_vertices(const Vector<Vector2> &p_vertices) {
 	{
-		MutexLock lock(navmesh_generation);
-		navmesh.unref();
+		MutexLock lock(navigation_mesh_generation);
+		navigation_mesh.unref();
 	}
 	vertices = p_vertices;
 	rect_cache_dirty = true;
@@ -94,8 +94,8 @@ Vector<Vector2> NavigationPolygon::get_vertices() const {
 
 void NavigationPolygon::_set_polygons(const TypedArray<Vector<int32_t>> &p_array) {
 	{
-		MutexLock lock(navmesh_generation);
-		navmesh.unref();
+		MutexLock lock(navigation_mesh_generation);
+		navigation_mesh.unref();
 	}
 	polygons.resize(p_array.size());
 	for (int i = 0; i < p_array.size(); i++) {
@@ -136,8 +136,8 @@ void NavigationPolygon::add_polygon(const Vector<int> &p_polygon) {
 	polygon.indices = p_polygon;
 	polygons.push_back(polygon);
 	{
-		MutexLock lock(navmesh_generation);
-		navmesh.unref();
+		MutexLock lock(navigation_mesh_generation);
+		navigation_mesh.unref();
 	}
 }
 
@@ -158,16 +158,16 @@ Vector<int> NavigationPolygon::get_polygon(int p_idx) {
 void NavigationPolygon::clear_polygons() {
 	polygons.clear();
 	{
-		MutexLock lock(navmesh_generation);
-		navmesh.unref();
+		MutexLock lock(navigation_mesh_generation);
+		navigation_mesh.unref();
 	}
 }
 
-Ref<NavigationMesh> NavigationPolygon::get_mesh() {
-	MutexLock lock(navmesh_generation);
+Ref<NavigationMesh> NavigationPolygon::get_navigation_mesh() {
+	MutexLock lock(navigation_mesh_generation);
 
-	if (navmesh.is_null()) {
-		navmesh.instantiate();
+	if (navigation_mesh.is_null()) {
+		navigation_mesh.instantiate();
 		Vector<Vector3> verts;
 		{
 			verts.resize(get_vertices().size());
@@ -179,14 +179,14 @@ Ref<NavigationMesh> NavigationPolygon::get_mesh() {
 				w[i] = Vector3(r[i].x, 0.0, r[i].y);
 			}
 		}
-		navmesh->set_vertices(verts);
+		navigation_mesh->set_vertices(verts);
 
 		for (int i(0); i < get_polygon_count(); i++) {
-			navmesh->add_polygon(get_polygon(i));
+			navigation_mesh->add_polygon(get_polygon(i));
 		}
 	}
 
-	return navmesh;
+	return navigation_mesh;
 }
 
 void NavigationPolygon::add_outline(const Vector<Vector2> &p_outline) {
@@ -222,8 +222,8 @@ void NavigationPolygon::clear_outlines() {
 
 void NavigationPolygon::make_polygons_from_outlines() {
 	{
-		MutexLock lock(navmesh_generation);
-		navmesh.unref();
+		MutexLock lock(navigation_mesh_generation);
+		navigation_mesh.unref();
 	}
 	List<TPPLPoly> in_poly, out_poly;
 
@@ -331,7 +331,7 @@ void NavigationPolygon::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_polygon_count"), &NavigationPolygon::get_polygon_count);
 	ClassDB::bind_method(D_METHOD("get_polygon", "idx"), &NavigationPolygon::get_polygon);
 	ClassDB::bind_method(D_METHOD("clear_polygons"), &NavigationPolygon::clear_polygons);
-	ClassDB::bind_method(D_METHOD("get_mesh"), &NavigationPolygon::get_mesh);
+	ClassDB::bind_method(D_METHOD("get_navigation_mesh"), &NavigationPolygon::get_navigation_mesh);
 
 	ClassDB::bind_method(D_METHOD("add_outline", "outline"), &NavigationPolygon::add_outline);
 	ClassDB::bind_method(D_METHOD("add_outline_at_index", "outline", "index"), &NavigationPolygon::add_outline_at_index);

--- a/scene/resources/navigation_polygon.h
+++ b/scene/resources/navigation_polygon.h
@@ -47,9 +47,9 @@ class NavigationPolygon : public Resource {
 	mutable Rect2 item_rect;
 	mutable bool rect_cache_dirty = true;
 
-	Mutex navmesh_generation;
+	Mutex navigation_mesh_generation;
 	// Navigation mesh
-	Ref<NavigationMesh> navmesh;
+	Ref<NavigationMesh> navigation_mesh;
 
 protected:
 	static void _bind_methods();
@@ -85,7 +85,7 @@ public:
 	Vector<int> get_polygon(int p_idx);
 	void clear_polygons();
 
-	Ref<NavigationMesh> get_mesh();
+	Ref<NavigationMesh> get_navigation_mesh();
 
 	NavigationPolygon() {}
 	~NavigationPolygon() {}

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -154,7 +154,7 @@ static ObjectID id_to_id(const ObjectID &id) {
 
 static Ref<NavigationMesh> poly_to_mesh(Ref<NavigationPolygon> d) {
 	if (d.is_valid()) {
-		return d->get_mesh();
+		return d->get_navigation_mesh();
 	} else {
 		return Ref<NavigationMesh>();
 	}
@@ -258,7 +258,7 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("region_set_navigation_layers", "region", "navigation_layers"), &NavigationServer2D::region_set_navigation_layers);
 	ClassDB::bind_method(D_METHOD("region_get_navigation_layers", "region"), &NavigationServer2D::region_get_navigation_layers);
 	ClassDB::bind_method(D_METHOD("region_set_transform", "region", "transform"), &NavigationServer2D::region_set_transform);
-	ClassDB::bind_method(D_METHOD("region_set_navpoly", "region", "nav_poly"), &NavigationServer2D::region_set_navpoly);
+	ClassDB::bind_method(D_METHOD("region_set_navigation_polygon", "region", "navigation_polygon"), &NavigationServer2D::region_set_navigation_polygon);
 	ClassDB::bind_method(D_METHOD("region_get_connections_count", "region"), &NavigationServer2D::region_get_connections_count);
 	ClassDB::bind_method(D_METHOD("region_get_connection_pathway_start", "region", "connection"), &NavigationServer2D::region_get_connection_pathway_start);
 	ClassDB::bind_method(D_METHOD("region_get_connection_pathway_end", "region", "connection"), &NavigationServer2D::region_get_connection_pathway_end);
@@ -361,8 +361,8 @@ void FORWARD_2_C(region_set_navigation_layers, RID, p_region, uint32_t, p_naviga
 uint32_t FORWARD_1_C(region_get_navigation_layers, RID, p_region, rid_to_rid);
 void FORWARD_2_C(region_set_transform, RID, p_region, Transform2D, p_transform, rid_to_rid, trf2_to_trf3);
 
-void NavigationServer2D::region_set_navpoly(RID p_region, Ref<NavigationPolygon> p_nav_mesh) const {
-	NavigationServer3D::get_singleton()->region_set_navmesh(p_region, poly_to_mesh(p_nav_mesh));
+void NavigationServer2D::region_set_navigation_polygon(RID p_region, Ref<NavigationPolygon> p_navigation_polygon) const {
+	NavigationServer3D::get_singleton()->region_set_navigation_mesh(p_region, poly_to_mesh(p_navigation_polygon));
 }
 
 int FORWARD_1_C(region_get_connections_count, RID, p_region, rid_to_rid);

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -126,7 +126,7 @@ public:
 	virtual void region_set_transform(RID p_region, Transform2D p_transform) const;
 
 	/// Set the navigation poly of this region.
-	virtual void region_set_navpoly(RID p_region, Ref<NavigationPolygon> p_nav_mesh) const;
+	virtual void region_set_navigation_polygon(RID p_region, Ref<NavigationPolygon> p_navigation_polygon) const;
 
 	/// Get a list of a region's connection to other regions.
 	virtual int region_get_connections_count(RID p_region) const;

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -77,8 +77,8 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("region_set_navigation_layers", "region", "navigation_layers"), &NavigationServer3D::region_set_navigation_layers);
 	ClassDB::bind_method(D_METHOD("region_get_navigation_layers", "region"), &NavigationServer3D::region_get_navigation_layers);
 	ClassDB::bind_method(D_METHOD("region_set_transform", "region", "transform"), &NavigationServer3D::region_set_transform);
-	ClassDB::bind_method(D_METHOD("region_set_navmesh", "region", "nav_mesh"), &NavigationServer3D::region_set_navmesh);
-	ClassDB::bind_method(D_METHOD("region_bake_navmesh", "mesh", "node"), &NavigationServer3D::region_bake_navmesh);
+	ClassDB::bind_method(D_METHOD("region_set_navigation_mesh", "region", "navigation_mesh"), &NavigationServer3D::region_set_navigation_mesh);
+	ClassDB::bind_method(D_METHOD("region_bake_navigation_mesh", "navigation_mesh", "root_node"), &NavigationServer3D::region_bake_navigation_mesh);
 	ClassDB::bind_method(D_METHOD("region_get_connections_count", "region"), &NavigationServer3D::region_get_connections_count);
 	ClassDB::bind_method(D_METHOD("region_get_connection_pathway_start", "region", "connection"), &NavigationServer3D::region_get_connection_pathway_start);
 	ClassDB::bind_method(D_METHOD("region_get_connection_pathway_end", "region", "connection"), &NavigationServer3D::region_get_connection_pathway_end);
@@ -155,7 +155,7 @@ NavigationServer3D::NavigationServer3D() {
 	debug_navigation_enable_link_connections_xray = GLOBAL_DEF("debug/shapes/navigation/enable_link_connections_xray", true);
 
 	if (Engine::get_singleton()->is_editor_hint()) {
-		// enable NavigationServer3D when in Editor or else navmesh edge connections are invisible
+		// enable NavigationServer3D when in Editor or else navigation mesh edge connections are invisible
 		// on runtime tests SceneTree has "Visible Navigation" set and main iteration takes care of this
 		set_debug_enabled(true);
 	}

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -138,10 +138,10 @@ public:
 	virtual void region_set_transform(RID p_region, Transform3D p_transform) const = 0;
 
 	/// Set the navigation mesh of this region.
-	virtual void region_set_navmesh(RID p_region, Ref<NavigationMesh> p_nav_mesh) const = 0;
+	virtual void region_set_navigation_mesh(RID p_region, Ref<NavigationMesh> p_navigation_mesh) const = 0;
 
 	/// Bake the navigation mesh.
-	virtual void region_bake_navmesh(Ref<NavigationMesh> r_mesh, Node *p_node) const = 0;
+	virtual void region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) const = 0;
 
 	/// Get a list of a region's connection to other regions.
 	virtual int region_get_connections_count(RID p_region) const = 0;


### PR DESCRIPTION
As stated again by @akien-mga Godot tries to avoid abbreviations in the user facing Godot API  and for both nodes and resources to keep things explicit and consistent.

The schema for navigation that was agreed on in devchat is to name user facing names and nodes / resources with "navigation" and internals, e.g. NavigationServer equivalents, with "nav" abbreviation. E.g. "navigation_region" <-> "nav_region", "navigation_mesh" <-> "nav_mesh". 

This distinction makes it also clearer what is talked about in discussions (especially among devs) without inventing new random names for the same thing.



Also renamed some other oddities along the way that showed up in global search while renaming since this pr will break compatibility anyway, e.g. ...

NavigationMesh SOURCE_GEOMETRY_NAVMESH_CHILDREN --> SOURCE_GEOMETRY_ROOT_NODE_CHILDREN
A navigation mesh is a resource, it can not have children nor can it be the root node of the source geometry parsing so this enum name made no sense.

GridMap Octant::Navmesh --> Octant::NavigationCell
It is not a navmesh, it is a struct that holds a combination of all navigation related data for a gridmap cell like the NavigationServer region RID, region transform and debug instance RID.

**UPDATE WARNING**
After this pr is merged NavigationPolygons and NavigationMeshes resources not saved to disk in old Godot versions but stored as build-ins of other nodes and resources like TileMap, GridMap and NavigationRegion might be lost. Those stored to disk will need to be reassigned.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
