### PR TITLE
Fix ambiguous touch input events on Android

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java
@@ -422,7 +422,7 @@ public class GodotInputHandler implements InputManager.InputDeviceListener {
 	}
 
 	private static boolean isMouseEvent(int eventSource) {
-		boolean mouseSource = ((eventSource & InputDevice.SOURCE_MOUSE) == InputDevice.SOURCE_MOUSE) || ((eventSource & InputDevice.SOURCE_STYLUS) == InputDevice.SOURCE_STYLUS);
+		boolean mouseSource = ((eventSource & InputDevice.SOURCE_MOUSE) == InputDevice.SOURCE_MOUSE) || ((eventSource & (InputDevice.SOURCE_TOUCHSCREEN | InputDevice.SOURCE_STYLUS)) == InputDevice.SOURCE_STYLUS);
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 			mouseSource = mouseSource || ((eventSource & InputDevice.SOURCE_MOUSE_RELATIVE) == InputDevice.SOURCE_MOUSE_RELATIVE);
 		}


### PR DESCRIPTION
There are multiple devices where touch input events are sent with both `SOURCE_TOUCHSCREEN` and `SOURCE_STYLUS`. These have previously been handled as mouse events with `button_index=0`, essentially breaking all interactions. See Bugs #69517 and #69536 for devices on which this occurs. (One noteworthy example is the android emulator, since that does allow to verify this behavior without requiring access to any particular physical device.)

In Godot 3.x, this problem did not occur, as the input handling only looked for SOURCE_MOUSE to switch to handling events as mouse events.

This PR now changes the `isMouseEvent` function to ignore `SOURCE_STYLUS` in the `eventSource` if the `SOURCE_TOUCHSCREEN` bit is also set. This fixes the input in this specific `SOURCE_TOUCHSCREEN | SOURCE_STYLUS` case while still allowing pure `SOURCE_STYLUS` events to be handled as mouse events.

Fixes #69517 and fixes #69536