### PR TITLE
Update GDScript name after script parse

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -866,6 +866,8 @@ Error GDScript::reload(bool p_keep_state) {
 		return ERR_PARSE_ERROR;
 	}
 
+	GDScriptCompiler::make_scripts(this, parser.get_tree(), true);
+
 	GDScriptAnalyzer analyzer(&parser);
 	err = analyzer.analyze();
 


### PR DESCRIPTION
Updates a `GDScript` class `name` and `fully_qualified_name` as soon as the script is parsed. Should fix some outstanding issues with #70246.

Currently, script names are updated when the script is compiled. This means that the first time that `class_name` is added or when it is changed, `GDScriptAnalyzer` might try to `GDScript::find_class` with an invalid name, resulting in a `NULL` result. By updating names right at parse time during `GDScript::reload()`, the analyzer will have the right data.

The issue that happens in #70246 is the following:

```GDScript
extends Node
class_name MyClass # Rename the class_name and the error should pop up

class B:
	pass

func _ready():
	var _test_instance = B.new()
```

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
