### PR TITLE
Fix Camera3D has an incorrect shape before opening the 2D tab

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -859,8 +859,8 @@ bool Viewport::_is_size_allocated() const {
 Rect2 Viewport::get_visible_rect() const {
 	Rect2 r;
 
-	if (size == Size2()) {
-		r = Rect2(Point2(), DisplayServer::get_singleton()->window_get_size());
+	if (is_inside_tree() && get_tree()->get_edited_scene_root() && get_tree()->get_edited_scene_root()->get_parent() == get_viewport()) {
+		r = Rect2(Point2(), Size2(GLOBAL_GET("display/window/size/viewport_width"), GLOBAL_GET("display/window/size/viewport_height")));
 	} else {
 		r = Rect2(Point2(), size);
 	}


### PR DESCRIPTION
Fixed default shape of frustum of camera3D, which had incorrect shape before opening the 2D tab. 

_Production edit: Fixes #70362_