### PR TITLE
Fix file formatting script dependencies and cleanup

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install -qq dos2unix recode clang-format-15 libxml2-utils python3-pip moreutils
+          sudo apt-get install -qq dos2unix clang-format-15 libxml2-utils python3-pip moreutils
           sudo update-alternatives --remove-all clang-format || true
           sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-15 100
           sudo pip3 install black==22.3.0 pygments pytest==7.1.2 mypy==0.971

--- a/misc/scripts/file_format.sh
+++ b/misc/scripts/file_format.sh
@@ -4,9 +4,9 @@
 # This is supplementary to clang_format.sh and black_format.sh, but should be
 # run before them.
 
-# We need dos2unix and recode.
-if [ ! -x "$(command -v dos2unix)" -o ! -x "$(command -v recode)" ]; then
-    printf "Install 'dos2unix' and 'recode' to use this script.\n"
+# We need dos2unix and isutf8.
+if [ ! -x "$(command -v dos2unix)" -o ! -x "$(command -v isutf8)" ]; then
+    printf "Install 'dos2unix' and 'isutf8' (moreutils package) to use this script.\n"
 fi
 
 set -uo pipefail
@@ -53,21 +53,23 @@ done
 
 diff=$(git diff --color)
 
-# If no UTF-8 violations were collected and no diff has been
-# generated all is OK, clean up, and exit.
 if [ ! -s utf8-validation.txt ] && [ -z "$diff" ] ; then
+    # If no UTF-8 violations were collected (the file is empty) and
+    # no diff has been generated all is OK, clean up, and exit.
     printf "Files in this commit comply with the formatting rules.\n"
-    rm -f utf8-violations.txt
+    rm -f utf8-validation.txt
     exit 0
 fi
 
-# Violations detected, notify the user, clean up, and exit.
 if [ -s utf8-validation.txt ]
 then
+    # If the file has content and is not empty, violations
+    # detected, notify the user, clean up, and exit.
     printf "\n*** The following files contain invalid UTF-8 character sequences:\n\n"
     cat utf8-validation.txt
-    rm -f utf8-validation.txt
 fi
+
+rm -f utf8-validation.txt
 
 if [ ! -z "$diff" ]
 then


### PR DESCRIPTION
This PR fixes two things:

* Fix incorrect dependencies at the top of the script. As of #65358, `isutf8` is required, not `recode`. Also update the error message to list the package.

* Fix `utf8-validation.txt` not being cleaned up. There were actually two problems here:
    - One is that in one place it was mistakenly named "violations" instead of "validation".
    - The `-s` file test operator checks if the file is not empty (see https://tldp.org/LDP/abs/html/fto.html), so an empty file was being left behind in cases where there were no errors.

Due to #65500, this should also be cherry-picked to 3.x.