### PR TITLE
Remove a duplicated unnecessary line from BlendSpace2DEditor

### DIFF
--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -74,7 +74,6 @@ void AnimationNodeBlendSpace2DEditor::edit(const Ref<AnimationNode> &p_node) {
 	}
 
 	tool_create->set_disabled(read_only);
-	interpolation->set_disabled(read_only);
 	max_x_value->set_editable(!read_only);
 	min_x_value->set_editable(!read_only);
 	max_y_value->set_editable(!read_only);


### PR DESCRIPTION
There is the same line just below...

![image](https://user-images.githubusercontent.com/61938263/213529172-a54608dc-8fce-41dd-9b74-2a4a645eb6c6.png)