### PR TITLE
Added gl_compatibility as an option to the project creation screen

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -628,6 +628,9 @@
 		<member name="network/tls/editor_tls_certificates" type="String" setter="" getter="">
 			The TLS certificate bundle to use for HTTP requests made within the editor (e.g. from the AssetLib tab). If left empty, the [url=https://github.com/godotengine/godot/blob/master/thirdparty/certs/ca-certificates.crt]included Mozilla certificate bundle[/url] will be used.
 		</member>
+		<member name="project_manager/default_renderer" type="String" setter="" getter="">
+			The renderer type that will be checked off by default when creating a new project. Accepted strings are "forward_plus", "mobile" or "gl_compatibility".
+		</member>
 		<member name="project_manager/sorting_order" type="int" setter="" getter="">
 			The sorting order to use in the project manager. When changing the sorting order in the project manager, this setting is set permanently in the editor settings.
 		</member>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -734,6 +734,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// TRANSLATORS: Project Manager here refers to the tool used to create/manage Godot projects.
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "project_manager/sorting_order", 0, "Last Edited,Name,Path")
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_NONE, "project_manager/default_renderer", "forward_plus", "forward_plus,mobile,gl_compatibility")
 
 	if (p_extra_config.is_valid()) {
 		if (p_extra_config->has_section("init_projects") && p_extra_config->has_section_key("init_projects", "list")) {

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -94,6 +94,7 @@ private:
 	Container *path_container;
 	Container *install_path_container;
 	Container *renderer_container;
+	Label *renderer_info;
 	HBoxContainer *default_files_container;
 	Ref<ButtonGroup> renderer_button_group;
 	Label *msg;
@@ -426,6 +427,35 @@ private:
 		ok_pressed();
 	}
 
+	void _renderer_selected() {
+		String renderer_type = renderer_button_group->get_pressed_button()->get_meta(SNAME("rendering_method"));
+
+		if (renderer_type == "forward_plus") {
+			renderer_info->set_text(
+					String::utf8("•  ") + TTR("Supports desktop platforms only.") +
+					String::utf8("\n•  ") + TTR("Advanced 3D graphics available.") +
+					String::utf8("\n•  ") + TTR("Can scale to large complex scenes.") +
+					String::utf8("\n•  ") + TTR("Uses RenderingDevice backend.") +
+					String::utf8("\n•  ") + TTR("Slower rendering of simple scenes."));
+		} else if (renderer_type == "mobile") {
+			renderer_info->set_text(
+					String::utf8("•  ") + TTR("Supports desktop + mobile platforms.") +
+					String::utf8("\n•  ") + TTR("Less advanced 3D graphics.") +
+					String::utf8("\n•  ") + TTR("Less scalable for complex scenes.") +
+					String::utf8("\n•  ") + TTR("Uses RenderingDevice backend.") +
+					String::utf8("\n•  ") + TTR("Fast rendering of simple scenes."));
+		} else if (renderer_type == "gl_compatibility") {
+			renderer_info->set_text(
+					String::utf8("•  ") + TTR("Supports desktop, mobile, + web platforms.") +
+					String::utf8("\n•  ") + TTR("Least advanced 3D graphics.") +
+					String::utf8("\n•  ") + TTR("Intended for low-end/older devices.") +
+					String::utf8("\n•  ") + TTR("Uses OpenGL 3 backend (OpenGL 3.3/ES 3.0/WebGL2).") +
+					String::utf8("\n•  ") + TTR("Fastest rendering of simple scenes."));
+		} else {
+			WARN_PRINT("Unknown renderer type. Please report this as a bug on GitHub.");
+		}
+	}
+
 	void ok_pressed() override {
 		String dir = project_path->get_text();
 
@@ -483,10 +513,15 @@ private:
 					String renderer_type = renderer_button_group->get_pressed_button()->get_meta(SNAME("rendering_method"));
 					initial_settings["rendering/renderer/rendering_method"] = renderer_type;
 
+					EditorSettings::get_singleton()->set("project_manager/default_renderer", renderer_type);
+					EditorSettings::get_singleton()->save();
+
 					if (renderer_type == "forward_plus") {
 						project_features.push_back("Forward Plus");
 					} else if (renderer_type == "mobile") {
 						project_features.push_back("Mobile");
+					} else if (renderer_type == "gl_compatibility") {
+						project_features.push_back("GL Compatibility");
 					} else {
 						WARN_PRINT("Unknown renderer type. Please report this as a bug on GitHub.");
 					}
@@ -860,42 +895,55 @@ public:
 		renderer_container->add_child(rshc);
 		renderer_button_group.instantiate();
 
+		// Left hand side, used for checkboxes to select renderer.
 		Container *rvb = memnew(VBoxContainer);
-		rvb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		rshc->add_child(rvb);
+
+		String default_renderer_type = "forward_plus";
+		if (EditorSettings::get_singleton()->has_setting("project_manager/default_renderer")) {
+			default_renderer_type = EditorSettings::get_singleton()->get_setting("project_manager/default_renderer");
+		}
+
 		Button *rs_button = memnew(CheckBox);
 		rs_button->set_button_group(renderer_button_group);
 		rs_button->set_text(TTR("Forward+"));
 		rs_button->set_meta(SNAME("rendering_method"), "forward_plus");
-		rs_button->set_pressed(true);
+		rs_button->connect("pressed", callable_mp(this, &ProjectDialog::_renderer_selected));
 		rvb->add_child(rs_button);
-		l = memnew(Label);
-		l->set_text(
-				String::utf8("•  ") + TTR("Supports desktop platforms only.") +
-				String::utf8("\n•  ") + TTR("Advanced 3D graphics available.") +
-				String::utf8("\n•  ") + TTR("Can scale to large complex scenes.") +
-				String::utf8("\n•  ") + TTR("Slower rendering of simple scenes."));
-		l->set_modulate(Color(1, 1, 1, 0.7));
-		rvb->add_child(l);
+		if (default_renderer_type == "forward_plus") {
+			rs_button->set_pressed(true);
+		}
 
-		rshc->add_child(memnew(VSeparator));
-
-		rvb = memnew(VBoxContainer);
-		rvb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		rshc->add_child(rvb);
 		rs_button = memnew(CheckBox);
 		rs_button->set_button_group(renderer_button_group);
 		rs_button->set_text(TTR("Mobile"));
 		rs_button->set_meta(SNAME("rendering_method"), "mobile");
+		rs_button->connect("pressed", callable_mp(this, &ProjectDialog::_renderer_selected));
 		rvb->add_child(rs_button);
-		l = memnew(Label);
-		l->set_text(
-				String::utf8("•  ") + TTR("Supports desktop + mobile platforms.") +
-				String::utf8("\n•  ") + TTR("Less advanced 3D graphics.") +
-				String::utf8("\n•  ") + TTR("Less scalable for complex scenes.") +
-				String::utf8("\n•  ") + TTR("Faster rendering of simple scenes."));
-		l->set_modulate(Color(1, 1, 1, 0.7));
-		rvb->add_child(l);
+		if (default_renderer_type == "mobile") {
+			rs_button->set_pressed(true);
+		}
+
+		rs_button = memnew(CheckBox);
+		rs_button->set_button_group(renderer_button_group);
+		rs_button->set_text(TTR("Compatibility"));
+		rs_button->set_meta(SNAME("rendering_method"), "gl_compatibility");
+		rs_button->connect("pressed", callable_mp(this, &ProjectDialog::_renderer_selected));
+		rvb->add_child(rs_button);
+		if (default_renderer_type == "gl_compatibility") {
+			rs_button->set_pressed(true);
+		}
+
+		rshc->add_child(memnew(VSeparator));
+
+		// Right hand side, used for text explaining each choice.
+		rvb = memnew(VBoxContainer);
+		rvb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		rshc->add_child(rvb);
+		renderer_info = memnew(Label);
+		renderer_info->set_modulate(Color(1, 1, 1, 0.7));
+		rvb->add_child(renderer_info);
+		_renderer_selected();
 
 		l = memnew(Label);
 		l->set_text(TTR("The renderer can be changed later, but scenes may need to be adjusted."));


### PR DESCRIPTION
This PR adds the gl_compatibility renderer to the options on project creation. As discussed with Akien on RocketChat, we are doing a very simple option menu for now, but in later releases we will expand this option menu further to allow choosing more than just a default renderer

This also saves the last selected renderer as the default renderer to be checked off next time you start a project.

![Screenshot from 2022-12-13 14-10-57](https://user-images.githubusercontent.com/16521339/207455000-19ea3c56-9bfa-451c-b392-8b76fa419eec.png)
![Screenshot from 2022-12-13 14-10-53](https://user-images.githubusercontent.com/16521339/207455002-c1fb5303-42cb-4913-8ec7-036c3ff850d0.png)


