### PR TITLE
Stop incrementing light_count once max number of lights are reached in 2D canvas renderer

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -803,7 +803,7 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 
 				light_count++;
 
-				if (light_count == data.max_lights_per_item) {
+				if (light_count == data.max_lights_per_item - 1) {
 					break;
 				}
 			}

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -455,7 +455,7 @@ void RendererCanvasRenderRD::_render_item(RD::DrawListID p_draw_list, RID p_rend
 
 				light_count++;
 
-				if (light_count == MAX_LIGHTS_PER_ITEM) {
+				if (light_count == MAX_LIGHTS_PER_ITEM - 1) {
 					break;
 				}
 			}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/68812

The issue is that we only have 4 bits to use to track the light count per item. ``light_count`` is actually tracking the max light index rather than the count itself so we need to quick once light count hits 1 - max lights otherwise we overflow to 5 bits and the value we end up passing is 0. 

Luckily the overflow wasn't causing other bugs as the flags bitfield is not tightly packed.