### PR TITLE
C#: Ensure property.SetMethod is not null

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/OverridenProperties.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/OverridenProperties.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+#pragma warning disable CS0169
+#pragma warning disable CS0414
+
+namespace Godot.SourceGenerators.Sample
+{
+    public partial class OverridenPropertiesBase : Godot.Object
+    {
+        // This property is not readonly, has both a getter and a setter.
+        public virtual int MyProperty { get; set; } = 1;
+    }
+
+    public partial class OverridenPropertiesDerived : OverridenPropertiesBase
+    {
+        // This property overrides only the getter so it doesn't have a setter,
+        // but since it overrides a property with a setter it's not readonly.
+        public override int MyProperty => 10;
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -296,7 +296,7 @@ namespace Godot.SourceGenerators
             {
                 // TODO: We should still restore read-only properties after reloading assembly. Two possible ways: reflection or turn RestoreGodotObjectData into a constructor overload.
                 // Ignore properties without a getter, without a setter or with an init-only setter. Godot properties must be both readable and writable.
-                if (property.IsWriteOnly || property.IsReadOnly || property.SetMethod!.IsInitOnly)
+                if (property.IsWriteOnly || property.IsReadOnly || property.HasInitOnlySetMethod())
                     continue;
 
                 var marshalType = MarshalUtils.ConvertManagedTypeToMarshalType(property.Type, typeCache);
@@ -328,6 +328,9 @@ namespace Godot.SourceGenerators
                 yield return new GodotFieldData(field, marshalType.Value);
             }
         }
+
+        public static bool HasInitOnlySetMethod(this IPropertySymbol property)
+            => property.SetMethod != null && property.SetMethod.IsInitOnly;
 
         public static string Path(this Location location)
             => location.SourceTree?.GetLineSpan(location.SourceSpan).Path

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -158,7 +158,7 @@ namespace Godot.SourceGenerators
                 // Generate SetGodotClassPropertyValue
 
                 bool allPropertiesAreReadOnly = godotClassFields.All(fi => fi.FieldSymbol.IsReadOnly) &&
-                                                godotClassProperties.All(pi => pi.PropertySymbol.IsReadOnly || pi.PropertySymbol.SetMethod!.IsInitOnly);
+                                                godotClassProperties.All(pi => pi.PropertySymbol.IsReadOnly || pi.PropertySymbol.HasInitOnlySetMethod());
 
                 if (!allPropertiesAreReadOnly)
                 {
@@ -168,7 +168,7 @@ namespace Godot.SourceGenerators
                     isFirstEntry = true;
                     foreach (var property in godotClassProperties)
                     {
-                        if (property.PropertySymbol.IsReadOnly || property.PropertySymbol.SetMethod!.IsInitOnly)
+                        if (property.PropertySymbol.IsReadOnly || property.PropertySymbol.HasInitOnlySetMethod())
                             continue;
 
                         GeneratePropertySetter(property.PropertySymbol.Name,

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
@@ -145,7 +145,7 @@ namespace Godot.SourceGenerators
                     continue;
                 }
 
-                if (property.IsReadOnly || property.SetMethod!.IsInitOnly)
+                if (property.IsReadOnly || property.HasInitOnlySetMethod())
                 {
                     Common.ReportExportedMemberIsReadOnly(context, property);
                     continue;


### PR DESCRIPTION
Non-readonly properties may still not have a setter so we can't assume the `SetMethod` won't be null after only checking readonlyness.

- Fixes https://github.com/godotengine/godot/issues/71102