### PR TITLE
Windows: Validate that the font family name exists before trying to get the font family

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1059,7 +1059,7 @@ String OS_Windows::get_system_font_path(const String &p_font_name, int p_weight,
 	UINT32 index = 0;
 	BOOL exists = false;
 	HRESULT hr = font_collection->FindFamilyName((const WCHAR *)font_name.utf16().get_data(), &index, &exists);
-	if (FAILED(hr)) {
+	if (FAILED(hr) || !exists) {
 		return String();
 	}
 


### PR DESCRIPTION
I didn't have the first emoji font installed, which led an an exception when calling font_collection->GetFontFamily() on the next rows.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
