### PR TITLE
C#: Add float and double overloads to Mathf

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Godot
 {
@@ -35,15 +36,18 @@ namespace Godot
         public const real_t NaN = real_t.NaN;
 
         // 0.0174532924f and 0.0174532925199433
-        private const real_t _degToRadConst = (real_t)0.0174532925199432957692369077M;
+        private const float _degToRadConstF = (float)0.0174532925199432957692369077M;
+        private const double _degToRadConstD = (double)0.0174532925199432957692369077M;
         // 57.29578f and 57.2957795130823
-        private const real_t _radToDegConst = (real_t)57.295779513082320876798154814M;
+        private const float _radToDegConstF = (float)57.295779513082320876798154814M;
+        private const double _radToDegConstD = (double)57.295779513082320876798154814M;
 
         /// <summary>
         /// Returns the absolute value of <paramref name="s"/> (i.e. positive value).
         /// </summary>
         /// <param name="s">The input number.</param>
         /// <returns>The absolute value of <paramref name="s"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Abs(int s)
         {
             return Math.Abs(s);
@@ -54,7 +58,19 @@ namespace Godot
         /// </summary>
         /// <param name="s">The input number.</param>
         /// <returns>The absolute value of <paramref name="s"/>.</returns>
-        public static real_t Abs(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Abs(float s)
+        {
+            return Math.Abs(s);
+        }
+
+        /// <summary>
+        /// Returns the absolute value of <paramref name="s"/> (i.e. positive value).
+        /// </summary>
+        /// <param name="s">The input number.</param>
+        /// <returns>The absolute value of <paramref name="s"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Abs(double s)
         {
             return Math.Abs(s);
         }
@@ -67,9 +83,24 @@ namespace Godot
         /// <returns>
         /// An angle that would result in the given cosine value. On the range <c>0</c> to <c>Tau/2</c>.
         /// </returns>
-        public static real_t Acos(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Acos(float s)
         {
-            return (real_t)Math.Acos(s);
+            return MathF.Acos(s);
+        }
+
+        /// <summary>
+        /// Returns the arc cosine of <paramref name="s"/> in radians.
+        /// Use to get the angle of cosine <paramref name="s"/>.
+        /// </summary>
+        /// <param name="s">The input cosine value. Must be on the range of -1.0 to 1.0.</param>
+        /// <returns>
+        /// An angle that would result in the given cosine value. On the range <c>0</c> to <c>Tau/2</c>.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Acos(double s)
+        {
+            return Math.Acos(s);
         }
 
         /// <summary>
@@ -80,9 +111,24 @@ namespace Godot
         /// <returns>
         /// An angle that would result in the given sine value. On the range <c>-Tau/4</c> to <c>Tau/4</c>.
         /// </returns>
-        public static real_t Asin(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Asin(float s)
         {
-            return (real_t)Math.Asin(s);
+            return MathF.Asin(s);
+        }
+
+        /// <summary>
+        /// Returns the arc sine of <paramref name="s"/> in radians.
+        /// Use to get the angle of sine <paramref name="s"/>.
+        /// </summary>
+        /// <param name="s">The input sine value. Must be on the range of -1.0 to 1.0.</param>
+        /// <returns>
+        /// An angle that would result in the given sine value. On the range <c>-Tau/4</c> to <c>Tau/4</c>.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Asin(double s)
+        {
+            return Math.Asin(s);
         }
 
         /// <summary>
@@ -90,15 +136,33 @@ namespace Godot
         /// Use to get the angle of tangent <paramref name="s"/>.
         ///
         /// The method cannot know in which quadrant the angle should fall.
-        /// See <see cref="Atan2(real_t, real_t)"/> if you have both <c>y</c> and <c>x</c>.
+        /// See <see cref="Atan2(float, float)"/> if you have both <c>y</c> and <c>x</c>.
         /// </summary>
         /// <param name="s">The input tangent value.</param>
         /// <returns>
         /// An angle that would result in the given tangent value. On the range <c>-Tau/4</c> to <c>Tau/4</c>.
         /// </returns>
-        public static real_t Atan(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Atan(float s)
         {
-            return (real_t)Math.Atan(s);
+            return MathF.Atan(s);
+        }
+
+        /// <summary>
+        /// Returns the arc tangent of <paramref name="s"/> in radians.
+        /// Use to get the angle of tangent <paramref name="s"/>.
+        ///
+        /// The method cannot know in which quadrant the angle should fall.
+        /// See <see cref="Atan2(double, double)"/> if you have both <c>y</c> and <c>x</c>.
+        /// </summary>
+        /// <param name="s">The input tangent value.</param>
+        /// <returns>
+        /// An angle that would result in the given tangent value. On the range <c>-Tau/4</c> to <c>Tau/4</c>.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Atan(double s)
+        {
+            return Math.Atan(s);
         }
 
         /// <summary>
@@ -113,9 +177,28 @@ namespace Godot
         /// <returns>
         /// An angle that would result in the given tangent value. On the range <c>-Tau/2</c> to <c>Tau/2</c>.
         /// </returns>
-        public static real_t Atan2(real_t y, real_t x)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Atan2(float y, float x)
         {
-            return (real_t)Math.Atan2(y, x);
+            return MathF.Atan2(y, x);
+        }
+
+        /// <summary>
+        /// Returns the arc tangent of <paramref name="y"/> and <paramref name="x"/> in radians.
+        /// Use to get the angle of the tangent of <c>y/x</c>. To compute the value, the method takes into
+        /// account the sign of both arguments in order to determine the quadrant.
+        ///
+        /// Important note: The Y coordinate comes first, by convention.
+        /// </summary>
+        /// <param name="y">The Y coordinate of the point to find the angle to.</param>
+        /// <param name="x">The X coordinate of the point to find the angle to.</param>
+        /// <returns>
+        /// An angle that would result in the given tangent value. On the range <c>-Tau/2</c> to <c>Tau/2</c>.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Atan2(double y, double x)
+        {
+            return Math.Atan2(y, x);
         }
 
         /// <summary>
@@ -123,9 +206,21 @@ namespace Godot
         /// </summary>
         /// <param name="s">The number to ceil.</param>
         /// <returns>The smallest whole number that is not less than <paramref name="s"/>.</returns>
-        public static real_t Ceil(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Ceil(float s)
         {
-            return (real_t)Math.Ceiling(s);
+            return MathF.Ceiling(s);
+        }
+
+        /// <summary>
+        /// Rounds <paramref name="s"/> upward (towards positive infinity).
+        /// </summary>
+        /// <param name="s">The number to ceil.</param>
+        /// <returns>The smallest whole number that is not less than <paramref name="s"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Ceil(double s)
+        {
+            return Math.Ceiling(s);
         }
 
         /// <summary>
@@ -136,9 +231,10 @@ namespace Godot
         /// <param name="min">The minimum allowed value.</param>
         /// <param name="max">The maximum allowed value.</param>
         /// <returns>The clamped value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Clamp(int value, int min, int max)
         {
-            return value < min ? min : value > max ? max : value;
+            return Math.Clamp(value, min, max);
         }
 
         /// <summary>
@@ -149,9 +245,24 @@ namespace Godot
         /// <param name="min">The minimum allowed value.</param>
         /// <param name="max">The maximum allowed value.</param>
         /// <returns>The clamped value.</returns>
-        public static real_t Clamp(real_t value, real_t min, real_t max)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Clamp(float value, float min, float max)
         {
-            return value < min ? min : value > max ? max : value;
+            return Math.Clamp(value, min, max);
+        }
+
+        /// <summary>
+        /// Clamps a <paramref name="value"/> so that it is not less than <paramref name="min"/>
+        /// and not more than <paramref name="max"/>.
+        /// </summary>
+        /// <param name="value">The value to clamp.</param>
+        /// <param name="min">The minimum allowed value.</param>
+        /// <param name="max">The maximum allowed value.</param>
+        /// <returns>The clamped value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Clamp(double value, double min, double max)
+        {
+            return Math.Clamp(value, min, max);
         }
 
         /// <summary>
@@ -159,9 +270,21 @@ namespace Godot
         /// </summary>
         /// <param name="s">The angle in radians.</param>
         /// <returns>The cosine of that angle.</returns>
-        public static real_t Cos(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Cos(float s)
         {
-            return (real_t)Math.Cos(s);
+            return MathF.Cos(s);
+        }
+
+        /// <summary>
+        /// Returns the cosine of angle <paramref name="s"/> in radians.
+        /// </summary>
+        /// <param name="s">The angle in radians.</param>
+        /// <returns>The cosine of that angle.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Cos(double s)
+        {
+            return Math.Cos(s);
         }
 
         /// <summary>
@@ -169,9 +292,21 @@ namespace Godot
         /// </summary>
         /// <param name="s">The angle in radians.</param>
         /// <returns>The hyperbolic cosine of that angle.</returns>
-        public static real_t Cosh(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Cosh(float s)
         {
-            return (real_t)Math.Cosh(s);
+            return MathF.Cosh(s);
+        }
+
+        /// <summary>
+        /// Returns the hyperbolic cosine of angle <paramref name="s"/> in radians.
+        /// </summary>
+        /// <param name="s">The angle in radians.</param>
+        /// <returns>The hyperbolic cosine of that angle.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Cosh(double s)
+        {
+            return Math.Cosh(s);
         }
 
         /// <summary>
@@ -184,7 +319,7 @@ namespace Godot
         /// <param name="post">The value which after "to" value for interpolation.</param>
         /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
         /// <returns>The resulting value of the interpolation.</returns>
-        public static real_t CubicInterpolate(real_t from, real_t to, real_t pre, real_t post, real_t weight)
+        public static float CubicInterpolate(float from, float to, float pre, float post, float weight)
         {
             return 0.5f *
                     ((from * 2.0f) +
@@ -194,9 +329,8 @@ namespace Godot
         }
 
         /// <summary>
-        /// Cubic interpolates between two rotation values with shortest path
-        /// by the factor defined in <paramref name="weight"/> with pre and post values.
-        /// See also <see cref="LerpAngle"/>.
+        /// Cubic interpolates between two values by the factor defined in <paramref name="weight"/>
+        /// with pre and post values.
         /// </summary>
         /// <param name="from">The start value for interpolation.</param>
         /// <param name="to">The destination value for interpolation.</param>
@@ -204,18 +338,65 @@ namespace Godot
         /// <param name="post">The value which after "to" value for interpolation.</param>
         /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
         /// <returns>The resulting value of the interpolation.</returns>
-        public static real_t CubicInterpolateAngle(real_t from, real_t to, real_t pre, real_t post, real_t weight)
+        public static double CubicInterpolate(double from, double to, double pre, double post, double weight)
         {
-            real_t fromRot = from % Mathf.Tau;
+            return 0.5 *
+                    ((from * 2.0) +
+                            (-pre + to) * weight +
+                            (2.0 * pre - 5.0 * from + 4.0 * to - post) * (weight * weight) +
+                            (-pre + 3.0 * from - 3.0 * to + post) * (weight * weight * weight));
+        }
 
-            real_t preDiff = (pre - fromRot) % Mathf.Tau;
-            real_t preRot = fromRot + (2.0f * preDiff) % Mathf.Tau - preDiff;
+        /// <summary>
+        /// Cubic interpolates between two rotation values with shortest path
+        /// by the factor defined in <paramref name="weight"/> with pre and post values.
+        /// See also <see cref="LerpAngle(float, float, float)"/>.
+        /// </summary>
+        /// <param name="from">The start value for interpolation.</param>
+        /// <param name="to">The destination value for interpolation.</param>
+        /// <param name="pre">The value which before "from" value for interpolation.</param>
+        /// <param name="post">The value which after "to" value for interpolation.</param>
+        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+        /// <returns>The resulting value of the interpolation.</returns>
+        public static float CubicInterpolateAngle(float from, float to, float pre, float post, float weight)
+        {
+            float fromRot = from % MathF.Tau;
 
-            real_t toDiff = (to - fromRot) % Mathf.Tau;
-            real_t toRot = fromRot + (2.0f * toDiff) % Mathf.Tau - toDiff;
+            float preDiff = (pre - fromRot) % MathF.Tau;
+            float preRot = fromRot + (2.0f * preDiff) % MathF.Tau - preDiff;
 
-            real_t postDiff = (post - toRot) % Mathf.Tau;
-            real_t postRot = toRot + (2.0f * postDiff) % Mathf.Tau - postDiff;
+            float toDiff = (to - fromRot) % MathF.Tau;
+            float toRot = fromRot + (2.0f * toDiff) % MathF.Tau - toDiff;
+
+            float postDiff = (post - toRot) % MathF.Tau;
+            float postRot = toRot + (2.0f * postDiff) % MathF.Tau - postDiff;
+
+            return CubicInterpolate(fromRot, toRot, preRot, postRot, weight);
+        }
+
+        /// <summary>
+        /// Cubic interpolates between two rotation values with shortest path
+        /// by the factor defined in <paramref name="weight"/> with pre and post values.
+        /// See also <see cref="LerpAngle(double, double, double)"/>.
+        /// </summary>
+        /// <param name="from">The start value for interpolation.</param>
+        /// <param name="to">The destination value for interpolation.</param>
+        /// <param name="pre">The value which before "from" value for interpolation.</param>
+        /// <param name="post">The value which after "to" value for interpolation.</param>
+        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+        /// <returns>The resulting value of the interpolation.</returns>
+        public static double CubicInterpolateAngle(double from, double to, double pre, double post, double weight)
+        {
+            double fromRot = from % Math.Tau;
+
+            double preDiff = (pre - fromRot) % Math.Tau;
+            double preRot = fromRot + (2.0 * preDiff) % Math.Tau - preDiff;
+
+            double toDiff = (to - fromRot) % Math.Tau;
+            double toRot = fromRot + (2.0 * toDiff) % Math.Tau - toDiff;
+
+            double postDiff = (post - toRot) % Math.Tau;
+            double postRot = toRot + (2.0 * postDiff) % Math.Tau - postDiff;
 
             return CubicInterpolate(fromRot, toRot, preRot, postRot, weight);
         }
@@ -223,7 +404,8 @@ namespace Godot
         /// <summary>
         /// Cubic interpolates between two values by the factor defined in <paramref name="weight"/>
         /// with pre and post values.
-        /// It can perform smoother interpolation than <see cref="CubicInterpolate"/>
+        /// It can perform smoother interpolation than
+        /// <see cref="CubicInterpolate(float, float, float, float, float)"/>
         /// by the time values.
         /// </summary>
         /// <param name="from">The start value for interpolation.</param>
@@ -235,23 +417,52 @@ namespace Godot
         /// <param name="preT"></param>
         /// <param name="postT"></param>
         /// <returns>The resulting value of the interpolation.</returns>
-        public static real_t CubicInterpolateInTime(real_t from, real_t to, real_t pre, real_t post, real_t weight, real_t toT, real_t preT, real_t postT)
+        public static float CubicInterpolateInTime(float from, float to, float pre, float post, float weight, float toT, float preT, float postT)
         {
             /* Barry-Goldman method */
-            real_t t = Lerp(0.0f, toT, weight);
-            real_t a1 = Lerp(pre, from, preT == 0 ? 0.0f : (t - preT) / -preT);
-            real_t a2 = Lerp(from, to, toT == 0 ? 0.5f : t / toT);
-            real_t a3 = Lerp(to, post, postT - toT == 0 ? 1.0f : (t - toT) / (postT - toT));
-            real_t b1 = Lerp(a1, a2, toT - preT == 0 ? 0.0f : (t - preT) / (toT - preT));
-            real_t b2 = Lerp(a2, a3, postT == 0 ? 1.0f : t / postT);
+            float t = Lerp(0.0f, toT, weight);
+            float a1 = Lerp(pre, from, preT == 0 ? 0.0f : (t - preT) / -preT);
+            float a2 = Lerp(from, to, toT == 0 ? 0.5f : t / toT);
+            float a3 = Lerp(to, post, postT - toT == 0 ? 1.0f : (t - toT) / (postT - toT));
+            float b1 = Lerp(a1, a2, toT - preT == 0 ? 0.0f : (t - preT) / (toT - preT));
+            float b2 = Lerp(a2, a3, postT == 0 ? 1.0f : t / postT);
             return Lerp(b1, b2, toT == 0 ? 0.5f : t / toT);
+        }
+
+        /// <summary>
+        /// Cubic interpolates between two values by the factor defined in <paramref name="weight"/>
+        /// with pre and post values.
+        /// It can perform smoother interpolation than
+        /// <see cref="CubicInterpolate(double, double, double, double, double)"/>
+        /// by the time values.
+        /// </summary>
+        /// <param name="from">The start value for interpolation.</param>
+        /// <param name="to">The destination value for interpolation.</param>
+        /// <param name="pre">The value which before "from" value for interpolation.</param>
+        /// <param name="post">The value which after "to" value for interpolation.</param>
+        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+        /// <param name="toT"></param>
+        /// <param name="preT"></param>
+        /// <param name="postT"></param>
+        /// <returns>The resulting value of the interpolation.</returns>
+        public static double CubicInterpolateInTime(double from, double to, double pre, double post, double weight, double toT, double preT, double postT)
+        {
+            /* Barry-Goldman method */
+            double t = Lerp(0.0, toT, weight);
+            double a1 = Lerp(pre, from, preT == 0 ? 0.0 : (t - preT) / -preT);
+            double a2 = Lerp(from, to, toT == 0 ? 0.5 : t / toT);
+            double a3 = Lerp(to, post, postT - toT == 0 ? 1.0 : (t - toT) / (postT - toT));
+            double b1 = Lerp(a1, a2, toT - preT == 0 ? 0.0 : (t - preT) / (toT - preT));
+            double b2 = Lerp(a2, a3, postT == 0 ? 1.0 : t / postT);
+            return Lerp(b1, b2, toT == 0 ? 0.5 : t / toT);
         }
 
         /// <summary>
         /// Cubic interpolates between two rotation values with shortest path
         /// by the factor defined in <paramref name="weight"/> with pre and post values.
-        /// See also <see cref="LerpAngle"/>.
-        /// It can perform smoother interpolation than <see cref="CubicInterpolateAngle"/>
+        /// See also <see cref="LerpAngle(float, float, float)"/>.
+        /// It can perform smoother interpolation than
+        /// <see cref="CubicInterpolateAngle(float, float, float, float, float)"/>
         /// by the time values.
         /// </summary>
         /// <param name="from">The start value for interpolation.</param>
@@ -263,19 +474,51 @@ namespace Godot
         /// <param name="preT"></param>
         /// <param name="postT"></param>
         /// <returns>The resulting value of the interpolation.</returns>
-        public static real_t CubicInterpolateAngleInTime(real_t from, real_t to, real_t pre, real_t post, real_t weight,
-                    real_t toT, real_t preT, real_t postT)
+        public static float CubicInterpolateAngleInTime(float from, float to, float pre, float post, float weight, float toT, float preT, float postT)
         {
-            real_t fromRot = from % Mathf.Tau;
+            float fromRot = from % MathF.Tau;
 
-            real_t preDiff = (pre - fromRot) % Mathf.Tau;
-            real_t preRot = fromRot + (2.0f * preDiff) % Mathf.Tau - preDiff;
+            float preDiff = (pre - fromRot) % MathF.Tau;
+            float preRot = fromRot + (2.0f * preDiff) % MathF.Tau - preDiff;
 
-            real_t toDiff = (to - fromRot) % Mathf.Tau;
-            real_t toRot = fromRot + (2.0f * toDiff) % Mathf.Tau - toDiff;
+            float toDiff = (to - fromRot) % MathF.Tau;
+            float toRot = fromRot + (2.0f * toDiff) % MathF.Tau - toDiff;
 
-            real_t postDiff = (post - toRot) % Mathf.Tau;
-            real_t postRot = toRot + (2.0f * postDiff) % Mathf.Tau - postDiff;
+            float postDiff = (post - toRot) % MathF.Tau;
+            float postRot = toRot + (2.0f * postDiff) % MathF.Tau - postDiff;
+
+            return CubicInterpolateInTime(fromRot, toRot, preRot, postRot, weight, toT, preT, postT);
+        }
+
+        /// <summary>
+        /// Cubic interpolates between two rotation values with shortest path
+        /// by the factor defined in <paramref name="weight"/> with pre and post values.
+        /// See also <see cref="LerpAngle(double, double, double)"/>.
+        /// It can perform smoother interpolation than
+        /// <see cref="CubicInterpolateAngle(double, double, double, double, double)"/>
+        /// by the time values.
+        /// </summary>
+        /// <param name="from">The start value for interpolation.</param>
+        /// <param name="to">The destination value for interpolation.</param>
+        /// <param name="pre">The value which before "from" value for interpolation.</param>
+        /// <param name="post">The value which after "to" value for interpolation.</param>
+        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+        /// <param name="toT"></param>
+        /// <param name="preT"></param>
+        /// <param name="postT"></param>
+        /// <returns>The resulting value of the interpolation.</returns>
+        public static double CubicInterpolateAngleInTime(double from, double to, double pre, double post, double weight, double toT, double preT, double postT)
+        {
+            double fromRot = from % Math.Tau;
+
+            double preDiff = (pre - fromRot) % Math.Tau;
+            double preRot = fromRot + (2.0 * preDiff) % Math.Tau - preDiff;
+
+            double toDiff = (to - fromRot) % Math.Tau;
+            double toRot = fromRot + (2.0 * toDiff) % Math.Tau - toDiff;
+
+            double postDiff = (post - toRot) % Math.Tau;
+            double postRot = toRot + (2.0 * postDiff) % Math.Tau - postDiff;
 
             return CubicInterpolateInTime(fromRot, toRot, preRot, postRot, weight, toT, preT, postT);
         }
@@ -290,16 +533,38 @@ namespace Godot
         /// <param name="end">The destination value for the interpolation.</param>
         /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
         /// <returns>The resulting value of the interpolation.</returns>
-        public static real_t BezierInterpolate(real_t start, real_t control1, real_t control2, real_t end, real_t t)
+        public static float BezierInterpolate(float start, float control1, float control2, float end, float t)
         {
             // Formula from Wikipedia article on Bezier curves
-            real_t omt = 1 - t;
-            real_t omt2 = omt * omt;
-            real_t omt3 = omt2 * omt;
-            real_t t2 = t * t;
-            real_t t3 = t2 * t;
+            float omt = 1.0f - t;
+            float omt2 = omt * omt;
+            float omt3 = omt2 * omt;
+            float t2 = t * t;
+            float t3 = t2 * t;
 
-            return start * omt3 + control1 * omt2 * t * 3 + control2 * omt * t2 * 3 + end * t3;
+            return start * omt3 + control1 * omt2 * t * 3.0f + control2 * omt * t2 * 3.0f + end * t3;
+        }
+
+        /// <summary>
+        /// Returns the point at the given <paramref name="t"/> on a one-dimensional Bezier curve defined by
+        /// the given <paramref name="control1"/>, <paramref name="control2"/>, and <paramref name="end"/> points.
+        /// </summary>
+        /// <param name="start">The start value for the interpolation.</param>
+        /// <param name="control1">Control point that defines the bezier curve.</param>
+        /// <param name="control2">Control point that defines the bezier curve.</param>
+        /// <param name="end">The destination value for the interpolation.</param>
+        /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+        /// <returns>The resulting value of the interpolation.</returns>
+        public static double BezierInterpolate(double start, double control1, double control2, double end, double t)
+        {
+            // Formula from Wikipedia article on Bezier curves
+            double omt = 1.0 - t;
+            double omt2 = omt * omt;
+            double omt3 = omt2 * omt;
+            double t2 = t * t;
+            double t3 = t2 * t;
+
+            return start * omt3 + control1 * omt2 * t * 3.0 + control2 * omt * t2 * 3.0 + end * t3;
         }
 
         /// <summary>
@@ -312,26 +577,58 @@ namespace Godot
         /// <param name="end">The destination value for the interpolation.</param>
         /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
         /// <returns>The resulting value of the interpolation.</returns>
-        public static real_t BezierDerivative(real_t start, real_t control1, real_t control2, real_t end, real_t t)
+        public static float BezierDerivative(float start, float control1, float control2, float end, float t)
         {
             // Formula from Wikipedia article on Bezier curves
-            real_t omt = 1 - t;
-            real_t omt2 = omt * omt;
-            real_t t2 = t * t;
+            float omt = 1.0f - t;
+            float omt2 = omt * omt;
+            float t2 = t * t;
 
-            real_t d = (control1 - start) * 3 * omt2 + (control2 - control1) * 6 * omt * t + (end - control2) * 3 * t2;
+            float d = (control1 - start) * 3.0f * omt2 + (control2 - control1) * 6.0f * omt * t + (end - control2) * 3.0f * t2;
+            return d;
+        }
+
+        /// <summary>
+        /// Returns the derivative at the given <paramref name="t"/> on a one dimensional Bezier curve defined by
+        /// the given <paramref name="control1"/>, <paramref name="control2"/>, and <paramref name="end"/> points.
+        /// </summary>
+        /// <param name="start">The start value for the interpolation.</param>
+        /// <param name="control1">Control point that defines the bezier curve.</param>
+        /// <param name="control2">Control point that defines the bezier curve.</param>
+        /// <param name="end">The destination value for the interpolation.</param>
+        /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+        /// <returns>The resulting value of the interpolation.</returns>
+        public static double BezierDerivative(double start, double control1, double control2, double end, double t)
+        {
+            // Formula from Wikipedia article on Bezier curves
+            double omt = 1.0 - t;
+            double omt2 = omt * omt;
+            double t2 = t * t;
+
+            double d = (control1 - start) * 3.0 * omt2 + (control2 - control1) * 6.0 * omt * t + (end - control2) * 3.0 * t2;
             return d;
         }
 
         /// <summary>
         /// Converts from decibels to linear energy (audio).
         /// </summary>
-        /// <seealso cref="LinearToDb(real_t)"/>
+        /// <seealso cref="LinearToDb(float)"/>
         /// <param name="db">Decibels to convert.</param>
         /// <returns>Audio volume as linear energy.</returns>
-        public static real_t DbToLinear(real_t db)
+        public static float DbToLinear(float db)
         {
-            return (real_t)Math.Exp(db * 0.11512925464970228420089957273422);
+            return MathF.Exp(db * 0.11512925464970228420089957273422f);
+        }
+
+        /// <summary>
+        /// Converts from decibels to linear energy (audio).
+        /// </summary>
+        /// <seealso cref="LinearToDb(double)"/>
+        /// <param name="db">Decibels to convert.</param>
+        /// <returns>Audio volume as linear energy.</returns>
+        public static double DbToLinear(double db)
+        {
+            return Math.Exp(db * 0.11512925464970228420089957273422);
         }
 
         /// <summary>
@@ -339,9 +636,19 @@ namespace Godot
         /// </summary>
         /// <param name="deg">An angle expressed in degrees.</param>
         /// <returns>The same angle expressed in radians.</returns>
-        public static real_t DegToRad(real_t deg)
+        public static float DegToRad(float deg)
         {
-            return deg * _degToRadConst;
+            return deg * _degToRadConstF;
+        }
+
+        /// <summary>
+        /// Converts an angle expressed in degrees to radians.
+        /// </summary>
+        /// <param name="deg">An angle expressed in degrees.</param>
+        /// <returns>The same angle expressed in radians.</returns>
+        public static double DegToRad(double deg)
+        {
+            return deg * _degToRadConstD;
         }
 
         /// <summary>
@@ -354,38 +661,82 @@ namespace Godot
         /// <c>0</c> is constant, <c>1</c> is linear, <c>0</c> to <c>1</c> is ease-in, <c>1</c> or more is ease-out.
         /// </param>
         /// <returns>The eased value.</returns>
-        public static real_t Ease(real_t s, real_t curve)
+        public static float Ease(float s, float curve)
         {
-            if (s < 0f)
+            if (s < 0.0f)
             {
-                s = 0f;
+                s = 0.0f;
             }
             else if (s > 1.0f)
             {
                 s = 1.0f;
             }
 
-            if (curve > 0f)
+            if (curve > 0.0f)
             {
                 if (curve < 1.0f)
                 {
-                    return 1.0f - Pow(1.0f - s, 1.0f / curve);
+                    return 1.0f - MathF.Pow(1.0f - s, 1.0f / curve);
                 }
 
-                return Pow(s, curve);
+                return MathF.Pow(s, curve);
             }
 
-            if (curve < 0f)
+            if (curve < 0.0f)
             {
                 if (s < 0.5f)
                 {
-                    return Pow(s * 2.0f, -curve) * 0.5f;
+                    return MathF.Pow(s * 2.0f, -curve) * 0.5f;
                 }
 
-                return ((1.0f - Pow(1.0f - ((s - 0.5f) * 2.0f), -curve)) * 0.5f) + 0.5f;
+                return ((1.0f - MathF.Pow(1.0f - ((s - 0.5f) * 2.0f), -curve)) * 0.5f) + 0.5f;
             }
 
-            return 0f;
+            return 0.0f;
+        }
+
+        /// <summary>
+        /// Easing function, based on exponent. The <paramref name="curve"/> values are:
+        /// <c>0</c> is constant, <c>1</c> is linear, <c>0</c> to <c>1</c> is ease-in, <c>1</c> or more is ease-out.
+        /// Negative values are in-out/out-in.
+        /// </summary>
+        /// <param name="s">The value to ease.</param>
+        /// <param name="curve">
+        /// <c>0</c> is constant, <c>1</c> is linear, <c>0</c> to <c>1</c> is ease-in, <c>1</c> or more is ease-out.
+        /// </param>
+        /// <returns>The eased value.</returns>
+        public static double Ease(double s, double curve)
+        {
+            if (s < 0.0)
+            {
+                s = 0.0;
+            }
+            else if (s > 1.0)
+            {
+                s = 1.0;
+            }
+
+            if (curve > 0)
+            {
+                if (curve < 1.0)
+                {
+                    return 1.0 - Math.Pow(1.0 - s, 1.0 / curve);
+                }
+
+                return Math.Pow(s, curve);
+            }
+
+            if (curve < 0.0)
+            {
+                if (s < 0.5)
+                {
+                    return Math.Pow(s * 2.0, -curve) * 0.5;
+                }
+
+                return ((1.0 - Math.Pow(1.0 - ((s - 0.5) * 2.0), -curve)) * 0.5) + 0.5;
+            }
+
+            return 0.0;
         }
 
         /// <summary>
@@ -394,9 +745,22 @@ namespace Godot
         /// </summary>
         /// <param name="s">The exponent to raise <c>e</c> to.</param>
         /// <returns><c>e</c> raised to the power of <paramref name="s"/>.</returns>
-        public static real_t Exp(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Exp(float s)
         {
-            return (real_t)Math.Exp(s);
+            return MathF.Exp(s);
+        }
+
+        /// <summary>
+        /// The natural exponential function. It raises the mathematical
+        /// constant <c>e</c> to the power of <paramref name="s"/> and returns it.
+        /// </summary>
+        /// <param name="s">The exponent to raise <c>e</c> to.</param>
+        /// <returns><c>e</c> raised to the power of <paramref name="s"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Exp(double s)
+        {
+            return Math.Exp(s);
         }
 
         /// <summary>
@@ -404,14 +768,26 @@ namespace Godot
         /// </summary>
         /// <param name="s">The number to floor.</param>
         /// <returns>The largest whole number that is not more than <paramref name="s"/>.</returns>
-        public static real_t Floor(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Floor(float s)
         {
-            return (real_t)Math.Floor(s);
+            return MathF.Floor(s);
+        }
+
+        /// <summary>
+        /// Rounds <paramref name="s"/> downward (towards negative infinity).
+        /// </summary>
+        /// <param name="s">The number to floor.</param>
+        /// <returns>The largest whole number that is not more than <paramref name="s"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Floor(double s)
+        {
+            return Math.Floor(s);
         }
 
         /// <summary>
         /// Returns a normalized value considering the given range.
-        /// This is the opposite of <see cref="Lerp(real_t, real_t, real_t)"/>.
+        /// This is the opposite of <see cref="Lerp(float, float, float)"/>.
         /// </summary>
         /// <param name="from">The start value for interpolation.</param>
         /// <param name="to">The destination value for interpolation.</param>
@@ -421,7 +797,24 @@ namespace Godot
         /// The returned value will be between 0.0 and 1.0 if <paramref name="weight"/> is
         /// between <paramref name="from"/> and <paramref name="to"/> (inclusive).
         /// </returns>
-        public static real_t InverseLerp(real_t from, real_t to, real_t weight)
+        public static float InverseLerp(float from, float to, float weight)
+        {
+            return (weight - from) / (to - from);
+        }
+
+        /// <summary>
+        /// Returns a normalized value considering the given range.
+        /// This is the opposite of <see cref="Lerp(double, double, double)"/>.
+        /// </summary>
+        /// <param name="from">The start value for interpolation.</param>
+        /// <param name="to">The destination value for interpolation.</param>
+        /// <param name="weight">The interpolated value.</param>
+        /// <returns>
+        /// The resulting value of the inverse interpolation.
+        /// The returned value will be between 0.0 and 1.0 if <paramref name="weight"/> is
+        /// between <paramref name="from"/> and <paramref name="to"/> (inclusive).
+        /// </returns>
+        public static double InverseLerp(double from, double to, double weight)
         {
             return (weight - from) / (to - from);
         }
@@ -434,7 +827,7 @@ namespace Godot
         /// <param name="a">One of the values.</param>
         /// <param name="b">The other value.</param>
         /// <returns>A <see langword="bool"/> for whether or not the two values are approximately equal.</returns>
-        public static bool IsEqualApprox(real_t a, real_t b)
+        public static bool IsEqualApprox(float a, float b)
         {
             // Check for exact equality first, required to handle "infinity" values.
             if (a == b)
@@ -442,12 +835,36 @@ namespace Godot
                 return true;
             }
             // Then check for approximate equality.
-            real_t tolerance = Epsilon * Abs(a);
-            if (tolerance < Epsilon)
+            float tolerance = _epsilonF * Math.Abs(a);
+            if (tolerance < _epsilonF)
             {
-                tolerance = Epsilon;
+                tolerance = _epsilonF;
             }
-            return Abs(a - b) < tolerance;
+            return Math.Abs(a - b) < tolerance;
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/> are approximately equal
+        /// to each other.
+        /// The comparison is done using a tolerance calculation with <see cref="Epsilon"/>.
+        /// </summary>
+        /// <param name="a">One of the values.</param>
+        /// <param name="b">The other value.</param>
+        /// <returns>A <see langword="bool"/> for whether or not the two values are approximately equal.</returns>
+        public static bool IsEqualApprox(double a, double b)
+        {
+            // Check for exact equality first, required to handle "infinity" values.
+            if (a == b)
+            {
+                return true;
+            }
+            // Then check for approximate equality.
+            double tolerance = _epsilonD * Math.Abs(a);
+            if (tolerance < _epsilonD)
+            {
+                tolerance = _epsilonD;
+            }
+            return Math.Abs(a - b) < tolerance;
         }
 
         /// <summary>
@@ -456,9 +873,22 @@ namespace Godot
         /// </summary>
         /// <param name="s">The value to check.</param>
         /// <returns>A <see langword="bool"/> for whether or not the value is a finite value.</returns>
-        public static bool IsFinite(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsFinite(float s)
         {
-            return real_t.IsFinite(s);
+            return float.IsFinite(s);
+        }
+
+        /// <summary>
+        /// Returns whether <paramref name="s"/> is a finite value, i.e. it is not
+        /// <see cref="NaN"/>, positive infinite, or negative infinity.
+        /// </summary>
+        /// <param name="s">The value to check.</param>
+        /// <returns>A <see langword="bool"/> for whether or not the value is a finite value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsFinite(double s)
+        {
+            return double.IsFinite(s);
         }
 
         /// <summary>
@@ -466,9 +896,21 @@ namespace Godot
         /// </summary>
         /// <param name="s">The value to check.</param>
         /// <returns>A <see langword="bool"/> for whether or not the value is an infinity value.</returns>
-        public static bool IsInf(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsInf(float s)
         {
-            return real_t.IsInfinity(s);
+            return float.IsInfinity(s);
+        }
+
+        /// <summary>
+        /// Returns whether <paramref name="s"/> is an infinity value (either positive infinity or negative infinity).
+        /// </summary>
+        /// <param name="s">The value to check.</param>
+        /// <returns>A <see langword="bool"/> for whether or not the value is an infinity value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsInf(double s)
+        {
+            return double.IsInfinity(s);
         }
 
         /// <summary>
@@ -476,34 +918,75 @@ namespace Godot
         /// </summary>
         /// <param name="s">The value to check.</param>
         /// <returns>A <see langword="bool"/> for whether or not the value is a <c>NaN</c> value.</returns>
-        public static bool IsNaN(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsNaN(float s)
         {
-            return real_t.IsNaN(s);
+            return float.IsNaN(s);
+        }
+
+        /// <summary>
+        /// Returns whether <paramref name="s"/> is a <c>NaN</c> ("Not a Number" or invalid) value.
+        /// </summary>
+        /// <param name="s">The value to check.</param>
+        /// <returns>A <see langword="bool"/> for whether or not the value is a <c>NaN</c> value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsNaN(double s)
+        {
+            return double.IsNaN(s);
         }
 
         /// <summary>
         /// Returns <see langword="true"/> if <paramref name="s"/> is zero or almost zero.
         /// The comparison is done using a tolerance calculation with <see cref="Epsilon"/>.
         ///
-        /// This method is faster than using <see cref="IsEqualApprox(real_t, real_t)"/> with
+        /// This method is faster than using <see cref="IsEqualApprox(float, float)"/> with
         /// one value as zero.
         /// </summary>
         /// <param name="s">The value to check.</param>
         /// <returns>A <see langword="bool"/> for whether or not the value is nearly zero.</returns>
-        public static bool IsZeroApprox(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsZeroApprox(float s)
         {
-            return Abs(s) < Epsilon;
+            return Math.Abs(s) < _epsilonF;
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> if <paramref name="s"/> is zero or almost zero.
+        /// The comparison is done using a tolerance calculation with <see cref="Epsilon"/>.
+        ///
+        /// This method is faster than using <see cref="IsEqualApprox(double, double)"/> with
+        /// one value as zero.
+        /// </summary>
+        /// <param name="s">The value to check.</param>
+        /// <returns>A <see langword="bool"/> for whether or not the value is nearly zero.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsZeroApprox(double s)
+        {
+            return Math.Abs(s) < _epsilonD;
         }
 
         /// <summary>
         /// Linearly interpolates between two values by a normalized value.
-        /// This is the opposite <see cref="InverseLerp(real_t, real_t, real_t)"/>.
+        /// This is the opposite <see cref="InverseLerp(float, float, float)"/>.
         /// </summary>
         /// <param name="from">The start value for interpolation.</param>
         /// <param name="to">The destination value for interpolation.</param>
         /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
         /// <returns>The resulting value of the interpolation.</returns>
-        public static real_t Lerp(real_t from, real_t to, real_t weight)
+        public static float Lerp(float from, float to, float weight)
+        {
+            return from + ((to - from) * weight);
+        }
+
+        /// <summary>
+        /// Linearly interpolates between two values by a normalized value.
+        /// This is the opposite <see cref="InverseLerp(double, double, double)"/>.
+        /// </summary>
+        /// <param name="from">The start value for interpolation.</param>
+        /// <param name="to">The destination value for interpolation.</param>
+        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+        /// <returns>The resulting value of the interpolation.</returns>
+        public static double Lerp(double from, double to, double weight)
         {
             return from + ((to - from) * weight);
         }
@@ -511,17 +994,34 @@ namespace Godot
         /// <summary>
         /// Linearly interpolates between two angles (in radians) by a normalized value.
         ///
-        /// Similar to <see cref="Lerp(real_t, real_t, real_t)"/>,
+        /// Similar to <see cref="Lerp(float, float, float)"/>,
         /// but interpolates correctly when the angles wrap around <see cref="Tau"/>.
         /// </summary>
         /// <param name="from">The start angle for interpolation.</param>
         /// <param name="to">The destination angle for interpolation.</param>
         /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
         /// <returns>The resulting angle of the interpolation.</returns>
-        public static real_t LerpAngle(real_t from, real_t to, real_t weight)
+        public static float LerpAngle(float from, float to, float weight)
         {
-            real_t difference = (to - from) % Mathf.Tau;
-            real_t distance = ((2 * difference) % Mathf.Tau) - difference;
+            float difference = (to - from) % MathF.Tau;
+            float distance = ((2 * difference) % MathF.Tau) - difference;
+            return from + (distance * weight);
+        }
+
+        /// <summary>
+        /// Linearly interpolates between two angles (in radians) by a normalized value.
+        ///
+        /// Similar to <see cref="Lerp(double, double, double)"/>,
+        /// but interpolates correctly when the angles wrap around <see cref="Tau"/>.
+        /// </summary>
+        /// <param name="from">The start angle for interpolation.</param>
+        /// <param name="to">The destination angle for interpolation.</param>
+        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+        /// <returns>The resulting angle of the interpolation.</returns>
+        public static double LerpAngle(double from, double to, double weight)
+        {
+            double difference = (to - from) % Math.Tau;
+            double distance = ((2 * difference) % Math.Tau) - difference;
             return from + (distance * weight);
         }
 
@@ -529,7 +1029,7 @@ namespace Godot
         /// Converts from linear energy to decibels (audio).
         /// This can be used to implement volume sliders that behave as expected (since volume isn't linear).
         /// </summary>
-        /// <seealso cref="DbToLinear(real_t)"/>
+        /// <seealso cref="DbToLinear(float)"/>
         /// <example>
         /// <code>
         /// // "slider" refers to a node that inherits Range such as HSlider or VSlider.
@@ -540,9 +1040,29 @@ namespace Godot
         /// </example>
         /// <param name="linear">The linear energy to convert.</param>
         /// <returns>Audio as decibels.</returns>
-        public static real_t LinearToDb(real_t linear)
+        public static float LinearToDb(float linear)
         {
-            return (real_t)(Math.Log(linear) * 8.6858896380650365530225783783321);
+            return MathF.Log(linear) * 8.6858896380650365530225783783321f;
+        }
+
+        /// <summary>
+        /// Converts from linear energy to decibels (audio).
+        /// This can be used to implement volume sliders that behave as expected (since volume isn't linear).
+        /// </summary>
+        /// <seealso cref="DbToLinear(double)"/>
+        /// <example>
+        /// <code>
+        /// // "slider" refers to a node that inherits Range such as HSlider or VSlider.
+        /// // Its range must be configured to go from 0 to 1.
+        /// // Change the bus name if you'd like to change the volume of a specific bus only.
+        /// AudioServer.SetBusVolumeDb(AudioServer.GetBusIndex("Master"), GD.LinearToDb(slider.value));
+        /// </code>
+        /// </example>
+        /// <param name="linear">The linear energy to convert.</param>
+        /// <returns>Audio as decibels.</returns>
+        public static double LinearToDb(double linear)
+        {
+            return Math.Log(linear) * 8.6858896380650365530225783783321;
         }
 
         /// <summary>
@@ -552,9 +1072,23 @@ namespace Godot
         /// </summary>
         /// <param name="s">The input value.</param>
         /// <returns>The natural log of <paramref name="s"/>.</returns>
-        public static real_t Log(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Log(float s)
         {
-            return (real_t)Math.Log(s);
+            return MathF.Log(s);
+        }
+
+        /// <summary>
+        /// Natural logarithm. The amount of time needed to reach a certain level of continuous growth.
+        ///
+        /// Note: This is not the same as the "log" function on most calculators, which uses a base 10 logarithm.
+        /// </summary>
+        /// <param name="s">The input value.</param>
+        /// <returns>The natural log of <paramref name="s"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Log(double s)
+        {
+            return Math.Log(s);
         }
 
         /// <summary>
@@ -563,9 +1097,10 @@ namespace Godot
         /// <param name="a">One of the values.</param>
         /// <param name="b">The other value.</param>
         /// <returns>Whichever of the two values is higher.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Max(int a, int b)
         {
-            return a > b ? a : b;
+            return Math.Max(a, b);
         }
 
         /// <summary>
@@ -574,9 +1109,22 @@ namespace Godot
         /// <param name="a">One of the values.</param>
         /// <param name="b">The other value.</param>
         /// <returns>Whichever of the two values is higher.</returns>
-        public static real_t Max(real_t a, real_t b)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Max(float a, float b)
         {
-            return a > b ? a : b;
+            return Math.Max(a, b);
+        }
+
+        /// <summary>
+        /// Returns the maximum of two values.
+        /// </summary>
+        /// <param name="a">One of the values.</param>
+        /// <param name="b">The other value.</param>
+        /// <returns>Whichever of the two values is higher.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Max(double a, double b)
+        {
+            return Math.Max(a, b);
         }
 
         /// <summary>
@@ -585,9 +1133,10 @@ namespace Godot
         /// <param name="a">One of the values.</param>
         /// <param name="b">The other value.</param>
         /// <returns>Whichever of the two values is lower.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Min(int a, int b)
         {
-            return a < b ? a : b;
+            return Math.Min(a, b);
         }
 
         /// <summary>
@@ -596,9 +1145,22 @@ namespace Godot
         /// <param name="a">One of the values.</param>
         /// <param name="b">The other value.</param>
         /// <returns>Whichever of the two values is lower.</returns>
-        public static real_t Min(real_t a, real_t b)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Min(float a, float b)
         {
-            return a < b ? a : b;
+            return Math.Min(a, b);
+        }
+
+        /// <summary>
+        /// Returns the minimum of two values.
+        /// </summary>
+        /// <param name="a">One of the values.</param>
+        /// <param name="b">The other value.</param>
+        /// <returns>Whichever of the two values is lower.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Min(double a, double b)
+        {
+            return Math.Min(a, b);
         }
 
         /// <summary>
@@ -610,12 +1172,29 @@ namespace Godot
         /// <param name="to">The value to move towards.</param>
         /// <param name="delta">The amount to move by.</param>
         /// <returns>The value after moving.</returns>
-        public static real_t MoveToward(real_t from, real_t to, real_t delta)
+        public static float MoveToward(float from, float to, float delta)
         {
-            if (Abs(to - from) <= delta)
+            if (Math.Abs(to - from) <= delta)
                 return to;
 
-            return from + (Sign(to - from) * delta);
+            return from + (Math.Sign(to - from) * delta);
+        }
+
+        /// <summary>
+        /// Moves <paramref name="from"/> toward <paramref name="to"/> by the <paramref name="delta"/> value.
+        ///
+        /// Use a negative <paramref name="delta"/> value to move away.
+        /// </summary>
+        /// <param name="from">The start value.</param>
+        /// <param name="to">The value to move towards.</param>
+        /// <param name="delta">The amount to move by.</param>
+        /// <returns>The value after moving.</returns>
+        public static double MoveToward(double from, double to, double delta)
+        {
+            if (Math.Abs(to - from) <= delta)
+                return to;
+
+            return from + (Math.Sign(to - from) * delta);
         }
 
         /// <summary>
@@ -657,9 +1236,25 @@ namespace Godot
         /// <param name="a">The dividend, the primary input.</param>
         /// <param name="b">The divisor. The output is on the range [0, <paramref name="b"/>).</param>
         /// <returns>The resulting output.</returns>
-        public static real_t PosMod(real_t a, real_t b)
+        public static float PosMod(float a, float b)
         {
-            real_t c = a % b;
+            float c = a % b;
+            if ((c < 0 && b > 0) || (c > 0 && b < 0))
+            {
+                c += b;
+            }
+            return c;
+        }
+
+        /// <summary>
+        /// Performs a canonical Modulus operation, where the output is on the range [0, <paramref name="b"/>).
+        /// </summary>
+        /// <param name="a">The dividend, the primary input.</param>
+        /// <param name="b">The divisor. The output is on the range [0, <paramref name="b"/>).</param>
+        /// <returns>The resulting output.</returns>
+        public static double PosMod(double a, double b)
+        {
+            double c = a % b;
             if ((c < 0 && b > 0) || (c > 0 && b < 0))
             {
                 c += b;
@@ -673,9 +1268,22 @@ namespace Godot
         /// <param name="x">The base.</param>
         /// <param name="y">The exponent.</param>
         /// <returns><paramref name="x"/> raised to the power of <paramref name="y"/>.</returns>
-        public static real_t Pow(real_t x, real_t y)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Pow(float x, float y)
         {
-            return (real_t)Math.Pow(x, y);
+            return MathF.Pow(x, y);
+        }
+
+        /// <summary>
+        /// Returns the result of <paramref name="x"/> raised to the power of <paramref name="y"/>.
+        /// </summary>
+        /// <param name="x">The base.</param>
+        /// <param name="y">The exponent.</param>
+        /// <returns><paramref name="x"/> raised to the power of <paramref name="y"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Pow(double x, double y)
+        {
+            return Math.Pow(x, y);
         }
 
         /// <summary>
@@ -683,9 +1291,21 @@ namespace Godot
         /// </summary>
         /// <param name="rad">An angle expressed in radians.</param>
         /// <returns>The same angle expressed in degrees.</returns>
-        public static real_t RadToDeg(real_t rad)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float RadToDeg(float rad)
         {
-            return rad * _radToDegConst;
+            return rad * _radToDegConstF;
+        }
+
+        /// <summary>
+        /// Converts an angle expressed in radians to degrees.
+        /// </summary>
+        /// <param name="rad">An angle expressed in radians.</param>
+        /// <returns>The same angle expressed in degrees.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double RadToDeg(double rad)
+        {
+            return rad * _radToDegConstD;
         }
 
         /// <summary>
@@ -698,7 +1318,22 @@ namespace Godot
         /// <param name="outFrom">The start value for the output interpolation.</param>
         /// <param name="outTo">The destination value for the output interpolation.</param>
         /// <returns>The resulting mapped value mapped.</returns>
-        public static real_t Remap(real_t value, real_t inFrom, real_t inTo, real_t outFrom, real_t outTo)
+        public static float Remap(float value, float inFrom, float inTo, float outFrom, float outTo)
+        {
+            return Lerp(outFrom, outTo, InverseLerp(inFrom, inTo, value));
+        }
+
+        /// <summary>
+        /// Maps a <paramref name="value"/> from [<paramref name="inFrom"/>, <paramref name="inTo"/>]
+        /// to [<paramref name="outFrom"/>, <paramref name="outTo"/>].
+        /// </summary>
+        /// <param name="value">The value to map.</param>
+        /// <param name="inFrom">The start value for the input interpolation.</param>
+        /// <param name="inTo">The destination value for the input interpolation.</param>
+        /// <param name="outFrom">The start value for the output interpolation.</param>
+        /// <param name="outTo">The destination value for the output interpolation.</param>
+        /// <returns>The resulting mapped value mapped.</returns>
+        public static double Remap(double value, double inFrom, double inTo, double outFrom, double outTo)
         {
             return Lerp(outFrom, outTo, InverseLerp(inFrom, inTo, value));
         }
@@ -709,9 +1344,22 @@ namespace Godot
         /// </summary>
         /// <param name="s">The number to round.</param>
         /// <returns>The rounded number.</returns>
-        public static real_t Round(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Round(float s)
         {
-            return (real_t)Math.Round(s);
+            return MathF.Round(s);
+        }
+
+        /// <summary>
+        /// Rounds <paramref name="s"/> to the nearest whole number,
+        /// with halfway cases rounded towards the nearest multiple of two.
+        /// </summary>
+        /// <param name="s">The number to round.</param>
+        /// <returns>The rounded number.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Round(double s)
+        {
+            return Math.Round(s);
         }
 
         /// <summary>
@@ -720,11 +1368,10 @@ namespace Godot
         /// </summary>
         /// <param name="s">The input number.</param>
         /// <returns>One of three possible values: <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Sign(int s)
         {
-            if (s == 0)
-                return 0;
-            return s < 0 ? -1 : 1;
+            return Math.Sign(s);
         }
 
         /// <summary>
@@ -733,11 +1380,22 @@ namespace Godot
         /// </summary>
         /// <param name="s">The input number.</param>
         /// <returns>One of three possible values: <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
-        public static int Sign(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Sign(float s)
         {
-            if (s == 0)
-                return 0;
-            return s < 0 ? -1 : 1;
+            return Math.Sign(s);
+        }
+
+        /// <summary>
+        /// Returns the sign of <paramref name="s"/>: <c>-1</c> or <c>1</c>.
+        /// Returns <c>0</c> if <paramref name="s"/> is <c>0</c>.
+        /// </summary>
+        /// <param name="s">The input number.</param>
+        /// <returns>One of three possible values: <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Sign(double s)
+        {
+            return Math.Sign(s);
         }
 
         /// <summary>
@@ -745,9 +1403,21 @@ namespace Godot
         /// </summary>
         /// <param name="s">The angle in radians.</param>
         /// <returns>The sine of that angle.</returns>
-        public static real_t Sin(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Sin(float s)
         {
-            return (real_t)Math.Sin(s);
+            return MathF.Sin(s);
+        }
+
+        /// <summary>
+        /// Returns the sine of angle <paramref name="s"/> in radians.
+        /// </summary>
+        /// <param name="s">The angle in radians.</param>
+        /// <returns>The sine of that angle.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Sin(double s)
+        {
+            return Math.Sin(s);
         }
 
         /// <summary>
@@ -755,27 +1425,58 @@ namespace Godot
         /// </summary>
         /// <param name="s">The angle in radians.</param>
         /// <returns>The hyperbolic sine of that angle.</returns>
-        public static real_t Sinh(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Sinh(float s)
         {
-            return (real_t)Math.Sinh(s);
+            return MathF.Sinh(s);
+        }
+
+        /// <summary>
+        /// Returns the hyperbolic sine of angle <paramref name="s"/> in radians.
+        /// </summary>
+        /// <param name="s">The angle in radians.</param>
+        /// <returns>The hyperbolic sine of that angle.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Sinh(double s)
+        {
+            return Math.Sinh(s);
         }
 
         /// <summary>
         /// Returns a number smoothly interpolated between <paramref name="from"/> and <paramref name="to"/>,
-        /// based on the <paramref name="weight"/>. Similar to <see cref="Lerp(real_t, real_t, real_t)"/>,
+        /// based on the <paramref name="weight"/>. Similar to <see cref="Lerp(float, float, float)"/>,
         /// but interpolates faster at the beginning and slower at the end.
         /// </summary>
         /// <param name="from">The start value for interpolation.</param>
         /// <param name="to">The destination value for interpolation.</param>
         /// <param name="weight">A value representing the amount of interpolation.</param>
         /// <returns>The resulting value of the interpolation.</returns>
-        public static real_t SmoothStep(real_t from, real_t to, real_t weight)
+        public static float SmoothStep(float from, float to, float weight)
         {
             if (IsEqualApprox(from, to))
             {
                 return from;
             }
-            real_t x = Clamp((weight - from) / (to - from), (real_t)0.0, (real_t)1.0);
+            float x = Math.Clamp((weight - from) / (to - from), 0.0f, 1.0f);
+            return x * x * (3 - (2 * x));
+        }
+
+        /// <summary>
+        /// Returns a number smoothly interpolated between <paramref name="from"/> and <paramref name="to"/>,
+        /// based on the <paramref name="weight"/>. Similar to <see cref="Lerp(double, double, double)"/>,
+        /// but interpolates faster at the beginning and slower at the end.
+        /// </summary>
+        /// <param name="from">The start value for interpolation.</param>
+        /// <param name="to">The destination value for interpolation.</param>
+        /// <param name="weight">A value representing the amount of interpolation.</param>
+        /// <returns>The resulting value of the interpolation.</returns>
+        public static double SmoothStep(double from, double to, double weight)
+        {
+            if (IsEqualApprox(from, to))
+            {
+                return from;
+            }
+            double x = Math.Clamp((weight - from) / (to - from), 0.0, 1.0);
             return x * x * (3 - (2 * x));
         }
 
@@ -786,9 +1487,23 @@ namespace Godot
         /// </summary>
         /// <param name="s">The input number. Must not be negative.</param>
         /// <returns>The square root of <paramref name="s"/>.</returns>
-        public static real_t Sqrt(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Sqrt(float s)
         {
-            return (real_t)Math.Sqrt(s);
+            return MathF.Sqrt(s);
+        }
+
+        /// <summary>
+        /// Returns the square root of <paramref name="s"/>, where <paramref name="s"/> is a non-negative number.
+        ///
+        /// If you need negative inputs, use <see cref="System.Numerics.Complex"/>.
+        /// </summary>
+        /// <param name="s">The input number. Must not be negative.</param>
+        /// <returns>The square root of <paramref name="s"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Sqrt(double s)
+        {
+            return Math.Sqrt(s);
         }
 
         /// <summary>
@@ -798,7 +1513,7 @@ namespace Godot
         /// </summary>
         /// <param name="step">The input value.</param>
         /// <returns>The position of the first non-zero digit.</returns>
-        public static int StepDecimals(real_t step)
+        public static int StepDecimals(double step)
         {
             double[] sd = new double[]
             {
@@ -812,7 +1527,7 @@ namespace Godot
                 0.00000009999,
                 0.000000009999,
             };
-            double abs = Abs(step);
+            double abs = Math.Abs(step);
             double decs = abs - (int)abs; // Strip away integer part
             for (int i = 0; i < sd.Length; i++)
             {
@@ -831,11 +1546,28 @@ namespace Godot
         /// <param name="s">The value to snap.</param>
         /// <param name="step">The step size to snap to.</param>
         /// <returns>The snapped value.</returns>
-        public static real_t Snapped(real_t s, real_t step)
+        public static float Snapped(float s, float step)
         {
             if (step != 0f)
             {
-                return Floor((s / step) + 0.5f) * step;
+                return MathF.Floor((s / step) + 0.5f) * step;
+            }
+
+            return s;
+        }
+
+        /// <summary>
+        /// Snaps float value <paramref name="s"/> to a given <paramref name="step"/>.
+        /// This can also be used to round a floating point number to an arbitrary number of decimals.
+        /// </summary>
+        /// <param name="s">The value to snap.</param>
+        /// <param name="step">The step size to snap to.</param>
+        /// <returns>The snapped value.</returns>
+        public static double Snapped(double s, double step)
+        {
+            if (step != 0f)
+            {
+                return Math.Floor((s / step) + 0.5f) * step;
             }
 
             return s;
@@ -846,9 +1578,21 @@ namespace Godot
         /// </summary>
         /// <param name="s">The angle in radians.</param>
         /// <returns>The tangent of that angle.</returns>
-        public static real_t Tan(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Tan(float s)
         {
-            return (real_t)Math.Tan(s);
+            return MathF.Tan(s);
+        }
+
+        /// <summary>
+        /// Returns the tangent of angle <paramref name="s"/> in radians.
+        /// </summary>
+        /// <param name="s">The angle in radians.</param>
+        /// <returns>The tangent of that angle.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Tan(double s)
+        {
+            return Math.Tan(s);
         }
 
         /// <summary>
@@ -856,9 +1600,21 @@ namespace Godot
         /// </summary>
         /// <param name="s">The angle in radians.</param>
         /// <returns>The hyperbolic tangent of that angle.</returns>
-        public static real_t Tanh(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Tanh(float s)
         {
-            return (real_t)Math.Tanh(s);
+            return MathF.Tanh(s);
+        }
+
+        /// <summary>
+        /// Returns the hyperbolic tangent of angle <paramref name="s"/> in radians.
+        /// </summary>
+        /// <param name="s">The angle in radians.</param>
+        /// <returns>The hyperbolic tangent of that angle.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Tanh(double s)
+        {
+            return Math.Tanh(s);
         }
 
         /// <summary>
@@ -884,15 +1640,15 @@ namespace Godot
         /// Wraps <paramref name="value"/> between <paramref name="min"/> and <paramref name="max"/>.
         /// Usable for creating loop-alike behavior or infinite surfaces.
         /// If <paramref name="min"/> is <c>0</c>, this is equivalent
-        /// to <see cref="PosMod(real_t, real_t)"/>, so prefer using that instead.
+        /// to <see cref="PosMod(float, float)"/>, so prefer using that instead.
         /// </summary>
         /// <param name="value">The value to wrap.</param>
         /// <param name="min">The minimum allowed value and lower bound of the range.</param>
         /// <param name="max">The maximum allowed value and upper bound of the range.</param>
         /// <returns>The wrapped value.</returns>
-        public static real_t Wrap(real_t value, real_t min, real_t max)
+        public static float Wrap(float value, float min, float max)
         {
-            real_t range = max - min;
+            float range = max - min;
             if (IsZeroApprox(range))
             {
                 return min;
@@ -900,9 +1656,24 @@ namespace Godot
             return min + ((((value - min) % range) + range) % range);
         }
 
-        private static real_t Fract(real_t value)
+        /// <summary>
+        /// Wraps <paramref name="value"/> between <paramref name="min"/> and <paramref name="max"/>.
+        /// Usable for creating loop-alike behavior or infinite surfaces.
+        /// If <paramref name="min"/> is <c>0</c>, this is equivalent
+        /// to <see cref="PosMod(double, double)"/>, so prefer using that instead.
+        /// </summary>
+        /// <param name="value">The value to wrap.</param>
+        /// <param name="min">The minimum allowed value and lower bound of the range.</param>
+        /// <param name="max">The maximum allowed value and upper bound of the range.</param>
+        /// <returns>The wrapped value.</returns>
+        public static double Wrap(double value, double min, double max)
         {
-            return value - (real_t)Math.Floor(value);
+            double range = max - min;
+            if (IsZeroApprox(range))
+            {
+                return min;
+            }
+            return min + ((((value - min) % range) + range) % range);
         }
 
         /// <summary>
@@ -914,9 +1685,33 @@ namespace Godot
         /// <param name="value">The value to pingpong.</param>
         /// <param name="length">The maximum value of the function.</param>
         /// <returns>The ping-ponged value.</returns>
-        public static real_t PingPong(real_t value, real_t length)
+        public static float PingPong(float value, float length)
         {
-            return (length != (real_t)0.0) ? Abs(Fract((value - length) / (length * (real_t)2.0)) * length * (real_t)2.0 - length) : (real_t)0.0;
+            return (length != 0.0f) ? Math.Abs(Fract((value - length) / (length * 2.0f)) * length * 2.0f - length) : 0.0f;
+
+            static float Fract(float value)
+            {
+                return value - MathF.Floor(value);
+            }
+        }
+
+        /// <summary>
+        /// Returns the <paramref name="value"/> wrapped between <c>0</c> and the <paramref name="length"/>.
+        /// If the limit is reached, the next value the function returned is decreased to the <c>0</c> side
+        /// or increased to the <paramref name="length"/> side (like a triangle wave).
+        /// If <paramref name="length"/> is less than zero, it becomes positive.
+        /// </summary>
+        /// <param name="value">The value to pingpong.</param>
+        /// <param name="length">The maximum value of the function.</param>
+        /// <returns>The ping-ponged value.</returns>
+        public static double PingPong(double value, double length)
+        {
+            return (length != 0.0) ? Math.Abs(Fract((value - length) / (length * 2.0)) * length * 2.0 - length) : 0.0;
+
+            static double Fract(double value)
+            {
+                return value - Math.Floor(value);
+            }
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/MathfEx.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/MathfEx.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Runtime.CompilerServices;
+
+// This file contains extra members for the Mathf class that aren't part of Godot's Core API.
+// Math API that is also part of Core should go into Mathf.cs.
 
 namespace Godot
 {
@@ -16,14 +20,18 @@ namespace Godot
         /// </summary>
         public const real_t Sqrt2 = (real_t)1.4142135623730950488016887242M; // 1.4142136f and 1.414213562373095
 
+        // Epsilon size should depend on the precision used.
+        private const float _epsilonF = 1e-06f;
+        private const double _epsilonD = 1e-14;
+
         /// <summary>
         /// A very small number used for float comparison with error tolerance.
         /// 1e-06 with single-precision floats, but 1e-14 if <c>REAL_T_IS_DOUBLE</c>.
         /// </summary>
 #if REAL_T_IS_DOUBLE
-        public const real_t Epsilon = 1e-14; // Epsilon size should depend on the precision used.
+        public const real_t Epsilon = _epsilonD;
 #else
-        public const real_t Epsilon = 1e-06f;
+        public const real_t Epsilon = _epsilonF;
 #endif
 
         /// <summary>
@@ -31,7 +39,8 @@ namespace Godot
         /// </summary>
         /// <param name="s">The input value.</param>
         /// <returns>The amount of digits.</returns>
-        public static int DecimalCount(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int DecimalCount(double s)
         {
             return DecimalCount((decimal)s);
         }
@@ -41,6 +50,7 @@ namespace Godot
         /// </summary>
         /// <param name="s">The input <see langword="decimal"/> value.</param>
         /// <returns>The amount of digits.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int DecimalCount(decimal s)
         {
             return BitConverter.GetBytes(decimal.GetBits(s)[3])[2];
@@ -49,11 +59,25 @@ namespace Godot
         /// <summary>
         /// Rounds <paramref name="s"/> upward (towards positive infinity).
         ///
-        /// This is the same as <see cref="Ceil(real_t)"/>, but returns an <see langword="int"/>.
+        /// This is the same as <see cref="Ceil(float)"/>, but returns an <see langword="int"/>.
         /// </summary>
         /// <param name="s">The number to ceil.</param>
         /// <returns>The smallest whole number that is not less than <paramref name="s"/>.</returns>
-        public static int CeilToInt(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int CeilToInt(float s)
+        {
+            return (int)MathF.Ceiling(s);
+        }
+
+        /// <summary>
+        /// Rounds <paramref name="s"/> upward (towards positive infinity).
+        ///
+        /// This is the same as <see cref="Ceil(double)"/>, but returns an <see langword="int"/>.
+        /// </summary>
+        /// <param name="s">The number to ceil.</param>
+        /// <returns>The smallest whole number that is not less than <paramref name="s"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int CeilToInt(double s)
         {
             return (int)Math.Ceiling(s);
         }
@@ -61,11 +85,25 @@ namespace Godot
         /// <summary>
         /// Rounds <paramref name="s"/> downward (towards negative infinity).
         ///
-        /// This is the same as <see cref="Floor(real_t)"/>, but returns an <see langword="int"/>.
+        /// This is the same as <see cref="Floor(float)"/>, but returns an <see langword="int"/>.
         /// </summary>
         /// <param name="s">The number to floor.</param>
         /// <returns>The largest whole number that is not more than <paramref name="s"/>.</returns>
-        public static int FloorToInt(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int FloorToInt(float s)
+        {
+            return (int)MathF.Floor(s);
+        }
+
+        /// <summary>
+        /// Rounds <paramref name="s"/> downward (towards negative infinity).
+        ///
+        /// This is the same as <see cref="Floor(double)"/>, but returns an <see langword="int"/>.
+        /// </summary>
+        /// <param name="s">The number to floor.</param>
+        /// <returns>The largest whole number that is not more than <paramref name="s"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int FloorToInt(double s)
         {
             return (int)Math.Floor(s);
         }
@@ -73,11 +111,25 @@ namespace Godot
         /// <summary>
         /// Rounds <paramref name="s"/> to the nearest whole number.
         ///
-        /// This is the same as <see cref="Round(real_t)"/>, but returns an <see langword="int"/>.
+        /// This is the same as <see cref="Round(float)"/>, but returns an <see langword="int"/>.
         /// </summary>
         /// <param name="s">The number to round.</param>
         /// <returns>The rounded number.</returns>
-        public static int RoundToInt(real_t s)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int RoundToInt(float s)
+        {
+            return (int)MathF.Round(s);
+        }
+
+        /// <summary>
+        /// Rounds <paramref name="s"/> to the nearest whole number.
+        ///
+        /// This is the same as <see cref="Round(double)"/>, but returns an <see langword="int"/>.
+        /// </summary>
+        /// <param name="s">The number to round.</param>
+        /// <returns>The rounded number.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int RoundToInt(double s)
         {
             return (int)Math.Round(s);
         }
@@ -87,23 +139,32 @@ namespace Godot
         /// </summary>
         /// <param name="s">The angle in radians.</param>
         /// <returns>The sine and cosine of that angle.</returns>
-        public static (real_t Sin, real_t Cos) SinCos(real_t s)
+        public static (float Sin, float Cos) SinCos(float s)
         {
-            (double sin, double cos) = Math.SinCos(s);
-            return ((real_t)sin, (real_t)cos);
+            return MathF.SinCos(s);
+        }
+
+        /// <summary>
+        /// Returns the sine and cosine of angle <paramref name="s"/> in radians.
+        /// </summary>
+        /// <param name="s">The angle in radians.</param>
+        /// <returns>The sine and cosine of that angle.</returns>
+        public static (double Sin, double Cos) SinCos(double s)
+        {
+            return Math.SinCos(s);
         }
 
         /// <summary>
         /// Returns <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/> are approximately
         /// equal to each other.
         /// The comparison is done using the provided tolerance value.
-        /// If you want the tolerance to be calculated for you, use <see cref="IsEqualApprox(real_t, real_t)"/>.
+        /// If you want the tolerance to be calculated for you, use <see cref="IsEqualApprox(float, float)"/>.
         /// </summary>
         /// <param name="a">One of the values.</param>
         /// <param name="b">The other value.</param>
         /// <param name="tolerance">The pre-calculated tolerance value.</param>
         /// <returns>A <see langword="bool"/> for whether or not the two values are equal.</returns>
-        public static bool IsEqualApprox(real_t a, real_t b, real_t tolerance)
+        public static bool IsEqualApprox(float a, float b, float tolerance)
         {
             // Check for exact equality first, required to handle "infinity" values.
             if (a == b)
@@ -111,7 +172,28 @@ namespace Godot
                 return true;
             }
             // Then check for approximate equality.
-            return Abs(a - b) < tolerance;
+            return Math.Abs(a - b) < tolerance;
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/> are approximately
+        /// equal to each other.
+        /// The comparison is done using the provided tolerance value.
+        /// If you want the tolerance to be calculated for you, use <see cref="IsEqualApprox(double, double)"/>.
+        /// </summary>
+        /// <param name="a">One of the values.</param>
+        /// <param name="b">The other value.</param>
+        /// <param name="tolerance">The pre-calculated tolerance value.</param>
+        /// <returns>A <see langword="bool"/> for whether or not the two values are equal.</returns>
+        public static bool IsEqualApprox(double a, double b, double tolerance)
+        {
+            // Check for exact equality first, required to handle "infinity" values.
+            if (a == b)
+            {
+                return true;
+            }
+            // Then check for approximate equality.
+            return Math.Abs(a - b) < tolerance;
         }
     }
 }


### PR DESCRIPTION
### Background and motivation

- Users complain that they have to add too many conversions to their code to handle mixing `double` and `float` [^1]. \
  Situations where you have to mix floating-type values may happen often since the engine uses `double` for scalar values and `float` for vector values.
- Users want to use our available math methods with `double` values. \
  Currently they are implemented using `real_t` which defaults to `float`, this can be changed to `double` with `--precision=double` but I see no reason not to offer the ability to use `double` APIs even when using `--precision=single`.
- Math operations that only use `float` may offer better performance by using `System.MathF` instead [^2]. \
  Currently we use `System.Math` which uses `double` and then convert to `float`, there's a tiny performance cost and we may want to optimize this given how most of our math is used in areas where `float` is all that is required.

### PR design

This PR aims to solve the mentioned issues by adding `float` and `double` overloads to all methods of `Mathf`. This allows the methods to be usable with `float`, `double` or `real_t`, regardless of the `--precision` flag.

- By implementing `double` and `float` overloads in the same class, users can seamlessly use `Mathf` regardless of the floating type that they're using. This should help reduce the need for converting to `float` or `real_t` and allows for mixing different floating types which would return a `double`. \
  This is the same behavior you would come to expect from math operations that mix `float` and `double`:
  ```csharp
  float a = 4.0f;
  double b = 2.0;
  var c = a * b; // c is a double
  ```
- Methods that take `double` are also available in builds that use `--precision=single`, allowing users to use the `float` or `double` methods depending on their use case.
- Having dedicated `double` and `float` methods allow us to use different implementations optimized for the situation. The `double` methods use `System.Math` just like before, but now the `float` methods can take advantage of `System.MathF` which should result in a minor performance improvement.
- Use aggressive inlining in hopes that the JIT replaces calls to `Mathf` with calls to the methods in `System.Math` and `System.MathF` directly.

#### Constants

One of the problems with this approach compared to **alternative designs** (see section below) is that when we only have one Math class we can't have constant overloads, so we end up with one of these options:

- Constants are `float`: \
  This looses precision that may be useful to users working with `double`.
- Constants are `double`: \
  This requires converting to `float` every time users are using `float`-based APIs.
- Constants are **both** `float` and `double`: \
  This means we need to duplicate every constant and give them different names, which tends to be ugly (e.g.: `PiF` and `PiD`).
- Constants are `real_t`: \
  This is the the way constants are currently defined today in `Mathf`, no changes.

Because I'm not really convinced with any of the options I choose to keep the status quo with this PR, constants remain defined as **`real_t`** just as before, this should allow ease of usage when working with `real_t`.

For users that require `float` or `double` constants my recommendation would be to get them from `System.Math`, `System.MathF`, `System.Double` and `System.Single` which contains most of the constants available in `Mathf`. Users are also free to define their own constants in their projects if they need to, and even publish libraries to NuGet for reusability.

### Alternative Designs

#### Multiple Math classes

We could implement the the Math methods in separate classes such as `MathF` and `MathD`, this has the benefit of allowing us to use the same name for the constants but has the following problems:

- Users need to explicitly use the right Math class. \
  I'd expect most users would end up using `MathD` simply because it works everywhere since `float` implicitly converts to `double`, missing out on minor performance improvements.
- Requires conversions when working with `real_t`.  \
  When working with `real_t` values, such as when using vector types, users can't assume the vector uses `float` so they'll be forced to use `MathD` and then convert to `real_t`. This could be fixed if we also provide a third Math class for `real_t` but that increases the maintainability burden.
- Users can already use `System.Math` and `System.MathF` so this approach doesn't really provide as many benefits.

#### Generic Math

The new **Generic Math** feature introduced in .NET 7.0 would allow us to implement a Math class with generic `T` methods where `T` is `INumber<T>` which means our methods would work with any numeric type (`int`, `long`, `float`, `double`, ...) and even any non-primitive type like a custom user-defined type as long as it implements the `INumber<T>` interface.

Unfortunately, this would require using .NET 7.0 and we're currently using .NET 6.0 (we may consider switching to .NET 7.0 for the 4.0 release but nothing has been decided so far).

Also, considering how important performance is for Math, I wonder if generic math is fast enough. This might not be an issue when using full AOT though, but we also don't support that today in Godot.

### Related issues and PRs

- Closes https://github.com/godotengine/godot-proposals/issues/5509.
- Closes https://github.com/godotengine/godot/pull/67605.
- Closes https://github.com/godotengine/godot/pull/65832.

[^1]: https://github.com/godotengine/godot-proposals/issues/5403
[^2]: https://github.com/godotengine/godot-proposals/issues/5509