### PR TITLE
Clear animation map when import settings is opened

### DIFF
--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -555,6 +555,7 @@ void SceneImportSettings::open_settings(const String &p_path, bool p_for_animati
 
 	material_set.clear();
 	mesh_set.clear();
+	animation_map.clear();
 	material_map.clear();
 	mesh_map.clear();
 	node_map.clear();


### PR DESCRIPTION
Fixes #69825 