### PR TITLE
Properly stringify args for Call Method Tracks

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2231,7 +2231,7 @@ void AnimationTrackEdit::draw_key(int p_index, float p_pixels_sec, int p_x, bool
 			if (i > 0) {
 				text += ", ";
 			}
-			text += String(args[i]);
+			text += args[i].get_construct_string();
 		}
 		text += ")";
 
@@ -2539,7 +2539,7 @@ String AnimationTrackEdit::get_tooltip(const Point2 &p_pos) const {
 						if (i > 0) {
 							text += ", ";
 						}
-						text += String(args[i]);
+						text += args[i].get_construct_string();
 					}
 					text += ")\n";
 


### PR DESCRIPTION
This ensures string arguments are always shown as properly enclose in quotes and escaped and should help avoid confusion, as the previously shown key frame labels could display as invalid code, most prominently missing quote characters around strings.

---

Currently, passing an empty string in a Call Method Track would display like this:
![image](https://user-images.githubusercontent.com/1854245/211187924-83b1eab3-b118-4a10-9d5a-44f5fd9d2b2b.png)
Passing a non-empty string, would look like this:
![image](https://user-images.githubusercontent.com/1854245/211187947-b22a4afa-fa55-4551-be9c-335f7a1addda.png)

Notice how there are no quote characters, since so far it's just converting the (`Variant`) argument, resulting in the raw string contents being returned. While this is just a minor nuisance to experienced users, it can be outright confusing to new developers. This makes it look as if you're supposed to add quotes (and escapes) to your string arguments in the inspector.

With this change, the above two cases render properly with quotes delimiting the string:
![image](https://user-images.githubusercontent.com/1854245/211187994-da64a313-0cdb-433f-bc52-6fec6ac0e923.png)
![image](https://user-images.githubusercontent.com/1854245/211187998-99c3f8e4-e1f4-4deb-bf4e-b14bcc3f6d33.png)
