### PR TITLE
Allow binding Callable arguments from an array

### DIFF
--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -102,6 +102,20 @@ Callable Callable::bindp(const Variant **p_arguments, int p_argcount) const {
 	}
 	return Callable(memnew(CallableCustomBind(*this, args)));
 }
+
+Callable Callable::bindv(const Array &p_arguments) {
+	if (p_arguments.is_empty()) {
+		return *this; // No point in creating a new callable if nothing is bound.
+	}
+
+	Vector<Variant> args;
+	args.resize(p_arguments.size());
+	for (int i = 0; i < p_arguments.size(); i++) {
+		args.write[i] = p_arguments[i];
+	}
+	return Callable(memnew(CallableCustomBind(*this, args)));
+}
+
 Callable Callable::unbind(int p_argcount) const {
 	return Callable(memnew(CallableCustomUnbind(*this, p_argcount)));
 }

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -98,6 +98,7 @@ public:
 
 	template <typename... VarArgs>
 	Callable bind(VarArgs... p_args);
+	Callable bindv(const Array &p_arguments);
 
 	Callable bindp(const Variant **p_arguments, int p_argcount) const;
 	Callable unbind(int p_argcount) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2017,6 +2017,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Callable, get_object_id, sarray(), varray());
 	bind_method(Callable, get_method, sarray(), varray());
 	bind_method(Callable, hash, sarray(), varray());
+	bind_method(Callable, bindv, sarray("arguments"), varray());
 	bind_method(Callable, unbind, sarray("argcount"), varray());
 
 	bind_custom(Callable, call, _VariantCall::func_Callable_call, true, Variant);

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -77,6 +77,13 @@
 				Returns a copy of this [Callable] with one or more arguments bound. When called, the bound arguments are passed [i]after[/i] the arguments supplied by [method call].
 			</description>
 		</method>
+		<method name="bindv">
+			<return type="Callable" />
+			<param index="0" name="arguments" type="Array" />
+			<description>
+				Returns a copy of this [Callable] with one or more arguments bound, reading them from an array. When called, the bound arguments are passed [i]after[/i] the arguments supplied by [method call].
+			</description>
+		</method>
 		<method name="call" qualifiers="vararg const">
 			<return type="Variant" />
 			<description>


### PR DESCRIPTION
Restores 3.x functionality that was removed in the Signal/Callable refactor of 4.0.

Closes https://github.com/godotengine/godot-proposals/issues/6034.

Usage:

```GDScript

new_callable = callable.bindv([arg1,arg2,arg3])

```

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
