### PR TITLE
Prevent visibility enablers to disable nodes on editor

### DIFF
--- a/scene/2d/visible_on_screen_notifier_2d.cpp
+++ b/scene/2d/visible_on_screen_notifier_2d.cpp
@@ -124,6 +124,9 @@ void VisibleOnScreenEnabler2D::_screen_exit() {
 
 void VisibleOnScreenEnabler2D::set_enable_mode(EnableMode p_mode) {
 	enable_mode = p_mode;
+	if (Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
 	if (is_inside_tree()) {
 		_update_enable_mode(is_on_screen());
 	}
@@ -137,6 +140,9 @@ void VisibleOnScreenEnabler2D::set_enable_node_path(NodePath p_path) {
 		return;
 	}
 	enable_node_path = p_path;
+	if (Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
 	if (is_inside_tree()) {
 		node_id = ObjectID();
 		Node *node = get_node(enable_node_path);

--- a/scene/3d/visible_on_screen_notifier_3d.cpp
+++ b/scene/3d/visible_on_screen_notifier_3d.cpp
@@ -115,6 +115,9 @@ void VisibleOnScreenEnabler3D::_screen_exit() {
 
 void VisibleOnScreenEnabler3D::set_enable_mode(EnableMode p_mode) {
 	enable_mode = p_mode;
+	if (Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
 	if (is_inside_tree()) {
 		_update_enable_mode(is_on_screen());
 	}
@@ -128,6 +131,9 @@ void VisibleOnScreenEnabler3D::set_enable_node_path(NodePath p_path) {
 		return;
 	}
 	enable_node_path = p_path;
+	if (Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
 	if (is_inside_tree()) {
 		node_id = ObjectID();
 		Node *node = get_node(enable_node_path);


### PR DESCRIPTION
Fixes #66772

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
