### PR TITLE
Automatically reparent editor progress dialog to avoid error spam.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -608,6 +608,9 @@ void EditorNode::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
+			if (progress_dialog) {
+				progress_dialog->queue_free();
+			}
 			editor_data.save_editor_external_data();
 			FileAccess::set_file_close_fail_notify_callback(nullptr);
 			log->deinit(); // Do not get messages anymore.
@@ -4307,7 +4310,7 @@ bool EditorNode::is_object_of_custom_type(const Object *p_object, const StringNa
 void EditorNode::progress_add_task(const String &p_task, const String &p_label, int p_steps, bool p_can_cancel) {
 	if (singleton->cmdline_export_mode) {
 		print_line(p_task + ": begin: " + p_label + " steps: " + itos(p_steps));
-	} else {
+	} else if (singleton->progress_dialog) {
 		singleton->progress_dialog->add_task(p_task, p_label, p_steps, p_can_cancel);
 	}
 }
@@ -4316,15 +4319,17 @@ bool EditorNode::progress_task_step(const String &p_task, const String &p_state,
 	if (singleton->cmdline_export_mode) {
 		print_line("\t" + p_task + ": step " + itos(p_step) + ": " + p_state);
 		return false;
-	} else {
+	} else if (singleton->progress_dialog) {
 		return singleton->progress_dialog->task_step(p_task, p_state, p_step, p_force_refresh);
+	} else {
+		return false;
 	}
 }
 
 void EditorNode::progress_end_task(const String &p_task) {
 	if (singleton->cmdline_export_mode) {
 		print_line(p_task + ": end");
-	} else {
+	} else if (singleton->progress_dialog) {
 		singleton->progress_dialog->end_task(p_task);
 	}
 }
@@ -6289,7 +6294,6 @@ EditorNode::EditorNode() {
 	resource_preview = memnew(EditorResourcePreview);
 	add_child(resource_preview);
 	progress_dialog = memnew(ProgressDialog);
-	gui_base->add_child(progress_dialog);
 
 	// Take up all screen.
 	gui_base->set_anchor(SIDE_RIGHT, Control::ANCHOR_END);

--- a/editor/progress_dialog.cpp
+++ b/editor/progress_dialog.cpp
@@ -32,6 +32,7 @@
 
 #include "core/object/message_queue.h"
 #include "core/os/os.h"
+#include "editor/editor_node.h"
 #include "editor/editor_scale.h"
 #include "main/main.h"
 #include "servers/display_server.h"
@@ -133,6 +134,14 @@ void BackgroundProgress::end_task(const String &p_task) {
 ProgressDialog *ProgressDialog::singleton = nullptr;
 
 void ProgressDialog::_notification(int p_what) {
+	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
+		if (!is_visible()) {
+			Node *p = get_parent();
+			if (p) {
+				p->remove_child(this);
+			}
+		}
+	}
 }
 
 void ProgressDialog::_popup() {
@@ -146,8 +155,17 @@ void ProgressDialog::_popup() {
 	main->set_offset(SIDE_TOP, style->get_margin(SIDE_TOP));
 	main->set_offset(SIDE_BOTTOM, -style->get_margin(SIDE_BOTTOM));
 
-	//raise();
-	popup_centered(ms);
+	EditorNode *ed = EditorNode::get_singleton();
+	if (ed && !is_inside_tree()) {
+		Window *w = ed->get_window();
+		while (w && w->get_exclusive_child()) {
+			w = w->get_exclusive_child();
+		}
+		if (w && w != this) {
+			w->add_child(this);
+			popup_centered(ms);
+		}
+	}
 }
 
 void ProgressDialog::add_task(const String &p_task, const String &p_label, int p_steps, bool p_can_cancel) {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -285,6 +285,7 @@ public:
 	bool is_wrapping_controls() const;
 	void child_controls_changed();
 
+	Window *get_exclusive_child() const { return exclusive_child; };
 	Window *get_parent_visible_window() const;
 	Viewport *get_parent_viewport() const;
 	void popup(const Rect2i &p_rect = Rect2i());


### PR DESCRIPTION
Sets editor `ProgressDialog` to be child of the topmost exclusive child of the editor when it's shown and detach it when hidden to avoid `Transient parent has another exclusive child.`.

Fixes https://github.com/godotengine/godot/issues/67122