### PR TITLE
New setting Generate Colliders into the Advanced Import Settings dialog

### DIFF
--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -195,6 +195,17 @@ class ResourceImporterScene : public ResourceImporter {
 		MESH_OVERRIDE_DISABLE,
 	};
 
+	enum PhysicsMode {
+		PHYSICS_DEFAULT,
+		PHYSICS_ENABLE,
+		PHYSICS_DISABLE,
+	};
+
+	enum CollisionMode {
+		COLLISION_DISABLED,
+		COLLISION_STATIC,
+	};
+
 	enum BodyType {
 		BODY_TYPE_STATIC,
 		BODY_TYPE_DYNAMIC,
@@ -279,7 +290,7 @@ public:
 
 	Node *_pre_fix_node(Node *p_node, Node *p_root, HashMap<Ref<ImporterMesh>, Vector<Ref<Shape3D>>> &r_collision_map, Pair<PackedVector3Array, PackedInt32Array> *r_occluder_arrays, List<Pair<NodePath, Node *>> &r_node_renames);
 	Node *_pre_fix_animations(Node *p_node, Node *p_root, const Dictionary &p_node_data, const Dictionary &p_animation_data, float p_animation_fps);
-	Node *_post_fix_node(Node *p_node, Node *p_root, HashMap<Ref<ImporterMesh>, Vector<Ref<Shape3D>>> &collision_map, Pair<PackedVector3Array, PackedInt32Array> &r_occluder_arrays, HashSet<Ref<ImporterMesh>> &r_scanned_meshes, const Dictionary &p_node_data, const Dictionary &p_material_data, const Dictionary &p_animation_data, float p_animation_fps);
+	Node *_post_fix_node(Node *p_node, Node *p_root, HashMap<Ref<ImporterMesh>, Vector<Ref<Shape3D>>> &collision_map, Pair<PackedVector3Array, PackedInt32Array> &r_occluder_arrays, HashSet<Ref<ImporterMesh>> &r_scanned_meshes, const Dictionary &p_node_data, const Dictionary &p_material_data, const Dictionary &p_animation_data, float p_animation_fps, int p_default_collisions);
 	Node *_post_fix_animations(Node *p_node, Node *p_root, const Dictionary &p_node_data, const Dictionary &p_animation_data, float p_animation_fps);
 
 	Ref<Animation> _save_animation_to_file(Ref<Animation> anim, bool p_save_to_file, String p_save_to_path, bool p_keep_custom_tracks);


### PR DESCRIPTION
This setting allow you to choose between Disabled and Static. By choosing Static, all Meshes of the 3D scene will be imported with a Static Trimesh collider by default. A use case with examples is in the proposal: https://github.com/godotengine/godot-proposals/issues/5955.

![imagen](https://user-images.githubusercontent.com/248383/208302657-23b9cecc-f4c0-4c7d-bbe3-5637863a7bdc.png)

Then each individual Mesh can override the setting. To accommodate for this, the Physics option from a Mesh was changed from a bool to an Enum with the options: Default, Enabled, Disabled.

![imagen](https://user-images.githubusercontent.com/248383/208302675-ad5faea4-1dce-4f6a-9e41-69a30501828c.png)

All meshes are Default by default, which will use the new "Generate Colliders" global value. With Enabled, the Mesh can override physics options and Disabled is self-descriptive.

Implements and closes https://github.com/godotengine/godot-proposals/issues/5955.

This is an alternative implementation of https://github.com/godotengine/godot/pull/53086 which covers only one aspect of that PR (only the Global collider setting), following the suggestion by @reduz in that PR: 

> On the Scene settings, add two enums: meshes/generate/collision [Disabled | Static]

## Known Issues

Currently, due to https://github.com/godotengine/godot/issues/70255 the settings are sometimes reset. But as it can be seem in the bug report, the physics settings are reset even without the changes from this PR, so when #70255 is fixed, it will automatically affect this setting as well.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
