### PR TITLE
Avoid color flash on window creation and resizing

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1262,6 +1262,12 @@
 				Tries to free an object in the RenderingServer.
 			</description>
 		</method>
+		<method name="get_default_clear_color">
+			<return type="Color" />
+			<description>
+				Returns the default clear color which is used when a specific clear color has not been selected.
+			</description>
+		</method>
 		<method name="get_frame_setup_time_cpu" qualifiers="const">
 			<return type="float" />
 			<description>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -688,6 +688,7 @@ void EditorNode::_notification(int p_what) {
 
 			if (theme_changed) {
 				theme = create_custom_theme(theme_base->get_theme());
+				DisplayServer::set_early_window_clear_color_override(true, theme->get_color(SNAME("background"), SNAME("Editor")));
 
 				theme_base->set_theme(theme);
 				gui_base->set_theme(theme);
@@ -6235,6 +6236,7 @@ EditorNode::EditorNode() {
 	// Exporters might need the theme.
 	EditorColorMap::create();
 	theme = create_custom_theme();
+	DisplayServer::set_early_window_clear_color_override(true, theme->get_color(SNAME("background"), SNAME("Editor")));
 
 	register_exporters();
 

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -753,6 +753,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Editor background
 	Color background_color_opaque = background_color;
 	background_color_opaque.a = 1.0;
+	theme->set_color("background", "Editor", background_color_opaque);
 	theme->set_stylebox("Background", "EditorStyles", make_flat_stylebox(background_color_opaque, default_margin_size, default_margin_size, default_margin_size, default_margin_size));
 
 	// Focus

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2653,8 +2653,9 @@ ProjectManager::ProjectManager() {
 		AcceptDialog::set_swap_cancel_ok(swap_cancel_ok == 2);
 	}
 
-	set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
-	set_theme(create_custom_theme());
+	Ref<Theme> theme = create_custom_theme();
+	set_theme(theme);
+	DisplayServer::set_early_window_clear_color_override(true, theme->get_color(SNAME("background"), SNAME("Editor")));
 
 	set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1920,6 +1920,9 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 			window_position = &position;
 		}
 
+		Color boot_bg_color = GLOBAL_DEF_BASIC("application/boot_splash/bg_color", boot_splash_bg_color);
+		DisplayServer::set_early_window_clear_color_override(true, boot_bg_color);
+
 		// rendering_driver now held in static global String in main and initialized in setup()
 		Error err;
 		display_server = DisplayServer::create(display_driver_idx, rendering_driver, window_mode, window_vsync_mode, window_flags, window_position, window_size, init_screen, err);
@@ -2085,7 +2088,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 			boot_logo->set_pixel(0, 0, Color(0, 0, 0, 0));
 		}
 
-		Color boot_bg_color = GLOBAL_DEF_BASIC("application/boot_splash/bg_color", boot_splash_bg_color);
+		Color boot_bg_color = GLOBAL_GET("application/boot_splash/bg_color");
 
 #if defined(TOOLS_ENABLED) && !defined(NO_EDITOR_SPLASH)
 		boot_bg_color =
@@ -2119,6 +2122,8 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		}
 #endif
 	}
+
+	DisplayServer::set_early_window_clear_color_override(false);
 
 	MAIN_PRINT("Main: DCC");
 	RenderingServer::get_singleton()->set_default_clear_color(

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -452,6 +452,8 @@ class DisplayServerWindows : public DisplayServer {
 	bool in_dispatch_input_event = false;
 
 	WNDCLASSEXW wc;
+	HBRUSH window_bkg_brush = nullptr;
+	uint32_t window_bkg_brush_color = 0;
 
 	HCURSOR cursors[CURSOR_MAX] = { nullptr };
 	CursorShape cursor_shape = CursorShape::CURSOR_ARROW;

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -38,6 +38,9 @@ DisplayServer *DisplayServer::singleton = nullptr;
 
 bool DisplayServer::hidpi_allowed = false;
 
+bool DisplayServer::window_early_clear_override_enabled = false;
+Color DisplayServer::window_early_clear_override_color = Color(0, 0, 0, 0);
+
 DisplayServer::DisplayServerCreate DisplayServer::server_create_functions[DisplayServer::MAX_SERVERS] = {
 	{ "headless", &DisplayServerHeadless::create_func, &DisplayServerHeadless::get_rendering_drivers_func }
 };
@@ -313,6 +316,23 @@ void DisplayServer::tts_post_utterance_event(TTSUtteranceEvent p_event, int p_id
 		default:
 			break;
 	}
+}
+
+bool DisplayServer::_get_window_early_clear_override(Color &r_color) {
+	if (window_early_clear_override_enabled) {
+		r_color = window_early_clear_override_color;
+		return true;
+	} else if (RenderingServer::get_singleton()) {
+		r_color = RenderingServer::get_singleton()->get_default_clear_color();
+		return true;
+	} else {
+		return false;
+	}
+}
+
+void DisplayServer::set_early_window_clear_color_override(bool p_enabled, Color p_color) {
+	window_early_clear_override_enabled = p_enabled;
+	window_early_clear_override_color = p_color;
 }
 
 void DisplayServer::mouse_set_mode(MouseMode p_mode) {

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -217,6 +217,16 @@ public:
 	virtual bool is_dark_mode() const { return false; };
 	virtual Color get_accent_color() const { return Color(0, 0, 0, 0); };
 
+private:
+	static bool window_early_clear_override_enabled;
+	static Color window_early_clear_override_color;
+
+protected:
+	static bool _get_window_early_clear_override(Color &r_color);
+
+public:
+	static void set_early_window_clear_color_override(bool p_enabled, Color p_color = Color(0, 0, 0, 0));
+
 	enum MouseMode {
 		MOUSE_MODE_VISIBLE,
 		MOUSE_MODE_HIDDEN,

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -291,6 +291,10 @@ void RenderingServerDefault::set_boot_image(const Ref<Image> &p_image, const Col
 	RSG::rasterizer->set_boot_image(p_image, p_color, p_scale, p_use_filter);
 }
 
+Color RenderingServerDefault::get_default_clear_color() {
+	return RSG::texture_storage->get_default_clear_color();
+}
+
 void RenderingServerDefault::set_default_clear_color(const Color &p_color) {
 	RSG::viewport->set_default_clear_color(p_color);
 }

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -986,6 +986,7 @@ public:
 	virtual double get_frame_setup_time_cpu() const override;
 
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) override;
+	virtual Color get_default_clear_color() override;
 	virtual void set_default_clear_color(const Color &p_color) override;
 
 	virtual bool has_feature(Features p_feature) const override;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2763,6 +2763,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_white_texture"), &RenderingServer::get_white_texture);
 
 	ClassDB::bind_method(D_METHOD("set_boot_image", "image", "color", "scale", "use_filter"), &RenderingServer::set_boot_image, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("get_default_clear_color"), &RenderingServer::get_default_clear_color);
 	ClassDB::bind_method(D_METHOD("set_default_clear_color", "color"), &RenderingServer::set_default_clear_color);
 
 	ClassDB::bind_method(D_METHOD("has_feature", "feature"), &RenderingServer::has_feature);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1560,6 +1560,7 @@ public:
 	virtual void mesh_add_surface_from_planes(RID p_mesh, const Vector<Plane> &p_planes);
 
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) = 0;
+	virtual Color get_default_clear_color() = 0;
 	virtual void set_default_clear_color(const Color &p_color) = 0;
 
 	enum Features {


### PR DESCRIPTION
On Windows (and maybe in some other windowing systems), when Godot creates a window, it's painted in white before the renderer has a chance to setup a swap chain or context. Windows being stretched also get the newly added region painted in that striking white for the brief time Godot can render something meaningful there.

This PR adds a little framework to let platform display managers to use a more suitable color in those early moments of the new pixels, plus it leverages it for Windows, where the flash of white is annoying.

All orbits around the concept of _early clear color override_:
- The very startup of the engine sets the color to the same of the splash screen.
- The editor and project manager use the theme background for that.
- In any other situation, as long as the rendering server has already been created, the default clear color is used.

I'm making this PR with the expectation that X11 and MacOS maintainers assess whether those platforms would benefit from this.

## BEFORE 🤮
https://user-images.githubusercontent.com/11797174/212178934-83538d63-974f-476a-b780-f9d09129b0d5.mp4

## AFTER 😍
https://user-images.githubusercontent.com/11797174/212178951-3f50fbee-2bce-473f-9722-5794b21be44f.mp4
