### PR TITLE
Add number to the end of filename if it exists when duplicating

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1975,6 +1975,22 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 				if (to_duplicate.is_file) {
 					String name = to_duplicate.path.get_file();
 					duplicate_dialog->set_title(TTR("Duplicating file:") + " " + name);
+					// Add a number to the end of the file name if it already exists.
+					String base_name = name.get_basename();
+					const String ext = name.get_extension();
+					const int underscore_index = base_name.rfind("_");
+					int number = 1;
+					if (underscore_index != -1) {
+						const String last = base_name.substr(underscore_index + 1, base_name.length());
+						if (last.is_valid_int()) {
+							base_name = base_name.substr(0, underscore_index);
+							number = last.to_int();
+						}
+					}
+					while (FileAccess::exists(to_duplicate.path.get_base_dir().path_join(base_name + "_" + itos(number) + "." + ext))) {
+						number++;
+					}
+					name = base_name + "_" + itos(number) + "." + ext;
 					duplicate_dialog_text->set_text(name);
 					duplicate_dialog_text->select(0, name.rfind("."));
 				} else {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/6029

This PR adds a number at the end of the suggested filename when duplicating.


Before:
<img width="303" alt="image" src="https://user-images.githubusercontent.com/43449832/210156166-3778ddb9-d3e7-49a4-a081-75127c2cef9e.png">
After:
<img width="274" alt="image" src="https://user-images.githubusercontent.com/43449832/210156176-e3cebd80-d40d-4518-9b23-d989fdac404c.png">

<img width="275" alt="Screenshot 2022-12-31 at 22 45 56" src="https://user-images.githubusercontent.com/43449832/210156181-267a8dff-b95d-47bb-abd7-cc1817a5f8a8.png">


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
