### PR TITLE
Rename getters and signals on XR nodes to be consistant with input types

### DIFF
--- a/doc/classes/XRController3D.xml
+++ b/doc/classes/XRController3D.xml
@@ -13,11 +13,18 @@
 		<link title="XR documentation index">$DOCS_URL/tutorials/xr/index.html</link>
 	</tutorials>
 	<methods>
-		<method name="get_axis" qualifiers="const">
-			<return type="Vector2" />
+		<method name="get_float" qualifiers="const">
+			<return type="float" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns a [Vector2] for the input with the given [param name]. This is used for thumbsticks and thumbpads found on many controllers.
+				Returns a numeric value for the input with the given [param name]. This is used for triggers and grip sensors.
+			</description>
+		</method>
+		<method name="get_input" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Returns a [Variant] for the input with the given [param name]. This works for any input type, the variant will be typed according to the actions configuration.
 			</description>
 		</method>
 		<method name="get_tracker_hand" qualifiers="const">
@@ -26,11 +33,11 @@
 				Returns the hand holding this controller, if known. See [enum XRPositionalTracker.TrackerHand].
 			</description>
 		</method>
-		<method name="get_value" qualifiers="const">
-			<return type="float" />
+		<method name="get_vector2" qualifiers="const">
+			<return type="Vector2" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns a numeric value for the input with the given [param name]. This is used for triggers and grip sensors.
+				Returns a [Vector2] for the input with the given [param name]. This is used for thumbsticks and thumbpads found on many controllers.
 			</description>
 		</method>
 		<method name="is_button_pressed" qualifiers="const">
@@ -54,18 +61,18 @@
 				Emitted when a button on this controller is released.
 			</description>
 		</signal>
-		<signal name="input_axis_changed">
-			<param index="0" name="name" type="String" />
-			<param index="1" name="value" type="Vector2" />
-			<description>
-				Emitted when a thumbstick or thumbpad on this controller is moved.
-			</description>
-		</signal>
-		<signal name="input_value_changed">
+		<signal name="input_float_changed">
 			<param index="0" name="name" type="String" />
 			<param index="1" name="value" type="float" />
 			<description>
 				Emitted when a trigger or similar input on this controller changes value.
+			</description>
+		</signal>
+		<signal name="input_vector2_changed">
+			<param index="0" name="name" type="String" />
+			<param index="1" name="value" type="Vector2" />
+			<description>
+				Emitted when a thumbstick or thumbpad on this controller is moved.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/XRPositionalTracker.xml
+++ b/doc/classes/XRPositionalTracker.xml
@@ -92,18 +92,18 @@
 				Emitted when a button on this tracker is released.
 			</description>
 		</signal>
-		<signal name="input_axis_changed">
-			<param index="0" name="name" type="String" />
-			<param index="1" name="vector" type="Vector2" />
-			<description>
-				Emitted when a thumbstick or thumbpad on this tracker moves.
-			</description>
-		</signal>
-		<signal name="input_value_changed">
+		<signal name="input_float_changed">
 			<param index="0" name="name" type="String" />
 			<param index="1" name="value" type="float" />
 			<description>
 				Emitted when a trigger or similar input on this tracker changes value.
+			</description>
+		</signal>
+		<signal name="input_vector2_changed">
+			<param index="0" name="name" type="String" />
+			<param index="1" name="vector" type="Vector2" />
+			<description>
+				Emitted when a thumbstick or thumbpad on this tracker moves.
 			</description>
 		</signal>
 		<signal name="pose_changed">

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -432,15 +432,16 @@ PackedStringArray XRNode3D::get_configuration_warnings() const {
 void XRController3D::_bind_methods() {
 	// passthroughs to information about our related joystick
 	ClassDB::bind_method(D_METHOD("is_button_pressed", "name"), &XRController3D::is_button_pressed);
-	ClassDB::bind_method(D_METHOD("get_value", "name"), &XRController3D::get_value);
-	ClassDB::bind_method(D_METHOD("get_axis", "name"), &XRController3D::get_axis);
+	ClassDB::bind_method(D_METHOD("get_input", "name"), &XRController3D::get_input);
+	ClassDB::bind_method(D_METHOD("get_float", "name"), &XRController3D::get_float);
+	ClassDB::bind_method(D_METHOD("get_vector2", "name"), &XRController3D::get_vector2);
 
 	ClassDB::bind_method(D_METHOD("get_tracker_hand"), &XRController3D::get_tracker_hand);
 
 	ADD_SIGNAL(MethodInfo("button_pressed", PropertyInfo(Variant::STRING, "name")));
 	ADD_SIGNAL(MethodInfo("button_released", PropertyInfo(Variant::STRING, "name")));
-	ADD_SIGNAL(MethodInfo("input_value_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::FLOAT, "value")));
-	ADD_SIGNAL(MethodInfo("input_axis_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::VECTOR2, "value")));
+	ADD_SIGNAL(MethodInfo("input_float_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::FLOAT, "value")));
+	ADD_SIGNAL(MethodInfo("input_vector2_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::VECTOR2, "value")));
 };
 
 void XRController3D::_bind_tracker() {
@@ -449,8 +450,8 @@ void XRController3D::_bind_tracker() {
 		// bind to input signals
 		tracker->connect("button_pressed", callable_mp(this, &XRController3D::_button_pressed));
 		tracker->connect("button_released", callable_mp(this, &XRController3D::_button_released));
-		tracker->connect("input_value_changed", callable_mp(this, &XRController3D::_input_value_changed));
-		tracker->connect("input_axis_changed", callable_mp(this, &XRController3D::_input_axis_changed));
+		tracker->connect("input_float_changed", callable_mp(this, &XRController3D::_input_float_changed));
+		tracker->connect("input_vector2_changed", callable_mp(this, &XRController3D::_input_vector2_changed));
 	}
 }
 
@@ -459,8 +460,8 @@ void XRController3D::_unbind_tracker() {
 		// unbind input signals
 		tracker->disconnect("button_pressed", callable_mp(this, &XRController3D::_button_pressed));
 		tracker->disconnect("button_released", callable_mp(this, &XRController3D::_button_released));
-		tracker->disconnect("input_value_changed", callable_mp(this, &XRController3D::_input_value_changed));
-		tracker->disconnect("input_axis_changed", callable_mp(this, &XRController3D::_input_axis_changed));
+		tracker->disconnect("input_float_changed", callable_mp(this, &XRController3D::_input_float_changed));
+		tracker->disconnect("input_vector2_changed", callable_mp(this, &XRController3D::_input_vector2_changed));
 	}
 
 	XRNode3D::_unbind_tracker();
@@ -476,14 +477,14 @@ void XRController3D::_button_released(const String &p_name) {
 	emit_signal(SNAME("button_released"), p_name);
 }
 
-void XRController3D::_input_value_changed(const String &p_name, float p_value) {
+void XRController3D::_input_float_changed(const String &p_name, float p_value) {
 	// just pass it on...
-	emit_signal(SNAME("input_value_changed"), p_name, p_value);
+	emit_signal(SNAME("input_float_changed"), p_name, p_value);
 }
 
-void XRController3D::_input_axis_changed(const String &p_name, Vector2 p_value) {
+void XRController3D::_input_vector2_changed(const String &p_name, Vector2 p_value) {
 	// just pass it on...
-	emit_signal(SNAME("input_axis_changed"), p_name, p_value);
+	emit_signal(SNAME("input_vector2_changed"), p_name, p_value);
 }
 
 bool XRController3D::is_button_pressed(const StringName &p_name) const {
@@ -496,7 +497,15 @@ bool XRController3D::is_button_pressed(const StringName &p_name) const {
 	}
 }
 
-float XRController3D::get_value(const StringName &p_name) const {
+Variant XRController3D::get_input(const StringName &p_name) const {
+	if (tracker.is_valid()) {
+		return tracker->get_input(p_name);
+	} else {
+		return Variant();
+	}
+}
+
+float XRController3D::get_float(const StringName &p_name) const {
 	if (tracker.is_valid()) {
 		// Inputs should already be of the correct type, our XR runtime handles conversions between raw input and the desired type, but just in case we convert
 		Variant input = tracker->get_input(p_name);
@@ -517,7 +526,7 @@ float XRController3D::get_value(const StringName &p_name) const {
 	}
 }
 
-Vector2 XRController3D::get_axis(const StringName &p_name) const {
+Vector2 XRController3D::get_vector2(const StringName &p_name) const {
 	if (tracker.is_valid()) {
 		// Inputs should already be of the correct type, our XR runtime handles conversions between raw input and the desired type, but just in case we convert
 		Variant input = tracker->get_input(p_name);

--- a/scene/3d/xr_nodes.h
+++ b/scene/3d/xr_nodes.h
@@ -131,13 +131,14 @@ protected:
 
 	void _button_pressed(const String &p_name);
 	void _button_released(const String &p_name);
-	void _input_value_changed(const String &p_name, float p_value);
-	void _input_axis_changed(const String &p_name, Vector2 p_value);
+	void _input_float_changed(const String &p_name, float p_value);
+	void _input_vector2_changed(const String &p_name, Vector2 p_value);
 
 public:
 	bool is_button_pressed(const StringName &p_name) const;
-	float get_value(const StringName &p_name) const;
-	Vector2 get_axis(const StringName &p_name) const;
+	Variant get_input(const StringName &p_name) const;
+	float get_float(const StringName &p_name) const;
+	Vector2 get_vector2(const StringName &p_name) const;
 
 	XRPositionalTracker::TrackerHand get_tracker_hand() const;
 

--- a/servers/xr/xr_positional_tracker.cpp
+++ b/servers/xr/xr_positional_tracker.cpp
@@ -67,8 +67,8 @@ void XRPositionalTracker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_input", "name", "value"), &XRPositionalTracker::set_input);
 	ADD_SIGNAL(MethodInfo("button_pressed", PropertyInfo(Variant::STRING, "name")));
 	ADD_SIGNAL(MethodInfo("button_released", PropertyInfo(Variant::STRING, "name")));
-	ADD_SIGNAL(MethodInfo("input_value_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::FLOAT, "value")));
-	ADD_SIGNAL(MethodInfo("input_axis_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::VECTOR2, "vector")));
+	ADD_SIGNAL(MethodInfo("input_float_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::FLOAT, "value")));
+	ADD_SIGNAL(MethodInfo("input_vector2_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::VECTOR2, "vector")));
 	ADD_SIGNAL(MethodInfo("profile_changed", PropertyInfo(Variant::STRING, "role")));
 };
 
@@ -203,12 +203,12 @@ void XRPositionalTracker::set_input(const StringName &p_action_name, const Varia
 				// TODO discuss whether we also want to create and emit an InputEventXRButton event
 			} break;
 			case Variant::FLOAT: {
-				emit_signal(SNAME("input_value_changed"), p_action_name, p_value);
+				emit_signal(SNAME("input_float_changed"), p_action_name, p_value);
 
 				// TODO discuss whether we also want to create and emit an InputEventXRValue event
 			} break;
 			case Variant::VECTOR2: {
-				emit_signal(SNAME("input_axis_changed"), p_action_name, p_value);
+				emit_signal(SNAME("input_vector2_changed"), p_action_name, p_value);
 
 				// TODO discuss whether we also want to create and emit an InputEventXRAxis event
 			} break;


### PR DESCRIPTION
Just a few renames on XRNodes, better do it now before we're stable. This brings the names of signals and getters on these nodes in line with the types that are actually stored and named in the action map. 

Minor breaking change for those already working on VR projects in Godot 4.
