### PR TITLE
Fix UTF-8 encoding for copyright in About dialog

### DIFF
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -153,8 +153,8 @@ EditorAbout::EditorAbout() {
 
 	Label *about_text = memnew(Label);
 	about_text->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
-	about_text->set_text(String::utf8("\xc2\xa9 2014-present ") + TTR("Godot Engine contributors") +
-			"\n\xc2\xa9 2007-2014 Juan Linietsky, Ariel Manzur.\n");
+	about_text->set_text(String::utf8("\xc2\xa9 2014-present ") + TTR("Godot Engine contributors") + "." +
+			String::utf8("\n\xc2\xa9 2007-2014 Juan Linietsky, Ariel Manzur.\n"));
 	version_info_vbc->add_child(about_text);
 
 	hbc->add_child(version_info_vbc);


### PR DESCRIPTION
Fix About Godot after https://github.com/godotengine/godot/pull/70885

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1756388/211198658-c167ef8a-2fc0-4e80-9e22-45edced85f48.png)| ![image](https://user-images.githubusercontent.com/1756388/211204253-11cc6d29-7006-45d4-8778-e79e271c3fdc.png)|
