### PR TITLE
Fix duplicate NavigationServer process

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3035,7 +3035,6 @@ bool Main::iteration() {
 			break;
 		}
 
-		NavigationServer3D::get_singleton()->process(physics_step * time_scale);
 		uint64_t navigation_begin = OS::get_singleton()->get_ticks_usec();
 
 		NavigationServer3D::get_singleton()->process(physics_step * time_scale);

--- a/main/performance.cpp
+++ b/main/performance.cpp
@@ -249,6 +249,9 @@ Performance::MonitorType Performance::get_monitor_type(Monitor p_monitor) const 
 		MONITOR_TYPE_QUANTITY,
 		MONITOR_TYPE_QUANTITY,
 		MONITOR_TYPE_QUANTITY,
+		MONITOR_TYPE_QUANTITY,
+		MONITOR_TYPE_QUANTITY,
+		MONITOR_TYPE_QUANTITY,
 
 	};
 


### PR DESCRIPTION
NavigationServer process was called twice each frame.

Regression added with recent https://github.com/godotengine/godot/pull/70731 .... don't rebase or review pr's while tipsy.

Also adds 3 missing MONITOR_TYPE entries.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
