### PR TITLE
Remove up/down input for text search in Tree

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3190,15 +3190,6 @@ void Tree::_go_up() {
 		selected_col = 0;
 	} else {
 		prev = selected_item->get_prev_visible();
-		if (last_keypress != 0) {
-			//incr search next
-			int col;
-			prev = _search_item_text(prev, incr_search, &col, true, true);
-			if (!prev) {
-				accept_event();
-				return;
-			}
-		}
 	}
 
 	if (select_mode == SELECT_MULTI) {
@@ -3231,16 +3222,6 @@ void Tree::_go_down() {
 		}
 	} else {
 		next = selected_item->get_next_visible();
-
-		if (last_keypress != 0) {
-			//incr search next
-			int col;
-			next = _search_item_text(next, incr_search, &col, true);
-			if (!next) {
-				accept_event();
-				return;
-			}
-		}
 	}
 
 	if (select_mode == SELECT_MULTI) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #34941

If you press any key with unicode>0 you get this "bug" (Space bar has code 32). Actually it is not a bug; if you start the text search by pressing any char key then for 1sec you can move to next or previous matching item by up and down keys, so if there is no more items it just do nothing.

For me it also looked like a bug so I think this functionality should be removed as you can iterate through matched items by clicking again the same char key, and blocking the up and down input for 1 sec is more annoying than helpful.