### PR TITLE
[4.x] Rework const on NavigationServer methods

### DIFF
--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -17,7 +17,7 @@
 		<link title="2D Navigation Demo">https://godotengine.org/asset-library/asset/117</link>
 	</tutorials>
 	<methods>
-		<method name="agent_create" qualifiers="const">
+		<method name="agent_create">
 			<return type="RID" />
 			<description>
 				Creates the agent.
@@ -37,7 +37,7 @@
 				Returns true if the map got changed the previous frame.
 			</description>
 		</method>
-		<method name="agent_set_callback" qualifiers="const">
+		<method name="agent_set_callback">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="object_id" type="int" />
@@ -48,7 +48,7 @@
 				[b]Note:[/b] Created callbacks are always processed independently of the SceneTree state as long as the agent is on a navigation map and not freed. To disable the dispatch of a callback from an agent use [method agent_set_callback] again with a [code]0[/code] ObjectID as the [param object_id].
 			</description>
 		</method>
-		<method name="agent_set_map" qualifiers="const">
+		<method name="agent_set_map">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="map" type="RID" />
@@ -56,7 +56,7 @@
 				Puts the agent in the map.
 			</description>
 		</method>
-		<method name="agent_set_max_neighbors" qualifiers="const">
+		<method name="agent_set_max_neighbors">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="count" type="int" />
@@ -64,7 +64,7 @@
 				Sets the maximum number of other agents the agent takes into account in the navigation. The larger this number, the longer the running time of the simulation. If the number is too low, the simulation will not be safe.
 			</description>
 		</method>
-		<method name="agent_set_max_speed" qualifiers="const">
+		<method name="agent_set_max_speed">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="max_speed" type="float" />
@@ -72,7 +72,7 @@
 				Sets the maximum speed of the agent. Must be positive.
 			</description>
 		</method>
-		<method name="agent_set_neighbor_distance" qualifiers="const">
+		<method name="agent_set_neighbor_distance">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="distance" type="float" />
@@ -80,7 +80,7 @@
 				Sets the maximum distance to other agents this agent takes into account in the navigation. The larger this number, the longer the running time of the simulation. If the number is too low, the simulation will not be safe.
 			</description>
 		</method>
-		<method name="agent_set_position" qualifiers="const">
+		<method name="agent_set_position">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="position" type="Vector2" />
@@ -88,7 +88,7 @@
 				Sets the position of the agent in world space.
 			</description>
 		</method>
-		<method name="agent_set_radius" qualifiers="const">
+		<method name="agent_set_radius">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="radius" type="float" />
@@ -96,7 +96,7 @@
 				Sets the radius of the agent.
 			</description>
 		</method>
-		<method name="agent_set_target_velocity" qualifiers="const">
+		<method name="agent_set_target_velocity">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="target_velocity" type="Vector2" />
@@ -104,7 +104,7 @@
 				Sets the new target velocity.
 			</description>
 		</method>
-		<method name="agent_set_time_horizon" qualifiers="const">
+		<method name="agent_set_time_horizon">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="time" type="float" />
@@ -112,7 +112,7 @@
 				The minimal amount of time for which the agent's velocities that are computed by the simulation are safe with respect to other agents. The larger this number, the sooner this agent will respond to the presence of other agents, but the less freedom this agent has in choosing its velocities. Must be positive.
 			</description>
 		</method>
-		<method name="agent_set_velocity" qualifiers="const">
+		<method name="agent_set_velocity">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="velocity" type="Vector2" />
@@ -120,7 +120,7 @@
 				Sets the current velocity of the agent.
 			</description>
 		</method>
-		<method name="free_rid" qualifiers="const">
+		<method name="free_rid">
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
 			<description>
@@ -133,7 +133,7 @@
 				Returns all created navigation map [RID]s on the NavigationServer. This returns both 2D and 3D created navigation maps as there is technically no distinction between them.
 			</description>
 		</method>
-		<method name="link_create" qualifiers="const">
+		<method name="link_create">
 			<return type="RID" />
 			<description>
 				Create a new link between two locations on a map.
@@ -195,7 +195,7 @@
 				Returns whether this [code]link[/code] can be travelled in both directions.
 			</description>
 		</method>
-		<method name="link_set_bidirectional" qualifiers="const">
+		<method name="link_set_bidirectional">
 			<return type="void" />
 			<param index="0" name="link" type="RID" />
 			<param index="1" name="bidirectional" type="bool" />
@@ -203,7 +203,7 @@
 				Sets whether this [code]link[/code] can be travelled in both directions.
 			</description>
 		</method>
-		<method name="link_set_end_location" qualifiers="const">
+		<method name="link_set_end_location">
 			<return type="void" />
 			<param index="0" name="link" type="RID" />
 			<param index="1" name="location" type="Vector2" />
@@ -211,7 +211,7 @@
 				Sets the exit location for the [code]link[/code].
 			</description>
 		</method>
-		<method name="link_set_enter_cost" qualifiers="const">
+		<method name="link_set_enter_cost">
 			<return type="void" />
 			<param index="0" name="link" type="RID" />
 			<param index="1" name="enter_cost" type="float" />
@@ -219,7 +219,7 @@
 				Sets the [code]enter_cost[/code] for this [code]link[/code].
 			</description>
 		</method>
-		<method name="link_set_map" qualifiers="const">
+		<method name="link_set_map">
 			<return type="void" />
 			<param index="0" name="link" type="RID" />
 			<param index="1" name="map" type="RID" />
@@ -227,7 +227,7 @@
 				Sets the navigation map [RID] for the link.
 			</description>
 		</method>
-		<method name="link_set_navigation_layers" qualifiers="const">
+		<method name="link_set_navigation_layers">
 			<return type="void" />
 			<param index="0" name="link" type="RID" />
 			<param index="1" name="navigation_layers" type="int" />
@@ -235,7 +235,7 @@
 				Set the links's navigation layers. This allows selecting links from a path request (when using [method NavigationServer2D.map_get_path]).
 			</description>
 		</method>
-		<method name="link_set_owner_id" qualifiers="const">
+		<method name="link_set_owner_id">
 			<return type="void" />
 			<param index="0" name="link" type="RID" />
 			<param index="1" name="owner_id" type="int" />
@@ -243,7 +243,7 @@
 				Set the [code]ObjectID[/code] of the object which manages this link.
 			</description>
 		</method>
-		<method name="link_set_start_location" qualifiers="const">
+		<method name="link_set_start_location">
 			<return type="void" />
 			<param index="0" name="link" type="RID" />
 			<param index="1" name="location" type="Vector2" />
@@ -251,7 +251,7 @@
 				Sets the entry location for this [code]link[/code].
 			</description>
 		</method>
-		<method name="link_set_travel_cost" qualifiers="const">
+		<method name="link_set_travel_cost">
 			<return type="void" />
 			<param index="0" name="link" type="RID" />
 			<param index="1" name="travel_cost" type="float" />
@@ -259,7 +259,7 @@
 				Sets the [code]travel_cost[/code] for this [code]link[/code].
 			</description>
 		</method>
-		<method name="map_create" qualifiers="const">
+		<method name="map_create">
 			<return type="RID" />
 			<description>
 				Create a new map.
@@ -351,7 +351,7 @@
 				Returns true if the map is active.
 			</description>
 		</method>
-		<method name="map_set_active" qualifiers="const">
+		<method name="map_set_active">
 			<return type="void" />
 			<param index="0" name="map" type="RID" />
 			<param index="1" name="active" type="bool" />
@@ -359,7 +359,7 @@
 				Sets the map active.
 			</description>
 		</method>
-		<method name="map_set_cell_size" qualifiers="const">
+		<method name="map_set_cell_size">
 			<return type="void" />
 			<param index="0" name="map" type="RID" />
 			<param index="1" name="cell_size" type="float" />
@@ -367,7 +367,7 @@
 				Set the map cell size used to weld the navigation mesh polygons.
 			</description>
 		</method>
-		<method name="map_set_edge_connection_margin" qualifiers="const">
+		<method name="map_set_edge_connection_margin">
 			<return type="void" />
 			<param index="0" name="map" type="RID" />
 			<param index="1" name="margin" type="float" />
@@ -375,7 +375,7 @@
 				Set the map edge connection margin used to weld the compatible region edges.
 			</description>
 		</method>
-		<method name="map_set_link_connection_radius" qualifiers="const">
+		<method name="map_set_link_connection_radius">
 			<return type="void" />
 			<param index="0" name="map" type="RID" />
 			<param index="1" name="radius" type="float" />
@@ -391,7 +391,7 @@
 				Queries a path in a given navigation map. Start and target position and other parameters are defined through [NavigationPathQueryParameters2D]. Updates the provided [NavigationPathQueryResult2D] result object with the path among other results requested by the query.
 			</description>
 		</method>
-		<method name="region_create" qualifiers="const">
+		<method name="region_create">
 			<return type="RID" />
 			<description>
 				Creates a new region.
@@ -465,7 +465,7 @@
 				[b]Note:[/b] If navigation meshes from different navigation regions overlap (which should be avoided in general) the result might not be what is expected.
 			</description>
 		</method>
-		<method name="region_set_enter_cost" qualifiers="const">
+		<method name="region_set_enter_cost">
 			<return type="void" />
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="enter_cost" type="float" />
@@ -473,7 +473,7 @@
 				Sets the [param enter_cost] for this [param region].
 			</description>
 		</method>
-		<method name="region_set_map" qualifiers="const">
+		<method name="region_set_map">
 			<return type="void" />
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="map" type="RID" />
@@ -481,7 +481,7 @@
 				Sets the map for the region.
 			</description>
 		</method>
-		<method name="region_set_navigation_layers" qualifiers="const">
+		<method name="region_set_navigation_layers">
 			<return type="void" />
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="navigation_layers" type="int" />
@@ -489,7 +489,7 @@
 				Set the region's navigation layers. This allows selecting regions from a path request (when using [method NavigationServer2D.map_get_path]).
 			</description>
 		</method>
-		<method name="region_set_navigation_polygon" qualifiers="const">
+		<method name="region_set_navigation_polygon">
 			<return type="void" />
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="navigation_polygon" type="NavigationPolygon" />
@@ -497,7 +497,7 @@
 				Sets the [param navigation_polygon] for the region.
 			</description>
 		</method>
-		<method name="region_set_owner_id" qualifiers="const">
+		<method name="region_set_owner_id">
 			<return type="void" />
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="owner_id" type="int" />
@@ -505,7 +505,7 @@
 				Set the [code]ObjectID[/code] of the object which manages this region.
 			</description>
 		</method>
-		<method name="region_set_transform" qualifiers="const">
+		<method name="region_set_transform">
 			<return type="void" />
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="transform" type="Transform2D" />
@@ -513,7 +513,7 @@
 				Sets the global transformation for the region.
 			</description>
 		</method>
-		<method name="region_set_travel_cost" qualifiers="const">
+		<method name="region_set_travel_cost">
 			<return type="void" />
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="travel_cost" type="float" />

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -17,7 +17,7 @@
 		<link title="3D Navmesh Demo">https://godotengine.org/asset-library/asset/124</link>
 	</tutorials>
 	<methods>
-		<method name="agent_create" qualifiers="const">
+		<method name="agent_create">
 			<return type="RID" />
 			<description>
 				Creates the agent.
@@ -37,7 +37,7 @@
 				Returns true if the map got changed the previous frame.
 			</description>
 		</method>
-		<method name="agent_set_callback" qualifiers="const">
+		<method name="agent_set_callback">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="object_id" type="int" />
@@ -48,7 +48,7 @@
 				[b]Note:[/b] Created callbacks are always processed independently of the SceneTree state as long as the agent is on a navigation map and not freed. To disable the dispatch of a callback from an agent use [method agent_set_callback] again with a [code]0[/code] ObjectID as the [param object_id].
 			</description>
 		</method>
-		<method name="agent_set_map" qualifiers="const">
+		<method name="agent_set_map">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="map" type="RID" />
@@ -56,7 +56,7 @@
 				Puts the agent in the map.
 			</description>
 		</method>
-		<method name="agent_set_max_neighbors" qualifiers="const">
+		<method name="agent_set_max_neighbors">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="count" type="int" />
@@ -64,7 +64,7 @@
 				Sets the maximum number of other agents the agent takes into account in the navigation. The larger this number, the longer the running time of the simulation. If the number is too low, the simulation will not be safe.
 			</description>
 		</method>
-		<method name="agent_set_max_speed" qualifiers="const">
+		<method name="agent_set_max_speed">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="max_speed" type="float" />
@@ -72,7 +72,7 @@
 				Sets the maximum speed of the agent. Must be positive.
 			</description>
 		</method>
-		<method name="agent_set_neighbor_distance" qualifiers="const">
+		<method name="agent_set_neighbor_distance">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="distance" type="float" />
@@ -80,7 +80,7 @@
 				Sets the maximum distance to other agents this agent takes into account in the navigation. The larger this number, the longer the running time of the simulation. If the number is too low, the simulation will not be safe.
 			</description>
 		</method>
-		<method name="agent_set_position" qualifiers="const">
+		<method name="agent_set_position">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="position" type="Vector3" />
@@ -88,7 +88,7 @@
 				Sets the position of the agent in world space.
 			</description>
 		</method>
-		<method name="agent_set_radius" qualifiers="const">
+		<method name="agent_set_radius">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="radius" type="float" />
@@ -96,7 +96,7 @@
 				Sets the radius of the agent.
 			</description>
 		</method>
-		<method name="agent_set_target_velocity" qualifiers="const">
+		<method name="agent_set_target_velocity">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="target_velocity" type="Vector3" />
@@ -104,7 +104,7 @@
 				Sets the new target velocity.
 			</description>
 		</method>
-		<method name="agent_set_time_horizon" qualifiers="const">
+		<method name="agent_set_time_horizon">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="time" type="float" />
@@ -112,7 +112,7 @@
 				The minimal amount of time for which the agent's velocities that are computed by the simulation are safe with respect to other agents. The larger this number, the sooner this agent will respond to the presence of other agents, but the less freedom this agent has in choosing its velocities. Must be positive.
 			</description>
 		</method>
-		<method name="agent_set_velocity" qualifiers="const">
+		<method name="agent_set_velocity">
 			<return type="void" />
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="velocity" type="Vector3" />
@@ -120,7 +120,7 @@
 				Sets the current velocity of the agent.
 			</description>
 		</method>
-		<method name="free_rid" qualifiers="const">
+		<method name="free_rid">
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
 			<description>
@@ -133,7 +133,7 @@
 				Returns all created navigation map [RID]s on the NavigationServer. This returns both 2D and 3D created navigation maps as there is technically no distinction between them.
 			</description>
 		</method>
-		<method name="link_create" qualifiers="const">
+		<method name="link_create">
 			<return type="RID" />
 			<description>
 				Create a new link between two locations on a map.
@@ -195,7 +195,7 @@
 				Returns whether this [code]link[/code] can be travelled in both directions.
 			</description>
 		</method>
-		<method name="link_set_bidirectional" qualifiers="const">
+		<method name="link_set_bidirectional">
 			<return type="void" />
 			<param index="0" name="link" type="RID" />
 			<param index="1" name="bidirectional" type="bool" />
@@ -203,7 +203,7 @@
 				Sets whether this [code]link[/code] can be travelled in both directions.
 			</description>
 		</method>
-		<method name="link_set_end_location" qualifiers="const">
+		<method name="link_set_end_location">
 			<return type="void" />
 			<param index="0" name="link" type="RID" />
 			<param index="1" name="location" type="Vector3" />
@@ -211,7 +211,7 @@
 				Sets the exit location for the [code]link[/code].
 			</description>
 		</method>
-		<method name="link_set_enter_cost" qualifiers="const">
+		<method name="link_set_enter_cost">
 			<return type="void" />
 			<param index="0" name="link" type="RID" />
 			<param index="1" name="enter_cost" type="float" />
@@ -219,7 +219,7 @@
 				Sets the [code]enter_cost[/code] for this [code]link[/code].
 			</description>
 		</method>
-		<method name="link_set_map" qualifiers="const">
+		<method name="link_set_map">
 			<return type="void" />
 			<param index="0" name="link" type="RID" />
 			<param index="1" name="map" type="RID" />
@@ -227,7 +227,7 @@
 				Sets the navigation map [RID] for the link.
 			</description>
 		</method>
-		<method name="link_set_navigation_layers" qualifiers="const">
+		<method name="link_set_navigation_layers">
 			<return type="void" />
 			<param index="0" name="link" type="RID" />
 			<param index="1" name="navigation_layers" type="int" />
@@ -235,7 +235,7 @@
 				Set the links's navigation layers. This allows selecting links from a path request (when using [method NavigationServer3D.map_get_path]).
 			</description>
 		</method>
-		<method name="link_set_owner_id" qualifiers="const">
+		<method name="link_set_owner_id">
 			<return type="void" />
 			<param index="0" name="link" type="RID" />
 			<param index="1" name="owner_id" type="int" />
@@ -243,7 +243,7 @@
 				Set the [code]ObjectID[/code] of the object which manages this link.
 			</description>
 		</method>
-		<method name="link_set_start_location" qualifiers="const">
+		<method name="link_set_start_location">
 			<return type="void" />
 			<param index="0" name="link" type="RID" />
 			<param index="1" name="location" type="Vector3" />
@@ -251,7 +251,7 @@
 				Sets the entry location for this [code]link[/code].
 			</description>
 		</method>
-		<method name="link_set_travel_cost" qualifiers="const">
+		<method name="link_set_travel_cost">
 			<return type="void" />
 			<param index="0" name="link" type="RID" />
 			<param index="1" name="travel_cost" type="float" />
@@ -259,7 +259,7 @@
 				Sets the [code]travel_cost[/code] for this [code]link[/code].
 			</description>
 		</method>
-		<method name="map_create" qualifiers="const">
+		<method name="map_create">
 			<return type="RID" />
 			<description>
 				Create a new map.
@@ -376,7 +376,7 @@
 				Returns true if the map is active.
 			</description>
 		</method>
-		<method name="map_set_active" qualifiers="const">
+		<method name="map_set_active">
 			<return type="void" />
 			<param index="0" name="map" type="RID" />
 			<param index="1" name="active" type="bool" />
@@ -384,7 +384,7 @@
 				Sets the map active.
 			</description>
 		</method>
-		<method name="map_set_cell_size" qualifiers="const">
+		<method name="map_set_cell_size">
 			<return type="void" />
 			<param index="0" name="map" type="RID" />
 			<param index="1" name="cell_size" type="float" />
@@ -392,7 +392,7 @@
 				Set the map cell size used to weld the navigation mesh polygons.
 			</description>
 		</method>
-		<method name="map_set_edge_connection_margin" qualifiers="const">
+		<method name="map_set_edge_connection_margin">
 			<return type="void" />
 			<param index="0" name="map" type="RID" />
 			<param index="1" name="margin" type="float" />
@@ -400,7 +400,7 @@
 				Set the map edge connection margin used to weld the compatible region edges.
 			</description>
 		</method>
-		<method name="map_set_link_connection_radius" qualifiers="const">
+		<method name="map_set_link_connection_radius">
 			<return type="void" />
 			<param index="0" name="map" type="RID" />
 			<param index="1" name="radius" type="float" />
@@ -408,7 +408,7 @@
 				Set the map's link connection radius used to connect links to navigation polygons.
 			</description>
 		</method>
-		<method name="map_set_up" qualifiers="const">
+		<method name="map_set_up">
 			<return type="void" />
 			<param index="0" name="map" type="RID" />
 			<param index="1" name="up" type="Vector3" />
@@ -433,7 +433,7 @@
 				Queries a path in a given navigation map. Start and target position and other parameters are defined through [NavigationPathQueryParameters3D]. Updates the provided [NavigationPathQueryResult3D] result object with the path among other results requested by the query.
 			</description>
 		</method>
-		<method name="region_bake_navigation_mesh" qualifiers="const">
+		<method name="region_bake_navigation_mesh">
 			<return type="void" />
 			<param index="0" name="navigation_mesh" type="NavigationMesh" />
 			<param index="1" name="root_node" type="Node" />
@@ -441,7 +441,7 @@
 				Bakes the [param navigation_mesh] with bake source geometry collected starting from the [param root_node].
 			</description>
 		</method>
-		<method name="region_create" qualifiers="const">
+		<method name="region_create">
 			<return type="RID" />
 			<description>
 				Creates a new region.
@@ -515,7 +515,7 @@
 				[b]Note:[/b] If navigation meshes from different navigation regions overlap (which should be avoided in general) the result might not be what is expected.
 			</description>
 		</method>
-		<method name="region_set_enter_cost" qualifiers="const">
+		<method name="region_set_enter_cost">
 			<return type="void" />
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="enter_cost" type="float" />
@@ -523,7 +523,7 @@
 				Sets the [param enter_cost] for this [param region].
 			</description>
 		</method>
-		<method name="region_set_map" qualifiers="const">
+		<method name="region_set_map">
 			<return type="void" />
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="map" type="RID" />
@@ -531,7 +531,7 @@
 				Sets the map for the region.
 			</description>
 		</method>
-		<method name="region_set_navigation_layers" qualifiers="const">
+		<method name="region_set_navigation_layers">
 			<return type="void" />
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="navigation_layers" type="int" />
@@ -539,7 +539,7 @@
 				Set the region's navigation layers. This allows selecting regions from a path request (when using [method NavigationServer3D.map_get_path]).
 			</description>
 		</method>
-		<method name="region_set_navigation_mesh" qualifiers="const">
+		<method name="region_set_navigation_mesh">
 			<return type="void" />
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="navigation_mesh" type="NavigationMesh" />
@@ -547,7 +547,7 @@
 				Sets the navigation mesh for the region.
 			</description>
 		</method>
-		<method name="region_set_owner_id" qualifiers="const">
+		<method name="region_set_owner_id">
 			<return type="void" />
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="owner_id" type="int" />
@@ -555,7 +555,7 @@
 				Set the [code]ObjectID[/code] of the object which manages this region.
 			</description>
 		</method>
-		<method name="region_set_transform" qualifiers="const">
+		<method name="region_set_transform">
 			<return type="void" />
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="transform" type="Transform3D" />
@@ -563,7 +563,7 @@
 				Sets the global transformation for the region.
 			</description>
 		</method>
-		<method name="region_set_travel_cost" qualifiers="const">
+		<method name="region_set_travel_cost">
 			<return type="void" />
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="travel_cost" type="float" />
@@ -571,7 +571,7 @@
 				Sets the [param travel_cost] for this [param region].
 			</description>
 		</method>
-		<method name="set_active" qualifiers="const">
+		<method name="set_active">
 			<return type="void" />
 			<param index="0" name="active" type="bool" />
 			<description>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -493,16 +493,16 @@ void EditorNode::_update_from_settings() {
 	tree->set_debug_collision_contact_color(GLOBAL_GET("debug/shapes/collision/contact_color"));
 
 #ifdef DEBUG_ENABLED
-	NavigationServer3D::get_singleton_mut()->set_debug_navigation_edge_connection_color(GLOBAL_GET("debug/shapes/navigation/edge_connection_color"));
-	NavigationServer3D::get_singleton_mut()->set_debug_navigation_geometry_edge_color(GLOBAL_GET("debug/shapes/navigation/geometry_edge_color"));
-	NavigationServer3D::get_singleton_mut()->set_debug_navigation_geometry_face_color(GLOBAL_GET("debug/shapes/navigation/geometry_face_color"));
-	NavigationServer3D::get_singleton_mut()->set_debug_navigation_geometry_edge_disabled_color(GLOBAL_GET("debug/shapes/navigation/geometry_edge_disabled_color"));
-	NavigationServer3D::get_singleton_mut()->set_debug_navigation_geometry_face_disabled_color(GLOBAL_GET("debug/shapes/navigation/geometry_face_disabled_color"));
-	NavigationServer3D::get_singleton_mut()->set_debug_navigation_enable_edge_connections(GLOBAL_GET("debug/shapes/navigation/enable_edge_connections"));
-	NavigationServer3D::get_singleton_mut()->set_debug_navigation_enable_edge_connections_xray(GLOBAL_GET("debug/shapes/navigation/enable_edge_connections_xray"));
-	NavigationServer3D::get_singleton_mut()->set_debug_navigation_enable_edge_lines(GLOBAL_GET("debug/shapes/navigation/enable_edge_lines"));
-	NavigationServer3D::get_singleton_mut()->set_debug_navigation_enable_edge_lines_xray(GLOBAL_GET("debug/shapes/navigation/enable_edge_lines_xray"));
-	NavigationServer3D::get_singleton_mut()->set_debug_navigation_enable_geometry_face_random_color(GLOBAL_GET("debug/shapes/navigation/enable_geometry_face_random_color"));
+	NavigationServer3D::get_singleton()->set_debug_navigation_edge_connection_color(GLOBAL_GET("debug/shapes/navigation/edge_connection_color"));
+	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_edge_color(GLOBAL_GET("debug/shapes/navigation/geometry_edge_color"));
+	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_face_color(GLOBAL_GET("debug/shapes/navigation/geometry_face_color"));
+	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_edge_disabled_color(GLOBAL_GET("debug/shapes/navigation/geometry_edge_disabled_color"));
+	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_face_disabled_color(GLOBAL_GET("debug/shapes/navigation/geometry_face_disabled_color"));
+	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_connections(GLOBAL_GET("debug/shapes/navigation/enable_edge_connections"));
+	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_connections_xray(GLOBAL_GET("debug/shapes/navigation/enable_edge_connections_xray"));
+	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_lines(GLOBAL_GET("debug/shapes/navigation/enable_edge_lines"));
+	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_lines_xray(GLOBAL_GET("debug/shapes/navigation/enable_edge_lines_xray"));
+	NavigationServer3D::get_singleton()->set_debug_navigation_enable_geometry_face_random_color(GLOBAL_GET("debug/shapes/navigation/enable_geometry_face_random_color"));
 #endif // DEBUG_ENABLED
 }
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2607,7 +2607,7 @@ bool Main::start() {
 		if (debug_navigation) {
 			sml->set_debug_navigation_hint(true);
 			NavigationServer3D::get_singleton()->set_active(true);
-			NavigationServer3D::get_singleton_mut()->set_debug_enabled(true);
+			NavigationServer3D::get_singleton()->set_debug_enabled(true);
 		}
 #endif
 
@@ -3032,7 +3032,7 @@ bool Main::iteration() {
 			break;
 		}
 
-		NavigationServer3D::get_singleton_mut()->process(physics_step * time_scale);
+		NavigationServer3D::get_singleton()->process(physics_step * time_scale);
 
 		message_queue->flush();
 

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -1310,8 +1310,8 @@ RID GridMap::get_bake_mesh_instance(int p_idx) {
 GridMap::GridMap() {
 	set_notify_transform(true);
 #ifdef DEBUG_ENABLED
-	NavigationServer3D::get_singleton_mut()->connect("map_changed", callable_mp(this, &GridMap::_navigation_map_changed));
-	NavigationServer3D::get_singleton_mut()->connect("navigation_debug_changed", callable_mp(this, &GridMap::_update_navigation_debug_edge_connections));
+	NavigationServer3D::get_singleton()->connect("map_changed", callable_mp(this, &GridMap::_navigation_map_changed));
+	NavigationServer3D::get_singleton()->connect("navigation_debug_changed", callable_mp(this, &GridMap::_update_navigation_debug_edge_connections));
 #endif // DEBUG_ENABLED
 }
 
@@ -1338,8 +1338,8 @@ GridMap::~GridMap() {
 
 	clear();
 #ifdef DEBUG_ENABLED
-	NavigationServer3D::get_singleton_mut()->disconnect("map_changed", callable_mp(this, &GridMap::_navigation_map_changed));
-	NavigationServer3D::get_singleton_mut()->disconnect("navigation_debug_changed", callable_mp(this, &GridMap::_update_navigation_debug_edge_connections));
+	NavigationServer3D::get_singleton()->disconnect("map_changed", callable_mp(this, &GridMap::_navigation_map_changed));
+	NavigationServer3D::get_singleton()->disconnect("navigation_debug_changed", callable_mp(this, &GridMap::_update_navigation_debug_edge_connections));
 #endif // DEBUG_ENABLED
 }
 
@@ -1421,7 +1421,7 @@ void GridMap::_update_octant_navigation_debug_edge_connections_mesh(const Octant
 		return;
 	}
 
-	Ref<StandardMaterial3D> edge_connections_material = NavigationServer3D::get_singleton_mut()->get_debug_navigation_edge_connections_material();
+	Ref<StandardMaterial3D> edge_connections_material = NavigationServer3D::get_singleton()->get_debug_navigation_edge_connections_material();
 
 	Array mesh_array;
 	mesh_array.resize(Mesh::ARRAY_MAX);

--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -52,7 +52,7 @@ using namespace NavigationUtilities;
 			server->MERGE(_cmd_, F_NAME)(d_0);                      \
 		}                                                           \
 	};                                                              \
-	void GodotNavigationServer::F_NAME(T_0 D_0) const {             \
+	void GodotNavigationServer::F_NAME(T_0 D_0) {                   \
 		auto cmd = memnew(MERGE(F_NAME, _command)(                  \
 				D_0));                                              \
 		add_command(cmd);                                           \
@@ -73,7 +73,7 @@ using namespace NavigationUtilities;
 			server->MERGE(_cmd_, F_NAME)(d_0, d_1);                 \
 		}                                                           \
 	};                                                              \
-	void GodotNavigationServer::F_NAME(T_0 D_0, T_1 D_1) const {    \
+	void GodotNavigationServer::F_NAME(T_0 D_0, T_1 D_1) {          \
 		auto cmd = memnew(MERGE(F_NAME, _command)(                  \
 				D_0,                                                \
 				D_1));                                              \
@@ -81,34 +81,34 @@ using namespace NavigationUtilities;
 	}                                                               \
 	void GodotNavigationServer::MERGE(_cmd_, F_NAME)(T_0 D_0, T_1 D_1)
 
-#define COMMAND_4(F_NAME, T_0, D_0, T_1, D_1, T_2, D_2, T_3, D_3)                  \
-	struct MERGE(F_NAME, _command) : public SetCommand {                           \
-		T_0 d_0;                                                                   \
-		T_1 d_1;                                                                   \
-		T_2 d_2;                                                                   \
-		T_3 d_3;                                                                   \
-		MERGE(F_NAME, _command)                                                    \
-		(                                                                          \
-				T_0 p_d_0,                                                         \
-				T_1 p_d_1,                                                         \
-				T_2 p_d_2,                                                         \
-				T_3 p_d_3) :                                                       \
-				d_0(p_d_0),                                                        \
-				d_1(p_d_1),                                                        \
-				d_2(p_d_2),                                                        \
-				d_3(p_d_3) {}                                                      \
-		virtual void exec(GodotNavigationServer *server) override {                \
-			server->MERGE(_cmd_, F_NAME)(d_0, d_1, d_2, d_3);                      \
-		}                                                                          \
-	};                                                                             \
-	void GodotNavigationServer::F_NAME(T_0 D_0, T_1 D_1, T_2 D_2, T_3 D_3) const { \
-		auto cmd = memnew(MERGE(F_NAME, _command)(                                 \
-				D_0,                                                               \
-				D_1,                                                               \
-				D_2,                                                               \
-				D_3));                                                             \
-		add_command(cmd);                                                          \
-	}                                                                              \
+#define COMMAND_4(F_NAME, T_0, D_0, T_1, D_1, T_2, D_2, T_3, D_3)            \
+	struct MERGE(F_NAME, _command) : public SetCommand {                     \
+		T_0 d_0;                                                             \
+		T_1 d_1;                                                             \
+		T_2 d_2;                                                             \
+		T_3 d_3;                                                             \
+		MERGE(F_NAME, _command)                                              \
+		(                                                                    \
+				T_0 p_d_0,                                                   \
+				T_1 p_d_1,                                                   \
+				T_2 p_d_2,                                                   \
+				T_3 p_d_3) :                                                 \
+				d_0(p_d_0),                                                  \
+				d_1(p_d_1),                                                  \
+				d_2(p_d_2),                                                  \
+				d_3(p_d_3) {}                                                \
+		virtual void exec(GodotNavigationServer *server) override {          \
+			server->MERGE(_cmd_, F_NAME)(d_0, d_1, d_2, d_3);                \
+		}                                                                    \
+	};                                                                       \
+	void GodotNavigationServer::F_NAME(T_0 D_0, T_1 D_1, T_2 D_2, T_3 D_3) { \
+		auto cmd = memnew(MERGE(F_NAME, _command)(                           \
+				D_0,                                                         \
+				D_1,                                                         \
+				D_2,                                                         \
+				D_3));                                                       \
+		add_command(cmd);                                                    \
+	}                                                                        \
 	void GodotNavigationServer::MERGE(_cmd_, F_NAME)(T_0 D_0, T_1 D_1, T_2 D_2, T_3 D_3)
 
 GodotNavigationServer::GodotNavigationServer() {}
@@ -117,12 +117,10 @@ GodotNavigationServer::~GodotNavigationServer() {
 	flush_queries();
 }
 
-void GodotNavigationServer::add_command(SetCommand *command) const {
-	GodotNavigationServer *mut_this = const_cast<GodotNavigationServer *>(this);
-	{
-		MutexLock lock(commands_mutex);
-		mut_this->commands.push_back(command);
-	}
+void GodotNavigationServer::add_command(SetCommand *command) {
+	MutexLock lock(commands_mutex);
+
+	commands.push_back(command);
 }
 
 TypedArray<RID> GodotNavigationServer::get_maps() const {
@@ -137,12 +135,12 @@ TypedArray<RID> GodotNavigationServer::get_maps() const {
 	return all_map_rids;
 }
 
-RID GodotNavigationServer::map_create() const {
-	GodotNavigationServer *mut_this = const_cast<GodotNavigationServer *>(this);
-	MutexLock lock(mut_this->operations_mutex);
+RID GodotNavigationServer::map_create() {
+	MutexLock lock(operations_mutex);
+
 	RID rid = map_owner.make_rid();
-	NavMap *space = map_owner.get_or_null(rid);
-	space->set_self(rid);
+	NavMap *map = map_owner.get_or_null(rid);
+	map->set_self(rid);
 	return rid;
 }
 
@@ -279,8 +277,10 @@ TypedArray<RID> GodotNavigationServer::map_get_regions(RID p_map) const {
 	TypedArray<RID> regions_rids;
 	const NavMap *map = map_owner.get_or_null(p_map);
 	ERR_FAIL_COND_V(map == nullptr, regions_rids);
+
 	const LocalVector<NavRegion *> regions = map->get_regions();
 	regions_rids.resize(regions.size());
+
 	for (uint32_t i = 0; i < regions.size(); i++) {
 		regions_rids[i] = regions[i]->get_self();
 	}
@@ -291,8 +291,10 @@ TypedArray<RID> GodotNavigationServer::map_get_agents(RID p_map) const {
 	TypedArray<RID> agents_rids;
 	const NavMap *map = map_owner.get_or_null(p_map);
 	ERR_FAIL_COND_V(map == nullptr, agents_rids);
+
 	const LocalVector<RvoAgent *> agents = map->get_agents();
 	agents_rids.resize(agents.size());
+
 	for (uint32_t i = 0; i < agents.size(); i++) {
 		agents_rids[i] = agents[i]->get_self();
 	}
@@ -302,6 +304,7 @@ TypedArray<RID> GodotNavigationServer::map_get_agents(RID p_map) const {
 RID GodotNavigationServer::region_get_map(RID p_region) const {
 	NavRegion *region = region_owner.get_or_null(p_region);
 	ERR_FAIL_COND_V(region == nullptr, RID());
+
 	if (region->get_map()) {
 		return region->get_map()->get_self();
 	}
@@ -311,15 +314,16 @@ RID GodotNavigationServer::region_get_map(RID p_region) const {
 RID GodotNavigationServer::agent_get_map(RID p_agent) const {
 	RvoAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_COND_V(agent == nullptr, RID());
+
 	if (agent->get_map()) {
 		return agent->get_map()->get_self();
 	}
 	return RID();
 }
 
-RID GodotNavigationServer::region_create() const {
-	GodotNavigationServer *mut_this = const_cast<GodotNavigationServer *>(this);
-	MutexLock lock(mut_this->operations_mutex);
+RID GodotNavigationServer::region_create() {
+	MutexLock lock(operations_mutex);
+
 	RID rid = region_owner.make_rid();
 	NavRegion *reg = region_owner.get_or_null(rid);
 	reg->set_self(rid);
@@ -402,6 +406,7 @@ ObjectID GodotNavigationServer::region_get_owner_id(RID p_region) const {
 bool GodotNavigationServer::region_owns_point(RID p_region, const Vector3 &p_point) const {
 	const NavRegion *region = region_owner.get_or_null(p_region);
 	ERR_FAIL_COND_V(region == nullptr, false);
+
 	if (region->get_map()) {
 		RID closest_point_owner = map_get_closest_point_owner(region->get_map()->get_self(), p_point);
 		return closest_point_owner == region->get_self();
@@ -430,7 +435,7 @@ COMMAND_2(region_set_navigation_mesh, RID, p_region, Ref<NavigationMesh>, p_navi
 	region->set_mesh(p_navigation_mesh);
 }
 
-void GodotNavigationServer::region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) const {
+void GodotNavigationServer::region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) {
 	ERR_FAIL_COND(p_navigation_mesh.is_null());
 	ERR_FAIL_COND(p_root_node == nullptr);
 
@@ -461,9 +466,9 @@ Vector3 GodotNavigationServer::region_get_connection_pathway_end(RID p_region, i
 	return region->get_connection_pathway_end(p_connection_id);
 }
 
-RID GodotNavigationServer::link_create() const {
-	GodotNavigationServer *mut_this = const_cast<GodotNavigationServer *>(this);
-	MutexLock lock(mut_this->operations_mutex);
+RID GodotNavigationServer::link_create() {
+	MutexLock lock(operations_mutex);
+
 	RID rid = link_owner.make_rid();
 	NavLink *link = link_owner.get_or_null(rid);
 	link->set_self(rid);
@@ -600,9 +605,9 @@ ObjectID GodotNavigationServer::link_get_owner_id(RID p_link) const {
 	return link->get_owner_id();
 }
 
-RID GodotNavigationServer::agent_create() const {
-	GodotNavigationServer *mut_this = const_cast<GodotNavigationServer *>(this);
-	MutexLock lock(mut_this->operations_mutex);
+RID GodotNavigationServer::agent_create() {
+	MutexLock lock(operations_mutex);
+
 	RID rid = agent_owner.make_rid();
 	RvoAgent *agent = agent_owner.get_or_null(rid);
 	agent->set_self(rid);
@@ -789,10 +794,10 @@ COMMAND_1(free, RID, p_object) {
 	}
 }
 
-void GodotNavigationServer::set_active(bool p_active) const {
-	GodotNavigationServer *mut_this = const_cast<GodotNavigationServer *>(this);
-	MutexLock lock(mut_this->operations_mutex);
-	mut_this->active = p_active;
+void GodotNavigationServer::set_active(bool p_active) {
+	MutexLock lock(operations_mutex);
+
+	active = p_active;
 }
 
 void GodotNavigationServer::flush_queries() {
@@ -800,6 +805,7 @@ void GodotNavigationServer::flush_queries() {
 	// even with mutable functions.
 	MutexLock lock(commands_mutex);
 	MutexLock lock2(operations_mutex);
+
 	for (size_t i(0); i < commands.size(); i++) {
 		commands[i]->exec(this);
 		memdelete(commands[i]);

--- a/modules/navigation/godot_navigation_server.h
+++ b/modules/navigation/godot_navigation_server.h
@@ -46,16 +46,16 @@
 #define MERGE_INTERNAL(A, B) A##B
 #define MERGE(A, B) MERGE_INTERNAL(A, B)
 
-#define COMMAND_1(F_NAME, T_0, D_0)              \
-	virtual void F_NAME(T_0 D_0) const override; \
+#define COMMAND_1(F_NAME, T_0, D_0)        \
+	virtual void F_NAME(T_0 D_0) override; \
 	void MERGE(_cmd_, F_NAME)(T_0 D_0)
 
-#define COMMAND_2(F_NAME, T_0, D_0, T_1, D_1)             \
-	virtual void F_NAME(T_0 D_0, T_1 D_1) const override; \
+#define COMMAND_2(F_NAME, T_0, D_0, T_1, D_1)       \
+	virtual void F_NAME(T_0 D_0, T_1 D_1) override; \
 	void MERGE(_cmd_, F_NAME)(T_0 D_0, T_1 D_1)
 
-#define COMMAND_4_DEF(F_NAME, T_0, D_0, T_1, D_1, T_2, D_2, T_3, D_3, D_3_DEF)        \
-	virtual void F_NAME(T_0 D_0, T_1 D_1, T_2 D_2, T_3 D_3 = D_3_DEF) const override; \
+#define COMMAND_4_DEF(F_NAME, T_0, D_0, T_1, D_1, T_2, D_2, T_3, D_3, D_3_DEF)  \
+	virtual void F_NAME(T_0 D_0, T_1 D_1, T_2 D_2, T_3 D_3 = D_3_DEF) override; \
 	void MERGE(_cmd_, F_NAME)(T_0 D_0, T_1 D_1, T_2 D_2, T_3 D_3)
 
 class GodotNavigationServer;
@@ -85,11 +85,11 @@ public:
 	GodotNavigationServer();
 	virtual ~GodotNavigationServer();
 
-	void add_command(SetCommand *command) const;
+	void add_command(SetCommand *command);
 
 	virtual TypedArray<RID> get_maps() const override;
 
-	virtual RID map_create() const override;
+	virtual RID map_create() override;
 	COMMAND_2(map_set_active, RID, p_map, bool, p_active);
 	virtual bool map_is_active(RID p_map) const override;
 
@@ -118,7 +118,7 @@ public:
 
 	virtual void map_force_update(RID p_map) override;
 
-	virtual RID region_create() const override;
+	virtual RID region_create() override;
 
 	COMMAND_2(region_set_enter_cost, RID, p_region, real_t, p_enter_cost);
 	virtual real_t region_get_enter_cost(RID p_region) const override;
@@ -136,12 +136,12 @@ public:
 	virtual uint32_t region_get_navigation_layers(RID p_region) const override;
 	COMMAND_2(region_set_transform, RID, p_region, Transform3D, p_transform);
 	COMMAND_2(region_set_navigation_mesh, RID, p_region, Ref<NavigationMesh>, p_navigation_mesh);
-	virtual void region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) const override;
+	virtual void region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) override;
 	virtual int region_get_connections_count(RID p_region) const override;
 	virtual Vector3 region_get_connection_pathway_start(RID p_region, int p_connection_id) const override;
 	virtual Vector3 region_get_connection_pathway_end(RID p_region, int p_connection_id) const override;
 
-	virtual RID link_create() const override;
+	virtual RID link_create() override;
 	COMMAND_2(link_set_map, RID, p_link, RID, p_map);
 	virtual RID link_get_map(RID p_link) const override;
 	COMMAND_2(link_set_bidirectional, RID, p_link, bool, p_bidirectional);
@@ -159,7 +159,7 @@ public:
 	COMMAND_2(link_set_owner_id, RID, p_link, ObjectID, p_owner_id);
 	virtual ObjectID link_get_owner_id(RID p_link) const override;
 
-	virtual RID agent_create() const override;
+	virtual RID agent_create() override;
 	COMMAND_2(agent_set_map, RID, p_agent, RID, p_map);
 	virtual RID agent_get_map(RID p_agent) const override;
 	COMMAND_2(agent_set_neighbor_distance, RID, p_agent, real_t, p_distance);
@@ -176,7 +176,7 @@ public:
 
 	COMMAND_1(free, RID, p_object);
 
-	virtual void set_active(bool p_active) const override;
+	virtual void set_active(bool p_active) override;
 
 	void flush_queries();
 	virtual void process(real_t p_delta_time) override;

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -48,10 +48,10 @@ void NavigationRegion2D::set_enabled(bool p_enabled) {
 
 	if (!enabled) {
 		NavigationServer2D::get_singleton()->region_set_map(region, RID());
-		NavigationServer2D::get_singleton_mut()->disconnect("map_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
+		NavigationServer2D::get_singleton()->disconnect("map_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
 	} else {
 		NavigationServer2D::get_singleton()->region_set_map(region, get_world_2d()->get_navigation_map());
-		NavigationServer2D::get_singleton_mut()->connect("map_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
+		NavigationServer2D::get_singleton()->connect("map_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
 	}
 
 #ifdef DEBUG_ENABLED
@@ -150,7 +150,7 @@ void NavigationRegion2D::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			if (enabled) {
 				NavigationServer2D::get_singleton()->region_set_map(region, get_world_2d()->get_navigation_map());
-				NavigationServer2D::get_singleton_mut()->connect("map_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
+				NavigationServer2D::get_singleton()->connect("map_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
 			}
 		} break;
 
@@ -161,7 +161,7 @@ void NavigationRegion2D::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			NavigationServer2D::get_singleton()->region_set_map(region, RID());
 			if (enabled) {
-				NavigationServer2D::get_singleton_mut()->disconnect("map_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
+				NavigationServer2D::get_singleton()->disconnect("map_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
 			}
 		} break;
 
@@ -337,8 +337,8 @@ NavigationRegion2D::NavigationRegion2D() {
 	NavigationServer2D::get_singleton()->region_set_travel_cost(region, get_travel_cost());
 
 #ifdef DEBUG_ENABLED
-	NavigationServer3D::get_singleton_mut()->connect("map_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
-	NavigationServer3D::get_singleton_mut()->connect("navigation_debug_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
+	NavigationServer3D::get_singleton()->connect("map_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
+	NavigationServer3D::get_singleton()->connect("navigation_debug_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
 #endif // DEBUG_ENABLED
 }
 
@@ -347,7 +347,7 @@ NavigationRegion2D::~NavigationRegion2D() {
 	NavigationServer2D::get_singleton()->free(region);
 
 #ifdef DEBUG_ENABLED
-	NavigationServer3D::get_singleton_mut()->disconnect("map_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
-	NavigationServer3D::get_singleton_mut()->disconnect("navigation_debug_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
+	NavigationServer3D::get_singleton()->disconnect("map_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
+	NavigationServer3D::get_singleton()->disconnect("navigation_debug_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
 #endif // DEBUG_ENABLED
 }

--- a/scene/3d/navigation_link_3d.cpp
+++ b/scene/3d/navigation_link_3d.cpp
@@ -133,8 +133,8 @@ void NavigationLink3D::_update_debug_mesh() {
 	RS::get_singleton()->instance_set_scenario(debug_instance, get_world_3d()->get_scenario());
 	RS::get_singleton()->instance_set_visible(debug_instance, is_visible_in_tree());
 
-	Ref<StandardMaterial3D> link_material = NavigationServer3D::get_singleton_mut()->get_debug_navigation_link_connections_material();
-	Ref<StandardMaterial3D> disabled_link_material = NavigationServer3D::get_singleton_mut()->get_debug_navigation_link_connections_disabled_material();
+	Ref<StandardMaterial3D> link_material = NavigationServer3D::get_singleton()->get_debug_navigation_link_connections_material();
+	Ref<StandardMaterial3D> disabled_link_material = NavigationServer3D::get_singleton()->get_debug_navigation_link_connections_disabled_material();
 
 	if (enabled) {
 		RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, link_material->get_rid());
@@ -262,10 +262,10 @@ void NavigationLink3D::set_enabled(bool p_enabled) {
 #ifdef DEBUG_ENABLED
 	if (debug_instance.is_valid() && debug_mesh.is_valid()) {
 		if (enabled) {
-			Ref<StandardMaterial3D> link_material = NavigationServer3D::get_singleton_mut()->get_debug_navigation_link_connections_material();
+			Ref<StandardMaterial3D> link_material = NavigationServer3D::get_singleton()->get_debug_navigation_link_connections_material();
 			RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, link_material->get_rid());
 		} else {
-			Ref<StandardMaterial3D> disabled_link_material = NavigationServer3D::get_singleton_mut()->get_debug_navigation_link_connections_disabled_material();
+			Ref<StandardMaterial3D> disabled_link_material = NavigationServer3D::get_singleton()->get_debug_navigation_link_connections_disabled_material();
 			RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, disabled_link_material->get_rid());
 		}
 	}

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -55,10 +55,10 @@ void NavigationRegion3D::set_enabled(bool p_enabled) {
 		if (!is_enabled()) {
 			if (debug_mesh.is_valid()) {
 				if (debug_mesh->get_surface_count() > 0) {
-					RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_face_disabled_material()->get_rid());
+					RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_disabled_material()->get_rid());
 				}
 				if (debug_mesh->get_surface_count() > 1) {
-					RS::get_singleton()->instance_set_surface_override_material(debug_instance, 1, NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_edge_disabled_material()->get_rid());
+					RS::get_singleton()->instance_set_surface_override_material(debug_instance, 1, NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_disabled_material()->get_rid());
 				}
 			}
 		} else {
@@ -365,9 +365,9 @@ NavigationRegion3D::NavigationRegion3D() {
 	NavigationServer3D::get_singleton()->region_set_travel_cost(region, get_travel_cost());
 
 #ifdef DEBUG_ENABLED
-	NavigationServer3D::get_singleton_mut()->connect("map_changed", callable_mp(this, &NavigationRegion3D::_navigation_map_changed));
-	NavigationServer3D::get_singleton_mut()->connect("navigation_debug_changed", callable_mp(this, &NavigationRegion3D::_update_debug_mesh));
-	NavigationServer3D::get_singleton_mut()->connect("navigation_debug_changed", callable_mp(this, &NavigationRegion3D::_update_debug_edge_connections_mesh));
+	NavigationServer3D::get_singleton()->connect("map_changed", callable_mp(this, &NavigationRegion3D::_navigation_map_changed));
+	NavigationServer3D::get_singleton()->connect("navigation_debug_changed", callable_mp(this, &NavigationRegion3D::_update_debug_mesh));
+	NavigationServer3D::get_singleton()->connect("navigation_debug_changed", callable_mp(this, &NavigationRegion3D::_update_debug_edge_connections_mesh));
 #endif // DEBUG_ENABLED
 }
 
@@ -379,9 +379,9 @@ NavigationRegion3D::~NavigationRegion3D() {
 	NavigationServer3D::get_singleton()->free(region);
 
 #ifdef DEBUG_ENABLED
-	NavigationServer3D::get_singleton_mut()->disconnect("map_changed", callable_mp(this, &NavigationRegion3D::_navigation_map_changed));
-	NavigationServer3D::get_singleton_mut()->disconnect("navigation_debug_changed", callable_mp(this, &NavigationRegion3D::_update_debug_mesh));
-	NavigationServer3D::get_singleton_mut()->disconnect("navigation_debug_changed", callable_mp(this, &NavigationRegion3D::_update_debug_edge_connections_mesh));
+	NavigationServer3D::get_singleton()->disconnect("map_changed", callable_mp(this, &NavigationRegion3D::_navigation_map_changed));
+	NavigationServer3D::get_singleton()->disconnect("navigation_debug_changed", callable_mp(this, &NavigationRegion3D::_update_debug_mesh));
+	NavigationServer3D::get_singleton()->disconnect("navigation_debug_changed", callable_mp(this, &NavigationRegion3D::_update_debug_edge_connections_mesh));
 
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (debug_instance.is_valid()) {
@@ -459,8 +459,8 @@ void NavigationRegion3D::_update_debug_mesh() {
 
 	Color debug_navigation_geometry_face_color = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_color();
 
-	Ref<StandardMaterial3D> face_material = NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_face_material();
-	Ref<StandardMaterial3D> line_material = NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_edge_material();
+	Ref<StandardMaterial3D> face_material = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_material();
+	Ref<StandardMaterial3D> line_material = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_material();
 
 	RandomPCG rand;
 	Color polygon_color = debug_navigation_geometry_face_color;
@@ -518,10 +518,10 @@ void NavigationRegion3D::_update_debug_mesh() {
 	if (!is_enabled()) {
 		if (debug_mesh.is_valid()) {
 			if (debug_mesh->get_surface_count() > 0) {
-				RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_face_disabled_material()->get_rid());
+				RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_disabled_material()->get_rid());
 			}
 			if (debug_mesh->get_surface_count() > 1) {
-				RS::get_singleton()->instance_set_surface_override_material(debug_instance, 1, NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_edge_disabled_material()->get_rid());
+				RS::get_singleton()->instance_set_surface_override_material(debug_instance, 1, NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_disabled_material()->get_rid());
 			}
 		}
 	} else {
@@ -610,7 +610,7 @@ void NavigationRegion3D::_update_debug_edge_connections_mesh() {
 		return;
 	}
 
-	Ref<StandardMaterial3D> edge_connections_material = NavigationServer3D::get_singleton_mut()->get_debug_navigation_edge_connections_material();
+	Ref<StandardMaterial3D> edge_connections_material = NavigationServer3D::get_singleton()->get_debug_navigation_edge_connections_material();
 
 	Array mesh_array;
 	mesh_array.resize(Mesh::ARRAY_MAX);

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -401,7 +401,7 @@ Ref<ArrayMesh> NavigationMesh::get_debug_mesh() {
 	}
 
 	debug_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, face_mesh_array);
-	Ref<StandardMaterial3D> debug_geometry_face_material = NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_face_material();
+	Ref<StandardMaterial3D> debug_geometry_face_material = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_material();
 	debug_mesh->surface_set_material(0, debug_geometry_face_material);
 
 	// if enabled build geometry edge line surface
@@ -426,7 +426,7 @@ Ref<ArrayMesh> NavigationMesh::get_debug_mesh() {
 		line_mesh_array.resize(Mesh::ARRAY_MAX);
 		line_mesh_array[Mesh::ARRAY_VERTEX] = line_vertex_array;
 		debug_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_LINES, line_mesh_array);
-		Ref<StandardMaterial3D> debug_geometry_edge_material = NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_edge_material();
+		Ref<StandardMaterial3D> debug_geometry_edge_material = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_material();
 		debug_mesh->surface_set_material(1, debug_geometry_edge_material);
 	}
 

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -36,15 +36,20 @@
 
 NavigationServer2D *NavigationServer2D::singleton = nullptr;
 
+#define FORWARD_0(FUNC_NAME)                                     \
+	NavigationServer2D::FUNC_NAME() {                            \
+		return NavigationServer3D::get_singleton()->FUNC_NAME(); \
+	}
+
 #define FORWARD_0_C(FUNC_NAME)                                   \
 	NavigationServer2D::FUNC_NAME()                              \
 			const {                                              \
 		return NavigationServer3D::get_singleton()->FUNC_NAME(); \
 	}
 
-#define FORWARD_1(FUNC_NAME, T_0, D_0, CONV_0)                                  \
-	NavigationServer2D::FUNC_NAME(T_0 D_0) {                                    \
-		return NavigationServer3D::get_singleton_mut()->FUNC_NAME(CONV_0(D_0)); \
+#define FORWARD_1(FUNC_NAME, T_0, D_0, CONV_0)                              \
+	NavigationServer2D::FUNC_NAME(T_0 D_0) {                                \
+		return NavigationServer3D::get_singleton()->FUNC_NAME(CONV_0(D_0)); \
 	}
 
 #define FORWARD_1_C(FUNC_NAME, T_0, D_0, CONV_0)                            \
@@ -59,6 +64,11 @@ NavigationServer2D *NavigationServer2D::singleton = nullptr;
 		return CONV_R(NavigationServer3D::get_singleton()->FUNC_NAME(CONV_0(D_0))); \
 	}
 
+#define FORWARD_2(FUNC_NAME, T_0, D_0, T_1, D_1, CONV_0, CONV_1)                         \
+	NavigationServer2D::FUNC_NAME(T_0 D_0, T_1 D_1) {                                    \
+		return NavigationServer3D::get_singleton()->FUNC_NAME(CONV_0(D_0), CONV_1(D_1)); \
+	}
+
 #define FORWARD_2_C(FUNC_NAME, T_0, D_0, T_1, D_1, CONV_0, CONV_1)                       \
 	NavigationServer2D::FUNC_NAME(T_0 D_0, T_1 D_1)                                      \
 			const {                                                                      \
@@ -69,6 +79,11 @@ NavigationServer2D *NavigationServer2D::singleton = nullptr;
 	NavigationServer2D::FUNC_NAME(T_0 D_0, T_1 D_1)                                              \
 			const {                                                                              \
 		return CONV_R(NavigationServer3D::get_singleton()->FUNC_NAME(CONV_0(D_0), CONV_1(D_1))); \
+	}
+
+#define FORWARD_4(FUNC_NAME, T_0, D_0, T_1, D_1, T_2, D_2, T_3, D_3, CONV_0, CONV_1, CONV_2, CONV_3)               \
+	NavigationServer2D::FUNC_NAME(T_0 D_0, T_1 D_1, T_2 D_2, T_3 D_3) {                                            \
+		return NavigationServer3D::get_singleton()->FUNC_NAME(CONV_0(D_0), CONV_1(D_1), CONV_2(D_2), CONV_3(D_3)); \
 	}
 
 #define FORWARD_4_R_C(CONV_R, FUNC_NAME, T_0, D_0, T_1, D_1, T_2, D_2, T_3, D_3, CONV_0, CONV_1, CONV_2, CONV_3)           \
@@ -166,14 +181,14 @@ void NavigationServer2D::_emit_map_changed(RID p_map) {
 
 #ifdef DEBUG_ENABLED
 void NavigationServer2D::set_debug_enabled(bool p_enabled) {
-	NavigationServer3D::get_singleton_mut()->set_debug_enabled(p_enabled);
+	NavigationServer3D::get_singleton()->set_debug_enabled(p_enabled);
 }
 bool NavigationServer2D::get_debug_enabled() const {
 	return NavigationServer3D::get_singleton()->get_debug_enabled();
 }
 
 void NavigationServer2D::set_debug_navigation_edge_connection_color(const Color &p_color) {
-	NavigationServer3D::get_singleton_mut()->set_debug_navigation_edge_connection_color(p_color);
+	NavigationServer3D::get_singleton()->set_debug_navigation_edge_connection_color(p_color);
 }
 
 Color NavigationServer2D::get_debug_navigation_edge_connection_color() const {
@@ -181,7 +196,7 @@ Color NavigationServer2D::get_debug_navigation_edge_connection_color() const {
 }
 
 void NavigationServer2D::set_debug_navigation_geometry_face_color(const Color &p_color) {
-	NavigationServer3D::get_singleton_mut()->set_debug_navigation_geometry_face_color(p_color);
+	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_face_color(p_color);
 }
 
 Color NavigationServer2D::get_debug_navigation_geometry_face_color() const {
@@ -189,7 +204,7 @@ Color NavigationServer2D::get_debug_navigation_geometry_face_color() const {
 }
 
 void NavigationServer2D::set_debug_navigation_geometry_face_disabled_color(const Color &p_color) {
-	NavigationServer3D::get_singleton_mut()->set_debug_navigation_geometry_face_disabled_color(p_color);
+	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_face_disabled_color(p_color);
 }
 
 Color NavigationServer2D::get_debug_navigation_geometry_face_disabled_color() const {
@@ -197,7 +212,7 @@ Color NavigationServer2D::get_debug_navigation_geometry_face_disabled_color() co
 }
 
 void NavigationServer2D::set_debug_navigation_link_connection_color(const Color &p_color) {
-	NavigationServer3D::get_singleton_mut()->set_debug_navigation_link_connection_color(p_color);
+	NavigationServer3D::get_singleton()->set_debug_navigation_link_connection_color(p_color);
 }
 
 Color NavigationServer2D::get_debug_navigation_link_connection_color() const {
@@ -205,7 +220,7 @@ Color NavigationServer2D::get_debug_navigation_link_connection_color() const {
 }
 
 void NavigationServer2D::set_debug_navigation_link_connection_disabled_color(const Color &p_color) {
-	NavigationServer3D::get_singleton_mut()->set_debug_navigation_link_connection_disabled_color(p_color);
+	NavigationServer3D::get_singleton()->set_debug_navigation_link_connection_disabled_color(p_color);
 }
 
 Color NavigationServer2D::get_debug_navigation_link_connection_disabled_color() const {
@@ -213,7 +228,7 @@ Color NavigationServer2D::get_debug_navigation_link_connection_disabled_color() 
 }
 
 void NavigationServer2D::set_debug_navigation_enable_edge_connections(const bool p_value) {
-	NavigationServer3D::get_singleton_mut()->set_debug_navigation_enable_edge_connections(p_value);
+	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_connections(p_value);
 }
 
 bool NavigationServer2D::get_debug_navigation_enable_edge_connections() const {
@@ -303,7 +318,7 @@ void NavigationServer2D::_bind_methods() {
 NavigationServer2D::NavigationServer2D() {
 	singleton = this;
 	ERR_FAIL_COND_MSG(!NavigationServer3D::get_singleton(), "The Navigation3D singleton should be initialized before the 2D one.");
-	NavigationServer3D::get_singleton_mut()->connect("map_changed", callable_mp(this, &NavigationServer2D::_emit_map_changed));
+	NavigationServer3D::get_singleton()->connect("map_changed", callable_mp(this, &NavigationServer2D::_emit_map_changed));
 }
 
 NavigationServer2D::~NavigationServer2D() {
@@ -322,23 +337,23 @@ RID FORWARD_1_C(region_get_map, RID, p_region, rid_to_rid);
 
 RID FORWARD_1_C(agent_get_map, RID, p_agent, rid_to_rid);
 
-RID FORWARD_0_C(map_create);
+RID FORWARD_0(map_create);
 
-void FORWARD_2_C(map_set_active, RID, p_map, bool, p_active, rid_to_rid, bool_to_bool);
+void FORWARD_2(map_set_active, RID, p_map, bool, p_active, rid_to_rid, bool_to_bool);
 
 bool FORWARD_1_C(map_is_active, RID, p_map, rid_to_rid);
 
 void NavigationServer2D::map_force_update(RID p_map) {
-	NavigationServer3D::get_singleton_mut()->map_force_update(p_map);
+	NavigationServer3D::get_singleton()->map_force_update(p_map);
 }
 
-void FORWARD_2_C(map_set_cell_size, RID, p_map, real_t, p_cell_size, rid_to_rid, real_to_real);
+void FORWARD_2(map_set_cell_size, RID, p_map, real_t, p_cell_size, rid_to_rid, real_to_real);
 real_t FORWARD_1_C(map_get_cell_size, RID, p_map, rid_to_rid);
 
-void FORWARD_2_C(map_set_edge_connection_margin, RID, p_map, real_t, p_connection_margin, rid_to_rid, real_to_real);
+void FORWARD_2(map_set_edge_connection_margin, RID, p_map, real_t, p_connection_margin, rid_to_rid, real_to_real);
 real_t FORWARD_1_C(map_get_edge_connection_margin, RID, p_map, rid_to_rid);
 
-void FORWARD_2_C(map_set_link_connection_radius, RID, p_map, real_t, p_connection_radius, rid_to_rid, real_to_real);
+void FORWARD_2(map_set_link_connection_radius, RID, p_map, real_t, p_connection_radius, rid_to_rid, real_to_real);
 real_t FORWARD_1_C(map_get_link_connection_radius, RID, p_map, rid_to_rid);
 
 Vector<Vector2> FORWARD_5_R_C(vector_v3_to_v2, map_get_path, RID, p_map, Vector2, p_origin, Vector2, p_destination, bool, p_optimize, uint32_t, p_layers, rid_to_rid, v2_to_v3, v2_to_v3, bool_to_bool, uint32_to_uint32);
@@ -346,22 +361,22 @@ Vector<Vector2> FORWARD_5_R_C(vector_v3_to_v2, map_get_path, RID, p_map, Vector2
 Vector2 FORWARD_2_R_C(v3_to_v2, map_get_closest_point, RID, p_map, const Vector2 &, p_point, rid_to_rid, v2_to_v3);
 RID FORWARD_2_C(map_get_closest_point_owner, RID, p_map, const Vector2 &, p_point, rid_to_rid, v2_to_v3);
 
-RID FORWARD_0_C(region_create);
+RID FORWARD_0(region_create);
 
-void FORWARD_2_C(region_set_enter_cost, RID, p_region, real_t, p_enter_cost, rid_to_rid, real_to_real);
+void FORWARD_2(region_set_enter_cost, RID, p_region, real_t, p_enter_cost, rid_to_rid, real_to_real);
 real_t FORWARD_1_C(region_get_enter_cost, RID, p_region, rid_to_rid);
-void FORWARD_2_C(region_set_travel_cost, RID, p_region, real_t, p_travel_cost, rid_to_rid, real_to_real);
+void FORWARD_2(region_set_travel_cost, RID, p_region, real_t, p_travel_cost, rid_to_rid, real_to_real);
 real_t FORWARD_1_C(region_get_travel_cost, RID, p_region, rid_to_rid);
-void FORWARD_2_C(region_set_owner_id, RID, p_region, ObjectID, p_owner_id, rid_to_rid, id_to_id);
+void FORWARD_2(region_set_owner_id, RID, p_region, ObjectID, p_owner_id, rid_to_rid, id_to_id);
 ObjectID FORWARD_1_C(region_get_owner_id, RID, p_region, rid_to_rid);
 bool FORWARD_2_C(region_owns_point, RID, p_region, const Vector2 &, p_point, rid_to_rid, v2_to_v3);
 
-void FORWARD_2_C(region_set_map, RID, p_region, RID, p_map, rid_to_rid, rid_to_rid);
-void FORWARD_2_C(region_set_navigation_layers, RID, p_region, uint32_t, p_navigation_layers, rid_to_rid, uint32_to_uint32);
+void FORWARD_2(region_set_map, RID, p_region, RID, p_map, rid_to_rid, rid_to_rid);
+void FORWARD_2(region_set_navigation_layers, RID, p_region, uint32_t, p_navigation_layers, rid_to_rid, uint32_to_uint32);
 uint32_t FORWARD_1_C(region_get_navigation_layers, RID, p_region, rid_to_rid);
-void FORWARD_2_C(region_set_transform, RID, p_region, Transform2D, p_transform, rid_to_rid, trf2_to_trf3);
+void FORWARD_2(region_set_transform, RID, p_region, Transform2D, p_transform, rid_to_rid, trf2_to_trf3);
 
-void NavigationServer2D::region_set_navigation_polygon(RID p_region, Ref<NavigationPolygon> p_navigation_polygon) const {
+void NavigationServer2D::region_set_navigation_polygon(RID p_region, Ref<NavigationPolygon> p_navigation_polygon) {
 	NavigationServer3D::get_singleton()->region_set_navigation_mesh(p_region, poly_to_mesh(p_navigation_polygon));
 }
 
@@ -369,56 +384,45 @@ int FORWARD_1_C(region_get_connections_count, RID, p_region, rid_to_rid);
 Vector2 FORWARD_2_R_C(v3_to_v2, region_get_connection_pathway_start, RID, p_region, int, p_connection_id, rid_to_rid, int_to_int);
 Vector2 FORWARD_2_R_C(v3_to_v2, region_get_connection_pathway_end, RID, p_region, int, p_connection_id, rid_to_rid, int_to_int);
 
-RID FORWARD_0_C(link_create);
+RID FORWARD_0(link_create);
 
-void FORWARD_2_C(link_set_map, RID, p_link, RID, p_map, rid_to_rid, rid_to_rid);
+void FORWARD_2(link_set_map, RID, p_link, RID, p_map, rid_to_rid, rid_to_rid);
 RID FORWARD_1_C(link_get_map, RID, p_link, rid_to_rid);
-void FORWARD_2_C(link_set_bidirectional, RID, p_link, bool, p_bidirectional, rid_to_rid, bool_to_bool);
+void FORWARD_2(link_set_bidirectional, RID, p_link, bool, p_bidirectional, rid_to_rid, bool_to_bool);
 bool FORWARD_1_C(link_is_bidirectional, RID, p_link, rid_to_rid);
-void FORWARD_2_C(link_set_navigation_layers, RID, p_link, uint32_t, p_navigation_layers, rid_to_rid, uint32_to_uint32);
+void FORWARD_2(link_set_navigation_layers, RID, p_link, uint32_t, p_navigation_layers, rid_to_rid, uint32_to_uint32);
 uint32_t FORWARD_1_C(link_get_navigation_layers, RID, p_link, rid_to_rid);
-void FORWARD_2_C(link_set_start_location, RID, p_link, Vector2, p_location, rid_to_rid, v2_to_v3);
+void FORWARD_2(link_set_start_location, RID, p_link, Vector2, p_location, rid_to_rid, v2_to_v3);
 Vector2 FORWARD_1_R_C(v3_to_v2, link_get_start_location, RID, p_link, rid_to_rid);
-void FORWARD_2_C(link_set_end_location, RID, p_link, Vector2, p_location, rid_to_rid, v2_to_v3);
+void FORWARD_2(link_set_end_location, RID, p_link, Vector2, p_location, rid_to_rid, v2_to_v3);
 Vector2 FORWARD_1_R_C(v3_to_v2, link_get_end_location, RID, p_link, rid_to_rid);
-void FORWARD_2_C(link_set_enter_cost, RID, p_link, real_t, p_enter_cost, rid_to_rid, real_to_real);
+void FORWARD_2(link_set_enter_cost, RID, p_link, real_t, p_enter_cost, rid_to_rid, real_to_real);
 real_t FORWARD_1_C(link_get_enter_cost, RID, p_link, rid_to_rid);
-void FORWARD_2_C(link_set_travel_cost, RID, p_link, real_t, p_travel_cost, rid_to_rid, real_to_real);
+void FORWARD_2(link_set_travel_cost, RID, p_link, real_t, p_travel_cost, rid_to_rid, real_to_real);
 real_t FORWARD_1_C(link_get_travel_cost, RID, p_link, rid_to_rid);
-void FORWARD_2_C(link_set_owner_id, RID, p_link, ObjectID, p_owner_id, rid_to_rid, id_to_id);
+void FORWARD_2(link_set_owner_id, RID, p_link, ObjectID, p_owner_id, rid_to_rid, id_to_id);
 ObjectID FORWARD_1_C(link_get_owner_id, RID, p_link, rid_to_rid);
 
-RID NavigationServer2D::agent_create() const {
+RID NavigationServer2D::agent_create() {
 	RID agent = NavigationServer3D::get_singleton()->agent_create();
 	NavigationServer3D::get_singleton()->agent_set_ignore_y(agent, true);
 	return agent;
 }
 
-void FORWARD_2_C(agent_set_map, RID, p_agent, RID, p_map, rid_to_rid, rid_to_rid);
-
-void FORWARD_2_C(agent_set_neighbor_distance, RID, p_agent, real_t, p_dist, rid_to_rid, real_to_real);
-
-void FORWARD_2_C(agent_set_max_neighbors, RID, p_agent, int, p_count, rid_to_rid, int_to_int);
-
-void FORWARD_2_C(agent_set_time_horizon, RID, p_agent, real_t, p_time, rid_to_rid, real_to_real);
-
-void FORWARD_2_C(agent_set_radius, RID, p_agent, real_t, p_radius, rid_to_rid, real_to_real);
-
-void FORWARD_2_C(agent_set_max_speed, RID, p_agent, real_t, p_max_speed, rid_to_rid, real_to_real);
-
-void FORWARD_2_C(agent_set_velocity, RID, p_agent, Vector2, p_velocity, rid_to_rid, v2_to_v3);
-
-void FORWARD_2_C(agent_set_target_velocity, RID, p_agent, Vector2, p_velocity, rid_to_rid, v2_to_v3);
-
-void FORWARD_2_C(agent_set_position, RID, p_agent, Vector2, p_position, rid_to_rid, v2_to_v3);
-
-void FORWARD_2_C(agent_set_ignore_y, RID, p_agent, bool, p_ignore, rid_to_rid, bool_to_bool);
-
+void FORWARD_2(agent_set_map, RID, p_agent, RID, p_map, rid_to_rid, rid_to_rid);
+void FORWARD_2(agent_set_neighbor_distance, RID, p_agent, real_t, p_dist, rid_to_rid, real_to_real);
+void FORWARD_2(agent_set_max_neighbors, RID, p_agent, int, p_count, rid_to_rid, int_to_int);
+void FORWARD_2(agent_set_time_horizon, RID, p_agent, real_t, p_time, rid_to_rid, real_to_real);
+void FORWARD_2(agent_set_radius, RID, p_agent, real_t, p_radius, rid_to_rid, real_to_real);
+void FORWARD_2(agent_set_max_speed, RID, p_agent, real_t, p_max_speed, rid_to_rid, real_to_real);
+void FORWARD_2(agent_set_velocity, RID, p_agent, Vector2, p_velocity, rid_to_rid, v2_to_v3);
+void FORWARD_2(agent_set_target_velocity, RID, p_agent, Vector2, p_velocity, rid_to_rid, v2_to_v3);
+void FORWARD_2(agent_set_position, RID, p_agent, Vector2, p_position, rid_to_rid, v2_to_v3);
+void FORWARD_2(agent_set_ignore_y, RID, p_agent, bool, p_ignore, rid_to_rid, bool_to_bool);
 bool FORWARD_1_C(agent_is_map_changed, RID, p_agent, rid_to_rid);
+void FORWARD_4(agent_set_callback, RID, p_agent, ObjectID, p_object_id, StringName, p_method, Variant, p_udata, rid_to_rid, id_to_id, sn_to_sn, var_to_var);
 
-void FORWARD_4_C(agent_set_callback, RID, p_agent, ObjectID, p_object_id, StringName, p_method, Variant, p_udata, rid_to_rid, id_to_id, sn_to_sn, var_to_var);
-
-void FORWARD_1_C(free, RID, p_object, rid_to_rid);
+void FORWARD_1(free, RID, p_object, rid_to_rid);
 
 void NavigationServer2D::query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result) const {
 	ERR_FAIL_COND(!p_query_parameters.is_valid());

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -51,36 +51,33 @@ protected:
 
 public:
 	/// Thread safe, can be used across many threads.
-	static const NavigationServer2D *get_singleton() { return singleton; }
-
-	/// MUST be used in single thread!
-	static NavigationServer2D *get_singleton_mut() { return singleton; }
+	static NavigationServer2D *get_singleton() { return singleton; }
 
 	virtual TypedArray<RID> get_maps() const;
 
 	/// Create a new map.
-	virtual RID map_create() const;
+	virtual RID map_create();
 
 	/// Set map active.
-	virtual void map_set_active(RID p_map, bool p_active) const;
+	virtual void map_set_active(RID p_map, bool p_active);
 
 	/// Returns true if the map is active.
 	virtual bool map_is_active(RID p_map) const;
 
 	/// Set the map cell size used to weld the navigation mesh polygons.
-	virtual void map_set_cell_size(RID p_map, real_t p_cell_size) const;
+	virtual void map_set_cell_size(RID p_map, real_t p_cell_size);
 
 	/// Returns the map cell size.
 	virtual real_t map_get_cell_size(RID p_map) const;
 
 	/// Set the map edge connection margin used to weld the compatible region edges.
-	virtual void map_set_edge_connection_margin(RID p_map, real_t p_connection_margin) const;
+	virtual void map_set_edge_connection_margin(RID p_map, real_t p_connection_margin);
 
 	/// Returns the edge connection margin of this map.
 	virtual real_t map_get_edge_connection_margin(RID p_map) const;
 
 	/// Set the map link connection radius used to attach links to the nav mesh.
-	virtual void map_set_link_connection_radius(RID p_map, real_t p_connection_radius) const;
+	virtual void map_set_link_connection_radius(RID p_map, real_t p_connection_radius);
 
 	/// Returns the link connection radius of this map.
 	virtual real_t map_get_link_connection_radius(RID p_map) const;
@@ -98,35 +95,35 @@ public:
 	virtual void map_force_update(RID p_map);
 
 	/// Creates a new region.
-	virtual RID region_create() const;
+	virtual RID region_create();
 
 	/// Set the enter_cost of a region
-	virtual void region_set_enter_cost(RID p_region, real_t p_enter_cost) const;
+	virtual void region_set_enter_cost(RID p_region, real_t p_enter_cost);
 	virtual real_t region_get_enter_cost(RID p_region) const;
 
 	/// Set the travel_cost of a region
-	virtual void region_set_travel_cost(RID p_region, real_t p_travel_cost) const;
+	virtual void region_set_travel_cost(RID p_region, real_t p_travel_cost);
 	virtual real_t region_get_travel_cost(RID p_region) const;
 
 	/// Set the node which manages this region.
-	virtual void region_set_owner_id(RID p_region, ObjectID p_owner_id) const;
+	virtual void region_set_owner_id(RID p_region, ObjectID p_owner_id);
 	virtual ObjectID region_get_owner_id(RID p_region) const;
 
 	virtual bool region_owns_point(RID p_region, const Vector2 &p_point) const;
 
 	/// Set the map of this region.
-	virtual void region_set_map(RID p_region, RID p_map) const;
+	virtual void region_set_map(RID p_region, RID p_map);
 	virtual RID region_get_map(RID p_region) const;
 
 	/// Set the region's layers
-	virtual void region_set_navigation_layers(RID p_region, uint32_t p_navigation_layers) const;
+	virtual void region_set_navigation_layers(RID p_region, uint32_t p_navigation_layers);
 	virtual uint32_t region_get_navigation_layers(RID p_region) const;
 
 	/// Set the global transformation of this region.
-	virtual void region_set_transform(RID p_region, Transform2D p_transform) const;
+	virtual void region_set_transform(RID p_region, Transform2D p_transform);
 
 	/// Set the navigation poly of this region.
-	virtual void region_set_navigation_polygon(RID p_region, Ref<NavigationPolygon> p_navigation_polygon) const;
+	virtual void region_set_navigation_polygon(RID p_region, Ref<NavigationPolygon> p_navigation_polygon);
 
 	/// Get a list of a region's connection to other regions.
 	virtual int region_get_connections_count(RID p_region) const;
@@ -134,45 +131,45 @@ public:
 	virtual Vector2 region_get_connection_pathway_end(RID p_region, int p_connection_id) const;
 
 	/// Creates a new link between locations in the nav map.
-	virtual RID link_create() const;
+	virtual RID link_create();
 
 	/// Set the map of this link.
-	virtual void link_set_map(RID p_link, RID p_map) const;
+	virtual void link_set_map(RID p_link, RID p_map);
 	virtual RID link_get_map(RID p_link) const;
 
 	/// Set whether this link travels in both directions.
-	virtual void link_set_bidirectional(RID p_link, bool p_bidirectional) const;
+	virtual void link_set_bidirectional(RID p_link, bool p_bidirectional);
 	virtual bool link_is_bidirectional(RID p_link) const;
 
 	/// Set the link's layers.
-	virtual void link_set_navigation_layers(RID p_link, uint32_t p_navigation_layers) const;
+	virtual void link_set_navigation_layers(RID p_link, uint32_t p_navigation_layers);
 	virtual uint32_t link_get_navigation_layers(RID p_link) const;
 
 	/// Set the start location of the link.
-	virtual void link_set_start_location(RID p_link, Vector2 p_location) const;
+	virtual void link_set_start_location(RID p_link, Vector2 p_location);
 	virtual Vector2 link_get_start_location(RID p_link) const;
 
 	/// Set the end location of the link.
-	virtual void link_set_end_location(RID p_link, Vector2 p_location) const;
+	virtual void link_set_end_location(RID p_link, Vector2 p_location);
 	virtual Vector2 link_get_end_location(RID p_link) const;
 
 	/// Set the enter cost of the link.
-	virtual void link_set_enter_cost(RID p_link, real_t p_enter_cost) const;
+	virtual void link_set_enter_cost(RID p_link, real_t p_enter_cost);
 	virtual real_t link_get_enter_cost(RID p_link) const;
 
 	/// Set the travel cost of the link.
-	virtual void link_set_travel_cost(RID p_link, real_t p_travel_cost) const;
+	virtual void link_set_travel_cost(RID p_link, real_t p_travel_cost);
 	virtual real_t link_get_travel_cost(RID p_link) const;
 
 	/// Set the node which manages this link.
-	virtual void link_set_owner_id(RID p_link, ObjectID p_owner_id) const;
+	virtual void link_set_owner_id(RID p_link, ObjectID p_owner_id);
 	virtual ObjectID link_get_owner_id(RID p_link) const;
 
 	/// Creates the agent.
-	virtual RID agent_create() const;
+	virtual RID agent_create();
 
 	/// Put the agent in the map.
-	virtual void agent_set_map(RID p_agent, RID p_map) const;
+	virtual void agent_set_map(RID p_agent, RID p_map);
 	virtual RID agent_get_map(RID p_agent) const;
 
 	/// The maximum distance (center point to
@@ -182,7 +179,7 @@ public:
 	/// time of the simulation. If the number is too
 	/// low, the simulation will not be safe.
 	/// Must be non-negative.
-	virtual void agent_set_neighbor_distance(RID p_agent, real_t p_distance) const;
+	virtual void agent_set_neighbor_distance(RID p_agent, real_t p_distance);
 
 	/// The maximum number of other agents this
 	/// agent takes into account in the navigation.
@@ -190,7 +187,7 @@ public:
 	/// running time of the simulation. If the
 	/// number is too low, the simulation will not
 	/// be safe.
-	virtual void agent_set_max_neighbors(RID p_agent, int p_count) const;
+	virtual void agent_set_max_neighbors(RID p_agent, int p_count);
 
 	/// The minimal amount of time for which this
 	/// agent's velocities that are computed by the
@@ -200,38 +197,38 @@ public:
 	/// other agents, but the less freedom this
 	/// agent has in choosing its velocities.
 	/// Must be positive.
-	virtual void agent_set_time_horizon(RID p_agent, real_t p_time) const;
+	virtual void agent_set_time_horizon(RID p_agent, real_t p_time);
 
 	/// The radius of this agent.
 	/// Must be non-negative.
-	virtual void agent_set_radius(RID p_agent, real_t p_radius) const;
+	virtual void agent_set_radius(RID p_agent, real_t p_radius);
 
 	/// The maximum speed of this agent.
 	/// Must be non-negative.
-	virtual void agent_set_max_speed(RID p_agent, real_t p_max_speed) const;
+	virtual void agent_set_max_speed(RID p_agent, real_t p_max_speed);
 
 	/// Current velocity of the agent
-	virtual void agent_set_velocity(RID p_agent, Vector2 p_velocity) const;
+	virtual void agent_set_velocity(RID p_agent, Vector2 p_velocity);
 
 	/// The new target velocity.
-	virtual void agent_set_target_velocity(RID p_agent, Vector2 p_velocity) const;
+	virtual void agent_set_target_velocity(RID p_agent, Vector2 p_velocity);
 
 	/// Position of the agent in world space.
-	virtual void agent_set_position(RID p_agent, Vector2 p_position) const;
+	virtual void agent_set_position(RID p_agent, Vector2 p_position);
 
 	/// Agent ignore the Y axis and avoid collisions by moving only on the horizontal plane
-	virtual void agent_set_ignore_y(RID p_agent, bool p_ignore) const;
+	virtual void agent_set_ignore_y(RID p_agent, bool p_ignore);
 
 	/// Returns true if the map got changed the previous frame.
 	virtual bool agent_is_map_changed(RID p_agent) const;
 
 	/// Callback called at the end of the RVO process
-	virtual void agent_set_callback(RID p_agent, ObjectID p_object_id, StringName p_method, Variant p_udata = Variant()) const;
+	virtual void agent_set_callback(RID p_agent, ObjectID p_object_id, StringName p_method, Variant p_udata = Variant());
 
 	virtual void query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result) const;
 
 	/// Destroy the `RID`
-	virtual void free(RID p_object) const;
+	virtual void free(RID p_object);
 
 	NavigationServer2D();
 	virtual ~NavigationServer2D();

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -125,11 +125,7 @@ void NavigationServer3D::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("navigation_debug_changed"));
 }
 
-const NavigationServer3D *NavigationServer3D::get_singleton() {
-	return singleton;
-}
-
-NavigationServer3D *NavigationServer3D::get_singleton_mut() {
+NavigationServer3D *NavigationServer3D::get_singleton() {
 	return singleton;
 }
 

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -55,42 +55,39 @@ protected:
 
 public:
 	/// Thread safe, can be used across many threads.
-	static const NavigationServer3D *get_singleton();
-
-	/// MUST be used in single thread!
-	static NavigationServer3D *get_singleton_mut();
+	static NavigationServer3D *get_singleton();
 
 	virtual TypedArray<RID> get_maps() const = 0;
 
 	/// Create a new map.
-	virtual RID map_create() const = 0;
+	virtual RID map_create() = 0;
 
 	/// Set map active.
-	virtual void map_set_active(RID p_map, bool p_active) const = 0;
+	virtual void map_set_active(RID p_map, bool p_active) = 0;
 
 	/// Returns true if the map is active.
 	virtual bool map_is_active(RID p_map) const = 0;
 
 	/// Set the map UP direction.
-	virtual void map_set_up(RID p_map, Vector3 p_up) const = 0;
+	virtual void map_set_up(RID p_map, Vector3 p_up) = 0;
 
 	/// Returns the map UP direction.
 	virtual Vector3 map_get_up(RID p_map) const = 0;
 
 	/// Set the map cell size used to weld the navigation mesh polygons.
-	virtual void map_set_cell_size(RID p_map, real_t p_cell_size) const = 0;
+	virtual void map_set_cell_size(RID p_map, real_t p_cell_size) = 0;
 
 	/// Returns the map cell size.
 	virtual real_t map_get_cell_size(RID p_map) const = 0;
 
 	/// Set the map edge connection margin used to weld the compatible region edges.
-	virtual void map_set_edge_connection_margin(RID p_map, real_t p_connection_margin) const = 0;
+	virtual void map_set_edge_connection_margin(RID p_map, real_t p_connection_margin) = 0;
 
 	/// Returns the edge connection margin of this map.
 	virtual real_t map_get_edge_connection_margin(RID p_map) const = 0;
 
 	/// Set the map link connection radius used to attach links to the nav mesh.
-	virtual void map_set_link_connection_radius(RID p_map, real_t p_connection_radius) const = 0;
+	virtual void map_set_link_connection_radius(RID p_map, real_t p_connection_radius) = 0;
 
 	/// Returns the link connection radius of this map.
 	virtual real_t map_get_link_connection_radius(RID p_map) const = 0;
@@ -110,38 +107,38 @@ public:
 	virtual void map_force_update(RID p_map) = 0;
 
 	/// Creates a new region.
-	virtual RID region_create() const = 0;
+	virtual RID region_create() = 0;
 
 	/// Set the enter_cost of a region
-	virtual void region_set_enter_cost(RID p_region, real_t p_enter_cost) const = 0;
+	virtual void region_set_enter_cost(RID p_region, real_t p_enter_cost) = 0;
 	virtual real_t region_get_enter_cost(RID p_region) const = 0;
 
 	/// Set the travel_cost of a region
-	virtual void region_set_travel_cost(RID p_region, real_t p_travel_cost) const = 0;
+	virtual void region_set_travel_cost(RID p_region, real_t p_travel_cost) = 0;
 	virtual real_t region_get_travel_cost(RID p_region) const = 0;
 
 	/// Set the node which manages this region.
-	virtual void region_set_owner_id(RID p_region, ObjectID p_owner_id) const = 0;
+	virtual void region_set_owner_id(RID p_region, ObjectID p_owner_id) = 0;
 	virtual ObjectID region_get_owner_id(RID p_region) const = 0;
 
 	virtual bool region_owns_point(RID p_region, const Vector3 &p_point) const = 0;
 
 	/// Set the map of this region.
-	virtual void region_set_map(RID p_region, RID p_map) const = 0;
+	virtual void region_set_map(RID p_region, RID p_map) = 0;
 	virtual RID region_get_map(RID p_region) const = 0;
 
 	/// Set the region's layers
-	virtual void region_set_navigation_layers(RID p_region, uint32_t p_navigation_layers) const = 0;
+	virtual void region_set_navigation_layers(RID p_region, uint32_t p_navigation_layers) = 0;
 	virtual uint32_t region_get_navigation_layers(RID p_region) const = 0;
 
 	/// Set the global transformation of this region.
-	virtual void region_set_transform(RID p_region, Transform3D p_transform) const = 0;
+	virtual void region_set_transform(RID p_region, Transform3D p_transform) = 0;
 
 	/// Set the navigation mesh of this region.
-	virtual void region_set_navigation_mesh(RID p_region, Ref<NavigationMesh> p_navigation_mesh) const = 0;
+	virtual void region_set_navigation_mesh(RID p_region, Ref<NavigationMesh> p_navigation_mesh) = 0;
 
 	/// Bake the navigation mesh.
-	virtual void region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) const = 0;
+	virtual void region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) = 0;
 
 	/// Get a list of a region's connection to other regions.
 	virtual int region_get_connections_count(RID p_region) const = 0;
@@ -149,45 +146,45 @@ public:
 	virtual Vector3 region_get_connection_pathway_end(RID p_region, int p_connection_id) const = 0;
 
 	/// Creates a new link between locations in the nav map.
-	virtual RID link_create() const = 0;
+	virtual RID link_create() = 0;
 
 	/// Set the map of this link.
-	virtual void link_set_map(RID p_link, RID p_map) const = 0;
+	virtual void link_set_map(RID p_link, RID p_map) = 0;
 	virtual RID link_get_map(RID p_link) const = 0;
 
 	/// Set whether this link travels in both directions.
-	virtual void link_set_bidirectional(RID p_link, bool p_bidirectional) const = 0;
+	virtual void link_set_bidirectional(RID p_link, bool p_bidirectional) = 0;
 	virtual bool link_is_bidirectional(RID p_link) const = 0;
 
 	/// Set the link's layers.
-	virtual void link_set_navigation_layers(RID p_link, uint32_t p_navigation_layers) const = 0;
+	virtual void link_set_navigation_layers(RID p_link, uint32_t p_navigation_layers) = 0;
 	virtual uint32_t link_get_navigation_layers(RID p_link) const = 0;
 
 	/// Set the start location of the link.
-	virtual void link_set_start_location(RID p_link, Vector3 p_location) const = 0;
+	virtual void link_set_start_location(RID p_link, Vector3 p_location) = 0;
 	virtual Vector3 link_get_start_location(RID p_link) const = 0;
 
 	/// Set the end location of the link.
-	virtual void link_set_end_location(RID p_link, Vector3 p_location) const = 0;
+	virtual void link_set_end_location(RID p_link, Vector3 p_location) = 0;
 	virtual Vector3 link_get_end_location(RID p_link) const = 0;
 
 	/// Set the enter cost of the link.
-	virtual void link_set_enter_cost(RID p_link, real_t p_enter_cost) const = 0;
+	virtual void link_set_enter_cost(RID p_link, real_t p_enter_cost) = 0;
 	virtual real_t link_get_enter_cost(RID p_link) const = 0;
 
 	/// Set the travel cost of the link.
-	virtual void link_set_travel_cost(RID p_link, real_t p_travel_cost) const = 0;
+	virtual void link_set_travel_cost(RID p_link, real_t p_travel_cost) = 0;
 	virtual real_t link_get_travel_cost(RID p_link) const = 0;
 
 	/// Set the node which manages this link.
-	virtual void link_set_owner_id(RID p_link, ObjectID p_owner_id) const = 0;
+	virtual void link_set_owner_id(RID p_link, ObjectID p_owner_id) = 0;
 	virtual ObjectID link_get_owner_id(RID p_link) const = 0;
 
 	/// Creates the agent.
-	virtual RID agent_create() const = 0;
+	virtual RID agent_create() = 0;
 
 	/// Put the agent in the map.
-	virtual void agent_set_map(RID p_agent, RID p_map) const = 0;
+	virtual void agent_set_map(RID p_agent, RID p_map) = 0;
 	virtual RID agent_get_map(RID p_agent) const = 0;
 
 	/// The maximum distance (center point to
@@ -197,7 +194,7 @@ public:
 	/// time of the simulation. If the number is too
 	/// low, the simulation will not be safe.
 	/// Must be non-negative.
-	virtual void agent_set_neighbor_distance(RID p_agent, real_t p_distance) const = 0;
+	virtual void agent_set_neighbor_distance(RID p_agent, real_t p_distance) = 0;
 
 	/// The maximum number of other agents this
 	/// agent takes into account in the navigation.
@@ -205,7 +202,7 @@ public:
 	/// running time of the simulation. If the
 	/// number is too low, the simulation will not
 	/// be safe.
-	virtual void agent_set_max_neighbors(RID p_agent, int p_count) const = 0;
+	virtual void agent_set_max_neighbors(RID p_agent, int p_count) = 0;
 
 	/// The minimal amount of time for which this
 	/// agent's velocities that are computed by the
@@ -215,39 +212,39 @@ public:
 	/// other agents, but the less freedom this
 	/// agent has in choosing its velocities.
 	/// Must be positive.
-	virtual void agent_set_time_horizon(RID p_agent, real_t p_time) const = 0;
+	virtual void agent_set_time_horizon(RID p_agent, real_t p_time) = 0;
 
 	/// The radius of this agent.
 	/// Must be non-negative.
-	virtual void agent_set_radius(RID p_agent, real_t p_radius) const = 0;
+	virtual void agent_set_radius(RID p_agent, real_t p_radius) = 0;
 
 	/// The maximum speed of this agent.
 	/// Must be non-negative.
-	virtual void agent_set_max_speed(RID p_agent, real_t p_max_speed) const = 0;
+	virtual void agent_set_max_speed(RID p_agent, real_t p_max_speed) = 0;
 
 	/// Current velocity of the agent
-	virtual void agent_set_velocity(RID p_agent, Vector3 p_velocity) const = 0;
+	virtual void agent_set_velocity(RID p_agent, Vector3 p_velocity) = 0;
 
 	/// The new target velocity.
-	virtual void agent_set_target_velocity(RID p_agent, Vector3 p_velocity) const = 0;
+	virtual void agent_set_target_velocity(RID p_agent, Vector3 p_velocity) = 0;
 
 	/// Position of the agent in world space.
-	virtual void agent_set_position(RID p_agent, Vector3 p_position) const = 0;
+	virtual void agent_set_position(RID p_agent, Vector3 p_position) = 0;
 
 	/// Agent ignore the Y axis and avoid collisions by moving only on the horizontal plane
-	virtual void agent_set_ignore_y(RID p_agent, bool p_ignore) const = 0;
+	virtual void agent_set_ignore_y(RID p_agent, bool p_ignore) = 0;
 
 	/// Returns true if the map got changed the previous frame.
 	virtual bool agent_is_map_changed(RID p_agent) const = 0;
 
 	/// Callback called at the end of the RVO process
-	virtual void agent_set_callback(RID p_agent, ObjectID p_object_id, StringName p_method, Variant p_udata = Variant()) const = 0;
+	virtual void agent_set_callback(RID p_agent, ObjectID p_object_id, StringName p_method, Variant p_udata = Variant()) = 0;
 
 	/// Destroy the `RID`
-	virtual void free(RID p_object) const = 0;
+	virtual void free(RID p_object) = 0;
 
 	/// Control activation of this server.
-	virtual void set_active(bool p_active) const = 0;
+	virtual void set_active(bool p_active) = 0;
 
 	/// Process the collision avoidance agents.
 	/// The result of this process is needed by the physics server,

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -301,8 +301,8 @@ void register_server_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("AudioServer", AudioServer::get_singleton(), "AudioServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PhysicsServer2D", PhysicsServer2D::get_singleton(), "PhysicsServer2D"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PhysicsServer3D", PhysicsServer3D::get_singleton(), "PhysicsServer3D"));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer2D", NavigationServer2D::get_singleton_mut(), "NavigationServer2D"));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer3D", NavigationServer3D::get_singleton_mut(), "NavigationServer3D"));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer2D", NavigationServer2D::get_singleton(), "NavigationServer2D"));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer3D", NavigationServer3D::get_singleton(), "NavigationServer3D"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("XRServer", XRServer::get_singleton(), "XRServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("CameraServer", CameraServer::get_singleton(), "CameraServer"));
 }


### PR DESCRIPTION
`const` is used on all methods, even when they cause modification of the server.  This reworks the methods of the server to only use `const` on methods that don't change the state of the server.

This achieves the following:
- Navigation server was the only server that used `const` on most methods. This change brings it more in line with other servers in Godot.
- Having methods that ultimately change the state of the server marked as `const` is confusing, as `const` indicates that the method will not change the class it is called on (with various exceptions).
- Having all methods marked as `const` also binds the hands of other users that might want to implement their own navigation server and don't want to defer updates until later.
- This gets rid of the need to `const_cast` in many methods in order to make the changes the method *actually* makes.
- There were two `get_singleton` methods that were used inconsistently.  There is now only one.

Should have no effect on usages of the server from GDScript. I haven't seen any changes in the behavior of the server from my testing.  I believe this change is backwards compatible, with the exception of custom modules that used the server directly and happened to rely on the odd `const`ness.
