### PR TITLE
Fix seeking process order to retrieve key correctly for AnimationTrack

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -956,8 +956,8 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double
 					}
 
 					if (player->is_playing()) {
-						player->play(anim_name);
 						player->seek(at_anim_pos);
+						player->play(anim_name);
 						nc->animation_playing = true;
 						playing_caches.insert(nc);
 					} else {
@@ -985,8 +985,8 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double
 								nc->animation_playing = false;
 							}
 						} else {
+							player->seek(0.0);
 							player->play(anim_name);
-							player->seek(0.0, true);
 							nc->animation_playing = true;
 							playing_caches.insert(nc);
 						}

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1584,8 +1584,8 @@ void AnimationTree::_process_graph(double p_delta) {
 							}
 
 							if (player2->is_playing() || seeked) {
-								player2->play(anim_name);
 								player2->seek(at_anim_pos);
+								player2->play(anim_name);
 								t->playing = true;
 								playing_caches.insert(t);
 							} else {


### PR DESCRIPTION
Fixes #69930.

- Follow up #69588.

That same fix needed to be applied to the AnimationPlaybackTrack.
