### PR TITLE
VariantParser make readahead optional

### DIFF
--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -42,7 +42,7 @@ char32_t VariantParser::Stream::get_char() {
 	}
 
 	// attempt to readahead
-	readahead_filled = _read_buffer(readahead_buffer, READAHEAD_SIZE);
+	readahead_filled = _read_buffer(readahead_buffer, readahead_enabled ? READAHEAD_SIZE : 1);
 	if (readahead_filled) {
 		readahead_pointer = 0;
 	} else {
@@ -54,8 +54,19 @@ char32_t VariantParser::Stream::get_char() {
 	return get_char();
 }
 
+bool VariantParser::Stream::is_eof() const {
+	if (readahead_enabled) {
+		return eof;
+	}
+	return _is_eof();
+}
+
 bool VariantParser::StreamFile::is_utf8() const {
 	return true;
+}
+
+bool VariantParser::StreamFile::_is_eof() const {
+	return f->eof_reached();
 }
 
 uint32_t VariantParser::StreamFile::_read_buffer(char32_t *p_buffer, uint32_t p_num_chars) {
@@ -77,6 +88,10 @@ uint32_t VariantParser::StreamFile::_read_buffer(char32_t *p_buffer, uint32_t p_
 
 bool VariantParser::StreamString::is_utf8() const {
 	return false;
+}
+
+bool VariantParser::StreamString::_is_eof() const {
+	return pos > s.length();
 }
 
 uint32_t VariantParser::StreamString::_read_buffer(char32_t *p_buffer, uint32_t p_num_chars) {

--- a/core/variant/variant_parser.h
+++ b/core/variant/variant_parser.h
@@ -46,14 +46,16 @@ public:
 		bool eof = false;
 
 	protected:
+		bool readahead_enabled = true;
 		virtual uint32_t _read_buffer(char32_t *p_buffer, uint32_t p_num_chars) = 0;
+		virtual bool _is_eof() const = 0;
 
 	public:
 		char32_t saved = 0;
 
 		char32_t get_char();
 		virtual bool is_utf8() const = 0;
-		bool is_eof() const { return eof; }
+		bool is_eof() const;
 
 		Stream() {}
 		virtual ~Stream() {}
@@ -62,13 +64,14 @@ public:
 	struct StreamFile : public Stream {
 	protected:
 		virtual uint32_t _read_buffer(char32_t *p_buffer, uint32_t p_num_chars) override;
+		virtual bool _is_eof() const override;
 
 	public:
 		Ref<FileAccess> f;
 
 		virtual bool is_utf8() const override;
 
-		StreamFile() {}
+		StreamFile(bool p_readahead_enabled = true) { readahead_enabled = p_readahead_enabled; }
 	};
 
 	struct StreamString : public Stream {
@@ -79,10 +82,11 @@ public:
 
 	protected:
 		virtual uint32_t _read_buffer(char32_t *p_buffer, uint32_t p_num_chars) override;
+		virtual bool _is_eof() const override;
 
 	public:
 		virtual bool is_utf8() const override;
-		StreamString() {}
+		StreamString(bool p_readahead_enabled = true) { readahead_enabled = p_readahead_enabled; }
 	};
 
 	typedef Error (*ParseResourceFunc)(void *p_self, Stream *p_stream, Ref<Resource> &r_res, int &line, String &r_err_str);

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -836,7 +836,8 @@ void ResourceLoaderText::set_translation_remapped(bool p_remapped) {
 	translation_remapped = p_remapped;
 }
 
-ResourceLoaderText::ResourceLoaderText() {}
+ResourceLoaderText::ResourceLoaderText() :
+		stream(false) {}
 
 void ResourceLoaderText::get_dependencies(Ref<FileAccess> p_f, List<String> *p_dependencies, bool p_add_types) {
 	open(p_f);


### PR DESCRIPTION
It turns out some areas are independently moving / reading filepointers outside of the VariantParser, which can cause the readahead caching to get out of sync.

This PR makes the VariantParser readahead to be optional to allow for these use cases.

Fixes #69794 (as far as I can see so far)
Alternative to #69835 (until we have time to finalize that PR)

## Notes
* Ideally we would like to use readahead wherever possible, but some cases are less straightforward, so being able to simply turn it off is useful.
* With more time available I'm sure we can get the readahead working with `ResourceLoaderText`, but this PR is to fix the regression as simply as possible, and allow us to work at leisure on improving `ResourceLoaderText` performance. 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
