### PR TITLE
GLES3: Fix canvas shader use of undefined draw_data

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -579,10 +579,10 @@ void main() {
 
 	if (normal_used || (using_light && bool(read_draw_data_flags & FLAGS_DEFAULT_NORMAL_MAP_USED))) {
 		normal.xy = texture(normal_texture, uv).xy * vec2(2.0, -2.0) - vec2(1.0, -1.0);
-		if (bool(draw_data.flags & FLAGS_FLIP_H)) {
+		if (bool(read_draw_data_flags & FLAGS_FLIP_H)) {
 			normal.x = -normal.x;
 		}
-		if (bool(draw_data.flags & FLAGS_FLIP_V)) {
+		if (bool(read_draw_data_flags & FLAGS_FLIP_V)) {
 			normal.y = -normal.y;
 		}
 		normal.z = sqrt(1.0 - dot(normal.xy, normal.xy));


### PR DESCRIPTION
Fixes #71551.

Bug introduced in #71382. Seems like it wasn't tested on GLES3.

CC @jainl28patel @clayjohn 