### PR TITLE
Get OpenXR with OpenGL working on SteamVR

### DIFF
--- a/modules/openxr/extensions/openxr_opengl_extension.cpp
+++ b/modules/openxr/extensions/openxr_opengl_extension.cpp
@@ -158,12 +158,14 @@ void *OpenXROpenGLExtension::set_session_create_and_get_next_pointer(void *p_nex
 
 void OpenXROpenGLExtension::get_usable_swapchain_formats(Vector<int64_t> &p_usable_swap_chains) {
 	p_usable_swap_chains.push_back(GL_RGBA8);
+	p_usable_swap_chains.push_back(GL_SRGB8_ALPHA8);
 }
 
 void OpenXROpenGLExtension::get_usable_depth_formats(Vector<int64_t> &p_usable_depth_formats) {
 	p_usable_depth_formats.push_back(GL_DEPTH_COMPONENT32F);
 	p_usable_depth_formats.push_back(GL_DEPTH24_STENCIL8);
 	p_usable_depth_formats.push_back(GL_DEPTH32F_STENCIL8);
+	p_usable_depth_formats.push_back(GL_DEPTH_COMPONENT24);
 }
 
 bool OpenXROpenGLExtension::get_swapchain_image_data(XrSwapchain p_swapchain, int64_t p_swapchain_format, uint32_t p_width, uint32_t p_height, uint32_t p_sample_count, uint32_t p_array_size, void **r_swapchain_graphics_data) {


### PR DESCRIPTION
This finally gets OpenXR with OpenGL working on SteamVR in my testing (with a Quest 2 over Air Link)!

Without this PR, you'll get:

```
Couldn't find usable color swap chain format, using GL_RGBA8 instead.
OpenXR: Failed to get swapchain [ XR_ERROR_SWAPCHAIN_FORMAT_UNSUPPORTED ]
```

It's adding back `GL_SRGB8_ALPHA8` as a possible color swapchain format, which was removed in PR #71224, but it's putting it at the end of the list (rather than the start) so `GL_RGBA8` will be selected if a headset/runtime supports both options. This should mean that the color issue on Pico that PR #71224 fixed will stay fixed, but it'd probably be good for @rsjtdrjgfuzkfg to double check!

It also adds `GL_DEPTH_COMPONENT24` as a depth swapchain format. This won't be needed for long, because SteamVR beta has support for `GL_DEPTH_COMPONENT32F` and it'll end up in the non-beta version soon. But it's still a good last choice fallback, since that's the normal non-XR depth format used by Godot, and I believe it's required by the OpenGL spec to be supported, so this should cover us for any future OpenXR headsets or runtimes.
