### PR TITLE
Bind methods related to disabling collision between joint bodies

### DIFF
--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -736,6 +736,14 @@
 			<description>
 			</description>
 		</method>
+		<method name="joint_disable_collisions_between_bodies">
+			<return type="void" />
+			<param index="0" name="joint" type="RID" />
+			<param index="1" name="disable" type="bool" />
+			<description>
+				Sets whether the bodies attached to the [Joint2D] will collide with each other.
+			</description>
+		</method>
 		<method name="joint_get_param" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
@@ -749,6 +757,13 @@
 			<param index="0" name="joint" type="RID" />
 			<description>
 				Returns a joint's type (see [enum JointType]).
+			</description>
+		</method>
+		<method name="joint_is_disabled_collisions_between_bodies" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns whether the bodies attached to the [Joint2D] will collide with each other.
 			</description>
 		</method>
 		<method name="joint_make_damped_spring">

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -815,6 +815,14 @@
 			<description>
 			</description>
 		</method>
+		<method name="joint_disable_collisions_between_bodies">
+			<return type="void" />
+			<param index="0" name="joint" type="RID" />
+			<param index="1" name="disable" type="bool" />
+			<description>
+				Sets whether the bodies attached to the [Joint3D] will collide with each other.
+			</description>
+		</method>
 		<method name="joint_get_solver_priority" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="joint" type="RID" />
@@ -827,6 +835,13 @@
 			<param index="0" name="joint" type="RID" />
 			<description>
 				Returns the type of the Joint3D.
+			</description>
+		</method>
+		<method name="joint_is_disabled_collisions_between_bodies" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Returns whether the bodies attached to the [Joint3D] will collide with each other.
 			</description>
 		</method>
 		<method name="joint_make_cone_twist">

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -772,6 +772,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="_joint_disable_collisions_between_bodies" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="joint" type="RID" />
+			<param index="1" name="disable" type="bool" />
+			<description>
+			</description>
+		</method>
 		<method name="_joint_get_solver_priority" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="joint" type="RID" />
@@ -780,6 +787,12 @@
 		</method>
 		<method name="_joint_get_type" qualifiers="virtual const">
 			<return type="int" enum="PhysicsServer3D.JointType" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_joint_is_disabled_collisions_between_bodies" qualifiers="virtual const">
+			<return type="bool" />
 			<param index="0" name="joint" type="RID" />
 			<description>
 			</description>

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -400,6 +400,9 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_joint_set_solver_priority, "joint", "priority");
 	GDVIRTUAL_BIND(_joint_get_solver_priority, "joint");
 
+	GDVIRTUAL_BIND(_joint_disable_collisions_between_bodies, "joint", "disable");
+	GDVIRTUAL_BIND(_joint_is_disabled_collisions_between_bodies, "joint");
+
 	GDVIRTUAL_BIND(_free_rid, "rid");
 
 	GDVIRTUAL_BIND(_set_active, "active");

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -765,6 +765,9 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("joint_set_param", "joint", "param", "value"), &PhysicsServer2D::joint_set_param);
 	ClassDB::bind_method(D_METHOD("joint_get_param", "joint", "param"), &PhysicsServer2D::joint_get_param);
 
+	ClassDB::bind_method(D_METHOD("joint_disable_collisions_between_bodies", "joint", "disable"), &PhysicsServer2D::joint_disable_collisions_between_bodies);
+	ClassDB::bind_method(D_METHOD("joint_is_disabled_collisions_between_bodies", "joint"), &PhysicsServer2D::joint_is_disabled_collisions_between_bodies);
+
 	ClassDB::bind_method(D_METHOD("joint_make_pin", "joint", "anchor", "body_a", "body_b"), &PhysicsServer2D::joint_make_pin, DEFVAL(RID()));
 	ClassDB::bind_method(D_METHOD("joint_make_groove", "joint", "groove1_a", "groove2_a", "anchor_b", "body_a", "body_b"), &PhysicsServer2D::joint_make_groove, DEFVAL(RID()), DEFVAL(RID()));
 	ClassDB::bind_method(D_METHOD("joint_make_damped_spring", "joint", "anchor_a", "anchor_b", "body_a", "body_b"), &PhysicsServer2D::joint_make_damped_spring, DEFVAL(RID()));

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -943,6 +943,9 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("joint_set_solver_priority", "joint", "priority"), &PhysicsServer3D::joint_set_solver_priority);
 	ClassDB::bind_method(D_METHOD("joint_get_solver_priority", "joint"), &PhysicsServer3D::joint_get_solver_priority);
 
+	ClassDB::bind_method(D_METHOD("joint_disable_collisions_between_bodies", "joint", "disable"), &PhysicsServer3D::joint_disable_collisions_between_bodies);
+	ClassDB::bind_method(D_METHOD("joint_is_disabled_collisions_between_bodies", "joint"), &PhysicsServer3D::joint_is_disabled_collisions_between_bodies);
+
 	ClassDB::bind_method(D_METHOD("joint_make_generic_6dof", "joint", "body_A", "local_ref_A", "body_B", "local_ref_B"), &PhysicsServer3D::joint_make_generic_6dof);
 
 	ClassDB::bind_method(D_METHOD("generic_6dof_joint_set_param", "joint", "axis", "param", "value"), &PhysicsServer3D::generic_6dof_joint_set_param);


### PR DESCRIPTION
Related to #65465, #65571 and #66936.

Currently, when implementing support for joints from a GDExtension, you'll get an error saying something like:

```
servers/extensions/physics_server_3d_extension.h:517 - Required virtual method SomeDerivedPhysicsServer3DExtension::_joint_disable_collisions_between_bodies must be overridden before calling.
```

There is however no such method to implement in `PhysicsServer3DExtension`. This seems to be due to some bindings missing for the methods related to disabling collision between joint bodies.

This PR addresses that problem, allowing you to actually override/implement the above mentioned method.

I also noticed that the 2D equivalent was also missing the equivalent bindings from the non-extended physics server, so I threw those in there as well.