### PR TITLE
Add line-circle and circle-circle closest points functions; improve cylinder-cylinder collisions

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -63,6 +63,11 @@ Copyright: 2011, Ole Kniemeyer, MAXON, www.maxon.net
  2007-2014, Juan Linietsky, Ariel Manzur
 License: Expat and Zlib
 
+Files: ./core/math/geometry_3d.cpp
+Comment: MinuteTorus
+Copyright: 2021, Sang Hyun Son and Youngjin Park
+License: MIT
+
 Files: ./platform/android/java/lib/aidl/com/android/*
  ./platform/android/java/lib/res/layout/status_bar_ongoing_event_progress_bar.xml
  ./platform/android/java/lib/src/com/google/android/*

--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -68,6 +68,12 @@ Comment: MinuteTorus
 Copyright: 2021, Sang Hyun Son and Youngjin Park
 License: MIT
 
+Files: ./core/math/geometry_3d.cpp
+ ./servers/physics_3d/godot_collision_solver_3d_sat.cpp
+Comment: Open Dynamics Engine
+Copyright: 2001-2003, Russell L. Smith, Alen Ladavac, Nguyen Binh
+License: BSD-3-clause
+
 Files: ./platform/android/java/lib/aidl/com/android/*
  ./platform/android/java/lib/res/layout/status_bar_ongoing_event_progress_bar.xml
  ./platform/android/java/lib/src/com/google/android/*
@@ -89,11 +95,6 @@ Copyright: 2001, Robert Penner
  2014-present, Godot Engine contributors
  2007-2014, Juan Linietsky, Ariel Manzur
 License: Expat
-
-Files: ./servers/physics_3d/collision_solver_3d_sat.cpp
-Comment: Open Dynamics Engine
-Copyright: 2001-2003, Russell L. Smith, Alen Ladavac, Nguyen Binh
-License: BSD-3-clause
 
 Files: ./servers/physics_3d/gjk_epa.cpp
  ./servers/physics_3d/joints/generic_6dof_joint_3d_sw.cpp

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -916,6 +916,13 @@ Vector3 Geometry3D::get_closest_point_to_segment_uncapped(const Vector3 &p_point
 	return ::Geometry3D::get_closest_point_to_segment_uncapped(p_point, s);
 }
 
+Vector<Vector3> Geometry3D::get_closest_points_between_circle_and_circle(const Transform3D &p_circle0_transform, const real_t p_circle0_radius, const Transform3D &p_circle1_transform, const real_t p_circle1_radius) {
+	Vector3 closest_points[2];
+	size_t num_closest_pairs = 0;
+	::Geometry3D::get_closest_points_between_circle_and_circle(p_circle0_transform, p_circle0_radius, p_circle1_transform, p_circle1_radius, closest_points, num_closest_pairs);
+	return { closest_points[0], closest_points[1] };
+}
+
 Variant Geometry3D::ray_intersects_triangle(const Vector3 &p_from, const Vector3 &p_dir, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2) {
 	Vector3 res;
 	if (::Geometry3D::ray_intersects_triangle(p_from, p_dir, p_v0, p_v1, p_v2, &res)) {
@@ -987,6 +994,8 @@ void Geometry3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_closest_point_to_segment", "point", "s1", "s2"), &Geometry3D::get_closest_point_to_segment);
 
 	ClassDB::bind_method(D_METHOD("get_closest_point_to_segment_uncapped", "point", "s1", "s2"), &Geometry3D::get_closest_point_to_segment_uncapped);
+
+	ClassDB::bind_method(D_METHOD("get_closest_points_between_circle_and_circle", "circle0_transform", "circle0_radius", "circle1_transform", "circle1_radius"), &Geometry3D::get_closest_points_between_circle_and_circle);
 
 	ClassDB::bind_method(D_METHOD("ray_intersects_triangle", "from", "dir", "a", "b", "c"), &Geometry3D::ray_intersects_triangle);
 	ClassDB::bind_method(D_METHOD("segment_intersects_triangle", "from", "to", "a", "b", "c"), &Geometry3D::segment_intersects_triangle);

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -923,6 +923,13 @@ Vector<Vector3> Geometry3D::get_closest_points_between_circle_and_circle(const T
 	return { closest_points[0], closest_points[1] };
 }
 
+Vector<Vector3> Geometry3D::get_closest_points_between_line_and_circle(const Vector3 &p_line_origin, const Vector3 &p_line_direction, const Transform3D &p_circle_transform, const real_t p_circle_radius) {
+	Vector3 closest_points[2];
+	size_t num_closest_pairs = 0;
+	::Geometry3D::get_closest_points_between_line_and_circle(p_line_origin, p_line_direction, p_circle_transform, p_circle_radius, closest_points, num_closest_pairs);
+	return { closest_points[0], closest_points[1] };
+}
+
 Variant Geometry3D::ray_intersects_triangle(const Vector3 &p_from, const Vector3 &p_dir, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2) {
 	Vector3 res;
 	if (::Geometry3D::ray_intersects_triangle(p_from, p_dir, p_v0, p_v1, p_v2, &res)) {
@@ -996,6 +1003,8 @@ void Geometry3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_closest_point_to_segment_uncapped", "point", "s1", "s2"), &Geometry3D::get_closest_point_to_segment_uncapped);
 
 	ClassDB::bind_method(D_METHOD("get_closest_points_between_circle_and_circle", "circle0_transform", "circle0_radius", "circle1_transform", "circle1_radius"), &Geometry3D::get_closest_points_between_circle_and_circle);
+
+	ClassDB::bind_method(D_METHOD("get_closest_points_between_line_and_circle", "line_origin", "line_direction", "circle_transform", "circle_radius"), &Geometry3D::get_closest_points_between_line_and_circle);
 
 	ClassDB::bind_method(D_METHOD("ray_intersects_triangle", "from", "dir", "a", "b", "c"), &Geometry3D::ray_intersects_triangle);
 	ClassDB::bind_method(D_METHOD("segment_intersects_triangle", "from", "to", "a", "b", "c"), &Geometry3D::segment_intersects_triangle);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -317,6 +317,7 @@ public:
 	Vector<Vector3> get_closest_points_between_segments(const Vector3 &p1, const Vector3 &p2, const Vector3 &q1, const Vector3 &q2);
 	Vector3 get_closest_point_to_segment(const Vector3 &p_point, const Vector3 &p_a, const Vector3 &p_b);
 	Vector3 get_closest_point_to_segment_uncapped(const Vector3 &p_point, const Vector3 &p_a, const Vector3 &p_b);
+	Vector<Vector3> get_closest_points_between_circle_and_circle(const Transform3D &p_circle0_transform, const real_t p_circle0_radius, const Transform3D &p_circle1_transform, const real_t p_circle1_radius);
 	Variant ray_intersects_triangle(const Vector3 &p_from, const Vector3 &p_dir, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2);
 	Variant segment_intersects_triangle(const Vector3 &p_from, const Vector3 &p_to, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -318,6 +318,7 @@ public:
 	Vector3 get_closest_point_to_segment(const Vector3 &p_point, const Vector3 &p_a, const Vector3 &p_b);
 	Vector3 get_closest_point_to_segment_uncapped(const Vector3 &p_point, const Vector3 &p_a, const Vector3 &p_b);
 	Vector<Vector3> get_closest_points_between_circle_and_circle(const Transform3D &p_circle0_transform, const real_t p_circle0_radius, const Transform3D &p_circle1_transform, const real_t p_circle1_radius);
+	Vector<Vector3> get_closest_points_between_line_and_circle(const Vector3 &p_line_origin, const Vector3 &p_line_direction, const Transform3D &p_circle_transform, const real_t p_circle_radius);
 	Variant ray_intersects_triangle(const Vector3 &p_from, const Vector3 &p_dir, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2);
 	Variant segment_intersects_triangle(const Vector3 &p_from, const Vector3 &p_to, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2);
 

--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -30,8 +30,11 @@
 
 #include "geometry_3d.h"
 
+#include "minimization.h"
 #include "thirdparty/misc/clipper.hpp"
 #include "thirdparty/misc/polypartition.h"
+
+constexpr real_t CIRCLE_CIRCLE_RELATIVE_TOLERANCE = 1e-6;
 
 void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const Vector3 &p_p1, const Vector3 &p_q0, const Vector3 &p_q1, Vector3 &r_ps, Vector3 &r_qt) {
 	// Based on David Eberly's Computation of Distance Between Line Segments algorithm.
@@ -983,4 +986,258 @@ Vector<int8_t> Geometry3D::generate_sdf8(const Vector<uint32_t> &p_positive, con
 		wsdf[i] = CLAMP(diff, -128, 127);
 	}
 	return sdf8;
+}
+
+/*
+ * Point-Circle distance
+ */
+
+Vector3 get_closest_point_on_circle(const Vector3 &p_point, const Transform3D &p_circle_transform, const real_t p_circle_radius) {
+	Vector3 point_local = p_point - p_circle_transform.origin;
+	Vector3 U = p_circle_transform.basis.get_column(0);
+	Vector3 V = p_circle_transform.basis.get_column(2);
+	Vector3 closest_local = U.dot(point_local) * U + V.dot(point_local) * V;
+	real_t closest_local_length = closest_local.length();
+	if (closest_local_length > 0.0) {
+		return p_circle_transform.origin + p_circle_radius * (closest_local / closest_local_length);
+	} else {
+		return p_circle_transform.origin + p_circle_radius * U.normalized();
+	}
+}
+
+/*
+ * Circle-Circle distance
+ * Based on David Vranek's Fast and Accurate Circle-Circle and Circle-Line 3D Distance Computation.
+ * Implementation based on the one in MinuteTorus by Sang Hyun Son, but significantly modified.
+ * See https://github.com/SonSang/MinuteTorus/blob/1a11cacc8cea6f62d16ffc9919ba35fe998742c9/Circle/CircleDistance.cpp
+ */
+
+/**********************************************************************************
+ * MinuteTorus, Copyright (c) [2021] [Sanghyun Son, Youngjin Park]                *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy   *
+ * of this software and associated documentation files (the "Software"), to deal  *
+ * in the Software without restriction, including without limitation the rights   *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      *
+ * copies of the Software, and to permit persons to whom the Software is          *
+ * furnished to do so, subject to the following conditions:                       *
+ *                                                                                *
+ * The above copyright notice and this permission notice shall be included in all *
+ * copies or substantial portions of the Software.                                *
+ *                                                                                *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  *
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  *
+ * SOFTWARE.                                                                      *
+ **********************************************************************************/
+
+struct CircleCircleDistanceData {
+	real_t a[10];
+	real_t t = INFINITY; // Ensure an update on the first call to update_t.
+	real_t cost = 0.0;
+	real_t sint = 0.0;
+	real_t cost2 = 0.0;
+	real_t sint2 = 0.0;
+	real_t costsint = 0.0;
+	real_t root = 0.0;
+
+	_FORCE_INLINE_ void update_t(real_t p_t) {
+		if (t == p_t) {
+			return;
+		}
+		t = p_t;
+		cost = cos(t);
+		sint = sin(t);
+		cost2 = cost * cost;
+		sint2 = sint * sint;
+		costsint = cost * sint;
+		root = sqrt(a[5] * cost2 + a[4] * sint2 + a[3] * cost + a[2] * sint + a[1] * costsint + a[0]);
+	}
+};
+
+inline real_t circle_circle_distance(void *p_data, real_t p_t) { // p_t is the angle on circle1
+	CircleCircleDistanceData *d = static_cast<CircleCircleDistanceData *>(p_data);
+	d->update_t(p_t);
+	return d->a[9] * d->cost + d->a[8] * d->sint + d->a[7] + d->a[6] * d->root;
+}
+
+inline real_t circle_circle_distance_derivative(void *p_data, real_t p_t) { // first derivative of circle_circle_distance
+	CircleCircleDistanceData *d = static_cast<CircleCircleDistanceData *>(p_data);
+	d->update_t(p_t);
+	return -d->a[9] * d->sint + d->a[8] * d->cost + d->a[6] * 0.5 * (1.0 / d->root) * (2.0 * d->costsint * (d->a[4] - d->a[5]) - d->a[3] * d->sint + d->a[2] * d->cost + d->a[1] * (d->cost2 - d->sint2));
+}
+
+bool real_roots_of_quadratic_polynomial(const real_t p_coeff[3], real_t *r_x) {
+	const real_t a = p_coeff[2];
+	const real_t b = p_coeff[1];
+	const real_t c = p_coeff[0];
+	if (a == 0.0) { // Not actually quadratic.
+		return false;
+	}
+	if (c == 0.0) { // At least one root is zero.
+		r_x[0] = 0.0;
+		r_x[1] = -b / a;
+		return true;
+	}
+	// Compute discriminant avoiding overflow.
+	real_t l_e;
+	real_t l_d;
+	const real_t l_b = 0.5 * b;
+	if (Math::abs(l_b) < Math::abs(c)) {
+		l_e = (c < 0.0) ? -a : a;
+		l_e = l_b * (l_b / Math::abs(c)) - l_e;
+		l_d = Math::sqrt(Math::abs(l_e)) * Math::sqrt(Math::abs(c));
+	} else {
+		l_e = 1.0 - (a / l_b) * (c / l_b);
+		l_d = Math::sqrt(Math::abs(l_e)) * Math::abs(l_b);
+	}
+	if (l_e >= 0.0) { // Real roots.
+		// Compute largest root (in absolute value) by avoiding cancellation.
+		if (l_b > 0.0) {
+			l_d = -l_d;
+		}
+		r_x[0] = (-l_b + l_d) / a;
+		r_x[1] = (r_x[0] != 0.0) ? (c / r_x[0]) / a : 0.0; // Smallest root.
+		return true;
+	} else { // Complex roots.
+		return false;
+	}
+}
+
+void Geometry3D::get_closest_points_between_circle_and_circle(const Transform3D &p_circle0_transform, const real_t p_circle0_radius, const Transform3D &p_circle1_transform, const real_t p_circle1_radius, Vector3 *r_closest_points, size_t &r_num_closest_pairs) {
+	// Constants used in the squared distance function.
+	Vector3 center_a = p_circle0_transform.origin;
+	Vector3 center_b = p_circle1_transform.origin;
+	Vector3 normal_a = p_circle0_transform.basis.get_column(1);
+	Vector3 U = p_circle1_transform.basis.get_column(0);
+	Vector3 V = p_circle1_transform.basis.get_column(2);
+	real_t R_a = p_circle0_radius;
+	real_t R_b = p_circle1_radius;
+	real_t tmp[11];
+	tmp[0] = center_a.dot(center_a);
+	tmp[1] = center_a.dot(center_b);
+	tmp[2] = center_b.dot(center_b);
+	tmp[3] = normal_a.dot(center_a);
+	tmp[4] = normal_a.dot(center_b);
+	tmp[5] = normal_a.dot(U);
+	tmp[6] = normal_a.dot(V);
+	tmp[7] = center_a.dot(U);
+	tmp[8] = center_a.dot(V);
+	tmp[9] = center_b.dot(U);
+	tmp[10] = center_b.dot(V);
+
+	// Coefficients used in the squared distance function and its derivative; see circle_circle_distance and circle_circle_distance_derivative.
+	CircleCircleDistanceData data;
+	data.a[0] = R_b * R_b + tmp[2] + tmp[0] - 2.0 * tmp[1] - (tmp[4] - tmp[3]) * (tmp[4] - tmp[3]);
+	data.a[1] = -2.0 * R_b * R_b * tmp[5] * tmp[6];
+	data.a[2] = 2.0 * R_b * tmp[10] - 2.0 * R_b * tmp[8] - 2.0 * R_b * (tmp[4] - tmp[3]) * tmp[6];
+	data.a[3] = 2.0 * R_b * tmp[9] - 2.0 * R_b * tmp[7] - 2.0 * R_b * (tmp[4] - tmp[3]) * tmp[5];
+	data.a[4] = -R_b * R_b * tmp[6] * tmp[6];
+	data.a[5] = -R_b * R_b * tmp[5] * tmp[5];
+	data.a[6] = -2.0 * R_a;
+	data.a[7] = R_a * R_a + R_b * R_b + tmp[0] + tmp[2] - 2.0 * tmp[1];
+	data.a[8] = 2.0 * R_b * tmp[10] - 2.0 * R_b * tmp[8];
+	data.a[9] = 2.0 * R_b * tmp[9] - 2.0 * R_b * tmp[7];
+
+	// Evaluate the squared distance function at three equally spaced angles.
+	real_t a = (-2.0 / 3.0) * Math_PI;
+	real_t b = 0;
+	real_t c = (2.0 / 3.0) * Math_PI;
+	real_t fa = circle_circle_distance(&data, a);
+	real_t fb = circle_circle_distance(&data, b);
+	real_t fc = circle_circle_distance(&data, c);
+
+	// TODO: Handle special cases like f(a) == f(b) == f(c) and the other three below, which do happen.
+
+	// Re-order the three angles to form a bracketing triplet.
+	if (fb > fc) {
+		if (fa > fc) { // f(c) is smallest; swap b and c.
+			b = (2.0 / 3.0) * Math_PI;
+			c = Math_TAU;
+			SWAP(fb, fc);
+		} else if (fa < fc) { // f(a) is smallest; swap b and a.
+			a = -Math_TAU;
+			b = -(2.0 / 3.0) * Math_PI;
+			SWAP(fb, fa);
+		} else { // f(b) is greater than f(a) == f(c)
+			ERR_FAIL_MSG("f(a) == f(c)");
+		}
+	} else if (fb < fc) {
+		if (fa < fb) { // f(a) is smallest; swap a and b.
+			a = -Math_TAU;
+			b = -(2.0 / 3.0) * Math_PI;
+			SWAP(fa, fb);
+		} else if (fa == fb) { // f(c) is greater than f(a) == f(b)
+			ERR_FAIL_MSG("f(a) == f(b)");
+		}
+		// else f(b) is smallest; nothing to do.
+	} else { // f(b) == f(c)
+		ERR_FAIL_MSG("f(b) == f(c)");
+	}
+
+	// Find a single local minimum of the distance function numerically, using a modification of Brent's minimization algorithm (making use of the derivative).
+	real_t loc_min_t;
+	real_t loc_min_dist = Minimization::get_local_minimum(&data, &circle_circle_distance, &circle_circle_distance_derivative, a, b, c, CIRCLE_CIRCLE_RELATIVE_TOLERANCE, &loc_min_t);
+
+	// Shift the distance function down by the local minimum; setting that equal to zero leads to a polynomial equation of degree four in z = cos(t).
+	real_t d[3] = { data.a[7] - loc_min_dist, data.a[6] * data.a[6], data.a[8] * data.a[8] };
+	real_t c1 = 2.0 * data.a[8] * d[0] - d[1] * data.a[2];
+	//real_t c2 = d[1] * data.a[4]; // NOTE: unused.
+	real_t c3 = d[0] * d[0] - d[1] * data.a[0] + d[2] - d[1] * data.a[4];
+	real_t c4 = 2.0 * data.a[9] * d[0] - d[1] * data.a[3];
+	real_t c5 = 2.0 * data.a[9] * data.a[8] - d[1] * data.a[1];
+	real_t c6 = -d[2] + d[1] * data.a[4] + data.a[9] * data.a[9] - d[1] * data.a[5];
+	// Coefficients of the quartic:
+	real_t quartic_coeff[5];
+	//quartic_coeff[0] = c3 * c3 - c1 * c1; // NOTE: unused.
+	//quartic_coeff[1] = -2.0 * c1 * c5 + 2.0 * c3 * c4; // NOTE: unused.
+	quartic_coeff[2] = c1 * c1 - c5 * c5 + 2.0 * c3 * c6 + c4 * c4;
+	quartic_coeff[3] = 2.0 * c1 * c5 + 2.0 * c4 * c6;
+	quartic_coeff[4] = c6 * c6 + c5 * c5;
+
+	// The polynomial of degree four in z = cos(t) has a double root at the previously found z0 = cos(loc_min_t); use Horner's method to deflate it to a quadratic polynomial.
+	real_t z = cos(loc_min_t);
+	real_t quadratic_coeff[3];
+	quadratic_coeff[0] = (3.0 * quartic_coeff[4] * z + 2.0 * quartic_coeff[3]) * z + quartic_coeff[2];
+	quadratic_coeff[1] = 2.0 * quartic_coeff[4] * z + quartic_coeff[3];
+	quadratic_coeff[2] = quartic_coeff[4];
+	real_t quadratic_roots[2];
+
+	real_t gl_min_dist = loc_min_dist;
+	real_t gl_min_t = loc_min_t;
+
+	// If the quadratic has two distinct real roots, then the global minimum lies between the two roots of the quadratic.
+	if (real_roots_of_quadratic_polynomial(quadratic_coeff, quadratic_roots)) {
+		real_t cosa = CLAMP(quadratic_roots[0], -1.0, 1.0);
+		real_t cosb = CLAMP(quadratic_roots[1], -1.0, 1.0);
+		a = acos(cosa); // In the range [0, pi].
+		b = acos(cosb); // In the range [0, pi].
+		if (circle_circle_distance_derivative(&data, a) * circle_circle_distance_derivative(&data, b) < 0.0) {
+			// Find a minimum in this interval.
+			// TODO: Can there be a local maximum instead of a minimum in this interval?
+			// TODO: If not, should we use a root finder here to find a zero of the derivative?
+			loc_min_dist = Minimization::get_local_minimum(&data, &circle_circle_distance, &circle_circle_distance_derivative, a, b, b, CIRCLE_CIRCLE_RELATIVE_TOLERANCE, &loc_min_t);
+			if (loc_min_dist < gl_min_dist) {
+				gl_min_dist = loc_min_dist;
+				gl_min_t = loc_min_t;
+			}
+		}
+		a = Math_TAU - a;
+		b = Math_TAU - b;
+		if (circle_circle_distance_derivative(&data, a) * circle_circle_distance_derivative(&data, b) < 0.0) {
+			loc_min_dist = Minimization::get_local_minimum(&data, &circle_circle_distance, &circle_circle_distance_derivative, a, b, b, CIRCLE_CIRCLE_RELATIVE_TOLERANCE, &loc_min_t);
+			if (loc_min_dist < gl_min_dist) {
+				gl_min_dist = loc_min_dist;
+				gl_min_t = loc_min_t;
+			}
+		}
+	}
+	// NOTE: If the quadratic has just one real root, then the previously found local minimum is a global minimum, and so is the root of the quadratic.
+	// If the quadratic has no real roots, then the previously found local minimum is the unique global minimum.
+
+	r_num_closest_pairs = 1;
+	r_closest_points[1] = p_circle1_transform.origin + R_b * Math::cos(gl_min_t) * U + R_b * Math::sin(gl_min_t) * V;
+	r_closest_points[0] = get_closest_point_on_circle(r_closest_points[1], p_circle0_transform, R_a);
 }

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -41,6 +41,8 @@ public:
 	static void get_closest_points_between_segments(const Vector3 &p_p0, const Vector3 &p_p1, const Vector3 &p_q0, const Vector3 &p_q1, Vector3 &r_ps, Vector3 &r_qt);
 	static real_t get_closest_distance_between_segments(const Vector3 &p_p0, const Vector3 &p_p1, const Vector3 &p_q0, const Vector3 &p_q1);
 
+	static void get_closest_points_between_circle_and_circle(const Transform3D &p_circle0_transform, const real_t p_circle0_radius, const Transform3D &p_circle1_transform, const real_t p_circle1_radius, Vector3 *r_closest_points, size_t &r_num_closest_pairs);
+
 	static inline bool ray_intersects_triangle(const Vector3 &p_from, const Vector3 &p_dir, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2, Vector3 *r_res = nullptr) {
 		Vector3 e1 = p_v1 - p_v0;
 		Vector3 e2 = p_v2 - p_v0;

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -42,6 +42,7 @@ public:
 	static real_t get_closest_distance_between_segments(const Vector3 &p_p0, const Vector3 &p_p1, const Vector3 &p_q0, const Vector3 &p_q1);
 
 	static void get_closest_points_between_circle_and_circle(const Transform3D &p_circle0_transform, const real_t p_circle0_radius, const Transform3D &p_circle1_transform, const real_t p_circle1_radius, Vector3 *r_closest_points, size_t &r_num_closest_pairs);
+	static void get_closest_points_between_line_and_circle(const Vector3 &p_line_origin, const Vector3 &p_line_direction, const Transform3D &p_circle_transform, const real_t p_circle_radius, Vector3 *r_closest_points, size_t &r_num_closest_pairs);
 
 	static inline bool ray_intersects_triangle(const Vector3 &p_from, const Vector3 &p_dir, const Vector3 &p_v0, const Vector3 &p_v1, const Vector3 &p_v2, Vector3 *r_res = nullptr) {
 		Vector3 e1 = p_v1 - p_v0;

--- a/core/math/minimization.cpp
+++ b/core/math/minimization.cpp
@@ -1,0 +1,218 @@
+/**************************************************************************/
+/*  minimization.cpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "minimization.h"
+
+#include "core/error/error_macros.h"
+#include "core/typedefs.h"
+#include "math_funcs.h"
+
+#define SIGN2(a, b) ((b) >= 0.0 ? Math::abs(a) : -Math::abs(a))
+
+/*
+ * Find a bracketing triplet (ax, bx, cx) such that bx is between ax and cx (so ax < bx < cx or cx < bx < ax) and f(bx) is less than both f(ax) and f(cx).
+ */
+
+constexpr real_t GOLD = 1.618034; // The default ratio by which successive intervals are magnified.
+constexpr real_t GLIMIT = 100.0; // The maximum magnification allowed for a parabolic-fit step.
+constexpr real_t TINY = 1.0e-20; // Used to prevent any possible division by zero.
+#define SHFT(a, b, c, d) \
+	(a) = (b);           \
+	(b) = (c);           \
+	(c) = (d);
+
+void Minimization::bracketing_triplet_from_interval(void *data, real_function *f, real_t *ax, real_t *bx, real_t *cx, real_t *fa, real_t *fb, real_t *fc) {
+	// Given a function f, and given distinct initial points ax and bx, this routine searches in
+	// the downhill direction (defined by the function as evaluated at the initial points) and returns
+	// new points ax, bx, cx that bracket a minimum of the function. Also returned are the function
+	// values at the three points, fa, fb, and fc.
+
+	real_t ulim, u, r, q, fu, dum;
+	*fa = (*f)(data, *ax);
+	*fb = (*f)(data, *bx);
+	if (*fb > *fa) { // Switch roles of a and b so that we can go downhill
+		SHFT(dum, *ax, *bx, dum) // in the direction from a to b.
+		SHFT(dum, *fb, *fa, dum)
+	}
+	*cx = (*bx) + GOLD * (*bx - *ax); // First guess for c.
+	*fc = (*f)(data, *cx);
+	while (*fb > *fc) { // Keep returning here until we bracket.
+		// Compute u by parabolic extrapolation from a; b; c.
+		r = (*bx - *ax) * (*fb - *fc);
+		q = (*bx - *cx) * (*fb - *fa);
+		u = (*bx) - ((*bx - *cx) * q - (*bx - *ax) * r) / (2.0 * SIGN2(MAX(Math::abs(q - r), TINY), q - r));
+		ulim = (*bx) + GLIMIT * (*cx - *bx);
+		// We won't go farther than this. Test various possibilities:
+		if ((*bx - u) * (u - *cx) > 0.0) { // Parabolic u is between b and c: try it.
+			fu = (*f)(data, u);
+			if (fu < *fc) { // Got a minimum between b and c.
+				*ax = (*bx);
+				*bx = u;
+				*fa = (*fb);
+				*fb = fu;
+				return;
+			} else if (fu > *fb) { // Got a minimum between between a and u.
+				*cx = u;
+				*fc = fu;
+				return;
+			}
+			u = (*cx) + GOLD * (*cx - *bx); // Parabolic fit was no use. Use default magnification.
+			fu = (*f)(data, u);
+		} else if ((*cx - u) * (u - ulim) > 0.0) { // Parabolic fit is between c and its allowed limit.
+			fu = (*f)(data, u);
+			if (fu < *fc) {
+				SHFT(*bx, *cx, u, *cx + GOLD * (*cx - *bx))
+				SHFT(*fb, *fc, fu, (*f)(data, u))
+			}
+		} else if ((u - ulim) * (ulim - *cx) >= 0.0) { // Limit parabolic u to maximum allowed value.
+			u = ulim;
+			fu = (*f)(data, u);
+		} else { // Reject parabolic u, use default magnification.
+			u = (*cx) + GOLD * (*cx - *bx);
+			fu = (*f)(data, u);
+		}
+		SHFT(*ax, *bx, *cx, u) // Eliminate oldest point and continue.
+		SHFT(*fa, *fb, *fc, fu)
+	}
+}
+
+/*
+ * Find a local minimum of a differentiable real-valued function using a modification of Richard P. Brent's method, making use of the derivative.
+ */
+
+constexpr int ITMAX = 100;
+constexpr real_t ZEPS = 1e-6;
+#define MOV3(a, b, c, d, e, f) \
+	(a) = (d);                 \
+	(b) = (e);                 \
+	(c) = (f);
+
+real_t Minimization::get_local_minimum(void *data, real_function *f, real_function *df, real_t ax, real_t bx, real_t cx, real_t tol, real_t *xmin) {
+	// Given a function f and its derivative function df, and given a bracketing triplet of abscissas ax,
+	// bx, cx [such that bx is between ax and cx, and f(bx) is less than both f(ax) and f(cx)],
+	// this routine isolates the minimum to a fractional precision of about tol using a modification of
+	// Brent's method that uses derivatives. The abscissa of the minimum is returned as xmin, and
+	// the minimum function value is returned as min, the returned function value.
+
+	int iter;
+	bool ok1, ok2; // Will be used as flags for whether proposed steps are acceptable or not.
+	real_t a, b, d = 0.0, d1, d2, du, dv, dw, dx, e = 0.0;
+	real_t fu, fv, fw, fx, olde = 0.0, tol1, tol2, u, u1, u2, v, w, x, xm;
+
+	a = (ax < cx ? ax : cx);
+	b = (ax > cx ? ax : cx);
+	x = w = v = bx;
+	fw = fv = fx = (*f)(data, x);
+	dw = dv = dx = (*df)(data, x);
+	for (iter = 1; iter <= ITMAX; iter++) {
+		xm = 0.5 * (a + b);
+		tol1 = tol * Math::abs(x) + ZEPS;
+		tol2 = 2.0 * tol1;
+		if (Math::abs(x - xm) <= (tol2 - 0.5 * (b - a))) {
+			*xmin = x;
+			return fx;
+		}
+		if (Math::abs(e) > tol1) {
+			// Initialize these d's to an out-of-bracket value.
+			d1 = 2.0 * (b - a);
+			d2 = d1;
+			if (dw != dx) {
+				d1 = (w - x) * dx / (dx - dw); // Secant method with one point.
+			}
+			if (dv != dx) {
+				d2 = (v - x) * dx / (dx - dv); // And the other.
+			}
+			// Which of these two estimates of d shall we take? We will insist that they be within the bracket, and on the side pointed to by the derivative at x.
+			u1 = x + d1;
+			u2 = x + d2;
+			ok1 = (a - u1) * (u1 - b) > 0.0 && dx * d1 <= 0.0;
+			ok2 = (a - u2) * (u2 - b) > 0.0 && dx * d2 <= 0.0;
+			olde = e; // Movement on the step before last.
+			e = d;
+			if (ok1 || ok2) { // Take only an acceptable d,
+				if (ok1 && ok2) { // and if both are acceptable, then take the smallest one.
+					d = (Math::abs(d1) < Math::abs(d2) ? d1 : d2);
+				} else if (ok1) {
+					d = d1;
+				} else {
+					d = d2;
+				}
+				if (Math::abs(d) <= Math::abs(0.5 * olde)) {
+					u = x + d;
+					if (u - a < tol2 || b - u < tol2) {
+						d = SIGN2(tol1, xm - x);
+					}
+				} else { // Bisect, not golden section.
+					d = 0.5 * (e = (dx >= 0.0 ? a - x : b - x)); // Decide which segment by the sign of the derivative.
+				}
+			} else {
+				d = 0.5 * (e = (dx >= 0.0 ? a - x : b - x));
+			}
+		} else {
+			d = 0.5 * (e = (dx >= 0.0 ? a - x : b - x));
+		}
+		if (Math::abs(d) >= tol1) {
+			u = x + d;
+			fu = (*f)(data, u);
+		} else {
+			u = x + SIGN2(tol1, d);
+			fu = (*f)(data, u);
+			if (fu > fx) { // If the minimum step in the downhill direction takes us uphill, then we are done.
+				*xmin = x;
+				return fx;
+			}
+		}
+		// Now all the housekeeping.
+		du = (*df)(data, u);
+		if (fu <= fx) {
+			if (u >= x) {
+				a = x;
+			} else {
+				b = x;
+			}
+			MOV3(v, fv, dv, w, fw, dw)
+			MOV3(w, fw, dw, x, fx, dx)
+			MOV3(x, fx, dx, u, fu, du)
+		} else {
+			if (u < x) {
+				a = u;
+			} else {
+				b = u;
+			}
+			if (fu <= fw || w == x) {
+				MOV3(v, fv, dv, w, fw, dw)
+				MOV3(w, fw, dw, u, fu, du)
+			} else if (fu < fv || v == x || v == w) {
+				MOV3(v, fv, dv, u, fu, du)
+			}
+		}
+	}
+	ERR_FAIL_V_MSG(0.0, "get_local_minimum failed to converge.");
+}

--- a/core/math/minimization.h
+++ b/core/math/minimization.h
@@ -1,0 +1,44 @@
+/**************************************************************************/
+/*  minimization.h                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef MINIMIZATION_H
+#define MINIMIZATION_H
+
+#include "core/math/math_defs.h"
+
+class Minimization {
+public:
+	typedef real_t real_function(void *data, real_t t);
+
+	static void bracketing_triplet_from_interval(void *data, real_function *f, real_t *ax, real_t *bx, real_t *cx, real_t *fa, real_t *fb, real_t *fc);
+	static real_t get_local_minimum(void *data, real_function *f, real_function *f_derivative, real_t ax, real_t bx, real_t cx, real_t tol, real_t *xmin);
+};
+
+#endif // MINIMIZATION_H

--- a/doc/classes/Geometry3D.xml
+++ b/doc/classes/Geometry3D.xml
@@ -73,6 +73,16 @@
 				Given two circles, finds pairs of points of minimal distance. Returns a [PackedVector3Array] that contains pairs of points such that in each pair the first point lies on the first circle and the second point lies on the second circle.
 			</description>
 		</method>
+		<method name="get_closest_points_between_line_and_circle">
+			<return type="PackedVector3Array" />
+			<param index="0" name="line_origin" type="Vector3" />
+			<param index="1" name="line_direction" type="Vector3" />
+			<param index="2" name="circle_transform" type="Transform3D" />
+			<param index="3" name="circle_radius" type="float" />
+			<description>
+				Given a line and a circle, finds pairs of points of minimal distance. Returns a [PackedVector3Array] that contains pairs of points such that in each pair the first point lies on the line and the second point lies on the circle. The [param line_direction] should be normalized.
+			</description>
+		</method>
 		<method name="get_closest_points_between_segments">
 			<return type="PackedVector3Array" />
 			<param index="0" name="p1" type="Vector3" />

--- a/doc/classes/Geometry3D.xml
+++ b/doc/classes/Geometry3D.xml
@@ -63,6 +63,16 @@
 				Returns the 3D point on the 3D line defined by ([param s1], [param s2]) that is closest to [param point]. The returned point can be inside the segment ([param s1], [param s2]) or outside of it, i.e. somewhere on the line extending from the segment.
 			</description>
 		</method>
+		<method name="get_closest_points_between_circle_and_circle">
+			<return type="PackedVector3Array" />
+			<param index="0" name="circle0_transform" type="Transform3D" />
+			<param index="1" name="circle0_radius" type="float" />
+			<param index="2" name="circle1_transform" type="Transform3D" />
+			<param index="3" name="circle1_radius" type="float" />
+			<description>
+				Given two circles, finds pairs of points of minimal distance. Returns a [PackedVector3Array] that contains pairs of points such that in each pair the first point lies on the first circle and the second point lies on the second circle.
+			</description>
+		</method>
 		<method name="get_closest_points_between_segments">
 			<return type="PackedVector3Array" />
 			<param index="0" name="p1" type="Vector3" />


### PR DESCRIPTION
This PR implements Vranek's [*Fast and Accurate Circle-Circle and Circle-Line 3D Distance Computation*](https://www.tandfonline.com/doi/abs/10.1080/10867651.2002.10487552) with the following API:

![line-circle_and_circle-circle_api](https://user-images.githubusercontent.com/229837/213831777-b495cc33-2f73-4ad3-b7ba-659ef1e1316a.png)

The line-circle implementation is based on the one in [`webots`](https://github.com/cyberbotics/webots/blob/21d6eefd7a2f59fa3277788b552587e388dfe0a4/src/ode/ode/src/cylinder_revolution_data.cpp) and the circle-circle implementation is based on the one in [`MinuteTorus`](https://github.com/SonSang/MinuteTorus/blob/1a11cacc8cea6f62d16ffc9919ba35fe998742c9/Circle/CircleDistance.cpp), though both have been significantly modified. The original article is sketchy regarding the line-circle case; I've added details in comments in the code, and answering my [question about the choice of bracketing triplet](https://math.stackexchange.com/questions/4618258/minimum-distance-between-a-line-and-a-circle-in-3d-bracketing-triplet) could improve the implementation.

* Works well even in `precision=single` builds, unlike the alternative implementation of these functions in https://github.com/godotengine/godot/pull/68958.

* Fixes cylinder sliding on cylinder in https://github.com/fabriceci/Godot-Physics-Tests

* Shows significant improvement in the "Face Z" and "Tumbling" cases of https://github.com/Malcolmnixon/PhysicsCollisionTest. I'm not sure why "Face Y" does not work better. I could use some help debugging this.

* Demo to test the circle-circle and line-circle closest points functions directly: [circle-distance-demo.zip](https://github.com/godotengine/godot/files/10471228/circle-distance-demo.zip)

* Demo to test cylinder-cylinder collisions: [CharacterAndCylinderIssue-modified.zip](https://github.com/godotengine/godot/files/10471227/CharacterAndCylinderIssue-modified.zip)

To improve cylinder collisions still further (and implement cylinder-cylinder distance), disk-circle and segment-circle closest points functions should be implemented.