### PR TITLE
Fix Scene Tree Editor icons shift when the pane is small

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2580,8 +2580,8 @@ void Tree::_range_click_timeout() {
 		mb.instantiate();
 
 		int x_limit = get_size().width - theme_cache.panel_style->get_minimum_size().width;
-		if (h_scroll->is_visible()) {
-			x_limit -= h_scroll->get_minimum_size().width;
+		if (v_scroll->is_visible()) {
+			x_limit -= v_scroll->get_minimum_size().width;
 		}
 
 		cache.rtl = is_layout_rtl();
@@ -3640,8 +3640,8 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 				propagate_mouse_activated = false;
 
 				int x_limit = get_size().width - theme_cache.panel_style->get_minimum_size().width;
-				if (h_scroll->is_visible()) {
-					x_limit -= h_scroll->get_minimum_size().width;
+				if (v_scroll->is_visible()) {
+					x_limit -= v_scroll->get_minimum_size().width;
 				}
 
 				cache.rtl = is_layout_rtl();
@@ -4015,8 +4015,8 @@ void Tree::_notification(int p_what) {
 			Point2 draw_ofs;
 			draw_ofs += bg->get_offset();
 			Size2 draw_size = get_size() - bg->get_minimum_size();
-			if (h_scroll->is_visible()) {
-				draw_size.width -= h_scroll->get_minimum_size().width;
+			if (v_scroll->is_visible()) {
+				draw_size.width -= v_scroll->get_minimum_size().width;
 			}
 
 			bg->draw(ci, Rect2(Point2(), get_size()));


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/68171

Use the vertical scrollbar (`v_scroll`) when calculating the width that can be used for drawing.
The horizontal scrollbar was used before, which is not correct as it has no influence to the drawing width (was probably an accident).

Note: There were two more locations that did this wrong.
Regression introduced by: f4379cbc

Before:

https://user-images.githubusercontent.com/66004280/210126735-d04519e7-8955-4134-9ae7-f53175c87b23.mp4

After:

https://user-images.githubusercontent.com/66004280/210126739-6a76c3de-11e3-4b00-93a8-bbfa92e4f257.mp4

---
The other location with the wrong code was responsible for the following behaviour.
The tree button was clickable although you are not on the button. This also happened in the Scene Tree Editor.

Before:

https://user-images.githubusercontent.com/66004280/210127004-51a64866-aa14-453f-abbb-ad8dcf238e4c.mp4

After:

https://user-images.githubusercontent.com/66004280/210127010-4b6192ff-37f2-48a4-b68c-c31900de1cae.mp4