### PR TITLE
[MP] Convert _spawn_custom to a Callable property.

### DIFF
--- a/modules/multiplayer/doc_classes/MultiplayerSpawner.xml
+++ b/modules/multiplayer/doc_classes/MultiplayerSpawner.xml
@@ -5,20 +5,12 @@
 	</brief_description>
 	<description>
 		Spawnable scenes can be configured in the editor or through code (see [method add_spawnable_scene]).
-		Also supports custom node spawns through [method spawn], calling [method _spawn_custom] on all peers.
+		Also supports custom node spawns through [method spawn], calling [member spawn_function] on all peers.
 		Internally, [MultiplayerSpawner] uses [method MultiplayerAPI.object_configuration_add] to notify spawns passing the spawned node as the [code]object[/code] and itself as the [code]configuration[/code], and [method MultiplayerAPI.object_configuration_remove] to notify despawns in a similar way.
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_spawn_custom" qualifiers="virtual">
-			<return type="Node" />
-			<param index="0" name="data" type="Variant" />
-			<description>
-				Method called on all peers when a custom spawn was requested by the authority using [method spawn]. Should return a [Node] that is not in the scene tree.
-				[b]Note:[/b] Spawned nodes should [b]not[/b] be added to the scene with [method Node.add_child]. This is done automatically.
-			</description>
-		</method>
 		<method name="add_spawnable_scene">
 			<return type="void" />
 			<param index="0" name="path" type="String" />
@@ -49,12 +41,16 @@
 			<return type="Node" />
 			<param index="0" name="data" type="Variant" default="null" />
 			<description>
-				Requests a custom spawn, with [code]data[/code] passed to [method _spawn_custom] on all peers. Returns the locally spawned node instance already inside the scene tree, and added as a child of the node pointed by [member spawn_path].
+				Requests a custom spawn, with [code]data[/code] passed to [member spawn_function] on all peers. Returns the locally spawned node instance already inside the scene tree, and added as a child of the node pointed by [member spawn_path].
 				[b]Note:[/b] Spawnable scenes are spawned automatically. [method spawn] is only needed for custom spawns.
 			</description>
 		</method>
 	</methods>
 	<members>
+		<member name="spawn_function" type="Callable" setter="set_spawn_function" getter="get_spawn_function">
+			Method called on all peers when for every custom [method spawn] requested by the authority. Will receive the [code]data[/code] parameter, and should return a [Node] that is not in the scene tree.
+			[b]Note:[/b] The returned node should [b]not[/b] be added to the scene with [method Node.add_child]. This is done automatically.
+		</member>
 		<member name="spawn_limit" type="int" setter="set_spawn_limit" getter="get_spawn_limit" default="0">
 			Maximum nodes that is allowed to be spawned by this spawner. Includes both spawnable scenes and custom spawns.
 			When set to [code]0[/code] (the default), there is no limit.

--- a/modules/multiplayer/multiplayer_spawner.h
+++ b/modules/multiplayer/multiplayer_spawner.h
@@ -71,6 +71,7 @@ private:
 	ObjectID spawn_node;
 	HashMap<ObjectID, SpawnInfo> tracked_nodes;
 	uint32_t spawn_limit = 0;
+	Callable spawn_function;
 
 	void _update_spawn_node();
 	void _track(Node *p_node, const Variant &p_argument, int p_scene_id = INVALID_ID);
@@ -106,6 +107,8 @@ public:
 	void set_spawn_path(const NodePath &p_path);
 	uint32_t get_spawn_limit() const { return spawn_limit; }
 	void set_spawn_limit(uint32_t p_limit) { spawn_limit = p_limit; }
+	void set_spawn_function(Callable p_spawn_function) { spawn_function = p_spawn_function; }
+	Callable get_spawn_function() const { return spawn_function; }
 
 	const Variant get_spawn_argument(const ObjectID &p_id) const;
 	int find_spawnable_scene_index_from_object(const ObjectID &p_id) const;
@@ -113,8 +116,6 @@ public:
 	Node *spawn(const Variant &p_data = Variant());
 	Node *instantiate_custom(const Variant &p_data);
 	Node *instantiate_scene(int p_idx);
-
-	GDVIRTUAL1R(Node *, _spawn_custom, const Variant &);
 
 	MultiplayerSpawner() {}
 };


### PR DESCRIPTION
Renamed to "spawn_function".
Allow both custom spawn and auto spawn list to co-exist.

This makes it possible to implement custom spawn without being forced to attach a script to MultiplayerSpawner directly.

For compatibility with previous betas, add to your old extended MultiplayerSpawner:

```gdscript
# extends MultiplayerSpawner

func _init():
  spawn_function = _spawn_custom

# func _spawn_custom(data: Variant) -> Node:
#  ... Your beta10 code that
#  return node
```

E.g. from parent node:

```gdscript
extends Node

func _enter_tree():
  $MultiplayerSpawner.spawn_function = _spawn_node(data)

func _spawn_node(data: Variant) -> Node:
#  ... Your beta11 code that
#  return node