### PR TITLE
Fixed RichTextLabel wrong selection offset after drop cap

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1470,7 +1470,16 @@ float RichTextLabel::_find_click_in_line(ItemFrame *p_frame, int p_line, const V
 				}
 			} break;
 		}
-
+		// Adjust for dropcap.
+		int dc_lines = l.text_buf->get_dropcap_lines();
+		float h_off = l.text_buf->get_dropcap_size().x;
+		if (line <= dc_lines) {
+			if (rtl) {
+				off.x -= h_off;
+			} else {
+				off.x += h_off;
+			}
+		}
 		off.y += TS->shaped_text_get_ascent(rid);
 
 		Array objects = TS->shaped_text_get_objects(rid);


### PR DESCRIPTION
Fixes an issue in RichTextLabel where starting a selection, or selecting across a drop cap, would incorrectly start the selection offset by the width of the drop cap.

I would recommend leaving in the comments, because this is where a future improvement would fix the issue of the drop cap text not currently being selectable, and figuring out how to obtain the drop cap text is not obvious.
