### PR TITLE
C#: Add missing `Transform{2D,3D}` and `Basis` constructors

### DIFF
--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -41,6 +41,7 @@
 			<return type="Transform3D" />
 			<param index="0" name="from" type="Projection" />
 			<description>
+				Constructs a Transform3D from a [Projection] by trimming the last row of the projection matrix ([code]from.x.w[/code], [code]from.y.w[/code], [code]from.z.w[/code], and [code]from.w.w[/code] are not copied over).
 			</description>
 		</constructor>
 		<constructor name="Transform3D">

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -977,8 +977,20 @@ namespace Godot
             // We need to assign the struct fields here first so we can't do it that way...
         }
 
-        // Arguments are named such that xy is equal to calling x.y
-        internal Basis(real_t xx, real_t yx, real_t zx, real_t xy, real_t yy, real_t zy, real_t xz, real_t yz, real_t zz)
+        /// <summary>
+        /// Constructs a transformation matrix from the given components.
+        /// Arguments are named such that xy is equal to calling <c>x.y</c>.
+        /// </summary>
+        /// <param name="xx">The X component of the X column vector, accessed via <c>b.x.x</c> or <c>[0][0]</c>.</param>
+        /// <param name="yx">The X component of the Y column vector, accessed via <c>b.y.x</c> or <c>[1][0]</c>.</param>
+        /// <param name="zx">The X component of the Z column vector, accessed via <c>b.z.x</c> or <c>[2][0]</c>.</param>
+        /// <param name="xy">The Y component of the X column vector, accessed via <c>b.x.y</c> or <c>[0][1]</c>.</param>
+        /// <param name="yy">The Y component of the Y column vector, accessed via <c>b.y.y</c> or <c>[1][1]</c>.</param>
+        /// <param name="zy">The Y component of the Z column vector, accessed via <c>b.y.y</c> or <c>[2][1]</c>.</param>
+        /// <param name="xz">The Z component of the X column vector, accessed via <c>b.x.y</c> or <c>[0][2]</c>.</param>
+        /// <param name="yz">The Z component of the Y column vector, accessed via <c>b.y.y</c> or <c>[1][2]</c>.</param>
+        /// <param name="zz">The Z component of the Z column vector, accessed via <c>b.y.y</c> or <c>[2][2]</c>.</param>
+        public Basis(real_t xx, real_t yx, real_t zx, real_t xy, real_t yy, real_t zy, real_t xz, real_t yz, real_t zz)
         {
             Row0 = new Vector3(xx, yx, zx);
             Row1 = new Vector3(xy, yy, zy);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -433,7 +433,7 @@ namespace Godot
 
         /// <summary>
         /// Constructs a transformation matrix from the given components.
-        /// Arguments are named such that xy is equal to calling x.y
+        /// Arguments are named such that xy is equal to calling <c>x.y</c>.
         /// </summary>
         /// <param name="xx">The X component of the X column vector, accessed via <c>t.x.x</c> or <c>[0][0]</c>.</param>
         /// <param name="xy">The Y component of the X column vector, accessed via <c>t.x.y</c> or <c>[0][1]</c>.</param>
@@ -459,6 +459,24 @@ namespace Godot
             x.x = y.y = Mathf.Cos(rotation);
             x.y = y.x = Mathf.Sin(rotation);
             y.x *= -1;
+            this.origin = origin;
+        }
+
+        /// <summary>
+        /// Constructs a transformation matrix from a <paramref name="rotation"/> value,
+        /// <paramref name="scale"/> vector, <paramref name="skew"/> value, and
+        /// <paramref name="origin"/> vector.
+        /// </summary>
+        /// <param name="rotation">The rotation of the new transform, in radians.</param>
+        /// <param name="scale">The scale of the new transform.</param>
+        /// <param name="skew">The skew of the new transform, in radians.</param>
+        /// <param name="origin">The origin vector, or column index 2.</param>
+        public Transform2D(real_t rotation, Vector2 scale, real_t skew, Vector2 origin)
+        {
+            x.x = Mathf.Cos(rotation) * scale.x;
+            y.y = Mathf.Cos(rotation + skew) * scale.y;
+            y.x = -Mathf.Sin(rotation + skew) * scale.y;
+            x.y = Mathf.Sin(rotation) * scale.x;
             this.origin = origin;
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -356,15 +356,25 @@ namespace Godot
         }
 
         /// <summary>
-        /// Constructs a transformation matrix from the given <paramref name="quaternion"/>
-        /// and <paramref name="origin"/> vector.
+        /// Constructs a transformation matrix from the given components.
+        /// Arguments are named such that xy is equal to calling <c>basis.x.y</c>.
         /// </summary>
-        /// <param name="quaternion">The <see cref="Quaternion"/> to create the basis from.</param>
-        /// <param name="origin">The origin vector, or column index 3.</param>
-        public Transform3D(Quaternion quaternion, Vector3 origin)
+        /// <param name="xx">The X component of the X column vector, accessed via <c>t.basis.x.x</c> or <c>[0][0]</c>.</param>
+        /// <param name="yx">The X component of the Y column vector, accessed via <c>t.basis.y.x</c> or <c>[1][0]</c>.</param>
+        /// <param name="zx">The X component of the Z column vector, accessed via <c>t.basis.z.x</c> or <c>[2][0]</c>.</param>
+        /// <param name="xy">The Y component of the X column vector, accessed via <c>t.basis.x.y</c> or <c>[0][1]</c>.</param>
+        /// <param name="yy">The Y component of the Y column vector, accessed via <c>t.basis.y.y</c> or <c>[1][1]</c>.</param>
+        /// <param name="zy">The Y component of the Z column vector, accessed via <c>t.basis.y.y</c> or <c>[2][1]</c>.</param>
+        /// <param name="xz">The Z component of the X column vector, accessed via <c>t.basis.x.y</c> or <c>[0][2]</c>.</param>
+        /// <param name="yz">The Z component of the Y column vector, accessed via <c>t.basis.y.y</c> or <c>[1][2]</c>.</param>
+        /// <param name="zz">The Z component of the Z column vector, accessed via <c>t.basis.y.y</c> or <c>[2][2]</c>.</param>
+        /// <param name="ox">The X component of the origin vector, accessed via <c>t.origin.x</c> or <c>[2][0]</c>.</param>
+        /// <param name="oy">The Y component of the origin vector, accessed via <c>t.origin.y</c> or <c>[2][1]</c>.</param>
+        /// <param name="oz">The Z component of the origin vector, accessed via <c>t.origin.z</c> or <c>[2][2]</c>.</param>
+        public Transform3D(real_t xx, real_t yx, real_t zx, real_t xy, real_t yy, real_t zy, real_t xz, real_t yz, real_t zz, real_t ox, real_t oy, real_t oz)
         {
-            basis = new Basis(quaternion);
-            this.origin = origin;
+            basis = new Basis(xx, yx, zx, xy, yy, zy, xz, yz, zz);
+            origin = new Vector3(ox, oy, oz);
         }
 
         /// <summary>
@@ -377,6 +387,29 @@ namespace Godot
         {
             this.basis = basis;
             this.origin = origin;
+        }
+
+        /// <summary>
+        /// Constructs a transformation matrix from the given <paramref name="projection"/>
+        /// by trimming the last row of the projection matrix (<c>projection.x.w</c>,
+        /// <c>projection.y.w</c>, <c>projection.z.w</c>, and <c>projection.w.w</c>
+        /// are not copied over).
+        /// </summary>
+        /// <param name="projection">The <see cref="Projection"/> to create the transform from.</param>
+        public Transform3D(Projection projection)
+        {
+            basis = new Basis
+            (
+                projection.x.x, projection.y.x, projection.z.x,
+                projection.x.y, projection.y.y, projection.z.y,
+                projection.x.z, projection.y.z, projection.z.z
+            );
+            origin = new Vector3
+            (
+                projection.w.x,
+                projection.w.y,
+                projection.w.z
+            );
         }
 
         /// <summary>


### PR DESCRIPTION
- Remove `Transform3D(Quaternion, Vector3)` constructor from C#.
	- Added to C# in https://github.com/godotengine/godot/pull/11899.
- Add `Transform3D(Projection)` constructor to C#.
	- Added to Core in https://github.com/godotengine/godot/pull/63219.
- Add documentation to the `Transform3D(Projection)` constructor in Core.
- Add `Transform3D` constructor with only real_t params to C# that mirrors `Transform2D`.
- Expose `Basis` constructor with only real_t params in C#.
- Add `Transform2D(real_t, Vector2, real_t, Vector2)` constructor to C#.
	- Added to Core in https://github.com/godotengine/godot/pull/52398.
