### PR TITLE
Document that you can't set ScrollContainer `scroll_*` value in `_ready()`

### DIFF
--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -52,10 +52,20 @@
 			Deadzone for touch scrolling. Lower deadzone makes the scrolling more sensitive.
 		</member>
 		<member name="scroll_horizontal" type="int" setter="set_h_scroll" getter="get_h_scroll" default="0">
-			The current horizontal scroll value.
+			The current horizontal scroll value. 
+			[b]Note:[/b] If you are setting this value in the [method Node._ready] function or earlier, it needs to be wrapped with [method Object.set_deferred], since scroll bar's [member Range.max_value] is not initialized yet.
+			[codeblock]
+			func _ready():
+			    set_deferred("scroll_horizontal", 600)
+			[/codeblock]
 		</member>
 		<member name="scroll_vertical" type="int" setter="set_v_scroll" getter="get_v_scroll" default="0">
 			The current vertical scroll value.
+			[b]Note:[/b] Setting it early needs to be deferred, just like in [member scroll_horizontal].
+			[codeblock]
+			func _ready():
+			    set_deferred("scroll_vertical", 600)
+			[/codeblock]
 		</member>
 		<member name="vertical_scroll_mode" type="int" setter="set_vertical_scroll_mode" getter="get_vertical_scroll_mode" enum="ScrollContainer.ScrollMode" default="1">
 			Controls whether vertical scrollbar can be used and when it should be visible. See [enum ScrollMode] for options.


### PR DESCRIPTION
Fix: #58914

for 3.x: #70563 