### PR TITLE
Changed the warning text to be more accurate to the documentation

### DIFF
--- a/scene/3d/collision_shape_3d.cpp
+++ b/scene/3d/collision_shape_3d.cpp
@@ -130,7 +130,7 @@ PackedStringArray CollisionShape3D::get_configuration_warnings() const {
 		if (Object::cast_to<ConcavePolygonShape3D>(*shape)) {
 			warnings.push_back(RTR("ConcavePolygonShape3D doesn't support RigidBody3D in another mode than static."));
 		} else if (Object::cast_to<WorldBoundaryShape3D>(*shape)) {
-			warnings.push_back(RTR("WorldBoundaryShape3D doesn't support RigidBody3D in another mode than static."));
+			warnings.push_back(RTR("WorldBoundaryShape3D is only supported as a direct child of a PhysicsBody3D or Area3D using a CollisionShape3D node."));
 		}
 	}
 


### PR DESCRIPTION
I think this warning message for RigidBody3D with a WorldBoundaryShape3D child should be more accurate to the documentation. [WorldBoundaryShape3D documentation ](https://docs.godotengine.org/en/latest/classes/class_worldboundaryshape3d.html)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
