### PR TITLE
Propagate the keying state in the inspector

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3365,7 +3365,10 @@ void EditorInspector::set_keying(bool p_active) {
 		return;
 	}
 	keying = p_active;
-	update_tree();
+	// Propagate the keying state to its editor properties.
+	Array args;
+	args.append(keying);
+	main_vbox->propagate_call(SNAME("set_keying"), args, true);
 }
 
 void EditorInspector::set_read_only(bool p_read_only) {

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -4121,6 +4121,8 @@ void EditorPropertyResource::update_property() {
 
 				if (use_editor) {
 					// Open editor directly and hide other such editors which are currently open.
+					// The opened editor is the one that edits the sub-resource, so keying state will be toggled to false.
+					sub_inspector->set_keying(false);
 					_open_editor_pressed();
 					if (is_inside_tree()) {
 						get_tree()->call_deferred(SNAME("call_group"), "_editor_resource_properties", "_fold_other_editors", this);


### PR DESCRIPTION
Toggling the keying state does not significantly change the structure of the inspector. So it's ok to propagate the keying state and then use `queue_redraw()` to update the keying icon.

Fixes #70588.
Supersedes #70616.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
