### PR TITLE
Only disable depth writing in opaque pipelines

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -309,14 +309,6 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 						}
 
 						RD::PipelineDepthStencilState depth_stencil = depth_stencil_state;
-						if (depth_pre_pass_enabled && casts_shadows() && !uses_depth_prepass_alpha) {
-							// We already have a depth from the depth pre-pass, there is no need to write it again.
-							// In addition we can use COMPARE_OP_EQUAL instead of COMPARE_OP_LESS_OR_EQUAL.
-							// This way we can use the early depth test to discard transparent fragments before the fragment shader even starts.
-							// This cannot be used with depth_prepass_alpha as it uses a different threshold during the depth-prepass and regular drawing.
-							depth_stencil.depth_compare_operator = RD::COMPARE_OP_EQUAL;
-							depth_stencil.enable_depth_write = false;
-						}
 
 						RD::PipelineColorBlendState blend_state;
 						RD::PipelineMultisampleState multisample_state;
@@ -337,6 +329,14 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 							}
 						} else {
 							blend_state = blend_state_color_opaque;
+
+							if (depth_pre_pass_enabled) {
+								// We already have a depth from the depth pre-pass, there is no need to write it again.
+								// In addition we can use COMPARE_OP_EQUAL instead of COMPARE_OP_LESS_OR_EQUAL.
+								// This way we can use the early depth test to discard transparent fragments before the fragment shader even starts.
+								depth_stencil.depth_compare_operator = RD::COMPARE_OP_EQUAL;
+								depth_stencil.enable_depth_write = false;
+							}
 
 							if (l & PIPELINE_COLOR_PASS_FLAG_SEPARATE_SPECULAR) {
 								shader_flags |= SHADER_COLOR_PASS_FLAG_SEPARATE_SPECULAR;


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/70214 and https://github.com/godotengine/godot/pull/70884

Fixes: https://github.com/godotengine/godot/issues/71249

While working on something else I noticed that there was a regression in master that caused objects with visibility fade alpha to not display unless the visibility was set to 0.0 and the fade was at fully opaque. If any alpha was introduced the object would disappear. 

The issue was caused by the depth-prepass optimization added in #70214 which makes it so that objects only draw where their depth matches the depth-prepass depth and it disables writing to the depth during the draw pass. This optimization hugely reduces the cost of drawing opaque geometry. However, it was tricky to apply to the transparent pass. In the end with #70884 we restricted the optimization to just objects that we know will get sent down the opaque pipeline (opaque objects transparent objects with alpha scissor or alpha hash). Even with the restriction we were needlessly applying the optimizations to both the opaque pipeline and the transparent pipeline (if a material passed our checks the object using our material should be sent down the opaque pipeline, not the transparent pipeline, so there is no reason to apply the optimization to the transparent pipeline).

Visibility fade introduces a case where an otherwise opaque object may get sent down the transparent pipeline. In which case, we need the transparent pipeline version to be compiled and ready to be used (i.e. _without_ the optimization). In the end, I realized that we never need to add the optimization to the transparent pipeline as the rendering logic checks for alpha scissor etc. and sends those materials down the opaque pipeline anyway.

_before:_

![Screenshot from 2023-01-09 09-47-28](https://user-images.githubusercontent.com/16521339/211373699-8d3721ad-28bb-4e5b-8527-a769fd7cd358.png)

_after:_

![Screenshot from 2023-01-09 09-46-34](https://user-images.githubusercontent.com/16521339/211373702-467222b7-9d37-4b0a-a302-5d61d4bf2ad1.png)

CC @Ansraer 
