### PR TITLE
Add blend mode setting to BlendSpace1D animation node, for parity with BlendSpace2D

### DIFF
--- a/doc/classes/AnimationNodeBlendSpace1D.xml
+++ b/doc/classes/AnimationNodeBlendSpace1D.xml
@@ -67,6 +67,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="blend_mode" type="int" setter="set_blend_mode" getter="get_blend_mode" enum="AnimationNodeBlendSpace1D.BlendMode" default="0">
+			Controls the interpolation between animations. See [enum BlendMode] constants.
+		</member>
 		<member name="max_space" type="float" setter="set_max_space" getter="get_max_space" default="1.0">
 			The blend space's axis's upper limit for the points' position. See [method add_blend_point].
 		</member>
@@ -84,4 +87,15 @@
 			Label of the virtual axis of the blend space.
 		</member>
 	</members>
+	<constants>
+		<constant name="BLEND_MODE_INTERPOLATED" value="0" enum="BlendMode">
+			The interpolation between animations is linear.
+		</constant>
+		<constant name="BLEND_MODE_DISCRETE" value="1" enum="BlendMode">
+			The blend space plays the animation of the node the blending position is closest to. Useful for frame-by-frame 2D animations.
+		</constant>
+		<constant name="BLEND_MODE_DISCRETE_CARRY" value="2" enum="BlendMode">
+			Similar to [constant BLEND_MODE_DISCRETE], but starts the new animation at the last animation's playback position.
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/AnimationNodeBlendSpace1D.xml
+++ b/doc/classes/AnimationNodeBlendSpace1D.xml
@@ -67,6 +67,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="blend_mode" type="int" setter="set_blend_mode" getter="get_blend_mode" enum="AnimationNodeBlendSpace2D.BlendMode" default="0">
+			Controls the interpolation between animations. See [enum BlendMode] constants.
+		</member>
 		<member name="max_space" type="float" setter="set_max_space" getter="get_max_space" default="1.0">
 			The blend space's axis's upper limit for the points' position. See [method add_blend_point].
 		</member>
@@ -84,4 +87,15 @@
 			Label of the virtual axis of the blend space.
 		</member>
 	</members>
+	<constants>
+		<constant name="BLEND_MODE_INTERPOLATED" value="0" enum="BlendMode">
+			The interpolation between animations is linear.
+		</constant>
+		<constant name="BLEND_MODE_DISCRETE" value="1" enum="BlendMode">
+			The blend space plays the animation of the node the blending position is closest to. Useful for frame-by-frame 2D animations.
+		</constant>
+		<constant name="BLEND_MODE_DISCRETE_CARRY" value="2" enum="BlendMode">
+			Similar to [constant BLEND_MODE_DISCRETE], but starts the new animation at the last animation's playback position.
+		</constant>
+	</constants>
 </class>

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -39,6 +39,7 @@
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/panel_container.h"
+#include "scene/gui/option_button.h"
 
 StringName AnimationNodeBlendSpace1DEditor::get_blend_position_path() const {
 	StringName path = AnimationTreeEditor::get_singleton()->get_base_path() + "blend_position";
@@ -328,6 +329,7 @@ void AnimationNodeBlendSpace1DEditor::_update_space() {
 	min_value->set_value(blend_space->get_min_space());
 
 	sync->set_pressed(blend_space->is_using_sync());
+	interpolation->select(blend_space->get_blend_mode());
 
 	label_value->set_text(blend_space->get_value_label());
 
@@ -354,6 +356,8 @@ void AnimationNodeBlendSpace1DEditor::_config_changed(double) {
 	undo_redo->add_undo_method(blend_space.ptr(), "set_snap", blend_space->get_snap());
 	undo_redo->add_do_method(blend_space.ptr(), "set_use_sync", sync->is_pressed());
 	undo_redo->add_undo_method(blend_space.ptr(), "set_use_sync", blend_space->is_using_sync());
+	undo_redo->add_do_method(blend_space.ptr(), "set_blend_mode", interpolation->get_selected());
+	undo_redo->add_undo_method(blend_space.ptr(), "set_blend_mode", blend_space->get_blend_mode());
 	undo_redo->add_do_method(this, "_update_space");
 	undo_redo->add_undo_method(this, "_update_space");
 	undo_redo->commit_action();
@@ -572,6 +576,10 @@ void AnimationNodeBlendSpace1DEditor::_notification(int p_what) {
 			tool_erase->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 			snap->set_icon(get_theme_icon(SNAME("SnapGrid"), SNAME("EditorIcons")));
 			open_editor->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
+			interpolation->clear();
+			interpolation->add_icon_item(get_theme_icon(SNAME("TrackContinuous"), SNAME("EditorIcons")), "", 0);
+			interpolation->add_icon_item(get_theme_icon(SNAME("TrackDiscrete"), SNAME("EditorIcons")), "", 1);
+			interpolation->add_icon_item(get_theme_icon(SNAME("TrackCapture"), SNAME("EditorIcons")), "", 2);
 		} break;
 
 		case NOTIFICATION_PROCESS: {
@@ -627,6 +635,7 @@ void AnimationNodeBlendSpace1DEditor::edit(const Ref<AnimationNode> &p_node) {
 	min_value->set_editable(!read_only);
 	max_value->set_editable(!read_only);
 	sync->set_disabled(read_only);
+	interpolation->set_disabled(read_only);
 }
 
 AnimationNodeBlendSpace1DEditor *AnimationNodeBlendSpace1DEditor::singleton = nullptr;
@@ -694,6 +703,13 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	sync = memnew(CheckBox);
 	top_hb->add_child(sync);
 	sync->connect("toggled", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_config_changed));
+
+	top_hb->add_child(memnew(VSeparator));
+
+	top_hb->add_child(memnew(Label(TTR("Blend:"))));
+	interpolation = memnew(OptionButton);
+	top_hb->add_child(interpolation);
+	interpolation->connect("item_selected", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_config_changed));
 
 	edit_hb = memnew(HBoxContainer);
 	top_hb->add_child(edit_hb);

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -38,8 +38,8 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/gui/check_box.h"
-#include "scene/gui/panel_container.h"
 #include "scene/gui/option_button.h"
+#include "scene/gui/panel_container.h"
 
 StringName AnimationNodeBlendSpace1DEditor::get_blend_position_path() const {
 	StringName path = AnimationTreeEditor::get_singleton()->get_base_path() + "blend_position";

--- a/editor/plugins/animation_blend_space_1d_editor.h
+++ b/editor/plugins/animation_blend_space_1d_editor.h
@@ -41,6 +41,7 @@
 #include "scene/gui/tree.h"
 
 class CheckBox;
+class OptionButton;
 class PanelContainer;
 
 class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
@@ -66,6 +67,7 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	SpinBox *min_value = nullptr;
 
 	CheckBox *sync = nullptr;
+	OptionButton *interpolation = nullptr;
 
 	HBoxContainer *edit_hb = nullptr;
 	SpinBox *edit_value = nullptr;

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -104,6 +104,7 @@ void AnimationNodeBlendSpace1D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_space", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_max_space", "get_max_space");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "snap", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_snap", "get_snap");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "value_label", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_value_label", "get_value_label");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "blend_mode", PROPERTY_HINT_ENUM, "Interpolated,Discrete,Carry", PROPERTY_USAGE_NO_EDITOR), "set_blend_mode", "get_blend_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sync", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_use_sync", "is_using_sync");
 
 	BIND_ENUM_CONSTANT(BLEND_MODE_INTERPOLATED);

--- a/scene/animation/animation_blend_space_1d.h
+++ b/scene/animation/animation_blend_space_1d.h
@@ -36,6 +36,14 @@
 class AnimationNodeBlendSpace1D : public AnimationRootNode {
 	GDCLASS(AnimationNodeBlendSpace1D, AnimationRootNode);
 
+public:
+	enum BlendMode {
+		BLEND_MODE_INTERPOLATED,
+		BLEND_MODE_DISCRETE,
+		BLEND_MODE_DISCRETE_CARRY,
+	};
+
+protected:
 	enum {
 		MAX_BLEND_POINTS = 64
 	};
@@ -61,6 +69,10 @@ class AnimationNodeBlendSpace1D : public AnimationRootNode {
 	void _tree_changed();
 
 	StringName blend_position = "blend_position";
+	StringName closest = "closest";
+	StringName length_internal = "length_internal";
+
+	BlendMode blend_mode = BLEND_MODE_INTERPOLATED;
 
 protected:
 	bool sync = false;
@@ -95,6 +107,9 @@ public:
 	void set_value_label(const String &p_label);
 	String get_value_label() const;
 
+	void set_blend_mode(BlendMode p_blend_mode);
+	BlendMode get_blend_mode() const;
+
 	void set_use_sync(bool p_sync);
 	bool is_using_sync() const;
 
@@ -106,5 +121,7 @@ public:
 	AnimationNodeBlendSpace1D();
 	~AnimationNodeBlendSpace1D();
 };
+
+VARIANT_ENUM_CAST(AnimationNodeBlendSpace1D::BlendMode)
 
 #endif // ANIMATION_BLEND_SPACE_1D_H


### PR DESCRIPTION
A simple patch to bring the blend mode setting from BlendSpace2D to BlendSpace1D.

This feature is useful for animating asymmetrical characters that have different left/right sprites. It also allows sprite-based games to use a similar Idle->Walk->Run blend like you would use in a 3D game.

It's also just an obvious stumbling block, especially since [the documentation](https://docs.godotengine.org/en/stable/tutorials/animation/animation_tree.html) implies that BlendSpace1D can be used like BlendSpace2D, however, BlendSpace2D works for sprites and BlendSpace1D doesn't.