### PR TITLE
[3.x] Add readahead buffering to FileAccess

### DIFF
--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -133,9 +133,13 @@ Error FileAccessCompressed::_open(const String &p_path, int p_mode_flags) {
 		}
 	}
 
+	// FileAccessCompressed seems to generally work better using only internal buffering
+	// rather than FileAccess buffering. If desired to use FileAccess buffering, uncomment next line.
+	// choose_buffering(p_mode_flags);
+
 	return OK;
 }
-void FileAccessCompressed::close() {
+void FileAccessCompressed::_close() {
 	if (!f) {
 		return;
 	}
@@ -190,7 +194,7 @@ bool FileAccessCompressed::is_open() const {
 	return f != nullptr;
 }
 
-void FileAccessCompressed::seek(uint64_t p_position) {
+void FileAccessCompressed::_seek(uint64_t p_position) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	if (writing) {
@@ -220,7 +224,7 @@ void FileAccessCompressed::seek(uint64_t p_position) {
 	}
 }
 
-void FileAccessCompressed::seek_end(int64_t p_position) {
+void FileAccessCompressed::_seek_end(int64_t p_position) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 	if (writing) {
 		seek(write_max + p_position);
@@ -229,7 +233,7 @@ void FileAccessCompressed::seek_end(int64_t p_position) {
 	}
 }
 
-uint64_t FileAccessCompressed::get_position() const {
+uint64_t FileAccessCompressed::_get_position() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 	if (writing) {
 		return write_pos;
@@ -247,7 +251,7 @@ uint64_t FileAccessCompressed::get_len() const {
 	}
 }
 
-bool FileAccessCompressed::eof_reached() const {
+bool FileAccessCompressed::_eof_reached() const {
 	ERR_FAIL_COND_V_MSG(!f, false, "File must be opened before use.");
 	if (writing) {
 		return false;
@@ -256,7 +260,7 @@ bool FileAccessCompressed::eof_reached() const {
 	}
 }
 
-uint8_t FileAccessCompressed::get_8() const {
+uint8_t FileAccessCompressed::_get_8() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 	ERR_FAIL_COND_V_MSG(writing, 0, "File has not been opened in read mode.");
 
@@ -288,7 +292,7 @@ uint8_t FileAccessCompressed::get_8() const {
 	return ret;
 }
 
-uint64_t FileAccessCompressed::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
+uint64_t FileAccessCompressed::_get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V_MSG(!f, -1, "File must be opened before use.");
 	ERR_FAIL_COND_V_MSG(writing, -1, "File has not been opened in read mode.");

--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -63,27 +63,26 @@ class FileAccessCompressed : public FileAccess {
 	mutable Vector<uint8_t> buffer;
 	FileAccess *f;
 
+protected:
+	virtual void _close(); ///< close a file
+	virtual void _seek(uint64_t p_position); ///< seek to a given position
+	virtual void _seek_end(int64_t p_position = 0); ///< seek from the end of file
+	virtual uint64_t _get_position() const; ///< get position in the file
+	virtual bool _eof_reached() const; ///< reading passed EOF
+	virtual uint8_t _get_8() const; ///< get a byte
+	virtual uint64_t _get_buffer(uint8_t *p_dst, uint64_t p_length) const;
+
 public:
+	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
+
 	void configure(const String &p_magic, Compression::Mode p_mode = Compression::MODE_ZSTD, uint32_t p_block_size = 4096);
 
 	Error open_after_magic(FileAccess *p_base);
 
-	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
-
-	virtual void seek(uint64_t p_position); ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual uint64_t get_position() const; ///< get position in the file
 	virtual uint64_t get_len() const; ///< get size of the file
 
-	virtual bool eof_reached() const; ///< reading passed EOF
-
-	virtual uint8_t get_8() const; ///< get a byte
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
-
 	virtual Error get_error() const; ///< get last error
-
 	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
 

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -112,7 +112,7 @@ Error FileAccessEncrypted::open_and_parse_password(FileAccess *p_base, const Str
 Error FileAccessEncrypted::_open(const String &p_path, int p_mode_flags) {
 	return OK;
 }
-void FileAccessEncrypted::close() {
+void FileAccessEncrypted::_close() {
 	if (!file) {
 		return;
 	}
@@ -180,7 +180,7 @@ String FileAccessEncrypted::get_path_absolute() const {
 	}
 }
 
-void FileAccessEncrypted::seek(uint64_t p_position) {
+void FileAccessEncrypted::_seek(uint64_t p_position) {
 	if (p_position > get_len()) {
 		p_position = get_len();
 	}
@@ -189,11 +189,11 @@ void FileAccessEncrypted::seek(uint64_t p_position) {
 	eofed = false;
 }
 
-void FileAccessEncrypted::seek_end(int64_t p_position) {
+void FileAccessEncrypted::_seek_end(int64_t p_position) {
 	seek(get_len() + p_position);
 }
 
-uint64_t FileAccessEncrypted::get_position() const {
+uint64_t FileAccessEncrypted::_get_position() const {
 	return pos;
 }
 
@@ -201,11 +201,11 @@ uint64_t FileAccessEncrypted::get_len() const {
 	return data.size();
 }
 
-bool FileAccessEncrypted::eof_reached() const {
+bool FileAccessEncrypted::_eof_reached() const {
 	return eofed;
 }
 
-uint8_t FileAccessEncrypted::get_8() const {
+uint8_t FileAccessEncrypted::_get_8() const {
 	ERR_FAIL_COND_V_MSG(writing, 0, "File has not been opened in read mode.");
 	if (pos >= get_len()) {
 		eofed = true;
@@ -217,7 +217,7 @@ uint8_t FileAccessEncrypted::get_8() const {
 	return b;
 }
 
-uint64_t FileAccessEncrypted::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
+uint64_t FileAccessEncrypted::_get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V_MSG(writing, -1, "File has not been opened in read mode.");
 

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -94,7 +94,7 @@ Error FileAccessMemory::_open(const String &p_path, int p_mode_flags) {
 	return OK;
 }
 
-void FileAccessMemory::close() {
+void FileAccessMemory::_close() {
 	data = nullptr;
 }
 
@@ -102,17 +102,17 @@ bool FileAccessMemory::is_open() const {
 	return data != nullptr;
 }
 
-void FileAccessMemory::seek(uint64_t p_position) {
+void FileAccessMemory::_seek(uint64_t p_position) {
 	ERR_FAIL_COND(!data);
 	pos = p_position;
 }
 
-void FileAccessMemory::seek_end(int64_t p_position) {
+void FileAccessMemory::_seek_end(int64_t p_position) {
 	ERR_FAIL_COND(!data);
 	pos = length + p_position;
 }
 
-uint64_t FileAccessMemory::get_position() const {
+uint64_t FileAccessMemory::_get_position() const {
 	ERR_FAIL_COND_V(!data, 0);
 	return pos;
 }
@@ -122,11 +122,11 @@ uint64_t FileAccessMemory::get_len() const {
 	return length;
 }
 
-bool FileAccessMemory::eof_reached() const {
+bool FileAccessMemory::_eof_reached() const {
 	return pos > length;
 }
 
-uint8_t FileAccessMemory::get_8() const {
+uint8_t FileAccessMemory::_get_8() const {
 	uint8_t ret = 0;
 	if (pos < length) {
 		ret = data[pos];
@@ -136,7 +136,7 @@ uint8_t FileAccessMemory::get_8() const {
 	return ret;
 }
 
-uint64_t FileAccessMemory::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
+uint64_t FileAccessMemory::_get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V(!data, -1);
 

--- a/core/io/file_access_memory.h
+++ b/core/io/file_access_memory.h
@@ -40,26 +40,24 @@ class FileAccessMemory : public FileAccess {
 
 	static FileAccess *create();
 
+protected:
+	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
+	virtual void _close(); ///< close a file
+	virtual void _seek(uint64_t p_position); ///< seek to a given position
+	virtual void _seek_end(int64_t p_position); ///< seek from the end of file
+	virtual uint64_t _get_position() const; ///< get position in the file
+	virtual bool _eof_reached() const; ///< reading passed EOF
+	virtual uint8_t _get_8() const; ///< get a byte
+	virtual uint64_t _get_buffer(uint8_t *p_dst, uint64_t p_length) const; ///< get an array of bytes
+
 public:
 	static void register_file(String p_name, Vector<uint8_t> p_data);
 	static void cleanup();
 
 	virtual Error open_custom(const uint8_t *p_data, uint64_t p_len); ///< open a file
-	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
-	virtual void seek(uint64_t p_position); ///< seek to a given position
-	virtual void seek_end(int64_t p_position); ///< seek from the end of file
-	virtual uint64_t get_position() const; ///< get position in the file
 	virtual uint64_t get_len() const; ///< get size of the file
-
-	virtual bool eof_reached() const; ///< reading passed EOF
-
-	virtual uint8_t get_8() const; ///< get a byte
-
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const; ///< get an array of bytes
-
 	virtual Error get_error() const; ///< get last error
 
 	virtual void flush();

--- a/core/io/file_access_network.cpp
+++ b/core/io/file_access_network.cpp
@@ -290,7 +290,7 @@ Error FileAccessNetwork::_open(const String &p_path, int p_mode_flags) {
 	return response;
 }
 
-void FileAccessNetwork::close() {
+void FileAccessNetwork::_close() {
 	if (!opened) {
 		return;
 	}
@@ -309,7 +309,7 @@ bool FileAccessNetwork::is_open() const {
 	return opened;
 }
 
-void FileAccessNetwork::seek(uint64_t p_position) {
+void FileAccessNetwork::_seek(uint64_t p_position) {
 	ERR_FAIL_COND_MSG(!opened, "File must be opened before use.");
 
 	eof_flag = p_position > total_size;
@@ -321,11 +321,11 @@ void FileAccessNetwork::seek(uint64_t p_position) {
 	pos = p_position;
 }
 
-void FileAccessNetwork::seek_end(int64_t p_position) {
+void FileAccessNetwork::_seek_end(int64_t p_position) {
 	seek(total_size + p_position);
 }
 
-uint64_t FileAccessNetwork::get_position() const {
+uint64_t FileAccessNetwork::_get_position() const {
 	ERR_FAIL_COND_V_MSG(!opened, 0, "File must be opened before use.");
 	return pos;
 }
@@ -335,12 +335,12 @@ uint64_t FileAccessNetwork::get_len() const {
 	return total_size;
 }
 
-bool FileAccessNetwork::eof_reached() const {
+bool FileAccessNetwork::_eof_reached() const {
 	ERR_FAIL_COND_V_MSG(!opened, false, "File must be opened before use.");
 	return eof_flag;
 }
 
-uint8_t FileAccessNetwork::get_8() const {
+uint8_t FileAccessNetwork::_get_8() const {
 	uint8_t v;
 	get_buffer(&v, 1);
 	return v;
@@ -367,7 +367,7 @@ void FileAccessNetwork::_queue_page(int32_t p_page) const {
 	}
 }
 
-uint64_t FileAccessNetwork::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
+uint64_t FileAccessNetwork::_get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 
 	if (pos + p_length > total_size) {

--- a/core/io/file_access_network.h
+++ b/core/io/file_access_network.h
@@ -117,6 +117,16 @@ class FileAccessNetwork : public FileAccess {
 	void _respond(uint64_t p_len, Error p_status);
 	void _set_block(uint64_t p_offset, const Vector<uint8_t> &p_block);
 
+protected:
+	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
+	virtual void _close(); ///< close a file
+	virtual void _seek(uint64_t p_position); ///< seek to a given position
+	virtual void _seek_end(int64_t p_position = 0); ///< seek from the end of file
+	virtual uint64_t _get_position() const; ///< get position in the file
+	virtual bool _eof_reached() const; ///< reading passed EOF
+	virtual uint8_t _get_8() const; ///< get a byte
+	virtual uint64_t _get_buffer(uint8_t *p_dst, uint64_t p_length) const;
+
 public:
 	enum Command {
 		COMMAND_OPEN_FILE,
@@ -133,22 +143,10 @@ public:
 		RESPONSE_GET_MODTIME,
 	};
 
-	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
-
-	virtual void seek(uint64_t p_position); ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual uint64_t get_position() const; ///< get position in the file
 	virtual uint64_t get_len() const; ///< get size of the file
 
-	virtual bool eof_reached() const; ///< reading passed EOF
-
-	virtual uint8_t get_8() const; ///< get a byte
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
-
 	virtual Error get_error() const; ///< get last error
-
 	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
 

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -257,7 +257,7 @@ Error FileAccessPack::_open(const String &p_path, int p_mode_flags) {
 	return ERR_UNAVAILABLE;
 }
 
-void FileAccessPack::close() {
+void FileAccessPack::_close() {
 	f->close();
 }
 
@@ -265,7 +265,7 @@ bool FileAccessPack::is_open() const {
 	return f->is_open();
 }
 
-void FileAccessPack::seek(uint64_t p_position) {
+void FileAccessPack::_seek(uint64_t p_position) {
 	if (p_position > pf.size) {
 		eof = true;
 	} else {
@@ -276,11 +276,11 @@ void FileAccessPack::seek(uint64_t p_position) {
 	pos = p_position;
 }
 
-void FileAccessPack::seek_end(int64_t p_position) {
+void FileAccessPack::_seek_end(int64_t p_position) {
 	seek(pf.size + p_position);
 }
 
-uint64_t FileAccessPack::get_position() const {
+uint64_t FileAccessPack::_get_position() const {
 	return pos;
 }
 
@@ -288,11 +288,11 @@ uint64_t FileAccessPack::get_len() const {
 	return pf.size;
 }
 
-bool FileAccessPack::eof_reached() const {
+bool FileAccessPack::_eof_reached() const {
 	return eof;
 }
 
-uint8_t FileAccessPack::get_8() const {
+uint8_t FileAccessPack::_get_8() const {
 	if (pos >= pf.size) {
 		eof = true;
 		return 0;
@@ -302,7 +302,7 @@ uint8_t FileAccessPack::get_8() const {
 	return f->get_8();
 }
 
-uint64_t FileAccessPack::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
+uint64_t FileAccessPack::_get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 
 	if (eof) {
@@ -325,7 +325,7 @@ uint64_t FileAccessPack::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	return to_read;
 }
 
-void FileAccessPack::set_endian_swap(bool p_swap) {
+void FileAccessPack::_set_endian_swap(bool p_swap) {
 	FileAccess::set_endian_swap(p_swap);
 	f->set_endian_swap(p_swap);
 }

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -148,30 +148,25 @@ class FileAccessPack : public FileAccess {
 	virtual uint32_t _get_unix_permissions(const String &p_file) { return 0; }
 	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions) { return FAILED; }
 
-public:
-	virtual void close();
-	virtual bool is_open() const;
+protected:
+	virtual void _close();
+	virtual void _seek(uint64_t p_position);
+	virtual void _seek_end(int64_t p_position = 0);
+	virtual uint64_t _get_position() const;
+	virtual bool _eof_reached() const;
+	virtual uint8_t _get_8() const;
+	virtual uint64_t _get_buffer(uint8_t *p_dst, uint64_t p_length) const;
+	virtual void _set_endian_swap(bool p_swap);
 
-	virtual void seek(uint64_t p_position);
-	virtual void seek_end(int64_t p_position = 0);
-	virtual uint64_t get_position() const;
+public:
+	virtual bool is_open() const;
 	virtual uint64_t get_len() const;
 
-	virtual bool eof_reached() const;
-
-	virtual uint8_t get_8() const;
-
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
-
-	virtual void set_endian_swap(bool p_swap);
-
 	virtual Error get_error() const;
-
 	virtual void flush();
 	virtual void store_8(uint8_t p_dest);
 
 	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length);
-
 	virtual bool file_exists(const String &p_name);
 
 	FileAccessPack(const String &p_path, const PackedData::PackedFile &p_file);

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -250,7 +250,7 @@ Error FileAccessZip::_open(const String &p_path, int p_mode_flags) {
 	return OK;
 }
 
-void FileAccessZip::close() {
+void FileAccessZip::_close() {
 	if (!zfile) {
 		return;
 	}
@@ -265,18 +265,18 @@ bool FileAccessZip::is_open() const {
 	return zfile != nullptr;
 }
 
-void FileAccessZip::seek(uint64_t p_position) {
+void FileAccessZip::_seek(uint64_t p_position) {
 	ERR_FAIL_COND(!zfile);
 
 	unzSeekCurrentFile(zfile, p_position);
 }
 
-void FileAccessZip::seek_end(int64_t p_position) {
+void FileAccessZip::_seek_end(int64_t p_position) {
 	ERR_FAIL_COND(!zfile);
 	unzSeekCurrentFile(zfile, get_len() + p_position);
 }
 
-uint64_t FileAccessZip::get_position() const {
+uint64_t FileAccessZip::_get_position() const {
 	ERR_FAIL_COND_V(!zfile, 0);
 	return unztell(zfile);
 }
@@ -286,19 +286,19 @@ uint64_t FileAccessZip::get_len() const {
 	return file_info.uncompressed_size;
 }
 
-bool FileAccessZip::eof_reached() const {
+bool FileAccessZip::_eof_reached() const {
 	ERR_FAIL_COND_V(!zfile, true);
 
 	return at_eof;
 }
 
-uint8_t FileAccessZip::get_8() const {
+uint8_t FileAccessZip::_get_8() const {
 	uint8_t ret = 0;
 	get_buffer(&ret, 1);
 	return ret;
 }
 
-uint64_t FileAccessZip::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
+uint64_t FileAccessZip::_get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V(!zfile, -1);
 

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -86,23 +86,21 @@ class FileAccessZip : public FileAccess {
 
 	mutable bool at_eof;
 
-public:
+protected:
 	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual void close(); ///< close a file
-	virtual bool is_open() const; ///< true when file is open
+	virtual void _close(); ///< close a file
+	virtual void _seek(uint64_t p_position); ///< seek to a given position
+	virtual void _seek_end(int64_t p_position = 0); ///< seek from the end of file
+	virtual uint64_t _get_position() const; ///< get position in the file
+	virtual bool _eof_reached() const; ///< reading passed EOF
+	virtual uint8_t _get_8() const; ///< get a byte
+	virtual uint64_t _get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
-	virtual void seek(uint64_t p_position); ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual uint64_t get_position() const; ///< get position in the file
+public:
+	virtual bool is_open() const; ///< true when file is open
 	virtual uint64_t get_len() const; ///< get size of the file
 
-	virtual bool eof_reached() const; ///< reading passed EOF
-
-	virtual uint8_t get_8() const; ///< get a byte
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
-
 	virtual Error get_error() const; ///< get last error
-
 	virtual void flush();
 	virtual void store_8(uint8_t p_dest); ///< store a byte
 

--- a/core/os/file_access_buffer.cpp
+++ b/core/os/file_access_buffer.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  file_access_encrypted.h                                              */
+/*  file_access_buffer.cpp                                               */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,65 +28,31 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef FILE_ACCESS_ENCRYPTED_H
-#define FILE_ACCESS_ENCRYPTED_H
+#include "file_access_buffer.h"
 
-#include "core/os/file_access.h"
+#include "core/error_macros.h"
 
-class FileAccessEncrypted : public FileAccess {
-public:
-	enum Mode {
-		MODE_READ,
-		MODE_WRITE_AES256,
-		MODE_MAX
-	};
+uint8_t *FileAccessBuffer::get_current_data() {
+	DEV_ASSERT(readahead_pointer < BUFFER_SIZE);
+	return &data[readahead_pointer];
+}
 
-private:
-	Mode mode;
-	Vector<uint8_t> key;
-	bool writing;
-	FileAccess *file;
-	uint64_t base;
-	uint64_t length;
-	Vector<uint8_t> data;
-	mutable uint64_t pos;
-	mutable bool eofed;
+const uint8_t *FileAccessBuffer::get_current_data() const {
+	DEV_ASSERT(readahead_pointer < BUFFER_SIZE);
+	return &data[readahead_pointer];
+}
 
-public:
-	Error open_and_parse(FileAccess *p_base, const Vector<uint8_t> &p_key, Mode p_mode);
-	Error open_and_parse_password(FileAccess *p_base, const String &p_key, Mode p_mode);
+uint32_t FileAccessBuffer::get_buffer_offset() const {
+	DEV_ASSERT(readahead_filled >= readahead_pointer);
+	return readahead_filled - readahead_pointer;
+}
 
-	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual void _close(); ///< close a file
-	virtual bool is_open() const; ///< true when file is open
+bool FileAccessBuffer::is_buffer_empty() const {
+	return get_buffer_offset() == 0;
+}
 
-	virtual String get_path() const; /// returns the path for the current open file
-	virtual String get_path_absolute() const; /// returns the absolute path for the current open file
-
-	virtual void _seek(uint64_t p_position); ///< seek to a given position
-	virtual void _seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual uint64_t _get_position() const; ///< get position in the file
-	virtual uint64_t get_len() const; ///< get size of the file
-
-	virtual bool _eof_reached() const; ///< reading passed EOF
-
-	virtual uint8_t _get_8() const; ///< get a byte
-	virtual uint64_t _get_buffer(uint8_t *p_dst, uint64_t p_length) const;
-
-	virtual Error get_error() const; ///< get last error
-
-	virtual void flush();
-	virtual void store_8(uint8_t p_dest); ///< store a byte
-	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length); ///< store an array of bytes
-
-	virtual bool file_exists(const String &p_name); ///< return true if a file exists
-
-	virtual uint64_t _get_modified_time(const String &p_file);
-	virtual uint32_t _get_unix_permissions(const String &p_file);
-	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions);
-
-	FileAccessEncrypted();
-	~FileAccessEncrypted();
-};
-
-#endif // FILE_ACCESS_ENCRYPTED_H
+void FileAccessBuffer::invalidate(bool p_eof) {
+	readahead_filled = 0;
+	readahead_pointer = 0;
+	eof = p_eof;
+}

--- a/core/os/file_access_buffer.h
+++ b/core/os/file_access_buffer.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  file_access_encrypted.h                                              */
+/*  file_access_buffer.h                                                 */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,65 +28,26 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef FILE_ACCESS_ENCRYPTED_H
-#define FILE_ACCESS_ENCRYPTED_H
+#ifndef FILE_ACCESS_BUFFER_H
+#define FILE_ACCESS_BUFFER_H
 
-#include "core/os/file_access.h"
+#include <stdint.h>
 
-class FileAccessEncrypted : public FileAccess {
-public:
-	enum Mode {
-		MODE_READ,
-		MODE_WRITE_AES256,
-		MODE_MAX
-	};
+struct FileAccessBuffer {
+	// 512 is best balance empirically.
+	// slim if any improvement above this,
+	// but large gain even with 8 plus
+	enum { BUFFER_SIZE = 512 };
+	uint8_t data[BUFFER_SIZE];
+	uint32_t readahead_pointer = 0;
+	uint32_t readahead_filled = 0;
+	bool eof = false;
 
-private:
-	Mode mode;
-	Vector<uint8_t> key;
-	bool writing;
-	FileAccess *file;
-	uint64_t base;
-	uint64_t length;
-	Vector<uint8_t> data;
-	mutable uint64_t pos;
-	mutable bool eofed;
-
-public:
-	Error open_and_parse(FileAccess *p_base, const Vector<uint8_t> &p_key, Mode p_mode);
-	Error open_and_parse_password(FileAccess *p_base, const String &p_key, Mode p_mode);
-
-	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual void _close(); ///< close a file
-	virtual bool is_open() const; ///< true when file is open
-
-	virtual String get_path() const; /// returns the path for the current open file
-	virtual String get_path_absolute() const; /// returns the absolute path for the current open file
-
-	virtual void _seek(uint64_t p_position); ///< seek to a given position
-	virtual void _seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual uint64_t _get_position() const; ///< get position in the file
-	virtual uint64_t get_len() const; ///< get size of the file
-
-	virtual bool _eof_reached() const; ///< reading passed EOF
-
-	virtual uint8_t _get_8() const; ///< get a byte
-	virtual uint64_t _get_buffer(uint8_t *p_dst, uint64_t p_length) const;
-
-	virtual Error get_error() const; ///< get last error
-
-	virtual void flush();
-	virtual void store_8(uint8_t p_dest); ///< store a byte
-	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length); ///< store an array of bytes
-
-	virtual bool file_exists(const String &p_name); ///< return true if a file exists
-
-	virtual uint64_t _get_modified_time(const String &p_file);
-	virtual uint32_t _get_unix_permissions(const String &p_file);
-	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions);
-
-	FileAccessEncrypted();
-	~FileAccessEncrypted();
+	bool is_buffer_empty() const;
+	uint32_t get_buffer_offset() const;
+	void invalidate(bool p_eof);
+	const uint8_t *get_current_data() const;
+	uint8_t *get_current_data();
 };
 
-#endif // FILE_ACCESS_ENCRYPTED_H
+#endif // FILE_ACCESS_BUFFER_H

--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -35,90 +35,34 @@
 #include "core/os/keyboard.h"
 #include "core/string_buffer.h"
 
-CharType VariantParser::Stream::get_char() {
-	// is within buffer?
-	if (readahead_pointer < readahead_filled) {
-		return readahead_buffer[readahead_pointer++];
-	}
-
-	// attempt to readahead
-	readahead_filled = _read_buffer(readahead_buffer, readahead_enabled ? READAHEAD_SIZE : 1);
-	if (readahead_filled) {
-		readahead_pointer = 0;
-	} else {
-		// EOF
-		readahead_pointer = 1;
-		eof = true;
-		return 0;
-	}
-	return get_char();
-}
-
-bool VariantParser::Stream::is_eof() const {
-	if (readahead_enabled) {
-		return eof;
-	}
-	return _is_eof();
-}
-
-uint32_t VariantParser::StreamFile::_read_buffer(CharType *p_buffer, uint32_t p_num_chars) {
-	// The buffer is assumed to include at least one character (for null terminator)
-	ERR_FAIL_COND_V(!p_num_chars, 0);
-
-	uint8_t *temp = (uint8_t *)alloca(p_num_chars);
-	uint64_t num_read = f->get_buffer(temp, p_num_chars);
-	ERR_FAIL_COND_V(num_read == UINT64_MAX, 0);
-
-	// translate to wchar
-	for (uint32_t n = 0; n < num_read; n++) {
-		p_buffer[n] = temp[n];
-	}
-
-	// could be less than p_num_chars, or zero
-	return num_read;
+CharType VariantParser::StreamFile::get_char() {
+	return f->get_8();
 }
 
 bool VariantParser::StreamFile::is_utf8() const {
 	return true;
 }
-
-bool VariantParser::StreamFile::_is_eof() const {
+bool VariantParser::StreamFile::is_eof() const {
 	return f->eof_reached();
 }
 
-uint32_t VariantParser::StreamString::_read_buffer(CharType *p_buffer, uint32_t p_num_chars) {
-	// The buffer is assumed to include at least one character (for null terminator)
-	ERR_FAIL_COND_V(!p_num_chars, 0);
-
-	int available = MAX(s.length() - pos, 0);
-	if (available >= (int)p_num_chars) {
-		const CharType *src = s.ptr();
-		src += pos;
-		memcpy(p_buffer, src, p_num_chars * sizeof(CharType));
-		pos += p_num_chars;
-
-		return p_num_chars;
+CharType VariantParser::StreamString::get_char() {
+	if (pos > s.length()) {
+		return 0;
+	} else if (pos == s.length()) {
+		// You need to try to read again when you have reached the end for EOF to be reported,
+		// so this works the same as files (like StreamFile does)
+		pos++;
+		return 0;
+	} else {
+		return s[pos++];
 	}
-
-	// going to reach EOF
-	if (available) {
-		const CharType *src = s.ptr();
-		src += pos;
-		memcpy(p_buffer, src, available * sizeof(CharType));
-		pos += available;
-	}
-
-	// add a zero
-	p_buffer[available] = 0;
-
-	return available;
 }
 
 bool VariantParser::StreamString::is_utf8() const {
 	return false;
 }
-
-bool VariantParser::StreamString::_is_eof() const {
+bool VariantParser::StreamString::is_eof() const {
 	return pos > s.length();
 }
 

--- a/core/variant_parser.h
+++ b/core/variant_parser.h
@@ -38,24 +38,11 @@
 class VariantParser {
 public:
 	struct Stream {
-	private:
-		enum { READAHEAD_SIZE = 2048 };
-		CharType readahead_buffer[READAHEAD_SIZE];
-		uint32_t readahead_pointer = 0;
-		uint32_t readahead_filled = 0;
-		bool eof = false;
-
-	protected:
-		bool readahead_enabled = true;
-		virtual uint32_t _read_buffer(CharType *p_buffer, uint32_t p_num_chars) = 0;
-		virtual bool _is_eof() const = 0;
-
-	public:
-		CharType saved;
-
-		CharType get_char();
+		virtual CharType get_char() = 0;
 		virtual bool is_utf8() const = 0;
-		bool is_eof() const;
+		virtual bool is_eof() const = 0;
+
+		CharType saved;
 
 		Stream() :
 				saved(0) {}
@@ -63,36 +50,24 @@ public:
 	};
 
 	struct StreamFile : public Stream {
-	protected:
-		virtual uint32_t _read_buffer(CharType *p_buffer, uint32_t p_num_chars);
-		virtual bool _is_eof() const;
-
-	public:
 		FileAccess *f;
 
+		virtual CharType get_char();
 		virtual bool is_utf8() const;
-		StreamFile(bool p_readahead_enabled = true) {
-			f = nullptr;
-			readahead_enabled = p_readahead_enabled;
-		}
+		virtual bool is_eof() const;
+
+		StreamFile() { f = nullptr; }
 	};
 
 	struct StreamString : public Stream {
-	private:
+		String s;
 		int pos;
 
-	protected:
-		virtual uint32_t _read_buffer(CharType *p_buffer, uint32_t p_num_chars);
-		virtual bool _is_eof() const;
-
-	public:
-		String s;
-
+		virtual CharType get_char();
 		virtual bool is_utf8() const;
-		StreamString(bool p_readahead_enabled = true) {
-			pos = 0;
-			readahead_enabled = p_readahead_enabled;
-		}
+		virtual bool is_eof() const;
+
+		StreamString() { pos = 0; }
 	};
 
 	typedef Error (*ParseResourceFunc)(void *p_self, Stream *p_stream, Ref<Resource> &r_res, int &line, String &r_err_str);

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -148,7 +148,7 @@ Error FileAccessUnix::_open(const String &p_path, int p_mode_flags) {
 	return OK;
 }
 
-void FileAccessUnix::close() {
+void FileAccessUnix::_close() {
 	if (!f) {
 		return;
 	}
@@ -184,7 +184,7 @@ String FileAccessUnix::get_path_absolute() const {
 	return path;
 }
 
-void FileAccessUnix::seek(uint64_t p_position) {
+void FileAccessUnix::_seek(uint64_t p_position) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	last_error = OK;
@@ -193,7 +193,7 @@ void FileAccessUnix::seek(uint64_t p_position) {
 	}
 }
 
-void FileAccessUnix::seek_end(int64_t p_position) {
+void FileAccessUnix::_seek_end(int64_t p_position) {
 	ERR_FAIL_COND_MSG(!f, "File must be opened before use.");
 
 	if (fseeko(f, p_position, SEEK_END)) {
@@ -201,7 +201,7 @@ void FileAccessUnix::seek_end(int64_t p_position) {
 	}
 }
 
-uint64_t FileAccessUnix::get_position() const {
+uint64_t FileAccessUnix::_get_position() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 
 	int64_t pos = ftello(f);
@@ -225,11 +225,11 @@ uint64_t FileAccessUnix::get_len() const {
 	return size;
 }
 
-bool FileAccessUnix::eof_reached() const {
+bool FileAccessUnix::_eof_reached() const {
 	return last_error == ERR_FILE_EOF;
 }
 
-uint8_t FileAccessUnix::get_8() const {
+uint8_t FileAccessUnix::_get_8() const {
 	ERR_FAIL_COND_V_MSG(!f, 0, "File must be opened before use.");
 	uint8_t b;
 	if (fread(&b, 1, 1, f) == 0) {
@@ -239,7 +239,7 @@ uint8_t FileAccessUnix::get_8() const {
 	return b;
 }
 
-uint64_t FileAccessUnix::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
+uint64_t FileAccessUnix::_get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V_MSG(!f, -1, "File must be opened before use.");
 

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -49,26 +49,24 @@ class FileAccessUnix : public FileAccess {
 	String path;
 	String path_src;
 
+protected:
+	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
+	virtual void _close(); ///< close a file
+	virtual void _seek(uint64_t p_position); ///< seek to a given position
+	virtual void _seek_end(int64_t p_position = 0); ///< seek from the end of file
+	virtual uint64_t _get_position() const; ///< get position in the file
+	virtual bool _eof_reached() const; ///< reading passed EOF
+	virtual uint8_t _get_8() const; ///< get a byte
+	virtual uint64_t _get_buffer(uint8_t *p_dst, uint64_t p_length) const;
+
 public:
 	static CloseNotificationFunc close_notification_func;
-
-	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
 	virtual String get_path() const; /// returns the path for the current open file
 	virtual String get_path_absolute() const; /// returns the absolute path for the current open file
 
-	virtual void seek(uint64_t p_position); ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual uint64_t get_position() const; ///< get position in the file
 	virtual uint64_t get_len() const; ///< get size of the file
-
-	virtual bool eof_reached() const; ///< reading passed EOF
-
-	virtual uint8_t get_8() const; ///< get a byte
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
-
 	virtual Error get_error() const; ///< get last error
 
 	virtual void flush();

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -131,7 +131,7 @@ Error FileAccessWindows::_open(const String &p_path, int p_mode_flags) {
 	}
 }
 
-void FileAccessWindows::close() {
+void FileAccessWindows::_close() {
 	if (!f)
 		return;
 
@@ -191,7 +191,7 @@ bool FileAccessWindows::is_open() const {
 	return (f != NULL);
 }
 
-void FileAccessWindows::seek(uint64_t p_position) {
+void FileAccessWindows::_seek(uint64_t p_position) {
 	ERR_FAIL_COND(!f);
 
 	last_error = OK;
@@ -200,14 +200,14 @@ void FileAccessWindows::seek(uint64_t p_position) {
 	prev_op = 0;
 }
 
-void FileAccessWindows::seek_end(int64_t p_position) {
+void FileAccessWindows::_seek_end(int64_t p_position) {
 	ERR_FAIL_COND(!f);
 	if (_fseeki64(f, p_position, SEEK_END))
 		check_errors();
 	prev_op = 0;
 }
 
-uint64_t FileAccessWindows::get_position() const {
+uint64_t FileAccessWindows::_get_position() const {
 	int64_t aux_position = _ftelli64(f);
 	if (aux_position < 0) {
 		check_errors();
@@ -226,12 +226,12 @@ uint64_t FileAccessWindows::get_len() const {
 	return size;
 }
 
-bool FileAccessWindows::eof_reached() const {
+bool FileAccessWindows::_eof_reached() const {
 	check_errors();
 	return last_error == ERR_FILE_EOF;
 }
 
-uint8_t FileAccessWindows::get_8() const {
+uint8_t FileAccessWindows::_get_8() const {
 	ERR_FAIL_COND_V(!f, 0);
 	if (flags == READ_WRITE || flags == WRITE_READ) {
 		if (prev_op == WRITE) {
@@ -248,7 +248,7 @@ uint8_t FileAccessWindows::get_8() const {
 	return b;
 }
 
-uint64_t FileAccessWindows::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
+uint64_t FileAccessWindows::_get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 	ERR_FAIL_COND_V(!f, -1);
 

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -48,24 +48,23 @@ class FileAccessWindows : public FileAccess {
 	String path_src;
 	String save_path;
 
-public:
+protected:
 	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual void close(); ///< close a file
+	virtual void _close(); ///< close a file
+	virtual void _seek(uint64_t p_position); ///< seek to a given position
+	virtual void _seek_end(int64_t p_position = 0); ///< seek from the end of file
+	virtual uint64_t _get_position() const; ///< get position in the file
+	virtual bool _eof_reached() const; ///< reading passed EOF
+	virtual uint8_t _get_8() const; ///< get a byte
+	virtual uint64_t _get_buffer(uint8_t *p_dst, uint64_t p_length) const;
+
+public:
 	virtual bool is_open() const; ///< true when file is open
 
 	virtual String get_path() const; /// returns the path for the current open file
 	virtual String get_path_absolute() const; /// returns the absolute path for the current open file
 
-	virtual void seek(uint64_t p_position); ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual uint64_t get_position() const; ///< get position in the file
 	virtual uint64_t get_len() const; ///< get size of the file
-
-	virtual bool eof_reached() const; ///< reading passed EOF
-
-	virtual uint8_t get_8() const; ///< get a byte
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
-
 	virtual Error get_error() const; ///< get last error
 
 	virtual void flush();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3736,7 +3736,11 @@ void EditorNode::open_request(const String &p_path) {
 		}
 	}
 
+	uint32_t before = OS::get_singleton()->get_ticks_msec();
 	load_scene(p_path); // as it will be opened in separate tab
+	uint32_t after = OS::get_singleton()->get_ticks_msec();
+
+	print_line("EditorNode::load_scene() took " + itos(after - before) + " ms.");
 }
 
 void EditorNode::request_instance_scene(const String &p_path) {

--- a/platform/android/file_access_android.cpp
+++ b/platform/android/file_access_android.cpp
@@ -63,7 +63,7 @@ Error FileAccessAndroid::_open(const String &p_path, int p_mode_flags) {
 	return OK;
 }
 
-void FileAccessAndroid::close() {
+void FileAccessAndroid::_close() {
 	if (!asset) {
 		return;
 	}
@@ -75,7 +75,7 @@ bool FileAccessAndroid::is_open() const {
 	return asset != nullptr;
 }
 
-void FileAccessAndroid::seek(uint64_t p_position) {
+void FileAccessAndroid::_seek(uint64_t p_position) {
 	ERR_FAIL_NULL(asset);
 
 	AAsset_seek(asset, p_position, SEEK_SET);
@@ -88,13 +88,13 @@ void FileAccessAndroid::seek(uint64_t p_position) {
 	}
 }
 
-void FileAccessAndroid::seek_end(int64_t p_position) {
+void FileAccessAndroid::_seek_end(int64_t p_position) {
 	ERR_FAIL_NULL(asset);
 	AAsset_seek(asset, p_position, SEEK_END);
 	pos = len + p_position;
 }
 
-uint64_t FileAccessAndroid::get_position() const {
+uint64_t FileAccessAndroid::_get_position() const {
 	return pos;
 }
 
@@ -102,11 +102,11 @@ uint64_t FileAccessAndroid::get_len() const {
 	return len;
 }
 
-bool FileAccessAndroid::eof_reached() const {
+bool FileAccessAndroid::_eof_reached() const {
 	return eof;
 }
 
-uint8_t FileAccessAndroid::get_8() const {
+uint8_t FileAccessAndroid::_get_8() const {
 	if (pos >= len) {
 		eof = true;
 		return 0;
@@ -118,7 +118,7 @@ uint8_t FileAccessAndroid::get_8() const {
 	return byte;
 }
 
-uint64_t FileAccessAndroid::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
+uint64_t FileAccessAndroid::_get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 
 	int r = AAsset_read(asset, p_dst, p_length);

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -44,28 +44,28 @@ class FileAccessAndroid : public FileAccess {
 	String absolute_path;
 	String path_src;
 
+protected:
+	virtual Error _open(const String &p_path, int p_mode_flags); // open a file
+	virtual void _close(); // close a file
+	virtual void _seek(uint64_t p_position); // seek to a given position
+	virtual void _seek_end(int64_t p_position = 0); // seek from the end of file
+	virtual uint64_t _get_position() const; // get position in the file
+	virtual bool _eof_reached() const; // reading passed EOF
+	virtual uint8_t _get_8() const; // get a byte
+	virtual uint64_t _get_buffer(uint8_t *p_dst, uint64_t p_length) const;
+
 public:
 	static AAssetManager *asset_manager;
 
-	virtual Error _open(const String &p_path, int p_mode_flags); // open a file
-	virtual void close(); // close a file
 	virtual bool is_open() const; // true when file is open
 
 	/// returns the path for the current open file
 	virtual String get_path() const;
+
 	/// returns the absolute path for the current open file
 	virtual String get_path_absolute() const;
 
-	virtual void seek(uint64_t p_position); // seek to a given position
-	virtual void seek_end(int64_t p_position = 0); // seek from the end of file
-	virtual uint64_t get_position() const; // get position in the file
 	virtual uint64_t get_len() const; // get size of the file
-
-	virtual bool eof_reached() const; // reading passed EOF
-
-	virtual uint8_t get_8() const; // get a byte
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
-
 	virtual Error get_error() const; // get last error
 
 	virtual void flush();

--- a/platform/android/file_access_filesystem_jandroid.cpp
+++ b/platform/android/file_access_filesystem_jandroid.cpp
@@ -94,7 +94,7 @@ Error FileAccessFilesystemJAndroid::_open(const String &p_path, int p_mode_flags
 	}
 }
 
-void FileAccessFilesystemJAndroid::close() {
+void FileAccessFilesystemJAndroid::_close() {
 	if (!is_open()) {
 		return;
 	}
@@ -111,7 +111,7 @@ bool FileAccessFilesystemJAndroid::is_open() const {
 	return id != 0;
 }
 
-void FileAccessFilesystemJAndroid::seek(uint64_t p_position) {
+void FileAccessFilesystemJAndroid::_seek(uint64_t p_position) {
 	if (_file_seek) {
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_COND(env == nullptr);
@@ -120,7 +120,7 @@ void FileAccessFilesystemJAndroid::seek(uint64_t p_position) {
 	}
 }
 
-void FileAccessFilesystemJAndroid::seek_end(int64_t p_position) {
+void FileAccessFilesystemJAndroid::_seek_end(int64_t p_position) {
 	if (_file_seek_end) {
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_COND(env == nullptr);
@@ -129,7 +129,7 @@ void FileAccessFilesystemJAndroid::seek_end(int64_t p_position) {
 	}
 }
 
-uint64_t FileAccessFilesystemJAndroid::get_position() const {
+uint64_t FileAccessFilesystemJAndroid::_get_position() const {
 	if (_file_tell) {
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_COND_V(env == nullptr, 0);
@@ -151,7 +151,7 @@ uint64_t FileAccessFilesystemJAndroid::get_len() const {
 	}
 }
 
-bool FileAccessFilesystemJAndroid::eof_reached() const {
+bool FileAccessFilesystemJAndroid::_eof_reached() const {
 	if (_file_eof) {
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_COND_V(env == nullptr, false);
@@ -172,7 +172,7 @@ void FileAccessFilesystemJAndroid::_set_eof(bool eof) {
 	}
 }
 
-uint8_t FileAccessFilesystemJAndroid::get_8() const {
+uint8_t FileAccessFilesystemJAndroid::_get_8() const {
 	ERR_FAIL_COND_V_MSG(!is_open(), 0, "File must be opened before use.");
 	uint8_t byte;
 	get_buffer(&byte, 1);
@@ -225,7 +225,7 @@ String FileAccessFilesystemJAndroid::get_line() const {
 	return result;
 }
 
-uint64_t FileAccessFilesystemJAndroid::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
+uint64_t FileAccessFilesystemJAndroid::_get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	if (_file_read) {
 		ERR_FAIL_COND_V_MSG(!is_open(), 0, "File must be opened before use.");
 		if (p_length == 0) {

--- a/platform/android/file_access_filesystem_jandroid.h
+++ b/platform/android/file_access_filesystem_jandroid.h
@@ -58,27 +58,27 @@ class FileAccessFilesystemJAndroid : public FileAccess {
 
 	void _set_eof(bool eof);
 
-public:
+protected:
 	virtual Error _open(const String &p_path, int p_mode_flags) override; ///< open a file
-	virtual void close() override; ///< close a file
+	virtual void _close() override; ///< close a file
+	virtual void _seek(uint64_t p_position) override; ///< seek to a given position
+	virtual void _seek_end(int64_t p_position = 0) override; ///< seek from the end of file
+	virtual uint64_t _get_position() const override; ///< get position in the file
+	virtual bool _eof_reached() const override; ///< reading passed EOF
+	virtual uint8_t _get_8() const override; ///< get a byte
+	virtual uint64_t _get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
+
+public:
 	virtual bool is_open() const override; ///< true when file is open
 
 	/// returns the path for the current open file
 	virtual String get_path() const override;
+
 	/// returns the absolute path for the current open file
 	virtual String get_path_absolute() const override;
 
-	virtual void seek(uint64_t p_position) override; ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
-	virtual uint64_t get_position() const override; ///< get position in the file
 	virtual uint64_t get_len() const override; ///< get size of the file
-
-	virtual bool eof_reached() const override; ///< reading passed EOF
-
-	virtual uint8_t get_8() const override; ///< get a byte
 	virtual String get_line() const override; ///< get a line
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
-
 	virtual Error get_error() const override; ///< get last error
 
 	virtual void flush() override;

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -629,8 +629,7 @@ void ResourceInteractiveLoaderText::set_translation_remapped(bool p_remapped) {
 	translation_remapped = p_remapped;
 }
 
-ResourceInteractiveLoaderText::ResourceInteractiveLoaderText() :
-		stream(false) {
+ResourceInteractiveLoaderText::ResourceInteractiveLoaderText() {
 	translation_remapped = false;
 }
 


### PR DESCRIPTION
Moves readahead buffering from `VariantParser` to `FileAccess`.
Reverts readahead buffering from `VariantParser`.

Alternative to #70254

## Implementation
* Changes most of the `FileAccess` functions to be underscored, and changes them to `protected`, so they can be wrapped by public functions in `FileAccess` that enable readahead buffering.

## Notes
* Just making draft for comparison to the approach in #70254
* Still needs a little more work to finalize
* Has the advantage that the file pointer cannot get out of sync versus the approach with readahead in `VariantParser`
* All file types automatically get buffering capability instead of having to add it per `FileAccess` type (I see Android had added this to `get_line()` but this may be able to be removed).
* Not as fast for loading as the `VariantParser` approach.

## Timings
Loading a large scene file:
Old 3560 ms
readahead in `FileAccess` 2100 ms
readahead in `VariantParser` 1700 ms

So we can see this approach is significantly faster than no readahead, but not as fast as `VariantParser`.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
