### PR TITLE
Improve remote tree node tooltips

### DIFF
--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -158,7 +158,11 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 		const SceneDebuggerTree::RemoteNode &node = p_tree->nodes[i];
 		TreeItem *item = create_item(parent);
 		item->set_text(0, node.name);
-		item->set_tooltip_text(0, TTR("Type:") + " " + node.type_name);
+		if (node.scene_file_path.is_empty()) {
+			item->set_tooltip_text(0, node.name + "\n" + TTR("Type:") + " " + node.type_name);
+		} else {
+			item->set_tooltip_text(0, node.name + "\n" + TTR("Instance:") + " " + node.scene_file_path + "\n" + TTR("Type:") + " " + node.type_name);
+		}
 		Ref<Texture2D> icon = EditorNode::get_singleton()->get_class_icon(node.type_name, "");
 		if (icon.is_valid()) {
 			item->set_icon(0, icon);


### PR DESCRIPTION
Include full node name and scene path if available
![image](https://user-images.githubusercontent.com/2223172/210395278-fbb85b62-e79b-4233-8ca8-6f7cce33c6f6.png)
Makes it more on par with local tree, which does the same.