### PR TITLE
Fix unable to switch to animation editor

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -4119,7 +4119,7 @@ void EditorPropertyResource::update_property() {
 					}
 				}
 
-				if (use_editor) {
+				if (use_editor && !is_keying()) {
 					// Open editor directly and hide other such editors which are currently open.
 					_open_editor_pressed();
 					if (is_inside_tree()) {


### PR DESCRIPTION
Fix #70588.

Previously, `interface/inspector/open_resources_in_current_inspector` needed to be disabled in order to key some sub-resource property values (plugins handling this resource type had a bottom panel item).

v4.0.beta8.official [45cac42c0] :

https://user-images.githubusercontent.com/30386067/209620581-8042a477-3eaf-4831-9dd3-b64d4c34cd23.mp4

This PR:


https://user-images.githubusercontent.com/30386067/209802744-f1214acd-89e9-4ca8-8357-fe32de053ba7.mp4




May flicker when toggled:
~~1. The bottom editor will be hidden first and then displayed;~~
2. The sub-EditorInspector may not be refreshed at the same time.

Switching from "Animation" to other buttons will switch to the editor with higher priority first. That is, some toggles may require two clicks.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
