### PR TITLE
VCS: Fix GDExtension return types for VCS after Array type hardening

### DIFF
--- a/doc/classes/EditorVCSInterface.xml
+++ b/doc/classes/EditorVCSInterface.xml
@@ -53,7 +53,7 @@
 			</description>
 		</method>
 		<method name="_get_branch_list" qualifiers="virtual">
-			<return type="Dictionary[]" />
+			<return type="String[]" />
 			<description>
 				Gets an instance of an [Array] of [String]s containing available branch names in the VCS.
 			</description>
@@ -94,7 +94,7 @@
 			</description>
 		</method>
 		<method name="_get_remotes" qualifiers="virtual">
-			<return type="Dictionary[]" />
+			<return type="String[]" />
 			<description>
 				Returns an [Array] of [String]s, each containing the name of a remote configured in the VCS.
 			</description>

--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -57,7 +57,7 @@ void EditorVCSInterface::set_credentials(String p_username, String p_password, S
 }
 
 List<String> EditorVCSInterface::get_remotes() {
-	TypedArray<Dictionary> result;
+	TypedArray<String> result;
 	if (!GDVIRTUAL_CALL(_get_remotes, result)) {
 		UNIMPLEMENTED();
 		return {};
@@ -137,7 +137,7 @@ List<EditorVCSInterface::Commit> EditorVCSInterface::get_previous_commits(int p_
 }
 
 List<String> EditorVCSInterface::get_branch_list() {
-	TypedArray<Dictionary> result;
+	TypedArray<String> result;
 	if (!GDVIRTUAL_CALL(_get_branch_list, result)) {
 		UNIMPLEMENTED();
 		return {};

--- a/editor/editor_vcs_interface.h
+++ b/editor/editor_vcs_interface.h
@@ -117,8 +117,8 @@ protected:
 	GDVIRTUAL0R(bool, _shut_down);
 	GDVIRTUAL0R(String, _get_vcs_name);
 	GDVIRTUAL1R(TypedArray<Dictionary>, _get_previous_commits, int);
-	GDVIRTUAL0R(TypedArray<Dictionary>, _get_branch_list);
-	GDVIRTUAL0R(TypedArray<Dictionary>, _get_remotes);
+	GDVIRTUAL0R(TypedArray<String>, _get_branch_list);
+	GDVIRTUAL0R(TypedArray<String>, _get_remotes);
 	GDVIRTUAL1(_create_branch, String);
 	GDVIRTUAL1(_remove_branch, String);
 	GDVIRTUAL2(_create_remote, String, String);


### PR DESCRIPTION
Fixes incorrect types found when building godot-git-plugin - https://github.com/godotengine/godot-git-plugin/pull/132#issuecomment-1358413179