### PR TITLE
add RichTextLabel::push_font_size description

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -283,6 +283,7 @@
 			<return type="void" />
 			<param index="0" name="font_size" type="int" />
 			<description>
+				Adds a [code][font_size][/code] tag to the tag stack. Overrides default font size for its duration.
 			</description>
 		</method>
 		<method name="push_hint">


### PR DESCRIPTION
Is it worth adding descriptions for the ItemType enum values (ITEM_FRAME , ITEM_TEXT etc.) or are they self explanatory enough?