### PR TITLE
Don't attempt to create or use an R8_UINT texture as storage if VRS is not supported

### DIFF
--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -3496,6 +3496,10 @@ void GI::init(SkyRD *p_sky) {
 	{
 		//calculate tables
 		String defines = "\n#define SDFGI_OCT_SIZE " + itos(SDFGI::LIGHTPROBE_OCT_SIZE) + "\n";
+		if (RendererSceneRenderRD::get_singleton()->is_vrs_supported()) {
+			defines += "\n#define USE_VRS\n";
+		}
+
 		Vector<String> gi_modes;
 
 		gi_modes.push_back("\n#define USE_VOXEL_GI_INSTANCES\n"); // MODE_VOXEL_GI
@@ -4011,7 +4015,7 @@ void GI::process_gi(Ref<RenderSceneBuffersRD> p_render_buffers, const RID *p_nor
 				u.append_id(rbgi->scene_data_ubo);
 				uniforms.push_back(u);
 			}
-			{
+			if (RendererSceneRenderRD::get_singleton()->is_vrs_supported()) {
 				RD::Uniform u;
 				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 19;

--- a/servers/rendering/renderer_rd/shaders/environment/gi.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/gi.glsl
@@ -108,7 +108,9 @@ layout(set = 0, binding = 18, std140) uniform SceneData {
 }
 scene_data;
 
+#ifdef USE_VRS
 layout(r8ui, set = 0, binding = 19) uniform restrict readonly uimage2D vrs_buffer;
+#endif
 
 layout(push_constant, std430) uniform Params {
 	uint max_voxel_gi_instances;
@@ -661,6 +663,7 @@ void main() {
 	ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
 
 	uint vrs_x, vrs_y;
+#ifdef USE_VRS
 	if (sc_use_vrs) {
 		ivec2 vrs_pos;
 
@@ -684,6 +687,7 @@ void main() {
 			return;
 		}
 	}
+#endif
 
 	if (sc_half_res) {
 		pos <<= 1;
@@ -708,6 +712,7 @@ void main() {
 	imageStore(ambient_buffer, pos, ambient_light);
 	imageStore(reflection_buffer, pos, reflection_light);
 
+#ifdef USE_VRS
 	if (sc_use_vrs) {
 		if (vrs_x > 1) {
 			imageStore(ambient_buffer, pos + ivec2(1, 0), ambient_light);
@@ -766,4 +771,5 @@ void main() {
 			imageStore(reflection_buffer, pos + ivec2(3, 3), reflection_light);
 		}
 	}
+#endif
 }

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -419,11 +419,12 @@ TextureStorage::TextureStorage() {
 		tformat.format = RD::DATA_FORMAT_R8_UINT;
 		tformat.width = 4;
 		tformat.height = 4;
-		tformat.usage_bits = RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
-		if (RD::get_singleton()->has_feature(RD::SUPPORTS_ATTACHMENT_VRS)) {
-			tformat.usage_bits |= RD::TEXTURE_USAGE_VRS_ATTACHMENT_BIT;
-		}
+		tformat.usage_bits = RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT | RD::TEXTURE_USAGE_VRS_ATTACHMENT_BIT;
 		tformat.texture_type = RD::TEXTURE_TYPE_2D;
+		if (!RD::get_singleton()->has_feature(RD::SUPPORTS_ATTACHMENT_VRS)) {
+			tformat.usage_bits = RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
+			tformat.format = RD::DATA_FORMAT_R8_UNORM;
+		}
 
 		Vector<uint8_t> pv;
 		pv.resize(4 * 4);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/67430

I can't reproduce the original issue so I changed the rendering device code to always return VRS not supported and to always fail when trying to allocate an R8_UINT texture. Would be good to have testing from @BastiaanOlij and some of the users who were able to reproduce the original error