### PR TITLE
Uppercase references to color constants in documentation

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -143,7 +143,7 @@
 				[gdscript]
 				func _forward_canvas_draw_over_viewport(overlay):
 				    # Draw a circle at cursor position.
-				    overlay.draw_circle(overlay.get_local_mouse_position(), 64, Color.white)
+				    overlay.draw_circle(overlay.get_local_mouse_position(), 64, Color.WHITE)
 
 				func _forward_canvas_gui_input(event):
 				    if event is InputEventMouseMotion:
@@ -347,7 +347,7 @@
 				[codeblock]
 				func _set_state(data):
 				    zoom = data.get("zoom", 1.0)
-				    preferred_color = data.get("my_color", Color.white)
+				    preferred_color = data.get("my_color", Color.WHITE)
 				[/codeblock]
 			</description>
 		</method>
@@ -359,7 +359,7 @@
 				[codeblock]
 				func _set_window_layout(configuration):
 				    $Window.position = configuration.get_value("MyPlugin", "window_position", Vector2())
-				    $Icon.modulate = configuration.get_value("MyPlugin", "icon_color", Color.white)
+				    $Icon.modulate = configuration.get_value("MyPlugin", "icon_color", Color.WHITE)
 				[/codeblock]
 			</description>
 		</method>

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -489,7 +489,7 @@
 				var img = Image.new()
 				img.create(img_width, img_height, false, Image.FORMAT_RGBA8)
 
-				img.set_pixel(1, 2, Color.red) # Sets the color at (1, 2) to red.
+				img.set_pixel(1, 2, Color.RED) # Sets the color at (1, 2) to red.
 				[/gdscript]
 				[csharp]
 				int imgWidth = 10;
@@ -517,7 +517,7 @@
 				var img = Image.new()
 				img.create(img_width, img_height, false, Image.FORMAT_RGBA8)
 
-				img.set_pixelv(Vector2i(1, 2), Color.red) # Sets the color at (1, 2) to red.
+				img.set_pixelv(Vector2i(1, 2), Color.RED) # Sets the color at (1, 2) to red.
 				[/gdscript]
 				[csharp]
 				int imgWidth = 10;

--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -11,7 +11,7 @@
 		[codeblocks]
 		[gdscript]
 		var tween = get_tree().create_tween()
-		tween.tween_property($Sprite, "modulate", Color.red, 1)
+		tween.tween_property($Sprite, "modulate", Color.RED, 1)
 		tween.tween_property($Sprite, "scale", Vector2(), 1)
 		tween.tween_callback($Sprite.queue_free)
 		[/gdscript]
@@ -27,7 +27,7 @@
 		[codeblocks]
 		[gdscript]
 		var tween = get_tree().create_tween()
-		tween.tween_property($Sprite, "modulate", Color.red, 1).set_trans(Tween.TRANS_SINE)
+		tween.tween_property($Sprite, "modulate", Color.RED, 1).set_trans(Tween.TRANS_SINE)
 		tween.tween_property($Sprite, "scale", Vector2(), 1).set_trans(Tween.TRANS_BOUNCE)
 		tween.tween_callback($Sprite.queue_free)
 		[/gdscript]
@@ -42,7 +42,7 @@
 		[codeblocks]
 		[gdscript]
 		var tween = get_tree().create_tween().bind_node(self).set_trans(Tween.TRANS_ELASTIC)
-		tween.tween_property($Sprite, "modulate", Color.red, 1)
+		tween.tween_property($Sprite, "modulate", Color.RED, 1)
 		tween.tween_property($Sprite, "scale", Vector2(), 1)
 		tween.tween_callback($Sprite.queue_free)
 		[/gdscript]
@@ -288,8 +288,8 @@
 				[codeblocks]
 				[gdscript]
 				var tween = get_tree().create_tween()
-				tween.tween_callback($Sprite.set_modulate.bind(Color.red)).set_delay(2)
-				tween.tween_callback($Sprite.set_modulate.bind(Color.blue)).set_delay(2)
+				tween.tween_callback($Sprite.set_modulate.bind(Color.RED)).set_delay(2)
+				tween.tween_callback($Sprite.set_modulate.bind(Color.BLUE)).set_delay(2)
 				[/gdscript]
 				[csharp]
 				Tween tween = GetTree().CreateTween();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Update all references to color constants in the documentation to use uppercase.

Related Godot docs PR: https://github.com/godotengine/godot-docs/pull/6602