### PR TITLE
Fixed issue " UI text size does not match theme "

### DIFF
--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -229,7 +229,7 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 
 	Ref<FontVariation> default_theme_fc;
 	default_theme_fc.instantiate();
-	if (custom_font_path.length() > 0 && dir->file_exists(custom_font_path)) {
+	if (!custom_font_path.is_empty() && dir->file_exists(custom_font_path)) {
 		Ref<FontFile> custom_font = load_external_font(custom_font_path, font_hinting, font_antialiasing, true, font_subpixel_positioning);
 		{
 			TypedArray<Font> fallback_custom;

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -148,6 +148,7 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	const float embolden_strength = 0.6;
 
 	Ref<Font> default_font = load_internal_font(_font_NotoSans_Regular, _font_NotoSans_Regular_size, font_hinting, font_antialiasing, true, font_subpixel_positioning, false);
+	Ref<Font> default_theme_font = load_internal_font(_font_OpenSans_SemiBold, _font_OpenSans_SemiBold_size, font_hinting, font_antialiasing, true, font_subpixel_positioning, false);
 	Ref<Font> default_font_msdf = load_internal_font(_font_NotoSans_Regular, _font_NotoSans_Regular_size, font_hinting, font_antialiasing, true, font_subpixel_positioning, true);
 
 	TypedArray<Font> fallbacks;
@@ -225,6 +226,23 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	}
 	default_fc->set_spacing(TextServer::SPACING_TOP, -EDSCALE);
 	default_fc->set_spacing(TextServer::SPACING_BOTTOM, -EDSCALE);
+
+	Ref<FontVariation> default_theme_fc;
+	default_theme_fc.instantiate();
+	if (custom_font_path.length() > 0 && dir->file_exists(custom_font_path)) {
+		Ref<FontFile> custom_font = load_external_font(custom_font_path, font_hinting, font_antialiasing, true, font_subpixel_positioning);
+		{
+			TypedArray<Font> fallback_custom;
+			fallback_custom.push_back(default_font);
+			custom_font->set_fallbacks(fallback_custom);
+		}
+		default_theme_fc->set_base_font(custom_font);
+	} else {
+		EditorSettings::get_singleton()->set_manually("interface/editor/main_font", "");
+		default_theme_fc->set_base_font(default_theme_font);
+	}
+	default_theme_fc->set_spacing(TextServer::SPACING_TOP, -EDSCALE);
+	default_theme_fc->set_spacing(TextServer::SPACING_BOTTOM, -EDSCALE);
 
 	Ref<FontVariation> default_fc_msdf;
 	default_fc_msdf.instantiate();
@@ -372,7 +390,7 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 
 	// Setup theme.
 
-	p_theme->set_default_font(default_fc); // Default theme font config.
+	p_theme->set_default_font(default_theme_fc); // Default theme font config.
 	p_theme->set_default_font_size(default_font_size);
 
 	// Main font.

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -390,7 +390,7 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 
 	// Setup theme.
 
-	p_theme->set_default_font(default_theme_fc); // Default theme font config.
+	p_theme->set_default_font(default_fc); // Default theme font config.
 	p_theme->set_default_font_size(default_font_size);
 
 	// Main font.

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -71,7 +71,7 @@ protected:
 public:
 	virtual void _invalidate_rids();
 
-	static constexpr int DEFAULT_FONT_SIZE = 16;
+	static constexpr int DEFAULT_FONT_SIZE = 14;
 
 	// Fallbacks.
 	virtual void set_fallbacks(const TypedArray<Font> &p_fallbacks);

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -105,7 +105,7 @@ protected:
 	// Default values configurable for each individual theme.
 	float default_base_scale = 0.0;
 	Ref<Font> default_font;
-	int default_font_size = -1;
+	int default_font_size = 16;
 
 	static void _bind_methods();
 


### PR DESCRIPTION
Fixed issue #69781.  Now theme preview have font size as 16 and font as OpenSans_SemiBold which is same the scene button.
![Screenshot 2022-12-20 021636](https://user-images.githubusercontent.com/77923967/208518910-fd744ee4-d8fa-4b0c-abec-4d7578aa942b.png)
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
