### PR TITLE
Fill and fix `PhysicsServer2D` documentation

### DIFF
--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -4,7 +4,14 @@
 		Server interface for low-level 2D physics access.
 	</brief_description>
 	<description>
-		PhysicsServer2D is the server responsible for all 2D physics. It can create many kinds of physics objects, but does not insert them on the node tree.
+		PhysicsServer2D is the server responsible for all 2D physics. It can directly create and manipulate all physics objects:
+		- A [i]space[/i] is a self-contained world for a physics simulation. It contains bodies, areas, and joints. Its state can be queried for collision and intersection information, and several parameters of the simulation can be modified.
+		- A [i]shape[/i] is a geometric figure such as a circle, a rectangle, a capsule, or a polygon. It can be used for collision detection by adding it to a body/area, possibly with an extra transformation relative to the body/area's origin. Bodies/areas can have multiple (transformed) shapes added to them, and a single shape can be added to bodies/areas multiple times with different local transformations.
+		- A [i]body[/i] is a physical object which can be in static, kinematic, or rigid mode. Its state (such as position and velocity) can be queried and updated. A force integration callback can be set to customize the body's physics.
+		- An [i]area[/i] is a region in space which can be used to detect bodies and areas entering and exiting it. A body monitoring callback can be set to report entering/exiting body shapes, and similarly an area monitoring callback can be set. Gravity and damping can be overridden within the area by setting area parameters.
+		- A [i]joint[/i] is a constraint, either between two bodies or on one body relative to a point. Parameters such as the joint bias and the rest length of a spring joint can be adjusted.
+		Physics objects in the physics server may be created and manipulated independently; they do not have to be tied to nodes in the scene tree.
+		[b]Note:[/b] All the physics nodes use the physics server internally. Adding a physics node to the scene tree will cause a corresponding physics object to be created in the physics server. A rigid body node registers a callback that updates the node's transform with the transform of the respective body object in the physics server (every physics update). An area node registers a callback to inform the area node about overlaps with the respective area object in the physics server. The raycast node queries the direct state of the relevant space in the physics server.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -16,7 +23,7 @@
 			<param index="2" name="transform" type="Transform2D" default="Transform2D(1, 0, 0, 1, 0, 0)" />
 			<param index="3" name="disabled" type="bool" default="false" />
 			<description>
-				Adds a shape to the area, along with a transform matrix. Shapes are usually referenced by their index, so you should track which shape has a given index.
+				Adds a shape to the area, with the given local transform. The shape (together with its [param transform] and [param disabled] properties) is added to an array of shapes, and the shapes of an area are usually referenced by their index in this array.
 			</description>
 		</method>
 		<method name="area_attach_canvas_instance_id">
@@ -24,6 +31,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="id" type="int" />
 			<description>
+				Attaches the [code]ObjectID[/code] of a canvas to the area. Use [method Object.get_instance_id] to get the [code]ObjectID[/code] of a [CanvasLayer].
 			</description>
 		</method>
 		<method name="area_attach_object_instance_id">
@@ -31,47 +39,48 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="id" type="int" />
 			<description>
-				Assigns the area to a descendant of [Object], so it can exist in the node tree.
+				Attaches the [code]ObjectID[/code] of an [Object] to the area. Use [method Object.get_instance_id] to get the [code]ObjectID[/code] of a [CollisionObject2D].
 			</description>
 		</method>
 		<method name="area_clear_shapes">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<description>
-				Removes all shapes from an area. It does not delete the shapes, so they can be reassigned later.
+				Removes all shapes from the area. This does not delete the shapes themselves, so they can continue to be used elsewhere or added back later.
 			</description>
 		</method>
 		<method name="area_create">
 			<return type="RID" />
 			<description>
-				Creates an [Area2D]. After creating an [Area2D] with this method, assign it to a space using [method area_set_space] to use the created [Area2D] in the physics world.
+				Creates a 2D area object in the physics server, and returns the [RID] that identifies it. Use [method area_add_shape] to add shapes to it, use [method area_set_transform] to set its transform, and use [method area_set_space] to add the area to a space.
 			</description>
 		</method>
 		<method name="area_get_canvas_instance_id" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
+				Returns the [code]ObjectID[/code] of the canvas attached to the area. Use [method @GlobalScope.instance_from_id] to retrieve a [CanvasLayer] from a nonzero [code]ObjectID[/code].
 			</description>
 		</method>
 		<method name="area_get_collision_layer" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
-				Returns the physics layer or layers an area belongs to.
+				Returns the physics layer or layers the area belongs to, as a bitmask.
 			</description>
 		</method>
 		<method name="area_get_collision_mask" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
-				Returns the physics layer or layers an area can contact with.
+				Returns the physics layer or layers the area can contact with, as a bitmask.
 			</description>
 		</method>
 		<method name="area_get_object_instance_id" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
-				Gets the instance ID of the object the area is assigned to.
+				Returns the [code]ObjectID[/code] attached to the area. Use [method @GlobalScope.instance_from_id] to retrieve an [Object] from a nonzero [code]ObjectID[/code].
 			</description>
 		</method>
 		<method name="area_get_param" qualifiers="const">
@@ -79,7 +88,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.AreaParameter" />
 			<description>
-				Returns an area parameter value. See [enum AreaParameter] for a list of available parameters.
+				Returns the value of the given area parameter. See [enum AreaParameter] for the list of available parameters.
 			</description>
 		</method>
 		<method name="area_get_shape" qualifiers="const">
@@ -87,14 +96,14 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<description>
-				Returns the [RID] of the nth shape of an area.
+				Returns the [RID] of the shape with the given index in the area's array of shapes.
 			</description>
 		</method>
 		<method name="area_get_shape_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
-				Returns the number of shapes assigned to an area.
+				Returns the number of shapes added to the area.
 			</description>
 		</method>
 		<method name="area_get_shape_transform" qualifiers="const">
@@ -102,21 +111,21 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<description>
-				Returns the transform matrix of a shape within an area.
+				Returns the local transform matrix of the shape with the given index in the area's array of shapes.
 			</description>
 		</method>
 		<method name="area_get_space" qualifiers="const">
 			<return type="RID" />
 			<param index="0" name="area" type="RID" />
 			<description>
-				Returns the space assigned to the area.
+				Returns the [RID] of the space assigned to the area. Returns [code]RID()[/code] if no space is assigned.
 			</description>
 		</method>
 		<method name="area_get_transform" qualifiers="const">
 			<return type="Transform2D" />
 			<param index="0" name="area" type="RID" />
 			<description>
-				Returns the transform matrix for an area.
+				Returns the transform matrix of the area.
 			</description>
 		</method>
 		<method name="area_remove_shape">
@@ -124,7 +133,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<description>
-				Removes a shape from an area. It does not delete the shape, so it can be reassigned later.
+				Removes the shape with the given index from the area's array of shapes. The shape itself is not deleted, so it can continue to be used elsewhere or added back later. As a result of this operation, the area's shapes which used to have indices higher than [param shape_idx] will have their index decreased by one.
 			</description>
 		</method>
 		<method name="area_set_area_monitor_callback">
@@ -132,6 +141,13 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="callback" type="Callable" />
 			<description>
+				Sets the area's area monitor callback. This callback will be called when any other (shape of an) area enters or exits (a shape of) the given area, and must take the following five parameters:
+				1. an integer [code]status[/code]: either [constant AREA_BODY_ADDED] or [constant AREA_BODY_REMOVED] depending on whether the other area's shape entered or exited the area,
+				2. an [RID] [code]area_rid[/code]: the [RID] of the other area that entered or exited the area,
+				3. an integer [code]instance_id[/code]: the [code]ObjectID[/code] attached to the other area,
+				4. an integer [code]area_shape_idx[/code]: the index of the shape of the other area that entered or exited the area,
+				5. an integer [code]self_shape_idx[/code]: the index of the shape of the area where the other area entered or exited.
+				By counting (or keeping track of) the shapes that enter and exit, it can be determined if an area (with all its shapes) is entering for the first time or exiting for the last time.
 			</description>
 		</method>
 		<method name="area_set_collision_layer">
@@ -139,7 +155,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="layer" type="int" />
 			<description>
-				Assigns the area to one or many physics layers.
+				Assigns the area to one or many physics layers, via a bitmask.
 			</description>
 		</method>
 		<method name="area_set_collision_mask">
@@ -147,7 +163,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="mask" type="int" />
 			<description>
-				Sets which physics layers the area will monitor.
+				Sets which physics layers the area will monitor, via a bitmask.
 			</description>
 		</method>
 		<method name="area_set_monitor_callback">
@@ -155,12 +171,13 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="callback" type="Callable" />
 			<description>
-				Sets the function to call when any body/area enters or exits the area. This callback will be called for any object interacting with the area, and takes five parameters:
-				1: [constant AREA_BODY_ADDED] or [constant AREA_BODY_REMOVED], depending on whether the object entered or exited the area.
-				2: [RID] of the object that entered/exited the area.
-				3: Instance ID of the object that entered/exited the area.
-				4: The shape index of the object that entered/exited the area.
-				5: The shape index of the area where the object entered/exited.
+				Sets the area's body monitor callback. This callback will be called when any other (shape of a) body enters or exits (a shape of) the given area, and must take the following five parameters:
+				1. an integer [code]status[/code]: either [constant AREA_BODY_ADDED] or [constant AREA_BODY_REMOVED] depending on whether the other body shape entered or exited the area,
+				2. an [RID] [code]body_rid[/code]: the [RID] of the body that entered or exited the area,
+				3. an integer [code]instance_id[/code]: the [code]ObjectID[/code] attached to the body,
+				4. an integer [code]body_shape_idx[/code]: the index of the shape of the body that entered or exited the area,
+				5. an integer [code]self_shape_idx[/code]: the index of the shape of the area where the body entered or exited.
+				By counting (or keeping track of) the shapes that enter and exit, it can be determined if a body (with all its shapes) is entering for the first time or exiting for the last time.
 			</description>
 		</method>
 		<method name="area_set_monitorable">
@@ -168,6 +185,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="monitorable" type="bool" />
 			<description>
+				Sets whether the area is monitorable or not. If [param monitorable] is [code]true[/code], the area monitoring callback of other areas will be called when this area enters or exits them.
 			</description>
 		</method>
 		<method name="area_set_param">
@@ -176,7 +194,7 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.AreaParameter" />
 			<param index="2" name="value" type="Variant" />
 			<description>
-				Sets the value for an area parameter. See [enum AreaParameter] for a list of available parameters.
+				Sets the value of the given area parameter. See [enum AreaParameter] for the list of available parameters.
 			</description>
 		</method>
 		<method name="area_set_shape">
@@ -185,7 +203,7 @@
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="shape" type="RID" />
 			<description>
-				Substitutes a given area shape by another. The old shape is selected by its index, the new one by its [RID].
+				Replaces the area's shape at the given index by another shape, while not affecting the [code]transform[/code] and [code]disabled[/code] properties at the same index.
 			</description>
 		</method>
 		<method name="area_set_shape_disabled">
@@ -194,7 +212,7 @@
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="disabled" type="bool" />
 			<description>
-				Disables a given shape in an area.
+				Sets the disabled property of the area's shape with the given index. If [param disabled] is [code]true[/code], then the shape will not detect any other shapes entering or exiting it.
 			</description>
 		</method>
 		<method name="area_set_shape_transform">
@@ -203,7 +221,7 @@
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="transform" type="Transform2D" />
 			<description>
-				Sets the transform matrix for an area shape.
+				Sets the local transform matrix of the area's shape with the given index.
 			</description>
 		</method>
 		<method name="area_set_space">
@@ -211,7 +229,8 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="space" type="RID" />
 			<description>
-				Assigns a space to the area.
+				Adds the area to the given space, after removing the area from the previously assigned space (if any).
+				[b]Note:[/b] To remove an area from a space without immediately adding it back elsewhere, use [code]PhysicsServer2D.area_set_space(area, RID())[/code].
 			</description>
 		</method>
 		<method name="area_set_transform">
@@ -219,7 +238,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="transform" type="Transform2D" />
 			<description>
-				Sets the transform matrix for an area.
+				Sets the transform matrix of the area.
 			</description>
 		</method>
 		<method name="body_add_collision_exception">
@@ -227,7 +246,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="excepted_body" type="RID" />
 			<description>
-				Adds a body to the list of bodies exempt from collisions.
+				Adds [param excepted_body] to the body's list of collision exceptions, so that collisions with it are ignored.
 			</description>
 		</method>
 		<method name="body_add_constant_central_force">
@@ -235,7 +254,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector2" />
 			<description>
-				Adds a constant directional force without affecting rotation that keeps being applied over time until cleared with [code]body_set_constant_force(body, Vector2(0, 0))[/code].
+				Adds a constant directional force to the body. The force does not affect rotation. The force remains applied over time until cleared with [code]PhysicsServer2D.body_set_constant_force(body, Vector2(0, 0))[/code].
 				This is equivalent to using [method body_add_constant_force] at the body's center of mass.
 			</description>
 		</method>
@@ -245,7 +264,7 @@
 			<param index="1" name="force" type="Vector2" />
 			<param index="2" name="position" type="Vector2" default="Vector2(0, 0)" />
 			<description>
-				Adds a constant positioned force to the body that keeps being applied over time until cleared with [code]body_set_constant_force(body, Vector2(0, 0))[/code].
+				Adds a constant positioned force to the body. The force can affect rotation if [param position] is different from the body's center of mass. The force remains applied over time until cleared with [code]PhysicsServer2D.body_set_constant_force(body, Vector2(0, 0))[/code].
 				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
@@ -254,7 +273,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="torque" type="float" />
 			<description>
-				Adds a constant rotational force without affecting position that keeps being applied over time until cleared with [code]body_set_constant_torque(body, 0)[/code].
+				Adds a constant rotational force to the body. The force does not affect position. The force remains applied over time until cleared with [code]PhysicsServer2D.body_set_constant_torque(body, 0)[/code].
 			</description>
 		</method>
 		<method name="body_add_shape">
@@ -264,7 +283,7 @@
 			<param index="2" name="transform" type="Transform2D" default="Transform2D(1, 0, 0, 1, 0, 0)" />
 			<param index="3" name="disabled" type="bool" default="false" />
 			<description>
-				Adds a shape to the body, along with a transform matrix. Shapes are usually referenced by their index, so you should track which shape has a given index.
+				Adds a shape to the area, with the given local transform. The shape (together with its [param transform] and [param disabled] properties) is added to an array of shapes, and the shapes of a body are usually referenced by their index in this array.
 			</description>
 		</method>
 		<method name="body_apply_central_force">
@@ -272,7 +291,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector2" />
 			<description>
-				Applies a directional force without affecting rotation. A force is time dependent and meant to be applied every physics update.
+				Applies a directional force to the body, at the body's center of mass. The force does not affect rotation. A force is time dependent and meant to be applied every physics update.
 				This is equivalent to using [method body_apply_force] at the body's center of mass.
 			</description>
 		</method>
@@ -281,7 +300,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="impulse" type="Vector2" />
 			<description>
-				Applies a directional impulse without affecting rotation.
+				Applies a directional impulse to the body, at the body's center of mass. The impulse does not affect rotation.
 				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
 				This is equivalent to using [method body_apply_impulse] at the body's center of mass.
 			</description>
@@ -292,7 +311,7 @@
 			<param index="1" name="force" type="Vector2" />
 			<param index="2" name="position" type="Vector2" default="Vector2(0, 0)" />
 			<description>
-				Applies a positioned force to the body. A force is time dependent and meant to be applied every physics update.
+				Applies a positioned force to the body. The force can affect rotation if [param position] is different from the body's center of mass. A force is time dependent and meant to be applied every physics update.
 				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
@@ -302,7 +321,7 @@
 			<param index="1" name="impulse" type="Vector2" />
 			<param index="2" name="position" type="Vector2" default="Vector2(0, 0)" />
 			<description>
-				Applies a positioned impulse to the body.
+				Applies a positioned impulse to the body. The impulse can affect rotation if [param position] is different from the body's center of mass.
 				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
 				[param position] is the offset from the body origin in global coordinates.
 			</description>
@@ -312,7 +331,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="torque" type="float" />
 			<description>
-				Applies a rotational force without affecting position. A force is time dependent and meant to be applied every physics update.
+				Applies a rotational force to the body. The force does not affect position. A force is time dependent and meant to be applied every physics update.
 			</description>
 		</method>
 		<method name="body_apply_torque_impulse">
@@ -320,7 +339,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="impulse" type="float" />
 			<description>
-				Applies a rotational impulse to the body without affecting the position.
+				Applies a rotational impulse to the body. The impulse does not affect position.
 				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
 			</description>
 		</method>
@@ -329,6 +348,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="id" type="int" />
 			<description>
+				Attaches the [code]ObjectID[/code] of a canvas to the body. Use [method Object.get_instance_id] to get the [code]ObjectID[/code] of a [CanvasLayer].
 			</description>
 		</method>
 		<method name="body_attach_object_instance_id">
@@ -336,54 +356,55 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="id" type="int" />
 			<description>
-				Assigns the area to a descendant of [Object], so it can exist in the node tree.
+				Attaches the [code]ObjectID[/code] of an [Object] to the body. Use [method Object.get_instance_id] to get the [code]ObjectID[/code] of a [CollisionObject2D].
 			</description>
 		</method>
 		<method name="body_clear_shapes">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Removes all shapes from a body.
+				Removes all shapes from the body. This does not delete the shapes themselves, so they can continue to be used elsewhere or added back later.
 			</description>
 		</method>
 		<method name="body_create">
 			<return type="RID" />
 			<description>
-				Creates a physics body.
+				Creates a 2D body object in the physics server, and returns the [RID] that identifies it. Use [method body_add_shape] to add shapes to it, use [method body_set_state] to set its transform, and use [method body_set_space] to add the body to a space.
 			</description>
 		</method>
 		<method name="body_get_canvas_instance_id" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
+				Returns the [code]ObjectID[/code] of the canvas attached to the body. Use [method @GlobalScope.instance_from_id] to retrieve a [CanvasLayer] from a nonzero [code]ObjectID[/code].
 			</description>
 		</method>
 		<method name="body_get_collision_layer" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Returns the physics layer or layers a body belongs to.
+				Returns the physics layer or layers the body belongs to, as a bitmask.
 			</description>
 		</method>
 		<method name="body_get_collision_mask" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Returns the physics layer or layers a body can collide with.
+				Returns the physics layer or layers the body can collide with, as a bitmask.
 			</description>
 		</method>
 		<method name="body_get_collision_priority" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Returns the body's collision priority.
+				Returns the body's collision priority. This is used in the depenetration phase of [method body_test_motion]. The higher the priority is, the lower the penetration into the body will be.
 			</description>
 		</method>
 		<method name="body_get_constant_force" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Returns the body's total constant positional forces applied during each physics update.
+				Returns the body's total constant positional force applied during each physics update.
 				See [method body_add_constant_force] and [method body_add_constant_central_force].
 			</description>
 		</method>
@@ -391,7 +412,7 @@
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Returns the body's total constant rotational forces applied during each physics update.
+				Returns the body's total constant rotational force applied during each physics update.
 				See [method body_add_constant_torque].
 			</description>
 		</method>
@@ -399,35 +420,35 @@
 			<return type="int" enum="PhysicsServer2D.CCDMode" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Returns the continuous collision detection mode.
+				Returns the body's continuous collision detection mode (see [enum CCDMode]).
 			</description>
 		</method>
 		<method name="body_get_direct_state">
 			<return type="PhysicsDirectBodyState2D" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Returns the [PhysicsDirectBodyState2D] of the body. Returns [code]null[/code] if the body is destroyed or removed from the physics space.
+				Returns the [PhysicsDirectBodyState2D] of the body. Returns [code]null[/code] if the body is destroyed or not assigned to a space.
 			</description>
 		</method>
 		<method name="body_get_max_contacts_reported" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Returns the maximum contacts that can be reported. See [method body_set_max_contacts_reported].
+				Returns the maximum number of contacts that the body can report. See [method body_set_max_contacts_reported].
 			</description>
 		</method>
 		<method name="body_get_mode" qualifiers="const">
 			<return type="int" enum="PhysicsServer2D.BodyMode" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Returns the body mode.
+				Returns the body's mode (see [enum BodyMode]).
 			</description>
 		</method>
 		<method name="body_get_object_instance_id" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Gets the instance ID of the object the area is assigned to.
+				Returns the [code]ObjectID[/code] attached to the body. Use [method @GlobalScope.instance_from_id] to retrieve an [Object] from a nonzero [code]ObjectID[/code].
 			</description>
 		</method>
 		<method name="body_get_param" qualifiers="const">
@@ -435,7 +456,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.BodyParameter" />
 			<description>
-				Returns the value of a body parameter. See [enum BodyParameter] for a list of available parameters.
+				Returns the value of the given body parameter. See [enum BodyParameter] for the list of available parameters.
 			</description>
 		</method>
 		<method name="body_get_shape" qualifiers="const">
@@ -443,14 +464,14 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<description>
-				Returns the [RID] of the nth shape of a body.
+				Returns the [RID] of the shape with the given index in the body's array of shapes.
 			</description>
 		</method>
 		<method name="body_get_shape_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Returns the number of shapes assigned to a body.
+				Returns the number of shapes added to the body.
 			</description>
 		</method>
 		<method name="body_get_shape_transform" qualifiers="const">
@@ -458,14 +479,14 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<description>
-				Returns the transform matrix of a body shape.
+				Returns the local transform matrix of the shape with the given index in the area's array of shapes.
 			</description>
 		</method>
 		<method name="body_get_space" qualifiers="const">
 			<return type="RID" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Returns the [RID] of the space assigned to a body.
+				Returns the [RID] of the space assigned to the body. Returns [code]RID()[/code] if no space is assigned.
 			</description>
 		</method>
 		<method name="body_get_state" qualifiers="const">
@@ -473,14 +494,14 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer2D.BodyState" />
 			<description>
-				Returns a body state.
+				Returns the value of the given state of the body. See [enum BodyState] for the list of available states.
 			</description>
 		</method>
 		<method name="body_is_omitting_force_integration" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Returns whether a body uses a callback function to calculate its own physics (see [method body_set_force_integration_callback]).
+				Returns [code]true[/code] if the body uses a callback function to calculate its own physics (see [method body_set_force_integration_callback]).
 			</description>
 		</method>
 		<method name="body_remove_collision_exception">
@@ -488,7 +509,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="excepted_body" type="RID" />
 			<description>
-				Removes a body from the list of bodies exempt from collisions.
+				Removes [param excepted_body] from the body's list of collision exceptions, so that collisions with it are no longer ignored.
 			</description>
 		</method>
 		<method name="body_remove_shape">
@@ -496,14 +517,14 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<description>
-				Removes a shape from a body. The shape is not deleted, so it can be reused afterwards.
+				Removes the shape with the given index from the body's array of shapes. The shape itself is not deleted, so it can continue to be used elsewhere or added back later. As a result of this operation, the body's shapes which used to have indices higher than [param shape_idx] will have their index decreased by one.
 			</description>
 		</method>
 		<method name="body_reset_mass_properties">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<description>
-				Restores the default inertia and center of mass based on shapes to cancel any custom values previously set using [method body_set_param].
+				Restores the default inertia and center of mass of the body based on its shapes. This undoes any custom values previously set using [method body_set_param].
 			</description>
 		</method>
 		<method name="body_set_axis_velocity">
@@ -511,7 +532,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="axis_velocity" type="Vector2" />
 			<description>
-				Sets an axis velocity. The velocity in the given vector axis will be set as the given vector length. This is useful for jumping behavior.
+				Modifies the body's linear velocity so that its projection to the axis [code]axis_velocity.normalized()[/code] is exactly [code]axis_velocity.length()[/code]. This is useful for jumping behavior.
 			</description>
 		</method>
 		<method name="body_set_collision_layer">
@@ -519,7 +540,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="layer" type="int" />
 			<description>
-				Sets the physics layer or layers a body belongs to.
+				Sets the physics layer or layers the body belongs to, via a bitmask.
 			</description>
 		</method>
 		<method name="body_set_collision_mask">
@@ -527,7 +548,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mask" type="int" />
 			<description>
-				Sets the physics layer or layers a body can collide with.
+				Sets the physics layer or layers the body can collide with, via a bitmask.
 			</description>
 		</method>
 		<method name="body_set_collision_priority">
@@ -535,7 +556,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="priority" type="float" />
 			<description>
-				Sets the body's collision priority.
+				Sets the body's collision priority. This is used in the depenetration phase of [method body_test_motion]. The higher the priority is, the lower the penetration into the body will be.
 			</description>
 		</method>
 		<method name="body_set_constant_force">
@@ -543,7 +564,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector2" />
 			<description>
-				Sets the body's total constant positional forces applied during each physics update.
+				Sets the body's total constant positional force applied during each physics update.
 				See [method body_add_constant_force] and [method body_add_constant_central_force].
 			</description>
 		</method>
@@ -552,7 +573,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="torque" type="float" />
 			<description>
-				Sets the body's total constant rotational forces applied during each physics update.
+				Sets the body's total constant rotational force applied during each physics update.
 				See [method body_add_constant_torque].
 			</description>
 		</method>
@@ -562,7 +583,7 @@
 			<param index="1" name="mode" type="int" enum="PhysicsServer2D.CCDMode" />
 			<description>
 				Sets the continuous collision detection mode using one of the [enum CCDMode] constants.
-				Continuous collision detection tries to predict where a moving body will collide, instead of moving it and correcting its movement if it collided.
+				Continuous collision detection tries to predict where a moving body would collide in between physics updates, instead of moving it and correcting its movement if it collided.
 			</description>
 		</method>
 		<method name="body_set_force_integration_callback">
@@ -571,10 +592,11 @@
 			<param index="1" name="callable" type="Callable" />
 			<param index="2" name="userdata" type="Variant" default="null" />
 			<description>
-				Sets the function used to calculate physics for an object, if that object allows it (see [method body_set_omit_force_integration]).
-				The force integration function takes 2 arguments:
-				[code]state:[/code] [PhysicsDirectBodyState2D] used to retrieve and modify the body's state.
-				[code]userdata:[/code] Optional user data, if it was passed when calling [code]body_set_force_integration_callback[/code].
+				Sets the function used to calculate physics for the body, if that body allows it (see [method body_set_omit_force_integration]).
+				The force integration function takes the following two parameters:
+				1. a [PhysicsDirectBodyState2D] [code]state[/code]: used to retrieve and modify the body's state,
+				2. a [Variant] [code]userdata[/code]: optional user data.
+				[b]Note:[/b] This callback is currently not called in Godot Physics.
 			</description>
 		</method>
 		<method name="body_set_max_contacts_reported">
@@ -582,7 +604,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="amount" type="int" />
 			<description>
-				Sets the maximum contacts to report. Bodies can keep a log of the contacts with other bodies. This is enabled by setting the maximum number of contacts reported to a number greater than 0.
+				Sets the maximum number of contacts that the body can report. If [param amount] is greater than zero, then the body will keep track of at most this many contacts with other bodies.
 			</description>
 		</method>
 		<method name="body_set_mode">
@@ -590,7 +612,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mode" type="int" enum="PhysicsServer2D.BodyMode" />
 			<description>
-				Sets the body mode using one of the [enum BodyMode] constants.
+				Sets the body's mode. See [enum BodyMode] for the list of available modes.
 			</description>
 		</method>
 		<method name="body_set_omit_force_integration">
@@ -598,7 +620,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="enable" type="bool" />
 			<description>
-				Sets whether a body uses a callback function to calculate its own physics (see [method body_set_force_integration_callback]).
+				Sets whether the body uses a callback function to calculate its own physics (see [method body_set_force_integration_callback]).
 			</description>
 		</method>
 		<method name="body_set_param">
@@ -607,7 +629,7 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.BodyParameter" />
 			<param index="2" name="value" type="Variant" />
 			<description>
-				Sets a body parameter. See [enum BodyParameter] for a list of available parameters.
+				Sets the value of the given body parameter. See [enum BodyParameter] for the list of available parameters.
 			</description>
 		</method>
 		<method name="body_set_shape">
@@ -616,7 +638,7 @@
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="shape" type="RID" />
 			<description>
-				Substitutes a given body shape by another. The old shape is selected by its index, the new one by its [RID].
+				Replaces the body's shape at the given index by another shape, while not affecting the [code]transform[/code], [code]disabled[/code], and one-way collision properties at the same index.
 			</description>
 		</method>
 		<method name="body_set_shape_as_one_way_collision">
@@ -626,7 +648,7 @@
 			<param index="2" name="enable" type="bool" />
 			<param index="3" name="margin" type="float" />
 			<description>
-				Enables one way collision on body if [param enable] is [code]true[/code].
+				Sets the one-way collision properties of the body's shape with the given index. If [param enable] is [code]true[/code], the one-way collision direction given by the shape's local upward axis [code]body_get_shape_transform(body, shape_idx).y[/code] will be used to ignore collisions with the shape in the opposite direction, and to ensure depenetration of kinematic bodies happens in this direction.
 			</description>
 		</method>
 		<method name="body_set_shape_disabled">
@@ -635,7 +657,7 @@
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="disabled" type="bool" />
 			<description>
-				Disables shape in body if [param disabled] is [code]true[/code].
+				Sets the disabled property of the body's shape with the given index. If [param disabled] is [code]true[/code], then the shape will be ignored in all collision detection.
 			</description>
 		</method>
 		<method name="body_set_shape_transform">
@@ -644,7 +666,7 @@
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="transform" type="Transform2D" />
 			<description>
-				Sets the transform matrix for a body shape.
+				Sets the local transform matrix of the body's shape with the given index.
 			</description>
 		</method>
 		<method name="body_set_space">
@@ -652,7 +674,10 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="space" type="RID" />
 			<description>
-				Assigns a space to the body (see [method space_create]).
+				Adds the body to the given space, after removing the body from the previously assigned space (if any). If the body's mode is set to [constant BODY_MODE_RIGID], then adding the body to a space will have the following additional effects:
+				- If the parameter [constant BODY_PARAM_CENTER_OF_MASS] has never been set explicitly, then the value of that parameter will be recalculated based on the body's shapes.
+				- If the parameter [constant BODY_PARAM_INERTIA] is set to a value [code]&lt;= 0.0[/code], then the value of that parameter will be recalculated based on the body's shapes, mass, and center of mass.
+				[b]Note:[/b] To remove a body from a space without immediately adding it back elsewhere, use [code]PhysicsServer2D.body_set_space(body, RID())[/code].
 			</description>
 		</method>
 		<method name="body_set_state">
@@ -661,8 +686,8 @@
 			<param index="1" name="state" type="int" enum="PhysicsServer2D.BodyState" />
 			<param index="2" name="value" type="Variant" />
 			<description>
-				Sets a body state using one of the [enum BodyState] constants.
-				Note that the method doesn't take effect immediately. The state will change on the next physics frame.
+				Sets the value of a body's state. See [enum BodyState] for the list of available states.
+				[b]Note:[/b] The state change doesn't take effect immediately. The state will change on the next physics frame.
 			</description>
 		</method>
 		<method name="body_test_motion">
@@ -671,27 +696,31 @@
 			<param index="1" name="parameters" type="PhysicsTestMotionParameters2D" />
 			<param index="2" name="result" type="PhysicsTestMotionResult2D" default="null" />
 			<description>
-				Returns [code]true[/code] if a collision would result from moving along a motion vector from a given point in space. [PhysicsTestMotionParameters2D] is passed to set motion parameters. [PhysicsTestMotionResult2D] can be passed to return additional information.
+				Returns [code]true[/code] if a collision would result from moving the body along a motion vector from a given point in space. See [PhysicsTestMotionParameters2D] for the available motion parameters. Optionally a [PhysicsTestMotionResult2D] object can be passed, which will be used to store the information about the resulting collision.
 			</description>
 		</method>
 		<method name="capsule_shape_create">
 			<return type="RID" />
 			<description>
+				Creates a 2D capsule shape in the physics server, and returns the [RID] that identifies it. Use [method shape_set_data] to set the capsule's height and radius.
 			</description>
 		</method>
 		<method name="circle_shape_create">
 			<return type="RID" />
 			<description>
+				Creates a 2D circle shape in the physics server, and returns the [RID] that identifies it. Use [method shape_set_data] to set the circle's radius.
 			</description>
 		</method>
 		<method name="concave_polygon_shape_create">
 			<return type="RID" />
 			<description>
+				Creates a 2D concave polygon shape in the physics server, and returns the [RID] that identifies it. Use [method shape_set_data] to set the concave polygon's segments.
 			</description>
 		</method>
 		<method name="convex_polygon_shape_create">
 			<return type="RID" />
 			<description>
+				Creates a 2D convex polygon shape in the physics server, and returns the [RID] that identifies it. Use [method shape_set_data] to set the convex polygon's points.
 			</description>
 		</method>
 		<method name="damped_spring_joint_get_param" qualifiers="const">
@@ -699,7 +728,7 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.DampedSpringParam" />
 			<description>
-				Returns the value of a damped spring joint parameter. See [enum DampedSpringParam] for a list of available parameters.
+				Returns the value of the given damped spring joint parameter. See [enum DampedSpringParam] for the list of available parameters.
 			</description>
 		</method>
 		<method name="damped_spring_joint_set_param">
@@ -708,32 +737,34 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.DampedSpringParam" />
 			<param index="2" name="value" type="float" />
 			<description>
-				Sets a damped spring joint parameter. See [enum DampedSpringParam] for a list of available parameters.
+				Sets the value of the given damped spring joint parameter. See [enum DampedSpringParam] for the list of available parameters.
 			</description>
 		</method>
 		<method name="free_rid">
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
 			<description>
-				Destroys any of the objects created by PhysicsServer2D. If the [RID] passed is not one of the objects that can be created by PhysicsServer2D, an error will be sent to the console.
+				Destroys any of the objects created by PhysicsServer2D. If the [RID] passed is not one of the objects that can be created by PhysicsServer2D, an error will be printed to the console.
 			</description>
 		</method>
 		<method name="get_process_info">
 			<return type="int" />
 			<param index="0" name="process_info" type="int" enum="PhysicsServer2D.ProcessInfo" />
 			<description>
-				Returns information about the current state of the 2D physics engine. See [enum ProcessInfo] for a list of available states.
+				Returns information about the current state of the 2D physics engine. See [enum ProcessInfo] for the list of available states.
 			</description>
 		</method>
 		<method name="joint_clear">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<description>
+				Destroys the joint with the given [RID], creates a new uninitialized joint, and makes the [RID] refer to this new joint.
 			</description>
 		</method>
 		<method name="joint_create">
 			<return type="RID" />
 			<description>
+				Creates a 2D joint in the physics server, and returns the [RID] that identifies it. To set the joint type, use [method joint_make_damped_spring], [method joint_make_groove] or [method joint_make_pin]. Use [method joint_set_param] to set generic joint parameters.
 			</description>
 		</method>
 		<method name="joint_disable_collisions_between_bodies">
@@ -749,14 +780,14 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.JointParam" />
 			<description>
-				Returns the value of a joint parameter.
+				Returns the value of the given joint parameter. See [enum JointParam] for the list of available parameters.
 			</description>
 		</method>
 		<method name="joint_get_type" qualifiers="const">
 			<return type="int" enum="PhysicsServer2D.JointType" />
 			<param index="0" name="joint" type="RID" />
 			<description>
-				Returns a joint's type (see [enum JointType]).
+				Returns the joint's type (see [enum JointType]).
 			</description>
 		</method>
 		<method name="joint_is_disabled_collisions_between_bodies" qualifiers="const">
@@ -774,6 +805,7 @@
 			<param index="3" name="body_a" type="RID" />
 			<param index="4" name="body_b" type="RID" />
 			<description>
+				Makes the joint a damped spring joint, attached at the point [param anchor_a] (given in global coordinates) on the body [param body_a] and at the point [param anchor_b] (given in global coordinates) on the body [param body_b]. To set the parameters which are specific to the damped spring, see [method damped_spring_joint_set_param].
 			</description>
 		</method>
 		<method name="joint_make_groove">
@@ -785,6 +817,7 @@
 			<param index="4" name="body_a" type="RID" />
 			<param index="5" name="body_b" type="RID" />
 			<description>
+				Makes the joint a groove joint.
 			</description>
 		</method>
 		<method name="joint_make_pin">
@@ -794,6 +827,7 @@
 			<param index="2" name="body_a" type="RID" />
 			<param index="3" name="body_b" type="RID" />
 			<description>
+				Makes the joint a pin joint. If [param body_b] is [code]RID()[/code], then [param body_a] is pinned to the point [param anchor] (given in global coordinates); otherwise, [param body_a] is pinned to [param body_b] at the point [param anchor] (given in global coordinates). To set the parameters which are specific to the pin joint, see [method pin_joint_set_param].
 			</description>
 		</method>
 		<method name="joint_set_param">
@@ -802,7 +836,7 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.JointParam" />
 			<param index="2" name="value" type="float" />
 			<description>
-				Sets a joint parameter. See [enum JointParam] for a list of available parameters.
+				Sets the value of the given joint parameter. See [enum JointParam] for the list of available parameters.
 			</description>
 		</method>
 		<method name="pin_joint_get_param" qualifiers="const">
@@ -825,37 +859,40 @@
 		<method name="rectangle_shape_create">
 			<return type="RID" />
 			<description>
+				Creates a 2D rectangle shape in the physics server, and returns the [RID] that identifies it. Use [method shape_set_data] to set the rectangle's half-extents.
 			</description>
 		</method>
 		<method name="segment_shape_create">
 			<return type="RID" />
 			<description>
+				Creates a 2D segment shape in the physics server, and returns the [RID] that identifies it. Use [method shape_set_data] to set the segment's start and end points.
 			</description>
 		</method>
 		<method name="separation_ray_shape_create">
 			<return type="RID" />
 			<description>
+				Creates a 2D separation ray shape in the physics server, and returns the [RID] that identifies it. Use [method shape_set_data] to set the shape's [code]length[/code] and [code]slide_on_slope[/code] properties.
 			</description>
 		</method>
 		<method name="set_active">
 			<return type="void" />
 			<param index="0" name="active" type="bool" />
 			<description>
-				Activates or deactivates the 2D physics engine.
+				Activates or deactivates the 2D physics server. If [param active] is [code]false[/code], then the physics server will not do anything in its physics step.
 			</description>
 		</method>
 		<method name="shape_get_data" qualifiers="const">
 			<return type="Variant" />
 			<param index="0" name="shape" type="RID" />
 			<description>
-				Returns the shape data.
+				Returns the shape data that defines the configuration of the shape, such as the half-extents of a rectangle or the segments of a concave shape. See [method shape_set_data] for the precise format of this data in each case.
 			</description>
 		</method>
 		<method name="shape_get_type" qualifiers="const">
 			<return type="int" enum="PhysicsServer2D.ShapeType" />
 			<param index="0" name="shape" type="RID" />
 			<description>
-				Returns a shape's type (see [enum ShapeType]).
+				Returns the shape's type (see [enum ShapeType]).
 			</description>
 		</method>
 		<method name="shape_set_data">
@@ -863,20 +900,29 @@
 			<param index="0" name="shape" type="RID" />
 			<param index="1" name="data" type="Variant" />
 			<description>
-				Sets the shape data that defines its shape and size. The data to be passed depends on the kind of shape created [method shape_get_type].
+				Sets the shape data that defines the configuration of the shape. The [param data] to be passed depends on the shape's type (see [method shape_get_type]):
+				- [constant SHAPE_WORLD_BOUNDARY]: an array of length two containing a [Vector2] [code]normal[/code] direction and a [code]float[/code] distance [code]d[/code],
+				- [constant SHAPE_SEPARATION_RAY]: a dictionary containing the key [code]length[/code] with a [code]float[/code] value and the key [code]slide_on_slope[/code] with a [code]bool[/code] value,
+				- [constant SHAPE_SEGMENT]: a [Rect2] [code]rect[/code] containing the first point of the segment in [code]rect.position[/code] and the second point of the segment in [code]rect.size[/code],
+				- [constant SHAPE_CIRCLE]: a [code]float[/code] [code]radius[/code],
+				- [constant SHAPE_RECTANGLE]: a [Vector2] [code]half_extents[/code],
+				- [constant SHAPE_CAPSULE]: an array of length two (or a [Vector2]) containing a [code]float[/code] [code]height[/code] and a [code]float[/code] [code]radius[/code],
+				- [constant SHAPE_CONVEX_POLYGON]: either a [PackedVector2Array] of points defining a convex polygon in counterclockwise order (the clockwise outward normal of each segment formed by consecutive points is calculated internally), or a [PackedFloat32Array] of length divisible by four so that every 4-tuple of [code]float[/code]s contains the coordinates of a point followed by the coordinates of the clockwise outward normal vector to the segment between the current point and the next point,
+				- [constant SHAPE_CONCAVE_POLYGON]: a [PackedVector2Array] of length divisible by two (each pair of points forms one segment).
+				[b]Warning[/b]: In the case of [constant SHAPE_CONVEX_POLYGON], this method does not check if the points supplied actually form a convex polygon (unlike the [member CollisionPolygon2D.polygon] property).
 			</description>
 		</method>
 		<method name="space_create">
 			<return type="RID" />
 			<description>
-				Creates a space. A space is a collection of parameters for the physics engine that can be assigned to an area or a body. It can be assigned to an area with [method area_set_space], or to a body with [method body_set_space].
+				Creates a 2D space in the physics server, and returns the [RID] that identifies it. A space contains bodies and areas, and controls the stepping of the physics simulation of the objects in it.
 			</description>
 		</method>
 		<method name="space_get_direct_state">
 			<return type="PhysicsDirectSpaceState2D" />
 			<param index="0" name="space" type="RID" />
 			<description>
-				Returns the state of a space, a [PhysicsDirectSpaceState2D]. This object can be used to make collision/intersection queries.
+				Returns the state of a space, a [PhysicsDirectSpaceState2D]. This object can be used for collision/intersection queries.
 			</description>
 		</method>
 		<method name="space_get_param" qualifiers="const">
@@ -884,14 +930,14 @@
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.SpaceParameter" />
 			<description>
-				Returns the value of a space parameter.
+				Returns the value of the given space parameter. See [enum SpaceParameter] for the list of available parameters.
 			</description>
 		</method>
 		<method name="space_is_active" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="space" type="RID" />
 			<description>
-				Returns whether the space is active.
+				Returns [code]true[/code] if the space is active.
 			</description>
 		</method>
 		<method name="space_set_active">
@@ -899,7 +945,7 @@
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="active" type="bool" />
 			<description>
-				Marks a space as active. It will not have an effect, unless it is assigned to an area or body.
+				Activates or deactivates the space. If [param active] is [code]false[/code], then the physics server will not do anything with this space in its physics step.
 			</description>
 		</method>
 		<method name="space_set_param">
@@ -908,42 +954,43 @@
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.SpaceParameter" />
 			<param index="2" name="value" type="float" />
 			<description>
-				Sets the value for a space parameter. See [enum SpaceParameter] for a list of available parameters.
+				Sets the value of the given space parameter. See [enum SpaceParameter] for the list of available parameters.
 			</description>
 		</method>
 		<method name="world_boundary_shape_create">
 			<return type="RID" />
 			<description>
+				Creates a 2D world boundary shape in the physics server, and returns the [RID] that identifies it. Use [method shape_set_data] to set the shape's normal direction and distance properties.
 			</description>
 		</method>
 	</methods>
 	<constants>
 		<constant name="SPACE_PARAM_CONTACT_RECYCLE_RADIUS" value="0" enum="SpaceParameter">
-			Constant to set/get the maximum distance a pair of bodies has to move before their collision status has to be recalculated.
+			Constant to set/get the maximum distance a pair of bodies has to move before their collision status has to be recalculated. The default value of this parameter is [member ProjectSettings.physics/2d/solver/contact_recycle_radius].
 		</constant>
 		<constant name="SPACE_PARAM_CONTACT_MAX_SEPARATION" value="1" enum="SpaceParameter">
-			Constant to set/get the maximum distance a shape can be from another before they are considered separated and the contact is discarded.
+			Constant to set/get the maximum distance a shape can be from another before they are considered separated and the contact is discarded. The default value of this parameter is [member ProjectSettings.physics/2d/solver/contact_max_separation].
 		</constant>
 		<constant name="SPACE_PARAM_CONTACT_MAX_ALLOWED_PENETRATION" value="2" enum="SpaceParameter">
-			Constant to set/get the maximum distance a shape can penetrate another shape before it is considered a collision.
+			Constant to set/get the maximum distance a shape can penetrate another shape before it is considered a collision. The default value of this parameter is [member ProjectSettings.physics/2d/solver/contact_max_allowed_penetration].
 		</constant>
 		<constant name="SPACE_PARAM_CONTACT_DEFAULT_BIAS" value="3" enum="SpaceParameter">
-			Constant to set/get the default solver bias for all physics contacts. A solver bias is a factor controlling how much two objects "rebound", after overlapping, to avoid leaving them in that state because of numerical imprecision.
+			Constant to set/get the default solver bias for all physics contacts. A solver bias is a factor controlling how much two objects "rebound", after overlapping, to avoid leaving them in that state because of numerical imprecision. The default value of this parameter is [member ProjectSettings.physics/2d/solver/default_contact_bias].
 		</constant>
 		<constant name="SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD" value="4" enum="SpaceParameter">
-			Constant to set/get the threshold linear velocity of activity. A body marked as potentially inactive for both linear and angular velocity will be put to sleep after the time given.
+			Constant to set/get the threshold linear velocity of activity. A body marked as potentially inactive for both linear and angular velocity will be put to sleep after the time given. The default value of this parameter is [member ProjectSettings.physics/2d/sleep_threshold_linear].
 		</constant>
 		<constant name="SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD" value="5" enum="SpaceParameter">
-			Constant to set/get the threshold angular velocity of activity. A body marked as potentially inactive for both linear and angular velocity will be put to sleep after the time given.
+			Constant to set/get the threshold angular velocity of activity. A body marked as potentially inactive for both linear and angular velocity will be put to sleep after the time given. The default value of this parameter is [member ProjectSettings.physics/2d/sleep_threshold_angular].
 		</constant>
 		<constant name="SPACE_PARAM_BODY_TIME_TO_SLEEP" value="6" enum="SpaceParameter">
-			Constant to set/get the maximum time of activity. A body marked as potentially inactive for both linear and angular velocity will be put to sleep after this time.
+			Constant to set/get the maximum time of activity. A body marked as potentially inactive for both linear and angular velocity will be put to sleep after this time. The default value of this parameter is [member ProjectSettings.physics/2d/time_before_sleep].
 		</constant>
 		<constant name="SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS" value="7" enum="SpaceParameter">
-			Constant to set/get the default solver bias for all physics constraints. A solver bias is a factor controlling how much two objects "rebound", after violating a constraint, to avoid leaving them in that state because of numerical imprecision.
+			Constant to set/get the default solver bias for all physics constraints. A solver bias is a factor controlling how much two objects "rebound", after violating a constraint, to avoid leaving them in that state because of numerical imprecision. The default value of this parameter is [member ProjectSettings.physics/2d/solver/default_constraint_bias].
 		</constant>
 		<constant name="SPACE_PARAM_SOLVER_ITERATIONS" value="8" enum="SpaceParameter">
-			Constant to set/get the number of solver iterations for all contacts and constraints. The greater the number of iterations, the more accurate the collisions will be. However, a greater number of iterations requires more CPU power, which can decrease performance.
+			Constant to set/get the number of solver iterations for all contacts and constraints. The greater the number of iterations, the more accurate the collisions will be. However, a greater number of iterations requires more CPU power, which can decrease performance. The default value of this parameter is [member ProjectSettings.physics/2d/solver/solver_iterations].
 		</constant>
 		<constant name="SHAPE_WORLD_BOUNDARY" value="0" enum="ShapeType">
 			This is the constant for creating world boundary shapes. A world boundary shape is an [i]infinite[/i] line with an origin point, and a normal. Thus, it can be used for front/behind checks.
@@ -964,7 +1011,7 @@
 			This is the constant for creating capsule shapes. A capsule shape is defined by a radius and a length. It can be used for intersections and inside/outside checks.
 		</constant>
 		<constant name="SHAPE_CONVEX_POLYGON" value="6" enum="ShapeType">
-			This is the constant for creating convex polygon shapes. A polygon is defined by a list of points. It can be used for intersections and inside/outside checks. Unlike the [member CollisionPolygon2D.polygon] property, polygons modified with [method shape_set_data] do not verify that the points supplied form is a convex polygon.
+			This is the constant for creating convex polygon shapes. A polygon is defined by a list of points. It can be used for intersections and inside/outside checks.
 		</constant>
 		<constant name="SHAPE_CONCAVE_POLYGON" value="7" enum="ShapeType">
 			This is the constant for creating concave polygon shapes. A polygon is defined by a list of points. It can be used for intersections checks, but not for inside/outside checks.
@@ -973,35 +1020,35 @@
 			This constant is used internally by the engine. Any attempt to create this kind of shape results in an error.
 		</constant>
 		<constant name="AREA_PARAM_GRAVITY_OVERRIDE_MODE" value="0" enum="AreaParameter">
-			Constant to set/get gravity override mode in an area. See [enum AreaSpaceOverrideMode] for possible values.
+			Constant to set/get gravity override mode in an area. See [enum AreaSpaceOverrideMode] for possible values. The default value of this parameter is [constant AREA_SPACE_OVERRIDE_DISABLED].
 		</constant>
 		<constant name="AREA_PARAM_GRAVITY" value="1" enum="AreaParameter">
-			Constant to set/get gravity strength in an area.
+			Constant to set/get gravity strength in an area. The default value of this parameter is [code]9.80665[/code].
 		</constant>
 		<constant name="AREA_PARAM_GRAVITY_VECTOR" value="2" enum="AreaParameter">
-			Constant to set/get gravity vector/center in an area.
+			Constant to set/get gravity vector/center in an area. The default value of this parameter is [code]Vector2(0, -1)[/code].
 		</constant>
 		<constant name="AREA_PARAM_GRAVITY_IS_POINT" value="3" enum="AreaParameter">
-			Constant to set/get whether the gravity vector of an area is a direction, or a center point.
+			Constant to set/get whether the gravity vector of an area is a direction, or a center point. The default value of this parameter is [code]false[/code].
 		</constant>
 		<constant name="AREA_PARAM_GRAVITY_POINT_UNIT_DISTANCE" value="4" enum="AreaParameter">
 			Constant to set/get the distance at which the gravity strength is equal to the gravity controlled by [constant AREA_PARAM_GRAVITY]. For example, on a planet 100 pixels in radius with a surface gravity of 4.0 px/s², set the gravity to 4.0 and the unit distance to 100.0. The gravity will have falloff according to the inverse square law, so in the example, at 200 pixels from the center the gravity will be 1.0 px/s² (twice the distance, 1/4th the gravity), at 50 pixels it will be 16.0 px/s² (half the distance, 4x the gravity), and so on.
-			The above is true only when the unit distance is a positive number. When the unit distance is set to 0.0, the gravity will be constant regardless of distance.
+			The above is true only when the unit distance is a positive number. When the unit distance is set to 0.0, the gravity will be constant regardless of distance. The default value of this parameter is [code]0.0[/code].
 		</constant>
 		<constant name="AREA_PARAM_LINEAR_DAMP_OVERRIDE_MODE" value="5" enum="AreaParameter">
-			Constant to set/get linear damping override mode in an area. See [enum AreaSpaceOverrideMode] for possible values.
+			Constant to set/get linear damping override mode in an area. See [enum AreaSpaceOverrideMode] for possible values. The default value of this parameter is [constant AREA_SPACE_OVERRIDE_DISABLED].
 		</constant>
 		<constant name="AREA_PARAM_LINEAR_DAMP" value="6" enum="AreaParameter">
-			Constant to set/get the linear damping factor of an area.
+			Constant to set/get the linear damping factor of an area. The default value of this parameter is [code]0.1[/code].
 		</constant>
 		<constant name="AREA_PARAM_ANGULAR_DAMP_OVERRIDE_MODE" value="7" enum="AreaParameter">
-			Constant to set/get angular damping override mode in an area. See [enum AreaSpaceOverrideMode] for possible values.
+			Constant to set/get angular damping override mode in an area. See [enum AreaSpaceOverrideMode] for possible values. The default value of this parameter is [constant AREA_SPACE_OVERRIDE_DISABLED].
 		</constant>
 		<constant name="AREA_PARAM_ANGULAR_DAMP" value="8" enum="AreaParameter">
-			Constant to set/get the angular damping factor of an area.
+			Constant to set/get the angular damping factor of an area. The default value of this parameter is [code]1.0[/code].
 		</constant>
 		<constant name="AREA_PARAM_PRIORITY" value="9" enum="AreaParameter">
-			Constant to set/get the priority (order of processing) of an area.
+			Constant to set/get the priority (order of processing) of an area. The default value of this parameter is [code]0[/code].
 		</constant>
 		<constant name="AREA_SPACE_OVERRIDE_DISABLED" value="0" enum="AreaSpaceOverrideMode">
 			This area does not affect gravity/damp. These are generally areas that exist only to detect collisions, and objects entering or exiting them.
@@ -1031,34 +1078,36 @@
 			Constant for linear rigid bodies. In this mode, a body can not rotate, and only its linear velocity is affected by external forces.
 		</constant>
 		<constant name="BODY_PARAM_BOUNCE" value="0" enum="BodyParameter">
-			Constant to set/get a body's bounce factor.
+			Constant to set/get a body's bounce factor. The default value of this parameter is [code]0.0[/code].
 		</constant>
 		<constant name="BODY_PARAM_FRICTION" value="1" enum="BodyParameter">
-			Constant to set/get a body's friction.
+			Constant to set/get a body's friction. The default value of this parameter is [code]1.0[/code].
 		</constant>
 		<constant name="BODY_PARAM_MASS" value="2" enum="BodyParameter">
-			Constant to set/get a body's mass.
+			Constant to set/get a body's mass. The default value of this parameter is [code]1.0[/code]. If the body's mode is set to [constant BODY_MODE_RIGID], then setting this parameter will have the following additional effects:
+			- If the parameter [constant BODY_PARAM_CENTER_OF_MASS] has never been set explicitly, then the value of that parameter will be recalculated based on the body's shapes.
+			- If the parameter [constant BODY_PARAM_INERTIA] is set to a value [code]&lt;= 0.0[/code], then the value of that parameter will be recalculated based on the body's shapes, mass, and center of mass.
 		</constant>
 		<constant name="BODY_PARAM_INERTIA" value="3" enum="BodyParameter">
-			Constant to set/get a body's inertia.
+			Constant to set/get a body's inertia. The default value of this parameter is [code]0.0[/code]. If the body's inertia is set to a value [code]&lt;= 0.0[/code], then the inertia will be recalculated based on the body's shapes, mass, and center of mass.
 		</constant>
 		<constant name="BODY_PARAM_CENTER_OF_MASS" value="4" enum="BodyParameter">
-			Constant to set/get a body's center of mass position in the body's local coordinate system.
+			Constant to set/get a body's center of mass position in the body's local coordinate system. The default value of this parameter is [code]Vector2(0,0)[/code]. If this parameter is never set explicitly, then it is recalculated based on the body's shapes when setting the parameter [constant BODY_PARAM_MASS] or when calling [method body_set_space].
 		</constant>
 		<constant name="BODY_PARAM_GRAVITY_SCALE" value="5" enum="BodyParameter">
-			Constant to set/get a body's gravity multiplier.
+			Constant to set/get a body's gravity multiplier. The default value of this parameter is [code]1.0[/code].
 		</constant>
 		<constant name="BODY_PARAM_LINEAR_DAMP_MODE" value="6" enum="BodyParameter">
-			Constant to set/get a body's linear damping mode. See [enum BodyDampMode] for possible values.
+			Constant to set/get a body's linear damping mode. See [enum BodyDampMode] for possible values. The default value of this parameter is [constant BODY_DAMP_MODE_COMBINE].
 		</constant>
 		<constant name="BODY_PARAM_ANGULAR_DAMP_MODE" value="7" enum="BodyParameter">
-			Constant to set/get a body's angular damping mode. See [enum BodyDampMode] for possible values.
+			Constant to set/get a body's angular damping mode. See [enum BodyDampMode] for possible values. The default value of this parameter is [constant BODY_DAMP_MODE_COMBINE].
 		</constant>
 		<constant name="BODY_PARAM_LINEAR_DAMP" value="8" enum="BodyParameter">
-			Constant to set/get a body's linear damping factor.
+			Constant to set/get a body's linear damping factor. The default value of this parameter is [code]0.0[/code].
 		</constant>
 		<constant name="BODY_PARAM_ANGULAR_DAMP" value="9" enum="BodyParameter">
-			Constant to set/get a body's angular damping factor.
+			Constant to set/get a body's angular damping factor. The default value of this parameter is [code]0.0[/code].
 		</constant>
 		<constant name="BODY_PARAM_MAX" value="10" enum="BodyParameter">
 			Represents the size of the [enum BodyParameter] enum.
@@ -1097,24 +1146,31 @@
 			Represents the size of the [enum JointType] enum.
 		</constant>
 		<constant name="JOINT_PARAM_BIAS" value="0" enum="JointParam">
+			Constant to set/get how fast the joint pulls the bodies back to satisfy the joint constraint. The lower the value, the more the two bodies can pull on the joint. The default value of this parameter is [code]0.0[/code].
+			[b]Note:[/b] In Godot Physics, this parameter is only used for pin joints and groove joints.
 		</constant>
 		<constant name="JOINT_PARAM_MAX_BIAS" value="1" enum="JointParam">
+			Constant to set/get the maximum speed with which the joint can apply corrections. The default value of this parameter is [code]3.40282e+38[/code].
+			[b]Note:[/b] In Godot Physics, this parameter is only used for groove joints.
 		</constant>
 		<constant name="JOINT_PARAM_MAX_FORCE" value="2" enum="JointParam">
+			Constant to set/get the maximum force that the joint can use to act on the two bodies. The default value of this parameter is [code]3.40282e+38[/code].
+			[b]Note:[/b] In Godot Physics, this parameter is only used for groove joints.
 		</constant>
 		<constant name="PIN_JOINT_SOFTNESS" value="0" enum="PinJointParam">
+			Constant to set/get a how much the bond of the pin joint can flex. The default value of this parameter is [code]0.0[/code].
 		</constant>
 		<constant name="DAMPED_SPRING_REST_LENGTH" value="0" enum="DampedSpringParam">
-			Sets the resting length of the spring joint. The joint will always try to go to back this length when pulled apart.
+			Sets the resting length of the spring joint. The joint will always try to go to back this length when pulled apart. The default value of this parameter is the distance between the joint's anchor points.
 		</constant>
 		<constant name="DAMPED_SPRING_STIFFNESS" value="1" enum="DampedSpringParam">
-			Sets the stiffness of the spring joint. The joint applies a force equal to the stiffness times the distance from its resting length.
+			Sets the stiffness of the spring joint. The joint applies a force equal to the stiffness times the distance from its resting length. The default value of this parameter is [code]20.0[/code].
 		</constant>
 		<constant name="DAMPED_SPRING_DAMPING" value="2" enum="DampedSpringParam">
-			Sets the damping ratio of the spring joint. A value of 0 indicates an undamped spring, while 1 causes the system to reach equilibrium as fast as possible (critical damping).
+			Sets the damping ratio of the spring joint. A value of 0 indicates an undamped spring, while 1 causes the system to reach equilibrium as fast as possible (critical damping). The default value of this parameter is [code]1.5[/code].
 		</constant>
 		<constant name="CCD_MODE_DISABLED" value="0" enum="CCDMode">
-			Disables continuous collision detection. This is the fastest way to detect body collisions, but can miss small, fast-moving objects.
+			Disables continuous collision detection. This is the fastest way to detect body collisions, but it can miss small and/or fast-moving objects.
 		</constant>
 		<constant name="CCD_MODE_CAST_RAY" value="1" enum="CCDMode">
 			Enables continuous collision detection by raycasting. It is faster than shapecasting, but less precise.


### PR DESCRIPTION
Fixes incorrect descriptions, adds more detail, and fills in missing descriptions. Also adds a physics object glossary at the beginning. Default values of body/area/joint parameters are now documented (based on the values in Godot Physics). More can be done, but it is already a big improvement. This can also be helpful to GDExtension physics server developers. (I did this to learn the API.)

Supersedes https://github.com/godotengine/godot/pull/36875