### PR TITLE
Fix substitute buttons were never enabled

### DIFF
--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -338,7 +338,7 @@ void RenameDialog::_bind_methods() {
 }
 
 void RenameDialog::_update_substitute() {
-	LineEdit *focus_owner_line_edit = Object::cast_to<LineEdit>(scene_tree_editor->get_viewport()->gui_get_focus_owner());
+	LineEdit *focus_owner_line_edit = Object::cast_to<LineEdit>(get_viewport()->gui_get_focus_owner());
 	bool is_main_field = _is_main_field(focus_owner_line_edit);
 
 	but_insert_name->set_disabled(!is_main_field);
@@ -636,7 +636,7 @@ bool RenameDialog::_is_main_field(LineEdit *line_edit) {
 }
 
 void RenameDialog::_insert_text(String text) {
-	LineEdit *focus_owner = Object::cast_to<LineEdit>(scene_tree_editor->get_viewport()->gui_get_focus_owner());
+	LineEdit *focus_owner = Object::cast_to<LineEdit>(get_viewport()->gui_get_focus_owner());
 
 	if (_is_main_field(focus_owner)) {
 		focus_owner->selection_delete();


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/70729

This happened because the viewport of the `scene_tree_editor` was queried for the `focus_owner` instead of the current `viewport`.

Also tested this change with the `--single-window` parameter.
Commit that broke that functionality: 4758057f