### PR TITLE
Added Projection to ConvertTo<T> and CreateFrom<T>

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
@@ -92,6 +92,9 @@ public partial class VariantUtils
         if (typeof(T) == typeof(Transform2D))
             return CreateFromTransform2D(UnsafeAs<Transform2D>(from));
 
+        if (typeof(T) == typeof(Projection))
+            return CreateFromProjection(UnsafeAs<Projection>(from));
+
         if (typeof(T) == typeof(Vector3))
             return CreateFromVector3(UnsafeAs<Vector3>(from));
 
@@ -292,6 +295,9 @@ public partial class VariantUtils
 
         if (typeof(T) == typeof(Transform3D))
             return UnsafeAsT(ConvertToTransform3D(variant));
+
+        if (typeof(T) == typeof(Projection))
+            return UnsafeAsT(ConvertToProjection(variant));
 
         if (typeof(T) == typeof(Vector4))
             return UnsafeAsT(ConvertToVector4(variant));


### PR DESCRIPTION
This PR just add the `ConvertTo` and `CreateFrom` missing cases for the `Projection` variant type, which I guess it's forbidden in the original commit.