### PR TITLE
Fix `BitMap.resize` error spam

### DIFF
--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -606,8 +606,8 @@ void BitMap::resize(const Size2 &p_new_size) {
 	Ref<BitMap> new_bitmap;
 	new_bitmap.instance();
 	new_bitmap->create(p_new_size);
-	int lw = MIN(width, p_new_size.width);
-	int lh = MIN(height, p_new_size.height);
+	int lw = MIN(width, new_bitmap->width);
+	int lh = MIN(height, new_bitmap->height);
 	for (int x = 0; x < lw; x++) {
 		for (int y = 0; y < lh; y++) {
 			new_bitmap->set_bit(Vector2(x, y), get_bit(Vector2(x, y)));


### PR DESCRIPTION
Fixes #70187.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
