### PR TITLE
Expose `OS.read_string_from_stdin()` to the scripting API (3.x)

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -520,6 +520,10 @@ Error _OS::shell_open(String p_uri) {
 	return OS::get_singleton()->shell_open(p_uri);
 };
 
+String _OS::read_string_from_stdin() {
+	return OS::get_singleton()->get_stdin_string();
+}
+
 int _OS::execute(const String &p_path, const Vector<String> &p_arguments, bool p_blocking, Array p_output, bool p_read_stderr, bool p_open_console) {
 	OS::ProcessID pid = -2;
 	int exitcode = 0;
@@ -1415,6 +1419,7 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_processor_name"), &_OS::get_processor_name);
 
 	ClassDB::bind_method(D_METHOD("get_executable_path"), &_OS::get_executable_path);
+	ClassDB::bind_method(D_METHOD("read_string_from_stdin"), &_OS::read_string_from_stdin);
 	ClassDB::bind_method(D_METHOD("execute", "path", "arguments", "blocking", "output", "read_stderr", "open_console"), &_OS::execute, DEFVAL(true), DEFVAL(Array()), DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("kill", "pid"), &_OS::kill);
 	ClassDB::bind_method(D_METHOD("shell_open", "uri"), &_OS::shell_open);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -264,6 +264,7 @@ public:
 	int get_low_processor_usage_mode_sleep_usec() const;
 
 	String get_executable_path() const;
+	String read_string_from_stdin();
 	int execute(const String &p_path, const Vector<String> &p_arguments, bool p_blocking = true, Array p_output = Array(), bool p_read_stderr = false, bool p_open_console = false);
 
 	Error kill(int p_pid);

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -185,7 +185,7 @@ public:
 	void printerr(const char *p_format, ...) _PRINTF_FORMAT_ATTRIBUTE_2_3;
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!") = 0;
-	virtual String get_stdin_string(bool p_block = true) = 0;
+	virtual String get_stdin_string() = 0;
 
 	enum MouseMode {
 		MOUSE_MODE_VISIBLE,

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -892,6 +892,13 @@
 				Shows all resources currently used by the game.
 			</description>
 		</method>
+		<method name="read_string_from_stdin">
+			<return type="String" />
+			<description>
+				Reads a user input string from the standard input (usually the terminal). This operation is [i]blocking[/i], which causes the window to freeze if [method read_string_from_stdin] is called on the main thread. The thread calling [method read_string_from_stdin] will block until the program receives a line break in standard input (usually by the user pressing [kbd]Enter[/kbd]).
+				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
+			</description>
+		</method>
 		<method name="request_attention">
 			<return type="void" />
 			<description>

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -136,15 +136,11 @@ void OS_Unix::alert(const String &p_alert, const String &p_title) {
 	fprintf(stderr, "ALERT: %s: %s\n", p_title.utf8().get_data(), p_alert.utf8().get_data());
 }
 
-String OS_Unix::get_stdin_string(bool p_block) {
-	if (p_block) {
-		char buff[1024];
-		String ret = stdin_buf + fgets(buff, 1024, stdin);
-		stdin_buf = "";
-		return ret;
-	}
-
-	return "";
+String OS_Unix::get_stdin_string() {
+	char buff[1024];
+	String ret = stdin_buf + fgets(buff, 1024, stdin);
+	stdin_buf = "";
+	return ret;
 }
 
 String OS_Unix::get_name() const {

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -53,7 +53,7 @@ public:
 	OS_Unix();
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
-	virtual String get_stdin_string(bool p_block);
+	virtual String get_stdin_string();
 
 	//virtual void set_mouse_show(bool p_show);
 	//virtual void set_mouse_grab(bool p_grab);

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -716,7 +716,7 @@ bool OS_UWP::set_environment(const String &p_var, const String &p_value) const {
 	return false;
 }
 
-String OS_UWP::get_stdin_string(bool p_block) {
+String OS_UWP::get_stdin_string() {
 	return String();
 }
 

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -167,7 +167,7 @@ public:
 	HANDLE mouse_mode_changed;
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
-	String get_stdin_string(bool p_block);
+	String get_stdin_string();
 
 	void set_mouse_mode(MouseMode p_mode);
 	MouseMode get_mouse_mode() const;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -3254,13 +3254,9 @@ bool OS_Windows::set_environment(const String &p_var, const String &p_value) con
 	return (bool)SetEnvironmentVariableW(p_var.c_str(), p_value.c_str());
 }
 
-String OS_Windows::get_stdin_string(bool p_block) {
-	if (p_block) {
-		char buff[1024];
-		return fgets(buff, 1024, stdin);
-	};
-
-	return String();
+String OS_Windows::get_stdin_string() {
+	char buff[1024];
+	return fgets(buff, 1024, stdin);
 }
 
 void OS_Windows::enable_for_stealing_focus(ProcessID pid) {

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -437,7 +437,7 @@ public:
 	LRESULT WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
-	String get_stdin_string(bool p_block);
+	String get_stdin_string();
 
 	void set_mouse_mode(MouseMode p_mode);
 	MouseMode get_mouse_mode() const;


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/65751. See https://github.com/godotengine/godot-proposals/issues/2322.

This can be used in scripts to read user input in a blocking manner.

This also removes the unused `block` argument, which is always `true`.

```gdscript
# Save this script as `example.gd`, then run:
#     godot -s my_script.gd
extends SceneTree

func _initialize():
	var text = ""
	while text != "quit":
		printraw("Insert some text: ")
		text = OS.read_string_from_stdin().strip_edges()
		print("You inserted: %s" % text)
	print("Quitting")
	call_deferred("quit")
```

___

Note that non-ASCII input doesn't appear to be handled correctly (tested on Linux):

```
Insert some text: 123 Hello × é
You inserted: 123 Hello
Insert some text: ééé×××x×
You inserted: x
```

In `master`, this occurs instead:

```
Insert some text: 123 Hello × é
You inserted: 123 Hello Ã Ã©
Insert some text: ééé×××x×
You inserted: Ã©Ã©Ã©ÃÃÃxÃ
```

Maybe @bruvzg knows about resolving this encoding issue?