### PR TITLE
Fix GDScript external inner class constant assignment

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3148,6 +3148,16 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 				case GDScriptParser::ClassNode::Member::FUNCTION:
 					p_identifier->set_datatype(make_callable_type(member.function->info));
 					break;
+				case GDScriptParser::ClassNode::Member::CLASS:
+					if (p_base != nullptr && p_base->is_constant) {
+						Error err = OK;
+						GDScript *scr = GDScriptCache::get_full_script(base.script_path, err).ptr();
+						ERR_FAIL_COND_MSG(err != OK, "Error while getting subscript full script.");
+						scr = scr->find_class(p_identifier->get_datatype().class_type->fqcn);
+						p_identifier->reduced_value = scr;
+						p_identifier->is_constant = true;
+					}
+					break;
 				default:
 					break; // Type already set.
 			}

--- a/modules/gdscript/tests/scripts/analyzer/features/inner_class_constant_assignment.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/inner_class_constant_assignment.gd
@@ -1,0 +1,7 @@
+const External = preload("inner_class_constant_assignment_external.notest.gd")
+const ExternalInnerClass = External.InnerClass
+
+func test():
+	var inst_external: ExternalInnerClass = ExternalInnerClass.new()
+	inst_external.x = 4.0
+	print(inst_external.x)

--- a/modules/gdscript/tests/scripts/analyzer/features/inner_class_constant_assignment.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/inner_class_constant_assignment.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+4

--- a/modules/gdscript/tests/scripts/analyzer/features/inner_class_constant_assignment_external.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/inner_class_constant_assignment_external.notest.gd
@@ -1,0 +1,2 @@
+class InnerClass:
+	var x: = 3.0


### PR DESCRIPTION
Sets the reduced value of a inner class as the parsed inner class GDScript instance.

This reenables the assignment of a inner class as a constant.

Fixes #69917 - GDScript 2.0: Cannot assign inner class as a constant