### PR TITLE
GDScript: Fix wrong native type for preloaded class

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3997,10 +3997,8 @@ GDScriptParser::DataType GDScriptAnalyzer::type_from_variant(const Variant &p_va
 			scr = obj->get_script();
 		}
 		if (scr.is_valid()) {
-			result.script_path = scr->get_path();
 			Ref<GDScript> gds = scr;
 			if (gds.is_valid()) {
-				result.kind = GDScriptParser::DataType::CLASS;
 				// This might be an inner class, so we want to get the parser for the root.
 				// But still get the inner class from that tree.
 				String script_path = gds->get_script_path();
@@ -4026,11 +4024,14 @@ GDScriptParser::DataType GDScriptAnalyzer::type_from_variant(const Variant &p_va
 					return error_type;
 				}
 
+				result.kind = GDScriptParser::DataType::CLASS;
+				result.native_type = found->get_datatype().native_type;
 				result.class_type = found;
 				result.script_path = ref->get_parser()->script_path;
 			} else {
 				result.kind = GDScriptParser::DataType::SCRIPT;
 				result.native_type = scr->get_instance_base_type();
+				result.script_path = scr->get_path();
 			}
 			result.script_type = scr;
 		} else {

--- a/modules/gdscript/tests/scripts/analyzer/features/preload_script_native_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/preload_script_native_type.gd
@@ -1,0 +1,15 @@
+const Preloaded := preload( 'preload_script_native_type.notest.gd' )
+
+func test() -> void:
+	var inferred := Preloaded.new()
+	var inferred_owner := inferred.owner
+
+	var typed: Preloaded
+	typed = Preloaded.new()
+	var typed_owner := typed.owner
+
+	print(typed_owner == inferred_owner)
+
+	inferred.free()
+	typed.free()
+	print('ok')

--- a/modules/gdscript/tests/scripts/analyzer/features/preload_script_native_type.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/preload_script_native_type.notest.gd
@@ -1,0 +1,1 @@
+extends Node

--- a/modules/gdscript/tests/scripts/analyzer/features/preload_script_native_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/preload_script_native_type.out
@@ -1,0 +1,3 @@
+GDTEST_OK
+true
+ok


### PR DESCRIPTION
`native_type` on `DataType` for script preload was `GDScript` - a native type for a class itslef, not for its instances like it should be. Set it properly.

One-line change, but moved two other lines in a function to their more appropriate places.

Fixes #70844.
Fixes #70856.