### PR TITLE
Add support for creating tiles when adding multiple atlases to a tileset

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -2207,12 +2207,12 @@ void TileSetAtlasSourceEditor::init_source(Vector<Ref<TileSetAtlasSource>> newSo
 	confirm_auto_create_tiles->popup_centered();
 }
 
-void TileSetAtlasSourceEditor::_auto_create_tiles() {
+void TileSetAtlasSourceEditor::_confirm_auto_create_tiles() {
 	_auto_create_tiles(pendingAtlases);
 	pendingAtlases.clear();
 }
 
-void TileSetAtlasSourceEditor::_auto_create_tiles_cancel() {
+void TileSetAtlasSourceEditor::_cancel_auto_create_tiles() {
 	pendingAtlases.clear();
 }
 
@@ -2584,8 +2584,8 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	confirm_auto_create_tiles->set_title(TTR("Auto Create Tiles in Non-Transparent Texture Regions?"));
 	confirm_auto_create_tiles->set_ok_button_text(TTR("Yes"));
 	confirm_auto_create_tiles->add_cancel_button()->set_text(TTR("No"));
-	confirm_auto_create_tiles->connect("confirmed", callable_mp(this, &TileSetAtlasSourceEditor::_auto_create_tiles));
-	confirm_auto_create_tiles->connect("cancelled", callable_mp(this, &TileSetAtlasSourceEditor::_auto_create_tiles_cancel));
+	confirm_auto_create_tiles->connect("confirmed", callable_mp(this, &TileSetAtlasSourceEditor::_confirm_auto_create_tiles));
+	confirm_auto_create_tiles->connect("cancelled", callable_mp(this, &TileSetAtlasSourceEditor::_cancel_auto_create_tiles));
 	add_child(confirm_auto_create_tiles);
 
 	// Inspector plugin.

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -2199,6 +2199,11 @@ void TileSetAtlasSourceEditor::edit(Ref<TileSet> p_tile_set, TileSetAtlasSource 
 
 void TileSetAtlasSourceEditor::init_source(Vector<Ref<TileSetAtlasSource>> newSources) {
 	pendingAtlases = newSources;
+	if (newSources.size() == 1) {
+		confirm_auto_create_tiles->set_text(TTR("Would you like to automatically create tiles for the newly added atlas?"));
+	} else {
+		confirm_auto_create_tiles->set_text(TTR("Would you like to automatically create for every new atlas?"));
+	}
 	confirm_auto_create_tiles->popup_centered();
 }
 
@@ -2577,7 +2582,6 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	// -- Dialogs --
 	confirm_auto_create_tiles = memnew(AcceptDialog);
 	confirm_auto_create_tiles->set_title(TTR("Auto Create Tiles in Non-Transparent Texture Regions?"));
-	confirm_auto_create_tiles->set_text(TTR("The atlas's texture was modified.\nWould you like to automatically create tiles in the atlas?"));
 	confirm_auto_create_tiles->set_ok_button_text(TTR("Yes"));
 	confirm_auto_create_tiles->add_cancel_button()->set_text(TTR("No"));
 	confirm_auto_create_tiles->connect("confirmed", callable_mp(this, &TileSetAtlasSourceEditor::_auto_create_tiles));

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -2197,7 +2197,7 @@ void TileSetAtlasSourceEditor::edit(Ref<TileSet> p_tile_set, TileSetAtlasSource 
 	_update_current_tile_data_editor();
 }
 
-void TileSetAtlasSourceEditor::init_source(Vector<Ref<TileSetAtlasSource>> newSources) {
+void TileSetAtlasSourceEditor::init_sources(Vector<Ref<TileSetAtlasSource>> newSources) {
 	pendingAtlases = newSources;
 	if (newSources.size() == 1) {
 		confirm_auto_create_tiles->set_text(TTR("Would you like to automatically create tiles for the newly added atlas?"));

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -119,6 +119,8 @@ private:
 
 	bool tile_set_changed_needs_update = false;
 
+	Vector<Ref<TileSetAtlasSource>> pendingAtlases;
+
 	// -- Properties painting --
 	ScrollContainer *tile_data_editors_scroll = nullptr;
 	VBoxContainer *tile_data_painting_editor_container = nullptr;
@@ -259,7 +261,9 @@ private:
 	void _unhandled_key_input(const Ref<InputEvent> &p_event);
 
 	// -- Misc --
+	void _auto_create_tiles(Vector<Ref<TileSetAtlasSource>> const &new_tile_set_atlas_sources);
 	void _auto_create_tiles();
+	void _auto_create_tiles_cancel();
 	void _auto_remove_tiles();
 	AcceptDialog *confirm_auto_create_tiles = nullptr;
 
@@ -275,7 +279,7 @@ protected:
 
 public:
 	void edit(Ref<TileSet> p_tile_set, TileSetAtlasSource *p_tile_set_source, int p_source_id);
-	void init_source();
+	void init_source(Vector<Ref<TileSetAtlasSource>> newSources);
 
 	TileSetAtlasSourceEditor();
 	~TileSetAtlasSourceEditor();

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -262,8 +262,8 @@ private:
 
 	// -- Misc --
 	void _auto_create_tiles(Vector<Ref<TileSetAtlasSource>> const &new_tile_set_atlas_sources);
-	void _auto_create_tiles();
-	void _auto_create_tiles_cancel();
+	void _confirm_auto_create_tiles();
+	void _cancel_auto_create_tiles();
 	void _auto_remove_tiles();
 	AcceptDialog *confirm_auto_create_tiles = nullptr;
 

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -279,7 +279,7 @@ protected:
 
 public:
 	void edit(Ref<TileSet> p_tile_set, TileSetAtlasSource *p_tile_set_source, int p_source_id);
-	void init_source(Vector<Ref<TileSetAtlasSource>> newSources);
+	void init_sources(Vector<Ref<TileSetAtlasSource>> newSources);
 
 	TileSetAtlasSourceEditor();
 	~TileSetAtlasSourceEditor();

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -55,9 +55,9 @@ void TileSetEditor::_drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 	if (p_from == sources_list) {
 		// Handle dropping a texture in the list of atlas resources.
 		int source_id = TileSet::INVALID_SOURCE;
-		int added = 0;
 		Dictionary d = p_data;
 		Vector<String> files = d["files"];
+		Vector<Ref<TileSetAtlasSource>> newSources;
 		for (int i = 0; i < files.size(); i++) {
 			Ref<Texture2D> resource = ResourceLoader::load(files[i]);
 			if (resource.is_valid()) {
@@ -66,6 +66,7 @@ void TileSetEditor::_drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 
 				// Actually create the new source.
 				Ref<TileSetAtlasSource> atlas_source = memnew(TileSetAtlasSource);
+				newSources.append(atlas_source);
 				atlas_source->set_texture(resource);
 				Ref<EditorUndoRedoManager> &undo_redo = EditorNode::get_undo_redo();
 				undo_redo->create_action(TTR("Add a new atlas source"));
@@ -73,13 +74,10 @@ void TileSetEditor::_drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 				undo_redo->add_do_method(*atlas_source, "set_texture_region_size", tile_set->get_tile_size());
 				undo_redo->add_undo_method(*tile_set, "remove_source", source_id);
 				undo_redo->commit_action();
-				added += 1;
 			}
 		}
 
-		if (added == 1) {
-			tile_set_atlas_source_editor->init_source();
-		}
+		tile_set_atlas_source_editor->init_source(newSources);
 
 		// Update the selected source (thus triggering an update).
 		_update_sources_list(source_id);

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -77,7 +77,7 @@ void TileSetEditor::_drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 			}
 		}
 
-		tile_set_atlas_source_editor->init_source(newSources);
+		tile_set_atlas_source_editor->init_sources(newSources);
 
 		// Update the selected source (thus triggering an update).
 		_update_sources_list(source_id);


### PR DESCRIPTION
Adds support for "batch" creating tiles when dragging multiple atlases into a tileset. See: https://github.com/godotengine/godot/issues/69273