### PR TITLE
Move global script class cache to separate file

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -33,6 +33,7 @@
 #include "core/core_bind.h" // For Compression enum.
 #include "core/core_string_names.h"
 #include "core/input/input_map.h"
+#include "core/io/config_file.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/file_access_network.h"
@@ -1146,6 +1147,29 @@ Variant ProjectSettings::get_setting(const String &p_setting, const Variant &p_d
 	} else {
 		return p_default_value;
 	}
+}
+
+Array ProjectSettings::get_global_class_list() {
+	Array script_classes;
+
+	Ref<ConfigFile> cf;
+	cf.instantiate();
+	if (cf->load(get_project_data_path().path_join("global_script_class_cache.cfg")) == OK) {
+		script_classes = cf->get_value("", "list");
+	} else {
+#ifndef TOOLS_ENABLED
+		// Script classes can't be recreated in exported project, so print an error.
+		ERR_PRINT("Could not load global script cache.");
+#endif
+	}
+	return script_classes;
+}
+
+void ProjectSettings::store_global_class_list(const Array &p_classes) {
+	Ref<ConfigFile> cf;
+	cf.instantiate();
+	cf->set_value("", "list", p_classes);
+	cf->save(get_project_data_path().path_join("global_script_class_cache.cfg"));
 }
 
 bool ProjectSettings::has_custom_feature(const String &p_feature) const {

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -141,6 +141,8 @@ public:
 
 	void set_setting(const String &p_setting, const Variant &p_value);
 	Variant get_setting(const String &p_setting, const Variant &p_default_value = Variant()) const;
+	Array get_global_class_list();
+	void store_global_class_list(const Array &p_classes);
 
 	bool has_setting(String p_var) const;
 	String localize_path(const String &p_path) const;

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -186,6 +186,7 @@ void ScriptServer::unregister_language(const ScriptLanguage *p_language) {
 void ScriptServer::init_languages() {
 	{ // Load global classes.
 		global_classes_clear();
+#ifndef DISABLE_DEPRECATED
 		if (ProjectSettings::get_singleton()->has_setting("_global_script_classes")) {
 			Array script_classes = GLOBAL_GET("_global_script_classes");
 
@@ -196,6 +197,17 @@ void ScriptServer::init_languages() {
 				}
 				add_global_class(c["class"], c["base"], c["language"], c["path"]);
 			}
+			ProjectSettings::get_singleton()->clear("_global_script_classes");
+		}
+#endif
+
+		Array script_classes = ProjectSettings::get_singleton()->get_global_class_list();
+		for (int i = 0; i < script_classes.size(); i++) {
+			Dictionary c = script_classes[i];
+			if (!c.has("class") || !c.has("language") || !c.has("path") || !c.has("base")) {
+				continue;
+			}
+			add_global_class(c["class"], c["base"], c["language"], c["path"]);
 		}
 	}
 
@@ -291,6 +303,17 @@ void ScriptServer::get_global_class_list(List<StringName> *r_global_classes) {
 }
 
 void ScriptServer::save_global_classes() {
+	Dictionary class_icons;
+
+	Array script_classes = ProjectSettings::get_singleton()->get_global_class_list();
+	for (int i = 0; i < script_classes.size(); i++) {
+		Dictionary d = script_classes[i];
+		if (!d.has("name") || !d.has("icon")) {
+			continue;
+		}
+		class_icons[d["name"]] = d["icon"];
+	}
+
 	List<StringName> gc;
 	get_global_class_list(&gc);
 	Array gcarr;
@@ -300,25 +323,10 @@ void ScriptServer::save_global_classes() {
 		d["language"] = global_classes[E].language;
 		d["path"] = global_classes[E].path;
 		d["base"] = global_classes[E].base;
+		d["icon"] = class_icons.get(E, "");
 		gcarr.push_back(d);
 	}
-
-	Array old;
-	if (ProjectSettings::get_singleton()->has_setting("_global_script_classes")) {
-		old = GLOBAL_GET("_global_script_classes");
-	}
-	if ((!old.is_empty() || gcarr.is_empty()) && gcarr.hash() == old.hash()) {
-		return;
-	}
-
-	if (gcarr.is_empty()) {
-		if (ProjectSettings::get_singleton()->has_setting("_global_script_classes")) {
-			ProjectSettings::get_singleton()->clear("_global_script_classes");
-		}
-	} else {
-		ProjectSettings::get_singleton()->set("_global_script_classes", gcarr);
-	}
-	ProjectSettings::get_singleton()->save();
+	ProjectSettings::get_singleton()->store_global_class_list(gcarr);
 }
 
 ////////////////////

--- a/doc/classes/Variant.xml
+++ b/doc/classes/Variant.xml
@@ -38,7 +38,7 @@
 		        # To get the name of the underlying Object type, you need the `get_class()` method.
 		        print("foo is a(n) %s" % foo.get_class()) # inject the class name into a formatted string.
 		        # Note also that there is not yet any way to get a script's `class_name` string easily.
-		        # To fetch that value, you need to dig deeply into a hidden ProjectSettings setting: an Array of Dictionaries called "_global_script_classes".
+		        # To fetch that value, you can parse the [code]res://.godot/global_script_class_cache.cfg[/code] file with the [ConfigFile] API.
 		        # Open your project.godot file to see it up close.
 		[/gdscript]
 		[csharp]

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -786,6 +786,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	HashSet<String> paths;
 	Vector<String> path_remaps;
 
+	paths.insert(ProjectSettings::get_singleton()->get_project_data_path().path_join("global_script_class_cache.cfg"));
 	if (p_preset->get_export_filter() == EditorExportPreset::EXPORT_ALL_RESOURCES) {
 		//find stuff
 		_export_find_resources(EditorFileSystem::get_singleton()->get_filesystem(), paths);


### PR DESCRIPTION
This PR removes `_global_script_classes` and `_global_script_class_icons` from `project.godot` and moves them to a separate file `.godot/global_script_class_cache.cfg`. The file is also included in the exported project.

Closes https://github.com/godotengine/godot-proposals/issues/5631
Also fixes #62889