### PR TITLE
Add `icon_modulate` set/get functionality to PopupMenu

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -209,6 +209,13 @@
 				Returns the maximum allowed width of the icon for the item at the given [param index].
 			</description>
 		</method>
+		<method name="get_item_icon_modulate" qualifiers="const">
+			<return type="Color" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns a [Color] modulating the item's icon at the given [param index].
+			</description>
+		</method>
 		<method name="get_item_id" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
@@ -410,6 +417,14 @@
 			<param index="1" name="width" type="int" />
 			<description>
 				Sets the maximum allowed width of the icon for the item at the given [param index]. This limit is applied on top of the default size of the icon and on top of [theme_item icon_max_width]. The height is adjusted according to the icon's ratio.
+			</description>
+		</method>
+		<method name="set_item_icon_modulate">
+			<return type="void" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="modulate" type="Color" />
+			<description>
+				Sets a modulating [Color] of the item's icon at the given [param index].
 			</description>
 		</method>
 		<method name="set_item_id">

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -635,6 +635,8 @@ void PopupMenu::_draw_items() {
 
 		Color icon_color(1, 1, 1, items[i].disabled && !items[i].separator ? 0.5 : 1);
 
+		icon_color *= items[i].icon_modulate;
+
 		// For non-separator items, add some padding for the content.
 		item_ofs.x += theme_cache.item_start_padding;
 
@@ -1249,6 +1251,20 @@ void PopupMenu::set_item_icon_max_width(int p_idx, int p_width) {
 	_menu_changed();
 }
 
+void PopupMenu::set_item_icon_modulate(int p_idx, const Color &p_modulate) {
+	if (p_idx < 0) {
+		p_idx += get_item_count();
+	}
+	ERR_FAIL_INDEX(p_idx, items.size());
+
+	if (items[p_idx].icon_modulate == p_modulate) {
+		return;
+	}
+
+	items.write[p_idx].icon_modulate = p_modulate;
+	control->queue_redraw();
+}
+
 void PopupMenu::set_item_checked(int p_idx, bool p_checked) {
 	if (p_idx < 0) {
 		p_idx += get_item_count();
@@ -1390,6 +1406,11 @@ Ref<Texture2D> PopupMenu::get_item_icon(int p_idx) const {
 int PopupMenu::get_item_icon_max_width(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, items.size(), 0);
 	return items[p_idx].icon_max_width;
+}
+
+Color PopupMenu::get_item_icon_modulate(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, items.size(), Color());
+	return items[p_idx].icon_modulate;
 }
 
 Key PopupMenu::get_item_accelerator(int p_idx) const {
@@ -2102,6 +2123,7 @@ void PopupMenu::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_item_language", "index", "language"), &PopupMenu::set_item_language);
 	ClassDB::bind_method(D_METHOD("set_item_icon", "index", "icon"), &PopupMenu::set_item_icon);
 	ClassDB::bind_method(D_METHOD("set_item_icon_max_width", "index", "width"), &PopupMenu::set_item_icon_max_width);
+	ClassDB::bind_method(D_METHOD("set_item_icon_modulate", "index", "modulate"), &PopupMenu::set_item_icon_modulate);
 	ClassDB::bind_method(D_METHOD("set_item_checked", "index", "checked"), &PopupMenu::set_item_checked);
 	ClassDB::bind_method(D_METHOD("set_item_id", "index", "id"), &PopupMenu::set_item_id);
 	ClassDB::bind_method(D_METHOD("set_item_accelerator", "index", "accel"), &PopupMenu::set_item_accelerator);
@@ -2125,6 +2147,7 @@ void PopupMenu::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_item_language", "index"), &PopupMenu::get_item_language);
 	ClassDB::bind_method(D_METHOD("get_item_icon", "index"), &PopupMenu::get_item_icon);
 	ClassDB::bind_method(D_METHOD("get_item_icon_max_width", "index"), &PopupMenu::get_item_icon_max_width);
+	ClassDB::bind_method(D_METHOD("get_item_icon_modulate", "index"), &PopupMenu::get_item_icon_modulate);
 	ClassDB::bind_method(D_METHOD("is_item_checked", "index"), &PopupMenu::is_item_checked);
 	ClassDB::bind_method(D_METHOD("get_item_id", "index"), &PopupMenu::get_item_id);
 	ClassDB::bind_method(D_METHOD("get_item_index", "id"), &PopupMenu::get_item_index);

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -43,6 +43,7 @@ class PopupMenu : public Popup {
 	struct Item {
 		Ref<Texture2D> icon;
 		int icon_max_width = 0;
+		Color icon_modulate = Color(1, 1, 1, 1);
 		String text;
 		String xl_text;
 		Ref<TextLine> text_buf;
@@ -226,6 +227,7 @@ public:
 	void set_item_language(int p_idx, const String &p_language);
 	void set_item_icon(int p_idx, const Ref<Texture2D> &p_icon);
 	void set_item_icon_max_width(int p_idx, int p_width);
+	void set_item_icon_modulate(int p_idx, const Color &p_modulate);
 	void set_item_checked(int p_idx, bool p_checked);
 	void set_item_id(int p_idx, int p_id);
 	void set_item_accelerator(int p_idx, Key p_accel);
@@ -250,6 +252,7 @@ public:
 	int get_item_idx_from_text(const String &text) const;
 	Ref<Texture2D> get_item_icon(int p_idx) const;
 	int get_item_icon_max_width(int p_idx) const;
+	Color get_item_icon_modulate(int p_idx) const;
 	bool is_item_checked(int p_idx) const;
 	int get_item_id(int p_idx) const;
 	int get_item_index(int p_id) const;


### PR DESCRIPTION
Copies the ``get_item_icon_modulate`` and ``set_item_icon_modulate`` functionality already present in the ``ItemList`` class over to ``PopupMenu``. I need this to be able to give different colors to items that have the same icon in a dropdown, so I'm guessing others may find the functionality useful as well?

![image](https://user-images.githubusercontent.com/18225391/208356995-dd3f2942-d680-47ad-a738-35dcb5ff28b6.png)
