### PR TITLE
[3.x] Set touch input as handled only after _gui_call_input

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2329,8 +2329,8 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 					}
 					touch_event->set_position(pos);
 					_gui_call_input(over, touch_event);
+					set_input_as_handled();
 				}
-				set_input_as_handled();
 				return;
 			}
 		} else {
@@ -2346,8 +2346,8 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				touch_event->set_position(pos);
 
 				_gui_call_input(over, touch_event);
+				set_input_as_handled();
 			}
-			set_input_as_handled();
 			gui.touch_focus.erase(touch_index);
 			return;
 		}


### PR DESCRIPTION
Fixes #70119, which was introduced after #68630.

Old code used to call `set_input_as_handled` even if there's no `Control` node at that position, which led to the event getting dismissed and not propagated in `_unhandled_event` calls in GDScript.

Note that this fix is not required for 4.x version (corresponding PR: #68632) because it uses the return value of `_gui_call_input` to determine whether the event should be marked as handled. (I didn't try to reproduce the bug in 4.x though.) This fix does not consider what `_gui_call_input` does because it returns `void` in 3.x. We can update the return value of that function in the future.