### PR TITLE
`Thread::wait_to_finish` rename to `Thread::join`; add detach method; correct warning/error

### DIFF
--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -381,7 +381,7 @@ class Thread : public RefCounted {
 
 protected:
 	Variant ret;
-	SafeFlag running;
+	SafeFlag running, joinable;
 	Callable target_callable;
 	::Thread thread;
 	static void _bind_methods();
@@ -399,7 +399,8 @@ public:
 	String get_id() const;
 	bool is_started() const;
 	bool is_alive() const;
-	Variant wait_to_finish();
+	Variant join();
+	void detach();
 };
 
 namespace special {

--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -66,7 +66,7 @@ int RemoteDebuggerPeerTCP::get_max_message_size() const {
 
 void RemoteDebuggerPeerTCP::close() {
 	running = false;
-	thread.wait_to_finish();
+	thread.join();
 	tcp_client->disconnect_from_host();
 	out_buf.clear();
 	in_buf.clear();

--- a/core/io/file_access_network.cpp
+++ b/core/io/file_access_network.cpp
@@ -216,7 +216,7 @@ FileAccessNetworkClient::FileAccessNetworkClient() {
 FileAccessNetworkClient::~FileAccessNetworkClient() {
 	quit = true;
 	sem.post();
-	thread.wait_to_finish();
+	thread.join();
 }
 
 void FileAccessNetwork::_set_block(uint64_t p_offset, const Vector<uint8_t> &p_block) {

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -350,7 +350,7 @@ IP::IP() {
 IP::~IP() {
 	resolver->thread_abort = true;
 	resolver->sem.post();
-	resolver->thread.wait_to_finish();
+	resolver->thread.join();
 
 	memdelete(resolver);
 }

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -494,7 +494,7 @@ Ref<Resource> ResourceLoader::load_threaded_get(const String &p_path, Error *r_e
 
 	if (load_task.requests == 0) {
 		if (load_task.thread) { //thread may not have been used
-			load_task.thread->wait_to_finish();
+			load_task.thread->join();
 			memdelete(load_task.thread);
 		}
 		thread_load_tasks.erase(local_path);
@@ -934,7 +934,7 @@ void ResourceLoader::clear_thread_load_tasks() {
 
 			case ResourceLoader::ThreadLoadStatus::THREAD_LOAD_IN_PROGRESS: {
 				if (E.value.thread != nullptr) {
-					E.value.thread->wait_to_finish();
+					E.value.thread->join();
 					memdelete(E.value.thread);
 					E.value.thread = nullptr;
 				}

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -250,7 +250,7 @@ void WorkerThreadPool::wait_for_task_completion(TaskID p_task_id) {
 	task_mutex.unlock();
 
 	if (use_native_low_priority_threads && task->low_priority) {
-		task->low_priority_thread->wait_to_finish();
+		task->low_priority_thread->join();
 		native_thread_allocator.free(task->low_priority_thread);
 	} else {
 		int *index = thread_ids.getptr(Thread::get_caller_id());
@@ -378,7 +378,7 @@ void WorkerThreadPool::wait_for_group_task_completion(GroupID p_group) {
 
 	if (group->low_priority_native_tasks.size() > 0) {
 		for (uint32_t i = 0; i < group->low_priority_native_tasks.size(); i++) {
-			group->low_priority_native_tasks[i]->low_priority_thread->wait_to_finish();
+			group->low_priority_native_tasks[i]->low_priority_thread->join();
 			native_thread_allocator.free(group->low_priority_native_tasks[i]->low_priority_thread);
 			task_mutex.lock();
 			task_allocator.free(group->low_priority_native_tasks[i]);
@@ -450,7 +450,7 @@ void WorkerThreadPool::finish() {
 	}
 
 	for (uint32_t i = 0; i < threads.size(); i++) {
-		threads[i].thread.wait_to_finish();
+		threads[i].thread.join();
 	}
 
 	threads.clear();

--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -99,8 +99,8 @@ public:
 
 	void start(Thread::Callback p_callback, void *p_user, const Settings &p_settings = Settings());
 	bool is_started() const;
-	///< waits until thread is finished, and deallocates it.
-	void wait_to_finish();
+	void join();
+	void detach();
 
 	Thread();
 	~Thread();

--- a/core/os/threaded_array_processor.h
+++ b/core/os/threaded_array_processor.h
@@ -79,7 +79,7 @@ void thread_process_array(uint32_t p_elements, C *p_instance, M p_method, U p_us
 	}
 
 	for (int i = 0; i < thread_count; i++) {
-		threads[i].wait_to_finish();
+		threads[i].join();
 	}
 	memdelete_arr(threads);
 }

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -40,7 +40,7 @@
 			</description>
 		</method>
 		<method name="get_baked_tilts" qualifiers="const">
-			<return type="PackedFloat32Array" />
+			<return type="PackedFloat64Array" />
 			<description>
 				Returns the cache of tilts as a [PackedFloat32Array].
 			</description>

--- a/doc/classes/HeightMapShape3D.xml
+++ b/doc/classes/HeightMapShape3D.xml
@@ -10,7 +10,7 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="map_data" type="PackedFloat32Array" setter="set_map_data" getter="get_map_data" default="PackedFloat32Array(0, 0, 0, 0)">
+		<member name="map_data" type="PackedFloat64Array" setter="set_map_data" getter="get_map_data" default="PackedFloat64Array(0, 0, 0, 0)">
 			Height map data, pool array must be of [member map_width] * [member map_depth] size.
 		</member>
 		<member name="map_depth" type="int" setter="set_map_depth" getter="get_map_depth" default="2">

--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -12,7 +12,7 @@
 	</tutorials>
 	<methods>
 		<method name="cast_motion">
-			<return type="PackedFloat32Array" />
+			<return type="PackedFloat64Array" />
 			<param index="0" name="parameters" type="PhysicsShapeQueryParameters2D" />
 			<description>
 				Checks how far a [Shape2D] can move without colliding. All the parameters for the query, including the shape and the motion, are supplied through a [PhysicsShapeQueryParameters2D] object.

--- a/doc/classes/PhysicsDirectSpaceState2DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState2DExtension.xml
@@ -16,8 +16,8 @@
 			<param index="4" name="collision_mask" type="int" />
 			<param index="5" name="collide_with_bodies" type="bool" />
 			<param index="6" name="collide_with_areas" type="bool" />
-			<param index="7" name="closest_safe" type="float*" />
-			<param index="8" name="closest_unsafe" type="float*" />
+			<param index="7" name="closest_safe" type="double*" />
+			<param index="8" name="closest_unsafe" type="double*" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -12,7 +12,7 @@
 	</tutorials>
 	<methods>
 		<method name="cast_motion">
-			<return type="PackedFloat32Array" />
+			<return type="PackedFloat64Array" />
 			<param index="0" name="parameters" type="PhysicsShapeQueryParameters3D" />
 			<description>
 				Checks how far a [Shape3D] can move without colliding. All the parameters for the query, including the shape, are supplied through a [PhysicsShapeQueryParameters3D] object.

--- a/doc/classes/PhysicsDirectSpaceState3DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState3DExtension.xml
@@ -16,8 +16,8 @@
 			<param index="4" name="collision_mask" type="int" />
 			<param index="5" name="collide_with_bodies" type="bool" />
 			<param index="6" name="collide_with_areas" type="bool" />
-			<param index="7" name="closest_safe" type="float*" />
-			<param index="8" name="closest_unsafe" type="float*" />
+			<param index="7" name="closest_safe" type="double*" />
+			<param index="8" name="closest_unsafe" type="double*" />
 			<param index="9" name="info" type="PhysicsServer3DExtensionShapeRestInfo*" />
 			<description>
 			</description>

--- a/doc/classes/Thread.xml
+++ b/doc/classes/Thread.xml
@@ -13,6 +13,13 @@
 		<link title="3D Voxel Demo">https://godotengine.org/asset-library/asset/676</link>
 	</tutorials>
 	<methods>
+		<method name="detach">
+			<return type="void" />
+			<description>
+				Detaches the [Thread] and allows it to continue processing. The return value of the [Callable] passed to [method start] will [b]not[/b] be retrievable; but signals can still be used to return data from the thread. This method fails silently when an attempt is made to detach after a thread is already detached or joined.
+				[b]Note:[/b] After the [Callable] passed to [method start] finishes, the thread will be disposed. If you want to use it again you will have to create a new instance of it.
+			</description>
+		</method>
 		<method name="get_id" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -32,6 +39,15 @@
 				Returns [code]true[/code] if this [Thread] has been started. Once started, this will return [code]true[/code] until it is joined using [method wait_to_finish]. For checking if a [Thread] is still executing its task, use [method is_alive].
 			</description>
 		</method>
+		<method name="join">
+			<return type="Variant" />
+			<description>
+				Joins the [Thread], waiting for it to finish. Returns the output of the [Callable] passed to [method start].
+				Should be used when you want to retrieve the value returned from the method called by the [Thread].
+				To determine if this can be called without blocking the calling thread, check if [method is_alive] is [code]false[/code].
+				[b]Note:[/b] After the [Thread] finishes joining it will be disposed. If you want to use it again you will have to create a new instance of it.
+			</description>
+		</method>
 		<method name="start">
 			<return type="int" enum="Error" />
 			<param index="0" name="callable" type="Callable" />
@@ -41,15 +57,6 @@
 				If the method takes some arguments, you can pass them using [method Callable.bind].
 				The [param priority] of the [Thread] can be changed by passing a value from the [enum Priority] enum.
 				Returns [constant OK] on success, or [constant ERR_CANT_CREATE] on failure.
-			</description>
-		</method>
-		<method name="wait_to_finish">
-			<return type="Variant" />
-			<description>
-				Joins the [Thread] and waits for it to finish. Returns the output of the [Callable] passed to [method start].
-				Should either be used when you want to retrieve the value returned from the method called by the [Thread] or before freeing the instance that contains the [Thread].
-				To determine if this can be called without blocking the calling thread, check if [method is_alive] is [code]false[/code].
-				[b]Note:[/b] After the [Thread] finishes joining it will be disposed. If you want to use it again you will have to create a new instance of it.
 			</description>
 		</method>
 	</methods>

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -325,7 +325,7 @@ void AudioDriverALSA::finish_device() {
 
 void AudioDriverALSA::finish() {
 	exit_thread.set();
-	thread.wait_to_finish();
+	thread.join();
 
 	finish_device();
 }

--- a/drivers/alsamidi/midi_driver_alsamidi.cpp
+++ b/drivers/alsamidi/midi_driver_alsamidi.cpp
@@ -207,7 +207,7 @@ Error MIDIDriverALSAMidi::open() {
 
 void MIDIDriverALSAMidi::close() {
 	exit_thread.set();
-	thread.wait_to_finish();
+	thread.join();
 
 	for (int i = 0; i < connected_inputs.size(); i++) {
 		snd_rawmidi_t *midi_in = connected_inputs[i].rawmidi_ptr;

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -659,7 +659,7 @@ void AudioDriverPulseAudio::finish() {
 	}
 
 	exit_thread.set();
-	thread.wait_to_finish();
+	thread.join();
 
 	finish_device();
 

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -931,7 +931,7 @@ void AudioDriverWASAPI::unlock() {
 
 void AudioDriverWASAPI::finish() {
 	exit_thread.set();
-	thread.wait_to_finish();
+	thread.join();
 
 	finish_capture_device();
 	finish_render_device();

--- a/drivers/xaudio2/audio_driver_xaudio2.cpp
+++ b/drivers/xaudio2/audio_driver_xaudio2.cpp
@@ -154,7 +154,7 @@ void AudioDriverXAudio2::unlock() {
 
 void AudioDriverXAudio2::finish() {
 	exit_thread.set();
-	thread.wait_to_finish();
+	thread.join();
 
 	if (source_voice) {
 		source_voice->Stop(0);

--- a/editor/audio_stream_preview.cpp
+++ b/editor/audio_stream_preview.cpp
@@ -231,7 +231,7 @@ void AudioStreamPreviewGenerator::_notification(int p_what) {
 			for (KeyValue<ObjectID, Preview> &E : previews) {
 				if (!E.value.generating.is_set()) {
 					if (E.value.thread) {
-						E.value.thread->wait_to_finish();
+						E.value.thread->join();
 						memdelete(E.value.thread);
 						E.value.thread = nullptr;
 					}

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1201,7 +1201,7 @@ void EditorFileSystem::_notification(int p_what) {
 				while (scanning) {
 					OS::get_singleton()->delay_usec(1000);
 				}
-				active_thread.wait_to_finish();
+				active_thread.join();
 				WARN_PRINT("Scan thread aborted...");
 				set_process(false);
 			}
@@ -1224,7 +1224,7 @@ void EditorFileSystem::_notification(int p_what) {
 
 						set_process(false);
 
-						thread_sources.wait_to_finish();
+						thread_sources.join();
 						if (_update_scan_actions()) {
 							emit_signal(SNAME("filesystem_changed"));
 						}
@@ -1240,7 +1240,7 @@ void EditorFileSystem::_notification(int p_what) {
 					}
 					filesystem = new_filesystem;
 					new_filesystem = nullptr;
-					thread.wait_to_finish();
+					thread.join();
 					_update_scan_actions();
 					emit_signal(SNAME("filesystem_changed"));
 					emit_signal(SNAME("sources_changed"), sources_changed.size() > 0);

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2132,7 +2132,7 @@ Thread EditorHelp::thread;
 
 void EditorHelp::_wait_for_thread() {
 	if (thread.is_started()) {
-		thread.wait_to_finish();
+		thread.join();
 	}
 }
 
@@ -2202,7 +2202,7 @@ void EditorHelp::update_doc() {
 void EditorHelp::cleanup_doc() {
 	_wait_for_thread();
 	if (doc_gen_use_threads) {
-		thread.wait_to_finish();
+		thread.join();
 	}
 	memdelete(doc);
 }

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5990,7 +5990,7 @@ int EditorNode::execute_and_show_output(const String &p_title, const String &p_p
 		OS::get_singleton()->delay_usec(1000);
 	}
 
-	eta.execute_output_thread.wait_to_finish();
+	eta.execute_output_thread.join();
 	execute_outputs->add_text("\nExit Code: " + itos(eta.exitcode));
 
 	if (p_close_on_errors && eta.exitcode != 0) {

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -436,7 +436,7 @@ void EditorResourcePreview::stop() {
 			OS::get_singleton()->delay_usec(10000);
 			RenderingServer::get_singleton()->sync(); //sync pending stuff, as thread may be blocked on rendering server
 		}
-		thread.wait_to_finish();
+		thread.join();
 	}
 }
 

--- a/editor/fileserver/editor_file_server.cpp
+++ b/editor/fileserver/editor_file_server.cpp
@@ -285,7 +285,7 @@ void EditorFileServer::_thread_start(void *s) {
 			Thread *w = *self->to_wait.begin();
 			self->to_wait.erase(w);
 			self->wait_mutex.unlock();
-			w->wait_to_finish();
+			w->join();
 			self->wait_mutex.lock();
 		}
 		self->wait_mutex.unlock();
@@ -319,5 +319,5 @@ EditorFileServer::EditorFileServer() {
 
 EditorFileServer::~EditorFileServer() {
 	quit = true;
-	thread.wait_to_finish();
+	thread.join();
 }

--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -435,6 +435,6 @@ TilesEditorPlugin::~TilesEditorPlugin() {
 			OS::get_singleton()->delay_usec(10000);
 			RenderingServer::get_singleton()->sync(); //sync pending stuff, as thread may be blocked on visual server
 		}
-		pattern_preview_thread.wait_to_finish();
+		pattern_preview_thread.join();
 	}
 }

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -100,7 +100,7 @@ void GDScriptLanguageServer::stop() {
 	if (use_thread) {
 		ERR_FAIL_COND(!thread.is_started());
 		thread_running = false;
-		thread.wait_to_finish();
+		thread.join();
 	}
 	protocol.stop();
 	started = false;

--- a/modules/noise/noise_texture_2d.cpp
+++ b/modules/noise/noise_texture_2d.cpp
@@ -44,7 +44,7 @@ NoiseTexture2D::~NoiseTexture2D() {
 	if (texture.is_valid()) {
 		RS::get_singleton()->free(texture);
 	}
-	noise_thread.wait_to_finish();
+	noise_thread.join();
 }
 
 void NoiseTexture2D::_bind_methods() {
@@ -124,7 +124,7 @@ void NoiseTexture2D::_set_texture_image(const Ref<Image> &p_image) {
 
 void NoiseTexture2D::_thread_done(const Ref<Image> &p_image) {
 	_set_texture_image(p_image);
-	noise_thread.wait_to_finish();
+	noise_thread.join();
 	if (regen_queued) {
 		noise_thread.start(_thread_function, this);
 		regen_queued = false;

--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -405,7 +405,7 @@ bool RaycastOcclusionCull::Scenario::update() {
 
 	if (commit_thread->is_started()) {
 		if (commit_done) {
-			commit_thread->wait_to_finish();
+			commit_thread->join();
 			current_scene_idx = 1 - current_scene_idx;
 		} else {
 			return false;
@@ -604,7 +604,7 @@ RaycastOcclusionCull::~RaycastOcclusionCull() {
 	for (KeyValue<RID, Scenario> &K : scenarios) {
 		Scenario &scenario = K.value;
 		if (scenario.commit_thread) {
-			scenario.commit_thread->wait_to_finish();
+			scenario.commit_thread->join();
 			memdelete(scenario.commit_thread);
 		}
 

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -147,7 +147,7 @@ void VideoStreamPlaybackTheora::clear() {
 #ifdef THEORA_USE_THREAD_STREAMING
 	thread_exit = true;
 	thread_sem->post(); //just in case
-	thread.wait_to_finish();
+	thread.join();
 	ring_buffer.clear();
 #endif
 

--- a/modules/upnp/doc_classes/UPNP.xml
+++ b/modules/upnp/doc_classes/UPNP.xml
@@ -45,7 +45,7 @@
 
 		func _exit_tree():
 		    # Wait for thread finish here to handle game exit while the thread is running.
-		    thread.wait_to_finish()
+		    thread.join()
 		[/codeblock]
 		[b]Terminology:[/b] In the context of UPnP networking, "gateway" (or "internet gateway device", short IGD) refers to network devices that allow computers in the local network to access the internet ("wide area network", WAN). These gateways are often also called "routers".
 		[b]Pitfalls:[/b]

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -3251,6 +3251,6 @@ EditorExportPlatformAndroid::EditorExportPlatformAndroid() {
 EditorExportPlatformAndroid::~EditorExportPlatformAndroid() {
 #ifndef ANDROID_ENABLED
 	quit_request.set();
-	check_for_changes_thread.wait_to_finish();
+	check_for_changes_thread.join();
 #endif
 }

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -1924,6 +1924,6 @@ EditorExportPlatformIOS::EditorExportPlatformIOS() {
 EditorExportPlatformIOS::~EditorExportPlatformIOS() {
 #ifndef ANDROID_ENABLED
 	quit_request.set();
-	check_for_changes_thread.wait_to_finish();
+	check_for_changes_thread.join();
 #endif
 }

--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -92,8 +92,8 @@ JoypadLinux::JoypadLinux(Input *in) {
 JoypadLinux::~JoypadLinux() {
 	monitor_joypads_exit.set();
 	joypad_events_exit.set();
-	monitor_joypads_thread.wait_to_finish();
-	joypad_events_thread.wait_to_finish();
+	monitor_joypads_thread.join();
+	joypad_events_thread.join();
 	close_joypads();
 }
 

--- a/platform/linuxbsd/tts_linux.cpp
+++ b/platform/linuxbsd/tts_linux.cpp
@@ -251,7 +251,7 @@ TTS_Linux::TTS_Linux() {
 }
 
 TTS_Linux::~TTS_Linux() {
-	init_thread.wait_to_finish();
+	init_thread.join();
 	if (synth) {
 		spd_close(synth);
 	}

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5299,7 +5299,7 @@ DisplayServerX11::~DisplayServerX11() {
 	_clipboard_transfer_ownership(XInternAtom(x11_display, "CLIPBOARD", 0), x11_main_window);
 
 	events_thread_done.set();
-	events_thread.wait_to_finish();
+	events_thread.join();
 
 	//destroy all windows
 	for (KeyValue<WindowID, WindowData> &E : windows) {

--- a/platform/web/audio_driver_web.cpp
+++ b/platform/web/audio_driver_web.cpp
@@ -243,5 +243,5 @@ void AudioDriverWorklet::unlock() {
 
 void AudioDriverWorklet::finish_driver() {
 	quit = true; // Ask thread to quit.
-	thread.wait_to_finish();
+	thread.join();
 }

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -665,5 +665,5 @@ EditorExportPlatformWeb::EditorExportPlatformWeb() {
 EditorExportPlatformWeb::~EditorExportPlatformWeb() {
 	server->stop();
 	server_quit = true;
-	server_thread.wait_to_finish();
+	server_thread.join();
 }

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -270,7 +270,7 @@ void NavigationRegion3D::bake_navigation_mesh(bool p_on_thread) {
 
 void NavigationRegion3D::_bake_finished(Ref<NavigationMesh> p_nav_mesh) {
 	set_navigation_mesh(p_nav_mesh);
-	bake_thread.wait_to_finish();
+	bake_thread.join();
 	emit_signal(SNAME("bake_finished"));
 }
 

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2677,7 +2677,7 @@ void RichTextLabel::_thread_function(void *self) {
 void RichTextLabel::_stop_thread() {
 	if (threaded) {
 		stop_thread.store(true);
-		thread.wait_to_finish();
+		thread.join();
 	}
 }
 

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -192,7 +192,7 @@ void HTTPRequest::cancel_request() {
 		set_process_internal(false);
 	} else {
 		thread_request_quit.set();
-		thread.wait_to_finish();
+		thread.join();
 	}
 
 	file.unref();

--- a/servers/audio/audio_driver_dummy.cpp
+++ b/servers/audio/audio_driver_dummy.cpp
@@ -136,7 +136,7 @@ void AudioDriverDummy::mix_audio(int p_frames, int32_t *p_buffer) {
 void AudioDriverDummy::finish() {
 	if (use_threads) {
 		exit_thread.set();
-		thread.wait_to_finish();
+		thread.join();
 	}
 
 	if (samples_in) {

--- a/servers/audio/effects/audio_effect_record.cpp
+++ b/servers/audio/effects/audio_effect_record.cpp
@@ -120,7 +120,7 @@ void AudioEffectRecordInstance::init() {
 }
 
 void AudioEffectRecordInstance::finish() {
-	io_thread.wait_to_finish();
+	io_thread.join();
 }
 
 AudioEffectRecordInstance::~AudioEffectRecordInstance() {

--- a/servers/physics_server_2d_wrap_mt.cpp
+++ b/servers/physics_server_2d_wrap_mt.cpp
@@ -109,7 +109,7 @@ void PhysicsServer2DWrapMT::init() {
 void PhysicsServer2DWrapMT::finish() {
 	if (thread.is_started()) {
 		command_queue.push(this, &PhysicsServer2DWrapMT::thread_exit);
-		thread.wait_to_finish();
+		thread.join();
 	} else {
 		physics_server_2d->finish();
 	}

--- a/servers/physics_server_3d_wrap_mt.cpp
+++ b/servers/physics_server_3d_wrap_mt.cpp
@@ -109,7 +109,7 @@ void PhysicsServer3DWrapMT::init() {
 void PhysicsServer3DWrapMT::finish() {
 	if (thread.is_started()) {
 		command_queue.push(this, &PhysicsServer3DWrapMT::thread_exit);
-		thread.wait_to_finish();
+		thread.join();
 	} else {
 		physics_server_3d->finish();
 	}

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -237,7 +237,7 @@ void RenderingServerDefault::init() {
 void RenderingServerDefault::finish() {
 	if (create_thread) {
 		command_queue.push(this, &RenderingServerDefault::_thread_exit);
-		thread.wait_to_finish();
+		thread.join();
 	} else {
 		_finish();
 	}


### PR DESCRIPTION
Not sure if I'm doing this right; this is my first attempt at a pull request/GitHub.

This changes `Thread::wait_to_finish` to be the more standard and shorter `Thread::join`; this is why it touches some 45 files. Maybe not the time to be changing this -- but I really don't see why we'd avoid the standardized naming conventions. Joining a thread implies a wait.

This adds a `detach` method (and documentation) to `Thread`. Detached threads continue processing, cleaning up when they return (C++ level, then OS/kernel level). This allows you to "fire-and-forget" a thread, letting it signal when it's done, returning the data then automatically cleaning up.

There was a warning about having to call `wait_to_finish`, but I can't see it doing *any* cleanup, really. I moved that "cleanup" code to the destructor in case of some template/macro artifact I may be missing because I am unfamiliar with the engine source, but I doubt it's necessary. The warning was removed.

There was an error that could occur, as a detached thread is likely still alive, just "disconnected" so to speak from the main thread. This meant I shouldn't cause that possible template/macro artifact and in doing so I added a SafeFlag `joinable`; it is used internally and not exposed to the end user in GDScript. This variable can likely be worked out of the equation if I give it more time.

Not in this pull request though related: I'd be willing to rewrite the threading stuff in an OS-specific manner. Doing so can greatly improve the speed of certain things (for example, using a critical section on Windows platforms is often much faster than a kernel-level mutex -- no ring jump), and can grant us the ability to cancel/kill threads we have created, which as it stands the C++ standard library does not provide a `std::thread::cancel`.