### PR TITLE
[3.x] Fix to allow TextureArrays to be serialized

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1579,14 +1579,17 @@ void ResourceFormatSaverBinaryInstance::_find_resources(const Variant &p_variant
 				if (E->get().usage & PROPERTY_USAGE_STORAGE) {
 					Variant value = res->get(E->get().name);
 					if (E->get().usage & PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT) {
+						NonPersistentKey npk;
+						npk.base = res;
+						npk.property = E->get().name;
+						non_persistent_map[npk] = value;
+
 						RES sres = value;
 						if (sres.is_valid()) {
-							NonPersistentKey npk;
-							npk.base = res;
-							npk.property = E->get().name;
-							non_persistent_map[npk] = sres;
 							resource_set.insert(sres);
 							saved_resources.push_back(sres);
+						} else {
+							_find_resources(value);
 						}
 					} else {
 						_find_resources(value);

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -129,7 +129,7 @@ class ResourceFormatSaverBinaryInstance {
 		bool operator<(const NonPersistentKey &p_key) const { return base == p_key.base ? property < p_key.property : base < p_key.base; }
 	};
 
-	Map<NonPersistentKey, RES> non_persistent_map;
+	Map<NonPersistentKey, Variant> non_persistent_map;
 	Map<StringName, int> string_map;
 	Vector<StringName> strings;
 

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1357,14 +1357,17 @@ void ResourceFormatSaverTextInstance::_find_resources(const Variant &p_variant, 
 					Variant v = res->get(I->get().name);
 
 					if (pi.usage & PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT) {
+						NonPersistentKey npk;
+						npk.base = res;
+						npk.property = pi.name;
+						non_persistent_map[npk] = v;
+
 						RES sres = v;
 						if (sres.is_valid()) {
-							NonPersistentKey npk;
-							npk.base = res;
-							npk.property = pi.name;
-							non_persistent_map[npk] = sres;
 							resource_set.insert(sres);
 							saved_resources.push_back(sres);
+						} else {
+							_find_resources(v);
 						}
 					} else {
 						_find_resources(v);

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -159,7 +159,7 @@ class ResourceFormatSaverTextInstance {
 		bool operator<(const NonPersistentKey &p_key) const { return base == p_key.base ? property < p_key.property : base < p_key.base; }
 	};
 
-	Map<NonPersistentKey, RES> non_persistent_map;
+	Map<NonPersistentKey, Variant> non_persistent_map;
 
 	Set<RES> resource_set;
 	List<RES> saved_resources;

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2703,7 +2703,7 @@ void TextureLayered::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_get_data"), &TextureLayered::_get_data);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "flags", PROPERTY_HINT_FLAGS, "Mipmaps,Repeat,Filter,Anisotropic Filter"), "set_flags", "get_flags");
-	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "_set_data", "_get_data");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT), "_set_data", "_get_data");
 
 	BIND_ENUM_CONSTANT(FLAGS_DEFAULT_TEXTURE_ARRAY);
 	BIND_ENUM_CONSTANT(FLAGS_DEFAULT_TEXTURE_3D);


### PR DESCRIPTION
This fixes serialisation of `TextureArray` based classes. For a long time (at least since 3.2) this has been broken, writing `null`s as layer images in the resulting resource files.

This is targeting `3.x` since serialisation is completely missing from the `master` branch, and code has diverged so much that there is no obvious way to fix it for both codebases in one go.

This will fix #54202, #38870, #34312 and many others.

NOTE: this commit was taken from https://github.com/V-Sekai/godot/commit/2ba3561e992fd4b2920518439068ca43ec1e51d9, authored by @SaracenOne that I was made aware of by @Calinou in issue #54202

Tested using the following snippet:

```gdscript
	var i := Image.new()
        i.create(1, 1, false, Image.FORMAT_RGB8)
	i.lock()
	i.set_pixel(0,0, Color(1,0,0))
	i.unlock()
	ResourceSaver.save("res://image.tres", i)
	var l := TextureArray.new()
	l.create(1, 1, 1, Image.FORMAT_RGB8)
	l.set_layer_data(i, 1)
	ResourceSaver.save("res://layered.tres", l)
```

and checking the `layered.tres` for non-null layer data.