### PR TITLE
Remove light from dynamic light list when removing scenario

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -748,6 +748,10 @@ void RendererSceneCull::instance_set_scenario(RID p_instance, RID p_scenario) {
 		switch (instance->base_type) {
 			case RS::INSTANCE_LIGHT: {
 				InstanceLightData *light = static_cast<InstanceLightData *>(instance->base_data);
+				if (instance->visible && RSG::light_storage->light_get_type(instance->base) != RS::LIGHT_DIRECTIONAL && light->bake_mode == RS::LIGHT_BAKE_DYNAMIC) {
+					instance->scenario->dynamic_lights.erase(light->instance);
+				}
+
 #ifdef DEBUG_ENABLED
 				if (light->geometries.size()) {
 					ERR_PRINT("BUG, indexing did not unpair geometries from light.");


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/57840

The issue here is that the scenario manages the dynamic light list, but the scenario is removed from the instance before the instance is freed when using ``queue_delete()`` as the scenario is unpaired when the light leaves the scene_tree. 

This change mirrors the logic in ``instance_set_base()``:
https://github.com/godotengine/godot/blob/1d8e739a9d3dd4769dfe71ba6ef9008a149b9ae1/servers/rendering/renderer_scene_cull.cpp#L525-L538
