### PR TITLE
Add support for Unicode identifiers in GDScript and Expression

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -434,14 +434,13 @@ Error Expression::_get_token(Token &r_token) {
 					}
 					return OK;
 
-				} else if (is_ascii_char(cchar) || is_underscore(cchar)) {
-					String id;
-					bool first = true;
+				} else if (is_unicode_identifier_start(cchar)) {
+					String id = String::chr(cchar);
+					cchar = GET_CHAR();
 
-					while (is_ascii_char(cchar) || is_underscore(cchar) || (!first && is_digit(cchar))) {
+					while (is_unicode_identifier_continue(cchar)) {
 						id += String::chr(cchar);
 						cchar = GET_CHAR();
-						first = false;
 					}
 
 					str_ofs--; //go back one

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -384,6 +384,9 @@
 		<member name="debug/gdscript/warnings/assert_always_true" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when an [code]assert[/code] call always evaluates to true.
 		</member>
+		<member name="debug/gdscript/warnings/confusable_identifier" type="int" setter="" getter="" default="1">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when an indentifier contains characters that can be confused with something else, like when mixing different alphabets.
+		</member>
 		<member name="debug/gdscript/warnings/constant_used_as_function" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a constant is used as a function.
 		</member>

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1361,8 +1361,11 @@ private:
 	void clear();
 	void push_error(const String &p_message, const Node *p_origin = nullptr);
 #ifdef DEBUG_ENABLED
-	void push_warning(const Node *p_source, GDScriptWarning::Code p_code, const String &p_symbol1 = String(), const String &p_symbol2 = String(), const String &p_symbol3 = String(), const String &p_symbol4 = String());
 	void push_warning(const Node *p_source, GDScriptWarning::Code p_code, const Vector<String> &p_symbols);
+	template <typename... Symbols>
+	void push_warning(const Node *p_source, GDScriptWarning::Code p_code, const Symbols &...p_symbols) {
+		push_warning(p_source, p_code, Vector<String>{ p_symbols... });
+	}
 #endif
 
 	void make_completion_context(CompletionType p_type, Node *p_node, int p_argument = -1, bool p_force = false);

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -224,6 +224,9 @@ private:
 	char32_t indent_char = '\0';
 	int position = 0;
 	int length = 0;
+#ifdef DEBUG_ENABLED
+	Vector<String> keyword_list;
+#endif // DEBUG_ENABLED
 
 #ifdef TOOLS_ENABLED
 	HashMap<int, CommentData> comments;
@@ -238,6 +241,10 @@ private:
 	String _get_indent_char_name(char32_t ch);
 	void _skip_whitespace();
 	void check_indent();
+
+#ifdef DEBUG_ENABLED
+	void make_keyword_list();
+#endif // DEBUG_ENABLED
 
 	Token make_error(const String &p_message);
 	void push_error(const String &p_message);

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -155,6 +155,10 @@ String GDScriptWarning::get_message() const {
 			CHECK_SYMBOLS(2);
 			return vformat(R"(The function '%s()' is a static function but was called from an instance. Instead, it should be directly called from the type: '%s.%s()'.)", symbols[0], symbols[1], symbols[0]);
 		}
+		case CONFUSABLE_IDENTIFIER: {
+			CHECK_SYMBOLS(1);
+			return vformat(R"(The identifier "%s" has misleading characters and might be confused with something else.)", symbols[0]);
+		}
 		case WARNING_MAX:
 			break; // Can't happen, but silences warning
 	}
@@ -219,6 +223,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"SHADOWED_GLOBAL_IDENTIFIER",
 		"INT_ASSIGNED_TO_ENUM",
 		"STATIC_CALLED_ON_INSTANCE",
+		"CONFUSABLE_IDENTIFIER",
 	};
 
 	static_assert((sizeof(names) / sizeof(*names)) == WARNING_MAX, "Amount of warning types don't match the amount of warning names.");

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -78,6 +78,7 @@ public:
 		SHADOWED_GLOBAL_IDENTIFIER, // A global class or function has the same name as variable.
 		INT_ASSIGNED_TO_ENUM, // An integer value was assigned to an enum-typed variable without casting.
 		STATIC_CALLED_ON_INSTANCE, // A static method was called on an instance of a class instead of on the class itself.
+		CONFUSABLE_IDENTIFIER, // The identifier contains misleading characters that can be confused. E.g. "usеr" (has Cyrillic "е" instead of Latin "e").
 		WARNING_MAX,
 	};
 

--- a/modules/gdscript/tests/scripts/analyzer/warnings/lambda_unused_arg.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/lambda_unused_arg.out
@@ -2,4 +2,4 @@ GDTEST_OK
 >> WARNING
 >> Line: 2
 >> UNUSED_PARAMETER
->>
+>> The parameter 'unused' is never used in the function ''. If this is intended, prefix it with an underscore: '_unused'

--- a/modules/gdscript/tests/scripts/parser/errors/identifier_similar_to_keyword.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/identifier_similar_to_keyword.gd
@@ -1,0 +1,3 @@
+func test():
+	var аs # Using Cyrillic "а".
+	print(аs)

--- a/modules/gdscript/tests/scripts/parser/errors/identifier_similar_to_keyword.out
+++ b/modules/gdscript/tests/scripts/parser/errors/identifier_similar_to_keyword.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Identifier "аs" is visually similar to the GDScript keyword "as" and thus not allowed.

--- a/modules/gdscript/tests/scripts/parser/features/unicode_identifiers.gd
+++ b/modules/gdscript/tests/scripts/parser/features/unicode_identifiers.gd
@@ -1,0 +1,35 @@
+const π = PI
+var ㄥ = π
+
+func test():
+	var փորձարկում = "test"
+	prints("փորձարկում", փորձարկում)
+	var امتحان = "test"
+	prints("امتحان", امتحان)
+	var পরীক্ষা = "test"
+	prints("পরীক্ষা", পরীক্ষা)
+	var тест = "test"
+	prints("тест", тест)
+	var जाँच = "test"
+	prints("जाँच", जाँच)
+	var 기준 = "test"
+	prints("기준", 기준)
+	var 测试 = "test"
+	prints("测试", 测试)
+	var テスト = "test"
+	prints("テスト", テスト)
+	var 試験 = "test"
+	prints("試験", 試験)
+	var പരീക്ഷ = "test"
+	prints("പരീക്ഷ", പരീക്ഷ)
+	var ทดสอบ = "test"
+	prints("ทดสอบ", ทดสอบ)
+	var δοκιμή = "test"
+	prints("δοκιμή", δοκιμή)
+
+	const d = 1.1
+	_process(d)
+	print(is_equal_approx(ㄥ, PI + (d * PI)))
+
+func _process(Δ: float) -> void:
+	ㄥ += Δ * π

--- a/modules/gdscript/tests/scripts/parser/features/unicode_identifiers.out
+++ b/modules/gdscript/tests/scripts/parser/features/unicode_identifiers.out
@@ -1,0 +1,14 @@
+GDTEST_OK
+փորձարկում test
+امتحان test
+পরীক্ষা test
+тест test
+जाँच test
+기준 test
+测试 test
+テスト test
+試験 test
+പരീക്ഷ test
+ทดสอบ test
+δοκιμή test
+true

--- a/modules/gdscript/tests/scripts/parser/warnings/confusable_identifier.gd
+++ b/modules/gdscript/tests/scripts/parser/warnings/confusable_identifier.gd
@@ -1,0 +1,5 @@
+func test():
+	var port = 0 # Only latin characters.
+	var pοrt = 1 # The "ο" is Greek omicron.
+
+	prints(port, pοrt)

--- a/modules/gdscript/tests/scripts/parser/warnings/confusable_identifier.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/confusable_identifier.out
@@ -1,0 +1,6 @@
+GDTEST_OK
+>> WARNING
+>> Line: 3
+>> CONFUSABLE_IDENTIFIER
+>> The identifier "pοrt" has misleading characters and might be confused with something else.
+0 1


### PR DESCRIPTION
This is using an adapted version of UAX#31 to not rely on the ICU database (which isn't available in builds without TextServerAdvanced). It allows most characters used in diverse scripts but not everything.

This is based on the previous work by @bruvzg on #53956.

This depends highly on #71598, otherwise it might show statements in a misleading order when there are RTL words.

![gdscript-unicode-ids](https://user-images.githubusercontent.com/5599796/213452903-94edb25f-b08d-484f-b419-f6dc7f2bb1ab.png)

**Confusable identifiers:** There are two checks for confusable identifiers using the methods of TextServer:

1) Using `spoof_check()` which checks for mixed characters that can be confusing. E.g. `var pοrt`, which uses Greek omicron instead of Latin `o`). This is checked mostly on declarations and only gives a warning.
2) Using `is_confusable()` against the list of GDScript keywords which checks for visual similarities. E.g. `аs`, which uses Cyrillic `а`). This gives an error.

Those checks only work properly if TextServerAdvanced is available. It is by default on official builds, but may be missing on custom builds (in such case they use the fallback noop from the basic TextServer).

**Known issues:**

* While `spoof_check()` gives a warning, visually similar identifiers are treated as different names.
* There are visually similar pairs that won't be able to have any warning if they don't use mixed scripts. E.g `ç` and `ç` (first uses regular "ç" character, that other uses a combining sequence "c+◌̧"). Also: `Å` and `Å` (first is `\u212B`, second is `\u00C5`).
	* One partial solution to this would be forbidding composition characters, except ones that never appears pre-composed. It would fix the first example but not the second. It could also create some hurdles for languages that uses lots of accents.
	* The proper solution would be to perform Unicode normalization. This would make the pairs in the examples become the same identifier, even if using a different codepoint combination. The problem is that this also requires ICU data.
* Visually similar identifiers **won't** be treated as the same nor give **any error or warning** (if they pass `spoof_check()`).
	* We could run the `is_confusable()` check against the list of previously declared identifiers, but that can become quite big overtime, especially if we want to compare with engine classes, global script classes, and singleton autoloads, not to mention the inheritance tree of the current script.
	* I'm am unaware of the full security implications this might have.  
* I used `𝛑` on the screenshot as an example and that creates a confusable identifier warning. I guess this is the mathematical symbol, not the Greek letter, but I'm not sure why a single character would be problematic. This is from the TextServerAdvanced implementation, so any needed change it would be done there, though this is probably accurate to Unicode specification.
* The Hebrew word `מִבְחָן` (I just used Google to translate `test`) also gives the confusable warning. I'm not familiar with Hebrew so can't tell for sure if there's an actual issue or if it's a false positive.
* The simplified nature of the check might make some valid words not valid identifiers. In particular scripts that needs the ZWNJ (zero-width non-joiner) or ZWJ (zero-width) characters to display words correctly, since those aren't allowed. The UAX#31 has specific rules for it, which are used in `TextServerAdvanced::is_valid_identifier()`, but those are quite complex to apply, and also needs the ICU data.

Closes https://github.com/godotengine/godot-proposals/issues/916

Special thanks to @bruvzg who did most of the groundwork and helped me out with this.