### PR TITLE
Fix missing check if shortcut event is handled for Control-nodes

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -942,6 +942,9 @@ void SceneTree::_call_input_pause(const StringName &p_group, CallInputType p_cal
 	}
 
 	for (const ObjectID &id : no_context_node_ids) {
+		if (p_viewport->is_input_handled()) {
+			break;
+		}
 		Node *n = Object::cast_to<Node>(ObjectDB::get_instance(id));
 		if (n) {
 			n->_call_shortcut_input(p_input);


### PR DESCRIPTION
Control-nodes without a shortcut-context were missing a check if the event was handled, so that a single shortcut-event was passed to multiple Control-nodes.

resolve #70070