### PR TITLE
Add handling of custom visual shader nodes from GDExtension

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -310,6 +310,7 @@ class VisualShaderEditor : public VBoxContainer {
 		int func = 0;
 		bool highend = false;
 		bool is_custom = false;
+		bool is_native = false;
 		int temp_idx = 0;
 
 		AddOption(const String &p_name = String(), const String &p_category = String(), const String &p_type = String(), const String &p_description = String(), const Vector<Variant> &p_ops = Vector<Variant>(), int p_return_type = -1, int p_mode = -1, int p_func = -1, bool p_highend = false) {
@@ -527,9 +528,10 @@ public:
 	VisualShaderGraphPlugin *get_graph_plugin() { return graph_plugin.ptr(); }
 
 	void clear_custom_types();
-	void add_custom_type(const String &p_name, const Ref<Script> &p_script, const String &p_description, int p_return_icon_type, const String &p_category, bool p_highend);
+	void add_custom_type(const String &p_name, const String &p_type, const Ref<Script> &p_script, const String &p_description, int p_return_icon_type, const String &p_category, bool p_highend);
 
 	Dictionary get_custom_node_data(Ref<VisualShaderNodeCustom> &p_custom_node);
+	void update_custom_type(const Ref<Resource> &p_resource);
 
 	virtual Size2 get_minimum_size() const override;
 	void edit(VisualShader *p_visual_shader);

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -611,6 +611,36 @@ void VisualShaderNodeCustom::_set_initialized(bool p_enabled) {
 	is_initialized = p_enabled;
 }
 
+String VisualShaderNodeCustom::_get_name() const {
+	String ret;
+	GDVIRTUAL_CALL(_get_name, ret);
+	return ret;
+}
+
+String VisualShaderNodeCustom::_get_description() const {
+	String ret;
+	GDVIRTUAL_CALL(_get_description, ret);
+	return ret;
+}
+
+String VisualShaderNodeCustom::_get_category() const {
+	String ret;
+	GDVIRTUAL_CALL(_get_category, ret);
+	return ret;
+}
+
+VisualShaderNodeCustom::PortType VisualShaderNodeCustom::_get_return_icon_type() const {
+	PortType ret = PORT_TYPE_SCALAR;
+	GDVIRTUAL_CALL(_get_return_icon_type, ret);
+	return ret;
+}
+
+bool VisualShaderNodeCustom::_is_highend() const {
+	bool ret = false;
+	GDVIRTUAL_CALL(_is_highend, ret);
+	return ret;
+}
+
 void VisualShaderNodeCustom::_bind_methods() {
 	GDVIRTUAL_BIND(_get_name);
 	GDVIRTUAL_BIND(_get_description);

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -411,6 +411,12 @@ public:
 
 	bool _is_initialized();
 	void _set_initialized(bool p_enabled);
+
+	String _get_name() const;
+	String _get_description() const;
+	String _get_category() const;
+	PortType _get_return_icon_type() const;
+	bool _is_highend() const;
 };
 
 /////


### PR DESCRIPTION
This will make the editor to intercept them from global class space, so for example (translated example from https://docs.godotengine.org/en/latest/tutorials/plugins/editor/visual_shader_plugins.html) the following C++ class will be handled correctly from its GDExtension module and can be added to the graph as node:

<details>
<summary>visual_shader_node_noise.h</summary>

```cpp
#pragma once

#ifdef WIN32
#include <windows.h>
#endif

#include <godot_cpp/core/binder_common.hpp>

#include <godot_cpp/classes/global_constants.hpp>
#include <godot_cpp/classes/visual_shader_node_custom.hpp>

using namespace godot;

class VisualShaderNodeNoise : public VisualShaderNodeCustom {
GDCLASS(VisualShaderNodeNoise, VisualShaderNodeCustom);

protected:
static void _bind_methods();

public:
virtual String _get_name() const override;
virtual String _get_category() const override;
virtual String _get_description() const override;

virtual int64_t _get_return_icon_type() const override;
virtual int64_t _get_input_port_count() const override;
virtual int64_t _get_input_port_type(int64_t port) const override;
virtual String _get_input_port_name(int64_t port) const override;
virtual int64_t _get_output_port_count() const override;
virtual int64_t _get_output_port_type(int64_t port) const override;
virtual String _get_output_port_name(int64_t port) const override;

virtual String _get_code(const TypedArray<String> &input_vars, const TypedArray<String> &output_vars, Shader::Mode mode, VisualShader::Type type) const override;
virtual String _get_global_code(Shader::Mode mode) const override;

public:
VisualShaderNodeNoise();
~VisualShaderNodeNoise();
};

```

</details>

<details>
<summary>visual_shader_node_noise.cpp</summary>

```cpp
#include "visual_shader_node_noise.h"

#include <godot_cpp/classes/global_constants.hpp>
#include <godot_cpp/core/class_db.hpp>
#include <godot_cpp/variant/utility_functions.hpp>

using namespace godot;

////////////////////////////////////////////////////////////////////////////////////////

String VisualShaderNodeNoise::_get_name() const {
return "Noise";
}

String VisualShaderNodeNoise::_get_category() const {
return "MyShaderNodes";
}

String VisualShaderNodeNoise::_get_description() const {
return "Classic Perlin-Noise-3D function (by Curly-Brace)";
}

int64_t VisualShaderNodeNoise::_get_return_icon_type() const {
return PORT_TYPE_SCALAR;
}

int64_t VisualShaderNodeNoise::_get_input_port_count() const {
return 4;
}

int64_t VisualShaderNodeNoise::_get_input_port_type(int64_t port) const {
switch (port) {
case 0:
return PORT_TYPE_VECTOR_3D;
case 1:
return PORT_TYPE_VECTOR_3D;
case 2:
return PORT_TYPE_SCALAR;
case 3:
return PORT_TYPE_SCALAR;
default:
break;
}
return PORT_TYPE_SCALAR;
}

String VisualShaderNodeNoise::_get_input_port_name(int64_t port) const {
switch (port) {
case 0:
return "uv";
case 1:
return "offset";
case 2:
return "scale";
case 3:
return "time";
default:
break;
}
return String();
}

int64_t VisualShaderNodeNoise::_get_output_port_count() const {
return 1;
}

int64_t VisualShaderNodeNoise::_get_output_port_type(int64_t port) const {
return PORT_TYPE_SCALAR;
}

String VisualShaderNodeNoise::_get_output_port_name(int64_t port) const {
return "result";
}

String VisualShaderNodeNoise::_get_code(const TypedArray<String> &input_vars, const TypedArray<String> &output_vars, Shader::Mode mode, VisualShader::Type type) const {
String code;
code = String(output_vars[0]) + String(" = cnoise(vec3((") + String(input_vars[0]) + String(".xy + ") + String(input_vars[1]) + String(".xy) * ") + String(input_vars[2]) + String(", ") + String(input_vars[3]) + String(")) * 0.5 + 0.5;");
return code;
}

String VisualShaderNodeNoise::_get_global_code(Shader::Mode mode) const {
return R"(vec3 mod289_3(vec3 x) {
            return x - floor(x * (1.0 / 289.0)) * 289.0;
        }

        vec4 mod289_4(vec4 x) {
            return x - floor(x * (1.0 / 289.0)) * 289.0;
        }

        vec4 permute(vec4 x) {
            return mod289_4(((x * 34.0) + 1.0) * x);
        }

        vec4 taylorInvSqrt(vec4 r) {
            return 1.79284291400159 - 0.85373472095314 * r;
        }

        vec3 fade(vec3 t) {
            return t * t * t * (t * (t * 6.0 - 15.0) + 10.0);
        }

        // Classic Perlin noise.
        float cnoise(vec3 P) {
            vec3 Pi0 = floor(P); // Integer part for indexing.
            vec3 Pi1 = Pi0 + vec3(1.0); // Integer part + 1.
            Pi0 = mod289_3(Pi0);
            Pi1 = mod289_3(Pi1);
            vec3 Pf0 = fract(P); // Fractional part for interpolation.
            vec3 Pf1 = Pf0 - vec3(1.0); // Fractional part - 1.0.
            vec4 ix = vec4(Pi0.x, Pi1.x, Pi0.x, Pi1.x);
            vec4 iy = vec4(Pi0.yy, Pi1.yy);
            vec4 iz0 = vec4(Pi0.z);
            vec4 iz1 = vec4(Pi1.z);

            vec4 ixy = permute(permute(ix) + iy);
            vec4 ixy0 = permute(ixy + iz0);
            vec4 ixy1 = permute(ixy + iz1);

            vec4 gx0 = ixy0 * (1.0 / 7.0);
            vec4 gy0 = fract(floor(gx0) * (1.0 / 7.0)) - 0.5;
            gx0 = fract(gx0);
            vec4 gz0 = vec4(0.5) - abs(gx0) - abs(gy0);
            vec4 sz0 = step(gz0, vec4(0.0));
            gx0 -= sz0 * (step(0.0, gx0) - 0.5);
            gy0 -= sz0 * (step(0.0, gy0) - 0.5);

            vec4 gx1 = ixy1 * (1.0 / 7.0);
            vec4 gy1 = fract(floor(gx1) * (1.0 / 7.0)) - 0.5;
            gx1 = fract(gx1);
            vec4 gz1 = vec4(0.5) - abs(gx1) - abs(gy1);
            vec4 sz1 = step(gz1, vec4(0.0));
            gx1 -= sz1 * (step(0.0, gx1) - 0.5);
            gy1 -= sz1 * (step(0.0, gy1) - 0.5);

            vec3 g000 = vec3(gx0.x, gy0.x, gz0.x);
            vec3 g100 = vec3(gx0.y, gy0.y, gz0.y);
            vec3 g010 = vec3(gx0.z, gy0.z, gz0.z);
            vec3 g110 = vec3(gx0.w, gy0.w, gz0.w);
            vec3 g001 = vec3(gx1.x, gy1.x, gz1.x);
            vec3 g101 = vec3(gx1.y, gy1.y, gz1.y);
            vec3 g011 = vec3(gx1.z, gy1.z, gz1.z);
            vec3 g111 = vec3(gx1.w, gy1.w, gz1.w);

            vec4 norm0 = taylorInvSqrt(vec4(dot(g000, g000), dot(g010, g010), dot(g100, g100), dot(g110, g110)));
            g000 *= norm0.x;
            g010 *= norm0.y;
            g100 *= norm0.z;
            g110 *= norm0.w;
            vec4 norm1 = taylorInvSqrt(vec4(dot(g001, g001), dot(g011, g011), dot(g101, g101), dot(g111, g111)));
            g001 *= norm1.x;
            g011 *= norm1.y;
            g101 *= norm1.z;
            g111 *= norm1.w;

            float n000 = dot(g000, Pf0);
            float n100 = dot(g100, vec3(Pf1.x, Pf0.yz));
            float n010 = dot(g010, vec3(Pf0.x, Pf1.y, Pf0.z));
            float n110 = dot(g110, vec3(Pf1.xy, Pf0.z));
            float n001 = dot(g001, vec3(Pf0.xy, Pf1.z));
            float n101 = dot(g101, vec3(Pf1.x, Pf0.y, Pf1.z));
            float n011 = dot(g011, vec3(Pf0.x, Pf1.yz));
            float n111 = dot(g111, Pf1);

            vec3 fade_xyz = fade(Pf0);
            vec4 n_z = mix(vec4(n000, n100, n010, n110), vec4(n001, n101, n011, n111), fade_xyz.z);
            vec2 n_yz = mix(n_z.xy, n_z.zw, fade_xyz.y);
            float n_xyz = mix(n_yz.x, n_yz.y, fade_xyz.x);
            return 2.2 * n_xyz;
        })";
}

void VisualShaderNodeNoise::_bind_methods() {
}

VisualShaderNodeNoise::VisualShaderNodeNoise() {
set_input_port_default_value(2, 0.0);
}

VisualShaderNodeNoise::~VisualShaderNodeNoise() {}

```

</details>

The results can be accessed from Add-on menu as usual:
![image](https://user-images.githubusercontent.com/3036176/210549027-63e5dd6f-7e71-4640-b00e-432bf1d4c56b.png)

Test project (without extension code):
[TestVSGDExt.zip](https://github.com/godotengine/godot/files/10343768/TestVSGDExt.zip)

The extension code (need to be placed to the godot-cpp folder in order to compile):
[test_vs.zip](https://github.com/godotengine/godot/files/10343793/test_vs.zip)


