### PR TITLE
Fix: Profiler and Visual Profiler start/stop state inconsistency

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -106,7 +106,7 @@ void EditorProfiler::clear() {
 	seeking = false;
 
 	// Ensure button text (start, stop) is correct
-	_set_button_text();
+	_update_button_text();
 	emit_signal(SNAME("enable_profiling"), activate->is_pressed());
 }
 
@@ -376,7 +376,7 @@ void EditorProfiler::_update_frame() {
 	updating_frame = false;
 }
 
-void EditorProfiler::_set_button_text() {
+void EditorProfiler::_update_button_text() {
 	if (activate->is_pressed()) {
 		activate->set_icon(get_theme_icon(SNAME("Stop"), SNAME("EditorIcons")));
 		activate->set_text(TTR("Stop"));
@@ -387,7 +387,7 @@ void EditorProfiler::_set_button_text() {
 }
 
 void EditorProfiler::_activate_pressed() {
-	_set_button_text();
+	_update_button_text();
 
 	if (activate->is_pressed()) {
 		_clear_pressed();
@@ -510,11 +510,15 @@ void EditorProfiler::_bind_methods() {
 }
 
 void EditorProfiler::set_enabled(bool p_enable, bool p_clear) {
-	activate->set_pressed(false);
 	activate->set_disabled(!p_enable);
 	if (p_clear) {
 		clear();
 	}
+}
+
+void EditorProfiler::set_pressed(bool p_pressed) {
+	activate->set_pressed(p_pressed);
+	_update_button_text();
 }
 
 bool EditorProfiler::is_profiling() {
@@ -595,6 +599,7 @@ EditorProfiler::EditorProfiler() {
 	add_child(hb);
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
+	activate->set_disabled(true);
 	activate->set_text(TTR("Start"));
 	activate->connect("pressed", callable_mp(this, &EditorProfiler::_activate_pressed));
 	hb->add_child(activate);

--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -122,7 +122,7 @@ private:
 	Timer *frame_delay = nullptr;
 	Timer *plot_delay = nullptr;
 
-	void _set_button_text();
+	void _update_button_text();
 	void _update_frame();
 
 	void _activate_pressed();
@@ -155,6 +155,7 @@ protected:
 public:
 	void add_frame_metric(const Metric &p_metric, bool p_final = false);
 	void set_enabled(bool p_enable, bool p_clear = true);
+	void set_pressed(bool p_pressed);
 	bool is_profiling();
 	bool is_seeking() { return seeking; }
 	void disable_seeking();

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -66,6 +66,7 @@ void EditorVisualProfiler::add_frame_metric(const Metric &p_metric) {
 	}
 
 	updating_frame = true;
+	clear_button->set_disabled(false);
 	cursor_metric_edit->set_max(frame_metrics[last_metric].frame_number);
 	cursor_metric_edit->set_min(MAX(frame_metrics[last_metric].frame_number - frame_metrics.size(), 0u));
 
@@ -408,6 +409,7 @@ void EditorVisualProfiler::_activate_pressed() {
 		activate->set_icon(get_theme_icon(SNAME("Stop"), SNAME("EditorIcons")));
 		activate->set_text(TTR("Stop"));
 		_clear_pressed(); //always clear on start
+		clear_button->set_disabled(false);
 	} else {
 		activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
 		activate->set_text(TTR("Start"));
@@ -416,6 +418,7 @@ void EditorVisualProfiler::_activate_pressed() {
 }
 
 void EditorVisualProfiler::_clear_pressed() {
+	clear_button->set_disabled(true);
 	clear();
 	_update_plot();
 }
@@ -647,8 +650,23 @@ void EditorVisualProfiler::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("enable_profiling", PropertyInfo(Variant::BOOL, "enable")));
 }
 
+void EditorVisualProfiler::_update_button_text() {
+	if (activate->is_pressed()) {
+		activate->set_icon(get_theme_icon(SNAME("Stop"), SNAME("EditorIcons")));
+		activate->set_text(TTR("Stop"));
+	} else {
+		activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
+		activate->set_text(TTR("Start"));
+	}
+}
+
 void EditorVisualProfiler::set_enabled(bool p_enable) {
 	activate->set_disabled(!p_enable);
+}
+
+void EditorVisualProfiler::set_pressed(bool p_pressed) {
+	activate->set_pressed(p_pressed);
+	_update_button_text();
 }
 
 bool EditorVisualProfiler::is_profiling() {
@@ -714,12 +732,14 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	add_child(hb);
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
+	activate->set_disabled(true);
 	activate->set_text(TTR("Start"));
 	activate->connect("pressed", callable_mp(this, &EditorVisualProfiler::_activate_pressed));
 	hb->add_child(activate);
 
 	clear_button = memnew(Button);
 	clear_button->set_text(TTR("Clear"));
+	clear_button->set_disabled(true);
 	clear_button->connect("pressed", callable_mp(this, &EditorVisualProfiler::_clear_pressed));
 	hb->add_child(clear_button);
 

--- a/editor/debugger/editor_visual_profiler.h
+++ b/editor/debugger/editor_visual_profiler.h
@@ -101,6 +101,8 @@ private:
 	Timer *frame_delay = nullptr;
 	Timer *plot_delay = nullptr;
 
+	void _update_button_text();
+
 	void _update_frame(bool p_focus_selected = false);
 
 	void _activate_pressed();
@@ -133,6 +135,7 @@ protected:
 public:
 	void add_frame_metric(const Metric &p_metric);
 	void set_enabled(bool p_enable);
+	void set_pressed(bool p_pressed);
 	bool is_profiling();
 	bool is_seeking() { return seeking; }
 	void disable_seeking();

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -319,6 +319,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 			tabs->set_current_tab(0);
 		}
 		profiler->set_enabled(false, false);
+		visual_profiler->set_enabled(false);
 		inspector->clear_cache(); // Take a chance to force remote objects update.
 
 	} else if (p_msg == "debug_exit") {
@@ -328,8 +329,12 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		_update_buttons_state();
 		_set_reason_text(TTR("Execution resumed."), MESSAGE_SUCCESS);
 		emit_signal(SNAME("breaked"), false, false, "", false);
+
 		profiler->set_enabled(true, false);
 		profiler->disable_seeking();
+
+		visual_profiler->set_enabled(true);
+
 	} else if (p_msg == "set_pid") {
 		ERR_FAIL_COND(p_data.size() < 1);
 		remote_pid = p_data[0];
@@ -901,6 +906,7 @@ void ScriptEditorDebugger::start(Ref<RemoteDebuggerPeer> p_peer) {
 	stop();
 
 	profiler->set_enabled(true, true);
+	visual_profiler->set_enabled(true);
 
 	peer = p_peer;
 	ERR_FAIL_COND(p_peer.is_null());
@@ -957,7 +963,11 @@ void ScriptEditorDebugger::stop() {
 	res_path_cache.clear();
 	profiler_signature.clear();
 
-	profiler->set_enabled(true, false);
+	profiler->set_enabled(false, false);
+	profiler->set_pressed(false);
+
+	visual_profiler->set_enabled(false);
+	visual_profiler->set_pressed(false);
 
 	inspector->edit(nullptr);
 	_update_buttons_state();


### PR DESCRIPTION
Fix: #70143 
Fix: #65209 

This is my Fix according to my understanding of the issues

- **Star**t buttons are disabled (grey out) if not running the program (default).
- **Start/Stop** buttons are enabled when run the program.
- **Start/Stop** buttons are disabled (grey out) when pause the program.
- Pressing **Start** buttons will change to **Stop** and vice visa
-  Stopping the program will reset **Stop** button to **Start** and disable the button.

also changes to the Clear button in "Visual Profiler" to be the same behavior with Profiler's Clear button.