### PR TITLE
Clean-up, harmonize, and improve StyleBox API

### DIFF
--- a/doc/classes/StyleBox.xml
+++ b/doc/classes/StyleBox.xml
@@ -17,21 +17,16 @@
 			<description>
 			</description>
 		</method>
-		<method name="_get_center_size" qualifiers="virtual const">
-			<return type="Vector2" />
-			<description>
-			</description>
-		</method>
 		<method name="_get_draw_rect" qualifiers="virtual const">
 			<return type="Rect2" />
 			<param index="0" name="rect" type="Rect2" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_style_margin" qualifiers="virtual const">
-			<return type="float" />
-			<param index="0" name="side" type="int" enum="Side" />
+		<method name="_get_minimum_size" qualifiers="virtual const">
+			<return type="Vector2" />
 			<description>
+				Virtual method to be implemented by the user. Returns a custom minimum size that the stylebox must respect when drawing. By default [method get_minimum_size] only takes content margins into account. This method can be overridden to add another size restriction. A combination of the default behavior and the output of this method will be used, to account for both sizes.
 			</description>
 		</method>
 		<method name="_test_mask" qualifiers="virtual const">
@@ -50,23 +45,17 @@
 				The [RID] value can either be the result of [method CanvasItem.get_canvas_item] called on an existing [CanvasItem]-derived node, or directly from creating a canvas item in the [RenderingServer] with [method RenderingServer.canvas_item_create].
 			</description>
 		</method>
-		<method name="get_center_size" qualifiers="const">
-			<return type="Vector2" />
+		<method name="get_content_margin" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="margin" type="int" enum="Side" />
 			<description>
-				Returns the size of this [StyleBox] without the margins.
+				Returns the default margin of the specified [enum Side].
 			</description>
 		</method>
 		<method name="get_current_item_drawn" qualifiers="const">
 			<return type="CanvasItem" />
 			<description>
 				Returns the [CanvasItem] that handles its [constant CanvasItem.NOTIFICATION_DRAW] or [method CanvasItem._draw] callback at this moment.
-			</description>
-		</method>
-		<method name="get_default_margin" qualifiers="const">
-			<return type="float" />
-			<param index="0" name="margin" type="int" enum="Side" />
-			<description>
-				Returns the default margin of the specified [enum Side].
 			</description>
 		</method>
 		<method name="get_margin" qualifiers="const">
@@ -89,7 +78,7 @@
 				Returns the "offset" of a stylebox. This helper function returns a value equivalent to [code]Vector2(style.get_margin(MARGIN_LEFT), style.get_margin(MARGIN_TOP))[/code].
 			</description>
 		</method>
-		<method name="set_default_margin">
+		<method name="set_content_margin">
 			<return type="void" />
 			<param index="0" name="margin" type="int" enum="Side" />
 			<param index="1" name="offset" type="float" />
@@ -97,7 +86,7 @@
 				Sets the default value of the specified [enum Side] to [param offset] pixels.
 			</description>
 		</method>
-		<method name="set_default_margin_all">
+		<method name="set_content_margin_all">
 			<return type="void" />
 			<param index="0" name="offset" type="float" />
 			<description>
@@ -114,21 +103,21 @@
 		</method>
 	</methods>
 	<members>
-		<member name="content_margin_bottom" type="float" setter="set_default_margin" getter="get_default_margin" default="-1.0">
+		<member name="content_margin_bottom" type="float" setter="set_content_margin" getter="get_content_margin" default="-1.0">
 			The bottom margin for the contents of this style box. Increasing this value reduces the space available to the contents from the bottom.
 			If this value is negative, it is ignored and a child-specific margin is used instead. For example for [StyleBoxFlat] the border thickness (if any) is used instead.
 			It is up to the code using this style box to decide what these contents are: for example, a [Button] respects this content margin for the textual contents of the button.
 			[method get_margin] should be used to fetch this value as consumer instead of reading these properties directly. This is because it correctly respects negative values and the fallback mentioned above.
 		</member>
-		<member name="content_margin_left" type="float" setter="set_default_margin" getter="get_default_margin" default="-1.0">
+		<member name="content_margin_left" type="float" setter="set_content_margin" getter="get_content_margin" default="-1.0">
 			The left margin for the contents of this style box.	Increasing this value reduces the space available to the contents from the left.
 			Refer to [member content_margin_bottom] for extra considerations.
 		</member>
-		<member name="content_margin_right" type="float" setter="set_default_margin" getter="get_default_margin" default="-1.0">
+		<member name="content_margin_right" type="float" setter="set_content_margin" getter="get_content_margin" default="-1.0">
 			The right margin for the contents of this style box. Increasing this value reduces the space available to the contents from the right.
 			Refer to [member content_margin_bottom] for extra considerations.
 		</member>
-		<member name="content_margin_top" type="float" setter="set_default_margin" getter="get_default_margin" default="-1.0">
+		<member name="content_margin_top" type="float" setter="set_content_margin" getter="get_content_margin" default="-1.0">
 			The top margin for the contents of this style box. Increasing this value reduces the space available to the contents from the top.
 			Refer to [member content_margin_bottom] for extra considerations.
 		</member>

--- a/doc/classes/StyleBoxTexture.xml
+++ b/doc/classes/StyleBoxTexture.xml
@@ -9,18 +9,26 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="get_expand_margin_size" qualifiers="const">
+		<method name="get_expand_margin" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="margin" type="int" enum="Side" />
 			<description>
 				Returns the expand margin size of the specified [enum Side].
 			</description>
 		</method>
-		<method name="get_margin_size" qualifiers="const">
+		<method name="get_texture_margin" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="margin" type="int" enum="Side" />
 			<description>
 				Returns the margin size of the specified [enum Side].
+			</description>
+		</method>
+		<method name="set_expand_margin">
+			<return type="void" />
+			<param index="0" name="margin" type="int" enum="Side" />
+			<param index="1" name="size" type="float" />
+			<description>
+				Sets the expand margin to [param size] pixels for the specified [enum Side].
 			</description>
 		</method>
 		<method name="set_expand_margin_all">
@@ -30,15 +38,7 @@
 				Sets the expand margin to [param size] pixels for all margins.
 			</description>
 		</method>
-		<method name="set_expand_margin_size">
-			<return type="void" />
-			<param index="0" name="margin" type="int" enum="Side" />
-			<param index="1" name="size" type="float" />
-			<description>
-				Sets the expand margin to [param size] pixels for the specified [enum Side].
-			</description>
-		</method>
-		<method name="set_margin_size">
+		<method name="set_texture_margin">
 			<return type="void" />
 			<param index="0" name="margin" type="int" enum="Side" />
 			<param index="1" name="size" type="float" />
@@ -46,7 +46,7 @@
 				Sets the margin to [param size] pixels for the specified [enum Side].
 			</description>
 		</method>
-		<method name="set_margin_size_all">
+		<method name="set_texture_margin_all">
 			<return type="void" />
 			<param index="0" name="size" type="float" />
 			<description>
@@ -64,37 +64,17 @@
 		<member name="draw_center" type="bool" setter="set_draw_center" getter="is_draw_center_enabled" default="true">
 			If [code]true[/code], the nine-patch texture's center tile will be drawn.
 		</member>
-		<member name="expand_margin_bottom" type="float" setter="set_expand_margin_size" getter="get_expand_margin_size" default="0.0">
+		<member name="expand_margin_bottom" type="float" setter="set_expand_margin" getter="get_expand_margin" default="0.0">
 			Expands the bottom margin of this style box when drawing, causing it to be drawn larger than requested.
 		</member>
-		<member name="expand_margin_left" type="float" setter="set_expand_margin_size" getter="get_expand_margin_size" default="0.0">
+		<member name="expand_margin_left" type="float" setter="set_expand_margin" getter="get_expand_margin" default="0.0">
 			Expands the left margin of this style box when drawing, causing it to be drawn larger than requested.
 		</member>
-		<member name="expand_margin_right" type="float" setter="set_expand_margin_size" getter="get_expand_margin_size" default="0.0">
+		<member name="expand_margin_right" type="float" setter="set_expand_margin" getter="get_expand_margin" default="0.0">
 			Expands the right margin of this style box when drawing, causing it to be drawn larger than requested.
 		</member>
-		<member name="expand_margin_top" type="float" setter="set_expand_margin_size" getter="get_expand_margin_size" default="0.0">
+		<member name="expand_margin_top" type="float" setter="set_expand_margin" getter="get_expand_margin" default="0.0">
 			Expands the top margin of this style box when drawing, causing it to be drawn larger than requested.
-		</member>
-		<member name="margin_bottom" type="float" setter="set_margin_size" getter="get_margin_size" default="0.0">
-			Increases the bottom margin of the 3×3 texture box.
-			A higher value means more of the source texture is considered to be part of the bottom border of the 3×3 box.
-			This is also the value used as fallback for [member StyleBox.content_margin_bottom] if it is negative.
-		</member>
-		<member name="margin_left" type="float" setter="set_margin_size" getter="get_margin_size" default="0.0">
-			Increases the left margin of the 3×3 texture box.
-			A higher value means more of the source texture is considered to be part of the left border of the 3×3 box.
-			This is also the value used as fallback for [member StyleBox.content_margin_left] if it is negative.
-		</member>
-		<member name="margin_right" type="float" setter="set_margin_size" getter="get_margin_size" default="0.0">
-			Increases the right margin of the 3×3 texture box.
-			A higher value means more of the source texture is considered to be part of the right border of the 3×3 box.
-			This is also the value used as fallback for [member StyleBox.content_margin_right] if it is negative.
-		</member>
-		<member name="margin_top" type="float" setter="set_margin_size" getter="get_margin_size" default="0.0">
-			Increases the top margin of the 3×3 texture box.
-			A higher value means more of the source texture is considered to be part of the top border of the 3×3 box.
-			This is also the value used as fallback for [member StyleBox.content_margin_top] if it is negative.
 		</member>
 		<member name="modulate_color" type="Color" setter="set_modulate" getter="get_modulate" default="Color(1, 1, 1, 1)">
 			Modulates the color of the texture when this style box is drawn.
@@ -105,6 +85,26 @@
 		</member>
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			The texture to use when drawing this style box.
+		</member>
+		<member name="texture_margin_bottom" type="float" setter="set_texture_margin" getter="get_texture_margin" default="0.0">
+			Increases the bottom margin of the 3×3 texture box.
+			A higher value means more of the source texture is considered to be part of the bottom border of the 3×3 box.
+			This is also the value used as fallback for [member StyleBox.content_margin_bottom] if it is negative.
+		</member>
+		<member name="texture_margin_left" type="float" setter="set_texture_margin" getter="get_texture_margin" default="0.0">
+			Increases the left margin of the 3×3 texture box.
+			A higher value means more of the source texture is considered to be part of the left border of the 3×3 box.
+			This is also the value used as fallback for [member StyleBox.content_margin_left] if it is negative.
+		</member>
+		<member name="texture_margin_right" type="float" setter="set_texture_margin" getter="get_texture_margin" default="0.0">
+			Increases the right margin of the 3×3 texture box.
+			A higher value means more of the source texture is considered to be part of the right border of the 3×3 box.
+			This is also the value used as fallback for [member StyleBox.content_margin_right] if it is negative.
+		</member>
+		<member name="texture_margin_top" type="float" setter="set_texture_margin" getter="get_texture_margin" default="0.0">
+			Increases the top margin of the 3×3 texture box.
+			A higher value means more of the source texture is considered to be part of the top border of the 3×3 box.
+			This is also the value used as fallback for [member StyleBox.content_margin_top] if it is negative.
 		</member>
 	</members>
 	<constants>

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -285,7 +285,7 @@ void ConnectDialog::_notification(int p_what) {
 
 			Ref<StyleBox> style = get_theme_stylebox("normal", "LineEdit")->duplicate();
 			if (style.is_valid()) {
-				style->set_default_margin(SIDE_TOP, style->get_default_margin(SIDE_TOP) + 1.0);
+				style->set_content_margin(SIDE_TOP, style->get_content_margin(SIDE_TOP) + 1.0);
 				from_signal->add_theme_style_override("normal", style);
 			}
 		} break;

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -980,7 +980,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	no_profile_selected_help = memnew(Label(TTR("Create or import a profile to edit available classes and properties.")));
 	// Add some spacing above the help label.
 	Ref<StyleBoxEmpty> sb = memnew(StyleBoxEmpty);
-	sb->set_default_margin(SIDE_TOP, 20 * EDSCALE);
+	sb->set_content_margin(SIDE_TOP, 20 * EDSCALE);
 	no_profile_selected_help->add_theme_style_override("normal", sb);
 	no_profile_selected_help->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	no_profile_selected_help->set_v_size_flags(Control::SIZE_EXPAND_FILL);

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -195,8 +195,8 @@ void EditorHelp::_class_desc_resized(bool p_force_update_theme) {
 		display_margin = new_display_margin;
 
 		Ref<StyleBox> class_desc_stylebox = EditorNode::get_singleton()->get_theme_base()->get_theme_stylebox(SNAME("background"), SNAME("EditorHelp"))->duplicate();
-		class_desc_stylebox->set_default_margin(SIDE_LEFT, display_margin);
-		class_desc_stylebox->set_default_margin(SIDE_RIGHT, display_margin);
+		class_desc_stylebox->set_content_margin(SIDE_LEFT, display_margin);
+		class_desc_stylebox->set_content_margin(SIDE_RIGHT, display_margin);
 		class_desc->add_theme_style_override("normal", class_desc_stylebox);
 		class_desc->add_theme_style_override("focused", class_desc_stylebox);
 	}

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -103,7 +103,7 @@ void EditorResourcePicker::_update_resource_preview(const String &p_path, const 
 		}
 
 		if (p_preview.is_valid()) {
-			preview_rect->set_offset(SIDE_LEFT, assign_button->get_icon()->get_width() + assign_button->get_theme_stylebox(SNAME("normal"))->get_default_margin(SIDE_LEFT) + get_theme_constant(SNAME("h_separation"), SNAME("Button")));
+			preview_rect->set_offset(SIDE_LEFT, assign_button->get_icon()->get_width() + assign_button->get_theme_stylebox(SNAME("normal"))->get_content_margin(SIDE_LEFT) + get_theme_constant(SNAME("h_separation"), SNAME("Button")));
 
 			// Resource-specific stretching.
 			if (Ref<GradientTexture1D>(edited_resource).is_valid() || Ref<Gradient>(edited_resource).is_valid()) {

--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -278,11 +278,11 @@ void EditorSpinSlider::_update_value_input_stylebox() {
 	// higher margin to match the location where the text begins.
 	// The margin values below were determined by empirical testing.
 	if (is_layout_rtl()) {
-		stylebox->set_default_margin(SIDE_LEFT, 0);
-		stylebox->set_default_margin(SIDE_RIGHT, (!get_label().is_empty() ? 23 : 16) * EDSCALE);
+		stylebox->set_content_margin(SIDE_LEFT, 0);
+		stylebox->set_content_margin(SIDE_RIGHT, (!get_label().is_empty() ? 23 : 16) * EDSCALE);
 	} else {
-		stylebox->set_default_margin(SIDE_LEFT, (!get_label().is_empty() ? 23 : 16) * EDSCALE);
-		stylebox->set_default_margin(SIDE_RIGHT, 0);
+		stylebox->set_content_margin(SIDE_LEFT, (!get_label().is_empty() ? 23 : 16) * EDSCALE);
+		stylebox->set_content_margin(SIDE_RIGHT, 0);
 	}
 
 	value_input->add_theme_style_override("normal", stylebox);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -197,15 +197,15 @@ void EditorColorMap::create() {
 static Ref<StyleBoxTexture> make_stylebox(Ref<Texture2D> p_texture, float p_left, float p_top, float p_right, float p_bottom, float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1, bool p_draw_center = true) {
 	Ref<StyleBoxTexture> style(memnew(StyleBoxTexture));
 	style->set_texture(p_texture);
-	style->set_margin_size_individual(p_left * EDSCALE, p_top * EDSCALE, p_right * EDSCALE, p_bottom * EDSCALE);
-	style->set_default_margin_individual(p_margin_left * EDSCALE, p_margin_top * EDSCALE, p_margin_right * EDSCALE, p_margin_bottom * EDSCALE);
+	style->set_texture_margin_individual(p_left * EDSCALE, p_top * EDSCALE, p_right * EDSCALE, p_bottom * EDSCALE);
+	style->set_content_margin_individual(p_margin_left * EDSCALE, p_margin_top * EDSCALE, p_margin_right * EDSCALE, p_margin_bottom * EDSCALE);
 	style->set_draw_center(p_draw_center);
 	return style;
 }
 
 static Ref<StyleBoxEmpty> make_empty_stylebox(float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1) {
 	Ref<StyleBoxEmpty> style(memnew(StyleBoxEmpty));
-	style->set_default_margin_individual(p_margin_left * EDSCALE, p_margin_top * EDSCALE, p_margin_right * EDSCALE, p_margin_bottom * EDSCALE);
+	style->set_content_margin_individual(p_margin_left * EDSCALE, p_margin_top * EDSCALE, p_margin_right * EDSCALE, p_margin_bottom * EDSCALE);
 	return style;
 }
 
@@ -215,7 +215,7 @@ static Ref<StyleBoxFlat> make_flat_stylebox(Color p_color, float p_margin_left =
 	// Adjust level of detail based on the corners' effective sizes.
 	style->set_corner_detail(Math::ceil(0.8 * p_corner_width * EDSCALE));
 	style->set_corner_radius_all(p_corner_width * EDSCALE);
-	style->set_default_margin_individual(p_margin_left * EDSCALE, p_margin_top * EDSCALE, p_margin_right * EDSCALE, p_margin_bottom * EDSCALE);
+	style->set_content_margin_individual(p_margin_left * EDSCALE, p_margin_top * EDSCALE, p_margin_right * EDSCALE, p_margin_bottom * EDSCALE);
 	// Work around issue about antialiased edges being blurrier (GH-35279).
 	style->set_anti_aliased(false);
 	return style;
@@ -648,7 +648,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Vector2 widget_default_margin = Vector2(extra_spacing + 6, extra_spacing + default_margin_size + 1) * EDSCALE;
 
 	Ref<StyleBoxFlat> style_widget = style_default->duplicate();
-	style_widget->set_default_margin_individual(widget_default_margin.x, widget_default_margin.y, widget_default_margin.x, widget_default_margin.y);
+	style_widget->set_content_margin_individual(widget_default_margin.x, widget_default_margin.y, widget_default_margin.x, widget_default_margin.y);
 	style_widget->set_bg_color(dark_color_1);
 	if (draw_extra_borders) {
 		style_widget->set_border_width_all(Math::round(EDSCALE));
@@ -684,7 +684,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Style for windows, popups, etc..
 	Ref<StyleBoxFlat> style_popup = style_default->duplicate();
 	const int popup_margin_size = default_margin_size * EDSCALE * 3;
-	style_popup->set_default_margin_all(popup_margin_size);
+	style_popup->set_content_margin_all(popup_margin_size);
 	style_popup->set_border_color(contrast_color_1);
 	const Color shadow_color = Color(0, 0, 0, dark_theme ? 0.3 : 0.1);
 	style_popup->set_shadow_color(shadow_color);
@@ -722,12 +722,12 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_tab_base->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
 
 	// When using a border width greater than 0, visually line up the left of the selected tab with the underlying panel.
-	style_tab_base->set_expand_margin_size(SIDE_LEFT, -border_width);
+	style_tab_base->set_expand_margin(SIDE_LEFT, -border_width);
 
-	style_tab_base->set_default_margin(SIDE_LEFT, widget_default_margin.x + 5 * EDSCALE);
-	style_tab_base->set_default_margin(SIDE_RIGHT, widget_default_margin.x + 5 * EDSCALE);
-	style_tab_base->set_default_margin(SIDE_BOTTOM, widget_default_margin.y);
-	style_tab_base->set_default_margin(SIDE_TOP, widget_default_margin.y);
+	style_tab_base->set_content_margin(SIDE_LEFT, widget_default_margin.x + 5 * EDSCALE);
+	style_tab_base->set_content_margin(SIDE_RIGHT, widget_default_margin.x + 5 * EDSCALE);
+	style_tab_base->set_content_margin(SIDE_BOTTOM, widget_default_margin.y);
+	style_tab_base->set_content_margin(SIDE_TOP, widget_default_margin.y);
 
 	Ref<StyleBoxFlat> style_tab_selected = style_tab_base->duplicate();
 
@@ -740,13 +740,13 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_tab_selected->set_corner_radius_all(0);
 
 	Ref<StyleBoxFlat> style_tab_unselected = style_tab_base->duplicate();
-	style_tab_unselected->set_expand_margin_size(SIDE_BOTTOM, 0);
+	style_tab_unselected->set_expand_margin(SIDE_BOTTOM, 0);
 	style_tab_unselected->set_bg_color(dark_color_1);
 	// Add some spacing between unselected tabs to make them easier to distinguish from each other
 	style_tab_unselected->set_border_color(Color(0, 0, 0, 0));
 
 	Ref<StyleBoxFlat> style_tab_disabled = style_tab_base->duplicate();
-	style_tab_disabled->set_expand_margin_size(SIDE_BOTTOM, 0);
+	style_tab_disabled->set_expand_margin(SIDE_BOTTOM, 0);
 	style_tab_disabled->set_bg_color(disabled_bg_color);
 	style_tab_disabled->set_border_color(disabled_bg_color);
 
@@ -772,7 +772,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// CanvasItem Editor
 	Ref<StyleBoxFlat> style_canvas_editor_info = make_flat_stylebox(Color(0.0, 0.0, 0.0, 0.2));
-	style_canvas_editor_info->set_expand_margin_size_all(4 * EDSCALE);
+	style_canvas_editor_info->set_expand_margin_all(4 * EDSCALE);
 	theme->set_stylebox("CanvasItemInfoOverlay", "EditorStyles", style_canvas_editor_info);
 
 	// 2D and 3D contextual toolbar.
@@ -787,7 +787,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Add an underline to the StyleBox, but prevent its minimum vertical size from changing.
 	toolbar_stylebox->set_border_color(accent_color);
 	toolbar_stylebox->set_border_width(SIDE_BOTTOM, Math::round(2 * EDSCALE));
-	toolbar_stylebox->set_default_margin(SIDE_BOTTOM, 0);
+	toolbar_stylebox->set_content_margin(SIDE_BOTTOM, 0);
 	theme->set_stylebox("ContextualToolbar", "EditorStyles", toolbar_stylebox);
 
 	// Script Editor
@@ -808,11 +808,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Ref<StyleBoxFlat> style_write_movie_button = style_widget_pressed->duplicate();
 	style_write_movie_button->set_bg_color(accent_color);
 	style_write_movie_button->set_corner_radius_all(corner_radius * EDSCALE);
-	style_write_movie_button->set_default_margin(SIDE_TOP, 0);
-	style_write_movie_button->set_default_margin(SIDE_BOTTOM, 0);
-	style_write_movie_button->set_default_margin(SIDE_LEFT, 0);
-	style_write_movie_button->set_default_margin(SIDE_RIGHT, 0);
-	style_write_movie_button->set_expand_margin_size(SIDE_RIGHT, 2 * EDSCALE);
+	style_write_movie_button->set_content_margin(SIDE_TOP, 0);
+	style_write_movie_button->set_content_margin(SIDE_BOTTOM, 0);
+	style_write_movie_button->set_content_margin(SIDE_LEFT, 0);
+	style_write_movie_button->set_content_margin(SIDE_RIGHT, 0);
+	style_write_movie_button->set_expand_margin(SIDE_RIGHT, 2 * EDSCALE);
 	theme->set_stylebox("MovieWriterButtonPressed", "EditorStyles", style_write_movie_button);
 
 	theme->set_stylebox("normal", "MenuButton", style_menu);
@@ -855,16 +855,16 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	color_inspector_action.a = 0.5;
 	Ref<StyleBoxFlat> style_inspector_action = style_widget->duplicate();
 	style_inspector_action->set_bg_color(color_inspector_action);
-	style_inspector_action->set_default_margin(SIDE_RIGHT, ACTION_BUTTON_EXTRA_MARGIN);
+	style_inspector_action->set_content_margin(SIDE_RIGHT, ACTION_BUTTON_EXTRA_MARGIN);
 	theme->set_stylebox("normal", "InspectorActionButton", style_inspector_action);
 	style_inspector_action = style_widget_hover->duplicate();
-	style_inspector_action->set_default_margin(SIDE_RIGHT, ACTION_BUTTON_EXTRA_MARGIN);
+	style_inspector_action->set_content_margin(SIDE_RIGHT, ACTION_BUTTON_EXTRA_MARGIN);
 	theme->set_stylebox("hover", "InspectorActionButton", style_inspector_action);
 	style_inspector_action = style_widget_pressed->duplicate();
-	style_inspector_action->set_default_margin(SIDE_RIGHT, ACTION_BUTTON_EXTRA_MARGIN);
+	style_inspector_action->set_content_margin(SIDE_RIGHT, ACTION_BUTTON_EXTRA_MARGIN);
 	theme->set_stylebox("pressed", "InspectorActionButton", style_inspector_action);
 	style_inspector_action = style_widget_disabled->duplicate();
-	style_inspector_action->set_default_margin(SIDE_RIGHT, ACTION_BUTTON_EXTRA_MARGIN);
+	style_inspector_action->set_content_margin(SIDE_RIGHT, ACTION_BUTTON_EXTRA_MARGIN);
 	theme->set_stylebox("disabled", "InspectorActionButton", style_inspector_action);
 	theme->set_constant("h_separation", "InspectorActionButton", ACTION_BUTTON_EXTRA_MARGIN);
 
@@ -908,11 +908,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Ref<StyleBoxFlat> style_option_button_pressed = style_widget_pressed->duplicate();
 	Ref<StyleBoxFlat> style_option_button_disabled = style_widget_disabled->duplicate();
 
-	style_option_button_focus->set_default_margin(SIDE_RIGHT, 4 * EDSCALE);
-	style_option_button_normal->set_default_margin(SIDE_RIGHT, 4 * EDSCALE);
-	style_option_button_hover->set_default_margin(SIDE_RIGHT, 4 * EDSCALE);
-	style_option_button_pressed->set_default_margin(SIDE_RIGHT, 4 * EDSCALE);
-	style_option_button_disabled->set_default_margin(SIDE_RIGHT, 4 * EDSCALE);
+	style_option_button_focus->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
+	style_option_button_normal->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
+	style_option_button_hover->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
+	style_option_button_pressed->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
+	style_option_button_disabled->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
 
 	theme->set_stylebox("focus", "OptionButton", style_option_button_focus);
 	theme->set_stylebox("normal", "OptionButton", style_widget);
@@ -978,7 +978,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// Checkbox
 	Ref<StyleBoxFlat> sb_checkbox = style_menu->duplicate();
-	sb_checkbox->set_default_margin_all(default_margin_size * EDSCALE);
+	sb_checkbox->set_content_margin_all(default_margin_size * EDSCALE);
 
 	theme->set_stylebox("normal", "CheckBox", sb_checkbox);
 	theme->set_stylebox("pressed", "CheckBox", sb_checkbox);
@@ -1018,7 +1018,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Use 1 pixel for the sides, since if 0 is used, the highlight of hovered items is drawn
 	// on top of the popup border. This causes a 'gap' in the panel border when an item is highlighted,
 	// and it looks weird. 1px solves this.
-	style_popup_menu->set_default_margin_individual(EDSCALE, 2 * EDSCALE, EDSCALE, 2 * EDSCALE);
+	style_popup_menu->set_content_margin_individual(EDSCALE, 2 * EDSCALE, EDSCALE, 2 * EDSCALE);
 	// Always display a border for PopupMenus so they can be distinguished from their background.
 	style_popup_menu->set_border_width_all(EDSCALE);
 	if (draw_extra_borders) {
@@ -1078,7 +1078,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 		sub_inspector_bg->set_bg_color(dark_color_1.lerp(si_base_color, 0.08));
 		sub_inspector_bg->set_border_width_all(2 * EDSCALE);
 		sub_inspector_bg->set_border_color(si_base_color * Color(0.7, 0.7, 0.7, 0.8));
-		sub_inspector_bg->set_default_margin_all(4 * EDSCALE);
+		sub_inspector_bg->set_content_margin_all(4 * EDSCALE);
 		sub_inspector_bg->set_corner_radius(CORNER_TOP_LEFT, 0);
 		sub_inspector_bg->set_corner_radius(CORNER_TOP_RIGHT, 0);
 
@@ -1318,7 +1318,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_content_panel->set_corner_radius(CORNER_TOP_LEFT, 0);
 	style_content_panel->set_corner_radius(CORNER_TOP_RIGHT, 0);
 	// Compensate for the border.
-	style_content_panel->set_default_margin_individual(margin_size_extra * EDSCALE, (2 + margin_size_extra) * EDSCALE, margin_size_extra * EDSCALE, margin_size_extra * EDSCALE);
+	style_content_panel->set_content_margin_individual(margin_size_extra * EDSCALE, (2 + margin_size_extra) * EDSCALE, margin_size_extra * EDSCALE, margin_size_extra * EDSCALE);
 	theme->set_stylebox("panel", "TabContainer", style_content_panel);
 
 	// Bottom panel.
@@ -1339,15 +1339,15 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// This stylebox is used in 3d and 2d viewports (no borders).
 	Ref<StyleBoxFlat> style_content_panel_vp = style_content_panel->duplicate();
-	style_content_panel_vp->set_default_margin_individual(border_width * 2, default_margin_size * EDSCALE, border_width * 2, border_width * 2);
+	style_content_panel_vp->set_content_margin_individual(border_width * 2, default_margin_size * EDSCALE, border_width * 2, border_width * 2);
 	theme->set_stylebox("Content", "EditorStyles", style_content_panel_vp);
 
 	// This stylebox is used by preview tabs in the Theme Editor.
 	Ref<StyleBoxFlat> style_theme_preview_tab = style_tab_selected_odd->duplicate();
-	style_theme_preview_tab->set_expand_margin_size(SIDE_BOTTOM, 5 * EDSCALE);
+	style_theme_preview_tab->set_expand_margin(SIDE_BOTTOM, 5 * EDSCALE);
 	theme->set_stylebox("ThemeEditorPreviewFG", "EditorStyles", style_theme_preview_tab);
 	Ref<StyleBoxFlat> style_theme_preview_bg_tab = style_tab_unselected->duplicate();
-	style_theme_preview_bg_tab->set_expand_margin_size(SIDE_BOTTOM, 2 * EDSCALE);
+	style_theme_preview_bg_tab->set_expand_margin(SIDE_BOTTOM, 2 * EDSCALE);
 	theme->set_stylebox("ThemeEditorPreviewBG", "EditorStyles", style_theme_preview_bg_tab);
 
 	// Separators
@@ -1361,9 +1361,9 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("DebuggerPanel", "EditorStyles", style_panel_debugger);
 
 	Ref<StyleBoxFlat> style_panel_invisible_top = style_content_panel->duplicate();
-	int stylebox_offset = theme->get_font(SNAME("tab_selected"), SNAME("TabContainer"))->get_height(theme->get_font_size(SNAME("tab_selected"), SNAME("TabContainer"))) + theme->get_stylebox(SNAME("tab_selected"), SNAME("TabContainer"))->get_minimum_size().height + theme->get_stylebox(SNAME("panel"), SNAME("TabContainer"))->get_default_margin(SIDE_TOP);
-	style_panel_invisible_top->set_expand_margin_size(SIDE_TOP, -stylebox_offset);
-	style_panel_invisible_top->set_default_margin(SIDE_TOP, 0);
+	int stylebox_offset = theme->get_font(SNAME("tab_selected"), SNAME("TabContainer"))->get_height(theme->get_font_size(SNAME("tab_selected"), SNAME("TabContainer"))) + theme->get_stylebox(SNAME("tab_selected"), SNAME("TabContainer"))->get_minimum_size().height + theme->get_stylebox(SNAME("panel"), SNAME("TabContainer"))->get_content_margin(SIDE_TOP);
+	style_panel_invisible_top->set_expand_margin(SIDE_TOP, -stylebox_offset);
+	style_panel_invisible_top->set_content_margin(SIDE_TOP, 0);
 	theme->set_stylebox("BottomPanelDebuggerOverride", "EditorStyles", style_panel_invisible_top);
 
 	// LineEdit
@@ -1371,7 +1371,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Ref<StyleBoxFlat> style_line_edit = style_widget->duplicate();
 	// The original style_widget style has an extra 1 pixel offset that makes LineEdits not align with Buttons,
 	// so this compensates for that.
-	style_line_edit->set_default_margin(SIDE_TOP, style_line_edit->get_default_margin(SIDE_TOP) - 1 * EDSCALE);
+	style_line_edit->set_content_margin(SIDE_TOP, style_line_edit->get_content_margin(SIDE_TOP) - 1 * EDSCALE);
 
 	// Don't round the bottom corner to make the line look sharper.
 	style_tab_selected->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
@@ -1459,12 +1459,12 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_window_title->set_corner_radius(CORNER_TOP_LEFT, 0);
 	style_window_title->set_corner_radius(CORNER_TOP_RIGHT, 0);
 	// Prevent visible line between window title and body.
-	style_window_title->set_expand_margin_size(SIDE_BOTTOM, 2 * EDSCALE);
+	style_window_title->set_expand_margin(SIDE_BOTTOM, 2 * EDSCALE);
 
 	Ref<StyleBoxFlat> style_window = style_popup->duplicate();
 	style_window->set_border_color(base_color);
 	style_window->set_border_width(SIDE_TOP, 24 * EDSCALE);
-	style_window->set_expand_margin_size(SIDE_TOP, 24 * EDSCALE);
+	style_window->set_expand_margin(SIDE_TOP, 24 * EDSCALE);
 	theme->set_stylebox("embedded_border", "Window", style_window);
 
 	theme->set_color("title_color", "Window", font_color);
@@ -1598,7 +1598,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// is only relevant for default tooltips.
 	Ref<StyleBoxFlat> style_tooltip = style_popup->duplicate();
 	style_tooltip->set_shadow_size(0);
-	style_tooltip->set_default_margin_all(default_margin_size * EDSCALE * 0.5);
+	style_tooltip->set_content_margin_all(default_margin_size * EDSCALE * 0.5);
 	style_tooltip->set_bg_color(dark_color_3 * Color(0.8, 0.8, 0.8, 0.9));
 	style_tooltip->set_border_width_all(0);
 	theme->set_color("font_color", "TooltipLabel", font_hover_color);
@@ -1610,10 +1610,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	Ref<StyleBoxFlat> control_editor_popup_style = style_popup->duplicate();
 	control_editor_popup_style->set_shadow_size(0);
-	control_editor_popup_style->set_default_margin(SIDE_LEFT, default_margin_size * EDSCALE);
-	control_editor_popup_style->set_default_margin(SIDE_TOP, default_margin_size * EDSCALE);
-	control_editor_popup_style->set_default_margin(SIDE_RIGHT, default_margin_size * EDSCALE);
-	control_editor_popup_style->set_default_margin(SIDE_BOTTOM, default_margin_size * EDSCALE);
+	control_editor_popup_style->set_content_margin(SIDE_LEFT, default_margin_size * EDSCALE);
+	control_editor_popup_style->set_content_margin(SIDE_TOP, default_margin_size * EDSCALE);
+	control_editor_popup_style->set_content_margin(SIDE_RIGHT, default_margin_size * EDSCALE);
+	control_editor_popup_style->set_content_margin(SIDE_BOTTOM, default_margin_size * EDSCALE);
 	control_editor_popup_style->set_border_width_all(0);
 
 	theme->set_stylebox("panel", "ControlEditorPopupPanel", control_editor_popup_style);
@@ -1826,8 +1826,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Dictionary editor add item.
 	// Expand to the left and right by 4px to compensate for the dictionary editor margins.
 	Ref<StyleBoxFlat> style_dictionary_add_item = make_flat_stylebox(prop_subsection_color, 0, 4, 0, 4, corner_radius);
-	style_dictionary_add_item->set_expand_margin_size(SIDE_LEFT, 4 * EDSCALE);
-	style_dictionary_add_item->set_expand_margin_size(SIDE_RIGHT, 4 * EDSCALE);
+	style_dictionary_add_item->set_expand_margin(SIDE_LEFT, 4 * EDSCALE);
+	style_dictionary_add_item->set_expand_margin(SIDE_RIGHT, 4 * EDSCALE);
 	theme->set_stylebox("DictionaryAddItem", "EditorStyles", style_dictionary_add_item);
 
 	Ref<StyleBoxEmpty> vshader_label_style = make_empty_stylebox(2, 1, 2, 1);

--- a/editor/editor_toaster.cpp
+++ b/editor/editor_toaster.cpp
@@ -525,7 +525,7 @@ EditorToaster::EditorToaster() {
 
 	Ref<StyleBoxFlat> boxes[] = { info_panel_style_background, warning_panel_style_background, error_panel_style_background };
 	for (int i = 0; i < 3; i++) {
-		boxes[i]->set_default_margin_individual(int(stylebox_radius * 2.5), 3, int(stylebox_radius * 2.5), 3);
+		boxes[i]->set_content_margin_individual(int(stylebox_radius * 2.5), 3, int(stylebox_radius * 2.5), 3);
 	}
 
 	// Theming (progress).

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -107,7 +107,7 @@ void EditorAssetLibraryItem::_bind_methods() {
 EditorAssetLibraryItem::EditorAssetLibraryItem() {
 	Ref<StyleBoxEmpty> border;
 	border.instantiate();
-	border->set_default_margin_all(5 * EDSCALE);
+	border->set_content_margin_all(5 * EDSCALE);
 	add_theme_style_override("panel", border);
 
 	HBoxContainer *hb = memnew(HBoxContainer);
@@ -1549,7 +1549,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
 	Ref<StyleBoxEmpty> border2;
 	border2.instantiate();
-	border2->set_default_margin_individual(15 * EDSCALE, 15 * EDSCALE, 35 * EDSCALE, 15 * EDSCALE);
+	border2->set_content_margin_individual(15 * EDSCALE, 15 * EDSCALE, 35 * EDSCALE, 15 * EDSCALE);
 
 	PanelContainer *library_vb_border = memnew(PanelContainer);
 	library_scroll->add_child(library_vb_border);

--- a/editor/plugins/bit_map_editor_plugin.cpp
+++ b/editor/plugins/bit_map_editor_plugin.cpp
@@ -53,7 +53,7 @@ BitMapEditor::BitMapEditor() {
 	// Reduce extra padding on top and bottom of size label.
 	Ref<StyleBoxEmpty> stylebox;
 	stylebox.instantiate();
-	stylebox->set_default_margin(SIDE_RIGHT, 4 * EDSCALE);
+	stylebox->set_content_margin(SIDE_RIGHT, 4 * EDSCALE);
 	size_label->add_theme_style_override("normal", stylebox);
 }
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3958,8 +3958,8 @@ void CanvasItemEditor::_notification(int p_what) {
 
 		case NOTIFICATION_ENTER_TREE: {
 			select_sb->set_texture(get_theme_icon(SNAME("EditorRect2D"), SNAME("EditorIcons")));
-			select_sb->set_margin_size_all(4);
-			select_sb->set_default_margin_all(4);
+			select_sb->set_texture_margin_all(4);
+			select_sb->set_content_margin_all(4);
 
 			AnimationPlayerEditor::get_singleton()->get_track_editor()->connect("visibility_changed", callable_mp(this, &CanvasItemEditor::_keying_changed));
 			_keying_changed();

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -256,10 +256,10 @@ void TextureRegionEditor::_region_draw() {
 			margins[2] = node_ninepatch->get_patch_margin(SIDE_LEFT);
 			margins[3] = node_ninepatch->get_patch_margin(SIDE_RIGHT);
 		} else if (obj_styleBox.is_valid()) {
-			margins[0] = obj_styleBox->get_margin_size(SIDE_TOP);
-			margins[1] = obj_styleBox->get_margin_size(SIDE_BOTTOM);
-			margins[2] = obj_styleBox->get_margin_size(SIDE_LEFT);
-			margins[3] = obj_styleBox->get_margin_size(SIDE_RIGHT);
+			margins[0] = obj_styleBox->get_texture_margin(SIDE_TOP);
+			margins[1] = obj_styleBox->get_texture_margin(SIDE_BOTTOM);
+			margins[2] = obj_styleBox->get_texture_margin(SIDE_LEFT);
+			margins[3] = obj_styleBox->get_texture_margin(SIDE_RIGHT);
 		}
 
 		Vector2 pos[4] = {
@@ -314,10 +314,10 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 						margins[2] = node_ninepatch->get_patch_margin(SIDE_LEFT);
 						margins[3] = node_ninepatch->get_patch_margin(SIDE_RIGHT);
 					} else if (obj_styleBox.is_valid()) {
-						margins[0] = obj_styleBox->get_margin_size(SIDE_TOP);
-						margins[1] = obj_styleBox->get_margin_size(SIDE_BOTTOM);
-						margins[2] = obj_styleBox->get_margin_size(SIDE_LEFT);
-						margins[3] = obj_styleBox->get_margin_size(SIDE_RIGHT);
+						margins[0] = obj_styleBox->get_texture_margin(SIDE_TOP);
+						margins[1] = obj_styleBox->get_texture_margin(SIDE_BOTTOM);
+						margins[2] = obj_styleBox->get_texture_margin(SIDE_LEFT);
+						margins[3] = obj_styleBox->get_texture_margin(SIDE_RIGHT);
 					}
 
 					Vector2 pos[4] = {
@@ -431,8 +431,8 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 						undo_redo->add_do_method(node_ninepatch, "set_patch_margin", side[edited_margin], node_ninepatch->get_patch_margin(side[edited_margin]));
 						undo_redo->add_undo_method(node_ninepatch, "set_patch_margin", side[edited_margin], prev_margin);
 					} else if (obj_styleBox.is_valid()) {
-						undo_redo->add_do_method(obj_styleBox.ptr(), "set_margin_size", side[edited_margin], obj_styleBox->get_margin_size(side[edited_margin]));
-						undo_redo->add_undo_method(obj_styleBox.ptr(), "set_margin_size", side[edited_margin], prev_margin);
+						undo_redo->add_do_method(obj_styleBox.ptr(), "set_texture_margin", side[edited_margin], obj_styleBox->get_texture_margin(side[edited_margin]));
+						undo_redo->add_undo_method(obj_styleBox.ptr(), "set_texture_margin", side[edited_margin], prev_margin);
 						obj_styleBox->emit_signal(CoreStringNames::get_singleton()->changed);
 					}
 					edited_margin = -1;
@@ -474,7 +474,7 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 						node_ninepatch->set_patch_margin(side[edited_margin], prev_margin);
 					}
 					if (obj_styleBox.is_valid()) {
-						obj_styleBox->set_margin_size(side[edited_margin], prev_margin);
+						obj_styleBox->set_texture_margin(side[edited_margin], prev_margin);
 					}
 					edited_margin = -1;
 				} else {
@@ -535,7 +535,7 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 					node_ninepatch->set_patch_margin(side[edited_margin], new_margin);
 				}
 				if (obj_styleBox.is_valid()) {
-					obj_styleBox->set_margin_size(side[edited_margin], new_margin);
+					obj_styleBox->set_texture_margin(side[edited_margin], new_margin);
 				}
 			} else {
 				Vector2 new_pos = mtx.affine_inverse().xform(mm->get_position());

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -471,7 +471,7 @@ ColorPicker::PickerShapeType ColorPicker::_get_actual_shape() const {
 
 void ColorPicker::_reset_theme() {
 	Ref<StyleBoxFlat> style_box_flat(memnew(StyleBoxFlat));
-	style_box_flat->set_default_margin(SIDE_TOP, 16 * get_theme_default_base_scale());
+	style_box_flat->set_content_margin(SIDE_TOP, 16 * get_theme_default_base_scale());
 	style_box_flat->set_bg_color(Color(0.2, 0.23, 0.31).lerp(Color(0, 0, 0, 1), 0.3).clamp());
 	for (int i = 0; i < SLIDER_COUNT; i++) {
 		sliders[i]->add_theme_icon_override("grabber", get_theme_icon(SNAME("bar_arrow"), SNAME("ColorPicker")));
@@ -890,7 +890,7 @@ void ColorPicker::set_colorize_sliders(bool p_colorize_sliders) {
 		alpha_slider->add_theme_style_override("slider", style_box_empty);
 	} else {
 		Ref<StyleBoxFlat> style_box_flat(memnew(StyleBoxFlat));
-		style_box_flat->set_default_margin(SIDE_TOP, 16 * get_theme_default_base_scale());
+		style_box_flat->set_content_margin(SIDE_TOP, 16 * get_theme_default_base_scale());
 		style_box_flat->set_bg_color(Color(0.2, 0.23, 0.31).lerp(Color(0, 0, 0, 1), 0.3).clamp());
 
 		if (!slider_theme_modified) {

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -594,17 +594,17 @@ void PopupMenu::_draw_items() {
 				int content_left = content_center - content_size / 2;
 				int content_right = content_center + content_size / 2;
 				if (content_left > item_ofs.x) {
-					int sep_h = theme_cache.labeled_separator_left->get_center_size().height + theme_cache.labeled_separator_left->get_minimum_size().height;
+					int sep_h = theme_cache.labeled_separator_left->get_minimum_size().height;
 					int sep_ofs = Math::floor((h - sep_h) / 2.0);
 					theme_cache.labeled_separator_left->draw(ci, Rect2(item_ofs + Point2(0, sep_ofs), Size2(MAX(0, content_left - item_ofs.x), sep_h)));
 				}
 				if (content_right < display_width) {
-					int sep_h = theme_cache.labeled_separator_right->get_center_size().height + theme_cache.labeled_separator_right->get_minimum_size().height;
+					int sep_h = theme_cache.labeled_separator_right->get_minimum_size().height;
 					int sep_ofs = Math::floor((h - sep_h) / 2.0);
 					theme_cache.labeled_separator_right->draw(ci, Rect2(Point2(content_right, item_ofs.y + sep_ofs), Size2(MAX(0, display_width - content_right), sep_h)));
 				}
 			} else {
-				int sep_h = theme_cache.separator_style->get_center_size().height + theme_cache.separator_style->get_minimum_size().height;
+				int sep_h = theme_cache.separator_style->get_minimum_size().height;
 				int sep_ofs = Math::floor((h - sep_h) / 2.0);
 				theme_cache.separator_style->draw(ci, Rect2(item_ofs + Point2(0, sep_ofs), Size2(display_width, sep_h)));
 			}

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -433,7 +433,7 @@ void ScrollBar::_notification(int p_what) {
 
 double ScrollBar::get_grabber_min_size() const {
 	Ref<StyleBox> grabber = theme_cache.grabber_style;
-	Size2 gminsize = grabber->get_minimum_size() + grabber->get_center_size();
+	Size2 gminsize = grabber->get_minimum_size();
 	return (orientation == VERTICAL) ? gminsize.height : gminsize.width;
 }
 
@@ -500,7 +500,7 @@ Size2 ScrollBar::get_minimum_size() const {
 	Size2 minsize;
 
 	if (orientation == VERTICAL) {
-		minsize.width = MAX(incr->get_size().width, (bg->get_minimum_size() + bg->get_center_size()).width);
+		minsize.width = MAX(incr->get_size().width, bg->get_minimum_size().width);
 		minsize.height += incr->get_size().height;
 		minsize.height += decr->get_size().height;
 		minsize.height += bg->get_minimum_size().height;
@@ -508,7 +508,7 @@ Size2 ScrollBar::get_minimum_size() const {
 	}
 
 	if (orientation == HORIZONTAL) {
-		minsize.height = MAX(incr->get_size().height, (bg->get_center_size() + bg->get_minimum_size()).height);
+		minsize.height = MAX(incr->get_size().height, bg->get_minimum_size().height);
 		minsize.width += incr->get_size().width;
 		minsize.width += decr->get_size().width;
 		minsize.width += bg->get_minimum_size().width;

--- a/scene/gui/separator.cpp
+++ b/scene/gui/separator.cpp
@@ -51,7 +51,7 @@ void Separator::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
 			Size2i size = get_size();
-			Size2i ssize = theme_cache.separator_style->get_minimum_size() + theme_cache.separator_style->get_center_size();
+			Size2i ssize = theme_cache.separator_style->get_minimum_size();
 
 			if (orientation == VERTICAL) {
 				theme_cache.separator_style->draw(get_canvas_item(), Rect2((size.x - ssize.x) / 2, 0, ssize.x, size.y));

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -33,7 +33,7 @@
 #include "core/os/keyboard.h"
 
 Size2 Slider::get_minimum_size() const {
-	Size2i ss = theme_cache.slider_style->get_minimum_size() + theme_cache.slider_style->get_center_size();
+	Size2i ss = theme_cache.slider_style->get_minimum_size();
 	Size2i rs = theme_cache.grabber_icon->get_size();
 
 	if (orientation == HORIZONTAL) {
@@ -212,7 +212,7 @@ void Slider::_notification(int p_what) {
 			}
 
 			if (orientation == VERTICAL) {
-				int widget_width = style->get_minimum_size().width + style->get_center_size().width;
+				int widget_width = style->get_minimum_size().width;
 				double areasize = size.height - grabber->get_size().height;
 				style->draw(ci, Rect2i(Point2i(size.width / 2 - widget_width / 2, 0), Size2i(widget_width, size.height)));
 				grabber_area->draw(ci, Rect2i(Point2i((size.width - widget_width) / 2, size.height - areasize * ratio - grabber->get_size().height / 2), Size2i(widget_width, areasize * ratio + grabber->get_size().height / 2)));
@@ -229,7 +229,7 @@ void Slider::_notification(int p_what) {
 				}
 				grabber->draw(ci, Point2i(size.width / 2 - grabber->get_size().width / 2 + get_theme_constant(SNAME("grabber_offset")), size.height - ratio * areasize - grabber->get_size().height));
 			} else {
-				int widget_height = style->get_minimum_size().height + style->get_center_size().height;
+				int widget_height = style->get_minimum_size().height;
 				double areasize = size.width - grabber->get_size().width;
 
 				style->draw(ci, Rect2i(Point2i(0, (size.height - widget_height) / 2), Size2i(size.width, widget_height)));

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -53,7 +53,7 @@ static const int default_corner_radius = 3;
 static Ref<StyleBoxFlat> make_flat_stylebox(Color p_color, float p_margin_left = default_margin, float p_margin_top = default_margin, float p_margin_right = default_margin, float p_margin_bottom = default_margin, int p_corner_radius = default_corner_radius, bool p_draw_center = true, int p_border_width = 0) {
 	Ref<StyleBoxFlat> style(memnew(StyleBoxFlat));
 	style->set_bg_color(p_color);
-	style->set_default_margin_individual(p_margin_left * scale, p_margin_top * scale, p_margin_right * scale, p_margin_bottom * scale);
+	style->set_content_margin_individual(p_margin_left * scale, p_margin_top * scale, p_margin_right * scale, p_margin_bottom * scale);
 
 	style->set_corner_radius_all(p_corner_radius);
 	style->set_anti_aliased(true);
@@ -67,10 +67,10 @@ static Ref<StyleBoxFlat> make_flat_stylebox(Color p_color, float p_margin_left =
 }
 
 static Ref<StyleBoxFlat> sb_expand(Ref<StyleBoxFlat> p_sbox, float p_left, float p_top, float p_right, float p_bottom) {
-	p_sbox->set_expand_margin_size(SIDE_LEFT, p_left * scale);
-	p_sbox->set_expand_margin_size(SIDE_TOP, p_top * scale);
-	p_sbox->set_expand_margin_size(SIDE_RIGHT, p_right * scale);
-	p_sbox->set_expand_margin_size(SIDE_BOTTOM, p_bottom * scale);
+	p_sbox->set_expand_margin(SIDE_LEFT, p_left * scale);
+	p_sbox->set_expand_margin(SIDE_TOP, p_top * scale);
+	p_sbox->set_expand_margin(SIDE_RIGHT, p_right * scale);
+	p_sbox->set_expand_margin(SIDE_BOTTOM, p_bottom * scale);
 	return p_sbox;
 }
 
@@ -93,7 +93,7 @@ static Ref<ImageTexture> generate_icon(int p_index) {
 
 static Ref<StyleBox> make_empty_stylebox(float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1) {
 	Ref<StyleBox> style(memnew(StyleBoxEmpty));
-	style->set_default_margin_individual(p_margin_left * scale, p_margin_top * scale, p_margin_right * scale, p_margin_bottom * scale);
+	style->set_content_margin_individual(p_margin_left * scale, p_margin_top * scale, p_margin_right * scale, p_margin_bottom * scale);
 	return style;
 }
 
@@ -148,7 +148,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	const Ref<StyleBoxFlat> button_disabled = make_flat_stylebox(style_disabled_color);
 	Ref<StyleBoxFlat> focus = make_flat_stylebox(style_focus_color, default_margin, default_margin, default_margin, default_margin, default_corner_radius, false, 2);
 	// Make the focus outline appear to be flush with the buttons it's focusing.
-	focus->set_expand_margin_size_all(2 * scale);
+	focus->set_expand_margin_all(2 * scale);
 
 	theme->set_stylebox("normal", "Button", button_normal);
 	theme->set_stylebox("hover", "Button", button_hover);
@@ -279,9 +279,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	// CheckBox
 
 	Ref<StyleBox> cbx_empty = memnew(StyleBoxEmpty);
-	cbx_empty->set_default_margin_all(4 * scale);
+	cbx_empty->set_content_margin_all(4 * scale);
 	Ref<StyleBox> cbx_focus = focus;
-	cbx_focus->set_default_margin_all(4 * scale);
+	cbx_focus->set_content_margin_all(4 * scale);
 
 	theme->set_stylebox("normal", "CheckBox", cbx_empty);
 	theme->set_stylebox("pressed", "CheckBox", cbx_empty);
@@ -317,7 +317,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	// CheckButton
 
 	Ref<StyleBox> cb_empty = memnew(StyleBoxEmpty);
-	cb_empty->set_default_margin_individual(6 * scale, 4 * scale, 6 * scale, 4 * scale);
+	cb_empty->set_content_margin_individual(6 * scale, 4 * scale, 6 * scale, 4 * scale);
 
 	theme->set_stylebox("normal", "CheckButton", cb_empty);
 	theme->set_stylebox("pressed", "CheckButton", cb_empty);
@@ -634,10 +634,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	Ref<StyleBoxLine> separator_horizontal = memnew(StyleBoxLine);
 	separator_horizontal->set_thickness(Math::round(scale));
 	separator_horizontal->set_color(style_separator_color);
-	separator_horizontal->set_default_margin_individual(default_margin, 0, default_margin, 0);
+	separator_horizontal->set_content_margin_individual(default_margin, 0, default_margin, 0);
 	Ref<StyleBoxLine> separator_vertical = separator_horizontal->duplicate();
 	separator_vertical->set_vertical(true);
-	separator_vertical->set_default_margin_individual(0, default_margin, 0, default_margin);
+	separator_vertical->set_content_margin_individual(0, default_margin, 0, default_margin);
 
 	// Always display a border for PopupMenus so they can be distinguished from their background.
 	Ref<StyleBoxFlat> style_popup_panel = make_flat_stylebox(style_popup_color);

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -34,76 +34,65 @@
 
 #include <limits.h>
 
-float StyleBox::get_style_margin(Side p_side) const {
-	float ret = 0;
-	GDVIRTUAL_REQUIRED_CALL(_get_style_margin, p_side, ret);
-	return ret;
+Size2 StyleBox::get_minimum_size() const {
+	Size2 min_size = Size2(get_margin(SIDE_LEFT) + get_margin(SIDE_RIGHT), get_margin(SIDE_TOP) + get_margin(SIDE_BOTTOM));
+	Size2 custom_size;
+	GDVIRTUAL_CALL(_get_minimum_size, custom_size);
+
+	if (min_size.x < custom_size.x) {
+		min_size.x = custom_size.x;
+	}
+	if (min_size.y < custom_size.y) {
+		min_size.y = custom_size.y;
+	}
+
+	return min_size;
 }
 
-bool StyleBox::test_mask(const Point2 &p_point, const Rect2 &p_rect) const {
-	bool ret = true;
-	GDVIRTUAL_CALL(_test_mask, p_point, p_rect, ret);
-	return ret;
-}
-
-void StyleBox::draw(RID p_canvas_item, const Rect2 &p_rect) const {
-	GDVIRTUAL_REQUIRED_CALL(_draw, p_canvas_item, p_rect);
-}
-
-void StyleBox::set_default_margin(Side p_side, float p_value) {
+void StyleBox::set_content_margin(Side p_side, float p_value) {
 	ERR_FAIL_INDEX((int)p_side, 4);
 
-	margin[p_side] = p_value;
+	content_margin[p_side] = p_value;
 	emit_changed();
 }
 
-void StyleBox::set_default_margin_all(float p_value) {
+void StyleBox::set_content_margin_all(float p_value) {
 	for (int i = 0; i < 4; i++) {
-		margin[i] = p_value;
+		content_margin[i] = p_value;
 	}
 	emit_changed();
 }
 
-void StyleBox::set_default_margin_individual(float p_left, float p_top, float p_right, float p_bottom) {
-	margin[SIDE_LEFT] = p_left;
-	margin[SIDE_TOP] = p_top;
-	margin[SIDE_RIGHT] = p_right;
-	margin[SIDE_BOTTOM] = p_bottom;
+void StyleBox::set_content_margin_individual(float p_left, float p_top, float p_right, float p_bottom) {
+	content_margin[SIDE_LEFT] = p_left;
+	content_margin[SIDE_TOP] = p_top;
+	content_margin[SIDE_RIGHT] = p_right;
+	content_margin[SIDE_BOTTOM] = p_bottom;
 	emit_changed();
 }
 
-float StyleBox::get_default_margin(Side p_side) const {
+float StyleBox::get_content_margin(Side p_side) const {
 	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);
 
-	return margin[p_side];
+	return content_margin[p_side];
 }
 
 float StyleBox::get_margin(Side p_side) const {
 	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);
 
-	if (margin[p_side] < 0) {
+	if (content_margin[p_side] < 0) {
 		return get_style_margin(p_side);
 	} else {
-		return margin[p_side];
+		return content_margin[p_side];
 	}
-}
-
-CanvasItem *StyleBox::get_current_item_drawn() const {
-	return CanvasItem::get_current_item_drawn();
-}
-
-Size2 StyleBox::get_minimum_size() const {
-	return Size2(get_margin(SIDE_LEFT) + get_margin(SIDE_RIGHT), get_margin(SIDE_TOP) + get_margin(SIDE_BOTTOM));
 }
 
 Point2 StyleBox::get_offset() const {
 	return Point2(get_margin(SIDE_LEFT), get_margin(SIDE_TOP));
 }
 
-Size2 StyleBox::get_center_size() const {
-	Size2 ret;
-	GDVIRTUAL_CALL(_get_center_size, ret);
-	return ret;
+void StyleBox::draw(RID p_canvas_item, const Rect2 &p_rect) const {
+	GDVIRTUAL_REQUIRED_CALL(_draw, p_canvas_item, p_rect);
 }
 
 Rect2 StyleBox::get_draw_rect(const Rect2 &p_rect) const {
@@ -114,37 +103,46 @@ Rect2 StyleBox::get_draw_rect(const Rect2 &p_rect) const {
 	return p_rect;
 }
 
-void StyleBox::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("test_mask", "point", "rect"), &StyleBox::test_mask);
+CanvasItem *StyleBox::get_current_item_drawn() const {
+	return CanvasItem::get_current_item_drawn();
+}
 
-	ClassDB::bind_method(D_METHOD("set_default_margin", "margin", "offset"), &StyleBox::set_default_margin);
-	ClassDB::bind_method(D_METHOD("set_default_margin_all", "offset"), &StyleBox::set_default_margin_all);
-	ClassDB::bind_method(D_METHOD("get_default_margin", "margin"), &StyleBox::get_default_margin);
+bool StyleBox::test_mask(const Point2 &p_point, const Rect2 &p_rect) const {
+	bool ret = true;
+	GDVIRTUAL_CALL(_test_mask, p_point, p_rect, ret);
+	return ret;
+}
+
+void StyleBox::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_minimum_size"), &StyleBox::get_minimum_size);
+
+	ClassDB::bind_method(D_METHOD("set_content_margin", "margin", "offset"), &StyleBox::set_content_margin);
+	ClassDB::bind_method(D_METHOD("set_content_margin_all", "offset"), &StyleBox::set_content_margin_all);
+	ClassDB::bind_method(D_METHOD("get_content_margin", "margin"), &StyleBox::get_content_margin);
 
 	ClassDB::bind_method(D_METHOD("get_margin", "margin"), &StyleBox::get_margin);
-	ClassDB::bind_method(D_METHOD("get_minimum_size"), &StyleBox::get_minimum_size);
-	ClassDB::bind_method(D_METHOD("get_center_size"), &StyleBox::get_center_size);
 	ClassDB::bind_method(D_METHOD("get_offset"), &StyleBox::get_offset);
-	ClassDB::bind_method(D_METHOD("get_current_item_drawn"), &StyleBox::get_current_item_drawn);
 
 	ClassDB::bind_method(D_METHOD("draw", "canvas_item", "rect"), &StyleBox::draw);
+	ClassDB::bind_method(D_METHOD("get_current_item_drawn"), &StyleBox::get_current_item_drawn);
+
+	ClassDB::bind_method(D_METHOD("test_mask", "point", "rect"), &StyleBox::test_mask);
 
 	ADD_GROUP("Content Margins", "content_margin_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "content_margin_left", PROPERTY_HINT_RANGE, "-1,2048,1,suffix:px"), "set_default_margin", "get_default_margin", SIDE_LEFT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "content_margin_top", PROPERTY_HINT_RANGE, "-1,2048,1,suffix:px"), "set_default_margin", "get_default_margin", SIDE_TOP);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "content_margin_right", PROPERTY_HINT_RANGE, "-1,2048,1,suffix:px"), "set_default_margin", "get_default_margin", SIDE_RIGHT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "content_margin_bottom", PROPERTY_HINT_RANGE, "-1,2048,1,suffix:px"), "set_default_margin", "get_default_margin", SIDE_BOTTOM);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "content_margin_left", PROPERTY_HINT_RANGE, "-1,2048,1,suffix:px"), "set_content_margin", "get_content_margin", SIDE_LEFT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "content_margin_top", PROPERTY_HINT_RANGE, "-1,2048,1,suffix:px"), "set_content_margin", "get_content_margin", SIDE_TOP);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "content_margin_right", PROPERTY_HINT_RANGE, "-1,2048,1,suffix:px"), "set_content_margin", "get_content_margin", SIDE_RIGHT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "content_margin_bottom", PROPERTY_HINT_RANGE, "-1,2048,1,suffix:px"), "set_content_margin", "get_content_margin", SIDE_BOTTOM);
 
-	GDVIRTUAL_BIND(_get_style_margin, "side")
-	GDVIRTUAL_BIND(_test_mask, "point", "rect")
-	GDVIRTUAL_BIND(_get_center_size)
-	GDVIRTUAL_BIND(_get_draw_rect, "rect")
 	GDVIRTUAL_BIND(_draw, "to_canvas_item", "rect")
+	GDVIRTUAL_BIND(_get_draw_rect, "rect")
+	GDVIRTUAL_BIND(_get_minimum_size)
+	GDVIRTUAL_BIND(_test_mask, "point", "rect")
 }
 
 StyleBox::StyleBox() {
 	for (int i = 0; i < 4; i++) {
-		margin[i] = -1;
+		content_margin[i] = -1;
 	}
 }
 
@@ -165,38 +163,38 @@ Ref<Texture2D> StyleBoxTexture::get_texture() const {
 	return texture;
 }
 
-void StyleBoxTexture::set_margin_size(Side p_side, float p_size) {
+void StyleBoxTexture::set_texture_margin(Side p_side, float p_size) {
 	ERR_FAIL_INDEX((int)p_side, 4);
 
-	margin[p_side] = p_size;
+	texture_margin[p_side] = p_size;
 	emit_changed();
 }
 
-void StyleBoxTexture::set_margin_size_all(float p_size) {
+void StyleBoxTexture::set_texture_margin_all(float p_size) {
 	for (int i = 0; i < 4; i++) {
-		margin[i] = p_size;
+		texture_margin[i] = p_size;
 	}
 	emit_changed();
 }
 
-void StyleBoxTexture::set_margin_size_individual(float p_left, float p_top, float p_right, float p_bottom) {
-	margin[SIDE_LEFT] = p_left;
-	margin[SIDE_TOP] = p_top;
-	margin[SIDE_RIGHT] = p_right;
-	margin[SIDE_BOTTOM] = p_bottom;
+void StyleBoxTexture::set_texture_margin_individual(float p_left, float p_top, float p_right, float p_bottom) {
+	texture_margin[SIDE_LEFT] = p_left;
+	texture_margin[SIDE_TOP] = p_top;
+	texture_margin[SIDE_RIGHT] = p_right;
+	texture_margin[SIDE_BOTTOM] = p_bottom;
 	emit_changed();
 }
 
-float StyleBoxTexture::get_margin_size(Side p_side) const {
+float StyleBoxTexture::get_texture_margin(Side p_side) const {
 	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);
 
-	return margin[p_side];
+	return texture_margin[p_side];
 }
 
 float StyleBoxTexture::get_style_margin(Side p_side) const {
 	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);
 
-	return margin[p_side];
+	return texture_margin[p_side];
 }
 
 Rect2 StyleBoxTexture::get_draw_rect(const Rect2 &p_rect) const {
@@ -218,7 +216,10 @@ void StyleBoxTexture::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	rect.size.x += expand_margin[SIDE_LEFT] + expand_margin[SIDE_RIGHT];
 	rect.size.y += expand_margin[SIDE_TOP] + expand_margin[SIDE_BOTTOM];
 
-	RenderingServer::get_singleton()->canvas_item_add_nine_patch(p_canvas_item, rect, src_rect, texture->get_rid(), Vector2(margin[SIDE_LEFT], margin[SIDE_TOP]), Vector2(margin[SIDE_RIGHT], margin[SIDE_BOTTOM]), RS::NinePatchAxisMode(axis_h), RS::NinePatchAxisMode(axis_v), draw_center, modulate);
+	Vector2 start_offset = Vector2(texture_margin[SIDE_LEFT], texture_margin[SIDE_TOP]);
+	Vector2 end_offset = Vector2(texture_margin[SIDE_RIGHT], texture_margin[SIDE_BOTTOM]);
+
+	RenderingServer::get_singleton()->canvas_item_add_nine_patch(p_canvas_item, rect, src_rect, texture->get_rid(), start_offset, end_offset, RS::NinePatchAxisMode(axis_h), RS::NinePatchAxisMode(axis_v), draw_center, modulate);
 }
 
 void StyleBoxTexture::set_draw_center(bool p_enabled) {
@@ -230,21 +231,29 @@ bool StyleBoxTexture::is_draw_center_enabled() const {
 	return draw_center;
 }
 
-Size2 StyleBoxTexture::get_center_size() const {
-	if (texture.is_null()) {
-		return Size2();
+Size2 StyleBoxTexture::get_minimum_size() const {
+	Size2 min_size = StyleBox::get_minimum_size();
+
+	// Make sure that the min size is no smaller than the used texture region.
+	if (texture.is_valid()) {
+		if (min_size.x < region_rect.size.x) {
+			min_size.x = region_rect.size.x;
+		}
+		if (min_size.y < region_rect.size.y) {
+			min_size.y = region_rect.size.y;
+		}
 	}
 
-	return region_rect.size - get_minimum_size();
+	return min_size;
 }
 
-void StyleBoxTexture::set_expand_margin_size(Side p_side, float p_size) {
+void StyleBoxTexture::set_expand_margin(Side p_side, float p_size) {
 	ERR_FAIL_INDEX((int)p_side, 4);
 	expand_margin[p_side] = p_size;
 	emit_changed();
 }
 
-void StyleBoxTexture::set_expand_margin_size_individual(float p_left, float p_top, float p_right, float p_bottom) {
+void StyleBoxTexture::set_expand_margin_individual(float p_left, float p_top, float p_right, float p_bottom) {
 	expand_margin[SIDE_LEFT] = p_left;
 	expand_margin[SIDE_TOP] = p_top;
 	expand_margin[SIDE_RIGHT] = p_right;
@@ -252,14 +261,14 @@ void StyleBoxTexture::set_expand_margin_size_individual(float p_left, float p_to
 	emit_changed();
 }
 
-void StyleBoxTexture::set_expand_margin_size_all(float p_expand_margin_size) {
+void StyleBoxTexture::set_expand_margin_all(float p_expand_margin_size) {
 	for (int i = 0; i < 4; i++) {
 		expand_margin[i] = p_expand_margin_size;
 	}
 	emit_changed();
 }
 
-float StyleBoxTexture::get_expand_margin_size(Side p_side) const {
+float StyleBoxTexture::get_expand_margin(Side p_side) const {
 	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
 	return expand_margin[p_side];
 }
@@ -313,13 +322,13 @@ void StyleBoxTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_texture", "texture"), &StyleBoxTexture::set_texture);
 	ClassDB::bind_method(D_METHOD("get_texture"), &StyleBoxTexture::get_texture);
 
-	ClassDB::bind_method(D_METHOD("set_margin_size", "margin", "size"), &StyleBoxTexture::set_margin_size);
-	ClassDB::bind_method(D_METHOD("set_margin_size_all", "size"), &StyleBoxTexture::set_margin_size_all);
-	ClassDB::bind_method(D_METHOD("get_margin_size", "margin"), &StyleBoxTexture::get_margin_size);
+	ClassDB::bind_method(D_METHOD("set_texture_margin", "margin", "size"), &StyleBoxTexture::set_texture_margin);
+	ClassDB::bind_method(D_METHOD("set_texture_margin_all", "size"), &StyleBoxTexture::set_texture_margin_all);
+	ClassDB::bind_method(D_METHOD("get_texture_margin", "margin"), &StyleBoxTexture::get_texture_margin);
 
-	ClassDB::bind_method(D_METHOD("set_expand_margin_size", "margin", "size"), &StyleBoxTexture::set_expand_margin_size);
-	ClassDB::bind_method(D_METHOD("set_expand_margin_all", "size"), &StyleBoxTexture::set_expand_margin_size_all);
-	ClassDB::bind_method(D_METHOD("get_expand_margin_size", "margin"), &StyleBoxTexture::get_expand_margin_size);
+	ClassDB::bind_method(D_METHOD("set_expand_margin", "margin", "size"), &StyleBoxTexture::set_expand_margin);
+	ClassDB::bind_method(D_METHOD("set_expand_margin_all", "size"), &StyleBoxTexture::set_expand_margin_all);
+	ClassDB::bind_method(D_METHOD("get_expand_margin", "margin"), &StyleBoxTexture::get_expand_margin);
 
 	ClassDB::bind_method(D_METHOD("set_region_rect", "region"), &StyleBoxTexture::set_region_rect);
 	ClassDB::bind_method(D_METHOD("get_region_rect"), &StyleBoxTexture::get_region_rect);
@@ -338,17 +347,17 @@ void StyleBoxTexture::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture");
 
-	ADD_GROUP("Margins", "margin_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "margin_left", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_margin_size", "get_margin_size", SIDE_LEFT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "margin_top", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_margin_size", "get_margin_size", SIDE_TOP);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "margin_right", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_margin_size", "get_margin_size", SIDE_RIGHT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "margin_bottom", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_margin_size", "get_margin_size", SIDE_BOTTOM);
+	ADD_GROUP("Texture Margins", "texture_margin_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "texture_margin_left", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_texture_margin", "get_texture_margin", SIDE_LEFT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "texture_margin_top", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_texture_margin", "get_texture_margin", SIDE_TOP);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "texture_margin_right", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_texture_margin", "get_texture_margin", SIDE_RIGHT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "texture_margin_bottom", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_texture_margin", "get_texture_margin", SIDE_BOTTOM);
 
 	ADD_GROUP("Expand Margins", "expand_margin_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "expand_margin_left", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_expand_margin_size", "get_expand_margin_size", SIDE_LEFT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "expand_margin_top", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_expand_margin_size", "get_expand_margin_size", SIDE_TOP);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "expand_margin_right", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_expand_margin_size", "get_expand_margin_size", SIDE_RIGHT);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "expand_margin_bottom", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_expand_margin_size", "get_expand_margin_size", SIDE_BOTTOM);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "expand_margin_left", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_expand_margin", "get_expand_margin", SIDE_LEFT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "expand_margin_top", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_expand_margin", "get_expand_margin", SIDE_TOP);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "expand_margin_right", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_expand_margin", "get_expand_margin", SIDE_RIGHT);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "expand_margin_bottom", PROPERTY_HINT_RANGE, "0,2048,1,suffix:px"), "set_expand_margin", "get_expand_margin", SIDE_BOTTOM);
 
 	ADD_GROUP("Axis Stretch", "axis_stretch_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "axis_stretch_horizontal", PROPERTY_HINT_ENUM, "Stretch,Tile,Tile Fit"), "set_h_axis_stretch_mode", "get_h_axis_stretch_mode");
@@ -450,13 +459,13 @@ int StyleBoxFlat::get_corner_radius(const Corner p_corner) const {
 	return corner_radius[p_corner];
 }
 
-void StyleBoxFlat::set_expand_margin_size(Side p_side, float p_size) {
+void StyleBoxFlat::set_expand_margin(Side p_side, float p_size) {
 	ERR_FAIL_INDEX((int)p_side, 4);
 	expand_margin[p_side] = p_size;
 	emit_changed();
 }
 
-void StyleBoxFlat::set_expand_margin_size_individual(float p_left, float p_top, float p_right, float p_bottom) {
+void StyleBoxFlat::set_expand_margin_individual(float p_left, float p_top, float p_right, float p_bottom) {
 	expand_margin[SIDE_LEFT] = p_left;
 	expand_margin[SIDE_TOP] = p_top;
 	expand_margin[SIDE_RIGHT] = p_right;
@@ -464,14 +473,14 @@ void StyleBoxFlat::set_expand_margin_size_individual(float p_left, float p_top, 
 	emit_changed();
 }
 
-void StyleBoxFlat::set_expand_margin_size_all(float p_expand_margin_size) {
+void StyleBoxFlat::set_expand_margin_all(float p_expand_margin_size) {
 	for (int i = 0; i < 4; i++) {
 		expand_margin[i] = p_expand_margin_size;
 	}
 	emit_changed();
 }
 
-float StyleBoxFlat::get_expand_margin_size(Side p_side) const {
+float StyleBoxFlat::get_expand_margin(Side p_side) const {
 	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);
 	return expand_margin[p_side];
 }
@@ -547,10 +556,6 @@ void StyleBoxFlat::set_corner_detail(const int &p_corner_detail) {
 
 int StyleBoxFlat::get_corner_detail() const {
 	return corner_detail;
-}
-
-Size2 StyleBoxFlat::get_center_size() const {
-	return Size2();
 }
 
 inline void set_inner_corner_radius(const Rect2 style_rect, const Rect2 inner_rect, const real_t corner_radius[4], real_t *inner_corner_radius) {
@@ -891,9 +896,9 @@ void StyleBoxFlat::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_corner_radius", "corner", "radius"), &StyleBoxFlat::set_corner_radius);
 	ClassDB::bind_method(D_METHOD("get_corner_radius", "corner"), &StyleBoxFlat::get_corner_radius);
 
-	ClassDB::bind_method(D_METHOD("set_expand_margin", "margin", "size"), &StyleBoxFlat::set_expand_margin_size);
-	ClassDB::bind_method(D_METHOD("set_expand_margin_all", "size"), &StyleBoxFlat::set_expand_margin_size_all);
-	ClassDB::bind_method(D_METHOD("get_expand_margin", "margin"), &StyleBoxFlat::get_expand_margin_size);
+	ClassDB::bind_method(D_METHOD("set_expand_margin", "margin", "size"), &StyleBoxFlat::set_expand_margin);
+	ClassDB::bind_method(D_METHOD("set_expand_margin_all", "size"), &StyleBoxFlat::set_expand_margin_all);
+	ClassDB::bind_method(D_METHOD("get_expand_margin", "margin"), &StyleBoxFlat::get_expand_margin);
 
 	ClassDB::bind_method(D_METHOD("set_draw_center", "draw_center"), &StyleBoxFlat::set_draw_center);
 	ClassDB::bind_method(D_METHOD("is_draw_center_enabled"), &StyleBoxFlat::is_draw_center_enabled);
@@ -1039,10 +1044,6 @@ float StyleBoxLine::get_style_margin(Side p_side) const {
 	}
 
 	return 0;
-}
-
-Size2 StyleBoxLine::get_center_size() const {
-	return Size2();
 }
 
 void StyleBoxLine::draw(RID p_canvas_item, const Rect2 &p_rect) const {

--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -41,36 +41,34 @@ class StyleBox : public Resource {
 	GDCLASS(StyleBox, Resource);
 	RES_BASE_EXTENSION("stylebox");
 	OBJ_SAVE_TYPE(StyleBox);
-	float margin[4];
+	float content_margin[4];
 
 protected:
-	virtual float get_style_margin(Side p_side) const;
+	virtual float get_style_margin(Side p_side) const { return 0; }
 	static void _bind_methods();
 
-	GDVIRTUAL1RC(float, _get_style_margin, Side)
-	GDVIRTUAL2RC(bool, _test_mask, Point2, Rect2)
-	GDVIRTUAL0RC(Size2, _get_center_size)
-	GDVIRTUAL1RC(Rect2, _get_draw_rect, Rect2)
 	GDVIRTUAL2C(_draw, RID, Rect2)
+	GDVIRTUAL1RC(Rect2, _get_draw_rect, Rect2)
+	GDVIRTUAL0RC(Size2, _get_minimum_size)
+	GDVIRTUAL2RC(bool, _test_mask, Point2, Rect2)
 
 public:
-	virtual bool test_mask(const Point2 &p_point, const Rect2 &p_rect) const;
+	virtual Size2 get_minimum_size() const;
 
-	void set_default_margin(Side p_side, float p_value);
-	void set_default_margin_all(float p_value);
-	void set_default_margin_individual(float p_left, float p_top, float p_right, float p_bottom);
-	float get_default_margin(Side p_side) const;
+	void set_content_margin(Side p_side, float p_value);
+	void set_content_margin_all(float p_value);
+	void set_content_margin_individual(float p_left, float p_top, float p_right, float p_bottom);
+	float get_content_margin(Side p_side) const;
 
 	float get_margin(Side p_side) const;
-	virtual Size2 get_center_size() const;
+	Point2 get_offset() const;
 
-	virtual Rect2 get_draw_rect(const Rect2 &p_rect) const;
 	virtual void draw(RID p_canvas_item, const Rect2 &p_rect) const;
+	virtual Rect2 get_draw_rect(const Rect2 &p_rect) const;
 
 	CanvasItem *get_current_item_drawn() const;
 
-	Size2 get_minimum_size() const;
-	Point2 get_offset() const;
+	virtual bool test_mask(const Point2 &p_point, const Rect2 &p_rect) const;
 
 	StyleBox();
 };
@@ -96,7 +94,7 @@ public:
 
 private:
 	float expand_margin[4] = {};
-	float margin[4] = {};
+	float texture_margin[4] = {};
 	Rect2 region_rect;
 	Ref<Texture2D> texture;
 	bool draw_center = true;
@@ -109,15 +107,17 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_expand_margin_size(Side p_expand_side, float p_size);
-	void set_expand_margin_size_all(float p_expand_margin_size);
-	void set_expand_margin_size_individual(float p_left, float p_top, float p_right, float p_bottom);
-	float get_expand_margin_size(Side p_expand_side) const;
+	virtual Size2 get_minimum_size() const override;
 
-	void set_margin_size(Side p_side, float p_size);
-	void set_margin_size_all(float p_size);
-	void set_margin_size_individual(float p_left, float p_top, float p_right, float p_bottom);
-	float get_margin_size(Side p_side) const;
+	void set_expand_margin(Side p_expand_side, float p_size);
+	void set_expand_margin_all(float p_expand_margin_size);
+	void set_expand_margin_individual(float p_left, float p_top, float p_right, float p_bottom);
+	float get_expand_margin(Side p_expand_side) const;
+
+	void set_texture_margin(Side p_side, float p_size);
+	void set_texture_margin_all(float p_size);
+	void set_texture_margin_individual(float p_left, float p_top, float p_right, float p_bottom);
+	float get_texture_margin(Side p_side) const;
 
 	void set_region_rect(const Rect2 &p_region_rect);
 	Rect2 get_region_rect() const;
@@ -127,7 +127,6 @@ public:
 
 	void set_draw_center(bool p_enabled);
 	bool is_draw_center_enabled() const;
-	virtual Size2 get_center_size() const override;
 
 	void set_h_axis_stretch_mode(AxisStretchMode p_mode);
 	AxisStretchMode get_h_axis_stretch_mode() const;
@@ -198,10 +197,10 @@ public:
 	void set_corner_detail(const int &p_corner_detail);
 	int get_corner_detail() const;
 
-	void set_expand_margin_size(Side p_expand_side, float p_size);
-	void set_expand_margin_size_all(float p_expand_margin_size);
-	void set_expand_margin_size_individual(float p_left, float p_top, float p_right, float p_bottom);
-	float get_expand_margin_size(Side p_expand_side) const;
+	void set_expand_margin(Side p_expand_side, float p_size);
+	void set_expand_margin_all(float p_expand_margin_size);
+	void set_expand_margin_individual(float p_left, float p_top, float p_right, float p_bottom);
+	float get_expand_margin(Side p_expand_side) const;
 
 	void set_draw_center(bool p_enabled);
 	bool is_draw_center_enabled() const;
@@ -222,8 +221,6 @@ public:
 	bool is_anti_aliased() const;
 	void set_aa_size(const real_t p_aa_size);
 	real_t get_aa_size() const;
-
-	virtual Size2 get_center_size() const override;
 
 	virtual Rect2 get_draw_rect(const Rect2 &p_rect) const override;
 	virtual void draw(RID p_canvas_item, const Rect2 &p_rect) const override;
@@ -260,8 +257,6 @@ public:
 
 	void set_grow_end(float p_grow);
 	float get_grow_end() const;
-
-	virtual Size2 get_center_size() const override;
 
 	virtual void draw(RID p_canvas_item, const Rect2 &p_rect) const override;
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5903. Should make it possible to properly solve https://github.com/godotengine/godot/pull/71657.

This PR attempts to clean up the StyleBox API before we're completely frozen for another ten years. There are 3 main changes:

1. **Many margin properties and their methods have names that don't follow the same convention.** I renamed a bunch of them that were falling out of line.

  - `content_margin_*` properties used the `default_margin` identifier in related methods. They all have been renamed to use `content_margin`. Internal property has also been renamed to `content_margins` instead of just `margins`, to reduce ambiguity with other margins from other classes.
  - `expand_margin_*` properties had `*_size` suffix, unlike some other margins. I removed the suffix from all the methods and identifiers.
  - `StyleBoxTexture` had just `margin` properties (which also used the `*_size` suffix) which related to the texture itself. I renamed those and their methods to explicitly state so, using the `texture_margin` identifier. Naming was especially confusing internally, as the internal property, `margins`, collided with the internal property for the content margins, also called `margins`, but being from a different scope.

2. **Virtual method `get_style_margin` is exposed, though doesn't have intended use for scripting.** It was exposed like so in https://github.com/godotengine/godot/pull/58972, but the method was only an internal virtual method used for internal logic of some stylebox types. It wasn't exposed before and wasn't documented, so it's preferable to hide it for now. Which I did.

3. **Minimum size computations throughout the codebase rely on the `get_center_size` method, which has no use outside of `StyleBoxTexture`, where it causes more issues than solved.** As discussed before, and proposed in https://github.com/godotengine/godot-proposals/issues/5903, I removed `get_center_size`, implemented a way to override `get_minimum_size` from code, and moved `StyleBoxTexture` to use the new logic instead. The margins are still respected regardless of the value returned from `_get_minimum_size`, a combined value is computed. This makes it possible to control the min size of scrollbars, for example (see https://github.com/godotengine/godot/pull/71657).

-----

Testing is appreciated! Some of these renames can be added to the project convertor, but I'd like to make sure we're okay with them first.