### PR TITLE
Queue inspector tree update when changing the theme (reverted)

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3867,6 +3867,10 @@ void EditorInspector::_notification(int p_what) {
 			_update_inspector_bg();
 		} break;
 
+		case NOTIFICATION_THEME_CHANGED: {
+			update_tree();
+		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			if (!sub_inspector) {
 				get_tree()->connect("node_removed", callable_mp(this, &EditorInspector::_node_removed));


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/70356

A tree update needs to be queued in when changing the theme so the inspector is rebuild with the correct theme constants in the next frame.
