### PR TITLE
OpenXR: Fix android loader extension detection

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -1224,8 +1224,12 @@ bool OpenXRAPI::resolve_instance_openxr_symbols() {
 	return true;
 }
 
+XrResult OpenXRAPI::try_get_instance_proc_addr(const char *p_name, PFN_xrVoidFunction *p_addr) {
+	return xrGetInstanceProcAddr(instance, p_name, p_addr);
+}
+
 XrResult OpenXRAPI::get_instance_proc_addr(const char *p_name, PFN_xrVoidFunction *p_addr) {
-	XrResult result = xrGetInstanceProcAddr(instance, p_name, p_addr);
+	XrResult result = try_get_instance_proc_addr(p_name, p_addr);
 
 	if (result != XR_SUCCESS) {
 		String error_message = String("Symbol ") + p_name + " not found in OpenXR instance.";

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -305,6 +305,7 @@ public:
 	static bool openxr_is_enabled(bool p_check_run_in_editor = true);
 	_FORCE_INLINE_ static OpenXRAPI *get_singleton() { return singleton; }
 
+	XrResult try_get_instance_proc_addr(const char *p_name, PFN_xrVoidFunction *p_addr);
 	XrResult get_instance_proc_addr(const char *p_name, PFN_xrVoidFunction *p_addr);
 	String get_error_string(XrResult result);
 	String get_swapchain_format_name(int64_t p_swapchain_format) const;

--- a/modules/openxr/util.h
+++ b/modules/openxr/util.h
@@ -53,6 +53,12 @@
 #define EXT_INIT_XR_FUNC(name) INIT_XR_FUNC(OpenXRAPI::get_singleton(), name)
 #define OPENXR_API_INIT_XR_FUNC(name) INIT_XR_FUNC(this, name)
 
+#define TRY_INIT_XR_FUNC(openxr_api, name) \
+	openxr_api->try_get_instance_proc_addr(#name, (PFN_xrVoidFunction *)&name##_ptr)
+
+#define EXT_TRY_INIT_XR_FUNC(name) TRY_INIT_XR_FUNC(OpenXRAPI::get_singleton(), name)
+#define OPENXR_TRY_API_INIT_XR_FUNC(name) TRY_INIT_XR_FUNC(this, name)
+
 #define EXT_PROTO_XRRESULT_FUNC1(func_name, arg1_type, arg1)                    \
 	PFN_##func_name func_name##_ptr = nullptr;                                  \
 	XRAPI_ATTR XrResult XRAPI_CALL func_name(UNPACK arg1_type p_##arg1) const { \


### PR DESCRIPTION
The OpenXR loader is initialized before enumerating extensions. This causes a warning about the lack of XR_KHR_loader_init_android to always be displayed, even if the runtime supports that extension.

While the cause of this is the OpenXR spec being inconsistent, we should only warn about a missing extension if the extension is actually missing. <strike>This PR thus moves the warning to be triggered after the loader is initialized.</strike> *After review and clarifications form the OpenXR working group, this PR now includes an improved warning if no extensions are present and fixes some additional aspects of loader extension detection.*

*This PR is fixing a very minor regression of https://github.com/godotengine/godot/pull/69392*