### PR TITLE
[3.x] Move navigation server finalize before physics server

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2530,9 +2530,9 @@ void Main::cleanup(bool p_force) {
 		memdelete(camera_server);
 	}
 
+	finalize_navigation_server();
 	OS::get_singleton()->finalize();
 	finalize_physics();
-	finalize_navigation_server();
 
 	if (packed_data) {
 		memdelete(packed_data);


### PR DESCRIPTION
3.x version of https://github.com/godotengine/godot/pull/69769

Moves finalize_navigation_server() before physics server (and also OS in 3.x). The NavigationServer command queue can have objects from other servers like physics or visuals so it needs to be flushed before.

OS::get_singleton()->finalize() is placed higher in 3.x so finalize_navigation_server() is placed before, else we have the same leaks / crashes instead of physics for visual meshes e.g. NavigationMesh.

Fixes https://github.com/godotengine/godot/issues/63678 in my tests (needs more testing).

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
