### PR TITLE
Expose ItemList's auto height value with `get_auto_height_value`

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -61,6 +61,14 @@
 			<return type="void" />
 			<description>
 				Forces an update to the list size based on its items. This happens automatically whenever size of the items, or other relevant settings like [member auto_height], change. The method can be used to trigger the update ahead of next drawing pass.
+				See [method get_auto_height_value] for the new auto_height value if [member auto_height] is [code]true[/code].
+			</description>
+		</method>
+		<method name="get_auto_height_value" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the calculated minimum height of the list according to its items if [member auto_height] is [code]true[/code], excluding [member Control.custom_minimum_size]. If [member auto_height] is [code]true[/code], this returns the last auto height value.
+				See [method force_update_list_size] for updating the value before the next draw.
 			</description>
 		</method>
 		<method name="get_h_scroll_bar">

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -2164,6 +2164,10 @@ bool ItemList::has_auto_height() const {
 	return auto_height;
 }
 
+float ItemList::get_auto_height_value() const {
+	return auto_height_value;
+}
+
 void ItemList::set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior) {
 	if (text_overrun_behavior != p_behavior) {
 		text_overrun_behavior = p_behavior;
@@ -2324,6 +2328,8 @@ void ItemList::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_auto_height", "enable"), &ItemList::set_auto_height);
 	ClassDB::bind_method(D_METHOD("has_auto_height"), &ItemList::has_auto_height);
+
+	ClassDB::bind_method(D_METHOD("get_auto_height_value"), &ItemList::get_auto_height_value);
 
 	ClassDB::bind_method(D_METHOD("is_anything_selected"), &ItemList::is_anything_selected);
 

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -324,6 +324,8 @@ public:
 	void set_auto_height(bool p_enable);
 	bool has_auto_height() const;
 
+	float get_auto_height_value() const;
+
 	void set_wraparound_items(bool p_enable);
 	bool has_wraparound_items() const;
 


### PR DESCRIPTION
- Depends on #63634 

Addresses godotengine/godot-proposals#254 with a more explicit call alongside #63634, as `custom_minimum_size` may hide the auto height value. This makes reliance on the auto height value more explicit for calculations, however since nothing yet forces the `auto_height_value` to update regardless of `auto_height`, technically https://github.com/godotengine/godot/pull/63634#issuecomment-1285087377 still presents a bit of an issue, as the return value here will just be from the last time `auto_height` was true or otherwise it'll return 0, perhaps it would be justified to implement:

```gdscript
func force_update_list_size(force : bool = false)
```

With such, an `force_update_list_size` call could force the `auto_height_value` to update even if `auto_height` is false as it currently does not allow the user to do so. As it stands the usefulness of this PR is quite limited and only really good for being explicit and avoiding `custom_minimum_size`.

## Exposed Additions
ItemList:
```gdscript
func get_auto_height_value() -> float
```