### PR TITLE
Revert "RID: Change comparison operators to use RID_Data id instead of address"

### DIFF
--- a/core/rid.h
+++ b/core/rid.h
@@ -68,13 +68,13 @@ public:
 		return _data == p_rid._data;
 	}
 	_FORCE_INLINE_ bool operator<(const RID &p_rid) const {
-		return get_id() < p_rid.get_id();
+		return _data < p_rid._data;
 	}
 	_FORCE_INLINE_ bool operator<=(const RID &p_rid) const {
-		return get_id() <= p_rid.get_id();
+		return _data <= p_rid._data;
 	}
 	_FORCE_INLINE_ bool operator>(const RID &p_rid) const {
-		return get_id() > p_rid.get_id();
+		return _data > p_rid._data;
 	}
 	_FORCE_INLINE_ bool operator!=(const RID &p_rid) const {
 		return _data != p_rid._data;


### PR DESCRIPTION
- Reverts #59234
- Fixes #67273
- Supersedes #69915

See https://github.com/godotengine/godot/pull/59234#issuecomment-1345606455 and #67273 for a description of the problem it causes.

The RID comparisons should be avoided as far as possible - there's only a few of them (see graph in #59234) and we should aim to make them more reliable in a safer way.