### PR TITLE
move "yield" to functions

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2388,7 +2388,7 @@ void GDScriptLanguage::get_reserved_words(List<String> *p_words) const {
 		// We highlight them as keywords to make errors easier to understand.
 		"trait",
 		"namespace",
-		"nullptr"
+		nullptr
 	};
 
 	const char **w = _reserved_words;

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2367,6 +2367,7 @@ void GDScriptLanguage::get_reserved_words(List<String> *p_words) const {
 		"preload",
 		"signal",
 		"super",
+		"yield",
 		// var
 		"const",
 		"enum",
@@ -2387,8 +2388,7 @@ void GDScriptLanguage::get_reserved_words(List<String> *p_words) const {
 		// We highlight them as keywords to make errors easier to understand.
 		"trait",
 		"namespace",
-		"yield",
-		nullptr
+		"nullptr"
 	};
 
 	const char **w = _reserved_words;


### PR DESCRIPTION
Yield is implemented already


This seems compatible with Godot 3 as well

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
