### PR TITLE
Force disable Vulkan overlays in the editor and project manager

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1677,10 +1677,21 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	OS::get_singleton()->_allow_hidpi = GLOBAL_DEF("display/window/dpi/allow_hidpi", true);
 	OS::get_singleton()->_allow_layered = GLOBAL_DEF("display/window/per_pixel_transparency/allowed", false);
 
+#ifdef TOOLS_ENABLED
 	if (editor || project_manager) {
-		// The editor and project manager always detect and use hiDPI if needed
+		// The editor and project manager always detect and use hiDPI if needed.
 		OS::get_singleton()->_allow_hidpi = true;
+		// Disable Vulkan overlays in editor, they cause various issues.
+		OS::get_singleton()->set_environment("DISABLE_MANGOHUD", "1"); // GH-57403.
+		OS::get_singleton()->set_environment("DISABLE_RTSS_LAYER", "1"); // GH-57937.
+		OS::get_singleton()->set_environment("DISABLE_VKBASALT", "1");
+	} else {
+		// Re-allow using Vulkan overlays, disabled while using the editor.
+		OS::get_singleton()->unset_environment("DISABLE_MANGOHUD");
+		OS::get_singleton()->unset_environment("DISABLE_RTSS_LAYER");
+		OS::get_singleton()->unset_environment("DISABLE_VKBASALT");
 	}
+#endif
 
 	if (rtm == -1) {
 		rtm = GLOBAL_DEF("rendering/driver/threads/thread_model", OS::RENDER_THREAD_SAFE);


### PR DESCRIPTION
MangoHud would be shown on every popup in multi-window mode, and seemed
to cause rendering issues for various users.

There are also issues with RTSS, and VkBasalt also doesn't seem
particularly good to use in the editor.

All these stay available to enable when running the project itself,
including running from the editor (so running the editor after e.g.
`export MANGOHUD=1` in the environment will ignore it for the editor,
but use it when playing the project).

Fixes #57403.
Fixes #57937.

---

Before:
![image](https://user-images.githubusercontent.com/4701338/212691352-ed45c883-449f-45cd-91a3-373af43242ee.png)

After:
![image](https://user-images.githubusercontent.com/4701338/212692282-3f8fa08a-44d0-4093-b0bf-4596d9c9347e.png)