### PR TITLE
Allow AnimationStateMachine / AnimationNode to restart when transitioning to the same state

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -49,6 +49,13 @@
 				When inheriting from [AnimationRootNode], implement this virtual method to return whether the blend tree editor should display filter editing on this node.
 			</description>
 		</method>
+		<method name="_is_parameter_read_only" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="parameter" type="StringName" />
+			<description>
+				When inheriting from [AnimationRootNode], implement this virtual method to return whether the [param parameter] is read-only. Parameters are custom local memory used for your nodes, given a resource can be reused in multiple trees.
+			</description>
+		</method>
 		<method name="_process" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="time" type="float" />

--- a/doc/classes/AnimationNodeOneShot.xml
+++ b/doc/classes/AnimationNodeOneShot.xml
@@ -28,6 +28,12 @@
 		</member>
 	</members>
 	<constants>
+		<constant name="ONE_SHOT_REQUEST_NONE" value="0" enum="OneShotRequest">
+		</constant>
+		<constant name="ONE_SHOT_REQUEST_FIRE" value="1" enum="OneShotRequest">
+		</constant>
+		<constant name="ONE_SHOT_REQUEST_ABORT" value="2" enum="OneShotRequest">
+		</constant>
 		<constant name="MIX_MODE_BLEND" value="0" enum="MixMode">
 		</constant>
 		<constant name="MIX_MODE_ADD" value="1" enum="MixMode">

--- a/doc/classes/AnimationNodeStateMachinePlayback.xml
+++ b/doc/classes/AnimationNodeStateMachinePlayback.xml
@@ -50,11 +50,19 @@
 				Returns [code]true[/code] if an animation is playing.
 			</description>
 		</method>
+		<method name="next">
+			<return type="void" />
+			<description>
+				If there is a next path by travel or auto advance, immediately transitions from the current state to the next state.
+			</description>
+		</method>
 		<method name="start">
 			<return type="void" />
 			<param index="0" name="node" type="StringName" />
+			<param index="1" name="reset" type="bool" default="true" />
 			<description>
 				Starts playing the given animation.
+				If [param reset] is [code]true[/code], the animation is played from the beginning.
 			</description>
 		</method>
 		<method name="stop">
@@ -66,8 +74,11 @@
 		<method name="travel">
 			<return type="void" />
 			<param index="0" name="to_node" type="StringName" />
+			<param index="1" name="reset_on_teleport" type="bool" default="true" />
 			<description>
 				Transitions from the current state to another one, following the shortest path.
+				If the path does not connect from the current state, the animation will play after the state teleports.
+				If [param reset_on_teleport] is [code]true[/code], the animation is played from the beginning when the travel cause a teleportation.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AnimationNodeStateMachineTransition.xml
+++ b/doc/classes/AnimationNodeStateMachineTransition.xml
@@ -28,6 +28,9 @@
 		<member name="priority" type="int" setter="set_priority" getter="get_priority" default="1">
 			Lower priority transitions are preferred when travelling through the tree via [method AnimationNodeStateMachinePlayback.travel] or [member advance_mode] is set to [constant ADVANCE_MODE_AUTO].
 		</member>
+		<member name="reset" type="bool" setter="set_reset" getter="is_reset" default="true">
+			If [code]true[/code], the destination animation is played back from the beginning when switched.
+		</member>
 		<member name="switch_mode" type="int" setter="set_switch_mode" getter="get_switch_mode" enum="AnimationNodeStateMachineTransition.SwitchMode" default="0">
 			The transition type.
 		</member>

--- a/doc/classes/AnimationNodeTransition.xml
+++ b/doc/classes/AnimationNodeTransition.xml
@@ -43,7 +43,7 @@
 		<member name="enabled_inputs" type="int" setter="set_enabled_inputs" getter="get_enabled_inputs" default="0">
 			The number of enabled input ports for this node.
 		</member>
-		<member name="from_start" type="bool" setter="set_from_start" getter="is_from_start" default="true">
+		<member name="reset" type="bool" setter="set_reset" getter="is_reset" default="true">
 			If [code]true[/code], the destination animation is played back from the beginning when switched.
 		</member>
 		<member name="xfade_curve" type="Curve" setter="set_xfade_curve" getter="get_xfade_curve">

--- a/doc/classes/AnimationNodeTransition.xml
+++ b/doc/classes/AnimationNodeTransition.xml
@@ -12,6 +12,12 @@
 		<link title="Third Person Shooter Demo">https://godotengine.org/asset-library/asset/678</link>
 	</tutorials>
 	<methods>
+		<method name="find_input_caption" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="caption" type="String" />
+			<description>
+			</description>
+		</method>
 		<method name="get_input_caption" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="input" type="int" />

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -342,12 +342,17 @@ void EditorPropertyTextEnum::_notification(int p_what) {
 }
 
 EditorPropertyTextEnum::EditorPropertyTextEnum() {
+	HBoxContainer *hb = memnew(HBoxContainer);
+	add_child(hb);
+
 	default_layout = memnew(HBoxContainer);
-	add_child(default_layout);
+	default_layout->set_h_size_flags(SIZE_EXPAND_FILL);
+	hb->add_child(default_layout);
 
 	edit_custom_layout = memnew(HBoxContainer);
+	edit_custom_layout->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit_custom_layout->hide();
-	add_child(edit_custom_layout);
+	hb->add_child(edit_custom_layout);
 
 	option_button = memnew(OptionButton);
 	option_button->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -187,7 +187,7 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 			String base_path = AnimationTreeEditor::get_singleton()->get_base_path() + String(E) + "/" + F.name;
 			EditorProperty *prop = EditorInspector::instantiate_property_editor(tree, F.type, base_path, F.hint, F.hint_string, F.usage);
 			if (prop) {
-				prop->set_read_only(read_only);
+				prop->set_read_only(read_only || (F.usage & PROPERTY_USAGE_READ_ONLY));
 				prop->set_object_and_property(tree, base_path);
 				prop->update_property();
 				prop->set_name_split_ratio(0);

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -718,12 +718,12 @@ Ref<Curve> AnimationNodeTransition::get_xfade_curve() const {
 	return xfade_curve;
 }
 
-void AnimationNodeTransition::set_from_start(bool p_from_start) {
-	from_start = p_from_start;
+void AnimationNodeTransition::set_reset(bool p_reset) {
+	reset = p_reset;
 }
 
-bool AnimationNodeTransition::is_from_start() const {
-	return from_start;
+bool AnimationNodeTransition::is_reset() const {
+	return reset;
 }
 
 double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_is_external_seeking) {
@@ -783,7 +783,7 @@ double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_is_ex
 
 		// Blend values must be more than CMP_EPSILON to process discrete keys in edge.
 		real_t blend_inv = 1.0 - blend;
-		if (from_start && !p_seek && switched) { //just switched, seek to start of current
+		if (reset && !p_seek && switched) { //just switched, seek to start of current
 			rem = blend_input(cur_current, 0, true, p_is_external_seeking, Math::is_zero_approx(blend_inv) ? CMP_EPSILON : blend_inv, FILTER_IGNORE, true);
 		} else {
 			rem = blend_input(cur_current, p_time, p_seek, p_is_external_seeking, Math::is_zero_approx(blend_inv) ? CMP_EPSILON : blend_inv, FILTER_IGNORE, true);
@@ -836,13 +836,13 @@ void AnimationNodeTransition::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_xfade_curve", "curve"), &AnimationNodeTransition::set_xfade_curve);
 	ClassDB::bind_method(D_METHOD("get_xfade_curve"), &AnimationNodeTransition::get_xfade_curve);
 
-	ClassDB::bind_method(D_METHOD("set_from_start", "from_start"), &AnimationNodeTransition::set_from_start);
-	ClassDB::bind_method(D_METHOD("is_from_start"), &AnimationNodeTransition::is_from_start);
+	ClassDB::bind_method(D_METHOD("set_reset", "reset"), &AnimationNodeTransition::set_reset);
+	ClassDB::bind_method(D_METHOD("is_reset"), &AnimationNodeTransition::is_reset);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "enabled_inputs", PROPERTY_HINT_RANGE, "0,64,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), "set_enabled_inputs", "get_enabled_inputs");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "xfade_time", PROPERTY_HINT_RANGE, "0,120,0.01,suffix:s"), "set_xfade_time", "get_xfade_time");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "xfade_curve", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_xfade_curve", "get_xfade_curve");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "from_start"), "set_from_start", "is_from_start");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "reset"), "set_reset", "is_reset");
 
 	for (int i = 0; i < MAX_INPUTS; i++) {
 		ADD_PROPERTYI(PropertyInfo(Variant::STRING, "input_" + itos(i) + "/name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_input_caption", "get_input_caption", i);

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -299,7 +299,7 @@ class AnimationNodeTransition : public AnimationNodeSync {
 
 	double xfade_time = 0.0;
 	Ref<Curve> xfade_curve;
-	bool from_start = true;
+	bool reset = true;
 
 	void _update_inputs();
 
@@ -328,8 +328,8 @@ public:
 	void set_xfade_curve(const Ref<Curve> &p_curve);
 	Ref<Curve> get_xfade_curve() const;
 
-	void set_from_start(bool p_from_start);
-	bool is_from_start() const;
+	void set_reset(bool p_reset);
+	bool is_reset() const;
 
 	double process(double p_time, bool p_seek, bool p_is_external_seeking) override;
 

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -96,6 +96,12 @@ class AnimationNodeOneShot : public AnimationNodeSync {
 	GDCLASS(AnimationNodeOneShot, AnimationNodeSync);
 
 public:
+	enum OneShotRequest {
+		ONE_SHOT_REQUEST_NONE,
+		ONE_SHOT_REQUEST_FIRE,
+		ONE_SHOT_REQUEST_ABORT,
+	};
+
 	enum MixMode {
 		MIX_MODE_BLEND,
 		MIX_MODE_ADD
@@ -110,13 +116,8 @@ private:
 	double autorestart_random_delay = 0.0;
 	MixMode mix = MIX_MODE_BLEND;
 
-	/*	bool active;
-	bool do_start;
-	double time;
-	double remaining;*/
-
+	StringName request = PNAME("request");
 	StringName active = PNAME("active");
-	StringName prev_active = "prev_active";
 	StringName time = "time";
 	StringName remaining = "remaining";
 	StringName time_to_restart = "time_to_restart";
@@ -127,6 +128,7 @@ protected:
 public:
 	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
+	virtual bool is_parameter_read_only(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
 
@@ -153,6 +155,7 @@ public:
 	AnimationNodeOneShot();
 };
 
+VARIANT_ENUM_CAST(AnimationNodeOneShot::OneShotRequest)
 VARIANT_ENUM_CAST(AnimationNodeOneShot::MixMode)
 
 class AnimationNodeAdd2 : public AnimationNodeSync {
@@ -284,18 +287,15 @@ class AnimationNodeTransition : public AnimationNodeSync {
 	InputData inputs[MAX_INPUTS];
 	int enabled_inputs = 0;
 
-	/*
-	double prev_xfading;
-	int prev;
-	double time;
-	int current;
-	int prev_current; */
-
-	StringName prev_xfading = "prev_xfading";
-	StringName prev = "prev";
 	StringName time = "time";
-	StringName current = PNAME("current");
-	StringName prev_current = "prev_current";
+	StringName prev_xfading = "prev_xfading";
+	StringName prev_index = "prev_index";
+	StringName current_index = PNAME("current_index");
+	StringName current_state = PNAME("current_state");
+	StringName transition_request = PNAME("transition_request");
+
+	StringName prev_frame_current = "pf_current";
+	StringName prev_frame_current_idx = "pf_current_idx";
 
 	double xfade_time = 0.0;
 	Ref<Curve> xfade_curve;
@@ -310,6 +310,7 @@ protected:
 public:
 	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
+	virtual bool is_parameter_read_only(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
 
@@ -321,6 +322,7 @@ public:
 
 	void set_input_caption(int p_input, const String &p_name);
 	String get_input_caption(int p_input) const;
+	int find_input_caption(const String &p_name) const;
 
 	void set_xfade_time(double p_fade);
 	double get_xfade_time() const;

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -236,7 +236,7 @@ bool AnimationNodeStateMachinePlayback::_travel(AnimationNodeStateMachine *p_sta
 	path.clear(); //a new one will be needed
 
 	if (current == p_travel) {
-		return true; //nothing to do
+		return false; // Will teleport oneself (restart).
 	}
 
 	Vector2 current_pos = p_state_machine->states[current].position;

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -57,6 +57,7 @@ private:
 	StringName advance_condition_name;
 	float xfade_time = 0.0;
 	Ref<Curve> xfade_curve;
+	bool reset = true;
 	int priority = 1;
 	String advance_expression;
 
@@ -83,6 +84,9 @@ public:
 
 	void set_xfade_time(float p_xfade);
 	float get_xfade_time() const;
+
+	void set_reset(bool p_reset);
+	bool is_reset() const;
 
 	void set_xfade_curve(const Ref<Curve> &p_curve);
 	Ref<Curve> get_xfade_curve() const;
@@ -131,10 +135,15 @@ class AnimationNodeStateMachinePlayback : public Resource {
 	bool playing = false;
 
 	StringName start_request;
-	bool start_request_travel = false;
+	StringName travel_request;
+	bool reset_request = false;
+	bool reset_request_on_teleport = false;
+	bool next_request = false;
 	bool stop_request = false;
 
 	bool _travel(AnimationNodeStateMachine *p_state_machine, const StringName &p_travel);
+	void _start(const StringName &p_state);
+	double _process(AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking);
 
 	double process(AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking);
 
@@ -144,8 +153,9 @@ protected:
 	static void _bind_methods();
 
 public:
-	void travel(const StringName &p_state);
-	void start(const StringName &p_state);
+	void travel(const StringName &p_state, bool p_reset_on_teleport = true);
+	void start(const StringName &p_state, bool p_reset = true);
+	void next();
 	void stop();
 	bool is_playing() const;
 	StringName get_current_node() const;

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -117,6 +117,7 @@ protected:
 	GDVIRTUAL0RC(Array, _get_parameter_list)
 	GDVIRTUAL1RC(Ref<AnimationNode>, _get_child_by_name, StringName)
 	GDVIRTUAL1RC(Variant, _get_parameter_default_value, StringName)
+	GDVIRTUAL1RC(bool, _is_parameter_read_only, StringName)
 	GDVIRTUAL3RC(double, _process, double, bool, bool)
 	GDVIRTUAL0RC(String, _get_caption)
 	GDVIRTUAL0RC(bool, _has_filter)
@@ -124,6 +125,7 @@ protected:
 public:
 	virtual void get_parameter_list(List<PropertyInfo> *r_list) const;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const;
+	virtual bool is_parameter_read_only(const StringName &p_parameter) const;
 
 	void set_parameter(const StringName &p_name, const Variant &p_value);
 	Variant get_parameter(const StringName &p_name) const;
@@ -304,7 +306,7 @@ private:
 	void _update_properties();
 	List<PropertyInfo> properties;
 	HashMap<StringName, HashMap<StringName, StringName>> property_parent_map;
-	HashMap<StringName, Variant> property_map;
+	HashMap<StringName, Pair<Variant, bool>> property_map; // Property value and read-only flag.
 
 	struct Activity {
 		uint64_t last_pass = 0;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5965
Fixed #69570
Fixed #69382
Fixed #71195

Allow AnimationStateMachine / AnimationNode to restart when transitioning to the same state. Also, allow NodeTransition to use String values.

Containing #71264. At first I was working with it as same PR #71264, but a few fundamental modifications caused break compatibility, so I separated this PR.

### StateMachine

Make it restart when it tries to travel() to the same state. This can be resolved with one line change.

### NodeTransition / NodeOneShot

For this, there was a problem with the original implementation, and 2 fundamental modifications are necessary.

1:
Currently they detect state changes by whether the property has changed from the previous frame, but this does not allow changes to the same state.

This means that they need an independent property as a request, like a StateMachine. So, implement the following properties for state changes.

**NodeTransition:**
```gdscript
# Property for the transition state requests. It will be cleared immediately in the next animation tree process.
anim_tree["parameters/TransitionNode/transition_request"] = "Input 2" # It is changed to String from int, to fix #69382.

# To avoid finding for an index every frame and to keep better performance, separate the following:
print(anim_tree["parameters/TransitionNode/current_state"]) # String value as state name for display. Read-only.
print(anim_tree["parameters/TransitionNode/current_index"]) # Int value as state index for internal use. Read-only.
```

**NodeOneShot:**
```gdscript
# Property for the transition state requests. It will be cleared immediately in the next animation tree process.
anim_tree["parameters/OneShotNode/request"] = AnimationNodeOneShot.ONE_SHOT_REQUEST_FIRE
anim_tree["parameters/OneShotNode/request"] = AnimationNodeOneShot.ONE_SHOT_REQUEST_ABORT

print(anim_tree["parameters/OneShotNode/active"]) # Read-only.
```

In addition, since there was only one `active` flag, there was no way to stop `auto restart` from the property, but now `auto restart` is stopped by an abort request.

2:
Some properties need to be changed only by request to prevent to make broken state, but the current status should be retrievable, so it should be PROPERTY_USAGE_READ_ONLY, not PROPERTY_USAGE_NONE.

However, the entity of the AnimationNode property is stored in the AnimationTree's map. During playback, the AnimationNode fetches the properties from the map, which means that read-only cannot be set using the USAGE flag.

Therefore, it is necessary to add a bool value to the AnimationTree map to implement read-only for the AnimationNode's parameter.

### Video

https://user-images.githubusercontent.com/61938263/212488143-a2efedb0-3c8f-46b5-9a6e-20dc5dee2379.mp4

https://user-images.githubusercontent.com/61938263/212488137-03b4e67b-0871-4d3b-9510-47ff6b7169e5.mp4

[restart_test.zip](https://github.com/godotengine/godot/files/10419585/restart_test.zip)

If approved, I will update the document as soon as possible.