### PR TITLE
Use proper indices for lights, decals, and reflection probes in mobile scene shader

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -866,7 +866,7 @@ void main() {
 		uint decal_indices = draw_call.decals.x;
 		for (uint i = 0; i < 8; i++) {
 			uint decal_index = decal_indices & 0xFF;
-			if (i == 4) {
+			if (i == 3) {
 				decal_indices = draw_call.decals.y;
 			} else {
 				decal_indices = decal_indices >> 8;
@@ -1148,7 +1148,7 @@ void main() {
 
 		for (uint i = 0; i < 8; i++) {
 			uint reflection_index = reflection_indices & 0xFF;
-			if (i == 4) {
+			if (i == 3) {
 				reflection_indices = draw_call.reflection_probes.y;
 			} else {
 				reflection_indices = reflection_indices >> 8;
@@ -1551,7 +1551,7 @@ void main() {
 		uint light_indices = draw_call.omni_lights.x;
 		for (uint i = 0; i < 8; i++) {
 			uint light_index = light_indices & 0xFF;
-			if (i == 4) {
+			if (i == 3) {
 				light_indices = draw_call.omni_lights.y;
 			} else {
 				light_indices = light_indices >> 8;
@@ -1596,7 +1596,7 @@ void main() {
 		uint light_indices = draw_call.spot_lights.x;
 		for (uint i = 0; i < 8; i++) {
 			uint light_index = light_indices & 0xFF;
-			if (i == 4) {
+			if (i == 3) {
 				light_indices = draw_call.spot_lights.y;
 			} else {
 				light_indices = light_indices >> 8;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/70280
Fixes: https://github.com/godotengine/godot/issues/70231

Because the logic in these loops reads from ``***_indices`` before incrementing, we are incrementing for the _next_ iteration not the current iteration. So we need to move to our second ``***_indices`` variable during the 4th iteration not during the 5th

By incrementing in the 4th iteration, we were always reading from the 0th index on the 5th iteration which often contains a thing (decal, probe, or light) that shouldn't be visible from this mesh. 