### PR TITLE
Disable interpolation and use variable FPS in GPUParticles by default

### DIFF
--- a/doc/classes/GPUParticles2D.xml
+++ b/doc/classes/GPUParticles2D.xml
@@ -55,13 +55,15 @@
 			How rapidly particles in an emission cycle are emitted. If greater than [code]0[/code], there will be a gap in emissions before the next cycle begins.
 		</member>
 		<member name="fixed_fps" type="int" setter="set_fixed_fps" getter="get_fixed_fps" default="30">
-			The particle system's frame rate is fixed to a value. For example, changing the value to 2 will make the particles render at 2 frames per second. Note this does not slow down the simulation of the particle system itself.
+			If set to a value higher than [code]0[/code], fixes particle system's simulation frame rate to the specified value. For example, changing the value to [code]2[/code] will make the particles render at 2 frames per second. If set to [code]0[/code], particles will be simulated every rendered frame. Simulating particles every rendered frame looks the smoothest with [member interpolate] disabled, but it will cause physics simulation to vary depending on rendering FPS. This can be noticeable for particles with collision enabled.
+			[b]Note:[/b] This does not slow down the simulation of the particle system itself (see [member speed_scale] instead).
 		</member>
 		<member name="fract_delta" type="bool" setter="set_fractional_delta" getter="get_fractional_delta" default="true">
 			If [code]true[/code], results in fractional delta calculation which has a smoother particles display effect.
 		</member>
-		<member name="interpolate" type="bool" setter="set_interpolate" getter="get_interpolate" default="true">
-			Enables particle interpolation, which makes the particle movement smoother when their [member fixed_fps] is lower than the screen refresh rate.
+		<member name="interpolate" type="bool" setter="set_interpolate" getter="get_interpolate" default="false">
+			If [code]true[/code], enables particle interpolation, which makes the particle movement smoother when their [member fixed_fps] is greater than [code]0[/code] but lower than the screen refresh rate.
+			[b]Note:[/b] Not all particle properties (such as color and scale curves) are interpolated yet.
 		</member>
 		<member name="lifetime" type="float" setter="set_lifetime" getter="get_lifetime" default="1.0">
 			Amount of time each particle will exist.

--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -83,14 +83,16 @@
 		<member name="explosiveness" type="float" setter="set_explosiveness_ratio" getter="get_explosiveness_ratio" default="0.0">
 			Time ratio between each emission. If [code]0[/code], particles are emitted continuously. If [code]1[/code], all particles are emitted simultaneously.
 		</member>
-		<member name="fixed_fps" type="int" setter="set_fixed_fps" getter="get_fixed_fps" default="30">
-			The particle system's frame rate is fixed to a value. For example, changing the value to 2 will make the particles render at 2 frames per second. Note this does not slow down the simulation of the particle system itself.
+		<member name="fixed_fps" type="int" setter="set_fixed_fps" getter="get_fixed_fps" default="0">
+			If set to a value higher than [code]0[/code], fixes particle system's simulation frame rate to the specified value. For example, changing the value to [code]2[/code] will make the particles render at 2 frames per second. If set to [code]0[/code], particles will be simulated every rendered frame. Simulating particles every rendered frame looks the smoothest with [member interpolate] disabled, but it will cause physics simulation to vary depending on rendering FPS. This can be noticeable for particles with collision enabled.
+			[b]Note:[/b] This does not slow down the simulation of the particle system itself (see [member speed_scale] instead).
 		</member>
 		<member name="fract_delta" type="bool" setter="set_fractional_delta" getter="get_fractional_delta" default="true">
 			If [code]true[/code], results in fractional delta calculation which has a smoother particles display effect.
 		</member>
-		<member name="interpolate" type="bool" setter="set_interpolate" getter="get_interpolate" default="true">
-			Enables particle interpolation, which makes the particle movement smoother when their [member fixed_fps] is lower than the screen refresh rate.
+		<member name="interpolate" type="bool" setter="set_interpolate" getter="get_interpolate" default="false">
+			If [code]true[/code], enables particle interpolation, which makes the particle movement smoother when their [member fixed_fps] is greater than [code]0[/code] but lower than the screen refresh rate.
+			[b]Note:[/b] Not all particle properties (such as color and scale curves) are interpolated yet.
 		</member>
 		<member name="lifetime" type="float" setter="set_lifetime" getter="get_lifetime" default="1.0">
 			Amount of time each particle will exist.

--- a/drivers/gles3/storage/particles_storage.h
+++ b/drivers/gles3/storage/particles_storage.h
@@ -225,8 +225,8 @@ private:
 
 		double speed_scale = 1.0;
 
-		int fixed_fps = 30;
-		bool interpolate = true;
+		int fixed_fps = 0;
+		bool interpolate = false;
 		bool fractional_delta = false;
 		double frame_remainder = 0;
 		real_t collision_base_size = 0.01;

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -675,7 +675,7 @@ GPUParticles2D::GPUParticles2D() {
 	set_lifetime(1);
 	set_fixed_fps(0);
 	set_fractional_delta(true);
-	set_interpolate(true);
+	set_interpolate(false);
 	set_pre_process_time(0);
 	set_explosiveness_ratio(0);
 	set_randomness_ratio(0);

--- a/scene/2d/gpu_particles_2d.h
+++ b/scene/2d/gpu_particles_2d.h
@@ -58,7 +58,7 @@ private:
 	bool local_coords = false;
 	int fixed_fps = 0;
 	bool fractional_delta = false;
-	bool interpolate = true;
+	bool interpolate = false;
 #ifdef TOOLS_ENABLED
 	bool show_visibility_rect = false;
 #endif

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -617,9 +617,9 @@ GPUParticles3D::GPUParticles3D() {
 	set_one_shot(false);
 	set_amount(8);
 	set_lifetime(1);
-	set_fixed_fps(30);
+	set_fixed_fps(0);
 	set_fractional_delta(true);
-	set_interpolate(true);
+	set_interpolate(false);
 	set_pre_process_time(0);
 	set_explosiveness_ratio(0);
 	set_randomness_ratio(0);

--- a/scene/3d/gpu_particles_3d.h
+++ b/scene/3d/gpu_particles_3d.h
@@ -71,7 +71,7 @@ private:
 	bool local_coords = false;
 	int fixed_fps = 0;
 	bool fractional_delta = false;
-	bool interpolate = true;
+	bool interpolate = false;
 	NodePath sub_emitter;
 	real_t collision_base_size = 0.01;
 

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -207,8 +207,8 @@ private:
 
 		double speed_scale = 1.0;
 
-		int fixed_fps = 30;
-		bool interpolate = true;
+		int fixed_fps = 0;
+		bool interpolate = false;
 		bool fractional_delta = false;
 		double frame_remainder = 0;
 		real_t collision_base_size = 0.01;


### PR DESCRIPTION
This fixes various issues caused by simulating particles at a low framerate (then interpolating the result), such as:

- Curve properties (scale, color) not being interpolated.
- Jitter at low speed scale, or when moving particles with global coordinates.
- Collision issues (tunneling, poor friction/bounce response).

From testing on two different GPUs (GeForce GTX 1080 and Radeon RX 6900 XT), simulating particles at a lower framerate then interpolating the result had very little performance benefit in most cases.

Instead, it's better to enable interpolation and reduce simulation rate only when it provides a tangible performance benefit. This may be the case with 100,000+ particles, not so much with a few thousand particles.

One downside of variable-rate simulation is that collision response may vary slightly depending on the rendering FPS. This can be alleviated by using a high fixed FPS value (200 or more), but this can have a noticeable performance impact. In most scenarios, the visual difference is hardly noticeable unless you specifically look for it.

This also improves the documentation for `fixed_fps` and `interpolate` properties in GPUParticles2D and GPUParticles3D.

This partially addresses https://github.com/godotengine/godot/issues/50824, https://github.com/godotengine/godot/issues/51318 and https://github.com/godotengine/godot/issues/70748.