### PR TITLE
[Web] User FS (user://) now correctly uses project name.

### DIFF
--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -30,6 +30,7 @@
 
 #include "os_web.h"
 
+#include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
 #include "drivers/unix/dir_access_unix.h"
 #include "drivers/unix/file_access_unix.h"
@@ -157,7 +158,22 @@ void OS_Web::vibrate_handheld(int p_duration_ms) {
 }
 
 String OS_Web::get_user_data_dir() const {
-	return "/userfs";
+	String userfs = "/userfs";
+	String appname = get_safe_dir_name(GLOBAL_GET("application/config/name"));
+	if (!appname.is_empty()) {
+		bool use_custom_dir = GLOBAL_GET("application/config/use_custom_user_dir");
+		if (use_custom_dir) {
+			String custom_dir = get_safe_dir_name(GLOBAL_GET("application/config/custom_user_dir_name"), true);
+			if (custom_dir.is_empty()) {
+				custom_dir = appname;
+			}
+			return userfs.path_join(custom_dir).replace("\\", "/");
+		} else {
+			return userfs.path_join(get_godot_dir_name()).path_join("app_userdata").path_join(appname).replace("\\", "/");
+		}
+	}
+
+	return userfs.path_join(get_godot_dir_name()).path_join("app_userdata").path_join("[unnamed project]");
 }
 
 String OS_Web::get_cache_path() const {


### PR DESCRIPTION
This allows multiple instances to co-exist in the same domain while keeping their user data separate (each in its own folder).