### PR TITLE
GLES2 fix octahedral half float unpacking

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -2120,6 +2120,11 @@ static PoolVector<uint8_t> _unpack_half_floats(const PoolVector<uint8_t> &array,
 					if (!(p_format & VS::ARRAY_COMPRESS_TANGENT && p_format & VS::ARRAY_COMPRESS_NORMAL)) {
 						src_size[VS::ARRAY_NORMAL] = 8;
 						dst_size[VS::ARRAY_NORMAL] = 8;
+
+						// These must be incremented manually,
+						// as we are modifying a previous attribute size.
+						src_stride += 4;
+						dst_stride += 4;
 					}
 					src_size[i] = 0;
 					dst_size[i] = 0;


### PR DESCRIPTION
The strides in `_unpack_half_floats()` were incorrectly calculated in the case where octahedral normals and tangents were in use.

## Notes
* I discovered this while debugging a crash in my BGFX rasterizer, which copies the unpacking code from GLES2.
* The bug occurs because the strides are incremented at the end of the loop:

```
		src_stride += src_size[i];
		dst_stride += dst_size[i];
```
Whereas the code in question modifies the size of `src_size[VS::ARRAY_NORMAL]` rather than the current attribute, therefore the stride is never added.

* This could do with being independently checked by e.g. @clayjohn 
* I'm not sure altogether whether this bug occurs in the wild (maybe this combination does not occur usually in GLES2) but it seems worth closing.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
