### PR TITLE
Exclude atomic lib under FreeBSD using LLVM [4.x]

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -405,9 +405,9 @@ def configure(env: "Environment"):
     # Link those statically for portability
     if env["use_static_cpp"]:
         env.Append(LINKFLAGS=["-static-libgcc", "-static-libstdc++"])
-        if env["use_llvm"]:
+        if env["use_llvm"] and platform.system() != "FreeBSD":
             env["LINKCOM"] = env["LINKCOM"] + " -l:libatomic.a"
 
     else:
-        if env["use_llvm"]:
+        if env["use_llvm"] and platform.system() != "FreeBSD":
             env.Append(LIBS=["atomic"])


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
PR for master branch with same commit (not tested), see https://github.com/godotengine/godot/pull/54394#issuecomment-956638759