### PR TITLE
Add NavigationAgent Path Debug Visualization

### DIFF
--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -111,6 +111,21 @@
 		<member name="avoidance_enabled" type="bool" setter="set_avoidance_enabled" getter="get_avoidance_enabled" default="false">
 			If [code]true[/code] the agent is registered for an RVO avoidance callback on the [NavigationServer2D]. When [method NavigationAgent2D.set_velocity] is used and the processing is completed a [code]safe_velocity[/code] Vector2 is received with a signal connection to [signal velocity_computed]. Avoidance processing with many registered agents has a significant performance cost and should only be enabled on agents that currently require it.
 		</member>
+		<member name="debug_enabled" type="bool" setter="set_debug_enabled" getter="get_debug_enabled" default="false">
+			If [code]true[/code] shows debug visuals for this agent.
+		</member>
+		<member name="debug_path_custom_color" type="Color" setter="set_debug_path_custom_color" getter="get_debug_path_custom_color" default="Color(1, 1, 1, 1)">
+			If [member debug_use_custom] is [code]true[/code] uses this color for this agent instead of global color.
+		</member>
+		<member name="debug_path_custom_line_width" type="float" setter="set_debug_path_custom_line_width" getter="get_debug_path_custom_line_width" default="1.0">
+			If [member debug_use_custom] is [code]true[/code] uses this line width for rendering paths for this agent instead of global line width.
+		</member>
+		<member name="debug_path_custom_point_size" type="float" setter="set_debug_path_custom_point_size" getter="get_debug_path_custom_point_size" default="4.0">
+			If [member debug_use_custom] is [code]true[/code] uses this rasterized point size for rendering path points for this agent instead of global point size.
+		</member>
+		<member name="debug_use_custom" type="bool" setter="set_debug_use_custom" getter="get_debug_use_custom" default="false">
+			If [code]true[/code] uses the defined [member debug_path_custom_color] for this agent instead of global color.
+		</member>
 		<member name="max_neighbors" type="int" setter="set_max_neighbors" getter="get_max_neighbors" default="10">
 			The maximum number of neighbors for the agent to consider.
 		</member>

--- a/doc/classes/NavigationAgent3D.xml
+++ b/doc/classes/NavigationAgent3D.xml
@@ -114,6 +114,18 @@
 		<member name="avoidance_enabled" type="bool" setter="set_avoidance_enabled" getter="get_avoidance_enabled" default="false">
 			If [code]true[/code] the agent is registered for an RVO avoidance callback on the [NavigationServer3D]. When [method NavigationAgent3D.set_velocity] is used and the processing is completed a [code]safe_velocity[/code] Vector3 is received with a signal connection to [signal velocity_computed]. Avoidance processing with many registered agents has a significant performance cost and should only be enabled on agents that currently require it.
 		</member>
+		<member name="debug_enabled" type="bool" setter="set_debug_enabled" getter="get_debug_enabled" default="false">
+			If [code]true[/code] shows debug visuals for this agent.
+		</member>
+		<member name="debug_path_custom_color" type="Color" setter="set_debug_path_custom_color" getter="get_debug_path_custom_color" default="Color(1, 1, 1, 1)">
+			If [member debug_use_custom] is [code]true[/code] uses this color for this agent instead of global color.
+		</member>
+		<member name="debug_path_custom_point_size" type="float" setter="set_debug_path_custom_point_size" getter="get_debug_path_custom_point_size" default="4.0">
+			If [member debug_use_custom] is [code]true[/code] uses this rasterized point size for rendering path points for this agent instead of global point size.
+		</member>
+		<member name="debug_use_custom" type="bool" setter="set_debug_use_custom" getter="get_debug_use_custom" default="false">
+			If [code]true[/code] uses the defined [member debug_path_custom_color] for this agent instead of global color.
+		</member>
 		<member name="ignore_y" type="bool" setter="set_ignore_y" getter="get_ignore_y" default="true">
 			Ignores collisions on the Y axis. Must be true to move on a horizontal plane.
 		</member>

--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -528,5 +528,10 @@
 				Emitted when a navigation map is updated, when a region moves or is modified.
 			</description>
 		</signal>
+		<signal name="navigation_debug_changed">
+			<description>
+				Emitted when navigation debug settings are changed. Only available in debug builds.
+			</description>
+		</signal>
 	</signals>
 </class>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -528,8 +528,20 @@
 		<member name="debug/shapes/collision/shape_color" type="Color" setter="" getter="" default="Color(0, 0.6, 0.7, 0.42)">
 			Color of the collision shapes, visible when "Visible Collision Shapes" is enabled in the Debug menu.
 		</member>
+		<member name="debug/shapes/navigation/agent_path_color" type="Color" setter="" getter="" default="Color(1, 0, 0, 1)">
+			Color to display enabled navigation agent paths when an agent has debug enabled.
+		</member>
+		<member name="debug/shapes/navigation/agent_path_point_size" type="float" setter="" getter="" default="4.0">
+			Rasterized size (pixel) used to render navigation agent path points when an agent has debug enabled.
+		</member>
 		<member name="debug/shapes/navigation/edge_connection_color" type="Color" setter="" getter="" default="Color(1, 0, 1, 1)">
 			Color to display edge connections between navigation regions, visible when "Visible Navigation" is enabled in the Debug menu.
+		</member>
+		<member name="debug/shapes/navigation/enable_agent_paths" type="bool" setter="" getter="" default="true">
+			If enabled, displays navigation agent paths when an agent has debug enabled.
+		</member>
+		<member name="debug/shapes/navigation/enable_agent_paths_xray" type="bool" setter="" getter="" default="true">
+			If enabled, displays navigation agent paths through geometry when an agent has debug enabled.
 		</member>
 		<member name="debug/shapes/navigation/enable_edge_connections" type="bool" setter="" getter="" default="true">
 			If enabled, displays edge connections between navigation regions when "Visible Navigation" is enabled in the Debug menu.

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -108,6 +108,26 @@ void NavigationAgent2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "time_horizon", PROPERTY_HINT_RANGE, "0.1,10,0.01,suffix:s"), "set_time_horizon", "get_time_horizon");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_speed", PROPERTY_HINT_RANGE, "0.1,10000,0.01,suffix:px/s"), "set_max_speed", "get_max_speed");
 
+#ifdef DEBUG_ENABLED
+	ClassDB::bind_method(D_METHOD("set_debug_enabled", "enabled"), &NavigationAgent2D::set_debug_enabled);
+	ClassDB::bind_method(D_METHOD("get_debug_enabled"), &NavigationAgent2D::get_debug_enabled);
+	ClassDB::bind_method(D_METHOD("set_debug_use_custom", "enabled"), &NavigationAgent2D::set_debug_use_custom);
+	ClassDB::bind_method(D_METHOD("get_debug_use_custom"), &NavigationAgent2D::get_debug_use_custom);
+	ClassDB::bind_method(D_METHOD("set_debug_path_custom_color", "color"), &NavigationAgent2D::set_debug_path_custom_color);
+	ClassDB::bind_method(D_METHOD("get_debug_path_custom_color"), &NavigationAgent2D::get_debug_path_custom_color);
+	ClassDB::bind_method(D_METHOD("set_debug_path_custom_point_size", "point_size"), &NavigationAgent2D::set_debug_path_custom_point_size);
+	ClassDB::bind_method(D_METHOD("get_debug_path_custom_point_size"), &NavigationAgent2D::get_debug_path_custom_point_size);
+	ClassDB::bind_method(D_METHOD("set_debug_path_custom_line_width", "line_width"), &NavigationAgent2D::set_debug_path_custom_line_width);
+	ClassDB::bind_method(D_METHOD("get_debug_path_custom_line_width"), &NavigationAgent2D::get_debug_path_custom_line_width);
+
+	ADD_GROUP("Debug", "");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_enabled"), "set_debug_enabled", "get_debug_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_use_custom"), "set_debug_use_custom", "get_debug_use_custom");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "debug_path_custom_color"), "set_debug_path_custom_color", "get_debug_path_custom_color");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "debug_path_custom_point_size", PROPERTY_HINT_RANGE, "1,50,1,suffix:px"), "set_debug_path_custom_point_size", "get_debug_path_custom_point_size");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "debug_path_custom_line_width", PROPERTY_HINT_RANGE, "1,50,1,suffix:px"), "set_debug_path_custom_line_width", "get_debug_path_custom_line_width");
+#endif // DEBUG_ENABLED
+
 	ADD_SIGNAL(MethodInfo("path_changed"));
 	ADD_SIGNAL(MethodInfo("target_reached"));
 	ADD_SIGNAL(MethodInfo("waypoint_reached", PropertyInfo(Variant::DICTIONARY, "details")));
@@ -123,6 +143,12 @@ void NavigationAgent2D::_notification(int p_what) {
 			// cannot use READY as ready does not get called if Node is readded to SceneTree
 			set_agent_parent(get_parent());
 			set_physics_process_internal(true);
+
+#ifdef DEBUG_ENABLED
+			if (NavigationServer2D::get_singleton()->get_debug_enabled()) {
+				debug_path_dirty = true;
+			}
+#endif // DEBUG_ENABLED
 		} break;
 
 		case NOTIFICATION_PARENTED: {
@@ -165,6 +191,12 @@ void NavigationAgent2D::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			agent_parent = nullptr;
 			set_physics_process_internal(false);
+
+#ifdef DEBUG_ENABLED
+			if (debug_path_instance.is_valid()) {
+				RenderingServer::get_singleton()->canvas_item_set_visible(debug_path_instance, false);
+			}
+#endif // DEBUG_ENABLED
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
@@ -176,6 +208,12 @@ void NavigationAgent2D::_notification(int p_what) {
 				}
 				_check_distance_to_target();
 			}
+
+#ifdef DEBUG_ENABLED
+			if (debug_path_dirty) {
+				_update_debug_path();
+			}
+#endif // DEBUG_ENABLED
 		} break;
 	}
 }
@@ -194,12 +232,25 @@ NavigationAgent2D::NavigationAgent2D() {
 
 	navigation_result = Ref<NavigationPathQueryResult2D>();
 	navigation_result.instantiate();
+
+#ifdef DEBUG_ENABLED
+	NavigationServer2D::get_singleton()->connect(SNAME("navigation_debug_changed"), callable_mp(this, &NavigationAgent2D::_navigation_debug_changed));
+#endif // DEBUG_ENABLED
 }
 
 NavigationAgent2D::~NavigationAgent2D() {
 	ERR_FAIL_NULL(NavigationServer2D::get_singleton());
 	NavigationServer2D::get_singleton()->free(agent);
 	agent = RID(); // Pointless
+
+#ifdef DEBUG_ENABLED
+	NavigationServer2D::get_singleton()->disconnect(SNAME("navigation_debug_changed"), callable_mp(this, &NavigationAgent2D::_navigation_debug_changed));
+
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	if (debug_path_instance.is_valid()) {
+		RenderingServer::get_singleton()->free(debug_path_instance);
+	}
+#endif // DEBUG_ENABLED
 }
 
 void NavigationAgent2D::set_avoidance_enabled(bool p_enabled) {
@@ -463,6 +514,9 @@ void NavigationAgent2D::update_navigation() {
 		}
 
 		NavigationServer2D::get_singleton()->query_path(navigation_query, navigation_result);
+#ifdef DEBUG_ENABLED
+		debug_path_dirty = true;
+#endif // DEBUG_ENABLED
 		navigation_finished = false;
 		navigation_path_index = 0;
 		emit_signal(SNAME("path_changed"));
@@ -549,3 +603,111 @@ void NavigationAgent2D::_check_distance_to_target() {
 		}
 	}
 }
+
+////////DEBUG////////////////////////////////////////////////////////////
+
+#ifdef DEBUG_ENABLED
+void NavigationAgent2D::set_debug_enabled(bool p_enabled) {
+	debug_enabled = p_enabled;
+	debug_path_dirty = true;
+}
+
+bool NavigationAgent2D::get_debug_enabled() const {
+	return debug_enabled;
+}
+
+void NavigationAgent2D::set_debug_use_custom(bool p_enabled) {
+	debug_use_custom = p_enabled;
+	debug_path_dirty = true;
+}
+
+bool NavigationAgent2D::get_debug_use_custom() const {
+	return debug_use_custom;
+}
+
+void NavigationAgent2D::set_debug_path_custom_color(Color p_color) {
+	debug_path_custom_color = p_color;
+	debug_path_dirty = true;
+}
+
+Color NavigationAgent2D::get_debug_path_custom_color() const {
+	return debug_path_custom_color;
+}
+
+void NavigationAgent2D::set_debug_path_custom_point_size(float p_point_size) {
+	debug_path_custom_point_size = MAX(0.1, p_point_size);
+	debug_path_dirty = true;
+}
+
+float NavigationAgent2D::get_debug_path_custom_point_size() const {
+	return debug_path_custom_point_size;
+}
+
+void NavigationAgent2D::set_debug_path_custom_line_width(float p_line_width) {
+	debug_path_custom_line_width = p_line_width;
+	debug_path_dirty = true;
+}
+
+float NavigationAgent2D::get_debug_path_custom_line_width() const {
+	return debug_path_custom_line_width;
+}
+
+void NavigationAgent2D::_navigation_debug_changed() {
+	debug_path_dirty = true;
+}
+
+void NavigationAgent2D::_update_debug_path() {
+	if (!debug_path_dirty) {
+		return;
+	}
+	debug_path_dirty = false;
+
+	if (!debug_path_instance.is_valid()) {
+		debug_path_instance = RenderingServer::get_singleton()->canvas_item_create();
+	}
+
+	RenderingServer::get_singleton()->canvas_item_clear(debug_path_instance);
+
+	if (!(debug_enabled && NavigationServer2D::get_singleton()->get_debug_navigation_enable_agent_paths())) {
+		return;
+	}
+
+	if (!(agent_parent && agent_parent->is_inside_tree())) {
+		return;
+	}
+
+	RenderingServer::get_singleton()->canvas_item_set_parent(debug_path_instance, agent_parent->get_canvas());
+	RenderingServer::get_singleton()->canvas_item_set_visible(debug_path_instance, agent_parent->is_visible_in_tree());
+
+	const Vector<Vector2> &navigation_path = navigation_result->get_path();
+
+	if (navigation_path.size() <= 1) {
+		return;
+	}
+
+	Color debug_path_color = NavigationServer2D::get_singleton()->get_debug_navigation_agent_path_color();
+	if (debug_use_custom) {
+		debug_path_color = debug_path_custom_color;
+	}
+
+	Vector<Color> debug_path_colors;
+	debug_path_colors.resize(navigation_path.size());
+	debug_path_colors.fill(debug_path_color);
+
+	RenderingServer::get_singleton()->canvas_item_add_polyline(debug_path_instance, navigation_path, debug_path_colors, debug_path_custom_line_width, false);
+
+	float point_size = NavigationServer2D::get_singleton()->get_debug_navigation_agent_path_point_size();
+	float half_point_size = point_size * 0.5;
+
+	if (debug_use_custom) {
+		point_size = debug_path_custom_point_size;
+		half_point_size = debug_path_custom_point_size * 0.5;
+	}
+
+	for (int i = 0; i < navigation_path.size(); i++) {
+		const Vector2 &vert = navigation_path[i];
+		Rect2 path_point_rect = Rect2(vert.x - half_point_size, vert.y - half_point_size, point_size, point_size);
+		RenderingServer::get_singleton()->canvas_item_add_rect(debug_path_instance, path_point_rect, debug_path_color);
+	}
+}
+#endif // DEBUG_ENABLED

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -74,6 +74,20 @@ class NavigationAgent2D : public Node {
 	// No initialized on purpose
 	uint32_t update_frame_id = 0;
 
+#ifdef DEBUG_ENABLED
+	bool debug_enabled = false;
+	bool debug_path_dirty = true;
+	RID debug_path_instance;
+	float debug_path_custom_point_size = 4.0;
+	float debug_path_custom_line_width = 1.0;
+	bool debug_use_custom = false;
+	Color debug_path_custom_color = Color(1.0, 1.0, 1.0, 1.0);
+
+private:
+	void _navigation_debug_changed();
+	void _update_debug_path();
+#endif // DEBUG_ENABLED
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
@@ -168,6 +182,23 @@ public:
 	void _avoidance_done(Vector3 p_new_velocity);
 
 	PackedStringArray get_configuration_warnings() const override;
+
+#ifdef DEBUG_ENABLED
+	void set_debug_enabled(bool p_enabled);
+	bool get_debug_enabled() const;
+
+	void set_debug_use_custom(bool p_enabled);
+	bool get_debug_use_custom() const;
+
+	void set_debug_path_custom_color(Color p_color);
+	Color get_debug_path_custom_color() const;
+
+	void set_debug_path_custom_point_size(float p_point_size);
+	float get_debug_path_custom_point_size() const;
+
+	void set_debug_path_custom_line_width(float p_line_width);
+	float get_debug_path_custom_line_width() const;
+#endif // DEBUG_ENABLED
 
 private:
 	void update_navigation();

--- a/scene/3d/navigation_agent_3d.h
+++ b/scene/3d/navigation_agent_3d.h
@@ -76,6 +76,22 @@ class NavigationAgent3D : public Node {
 	// No initialized on purpose
 	uint32_t update_frame_id = 0;
 
+#ifdef DEBUG_ENABLED
+	bool debug_enabled = false;
+	bool debug_path_dirty = true;
+	RID debug_path_instance;
+	Ref<ArrayMesh> debug_path_mesh;
+	float debug_path_custom_point_size = 4.0;
+	bool debug_use_custom = false;
+	Color debug_path_custom_color = Color(1.0, 1.0, 1.0, 1.0);
+	Ref<StandardMaterial3D> debug_agent_path_line_custom_material;
+	Ref<StandardMaterial3D> debug_agent_path_point_custom_material;
+
+private:
+	void _navigation_debug_changed();
+	void _update_debug_path();
+#endif // DEBUG_ENABLED
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
@@ -180,6 +196,20 @@ public:
 	void _avoidance_done(Vector3 p_new_velocity);
 
 	PackedStringArray get_configuration_warnings() const override;
+
+#ifdef DEBUG_ENABLED
+	void set_debug_enabled(bool p_enabled);
+	bool get_debug_enabled() const;
+
+	void set_debug_use_custom(bool p_enabled);
+	bool get_debug_use_custom() const;
+
+	void set_debug_path_custom_color(Color p_color);
+	Color get_debug_path_custom_color() const;
+
+	void set_debug_path_custom_point_size(float p_point_size);
+	float get_debug_path_custom_point_size() const;
+#endif // DEBUG_ENABLED
 
 private:
 	void update_navigation();

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -207,6 +207,30 @@ void NavigationServer2D::set_debug_navigation_enable_edge_connections(const bool
 bool NavigationServer2D::get_debug_navigation_enable_edge_connections() const {
 	return NavigationServer3D::get_singleton()->get_debug_navigation_enable_edge_connections();
 }
+
+void NavigationServer2D::set_debug_navigation_agent_path_color(const Color &p_color) {
+	NavigationServer3D::get_singleton()->set_debug_navigation_agent_path_color(p_color);
+}
+
+Color NavigationServer2D::get_debug_navigation_agent_path_color() const {
+	return NavigationServer3D::get_singleton()->get_debug_navigation_agent_path_color();
+}
+
+void NavigationServer2D::set_debug_navigation_enable_agent_paths(const bool p_value) {
+	NavigationServer3D::get_singleton()->set_debug_navigation_enable_agent_paths(p_value);
+}
+
+bool NavigationServer2D::get_debug_navigation_enable_agent_paths() const {
+	return NavigationServer3D::get_singleton()->get_debug_navigation_enable_agent_paths();
+}
+
+void NavigationServer2D::set_debug_navigation_agent_path_point_size(float p_point_size) {
+	NavigationServer3D::get_singleton()->set_debug_navigation_agent_path_point_size(p_point_size);
+}
+
+float NavigationServer2D::get_debug_navigation_agent_path_point_size() const {
+	return NavigationServer3D::get_singleton()->get_debug_navigation_agent_path_point_size();
+}
 #endif // DEBUG_ENABLED
 
 void NavigationServer2D::_bind_methods() {
@@ -286,13 +310,25 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &NavigationServer2D::free);
 
 	ADD_SIGNAL(MethodInfo("map_changed", PropertyInfo(Variant::RID, "map")));
+
+	ADD_SIGNAL(MethodInfo("navigation_debug_changed"));
 }
 
 NavigationServer2D::NavigationServer2D() {
 	singleton = this;
 	ERR_FAIL_COND_MSG(!NavigationServer3D::get_singleton(), "The Navigation3D singleton should be initialized before the 2D one.");
 	NavigationServer3D::get_singleton()->connect("map_changed", callable_mp(this, &NavigationServer2D::_emit_map_changed));
+
+#ifdef DEBUG_ENABLED
+	NavigationServer3D::get_singleton()->connect(SNAME("navigation_debug_changed"), callable_mp(this, &NavigationServer2D::_emit_navigation_debug_changed_signal));
+#endif // DEBUG_ENABLED
 }
+
+#ifdef DEBUG_ENABLED
+void NavigationServer2D::_emit_navigation_debug_changed_signal() {
+	emit_signal(SNAME("navigation_debug_changed"));
+}
+#endif // DEBUG_ENABLED
 
 NavigationServer2D::~NavigationServer2D() {
 	singleton = nullptr;

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -254,6 +254,20 @@ public:
 
 	void set_debug_navigation_enable_edge_connections(const bool p_value);
 	bool get_debug_navigation_enable_edge_connections() const;
+
+	void set_debug_navigation_agent_path_color(const Color &p_color);
+	Color get_debug_navigation_agent_path_color() const;
+
+	void set_debug_navigation_enable_agent_paths(const bool p_value);
+	bool get_debug_navigation_enable_agent_paths() const;
+
+	void set_debug_navigation_agent_path_point_size(float p_point_size);
+	float get_debug_navigation_agent_path_point_size() const;
+#endif // DEBUG_ENABLED
+
+#ifdef DEBUG_ENABLED
+private:
+	void _emit_navigation_debug_changed_signal();
 #endif // DEBUG_ENABLED
 };
 

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -159,6 +159,7 @@ NavigationServer3D::NavigationServer3D() {
 	debug_navigation_geometry_face_disabled_color = GLOBAL_DEF("debug/shapes/navigation/geometry_face_disabled_color", Color(0.5, 0.5, 0.5, 0.4));
 	debug_navigation_link_connection_color = GLOBAL_DEF("debug/shapes/navigation/link_connection_color", Color(1.0, 0.5, 1.0, 1.0));
 	debug_navigation_link_connection_disabled_color = GLOBAL_DEF("debug/shapes/navigation/link_connection_disabled_color", Color(0.5, 0.5, 0.5, 1.0));
+	debug_navigation_agent_path_color = GLOBAL_DEF("debug/shapes/navigation/agent_path_color", Color(1.0, 0.0, 0.0, 1.0));
 
 	debug_navigation_enable_edge_connections = GLOBAL_DEF("debug/shapes/navigation/enable_edge_connections", true);
 	debug_navigation_enable_edge_connections_xray = GLOBAL_DEF("debug/shapes/navigation/enable_edge_connections_xray", true);
@@ -167,6 +168,11 @@ NavigationServer3D::NavigationServer3D() {
 	debug_navigation_enable_geometry_face_random_color = GLOBAL_DEF("debug/shapes/navigation/enable_geometry_face_random_color", true);
 	debug_navigation_enable_link_connections = GLOBAL_DEF("debug/shapes/navigation/enable_link_connections", true);
 	debug_navigation_enable_link_connections_xray = GLOBAL_DEF("debug/shapes/navigation/enable_link_connections_xray", true);
+
+	debug_navigation_enable_agent_paths = GLOBAL_DEF("debug/shapes/navigation/enable_agent_paths", true);
+	debug_navigation_enable_agent_paths_xray = GLOBAL_DEF("debug/shapes/navigation/enable_agent_paths_xray", true);
+
+	debug_navigation_agent_path_point_size = GLOBAL_DEF("debug/shapes/navigation/agent_path_point_size", 4.0);
 
 	if (Engine::get_singleton()->is_editor_hint()) {
 		// enable NavigationServer3D when in Editor or else navigation mesh edge connections are invisible
@@ -329,6 +335,42 @@ Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_link_connection
 	return debug_navigation_link_connections_disabled_material;
 }
 
+Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_agent_path_line_material() {
+	if (debug_navigation_agent_path_line_material.is_valid()) {
+		return debug_navigation_agent_path_line_material;
+	}
+
+	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	material->set_albedo(debug_navigation_agent_path_color);
+	if (debug_navigation_enable_agent_paths_xray) {
+		material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
+	}
+	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MAX - 2);
+
+	debug_navigation_agent_path_line_material = material;
+	return debug_navigation_agent_path_line_material;
+}
+
+Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_agent_path_point_material() {
+	if (debug_navigation_agent_path_point_material.is_valid()) {
+		return debug_navigation_agent_path_point_material;
+	}
+
+	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	material->set_albedo(debug_navigation_agent_path_color);
+	material->set_flag(StandardMaterial3D::FLAG_USE_POINT_SIZE, true);
+	material->set_point_size(debug_navigation_agent_path_point_size);
+	if (debug_navigation_enable_agent_paths_xray) {
+		material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
+	}
+	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MAX - 2);
+
+	debug_navigation_agent_path_point_material = material;
+	return debug_navigation_agent_path_point_material;
+}
+
 void NavigationServer3D::set_debug_navigation_edge_connection_color(const Color &p_color) {
 	debug_navigation_edge_connection_color = p_color;
 	if (debug_navigation_edge_connections_material.is_valid()) {
@@ -404,6 +446,31 @@ void NavigationServer3D::set_debug_navigation_link_connection_disabled_color(con
 
 Color NavigationServer3D::get_debug_navigation_link_connection_disabled_color() const {
 	return debug_navigation_link_connection_disabled_color;
+}
+
+void NavigationServer3D::set_debug_navigation_agent_path_point_size(float p_point_size) {
+	debug_navigation_agent_path_point_size = MAX(0.1, p_point_size);
+	if (debug_navigation_agent_path_point_material.is_valid()) {
+		debug_navigation_agent_path_point_material->set_point_size(debug_navigation_agent_path_point_size);
+	}
+}
+
+float NavigationServer3D::get_debug_navigation_agent_path_point_size() const {
+	return debug_navigation_agent_path_point_size;
+}
+
+void NavigationServer3D::set_debug_navigation_agent_path_color(const Color &p_color) {
+	debug_navigation_agent_path_color = p_color;
+	if (debug_navigation_agent_path_line_material.is_valid()) {
+		debug_navigation_agent_path_line_material->set_albedo(debug_navigation_agent_path_color);
+	}
+	if (debug_navigation_agent_path_point_material.is_valid()) {
+		debug_navigation_agent_path_point_material->set_albedo(debug_navigation_agent_path_color);
+	}
+}
+
+Color NavigationServer3D::get_debug_navigation_agent_path_color() const {
+	return debug_navigation_agent_path_color;
 }
 
 void NavigationServer3D::set_debug_navigation_enable_edge_connections(const bool p_value) {
@@ -494,6 +561,37 @@ void NavigationServer3D::set_debug_enabled(bool p_enabled) {
 bool NavigationServer3D::get_debug_enabled() const {
 	return debug_enabled;
 }
+
+void NavigationServer3D::set_debug_navigation_enable_agent_paths(const bool p_value) {
+	if (debug_navigation_enable_agent_paths != p_value) {
+		debug_dirty = true;
+	}
+
+	debug_navigation_enable_agent_paths = p_value;
+
+	if (debug_dirty) {
+		call_deferred("_emit_navigation_debug_changed_signal");
+	}
+}
+
+bool NavigationServer3D::get_debug_navigation_enable_agent_paths() const {
+	return debug_navigation_enable_agent_paths;
+}
+
+void NavigationServer3D::set_debug_navigation_enable_agent_paths_xray(const bool p_value) {
+	debug_navigation_enable_agent_paths_xray = p_value;
+	if (debug_navigation_agent_path_line_material.is_valid()) {
+		debug_navigation_agent_path_line_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, debug_navigation_enable_agent_paths_xray);
+	}
+	if (debug_navigation_agent_path_point_material.is_valid()) {
+		debug_navigation_agent_path_point_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, debug_navigation_enable_agent_paths_xray);
+	}
+}
+
+bool NavigationServer3D::get_debug_navigation_enable_agent_paths_xray() const {
+	return debug_navigation_enable_agent_paths_xray;
+}
+
 #endif // DEBUG_ENABLED
 
 ///////////////////////////////////////////////////////

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -287,6 +287,9 @@ private:
 	Color debug_navigation_geometry_face_disabled_color = Color(0.5, 0.5, 0.5, 0.4);
 	Color debug_navigation_link_connection_color = Color(1.0, 0.5, 1.0, 1.0);
 	Color debug_navigation_link_connection_disabled_color = Color(0.5, 0.5, 0.5, 1.0);
+	Color debug_navigation_agent_path_color = Color(1.0, 0.0, 0.0, 1.0);
+
+	float debug_navigation_agent_path_point_size = 4.0;
 
 	bool debug_navigation_enable_edge_connections = true;
 	bool debug_navigation_enable_edge_connections_xray = true;
@@ -295,6 +298,8 @@ private:
 	bool debug_navigation_enable_geometry_face_random_color = true;
 	bool debug_navigation_enable_link_connections = true;
 	bool debug_navigation_enable_link_connections_xray = true;
+	bool debug_navigation_enable_agent_paths = true;
+	bool debug_navigation_enable_agent_paths_xray = true;
 
 	Ref<StandardMaterial3D> debug_navigation_geometry_edge_material;
 	Ref<StandardMaterial3D> debug_navigation_geometry_face_material;
@@ -303,6 +308,9 @@ private:
 	Ref<StandardMaterial3D> debug_navigation_edge_connections_material;
 	Ref<StandardMaterial3D> debug_navigation_link_connections_material;
 	Ref<StandardMaterial3D> debug_navigation_link_connections_disabled_material;
+
+	Ref<StandardMaterial3D> debug_navigation_agent_path_line_material;
+	Ref<StandardMaterial3D> debug_navigation_agent_path_point_material;
 
 public:
 	void set_debug_enabled(bool p_enabled);
@@ -329,6 +337,9 @@ public:
 	void set_debug_navigation_link_connection_disabled_color(const Color &p_color);
 	Color get_debug_navigation_link_connection_disabled_color() const;
 
+	void set_debug_navigation_agent_path_color(const Color &p_color);
+	Color get_debug_navigation_agent_path_color() const;
+
 	void set_debug_navigation_enable_edge_connections(const bool p_value);
 	bool get_debug_navigation_enable_edge_connections() const;
 
@@ -350,6 +361,15 @@ public:
 	void set_debug_navigation_enable_link_connections_xray(const bool p_value);
 	bool get_debug_navigation_enable_link_connections_xray() const;
 
+	void set_debug_navigation_enable_agent_paths(const bool p_value);
+	bool get_debug_navigation_enable_agent_paths() const;
+
+	void set_debug_navigation_enable_agent_paths_xray(const bool p_value);
+	bool get_debug_navigation_enable_agent_paths_xray() const;
+
+	void set_debug_navigation_agent_path_point_size(float p_point_size);
+	float get_debug_navigation_agent_path_point_size() const;
+
 	Ref<StandardMaterial3D> get_debug_navigation_geometry_face_material();
 	Ref<StandardMaterial3D> get_debug_navigation_geometry_edge_material();
 	Ref<StandardMaterial3D> get_debug_navigation_geometry_face_disabled_material();
@@ -357,6 +377,9 @@ public:
 	Ref<StandardMaterial3D> get_debug_navigation_edge_connections_material();
 	Ref<StandardMaterial3D> get_debug_navigation_link_connections_material();
 	Ref<StandardMaterial3D> get_debug_navigation_link_connections_disabled_material();
+
+	Ref<StandardMaterial3D> get_debug_navigation_agent_path_line_material();
+	Ref<StandardMaterial3D> get_debug_navigation_agent_path_point_material();
 #endif // DEBUG_ENABLED
 };
 


### PR DESCRIPTION
Adds path debug visuals for NavigationAgent2D, NavigationAgent3D and NavigationServer.

The NavigationAgent build-in path debug visuals are toggleable per agent in the inspector with `debug_enabled` property. Custom properties like path color or rasterized point size can be also used per agent instead of the global values when `debug_use_custom` is enabled.

![agent_debug](https://user-images.githubusercontent.com/52464204/212806663-97ed73cf-3e75-43ce-82a0-ea054589fa7a.jpg)

As with other navigation debugs the global values can be controlled in the ProjectSettings from ProjectSettings->Debug->Shapes.

![agent_debug_ps](https://user-images.githubusercontent.com/52464204/212806756-f0acfb91-0e1a-4a17-a49f-07d1f53bcea1.jpg)

While 2D always had an easy time just adding the navigation path points array to a Line2D node for display such an option did not exist for 3D and creating a debug mesh for paths was actually a ton of work and troublesome for beginners. Even for 2D using a node for display was troublesome as it messed with the SceneTree and child functions.

The debug visuals now use the RenderingServer directly, so no unexpected debug Nodes that appear in the SceneTree or RemoteSceneTree and mess up child functions and also no Node overhead. The rendering is updated only once when the agent path or properties change and not every frame to keep runtime performance cost low.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
