### PR TITLE
Remove mesh bone_aabbs as they are not used anywhere and calculating them is a pain

### DIFF
--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -323,27 +323,8 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 	}
 
 	if (mesh->surface_count == 0) {
-		mesh->bone_aabbs = p_surface.bone_aabbs;
 		mesh->aabb = p_surface.aabb;
 	} else {
-		if (mesh->bone_aabbs.size() < p_surface.bone_aabbs.size()) {
-			// ArrayMesh::_surface_set_data only allocates bone_aabbs up to max_bone
-			// Each surface may affect different numbers of bones.
-			mesh->bone_aabbs.resize(p_surface.bone_aabbs.size());
-		}
-		for (int i = 0; i < p_surface.bone_aabbs.size(); i++) {
-			const AABB &bone = p_surface.bone_aabbs[i];
-			if (bone.has_volume()) {
-				AABB &mesh_bone = mesh->bone_aabbs.write[i];
-				if (mesh_bone != AABB()) {
-					// Already initialized, merge AABBs.
-					mesh_bone.merge_with(bone);
-				} else {
-					// Not yet initialized, copy the bone AABB.
-					mesh_bone = bone;
-				}
-			}
-		}
 		mesh->aabb.merge_with(p_surface.aabb);
 	}
 

--- a/drivers/gles3/storage/mesh_storage.h
+++ b/drivers/gles3/storage/mesh_storage.h
@@ -120,8 +120,6 @@ struct Mesh {
 	Surface **surfaces = nullptr;
 	uint32_t surface_count = 0;
 
-	Vector<AABB> bone_aabbs;
-
 	bool has_bone_weights = false;
 
 	AABB aabb;

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -434,27 +434,8 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 	}
 
 	if (mesh->surface_count == 0) {
-		mesh->bone_aabbs = p_surface.bone_aabbs;
 		mesh->aabb = p_surface.aabb;
 	} else {
-		if (mesh->bone_aabbs.size() < p_surface.bone_aabbs.size()) {
-			// ArrayMesh::_surface_set_data only allocates bone_aabbs up to max_bone
-			// Each surface may affect different numbers of bones.
-			mesh->bone_aabbs.resize(p_surface.bone_aabbs.size());
-		}
-		for (int i = 0; i < p_surface.bone_aabbs.size(); i++) {
-			const AABB &bone = p_surface.bone_aabbs[i];
-			if (bone.has_volume()) {
-				AABB &mesh_bone = mesh->bone_aabbs.write[i];
-				if (mesh_bone != AABB()) {
-					// Already initialized, merge AABBs.
-					mesh_bone.merge_with(bone);
-				} else {
-					// Not yet initialized, copy the bone AABB.
-					mesh_bone = bone;
-				}
-			}
-		}
 		mesh->aabb.merge_with(p_surface.aabb);
 	}
 

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
@@ -138,8 +138,6 @@ private:
 		Surface **surfaces = nullptr;
 		uint32_t surface_count = 0;
 
-		Vector<AABB> bone_aabbs;
-
 		bool has_bone_weights = false;
 
 		AABB aabb;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/56458 once and for all

Tested with MRPs from: https://github.com/godotengine/godot/issues/56458, https://github.com/godotengine/godot/issues/69516, and https://github.com/godotengine/godot/pull/64416#issuecomment-1219783299

The ``bone_aabbs`` array was added in 449df8f688080c02bfbbfafc45421875b77deb1b and was only used in one place. That one place was removed in https://github.com/godotengine/godot/pull/44649 and since then ``bone_aabbs`` has never been used. We do however, use ``surface[i].bone_aabbs``.

There is no point in merging together the various ``bone_aabbs`` as the bone indices don't necessarily correlate with each other at all. At best this resulted in a fairly chaotic array of ``AABB``s. 

I will need to discuss with @reduz, but my guess behind the original intention of this code was that it should expand the ``mesh->aabb`` to cover all the individual bone AABBS. If that is the case, then we will be better off doing that during the original calculation of the ``bone_aabbs`` in the RenderingServer