### PR TITLE
C#: Implement `ExportPlugin::_get_name` and move `GLOBAL_DEF` to CSharpLanguage

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -652,6 +652,13 @@
 			See [enum DisplayServer.VSyncMode] for possible values and how they affect the behavior of your application.
 			Depending on the platform and used renderer, the engine will fall back to [code]Enabled[/code], if the desired mode is not supported.
 		</member>
+		<member name="dotnet/project/assembly_name" type="String" setter="" getter="" default="&quot;&quot;">
+			Name of the .NET assembly. This name is used as the name of the [code].csproj[/code] and [code].sln[/code] files. By default, it's set to the name of the project ([member application/config/name]) allowing to change it in the future without affecting the .NET assembly.
+		</member>
+		<member name="dotnet/project/solution_directory" type="String" setter="" getter="" default="&quot;&quot;">
+			Directory that contains the [code].sln[/code] file. By default, the [code].sln[/code] files is in the root of the project directory, next to the [code]project.godot[/code] and [code].csproj[/code] files.
+			Changing this value allows setting up a multi-project scenario where there are multiple [code].csproj[/code]. Keep in mind that the Godot project is considered one of the C# projects in the workspace and it's root directory should contain the [code]project.godot[/code] and [code].csproj[/code] next to each other.
+		</member>
 		<member name="editor/movie_writer/disable_vsync" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], requests V-Sync to be disabled when writing a movie (similar to setting [member display/window/vsync/vsync_mode] to [b]Disabled[/b]). This can speed up video writing if the hardware is fast enough to render, encode and save the video at a framerate higher than the monitor's refresh rate.
 			[b]Note:[/b] [member editor/movie_writer/disable_vsync] has no effect if the operating system or graphics driver forces V-Sync with no way for applications to disable it.

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -113,6 +113,11 @@ void CSharpLanguage::init() {
 	BindingsGenerator::handle_cmdline_args(cmdline_args);
 #endif
 
+	GLOBAL_DEF("dotnet/project/assembly_name", "");
+#ifdef TOOLS_ENABLED
+	GLOBAL_DEF("dotnet/project/solution_directory", "");
+#endif
+
 	gdmono = memnew(GDMono);
 	gdmono->initialize();
 

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -17,6 +17,8 @@ namespace GodotTools.Export
 {
     public partial class ExportPlugin : EditorExportPlugin
     {
+        public override string _GetName() => "C#";
+
         private List<string> _tempFolders = new List<string>();
 
         public void RegisterExportSettings()

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -411,8 +411,6 @@ namespace GodotTools
 
             _editorSettings = editorInterface.GetEditorSettings();
 
-            GodotSharpDirs.RegisterProjectSettings();
-
             _errorDialog = new AcceptDialog();
             editorBaseControl.AddChild(_errorDialog);
 

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
@@ -48,12 +48,6 @@ namespace GodotTools.Internals
             }
         }
 
-        public static void RegisterProjectSettings()
-        {
-            GlobalDef("dotnet/project/assembly_name", "");
-            GlobalDef("dotnet/project/solution_directory", "");
-        }
-
         public static void DetermineProjectLocation()
         {
             static string DetermineProjectName()


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/71608.
- Also documents the .NET project settings.