### PR TITLE
Fix scene replication segfault when there are mismatched authorities

### DIFF
--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -720,6 +720,7 @@ Error SceneReplicationInterface::on_sync_receive(int p_from, const uint8_t *p_bu
 		}
 		Node *node = sync->get_root_node();
 		if (sync->get_multiplayer_authority() != p_from || !node) {
+			ofs += size;
 			ERR_CONTINUE(true);
 		}
 		if (!sync->update_inbound_sync_time(time)) {


### PR DESCRIPTION
Ran into a segfault whenever 2 peers disagreed on authority.  From reading the code it seems that the offset pointer wasn't incremented in this case, leading to bad data being read from the buffer.

Skimming through the issues this might be related to https://github.com/godotengine/godot/issues/68436.