### PR TITLE
Fix `ScriptInstanceExtension::get_property_default_value` return value

### DIFF
--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -125,7 +125,8 @@ public:
 		}
 		Variant ret;
 		GDVIRTUAL_REQUIRED_CALL(_get_property_default_value, p_property, ret);
-		return ret;
+		r_value = ret;
+		return true;
 	}
 
 	EXBIND0(update_exports)


### PR DESCRIPTION
Seems to be a typo.
Allows property reverting to work in the editor.