### PR TITLE
Fix TAB key usage in EditorSpinSlider (and hence inpector).

### DIFF
--- a/editor/editor_spin_slider.h
+++ b/editor/editor_spin_slider.h
@@ -65,7 +65,7 @@ class EditorSpinSlider : public Range {
 
 	Control *value_input_popup = nullptr;
 	LineEdit *value_input = nullptr;
-	bool value_input_just_closed = false;
+	uint64_t value_input_closed_frame = 0;
 	bool value_input_dirty = false;
 
 	bool hide_slider = false;


### PR DESCRIPTION
* This ensures that the tab key usage is correct in all situations in EditorSpinSlider
* The ESC key can also close the lineedit popup.

Fixes #37723.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
