### PR TITLE
Implement a quick script inheritance check

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -56,10 +56,12 @@ class ScriptServer {
 	struct GlobalScriptClass {
 		StringName language;
 		String path;
-		String base;
+		StringName base;
 	};
 
 	static HashMap<StringName, GlobalScriptClass> global_classes;
+	static HashMap<StringName, Vector<StringName>> inheriters_cache;
+	static bool inheriters_cache_dirty;
 
 public:
 	static ScriptEditRequestFunction edit_request_func;
@@ -87,6 +89,7 @@ public:
 	static StringName get_global_class_base(const String &p_class);
 	static StringName get_global_class_native_base(const String &p_class);
 	static void get_global_class_list(List<StringName> *r_global_classes);
+	static void get_inheriters_list(const StringName &p_base_type, List<StringName> *r_classes);
 	static void save_global_classes();
 
 	static void init_languages();

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -42,8 +42,6 @@ class EditorQuickOpen;
 class EditorResourcePicker : public HBoxContainer {
 	GDCLASS(EditorResourcePicker, HBoxContainer);
 
-	static HashMap<StringName, List<StringName>> allowed_types_cache;
-
 	String base_type;
 	Ref<Resource> edited_resource;
 
@@ -92,9 +90,9 @@ class EditorResourcePicker : public HBoxContainer {
 	void _button_input(const Ref<InputEvent> &p_event);
 
 	String _get_resource_type(const Ref<Resource> &p_resource) const;
-	void _get_allowed_types(bool p_with_convert, HashSet<String> *p_vector) const;
+	void _get_allowed_types(bool p_with_convert, HashSet<StringName> *p_vector) const;
 	bool _is_drop_valid(const Dictionary &p_drag_data) const;
-	bool _is_type_valid(const String p_type_name, HashSet<String> p_allowed_types) const;
+	bool _is_type_valid(const String p_type_name, HashSet<StringName> p_allowed_types) const;
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
@@ -118,8 +116,6 @@ protected:
 	GDVIRTUAL1R(bool, _handle_menu_selected, int)
 
 public:
-	static void clear_caches();
-
 	void set_base_type(const String &p_base_type);
 	String get_base_type() const;
 	Vector<String> get_allowed_types() const;

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -219,6 +219,4 @@ void unregister_editor_types() {
 	if (EditorPaths::get_singleton()) {
 		EditorPaths::free();
 	}
-
-	EditorResourcePicker::clear_caches();
 }


### PR DESCRIPTION
Optimizes, simplifies and fixes EditorResourcePicker (was not refreshing custom clases).

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
