### PR TITLE
Ensure that particles are processed at least once before being used

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -485,9 +485,9 @@ public:
 	_FORCE_INLINE_ RID particles_get_instance_buffer_uniform_set(RID p_particles, RID p_shader, uint32_t p_set) {
 		Particles *particles = particles_owner.get_or_null(p_particles);
 		ERR_FAIL_COND_V(!particles, RID());
-		if (particles->particles_transforms_buffer_uniform_set.is_null()) {
+		if (particles->particles_transforms_buffer_uniform_set.is_null() || !RD::get_singleton()->uniform_set_is_valid(particles->particles_transforms_buffer_uniform_set)) {
 			_particles_update_buffers(particles);
-
+			update_particles();
 			Vector<RD::Uniform> uniforms;
 
 			{


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/56691
Fixes: https://github.com/godotengine/godot/issues/59072
Fixes: https://github.com/godotengine/godot/issues/65443

The underlying problem in these issues is that the particles were being used for 1 frame before they were ever processed. So for the first frame the particle data came from uninitialized memory. This PR ensures that the particles will be updated at least one before they are drawn. 

Oddly enough, these bugs were exposed in https://github.com/godotengine/godot/pull/58491. My theory is that prior to https://github.com/godotengine/godot/pull/58491 the uninitialized memory looked enough like a normal particle storage buffer that the bug did not surface often. 

CC @RandomShaper who helped me debug this earlier today. 