### PR TITLE
Get rid of mouse wheel switch in scene tabs

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5619,16 +5619,6 @@ void EditorNode::_scene_tab_input(const Ref<InputEvent> &p_input) {
 			scene_tabs_context_menu->reset_size();
 			scene_tabs_context_menu->popup();
 		}
-		if (mb->get_button_index() == MouseButton::WHEEL_UP && mb->is_pressed()) {
-			int previous_tab = editor_data.get_edited_scene() - 1;
-			previous_tab = previous_tab >= 0 ? previous_tab : editor_data.get_edited_scene_count() - 1;
-			_scene_tab_changed(previous_tab);
-		}
-		if (mb->get_button_index() == MouseButton::WHEEL_DOWN && mb->is_pressed()) {
-			int next_tab = editor_data.get_edited_scene() + 1;
-			next_tab %= editor_data.get_edited_scene_count();
-			_scene_tab_changed(next_tab);
-		}
 	}
 }
 


### PR DESCRIPTION
Editor allows to switch scene tabs with mouse wheel since #47700
However, just like with #65302, 100% of the times I used this functionality it was by accident (and it happens surprisingly often).

This PR ~~adds a `interface/scene_tabs/change_tabs_with_mouse_wheel` editor setting that disables this function.~~ **removes the "feature"**.