### PR TITLE
[MP] Fix nested spawning during "ready".

### DIFF
--- a/modules/multiplayer/multiplayer_spawner.cpp
+++ b/modules/multiplayer/multiplayer_spawner.cpp
@@ -199,10 +199,6 @@ void MultiplayerSpawner::_notification(int p_what) {
 				Node *node = Object::cast_to<Node>(ObjectDB::get_instance(E.key));
 				ERR_CONTINUE(!node);
 				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &MultiplayerSpawner::_node_exit));
-				// This is unlikely, but might still crash the engine.
-				if (node->is_connected(SceneStringNames::get_singleton()->ready, callable_mp(this, &MultiplayerSpawner::_node_ready))) {
-					node->disconnect(SceneStringNames::get_singleton()->ready, callable_mp(this, &MultiplayerSpawner::_node_ready));
-				}
 				get_multiplayer()->object_configuration_remove(node, this);
 			}
 			tracked_nodes.clear();
@@ -244,11 +240,11 @@ void MultiplayerSpawner::_track(Node *p_node, const Variant &p_argument, int p_s
 	if (!tracked_nodes.has(oid)) {
 		tracked_nodes[oid] = SpawnInfo(p_argument.duplicate(true), p_scene_id);
 		p_node->connect(SceneStringNames::get_singleton()->tree_exiting, callable_mp(this, &MultiplayerSpawner::_node_exit).bind(p_node->get_instance_id()), CONNECT_ONE_SHOT);
-		p_node->connect(SceneStringNames::get_singleton()->ready, callable_mp(this, &MultiplayerSpawner::_node_ready).bind(p_node->get_instance_id()), CONNECT_ONE_SHOT);
+		_spawn_notify(p_node->get_instance_id());
 	}
 }
 
-void MultiplayerSpawner::_node_ready(ObjectID p_id) {
+void MultiplayerSpawner::_spawn_notify(ObjectID p_id) {
 	get_multiplayer()->object_configuration_add(ObjectDB::get_instance(p_id), this);
 }
 

--- a/modules/multiplayer/multiplayer_spawner.h
+++ b/modules/multiplayer/multiplayer_spawner.h
@@ -77,7 +77,7 @@ private:
 	void _track(Node *p_node, const Variant &p_argument, int p_scene_id = INVALID_ID);
 	void _node_added(Node *p_node);
 	void _node_exit(ObjectID p_id);
-	void _node_ready(ObjectID p_id);
+	void _spawn_notify(ObjectID p_id);
 
 	Vector<String> _get_spawnable_scenes() const;
 	void _set_spawnable_scenes(const Vector<String> &p_scenes);

--- a/modules/multiplayer/scene_replication_interface.h
+++ b/modules/multiplayer/scene_replication_interface.h
@@ -51,7 +51,6 @@ private:
 
 		bool operator==(const ObjectID &p_other) { return id == p_other; }
 
-		_FORCE_INLINE_ MultiplayerSpawner *get_spawner() const { return spawner.is_valid() ? Object::cast_to<MultiplayerSpawner>(ObjectDB::get_instance(spawner)) : nullptr; }
 		TrackedNode() {}
 		TrackedNode(const ObjectID &p_id) { id = p_id; }
 		TrackedNode(const ObjectID &p_id, uint32_t p_net_id) {
@@ -75,7 +74,10 @@ private:
 	HashSet<ObjectID> spawned_nodes;
 	HashSet<ObjectID> sync_nodes;
 
-	// Pending spawn information.
+	// Pending local spawn information (handles spawning nested nodes during ready).
+	HashSet<ObjectID> spawn_queue;
+
+	// Pending remote spawn information.
 	ObjectID pending_spawn;
 	int pending_spawn_remote = 0;
 	const uint8_t *pending_buffer = nullptr;
@@ -89,6 +91,7 @@ private:
 
 	TrackedNode &_track(const ObjectID &p_id);
 	void _untrack(const ObjectID &p_id);
+	void _node_ready(const ObjectID &p_oid);
 
 	void _send_sync(int p_peer, const HashSet<ObjectID> p_synchronizers, uint16_t p_sync_net_time, uint64_t p_msec);
 	Error _make_spawn_packet(Node *p_node, MultiplayerSpawner *p_spawner, int &r_len);


### PR DESCRIPTION
We want our spawns to be notified after ready, but we need to notify them in the order they entered tree, so that nested spawners can be used during "ready" (instead of having to await a frame).

This feels a bit more brittle than I'd like, but allows nested spawns to happen during the `_ready` function, ensuring that spawns happens in the order in which  nodes enters tree instead of their ready state (which is reversed).