### PR TITLE
Add MethodInfo to signal datatype

### DIFF
--- a/modules/gdscript/tests/scripts/analyzer/errors/assign_signal.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/assign_signal.gd
@@ -1,0 +1,4 @@
+signal your_base
+signal my_base
+func test():
+	your_base = my_base

--- a/modules/gdscript/tests/scripts/analyzer/errors/assign_signal.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/assign_signal.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot assign a new value to a constant.


### PR DESCRIPTION
Fixes #62645 and is more general than its current proposed solution #62660.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
