### PR TITLE
Add ratio to cpu particles to dynamically change amount emitted

### DIFF
--- a/doc/classes/CPUParticles2D.xml
+++ b/doc/classes/CPUParticles2D.xml
@@ -89,6 +89,11 @@
 		<member name="amount" type="int" setter="set_amount" getter="get_amount" default="8">
 			Number of particles emitted in one emission cycle.
 		</member>
+		<member name="amount_ratio" type="float" setter="set_amount_ratio" getter="get_amount_ratio" default="1.0">
+			Amount Ratio multiplied by [member amount] is how many particles will be emmitted each cycle. This value is to be adjusted while emitting particles as it will not clear the existing particles.
+			When not used leave this ratio at 1 and adjust amount accordingly.
+			Setting this value to zero will clear [member emitting] flag, increasing it from zero will set emitting.
+		</member>
 		<member name="angle_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's rotation will be animated along this [Curve].
 		</member>

--- a/doc/classes/CPUParticles3D.xml
+++ b/doc/classes/CPUParticles3D.xml
@@ -88,6 +88,11 @@
 		<member name="amount" type="int" setter="set_amount" getter="get_amount" default="8">
 			Number of particles emitted in one emission cycle.
 		</member>
+		<member name="amount_ratio" type="float" setter="set_amount_ratio" getter="get_amount_ratio" default="1.0">
+			Amount Ratio multiplied by [member amount] is how many particles will be emmitted each cycle. This value is to be adjusted while emitting particles as it will not clear the existing particles.
+			When not used leave this ratio at 1 and adjust amount accordingly.
+			Setting this value to zero will clear [member emitting] flag, increasing it from zero will set emitting.
+		</member>
 		<member name="angle_curve" type="Curve" setter="set_param_curve" getter="get_param_curve">
 			Each particle's rotation will be animated along this [Curve].
 		</member>

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -86,6 +86,8 @@ private:
 		real_t rotation = 0.0;
 		Vector2 velocity;
 		bool active = false;
+		bool stopping = false;
+		bool stopped = false;
 		real_t angle_rand = 0.0;
 		real_t scale_rand = 0.0;
 		real_t hue_rot_rand = 0.0;
@@ -131,6 +133,7 @@ private:
 
 	bool one_shot = false;
 
+	float amount_ratio = 1;
 	double lifetime = 1.0;
 	double pre_process_time = 0.0;
 	real_t explosiveness_ratio = 0.0;
@@ -198,6 +201,7 @@ protected:
 public:
 	void set_emitting(bool p_emitting);
 	void set_amount(int p_amount);
+	void set_amount_ratio(float p_amount_ratio);
 	void set_lifetime(double p_lifetime);
 	void set_one_shot(bool p_one_shot);
 	void set_pre_process_time(double p_time);
@@ -209,6 +213,7 @@ public:
 
 	bool is_emitting() const;
 	int get_amount() const;
+	float get_amount_ratio() const;
 	double get_lifetime() const;
 	bool get_one_shot() const;
 	double get_pre_process_time() const;

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -73,6 +73,32 @@ void CPUParticles3D::set_amount(int p_amount) {
 	RS::get_singleton()->multimesh_allocate_data(multimesh, p_amount, RS::MULTIMESH_TRANSFORM_3D, true, true);
 
 	particle_order.resize(p_amount);
+	set_amount_ratio(amount_ratio);
+}
+
+void CPUParticles3D::set_amount_ratio(float p_amount_ratio) {
+	if (p_amount_ratio == 0) {
+		set_emitting(false);
+	} else if (!emitting && amount_ratio == 0) {
+		set_emitting(true);
+	}
+
+	amount_ratio = p_amount_ratio;
+
+	float tot = 1;
+	int pcount = particles.size();
+	Particle *w = particles.ptrw();
+
+	for (int i = 0; i < pcount; i++) {
+		tot += amount_ratio;
+		w[i].stopped = false;
+		if (tot >= 1) {
+			w[i].stopping = false;
+			tot -= 1;
+		} else {
+			w[i].stopping = true;
+		}
+	}
 }
 
 void CPUParticles3D::set_lifetime(double p_lifetime) {
@@ -114,6 +140,10 @@ bool CPUParticles3D::is_emitting() const {
 
 int CPUParticles3D::get_amount() const {
 	return particles.size();
+}
+
+float CPUParticles3D::get_amount_ratio() const {
+	return amount_ratio;
 }
 
 double CPUParticles3D::get_lifetime() const {
@@ -673,6 +703,10 @@ void CPUParticles3D::_particles_process(double p_delta) {
 	for (int i = 0; i < pcount; i++) {
 		Particle &p = parray[i];
 
+		if (p.stopped) {
+			continue;
+		}
+
 		if (!emitting && !p.active) {
 			continue;
 		}
@@ -731,6 +765,12 @@ void CPUParticles3D::_particles_process(double p_delta) {
 		float tv = 0.0;
 
 		if (restart) {
+			if (p.stopping) {
+				p.stopped = true;
+				p.active = false;
+				continue;
+			}
+
 			if (!emitting) {
 				p.active = false;
 				continue;
@@ -1410,6 +1450,7 @@ void CPUParticles3D::convert_from_particles(Node *p_particles) {
 void CPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emitting", "emitting"), &CPUParticles3D::set_emitting);
 	ClassDB::bind_method(D_METHOD("set_amount", "amount"), &CPUParticles3D::set_amount);
+	ClassDB::bind_method(D_METHOD("set_amount_ratio", "amount_ratio"), &CPUParticles3D::set_amount_ratio);
 	ClassDB::bind_method(D_METHOD("set_lifetime", "secs"), &CPUParticles3D::set_lifetime);
 	ClassDB::bind_method(D_METHOD("set_one_shot", "enable"), &CPUParticles3D::set_one_shot);
 	ClassDB::bind_method(D_METHOD("set_pre_process_time", "secs"), &CPUParticles3D::set_pre_process_time);
@@ -1423,6 +1464,7 @@ void CPUParticles3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("is_emitting"), &CPUParticles3D::is_emitting);
 	ClassDB::bind_method(D_METHOD("get_amount"), &CPUParticles3D::get_amount);
+	ClassDB::bind_method(D_METHOD("get_amount_ratio"), &CPUParticles3D::get_amount_ratio);
 	ClassDB::bind_method(D_METHOD("get_lifetime"), &CPUParticles3D::get_lifetime);
 	ClassDB::bind_method(D_METHOD("get_one_shot"), &CPUParticles3D::get_one_shot);
 	ClassDB::bind_method(D_METHOD("get_pre_process_time"), &CPUParticles3D::get_pre_process_time);
@@ -1445,6 +1487,7 @@ void CPUParticles3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_RANGE, "1,1000000,1,exp"), "set_amount", "get_amount");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "amount_ratio", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_amount_ratio", "get_amount_ratio");
 	ADD_GROUP("Time", "");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "lifetime", PROPERTY_HINT_RANGE, "0.01,600.0,0.01,or_greater,exp,suffix:s"), "set_lifetime", "get_lifetime");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "one_shot"), "set_one_shot", "get_one_shot");
@@ -1658,6 +1701,7 @@ CPUParticles3D::CPUParticles3D() {
 
 	set_emitting(true);
 	set_amount(8);
+	set_amount_ratio(1);
 
 	set_param_min(PARAM_INITIAL_LINEAR_VELOCITY, 0);
 	set_param_min(PARAM_ANGULAR_VELOCITY, 0);

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -88,6 +88,8 @@ private:
 		real_t custom[4] = {};
 		Vector3 velocity;
 		bool active = false;
+		bool stopping = false;
+		bool stopped = false;
 		real_t angle_rand = 0.0;
 		real_t scale_rand = 0.0;
 		real_t hue_rot_rand = 0.0;
@@ -132,6 +134,7 @@ private:
 
 	bool one_shot = false;
 
+	float amount_ratio = 1;
 	double lifetime = 1.0;
 	double pre_process_time = 0.0;
 	real_t explosiveness_ratio = 0.0;
@@ -205,6 +208,7 @@ public:
 
 	void set_emitting(bool p_emitting);
 	void set_amount(int p_amount);
+	void set_amount_ratio(float p_amount_ratio);
 	void set_lifetime(double p_lifetime);
 	void set_one_shot(bool p_one_shot);
 	void set_pre_process_time(double p_time);
@@ -216,6 +220,7 @@ public:
 
 	bool is_emitting() const;
 	int get_amount() const;
+	float get_amount_ratio() const;
 	double get_lifetime() const;
 	bool get_one_shot() const;
 	double get_pre_process_time() const;


### PR DESCRIPTION
This commit adds a ratio slider expressed in percentage to the cpu particles so that users can dynamically adjusts the amount of emitted particles without clearing or resetting the existing particles.

A new property ratio is added
Two extra bool properties are added to the particle array to control processing of the particles

Setting the ratio clears the stopped flag and evenly distributes which particles should be stopped by setting a stopping flag or clearing it for other particles that should keep running
Each particle continues its life until it restarts
When the particle is restarted the stopping flag is checked, if true the stopped flag is set

It will always submit at least 1 particle.

Another option maybe to:
1. Clear emitting when ratio is set 0% and when raised above 0% set emitting
2. Use integer math instead of float
3. Increase ratio precision

![image](https://user-images.githubusercontent.com/1736172/208085652-8cb4f321-0ecd-4e80-b88b-1ed5af29f2b0.png)

This is my first commit and pull request

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/5939.*