### PR TITLE
Added Rect (rect_) properties to the c# migration table

### DIFF
--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -1240,6 +1240,14 @@ static const char *csharp_properties_renames[][2] = {
 	{ "PhysicalScancode", "PhysicalKeycode" }, // InputEventKey
 	{ "PopupExclusive", "Exclusive" }, // Window
 	{ "ProximityFadeEnable", "ProximityFadeEnabled" }, // Material
+	{ "RectPosition", "Position" }, // Control
+	{ "RectGlobalPosition", "GlobalPosition" }, // Control
+	{ "RectSize", "Size" }, // Control
+	{ "RectMinSize", "CustomMinimumSize" }, // Control
+	{ "RectRotation", "Rotation" }, // Control
+	{ "RectScale", "Scale" }, // Control
+	{ "RectPivotOffset", "PivotOffset" }, // Control
+	{ "RectClipContent", "ClipContents" }, // Control
 	{ "RefuseNewNetworkConnections", "RefuseNewConnections" }, // MultiplayerAPI
 	{ "RegionFilterClip", "RegionFilterClipEnabled" }, // Sprite2D
 	{ "ReverbBusEnable", "ReverbBusEnabled" }, // Area3D
@@ -2727,7 +2735,7 @@ bool ProjectConverter3To4::test_array_names() {
 	valid = valid && test_single_array(gdscript_function_renames, true);
 	valid = valid && test_single_array(csharp_function_renames, true);
 	valid = valid && test_single_array(gdscript_properties_renames, true);
-	valid = valid && test_single_array(csharp_properties_renames);
+	valid = valid && test_single_array(csharp_properties_renames, true);
 	valid = valid && test_single_array(shaders_renames, true);
 	valid = valid && test_single_array(gdscript_signals_renames);
 	valid = valid && test_single_array(project_settings_renames);


### PR DESCRIPTION
While working on https://github.com/godotengine/godot/pull/70913, I found that the `rect_`/`Rect` migration was only added to the gdscript table (in https://github.com/godotengine/godot/pull/64396), but not to the C# table.
Now the `rect_`/`Rect` migration is in sync with the gscript table, except `custom_minimum_size` (is done in  https://github.com/godotengine/godot/pull/70913)