### PR TITLE
Fix wrong `AnimationStateMachine` process for end of fading

### DIFF
--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -415,9 +415,6 @@ double AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_s
 				fading_pos += p_time;
 			}
 			fade_blend = MIN(1.0, fading_pos / fading_time);
-			if (fade_blend > 1.0) {
-				fading_from = StringName();
-			}
 		}
 	}
 
@@ -426,9 +423,12 @@ double AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_s
 	}
 	double rem = p_state_machine->blend_node(current, p_state_machine->states[current].node, p_time, p_seek, p_is_external_seeking, Math::is_zero_approx(fade_blend) ? CMP_EPSILON : fade_blend, AnimationNode::FILTER_IGNORE, true); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
 
-	double fade_blend_inv = 1.0 - fade_blend;
 	if (fading_from != StringName()) {
+		double fade_blend_inv = 1.0 - fade_blend;
 		p_state_machine->blend_node(fading_from, p_state_machine->states[fading_from].node, p_time, p_seek, p_is_external_seeking, Math::is_zero_approx(fade_blend_inv) ? CMP_EPSILON : fade_blend_inv, AnimationNode::FILTER_IGNORE, true); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
+		if (fade_blend >= 1.0) {
+			fading_from = StringName();
+		}
 	}
 
 	//guess playback position


### PR DESCRIPTION
Fixes #70536
Follow up #70278

The proper implementation is not to change the blend value threshold of the fade, but to change the order of the fade termination process.