### PR TITLE
Fixed bug with missing reset button for orbital velocity

### DIFF
--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -1433,10 +1433,6 @@ void ParticleProcessMaterial::_validate_property(PropertyInfo &p_property) const
 		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (p_property.name.begins_with("orbit_") && !particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
-		p_property.usage = PROPERTY_USAGE_NONE;
-	}
-
 	if (!turbulence_enabled) {
 		if (p_property.name == "turbulence_noise_strength" ||
 				p_property.name == "turbulence_noise_scale" ||


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

This pull request is intended to fix the issue brought up in https://github.com/godotengine/godot/issues/68495.

The bug before was that the reset button would not appear when the values for Orbit Velocity were changed for ParticleProcessMaterial. The following gif shows this functionality working now.

![orbital_velocity](https://user-images.githubusercontent.com/71104748/207095033-a8864860-b5cd-4c34-9038-a26cb8fb89f1.gif)

In order to get this to work I deleted lines of code which set the usage property of Orbit Velocity to none. I looked back to previous pull requests to see why this line of code was here, and I am still struggling to find out the original purpose of this if statement. I traced back to this commit https://github.com/godotengine/godot/commit/5fe01d4cfc6a915d24bcb8cdc32ab371c01e94c6 which is where particles_material.cpp was introduced.

I kept backtracking to https://github.com/godotengine/godot/commit/6527f2e68465b06113b3960ad4e366f1373699c9 which is where the if statement was first introduced. I'm still not 100% sure why this was added, but it seems like there was different handling of orbital velocity depending on if it was 3d or 2d, so this if statement that I removed in this pull request may have been a temporary fix? Let me know your thoughts on this issue.

Note: It looks like the current stable version 3.x could also be fixed by this because the reset button does not appear there either.

