### PR TITLE
C#: Replace `Rotation` and `Scale` properties with get methods

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -120,31 +120,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// The scale of this basis.
-        /// </summary>
-        /// <value>Equivalent to the lengths of each column vector, but negative if the determinant is negative.</value>
-        public Vector3 Scale
-        {
-            readonly get
-            {
-                real_t detSign = Mathf.Sign(Determinant());
-                return detSign * new Vector3
-                (
-                    Column0.Length(),
-                    Column1.Length(),
-                    Column2.Length()
-                );
-            }
-            set
-            {
-                value /= Scale; // Value becomes what's called "delta_scale" in core.
-                Column0 *= value.x;
-                Column1 *= value.y;
-                Column2 *= value.z;
-            }
-        }
-
-        /// <summary>
         /// Access whole columns in the form of <see cref="Vector3"/>.
         /// </summary>
         /// <param name="column">Which column vector.</param>
@@ -564,6 +539,21 @@ namespace Godot
             }
 
             return orthonormalizedBasis.GetQuaternion();
+        }
+
+        /// <summary>
+        /// Assuming that the matrix is the combination of a rotation and scaling,
+        /// return the absolute value of scaling factors along each axis.
+        /// </summary>
+        public readonly Vector3 GetScale()
+        {
+            real_t detSign = Mathf.Sign(Determinant());
+            return detSign * new Vector3
+            (
+                Column0.Length(),
+                Column1.Length(),
+                Column2.Length()
+            );
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -32,45 +32,6 @@ namespace Godot
         public Vector2 origin;
 
         /// <summary>
-        /// The rotation of this transformation matrix.
-        /// </summary>
-        /// <value>Getting is equivalent to calling <see cref="Mathf.Atan2(real_t, real_t)"/> with the values of <see cref="x"/>.</value>
-        public real_t Rotation
-        {
-            readonly get
-            {
-                return Mathf.Atan2(x.y, x.x);
-            }
-            set
-            {
-                Vector2 scale = Scale;
-                x.x = y.y = Mathf.Cos(value);
-                x.y = y.x = Mathf.Sin(value);
-                y.x *= -1;
-                Scale = scale;
-            }
-        }
-
-        /// <summary>
-        /// The scale of this transformation matrix.
-        /// </summary>
-        /// <value>Equivalent to the lengths of each column vector, but Y is negative if the determinant is negative.</value>
-        public Vector2 Scale
-        {
-            readonly get
-            {
-                real_t detSign = Mathf.Sign(BasisDeterminant());
-                return new Vector2(x.Length(), detSign * y.Length());
-            }
-            set
-            {
-                value /= Scale; // Value becomes what's called "delta_scale" in core.
-                x *= value.x;
-                y *= value.y;
-            }
-        }
-
-        /// <summary>
         /// Access whole columns in the form of <see cref="Vector2"/>.
         /// The third column is the <see cref="origin"/> vector.
         /// </summary>
@@ -203,6 +164,23 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the transform's rotation (in radians).
+        /// </summary>
+        public readonly real_t GetRotation()
+        {
+            return Mathf.Atan2(x.y, x.x);
+        }
+
+        /// <summary>
+        /// Returns the scale.
+        /// </summary>
+        public readonly Vector2 GetScale()
+        {
+            real_t detSign = Mathf.Sign(BasisDeterminant());
+            return new Vector2(x.Length(), detSign * y.Length());
+        }
+
+        /// <summary>
         /// Interpolates this transform to the other <paramref name="transform"/> by <paramref name="weight"/>.
         /// </summary>
         /// <param name="transform">The other transform.</param>
@@ -210,11 +188,11 @@ namespace Godot
         /// <returns>The interpolated transform.</returns>
         public readonly Transform2D InterpolateWith(Transform2D transform, real_t weight)
         {
-            real_t r1 = Rotation;
-            real_t r2 = transform.Rotation;
+            real_t r1 = GetRotation();
+            real_t r2 = transform.GetRotation();
 
-            Vector2 s1 = Scale;
-            Vector2 s2 = transform.Scale;
+            Vector2 s1 = GetScale();
+            Vector2 s2 = transform.GetScale();
 
             // Slerp rotation
             var v1 = new Vector2(Mathf.Cos(r1), Mathf.Sin(r1));

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -124,11 +124,11 @@ namespace Godot
         /// <returns>The interpolated transform.</returns>
         public readonly Transform3D InterpolateWith(Transform3D transform, real_t weight)
         {
-            Vector3 sourceScale = basis.Scale;
+            Vector3 sourceScale = basis.GetScale();
             Quaternion sourceRotation = basis.GetRotationQuaternion();
             Vector3 sourceLocation = origin;
 
-            Vector3 destinationScale = transform.basis.Scale;
+            Vector3 destinationScale = transform.basis.GetScale();
             Quaternion destinationRotation = transform.basis.GetRotationQuaternion();
             Vector3 destinationLocation = transform.origin;
 


### PR DESCRIPTION
- Replace `Rotation` property with `GetRotation` method in `Transform2D`.
- Replace `Scale` property with `GetScale` method in `Transform2D`.
- Replace `Scale` property with `GetScale` method in `Basis`.

Core does not expose set methods.
