### PR TITLE
GDScript: Begin making constants deep, not shallow or flat

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -54,16 +54,6 @@ void Array::_ref(const Array &p_from) const {
 
 	ERR_FAIL_COND(!_fp); // should NOT happen.
 
-	if (unlikely(_fp->read_only != nullptr)) {
-		// If p_from is a read-only array, just copy the contents to avoid further modification.
-		_unref();
-		_p = memnew(ArrayPrivate);
-		_p->refcount.init();
-		_p->array = _fp->array;
-		_p->typed = _fp->typed;
-		return;
-	}
-
 	if (_fp == _p) {
 		return; // whatever it is, nothing to do here move along
 	}

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -211,16 +211,6 @@ bool Dictionary::recursive_equal(const Dictionary &p_dictionary, int recursion_c
 }
 
 void Dictionary::_ref(const Dictionary &p_from) const {
-	if (unlikely(p_from._p->read_only != nullptr)) {
-		// If p_from is a read-only dictionary, just copy the contents to avoid further modification.
-		if (_p) {
-			_unref();
-		}
-		_p = memnew(DictionaryPrivate);
-		_p->refcount.init();
-		_p->variant_map = p_from._p->variant_map;
-		return;
-	}
 	//make a copy first (thread safe)
 	if (!p_from._p->refcount.ref()) {
 		return; // couldn't copy

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1507,9 +1507,9 @@ void GDScriptAnalyzer::resolve_assignable(GDScriptParser::AssignableNode *p_assi
 
 		if (is_constant) {
 			if (p_assignable->initializer->type == GDScriptParser::Node::ARRAY) {
-				const_fold_array(static_cast<GDScriptParser::ArrayNode *>(p_assignable->initializer));
+				const_fold_array(static_cast<GDScriptParser::ArrayNode *>(p_assignable->initializer), true);
 			} else if (p_assignable->initializer->type == GDScriptParser::Node::DICTIONARY) {
-				const_fold_dictionary(static_cast<GDScriptParser::DictionaryNode *>(p_assignable->initializer));
+				const_fold_dictionary(static_cast<GDScriptParser::DictionaryNode *>(p_assignable->initializer), true);
 			}
 			if (!p_assignable->initializer->is_constant) {
 				push_error(vformat(R"(Assigned value for %s "%s" isn't a constant expression.)", p_kind, p_assignable->identifier->name), p_assignable->initializer);
@@ -2063,16 +2063,16 @@ void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assig
 
 	GDScriptParser::DataType assignee_type = p_assignment->assignee->get_datatype();
 
+	if (assignee_type.is_constant || (p_assignment->assignee->type == GDScriptParser::Node::SUBSCRIPT && static_cast<GDScriptParser::SubscriptNode *>(p_assignment->assignee)->base->is_constant)) {
+		push_error("Cannot assign a new value to a constant.", p_assignment->assignee);
+	}
+
 	// Check if assigned value is an array literal, so we can make it a typed array too if appropriate.
 	if (assignee_type.has_container_element_type() && p_assignment->assigned_value->type == GDScriptParser::Node::ARRAY) {
 		update_array_literal_element_type(assignee_type, static_cast<GDScriptParser::ArrayNode *>(p_assignment->assigned_value));
 	}
 
 	GDScriptParser::DataType assigned_value_type = p_assignment->assigned_value->get_datatype();
-
-	if (assignee_type.is_constant) {
-		push_error("Cannot assign a new value to a constant.", p_assignment->assignee);
-	}
 
 	bool compatible = true;
 	GDScriptParser::DataType op_type = assigned_value_type;
@@ -3411,9 +3411,9 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 		reduce_expression(p_subscript->base);
 
 		if (p_subscript->base->type == GDScriptParser::Node::ARRAY) {
-			const_fold_array(static_cast<GDScriptParser::ArrayNode *>(p_subscript->base));
+			const_fold_array(static_cast<GDScriptParser::ArrayNode *>(p_subscript->base), false);
 		} else if (p_subscript->base->type == GDScriptParser::Node::DICTIONARY) {
-			const_fold_dictionary(static_cast<GDScriptParser::DictionaryNode *>(p_subscript->base));
+			const_fold_dictionary(static_cast<GDScriptParser::DictionaryNode *>(p_subscript->base), false);
 		}
 	}
 
@@ -3738,16 +3738,16 @@ void GDScriptAnalyzer::reduce_unary_op(GDScriptParser::UnaryOpNode *p_unary_op) 
 	p_unary_op->set_datatype(result);
 }
 
-void GDScriptAnalyzer::const_fold_array(GDScriptParser::ArrayNode *p_array) {
+void GDScriptAnalyzer::const_fold_array(GDScriptParser::ArrayNode *p_array, bool p_is_const) {
 	bool all_is_constant = true;
 
 	for (int i = 0; i < p_array->elements.size(); i++) {
 		GDScriptParser::ExpressionNode *element = p_array->elements[i];
 
 		if (element->type == GDScriptParser::Node::ARRAY) {
-			const_fold_array(static_cast<GDScriptParser::ArrayNode *>(element));
+			const_fold_array(static_cast<GDScriptParser::ArrayNode *>(element), p_is_const);
 		} else if (element->type == GDScriptParser::Node::DICTIONARY) {
-			const_fold_dictionary(static_cast<GDScriptParser::DictionaryNode *>(element));
+			const_fold_dictionary(static_cast<GDScriptParser::DictionaryNode *>(element), p_is_const);
 		}
 
 		all_is_constant = all_is_constant && element->is_constant;
@@ -3761,20 +3761,23 @@ void GDScriptAnalyzer::const_fold_array(GDScriptParser::ArrayNode *p_array) {
 	for (int i = 0; i < p_array->elements.size(); i++) {
 		array[i] = p_array->elements[i]->reduced_value;
 	}
+	if (p_is_const) {
+		array.set_read_only(true);
+	}
 	p_array->is_constant = true;
 	p_array->reduced_value = array;
 }
 
-void GDScriptAnalyzer::const_fold_dictionary(GDScriptParser::DictionaryNode *p_dictionary) {
+void GDScriptAnalyzer::const_fold_dictionary(GDScriptParser::DictionaryNode *p_dictionary, bool p_is_const) {
 	bool all_is_constant = true;
 
 	for (int i = 0; i < p_dictionary->elements.size(); i++) {
 		const GDScriptParser::DictionaryNode::Pair &element = p_dictionary->elements[i];
 
 		if (element.value->type == GDScriptParser::Node::ARRAY) {
-			const_fold_array(static_cast<GDScriptParser::ArrayNode *>(element.value));
+			const_fold_array(static_cast<GDScriptParser::ArrayNode *>(element.value), p_is_const);
 		} else if (element.value->type == GDScriptParser::Node::DICTIONARY) {
-			const_fold_dictionary(static_cast<GDScriptParser::DictionaryNode *>(element.value));
+			const_fold_dictionary(static_cast<GDScriptParser::DictionaryNode *>(element.value), p_is_const);
 		}
 
 		all_is_constant = all_is_constant && element.key->is_constant && element.value->is_constant;
@@ -3787,6 +3790,9 @@ void GDScriptAnalyzer::const_fold_dictionary(GDScriptParser::DictionaryNode *p_d
 	for (int i = 0; i < p_dictionary->elements.size(); i++) {
 		const GDScriptParser::DictionaryNode::Pair &element = p_dictionary->elements[i];
 		dict[element.key->reduced_value] = element.value->reduced_value;
+	}
+	if (p_is_const) {
+		dict.set_read_only(true);
 	}
 	p_dictionary->is_constant = true;
 	p_dictionary->reduced_value = dict;

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -102,8 +102,8 @@ class GDScriptAnalyzer {
 	void reduce_ternary_op(GDScriptParser::TernaryOpNode *p_ternary_op);
 	void reduce_unary_op(GDScriptParser::UnaryOpNode *p_unary_op);
 
-	void const_fold_array(GDScriptParser::ArrayNode *p_array);
-	void const_fold_dictionary(GDScriptParser::DictionaryNode *p_dictionary);
+	void const_fold_array(GDScriptParser::ArrayNode *p_array, bool p_is_const);
+	void const_fold_dictionary(GDScriptParser::DictionaryNode *p_dictionary, bool p_is_const);
 
 	// Helpers.
 	GDScriptParser::DataType type_from_variant(const Variant &p_value, const GDScriptParser::Node *p_source);

--- a/modules/gdscript/tests/scripts/analyzer/errors/constant_array_index_assign.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/constant_array_index_assign.gd
@@ -1,0 +1,5 @@
+const array: Array = [0]
+
+func test():
+	var key: int = 0
+	array[key] = 0

--- a/modules/gdscript/tests/scripts/analyzer/errors/constant_array_index_assign.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/constant_array_index_assign.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot assign a new value to a constant.

--- a/modules/gdscript/tests/scripts/analyzer/errors/constant_dictionary_index_assign.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/constant_dictionary_index_assign.gd
@@ -1,0 +1,5 @@
+const dictionary := {}
+
+func test():
+	var key: int = 0
+	dictionary[key] = 0

--- a/modules/gdscript/tests/scripts/analyzer/errors/constant_dictionary_index_assign.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/constant_dictionary_index_assign.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot assign a new value to a constant.

--- a/modules/gdscript/tests/scripts/runtime/errors/constant_array_is_deep.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/constant_array_is_deep.gd
@@ -1,0 +1,6 @@
+const array: Array = [{}]
+
+func test():
+	var dictionary := array[0]
+	var key: int = 0
+	dictionary[key] = 0

--- a/modules/gdscript/tests/scripts/runtime/errors/constant_array_is_deep.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/constant_array_is_deep.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: test()
+>> runtime/errors/constant_array_is_deep.gd
+>> 6
+>> Invalid set index '0' (on base: 'Dictionary') with value of type 'int'

--- a/modules/gdscript/tests/scripts/runtime/errors/constant_array_push_back.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/constant_array_push_back.gd
@@ -1,0 +1,4 @@
+const array: Array = [0]
+
+func test():
+	array.push_back(0)

--- a/modules/gdscript/tests/scripts/runtime/errors/constant_array_push_back.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/constant_array_push_back.out
@@ -1,0 +1,7 @@
+GDTEST_RUNTIME_ERROR
+>> ERROR
+>> on function: push_back()
+>> core/variant/array.cpp
+>> 253
+>> Condition "_p->read_only" is true.
+>> Array is in read-only state.

--- a/modules/gdscript/tests/scripts/runtime/errors/constant_dictionary_erase.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/constant_dictionary_erase.gd
@@ -1,0 +1,4 @@
+const dictionary := {}
+
+func test():
+  dictionary.erase(0)

--- a/modules/gdscript/tests/scripts/runtime/errors/constant_dictionary_erase.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/constant_dictionary_erase.out
@@ -1,0 +1,7 @@
+GDTEST_RUNTIME_ERROR
+>> ERROR
+>> on function: erase()
+>> core/variant/dictionary.cpp
+>> 177
+>> Condition "_p->read_only" is true. Returning: false
+>> Dictionary is in read-only state.

--- a/modules/gdscript/tests/scripts/runtime/errors/constant_dictionary_is_deep.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/constant_dictionary_is_deep.gd
@@ -1,0 +1,6 @@
+const dictionary := {0: [0]}
+
+func test():
+	var array := dictionary[0]
+	var key: int = 0
+	array[key] = 0

--- a/modules/gdscript/tests/scripts/runtime/errors/constant_dictionary_is_deep.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/constant_dictionary_is_deep.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: test()
+>> runtime/errors/constant_dictionary_is_deep.gd
+>> 6
+>> Invalid set index '0' (on base: 'Array') with value of type 'int'


### PR DESCRIPTION
Current behavior of const is troubled. They want to act like deep, but they are shallow and used by some as static variables:
```gdscript
const inconsistent = [0]

inconsistent[0] = 1 # error

var zero := 0
inconsistent[zero] = 1 # no problem
inconsistent.push_back(2) # no problem
print(inconsistent) # [1, 2]

print(inconsistent[0]) # 0
print(inconsistent[zero]) # 1
```

It is possible to resolve this in two ways:

1) Either declare them as mutable and protected only from reassignment. Then do not expect them to produce constant results outside of constant context. (In this case, maybe, it is actually better to name them `static const`, as they are static.)

2) Or declare them as deeply immutable. Then do not allow any modifications to the stored value, making it read-only.

In yesterday discussion between GDScript contributors it was decided to go with later option. This PR is a first move into that direction. It recursively makes array/dictionary literals to be read-only and disallows subscript assignments on constant base. 

This does not cover all bases - other builtin types need to implement read-only mode too and other expressions than simple literals need to be covered too, also `set_read_only` most likely should be removed from public api for Array. 

But this one should cover most popular cases, making it clear what is expected and what is not. This change is a breaking one (resolution of this inconsistency in either direction will be breaking), preferably it should be included earlier than later.

Connected issues:
Related to #30212 (expectation about it being deep).
Related to #32063 (expectation about it being shallow and non-static).
Related to #54718 (expectation about it being deep).
Related to #56306 (expectation about it being shallow, problem with modifying).
Closes #61274 (expectation about it being deep).
Closes #61919 (expectation about it being shallow, problem with modifying).
Closes #62680 (expectation about it being deep, inconsistent behavior).
Closes #70349 (expectation about it being deep).
Closes #70469 (expectation about it being shallow, inconsistent behavior).
Closes #70730 (expectation about it being shallow, inconsistent behavior).
Closes [#4576](https://github.com/godotengine/godot-proposals/issues/4576) (proposal to make them deep).