### PR TITLE
Fix wrong BezierTrack init value

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -754,7 +754,7 @@ bool AnimationTree::_update_caches(AnimationPlayer *player) {
 						if (has_reset_anim) {
 							int rt = reset_anim->find_track(path, track_type);
 							if (rt >= 0 && reset_anim->track_get_key_count(rt) > 0) {
-								track_bezier->init_value = reset_anim->track_get_key_value(rt, 0);
+								track_bezier->init_value = (reset_anim->track_get_key_value(rt, 0).operator Array())[0];
 							}
 						}
 					} break;


### PR DESCRIPTION
Fixes #71532.

BezierTrack returns an Array including the handle value as key value, but only the first element is needed as init value.