### PR TITLE
Warn when trying to enable TAA from mobile or gl_compatibility backend

### DIFF
--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -1138,6 +1138,7 @@ void RendererViewport::viewport_set_screen_space_aa(RID p_viewport, RS::Viewport
 void RendererViewport::viewport_set_use_taa(RID p_viewport, bool p_use_taa) {
 	Viewport *viewport = viewport_owner.get_or_null(p_viewport);
 	ERR_FAIL_COND(!viewport);
+	ERR_FAIL_COND_EDMSG(OS::get_singleton()->get_current_rendering_method() != "forward_plus", "TAA is only available when using the Forward+ renderer.");
 
 	if (viewport->use_taa == p_use_taa) {
 		return;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/71488#event-8234674826

Regression from: https://github.com/godotengine/godot/pull/65469

In https://github.com/godotengine/godot/pull/65469 we unified the UBO logic for mobile and forward+, but this meant that the TAA jitter was always applied (previously the mobile renderer just ignored it). I chose to keep the logic out of scene_data as eventually we will be adding TAA to the mobile renderer, so it is fine to keep the unified logic on the scene_data end. 

This PR ensures that ``use_taa`` remains false for both the mobile and gl_compatibility renderers.