### PR TITLE
[X11] Grab server while focusing window.

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -3914,6 +3914,9 @@ void DisplayServerX11::process_events() {
 
 				XWindowAttributes xwa;
 				XSync(x11_display, False);
+
+				// Grab the server to avoid map_state changes between calling XGetWindowAttributes and XSetInputFocus.
+				XGrabServer(x11_display);
 				XGetWindowAttributes(x11_display, wd.x11_window, &xwa);
 
 				// Set focus when menu window is re-used.
@@ -3922,6 +3925,7 @@ void DisplayServerX11::process_events() {
 				if ((xwa.map_state == IsViewable) && !wd.no_focus && !wd.is_popup) {
 					XSetInputFocus(x11_display, wd.x11_window, RevertToPointerRoot, CurrentTime);
 				}
+				XUngrabServer(x11_display); // Very important to ungrab the server otherwise X11 becomes unresponsive.
 
 				_window_changed(&event);
 			} break;


### PR DESCRIPTION
Fixes #65425

More detail in https://github.com/godotengine/godot/issues/65425#issuecomment-1365731567.

When handling the `ConfigureNotify` event, we get window attributes using `XGetWindowAttributes` and only call `XSetInputFocus` if the `map_state` attribute is `IsViewable`.

Occasionally, the `map_state` attribute was `IsViewable` but would become `IsUnmapped` by the time the `XSetInputFocus` request was received due to a request from another X server connection (e.g. the window manager). This would result in a `BadMatch` error and cause Godot to crash.

By calling `XGrabServer` before `XGetWindowAttributes` and `XSetInputFocus` we ensure that the X server will only receive requests from this connection and therefore the `map_state` attribute will not change until `XUngrabServer` is called.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
