### PR TITLE
Implement toggling pause / stop button to AnimationPlayerEditor

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -94,6 +94,7 @@ void AnimationPlayerEditor::_notification(int p_what) {
 				// Need the last frame after it stopped.
 				frame->set_value(player->get_current_animation_position());
 				track_editor->set_anim_pos(player->get_current_animation_position());
+				stop->set_icon(stop_icon);
 			}
 
 			last_active = player->is_playing();
@@ -119,8 +120,15 @@ void AnimationPlayerEditor::_notification(int p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_THEME_CHANGED: {
-			autoplay->set_icon(get_theme_icon(SNAME("AutoPlay"), SNAME("EditorIcons")));
+			stop_icon = get_theme_icon(SNAME("Stop"), SNAME("EditorIcons"));
+			pause_icon = get_theme_icon(SNAME("Pause"), SNAME("EditorIcons"));
+			if (player && player->is_playing()) {
+				stop->set_icon(pause_icon);
+			} else {
+				stop->set_icon(stop_icon);
+			}
 
+			autoplay->set_icon(get_theme_icon(SNAME("AutoPlay"), SNAME("EditorIcons")));
 			play->set_icon(get_theme_icon(SNAME("PlayStart"), SNAME("EditorIcons")));
 			play_from->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
 			play_bw->set_icon(get_theme_icon(SNAME("PlayStartBackwards"), SNAME("EditorIcons")));
@@ -137,7 +145,6 @@ void AnimationPlayerEditor::_notification(int p_what) {
 				autoplay_reset_img->blit_rect(reset_img, Rect2i(Point2i(), icon_size), Point2i(icon_size.x, 0));
 				autoplay_reset_icon = ImageTexture::create_from_image(autoplay_reset_img);
 			}
-			stop->set_icon(get_theme_icon(SNAME("Stop"), SNAME("EditorIcons")));
 
 			onion_toggle->set_icon(get_theme_icon(SNAME("Onion"), SNAME("EditorIcons")));
 			onion_skinning->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
@@ -204,7 +211,7 @@ void AnimationPlayerEditor::_play_pressed() {
 	}
 
 	//unstop
-	stop->set_pressed(false);
+	stop->set_icon(pause_icon);
 }
 
 void AnimationPlayerEditor::_play_from_pressed() {
@@ -221,7 +228,7 @@ void AnimationPlayerEditor::_play_from_pressed() {
 	}
 
 	//unstop
-	stop->set_pressed(false);
+	stop->set_icon(pause_icon);
 }
 
 String AnimationPlayerEditor::_get_current() const {
@@ -242,7 +249,7 @@ void AnimationPlayerEditor::_play_bw_pressed() {
 	}
 
 	//unstop
-	stop->set_pressed(false);
+	stop->set_icon(pause_icon);
 }
 
 void AnimationPlayerEditor::_play_bw_from_pressed() {
@@ -259,7 +266,7 @@ void AnimationPlayerEditor::_play_bw_from_pressed() {
 	}
 
 	//unstop
-	stop->set_pressed(false);
+	stop->set_icon(pause_icon);
 }
 
 void AnimationPlayerEditor::_stop_pressed() {
@@ -267,9 +274,16 @@ void AnimationPlayerEditor::_stop_pressed() {
 		return;
 	}
 
-	player->pause();
-	play->set_pressed(false);
-	stop->set_pressed(true);
+	if (player->is_playing()) {
+		player->pause();
+	} else {
+		String current = _get_current();
+		player->stop();
+		player->set_assigned_animation(current);
+		frame->set_value(0);
+		track_editor->set_anim_pos(0);
+	}
+	stop->set_icon(stop_icon);
 }
 
 void AnimationPlayerEditor::_animation_selected(int p_which) {
@@ -798,12 +812,9 @@ void AnimationPlayerEditor::_update_animation() {
 	updating = true;
 
 	if (player->is_playing()) {
-		play->set_pressed(true);
-		stop->set_pressed(false);
-
+		stop->set_icon(pause_icon);
 	} else {
-		play->set_pressed(false);
-		stop->set_pressed(true);
+		stop->set_icon(stop_icon);
 	}
 
 	scale->set_text(String::num(player->get_speed_scale(), 2));
@@ -1663,7 +1674,6 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 
 	stop = memnew(Button);
 	stop->set_flat(true);
-	stop->set_toggle_mode(true);
 	hb->add_child(stop);
 	stop->set_tooltip_text(TTR("Stop animation playback. (S)"));
 

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -101,6 +101,8 @@ class AnimationPlayerEditor : public VBoxContainer {
 	OptionButton *library = nullptr;
 	Label *name_title = nullptr;
 
+	Ref<Texture2D> stop_icon;
+	Ref<Texture2D> pause_icon;
 	Ref<Texture2D> autoplay_icon;
 	Ref<Texture2D> reset_icon;
 	Ref<ImageTexture> autoplay_reset_icon;


### PR DESCRIPTION
**This PR depends on #33733, recommended that we merge #33733 first.**

Make the button for stopping the AnimationPlayerEditor to be the Pause button during playback and the Stop button otherwise (while pausing), to clarify operation of resetting the animation position.

https://user-images.githubusercontent.com/61938263/212312788-269602d7-0884-4c20-8a2b-4a8a65487751.mp4
