### PR TITLE
Fix SceneImportSettings perf issues

### DIFF
--- a/editor/import/scene_import_settings.h
+++ b/editor/import/scene_import_settings.h
@@ -191,6 +191,7 @@ class SceneImportSettings : public ConfirmationDialog {
 	void _load_default_subresource_settings(HashMap<StringName, Variant> &settings, const String &p_type, const String &p_import_id, ResourceImporterScene::InternalImportCategory p_category);
 
 	bool editing_animation = false;
+	bool generate_collider = false;
 
 	Timer *update_view_timer = nullptr;
 
@@ -199,6 +200,7 @@ protected:
 
 public:
 	bool is_editing_animation() const { return editing_animation; }
+	void request_generate_collider();
 	void update_view();
 	void open_settings(const String &p_path, bool p_for_animation = false);
 	static SceneImportSettings *get_singleton();


### PR DESCRIPTION
Scene Importer was generating collider mesh at every tick when `Physics` options was enabled, this makes it only do it when changing settings related to `INTERNAL_IMPORT_CATEGORY_MESH_3D_NODE`.

Honestly I am not 100% confident the actual implementation is how something like this would be done in the project but I couldn't find some clear pattern to replicate.

This closes https://github.com/godotengine/godot/issues/68301