### PR TITLE
[3.x] Fix RichTextLabel discards appended BBCode text on window resize when using DynamicFont

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1016,20 +1016,17 @@ void RichTextLabel::_notification(int p_what) {
 				update();
 			}
 		} break;
-		case NOTIFICATION_RESIZED: {
+		case NOTIFICATION_RESIZED:
+		case NOTIFICATION_THEME_CHANGED: {
 			main->first_invalid_line = 0; //invalidate ALL
 			update();
-
 		} break;
-		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_ENTER_TREE: {
 			if (bbcode != "") {
 				set_bbcode(bbcode);
 			}
-
 			main->first_invalid_line = 0; //invalidate ALL
 			update();
-
 		} break;
 		case NOTIFICATION_DRAW: {
 			_validate_line_caches(main);


### PR DESCRIPTION
Fixes #62640