### PR TITLE
Rename `get_points_count()` to `get_point_count()` in Gradient

### DIFF
--- a/scene/2d/line_builder.cpp
+++ b/scene/2d/line_builder.cpp
@@ -380,7 +380,7 @@ void LineBuilder::build() {
 		current_distance1 += pos0.distance_to(pos1);
 	}
 	if (_interpolate_color) {
-		color1 = gradient->get_color(gradient->get_points_count() - 1);
+		color1 = gradient->get_color(gradient->get_point_count() - 1);
 	}
 	if (retrieve_curve) {
 		width_factor = curve->sample_baked(1.f);
@@ -406,7 +406,7 @@ void LineBuilder::build() {
 	// End cap (round)
 	if (end_cap_mode == Line2D::LINE_CAP_ROUND) {
 		// Note: color is not used in case we don't interpolate...
-		Color color = _interpolate_color ? gradient->get_color(gradient->get_points_count() - 1) : Color(0, 0, 0);
+		Color color = _interpolate_color ? gradient->get_color(gradient->get_point_count() - 1) : Color(0, 0, 0);
 		float dist = 0;
 		if (texture_mode == Line2D::LINE_TEXTURE_TILE) {
 			dist = width_factor / tile_aspect;

--- a/scene/resources/gradient.cpp
+++ b/scene/resources/gradient.cpp
@@ -58,7 +58,7 @@ void Gradient::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("sample", "offset"), &Gradient::get_color_at_offset);
 
-	ClassDB::bind_method(D_METHOD("get_point_count"), &Gradient::get_points_count);
+	ClassDB::bind_method(D_METHOD("get_point_count"), &Gradient::get_point_count);
 
 	ClassDB::bind_method(D_METHOD("set_offsets", "offsets"), &Gradient::set_offsets);
 	ClassDB::bind_method(D_METHOD("get_offsets"), &Gradient::get_offsets);
@@ -190,6 +190,6 @@ Color Gradient::get_color(int pos) {
 	return points[pos].color;
 }
 
-int Gradient::get_points_count() const {
+int Gradient::get_point_count() const {
 	return points.size();
 }

--- a/scene/resources/gradient.h
+++ b/scene/resources/gradient.h
@@ -171,7 +171,7 @@ public:
 		}
 	}
 
-	int get_points_count() const;
+	int get_point_count() const;
 };
 
 VARIANT_ENUM_CAST(Gradient::InterpolationMode);

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2310,9 +2310,9 @@ void GradientTexture2D::_update() {
 	Ref<Image> image;
 	image.instantiate();
 
-	if (gradient->get_points_count() <= 1) { // No need to interpolate.
+	if (gradient->get_point_count() <= 1) { // No need to interpolate.
 		image->initialize_data(width, height, false, (use_hdr) ? Image::FORMAT_RGBAF : Image::FORMAT_RGBA8);
-		image->fill((gradient->get_points_count() == 1) ? gradient->get_color(0) : Color(0, 0, 0, 1));
+		image->fill((gradient->get_point_count() == 1) ? gradient->get_color(0) : Color(0, 0, 0, 1));
 	} else {
 		if (use_hdr) {
 			image->initialize_data(width, height, false, Image::FORMAT_RGBAF);

--- a/tests/scene/test_gradient.h
+++ b/tests/scene/test_gradient.h
@@ -42,7 +42,7 @@ TEST_CASE("[Gradient] Default gradient") {
 	Ref<Gradient> gradient = memnew(Gradient);
 
 	CHECK_MESSAGE(
-			gradient->get_points_count() == 2,
+			gradient->get_point_count() == 2,
 			"Default gradient should contain the expected number of points.");
 
 	CHECK_MESSAGE(
@@ -77,7 +77,7 @@ TEST_CASE("[Gradient] Custom gradient (points specified in order)") {
 	gradient->set_points(points);
 
 	CHECK_MESSAGE(
-			gradient->get_points_count() == 3,
+			gradient->get_point_count() == 3,
 			"Custom gradient should contain the expected number of points.");
 
 	CHECK_MESSAGE(
@@ -98,7 +98,7 @@ TEST_CASE("[Gradient] Custom gradient (points specified in order)") {
 
 	gradient->remove_point(1);
 	CHECK_MESSAGE(
-			gradient->get_points_count() == 2,
+			gradient->get_point_count() == 2,
 			"Custom gradient should contain the expected number of points after removing one point.");
 	CHECK_MESSAGE(
 			gradient->get_color_at_offset(0.5).is_equal_approx(Color(0.5, 1, 0)),
@@ -119,7 +119,7 @@ TEST_CASE("[Gradient] Custom gradient (points specified out-of-order)") {
 	gradient->set_points(points);
 
 	CHECK_MESSAGE(
-			gradient->get_points_count() == 6,
+			gradient->get_point_count() == 6,
 			"Custom out-of-order gradient should contain the expected number of points.");
 
 	CHECK_MESSAGE(
@@ -137,7 +137,7 @@ TEST_CASE("[Gradient] Custom gradient (points specified out-of-order)") {
 
 	gradient->remove_point(0);
 	CHECK_MESSAGE(
-			gradient->get_points_count() == 5,
+			gradient->get_point_count() == 5,
 			"Custom out-of-order gradient should contain the expected number of points after removing one point.");
 	// The color will be clamped to the nearest point (which is at offset 0.2).
 	CHECK_MESSAGE(


### PR DESCRIPTION
It's already exposed to users as `get_point_count()` but internally we use `get_points_count()`. But "point count" is grammatically correct, so this is just confusing and longer.