### PR TITLE
Fix error spam when hovering minimap in the script editor

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4362,7 +4362,9 @@ int TextEdit::get_minimap_line_at_pos(const Point2i &p_pos) const {
 	if (first_vis_line > 0 && minimap_line >= 0) {
 		minimap_line -= get_next_visible_line_index_offset_from(first_vis_line, 0, -num_lines_before).x;
 		minimap_line -= (minimap_line > 0 && smooth_scroll_enabled ? 1 : 0);
-	} else {
+	}
+
+	if (minimap_line < 0) {
 		minimap_line = 0;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/70775

The calculation on 4338 would end up setting `minimap_line` to -1

This happened when the document had enough lines that it reached the bottom of the viewport.

This fix is inline with the existing behaviour of if `minimap_line` is -1, then set it to zero.