### PR TITLE
Initial tests for node

### DIFF
--- a/tests/scene/test_node.h
+++ b/tests/scene/test_node.h
@@ -1,0 +1,415 @@
+/*************************************************************************/
+/*  test_node.h                                                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEST_NODE_H
+#define TEST_NODE_H
+
+#include "scene/main/node.h"
+
+#include "tests/test_macros.h"
+
+namespace TestNode {
+
+TEST_CASE("[SceneTree][Node] Simple Add/Remove/Move/Find") {
+	Node *node = memnew(Node);
+
+	// Check initial scene tree setup.
+	CHECK_EQ(SceneTree::get_singleton()->get_root()->get_child_count(), 0);
+	CHECK_EQ(SceneTree::get_singleton()->get_node_count(), 1);
+
+	// Check initial node setup.
+	CHECK(node->get_name() == StringName());
+	CHECK_FALSE(node->is_inside_tree());
+	CHECK_EQ(node->get_parent(), nullptr);
+	ERR_PRINT_OFF;
+	CHECK(node->get_path().is_empty());
+	ERR_PRINT_ON;
+	CHECK_EQ(node->get_child_count(), 0);
+
+	SceneTree::get_singleton()->get_root()->add_child(node);
+
+	CHECK_EQ(SceneTree::get_singleton()->get_root()->get_child_count(), 1);
+	CHECK_EQ(SceneTree::get_singleton()->get_node_count(), 2);
+
+	CHECK(node->get_name() != StringName());
+	CHECK(node->is_inside_tree());
+	CHECK_EQ(SceneTree::get_singleton()->get_root(), node->get_parent());
+	CHECK_FALSE(node->get_path().is_empty());
+	CHECK_EQ(node->get_child_count(), 0);
+
+	SUBCASE("Node should be accessible as first child") {
+		Node *child = SceneTree::get_singleton()->get_root()->get_child(0);
+		CHECK_EQ(child, node);
+	}
+
+	SUBCASE("Node should be accessible via the node path") {
+		Node *child_by_path = SceneTree::get_singleton()->get_root()->get_node_or_null(node->get_path());
+		CHECK_EQ(child_by_path, node);
+
+		child_by_path = SceneTree::get_singleton()->get_root()->get_node_or_null(NodePath("Node"));
+		CHECK_EQ(child_by_path, nullptr);
+
+		child_by_path = SceneTree::get_singleton()->get_root()->get_node_or_null(NodePath("/root/Node"));
+		CHECK_EQ(child_by_path, nullptr);
+
+		node->set_name("Node");
+
+		child_by_path = SceneTree::get_singleton()->get_root()->get_node_or_null(node->get_path());
+		CHECK_EQ(child_by_path, node);
+
+		child_by_path = SceneTree::get_singleton()->get_root()->get_node_or_null(NodePath("Node"));
+		CHECK_EQ(child_by_path, node);
+
+		child_by_path = SceneTree::get_singleton()->get_root()->get_node_or_null(NodePath("/root/Node"));
+		CHECK_EQ(child_by_path, node);
+	}
+
+	SUBCASE("Node should be accessible via group") {
+		List<Node *> nodes;
+		SceneTree::get_singleton()->get_nodes_in_group("nodes", &nodes);
+		CHECK(nodes.is_empty());
+
+		node->add_to_group("nodes");
+
+		SceneTree::get_singleton()->get_nodes_in_group("nodes", &nodes);
+		CHECK_EQ(nodes.size(), 1);
+		List<Node *>::Element *E = nodes.front();
+		CHECK_EQ(E->get(), node);
+	}
+
+	SUBCASE("Node should be possible to find") {
+		Node *child = SceneTree::get_singleton()->get_root()->find_child("Node", true, false);
+		CHECK_EQ(child, nullptr);
+
+		node->set_name("Node");
+
+		child = SceneTree::get_singleton()->get_root()->find_child("Node", true, false);
+		CHECK_EQ(child, node);
+	}
+
+	SUBCASE("Node should be possible to remove") {
+		SceneTree::get_singleton()->get_root()->remove_child(node);
+
+		CHECK_EQ(SceneTree::get_singleton()->get_root()->get_child_count(), 0);
+		CHECK_EQ(SceneTree::get_singleton()->get_node_count(), 1);
+
+		CHECK_FALSE(node->is_inside_tree());
+		CHECK_EQ(node->get_parent(), nullptr);
+		ERR_PRINT_OFF;
+		CHECK(node->get_path().is_empty());
+		ERR_PRINT_ON;
+	}
+
+	SUBCASE("Node should be possible to move") {
+		SceneTree::get_singleton()->get_root()->move_child(node, 0);
+
+		Node *child = SceneTree::get_singleton()->get_root()->get_child(0);
+		CHECK_EQ(child, node);
+		CHECK(node->is_inside_tree());
+	}
+
+	memdelete(node);
+}
+
+TEST_CASE("[SceneTree][Node] Nested Add/Remove/Move/Find") {
+	Node *node1 = memnew(Node);
+	Node *node2 = memnew(Node);
+	Node *node1_1 = memnew(Node);
+
+	SceneTree::get_singleton()->get_root()->add_child(node1);
+	SceneTree::get_singleton()->get_root()->add_child(node2);
+
+	node1->add_child(node1_1);
+
+	CHECK(node1_1->is_inside_tree());
+	CHECK_EQ(node1_1->get_parent(), node1);
+	CHECK_EQ(node1->get_child_count(), 1);
+
+	CHECK_EQ(SceneTree::get_singleton()->get_root()->get_child_count(), 2);
+	CHECK_EQ(SceneTree::get_singleton()->get_node_count(), 4);
+
+	SUBCASE("Nodes should be accessible via get_child(..)") {
+		Node *child1 = SceneTree::get_singleton()->get_root()->get_child(0);
+		CHECK_EQ(child1, node1);
+
+		Node *child2 = SceneTree::get_singleton()->get_root()->get_child(1);
+		CHECK_EQ(child2, node2);
+
+		Node *child1_1 = node1->get_child(0);
+		CHECK_EQ(child1_1, node1_1);
+	}
+
+	SUBCASE("Removed nodes should also remove their children from the scene tree") {
+		// Should also remove node1_1 from the scene tree.
+		SceneTree::get_singleton()->get_root()->remove_child(node1);
+
+		CHECK_EQ(node1->get_child_count(), 1);
+
+		CHECK_EQ(SceneTree::get_singleton()->get_root()->get_child_count(), 1);
+		CHECK_EQ(SceneTree::get_singleton()->get_node_count(), 2);
+
+		// First child should now be the second node.
+		Node *child1 = SceneTree::get_singleton()->get_root()->get_child(0);
+		CHECK_EQ(child1, node2);
+	}
+
+	SUBCASE("Removed children nodes should not affect their parent in the scene tree") {
+		node1->remove_child(node1_1);
+
+		CHECK_EQ(node1_1->get_parent(), nullptr);
+		CHECK_EQ(node1->get_child_count(), 0);
+
+		CHECK_EQ(SceneTree::get_singleton()->get_node_count(), 3);
+	}
+
+	SUBCASE("Nodes should be in the expected order when a node is moved to the back") {
+		SceneTree::get_singleton()->get_root()->move_child(node1, 1);
+
+		Node *child1 = SceneTree::get_singleton()->get_root()->get_child(0);
+		CHECK_EQ(child1, node2);
+
+		Node *child2 = SceneTree::get_singleton()->get_root()->get_child(1);
+		CHECK_EQ(child2, node1);
+	}
+
+	SUBCASE("Nodes should be in the expected order when a node is moved to the front") {
+		SceneTree::get_singleton()->get_root()->move_child(node2, 0);
+
+		Node *child1 = SceneTree::get_singleton()->get_root()->get_child(0);
+		CHECK_EQ(child1, node2);
+
+		Node *child2 = SceneTree::get_singleton()->get_root()->get_child(1);
+		CHECK_EQ(child2, node1);
+	}
+
+	SUBCASE("Nodes should be in the expected order when reparented") {
+		CHECK_EQ(node2->get_child_count(), 0);
+
+		node1->remove_child(node1_1);
+		CHECK_EQ(node1->get_child_count(), 0);
+		CHECK_EQ(node1_1->get_parent(), nullptr);
+
+		node2->add_child(node1_1);
+		CHECK_EQ(node2->get_child_count(), 1);
+		CHECK_EQ(node1_1->get_parent(), node2);
+
+		Node *child = node2->get_child(0);
+		CHECK_EQ(child, node1_1);
+
+		CHECK_EQ(SceneTree::get_singleton()->get_root()->get_child_count(), 2);
+		CHECK_EQ(SceneTree::get_singleton()->get_node_count(), 4);
+	}
+
+	SUBCASE("Nodes should be possible to find") {
+		Node *child = SceneTree::get_singleton()->get_root()->find_child("NestedNode", true, false);
+		CHECK_EQ(child, nullptr);
+
+		node1->set_name("Node1");
+		node2->set_name("Node2");
+		node1_1->set_name("NestedNode");
+
+		child = SceneTree::get_singleton()->get_root()->find_child("NestedNode", true, false);
+		CHECK_EQ(child, node1_1);
+
+		// First node that matches with the name is node1.
+		child = SceneTree::get_singleton()->get_root()->find_child("Node?", true, false);
+		CHECK_EQ(child, node1);
+
+		SceneTree::get_singleton()->get_root()->move_child(node2, 0);
+
+		// It should be node2, as it is now the first one in the tree.
+		child = SceneTree::get_singleton()->get_root()->find_child("Node?", true, false);
+		CHECK_EQ(child, node2);
+	}
+
+	SUBCASE("Nodes should be accessible via their node path") {
+		Node *child_by_path = SceneTree::get_singleton()->get_root()->get_node_or_null(node1->get_path());
+		CHECK_EQ(child_by_path, node1);
+
+		child_by_path = SceneTree::get_singleton()->get_root()->get_node_or_null(node2->get_path());
+		CHECK_EQ(child_by_path, node2);
+
+		child_by_path = SceneTree::get_singleton()->get_root()->get_node_or_null(node1_1->get_path());
+		CHECK_EQ(child_by_path, node1_1);
+
+		node1->set_name("Node1");
+		node1_1->set_name("NestedNode");
+
+		child_by_path = node1->get_node_or_null(NodePath("NestedNode"));
+		CHECK_EQ(child_by_path, node1_1);
+
+		child_by_path = SceneTree::get_singleton()->get_root()->get_node_or_null(NodePath("/root/Node1/NestedNode"));
+		CHECK_EQ(child_by_path, node1_1);
+
+		child_by_path = SceneTree::get_singleton()->get_root()->get_node_or_null(NodePath("Node1/NestedNode"));
+		CHECK_EQ(child_by_path, node1_1);
+	}
+
+	SUBCASE("Nodes should be accessible via their groups") {
+		List<Node *> nodes;
+		SceneTree::get_singleton()->get_nodes_in_group("nodes", &nodes);
+		CHECK(nodes.is_empty());
+
+		SceneTree::get_singleton()->get_nodes_in_group("other_nodes", &nodes);
+		CHECK(nodes.is_empty());
+
+		node1->add_to_group("nodes");
+		node2->add_to_group("other_nodes");
+		node1_1->add_to_group("nodes");
+		node1_1->add_to_group("other_nodes");
+
+		SceneTree::get_singleton()->get_nodes_in_group("nodes", &nodes);
+		CHECK_EQ(nodes.size(), 2);
+
+		List<Node *>::Element *E = nodes.front();
+		CHECK_EQ(E->get(), node1);
+		E = E->next();
+		CHECK_EQ(E->get(), node1_1);
+
+		// Clear and try again with the other group.
+		nodes.clear();
+
+		SceneTree::get_singleton()->get_nodes_in_group("other_nodes", &nodes);
+		CHECK_EQ(nodes.size(), 2);
+
+		E = nodes.front();
+		CHECK_EQ(E->get(), node1_1);
+		E = E->next();
+		CHECK_EQ(E->get(), node2);
+
+		// Clear and try again with the other group and one node removed.
+		nodes.clear();
+
+		node1->remove_from_group("nodes");
+		SceneTree::get_singleton()->get_nodes_in_group("nodes", &nodes);
+		CHECK_EQ(nodes.size(), 1);
+
+		E = nodes.front();
+		CHECK_EQ(E->get(), node1_1);
+	}
+
+	memdelete(node1_1);
+	memdelete(node1);
+	memdelete(node2);
+}
+
+TEST_CASE("[Node] Processing") {
+	Node *node = memnew(Node);
+
+	SUBCASE("Processing") {
+		CHECK_FALSE(node->is_processing());
+
+		node->set_process(true);
+
+		CHECK(node->is_processing());
+
+		node->set_process(false);
+
+		CHECK_FALSE(node->is_processing());
+	}
+
+	SUBCASE("Physics processing") {
+		CHECK_FALSE(node->is_physics_processing());
+
+		node->set_physics_process(true);
+
+		CHECK(node->is_physics_processing());
+
+		node->set_physics_process(false);
+
+		CHECK_FALSE(node->is_physics_processing());
+	}
+
+	SUBCASE("Unhandled input processing") {
+		CHECK_FALSE(node->is_processing_unhandled_input());
+
+		node->set_process_unhandled_input(true);
+
+		CHECK(node->is_processing_unhandled_input());
+
+		node->set_process_unhandled_input(false);
+
+		CHECK_FALSE(node->is_processing_unhandled_input());
+	}
+
+	SUBCASE("Input processing") {
+		CHECK_FALSE(node->is_processing_input());
+
+		node->set_process_input(true);
+
+		CHECK(node->is_processing_input());
+
+		node->set_process_input(false);
+
+		CHECK_FALSE(node->is_processing_input());
+	}
+
+	SUBCASE("Unhandled key input processing") {
+		CHECK_FALSE(node->is_processing_unhandled_key_input());
+
+		node->set_process_unhandled_key_input(true);
+
+		CHECK(node->is_processing_unhandled_key_input());
+
+		node->set_process_unhandled_key_input(false);
+
+		CHECK_FALSE(node->is_processing_unhandled_key_input());
+	}
+
+	SUBCASE("Shortcut input processing") {
+		CHECK_FALSE(node->is_processing_shortcut_input());
+
+		node->set_process_shortcut_input(true);
+
+		CHECK(node->is_processing_shortcut_input());
+
+		node->set_process_shortcut_input(false);
+
+		CHECK_FALSE(node->is_processing_shortcut_input());
+	}
+
+	SUBCASE("Internal processing") {
+		CHECK_FALSE(node->is_processing_internal());
+
+		node->set_process_internal(true);
+
+		CHECK(node->is_processing_internal());
+
+		node->set_process_internal(false);
+
+		CHECK_FALSE(node->is_processing_internal());
+	}
+
+	memdelete(node);
+}
+
+} // namespace TestNode
+
+#endif // TEST_NODE_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -92,6 +92,7 @@
 #include "tests/scene/test_code_edit.h"
 #include "tests/scene/test_curve.h"
 #include "tests/scene/test_gradient.h"
+#include "tests/scene/test_node.h"
 #include "tests/scene/test_path_2d.h"
 #include "tests/scene/test_path_3d.h"
 #include "tests/scene/test_primitives.h"


### PR DESCRIPTION
These PR includes some initial tests for `node`.
As tracked by https://github.com/godotengine/godot/issues/43440, there are no tests yet for `node`, so I decided to create some.

The following operations are tested for `node`:
- add
- remove
- move
- get (by index, node path and group)
- find
- count
- is_inside_tree
- name
- Verifying the scene tree (node count)
- Processing setup

My goal is to create more tests in the future. 
Some requires more work (I got some crashes when trying to simulate a `_process` call).