### PR TITLE
Disable properties that don't have an effect in the advanced audio im…

### DIFF
--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -465,12 +465,17 @@ void AudioStreamImportSettings::_settings_changed() {
 	updating_settings = true;
 	stream->call("set_loop", loop->is_pressed());
 	stream->call("set_loop_offset", loop_offset->get_value());
+	if (loop->is_pressed()) {
+		loop_offset->set_editable(true);
+	} else {
+		loop_offset->set_editable(false);
+	}
+
 	if (bpm_enabled->is_pressed()) {
 		stream->call("set_bpm", bpm_edit->get_value());
-		beats_enabled->show();
-		beats_edit->show();
-		bar_beats_label->show();
-		bar_beats_edit->show();
+		beats_enabled->set_disabled(false);
+		beats_edit->set_editable(true);
+		bar_beats_edit->set_editable(true);
 		double bpm = bpm_edit->get_value();
 		if (bpm > 0) {
 			float beat_size = 60 / float(bpm);
@@ -486,10 +491,9 @@ void AudioStreamImportSettings::_settings_changed() {
 	} else {
 		stream->call("set_bpm", 0);
 		stream->call("set_bar_beats", 4);
-		beats_enabled->hide();
-		beats_edit->hide();
-		bar_beats_label->hide();
-		bar_beats_edit->hide();
+		beats_enabled->set_disabled(true);
+		beats_edit->set_editable(false);
+		bar_beats_edit->set_editable(false);
 	}
 	if (bpm_enabled->is_pressed() && beats_enabled->is_pressed()) {
 		stream->call("set_beat_count", beats_edit->get_value());
@@ -552,15 +556,6 @@ AudioStreamImportSettings::AudioStreamImportSettings() {
 	bpm_edit->connect("value_changed", callable_mp(this, &AudioStreamImportSettings::_settings_changed).unbind(1));
 	interactive_hb->add_child(bpm_edit);
 	interactive_hb->add_spacer();
-	bar_beats_label = memnew(Label(TTR("Bar Beats:")));
-	interactive_hb->add_child(bar_beats_label);
-	bar_beats_edit = memnew(SpinBox);
-	bar_beats_edit->set_tooltip_text(TTR("Configure the Beats Per Bar. This used for music-aware transitions between AudioStreams."));
-	bar_beats_edit->set_min(2);
-	bar_beats_edit->set_max(32);
-	bar_beats_edit->connect("value_changed", callable_mp(this, &AudioStreamImportSettings::_settings_changed).unbind(1));
-	interactive_hb->add_child(bar_beats_edit);
-	interactive_hb->add_spacer();
 	beats_enabled = memnew(CheckBox);
 	beats_enabled->set_text(TTR("Beat Count:"));
 	beats_enabled->connect("toggled", callable_mp(this, &AudioStreamImportSettings::_settings_changed).unbind(1));
@@ -570,6 +565,15 @@ AudioStreamImportSettings::AudioStreamImportSettings() {
 	beats_edit->set_max(99999);
 	beats_edit->connect("value_changed", callable_mp(this, &AudioStreamImportSettings::_settings_changed).unbind(1));
 	interactive_hb->add_child(beats_edit);
+	bar_beats_label = memnew(Label(TTR("Bar Beats:")));
+	interactive_hb->add_child(bar_beats_label);
+	bar_beats_edit = memnew(SpinBox);
+	bar_beats_edit->set_tooltip_text(TTR("Configure the Beats Per Bar. This used for music-aware transitions between AudioStreams."));
+	bar_beats_edit->set_min(2);
+	bar_beats_edit->set_max(32);
+	bar_beats_edit->connect("value_changed", callable_mp(this, &AudioStreamImportSettings::_settings_changed).unbind(1));
+	interactive_hb->add_child(bar_beats_edit);
+	interactive_hb->add_spacer();
 	main_vbox->add_margin_child(TTR("Music Playback:"), interactive_hb);
 
 	color_rect = memnew(ColorRect);


### PR DESCRIPTION
Fixes #70245. Instead of hiding the properties it just disables them so they can't be edited (suggested by Akien in https://github.com/godotengine/godot/issues/70245#issuecomment-1358072797). This should be less confusing:

![image](https://user-images.githubusercontent.com/19669673/208732167-0156087d-0456-4554-81e2-fe866612aeb6.png)

Labels themselves can't be disabled though, so they look a bit weird. Doesn't seam like there's any easy way to change that though.

Also adds the disabled effect to the loop offset when loop is disabled. Finally it changed the order of bar beats and beat count to match the order in the regular audio importer.