### PR TITLE
Display a checkerboard pattern on the fallback 3D material

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -726,16 +726,106 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 		material_storage->shader_initialize(default_shader);
 		material_storage->shader_set_code(default_shader, R"(
 // Default 3D material shader (clustered).
-
 shader_type spatial;
 
-void vertex() {
-	ROUGHNESS = 0.8;
+varying vec3 Position;
+varying vec3 Normal;
+
+void vertex()
+{
+	Position = VERTEX;
+	Normal = NORMAL;
 }
 
-void fragment() {
-	ALBEDO = vec3(0.6);
-	ROUGHNESS = 0.8;
+float SquareAntialiased(float coord, float dd) // antialiased square wave
+{
+	coord += dd * 0.5f;
+
+	dd = max(dd, 0.0001f);
+	float invdd = 1.0f / dd;
+
+	coord = mod(coord, 1.0f);
+	float c = min(coord * invdd, 0.5f - (coord - 0.5f) / dd + 0.5f);
+	c = clamp(c, 0.0f, 1.0f);
+
+	return c;
+}
+
+float SXOR(float a, float b) // "smooth" xor, used to combine checker patterns
+{
+	return abs(a - b);
+}
+
+float Checkers(vec3 coord, vec3 ddxyz, vec3 tripCoeff)
+{
+	vec3 fade = clamp(1.0f / (ddxyz * 2.0f) - 1.0f, 0.0f, 1.0f);
+
+	float cx = SquareAntialiased(coord.x, ddxyz.x);
+	float cy = SquareAntialiased(coord.y, ddxyz.y);
+	float cz = SquareAntialiased(coord.z, ddxyz.z);
+
+	vec3 filter = clamp(1.0f / ddxyz * 0.5f - 0.5f, 0.0f, 1.0f); // smooth, manual filtering
+
+	float c = SXOR(cy * filter.y, cz * filter.z) * tripCoeff.x;
+	c += SXOR(cz * filter.z, cx * filter.x) * tripCoeff.y;
+	c += SXOR(cx * filter.x, cy * filter.y) * tripCoeff.z;
+	c += 1.0f - dot(filter, vec3(0.3333f));
+
+	return c;
+}
+
+vec4 texturePointSmooth(sampler2D smp, vec2 uv, vec2 tex_size, vec2 filter_width)
+{
+	float fade = clamp(max(1.0f / filter_width.x, 1.0f / filter_width.y) - 1.0f, 0.0f, 1.0f);
+	filter_width = max(filter_width, vec2(1.0f));
+	vec2 uv_pixels = uv * tex_size;
+
+	vec2 uv_pixels_floor = round(uv_pixels) - vec2(0.5f);
+	vec2 uv_dxy_pixels = uv_pixels - uv_pixels_floor;
+
+	uv_dxy_pixels = clamp((uv_dxy_pixels - vec2(0.5f)) * filter_width + vec2(0.5f), 0.0f, 1.0f);
+
+	uv = uv_pixels_floor / tex_size;
+
+	return mix(textureLod(smp, uv + uv_dxy_pixels / tex_size, 0.0f), vec4(0.5f, 0.5f, 0.5f, 1.0f), fade);
+}
+
+vec4 TextureTriplanar(sampler2D smp, vec2 texSize, vec3 coord, vec3 ddxyz, vec3 tripCoeff)
+{
+	vec4 cx = texturePointSmooth(smp, coord.yz, texSize, 1.0f / ddxyz.yz / texSize);
+	vec4 cy = texturePointSmooth(smp, coord.zx, texSize, 1.0f / ddxyz.zx / texSize);
+	vec4 cz = texturePointSmooth(smp, coord.xy, texSize, 1.0f / ddxyz.xy / texSize);
+
+	vec3 filter = clamp(1.0f / ddxyz * 0.5f - 0.5f, 0.0f, 1.0f); // smooth, manual filtering
+
+	vec4 c = cx * tripCoeff.x;
+	c += cy * tripCoeff.y;
+	c += cz * tripCoeff.z;
+
+	return c;
+}
+
+void fragment()
+{
+	ALBEDO = vec3(0.6f, 0.6f, 0.6f);
+
+	vec3 coord = Position.xyz * 4.0f;
+	vec3 ddxyz = fwidth(coord) * 1.0f;
+
+	vec3 tripCoeff = max((Normal * Normal * 2.0f - 0.5f), 0.001f);
+	tripCoeff /= (tripCoeff.x + tripCoeff.y + tripCoeff.z);
+	float checkers = Checkers(coord, ddxyz, tripCoeff);
+
+	coord = Position.xyz;
+	ddxyz = fwidth(coord);
+	float checkersL = 1.0f - Checkers(coord, ddxyz, tripCoeff);
+
+	checkers = mix(checkers, checkersL, 0.7f);
+
+	ALBEDO = mix(vec3(0.5f, 0.5f, 0.5f), vec3(0.7f, 0.7f, 0.7f), checkers);
+	// Roughness between 0.6 (dark areas) and 0.8 (light areas).
+	ROUGHNESS = 1.4 - ALBEDO.r;
+
 	METALLIC = 0.2;
 }
 )");


### PR DESCRIPTION
**Marked as draft**, as this currently affects the **Display Lighting** debug draw mode. This debug draw mode should be modified to use a different, untextured fallback material.

This has two benefits over a plain untextured surface:

- It looks better, and gives a better first impression of the engine's visuals.
  - As a bonus, the checkerboard pattern helps make color banding and shadow dithering patterns less noticeable (closer to how it'd be in most finished projects).
- It has better usability, as the checkerboard gives you a sense of scale.

This shader is based on @CptPotato's [procedural checker shader](https://github.com/CptPotato/GodotThings/blob/master/ProceduralCheckerboard/ProcCheckers.shader).

This closes https://github.com/godotengine/godot-proposals/issues/6138.

**Testing project:** [test_fallback_material.zip](https://github.com/godotengine/godot/files/10471277/test_fallback_material.zip)

## Preview

### Daytime

Current fallback material | With checkerboard material
-|-
![Screenshot_20230121_014105 webp](https://user-images.githubusercontent.com/180032/213831920-8d516699-0726-4595-81ae-6ee4d1854eff.png) | ![Screenshot_20230121_014057 webp](https://user-images.githubusercontent.com/180032/213831917-e86dbf0e-cd0b-4837-a1d5-36afd28d1cbf.png)
![Screenshot_20230121_014158 webp](https://user-images.githubusercontent.com/180032/213831924-3309dd69-78e6-478b-9a8d-bb6a1066ceeb.png) | ![Screenshot_20230121_014152 webp](https://user-images.githubusercontent.com/180032/213831921-289a43f3-58c1-4d03-a69f-963444680bf1.png)
![Screenshot_20230121_014223 webp](https://user-images.githubusercontent.com/180032/213831926-751dc324-7371-4f91-a00f-c2277f20f512.png) | ![Screenshot_20230121_014215 webp](https://user-images.githubusercontent.com/180032/213831925-6592d5f9-a4b3-4408-b5ce-2138e6726ca5.png)

### Nighttime

Current fallback material | With checkerboard material
-|-
![Screenshot_20230121_013636 webp](https://user-images.githubusercontent.com/180032/213831911-a34d1632-ac36-4d57-a86b-bff3f535a3a4.png) | ![Screenshot_20230121_013603 webp](https://user-images.githubusercontent.com/180032/213831908-ba89dd50-22a5-48b5-8c0c-670bf8d32841.png)
![Screenshot_20230121_013813 webp](https://user-images.githubusercontent.com/180032/213831914-9d4d0f1c-d5ec-4269-82bf-a1ad2e852588.png) | ![Screenshot_20230121_013804 webp](https://user-images.githubusercontent.com/180032/213831912-55975868-68cb-4310-a734-eeb9bbc0be2b.png)
![Screenshot_20230121_013926 webp](https://user-images.githubusercontent.com/180032/213831916-e32b2e94-6ea0-4afb-8607-29cfad949baf.png) | ![Screenshot_20230121_013918 webp](https://user-images.githubusercontent.com/180032/213831915-9009814a-f596-427d-b3a4-9c17857989a3.png)
