### PR TITLE
Ensure that rim lighting uses an exponent base greater than zero

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -134,7 +134,8 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, float atte
 #endif
 
 #if defined(LIGHT_RIM_USED)
-		float rim_light = pow(max(0.0, 1.0 - cNdotV), max(0.0, (1.0 - roughness) * 16.0));
+		// Epsilon min to prevent pow(0, 0) singularity which results in undefined behavior.
+		float rim_light = pow(max(1e-4, 1.0 - cNdotV), max(0.0, (1.0 - roughness) * 16.0));
 		diffuse_light += rim_light * rim * mix(vec3(1.0), albedo, rim_tint) * light_color;
 #endif
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/69908

This avoids the undefined behavior that happens if the base is zero and the exponent is zero

See https://registry.khronos.org/OpenGL-Refpages/gl4/html/pow.xhtml

Alternatively we could ensure the exponent is always greater than 0, but that would essentially be a change to the roughness of the material and would change the rim to be the same as if the roughness was less than 1. This change ensures the smallest visual difference. 

_Before:_
![Screenshot from 2022-12-12 13-29-09](https://user-images.githubusercontent.com/16521339/207158509-abc3db76-1183-4435-b74c-6fcb003c2d77.png)

_After:_
![Screenshot from 2022-12-12 13-24-26](https://user-images.githubusercontent.com/16521339/207158515-91d12d05-f5f5-4ce0-8db4-be96e3a93fd8.png)
