### PR TITLE
Fix errors related to reflection probe now using a render buffers object

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -362,6 +362,8 @@ RID RenderForwardMobile::_setup_render_pass_uniform_set(RenderListType p_render_
 	if (p_render_data && p_render_data->render_buffers.is_valid()) {
 		rb = p_render_data->render_buffers;
 		if (rb->has_custom_data(RB_SCOPE_MOBILE)) {
+			// Our forward mobile custom data buffer will only be available when we're rendering our normal view.
+			// This will not be available when rendering reflection probes.
 			rb_data = rb->get_custom_data(RB_SCOPE_MOBILE);
 		}
 	}
@@ -643,6 +645,8 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 	if (p_render_data->render_buffers.is_valid()) {
 		rb = p_render_data->render_buffers;
 		if (rb->has_custom_data(RB_SCOPE_MOBILE)) {
+			// Our forward mobile custom data buffer will only be available when we're rendering our normal view.
+			// This will not be available when rendering reflection probes.
 			rb_data = rb->get_custom_data(RB_SCOPE_MOBILE);
 		}
 	}

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
@@ -202,6 +202,7 @@ void RenderSceneBuffersRD::configure(RID p_render_target, const Size2i p_interna
 		vrs_texture = create_texture(RB_SCOPE_VRS, RB_TEXTURE, RD::DATA_FORMAT_R8_UINT, usage_bits, RD::TEXTURE_SAMPLES_1, vrs->get_vrs_texture_size(internal_size));
 	}
 
+	// (re-)configure any named buffers
 	for (KeyValue<StringName, Ref<RenderBufferCustomDataRD>> &E : data_buffers) {
 		E.value->configure(this);
 	}
@@ -220,6 +221,14 @@ void RenderSceneBuffersRD::configure_for_reflections(const Size2i p_reflection_s
 	use_taa = false;
 	use_debanding = false;
 	view_count = 1;
+
+	// cleanout any old buffers we had.
+	cleanup();
+
+	// (re-)configure any named buffers
+	for (KeyValue<StringName, Ref<RenderBufferCustomDataRD>> &E : data_buffers) {
+		E.value->configure(this);
+	}
 }
 
 void RenderSceneBuffersRD::set_fsr_sharpness(float p_fsr_sharpness) {
@@ -498,10 +507,6 @@ void RenderSceneBuffersRD::set_custom_data(const StringName &p_name, Ref<RenderB
 }
 
 Ref<RenderBufferCustomDataRD> RenderSceneBuffersRD::get_custom_data(const StringName &p_name) const {
-	if (!data_buffers.has(p_name)) {
-		print_line("test");
-	}
-
 	ERR_FAIL_COND_V(!data_buffers.has(p_name), Ref<RenderBufferCustomDataRD>());
 
 	Ref<RenderBufferCustomDataRD> ret = data_buffers[p_name];


### PR DESCRIPTION
Fixes #70532 

Now that we're using render buffers for reflection probes as well there were a few places I missed where the old logic was assuming that if render buffers where valid, we must not be rendering reflection probes.