### PR TITLE
[3.x] Add boot splash for the Godot Editor

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1422,7 +1422,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	MAIN_PRINT("Main: Setup Logo");
 
-#if defined(JAVASCRIPT_ENABLED) || defined(ANDROID_ENABLED)
+#if !defined(TOOLS_ENABLED) && (defined(JAVASCRIPT_ENABLED) || defined(ANDROID_ENABLED))
 	bool show_logo = false;
 #else
 	bool show_logo = true;

--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
         android:icon="@mipmap/icon"
         android:label="@string/godot_editor_name_string"
         tools:ignore="GoogleAppIndexingWarning"
+        android:theme="@style/GodotEditorTheme"
         android:requestLegacyExternalStorage="true">
 
         <activity
@@ -35,7 +36,6 @@
             android:launchMode="singleTask"
             android:screenOrientation="userLandscape"
             android:exported="true"
-            android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen"
             android:process=":GodotProjectManager">
 
             <layout android:defaultHeight="@dimen/editor_default_window_height"
@@ -53,8 +53,7 @@
             android:process=":GodotEditor"
             android:launchMode="singleTask"
             android:screenOrientation="userLandscape"
-            android:exported="false"
-            android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen">
+            android:exported="false">
             <layout android:defaultHeight="@dimen/editor_default_window_height"
                 android:defaultWidth="@dimen/editor_default_window_width" />
         </activity>
@@ -66,8 +65,7 @@
             android:process=":GodotGame"
             android:launchMode="singleTask"
             android:exported="false"
-            android:screenOrientation="userLandscape"
-            android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen">
+            android:screenOrientation="userLandscape">
             <layout android:defaultHeight="@dimen/editor_default_window_height"
                 android:defaultWidth="@dimen/editor_default_window_width" />
         </activity>

--- a/platform/android/java/editor/src/main/res/values/themes.xml
+++ b/platform/android/java/editor/src/main/res/values/themes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+	<style name="GodotEditorTheme" parent="@android:style/Theme.Black.NoTitleBar.Fullscreen">
+	</style>
+</resources>


### PR DESCRIPTION

https://user-images.githubusercontent.com/914968/208160668-17b54b85-810b-48f1-ac2c-4bcb45705523.mp4

[main version](https://github.com/godotengine/godot/pull/70161)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
