### PR TITLE
Make EditorResourceConversionPlugin usable.

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -467,6 +467,14 @@
 				See [method add_inspector_plugin] for an example of how to register a plugin.
 			</description>
 		</method>
+		<method name="add_resource_conversion_plugin">
+			<return type="void" />
+			<param index="0" name="plugin" type="EditorResourceConversionPlugin" />
+			<description>
+				Registers a new [EditorResourceConversionPlugin]. Resource conversion plugins are used to add custom resource converters to the editor inspector.
+				See [EditorResourceConversionPlugin] for an example of how to create a resource conversion plugin.
+			</description>
+		</method>
 		<method name="add_scene_format_importer_plugin">
 			<return type="void" />
 			<param index="0" name="scene_format_importer" type="EditorSceneFormatImporter" />
@@ -630,6 +638,13 @@
 			<param index="0" name="plugin" type="EditorNode3DGizmoPlugin" />
 			<description>
 				Removes a gizmo plugin registered by [method add_node_3d_gizmo_plugin].
+			</description>
+		</method>
+		<method name="remove_resource_conversion_plugin">
+			<return type="void" />
+			<param index="0" name="plugin" type="EditorResourceConversionPlugin" />
+			<description>
+				Removes a resource conversion plugin registered by [method add_resource_conversion_plugin].
 			</description>
 		</method>
 		<method name="remove_scene_format_importer_plugin">

--- a/doc/classes/EditorResourceConversionPlugin.xml
+++ b/doc/classes/EditorResourceConversionPlugin.xml
@@ -1,8 +1,28 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="EditorResourceConversionPlugin" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Plugin for adding custom converters from one resource format to another in the editor resource picker context menu; for example, converting a [StandardMaterial3D] to a [ShaderMaterial].
 	</brief_description>
 	<description>
+		[EditorResourceConversionPlugin] is invoked when the context menu is brought up for a resource in the editor inspector. Relevant conversion plugins will appear as menu options to convert the given resource to a target type.
+		Below shows an example of a basic plugin that will convert an [ImageTexture] to a [PortableCompressedTexture2D].
+		[codeblocks]
+		[gdscript]
+		extends EditorResourceConversionPlugin
+
+		func _handles(resource : Resource):
+		    return resource is ImageTexture
+
+		func _converts_to():
+		    return "PortableCompressedTexture2D"
+
+		func _convert(itex : Resource):
+		    var ptex = PortableCompressedTexture2D.new()
+		    ptex.create_from_image(itex.get_image(), PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)
+		    return ptex
+		[/gdscript]
+		[/codeblocks]
+		To use an [EditorResourceConversionPlugin], register it using the [method EditorPlugin.add_resource_conversion_plugin] method first.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -11,17 +31,20 @@
 			<return type="Resource" />
 			<param index="0" name="resource" type="Resource" />
 			<description>
+				Takes an input [Resource] and converts it to the type given in [method _converts_to]. The returned [Resource] is the result of the conversion, and the input [Resource] remains unchanged.
 			</description>
 		</method>
 		<method name="_converts_to" qualifiers="virtual const">
 			<return type="String" />
 			<description>
+				Returns the class name of the target type of [Resource] that this plugin converts source resources to.
 			</description>
 		</method>
 		<method name="_handles" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="resource" type="Resource" />
 			<description>
+				Called to determine whether a particular [Resource] can be converted to the target resource type by this plugin.
 			</description>
 		</method>
 	</methods>

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -45,6 +45,7 @@
 #include "editor/inspector_dock.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
 #include "editor/plugins/editor_debugger_plugin.h"
+#include "editor/plugins/editor_resource_conversion_plugin.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "editor/plugins/script_editor_plugin.h"
 #include "editor/project_settings_editor.h"
@@ -856,6 +857,14 @@ void EditorPlugin::remove_debugger_plugin(const Ref<EditorDebuggerPlugin> &p_plu
 	EditorDebuggerNode::get_singleton()->remove_debugger_plugin(p_plugin);
 }
 
+void EditorPlugin::add_resource_conversion_plugin(const Ref<EditorResourceConversionPlugin> &p_plugin) {
+	EditorNode::get_singleton()->add_resource_conversion_plugin(p_plugin);
+}
+
+void EditorPlugin::remove_resource_conversion_plugin(const Ref<EditorResourceConversionPlugin> &p_plugin) {
+	EditorNode::get_singleton()->remove_resource_conversion_plugin(p_plugin);
+}
+
 void EditorPlugin::_editor_project_settings_changed() {
 	emit_signal(SNAME("project_settings_changed"));
 }
@@ -911,6 +920,8 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_node_3d_gizmo_plugin", "plugin"), &EditorPlugin::remove_node_3d_gizmo_plugin);
 	ClassDB::bind_method(D_METHOD("add_inspector_plugin", "plugin"), &EditorPlugin::add_inspector_plugin);
 	ClassDB::bind_method(D_METHOD("remove_inspector_plugin", "plugin"), &EditorPlugin::remove_inspector_plugin);
+	ClassDB::bind_method(D_METHOD("add_resource_conversion_plugin", "plugin"), &EditorPlugin::add_resource_conversion_plugin);
+	ClassDB::bind_method(D_METHOD("remove_resource_conversion_plugin", "plugin"), &EditorPlugin::remove_resource_conversion_plugin);
 	ClassDB::bind_method(D_METHOD("set_input_event_forwarding_always_enabled"), &EditorPlugin::set_input_event_forwarding_always_enabled);
 	ClassDB::bind_method(D_METHOD("set_force_draw_over_forwarding_enabled"), &EditorPlugin::set_force_draw_over_forwarding_enabled);
 

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -48,6 +48,7 @@ class EditorInspector;
 class EditorInspectorPlugin;
 class EditorNode3DGizmoPlugin;
 class EditorPaths;
+class EditorResourceConversionPlugin;
 class EditorResourcePreview;
 class EditorSceneFormatImporter;
 class EditorScenePostImportPlugin;
@@ -306,6 +307,9 @@ public:
 
 	void add_debugger_plugin(const Ref<EditorDebuggerPlugin> &p_plugin);
 	void remove_debugger_plugin(const Ref<EditorDebuggerPlugin> &p_plugin);
+
+	void add_resource_conversion_plugin(const Ref<EditorResourceConversionPlugin> &p_plugin);
+	void remove_resource_conversion_plugin(const Ref<EditorResourceConversionPlugin> &p_plugin);
 
 	void enable_plugin();
 	void disable_plugin();


### PR DESCRIPTION
Previously, `EditorResourceConversionPlugin` nominally existed in scripting, but there was no way for a user to actually register one. This PR adds methods to `EditorPlugin` for registering/unregistering `EditorResourceConversionPlugins`. Additionally, it documents `EditorResourceConversionPlugin` with descriptions and a basic example.
I do wonder if there's a better place to store resource conversion plugins than in `EditorNode`, since it's already fairly bloated with other features.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
