### PR TITLE
Improve the groups editor (dialog)

### DIFF
--- a/editor/groups_editor.h
+++ b/editor/groups_editor.h
@@ -80,11 +80,11 @@ class GroupDialog : public AcceptDialog {
 	void _group_renamed();
 	void _rename_group_item(const String &p_old_name, const String &p_new_name);
 
-	void _add_group(String p_name);
+	void _add_group(String p_name, bool p_can_be_edited = true);
 	void _modify_group_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 	void _delete_group_item(const String &p_name);
 
-	void _load_groups(Node *p_current);
+	void _load_groups(Node *p_current, HashMap<StringName, bool> &p_groups_map);
 	void _load_nodes(Node *p_current);
 
 protected:


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/69649
Note: This PR is superseded by https://github.com/godotengine/godot/pull/60965

I made the following improvements:

1.) GroupEditor: Show the copy button even if the group itself can not be edited/deleted
| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/66004280/209102673-35ea785d-80f6-43d4-a6b7-003a04a16f55.png) | ![image](https://user-images.githubusercontent.com/66004280/209102728-be71d4ae-2d40-4771-a02d-ae51fc008384.png) | 

2.) GroupEditorDialog: Only allow renaming/deletion, when the group was added on an instanced scene
| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/66004280/209102978-0ccb227d-f537-4311-86ad-ee9eaa0c045b.png) | ![image](https://user-images.githubusercontent.com/66004280/209103029-ce164345-75ca-4612-b69f-320b9c7bd8e1.png) |

3.) GroupEditorDialog: Sort groups alphabetically (like the normal group editor)
| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/66004280/209103365-4a1bf936-f686-4a71-86ec-91b696487287.png) | ![image](https://user-images.githubusercontent.com/66004280/209103403-056c2efa-7bcb-4457-ba15-6f03208a4346.png) |