### PR TITLE
Propagate allowed input types to `event_listener` when setting them on `InputEventConfigurationDialog`

### DIFF
--- a/editor/event_listener_line_edit.cpp
+++ b/editor/event_listener_line_edit.cpp
@@ -168,8 +168,8 @@ void EventListenerLineEdit::clear_event() {
 	}
 }
 
-void EventListenerLineEdit::set_allowed_input_types(int input_types) {
-	allowed_input_types = input_types;
+void EventListenerLineEdit::set_allowed_input_types(int p_type_masks) {
+	allowed_input_types = p_type_masks;
 }
 
 int EventListenerLineEdit::get_allowed_input_types() const {

--- a/editor/event_listener_line_edit.h
+++ b/editor/event_listener_line_edit.h
@@ -67,7 +67,7 @@ public:
 	Ref<InputEvent> get_event() const;
 	void clear_event();
 
-	void set_allowed_input_types(int input_types);
+	void set_allowed_input_types(int p_type_masks);
 	int get_allowed_input_types() const;
 
 	void grab_focus();

--- a/editor/input_event_configuration_dialog.cpp
+++ b/editor/input_event_configuration_dialog.cpp
@@ -515,6 +515,7 @@ Ref<InputEvent> InputEventConfigurationDialog::get_event() const {
 
 void InputEventConfigurationDialog::set_allowed_input_types(int p_type_masks) {
 	allowed_input_types = p_type_masks;
+	event_listener->set_allowed_input_types(p_type_masks);
 }
 
 InputEventConfigurationDialog::InputEventConfigurationDialog() {


### PR DESCRIPTION
Whoops - in the Editor Settings shortcuts, the event listener would accept mouse and joypad inputs even though those are not allowed on the parent InputEventConfigurationDialog.