### PR TITLE
Only setup depth framebuffer properties when not rendering ReflectionProbes

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1707,7 +1707,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 
 	RD::get_singleton()->draw_command_end_label();
 
-	if (rb.is_valid()) {
+	if (rb.is_valid() && !p_render_data->reflection_probe.is_valid()) {
 		if (using_voxelgi) {
 			depth_pass_mode = PASS_MODE_DEPTH_NORMAL_ROUGHNESS_VOXEL_GI;
 		} else if (p_render_data->environment.is_valid()) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/71301

This was my mistake in https://github.com/godotengine/godot/pull/71130 The code there was moved down from a branch of the form
```
if (p_render_data->reflection_probe.is_valid()) {
...
} else if (rb.is_valid()) {
...
}
```

Accordingly, it wasn't enough to only check if ``rb`` was valid. We need to also ensure that we are not in a reflection probe pass. 