### PR TITLE
Properly report Callable bound arguments

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1055,7 +1055,7 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 				if (ce.error == Callable::CallError::CALL_ERROR_INVALID_METHOD && !ClassDB::class_exists(target->get_class_name())) {
 					//most likely object is not initialized yet, do not throw error.
 				} else {
-					ERR_PRINT("Error calling from signal '" + String(p_name) + "' to callable: " + Variant::get_callable_error_text(c.callable, args, argc, ce) + ".");
+					ERR_PRINT("Error calling from signal '" + String(p_name) + "' to callable: " + Variant::get_callable_error_text(c.callable, args, argc + c.callable.get_bound_arguments_count(), ce) + ".");
 					err = ERR_METHOD_NOT_FOUND;
 				}
 			}

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -137,6 +137,14 @@ StringName Callable::get_method() const {
 	return method;
 }
 
+int Callable::get_bound_arguments_count() const {
+	if (!is_null() && is_custom()) {
+		return custom->get_bound_arguments_count();
+	} else {
+		return 0;
+	}
+}
+
 CallableCustom *Callable::get_custom() const {
 	ERR_FAIL_COND_V_MSG(!is_custom(), nullptr,
 			vformat("Can't get custom on non-CallableCustom \"%s\".", operator String()));
@@ -342,6 +350,10 @@ Error CallableCustom::rpc(int p_peer_id, const Variant **p_arguments, int p_argc
 
 const Callable *CallableCustom::get_base_comparator() const {
 	return nullptr;
+}
+
+int CallableCustom::get_bound_arguments_count() const {
+	return 0;
 }
 
 CallableCustom::CallableCustom() {

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -106,6 +106,7 @@ public:
 	ObjectID get_object_id() const;
 	StringName get_method() const;
 	CallableCustom *get_custom() const;
+	int get_bound_arguments_count() const;
 
 	uint32_t hash() const;
 
@@ -146,6 +147,7 @@ public:
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const = 0;
 	virtual Error rpc(int p_peer_id, const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) const;
 	virtual const Callable *get_base_comparator() const;
+	virtual int get_bound_arguments_count() const;
 
 	CallableCustom();
 	virtual ~CallableCustom() {}

--- a/core/variant/callable_bind.cpp
+++ b/core/variant/callable_bind.cpp
@@ -87,6 +87,10 @@ const Callable *CallableCustomBind::get_base_comparator() const {
 	return &callable;
 }
 
+int CallableCustomBind::get_bound_arguments_count() const {
+	return callable.get_bound_arguments_count() + binds.size();
+}
+
 void CallableCustomBind::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
 	const Variant **args = (const Variant **)alloca(sizeof(const Variant **) * (binds.size() + p_argcount));
 	for (int i = 0; i < p_argcount; i++) {
@@ -162,6 +166,10 @@ ObjectID CallableCustomUnbind::get_object() const {
 
 const Callable *CallableCustomUnbind::get_base_comparator() const {
 	return &callable;
+}
+
+int CallableCustomUnbind::get_bound_arguments_count() const {
+	return callable.get_bound_arguments_count() - argcount;
 }
 
 void CallableCustomUnbind::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {

--- a/core/variant/callable_bind.h
+++ b/core/variant/callable_bind.h
@@ -51,7 +51,7 @@ public:
 	virtual ObjectID get_object() const override; //must always be able to provide an object
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 	virtual const Callable *get_base_comparator() const override;
-
+	virtual int get_bound_arguments_count() const override;
 	Callable get_callable() { return callable; }
 	Vector<Variant> get_binds() { return binds; }
 
@@ -76,6 +76,7 @@ public:
 	virtual ObjectID get_object() const override; //must always be able to provide an object
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 	virtual const Callable *get_base_comparator() const override;
+	virtual int get_bound_arguments_count() const override;
 
 	Callable get_callable() { return callable; }
 	int get_unbinds() { return argcount; }

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2016,6 +2016,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Callable, get_object, sarray(), varray());
 	bind_method(Callable, get_object_id, sarray(), varray());
 	bind_method(Callable, get_method, sarray(), varray());
+	bind_method(Callable, get_bound_arguments_count, sarray(), varray());
 	bind_method(Callable, hash, sarray(), varray());
 	bind_method(Callable, unbind, sarray("argcount"), varray());
 

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -100,6 +100,12 @@
 				Calls the method represented by this [Callable]. Unlike [method call], this method expects all arguments to be contained inside the [param arguments] [Array].
 			</description>
 		</method>
+		<method name="get_bound_arguments_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the total amount of arguments bound (or unbound) via successive [method bind] or [method unbind] calls. If the amount of arguments unbound is greater than the ones bound, this function returns a value less than zero.
+			</description>
+		</method>
 		<method name="get_method" qualifiers="const">
 			<return type="StringName" />
 			<description>


### PR DESCRIPTION
Fixes #63213
Adds a function: Callable::get_bound_arguments_count() to query this in callables. Exposed to the engine API.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
