### PR TITLE
Add MultiRect command

### DIFF
--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -801,4 +801,28 @@ void _err_flush_stdout();
 #define DEV_ASSERT(m_cond)
 #endif
 
+/**
+ * These should be 'free' checks for program flow and should not be needed in any releases,
+ *  only used in dev builds.
+ */
+#ifdef DEV_ENABLED
+#define DEV_CHECK(m_cond)                                              \
+	if (unlikely(!(m_cond))) {                                         \
+		ERR_PRINT("DEV_CHECK failed  \"" _STR(m_cond) "\" is false."); \
+	} else                                                             \
+		((void)0)
+#else
+#define DEV_CHECK(m_cond)
+#endif
+
+#ifdef DEV_ENABLED
+#define DEV_CHECK_ONCE(m_cond)                                                   \
+	if (unlikely(!(m_cond))) {                                                   \
+		ERR_PRINT_ONCE("DEV_CHECK_ONCE failed  \"" _STR(m_cond) "\" is false."); \
+	} else                                                                       \
+		((void)0)
+#else
+#define DEV_CHECK_ONCE(m_cond)
+#endif
+
 #endif // ERROR_MACROS_H

--- a/core/templates/fixed_array.h
+++ b/core/templates/fixed_array.h
@@ -1,0 +1,136 @@
+/*************************************************************************/
+/*  fixed_array.h                                                        */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef FIXED_ARRAY_H
+#define FIXED_ARRAY_H
+
+#include "core/templates/local_vector.h"
+
+// High performance fixed size array, single threaded.
+// Especially useful if you need to create an array on the stack, to
+// prevent dynamic allocations (especially in bottleneck code).
+
+template <class T, uint32_t CAPACITY = 8, bool force_trivial = false, uint32_t ALIGN = 1>
+class FixedArray {
+	static_assert(ALIGN > 0, "ALIGN must be at least 1.");
+	const static uint32_t UNIT_SIZE = ((sizeof(T) + ALIGN - 1) / ALIGN * ALIGN);
+	const static bool CONSTRUCT = !std::is_trivially_constructible<T>::value && !force_trivial;
+	const static bool DESTRUCT = !std::is_trivially_destructible<T>::value && !force_trivial;
+
+	uint32_t _size = 0;
+	uint8_t _data[CAPACITY * UNIT_SIZE];
+
+	const T &get(uint32_t p_index) const {
+		return *(const T *)&_data[p_index * UNIT_SIZE];
+	}
+	T &get(uint32_t p_index) {
+		return *(T *)&_data[p_index * UNIT_SIZE];
+	}
+
+public:
+	uint32_t size() const { return _size; }
+	bool is_empty() const { return !_size; }
+	bool is_full() const { return _size == CAPACITY; }
+	uint32_t capacity() const { return CAPACITY; }
+
+	T *request(bool p_construct = true) {
+		if (size() < CAPACITY) {
+			T *ele = &get(_size++);
+			if (CONSTRUCT && p_construct) {
+				memnew_placement(ele, T);
+			}
+			return ele;
+		}
+		return nullptr;
+	}
+	void push_back(const T &p_val) {
+		T *mem = request(false);
+		ERR_FAIL_NULL(mem);
+		*mem = p_val;
+	}
+	void clear() {
+		resize(0);
+	}
+	void remove_unordered(uint32_t p_index) {
+		ERR_FAIL_UNSIGNED_INDEX(p_index, _size);
+
+		_size--;
+		if (_size > p_index) {
+			get(p_index) = get(_size);
+		}
+
+		if (DESTRUCT) {
+			get(_size).~T();
+		}
+	}
+	void resize(uint32_t p_size) {
+		ERR_FAIL_COND(p_size > CAPACITY);
+
+		if (DESTRUCT && (p_size < _size)) {
+			for (uint32_t i = p_size; i < _size; i++) {
+				get(i).~T();
+			}
+		}
+
+		if (CONSTRUCT && (p_size > _size)) {
+			for (uint32_t i = _size; i < p_size; i++) {
+				memnew_placement(&get(i), T);
+			}
+		}
+
+		_size = p_size;
+	}
+	const T &operator[](uint32_t p_index) const {
+		DEV_ASSERT(p_index < size());
+		return get(p_index);
+	}
+	T &operator[](uint32_t p_index) {
+		DEV_ASSERT(p_index < size());
+		return get(p_index);
+	}
+
+	operator Vector<T>() const {
+		Vector<T> ret;
+		if (size()) {
+			ret.resize(size());
+			T *dest = ret.ptrw();
+			if (ALIGN <= 1) {
+				memcpy(dest, _data, sizeof(T) * _size);
+			} else {
+				for (uint32_t n = 0; n < _size; n++) {
+					dest[n] = get(n);
+				}
+			}
+		}
+		return ret;
+	}
+};
+
+#endif // FIXED_ARRAY_H

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -962,6 +962,9 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 				_add_to_batch(r_index, r_batch_broken);
 			} break;
 
+			case Item::Command::TYPE_MULTIRECT: {
+			} break;
+
 			case Item::Command::TYPE_NINEPATCH: {
 				const Item::CommandNinePatch *np = static_cast<const Item::CommandNinePatch *>(c);
 
@@ -1231,6 +1234,8 @@ void RasterizerCanvasGLES3::_render_batch(Light *p_lights, uint32_t p_index) {
 			glDrawElementsInstanced(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0, state.canvas_instance_batches[p_index].instance_count);
 			glBindVertexArray(0);
 
+		} break;
+		case Item::Command::TYPE_MULTIRECT: {
 		} break;
 
 		case Item::Command::TYPE_POLYGON: {

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -3230,7 +3230,7 @@ void TextServerAdvanced::_font_render_glyph(const RID &p_font_rid, const Vector2
 #endif
 }
 
-void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const {
+void TextServerAdvanced::_font_draw_glyph_multirect(MultiRect *p_multirect, const RID &p_font_rid, const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const {
 	FontAdvanced *fd = font_owner.get_or_null(p_font_rid);
 	ERR_FAIL_COND(!fd);
 
@@ -3314,12 +3314,20 @@ void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 					if (lcd_aa) {
 						RenderingServer::get_singleton()->canvas_item_add_lcd_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, gl.uv_rect, modulate);
 					} else {
-						RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, gl.uv_rect, modulate, false, false);
+						if (p_multirect) {
+							p_multirect->add_rect(p_canvas, Rect2(cpos, csize), texture, gl.uv_rect, modulate);
+						} else {
+							RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, gl.uv_rect, modulate, false, false);
+						}
 					}
 				}
 			}
 		}
 	}
+}
+
+void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const {
+	_font_draw_glyph_multirect(nullptr, p_font_rid, p_canvas, p_size, p_pos, p_index, p_color);
 }
 
 void TextServerAdvanced::_font_draw_glyph_outline(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const {

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -819,6 +819,7 @@ public:
 
 	MODBIND6C(font_draw_glyph, const RID &, const RID &, int64_t, const Vector2 &, int64_t, const Color &);
 	MODBIND7C(font_draw_glyph_outline, const RID &, const RID &, int64_t, int64_t, const Vector2 &, int64_t, const Color &);
+	MODBIND7C(font_draw_glyph_multirect, MultiRect *, const RID &, const RID &, int64_t, const Vector2 &, int64_t, const Color &);
 
 	MODBIND2RC(bool, font_is_language_supported, const RID &, const String &);
 	MODBIND3(font_set_language_support_override, const RID &, const String &, bool);

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -250,9 +250,9 @@ void Label::_update_visible() {
 	}
 }
 
-inline void draw_glyph(const Glyph &p_gl, const RID &p_canvas, const Color &p_font_color, const Vector2 &p_ofs) {
+inline void draw_glyph(const Glyph &p_gl, const RID &p_canvas, const Color &p_font_color, const Vector2 &p_ofs, MultiRect *p_multirect) {
 	if (p_gl.font_rid != RID()) {
-		TS->font_draw_glyph(p_gl.font_rid, p_canvas, p_gl.font_size, p_ofs + Vector2(p_gl.x_off, p_gl.y_off), p_gl.index, p_font_color);
+		TS->font_draw_glyph_multirect(p_multirect, p_gl.font_rid, p_canvas, p_gl.font_size, p_ofs + Vector2(p_gl.x_off, p_gl.y_off), p_gl.index, p_font_color);
 	} else {
 		TS->draw_hex_code_box(p_canvas, p_gl.font_size, p_ofs + Vector2(p_gl.x_off, p_gl.y_off), p_gl.index, p_font_color);
 	}
@@ -533,13 +533,14 @@ void Label::_notification(int p_what) {
 				// Draw main text. Note: Do not merge this into the single loop with the outline, to prevent overlaps.
 
 				// Draw RTL ellipsis string when necessary.
+				MultiRect multirect;
 				if (rtl && ellipsis_pos >= 0) {
 					for (int gl_idx = ellipsis_gl_size - 1; gl_idx >= 0; gl_idx--) {
 						for (int j = 0; j < ellipsis_glyphs[gl_idx].repeat; j++) {
 							bool skip = (trim_chars && ellipsis_glyphs[gl_idx].end > visible_chars) || (trim_glyphs_ltr && (processed_glyphs >= visible_glyphs)) || (trim_glyphs_rtl && (processed_glyphs < total_glyphs - visible_glyphs));
 							//Draw glyph outlines and shadow.
 							if (!skip) {
-								draw_glyph(ellipsis_glyphs[gl_idx], ci, font_color, ofs);
+								draw_glyph(ellipsis_glyphs[gl_idx], ci, font_color, ofs, &multirect);
 							}
 							processed_glyphs++;
 							ofs.x += ellipsis_glyphs[gl_idx].advance;
@@ -566,7 +567,7 @@ void Label::_notification(int p_what) {
 
 						// Draw glyph outlines and shadow.
 						if (!skip) {
-							draw_glyph(glyphs[j], ci, font_color, ofs);
+							draw_glyph(glyphs[j], ci, font_color, ofs, &multirect);
 						}
 						processed_glyphs++;
 						ofs.x += glyphs[j].advance;
@@ -579,7 +580,7 @@ void Label::_notification(int p_what) {
 							bool skip = (trim_chars && ellipsis_glyphs[gl_idx].end > visible_chars) || (trim_glyphs_ltr && (processed_glyphs >= visible_glyphs)) || (trim_glyphs_rtl && (processed_glyphs < total_glyphs - visible_glyphs));
 							//Draw glyph outlines and shadow.
 							if (!skip) {
-								draw_glyph(ellipsis_glyphs[gl_idx], ci, font_color, ofs);
+								draw_glyph(ellipsis_glyphs[gl_idx], ci, font_color, ofs, &multirect);
 							}
 							processed_glyphs++;
 							ofs.x += ellipsis_glyphs[gl_idx].advance;

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -1292,6 +1292,29 @@ void RendererCanvasCull::canvas_item_add_texture_rect_region(RID p_item, const R
 	}
 }
 
+void RendererCanvasCull::canvas_item_add_texture_multirect_region(RID p_item, const Vector<Rect2> &p_rects, RID p_texture, const Vector<Rect2> &p_src_rects, const Color &p_modulate, uint32_t p_canvas_rect_flags) {
+	ERR_FAIL_COND(p_rects.size() != p_src_rects.size());
+
+#if 0
+	// Compatibility until clayjohn has implemented
+	for (int n = 0; n < p_rects.size(); n++) {
+		canvas_item_add_texture_rect_region(p_item, p_rects[n], p_texture, p_src_rects[n], p_modulate, p_canvas_rect_flags & RendererCanvasRender::CANVAS_RECT_TRANSPOSE, p_canvas_rect_flags & RendererCanvasRender::CANVAS_RECT_CLIP_UV);
+	}
+#else
+	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
+	ERR_FAIL_COND(!canvas_item);
+
+	Item::CommandMultiRect *mrect = canvas_item->alloc_command<Item::CommandMultiRect>();
+	ERR_FAIL_COND(!mrect);
+	mrect->modulate = p_modulate;
+	mrect->texture = p_texture;
+	mrect->flags = p_canvas_rect_flags;
+
+	mrect->rects = p_rects;
+	mrect->sources = p_src_rects;
+#endif
+}
+
 void RendererCanvasCull::canvas_item_add_nine_patch(RID p_item, const Rect2 &p_rect, const Rect2 &p_source, RID p_texture, const Vector2 &p_topleft, const Vector2 &p_bottomright, RS::NinePatchAxisMode p_x_axis_mode, RS::NinePatchAxisMode p_y_axis_mode, bool p_draw_center, const Color &p_modulate) {
 	Item *canvas_item = canvas_item_owner.get_or_null(p_item);
 	ERR_FAIL_COND(!canvas_item);

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -228,6 +228,7 @@ public:
 	void canvas_item_add_circle(RID p_item, const Point2 &p_pos, float p_radius, const Color &p_color);
 	void canvas_item_add_texture_rect(RID p_item, const Rect2 &p_rect, RID p_texture, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false);
 	void canvas_item_add_texture_rect_region(RID p_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = false);
+	void canvas_item_add_texture_multirect_region(RID p_item, const Vector<Rect2> &p_rects, RID p_texture, const Vector<Rect2> &p_src_rects, const Color &p_modulate = Color(1, 1, 1), uint32_t p_canvas_rect_flags = 0);
 	void canvas_item_add_msdf_texture_rect_region(RID p_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), int p_outline_size = 0, float p_px_range = 1.0, float p_scale = 1.0);
 	void canvas_item_add_lcd_texture_rect_region(RID p_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1));
 	void canvas_item_add_nine_patch(RID p_item, const Rect2 &p_rect, const Rect2 &p_source, RID p_texture, const Vector2 &p_topleft, const Vector2 &p_bottomright, RS::NinePatchAxisMode p_x_axis_mode = RS::NINE_PATCH_STRETCH, RS::NinePatchAxisMode p_y_axis_mode = RS::NINE_PATCH_STRETCH, bool p_draw_center = true, const Color &p_modulate = Color(1, 1, 1));

--- a/servers/rendering/renderer_canvas_helper.cpp
+++ b/servers/rendering/renderer_canvas_helper.cpp
@@ -1,0 +1,278 @@
+/*************************************************************************/
+/*  visual_server_canvas_helper.cpp                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "renderer_canvas_helper.h"
+
+#include "servers/rendering/renderer_canvas_render.h"
+#include "servers/rendering_server.h"
+
+LocalVector<MultiRect> RendererCanvasHelper::_tilemap_multirects;
+Mutex RendererCanvasHelper::_tilemap_mutex;
+
+bool RendererCanvasHelper::_multirect_enabled = true;
+
+MultiRect::MultiRect() {
+	begin();
+}
+MultiRect::~MultiRect() {
+	end();
+}
+
+void MultiRect::begin() {
+	DEV_CHECK_ONCE(!rects.size());
+	rects.clear();
+	sources.clear();
+
+	state.flags = 0;
+	state_set = false;
+}
+
+void MultiRect::add_rect(RID p_canvas_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate, bool p_transpose, bool p_clip_uv) {
+	bool new_common_data = true;
+
+	Rect2 rect = p_rect;
+	Rect2 source = p_src_rect;
+
+	// To make the rendering code as efficient as possible,
+	// a single MultiRect command should have identical flips and transpose etc.
+	// If these change, it flushes the previous multirect and starts a new one.
+	uint32_t flags = 0;
+
+	if (p_rect.size.x < 0) {
+		flags |= RendererCanvasRender::CANVAS_RECT_FLIP_H;
+		rect.size.x = -rect.size.x;
+	}
+	if (source.size.x < 0) {
+		flags ^= RendererCanvasRender::CANVAS_RECT_FLIP_H;
+		source.size.x = -source.size.x;
+	}
+	if (p_rect.size.y < 0) {
+		flags |= RendererCanvasRender::CANVAS_RECT_FLIP_V;
+		rect.size.y = -rect.size.y;
+	}
+	if (source.size.y < 0) {
+		flags ^= RendererCanvasRender::CANVAS_RECT_FLIP_V;
+		source.size.y = -source.size.y;
+	}
+
+	if (p_transpose) {
+		flags |= RendererCanvasRender::CANVAS_RECT_TRANSPOSE;
+		SWAP(rect.size.x, rect.size.y);
+	}
+
+	if (p_clip_uv) {
+		flags |= RendererCanvasRender::CANVAS_RECT_CLIP_UV;
+	}
+
+	RendererCanvasHelper::State s;
+	s.item = p_canvas_item;
+	s.texture = p_texture;
+	s.modulate = p_modulate;
+	s.flags = flags;
+
+	if (!is_empty()) {
+		if ((state != s) ||
+				(rects.size() >= MAX_RECTS)) {
+			end();
+		} else {
+			new_common_data = false;
+		}
+	}
+
+	if (new_common_data) {
+		state = s;
+	}
+
+	rects.push_back(rect);
+	sources.push_back(source);
+}
+
+void MultiRect::begin(const RendererCanvasHelper::State &p_state) {
+	DEV_CHECK_ONCE(!rects.size());
+	rects.clear();
+	sources.clear();
+
+	state = p_state;
+	state_set = true;
+}
+
+uint32_t MultiRect::flags_from_rects(Rect2 &r_rect, Rect2 &r_source) {
+	uint32_t flags = 0;
+
+	if (r_rect.size.x < 0) {
+		flags |= RendererCanvasRender::CANVAS_RECT_FLIP_H;
+		r_rect.size.x = -r_rect.size.x;
+	}
+	if (r_rect.size.y < 0) {
+		flags |= RendererCanvasRender::CANVAS_RECT_FLIP_V;
+		r_rect.size.y = -r_rect.size.y;
+	}
+
+	if (r_source.size.x < 0) {
+		flags ^= RendererCanvasRender::CANVAS_RECT_FLIP_H;
+		r_source.size.x = -r_source.size.x;
+	}
+	if (r_source.size.y < 0) {
+		flags ^= RendererCanvasRender::CANVAS_RECT_FLIP_V;
+		r_source.size.y = -r_source.size.y;
+	}
+
+	return flags;
+}
+
+bool MultiRect::add_pre_flipped(const Rect2 &p_rect, const Rect2 &p_src_rect) {
+	if (rects.is_full()) {
+		return false;
+	}
+	*rects.request() = p_rect;
+	*sources.request() = p_src_rect;
+	return true;
+}
+
+bool MultiRect::add(const Rect2 &p_rect, const Rect2 &p_src_rect, bool p_commit_on_flip_change) {
+	if (rects.is_full()) {
+		return false;
+	}
+
+	Rect2 rect = p_rect;
+	Rect2 source = p_src_rect;
+
+	uint32_t flags = flags_from_rects(rect, source);
+
+	if (state_set) {
+		// if we are changing these flips, we can no longer continue the same multirect
+		if ((state.flags & (RendererCanvasRender::CANVAS_RECT_FLIP_H | RendererCanvasRender::CANVAS_RECT_FLIP_V)) != flags) {
+			// different state requires a new multirect
+			return false;
+		}
+
+	} else {
+		state.flags |= flags;
+		state_set = true;
+	}
+
+	*rects.request() = rect;
+	*sources.request() = source;
+	return true;
+}
+
+void MultiRect::end() {
+	if (!is_empty()) {
+		if (RendererCanvasHelper::_multirect_enabled) {
+			RenderingServer::get_singleton()->canvas_item_add_texture_multirect_region(state.item, rects, state.texture, sources, state.modulate, state.flags);
+
+		} else {
+			// legacy path
+			bool transpose = state.flags & RendererCanvasRender::CANVAS_RECT_TRANSPOSE;
+			bool clip_uv = state.flags & RendererCanvasRender::CANVAS_RECT_CLIP_UV;
+
+			for (uint32_t n = 0; n < rects.size(); n++) {
+				RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(state.item, rects[n], state.texture, sources[n], state.modulate, transpose, clip_uv);
+			}
+		}
+
+		rects.clear();
+		sources.clear();
+	}
+	state_set = false;
+}
+
+void RendererCanvasHelper::tilemap_begin() {
+	if (_multirect_enabled) {
+		_tilemap_mutex.lock();
+	}
+}
+
+void RendererCanvasHelper::tilemap_add_rect(RID p_canvas_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate, bool p_transpose, bool p_clip_uv) {
+	if (!_multirect_enabled) {
+		RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas_item, p_rect, p_texture, p_src_rect, p_modulate, p_transpose, p_clip_uv);
+		return;
+	}
+
+	Rect2 rect = p_rect;
+	Rect2 source = p_src_rect;
+
+	// To make the rendering code as efficient as possible,
+	// a single MultiRect command should have identical flips and transpose etc.
+	// If these change, it flushes the previous multirect and starts a new one.
+	uint32_t flags = MultiRect::flags_from_rects(rect, source);
+
+	if (p_transpose) {
+		flags |= RendererCanvasRender::CANVAS_RECT_TRANSPOSE;
+		SWAP(rect.size.x, rect.size.y);
+	}
+
+	if (p_clip_uv) {
+		flags |= RendererCanvasRender::CANVAS_RECT_CLIP_UV;
+	}
+
+	State state;
+	state.item = p_canvas_item;
+	state.texture = p_texture;
+	state.modulate = p_modulate;
+	state.flags = flags;
+
+	// attempt to add to existing multirect
+	for (int n = _tilemap_multirects.size() - 1; n >= 0; n--) {
+		MultiRect &mr = _tilemap_multirects[n];
+
+		// matches state?
+		if (mr.state == state) {
+			// add .. this may fail if the multirect is full
+			if (mr.add_pre_flipped(rect, source)) {
+				return;
+			}
+		}
+
+		// disallow if we overlap a multirect
+		if (mr.overlaps(rect)) {
+			break;
+		}
+	}
+
+	// create new multirect
+	_tilemap_multirects.resize(_tilemap_multirects.size() + 1);
+	MultiRect &mr = _tilemap_multirects[_tilemap_multirects.size() - 1];
+	mr.begin(state);
+	mr.add_pre_flipped(rect, source);
+}
+
+void RendererCanvasHelper::tilemap_end() {
+	if (!_multirect_enabled) {
+		return;
+	}
+
+	for (uint32_t n = 0; n < _tilemap_multirects.size(); n++) {
+		_tilemap_multirects[n].end();
+	}
+
+	_tilemap_multirects.clear();
+	_tilemap_mutex.unlock();
+}

--- a/servers/rendering/renderer_canvas_helper.h
+++ b/servers/rendering/renderer_canvas_helper.h
@@ -1,0 +1,113 @@
+/*************************************************************************/
+/*  visual_server_canvas_helper.h                                        */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef RENDERER_CANVAS_HELPER_H
+#define RENDERER_CANVAS_HELPER_H
+
+#include "core/math/color.h"
+#include "core/math/rect2.h"
+#include "core/os/mutex.h"
+#include "core/templates/fixed_array.h"
+#include "core/templates/local_vector.h"
+#include "core/templates/rid.h"
+
+class MultiRect;
+
+class RendererCanvasHelper {
+public:
+	struct State {
+		RID item;
+		RID texture;
+		Color modulate;
+		uint32_t flags = 0;
+
+		bool operator==(const State &p_state) const {
+			return ((item == p_state.item) &&
+					(texture == p_state.texture) &&
+					(modulate == p_state.modulate) &&
+					(flags == p_state.flags));
+		}
+		bool operator!=(const State &p_state) const { return !(*this == p_state); }
+	};
+
+private:
+	// There is a single mutex for tilemaps, only one quadrant can be adding
+	// at a time.
+	static LocalVector<MultiRect> _tilemap_multirects;
+	static Mutex _tilemap_mutex;
+
+public:
+	static void tilemap_begin();
+	static void tilemap_add_rect(RID p_canvas_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = false);
+	static void tilemap_end();
+
+	static bool _multirect_enabled;
+};
+
+class MultiRect {
+	friend class RendererCanvasHelper;
+
+public:
+	enum { MAX_RECTS = 2048 };
+
+private:
+	RendererCanvasHelper::State state;
+	bool state_set = false;
+	FixedArray<Rect2, MAX_RECTS, true> rects;
+	FixedArray<Rect2, MAX_RECTS, true> sources;
+
+	static uint32_t flags_from_rects(Rect2 &r_rect, Rect2 &r_source);
+	bool overlaps(const Rect2 &p_rect) const {
+		for (uint32_t n = 0; n < rects.size(); n++) {
+			if (rects[n].intersects(p_rect)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	bool add_pre_flipped(const Rect2 &p_rect, const Rect2 &p_src_rect);
+
+public:
+	// Simple API
+	void begin();
+	void add_rect(RID p_canvas_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = false);
+
+	// Efficient API
+	void begin(const RendererCanvasHelper::State &p_state);
+	bool add(const Rect2 &p_rect, const Rect2 &p_src_rect, bool p_commit_on_flip_change = true);
+	bool is_empty() const { return rects.is_empty(); }
+	bool is_full() const { return rects.is_full(); }
+	void end();
+
+	MultiRect();
+	~MultiRect();
+};
+
+#endif // RENDERER_CANVAS_HELPER_H

--- a/servers/rendering/renderer_canvas_render.cpp
+++ b/servers/rendering/renderer_canvas_render.cpp
@@ -59,6 +59,16 @@ const Rect2 &RendererCanvasRender::Item::get_rect() const {
 				r = crect->rect;
 
 			} break;
+			case Item::Command::TYPE_MULTIRECT: {
+				const Item::CommandMultiRect *mrect = static_cast<const Item::CommandMultiRect *>(c);
+				int num_rects = mrect->rects.size();
+				if (num_rects) {
+					r = mrect->rects[0];
+					for (int n = 1; n < num_rects; n++) {
+						r = mrect->rects[n].merge(r);
+					}
+				}
+			} break;
 			case Item::Command::TYPE_NINEPATCH: {
 				const Item::CommandNinePatch *style = static_cast<const Item::CommandNinePatch *>(c);
 				r = style->rect;

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -174,6 +174,7 @@ public:
 		struct Command {
 			enum Type {
 				TYPE_RECT,
+				TYPE_MULTIRECT,
 				TYPE_NINEPATCH,
 				TYPE_POLYGON,
 				TYPE_PRIMITIVE,
@@ -205,6 +206,20 @@ public:
 				outline = 0;
 				px_range = 1;
 				type = TYPE_RECT;
+			}
+		};
+
+		struct CommandMultiRect : public Command {
+			Color modulate;
+			uint16_t flags;
+			RID texture;
+
+			Vector<Rect2> rects;
+			Vector<Rect2> sources;
+
+			CommandMultiRect() {
+				flags = 0;
+				type = TYPE_MULTIRECT;
 			}
 		};
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -585,6 +585,10 @@ void RendererCanvasRenderRD::_render_item(RD::DrawListID p_draw_list, RID p_rend
 
 			} break;
 
+			case Item::Command::TYPE_MULTIRECT: {
+				// NYI
+			} break;
+
 			case Item::Command::TYPE_NINEPATCH: {
 				const Item::CommandNinePatch *np = static_cast<const Item::CommandNinePatch *>(c);
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -850,6 +850,7 @@ public:
 	FUNC4(canvas_item_add_circle, RID, const Point2 &, float, const Color &)
 	FUNC6(canvas_item_add_texture_rect, RID, const Rect2 &, RID, bool, const Color &, bool)
 	FUNC7(canvas_item_add_texture_rect_region, RID, const Rect2 &, RID, const Rect2 &, const Color &, bool, bool)
+	FUNC6(canvas_item_add_texture_multirect_region, RID, const Vector<Rect2> &, RID, const Vector<Rect2> &, const Color &, uint32_t)
 	FUNC8(canvas_item_add_msdf_texture_rect_region, RID, const Rect2 &, RID, const Rect2 &, const Color &, int, float, float)
 	FUNC5(canvas_item_add_lcd_texture_rect_region, RID, const Rect2 &, RID, const Rect2 &, const Color &)
 	FUNC10(canvas_item_add_nine_patch, RID, const Rect2 &, const Rect2 &, RID, const Vector2 &, const Vector2 &, NinePatchAxisMode, NinePatchAxisMode, bool, const Color &)

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1339,6 +1339,7 @@ public:
 	virtual void canvas_item_add_circle(RID p_item, const Point2 &p_pos, float p_radius, const Color &p_color) = 0;
 	virtual void canvas_item_add_texture_rect(RID p_item, const Rect2 &p_rect, RID p_texture, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) = 0;
 	virtual void canvas_item_add_texture_rect_region(RID p_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = false) = 0;
+	virtual void canvas_item_add_texture_multirect_region(RID p_item, const Vector<Rect2> &p_rects, RID p_texture, const Vector<Rect2> &p_src_rects, const Color &p_modulate = Color(1, 1, 1), uint32_t p_canvas_rect_flags = 0) = 0;
 	virtual void canvas_item_add_msdf_texture_rect_region(RID p_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), int p_outline_size = 0, float p_px_range = 1.0, float p_scale = 1.0) = 0;
 	virtual void canvas_item_add_lcd_texture_rect_region(RID p_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1)) = 0;
 	virtual void canvas_item_add_nine_patch(RID p_item, const Rect2 &p_rect, const Rect2 &p_source, RID p_texture, const Vector2 &p_topleft, const Vector2 &p_bottomright, NinePatchAxisMode p_x_axis_mode = NINE_PATCH_STRETCH, NinePatchAxisMode p_y_axis_mode = NINE_PATCH_STRETCH, bool p_draw_center = true, const Color &p_modulate = Color(1, 1, 1)) = 0;

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -36,6 +36,7 @@
 #include "core/templates/rid.h"
 #include "core/variant/native_ptr.h"
 #include "core/variant/variant.h"
+#include "servers/rendering/renderer_canvas_helper.h"
 
 template <typename T>
 class TypedArray;
@@ -367,6 +368,7 @@ public:
 
 	virtual void font_draw_glyph(const RID &p_font, const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color = Color(1, 1, 1)) const = 0;
 	virtual void font_draw_glyph_outline(const RID &p_font, const RID &p_canvas, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color = Color(1, 1, 1)) const = 0;
+	virtual void font_draw_glyph_multirect(MultiRect *p_multirect, const RID &p_font, const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color = Color(1, 1, 1)) const { font_draw_glyph(p_font, p_canvas, p_size, p_pos, p_index, p_color); }
 
 	virtual bool font_is_language_supported(const RID &p_font_rid, const String &p_language) const = 0;
 	virtual void font_set_language_support_override(const RID &p_font_rid, const String &p_language, bool p_supported) = 0;


### PR DESCRIPTION
Large groups of similar rects can be processed more efficiently using the MultiRect command. Processing common to the group can be done as a one off, instead of per rect.

Adds the new API to RendererCanvasRender, and uses the new functionality from Label, via the RendererCanvasHelper class.

Very modified port of #68960 for Godot 4.x.

## Notes
* This is very much a WIP, but should be enough for @clayjohn to have a look at adding OpenGL (and possibly vulkan) backend.
* It's only implemented for `Label` so far but should be enough to test.
* The font side and the backend will be completely different to 3.x, especially as the fonts are handled through a text server in master.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
