### PR TITLE
GDScript: Fix editor ignoring parsing errors during code suggestions

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2688,9 +2688,12 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
 
 	GDScriptParser parser;
-	GDScriptAnalyzer analyzer(&parser);
+	Error parser_error = parser.parse(p_code, p_path, true);
+	if (parser_error) {
+		return parser_error;
+	}
 
-	parser.parse(p_code, p_path, true);
+	GDScriptAnalyzer analyzer(&parser);
 	analyzer.analyze();
 
 	r_forced = false;
@@ -3276,7 +3279,10 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 	}
 
 	GDScriptParser parser;
-	parser.parse(p_code, p_path, true);
+	Error parser_error = parser.parse(p_code, p_path, true);
+	if (parser_error) {
+		return parser_error;
+	}
 
 	GDScriptParser::CompletionContext context = parser.get_completion_context();
 	context.base = p_owner;


### PR DESCRIPTION
Analyzer expects valid state from parser, like absence of name conflicts between members of a class. Editor was ignoring errors from parser in `GDScriptLanguage::complete_code` and `GDScriptLanguage::lookup_code`, which in case of issue bellow was crashing editor.

Analyzer itself can return an error too. Is it ok to ignore it for code suggestions?

Fixes #70665.