### PR TITLE
Fix crash after executing `ItemList.set_icon_scale`

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1550,6 +1550,7 @@ bool ItemList::get_allow_reselect() const {
 }
 
 void ItemList::set_icon_scale(real_t p_scale) {
+	ERR_FAIL_COND(!Math::is_finite(p_scale));
 	icon_scale = p_scale;
 }
 


### PR DESCRIPTION
Fixes #70004

Setting `icon_scale` to `NAN` messes up size cache, thus the index out of bound error in drawing code.

Update: using `INF` also crashes, so changing to `is_finite()`. Note when cherry-picking: `is_finite()` is not available on `3.x`, but `!is_finite()` is equivalent to `is_nan() || is_inf()`.