### PR TITLE
Revert setting path when `ResourceFormatLoader::CACHE_MODE_IGNORE`

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -602,13 +602,9 @@ Error ResourceLoaderText::load() {
 		resource_current++;
 
 		int_resources[id] = res; //always assign int resources
-		if (do_assign) {
-			if (cache_mode == ResourceFormatLoader::CACHE_MODE_IGNORE) {
-				res->set_path(path);
-			} else {
-				res->set_path(path, cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE);
-				res->set_scene_unique_id(id);
-			}
+		if (do_assign && cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
+			res->set_path(path, cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE);
+			res->set_scene_unique_id(id);
 		}
 
 		Dictionary missing_resource_properties;


### PR DESCRIPTION
[As discussed](https://chat.godotengine.org/channel/gdscript?msg=Je2zvNDr4nsgrFr2i) with @reduz in the Godot contributors chat.

The current behaviour could be linked to a multitude of reloading issues. To cite Juan:
> If cache mode is IGNORE, it should never set the path, because there can only be a single resource using a single path, and cache mode IGNORE is used in all sort of situations when you want to load a version of the resource without setting the path
