### PR TITLE
Add "Close Tabs Below" option to script editor context menu

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -863,6 +863,18 @@ void ScriptEditor::_close_other_tabs() {
 	_queue_close_tabs();
 }
 
+void ScriptEditor::_close_tabs_below() {
+	int current_idx = tab_container->get_current_tab();
+	for (int i = tab_container->get_tab_count() - 1; i >= 0; i--) {
+		if (i == current_idx) {
+			break;
+		}
+		script_close_queue.push_back(i);
+	}
+	_go_to_tab(current_idx);
+	_queue_close_tabs();
+}
+
 void ScriptEditor::_close_all_tabs() {
 	for (int i = tab_container->get_tab_count() - 1; i >= 0; i--) {
 		script_close_queue.push_back(i);
@@ -1384,6 +1396,9 @@ void ScriptEditor::_menu_option(int p_option) {
 			case CLOSE_OTHER_TABS: {
 				_close_other_tabs();
 			} break;
+			case CLOSE_TABS_BELOW: {
+				_close_tabs_below();
+			} break;
 			case CLOSE_ALL: {
 				_close_all_tabs();
 			} break;
@@ -1429,6 +1444,9 @@ void ScriptEditor::_menu_option(int p_option) {
 				} break;
 				case CLOSE_OTHER_TABS: {
 					_close_other_tabs();
+				} break;
+				case CLOSE_TABS_BELOW: {
+					_close_tabs_below();
 				} break;
 				case CLOSE_ALL: {
 					_close_all_tabs();
@@ -3052,6 +3070,7 @@ void ScriptEditor::_make_script_list_context_menu() {
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_file"), FILE_CLOSE);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_all"), CLOSE_ALL);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_other_tabs"), CLOSE_OTHER_TABS);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_tabs_below"), CLOSE_TABS_BELOW);
 	context_menu->add_separator();
 	if (se) {
 		Ref<Script> scr = se->get_edited_resource();
@@ -3074,6 +3093,7 @@ void ScriptEditor::_make_script_list_context_menu() {
 
 	context_menu->set_item_disabled(context_menu->get_item_index(CLOSE_ALL), tab_container->get_tab_count() <= 0);
 	context_menu->set_item_disabled(context_menu->get_item_index(CLOSE_OTHER_TABS), tab_container->get_tab_count() <= 1);
+	context_menu->set_item_disabled(context_menu->get_item_index(CLOSE_TABS_BELOW), tab_container->get_current_tab() >= tab_container->get_tab_count() - 1);
 	context_menu->set_item_disabled(context_menu->get_item_index(WINDOW_MOVE_UP), tab_container->get_current_tab() <= 0);
 	context_menu->set_item_disabled(context_menu->get_item_index(WINDOW_MOVE_DOWN), tab_container->get_current_tab() >= tab_container->get_tab_count() - 1);
 	context_menu->set_item_disabled(context_menu->get_item_index(WINDOW_SORT), tab_container->get_tab_count() <= 1);
@@ -3595,6 +3615,7 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method("_close_docs_tab", &ScriptEditor::_close_docs_tab);
 	ClassDB::bind_method("_close_all_tabs", &ScriptEditor::_close_all_tabs);
 	ClassDB::bind_method("_close_other_tabs", &ScriptEditor::_close_other_tabs);
+	ClassDB::bind_method("_close_tabs_below", &ScriptEditor::_close_tabs_below);
 	ClassDB::bind_method("_goto_script_line2", &ScriptEditor::_goto_script_line2);
 	ClassDB::bind_method("_copy_script_path", &ScriptEditor::_copy_script_path);
 
@@ -3791,6 +3812,7 @@ ScriptEditor::ScriptEditor() {
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/close_file", TTR("Close"), KeyModifierMask::CMD_OR_CTRL | Key::W), FILE_CLOSE);
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/close_all", TTR("Close All")), CLOSE_ALL);
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/close_other_tabs", TTR("Close Other Tabs")), CLOSE_OTHER_TABS);
+	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/close_tabs_below", TTR("Close Tabs Below")), CLOSE_TABS_BELOW);
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/close_docs", TTR("Close Docs")), CLOSE_DOCS);
 
 	file_menu->get_popup()->add_separator();

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -203,6 +203,7 @@ class ScriptEditor : public PanelContainer {
 		CLOSE_DOCS,
 		CLOSE_ALL,
 		CLOSE_OTHER_TABS,
+		CLOSE_TABS_BELOW,
 		TOGGLE_SCRIPTS_PANEL,
 		SHOW_IN_FILE_SYSTEM,
 		FILE_COPY_PATH,
@@ -343,6 +344,7 @@ class ScriptEditor : public PanelContainer {
 	void _close_discard_current_tab(const String &p_str);
 	void _close_docs_tab();
 	void _close_other_tabs();
+	void _close_tabs_below();
 	void _close_all_tabs();
 	void _queue_close_tabs();
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5976

Adds an option to quickly close all the tabs below the selected tab in the script editor right-click context menu. This adds consistency with the scene tab context menu, which has the option to close all tabs to the right.

![image](https://user-images.githubusercontent.com/89754713/212493860-1e7bf936-6ef5-4240-b588-4aa2a8ce276a.png)
