### PR TITLE
Make NOTIFICATION_MOVED_IN_PARENT opt-in.

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1302,6 +1302,7 @@ CanvasItem::TextureRepeat CanvasItem::get_texture_repeat_in_tree() {
 CanvasItem::CanvasItem() :
 		xform_change(this) {
 	canvas_item = RenderingServer::get_singleton()->canvas_item_create();
+	set_notify_moved_in_parent(true);
 }
 
 CanvasItem::~CanvasItem() {

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -344,6 +344,7 @@ void CanvasLayer::_bind_methods() {
 
 CanvasLayer::CanvasLayer() {
 	canvas = RS::get_singleton()->canvas_create();
+	set_notify_moved_in_parent(true);
 }
 
 CanvasLayer::~CanvasLayer() {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -391,7 +391,9 @@ void Node::_move_child(Node *p_child, int p_index, bool p_ignore_end) {
 	// notification second
 	move_child_notify(p_child);
 	for (int i = motion_from; i <= motion_to; i++) {
-		data.children[i]->notification(NOTIFICATION_MOVED_IN_PARENT);
+		if (data.children[i]->data.notify_moved_in_parent) {
+			data.children[i]->notification(NOTIFICATION_MOVED_IN_PARENT);
+		}
 	}
 	p_child->_propagate_groups_dirty();
 
@@ -1209,8 +1211,11 @@ void Node::remove_child(Node *p_child) {
 	children = data.children.ptrw();
 
 	for (int i = idx; i < child_count; i++) {
-		children[i]->data.index = i;
-		children[i]->notification(NOTIFICATION_MOVED_IN_PARENT);
+		Node *child = children[i];
+		child->data.index = i;
+		if (child->data.notify_moved_in_parent) {
+			child->notification(NOTIFICATION_MOVED_IN_PARENT);
+		}
 	}
 
 	p_child->data.parent = nullptr;
@@ -1219,6 +1224,10 @@ void Node::remove_child(Node *p_child) {
 	if (data.inside_tree) {
 		p_child->_propagate_after_exit_tree();
 	}
+}
+
+void Node::set_notify_moved_in_parent(bool enabled) {
+	data.notify_moved_in_parent = enabled;
 }
 
 int Node::get_child_count(bool p_include_internal) const {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -151,6 +151,8 @@ private:
 		bool display_folded = false;
 		bool editable_instance = false;
 
+		bool notify_moved_in_parent = false;
+
 		mutable NodePath *path_cache = nullptr;
 
 	} data;
@@ -502,6 +504,8 @@ public:
 	Error rpcp(int p_peer_id, const StringName &p_method, const Variant **p_arg, int p_argcount);
 
 	Ref<MultiplayerAPI> get_multiplayer() const;
+
+	void set_notify_moved_in_parent(bool enabled);
 
 	Node();
 	~Node();


### PR DESCRIPTION
Makes it faster to remove non-2D nodes from the scene tree when they have lots of siblings.

This partly solves https://github.com/godotengine/godot/issues/61929 for non-2D nodes, with a very simple change. This is not exclusive to possible improvements mentionned in https://github.com/godotengine/godot/issues/61929#issuecomment-1354351264 (although so far they are for Godot 3).
Only 2D nodes use this notification so I thought it made sense if that notification wasn't always sent to others in the first place. It was causing stalls in my 3D game.
