### PR TITLE
Fix possible Tween leak on exit

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -594,6 +594,12 @@ void SceneTree::finalize() {
 		timer->release_connections();
 	}
 	timers.clear();
+
+	// Cleanup tweens.
+	for (Ref<Tween> &tween : tweens) {
+		tween->clear();
+	}
+	tweens.clear();
 }
 
 void SceneTree::quit(int p_exit_code) {


### PR DESCRIPTION
Remaining `Tween` objects were not cleaned up on exit.

For example, if a `Tween` is set to loop infinitely, exiting the game leaks that tween object (together with its tweeners).

```
WARNING: ObjectDB instances leaked at exit (run with --verbose for details).
     at: cleanup (core/object/object.cpp:1999)
Leaked instance: PropertyTweener:-9222475385122324058
Leaked instance: PropertyTweener:-9222475934878137943
Leaked instance: Tween:-9222476484633951511
```

Note when cherry-picking: `Tween` → `SceneTreeTween`.