### PR TITLE
[3.x] Fix local variables not showing when breaking on final line

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1651,7 +1651,7 @@ void GDScriptFunction::debug_get_stack_member_state(int p_line, List<Pair<String
 	Map<StringName, _GDFKC> sdmap;
 	for (const List<StackDebug>::Element *E = stack_debug.front(); E; E = E->next()) {
 		const StackDebug &sd = E->get();
-		if (sd.line > p_line) {
+		if (sd.line >= p_line) {
 			break;
 		}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Backported #58201 from `4.0` to `3.x` as discussed in #38608:
Changed the scoping check in `debug_get_stack_member_state` from `>` to `>=`, so that local variables are no longer prevented from appearing in the debugger messages when the code execution is paused on the last line of a code block.

Closes https://github.com/godotengine/godot/issues/53442