### PR TITLE
Provide a convenient way to await thread finish.

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1268,6 +1268,16 @@ Error Thread::start(const Callable &p_callable, Priority p_priority) {
 	return OK;
 }
 
+Ref<Thread> Thread::run(const Callable &p_callable, Thread::Priority p_priority) {
+	Ref<Thread> ret;
+	ret.instantiate();
+	Error err = ret->start(p_callable, p_priority);
+	if (err == OK) {
+		return ret;
+	}
+	return nullptr;
+}
+
 String Thread::get_id() const {
 	return itos(thread.get_id());
 }
@@ -1286,6 +1296,7 @@ Variant Thread::wait_to_finish() {
 	Variant r = ret;
 	target_callable = Callable();
 
+	emit_signal(SNAME("finished"), r);
 	return r;
 }
 
@@ -1294,14 +1305,36 @@ void Thread::set_thread_safety_checks_enabled(bool p_enabled) {
 	set_current_thread_safe_for_nodes(!p_enabled);
 }
 
+void Thread::_try_finish() {
+	if (is_alive()) {
+		return;
+	}
+	Engine::get_singleton()->get_main_loop()->disconnect(SNAME("process_frame"), callable_mp(this, &Thread::_try_finish));
+	wait_to_finish();
+}
+
+Signal Thread::await_to_finish() {
+	Signal finished_signal = Signal(this, SNAME("finished"));
+	ERR_FAIL_COND_V_MSG(!is_started(), finished_signal, "Thread must have been started to await for its completion.");
+	if (!Engine::get_singleton()->get_main_loop()->is_connected(SNAME("process_frame"), callable_mp(this, &Thread::_try_finish))) {
+		ERR_FAIL_COND_V(Engine::get_singleton()->get_main_loop()->connect(SNAME("process_frame"), callable_mp(this, &Thread::_try_finish)) != OK, finished_signal);
+	} else {
+		WARN_PRINT("\"Thread.await_to_finish()\" should only be called once before the thread's signal \"finished\" is emitted.");
+	}
+	return finished_signal;
+}
+
 void Thread::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("start", "callable", "priority"), &Thread::start, DEFVAL(PRIORITY_NORMAL));
 	ClassDB::bind_method(D_METHOD("get_id"), &Thread::get_id);
 	ClassDB::bind_method(D_METHOD("is_started"), &Thread::is_started);
 	ClassDB::bind_method(D_METHOD("is_alive"), &Thread::is_alive);
 	ClassDB::bind_method(D_METHOD("wait_to_finish"), &Thread::wait_to_finish);
-
+	ClassDB::bind_method(D_METHOD("await_to_finish"), &Thread::await_to_finish);
+	ClassDB::bind_static_method("Thread", D_METHOD("run", "callable", "priority"), &Thread::run, DEFVAL(PRIORITY_NORMAL));
 	ClassDB::bind_static_method("Thread", D_METHOD("set_thread_safety_checks_enabled", "enabled"), &Thread::set_thread_safety_checks_enabled);
+
+	ADD_SIGNAL(MethodInfo("finished", PropertyInfo(Variant::NIL, "result")));
 
 	BIND_ENUM_CONSTANT(PRIORITY_LOW);
 	BIND_ENUM_CONSTANT(PRIORITY_NORMAL);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -396,6 +396,9 @@ protected:
 	SafeFlag running;
 	Callable target_callable;
 	::Thread thread;
+
+	void _try_finish();
+
 	static void _bind_methods();
 	static void _start_func(void *ud);
 
@@ -412,7 +415,9 @@ public:
 	bool is_started() const;
 	bool is_alive() const;
 	Variant wait_to_finish();
+	Signal await_to_finish();
 
+	static Ref<Thread> run(const Callable &p_callable, Priority p_priority = PRIORITY_NORMAL);
 	static void set_thread_safety_checks_enabled(bool p_enabled);
 };
 

--- a/doc/classes/Thread.xml
+++ b/doc/classes/Thread.xml
@@ -17,6 +17,30 @@
 		<link title="3D Voxel Demo">https://godotengine.org/asset-library/asset/676</link>
 	</tutorials>
 	<methods>
+		<method name="await_to_finish">
+			<return type="Signal" />
+			<description>
+				Start to await this thread and return the [signal finished] signal.
+				It means that you can await this method for a started thread to get its return value without blocking main thread.
+				For example:
+				[codeblocks]
+				[gdscript]
+				func _ready():
+				    var count = 999999
+				    var thread = Thread.run(do_something_heavy.bind(count))
+				    var return_value = await thread.await_to_finish()
+				    print(return_value)
+
+				func do_something_heavy(count):
+				    # Do something heavy.
+				    var total = 0
+				    while total != count:
+				        total += 1
+				    return OK
+				[/gdscript]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="get_id" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -34,6 +58,15 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if this [Thread] has been started. Once started, this will return [code]true[/code] until it is joined using [method wait_to_finish]. For checking if a [Thread] is still executing its task, use [method is_alive].
+			</description>
+		</method>
+		<method name="run" qualifiers="static">
+			<return type="Thread" />
+			<param index="0" name="callable" type="Callable" />
+			<param index="1" name="priority" type="int" enum="Thread.Priority" default="1" />
+			<description>
+				Creates a new [Thread] and starts it like [method start].
+				Return a [Thread] if it is started successfully, else will return null.
 			</description>
 		</method>
 		<method name="set_thread_safety_checks_enabled" qualifiers="static">
@@ -69,6 +102,36 @@
 			</description>
 		</method>
 	</methods>
+	<signals>
+		<signal name="finished">
+			<param index="0" name="result" type="Variant" />
+			<description>
+				Emit when this thread finish, [param result] is the return value of the callable which started by [method start] or [method run].
+				CAUTIOUS:
+				[param result] can be a GDScriptFunctionState if the thread start a async callable.
+				The GDScript async mechanism only run in main thread.
+				You can deal with it like this:
+				[codeblocks]
+				[gdscript]
+				func _ready():
+				    var count = 999999
+				    var thread = Thread.run(do_something_async)
+				    thread.await_to_finish().connect(
+				        func(result):
+				            # Here we know the result is a `GDScriptFunctionState`.
+				            var result = await result
+				            print(result)
+				    )
+
+				func do_something_async():
+				    # Do something async.
+				    await get_tree().create_timer(5).timeout
+				    return OK
+				[/gdscript]
+				[/codeblocks]
+			</description>
+		</signal>
+	</signals>
 	<constants>
 		<constant name="PRIORITY_LOW" value="0" enum="Priority">
 			A thread running with lower priority than normally.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Because my branch has not contian [#69968](https://github.com/godotengine/godot/pull/69968) and I can't keep 1 commit, I remake this pr.
Replace [#69796](https://github.com/godotengine/godot/pull/69796).
