### PR TITLE
Fix autocomplete box placement

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -115,7 +115,9 @@ void CodeEdit::_notification(int p_what) {
 
 				const Point2 caret_pos = get_caret_draw_pos();
 				const int total_height = csb->get_minimum_size().y + code_completion_rect.size.height;
-				if (caret_pos.y + row_height + total_height > get_size().height) {
+				const bool can_fit_completion_above = (caret_pos.y - row_height > total_height);
+				const bool can_fit_completion_below = (caret_pos.y + row_height + total_height <= get_size().height);
+				if (!can_fit_completion_below && can_fit_completion_above) {
 					code_completion_rect.position.y = (caret_pos.y - total_height - row_height) + line_spacing;
 				} else {
 					code_completion_rect.position.y = caret_pos.y + (line_spacing / 2.0f);

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -3027,7 +3027,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			CHECK(code_edit->get_code_completion_selected_index() == 0);
 
 			Point2 caret_pos = code_edit->get_caret_draw_pos();
-			caret_pos.y -= code_edit->get_line_height();
+			caret_pos.y += code_edit->get_line_height();
 			SEND_GUI_MOUSE_BUTTON_EVENT(code_edit, caret_pos, MouseButton::WHEEL_DOWN, MouseButton::NONE, Key::NONE);
 			CHECK(code_edit->get_code_completion_selected_index() == 1);
 
@@ -3035,6 +3035,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			CHECK(code_edit->get_code_completion_selected_index() == 0);
 
 			/* Single click selects. */
+			caret_pos.y += code_edit->get_line_height() * 2;
 			SEND_GUI_MOUSE_BUTTON_EVENT(code_edit, caret_pos, MouseButton::LEFT, MouseButton::MASK_LEFT, Key::NONE);
 			CHECK(code_edit->get_code_completion_selected_index() == 2);
 


### PR DESCRIPTION
Prevents `CodeEdit`'s autocomplete box from being placed above the edited line if there is no room to do so.

Fixes #70088

Before/After:
![image](https://user-images.githubusercontent.com/14885846/208191583-e2f00647-0221-47ac-9803-4f721e7719be.png)
