### PR TITLE
C#: Allow use of .NET 7

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotPlugins/GodotPlugins.csproj
+++ b/modules/mono/glue/GodotSharp/GodotPlugins/GodotPlugins.csproj
@@ -8,6 +8,7 @@
 
         <!-- To generate the .runtimeconfig.json file-->
         <EnableDynamicLoading>true</EnableDynamicLoading>
+        <RollForward>LatestMajor</RollForward>
     </PropertyGroup>
 
     <ItemGroup>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
@@ -104,7 +104,7 @@ namespace Godot.NativeInterop
         }
     }
 
-    [StructLayout(LayoutKind.Explicit)]
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_variant
     {
@@ -113,11 +113,11 @@ namespace Godot.NativeInterop
             => (godot_variant*)Unsafe.AsPointer(ref Unsafe.AsRef(in _typeField));
 
         // Variant.Type is generated as an enum of type long, so we can't use for the field as it must only take 32-bits.
-        [FieldOffset(0)] private int _typeField;
+        private int _typeField;
 
         // There's padding here
 
-        [FieldOffset(8)] private godot_variant_data _data;
+        private godot_variant_data _data;
 
         [StructLayout(LayoutKind.Explicit)]
         // ReSharper disable once InconsistentNaming


### PR DESCRIPTION
Unlike #71241 this does not change the target framework the godot assemblies, instead it just allows the godot editor to run using the latest .NET version installed on the machine (including .NET 7).

The change in `InteropStructs.cs` only exists to work around https://github.com/dotnet/runtime/issues/80624. It does not actually change anything, but otherwise if the latest installed .NET version is 7.0.0 or 7.0.2 godot would crash [^1].

Behavior with different .net version installed:
action | none | .net6 | .net7 | .net6 and .net7
--- | --- | --- | --- | ---
running the editor on master | crash | uses .net6 | crash | uses .net6
running the editor on PR | crash | uses .net6 | uses .net7 | uses .net7
exporting project targeting .net6 on master | n/a | uses .net6 | n/a | uses .net6
exporting project targeting .net6 on PR| n/a | uses .net6 | uses .net6 [^2] | uses .net6
exporting project targeting .net7 on master | n/a | build fails | n/a | build fails
exporting project targeting .net7 on PR| n/a | build fails | uses .net7 | uses .net7

Running the exported project does not depend on the installed .net versions and always runs on the target version specified in the the csproj.

I think this is generally the behavior on would expect, except that .net6 projects may run under .net7 inside the editor, but that should generally not change anything and if it does cause issues for a project can be worked around by uninstalling .net7.

Test projects that shows a message box with the current running .net version: [Net7.zip](https://github.com/godotengine/godot/files/10473173/Net7.zip)


Probably makes #68652 and maybe #70129 go away, although there the underlying issue seems to be a .NET 6 installation that got corrupted in the process of installing .NET 7 and not actually something that can really be fixed.

---

For users this PR means that they can use the godot editor (mono version) without crashing at startup if only .NET 7 is installed on their machine, and if they have .NET 7 installed they can change the `TargetFramework` in their `.csproj` to `net7.0` and start using .NET 7 and C# 11 features in their code.


[^1]: 7.0.1 does not exist and 7.0.4, the version that likely contains the fix is not released yet.
[^2]: I was concerned about this case, but somehow the exported projects correctly runs using .net6 even tho that version is not installed anywhere