### PR TITLE
Modify reload_from_file and load to replace resources on reload

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -178,7 +178,7 @@ void Resource::reload_from_file() {
 		return;
 	}
 
-	Ref<Resource> s = ResourceLoader::load(ResourceLoader::path_remap(path), get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
+	Ref<Resource> s = ResourceLoader::load(ResourceLoader::path_remap(path), get_class(), ResourceFormatLoader::CACHE_MODE_REPLACE);
 
 	if (!s.is_valid()) {
 		return;


### PR DESCRIPTION
`reload_from_file` is changed to use CACHE_MODE_REPLACE instead of ignore, `load` actually checks if it should use the cache, and if the mode is set to CACHE_MODE_REPLACE it will not, and instead pass that to `_thread_load_function` that will take over the resource path.

This is my first time contributing any code, and this seemed like a not-so-difficult thing to fix. Hopefully I didn't miss anything improtant.

Fixes #39179