### PR TITLE
Adjust OptionButton icon sizes in PopupMenu automatically

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -35,10 +35,7 @@
 #include "servers/rendering_server.h"
 
 Size2 Button::get_minimum_size() const {
-	Ref<Texture2D> _icon = icon;
-	if (_icon.is_null() && has_theme_icon(SNAME("icon"))) {
-		_icon = theme_cache.icon;
-	}
+	Ref<Texture2D> _icon = get_icon();
 
 	return get_minimum_size_for_text_and_icon("", _icon);
 }
@@ -229,12 +226,7 @@ void Button::_notification(int p_what) {
 				style2->draw(ci, Rect2(Point2(), size));
 			}
 
-			Ref<Texture2D> _icon;
-			if (icon.is_null() && has_theme_icon(SNAME("icon"))) {
-				_icon = theme_cache.icon;
-			} else {
-				_icon = icon;
-			}
+			Ref<Texture2D> _icon = get_icon();
 
 			Rect2 icon_region;
 			HorizontalAlignment icon_align_rtl_checked = horizontal_icon_alignment;
@@ -290,12 +282,12 @@ void Button::_notification(int p_what) {
 					if (vertical_icon_alignment != VERTICAL_ALIGNMENT_CENTER) {
 						_size.height -= text_buf->get_size().height;
 					}
-					float icon_width = _icon->get_width() * _size.height / _icon->get_height();
 					float icon_height = _size.height;
+					float icon_width = get_icon_width_with_aspect_ratio(icon_height);
 
 					if (icon_width > _size.width) {
 						icon_width = _size.width;
-						icon_height = _icon->get_height() * icon_width / _icon->get_width();
+						icon_height = get_icon_height_with_aspect_ratio(icon_width);
 					}
 
 					icon_size = Size2(icon_width, icon_height);
@@ -560,7 +552,21 @@ void Button::_texture_changed() {
 }
 
 Ref<Texture2D> Button::get_icon() const {
-	return icon;
+	if (icon.is_null() && has_theme_icon(SNAME("icon"))) {
+		return theme_cache.icon;
+	} else {
+		return icon;
+	}
+}
+
+int Button::get_icon_width_with_aspect_ratio(const int &height) {
+	Ref<Texture2D> _icon = get_icon();
+	return _icon->get_width() * height / _icon->get_height();
+}
+
+int Button::get_icon_height_with_aspect_ratio(const int &width) {
+	Ref<Texture2D> _icon = get_icon();
+	return _icon->get_height() * width / _icon->get_width();
 }
 
 void Button::set_expand_icon(bool p_enabled) {

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -125,6 +125,9 @@ public:
 	void set_icon(const Ref<Texture2D> &p_icon);
 	Ref<Texture2D> get_icon() const;
 
+	int get_icon_height_with_aspect_ratio(const int &width);
+	int get_icon_width_with_aspect_ratio(const int &height);
+
 	void set_expand_icon(bool p_enabled);
 	bool is_expand_icon() const;
 

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -504,6 +504,13 @@ void OptionButton::show_popup() {
 
 	Rect2 rect = get_screen_rect();
 	rect.position.y += rect.size.height;
+	if (get_icon().is_valid()) {
+		Size2 _size = get_size() - theme_cache.normal->get_offset() * 2;
+		float icon_width = get_icon_width_with_aspect_ratio(_size.height);
+		for (int i = 0; i < popup->get_item_count(); i++) {
+			popup->set_item_icon_max_width(i, icon_width);
+		}
+	}
 	rect.size.height = 0;
 	popup->set_position(rect.position);
 	popup->set_size(rect.size);


### PR DESCRIPTION
~~Added a `max_item_height` property to `PopupMenu`s which limits the height of each item. In practice this is used to shrink icons to an acceptable size. `OptionButton` sets this value automatically to it's current height.~~ (edit: implemented by https://github.com/godotengine/godot/pull/75472)

`OptionButton` nodes now automatically adjust icon sizes from the internal `PopupMenu` to match the existing icon size when overrided.

![Peek 2023-01-21 22-38](https://user-images.githubusercontent.com/6501975/213889828-5af09496-6dfc-4382-88bd-ba43fd31abbd.gif)

Closes #58283 and https://github.com/godotengine/godot-proposals/issues/6139