### PR TITLE
Do not add child twice and set initial focus in editor layout dialog

### DIFF
--- a/editor/editor_layouts_dialog.cpp
+++ b/editor/editor_layouts_dialog.cpp
@@ -98,6 +98,11 @@ void EditorLayoutsDialog::_post_popup() {
 	for (const String &E : layouts) {
 		layout_names->add_item(E);
 	}
+	if (name->is_visible()) {
+		name->grab_focus();
+	} else {
+		layout_names->grab_focus();
+	}
 }
 
 EditorLayoutsDialog::EditorLayoutsDialog() {
@@ -109,7 +114,6 @@ EditorLayoutsDialog::EditorLayoutsDialog() {
 	layout_names = memnew(ItemList);
 	layout_names->set_auto_height(true);
 	makevb->add_margin_child(TTR("Select existing layout:"), layout_names);
-	makevb->add_child(layout_names);
 	layout_names->set_custom_minimum_size(Size2(300 * EDSCALE, 1));
 	layout_names->set_visible(true);
 	layout_names->set_offset(SIDE_TOP, 5);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5194,15 +5194,15 @@ void EditorNode::_layout_menu_option(int p_id) {
 			current_menu_option = p_id;
 			layout_dialog->set_title(TTR("Save Layout"));
 			layout_dialog->set_ok_button_text(TTR("Save"));
-			layout_dialog->popup_centered();
 			layout_dialog->set_name_line_enabled(true);
+			layout_dialog->popup_centered();
 		} break;
 		case SETTINGS_LAYOUT_DELETE: {
 			current_menu_option = p_id;
 			layout_dialog->set_title(TTR("Delete Layout"));
 			layout_dialog->set_ok_button_text(TTR("Delete"));
-			layout_dialog->popup_centered();
 			layout_dialog->set_name_line_enabled(false);
+			layout_dialog->popup_centered();
 		} break;
 		case SETTINGS_LAYOUT_DEFAULT: {
 			_load_docks_from_config(default_layout, "docks");


### PR DESCRIPTION
The `layout_names` node was already added by `add_margin_child`, so `add_child` was not needed. This in fact also logged a warning when starting up.

![image](https://user-images.githubusercontent.com/66004280/209006155-3fafa8b6-6b70-494f-afff-fa4a63df60cb.png)
-
Also added initial focus grabbing.
When clicking `Save Layout`, the `name` `LineEdit` is focused.
When clicking `Delete Layout`, the `layout_names` `ItemList` is focused (name is not visible here).

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/66004280/209006305-433b4f46-3852-454b-a3a0-89884eb19fff.png) | ![image](https://user-images.githubusercontent.com/66004280/209006551-59373416-fe75-476f-9c4e-1cef3d4940af.png) | 
| ![image](https://user-images.githubusercontent.com/66004280/209006344-35f29b88-3419-4811-8269-9a319fbd29c7.png) | ![image](https://user-images.githubusercontent.com/66004280/209006598-950bf90c-d7cc-4dbf-93b4-605ef62ddded.png) |