### PR TITLE
Sync C# vectors with Core

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -359,24 +359,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the result of the linear interpolation between
-        /// this color and <paramref name="to"/> by color amount <paramref name="weight"/>.
-        /// </summary>
-        /// <param name="to">The destination color for interpolation.</param>
-        /// <param name="weight">A color with components on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting color of the interpolation.</returns>
-        public readonly Color Lerp(Color to, Color weight)
-        {
-            return new Color
-            (
-                (float)Mathf.Lerp(r, to.r, weight.r),
-                (float)Mathf.Lerp(g, to.g, weight.g),
-                (float)Mathf.Lerp(b, to.b, weight.b),
-                (float)Mathf.Lerp(a, to.a, weight.a)
-            );
-        }
-
-        /// <summary>
         /// Returns the color converted to the sRGB color space.
         /// This method assumes the original color is in the linear color space.
         /// See also <see cref="SrgbToLinear"/> which performs the opposite operation.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -390,24 +390,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the result of the linear interpolation between
-        /// this vector and <paramref name="to"/> by the vector amount <paramref name="weight"/>.
-        /// </summary>
-        /// <param name="to">The destination vector for interpolation.</param>
-        /// <param name="weight">
-        /// A vector with components on the range of 0.0 to 1.0, representing the amount of interpolation.
-        /// </param>
-        /// <returns>The resulting vector of the interpolation.</returns>
-        public readonly Vector2 Lerp(Vector2 to, Vector2 weight)
-        {
-            return new Vector2
-            (
-                Mathf.Lerp(x, to.x, weight.x),
-                Mathf.Lerp(y, to.y, weight.y)
-            );
-        }
-
-        /// <summary>
         /// Returns the vector with a maximum length by limiting its length to <paramref name="length"/>.
         /// </summary>
         /// <param name="length">The length to limit to.</param>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
@@ -95,38 +95,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns this vector's angle with respect to the X axis, or (1, 0) vector, in radians.
-        ///
-        /// Equivalent to the result of <see cref="Mathf.Atan2(real_t, real_t)"/> when
-        /// called with the vector's <see cref="y"/> and <see cref="x"/> as parameters: <c>Mathf.Atan2(v.y, v.x)</c>.
-        /// </summary>
-        /// <returns>The angle of this vector, in radians.</returns>
-        public readonly real_t Angle()
-        {
-            return Mathf.Atan2(y, x);
-        }
-
-        /// <summary>
-        /// Returns the angle to the given vector, in radians.
-        /// </summary>
-        /// <param name="to">The other vector to compare this vector to.</param>
-        /// <returns>The angle between the two vectors, in radians.</returns>
-        public readonly real_t AngleTo(Vector2i to)
-        {
-            return Mathf.Atan2(Cross(to), Dot(to));
-        }
-
-        /// <summary>
-        /// Returns the angle between the line connecting the two points and the X axis, in radians.
-        /// </summary>
-        /// <param name="to">The other vector to compare this vector to.</param>
-        /// <returns>The angle between the two vectors, in radians.</returns>
-        public readonly real_t AngleToPoint(Vector2i to)
-        {
-            return Mathf.Atan2(to.y - y, to.x - x);
-        }
-
-        /// <summary>
         /// Returns the aspect ratio of this vector, the ratio of <see cref="x"/> to <see cref="y"/>.
         /// </summary>
         /// <returns>The <see cref="x"/> component divided by the <see cref="y"/> component.</returns>
@@ -150,48 +118,6 @@ namespace Godot
                 Mathf.Clamp(x, min.x, max.x),
                 Mathf.Clamp(y, min.y, max.y)
             );
-        }
-
-        /// <summary>
-        /// Returns the cross product of this vector and <paramref name="with"/>.
-        /// </summary>
-        /// <param name="with">The other vector.</param>
-        /// <returns>The cross product vector.</returns>
-        public readonly int Cross(Vector2i with)
-        {
-            return x * with.y - y * with.x;
-        }
-
-        /// <summary>
-        /// Returns the squared distance between this vector and <paramref name="to"/>.
-        /// This method runs faster than <see cref="DistanceTo"/>, so prefer it if
-        /// you need to compare vectors or need the squared distance for some formula.
-        /// </summary>
-        /// <param name="to">The other vector to use.</param>
-        /// <returns>The squared distance between the two vectors.</returns>
-        public readonly int DistanceSquaredTo(Vector2i to)
-        {
-            return (to - this).LengthSquared();
-        }
-
-        /// <summary>
-        /// Returns the distance between this vector and <paramref name="to"/>.
-        /// </summary>
-        /// <param name="to">The other vector to use.</param>
-        /// <returns>The distance between the two vectors.</returns>
-        public readonly real_t DistanceTo(Vector2i to)
-        {
-            return (to - this).Length();
-        }
-
-        /// <summary>
-        /// Returns the dot product of this vector and <paramref name="with"/>.
-        /// </summary>
-        /// <param name="with">The other vector to use.</param>
-        /// <returns>The dot product of the two vectors.</returns>
-        public readonly int Dot(Vector2i with)
-        {
-            return x * with.x + y * with.y;
         }
 
         /// <summary>
@@ -242,38 +168,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns a vector composed of the <see cref="Mathf.PosMod(int, int)"/> of this vector's components
-        /// and <paramref name="mod"/>.
-        /// </summary>
-        /// <param name="mod">A value representing the divisor of the operation.</param>
-        /// <returns>
-        /// A vector with each component <see cref="Mathf.PosMod(int, int)"/> by <paramref name="mod"/>.
-        /// </returns>
-        public readonly Vector2i PosMod(int mod)
-        {
-            Vector2i v = this;
-            v.x = Mathf.PosMod(v.x, mod);
-            v.y = Mathf.PosMod(v.y, mod);
-            return v;
-        }
-
-        /// <summary>
-        /// Returns a vector composed of the <see cref="Mathf.PosMod(int, int)"/> of this vector's components
-        /// and <paramref name="modv"/>'s components.
-        /// </summary>
-        /// <param name="modv">A vector representing the divisors of the operation.</param>
-        /// <returns>
-        /// A vector with each component <see cref="Mathf.PosMod(int, int)"/> by <paramref name="modv"/>'s components.
-        /// </returns>
-        public readonly Vector2i PosMod(Vector2i modv)
-        {
-            Vector2i v = this;
-            v.x = Mathf.PosMod(v.x, modv.x);
-            v.y = Mathf.PosMod(v.y, modv.y);
-            return v;
-        }
-
-        /// <summary>
         /// Returns a vector with each component set to one or negative one, depending
         /// on the signs of this vector's components, or zero if the component is zero,
         /// by calling <see cref="Mathf.Sign(int)"/> on each component.
@@ -285,16 +179,6 @@ namespace Godot
             v.x = Mathf.Sign(v.x);
             v.y = Mathf.Sign(v.y);
             return v;
-        }
-
-        /// <summary>
-        /// Returns a perpendicular vector rotated 90 degrees counter-clockwise
-        /// compared to the original, with the same length.
-        /// </summary>
-        /// <returns>The perpendicular vector.</returns>
-        public readonly Vector2i Orthogonal()
-        {
-            return new Vector2i(y, -x);
         }
 
         // Constants
@@ -467,7 +351,7 @@ namespace Godot
         /// with the components of the given <see langword="int"/>.
         /// This operation uses truncated division, which is often not desired
         /// as it does not work well with negative numbers.
-        /// Consider using <see cref="PosMod(int)"/> instead
+        /// Consider using <see cref="Mathf.PosMod(int, int)"/> instead
         /// if you want to handle negative numbers.
         /// </summary>
         /// <example>
@@ -490,7 +374,7 @@ namespace Godot
         /// with the components of the given <see cref="Vector2i"/>.
         /// This operation uses truncated division, which is often not desired
         /// as it does not work well with negative numbers.
-        /// Consider using <see cref="PosMod(Vector2i)"/> instead
+        /// Consider using <see cref="Mathf.PosMod(int, int)"/> instead
         /// if you want to handle negative numbers.
         /// </summary>
         /// <example>
@@ -505,34 +389,6 @@ namespace Godot
         {
             vec.x %= divisorv.x;
             vec.y %= divisorv.y;
-            return vec;
-        }
-
-        /// <summary>
-        /// Performs a bitwise AND operation with this <see cref="Vector2i"/>
-        /// and the given <see langword="int"/>.
-        /// </summary>
-        /// <param name="vec">The vector to AND with.</param>
-        /// <param name="and">The integer to AND with.</param>
-        /// <returns>The result of the bitwise AND.</returns>
-        public static Vector2i operator &(Vector2i vec, int and)
-        {
-            vec.x &= and;
-            vec.y &= and;
-            return vec;
-        }
-
-        /// <summary>
-        /// Performs a bitwise AND operation with this <see cref="Vector2i"/>
-        /// and the given <see cref="Vector2i"/>.
-        /// </summary>
-        /// <param name="vec">The left vector to AND with.</param>
-        /// <param name="andv">The right vector to AND with.</param>
-        /// <returns>The result of the bitwise AND.</returns>
-        public static Vector2i operator &(Vector2i vec, Vector2i andv)
-        {
-            vec.x &= andv.x;
-            vec.y &= andv.y;
             return vec;
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -396,23 +396,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the result of the linear interpolation between
-        /// this vector and <paramref name="to"/> by the vector amount <paramref name="weight"/>.
-        /// </summary>
-        /// <param name="to">The destination vector for interpolation.</param>
-        /// <param name="weight">A vector with components on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting vector of the interpolation.</returns>
-        public readonly Vector3 Lerp(Vector3 to, Vector3 weight)
-        {
-            return new Vector3
-            (
-                Mathf.Lerp(x, to.x, weight.x),
-                Mathf.Lerp(y, to.y, weight.y),
-                Mathf.Lerp(z, to.z, weight.z)
-            );
-        }
-
-        /// <summary>
         /// Returns the vector with a maximum length by limiting its length to <paramref name="length"/>.
         /// </summary>
         /// <param name="length">The length to limit to.</param>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
@@ -129,39 +129,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the squared distance between this vector and <paramref name="to"/>.
-        /// This method runs faster than <see cref="DistanceTo"/>, so prefer it if
-        /// you need to compare vectors or need the squared distance for some formula.
-        /// </summary>
-        /// <param name="to">The other vector to use.</param>
-        /// <returns>The squared distance between the two vectors.</returns>
-        public readonly int DistanceSquaredTo(Vector3i to)
-        {
-            return (to - this).LengthSquared();
-        }
-
-        /// <summary>
-        /// Returns the distance between this vector and <paramref name="to"/>.
-        /// </summary>
-        /// <seealso cref="DistanceSquaredTo(Vector3i)"/>
-        /// <param name="to">The other vector to use.</param>
-        /// <returns>The distance between the two vectors.</returns>
-        public readonly real_t DistanceTo(Vector3i to)
-        {
-            return (to - this).Length();
-        }
-
-        /// <summary>
-        /// Returns the dot product of this vector and <paramref name="with"/>.
-        /// </summary>
-        /// <param name="with">The other vector to use.</param>
-        /// <returns>The dot product of the two vectors.</returns>
-        public readonly int Dot(Vector3i with)
-        {
-            return x * with.x + y * with.y + z * with.z;
-        }
-
-        /// <summary>
         /// Returns the length (magnitude) of this vector.
         /// </summary>
         /// <seealso cref="LengthSquared"/>
@@ -208,40 +175,6 @@ namespace Godot
         public readonly Axis MinAxisIndex()
         {
             return x < y ? (x < z ? Axis.X : Axis.Z) : (y < z ? Axis.Y : Axis.Z);
-        }
-
-        /// <summary>
-        /// Returns a vector composed of the <see cref="Mathf.PosMod(int, int)"/> of this vector's components
-        /// and <paramref name="mod"/>.
-        /// </summary>
-        /// <param name="mod">A value representing the divisor of the operation.</param>
-        /// <returns>
-        /// A vector with each component <see cref="Mathf.PosMod(int, int)"/> by <paramref name="mod"/>.
-        /// </returns>
-        public readonly Vector3i PosMod(int mod)
-        {
-            Vector3i v = this;
-            v.x = Mathf.PosMod(v.x, mod);
-            v.y = Mathf.PosMod(v.y, mod);
-            v.z = Mathf.PosMod(v.z, mod);
-            return v;
-        }
-
-        /// <summary>
-        /// Returns a vector composed of the <see cref="Mathf.PosMod(int, int)"/> of this vector's components
-        /// and <paramref name="modv"/>'s components.
-        /// </summary>
-        /// <param name="modv">A vector representing the divisors of the operation.</param>
-        /// <returns>
-        /// A vector with each component <see cref="Mathf.PosMod(int, int)"/> by <paramref name="modv"/>'s components.
-        /// </returns>
-        public readonly Vector3i PosMod(Vector3i modv)
-        {
-            Vector3i v = this;
-            v.x = Mathf.PosMod(v.x, modv.x);
-            v.y = Mathf.PosMod(v.y, modv.y);
-            v.z = Mathf.PosMod(v.z, modv.z);
-            return v;
         }
 
         /// <summary>
@@ -455,7 +388,7 @@ namespace Godot
         /// with the components of the given <see langword="int"/>.
         /// This operation uses truncated division, which is often not desired
         /// as it does not work well with negative numbers.
-        /// Consider using <see cref="PosMod(int)"/> instead
+        /// Consider using <see cref="Mathf.PosMod(int, int)"/> instead
         /// if you want to handle negative numbers.
         /// </summary>
         /// <example>
@@ -479,7 +412,7 @@ namespace Godot
         /// with the components of the given <see cref="Vector3i"/>.
         /// This operation uses truncated division, which is often not desired
         /// as it does not work well with negative numbers.
-        /// Consider using <see cref="PosMod(Vector3i)"/> instead
+        /// Consider using <see cref="Mathf.PosMod(int, int)"/> instead
         /// if you want to handle negative numbers.
         /// </summary>
         /// <example>
@@ -495,36 +428,6 @@ namespace Godot
             vec.x %= divisorv.x;
             vec.y %= divisorv.y;
             vec.z %= divisorv.z;
-            return vec;
-        }
-
-        /// <summary>
-        /// Performs a bitwise AND operation with this <see cref="Vector3i"/>
-        /// and the given <see langword="int"/>.
-        /// </summary>
-        /// <param name="vec">The vector to AND with.</param>
-        /// <param name="and">The integer to AND with.</param>
-        /// <returns>The result of the bitwise AND.</returns>
-        public static Vector3i operator &(Vector3i vec, int and)
-        {
-            vec.x &= and;
-            vec.y &= and;
-            vec.z &= and;
-            return vec;
-        }
-
-        /// <summary>
-        /// Performs a bitwise AND operation with this <see cref="Vector3i"/>
-        /// and the given <see cref="Vector3i"/>.
-        /// </summary>
-        /// <param name="vec">The left vector to AND with.</param>
-        /// <param name="andv">The right vector to AND with.</param>
-        /// <returns>The result of the bitwise AND.</returns>
-        public static Vector3i operator &(Vector3i vec, Vector3i andv)
-        {
-            vec.x &= andv.x;
-            vec.y &= andv.y;
-            vec.z &= andv.z;
             return vec;
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4i.cs
@@ -433,38 +433,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Performs a bitwise AND operation with this <see cref="Vector4i"/>
-        /// and the given <see langword="int"/>.
-        /// </summary>
-        /// <param name="vec">The vector to AND with.</param>
-        /// <param name="and">The integer to AND with.</param>
-        /// <returns>The result of the bitwise AND.</returns>
-        public static Vector4i operator &(Vector4i vec, int and)
-        {
-            vec.x &= and;
-            vec.y &= and;
-            vec.z &= and;
-            vec.w &= and;
-            return vec;
-        }
-
-        /// <summary>
-        /// Performs a bitwise AND operation with this <see cref="Vector4i"/>
-        /// and the given <see cref="Vector4i"/>.
-        /// </summary>
-        /// <param name="vec">The left vector to AND with.</param>
-        /// <param name="andv">The right vector to AND with.</param>
-        /// <returns>The result of the bitwise AND.</returns>
-        public static Vector4i operator &(Vector4i vec, Vector4i andv)
-        {
-            vec.x &= andv.x;
-            vec.y &= andv.y;
-            vec.z &= andv.z;
-            vec.w &= andv.w;
-            return vec;
-        }
-
-        /// <summary>
         /// Returns <see langword="true"/> if the vectors are equal.
         /// </summary>
         /// <param name="left">The left vector.</param>


### PR DESCRIPTION
- Remove `Vector2.Lerp` overload that takes a weight parameter of type `Vector2`.
- Remove `Vector3.Lerp` overload that takes a weight parameter of type `Vector3`.
- Remove `Color.Lerp` overload that takes a weight parameter of type `Color`.
- Remove `Angle` method from `Vector2i`.
- Remove `AngleTo` method from `Vector2i`.
- Remove `AngleToPoint` method from `Vector2i`.
- Remove `Cross` method from `Vector2i`.
- Remove `DistanceSquaredTo` method from `Vector2i` and `Vector3i`.
- Remove `DistanceTo` method from `Vector2i` and `Vector3i`.
- Remove `Dot` method from `Vector2i` and `Vector3i`.
- Remove `PosMod` method from `Vector2i` and `Vector3i`.
- Remove `Orthogonal` method from `Vector2i`.
- Remove `&` operator from `Vector2i` and `Vector3i`.