### PR TITLE
Check for disabled particle trail particle before initializing particle trail

### DIFF
--- a/servers/rendering/renderer_rd/shaders/particles.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles.glsl
@@ -243,8 +243,14 @@ void main() {
 
 	if (params.trail_size > 1) {
 		if (params.trail_pass) {
+			if (particle >= params.total_particles * (params.trail_size - 1)) {
+				return;
+			}
 			particle += (particle / (params.trail_size - 1)) + 1;
 		} else {
+			if (particle >= params.total_particles) {
+				return;
+			}
 			particle *= params.trail_size;
 		}
 	}
@@ -298,17 +304,17 @@ void main() {
 			PARTICLE.flags = PARTICLE_FLAG_TRAILED | ((frame_history.data[0].frame & PARTICLE_FRAME_MASK) << PARTICLE_FRAME_SHIFT); //mark it as trailed, save in which frame it will start
 			PARTICLE.xform = particles.data[src_idx].xform;
 		}
-
-		if (bool(PARTICLE.flags & PARTICLE_FLAG_TRAILED) && ((PARTICLE.flags >> PARTICLE_FRAME_SHIFT) == (FRAME.frame & PARTICLE_FRAME_MASK))) { //check this is trailed and see if it should start now
-			// we just assume that this is the first frame of the particle, the rest is deterministic
-			PARTICLE.flags = PARTICLE_FLAG_ACTIVE | (particles.data[src_idx].flags & (PARTICLE_FRAME_MASK << PARTICLE_FRAME_SHIFT));
-			return; //- this appears like it should be correct, but it seems not to be.. wonder why.
-		}
 		if (!bool(particles.data[src_idx].flags & PARTICLE_FLAG_ACTIVE)) {
 			// Disable the entire trail if the parent is no longer active.
 			PARTICLE.flags = 0;
 			return;
 		}
+		if (bool(PARTICLE.flags & PARTICLE_FLAG_TRAILED) && ((PARTICLE.flags >> PARTICLE_FRAME_SHIFT) == (FRAME.frame & PARTICLE_FRAME_MASK))) { //check this is trailed and see if it should start now
+			// we just assume that this is the first frame of the particle, the rest is deterministic
+			PARTICLE.flags = PARTICLE_FLAG_ACTIVE | (particles.data[src_idx].flags & (PARTICLE_FRAME_MASK << PARTICLE_FRAME_SHIFT));
+			return; //- this appears like it should be correct, but it seems not to be.. wonder why.
+		}
+
 	} else {
 		PARTICLE.flags &= ~PARTICLE_FLAG_STARTED;
 	}


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/70422

This fixes an case that wasnt fully resolved by https://github.com/godotengine/godot/pull/70422. When a particle trail is first initialized, it just copies the flags from the parent and then returns. An issue arose where particles that were just initialized would set themselves to active and return, but since the parent was not active, they should not have been set to active in the first place. The solution is to check if the parent is active first, so if the parent is in fact not active, the trail particle can be set to not active and return early. 

This PR also has a more granular return when using trials. Trails run in two passes of size num_particles and num_particles * (trail_size -1) for a total of num_particles * trail size. Since we always process particles in groups of 64 we have a check to early return threads whose index is greater than or equal to num_particles * trail_size however, since the trail pass is in two passes that are much smaller than that we end up processing a lot of particles and writing to unallocated memory. With memory boundary checks on, this just wastes performance. However, we would like to eventually disable memory boundary checks as they greatly reduce performance on mobile devices. So this ensures that particles do not attempt to write outside of their allocated memory when using trails.

CC @unfa Who caught this bug and provided an MRP. 