### PR TITLE
Fix flickering of lines in Vulkan

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -520,6 +520,12 @@ void RenderForwardClustered::_render_list_template(RenderingDevice::DrawListID p
 			instance_count /= surf->owner->trail_steps;
 		}
 
+#if defined(WINDOWS_ENABLED) || defined(X11_ENABLED)
+		if (primitive == RS::PRIMITIVE_LINES || primitive == RS::PRIMITIVE_LINE_STRIP) {
+			RD::get_singleton()->draw_list_set_line_width(draw_list, 2.0); // To prevent line's flickering.
+		}
+#endif
+
 		RD::get_singleton()->draw_list_draw(draw_list, index_array_rd.is_valid(), instance_count);
 		i += element_info.repeat - 1; //skip equal elements
 	}


### PR DESCRIPTION
Fix (partially) https://github.com/godotengine/godot/issues/37016 (according to @clayjohn does not working on platforms other that Windows and Linux(X11)).
![fix_flickering](https://user-images.githubusercontent.com/3036176/212856542-c6f73aa2-6d28-4db2-b4ca-8151b55b35b3.gif)
