### PR TITLE
Fix contentScaleFactor on iOS

### DIFF
--- a/platform/ios/display_server_ios.mm
+++ b/platform/ios/display_server_ios.mm
@@ -437,7 +437,7 @@ float DisplayServerIOS::screen_get_refresh_rate(int p_screen) const {
 }
 
 float DisplayServerIOS::screen_get_scale(int p_screen) const {
-	return [UIScreen mainScreen].nativeScale;
+	return [UIScreen mainScreen].scale;
 }
 
 Vector<DisplayServer::WindowID> DisplayServerIOS::get_window_list() const {

--- a/platform/ios/godot_view.mm
+++ b/platform/ios/godot_view.mm
@@ -151,7 +151,7 @@ static const float earth_gravity = 9.80665;
 }
 
 - (void)godot_commonInit {
-	self.contentScaleFactor = [UIScreen mainScreen].nativeScale;
+	self.contentScaleFactor = [UIScreen mainScreen].scale;
 
 	[self initTouches];
 


### PR DESCRIPTION
Fixes #69267

This PR fixes a bug where on some iOS devices games didn't fill the whole screen (check the picture in #69267). Before this fix a default Godot project didn't render properly on e.g. an iPhone 12 Mini or iPhone 7 Plus. It did however render fine on an iPad Pro, iPhone 11 Pro and iPhone 11. 

Now with this fix I managed to get consistent results across all devices (iPhone 12 Mini, iPhone 7 Plus, iPhone 11, iPhone 11 Pro, iPad Pro).