### PR TITLE
Fix `const` array with different type of elements error

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -747,7 +747,7 @@ void GDScriptAnalyzer::resolve_class_interface(GDScriptParser::ClassNode *p_clas
 						const_fold_array(array);
 
 						// Can only infer typed array if it has elements.
-						if (array->elements.size() > 0 || (member.constant->datatype_specifier != nullptr && specified_type.has_container_element_type())) {
+						if (array->elements.size() > 0 && member.constant->datatype_specifier != nullptr && specified_type.has_container_element_type()) {
 							update_array_literal_element_type(specified_type, array);
 						}
 					} else if (member.constant->initializer->type == GDScriptParser::Node::DICTIONARY) {


### PR DESCRIPTION
Fixes  #70021
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
