### PR TITLE
Add a project setting to make the root viewport transparent (3.x)

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -1204,7 +1204,7 @@
 		</member>
 		<member name="window_per_pixel_transparency_enabled" type="bool" setter="set_window_per_pixel_transparency_enabled" getter="get_window_per_pixel_transparency_enabled" default="false">
 			If [code]true[/code], the window background is transparent and the window frame is removed.
-			Use [code]get_tree().get_root().set_transparent_background(true)[/code] to disable main viewport background rendering.
+			Enable [member ProjectSettings.rendering/viewport/transparent_background] or call [code]get_tree().get_root().set_transparent_background(true)[/code] to disable background rendering on the root [Viewport].
 			[b]Note:[/b] This property has no effect if [member ProjectSettings.display/window/per_pixel_transparency/allowed] setting is disabled.
 			[b]Note:[/b] This property is implemented on HTML5, Linux, macOS, Windows, and Android. It can't be changed at runtime for Android. Use [member ProjectSettings.display/window/per_pixel_transparency/enabled] to set it at startup instead.
 		</member>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -494,13 +494,15 @@
 			[b]Note:[/b] This setting has no effect on the home indicator if [code]hide_home_indicator[/code] is [code]true[/code].
 		</member>
 		<member name="display/window/per_pixel_transparency/allowed" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], allows per-pixel transparency for the window background. This affects performance, so leave it on [code]false[/code] unless you need it.
+			If [code]true[/code], allows per-pixel transparency for the window background. This affects performance, so leave it on [code]false[/code] unless you need it. See also [member display/window/per_pixel_transparency/enabled] and [member rendering/viewport/transparent_background].
+			[b]Note:[/b] Enabling [member display/window/per_pixel_transparency/allowed] does not make the background actually transparent. For the background to be transparent, the root viewport must also be made transparent by enabling [member rendering/viewport/transparent_background]. [member display/window/per_pixel_transparency/enabled] must also be enabled.
 			See [member OS.window_per_pixel_transparency_enabled] for more details.
 			[b]Note:[/b] This feature is implemented on HTML5, Linux, macOS, Windows, and Android.
 		</member>
 		<member name="display/window/per_pixel_transparency/enabled" type="bool" setter="" getter="" default="false">
 			Sets the window background to transparent when it starts.
 			See [member OS.window_per_pixel_transparency_enabled] for more details.
+			[b]Note:[/b] Enabling [member display/window/per_pixel_transparency/enabled] does not make the background actually transparent. For the background to be transparent, the root viewport must also be made transparent by enabling [member rendering/viewport/transparent_background]. [member display/window/per_pixel_transparency/allowed] must also be enabled.
 			[b]Note:[/b] This feature is implemented on HTML5, Linux, macOS, Windows, and Android.
 		</member>
 		<member name="display/window/size/always_on_top" type="bool" setter="" getter="" default="false">
@@ -1834,6 +1836,9 @@
 		<member name="rendering/threads/thread_safe_bvh" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], a thread safe version of BVH (bounding volume hierarchy) will be used in rendering and Godot physics.
 			Try enabling this option if you see any visual anomalies in 3D (such as incorrect object visibility).
+		</member>
+		<member name="rendering/viewport/transparent_background" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], enables [member Viewport.transparent_bg] on the root viewport. This allows per-pixel transparency to be effective after also enabling [member display/window/per_pixel_transparency/allowed] and [member display/window/per_pixel_transparency/enabled].
 		</member>
 		<member name="rendering/vram_compression/import_bptc" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the texture importer will import VRAM-compressed textures using the BPTC algorithm. This texture compression algorithm is only supported on desktop platforms, and only when using the GLES3 renderer.

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2691,12 +2691,15 @@ void SpatialEditorViewport::_project_settings_changed() {
 		viewport->set_shadow_atlas_quadrant_subdiv(2, Viewport::ShadowAtlasQuadrantSubdiv(atlas_q2));
 		viewport->set_shadow_atlas_quadrant_subdiv(3, Viewport::ShadowAtlasQuadrantSubdiv(atlas_q3));
 
-		// Update MSAA, FXAA, debanding and HDR if changed.
+		// Update MSAA, FXAA, transparent background, debanding, sharpening and HDR if changed.
 		int msaa_mode = ProjectSettings::get_singleton()->get("rendering/quality/filters/msaa");
 		viewport->set_msaa(Viewport::MSAA(msaa_mode));
 
 		bool use_fxaa = ProjectSettings::get_singleton()->get("rendering/quality/filters/use_fxaa");
 		viewport->set_use_fxaa(use_fxaa);
+
+		const bool transparent_background = GLOBAL_GET("rendering/viewport/transparent_background");
+		viewport->set_transparent_background(transparent_background);
 
 		bool use_debanding = ProjectSettings::get_singleton()->get("rendering/quality/filters/use_debanding");
 		viewport->set_use_debanding(use_debanding);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2250,6 +2250,9 @@ SceneTree::SceneTree() {
 	const bool use_fxaa = GLOBAL_DEF("rendering/quality/filters/use_fxaa", false);
 	root->set_use_fxaa(use_fxaa);
 
+	const bool transparent_background = GLOBAL_DEF("rendering/viewport/transparent_background", false);
+	root->set_transparent_background(transparent_background);
+
 	const bool use_debanding = GLOBAL_DEF("rendering/quality/filters/use_debanding", false);
 	root->set_use_debanding(use_debanding);
 


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/67104.

This allows creating a project with a transparent window without having to write any script.

**Testing project:** [test_viewport_transparent_background_3.x.zip](https://github.com/godotengine/godot/files/10252839/test_viewport_transparent_background_3.x.zip)

## Preview

![image](https://user-images.githubusercontent.com/180032/208268288-0ad1025a-3673-45a3-813c-f5725f2eed16.png)