### PR TITLE
Fix crash in RichTextLabel table parsing

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3336,6 +3336,7 @@ void RichTextLabel::push_table(int p_columns, InlineAlignment p_alignment, int p
 	_stop_thread();
 	MutexLock data_lock(data_mutex);
 
+	ERR_FAIL_COND(current->type == ITEM_TABLE);
 	ERR_FAIL_COND(p_columns < 1);
 	ItemTable *item = memnew(ItemTable);
 


### PR DESCRIPTION
This fixes project/editor crash while editing the bbcode for RichTextLabel

bbcode that causes the crash
```
QQQ
[table=1]
[table=
[url=XXX]AAA[/url][url=YYY]BBB[/url][url=ZZZ]CCC[/url]

```

backtrace of the crash:
```
#0  0x00007fa19fd1364c in ?? () from /usr/lib/libc.so.6
#1  0x00007fa19fcc3958 in raise () from /usr/lib/libc.so.6
#2  0x00007fa19fcad53d in abort () from /usr/lib/libc.so.6
#3  0x000055f1c74011a7 in handle_crash (sig=11) at platform/linuxbsd/crash_handler_linuxbsd.cpp:131
#4  <signal handler called>
#5  0x00007fa19fd14b04 in pthread_mutex_lock () from /usr/lib/libc.so.6
#6  0x000055f1c74122b4 in __gthread_mutex_lock (__mutex=0x198) at /usr/include/c++/12.2.0/x86_64-pc-linux-gnu/bits/gthr-default.h:749
#7  0x000055f1c7412304 in __gthread_recursive_mutex_lock (__mutex=0x198) at /usr/include/c++/12.2.0/x86_64-pc-linux-gnu/bits/gthr-default.h:811
#8  0x000055f1c7412338 in std::recursive_mutex::lock (this=0x198) at /usr/include/c++/12.2.0/mutex:108
#9  0x000055f1ca335537 in MutexImpl<std::recursive_mutex>::lock (this=0x198) at ./core/os/mutex.h:45
#10 MutexLock<MutexImpl<std::recursive_mutex> >::MutexLock (p_mutex=..., this=<optimized out>) at ./core/os/mutex.h:64
#11 RichTextLabel::_draw_line (this=0x55f1ea77e130, p_frame=0x55f1d19b1ff0, p_line=0, p_ofs=..., p_width=3, p_base_color=..., p_outline_size=0, p_outline_color=..., p_font_shadow_color=..., 
    p_shadow_outline_size=1, p_shadow_ofs=..., r_processed_glyphs=@0x7ffd23596474: 3) at scene/gui/rich_text_label.cpp:751
#12 0x000055f1ca337137 in RichTextLabel::_draw_line (this=0x55f1ea77e130, p_frame=0x55f1e5378b40, p_line=1, p_ofs=..., p_width=770, p_base_color=..., p_outline_size=0, p_outline_color=..., 
    p_font_shadow_color=..., p_shadow_outline_size=1, p_shadow_ofs=..., r_processed_glyphs=@0x7ffd23596474: 3) at scene/gui/rich_text_label.cpp:951
#13 0x000055f1ca341bdd in RichTextLabel::_notification (this=0x55f1ea77e130, p_what=30) at scene/gui/rich_text_label.cpp:1859
#14 0x000055f1ca3675c2 in RichTextLabel::_notificationv (this=0x55f1ea77e130, p_notification=30, p_reversed=false) at scene/gui/rich_text_label.h:40
#15 0x000055f1cc24cdb9 in Object::notification (this=0x55f1ea77e130, p_notification=30, p_reversed=false) at core/object/object.cpp:790
#16 0x000055f1c9fbaccb in CanvasItem::_redraw_callback (this=0x55f1ea77e130) at scene/main/canvas_item.cpp:135
#17 0x000055f1c8df6354 in call_with_variant_args_helper<CanvasItem>(CanvasItem*, void (CanvasItem::*)(), Variant const**, Callable::CallError&, IndexSequence<>) (p_instance=0x55f1ea77e130, 
    p_method=(void (CanvasItem::*)(CanvasItem * const)) 0x55f1c9fbac34 <CanvasItem::_redraw_callback()>, p_args=0x0, r_error=...) at ./core/variant/binder_common.h:262
#18 0x000055f1c8df3a4a in call_with_variant_args<CanvasItem> (p_instance=0x55f1ea77e130, p_method=(void (CanvasItem::*)(CanvasItem * const)) 0x55f1c9fbac34 <CanvasItem::_redraw_callback()>, p_args=0x0, 
    p_argcount=0, r_error=...) at ./core/variant/binder_common.h:376
#19 0x000055f1c8df02e0 in CallableCustomMethodPointer<CanvasItem>::call (this=0x55f1d9be44a0, p_arguments=0x0, p_argcount=0, r_return_value=..., r_call_error=...) at ./core/object/callable_method_pointer.h:104
#20 0x000055f1cbeba4b9 in Callable::callp (this=0x7fa19c3b9080, p_arguments=0x0, p_argcount=0, r_return_value=..., r_call_error=...) at core/variant/callable.cpp:50
#21 0x000055f1cc24691c in MessageQueue::_call_function (this=0x55f1d14d3b20, p_callable=..., p_args=0x7fa19c3b9098, p_argcount=0, p_show_error=false) at core/object/message_queue.cpp:229
#22 0x000055f1cc246c6b in MessageQueue::flush (this=0x55f1d14d3b20) at core/object/message_queue.cpp:275
#23 0x000055f1ca066b58 in SceneTree::process (this=0x55f1d3ad6910, p_time=0.010521666666666667) at scene/main/scene_tree.cpp:461
#24 0x000055f1c747b897 in Main::iteration () at main/main.cpp:3193
#25 0x000055f1c7409622 in OS_LinuxBSD::run (this=0x7ffd23596ba0) at platform/linuxbsd/os_linuxbsd.cpp:878
#26 0x000055f1c7400884 in main (argc=4, argv=0x7ffd235970e8) at platform/linuxbsd/godot_linuxbsd.cpp:73


```