### PR TITLE
Fix `Range`-derived nodes not redrawing after `set_value_no_signal`

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -74,16 +74,26 @@ void Range::Shared::emit_changed(const char *p_what) {
 	}
 }
 
+void Range::Shared::redraw_owners() {
+	for (Range *E : owners) {
+		Range *r = E;
+		if (!r->is_inside_tree()) {
+			continue;
+		}
+		r->queue_redraw();
+	}
+}
+
 void Range::set_value(double p_val) {
 	double prev_val = shared->val;
-	set_value_no_signal(p_val);
+	_set_value_no_signal(p_val);
 
 	if (shared->val != prev_val) {
 		shared->emit_value_changed();
 	}
 }
 
-void Range::set_value_no_signal(double p_val) {
+void Range::_set_value_no_signal(double p_val) {
 	if (shared->step > 0) {
 		p_val = Math::round((p_val - shared->min) / shared->step) * shared->step + shared->min;
 	}
@@ -105,6 +115,15 @@ void Range::set_value_no_signal(double p_val) {
 	}
 
 	shared->val = p_val;
+}
+
+void Range::set_value_no_signal(double p_val) {
+	double prev_val = shared->val;
+	_set_value_no_signal(p_val);
+
+	if (shared->val != prev_val) {
+		shared->redraw_owners();
+	}
 }
 
 void Range::set_min(double p_min) {

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -48,6 +48,7 @@ class Range : public Control {
 		HashSet<Range *> owners;
 		void emit_value_changed();
 		void emit_changed(const char *p_what = "");
+		void redraw_owners();
 	};
 
 	Shared *shared = nullptr;
@@ -59,6 +60,7 @@ class Range : public Control {
 
 	void _value_changed_notify();
 	void _changed_notify(const char *p_what = "");
+	void _set_value_no_signal(double p_val);
 
 protected:
 	virtual void _value_changed(double p_value);

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -39,7 +39,7 @@ Size2 SpinBox::get_minimum_size() const {
 	return ms;
 }
 
-void SpinBox::_value_changed(double p_value) {
+void SpinBox::_update_text() {
 	String value = String::num(get_value(), Math::range_step_decimals(get_step()));
 	if (is_localizing_numeral_system()) {
 		value = TS->format_number(value);
@@ -55,7 +55,6 @@ void SpinBox::_value_changed(double p_value) {
 	}
 
 	line_edit->set_text(value);
-	Range::_value_changed(p_value);
 }
 
 void SpinBox::_text_submitted(const String &p_string) {
@@ -73,7 +72,7 @@ void SpinBox::_text_submitted(const String &p_string) {
 	if (value.get_type() != Variant::NIL) {
 		set_value(value);
 	}
-	_value_changed(0);
+	_update_text();
 }
 
 void SpinBox::_text_changed(const String &p_string) {
@@ -192,7 +191,7 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 
 void SpinBox::_line_edit_focus_enter() {
 	int col = line_edit->get_caret_column();
-	_value_changed(0); // Update the LineEdit's text.
+	_update_text();
 	line_edit->set_caret_column(col);
 
 	// LineEdit text might change and it clears any selection. Have to re-select here.
@@ -202,6 +201,10 @@ void SpinBox::_line_edit_focus_enter() {
 }
 
 void SpinBox::_line_edit_focus_exit() {
+	// Discontinue because the focus_exit was caused by left-clicking the arrows.
+	if (get_viewport()->gui_get_focus_owner() == get_line_edit()) {
+		return;
+	}
 	// Discontinue because the focus_exit was caused by right-click context menu.
 	if (line_edit->is_menu_visible()) {
 		return;
@@ -228,6 +231,7 @@ void SpinBox::_update_theme_item_cache() {
 void SpinBox::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
+			_update_text();
 			_adjust_width_for_icon(theme_cache.updown_icon);
 
 			RID ci = get_canvas_item();
@@ -242,7 +246,7 @@ void SpinBox::_notification(int p_what) {
 
 		case NOTIFICATION_ENTER_TREE: {
 			_adjust_width_for_icon(theme_cache.updown_icon);
-			_value_changed(0);
+			_update_text();
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
@@ -250,7 +254,6 @@ void SpinBox::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {
-			_value_changed(0);
 			queue_redraw();
 		} break;
 
@@ -279,7 +282,7 @@ void SpinBox::set_suffix(const String &p_suffix) {
 	}
 
 	suffix = p_suffix;
-	_value_changed(0);
+	_update_text();
 }
 
 String SpinBox::get_suffix() const {
@@ -292,7 +295,7 @@ void SpinBox::set_prefix(const String &p_prefix) {
 	}
 
 	prefix = p_prefix;
-	_value_changed(0);
+	_update_text();
 }
 
 String SpinBox::get_prefix() const {

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -46,8 +46,8 @@ class SpinBox : public Range {
 	void _range_click_timeout();
 	void _release_mouse();
 
+	void _update_text();
 	void _text_submitted(const String &p_string);
-	virtual void _value_changed(double p_value) override;
 	void _text_changed(const String &p_string);
 
 	String prefix;


### PR DESCRIPTION
Edit:
Everything seems to be correct now, including "shared" ranges.

`SpinBox` used to call `_value_changed(0)` to set the underlying Label's text. I moved that code in a new function `_update_text()`.

The project I used for testing:
[Range-test.zip](https://github.com/godotengine/godot/files/10338634/Range-test.zip)


Fixes #70821.