### PR TITLE
Clarify the description of ArrayMesh::regen_normal_maps

### DIFF
--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -102,13 +102,13 @@
 			<param index="0" name="transform" type="Transform3D" />
 			<param index="1" name="texel_size" type="float" />
 			<description>
-				Will perform a UV unwrap on the [ArrayMesh] to prepare the mesh for lightmapping.
+				Performs a UV unwrap on the [ArrayMesh] to prepare the mesh for lightmapping.
 			</description>
 		</method>
 		<method name="regen_normal_maps">
 			<return type="void" />
 			<description>
-				Will regenerate normal maps for the [ArrayMesh].
+				Regenerates tangents for each of the [ArrayMesh]'s surfaces.
 			</description>
 		</method>
 		<method name="set_blend_shape_name">


### PR DESCRIPTION
I rewrote the documentation description for the method ArrayMesh::regen_normal_maps() to make it clear that it does not generate any new normal map textures but instead goes through each of a mesh's surfaces and creates tangent infomation for them. This was brought up in #52444. I agree with @Calinou that the method name does not make it clear as to its purpose.