### PR TITLE
Implement collision impulse in Godot Physics 3D

### DIFF
--- a/doc/classes/PhysicsDirectBodyState3D.xml
+++ b/doc/classes/PhysicsDirectBodyState3D.xml
@@ -152,10 +152,10 @@
 			</description>
 		</method>
 		<method name="get_contact_impulse" qualifiers="const">
-			<return type="float" />
+			<return type="Vector3" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
-				Impulse created by the contact. Only implemented for Bullet physics.
+				Impulse created by the contact.
 			</description>
 		</method>
 		<method name="get_contact_local_normal" qualifiers="const">

--- a/doc/classes/PhysicsDirectBodyState3DExtension.xml
+++ b/doc/classes/PhysicsDirectBodyState3DExtension.xml
@@ -131,7 +131,7 @@
 			</description>
 		</method>
 		<method name="_get_contact_impulse" qualifiers="virtual const">
-			<return type="float" />
+			<return type="Vector3" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 			</description>

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -94,7 +94,7 @@ public:
 
 	EXBIND1RC(Vector3, get_contact_local_position, int)
 	EXBIND1RC(Vector3, get_contact_local_normal, int)
-	EXBIND1RC(real_t, get_contact_impulse, int)
+	EXBIND1RC(Vector3, get_contact_impulse, int)
 	EXBIND1RC(int, get_contact_local_shape, int)
 	EXBIND1RC(RID, get_contact_collider, int)
 	EXBIND1RC(Vector3, get_contact_collider_position, int)

--- a/servers/physics_3d/godot_body_3d.h
+++ b/servers/physics_3d/godot_body_3d.h
@@ -126,6 +126,7 @@ class GodotBody3D : public GodotCollisionObject3D {
 		ObjectID collider_instance_id;
 		RID collider;
 		Vector3 collider_velocity_at_pos;
+		Vector3 impulse;
 	};
 
 	Vector<Contact> contacts; //no contacts by default
@@ -183,7 +184,7 @@ public:
 	_FORCE_INLINE_ int get_max_contacts_reported() const { return contacts.size(); }
 
 	_FORCE_INLINE_ bool can_report_contacts() const { return !contacts.is_empty(); }
-	_FORCE_INLINE_ void add_contact(const Vector3 &p_local_pos, const Vector3 &p_local_normal, real_t p_depth, int p_local_shape, const Vector3 &p_collider_pos, int p_collider_shape, ObjectID p_collider_instance_id, const RID &p_collider, const Vector3 &p_collider_velocity_at_pos);
+	_FORCE_INLINE_ void add_contact(const Vector3 &p_local_pos, const Vector3 &p_local_normal, real_t p_depth, int p_local_shape, const Vector3 &p_collider_pos, int p_collider_shape, ObjectID p_collider_instance_id, const RID &p_collider, const Vector3 &p_collider_velocity_at_pos, const Vector3 &p_impulse);
 
 	_FORCE_INLINE_ void add_exception(const RID &p_exception) { exceptions.insert(p_exception); }
 	_FORCE_INLINE_ void remove_exception(const RID &p_exception) { exceptions.erase(p_exception); }
@@ -347,7 +348,7 @@ public:
 
 //add contact inline
 
-void GodotBody3D::add_contact(const Vector3 &p_local_pos, const Vector3 &p_local_normal, real_t p_depth, int p_local_shape, const Vector3 &p_collider_pos, int p_collider_shape, ObjectID p_collider_instance_id, const RID &p_collider, const Vector3 &p_collider_velocity_at_pos) {
+void GodotBody3D::add_contact(const Vector3 &p_local_pos, const Vector3 &p_local_normal, real_t p_depth, int p_local_shape, const Vector3 &p_collider_pos, int p_collider_shape, ObjectID p_collider_instance_id, const RID &p_collider, const Vector3 &p_collider_velocity_at_pos, const Vector3 &p_impulse) {
 	int c_max = contacts.size();
 
 	if (c_max == 0) {
@@ -387,6 +388,7 @@ void GodotBody3D::add_contact(const Vector3 &p_local_pos, const Vector3 &p_local
 	c[idx].collider_instance_id = p_collider_instance_id;
 	c[idx].collider = p_collider;
 	c[idx].collider_velocity_at_pos = p_collider_velocity_at_pos;
+	c[idx].impulse = p_impulse;
 }
 
 #endif // GODOT_BODY_3D_H

--- a/servers/physics_3d/godot_body_direct_state_3d.cpp
+++ b/servers/physics_3d/godot_body_direct_state_3d.cpp
@@ -188,8 +188,9 @@ Vector3 GodotPhysicsDirectBodyState3D::get_contact_local_normal(int p_contact_id
 	return body->contacts[p_contact_idx].local_normal;
 }
 
-real_t GodotPhysicsDirectBodyState3D::get_contact_impulse(int p_contact_idx) const {
-	return 0.0f; // Only implemented for bullet
+Vector3 GodotPhysicsDirectBodyState3D::get_contact_impulse(int p_contact_idx) const {
+	ERR_FAIL_INDEX_V(p_contact_idx, body->contact_count, Vector3());
+	return body->contacts[p_contact_idx].impulse;
 }
 
 int GodotPhysicsDirectBodyState3D::get_contact_local_shape(int p_contact_idx) const {

--- a/servers/physics_3d/godot_body_direct_state_3d.h
+++ b/servers/physics_3d/godot_body_direct_state_3d.h
@@ -89,7 +89,7 @@ public:
 
 	virtual Vector3 get_contact_local_position(int p_contact_idx) const override;
 	virtual Vector3 get_contact_local_normal(int p_contact_idx) const override;
-	virtual real_t get_contact_impulse(int p_contact_idx) const override;
+	virtual Vector3 get_contact_impulse(int p_contact_idx) const override;
 	virtual int get_contact_local_shape(int p_contact_idx) const override;
 
 	virtual RID get_contact_collider(int p_contact_idx) const override;

--- a/servers/physics_3d/godot_body_pair_3d.h
+++ b/servers/physics_3d/godot_body_pair_3d.h
@@ -44,6 +44,7 @@ protected:
 		Vector3 normal;
 		int index_A = 0, index_B = 0;
 		Vector3 local_A, local_B;
+		Vector3 acc_impulse; // accumulated impulse - only one of the object's impulse is needed as impulse_a == -impulse_b
 		real_t acc_normal_impulse = 0.0; // accumulated normal impulse (Pn)
 		Vector3 acc_tangent_impulse; // accumulated tangent impulse (Pt)
 		real_t acc_bias_impulse = 0.0; // accumulated normal impulse for position bias (Pnb)

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -95,7 +95,7 @@ public:
 
 	virtual Vector3 get_contact_local_position(int p_contact_idx) const = 0;
 	virtual Vector3 get_contact_local_normal(int p_contact_idx) const = 0;
-	virtual real_t get_contact_impulse(int p_contact_idx) const = 0;
+	virtual Vector3 get_contact_impulse(int p_contact_idx) const = 0;
 	virtual int get_contact_local_shape(int p_contact_idx) const = 0;
 
 	virtual RID get_contact_collider(int p_contact_idx) const = 0;


### PR DESCRIPTION
Going off of #39114 and the outdated 3D physics state docs:
``Impulse created by the contact. Only implemented for Bullet physics.``

I've implemented the returning of the impulse forces by contacts into GodotPhysics3D
I had originally feared this would break compatibility but considering the function didn't work at all and simply returned ``0.0`` it shouldn't cause any issues with it now returning a Vector3 of the impulse forces.