### PR TITLE
Document image size restrictions for custom mouse cursors in HTML5

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -297,6 +297,7 @@
 				[param hotspot] must be within [param image]'s size.
 				[b]Note:[/b] [AnimatedTexture]s aren't supported as custom mouse cursors. If using an [AnimatedTexture], only the first frame will be displayed.
 				[b]Note:[/b] Only images imported with the [b]Lossless[/b], [b]Lossy[/b] or [b]Uncompressed[/b] compression modes are supported. The [b]Video RAM[/b] compression mode can't be used for custom cursors.
+				[b]Note:[/b] On the web platform, the maximum allowed cursor image size is 128×128. Cursor images larger than 32×32 will also only be displayed if the mouse cursor image is entirely located within the page for [url=https://chromestatus.com/feature/5825971391299584]security reasons[/url].
 			</description>
 		</method>
 		<method name="set_default_cursor_shape">


### PR DESCRIPTION
Credit to @Sharkalien for finding out about this security limitation :slightly_smiling_face:

> Closing this issue since [using](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#icon_size_limits) a custom cursor larger than 32x32 pixels will cause the behavior exhibited above, and this is [implemented into browsers](https://chromestatus.com/feature/5825971391299584) as a security feature against spoofing, so this is outside of Godot's control. 

This closes https://github.com/godotengine/godot/issues/71291.
