### PR TITLE
fix normal map not flipping in sprite2D

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -905,10 +905,12 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 
 					if (rect->flags & CANVAS_RECT_FLIP_H) {
 						src_rect.size.x *= -1;
+						state.instance_data_array[r_index].flags |= FLAGS_FLIP_H;
 					}
 
 					if (rect->flags & CANVAS_RECT_FLIP_V) {
 						src_rect.size.y *= -1;
+						state.instance_data_array[r_index].flags |= FLAGS_FLIP_V;
 					}
 
 					if (rect->flags & CANVAS_RECT_TRANSPOSE) {

--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -75,6 +75,9 @@ class RasterizerCanvasGLES3 : public RendererCanvasRender {
 
 		FLAGS_USE_MSDF = (1 << 28),
 		FLAGS_USE_LCD = (1 << 29),
+
+		FLAGS_FLIP_H = (1 << 30),
+		FLAGS_FLIP_V = (1 << 31),
 	};
 
 	enum {

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -579,6 +579,12 @@ void main() {
 
 	if (normal_used || (using_light && bool(read_draw_data_flags & FLAGS_DEFAULT_NORMAL_MAP_USED))) {
 		normal.xy = texture(normal_texture, uv).xy * vec2(2.0, -2.0) - vec2(1.0, -1.0);
+		if (bool(draw_data.flags & FLAGS_FLIP_H)) {
+			normal.x = -normal.x;
+		}
+		if (bool(draw_data.flags & FLAGS_FLIP_V)) {
+			normal.y = -normal.y;
+		}
 		normal.z = sqrt(1.0 - dot(normal.xy, normal.xy));
 		normal_used = true;
 	} else {

--- a/drivers/gles3/shaders/canvas_uniforms_inc.glsl
+++ b/drivers/gles3/shaders/canvas_uniforms_inc.glsl
@@ -27,6 +27,9 @@
 #define FLAGS_USE_MSDF uint(1 << 28)
 #define FLAGS_USE_LCD uint(1 << 29)
 
+#define FLAGS_FLIP_H uint(1 << 30)
+#define FLAGS_FLIP_V uint(1 << 31)
+
 layout(std140) uniform GlobalShaderUniformData { //ubo:1
 	vec4 global_shader_uniforms[MAX_GLOBAL_SHADER_UNIFORMS];
 };

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -525,10 +525,12 @@ void RendererCanvasRenderRD::_render_item(RD::DrawListID p_draw_list, RID p_rend
 
 					if (rect->flags & CANVAS_RECT_FLIP_H) {
 						src_rect.size.x *= -1;
+						push_constant.flags |= FLAGS_FLIP_H;
 					}
 
 					if (rect->flags & CANVAS_RECT_FLIP_V) {
 						src_rect.size.y *= -1;
+						push_constant.flags |= FLAGS_FLIP_V;
 					}
 
 					if (rect->flags & CANVAS_RECT_TRANSPOSE) {

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -86,6 +86,9 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 
 		FLAGS_USE_MSDF = (1 << 28),
 		FLAGS_USE_LCD = (1 << 29),
+
+		FLAGS_FLIP_H = (1 << 30),
+		FLAGS_FLIP_V = (1 << 31),
 	};
 
 	enum {

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -502,6 +502,12 @@ void main() {
 
 	if (normal_used || (using_light && bool(draw_data.flags & FLAGS_DEFAULT_NORMAL_MAP_USED))) {
 		normal.xy = texture(sampler2D(normal_texture, texture_sampler), uv).xy * vec2(2.0, -2.0) - vec2(1.0, -1.0);
+		if (bool(draw_data.flags & FLAGS_FLIP_H)) {
+			normal.x = -normal.x;
+		}
+		if (bool(draw_data.flags & FLAGS_FLIP_V)) {
+			normal.y = -normal.y;
+		}
 		normal.z = sqrt(1.0 - dot(normal.xy, normal.xy));
 		normal_used = true;
 	} else {

--- a/servers/rendering/renderer_rd/shaders/canvas_uniforms_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas_uniforms_inc.glsl
@@ -27,6 +27,9 @@
 #define FLAGS_USE_MSDF (1 << 28)
 #define FLAGS_USE_LCD (1 << 29)
 
+#define FLAGS_FLIP_H (1 << 30)
+#define FLAGS_FLIP_V (1 << 31)
+
 #define SAMPLER_NEAREST_CLAMP 0
 #define SAMPLER_LINEAR_CLAMP 1
 #define SAMPLER_NEAREST_WITH_MIPMAPS_CLAMP 2


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

This PR fixes [#70517](https://github.com/godotengine/godot/issues/70517) issue.

Here are the results
<img width="358" alt="image" src="https://user-images.githubusercontent.com/95585633/212459342-5b1a80f4-92f1-4ee3-81b6-1cec11d9a8d7.png">
**Standard**
<br>
<img width="322" alt="image" src="https://user-images.githubusercontent.com/95585633/212459370-989ef620-871a-421b-aca7-05100a14366c.png">
**Horizontal Flip**
<br>
<img width="411" alt="image" src="https://user-images.githubusercontent.com/95585633/212459383-8c192b6a-69b9-48f7-8f02-cf365743451b.png">
**Vertical Flip**
