### PR TITLE
Add project setting for Movie Writer to create new file instead of overwriting

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1138,6 +1138,9 @@
 		<member name="editor/movie_writer/audio_bit_depth" type="int" setter="" getter="" default="16">
 			Number of bits per audio sample written to the [code].avi[/code] file. Only 16 and 32-bit are supported.
 		</member>
+		<member name="editor/movie_writer/create_new_file_if_existing" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], uses a new file name with a [code]_N[/code] suffix (where [code]N[/code] is an incremental number starting from 1) when writing a movie if it already exists. If [code]false[/code], overwrites the existing file.
+		</member>
 		<member name="editor/movie_writer/disable_vsync" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], requests V-Sync to be disabled when writing a movie (similar to setting [member display/window/vsync/vsync_mode] to [b]Disabled[/b]). This can speed up video writing if the hardware is fast enough to render, encode and save the video at a framerate higher than the monitor's refresh rate.
 			[b]Note:[/b] [member editor/movie_writer/disable_vsync] has no effect if the operating system or graphics driver forces V-Sync with no way for applications to disable it.

--- a/modules/jpg/movie_writer_mjpeg.cpp
+++ b/modules/jpg/movie_writer_mjpeg.cpp
@@ -58,6 +58,19 @@ Error MovieWriterMJPEG::write_begin(const Size2i &p_movie_size, uint32_t p_fps, 
 
 	base_path += ".avi";
 
+	if (GLOBAL_GET("editor/movie_writer/create_new_file_if_existing")) {
+		String tmp_fullpath = base_path;
+		String tmp_basename = base_path.get_basename();
+		int number = 1;
+		while (FileAccess::exists(tmp_fullpath)) {
+			tmp_fullpath = tmp_basename + "_" + itos(number) + ".avi";
+			number++;
+		}
+		base_path = tmp_fullpath;
+	}
+
+	output_path = base_path;
+
 	f = FileAccess::open(base_path, FileAccess::WRITE_READ);
 
 	fps = p_fps;

--- a/modules/theora/editor/movie_writer_ogv.cpp
+++ b/modules/theora/editor/movie_writer_ogv.cpp
@@ -119,6 +119,19 @@ Error MovieWriterOGV::write_begin(const Size2i &p_movie_size, uint32_t p_fps, co
 	}
 	base_path += ".ogv";
 
+	if (GLOBAL_GET("editor/movie_writer/create_new_file_if_existing")) {
+		String tmp_fullpath = base_path;
+		String tmp_basename = base_path.get_basename();
+		int number = 1;
+		while (FileAccess::exists(tmp_fullpath)) {
+			tmp_fullpath = tmp_basename + "_" + itos(number) + ".ogv";
+			number++;
+		}
+		base_path = tmp_fullpath;
+	}
+
+	output_path = base_path;
+
 	f = FileAccess::open(base_path, FileAccess::WRITE_READ);
 	ERR_FAIL_COND_V(f.is_null(), ERR_CANT_OPEN);
 

--- a/servers/movie_writer/movie_writer.cpp
+++ b/servers/movie_writer/movie_writer.cpp
@@ -108,8 +108,10 @@ void MovieWriter::begin(const Size2i &p_movie_size, uint32_t p_fps, const String
 	// Check for available disk space and warn the user if needed.
 	Ref<DirAccess> dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	String path = p_base_path.get_base_dir();
+	output_path = p_base_path;
 	if (path.is_relative_path()) {
 		path = "res://" + path;
+		output_path = "res://" + output_path;
 	}
 	dir->open(path);
 	if (dir->get_space_left() < 10 * Math::pow(1024.0, 3.0)) {
@@ -159,6 +161,7 @@ void MovieWriter::_bind_methods() {
 	// Used by the editor.
 	GLOBAL_DEF_BASIC("editor/movie_writer/movie_file", "");
 	GLOBAL_DEF_BASIC("editor/movie_writer/disable_vsync", false);
+	GLOBAL_DEF_BASIC("editor/movie_writer/create_new_file_if_existing", true);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "editor/movie_writer/fps", PROPERTY_HINT_RANGE, "1,300,1,suffix:FPS"), 60);
 }
 
@@ -257,7 +260,7 @@ void MovieWriter::end() {
 
 	// Print a report with various statistics.
 	print_line("--------------------------------------------------------------------------------");
-	String movie_path = Engine::get_singleton()->get_write_movie_path();
+	String movie_path = output_path;
 	if (movie_path.is_relative_path()) {
 		// Print absolute path to make finding the file easier,
 		// and to make it clickable in terminal emulators that support this.

--- a/servers/movie_writer/movie_writer.h
+++ b/servers/movie_writer/movie_writer.h
@@ -60,6 +60,7 @@ class MovieWriter : public Object {
 	static uint32_t writer_count;
 
 protected:
+	String output_path;
 	virtual uint32_t get_audio_mix_rate() const;
 	virtual AudioServer::SpeakerMode get_audio_speaker_mode() const;
 

--- a/servers/movie_writer/movie_writer_pngwav.cpp
+++ b/servers/movie_writer/movie_writer_pngwav.cpp
@@ -68,7 +68,19 @@ Error MovieWriterPNGWAV::write_begin(const Size2i &p_movie_size, uint32_t p_fps,
 		base_path = "res://" + base_path;
 	}
 
-	{
+	if (GLOBAL_GET("editor/movie_writer/create_new_file_if_existing")) {
+		// Find a unique file name
+		uint32_t idx = 0;
+		String tmp_fullpath = base_path + "_" + zeros_str(idx) + ".png";
+		String tmp_basename = base_path;
+		int number = 1;
+		while (FileAccess::exists(tmp_fullpath)) {
+			tmp_basename = base_path + "_" + itos(number);
+			tmp_fullpath = tmp_basename + "_" + zeros_str(idx) + ".png";
+			number++;
+		}
+		base_path = tmp_basename;
+	} else {
 		//Remove existing files before writing anew
 		uint32_t idx = 0;
 		Ref<DirAccess> d = DirAccess::open(base_path.get_base_dir());
@@ -76,12 +88,15 @@ Error MovieWriterPNGWAV::write_begin(const Size2i &p_movie_size, uint32_t p_fps,
 
 		String file = base_path.get_file();
 		while (true) {
-			String path = file + zeros_str(idx) + ".png";
+			String path = file + "_" + zeros_str(idx) + ".png";
 			if (d->remove(path) != OK) {
 				break;
 			}
+			idx++;
 		}
 	}
+
+	output_path = base_path + ".png";
 
 	f_wav = FileAccess::open(base_path + ".wav", FileAccess::WRITE_READ);
 	ERR_FAIL_COND_V(f_wav.is_null(), ERR_CANT_OPEN);
@@ -146,7 +161,7 @@ Error MovieWriterPNGWAV::write_frame(const Ref<Image> &p_image, const int32_t *p
 
 	Vector<uint8_t> png_buffer = p_image->save_png_to_buffer();
 
-	Ref<FileAccess> fi = FileAccess::open(base_path + zeros_str(frame_count) + ".png", FileAccess::WRITE);
+	Ref<FileAccess> fi = FileAccess::open(base_path + "_" + zeros_str(frame_count) + ".png", FileAccess::WRITE);
 	fi->store_buffer(png_buffer.ptr(), png_buffer.size());
 	f_wav->store_buffer((const uint8_t *)p_audio_data, audio_block_size);
 


### PR DESCRIPTION
This makes the movie writer create new files instead of overwriting or deleting existing files.

Closes https://github.com/godotengine/godot-proposals/issues/5989

Resulting files when the `movie_file` is `bla.avi`
<img width="147" alt="Screenshot 2023-01-14 at 19 06 51" src="https://user-images.githubusercontent.com/43449832/212488549-498dd9d9-4f6c-4a58-bf47-7574c1353ad2.png">

Resulting files when the `movie_file` is `bla.png`
<img width="312" alt="Screenshot 2023-01-14 at 19 09 17" src="https://user-images.githubusercontent.com/43449832/212488627-c9d88d48-5299-4fb4-b420-a87242d93f8b.png">

