### PR TITLE
GDScript: Fix getting type from PropertyInfo for Variant arguments

### DIFF
--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -108,7 +108,7 @@ class GDScriptAnalyzer {
 	// Helpers.
 	GDScriptParser::DataType type_from_variant(const Variant &p_value, const GDScriptParser::Node *p_source);
 	static GDScriptParser::DataType type_from_metatype(const GDScriptParser::DataType &p_meta_type);
-	GDScriptParser::DataType type_from_property(const PropertyInfo &p_property) const;
+	GDScriptParser::DataType type_from_property(const PropertyInfo &p_property, bool p_is_arg = false) const;
 	GDScriptParser::DataType make_global_class_meta_type(const StringName &p_class_name, const GDScriptParser::Node *p_source);
 	bool get_function_signature(GDScriptParser::Node *p_source, bool p_is_constructor, GDScriptParser::DataType base_type, const StringName &p_function, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, bool &r_static, bool &r_vararg);
 	bool function_signature_from_info(const MethodInfo &p_info, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, bool &r_static, bool &r_vararg);

--- a/modules/gdscript/tests/scripts/analyzer/errors/enum_shadows_outer_enum.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/enum_shadows_outer_enum.gd
@@ -1,7 +1,0 @@
-enum { V }
-
-class InnerClass:
-	enum { V }
-
-func test():
-	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/enum_shadows_outer_enum.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/enum_shadows_outer_enum.out
@@ -1,2 +1,0 @@
-GDTEST_PARSER_ERROR
-Name "V" is already used as a class enum value.

--- a/modules/gdscript/tests/scripts/analyzer/features/variant_arg_in_virtual_method.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/variant_arg_in_virtual_method.gd
@@ -1,0 +1,6 @@
+class Check extends Node:
+	func _set(_property: StringName, _value: Variant) -> bool:
+		return true
+
+func test() -> void:
+	print('OK')

--- a/modules/gdscript/tests/scripts/analyzer/features/variant_arg_in_virtual_method.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/variant_arg_in_virtual_method.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+OK


### PR DESCRIPTION
There is a difference between `PropertyInfo` for arguments and for other things: `PROPERTY_USAGE_NIL_IS_VARIANT` is [not used](https://github.com/godotengine/godot/blob/b6e06038f8a373f7fb8d26e92d5f06887e459598/core/doc_data.cpp#L85) for Variant arguments because arguments cannot be void.

But analyzer was ignoring this difference and typing variants in build-in methods wrong. Added optional bool `p_is_arg` to `GDScriptAnalyzer::type_from_property` to resolve that.

Fixes #64149.
Fixes #70054 (duplicate of the one above).