### PR TITLE
Complete support of callables of static methods

### DIFF
--- a/core/object/callable_method_pointer.h
+++ b/core/object/callable_method_pointer.h
@@ -198,7 +198,7 @@ class CallableCustomMethodPointerRetC : public CallableCustomMethodPointerBase {
 	} data;
 
 public:
-	virtual ObjectID get_object() const {
+	virtual ObjectID get_object() const override {
 #ifdef DEBUG_ENABLED
 		if (ObjectDB::get_instance(ObjectID(data.object_id)) == nullptr) {
 			return ObjectID();
@@ -207,7 +207,7 @@ public:
 		return data.instance->get_instance_id();
 	}
 
-	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
+	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override {
 #ifdef DEBUG_ENABLED
 		ERR_FAIL_COND_MSG(ObjectDB::get_instance(ObjectID(data.object_id)) == nullptr, "Invalid Object id '" + uitos(data.object_id) + "', can't call method.");
 #endif
@@ -254,11 +254,15 @@ class CallableCustomStaticMethodPointer : public CallableCustomMethodPointerBase
 	} data;
 
 public:
-	virtual ObjectID get_object() const {
+	virtual bool is_valid() const override {
+		return true;
+	}
+
+	virtual ObjectID get_object() const override {
 		return ObjectID();
 	}
 
-	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
+	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override {
 		call_with_variant_args_static_ret(data.method, p_arguments, p_argcount, r_return_value, r_call_error);
 		r_return_value = Variant();
 	}
@@ -292,11 +296,15 @@ class CallableCustomStaticMethodPointerRet : public CallableCustomMethodPointerB
 	} data;
 
 public:
-	virtual ObjectID get_object() const {
+	virtual bool is_valid() const override {
+		return true;
+	}
+
+	virtual ObjectID get_object() const override {
 		return ObjectID();
 	}
 
-	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
+	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override {
 		call_with_variant_args_static_ret(data.method, p_arguments, p_argcount, r_return_value, r_call_error);
 	}
 

--- a/core/object/message_queue.h
+++ b/core/object/message_queue.h
@@ -51,8 +51,9 @@ private:
 		TYPE_NOTIFICATION,
 		TYPE_SET,
 		TYPE_END, // End marker.
+		FLAG_NULL_IS_OK = 1 << 13,
 		FLAG_SHOW_ERROR = 1 << 14,
-		FLAG_MASK = FLAG_SHOW_ERROR - 1,
+		FLAG_MASK = FLAG_NULL_IS_OK - 1,
 	};
 
 	struct Page {

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -122,7 +122,11 @@ Callable Callable::unbind(int p_argcount) const {
 }
 
 bool Callable::is_valid() const {
-	return get_object() && (is_custom() || get_object()->has_method(get_method()));
+	if (is_custom()) {
+		return get_custom()->is_valid();
+	} else {
+		return get_object() && get_object()->has_method(get_method());
+	}
 }
 
 Object *Callable::get_object() const {
@@ -371,6 +375,11 @@ Callable::~Callable() {
 			memdelete(custom);
 		}
 	}
+}
+
+bool CallableCustom::is_valid() const {
+	// Sensible default implementation so most custom callables don't need their own.
+	return ObjectDB::get_instance(get_object());
 }
 
 StringName CallableCustom::get_method() const {

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -145,8 +145,9 @@ public:
 	virtual String get_as_text() const = 0;
 	virtual CompareEqualFunc get_compare_equal_func() const = 0;
 	virtual CompareLessFunc get_compare_less_func() const = 0;
+	virtual bool is_valid() const;
 	virtual StringName get_method() const;
-	virtual ObjectID get_object() const = 0; //must always be able to provide an object
+	virtual ObjectID get_object() const = 0;
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const = 0;
 	virtual Error rpc(int p_peer_id, const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) const;
 	virtual const Callable *get_base_comparator() const;

--- a/core/variant/callable_bind.cpp
+++ b/core/variant/callable_bind.cpp
@@ -75,6 +75,10 @@ CallableCustom::CompareLessFunc CallableCustomBind::get_compare_less_func() cons
 	return _less_func;
 }
 
+bool CallableCustomBind::is_valid() const {
+	return callable.is_valid();
+}
+
 StringName CallableCustomBind::get_method() const {
 	return callable.get_method();
 }
@@ -191,6 +195,10 @@ CallableCustom::CompareEqualFunc CallableCustomUnbind::get_compare_equal_func() 
 
 CallableCustom::CompareLessFunc CallableCustomUnbind::get_compare_less_func() const {
 	return _less_func;
+}
+
+bool CallableCustomUnbind::is_valid() const {
+	return callable.is_valid();
 }
 
 StringName CallableCustomUnbind::get_method() const {

--- a/core/variant/callable_bind.h
+++ b/core/variant/callable_bind.h
@@ -47,8 +47,9 @@ public:
 	virtual String get_as_text() const override;
 	virtual CompareEqualFunc get_compare_equal_func() const override;
 	virtual CompareLessFunc get_compare_less_func() const override;
+	virtual bool is_valid() const override;
 	virtual StringName get_method() const override;
-	virtual ObjectID get_object() const override; //must always be able to provide an object
+	virtual ObjectID get_object() const override;
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 	virtual const Callable *get_base_comparator() const override;
 	virtual int get_bound_arguments_count() const override;
@@ -73,8 +74,9 @@ public:
 	virtual String get_as_text() const override;
 	virtual CompareEqualFunc get_compare_equal_func() const override;
 	virtual CompareLessFunc get_compare_less_func() const override;
+	virtual bool is_valid() const override;
 	virtual StringName get_method() const override;
-	virtual ObjectID get_object() const override; //must always be able to provide an object
+	virtual ObjectID get_object() const override;
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 	virtual const Callable *get_base_comparator() const override;
 	virtual int get_bound_arguments_count() const override;


### PR DESCRIPTION
We now have the possibility of creating a callable out of a static function, but it had a couple of flaws:
1. Since the `MessageQueue` checks for the target object being non-null, `push_callable()` wouldn't work with static calls. Upon reaching the corresponding call during a flush it would just be skipped. In other words, `callable_mp_static(&SomeClass::some_static_function).call_deferred();` is helpless.
2. There's the concept of a valid callable. The only implementation was in `Callable::is_valid()`, enforcing that at least the object was non-null. Therefore, the custom callables implementing static calls (`CallableCustomStaticMethodPointer*`), that have a null target object by nature, wouldn't be able to claim themselves as valid.

This PR improves the situation by doing the following, respectively:
1. Enhances the `MessageQueue` so it remembers if the `Callable` backing a call message was originally a `Callable`, in which case it will accept a null target object as long as the callable validation tells that's OK.
2. Allows the custom callables to perform the kind of validation that make sense for each, with a reasonable default implementation.

This changes are needed for #71280 and ~#71644~ #72855, where callables to static methods are used.

This is ready for review, but I'll tag it as _Needs testing_ until I'm sure it won't cause regressions.

**UPDATE:** Version for 4.0 is #75994.