### PR TITLE
Remove references to compiled GDScript in export

### DIFF
--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -77,7 +77,6 @@ void EditorExport::_save() {
 		config->set_value(section, "encryption_exclude_filters", preset->get_enc_ex_filter());
 		config->set_value(section, "encrypt_pck", preset->get_enc_pck());
 		config->set_value(section, "encrypt_directory", preset->get_enc_directory());
-		config->set_value(section, "script_export_mode", preset->get_script_export_mode());
 		config->set_value(section, "script_encryption_key", preset->get_script_encryption_key());
 
 		String option_section = "preset." + itos(i) + ".options";
@@ -263,9 +262,6 @@ void EditorExport::load_config() {
 		}
 		if (config->has_section_key(section, "encryption_exclude_filters")) {
 			preset->set_enc_ex_filter(config->get_value(section, "encryption_exclude_filters"));
-		}
-		if (config->has_section_key(section, "script_export_mode")) {
-			preset->set_script_export_mode(config->get_value(section, "script_export_mode"));
 		}
 		if (config->has_section_key(section, "script_encryption_key")) {
 			preset->set_script_encryption_key(config->get_value(section, "script_encryption_key"));

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -203,15 +203,6 @@ bool EditorExportPreset::get_enc_directory() const {
 	return enc_directory;
 }
 
-void EditorExportPreset::set_script_export_mode(int p_mode) {
-	script_mode = p_mode;
-	EditorExport::singleton->save_presets();
-}
-
-int EditorExportPreset::get_script_export_mode() const {
-	return script_mode;
-}
-
 void EditorExportPreset::set_script_encryption_key(const String &p_key) {
 	script_key = p_key;
 	EditorExport::singleton->save_presets();

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -46,11 +46,6 @@ public:
 		EXCLUDE_SELECTED_RESOURCES,
 	};
 
-	enum ScriptExportMode {
-		MODE_SCRIPT_TEXT,
-		MODE_SCRIPT_COMPILED,
-	};
-
 private:
 	Ref<EditorExportPlatform> platform;
 	ExportFilter export_filter = EXPORT_ALL_RESOURCES;
@@ -78,7 +73,6 @@ private:
 	bool enc_pck = false;
 	bool enc_directory = false;
 
-	int script_mode = MODE_SCRIPT_COMPILED;
 	String script_key;
 
 protected:
@@ -131,9 +125,6 @@ public:
 
 	void set_enc_directory(bool p_enabled);
 	bool get_enc_directory() const;
-
-	void set_script_export_mode(int p_mode);
-	int get_script_export_mode() const;
 
 	void set_script_encryption_key(const String &p_key);
 	String get_script_encryption_key() const;

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -317,9 +317,6 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 	bool enc_directory_mode = current->get_enc_directory();
 	enc_directory->set_pressed(enc_directory_mode);
 
-	int script_export_mode = current->get_script_export_mode();
-	script_mode->select(script_export_mode);
-
 	String key = current->get_script_encryption_key();
 	if (!updating_script_key) {
 		script_key->set_text(key);
@@ -509,19 +506,6 @@ void ProjectExportDialog::_enc_directory_changed(bool p_pressed) {
 	ERR_FAIL_COND(current.is_null());
 
 	current->set_enc_directory(p_pressed);
-
-	_update_current_preset();
-}
-
-void ProjectExportDialog::_script_export_mode_changed(int p_mode) {
-	if (updating) {
-		return;
-	}
-
-	Ref<EditorExportPreset> current = get_current_preset();
-	ERR_FAIL_COND(current.is_null());
-
-	current->set_script_export_mode(p_mode);
 
 	_update_current_preset();
 }
@@ -1110,12 +1094,6 @@ ProjectExportDialog::ProjectExportDialog() {
 			TTR("Filters to exclude files/folders from project\n(comma-separated, e.g: *.json, *.txt, docs/*)"),
 			exclude_filters);
 	exclude_filters->connect("text_changed", callable_mp(this, &ProjectExportDialog::_filter_changed));
-
-	script_mode = memnew(OptionButton);
-	resources_vb->add_margin_child(TTR("GDScript Export Mode:"), script_mode);
-	script_mode->add_item(TTR("Text"), (int)EditorExportPreset::MODE_SCRIPT_TEXT);
-	script_mode->add_item(TTR("Compiled Bytecode (Faster Loading)"), (int)EditorExportPreset::MODE_SCRIPT_COMPILED);
-	script_mode->connect("item_selected", callable_mp(this, &ProjectExportDialog::_script_export_mode_changed));
 
 	// Feature tags.
 

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -86,7 +86,6 @@ private:
 	LineEdit *custom_features = nullptr;
 	RichTextLabel *custom_feature_display = nullptr;
 
-	OptionButton *script_mode = nullptr;
 	LineEdit *script_key = nullptr;
 	Label *script_key_error = nullptr;
 
@@ -152,7 +151,6 @@ private:
 	void _enc_pck_changed(bool p_pressed);
 	void _enc_directory_changed(bool p_pressed);
 	void _enc_filters_changed(const String &p_text);
-	void _script_export_mode_changed(int p_mode);
 	void _script_encryption_key_changed(const String &p_key);
 	bool _validate_script_encryption_key(const String &p_key);
 

--- a/modules/gdscript/doc_classes/GDScript.xml
+++ b/modules/gdscript/doc_classes/GDScript.xml
@@ -11,12 +11,6 @@
 		<link title="GDScript documentation index">$DOCS_URL/tutorials/scripting/gdscript/index.html</link>
 	</tutorials>
 	<methods>
-		<method name="get_as_byte_code" qualifiers="const">
-			<return type="PackedByteArray" />
-			<description>
-				Returns byte code for the script source code.
-			</description>
-		</method>
 		<method name="new" qualifiers="vararg">
 			<return type="Variant" />
 			<description>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1007,17 +1007,6 @@ void GDScript::_get_property_list(List<PropertyInfo> *p_properties) const {
 
 void GDScript::_bind_methods() {
 	ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "new", &GDScript::_new, MethodInfo("new"));
-
-	ClassDB::bind_method(D_METHOD("get_as_byte_code"), &GDScript::get_as_byte_code);
-}
-
-Vector<uint8_t> GDScript::get_as_byte_code() const {
-	return Vector<uint8_t>();
-};
-
-// TODO: Fully remove this. There's not this kind of "bytecode" anymore.
-Error GDScript::load_byte_code(const String &p_path) {
-	return ERR_COMPILATION_FAILED;
 }
 
 void GDScript::set_path(const String &p_path, bool p_take_over) {
@@ -2647,8 +2636,6 @@ Ref<Resource> ResourceFormatLoaderGDScript::load(const String &p_path, const Str
 	Error err;
 	Ref<GDScript> scr = GDScriptCache::get_full_script(p_path, err, "", p_cache_mode == CACHE_MODE_IGNORE);
 
-	// TODO: Reintroduce binary and encrypted scripts.
-
 	if (scr.is_null()) {
 		// Don't fail loading because of parsing error.
 		scr.instantiate();
@@ -2663,9 +2650,6 @@ Ref<Resource> ResourceFormatLoaderGDScript::load(const String &p_path, const Str
 
 void ResourceFormatLoaderGDScript::get_recognized_extensions(List<String> *p_extensions) const {
 	p_extensions->push_back("gd");
-	// TODO: Reintroduce binary and encrypted scripts.
-	// p_extensions->push_back("gdc");
-	// p_extensions->push_back("gde");
 }
 
 bool ResourceFormatLoaderGDScript::handles_type(const String &p_type) const {
@@ -2674,8 +2658,7 @@ bool ResourceFormatLoaderGDScript::handles_type(const String &p_type) const {
 
 String ResourceFormatLoaderGDScript::get_resource_type(const String &p_path) const {
 	String el = p_path.get_extension().to_lower();
-	// TODO: Reintroduce binary and encrypted scripts.
-	if (el == "gd" /*|| el == "gdc" || el == "gde"*/) {
+	if (el == "gd") {
 		return "GDScript";
 	}
 	return "";

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -250,9 +250,6 @@ public:
 	virtual void set_path(const String &p_path, bool p_take_over = false) override;
 	String get_script_path() const;
 	Error load_source_code(const String &p_path);
-	Error load_byte_code(const String &p_path);
-
-	Vector<uint8_t> get_as_byte_code() const;
 
 	bool get_property_default_value(const StringName &p_property, Variant &r_value) const override;
 

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -71,21 +71,18 @@ class EditorExportGDScript : public EditorExportPlugin {
 
 public:
 	virtual void _export_file(const String &p_path, const String &p_type, const HashSet<String> &p_features) override {
-		int script_mode = EditorExportPreset::MODE_SCRIPT_COMPILED;
 		String script_key;
 
 		const Ref<EditorExportPreset> &preset = get_export_preset();
 
 		if (preset.is_valid()) {
-			script_mode = preset->get_script_export_mode();
 			script_key = preset->get_script_encryption_key().to_lower();
 		}
 
-		if (!p_path.ends_with(".gd") || script_mode == EditorExportPreset::MODE_SCRIPT_TEXT) {
+		if (!p_path.ends_with(".gd")) {
 			return;
 		}
 
-		// TODO: Re-add compiled GDScript on export.
 		return;
 	}
 


### PR DESCRIPTION
This feature was removed from GDScript so it should not be present on the interface nor in the saved export presets.

Closes #59241

Also removed mentions for encrypted scripts since those are obsolete now that you can encrypt any resource.

**Note:** The name of the feature may be misleading, since scripts are not "compiled" when this option was selected (in 3.x), it simply stores a binary version of the tokenized file (more details on the linked issue) that helps only a bit for faster loading. There's a plan to store actual compiled files on the exported project, which will be superior in many ways, but unfortunately will not be available in the 4.0 release.