### PR TITLE
Fix some `SpotLight3D` issues (clustering artifacts, leaking light, AABB)

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -690,7 +690,8 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, float atte
 #endif
 
 #if defined(LIGHT_RIM_USED)
-		float rim_light = pow(max(0.0, 1.0 - cNdotV), max(0.0, (1.0 - roughness) * 16.0));
+		// Epsilon min to prevent pow(0, 0) singularity which results in undefined behavior.
+		float rim_light = pow(max(1e-4, 1.0 - cNdotV), max(0.0, (1.0 - roughness) * 16.0));
 		diffuse_light += rim_light * rim * mix(vec3(1.0), albedo, rim_tint) * light_color;
 #endif
 	}

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -157,9 +157,16 @@ AABB Light3D::get_aabb() const {
 		return AABB(Vector3(-1, -1, -1) * param[PARAM_RANGE], Vector3(2, 2, 2) * param[PARAM_RANGE]);
 
 	} else if (type == RenderingServer::LIGHT_SPOT) {
-		real_t len = param[PARAM_RANGE];
-		real_t size = Math::tan(Math::deg_to_rad(param[PARAM_SPOT_ANGLE])) * len;
-		return AABB(Vector3(-size, -size, -len), Vector3(size * 2, size * 2, len));
+		real_t cone_slant_height = param[PARAM_RANGE];
+		real_t cone_angle_rad = Math::deg_to_rad(param[PARAM_SPOT_ANGLE]);
+
+		if (cone_angle_rad > Math_PI / 2.0) {
+			// Just return the AABB of an omni light if the spot angle is above 90 degrees.
+			return AABB(Vector3(-1, -1, -1) * cone_slant_height, Vector3(2, 2, 2) * cone_slant_height);
+		}
+
+		real_t size = Math::sin(cone_angle_rad) * cone_slant_height;
+		return AABB(Vector3(-size, -size, -cone_slant_height), Vector3(2 * size, 2 * size, cone_slant_height));
 	}
 
 	return AABB();

--- a/servers/rendering/renderer_rd/cluster_builder_rd.cpp
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.cpp
@@ -74,7 +74,7 @@ ClusterBuilderSharedDataRD::ClusterBuilderSharedDataRD() {
 		cluster_debug.shader_pipeline = RD::get_singleton()->compute_pipeline_create(cluster_debug.shader);
 	}
 
-	{ // SPHERE
+	{ // Sphere mesh data.
 		static const uint32_t icosphere_vertex_count = 42;
 		static const float icosphere_vertices[icosphere_vertex_count * 3] = {
 			0, 0, -1, 0.7236073, -0.5257253, -0.4472195, -0.276388, -0.8506492, -0.4472199, -0.8944262, 0, -0.4472156, -0.276388, 0.8506492, -0.4472199, 0.7236073, 0.5257253, -0.4472195, 0.276388, -0.8506492, 0.4472199, -0.7236073, -0.5257253, 0.4472195, -0.7236073, 0.5257253, 0.4472195, 0.276388, 0.8506492, 0.4472199, 0.8944262, 0, 0.4472156, 0, 0, 1, -0.1624555, -0.4999952, -0.8506544, 0.4253227, -0.3090114, -0.8506542, 0.2628688, -0.8090116, -0.5257377, 0.8506479, 0, -0.5257359, 0.4253227, 0.3090114, -0.8506542, -0.5257298, 0, -0.8506517, -0.6881894, -0.4999969, -0.5257362, -0.1624555, 0.4999952, -0.8506544, -0.6881894, 0.4999969, -0.5257362, 0.2628688, 0.8090116, -0.5257377, 0.9510579, -0.3090126, 0, 0.9510579, 0.3090126, 0, 0, -1, 0, 0.5877856, -0.8090167, 0, -0.9510579, -0.3090126, 0, -0.5877856, -0.8090167, 0, -0.5877856, 0.8090167, 0, -0.9510579, 0.3090126, 0, 0.5877856, 0.8090167, 0, 0, 1, 0, 0.6881894, -0.4999969, 0.5257362, -0.2628688, -0.8090116, 0.5257377, -0.8506479, 0, 0.5257359, -0.2628688, 0.8090116, 0.5257377, 0.6881894, 0.4999969, 0.5257362, 0.1624555, -0.4999952, 0.8506544, 0.5257298, 0, 0.8506517, -0.4253227, -0.3090114, 0.8506542, -0.4253227, 0.3090114, 0.8506542, 0.1624555, 0.4999952, 0.8506544
@@ -118,7 +118,7 @@ ClusterBuilderSharedDataRD::ClusterBuilderSharedDataRD() {
 		sphere_overfit = 1.0 / min_d;
 	}
 
-	{ // CONE
+	{ // Cone mesh data.
 		static const uint32_t cone_vertex_count = 99;
 		static const float cone_vertices[cone_vertex_count * 3] = {
 			0, 1, -1, 0.1950903, 0.9807853, -1, 0.3826835, 0.9238795, -1, 0.5555703, 0.8314696, -1, 0.7071068, 0.7071068, -1, 0.8314697, 0.5555702, -1, 0.9238795, 0.3826834, -1, 0.9807853, 0.1950903, -1, 1, 0, -1, 0.9807853, -0.1950902, -1, 0.9238796, -0.3826833, -1, 0.8314697, -0.5555702, -1, 0.7071068, -0.7071068, -1, 0.5555702, -0.8314697, -1, 0.3826833, -0.9238796, -1, 0.1950901, -0.9807853, -1, -3.25841e-7, -1, -1, -0.1950907, -0.9807852, -1, -0.3826839, -0.9238793, -1, -0.5555707, -0.8314693, -1, -0.7071073, -0.7071063, -1, -0.83147, -0.5555697, -1, -0.9238799, -0.3826827, -1, 0, 0, 0, -0.9807854, -0.1950894, -1, -1, 9.65599e-7, -1, -0.9807851, 0.1950913, -1, -0.9238791, 0.3826845, -1, -0.8314689, 0.5555713, -1, -0.7071059, 0.7071077, -1, -0.5555691, 0.8314704, -1, -0.3826821, 0.9238801, -1, -0.1950888, 0.9807856, -1
@@ -172,7 +172,7 @@ ClusterBuilderSharedDataRD::ClusterBuilderSharedDataRD() {
 		cone_overfit = 1.0 / min_d;
 	}
 
-	{ // BOX
+	{ // Box mesh data.
 		static const uint32_t box_vertex_count = 8;
 		static const float box_vertices[box_vertex_count * 3] = {
 			-1, -1, -1, -1, -1, 1, -1, 1, -1, -1, 1, 1, 1, -1, -1, 1, -1, 1, 1, 1, -1, 1, 1, 1
@@ -219,8 +219,9 @@ ClusterBuilderSharedDataRD::~ClusterBuilderSharedDataRD() {
 
 void ClusterBuilderRD::_clear() {
 	if (cluster_buffer.is_null()) {
-		return; //nothing to clear
+		return;
 	}
+
 	RD::get_singleton()->free(cluster_buffer);
 	RD::get_singleton()->free(cluster_render_buffer);
 	RD::get_singleton()->free(element_buffer);
@@ -254,7 +255,7 @@ void ClusterBuilderRD::setup(Size2i p_screen_size, uint32_t p_max_elements, RID 
 	cluster_screen_size.height = (p_screen_size.height - 1) / cluster_size + 1;
 
 	max_elements_by_type = p_max_elements;
-	if (max_elements_by_type % 32) { //need to be 32 aligned
+	if (max_elements_by_type % 32) { // Needs to be aligned to 32.
 		max_elements_by_type += 32 - (max_elements_by_type % 32);
 	}
 
@@ -264,7 +265,8 @@ void ClusterBuilderRD::setup(Size2i p_screen_size, uint32_t p_max_elements, RID 
 
 	uint32_t element_tag_bits_size = render_element_max / 32;
 	uint32_t element_tag_depth_bits_size = render_element_max;
-	cluster_render_buffer_size = cluster_screen_size.x * cluster_screen_size.y * (element_tag_bits_size + element_tag_depth_bits_size) * 4; // tag bits (element was used) and tag depth (depth range in which it was used)
+
+	cluster_render_buffer_size = cluster_screen_size.x * cluster_screen_size.y * (element_tag_bits_size + element_tag_depth_bits_size) * 4; // Tag bits (element was used) and tag depth (depth range in which it was used).
 
 	cluster_render_buffer = RD::get_singleton()->storage_buffer_create(cluster_render_buffer_size);
 	cluster_buffer = RD::get_singleton()->storage_buffer_create(cluster_buffer_size);
@@ -379,9 +381,9 @@ void ClusterBuilderRD::begin(const Transform3D &p_view_transform, const Projecti
 	projection = p_cam_projection;
 	z_near = projection.get_z_near();
 	z_far = projection.get_z_far();
-	orthogonal = p_cam_projection.is_orthogonal();
+	camera_orthogonal = p_cam_projection.is_orthogonal();
 	adjusted_projection = projection;
-	if (!orthogonal) {
+	if (!camera_orthogonal) {
 		adjusted_projection.adjust_perspective_znear(0.0001);
 	}
 
@@ -390,7 +392,7 @@ void ClusterBuilderRD::begin(const Transform3D &p_view_transform, const Projecti
 	projection = correction * projection;
 	adjusted_projection = correction * adjusted_projection;
 
-	//reset counts
+	// Reset counts.
 	render_element_count = 0;
 	for (uint32_t i = 0; i < ELEMENT_TYPE_MAX; i++) {
 		cluster_count_by_type[i] = 0;
@@ -402,14 +404,14 @@ void ClusterBuilderRD::bake_cluster() {
 
 	RD::get_singleton()->draw_command_begin_label("Bake Light Cluster");
 
-	//clear cluster buffer
+	// Clear cluster buffer.
 	RD::get_singleton()->buffer_clear(cluster_buffer, 0, cluster_buffer_size, RD::BARRIER_MASK_RASTER | RD::BARRIER_MASK_COMPUTE);
 
 	if (render_element_count > 0) {
-		//clear render buffer
+		// Clear render buffer.
 		RD::get_singleton()->buffer_clear(cluster_render_buffer, 0, cluster_render_buffer_size, RD::BARRIER_MASK_RASTER);
 
-		{ //fill state uniform
+		{ // Fill state uniform.
 
 			StateUniform state;
 
@@ -425,13 +427,13 @@ void ClusterBuilderRD::bake_cluster() {
 			RD::get_singleton()->buffer_update(state_uniform, 0, sizeof(StateUniform), &state, RD::BARRIER_MASK_RASTER | RD::BARRIER_MASK_COMPUTE);
 		}
 
-		//update instances
+		// Update instances.
 
 		RD::get_singleton()->buffer_update(element_buffer, 0, sizeof(RenderElementData) * render_element_count, render_elements, RD::BARRIER_MASK_RASTER | RD::BARRIER_MASK_COMPUTE);
 
 		RENDER_TIMESTAMP("Render 3D Cluster Elements");
 
-		//render elements
+		// Render elements.
 		{
 			RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin(framebuffer, RD::INITIAL_ACTION_DROP, RD::FINAL_ACTION_DISCARD, RD::INITIAL_ACTION_DROP, RD::FINAL_ACTION_DISCARD);
 			ClusterBuilderSharedDataRD::ClusterRender::PushConstant push_constant = {};
@@ -447,8 +449,16 @@ void ClusterBuilderRD::bake_cluster() {
 						RD::get_singleton()->draw_list_bind_index_array(draw_list, shared->sphere_index_array);
 					} break;
 					case ELEMENT_TYPE_SPOT_LIGHT: {
-						RD::get_singleton()->draw_list_bind_vertex_array(draw_list, shared->cone_vertex_array);
-						RD::get_singleton()->draw_list_bind_index_array(draw_list, shared->cone_index_array);
+						// If the spot angle is above a certain threshold, use a sphere instead of a cone for building the clusters
+						// since the cone gets too flat/large (spot angle close to 90 degrees) or
+						// can't even cover the affected area of the light (spot angle above 90 degrees).
+						if (render_elements[i].has_wide_spot_angle) {
+							RD::get_singleton()->draw_list_bind_vertex_array(draw_list, shared->sphere_vertex_array);
+							RD::get_singleton()->draw_list_bind_index_array(draw_list, shared->sphere_index_array);
+						} else {
+							RD::get_singleton()->draw_list_bind_vertex_array(draw_list, shared->cone_vertex_array);
+							RD::get_singleton()->draw_list_bind_index_array(draw_list, shared->cone_index_array);
+						}
 					} break;
 					case ELEMENT_TYPE_DECAL:
 					case ELEMENT_TYPE_REFLECTION_PROBE: {
@@ -465,7 +475,7 @@ void ClusterBuilderRD::bake_cluster() {
 			}
 			RD::get_singleton()->draw_list_end(RD::BARRIER_MASK_COMPUTE);
 		}
-		//store elements
+		// Store elements.
 		RENDER_TIMESTAMP("Pack 3D Cluster Elements");
 
 		{
@@ -509,7 +519,7 @@ void ClusterBuilderRD::debug(ElementType p_element) {
 	push_constant.cluster_screen_size[1] = cluster_screen_size.y;
 	push_constant.cluster_shift = get_shift_from_power_of_2(cluster_size);
 	push_constant.cluster_type = p_element;
-	push_constant.orthogonal = orthogonal;
+	push_constant.orthogonal = camera_orthogonal;
 	push_constant.z_far = z_far;
 	push_constant.z_near = z_near;
 	push_constant.max_cluster_element_count_div_32 = max_elements_by_type / 32;

--- a/servers/rendering/renderer_rd/cluster_builder_rd.h
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.h
@@ -43,13 +43,13 @@ class ClusterBuilderSharedDataRD {
 	RID sphere_vertex_array;
 	RID sphere_index_buffer;
 	RID sphere_index_array;
-	float sphere_overfit = 0.0; //because an icosphere is not a perfect sphere, we need to enlarge it to cover the sphere area
+	float sphere_overfit = 0.0; // Because an icosphere is not a perfect sphere, we need to enlarge it to cover the sphere area.
 
 	RID cone_vertex_buffer;
 	RID cone_vertex_array;
 	RID cone_index_buffer;
 	RID cone_index_array;
-	float cone_overfit = 0.0; //because an cone mesh is not a perfect sphere, we need to enlarge it to cover the actual cone area
+	float cone_overfit = 0.0; // Because an cone mesh is not a perfect cone, we need to enlarge it to cover the actual cone area.
 
 	RID box_vertex_buffer;
 	RID box_vertex_array;
@@ -73,6 +73,7 @@ class ClusterBuilderSharedDataRD {
 		ClusterRenderShaderRD cluster_render_shader;
 		RID shader_version;
 		RID shader;
+
 		enum PipelineVersion {
 			PIPELINE_NORMAL,
 			PIPELINE_MSAA,
@@ -85,10 +86,11 @@ class ClusterBuilderSharedDataRD {
 	struct ClusterStore {
 		struct PushConstant {
 			uint32_t cluster_render_data_size; // how much data for a single cluster takes
-			uint32_t max_render_element_count_div_32; //divided by 32
+			uint32_t max_render_element_count_div_32; // divided by 32
 			uint32_t cluster_screen_size[2];
-			uint32_t render_element_count_div_32; //divided by 32
-			uint32_t max_cluster_element_count_div_32; //divided by 32
+			uint32_t render_element_count_div_32; // divided by 32
+			uint32_t max_cluster_element_count_div_32; // divided by 32
+
 			uint32_t pad1;
 			uint32_t pad2;
 		};
@@ -111,6 +113,7 @@ class ClusterBuilderSharedDataRD {
 
 			uint32_t orthogonal;
 			uint32_t max_cluster_element_count_div_32;
+
 			uint32_t pad1;
 			uint32_t pad2;
 		};
@@ -128,6 +131,8 @@ public:
 
 class ClusterBuilderRD {
 public:
+	static constexpr float WIDE_SPOT_ANGLE_THRESHOLD_DEG = 60.0f;
+
 	enum LightType {
 		LIGHT_TYPE_OMNI,
 		LIGHT_TYPE_SPOT
@@ -144,21 +149,20 @@ public:
 		ELEMENT_TYPE_DECAL,
 		ELEMENT_TYPE_REFLECTION_PROBE,
 		ELEMENT_TYPE_MAX,
-
 	};
 
 private:
 	ClusterBuilderSharedDataRD *shared = nullptr;
 
 	struct RenderElementData {
-		uint32_t type; //0-4
+		uint32_t type; // 0-4
 		uint32_t touches_near;
 		uint32_t touches_far;
 		uint32_t original_index;
-		float transform_inv[12]; //transposed transform for less space
+		float transform_inv[12]; // Transposed transform for less space.
 		float scale[3];
-		uint32_t pad;
-	};
+		uint32_t has_wide_spot_angle;
+	}; // Keep aligned to 32 bytes.
 
 	uint32_t cluster_count_by_type[ELEMENT_TYPE_MAX] = {};
 	uint32_t max_elements_by_type = 0;
@@ -172,7 +176,7 @@ private:
 	Projection projection;
 	float z_far = 0;
 	float z_near = 0;
-	bool orthogonal = false;
+	bool camera_orthogonal = false;
 
 	enum Divisor {
 		DIVISOR_1,
@@ -188,26 +192,27 @@ private:
 	Size2i cluster_screen_size;
 
 	RID framebuffer;
-	RID cluster_render_buffer; //used for creating
-	RID cluster_buffer; //used for rendering
-	RID element_buffer; //used for storing, to hint element touches far plane or near plane
+	RID cluster_render_buffer; // Used for creating.
+	RID cluster_buffer; // Used for rendering.
+	RID element_buffer; // Used for storing, to hint element touches far plane or near plane.
 	uint32_t cluster_render_buffer_size = 0;
 	uint32_t cluster_buffer_size = 0;
 
 	RID cluster_render_uniform_set;
 	RID cluster_store_uniform_set;
 
-	//persistent data
+	// Persistent data.
 
 	void _clear();
 
 	struct StateUniform {
 		float projection[16];
 		float inv_z_far;
-		uint32_t screen_to_clusters_shift; // shift to obtain coordinates in block indices
-		uint32_t cluster_screen_width; //
-		uint32_t cluster_data_size; // how much data for a single cluster takes
+		uint32_t screen_to_clusters_shift; // Shift to obtain coordinates in block indices.
+		uint32_t cluster_screen_width;
+		uint32_t cluster_data_size; // How much data is needed for a single cluster.
 		uint32_t cluster_depth_offset;
+
 		uint32_t pad0;
 		uint32_t pad1;
 		uint32_t pad2;
@@ -224,10 +229,10 @@ public:
 
 	_FORCE_INLINE_ void add_light(LightType p_type, const Transform3D &p_transform, float p_radius, float p_spot_aperture) {
 		if (p_type == LIGHT_TYPE_OMNI && cluster_count_by_type[ELEMENT_TYPE_OMNI_LIGHT] == max_elements_by_type) {
-			return; //max number elements reached
+			return; // Max number elements reached.
 		}
 		if (p_type == LIGHT_TYPE_SPOT && cluster_count_by_type[ELEMENT_TYPE_SPOT_LIGHT] == max_elements_by_type) {
-			return; //max number elements reached
+			return; // Max number elements reached.
 		}
 
 		RenderElementData &e = render_elements[render_element_count];
@@ -242,15 +247,14 @@ public:
 		radius *= p_radius;
 
 		if (p_type == LIGHT_TYPE_OMNI) {
-			radius *= shared->sphere_overfit; // overfit icosphere
+			radius *= shared->sphere_overfit; // Overfit icosphere.
 
-			//omni
 			float depth = -xform.origin.z;
-			if (orthogonal) {
+			if (camera_orthogonal) {
 				e.touches_near = (depth - radius) < z_near;
 			} else {
-				//contains camera inside light
-				float radius2 = radius * shared->sphere_overfit; // overfit again for outer size (camera may be outside actual sphere but behind an icosphere vertex)
+				// Contains camera inside light.
+				float radius2 = radius * shared->sphere_overfit; // Overfit again for outer size (camera may be outside actual sphere but behind an icosphere vertex)
 				e.touches_near = xform.origin.length_squared() < radius2 * radius2;
 			}
 
@@ -265,12 +269,11 @@ public:
 
 			cluster_count_by_type[ELEMENT_TYPE_OMNI_LIGHT]++;
 
-		} else {
-			//spot
-			radius *= shared->cone_overfit; // overfit icosphere
+		} else /*LIGHT_TYPE_SPOT */ {
+			radius *= shared->cone_overfit; // Overfit icosphere
 
 			real_t len = Math::tan(Math::deg_to_rad(p_spot_aperture)) * radius;
-			//approximate, probably better to use a cone support function
+			// Approximate, probably better to use a cone support function.
 			float max_d = -1e20;
 			float min_d = 1e20;
 #define CONE_MINMAX(m_x, m_y)                                             \
@@ -285,14 +288,13 @@ public:
 			CONE_MINMAX(-1, -1);
 			CONE_MINMAX(1, -1);
 
-			if (orthogonal) {
+			if (camera_orthogonal) {
 				e.touches_near = min_d < z_near;
 			} else {
-				//contains camera inside light
 				Plane base_plane(-xform.basis.get_column(Vector3::AXIS_Z), xform.origin);
 				float dist = base_plane.distance_to(Vector3());
 				if (dist >= 0 && dist < radius) {
-					//inside, check angle
+					// Contains camera inside light, check angle.
 					float angle = Math::rad_to_deg(Math::acos((-xform.origin.normalized()).dot(-xform.basis.get_column(Vector3::AXIS_Z))));
 					e.touches_near = angle < p_spot_aperture * 1.05; //overfit aperture a little due to cone overfit
 				} else {
@@ -302,12 +304,23 @@ public:
 
 			e.touches_far = max_d > z_far;
 
-			e.scale[0] = len * shared->cone_overfit;
-			e.scale[1] = len * shared->cone_overfit;
-			e.scale[2] = radius;
+			// If the spot angle is above the threshold, use a sphere instead of a cone for building the clusters
+			// since the cone gets too flat/large (spot angle close to 90 degrees) or
+			// can't even cover the affected area of the light (spot angle above 90 degrees).
+			if (p_spot_aperture > WIDE_SPOT_ANGLE_THRESHOLD_DEG) {
+				e.scale[0] = radius;
+				e.scale[1] = radius;
+				e.scale[2] = radius;
+				e.has_wide_spot_angle = true;
+			} else {
+				e.scale[0] = len * shared->cone_overfit;
+				e.scale[1] = len * shared->cone_overfit;
+				e.scale[2] = radius;
+				e.has_wide_spot_angle = false;
+			}
 
 			e.type = ELEMENT_TYPE_SPOT_LIGHT;
-			e.original_index = cluster_count_by_type[ELEMENT_TYPE_SPOT_LIGHT]; //use omni since they share index
+			e.original_index = cluster_count_by_type[ELEMENT_TYPE_SPOT_LIGHT]; // Use omni light since they share index.
 
 			RendererRD::MaterialStorage::store_transform_transposed_3x4(xform, e.transform_inv);
 
@@ -319,16 +332,16 @@ public:
 
 	_FORCE_INLINE_ void add_box(BoxType p_box_type, const Transform3D &p_transform, const Vector3 &p_half_extents) {
 		if (p_box_type == BOX_TYPE_DECAL && cluster_count_by_type[ELEMENT_TYPE_DECAL] == max_elements_by_type) {
-			return; //max number elements reached
+			return; // Max number elements reached.
 		}
 		if (p_box_type == BOX_TYPE_REFLECTION_PROBE && cluster_count_by_type[ELEMENT_TYPE_REFLECTION_PROBE] == max_elements_by_type) {
-			return; //max number elements reached
+			return; // Max number elements reached.
 		}
 
 		RenderElementData &e = render_elements[render_element_count];
 		Transform3D xform = view_xform * p_transform;
 
-		//extract scale and scale the matrix by it, makes things simpler
+		// Extract scale and scale the matrix by it, makes things simpler.
 		Vector3 scale = p_half_extents;
 		for (uint32_t i = 0; i < 3; i++) {
 			float s = xform.basis.rows[i].length();
@@ -339,10 +352,10 @@ public:
 		float box_depth = Math::abs(xform.basis.xform_inv(Vector3(0, 0, -1)).dot(scale));
 		float depth = -xform.origin.z;
 
-		if (orthogonal) {
+		if (camera_orthogonal) {
 			e.touches_near = depth - box_depth < z_near;
 		} else {
-			//contains camera inside box
+			// Contains camera inside box.
 			Vector3 inside = xform.xform_inv(Vector3(0, 0, 0)).abs();
 			e.touches_near = inside.x < scale.x && inside.y < scale.y && inside.z < scale.z;
 		}

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -794,8 +794,13 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 	float light_length = length(light_rel_vec);
 	float spot_attenuation = get_omni_attenuation(light_length, spot_lights.data[idx].inv_radius, spot_lights.data[idx].attenuation);
 	vec3 spot_dir = spot_lights.data[idx].direction;
-	float scos = max(dot(-normalize(light_rel_vec), spot_dir), spot_lights.data[idx].cone_angle);
-	float spot_rim = max(0.0001, (1.0 - scos) / (1.0 - spot_lights.data[idx].cone_angle));
+
+	// This conversion to a highp float is crucial to prevent light leaking
+	// due to precision errors in the following calculations (cone angle is mediump).
+	highp float cone_angle = spot_lights.data[idx].cone_angle;
+	float scos = max(dot(-normalize(light_rel_vec), spot_dir), cone_angle);
+	float spot_rim = max(0.0001, (1.0 - scos) / (1.0 - cone_angle));
+
 	spot_attenuation *= 1.0 - pow(spot_rim, spot_lights.data[idx].cone_attenuation);
 	float light_attenuation = spot_attenuation;
 	vec3 color = spot_lights.data[idx].color;


### PR DESCRIPTION
- Fixes light leak to the outside of the cone, visible at certain cone angles (the leaked light changed periodically from being negative to positive, see green spot lights with slightly different spot angle in picture below)
	Fixes #70698
	Fixes #69936
	Fixes #68969
	Fixes #59262 (likely, could not test since no MRP was provided)
	(These basically boil down to the same bug: no clustering issue, but since the light leaks in directions where the cluster builder doesn't expect it to be it looks blocky; its also visible in the mobile renderer)
	Cause: Bisected to #51843. Seems to be a precision issue, changing the precision of `cone_angle` from `mediump` to `highp` in the `LightData` struct (`light_data_inc.glsl`) also fixes the issue, but I went with converting `cone_angle` to a `highp float` inside the shader so the struct size doesn't have to be increased.

- Fixes AABB generation
	The wrong trigonometric function was used, so the AABB would grow towards infinity for angles close to 90 degrees. For angles above 90 degrees a box enclosing the whole sphere (radius = range) is generated.

- Fixes clustering for angles close to and above 90 degrees
	Fixes #48054
	Introduces a threshold constant: the angle above which the cluster builder uses a sphere instead of a cone (see comment in code).

**Before**
![Godot_v4 0-beta14_win64_nSIGPu2u3W](https://user-images.githubusercontent.com/50084500/213898855-35e32f4b-dc91-4907-bdee-2a554feeb06d.png)

**With this PR**
![0nhWuPqzLZ](https://user-images.githubusercontent.com/50084500/213898853-edc61a0c-63b9-432e-8fab-6cf93a50ef1e.png)

