### PR TITLE
CI: Add official codespell action with PR annotations

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -71,3 +71,11 @@ jobs:
       - name: Style checks via dotnet format (dotnet_format.sh)
         run: |
           bash ./misc/scripts/dotnet_format.sh
+
+      - name: Spell checks via codespell
+        uses: codespell-project/actions-codespell@v1
+        with:
+          skip: ./.*,./**/.*,./bin,./thirdparty,*.desktop,*.gen.*,*.po,*.pot,*.rc,./AUTHORS.md,./COPYRIGHT.txt,./DONORS.md,./core/input/gamecontrollerdb.txt,./core/string/locales.h,./editor/project_converter_3_to_4.cpp,./misc/scripts/codespell.sh,./platform/android/java/lib/src/com,./platform/web/node_modules,./platform/web/package-lock.json
+          check_hidden: false
+          ignore_words_list: curvelinear,doubleclick,expct,findn,gird,hel,inout,lod,nd,numer,ot,te
+          only_warn: true

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -301,13 +301,13 @@ bool ProjectSettings::_set(const StringName &p_name, const Variant &p_value) {
 
 				for (int i = 1; i < s.size(); i++) {
 					String feature = s[i].strip_edges();
-					Pair<StringName, StringName> fo(feature, p_name);
+					Pair<StringName, StringName> feature_override(feature, p_name);
 
 					if (!feature_overrides.has(s[0])) {
 						feature_overrides[s[0]] = LocalVector<Pair<StringName, StringName>>();
 					}
 
-					feature_overrides[s[0]].push_back(fo);
+					feature_overrides[s[0]].push_back(feature_override);
 				}
 			}
 		}

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -383,15 +383,15 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 
 			if (O->get().plane.is_equal_approx(f.plane)) {
 				//merge and delete edge and contiguous face, while repointing edges (uuugh!)
-				int ois = O->get().indices.size();
+				int o_index_size = O->get().indices.size();
 
-				for (int j = 0; j < ois; j++) {
+				for (int j = 0; j < o_index_size; j++) {
 					//search a
 					if (O->get().indices[j] == a) {
 						//append the rest
-						for (int k = 0; k < ois; k++) {
-							int idx = O->get().indices[(k + j) % ois];
-							int idxn = O->get().indices[(k + j + 1) % ois];
+						for (int k = 0; k < o_index_size; k++) {
+							int idx = O->get().indices[(k + j) % o_index_size];
+							int idxn = O->get().indices[(k + j + 1) % o_index_size];
 							if (idx == b && idxn == a) { //already have b!
 								break;
 							}

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -151,7 +151,7 @@ void Transform2D::orthonormalize() {
 	Vector2 y = columns[1];
 
 	x.normalize();
-	y = (y - x * (x.dot(y)));
+	y = y - x * x.dot(y);
 	y.normalize();
 
 	columns[0] = x;
@@ -159,9 +159,9 @@ void Transform2D::orthonormalize() {
 }
 
 Transform2D Transform2D::orthonormalized() const {
-	Transform2D on = *this;
-	on.orthonormalize();
-	return on;
+	Transform2D ortho = *this;
+	ortho.orthonormalize();
+	return ortho;
 }
 
 bool Transform2D::is_equal_approx(const Transform2D &p_transform) const {

--- a/core/object/worker_thread_pool.h
+++ b/core/object/worker_thread_pool.h
@@ -173,8 +173,8 @@ public:
 
 	template <class C, class M, class U>
 	GroupID add_template_group_task(C *p_instance, M p_method, U p_userdata, int p_elements, int p_tasks = -1, bool p_high_priority = false, const String &p_description = String()) {
-		typedef GroupUserData<C, M, U> GUD;
-		GUD *ud = memnew(GUD);
+		typedef GroupUserData<C, M, U> GroupUD;
+		GroupUD *ud = memnew(GroupUD);
 		ud->instance = p_instance;
 		ud->method = p_method;
 		ud->userdata = p_userdata;

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -553,11 +553,11 @@
 				[b]Note:[/b] If the user has disabled the recycle bin on their system, the file will be permanently deleted instead.
 				[codeblocks]
 				[gdscript]
-				var file_to_remove = "user://slot1.sav"
+				var file_to_remove = "user://slot1.save"
 				OS.move_to_trash(ProjectSettings.globalize_path(file_to_remove))
 				[/gdscript]
 				[csharp]
-				var fileToRemove = "user://slot1.sav";
+				var fileToRemove = "user://slot1.save";
 				OS.MoveToTrash(ProjectSettings.GlobalizePath(fileToRemove));
 				[/csharp]
 				[/codeblocks]

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -241,8 +241,8 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 	}
 
 	for (int i = 0; i < favorite_paths.size(); i++) {
-		String fave = favorite_paths[i];
-		if (!fave.begins_with("res://")) {
+		String favorite = favorite_paths[i];
+		if (!favorite.begins_with("res://")) {
 			continue;
 		}
 
@@ -252,18 +252,18 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 		String text;
 		Ref<Texture2D> icon;
 		Color color;
-		if (fave == "res://") {
+		if (favorite == "res://") {
 			text = "/";
 			icon = folder_icon;
 			color = folder_color;
-		} else if (fave.ends_with("/")) {
-			text = fave.substr(0, fave.length() - 1).get_file();
+		} else if (favorite.ends_with("/")) {
+			text = favorite.substr(0, favorite.length() - 1).get_file();
 			icon = folder_icon;
 			color = folder_color;
 		} else {
-			text = fave.get_file();
+			text = favorite.get_file();
 			int index;
-			EditorFileSystemDirectory *dir = EditorFileSystem::get_singleton()->find_file(fave, &index);
+			EditorFileSystemDirectory *dir = EditorFileSystem::get_singleton()->find_file(favorite, &index);
 			if (dir) {
 				icon = _get_tree_item_icon(dir->get_file_import_is_valid(index), dir->get_file_type(index));
 			} else {
@@ -277,18 +277,18 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 			ti->set_text(0, text);
 			ti->set_icon(0, icon);
 			ti->set_icon_modulate(0, color);
-			ti->set_tooltip_text(0, fave);
+			ti->set_tooltip_text(0, favorite);
 			ti->set_selectable(0, true);
-			ti->set_metadata(0, fave);
-			if (p_select_in_favorites && fave == path) {
+			ti->set_metadata(0, favorite);
+			if (p_select_in_favorites && favorite == path) {
 				ti->select(0);
 				ti->set_as_cursor(0);
 			}
-			if (!fave.ends_with("/")) {
+			if (!favorite.ends_with("/")) {
 				Array udata;
 				udata.push_back(tree_update_id);
 				udata.push_back(ti);
-				EditorResourcePreview::get_singleton()->queue_resource_preview(fave, this, "_tree_thumbnail_done", udata);
+				EditorResourcePreview::get_singleton()->queue_resource_preview(favorite, this, "_tree_thumbnail_done", udata);
 			}
 		}
 	}

--- a/misc/scripts/codespell.sh
+++ b/misc/scripts/codespell.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-SKIP_LIST="./.*,./bin,./thirdparty,*.desktop,*.gen.*,*.po,*.pot,*.rc,./AUTHORS.md,./COPYRIGHT.txt,./DONORS.md,"
-SKIP_LIST+="./core/string/locales.h,./editor/project_converter_3_to_4.cpp,./misc/scripts/codespell.sh,"
+SKIP_LIST="./.*,./**/.*,./bin,./thirdparty,*.desktop,*.gen.*,*.po,*.pot,*.rc,./AUTHORS.md,./COPYRIGHT.txt,./DONORS.md,"
+SKIP_LIST+="./core/input/gamecontrollerdb.txt,./core/string/locales.h,./editor/project_converter_3_to_4.cpp,./misc/scripts/codespell.sh,"
 SKIP_LIST+="./platform/android/java/lib/src/com,./platform/web/node_modules,./platform/web/package-lock.json,"
 
-IGNORE_LIST="alo,ba,complies,curvelinear,doubleclick,expct,fave,findn,gird,gud,inout,lod,nd,numer,ois,readded,ro,sav,statics,te,varius,varn,wan"
+IGNORE_LIST="curvelinear,doubleclick,expct,findn,gird,hel,inout,lod,nd,numer,ot,te"
 
 codespell -w -q 3 -S "${SKIP_LIST}" -L "${IGNORE_LIST}" --builtin "clear,rare,en-GB_to_en-US"

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -247,19 +247,19 @@ namespace Godot
         /// <returns>The orthonormalized transform.</returns>
         public readonly Transform2D Orthonormalized()
         {
-            Transform2D on = this;
+            Transform2D ortho = this;
 
-            Vector2 onX = on.X;
-            Vector2 onY = on.Y;
+            Vector2 orthoX = ortho.X;
+            Vector2 orthoY = ortho.Y;
 
-            onX.Normalize();
-            onY = onY - (onX * onX.Dot(onY));
-            onY.Normalize();
+            orthoX.Normalize();
+            orthoY = orthoY - orthoX * orthoX.Dot(orthoY);
+            orthoY.Normalize();
 
-            on.X = onX;
-            on.Y = onY;
+            ortho.X = orthoX;
+            ortho.Y = orthoY;
 
-            return on;
+            return ortho;
         }
 
         /// <summary>

--- a/platform/android/java/lib/src/org/godotengine/godot/FullScreenGodotApp.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/FullScreenGodotApp.java
@@ -99,7 +99,7 @@ public abstract class FullScreenGodotApp extends FragmentActivity implements God
 				// from scratch. Therefore, we need to kill the whole app process and relaunch it.
 				//
 				// Restarting only the activity, wouldn't be enough unless it did proper cleanup (including
-				// releasing and reloading native libs or resetting their state somehow and clearing statics).
+				// releasing and reloading native libs or resetting their state somehow and clearing static data).
 				Log.v(TAG, "Restarting Godot instance...");
 				ProcessPhoenix.triggerRebirth(FullScreenGodotApp.this);
 			}

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -140,7 +140,7 @@ void NavigationAgent2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_POST_ENTER_TREE: {
 			// need to use POST_ENTER_TREE cause with normal ENTER_TREE not all required Nodes are ready.
-			// cannot use READY as ready does not get called if Node is readded to SceneTree
+			// cannot use READY as ready does not get called if Node is re-added to SceneTree
 			set_agent_parent(get_parent());
 			set_physics_process_internal(true);
 

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -143,7 +143,7 @@ void NavigationAgent3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_POST_ENTER_TREE: {
 			// need to use POST_ENTER_TREE cause with normal ENTER_TREE not all required Nodes are ready.
-			// cannot use READY as ready does not get called if Node is readded to SceneTree
+			// cannot use READY as ready does not get called if Node is re-added to SceneTree
 			set_agent_parent(get_parent());
 			set_physics_process_internal(true);
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2135,13 +2135,13 @@ Node *Node::_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap) c
 	} else if ((p_flags & DUPLICATE_USE_INSTANTIATION) && !get_scene_file_path().is_empty()) {
 		Ref<PackedScene> res = ResourceLoader::load(get_scene_file_path());
 		ERR_FAIL_COND_V(res.is_null(), nullptr);
-		PackedScene::GenEditState ges = PackedScene::GEN_EDIT_STATE_DISABLED;
+		PackedScene::GenEditState edit_state = PackedScene::GEN_EDIT_STATE_DISABLED;
 #ifdef TOOLS_ENABLED
 		if (p_flags & DUPLICATE_FROM_EDITOR) {
-			ges = PackedScene::GEN_EDIT_STATE_INSTANCE;
+			edit_state = PackedScene::GEN_EDIT_STATE_INSTANCE;
 		}
 #endif
-		node = res->instantiate(ges);
+		node = res->instantiate(edit_state);
 		ERR_FAIL_COND_V(!node, nullptr);
 		node->set_scene_instance_load_placeholder(get_scene_instance_load_placeholder());
 

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -2379,15 +2379,15 @@ Error ResourceFormatSaverText::set_uid(const String &p_path, ResourceUID::ID p_u
 	String local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 	Error err = OK;
 	{
-		Ref<FileAccess> fo = FileAccess::open(p_path, FileAccess::READ);
-		if (fo.is_null()) {
+		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::READ);
+		if (file.is_null()) {
 			ERR_FAIL_V(ERR_CANT_OPEN);
 		}
 
 		ResourceLoaderText loader;
 		loader.local_path = local_path;
 		loader.res_path = loader.local_path;
-		err = loader.set_uid(fo, p_uid);
+		err = loader.set_uid(file, p_uid);
 	}
 
 	if (err == OK) {

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.h
@@ -323,13 +323,13 @@ public:
 
 	// http://andrewthall.org/papers/df64_qf128.pdf
 #ifdef REAL_T_IS_DOUBLE
-	static _FORCE_INLINE_ void split_double(double a, float *ahi, float *alo) {
+	static _FORCE_INLINE_ void split_double(double a, float *a_hi, float *a_lo) {
 		const double SPLITTER = (1 << 29) + 1;
 		double t = a * SPLITTER;
-		double thi = t - (t - a);
-		double tlo = a - thi;
-		*ahi = (float)thi;
-		*alo = (float)tlo;
+		double t_hi = t - (t - a);
+		double t_lo = a - t_hi;
+		*a_hi = (float)t_hi;
+		*a_lo = (float)t_lo;
 	}
 #endif
 

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -4530,14 +4530,14 @@ bool ShaderLanguage::_check_node_constness(const Node *p_node) const {
 		case Node::TYPE_CONSTANT:
 			break;
 		case Node::TYPE_VARIABLE: {
-			const VariableNode *varn = static_cast<const VariableNode *>(p_node);
-			if (!varn->is_const) {
+			const VariableNode *var_node = static_cast<const VariableNode *>(p_node);
+			if (!var_node->is_const) {
 				return false;
 			}
 		} break;
 		case Node::TYPE_ARRAY: {
-			const ArrayNode *arrn = static_cast<const ArrayNode *>(p_node);
-			if (!arrn->is_const) {
+			const ArrayNode *arr_node = static_cast<const ArrayNode *>(p_node);
+			if (!arr_node->is_const) {
 				return false;
 			}
 		} break;

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -3086,7 +3086,7 @@ TEST_CASE("[SceneTree][TextEdit] context menu") {
 	text_edit->get_viewport()->set_embedding_subwindows(true); // Bypass display server for drop handling.
 
 	text_edit->set_size(Size2(800, 200));
-	text_edit->set_line(0, "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec varius mattis leo, sed porta ex lacinia bibendum. Nunc bibendum pellentesque.");
+	text_edit->set_line(0, "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vasius mattis leo, sed porta ex lacinia bibendum. Nunc bibendum pellentesque.");
 	MessageQueue::get_singleton()->flush();
 
 	text_edit->set_context_menu_enabled(false);
@@ -3227,7 +3227,7 @@ TEST_CASE("[SceneTree][TextEdit] mouse") {
 	SceneTree::get_singleton()->get_root()->add_child(text_edit);
 
 	text_edit->set_size(Size2(800, 200));
-	text_edit->set_line(0, "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec varius mattis leo, sed porta ex lacinia bibendum. Nunc bibendum pellentesque.");
+	text_edit->set_line(0, "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vasius mattis leo, sed porta ex lacinia bibendum. Nunc bibendum pellentesque.");
 	MessageQueue::get_singleton()->flush();
 
 	CHECK(text_edit->get_word_at_pos(text_edit->get_pos_at_line_column(0, 1)) == "Lorem");
@@ -3305,9 +3305,9 @@ TEST_CASE("[SceneTree][TextEdit] caret") {
 	SEND_GUI_ACTION(text_edit, "ui_text_caret_left");
 	CHECK(text_edit->get_caret_column() == 0);
 
-	text_edit->set_line(0, "Lorem  ipsum dolor sit amet, consectetur adipiscing elit. Donec varius mattis leo, sed porta ex lacinia bibendum. Nunc bibendum pellentesque.");
+	text_edit->set_line(0, "Lorem  ipsum dolor sit amet, consectetur adipiscing elit. Donec vasius mattis leo, sed porta ex lacinia bibendum. Nunc bibendum pellentesque.");
 	for (int i = 0; i < 3; i++) {
-		text_edit->insert_line_at(0, "Lorem  ipsum dolor sit amet, consectetur adipiscing elit. Donec varius mattis leo, sed porta ex lacinia bibendum. Nunc bibendum pellentesque.");
+		text_edit->insert_line_at(0, "Lorem  ipsum dolor sit amet, consectetur adipiscing elit. Donec vasius mattis leo, sed porta ex lacinia bibendum. Nunc bibendum pellentesque.");
 	}
 	MessageQueue::get_singleton()->flush();
 
@@ -3519,7 +3519,7 @@ TEST_CASE("[SceneTree][TextEdit] line wrapping") {
 
 	// Set size for boundary.
 	text_edit->set_size(Size2(800, 200));
-	text_edit->set_line(0, "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec varius mattis leo, sed porta ex lacinia bibendum. Nunc bibendum pellentesque.");
+	text_edit->set_line(0, "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vasius mattis leo, sed porta ex lacinia bibendum. Nunc bibendum pellentesque.");
 	CHECK_FALSE(text_edit->is_line_wrapped(0));
 	CHECK(text_edit->get_line_wrap_count(0) == 0);
 	CHECK(text_edit->get_line_wrap_index_at_column(0, 130) == 0);
@@ -3569,7 +3569,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	// No subcases here for performance.
 	text_edit->set_size(Size2(800, 600));
 	for (int i = 0; i < 50; i++) {
-		text_edit->insert_line_at(0, "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec varius mattis leo, sed porta ex lacinia bibendum. Nunc bibendum pellentesque.");
+		text_edit->insert_line_at(0, "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vasius mattis leo, sed porta ex lacinia bibendum. Nunc bibendum pellentesque.");
 	}
 	MessageQueue::get_singleton()->flush();
 
@@ -3897,7 +3897,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_h_scroll() == 0);
 
 	text_edit->set_h_scroll(10000000);
-	CHECK(text_edit->get_h_scroll() == 313);
+	CHECK(text_edit->get_h_scroll() == 314);
 
 	text_edit->set_h_scroll(-100);
 	CHECK(text_edit->get_h_scroll() == 0);


### PR DESCRIPTION
From https://github.com/codespell-project/actions-codespell

Seems to work well, though it's a bit stricter than the command line one. On the command line, some potential typos like "fo" for "of" were not changed because there are too many potential false positives, but the action wouldn't make a distinction.

So instead of adding yet another batch of small words to the ignore list, I did a full review of which words should still be ignored, and which ones can actually be changed in the codebase to remove the false positive (and allow catching potential real typos in future PRs).