### PR TITLE
Fixed SpriteFrame allowed entering an empty name

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -807,13 +807,17 @@ void SpriteFramesEditor::_animation_name_edited() {
 		return;
 	}
 
+	if (new_name.is_empty()) {
+		new_name = "new_animation";
+	}
+
 	new_name = new_name.replace("/", "_").replace(",", " ");
 
 	String name = new_name;
 	int counter = 0;
 	while (frames->has_animation(name)) {
 		counter++;
-		name = new_name + " " + itos(counter);
+		name = new_name + "_" + itos(counter);
 	}
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();


### PR DESCRIPTION
Fixed issue #70769 where the user could enter an empty name in the SpriteFrame window.
Added a check for an empty string and if so, the name is changed to TTR("Default").
Try to change the name in the attached sample project and see that it is now changes to Default instead of staying as an empty string.
[Empty SpriteFrame Test.zip](https://github.com/godotengine/godot/files/10328144/Empty.SpriteFrame.Test.zip)

<i>Bugsquad edit:</i> 
- Fix #70769


