### PR TITLE
Fix jumping in `AStarGrid2D` when `DIAGONAL_MODE_NEVER` is enabled

### DIFF
--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -246,17 +246,11 @@ AStarGrid2D::Point *AStarGrid2D::_jump(Point *p_from, Point *p_to) {
 		}
 	} else { // DIAGONAL_MODE_NEVER
 		if (dx != 0) {
-			if (!_is_walkable(to_x + dx, to_y)) {
+			if ((_is_walkable(to_x, to_y - 1) && !_is_walkable(to_x - dx, to_y - 1)) || (_is_walkable(to_x, to_y + 1) && !_is_walkable(to_x - dx, to_y + 1))) {
 				return p_to;
 			}
-			if (_jump(p_to, _get_point(to_x, to_y + 1)) != nullptr) {
-				return p_to;
-			}
-			if (_jump(p_to, _get_point(to_x, to_y - 1)) != nullptr) {
-				return p_to;
-			}
-		} else {
-			if (!_is_walkable(to_x, to_y + dy)) {
+		} else if (dy != 0) {
+			if ((_is_walkable(to_x - 1, to_y) && !_is_walkable(to_x - 1, to_y - dy)) || (_is_walkable(to_x + 1, to_y) && !_is_walkable(to_x + 1, to_y - dy))) {
 				return p_to;
 			}
 			if (_jump(p_to, _get_point(to_x + 1, to_y)) != nullptr) {
@@ -266,9 +260,7 @@ AStarGrid2D::Point *AStarGrid2D::_jump(Point *p_from, Point *p_to) {
 				return p_to;
 			}
 		}
-		if (_is_walkable(to_x + dx, to_y + dy) && _is_walkable(to_x + dx, to_y) && _is_walkable(to_x, to_y + dy)) {
-			return _jump(p_to, _get_point(to_x + dx, to_y + dy));
-		}
+		return _jump(p_to, _get_point(to_x + dx, to_y + dy));
 	}
 	return nullptr;
 }


### PR DESCRIPTION
Currently, jumping seems to be processes incorrectly when diagonal_mode == DIAGONAL_MODE_NEVER:

![image](https://user-images.githubusercontent.com/3036176/209391374-d5d3e57f-aead-4541-bbf4-8aadfce5a4d5.png)

After the fix:

![image](https://user-images.githubusercontent.com/3036176/209391504-d3d309a3-b6a4-49a3-98a5-4151803e3923.png)

I took the algorithm from https://github.com/qiao/PathFinding.js/blob/master/src/finders/JPFNeverMoveDiagonally.js. All other modes seem to working correctly according to that repo (the original code taken from https://github.com/juhgiyo/EpPathFinding.cs).

