### PR TITLE
Fix NavigationPolygon error msg

### DIFF
--- a/scene/resources/navigation_polygon.cpp
+++ b/scene/resources/navigation_polygon.cpp
@@ -295,7 +295,7 @@ void NavigationPolygon::make_polygons_from_outlines() {
 	if (tpart.ConvexPartition_HM(&in_poly, &out_poly) == 0) { //failed!
 		ERR_PRINT("NavigationPolygon: Convex partition failed! Failed to convert outlines to a valid NavigationMesh."
 				  "\nNavigationPolygon outlines can not overlap vertices or edges inside same outline or with other outlines or have any intersections."
-				  "\nAdd the outmost and largest outline first. To add holes inside this outline add the smaller outlines with opposite winding order.");
+				  "\nAdd the outmost and largest outline first. To add holes inside this outline add the smaller outlines with same winding order.");
 		return;
 	}
 


### PR DESCRIPTION
Related to original bug report from #70823

Outline arrays need the same winding order which got confused with the internal polygon conversion in the error msg.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
