### PR TITLE
[macOS] Fix stylus tilt Y direction.

### DIFF
--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -440,7 +440,7 @@
 	NSEventSubtype subtype = [event subtype];
 	if (subtype == NSEventSubtypeTabletPoint) {
 		const NSPoint p = [event tilt];
-		mm->set_tilt(Vector2(p.x, p.y));
+		mm->set_tilt(Vector2(p.x, -p.y));
 		mm->set_pen_inverted(last_pen_inverted);
 	} else if (subtype == NSEventSubtypeTabletProximity) {
 		// Check if using the eraser end of pen only on proximity event.


### PR DESCRIPTION
At least when using Apple Pencil in Sidecar mode, the Y axis was inverted. Testing it with other tilt sensitive devices is appreciated.