### PR TITLE
C#: Remove `Area` property from `Rect2{i}`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -50,15 +50,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// The area of this <see cref="Rect2"/>.
-        /// </summary>
-        /// <value>Equivalent to <see cref="GetArea()"/>.</value>
-        public readonly real_t Area
-        {
-            get { return GetArea(); }
-        }
-
-        /// <summary>
         /// Returns a <see cref="Rect2"/> with equivalent position and size, modified so that
         /// the top-left corner is the origin and width and height are positive.
         /// </summary>
@@ -162,6 +153,7 @@ namespace Godot
 
         /// <summary>
         /// Returns the area of the <see cref="Rect2"/>.
+        /// See also <see cref="HasArea"/>.
         /// </summary>
         /// <returns>The area.</returns>
         public readonly real_t GetArea()

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
@@ -50,15 +50,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// The area of this <see cref="Rect2i"/>.
-        /// </summary>
-        /// <value>Equivalent to <see cref="GetArea()"/>.</value>
-        public readonly int Area
-        {
-            get { return GetArea(); }
-        }
-
-        /// <summary>
         /// Returns a <see cref="Rect2i"/> with equivalent position and size, modified so that
         /// the top-left corner is the origin and width and height are positive.
         /// </summary>
@@ -152,6 +143,7 @@ namespace Godot
 
         /// <summary>
         /// Returns the area of the <see cref="Rect2i"/>.
+        /// See also <see cref="HasArea"/>.
         /// </summary>
         /// <returns>The area.</returns>
         public readonly int GetArea()


### PR DESCRIPTION
- Alternative of https://github.com/godotengine/godot/pull/71992 that keeps the methods instead of the properties.
- Remove `Area` property in favor of the `GetArea` method.
	- This avoids having 2 members that do the same thing and may confuse users.
	- `AABB` implements `GetVolume()` as a method so it'd be consistent.
	- Since the implementation seems cheap enough we could decide to keep the property instead[^1].

[^1]: This is not possible in GDScript because it doesn't support readonly properties but in C# we can.