### PR TITLE
Fix Basis Universal format texture rendering failure

### DIFF
--- a/modules/basis_universal/register_types.cpp
+++ b/modules/basis_universal/register_types.cpp
@@ -277,6 +277,7 @@ void initialize_basis_universal_module(ModuleInitializationLevel p_level) {
 	basisu_encoder_init();
 	Image::basis_universal_packer = basis_universal_packer;
 #endif
+	basist::basisu_transcoder_init();
 	Image::basis_universal_unpacker = basis_universal_unpacker;
 	Image::basis_universal_unpacker_ptr = basis_universal_unpacker_ptr;
 }


### PR DESCRIPTION
Fix "failed! on level 0" error message on exported projects with Basis Universal textures.
This will fix the issue #67558 and #70341.
Tested in Windows 11 and Chrome for Windows.

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/67558
- Fixes https://github.com/godotengine/godot/issues/70341.