### PR TITLE
Add missing property and method descriptions to AnimationNodeTransition class reference

### DIFF
--- a/doc/classes/AnimationNodeTransition.xml
+++ b/doc/classes/AnimationNodeTransition.xml
@@ -16,18 +16,21 @@
 			<return type="int" />
 			<param index="0" name="caption" type="String" />
 			<description>
+				Returns the input index which corresponds to [param caption]. If not found, returns [code]-1[/code].
 			</description>
 		</method>
 		<method name="get_input_caption" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="input" type="int" />
 			<description>
+				Returns the name of the input at the given [param input] index. This name is displayed in the editor next to the node input.
 			</description>
 		</method>
 		<method name="is_input_set_as_auto_advance" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="input" type="int" />
 			<description>
+				Returns [code]true[/code] if auto-advance is enabled for the given [param input] index.
 			</description>
 		</method>
 		<method name="set_input_as_auto_advance">
@@ -35,6 +38,7 @@
 			<param index="0" name="input" type="int" />
 			<param index="1" name="enable" type="bool" />
 			<description>
+				Enables or disables auto-advance for the given [param input] index. If enabled, state changes to the next input after playing the animation once. If enabled for the last input state, it loops to the first.
 			</description>
 		</method>
 		<method name="set_input_caption">
@@ -42,17 +46,19 @@
 			<param index="0" name="input" type="int" />
 			<param index="1" name="caption" type="String" />
 			<description>
+				Sets the name of the input at the given [param input] index. This name is displayed in the editor next to the node input.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="enabled_inputs" type="int" setter="set_enabled_inputs" getter="get_enabled_inputs" default="0">
-			The number of enabled input ports for this node.
+			The number of enabled input ports for this node. The maximum is [code]31[/code].
 		</member>
 		<member name="reset" type="bool" setter="set_reset" getter="is_reset" default="true">
 			If [code]true[/code], the destination animation is played back from the beginning when switched.
 		</member>
 		<member name="xfade_curve" type="Curve" setter="set_xfade_curve" getter="get_xfade_curve">
+			Determines how cross-fading between animations is eased. If empty, the transition will be linear.
 		</member>
 		<member name="xfade_time" type="float" setter="set_xfade_time" getter="get_xfade_time" default="0.0">
 			Cross-fading time (in seconds) between each animation connected to the inputs.


### PR DESCRIPTION
Adds missing descriptions for AnimationNodeTransition class reference ([docs](https://docs.godotengine.org/en/latest/classes/class_animationnodetransition.html)). Also adds mention of maximum value for inputs.