### PR TITLE
Fixes to JSON as resource

### DIFF
--- a/core/io/json.h
+++ b/core/io/json.h
@@ -36,8 +36,8 @@
 #include "core/io/resource_saver.h"
 #include "core/variant/variant.h"
 
-class JSON : public RefCounted {
-	GDCLASS(JSON, RefCounted);
+class JSON : public Resource {
+	GDCLASS(JSON, Resource);
 
 	enum TokenType {
 		TK_CURLY_BRACKET_OPEN,
@@ -65,6 +65,7 @@ class JSON : public RefCounted {
 		Variant value;
 	};
 
+	String text;
 	Variant data;
 	String err_str;
 	int err_line = 0;
@@ -83,7 +84,9 @@ protected:
 	static void _bind_methods();
 
 public:
-	Error parse(const String &p_json_string);
+	Error parse(const String &p_json_string, bool p_keep_text = false);
+	String get_parsed_text() const;
+
 	static String stringify(const Variant &p_var, const String &p_indent = "", bool p_sort_keys = true, bool p_full_precision = false);
 	static Variant parse_string(const String &p_json_string);
 

--- a/doc/classes/JSON.xml
+++ b/doc/classes/JSON.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="JSON" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="JSON" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Helper class for creating and parsing JSON data.
 	</brief_description>
@@ -49,13 +49,21 @@
 				Returns an empty string if the last call to [method parse] was successful, or the error message if it failed.
 			</description>
 		</method>
+		<method name="get_parsed_text" qualifiers="const">
+			<return type="String" />
+			<description>
+				Return the text parsed by [method parse] as long as the function is instructed to keep it.
+			</description>
+		</method>
 		<method name="parse">
 			<return type="int" enum="Error" />
-			<param index="0" name="json_string" type="String" />
+			<param index="0" name="json_text" type="String" />
+			<param index="1" name="keep_text" type="bool" default="false" />
 			<description>
-				Attempts to parse the [param json_string] provided.
+				Attempts to parse the [param json_text] provided.
 				Returns an [enum Error]. If the parse was successful, it returns [constant OK] and the result can be retrieved using [member data]. If unsuccessful, use [method get_error_line] and [method get_error_message] for identifying the source of the failure.
 				Non-static variant of [method parse_string], if you want custom error handling.
+				The optional [param keep_text] argument instructs the parser to keep a copy of the original text. This text can be obtained later by using the [method get_parsed_text] function and is used when saving the resource (instead of generating new text from [member data]).
 			</description>
 		</method>
 		<method name="parse_string" qualifiers="static">


### PR DESCRIPTION
* It was not a resource, hence it was not working to load it as such.
* Changed so, when opened in editor, a parse error will not fail load and the text will be kept.
* This should allow proper editing from within the code editor, including syntax checking and saving files as-is in text.

Partially addresses #66820.

The code editor still needs to be changed for this to work.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
