### PR TITLE
Fixes issue where failed start of OpenXR causes issues

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -560,6 +560,12 @@ void OpenXRAPI::destroy_instance() {
 		instance = XR_NULL_HANDLE;
 	}
 	enabled_extensions.clear();
+
+	if (graphics_extension != nullptr) {
+		unregister_extension_wrapper(graphics_extension);
+		memdelete(graphics_extension);
+		graphics_extension = nullptr;
+	}
 }
 
 bool OpenXRAPI::create_session() {
@@ -1345,6 +1351,10 @@ void OpenXRAPI::set_xr_interface(OpenXRInterface *p_xr_interface) {
 
 void OpenXRAPI::register_extension_wrapper(OpenXRExtensionWrapper *p_extension_wrapper) {
 	registered_extension_wrappers.push_back(p_extension_wrapper);
+}
+
+void OpenXRAPI::unregister_extension_wrapper(OpenXRExtensionWrapper *p_extension_wrapper) {
+	registered_extension_wrappers.erase(p_extension_wrapper);
 }
 
 void OpenXRAPI::register_extension_metadata() {

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -312,6 +312,7 @@ public:
 
 	void set_xr_interface(OpenXRInterface *p_xr_interface);
 	static void register_extension_wrapper(OpenXRExtensionWrapper *p_extension_wrapper);
+	static void unregister_extension_wrapper(OpenXRExtensionWrapper *p_extension_wrapper);
 	static void register_extension_metadata();
 	static void cleanup_extension_wrappers();
 

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -111,6 +111,10 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 			ERR_FAIL_NULL(openxr_api);
 
 			if (!openxr_api->initialize(Main::get_rendering_driver_name())) {
+				OS::get_singleton()->alert("OpenXR was requested but failed to start.\n"
+										   "Please check if your HMD is connected.\n"
+										   "When using Windows MR please note that WMR only has DirectX support, make sure SteamVR is your default OpenXR runtime.\n"
+										   "Godot will start in normal mode.\n");
 				memdelete(openxr_api);
 				openxr_api = nullptr;
 				return;


### PR DESCRIPTION
We recently changed the way OpenXR manages extensions. This resulted in graphics API extension not being cleaned up if OpenXR was requested but failed to start. When using the Vulkan graphics API this results in the Vulkan hooks remaining in place causing a number of flow on issues.

We're now properly cleaning up the graphics API extension on failure and presenting a message to the user that while OpenXR was requested, it failed to start.

OpenXR will fail to start if:
- No OpenXR runtime is installed
- SteamVR is used but no headset is connected
- WMR is used natively as it only supports DirectX.

This likely fixes #71266 and fixes #64584