### PR TITLE
Fix edge map capacity in convex hull computer

### DIFF
--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -2274,8 +2274,7 @@ Error ConvexHullComputer::convex_hull(const Vector<Vector3> &p_points, Geometry3
 
 	// Copy the edges over. There's two "half-edges" for every edge, so we pick only one of them.
 	r_mesh.edges.resize(ch.edges.size() / 2);
-	OAHashMap<uint64_t, int32_t> edge_map;
-	edge_map.reserve(ch.edges.size() * 4); // The higher the capacity, the faster the insert
+	OAHashMap<uint64_t, int32_t> edge_map(ch.edges.size() * 4); // The higher the capacity, the faster the insert
 
 	uint32_t edges_copied = 0;
 	for (uint32_t i = 0; i < ch.edges.size(); i++) {


### PR DESCRIPTION
The desired capacity could be less than the default, so `reserve` would error.

Fixes https://github.com/godotengine/godot/issues/70402
