### PR TITLE
Fix DirectionalLight3D shadow opacity on Forward Mobile rendering backend

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1798,7 +1798,7 @@ void fragment_shader(in SceneData scene_data) {
 				shadow = float(shadow1 >> ((i - 4u) * 8u) & 0xFFu) / 255.0;
 			}
 
-			shadow = shadow * directional_lights.data[i].shadow_opacity + 1.0 - directional_lights.data[i].shadow_opacity;
+			shadow = mix(1.0, shadow, directional_lights.data[i].shadow_opacity);
 #endif
 
 			blur_shadow(shadow);

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1515,6 +1515,8 @@ void main() {
 			} else {
 				shadow = float(shadow1 >> ((i - 4) * 8) & 0xFF) / 255.0;
 			}
+
+			shadow = mix(1.0, shadow, directional_lights.data[i].shadow_opacity);
 #endif
 			blur_shadow(shadow);
 


### PR DESCRIPTION
This adds a line of code that was only added to `scene_forward_clustered.glsl` by https://github.com/godotengine/godot/pull/61893.

Thanks @lostminds for spotting the issue :slightly_smiling_face:

This closes https://github.com/godotengine/godot/issues/71606.

**Testing project:** [test_directionallight3d_shadow_opacity_mobile.zip](https://github.com/godotengine/godot/files/10460088/test_directionallight3d_shadow_opacity_mobile.zip)

## Preview

https://user-images.githubusercontent.com/180032/213532934-967124d8-711c-4251-990a-b26075781aa4.mp4