### PR TITLE
[Android export] Added validation of the project name when using $genname in the 'Unique Name' field.

### DIFF
--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -91,9 +91,12 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 	String get_package_name(const String &p_package) const;
 
+	String get_valid_basename() const;
+
 	String get_assets_directory(const Ref<EditorExportPreset> &p_preset, int p_export_format) const;
 
 	bool is_package_name_valid(const String &p_package, String *r_error = nullptr) const;
+	bool is_project_name_valid() const;
 
 	static bool _should_compress_asset(const String &p_path, const Vector<uint8_t> &p_data);
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #71645.