### PR TITLE
[macOS] Move extended title bar input to _gui_input and add mouse filters to prevent editor buttons from passing double-click to title.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6755,6 +6755,7 @@ EditorNode::EditorNode() {
 		project_title->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 		project_title->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
 		project_title->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		project_title->set_mouse_filter(Control::MOUSE_FILTER_PASS);
 		left_spacer->add_child(project_title);
 	}
 

--- a/editor/editor_title_bar.cpp
+++ b/editor/editor_title_bar.cpp
@@ -30,7 +30,7 @@
 
 #include "editor/editor_title_bar.h"
 
-void EditorTitleBar::input(const Ref<InputEvent> &p_event) {
+void EditorTitleBar::gui_input(const Ref<InputEvent> &p_event) {
 	if (!can_move) {
 		return;
 	}

--- a/editor/editor_title_bar.h
+++ b/editor/editor_title_bar.h
@@ -42,7 +42,7 @@ class EditorTitleBar : public HBoxContainer {
 	bool can_move = false;
 
 protected:
-	virtual void input(const Ref<InputEvent> &p_event) override;
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	static void _bind_methods(){};
 
 public:


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/71721