### PR TITLE
Tweak fbx2gltf file filter to remove naming restriction

### DIFF
--- a/editor/fbx_importer_manager.cpp
+++ b/editor/fbx_importer_manager.cpp
@@ -144,12 +144,8 @@ FBXImporterManager::FBXImporterManager() {
 	browse_dialog = memnew(EditorFileDialog);
 	browse_dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	browse_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
-#if defined(X11_ENABLED)
-	browse_dialog->add_filter("FBX2glTF-linux-x86_64");
-#elif defined(OSX_ENABLED)
-	browse_dialog->add_filter("FBX2glTF-macos-x86_64");
-#elif defined(WINDOWS_ENABLED)
-	browse_dialog->add_filter("FBX2glTF-windows-x86_64");
+#ifdef WINDOWS_ENABLED
+	browse_dialog->add_filter("*.exe");
 #endif
 
 	browse_dialog->connect("file_selected", callable_mp(this, &FBXImporterManager::_select_file));


### PR DESCRIPTION
This relaxes the naming restriction on fbx2gltf binaries, as people may be renaming them then wondering why they've disappeared from the dialog.

~~**Note:** The `.bat`/`.cmd` part is untested, please test before merging this. Could `.ps1` also be added to the list? I know Windows doesn't allow you to double-click those to run them, and I don't remember if it's part of `PATHEXT` by default on Windows 10 or later.~~