### PR TITLE
VCS: Remove `project_path` VCS property, let plugins decide

### DIFF
--- a/editor/plugins/version_control_editor_plugin.h
+++ b/editor/plugins/version_control_editor_plugin.h
@@ -73,8 +73,6 @@ private:
 	AcceptDialog *set_up_dialog = nullptr;
 	CheckButton *toggle_vcs_choice = nullptr;
 	OptionButton *set_up_choice = nullptr;
-	LineEdit *project_path_input = nullptr;
-	Button *select_project_path_button = nullptr;
 	VBoxContainer *set_up_vbc = nullptr;
 	VBoxContainer *set_up_settings_vbc = nullptr;
 	LineEdit *set_up_username = nullptr;
@@ -150,7 +148,7 @@ private:
 	void _update_opened_tabs();
 	void _update_extra_options();
 
-	bool _load_plugin(String p_name, String p_project_path);
+	bool _load_plugin(String p_name);
 
 	void _pull();
 	void _push();
@@ -193,7 +191,6 @@ private:
 	void _create_vcs_metadata_files();
 	void _popup_file_dialog(Variant p_file_dialog_variant);
 	void _toggle_vcs_integration(bool p_toggled);
-	void _project_path_selected(String p_project_path);
 
 	friend class EditorVCSInterface;
 


### PR DESCRIPTION
Screenshots:
> On a completely new repo (no .git directory in current or parent paths)

![image](https://user-images.githubusercontent.com/31801364/208705038-f50060a2-00cc-4176-831b-0f9764dc1784.png)


> On a seasoned repo (parent path has a .git directory)

![image](https://user-images.githubusercontent.com/31801364/208705058-560c6815-7da9-4bbf-993f-9dc57e04751e.png)

This PR was made in parallel with - https://github.com/twaritwaikar/godot-git-plugin/pull/1

The project path is no longer required because if the plugin can self-identify the project directory, then there is no need for the user to customize this behaviour. Using a bad project path will result in frustrating errors since we expect the plugin to work the same way as the git CLI.
