### PR TITLE
GDScript: Fix extending abstract classes, forbid their construction

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -148,6 +148,11 @@ bool CreateDialog::_should_hide_type(const String &p_type) const {
 			return true;
 		}
 
+		StringName native_type = ScriptServer::get_global_class_native_base(p_type);
+		if (ClassDB::class_exists(native_type) && !ClassDB::can_instantiate(native_type)) {
+			return true;
+		}
+
 		String script_path = ScriptServer::get_global_class_path(p_type);
 		if (script_path.begins_with("res://addons/")) {
 			if (!EditorNode::get_singleton()->is_addon_plugin_enabled(script_path.get_slicec('/', 3))) {

--- a/modules/gdscript/tests/scripts/analyzer/errors/abstract_class_instantiate.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/abstract_class_instantiate.gd
@@ -1,0 +1,2 @@
+func test():
+	CanvasItem.new()

--- a/modules/gdscript/tests/scripts/analyzer/errors/abstract_class_instantiate.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/abstract_class_instantiate.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Native class "CanvasItem" cannot be constructed as it is abstract.

--- a/modules/gdscript/tests/scripts/analyzer/errors/abstract_script_instantiate.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/abstract_script_instantiate.gd
@@ -1,0 +1,9 @@
+class A extends CanvasItem:
+	func _init():
+		print('no')
+
+class B extends A:
+	pass
+
+func test():
+	B.new()

--- a/modules/gdscript/tests/scripts/analyzer/errors/abstract_script_instantiate.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/abstract_script_instantiate.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Class "abstract_script_instantiate.gd::B" cannot be constructed as it is based on abstract native class "CanvasItem".

--- a/modules/gdscript/tests/scripts/analyzer/features/extend_abstract_class.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/extend_abstract_class.gd
@@ -1,0 +1,12 @@
+class A extends CanvasItem:
+	func _init():
+		pass
+
+class B extends A:
+	pass
+
+class C extends CanvasItem:
+	pass
+
+func test():
+	print('ok')

--- a/modules/gdscript/tests/scripts/analyzer/features/extend_abstract_class.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/extend_abstract_class.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok


### PR DESCRIPTION
```gdscript
class MyCanvasItem extends CanvasItem: pass # now ok

func _ready() -> void:
  CanvasItem.new() # now warned as bad, before wasn't
  MyCanvasItem.new() # warned, not allowed
  
  var control := Control.new()
  control.set_script(MyCanvasItem) # ok
```

Unfortunately could not add a test for right usage with `set_script`, abstract classes like `CanvasItem` do require some singletons that are unavailable in test environment. If you know an abstract class that have instantiatable subclasses in tests let me know. 

Fixes #46073.