### PR TITLE
Fix shader preprocessor memory leak

### DIFF
--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -1081,21 +1081,17 @@ ShaderPreprocessor::Define *ShaderPreprocessor::create_define(const String &p_bo
 	return define;
 }
 
-void ShaderPreprocessor::clear() {
-	if (state_owner && state != nullptr) {
+void ShaderPreprocessor::clear_state() {
+	if (state != nullptr) {
 		for (const RBMap<String, Define *>::Element *E = state->defines.front(); E; E = E->next()) {
 			memdelete(E->get());
 		}
-
-		memdelete(state);
+		state->defines.clear();
 	}
-	state_owner = false;
 	state = nullptr;
 }
 
 Error ShaderPreprocessor::preprocess(State *p_state, const String &p_code, String &r_result) {
-	clear();
-
 	output.clear();
 
 	state = p_state;
@@ -1242,6 +1238,9 @@ Error ShaderPreprocessor::preprocess(const String &p_code, const String &p_filen
 			}
 		}
 	}
+
+	clear_state();
+
 	return err;
 }
 
@@ -1273,5 +1272,4 @@ ShaderPreprocessor::ShaderPreprocessor() {
 }
 
 ShaderPreprocessor::~ShaderPreprocessor() {
-	clear();
 }

--- a/servers/rendering/shader_preprocessor.h
+++ b/servers/rendering/shader_preprocessor.h
@@ -167,7 +167,6 @@ private:
 private:
 	LocalVector<char32_t> output;
 	State *state = nullptr;
-	bool state_owner = false;
 
 private:
 	static bool is_char_word(char32_t p_char);
@@ -211,7 +210,7 @@ private:
 
 	static Define *create_define(const String &p_body);
 
-	void clear();
+	void clear_state();
 
 	Error preprocess(State *p_state, const String &p_code, String &r_result);
 


### PR DESCRIPTION
Fixes a memory leak in the shader preprocessor I noticed (not reported previously).

The leak was introduced at some point during the refactoring, state_owner boolean tracking the state ownership was never set to true for the topmost preprocessor which then leaked all macro structures afterwards. I removed the whole flag as it is no longer needed because the State object is now kept on stack (so no need to call _memdelete(state)_ either) inside the function instead of heap allocated so we always know if we are the owner. Also removed the clear from destructor, it is no longer needed as the whole processing step is self-contained inside the function and it might confuse people because of the recursive nature of the state handling.