### PR TITLE
[4.x] Fix typo and ensure backwards compatibility for changed property names

### DIFF
--- a/doc/classes/NavigationMesh.xml
+++ b/doc/classes/NavigationMesh.xml
@@ -137,9 +137,6 @@
 			The name of the group to scan for geometry.
 			Only used when [member geometry_source_geometry_mode] is [constant SOURCE_GEOMETRY_GROUPS_WITH_CHILDREN] or [constant SOURCE_GEOMETRY_GROUPS_EXPLICIT].
 		</member>
-		<member name="polygon_vertices_per_polyon" type="float" setter="set_vertices_per_polyon" getter="get_vertices_per_polyon" default="6.0">
-			The maximum number of vertices allowed for polygons generated during the contour to polygon conversion process.
-		</member>
 		<member name="region_merge_size" type="float" setter="set_region_merge_size" getter="get_region_merge_size" default="20.0">
 			Any regions with a size smaller than this will be merged with larger regions if possible.
 			[b]Note:[/b] This value will be squared to calculate the number of cells. For example, a value of 20 will set the number of cells to 400.
@@ -150,6 +147,9 @@
 		</member>
 		<member name="sample_partition_type" type="int" setter="set_sample_partition_type" getter="get_sample_partition_type" enum="NavigationMesh.SamplePartitionType" default="0">
 			Partitioning algorithm for creating the navigation mesh polys. See [enum SamplePartitionType] for possible values.
+		</member>
+		<member name="vertices_per_polygon" type="float" setter="set_vertices_per_polygon" getter="get_vertices_per_polygon" default="6.0">
+			The maximum number of vertices allowed for polygons generated during the contour to polygon conversion process.
 		</member>
 	</members>
 	<constants>

--- a/modules/navigation/navigation_mesh_generator.cpp
+++ b/modules/navigation/navigation_mesh_generator.cpp
@@ -538,7 +538,7 @@ void NavigationMeshGenerator::_build_recast_navigation_mesh(
 	cfg.maxSimplificationError = p_navigation_mesh->get_edge_max_error();
 	cfg.minRegionArea = (int)(p_navigation_mesh->get_region_min_size() * p_navigation_mesh->get_region_min_size());
 	cfg.mergeRegionArea = (int)(p_navigation_mesh->get_region_merge_size() * p_navigation_mesh->get_region_merge_size());
-	cfg.maxVertsPerPoly = (int)p_navigation_mesh->get_vertices_per_polyon();
+	cfg.maxVertsPerPoly = (int)p_navigation_mesh->get_vertices_per_polygon();
 	cfg.detailSampleDist = MAX(p_navigation_mesh->get_cell_size() * p_navigation_mesh->get_detail_sample_distance(), 0.1f);
 	cfg.detailSampleMaxError = p_navigation_mesh->get_cell_height() * p_navigation_mesh->get_detail_sample_max_error();
 
@@ -560,8 +560,8 @@ void NavigationMeshGenerator::_build_recast_navigation_mesh(
 	if (!Math::is_equal_approx((float)cfg.mergeRegionArea, p_navigation_mesh->get_region_merge_size() * p_navigation_mesh->get_region_merge_size())) {
 		WARN_PRINT("Property region_merge_size is converted to int and loses precision.");
 	}
-	if (!Math::is_equal_approx((float)cfg.maxVertsPerPoly, p_navigation_mesh->get_vertices_per_polyon())) {
-		WARN_PRINT("Property vertices_per_polyon is converted to int and loses precision.");
+	if (!Math::is_equal_approx((float)cfg.maxVertsPerPoly, p_navigation_mesh->get_vertices_per_polygon())) {
+		WARN_PRINT("Property vertices_per_polygon is converted to int and loses precision.");
 	}
 	if (p_navigation_mesh->get_cell_size() * p_navigation_mesh->get_detail_sample_distance() < 0.1f) {
 		WARN_PRINT("Property detail_sample_distance is clamped to 0.1 world units as the resulting value from multiplying with cell_size is too low.");

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -309,6 +309,25 @@ void NavigationRegion2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "travel_cost"), "set_travel_cost", "get_travel_cost");
 }
 
+#ifndef DISABLE_DEPRECATED
+// Compatibility with earlier 4.0 betas.
+bool NavigationRegion2D::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == "navpoly") {
+		set_navigation_polygon(p_value);
+		return true;
+	}
+	return false;
+}
+
+bool NavigationRegion2D::_get(const StringName &p_name, Variant &r_ret) const {
+	if (p_name == "navpoly") {
+		r_ret = get_navigation_polygon();
+		return true;
+	}
+	return false;
+}
+#endif // DISABLE_DEPRECATED
+
 NavigationRegion2D::NavigationRegion2D() {
 	set_notify_transform(true);
 

--- a/scene/2d/navigation_region_2d.h
+++ b/scene/2d/navigation_region_2d.h
@@ -50,6 +50,11 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+#endif // DISABLE_DEPRECATED
+
 public:
 #ifdef TOOLS_ENABLED
 	virtual Rect2 _edit_get_rect() const override;

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -320,6 +320,25 @@ void NavigationRegion3D::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("bake_finished"));
 }
 
+#ifndef DISABLE_DEPRECATED
+// Compatibility with earlier 4.0 betas.
+bool NavigationRegion3D::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == "navmesh") {
+		set_navigation_mesh(p_value);
+		return true;
+	}
+	return false;
+}
+
+bool NavigationRegion3D::_get(const StringName &p_name, Variant &r_ret) const {
+	if (p_name == "navmesh") {
+		r_ret = get_navigation_mesh();
+		return true;
+	}
+	return false;
+}
+#endif // DISABLE_DEPRECATED
+
 void NavigationRegion3D::_navigation_changed() {
 	update_gizmos();
 	update_configuration_warnings();

--- a/scene/3d/navigation_region_3d.h
+++ b/scene/3d/navigation_region_3d.h
@@ -64,6 +64,11 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+#endif // DISABLE_DEPRECATED
+
 public:
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const;

--- a/scene/resources/mesh_library.cpp
+++ b/scene/resources/mesh_library.cpp
@@ -61,6 +61,12 @@ bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
 			set_item_navigation_mesh(idx, p_value);
 		} else if (what == "navigation_mesh_transform") {
 			set_item_navigation_mesh_transform(idx, p_value);
+#ifndef DISABLE_DEPRECATED
+		} else if (what == "navmesh") { // Renamed in 4.0 beta 9.
+			set_item_navigation_mesh(idx, p_value);
+		} else if (what == "navmesh_transform") { // Renamed in 4.0 beta 9.
+			set_item_navigation_mesh_transform(idx, p_value);
+#endif // DISABLE_DEPRECATED
 		} else {
 			return false;
 		}
@@ -89,6 +95,12 @@ bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
 		r_ret = get_item_navigation_mesh(idx);
 	} else if (what == "navigation_mesh_transform") {
 		r_ret = get_item_navigation_mesh_transform(idx);
+#ifndef DISABLE_DEPRECATED
+	} else if (what == "navmesh") { // Renamed in 4.0 beta 9.
+		r_ret = get_item_navigation_mesh(idx);
+	} else if (what == "navmesh_transform") { // Renamed in 4.0 beta 9.
+		r_ret = get_item_navigation_mesh_transform(idx);
+#endif // DISABLE_DEPRECATED
 	} else if (what == "preview") {
 		r_ret = get_item_preview(idx);
 	} else {

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -225,13 +225,13 @@ float NavigationMesh::get_edge_max_error() const {
 	return edge_max_error;
 }
 
-void NavigationMesh::set_vertices_per_polyon(float p_value) {
+void NavigationMesh::set_vertices_per_polygon(float p_value) {
 	ERR_FAIL_COND(p_value < 3);
-	vertices_per_polyon = p_value;
+	vertices_per_polygon = p_value;
 }
 
-float NavigationMesh::get_vertices_per_polyon() const {
-	return vertices_per_polyon;
+float NavigationMesh::get_vertices_per_polygon() const {
+	return vertices_per_polygon;
 }
 
 void NavigationMesh::set_detail_sample_distance(float p_value) {
@@ -483,8 +483,8 @@ void NavigationMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_edge_max_error", "edge_max_error"), &NavigationMesh::set_edge_max_error);
 	ClassDB::bind_method(D_METHOD("get_edge_max_error"), &NavigationMesh::get_edge_max_error);
 
-	ClassDB::bind_method(D_METHOD("set_vertices_per_polyon", "vertices_per_polyon"), &NavigationMesh::set_vertices_per_polyon);
-	ClassDB::bind_method(D_METHOD("get_vertices_per_polyon"), &NavigationMesh::get_vertices_per_polyon);
+	ClassDB::bind_method(D_METHOD("set_vertices_per_polygon", "vertices_per_polygon"), &NavigationMesh::set_vertices_per_polygon);
+	ClassDB::bind_method(D_METHOD("get_vertices_per_polygon"), &NavigationMesh::get_vertices_per_polygon);
 
 	ClassDB::bind_method(D_METHOD("set_detail_sample_distance", "detail_sample_dist"), &NavigationMesh::set_detail_sample_distance);
 	ClassDB::bind_method(D_METHOD("get_detail_sample_distance"), &NavigationMesh::get_detail_sample_distance);
@@ -544,8 +544,8 @@ void NavigationMesh::_bind_methods() {
 	ADD_GROUP("Edges", "edge_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "edge_max_length", PROPERTY_HINT_RANGE, "0.0,50.0,0.01,or_greater,suffix:m"), "set_edge_max_length", "get_edge_max_length");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "edge_max_error", PROPERTY_HINT_RANGE, "0.1,3.0,0.01,or_greater,suffix:m"), "set_edge_max_error", "get_edge_max_error");
-	ADD_GROUP("Polygons", "polygon_");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "polygon_vertices_per_polyon", PROPERTY_HINT_RANGE, "3.0,12.0,1.0,or_greater"), "set_vertices_per_polyon", "get_vertices_per_polyon");
+	ADD_GROUP("Polygons", "");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "vertices_per_polygon", PROPERTY_HINT_RANGE, "3.0,12.0,1.0,or_greater"), "set_vertices_per_polygon", "get_vertices_per_polygon");
 	ADD_GROUP("Details", "detail_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "detail_sample_distance", PROPERTY_HINT_RANGE, "0.1,16.0,0.01,or_greater,suffix:m"), "set_detail_sample_distance", "get_detail_sample_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "detail_sample_max_error", PROPERTY_HINT_RANGE, "0.0,16.0,0.01,or_greater,suffix:m"), "set_detail_sample_max_error", "get_detail_sample_max_error");
@@ -595,13 +595,16 @@ bool NavigationMesh::_set(const StringName &p_name, const Variant &p_value) {
 		// Compatibility with pre-3.5 "category/path" property names.
 		prop_name = prop_name.replace("/", "_");
 		if (prop_name == "sample_partition_type_sample_partition_type") {
-			set("sample_partition_type", p_value);
+			set_sample_partition_type((NavigationMesh::SamplePartitionType)p_value.operator int());
 		} else if (prop_name == "filter_filter_walkable_low_height_spans") {
-			set("filter_walkable_low_height_spans", p_value);
+			set_filter_walkable_low_height_spans(p_value);
 		} else {
 			set(prop_name, p_value);
 		}
-
+		return true;
+	}
+	if (p_name == "polygon_verts_per_poly") { // Renamed in 4.0 beta 9.
+		set_vertices_per_polygon(p_value);
 		return true;
 	}
 	return false;
@@ -613,12 +616,16 @@ bool NavigationMesh::_get(const StringName &p_name, Variant &r_ret) const {
 		// Compatibility with pre-3.5 "category/path" property names.
 		prop_name = prop_name.replace("/", "_");
 		if (prop_name == "sample_partition_type_sample_partition_type") {
-			r_ret = get("sample_partition_type");
+			r_ret = get_sample_partition_type();
 		} else if (prop_name == "filter_filter_walkable_low_height_spans") {
-			r_ret = get("filter_walkable_low_height_spans");
+			r_ret = get_filter_walkable_low_height_spans();
 		} else {
 			r_ret = get(prop_name);
 		}
+		return true;
+	}
+	if (p_name == "polygon_verts_per_poly") { // Renamed in 4.0 beta 9.
+		r_ret = get_vertices_per_polygon();
 		return true;
 	}
 	return false;

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -101,7 +101,7 @@ protected:
 	float region_merge_size = 20.0f;
 	float edge_max_length = 12.0f;
 	float edge_max_error = 1.3f;
-	float vertices_per_polyon = 6.0f;
+	float vertices_per_polygon = 6.0f;
 	float detail_sample_distance = 6.0f;
 	float detail_sample_max_error = 1.0f;
 
@@ -168,8 +168,8 @@ public:
 	void set_edge_max_error(float p_value);
 	float get_edge_max_error() const;
 
-	void set_vertices_per_polyon(float p_value);
-	float get_vertices_per_polyon() const;
+	void set_vertices_per_polygon(float p_value);
+	float get_vertices_per_polygon() const;
 
 	void set_detail_sample_distance(float p_value);
 	float get_detail_sample_distance() const;


### PR DESCRIPTION
Changes to the name of the `navmesh` and `navpoly` properties in #69931 cause navigation data to be lost on load for projects created before the PR was merged. 

This PR creates hidden properties that will convert the older names to the new names on load, preserving the data.

Also fixes a typo on `get_vertices_per_polygon` in `NavigationMesh`.