### PR TITLE
Expose and document ProjectSettings.get_global_class_list()

### DIFF
--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -37,6 +37,9 @@
 #include "core/templates/local_vector.h"
 #include "core/templates/rb_set.h"
 
+template <typename T>
+class TypedArray;
+
 class ProjectSettings : public Object {
 	GDCLASS(ProjectSettings, Object);
 	_THREAD_SAFE_CLASS_
@@ -99,6 +102,9 @@ protected:
 
 	HashMap<StringName, AutoloadInfo> autoloads;
 
+	Array global_class_list;
+	bool is_global_class_list_loaded = false;
+
 	String project_data_dir_name;
 
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -141,7 +147,7 @@ public:
 
 	void set_setting(const String &p_setting, const Variant &p_value);
 	Variant get_setting(const String &p_setting, const Variant &p_default_value = Variant()) const;
-	Array get_global_class_list();
+	TypedArray<Dictionary> get_global_class_list();
 	void store_global_class_list(const Array &p_classes);
 	String get_global_class_list_path() const;
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -60,6 +60,18 @@
 				Clears the whole configuration (not recommended, may break things).
 			</description>
 		</method>
+		<method name="get_global_class_list">
+			<return type="Dictionary[]" />
+			<description>
+				Returns an [Array] of registered global classes. Each global class is represented as a [Dictionary] that contains the following entries:
+				- [code]base[/code] is a name of the base class;
+				- [code]class[/code] is a name of the registered global class;
+				- [code]icon[/code] is a path to a custom icon of the global class, if it has any;
+				- [code]language[/code] is a name of a programming language in which the global class is written;
+				- [code]path[/code] is a path to a file containing the global class.
+				[b]Note:[/b] Both the script and the icon paths are local to the project filesystem, i.e. they start with [code]res://[/code].
+			</description>
+		</method>
 		<method name="get_order" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="name" type="String" />

--- a/doc/classes/Variant.xml
+++ b/doc/classes/Variant.xml
@@ -38,7 +38,7 @@
 		        # To get the name of the underlying Object type, you need the `get_class()` method.
 		        print("foo is a(n) %s" % foo.get_class()) # inject the class name into a formatted string.
 		        # Note also that there is not yet any way to get a script's `class_name` string easily.
-		        # To fetch that value, you can parse the [code]res://.godot/global_script_class_cache.cfg[/code] file with the [ConfigFile] API.
+		        # To fetch that value, you can use [member ProjectSettings.get_global_class_list].
 		        # Open your project.godot file to see it up close.
 		[/gdscript]
 		[csharp]


### PR DESCRIPTION
Exposes a better way to get global script classes now that https://github.com/godotengine/godot/pull/70557 is merged. The currently supported and documented way feels really sketchy, you have to read and parse a random config file in a hidden directory. If I saw that in a project code without knowing it, I would assume it's some kind of fragile hack to get some undocumented data. We have the API call now, so why not expose it to users instead? This also makes it possible to easily change the actual storage implementation later without breaking all user code. Also see https://github.com/godotengine/godot-docs/issues/6632