### PR TITLE
Add few methods to retrieve specified cells from `TileMap`

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -188,6 +188,22 @@
 				Returns a [Vector2] array with the positions of all cells containing a tile in the given layer. A cell is considered empty if its source identifier equals -1, its atlas coordinates identifiers is [code]Vector2(-1, -1)[/code] and its alternative identifier is -1.
 			</description>
 		</method>
+		<method name="get_used_cells_by_alternative_tile" qualifiers="const">
+			<return type="Vector2i[]" />
+			<param index="0" name="layer" type="int" />
+			<param index="1" name="alternative_tile" type="int" />
+			<description>
+				Returns an array of all cells from the given layer with the given alternative tile index specified in [param alternative_tile].
+			</description>
+		</method>
+		<method name="get_used_cells_by_source_id" qualifiers="const">
+			<return type="Vector2i[]" />
+			<param index="0" name="layer" type="int" />
+			<param index="1" name="source_id" type="int" />
+			<description>
+				Returns an array of all cells from the given layer with the given source index specified in [param source_id].
+			</description>
+		</method>
 		<method name="get_used_rect">
 			<return type="Rect2i" />
 			<description>

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -3738,6 +3738,34 @@ TypedArray<Vector2i> TileMap::get_used_cells(int p_layer) const {
 	return a;
 }
 
+TypedArray<Vector2i> TileMap::get_used_cells_by_source_id(int p_layer, int p_source_id) const {
+	ERR_FAIL_INDEX_V(p_layer, (int)layers.size(), TypedArray<Vector2i>());
+
+	TypedArray<Vector2i> a;
+	for (const KeyValue<Vector2i, TileMapCell> &E : layers[p_layer].tile_map) {
+		if (E.value.source_id == p_source_id) {
+			Vector2i p(E.key.x, E.key.y);
+			a.push_back(p);
+		}
+	}
+
+	return a;
+}
+
+TypedArray<Vector2i> TileMap::get_used_cells_by_alternative_tile(int p_layer, int p_alternative_tile) const {
+	ERR_FAIL_INDEX_V(p_layer, (int)layers.size(), TypedArray<Vector2i>());
+
+	TypedArray<Vector2i> a;
+	for (const KeyValue<Vector2i, TileMapCell> &E : layers[p_layer].tile_map) {
+		if (E.value.alternative_tile == p_alternative_tile) {
+			Vector2i p(E.key.x, E.key.y);
+			a.push_back(p);
+		}
+	}
+
+	return a;
+}
+
 Rect2i TileMap::get_used_rect() { // Not const because of cache
 	// Return the rect of the currently used area
 	if (used_rect_cache_dirty) {
@@ -4030,6 +4058,8 @@ void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_surrounding_cells", "coords"), &TileMap::get_surrounding_cells);
 
 	ClassDB::bind_method(D_METHOD("get_used_cells", "layer"), &TileMap::get_used_cells);
+	ClassDB::bind_method(D_METHOD("get_used_cells_by_source_id", "layer", "source_id"), &TileMap::get_used_cells_by_source_id);
+	ClassDB::bind_method(D_METHOD("get_used_cells_by_alternative_tile", "layer", "alternative_tile"), &TileMap::get_used_cells_by_alternative_tile);
 	ClassDB::bind_method(D_METHOD("get_used_rect"), &TileMap::get_used_rect);
 
 	ClassDB::bind_method(D_METHOD("map_to_local", "map_position"), &TileMap::map_to_local);

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -377,6 +377,8 @@ public:
 	Vector2i get_neighbor_cell(const Vector2i &p_coords, TileSet::CellNeighbor p_cell_neighbor) const;
 
 	TypedArray<Vector2i> get_used_cells(int p_layer) const;
+	TypedArray<Vector2i> get_used_cells_by_source_id(int p_layer, int p_source_id) const;
+	TypedArray<Vector2i> get_used_cells_by_alternative_tile(int p_layer, int p_alternative_tile) const;
 	Rect2i get_used_rect(); // Not const because of cache
 
 	// Override some methods of the CanvasItem class to pass the changes to the quadrants CanvasItems


### PR DESCRIPTION
Adds `get_used_cells_by_source_id` and `get_used_cells_by_alternative_tile` methods to the `TileMap` class.
Fix https://github.com/godotengine/godot/issues/71286