### PR TITLE
GDScript: Do not warn about static call from inside a class

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2840,7 +2840,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 			parser->push_warning(p_call, GDScriptWarning::RETURN_VALUE_DISCARDED, p_call->function_name);
 		}
 
-		if (is_static && !base_type.is_meta_type && !(is_self && parser->current_function != nullptr && parser->current_function->is_static)) {
+		if (is_static && !base_type.is_meta_type && !(is_self && parser->current_function != nullptr && parser->current_function->is_static) && callee_type != GDScriptParser::Node::IDENTIFIER) {
 			String caller_type = String(base_type.native_type);
 
 			if (caller_type.is_empty()) {

--- a/modules/gdscript/tests/scripts/analyzer/features/static_call_with_no_warning.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/static_call_with_no_warning.gd
@@ -1,0 +1,5 @@
+static func ok() -> void:
+  print('OK')
+
+func test():
+  ok()

--- a/modules/gdscript/tests/scripts/analyzer/features/static_call_with_no_warning.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/static_call_with_no_warning.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+OK


### PR DESCRIPTION
Do not warn about static call if it is done by identifier directly from inside a class. Test for no warning:
```gdscript
static func ok() -> void:
  print('OK')

func test():
  ok()
```

Currently Godot does complain and only solution to avoid that is to use `class_name` which pollutes global namespace. 

It is kinda strange actually that Godot allows access to static members through an instance: `instance.MyEnum`, `instance.MyConst` or `instance.InnerClass`. What other languages do support that?

Fixes #69282.