### PR TITLE
Fix unnammed enum crash regression

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3171,7 +3171,7 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 		for (int i = 0; i < current_enum->values.size(); i++) {
 			const GDScriptParser::EnumNode::Value &element = current_enum->values[i];
 			if (element.identifier->name == p_identifier->name) {
-				StringName enum_name = current_enum->identifier->name ? current_enum->identifier->name : UNNAMED_ENUM;
+				StringName enum_name = current_enum->identifier ? current_enum->identifier->name : UNNAMED_ENUM;
 				GDScriptParser::DataType type = make_enum_type(enum_name, parser->current_class->fqcn, false);
 				if (element.parent_enum->identifier) {
 					type.enum_type = element.parent_enum->identifier->name;

--- a/modules/gdscript/tests/scripts/analyzer/features/enum_unnamed_depend.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/enum_unnamed_depend.gd
@@ -1,0 +1,7 @@
+enum {
+	V1,
+	V2 = V1,
+}
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/features/enum_unnamed_depend.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/enum_unnamed_depend.out
@@ -1,0 +1,1 @@
+GDTEST_OK


### PR DESCRIPTION
Fix #71588 regression :)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
