### PR TITLE
Ensure `MainLoop` and its custom script is set right after it's resolved

### DIFF
--- a/core/os/main_loop.cpp
+++ b/core/os/main_loop.cpp
@@ -52,15 +52,7 @@ void MainLoop::_bind_methods() {
 	GDVIRTUAL_BIND(_finalize);
 }
 
-void MainLoop::set_initialize_script(const Ref<Script> &p_initialize_script) {
-	initialize_script = p_initialize_script;
-}
-
 void MainLoop::initialize() {
-	if (initialize_script.is_valid()) {
-		set_script(initialize_script);
-	}
-
 	GDVIRTUAL_CALL(_initialize);
 }
 

--- a/core/os/main_loop.h
+++ b/core/os/main_loop.h
@@ -39,8 +39,6 @@
 class MainLoop : public Object {
 	GDCLASS(MainLoop, Object);
 
-	Ref<Script> initialize_script;
-
 protected:
 	static void _bind_methods();
 
@@ -68,8 +66,6 @@ public:
 	virtual bool physics_process(double p_time);
 	virtual bool process(double p_time);
 	virtual void finalize();
-
-	void set_initialize_script(const Ref<Script> &p_initialize_script);
 
 	MainLoop() {}
 	virtual ~MainLoop() {}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2657,7 +2657,7 @@ bool Main::start() {
 				ERR_FAIL_V_MSG(false, vformat("Can't load the script \"%s\" as it doesn't inherit from SceneTree or MainLoop.", script));
 			}
 
-			script_loop->set_initialize_script(script_res);
+			script_loop->set_script(script_res);
 			main_loop = script_loop;
 		} else {
 			return false;
@@ -2680,7 +2680,7 @@ bool Main::start() {
 				OS::get_singleton()->alert("Error: Invalid MainLoop script base type: " + script_base);
 				ERR_FAIL_V_MSG(false, vformat("The global class %s does not inherit from SceneTree or MainLoop.", main_loop_type));
 			}
-			script_loop->set_initialize_script(script_res);
+			script_loop->set_script(script_res);
 			main_loop = script_loop;
 		}
 	}
@@ -2704,6 +2704,8 @@ bool Main::start() {
 			}
 		}
 	}
+
+	OS::get_singleton()->set_main_loop(main_loop);
 
 	SceneTree *sml = Object::cast_to<SceneTree>(main_loop);
 	if (sml) {
@@ -3053,8 +3055,6 @@ bool Main::start() {
 		Ref<Image> icon = memnew(Image(app_icon_png));
 		DisplayServer::get_singleton()->set_icon(icon);
 	}
-
-	OS::get_singleton()->set_main_loop(main_loop);
 
 	if (movie_writer) {
 		movie_writer->begin(DisplayServer::get_singleton()->window_get_size(), fixed_fps, Engine::get_singleton()->get_write_movie_path());


### PR DESCRIPTION
For a `SceneTree`-derived `main_loop` the `OS::get_singleton()->set_main_loop(main_loop);` was called after adding AutoLoads and the main scene to the tree. This PR makes it be set right after the `main_loop` is resolved.

Also previously setting custom script of the `main_loop` was postponed (via `MainLoop::set_initialize_script`) to be done in `MainLoop::initialize`. This PR removes `MainLoop::set_initialize_script` and makes the script of the `main_loop` be set directly right after it's instantiated.

Fixes #70764.