### PR TITLE
GDScript: Disallow return with value in void functions

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2044,6 +2044,9 @@ void GDScriptAnalyzer::resolve_return(GDScriptParser::ReturnNode *p_return) {
 				update_array_literal_element_type(expected_type, static_cast<GDScriptParser::ArrayNode *>(p_return->return_value));
 			}
 		}
+		if (has_expected_type && expected_type.is_hard_type() && expected_type.kind == GDScriptParser::DataType::BUILTIN && expected_type.builtin_type == Variant::NIL) {
+			push_error("A void function cannot return a value.", p_return);
+		}
 		result = p_return->return_value->get_datatype();
 	} else {
 		// Return type is null by default.

--- a/modules/gdscript/tests/scripts/analyzer/errors/return_null_in_void_func.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/return_null_in_void_func.gd
@@ -1,0 +1,2 @@
+func test() -> void:
+  return null

--- a/modules/gdscript/tests/scripts/analyzer/errors/return_null_in_void_func.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/return_null_in_void_func.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+A void function cannot return a value.

--- a/modules/gdscript/tests/scripts/analyzer/errors/return_variant_in_void_func.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/return_variant_in_void_func.gd
@@ -1,0 +1,4 @@
+func test() -> void:
+  var a
+  a = 1
+  return a

--- a/modules/gdscript/tests/scripts/analyzer/errors/return_variant_in_void_func.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/return_variant_in_void_func.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+A void function cannot return a value.

--- a/modules/gdscript/tests/scripts/analyzer/features/return_variant_typed.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/return_variant_typed.gd
@@ -1,0 +1,5 @@
+func variant() -> Variant:
+  return 'variant'
+
+func test():
+  print(variant())

--- a/modules/gdscript/tests/scripts/analyzer/features/return_variant_typed.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/return_variant_typed.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+variant


### PR DESCRIPTION
Test:
```gdscript
func test() -> void:
  return null # this is wrong
```

Man, GDScript test system sucks for negative checks, one file per assertion is crazy...

Fixes #61657.