### PR TITLE
Add scroll container for tile data editors

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -807,9 +807,7 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 	} else {
 		tile_data_editor_dropdown_button->set_text(TTR("Select a property editor"));
 	}
-	tile_data_editors_label->set_visible(is_visible);
-	tile_data_editors_tree->set_visible(is_visible);
-	tile_data_painting_editor_container->set_visible(is_visible);
+	tile_data_editors_scroll->set_visible(is_visible);
 }
 
 void TileSetAtlasSourceEditor::_update_current_tile_data_editor() {
@@ -2428,17 +2426,26 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	middle_vbox_container->add_child(tile_inspector_no_tile_selected_label);
 
 	// Property values palette.
+	tile_data_editors_scroll = memnew(ScrollContainer);
+	tile_data_editors_scroll->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
+	tile_data_editors_scroll->set_v_size_flags(SIZE_EXPAND_FILL);
+	middle_vbox_container->add_child(tile_data_editors_scroll);
+
+	VBoxContainer *tile_data_editors_vbox = memnew(VBoxContainer);
+	tile_data_editors_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
+	tile_data_editors_scroll->add_child(tile_data_editors_vbox);
+
 	tile_data_editors_popup = memnew(Popup);
 
 	tile_data_editors_label = memnew(Label);
 	tile_data_editors_label->set_text(TTR("Paint Properties:"));
 	tile_data_editors_label->set_theme_type_variation("HeaderSmall");
-	middle_vbox_container->add_child(tile_data_editors_label);
+	tile_data_editors_vbox->add_child(tile_data_editors_label);
 
 	tile_data_editor_dropdown_button = memnew(Button);
 	tile_data_editor_dropdown_button->connect("draw", callable_mp(this, &TileSetAtlasSourceEditor::_tile_data_editor_dropdown_button_draw));
 	tile_data_editor_dropdown_button->connect("pressed", callable_mp(this, &TileSetAtlasSourceEditor::_tile_data_editor_dropdown_button_pressed));
-	middle_vbox_container->add_child(tile_data_editor_dropdown_button);
+	tile_data_editors_vbox->add_child(tile_data_editor_dropdown_button);
 	tile_data_editor_dropdown_button->add_child(tile_data_editors_popup);
 
 	tile_data_editors_tree = memnew(Tree);
@@ -2451,7 +2458,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 
 	tile_data_painting_editor_container = memnew(VBoxContainer);
 	tile_data_painting_editor_container->set_h_size_flags(SIZE_EXPAND_FILL);
-	middle_vbox_container->add_child(tile_data_painting_editor_container);
+	tile_data_editors_vbox->add_child(tile_data_painting_editor_container);
 
 	// Atlas source inspector.
 	atlas_source_proxy_object = memnew(TileSetAtlasSourceProxyObject());

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -120,6 +120,7 @@ private:
 	bool tile_set_changed_needs_update = false;
 
 	// -- Properties painting --
+	ScrollContainer *tile_data_editors_scroll = nullptr;
 	VBoxContainer *tile_data_painting_editor_container = nullptr;
 	Label *tile_data_editors_label = nullptr;
 	Button *tile_data_editor_dropdown_button = nullptr;


### PR DESCRIPTION
Follow-up to #69300

The previous PR changed the middle column to use inspector's built-in scrolling instead of using a global ScrollContainer. This leaves the tile data editors (the Paint tool) to handle the scrolling themselves.

I thought tile data editors only have one or two property editors so scrolling is not necessary. However, the number of properties in TileDataCollisionEditor grows as long as you add multiple polygons for the collision shape.

So this PR adds a ScrollContainer for the tile data editors, so they can be scrolled as before.

![Peek 2022-12-13 15-11](https://user-images.githubusercontent.com/372476/207250130-0cdfdcd4-9b15-4bed-9a77-845b61f3c250.gif)
