### PR TITLE
Fix Viewport::get_mouse_position for SubViewports

### DIFF
--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -651,7 +651,8 @@ public:
 
 	virtual bool is_size_2d_override_stretch_enabled() const { return true; }
 
-	virtual Transform2D get_screen_transform() const;
+	Transform2D get_screen_transform() const;
+	virtual Transform2D get_screen_transform_internal(bool p_absolute_position = false) const;
 	virtual Transform2D get_popup_base_transform() const { return Transform2D(); }
 
 #ifndef _3D_DISABLED
@@ -780,7 +781,7 @@ public:
 	void set_clear_mode(ClearMode p_mode);
 	ClearMode get_clear_mode() const;
 
-	virtual Transform2D get_screen_transform() const override;
+	virtual Transform2D get_screen_transform_internal(bool p_absolute_position = false) const override;
 	virtual Transform2D get_popup_base_transform() const override;
 
 	SubViewport();

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2120,11 +2120,13 @@ Transform2D Window::get_final_transform() const {
 	return window_transform * stretch_transform * global_canvas_transform;
 }
 
-Transform2D Window::get_screen_transform() const {
+Transform2D Window::get_screen_transform_internal(bool p_absolute_position) const {
 	Transform2D embedder_transform;
 	if (_get_embedder()) {
 		embedder_transform.translate_local(get_position());
-		embedder_transform = _get_embedder()->get_screen_transform() * embedder_transform;
+		embedder_transform = _get_embedder()->get_screen_transform_internal(p_absolute_position) * embedder_transform;
+	} else if (p_absolute_position) {
+		embedder_transform.translate_local(get_position());
 	}
 	return embedder_transform * get_final_transform();
 }

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -377,7 +377,7 @@ public:
 	//
 
 	virtual Transform2D get_final_transform() const override;
-	virtual Transform2D get_screen_transform() const override;
+	virtual Transform2D get_screen_transform_internal(bool p_absolute_position = false) const override;
 	virtual Transform2D get_popup_base_transform() const override;
 
 	Rect2i get_parent_rect() const;


### PR DESCRIPTION
SubViewports don't have a cached mouse position available. This PR calculates the mouse position from the screen position of the mouse cursor.

Closes #60390
Closes #72807
supersedes #62274

The `get_screen_transform` API-change doesn't break compatibility, because the behavior with the default-value stays the same.

Updated 2023-01-27: Fix merge conflict
Updated 2023-01-31: Rebase to master after #71972 which made necessary changes to unittests.
Updated 2023-02-01: Fix merge conflict
Updated 2023-02-03: Fix merge conflict