### PR TITLE
Fix ImageTextureLayered serialization issues

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1970,14 +1970,17 @@ void ResourceFormatSaverBinaryInstance::_find_resources(const Variant &p_variant
 				if (E.usage & PROPERTY_USAGE_STORAGE) {
 					Variant value = res->get(E.name);
 					if (E.usage & PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT) {
+						NonPersistentKey npk;
+						npk.base = res;
+						npk.property = E.name;
+						non_persistent_map[npk] = value;
+
 						Ref<Resource> sres = value;
 						if (sres.is_valid()) {
-							NonPersistentKey npk;
-							npk.base = res;
-							npk.property = E.name;
-							non_persistent_map[npk] = sres;
 							resource_set.insert(sres);
 							saved_resources.push_back(sres);
+						} else {
+							_find_resources(value);
 						}
 					} else {
 						_find_resources(value);

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -139,7 +139,7 @@ class ResourceFormatSaverBinaryInstance {
 		bool operator<(const NonPersistentKey &p_key) const { return base == p_key.base ? property < p_key.property : base < p_key.base; }
 	};
 
-	RBMap<NonPersistentKey, Ref<Resource>> non_persistent_map;
+	RBMap<NonPersistentKey, Variant> non_persistent_map;
 	HashMap<StringName, int> string_map;
 	Vector<StringName> strings;
 

--- a/scene/resources/image_texture.cpp
+++ b/scene/resources/image_texture.cpp
@@ -371,7 +371,7 @@ void ImageTextureLayered::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_get_images"), &ImageTextureLayered::_get_images);
 	ClassDB::bind_method(D_METHOD("_set_images", "images"), &ImageTextureLayered::_set_images);
 
-	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "_images", PROPERTY_HINT_ARRAY_TYPE, "Image", PROPERTY_USAGE_INTERNAL), "_set_images", "_get_images");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "_images", PROPERTY_HINT_ARRAY_TYPE, "Image", PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT), "_set_images", "_get_images");
 }
 
 ImageTextureLayered::ImageTextureLayered(LayeredType p_layered_type) {

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1893,14 +1893,17 @@ void ResourceFormatSaverTextInstance::_find_resources(const Variant &p_variant, 
 					Variant v = res->get(I->get().name);
 
 					if (pi.usage & PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT) {
+						NonPersistentKey npk;
+						npk.base = res;
+						npk.property = pi.name;
+						non_persistent_map[npk] = v;
+
 						Ref<Resource> sres = v;
 						if (sres.is_valid()) {
-							NonPersistentKey npk;
-							npk.base = res;
-							npk.property = pi.name;
-							non_persistent_map[npk] = sres;
 							resource_set.insert(sres);
 							saved_resources.push_back(sres);
+						} else {
+							_find_resources(v);
 						}
 					} else {
 						_find_resources(v);

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -171,7 +171,7 @@ class ResourceFormatSaverTextInstance {
 		bool operator<(const NonPersistentKey &p_key) const { return base == p_key.base ? property < p_key.property : base < p_key.base; }
 	};
 
-	RBMap<NonPersistentKey, Ref<Resource>> non_persistent_map;
+	RBMap<NonPersistentKey, Variant> non_persistent_map;
 
 	HashSet<Ref<Resource>> resource_set;
 	List<Ref<Resource>> saved_resources;


### PR DESCRIPTION
This is a `master` branch version of PR #70212 , fixing many of the issues with serialisation for `ImageTextureLayered` subclasses.

NOTE: this commit was very much inspired by commit https://github.com/V-Sekai/godot/commit/2ba3561e992fd4b2920518439068ca43ec1e51d9, authored by @SaracenOne that I was made aware of by @Calinou in issue https://github.com/godotengine/godot/issues/54202

It needed some more rework due to code of 3.x and 4.x diverging in relevant areas.
