### PR TITLE
Fix cursor behavior for multiselect in Tree while holding CTRL

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1100,9 +1100,15 @@ void SceneTreeEditor::_update_selection(TreeItem *item) {
 	}
 
 	if (editor_selection->is_selected(n)) {
-		item->select(0);
+		if (!item->is_selected(0)) {
+			item->select(0);
+		}
 	} else {
-		item->deselect(0);
+		if (item->is_selected(0)) {
+			TreeItem *previous_cursor_item = tree->get_selected();
+			item->deselect(0);
+			previous_cursor_item->set_as_cursor(0);
+		}
 	}
 
 	TreeItem *c = item->get_first_child();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
It fixes cursor behaviour for selecting multiple items in `Tree` while holding CTRL button.
Before:

https://user-images.githubusercontent.com/23726629/211151367-be948a0e-fbbb-419c-8cc3-12935365a3ea.mp4

After:

https://user-images.githubusercontent.com/23726629/211151333-a339786b-6b3c-4f16-9be0-161cfc57f24c.mp4

The fix in `scene/gui/tree.cpp` exposed a problem in `editor/scene_tree_editor.cpp` as every node in the list was selected/deselected each time there was any selection change:

https://user-images.githubusercontent.com/23726629/211151959-2e0f6f3d-fffc-4ac5-9153-29eef835bb03.mp4

So in `editor/scene_tree_editor.cpp` I fixed it to behave the same as before:

https://user-images.githubusercontent.com/23726629/211152184-4baf32a9-dbd1-4c43-8e87-fd8b312dd3b7.mp4

I think the `_update_selection` in `scene_tree_editor.cpp` should be redesigned to be more dependent on the selection from a Tree, not the opposite way. Or Space button shouldn't be for rename where there is F2 for that, but it is a topic for separete proposal :)