### PR TITLE
Fix node name in the SceneTreeEditor allows a node to have no name

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -993,6 +993,10 @@ void SceneTreeEditor::_renamed() {
 	}
 
 	if (new_name == n->get_name()) {
+		if (which->get_text(0).is_empty()) {
+			which->set_text(0, new_name);
+		}
+
 		return;
 	}
 


### PR DESCRIPTION
Fixes: #70981

Regression occur at: 3a2abf7486f00005248ece35dc2c0b67afe3119e

When user deletes the name of a newly created node. Which currently has the name of its _class name_ and causes the statement below to **return** but forget to revert the name of the **tree item** in editor to the original state.

https://github.com/godotengine/godot/blob/269fa200d04ae96b0114b788e18df638c5fb164b/editor/scene_tree_editor.cpp#L995-L997


