### PR TITLE
Fix outer class lookup

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3167,7 +3167,7 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 		// TODO: Allow outer static functions.
 		if (base_class->outer != nullptr) {
 			List<GDScriptParser::ClassNode *> script_classes;
-			get_class_node_current_scope_classes(parser->current_class, &script_classes);
+			get_class_node_current_scope_classes(base_class->outer, &script_classes);
 			for (GDScriptParser::ClassNode *script_class : script_classes) {
 				if (script_class->has_member(name)) {
 					resolve_class_member(script_class, name, p_identifier);

--- a/modules/gdscript/tests/scripts/analyzer/errors/outer_class_lookup.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/outer_class_lookup.gd
@@ -1,0 +1,12 @@
+class A:
+    class B:
+        func test():
+            print(A.B.D)
+
+class C:
+    class D:
+        pass
+
+func test():
+    var inst = A.B.new()
+    inst.test()

--- a/modules/gdscript/tests/scripts/analyzer/errors/outer_class_lookup.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/outer_class_lookup.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot find member "D" in base "B".


### PR DESCRIPTION
It wasn't the logic that was wrong, but the base of the lookup in `GDScriptAnalyzer::reduce_identifier_from_base()`.

Fixes #70216 - GDScript 2.0: Wrong lookup for outer things