### PR TITLE
`EditorProperty` Copy value also to the clipboard

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -922,7 +922,9 @@ Control *EditorProperty::make_custom_tooltip(const String &p_text) const {
 void EditorProperty::menu_option(int p_option) {
 	switch (p_option) {
 		case MENU_COPY_VALUE: {
-			InspectorDock::get_inspector_singleton()->set_property_clipboard(object->get(property));
+			Variant value = object->get(property);
+			InspectorDock::get_inspector_singleton()->set_property_clipboard(value);
+			DisplayServer::get_singleton()->clipboard_set(value.get_construct_string());
 		} break;
 		case MENU_PASTE_VALUE: {
 			emit_changed(property, InspectorDock::get_inspector_singleton()->get_property_clipboard());


### PR DESCRIPTION
"Copy Value" of property in the inspector was copying the value only within the context of the inspector, nothing was copied to the clipboard. See https://github.com/godotengine/godot/pull/66689#issuecomment-1266878345. Now `value.get_construct_string()` is set to the clipboard.

- This seems to work nice with the non-Object built-in types, including Arrays or Dictionaries (nested too).
- Enum values are copied as the underlying value so e.g. `0` instead of `PROCESS_MODE_INHERIT`.
- Not too useful for Resources, e.g.:
	- copying Texture produces something like `Resource("res://icon.svg")`,
	- copying scene's ShaderMaterial subresource produces `Object(ShaderMaterial,"resource_local_to_scene":false,"resource_name":"","shader":null,"script":null)`

Not sure if Resources should be handled somehow differently or if it's fine as is.