### PR TITLE
OpenXR: fix action map editor crash on save / reset

### DIFF
--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -57,7 +57,7 @@ void OpenXRActionMapEditor::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
 			for (int i = 0; i < tabs->get_child_count(); i++) {
-				Control *tab = static_cast<Control *>(tabs->get_child(i));
+				Control *tab = Object::cast_to<Control>(tabs->get_child(i));
 				if (tab) {
 					tab->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 				}
@@ -208,7 +208,7 @@ void OpenXRActionMapEditor::_on_remove_action_set(Object *p_action_set_editor) {
 void OpenXRActionMapEditor::_on_action_removed() {
 	for (int i = 0; i < tabs->get_tab_count(); i++) {
 		// First tab won't be an interaction profile editor, but being thorough..
-		OpenXRInteractionProfileEditorBase *interaction_profile_editor = static_cast<OpenXRInteractionProfileEditorBase *>(tabs->get_tab_control(i));
+		OpenXRInteractionProfileEditorBase *interaction_profile_editor = Object::cast_to<OpenXRInteractionProfileEditorBase>(tabs->get_tab_control(i));
 		if (interaction_profile_editor) {
 		}
 	}
@@ -309,7 +309,7 @@ void OpenXRActionMapEditor::_on_tabs_tab_changed(int p_tab) {
 }
 
 void OpenXRActionMapEditor::_on_tab_button_pressed(int p_tab) {
-	OpenXRInteractionProfileEditorBase *interaction_profile_editor = static_cast<OpenXRInteractionProfileEditorBase *>(tabs->get_tab_control(p_tab));
+	OpenXRInteractionProfileEditorBase *interaction_profile_editor = Object::cast_to<OpenXRInteractionProfileEditorBase>(tabs->get_tab_control(p_tab));
 	ERR_FAIL_NULL(interaction_profile_editor);
 
 	undo_redo->create_action(TTR("Remove interaction profile"));
@@ -375,9 +375,9 @@ void OpenXRActionMapEditor::_clear_action_map() {
 		child->queue_free();
 	}
 
-	for (int i = 0; i < tabs->get_tab_count(); i++) {
+	for (int i = tabs->get_tab_count() - 1; i >= 0; --i) {
 		// First tab won't be an interaction profile editor, but being thorough..
-		OpenXRInteractionProfileEditorBase *interaction_profile_editor = static_cast<OpenXRInteractionProfileEditorBase *>(tabs->get_tab_control(i));
+		OpenXRInteractionProfileEditorBase *interaction_profile_editor = Object::cast_to<OpenXRInteractionProfileEditorBase>(tabs->get_tab_control(i));
 		if (interaction_profile_editor) {
 			tabs->remove_child(interaction_profile_editor);
 			interaction_profile_editor->queue_free();

--- a/modules/openxr/editor/openxr_interaction_profile_editor.cpp
+++ b/modules/openxr/editor/openxr_interaction_profile_editor.cpp
@@ -308,7 +308,7 @@ void OpenXRInteractionProfileEditor::_update_interaction_profile() {
 
 void OpenXRInteractionProfileEditor::_theme_changed() {
 	for (int i = 0; i < main_hb->get_child_count(); i++) {
-		Control *panel = static_cast<Control *>(main_hb->get_child(i));
+		Control *panel = Object::cast_to<Control>(main_hb->get_child(i));
 		if (panel) {
 			panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")));
 		}

--- a/modules/openxr/editor/openxr_select_action_dialog.cpp
+++ b/modules/openxr/editor/openxr_select_action_dialog.cpp
@@ -47,7 +47,7 @@ void OpenXRSelectActionDialog::_notification(int p_what) {
 void OpenXRSelectActionDialog::_on_select_action(const String p_action) {
 	if (selected_action != "") {
 		NodePath button_path = action_buttons[selected_action];
-		Button *button = static_cast<Button *>(get_node(button_path));
+		Button *button = Object::cast_to<Button>(get_node(button_path));
 		if (button != nullptr) {
 			button->set_flat(true);
 		}
@@ -57,7 +57,7 @@ void OpenXRSelectActionDialog::_on_select_action(const String p_action) {
 
 	if (selected_action != "") {
 		NodePath button_path = action_buttons[selected_action];
-		Button *button = static_cast<Button *>(get_node(button_path));
+		Button *button = Object::cast_to<Button>(get_node(button_path));
 		if (button != nullptr) {
 			button->set_flat(false);
 		}

--- a/modules/openxr/editor/openxr_select_interaction_profile_dialog.cpp
+++ b/modules/openxr/editor/openxr_select_interaction_profile_dialog.cpp
@@ -46,7 +46,7 @@ void OpenXRSelectInteractionProfileDialog::_notification(int p_what) {
 void OpenXRSelectInteractionProfileDialog::_on_select_interaction_profile(const String p_interaction_profile) {
 	if (selected_interaction_profile != "") {
 		NodePath button_path = ip_buttons[selected_interaction_profile];
-		Button *button = static_cast<Button *>(get_node(button_path));
+		Button *button = Object::cast_to<Button>(get_node(button_path));
 		if (button != nullptr) {
 			button->set_flat(true);
 		}
@@ -56,7 +56,7 @@ void OpenXRSelectInteractionProfileDialog::_on_select_interaction_profile(const 
 
 	if (selected_interaction_profile != "") {
 		NodePath button_path = ip_buttons[selected_interaction_profile];
-		Button *button = static_cast<Button *>(get_node(button_path));
+		Button *button = Object::cast_to<Button>(get_node(button_path));
 		if (button != nullptr) {
 			button->set_flat(false);
 		}


### PR DESCRIPTION
This PR replaces static casts that are known to not always be permissible and fixes an enumeration to fix the action map editor crashing and/or displaying additional copies of profiles when saving or resetting the action maps.

@BastiaanOlij could you review?

I also saw quite a few other casts that look potentially suspect (static_cast followed by null check), but did not experience crashes coming from them casting invalid things. I assume they are intentional?