### PR TITLE
[3.x] Add "Close Tabs Below" option to script editor context menu

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -651,6 +651,18 @@ void ScriptEditor::_close_all_tabs() {
 	_queue_close_tabs();
 }
 
+void ScriptEditor::_close_tabs_below() {
+	int current_idx = tab_container->get_current_tab();
+	for (int i = tab_container->get_tab_count() - 1; i >= 0; i--) {
+		if (i == current_idx) {
+			break;
+		}
+		script_close_queue.push_back(i);
+	}
+	_go_to_tab(current_idx);
+	_queue_close_tabs();
+}
+
 void ScriptEditor::_queue_close_tabs() {
 	while (!script_close_queue.empty()) {
 		int idx = script_close_queue.front()->get();
@@ -1222,6 +1234,9 @@ void ScriptEditor::_menu_option(int p_option) {
 			case CLOSE_ALL: {
 				_close_all_tabs();
 			} break;
+			case CLOSE_TABS_BELOW: {
+				_close_tabs_below();
+			} break;
 			case DEBUG_NEXT: {
 				if (debugger) {
 					debugger->debug_next();
@@ -1290,6 +1305,9 @@ void ScriptEditor::_menu_option(int p_option) {
 				} break;
 				case CLOSE_ALL: {
 					_close_all_tabs();
+				} break;
+				case CLOSE_TABS_BELOW: {
+					_close_tabs_below();
 				} break;
 				case WINDOW_MOVE_UP: {
 					if (tab_container->get_current_tab() > 0) {
@@ -1400,6 +1418,7 @@ void ScriptEditor::_prepare_file_menu() {
 	menu->set_item_disabled(menu->get_item_index(FILE_CLOSE), tab_container->get_child_count() < 1);
 	menu->set_item_disabled(menu->get_item_index(CLOSE_ALL), tab_container->get_child_count() < 1);
 	menu->set_item_disabled(menu->get_item_index(CLOSE_OTHER_TABS), tab_container->get_child_count() <= 1);
+	menu->set_item_disabled(menu->get_item_index(CLOSE_TABS_BELOW), tab_container->get_current_tab() >= tab_container->get_tab_count() - 1);
 	menu->set_item_disabled(menu->get_item_index(CLOSE_DOCS), !_has_docs_tab());
 
 	menu->set_item_disabled(menu->get_item_index(FILE_RUN), current_is_doc);
@@ -2717,6 +2736,7 @@ void ScriptEditor::_make_script_list_context_menu() {
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_file"), FILE_CLOSE);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_all"), CLOSE_ALL);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_other_tabs"), CLOSE_OTHER_TABS);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_tabs_below"), CLOSE_TABS_BELOW);
 	context_menu->add_separator();
 	if (se) {
 		Ref<Script> scr = se->get_edited_resource();
@@ -2739,6 +2759,7 @@ void ScriptEditor::_make_script_list_context_menu() {
 
 	context_menu->set_item_disabled(context_menu->get_item_index(CLOSE_ALL), tab_container->get_child_count() <= 0);
 	context_menu->set_item_disabled(context_menu->get_item_index(CLOSE_OTHER_TABS), tab_container->get_child_count() <= 1);
+	context_menu->set_item_disabled(context_menu->get_item_index(CLOSE_TABS_BELOW), tab_container->get_current_tab() >= tab_container->get_tab_count() - 1);
 	context_menu->set_item_disabled(context_menu->get_item_index(WINDOW_MOVE_UP), tab_container->get_current_tab() <= 0);
 	context_menu->set_item_disabled(context_menu->get_item_index(WINDOW_MOVE_DOWN), tab_container->get_current_tab() >= tab_container->get_child_count() - 1);
 	context_menu->set_item_disabled(context_menu->get_item_index(WINDOW_SORT), tab_container->get_child_count() <= 1);
@@ -3168,6 +3189,7 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method("_tab_changed", &ScriptEditor::_tab_changed);
 	ClassDB::bind_method("_menu_option", &ScriptEditor::_menu_option);
 	ClassDB::bind_method("_close_current_tab", &ScriptEditor::_close_current_tab);
+	ClassDB::bind_method("_close_tabs_below", &ScriptEditor::_close_tabs_below);
 	ClassDB::bind_method("_close_discard_current_tab", &ScriptEditor::_close_discard_current_tab);
 	ClassDB::bind_method("_close_docs_tab", &ScriptEditor::_close_docs_tab);
 	ClassDB::bind_method("_close_all_tabs", &ScriptEditor::_close_all_tabs);
@@ -3397,6 +3419,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/close_file", TTR("Close"), KEY_MASK_CMD | KEY_W), FILE_CLOSE);
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/close_all", TTR("Close All")), CLOSE_ALL);
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/close_other_tabs", TTR("Close Other Tabs")), CLOSE_OTHER_TABS);
+	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/close_tabs_below", TTR("Close Tabs Below")), CLOSE_TABS_BELOW);
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/close_docs", TTR("Close Docs")), CLOSE_DOCS);
 
 	file_menu->get_popup()->add_separator();

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -148,6 +148,7 @@ class ScriptEditor : public PanelContainer {
 		CLOSE_DOCS,
 		CLOSE_ALL,
 		CLOSE_OTHER_TABS,
+		CLOSE_TABS_BELOW,
 		TOGGLE_SCRIPTS_PANEL,
 		SHOW_IN_FILE_SYSTEM,
 		FILE_COPY_PATH,
@@ -297,6 +298,7 @@ class ScriptEditor : public PanelContainer {
 	void _close_discard_current_tab(const String &p_str);
 	void _close_docs_tab();
 	void _close_other_tabs();
+	void _close_tabs_below();
 	void _close_all_tabs();
 	void _queue_close_tabs();
 


### PR DESCRIPTION
`3.x` version of #71432.

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/5976.*