### PR TITLE
OpenXR: Do not use SRGB swapchains with OpenGL

### DIFF
--- a/modules/openxr/extensions/openxr_opengl_extension.cpp
+++ b/modules/openxr/extensions/openxr_opengl_extension.cpp
@@ -157,7 +157,6 @@ void *OpenXROpenGLExtension::set_session_create_and_get_next_pointer(void *p_nex
 }
 
 void OpenXROpenGLExtension::get_usable_swapchain_formats(Vector<int64_t> &p_usable_swap_chains) {
-	p_usable_swap_chains.push_back(GL_SRGB8_ALPHA8);
 	p_usable_swap_chains.push_back(GL_RGBA8);
 }
 


### PR DESCRIPTION
This PR removes SRGB swapchain options for use with OpenGL, to avoid the hardware doing an additional SRGB conversion and thus causing colors to differ from other rendering paths.

In practice, this fixes render results to appear brighter on the Pico 4 than on PC and with different renderers.

*I can only test things on Pico, would be great if somebody could test this PR on a different headset.*