### PR TITLE
C#: Move GodotSharp to net7.0

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -100,7 +100,7 @@ jobs:
         uses: actions/setup-dotnet@v2
         if: ${{ matrix.build-mono }}
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '7.0.x'
 
       - name: Setup GCC problem matcher
         uses: ammaraskar/gcc-problem-matcher@master

--- a/modules/mono/build_scripts/build_assemblies.py
+++ b/modules/mono/build_scripts/build_assemblies.py
@@ -230,7 +230,7 @@ def build_godot_api(msbuild_tool, module_dir, output_dir, push_nupkgs_local, pre
 
         core_src_dir = os.path.abspath(os.path.join(sln, os.pardir, "GodotSharp", "bin", build_config))
         editor_src_dir = os.path.abspath(os.path.join(sln, os.pardir, "GodotSharpEditor", "bin", build_config))
-        plugins_src_dir = os.path.abspath(os.path.join(sln, os.pardir, "GodotPlugins", "bin", build_config, "net6.0"))
+        plugins_src_dir = os.path.abspath(os.path.join(sln, os.pardir, "GodotPlugins", "bin", build_config, "net7.0"))
 
         if not os.path.isdir(editor_api_dir):
             assert not os.path.isfile(editor_api_dir)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Godot.SourceGenerators.Sample.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Godot.SourceGenerators.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/modules/mono/editor/GodotTools/GodotTools.Core/GodotTools.Core.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.Core/GodotTools.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{639E48BD-44E5-4091-8EDD-22D36DC0768D}</ProjectGuid>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>10</LangVersion>
   </PropertyGroup>
 </Project>

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/GodotTools.ProjectEditor.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/GodotTools.ProjectEditor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{A8CDAD94-C6D4-4B19-A7E7-76C53CC92984}</ProjectGuid>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>10</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
@@ -22,7 +22,7 @@ namespace GodotTools.ProjectEditor
             root.Sdk = GodotSdkAttrValue;
 
             var mainGroup = root.AddPropertyGroup();
-            mainGroup.AddProperty("TargetFramework", "net6.0");
+            mainGroup.AddProperty("TargetFramework", "net7.0");
             mainGroup.AddProperty("EnableDynamicLoading", "true");
 
             string sanitizedName = IdentifierUtils.SanitizeQualifiedIdentifier(name, allowEmptyIdentifiers: true);

--- a/modules/mono/editor/GodotTools/GodotTools.Shared/GodotTools.Shared.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.Shared/GodotTools.Shared.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <!-- Specify compile items manually to avoid including dangling generated items. -->
         <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     </PropertyGroup>

--- a/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotTools.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{27B00618-A6F2-4828-B922-05CAEB08C286}</ProjectGuid>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <LangVersion>10</LangVersion>
     <!-- The Godot editor uses the Debug Godot API assemblies -->

--- a/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/UnmanagedCallbacksGenerator.cs
+++ b/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/UnmanagedCallbacksGenerator.cs
@@ -168,9 +168,7 @@ using Godot.NativeInterop;
             {
                 var parameter = callback.Parameters[i];
 
-                source.Append(parameter.ToDisplayString());
-                source.Append(' ');
-                source.Append(parameter.Name);
+                source.Append(parameter.DeclaringSyntaxReferences[0].GetSyntax().ToString());
 
                 if (parameter.RefKind == RefKind.Out)
                 {

--- a/modules/mono/glue/GodotSharp/GodotPlugins/GodotPlugins.csproj
+++ b/modules/mono/glue/GodotSharp/GodotPlugins/GodotPlugins.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
@@ -104,7 +104,7 @@ namespace Godot.NativeInterop
         }
     }
 
-    [StructLayout(LayoutKind.Explicit)]
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_variant
     {
@@ -112,12 +112,12 @@ namespace Godot.NativeInterop
         internal readonly unsafe godot_variant* GetUnsafeAddress()
             => (godot_variant*)Unsafe.AsPointer(ref Unsafe.AsRef(in _typeField));
 
-        // Variant.Type is generated as an enum of type long, so we can't use for the field as it must only take 32-bits.
-        [FieldOffset(0)] private int _typeField;
+        // Variant.Type is generated as an enum of type long, so we can't use for the field as it must only take 32-bits. (the native enum actually has no fixed underlying type so it is only at least 6 bits long)
+        private int _typeField;
 
         // There's padding here
 
-        [FieldOffset(8)] private godot_variant_data _data;
+        private godot_variant_data _data;
 
         [StructLayout(LayoutKind.Explicit)]
         // ReSharper disable once InconsistentNaming

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
@@ -225,7 +225,7 @@ namespace Godot.NativeInterop
 
         // Callable
 
-        public static godot_callable ConvertCallableToNative(in Callable p_managed_callable)
+        public static godot_callable ConvertCallableToNative(scoped in Callable p_managed_callable)
         {
             if (p_managed_callable.Delegate != null)
             {
@@ -290,7 +290,7 @@ namespace Godot.NativeInterop
 
         // Signal
 
-        public static godot_signal ConvertSignalToNative(in Signal p_managed_signal)
+        public static godot_signal ConvertSignalToNative(scoped in Signal p_managed_signal)
         {
             ulong ownerId = p_managed_signal.Owner.GetInstanceId();
             godot_string_name name;
@@ -389,7 +389,7 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static unsafe godot_packed_byte_array ConvertSystemArrayToNativePackedByteArray(Span<byte> p_array)
+        public static unsafe godot_packed_byte_array ConvertSystemArrayToNativePackedByteArray(scoped Span<byte> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_byte_array();
@@ -412,7 +412,7 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static unsafe godot_packed_int32_array ConvertSystemArrayToNativePackedInt32Array(Span<int> p_array)
+        public static unsafe godot_packed_int32_array ConvertSystemArrayToNativePackedInt32Array(scoped Span<int> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_int32_array();
@@ -435,7 +435,7 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static unsafe godot_packed_int64_array ConvertSystemArrayToNativePackedInt64Array(Span<long> p_array)
+        public static unsafe godot_packed_int64_array ConvertSystemArrayToNativePackedInt64Array(scoped Span<long> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_int64_array();
@@ -459,7 +459,7 @@ namespace Godot.NativeInterop
         }
 
         public static unsafe godot_packed_float32_array ConvertSystemArrayToNativePackedFloat32Array(
-            Span<float> p_array)
+            scoped Span<float> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_float32_array();
@@ -483,7 +483,7 @@ namespace Godot.NativeInterop
         }
 
         public static unsafe godot_packed_float64_array ConvertSystemArrayToNativePackedFloat64Array(
-            Span<double> p_array)
+            scoped Span<double> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_float64_array();
@@ -505,7 +505,7 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static godot_packed_string_array ConvertSystemArrayToNativePackedStringArray(Span<string> p_array)
+        public static godot_packed_string_array ConvertSystemArrayToNativePackedStringArray(scoped Span<string> p_array)
         {
             godot_packed_string_array dest = new godot_packed_string_array();
 
@@ -540,7 +540,7 @@ namespace Godot.NativeInterop
         }
 
         public static unsafe godot_packed_vector2_array ConvertSystemArrayToNativePackedVector2Array(
-            Span<Vector2> p_array)
+            scoped Span<Vector2> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_vector2_array();
@@ -564,7 +564,7 @@ namespace Godot.NativeInterop
         }
 
         public static unsafe godot_packed_vector3_array ConvertSystemArrayToNativePackedVector3Array(
-            Span<Vector3> p_array)
+            scoped Span<Vector3> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_vector3_array();
@@ -587,7 +587,7 @@ namespace Godot.NativeInterop
             return array;
         }
 
-        public static unsafe godot_packed_color_array ConvertSystemArrayToNativePackedColorArray(Span<Color> p_array)
+        public static unsafe godot_packed_color_array ConvertSystemArrayToNativePackedColorArray(scoped Span<Color> p_array)
         {
             if (p_array.IsEmpty)
                 return new godot_packed_color_array();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -92,10 +92,10 @@ namespace Godot.NativeInterop
 
         internal static partial void godotsharp_internal_reload_registered_script(IntPtr scriptPtr);
 
-        internal static partial void godotsharp_array_filter_godot_objects_by_native(in godot_string_name p_native_name,
-            in godot_array p_input, out godot_array r_output);
+        internal static partial void godotsharp_array_filter_godot_objects_by_native(scoped in godot_string_name p_native_name,
+            scoped in godot_array p_input, out godot_array r_output);
 
-        internal static partial void godotsharp_array_filter_godot_objects_by_non_native(in godot_array p_input,
+        internal static partial void godotsharp_array_filter_godot_objects_by_non_native(scoped in godot_array p_input,
             out godot_array r_output);
 
         public static partial void godotsharp_ref_new_from_ref_counted_ptr(out godot_ref r_dest,
@@ -104,15 +104,15 @@ namespace Godot.NativeInterop
         public static partial void godotsharp_ref_destroy(ref godot_ref p_instance);
 
         public static partial void godotsharp_string_name_new_from_string(out godot_string_name r_dest,
-            in godot_string p_name);
+            scoped in godot_string p_name);
 
         public static partial void godotsharp_node_path_new_from_string(out godot_node_path r_dest,
-            in godot_string p_name);
+            scoped in godot_string p_name);
 
         public static partial void
-            godotsharp_string_name_as_string(out godot_string r_dest, in godot_string_name p_name);
+            godotsharp_string_name_as_string(out godot_string r_dest, scoped in godot_string_name p_name);
 
-        public static partial void godotsharp_node_path_as_string(out godot_string r_dest, in godot_node_path p_np);
+        public static partial void godotsharp_node_path_as_string(out godot_string r_dest, scoped in godot_node_path p_np);
 
         public static partial godot_packed_byte_array godotsharp_packed_byte_array_new_mem_copy(byte* p_src,
             int p_length);
@@ -144,10 +144,10 @@ namespace Godot.NativeInterop
         public static partial void godotsharp_callable_new_with_delegate(IntPtr p_delegate_handle, IntPtr p_trampoline,
             IntPtr p_object, out godot_callable r_callable);
 
-        internal static partial godot_bool godotsharp_callable_get_data_for_marshalling(in godot_callable p_callable,
+        internal static partial godot_bool godotsharp_callable_get_data_for_marshalling(scoped in godot_callable p_callable,
             out IntPtr r_delegate_handle, out IntPtr r_trampoline, out IntPtr r_object, out godot_string_name r_name);
 
-        internal static partial godot_variant godotsharp_callable_call(in godot_callable p_callable,
+        internal static partial godot_variant godotsharp_callable_call(scoped in godot_callable p_callable,
             godot_variant** p_args, int p_arg_count, out godot_variant_call_error p_call_error);
 
         internal static partial void godotsharp_callable_call_deferred(in godot_callable p_callable,
@@ -168,55 +168,55 @@ namespace Godot.NativeInterop
         // variant.h
 
         public static partial void
-            godotsharp_variant_new_string_name(out godot_variant r_dest, in godot_string_name p_s);
+            godotsharp_variant_new_string_name(out godot_variant r_dest, scoped in godot_string_name p_s);
 
-        public static partial void godotsharp_variant_new_copy(out godot_variant r_dest, in godot_variant p_src);
+        public static partial void godotsharp_variant_new_copy(out godot_variant r_dest, scoped in godot_variant p_src);
 
-        public static partial void godotsharp_variant_new_node_path(out godot_variant r_dest, in godot_node_path p_np);
+        public static partial void godotsharp_variant_new_node_path(out godot_variant r_dest, scoped in godot_node_path p_np);
 
         public static partial void godotsharp_variant_new_object(out godot_variant r_dest, IntPtr p_obj);
 
-        public static partial void godotsharp_variant_new_transform2d(out godot_variant r_dest, in Transform2D p_t2d);
+        public static partial void godotsharp_variant_new_transform2d(out godot_variant r_dest, scoped in Transform2D p_t2d);
 
-        public static partial void godotsharp_variant_new_basis(out godot_variant r_dest, in Basis p_basis);
+        public static partial void godotsharp_variant_new_basis(out godot_variant r_dest, scoped in Basis p_basis);
 
-        public static partial void godotsharp_variant_new_transform3d(out godot_variant r_dest, in Transform3D p_trans);
+        public static partial void godotsharp_variant_new_transform3d(out godot_variant r_dest, scoped in Transform3D p_trans);
 
-        public static partial void godotsharp_variant_new_projection(out godot_variant r_dest, in Projection p_proj);
+        public static partial void godotsharp_variant_new_projection(out godot_variant r_dest, scoped in Projection p_proj);
 
-        public static partial void godotsharp_variant_new_aabb(out godot_variant r_dest, in AABB p_aabb);
+        public static partial void godotsharp_variant_new_aabb(out godot_variant r_dest, scoped in AABB p_aabb);
 
         public static partial void godotsharp_variant_new_dictionary(out godot_variant r_dest,
-            in godot_dictionary p_dict);
+            scoped in godot_dictionary p_dict);
 
-        public static partial void godotsharp_variant_new_array(out godot_variant r_dest, in godot_array p_arr);
+        public static partial void godotsharp_variant_new_array(out godot_variant r_dest, scoped in godot_array p_arr);
 
         public static partial void godotsharp_variant_new_packed_byte_array(out godot_variant r_dest,
-            in godot_packed_byte_array p_pba);
+            scoped in godot_packed_byte_array p_pba);
 
         public static partial void godotsharp_variant_new_packed_int32_array(out godot_variant r_dest,
-            in godot_packed_int32_array p_pia);
+            scoped in godot_packed_int32_array p_pia);
 
         public static partial void godotsharp_variant_new_packed_int64_array(out godot_variant r_dest,
-            in godot_packed_int64_array p_pia);
+            scoped in godot_packed_int64_array p_pia);
 
         public static partial void godotsharp_variant_new_packed_float32_array(out godot_variant r_dest,
-            in godot_packed_float32_array p_pra);
+            scoped in godot_packed_float32_array p_pra);
 
         public static partial void godotsharp_variant_new_packed_float64_array(out godot_variant r_dest,
-            in godot_packed_float64_array p_pra);
+            scoped in godot_packed_float64_array p_pra);
 
         public static partial void godotsharp_variant_new_packed_string_array(out godot_variant r_dest,
-            in godot_packed_string_array p_psa);
+            scoped in godot_packed_string_array p_psa);
 
         public static partial void godotsharp_variant_new_packed_vector2_array(out godot_variant r_dest,
-            in godot_packed_vector2_array p_pv2a);
+            scoped in godot_packed_vector2_array p_pv2a);
 
         public static partial void godotsharp_variant_new_packed_vector3_array(out godot_variant r_dest,
-            in godot_packed_vector3_array p_pv3a);
+            scoped in godot_packed_vector3_array p_pv3a);
 
         public static partial void godotsharp_variant_new_packed_color_array(out godot_variant r_dest,
-            in godot_packed_color_array p_pca);
+            scoped in godot_packed_color_array p_pca);
 
         public static partial godot_bool godotsharp_variant_as_bool(in godot_variant p_self);
 
@@ -224,7 +224,7 @@ namespace Godot.NativeInterop
 
         public static partial double godotsharp_variant_as_float(in godot_variant p_self);
 
-        public static partial godot_string godotsharp_variant_as_string(in godot_variant p_self);
+        public static partial godot_string godotsharp_variant_as_string(scoped in godot_variant p_self);
 
         public static partial Vector2 godotsharp_variant_as_vector2(in godot_variant p_self);
 
@@ -258,42 +258,42 @@ namespace Godot.NativeInterop
 
         public static partial Color godotsharp_variant_as_color(in godot_variant p_self);
 
-        public static partial godot_string_name godotsharp_variant_as_string_name(in godot_variant p_self);
+        public static partial godot_string_name godotsharp_variant_as_string_name(scoped in godot_variant p_self);
 
-        public static partial godot_node_path godotsharp_variant_as_node_path(in godot_variant p_self);
+        public static partial godot_node_path godotsharp_variant_as_node_path(scoped in godot_variant p_self);
 
         public static partial RID godotsharp_variant_as_rid(in godot_variant p_self);
 
-        public static partial godot_callable godotsharp_variant_as_callable(in godot_variant p_self);
+        public static partial godot_callable godotsharp_variant_as_callable(scoped in godot_variant p_self);
 
-        public static partial godot_signal godotsharp_variant_as_signal(in godot_variant p_self);
+        public static partial godot_signal godotsharp_variant_as_signal(scoped in godot_variant p_self);
 
-        public static partial godot_dictionary godotsharp_variant_as_dictionary(in godot_variant p_self);
+        public static partial godot_dictionary godotsharp_variant_as_dictionary(scoped in godot_variant p_self);
 
-        public static partial godot_array godotsharp_variant_as_array(in godot_variant p_self);
+        public static partial godot_array godotsharp_variant_as_array(scoped in godot_variant p_self);
 
-        public static partial godot_packed_byte_array godotsharp_variant_as_packed_byte_array(in godot_variant p_self);
+        public static partial godot_packed_byte_array godotsharp_variant_as_packed_byte_array(scoped in godot_variant p_self);
 
-        public static partial godot_packed_int32_array godotsharp_variant_as_packed_int32_array(in godot_variant p_self);
+        public static partial godot_packed_int32_array godotsharp_variant_as_packed_int32_array(scoped in godot_variant p_self);
 
-        public static partial godot_packed_int64_array godotsharp_variant_as_packed_int64_array(in godot_variant p_self);
+        public static partial godot_packed_int64_array godotsharp_variant_as_packed_int64_array(scoped in godot_variant p_self);
 
         public static partial godot_packed_float32_array godotsharp_variant_as_packed_float32_array(
-            in godot_variant p_self);
+            scoped in godot_variant p_self);
 
         public static partial godot_packed_float64_array godotsharp_variant_as_packed_float64_array(
-            in godot_variant p_self);
+            scoped in godot_variant p_self);
 
         public static partial godot_packed_string_array godotsharp_variant_as_packed_string_array(
-            in godot_variant p_self);
+            scoped in godot_variant p_self);
 
         public static partial godot_packed_vector2_array godotsharp_variant_as_packed_vector2_array(
-            in godot_variant p_self);
+            scoped in godot_variant p_self);
 
         public static partial godot_packed_vector3_array godotsharp_variant_as_packed_vector3_array(
-            in godot_variant p_self);
+            scoped in godot_variant p_self);
 
-        public static partial godot_packed_color_array godotsharp_variant_as_packed_color_array(in godot_variant p_self);
+        public static partial godot_packed_color_array godotsharp_variant_as_packed_color_array(scoped in godot_variant p_self);
 
         public static partial godot_bool godotsharp_variant_equals(in godot_variant p_a, in godot_variant p_b);
 
@@ -304,17 +304,17 @@ namespace Godot.NativeInterop
         // string_name.h
 
         public static partial void godotsharp_string_name_new_copy(out godot_string_name r_dest,
-            in godot_string_name p_src);
+            scoped in godot_string_name p_src);
 
         // node_path.h
 
-        public static partial void godotsharp_node_path_new_copy(out godot_node_path r_dest, in godot_node_path p_src);
+        public static partial void godotsharp_node_path_new_copy(out godot_node_path r_dest, scoped in godot_node_path p_src);
 
         // array.h
 
         public static partial void godotsharp_array_new(out godot_array r_dest);
 
-        public static partial void godotsharp_array_new_copy(out godot_array r_dest, in godot_array p_src);
+        public static partial void godotsharp_array_new_copy(out godot_array r_dest, scoped in godot_array p_src);
 
         public static partial godot_variant* godotsharp_array_ptrw(ref godot_array p_self);
 
@@ -323,7 +323,7 @@ namespace Godot.NativeInterop
         public static partial void godotsharp_dictionary_new(out godot_dictionary r_dest);
 
         public static partial void godotsharp_dictionary_new_copy(out godot_dictionary r_dest,
-            in godot_dictionary p_src);
+            scoped in godot_dictionary p_src);
 
         // destroy functions
 
@@ -366,7 +366,7 @@ namespace Godot.NativeInterop
         public static partial int godotsharp_array_add(ref godot_array p_self, in godot_variant p_item);
 
         public static partial void
-            godotsharp_array_duplicate(ref godot_array p_self, godot_bool p_deep, out godot_array r_dest);
+            godotsharp_array_duplicate(scoped ref godot_array p_self, godot_bool p_deep, out godot_array r_dest);
 
         public static partial int godotsharp_array_index_of(ref godot_array p_self, in godot_variant p_item);
 
@@ -378,24 +378,24 @@ namespace Godot.NativeInterop
 
         public static partial void godotsharp_array_shuffle(ref godot_array p_self);
 
-        public static partial void godotsharp_array_to_string(ref godot_array p_self, out godot_string r_str);
+        public static partial void godotsharp_array_to_string(scoped ref godot_array p_self, out godot_string r_str);
 
         // Dictionary
 
-        public static partial godot_bool godotsharp_dictionary_try_get_value(ref godot_dictionary p_self,
-            in godot_variant p_key,
+        public static partial godot_bool godotsharp_dictionary_try_get_value(scoped ref godot_dictionary p_self,
+            scoped in godot_variant p_key,
             out godot_variant r_value);
 
         public static partial void godotsharp_dictionary_set_value(ref godot_dictionary p_self, in godot_variant p_key,
             in godot_variant p_value);
 
-        public static partial void godotsharp_dictionary_keys(ref godot_dictionary p_self, out godot_array r_dest);
+        public static partial void godotsharp_dictionary_keys(scoped ref godot_dictionary p_self, out godot_array r_dest);
 
-        public static partial void godotsharp_dictionary_values(ref godot_dictionary p_self, out godot_array r_dest);
+        public static partial void godotsharp_dictionary_values(scoped ref godot_dictionary p_self, out godot_array r_dest);
 
         public static partial int godotsharp_dictionary_count(ref godot_dictionary p_self);
 
-        public static partial void godotsharp_dictionary_key_value_pair_at(ref godot_dictionary p_self, int p_index,
+        public static partial void godotsharp_dictionary_key_value_pair_at(scoped ref godot_dictionary p_self, int p_index,
             out godot_variant r_key, out godot_variant r_value);
 
         public static partial void godotsharp_dictionary_add(ref godot_dictionary p_self, in godot_variant p_key,
@@ -406,26 +406,26 @@ namespace Godot.NativeInterop
         public static partial godot_bool godotsharp_dictionary_contains_key(ref godot_dictionary p_self,
             in godot_variant p_key);
 
-        public static partial void godotsharp_dictionary_duplicate(ref godot_dictionary p_self, godot_bool p_deep,
+        public static partial void godotsharp_dictionary_duplicate(scoped ref godot_dictionary p_self, godot_bool p_deep,
             out godot_dictionary r_dest);
 
         public static partial godot_bool godotsharp_dictionary_remove_key(ref godot_dictionary p_self,
             in godot_variant p_key);
 
-        public static partial void godotsharp_dictionary_to_string(ref godot_dictionary p_self, out godot_string r_str);
+        public static partial void godotsharp_dictionary_to_string(scoped ref godot_dictionary p_self, out godot_string r_str);
 
         // StringExtensions
 
-        public static partial void godotsharp_string_simplify_path(in godot_string p_self,
+        public static partial void godotsharp_string_simplify_path(scoped in godot_string p_self,
             out godot_string r_simplified_path);
 
-        public static partial void godotsharp_string_to_camel_case(in godot_string p_self,
+        public static partial void godotsharp_string_to_camel_case(scoped in godot_string p_self,
             out godot_string r_camel_case);
 
-        public static partial void godotsharp_string_to_pascal_case(in godot_string p_self,
+        public static partial void godotsharp_string_to_pascal_case(scoped in godot_string p_self,
             out godot_string r_pascal_case);
 
-        public static partial void godotsharp_string_to_snake_case(in godot_string p_self,
+        public static partial void godotsharp_string_to_snake_case(scoped in godot_string p_self,
             out godot_string r_snake_case);
 
         // NodePath
@@ -433,18 +433,18 @@ namespace Godot.NativeInterop
         public static partial void godotsharp_node_path_get_as_property_path(in godot_node_path p_self,
             ref godot_node_path r_dest);
 
-        public static partial void godotsharp_node_path_get_concatenated_names(in godot_node_path p_self,
+        public static partial void godotsharp_node_path_get_concatenated_names(scoped in godot_node_path p_self,
             out godot_string r_names);
 
-        public static partial void godotsharp_node_path_get_concatenated_subnames(in godot_node_path p_self,
+        public static partial void godotsharp_node_path_get_concatenated_subnames(scoped in godot_node_path p_self,
             out godot_string r_subnames);
 
-        public static partial void godotsharp_node_path_get_name(in godot_node_path p_self, int p_idx,
+        public static partial void godotsharp_node_path_get_name(scoped in godot_node_path p_self, int p_idx,
             out godot_string r_name);
 
         public static partial int godotsharp_node_path_get_name_count(in godot_node_path p_self);
 
-        public static partial void godotsharp_node_path_get_subname(in godot_node_path p_self, int p_idx,
+        public static partial void godotsharp_node_path_get_subname(scoped in godot_node_path p_self, int p_idx,
             out godot_string r_subname);
 
         public static partial int godotsharp_node_path_get_subname_count(in godot_node_path p_self);
@@ -453,11 +453,11 @@ namespace Godot.NativeInterop
 
         // GD, etc
 
-        internal static partial void godotsharp_bytes_to_var(in godot_packed_byte_array p_bytes,
+        internal static partial void godotsharp_bytes_to_var(scoped in godot_packed_byte_array p_bytes,
             godot_bool p_allow_objects,
             out godot_variant r_ret);
 
-        internal static partial void godotsharp_convert(in godot_variant p_what, int p_type,
+        internal static partial void godotsharp_convert(scoped in godot_variant p_what, int p_type,
             out godot_variant r_ret);
 
         internal static partial int godotsharp_hash(in godot_variant p_var);
@@ -494,14 +494,14 @@ namespace Godot.NativeInterop
 
         internal static partial void godotsharp_weakref(IntPtr p_obj, out godot_ref r_weak_ref);
 
-        internal static partial void godotsharp_str(in godot_array p_what, out godot_string r_ret);
+        internal static partial void godotsharp_str(scoped in godot_array p_what, out godot_string r_ret);
 
-        internal static partial void godotsharp_str_to_var(in godot_string p_str, out godot_variant r_ret);
+        internal static partial void godotsharp_str_to_var(scoped in godot_string p_str, out godot_variant r_ret);
 
-        internal static partial void godotsharp_var_to_bytes(in godot_variant p_what, godot_bool p_full_objects,
+        internal static partial void godotsharp_var_to_bytes(scoped in godot_variant p_what, godot_bool p_full_objects,
             out godot_packed_byte_array r_bytes);
 
-        internal static partial void godotsharp_var_to_str(in godot_variant p_var, out godot_string r_ret);
+        internal static partial void godotsharp_var_to_str(scoped in godot_variant p_var, out godot_string r_ret);
 
         internal static partial void godotsharp_pusherror(in godot_string p_str);
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.extended.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.extended.cs
@@ -4,7 +4,7 @@ namespace Godot.NativeInterop
 {
     public static partial class NativeFuncs
     {
-        public static godot_variant godotsharp_variant_new_copy(in godot_variant src)
+        public static godot_variant godotsharp_variant_new_copy(scoped in godot_variant src)
         {
             switch (src.Type)
             {
@@ -46,7 +46,7 @@ namespace Godot.NativeInterop
             return ret;
         }
 
-        public static godot_string_name godotsharp_string_name_new_copy(in godot_string_name src)
+        public static godot_string_name godotsharp_string_name_new_copy(scoped in godot_string_name src)
         {
             if (src.IsEmpty)
                 return default;
@@ -54,7 +54,7 @@ namespace Godot.NativeInterop
             return ret;
         }
 
-        public static godot_node_path godotsharp_node_path_new_copy(in godot_node_path src)
+        public static godot_node_path godotsharp_node_path_new_copy(scoped in godot_node_path src)
         {
             if (src.IsEmpty)
                 return default;
@@ -68,7 +68,7 @@ namespace Godot.NativeInterop
             return ret;
         }
 
-        public static godot_array godotsharp_array_new_copy(in godot_array src)
+        public static godot_array godotsharp_array_new_copy(scoped in godot_array src)
         {
             godotsharp_array_new_copy(out godot_array ret, src);
             return ret;
@@ -80,7 +80,7 @@ namespace Godot.NativeInterop
             return ret;
         }
 
-        public static godot_dictionary godotsharp_dictionary_new_copy(in godot_dictionary src)
+        public static godot_dictionary godotsharp_dictionary_new_copy(scoped in godot_dictionary src)
         {
             godotsharp_dictionary_new_copy(out godot_dictionary ret, src);
             return ret;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
@@ -114,130 +114,130 @@ namespace Godot.NativeInterop
         public static godot_variant CreateFromString(string? from)
             => CreateFromStringTakingOwnershipOfDisposableValue(Marshaling.ConvertStringToNative(from));
 
-        public static godot_variant CreateFromPackedByteArray(in godot_packed_byte_array from)
+        public static godot_variant CreateFromPackedByteArray(scoped in godot_packed_byte_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_byte_array(out godot_variant ret, from);
             return ret;
         }
 
-        public static godot_variant CreateFromPackedInt32Array(in godot_packed_int32_array from)
+        public static godot_variant CreateFromPackedInt32Array(scoped in godot_packed_int32_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_int32_array(out godot_variant ret, from);
             return ret;
         }
 
-        public static godot_variant CreateFromPackedInt64Array(in godot_packed_int64_array from)
+        public static godot_variant CreateFromPackedInt64Array(scoped in godot_packed_int64_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_int64_array(out godot_variant ret, from);
             return ret;
         }
 
-        public static godot_variant CreateFromPackedFloat32Array(in godot_packed_float32_array from)
+        public static godot_variant CreateFromPackedFloat32Array(scoped in godot_packed_float32_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_float32_array(out godot_variant ret, from);
             return ret;
         }
 
-        public static godot_variant CreateFromPackedFloat64Array(in godot_packed_float64_array from)
+        public static godot_variant CreateFromPackedFloat64Array(scoped in godot_packed_float64_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_float64_array(out godot_variant ret, from);
             return ret;
         }
 
-        public static godot_variant CreateFromPackedStringArray(in godot_packed_string_array from)
+        public static godot_variant CreateFromPackedStringArray(scoped in godot_packed_string_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_string_array(out godot_variant ret, from);
             return ret;
         }
 
-        public static godot_variant CreateFromPackedVector2Array(in godot_packed_vector2_array from)
+        public static godot_variant CreateFromPackedVector2Array(scoped in godot_packed_vector2_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_vector2_array(out godot_variant ret, from);
             return ret;
         }
 
-        public static godot_variant CreateFromPackedVector3Array(in godot_packed_vector3_array from)
+        public static godot_variant CreateFromPackedVector3Array(scoped in godot_packed_vector3_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_vector3_array(out godot_variant ret, from);
             return ret;
         }
 
-        public static godot_variant CreateFromPackedColorArray(in godot_packed_color_array from)
+        public static godot_variant CreateFromPackedColorArray(scoped in godot_packed_color_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_color_array(out godot_variant ret, from);
             return ret;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedByteArray(Span<byte> from)
+        public static godot_variant CreateFromPackedByteArray(scoped Span<byte> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedByteArray(from);
             return CreateFromPackedByteArray(nativePackedArray);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedInt32Array(Span<int> from)
+        public static godot_variant CreateFromPackedInt32Array(scoped Span<int> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedInt32Array(from);
             return CreateFromPackedInt32Array(nativePackedArray);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedInt64Array(Span<long> from)
+        public static godot_variant CreateFromPackedInt64Array(scoped Span<long> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedInt64Array(from);
             return CreateFromPackedInt64Array(nativePackedArray);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedFloat32Array(Span<float> from)
+        public static godot_variant CreateFromPackedFloat32Array(scoped Span<float> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedFloat32Array(from);
             return CreateFromPackedFloat32Array(nativePackedArray);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedFloat64Array(Span<double> from)
+        public static godot_variant CreateFromPackedFloat64Array(scoped Span<double> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedFloat64Array(from);
             return CreateFromPackedFloat64Array(nativePackedArray);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedStringArray(Span<string> from)
+        public static godot_variant CreateFromPackedStringArray(scoped Span<string> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedStringArray(from);
             return CreateFromPackedStringArray(nativePackedArray);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedVector2Array(Span<Vector2> from)
+        public static godot_variant CreateFromPackedVector2Array(scoped Span<Vector2> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedVector2Array(from);
             return CreateFromPackedVector2Array(nativePackedArray);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedVector3Array(Span<Vector3> from)
+        public static godot_variant CreateFromPackedVector3Array(scoped Span<Vector3> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedVector3Array(from);
             return CreateFromPackedVector3Array(nativePackedArray);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedColorArray(Span<Color> from)
+        public static godot_variant CreateFromPackedColorArray(scoped Span<Color> from)
         {
             using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedColorArray(from);
             return CreateFromPackedColorArray(nativePackedArray);
         }
 
-        public static godot_variant CreateFromSystemArrayOfStringName(Span<StringName> from)
+        public static godot_variant CreateFromSystemArrayOfStringName(scoped Span<StringName> from)
             => CreateFromArray(new Collections.Array(from));
 
-        public static godot_variant CreateFromSystemArrayOfNodePath(Span<NodePath> from)
+        public static godot_variant CreateFromSystemArrayOfNodePath(scoped Span<NodePath> from)
             => CreateFromArray(new Collections.Array(from));
 
-        public static godot_variant CreateFromSystemArrayOfRID(Span<RID> from)
+        public static godot_variant CreateFromSystemArrayOfRID(scoped Span<RID> from)
             => CreateFromArray(new Collections.Array(from));
 
         // ReSharper disable once RedundantNameQualifier
@@ -249,7 +249,7 @@ namespace Godot.NativeInterop
             return CreateFromArray((godot_array)fromGodot.NativeValue);
         }
 
-        public static godot_variant CreateFromArray(godot_array from)
+        public static godot_variant CreateFromArray(scoped in godot_array from)
         {
             NativeFuncs.godotsharp_variant_new_array(out godot_variant ret, from);
             return ret;
@@ -263,7 +263,7 @@ namespace Godot.NativeInterop
         public static godot_variant CreateFromArray<T>(Array<T>? from)
             => from != null ? CreateFromArray((godot_array)((Collections.Array)from).NativeValue) : default;
 
-        public static godot_variant CreateFromDictionary(godot_dictionary from)
+        public static godot_variant CreateFromDictionary(scoped in godot_dictionary from)
         {
             NativeFuncs.godotsharp_variant_new_dictionary(out godot_variant ret, from);
             return ret;
@@ -277,7 +277,7 @@ namespace Godot.NativeInterop
         public static godot_variant CreateFromDictionary<TKey, TValue>(Dictionary<TKey, TValue>? from)
             => from != null ? CreateFromDictionary((godot_dictionary)((Dictionary)from).NativeValue) : default;
 
-        public static godot_variant CreateFromStringName(godot_string_name from)
+        public static godot_variant CreateFromStringName(scoped in godot_string_name from)
         {
             NativeFuncs.godotsharp_variant_new_string_name(out godot_variant ret, from);
             return ret;
@@ -287,7 +287,7 @@ namespace Godot.NativeInterop
         public static godot_variant CreateFromStringName(StringName? from)
             => from != null ? CreateFromStringName((godot_string_name)from.NativeValue) : default;
 
-        public static godot_variant CreateFromNodePath(godot_node_path from)
+        public static godot_variant CreateFromNodePath(scoped in godot_node_path from)
         {
             NativeFuncs.godotsharp_variant_new_node_path(out godot_variant ret, from);
             return ret;
@@ -482,7 +482,7 @@ namespace Godot.NativeInterop
             }
         }
 
-        public static godot_string_name ConvertToNativeStringName(in godot_variant p_var)
+        public static godot_string_name ConvertToNativeStringName(scoped in godot_variant p_var)
             => p_var.Type == Variant.Type.StringName ?
                 NativeFuncs.godotsharp_string_name_new_copy(p_var.StringName) :
                 NativeFuncs.godotsharp_variant_as_string_name(p_var);
@@ -491,7 +491,7 @@ namespace Godot.NativeInterop
         public static StringName ConvertToStringName(in godot_variant p_var)
             => StringName.CreateTakingOwnershipOfDisposableValue(ConvertToNativeStringName(p_var));
 
-        public static godot_node_path ConvertToNativeNodePath(in godot_variant p_var)
+        public static godot_node_path ConvertToNativeNodePath(scoped in godot_variant p_var)
             => p_var.Type == Variant.Type.NodePath ?
                 NativeFuncs.godotsharp_node_path_new_copy(p_var.NodePath) :
                 NativeFuncs.godotsharp_variant_as_node_path(p_var);
@@ -501,7 +501,7 @@ namespace Godot.NativeInterop
             => NodePath.CreateTakingOwnershipOfDisposableValue(ConvertToNativeNodePath(p_var));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_callable ConvertToNativeCallable(in godot_variant p_var)
+        public static godot_callable ConvertToNativeCallable(scoped in godot_variant p_var)
             => NativeFuncs.godotsharp_variant_as_callable(p_var);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -509,14 +509,14 @@ namespace Godot.NativeInterop
             => Marshaling.ConvertCallableToManaged(ConvertToNativeCallable(p_var));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_signal ConvertToNativeSignal(in godot_variant p_var)
+        public static godot_signal ConvertToNativeSignal(scoped in godot_variant p_var)
             => NativeFuncs.godotsharp_variant_as_signal(p_var);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Signal ConvertToSignal(in godot_variant p_var)
             => Marshaling.ConvertSignalToManaged(ConvertToNativeSignal(p_var));
 
-        public static godot_array ConvertToNativeArray(in godot_variant p_var)
+        public static godot_array ConvertToNativeArray(scoped in godot_variant p_var)
             => p_var.Type == Variant.Type.Array ?
                 NativeFuncs.godotsharp_array_new_copy(p_var.Array) :
                 NativeFuncs.godotsharp_variant_as_array(p_var);
@@ -529,7 +529,7 @@ namespace Godot.NativeInterop
         public static Array<T> ConvertToArray<T>(in godot_variant p_var)
             => Array<T>.CreateTakingOwnershipOfDisposableValue(ConvertToNativeArray(p_var));
 
-        public static godot_dictionary ConvertToNativeDictionary(in godot_variant p_var)
+        public static godot_dictionary ConvertToNativeDictionary(scoped in godot_variant p_var)
             => p_var.Type == Variant.Type.Dictionary ?
                 NativeFuncs.godotsharp_dictionary_new_copy(p_var.Dictionary) :
                 NativeFuncs.godotsharp_variant_as_dictionary(p_var);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
@@ -13,8 +13,10 @@ public partial class VariantUtils
 
     internal static class GenericConversion<T>
     {
-        public static unsafe godot_variant ToVariant(in T from) =>
+        public static unsafe godot_variant ToVariant(scoped in T from) =>
+#pragma warning disable CS9088 // the delegate pointer cannot be marked scoped, but it should be
             ToVariantCb != null ? ToVariantCb(from) : throw UnsupportedType<T>();
+#pragma warning restore CS9088
 
         public static unsafe T FromVariant(in godot_variant variant) =>
             FromVariantCb != null ? FromVariantCb(variant) : throw UnsupportedType<T>();
@@ -34,7 +36,7 @@ public partial class VariantUtils
 
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     [SuppressMessage("ReSharper", "RedundantNameQualifier")]
-    public static godot_variant CreateFrom<[MustBeVariant] T>(in T from)
+    public static godot_variant CreateFrom<[MustBeVariant] T>(scoped in T from)
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static TTo UnsafeAs<TTo>(in T f) => Unsafe.As<T, TTo>(ref Unsafe.AsRef(f));

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -4,11 +4,11 @@
     <OutputPath>bin/$(Configuration)</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace>Godot</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <DocumentationFile>$(OutputPath)/$(AssemblyName).xml</DocumentationFile>
     <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>10</LangVersion>
+    <LangVersion>11</LangVersion>
 
     <AnalysisMode>Recommended</AnalysisMode>
 

--- a/modules/mono/glue/GodotSharp/GodotSharpEditor/GodotSharpEditor.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharpEditor/GodotSharpEditor.csproj
@@ -4,7 +4,7 @@
     <OutputPath>bin/$(Configuration)</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace>Godot</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <DocumentationFile>$(OutputPath)/$(AssemblyName).xml</DocumentationFile>
     <EnableDefaultItems>false</EnableDefaultItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Use .NET 7 instead of .NET 6 as the C# runtime.

While programs targeting .NET 6 can generally run under .NET 7, there are some breaking changes, but changing the .net version is way simpler than trying to support multiple versions and on RC it looks like the plan is to drop support for 6 in favor of 7 anyways, so here is that change.

When updating to net 7 the only thing that causes issues in godot are [the ref safety changes](https://learn.microsoft.com/dotnet/csharp/language-reference/proposals/csharp-11.0/low-level-struct-improvements), which mean that you cannot return a ref struct that was returned from a method that takes a reference to a local parameter. Because all the interop structs are `ref struct`s and most of the interop code takes parameters by `in` reference, this causes errors in a lot of places.

To fix this either the `ref` parameters have to be annotated with the `scoped` keyword to mark that that reference is not captured anywhere or the return types have to no be made `ref struct`s.

The first required fairly extensive changes, including support in the source generator, and in the end only led to consistent JIT crashes that is was not able to diagnose, Thus I went with the second solution, since the interop structs don't actually contain any `ref struct`s or `ref` fields.

The only issue with this is that these types were presumably made `ref struct`s for a reason, but i cannot see what that reason might be.



