### PR TITLE
Add safety-checks before some servers `free()`

### DIFF
--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -436,6 +436,7 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 }
 
 EditorMaterialPreviewPlugin::~EditorMaterialPreviewPlugin() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(sphere);
 	RS::get_singleton()->free(sphere_instance);
 	RS::get_singleton()->free(viewport);
@@ -767,6 +768,7 @@ EditorMeshPreviewPlugin::EditorMeshPreviewPlugin() {
 }
 
 EditorMeshPreviewPlugin::~EditorMeshPreviewPlugin() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	//RS::get_singleton()->free(sphere);
 	RS::get_singleton()->free(mesh_instance);
 	RS::get_singleton()->free(viewport);
@@ -867,6 +869,7 @@ EditorFontPreviewPlugin::EditorFontPreviewPlugin() {
 }
 
 EditorFontPreviewPlugin::~EditorFontPreviewPlugin() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(canvas_item);
 	RS::get_singleton()->free(canvas);
 	RS::get_singleton()->free(viewport);

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -100,6 +100,7 @@ bool EditorNode3DGizmo::is_editable() const {
 }
 
 void EditorNode3DGizmo::clear() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	for (int i = 0; i < instances.size(); i++) {
 		if (instances[i].instance.is_valid()) {
 			RS::get_singleton()->free(instances[i].instance);
@@ -809,6 +810,7 @@ void EditorNode3DGizmo::transform() {
 }
 
 void EditorNode3DGizmo::free() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	ERR_FAIL_COND(!spatial_node);
 	ERR_FAIL_COND(!valid);
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3557,6 +3557,7 @@ void Node3DEditorViewport::_init_gizmo_instance(int p_idx) {
 }
 
 void Node3DEditorViewport::_finish_gizmo_instances() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	for (int i = 0; i < 3; i++) {
 		RS::get_singleton()->free(move_gizmo_instance[i]);
 		RS::get_singleton()->free(move_plane_gizmo_instance[i]);
@@ -5536,6 +5537,7 @@ Node3DEditorViewportContainer::Node3DEditorViewportContainer() {
 Node3DEditor *Node3DEditor::singleton = nullptr;
 
 Node3DEditorSelectedItem::~Node3DEditorSelectedItem() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (sbox_instance.is_valid()) {
 		RenderingServer::get_singleton()->free(sbox_instance);
 	}

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1405,6 +1405,7 @@ GridMapEditor::GridMapEditor() {
 }
 
 GridMapEditor::~GridMapEditor() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	_clear_clipboard_data();
 
 	for (int i = 0; i < 3; i++) {

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -796,6 +796,10 @@ void GridMap::_octant_enter_world(const OctantKey &p_key) {
 }
 
 void GridMap::_octant_exit_world(const OctantKey &p_key) {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
+	ERR_FAIL_NULL(NavigationServer3D::get_singleton());
+
 	ERR_FAIL_COND(!octant_map.has(p_key));
 	Octant &g = *octant_map[p_key];
 	PhysicsServer3D::get_singleton()->body_set_state(g.static_body, PhysicsServer3D::BODY_STATE_TRANSFORM, get_global_transform());
@@ -834,6 +838,10 @@ void GridMap::_octant_exit_world(const OctantKey &p_key) {
 }
 
 void GridMap::_octant_clean_up(const OctantKey &p_key) {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
+	ERR_FAIL_NULL(NavigationServer3D::get_singleton());
+
 	ERR_FAIL_COND(!octant_map.has(p_key));
 	Octant &g = *octant_map[p_key];
 
@@ -1186,6 +1194,7 @@ Vector3 GridMap::_get_offset() const {
 }
 
 void GridMap::clear_baked_meshes() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	for (int i = 0; i < baked_meshes.size(); i++) {
 		RS::get_singleton()->free(baked_meshes[i].instance);
 	}

--- a/modules/noise/noise_texture_2d.cpp
+++ b/modules/noise/noise_texture_2d.cpp
@@ -40,6 +40,7 @@ NoiseTexture2D::NoiseTexture2D() {
 }
 
 NoiseTexture2D::~NoiseTexture2D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (texture.is_valid()) {
 		RS::get_singleton()->free(texture);
 	}

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -661,5 +661,6 @@ CollisionObject2D::CollisionObject2D() {
 }
 
 CollisionObject2D::~CollisionObject2D() {
+	ERR_FAIL_NULL(PhysicsServer2D::get_singleton());
 	PhysicsServer2D::get_singleton()->free(rid);
 }

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -1507,6 +1507,7 @@ CPUParticles2D::CPUParticles2D() {
 }
 
 CPUParticles2D::~CPUParticles2D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(multimesh);
 	RS::get_singleton()->free(mesh);
 }

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -688,6 +688,7 @@ GPUParticles2D::GPUParticles2D() {
 }
 
 GPUParticles2D::~GPUParticles2D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(particles);
 	RS::get_singleton()->free(mesh);
 }

--- a/scene/2d/joint_2d.cpp
+++ b/scene/2d/joint_2d.cpp
@@ -246,6 +246,7 @@ Joint2D::Joint2D() {
 }
 
 Joint2D::~Joint2D() {
+	ERR_FAIL_NULL(PhysicsServer2D::get_singleton());
 	PhysicsServer2D::get_singleton()->free(joint);
 }
 

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -321,6 +321,7 @@ Light2D::Light2D() {
 }
 
 Light2D::~Light2D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RenderingServer::get_singleton()->free(canvas_light);
 }
 

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -148,6 +148,7 @@ OccluderPolygon2D::OccluderPolygon2D() {
 }
 
 OccluderPolygon2D::~OccluderPolygon2D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(occ_polygon);
 }
 
@@ -291,5 +292,7 @@ LightOccluder2D::LightOccluder2D() {
 }
 
 LightOccluder2D::~LightOccluder2D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+
 	RS::get_singleton()->free(occluder);
 }

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -197,6 +197,7 @@ NavigationAgent2D::NavigationAgent2D() {
 }
 
 NavigationAgent2D::~NavigationAgent2D() {
+	ERR_FAIL_NULL(NavigationServer2D::get_singleton());
 	NavigationServer2D::get_singleton()->free(agent);
 	agent = RID(); // Pointless
 }

--- a/scene/2d/navigation_link_2d.cpp
+++ b/scene/2d/navigation_link_2d.cpp
@@ -285,6 +285,7 @@ NavigationLink2D::NavigationLink2D() {
 }
 
 NavigationLink2D::~NavigationLink2D() {
+	ERR_FAIL_NULL(NavigationServer2D::get_singleton());
 	NavigationServer2D::get_singleton()->free(link);
 	link = RID();
 }

--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -116,6 +116,7 @@ NavigationObstacle2D::NavigationObstacle2D() {
 }
 
 NavigationObstacle2D::~NavigationObstacle2D() {
+	ERR_FAIL_NULL(NavigationServer2D::get_singleton());
 	NavigationServer2D::get_singleton()->free(agent);
 	agent = RID(); // Pointless
 }

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -343,6 +343,7 @@ NavigationRegion2D::NavigationRegion2D() {
 }
 
 NavigationRegion2D::~NavigationRegion2D() {
+	ERR_FAIL_NULL(NavigationServer2D::get_singleton());
 	NavigationServer2D::get_singleton()->free(region);
 
 #ifdef DEBUG_ENABLED

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -664,6 +664,7 @@ Polygon2D::Polygon2D() {
 
 Polygon2D::~Polygon2D() {
 	// This will free the internally-allocated mesh instance, if allocated.
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->canvas_item_attach_skeleton(get_canvas_item(), RID());
 	RS::get_singleton()->free(mesh);
 }

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -529,6 +529,7 @@ Bone2D::Bone2D() {
 Bone2D::~Bone2D() {
 #ifdef TOOLS_ENABLED
 	if (!editor_gizmo_rid.is_null()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RenderingServer::get_singleton()->free(editor_gizmo_rid);
 	}
 #endif // TOOLS_ENABLED
@@ -803,5 +804,6 @@ Skeleton2D::Skeleton2D() {
 }
 
 Skeleton2D::~Skeleton2D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(skeleton);
 }

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1108,6 +1108,7 @@ void TileMap::_rendering_update_layer(int p_layer) {
 void TileMap::_rendering_cleanup_layer(int p_layer) {
 	ERR_FAIL_INDEX(p_layer, (int)layers.size());
 
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RenderingServer *rs = RenderingServer::get_singleton();
 	if (layers[p_layer].canvas_item.is_valid()) {
 		rs->free(layers[p_layer].canvas_item);
@@ -1280,6 +1281,7 @@ void TileMap::_rendering_create_quadrant(TileMapQuadrant *p_quadrant) {
 }
 
 void TileMap::_rendering_cleanup_quadrant(TileMapQuadrant *p_quadrant) {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	// Free the canvas items.
 	for (const RID &ci : p_quadrant->canvas_items) {
 		RenderingServer::get_singleton()->free(ci);
@@ -1596,6 +1598,7 @@ void TileMap::_physics_update_dirty_quadrants(SelfList<TileMapQuadrant>::List &r
 
 void TileMap::_physics_cleanup_quadrant(TileMapQuadrant *p_quadrant) {
 	// Remove a quadrant.
+	ERR_FAIL_NULL(PhysicsServer2D::get_singleton());
 	for (RID body : p_quadrant->bodies) {
 		bodies_coords.erase(body);
 		PhysicsServer2D::get_singleton()->free(body);
@@ -1754,6 +1757,7 @@ void TileMap::_navigation_update_dirty_quadrants(SelfList<TileMapQuadrant>::List
 
 void TileMap::_navigation_cleanup_quadrant(TileMapQuadrant *p_quadrant) {
 	// Clear navigation shapes in the quadrant.
+	ERR_FAIL_NULL(NavigationServer2D::get_singleton());
 	for (const KeyValue<Vector2i, Vector<RID>> &E : p_quadrant->navigation_regions) {
 		for (int i = 0; i < E.value.size(); i++) {
 			RID region = E.value[i];

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -744,8 +744,10 @@ Camera3D::Camera3D() {
 }
 
 Camera3D::~Camera3D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RenderingServer::get_singleton()->free(camera);
 	if (pyramid_shape.is_valid()) {
+		ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
 		PhysicsServer3D::get_singleton()->free(pyramid_shape);
 	}
 }

--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -352,6 +352,8 @@ void CollisionObject3D::_shape_changed(const Ref<Shape3D> &p_shape) {
 }
 
 void CollisionObject3D::_update_debug_shapes() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+
 	if (!is_inside_tree()) {
 		debug_shapes_to_update.clear();
 		return;
@@ -393,6 +395,8 @@ void CollisionObject3D::_update_debug_shapes() {
 }
 
 void CollisionObject3D::_clear_debug_shapes() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+
 	for (KeyValue<uint32_t, ShapeData> &E : shapes) {
 		ShapeData &shapedata = E.value;
 		ShapeData::ShapeBase *shape_bases = shapedata.shapes.ptrw();
@@ -627,6 +631,7 @@ int CollisionObject3D::shape_owner_get_shape_index(uint32_t p_owner, int p_shape
 }
 
 void CollisionObject3D::shape_owner_remove_shape(uint32_t p_owner, int p_shape) {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	ERR_FAIL_COND(!shapes.has(p_owner));
 	ERR_FAIL_INDEX(p_shape, shapes[p_owner].shapes.size());
 
@@ -722,5 +727,6 @@ CollisionObject3D::CollisionObject3D() {
 }
 
 CollisionObject3D::~CollisionObject3D() {
+	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
 	PhysicsServer3D::get_singleton()->free(rid);
 }

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -1701,5 +1701,6 @@ CPUParticles3D::CPUParticles3D() {
 }
 
 CPUParticles3D::~CPUParticles3D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(multimesh);
 }

--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -254,5 +254,6 @@ Decal::Decal() {
 }
 
 Decal::~Decal() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(decal);
 }

--- a/scene/3d/fog_volume.cpp
+++ b/scene/3d/fog_volume.cpp
@@ -118,5 +118,6 @@ FogVolume::FogVolume() {
 }
 
 FogVolume::~FogVolume() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(volume);
 }

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -634,5 +634,6 @@ GPUParticles3D::GPUParticles3D() {
 }
 
 GPUParticles3D::~GPUParticles3D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(particles);
 }

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -58,6 +58,7 @@ GPUParticlesCollision3D::GPUParticlesCollision3D(RS::ParticlesCollisionType p_ty
 }
 
 GPUParticlesCollision3D::~GPUParticlesCollision3D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(collision);
 }
 
@@ -819,6 +820,7 @@ GPUParticlesAttractor3D::GPUParticlesAttractor3D(RS::ParticlesCollisionType p_ty
 	set_base(collision);
 }
 GPUParticlesAttractor3D::~GPUParticlesAttractor3D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(collision);
 }
 

--- a/scene/3d/joint_3d.cpp
+++ b/scene/3d/joint_3d.cpp
@@ -234,6 +234,7 @@ Joint3D::Joint3D() {
 }
 
 Joint3D::~Joint3D() {
+	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
 	PhysicsServer3D::get_singleton()->free(joint);
 }
 

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -966,6 +966,7 @@ Label3D::~Label3D() {
 
 	TS->free_rid(text_rid);
 
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RenderingServer::get_singleton()->free(mesh);
 	for (KeyValue<SurfaceKey, SurfaceData> E : surfaces) {
 		RenderingServer::get_singleton()->free(E.value.material);

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -476,6 +476,7 @@ Light3D::Light3D() {
 }
 
 Light3D::~Light3D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->instance_set_base(get_instance(), RID());
 
 	if (light.is_valid()) {

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -313,6 +313,7 @@ LightmapGIData::LightmapGIData() {
 }
 
 LightmapGIData::~LightmapGIData() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(lightmap);
 }
 

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -204,6 +204,7 @@ NavigationAgent3D::NavigationAgent3D() {
 }
 
 NavigationAgent3D::~NavigationAgent3D() {
+	ERR_FAIL_NULL(NavigationServer3D::get_singleton());
 	NavigationServer3D::get_singleton()->free(agent);
 	agent = RID(); // Pointless
 }

--- a/scene/3d/navigation_link_3d.cpp
+++ b/scene/3d/navigation_link_3d.cpp
@@ -227,10 +227,12 @@ NavigationLink3D::NavigationLink3D() {
 }
 
 NavigationLink3D::~NavigationLink3D() {
+	ERR_FAIL_NULL(NavigationServer3D::get_singleton());
 	NavigationServer3D::get_singleton()->free(link);
 	link = RID();
 
 #ifdef DEBUG_ENABLED
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (debug_instance.is_valid()) {
 		RenderingServer::get_singleton()->free(debug_instance);
 	}

--- a/scene/3d/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation_obstacle_3d.cpp
@@ -122,6 +122,7 @@ NavigationObstacle3D::NavigationObstacle3D() {
 }
 
 NavigationObstacle3D::~NavigationObstacle3D() {
+	ERR_FAIL_NULL(NavigationServer3D::get_singleton());
 	NavigationServer3D::get_singleton()->free(agent);
 	agent = RID(); // Pointless
 }

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -375,12 +375,15 @@ NavigationRegion3D::~NavigationRegion3D() {
 	if (navigation_mesh.is_valid()) {
 		navigation_mesh->disconnect("changed", callable_mp(this, &NavigationRegion3D::_navigation_changed));
 	}
+	ERR_FAIL_NULL(NavigationServer3D::get_singleton());
 	NavigationServer3D::get_singleton()->free(region);
 
 #ifdef DEBUG_ENABLED
 	NavigationServer3D::get_singleton_mut()->disconnect("map_changed", callable_mp(this, &NavigationRegion3D::_navigation_map_changed));
 	NavigationServer3D::get_singleton_mut()->disconnect("navigation_debug_changed", callable_mp(this, &NavigationRegion3D::_update_debug_mesh));
 	NavigationServer3D::get_singleton_mut()->disconnect("navigation_debug_changed", callable_mp(this, &NavigationRegion3D::_update_debug_edge_connections_mesh));
+
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (debug_instance.is_valid()) {
 		RenderingServer::get_singleton()->free(debug_instance);
 	}

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -138,6 +138,7 @@ Occluder3D::Occluder3D() {
 
 Occluder3D::~Occluder3D() {
 	if (occluder.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RS::get_singleton()->free(occluder);
 	}
 }

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -40,6 +40,7 @@ Path3D::Path3D() {
 }
 
 Path3D::~Path3D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (debug_instance.is_valid()) {
 		RS::get_singleton()->free(debug_instance);
 	}

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -3358,6 +3358,7 @@ PhysicalBone3D::~PhysicalBone3D() {
 	if (joint_data) {
 		memdelete(joint_data);
 	}
+	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
 	PhysicsServer3D::get_singleton()->free(joint);
 }
 

--- a/scene/3d/reflection_probe.cpp
+++ b/scene/3d/reflection_probe.cpp
@@ -257,5 +257,6 @@ ReflectionProbe::ReflectionProbe() {
 }
 
 ReflectionProbe::~ReflectionProbe() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(probe);
 }

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -58,10 +58,10 @@ Ref<Skin> SkinReference::get_skin() const {
 }
 
 SkinReference::~SkinReference() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (skeleton_node) {
 		skeleton_node->skin_bindings.erase(this);
 	}
-
 	RS::get_singleton()->free(skeleton);
 }
 

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -704,6 +704,7 @@ SoftBody3D::SoftBody3D() :
 
 SoftBody3D::~SoftBody3D() {
 	memdelete(rendering_server_handler);
+	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
 	PhysicsServer3D::get_singleton()->free(physics_rid);
 }
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -611,6 +611,7 @@ SpriteBase3D::SpriteBase3D() {
 }
 
 SpriteBase3D::~SpriteBase3D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RenderingServer::get_singleton()->free(mesh);
 	RenderingServer::get_singleton()->free(material);
 }

--- a/scene/3d/visible_on_screen_notifier_3d.cpp
+++ b/scene/3d/visible_on_screen_notifier_3d.cpp
@@ -99,6 +99,7 @@ VisibleOnScreenNotifier3D::VisibleOnScreenNotifier3D() {
 VisibleOnScreenNotifier3D::~VisibleOnScreenNotifier3D() {
 	RID base_old = get_base();
 	set_base(RID());
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(base_old);
 }
 

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -157,6 +157,7 @@ VisualInstance3D::VisualInstance3D() {
 }
 
 VisualInstance3D::~VisualInstance3D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RenderingServer::get_singleton()->free(instance);
 }
 

--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -242,6 +242,7 @@ VoxelGIData::VoxelGIData() {
 }
 
 VoxelGIData::~VoxelGIData() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(probe);
 }
 
@@ -516,5 +517,6 @@ VoxelGI::VoxelGI() {
 }
 
 VoxelGI::~VoxelGI() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(voxel_gi);
 }

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1305,6 +1305,7 @@ CanvasItem::CanvasItem() :
 }
 
 CanvasItem::~CanvasItem() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RenderingServer::get_singleton()->free(canvas_item);
 }
 
@@ -1459,5 +1460,6 @@ CanvasTexture::CanvasTexture() {
 	canvas_texture = RS::get_singleton()->canvas_texture_create();
 }
 CanvasTexture::~CanvasTexture() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(canvas_texture);
 }

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -360,5 +360,6 @@ CanvasLayer::CanvasLayer() {
 }
 
 CanvasLayer::~CanvasLayer() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(canvas);
 }

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -80,6 +80,7 @@ void ViewportTexture::setup_local_to_scene() {
 
 	vp->viewport_textures.insert(this);
 
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (proxy_ph.is_valid()) {
 		RS::get_singleton()->texture_proxy_update(proxy, vp->texture_rid);
 		RS::get_singleton()->free(proxy_ph);
@@ -152,6 +153,8 @@ ViewportTexture::~ViewportTexture() {
 	if (vp) {
 		vp->viewport_textures.erase(this);
 	}
+
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 
 	if (proxy_ph.is_valid()) {
 		RS::get_singleton()->free(proxy_ph);
@@ -300,6 +303,8 @@ void Viewport::_sub_window_grab_focus(Window *p_window) {
 void Viewport::_sub_window_remove(Window *p_window) {
 	int index = _sub_window_find(p_window);
 	ERR_FAIL_COND(index == -1);
+
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 
 	RS::get_singleton()->free(gui.sub_windows[index].canvas_item);
 	gui.sub_windows.remove_at(index);
@@ -4117,6 +4122,7 @@ Viewport::~Viewport() {
 	for (ViewportTexture *E : viewport_textures) {
 		E->vp = nullptr;
 	}
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RenderingServer::get_singleton()->free(viewport);
 }
 

--- a/scene/resources/camera_attributes.cpp
+++ b/scene/resources/camera_attributes.cpp
@@ -135,6 +135,7 @@ CameraAttributes::CameraAttributes() {
 }
 
 CameraAttributes::~CameraAttributes() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(camera_attributes);
 }
 

--- a/scene/resources/canvas_item_material.cpp
+++ b/scene/resources/canvas_item_material.cpp
@@ -294,6 +294,8 @@ CanvasItemMaterial::CanvasItemMaterial() :
 CanvasItemMaterial::~CanvasItemMaterial() {
 	MutexLock lock(material_mutex);
 
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+
 	if (shader_map.has(current_key)) {
 		shader_map[current_key].users--;
 		if (shader_map[current_key].users == 0) {

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -1550,5 +1550,6 @@ Environment::Environment() {
 }
 
 Environment::~Environment() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(environment);
 }

--- a/scene/resources/fog_material.cpp
+++ b/scene/resources/fog_material.cpp
@@ -132,6 +132,7 @@ void FogMaterial::_bind_methods() {
 
 void FogMaterial::cleanup_shader() {
 	if (shader.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RS::get_singleton()->free(shader);
 	}
 }

--- a/scene/resources/immediate_mesh.cpp
+++ b/scene/resources/immediate_mesh.cpp
@@ -410,5 +410,6 @@ ImmediateMesh::ImmediateMesh() {
 	mesh = RS::get_singleton()->mesh_create();
 }
 ImmediateMesh::~ImmediateMesh() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(mesh);
 }

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -141,6 +141,7 @@ Material::Material() {
 }
 
 Material::~Material() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RenderingServer::get_singleton()->free(material);
 }
 
@@ -3005,6 +3006,7 @@ BaseMaterial3D::BaseMaterial3D(bool p_orm) :
 }
 
 BaseMaterial3D::~BaseMaterial3D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	MutexLock lock(material_mutex);
 
 	if (shader_map.has(current_key)) {

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -2117,6 +2117,7 @@ ArrayMesh::ArrayMesh() {
 
 ArrayMesh::~ArrayMesh() {
 	if (mesh.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RenderingServer::get_singleton()->free(mesh);
 	}
 }
@@ -2132,5 +2133,6 @@ PlaceholderMesh::PlaceholderMesh() {
 }
 
 PlaceholderMesh::~PlaceholderMesh() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(rid);
 }

--- a/scene/resources/multimesh.cpp
+++ b/scene/resources/multimesh.cpp
@@ -365,5 +365,6 @@ MultiMesh::MultiMesh() {
 }
 
 MultiMesh::~MultiMesh() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RenderingServer::get_singleton()->free(multimesh);
 }

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -1894,6 +1894,7 @@ ParticleProcessMaterial::ParticleProcessMaterial() :
 }
 
 ParticleProcessMaterial::~ParticleProcessMaterial() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	MutexLock lock(material_mutex);
 
 	if (shader_map.has(current_key)) {

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -340,6 +340,7 @@ PrimitiveMesh::PrimitiveMesh() {
 }
 
 PrimitiveMesh::~PrimitiveMesh() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RenderingServer::get_singleton()->free(mesh);
 }
 

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -208,6 +208,7 @@ Shader::Shader() {
 }
 
 Shader::~Shader() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RenderingServer::get_singleton()->free(shader);
 }
 

--- a/scene/resources/sky.cpp
+++ b/scene/resources/sky.cpp
@@ -106,5 +106,6 @@ Sky::Sky() {
 }
 
 Sky::~Sky() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(sky);
 }

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -324,6 +324,7 @@ ImageTexture::ImageTexture() {}
 
 ImageTexture::~ImageTexture() {
 	if (texture.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RenderingServer::get_singleton()->free(texture);
 	}
 }
@@ -630,6 +631,7 @@ PortableCompressedTexture2D::PortableCompressedTexture2D() {}
 
 PortableCompressedTexture2D::~PortableCompressedTexture2D() {
 	if (texture.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RenderingServer::get_singleton()->free(texture);
 	}
 }
@@ -1041,6 +1043,7 @@ CompressedTexture2D::CompressedTexture2D() {}
 
 CompressedTexture2D::~CompressedTexture2D() {
 	if (texture.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RS::get_singleton()->free(texture);
 	}
 }
@@ -1225,6 +1228,7 @@ ImageTexture3D::ImageTexture3D() {
 
 ImageTexture3D::~ImageTexture3D() {
 	if (texture.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RS::get_singleton()->free(texture);
 	}
 }
@@ -1386,6 +1390,7 @@ CompressedTexture3D::CompressedTexture3D() {}
 
 CompressedTexture3D::~CompressedTexture3D() {
 	if (texture.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RS::get_singleton()->free(texture);
 	}
 }
@@ -1911,6 +1916,7 @@ CurveTexture::CurveTexture() {}
 
 CurveTexture::~CurveTexture() {
 	if (_texture.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RS::get_singleton()->free(_texture);
 	}
 }
@@ -2109,6 +2115,7 @@ CurveXYZTexture::CurveXYZTexture() {}
 
 CurveXYZTexture::~CurveXYZTexture() {
 	if (_texture.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RS::get_singleton()->free(_texture);
 	}
 }
@@ -2121,6 +2128,7 @@ GradientTexture1D::GradientTexture1D() {
 
 GradientTexture1D::~GradientTexture1D() {
 	if (texture.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RS::get_singleton()->free(texture);
 	}
 }
@@ -2263,6 +2271,7 @@ GradientTexture2D::GradientTexture2D() {
 
 GradientTexture2D::~GradientTexture2D() {
 	if (texture.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RS::get_singleton()->free(texture);
 	}
 }
@@ -2521,6 +2530,7 @@ void ProxyTexture::set_base(const Ref<Texture2D> &p_texture) {
 
 	base = p_texture;
 	if (base.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		if (proxy_ph.is_valid()) {
 			RS::get_singleton()->texture_proxy_update(proxy, base->get_rid());
 			RS::get_singleton()->free(proxy_ph);
@@ -2571,6 +2581,7 @@ ProxyTexture::ProxyTexture() {
 }
 
 ProxyTexture::~ProxyTexture() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (proxy_ph.is_valid()) {
 		RS::get_singleton()->free(proxy_ph);
 	}
@@ -2828,6 +2839,7 @@ AnimatedTexture::AnimatedTexture() {
 }
 
 AnimatedTexture::~AnimatedTexture() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(proxy);
 	RS::get_singleton()->free(proxy_ph);
 }
@@ -3031,6 +3043,7 @@ ImageTextureLayered::ImageTextureLayered(LayeredType p_layered_type) {
 
 ImageTextureLayered::~ImageTextureLayered() {
 	if (texture.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RS::get_singleton()->free(texture);
 	}
 }
@@ -3198,6 +3211,7 @@ CompressedTextureLayered::CompressedTextureLayered(LayeredType p_type) {
 
 CompressedTextureLayered::~CompressedTextureLayered() {
 	if (texture.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RS::get_singleton()->free(texture);
 	}
 }
@@ -3353,6 +3367,7 @@ CameraTexture::CameraTexture() {}
 
 CameraTexture::~CameraTexture() {
 	if (_texture.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RenderingServer::get_singleton()->free(_texture);
 	}
 }
@@ -3394,6 +3409,7 @@ PlaceholderTexture2D::PlaceholderTexture2D() {
 }
 
 PlaceholderTexture2D::~PlaceholderTexture2D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(rid);
 }
 
@@ -3441,6 +3457,7 @@ PlaceholderTexture3D::PlaceholderTexture3D() {
 	rid = RS::get_singleton()->texture_3d_placeholder_create();
 }
 PlaceholderTexture3D::~PlaceholderTexture3D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(rid);
 }
 
@@ -3499,5 +3516,6 @@ PlaceholderTextureLayered::PlaceholderTextureLayered(LayeredType p_type) {
 	rid = RS::get_singleton()->texture_2d_layered_placeholder_create(RS::TextureLayeredType(layered_type));
 }
 PlaceholderTextureLayered::~PlaceholderTextureLayered() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(rid);
 }

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -89,6 +89,9 @@ World2D::World2D() {
 }
 
 World2D::~World2D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	ERR_FAIL_NULL(PhysicsServer2D::get_singleton());
+	ERR_FAIL_NULL(NavigationServer2D::get_singleton());
 	RenderingServer::get_singleton()->free(canvas);
 	PhysicsServer2D::get_singleton()->free(space);
 	NavigationServer2D::get_singleton()->free(navigation_map);

--- a/scene/resources/world_3d.cpp
+++ b/scene/resources/world_3d.cpp
@@ -157,6 +157,9 @@ World3D::World3D() {
 }
 
 World3D::~World3D() {
+	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	ERR_FAIL_NULL(NavigationServer3D::get_singleton());
 	PhysicsServer3D::get_singleton()->free(space);
 	RenderingServer::get_singleton()->free(scenario);
 	NavigationServer3D::get_singleton()->free(navigation_map);

--- a/servers/camera/camera_feed.cpp
+++ b/servers/camera/camera_feed.cpp
@@ -165,6 +165,7 @@ CameraFeed::CameraFeed(String p_name, FeedPosition p_position) {
 
 CameraFeed::~CameraFeed() {
 	// Free our textures
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RenderingServer::get_singleton()->free(texture[CameraServer::FEED_Y_IMAGE]);
 	RenderingServer::get_singleton()->free(texture[CameraServer::FEED_CBCR_IMAGE]);
 }

--- a/servers/rendering/renderer_scene_occlusion_cull.cpp
+++ b/servers/rendering/renderer_scene_occlusion_cull.cpp
@@ -60,6 +60,8 @@ void RendererSceneOcclusionCull::HZBuffer::clear() {
 	if (debug_image.is_valid()) {
 		debug_image.unref();
 	}
+
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->free(debug_texture);
 }
 

--- a/servers/xr/xr_interface.cpp
+++ b/servers/xr/xr_interface.cpp
@@ -123,6 +123,7 @@ XRInterface::XRInterface() {}
 
 XRInterface::~XRInterface() {
 	if (vrs.vrs_texture.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RS::get_singleton()->free(vrs.vrs_texture);
 		vrs.vrs_texture = RID();
 	}


### PR DESCRIPTION
Adds `ERR_FAIL_NULL()` checks to make sure servers singleton exist before freeing resources. Adds checks for `NavigationServer{2D,3D}`, `PhysicsServer{2D,3D}` and `RenderingServer`.

This makes so that leaks don't crash the engine when exiting.

Fixes #69910 - Destructing leaking RenderingServer RID objects can crash the engine on exit as RenderingServer singleton is already deleted 