### PR TITLE
Allow building X11 without Vulkan

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -339,9 +339,6 @@ def configure(env: "Environment"):
     env.Prepend(CPPPATH=["#platform/linuxbsd"])
 
     if env["x11"]:
-        if not env["vulkan"]:
-            print("Error: X11 support requires vulkan=yes")
-            env.Exit(255)
         env.Append(CPPDEFINES=["X11_ENABLED"])
 
     env.Append(CPPDEFINES=["UNIX_ENABLED"])


### PR DESCRIPTION
This limit was likely introduced when Vulkan was the only option.

After some small testing this seems to work fine, although the experience could be improved, as one can still create a forward plus project and run it, although they will be greeted by an error.