### PR TITLE
Fix keep_screen_on being applied for the editor

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5284,7 +5284,10 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 
 #ifdef DBUS_ENABLED
 	screensaver = memnew(FreeDesktopScreenSaver);
-	screen_set_keep_on(GLOBAL_GET("display/window/energy_saving/keep_screen_on"));
+
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		screen_set_keep_on(GLOBAL_GET("display/window/energy_saving/keep_screen_on"));
+	}
 
 	portal_desktop = memnew(FreeDesktopPortalDesktop);
 #endif

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3880,7 +3880,9 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 	}
 #endif
 
-	screen_set_keep_on(GLOBAL_GET("display/window/energy_saving/keep_screen_on"));
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		screen_set_keep_on(GLOBAL_GET("display/window/energy_saving/keep_screen_on"));
+	}
 }
 
 DisplayServerMacOS::~DisplayServerMacOS() {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3907,7 +3907,9 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 	tts = memnew(TTS_Windows);
 
 	// Enforce default keep screen on value.
-	screen_set_keep_on(GLOBAL_GET("display/window/energy_saving/keep_screen_on"));
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		screen_set_keep_on(GLOBAL_GET("display/window/energy_saving/keep_screen_on"));
+	}
 
 	// Load Windows version info.
 	OSVERSIONINFOW os_ver;
@@ -4147,7 +4149,9 @@ DisplayServerWindows::~DisplayServerWindows() {
 	}
 
 	// Close power request handle.
-	screen_set_keep_on(false);
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		screen_set_keep_on(false);
+	}
 
 #ifdef GLES3_ENABLED
 	// destroy windows .. NYI?


### PR DESCRIPTION
Fixes #69167

This should be handled by the `keep_screen_on.editor` override, but there doesn't seem to currently be a consensus on how these overrides should be handled (#64100), so this is a simple fix in the meantime.