### PR TITLE
Simplify some editor plugin logic and remove dead code

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -165,11 +165,6 @@
 		</member>
 	</members>
 	<signals>
-		<signal name="removed_from_graph">
-			<description>
-				Emitted when the node was removed from the graph.
-			</description>
-		</signal>
 		<signal name="tree_changed">
 			<description>
 				Emitted by nodes that inherit from this class and that have an internal tree when one of their nodes changes. The nodes that emit this signal are [AnimationNodeBlendSpace1D], [AnimationNodeBlendSpace2D], [AnimationNodeStateMachine], and [AnimationNodeBlendTree].

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -795,7 +795,6 @@ public:
 	void push_item(Object *p_object, const String &p_property = "", bool p_inspector_only = false);
 	void edit_item(Object *p_object);
 	void edit_item_resource(Ref<Resource> p_resource);
-	bool item_has_editor(Object *p_object);
 	void hide_top_editors();
 
 	void select_editor_by_name(const String &p_name);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3925,7 +3925,7 @@ void EditorPropertyResource::_open_editor_pressed() {
 	Ref<Resource> res = get_edited_object()->get(get_edited_property());
 	if (res.is_valid()) {
 		// May clear the editor so do it deferred.
-		EditorNode::get_singleton()->call_deferred(SNAME("edit_item_resource"), res);
+		callable_mp(EditorNode::get_singleton(), &EditorNode::edit_item_resource).bind(res).call_deferred();
 	}
 }
 
@@ -4189,7 +4189,6 @@ void EditorPropertyResource::_notification(int p_what) {
 }
 
 void EditorPropertyResource::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_open_editor_pressed"), &EditorPropertyResource::_open_editor_pressed);
 	ClassDB::bind_method(D_METHOD("_fold_other_editors"), &EditorPropertyResource::_fold_other_editors);
 }
 

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -855,10 +855,6 @@ void AnimationNodeBlendSpace2DEditor::_open_editor() {
 	}
 }
 
-void AnimationNodeBlendSpace2DEditor::_removed_from_graph() {
-	EditorNode::get_singleton()->edit_item(nullptr);
-}
-
 void AnimationNodeBlendSpace2DEditor::_auto_triangles_toggled() {
 	Ref<EditorUndoRedoManager> &undo_redo = EditorNode::get_undo_redo();
 	undo_redo->create_action(TTR("Toggle Auto Triangles"));
@@ -874,8 +870,6 @@ void AnimationNodeBlendSpace2DEditor::_bind_methods() {
 	ClassDB::bind_method("_update_tool_erase", &AnimationNodeBlendSpace2DEditor::_update_tool_erase);
 
 	ClassDB::bind_method("_update_edited_point_pos", &AnimationNodeBlendSpace2DEditor::_update_edited_point_pos);
-
-	ClassDB::bind_method("_removed_from_graph", &AnimationNodeBlendSpace2DEditor::_removed_from_graph);
 }
 
 AnimationNodeBlendSpace2DEditor *AnimationNodeBlendSpace2DEditor::singleton = nullptr;

--- a/editor/plugins/animation_blend_space_2d_editor.h
+++ b/editor/plugins/animation_blend_space_2d_editor.h
@@ -121,8 +121,6 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	void _edit_point_pos(double);
 	void _open_editor();
 
-	void _removed_from_graph();
-
 	void _auto_triangles_toggled();
 
 	StringName get_blend_position_path() const;

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -815,12 +815,6 @@ void AnimationNodeBlendTreeEditor::_inspect_filters(const String &p_which) {
 	filter_dialog->popup_centered(Size2(500, 500) * EDSCALE);
 }
 
-void AnimationNodeBlendTreeEditor::_removed_from_graph() {
-	if (is_visible()) {
-		EditorNode::get_singleton()->edit_item(nullptr);
-	}
-}
-
 void AnimationNodeBlendTreeEditor::_update_editor_settings() {
 	graph->get_panner()->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
 	graph->set_warped_panning(bool(EDITOR_GET("editors/panning/warped_mouse_panning")));
@@ -1050,7 +1044,6 @@ bool AnimationNodeBlendTreeEditor::can_edit(const Ref<AnimationNode> &p_node) {
 void AnimationNodeBlendTreeEditor::edit(const Ref<AnimationNode> &p_node) {
 	if (blend_tree.is_valid()) {
 		blend_tree->disconnect("node_changed", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_changed));
-		blend_tree->disconnect("removed_from_graph", callable_mp(this, &AnimationNodeBlendTreeEditor::_removed_from_graph));
 	}
 
 	blend_tree = p_node;
@@ -1063,7 +1056,6 @@ void AnimationNodeBlendTreeEditor::edit(const Ref<AnimationNode> &p_node) {
 		read_only = EditorNode::get_singleton()->is_resource_read_only(blend_tree);
 
 		blend_tree->connect("node_changed", callable_mp(this, &AnimationNodeBlendTreeEditor::_node_changed));
-		blend_tree->connect("removed_from_graph", callable_mp(this, &AnimationNodeBlendTreeEditor::_removed_from_graph));
 
 		update_graph();
 	}

--- a/editor/plugins/animation_blend_tree_editor_plugin.h
+++ b/editor/plugins/animation_blend_tree_editor_plugin.h
@@ -123,7 +123,6 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	void _connection_from_empty(const String &p_to, int p_to_slot, const Vector2 &p_release_position);
 
 	void _property_changed(const StringName &p_property, const Variant &p_value, const String &p_field, bool p_changing);
-	void _removed_from_graph();
 
 	void _update_editor_settings();
 	void _update_theme();

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1760,10 +1760,6 @@ void AnimationNodeStateMachineEditor::_open_editor(const String &p_name) {
 	AnimationTreeEditor::get_singleton()->enter_editor(p_name);
 }
 
-void AnimationNodeStateMachineEditor::_removed_from_graph() {
-	EditorNode::get_singleton()->edit_item(nullptr);
-}
-
 void AnimationNodeStateMachineEditor::_name_edited(const String &p_text) {
 	const String &new_name = p_text;
 
@@ -1942,7 +1938,6 @@ void AnimationNodeStateMachineEditor::_update_mode() {
 
 void AnimationNodeStateMachineEditor::_bind_methods() {
 	ClassDB::bind_method("_update_graph", &AnimationNodeStateMachineEditor::_update_graph);
-	ClassDB::bind_method("_removed_from_graph", &AnimationNodeStateMachineEditor::_removed_from_graph);
 	ClassDB::bind_method("_open_editor", &AnimationNodeStateMachineEditor::_open_editor);
 	ClassDB::bind_method("_connect_to", &AnimationNodeStateMachineEditor::_connect_to);
 	ClassDB::bind_method("_stop_connecting", &AnimationNodeStateMachineEditor::_stop_connecting);

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -127,8 +127,6 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	void _add_animation_type(int p_index);
 	void _connect_to(int p_index);
 
-	void _removed_from_graph();
-
 	struct NodeRect {
 		StringName node_name;
 		Rect2 node;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -431,7 +431,6 @@ void AnimationNode::_bind_methods() {
 	GDVIRTUAL_BIND(_get_caption);
 	GDVIRTUAL_BIND(_has_filter);
 
-	ADD_SIGNAL(MethodInfo("removed_from_graph"));
 	ADD_SIGNAL(MethodInfo("tree_changed"));
 
 	BIND_ENUM_CONSTANT(FILTER_IGNORE);


### PR DESCRIPTION
While looking into https://github.com/godotengine/godot/issues/70914, I noticed a bunch of related code that was either unused or duplicated. So I did a little clean up, which should help us in a future refactoring.

- `removed_from_graph` was added in https://github.com/godotengine/godot/commit/b80946ee0dbb7c28021c55d2623a35e89fc972f4, but later the signal was removed from code, so methods were never called; in some classes they weren't even connected.
- `EditorNode::item_has_editor` wasn't used, I think it was only needed for the animation tree, and that need was removed in https://github.com/godotengine/godot/commit/c7e4527a88b90062e1d5fdea50c1b85cea3c8c6c.
- `EditorNode::edit_item` and `EditorNode::_edit_current` shared some logic, so I made one use another.
- Some methods were bound for no good reason, namely `EditorNode::edit_item_resource` was bound just for a deferred call, which can be achieved with a callable now.

This doesn't fix any particular issue, but it should still be good to have. This is technically breaking API compatibility, as a previously defined signal was removed, but since it was never used, it shouldn't affect anyone.

-----

I didn't notice any changes in the behavior when working with the inspector or with the animation tree editor. But testing is obviously welcome.