### PR TITLE
GDScript: Fix typing of iterator in for loop

### DIFF
--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -1253,7 +1253,7 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 			return _data._int > 0;
 		} break;
 		case FLOAT: {
-			r_iter = 0;
+			r_iter = 0.0;
 			return _data._float > 0.0;
 		} break;
 		case VECTOR2: {
@@ -1457,7 +1457,7 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 			return true;
 		} break;
 		case FLOAT: {
-			int64_t idx = r_iter;
+			double idx = r_iter;
 			idx++;
 			if (idx >= _data._float) {
 				return false;

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_constant_float.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_constant_float.gd
@@ -1,0 +1,6 @@
+const constant_float = 1.0
+
+func test():
+	for x in constant_float:
+		if x is String:
+			pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_constant_float.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_constant_float.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Expression is of type "float" so it can't be of type "String".

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_constant_int.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_constant_int.gd
@@ -1,0 +1,6 @@
+const constant_int = 1
+
+func test():
+	for x in constant_int:
+		if x is String:
+			pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_constant_int.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_constant_int.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Expression is of type "int" so it can't be of type "String".

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_enum_value.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_enum_value.gd
@@ -1,0 +1,6 @@
+enum { enum_value = 1 }
+
+func test():
+	for x in enum_value:
+		if x is String:
+			pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_enum_value.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_enum_value.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Expression is of type "int" so it can't be of type "String".

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_float.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_float.gd
@@ -1,0 +1,6 @@
+func test():
+	var hard_float := 1.0
+
+	for x in hard_float:
+		if x is String:
+			pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_float.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_float.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Expression is of type "float" so it can't be of type "String".

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_int.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_int.gd
@@ -1,0 +1,6 @@
+func test():
+	var hard_int := 1
+
+	for x in hard_int:
+		if x is String:
+			pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_int.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_int.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Expression is of type "int" so it can't be of type "String".

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_iterator.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_iterator.gd
@@ -1,0 +1,14 @@
+class Iterator:
+	func _iter_init(_count):
+		return true
+	func _iter_next(_count):
+		return false
+	func _iter_get(_count) -> StringName:
+		return &'custom'
+
+func test():
+	var hard_iterator := Iterator.new()
+
+	for x in hard_iterator:
+		if x is int:
+			pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_iterator.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_iterator.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Expression is of type "StringName" so it can't be of type "int".

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_string.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_string.gd
@@ -1,0 +1,6 @@
+func test():
+	var hard_string := 'a'
+
+	for x in hard_string:
+		if x is int:
+			pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_string.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_string.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Expression is of type "String" so it can't be of type "int".

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_literal_bool.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_literal_bool.gd
@@ -1,0 +1,3 @@
+func test():
+	for x in true:
+		pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_literal_bool.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_literal_bool.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Unable to iterate on value of type "bool".

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_literal_int.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_literal_int.gd
@@ -1,0 +1,4 @@
+func test():
+	for x in 1:
+		if x is String:
+			pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_literal_int.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_literal_int.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Expression is of type "int" so it can't be of type "String".

--- a/modules/gdscript/tests/scripts/analyzer/features/for_loop_on_variant.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/for_loop_on_variant.gd
@@ -1,0 +1,15 @@
+func test():
+	var variant_int: Variant = 1
+	var weak_int = 1
+
+	for x in variant_int:
+		if x is String:
+			print('never')
+		print(x)
+
+	for x in weak_int:
+		if x is String:
+			print('never')
+		print(x)
+
+	print('ok')

--- a/modules/gdscript/tests/scripts/analyzer/features/for_loop_on_variant.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/for_loop_on_variant.out
@@ -1,0 +1,4 @@
+GDTEST_OK
+0
+0
+ok

--- a/modules/gdscript/tests/scripts/runtime/features/for_loop_iterator_types.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/for_loop_iterator_types.gd
@@ -1,0 +1,51 @@
+const constant_float = 1.0
+const constant_int = 1
+enum { enum_value = 1 }
+
+class Iterator:
+	func _iter_init(_count):
+		return true
+	func _iter_next(_count):
+		return false
+	func _iter_get(_count) -> StringName:
+		return &'custom'
+
+func test():
+	var hard_float := 1.0
+	var hard_int := 1
+	var hard_string := '0'
+	var hard_iterator := Iterator.new()
+
+	var variant_float: Variant = hard_float
+	var variant_int: Variant = hard_int
+	var variant_string: Variant = hard_string
+	var variant_iterator: Variant = hard_iterator
+
+	for i in 1.0:
+		print(typeof(i) == TYPE_FLOAT)
+	for i in 1:
+		print(typeof(i) == TYPE_INT)
+	for i in 'a':
+		print(typeof(i) == TYPE_STRING)
+	for i in Iterator.new():
+		print(typeof(i) == TYPE_STRING_NAME)
+
+	for i in hard_float:
+		print(typeof(i) == TYPE_FLOAT)
+	for i in hard_int:
+		print(typeof(i) == TYPE_INT)
+	for i in hard_string:
+		print(typeof(i) == TYPE_STRING)
+	for i in hard_iterator:
+		print(typeof(i) == TYPE_STRING_NAME)
+
+	for i in variant_float:
+		print(typeof(i) == TYPE_FLOAT)
+	for i in variant_int:
+		print(typeof(i) == TYPE_INT)
+	for i in variant_string:
+		print(typeof(i) == TYPE_STRING)
+	for i in variant_iterator:
+		print(typeof(i) == TYPE_STRING_NAME)
+
+	print('ok')

--- a/modules/gdscript/tests/scripts/runtime/features/for_loop_iterator_types.out
+++ b/modules/gdscript/tests/scripts/runtime/features/for_loop_iterator_types.out
@@ -1,0 +1,14 @@
+GDTEST_OK
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+ok


### PR DESCRIPTION
Fixed missing typings for for-loop iterator:
```gdscript
for i in 1: # i is int
for i in 1.0: # i is float
for i in 'abc': # i is string
for i in custom_iterator: # i is return type of _iter_get
```

Fixed `iter_init` and `iter_next` of float Variant to match that of codegen behaviour:
```gdscript
for i in 1.0:
  print(typeof(i) == TYPE_FLOAT) # currently true
  
var variant_float: Variant = 1.0
for i in variant_float: 
  print(typeof(i) == TYPE_FLOAT) # currently false, now true
```

Marked for-in input as unsafe when variant/weak type is used. 

If a strong non-matching input is provided now an error is produced at analysis stage.

Made level of certainty for an iterator to match that of a provided input, so if an input has a weak type then an iterator will be weak too.

_Bugsquad edit:_ Fix #61727