### PR TITLE
Tweak comment colors in the default syntax themes

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -766,7 +766,7 @@ void EditorSettings::_load_godot2_text_editor_theme() {
 	_initial_set("text_editor/theme/highlighting/base_type_color", Color(0.64, 1.0, 0.83));
 	_initial_set("text_editor/theme/highlighting/engine_type_color", Color(0.51, 0.83, 1.0));
 	_initial_set("text_editor/theme/highlighting/user_type_color", Color(0.42, 0.67, 0.93));
-	_initial_set("text_editor/theme/highlighting/comment_color", Color(0.4, 0.4, 0.4));
+	_initial_set("text_editor/theme/highlighting/comment_color", Color(0.6, 0.42, 0.35));
 	_initial_set("text_editor/theme/highlighting/string_color", Color(0.94, 0.43, 0.75));
 	_initial_set("text_editor/theme/highlighting/background_color", Color(0.13, 0.12, 0.15));
 	_initial_set("text_editor/theme/highlighting/completion_background_color", Color(0.17, 0.16, 0.2));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1846,7 +1846,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color base_type_color = dark_theme ? Color(0.26, 1.0, 0.76) : Color(0, 0.6, 0.2);
 	const Color engine_type_color = dark_theme ? Color(0.56, 1, 0.86) : Color(0.11, 0.55, 0.4);
 	const Color user_type_color = dark_theme ? Color(0.78, 1, 0.93) : Color(0.18, 0.45, 0.4);
-	const Color comment_color = dark_theme ? dim_color : Color(0.08, 0.08, 0.08, 0.5);
+	const Color comment_color = dark_theme ? Color(0.62, 0.66, 1.0, 0.61) : Color(0.11, 0.17, 0.7, 0.61);
 	const Color string_color = dark_theme ? Color(1, 0.93, 0.63) : Color(0.6, 0.42, 0);
 
 	// Use the brightest background color on a light theme (which generally uses a negative contrast rate).


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/71036 (can be merged independently, but this makes the most sense with that PR merged first).

The new colors are not translucent versions of the base text colors anymore, as this made them look the exact same as disabled shader preprocessor branches.

## Preview

*These screenshots also showcase changes from https://github.com/godotengine/godot/pull/71036.*

Prior to those changes, comments had the exact same color as the disabled preprocessor branches shown on those screenshots.

### Default (dark theme)

![2023-01-07_20 27 22](https://user-images.githubusercontent.com/180032/211167734-4b16760a-a8e4-43ab-b260-654339246e05.png)

### Default (light theme)

![2023-01-07_20 34 42](https://user-images.githubusercontent.com/180032/211167733-af7c2aec-353d-4843-b051-19a760df1712.png)

### Godot 2

*Uses the [pre-Godot 2.1 comment color](https://github.com/godotengine/godot/pull/4763)[^1] with halved saturation.*

![2023-01-07_20 36 35](https://user-images.githubusercontent.com/180032/211167732-f437e4a7-5cef-4e44-9dd1-ee0829a9914e.png)

<details>
<summary>Original code</summary>

```glsl
shader_type spatial;

#define COLOR_TEST

void fragment() {
#ifdef COLOR_TEST
	ALBEDO = vec3(1, 0, 0); /* Red */
#else
	ALBEDO = vec3(0, 1, 0); /* Green */
#endif
	
	// Negative test.
#ifndef COLOR_TEST
	ALBEDO = vec3(0, 0, 1); /* Blue */
#else
	ALBEDO = vec3(1, 0, 1); /* Magenta */
#endif
}
```
</details>

[^1]: Fun fact: this was my second PR ever merged in Godot :slightly_smiling_face: 