### PR TITLE
Split pause() from AnimationPlayer's stop()

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -137,6 +137,13 @@
 				Returns [code]true[/code] if playing an animation.
 			</description>
 		</method>
+		<method name="pause">
+			<return type="void" />
+			<description>
+				Pauses the currently playing animation. The [member current_animation_position] will be kept and calling [method play] or [method play_backwards] without arguments or with the same animation name as [member assigned_animation] will resume the animation.
+				See also [method stop].
+			</description>
+		</method>
 		<method name="play">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" default="&quot;&quot;" />
@@ -201,10 +208,9 @@
 		</method>
 		<method name="stop">
 			<return type="void" />
-			<param index="0" name="reset" type="bool" default="true" />
 			<description>
-				Stops or pauses the currently playing animation. If [param reset] is [code]true[/code], the animation position is reset to [code]0[/code] and the playback speed is reset to [code]1.0[/code].
-				If [param reset] is [code]false[/code], the [member current_animation_position] will be kept and calling [method play] or [method play_backwards] without arguments or with the same animation name as [member assigned_animation] will resume the animation.
+				Stops the currently playing animation. The animation position is reset to [code]0[/code] and the playback speed is reset to [code]1.0[/code].
+				See also [method pause].
 			</description>
 		</method>
 	</methods>

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -267,7 +267,7 @@ void AnimationPlayerEditor::_stop_pressed() {
 		return;
 	}
 
-	player->stop(false);
+	player->pause();
 	play->set_pressed(false);
 	stop->set_pressed(true);
 }
@@ -1155,7 +1155,7 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_set, bool 
 
 			player->seek_delta(pos, pos - cpos);
 		} else {
-			player->stop(true);
+			player->stop();
 			player->seek(pos, true);
 		}
 	}

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1731,18 +1731,12 @@ String AnimationPlayer::get_assigned_animation() const {
 	return playback.assigned;
 }
 
-void AnimationPlayer::stop(bool p_reset) {
-	_stop_playing_caches();
-	Playback &c = playback;
-	c.blend.clear();
-	if (p_reset) {
-		c.current.from = nullptr;
-		c.current.speed_scale = 1;
-		c.current.pos = 0;
-	}
-	_set_process(false);
-	queued.clear();
-	playing = false;
+void AnimationPlayer::pause() {
+	_stop_internal(false);
+}
+
+void AnimationPlayer::stop() {
+	_stop_internal(true);
 }
 
 void AnimationPlayer::set_speed_scale(float p_speed) {
@@ -1957,6 +1951,20 @@ void AnimationPlayer::_set_process(bool p_process, bool p_force) {
 	processing = p_process;
 }
 
+void AnimationPlayer::_stop_internal(bool p_reset) {
+	_stop_playing_caches();
+	Playback &c = playback;
+	c.blend.clear();
+	if (p_reset) {
+		c.current.from = nullptr;
+		c.current.speed_scale = 1;
+		c.current.pos = 0;
+	}
+	_set_process(false);
+	queued.clear();
+	playing = false;
+}
+
 void AnimationPlayer::animation_set_next(const StringName &p_animation, const StringName &p_next) {
 	ERR_FAIL_COND_MSG(!animation_set.has(p_animation), vformat("Animation not found: %s.", p_animation));
 	animation_set[p_animation].next = p_next;
@@ -2119,7 +2127,8 @@ void AnimationPlayer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("play", "name", "custom_blend", "custom_speed", "from_end"), &AnimationPlayer::play, DEFVAL(""), DEFVAL(-1), DEFVAL(1.0), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("play_backwards", "name", "custom_blend"), &AnimationPlayer::play_backwards, DEFVAL(""), DEFVAL(-1));
-	ClassDB::bind_method(D_METHOD("stop", "reset"), &AnimationPlayer::stop, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("pause"), &AnimationPlayer::pause);
+	ClassDB::bind_method(D_METHOD("stop"), &AnimationPlayer::stop);
 	ClassDB::bind_method(D_METHOD("is_playing"), &AnimationPlayer::is_playing);
 
 	ClassDB::bind_method(D_METHOD("set_current_animation", "anim"), &AnimationPlayer::set_current_animation);

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -294,6 +294,7 @@ private:
 	void _animation_changed(const StringName &p_name);
 
 	void _set_process(bool p_process, bool p_force = false);
+	void _stop_internal(bool p_reset);
 
 	bool playing = false;
 
@@ -346,7 +347,8 @@ public:
 	void queue(const StringName &p_name);
 	Vector<String> get_queue();
 	void clear_queue();
-	void stop(bool p_reset = true);
+	void pause();
+	void stop();
 	bool is_playing() const;
 	String get_current_animation() const;
 	void set_current_animation(const String &p_anim);

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -60,7 +60,7 @@ void Tweener::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("finished"));
 }
 
-void Tween::start_tweeners() {
+void Tween::_start_tweeners() {
 	if (tweeners.is_empty()) {
 		dead = true;
 		ERR_FAIL_MSG("Tween without commands, aborting.");
@@ -68,6 +68,15 @@ void Tween::start_tweeners() {
 
 	for (Ref<Tweener> &tweener : tweeners.write[current_step]) {
 		tweener->start();
+	}
+}
+
+void Tween::_stop_internal(bool p_reset) {
+	running = false;
+	if (p_reset) {
+		started = false;
+		dead = false;
+		total_time = 0;
 	}
 }
 
@@ -135,14 +144,11 @@ void Tween::append(Ref<Tweener> p_tweener) {
 }
 
 void Tween::stop() {
-	started = false;
-	running = false;
-	dead = false;
-	total_time = 0;
+	_stop_internal(true);
 }
 
 void Tween::pause() {
-	running = false;
+	_stop_internal(false);
 }
 
 void Tween::play() {
@@ -278,7 +284,7 @@ bool Tween::step(double p_delta) {
 		current_step = 0;
 		loops_done = 0;
 		total_time = 0;
-		start_tweeners();
+		_start_tweeners();
 		started = true;
 	}
 
@@ -319,7 +325,7 @@ bool Tween::step(double p_delta) {
 				} else {
 					emit_signal(SNAME("loop_finished"), loops_done);
 					current_step = 0;
-					start_tweeners();
+					_start_tweeners();
 #ifdef DEBUG_ENABLED
 					if (loops <= 0 && Math::is_equal_approx(rem_delta, initial_delta)) {
 						if (!potential_infinite) {
@@ -332,7 +338,7 @@ bool Tween::step(double p_delta) {
 #endif
 				}
 			} else {
-				start_tweeners();
+				_start_tweeners();
 			}
 		}
 	}

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -123,7 +123,8 @@ private:
 	typedef real_t (*interpolater)(real_t t, real_t b, real_t c, real_t d);
 	static interpolater interpolaters[TRANS_MAX][EASE_MAX];
 
-	void start_tweeners();
+	void _start_tweeners();
+	void _stop_internal(bool p_reset);
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Counter-PR to #71208
This is a minimal change, unlike #56645

`stop()` will function exactly the same as it did.
`stop(false)` is now `pause()`.
Everything else stays the same.