### PR TITLE
Keep terrain choice when changing layer in tilemap editor

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -3301,12 +3301,16 @@ void TileMapEditorTerrainsPlugin::_update_theme() {
 void TileMapEditorTerrainsPlugin::edit(ObjectID p_tile_map_id, int p_tile_map_layer) {
 	_stop_dragging(); // Avoids staying in a wrong drag state.
 
-	tile_map_id = p_tile_map_id;
-	tile_map_layer = p_tile_map_layer;
+	if (tile_map_id != p_tile_map_id) {
+		tile_map_id = p_tile_map_id;
 
-	_update_terrains_cache();
-	_update_terrains_tree();
-	_update_tiles_list();
+		// Clear the selection.
+		_update_terrains_cache();
+		_update_terrains_tree();
+		_update_tiles_list();
+	}
+
+	tile_map_layer = p_tile_map_layer;
 }
 
 TileMapEditorTerrainsPlugin::TileMapEditorTerrainsPlugin() {


### PR DESCRIPTION
Make `TileMapEditorTerrainsPlugin::edit` logic analogous to `TileMapEditorTilesPlugin::edit`, in that the selection is only cleared when switching to another tilemap.

Closes #70033.

Compatible with 4.x only.