### PR TITLE
Fix crash when reparenting `SoftBody3D` with pinned points

### DIFF
--- a/scene/3d/soft_body_3d.h
+++ b/scene/3d/soft_body_3d.h
@@ -179,6 +179,8 @@ public:
 	void pin_point(int p_point_index, bool pin, const NodePath &p_spatial_attachment_path = NodePath());
 	bool is_point_pinned(int p_point_index) const;
 
+	void _pin_point_deferred(int p_point_index, bool pin, const NodePath p_spatial_attachment_path);
+
 	void set_ray_pickable(bool p_ray_pickable);
 	bool is_ray_pickable() const;
 


### PR DESCRIPTION
Fixes #71785.

Moves call to `pin_point()` to a deferred function, thus preventing it from calling methods on a referenced node before it gets moved, which resulted in a null pointer.

Thanks to @YuriSizov and @rburing for the help!
