### PR TITLE
Enable column clip content in SceneTreeEditor

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1411,6 +1411,7 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 	tree->set_begin(Point2(0, p_label ? 18 : 0));
 	tree->set_end(Point2(0, 0));
 	tree->set_allow_reselect(true);
+	tree->set_column_clip_content(0, true);
 	tree->add_theme_constant_override("button_margin", 0);
 
 	add_child(tree);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/68218#issuecomment-1386957073
Enable column clip content in SceneTreeEditor.
| Before | After |
| --- | --- |
|![image](https://user-images.githubusercontent.com/1756388/213421729-f3acf626-5f34-4ce3-bec7-931e69d966be.png)| ![image](https://user-images.githubusercontent.com/1756388/213421642-904e174d-a0db-4490-8eee-3765f7cc90bc.png)|