### PR TITLE
Fix missing undo/redo object and issue with removing actions

### DIFF
--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -205,11 +205,12 @@ void OpenXRActionMapEditor::_on_remove_action_set(Object *p_action_set_editor) {
 	action_map->set_edited(true);
 }
 
-void OpenXRActionMapEditor::_on_action_removed() {
+void OpenXRActionMapEditor::_on_action_removed(Ref<OpenXRAction> p_action) {
 	for (int i = 0; i < tabs->get_tab_count(); i++) {
 		// First tab won't be an interaction profile editor, but being thorough..
 		OpenXRInteractionProfileEditorBase *interaction_profile_editor = Object::cast_to<OpenXRInteractionProfileEditorBase>(tabs->get_tab_control(i));
 		if (interaction_profile_editor) {
+			interaction_profile_editor->remove_all_bindings_for_action(p_action);
 		}
 	}
 }

--- a/modules/openxr/editor/openxr_action_map_editor.h
+++ b/modules/openxr/editor/openxr_action_map_editor.h
@@ -75,7 +75,7 @@ private:
 	void _on_add_action_set();
 	void _set_focus_on_action_set(OpenXRActionSetEditor *p_action_set_editor);
 	void _on_remove_action_set(Object *p_action_set_editor);
-	void _on_action_removed();
+	void _on_action_removed(Ref<OpenXRAction> p_action);
 
 	void _on_add_interaction_profile();
 	void _on_interaction_profile_selected(const String p_path);

--- a/modules/openxr/editor/openxr_action_set_editor.cpp
+++ b/modules/openxr/editor/openxr_action_set_editor.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "openxr_action_set_editor.h"
+#include "editor/editor_node.h"
 #include "openxr_action_editor.h"
 
 void OpenXRActionSetEditor::_bind_methods() {
@@ -211,6 +212,7 @@ void OpenXRActionSetEditor::set_focus_on_entry() {
 }
 
 OpenXRActionSetEditor::OpenXRActionSetEditor(Ref<OpenXRActionMap> p_action_map, Ref<OpenXRActionSet> p_action_set) {
+	undo_redo = EditorNode::get_undo_redo();
 	action_map = p_action_map;
 	action_set = p_action_set;
 

--- a/modules/openxr/editor/openxr_interaction_profile_editor.cpp
+++ b/modules/openxr/editor/openxr_interaction_profile_editor.cpp
@@ -124,8 +124,8 @@ void OpenXRInteractionProfileEditorBase::remove_all_bindings_for_action(Ref<Open
 		undo_redo->create_action(TTR("Remove action from interaction profile"));
 		PackedStringArray paths = binding->get_paths();
 		for (const String &path : paths) {
-			undo_redo->add_do_method(this, "_remove_binding", p_action, path);
-			undo_redo->add_undo_method(this, "_add_binding", p_action, path);
+			undo_redo->add_do_method(this, "_remove_binding", action_name, path);
+			undo_redo->add_undo_method(this, "_add_binding", action_name, path);
 		}
 		undo_redo->commit_action(false);
 


### PR DESCRIPTION
Fix issue with missing undo/redo object that lead to a crash (fixes #70157) and fixed missing implementation for removing action bindings when action is removed.
