### PR TITLE
C#: Fix premature free of returned Variant in vararg methods

### DIFF
--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -2489,9 +2489,12 @@ Error BindingsGenerator::_generate_cs_native_calls(const InternalCall &p_icall, 
 
 			if (!ret_void) {
 				if (return_type->cname != name_cache.type_Variant) {
+					// Usually the return value takes ownership, but in this case the variant is only used
+					// for conversion to another return type. As such, the local variable takes ownership.
 					r_output << "using godot_variant " << C_LOCAL_VARARG_RET " = ";
 				} else {
-					r_output << "using godot_variant " << C_LOCAL_RET " = ";
+					// Variant's [c_out] takes ownership of the variant value
+					r_output << "godot_variant " << C_LOCAL_RET " = ";
 				}
 			}
 


### PR DESCRIPTION
Notably, this fixes obscure issues after calling `script.New()` when the returned instance is a `RefCounted`.

May fix ~ #68148
