### PR TITLE
`AtlasTexture` Fix calculating rects when flipping

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1591,35 +1591,28 @@ bool AtlasTexture::get_rect_region(const Rect2 &p_rect, const Rect2 &p_src_rect,
 		return false;
 	}
 
-	Rect2 rc = region;
-
 	Rect2 src = p_src_rect;
 	if (src.size == Size2()) {
-		src.size = rc.size;
+		src.size = region.size;
 	}
 	Vector2 scale = p_rect.size / src.size;
 
-	src.position += (rc.position - margin.position);
-	Rect2 src_c = rc.intersection(src);
-	if (src_c.size == Size2()) {
+	src.position += (region.position - margin.position);
+	Rect2 src_clipped = region.intersection(src);
+	if (src_clipped.size == Size2()) {
 		return false;
 	}
-	Vector2 ofs = (src_c.position - src.position);
 
+	Vector2 ofs = (src_clipped.position - src.position);
 	if (scale.x < 0) {
-		float mx = (margin.size.width - margin.position.x);
-		mx -= margin.position.x;
-		ofs.x = -(ofs.x + mx);
+		ofs.x += (src_clipped.size.x - src.size.x);
 	}
 	if (scale.y < 0) {
-		float my = margin.size.height - margin.position.y;
-		my -= margin.position.y;
-		ofs.y = -(ofs.y + my);
+		ofs.y += (src_clipped.size.y - src.size.y);
 	}
-	Rect2 dr(p_rect.position + ofs * scale, src_c.size * scale);
 
-	r_rect = dr;
-	r_src_rect = src_c;
+	r_rect = Rect2(p_rect.position + ofs * scale, src_clipped.size * scale);
+	r_src_rect = src_clipped;
 	return true;
 }
 


### PR DESCRIPTION
Fixes #70178.

The issue was likely caused/revealed by #56795/#56796, quoting myself:
>(...) As a result an AtlasTexture being a source atlas of another AtlasTexture could have resulted in incorrect rendering. This should be fixed now (**assuming other methods work as they're supposed to**).

Seems like this wasn't the case, `offset` calculations when flipping the texture (when destination rect has negative size):
https://github.com/godotengine/godot/blob/d44d0cc0fd543da143010ad96978951facd87c1e/scene/resources/texture.cpp#L1607-L1618
don't make much sense to me. When not flipping the offset is correctly the difference of the positions of the clipped source rect and the non-clipped source rect. When flipping the offset (for the axes being flipped) should be the difference between the `rect.end`s of the same rects instead (this should already account for the margins as the source rect is clipped to the `region`), meaning just adding the difference of the sizes of these rects should be enough. And that's what this PR does, the rest are cosmetic changes to clarify the code a little (renaming/removing some variables).
