### PR TITLE
Fix GPUParticles2D not recomputing transforms each frame

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1415,7 +1415,6 @@ void ParticlesStorage::update_particles() {
 		}
 
 		bool zero_time_scale = Engine::get_singleton()->get_time_scale() <= 0.0;
-		bool updated = false;
 
 		if (particles->clear && particles->pre_process_time > 0.0) {
 			double frame_time;
@@ -1430,7 +1429,6 @@ void ParticlesStorage::update_particles() {
 			while (todo >= 0) {
 				_particles_process(particles, frame_time);
 				todo -= frame_time;
-				updated = true;
 			}
 		}
 
@@ -1452,10 +1450,9 @@ void ParticlesStorage::update_particles() {
 			}
 			double todo = particles->frame_remainder + delta;
 
-			while (todo >= frame_time || (particles->clear && !updated)) {
+			while (todo >= frame_time || particles->clear) {
 				_particles_process(particles, frame_time);
 				todo -= decr;
-				updated = true;
 			}
 
 			particles->frame_remainder = todo;
@@ -1463,16 +1460,16 @@ void ParticlesStorage::update_particles() {
 		} else {
 			if (zero_time_scale) {
 				_particles_process(particles, 0.0);
-				updated = true;
 			} else {
 				_particles_process(particles, RendererCompositorRD::singleton->get_frame_delta_time());
-				updated = true;
 			}
 		}
 
-		//copy particles to instance buffer
+		// Ensure that memory is initialized (the code above should ensure that _particles_process is always called at least once upon clearing).
+		DEV_ASSERT(!particles->clear);
 
-		if (updated && particles->draw_order != RS::PARTICLES_DRAW_ORDER_VIEW_DEPTH && particles->transform_align != RS::PARTICLES_TRANSFORM_ALIGN_Z_BILLBOARD && particles->transform_align != RS::PARTICLES_TRANSFORM_ALIGN_Z_BILLBOARD_Y_TO_VELOCITY) {
+		// Copy particles to instance buffer.
+		if (particles->draw_order != RS::PARTICLES_DRAW_ORDER_VIEW_DEPTH && particles->transform_align != RS::PARTICLES_TRANSFORM_ALIGN_Z_BILLBOARD && particles->transform_align != RS::PARTICLES_TRANSFORM_ALIGN_Z_BILLBOARD_Y_TO_VELOCITY) {
 			//does not need view dependent operation, do copy here
 			ParticlesShader::CopyPushConstant copy_push_constant;
 


### PR DESCRIPTION
Regression introduced in #70418.

Fixes #71480 and fixes #71225 - using the same repro project from the first issue, here is the result with this fix applied (observe that the particles don't rotate with the parent node any more):

https://user-images.githubusercontent.com/4420888/212732145-22202e9a-08d2-4c93-8074-44c408b6ea88.mp4

_Note: this is my first PR against Godot (😄), so let me know if I need to make any other changes - e.g. are there any tests I should update?_