### PR TITLE
Update `@icon` and `@tool` definitions to add a note

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -553,6 +553,7 @@
 				@icon("res://path/to/class/icon.svg")
 				[/codeblock]
 				[b]Note:[/b] Only the script can have a custom icon. Inner classes are not supported.
+				[b]Note:[/b] As annotations describe their subject, the [code]@icon[/code] annotation must be placed before the class definition and inheritance.
 			</description>
 		</annotation>
 		<annotation name="@onready">
@@ -585,6 +586,7 @@
 				@tool
 				extends Node
 				[/codeblock]
+				[b]Note:[/b] As annotations describe their subject, the [code]@tool[/code] annotation must be placed before the class definition and inheritance.
 			</description>
 		</annotation>
 		<annotation name="@warning_ignore" qualifiers="vararg">


### PR DESCRIPTION
Adds a note about the position of the annotation `@icon` due to the merge of #67774

Relates to #71592
Relates to godotengine/godot-docs#6628