### PR TITLE
Unify GDScriptAnalyzer in-editor and runtime autoload checks

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1966,6 +1966,16 @@ void GDScriptLanguage::add_named_global_constant(const StringName &p_name, const
 	named_globals[p_name] = p_value;
 }
 
+Variant GDScriptLanguage::get_any_global_constant(const StringName &p_name) {
+	if (named_globals.has(p_name)) {
+		return named_globals[p_name];
+	}
+	if (globals.has(p_name)) {
+		return _global_array[globals[p_name]];
+	}
+	ERR_FAIL_V_MSG(Variant(), vformat("Could not find any global constant with name: %s.", p_name));
+}
+
 void GDScriptLanguage::remove_named_global_constant(const StringName &p_name) {
 	ERR_FAIL_COND(!named_globals.has(p_name));
 	named_globals.erase(p_name);

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -455,6 +455,9 @@ public:
 	_FORCE_INLINE_ Variant *get_global_array() { return _global_array; }
 	_FORCE_INLINE_ const HashMap<StringName, int> &get_global_map() const { return globals; }
 	_FORCE_INLINE_ const HashMap<StringName, Variant> &get_named_globals_map() const { return named_globals; }
+	// These two functions should be used when behavior needs to be consistent between in-editor and running the scene
+	bool has_any_global_constant(const StringName &p_name) { return named_globals.has(p_name) || globals.has(p_name); }
+	Variant get_any_global_constant(const StringName &p_name);
 
 	_FORCE_INLINE_ static GDScriptLanguage *get_singleton() { return singleton; }
 

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3403,8 +3403,8 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 					}
 				}
 			} else if (ResourceLoader::get_resource_type(autoload.path) == "PackedScene") {
-				if (GDScriptLanguage::get_singleton()->get_named_globals_map().has(name)) {
-					Variant constant = GDScriptLanguage::get_singleton()->get_named_globals_map()[name];
+				if (GDScriptLanguage::get_singleton()->has_any_global_constant(name)) {
+					Variant constant = GDScriptLanguage::get_singleton()->get_any_global_constant(name);
 					Node *node = Object::cast_to<Node>(constant);
 					if (node != nullptr) {
 						Ref<GDScript> scr = node->get_script();
@@ -3426,17 +3426,8 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 		}
 	}
 
-	if (GDScriptLanguage::get_singleton()->get_global_map().has(name)) {
-		int idx = GDScriptLanguage::get_singleton()->get_global_map()[name];
-		Variant constant = GDScriptLanguage::get_singleton()->get_global_array()[idx];
-		p_identifier->set_datatype(type_from_variant(constant, p_identifier));
-		p_identifier->is_constant = true;
-		p_identifier->reduced_value = constant;
-		return;
-	}
-
-	if (GDScriptLanguage::get_singleton()->get_named_globals_map().has(name)) {
-		Variant constant = GDScriptLanguage::get_singleton()->get_named_globals_map()[name];
+	if (GDScriptLanguage::get_singleton()->has_any_global_constant(name)) {
+		Variant constant = GDScriptLanguage::get_singleton()->get_any_global_constant(name);
 		p_identifier->set_datatype(type_from_variant(constant, p_identifier));
 		p_identifier->is_constant = true;
 		p_identifier->reduced_value = constant;


### PR DESCRIPTION
Fixes #63045
Fixes #70127

I dug deeper into #70127, and this together with #70275 should capture a lot more cases!

When running in-editor, `EditorAutoloadSettings` uses `add_named_global_constant()`, whereas when running the game itself, `main.cpp` uses `add_global_constant()`. `GDScriptAnalyzer` was only checking `named_globals`, which weren't present at runtime.

This ensures the analyzer checks both, so it works similarly in-editor and in-game.

This should allow some extra type inferences when running the main game. Particularly, any optimizations related to autoloaded scripts/scenes that are currently possible while in-editor are now possible while running the game. Right now these are only `const`-based optimizations, but maybe in the future it could be more :)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
