### PR TITLE
Fix AnimationStateMachine cannot connect nodes bug

### DIFF
--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -835,7 +835,8 @@ void AnimationNodeStateMachine::rename_node(const StringName &p_name, const Stri
 
 	_rename_transitions(p_name, p_new_name);
 
-	emit_signal("tree_changed");
+	emit_changed();
+	emit_signal(SNAME("tree_changed"));
 }
 
 void AnimationNodeStateMachine::_rename_transitions(const StringName &p_name, const StringName &p_new_name) {
@@ -878,9 +879,8 @@ void AnimationNodeStateMachine::_rename_transitions(const StringName &p_name, co
 
 			transitions.write[i].to = p_new_name;
 		}
-
-		updating_transitions = false;
 	}
+	updating_transitions = false;
 }
 
 void AnimationNodeStateMachine::get_node_list(List<StringName> *r_nodes) const {
@@ -1292,6 +1292,7 @@ Vector2 AnimationNodeStateMachine::get_node_position(const StringName &p_name) c
 }
 
 void AnimationNodeStateMachine::_tree_changed() {
+	emit_changed();
 	emit_signal(SNAME("tree_changed"));
 }
 


### PR DESCRIPTION
Fixed #65988.

The bug was that the unlocking of updating_transitions in _rename_transitions() was unexpectedly inside the for loop, so if the transition did not exist, it would not enter the for loop and updating_transitions would not be unlocked. Maybe it's a rebase or a copy-paste error.

In addition, some lacked signals have been added.