### PR TITLE
Use instanced array buffer instead of UBO for canvas item batching

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -245,7 +245,7 @@ public:
 		uint32_t max_lights_per_render = 256;
 		uint32_t max_lights_per_item = 16;
 		uint32_t max_instances_per_batch = 512;
-		uint32_t max_instances_per_ubo = 16384;
+		uint32_t max_instances_per_buffer = 16384;
 		uint32_t max_instance_buffer_size = 16384 * 128;
 	} data;
 
@@ -278,7 +278,7 @@ public:
 	// We track them and ensure that they don't get reused until at least 2 frames have passed
 	// to avoid the GPU stalling to wait for a resource to become available.
 	struct DataBuffer {
-		GLuint ubo = 0;
+		GLuint buffer = 0;
 		GLuint light_ubo = 0;
 		GLuint state_ubo = 0;
 		uint64_t last_frame_used = -3;
@@ -359,6 +359,7 @@ public:
 	void _add_to_batch(uint32_t &r_index, bool &r_batch_broken);
 	void _allocate_instance_data_buffer();
 	void _align_instance_data_buffer(uint32_t &r_index);
+	void _enable_attributes(uint32_t p_start, bool p_primitive, uint32_t p_rate = 1);
 
 	void set_time(double p_time);
 

--- a/drivers/gles3/shaders/canvas_uniforms_inc.glsl
+++ b/drivers/gles3/shaders/canvas_uniforms_inc.glsl
@@ -27,38 +27,6 @@
 #define FLAGS_USE_MSDF uint(1 << 28)
 #define FLAGS_USE_LCD uint(1 << 29)
 
-// must be always 128 bytes long
-struct DrawData {
-	vec2 world_x;
-	vec2 world_y;
-	vec2 world_ofs;
-	vec2 color_texture_pixel_size;
-#ifdef USE_PRIMITIVE
-	vec2 point_a;
-	vec2 point_b;
-	vec2 point_c;
-	vec2 uv_a;
-	vec2 uv_b;
-	vec2 uv_c;
-	uint color_a_rg;
-	uint color_a_ba;
-	uint color_b_rg;
-	uint color_b_ba;
-	uint color_c_rg;
-	uint color_c_ba;
-#else
-	vec4 modulation;
-	vec4 ninepatch_margins;
-	vec4 dst_rect; //for built-in rect and UV
-	vec4 src_rect;
-	uint pad;
-	uint pad2;
-#endif
-	uint flags;
-	uint specular_shininess;
-	uvec4 lights;
-};
-
 layout(std140) uniform GlobalShaderUniformData { //ubo:1
 	vec4 global_shader_uniforms[MAX_GLOBAL_SHADER_UNIFORMS];
 };
@@ -116,7 +84,3 @@ layout(std140) uniform LightData { //ubo:2
 	Light light_array[MAX_LIGHTS];
 };
 #endif // DISABLE_LIGHTING
-layout(std140) uniform DrawDataInstances { //ubo:3
-
-	DrawData draw_data[MAX_DRAW_DATA_INSTANCES];
-};

--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -90,8 +90,6 @@ Config::Config() {
 	glGetIntegerv(GL_MAX_UNIFORM_BLOCK_SIZE, &max_uniform_buffer_size);
 	glGetIntegerv(GL_MAX_VIEWPORT_DIMS, max_viewport_size);
 
-	glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &uniform_buffer_offset_alignment);
-
 	support_anisotropic_filter = extensions.has("GL_EXT_texture_filter_anisotropic");
 	if (support_anisotropic_filter) {
 		glGetFloatv(_GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &anisotropic_level);

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -67,8 +67,6 @@ public:
 	int max_renderable_lights = 0;
 	int max_lights_per_object = 0;
 
-	int uniform_buffer_offset_alignment = 0;
-
 	// TODO implement wireframe in OpenGL
 	// bool generate_wireframes;
 


### PR DESCRIPTION
This simplifies the generated shader code which increases both performance and compile time on low end devices. However, the main purpose of this PR is to get OpenGL rendering on Apple devices again. 

Fixes: https://github.com/godotengine/godot/issues/68760

May fix: https://github.com/godotengine/godot/issues/68980
May fix: https://github.com/godotengine/godot/issues/68819
May fix: https://github.com/godotengine/godot/issues/67595

### Background
This started as a search for a workaround to the issues we were facing on Apple devices, but as it turns out, this new approach can also be more efficient on some devices, especially low end devices. 

Basically what this PR does is switch from using a giant Uniform Buffer Object to using a giant Vertex Buffer Object. Instead of dynamically indexing into an array of uniforms (using instance ID is the index) in the shader, we push instance rate attributes to the shader. This improves codegen as there is no dynamic indexing. 

For Uniform Buffers we had the ability to bind a specific range, for Vertex Buffers we don't, but we can specify an offset while binding the buffer. Unfortunately, this means we need to rebind the buffer for every batch. In my testing this doesn't carry a noticeable performance penalty. 

By way of background, the approach we were using is often referred to as "vertex pulling" i.e. we are using an index to pull vertex data from some buffer. This contrasts with "vertex pushing" which is when we use attributes to push vertex data to a shader (so the shader only sees the data for the current vertex). On modern desktop hardware vertex pulling can be way more efficient as it often allows you to get by with much less data.

In our case, since we only need information on a per-vertex or per-instance basis, the built in tools in OpenGL for vertex attributes and instance attributes work just fine. There is an overhead to instancing, however, in my testing it appears the benefits outweigh the costs. 

### Performance analysis

I carried out the best analysis I could of rendering performance. For the most part this means that I profiled GPU operations using the best tools available for the platform. On macOS I was limited to printing FPS which is understandably a poor way of measuring GPU performance. 

All measurements were taken with the Project Manager

| Platform      | Device                         | 4.0-dev   | This PR   | Notes                  |
|---------------|--------------------------------|-----------|-----------|------------------------|
| Windows       | RX 6900XT                      | 1.1-1.4ms | 1.0ms     | Renderdoc              |
| PopOS 22.04   | i7-1165G7 (Xe graphics)        | 1.6ms     | 1.4ms     | Renderdoc              |
| Windows       | i5-8265U 1.6GHz (intel HD 620) | 1.7-1.9ms | 1.5-1.6ms | Renderdoc              |
| Windows       | i5-8265U 1.6GHz (intel HD 620) | 0.8ms     | 0.5ms     | Intel Graphics Monitor |
| macOS 12.6.1  | 2.7 GHz Dual core intel i5     | N/A       | 6-10ms*   | ``--print-fps``        |
| Android 13    | Pixel 4                        | 5.3ms     | 5.2ms     | Android GPU Inspector  |
| Android 13    | Pixel 7                        | 4.7ms     | 4.4ms     | Android GPU Inspector  |
| Lubuntu 20.04 | Intel Celeron N2840 2.16GHz**  | 6.5ms     | 4.4ms     | Renderdoc              |
* On macOS I forcibly disabled low processor mode and vsync However, It appears some form of vsync was still occurring, as the times it was at 6ish ms it appeared locked at 144 FPS
** This device is a 2014 Chromebook with ChromeOS wiped

Given these results, I feel comfortable saying that this PR will run at least as fast as the previous approach and may even run faster on some devices. 

### Further work

I quickly tried out two improvements that are promising but did not show a performance improvement on my main development device (there may be improvements on other devices though). Noting the approaches here for future reference:
1. Add a "single instance" mode to the shader so batches with a single instance avoid utilizing the vertex buffer and instead pass their per-instance data in a single uniform. In theory this should be faster as it still avoids dynamic indexing and reduces vertex pressure/bandwidth, however in testing on my main device this resulted in a marginal decrease in performance (perhaps due to all the context switching) (https://github.com/clayjohn/godot/tree/GLES3-SI) Needs testing on bandwidth restricted devices (i.e. mobile)
2. Use non-instanced variations of draw functions when instance count is 1 (i.e. ``glDrawArrays`` instead of ``glDrawArraysInstanced``). Doing so resulted in no performance benefit. This may be because the drivers on my development device optimize for this situation already. This should be tested on a wider variety of hardware.
