### PR TITLE
`CanvasItem::draw_arc` Clamp angle difference so arc won't overlap itself

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -45,7 +45,8 @@
 			<param index="6" name="width" type="float" default="1.0" />
 			<param index="7" name="antialiased" type="bool" default="false" />
 			<description>
-				Draws a unfilled arc between the given angles. The larger the value of [param point_count], the smoother the curve. See also [method draw_circle].
+				Draws an unfilled arc between the given angles. The larger the value of [param point_count], the smoother the curve. See also [method draw_circle].
+				The arc is drawn from [param start_angle] towards the value of [param end_angle] so in clockwise direction if [code]start_angle &lt; end_angle[/code] and counter-clockwise otherwise. Passing the same angles but in reversed order will produce the same arc. If absolute difference of [param start_angle] and [param end_angle] is greater than [constant @GDScript.TAU] radians, then a full circle arc is drawn (i.e. arc will not overlap itself).
 			</description>
 		</method>
 		<method name="draw_char" qualifiers="const">

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -531,10 +531,13 @@ void CanvasItem::draw_polyline_colors(const Vector<Point2> &p_points, const Vect
 void CanvasItem::draw_arc(const Vector2 &p_center, real_t p_radius, real_t p_start_angle, real_t p_end_angle, int p_point_count, const Color &p_color, real_t p_width, bool p_antialiased) {
 	Vector<Point2> points;
 	points.resize(p_point_count);
-	const real_t delta_angle = p_end_angle - p_start_angle;
+	Point2 *points_ptr = points.ptrw();
+
+	// Clamp angle difference to full circle so arc won't overlap itself.
+	const real_t delta_angle = CLAMP(p_end_angle - p_start_angle, -Math_TAU, Math_TAU);
 	for (int i = 0; i < p_point_count; i++) {
 		real_t theta = (i / (p_point_count - 1.0f)) * delta_angle + p_start_angle;
-		points.set(i, p_center + Vector2(Math::cos(theta), Math::sin(theta)) * p_radius);
+		points_ptr[i] = p_center + Vector2(Math::cos(theta), Math::sin(theta)) * p_radius;
 	}
 
 	draw_polyline(points, p_color, p_width, p_antialiased);

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -1207,20 +1207,23 @@ void RendererCanvasCull::canvas_item_add_circle(RID p_item, const Point2 &p_pos,
 	static const int circle_points = 64;
 
 	points.resize(circle_points);
+	Vector2 *points_ptr = points.ptrw();
 	const real_t circle_point_step = Math_TAU / circle_points;
 
 	for (int i = 0; i < circle_points; i++) {
 		float angle = i * circle_point_step;
-		points.write[i].x = Math::cos(angle) * p_radius;
-		points.write[i].y = Math::sin(angle) * p_radius;
-		points.write[i] += p_pos;
+		points_ptr[i].x = Math::cos(angle) * p_radius;
+		points_ptr[i].y = Math::sin(angle) * p_radius;
+		points_ptr[i] += p_pos;
 	}
+
 	indices.resize((circle_points - 2) * 3);
+	int *indices_ptr = indices.ptrw();
 
 	for (int i = 0; i < circle_points - 2; i++) {
-		indices.write[i * 3 + 0] = 0;
-		indices.write[i * 3 + 1] = i + 1;
-		indices.write[i * 3 + 2] = i + 2;
+		indices_ptr[i * 3 + 0] = 0;
+		indices_ptr[i * 3 + 1] = i + 1;
+		indices_ptr[i * 3 + 2] = i + 2;
 	}
 
 	Vector<Color> color;


### PR DESCRIPTION
Ensures that in case of a big angle difference `CanvasItem::draw_arc` uses all points for drawing at most a single full circle, instead of drawing an arc which overlaps itself.

Improved `CanvasItem::draw_arc`'s docs.
Resolves #64685.

<details>
<summary>Examples</summary>

|Angle|Point count|Before|Afer|
|-|-|-|-|
|-90 to 630 degrees|5 + 1|![rY67xEKhOC](https://user-images.githubusercontent.com/9283098/213171964-dec82a5c-76be-4014-b7be-05b8b4ca959e.png)|![nx821hTMeX](https://user-images.githubusercontent.com/9283098/213171956-2181bbe0-c0c6-42cd-9189-9f9c03969d23.png)|
|-90 to 630 degrees|17 + 1|![5aM7zps2r6](https://user-images.githubusercontent.com/9283098/213172968-cb2e0f43-4ebb-47ef-9e33-c9ee3a2ac004.png)|![QsRLn5ns9N](https://user-images.githubusercontent.com/9283098/213172980-789133ae-fd66-451d-a31f-33d74a34fee9.png)|
|0 to 450 degrees|7 + 1|![vUiBEEXOJt](https://user-images.githubusercontent.com/9283098/213173675-5b0fb6ef-08bc-4538-8f61-049a2ca0a3fb.png)|![Dp3guiZl3d](https://user-images.githubusercontent.com/9283098/213173683-053d3e44-6b65-4c63-8a0b-caeafc666f70.png)|

</details>

Also changed some writing to vectors so `_copy_on_write` will be called just once (when obtaining the pointer with `ptrw()`).

