### PR TITLE
Ensure that the cached layout mode is in sync

### DIFF
--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -727,6 +727,7 @@ void ControlEditorToolbar::_anchors_preset_selected(int p_preset) {
 	for (Node *E : selection) {
 		Control *control = Object::cast_to<Control>(E);
 		if (control) {
+			undo_redo->add_do_property(control, "layout_mode", LayoutMode::LAYOUT_MODE_ANCHORS);
 			undo_redo->add_do_property(control, "anchors_preset", preset);
 			undo_redo->add_undo_method(control, "_edit_set_state", control->_edit_get_state());
 		}

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -864,6 +864,14 @@ void Control::_set_layout_mode(LayoutMode p_mode) {
 	}
 }
 
+void Control::_update_layout_mode() {
+	LayoutMode computed_layout = _get_layout_mode();
+	if (data.stored_layout_mode != computed_layout) {
+		data.stored_layout_mode = computed_layout;
+		notify_property_list_changed();
+	}
+}
+
 Control::LayoutMode Control::_get_layout_mode() const {
 	Node *parent_node = get_parent_control();
 	// In these modes the property is read-only.
@@ -2870,6 +2878,8 @@ void Control::_notification(int p_notification) {
 			data.parent_window = Object::cast_to<Window>(parent_node);
 
 			data.theme_owner->assign_theme_on_parented(this);
+
+			_update_layout_mode();
 		} break;
 
 		case NOTIFICATION_UNPARENTED: {

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -280,6 +280,7 @@ private:
 	void _compute_anchors(Rect2 p_rect, const real_t p_offsets[4], real_t (&r_anchors)[4]);
 
 	void _set_layout_mode(LayoutMode p_mode);
+	void _update_layout_mode();
 	LayoutMode _get_layout_mode() const;
 	LayoutMode _get_default_layout_mode() const;
 	void _set_anchors_layout_preset(int p_preset);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/71178.

I missed this in https://github.com/godotengine/godot/pull/70882. Now that the relationship between the two editor-only properties is validated more strictly, some operations require us to set the layout mode beforehand. This doesn't affect setting anchors directly, using handles or `set_anchor`, `set_anchors_preset`, etc. But it does affect the inspector and other parts of the editor UI which need a bit more work to keep in sync.

With this PR I fix two cases:

- Controls now check for the node they've been parented to to update the layout mode, if necessary (without changing anything else, so user changes should be preserved).
- Using the toolbar to change the anchors preset on controls currently in the "Position" mode works again (changing the preset with the inspector didn't suffer).