### PR TITLE
Add configuration warning when ButtonGroup is used with non-toggleable buttons

### DIFF
--- a/doc/classes/ButtonGroup.xml
+++ b/doc/classes/ButtonGroup.xml
@@ -4,8 +4,8 @@
 		Group of Buttons.
 	</brief_description>
 	<description>
-		Group of [Button]. All direct and indirect children buttons become radios. Only one allows being pressed.
-		[member BaseButton.toggle_mode] should be [code]true[/code].
+		Group of [BaseButton]. The members of this group are treated like radio buttons in the sense that only one button can be pressed at the same time.
+		Every member of the ButtonGroup should have [member BaseButton.toggle_mode] set to [code]true[/code].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -300,6 +300,7 @@ void BaseButton::set_toggle_mode(bool p_on) {
 	}
 
 	toggle_mode = p_on;
+	update_configuration_warnings();
 }
 
 bool BaseButton::is_toggle_mode() const {
@@ -381,6 +382,7 @@ void BaseButton::set_button_group(const Ref<ButtonGroup> &p_group) {
 	}
 
 	queue_redraw(); //checkbox changes to radio if set a buttongroup
+	update_configuration_warnings();
 }
 
 Ref<ButtonGroup> BaseButton::get_button_group() const {
@@ -397,6 +399,16 @@ void BaseButton::set_shortcut_feedback(bool p_feedback) {
 
 bool BaseButton::is_shortcut_feedback() const {
 	return shortcut_feedback;
+}
+
+PackedStringArray BaseButton::get_configuration_warnings() const {
+	PackedStringArray warnings = Control::get_configuration_warnings();
+
+	if (get_button_group().is_valid() && !is_toggle_mode()) {
+		warnings.push_back(RTR("ButtonGroup is intended to be used only with buttons that have toggle_mode set to true."));
+	}
+
+	return warnings;
 }
 
 void BaseButton::_bind_methods() {

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -136,6 +136,8 @@ public:
 	void set_shortcut_feedback(bool p_feedback);
 	bool is_shortcut_feedback() const;
 
+	PackedStringArray get_configuration_warnings() const override;
+
 	BaseButton();
 	~BaseButton();
 };


### PR DESCRIPTION
Also documentation of ButtonGroup was ambiguous.

resolve #70326