### PR TITLE
Fix writing value for hand-tracking V2.0 to AndroidManifest.xml

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1025,7 +1025,7 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 							string_table.write[attr_value] = "com.oculus.handtracking.version";
 						}
 
-						if (tname == "meta-data" && attrname == "name" && value == "xr_hand_tracking_version_value") {
+						if (tname == "meta-data" && attrname == "value" && value == "xr_hand_tracking_version_value") {
 							string_table.write[attr_value] = "V2.0";
 						}
 					}


### PR DESCRIPTION
Due to a typo, the value for the meta-data tag for the hand-tracking-version was never set. It should be set in the "value" attribute, not in the "name" attribute.

Corresponding excerpt from the AndroidManifest.xml:
```
        <meta-data
            android:name="xr_hand_tracking_version_name"
            android:value="xr_hand_tracking_version_value"/>
```

Compatible with 3.x