### PR TITLE
Add Human Readable Error Message for Object::set_meta

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -892,7 +892,7 @@ void Object::set_meta(const StringName &p_name, const Variant &p_value) {
 	if (E) {
 		E->value = p_value;
 	} else {
-		ERR_FAIL_COND(!p_name.operator String().is_valid_identifier());
+		ERR_FAIL_COND_MSG(!p_name.operator String().is_valid_identifier(), "Invalid metadata identifier: '" + p_name + "'.");
 		Variant *V = &metadata.insert(p_name, p_value)->value;
 		metadata_properties["metadata/" + p_name.operator String()] = V;
 		notify_property_list_changed();


### PR DESCRIPTION
Fixes: #70141 

Updates a call from a non-descriptive error macro to one that is easier to understand for the typical user.

_Bugsquad edit:_ [This PR](https://github.com/godotengine/godot/pull/76477) exists for the docs change