### PR TITLE
Support Git worktrees in generation of hash header

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -111,6 +111,10 @@ def get_version_info(module_version_string="", silent=False):
         head = open(os.path.join(gitfolder, "HEAD"), "r", encoding="utf8").readline().strip()
         if head.startswith("ref: "):
             ref = head[5:]
+            # If this directory is a Git worktree instead of a root clone.
+            parts = gitfolder.split("/")
+            if len(parts) > 2 and parts[-2] == "worktrees":
+                gitfolder = "/".join(parts[0:-2])
             head = os.path.join(gitfolder, ref)
             packedrefs = os.path.join(gitfolder, "packed-refs")
             if os.path.isfile(head):


### PR DESCRIPTION
I'm an avid user of Git worktrees and noticed that my `VERSION_HASH` was an empty string. This PR addresses that.