### PR TITLE
Fix code completion override of home and end keys

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -479,19 +479,8 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			accept_event();
 			return;
 		}
-		if (k->is_action("ui_home", true)) {
-			code_completion_current_selected = 0;
-			code_completion_force_item_center = -1;
-			queue_redraw();
-			accept_event();
-			return;
-		}
-		if (k->is_action("ui_end", true)) {
-			code_completion_current_selected = code_completion_options.size() - 1;
-			code_completion_force_item_center = -1;
-			queue_redraw();
-			accept_event();
-			return;
+		if (k->is_action("ui_text_caret_line_start", true) || k->is_action("ui_text_caret_line_end", true)) {
+			cancel_code_completion();
 		}
 		if (k->is_action("ui_text_completion_replace", true) || k->is_action("ui_text_completion_accept", true)) {
 			confirm_code_completion(k->is_action("ui_text_completion_replace", true));

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -3364,7 +3364,9 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 
 			/* After update, pending add should not be counted, */
 			/* also does not work on col 0                      */
+			int before_text_caret_column = code_edit->get_caret_column();
 			code_edit->insert_text_at_caret("i");
+
 			code_edit->update_code_completion_options();
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0.", "item_0", Color(1, 0, 0), Ref<Resource>(), Color(1, 0, 0));
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "item_1.", "item_1");
@@ -3400,12 +3402,40 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			/* Set size for mouse input. */
 			code_edit->set_size(Size2(100, 100));
 
-			/* Check input. */
-			SEND_GUI_ACTION("ui_end");
-			CHECK(code_edit->get_code_completion_selected_index() == 2);
+			/* Test home and end keys close the completion and move the caret */
+			/* => ui_text_caret_line_start */
+			code_edit->set_caret_column(before_text_caret_column + 1);
+			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0.", "item_0", Color(1, 0, 0), Ref<Resource>(), Color(1, 0, 0));
+			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "item_1.", "item_1");
+			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "item_2.", "item_2");
 
-			SEND_GUI_ACTION("ui_home");
-			CHECK(code_edit->get_code_completion_selected_index() == 0);
+			code_edit->update_code_completion_options();
+
+			SEND_GUI_ACTION("ui_text_caret_line_start");
+			code_edit->update_code_completion_options();
+			CHECK(code_edit->get_code_completion_selected_index() == -1);
+			CHECK(code_edit->get_caret_column() == 0);
+
+			/* => ui_text_caret_line_end */
+			code_edit->set_caret_column(before_text_caret_column + 1);
+			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0.", "item_0", Color(1, 0, 0), Ref<Resource>(), Color(1, 0, 0));
+			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "item_1.", "item_1");
+			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "item_2.", "item_2");
+
+			code_edit->update_code_completion_options();
+
+			SEND_GUI_ACTION("ui_text_caret_line_end");
+			code_edit->update_code_completion_options();
+			CHECK(code_edit->get_code_completion_selected_index() == -1);
+			CHECK(code_edit->get_caret_column() == before_text_caret_column + 1);
+
+			/* Check input. */
+			code_edit->set_caret_column(before_text_caret_column + 1);
+			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0.", "item_0", Color(1, 0, 0), Ref<Resource>(), Color(1, 0, 0));
+			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "item_1.", "item_1");
+			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "item_2.", "item_2");
+
+			code_edit->update_code_completion_options();
 
 			SEND_GUI_ACTION("ui_page_down");
 			CHECK(code_edit->get_code_completion_selected_index() == 2);


### PR DESCRIPTION
Changes the behaviour of the home and end keys when the autocomplete popup is open.

Rather than going to the top and the bottom of the list, home and end closes the autocomplete popup and work as usual.

Fixes #71471