### PR TITLE
Fix `get_path()` is not working when files are opend with `open_compressed`

### DIFF
--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -184,6 +184,22 @@ bool FileAccessCompressed::is_open() const {
 	return f.is_valid();
 }
 
+String FileAccessCompressed::get_path() const {
+	if (f.is_valid()) {
+		return f->get_path();
+	} else {
+		return "";
+	}
+}
+
+String FileAccessCompressed::get_path_absolute() const {
+	if (f.is_valid()) {
+		return f->get_path_absolute();
+	} else {
+		return "";
+	}
+}
+
 void FileAccessCompressed::seek(uint64_t p_position) {
 	ERR_FAIL_COND_MSG(f.is_null(), "File must be opened before use.");
 

--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -73,6 +73,9 @@ public:
 	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
 
+	virtual String get_path() const override; /// returns the path for the current open file
+	virtual String get_path_absolute() const override; /// returns the absolute path for the current open file
+
 	virtual void seek(uint64_t p_position) override; ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
 	virtual uint64_t get_position() const override; ///< get position in the file


### PR DESCRIPTION
This commit fixes #70712.
And also fixed `get_path_absolute()` in the same way.

Note that there's the same problem in v3.5.1. If neccessary, I will also create another PR for v3.5 branch.