### PR TITLE
Fix text search in Tree with multiselect

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4850,7 +4850,11 @@ void Tree::_do_incr_search(const String &p_add) {
 		return;
 	}
 
-	item->select(col);
+	if (select_mode == SELECT_MULTI) {
+		item->set_as_cursor(col);
+	} else {
+		item->select(col);
+	}
 	ensure_cursor_is_visible();
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Currently in Tree with multiselect, searching an item by clicking a char key will only work for one matched item. And also with multiselect it shouldn't select an item, it should only move the cursor position.
Before:

https://user-images.githubusercontent.com/23726629/211169211-4e2cd4a2-69d8-45a2-a975-6f3c0419ab92.mp4

After:

https://user-images.githubusercontent.com/23726629/211169224-e2bc1f2b-9ec2-4611-a9da-63a069928911.mp4

