### PR TITLE
Make SubViewportContainer's adjustments optional

### DIFF
--- a/doc/classes/SubViewport.xml
+++ b/doc/classes/SubViewport.xml
@@ -7,6 +7,7 @@
 		[SubViewport] Isolates a rectangular region of a scene to be displayed independently. This can be used, for example, to display UI in 3D space.
 		[b]Note:[/b] [SubViewport] is a [Viewport] that isn't a [Window], i.e. it doesn't draw anything by itself. To display anything, [SubViewport] must have a non-zero size and be either put inside a [SubViewportContainer] or assigned to a [ViewportTexture].
 		[b]Note:[/b] [InputEvent]s are not passed to a standalone [SubViewport] by default. To ensure [InputEvent] propagation, a [SubViewport] can be placed inside of a [SubViewportContainer].
+		[b]Note:[/b] If this node is under [SubViewportContainer], some of its properties are being overridden by the container.
 	</description>
 	<tutorials>
 		<link title="Using Viewports">$DOCS_URL/tutorials/rendering/viewports.html</link>

--- a/doc/classes/SubViewportContainer.xml
+++ b/doc/classes/SubViewportContainer.xml
@@ -7,6 +7,7 @@
 		A container that displays the contents of underlying [SubViewport] child nodes. It uses the combined size of the [SubViewport]s as minimum size, unless [member stretch] is enabled.
 		[b]Note:[/b] Changing a [SubViewportContainer]'s [member Control.scale] will cause its contents to appear distorted. To change its visual size without causing distortion, adjust the node's margins instead (if it's not already in a container).
 		[b]Note:[/b] The [SubViewportContainer] forwards mouse-enter and mouse-exit notifications to its sub-viewports.
+		[b]Note:[/b] The SubViewportContainer will automatically modify sub-viewports' [member SubViewport.render_target_update_mode] and [member Viewport.handle_input_locally], unless [member adjust_viewport_properties] is disabled.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -21,6 +22,10 @@
 	</methods>
 	<members>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="1" />
+		<member name="adjust_viewport_properties" type="bool" setter="set_adjust_viewport_properties" getter="is_adjust_viewport_properties_enabled" default="true">
+			If [code]true[/code], sub-viewports' [member SubViewport.render_target_update_mode] will be automatically set based on container's visibility. [member Viewport.handle_input_locally] will be set to [code]false[/code]. This matches the default intended [SubViewportContainer] usage, but you can disable this property for custom behavior.
+			The property takes effect when [SubViewportContainer] enters the scene tree or changes visibility (including inside the editor). Setting this property from [code]false[/code] to [code]true[/code] will take effect immediately.
+		</member>
 		<member name="mouse_target" type="bool" setter="set_mouse_target" getter="is_mouse_target_enabled" default="false">
 			Configure, if either the [SubViewportContainer] or alternatively the [Control] nodes of its [SubViewport] children should be available as targets of mouse-related functionalities, like identifying the drop target in drag-and-drop operations or cursor shape of hovered [Control] node.
 			If [code]false[/code], the [Control] nodes inside its [SubViewport] children are considered as targets.

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -67,6 +67,21 @@ bool SubViewportContainer::is_stretch_enabled() const {
 	return stretch;
 }
 
+void SubViewportContainer::set_adjust_viewport_properties(bool p_enable) {
+	if (adjust_viewport_properties == p_enable) {
+		return;
+	}
+
+	adjust_viewport_properties = p_enable;
+	if (adjust_viewport_properties) {
+		_queue_adjust_viewport_properties();
+	}
+}
+
+bool SubViewportContainer::is_adjust_viewport_properties_enabled() const {
+	return adjust_viewport_properties;
+}
+
 void SubViewportContainer::set_stretch_shrink(int p_shrink) {
 	ERR_FAIL_COND(p_shrink < 1);
 	if (shrink == p_shrink) {
@@ -109,25 +124,18 @@ Vector<int> SubViewportContainer::get_allowed_size_flags_vertical() const {
 
 void SubViewportContainer::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_READY: {
+			connect("child_entered_tree", callable_mp(this, &SubViewportContainer::_queue_adjust_viewport_properties).unbind(1));
+		}
+
 		case NOTIFICATION_RESIZED: {
 			recalc_force_viewport_sizes();
 		} break;
 
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			for (int i = 0; i < get_child_count(); i++) {
-				SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
-				if (!c) {
-					continue;
-				}
-
-				if (is_visible_in_tree()) {
-					c->set_update_mode(SubViewport::UPDATE_ALWAYS);
-				} else {
-					c->set_update_mode(SubViewport::UPDATE_DISABLED);
-				}
-
-				c->set_handle_input_locally(false); //do not handle input locally here
+			if (adjust_viewport_properties) {
+				_queue_adjust_viewport_properties();
 			}
 		} break;
 
@@ -168,6 +176,33 @@ void SubViewportContainer::_notify_viewports(int p_notification) {
 		}
 		c->notification(p_notification);
 	}
+}
+
+void SubViewportContainer::_adjust_viewport_properties() {
+	property_adjust_queued = false;
+
+	for (int i = 0; i < get_child_count(); i++) {
+		SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
+		if (!c) {
+			continue;
+		}
+
+		if (is_visible_in_tree()) {
+			c->set_update_mode(SubViewport::UPDATE_ALWAYS);
+		} else {
+			c->set_update_mode(SubViewport::UPDATE_DISABLED);
+		}
+
+		c->set_handle_input_locally(false);
+	}
+}
+
+void SubViewportContainer::_queue_adjust_viewport_properties() {
+	if (property_adjust_queued) {
+		return;
+	}
+	callable_mp(this, &SubViewportContainer::_adjust_viewport_properties).call_deferred();
+	property_adjust_queued = true;
 }
 
 void SubViewportContainer::input(const Ref<InputEvent> &p_event) {
@@ -297,9 +332,16 @@ void SubViewportContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mouse_target", "amount"), &SubViewportContainer::set_mouse_target);
 	ClassDB::bind_method(D_METHOD("is_mouse_target_enabled"), &SubViewportContainer::is_mouse_target_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_adjust_viewport_properties", "enable"), &SubViewportContainer::set_adjust_viewport_properties);
+	ClassDB::bind_method(D_METHOD("is_adjust_viewport_properties_enabled"), &SubViewportContainer::is_adjust_viewport_properties_enabled);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stretch"), "set_stretch", "is_stretch_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "stretch_shrink", PROPERTY_HINT_RANGE, "1,32,1,or_greater"), "set_stretch_shrink", "get_stretch_shrink");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mouse_target"), "set_mouse_target", "is_mouse_target_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "adjust_viewport_properties"), "set_adjust_viewport_properties", "is_adjust_viewport_properties_enabled");
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stretch"), "set_stretch", "is_stretch_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "stretch_shrink"), "set_stretch_shrink", "get_stretch_shrink");
 
 	GDVIRTUAL_BIND(_propagate_input_event, "event");
 }

--- a/scene/gui/subviewport_container.h
+++ b/scene/gui/subviewport_container.h
@@ -38,11 +38,15 @@ class SubViewportContainer : public Container {
 	bool stretch = false;
 	int shrink = 1;
 	bool mouse_target = false;
+	bool adjust_viewport_properties = true;
+	bool property_adjust_queued = false;
 
 	void _notify_viewports(int p_notification);
 	bool _is_propagated_in_gui_input(const Ref<InputEvent> &p_event);
 	void _send_event_to_viewports(const Ref<InputEvent> &p_event);
 	void _propagate_nonpositional_event(const Ref<InputEvent> &p_event);
+	void _adjust_viewport_properties();
+	void _queue_adjust_viewport_properties();
 
 protected:
 	void _notification(int p_what);
@@ -56,6 +60,9 @@ protected:
 public:
 	void set_stretch(bool p_enable);
 	bool is_stretch_enabled() const;
+
+	void set_adjust_viewport_properties(bool p_enable);
+	bool is_adjust_viewport_properties_enabled() const;
 
 	virtual void input(const Ref<InputEvent> &p_event) override;
 	virtual void unhandled_input(const Ref<InputEvent> &p_event) override;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -5592,12 +5592,14 @@ void SubViewport::_validate_property(PropertyInfo &p_property) const {
 	if (!Engine::get_singleton()->is_editor_hint()) {
 		return;
 	}
-	if (p_property.name == "size") {
-		SubViewportContainer *parent_svc = Object::cast_to<SubViewportContainer>(get_parent());
-		if (parent_svc && parent_svc->is_stretch_enabled()) {
-			p_property.usage = PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY;
-		} else {
-			p_property.usage = PROPERTY_USAGE_DEFAULT;
+	SubViewportContainer *parent_svc = Object::cast_to<SubViewportContainer>(get_parent());
+	if (parent_svc) {
+		if (parent_svc->is_stretch_enabled() && p_property.name == "size") {
+			p_property.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY;
+		}
+
+		if (parent_svc->is_adjust_viewport_properties_enabled() && (p_property.name == "render_target_update_mode" || p_property.name == "handle_input_locally")) {
+			p_property.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY;
 		}
 	}
 }


### PR DESCRIPTION
This PR improves documentation about properties modified by SubViewportContainer and makes this behavior optional by adding `adjust_viewport_properties` property.
Closes #56502
Closes #23729