### PR TITLE
C#: Remove `includeBorders` parameter from `Rect2i.Intersects` and `AABB.Intersects`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
@@ -437,48 +437,25 @@ namespace Godot
         /// <summary>
         /// Returns <see langword="true"/> if the <see cref="AABB"/> overlaps with <paramref name="with"/>
         /// (i.e. they have at least one point in common).
-        ///
-        /// If <paramref name="includeBorders"/> is <see langword="true"/>,
-        /// they will also be considered overlapping if their borders touch,
-        /// even without intersection.
         /// </summary>
         /// <param name="with">The other <see cref="AABB"/> to check for intersections with.</param>
-        /// <param name="includeBorders">Whether or not to consider borders.</param>
         /// <returns>
         /// A <see langword="bool"/> for whether or not they are intersecting.
         /// </returns>
-        public readonly bool Intersects(AABB with, bool includeBorders = false)
+        public readonly bool Intersects(AABB with)
         {
-            if (includeBorders)
-            {
-                if (_position.x > with._position.x + with._size.x)
-                    return false;
-                if (_position.x + _size.x < with._position.x)
-                    return false;
-                if (_position.y > with._position.y + with._size.y)
-                    return false;
-                if (_position.y + _size.y < with._position.y)
-                    return false;
-                if (_position.z > with._position.z + with._size.z)
-                    return false;
-                if (_position.z + _size.z < with._position.z)
-                    return false;
-            }
-            else
-            {
-                if (_position.x >= with._position.x + with._size.x)
-                    return false;
-                if (_position.x + _size.x <= with._position.x)
-                    return false;
-                if (_position.y >= with._position.y + with._size.y)
-                    return false;
-                if (_position.y + _size.y <= with._position.y)
-                    return false;
-                if (_position.z >= with._position.z + with._size.z)
-                    return false;
-                if (_position.z + _size.z <= with._position.z)
-                    return false;
-            }
+            if (_position.x >= with._position.x + with._size.x)
+                return false;
+            if (_position.x + _size.x <= with._position.x)
+                return false;
+            if (_position.y >= with._position.y + with._size.y)
+                return false;
+            if (_position.y + _size.y <= with._position.y)
+                return false;
+            if (_position.z >= with._position.z + with._size.z)
+                return false;
+            if (_position.z + _size.z <= with._position.z)
+                return false;
 
             return true;
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
@@ -275,38 +275,19 @@ namespace Godot
         /// <summary>
         /// Returns <see langword="true"/> if the <see cref="Rect2i"/> overlaps with <paramref name="b"/>
         /// (i.e. they have at least one point in common).
-        ///
-        /// If <paramref name="includeBorders"/> is <see langword="true"/>,
-        /// they will also be considered overlapping if their borders touch,
-        /// even without intersection.
         /// </summary>
         /// <param name="b">The other <see cref="Rect2i"/> to check for intersections with.</param>
-        /// <param name="includeBorders">Whether or not to consider borders.</param>
         /// <returns>A <see langword="bool"/> for whether or not they are intersecting.</returns>
-        public readonly bool Intersects(Rect2i b, bool includeBorders = false)
+        public readonly bool Intersects(Rect2i b)
         {
-            if (includeBorders)
-            {
-                if (_position.x > b._position.x + b._size.x)
-                    return false;
-                if (_position.x + _size.x < b._position.x)
-                    return false;
-                if (_position.y > b._position.y + b._size.y)
-                    return false;
-                if (_position.y + _size.y < b._position.y)
-                    return false;
-            }
-            else
-            {
-                if (_position.x >= b._position.x + b._size.x)
-                    return false;
-                if (_position.x + _size.x <= b._position.x)
-                    return false;
-                if (_position.y >= b._position.y + b._size.y)
-                    return false;
-                if (_position.y + _size.y <= b._position.y)
-                    return false;
-            }
+            if (_position.x >= b._position.x + b._size.x)
+                return false;
+            if (_position.x + _size.x <= b._position.x)
+                return false;
+            if (_position.y >= b._position.y + b._size.y)
+                return false;
+            if (_position.y + _size.y <= b._position.y)
+                return false;
 
             return true;
         }


### PR DESCRIPTION
- Remove `includeBorders` parameter from `Rect2i.Intersects`
	- Rejected from Core in https://github.com/godotengine/godot/pull/40203.
- Remove `includeBorders` parameter from `AABB.Intersects`
	- I don't think this parameter ever existed in Core.