### PR TITLE
[3.x] VariantParser improvements to readahead

### DIFF
--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -243,7 +243,7 @@ Error ConfigFile::load_encrypted_pass(const String &p_path, const String &p_pass
 
 Error ConfigFile::_internal_load(const String &p_path, FileAccess *f) {
 	VariantParser::StreamFile stream;
-	stream.f = f;
+	stream.set_file(f, VariantParser::Stream::READAHEAD_ENABLED);
 
 	Error err = _parse(p_path, &stream);
 

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -39,18 +39,14 @@ bool ResourceFormatImporter::SortImporterByName::operator()(const Ref<ResourceIm
 }
 
 Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndType &r_path_and_type, bool *r_valid) const {
-	Error err;
-	FileAccess *f = FileAccess::open(p_path + ".import", FileAccess::READ, &err);
-
-	if (!f) {
+	VariantParser::StreamFile stream;
+	Error err = stream.open_file(p_path + ".import");
+	if (err != OK) {
 		if (r_valid) {
 			*r_valid = false;
 		}
 		return err;
 	}
-
-	VariantParser::StreamFile stream;
-	stream.f = f;
 
 	String assign;
 	Variant value;
@@ -70,11 +66,9 @@ Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndTy
 
 		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true);
 		if (err == ERR_FILE_EOF) {
-			memdelete(f);
 			return OK;
 		} else if (err != OK) {
 			ERR_PRINT("ResourceFormatImporter::load - " + p_path + ".import:" + itos(lines) + " error: " + error_text);
-			memdelete(f);
 			return err;
 		}
 
@@ -107,8 +101,6 @@ Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndTy
 			break;
 		}
 	}
-
-	memdelete(f);
 
 	if (r_path_and_type.path == String() || r_path_and_type.type == String()) {
 		return ERR_FILE_CORRUPT;
@@ -243,15 +235,11 @@ String ResourceFormatImporter::get_internal_resource_path(const String &p_path) 
 }
 
 void ResourceFormatImporter::get_internal_resource_path_list(const String &p_path, List<String> *r_paths) {
-	Error err;
-	FileAccess *f = FileAccess::open(p_path + ".import", FileAccess::READ, &err);
-
-	if (!f) {
+	VariantParser::StreamFile stream;
+	Error err = stream.open_file(p_path + ".import");
+	if (err != OK) {
 		return;
 	}
-
-	VariantParser::StreamFile stream;
-	stream.f = f;
 
 	String assign;
 	Variant value;
@@ -266,11 +254,9 @@ void ResourceFormatImporter::get_internal_resource_path_list(const String &p_pat
 
 		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true);
 		if (err == ERR_FILE_EOF) {
-			memdelete(f);
 			return;
 		} else if (err != OK) {
 			ERR_PRINT("ResourceFormatImporter::get_internal_resource_path_list - " + p_path + ".import:" + itos(lines) + " error: " + error_text);
-			memdelete(f);
 			return;
 		}
 
@@ -284,7 +270,6 @@ void ResourceFormatImporter::get_internal_resource_path_list(const String &p_pat
 			break;
 		}
 	}
-	memdelete(f);
 }
 
 String ResourceFormatImporter::get_import_group_file(const String &p_path) const {

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -768,13 +768,9 @@ String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_rem
 		new_path = path_remaps[new_path];
 	} else {
 		// Try file remap.
-		Error err;
-		FileAccess *f = FileAccess::open(new_path + ".remap", FileAccess::READ, &err);
-
-		if (f) {
-			VariantParser::StreamFile stream;
-			stream.f = f;
-
+		VariantParser::StreamFile stream;
+		Error err = stream.open_file(new_path + ".remap");
+		if (err == OK) {
 			String assign;
 			Variant value;
 			VariantParser::Tag next_tag;
@@ -801,8 +797,6 @@ String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_rem
 					break;
 				}
 			}
-
-			memdelete(f);
 		}
 	}
 

--- a/core/variant_parser.h
+++ b/core/variant_parser.h
@@ -31,6 +31,7 @@
 #ifndef VARIANT_PARSER_H
 #define VARIANT_PARSER_H
 
+#include "core/error_list.h"
 #include "core/os/file_access.h"
 #include "core/resource.h"
 #include "core/variant.h"
@@ -38,23 +39,45 @@
 class VariantParser {
 public:
 	struct Stream {
-	private:
-		enum { READAHEAD_SIZE = 2048 };
-		CharType readahead_buffer[READAHEAD_SIZE];
-		uint32_t readahead_pointer = 0;
-		uint32_t readahead_filled = 0;
-		bool eof = false;
-
 	protected:
-		bool readahead_enabled = true;
+		// The readahead buffer is set by derived classes,
+		// and can be a single character to effectively turn off readahead.
+		CharType *readahead_buffer = nullptr;
+		uint32_t readahead_size = 0;
+
+		// The eof is NOT necessarily the source (e.g. file) eof,
+		// because the readahead will reach source eof BEFORE
+		// the stream catches up.
+		bool _eof = false;
+
+		// Number of characters we have read through already
+		// in the buffer (points to the next one to read).
+		uint32_t readahead_pointer = 0;
+
+		// Characters filled in the buffer
+		uint32_t readahead_filled = 0;
+
 		virtual uint32_t _read_buffer(CharType *p_buffer, uint32_t p_num_chars) = 0;
 		virtual bool _is_eof() const = 0;
 
+		void invalidate_readahead(bool p_eof);
+		bool readahead_enabled() const { return readahead_size != 1; }
+
+		// The offset between the current read position (usually behind) and the current
+		// file position (usually ahead), due to the readahead cache.
+		uint32_t get_readahead_offset() const;
+
 	public:
+		enum Readahead {
+			READAHEAD_DISABLED,
+			READAHEAD_ENABLED,
+		};
+
 		CharType saved;
 
 		CharType get_char();
 		virtual bool is_utf8() const = 0;
+		virtual uint64_t get_position() const = 0;
 		bool is_eof() const;
 
 		Stream() :
@@ -63,35 +86,86 @@ public:
 	};
 
 	struct StreamFile : public Stream {
+	private:
+		enum { READAHEAD_SIZE = 2048 };
+
+#ifdef DEV_ENABLED
+		// These are used exclusively to check for out of sync errors.
+		uint64_t _readahead_start_source_pos = 0;
+		uint64_t _readahead_end_source_pos = 0;
+#endif
+		FileAccess *_file = nullptr;
+
+		// Owned files are opened using open_file() rather than set_file().
+		// They cannot be modified from outside StreamFile,
+		// so are safe for readahead.
+		// They will also be automatically closed when StreamFile
+		// is destructed, or can optionally be closed using close_file().
+		bool _is_owned_file = false;
+
+		// Put buffer last in struct to keep the rest in cache
+		CharType _buffer[READAHEAD_SIZE];
+
+		void invalidate_readahead();
+
 	protected:
 		virtual uint32_t _read_buffer(CharType *p_buffer, uint32_t p_num_chars);
 		virtual bool _is_eof() const;
 
 	public:
-		FileAccess *f;
+		// NOTE:
+		// Whenever possible, prefer to use the open_file() / close_file() functions
+		// for the StreamFile to have internal ownership of the FileAccess.
+
+		// If you intend to manipulate the file / file position from outside StreamFile,
+		// make sure to either set readahead to false (to avoid syncing errors),
+		// otherwise the readahead will GET OUT OF SYNC, and corrupt files may ensue.
+
+		// Readahead is approx twice as fast, so should be used when possible.
+		void set_file(FileAccess *p_file, Readahead p_readahead = READAHEAD_DISABLED);
+
+		// Rather than have external ownership, it is safer to allow StreamFile
+		// internal ownership of the file, to prevent external changes to the file
+		// (via seeking / closing etc) which would make the readahead lose sync.
+		Error open_file(const String &p_path);
+		Error close_file();
 
 		virtual bool is_utf8() const;
-		StreamFile(bool p_readahead_enabled = true) {
-			f = nullptr;
-			readahead_enabled = p_readahead_enabled;
+		virtual uint64_t get_position() const;
+
+		StreamFile() {
+			readahead_buffer = _buffer;
+			readahead_size = READAHEAD_SIZE;
 		}
+		virtual ~StreamFile();
 	};
 
 	struct StreamString : public Stream {
 	private:
-		int pos;
+		// Keep the buffer as compact as possible for String,
+		// as it will have little effect, but to prevent the need for a virtual get_char() function.
+		enum { READAHEAD_SIZE = 8 };
+		int _pos;
+
+	public:
+		String s;
+
+	private:
+		// Put buffer last in struct to keep the rest in cache
+		CharType _buffer[READAHEAD_SIZE];
 
 	protected:
 		virtual uint32_t _read_buffer(CharType *p_buffer, uint32_t p_num_chars);
 		virtual bool _is_eof() const;
 
 	public:
-		String s;
-
 		virtual bool is_utf8() const;
-		StreamString(bool p_readahead_enabled = true) {
-			pos = 0;
-			readahead_enabled = p_readahead_enabled;
+		virtual uint64_t get_position() const;
+
+		StreamString() {
+			readahead_buffer = _buffer;
+			readahead_size = READAHEAD_SIZE;
+			_pos = 0;
 		}
 	};
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3736,7 +3736,20 @@ void EditorNode::open_request(const String &p_path) {
 		}
 	}
 
+#ifdef TOOLS_ENABLED
+#if 0
+#define GODOT_TIME_SCENE_LOADING
+#endif
+#endif
+
+#ifdef GODOT_TIME_SCENE_LOADING
+	uint32_t before = OS::get_singleton()->get_ticks_msec();
+	load_scene(p_path);
+	uint32_t after = OS::get_singleton()->get_ticks_msec();
+	print_verbose("EditorNode::load_scene() took " + itos(after - before) + " ms.");
+#else
 	load_scene(p_path); // as it will be opened in separate tab
+#endif
 }
 
 void EditorNode::request_instance_scene(const String &p_path) {

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -629,8 +629,7 @@ void ResourceInteractiveLoaderText::set_translation_remapped(bool p_remapped) {
 	translation_remapped = p_remapped;
 }
 
-ResourceInteractiveLoaderText::ResourceInteractiveLoaderText() :
-		stream(false) {
+ResourceInteractiveLoaderText::ResourceInteractiveLoaderText() {
 	translation_remapped = false;
 }
 
@@ -684,7 +683,7 @@ void ResourceInteractiveLoaderText::get_dependencies(FileAccess *p_f, List<Strin
 }
 
 Error ResourceInteractiveLoaderText::rename_dependencies(FileAccess *p_f, const String &p_path, const Map<String, String> &p_map) {
-	open(p_f, true);
+	open(p_f, true, false);
 	ERR_FAIL_COND_V(error != OK, error);
 	ignore_resource_parsing = true;
 	//FileAccess
@@ -786,13 +785,13 @@ Error ResourceInteractiveLoaderText::rename_dependencies(FileAccess *p_f, const 
 	return OK;
 }
 
-void ResourceInteractiveLoaderText::open(FileAccess *p_f, bool p_skip_first_tag) {
+void ResourceInteractiveLoaderText::open(FileAccess *p_f, bool p_skip_first_tag, bool p_readahead) {
 	error = OK;
 
 	lines = 1;
 	f = p_f;
 
-	stream.f = f;
+	stream.set_file(f, p_readahead ? VariantParser::Stream::READAHEAD_ENABLED : VariantParser::Stream::READAHEAD_DISABLED);
 	is_scene = false;
 	ignore_resource_parsing = false;
 	resource_current = 0;
@@ -1133,7 +1132,7 @@ String ResourceInteractiveLoaderText::recognize(FileAccess *p_f) {
 	lines = 1;
 	f = p_f;
 
-	stream.f = f;
+	stream.set_file(f, VariantParser::Stream::READAHEAD_ENABLED);
 
 	ignore_resource_parsing = true;
 

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -116,7 +116,7 @@ public:
 	virtual int get_stage_count() const;
 	virtual void set_translation_remapped(bool p_remapped);
 
-	void open(FileAccess *p_f, bool p_skip_first_tag = false);
+	void open(FileAccess *p_f, bool p_skip_first_tag = false, bool p_readahead = true);
 	String recognize(FileAccess *p_f);
 	void get_dependencies(FileAccess *p_f, List<String> *p_dependencies, bool p_add_types);
 	Error rename_dependencies(FileAccess *p_f, const String &p_path, const Map<String, String> &p_map);


### PR DESCRIPTION
Reintroduces readahead to ResourceInteractiveLoaderText, except in cases where file pointers are modified externally. Adds a new safe mechanism to open FileAccess within VariantParser::StreamFile, rather than relying on externally supplied FileAccess.

## Background
#65079 introduced readahead buffer to `VariantParser`, to increase loading speed.

Unfortunately there was a regression #69794 due to `ResourceInteractiveLoaderText::rename_dependencies()` modifying file pointers to the `FileAccess` simultaneously to the use of `VariantParser`, because it worked on the assumption that the `FileAccess` file pointer was always in sync with the `VariantParser`.

In order to quickly close this bug, #69963 simply turned off readahead for `ResourceInteractiveLoaderText` completely. This solved the bug but slowed down most of the loading to the old speed, so it was seen as a temporary fix before properly addressing the issue.

## Synchronization
The external specification of `FileAccess` leaves open this synchronization bug. An alternative way of solving the readahead issue is to place the readahead into the `FileAccess`, rather than the `VariantParser`. I mentioned this during the original PR #65079.

To that end I have written a draft PR to allow all `FileAccess` to optionally use a readahead buffer (#70260). This worked, but the performance was not as high as performing readahead in the `VariantParser`, as this is a very sensitive bottleneck.

#### Timings loading a large scene:
Old 3560 ms
readahead in `FileAccess` 2100 ms
readahead in `VariantParser` 1700 ms

I will be adding PRs for both, but this one explores the `VariantParser` option, which is still susceptible to the synchronization bug in future (so defaults to readahead off), but is significantly faster for a key area of the engine (loading), so this risk may be worth it, and makes all attempts to mitigate the risk.

## Safe owned `FileAccess`
Ideally we would like to prevent modification of the `FileAccess` outside of the `VariantParser`, but the previous design did not allow this. To that end I've added a new way of opening files and a simpler way to use `VariantParser::StreamFile` - you can now open the file indirectly through the `VariantParser`, which retains ownership and prevents access to the `FileAccess`, and closes the file automatically when `VariantParser` is destroyed.

`FileAccess` is now controlled by 3 functions:

* `void set_file(FileAccess *p_file, Readahead p_readahead = READAHEAD_DISABLED);`
Instead of public access to `f`, the pointer is set through a member function, and allows specifying readahead. This is the unsafe legacy function, and thus defaults to disabled readahead.

* `Error open_file(const String &p_path);` and `Error close_file();`
These functions allow opening an *owned* READ_ONLY file, the lifetime managed by the `VariantParser`. Any open file will be closed as the `VariantParser` is destructed. Alternatively the file can be manually closed with `close_file()`.
The advantage of using these functions is they guarantee `FileAccess` is not exposed, de-sync cannot occur, and thus readahead can be used by default. This also makes calling code slightly simpler too.

## Error detection
For the case of `FileAccess` specified using the old `set_file()` method, where readahead is selected, in `DEV_ENABLED` builds it will also check file pointers before every read through `VariantParser`, in order to detect de-syncs.

These are bad news as they will read the wrong data. As there is not an obvious way of preventing this at compile time (using the legacy API) we do the next best thing and try to detect it as soon as possible so that it can be fixed.

## Notes
* This also applies to 4.x, I'm leading on 3.x simply because faster to compile etc, but if we agree on an approach I can make relevant PR for master.

## Discussion
While this PR does attempt to mitigate risks of synchronization, it is not perfect, but on the other hand it does lead to loading being twice as fast. On balance that may be worth taking.
Other options include readahead on the `FileAccess` (PR coming) which is safer but not quite as fast for variant parsing (which is the bottleneck).

Alternatively it is possible to modify this PR so that readahead is only possible via the "owned file" method, and modify `ResourceInteractiveLoaderText` to use "owned file" except in the case of the problematic `ResourceInteractiveLoaderText::rename_dependencies()` method.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
