### PR TITLE
Add Node::get_window() method.

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -421,6 +421,12 @@
 				Returns the node's [Viewport].
 			</description>
 		</method>
+		<method name="get_window" qualifiers="const">
+			<return type="Window" />
+			<description>
+				Returns the [Window] that contains this node. If the node is in the main window, this is equivalent to getting the root node ([code]get_tree().get_root()[/code]).
+			</description>
+		</method>
 		<method name="has_node" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="path" type="NodePath" />

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -39,6 +39,7 @@
 #include "scene/animation/tween.h"
 #include "scene/debugger/scene_debugger.h"
 #include "scene/main/multiplayer_api.h"
+#include "scene/main/window.h"
 #include "scene/resources/packed_scene.h"
 #include "scene/scene_string_names.h"
 #include "viewport.h"
@@ -1467,6 +1468,14 @@ Node *Node::find_parent(const String &p_pattern) const {
 	return nullptr;
 }
 
+Window *Node::get_window() const {
+	Viewport *vp = get_viewport();
+	if (vp) {
+		return vp->get_base_window();
+	}
+	return nullptr;
+}
+
 bool Node::is_ancestor_of(const Node *p_node) const {
 	ERR_FAIL_NULL_V(p_node, false);
 	Node *p = p_node->data.parent;
@@ -2858,6 +2867,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_physics_process_internal", "enable"), &Node::set_physics_process_internal);
 	ClassDB::bind_method(D_METHOD("is_physics_processing_internal"), &Node::is_physics_processing_internal);
 
+	ClassDB::bind_method(D_METHOD("get_window"), &Node::get_window);
 	ClassDB::bind_method(D_METHOD("get_tree"), &Node::get_tree);
 	ClassDB::bind_method(D_METHOD("create_tween"), &Node::create_tween);
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -37,6 +37,7 @@
 #include "scene/main/scene_tree.h"
 
 class Viewport;
+class Window;
 class SceneState;
 class Tween;
 class PropertyTweener;
@@ -320,6 +321,8 @@ public:
 	virtual void reparent(Node *p_parent, bool p_keep_global_transform = true);
 	Node *get_parent() const;
 	Node *find_parent(const String &p_pattern) const;
+
+	Window *get_window() const;
 
 	_FORCE_INLINE_ SceneTree *get_tree() const {
 		ERR_FAIL_COND_V(!data.tree, nullptr);


### PR DESCRIPTION
Syntax sugar to modify window from code.
e.g, `get_window().min_size = Vector2i(500, 200)`

See #71071 and #70863.

*Edit: changed according to https://github.com/godotengine/godot/pull/71071#issuecomment-1376852100, to use `get_window()` for current window not main window.*