### PR TITLE
Fix AltGR getting stuck on Windows right Alt-Tab

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3513,6 +3513,7 @@ void DisplayServerWindows::_process_activate_event(WindowID p_window_id, WPARAM 
 		alt_mem = false;
 		control_mem = false;
 		shift_mem = false;
+		gr_mem = false;
 
 		// Restore mouse mode.
 		_set_mouse_mode_impl(mouse_mode);


### PR DESCRIPTION
Fixes #28511.

**Note**: This fix can be backported to 3.x, should be the same code added here:
https://github.com/godotengine/godot/blob/3.x/platform/windows/os_windows.cpp#L358

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
