### PR TITLE
Fix GDScript script templates to use a PascalCase style for `_CLASS_`

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -80,7 +80,7 @@ Ref<Script> GDScriptLanguage::make_template(const String &p_template, const Stri
 	}
 
 	processed_template = processed_template.replace("_BASE_", p_base_class_name)
-								 .replace("_CLASS_", p_class_name)
+								 .replace("_CLASS_", p_class_name.to_pascal_case())
 								 .replace("_TS_", _get_indentation());
 	scr->set_source_code(processed_template);
 	return scr;


### PR DESCRIPTION
I think it's better to use that style, since all classes in Godot use it. So if the user enters the `res://foo_test.cs` to the path in the dialogue, it should not generate the:

![image](https://user-images.githubusercontent.com/3036176/212472888-0cf3fc50-fada-4f9a-b80f-9ebe6cf04516.png)

instead, it will be converted into:

![image](https://user-images.githubusercontent.com/3036176/212472905-bb6b0cb4-dbdd-4d34-b232-eed5e94dbbcf.png)

