### PR TITLE
New switch 'At Time' option to AnimationStateMachineTransition

### DIFF
--- a/doc/classes/AnimationNodeStateMachineTransition.xml
+++ b/doc/classes/AnimationNodeStateMachineTransition.xml
@@ -31,6 +31,10 @@
 		<member name="switch_mode" type="int" setter="set_switch_mode" getter="get_switch_mode" enum="AnimationNodeStateMachineTransition.SwitchMode" default="0">
 			The transition type.
 		</member>
+		<member name="switch_target_offset" type="float" setter="set_switch_target_offset" getter="get_switch_target_offset" default="0.0">
+		</member>
+		<member name="switch_time" type="float" setter="set_switch_time" getter="get_switch_time" default="0.0">
+		</member>
 		<member name="xfade_curve" type="Curve" setter="set_xfade_curve" getter="get_xfade_curve">
 			Ease curve for better control over cross-fade between this state and the next.
 		</member>
@@ -55,7 +59,9 @@
 		<constant name="SWITCH_MODE_AT_END" value="2" enum="SwitchMode">
 			Wait for the current state playback to end, then switch to the beginning of the next state animation.
 		</constant>
-		<constant name="ADVANCE_MODE_DISABLED" value="0" enum="AdvanceMode">
+		<constant name="SWITCH_MODE_AT_TIME" value="3" enum="SwitchMode">
+			Wait for a discreet time window before evaluating, then switch to a time in the next state animation.
+		</constant>		<constant name="ADVANCE_MODE_DISABLED" value="0" enum="AdvanceMode">
 			Don't use this transition.
 		</constant>
 		<constant name="ADVANCE_MODE_ENABLED" value="1" enum="AdvanceMode">

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1128,6 +1128,12 @@ void AnimationNodeStateMachineEditor::_add_transition(const bool p_nested_action
 }
 
 void AnimationNodeStateMachineEditor::_connection_draw(const Vector2 &p_from, const Vector2 &p_to, AnimationNodeStateMachineTransition::SwitchMode p_mode, bool p_enabled, bool p_selected, bool p_travel, bool p_auto_advance, bool p_multi_transitions) {
+	// Prevents a crash if the mode is invalid.
+	if (p_mode >= AnimationNodeStateMachineTransition::SWITCH_MODE_COUNT) {
+		p_mode = AnimationNodeStateMachineTransition::SWITCH_MODE_IMMEDIATE;
+		p_enabled = false;
+	}
+
 	Color linecolor = get_theme_color(SNAME("font_color"), SNAME("Label"));
 	Color icon_color(1, 1, 1);
 	Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
@@ -1138,13 +1144,15 @@ void AnimationNodeStateMachineEditor::_connection_draw(const Vector2 &p_from, co
 		accent.a *= 0.6;
 	}
 
-	const Ref<Texture2D> icons[6] = {
+	const Ref<Texture2D> icons[8] = {
 		get_theme_icon(SNAME("TransitionImmediateBig"), SNAME("EditorIcons")),
 		get_theme_icon(SNAME("TransitionSyncBig"), SNAME("EditorIcons")),
 		get_theme_icon(SNAME("TransitionEndBig"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("TransitionEndBig"), SNAME("EditorIcons")),
 		get_theme_icon(SNAME("TransitionImmediateAutoBig"), SNAME("EditorIcons")),
 		get_theme_icon(SNAME("TransitionSyncAutoBig"), SNAME("EditorIcons")),
-		get_theme_icon(SNAME("TransitionEndAutoBig"), SNAME("EditorIcons"))
+		get_theme_icon(SNAME("TransitionEndAutoBig"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("TransitionEndAutoBig"), SNAME("EditorIcons")),
 	};
 
 	if (p_selected) {
@@ -1158,7 +1166,7 @@ void AnimationNodeStateMachineEditor::_connection_draw(const Vector2 &p_from, co
 
 	state_machine_draw->draw_line(p_from, p_to, linecolor, 2);
 
-	Ref<Texture2D> icon = icons[p_mode + (p_auto_advance ? 3 : 0)];
+	Ref<Texture2D> icon = icons[p_mode + (p_auto_advance ? 4 : 0)];
 
 	Transform2D xf;
 	xf.columns[0] = (p_to - p_from).normalized();

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -42,6 +42,8 @@ public:
 		SWITCH_MODE_IMMEDIATE,
 		SWITCH_MODE_SYNC,
 		SWITCH_MODE_AT_END,
+		SWITCH_MODE_AT_TIME,
+		SWITCH_MODE_COUNT
 	};
 
 	enum AdvanceMode {
@@ -52,6 +54,8 @@ public:
 
 private:
 	SwitchMode switch_mode = SWITCH_MODE_IMMEDIATE;
+	float switch_time = 0.0;
+	float switch_target_offset = 0.0;
 	AdvanceMode advance_mode = ADVANCE_MODE_ENABLED;
 	StringName advance_condition;
 	StringName advance_condition_name;
@@ -69,6 +73,12 @@ protected:
 public:
 	void set_switch_mode(SwitchMode p_mode);
 	SwitchMode get_switch_mode() const;
+
+	void set_switch_time(float p_time);
+	float get_switch_time() const;
+
+	void set_switch_target_offset(float p_time);
+	float get_switch_target_offset() const;
 
 	void set_advance_mode(AdvanceMode p_mode);
 	AdvanceMode get_advance_mode() const;
@@ -115,7 +125,9 @@ class AnimationNodeStateMachinePlayback : public Resource {
 	};
 
 	double len_current = 0.0;
+	double pos_previous = 0.0;
 	double pos_current = 0.0;
+	int cycle_count = 0; // The amount of times an animation has looped.
 	bool end_loop = false;
 
 	StringName current;
@@ -138,6 +150,7 @@ class AnimationNodeStateMachinePlayback : public Resource {
 
 	double process(AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking);
 
+	bool _check_transition_time_is_valid(const Ref<AnimationNodeStateMachine> p_state_machine, const Ref<AnimationNodeStateMachineTransition> transition, float p_pos_current, float p_len_current, int p_cycle_count) const;
 	bool _check_advance_condition(const Ref<AnimationNodeStateMachine> p_state_machine, const Ref<AnimationNodeStateMachineTransition> p_transition) const;
 
 protected:


### PR DESCRIPTION
PR to add support for a new switch type which allows specifying an exact time (as a ratio) in the AnimationStateMachineTransition. This will allow you to add discreet 'evaluation windows' during an animation when to evaluate if we can switch to another for things like mid-animation interruption.

Keeping as a draft for now until additional features and usability are improved:
- [ ] Add support for full min-time and max-time for when to switch.
- [ ] Improve Inspector to provide a much easier UX for setting up transition windows in an intuitive fashion.
- [ ] Add full documentation.