### PR TITLE
Add fallback values for font and scale to the default theme

### DIFF
--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -100,6 +100,11 @@ static Ref<StyleBox> make_empty_stylebox(float p_margin_left = -1, float p_margi
 void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const Ref<Font> &bold_font, const Ref<Font> &bold_italics_font, const Ref<Font> &italics_font, Ref<Texture2D> &default_icon, Ref<StyleBox> &default_style, float p_scale) {
 	scale = p_scale;
 
+	// Default theme properties.
+	theme->set_default_font(default_font);
+	theme->set_default_font_size(default_font_size * scale);
+	theme->set_default_base_scale(scale);
+
 	// Font colors
 	const Color control_font_color = Color(0.875, 0.875, 0.875);
 	const Color control_font_low_color = Color(0.7, 0.7, 0.7);

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -70,7 +70,9 @@ void ThemeDB::initialize_theme() {
 	Ref<Font> font;
 	if (!font_path.is_empty()) {
 		font = ResourceLoader::load(font_path);
-		if (!font.is_valid()) {
+		if (font.is_valid()) {
+			set_fallback_font(font);
+		} else {
 			ERR_PRINT("Error loading custom font '" + font_path + "'");
 		}
 	}
@@ -84,9 +86,6 @@ void ThemeDB::initialize_theme() {
 		Ref<Theme> theme = ResourceLoader::load(theme_path);
 		if (theme.is_valid()) {
 			set_project_theme(theme);
-			if (font.is_valid()) {
-				set_fallback_font(font);
-			}
 		} else {
 			ERR_PRINT("Error loading custom theme '" + theme_path + "'");
 		}


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/69781. Supersedes https://github.com/godotengine/godot/pull/70316.

As discussed in the original PR, there is a better solution to avoid leaking themes into different contexts, but I will only be able to work on it for a future version of Godot. For now, I think it's safe to set the default fallback values directly on the default theme instead of letting it fall through to the global fallback values. It should work the same for the majority of cases, because it's literally the same values, but it also fixes the leak in the theme preview window.

Proof:
![godot windows editor dev x86_64_2022-12-21_19-27-44](https://user-images.githubusercontent.com/11782833/208956019-086aa667-f393-48ee-b964-6665d31fcfd1.png)


There is still a bit of a discrepancy in my screenshot, but I think it has to do with the scale for the 2d viewport, because everything is scaled by 1.25 there, not just the font (and that's my editor scale precisely).