### PR TITLE
Disable particle trails particles when parent parent is not active.

### DIFF
--- a/servers/rendering/renderer_rd/shaders/particles.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles.glsl
@@ -304,6 +304,11 @@ void main() {
 			PARTICLE.flags = PARTICLE_FLAG_ACTIVE | (particles.data[src_idx].flags & (PARTICLE_FRAME_MASK << PARTICLE_FRAME_SHIFT));
 			return; //- this appears like it should be correct, but it seems not to be.. wonder why.
 		}
+		if (!bool(particles.data[src_idx].flags & PARTICLE_FLAG_ACTIVE)) {
+			// Disable the entire trail if the parent is no longer active.
+			PARTICLE.flags = 0;
+			return;
+		}
 	} else {
 		PARTICLE.flags &= ~PARTICLE_FLAG_STARTED;
 	}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/54771
Fixes: https://github.com/godotengine/godot/issues/55842

The issue here is that when the parent particle is disabled, it gets assigned a zero'd transform. With a single particle this causes the mesh to not render (as every vertex ends up as (0,0,0). With a trail, it essentially treats the first bone as being at (0,0,0) but the rest of the bones (the trail) maintain their previous positions until the entire particle system resets. 

The solution is to disable all trail particles once the parent particle is deactivated. This ensures that the entire mesh is nullified when it comes time to render. 

This is an alternative approach to https://github.com/godotengine/godot/pull/58549 which tried to avoid having the trail particles disappear when the main particle was deactivated. 