### PR TITLE
Fix inconsistent state of Controls when editing and running scenes

### DIFF
--- a/editor/scene_create_dialog.cpp
+++ b/editor/scene_create_dialog.cpp
@@ -171,7 +171,9 @@ Node *SceneCreateDialog::create_scene_root() {
 			break;
 		case ROOT_USER_INTERFACE: {
 			Control *gui_ctl = memnew(Control);
+			// Making the root control full rect by default is more useful for resizable UIs.
 			gui_ctl->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
+			gui_ctl->set_grow_direction_preset(Control::PRESET_FULL_RECT);
 			root = gui_ctl;
 		} break;
 		case ROOT_OTHER:

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1184,7 +1184,9 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 						break;
 					case TOOL_CREATE_USER_INTERFACE: {
 						Control *node = memnew(Control);
-						node->set_anchors_and_offsets_preset(PRESET_FULL_RECT); //more useful for resizable UIs.
+						// Making the root control full rect by default is more useful for resizable UIs.
+						node->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
+						node->set_grow_direction_preset(PRESET_FULL_RECT);
 						new_node = node;
 
 					} break;

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -165,7 +165,7 @@ private:
 
 		List<Control *>::Element *RI = nullptr;
 
-		Control *parent = nullptr;
+		Control *parent_control = nullptr;
 		Window *parent_window = nullptr;
 		CanvasItem *parent_canvas_item = nullptr;
 		ObjectID drag_owner;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/67095. Special thanks to @ashelleyPurdue for a comprehensive set of tests for some of these issues.

The linked issue uncovered quite a few inconsistencies in handling controls in the editor, and fixing it uncovered other (potential) issues too. Here's a list of the changes:

1. When a new UI scene is created/a root node for a scene is set to a Control node, it is given the full rect preset. Except the grow directions are not set correctly by the editor. Opening the scene again later fixes it, upon load, but this creates suspicious new lines for users in their git diffs. I made sure to set grow directions to their correct default state in these cases.

2. The "Anchors" layout mode was not handled consistently, and it was sometimes applied to nodes which should not be in that mode, overwriting their actual state and once again creating suspicious diffs. There has been a reason for the existing logic, but it doesn't seem relevant anymore. So this is now prevented, and the "Anchors" mode must be set directly before anchor presets can be used. It also works correctly in the "Uncontrolled" mode.

3. Some general code quality improvements were needed. The "Uncontrolled" mode was not handled correctly in some places, and now it is. Also the anchors preset getter now has a short path for when it is accessed in a layout mode that doesn't rely on anchor presets, avoiding excessive checks.

4. Finally, the meat of the linked issue was related to the fact that `_validate_property` relied on parent information to correctly deduce restrictions for some properties. This parent information was cached upon entering the canvas and cleared when controls exited canvas, despite still having a parent. As suggested by @KoBeWi, there was little need to cache that information, so I changed the code to resolve it dynamically instead. This also positively affects a couple of public methods, `get_parent_control` and `get_parent_window`, which can now be relied on in controls outside of the scene tree.

5. While resolving the issue in 4. I noticed some weird code in `Control::update_minimum_size()`. It has a bit where it checks if there is a `Control` parent, and if not – if there is a `Window` parent. Except, it doesn't check the parent of the node that we are currently iterating over and instead it checks the parent of the node that the method has been called on in the first place. That seems very much incorrect, and probably leads to some sizing bugs in windows with controls. Hopefully this doesn't introduce new bugs, but the existing behavior was not correct in any case 🙂 

https://github.com/godotengine/godot/blob/26bed8aa85fc2f98e38552a82929e1deb5b29d8a/scene/gui/control.cpp#L1526-L1541

-----

Testing is appreciated, with any GUI related scenes and code that you might have.