### PR TITLE
[3.x] VariantParser make readahead optional

### DIFF
--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -42,7 +42,7 @@ CharType VariantParser::Stream::get_char() {
 	}
 
 	// attempt to readahead
-	readahead_filled = _read_buffer(readahead_buffer, READAHEAD_SIZE);
+	readahead_filled = _read_buffer(readahead_buffer, readahead_enabled ? READAHEAD_SIZE : 1);
 	if (readahead_filled) {
 		readahead_pointer = 0;
 	} else {
@@ -52,6 +52,13 @@ CharType VariantParser::Stream::get_char() {
 		return 0;
 	}
 	return get_char();
+}
+
+bool VariantParser::Stream::is_eof() const {
+	if (readahead_enabled) {
+		return eof;
+	}
+	return _is_eof();
 }
 
 uint32_t VariantParser::StreamFile::_read_buffer(CharType *p_buffer, uint32_t p_num_chars) {
@@ -73,6 +80,10 @@ uint32_t VariantParser::StreamFile::_read_buffer(CharType *p_buffer, uint32_t p_
 
 bool VariantParser::StreamFile::is_utf8() const {
 	return true;
+}
+
+bool VariantParser::StreamFile::_is_eof() const {
+	return f->eof_reached();
 }
 
 uint32_t VariantParser::StreamString::_read_buffer(CharType *p_buffer, uint32_t p_num_chars) {
@@ -105,6 +116,10 @@ uint32_t VariantParser::StreamString::_read_buffer(CharType *p_buffer, uint32_t 
 
 bool VariantParser::StreamString::is_utf8() const {
 	return false;
+}
+
+bool VariantParser::StreamString::_is_eof() const {
+	return pos > s.length();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/core/variant_parser.h
+++ b/core/variant_parser.h
@@ -46,14 +46,16 @@ public:
 		bool eof = false;
 
 	protected:
+		bool readahead_enabled = true;
 		virtual uint32_t _read_buffer(CharType *p_buffer, uint32_t p_num_chars) = 0;
+		virtual bool _is_eof() const = 0;
 
 	public:
 		CharType saved;
 
 		CharType get_char();
 		virtual bool is_utf8() const = 0;
-		bool is_eof() const { return eof; }
+		bool is_eof() const;
 
 		Stream() :
 				saved(0) {}
@@ -63,12 +65,16 @@ public:
 	struct StreamFile : public Stream {
 	protected:
 		virtual uint32_t _read_buffer(CharType *p_buffer, uint32_t p_num_chars);
+		virtual bool _is_eof() const;
 
 	public:
 		FileAccess *f;
 
 		virtual bool is_utf8() const;
-		StreamFile() { f = nullptr; }
+		StreamFile(bool p_readahead_enabled = true) {
+			f = nullptr;
+			readahead_enabled = p_readahead_enabled;
+		}
 	};
 
 	struct StreamString : public Stream {
@@ -77,12 +83,16 @@ public:
 
 	protected:
 		virtual uint32_t _read_buffer(CharType *p_buffer, uint32_t p_num_chars);
+		virtual bool _is_eof() const;
 
 	public:
 		String s;
 
 		virtual bool is_utf8() const;
-		StreamString() { pos = 0; }
+		StreamString(bool p_readahead_enabled = true) {
+			pos = 0;
+			readahead_enabled = p_readahead_enabled;
+		}
 	};
 
 	typedef Error (*ParseResourceFunc)(void *p_self, Stream *p_stream, Ref<Resource> &r_res, int &line, String &r_err_str);

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -629,7 +629,8 @@ void ResourceInteractiveLoaderText::set_translation_remapped(bool p_remapped) {
 	translation_remapped = p_remapped;
 }
 
-ResourceInteractiveLoaderText::ResourceInteractiveLoaderText() {
+ResourceInteractiveLoaderText::ResourceInteractiveLoaderText() :
+		stream(false) {
 	translation_remapped = false;
 }
 


### PR DESCRIPTION
It turns out some areas are independently moving / reading filepointers outside of the VariantParser, which can cause the readahead caching to get out of sync.

This PR makes the VariantParser readahead to be optional to allow for these use cases.

Fixes #69794 (for 3.x)
3.x version of #69961

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
