### PR TITLE
Fix crashed when compressing empty image data.

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2625,6 +2625,8 @@ Error Image::compress(CompressMode p_mode, CompressSource p_source, float p_loss
 }
 
 Error Image::compress_from_channels(CompressMode p_mode, UsedChannels p_channels, float p_lossy_quality, ASTCFormat p_astc_format) {
+	ERR_FAIL_COND_V(data.is_empty(), ERR_INVALID_DATA);
+
 	switch (p_mode) {
 		case COMPRESS_S3TC: {
 			ERR_FAIL_COND_V(!_image_compress_bc_func, ERR_UNAVAILABLE);


### PR DESCRIPTION
Fix: #70197 