### PR TITLE
Make physics servers `end_sync` on exit

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3030,6 +3030,9 @@ bool Main::iteration() {
 		PhysicsServer2D::get_singleton()->flush_queries();
 
 		if (OS::get_singleton()->get_main_loop()->physics_process(physics_step * time_scale)) {
+			PhysicsServer3D::get_singleton()->end_sync();
+			PhysicsServer2D::get_singleton()->end_sync();
+
 			exit = true;
 			break;
 		}


### PR DESCRIPTION
While experimenting with utilizing `PhysicsServer3D::sync` and `PhysicsServer3D::end_sync` for locking the physics world in my physics server implementation, I noticed that `end_sync` is never called on the last iteration. I figured this was probably not the intention, so I went ahead and added it.

While this doesn't really change much as far as Godot Physics is concerned, I think this does fix a potential bug where you could erroneously access the direct body/space state during the very last `process` when using `physics/3d/run_on_separate_thread`, since `GodotPhysicsServer3D::doing_sync` would still be `true`.