### PR TITLE
Fix crash in CodeEdit when caret column exceeds line length.

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2899,6 +2899,7 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 	const int caret_line = get_caret_line();
 	const int caret_column = get_caret_column();
 	const String line = get_line(caret_line);
+	ERR_FAIL_INDEX_MSG(caret_column - 1, line.length(), "Caret column exceeds line length.");
 
 	if (caret_column > 0 && line[caret_column - 1] == '(' && !code_completion_forced) {
 		cancel_code_completion();


### PR DESCRIPTION
Fixes #68176

Unlikely to ever occur but hey, it closes an issue 😄