### PR TITLE
Initialize light index push constants to 0xFFFFFFFF instead of 0xFFFF

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -70,17 +70,17 @@ void RenderForwardMobile::ForwardIDStorageMobile::map_forward_id(RendererRD::For
 void RenderForwardMobile::ForwardIDStorageMobile::fill_push_constant_instance_indices(GeometryInstanceForwardMobile::PushConstant *p_push_constant, uint32_t &spec_constants, const GeometryInstanceForwardMobile *p_instance) {
 	// first zero out our indices
 
-	p_push_constant->omni_lights[0] = 0xFFFF;
-	p_push_constant->omni_lights[1] = 0xFFFF;
+	p_push_constant->omni_lights[0] = 0xFFFFFFFF;
+	p_push_constant->omni_lights[1] = 0xFFFFFFFF;
 
-	p_push_constant->spot_lights[0] = 0xFFFF;
-	p_push_constant->spot_lights[1] = 0xFFFF;
+	p_push_constant->spot_lights[0] = 0xFFFFFFFF;
+	p_push_constant->spot_lights[1] = 0xFFFFFFFF;
 
-	p_push_constant->decals[0] = 0xFFFF;
-	p_push_constant->decals[1] = 0xFFFF;
+	p_push_constant->decals[0] = 0xFFFFFFFF;
+	p_push_constant->decals[1] = 0xFFFFFFFF;
 
-	p_push_constant->reflection_probes[0] = 0xFFFF;
-	p_push_constant->reflection_probes[1] = 0xFFFF;
+	p_push_constant->reflection_probes[0] = 0xFFFFFFFF;
+	p_push_constant->reflection_probes[1] = 0xFFFFFFFF;
 
 	if (p_instance->omni_light_count == 0) {
 		spec_constants |= 1 << SPEC_CONSTANT_DISABLE_OMNI_LIGHTS;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/55881

Each of these push constants is a 32 bit integer used to carry 4 singly byte integers (0-255 range). In the shader, the value of 0xFF is used to check if a light is unused in which case it skips rendering that light. Since we initialized the values to 0xFFFF, the shader would think that the indices are as follows (0, 1, 0, 0) instead of (0, 1, 255, 255). So instead of skipping the last two indices, it just draws the light at index 0 3 times (actually five times because a total of 8 potential lights are used). 

This PR should also improve performance as the expensive lighting calculations are now only done as many times as needed.

_Before_
![Screenshot from 2022-12-14 10-34-25](https://user-images.githubusercontent.com/16521339/207681543-fd104ac2-bda1-4b27-82c1-6f9a71aa83ba.png)

_After_
![Screenshot from 2022-12-14 10-34-46](https://user-images.githubusercontent.com/16521339/207681537-2fa5e0e4-9638-4232-a39b-fb35bcdf7c3f.png)
