### PR TITLE
Fix closing project setting window with ESC while listening for input

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -35,6 +35,7 @@
 #include "editor/input_event_configuration_dialog.h"
 #include "scene/gui/check_button.h"
 #include "scene/gui/tree.h"
+#include "scene/scene_string_names.h"
 
 static bool _is_action_name_valid(const String &p_name) {
 	const char32_t *cstr = p_name.get_data();
@@ -362,6 +363,8 @@ void ActionMapEditor::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("action_removed", PropertyInfo(Variant::STRING, "name")));
 	ADD_SIGNAL(MethodInfo("action_renamed", PropertyInfo(Variant::STRING, "old_name"), PropertyInfo(Variant::STRING, "new_name")));
 	ADD_SIGNAL(MethodInfo("action_reordered", PropertyInfo(Variant::STRING, "action_name"), PropertyInfo(Variant::STRING, "relative_to"), PropertyInfo(Variant::BOOL, "before")));
+	ADD_SIGNAL(MethodInfo(SNAME("filter_focused")));
+	ADD_SIGNAL(MethodInfo(SNAME("filter_unfocused")));
 }
 
 LineEdit *ActionMapEditor::get_search_box() const {
@@ -492,6 +495,14 @@ void ActionMapEditor::use_external_search_box(LineEdit *p_searchbox) {
 	action_list_search->connect("text_changed", callable_mp(this, &ActionMapEditor::_search_term_updated));
 }
 
+void ActionMapEditor::_on_filter_focused() {
+	emit_signal(SNAME("filter_focused"));
+}
+
+void ActionMapEditor::_on_filter_unfocused() {
+	emit_signal(SNAME("filter_unfocused"));
+}
+
 ActionMapEditor::ActionMapEditor() {
 	// Main Vbox Container
 	VBoxContainer *main_vbox = memnew(VBoxContainer);
@@ -512,6 +523,8 @@ ActionMapEditor::ActionMapEditor() {
 	action_list_search_by_event->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	action_list_search_by_event->set_stretch_ratio(0.75);
 	action_list_search_by_event->connect("event_changed", callable_mp(this, &ActionMapEditor::_search_by_event));
+	action_list_search_by_event->connect(SceneStringNames::get_singleton()->focus_entered, callable_mp(this, &ActionMapEditor::_on_filter_focused));
+	action_list_search_by_event->connect(SceneStringNames::get_singleton()->focus_exited, callable_mp(this, &ActionMapEditor::_on_filter_unfocused));
 	top_hbox->add_child(action_list_search_by_event);
 
 	Button *clear_all_search = memnew(Button);

--- a/editor/action_map_editor.h
+++ b/editor/action_map_editor.h
@@ -106,6 +106,9 @@ private:
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 
+	void _on_filter_focused();
+	void _on_filter_unfocused();
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -553,6 +553,14 @@ void ProjectSettingsEditor::_update_theme() {
 	}
 }
 
+void ProjectSettingsEditor::_input_filter_focused() {
+	set_close_on_escape(false);
+}
+
+void ProjectSettingsEditor::_input_filter_unfocused() {
+	set_close_on_escape(true);
+}
+
 void ProjectSettingsEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -683,6 +691,8 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	action_map_editor->connect("action_removed", callable_mp(this, &ProjectSettingsEditor::_action_removed));
 	action_map_editor->connect("action_renamed", callable_mp(this, &ProjectSettingsEditor::_action_renamed));
 	action_map_editor->connect("action_reordered", callable_mp(this, &ProjectSettingsEditor::_action_reordered));
+	action_map_editor->connect(SNAME("filter_focused"), callable_mp(this, &ProjectSettingsEditor::_input_filter_focused));
+	action_map_editor->connect(SNAME("filter_unfocused"), callable_mp(this, &ProjectSettingsEditor::_input_filter_unfocused));
 	tab_container->add_child(action_map_editor);
 
 	localization_editor = memnew(LocalizationEditor);

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -107,6 +107,9 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _update_action_map_editor();
 	void _update_theme();
 
+	void _input_filter_focused();
+	void _input_filter_unfocused();
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();


### PR DESCRIPTION
This is done by disallowing ESC to be used for closing the window while the filter-LineEdit is focused.

resolve #70379