### PR TITLE
Fix the Frame Selection (Shift + F) functionality in the 2D editor

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4370,8 +4370,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 			show_rulers = !show_rulers;
 			int idx = view_menu->get_popup()->get_item_index(SHOW_RULERS);
 			view_menu->get_popup()->set_item_checked(idx, show_rulers);
-			_update_scrollbars();
-			viewport->queue_redraw();
+			update_viewport();
 		} break;
 		case SHOW_GUIDES: {
 			show_guides = !show_guides;
@@ -4683,25 +4682,18 @@ void CanvasItemEditor::_focus_selection(int p_op) {
 		} else {
 			rect = rect.merge(canvas_item_rect);
 		}
-	};
+	}
 
-	if (p_op == VIEW_CENTER_TO_SELECTION) {
-		center = rect.get_center();
-		Vector2 offset = viewport->get_size() / 2 - EditorNode::get_singleton()->get_scene_root()->get_global_canvas_transform().xform(center);
-		view_offset -= (offset / zoom).round();
-		update_viewport();
-
-	} else { // VIEW_FRAME_TO_SELECTION
-
-		if (rect.size.x > CMP_EPSILON && rect.size.y > CMP_EPSILON) {
-			real_t scale_x = viewport->get_size().x / rect.size.x;
-			real_t scale_y = viewport->get_size().y / rect.size.y;
-			zoom = scale_x < scale_y ? scale_x : scale_y;
-			zoom *= 0.90;
-			viewport->queue_redraw();
-			zoom_widget->set_zoom(zoom);
-			call_deferred(SNAME("_popup_callback"), VIEW_CENTER_TO_SELECTION);
-		}
+	if (p_op == VIEW_FRAME_TO_SELECTION && rect.size.x > CMP_EPSILON && rect.size.y > CMP_EPSILON) {
+		real_t scale_x = viewport->get_size().x / rect.size.x;
+		real_t scale_y = viewport->get_size().y / rect.size.y;
+		zoom = scale_x < scale_y ? scale_x : scale_y;
+		zoom *= 0.90;
+		zoom_widget->set_zoom(zoom);
+		viewport->queue_redraw(); // Redraw to update the global canvas transform after zoom changes.
+		call_deferred(SNAME("center_at"), rect.get_center()); // Defer because the updated transform is needed.
+	} else {
+		center_at(rect.get_center());
 	}
 }
 
@@ -4715,6 +4707,7 @@ void CanvasItemEditor::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_state"), &CanvasItemEditor::set_state);
 	ClassDB::bind_method(D_METHOD("update_viewport"), &CanvasItemEditor::update_viewport);
+	ClassDB::bind_method(D_METHOD("center_at", "position"), &CanvasItemEditor::center_at);
 
 	ClassDB::bind_method("_set_owner_for_node_and_children", &CanvasItemEditor::_set_owner_for_node_and_children);
 
@@ -4959,6 +4952,12 @@ VSplitContainer *CanvasItemEditor::get_bottom_split() {
 
 void CanvasItemEditor::focus_selection() {
 	_focus_selection(VIEW_CENTER_TO_SELECTION);
+}
+
+void CanvasItemEditor::center_at(const Point2 &p_pos) {
+	Vector2 offset = viewport->get_size() / 2 - EditorNode::get_singleton()->get_scene_root()->get_global_canvas_transform().xform(p_pos);
+	view_offset -= (offset / zoom).round();
+	update_viewport();
 }
 
 CanvasItemEditor::CanvasItemEditor() {

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -550,6 +550,7 @@ public:
 	void edit(CanvasItem *p_canvas_item);
 
 	void focus_selection();
+	void center_at(const Point2 &p_pos);
 
 	EditorSelection *editor_selection = nullptr;
 


### PR DESCRIPTION
Super helpful functionality that people are probably scratching their heads at because it doesn't work (it zooms in, but doesn't center itself on the selection). Anyway, all fixed:

https://user-images.githubusercontent.com/85438892/212076322-7de51966-d36c-4157-b823-e71de7ce8619.mp4

-----

<details>
<summary>Code specifics for reviewers</summary>

The reason it didn't work before was because `_popup_callback()` wasn't bound even though it had to be deferred. So without a warning, the call needed to center the selection didn't happen.

Instead of just binding it, I created a helper method `center_at(p_pos)` and passed the center of the selection to it. This is cleaner as Godot won't have to walk through `_focus_selection()` and recalculate the center all over.

Also simplified a bit of code earlier for which there is a dedicated method, since I like negative diffs.
</details>

-----

<details>
<summary>Wow take a look at what I found about this functionality!</summary>
It bypasses the limits for zoom in or out. So you can for example create a ColorRect, set its size to 0.001px and set its scale to 0.001, and then do Shift+F to get this craziness in Vanilla Godot:

![image](https://user-images.githubusercontent.com/85438892/212081249-f40c10ca-feaa-4fb4-9bf9-af3dc28ec8de.png)

At this zoom level you can see the effects of floating point precision less than a pixel away from (0, 0).

Works the other way around too:

![image](https://user-images.githubusercontent.com/85438892/212081628-308e5e54-b2c1-4497-afe9-bd1b55eb22bc.png)

Although this glitches out and trying to move things tends to snap them to (NAN, NAN).
</details>

-----