### PR TITLE
Fix: NaN value making infinite loop inside GraphEdit's `NOTIFICATION_DRAW`

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -758,6 +758,7 @@ void Control::set_anchor_and_offset(Side p_side, real_t p_anchor, real_t p_pos, 
 }
 
 void Control::set_begin(const Size2 &p_point) {
+	ERR_FAIL_COND(!isfinite(p_point.x) || !isfinite(p_point.y));
 	if (data.offset[0] == p_point.x && data.offset[1] == p_point.y) {
 		return;
 	}
@@ -1405,6 +1406,7 @@ void Control::_set_size(const Size2 &p_size) {
 }
 
 void Control::set_size(const Size2 &p_size, bool p_keep_offsets) {
+	ERR_FAIL_COND(!isfinite(p_size.x) || !isfinite(p_size.y));
 	Size2 new_size = p_size;
 	Size2 min = get_combined_minimum_size();
 	if (new_size.x < min.x) {
@@ -1595,7 +1597,7 @@ void Control::set_custom_minimum_size(const Size2 &p_custom) {
 		return;
 	}
 
-	if (isnan(p_custom.x) || isnan(p_custom.y)) {
+	if (!isfinite(p_custom.x) || !isfinite(p_custom.y)) {
 		// Prevent infinite loop.
 		return;
 	}

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1496,6 +1496,7 @@ float GraphEdit::get_zoom() const {
 
 void GraphEdit::set_zoom_step(float p_zoom_step) {
 	p_zoom_step = abs(p_zoom_step);
+	ERR_FAIL_COND(!isfinite(p_zoom_step));
 	if (zoom_step == p_zoom_step) {
 		return;
 	}


### PR DESCRIPTION
Fix: #70147 
