### PR TITLE
Add compilation profiling option for MSVC builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -288,6 +288,8 @@ Generated\ Files/
 *.pidb
 *.svclog
 *.scc
+# compile profiler output
+*.obj.profile
 
 # Visual C++ cache files
 ipch/

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -189,6 +189,11 @@ def get_opts():
         BoolVariable("use_static_cpp", "Link MinGW/MSVC C++ runtime libraries statically", True),
         BoolVariable("use_asan", "Use address sanitizer (ASAN)", False),
         BoolVariable("debug_crt", "Compile with MSVC's debug CRT (/MDd)", False),
+        BoolVariable(
+            "profile_compilation",
+            "Compile with MSVCs compile-time profiling flags (/Bt /d2cgsummary /d2wpasummary)",
+            False,
+        ),
     ]
 
 
@@ -339,6 +344,12 @@ def configure_msvc(env, vcvars_msvc_config):
         env.AppendUnique(CPPDEFINES=["WINDOWS_SUBSYSTEM_CONSOLE"])
 
     ## Compile/link flags
+
+    if env["profile_compilation"]:
+        env.AppendUnique(CCFLAGS=["/Bt", "/d2cgsummary", "/d2wpasummary"])
+        env.AppendUnique(LINKFLAGS=["/d2:-cgsummary", "/d2:-wpasummary"])
+        # We use our own spawn() for compilation profiling because we can't get the output otherwise
+        env.use_windows_spawn_fix()
 
     if env["debug_crt"]:
         # Always use dynamic runtime, static debug CRT breaks thread_local.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

After noticing some anomalistic build times with MSVC, I decided to implement a build option to profile the compilation and output the performance metrics of each file.

This is enabled with the use of a few MSVC flags:
- [/Bt:](https://www.geoffchappell.com/studies/msvc/cl/cl/options/b$t.htm) This just runs "time()" on each step of the build process, giving us the time that both the frontend and the backend ran for.
- [/d2cgsummary:](https://aras-p.info/blog/2017/10/23/Best-unknown-MSVC-flag-d2cgsummary/) This has a detailed breakdown of performance of the code generation, detailing what functions had anomalistic compile times and caching stats
- [/d2wpasummary:](https://www.reddit.com/r/cpp/comments/787lmw/comment/dotppkq/) This has a detailed breakdown of the time spent in the whole-program-optimization phase of the compiler. However, you need to have WPA installed and configured correctly for this to be useful; it's not necessary since we don't do LTCG, but it's included in case we do sometime down the line

Thus, we end up with output like this:
```
text_server_adv.cpp
time(C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\bin\HostX64\x64\c1xx.dll)=1.898s
Elapsed Time before Code Generation:  0.000 sec
Code Generation Summary
	Total Function Count: 1805
	Elapsed Time: 174.412 sec
	Total Compilation Time: 444.424 sec
	Average time per function: 0.246 sec
	Anomalistic Compile Times: 2
		public: virtual void __cdecl TextServerAdvanced::_font_render_range(class RID const &, struct Vector2i const &, __int64, __int64): 167.091 sec, 196944 instrs
		public: virtual void __cdecl TextServerAdvanced::_font_render_glyph(class RID const &, struct Vector2i const &, __int64): 160.133 sec, 197813 instrs
	Serialized Initializer Count: 1
	Serialized Initializer Time: 0.001 sec

RdrReadProc Caching Stats
	Functions Cached: 89
	Retrieved Count: 52420
	Abandoned Retrieval Count: 0
	Abandoned Caching Count: 11
	Wasted Caching Attempts: 0
	Functions Retrieved at Least Once: 89
	Functions Cached and Never Retrieved: 0
	Most Hits:
		public: unsigned int __cdecl std::_Atomic_integral_facade<unsigned int>::fetch_sub(unsigned int, enum std::memory_order): 3865
		public: static unsigned int __cdecl std::_Atomic_integral_facade<unsigned int>::_Negate(unsigned int): 3865
		[...]

	Least Hits:
		public: __cdecl String::String(void): 6
		public: __cdecl String::String(class String const &): 8
                [...]
Elapsed Time after Code Generation:   0.000 sec
time(C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\bin\HostX64\x64\c2.dll)=174.797s
```


## How this option works:
Add "profile_compilation=yes" to an MSVC build.

You'll see a line for each file after it's compiled, detailing the total time spent compiling and the time spend in the frontend and backend:

`PERF - basisu_etc.windows.editor.x86_64.obj: total: 1.20s  frontend: 0.65s  backend: 0.55s`
A "profile" file is written for each object compiled, e.g. `tests\test_main.windows.editor.x86_64.obj.profile`

If an object is compiled for more than 40 seconds, we output which functions had anomalistic compile times and point to the profile:

```
!!!! PERF - test_main.windows.editor.x86_64.obj: total: 141.71s  frontend: 13.30s  backend: 128.41s !!!!
!!!! Anomalistic functions:
!!!! void __cdecl TestCodeEdit::DOCTEST_ANON_FUNC_5536(void): 71.43 secs, 133585 instrs
!!!! void __cdecl TestClassDB::add_exposed_classes(struct TestClassDB::Context &): 2.56 secs, 19434 instrs
!!!! See profiling report for more details: tests\test_main.windows.editor.x86_64.obj.profile
```

We add the ".profile" files to `env.Clean()` so that they get cleaned up when running `--clean`.

## Implementation notes:

This is implemented in the custom spawner that was created for MINGW builds because there's no other way to get the compiler output after scons runs `spawn()`. Ideally, this would be a separate build step, but this would require creating a custom build action for windows builds.

This also imports [pydemangler](https://github.com/wbenny/pydemangler) for demangling the functions in the compiler output. /d2cgsummary only outputs the MSVC mangled function names for each, e.g. `?Fxi@@YAHP6AHH@Z@Z`. This makes parsing the output a lot easier, but it also means that we have to have `pydemangler` in our build environment. 
`pydemangler` unfortunately is not in the pip repo, so this requires installing via git. I would have chosen another one that was available in pip, but none of the demanglers I've tried work. They either don't support MSVC or just fail to install entirely.
Because of this, I've made it an optional dependency.

I have not added this to the CI in this PR, but I have [tested this on my fork](https://github.com/nikitalita/godot/actions/runs/3688664659) and it does work there. 