### PR TITLE
C#: Add note about the class name in instantiate error

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2292,7 +2292,7 @@ bool CSharpScript::can_instantiate() const {
 	// For tool scripts, this will never fire if the class is not found. That's because we
 	// don't know if it's a tool script if we can't find the class to access the attributes.
 	if (extra_cond && !valid) {
-		ERR_FAIL_V_MSG(false, "Cannot instance script because the associated class could not be found. Script: '" + get_path() + "'.");
+		ERR_FAIL_V_MSG(false, "Cannot instance script because the associated class could not be found. Script: '" + get_path() + "'. Make sure the script exists and contains a class definition with a name that matches the filename of the script exactly (it's case-sensitive).");
 	}
 
 	return valid && extra_cond;


### PR DESCRIPTION
Adds a note about the requirement that a C# class name must match the script filename in which the they are defined to the instantiate error.

This should hopefully make the error more user-friendly and avoid issues such as https://github.com/godotengine/godot/issues/66419 in the future.

Feel free to suggest a better message, the goal is to mention the common reasons why the associated class was not found:
- **File at the specified path does not exist**. \
  In case the user attached a script to a Node and then deleted the script without detaching it from the Node.
- The file exists but it contains no class or **the class defined does not match the name of the filename**.
- The script filename and the class name are **case-sensitive**. \
  It seems common for users to define a class such as `Player` using PascalCase to follow .NET class naming conventions and then name the script `player.cs` because Godot uses snake_case for filenames by default.
