### PR TITLE
Few improvements for SpriteFrames Editor

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -73,6 +73,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	Ref<Texture2D> autoplay_icon;
 	Ref<Texture2D> stop_icon;
 	Ref<Texture2D> pause_icon;
+	Ref<Texture2D> empty_icon = memnew(ImageTexture);
 
 	HBoxContainer *playback_container = nullptr;
 	Button *stop = nullptr;
@@ -100,13 +101,14 @@ class SpriteFramesEditor : public HSplitContainer {
 
 	Button *add_anim = nullptr;
 	Button *delete_anim = nullptr;
+	SpinBox *anim_speed = nullptr;
+	Button *anim_loop = nullptr;
+
 	HBoxContainer *autoplay_container = nullptr;
 	Button *autoplay = nullptr;
-	LineEdit *anim_search_box = nullptr;
 
+	LineEdit *anim_search_box = nullptr;
 	Tree *animations = nullptr;
-	SpinBox *anim_speed = nullptr;
-	CheckButton *anim_loop = nullptr;
 
 	EditorFileDialog *file = nullptr;
 


### PR DESCRIPTION
* Added custom arrow step for Speed and Frame Duration fields.
* Moved Animation Speed and Animation Looping to the top to increase the height of the animation list.
* Fixed label position for empty frames.
* Corrected label format (colon and decimals are not displayed unnecessarily).

**Before:**
![](https://user-images.githubusercontent.com/47700418/215283269-a9a8b7ef-9d5e-4adb-ad91-a7d1a3ff8dc0.png)

**After:**
![](https://user-images.githubusercontent.com/47700418/215283309-63751df7-438d-4368-a753-6e9312ca4980.png)

Closes godotengine/godot-proposals#6101.
