### PR TITLE
[3.x] Add support for svg images in the asset library

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -38,6 +38,11 @@
 #include "editor/editor_settings.h"
 #include "editor/project_settings_editor.h"
 
+#include "modules/modules_enabled.gen.h" // For svg.
+#ifdef MODULE_SVG_ENABLED
+#include "modules/svg/image_loader_svg.h"
+#endif
+
 static inline void setup_http_request(HTTPRequest *request) {
 	request->set_use_threads(EDITOR_DEF("asset_library/use_threads", true));
 
@@ -744,13 +749,29 @@ void EditorAssetLibrary::_image_update(bool use_cache, bool final, const PoolByt
 
 		uint8_t png_signature[8] = { 137, 80, 78, 71, 13, 10, 26, 10 };
 		uint8_t jpg_signature[3] = { 255, 216, 255 };
+		uint8_t webp_signature[4] = { 82, 73, 70, 70 };
+		uint8_t bmp_signature[2] = { 66, 77 };
 
 		if (r.ptr()) {
 			if ((memcmp(&r[0], &png_signature[0], 8) == 0) && Image::_png_mem_loader_func) {
 				image->copy_internals_from(Image::_png_mem_loader_func(r.ptr(), len));
 			} else if ((memcmp(&r[0], &jpg_signature[0], 3) == 0) && Image::_jpg_mem_loader_func) {
 				image->copy_internals_from(Image::_jpg_mem_loader_func(r.ptr(), len));
+			} else if ((memcmp(&r[0], &webp_signature[0], 4) == 0) && Image::_webp_mem_loader_func) {
+				image->copy_internals_from(Image::_webp_mem_loader_func(r.ptr(), len));
+			} else if ((memcmp(&r[0], &bmp_signature[0], 2) == 0) && Image::_bmp_mem_loader_func) {
+				image->copy_internals_from(Image::_bmp_mem_loader_func(r.ptr(), len));
 			}
+#ifdef MODULE_SVG_ENABLED
+			else {
+				ImageLoaderSVG svg_loader;
+				Ref<Image> img = Ref<Image>(memnew(Image));
+				Error err = svg_loader.create_image(img, &image_data, 1.0, false, false);
+				if (err == OK) {
+					image->copy_internals_from(img);
+				}
+			}
+#endif
 		}
 
 		if (!image->empty()) {

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -90,7 +90,7 @@ void ImageLoaderSVG::set_convert_colors(Dictionary *p_replace_color) {
 	}
 }
 
-Error ImageLoaderSVG::_create_image(Ref<Image> p_image, const PoolVector<uint8_t> *p_data, float p_scale, bool upsample, bool convert_colors) {
+Error ImageLoaderSVG::create_image(Ref<Image> p_image, const PoolVector<uint8_t> *p_data, float p_scale, bool upsample, bool convert_colors) {
 	NSVGimage *svg_image;
 	PoolVector<uint8_t>::Read src_r = p_data->read();
 	svg_image = nsvgParse((char *)src_r.ptr(), "px", 96);
@@ -135,8 +135,7 @@ Error ImageLoaderSVG::create_image_from_string(Ref<Image> p_image, const char *p
 	src_data.resize(str_len + 1);
 	PoolVector<uint8_t>::Write src_w = src_data.write();
 	memcpy(src_w.ptr(), p_svg_str, str_len + 1);
-
-	return _create_image(p_image, &src_data, p_scale, upsample, convert_colors);
+	return create_image(p_image, &src_data, p_scale, upsample, convert_colors);
 }
 
 Error ImageLoaderSVG::load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale) {
@@ -147,7 +146,7 @@ Error ImageLoaderSVG::load_image(Ref<Image> p_image, FileAccess *f, bool p_force
 	f->get_buffer(src_w.ptr(), size);
 	src_w.ptr()[size] = '\0';
 
-	return _create_image(p_image, &src_image, p_scale, 1.0);
+	return create_image(p_image, &src_image, p_scale, 1.0);
 }
 
 void ImageLoaderSVG::get_recognized_extensions(List<String> *p_extensions) const {

--- a/modules/svg/image_loader_svg.h
+++ b/modules/svg/image_loader_svg.h
@@ -59,10 +59,10 @@ class ImageLoaderSVG : public ImageFormatLoader {
 	} replace_colors;
 	static SVGRasterizer rasterizer;
 	static void _convert_colors(NSVGimage *p_svg_image);
-	static Error _create_image(Ref<Image> p_image, const PoolVector<uint8_t> *p_data, float p_scale, bool upsample, bool convert_colors = false);
 
 public:
 	static void set_convert_colors(Dictionary *p_replace_color = nullptr);
+	static Error create_image(Ref<Image> p_image, const PoolVector<uint8_t> *p_data, float p_scale, bool upsample, bool convert_colors = false);
 	static Error create_image_from_string(Ref<Image> p_image, const char *p_svg_str, float p_scale, bool upsample, bool convert_colors = false);
 
 	virtual Error load_image(Ref<Image> p_image, FileAccess *f, bool p_force_linear, float p_scale);


### PR DESCRIPTION
Backport of #70317

Some assets to test svg support:
- https://godotengine.org/asset-library/asset/704
- https://godotengine.org/asset-library/asset/103

> **Note:** the icons of the example assets look diffrent in the asset lib compared to the online version. This is because they are using features that nanosvg does not support (text and css styles). When importing them as svg files they look like they are shown in the editor asset lib so this is not a problem of this PR.

@Calinou mentioned [here](https://github.com/godotengine/godot/issues/70195#issuecomment-1356331368) that svg support would propably not be possible in 3.x. From what I can tell it works the same. Please tell me if I am missing some important detail.