### PR TITLE
Unbind Variant methods that change immutable types.

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2059,9 +2059,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Transform2D, interpolate_with, sarray("xform", "weight"), varray());
 	bind_method(Transform2D, is_equal_approx, sarray("xform"), varray());
 	bind_method(Transform2D, is_finite, sarray(), varray());
-	bind_method(Transform2D, set_rotation, sarray("rotation"), varray());
-	bind_method(Transform2D, set_scale, sarray("scale"), varray());
-	bind_method(Transform2D, set_skew, sarray("skew"), varray());
+	// Do not bind functions like set_rotation, set_scale, set_skew, etc because this type is immutable and can't be modified.
 	bind_method(Transform2D, looking_at, sarray("target"), varray(Vector2()));
 
 	/* Basis */

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -183,28 +183,6 @@
 				This can be seen as transforming with respect to the local frame.
 			</description>
 		</method>
-		<method name="set_rotation">
-			<return type="void" />
-			<param index="0" name="rotation" type="float" />
-			<description>
-				Sets the transform's rotation (in radians).
-			</description>
-		</method>
-		<method name="set_scale">
-			<return type="void" />
-			<param index="0" name="scale" type="Vector2" />
-			<description>
-				Sets the transform's scale.
-				[b]Note:[/b] Negative X scales in 2D are not decomposable from the transformation matrix. Due to the way scale is represented with transformation matrices in Godot, negative scales on the X axis will be changed to negative scales on the Y axis and a rotation of 180 degrees when decomposed.
-			</description>
-		</method>
-		<method name="set_skew">
-			<return type="void" />
-			<param index="0" name="skew" type="float" />
-			<description>
-				Sets the transform's skew (in radians).
-			</description>
-		</method>
 		<method name="translated" qualifiers="const">
 			<return type="Transform2D" />
 			<param index="0" name="offset" type="Vector2" />


### PR DESCRIPTION
Fixes #62706.
Code is commented instead of removed to clarify why they should not be re-added.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
