### PR TITLE
Improve visibility of Actions button in Advanced import settings dialog

### DIFF
--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -1236,6 +1236,12 @@ SceneImportSettings::SceneImportSettings() {
 
 	action_menu = memnew(MenuButton);
 	action_menu->set_text(TTR("Actions..."));
+	// Style the MenuButton like a regular Button to make it more noticeable.
+	action_menu->set_flat(false);
+	action_menu->add_theme_style_override("normal", get_theme_stylebox("normal", "Button"));
+	action_menu->add_theme_style_override("hover", get_theme_stylebox("hover", "Button"));
+	action_menu->add_theme_style_override("pressed", get_theme_stylebox("pressed", "Button"));
+	action_menu->set_focus_mode(Control::FOCUS_ALL);
 	menu_hb->add_child(action_menu);
 
 	action_menu->get_popup()->add_item(TTR("Extract Materials"), ACTION_EXTRACT_MATERIALS);


### PR DESCRIPTION
This is more of a bandaid than a real fix, but I don't know how else we could improve visibility of this button. Moving the button to the bottom could be confusing, but maybe it's still better than having it tucked in the top-left corner.

Also, the padding within the button seems wrong but I don't know why.

## Preview

### Before

![Screenshot_20230117_221734](https://user-images.githubusercontent.com/180032/213015976-9058e6db-1f10-4445-bf09-9509b89d1867.png)

### After

![Screenshot_20230117_222556](https://user-images.githubusercontent.com/180032/213015987-acd789fe-f2a2-4796-9fb7-51280b60be9f.png)