### PR TITLE
Fix hovering-color of MenuBar entries when reentering MenuBar

### DIFF
--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -345,6 +345,7 @@ void MenuBar::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_MOUSE_EXIT: {
 			focused_menu = -1;
+			selected_menu = -1;
 			queue_redraw();
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED:


### PR DESCRIPTION
When reentering MenuBar with the mouse cursor, the hovering-color was not set, because the previously hovered entry was still referenced in selected_menu. This PR resets selected_menu on mouse-exit.

resolve #70661