### PR TITLE
Tweak text color for disabled preprocessor branches in the shader editor

### DIFF
--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -301,7 +301,9 @@ void ShaderTextEditor::_load_theme_settings() {
 	syntax_highlighter->clear_color_regions();
 	syntax_highlighter->add_color_region("/*", "*/", comment_color, false);
 	syntax_highlighter->add_color_region("//", "", comment_color, true);
-	syntax_highlighter->set_disabled_branch_color(comment_color);
+
+	// Disabled preprocessor branches use translucent text color to be easier to distinguish from comments.
+	syntax_highlighter->set_disabled_branch_color(Color(EDITOR_GET("text_editor/theme/highlighting/text_color")) * Color(1, 1, 1, 0.5));
 
 	te->clear_comment_delimiters();
 	te->add_comment_delimiter("/*", "*/", false);


### PR DESCRIPTION
This makes text within disabled branches easier to distinguish from comments when using a non-default editor syntax theme. (The default editor syntax theme uses the same color as the text with 50% opacity for comments, which means it looks the exact same.)

## Preview

*Using VS Code Dark from https://github.com/godotengine/godot-syntax-themes/tree/4.0-dev. Previously, disabled branches would be displayed in dark green like comments.*

![2023-01-07_20 18 08](https://user-images.githubusercontent.com/180032/211167091-d2d8bc47-b458-4f14-8667-4f7bc5fd3b43.png)

<details>
<summary>Original code</summary>

```glsl
shader_type spatial;

#define COLOR_TEST

void fragment() {
#ifdef COLOR_TEST
	ALBEDO = vec3(1, 0, 0); /* Red */
#else
	ALBEDO = vec3(0, 1, 0); /* Green */
#endif
	
	// Negative test.
#ifndef COLOR_TEST
	ALBEDO = vec3(0, 0, 1); /* Blue */
#else
	ALBEDO = vec3(1, 0, 1); /* Magenta */
#endif
}
```
</details>