### PR TITLE
Run `XRServer::pre_render` before emitting `frame_pre_draw`

### DIFF
--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -636,9 +636,6 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 	Ref<XRInterface> xr_interface;
 	XRServer *xr_server = XRServer::get_singleton();
 	if (xr_server != nullptr) {
-		// let our XR server know we're about to render our frames so we can get our frame timing
-		xr_server->pre_render();
-
 		// retrieve the interface responsible for rendering
 		xr_interface = xr_server->get_primary_interface();
 	}

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -69,6 +69,13 @@ void RenderingServerDefault::request_frame_drawn_callback(const Callable &p_call
 }
 
 void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
+#ifndef _3D_DISABLED
+	XRServer *xr_server = XRServer::get_singleton();
+	if (xr_server != nullptr) {
+		// let our XR server know we're about to render our frames so we can get our frame timing
+		xr_server->pre_render();
+	}
+#endif // _3D_DISABLED
 	//needs to be done before changes is reset to 0, to not force the editor to redraw
 	RS::get_singleton()->emit_signal(SNAME("frame_pre_draw"));
 
@@ -92,15 +99,6 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 	RSG::canvas_render->update();
 
 	RSG::rasterizer->end_frame(p_swap_buffers);
-
-#ifndef _3D_DISABLED
-	XRServer *xr_server = XRServer::get_singleton();
-	if (xr_server != nullptr) {
-		// let our XR server know we're done so we can get our frame timing
-		xr_server->end_frame();
-	}
-#endif // _3D_DISABLED
-
 	RSG::canvas->update_visibility_notifiers();
 	RSG::scene->update_visibility_notifiers();
 


### PR DESCRIPTION
This is required to be able to use the HMD position from the `frame_pre_draw` signal in scripts.

An example usecase is making a simple portal or mirror using the Camera3D frustum mode. Currently this is not possible in XR without potentially having an old HMD position.

Needed by https://github.com/V-Sekai/avatar_vr_demo to avoid a 1 frame delay. This bug requires a mirror script and player controller to observe, which is in this project.