### PR TITLE
[3.x] Make CollisionShape selection box use shape AABB

### DIFF
--- a/scene/3d/collision_shape.cpp
+++ b/scene/3d/collision_shape.cpp
@@ -141,6 +141,18 @@ String CollisionShape::get_configuration_warning() const {
 	return warning;
 }
 
+#ifdef TOOLS_ENABLED
+AABB CollisionShape::get_fallback_gizmo_aabb() const {
+	if (shape.is_null()) {
+		return Spatial::get_fallback_gizmo_aabb();
+	}
+
+	// get_debug_mesh() is not const because the mesh is lazy initialized and cached.
+	// It would be better if we can mark the cache mutable and make get_debug_mesh() const.
+	return const_cast<CollisionShape *>(this)->shape->get_debug_mesh()->get_aabb();
+}
+#endif
+
 void CollisionShape::_bind_methods() {
 	//not sure if this should do anything
 	ClassDB::bind_method(D_METHOD("resource_changed", "resource"), &CollisionShape::resource_changed);

--- a/scene/3d/collision_shape.h
+++ b/scene/3d/collision_shape.h
@@ -64,6 +64,10 @@ public:
 
 	String get_configuration_warning() const;
 
+#ifdef TOOLS_ENABLED
+	virtual AABB get_fallback_gizmo_aabb() const;
+#endif
+
 	CollisionShape();
 	~CollisionShape();
 };


### PR DESCRIPTION
The orange selection box is always shown for Spatial nodes in 3.x.

A CollisionShape is not a VisualInstance so it does not have a AABB itself, and the editor used a fixed fallback AABB. This can produce unexpected selection box for ancestor nodes.

This PR makes use of the shape's AABB. When no shape is assigned, it still falls back to the fixed size AABB.

| Before | After |
|----|----|
|![before](https://user-images.githubusercontent.com/372476/212296800-8b22df5c-4089-4fc3-8c8a-533bf9ca67e4.png) | ![after](https://user-images.githubusercontent.com/372476/212296794-03d68690-c8db-4d34-8a1f-1652115f2d5e.png) |