### PR TITLE
Fix invalid return address 0 in GDScript

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -1120,9 +1120,9 @@ void GDScriptByteCodeGenerator::write_call_method_bind(const Address &p_target, 
 }
 
 void GDScriptByteCodeGenerator::write_call_ptrcall(const Address &p_target, const Address &p_base, MethodBind *p_method, const Vector<Address> &p_arguments) {
-#define CASE_TYPE(m_type)                                                                                   \
-	case Variant::m_type:                                                                                   \
-		append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL_PTRCALL_##m_type, 2 + p_arguments.size()); \
+#define CASE_TYPE(m_type)                                                                                                                                                               \
+	case Variant::m_type:                                                                                                                                                               \
+		append_opcode_and_argcount(p_target.mode == Address::NIL ? GDScriptFunction::OPCODE_CALL_METHOD_BIND : GDScriptFunction::OPCODE_CALL_PTRCALL_##m_type, 2 + p_arguments.size()); \
 		break
 
 	bool is_ptrcall = true;


### PR DESCRIPTION
Fixes #70936, created by 0c15844. 
In the past, all method returns would have a temporary return address assigned to it, even if its return type is null. Now, the return address can be empty (`Address:NIL`, which has an `address` of 0), but the bytecode still attempts to send the returned value to this address. `Address:NIL` is the default state of the Address class when using an empty constructor, so sending the returned value here probably messes some stuff up for things that use `Address()` to represent an empty address (Such as the unary operator).

I'm not too knowledgable on the inner workings of the VM/Compiler, so this may not be the correct fix. The bug is gone and all tests pass, so I assume this was the problem...
If this is not the correct fix, please let me know :+1: