### PR TITLE
Avoid binding methods returning raw Object pointer

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -410,6 +410,10 @@ Object *EditorProperty::get_edited_object() {
 	return object;
 }
 
+Variant EditorProperty::_get_edited_object_bind() {
+	return Variant(object);
+}
+
 StringName EditorProperty::get_edited_property() const {
 	return property;
 }
@@ -964,7 +968,7 @@ void EditorProperty::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_deletable"), &EditorProperty::is_deletable);
 
 	ClassDB::bind_method(D_METHOD("get_edited_property"), &EditorProperty::get_edited_property);
-	ClassDB::bind_method(D_METHOD("get_edited_object"), &EditorProperty::get_edited_object);
+	ClassDB::bind_method(D_METHOD("get_edited_object"), &EditorProperty::_get_edited_object_bind);
 
 	ClassDB::bind_method(D_METHOD("update_property"), &EditorProperty::update_property);
 

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -126,6 +126,8 @@ private:
 
 	void _update_pin_flags();
 
+	Variant _get_edited_object_bind();
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -515,13 +515,13 @@ void CanvasItemEditor::shortcut_input(const Ref<InputEvent> &p_ev) {
 	}
 }
 
-Object *CanvasItemEditor::_get_editor_data(Object *p_what) {
+Variant CanvasItemEditor::_get_editor_data(Object *p_what) {
 	CanvasItem *ci = Object::cast_to<CanvasItem>(p_what);
 	if (!ci) {
-		return nullptr;
+		return Variant();
 	}
 
-	return memnew(CanvasItemEditorSelectedItem);
+	return Variant(memnew(CanvasItemEditorSelectedItem));
 }
 
 void CanvasItemEditor::_keying_changed() {

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -407,7 +407,7 @@ private:
 	void _expand_encompassing_rect_using_children(Rect2 &r_rect, const Node *p_node, bool &r_first, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D(), bool include_locked_nodes = true);
 	Rect2 _get_encompassing_rect(const Node *p_node);
 
-	Object *_get_editor_data(Object *p_what);
+	Variant _get_editor_data(Object *p_what);
 
 	void _insert_animation_keys(bool p_location, bool p_rotation, bool p_scale, bool p_on_existing);
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -5636,10 +5636,10 @@ void Node3DEditor::update_all_gizmos(Node *p_node) {
 	_update_all_gizmos(p_node);
 }
 
-Object *Node3DEditor::_get_editor_data(Object *p_what) {
+Variant Node3DEditor::_get_editor_data(Object *p_what) {
 	Node3D *sp = Object::cast_to<Node3D>(p_what);
 	if (!sp) {
-		return nullptr;
+		return Variant();
 	}
 
 	Node3DEditorSelectedItem *si = memnew(Node3DEditorSelectedItem);
@@ -5686,7 +5686,7 @@ Object *Node3DEditor::_get_editor_data(Object *p_what) {
 	RS::get_singleton()->instance_geometry_set_flag(si->sbox_instance_xray_offset, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
 	RS::get_singleton()->instance_geometry_set_flag(si->sbox_instance_xray_offset, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 
-	return si;
+	return Variant(si);
 }
 
 void Node3DEditor::_generate_selection_boxes() {

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -711,7 +711,7 @@ private:
 
 	Node *custom_camera = nullptr;
 
-	Object *_get_editor_data(Object *p_what);
+	Variant _get_editor_data(Object *p_what);
 
 	Ref<Environment> viewport_environment;
 

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -397,6 +397,10 @@ Object *CollisionObject2D::shape_owner_get_owner(uint32_t p_owner) const {
 	return ObjectDB::get_instance(shapes[p_owner].owner_id);
 }
 
+Variant CollisionObject2D::_shape_owner_get_owner_bind(uint32_t p_owner) const {
+	return Variant(shape_owner_get_owner(p_owner));
+}
+
 void CollisionObject2D::shape_owner_add_shape(uint32_t p_owner, const Ref<Shape2D> &p_shape) {
 	ERR_FAIL_COND(!shapes.has(p_owner));
 	ERR_FAIL_COND(p_shape.is_null());
@@ -596,7 +600,7 @@ void CollisionObject2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_shape_owners"), &CollisionObject2D::_get_shape_owners);
 	ClassDB::bind_method(D_METHOD("shape_owner_set_transform", "owner_id", "transform"), &CollisionObject2D::shape_owner_set_transform);
 	ClassDB::bind_method(D_METHOD("shape_owner_get_transform", "owner_id"), &CollisionObject2D::shape_owner_get_transform);
-	ClassDB::bind_method(D_METHOD("shape_owner_get_owner", "owner_id"), &CollisionObject2D::shape_owner_get_owner);
+	ClassDB::bind_method(D_METHOD("shape_owner_get_owner", "owner_id"), &CollisionObject2D::_shape_owner_get_owner_bind);
 	ClassDB::bind_method(D_METHOD("shape_owner_set_disabled", "owner_id", "disabled"), &CollisionObject2D::shape_owner_set_disabled);
 	ClassDB::bind_method(D_METHOD("is_shape_owner_disabled", "owner_id"), &CollisionObject2D::is_shape_owner_disabled);
 	ClassDB::bind_method(D_METHOD("shape_owner_set_one_way_collision", "owner_id", "enable"), &CollisionObject2D::shape_owner_set_one_way_collision);

--- a/scene/2d/collision_object_2d.h
+++ b/scene/2d/collision_object_2d.h
@@ -82,6 +82,8 @@ private:
 	void _apply_disabled();
 	void _apply_enabled();
 
+	Variant _shape_owner_get_owner_bind(uint32_t p_owner) const;
+
 protected:
 	CollisionObject2D(RID p_rid, bool p_area);
 

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1836,12 +1836,20 @@ Object *KinematicCollision2D::get_local_shape() const {
 	return owner->shape_owner_get_owner(ownerid);
 }
 
+Variant KinematicCollision2D::_get_local_shape_bind() const {
+	return Variant(get_local_shape());
+}
+
 Object *KinematicCollision2D::get_collider() const {
 	if (result.collider_id.is_valid()) {
 		return ObjectDB::get_instance(result.collider_id);
 	}
 
 	return nullptr;
+}
+
+Variant KinematicCollision2D::_get_collider_bind() const {
+	return Variant(get_collider());
 }
 
 ObjectID KinematicCollision2D::get_collider_id() const {
@@ -1865,6 +1873,10 @@ Object *KinematicCollision2D::get_collider_shape() const {
 	return nullptr;
 }
 
+Variant KinematicCollision2D::_get_collider_shape_bind() const {
+	return Variant(get_collider_shape());
+}
+
 int KinematicCollision2D::get_collider_shape_index() const {
 	return result.collider_shape;
 }
@@ -1880,11 +1892,11 @@ void KinematicCollision2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_remainder"), &KinematicCollision2D::get_remainder);
 	ClassDB::bind_method(D_METHOD("get_angle", "up_direction"), &KinematicCollision2D::get_angle, DEFVAL(Vector2(0.0, -1.0)));
 	ClassDB::bind_method(D_METHOD("get_depth"), &KinematicCollision2D::get_depth);
-	ClassDB::bind_method(D_METHOD("get_local_shape"), &KinematicCollision2D::get_local_shape);
-	ClassDB::bind_method(D_METHOD("get_collider"), &KinematicCollision2D::get_collider);
+	ClassDB::bind_method(D_METHOD("get_local_shape"), &KinematicCollision2D::_get_local_shape_bind);
+	ClassDB::bind_method(D_METHOD("get_collider"), &KinematicCollision2D::_get_collider_bind);
 	ClassDB::bind_method(D_METHOD("get_collider_id"), &KinematicCollision2D::get_collider_id);
 	ClassDB::bind_method(D_METHOD("get_collider_rid"), &KinematicCollision2D::get_collider_rid);
-	ClassDB::bind_method(D_METHOD("get_collider_shape"), &KinematicCollision2D::get_collider_shape);
+	ClassDB::bind_method(D_METHOD("get_collider_shape"), &KinematicCollision2D::_get_collider_shape_bind);
 	ClassDB::bind_method(D_METHOD("get_collider_shape_index"), &KinematicCollision2D::get_collider_shape_index);
 	ClassDB::bind_method(D_METHOD("get_collider_velocity"), &KinematicCollision2D::get_collider_velocity);
 }

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -465,6 +465,10 @@ class KinematicCollision2D : public RefCounted {
 	friend class CharacterBody2D;
 	PhysicsServer2D::MotionResult result;
 
+	Variant _get_local_shape_bind() const;
+	Variant _get_collider_bind() const;
+	Variant _get_collider_shape_bind() const;
+
 protected:
 	static void _bind_methods();
 

--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -82,6 +82,10 @@ Object *RayCast2D::get_collider() const {
 	return ObjectDB::get_instance(against);
 }
 
+Variant RayCast2D::_get_collider_bind() const {
+	return Variant(get_collider());
+}
+
 RID RayCast2D::get_collider_rid() const {
 	return against_rid;
 }
@@ -326,7 +330,7 @@ void RayCast2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_colliding"), &RayCast2D::is_colliding);
 	ClassDB::bind_method(D_METHOD("force_raycast_update"), &RayCast2D::force_raycast_update);
 
-	ClassDB::bind_method(D_METHOD("get_collider"), &RayCast2D::get_collider);
+	ClassDB::bind_method(D_METHOD("get_collider"), &RayCast2D::_get_collider_bind);
 	ClassDB::bind_method(D_METHOD("get_collider_rid"), &RayCast2D::get_collider_rid);
 	ClassDB::bind_method(D_METHOD("get_collider_shape"), &RayCast2D::get_collider_shape);
 	ClassDB::bind_method(D_METHOD("get_collision_point"), &RayCast2D::get_collision_point);

--- a/scene/2d/ray_cast_2d.h
+++ b/scene/2d/ray_cast_2d.h
@@ -58,6 +58,8 @@ class RayCast2D : public Node2D {
 
 	void _draw_debug_shape();
 
+	Variant _get_collider_bind() const;
+
 protected:
 	void _notification(int p_what);
 	void _update_raycast_state();

--- a/scene/2d/shape_cast_2d.cpp
+++ b/scene/2d/shape_cast_2d.cpp
@@ -107,6 +107,10 @@ Object *ShapeCast2D::get_collider(int p_idx) const {
 	return ObjectDB::get_instance(result[p_idx].collider_id);
 }
 
+Variant ShapeCast2D::_get_collider_bind(int p_idx) const {
+	return Variant(get_collider(p_idx));
+}
+
 RID ShapeCast2D::get_collider_rid(int p_idx) const {
 	ERR_FAIL_INDEX_V_MSG(p_idx, result.size(), RID(), "No collider RID found.");
 	return result[p_idx].rid;
@@ -426,7 +430,7 @@ void ShapeCast2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("force_shapecast_update"), &ShapeCast2D::force_shapecast_update);
 
-	ClassDB::bind_method(D_METHOD("get_collider", "index"), &ShapeCast2D::get_collider);
+	ClassDB::bind_method(D_METHOD("get_collider", "index"), &ShapeCast2D::_get_collider_bind);
 	ClassDB::bind_method(D_METHOD("get_collider_rid", "index"), &ShapeCast2D::get_collider_rid);
 	ClassDB::bind_method(D_METHOD("get_collider_shape", "index"), &ShapeCast2D::get_collider_shape);
 	ClassDB::bind_method(D_METHOD("get_collision_point", "index"), &ShapeCast2D::get_collision_point);

--- a/scene/2d/shape_cast_2d.h
+++ b/scene/2d/shape_cast_2d.h
@@ -63,6 +63,8 @@ class ShapeCast2D : public Node2D {
 	Array _get_collision_result() const;
 	void _redraw_shape();
 
+	Variant _get_collider_bind(int p_idx) const;
+
 protected:
 	void _notification(int p_what);
 	void _update_shapecast_state();

--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -458,7 +458,7 @@ void CollisionObject3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_shape_owners"), &CollisionObject3D::_get_shape_owners);
 	ClassDB::bind_method(D_METHOD("shape_owner_set_transform", "owner_id", "transform"), &CollisionObject3D::shape_owner_set_transform);
 	ClassDB::bind_method(D_METHOD("shape_owner_get_transform", "owner_id"), &CollisionObject3D::shape_owner_get_transform);
-	ClassDB::bind_method(D_METHOD("shape_owner_get_owner", "owner_id"), &CollisionObject3D::shape_owner_get_owner);
+	ClassDB::bind_method(D_METHOD("shape_owner_get_owner", "owner_id"), &CollisionObject3D::_shape_owner_get_owner_bind);
 	ClassDB::bind_method(D_METHOD("shape_owner_set_disabled", "owner_id", "disabled"), &CollisionObject3D::shape_owner_set_disabled);
 	ClassDB::bind_method(D_METHOD("is_shape_owner_disabled", "owner_id"), &CollisionObject3D::is_shape_owner_disabled);
 	ClassDB::bind_method(D_METHOD("shape_owner_add_shape", "owner_id", "shape"), &CollisionObject3D::shape_owner_add_shape);
@@ -583,6 +583,10 @@ Object *CollisionObject3D::shape_owner_get_owner(uint32_t p_owner) const {
 	ERR_FAIL_COND_V(!shapes.has(p_owner), nullptr);
 
 	return ObjectDB::get_instance(shapes[p_owner].owner_id);
+}
+
+Variant CollisionObject3D::_shape_owner_get_owner_bind(uint32_t p_owner) const {
+	return Variant(shape_owner_get_owner(p_owner));
 }
 
 void CollisionObject3D::shape_owner_add_shape(uint32_t p_owner, const Ref<Shape3D> &p_shape) {

--- a/scene/3d/collision_object_3d.h
+++ b/scene/3d/collision_object_3d.h
@@ -94,6 +94,8 @@ private:
 	void _apply_disabled();
 	void _apply_enabled();
 
+	Variant _shape_owner_get_owner_bind(uint32_t p_owner) const;
+
 protected:
 	CollisionObject3D(RID p_rid, bool p_area);
 

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -2083,6 +2083,10 @@ Object *KinematicCollision3D::get_local_shape(int p_collision_index) const {
 	return owner->shape_owner_get_owner(ownerid);
 }
 
+Variant KinematicCollision3D::_get_local_shape_bind(int p_collision_index) const {
+	return Variant(get_local_shape(p_collision_index));
+}
+
 Object *KinematicCollision3D::get_collider(int p_collision_index) const {
 	ERR_FAIL_INDEX_V(p_collision_index, result.collision_count, nullptr);
 	if (result.collisions[p_collision_index].collider_id.is_valid()) {
@@ -2090,6 +2094,10 @@ Object *KinematicCollision3D::get_collider(int p_collision_index) const {
 	}
 
 	return nullptr;
+}
+
+Variant KinematicCollision3D::_get_collider_bind(int p_collision_index) const {
+	return Variant(get_collider(p_collision_index));
 }
 
 ObjectID KinematicCollision3D::get_collider_id(int p_collision_index) const {
@@ -2115,6 +2123,10 @@ Object *KinematicCollision3D::get_collider_shape(int p_collision_index) const {
 	return nullptr;
 }
 
+Variant KinematicCollision3D::_get_collider_shape_bind(int p_collision_index) const {
+	return Variant(get_collider_shape(p_collision_index));
+}
+
 int KinematicCollision3D::get_collider_shape_index(int p_collision_index) const {
 	ERR_FAIL_INDEX_V(p_collision_index, result.collision_count, 0);
 	return result.collisions[p_collision_index].collider_shape;
@@ -2133,11 +2145,11 @@ void KinematicCollision3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_position", "collision_index"), &KinematicCollision3D::get_position, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_normal", "collision_index"), &KinematicCollision3D::get_normal, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_angle", "collision_index", "up_direction"), &KinematicCollision3D::get_angle, DEFVAL(0), DEFVAL(Vector3(0.0, 1.0, 0.0)));
-	ClassDB::bind_method(D_METHOD("get_local_shape", "collision_index"), &KinematicCollision3D::get_local_shape, DEFVAL(0));
-	ClassDB::bind_method(D_METHOD("get_collider", "collision_index"), &KinematicCollision3D::get_collider, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_local_shape", "collision_index"), &KinematicCollision3D::_get_local_shape_bind, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_collider", "collision_index"), &KinematicCollision3D::_get_collider_bind, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_collider_id", "collision_index"), &KinematicCollision3D::get_collider_id, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_collider_rid", "collision_index"), &KinematicCollision3D::get_collider_rid, DEFVAL(0));
-	ClassDB::bind_method(D_METHOD("get_collider_shape", "collision_index"), &KinematicCollision3D::get_collider_shape, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_collider_shape", "collision_index"), &KinematicCollision3D::_get_collider_shape_bind, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_collider_shape_index", "collision_index"), &KinematicCollision3D::get_collider_shape_index, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_collider_velocity", "collision_index"), &KinematicCollision3D::get_collider_velocity, DEFVAL(0));
 }

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -498,6 +498,10 @@ class KinematicCollision3D : public RefCounted {
 	friend class CharacterBody3D;
 	PhysicsServer3D::MotionResult result;
 
+	Variant _get_local_shape_bind(int p_collision_index) const;
+	Variant _get_collider_bind(int p_collision_index) const;
+	Variant _get_collider_shape_bind(int p_collision_index) const;
+
 protected:
 	static void _bind_methods();
 

--- a/scene/3d/ray_cast_3d.cpp
+++ b/scene/3d/ray_cast_3d.cpp
@@ -88,6 +88,10 @@ Object *RayCast3D::get_collider() const {
 	return ObjectDB::get_instance(against);
 }
 
+Variant RayCast3D::_get_collider_bind() const {
+	return Variant(get_collider());
+}
+
 RID RayCast3D::get_collider_rid() const {
 	return against_rid;
 }
@@ -307,7 +311,7 @@ void RayCast3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_colliding"), &RayCast3D::is_colliding);
 	ClassDB::bind_method(D_METHOD("force_raycast_update"), &RayCast3D::force_raycast_update);
 
-	ClassDB::bind_method(D_METHOD("get_collider"), &RayCast3D::get_collider);
+	ClassDB::bind_method(D_METHOD("get_collider"), &RayCast3D::_get_collider_bind);
 	ClassDB::bind_method(D_METHOD("get_collider_rid"), &RayCast3D::get_collider_rid);
 	ClassDB::bind_method(D_METHOD("get_collider_shape"), &RayCast3D::get_collider_shape);
 	ClassDB::bind_method(D_METHOD("get_collision_point"), &RayCast3D::get_collision_point);

--- a/scene/3d/ray_cast_3d.h
+++ b/scene/3d/ray_cast_3d.h
@@ -70,6 +70,8 @@ class RayCast3D : public Node3D {
 
 	bool hit_from_inside = false;
 
+	Variant _get_collider_bind() const;
+
 protected:
 	void _notification(int p_what);
 	void _update_raycast_state();

--- a/scene/3d/shape_cast_3d.cpp
+++ b/scene/3d/shape_cast_3d.cpp
@@ -114,7 +114,7 @@ void ShapeCast3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("force_shapecast_update"), &ShapeCast3D::force_shapecast_update);
 
-	ClassDB::bind_method(D_METHOD("get_collider", "index"), &ShapeCast3D::get_collider);
+	ClassDB::bind_method(D_METHOD("get_collider", "index"), &ShapeCast3D::_get_collider_bind);
 	ClassDB::bind_method(D_METHOD("get_collider_rid", "index"), &ShapeCast3D::get_collider_rid);
 	ClassDB::bind_method(D_METHOD("get_collider_shape", "index"), &ShapeCast3D::get_collider_shape);
 	ClassDB::bind_method(D_METHOD("get_collision_point", "index"), &ShapeCast3D::get_collision_point);
@@ -281,6 +281,10 @@ Object *ShapeCast3D::get_collider(int p_idx) const {
 		return nullptr;
 	}
 	return ObjectDB::get_instance(result[p_idx].collider_id);
+}
+
+Variant ShapeCast3D::_get_collider_bind(int p_idx) const {
+	return Variant(get_collider(p_idx));
 }
 
 RID ShapeCast3D::get_collider_rid(int p_idx) const {

--- a/scene/3d/shape_cast_3d.h
+++ b/scene/3d/shape_cast_3d.h
@@ -74,6 +74,8 @@ class ShapeCast3D : public Node3D {
 
 	~ShapeCast3D();
 
+	Variant _get_collider_bind(int p_idx) const;
+
 protected:
 	void _notification(int p_what);
 	void _update_shapecast_state();


### PR DESCRIPTION
A brave person should also add checks for the arguments.

Fixes #70311. (And maybe others?

CC @briansemrau

**NOTE:** This is a draft until tomorrow, when I'll mend the remaining cases, but this is enough for a review.