### PR TITLE
Fix typo in hint when using removed built-in textures

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -5402,7 +5402,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 						if (identifier == "SCREEN_TEXTURE" || identifier == "DEPTH_TEXTURE" || identifier == "NORMAL_ROUGHNESS_TEXTURE") {
 							String name = String(identifier);
 							String name_lower = name.to_lower();
-							_set_error(vformat(RTR("%s has been removed in favor of using hint_%s with a uniform.\nTo continue with minimal code changes add 'uniform sampler2D %s : hint_%s, filter_linear_mipmaps;' near the top of your shader."), name, name_lower, name, name_lower));
+							_set_error(vformat(RTR("%s has been removed in favor of using hint_%s with a uniform.\nTo continue with minimal code changes add 'uniform sampler2D %s : hint_%s, filter_linear_mipmap;' near the top of your shader."), name, name_lower, name, name_lower));
 							return nullptr;
 						}
 						_set_error(vformat(RTR("Unknown identifier in expression: '%s'."), String(identifier)));


### PR DESCRIPTION
**Edit:** Didn't realize this was marked as a first issue fix. While I probably am still worthy of such a label (🤣), if a first-timer wants to handle this before it gets merged, feel free to do so!

Fixes #71736.