### PR TITLE
Cache mesh AABB when modified by skeleton and update instance AABB when skeleton changes

### DIFF
--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -528,7 +528,7 @@ AABB MeshStorage::mesh_get_aabb(RID p_mesh, RID p_skeleton) {
 
 	Skeleton *skeleton = skeleton_owner.get_or_null(p_skeleton);
 
-	if (!skeleton || skeleton->size == 0) {
+	if (!skeleton || skeleton->size == 0 || mesh->skeleton_aabb_version == skeleton->version) {
 		return mesh->aabb;
 	}
 
@@ -622,6 +622,8 @@ AABB MeshStorage::mesh_get_aabb(RID p_mesh, RID p_skeleton) {
 		}
 	}
 
+	mesh->aabb = aabb;
+	mesh->skeleton_aabb_version = skeleton->version;
 	return aabb;
 }
 

--- a/drivers/gles3/storage/mesh_storage.h
+++ b/drivers/gles3/storage/mesh_storage.h
@@ -126,6 +126,7 @@ struct Mesh {
 
 	AABB aabb;
 	AABB custom_aabb;
+	uint64_t skeleton_aabb_version = 0;
 
 	Vector<RID> material_cache;
 

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -715,6 +715,8 @@ AABB MeshStorage::mesh_get_aabb(RID p_mesh, RID p_skeleton) {
 		}
 	}
 
+	mesh->aabb = aabb;
+
 	mesh->skeleton_aabb_version = skeleton->version;
 	return aabb;
 }

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -476,6 +476,7 @@ public:
 			Instance *instance = (Instance *)tracker->userdata;
 			switch (p_notification) {
 				case Dependency::DEPENDENCY_CHANGED_SKELETON_DATA:
+				case Dependency::DEPENDENCY_CHANGED_SKELETON_BONES:
 				case Dependency::DEPENDENCY_CHANGED_AABB: {
 					singleton->_instance_queue_update(instance, true, false);
 
@@ -491,8 +492,7 @@ public:
 				case Dependency::DEPENDENCY_CHANGED_REFLECTION_PROBE: {
 					singleton->_instance_queue_update(instance, true, true);
 				} break;
-				case Dependency::DEPENDENCY_CHANGED_MULTIMESH_VISIBLE_INSTANCES:
-				case Dependency::DEPENDENCY_CHANGED_SKELETON_BONES: {
+				case Dependency::DEPENDENCY_CHANGED_MULTIMESH_VISIBLE_INSTANCES: {
 					//ignored
 				} break;
 				case Dependency::DEPENDENCY_CHANGED_LIGHT_SOFT_SHADOW_AND_PROJECTOR: {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/57740

This implements the 3.x behaviour where every frame that a skeleton is changed it recomputes its AABB and caches it. 

Technically this is enough to fix the bug in https://github.com/godotengine/godot/issues/57740, however, as pointed out by reduz and lawnjelly, recalculating the mesh aabb every time the skeleton changes is not ideal as it can be a lot of heavy calculations and skeletons tend to change every frame. 

In addition to this bug fix, we need to discuss what a better solution would be. Right now (with this change) the only way to avoid the cost of recalculating every frame is to set a custom_aabb. Setting a custom AABB skips the expensive calculations here and gives users control over the AABB. To me that seems like it may be enough, but would love to hear more from others

cc @lawnjelly @fire 