### PR TITLE
Ensure sleep on monitor_joypads thread

### DIFF
--- a/platform/x11/joypad_linux.cpp
+++ b/platform/x11/joypad_linux.cpp
@@ -204,6 +204,8 @@ void JoypadLinux::monitor_joypads(udev *p_udev) {
 #endif
 
 void JoypadLinux::monitor_joypads() {
+	bool has_slept = false;
+
 	while (!monitor_joypads_exit.is_set()) {
 		DIR *input_directory;
 		input_directory = opendir("/dev/input");
@@ -222,6 +224,11 @@ void JoypadLinux::monitor_joypads() {
 			}
 		}
 		closedir(input_directory);
+		usleep(1000000); // 1s
+		has_slept = true;
+	}
+
+	if (!has_slept) {
 		usleep(1000000); // 1s
 	}
 }


### PR DESCRIPTION
Make sure sleep is occurring during monitor_joypads() function to ensure thread is not busy.

May fix #69942

## Notes
* This may or may not be a problem, the loop includes `while (!monitor_joypads_exit.is_set()) {`, which may be enough but I don't really know this bit of code.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
