### PR TITLE
[3.x] Check for null event in Tree._gui_input to avoid engine crash

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2175,6 +2175,8 @@ void Tree::_go_down() {
 }
 
 void Tree::_gui_input(Ref<InputEvent> p_event) {
+	ERR_FAIL_COND(p_event.is_null());
+
 	Ref<InputEventKey> k = p_event;
 
 	bool is_command = k.is_valid() && k->get_command();


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/70097

Same fix as done in https://github.com/godotengine/godot/pull/69246 for the same problem in other nodes.