### PR TITLE
Remove redundant definition of `convert_text_resources_to_binary`

### DIFF
--- a/editor/export/editor_export_plugin.cpp
+++ b/editor/export/editor_export_plugin.cpp
@@ -227,8 +227,6 @@ void EditorExportPlugin::_bind_methods() {
 }
 
 EditorExportPlugin::EditorExportPlugin() {
-	GLOBAL_DEF("editor/export/convert_text_resources_to_binary", false);
-
 	EDITOR_DEF("export/ssh/ssh", "");
 	EDITOR_DEF("export/ssh/scp", "");
 }


### PR DESCRIPTION
Fixes #71811 that was seemingly introduced in #63312.

Considering that `EditorExportPlugin` lives within `EditorExport` anyway it seemed to me that this second definition was redundant.

I'll admit I don't know what (if any) consequences this might have on the stuff that was done in #63312, so I'd appreciate if you could give it a review @bruvzg.