### PR TITLE
Fix shortcuts which have feature override defined reverting to default when user changes the shortcut to be same as non-overridden.

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1485,11 +1485,11 @@ void ED_SHORTCUT_OVERRIDE_ARRAY(const String &p_path, const String &p_feature, c
 	}
 
 	// Override the existing shortcut only if it wasn't customized by the user (i.e. still "original").
+	sc->set_meta("original", events.duplicate(true));
+
 	if (Shortcut::is_event_array_equal(sc->get_events(), sc->get_meta("original"))) {
 		sc->set_events(events);
 	}
-
-	sc->set_meta("original", events.duplicate(true));
 }
 
 Ref<Shortcut> ED_SHORTCUT(const String &p_path, const String &p_name, Key p_keycode) {


### PR DESCRIPTION
Fixes #66428