### PR TITLE
Fix cancelling selection (pressing escape) while gizmo editing making uncommitted changes.

### DIFF
--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -356,6 +356,7 @@ bool CollisionShape2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_e
 					return false;
 				}
 
+				original_point = handles[edit_handle];
 				original = get_handle_value(edit_handle);
 				original_transform = node->get_global_transform();
 				last_point = original;
@@ -572,6 +573,11 @@ void CollisionShape2DEditor::edit(Node *p_node) {
 		_get_current_shape_type();
 
 	} else {
+		if (pressed) {
+			set_handle(edit_handle, original_point);
+			pressed = false;
+		}
+
 		edit_handle = -1;
 		shape_type = -1;
 

--- a/editor/plugins/collision_shape_2d_editor_plugin.h
+++ b/editor/plugins/collision_shape_2d_editor_plugin.h
@@ -71,6 +71,7 @@ class CollisionShape2DEditor : public Control {
 	bool pressed;
 	Variant original;
 	Transform2D original_transform;
+	Vector2 original_point;
 	Point2 last_point;
 
 	Variant get_handle_value(int idx) const;

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2103,6 +2103,11 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		}
 
 		if (_edit.mode == TRANSFORM_NONE) {
+			if (_edit.gizmo.is_valid()) {
+				// Restore.
+				_edit.gizmo->commit_handle(_edit.gizmo_handle, _edit.gizmo_handle_secondary, _edit.gizmo_initial_value, true);
+				_edit.gizmo = Ref<EditorNode3DGizmo>();
+			}
 			if (k->get_keycode() == Key::ESCAPE && !cursor.region_select) {
 				_clear_selected();
 				return;


### PR DESCRIPTION
* Pressing escape while gizmo editing will discard the changes made during that edit 'session'

Fixes #71113

https://user-images.githubusercontent.com/41730826/211541019-2aa85e70-3b7e-49b0-88ad-f71ce65b65df.mp4

https://user-images.githubusercontent.com/41730826/211541064-da138337-501f-4fbd-b215-a33b00fa5b4f.mp4

