### PR TITLE
Rename `(de)selected` signals to `node_(de)selected` in `GraphNode`

### DIFF
--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -280,16 +280,21 @@
 				Emitted when the GraphNode is requested to be closed. Happens on clicking the close button (see [member show_close]).
 			</description>
 		</signal>
-		<signal name="deselected">
-			<description>
-				Emitted when the GraphNode is deselected.
-			</description>
-		</signal>
 		<signal name="dragged">
 			<param index="0" name="from" type="Vector2" />
 			<param index="1" name="to" type="Vector2" />
 			<description>
 				Emitted when the GraphNode is dragged.
+			</description>
+		</signal>
+		<signal name="node_deselected">
+			<description>
+				Emitted when the GraphNode is deselected.
+			</description>
+		</signal>
+		<signal name="node_selected">
+			<description>
+				Emitted when the GraphNode is selected.
 			</description>
 		</signal>
 		<signal name="position_offset_changed">
@@ -306,11 +311,6 @@
 			<param index="0" name="new_minsize" type="Vector2" />
 			<description>
 				Emitted when the GraphNode is requested to be resized. Happens on dragging the resizer handle (see [member resizable]).
-			</description>
-		</signal>
-		<signal name="selected">
-			<description>
-				Emitted when the GraphNode is selected.
 			</description>
 		</signal>
 		<signal name="slot_updated">

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -404,8 +404,8 @@ void GraphEdit::add_child_notify(Node *p_child) {
 	if (gn) {
 		gn->set_scale(Vector2(zoom, zoom));
 		gn->connect("position_offset_changed", callable_mp(this, &GraphEdit::_graph_node_moved).bind(gn));
-		gn->connect("selected", callable_mp(this, &GraphEdit::_graph_node_selected).bind(gn));
-		gn->connect("deselected", callable_mp(this, &GraphEdit::_graph_node_deselected).bind(gn));
+		gn->connect("node_selected", callable_mp(this, &GraphEdit::_graph_node_selected).bind(gn));
+		gn->connect("node_deselected", callable_mp(this, &GraphEdit::_graph_node_deselected).bind(gn));
 		gn->connect("slot_updated", callable_mp(this, &GraphEdit::_graph_node_slot_updated).bind(gn));
 		gn->connect("raise_request", callable_mp(this, &GraphEdit::_graph_node_raised).bind(gn));
 		gn->connect("item_rect_changed", callable_mp((CanvasItem *)connections_layer, &CanvasItem::queue_redraw));
@@ -432,8 +432,8 @@ void GraphEdit::remove_child_notify(Node *p_child) {
 	GraphNode *gn = Object::cast_to<GraphNode>(p_child);
 	if (gn) {
 		gn->disconnect("position_offset_changed", callable_mp(this, &GraphEdit::_graph_node_moved));
-		gn->disconnect("selected", callable_mp(this, &GraphEdit::_graph_node_selected));
-		gn->disconnect("deselected", callable_mp(this, &GraphEdit::_graph_node_deselected));
+		gn->disconnect("node_selected", callable_mp(this, &GraphEdit::_graph_node_selected));
+		gn->disconnect("node_deselected", callable_mp(this, &GraphEdit::_graph_node_deselected));
 		gn->disconnect("slot_updated", callable_mp(this, &GraphEdit::_graph_node_slot_updated));
 		gn->disconnect("raise_request", callable_mp(this, &GraphEdit::_graph_node_raised));
 

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -749,7 +749,7 @@ void GraphNode::set_selected(bool p_selected) {
 	}
 
 	selected = p_selected;
-	emit_signal(p_selected ? SNAME("selected") : SNAME("deselected"));
+	emit_signal(p_selected ? SNAME("node_selected") : SNAME("node_deselected"));
 	queue_redraw();
 }
 
@@ -1161,8 +1161,8 @@ void GraphNode::_bind_methods() {
 	ADD_GROUP("", "");
 
 	ADD_SIGNAL(MethodInfo("position_offset_changed"));
-	ADD_SIGNAL(MethodInfo("selected"));
-	ADD_SIGNAL(MethodInfo("deselected"));
+	ADD_SIGNAL(MethodInfo("node_selected"));
+	ADD_SIGNAL(MethodInfo("node_deselected"));
 	ADD_SIGNAL(MethodInfo("slot_updated", PropertyInfo(Variant::INT, "idx")));
 	ADD_SIGNAL(MethodInfo("dragged", PropertyInfo(Variant::VECTOR2, "from"), PropertyInfo(Variant::VECTOR2, "to")));
 	ADD_SIGNAL(MethodInfo("raise_request"));


### PR DESCRIPTION
Fixes #70734 by renaming the following signals of `GraphNode` as discussed in RC:
- `selected` -> `node_selected`
- `deselected` -> `node_deselected`