### PR TITLE
[3.x] Avoid compiling Editor checks in release builds for `VisibilityNotifier2D`

### DIFF
--- a/scene/2d/visibility_notifier_2d.cpp
+++ b/scene/2d/visibility_notifier_2d.cpp
@@ -52,10 +52,6 @@ void VisibilityNotifier2D::_enter_viewport(Viewport *p_viewport) {
 	ERR_FAIL_COND(viewports.has(p_viewport));
 	viewports.insert(p_viewport);
 
-	if (is_inside_tree() && Engine::get_singleton()->is_editor_hint()) {
-		return;
-	}
-
 	if (viewports.size() == 1) {
 		emit_signal(SceneStringNames::get_singleton()->screen_entered);
 
@@ -68,10 +64,6 @@ void VisibilityNotifier2D::_exit_viewport(Viewport *p_viewport) {
 	ERR_FAIL_COND(!viewports.has(p_viewport));
 	viewports.erase(p_viewport);
 
-	if (is_inside_tree() && Engine::get_singleton()->is_editor_hint()) {
-		return;
-	}
-
 	emit_signal(SceneStringNames::get_singleton()->viewport_exited, p_viewport);
 	if (viewports.size() == 0) {
 		emit_signal(SceneStringNames::get_singleton()->screen_exited);
@@ -83,11 +75,16 @@ void VisibilityNotifier2D::_exit_viewport(Viewport *p_viewport) {
 void VisibilityNotifier2D::set_rect(const Rect2 &p_rect) {
 	rect = p_rect;
 	if (is_inside_tree()) {
-		get_world_2d()->_update_notifier(this, get_global_transform().xform(rect));
+#ifdef TOOLS_ENABLED
 		if (Engine::get_singleton()->is_editor_hint()) {
 			update();
 			item_rect_changed();
+		} else {
+			get_world_2d()->_update_notifier(this, get_global_transform().xform(rect));
 		}
+#else
+		get_world_2d()->_update_notifier(this, get_global_transform().xform(rect));
+#endif
 	}
 
 	_change_notify("rect");
@@ -100,20 +97,38 @@ Rect2 VisibilityNotifier2D::get_rect() const {
 void VisibilityNotifier2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			//get_world_2d()->
+#ifdef TOOLS_ENABLED
+			if (!Engine::get_singleton()->is_editor_hint()) {
+				get_world_2d()->_register_notifier(this, get_global_transform().xform(rect));
+			}
+#else
 			get_world_2d()->_register_notifier(this, get_global_transform().xform(rect));
+#endif
 		} break;
 		case NOTIFICATION_TRANSFORM_CHANGED: {
-			//get_world_2d()->
+#ifdef TOOLS_ENABLED
+			if (!Engine::get_singleton()->is_editor_hint()) {
+				get_world_2d()->_update_notifier(this, get_global_transform().xform(rect));
+			}
+#else
 			get_world_2d()->_update_notifier(this, get_global_transform().xform(rect));
+#endif
 		} break;
+#ifdef TOOLS_ENABLED
 		case NOTIFICATION_DRAW: {
 			if (Engine::get_singleton()->is_editor_hint()) {
 				draw_rect(rect, Color(1, 0.5, 1, 0.2));
 			}
 		} break;
+#endif
 		case NOTIFICATION_EXIT_TREE: {
+#ifdef TOOLS_ENABLED
+			if (!Engine::get_singleton()->is_editor_hint()) {
+				get_world_2d()->_remove_notifier(this);
+			}
+#else
 			get_world_2d()->_remove_notifier(this);
+#endif
 		} break;
 	}
 }
@@ -223,9 +238,11 @@ void VisibilityEnabler2D::_find_nodes(Node *p_node) {
 
 void VisibilityEnabler2D::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
+#ifdef TOOLS_ENABLED
 		if (Engine::get_singleton()->is_editor_hint()) {
 			return;
 		}
+#endif
 
 		Node *from = this;
 		//find where current scene starts
@@ -251,9 +268,11 @@ void VisibilityEnabler2D::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_EXIT_TREE) {
+#ifdef TOOLS_ENABLED
 		if (Engine::get_singleton()->is_editor_hint()) {
 			return;
 		}
+#endif
 
 		for (Map<Node *, Variant>::Element *E = nodes.front(); E; E = E->next()) {
 			if (!visible) {


### PR DESCRIPTION
There's no change in behavior. This PR is simply to avoid compiling in Editor checks in release builds for `VisibilityNotifier2D` similar to the work done in #54115.

Here we do not register the notifiers whilst the node is managed through the Editor, which avoids the checks in `_enter_viewport` and `_exit_viewport`.