### PR TITLE
GDScript Analyzer: Fix String type compatibility being too permissive

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1595,7 +1595,7 @@ void GDScriptAnalyzer::resolve_constant(GDScriptParser::ConstantNode *p_constant
 	}
 
 	if (p_constant->datatype_specifier != nullptr) {
-		if (!is_type_compatible(explicit_type, type)) {
+		if (!is_type_compatible(explicit_type, type, true)) {
 			push_error(vformat(R"(Assigned value for constant "%s" has type %s which is not compatible with defined type %s.)", p_constant->identifier->name, type.to_string(), explicit_type.to_string()), p_constant->initializer);
 #ifdef DEBUG_ENABLED
 		} else if (explicit_type.builtin_type == Variant::INT && type.builtin_type == Variant::FLOAT) {
@@ -4187,8 +4187,6 @@ bool GDScriptAnalyzer::is_type_compatible(const GDScriptParser::DataType &p_targ
 
 	if (p_target.kind == GDScriptParser::DataType::BUILTIN) {
 		bool valid = p_source.kind == GDScriptParser::DataType::BUILTIN && p_target.builtin_type == p_source.builtin_type;
-		valid |= p_source.builtin_type == Variant::STRING && p_target.builtin_type == Variant::STRING_NAME;
-		valid |= p_source.builtin_type == Variant::STRING_NAME && p_target.builtin_type == Variant::STRING;
 		if (!valid && p_allow_implicit_conversion) {
 			valid = Variant::can_convert_strict(p_source.builtin_type, p_target.builtin_type);
 		}
@@ -4204,7 +4202,7 @@ bool GDScriptAnalyzer::is_type_compatible(const GDScriptParser::DataType &p_targ
 					// Variant array can't be appended to typed array.
 					valid = false;
 				} else {
-					valid = is_type_compatible(p_target.get_container_element_type(), p_source.get_container_element_type(), false);
+					valid = is_type_compatible(p_target.get_container_element_type(), p_source.get_container_element_type(), p_allow_implicit_conversion);
 				}
 			}
 		}

--- a/modules/gdscript/tests/scripts/analyzer/features/array_string_stringname_equivalent.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/array_string_stringname_equivalent.gd
@@ -1,4 +1,11 @@
+
+var m_string_array: Array[String] = [&"abc"]
+var m_stringname_array: Array[StringName] = ["abc"]
+
 func test():
+	print(m_string_array)
+	print(m_stringname_array)
+
 	# Converted to String when initialized
 	var string_array: Array[String] = [&"abc"]
 	print(string_array)

--- a/modules/gdscript/tests/scripts/analyzer/features/array_string_stringname_equivalent.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/array_string_stringname_equivalent.out
@@ -1,3 +1,5 @@
 GDTEST_OK
 ["abc"]
 [&"abc"]
+["abc"]
+[&"abc"]


### PR DESCRIPTION
in https://github.com/godotengine/godot/pull/68747 `is_type_compatible()` was too relaxed with compatability between String and StringName, sometimes treating them as the same type

instead this relaxes the compatibility of typed arrays (the actual issue i was trying to solve) because the compiler will already do a proper typed assign when initializing vars and consts of typed arrays

`resolve_constant` also had a difference from the member resolution version, fixed to make my tests complete