### PR TITLE
Implement Curve::get_closest_point_index

### DIFF
--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -55,6 +55,14 @@
 				[param to_point] must be in this curve's local space.
 			</description>
 		</method>
+		<method name="get_closest_point_index" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="to_point" type="Vector2" />
+			<description>
+				Returns the index of the closest point on baked segments (in curve's local space) to [param to_point].
+				[param to_point] must be in this curve's local space.
+			</description>
+		</method>
 		<method name="get_point_in" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="idx" type="int" />

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -68,6 +68,14 @@
 				[param to_point] must be in this curve's local space.
 			</description>
 		</method>
+		<method name="get_closest_point_index" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="to_point" type="Vector3" />
+			<description>
+				Returns the index of the closest point on baked segments (in curve's local space) to [param to_point].
+				[param to_point] must be in this curve's local space.
+			</description>
+		</method>
 		<method name="get_point_in" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="idx" type="int" />

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -1062,6 +1062,46 @@ Vector2 Curve2D::get_closest_point(const Vector2 &p_to_point) const {
 	return nearest;
 }
 
+int Curve2D::get_closest_point_index(const Vector2 &p_to_point) const {
+	// Brute force method.
+
+	if (baked_cache_dirty) {
+		_bake();
+	}
+
+	// Validate: Curve may not have baked points.
+	int pc = baked_point_cache.size();
+	ERR_FAIL_COND_V_MSG(pc == 0, 0, "No points in Curve2D.");
+
+	if (pc == 1) {
+		// return first index if there is only one point in Curve3D
+		return 0;
+	}
+
+	const Vector2 *r = baked_point_cache.ptr();
+
+	int nearest_index = 0;
+	real_t nearest_dist = -1.0f;
+
+	for (int i = 0; i < pc - 1; i++) {
+		const real_t interval = baked_dist_cache[i + 1] - baked_dist_cache[i];
+		Vector2 origin = r[i];
+		Vector2 direction = (r[i + 1] - origin) / interval;
+
+		real_t d = CLAMP((p_to_point - origin).dot(direction), 0.0f, interval);
+		Vector2 proj = origin + direction * d;
+
+		real_t dist = proj.distance_squared_to(p_to_point);
+
+		if (nearest_dist < 0.0f || dist < nearest_dist) {
+			nearest_index = i;
+			nearest_dist = dist;
+		}
+	}
+
+	return nearest_index;
+}
+
 real_t Curve2D::get_closest_offset(const Vector2 &p_to_point) const {
 	// Brute force method.
 
@@ -1302,6 +1342,7 @@ void Curve2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("sample_baked", "offset", "cubic"), &Curve2D::sample_baked, DEFVAL(0.0), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("sample_baked_with_rotation", "offset", "cubic"), &Curve2D::sample_baked_with_rotation, DEFVAL(0.0), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_baked_points"), &Curve2D::get_baked_points);
+	ClassDB::bind_method(D_METHOD("get_closest_point_index", "to_point"), &Curve2D::get_closest_point_index);
 	ClassDB::bind_method(D_METHOD("get_closest_point", "to_point"), &Curve2D::get_closest_point);
 	ClassDB::bind_method(D_METHOD("get_closest_offset", "to_point"), &Curve2D::get_closest_offset);
 	ClassDB::bind_method(D_METHOD("tessellate", "max_stages", "tolerance_degrees"), &Curve2D::tessellate, DEFVAL(5), DEFVAL(4));
@@ -1946,6 +1987,46 @@ Vector3 Curve3D::get_closest_point(const Vector3 &p_to_point) const {
 	return nearest;
 }
 
+int Curve3D::get_closest_point_index(const Vector3 &p_to_point) const {
+	// Brute force method.
+
+	if (baked_cache_dirty) {
+		_bake();
+	}
+
+	// Validate: Curve may not have baked points.
+	int pc = baked_point_cache.size();
+	ERR_FAIL_COND_V_MSG(pc == 0, 0, "No points in Curve3D.");
+
+	if (pc == 1) {
+		// return first index if there is only one point in Curve3D
+		return 0;
+	}
+
+	const Vector3 *r = baked_point_cache.ptr();
+
+	int nearest_index = 0;
+	real_t nearest_dist = -1.0f;
+
+	for (int i = 0; i < pc - 1; i++) {
+		const real_t interval = baked_dist_cache[i + 1] - baked_dist_cache[i];
+		Vector3 origin = r[i];
+		Vector3 direction = (r[i + 1] - origin) / interval;
+
+		real_t d = CLAMP((p_to_point - origin).dot(direction), 0.0f, interval);
+		Vector3 proj = origin + direction * d;
+
+		real_t dist = proj.distance_squared_to(p_to_point);
+
+		if (nearest_dist < 0.0f || dist < nearest_dist) {
+			nearest_index = i;
+			nearest_dist = dist;
+		}
+	}
+
+	return nearest_index;
+}
+
 real_t Curve3D::get_closest_offset(const Vector3 &p_to_point) const {
 	// Brute force method.
 
@@ -2228,6 +2309,7 @@ void Curve3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_baked_points"), &Curve3D::get_baked_points);
 	ClassDB::bind_method(D_METHOD("get_baked_tilts"), &Curve3D::get_baked_tilts);
 	ClassDB::bind_method(D_METHOD("get_baked_up_vectors"), &Curve3D::get_baked_up_vectors);
+	ClassDB::bind_method(D_METHOD("get_closest_point_index", "to_point"), &Curve3D::get_closest_point_index);
 	ClassDB::bind_method(D_METHOD("get_closest_point", "to_point"), &Curve3D::get_closest_point);
 	ClassDB::bind_method(D_METHOD("get_closest_offset", "to_point"), &Curve3D::get_closest_offset);
 	ClassDB::bind_method(D_METHOD("tessellate", "max_stages", "tolerance_degrees"), &Curve3D::tessellate, DEFVAL(5), DEFVAL(4));

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -232,6 +232,7 @@ public:
 	Transform2D sample_baked_with_rotation(real_t p_offset, bool p_cubic = false) const;
 	PackedVector2Array get_baked_points() const; //useful for going through
 	Vector2 get_closest_point(const Vector2 &p_to_point) const;
+	int get_closest_point_index(const Vector2 &p_to_point) const;
 	real_t get_closest_offset(const Vector2 &p_to_point) const;
 
 	PackedVector2Array tessellate(int p_max_stages = 5, real_t p_tolerance = 4) const; //useful for display
@@ -326,6 +327,7 @@ public:
 	Vector<real_t> get_baked_tilts() const; //useful for going through
 	PackedVector3Array get_baked_up_vectors() const;
 	Vector3 get_closest_point(const Vector3 &p_to_point) const;
+	int get_closest_point_index(const Vector3 &p_to_point) const;
 	real_t get_closest_offset(const Vector3 &p_to_point) const;
 
 	PackedVector3Array tessellate(int p_max_stages = 5, real_t p_tolerance = 4) const; // Useful for display.


### PR DESCRIPTION
Added a `get_closest_point_index` function for both Curve2D and Curve3D. This was proposed in [#1279](https://github.com/godotengine/godot-proposals/issues/1279) and discussed further in [#68810](https://github.com/godotengine/godot/pull/68810).

Both functions use the curve's baked points—the same as the original `get_closest_point`.