### PR TITLE
Fix auto-complete not suggesting custom class names on identifiers

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1271,6 +1271,14 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 		}
 		r_result.insert(option.display, option);
 	}
+
+	// Global classes
+	List<StringName> global_classes;
+	ScriptServer::get_global_class_list(&global_classes);
+	for (const StringName &E : global_classes) {
+		ScriptLanguage::CodeCompletionOption option(E, ScriptLanguage::CODE_COMPLETION_KIND_CLASS, ScriptLanguage::LOCATION_OTHER_USER_CODE);
+		r_result.insert(option.display, option);
+	}
 }
 
 static GDScriptCompletionIdentifier _type_from_variant(const Variant &p_value) {


### PR DESCRIPTION
Fixes #69941

In 4.x, auto-complete will suggest custom classes only when completing types, not identifiers. This makes it auto-complete for identifiers as well, as this was the behavior in 3.x.

![image](https://user-images.githubusercontent.com/74857873/207100492-c069e364-327b-44d3-beeb-881c9d58bf40.png)

![image](https://user-images.githubusercontent.com/74857873/207100451-c0cfb131-e069-48e0-9fdd-313fc33a18d5.png)

