### PR TITLE
C#: Lookup signals and methods in Get method

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -272,6 +272,25 @@ namespace Godot.SourceGenerators
                 source.Append("    }\n");
             }
 
+            // Generate HasGodotClassSignal
+
+            if (godotSignalDelegates.Count > 0)
+            {
+                source.Append(
+                    "    protected override bool HasGodotClassSignal(in godot_string_name signal)\n    {\n");
+
+                bool isFirstEntry = true;
+                foreach (var signal in godotSignalDelegates)
+                {
+                    GenerateHasSignalEntry(signal.Name, source, isFirstEntry);
+                    isFirstEntry = false;
+                }
+
+                source.Append("        return base.HasGodotClassSignal(signal);\n");
+
+                source.Append("    }\n");
+            }
+
             source.Append("}\n"); // partial class
 
             if (isInnerClass)
@@ -395,6 +414,20 @@ namespace Godot.SourceGenerators
 
             return new PropertyInfo(memberVariantType, name,
                 PropertyHint.None, string.Empty, propUsage, exported: false);
+        }
+
+        private static void GenerateHasSignalEntry(
+            string signalName,
+            StringBuilder source,
+            bool isFirstEntry
+        )
+        {
+            source.Append("        ");
+            if (!isFirstEntry)
+                source.Append("else ");
+            source.Append("if (signal == SignalName.");
+            source.Append(signalName);
+            source.Append(") {\n           return true;\n        }\n");
         }
 
         private static void GenerateSignalEventInvoker(

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/CSharpInstanceBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/CSharpInstanceBridge.cs
@@ -84,9 +84,26 @@ namespace Godot.Bridge
                 if (godotObject == null)
                     throw new InvalidOperationException();
 
+                // Properties
                 if (godotObject.GetGodotClassPropertyValue(CustomUnsafe.AsRef(name), out godot_variant outRetValue))
                 {
                     *outRet = outRetValue;
+                    return godot_bool.True;
+                }
+
+                // Signals
+                if (godotObject.HasGodotClassSignal(CustomUnsafe.AsRef(name)))
+                {
+                    godot_signal signal = new godot_signal(*name, godotObject.GetInstanceId());
+                    *outRet = VariantUtils.CreateFromSignalTakingOwnershipOfDisposableValue(signal);
+                    return godot_bool.True;
+                }
+
+                // Methods
+                if (godotObject.HasGodotClassMethod(CustomUnsafe.AsRef(name)))
+                {
+                    godot_callable method = new godot_callable(*name, godotObject.GetInstanceId());
+                    *outRet = VariantUtils.CreateFromCallableTakingOwnershipOfDisposableValue(method);
                     return godot_bool.True;
                 }
 


### PR DESCRIPTION
Allows to retrieve `Callable`s and `Signal`s using `Get` like it works in GDScript.

- Fixes https://github.com/godotengine/godot/issues/71348
