### PR TITLE
Prevent infinite cascade of re-layout after label text reshaping

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -222,6 +222,7 @@ void Label::_shape() {
 			}
 		}
 		lines_dirty = false;
+		lines_shaped_last_width = get_size().width;
 	}
 
 	_update_visible();
@@ -596,7 +597,13 @@ void Label::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_RESIZED: {
-			lines_dirty = true;
+			// It may happen that the reshaping due to this size change triggers a cascade of re-layout
+			// across the hierarchy where this label belongs to in a way that its size changes multiple
+			// times, but ending up with the original size it was already shaped for.
+			// This check prevents the catastrophic, freezing infinite cascade of re-layout.
+			if (lines_shaped_last_width != get_size().width) {
+				lines_dirty = true;
+			}
 		} break;
 	}
 }

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -49,6 +49,8 @@ private:
 	bool uppercase = false;
 
 	bool lines_dirty = true;
+	int lines_shaped_last_width = -1;
+
 	bool dirty = true;
 	bool font_dirty = true;
 	RID text_rid;


### PR DESCRIPTION
This avoids the editor freeze that some, including @clayjohn, have run into when certain internal errors occur and are shown in toasts.