### PR TITLE
CI: Run `--doctool` on `precision=double` build

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -37,6 +37,7 @@ jobs:
             target: editor
             tests: true
             sconsflags: dev_build=yes precision=double use_asan=yes use_ubsan=yes linker=gold
+            doc-test: true
             proj-test: true
             # Can be turned off for PRs that intentionally break compat with godot-cpp,
             # until both the upstream PR and the matching godot-cpp changes are merged.


### PR DESCRIPTION
This should help catch involuntary API differences.

Related to #71416. Should fail CI currently as there *are* API differences, we just don't know the full extent of it yet.