### PR TITLE
Always try to clear render target before drawing 3D with Canvas BG mode

### DIFF
--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -496,6 +496,9 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 		}
 
 		if (scenario_draw_canvas_bg && canvas_map.begin() && canvas_map.begin()->key.get_layer() > scenario_canvas_max_layer) {
+			// There may be an outstanding clear request if a clear was requested, but no 2D elements were drawn.
+			// Clear now otherwise we copy over garbage from the render target.
+			RSG::texture_storage->render_target_do_clear_request(p_viewport->render_target);
 			if (!can_draw_3d) {
 				RSG::scene->render_empty_scene(p_viewport->render_buffers, p_viewport->scenario, p_viewport->shadow_atlas);
 			} else {
@@ -536,6 +539,9 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 			}
 
 			if (scenario_draw_canvas_bg && E.key.get_layer() >= scenario_canvas_max_layer) {
+				// There may be an outstanding clear request if a clear was requested, but no 2D elements were drawn.
+				// Clear now otherwise we copy over garbage from the render target.
+				RSG::texture_storage->render_target_do_clear_request(p_viewport->render_target);
 				if (!can_draw_3d) {
 					RSG::scene->render_empty_scene(p_viewport->render_buffers, p_viewport->scenario, p_viewport->shadow_atlas);
 				} else {
@@ -547,12 +553,12 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 		}
 
 		if (scenario_draw_canvas_bg) {
+			// There may be an outstanding clear request if a clear was requested, but no 2D elements were drawn.
+			// Clear now otherwise we copy over garbage from the render target.
+			RSG::texture_storage->render_target_do_clear_request(p_viewport->render_target);
 			if (!can_draw_3d) {
 				RSG::scene->render_empty_scene(p_viewport->render_buffers, p_viewport->scenario, p_viewport->shadow_atlas);
 			} else {
-				// There may be an outstanding clear request if a clear was requested, but no 2D elements were drawn.
-				// Clear now otherwise we copy over garbage from the render target.
-				RSG::texture_storage->render_target_do_clear_request(p_viewport->render_target);
 				_draw_3d(p_viewport);
 			}
 		}


### PR DESCRIPTION
This is necessary to ensure that we aren't copying garbage data to the 3D renderbuffer

Previously I thought it was only needed when no CanvasItems were present in the scene, but it is also needed when CanvasItems are present, but nothing is rendered. 

``render_target_do_clear_request()`` has an early-out in case a clear has already been done this frame. 
