### PR TITLE
[3.x] Let make_rst.py be forward compatible with 4.0's

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -345,6 +345,11 @@ def main():  # type: () -> None
     parser.add_argument("path", nargs="+", help="A path to an XML file or a directory containing XML files to parse.")
     parser.add_argument("--filter", default="", help="The filepath pattern for XML files to filter.")
     parser.add_argument("--lang", "-l", default="en", help="Language to use for section headings.")
+    parser.add_argument(
+        "--color",
+        action="store_true",
+        help="Ignored. Supported for forward compatibility.",
+    )
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--output", "-o", default=".", help="The directory to save output .rst files in.")
     group.add_argument(


### PR DESCRIPTION
If you're using a worktree-based workflow with Git involving Godot 3 and 4, you need this so your unique set of hooks (i.e., those from 4.0) don't error on 3.x worktrees.

**NOTE:** I think that some day it won't be possible to keep compatibility, but as of now this patch does the trick until that dark day arrives.