### PR TITLE
StringName Dictionary keys

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -605,7 +605,7 @@ Variant Object::_call_bind(const Variant **p_args, int p_argcount, Callable::Cal
 		return Variant();
 	}
 
-	if (p_args[0]->get_type() != Variant::STRING_NAME && p_args[0]->get_type() != Variant::STRING) {
+	if (!p_args[0]->is_string()) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 0;
 		r_error.expected = Variant::STRING_NAME;
@@ -624,7 +624,7 @@ Variant Object::_call_deferred_bind(const Variant **p_args, int p_argcount, Call
 		return Variant();
 	}
 
-	if (p_args[0]->get_type() != Variant::STRING_NAME && p_args[0]->get_type() != Variant::STRING) {
+	if (!p_args[0]->is_string()) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 0;
 		r_error.expected = Variant::STRING_NAME;
@@ -720,7 +720,7 @@ Variant Object::getvar(const Variant &p_key, bool *r_valid) const {
 		*r_valid = false;
 	}
 
-	if (p_key.get_type() == Variant::STRING_NAME || p_key.get_type() == Variant::STRING) {
+	if (p_key.is_string()) {
 		return get(p_key, r_valid);
 	}
 	return Variant();
@@ -730,7 +730,7 @@ void Object::setvar(const Variant &p_key, const Variant &p_value, bool *r_valid)
 	if (r_valid) {
 		*r_valid = false;
 	}
-	if (p_key.get_type() == Variant::STRING_NAME || p_key.get_type() == Variant::STRING) {
+	if (p_key.is_string()) {
 		return set(p_key, p_value, r_valid);
 	}
 }
@@ -1096,7 +1096,7 @@ Error Object::_emit_signal(const Variant **p_args, int p_argcount, Callable::Cal
 		ERR_FAIL_V(Error::ERR_INVALID_PARAMETER);
 	}
 
-	if (unlikely(p_args[0]->get_type() != Variant::STRING_NAME && p_args[0]->get_type() != Variant::STRING)) {
+	if (unlikely(!p_args[0]->is_string())) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 0;
 		r_error.expected = Variant::STRING_NAME;

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -81,15 +81,7 @@ Variant Dictionary::get_value_at_index(int p_index) const {
 
 Variant &Dictionary::operator[](const Variant &p_key) {
 	if (unlikely(_p->read_only)) {
-		if (p_key.get_type() == Variant::STRING_NAME) {
-			const StringName *sn = VariantInternal::get_string_name(&p_key);
-			const String &key = sn->operator String();
-			if (likely(_p->variant_map.has(key))) {
-				*_p->read_only = _p->variant_map[key];
-			} else {
-				*_p->read_only = Variant();
-			}
-		} else if (likely(_p->variant_map.has(p_key))) {
+		if (likely(_p->variant_map.has(p_key))) {
 			*_p->read_only = _p->variant_map[p_key];
 		} else {
 			*_p->read_only = Variant();
@@ -97,12 +89,7 @@ Variant &Dictionary::operator[](const Variant &p_key) {
 
 		return *_p->read_only;
 	} else {
-		if (p_key.get_type() == Variant::STRING_NAME) {
-			const StringName *sn = VariantInternal::get_string_name(&p_key);
-			return _p->variant_map[sn->operator String()];
-		} else {
-			return _p->variant_map[p_key];
-		}
+		return _p->variant_map[p_key];
 	}
 }
 

--- a/core/variant/variant_construct.h
+++ b/core/variant/variant_construct.h
@@ -232,7 +232,7 @@ template <typename T>
 class VariantConstructorFromString {
 public:
 	static void construct(Variant &r_ret, const Variant **p_args, Callable::CallError &r_error) {
-		if (p_args[0]->get_type() != Variant::STRING) {
+		if (!p_args[0]->is_string()) {
 			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 			r_error.argument = 0;
 			r_error.expected = Variant::STRING;
@@ -240,7 +240,7 @@ public:
 		}
 
 		VariantTypeChanger<T>::change(&r_ret);
-		const String &src_str = *VariantGetInternalPtr<String>::get_ptr(p_args[0]);
+		const String src_str = *p_args[0];
 
 		if (r_ret.get_type() == Variant::Type::INT) {
 			r_ret = src_str.to_int();
@@ -417,7 +417,7 @@ public:
 			return;
 		}
 
-		if (p_args[2]->get_type() != Variant::STRING_NAME) {
+		if (!p_args[2]->is_string()) {
 			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 			r_error.argument = 2;
 			r_error.expected = Variant::STRING_NAME;
@@ -426,8 +426,7 @@ public:
 
 		const Array &base_arr = *VariantGetInternalPtr<Array>::get_ptr(p_args[0]);
 		const uint32_t type = p_args[1]->operator uint32_t();
-		const StringName &class_name = *VariantGetInternalPtr<StringName>::get_ptr(p_args[2]);
-		r_ret = Array(base_arr, type, class_name, *p_args[3]);
+		r_ret = Array(base_arr, type, *p_args[2], *p_args[3]);
 	}
 
 	static inline void validated_construct(Variant *r_ret, const Variant **p_args) {

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -1288,8 +1288,8 @@ void Variant::get_property_list(List<PropertyInfo> *p_list) const {
 		List<Variant> keys;
 		dic->get_key_list(&keys);
 		for (const Variant &E : keys) {
-			if (E.get_type() == Variant::STRING) {
-				p_list->push_back(PropertyInfo(Variant::STRING, E));
+			if (E.is_string()) {
+				p_list->push_back(PropertyInfo(dic->get_valid(E).get_type(), E));
 			}
 		}
 	} else if (type == OBJECT) {

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -151,7 +151,7 @@ ObjectID EditorDebuggerInspector::add_object(const Array &p_arr) {
 		Variant &var = property.second;
 
 		if (pinfo.type == Variant::OBJECT) {
-			if (var.get_type() == Variant::STRING) {
+			if (var.is_string()) {
 				String path = var;
 				if (path.contains("::")) {
 					// built-in resource

--- a/editor/editor_build_profile.cpp
+++ b/editor/editor_build_profile.cpp
@@ -649,7 +649,7 @@ void EditorBuildProfileManager::_class_list_item_selected() {
 	}
 
 	Variant md = item->get_metadata(0);
-	if (md.get_type() == Variant::STRING || md.get_type() == Variant::STRING_NAME) {
+	if (md.is_string()) {
 		description_bit->parse_symbol("class|" + md.operator String() + "|");
 	} else if (md.get_type() == Variant::INT) {
 		String build_option_description = EditorBuildProfile::get_build_option_description(EditorBuildProfile::BuildOption((int)md));
@@ -670,7 +670,7 @@ void EditorBuildProfileManager::_class_list_item_edited() {
 	bool checked = item->is_checked(0);
 
 	Variant md = item->get_metadata(0);
-	if (md.get_type() == Variant::STRING || md.get_type() == Variant::STRING_NAME) {
+	if (md.is_string()) {
 		String class_selected = md;
 		edited->set_disable_class(class_selected, !checked);
 		_update_edited_profile();
@@ -691,7 +691,7 @@ void EditorBuildProfileManager::_class_list_item_collapsed(Object *p_item) {
 	}
 
 	Variant md = item->get_metadata(0);
-	if (md.get_type() != Variant::STRING && md.get_type() != Variant::STRING_NAME) {
+	if (!md.is_string()) {
 		return;
 	}
 
@@ -706,7 +706,7 @@ void EditorBuildProfileManager::_update_edited_profile() {
 
 	if (class_list->get_selected()) {
 		Variant md = class_list->get_selected()->get_metadata(0);
-		if (md.get_type() == Variant::STRING || md.get_type() == Variant::STRING_NAME) {
+		if (md.is_string()) {
 			class_selected = md;
 		} else if (md.get_type() == Variant::INT) {
 			build_option_selected = md;

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -558,7 +558,7 @@ void EditorFeatureProfileManager::_class_list_item_selected() {
 	}
 
 	Variant md = item->get_metadata(0);
-	if (md.get_type() == Variant::STRING || md.get_type() == Variant::STRING_NAME) {
+	if (md.is_string()) {
 		description_bit->parse_symbol("class|" + md.operator String() + "|");
 	} else if (md.get_type() == Variant::INT) {
 		String feature_description = EditorFeatureProfile::get_feature_description(EditorFeatureProfile::Feature((int)md));
@@ -643,7 +643,7 @@ void EditorFeatureProfileManager::_class_list_item_edited() {
 	bool checked = item->is_checked(0);
 
 	Variant md = item->get_metadata(0);
-	if (md.get_type() == Variant::STRING || md.get_type() == Variant::STRING_NAME) {
+	if (md.is_string()) {
 		String class_selected = md;
 		edited->set_disable_class(class_selected, !checked);
 		_save_and_update();
@@ -666,7 +666,7 @@ void EditorFeatureProfileManager::_class_list_item_collapsed(Object *p_item) {
 	}
 
 	Variant md = item->get_metadata(0);
-	if (md.get_type() != Variant::STRING && md.get_type() != Variant::STRING_NAME) {
+	if (!md.is_string()) {
 		return;
 	}
 
@@ -686,7 +686,7 @@ void EditorFeatureProfileManager::_property_item_edited() {
 	}
 
 	Variant md = class_item->get_metadata(0);
-	if (md.get_type() != Variant::STRING && md.get_type() != Variant::STRING_NAME) {
+	if (!md.is_string()) {
 		return;
 	}
 
@@ -699,7 +699,7 @@ void EditorFeatureProfileManager::_property_item_edited() {
 	bool checked = item->is_checked(0);
 
 	md = item->get_metadata(0);
-	if (md.get_type() == Variant::STRING || md.get_type() == Variant::STRING_NAME) {
+	if (md.is_string()) {
 		String property_selected = md;
 		edited->set_disable_class_property(class_name, property_selected, !checked);
 		_save_and_update();
@@ -732,7 +732,7 @@ void EditorFeatureProfileManager::_update_selected_profile() {
 
 	if (class_list->get_selected()) {
 		Variant md = class_list->get_selected()->get_metadata(0);
-		if (md.get_type() == Variant::STRING || md.get_type() == Variant::STRING_NAME) {
+		if (md.is_string()) {
 			class_selected = md;
 		} else if (md.get_type() == Variant::INT) {
 			feature_selected = md;

--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -177,7 +177,7 @@ void EditorUndoRedoManager::_add_do_method(const Variant **p_args, int p_argcoun
 		return;
 	}
 
-	if (p_args[1]->get_type() != Variant::STRING_NAME && p_args[1]->get_type() != Variant::STRING) {
+	if (!p_args[1]->is_string()) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 1;
 		r_error.expected = Variant::STRING_NAME;
@@ -206,7 +206,7 @@ void EditorUndoRedoManager::_add_undo_method(const Variant **p_args, int p_argco
 		return;
 	}
 
-	if (p_args[1]->get_type() != Variant::STRING_NAME && p_args[1]->get_type() != Variant::STRING) {
+	if (!p_args[1]->is_string()) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 1;
 		r_error.expected = Variant::STRING_NAME;

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2201,7 +2201,7 @@ void VisualShaderEditor::_update_options_menu() {
 					if (input.is_valid()) {
 						input->set_shader_mode(visual_shader->get_mode());
 						input->set_shader_type(visual_shader->get_shader_type());
-						if (!add_options[i].ops.is_empty() && add_options[i].ops[0].get_type() == Variant::STRING) {
+						if (!add_options[i].ops.is_empty() && add_options[i].ops[0].is_string()) {
 							input->set_input_name((String)add_options[i].ops[0]);
 						}
 					}
@@ -3281,7 +3281,7 @@ void VisualShaderEditor::_setup_node(VisualShaderNode *p_node, const Vector<Vari
 		VisualShaderNodeInput *input = Object::cast_to<VisualShaderNodeInput>(p_node);
 
 		if (input) {
-			ERR_FAIL_COND(p_ops[0].get_type() != Variant::STRING);
+			ERR_FAIL_COND(!p_ops[0].is_string());
 			input->set_input_name((String)p_ops[0]);
 			return;
 		}

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
@@ -71,7 +71,7 @@ Error GDScriptEditorTranslationParserPlugin::parse_file(const String &p_path, Ve
 
 bool GDScriptEditorTranslationParserPlugin::_is_constant_string(const GDScriptParser::ExpressionNode *p_expression) {
 	ERR_FAIL_NULL_V(p_expression, false);
-	return p_expression->is_constant && (p_expression->reduced_value.get_type() == Variant::STRING || p_expression->reduced_value.get_type() == Variant::STRING_NAME);
+	return p_expression->is_constant && p_expression->reduced_value.is_string();
 }
 
 void GDScriptEditorTranslationParserPlugin::_traverse_class(const GDScriptParser::ClassNode *p_class) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1997,7 +1997,7 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 					}
 
 					// Look for valid indexing in other types
-					if (!found && (index.value.get_type() == Variant::STRING || index.value.get_type() == Variant::NODE_PATH)) {
+					if (!found && (index.value.is_string() || index.value.get_type() == Variant::NODE_PATH)) {
 						StringName id = index.value;
 						found = _guess_identifier_type_from_base(c, base, id, r_type);
 					} else if (!found && index.type.kind == GDScriptParser::DataType::BUILTIN) {

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -232,7 +232,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 
 	static inline void load(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
 		VALIDATE_ARG_COUNT(1);
-		if (p_args[0]->get_type() != Variant::STRING) {
+		if (!p_args[0]->is_string()) {
 			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 			r_error.argument = 0;
 			r_error.expected = Variant::STRING;

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -309,7 +309,7 @@ Dictionary GDScriptTextDocument::resolve(const Dictionary &p_params) {
 		params.load(p_params["data"]);
 		symbol = GDScriptLanguageProtocol::get_singleton()->get_workspace()->resolve_symbol(params, item.label, item.kind == lsp::CompletionItemKind::Method || item.kind == lsp::CompletionItemKind::Function);
 
-	} else if (data.get_type() == Variant::STRING) {
+	} else if (data.is_string()) {
 		String query = data;
 
 		Vector<String> param_symbols = query.split(SYMBOL_SEPERATOR, false);

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -1064,7 +1064,7 @@ struct CompletionItem {
 		}
 		if (p_dict.has("documentation")) {
 			Variant doc = p_dict["documentation"];
-			if (doc.get_type() == Variant::STRING) {
+			if (doc.is_string()) {
 				documentation.value = doc;
 			} else if (doc.get_type() == Variant::DICTIONARY) {
 				Dictionary v = doc;

--- a/modules/gdscript/tests/scripts/analyzer/warnings/confusable_capture_reassignment.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/confusable_capture_reassignment.out
@@ -15,5 +15,5 @@ GDTEST_OK
 >> Line: 16
 >> CONFUSABLE_CAPTURE_REASSIGNMENT
 >> Reassigning lambda capture does not modify the outer local variable "array_assign".
-lambda 2 2 12 (2, 0) [2] [2] { "x": 2 }
-outer 2 1 1 (1, 0) [1] [2] { "x": 2 }
+lambda 2 2 12 (2, 0) [2] [2] { &"x": 2 }
+outer 2 1 1 (1, 0) [1] [2] { &"x": 2 }

--- a/modules/gdscript/tests/scripts/parser/features/dictionary_lua_style.out
+++ b/modules/gdscript/tests/scripts/parser/features/dictionary_lua_style.out
@@ -1,2 +1,2 @@
 GDTEST_OK
-{ "a": 1, "b": 2, "with spaces": 3, "2": 4 }
+{ &"a": 1, &"b": 2, &"with spaces": 3, &"2": 4 }

--- a/modules/gdscript/tests/scripts/parser/features/dictionary_mixed_syntax.out
+++ b/modules/gdscript/tests/scripts/parser/features/dictionary_mixed_syntax.out
@@ -1,2 +1,2 @@
 GDTEST_OK
-{ "hello": { "world": { "is": "beautiful" } } }
+{ "hello": { &"world": { "is": "beautiful" } } }

--- a/modules/gdscript/tests/scripts/runtime/features/dictionary_string_stringname_equivalent.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/dictionary_string_stringname_equivalent.gd
@@ -7,11 +7,11 @@ func test():
 	stringname_dict[&"abc"] = 24
 
 	print("String key is TYPE_STRING: ", typeof(string_dict.keys()[0]) == TYPE_STRING)
-	print("StringName key is TYPE_STRING: ", typeof(stringname_dict.keys()[0]) == TYPE_STRING)
+	print("StringName key is TYPE_STRING_NAME: ", typeof(stringname_dict.keys()[0]) == TYPE_STRING_NAME)
 
 	print("StringName gets String: ", string_dict.get(&"abc"))
 	print("String gets StringName: ", stringname_dict.get("abc"))
 
 	stringname_dict[&"abc"] = 42
-	# They compare equal because StringName keys are converted to String.
+	# They compare equal because StringName keys are considered equivalent to String keys.
 	print("String Dictionary == StringName Dictionary: ", string_dict == stringname_dict)

--- a/modules/gdscript/tests/scripts/runtime/features/dictionary_string_stringname_equivalent.out
+++ b/modules/gdscript/tests/scripts/runtime/features/dictionary_string_stringname_equivalent.out
@@ -1,6 +1,6 @@
 GDTEST_OK
 String key is TYPE_STRING: true
-StringName key is TYPE_STRING: true
+StringName key is TYPE_STRING_NAME: true
 StringName gets String: 42
 String gets StringName: 24
 String Dictionary == StringName Dictionary: true

--- a/modules/multiplayer/scene_rpc_interface.cpp
+++ b/modules/multiplayer/scene_rpc_interface.cpp
@@ -82,7 +82,7 @@ void SceneRPCInterface::_parse_rpc_config(const Variant &p_config, bool p_for_no
 	Array names = config.keys();
 	names.sort(); // Ensure ID order
 	for (int i = 0; i < names.size(); i++) {
-		ERR_CONTINUE(names[i].get_type() != Variant::STRING && names[i].get_type() != Variant::STRING_NAME);
+		ERR_CONTINUE(!names[i].is_string());
 		String name = names[i].operator String();
 		ERR_CONTINUE(config[name].get_type() != Variant::DICTIONARY);
 		ERR_CONTINUE(!config[name].operator Dictionary().has("rpc_mode"));

--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -54,8 +54,8 @@ int RegExMatch::_find(const Variant &p_name) const {
 			return -1;
 		}
 		return i;
-	} else if (p_name.get_type() == Variant::STRING || p_name.get_type() == Variant::STRING_NAME) {
-		HashMap<String, int>::ConstIterator found = names.find((String)p_name);
+	} else if (p_name.is_string()) {
+		HashMap<String, int>::ConstIterator found = names.find(p_name);
 		if (found) {
 			return found->value;
 		}

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -5902,7 +5902,7 @@ _FORCE_INLINE_ void TextServerAdvanced::_add_featuers(const Dictionary &p_source
 		int32_t value = values[i];
 		if (value >= 0) {
 			hb_feature_t feature;
-			if (keys[i].get_type() == Variant::STRING) {
+			if (keys[i].is_string()) {
 				feature.tag = _name_to_tag(keys[i]);
 			} else {
 				feature.tag = keys[i];

--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -97,7 +97,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 					}
 				} break;
 				case ARG_TYPE_STRING: {
-					if (p_args[i]->get_type() != Variant::STRING) {
+					if (!p_args[i]->is_string()) {
 						arg_expected = Variant::STRING;
 					}
 				} break;

--- a/platform/web/api/api.cpp
+++ b/platform/web/api/api.cpp
@@ -99,7 +99,7 @@ Variant JavaScriptBridge::_create_object_bind(const Variant **p_args, int p_argc
 		r_error.expected = 1;
 		return Ref<JavaScriptObject>();
 	}
-	if (p_args[0]->get_type() != Variant::STRING) {
+	if (!p_args[0]->is_string()) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 0;
 		r_error.expected = Variant::STRING;

--- a/platform/web/javascript_bridge_singleton.cpp
+++ b/platform/web/javascript_bridge_singleton.cpp
@@ -304,7 +304,7 @@ Variant JavaScriptBridge::_create_object_bind(const Variant **p_args, int p_argc
 		r_error.expected = 1;
 		return Ref<JavaScriptObject>();
 	}
-	if (p_args[0]->get_type() != Variant::STRING) {
+	if (!p_args[0]->is_string()) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 0;
 		r_error.expected = Variant::STRING;

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -698,13 +698,13 @@ bool LineEdit::can_drop_data(const Point2 &p_point, const Variant &p_data) const
 		return drop_override;
 	}
 
-	return is_editable() && p_data.get_type() == Variant::STRING;
+	return is_editable() && p_data.is_string();
 }
 
 void LineEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 	Control::drop_data(p_point, p_data);
 
-	if (p_data.get_type() == Variant::STRING && is_editable()) {
+	if (p_data.is_string() && is_editable()) {
 		set_caret_at_pixel_pos(p_point.x);
 		int caret_column_tmp = caret_column;
 		bool is_inside_sel = selection.enabled && caret_column >= selection.begin && caret_column <= selection.end;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2963,13 +2963,13 @@ bool TextEdit::can_drop_data(const Point2 &p_point, const Variant &p_data) const
 		return drop_override;
 	}
 
-	return is_editable() && p_data.get_type() == Variant::STRING;
+	return is_editable() && p_data.is_string();
 }
 
 void TextEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 	Control::drop_data(p_point, p_data);
 
-	if (p_data.get_type() == Variant::STRING && is_editable()) {
+	if (p_data.is_string() && is_editable()) {
 		Point2i pos = get_line_column_at_pos(get_local_mouse_pos());
 		int drop_at_line = pos.y;
 		int drop_at_column = pos.x;

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1564,7 +1564,7 @@ void TreeItem::_call_recursive_bind(const Variant **p_args, int p_argcount, Call
 		return;
 	}
 
-	if (p_args[0]->get_type() != Variant::STRING && p_args[0]->get_type() != Variant::STRING_NAME) {
+	if (!p_args[0]->is_string()) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 0;
 		r_error.expected = Variant::STRING_NAME;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -770,8 +770,7 @@ Error Node::_rpc_bind(const Variant **p_args, int p_argcount, Callable::CallErro
 		return ERR_INVALID_PARAMETER;
 	}
 
-	Variant::Type type = p_args[0]->get_type();
-	if (type != Variant::STRING_NAME && type != Variant::STRING) {
+	if (!p_args[0]->is_string()) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 0;
 		r_error.expected = Variant::STRING_NAME;
@@ -799,8 +798,7 @@ Error Node::_rpc_id_bind(const Variant **p_args, int p_argcount, Callable::CallE
 		return ERR_INVALID_PARAMETER;
 	}
 
-	Variant::Type type = p_args[1]->get_type();
-	if (type != Variant::STRING_NAME && type != Variant::STRING) {
+	if (!p_args[1]->is_string()) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 1;
 		r_error.expected = Variant::STRING_NAME;
@@ -3436,7 +3434,7 @@ Variant Node::_call_deferred_thread_group_bind(const Variant **p_args, int p_arg
 		return Variant();
 	}
 
-	if (p_args[0]->get_type() != Variant::STRING_NAME && p_args[0]->get_type() != Variant::STRING) {
+	if (!p_args[0]->is_string()) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 0;
 		r_error.expected = Variant::STRING_NAME;
@@ -3459,7 +3457,7 @@ Variant Node::_call_thread_safe_bind(const Variant **p_args, int p_argcount, Cal
 		return Variant();
 	}
 
-	if (p_args[0]->get_type() != Variant::STRING_NAME && p_args[0]->get_type() != Variant::STRING) {
+	if (!p_args[0]->is_string()) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 0;
 		r_error.expected = Variant::STRING_NAME;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1315,8 +1315,8 @@ void SceneTree::_call_group_flags(const Variant **p_args, int p_argcount, Callab
 
 	ERR_FAIL_COND(p_argcount < 3);
 	ERR_FAIL_COND(!p_args[0]->is_num());
-	ERR_FAIL_COND(p_args[1]->get_type() != Variant::STRING_NAME && p_args[1]->get_type() != Variant::STRING);
-	ERR_FAIL_COND(p_args[2]->get_type() != Variant::STRING_NAME && p_args[2]->get_type() != Variant::STRING);
+	ERR_FAIL_COND(!p_args[1]->is_string());
+	ERR_FAIL_COND(!p_args[2]->is_string());
 
 	int flags = *p_args[0];
 	StringName group = *p_args[1];
@@ -1329,8 +1329,8 @@ void SceneTree::_call_group(const Variant **p_args, int p_argcount, Callable::Ca
 	r_error.error = Callable::CallError::CALL_OK;
 
 	ERR_FAIL_COND(p_argcount < 2);
-	ERR_FAIL_COND(p_args[0]->get_type() != Variant::STRING_NAME && p_args[0]->get_type() != Variant::STRING);
-	ERR_FAIL_COND(p_args[1]->get_type() != Variant::STRING_NAME && p_args[1]->get_type() != Variant::STRING);
+	ERR_FAIL_COND(!p_args[0]->is_string());
+	ERR_FAIL_COND(!p_args[1]->is_string());
 
 	StringName group = *p_args[0];
 	StringName method = *p_args[1];

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -3920,7 +3920,7 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 				int terrain_index = components[1].trim_prefix("terrain_").to_int();
 				ERR_FAIL_COND_V(terrain_index < 0, false);
 				if (components[2] == "name") {
-					ERR_FAIL_COND_V(p_value.get_type() != Variant::STRING, false);
+					ERR_FAIL_COND_V(!p_value.is_string(), false);
 					while (terrain_set_index >= terrain_sets.size()) {
 						add_terrain_set();
 					}
@@ -3958,7 +3958,7 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 			int index = components[0].trim_prefix("custom_data_layer_").to_int();
 			ERR_FAIL_COND_V(index < 0, false);
 			if (components[1] == "name") {
-				ERR_FAIL_COND_V(p_value.get_type() != Variant::STRING, false);
+				ERR_FAIL_COND_V(!p_value.is_string(), false);
 				while (index >= custom_data_layers.size()) {
 					add_custom_data_layer();
 				}

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -1717,7 +1717,7 @@ int Animation::track_insert_key(int p_track, double p_time, const Variant &p_key
 			ERR_FAIL_COND_V(p_key.get_type() != Variant::DICTIONARY, -1);
 
 			Dictionary d = p_key;
-			ERR_FAIL_COND_V(!d.has("method") || (d["method"].get_type() != Variant::STRING_NAME && d["method"].get_type() != Variant::STRING), -1);
+			ERR_FAIL_COND_V(!d.has("method") || !d["method"].is_string(), -1);
 			ERR_FAIL_COND_V(!d.has("args") || !d["args"].is_array(), -1);
 
 			MethodKey k;

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -1988,7 +1988,7 @@ TypedArray<Vector3i> TextServer::parse_structured_text(StructuredTextParser p_pa
 			}
 		} break;
 		case STRUCTURED_TEXT_LIST: {
-			if (p_args.size() == 1 && p_args[0].get_type() == Variant::STRING) {
+			if (p_args.size() == 1 && p_args[0].is_string()) {
 				Vector<String> tags = p_text.split(String(p_args[0]));
 				int prev = 0;
 				for (int i = 0; i < tags.size(); i++) {

--- a/tests/core/variant/test_dictionary.h
+++ b/tests/core/variant/test_dictionary.h
@@ -66,8 +66,7 @@ TEST_CASE("[Dictionary] Assignment using bracket notation ([])") {
 
 	map[StringName("HelloName")] = 6;
 	CHECK(int(map[StringName("HelloName")]) == 6);
-	// Check that StringName key is converted to String.
-	CHECK(int(map.find_key(6).get_type()) == Variant::STRING);
+	CHECK(int(map.find_key(6).get_type()) == Variant::STRING_NAME);
 	map[StringName("HelloName")] = 7;
 	CHECK(int(map[StringName("HelloName")]) == 7);
 


### PR DESCRIPTION
follow up for https://github.com/godotengine/godot/pull/68747
removes conversion from StringName to String in Dictionary

it seems like a simple change, but many places still compare a Variants type with STRING
simply removing the conversion gave me alot of errors, so i did the sane thing and looked at every instance of an equality comparison to `Variant::STRING`, and updated most of them with an `is_string()` method i added to variant:
-- if it accepted String and StringName, i updated it to use `is_string()` (might as well, it's much easier to read)
-- if it was a closed system, (as in no external input, the type is always known to be string), i let it be
-- if it accepted input, (especially from GDScript), i updated it
-- if i couldn't tell for sure if it was a closed system (like in `editor_debugger_inspector.cpp`):
---- if it gave an error for StringName input, i left it (could be caught later)
---- if it silently failed, i updated it

note: Variant does not convert StringName to Color or to NodePath, i'm not sure whether it makes sense to accept StringName, so i let it be for now

fixes https://github.com/godotengine/godot/issues/68834

here are some numbers i got from this example, with different length keys (on a production build):
[TestDictIndexing.zip](https://github.com/godotengine/godot/files/10241791/TestDictIndexing.zip):
```
"%s":
  2.318s: String keys create
 81.679s: StringName keys create
  7.384s: String assign create
  1.973s: String dict String index read
  2.145s: String dict StringName index read
  7.278s: StringName assign create
  2.324s: StringName dict String index read
  1.788s: StringName dict StringName index read

"longer-test-key-%s":
  3.883s: String keys create
 83.304s: StringName keys create
  8.323s: String assign create
  2.406s: String dict String index read
  2.462s: String dict StringName index read
  7.543s: StringName assign create
  2.792s: StringName dict String index read
  1.732s: StringName dict StringName index read
```
with a long enough test key, StringName is faster even when finding a String key:
```
"how-long-could-it-take-to-hash-this-string?-key-%s":
  4.566s: String keys create
 82.376s: StringName keys create
 10.346s: String assign create
  2.949s: String dict String index read
  2.697s: String dict StringName index read
  8.529s: StringName assign create
  3.408s: StringName dict String index read
  1.727s: StringName dict StringName index read
```