### PR TITLE
Adds more Collision features to CSGShape3D when use_collision is enabled

### DIFF
--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -42,6 +42,13 @@
 				Returns the camera's frustum planes in world space units as an array of [Plane]s in the following order: near, far, left, top, right, bottom. Not to be confused with [member frustum_offset].
 			</description>
 		</method>
+		<method name="get_pick_mask_value" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="layer_number" type="int" />
+			<description>
+				Returns whether or not the specified layer of the [member pick_mask] is enabled, given a [code]layer_number[/code] between 1 and 32.
+			</description>
+		</method>
 		<method name="get_pyramid_shape_rid">
 			<return type="RID" />
 			<description>
@@ -134,6 +141,14 @@
 				Sets the camera projection to perspective mode (see [constant PROJECTION_PERSPECTIVE]), by specifying a [param fov] (field of view) angle in degrees, and the [param z_near] and [param z_far] clip planes in world space units.
 			</description>
 		</method>
+		<method name="set_pick_mask_value">
+			<return type="void" />
+			<param index="0" name="layer_number" type="int" />
+			<param index="1" name="value" type="bool" />
+			<description>
+				Based on [code]value[/code], enables or disables the specified layer in the [member pick_mask], given a [code]layer_number[/code] between 1 and 32.
+			</description>
+		</method>
 		<method name="unproject_position" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="world_point" type="Vector3" />
@@ -189,6 +204,9 @@
 		</member>
 		<member name="near" type="float" setter="set_near" getter="get_near" default="0.05">
 			The distance to the near culling boundary for this camera relative to its local Z axis.
+		</member>
+		<member name="pick_mask" type="int" setter="set_pick_mask" getter="get_pick_mask" default="4294967295">
+			The physics layers this camera scans for picking rays.
 		</member>
 		<member name="projection" type="int" setter="set_projection" getter="get_projection" enum="Camera3D.ProjectionType" default="0">
 			The camera's projection mode. In [constant PROJECTION_PERSPECTIVE] mode, objects' Z distance from the camera's local space scales their perceived size.

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -34,6 +34,7 @@
 #define CSGJS_HEADER_ONLY
 
 #include "csg.h"
+#include "scene/3d/camera_3d.h"
 #include "scene/3d/path_3d.h"
 #include "scene/3d/visual_instance_3d.h"
 #include "scene/resources/concave_polygon_shape_3d.h"
@@ -68,6 +69,9 @@ private:
 	real_t collision_priority = 1.0;
 	Ref<ConcavePolygonShape3D> root_collision_shape;
 	RID root_collision_instance;
+
+	bool ray_pickable = true;
+	bool capture_input_on_drag = false;
 
 	bool calculate_tangents = true;
 
@@ -107,6 +111,7 @@ private:
 
 	void _update_shape();
 	void _update_collision_faces();
+	void _update_pickable();
 
 protected:
 	void _notification(int p_what);
@@ -120,6 +125,14 @@ protected:
 
 	void _validate_property(PropertyInfo &p_property) const;
 
+	friend class Viewport;
+	virtual void _input_event_call(Camera3D *p_camera, const Ref<InputEvent> &p_input_event, const Vector3 &p_pos, const Vector3 &p_normal, int p_shape);
+	virtual void _mouse_enter();
+	virtual void _mouse_exit();
+
+	GDVIRTUAL5(_input_event, Camera3D *, Ref<InputEvent>, Vector3, Vector3, int)
+	GDVIRTUAL0(_mouse_enter)
+	GDVIRTUAL0(_mouse_exit)
 public:
 	Array get_meshes() const;
 
@@ -147,6 +160,12 @@ public:
 
 	void set_collision_priority(real_t p_priority);
 	real_t get_collision_priority() const;
+
+	void set_ray_pickable(bool p_ray_pickable);
+	bool is_ray_pickable() const;
+
+	void set_capture_input_on_drag(bool p_capture);
+	bool get_capture_input_on_drag() const;
 
 	void set_snap(float p_snap);
 	float get_snap() const;

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -11,6 +11,30 @@
 		<link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
 	</tutorials>
 	<methods>
+		<method name="_input_event" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="camera" type="Camera3D" />
+			<param index="1" name="event" type="InputEvent" />
+			<param index="2" name="position" type="Vector3" />
+			<param index="3" name="normal" type="Vector3" />
+			<param index="4" name="shape_idx" type="int" />
+			<description>
+				Receives unhandled [InputEvent]s. [param position] is the location in world space of the mouse pointer on the surface of the shape with index [param shape_idx] and [param normal] is the normal vector of the surface at that point. Connect to the [signal input_event] signal to easily pick up these events.
+				[b]Note:[/b] [method _input_event] requires [member use_collision] and [member input_ray_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set.
+			</description>
+		</method>
+		<method name="_mouse_enter" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the mouse pointer enters any of this object's shapes. Requires [member use_collision] and [member input_ray_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set. Note that moving between different shapes within a single [CSGShape3D] won't cause this function to be called.
+			</description>
+		</method>
+		<method name="_mouse_exit" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the mouse pointer exits all this object's shapes. Requires [member use_collision] and [member input_ray_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set. Note that moving between different shapes within a single [CSGShape3D] won't cause this function to be called.
+			</description>
+		</method>
 		<method name="get_collision_layer_value" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
@@ -69,6 +93,12 @@
 		<member name="collision_priority" type="float" setter="set_collision_priority" getter="get_collision_priority" default="1.0">
 			The priority used to solve colliding when occurring penetration. Only effective if [member use_collision] is [code]true[/code]. The higher the priority is, the lower the penetration into the object will be. This can for example be used to prevent the player from breaking through the boundaries of a level.
 		</member>
+		<member name="input_capture_on_drag" type="bool" setter="set_capture_input_on_drag" getter="get_capture_input_on_drag" default="false">
+			If [code]true[/code], the [CSGShape3D] will continue to receive input events as the mouse is dragged across its shapes.
+		</member>
+		<member name="input_ray_pickable" type="bool" setter="set_ray_pickable" getter="is_ray_pickable" default="true">
+			If [code]true[/code], this object is pickable. A pickable object can detect the mouse pointer entering/leaving, and if the mouse is inside it, report input events. Requires at least one [member collision_layer] bit to be set.
+		</member>
 		<member name="operation" type="int" setter="set_operation" getter="get_operation" enum="CSGShape3D.Operation" default="0">
 			The operation that is performed on this shape. This is ignored for the first CSG child node as the operation is between this node and the previous child of this nodes parent.
 		</member>
@@ -79,6 +109,31 @@
 			Adds a collision shape to the physics engine for our CSG shape. This will always act like a static body. Note that the collision shape is still active even if the CSG shape itself is hidden. See also [member collision_mask] and [member collision_priority].
 		</member>
 	</members>
+	<signals>
+		<signal name="input_event">
+			<param index="0" name="camera" type="Node" />
+			<param index="1" name="event" type="InputEvent" />
+			<param index="2" name="position" type="Vector3" />
+			<param index="3" name="normal" type="Vector3" />
+			<param index="4" name="shape_idx" type="int" />
+			<description>
+				Emitted when the object receives an unhandled [InputEvent]. [param position] is the location in world space of the mouse pointer on the surface of the shape with index [param shape_idx] and [param normal] is the normal vector of the surface at that point.
+				[b]Note:[/b] [signal input_event] requires [member use_collision] and [member input_ray_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set.
+			</description>
+		</signal>
+		<signal name="mouse_entered">
+			<description>
+				Emitted when the mouse pointer enters any of this object's shapes. Requires [member use_collision] and [member input_ray_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set.
+				[b]Note:[/b] Due to the lack of continuous collision detection, this signal may not be emitted in the expected order if the mouse moves fast enough and the [CSGShape3D]'s area is small. This signal may also not be emitted if another [CSGShape3D] is overlapping the [CSGShape3D] in question.
+			</description>
+		</signal>
+		<signal name="mouse_exited">
+			<description>
+				Emitted when the mouse pointer exits all this object's shapes. Requires [member use_collision] and [member input_ray_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set.
+				[b]Note:[/b] Due to the lack of continuous collision detection, this signal may not be emitted in the expected order if the mouse moves fast enough and the [CSGShape3D]'s area is small. This signal may also not be emitted if another [CSGShape3D] is overlapping the [CSGShape3D] in question.
+			</description>
+		</signal>
+	</signals>
 	<constants>
 		<constant name="OPERATION_UNION" value="0" enum="Operation">
 			Geometry of both primitives is merged, intersecting geometry is removed.

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -526,6 +526,8 @@ void Camera3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_v_offset"), &Camera3D::get_v_offset);
 	ClassDB::bind_method(D_METHOD("set_cull_mask", "mask"), &Camera3D::set_cull_mask);
 	ClassDB::bind_method(D_METHOD("get_cull_mask"), &Camera3D::get_cull_mask);
+	ClassDB::bind_method(D_METHOD("set_pick_mask", "pick_mask"), &Camera3D::set_pick_mask);
+	ClassDB::bind_method(D_METHOD("get_pick_mask"), &Camera3D::get_pick_mask);
 	ClassDB::bind_method(D_METHOD("set_environment", "env"), &Camera3D::set_environment);
 	ClassDB::bind_method(D_METHOD("get_environment"), &Camera3D::get_environment);
 	ClassDB::bind_method(D_METHOD("set_attributes", "env"), &Camera3D::set_attributes);
@@ -541,11 +543,14 @@ void Camera3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_cull_mask_value", "layer_number", "value"), &Camera3D::set_cull_mask_value);
 	ClassDB::bind_method(D_METHOD("get_cull_mask_value", "layer_number"), &Camera3D::get_cull_mask_value);
+	ClassDB::bind_method(D_METHOD("set_pick_mask_value", "layer_number", "value"), &Camera3D::set_pick_mask_value);
+	ClassDB::bind_method(D_METHOD("get_pick_mask_value", "layer_number"), &Camera3D::get_pick_mask_value);
 
 	//ClassDB::bind_method(D_METHOD("_camera_make_current"),&Camera::_camera_make_current );
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "keep_aspect", PROPERTY_HINT_ENUM, "Keep Width,Keep Height"), "set_keep_aspect_mode", "get_keep_aspect_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "cull_mask", PROPERTY_HINT_LAYERS_3D_RENDER), "set_cull_mask", "get_cull_mask");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "pick_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_pick_mask", "get_pick_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "environment", PROPERTY_HINT_RESOURCE_TYPE, "Environment"), "set_environment", "get_environment");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "attributes", PROPERTY_HINT_RESOURCE_TYPE, "CameraAttributesPractical,CameraAttributesPhysical"), "set_attributes", "get_attributes");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "h_offset", PROPERTY_HINT_NONE, "suffix:m"), "set_h_offset", "get_h_offset");
@@ -648,6 +653,32 @@ bool Camera3D::get_cull_mask_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Render layer number must be between 1 and 20 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 20, false, "Render layer number must be between 1 and 20 inclusive.");
 	return layers & (1 << (p_layer_number - 1));
+}
+
+void Camera3D::set_pick_mask(uint32_t p_layers) {
+	pick_layers = p_layers;
+}
+
+uint32_t Camera3D::get_pick_mask() const {
+	return pick_layers;
+}
+
+void Camera3D::set_pick_mask_value(int p_layer_number, bool p_value) {
+	ERR_FAIL_COND_MSG(p_layer_number < 1, "Pick layer number must be between 1 and 32 inclusive.");
+	ERR_FAIL_COND_MSG(p_layer_number > 32, "Pick layer number must be between 1 and 32 inclusive.");
+	uint32_t mask = get_pick_mask();
+	if (p_value) {
+		mask |= 1 << (p_layer_number - 1);
+	} else {
+		mask &= ~(1 << (p_layer_number - 1));
+	}
+	set_pick_mask(mask);
+}
+
+bool Camera3D::get_pick_mask_value(int p_layer_number) const {
+	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Pick layer number must be between 1 and 32 inclusive.");
+	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Pick layer number must be between 1 and 32 inclusive.");
+	return pick_layers & (1 << (p_layer_number - 1));
 }
 
 Vector<Plane> Camera3D::get_frustum() const {

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -78,7 +78,8 @@ private:
 
 	// String camera_group;
 
-	uint32_t layers = 0xfffff;
+	uint32_t layers = 0xfffff; // cull_layers
+	uint32_t pick_layers = 0xffffffff;
 
 	Ref<Environment> environment;
 	Ref<CameraAttributes> attributes;
@@ -153,6 +154,12 @@ public:
 
 	void set_cull_mask_value(int p_layer_number, bool p_enable);
 	bool get_cull_mask_value(int p_layer_number) const;
+
+	void set_pick_mask(uint32_t p_layers);
+	uint32_t get_pick_mask() const;
+
+	void set_pick_mask_value(int p_layer_number, bool p_enable);
+	bool get_pick_mask_value(int p_layer_number) const;
 
 	virtual Vector<Plane> get_frustum() const;
 	bool is_position_in_frustum(const Vector3 &p_position) const;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -39,6 +39,10 @@ class Camera3D;
 class CollisionObject3D;
 class AudioListener3D;
 class World3D;
+#include "modules/modules_enabled.gen.h" // For csg.
+#ifdef MODULE_CSG_ENABLED
+class CSGShape3D;
+#endif // MODULE_CSG_ENABLED
 #endif // _3D_DISABLED
 
 class AudioListener2D;
@@ -668,6 +672,9 @@ public:
 	void _audio_listener_3d_make_next_current(AudioListener3D *p_exclude);
 
 	void _collision_object_3d_input_event(CollisionObject3D *p_object, Camera3D *p_camera, const Ref<InputEvent> &p_input_event, const Vector3 &p_pos, const Vector3 &p_normal, int p_shape);
+#ifdef MODULE_CSG_ENABLED
+	void _csg_shape_3d_input_event(CSGShape3D *p_object, Camera3D *p_camera, const Ref<InputEvent> &p_input_event, const Vector3 &p_pos, const Vector3 &p_normal, int p_shape);
+#endif // MODULE_CSG_ENABLED
 
 	struct Camera3DOverrideData {
 		Transform3D transform;


### PR DESCRIPTION
# Context

I'm developing an architectural visualization project where the walls have openings (doors) but must be pickable for editing, even when hovering these openings.
I'm using the CSGCombiner3D nodes to create the walls and settings `use_collision=true` to make the first-person collision, where the player must pass through the doors, but I'm also creating an Area3D matching the walls' extent to allow the picking action.

# Previous Behaviour

There were two issues when performing these actions: first, the camera pick didn't limit the pickable layers so, every physics objects were pickable. And second, despite the CSGShape3D objects creating the physics shapes, they didn't expose the picking properties and the `input_event`, `mouse_enter`, and `mouse_exit` signals.

# Solution

I copied the CollisionObject3D properties and signals to the CSGShape3D to make them compatible and also added a picking mask to the Camera3D to allow limiting the physics layers it works on.

The previous behaviour is kept so it doesn't break the compatibility.

![image](https://user-images.githubusercontent.com/1322552/213289801-69ea979c-c9af-4d5f-a2f7-8de4bda51115.png)
![image](https://user-images.githubusercontent.com/1322552/213289866-dfeadc42-a731-40bc-a554-d025efdc41ce.png)
