### PR TITLE
Add editor setting for instantiated scenes to have editable children by default

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -317,6 +317,9 @@
 		<member name="docks/scene_tree/center_node_on_reparent" type="bool" setter="" getter="">
 			If [code]true[/code], new node created when reparenting node(s) will be positioned at the average position of the selected node(s).
 		</member>
+		<member name="docks/scene_tree/enable_editable_children_by_default" type="bool" setter="" getter="">
+			If [code]true[/code], instantiated nodes will automatically have Editable Children set to [code]true[/code] in the scene tree dock.
+		</member>
 		<member name="docks/scene_tree/hide_filtered_out_parents" type="bool" setter="" getter="">
 			If [code]true[/code], the scene tree dock will only show nodes that match the filter, without showing parents that don't. This settings can also be changed in the Scene dock's top menu.
 		</member>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -323,6 +323,9 @@
 		<member name="docks/scene_tree/derive_script_globals_by_name" type="bool" setter="" getter="">
 			If [code]true[/code], when extending a script, the global class name of the script is inserted in the script creation dialog, if it exists. If [code]false[/code], the script's file path is always inserted.
 		</member>
+		<member name="docks/scene_tree/enable_editable_children_by_default" type="bool" setter="" getter="">
+			If [code]true[/code], instantiated nodes will automatically have Editable Children set to [code]true[/code] in the scene tree dock.
+		</member>
 		<member name="docks/scene_tree/hide_filtered_out_parents" type="bool" setter="" getter="">
 			If [code]true[/code], the scene tree dock will only show nodes that match the filter, without showing parents that don't. This settings can also be changed in the Scene dock's top menu.
 		</member>

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -364,6 +364,8 @@ void SceneTreeDock::_perform_instantiate_scenes(const Vector<String> &p_files, N
 	undo_redo->create_action_for_history(TTRN("Instantiate Scene", "Instantiate Scenes", instances.size()), editor_data->get_current_edited_scene_history_id());
 	undo_redo->add_do_method(editor_selection, "clear");
 
+	bool enable_editable_children_by_default = EDITOR_GET("docks/scene_tree/enable_editable_children_by_default");
+
 	for (int i = 0; i < instances.size(); i++) {
 		Node *instantiated_scene = instances[i];
 
@@ -375,6 +377,11 @@ void SceneTreeDock::_perform_instantiate_scenes(const Vector<String> &p_files, N
 		undo_redo->add_do_method(editor_selection, "add_node", instantiated_scene);
 		undo_redo->add_do_reference(instantiated_scene);
 		undo_redo->add_undo_method(p_parent, "remove_child", instantiated_scene);
+
+		if (enable_editable_children_by_default) {
+			undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_editable_instance", instantiated_scene, true);
+			undo_redo->add_do_method(instantiated_scene, "set_display_folded", true);
+		}
 
 		String new_name = p_parent->validate_child_name(instantiated_scene);
 		EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -407,6 +407,8 @@ void SceneTreeDock::_perform_instantiate_scenes(const Vector<String> &p_files, N
 	undo_redo->create_action_for_history(TTRN("Instantiate Scene", "Instantiate Scenes", instances.size()), editor_data->get_current_edited_scene_history_id());
 	undo_redo->add_do_method(editor_selection, "clear");
 
+	bool enable_editable_children_by_default = EDITOR_GET("docks/scene_tree/enable_editable_children_by_default");
+
 	for (int i = 0; i < instances.size(); i++) {
 		Node *instantiated_scene = instances[i];
 
@@ -418,6 +420,11 @@ void SceneTreeDock::_perform_instantiate_scenes(const Vector<String> &p_files, N
 		undo_redo->add_do_method(editor_selection, "add_node", instantiated_scene);
 		undo_redo->add_do_reference(instantiated_scene);
 		undo_redo->add_undo_method(p_parent, "remove_child", instantiated_scene);
+
+		if (enable_editable_children_by_default) {
+			undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_editable_instance", instantiated_scene, true);
+			undo_redo->add_do_method(instantiated_scene, "set_display_folded", true);
+		}
 
 		String new_name = p_parent->validate_child_name(instantiated_scene);
 		EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -5718,6 +5718,11 @@ bool Node3DEditorViewport::_create_instance(Node *p_parent, const String &p_path
 	undo_redo->add_undo_method(p_parent, "remove_child", instantiated_scene);
 	undo_redo->add_do_method(editor_selection, "add_node", instantiated_scene);
 
+	if (EDITOR_GET("docks/scene_tree/enable_editable_children_by_default")) {
+		undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_editable_instance", instantiated_scene, true);
+		undo_redo->add_do_method(instantiated_scene, "set_display_folded", true);
+	}
+
 	String new_name = p_parent->validate_child_name(instantiated_scene);
 	EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
 	undo_redo->add_do_method(ed, "live_debug_instantiate_node", EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent), p_path, new_name);

--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -5814,6 +5814,11 @@ bool Node3DEditorViewport::_create_instance(Node *p_parent, const String &p_path
 	undo_redo->add_undo_method(p_parent, "remove_child", instantiated_scene);
 	undo_redo->add_do_method(editor_selection, "add_node", instantiated_scene);
 
+	if (EDITOR_GET("docks/scene_tree/enable_editable_children_by_default")) {
+		undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_editable_instance", instantiated_scene, true);
+		undo_redo->add_do_method(instantiated_scene, "set_display_folded", true);
+	}
+
 	String new_name = p_parent->validate_child_name(instantiated_scene);
 	EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
 	undo_redo->add_do_method(ed, "live_debug_instantiate_node", EditorNode::get_singleton()->get_edited_scene()->get_path_to(p_parent), p_path, new_name);

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -6421,6 +6421,11 @@ bool CanvasItemEditorViewport::_create_instance(Node *p_parent, const String &p_
 	undo_redo->add_undo_method(p_parent, "remove_child", instantiated_scene);
 	undo_redo->add_do_method(editor_selection, "add_node", instantiated_scene);
 
+	if (EDITOR_GET("docks/scene_tree/enable_editable_children_by_default")) {
+		undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_editable_instance", instantiated_scene, true);
+		undo_redo->add_do_method(instantiated_scene, "set_display_folded", true);
+	}
+
 	String new_name = p_parent->validate_child_name(instantiated_scene);
 	EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
 	undo_redo->add_do_method(ed, "live_debug_instantiate_node", edited_scene->get_path_to(p_parent), p_path, new_name);

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -6601,6 +6601,11 @@ bool CanvasItemEditorViewport::_create_instance(Node *p_parent, const String &p_
 	undo_redo->add_undo_method(p_parent, "remove_child", instantiated_scene);
 	undo_redo->add_do_method(editor_selection, "add_node", instantiated_scene);
 
+	if (EDITOR_GET("docks/scene_tree/enable_editable_children_by_default")) {
+		undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_editable_instance", instantiated_scene, true);
+		undo_redo->add_do_method(instantiated_scene, "set_display_folded", true);
+	}
+
 	String new_name = p_parent->validate_child_name(instantiated_scene);
 	EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
 	undo_redo->add_do_method(ed, "live_debug_instantiate_node", edited_scene->get_path_to(p_parent), p_path, new_name);

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -710,6 +710,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("docks/scene_tree/center_node_on_reparent", false);
 	_initial_set("docks/scene_tree/hide_filtered_out_parents", true);
 	_initial_set("docks/scene_tree/accessibility_warnings", false);
+	_initial_set("docks/scene_tree/enable_editable_children_by_default", false);
 
 	// FileSystem
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "docks/filesystem/thumbnail_size", 64, "32,128,16")

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -725,6 +725,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("docks/scene_tree/center_node_on_reparent", false);
 	_initial_set("docks/scene_tree/hide_filtered_out_parents", true);
 	_initial_set("docks/scene_tree/accessibility_warnings", false);
+	_initial_set("docks/scene_tree/enable_editable_children_by_default", false);
 
 	// FileSystem
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "docks/filesystem/thumbnail_size", 64, "32,224,16")


### PR DESCRIPTION
Part of the usability changes for https://github.com/godotengine/godot-proposals/issues/3248

I added a new editor setting that is disabled by default, so this is entirely opt-in.

<img width="781" alt="Screenshot 2023-01-05 at 14 47 45" src="https://user-images.githubusercontent.com/43449832/210794916-8a2c7d8c-0354-4b44-a153-1a7bbcced1cc.png">

I added code for this in 3 places, so that it would work with the Instantiate button, with dragging into the scene tree, and with dragging into the viewport.

https://user-images.githubusercontent.com/43449832/210794693-01890b1b-e6c3-49eb-8ba1-e8bfcc4b1ebe.mp4

Let me know what you think, I am open to feedback.

