### PR TITLE
Properly expose SCREEN_TEXTURE when using physical light units

### DIFF
--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -1311,6 +1311,9 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 					if (is_screen_texture && actions.apply_luminance_multiplier) {
 						code = "(" + code + " * vec4(vec3(sc_luminance_multiplier), 1.0))";
 					}
+					if (is_screen_texture && GLOBAL_GET("rendering/lights_and_shadows/use_physical_light_units")) {
+						code = "(" + code + " / vec4(vec3(scene_data.emissive_exposure_normalization), 1.0))";
+					}
 				} break;
 				case SL::OP_INDEX: {
 					code += _dump_node_code(onode->arguments[0], p_level, r_gen_code, p_actions, p_default_actions, p_assigning);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/69847

We have to detect anytime that ``SCREEN_TEXTURE`` is used and add a division by the emission normalization amount. This works because the emission normalization amount is ``1.0 / exposure``. Accordingly, this brings the results of reading ``SCREEN_TEXTURE`` back to their full pre-exposure brightness.

While this makes sense for the use case in #69847, I am unsure whether it is preferable to present ``SCREEN_TEXTURE`` in the pre-exposure brightness or its post-exposure brightness. With this PR, reading from the ``SCREEN_TEXTURE`` and assigning it to ``ALBEDO`` will make the object way too bright. 

I think a better solution here will be to introduce a new built in to the scene shader that allows the shader author to expose values as they see fit. I.e. something like ``PHYSICAL_EXPOSURE`` which would also be ``1.0`` when physical light units is disabled. We could then easily insert that in the code block for refraction to get a proper colour balance. 

What do you think @arnklit?