### PR TITLE
Fix arm64 build when using Clang

### DIFF
--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -96,7 +96,7 @@ if env["builtin_embree"]:
 
     if not env.msvc:
         # Flags synced with upstream gnu.cmake.
-        if env["arch"] == "arm64" and env["platform"] == "linuxbsd":
+        if env["arch"] == "arm64" and env["platform"] == "linuxbsd" and not env["use_llvm"]:
             env_thirdparty.Append(CXXFLAGS=["-flax-vector-conversions"])
 
         env_thirdparty.Append(


### PR DESCRIPTION
The commit b5a8055b5c should target GCC builds only as -flax-vector-conversions has different behaviour in Clang and is currently making the build fail.

This PR addresses #70683.

_Production edit: Fixes https://github.com/godotengine/godot/issues/70683_