### PR TITLE
Avoid flash of garbage on window creation/resizing on X11

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -139,6 +139,7 @@ class DisplayServerX11 : public DisplayServer {
 		Window x11_window;
 		Window x11_xim_window;
 		::XIC xic;
+		::GC gc;
 		bool ime_active = false;
 		bool ime_in_progress = false;
 		bool ime_suppress_next_keyup = false;
@@ -191,6 +192,8 @@ class DisplayServerX11 : public DisplayServer {
 	xkb_compose_table *dead_tbl = nullptr;
 
 	HashMap<WindowID, WindowData> windows;
+	HashSet<WindowID> windows_pending_map;
+	bool main_win_first_drawn = false;
 
 	unsigned int last_mouse_monitor_mask = 0;
 	uint64_t time_since_popup = 0;


### PR DESCRIPTION
Follow-up of #71289 and #71295.

**(Updated.)**

This is the best implementation I've been able to come up with. Tested on Ubuntu.

- Regarding resize, depending on how fast the renderer repaints the "scene", you may (and most certainly will) still see some ghost black and some ghost transparent.
- Regarding creation, I've used the trick of mapping a window only once buffers have been swapped, unless it's the main window for the first time.

Results are pretty mediocre. Please test on Vulkan and GL to see if it at least improves the current state of affairs. My current Linux setup is a bit limited.

A proper way to do this would likely require the GL and Vulkan renderers to clear the visible surface themselves as needed and probably something else.

We may or may not consider #66742 is closed.