### PR TITLE
Fix pairing crash in physics Octree

### DIFF
--- a/servers/physics/broad_phase_octree.cpp
+++ b/servers/physics/broad_phase_octree.cpp
@@ -85,19 +85,6 @@ void *BroadPhaseOctree::_pair_callback(void *self, OctreeElementID p_A, Collisio
 	}
 
 	bool valid_collision_pair = p_object_A->test_collision_mask(p_object_B);
-	void *pair_data = bpo->pair_userdata;
-
-	if (pair_data) {
-		// Checking an existing pair.
-		if (valid_collision_pair) {
-			// Nothing to do, pair is still valid.
-			return pair_data;
-		} else {
-			// Logical collision not valid anymore, unpair.
-			_unpair_callback(self, p_A, p_object_A, subindex_A, p_B, p_object_B, subindex_B, pair_data);
-			return nullptr;
-		}
-	}
 
 	if (!valid_collision_pair) {
 		return nullptr;


### PR DESCRIPTION
Remove section of code that should not run and was causing crash.

Fixes #70322

## Notes
* Regression caused by #55640
* The section of code previously passed `nullptr` to `SpaceSW::_broadphase_pair` in `p_pair_data`, this meant that the middle of the removed section never should have ran.
* Only relevant in 3.x as we removed octree from 4.x

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
