### PR TITLE
C#: Rename `ConvertToX` methods

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -451,7 +451,7 @@ static String variant_type_to_managed_name(const String &p_var_type_name) {
 	}
 
 	if (p_var_type_name == Variant::get_type_name(Variant::SIGNAL)) {
-		return "SignalInfo";
+		return "Signal";
 	}
 
 	Variant::Type var_types[] = {

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MarshalUtils.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MarshalUtils.cs
@@ -311,12 +311,12 @@ namespace Godot.SourceGenerators
                         inputExpr, ")"),
                 // We need a special case for generic Godot collections and GodotObjectOrDerived[], because VariantUtils.ConvertTo<T> is slower
                 MarshalType.GodotGenericDictionary =>
-                    source.Append(VariantUtils, ".ConvertToDictionaryObject<",
+                    source.Append(VariantUtils, ".ConvertToDictionary<",
                         ((INamedTypeSymbol)typeSymbol).TypeArguments[0].FullQualifiedNameIncludeGlobal(), ", ",
                         ((INamedTypeSymbol)typeSymbol).TypeArguments[1].FullQualifiedNameIncludeGlobal(), ">(",
                         inputExpr, ")"),
                 MarshalType.GodotGenericArray =>
-                    source.Append(VariantUtils, ".ConvertToArrayObject<",
+                    source.Append(VariantUtils, ".ConvertToArray<",
                         ((INamedTypeSymbol)typeSymbol).TypeArguments[0].FullQualifiedNameIncludeGlobal(), ">(",
                         inputExpr, ")"),
                 _ => source.Append(VariantUtils, ".ConvertTo<",

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -3650,7 +3650,7 @@ void BindingsGenerator::_populate_builtin_type_interfaces() {
 	itype = TypeInterface();
 	itype.name = "Signal";
 	itype.cname = itype.name;
-	itype.proxy_name = "SignalInfo";
+	itype.proxy_name = "Signal";
 	itype.cs_type = itype.proxy_name;
 	itype.cs_in_expr = "%0";
 	itype.c_in = "%5using %0 %1_in = " C_METHOD_MANAGED_TO_SIGNAL "(in %1);\n";
@@ -3732,7 +3732,7 @@ void BindingsGenerator::_populate_builtin_type_interfaces() {
 	itype.cname = itype.name;
 	itype.cs_out = "%5return new %2(%0(%1));";
 	// For generic Godot collections, Variant.From<T>/As<T> is slower, so we need this special case
-	itype.cs_variant_to_managed = "VariantUtils.ConvertToArrayObject(%0)";
+	itype.cs_variant_to_managed = "VariantUtils.ConvertToArray(%0)";
 	itype.cs_managed_to_variant = "VariantUtils.CreateFromArray(%0)";
 	builtin_types.insert(itype.cname, itype);
 
@@ -3759,7 +3759,7 @@ void BindingsGenerator::_populate_builtin_type_interfaces() {
 	itype.cname = itype.name;
 	itype.cs_out = "%5return new %2(%0(%1));";
 	// For generic Godot collections, Variant.From<T>/As<T> is slower, so we need this special case
-	itype.cs_variant_to_managed = "VariantUtils.ConvertToDictionaryObject(%0)";
+	itype.cs_variant_to_managed = "VariantUtils.ConvertToDictionary(%0)";
 	itype.cs_managed_to_variant = "VariantUtils.CreateFromDictionary(%0)";
 	builtin_types.insert(itype.cname, itype);
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
@@ -499,7 +499,7 @@ namespace Godot.Collections
             VariantUtils.CreateFromArray(godotArray);
 
         private static Array<T> FromVariantFunc(in godot_variant variant) =>
-            VariantUtils.ConvertToArrayObject<T>(variant);
+            VariantUtils.ConvertToArray<T>(variant);
 
         static unsafe Array()
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
@@ -366,7 +366,7 @@ namespace Godot.Collections
             VariantUtils.CreateFromDictionary(godotDictionary);
 
         private static Dictionary<TKey, TValue> FromVariantFunc(in godot_variant variant) =>
-            VariantUtils.ConvertToDictionaryObject<TKey, TValue>(variant);
+            VariantUtils.ConvertToDictionary<TKey, TValue>(variant);
 
         static unsafe Dictionary()
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
@@ -436,7 +436,7 @@ namespace Godot.NativeInterop
         public static Godot.Object ConvertToGodotObject(in godot_variant p_var)
             => InteropUtils.UnmanagedGetManaged(ConvertToGodotObjectPtr(p_var));
 
-        public static string ConvertToStringObject(in godot_variant p_var)
+        public static string ConvertToString(in godot_variant p_var)
         {
             switch (p_var.Type)
             {
@@ -455,65 +455,65 @@ namespace Godot.NativeInterop
             }
         }
 
-        public static godot_string_name ConvertToStringName(in godot_variant p_var)
+        public static godot_string_name ConvertToNativeStringName(in godot_variant p_var)
             => p_var.Type == Variant.Type.StringName ?
                 NativeFuncs.godotsharp_string_name_new_copy(p_var.StringName) :
                 NativeFuncs.godotsharp_variant_as_string_name(p_var);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static StringName ConvertToStringNameObject(in godot_variant p_var)
-            => StringName.CreateTakingOwnershipOfDisposableValue(ConvertToStringName(p_var));
+        public static StringName ConvertToStringName(in godot_variant p_var)
+            => StringName.CreateTakingOwnershipOfDisposableValue(ConvertToNativeStringName(p_var));
 
-        public static godot_node_path ConvertToNodePath(in godot_variant p_var)
+        public static godot_node_path ConvertToNativeNodePath(in godot_variant p_var)
             => p_var.Type == Variant.Type.NodePath ?
                 NativeFuncs.godotsharp_node_path_new_copy(p_var.NodePath) :
                 NativeFuncs.godotsharp_variant_as_node_path(p_var);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NodePath ConvertToNodePathObject(in godot_variant p_var)
-            => NodePath.CreateTakingOwnershipOfDisposableValue(ConvertToNodePath(p_var));
+        public static NodePath ConvertToNodePath(in godot_variant p_var)
+            => NodePath.CreateTakingOwnershipOfDisposableValue(ConvertToNativeNodePath(p_var));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_callable ConvertToCallable(in godot_variant p_var)
+        public static godot_callable ConvertToNativeCallable(in godot_variant p_var)
             => NativeFuncs.godotsharp_variant_as_callable(p_var);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Callable ConvertToCallableManaged(in godot_variant p_var)
-            => Marshaling.ConvertCallableToManaged(ConvertToCallable(p_var));
+        public static Callable ConvertToCallable(in godot_variant p_var)
+            => Marshaling.ConvertCallableToManaged(ConvertToNativeCallable(p_var));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_signal ConvertToSignal(in godot_variant p_var)
+        public static godot_signal ConvertToNativeSignal(in godot_variant p_var)
             => NativeFuncs.godotsharp_variant_as_signal(p_var);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Signal ConvertToSignalManaged(in godot_variant p_var)
-            => Marshaling.ConvertSignalToManaged(ConvertToSignal(p_var));
+        public static Signal ConvertToSignal(in godot_variant p_var)
+            => Marshaling.ConvertSignalToManaged(ConvertToNativeSignal(p_var));
 
-        public static godot_array ConvertToArray(in godot_variant p_var)
+        public static godot_array ConvertToNativeArray(in godot_variant p_var)
             => p_var.Type == Variant.Type.Array ?
                 NativeFuncs.godotsharp_array_new_copy(p_var.Array) :
                 NativeFuncs.godotsharp_variant_as_array(p_var);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Collections.Array ConvertToArrayObject(in godot_variant p_var)
-            => Collections.Array.CreateTakingOwnershipOfDisposableValue(ConvertToArray(p_var));
+        public static Collections.Array ConvertToArray(in godot_variant p_var)
+            => Collections.Array.CreateTakingOwnershipOfDisposableValue(ConvertToNativeArray(p_var));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Array<T> ConvertToArrayObject<T>(in godot_variant p_var)
-            => Array<T>.CreateTakingOwnershipOfDisposableValue(ConvertToArray(p_var));
+        public static Array<T> ConvertToArray<T>(in godot_variant p_var)
+            => Array<T>.CreateTakingOwnershipOfDisposableValue(ConvertToNativeArray(p_var));
 
-        public static godot_dictionary ConvertToDictionary(in godot_variant p_var)
+        public static godot_dictionary ConvertToNativeDictionary(in godot_variant p_var)
             => p_var.Type == Variant.Type.Dictionary ?
                 NativeFuncs.godotsharp_dictionary_new_copy(p_var.Dictionary) :
                 NativeFuncs.godotsharp_variant_as_dictionary(p_var);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Dictionary ConvertToDictionaryObject(in godot_variant p_var)
-            => Dictionary.CreateTakingOwnershipOfDisposableValue(ConvertToDictionary(p_var));
+        public static Dictionary ConvertToDictionary(in godot_variant p_var)
+            => Dictionary.CreateTakingOwnershipOfDisposableValue(ConvertToNativeDictionary(p_var));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Dictionary<TKey, TValue> ConvertToDictionaryObject<TKey, TValue>(in godot_variant p_var)
-            => Dictionary<TKey, TValue>.CreateTakingOwnershipOfDisposableValue(ConvertToDictionary(p_var));
+        public static Dictionary<TKey, TValue> ConvertToDictionary<TKey, TValue>(in godot_variant p_var)
+            => Dictionary<TKey, TValue>.CreateTakingOwnershipOfDisposableValue(ConvertToNativeDictionary(p_var));
 
         public static byte[] ConvertAsPackedByteArrayToSystemArray(in godot_variant p_var)
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
@@ -315,13 +315,13 @@ public partial class VariantUtils
             return UnsafeAsT(ConvertToPlane(variant));
 
         if (typeof(T) == typeof(Callable))
-            return UnsafeAsT(ConvertToCallableManaged(variant));
+            return UnsafeAsT(ConvertToCallable(variant));
 
         if (typeof(T) == typeof(Signal))
-            return UnsafeAsT(ConvertToSignalManaged(variant));
+            return UnsafeAsT(ConvertToSignal(variant));
 
         if (typeof(T) == typeof(string))
-            return UnsafeAsT(ConvertToStringObject(variant));
+            return UnsafeAsT(ConvertToString(variant));
 
         if (typeof(T) == typeof(byte[]))
             return UnsafeAsT(ConvertAsPackedByteArrayToSystemArray(variant));
@@ -360,19 +360,19 @@ public partial class VariantUtils
             return UnsafeAsT(ConvertToSystemArrayOfRID(variant));
 
         if (typeof(T) == typeof(StringName))
-            return UnsafeAsT(ConvertToStringNameObject(variant));
+            return UnsafeAsT(ConvertToStringName(variant));
 
         if (typeof(T) == typeof(NodePath))
-            return UnsafeAsT(ConvertToNodePathObject(variant));
+            return UnsafeAsT(ConvertToNodePath(variant));
 
         if (typeof(T) == typeof(RID))
             return UnsafeAsT(ConvertToRID(variant));
 
         if (typeof(T) == typeof(Godot.Collections.Dictionary))
-            return UnsafeAsT(ConvertToDictionaryObject(variant));
+            return UnsafeAsT(ConvertToDictionary(variant));
 
         if (typeof(T) == typeof(Godot.Collections.Array))
-            return UnsafeAsT(ConvertToArrayObject(variant));
+            return UnsafeAsT(ConvertToArray(variant));
 
         if (typeof(T) == typeof(Variant))
             return UnsafeAsT(Variant.CreateCopyingBorrowed(variant));

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Variant.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Variant.cs
@@ -212,7 +212,7 @@ public partial struct Variant : IDisposable
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public string AsString() =>
-        VariantUtils.ConvertToStringObject((godot_variant)NativeVar);
+        VariantUtils.ConvertToString((godot_variant)NativeVar);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Vector2 AsVector2() =>
@@ -280,11 +280,11 @@ public partial struct Variant : IDisposable
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Callable AsCallable() =>
-        VariantUtils.ConvertToCallableManaged((godot_variant)NativeVar);
+        VariantUtils.ConvertToCallable((godot_variant)NativeVar);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Signal AsSignal() =>
-        VariantUtils.ConvertToSignalManaged((godot_variant)NativeVar);
+        VariantUtils.ConvertToSignal((godot_variant)NativeVar);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public byte[] AsByteArray() =>
@@ -329,11 +329,11 @@ public partial struct Variant : IDisposable
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Collections.Dictionary<TKey, TValue> AsGodotDictionary<TKey, TValue>() =>
-        VariantUtils.ConvertToDictionaryObject<TKey, TValue>((godot_variant)NativeVar);
+        VariantUtils.ConvertToDictionary<TKey, TValue>((godot_variant)NativeVar);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Collections.Array<T> AsGodotArray<T>() =>
-        VariantUtils.ConvertToArrayObject<T>((godot_variant)NativeVar);
+        VariantUtils.ConvertToArray<T>((godot_variant)NativeVar);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public StringName[] AsSystemArrayOfStringName() =>
@@ -353,11 +353,11 @@ public partial struct Variant : IDisposable
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public StringName AsStringName() =>
-        VariantUtils.ConvertToStringNameObject((godot_variant)NativeVar);
+        VariantUtils.ConvertToStringName((godot_variant)NativeVar);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public NodePath AsNodePath() =>
-        VariantUtils.ConvertToNodePathObject((godot_variant)NativeVar);
+        VariantUtils.ConvertToNodePath((godot_variant)NativeVar);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public RID AsRID() =>
@@ -365,11 +365,11 @@ public partial struct Variant : IDisposable
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Collections.Dictionary AsGodotDictionary() =>
-        VariantUtils.ConvertToDictionaryObject((godot_variant)NativeVar);
+        VariantUtils.ConvertToDictionary((godot_variant)NativeVar);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Collections.Array AsGodotArray() =>
-        VariantUtils.ConvertToArrayObject((godot_variant)NativeVar);
+        VariantUtils.ConvertToArray((godot_variant)NativeVar);
 
     // Explicit conversion operators to supported types
 


### PR DESCRIPTION
- Follow up to https://github.com/godotengine/godot/pull/69968.
- Renamed `ConvertToX` to `ConvertToNativeX`.
- Renamed `ConvertToXObject` to `ConvertToX`.
- Renamed `ConvertToXManaged` to `ConvertToX`.
- Fix `Signal` name in bindings generator and csharp script.
	- Found by @Daylily-Zeleen in https://github.com/godotengine/godot/pull/70299#issuecomment-1358867210

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
