### PR TITLE
C#: Restore `Scale` and `Rotation` properties

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -120,6 +120,24 @@ namespace Godot
         }
 
         /// <summary>
+        /// Assuming that the matrix is the combination of a rotation and scaling,
+        /// return the absolute value of scaling factors along each axis.
+        /// </summary>
+        public readonly Vector3 Scale
+        {
+            get
+            {
+                real_t detSign = Mathf.Sign(Determinant());
+                return detSign * new Vector3
+                (
+                    Column0.Length(),
+                    Column1.Length(),
+                    Column2.Length()
+                );
+            }
+        }
+
+        /// <summary>
         /// Access whole columns in the form of <see cref="Vector3"/>.
         /// </summary>
         /// <param name="column">Which column vector.</param>
@@ -539,21 +557,6 @@ namespace Godot
             }
 
             return orthonormalizedBasis.GetQuaternion();
-        }
-
-        /// <summary>
-        /// Assuming that the matrix is the combination of a rotation and scaling,
-        /// return the absolute value of scaling factors along each axis.
-        /// </summary>
-        public readonly Vector3 GetScale()
-        {
-            real_t detSign = Mathf.Sign(Determinant());
-            return detSign * new Vector3
-            (
-                Column0.Length(),
-                Column1.Length(),
-                Column2.Length()
-            );
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Godot
@@ -30,6 +31,23 @@ namespace Godot
         /// The origin vector represents translation.
         /// </summary>
         public Vector2 origin;
+
+        /// <summary>
+        /// Returns the transform's rotation (in radians).
+        /// </summary>
+        public readonly real_t Rotation => Mathf.Atan2(x.y, x.x);
+
+        /// <summary>
+        /// Returns the scale.
+        /// </summary>
+        public readonly Vector2 Scale
+        {
+            get
+            {
+                real_t detSign = Mathf.Sign(BasisDeterminant());
+                return new Vector2(x.Length(), detSign * y.Length());
+            }
+        }
 
         /// <summary>
         /// Access whole columns in the form of <see cref="Vector2"/>.
@@ -131,6 +149,7 @@ namespace Godot
         /// and is usually considered invalid.
         /// </summary>
         /// <returns>The determinant of the basis matrix.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private readonly real_t BasisDeterminant()
         {
             return (x.x * y.y) - (x.y * y.x);
@@ -164,23 +183,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the transform's rotation (in radians).
-        /// </summary>
-        public readonly real_t GetRotation()
-        {
-            return Mathf.Atan2(x.y, x.x);
-        }
-
-        /// <summary>
-        /// Returns the scale.
-        /// </summary>
-        public readonly Vector2 GetScale()
-        {
-            real_t detSign = Mathf.Sign(BasisDeterminant());
-            return new Vector2(x.Length(), detSign * y.Length());
-        }
-
-        /// <summary>
         /// Interpolates this transform to the other <paramref name="transform"/> by <paramref name="weight"/>.
         /// </summary>
         /// <param name="transform">The other transform.</param>
@@ -188,11 +190,11 @@ namespace Godot
         /// <returns>The interpolated transform.</returns>
         public readonly Transform2D InterpolateWith(Transform2D transform, real_t weight)
         {
-            real_t r1 = GetRotation();
-            real_t r2 = transform.GetRotation();
+            real_t r1 = Rotation;
+            real_t r2 = transform.Rotation;
 
-            Vector2 s1 = GetScale();
-            Vector2 s2 = transform.GetScale();
+            Vector2 s1 = Scale;
+            Vector2 s2 = transform.Scale;
 
             // Slerp rotation
             (real_t sin1, real_t cos1) = Mathf.SinCos(r1);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -124,11 +124,11 @@ namespace Godot
         /// <returns>The interpolated transform.</returns>
         public readonly Transform3D InterpolateWith(Transform3D transform, real_t weight)
         {
-            Vector3 sourceScale = basis.GetScale();
+            Vector3 sourceScale = basis.Scale;
             Quaternion sourceRotation = basis.GetRotationQuaternion();
             Vector3 sourceLocation = origin;
 
-            Vector3 destinationScale = transform.basis.GetScale();
+            Vector3 destinationScale = transform.basis.Scale;
             Quaternion destinationRotation = transform.basis.GetRotationQuaternion();
             Vector3 destinationLocation = transform.origin;
 


### PR DESCRIPTION
After receiving feedback from users, it seems that these members make more sense as properties than methods and since they are not expensive enough to requisite being implemented as methods I decided to partly revert https://github.com/godotengine/godot/pull/71431 and implement these methods as readonly properties.

- Replace `GetRotation` method with `Rotation` readonly property in `Transform2D`.
- Replace `GetScale` method with `Scale` readonly property in `Transform2D`.
- Replace `GetScale` method with `Scale` readonly property in `Basis`.

_This breaks compatibility with beta 13 and 14_.