### PR TITLE
Fix custom theme outline settings affects the editor theme as well

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -508,6 +508,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color font_disabled_color = Color(mono_color.r, mono_color.g, mono_color.b, 0.35);
 	const Color font_readonly_color = Color(mono_color.r, mono_color.g, mono_color.b, 0.65);
 	const Color font_placeholder_color = Color(mono_color.r, mono_color.g, mono_color.b, 0.6);
+	const Color font_outline_color = Color(0, 0, 0, 0);
 	const Color selection_color = accent_color * Color(1, 1, 1, 0.4);
 	const Color disabled_color = mono_color.inverted().lerp(base_color, 0.7);
 	const Color disabled_bg_color = mono_color.inverted().lerp(base_color, 0.9);
@@ -815,6 +816,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_write_movie_button->set_expand_margin_size(SIDE_RIGHT, 2 * EDSCALE);
 	theme->set_stylebox("MovieWriterButtonPressed", "EditorStyles", style_write_movie_button);
 
+	// MenuButton
 	theme->set_stylebox("normal", "MenuButton", style_menu);
 	theme->set_stylebox("hover", "MenuButton", style_widget_hover);
 	theme->set_stylebox("pressed", "MenuButton", style_menu);
@@ -825,6 +827,9 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_hover_color", "MenuButton", font_hover_color);
 	theme->set_color("font_hover_pressed_color", "MenuButton", font_hover_pressed_color);
 	theme->set_color("font_focus_color", "MenuButton", font_focus_color);
+	theme->set_color("font_outline_color", "MenuButton", font_outline_color);
+
+	theme->set_constant("outline_size", "MenuButton", 0 * EDSCALE);
 
 	theme->set_stylebox("MenuHover", "EditorStyles", style_widget_hover);
 
@@ -841,12 +846,15 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_focus_color", "Button", font_focus_color);
 	theme->set_color("font_pressed_color", "Button", accent_color);
 	theme->set_color("font_disabled_color", "Button", font_disabled_color);
+	theme->set_color("font_outline_color", "Button", font_outline_color);
 
 	theme->set_color("icon_normal_color", "Button", icon_normal_color);
 	theme->set_color("icon_hover_color", "Button", icon_hover_color);
 	theme->set_color("icon_focus_color", "Button", icon_focus_color);
 	theme->set_color("icon_pressed_color", "Button", icon_pressed_color);
 	theme->set_color("icon_disabled_color", "Button", icon_disabled_color);
+
+	theme->set_constant("outline_size", "Button", 0 * EDSCALE);
 
 	const float ACTION_BUTTON_EXTRA_MARGIN = 32 * EDSCALE;
 
@@ -894,12 +902,15 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_focus_color", "MenuBar", font_focus_color);
 	theme->set_color("font_pressed_color", "MenuBar", accent_color);
 	theme->set_color("font_disabled_color", "MenuBar", font_disabled_color);
+	theme->set_color("font_outline_color", "MenuBar", font_outline_color);
 
 	theme->set_color("icon_normal_color", "MenuBar", icon_normal_color);
 	theme->set_color("icon_hover_color", "MenuBar", icon_hover_color);
 	theme->set_color("icon_focus_color", "MenuBar", icon_focus_color);
 	theme->set_color("icon_pressed_color", "MenuBar", icon_pressed_color);
 	theme->set_color("icon_disabled_color", "MenuBar", icon_disabled_color);
+
+	theme->set_constant("outline_size", "MenuBar", 0 * EDSCALE);
 
 	// OptionButton
 	Ref<StyleBoxFlat> style_option_button_focus = style_widget_focus->duplicate();
@@ -931,6 +942,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_focus_color", "OptionButton", font_focus_color);
 	theme->set_color("font_pressed_color", "OptionButton", accent_color);
 	theme->set_color("font_disabled_color", "OptionButton", font_disabled_color);
+	theme->set_color("font_outline_color", "OptionButton", font_outline_color);
 
 	theme->set_color("icon_normal_color", "OptionButton", icon_normal_color);
 	theme->set_color("icon_hover_color", "OptionButton", icon_hover_color);
@@ -942,6 +954,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_constant("arrow_margin", "OptionButton", widget_default_margin.x - 2 * EDSCALE);
 	theme->set_constant("modulate_arrow", "OptionButton", true);
 	theme->set_constant("h_separation", "OptionButton", 4 * EDSCALE);
+	theme->set_constant("outline_size", "OptionButton", 0 * EDSCALE);
 
 	// CheckButton
 	theme->set_stylebox("normal", "CheckButton", style_menu);
@@ -966,6 +979,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_focus_color", "CheckButton", font_focus_color);
 	theme->set_color("font_pressed_color", "CheckButton", accent_color);
 	theme->set_color("font_disabled_color", "CheckButton", font_disabled_color);
+	theme->set_color("font_outline_color", "CheckButton", font_outline_color);
 
 	theme->set_color("icon_normal_color", "CheckButton", icon_normal_color);
 	theme->set_color("icon_hover_color", "CheckButton", icon_hover_color);
@@ -975,6 +989,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	theme->set_constant("h_separation", "CheckButton", 8 * EDSCALE);
 	theme->set_constant("check_v_offset", "CheckButton", 0 * EDSCALE);
+	theme->set_constant("outline_size", "CheckButton", 0 * EDSCALE);
 
 	// Checkbox
 	Ref<StyleBoxFlat> sb_checkbox = style_menu->duplicate();
@@ -1000,6 +1015,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_focus_color", "CheckBox", font_focus_color);
 	theme->set_color("font_pressed_color", "CheckBox", accent_color);
 	theme->set_color("font_disabled_color", "CheckBox", font_disabled_color);
+	theme->set_color("font_outline_color", "CheckBox", font_outline_color);
 
 	theme->set_color("icon_normal_color", "CheckBox", icon_normal_color);
 	theme->set_color("icon_hover_color", "CheckBox", icon_hover_color);
@@ -1009,6 +1025,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	theme->set_constant("h_separation", "CheckBox", 8 * EDSCALE);
 	theme->set_constant("check_v_offset", "CheckBox", 0 * EDSCALE);
+	theme->set_constant("outline_size", "CheckBox", 0 * EDSCALE);
 
 	// PopupDialog
 	theme->set_stylebox("panel", "PopupDialog", style_popup);
@@ -1042,6 +1059,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_accelerator_color", "PopupMenu", font_disabled_color);
 	theme->set_color("font_disabled_color", "PopupMenu", font_disabled_color);
 	theme->set_color("font_separator_color", "PopupMenu", font_disabled_color);
+	theme->set_color("font_outline_color", "PopupMenu", font_outline_color);
 	theme->set_icon("checked", "PopupMenu", theme->get_icon(SNAME("GuiChecked"), SNAME("EditorIcons")));
 	theme->set_icon("unchecked", "PopupMenu", theme->get_icon(SNAME("GuiUnchecked"), SNAME("EditorIcons")));
 	theme->set_icon("radio_checked", "PopupMenu", theme->get_icon(SNAME("GuiRadioChecked"), SNAME("EditorIcons")));
@@ -1062,6 +1080,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const int vsep_base = extra_spacing + default_margin_size + 6;
 	const int force_even_vsep = vsep_base + (vsep_base % 2);
 	theme->set_constant("v_separation", "PopupMenu", force_even_vsep * EDSCALE);
+	theme->set_constant("outline_size", "PopupMenu", 0 * EDSCALE);
 	theme->set_constant("item_start_padding", "PopupMenu", default_margin_size * 1.5 * EDSCALE);
 	theme->set_constant("item_end_padding", "PopupMenu", default_margin_size * 1.5 * EDSCALE);
 
@@ -1170,6 +1189,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("custom_button_font_highlight", "Tree", font_hover_color);
 	theme->set_color("font_color", "Tree", font_color);
 	theme->set_color("font_selected_color", "Tree", mono_color);
+	theme->set_color("font_outline_color", "Tree", font_outline_color);
 	theme->set_color("title_button_color", "Tree", font_color);
 	theme->set_color("drop_position_color", "Tree", accent_color);
 	theme->set_constant("v_separation", "Tree", widget_default_margin.y - EDSCALE);
@@ -1179,6 +1199,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_constant("button_margin", "Tree", default_margin_size * EDSCALE);
 	theme->set_constant("scroll_border", "Tree", 40 * EDSCALE);
 	theme->set_constant("scroll_speed", "Tree", 12);
+	theme->set_constant("outline_size", "Tree", 0 * EDSCALE);
 
 	const Color guide_color = mono_color * Color(1, 1, 1, 0.05);
 	Color relationship_line_color = mono_color * Color(1, 1, 1, relationship_line_opacity);
@@ -1268,11 +1289,13 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("selected", "ItemList", style_tree_selected);
 	theme->set_color("font_color", "ItemList", font_color);
 	theme->set_color("font_selected_color", "ItemList", mono_color);
+	theme->set_color("font_outline_color", "ItemList", font_outline_color);
 	theme->set_color("guide_color", "ItemList", guide_color);
 	theme->set_constant("v_separation", "ItemList", force_even_vsep * 0.5 * EDSCALE);
 	theme->set_constant("h_separation", "ItemList", 6 * EDSCALE);
 	theme->set_constant("icon_margin", "ItemList", 6 * EDSCALE);
 	theme->set_constant("line_separation", "ItemList", 3 * EDSCALE);
+	theme->set_constant("outline_size", "ItemList", 0 * EDSCALE);
 
 	// TabBar & TabContainer
 	Ref<StyleBoxFlat> style_tabbar_background = make_flat_stylebox(dark_color_1, 0, 0, 0, 0, corner_radius * EDSCALE);
@@ -1290,8 +1313,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("button_highlight", "TabBar", style_menu);
 	theme->set_color("font_selected_color", "TabContainer", font_color);
 	theme->set_color("font_unselected_color", "TabContainer", font_disabled_color);
+	theme->set_color("font_outline_color", "TabContainer", font_outline_color);
 	theme->set_color("font_selected_color", "TabBar", font_color);
 	theme->set_color("font_unselected_color", "TabBar", font_disabled_color);
+	theme->set_color("font_outline_color", "TabBar", font_outline_color);
 	theme->set_color("drop_mark_color", "TabContainer", tab_highlight);
 	theme->set_color("drop_mark_color", "TabBar", tab_highlight);
 	theme->set_icon("menu", "TabContainer", theme->get_icon(SNAME("GuiTabMenu"), SNAME("EditorIcons")));
@@ -1308,7 +1333,9 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("drop_mark", "TabContainer", theme->get_icon(SNAME("GuiTabDropMark"), SNAME("EditorIcons")));
 	theme->set_icon("drop_mark", "TabBar", theme->get_icon(SNAME("GuiTabDropMark"), SNAME("EditorIcons")));
 	theme->set_constant("side_margin", "TabContainer", 0);
+	theme->set_constant("outline_size", "TabContainer", 0 * EDSCALE);
 	theme->set_constant("h_separation", "TabBar", 4 * EDSCALE);
+	theme->set_constant("outline_size", "TabBar", 0 * EDSCALE);
 
 	// Content of each tab.
 	Ref<StyleBoxFlat> style_content_panel = style_default->duplicate();
@@ -1399,10 +1426,12 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_selected_color", "LineEdit", mono_color);
 	theme->set_color("font_uneditable_color", "LineEdit", font_readonly_color);
 	theme->set_color("font_placeholder_color", "LineEdit", font_placeholder_color);
+	theme->set_color("font_outline_color", "LineEdit", font_outline_color);
 	theme->set_color("caret_color", "LineEdit", font_color);
 	theme->set_color("selection_color", "LineEdit", selection_color);
 	theme->set_color("clear_button_color", "LineEdit", font_color);
 	theme->set_color("clear_button_color_pressed", "LineEdit", accent_color);
+	theme->set_constant("outline_size", "LineEdit", 0 * EDSCALE);
 
 	// TextEdit
 	theme->set_stylebox("normal", "TextEdit", style_line_edit);
@@ -1413,9 +1442,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_color", "TextEdit", font_color);
 	theme->set_color("font_readonly_color", "TextEdit", font_readonly_color);
 	theme->set_color("font_placeholder_color", "TextEdit", font_placeholder_color);
+	theme->set_color("font_outline_color", "TextEdit", font_outline_color);
 	theme->set_color("caret_color", "TextEdit", font_color);
 	theme->set_color("selection_color", "TextEdit", selection_color);
 	theme->set_constant("line_spacing", "TextEdit", 4 * EDSCALE);
+	theme->set_constant("outline_size", "TextEdit", 0 * EDSCALE);
 
 	theme->set_icon("h_grabber", "SplitContainer", theme->get_icon(SNAME("GuiHsplitter"), SNAME("EditorIcons")));
 	theme->set_icon("v_grabber", "SplitContainer", theme->get_icon(SNAME("GuiVsplitter"), SNAME("EditorIcons")));
@@ -1538,9 +1569,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// RichTextLabel
 	theme->set_color("default_color", "RichTextLabel", font_color);
 	theme->set_color("font_shadow_color", "RichTextLabel", Color(0, 0, 0, 0));
+	theme->set_color("font_outline_color", "RichTextLabel", font_outline_color);
 	theme->set_constant("shadow_offset_x", "RichTextLabel", 1 * EDSCALE);
 	theme->set_constant("shadow_offset_y", "RichTextLabel", 1 * EDSCALE);
 	theme->set_constant("shadow_outline_size", "RichTextLabel", 1 * EDSCALE);
+	theme->set_constant("outline_size", "RichTextLabel", 0 * EDSCALE);
 	theme->set_stylebox("focus", "RichTextLabel", make_empty_stylebox());
 	theme->set_stylebox("normal", "RichTextLabel", style_tree_bg);
 
@@ -1579,10 +1612,12 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("normal", "Label", style_empty);
 	theme->set_color("font_color", "Label", font_color);
 	theme->set_color("font_shadow_color", "Label", Color(0, 0, 0, 0));
+	theme->set_color("font_outline_color", "Label", font_outline_color);
 	theme->set_constant("shadow_offset_x", "Label", 1 * EDSCALE);
 	theme->set_constant("shadow_offset_y", "Label", 1 * EDSCALE);
 	theme->set_constant("shadow_outline_size", "Label", 1 * EDSCALE);
 	theme->set_constant("line_spacing", "Label", 3 * EDSCALE);
+	theme->set_constant("outline_size", "Label", 0 * EDSCALE);
 
 	// LinkButton
 	theme->set_stylebox("focus", "LinkButton", style_empty);
@@ -1592,6 +1627,9 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_focus_color", "LinkButton", font_focus_color);
 	theme->set_color("font_pressed_color", "LinkButton", accent_color);
 	theme->set_color("font_disabled_color", "LinkButton", font_disabled_color);
+	theme->set_color("font_outline_color", "LinkButton", font_outline_color);
+
+	theme->set_constant("outline_size", "LinkButton", 0 * EDSCALE);
 
 	// TooltipPanel + TooltipLabel
 	// TooltipPanel is also used for custom tooltips, while TooltipLabel
@@ -1627,6 +1665,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("background", "ProgressBar", make_stylebox(theme->get_icon(SNAME("GuiProgressBar"), SNAME("EditorIcons")), 4, 4, 4, 4, 0, 0, 0, 0));
 	theme->set_stylebox("fill", "ProgressBar", make_stylebox(theme->get_icon(SNAME("GuiProgressFill"), SNAME("EditorIcons")), 6, 6, 6, 6, 2, 1, 2, 1));
 	theme->set_color("font_color", "ProgressBar", font_color);
+	theme->set_color("font_outline_color", "ProgressBar", font_outline_color);
+	theme->set_constant("outline_size", "ProgressBar", 0 * EDSCALE);
 
 	// GraphEdit
 	theme->set_stylebox("bg", "GraphEdit", style_tree_bg);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/71006

The `font_outline_color` and `outline_size` settings were never set in the default theme.
Because of this, all `outline` changes affected the editor directly, resulting in a very colorful editor when using it on every control. :P

![godot_theme_bug1](https://user-images.githubusercontent.com/66004280/212561062-6382c97f-1143-4535-bc0a-ba74ec1cc1da.png)

So this PR sets a default `outline_size` of 0 and a default `font_outline_color`, which for now is transparent since we never use an `outline` in the editor.

Note: While testing I found even more settings which were not set in the default theme and therefore can be overridden for the editor. See the `Buttons` in the screenshot above as an example. I have set the `h_separation` to a much higher value there.

For the sake of simplicity, this PR ONLY touches the two `outline` setting. For the other properties I found, I will submit another PR soon. :)