### PR TITLE
[CI] Use multiple forced unmount attempts for MoltenVK image.

### DIFF
--- a/misc/scripts/install_vulkan_sdk_macos.sh
+++ b/misc/scripts/install_vulkan_sdk_macos.sh
@@ -8,7 +8,15 @@ curl -L "https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.dmg" -o /tmp/
 hdiutil attach /tmp/vulkan-sdk.dmg -mountpoint /Volumes/vulkan-sdk
 /Volumes/vulkan-sdk/InstallVulkan.app/Contents/MacOS/InstallVulkan \
     --accept-licenses --default-answer --confirm-command install
-hdiutil detach /Volumes/vulkan-sdk
+
+cnt=5
+until hdiutil detach -force /Volumes/vulkan-sdk
+do
+   [[ cnt -eq "0" ]] && break
+   sleep 1
+   ((cnt--))
+done
+
 rm -f /tmp/vulkan-sdk.dmg
 
 echo 'Vulkan SDK installed successfully! You can now build Godot by running "scons".'


### PR DESCRIPTION
Adds `-force` flag to unmount command and run it up to 5 times with a delay to ensure MoltenVK files aren't in use and image is unmounted.

Should fix `hdiutil: couldn't unmount "disk3" - Resource busy` macOS CI errors.