### PR TITLE
Improve performance of imported file scan

### DIFF
--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -213,7 +213,7 @@ private:
 	void _file_multi_selected(int p_index, bool p_selected);
 	void _tree_multi_selected(Object *p_item, int p_column, bool p_selected);
 
-	void _get_imported_files(const String &p_path, Vector<String> &r_files) const;
+	bool _get_imported_files(const String &p_path, String &r_extension, Vector<String> &r_files) const;
 	void _update_import_dock();
 
 	void _get_all_items_in_dir(EditorFileSystemDirectory *p_efsd, Vector<String> &r_files, Vector<String> &r_folders) const;


### PR DESCRIPTION
Closes #66901

I optimized `_get_imported_files()` a bit (now it will abort scan when files are different, not after scanning everything), but it was not enough, so I handled `res://` separately.