### PR TITLE
C#: Skip methods with pointer parameters

### DIFF
--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -2795,6 +2795,18 @@ bool BindingsGenerator::_arg_default_value_is_assignable_to_type(const Variant &
 	return false;
 }
 
+bool method_has_ptr_parameter(MethodInfo p_method_info) {
+	if (p_method_info.return_val.type == Variant::INT && p_method_info.return_val.hint == PROPERTY_HINT_INT_IS_POINTER) {
+		return true;
+	}
+	for (PropertyInfo arg : p_method_info.arguments) {
+		if (arg.type == Variant::INT && arg.hint == PROPERTY_HINT_INT_IS_POINTER) {
+			return true;
+		}
+	}
+	return false;
+}
+
 bool BindingsGenerator::_populate_object_type_interfaces() {
 	obj_types.clear();
 
@@ -2935,6 +2947,11 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 			String cname = method_info.name;
 
 			if (blacklisted_methods.find(itype.cname) && blacklisted_methods[itype.cname].find(cname)) {
+				continue;
+			}
+
+			if (method_has_ptr_parameter(method_info)) {
+				// Pointers are not supported.
 				continue;
 			}
 


### PR DESCRIPTION
Ignore methods with pointer parameters when generating the C# API. Currently these methods are generated using integer type parameters which makes them unusable.

Example of a method with pointer parameters: `MultiplayerPeerExtension::_get_packet`

https://github.com/godotengine/godot/blob/0ddd9c3e8f9088fa139e25b2903289d727073e12/doc/classes/MultiplayerPeerExtension.xml#L44-L51

This generates the following C#:

```csharp
public virtual Error _GetPacket(long rBuffer, long rBufferSize)
{
    return default;
}
```

The parameters are `Variant::INT`, virtual methods currently don't have metadata so they are `long` (this is a separate issue unrelated to this PR), the important thing to notice is that these parameters are meant to be pointers because they are out parameters, the generated C# methods make them impossible to use.

This breaks compat because it removes methods from the public API but I don't think anyone is using them since they don't work.

For convenience, this is the diff of the generated C# API with this PR:

[diff.zip](https://github.com/godotengine/godot/files/10431111/diff.zip)

