### PR TITLE
[Editor] Fix missing "debug"/"release" export presets feature tags.

### DIFF
--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -444,8 +444,10 @@ HashSet<String> EditorExportPlatform::get_features(const Ref<EditorExportPreset>
 
 	result.insert("template");
 	if (p_debug) {
+		result.insert("debug");
 		result.insert("template_debug");
 	} else {
+		result.insert("release");
 		result.insert("template_release");
 	}
 


### PR DESCRIPTION
So the same code can be used in editor and debug exports ("release" is kept for consistency).

Fixes #71090