### PR TITLE
Fix docstring for String.get_base_dir

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -237,7 +237,7 @@
 			<description>
 				If the string is a valid file path, returns the base directory name.
 				[codeblock]
-				var dir_path = "/path/to/file.txt".get_basename() # dir_path is "/path/to"
+				var dir_path = "/path/to/file.txt".get_base_dir() # dir_path is "/path/to"
 				[/codeblock]
 			</description>
 		</method>

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -220,7 +220,7 @@
 			<description>
 				If the string is a valid file path, returns the base directory name.
 				[codeblock]
-				var dir_path = "/path/to/file.txt".get_basename() # dir_path is "/path/to"
+				var dir_path = "/path/to/file.txt".get_base_dir() # dir_path is "/path/to"
 				[/codeblock]
 			</description>
 		</method>


### PR DESCRIPTION
Fix small docs typo, where the example of the `get_base_dir` method of the String class is calling `get_basename` instead.
