### PR TITLE
Enforce a default minimum lightmap size hint size

### DIFF
--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -763,7 +763,15 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 
 			MeshesFound &mf = meshes_found.write[m_i];
 
-			Size2i lightmap_size = mf.mesh->get_lightmap_size_hint() * mf.lightmap_scale;
+			Size2i lightmap_size = mf.mesh->get_lightmap_size_hint();
+
+			if (lightmap_size == Size2i(0, 0)) {
+				// TODO we should compute a size if no lightmap hint is set, as we did in 3.x.
+				// For now set to basic size to avoid crash.
+				lightmap_size = Size2i(64, 64);
+			}
+
+			lightmap_size *= mf.lightmap_scale;
 			TypedArray<RID> overrides;
 			overrides.resize(mf.overrides.size());
 			for (int i = 0; i < mf.overrides.size(); i++) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/51637

I left a TODO in the code because in 3.x when ``lightmap_hint_size`` was ``(0, 0)`` we [calculated an appropriate size](https://github.com/godotengine/godot/blob/7d6db300d221d41937d1b2f1312e421ae749e232/scene/3d/baked_lightmap.cpp#L660-L665) to use, we should do the same. For now we set a default size just to avoid the crash 