### PR TITLE
Add few improvements for `VisualShaderNodeParticleRandomness`

### DIFF
--- a/doc/classes/VisualShaderNodeParticleRandomness.xml
+++ b/doc/classes/VisualShaderNodeParticleRandomness.xml
@@ -21,7 +21,10 @@
 		<constant name="OP_TYPE_VECTOR_3D" value="2" enum="OpType">
 			A 3D vector type.
 		</constant>
-		<constant name="OP_TYPE_MAX" value="3" enum="OpType">
+		<constant name="OP_TYPE_VECTOR_4D" value="3" enum="OpType">
+			A 4D vector type.
+		</constant>
+		<constant name="OP_TYPE_MAX" value="4" enum="OpType">
 			Represents the size of the [enum OpType] enum.
 		</constant>
 	</constants>

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -2508,14 +2508,6 @@ void VisualShader::_update_shader() const {
 		global_compute_code += "	return __rand_from_seed(seed) * (to - from) + from;\n";
 		global_compute_code += "}\n\n";
 
-		global_compute_code += "vec2 __randv2_range(inout uint seed, vec2 from, vec2 to) {\n";
-		global_compute_code += "	return vec2(__randf_range(seed, from.x, to.x), __randf_range(seed, from.y, to.y));\n";
-		global_compute_code += "}\n\n";
-
-		global_compute_code += "vec3 __randv3_range(inout uint seed, vec3 from, vec3 to) {\n";
-		global_compute_code += "	return vec3(__randf_range(seed, from.x, to.x), __randf_range(seed, from.y, to.y), __randf_range(seed, from.z, to.z));\n";
-		global_compute_code += "}\n\n";
-
 		global_compute_code += "uint __hash(uint x) {\n";
 		global_compute_code += "	x = ((x >> uint(16)) ^ x) * uint(73244475);\n";
 		global_compute_code += "	x = ((x >> uint(16)) ^ x) * uint(73244475);\n";

--- a/scene/resources/visual_shader_particle_nodes.cpp
+++ b/scene/resources/visual_shader_particle_nodes.cpp
@@ -911,11 +911,12 @@ void VisualShaderNodeParticleRandomness::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_op_type", "type"), &VisualShaderNodeParticleRandomness::set_op_type);
 	ClassDB::bind_method(D_METHOD("get_op_type"), &VisualShaderNodeParticleRandomness::get_op_type);
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "op_type", PROPERTY_HINT_ENUM, "Scalar,Vector2,Vector3"), "set_op_type", "get_op_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "op_type", PROPERTY_HINT_ENUM, "Scalar,Vector2,Vector3,Vector4"), "set_op_type", "get_op_type");
 
 	BIND_ENUM_CONSTANT(OP_TYPE_SCALAR);
 	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_2D);
 	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_3D);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_4D);
 	BIND_ENUM_CONSTANT(OP_TYPE_MAX);
 }
 
@@ -939,6 +940,8 @@ VisualShaderNodeParticleRandomness::PortType VisualShaderNodeParticleRandomness:
 			return PORT_TYPE_VECTOR_2D;
 		case OP_TYPE_VECTOR_3D:
 			return PORT_TYPE_VECTOR_3D;
+		case OP_TYPE_VECTOR_4D:
+			return PORT_TYPE_VECTOR_4D;
 		default:
 			break;
 	}
@@ -950,46 +953,67 @@ String VisualShaderNodeParticleRandomness::get_output_port_name(int p_port) cons
 }
 
 int VisualShaderNodeParticleRandomness::get_input_port_count() const {
-	return 2;
+	return 3;
 }
 
 VisualShaderNodeParticleRandomness::PortType VisualShaderNodeParticleRandomness::get_input_port_type(int p_port) const {
-	switch (op_type) {
-		case OP_TYPE_VECTOR_2D:
-			return PORT_TYPE_VECTOR_2D;
-		case OP_TYPE_VECTOR_3D:
-			return PORT_TYPE_VECTOR_3D;
-		default:
+	switch (p_port) {
+		case 0:
+			return PORT_TYPE_SCALAR_UINT;
+		case 1:
+		case 2:
+			switch (op_type) {
+				case OP_TYPE_VECTOR_2D:
+					return PORT_TYPE_VECTOR_2D;
+				case OP_TYPE_VECTOR_3D:
+					return PORT_TYPE_VECTOR_3D;
+				case OP_TYPE_VECTOR_4D:
+					return PORT_TYPE_VECTOR_4D;
+				default:
+					break;
+			}
 			break;
 	}
 	return PORT_TYPE_SCALAR;
 }
 
 String VisualShaderNodeParticleRandomness::get_input_port_name(int p_port) const {
-	if (p_port == 0) {
-		return "min";
-	} else if (p_port == 1) {
-		return "max";
+	switch (p_port) {
+		case 0:
+			return "seed";
+		case 1:
+			return "min";
+		case 2:
+			return "max";
 	}
 	return String();
 }
 
-String VisualShaderNodeParticleRandomness::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
+bool VisualShaderNodeParticleRandomness::is_input_port_default(int p_port, Shader::Mode p_mode) const {
+	return p_port == 0; // seed
+}
+
+String VisualShaderNodeParticleRandomness::generate_global_per_node(Shader::Mode p_mode, int p_id) const {
 	String code;
-	switch (op_type) {
-		case OP_TYPE_SCALAR: {
-			code += vformat("	%s = __randf_range(__seed, %s, %s);\n", p_output_vars[0], p_input_vars[0].is_empty() ? (String)get_input_port_default_value(0) : p_input_vars[0], p_input_vars[1].is_empty() ? (String)get_input_port_default_value(1) : p_input_vars[1]);
-		} break;
-		case OP_TYPE_VECTOR_2D: {
-			code += vformat("	%s = __randv2_range(__seed, %s, %s);\n", p_output_vars[0], p_input_vars[0].is_empty() ? (String)get_input_port_default_value(0) : p_input_vars[0], p_input_vars[1].is_empty() ? (String)get_input_port_default_value(1) : p_input_vars[1]);
-		} break;
-		case OP_TYPE_VECTOR_3D: {
-			code += vformat("	%s = __randv3_range(__seed, %s, %s);\n", p_output_vars[0], p_input_vars[0].is_empty() ? (String)get_input_port_default_value(0) : p_input_vars[0], p_input_vars[1].is_empty() ? (String)get_input_port_default_value(1) : p_input_vars[1]);
-		} break;
-		default:
-			break;
-	}
+
+	code += "vec2 __randv2_range(inout uint seed, vec2 from, vec2 to) {\n";
+	code += "	return vec2(__randf_range(seed, from.x, to.x), __randf_range(seed, from.y, to.y));\n";
+	code += "}\n\n";
+
+	code += "vec3 __randv3_range(inout uint seed, vec3 from, vec3 to) {\n";
+	code += "	return vec3(__randf_range(seed, from.x, to.x), __randf_range(seed, from.y, to.y), __randf_range(seed, from.z, to.z));\n";
+	code += "}\n\n";
+
+	code += "vec4 __randv4_range(inout uint seed, vec4 from, vec4 to) {\n";
+	code += "	return vec4(__randf_range(seed, from.x, to.x), __randf_range(seed, from.y, to.y), __randf_range(seed, from.z, to.z), __randf_range(seed, from.w, to.w));\n";
+	code += "}\n\n";
+
 	return code;
+}
+
+String VisualShaderNodeParticleRandomness::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
+	static const char *func[(int)OP_TYPE_MAX] = { "__randf_range", "__randv2_range", "__randv3_range", "__randv4_range" };
+	return vformat("	%s = %s(%s, %s, %s);\n", p_output_vars[0], func[op_type], p_input_vars[0].is_empty() ? "__seed" : p_input_vars[0], p_input_vars[1].is_empty() ? (String)get_input_port_default_value(1) : p_input_vars[1], p_input_vars[2].is_empty() ? (String)get_input_port_default_value(2) : p_input_vars[2]);
 }
 
 void VisualShaderNodeParticleRandomness::set_op_type(OpType p_op_type) {
@@ -999,16 +1023,20 @@ void VisualShaderNodeParticleRandomness::set_op_type(OpType p_op_type) {
 	}
 	switch (p_op_type) {
 		case OP_TYPE_SCALAR: {
-			set_input_port_default_value(0, 0.0, get_input_port_default_value(0));
 			set_input_port_default_value(1, 0.0, get_input_port_default_value(1));
+			set_input_port_default_value(2, 0.0, get_input_port_default_value(2));
 		} break;
 		case OP_TYPE_VECTOR_2D: {
-			set_input_port_default_value(0, Vector2(), get_input_port_default_value(0));
 			set_input_port_default_value(1, Vector2(), get_input_port_default_value(1));
+			set_input_port_default_value(2, Vector2(), get_input_port_default_value(2));
 		} break;
 		case OP_TYPE_VECTOR_3D: {
-			set_input_port_default_value(0, Vector3(), get_input_port_default_value(0));
 			set_input_port_default_value(1, Vector3(), get_input_port_default_value(1));
+			set_input_port_default_value(2, Vector3(), get_input_port_default_value(2));
+		} break;
+		case OP_TYPE_VECTOR_4D: {
+			set_input_port_default_value(1, Quaternion(), get_input_port_default_value(1));
+			set_input_port_default_value(2, Quaternion(), get_input_port_default_value(2));
 		} break;
 		default:
 			break;
@@ -1026,8 +1054,8 @@ bool VisualShaderNodeParticleRandomness::has_output_port_preview(int p_port) con
 }
 
 VisualShaderNodeParticleRandomness::VisualShaderNodeParticleRandomness() {
-	set_input_port_default_value(0, -1.0);
-	set_input_port_default_value(1, 1.0);
+	set_input_port_default_value(1, -1.0);
+	set_input_port_default_value(2, 1.0);
 }
 
 // VisualShaderNodeParticleAccelerator

--- a/scene/resources/visual_shader_particle_nodes.h
+++ b/scene/resources/visual_shader_particle_nodes.h
@@ -216,6 +216,7 @@ public:
 		OP_TYPE_SCALAR,
 		OP_TYPE_VECTOR_2D,
 		OP_TYPE_VECTOR_3D,
+		OP_TYPE_VECTOR_4D,
 		OP_TYPE_MAX,
 	};
 
@@ -232,12 +233,14 @@ public:
 	virtual int get_input_port_count() const override;
 	virtual PortType get_input_port_type(int p_port) const override;
 	virtual String get_input_port_name(int p_port) const override;
+	virtual bool is_input_port_default(int p_port, Shader::Mode p_mode) const override;
 
 	virtual int get_output_port_count() const override;
 	virtual PortType get_output_port_type(int p_port) const override;
 	virtual String get_output_port_name(int p_port) const override;
 	virtual bool has_output_port_preview(int p_port) const override;
 
+	virtual String generate_global_per_node(Shader::Mode p_mode, int p_id) const override;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
 
 	void set_op_type(OpType p_type);


### PR DESCRIPTION
Changes:
- Adds an optional `seed` uint parameter.
- Adds a Vector4 type support
- Places the code generation for all vector types to the node itself (to `generate_global_per_node` which generates only if at least one `VisualShaderNodeParticleRandomness` node is present).
- Makes the content of `get_code` less clunky by using a static string array.

![image](https://user-images.githubusercontent.com/3036176/211367917-c7eebd15-c4f5-4b65-b50a-ae778c2f2d78.png)
