### PR TITLE
Add `p_keep_state` to `AnimationPlayer::stop()`

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -208,9 +208,11 @@
 		</method>
 		<method name="stop">
 			<return type="void" />
+			<param index="0" name="keep_state" type="bool" default="false" />
 			<description>
-				Stops the currently playing animation. The animation position is reset to [code]0[/code] and the playback speed is reset to [code]1.0[/code].
-				See also [method pause].
+				Stops the currently playing animation. The animation position is reset to [code]0[/code] and the playback speed is reset to [code]1.0[/code]. See also [method pause].
+				If [param keep_state] is [code]true[/code], the animation state is not updated visually.
+				[b]Note:[/b] The method / audio / animation playback tracks will not be processed by this method.
 			</description>
 		</method>
 	</methods>

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1736,11 +1736,11 @@ String AnimationPlayer::get_assigned_animation() const {
 }
 
 void AnimationPlayer::pause() {
-	_stop_internal(false);
+	_stop_internal(false, false);
 }
 
-void AnimationPlayer::stop() {
-	_stop_internal(true);
+void AnimationPlayer::stop(bool p_keep_state) {
+	_stop_internal(true, p_keep_state);
 }
 
 void AnimationPlayer::set_speed_scale(float p_speed) {
@@ -1960,14 +1960,18 @@ void AnimationPlayer::_set_process(bool p_process, bool p_force) {
 	processing = p_process;
 }
 
-void AnimationPlayer::_stop_internal(bool p_reset) {
+void AnimationPlayer::_stop_internal(bool p_reset, bool p_keep_state) {
 	_stop_playing_caches(p_reset);
 	Playback &c = playback;
 	c.blend.clear();
 	if (p_reset) {
-		is_stopping = true;
-		seek(0, true);
-		is_stopping = false;
+		if (p_keep_state) {
+			c.current.pos = 0;
+		} else {
+			is_stopping = true;
+			seek(0, true);
+			is_stopping = false;
+		}
 		c.current.from = nullptr;
 		c.current.speed_scale = 1;
 	}
@@ -2139,7 +2143,7 @@ void AnimationPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("play", "name", "custom_blend", "custom_speed", "from_end"), &AnimationPlayer::play, DEFVAL(""), DEFVAL(-1), DEFVAL(1.0), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("play_backwards", "name", "custom_blend"), &AnimationPlayer::play_backwards, DEFVAL(""), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("pause"), &AnimationPlayer::pause);
-	ClassDB::bind_method(D_METHOD("stop"), &AnimationPlayer::stop);
+	ClassDB::bind_method(D_METHOD("stop", "keep_state"), &AnimationPlayer::stop, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("is_playing"), &AnimationPlayer::is_playing);
 
 	ClassDB::bind_method(D_METHOD("set_current_animation", "anim"), &AnimationPlayer::set_current_animation);

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -295,7 +295,7 @@ private:
 	void _animation_changed(const StringName &p_name);
 
 	void _set_process(bool p_process, bool p_force = false);
-	void _stop_internal(bool p_reset);
+	void _stop_internal(bool p_reset, bool p_keep_state);
 
 	bool playing = false;
 
@@ -349,7 +349,7 @@ public:
 	Vector<String> get_queue();
 	void clear_queue();
 	void pause();
-	void stop();
+	void stop(bool p_keep_state = false);
 	bool is_playing() const;
 	String get_current_animation() const;
 	void set_current_animation(const String &p_anim);


### PR DESCRIPTION
Follow up #33733.

Add an option `p_keep_state` to `AnimationPlayer::stop()` to avoid state updates for 3.x compatibility and for versatility.