### PR TITLE
call update_exports from LSP didSave function

### DIFF
--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -107,6 +107,7 @@ void GDScriptTextDocument::didSave(const Variant &p_param) {
 		} else {
 			scr->reload(true);
 		}
+		scr->update_exports();
 		ScriptEditor::get_singleton()->update_docs_from_script(scr);
 	}
 }


### PR DESCRIPTION
Exports in the inspector were not properly appearing when a gdscript was saved using an external IDE

This commit adds a call to GDScript::UpdateExports toward the end of GDScriptTextDocument::didSave

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
