### PR TITLE
Implement export_multiline support for Array[String] and Dictionary

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -4647,6 +4647,7 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				return editor;
 			} else {
 				EditorPropertyDictionary *editor = memnew(EditorPropertyDictionary);
+				editor->setup(p_hint);
 				return editor;
 			}
 		} break;

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -818,6 +818,10 @@ void EditorPropertyDictionary::_change_type_menu(int p_index) {
 	update_property();
 }
 
+void EditorPropertyDictionary::setup(PropertyHint p_hint) {
+	property_hint = p_hint;
+}
+
 void EditorPropertyDictionary::update_property() {
 	Variant updated_val = get_edited_object()->get(get_edited_property());
 
@@ -929,7 +933,13 @@ void EditorPropertyDictionary::update_property() {
 					prop = editor;
 				} break;
 				case Variant::STRING: {
-					prop = memnew(EditorPropertyText);
+					if (i != amount && property_hint == PROPERTY_HINT_MULTILINE_TEXT) {
+						// If this is NOT the new key field and there's a multiline hint,
+						// show the field as multiline
+						prop = memnew(EditorPropertyMultilineText);
+					} else {
+						prop = memnew(EditorPropertyText);
+					}
 
 				} break;
 

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -154,6 +154,7 @@ class EditorPropertyDictionary : public EditorProperty {
 	EditorSpinSlider *size_sliderv = nullptr;
 	Button *button_add_item = nullptr;
 	EditorPaginator *paginator = nullptr;
+	PropertyHint property_hint;
 
 	void _page_changed(int p_page);
 	void _edit_pressed();
@@ -169,6 +170,7 @@ protected:
 	void _notification(int p_what);
 
 public:
+	void setup(PropertyHint p_hint);
 	virtual void update_property() override;
 	EditorPropertyDictionary();
 };

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3793,6 +3793,26 @@ bool GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node
 			variable->export_info.type = Variant::INT;
 		}
 	}
+	if (p_annotation->name == SNAME("@export_multiline")) {
+		if (export_type.builtin_type == Variant::ARRAY && export_type.has_container_element_type()) {
+			DataType inner_type = export_type.get_container_element_type();
+			if (inner_type.builtin_type != Variant::STRING) {
+				push_error(vformat(R"("%s" annotation on arrays requires a string type but type "%s" was given instead.)", p_annotation->name.operator String(), inner_type.to_string()), variable);
+				return false;
+			}
+
+			String hint_prefix = itos(inner_type.builtin_type) + "/" + itos(variable->export_info.hint);
+			variable->export_info.hint = PROPERTY_HINT_TYPE_STRING;
+			variable->export_info.hint_string = hint_prefix + ":" + variable->export_info.hint_string;
+			variable->export_info.type = Variant::ARRAY;
+
+			return true;
+		} else if (export_type.builtin_type == Variant::DICTIONARY) {
+			variable->export_info.type = Variant::DICTIONARY;
+
+			return true;
+		}
+	}
 
 	if (p_annotation->name == SNAME("@export")) {
 		if (variable->datatype_specifier == nullptr && variable->initializer == nullptr) {


### PR DESCRIPTION
For arrays, specifically check if it's a string array and pass the type on to the editor. For dictionaries, save the hint on the type and use it later to draw the multiline editor, except for when adding a string key, because that doesn't make much sense. All string values however will be drawn as multiline.

Closes #62011
