### PR TITLE
Make `Tween::stop()` consistent with AnimationPlayer API

### DIFF
--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -197,12 +197,6 @@
 				You can make the [Tween] parallel by default by using [method set_parallel].
 			</description>
 		</method>
-		<method name="pause">
-			<return type="void" />
-			<description>
-				Pauses the tweening. The animation can be resumed by using [method play].
-			</description>
-		</method>
 		<method name="play">
 			<return type="void" />
 			<description>
@@ -264,8 +258,10 @@
 		</method>
 		<method name="stop">
 			<return type="void" />
+			<param index="0" name="reset" type="bool" default="true" />
 			<description>
 				Stops the tweening and resets the [Tween] to its initial state. This will not remove any appended [Tweener]s.
+				If [param reset] is [code]false[/code], pauses the tweening. The animation can be resumed by using [method play].
 			</description>
 		</method>
 		<method name="tween_callback">

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -134,15 +134,13 @@ void Tween::append(Ref<Tweener> p_tweener) {
 	tweeners.write[current_step].push_back(p_tweener);
 }
 
-void Tween::stop() {
-	started = false;
+void Tween::stop(bool p_reset) {
 	running = false;
 	dead = false;
-	total_time = 0;
-}
-
-void Tween::pause() {
-	running = false;
+	if (p_reset) {
+		started = false;
+		total_time = 0;
+	}
 }
 
 void Tween::play() {
@@ -394,8 +392,7 @@ void Tween::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("tween_method", "method", "from", "to", "duration"), &Tween::tween_method);
 
 	ClassDB::bind_method(D_METHOD("custom_step", "delta"), &Tween::custom_step);
-	ClassDB::bind_method(D_METHOD("stop"), &Tween::stop);
-	ClassDB::bind_method(D_METHOD("pause"), &Tween::pause);
+	ClassDB::bind_method(D_METHOD("stop", "reset"), &Tween::stop, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("play"), &Tween::play);
 	ClassDB::bind_method(D_METHOD("kill"), &Tween::kill);
 	ClassDB::bind_method(D_METHOD("get_total_elapsed_time"), &Tween::get_total_time);

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -136,8 +136,7 @@ public:
 	void append(Ref<Tweener> p_tweener);
 
 	bool custom_step(double p_delta);
-	void stop();
-	void pause();
+	void stop(bool p_reset = true);
 	void play();
 	void kill();
 


### PR DESCRIPTION
This consistency is slightly related to https://github.com/godotengine/godot-proposals/issues/6043.

Whether the `AnimationPlayer` has a `pause()` method or not continues to be discussed in #56645. It may seem to be bikesheded, but the current inconsistent APIs is definitely not good.

IMO, I recommend making it the default to have `reset` as an argument to `stop()` for now.

This way, if we implement `pause()` methods in the future, it can be easily implemented in all classes as a wrapper function by using the same procedure. CC @KoBeWi 