### PR TITLE
add more defaults to generated files

### DIFF
--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -419,8 +419,8 @@ void EditorVCSInterface::create_vcs_metadata_files(VCSMetadata p_vcs_metadata_ty
 			ERR_FAIL_MSG("Couldn't create .gitattributes in project path.");
 		} else {
 			f->store_line("# Properly detect languages on GitHub");
-			f->store_line("*.gd linguist-language=GDScript")
-			f->store_line("")
+			f->store_line("*.gd linguist-language=GDScript");
+			f->store_line("");
 			f->store_line("# Normalize EOL for all files that Git considers text files");
 			f->store_line("* text=auto eol=lf");
 			f->store_line("# Except for Batch files, which don't behave correctly otherwise");

--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -424,7 +424,7 @@ void EditorVCSInterface::create_vcs_metadata_files(VCSMetadata p_vcs_metadata_ty
 			f->store_line("# Normalize EOL for all files that Git considers text files");
 			f->store_line("* text=auto eol=lf");
 			f->store_line("# Except for Batch files, which don't behave correctly otherwise");
-			f->store_line("*.bat eol=crlf")
+			f->store_line("*.bat eol=crlf");
 		}
 	}
 }

--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -423,7 +423,7 @@ void EditorVCSInterface::create_vcs_metadata_files(VCSMetadata p_vcs_metadata_ty
 			f->store_line("")
 			f->store_line("# Normalize EOL for all files that Git considers text files");
 			f->store_line("* text=auto eol=lf");
-			f->store_line("# Except for bat files, which are Windows only files")
+			f->store_line("# Except for Batch files, which don't behave correctly otherwise");
 			f->store_line("*.bat eol=crlf")
 		}
 	}

--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -418,7 +418,7 @@ void EditorVCSInterface::create_vcs_metadata_files(VCSMetadata p_vcs_metadata_ty
 		if (f.is_null()) {
 			ERR_FAIL_MSG("Couldn't create .gitattributes in project path.");
 		} else {
-			f->store_line("# Properly detect languages on Github")
+			f->store_line("# Properly detect languages on GitHub");
 			f->store_line("*.gd linguist-language=GDScript")
 			f->store_line("")
 			f->store_line("# Normalize EOL for all files that Git considers text files");

--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -418,8 +418,13 @@ void EditorVCSInterface::create_vcs_metadata_files(VCSMetadata p_vcs_metadata_ty
 		if (f.is_null()) {
 			ERR_FAIL_MSG("Couldn't create .gitattributes in project path.");
 		} else {
-			f->store_line("# Normalize EOL for all files that Git considers text files.");
+			f->store_line("# Properly detect languages on Github")
+			f->store_line("*.gd linguist-language=GDScript")
+			f->store_line("")
+			f->store_line("# Normalize EOL for all files that Git considers text files");
 			f->store_line("* text=auto eol=lf");
+			f->store_line("# Except for bat files, which are Windows only files")
+			f->store_line("*.bat eol=crlf")
 		}
 	}
 }


### PR DESCRIPTION
Hey so with Godot 4 being available soon I think a lot of new projects will be created and currently on Github there are a lot of gdscript project that show up as GAP incorrectly.

So I think it would be a good idea to just generate everything you would want so people don't have to bother with that at all. I just imitated the Godot engine .gitattributes I don't think there's any downsides besides adding some bytes.

I didn't touch the .gitignore because I'm unsure which are relevant for godot 4, but I think the following could be added?

```
# Imported translations (automatically generated from CSV files)
*.translation

# Mono-specific ignores
.mono/
data_*/
mono_crash.*.json
```