### PR TITLE
Remove conditons for unfolding inspector sections

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1374,38 +1374,22 @@ void EditorInspectorSection::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_DRAG_BEGIN: {
-			Dictionary dd = get_viewport()->gui_get_drag_data();
-
-			// Only allow dropping if the section contains properties which can take the dragged data.
-			bool children_can_drop = false;
-			for (int child_idx = 0; child_idx < vbox->get_child_count(); child_idx++) {
-				Control *editor_property = Object::cast_to<Control>(vbox->get_child(child_idx));
-
-				// Test can_drop_data and can_drop_data_fw, since can_drop_data only works if set up with forwarding or if script attached.
-				if (editor_property && (editor_property->can_drop_data(Point2(), dd) || editor_property->call("_can_drop_data_fw", Point2(), dd, this))) {
-					children_can_drop = true;
-					break;
-				}
-			}
-
-			dropping = children_can_drop;
-			queue_redraw();
+			dropping_for_unfold = true;
 		} break;
 
 		case NOTIFICATION_DRAG_END: {
-			dropping = false;
-			queue_redraw();
+			dropping_for_unfold = false;
 		} break;
 
 		case NOTIFICATION_MOUSE_ENTER: {
-			if (dropping) {
+			if (dropping || dropping_for_unfold) {
 				dropping_unfold_timer->start();
 			}
 			queue_redraw();
 		} break;
 
 		case NOTIFICATION_MOUSE_EXIT: {
-			if (dropping) {
+			if (dropping || dropping_for_unfold) {
 				dropping_unfold_timer->stop();
 			}
 			queue_redraw();

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -276,6 +276,7 @@ class EditorInspectorSection : public Container {
 
 	Timer *dropping_unfold_timer = nullptr;
 	bool dropping = false;
+	bool dropping_for_unfold = false;
 
 	HashSet<StringName> revertable_properties;
 


### PR DESCRIPTION
Fixes #56225

The condition was supposed to determine if there is a valid property inside the section that can be dropped to, but it was very lacking. A proper condition would be much more complex and would have to handle different edge cases, like nested sub-resources. It could still be implemented in the future (IMO it's not really needed tho), but for now it's better to have the feature work at all. So dragging over a section will now always unfold it, which is intuitive behavior tbh.