### PR TITLE
Fix reading Unicode from stdio.

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -152,12 +152,10 @@ Vector<String> OS_Unix::get_video_adapter_driver_info() const {
 String OS_Unix::get_stdin_string(bool p_block) {
 	if (p_block) {
 		char buff[1024];
-		String ret = stdin_buf + fgets(buff, 1024, stdin);
-		stdin_buf = "";
-		return ret;
+		return String::utf8(fgets(buff, 1024, stdin));
 	}
 
-	return "";
+	return String();
 }
 
 Error OS_Unix::get_entropy(uint8_t *r_buffer, int p_bytes) {

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -46,8 +46,6 @@ protected:
 
 	virtual void finalize_core() override;
 
-	String stdin_buf;
-
 public:
 	OS_Unix();
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1164,8 +1164,11 @@ bool OS_Windows::set_environment(const String &p_var, const String &p_value) con
 
 String OS_Windows::get_stdin_string(bool p_block) {
 	if (p_block) {
-		char buff[1024];
-		return fgets(buff, 1024, stdin);
+		WCHAR buff[1024];
+		DWORD count = 0;
+		if (ReadConsoleW(GetStdHandle(STD_INPUT_HANDLE), buff, 1024, &count, nullptr)) {
+			return String::utf16((const char16_t *)buff, count);
+		}
 	}
 
 	return String();


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/70378

- Adds UTF-8 decoding for Unix stdin reads.
- Adds UTF-16 decoding for Windows stdin reads and use Windows API to read in (CRT i/o is broken in some versions).