### PR TITLE
etcpak: Fix ETCPAK_TYPE_ETC2_RA_AS_RG

### DIFF
--- a/modules/etcpak/image_compress_etcpak.cpp
+++ b/modules/etcpak/image_compress_etcpak.cpp
@@ -118,6 +118,7 @@ void _compress_etcpak(EtcpakType p_compresstype, Image *r_img, float p_lossy_qua
 	} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC2_RA_AS_RG) {
 		target_format = Image::FORMAT_ETC2_RA_AS_RG;
 		r_img->convert_rg_to_ra_rgba8();
+		r_img->convert_rgba8_to_bgra8(); // It's badly documented but ETCPAK seems to be expected BGRA8 for ETC.
 	} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC2_ALPHA) {
 		target_format = Image::FORMAT_ETC2_RGBA8;
 		r_img->convert_rgba8_to_bgra8(); // It's badly documented but ETCPAK seems to be expected BGRA8 for ETC.
@@ -222,9 +223,9 @@ void _compress_etcpak(EtcpakType p_compresstype, Image *r_img, float p_lossy_qua
 		}
 		if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC1) {
 			CompressEtc1RgbDither(src_mip_read, dest_mip_write, blocks, mip_w);
-		} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC2 || p_compresstype == EtcpakType::ETCPAK_TYPE_ETC2_RA_AS_RG) {
+		} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC2) {
 			CompressEtc2Rgb(src_mip_read, dest_mip_write, blocks, mip_w, true);
-		} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC2_ALPHA) {
+		} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_ETC2_ALPHA || p_compresstype == EtcpakType::ETCPAK_TYPE_ETC2_RA_AS_RG) {
 			CompressEtc2Rgba(src_mip_read, dest_mip_write, blocks, mip_w, true);
 		} else if (p_compresstype == EtcpakType::ETCPAK_TYPE_DXT1) {
 			CompressDxt1Dither(src_mip_read, dest_mip_write, blocks, mip_w);


### PR DESCRIPTION
This PR fixes texture compression via `ETCPAK_TYPE_ETC2_RA_AS_RG`, switching to the right color channels (see #69448) and using the right compression method (RGBA instead of RGB).

Note that you need to re-import textures to see the changes. To reproduce the issue, create a texture with the Normal Map option selected and export to Android. I tested on the OpenGL renderer, but the issue is very likely renderer-independent.