### PR TITLE
Update stale node ref after replace_by in GLTF importer

### DIFF
--- a/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.cpp
+++ b/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.cpp
@@ -59,6 +59,7 @@ Error GLTFDocumentExtensionConvertImporterMesh::import_post(Ref<GLTFState> p_sta
 				mesh_instance_node_3d->set_skeleton_path(mesh_3d->get_skeleton_path());
 				node->replace_by(mesh_instance_node_3d);
 				delete_queue.push_back(node);
+				node = mesh_instance_node_3d;
 			} else {
 				memdelete(mesh_instance_node_3d);
 			}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/70709

Sub-nodes of a mesh where not being added in `GLTFDocumentExtensionConvertImporterMesh::import_post` due to the call to 
`node->replace_by` moving the children of `node` to the new `mesh_instance`.

![fix-stale-ref-node-gltf](https://user-images.githubusercontent.com/108040/210183582-426e0842-1600-4de6-958d-1f56d3661346.gif)
