### PR TITLE
Add open scene button in Inspector for PackedScene resource

### DIFF
--- a/editor/plugins/packed_scene_editor_plugin.cpp
+++ b/editor/plugins/packed_scene_editor_plugin.cpp
@@ -1,0 +1,81 @@
+/*************************************************************************/
+/*  packed_scene_editor_plugin.cpp                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "packed_scene_editor_plugin.h"
+
+#include "editor/editor_node.h"
+#include "scene/gui/button.h"
+#include "scene/resources/packed_scene.h"
+#include "scene/scene_string_names.h"
+
+void PackedSceneEditor::_on_open_scene_pressed() {
+	// Using deferred call because changing scene updates the Inspector and thus destroys this plugin.
+	callable_mp(EditorNode::get_singleton(), &EditorNode::open_request).call_deferred(packed_scene->get_path());
+}
+
+void PackedSceneEditor::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			open_scene_button->set_icon(get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons")));
+		} break;
+	}
+}
+
+PackedSceneEditor::PackedSceneEditor(Ref<PackedScene> &p_packed_scene) {
+	packed_scene = p_packed_scene;
+
+	open_scene_button = EditorInspector::create_inspector_action_button(TTR("Open Scene"));
+	open_scene_button->connect(SNAME("pressed"), callable_mp(this, &PackedSceneEditor::_on_open_scene_pressed));
+	open_scene_button->set_disabled(!packed_scene->get_path().get_file().is_valid_filename());
+	add_child(open_scene_button);
+
+	add_child(memnew(Control)); // Add padding before the regular properties.
+}
+
+///////////////////////
+
+bool EditorInspectorPluginPackedScene::can_handle(Object *p_object) {
+	return Object::cast_to<PackedScene>(p_object) != nullptr;
+}
+
+void EditorInspectorPluginPackedScene::parse_begin(Object *p_object) {
+	Ref<PackedScene> packed_scene(p_object);
+	PackedSceneEditor *editor = memnew(PackedSceneEditor(packed_scene));
+	add_custom_control(editor);
+}
+
+///////////////////////
+
+PackedSceneEditorPlugin::PackedSceneEditorPlugin() {
+	Ref<EditorInspectorPluginPackedScene> plugin;
+	plugin.instantiate();
+	add_inspector_plugin(plugin);
+}

--- a/editor/plugins/packed_scene_editor_plugin.h
+++ b/editor/plugins/packed_scene_editor_plugin.h
@@ -1,0 +1,68 @@
+/*************************************************************************/
+/*  packed_scene_editor_plugin.h                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef PACKED_SCENE_EDITOR_PLUGIN_H
+#define PACKED_SCENE_EDITOR_PLUGIN_H
+
+#include "editor/editor_inspector.h"
+#include "editor/editor_plugin.h"
+#include "scene/gui/box_container.h"
+
+class PackedSceneEditor : public VBoxContainer {
+	GDCLASS(PackedSceneEditor, VBoxContainer);
+
+	Ref<PackedScene> packed_scene;
+	Button *open_scene_button;
+
+	void _on_open_scene_pressed();
+
+protected:
+	void _notification(int p_what);
+
+public:
+	PackedSceneEditor(Ref<PackedScene> &p_packed_scene);
+};
+
+class EditorInspectorPluginPackedScene : public EditorInspectorPlugin {
+	GDCLASS(EditorInspectorPluginPackedScene, EditorInspectorPlugin);
+
+public:
+	virtual bool can_handle(Object *p_object) override;
+	virtual void parse_begin(Object *p_object) override;
+};
+
+class PackedSceneEditorPlugin : public EditorPlugin {
+	GDCLASS(PackedSceneEditorPlugin, EditorPlugin);
+
+public:
+	PackedSceneEditorPlugin();
+};
+
+#endif // PACKED_SCENE_EDITOR_PLUGIN_H

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -79,6 +79,7 @@
 #include "editor/plugins/navigation_polygon_editor_plugin.h"
 #include "editor/plugins/node_3d_editor_gizmos.h"
 #include "editor/plugins/occluder_instance_3d_editor_plugin.h"
+#include "editor/plugins/packed_scene_editor_plugin.h"
 #include "editor/plugins/path_2d_editor_plugin.h"
 #include "editor/plugins/path_3d_editor_plugin.h"
 #include "editor/plugins/physical_bone_3d_editor_plugin.h"
@@ -175,6 +176,7 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<MeshLibraryEditorPlugin>();
 	EditorPlugins::add_by_type<MultiMeshEditorPlugin>();
 	EditorPlugins::add_by_type<OccluderInstance3DEditorPlugin>();
+	EditorPlugins::add_by_type<PackedSceneEditorPlugin>();
 	EditorPlugins::add_by_type<Path3DEditorPlugin>();
 	EditorPlugins::add_by_type<PhysicalBone3DEditorPlugin>();
 	EditorPlugins::add_by_type<Polygon3DEditorPlugin>();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/3338

Adds an "Open Scene" button when editing a PackedScene resource:

![ksnip_20221212-111523](https://user-images.githubusercontent.com/372476/206964199-a4b25d53-c1f5-463b-8bdb-4703b4772a71.png)
