### PR TITLE
[RTL] Rename remove_line() to remove_paragraph() for naming consistancy.

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -378,12 +378,12 @@
 				Adds a [code][u][/code] tag to the tag stack.
 			</description>
 		</method>
-		<method name="remove_line">
+		<method name="remove_paragraph">
 			<return type="bool" />
-			<param index="0" name="line" type="int" />
+			<param index="0" name="paragraph" type="int" />
 			<description>
-				Removes a line of content from the label. Returns [code]true[/code] if the line exists.
-				The [param line] argument is the index of the line to remove, it can take values in the interval [code][0, get_line_count() - 1][/code].
+				Removes a paragraph of content from the label. Returns [code]true[/code] if the paragraph exists.
+				The [param paragraph] argument is the index of the paragraph to remove, it can take values in the interval [code][0, get_paragraph_count() - 1][/code].
 			</description>
 		</method>
 		<method name="scroll_to_line">

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -286,7 +286,7 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 		// Remove last line if replacing, as it will be replace by the next added line.
 		// Why "- 2"? RichTextLabel is weird. When you add a line with add_newline(), it also adds an element to the list of lines which is null/blank,
 		// but it still counts as a line. So if you remove the last line (count - 1) you are actually removing nothing...
-		log->remove_line(log->get_paragraph_count() - 2);
+		log->remove_paragraph(log->get_paragraph_count() - 2);
 	}
 
 	switch (p_message.type) {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3071,18 +3071,18 @@ void RichTextLabel::add_newline() {
 	queue_redraw();
 }
 
-bool RichTextLabel::remove_line(const int p_line) {
+bool RichTextLabel::remove_paragraph(const int p_paragraph) {
 	_stop_thread();
 	MutexLock data_lock(data_mutex);
 
-	if (p_line >= (int)current_frame->lines.size() || p_line < 0) {
+	if (p_paragraph >= (int)current_frame->lines.size() || p_paragraph < 0) {
 		return false;
 	}
 
 	// Remove all subitems with the same line as that provided.
 	Vector<int> subitem_indices_to_remove;
 	for (int i = 0; i < current->subitems.size(); i++) {
-		if (current->subitems[i]->line == p_line) {
+		if (current->subitems[i]->line == p_paragraph) {
 			subitem_indices_to_remove.push_back(i);
 		}
 	}
@@ -3092,17 +3092,17 @@ bool RichTextLabel::remove_line(const int p_line) {
 	for (int i = subitem_indices_to_remove.size() - 1; i >= 0; i--) {
 		int subitem_idx = subitem_indices_to_remove[i];
 		had_newline = had_newline || current->subitems[subitem_idx]->type == ITEM_NEWLINE;
-		_remove_item(current->subitems[subitem_idx], current->subitems[subitem_idx]->line, p_line);
+		_remove_item(current->subitems[subitem_idx], current->subitems[subitem_idx]->line, p_paragraph);
 	}
 
 	if (!had_newline) {
-		current_frame->lines.remove_at(p_line);
+		current_frame->lines.remove_at(p_paragraph);
 		if (current_frame->lines.size() == 0) {
 			current_frame->lines.resize(1);
 		}
 	}
 
-	if (p_line == 0 && current->subitems.size() > 0) {
+	if (p_paragraph == 0 && current->subitems.size() > 0) {
 		main->lines[0].from = main;
 	}
 
@@ -5313,7 +5313,7 @@ void RichTextLabel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_text", "text"), &RichTextLabel::set_text);
 	ClassDB::bind_method(D_METHOD("add_image", "image", "width", "height", "color", "inline_align", "region"), &RichTextLabel::add_image, DEFVAL(0), DEFVAL(0), DEFVAL(Color(1.0, 1.0, 1.0)), DEFVAL(INLINE_ALIGNMENT_CENTER), DEFVAL(Rect2(0, 0, 0, 0)));
 	ClassDB::bind_method(D_METHOD("newline"), &RichTextLabel::add_newline);
-	ClassDB::bind_method(D_METHOD("remove_line", "line"), &RichTextLabel::remove_line);
+	ClassDB::bind_method(D_METHOD("remove_paragraph", "paragraph"), &RichTextLabel::remove_paragraph);
 	ClassDB::bind_method(D_METHOD("push_font", "font", "font_size"), &RichTextLabel::push_font);
 	ClassDB::bind_method(D_METHOD("push_font_size", "font_size"), &RichTextLabel::push_font_size);
 	ClassDB::bind_method(D_METHOD("push_normal"), &RichTextLabel::push_normal);

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -573,7 +573,7 @@ public:
 	void add_text(const String &p_text);
 	void add_image(const Ref<Texture2D> &p_image, const int p_width = 0, const int p_height = 0, const Color &p_color = Color(1.0, 1.0, 1.0), InlineAlignment p_alignment = INLINE_ALIGNMENT_CENTER, const Rect2 &p_region = Rect2(0, 0, 0, 0));
 	void add_newline();
-	bool remove_line(const int p_line);
+	bool remove_paragraph(const int p_paragraph);
 	void push_dropcap(const String &p_string, const Ref<Font> &p_font, int p_size, const Rect2 &p_dropcap_margins = Rect2(), const Color &p_color = Color(1, 1, 1), int p_ol_size = 0, const Color &p_ol_color = Color(0, 0, 0, 0));
 	void _push_def_font(DefaultFont p_def_font);
 	void _push_def_font_var(DefaultFont p_def_font, const Ref<Font> &p_font, int p_size = -1);


### PR DESCRIPTION
Renamed `remove_line()` to `remove_paragraph()` to make the API self-consistent. For example, there are `scroll_to_line()` and `scroll_to_paragraph()`, and `get_visible_line_count()` and `get_visible_paragraph_count()`; the current `remove_line()` actually removes a "paragraph" in this lexicon. `remove_line()` is called only once by editor_log.cpp, so that is the only code change outside of rich_text_label.cpp and rich_text_label.h (not including the xml).

Also as evidence that this change is accurate, in editor_log.cpp, the index for `remove_line()` is correctly obtained from `get_paragraph_count()`.

Ideally, this is merged before 4.0 is released to avoid a future regression.
