### PR TITLE
Add macro override API to `ShaderMaterial`

### DIFF
--- a/doc/classes/ShaderMaterial.xml
+++ b/doc/classes/ShaderMaterial.xml
@@ -10,11 +10,29 @@
 		<link title="Shaders documentation index">$DOCS_URL/tutorials/shaders/index.html</link>
 	</tutorials>
 	<methods>
+		<method name="clear_shader_macro_overrides">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+		<method name="get_shader_macro_override" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+			</description>
+		</method>
 		<method name="get_shader_parameter" qualifiers="const">
 			<return type="Variant" />
 			<param index="0" name="param" type="StringName" />
 			<description>
 				Returns the current value set for this material of a uniform in the shader.
+			</description>
+		</method>
+		<method name="set_shader_macro_override">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="value" type="String" />
+			<description>
 			</description>
 		</method>
 		<method name="set_shader_parameter">

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -84,9 +84,13 @@ public:
 class ShaderMaterial : public Material {
 	GDCLASS(ShaderMaterial, Material);
 	Ref<Shader> shader;
+	Ref<Shader> shader_with_macro_override;
 
 	mutable HashMap<StringName, StringName> remap_cache;
+	mutable HashMap<StringName, String> macro_cache;
 	mutable HashMap<StringName, Variant> param_cache;
+
+	bool macro_dirty = false;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -110,6 +114,10 @@ public:
 
 	void set_shader_parameter(const StringName &p_param, const Variant &p_value);
 	Variant get_shader_parameter(const StringName &p_param) const;
+
+	void set_shader_macro_override(const StringName &p_name, const String &p_value);
+	String get_shader_macro_override(const StringName &p_name) const;
+	void clear_shader_macro_overrides();
 
 	virtual Shader::Mode get_shader_mode() const override;
 

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -61,6 +61,16 @@ void Shader::set_include_path(const String &p_path) {
 	include_path = p_path;
 }
 
+void Shader::set_define_override(const StringName &p_name, const String &p_value) {
+	if (p_value.is_empty()) {
+		if (define_override.has(p_name)) {
+			define_override.erase(p_name);
+		}
+	} else {
+		define_override[p_name] = p_value;
+	}
+}
+
 void Shader::set_code(const String &p_code) {
 	for (Ref<ShaderInclude> E : include_dependencies) {
 		E->disconnect(SNAME("changed"), callable_mp(this, &Shader::_dependency_changed));
@@ -94,6 +104,9 @@ void Shader::set_code(const String &p_code) {
 		// 1) Need to keep track of include dependencies at resource level
 		// 2) Server does not do interaction with Resource filetypes, this is a scene level feature.
 		ShaderPreprocessor preprocessor;
+		for (const KeyValue<StringName, String> &define : define_override) {
+			preprocessor.set_define_override(define.key, define.value);
+		}
 		preprocessor.preprocess(p_code, path, pp_code, nullptr, nullptr, nullptr, &new_include_dependencies);
 	}
 

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -59,6 +59,7 @@ private:
 	String include_path;
 
 	HashMap<StringName, HashMap<int, Ref<Texture2D>>> default_textures;
+	HashMap<StringName, String> define_override;
 
 	void _dependency_changed();
 	void _recompile();
@@ -74,6 +75,8 @@ public:
 
 	virtual void set_path(const String &p_path, bool p_take_over = false) override;
 	void set_include_path(const String &p_path);
+
+	void set_define_override(const StringName &p_name, const String &p_value);
 
 	void set_code(const String &p_code);
 	String get_code() const;

--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -445,12 +445,22 @@ void ShaderPreprocessor::process_define(Tokenizer *p_tokenizer) {
 
 		Define *define = memnew(Define);
 		define->arguments = args;
-		define->body = tokens_to_string(p_tokenizer->advance('\n')).strip_edges();
+		if (define_override.has(label)) {
+			define->body = define_override[label];
+			p_tokenizer->advance('\n');
+		} else {
+			define->body = tokens_to_string(p_tokenizer->advance('\n')).strip_edges();
+		}
 		state->defines[label] = define;
 	} else {
 		// Simple substitution macro.
 		Define *define = memnew(Define);
-		define->body = tokens_to_string(p_tokenizer->advance('\n')).strip_edges();
+		if (define_override.has(label)) {
+			define->body = define_override[label];
+			p_tokenizer->advance('\n');
+		} else {
+			define->body = tokens_to_string(p_tokenizer->advance('\n')).strip_edges();
+		}
 		state->defines[label] = define;
 	}
 }
@@ -1257,6 +1267,16 @@ Error ShaderPreprocessor::preprocess(State *p_state, const String &p_code, Strin
 	r_result = vector_to_string(output);
 
 	return OK;
+}
+
+void ShaderPreprocessor::set_define_override(const StringName &p_name, const String &p_value) {
+	if (p_value.is_empty()) {
+		if (define_override.has(p_name)) {
+			define_override.erase(p_name);
+		}
+	} else {
+		define_override[p_name] = p_value;
+	}
 }
 
 Error ShaderPreprocessor::preprocess(const String &p_code, const String &p_filename, String &r_result, String *r_error_text, List<FilePosition> *r_error_position, List<Region> *r_regions, HashSet<Ref<ShaderInclude>> *r_includes, List<ScriptLanguage::CodeCompletionOption> *r_completion_options, List<ScriptLanguage::CodeCompletionOption> *r_completion_defines, IncludeCompletionFunction p_include_completion_func) {

--- a/servers/rendering/shader_preprocessor.h
+++ b/servers/rendering/shader_preprocessor.h
@@ -168,6 +168,7 @@ private:
 
 private:
 	LocalVector<char32_t> output;
+	RBMap<StringName, String> define_override;
 	State *state = nullptr;
 
 private:
@@ -218,6 +219,8 @@ private:
 
 public:
 	typedef void (*IncludeCompletionFunction)(List<ScriptLanguage::CodeCompletionOption> *);
+
+	void set_define_override(const StringName &p_name, const String &p_value);
 
 	Error preprocess(const String &p_code, const String &p_filename, String &r_result, String *r_error_text = nullptr, List<FilePosition> *r_error_position = nullptr, List<Region> *r_regions = nullptr, HashSet<Ref<ShaderInclude>> *r_includes = nullptr, List<ScriptLanguage::CodeCompletionOption> *r_completion_options = nullptr, List<ScriptLanguage::CodeCompletionOption> *r_completion_defines = nullptr, IncludeCompletionFunction p_include_completion_func = nullptr);
 


### PR DESCRIPTION
This will allow users to set `#define` expressions at runtime, by allocating the internal shader inside the shader material if any macro override is declared. This is a first step to solve https://github.com/godotengine/godot-proposals/issues/5062.

![shader_material_macro](https://user-images.githubusercontent.com/3036176/210101286-79552622-a93c-4135-a127-959968f1a333.gif)

Test Project:  [Test.zip](https://github.com/godotengine/godot/files/10325863/Test.zip)

