### PR TITLE
Use a fixed width of 1 pixel for editor debug UV drawing

### DIFF
--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -460,7 +460,7 @@ void MeshInstance3DEditor::_debug_uv_draw() {
 	debug_uv->draw_rect(Rect2(Vector2(), debug_uv->get_size()), get_theme_color(SNAME("dark_color_3"), SNAME("Editor")));
 	debug_uv->draw_set_transform(Vector2(), 0, debug_uv->get_size());
 	// Use a translucent color to allow overlapping triangles to be visible.
-	debug_uv->draw_multiline(uv_lines, get_theme_color(SNAME("mono_color"), SNAME("Editor")) * Color(1, 1, 1, 0.5), Math::round(EDSCALE));
+	debug_uv->draw_multiline(uv_lines, get_theme_color(SNAME("mono_color"), SNAME("Editor")) * Color(1, 1, 1, 0.5));
 }
 
 void MeshInstance3DEditor::_create_outline_mesh() {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/71647

Because the transform makes it so that the scene is super zoomed in the fixed line widths ended up being huge. Instead we use the default setting and keep the line width at one pixel wide. This likely wasn't caught before https://github.com/godotengine/godot/pull/69851 because the EDSCALE just happened to be 1 (which was the old default) which meant that the fixed width of 1 was used. 

CC @dalexeev