### PR TITLE
Update the logic to calculate the screen scale on Android

### DIFF
--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -212,7 +212,18 @@ float DisplayServerAndroid::screen_get_scale(int p_screen) const {
 	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
 	ERR_FAIL_NULL_V(godot_io_java, 1.0f);
 
-	return godot_io_java->get_scaled_density();
+	float screen_scale = godot_io_java->get_scaled_density();
+
+	// Update the scale to avoid cropping.
+	Size2i screen_size = screen_get_size(p_screen);
+	if (screen_size != Size2i()) {
+		float width_scale = screen_size.width / (float)OS_Android::DEFAULT_WINDOW_WIDTH;
+		float height_scale = screen_size.height / (float)OS_Android::DEFAULT_WINDOW_HEIGHT;
+		screen_scale = MIN(screen_scale, MIN(width_scale, height_scale));
+	}
+
+	print_line("Selected screen scale: ", screen_scale);
+	return screen_scale;
 }
 
 float DisplayServerAndroid::screen_get_refresh_rate(int p_screen) const {

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -150,7 +150,6 @@ public class GodotIO {
 		} else {
 			selectedScaledDensity = 0.75f;
 		}
-		Log.d(TAG, "Selected scaled density: " + selectedScaledDensity);
 		return selectedScaledDensity;
 	}
 

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -695,8 +695,8 @@ bool OS_Android::_check_internal_feature_support(const String &p_feature) {
 }
 
 OS_Android::OS_Android(GodotJavaWrapper *p_godot_java, GodotIOJavaWrapper *p_godot_io_java, bool p_use_apk_expansion) {
-	display_size.width = 800;
-	display_size.height = 600;
+	display_size.width = DEFAULT_WINDOW_WIDTH;
+	display_size.height = DEFAULT_WINDOW_HEIGHT;
 
 	use_apk_expansion = p_use_apk_expansion;
 

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -86,6 +86,8 @@ private:
 
 public:
 	static const char *ANDROID_EXEC_PATH;
+	static const int DEFAULT_WINDOW_WIDTH = 800;
+	static const int DEFAULT_WINDOW_HEIGHT = 600;
 
 	virtual void initialize_core() override;
 	virtual void initialize() override;


### PR DESCRIPTION
Takes into account the ratio between the screen size and the default window dimensions, which allows to get rid of cropping issues.

Address cropping issue for the Godot Android Editor following https://github.com/godotengine/godot/pull/70863

Fixes https://github.com/godotengine/godot/issues/71198
Fixes https://github.com/godotengine/godot/issues/65889
Fixes https://github.com/godotengine/godot/issues/71246

[3.x version](https://github.com/godotengine/godot/pull/71838)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
