### PR TITLE
Rename `center` method to `get_center` in Plane.

### DIFF
--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -748,7 +748,7 @@ Geometry3D::MeshData Geometry3D::build_convex_mesh(const Vector<Plane> &p_planes
 		Vector3 right = p.normal.cross(ref).normalized();
 		Vector3 up = p.normal.cross(right).normalized();
 
-		Vector3 center = p.center();
+		Vector3 center = p.get_center();
 
 		// make a quad clockwise
 		LocalVector<Vector3> vertices = {

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -47,7 +47,7 @@ struct _NO_DISCARD_ Plane {
 
 	/* Plane-Point operations */
 
-	_FORCE_INLINE_ Vector3 center() const { return normal * d; }
+	_FORCE_INLINE_ Vector3 get_center() const { return normal * d; }
 	Vector3 get_any_perpendicular_normal() const;
 
 	_FORCE_INLINE_ bool is_point_over(const Vector3 &p_point) const; ///< Point is over plane

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1923,7 +1923,7 @@ static void _register_variant_builtin_methods() {
 	/* Plane */
 
 	bind_method(Plane, normalized, sarray(), varray());
-	bind_method(Plane, center, sarray(), varray());
+	bind_method(Plane, get_center, sarray(), varray());
 	bind_method(Plane, is_equal_approx, sarray("to_plane"), varray());
 	bind_method(Plane, is_finite, sarray(), varray());
 	bind_method(Plane, is_point_over, sarray("point"), varray());

--- a/doc/classes/Plane.xml
+++ b/doc/classes/Plane.xml
@@ -67,17 +67,17 @@
 		</constructor>
 	</constructors>
 	<methods>
-		<method name="center" qualifiers="const">
-			<return type="Vector3" />
-			<description>
-				Returns the center of the plane.
-			</description>
-		</method>
 		<method name="distance_to" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="point" type="Vector3" />
 			<description>
 				Returns the shortest distance from the plane to the position [param point]. If the point is above the plane, the distance will be positive. If below, the distance will be negative.
+			</description>
+		</method>
+		<method name="get_center" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Returns the center of the plane.
 			</description>
 		</method>
 		<method name="has_point" qualifiers="const">

--- a/servers/rendering/renderer_scene_render.cpp
+++ b/servers/rendering/renderer_scene_render.cpp
@@ -84,7 +84,7 @@ void RendererSceneRender::CameraData::set_multiview_camera(uint32_t p_view_count
 	Transform3D main_transform_inv = main_transform.inverse();
 
 	// 5. figure out far plane, this could use some improvement, we may have our far plane too close like this, not sure if this matters
-	Vector3 far_center = (planes[0][Projection::PLANE_FAR].center() + planes[1][Projection::PLANE_FAR].center()) * 0.5;
+	Vector3 far_center = (planes[0][Projection::PLANE_FAR].get_center() + planes[1][Projection::PLANE_FAR].get_center()) * 0.5;
 	Plane far(-z, far_center);
 
 	/////////////////////////////////////////////////////////////////////////////

--- a/tests/core/math/test_plane.h
+++ b/tests/core/math/test_plane.h
@@ -87,8 +87,8 @@ TEST_CASE("[Plane] Plane-point operations") {
 	const Plane y_facing_plane = Plane(0, 1, 0, 4);
 
 	CHECK_MESSAGE(
-			plane.center().is_equal_approx(Vector3(32 * 3, 22 * 3, 16 * 3)),
-			"center() should return a vector pointing to the center of the plane.");
+			plane.get_center().is_equal_approx(Vector3(32 * 3, 22 * 3, 16 * 3)),
+			"get_center() should return a vector pointing to the center of the plane.");
 
 	CHECK_MESSAGE(
 			y_facing_plane.is_point_over(Vector3(0, 5, 0)),


### PR DESCRIPTION
- Rename `center` method to `get_center` in Plane to match the `get_center` method in AABB, Rect2, and Rect2i.