### PR TITLE
Unify typing of variables, constants and parameters in GDScript

### DIFF
--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -69,16 +69,17 @@ class GDScriptAnalyzer {
 	void resolve_function_body(GDScriptParser::FunctionNode *p_function);
 	void resolve_node(GDScriptParser::Node *p_node, bool p_is_root = true);
 	void resolve_suite(GDScriptParser::SuiteNode *p_suite);
+	void resolve_assignable(GDScriptParser::AssignableNode *p_assignable, const char *p_kind);
+	void resolve_variable(GDScriptParser::VariableNode *p_variable, bool p_is_local);
+	void resolve_constant(GDScriptParser::ConstantNode *p_constant, bool p_is_local);
+	void resolve_parameter(GDScriptParser::ParameterNode *p_parameter);
 	void resolve_if(GDScriptParser::IfNode *p_if);
 	void resolve_for(GDScriptParser::ForNode *p_for);
 	void resolve_while(GDScriptParser::WhileNode *p_while);
-	void resolve_variable(GDScriptParser::VariableNode *p_variable);
-	void resolve_constant(GDScriptParser::ConstantNode *p_constant);
 	void resolve_assert(GDScriptParser::AssertNode *p_assert);
 	void resolve_match(GDScriptParser::MatchNode *p_match);
 	void resolve_match_branch(GDScriptParser::MatchBranchNode *p_match_branch, GDScriptParser::ExpressionNode *p_match_test);
 	void resolve_match_pattern(GDScriptParser::PatternNode *p_match_pattern, GDScriptParser::ExpressionNode *p_match_test);
-	void resolve_parameter(GDScriptParser::ParameterNode *p_parameter);
 	void resolve_return(GDScriptParser::ReturnNode *p_return);
 
 	// Reduction functions.

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2022,10 +2022,10 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 		for (int i = 0; i < p_func->parameters.size(); i++) {
 			const GDScriptParser::ParameterNode *parameter = p_func->parameters[i];
 			GDScriptDataType par_type = _gdtype_from_datatype(parameter->get_datatype(), p_script);
-			uint32_t par_addr = codegen.generator->add_parameter(parameter->identifier->name, parameter->default_value != nullptr, par_type);
+			uint32_t par_addr = codegen.generator->add_parameter(parameter->identifier->name, parameter->initializer != nullptr, par_type);
 			codegen.parameters[parameter->identifier->name] = GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::FUNCTION_PARAMETER, par_addr, par_type);
 
-			if (p_func->parameters[i]->default_value != nullptr) {
+			if (p_func->parameters[i]->initializer != nullptr) {
 				optional_parameters++;
 			}
 		}
@@ -2097,7 +2097,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 			codegen.generator->start_parameters();
 			for (int i = p_func->parameters.size() - optional_parameters; i < p_func->parameters.size(); i++) {
 				const GDScriptParser::ParameterNode *parameter = p_func->parameters[i];
-				GDScriptCodeGenerator::Address src_addr = _parse_expression(codegen, r_error, parameter->default_value);
+				GDScriptCodeGenerator::Address src_addr = _parse_expression(codegen, r_error, parameter->initializer);
 				if (r_error) {
 					memdelete(codegen.generator);
 					return nullptr;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -683,37 +683,37 @@ static String _make_arguments_hint(const GDScriptParser::FunctionNode *p_functio
 			arghint += par->identifier->name.operator String() + ": " + par->get_datatype().to_string();
 		}
 
-		if (par->default_value) {
+		if (par->initializer) {
 			String def_val = "<unknown>";
-			switch (par->default_value->type) {
+			switch (par->initializer->type) {
 				case GDScriptParser::Node::LITERAL: {
-					const GDScriptParser::LiteralNode *literal = static_cast<const GDScriptParser::LiteralNode *>(par->default_value);
+					const GDScriptParser::LiteralNode *literal = static_cast<const GDScriptParser::LiteralNode *>(par->initializer);
 					def_val = literal->value.get_construct_string();
 				} break;
 				case GDScriptParser::Node::IDENTIFIER: {
-					const GDScriptParser::IdentifierNode *id = static_cast<const GDScriptParser::IdentifierNode *>(par->default_value);
+					const GDScriptParser::IdentifierNode *id = static_cast<const GDScriptParser::IdentifierNode *>(par->initializer);
 					def_val = id->name.operator String();
 				} break;
 				case GDScriptParser::Node::CALL: {
-					const GDScriptParser::CallNode *call = static_cast<const GDScriptParser::CallNode *>(par->default_value);
+					const GDScriptParser::CallNode *call = static_cast<const GDScriptParser::CallNode *>(par->initializer);
 					if (call->is_constant && call->reduced) {
 						def_val = call->function_name.operator String() + call->reduced_value.operator String();
 					}
 				} break;
 				case GDScriptParser::Node::ARRAY: {
-					const GDScriptParser::ArrayNode *arr = static_cast<const GDScriptParser::ArrayNode *>(par->default_value);
+					const GDScriptParser::ArrayNode *arr = static_cast<const GDScriptParser::ArrayNode *>(par->initializer);
 					if (arr->is_constant && arr->reduced) {
 						def_val = arr->reduced_value.operator String();
 					}
 				} break;
 				case GDScriptParser::Node::DICTIONARY: {
-					const GDScriptParser::DictionaryNode *dict = static_cast<const GDScriptParser::DictionaryNode *>(par->default_value);
+					const GDScriptParser::DictionaryNode *dict = static_cast<const GDScriptParser::DictionaryNode *>(par->initializer);
 					if (dict->is_constant && dict->reduced) {
 						def_val = dict->reduced_value.operator String();
 					}
 				} break;
 				case GDScriptParser::Node::SUBSCRIPT: {
-					const GDScriptParser::SubscriptNode *sub = static_cast<const GDScriptParser::SubscriptNode *>(par->default_value);
+					const GDScriptParser::SubscriptNode *sub = static_cast<const GDScriptParser::SubscriptNode *>(par->initializer);
 					if (sub->is_constant) {
 						if (sub->datatype.kind == GDScriptParser::DataType::ENUM) {
 							def_val = sub->get_datatype().to_string();
@@ -1856,9 +1856,9 @@ static bool _guess_identifier_type(GDScriptParser::CompletionContext &p_context,
 					}
 					break;
 				case GDScriptParser::SuiteNode::Local::PARAMETER:
-					if (local.parameter->default_value) {
-						last_assign_line = local.parameter->default_value->end_line;
-						last_assigned_expression = local.parameter->default_value;
+					if (local.parameter->initializer) {
+						last_assign_line = local.parameter->initializer->end_line;
+						last_assigned_expression = local.parameter->initializer;
 					}
 					is_function_parameter = true;
 					break;
@@ -1939,12 +1939,12 @@ static bool _guess_identifier_type(GDScriptParser::CompletionContext &p_context,
 						if ((!id_type.is_set() || id_type.is_variant()) && parameter->get_datatype().is_hard_type()) {
 							id_type = parameter->get_datatype();
 						}
-						if (parameter->default_value) {
+						if (parameter->initializer) {
 							GDScriptParser::CompletionContext c = p_context;
 							c.current_function = parent_function;
 							c.current_class = base_type.class_type;
 							c.base = nullptr;
-							if (_guess_expression_type(c, parameter->default_value, r_type)) {
+							if (_guess_expression_type(c, parameter->initializer, r_type)) {
 								return true;
 							}
 						}

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1219,7 +1219,7 @@ GDScriptParser::ParameterNode *GDScriptParser::parse_parameter() {
 
 	if (match(GDScriptTokenizer::Token::EQUAL)) {
 		// Default value.
-		parameter->default_value = parse_expression(false);
+		parameter->initializer = parse_expression(false);
 	}
 
 	complete_extents(parameter);
@@ -1250,7 +1250,7 @@ GDScriptParser::SignalNode *GDScriptParser::parse_signal() {
 				push_error("Expected signal parameter name.");
 				break;
 			}
-			if (parameter->default_value != nullptr) {
+			if (parameter->initializer != nullptr) {
 				push_error(R"(Signal parameters cannot have a default value.)");
 			}
 			if (signal->parameters_indices.has(parameter->identifier->name)) {
@@ -1395,7 +1395,7 @@ void GDScriptParser::parse_function_signature(FunctionNode *p_function, SuiteNod
 			if (parameter == nullptr) {
 				break;
 			}
-			if (parameter->default_value != nullptr) {
+			if (parameter->initializer != nullptr) {
 				default_used = true;
 			} else {
 				if (default_used) {
@@ -4776,9 +4776,9 @@ void GDScriptParser::TreePrinter::print_parameter(ParameterNode *p_parameter) {
 		push_text(" : ");
 		print_type(p_parameter->datatype_specifier);
 	}
-	if (p_parameter->default_value != nullptr) {
+	if (p_parameter->initializer != nullptr) {
 		push_text(" = ");
-		print_expression(p_parameter->default_value);
+		print_expression(p_parameter->initializer);
 	}
 }
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -57,6 +57,7 @@ public:
 	struct AnnotationNode;
 	struct ArrayNode;
 	struct AssertNode;
+	struct AssignableNode;
 	struct AssignmentNode;
 	struct AwaitNode;
 	struct BinaryOpNode;
@@ -352,6 +353,19 @@ public:
 		AssertNode() {
 			type = ASSERT;
 		}
+	};
+
+	struct AssignableNode : public Node {
+		IdentifierNode *identifier = nullptr;
+		ExpressionNode *initializer = nullptr;
+		TypeNode *datatype_specifier = nullptr;
+		bool infer_datatype = false;
+		int usages = 0;
+
+		virtual ~AssignableNode() {}
+
+	protected:
+		AssignableNode() {}
 	};
 
 	struct AssignmentNode : public ExpressionNode {
@@ -732,12 +746,7 @@ public:
 		}
 	};
 
-	struct ConstantNode : public Node {
-		IdentifierNode *identifier = nullptr;
-		ExpressionNode *initializer = nullptr;
-		TypeNode *datatype_specifier = nullptr;
-		bool infer_datatype = false;
-		int usages = 0;
+	struct ConstantNode : public AssignableNode {
 #ifdef TOOLS_ENABLED
 		String doc_description;
 #endif // TOOLS_ENABLED
@@ -902,13 +911,7 @@ public:
 		}
 	};
 
-	struct ParameterNode : public Node {
-		IdentifierNode *identifier = nullptr;
-		ExpressionNode *default_value = nullptr;
-		TypeNode *datatype_specifier = nullptr;
-		bool infer_datatype = false;
-		int usages = 0;
-
+	struct ParameterNode : public AssignableNode {
 		ParameterNode() {
 			type = PARAMETER;
 		}
@@ -1157,17 +1160,12 @@ public:
 		}
 	};
 
-	struct VariableNode : public Node {
+	struct VariableNode : public AssignableNode {
 		enum PropertyStyle {
 			PROP_NONE,
 			PROP_INLINE,
 			PROP_SETGET,
 		};
-
-		IdentifierNode *identifier = nullptr;
-		ExpressionNode *initializer = nullptr;
-		TypeNode *datatype_specifier = nullptr;
-		bool infer_datatype = false;
 
 		PropertyStyle property = PROP_NONE;
 		union {
@@ -1184,7 +1182,6 @@ public:
 		bool onready = false;
 		PropertyInfo export_info;
 		int assignments = 0;
-		int usages = 0;
 		bool use_conversion_assign = false;
 #ifdef TOOLS_ENABLED
 		String doc_description;

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -350,8 +350,8 @@ void ExtendGDScriptParser::parse_function_symbol(const GDScriptParser::FunctionN
 		if (parameter->get_datatype().is_hard_type()) {
 			parameters += ": " + parameter->get_datatype().to_string();
 		}
-		if (parameter->default_value != nullptr) {
-			parameters += " = " + parameter->default_value->reduced_value.to_json_string();
+		if (parameter->initializer != nullptr) {
+			parameters += " = " + parameter->initializer->reduced_value.to_json_string();
 		}
 	}
 	r_symbol.detail += parameters + ")";
@@ -695,8 +695,8 @@ Dictionary ExtendGDScriptParser::dump_function_api(const GDScriptParser::Functio
 		Dictionary arg;
 		arg["name"] = p_func->parameters[i]->identifier->name;
 		arg["type"] = p_func->parameters[i]->get_datatype().to_string();
-		if (p_func->parameters[i]->default_value != nullptr) {
-			arg["default_value"] = p_func->parameters[i]->default_value->reduced_value;
+		if (p_func->parameters[i]->initializer != nullptr) {
+			arg["default_value"] = p_func->parameters[i]->initializer->reduced_value;
 		}
 		parameters.push_back(arg);
 	}

--- a/modules/gdscript/tests/scripts/analyzer/errors/enum_class_var_init_with_wrong_enum_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/enum_class_var_init_with_wrong_enum_type.out
@@ -1,2 +1,2 @@
 GDTEST_ANALYZER_ERROR
-Value of type "MyOtherEnum (enum)" cannot be assigned to a variable of type "MyEnum (enum)".
+Cannot assign a value of type MyOtherEnum (enum) to variable "class_var" with specified type MyEnum (enum).

--- a/modules/gdscript/tests/scripts/analyzer/errors/enum_local_var_init_with_wrong_enum_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/enum_local_var_init_with_wrong_enum_type.out
@@ -1,2 +1,2 @@
 GDTEST_ANALYZER_ERROR
-Value of type "MyOtherEnum (enum)" cannot be assigned to a variable of type "MyEnum (enum)".
+Cannot assign a value of type MyOtherEnum (enum) to variable "local_var" with specified type MyEnum (enum).

--- a/modules/gdscript/tests/scripts/analyzer/errors/setter_parameter_uses_property_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/setter_parameter_uses_property_type.out
@@ -1,2 +1,2 @@
 GDTEST_ANALYZER_ERROR
-Value of type "int" cannot be assigned to a variable of type "String".
+Cannot assign a value of type int to variable "x" with specified type String.

--- a/modules/gdscript/tests/scripts/analyzer/features/default_arg_convertable.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/default_arg_convertable.gd
@@ -1,0 +1,6 @@
+func check(arg: float = 3):
+	return typeof(arg) == typeof(3.0)
+
+func test():
+	if check():
+		print('ok')

--- a/modules/gdscript/tests/scripts/analyzer/features/default_arg_convertable.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/default_arg_convertable.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok

--- a/modules/gdscript/tests/scripts/analyzer/features/null_initializer.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/null_initializer.gd
@@ -1,0 +1,32 @@
+func check(input: int) -> bool:
+	return input == 1
+
+var recur = null
+var prop = null
+
+func check_arg(arg = null) -> void:
+	if arg != null:
+		print(check(arg))
+
+func check_recur() -> void:
+	if recur != null:
+		print(check(recur))
+	else:
+		recur = 1
+		check_recur()
+
+func test() -> void:
+	check_arg(1)
+
+	check_recur()
+
+	if prop == null:
+		set('prop', 1)
+		print(check(prop))
+		set('prop', null)
+
+	var loop = null
+	while loop != 2:
+		if loop != null:
+			print(check(loop))
+		loop = 1 if loop == null else 2

--- a/modules/gdscript/tests/scripts/analyzer/features/null_initializer.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/null_initializer.out
@@ -1,0 +1,5 @@
+GDTEST_OK
+true
+true
+true
+true

--- a/modules/gdscript/tests/scripts/analyzer/features/weak_initializer.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/weak_initializer.gd
@@ -1,0 +1,5 @@
+func test():
+	var bar = 1
+	var foo: float = bar
+	print(typeof(foo))
+	print(foo is float)

--- a/modules/gdscript/tests/scripts/analyzer/features/weak_initializer.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/weak_initializer.out
@@ -1,0 +1,3 @@
+GDTEST_OK
+3
+true

--- a/modules/gdscript/tests/scripts/analyzer/typed_array_assignment.out
+++ b/modules/gdscript/tests/scripts/analyzer/typed_array_assignment.out
@@ -1,2 +1,2 @@
 GDTEST_ANALYZER_ERROR
-Assigned value for constant "arr" has type Array[String] which is not compatible with defined type Array[int].
+Cannot assign a value of type Array[String] to constant "arr" with specified type Array[int].


### PR DESCRIPTION
Member variables, local variables, member constants, local constants and parameters - all of those have almost the same code for determining a type. This PR tries to unify that logic under one function, fix inconsistencies and to show explicitly what are the differences between those types.

Introduced `GDScriptParser::AssignableNode` as a parent for `VariableNode`, `ConstantNode` and `ParameterNode`. They all have the same properties that used by the resolving logic:
```cpp
IdentifierNode *identifier;
ExpressionNode *initializer;
TypeNode *datatype_specifier;
bool infer_datatype;
int usages;
```

The only difference is that in `ParameterNode` `initializer` was called `default_value`. If this rename is a deal breaker - can remove `AssignableNode` and pass those properties one by one instead.

Otherwise pretty-straightforward.

Notes:

- A variable has `use_conversion_assign`, strange that same functionality is not exposed to a parameter.

- I used construction like `static constexpr const char* kind = "variable";` inside a function to pass a string used in errors. Did so to avoid allocations/conversions. If this does not matter and I should use `String` instead - just let me know.

Next issue(s) about typing of null as default value is fixed (example in [next comment](https://github.com/godotengine/godot/pull/70464#issuecomment-1367688699)):  
Fixes #53115.
Fixes #56217.
Fixes #67048.
Fixes #70523.

Next issue(s) connected to assignment of weak default value to typed variable is fixed:
Fixes #66141.
Fixes #70912.