### PR TITLE
Add a method to get global modulate

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -922,7 +922,7 @@ void TileMapEditorTilesPlugin::forward_canvas_draw_over_viewport(Control *p_over
 
 							// Get the tile modulation.
 							Color modulate = tile_data->get_modulate();
-							Color self_modulate = tile_map->get_self_modulate();
+							Color self_modulate = tile_map->get_modulate_in_tree() * tile_map->get_self_modulate();
 							modulate *= self_modulate;
 
 							// Draw the tile.

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -388,6 +388,16 @@ Color CanvasItem::get_modulate() const {
 	return modulate;
 }
 
+Color CanvasItem::get_modulate_in_tree() const {
+	Color final_modulate = modulate;
+	CanvasItem *parent_item = get_parent_item();
+	while (parent_item) {
+		final_modulate *= parent_item->get_modulate();
+		parent_item = parent_item->get_parent_item();
+	}
+	return final_modulate;
+}
+
 void CanvasItem::set_as_top_level(bool p_top_level) {
 	if (top_level == p_top_level) {
 		return;

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -224,6 +224,7 @@ public:
 
 	void set_modulate(const Color &p_modulate);
 	Color get_modulate() const;
+	Color get_modulate_in_tree() const;
 
 	void set_self_modulate(const Color &p_self_modulate);
 	Color get_self_modulate() const;


### PR DESCRIPTION
Similar to #66546, this PR adds a (unexposed) method that returns modulate in node's tree branch. I wanted it to also use color from CanvasModulate, but there is no `canvas_get_modulate()` method.

I added a usage in TileMap editor to make the drawing previews use correct color.