### PR TITLE
Properly initialize directional_light_count in RD sky shaders

### DIFF
--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -1085,8 +1085,8 @@ void SkyRD::setup_sky(RID p_env, Ref<RenderSceneBuffersRD> p_render_buffers, con
 			sky->reflection.dirty = true;
 		}
 
+		sky_scene_state.ubo.directional_light_count = 0;
 		if (shader_data->uses_light) {
-			sky_scene_state.ubo.directional_light_count = 0;
 			// Run through the list of lights in the scene and pick out the Directional Lights.
 			// This can't be done in RenderSceneRenderRD::_setup lights because that needs to be called
 			// after the depth prepass, but this runs before the depth prepass


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/70015

The directional light count in the shader was left uninitialized if there were no directional lights used in the shader. This is a huge problem as sun_scatter loops over all directional lights.

In the run that I managed to capture this meant the shader thought that there were over 524,000 DirectionalLights in the scene and it was running the sun scatter code for each of them, naturally reading from random memory for each.