### PR TITLE
Rename *_surface_override_material to *_surface_material_override

### DIFF
--- a/doc/classes/MeshInstance3D.xml
+++ b/doc/classes/MeshInstance3D.xml
@@ -65,17 +65,17 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_surface_override_material" qualifiers="const">
+		<method name="get_surface_material_override" qualifiers="const">
 			<return type="Material" />
 			<param index="0" name="surface" type="int" />
 			<description>
-				Returns the override [Material] for the specified surface of the [Mesh] resource.
+				Returns the [Material] override for the specified surface of the [Mesh] resource.
 			</description>
 		</method>
-		<method name="get_surface_override_material_count" qualifiers="const">
+		<method name="get_surface_material_override_count" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the number of surface override materials. This is equivalent to [method Mesh.get_surface_count].
+				Returns the number of surface material overrides. This is equivalent to [method Mesh.get_surface_count].
 			</description>
 		</method>
 		<method name="set_blend_shape_value">
@@ -85,12 +85,12 @@
 			<description>
 			</description>
 		</method>
-		<method name="set_surface_override_material">
+		<method name="set_surface_material_override">
 			<return type="void" />
 			<param index="0" name="surface" type="int" />
 			<param index="1" name="material" type="Material" />
 			<description>
-				Sets the override [Material] for the specified surface of the [Mesh] resource. This material is associated with this [MeshInstance3D] rather than with the [Mesh] resource.
+				Sets the [Material] override for the specified surface of the [Mesh] resource. This material is associated with this [MeshInstance3D] rather than with the [Mesh] resource.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1593,13 +1593,13 @@
 				Sets the scenario that the instance is in. The scenario is the 3D world that the objects will be displayed in.
 			</description>
 		</method>
-		<method name="instance_set_surface_override_material">
+		<method name="instance_set_surface_material_override">
 			<return type="void" />
 			<param index="0" name="instance" type="RID" />
 			<param index="1" name="surface" type="int" />
 			<param index="2" name="material" type="RID" />
 			<description>
-				Sets the override material of a specific surface. Equivalent to [method MeshInstance3D.set_surface_override_material].
+				Sets the material override of a specific surface. Equivalent to [method MeshInstance3D.set_surface_material_override].
 			</description>
 		</method>
 		<method name="instance_set_transform">

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -2068,7 +2068,7 @@ void ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_m
 			if (mesh.is_valid()) {
 				mesh_node->set_mesh(mesh);
 				for (int i = 0; i < mesh->get_surface_count(); i++) {
-					mesh_node->set_surface_override_material(i, src_mesh_node->get_surface_material(i));
+					mesh_node->set_surface_material_override(i, src_mesh_node->get_surface_material(i));
 				}
 			}
 		}

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -98,7 +98,7 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 
 		mesh = mesh->duplicate();
 		for (int j = 0; j < mesh->get_surface_count(); ++j) {
-			Ref<Material> mat = mi->get_surface_override_material(j);
+			Ref<Material> mat = mi->get_surface_material_override(j);
 
 			if (mat.is_valid()) {
 				mesh->surface_set_material(j, mat);

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4152,10 +4152,10 @@ bool Node3DEditorViewport::_apply_preview_material(ObjectID p_target, const Poin
 			return false;
 		}
 
-		if (spatial_editor->get_preview_material() != mesh_instance->get_surface_override_material(closest_surface)) {
+		if (spatial_editor->get_preview_material() != mesh_instance->get_surface_material_override(closest_surface)) {
 			spatial_editor->set_preview_material_surface(closest_surface);
-			spatial_editor->set_preview_reset_material(mesh_instance->get_surface_override_material(closest_surface));
-			mesh_instance->set_surface_override_material(closest_surface, spatial_editor->get_preview_material());
+			spatial_editor->set_preview_reset_material(mesh_instance->get_surface_material_override(closest_surface));
+			mesh_instance->set_surface_material_override(closest_surface, spatial_editor->get_preview_material());
 		}
 
 		return true;
@@ -4181,7 +4181,7 @@ void Node3DEditorViewport::_reset_preview_material() const {
 	MeshInstance3D *mesh_instance = Object::cast_to<MeshInstance3D>(last_target_inst);
 	GeometryInstance3D *geometry_instance = Object::cast_to<GeometryInstance3D>(last_target_inst);
 	if (mesh_instance && spatial_editor->get_preview_material_surface() != -1) {
-		mesh_instance->set_surface_override_material(spatial_editor->get_preview_material_surface(), spatial_editor->get_preview_reset_material());
+		mesh_instance->set_surface_material_override(spatial_editor->get_preview_material_surface(), spatial_editor->get_preview_reset_material());
 		spatial_editor->set_preview_material_surface(-1);
 	} else if (geometry_instance) {
 		geometry_instance->set_material_override(spatial_editor->get_preview_reset_material());
@@ -4291,8 +4291,8 @@ void Node3DEditorViewport::_perform_drop_data() {
 		MeshInstance3D *mesh_instance = Object::cast_to<MeshInstance3D>(ObjectDB::get_instance(spatial_editor->get_preview_material_target()));
 		if (mesh_instance && spatial_editor->get_preview_material_surface() != -1) {
 			undo_redo->create_action(vformat(TTR("Set Surface %d Override Material"), spatial_editor->get_preview_material_surface()));
-			undo_redo->add_do_method(geometry_instance, "set_surface_override_material", spatial_editor->get_preview_material_surface(), spatial_editor->get_preview_material());
-			undo_redo->add_undo_method(geometry_instance, "set_surface_override_material", spatial_editor->get_preview_material_surface(), spatial_editor->get_preview_reset_material());
+			undo_redo->add_do_method(geometry_instance, "set_surface_material_override", spatial_editor->get_preview_material_surface(), spatial_editor->get_preview_material());
+			undo_redo->add_undo_method(geometry_instance, "set_surface_material_override", spatial_editor->get_preview_material_surface(), spatial_editor->get_preview_reset_material());
 			undo_redo->commit_action();
 		} else if (geometry_instance) {
 			undo_redo->create_action(TTR("Set Material Override"));

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -375,8 +375,8 @@ static const char *gdscript_function_renames[][2] = {
 	{ "get_spatial_node", "get_node_3d" }, // EditorNode3DGizmo
 	{ "get_speed", "get_velocity" }, // InputEventMouseMotion
 	{ "get_stylebox_types", "get_stylebox_type_list" }, // Theme
-	{ "get_surface_material", "get_surface_override_material" }, // MeshInstance3D broke ImporterMesh
-	{ "get_surface_material_count", "get_surface_override_material_count" }, // MeshInstance3D
+	{ "get_surface_material", "get_surface_material_override" }, // MeshInstance3D broke ImporterMesh
+	{ "get_surface_material_count", "get_surface_material_override_count" }, // MeshInstance3D
 	{ "get_tab_disabled", "is_tab_disabled" }, // Tab
 	{ "get_tab_hidden", "is_tab_hidden" }, // Tab
 	{ "get_text_align", "get_text_alignment" }, // Button
@@ -413,7 +413,7 @@ static const char *gdscript_function_renames[][2] = {
 	{ "http_escape", "uri_encode" }, // String
 	{ "http_unescape", "uri_decode" }, // String
 	{ "import_scene_from_other_importer", "_import_scene" }, //EditorSceneFormatImporter
-	{ "instance_set_surface_material", "instance_set_surface_override_material" }, // RenderingServer
+	{ "instance_set_surface_material", "instance_set_surface_material_override" }, // RenderingServer
 	{ "interpolate", "sample" }, // Curve, Curve2D, Curve3D, Gradient
 	{ "intersect_polygons_2d", "intersect_polygons" }, // Geometry2D
 	{ "intersect_polyline_with_polygon_2d", "intersect_polyline_with_polygon" }, // Geometry2D
@@ -550,7 +550,7 @@ static const char *gdscript_function_renames[][2] = {
 	{ "set_spatial_node", "set_node_3d" }, // EditorNode3DGizmo
 	{ "set_speed", "set_velocity" }, // InputEventMouseMotion
 	{ "set_ssao_edge_sharpness", "set_ssao_sharpness" }, // Environment
-	{ "set_surface_material", "set_surface_override_material" }, // MeshInstance3D broke ImporterMesh
+	{ "set_surface_material", "set_surface_material_override" }, // MeshInstance3D broke ImporterMesh
 	{ "set_tab_align", "set_tab_alignment" }, //TabContainer
 	{ "set_tangent", "surface_set_tangent" }, // ImmediateGeometry broke SurfaceTool
 	{ "set_text_align", "set_text_alignment" }, // Button

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5138,8 +5138,8 @@ GLTFMeshIndex GLTFDocument::_convert_mesh_to_gltf(Ref<GLTFState> p_state, MeshIn
 	TypedArray<Material> instance_materials;
 	for (int32_t surface_i = 0; surface_i < current_mesh->get_surface_count(); surface_i++) {
 		Ref<Material> mat = current_mesh->get_surface_material(surface_i);
-		if (p_mesh_instance->get_surface_override_material(surface_i).is_valid()) {
-			mat = p_mesh_instance->get_surface_override_material(surface_i);
+		if (p_mesh_instance->get_surface_material_override(surface_i).is_valid()) {
+			mat = p_mesh_instance->get_surface_material_override(surface_i);
 		}
 		if (p_mesh_instance->get_material_override().is_valid()) {
 			mat = p_mesh_instance->get_material_override();

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -357,7 +357,7 @@ void LightmapGI::_find_meshes_and_lights(Node *p_at_node, Vector<MeshesFound> &m
 					if (all_override.is_valid()) {
 						mf.overrides.push_back(all_override);
 					} else {
-						mf.overrides.push_back(mi->get_surface_override_material(i));
+						mf.overrides.push_back(mi->get_surface_material_override(i));
 					}
 				}
 

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -64,11 +64,11 @@ bool MeshInstance3D::_set(const StringName &p_name, const Variant &p_value) {
 			idx--;
 		}
 
-		if (idx > surface_override_materials.size() || idx < 0) {
+		if (idx > surface_material_overrides.size() || idx < 0) {
 			return false;
 		}
 
-		set_surface_override_material(idx, p_value);
+		set_surface_material_override(idx, p_value);
 		return true;
 	}
 
@@ -88,10 +88,10 @@ bool MeshInstance3D::_get(const StringName &p_name, Variant &r_ret) const {
 
 	if (p_name.operator String().begins_with("surface_material_override/")) {
 		int idx = p_name.operator String().get_slicec('/', 1).to_int();
-		if (idx >= surface_override_materials.size() || idx < 0) {
+		if (idx >= surface_material_overrides.size() || idx < 0) {
 			return false;
 		}
-		r_ret = surface_override_materials[idx];
+		r_ret = surface_material_overrides[idx];
 		return true;
 	}
 	return false;
@@ -342,26 +342,26 @@ void MeshInstance3D::_notification(int p_what) {
 	}
 }
 
-int MeshInstance3D::get_surface_override_material_count() const {
-	return surface_override_materials.size();
+int MeshInstance3D::get_surface_material_override_count() const {
+	return surface_material_overrides.size();
 }
 
-void MeshInstance3D::set_surface_override_material(int p_surface, const Ref<Material> &p_material) {
-	ERR_FAIL_INDEX(p_surface, surface_override_materials.size());
+void MeshInstance3D::set_surface_material_override(int p_surface, const Ref<Material> &p_material) {
+	ERR_FAIL_INDEX(p_surface, surface_material_overrides.size());
 
-	surface_override_materials.write[p_surface] = p_material;
+	surface_material_overrides.write[p_surface] = p_material;
 
-	if (surface_override_materials[p_surface].is_valid()) {
-		RS::get_singleton()->instance_set_surface_override_material(get_instance(), p_surface, surface_override_materials[p_surface]->get_rid());
+	if (surface_material_overrides[p_surface].is_valid()) {
+		RS::get_singleton()->instance_set_surface_material_override(get_instance(), p_surface, surface_material_overrides[p_surface]->get_rid());
 	} else {
-		RS::get_singleton()->instance_set_surface_override_material(get_instance(), p_surface, RID());
+		RS::get_singleton()->instance_set_surface_material_override(get_instance(), p_surface, RID());
 	}
 }
 
-Ref<Material> MeshInstance3D::get_surface_override_material(int p_surface) const {
-	ERR_FAIL_INDEX_V(p_surface, surface_override_materials.size(), Ref<Material>());
+Ref<Material> MeshInstance3D::get_surface_material_override(int p_surface) const {
+	ERR_FAIL_INDEX_V(p_surface, surface_material_overrides.size(), Ref<Material>());
 
-	return surface_override_materials[p_surface];
+	return surface_material_overrides[p_surface];
 }
 
 Ref<Material> MeshInstance3D::get_active_material(int p_surface) const {
@@ -370,7 +370,7 @@ Ref<Material> MeshInstance3D::get_active_material(int p_surface) const {
 		return mat_override;
 	}
 
-	Ref<Material> surface_material = get_surface_override_material(p_surface);
+	Ref<Material> surface_material = get_surface_material_override(p_surface);
 	if (surface_material.is_valid()) {
 		return surface_material;
 	}
@@ -385,7 +385,7 @@ Ref<Material> MeshInstance3D::get_active_material(int p_surface) const {
 
 void MeshInstance3D::_mesh_changed() {
 	ERR_FAIL_COND(mesh.is_null());
-	surface_override_materials.resize(mesh->get_surface_count());
+	surface_material_overrides.resize(mesh->get_surface_count());
 
 	uint32_t initialize_bs_from = blend_shape_tracks.size();
 	blend_shape_tracks.resize(mesh->get_blend_shape_count());
@@ -401,8 +401,8 @@ void MeshInstance3D::_mesh_changed() {
 
 	int surface_count = mesh->get_surface_count();
 	for (int surface_index = 0; surface_index < surface_count; ++surface_index) {
-		if (surface_override_materials[surface_index].is_valid()) {
-			RS::get_singleton()->instance_set_surface_override_material(get_instance(), surface_index, surface_override_materials[surface_index]->get_rid());
+		if (surface_material_overrides[surface_index].is_valid()) {
+			RS::get_singleton()->instance_set_surface_material_override(get_instance(), surface_index, surface_material_overrides[surface_index]->get_rid());
 		}
 	}
 
@@ -504,9 +504,9 @@ void MeshInstance3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_skin", "skin"), &MeshInstance3D::set_skin);
 	ClassDB::bind_method(D_METHOD("get_skin"), &MeshInstance3D::get_skin);
 
-	ClassDB::bind_method(D_METHOD("get_surface_override_material_count"), &MeshInstance3D::get_surface_override_material_count);
-	ClassDB::bind_method(D_METHOD("set_surface_override_material", "surface", "material"), &MeshInstance3D::set_surface_override_material);
-	ClassDB::bind_method(D_METHOD("get_surface_override_material", "surface"), &MeshInstance3D::get_surface_override_material);
+	ClassDB::bind_method(D_METHOD("get_surface_material_override_count"), &MeshInstance3D::get_surface_material_override_count);
+	ClassDB::bind_method(D_METHOD("set_surface_material_override", "surface", "material"), &MeshInstance3D::set_surface_material_override);
+	ClassDB::bind_method(D_METHOD("get_surface_material_override", "surface"), &MeshInstance3D::get_surface_material_override);
 	ClassDB::bind_method(D_METHOD("get_active_material", "surface"), &MeshInstance3D::get_active_material);
 
 	ClassDB::bind_method(D_METHOD("create_trimesh_collision"), &MeshInstance3D::create_trimesh_collision);

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -48,7 +48,7 @@ protected:
 
 	LocalVector<float> blend_shape_tracks;
 	HashMap<StringName, int> blend_shape_properties;
-	Vector<Ref<Material>> surface_override_materials;
+	Vector<Ref<Material>> surface_material_overrides;
 
 	void _mesh_changed();
 	void _resolve_skeleton_path();
@@ -77,9 +77,9 @@ public:
 	float get_blend_shape_value(int p_blend_shape) const;
 	void set_blend_shape_value(int p_blend_shape, float p_value);
 
-	int get_surface_override_material_count() const;
-	void set_surface_override_material(int p_surface, const Ref<Material> &p_material);
-	Ref<Material> get_surface_override_material(int p_surface) const;
+	int get_surface_material_override_count() const;
+	void set_surface_material_override(int p_surface, const Ref<Material> &p_material);
+	Ref<Material> get_surface_material_override(int p_surface) const;
 	Ref<Material> get_active_material(int p_surface) const;
 
 	Node *create_trimesh_collision_node();

--- a/scene/3d/navigation_link_3d.cpp
+++ b/scene/3d/navigation_link_3d.cpp
@@ -137,9 +137,9 @@ void NavigationLink3D::_update_debug_mesh() {
 	Ref<StandardMaterial3D> disabled_link_material = NavigationServer3D::get_singleton_mut()->get_debug_navigation_link_connections_disabled_material();
 
 	if (enabled) {
-		RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, link_material->get_rid());
+		RS::get_singleton()->instance_set_surface_material_override(debug_instance, 0, link_material->get_rid());
 	} else {
-		RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, disabled_link_material->get_rid());
+		RS::get_singleton()->instance_set_surface_material_override(debug_instance, 0, disabled_link_material->get_rid());
 	}
 }
 #endif // DEBUG_ENABLED
@@ -261,10 +261,10 @@ void NavigationLink3D::set_enabled(bool p_enabled) {
 	if (debug_instance.is_valid() && debug_mesh.is_valid()) {
 		if (enabled) {
 			Ref<StandardMaterial3D> link_material = NavigationServer3D::get_singleton_mut()->get_debug_navigation_link_connections_material();
-			RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, link_material->get_rid());
+			RS::get_singleton()->instance_set_surface_material_override(debug_instance, 0, link_material->get_rid());
 		} else {
 			Ref<StandardMaterial3D> disabled_link_material = NavigationServer3D::get_singleton_mut()->get_debug_navigation_link_connections_disabled_material();
-			RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, disabled_link_material->get_rid());
+			RS::get_singleton()->instance_set_surface_material_override(debug_instance, 0, disabled_link_material->get_rid());
 		}
 	}
 #endif // DEBUG_ENABLED

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -55,19 +55,19 @@ void NavigationRegion3D::set_enabled(bool p_enabled) {
 		if (!is_enabled()) {
 			if (debug_mesh.is_valid()) {
 				if (debug_mesh->get_surface_count() > 0) {
-					RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_face_disabled_material()->get_rid());
+					RS::get_singleton()->instance_set_surface_material_override(debug_instance, 0, NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_face_disabled_material()->get_rid());
 				}
 				if (debug_mesh->get_surface_count() > 1) {
-					RS::get_singleton()->instance_set_surface_override_material(debug_instance, 1, NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_edge_disabled_material()->get_rid());
+					RS::get_singleton()->instance_set_surface_material_override(debug_instance, 1, NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_edge_disabled_material()->get_rid());
 				}
 			}
 		} else {
 			if (debug_mesh.is_valid()) {
 				if (debug_mesh->get_surface_count() > 0) {
-					RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, RID());
+					RS::get_singleton()->instance_set_surface_material_override(debug_instance, 0, RID());
 				}
 				if (debug_mesh->get_surface_count() > 1) {
-					RS::get_singleton()->instance_set_surface_override_material(debug_instance, 1, RID());
+					RS::get_singleton()->instance_set_surface_material_override(debug_instance, 1, RID());
 				}
 			}
 		}
@@ -496,19 +496,19 @@ void NavigationRegion3D::_update_debug_mesh() {
 	if (!is_enabled()) {
 		if (debug_mesh.is_valid()) {
 			if (debug_mesh->get_surface_count() > 0) {
-				RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_face_disabled_material()->get_rid());
+				RS::get_singleton()->instance_set_surface_material_override(debug_instance, 0, NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_face_disabled_material()->get_rid());
 			}
 			if (debug_mesh->get_surface_count() > 1) {
-				RS::get_singleton()->instance_set_surface_override_material(debug_instance, 1, NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_edge_disabled_material()->get_rid());
+				RS::get_singleton()->instance_set_surface_material_override(debug_instance, 1, NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_edge_disabled_material()->get_rid());
 			}
 		}
 	} else {
 		if (debug_mesh.is_valid()) {
 			if (debug_mesh->get_surface_count() > 0) {
-				RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, RID());
+				RS::get_singleton()->instance_set_surface_material_override(debug_instance, 0, RID());
 			}
 			if (debug_mesh->get_surface_count() > 1) {
-				RS::get_singleton()->instance_set_surface_override_material(debug_instance, 1, RID());
+				RS::get_singleton()->instance_set_surface_material_override(debug_instance, 1, RID());
 			}
 		}
 	}

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -476,7 +476,7 @@ void SoftBody3D::_prepare_physics_server() {
 
 void SoftBody3D::_become_mesh_owner() {
 	Vector<Ref<Material>> copy_materials;
-	copy_materials.append_array(surface_override_materials);
+	copy_materials.append_array(surface_material_overrides);
 
 	ERR_FAIL_COND(!mesh->get_surface_count());
 
@@ -496,7 +496,7 @@ void SoftBody3D::_become_mesh_owner() {
 	set_mesh(soft_mesh);
 
 	for (int i = copy_materials.size() - 1; 0 <= i; --i) {
-		set_surface_override_material(i, copy_materials[i]);
+		set_surface_material_override(i, copy_materials[i]);
 	}
 
 	owned_mesh = soft_mesh->get_rid();

--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -304,9 +304,9 @@ void VoxelGI::_find_meshes(Node *p_at_node, List<PlotMesh> &plot_meshes) {
 				pm.local_xform = xf;
 				pm.mesh = mesh;
 				for (int i = 0; i < mesh->get_surface_count(); i++) {
-					pm.instance_materials.push_back(mi->get_surface_override_material(i));
+					pm.instance_materials.push_back(mi->get_surface_material_override(i));
 				}
-				pm.override_material = mi->get_material_override();
+				pm.material_override = mi->get_material_override();
 				plot_meshes.push_back(pm);
 			}
 		}
@@ -408,7 +408,7 @@ void VoxelGI::bake(Node *p_from_node, bool p_create_visual_debug) {
 
 		pmc++;
 
-		baker.plot_mesh(E.local_xform, E.mesh, E.instance_materials, E.override_material);
+		baker.plot_mesh(E.local_xform, E.mesh, E.instance_materials, E.material_override);
 	}
 	if (bake_step_function) {
 		bake_step_function(pmc++, RTR("Finishing Plot"));

--- a/scene/3d/voxel_gi.h
+++ b/scene/3d/voxel_gi.h
@@ -122,7 +122,7 @@ private:
 	Ref<CameraAttributes> camera_attributes;
 
 	struct PlotMesh {
-		Ref<Material> override_material;
+		Ref<Material> material_override;
 		Vector<Ref<Material>> instance_materials;
 		Ref<Mesh> mesh;
 		Transform3D local_xform;

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -378,7 +378,7 @@ Voxelizer::MaterialCache Voxelizer::_get_material_cache(Ref<Material> p_material
 	return mc;
 }
 
-void Voxelizer::plot_mesh(const Transform3D &p_xform, Ref<Mesh> &p_mesh, const Vector<Ref<Material>> &p_materials, const Ref<Material> &p_override_material) {
+void Voxelizer::plot_mesh(const Transform3D &p_xform, Ref<Mesh> &p_mesh, const Vector<Ref<Material>> &p_materials, const Ref<Material> &p_material_override) {
 	for (int i = 0; i < p_mesh->get_surface_count(); i++) {
 		if (p_mesh->surface_get_primitive_type(i) != Mesh::PRIMITIVE_TRIANGLES) {
 			continue; //only triangles
@@ -386,8 +386,8 @@ void Voxelizer::plot_mesh(const Transform3D &p_xform, Ref<Mesh> &p_mesh, const V
 
 		Ref<Material> src_material;
 
-		if (p_override_material.is_valid()) {
-			src_material = p_override_material;
+		if (p_material_override.is_valid()) {
+			src_material = p_material_override;
 		} else if (i < p_materials.size() && p_materials[i].is_valid()) {
 			src_material = p_materials[i];
 		} else {

--- a/scene/3d/voxelizer.h
+++ b/scene/3d/voxelizer.h
@@ -113,7 +113,7 @@ private:
 
 public:
 	void begin_bake(int p_subdiv, const AABB &p_bounds, float p_exposure_normalization);
-	void plot_mesh(const Transform3D &p_xform, Ref<Mesh> &p_mesh, const Vector<Ref<Material>> &p_materials, const Ref<Material> &p_override_material);
+	void plot_mesh(const Transform3D &p_xform, Ref<Mesh> &p_mesh, const Vector<Ref<Material>> &p_materials, const Ref<Material> &p_material_override);
 	void end_bake();
 
 	int get_voxel_gi_octree_depth() const;

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -897,7 +897,7 @@ void RendererSceneCull::instance_set_blend_shape_weight(RID p_instance, int p_sh
 	}
 }
 
-void RendererSceneCull::instance_set_surface_override_material(RID p_instance, int p_surface, RID p_material) {
+void RendererSceneCull::instance_set_surface_material_override(RID p_instance, int p_surface, RID p_material) {
 	Instance *instance = instance_owner.get_or_null(p_instance);
 	ERR_FAIL_COND(!instance);
 

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -936,7 +936,7 @@ public:
 	virtual void instance_set_transform(RID p_instance, const Transform3D &p_transform);
 	virtual void instance_attach_object_instance_id(RID p_instance, ObjectID p_id);
 	virtual void instance_set_blend_shape_weight(RID p_instance, int p_shape, float p_weight);
-	virtual void instance_set_surface_override_material(RID p_instance, int p_surface, RID p_material);
+	virtual void instance_set_surface_material_override(RID p_instance, int p_surface, RID p_material);
 	virtual void instance_set_visible(RID p_instance, bool p_visible);
 	virtual void instance_geometry_set_transparency(RID p_instance, float p_transparency);
 

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -75,7 +75,7 @@ public:
 	virtual void instance_set_transform(RID p_instance, const Transform3D &p_transform) = 0;
 	virtual void instance_attach_object_instance_id(RID p_instance, ObjectID p_id) = 0;
 	virtual void instance_set_blend_shape_weight(RID p_instance, int p_shape, float p_weight) = 0;
-	virtual void instance_set_surface_override_material(RID p_instance, int p_surface, RID p_material) = 0;
+	virtual void instance_set_surface_material_override(RID p_instance, int p_surface, RID p_material) = 0;
 	virtual void instance_set_visible(RID p_instance, bool p_visible) = 0;
 	virtual void instance_geometry_set_transparency(RID p_instance, float p_transparency) = 0;
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -765,7 +765,7 @@ public:
 	FUNC2(instance_set_transform, RID, const Transform3D &)
 	FUNC2(instance_attach_object_instance_id, RID, ObjectID)
 	FUNC3(instance_set_blend_shape_weight, RID, int, float)
-	FUNC3(instance_set_surface_override_material, RID, int, RID)
+	FUNC3(instance_set_surface_material_override, RID, int, RID)
 	FUNC2(instance_set_visible, RID, bool)
 
 	FUNC2(instance_set_custom_aabb, RID, AABB)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2483,7 +2483,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("instance_set_transform", "instance", "transform"), &RenderingServer::instance_set_transform);
 	ClassDB::bind_method(D_METHOD("instance_attach_object_instance_id", "instance", "id"), &RenderingServer::instance_attach_object_instance_id);
 	ClassDB::bind_method(D_METHOD("instance_set_blend_shape_weight", "instance", "shape", "weight"), &RenderingServer::instance_set_blend_shape_weight);
-	ClassDB::bind_method(D_METHOD("instance_set_surface_override_material", "instance", "surface", "material"), &RenderingServer::instance_set_surface_override_material);
+	ClassDB::bind_method(D_METHOD("instance_set_surface_material_override", "instance", "surface", "material"), &RenderingServer::instance_set_surface_material_override);
 	ClassDB::bind_method(D_METHOD("instance_set_visible", "instance", "visible"), &RenderingServer::instance_set_visible);
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_transparency", "instance", "transparency"), &RenderingServer::instance_geometry_set_transparency);
 

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1212,7 +1212,7 @@ public:
 	virtual void instance_set_transform(RID p_instance, const Transform3D &p_transform) = 0;
 	virtual void instance_attach_object_instance_id(RID p_instance, ObjectID p_id) = 0;
 	virtual void instance_set_blend_shape_weight(RID p_instance, int p_shape, float p_weight) = 0;
-	virtual void instance_set_surface_override_material(RID p_instance, int p_surface, RID p_material) = 0;
+	virtual void instance_set_surface_material_override(RID p_instance, int p_surface, RID p_material) = 0;
 	virtual void instance_set_visible(RID p_instance, bool p_visible) = 0;
 
 	virtual void instance_set_custom_aabb(RID p_instance, AABB aabb) = 0;


### PR DESCRIPTION
Fixes #70233 

Material override sounds better than override material imo, and this is also what is currently visible in the inspector.

This breaks compat however it might be worth it? 4.0 still hasn't released and it will be a while until compat can be broken again.