### PR TITLE
Add Loop Region to SpriteFrames/Animated Sprites

### DIFF
--- a/doc/classes/AnimatedSprite2D.xml
+++ b/doc/classes/AnimatedSprite2D.xml
@@ -49,6 +49,9 @@
 		<member name="frames" type="SpriteFrames" setter="set_sprite_frames" getter="get_sprite_frames">
 			The [SpriteFrames] resource containing the animation(s). Allows you the option to load, edit, clear, make unique and save the states of the [SpriteFrames] resource.
 		</member>
+		<member name="loop_animation" type="bool" setter="set_loop_animation" getter="is_looping_animation">
+			If [code]true[/code], the [member animation] will loop if [member frame] is in it's loop region. Setting this property to [code]false[/code] can be used to exit or prevent a loop.
+		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The texture's drawing offset.
 		</member>
@@ -63,6 +66,11 @@
 		<signal name="animation_finished">
 			<description>
 				Emitted when the animation is finished (when it plays the last frame). If the animation is looping, this signal is emitted every time the last frame is drawn.
+			</description>
+		</signal>
+		<signal name="animation_looped">
+			<description>
+				Emitted when each time the animation is looped.
 			</description>
 		</signal>
 		<signal name="frame_changed">

--- a/doc/classes/AnimatedSprite3D.xml
+++ b/doc/classes/AnimatedSprite3D.xml
@@ -38,6 +38,9 @@
 		<member name="frames" type="SpriteFrames" setter="set_sprite_frames" getter="get_sprite_frames">
 			The [SpriteFrames] resource containing the animation(s).
 		</member>
+		<member name="loop_animation" type="bool" setter="set_loop_animation" getter="is_looping_animation">
+			If [code]true[/code], the [member animation] will loop if [member frame] is in it's loop region. Setting this property to [code]false[/code] can be used to exit or prevent a loop.
+		</member>
 		<member name="playing" type="bool" setter="set_playing" getter="is_playing" default="false">
 			If [code]true[/code], the [member animation] is currently playing. Setting this property to [code]false[/code] is the equivalent of calling [method stop].
 		</member>
@@ -49,6 +52,11 @@
 		<signal name="animation_finished">
 			<description>
 				Emitted when the animation is finished (when it plays the last frame). If the animation is looping, this signal is emitted every time the last frame is drawn.
+			</description>
+		</signal>
+		<signal name="animation_looped">
+			<description>
+				Emitted when each time the animation is looped.
 			</description>
 		</signal>
 		<signal name="frame_changed">

--- a/doc/classes/SpriteFrames.xml
+++ b/doc/classes/SpriteFrames.xml
@@ -46,6 +46,20 @@
 				Returns [code]true[/code] if the given animation is configured to loop when it finishes playing. Otherwise, returns [code]false[/code].
 			</description>
 		</method>
+		<method name="get_animation_loop_begin" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="anim" type="StringName" />
+			<description>
+				Returns the beginning of the loop region for the given animation.
+			</description>
+		</method>
+		<method name="get_animation_loop_end" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="anim" type="StringName" />
+			<description>
+				Returns the end of the loop region for the given animation.
+			</description>
+		</method>
 		<method name="get_animation_names" qualifiers="const">
 			<return type="PackedStringArray" />
 			<description>
@@ -110,6 +124,22 @@
 			<param index="1" name="loop" type="bool" />
 			<description>
 				If [code]true[/code], the animation will loop.
+			</description>
+		</method>
+		<method name="set_animation_loop_begin">
+			<return type="void" />
+			<param index="0" name="anim" type="StringName" />
+			<param index="1" name="loop_begin" type="int" />
+			<description>
+				Sets the beginning of the loop region for the given animation.
+			</description>
+		</method>
+		<method name="set_animation_loop_end">
+			<return type="void" />
+			<param index="0" name="anim" type="StringName" />
+			<param index="1" name="loop_end" type="int" />
+			<description>
+				Sets the end of the loop region for the given animation.
 			</description>
 		</method>
 		<method name="set_animation_speed">

--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -81,6 +81,8 @@ class SpriteFramesEditor : public HSplitContainer {
 	Tree *animations = nullptr;
 	SpinBox *anim_speed = nullptr;
 	CheckButton *anim_loop = nullptr;
+	SpinBox *anim_loop_begin = nullptr;
+	SpinBox *anim_loop_end = nullptr;
 
 	EditorFileDialog *file = nullptr;
 
@@ -143,6 +145,8 @@ class SpriteFramesEditor : public HSplitContainer {
 	void _animation_remove_confirmed();
 	void _animation_search_text_changed(const String &p_text);
 	void _animation_loop_changed();
+	void _animation_loop_begin_changed(int p_value);
+	void _animation_loop_end_changed(int p_value);
 	void _animation_fps_changed(double p_value);
 
 	void _tree_input(const Ref<InputEvent> &p_event);

--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -39,6 +39,7 @@ class AnimatedSprite2D : public Node2D {
 
 	Ref<SpriteFrames> frames;
 	bool playing = false;
+	bool loop_animation = false;
 	bool playing_backwards = false;
 	bool backwards = false;
 	StringName animation = "default";
@@ -87,6 +88,8 @@ public:
 
 	void set_playing(bool p_playing);
 	bool is_playing() const;
+	void set_loop_animation(bool p_looping);
+	bool is_looping_animation() const;
 
 	void set_animation(const StringName &p_animation);
 	StringName get_animation() const;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -917,6 +917,11 @@ void AnimatedSprite3D::_validate_property(PropertyInfo &p_property) const {
 
 void AnimatedSprite3D::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_READY: {
+			if (frames.is_valid()) {
+				set_loop_animation(frames->get_animation_loop(animation));
+			}
+		} break;
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (frames.is_null() || !frames->has_animation(animation)) {
 				return;
@@ -926,7 +931,26 @@ void AnimatedSprite3D::_notification(int p_what) {
 			if (speed == 0) {
 				return; // Do nothing.
 			}
-			int last_frame = frames->get_frame_count(animation) - 1;
+
+			int loop_region[2] = {};
+			if (loop_animation) {
+				// Uses `_get_animation_loop_region` instead of `get_loop_region_begin/end` to prevent multiple searches for the correct animation
+				frames->_get_animation_loop_region(animation, loop_region[0], loop_region[1]);
+				if (loop_region[1] == -1) {
+					loop_region[0] = MAX(loop_region[0], 0);
+					loop_region[1] = frames->get_frame_count(animation) - 1;
+				} else { // Validate region
+					if (loop_region[1] < loop_region[0]) {
+						loop_region[1] = frames->get_frame_count(animation) - 1;
+					}
+					if (loop_region[0] > loop_region[1]) {
+						loop_region[0] = loop_region[1] - 1;
+					}
+				}
+			} else {
+				loop_region[0] = 0; // First Frame
+				loop_region[1] = frames->get_frame_count(animation) - 1; // Last Frame
+			}
 
 			double remaining = get_process_delta_time();
 			while (remaining) {
@@ -935,12 +959,12 @@ void AnimatedSprite3D::_notification(int p_what) {
 
 					if (!playing_backwards) {
 						// Forward.
-						if (frame >= last_frame) {
-							if (frames->get_animation_loop(animation)) {
-								frame = 0;
-								emit_signal(SceneStringNames::get_singleton()->animation_finished);
+						if (frame >= loop_region[1]) {
+							if (loop_animation) {
+								frame = loop_region[0];
+								emit_signal(SceneStringNames::get_singleton()->animation_looped);
 							} else {
-								frame = last_frame;
+								frame = loop_region[1];
 								if (!is_over) {
 									is_over = true;
 									emit_signal(SceneStringNames::get_singleton()->animation_finished);
@@ -951,12 +975,12 @@ void AnimatedSprite3D::_notification(int p_what) {
 						}
 					} else {
 						// Reversed.
-						if (frame <= 0) {
-							if (frames->get_animation_loop(animation)) {
-								frame = last_frame;
-								emit_signal(SceneStringNames::get_singleton()->animation_finished);
+						if (frame <= loop_region[0]) {
+							if (loop_animation) {
+								frame = loop_region[1];
+								emit_signal(SceneStringNames::get_singleton()->animation_looped);
 							} else {
-								frame = 0;
+								frame = loop_region[0];
 								if (!is_over) {
 									is_over = true;
 									emit_signal(SceneStringNames::get_singleton()->animation_finished);
@@ -1104,6 +1128,39 @@ void AnimatedSprite3D::set_playing(bool p_playing) {
 bool AnimatedSprite3D::is_playing() const {
 	return playing;
 }
+void AnimatedSprite3D::set_loop_animation(bool p_loop_animation) {
+	if (!frames.is_valid()) {
+		return;
+	}
+	if (!playing) {
+		return;
+	}
+	loop_animation = p_loop_animation;
+}
+
+bool AnimatedSprite3D::is_looping_animation() const {
+	if (!frames.is_valid()) {
+		return false;
+	}
+	if (!playing) {
+		return false;
+	}
+	if (!loop_animation) {
+		return false;
+	}
+	if (!frames->has_animation(animation)) {
+		return false;
+	}
+	int loop_region[2] = {};
+	frames->_get_animation_loop_region(animation, loop_region[0], loop_region[1]);
+	if (loop_region[1] == -1) {
+		loop_region[1] = frames->get_frame_count(animation) - 1;
+	}
+	if (frame >= loop_region[0] && frame <= loop_region[1]) {
+		return true;
+	}
+	return false;
+}
 
 void AnimatedSprite3D::play(const StringName &p_animation, bool p_backwards) {
 	backwards = p_backwards;
@@ -1114,6 +1171,8 @@ void AnimatedSprite3D::play(const StringName &p_animation, bool p_backwards) {
 		if (frames.is_valid() && playing_backwards && get_frame() == 0) {
 			set_frame(frames->get_frame_count(p_animation) - 1);
 		}
+	} else if (frames.is_valid()) {
+		set_loop_animation(frames->get_animation_loop(p_animation));
 	}
 
 	is_over = false;
@@ -1153,6 +1212,7 @@ void AnimatedSprite3D::set_animation(const StringName &p_animation) {
 	animation = p_animation;
 	_reset_timeout();
 	set_frame(0);
+	set_loop_animation(frames->get_animation_loop(animation));
 	notify_property_list_changed();
 	_queue_redraw();
 }
@@ -1190,6 +1250,8 @@ void AnimatedSprite3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_playing", "playing"), &AnimatedSprite3D::set_playing);
 	ClassDB::bind_method(D_METHOD("is_playing"), &AnimatedSprite3D::is_playing);
+	ClassDB::bind_method(D_METHOD("set_loop_animation", "loop_animation"), &AnimatedSprite3D::set_loop_animation);
+	ClassDB::bind_method(D_METHOD("is_looping_animation"), &AnimatedSprite3D::is_looping_animation);
 
 	ClassDB::bind_method(D_METHOD("play", "anim", "backwards"), &AnimatedSprite3D::play, DEFVAL(StringName()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("stop"), &AnimatedSprite3D::stop);
@@ -1203,6 +1265,7 @@ void AnimatedSprite3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_res_changed"), &AnimatedSprite3D::_res_changed);
 
 	ADD_SIGNAL(MethodInfo("frame_changed"));
+	ADD_SIGNAL(MethodInfo("animation_looped"));
 	ADD_SIGNAL(MethodInfo("animation_finished"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "frames", PROPERTY_HINT_RESOURCE_TYPE, "SpriteFrames"), "set_sprite_frames", "get_sprite_frames");
@@ -1210,6 +1273,7 @@ void AnimatedSprite3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "frame"), "set_frame", "get_frame");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_scale"), "set_speed_scale", "get_speed_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing"), "set_playing", "is_playing");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "loop_animation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_INSTANCE_STATE), "set_loop_animation", "is_looping_animation");
 }
 
 AnimatedSprite3D::AnimatedSprite3D() {

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -210,6 +210,7 @@ class AnimatedSprite3D : public SpriteBase3D {
 
 	Ref<SpriteFrames> frames;
 	bool playing = false;
+	bool loop_animation = false;
 	bool playing_backwards = false;
 	bool backwards = false;
 	StringName animation = "default";
@@ -241,6 +242,8 @@ public:
 
 	void set_playing(bool p_playing);
 	bool is_playing() const;
+	void set_loop_animation(bool p_looping);
+	bool is_looping_animation() const;
 
 	void set_animation(const StringName &p_animation);
 	StringName get_animation() const;

--- a/scene/resources/sprite_frames.h
+++ b/scene/resources/sprite_frames.h
@@ -36,9 +36,15 @@
 class SpriteFrames : public Resource {
 	GDCLASS(SpriteFrames, Resource);
 
+	struct LoopRegion {
+		int begin = 0;
+		int end = -1; // (-1 = animation length)
+	};
+
 	struct Anim {
 		double speed = 5.0;
 		bool loop = true;
+		LoopRegion loop_region = {};
 		Vector<Ref<Texture2D>> frames;
 	};
 
@@ -46,6 +52,7 @@ class SpriteFrames : public Resource {
 
 	Array _get_animations() const;
 	void _set_animations(const Array &p_animations);
+	void _validate_loop_region(SpriteFrames::LoopRegion &r_loop_region);
 
 protected:
 	static void _bind_methods();
@@ -63,7 +70,13 @@ public:
 	double get_animation_speed(const StringName &p_anim) const;
 
 	void set_animation_loop(const StringName &p_anim, bool p_loop);
+	void set_animation_loop_region(const StringName &p_anim, int p_loop_begin, int p_loop_end);
+	void set_animation_loop_begin(const StringName &p_anim, int p_loop_begin);
+	void set_animation_loop_end(const StringName &p_anim, int p_loop_end);
 	bool get_animation_loop(const StringName &p_anim) const;
+	void _get_animation_loop_region(const StringName &p_anim, int &r_loop_begin, int &r_loop_end) const;
+	int get_animation_loop_begin(const StringName &p_anim) const;
+	int get_animation_loop_end(const StringName &p_anim) const;
 
 	void add_frame(const StringName &p_anim, const Ref<Texture2D> &p_frame, int p_at_pos = -1);
 	int get_frame_count(const StringName &p_anim) const;

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -61,6 +61,7 @@ SceneStringNames::SceneStringNames() {
 	animation_finished = StaticCString::create("animation_finished");
 	animation_changed = StaticCString::create("animation_changed");
 	animation_started = StaticCString::create("animation_started");
+	animation_looped = StaticCString::create("animation_looped");
 	RESET = StaticCString::create("RESET");
 
 	pose_updated = StaticCString::create("pose_updated");

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -97,6 +97,7 @@ public:
 	StringName animation_finished;
 	StringName animation_changed;
 	StringName animation_started;
+	StringName animation_looped;
 	StringName RESET;
 
 	StringName pose_updated;

--- a/tests/scene/test_sprite_frames.h
+++ b/tests/scene/test_sprite_frames.h
@@ -196,6 +196,53 @@ TEST_CASE("[SpriteFrames] Animation Loop getter and setter") {
 	ERR_PRINT_ON;
 }
 
+TEST_CASE("[SpriteFrames] Animation Loop Region getter and setter") {
+	SpriteFrames frames;
+
+	frames.add_animation(test_animation_name);
+
+	frames.add_frame(test_animation_name, nullptr); // 0
+	frames.add_frame(test_animation_name, nullptr); // 1
+	frames.add_frame(test_animation_name, nullptr); // 2
+	frames.set_animation_loop_begin(test_animation_name, 1);
+
+	CHECK_MESSAGE(
+			frames.get_animation_loop_begin(test_animation_name) == 1,
+			"Sets loop region begin to frame 1");
+
+	frames.set_animation_loop_begin(test_animation_name, 10);
+
+	CHECK_MESSAGE(
+			frames.get_animation_loop_begin(test_animation_name) == 2,
+			"Prevent out of range loop begin.");
+	frames.set_animation_loop_begin(test_animation_name, 0); // Reset for next test
+
+	frames.set_animation_loop_end(test_animation_name, 1);
+
+	CHECK_MESSAGE(
+			frames.get_animation_loop_end(test_animation_name) == 1,
+			"Sets loop region end to frame 1");
+
+	frames.set_animation_loop_end(test_animation_name, 8);
+
+	CHECK_MESSAGE(
+			frames.get_animation_loop_end(test_animation_name) == 2,
+			"Prevent out of range loop end.");
+
+	frames.set_animation_loop_begin(test_animation_name, 2);
+	frames.set_animation_loop_end(test_animation_name, 1);
+
+	CHECK_MESSAGE(
+			frames.get_animation_loop_end(test_animation_name) == 2,
+			"Loop start and end cannot be inverted.");
+
+	// These error handling cases should not crash.
+	ERR_PRINT_OFF;
+	frames.get_animation_loop_begin("This does not exist");
+	frames.set_animation_loop_region("This does not exist", 0, 0);
+	ERR_PRINT_ON;
+}
+
 // TODO
 TEST_CASE("[SpriteFrames] Frame addition, removal, and retrieval") {
 	Ref<Texture2D> dummy_frame1;


### PR DESCRIPTION
Implements godotengine/godot-proposals#5934

> If an animation has `loop` enabled, the animation won't loop until it's entered the defined loop region. The animation will only loop through the frames in the region, instead of the entire animation. Then, setting `loop_animation` to false on the AnimatedSprite will disable looping for the current animation. Changing `loop_animation` is not persistent and does not carry between different animations. Each time an animation is played, `loop_animation` is reset to the SpriteFrames' `loop` value.

Adds loop regions to SpriteFrames.
Also adds the `animation_looped` signal, since animation_finished is now only played when the end is reached.

Screenshots:
![image](https://user-images.githubusercontent.com/12436824/207492970-23cce710-3717-4da7-b254-eddae0504da6.png)

> ## Disabling `loop` hides loop region.
![image](https://user-images.githubusercontent.com/12436824/207493001-5901b859-8d96-4c2c-bd65-a098292193dc.png)

> ## Looping the entire animation is still possible (Default)
![image](https://user-images.githubusercontent.com/12436824/207493087-0c14c3fc-d171-45b3-985f-de0a5e00fbfd.png)