### PR TITLE
Add "dedicated server" export mode which can strip unneeded visual resources

### DIFF
--- a/doc/classes/Cubemap.xml
+++ b/doc/classes/Cubemap.xml
@@ -11,4 +11,12 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="create_placeholder" qualifiers="const">
+			<return type="Resource" />
+			<description>
+				Creates a placeholder version of this resource ([PlaceholderCubemap]).
+			</description>
+		</method>
+	</methods>
 </class>

--- a/doc/classes/CubemapArray.xml
+++ b/doc/classes/CubemapArray.xml
@@ -12,4 +12,12 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="create_placeholder" qualifiers="const">
+			<return type="Resource" />
+			<description>
+				Creates a placeholder version of this resource ([PlaceholderCubemapArray]).
+			</description>
+		</method>
+	</methods>
 </class>

--- a/doc/classes/Material.xml
+++ b/doc/classes/Material.xml
@@ -31,6 +31,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="create_placeholder" qualifiers="const">
+			<return type="Resource" />
+			<description>
+				Creates a placeholder version of this resource ([PlaceholderMaterial]).
+			</description>
+		</method>
 		<method name="inspect_native_shader_code">
 			<return type="void" />
 			<description>

--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -114,6 +114,12 @@
 				[b]Note:[/b] This method typically returns the vertices in reverse order (e.g. clockwise to counterclockwise).
 			</description>
 		</method>
+		<method name="create_placeholder" qualifiers="const">
+			<return type="Resource" />
+			<description>
+				Creates a placeholder version of this resource ([PlaceholderMesh]).
+			</description>
+		</method>
 		<method name="create_trimesh_shape" qualifiers="const">
 			<return type="ConcavePolygonShape3D" />
 			<description>

--- a/doc/classes/Texture2D.xml
+++ b/doc/classes/Texture2D.xml
@@ -74,6 +74,12 @@
 				Called when a pixel's opaque state in the [Texture2D] is queried at the specified [code](x, y)[/code] position.
 			</description>
 		</method>
+		<method name="create_placeholder" qualifiers="const">
+			<return type="Resource" />
+			<description>
+				Creates a placeholder version of this resource ([PlaceholderTexture2D]).
+			</description>
+		</method>
 		<method name="draw" qualifiers="const">
 			<return type="void" />
 			<param index="0" name="canvas_item" type="RID" />

--- a/doc/classes/Texture2DArray.xml
+++ b/doc/classes/Texture2DArray.xml
@@ -10,4 +10,12 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="create_placeholder" qualifiers="const">
+			<return type="Resource" />
+			<description>
+				Creates a placeholder version of this resource ([PlaceholderTexture2DArray]).
+			</description>
+		</method>
+	</methods>
 </class>

--- a/doc/classes/Texture3D.xml
+++ b/doc/classes/Texture3D.xml
@@ -47,6 +47,12 @@
 				Called when the presence of mipmaps in the [Texture3D] is queried.
 			</description>
 		</method>
+		<method name="create_placeholder" qualifiers="const">
+			<return type="Resource" />
+			<description>
+				Creates a placeholder version of this resource ([PlaceholderTexture3D]).
+			</description>
+		</method>
 		<method name="get_data" qualifiers="const">
 			<return type="Image[]" />
 			<description>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -124,6 +124,7 @@
 #include "editor/plugins/asset_library_editor_plugin.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
 #include "editor/plugins/debugger_editor_plugin.h"
+#include "editor/plugins/dedicated_server_export_plugin.h"
 #include "editor/plugins/editor_preview_plugins.h"
 #include "editor/plugins/editor_resource_conversion_plugin.h"
 #include "editor/plugins/gdextension_export_plugin.h"
@@ -7349,6 +7350,11 @@ EditorNode::EditorNode() {
 	gdextension_export_plugin.instantiate();
 
 	EditorExport::get_singleton()->add_export_plugin(gdextension_export_plugin);
+
+	Ref<DedicatedServerExportPlugin> dedicated_server_export_plugin;
+	dedicated_server_export_plugin.instantiate();
+
+	EditorExport::get_singleton()->add_export_plugin(dedicated_server_export_plugin);
 
 	Ref<PackedSceneEditorTranslationParserPlugin> packed_scene_translation_parser_plugin;
 	packed_scene_translation_parser_plugin.instantiate();

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -45,6 +45,7 @@ void EditorExport::_save() {
 		config->set_value(section, "name", preset->get_name());
 		config->set_value(section, "platform", preset->get_platform()->get_name());
 		config->set_value(section, "runnable", preset->is_runnable());
+		config->set_value(section, "dedicated_server", preset->is_dedicated_server());
 		config->set_value(section, "custom_features", preset->get_custom_features());
 
 		bool save_files = false;
@@ -64,6 +65,11 @@ void EditorExport::_save() {
 				config->set_value(section, "export_filter", "exclude");
 				save_files = true;
 			} break;
+			case EditorExportPreset::EXPORT_CUSTOMIZED: {
+				config->set_value(section, "export_filter", "customized");
+				config->set_value(section, "customized_files", preset->get_customized_files());
+				save_files = false;
+			};
 		}
 
 		if (save_files) {
@@ -208,6 +214,7 @@ void EditorExport::load_config() {
 
 		preset->set_name(config->get_value(section, "name"));
 		preset->set_runnable(config->get_value(section, "runnable"));
+		preset->set_dedicated_server(config->get_value(section, "dedicated_server", false));
 
 		if (config->has_section_key(section, "custom_features")) {
 			preset->set_custom_features(config->get_value(section, "custom_features"));
@@ -228,6 +235,10 @@ void EditorExport::load_config() {
 		} else if (export_filter == "exclude") {
 			preset->set_export_filter(EditorExportPreset::EXCLUDE_SELECTED_RESOURCES);
 			get_files = true;
+		} else if (export_filter == "customized") {
+			preset->set_export_filter(EditorExportPreset::EXPORT_CUSTOMIZED);
+			preset->set_customized_files(config->get_value(section, "customized_files", Dictionary()));
+			get_files = false;
 		}
 
 		if (get_files) {

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -90,6 +90,7 @@ private:
 	Vector<ExportMessage> messages;
 
 	void _export_find_resources(EditorFileSystemDirectory *p_dir, HashSet<String> &p_paths);
+	void _export_find_customized_resources(const Ref<EditorExportPreset> &p_preset, EditorFileSystemDirectory *p_dir, EditorExportPreset::FileExportMode p_mode, HashSet<String> &p_paths);
 	void _export_find_dependencies(const String &p_path, HashSet<String> &p_paths);
 
 	void gen_debug_flags(Vector<String> &r_flags, int p_flags);
@@ -112,6 +113,7 @@ private:
 	bool _export_customize_array(Array &array, LocalVector<Ref<EditorExportPlugin>> &customize_resources_plugins);
 	bool _export_customize_object(Object *p_object, LocalVector<Ref<EditorExportPlugin>> &customize_resources_plugins);
 	bool _export_customize_scene_resources(Node *p_root, Node *p_node, LocalVector<Ref<EditorExportPlugin>> &customize_resources_plugins);
+	bool _is_editable_ancestor(Node *p_root, Node *p_node);
 
 	String _export_customize(const String &p_path, LocalVector<Ref<EditorExportPlugin>> &customize_resources_plugins, LocalVector<Ref<EditorExportPlugin>> &customize_scenes_plugins, HashMap<String, FileExportCache> &export_cache, const String &export_base_path, bool p_force_save);
 

--- a/editor/export/editor_export_plugin.cpp
+++ b/editor/export/editor_export_plugin.cpp
@@ -140,7 +140,7 @@ void EditorExportPlugin::_export_end_script() {
 
 // Customization
 
-bool EditorExportPlugin::_begin_customize_resources(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) const {
+bool EditorExportPlugin::_begin_customize_resources(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) {
 	bool ret = false;
 	GDVIRTUAL_CALL(_begin_customize_resources, p_platform, p_features, ret);
 	return ret;
@@ -152,7 +152,7 @@ Ref<Resource> EditorExportPlugin::_customize_resource(const Ref<Resource> &p_res
 	return ret;
 }
 
-bool EditorExportPlugin::_begin_customize_scenes(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) const {
+bool EditorExportPlugin::_begin_customize_scenes(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) {
 	bool ret = false;
 	GDVIRTUAL_CALL(_begin_customize_scenes, p_platform, p_features, ret);
 	return ret;
@@ -181,6 +181,12 @@ void EditorExportPlugin::_end_customize_resources() {
 String EditorExportPlugin::_get_name() const {
 	String ret;
 	GDVIRTUAL_REQUIRED_CALL(_get_name, ret);
+	return ret;
+}
+
+PackedStringArray EditorExportPlugin::_get_export_features(const Ref<EditorExportPlatform> &p_platform, bool p_debug) const {
+	PackedStringArray ret;
+	GDVIRTUAL_CALL(_get_export_features, p_platform, p_debug, ret);
 	return ret;
 }
 

--- a/editor/export/editor_export_plugin.h
+++ b/editor/export/editor_export_plugin.h
@@ -120,18 +120,22 @@ protected:
 	GDVIRTUAL0(_end_customize_scenes)
 	GDVIRTUAL0(_end_customize_resources)
 
+	GDVIRTUAL2RC(PackedStringArray, _get_export_features, const Ref<EditorExportPlatform> &, bool);
+
 	GDVIRTUAL0RC(String, _get_name)
 
-	bool _begin_customize_resources(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) const; // Return true if this plugin does property export customization
-	Ref<Resource> _customize_resource(const Ref<Resource> &p_resource, const String &p_path); // If nothing is returned, it means do not touch (nothing changed). If something is returned (either the same or a different resource) it means changes are made.
+	virtual bool _begin_customize_resources(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features); // Return true if this plugin does property export customization
+	virtual Ref<Resource> _customize_resource(const Ref<Resource> &p_resource, const String &p_path); // If nothing is returned, it means do not touch (nothing changed). If something is returned (either the same or a different resource) it means changes are made.
 
-	bool _begin_customize_scenes(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) const; // Return true if this plugin does property export customization
-	Node *_customize_scene(Node *p_root, const String &p_path); // Return true if a change was made
+	virtual bool _begin_customize_scenes(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features); // Return true if this plugin does property export customization
+	virtual Node *_customize_scene(Node *p_root, const String &p_path); // Return true if a change was made
 
-	uint64_t _get_customization_configuration_hash() const; // Hash used for caching customized resources and scenes.
+	virtual uint64_t _get_customization_configuration_hash() const; // Hash used for caching customized resources and scenes.
 
-	void _end_customize_scenes();
-	void _end_customize_resources();
+	virtual void _end_customize_scenes();
+	virtual void _end_customize_resources();
+
+	virtual PackedStringArray _get_export_features(const Ref<EditorExportPlatform> &p_export_platform, bool p_debug) const;
 
 	virtual String _get_name() const;
 

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -44,6 +44,14 @@ public:
 		EXPORT_SELECTED_SCENES,
 		EXPORT_SELECTED_RESOURCES,
 		EXCLUDE_SELECTED_RESOURCES,
+		EXPORT_CUSTOMIZED,
+	};
+
+	enum FileExportMode {
+		MODE_FILE_NOT_CUSTOMIZED,
+		MODE_FILE_STRIP,
+		MODE_FILE_KEEP,
+		MODE_FILE_REMOVE,
 	};
 
 	enum ScriptExportMode {
@@ -60,7 +68,9 @@ private:
 
 	String exporter;
 	HashSet<String> selected_files;
+	HashMap<String, FileExportMode> customized_files;
 	bool runnable = false;
+	bool dedicated_server = false;
 
 	friend class EditorExport;
 	friend class EditorExportPlatform;
@@ -91,19 +101,28 @@ public:
 
 	bool has(const StringName &p_property) const { return values.has(p_property); }
 
-	void update_files_to_export();
+	void update_files();
 
 	Vector<String> get_files_to_export() const;
+	Dictionary get_customized_files() const;
+	int get_customized_files_count() const;
+	void set_customized_files(const Dictionary &p_files);
 
 	void add_export_file(const String &p_path);
 	void remove_export_file(const String &p_path);
 	bool has_export_file(const String &p_path);
+
+	void set_file_export_mode(const String &p_path, FileExportMode p_mode);
+	FileExportMode get_file_export_mode(const String &p_path, FileExportMode p_default = MODE_FILE_NOT_CUSTOMIZED) const;
 
 	void set_name(const String &p_name);
 	String get_name() const;
 
 	void set_runnable(bool p_enable);
 	bool is_runnable() const;
+
+	void set_dedicated_server(bool p_enable);
+	bool is_dedicated_server() const;
 
 	void set_export_filter(ExportFilter p_filter);
 	ExportFilter get_export_filter() const;

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -31,11 +31,11 @@
 #ifndef PROJECT_EXPORT_H
 #define PROJECT_EXPORT_H
 
+#include "editor/export/editor_export_preset.h"
 #include "scene/gui/dialogs.h"
 
 class CheckBox;
 class CheckButton;
-class EditorExportPreset;
 class EditorFileDialog;
 class EditorFileSystemDirectory;
 class EditorInspector;
@@ -43,6 +43,7 @@ class EditorPropertyPath;
 class ItemList;
 class MenuButton;
 class OptionButton;
+class PopupMenu;
 class RichTextLabel;
 class TabContainer;
 class Tree;
@@ -75,6 +76,8 @@ private:
 	LineEdit *include_filters = nullptr;
 	LineEdit *exclude_filters = nullptr;
 	Tree *include_files = nullptr;
+	Label *server_strip_message = nullptr;
+	PopupMenu *file_mode_popup = nullptr;
 
 	Label *include_label = nullptr;
 	MarginContainer *include_margin = nullptr;
@@ -114,9 +117,12 @@ private:
 	void _export_type_changed(int p_which);
 	void _filter_changed(const String &p_filter);
 	void _fill_resource_tree();
-	bool _fill_tree(EditorFileSystemDirectory *p_dir, TreeItem *p_item, Ref<EditorExportPreset> &current, bool p_only_scenes);
+	void _setup_item_for_file_mode(TreeItem *p_item, EditorExportPreset::FileExportMode p_mode);
+	bool _fill_tree(EditorFileSystemDirectory *p_dir, TreeItem *p_item, Ref<EditorExportPreset> &current, EditorExportPreset::ExportFilter p_export_filter);
 	void _tree_changed();
 	void _check_propagated_to_item(Object *p_obj, int column);
+	void _tree_popup_edited(bool p_arrow_clicked);
+	void _set_file_export_mode(int p_id);
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;

--- a/editor/plugins/dedicated_server_export_plugin.cpp
+++ b/editor/plugins/dedicated_server_export_plugin.cpp
@@ -1,0 +1,139 @@
+/**************************************************************************/
+/*  dedicated_server_export_plugin.cpp                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "dedicated_server_export_plugin.h"
+
+EditorExportPreset::FileExportMode DedicatedServerExportPlugin::_get_export_mode_for_path(const String &p_path) {
+	Ref<EditorExportPreset> preset = get_export_preset();
+	ERR_FAIL_COND_V(preset.is_null(), EditorExportPreset::MODE_FILE_NOT_CUSTOMIZED);
+
+	EditorExportPreset::FileExportMode mode = preset->get_file_export_mode(p_path);
+	if (mode != EditorExportPreset::MODE_FILE_NOT_CUSTOMIZED) {
+		return mode;
+	}
+
+	String path = p_path;
+	if (path.begins_with("res://")) {
+		path = path.substr(6);
+	}
+
+	Vector<String> parts = path.split("/");
+
+	while (parts.size() > 0) {
+		parts.resize(parts.size() - 1);
+
+		String test_path = "res://";
+		if (parts.size() > 0) {
+			test_path += String("/").join(parts) + "/";
+		}
+
+		mode = preset->get_file_export_mode(test_path);
+		if (mode != EditorExportPreset::MODE_FILE_NOT_CUSTOMIZED) {
+			break;
+		}
+	}
+
+	return mode;
+}
+
+PackedStringArray DedicatedServerExportPlugin::_get_export_features(const Ref<EditorExportPlatform> &p_platform, bool p_debug) const {
+	PackedStringArray ret;
+
+	Ref<EditorExportPreset> preset = get_export_preset();
+	ERR_FAIL_COND_V(preset.is_null(), ret);
+
+	if (preset->is_dedicated_server()) {
+		ret.append("dedicated_server");
+	}
+	return ret;
+}
+
+uint64_t DedicatedServerExportPlugin::_get_customization_configuration_hash() const {
+	Ref<EditorExportPreset> preset = get_export_preset();
+	ERR_FAIL_COND_V(preset.is_null(), 0);
+
+	if (preset->get_export_filter() != EditorExportPreset::EXPORT_CUSTOMIZED) {
+		return 0;
+	}
+
+	return preset->get_customized_files().hash();
+}
+
+bool DedicatedServerExportPlugin::_begin_customize_scenes(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) {
+	Ref<EditorExportPreset> preset = get_export_preset();
+	ERR_FAIL_COND_V(preset.is_null(), false);
+
+	current_export_mode = EditorExportPreset::MODE_FILE_NOT_CUSTOMIZED;
+
+	return preset->get_export_filter() == EditorExportPreset::EXPORT_CUSTOMIZED;
+}
+
+bool DedicatedServerExportPlugin::_begin_customize_resources(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) {
+	Ref<EditorExportPreset> preset = get_export_preset();
+	ERR_FAIL_COND_V(preset.is_null(), false);
+
+	current_export_mode = EditorExportPreset::MODE_FILE_NOT_CUSTOMIZED;
+
+	return preset->get_export_filter() == EditorExportPreset::EXPORT_CUSTOMIZED;
+}
+
+Node *DedicatedServerExportPlugin::_customize_scene(Node *p_root, const String &p_path) {
+	// Simply set the export mode based on the scene path. All the real
+	// customization happens in _customize_resource().
+	current_export_mode = _get_export_mode_for_path(p_path);
+	return nullptr;
+}
+
+Ref<Resource> DedicatedServerExportPlugin::_customize_resource(const Ref<Resource> &p_resource, const String &p_path) {
+	// If the resource has a path, we use that to get our export mode. But if it
+	// doesn't, we assume that this resource is embedded in the last resource with
+	// a path.
+	if (p_path != "") {
+		current_export_mode = _get_export_mode_for_path(p_path);
+	}
+
+	if (p_resource.is_valid() && current_export_mode == EditorExportPreset::MODE_FILE_STRIP && p_resource->has_method("create_placeholder")) {
+		Callable::CallError err;
+		Ref<Resource> result = const_cast<Resource *>(p_resource.ptr())->callp("create_placeholder", nullptr, 0, err);
+		if (err.error == Callable::CallError::CALL_OK) {
+			return result;
+		}
+	}
+
+	return Ref<Resource>();
+}
+
+void DedicatedServerExportPlugin::_end_customize_scenes() {
+	current_export_mode = EditorExportPreset::MODE_FILE_NOT_CUSTOMIZED;
+}
+
+void DedicatedServerExportPlugin::_end_customize_resources() {
+	current_export_mode = EditorExportPreset::MODE_FILE_NOT_CUSTOMIZED;
+}

--- a/editor/plugins/dedicated_server_export_plugin.h
+++ b/editor/plugins/dedicated_server_export_plugin.h
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/*  dedicated_server_export_plugin.h                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DEDICATED_SERVER_EXPORT_PLUGIN_H
+#define DEDICATED_SERVER_EXPORT_PLUGIN_H
+
+#include "editor/export/editor_export.h"
+
+class DedicatedServerExportPlugin : public EditorExportPlugin {
+private:
+	EditorExportPreset::FileExportMode current_export_mode;
+
+	EditorExportPreset::FileExportMode _get_export_mode_for_path(const String &p_path);
+
+protected:
+	String _get_name() const override { return "DedicatedServer"; }
+
+	PackedStringArray _get_export_features(const Ref<EditorExportPlatform> &p_platform, bool p_debug) const override;
+	uint64_t _get_customization_configuration_hash() const override;
+
+	bool _begin_customize_scenes(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) override;
+	bool _begin_customize_resources(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) override;
+
+	Node *_customize_scene(Node *p_root, const String &p_path) override;
+	Ref<Resource> _customize_resource(const Ref<Resource> &p_resource, const String &p_path) override;
+
+	void _end_customize_scenes() override;
+	void _end_customize_resources() override;
+};
+
+#endif // DEDICATED_SERVER_EXPORT_PLUGIN_H

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -113,6 +113,12 @@ bool Material::_can_use_render_priority() const {
 	return ret;
 }
 
+Ref<Resource> Material::create_placeholder() const {
+	Ref<PlaceholderMaterial> placeholder;
+	placeholder.instantiate();
+	return placeholder;
+}
+
 void Material::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_next_pass", "next_pass"), &Material::set_next_pass);
 	ClassDB::bind_method(D_METHOD("get_next_pass"), &Material::get_next_pass);
@@ -122,6 +128,8 @@ void Material::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("inspect_native_shader_code"), &Material::inspect_native_shader_code);
 	ClassDB::set_method_flags(get_class_static(), _scs_create("inspect_native_shader_code"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
+
+	ClassDB::bind_method(D_METHOD("create_placeholder"), &Material::create_placeholder);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "render_priority", PROPERTY_HINT_RANGE, itos(RENDER_PRIORITY_MIN) + "," + itos(RENDER_PRIORITY_MAX) + ",1"), "set_render_priority", "get_render_priority");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "next_pass", PROPERTY_HINT_RESOURCE_TYPE, "Material"), "set_next_pass", "get_next_pass");

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -74,6 +74,9 @@ public:
 	virtual RID get_rid() const override;
 	virtual RID get_shader_rid() const;
 	virtual Shader::Mode get_shader_mode() const;
+
+	virtual Ref<Resource> create_placeholder() const;
+
 	Material();
 	virtual ~Material();
 };

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -614,6 +614,13 @@ Size2i Mesh::get_lightmap_size_hint() const {
 	return lightmap_size_hint;
 }
 
+Ref<Resource> Mesh::create_placeholder() const {
+	Ref<PlaceholderMesh> placeholder;
+	placeholder.instantiate();
+	placeholder->set_aabb(get_aabb());
+	return placeholder;
+}
+
 void Mesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_lightmap_size_hint", "size"), &Mesh::set_lightmap_size_hint);
 	ClassDB::bind_method(D_METHOD("get_lightmap_size_hint"), &Mesh::get_lightmap_size_hint);
@@ -626,6 +633,7 @@ void Mesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("surface_get_blend_shape_arrays", "surf_idx"), &Mesh::surface_get_blend_shape_arrays);
 	ClassDB::bind_method(D_METHOD("surface_set_material", "surf_idx", "material"), &Mesh::surface_set_material);
 	ClassDB::bind_method(D_METHOD("surface_get_material", "surf_idx"), &Mesh::surface_get_material);
+	ClassDB::bind_method(D_METHOD("create_placeholder"), &Mesh::create_placeholder);
 
 	BIND_ENUM_CONSTANT(PRIMITIVE_POINTS);
 	BIND_ENUM_CONSTANT(PRIMITIVE_LINES);

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -220,6 +220,8 @@ public:
 	virtual int get_builtin_bind_pose_count() const;
 	virtual Transform3D get_builtin_bind_pose(int p_index) const;
 
+	virtual Ref<Resource> create_placeholder() const;
+
 	Mesh();
 };
 

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -94,6 +94,13 @@ bool Texture2D::get_rect_region(const Rect2 &p_rect, const Rect2 &p_src_rect, Re
 	return true;
 }
 
+Ref<Resource> Texture2D::create_placeholder() const {
+	Ref<PlaceholderTexture2D> placeholder;
+	placeholder.instantiate();
+	placeholder->set_size(get_size());
+	return placeholder;
+}
+
 void Texture2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_width"), &Texture2D::get_width);
 	ClassDB::bind_method(D_METHOD("get_height"), &Texture2D::get_height);
@@ -103,6 +110,7 @@ void Texture2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("draw_rect", "canvas_item", "rect", "tile", "modulate", "transpose"), &Texture2D::draw_rect, DEFVAL(Color(1, 1, 1)), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("draw_rect_region", "canvas_item", "rect", "src_rect", "modulate", "transpose", "clip_uv"), &Texture2D::draw_rect_region, DEFVAL(Color(1, 1, 1)), DEFVAL(false), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("get_image"), &Texture2D::get_image);
+	ClassDB::bind_method(D_METHOD("create_placeholder"), &Texture2D::create_placeholder);
 
 	ADD_GROUP("", "");
 
@@ -1137,6 +1145,7 @@ void Texture3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_depth"), &Texture3D::get_depth);
 	ClassDB::bind_method(D_METHOD("has_mipmaps"), &Texture3D::has_mipmaps);
 	ClassDB::bind_method(D_METHOD("get_data"), &Texture3D::_get_datai);
+	ClassDB::bind_method(D_METHOD("create_placeholder"), &Texture3D::create_placeholder);
 
 	GDVIRTUAL_BIND(_get_format);
 	GDVIRTUAL_BIND(_get_width);
@@ -1145,6 +1154,14 @@ void Texture3D::_bind_methods() {
 	GDVIRTUAL_BIND(_has_mipmaps);
 	GDVIRTUAL_BIND(_get_data);
 }
+
+Ref<Resource> Texture3D::create_placeholder() const {
+	Ref<PlaceholderTexture3D> placeholder;
+	placeholder.instantiate();
+	placeholder->set_size(Vector3i(get_width(), get_height(), get_depth()));
+	return placeholder;
+}
+
 //////////////////////////////////////////
 
 Image::Format ImageTexture3D::get_format() const {
@@ -3046,6 +3063,42 @@ ImageTextureLayered::~ImageTextureLayered() {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RS::get_singleton()->free(texture);
 	}
+}
+
+void Texture2DArray::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("create_placeholder"), &Texture2DArray::create_placeholder);
+}
+
+Ref<Resource> Texture2DArray::create_placeholder() const {
+	Ref<PlaceholderTexture2DArray> placeholder;
+	placeholder.instantiate();
+	placeholder->set_size(Size2i(get_width(), get_height()));
+	placeholder->set_layers(get_layers());
+	return placeholder;
+}
+
+void Cubemap::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("create_placeholder"), &Cubemap::create_placeholder);
+}
+
+Ref<Resource> Cubemap::create_placeholder() const {
+	Ref<PlaceholderCubemap> placeholder;
+	placeholder.instantiate();
+	placeholder->set_size(Size2i(get_width(), get_height()));
+	placeholder->set_layers(get_layers());
+	return placeholder;
+}
+
+void CubemapArray::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("create_placeholder"), &CubemapArray::create_placeholder);
+}
+
+Ref<Resource> CubemapArray::create_placeholder() const {
+	Ref<PlaceholderCubemapArray> placeholder;
+	placeholder.instantiate();
+	placeholder->set_size(Size2i(get_width(), get_height()));
+	placeholder->set_layers(get_layers());
+	return placeholder;
 }
 
 ///////////////////////////////////////////

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -82,6 +82,8 @@ public:
 
 	virtual Ref<Image> get_image() const { return Ref<Image>(); }
 
+	virtual Ref<Resource> create_placeholder() const;
+
 	Texture2D();
 };
 
@@ -450,25 +452,41 @@ public:
 
 class Texture2DArray : public ImageTextureLayered {
 	GDCLASS(Texture2DArray, ImageTextureLayered)
+
+protected:
+	static void _bind_methods();
+
 public:
 	Texture2DArray() :
 			ImageTextureLayered(LAYERED_TYPE_2D_ARRAY) {}
+
+	virtual Ref<Resource> create_placeholder() const;
 };
 
 class Cubemap : public ImageTextureLayered {
 	GDCLASS(Cubemap, ImageTextureLayered);
 
+protected:
+	static void _bind_methods();
+
 public:
 	Cubemap() :
 			ImageTextureLayered(LAYERED_TYPE_CUBEMAP) {}
+
+	virtual Ref<Resource> create_placeholder() const;
 };
 
 class CubemapArray : public ImageTextureLayered {
 	GDCLASS(CubemapArray, ImageTextureLayered);
 
+protected:
+	static void _bind_methods();
+
 public:
 	CubemapArray() :
 			ImageTextureLayered(LAYERED_TYPE_CUBEMAP_ARRAY) {}
+
+	virtual Ref<Resource> create_placeholder() const;
 };
 
 class CompressedTextureLayered : public TextureLayered {
@@ -580,6 +598,7 @@ public:
 	virtual int get_depth() const;
 	virtual bool has_mipmaps() const;
 	virtual Vector<Ref<Image>> get_data() const;
+	virtual Ref<Resource> create_placeholder() const;
 };
 
 class ImageTexture3D : public Texture3D {


### PR DESCRIPTION
This PR implements https://github.com/godotengine/godot-proposals/issues/5970 and supersedes #69546

Based on feedback from @Faless on the old PR, this PR is mostly contained within the export system.

It also includes two suggestions that @jordo gave on the old PR:

- The name of the headless video driver and dummy audio driver were moved into constants in main.cpp
- ~~A virtual method `create_placeholder()` was added to `Resource` so that it's up to each resource to convert itself into a placeholder if it can. This will make it a little easier to add more placeholder classes going forward.~~ Per @reduz's request this isn't a virtual method on `Resource`, it's bound individually on each resource that can make a placeholder.

Here's a current screenshot of the UI:

![Selection_486](https://user-images.githubusercontent.com/191561/214120684-06174333-4df6-46a5-a673-19d3d9de004d.png)

Otherwise, see the proposal for information about how this feature is meant to work!

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/5970.*

---
🍀 **This work has been financed and kindly donated to the Godot Engine project by [W4 Games](https://w4games.com).** 🍀