### PR TITLE
Fix inconsistent audio import menu naming

### DIFF
--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -552,7 +552,7 @@ AudioStreamImportSettings::AudioStreamImportSettings() {
 	bpm_edit->connect("value_changed", callable_mp(this, &AudioStreamImportSettings::_settings_changed).unbind(1));
 	interactive_hb->add_child(bpm_edit);
 	interactive_hb->add_spacer();
-	bar_beats_label = memnew(Label(TTR("Beats/Bar:")));
+	bar_beats_label = memnew(Label(TTR("Bar Beats:")));
 	interactive_hb->add_child(bar_beats_label);
 	bar_beats_edit = memnew(SpinBox);
 	bar_beats_edit->set_tooltip_text(TTR("Configure the Beats Per Bar. This used for music-aware transitions between AudioStreams."));
@@ -562,7 +562,7 @@ AudioStreamImportSettings::AudioStreamImportSettings() {
 	interactive_hb->add_child(bar_beats_edit);
 	interactive_hb->add_spacer();
 	beats_enabled = memnew(CheckBox);
-	beats_enabled->set_text(TTR("Length (in beats):"));
+	beats_enabled->set_text(TTR("Beat Count:"));
 	beats_enabled->connect("toggled", callable_mp(this, &AudioStreamImportSettings::_settings_changed).unbind(1));
 	interactive_hb->add_child(beats_enabled);
 	beats_edit = memnew(SpinBox);


### PR DESCRIPTION
Fixes #70242 

Before: 
![before](https://user-images.githubusercontent.com/19669673/208476734-278eb99b-56eb-45b1-b6de-01ec8e5a4a33.png)

After:
![after](https://user-images.githubusercontent.com/19669673/208476770-0878d80d-81dc-49ad-999c-38f4c73bdc84.png)

The reason that the import names where chosen instead of the advanced import name is that the advanced names were simply a label. The "normal" import names however depend on the internal property names, which afaik can't have the '/' char.

Should I change the order of bar beats and beat count in the advanced import settings so the order matches as well?