### PR TITLE
Add a path existence check to AnimationStateMachine for teleporting travel

### DIFF
--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -367,9 +367,15 @@ double AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_s
 			} else {
 				if (!_travel(p_state_machine, start_request)) {
 					// can't travel, then teleport
-					path.clear();
-					current = start_request;
-					play_start = true;
+					if (p_state_machine->states.has(start_request)) {
+						path.clear();
+						current = start_request;
+						play_start = true;
+					} else {
+						StringName node = start_request;
+						start_request = StringName(); //clear start request
+						ERR_FAIL_V_MSG(0, "No such node: '" + node + "'");
+					}
 				}
 				start_request = StringName(); //clear start request
 			}


### PR DESCRIPTION
For https://github.com/gdquest-demos/godot-4-3d-third-person-controller/issues/5#issue-1510189832

Without this, StateMachine will try to teleporting travel to invalid paths continuously.