### PR TITLE
Remove side effect of the `handles` method

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -8670,13 +8670,7 @@ void Node3DEditorPlugin::edit(Object *p_object) {
 }
 
 bool Node3DEditorPlugin::handles(Object *p_object) const {
-	if (p_object->is_class("Node3D")) {
-		return true;
-	} else {
-		// This ensures that gizmos are cleared when selecting a non-Node3D node.
-		const_cast<Node3DEditorPlugin *>(this)->edit((Object *)nullptr);
-		return false;
-	}
+	return p_object->is_class("Node3D");
 }
 
 Dictionary Node3DEditorPlugin::get_state() const {


### PR DESCRIPTION
*Bugsquad edited:*
Fix partially https://github.com/godotengine/godot/issues/70688

I tracked down the cause of the problem, but I am not sure the fix is appropriate, as I am not familiar enough with the editor code.

The cause of the problem is that, when the inspector panel is on, selecting a `Path3D` object will generate two calls to `Node3DEditorPlugin::handles(Object *p_object)`. In the first call, the `p_object` parameter is the `Path3D` object itself, so the gizmo is turned on. 

However in the second call, generated by the inspector to test if inner resources can be handled by editor plugins
https://github.com/godotengine/godot/blob/0160fea1ced6697d5b72ad2f41332e8768080be4/editor/editor_properties.cpp#L4114-L4120
the parameter is a `Curve3D`, the inner resource of "Path3D". Because the side effect of the `handles` method, the gizmos is turned off again, hence the problem. When the inspector panel is off, there is no second call, hence no problem.

Removing the side effect from "handles" method solve current problem, but based on the comments, it may cause problem in places where side effect is desired. But I think those place should clear gizmo explicitly, or call a version that contains side effect.
