### PR TITLE
Revert improve update tree

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2586,7 +2586,7 @@ bool EditorInspector::_is_property_disabled_by_feature_profile(const StringName 
 	return false;
 }
 
-void EditorInspector::_update_tree() {
+void EditorInspector::update_tree() {
 	//to update properly if all is refreshed
 	StringName current_selected = property_selected;
 	int current_focusable = -1;
@@ -3305,10 +3305,6 @@ void EditorInspector::_update_tree() {
 	}
 }
 
-void EditorInspector::update_tree() {
-	update_tree_pending = true;
-}
-
 void EditorInspector::update_property(const String &p_prop) {
 	if (!editor_property_map.has(p_prop)) {
 		return;
@@ -3906,9 +3902,10 @@ void EditorInspector::_notification(int p_what) {
 			changing++;
 
 			if (update_tree_pending) {
+				update_tree();
 				update_tree_pending = false;
 				pending.clear();
-				_update_tree();
+
 			} else {
 				while (pending.size()) {
 					StringName prop = *pending.begin();

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3361,10 +3361,7 @@ void EditorInspector::set_keying(bool p_active) {
 		return;
 	}
 	keying = p_active;
-	// Propagate the keying state to its editor properties.
-	Array args;
-	args.append(keying);
-	main_vbox->propagate_call(SNAME("set_keying"), args, true);
+	update_tree();
 }
 
 void EditorInspector::set_read_only(bool p_read_only) {

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -542,8 +542,6 @@ class EditorInspector : public ScrollContainer {
 	void _show_add_meta_dialog();
 	void _check_meta_name(const String &p_name);
 
-	void _update_tree();
-
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -4121,8 +4121,6 @@ void EditorPropertyResource::update_property() {
 
 				if (use_editor) {
 					// Open editor directly and hide other such editors which are currently open.
-					// The opened editor is the one that edits the sub-resource, so keying state will be toggled to false.
-					sub_inspector->set_keying(false);
 					_open_editor_pressed();
 					if (is_inside_tree()) {
 						get_tree()->call_deferred(SNAME("call_group"), "_editor_resource_properties", "_fold_other_editors", this);


### PR DESCRIPTION
Fixes #70914. Fixes #70688.

See also https://github.com/godotengine/godot/pull/70907#pullrequestreview-1235676384.

Many EditorPlugins rely on Inspector updates. In fact, some problems (#70588, #70688) were caused by #68498, so we need to revert them to restore stability. And we should be careful when changing the timing of inspector updates.