### PR TITLE
Fix Callable call error reporting.

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1055,7 +1055,7 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 				if (ce.error == Callable::CallError::CALL_ERROR_INVALID_METHOD && !ClassDB::class_exists(target->get_class_name())) {
 					//most likely object is not initialized yet, do not throw error.
 				} else {
-					ERR_PRINT("Error calling from signal '" + String(p_name) + "' to callable: " + Variant::get_callable_error_text(c.callable, args, argc + c.callable.get_bound_arguments_count(), ce) + ".");
+					ERR_PRINT("Error calling from signal '" + String(p_name) + "' to callable: " + Variant::get_callable_error_text(c.callable, args, argc, ce) + ".");
 					err = ERR_METHOD_NOT_FOUND;
 				}
 			}

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -117,6 +117,7 @@ Callable Callable::bindv(const Array &p_arguments) {
 }
 
 Callable Callable::unbind(int p_argcount) const {
+	ERR_FAIL_COND_V_MSG(p_argcount <= 0, Callable(*this), "Amount of unbind() arguments must be 1 or greater.");
 	return Callable(memnew(CallableCustomUnbind(*this, p_argcount)));
 }
 
@@ -157,6 +158,27 @@ int Callable::get_bound_arguments_count() const {
 	} else {
 		return 0;
 	}
+}
+
+void Callable::get_bound_arguments_ref(Vector<Variant> &r_arguments, int &r_argcount) const {
+	if (!is_null() && is_custom()) {
+		custom->get_bound_arguments(r_arguments, r_argcount);
+	} else {
+		r_arguments.clear();
+		r_argcount = 0;
+	}
+}
+
+Array Callable::get_bound_arguments() const {
+	Vector<Variant> arr;
+	int ac;
+	get_bound_arguments_ref(arr, ac);
+	Array ret;
+	ret.resize(arr.size());
+	for (int i = 0; i < arr.size(); i++) {
+		ret[i] = arr[i];
+	}
+	return ret;
 }
 
 CallableCustom *Callable::get_custom() const {
@@ -368,6 +390,11 @@ const Callable *CallableCustom::get_base_comparator() const {
 
 int CallableCustom::get_bound_arguments_count() const {
 	return 0;
+}
+
+void CallableCustom::get_bound_arguments(Vector<Variant> &r_arguments, int &r_argcount) const {
+	r_arguments = Vector<Variant>();
+	r_argcount = 0;
 }
 
 CallableCustom::CallableCustom() {

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -108,6 +108,8 @@ public:
 	StringName get_method() const;
 	CallableCustom *get_custom() const;
 	int get_bound_arguments_count() const;
+	void get_bound_arguments_ref(Vector<Variant> &r_arguments, int &r_argcount) const; // Internal engine use, the exposed one is below.
+	Array get_bound_arguments() const;
 
 	uint32_t hash() const;
 
@@ -149,6 +151,7 @@ public:
 	virtual Error rpc(int p_peer_id, const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) const;
 	virtual const Callable *get_base_comparator() const;
 	virtual int get_bound_arguments_count() const;
+	virtual void get_bound_arguments(Vector<Variant> &r_arguments, int &r_argcount) const;
 
 	CallableCustom();
 	virtual ~CallableCustom() {}

--- a/core/variant/callable_bind.h
+++ b/core/variant/callable_bind.h
@@ -52,6 +52,7 @@ public:
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 	virtual const Callable *get_base_comparator() const override;
 	virtual int get_bound_arguments_count() const override;
+	virtual void get_bound_arguments(Vector<Variant> &r_arguments, int &r_argcount) const override;
 	Callable get_callable() { return callable; }
 	Vector<Variant> get_binds() { return binds; }
 
@@ -77,6 +78,7 @@ public:
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 	virtual const Callable *get_base_comparator() const override;
 	virtual int get_bound_arguments_count() const override;
+	virtual void get_bound_arguments(Vector<Variant> &r_arguments, int &r_argcount) const override;
 
 	Callable get_callable() { return callable; }
 	int get_unbinds() { return argcount; }

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2017,6 +2017,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Callable, get_object_id, sarray(), varray());
 	bind_method(Callable, get_method, sarray(), varray());
 	bind_method(Callable, get_bound_arguments_count, sarray(), varray());
+	bind_method(Callable, get_bound_arguments, sarray(), varray());
 	bind_method(Callable, hash, sarray(), varray());
 	bind_method(Callable, bindv, sarray("arguments"), varray());
 	bind_method(Callable, unbind, sarray("argcount"), varray());

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -107,6 +107,12 @@
 				Calls the method represented by this [Callable]. Unlike [method call], this method expects all arguments to be contained inside the [param arguments] [Array].
 			</description>
 		</method>
+		<method name="get_bound_arguments" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Return the bound arguments (as long as [method get_bound_arguments_count] is greater than zero), or empty (if [method get_bound_arguments_count] is less than or equal to zero).
+			</description>
+		</method>
 		<method name="get_bound_arguments_count" qualifiers="const">
 			<return type="int" />
 			<description>


### PR DESCRIPTION
* Fix potential crash when using bind in `Variant::get_callable_error_text()`
* Properly compute bound arguments so they can be properly shown.
* Add a function to obtain the actual bound arguments.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
