### PR TITLE
[3.x] Make `dict2inst` to work with arbitrary `_init` parameters

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -110,6 +110,9 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 	instances.insert(instance->owner);
 	GDScriptLanguage::singleton->lock.unlock();
 
+	if (p_argcount < 0) {
+		return instance;
+	}
 	initializer->call(instance, p_args, p_argcount, r_error);
 
 	if (r_error.error != Variant::CallError::CALL_OK) {
@@ -123,9 +126,8 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 		GDScriptLanguage::singleton->lock.unlock();
 #endif
 
-		ERR_FAIL_COND_V(r_error.error != Variant::CallError::CALL_OK, nullptr); //error constructing
+		ERR_FAIL_V_MSG(nullptr, "Error constructing a GDScriptInstance.");
 	}
-
 	//@TODO make thread safe
 	return instance;
 }

--- a/modules/gdscript/gdscript_functions.cpp
+++ b/modules/gdscript/gdscript_functions.cpp
@@ -1153,8 +1153,7 @@ void GDScriptFunctions::call(Function p_func, const Variant **p_args, int p_arg_
 					return;
 				}
 			}
-
-			r_ret = gdscr->_new(nullptr, 0, r_error);
+			r_ret = gdscr->_new(nullptr, -1 /*skip initializer*/, r_error);
 
 			if (r_error.error != Variant::CallError::CALL_OK) {
 				r_ret = Variant();


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/32534.

This is achieved by skipping initializer call while creating an instance of a GDScript. This is implemented by passing -1 as an argument count to `_new` and interpreting any value below 0 to mean that the initializer should not be called during instantiation, because internal members of an instance are going to be overridden afterwards.