### PR TITLE
Fix GDScript base and outer classes, signals and functions lookup order

### DIFF
--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -123,6 +123,7 @@ class GDScriptAnalyzer {
 	void mark_lambda_use_self();
 	bool class_exists(const StringName &p_class) const;
 	Ref<GDScriptParserRef> get_parser_for(const String &p_path);
+	static void reduce_identifier_from_base_set_class(GDScriptParser::IdentifierNode *p_identifier, GDScriptParser::DataType p_identifier_datatype);
 #ifdef DEBUG_ENABLED
 	bool is_shadowing(GDScriptParser::IdentifierNode *p_local, const String &p_context);
 #endif

--- a/modules/gdscript/tests/scripts/analyzer/errors/outer_class_constants.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/outer_class_constants.gd
@@ -1,0 +1,8 @@
+class Outer:
+	const OUTER_CONST: = 0
+	class Inner:
+		pass
+
+func test() -> void:
+	var type: = Outer.Inner
+	print(type.OUTER_CONST)

--- a/modules/gdscript/tests/scripts/analyzer/errors/outer_class_constants.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/outer_class_constants.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: test()
+>> analyzer/errors/outer_class_constants.gd
+>> 8
+>> Invalid get index 'OUTER_CONST' (on base: 'GDScript').

--- a/modules/gdscript/tests/scripts/analyzer/errors/outer_class_constants_as_variant.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/outer_class_constants_as_variant.gd
@@ -1,0 +1,9 @@
+class Outer:
+	const OUTER_CONST: = 0
+	class Inner:
+		pass
+
+func test() -> void:
+	var type: = Outer.Inner
+	var type_v: Variant = type
+	print(type_v.OUTER_CONST)

--- a/modules/gdscript/tests/scripts/analyzer/errors/outer_class_constants_as_variant.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/outer_class_constants_as_variant.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: test()
+>> analyzer/errors/outer_class_constants_as_variant.gd
+>> 9
+>> Invalid get index 'OUTER_CONST' (on base: 'GDScript').

--- a/modules/gdscript/tests/scripts/analyzer/errors/outer_class_instance_constants.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/outer_class_instance_constants.gd
@@ -1,0 +1,8 @@
+class Outer:
+	const OUTER_CONST: = 0
+	class Inner:
+		pass
+
+func test() -> void:
+	var instance: = Outer.Inner.new()
+	print(instance.OUTER_CONST)

--- a/modules/gdscript/tests/scripts/analyzer/errors/outer_class_instance_constants.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/outer_class_instance_constants.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: test()
+>> analyzer/errors/outer_class_instance_constants.gd
+>> 8
+>> Invalid get index 'OUTER_CONST' (on base: 'RefCounted (Inner)').

--- a/modules/gdscript/tests/scripts/analyzer/errors/outer_class_instance_constants_as_variant.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/outer_class_instance_constants_as_variant.gd
@@ -1,0 +1,9 @@
+class Outer:
+	const OUTER_CONST: = 0
+	class Inner:
+		pass
+
+func test() -> void:
+	var instance: = Outer.Inner.new()
+	var instance_v: Variant = instance
+	print(instance_v.OUTER_CONST)

--- a/modules/gdscript/tests/scripts/analyzer/errors/outer_class_instance_constants_as_variant.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/outer_class_instance_constants_as_variant.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: test()
+>> analyzer/errors/outer_class_instance_constants_as_variant.gd
+>> 9
+>> Invalid get index 'OUTER_CONST' (on base: 'RefCounted (Inner)').

--- a/modules/gdscript/tests/scripts/analyzer/features/lookup_class.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/lookup_class.gd
@@ -1,0 +1,50 @@
+# Inner-outer class lookup
+class A:
+    const Q: = "right one"
+
+class X:
+    const Q: = "wrong one"
+
+class Y extends X:
+    class B extends A:
+        static func check() -> void:
+            print(Q)
+
+# External class lookup
+const External: = preload("lookup_class_external.notest.gd")
+
+class Internal extends External.A:
+    static func check() -> void:
+        print(TARGET)
+
+    class E extends External.E:
+        static func check() -> void:
+            print(TARGET)
+            print(WAITING)
+
+# Variable lookup
+class C:
+    var Q := 'right one'
+
+class D:
+    const Q := 'wrong one'
+
+class E extends D:
+    class F extends C:
+        func check() -> void:
+            print(Q)
+
+# Test
+func test() -> void:
+    # Inner-outer class lookup
+    Y.B.check()
+    print("---")
+
+    # External class lookup
+    Internal.check()
+    Internal.E.check()
+    print("---")
+
+    # Variable lookup
+    var f: = E.F.new()
+    f.check()

--- a/modules/gdscript/tests/scripts/analyzer/features/lookup_class.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/lookup_class.out
@@ -1,0 +1,8 @@
+GDTEST_OK
+right one
+---
+wrong
+right
+godot
+---
+right one

--- a/modules/gdscript/tests/scripts/analyzer/features/lookup_class_external.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/lookup_class_external.notest.gd
@@ -1,0 +1,15 @@
+class A:
+	const TARGET: = "wrong"
+
+	class B:
+		const TARGET: = "wrong"
+		const WAITING: = "godot"
+
+		class D extends C:
+			pass
+
+class C:
+	const TARGET: = "right"
+
+class E extends A.B.D:
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/features/lookup_signal.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/lookup_signal.gd
@@ -1,0 +1,41 @@
+signal hello
+
+func get_signal() -> Signal:
+    return hello
+
+class A:
+    signal hello
+
+    func get_signal() -> Signal:
+        return hello
+
+    class B:
+        signal hello
+
+        func get_signal() -> Signal:
+            return hello
+
+class C extends A.B:
+    func get_signal() -> Signal:
+        return hello
+
+func test():
+    var a: = A.new()
+    var b: = A.B.new()
+    var c: = C.new()
+
+    var hello_a_result: = hello == a.get_signal()
+    var hello_b_result: = hello == b.get_signal()
+    var hello_c_result: = hello == c.get_signal()
+    var a_b_result: = a.get_signal() == b.get_signal()
+    var a_c_result: = a.get_signal() == c.get_signal()
+    var b_c_result: = b.get_signal() == c.get_signal()
+    var c_c_result: = c.get_signal() == c.get_signal()
+
+    print("hello == A.hello? %s" % hello_a_result)
+    print("hello == A.B.hello? %s" % hello_b_result)
+    print("hello == C.hello? %s" % hello_c_result)
+    print("A.hello == A.B.hello? %s" % a_b_result)
+    print("A.hello == C.hello? %s" % a_c_result)
+    print("A.B.hello == C.hello? %s" % b_c_result)
+    print("C.hello == C.hello? %s" % c_c_result)

--- a/modules/gdscript/tests/scripts/analyzer/features/lookup_signal.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/lookup_signal.out
@@ -1,0 +1,8 @@
+GDTEST_OK
+hello == A.hello? false
+hello == A.B.hello? false
+hello == C.hello? false
+A.hello == A.B.hello? false
+A.hello == C.hello? false
+A.B.hello == C.hello? false
+C.hello == C.hello? true


### PR DESCRIPTION
Fix GDScript inner and outer classes lookup order
- Add outer class lookup test
- Add signal lookup test

Fixes #70216 (again)
Fixes #70495 - Accessing keys() dict of an enum defined in a singleton crashes app