### PR TITLE
Fix 'Navigation Process' monitor initialization

### DIFF
--- a/main/performance.cpp
+++ b/main/performance.cpp
@@ -316,6 +316,7 @@ uint64_t Performance::get_monitor_modification_time() {
 Performance::Performance() {
 	_process_time = 0;
 	_physics_process_time = 0;
+	_navigation_process_time = 0;
 	_monitor_modification_time = 0;
 	singleton = this;
 }


### PR DESCRIPTION
Fixes this issue:
![2023-01-13-193405_4480x1440_scrot](https://user-images.githubusercontent.com/1207385/212433492-730d92fb-c681-4f82-8a52-9787d56af7c0.png)
by setting the initial value to `0` 

CC @smix8 