### PR TITLE
C#: Rename `SignalInfo` to `Signal` and make awaitable

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ExportedFields.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ExportedFields.cs
@@ -45,7 +45,7 @@ namespace Godot.SourceGenerators.Sample
         [Export] private Color field_Color = Colors.Aquamarine;
         [Export] private Plane field_Plane = Plane.PlaneXZ;
         [Export] private Callable field_Callable = new Callable(Engine.GetMainLoop(), "_process");
-        [Export] private SignalInfo field_SignalInfo = new SignalInfo(Engine.GetMainLoop(), "property_list_changed");
+        [Export] private Signal field_Signal = new Signal(Engine.GetMainLoop(), "property_list_changed");
 
         // Enums
         [SuppressMessage("ReSharper", "UnusedMember.Local")]

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ExportedProperties.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ExportedProperties.cs
@@ -133,7 +133,7 @@ namespace Godot.SourceGenerators.Sample
         [Export] private Color property_Color { get; set; } = Colors.Aquamarine;
         [Export] private Plane property_Plane { get; set; } = Plane.PlaneXZ;
         [Export] private Callable property_Callable { get; set; } = new Callable(Engine.GetMainLoop(), "_process");
-        [Export] private SignalInfo property_SignalInfo { get; set; } = new SignalInfo(Engine.GetMainLoop(), "property_list_changed");
+        [Export] private Signal property_Signal { get; set; } = new Signal(Engine.GetMainLoop(), "property_list_changed");
 
         // Enums
         [SuppressMessage("ReSharper", "UnusedMember.Local")]

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MarshalType.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MarshalType.cs
@@ -37,7 +37,7 @@ namespace Godot.SourceGenerators
         Color,
         Plane,
         Callable,
-        SignalInfo,
+        Signal,
 
         // Enums
         Enum,

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MarshalUtils.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MarshalUtils.cs
@@ -56,7 +56,7 @@ namespace Godot.SourceGenerators
                 MarshalType.Color => VariantType.Color,
                 MarshalType.Plane => VariantType.Plane,
                 MarshalType.Callable => VariantType.Callable,
-                MarshalType.SignalInfo => VariantType.Signal,
+                MarshalType.Signal => VariantType.Signal,
                 MarshalType.Enum => VariantType.Int,
                 MarshalType.ByteArray => VariantType.PackedByteArray,
                 MarshalType.Int32Array => VariantType.PackedInt32Array,
@@ -147,7 +147,7 @@ namespace Godot.SourceGenerators
                                 { Name: "Plane" } => MarshalType.Plane,
                                 { Name: "RID" } => MarshalType.RID,
                                 { Name: "Callable" } => MarshalType.Callable,
-                                { Name: "SignalInfo" } => MarshalType.SignalInfo,
+                                { Name: "Signal" } => MarshalType.Signal,
                                 { Name: "Variant" } => MarshalType.Variant,
                                 _ => null
                             };

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -3651,7 +3651,7 @@ void BindingsGenerator::_populate_builtin_type_interfaces() {
 	itype.cs_type = itype.proxy_name;
 	itype.cs_in_expr = "%0";
 	itype.c_in = "%5using %0 %1_in = " C_METHOD_MANAGED_TO_SIGNAL "(in %1);\n";
-	itype.c_out = "%5return " C_METHOD_MANAGED_FROM_SIGNAL "(&%1);\n";
+	itype.c_out = "%5return " C_METHOD_MANAGED_FROM_SIGNAL "(in %1);\n";
 	itype.c_arg_in = "&%s_in";
 	itype.c_type = "godot_signal";
 	itype.c_type_in = "in " + itype.cs_type;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
@@ -613,8 +613,8 @@ namespace Godot
                         return VariantUtils.CreateFrom(plane);
                     case Callable callable:
                         return VariantUtils.CreateFrom(callable);
-                    case SignalInfo signalInfo:
-                        return VariantUtils.CreateFrom(signalInfo);
+                    case Signal signal:
+                        return VariantUtils.CreateFrom(signal);
                     case string @string:
                         return VariantUtils.CreateFrom(@string);
                     case byte[] byteArray:
@@ -705,7 +705,7 @@ namespace Godot
                     [typeof(Color)] = (in godot_variant variant) => VariantUtils.ConvertTo<Color>(variant),
                     [typeof(Plane)] = (in godot_variant variant) => VariantUtils.ConvertTo<Plane>(variant),
                     [typeof(Callable)] = (in godot_variant variant) => VariantUtils.ConvertTo<Callable>(variant),
-                    [typeof(SignalInfo)] = (in godot_variant variant) => VariantUtils.ConvertTo<SignalInfo>(variant),
+                    [typeof(Signal)] = (in godot_variant variant) => VariantUtils.ConvertTo<Signal>(variant),
                     [typeof(string)] = (in godot_variant variant) => VariantUtils.ConvertTo<string>(variant),
                     [typeof(byte[])] = (in godot_variant variant) => VariantUtils.ConvertTo<byte[]>(variant),
                     [typeof(int[])] = (in godot_variant variant) => VariantUtils.ConvertTo<int[]>(variant),

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
@@ -99,7 +99,7 @@ namespace Godot.NativeInterop
                     if (type == typeof(Callable))
                         return Variant.Type.Callable;
 
-                    if (type == typeof(SignalInfo))
+                    if (type == typeof(Signal))
                         return Variant.Type.Signal;
 
                     if (type.IsEnum)
@@ -288,9 +288,9 @@ namespace Godot.NativeInterop
             return new Callable();
         }
 
-        // SignalInfo
+        // Signal
 
-        public static godot_signal ConvertSignalToNative(in SignalInfo p_managed_signal)
+        public static godot_signal ConvertSignalToNative(in Signal p_managed_signal)
         {
             ulong ownerId = p_managed_signal.Owner.GetInstanceId();
             godot_string_name name;
@@ -308,12 +308,12 @@ namespace Godot.NativeInterop
             return new godot_signal(name, ownerId);
         }
 
-        public static SignalInfo ConvertSignalToManaged(in godot_signal p_signal)
+        public static Signal ConvertSignalToManaged(in godot_signal p_signal)
         {
             var owner = GD.InstanceFromId(p_signal.ObjectId);
             var name = StringName.CreateTakingOwnershipOfDisposableValue(
                 NativeFuncs.godotsharp_string_name_new_copy(p_signal.Name));
-            return new SignalInfo(owner, name);
+            return new Signal(owner, name);
         }
 
         // Array

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
@@ -102,7 +102,7 @@ namespace Godot.NativeInterop
             => new() { Type = Variant.Type.Signal, Signal = from };
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromSignalInfo(SignalInfo from)
+        public static godot_variant CreateFromSignal(Signal from)
             => CreateFromSignalTakingOwnershipOfDisposableValue(
                 Marshaling.ConvertSignalToNative(from));
 
@@ -486,7 +486,7 @@ namespace Godot.NativeInterop
             => NativeFuncs.godotsharp_variant_as_signal(p_var);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static SignalInfo ConvertToSignalInfo(in godot_variant p_var)
+        public static Signal ConvertToSignalManaged(in godot_variant p_var)
             => Marshaling.ConvertSignalToManaged(ConvertToSignal(p_var));
 
         public static godot_array ConvertToArray(in godot_variant p_var)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
@@ -125,8 +125,8 @@ public partial class VariantUtils
         if (typeof(T) == typeof(Callable))
             return CreateFromCallable(UnsafeAs<Callable>(from));
 
-        if (typeof(T) == typeof(SignalInfo))
-            return CreateFromSignalInfo(UnsafeAs<SignalInfo>(from));
+        if (typeof(T) == typeof(Signal))
+            return CreateFromSignal(UnsafeAs<Signal>(from));
 
         if (typeof(T) == typeof(string))
             return CreateFromString(UnsafeAs<string>(from));
@@ -311,8 +311,8 @@ public partial class VariantUtils
         if (typeof(T) == typeof(Callable))
             return UnsafeAsT(ConvertToCallableManaged(variant));
 
-        if (typeof(T) == typeof(SignalInfo))
-            return UnsafeAsT(ConvertToSignalInfo(variant));
+        if (typeof(T) == typeof(Signal))
+            return UnsafeAsT(ConvertToSignalManaged(variant));
 
         if (typeof(T) == typeof(string))
             return UnsafeAsT(ConvertToStringObject(variant));

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Signal.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Signal.cs
@@ -3,7 +3,7 @@ namespace Godot
     /// <summary>
     /// Represents a signal defined in an object.
     /// </summary>
-    public readonly struct SignalInfo
+    public readonly struct Signal : IAwaitable<Variant[]>
     {
         private readonly Object _owner;
         private readonly StringName _signalName;
@@ -18,15 +18,20 @@ namespace Godot
         public StringName Name => _signalName;
 
         /// <summary>
-        /// Creates a new <see cref="SignalInfo"/> with the name <paramref name="name"/>
+        /// Creates a new <see cref="Signal"/> with the name <paramref name="name"/>
         /// in the specified <paramref name="owner"/>.
         /// </summary>
         /// <param name="owner">Object that contains the signal.</param>
         /// <param name="name">Name of the signal.</param>
-        public SignalInfo(Object owner, StringName name)
+        public Signal(Object owner, StringName name)
         {
             _owner = owner;
             _signalName = name;
+        }
+
+        public IAwaiter<Variant[]> GetAwaiter()
+        {
+            return new SignalAwaiter(_owner, _signalName, _owner);
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Variant.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Variant.cs
@@ -137,7 +137,7 @@ public partial struct Variant : IDisposable
             Type.Rid => AsRID(),
             Type.Object => AsGodotObject(),
             Type.Callable => AsCallable(),
-            Type.Signal => AsSignalInfo(),
+            Type.Signal => AsSignal(),
             Type.Dictionary => AsGodotDictionary(),
             Type.Array => AsGodotArray(),
             Type.PackedByteArray => AsByteArray(),
@@ -283,8 +283,8 @@ public partial struct Variant : IDisposable
         VariantUtils.ConvertToCallableManaged((godot_variant)NativeVar);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public SignalInfo AsSignalInfo() =>
-        VariantUtils.ConvertToSignalInfo((godot_variant)NativeVar);
+    public Signal AsSignal() =>
+        VariantUtils.ConvertToSignalManaged((godot_variant)NativeVar);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public byte[] AsByteArray() =>
@@ -464,7 +464,7 @@ public partial struct Variant : IDisposable
     public static explicit operator Callable(Variant from) => from.AsCallable();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static explicit operator SignalInfo(Variant from) => from.AsSignalInfo();
+    public static explicit operator Signal(Variant from) => from.AsSignal();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator byte[](Variant from) => from.AsByteArray();
@@ -614,7 +614,7 @@ public partial struct Variant : IDisposable
     public static Variant CreateFrom(Callable from) => from;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Variant CreateFrom(SignalInfo from) => from;
+    public static Variant CreateFrom(Signal from) => from;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Span<byte> from) => from;
@@ -804,8 +804,8 @@ public partial struct Variant : IDisposable
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromCallable(from));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator Variant(SignalInfo from) =>
-        CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromSignalInfo(from));
+    public static implicit operator Variant(Signal from) =>
+        CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromSignal(from));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(byte[] from) =>

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -116,7 +116,7 @@
     <Compile Include="Core\NativeInterop\NativeFuncs.cs" />
     <Compile Include="Core\NativeInterop\InteropStructs.cs" />
     <Compile Include="Core\NativeInterop\Marshaling.cs" />
-    <Compile Include="Core\SignalInfo.cs" />
+    <Compile Include="Core\Signal.cs" />
     <Compile Include="Core\SignalAwaiter.cs" />
     <Compile Include="Core\StringExtensions.cs" />
     <Compile Include="Core\StringName.cs" />


### PR DESCRIPTION
- Fix bindings generator for methods that return Signals.
	- Fixes CI in https://github.com/godotengine/godot/pull/69796.
- Rename `SignalInfo` to `Signal` and make awaitable.
	- As described in https://github.com/godotengine/godot/pull/69796#issuecomment-1345680246.