### PR TITLE
[macOS] Add support for one step universal binary build.

### DIFF
--- a/modules/raycast/config.py
+++ b/modules/raycast/config.py
@@ -1,6 +1,6 @@
 def can_build(env, platform):
     # Supported architectures depend on the Embree library.
-    if env["arch"] in ["x86_64", "arm64", "wasm32"]:
+    if env["arch"] in ["x86_64", "arm64", "wasm32", "universal"]:
         return True
     # x86_32 only seems supported on Windows for now.
     if env["arch"] == "x86_32" and platform == "windows":

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -79,7 +79,7 @@ def get_mvk_sdk_path():
 
 def configure(env: "Environment"):
     # Validate arch.
-    supported_arches = ["x86_64", "arm64"]
+    supported_arches = ["x86_64", "arm64", "universal"]
     if env["arch"] not in supported_arches:
         print(
             'Unsupported CPU architecture "%s" for macOS. Supported architectures are: %s.'
@@ -102,7 +102,12 @@ def configure(env: "Environment"):
         env["osxcross"] = True
 
     # CPU architecture.
-    if env["arch"] == "arm64":
+    if env["arch"] == "universal":
+        print("Building for macOS 11.0+ (Universal).")
+        env.Append(ASFLAGS=["-arch", "arm64", "-arch", "x86_64", "-mmacosx-version-min=11.0"])
+        env.Append(CCFLAGS=["-arch", "arm64", "-arch", "x86_64", "-mmacosx-version-min=11.0"])
+        env.Append(LINKFLAGS=["-arch", "arm64", "-arch", "x86_64", "-mmacosx-version-min=11.0"])
+    elif env["arch"] == "arm64":
         print("Building for macOS 11.0+.")
         env.Append(ASFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.0"])
         env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.0"])

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -80,7 +80,7 @@ def subprocess_main(namespace):
 
 
 # CPU architecture options.
-architectures = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "wasm32"]
+architectures = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "wasm32", "universal"]
 architecture_aliases = {
     "x86": "x86_32",
     "x64": "x86_64",


### PR DESCRIPTION
Adds support for building with `arch=universal` on macOS. Pros: faster build. Cons: targets the same OS version (11.0+) for both x86_64 and arm64 parts.