### PR TITLE
Remove normal_map from MeshInstance2D and MultiMeshInstance2D

### DIFF
--- a/doc/classes/MeshInstance2D.xml
+++ b/doc/classes/MeshInstance2D.xml
@@ -13,10 +13,6 @@
 		<member name="mesh" type="Mesh" setter="set_mesh" getter="get_mesh">
 			The [Mesh] that will be drawn by the [MeshInstance2D].
 		</member>
-		<member name="normal_map" type="Texture2D" setter="set_normal_map" getter="get_normal_map">
-			The normal map that will be used if using the default [CanvasItemMaterial].
-			[b]Note:[/b] Godot expects the normal map to use X+, Y+, and Z+ coordinates. See [url=http://wiki.polycount.com/wiki/Normal_Map_Technical_Details#Common_Swizzle_Coordinates]this page[/url] for a comparison of normal map coordinates expected by popular engines.
-		</member>
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			The [Texture2D] that will be used if using the default [CanvasItemMaterial]. Can be accessed as [code]TEXTURE[/code] in CanvasItem shader.
 		</member>

--- a/doc/classes/MultiMeshInstance2D.xml
+++ b/doc/classes/MultiMeshInstance2D.xml
@@ -13,10 +13,6 @@
 		<member name="multimesh" type="MultiMesh" setter="set_multimesh" getter="get_multimesh">
 			The [MultiMesh] that will be drawn by the [MultiMeshInstance2D].
 		</member>
-		<member name="normal_map" type="Texture2D" setter="set_normal_map" getter="get_normal_map">
-			The normal map that will be used if using the default [CanvasItemMaterial].
-			[b]Note:[/b] Godot expects the normal map to use X+, Y+, and Z+ coordinates. See [url=http://wiki.polycount.com/wiki/Normal_Map_Technical_Details#Common_Swizzle_Coordinates]this page[/url] for a comparison of normal map coordinates expected by popular engines.
-		</member>
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			The [Texture2D] that will be used if using the default [CanvasItemMaterial]. Can be accessed as [code]TEXTURE[/code] in CanvasItem shader.
 		</member>

--- a/scene/2d/mesh_instance_2d.cpp
+++ b/scene/2d/mesh_instance_2d.cpp
@@ -49,14 +49,10 @@ void MeshInstance2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_texture", "texture"), &MeshInstance2D::set_texture);
 	ClassDB::bind_method(D_METHOD("get_texture"), &MeshInstance2D::get_texture);
 
-	ClassDB::bind_method(D_METHOD("set_normal_map", "normal_map"), &MeshInstance2D::set_normal_map);
-	ClassDB::bind_method(D_METHOD("get_normal_map"), &MeshInstance2D::get_normal_map);
-
 	ADD_SIGNAL(MethodInfo("texture_changed"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh", PROPERTY_HINT_RESOURCE_TYPE, "Mesh"), "set_mesh", "get_mesh");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "normal_map", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_normal_map", "get_normal_map");
 }
 
 void MeshInstance2D::set_mesh(const Ref<Mesh> &p_mesh) {
@@ -75,15 +71,6 @@ void MeshInstance2D::set_texture(const Ref<Texture2D> &p_texture) {
 	texture = p_texture;
 	queue_redraw();
 	emit_signal(SceneStringNames::get_singleton()->texture_changed);
-}
-
-void MeshInstance2D::set_normal_map(const Ref<Texture2D> &p_texture) {
-	normal_map = p_texture;
-	queue_redraw();
-}
-
-Ref<Texture2D> MeshInstance2D::get_normal_map() const {
-	return normal_map;
 }
 
 Ref<Texture2D> MeshInstance2D::get_texture() const {

--- a/scene/2d/mesh_instance_2d.h
+++ b/scene/2d/mesh_instance_2d.h
@@ -39,7 +39,6 @@ class MeshInstance2D : public Node2D {
 	Ref<Mesh> mesh;
 
 	Ref<Texture2D> texture;
-	Ref<Texture2D> normal_map;
 
 protected:
 	void _notification(int p_what);
@@ -56,9 +55,6 @@ public:
 
 	void set_texture(const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_texture() const;
-
-	void set_normal_map(const Ref<Texture2D> &p_texture);
-	Ref<Texture2D> get_normal_map() const;
 
 	MeshInstance2D();
 };

--- a/scene/2d/multimesh_instance_2d.cpp
+++ b/scene/2d/multimesh_instance_2d.cpp
@@ -50,14 +50,10 @@ void MultiMeshInstance2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_texture", "texture"), &MultiMeshInstance2D::set_texture);
 	ClassDB::bind_method(D_METHOD("get_texture"), &MultiMeshInstance2D::get_texture);
 
-	ClassDB::bind_method(D_METHOD("set_normal_map", "normal_map"), &MultiMeshInstance2D::set_normal_map);
-	ClassDB::bind_method(D_METHOD("get_normal_map"), &MultiMeshInstance2D::get_normal_map);
-
 	ADD_SIGNAL(MethodInfo("texture_changed"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "multimesh", PROPERTY_HINT_RESOURCE_TYPE, "MultiMesh"), "set_multimesh", "get_multimesh");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "normal_map", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_normal_map", "get_normal_map");
 }
 
 void MultiMeshInstance2D::set_multimesh(const Ref<MultiMesh> &p_multimesh) {
@@ -89,15 +85,6 @@ void MultiMeshInstance2D::set_texture(const Ref<Texture2D> &p_texture) {
 
 Ref<Texture2D> MultiMeshInstance2D::get_texture() const {
 	return texture;
-}
-
-void MultiMeshInstance2D::set_normal_map(const Ref<Texture2D> &p_texture) {
-	normal_map = p_texture;
-	queue_redraw();
-}
-
-Ref<Texture2D> MultiMeshInstance2D::get_normal_map() const {
-	return normal_map;
 }
 
 #ifdef TOOLS_ENABLED

--- a/scene/2d/multimesh_instance_2d.h
+++ b/scene/2d/multimesh_instance_2d.h
@@ -40,7 +40,6 @@ class MultiMeshInstance2D : public Node2D {
 	Ref<MultiMesh> multimesh;
 
 	Ref<Texture2D> texture;
-	Ref<Texture2D> normal_map;
 
 protected:
 	void _notification(int p_what);
@@ -56,9 +55,6 @@ public:
 
 	void set_texture(const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_texture() const;
-
-	void set_normal_map(const Ref<Texture2D> &p_texture);
-	Ref<Texture2D> get_normal_map() const;
 
 	MultiMeshInstance2D();
 	~MultiMeshInstance2D();


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/62855

Meshinstance2D and MultiMeshInstance2D were missed in https://github.com/godotengine/godot/pull/43052 where the normal map functionality was removed and the property was removed from all other 2D nodes. 

The approach now is to use a CanvasTexture to apply lighting properties (diffuse, specular, normals).

Not tagging as a breaking change as the properties/functions did nothing before, but this will break GDScripts where the property is set programatically. 
