### PR TITLE
Transform sdf xfrom by particle emission transform when particles are in global space

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1131,16 +1131,10 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 					RID particles = pt->particles;
 					state.canvas_instance_batches[state.current_batch_index].tex = pt->texture;
 					state.canvas_instance_batches[state.current_batch_index].shader_variant = CanvasShaderGLES3::MODE_INSTANCED;
-					bool local_coords = particles_storage->particles_is_using_local_coords(particles);
 
 					if (particles_storage->particles_has_collision(particles) && texture_storage->render_target_is_sdf_enabled(p_render_target)) {
 						// Pass collision information.
-						Transform2D xform;
-						if (local_coords) {
-							xform = p_item->final_transform;
-						} else {
-							xform = p_canvas_transform_inverse;
-						}
+						Transform2D xform = p_item->final_transform;
 
 						GLuint sdf_texture = texture_storage->render_target_get_sdf_texture(p_render_target);
 

--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -528,6 +528,15 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 			//2D collision
 
 			Transform2D xform = p_particles->sdf_collision_transform; //will use dotproduct manually so invert beforehand
+
+			if (!p_particles->use_local_coords) {
+				Transform2D emission;
+				emission.columns[0] = Vector2(p_particles->emission_transform.basis.get_column(0).x, p_particles->emission_transform.basis.get_column(0).y);
+				emission.columns[1] = Vector2(p_particles->emission_transform.basis.get_column(1).x, p_particles->emission_transform.basis.get_column(1).y);
+				emission.set_origin(Vector2(p_particles->emission_transform.origin.x, p_particles->emission_transform.origin.y));
+				xform = xform * emission.affine_inverse();
+			}
+
 			Transform2D revert = xform.affine_inverse();
 			frame_params.collider_count = 1;
 			frame_params.colliders[0].transform[0] = xform.columns[0][0];

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -810,6 +810,15 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 			//2D collision
 
 			Transform2D xform = p_particles->sdf_collision_transform; //will use dotproduct manually so invert beforehand
+
+			if (!p_particles->use_local_coords) {
+				Transform2D emission;
+				emission.columns[0] = Vector2(p_particles->emission_transform.basis.get_column(0).x, p_particles->emission_transform.basis.get_column(0).y);
+				emission.columns[1] = Vector2(p_particles->emission_transform.basis.get_column(1).x, p_particles->emission_transform.basis.get_column(1).y);
+				emission.set_origin(Vector2(p_particles->emission_transform.origin.x, p_particles->emission_transform.origin.y));
+				xform = xform * emission.affine_inverse();
+			}
+
 			Transform2D revert = xform.affine_inverse();
 			frame_params.collider_count = 1;
 			frame_params.colliders[0].transform[0] = xform.columns[0][0];


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/69358

This just transforms the SDF into global space instead of local space when the particles are in global space.

GLES3 needed to remove a workaround that didn't fully solve the problem. Now GLES3 and RD work the same

This was a bit annoying as we don't have an easy way to turn a Transform3D into a Transform2D. 