### PR TITLE
C#: Disallow init-only properties

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -295,8 +295,8 @@ namespace Godot.SourceGenerators
             foreach (var property in properties)
             {
                 // TODO: We should still restore read-only properties after reloading assembly. Two possible ways: reflection or turn RestoreGodotObjectData into a constructor overload.
-                // Ignore properties without a getter or without a setter. Godot properties must be both readable and writable.
-                if (property.IsWriteOnly || property.IsReadOnly)
+                // Ignore properties without a getter, without a setter or with an init-only setter. Godot properties must be both readable and writable.
+                if (property.IsWriteOnly || property.IsReadOnly || property.SetMethod!.IsInitOnly)
                     continue;
 
                 var marshalType = MarshalUtils.ConvertManagedTypeToMarshalType(property.Type, typeCache);

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -158,7 +158,7 @@ namespace Godot.SourceGenerators
                 // Generate SetGodotClassPropertyValue
 
                 bool allPropertiesAreReadOnly = godotClassFields.All(fi => fi.FieldSymbol.IsReadOnly) &&
-                                                godotClassProperties.All(pi => pi.PropertySymbol.IsReadOnly);
+                                                godotClassProperties.All(pi => pi.PropertySymbol.IsReadOnly || pi.PropertySymbol.SetMethod!.IsInitOnly);
 
                 if (!allPropertiesAreReadOnly)
                 {
@@ -168,7 +168,7 @@ namespace Godot.SourceGenerators
                     isFirstEntry = true;
                     foreach (var property in godotClassProperties)
                     {
-                        if (property.PropertySymbol.IsReadOnly)
+                        if (property.PropertySymbol.IsReadOnly || property.PropertySymbol.SetMethod!.IsInitOnly)
                             continue;
 
                         GeneratePropertySetter(property.PropertySymbol.Name,
@@ -407,7 +407,7 @@ namespace Godot.SourceGenerators
                     return null;
                 }
 
-                if (propertySymbol.SetMethod == null)
+                if (propertySymbol.SetMethod == null || propertySymbol.SetMethod.IsInitOnly)
                 {
                     // This should never happen, as we filtered ReadOnly properties, but just in case.
                     Common.ReportExportedMemberIsReadOnly(context, propertySymbol);

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
@@ -138,14 +138,14 @@ namespace Godot.SourceGenerators
                 }
 
                 // TODO: We should still restore read-only properties after reloading assembly. Two possible ways: reflection or turn RestoreGodotObjectData into a constructor overload.
-                // Ignore properties without a getter or without a setter. Godot properties must be both readable and writable.
+                // Ignore properties without a getter, without a setter or with an init-only setter. Godot properties must be both readable and writable.
                 if (property.IsWriteOnly)
                 {
                     Common.ReportExportedMemberIsWriteOnly(context, property);
                     continue;
                 }
 
-                if (property.IsReadOnly)
+                if (property.IsReadOnly || property.SetMethod!.IsInitOnly)
                 {
                     Common.ReportExportedMemberIsReadOnly(context, property);
                     continue;


### PR DESCRIPTION
ReadOnly properties are currently not allowed because the generated code needs to set them, this also apply to `init` properties because they need to be set after initialization.

- Fixes https://github.com/godotengine/godot/issues/70479
