### PR TITLE
Make keys deselected when keying property for animation to avoid crash

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1922,10 +1922,12 @@ void AnimationPlayerEditorPlugin::_notification(int p_what) {
 }
 
 void AnimationPlayerEditorPlugin::_property_keyed(const String &p_keyed, const Variant &p_value, bool p_advance) {
-	if (!anim_editor->get_track_editor()->has_keying()) {
+	AnimationTrackEditor *te = anim_editor->get_track_editor();
+	if (!te || !te->has_keying()) {
 		return;
 	}
-	anim_editor->get_track_editor()->insert_value_key(p_keyed, p_value, p_advance);
+	te->_clear_selection();
+	te->insert_value_key(p_keyed, p_value, p_advance);
 }
 
 void AnimationPlayerEditorPlugin::_transform_key_request(Object *sp, const String &p_sub, const Transform3D &p_key) {

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -153,9 +153,10 @@ void BoneTransformEditor::set_target(const String &p_prop) {
 
 void BoneTransformEditor::_property_keyed(const String &p_path, bool p_advance) {
 	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
-	if (!te->has_keying()) {
+	if (!te || !te->has_keying()) {
 		return;
 	}
+	te->_clear_selection();
 	PackedStringArray split = p_path.split("/");
 	if (split.size() == 3 && split[0] == "bones") {
 		int bone_idx = split[1].to_int();


### PR DESCRIPTION
Fixes #69829 Fixes #70058
Supersedes #69834

If a dummy object `AnimationTrackEdit` remains when keying from a property, animation updates will conflict with inspector updates. This fix make the dummy object is cleared and deselected when keying from the inspector property key button.