### PR TITLE
C#: Skip getting class info for unbound generics

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPathAttributeGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPathAttributeGenerator.cs
@@ -45,8 +45,11 @@ namespace Godot.SourceGenerators
                             return false;
                         })
                 )
-                // Ignore classes whose name is not the same as the file name
-                .Where(x => Path.GetFileNameWithoutExtension(x.cds.SyntaxTree.FilePath) == x.symbol.Name)
+                .Where(x =>
+                    // Ignore classes whose name is not the same as the file name
+                    Path.GetFileNameWithoutExtension(x.cds.SyntaxTree.FilePath) == x.symbol.Name &&
+                    // Ignore generic classes
+                    !x.symbol.IsGenericType)
                 .GroupBy(x => x.symbol)
                 .ToDictionary(g => g.Key, g => g.Select(x => x.cds));
 
@@ -150,8 +153,6 @@ namespace Godot.SourceGenerators
                 first = false;
                 sourceBuilder.Append("typeof(");
                 sourceBuilder.Append(qualifiedName);
-                if (godotClass.Key.IsGenericType)
-                    sourceBuilder.Append($"<{new string(',', godotClass.Key.TypeParameters.Count() - 1)}>");
                 sourceBuilder.Append(")");
             }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -297,7 +297,7 @@ namespace Godot.Bridge
 
                 foreach (var type in assembly.GetTypes())
                 {
-                    if (type.IsNested)
+                    if (type.IsNested || type.IsGenericType)
                         continue;
 
                     if (!typeOfGodotObject.IsAssignableFrom(type))
@@ -314,9 +314,12 @@ namespace Godot.Bridge
 
                 if (scriptTypes != null)
                 {
-                    for (int i = 0; i < scriptTypes.Length; i++)
+                    foreach (var type in scriptTypes)
                     {
-                        LookupScriptForClass(scriptTypes[i]);
+                        if (type.IsGenericType)
+                            continue;
+
+                        LookupScriptForClass(type);
                     }
                 }
             }
@@ -729,6 +732,7 @@ namespace Godot.Bridge
             {
                 ExceptionUtils.LogException(e);
                 *outTool = godot_bool.False;
+                *outMethodsDest = NativeFuncs.godotsharp_array_new();
                 *outRpcFunctionsDest = NativeFuncs.godotsharp_dictionary_new();
                 *outEventSignalsDest = NativeFuncs.godotsharp_dictionary_new();
                 *outBaseScript = default;


### PR DESCRIPTION
- Avoid trying to invoke methods in types with unbound generics when trying to retrieve the script class info. Generic types are not allowed as scripts so we don't need this info.
- Set `outMethodsDest` in `ScriptManagerBridge.UpdateScriptClassInfo`.
- Fixes https://github.com/godotengine/godot/issues/67140.
- Fixes https://github.com/godotengine/godot/issues/67537.
- Fixes https://github.com/godotengine/godot/issues/68443.
