### PR TITLE
GDScript: Fix multiline and trailing comma for assert

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1799,24 +1799,29 @@ GDScriptParser::AssertNode *GDScriptParser::parse_assert() {
 	// TODO: Add assert message.
 	AssertNode *assert = alloc_node<AssertNode>();
 
+	push_multiline(true);
 	consume(GDScriptTokenizer::Token::PARENTHESIS_OPEN, R"(Expected "(" after "assert".)");
+
 	assert->condition = parse_expression(false);
 	if (assert->condition == nullptr) {
 		push_error("Expected expression to assert.");
+		pop_multiline();
 		complete_extents(assert);
 		return nullptr;
 	}
 
-	if (match(GDScriptTokenizer::Token::COMMA)) {
-		// Error message.
+	if (match(GDScriptTokenizer::Token::COMMA) && !check(GDScriptTokenizer::Token::PARENTHESIS_CLOSE)) {
 		assert->message = parse_expression(false);
 		if (assert->message == nullptr) {
 			push_error(R"(Expected error message for assert after ",".)");
+			pop_multiline();
 			complete_extents(assert);
 			return nullptr;
 		}
+		match(GDScriptTokenizer::Token::COMMA);
 	}
 
+	pop_multiline();
 	consume(GDScriptTokenizer::Token::PARENTHESIS_CLOSE, R"*(Expected ")" after assert expression.)*");
 
 	complete_extents(assert);

--- a/modules/gdscript/tests/scripts/parser/features/multiline_assert.gd
+++ b/modules/gdscript/tests/scripts/parser/features/multiline_assert.gd
@@ -1,0 +1,24 @@
+func test():
+	var x := 5
+
+	assert(x > 0)
+	assert(x > 0,)
+	assert(x > 0, 'message')
+	assert(x > 0, 'message',)
+
+	assert(
+		x > 0
+	)
+	assert(
+		x > 0,
+	)
+	assert(
+		x > 0,
+		'message'
+	)
+	assert(
+		x > 0,
+		'message',
+	)
+
+	print('OK')

--- a/modules/gdscript/tests/scripts/parser/features/multiline_assert.out
+++ b/modules/gdscript/tests/scripts/parser/features/multiline_assert.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+OK


### PR DESCRIPTION
Fixed parsing of `assert` with multiline and/or trailing comma.

Fixes #66535.