### PR TITLE
Bind methods related to physics query exclusions

### DIFF
--- a/doc/classes/PhysicsDirectSpaceState2DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState2DExtension.xml
@@ -87,5 +87,11 @@
 			<description>
 			</description>
 		</method>
+		<method name="is_body_excluded_from_query" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
 	</methods>
 </class>

--- a/doc/classes/PhysicsDirectSpaceState3DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState3DExtension.xml
@@ -95,5 +95,11 @@
 			<description>
 			</description>
 		</method>
+		<method name="is_body_excluded_from_query" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
 	</methods>
 </class>

--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -933,5 +933,17 @@
 			<description>
 			</description>
 		</method>
+		<method name="body_test_motion_is_excluding_body" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="body_test_motion_is_excluding_object" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="object" type="int" />
+			<description>
+			</description>
+		</method>
 	</methods>
 </class>

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -1284,5 +1284,17 @@
 			<description>
 			</description>
 		</method>
+		<method name="body_test_motion_is_excluding_body" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="body_test_motion_is_excluding_object" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="object" type="int" />
+			<description>
+			</description>
+		</method>
 	</methods>
 </class>

--- a/servers/extensions/physics_server_2d_extension.cpp
+++ b/servers/extensions/physics_server_2d_extension.cpp
@@ -37,6 +37,8 @@ bool PhysicsDirectSpaceState2DExtension::is_body_excluded_from_query(const RID &
 thread_local const HashSet<RID> *PhysicsDirectSpaceState2DExtension::exclude = nullptr;
 
 void PhysicsDirectSpaceState2DExtension::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_body_excluded_from_query", "body"), &PhysicsDirectSpaceState2DExtension::is_body_excluded_from_query);
+
 	GDVIRTUAL_BIND(_intersect_ray, "from", "to", "collision_mask", "collide_with_bodies", "collide_with_areas", "hit_from_inside", "result");
 	GDVIRTUAL_BIND(_intersect_point, "position", "canvas_instance_id", "collision_mask", "collide_with_bodies", "collide_with_areas", "results", "max_results");
 	GDVIRTUAL_BIND(_intersect_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "result", "max_results");
@@ -201,6 +203,9 @@ void PhysicsServer2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_area_set_area_monitor_callback, "area", "callback");
 
 	/* BODY API */
+
+	ClassDB::bind_method(D_METHOD("body_test_motion_is_excluding_body", "body"), &PhysicsServer2DExtension::body_test_motion_is_excluding_body);
+	ClassDB::bind_method(D_METHOD("body_test_motion_is_excluding_object", "object"), &PhysicsServer2DExtension::body_test_motion_is_excluding_object);
 
 	GDVIRTUAL_BIND(_body_create);
 

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -37,6 +37,8 @@ bool PhysicsDirectSpaceState3DExtension::is_body_excluded_from_query(const RID &
 thread_local const HashSet<RID> *PhysicsDirectSpaceState3DExtension::exclude = nullptr;
 
 void PhysicsDirectSpaceState3DExtension::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_body_excluded_from_query", "body"), &PhysicsDirectSpaceState3DExtension::is_body_excluded_from_query);
+
 	GDVIRTUAL_BIND(_intersect_ray, "from", "to", "collision_mask", "collide_with_bodies", "collide_with_areas", "hit_from_inside", "hit_back_faces", "result");
 	GDVIRTUAL_BIND(_intersect_point, "position", "collision_mask", "collide_with_bodies", "collide_with_areas", "results", "max_results");
 	GDVIRTUAL_BIND(_intersect_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "result_count", "max_results");
@@ -205,6 +207,9 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_area_set_area_monitor_callback, "area", "callback");
 
 	/* BODY API */
+
+	ClassDB::bind_method(D_METHOD("body_test_motion_is_excluding_body", "body"), &PhysicsServer3DExtension::body_test_motion_is_excluding_body);
+	ClassDB::bind_method(D_METHOD("body_test_motion_is_excluding_object", "object"), &PhysicsServer3DExtension::body_test_motion_is_excluding_object);
 
 	GDVIRTUAL_BIND(_body_create);
 


### PR DESCRIPTION
Related to #65465, #65571, #66936 and #70477.

Currently, when implementing support for physics queries from a GDExtension, the list of excluded bodies that you normally find in places like `PhysicsDirectSpaceState3D::RayParameters` are not passed on to `PhysicsDirectSpaceState3DExtension::_intersect_ray`. It seems instead that there were methods created for querying a cached thread-local set, for reasons that are unclear to me. These methods were however not bound, so here I am binding them.