### PR TITLE
Remove unnecessary if on Curve2D/3D::_calculate_tangent

### DIFF
--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -792,11 +792,7 @@ void Curve2D::_bake_segment2d_even_length(RBMap<real_t, Vector2> &r_bake, real_t
 
 Vector2 Curve2D::_calculate_tangent(const Vector2 &p_begin, const Vector2 &p_control_1, const Vector2 &p_control_2, const Vector2 &p_end, const real_t p_t) {
 	// Handle corner cases.
-	if (Math::is_zero_approx(p_t - 0.0f) && p_control_1.is_equal_approx(p_begin)) {
-		return (p_end - p_begin).normalized();
-	}
-
-	if (Math::is_zero_approx(p_t - 1.0f) && p_control_2.is_equal_approx(p_end)) {
+	if ((Math::is_zero_approx(p_t) && p_control_1.is_equal_approx(p_begin)) || (Math::is_zero_approx(p_t - 1.0f) && p_control_2.is_equal_approx(p_end))) {
 		return (p_end - p_begin).normalized();
 	}
 
@@ -1497,11 +1493,7 @@ void Curve3D::_bake_segment3d_even_length(RBMap<real_t, Vector3> &r_bake, real_t
 
 Vector3 Curve3D::_calculate_tangent(const Vector3 &p_begin, const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, const real_t p_t) {
 	// Handle corner cases.
-	if (Math::is_zero_approx(p_t - 0.0f) && p_control_1.is_equal_approx(p_begin)) {
-		return (p_end - p_begin).normalized();
-	}
-
-	if (Math::is_zero_approx(p_t - 1.0f) && p_control_2.is_equal_approx(p_end)) {
+	if ((Math::is_zero_approx(p_t) && p_control_1.is_equal_approx(p_begin)) || (Math::is_zero_approx(p_t - 1.0f) && p_control_2.is_equal_approx(p_end))) {
 		return (p_end - p_begin).normalized();
 	}
 


### PR DESCRIPTION
I was looking at the issue #70047, but look likes it already had a fix. But for some reason there is two if with same return one after another, c++ uses short circuit evaluation so it's unnecessary, so both conditionals can me merged in a single one.