### PR TITLE
Fix move_and_collide for concave CharacterBody3D objects

### DIFF
--- a/servers/physics_3d/godot_collision_solver_3d.cpp
+++ b/servers/physics_3d/godot_collision_solver_3d.cpp
@@ -513,10 +513,6 @@ bool GodotCollisionSolver3D::solve_distance_world_boundary(const GodotShape3D *p
 }
 
 bool GodotCollisionSolver3D::solve_distance(const GodotShape3D *p_shape_A, const Transform3D &p_transform_A, const GodotShape3D *p_shape_B, const Transform3D &p_transform_B, Vector3 &r_point_A, Vector3 &r_point_B, const AABB &p_concave_hint, Vector3 *r_sep_axis) {
-	if (p_shape_A->is_concave()) {
-		return false;
-	}
-
 	if (p_shape_B->get_type() == PhysicsServer3D::SHAPE_WORLD_BOUNDARY) {
 		Vector3 a, b;
 		bool col = solve_distance_world_boundary(p_shape_B, p_transform_B, p_shape_A, p_transform_A, a, b);


### PR DESCRIPTION
This PR fixes #70653. The GodotCollisionSolver3D::solve_distance method appears to have an unnecessary early-bail-out test if the A object is concave; however the code further down appears to detect for and handle the A object being concave.

Testing with the https://github.com/Malcolmnixon/PhysicsCollisionTest project shows it can detect valid collisions against the other standard shape types (Sphere, Capsule, Cylinder, Box, and Concave).
![image](https://user-images.githubusercontent.com/1863707/209745633-f570b566-258d-4d8f-853f-b8d87e1ee242.png)
![image](https://user-images.githubusercontent.com/1863707/209745698-fb9ac315-9608-4de2-9387-4044bdaa5c30.png)
