### PR TITLE
GDScript: Disallow mismatching native type when attaching to object

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -394,7 +394,7 @@ ScriptInstance *GDScript::instance_create(Object *p_this) {
 	}
 
 	if (top->native.is_valid()) {
-		if (!ClassDB::is_parent_class(p_this->get_class_name(), top->native->get_name())) {
+		if (p_this->get_class_name() != top->native->get_name()) {
 			if (EngineDebugger::is_active()) {
 				GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), 1, "Script inherits from native type '" + String(top->native->get_name()) + "', so it can't be assigned to an object of type: '" + p_this->get_class() + "'");
 			}


### PR DESCRIPTION
**Note:** This is a compatibility breakage so it might be too late to change. I did intend to send this quite some time ago but unfortunately there has been unforeseen circumstances. Still, I will open this for the discussion since the only uses for this "feature" are hacks and it does get in the way of somethings the GDScript compiler do to analyze and optimize scripts.

If this is accepted, the PR can be improved with error messages in the editor. We can also consider if this will be done for GDScript or for all languages.

----

This used to allow subtypes to be attached to an object but this is not really expected by the GDScript compiler. It assumes that the `extends` statement is exact, which allow for some optimizations and preemptive errors.

There's really no reason to allow different types, even if a subtype, since the only cases for this is to allow some hacks that could be avoided with better solutions.
