### PR TITLE
Fix issues with GDScript first-time parsing

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -922,6 +922,15 @@ void EditorFileSystem::_scan_new_dir(EditorFileSystemDirectory *p_dir, Ref<DirAc
 			}
 		}
 
+		p_dir->files.push_back(fi);
+		p_progress.update(idx, total);
+	}
+
+	_scan_script_classes(p_dir);
+
+	for (EditorFileSystemDirectory::FileInfo *fi : p_dir->files) {
+		String path = cd.path_join(fi->file);
+
 		for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 			ScriptLanguage *lang = ScriptServer::get_language(i);
 			if (lang->supports_documentation() && fi->type == lang->get_type()) {
@@ -935,9 +944,6 @@ void EditorFileSystem::_scan_new_dir(EditorFileSystemDirectory *p_dir, Ref<DirAc
 				}
 			}
 		}
-
-		p_dir->files.push_back(fi);
-		p_progress.update(idx, total);
 	}
 }
 


### PR DESCRIPTION
Fixes #71570

### tl;dr
This fixes the parse errors of GDScript files when fresh importing a project (or when running the project after deleting the `.godot` directory)

### About the first problem
> https://github.com/godotengine/godot/blob/master/modules/gdscript/gdscript.cpp#L2468
> This should be more tolerant to parse errors, so even if parse is not ok, this information will almost certainly still be there in the parse tree.

Removed the `err == OK` check in `String GDScriptLanguage::get_global_class_name()`. Doesn't crash when there's a parse error, but it doesn't really returns the global class name neither when there's a parse error. So, I don't really know if it's fixing something.

### About the second problem
> The second one is a design problem of the feature:
>https://github.com/godotengine/godot/blob/master/editor/editor_file_system.cpp#L925
> this has the following problems:
>
> - This is way too early to load a script, most clases in the filesystem have not been scanned and it is highly likely the parsing will fail. this should be done later on in the scan scripts phase.
> - The function to get documentation should still not load the script resource in a thread. This is dangerous as the script could have init logic not meant to run on a thread. This should be a dedicated function that uses the parser on the file on disk without opening the resource.
> 
> ### Steps to reproduce
> Here is a script that lets you generate a lot of Godot classes, you can see the second problem appear easily if you use this (I have no idea where this cache goes, but it seems the error only happens on the first time:
> ![image](https://user-images.githubusercontent.com/270928/213106498-4375b082-bcac-4b63-a95b-d2c1446cc452.png)

#### Part one
> - This is way too early to load a script, most clases in the filesystem have not been scanned and it is highly likely the parsing will fail. this should be done later on in the scan scripts phase.

This is fixed by running `_scan_script_classes(p_dir)`. This parses files with `fi->script_class_name` set by `_get_global_script_class()` and it seems to do the trick. It creates global classes for those scripts, which future script loads will be able to refer to.

#### Part two
> - The function to get documentation should still not load the script resource in a thread. This is dangerous as the script could have init logic not meant to run on a thread. This should be a dedicated function that uses the parser on the file on disk without opening the resource.

The scripts are still loaded in a thread, but after the part one fix. The init logic of the scripts are never ran, as only the source code is loaded. I don't see which code not meant to run on a thread could be run.

### Conclusion

I tested a fresh import of classes and no parse error were signalled. And the documentation was complete after the import.