### PR TITLE
OpenGL: Improve logging in dev builds

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -53,6 +53,8 @@
 #define _EXT_DEBUG_TYPE_PORTABILITY_ARB 0x824F
 #define _EXT_DEBUG_TYPE_PERFORMANCE_ARB 0x8250
 #define _EXT_DEBUG_TYPE_OTHER_ARB 0x8251
+#define _EXT_DEBUG_TYPE_MARKER_ARB 0x8268
+#define _EXT_DEBUG_SEVERITY_NOTIFICATION_ARB 0x826B
 #define _EXT_MAX_DEBUG_MESSAGE_LENGTH_ARB 0x9143
 #define _EXT_MAX_DEBUG_LOGGED_MESSAGES_ARB 0x9144
 #define _EXT_DEBUG_LOGGED_MESSAGES_ARB 0x9145
@@ -120,7 +122,7 @@ static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GL
 		return;
 	}
 
-	if (type == _EXT_DEBUG_TYPE_PERFORMANCE_ARB) {
+	if (type == _EXT_DEBUG_TYPE_PERFORMANCE_ARB || type == _EXT_DEBUG_TYPE_MARKER_ARB) {
 		return; //these are ultimately annoying, so removing for now
 	}
 
@@ -138,6 +140,8 @@ static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GL
 		strcpy(debSource, "Application");
 	} else if (source == _EXT_DEBUG_SOURCE_OTHER_ARB) {
 		strcpy(debSource, "Other");
+	} else {
+		strcpy(debSource, "(unknown)");
 	}
 
 	if (type == _EXT_DEBUG_TYPE_ERROR_ARB) {
@@ -150,8 +154,12 @@ static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GL
 		strcpy(debType, "Portability");
 	} else if (type == _EXT_DEBUG_TYPE_PERFORMANCE_ARB) {
 		strcpy(debType, "Performance");
+	} else if (type == _EXT_DEBUG_TYPE_MARKER_ARB) {
+		strcpy(debType, "Marker");
 	} else if (type == _EXT_DEBUG_TYPE_OTHER_ARB) {
 		strcpy(debType, "Other");
+	} else {
+		strcpy(debType, "(unknown)");
 	}
 
 	if (severity == _EXT_DEBUG_SEVERITY_HIGH_ARB) {
@@ -160,6 +168,10 @@ static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GL
 		strcpy(debSev, "Medium");
 	} else if (severity == _EXT_DEBUG_SEVERITY_LOW_ARB) {
 		strcpy(debSev, "Low");
+	} else if (severity == _EXT_DEBUG_SEVERITY_NOTIFICATION_ARB) {
+		strcpy(debSev, "Notification");
+	} else {
+		strcpy(debSev, "(unknown)");
 	}
 
 	String output = String() + "GL ERROR: Source: " + debSource + "\tType: " + debType + "\tID: " + itos(id) + "\tSeverity: " + debSev + "\tMessage: " + message;


### PR DESCRIPTION
This PR prevents the debug message handler used in dev builds from accessing uninitialized memory and support `DEBUG_TYPE_MARKER` and `DEBUG_SEVERITY_NOTIFICATION`. As markers can be injected on a per-frame basis (which happens for example with OpenXR), it disables debug output for markers for now to avoid spamming the logs.

Stuff to consider when reviewing:
* I added the excludion of `DEBUG_TYPE_MARKER` to avoid massive per-frame spamming of the log with OpenXR on a Pico 4, as having an error per frame makes logs unreadable; going by type felt suitable to match surrounding code, but we could also filter by `DEBUG_SEVERITY_NOTIFICATION` instead, if that would be preferable?
* I kept the existing `if`/`else if` structure to avoid changing too much, but `switch` might make code more readable?

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
