### PR TITLE
Support signals and callables in exposed dictionaries

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -1052,6 +1052,14 @@ void EditorPropertyDictionary::update_property() {
 					prop = memnew(EditorPropertyRID);
 
 				} break;
+				case Variant::SIGNAL: {
+					prop = memnew(EditorPropertySignal);
+
+				} break;
+				case Variant::CALLABLE: {
+					prop = memnew(EditorPropertyCallable);
+
+				} break;
 				case Variant::OBJECT: {
 					if (Object::cast_to<EncodedObjectAsID>(value)) {
 						EditorPropertyObjectID *editor = memnew(EditorPropertyObjectID);


### PR DESCRIPTION
Previously the dictionary would display to have more elements than shown, because signals and callables caused an error.