### PR TITLE
Fixes TileMap undo not restoring tiles

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -2839,7 +2839,7 @@ void TileMap::_set_tile_data(int p_layer, const Vector<int> &p_data) {
 	const int *r = p_data.ptr();
 
 	int offset = (format >= FORMAT_2) ? 3 : 2;
-	ERR_FAIL_COND_MSG(c % offset != 0, "Corrupted tile data.");
+	ERR_FAIL_COND_MSG(c % offset != 0, vformat("Corrupted tile data. Got size: %s. Expected modulo: %s", offset));
 
 	clear_layer(p_layer);
 

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -179,7 +179,7 @@ private:
 		FORMAT_2,
 		FORMAT_3
 	};
-	mutable DataFormat format = FORMAT_1; // Assume lowest possible format if none is present;
+	mutable DataFormat format = FORMAT_3;
 
 	static constexpr float FP_ADJUST = 0.00001;
 


### PR DESCRIPTION
Sooo this is a bit of a weird error, but basically, when a TileMap was created but not saved to disk, it would assume the oldest format of TileMap. This caused issue when handling tile_data undo/redo, and maybe some other things I am not aware of.

This could cause some issues if we imported really old TileMaps, but since the format is mentioned first as the first property in 3.x it should be fine.

Fixes [#56454](https://github.com/godotengine/godot/issues/56454)