### PR TITLE
Add missing != operator to `StringName`

### DIFF
--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -169,6 +169,10 @@ bool StringName::operator!=(const String &p_name) const {
 	return !(operator==(p_name));
 }
 
+bool StringName::operator!=(const char *p_name) const {
+	return !(operator==(p_name));
+}
+
 bool StringName::operator!=(const StringName &p_name) const {
 	// the real magic of all this mess happens here.
 	// this is why path comparisons are very fast

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -102,6 +102,7 @@ public:
 	bool operator==(const String &p_name) const;
 	bool operator==(const char *p_name) const;
 	bool operator!=(const String &p_name) const;
+	bool operator!=(const char *p_name) const;
 
 	_FORCE_INLINE_ bool is_node_unique_name() const {
 		if (!_data) {

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -1263,7 +1263,7 @@ Dictionary VisualShaderEditor::get_custom_node_data(Ref<VisualShaderNodeCustom> 
 
 void VisualShaderEditor::update_custom_type(const Ref<Resource> &p_resource) {
 	Ref<Script> scr = Ref<Script>(p_resource.ptr());
-	if (scr.is_null() || scr->get_instance_base_type() != String("VisualShaderNodeCustom")) {
+	if (scr.is_null() || scr->get_instance_base_type() != "VisualShaderNodeCustom") {
 		return;
 	}
 

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -4417,7 +4417,7 @@ bool ShaderLanguage::_is_operator_assign(Operator p_op) const {
 }
 
 bool ShaderLanguage::_validate_varying_assign(ShaderNode::Varying &p_varying, String *r_message) {
-	if (current_function != String("vertex") && current_function != String("fragment")) {
+	if (current_function != "vertex" && current_function != "fragment") {
 		*r_message = vformat(RTR("Varying may not be assigned in the '%s' function."), current_function);
 		return false;
 	}


### PR DESCRIPTION
I think it's strange that `StringName` allows comparison with char* strings for equality but not for the inequality.
