### PR TITLE
[RichTextLabel] Match minimum size calculation of Label (proper content fitting)

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -8,7 +8,7 @@
 		[b]Note:[/b] Assignments to [member text] clear the tag stack and reconstruct it from the property's contents. Any edits made to [member text] will erase previous edits made from other manual sources such as [method append_text] and the [code]push_*[/code] / [method pop] methods.
 		[b]Note:[/b] RichTextLabel doesn't support entangled BBCode tags. For example, instead of using [code][b]bold[i]bold italic[/b]italic[/i][/code], use [code][b]bold[i]bold italic[/i][/b][i]italic[/i][/code].
 		[b]Note:[/b] [code]push_*/pop[/code] functions won't affect BBCode.
-		[b]Note:[/b] Unlike [Label], RichTextLabel doesn't have a [i]property[/i] to horizontally align text to the center. Instead, enable [member bbcode_enabled] and surround the text in a [code][center][/code] tag as follows: [code][center]Example[/center][/code]. There is currently no built-in way to vertically align text either, but this can be emulated by relying on anchors/containers and the [member fit_content_height] property.
+		[b]Note:[/b] Unlike [Label], RichTextLabel doesn't have a [i]property[/i] to horizontally align text to the center. Instead, enable [member bbcode_enabled] and surround the text in a [code][center][/code] tag as follows: [code][center]Example[/center][/code]. There is currently no built-in way to vertically align text either, but this can be emulated by relying on anchors/containers and the [member fit_content] property.
 	</description>
 	<tutorials>
 		<link title="BBCode in RichTextLabel">$DOCS_URL/tutorials/ui/bbcode_in_richtextlabel.html</link>
@@ -473,9 +473,8 @@
 		<member name="deselect_on_focus_loss_enabled" type="bool" setter="set_deselect_on_focus_loss_enabled" getter="is_deselect_on_focus_loss_enabled" default="true">
 			If [code]true[/code], the selected text will be deselected when focus is lost.
 		</member>
-		<member name="fit_content_height" type="bool" setter="set_fit_content_height" getter="is_fit_content_height_enabled" default="false">
-			If [code]true[/code], the label's height will be automatically updated to fit its content.
-			[b]Note:[/b] This property is used as a workaround to fix issues with [RichTextLabel] in [Container]s, but it's unreliable in some cases and will be removed in future versions.
+		<member name="fit_content" type="bool" setter="set_fit_content" getter="is_fit_content_enabled" default="false">
+			If [code]true[/code], the label's minimum size will be automatically updated to fit its content, matching the behavior of [Label].
 		</member>
 		<member name="hint_underlined" type="bool" setter="set_hint_underline" getter="is_hint_underlined" default="true">
 			If [code]true[/code], the label underlines hint tags such as [code][hint=description]{text}[/hint][/code].

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -566,7 +566,7 @@ ConnectDialog::~ConnectDialog() {
 // Originally copied and adapted from EditorProperty, try to keep style in sync.
 Control *ConnectionsDockTree::make_custom_tooltip(const String &p_text) const {
 	EditorHelpBit *help_bit = memnew(EditorHelpBit);
-	help_bit->get_rich_text()->set_fixed_size_to_width(360 * EDSCALE);
+	help_bit->get_rich_text()->set_custom_minimum_size(Size2(360 * EDSCALE, 1));
 
 	// p_text is expected to be something like this:
 	// "gui_input::(event: InputEvent)::<Signal description>"

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2370,7 +2370,7 @@ EditorHelpBit::EditorHelpBit() {
 	rich_text = memnew(RichTextLabel);
 	add_child(rich_text);
 	rich_text->connect("meta_clicked", callable_mp(this, &EditorHelpBit::_meta_clicked));
-	rich_text->set_fit_content_height(true);
+	rich_text->set_fit_content(true);
 	set_custom_minimum_size(Size2(0, 50 * EDSCALE));
 }
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -886,7 +886,7 @@ void EditorProperty::_update_pin_flags() {
 
 static Control *make_help_bit(const String &p_text, bool p_property) {
 	EditorHelpBit *help_bit = memnew(EditorHelpBit);
-	help_bit->get_rich_text()->set_fixed_size_to_width(360 * EDSCALE);
+	help_bit->get_rich_text()->set_custom_minimum_size(Size2(360 * EDSCALE, 1));
 
 	PackedStringArray slices = p_text.split("::", false);
 	if (slices.is_empty()) {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -524,9 +524,7 @@ private:
 	bool use_bbcode = false;
 	String text;
 
-	int fixed_width = -1;
-
-	bool fit_content_height = false;
+	bool fit_content = false;
 
 	struct ThemeCache {
 		Ref<StyleBox> normal_style;
@@ -640,8 +638,8 @@ public:
 	void set_shortcut_keys_enabled(bool p_enabled);
 	bool is_shortcut_keys_enabled() const;
 
-	void set_fit_content_height(bool p_enabled);
-	bool is_fit_content_height_enabled() const;
+	void set_fit_content(bool p_enabled);
+	bool is_fit_content_enabled() const;
 
 	bool search(const String &p_string, bool p_from_selection = false, bool p_search_previous = false);
 
@@ -731,7 +729,6 @@ public:
 
 	void install_effect(const Variant effect);
 
-	void set_fixed_size_to_width(int p_width);
 	virtual Size2 get_minimum_size() const override;
 
 	RichTextLabel(const String &p_text = String());


### PR DESCRIPTION

![rtl-demo-v2](https://user-images.githubusercontent.com/50084500/212339141-d4fb758a-2675-42d0-8937-c217686c1ab9.gif)

This PR aims to fix #18260 by matching Label's sizing behavior (optional via the `fit_content` property).

**Detailed changes**:
- Replace the `fit_content_height` property with `fit_content` since it affects both width and height
- Remove `set_fixed_size_to_width(bool)` which was a rather hacky solution; now the same can be achieved with `set_custom_minimum_size(Vector2)` like with e.g. `Label` or `FlowContainer`, making it more consistent with Godot's GUI system

**Things to discuss**:
1. Enable `fit_content` per default to match the behavior of `Label` ?
2. Combine `get_content_width()` + `get_content_height()` into `get_content_size()` method or unexpose/remove them (since `get_minimum_size()` return the correct values in most cases)?

Tested with Right-To-Left text and in threaded mode. 
In addition I think there might be room for some optimization (e.g. caching the content size, especially if we decide for 2.), but that's for a later PR.

As always, testing and feedback is much appreciated :)

