### PR TITLE
Fix constant editor redraw after shortcut

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -385,6 +385,7 @@ void BaseButton::shortcut_input(const Ref<InputEvent> &p_event) {
 		if (shortcut_feedback) {
 			if (shortcut_feedback_timer == nullptr) {
 				shortcut_feedback_timer = memnew(Timer);
+				shortcut_feedback_timer->set_one_shot(true);
 				add_child(shortcut_feedback_timer);
 				shortcut_feedback_timer->set_wait_time(GLOBAL_GET("gui/timers/button_shortcut_feedback_highlight_time"));
 				shortcut_feedback_timer->connect("timeout", callable_mp(this, &BaseButton::_shortcut_feedback_timeout));


### PR DESCRIPTION
Introduced by me by mistake on #71328. Fixes #71652.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
