### PR TITLE
C#: reverse Vector2.AngleToPoint

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -139,7 +139,7 @@ namespace Godot
         /// <returns>The angle between the two vectors, in radians.</returns>
         public readonly real_t AngleToPoint(Vector2 to)
         {
-            return Mathf.Atan2(y - to.y, x - to.x);
+            return Mathf.Atan2(to.y - y, to.x - x);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
@@ -123,7 +123,7 @@ namespace Godot
         /// <returns>The angle between the two vectors, in radians.</returns>
         public readonly real_t AngleToPoint(Vector2i to)
         {
-            return Mathf.Atan2(y - to.y, x - to.x);
+            return Mathf.Atan2(to.y - y, to.x - x);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #70499 ; Reverses subtraction to make C# AngleToPoint match GDScript's angle_to_point

C# glue also has the function for Vector2i (GDScript appears to have no equivalent), which I gave the same treatment

Building engine and running the example project from #70499 should output 2 zeroes (also tested Vector2i so 3)