### PR TITLE
docs: Improve `InputEventAction` reference

### DIFF
--- a/doc/classes/InputEventAction.xml
+++ b/doc/classes/InputEventAction.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Contains a generic action which can be targeted from several types of inputs. Actions can be created from the [b]Input Map[/b] tab in the [b]Project &gt; Project Settings[/b] menu. See [method Node._input].
+		[b]Note:[/b] Unlike the other [InputEvent] subclasses which map to unique physical events, this virtual one is not emitted by the engine. This class is useful to emit actions manually with [method Input.parse_input_event], which are then received in [method Node._input]. To check if a physical event matches an action from the Input Map, use [method InputEvent.is_action] and [method InputEvent.is_action_pressed].
 	</description>
 	<tutorials>
 		<link title="InputEvent: Actions">$DOCS_URL/tutorials/inputs/inputevent.html#actions</link>


### PR DESCRIPTION
Improves `InputEventAction` reference by clearly stating that it's *not* emitted in `Node._input()`.
Related: #70889 