### PR TITLE
Auto resize custom class category icon in inspector.

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1124,14 +1124,16 @@ void EditorInspectorCategory::_notification(int p_what) {
 
 			int w = font->get_string_size(label, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).width;
 			if (icon.is_valid()) {
-				w += hs + icon->get_width();
+				w += (hs + 16 * EDSCALE);
 			}
 
 			int ofs = (get_size().width - w) / 2;
 
 			if (icon.is_valid()) {
-				draw_texture(icon, Point2(ofs, (get_size().height - icon->get_height()) / 2).floor());
-				ofs += hs + icon->get_width();
+				auto rect_size = Size2(16 * EDSCALE, 16 * EDSCALE);
+				auto rect_pos = Point2(ofs, (get_size().height - rect_size.height) / 2).floor();
+				draw_texture_rect(icon, Rect2(rect_pos, rect_size), false);
+				ofs += hs + rect_size.width;
 			}
 
 			Color color = get_theme_color(SNAME("font_color"), SNAME("Tree"));


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Before:
![category_icon](https://user-images.githubusercontent.com/61624558/213875759-cd241bdd-5270-44ff-abf8-7e7d28b5eaa4.png)


After:
![category fixed](https://user-images.githubusercontent.com/61624558/213875762-cae68c96-c750-4f27-914f-3f7bd58ae9ca.png)


Fixed [#68962](https://github.com/godotengine/godot/issues/68962).
