### PR TITLE
SCons: Fix `separate_debug_symbols` option for Windows/MinGW

### DIFF
--- a/platform/windows/platform_windows_builders.py
+++ b/platform/windows/platform_windows_builders.py
@@ -4,18 +4,15 @@ All such functions are invoked in a subprocess on Windows to prevent build flaki
 
 """
 import os
+from detect import get_mingw_bin_prefix
 from platform_methods import subprocess_main
 
 
 def make_debug_mingw(target, source, env):
-    mingw_prefix = ""
-    if env["arch"] == "x86_32":
-        mingw_prefix = env["mingw_prefix_32"]
-    else:
-        mingw_prefix = env["mingw_prefix_64"]
-    os.system(mingw_prefix + "objcopy --only-keep-debug {0} {0}.debugsymbols".format(target[0]))
-    os.system(mingw_prefix + "strip --strip-debug --strip-unneeded {0}".format(target[0]))
-    os.system(mingw_prefix + "objcopy --add-gnu-debuglink={0}.debugsymbols {0}".format(target[0]))
+    mingw_bin_prefix = get_mingw_bin_prefix(env["mingw_prefix"], env["arch"])
+    os.system(mingw_bin_prefix + "objcopy --only-keep-debug {0} {0}.debugsymbols".format(target[0]))
+    os.system(mingw_bin_prefix + "strip --strip-debug --strip-unneeded {0}".format(target[0]))
+    os.system(mingw_bin_prefix + "objcopy --add-gnu-debuglink={0}.debugsymbols {0}".format(target[0]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Example files for `target=editor dev_build=yes separate_debug_symbols=yes`:
```
$ ls -l
total 2389504
-rwxr-xr-x 1 akien akien  190570128 Dec 21 10:15 godot.linuxbsd.editor.dev.x86_64*
-rwxr-xr-x 1 akien akien  565707368 Dec 21 10:04 godot.linuxbsd.editor.dev.x86_64.debugsymbols*
-rwxr-xr-x 1 akien akien     190457 Dec 21 13:34 godot.windows.editor.dev.x86_64.console.exe*
-rwxr-xr-x 1 akien akien    1575697 Dec 21 13:34 godot.windows.editor.dev.x86_64.console.exe.debugsymbols*
-rwxr-xr-x 1 akien akien  151218540 Dec 21 13:42 godot.windows.editor.dev.x86_64.exe*
-rwxr-xr-x 1 akien akien 1537465339 Dec 21 13:42 godot.windows.editor.dev.x86_64.exe.debugsymbols*
```

Running the Windows build in Wine, it doesn't seem to be able to load the debugsymbols file. Would be good to test if it works properly on Windows.