### PR TITLE
Add expand mode compat to TextureRect

### DIFF
--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -178,6 +178,16 @@ void TextureRect::_bind_methods() {
 	BIND_ENUM_CONSTANT(STRETCH_KEEP_ASPECT_COVERED);
 }
 
+#ifndef DISABLE_DEPRECATED
+bool TextureRect::_set(const StringName &p_name, const Variant &p_value) {
+	if ((p_name == SNAME("expand") || p_name == SNAME("ignore_texture_size")) && p_value.operator bool()) {
+		expand_mode = EXPAND_IGNORE_SIZE;
+		return true;
+	}
+	return false;
+}
+#endif
+
 void TextureRect::_texture_changed() {
 	if (texture.is_valid()) {
 		queue_redraw();

--- a/scene/gui/texture_rect.h
+++ b/scene/gui/texture_rect.h
@@ -69,6 +69,9 @@ protected:
 	void _notification(int p_what);
 	virtual Size2 get_minimum_size() const override;
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	bool _set(const StringName &p_name, const Variant &p_value);
+#endif
 
 public:
 	void set_texture(const Ref<Texture2D> &p_tex);


### PR DESCRIPTION
Fixes #71340 >_>
Adds 3.x compatibility as a bonus.