### PR TITLE
AudioServer: Remove redundant nullptr check before `delete`

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -449,12 +449,8 @@ void AudioServer::_mix_step() {
 			case AudioStreamPlaybackListNode::AWAITING_DELETION:
 			case AudioStreamPlaybackListNode::FADE_OUT_TO_DELETION:
 				playback_list.erase(playback, [](AudioStreamPlaybackListNode *p) {
-					if (p->prev_bus_details) {
-						delete p->prev_bus_details;
-					}
-					if (p->bus_details) {
-						delete p->bus_details;
-					}
+					delete p->prev_bus_details;
+					delete p->bus_details;
 					p->stream_playback.unref();
 					delete p;
 				});


### PR DESCRIPTION
Remove redundant `nullptr` check before `delete`. The `delete` keyword already checks if the pointer is null under the hood, so this check is performed two times.