### PR TITLE
Fix "p_zfar" to "p_znear" in Projection.create_orthogonal

### DIFF
--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -134,7 +134,7 @@ Projection Projection::create_for_hmd(int p_eye, real_t p_aspect, real_t p_intra
 
 Projection Projection::create_orthogonal(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_znear, real_t p_zfar) {
 	Projection proj;
-	proj.set_orthogonal(p_left, p_right, p_bottom, p_top, p_zfar, p_zfar);
+	proj.set_orthogonal(p_left, p_right, p_bottom, p_top, p_znear, p_zfar);
 	return proj;
 }
 


### PR DESCRIPTION
Was confused why it always gave inf:s.
