### PR TITLE
Further fixes to global script class parsing

### DIFF
--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -261,6 +261,7 @@ class EditorFileSystem : public Node {
 	HashSet<String> update_script_paths;
 	void _queue_update_script_class(const String &p_path);
 	void _update_script_classes();
+	void _update_pending_script_classes();
 
 	String _get_global_script_class(const String &p_type, const String &p_path, String *r_extends, String *r_icon_path) const;
 


### PR DESCRIPTION
Bugs were introduced on first parse by #71628

This should fix everything remaining. No errors of any type were observed.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
