### PR TITLE
Explain that Array.duplicate will not deep-copy Object.

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -243,7 +243,7 @@
 			<param index="0" name="deep" type="bool" default="false" />
 			<description>
 				Returns a copy of the array.
-				If [param deep] is [code]true[/code], a deep copy is performed: all nested arrays and dictionaries are duplicated and will not be shared with the original array. If [code]false[/code], a shallow copy is made and references to the original nested arrays and dictionaries are kept, so that modifying a sub-array or dictionary in the copy will also impact those referenced in the source array.
+				If [param deep] is [code]true[/code], a deep copy is performed: all nested arrays and dictionaries are duplicated and will not be shared with the original array. If [code]false[/code], a shallow copy is made and references to the original nested arrays and dictionaries are kept, so that modifying a sub-array or dictionary in the copy will also impact those referenced in the source array. Note that any [Object]-derived elements will be shallow copied regardless of the [param deep] setting.
 			</description>
 		</method>
 		<method name="erase">


### PR DESCRIPTION
This was somewhat implied by specifically calling out nested arrays and
dictionaries, but I was still unsure and had to test it myself.
One might expect that `Resource` objects, which have a `duplicate`
method, might be deep-copied.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
