### PR TITLE
Fix parse error using Vector{2,3,4}.INF

### DIFF
--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -164,6 +164,7 @@ bool GDScriptTokenizer::Token::is_identifier() const {
 	switch (type) {
 		case IDENTIFIER:
 		case MATCH: // Used in String.match().
+		case CONST_INF: // Used in Vector{2,3,4}.INF
 			return true;
 		default:
 			return false;

--- a/modules/gdscript/tests/scripts/parser/features/vector_inf.gd
+++ b/modules/gdscript/tests/scripts/parser/features/vector_inf.gd
@@ -1,0 +1,6 @@
+func test():
+	var vec2: = Vector2.INF
+	var vec3: = Vector3.INF
+
+	print(vec2.x == INF)
+	print(vec3.z == INF)

--- a/modules/gdscript/tests/scripts/parser/features/vector_inf.out
+++ b/modules/gdscript/tests/scripts/parser/features/vector_inf.out
@@ -1,0 +1,3 @@
+GDTEST_OK
+true
+true


### PR DESCRIPTION
Fixes #45139

Yes, technically, it would be now possible to run this code, without warning, but it's already the case with `match`.

```gdscript
extends Node

func _ready() -> void:
    var INF: = 42
    print(INF)  # prints `inf`
```