### PR TITLE
[3.x] Fix wrong `SpriteFrames` docs

### DIFF
--- a/doc/classes/AnimatedSprite.xml
+++ b/doc/classes/AnimatedSprite.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		[AnimatedSprite] is similar to the [Sprite] node, except it carries multiple textures as animation frames. Animations are created using a [SpriteFrames] resource, which allows you to import image files (or a folder containing said files) to provide the animation frames for the sprite. The [SpriteFrames] resource can be configured in the editor via the SpriteFrames bottom panel.
-		[b]Note:[/b] You can associate a set of normal or specular maps by creating additional [SpriteFrames] resources with a [code]_normal[/code] or [code]_specular[/code] suffix. For example, having 3 [SpriteFrames] resources [code]run[/code], [code]run_normal[/code], and [code]run_specular[/code] will make it so the [code]run[/code] animation uses normal and specular maps.
+		[b]Note:[/b] You can associate a set of normal maps by creating additional animations with a [code]_normal[/code] suffix. For example, having 2 animations [code]run[/code] and [code]run_normal[/code] will make it so the [code]run[/code] animation uses the normal map.
 	</description>
 	<tutorials>
 		<link title="2D Sprite animation">$DOCS_URL/tutorials/2d/2d_sprite_animation.html</link>

--- a/doc/classes/SpriteFrames.xml
+++ b/doc/classes/SpriteFrames.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		Sprite frame library for an [AnimatedSprite] or [AnimatedSprite3D] node. Contains frames and animation data for playback.
-		[b]Note:[/b] You can associate a set of normal maps by creating additional [SpriteFrames] resources with a [code]_normal[/code] suffix. For example, having 2 [SpriteFrames] resources [code]run[/code] and [code]run_normal[/code] will make it so the [code]run[/code] animation uses the normal map.
+		[b]Note:[/b] You can associate a set of normal maps by creating additional animations with a [code]_normal[/code] suffix. For example, having 2 animations [code]run[/code] and [code]run_normal[/code] will make it so the [code]run[/code] animation uses the normal map.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
* Fixed confusing wording about additional `SpriteFrames` resources (see https://github.com/godotengine/godot/pull/40269#discussion_r1061806804).
* In 3.x `AnimatedSprite` does not support specular maps, only normal maps ([source](https://github.com/godotengine/godot/blob/111de09c038b7646f7ee0bc20bcf0e15d4e28334/scene/2d/animated_sprite.cpp#L40)). Apparently this error happened during cherry-picking.
