### PR TITLE
Web Editor: Fix callable binding for Download Zip menu item

### DIFF
--- a/platform/web/api/web_tools_editor_plugin.cpp
+++ b/platform/web/api/web_tools_editor_plugin.cpp
@@ -57,7 +57,7 @@ WebToolsEditorPlugin::WebToolsEditorPlugin() {
 	add_tool_menu_item("Download Project Source", callable_mp(this, &WebToolsEditorPlugin::_download_zip));
 }
 
-void WebToolsEditorPlugin::_download_zip(Variant p_v) {
+void WebToolsEditorPlugin::_download_zip() {
 	if (!Engine::get_singleton() || !Engine::get_singleton()->is_editor_hint()) {
 		ERR_PRINT("Downloading the project as a ZIP archive is only available in Editor mode.");
 		return;

--- a/platform/web/api/web_tools_editor_plugin.h
+++ b/platform/web/api/web_tools_editor_plugin.h
@@ -41,7 +41,7 @@ class WebToolsEditorPlugin : public EditorPlugin {
 private:
 	void _zip_file(String p_path, String p_base_path, zipFile p_zip);
 	void _zip_recursive(String p_path, String p_base_path, zipFile p_zip);
-	void _download_zip(Variant p_v);
+	void _download_zip();
 
 public:
 	static void initialize();


### PR DESCRIPTION
Fixes #71702.

Note: I didn't test, it could be that the Variant arg is a mandatory part of binding to menu item and that it should be readded as bind.