### PR TITLE
Fix `GDScript::_get_gdscript_from_variant()` crash

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1288,15 +1288,10 @@ String GDScript::_get_gdscript_reference_class_name(const GDScript *p_gdscript) 
 }
 
 GDScript *GDScript::_get_gdscript_from_variant(const Variant &p_variant) {
-	Variant::Type type = p_variant.get_type();
-	if (type != Variant::Type::OBJECT)
-		return nullptr;
-
 	Object *obj = p_variant;
-	if (obj == nullptr) {
+	if (obj == nullptr || obj->get_instance_id().is_null()) {
 		return nullptr;
 	}
-
 	return Object::cast_to<GDScript>(obj);
 }
 


### PR DESCRIPTION
The crash would happen, theoretically, when getting the type of a invalid or null variant.

As I couldn't reproduce #70081, I cannot be 100% sure it fixes it, but at least `GDScript::_get_gdscript_from_variant()` will be more resilient.

Fixes #70081 - GDScript-related crash on exiting the editor