### PR TITLE
Silence `Input.vibrate_handheld()` warning as it's already documented

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -155,10 +155,6 @@ int OS::get_process_id() const {
 	return -1;
 }
 
-void OS::vibrate_handheld(int p_duration_ms) {
-	WARN_PRINT("vibrate_handheld() only works with Android, iOS and Web");
-}
-
 bool OS::is_stdout_verbose() const {
 	return _verbose_stdout;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -159,7 +159,7 @@ public:
 	virtual Error kill(const ProcessID &p_pid) = 0;
 	virtual int get_process_id() const;
 	virtual bool is_process_running(const ProcessID &p_pid) const = 0;
-	virtual void vibrate_handheld(int p_duration_ms = 500);
+	virtual void vibrate_handheld(int p_duration_ms = 500) {}
 
 	virtual Error shell_open(String p_uri);
 	virtual Error set_cwd(const String &p_cwd);

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -339,7 +339,7 @@
 			<param index="2" name="strong_magnitude" type="float" />
 			<param index="3" name="duration" type="float" default="0" />
 			<description>
-				Starts to vibrate the joypad. Joypads usually come with two rumble motors, a strong and a weak one. [param weak_magnitude] is the strength of the weak motor (between 0 and 1) and [param strong_magnitude] is the strength of the strong motor (between 0 and 1). [param duration] is the duration of the effect in seconds (a duration of 0 will try to play the vibration indefinitely).
+				Starts to vibrate the joypad. Joypads usually come with two rumble motors, a strong and a weak one. [param weak_magnitude] is the strength of the weak motor (between 0 and 1) and [param strong_magnitude] is the strength of the strong motor (between 0 and 1). [param duration] is the duration of the effect in seconds (a duration of 0 will try to play the vibration indefinitely). The vibration can be stopped early by calling [method stop_joy_vibration].
 				[b]Note:[/b] Not every hardware is compatible with long effect durations; it is recommended to restart an effect if it has to be played for more than a few seconds.
 			</description>
 		</method>
@@ -347,18 +347,18 @@
 			<return type="void" />
 			<param index="0" name="device" type="int" />
 			<description>
-				Stops the vibration of the joypad.
+				Stops the vibration of the joypad started with [method start_joy_vibration].
 			</description>
 		</method>
 		<method name="vibrate_handheld">
 			<return type="void" />
 			<param index="0" name="duration_ms" type="int" default="500" />
 			<description>
-				Vibrate handheld devices.
-				[b]Note:[/b] This method is implemented on Android, iOS, and Web.
-				[b]Note:[/b] For Android, it requires enabling the [code]VIBRATE[/code] permission in the export preset.
-				[b]Note:[/b] For iOS, specifying the duration is supported in iOS 13 and later.
-				[b]Note:[/b] Some web browsers such as Safari and Firefox for Android do not support this method.
+				Vibrate the handheld device for the specified duration in milliseconds.
+				[b]Note:[/b] This method is implemented on Android, iOS, and Web. It has no effect on other platforms.
+				[b]Note:[/b] For Android, [method vibrate_handheld] requires enabling the [code]VIBRATE[/code] permission in the export preset. Otherwise, [method vibrate_handheld] will have no effect.
+				[b]Note:[/b] For iOS, specifying the duration is only supported in iOS 13 and later.
+				[b]Note:[/b] Some web browsers such as Safari and Firefox for Android do not support [method vibrate_handheld].
 			</description>
 		</method>
 		<method name="warp_mouse">


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/69831.

The warning causes messages to be spammed if you are calling this method in a game that runs on both desktop and mobile platforms, unless you guard all calls to `Input.vibrate_handheld()` with `OS.has_feature("mobile") or OS.has_feature("web")`.

Since the limitation is already documented (and is obvious enough given the method's name), the warning message is redundant.