### PR TITLE
Make GDScript's null a VARIANT datatype again

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2000,6 +2000,12 @@ void GDScriptAnalyzer::resolve_parameter(GDScriptParser::ParameterNode *p_parame
 	if (p_parameter->default_value != nullptr) {
 		reduce_expression(p_parameter->default_value);
 		result = p_parameter->default_value->get_datatype();
+
+		// We can assume nothing from a parameter whose default value is null.
+		if (p_parameter->default_value->is_constant && p_parameter->default_value->reduced_value.get_type() == Variant::NIL) {
+			result.kind = GDScriptParser::DataType::VARIANT;
+		}
+
 		if (p_parameter->infer_datatype) {
 			result.type_source = GDScriptParser::DataType::ANNOTATED_INFERRED;
 		} else {

--- a/modules/gdscript/tests/scripts/analyzer/features/null_is_variant.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/null_is_variant.gd
@@ -1,0 +1,5 @@
+func test_default(e = null):
+	print(e[0])
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/features/null_is_variant.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/null_is_variant.out
@@ -1,0 +1,1 @@
+GDTEST_OK


### PR DESCRIPTION
Fixes #70523.

Reverts the changes made in #70440, but only for function parameters. This means that largely the `null` variant will still be a builtin type, as redefined in #70440 remain, except in the following case:

A function parameter's default value, when it is `null`, shouldn't define what the parameter may actually contain. Therefore, in that case, and only for function parameters, we let the analyzer know that it may actually be anything (i.e. be a `VARIANT`).

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
