### PR TITLE
Alter linux debug stacktraces handling to support more environments

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -540,6 +540,9 @@ if selected_platform in platform_list:
             env.Append(CCFLAGS=["/Od"])
     else:
         if env["debug_symbols"]:
+            # Adding dwarf-4 explicitly makes stacktraces work with clang builds,
+            # otherwise addr2line doesn't understand them
+            env.Append(CCFLAGS=["-gdwarf-4"])
             if env.dev_build:
                 env.Append(CCFLAGS=["-g3"])
             else:


### PR DESCRIPTION
- Use -gdwarf-4 to support both LLVM and GCC when calling addr2line
  As discussed in `#devel` on chat.godotengine.org:
  > GCC and LLVM debug symbols should be compatible but depending on compiler versions and addr2line version in might be support only some versions of debug symbols, so adding -gdwarf-4 build flag to LLVM build might help. LLVM 14 and latest GCC versions use version 5 by default.

  This indeed seems to be true, as without specifying `-gdwarf-4` addr2line does not work with clang builds (and llvm-addr2line has to be used instead).

- Subtract position-independant execuable relocation when passing the address to addr2line
  The PIE executable change shouldn't interfere with any logic for non-PIE executables, since for them the relocation is equal to zero. 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
