### PR TITLE
Fixes TileSet atlas merging not working correctly

### DIFF
--- a/editor/plugins/tiles/atlas_merging_dialog.h
+++ b/editor/plugins/tiles/atlas_merging_dialog.h
@@ -75,6 +75,8 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 
+	void _notification(int p_what);
+
 public:
 	void update_tile_set(Ref<TileSet> p_tile_set);
 


### PR DESCRIPTION
This fixes issues with atlas merging not working correctly as pointed out in the discussion there: https://github.com/godotengine/godot/issues/71188

Basically:
- Tiles properties were not copied at all,
- The new texture was not set correctly,
- The dialog would keep an outdated preview when opening it again.