### PR TITLE
Add independent spinbox arrow step precision (3.x)

### DIFF
--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -39,6 +39,9 @@
 		<member name="align" type="int" setter="set_align" getter="get_align" enum="LineEdit.Align" default="0">
 			Sets the text alignment of the [SpinBox].
 		</member>
+		<member name="custom_arrow_step" type="float" setter="set_custom_arrow_step" getter="get_custom_arrow_step" default="0.0">
+			If not [code]0[/code], [code]value[/code] will always be rounded to a multiple of [code]custom_arrow_step[/code] when interacting with the arrow buttons of the [SpinBox].
+		</member>
 		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="true">
 			If [code]true[/code], the [SpinBox] will be editable. Otherwise, it will be read only.
 		</member>

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -49,6 +49,7 @@ class SpinBox : public Range {
 	virtual void _value_changed(double);
 	String prefix;
 	String suffix;
+	double custom_arrow_step = 0.0;
 
 	void _line_edit_input(const Ref<InputEvent> &p_event);
 
@@ -90,6 +91,8 @@ public:
 	String get_prefix() const;
 
 	void apply();
+	void set_custom_arrow_step(const double p_custom_arrow_step);
+	double get_custom_arrow_step() const;
 
 	SpinBox();
 };


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/54792. Thanks @EIREXE for the original rebasing :slightly_smiling_face: 

Backported from the `master` branch, with a [property hint added](https://github.com/godotengine/godot/pull/71427) (only positive or zero values make sense for this property).

This will be useful to implement https://github.com/godotengine/godot-proposals/issues/6101 in `3.x`.

**Testing project:** [test_spinbox_custom_arrow_step_3.x.zip](https://github.com/godotengine/godot/files/10418658/test_spinbox_custom_arrow_step_3.x.zip)