### PR TITLE
Remove extra range conversion in Sprite3D normal encoding

### DIFF
--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -191,9 +191,7 @@ void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect,
 
 	uint32_t v_normal;
 	{
-		Vector3 n = normal * Vector3(0.5, 0.5, 0.5) + Vector3(0.5, 0.5, 0.5);
-
-		Vector2 res = n.octahedron_encode();
+		Vector2 res = normal.octahedron_encode();
 		uint32_t value = 0;
 		value |= (uint16_t)CLAMP(res.x * 65535, 0, 65535);
 		value |= (uint16_t)CLAMP(res.y * 65535, 0, 65535) << 16;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/70018

It looks like a line converting normals from -1 to 1 range to 0 to 1 range was left in when we moved to exclusively using octahedral normals. Octahedral encode expects normalized normals, so the resulting normals kept the 0 to 1 range and ended up skewing into the positive direction

_Before: Sprite3D in center and right, Quad on left_
![Screenshot from 2022-12-14 15-43-07](https://user-images.githubusercontent.com/16521339/207739105-cf9c9e91-1fa8-44d1-887f-bfda309ef4ac.png)

_After: Lights look good_
![Screenshot from 2022-12-14 15-40-32](https://user-images.githubusercontent.com/16521339/207739106-7e0f5227-9080-4a11-8d3e-6473bd4643c5.png)

_Before: Showing normal buffer_
![Screenshot from 2022-12-14 15-43-12](https://user-images.githubusercontent.com/16521339/207739103-cbb83829-b57a-49af-b970-935479644756.png)

_After: all normals are the same now_
![Screenshot from 2022-12-14 15-40-26](https://user-images.githubusercontent.com/16521339/207739112-e55d8c6e-2a2f-42f8-b3f3-fbb3d32695f8.png)






