### PR TITLE
 Implement "looped" signal for AudioStreamPlayer, 2D and 3D 

### DIFF
--- a/doc/classes/AudioStreamPlayback.xml
+++ b/doc/classes/AudioStreamPlayback.xml
@@ -56,4 +56,11 @@
 			</description>
 		</method>
 	</methods>
+	<signals>
+		<signal name="looped">
+			<description>
+				Emitted when the audio loops.
+			</description>
+		</signal>
+	</signals>
 </class>

--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -85,6 +85,11 @@
 				Emitted when the audio stops playing.
 			</description>
 		</signal>
+		<signal name="looped">
+			<description>
+				Emitted when the audio loops.
+			</description>
+		</signal>
 	</signals>
 	<constants>
 		<constant name="MIX_TARGET_STEREO" value="0" enum="MixTarget">

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -91,5 +91,10 @@
 				Emitted when the audio stops playing.
 			</description>
 		</signal>
+		<signal name="looped">
+			<description>
+				Emitted when the audio loops.
+			</description>
+		</signal>
 	</signals>
 </class>

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -115,6 +115,11 @@
 				Emitted when the audio stops playing.
 			</description>
 		</signal>
+		<signal name="looped">
+			<description>
+				Emitted when the audio loops.
+			</description>
+		</signal>
 	</signals>
 	<constants>
 		<constant name="ATTENUATION_INVERSE_DISTANCE" value="0" enum="AttenuationModel">

--- a/modules/minimp3/audio_stream_mp3.cpp
+++ b/modules/minimp3/audio_stream_mp3.cpp
@@ -77,7 +77,9 @@ int AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 				}
 				loop_fade_remaining = 0;
 				seek(mp3_stream->loop_offset);
+
 				loops++;
+				emit_signal(SNAME("looped"));
 			}
 		}
 
@@ -85,7 +87,9 @@ int AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 			//EOF
 			if (mp3_stream->loop) {
 				seek(mp3_stream->loop_offset);
+
 				loops++;
+				emit_signal(SNAME("looped"));
 			} else {
 				frames_mixed_this_step = p_frames - todo;
 				//fill remainder with silence

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -114,7 +114,10 @@ int AudioStreamPlaybackOggVorbis::_mix_internal(AudioFrame *p_buffer, int p_fram
 				}
 
 				seek(vorbis_stream->loop_offset);
+
 				loops++;
+				emit_signal(SNAME("looped"));
+
 				// We still have buffer to fill, start from this element in the next iteration.
 				continue;
 			}
@@ -128,6 +131,8 @@ int AudioStreamPlaybackOggVorbis::_mix_internal(AudioFrame *p_buffer, int p_fram
 
 				seek(vorbis_stream->loop_offset);
 				loops++;
+				emit_signal(SNAME("looped"));
+
 				// We still have buffer to fill, start from this element in the next iteration.
 
 			} else {

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -74,6 +74,8 @@ private:
 	void _update_panning();
 	void _bus_layout_changed();
 
+	void _looped();
+
 	static void _listener_changed_cb(void *self) { reinterpret_cast<AudioStreamPlayer2D *>(self)->_update_panning(); }
 
 	uint32_t area_mask = 1;

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -119,6 +119,8 @@ private:
 	float panning_strength = 1.0f;
 	float cached_global_panning_strength = 0.5f;
 
+	void _looped();
+
 protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -69,6 +69,8 @@ private:
 	void _bus_layout_changed();
 	void _mix_to_bus(const AudioFrame *p_frames, int p_amount);
 
+	void _looped();
+
 	Vector<AudioFrame> _get_volume_vector();
 
 protected:

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -89,6 +89,8 @@ void AudioStreamPlayback::_bind_methods() {
 	GDVIRTUAL_BIND(_seek, "position")
 	GDVIRTUAL_BIND(_mix, "buffer", "rate_scale", "frames");
 	GDVIRTUAL_BIND(_tag_used_streams);
+
+	ADD_SIGNAL(MethodInfo("looped"));
 }
 //////////////////////////////
 
@@ -761,12 +763,18 @@ void AudioStreamPlaybackRandomizer::start(double p_from_pos) {
 
 	if (playing.is_valid()) {
 		playing->start(p_from_pos);
+		playing->connect(SNAME("looped"), callable_mp(this, &AudioStreamPlaybackRandomizer::_looped));
 	}
+}
+
+void AudioStreamPlaybackRandomizer::_looped() {
+	emit_signal(SNAME("looped"));
 }
 
 void AudioStreamPlaybackRandomizer::stop() {
 	if (playing.is_valid()) {
 		playing->stop();
+		playing->disconnect(SNAME("looped"), callable_mp(this, &AudioStreamPlaybackRandomizer::_looped));
 	}
 }
 

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -282,6 +282,8 @@ class AudioStreamPlaybackRandomizer : public AudioStreamPlayback {
 	float pitch_scale;
 	float volume_scale;
 
+	void _looped();
+
 public:
 	virtual void start(double p_from_pos = 0.0) override;
 	virtual void stop() override;


### PR DESCRIPTION
Track the number of loops on the player and if it changes, emit a singal. 

Closes godotengine/godot-proposals#1641

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
