### PR TITLE
C# cleaner signal emission (v2)

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/ObjectExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/ObjectExtensions.cs
@@ -44,5 +44,19 @@ namespace Godot
                 return (WeakRef)InteropUtils.UnmanagedGetManaged(weakRef.Reference);
             }
         }
+
+        /// <summary>
+        /// <para>Gets a <see cref="ISignalEmitter"/> to emit a signal.</para>
+        /// <para>Example:</para>
+        /// <code>GetEmitter&lt;SignalEmit.SignalName&gt;().Emit();</code>
+        /// </summary>
+        /// <returns>A <typeparamref name="TSignalEmitter"/> ready to call <see langword="Emit"/> on.</returns>
+        protected TSignalEmitter GetEmitter<TSignalEmitter>()
+            where TSignalEmitter : struct, ISignalEmitter
+        {
+            var signalEmitter = default(TSignalEmitter);
+            signalEmitter.Bound = this;
+            return signalEmitter;
+        }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/ISignalEmitter.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/ISignalEmitter.cs
@@ -1,0 +1,7 @@
+namespace Godot
+{
+    public interface ISignalEmitter
+    {
+        Godot.Object Bound { get; set; }
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Core\Interfaces\IAwaitable.cs" />
     <Compile Include="Core\Interfaces\IAwaiter.cs" />
     <Compile Include="Core\Interfaces\ISerializationListener.cs" />
+    <Compile Include="Core\Interfaces\ISignalEmitter.cs" />
     <Compile Include="Core\Mathf.cs" />
     <Compile Include="Core\MathfEx.cs" />
     <Compile Include="Core\NativeInterop\CustomUnsafe.cs" />


### PR DESCRIPTION
Provides a type safe way to emit signals in c#.

Previous:
```c#
EmitSignal(SignalName.SomethingHappened, arg1, arg2, arg3);
// This does not have syntax highlighting and compile error when signature is not met.
```
Now:
```c#
GetEmitter<SignalEmitter.SomethingHappened>().Emit(arg1, arg2, arg3);
```

I also implemented that enums can be used.

> Previous PR: [C#: Cleaner signal emission](https://github.com/godotengine/godot/pull/69142)
> Can't be archieved seamlessly (allocations or pullotion)

> Alternative: [C#: Generate strongly-typed method to raise signal events and fix event accessibility](https://github.com/godotengine/godot/pull/68233)
> - Pollutes classes
> - Shorter code
> - Guidelines