### PR TITLE
Replace certain sanity checks with proper dev-only assertions in Vulkan RD

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -5469,10 +5469,8 @@ RID RenderingDeviceVulkan::uniform_set_create(const Vector<Uniform> &p_uniforms,
 						// Can also be used as storage, add to mutable sampled.
 						mutable_sampled_textures.push_back(texture);
 					}
-					if (texture->owner.is_valid()) {
-						texture = texture_owner.get_or_null(texture->owner);
-						ERR_FAIL_COND_V(!texture, RID()); // Bug, should never happen.
-					}
+
+					DEV_ASSERT(!texture->owner.is_valid() || texture_owner.get_or_null(texture->owner));
 
 					img_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
@@ -5523,10 +5521,7 @@ RID RenderingDeviceVulkan::uniform_set_create(const Vector<Uniform> &p_uniforms,
 						mutable_sampled_textures.push_back(texture);
 					}
 
-					if (texture->owner.is_valid()) {
-						texture = texture_owner.get_or_null(texture->owner);
-						ERR_FAIL_COND_V(!texture, RID()); // Bug, should never happen.
-					}
+					DEV_ASSERT(!texture->owner.is_valid() || texture_owner.get_or_null(texture->owner));
 
 					img_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
@@ -5571,10 +5566,7 @@ RID RenderingDeviceVulkan::uniform_set_create(const Vector<Uniform> &p_uniforms,
 						mutable_storage_textures.push_back(texture);
 					}
 
-					if (texture->owner.is_valid()) {
-						texture = texture_owner.get_or_null(texture->owner);
-						ERR_FAIL_COND_V(!texture, RID()); // Bug, should never happen.
-					}
+					DEV_ASSERT(!texture->owner.is_valid() || texture_owner.get_or_null(texture->owner));
 
 					img_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
@@ -5736,10 +5728,7 @@ RID RenderingDeviceVulkan::uniform_set_create(const Vector<Uniform> &p_uniforms,
 					img_info.sampler = VK_NULL_HANDLE;
 					img_info.imageView = texture->view;
 
-					if (texture->owner.is_valid()) {
-						texture = texture_owner.get_or_null(texture->owner);
-						ERR_FAIL_COND_V(!texture, RID()); // Bug, should never happen.
-					}
+					DEV_ASSERT(!texture->owner.is_valid() || texture_owner.get_or_null(texture->owner));
 
 					img_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 


### PR DESCRIPTION
The former _Bug, should never happen._ comments sound a lot like those should be dev-only extreme sanity checks, don't they?

**UPDATE:** After the discussion below, I realize this description makes this change look as if it had been based solely on the human targeted semantics of the comment. Not the case. 😀