### PR TITLE
[Git hooks] Add AppleScript dialog script for macOS.

### DIFF
--- a/misc/hooks/asmessage.applescript
+++ b/misc/hooks/asmessage.applescript
@@ -1,0 +1,59 @@
+on run argv
+    set vButtons to { "OK" }
+    set vButtonCodes to { 0 }
+    set vDbutton to "OK"
+    set vText to ""
+    set vTitle to ""
+    set vTimeout to -1
+
+    repeat with i from 1 to length of argv
+        try
+            set vArg to item i of argv
+            if vArg = "-buttons" then
+                set vButtonsAndCodes to my fSplit(item (i + 1) of argv, ",")
+                set vButtons to {}
+                set vButtonCodes to {}
+                repeat with j from 1 to length of vButtonsAndCodes
+                    set vBtn to my fSplit(item j of vButtonsAndCodes, ":")
+                    copy (item 1 of vBtn) to the end of the vButtons
+                    copy (item 2 of vBtn) to the end of the vButtonCodes
+                end repeat
+            else if vArg = "-title" then
+                set vTitle to item (i + 1) of argv
+            else if vArg = "-center" then
+                -- not supported
+            else if vArg = "-default" then
+                set vDbutton to item (i + 1) of argv
+            else if vArg = "-geometry" then
+                -- not supported
+            else if vArg = "-nearmouse" then
+                -- not supported
+            else if vArg = "-timeout" then
+                set vTimeout to item (i + 1) of argv as integer
+            else if vArg = "-file" then
+                set vText to read (item (i + 1) of argv) as string
+            else if vArg = "-text" then
+                set vText to item (i + 1) of argv
+            end if
+        end try
+    end repeat
+
+    set vDlg to display dialog vText buttons vButtons default button vDbutton with title vTitle giving up after vTimeout with icon stop
+    set vRet to button returned of vDlg
+    repeat with i from 1 to length of vButtons
+        set vBtn to item i of vButtons
+        if vBtn = vRet
+            return item i of vButtonCodes
+        end if
+    end repeat
+
+    return 0
+end run
+
+on fSplit(vString, vDelimiter)
+    set oldDelimiters to AppleScript's text item delimiters
+    set AppleScript's text item delimiters to vDelimiter
+    set vArray to every text item of vString
+    set AppleScript's text item delimiters to oldDelimiters
+    return vArray
+end fSplit

--- a/misc/hooks/pre-commit-black
+++ b/misc/hooks/pre-commit-black
@@ -34,6 +34,9 @@ XMSG=`which xmessage 2>/dev/null`
 # Path to powershell (Windows only)
 PWSH=`which powershell 2>/dev/null`
 
+# Path to osascript (macOS only)
+OSA=`which osascript 2>/dev/null`
+
 ##################################################################
 # There should be no need to change anything below this line.
 
@@ -68,6 +71,10 @@ if [ ! -x "$BLACK" ] ; then
             exit 1
         elif [ -x "$XMSG" ] ; then
             $XMSG -center -title "Error" "Error: black executable not found."
+            exit 1
+        elif [ -x "$OSA" ] ; then
+            asmessage="$(canonicalize_filename "$(dirname -- "$0")/asmessage.applescript")"
+            $OSA "$asmessage" -center -title "Error" --text "Error: black executable not found."
             exit 1
         elif [ \( \( "$OSTYPE" = "msys" \) -o \( "$OSTYPE" = "win32" \) \) -a \( -x "$PWSH" \) ]; then
             winmessage="$(canonicalize_filename "$(dirname -- "$0")/winmessage.ps1")"
@@ -159,6 +166,16 @@ while true; do
             else
                 yn="N"
             fi
+        elif [ -x "$OSA" ] ; then
+            asmessage="$(canonicalize_filename "$(dirname -- "$0")/asmessage.applescript")"
+            choice=`$OSA "$asmessage" -file "$patch" -buttons "Apply":100,"Apply and stage":200,"Do not apply":0 -center -default "Do not apply" -geometry 800x600 -title "Do you want to apply that patch?"`
+            if [ "$choice" = "100" ] ; then
+                yn="Y"
+            elif [ "$choice" = "200" ] ; then
+                yn="S"
+            else
+                yn="N"
+            fi
         elif [ \( \( "$OSTYPE" = "msys" \) -o \( "$OSTYPE" = "win32" \) \) -a \( -x "$PWSH" \) ]; then
             winmessage="$(canonicalize_filename "$(dirname -- "$0")/winmessage.ps1")"
             $PWSH -noprofile -executionpolicy bypass -file "$winmessage" -file "$patch" -buttons "Apply":100,"Apply and stage":200,"Do not apply":0 -center -default "Do not apply" -geometry 800x600 -title "Do you want to apply that patch?"
@@ -171,7 +188,7 @@ while true; do
                 yn="N"
             fi
         else
-            printf "Error: zenity, xmessage, or powershell executable not found.\n"
+            printf "Error: zenity, xmessage, osascript, or powershell executable not found.\n"
             exit 1
         fi
     else

--- a/misc/hooks/pre-commit-clang-format
+++ b/misc/hooks/pre-commit-clang-format
@@ -47,6 +47,9 @@ XMSG=`which xmessage 2>/dev/null`
 # Path to powershell (Windows only)
 PWSH=`which powershell 2>/dev/null`
 
+# Path to osascript (macOS only)
+OSA=`which osascript 2>/dev/null`
+
 ##################################################################
 # There should be no need to change anything below this line.
 
@@ -88,6 +91,10 @@ if [ ! -x "$CLANG_FORMAT" ] ; then
             exit 1
         elif [ -x "$XMSG" ] ; then
             $XMSG -center -title "Error" "$message"
+            exit 1
+        elif [ -x "$OSA" ] ; then
+            asmessage="$(canonicalize_filename "$(dirname -- "$0")/asmessage.applescript")"
+            $OSA "$asmessage" -center -title "Error" --text "$message"
             exit 1
         elif [ \( \( "$OSTYPE" = "msys" \) -o \( "$OSTYPE" = "win32" \) \) -a \( -x "$PWSH" \) ]; then
             winmessage="$(canonicalize_filename "$(dirname -- "$0")/winmessage.ps1")"
@@ -199,6 +206,16 @@ while true; do
             else
                 yn="N"
             fi
+        elif [ -x "$OSA" ] ; then
+            asmessage="$(canonicalize_filename "$(dirname -- "$0")/asmessage.applescript")"
+            choice=`$OSA "$asmessage" -file "$patch" -buttons "Apply":100,"Apply and stage":200,"Do not apply":0 -center -default "Do not apply" -geometry 800x600 -title "Do you want to apply that patch?"`
+            if [ "$choice" = "100" ] ; then
+                yn="Y"
+            elif [ "$choice" = "200" ] ; then
+                yn="S"
+            else
+                yn="N"
+            fi
         elif [ \( \( "$OSTYPE" = "msys" \) -o \( "$OSTYPE" = "win32" \) \) -a \( -x "$PWSH" \) ]; then
             winmessage="$(canonicalize_filename "$(dirname -- "$0")/winmessage.ps1")"
             $PWSH -noprofile -executionpolicy bypass -file "$winmessage" -file "$patch" -buttons "Apply":100,"Apply and stage":200,"Do not apply":0 -center -default "Do not apply" -geometry 800x600 -title "Do you want to apply that patch?"
@@ -211,7 +228,7 @@ while true; do
                 yn="N"
             fi
         else
-            printf "Error: zenity, xmessage, or powershell executable not found.\n"
+            printf "Error: zenity, xmessage, osascript, or powershell executable not found.\n"
             exit 1
         fi
     else


### PR DESCRIPTION
Adds AppleScript based dialog for the GUI git hooks to avoid `zenity` (not installed by default) dependency on macOS.

<img width="674" alt="Screenshot 2023-01-16 at 14 15 25" src="https://user-images.githubusercontent.com/7645683/212676877-1e4ba0cd-ffe5-441a-a369-f5665e0b3537.png">
