### PR TITLE
Fix shader crash when using boolean type for vertex->fragment varyings

### DIFF
--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -134,6 +134,8 @@ static String _interpstr(SL::DataInterpolation p_interp) {
 			return "flat ";
 		case SL::INTERPOLATION_SMOOTH:
 			return "";
+		case SL::INTERPOLATION_DEFAULT:
+			return "";
 	}
 	return "";
 }
@@ -666,6 +668,9 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 					var_frag_to_light.push_back(Pair<StringName, SL::ShaderNode::Varying>(varying_name, varying));
 					fragment_varyings.insert(varying_name);
 					continue;
+				}
+				if (varying.type < SL::TYPE_INT) {
+					continue; // Ignore boolean types to prevent crashing (if varying is just declared).
 				}
 
 				String vcode;

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -247,6 +247,7 @@ public:
 	enum DataInterpolation {
 		INTERPOLATION_FLAT,
 		INTERPOLATION_SMOOTH,
+		INTERPOLATION_DEFAULT,
 	};
 
 	enum Operator {
@@ -774,6 +775,7 @@ public:
 	static bool is_token_arg_qual(TokenType p_type);
 	static DataPrecision get_token_precision(TokenType p_type);
 	static String get_precision_name(DataPrecision p_type);
+	static String get_interpolation_name(DataInterpolation p_interpolation);
 	static String get_datatype_name(DataType p_type);
 	static String get_uniform_hint_name(ShaderNode::Uniform::Hint p_hint);
 	static String get_texture_filter_name(TextureFilter p_filter);


### PR DESCRIPTION
Currently, shader with declared boolean or boolean vector varying crashing with an error:

```
ERROR: 0:642: 'out' : cannot be bool
```

I've restrict using of them in that context (only fragment-to-light should be allowed now). Fixes crashing in three possible conditions:

```
varying flat bool test;

void vertex(){
	test = true; // Prints: "Varying with '%s' data type may be assigned only in 'fragment' function."
}

void fragment(){
}
```

```
varying flat bool test;

void vertex(){
}

void fragment(){
	if(test) // Prints: "Varying with 'bool' data type must be assigned in 'fragment' function first."
 	{
	}
}
```


```
varying flat bool test; // Prints nothing, but prevent shader crash in shader compiler.

void vertex(){
}

void fragment(){
}
```