### PR TITLE
GDScript: Fix return type of constructor call for extending class

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4174,7 +4174,7 @@ bool GDScriptAnalyzer::get_function_signature(GDScriptParser::Node *p_source, bo
 				r_default_arg_count++;
 			}
 		}
-		r_return_type = found_function->get_datatype();
+		r_return_type = p_is_constructor ? p_base_type : found_function->get_datatype();
 		r_return_type.is_meta_type = false;
 		r_return_type.is_coroutine = found_function->is_coroutine;
 

--- a/modules/gdscript/tests/scripts/analyzer/errors/constructor_call_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/constructor_call_type.gd
@@ -1,0 +1,10 @@
+class A:
+	func _init():
+		pass
+
+class B extends A: pass
+class C extends A: pass
+
+func test():
+	var x := B.new()
+	print(x is C)

--- a/modules/gdscript/tests/scripts/analyzer/errors/constructor_call_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/constructor_call_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Expression is of type "B" so it can't be of type "C".


### PR DESCRIPTION
One-line change. For cases where base class defines a constructor and extending class does not.

Test:
```gdscript
class A:
  func _init():
    pass

class B extends A: pass
class C extends A: pass

func test():
  var x := B.new()
  print(x is C)
```
This now correctly produces analyzer error `Expression is of type "B" so it can't be of type "C".`.

Fixes #70605.
