### PR TITLE
Enable column clip content in ConnectionDock and FilesystemDock

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -1196,6 +1196,7 @@ ConnectionsDock::ConnectionsDock() {
 	tree->set_columns(1);
 	tree->set_select_mode(Tree::SELECT_ROW);
 	tree->set_hide_root(true);
+	tree->set_column_clip_content(0, true);
 	vbc->add_child(tree);
 	tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	tree->set_allow_rmb_select(true);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -3120,6 +3120,7 @@ FileSystemDock::FileSystemDock() {
 	tree->set_allow_rmb_select(true);
 	tree->set_select_mode(Tree::SELECT_MULTI);
 	tree->set_custom_minimum_size(Size2(0, 15 * EDSCALE));
+	tree->set_column_clip_content(0, true);
 	split_box->add_child(tree);
 
 	tree->connect("item_activated", callable_mp(this, &FileSystemDock::_tree_activate_file));


### PR DESCRIPTION
Enable column clip content in ConnectionDock and FilesystemDock

**ConnectionDock**
| Godot 3.5.1 | Godot 4 beta 10 | This version |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/1756388/211152356-95c73af7-2da8-4428-9d48-d77c4bbffb50.png)|  ![image](https://user-images.githubusercontent.com/1756388/211152387-b2ad8273-b95a-4f26-b7ab-cba319fc7c4c.png)| ![image](https://user-images.githubusercontent.com/1756388/211152703-b3344c18-bdb2-49c2-a58f-4ec3acf63670.png)|

**FilesystemDock**
| Godot 3.5.1 | Godot 4 beta 10 | This version |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/1756388/211153026-91ee5c3a-6ad4-4852-951b-67f848cfa2ac.png)| ![image](https://user-images.githubusercontent.com/1756388/211153063-1cca5352-68b5-4643-b50d-18d04361f2d8.png)| ![image](https://user-images.githubusercontent.com/1756388/211153141-08024c8a-6f81-4c8d-96a6-94a7ea8d1ac9.png)|
