### PR TITLE
Make `AStarGrid2D` class less memory consuming & multithreaded friendly

### DIFF
--- a/doc/classes/AStarGrid2D.xml
+++ b/doc/classes/AStarGrid2D.xml
@@ -52,21 +52,22 @@
 				Clears the grid and sets the [member size] to [constant Vector2i.ZERO].
 			</description>
 		</method>
-		<method name="get_id_path">
+		<method name="get_id_path" qualifiers="const">
 			<return type="Vector2i[]" />
 			<param index="0" name="from_id" type="Vector2i" />
 			<param index="1" name="to_id" type="Vector2i" />
 			<description>
 				Returns an array with the IDs of the points that form the path found by AStar2D between the given points. The array is ordered from the starting point to the ending point of the path.
+				[b]Note:[/b] This method is thread-safe, it can be used concurrently.
 			</description>
 		</method>
-		<method name="get_point_path">
+		<method name="get_point_path" qualifiers="const">
 			<return type="PackedVector2Array" />
 			<param index="0" name="from_id" type="Vector2i" />
 			<param index="1" name="to_id" type="Vector2i" />
 			<description>
 				Returns an array with the points that are in the path found by AStarGrid2D between the given points. The array is ordered from the starting point to the ending point of the path.
-				[b]Note:[/b] This method is not thread-safe. If called from a [Thread], it will return an empty [PackedVector3Array] and will print an error message.
+				[b]Note:[/b] This method is thread-safe, it can be used concurrently.
 			</description>
 		</method>
 		<method name="get_point_position" qualifiers="const">


### PR DESCRIPTION
This will make the points in that class to not keep the temporary information. This should decrease memory consumption taken by this class (from 56mb to 25mb on 1000x1000 grid). Instead, that information will allocate on demand in `_solve` function, and will be released when this function ends. The `get_id_path`/`get_point_path` as well as `_solve` and some others will receive a `const` tag, so now you can potentially call it in multiple threads using a single `AStarGrid2D` instance.
Also apply changes from https://github.com/godotengine/godot/pull/70485.

If this change become welcome, I will think to make a similar change to AStar3D/2D.