### PR TITLE
[3.x] Update the logic to calculate the screen scale on Android

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -150,7 +150,6 @@ public class GodotIO {
 		} else {
 			selectedScaledDensity = 0.75f;
 		}
-		Log.d(TAG, "Selected scaled density: " + selectedScaledDensity);
 		return selectedScaledDensity;
 	}
 

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -55,6 +55,8 @@
 #include "tts_android.h"
 
 const char *OS_Android::ANDROID_EXEC_PATH = "apk";
+static const int DEFAULT_WINDOW_WIDTH = 800;
+static const int DEFAULT_WINDOW_HEIGHT = 600;
 
 String _remove_symlink(const String &dir) {
 	// Workaround for Android 6.0+ using a symlink.
@@ -530,7 +532,18 @@ int OS_Android::get_screen_dpi(int p_screen) const {
 }
 
 float OS_Android::get_screen_scale(int p_screen) const {
-	return godot_io_java->get_scaled_density();
+	float screen_scale = godot_io_java->get_scaled_density();
+
+	// Update the scale to avoid cropping.
+	Vector2 screen_size = get_window_size();
+	if (screen_size != Vector2()) {
+		float width_scale = screen_size.width / (float)DEFAULT_WINDOW_WIDTH;
+		float height_scale = screen_size.height / (float)DEFAULT_WINDOW_HEIGHT;
+		screen_scale = MIN(screen_scale, MIN(width_scale, height_scale));
+	}
+
+	print_line("Selected screen scale: " + rtos(screen_scale));
+	return screen_scale;
 }
 
 float OS_Android::get_screen_max_scale() const {
@@ -679,8 +692,8 @@ bool OS_Android::_check_internal_feature_support(const String &p_feature) {
 
 OS_Android::OS_Android(GodotJavaWrapper *p_godot_java, GodotIOJavaWrapper *p_godot_io_java, bool p_use_apk_expansion) {
 	use_apk_expansion = p_use_apk_expansion;
-	default_videomode.width = 800;
-	default_videomode.height = 600;
+	default_videomode.width = DEFAULT_WINDOW_WIDTH;
+	default_videomode.height = DEFAULT_WINDOW_HEIGHT;
 	default_videomode.fullscreen = true;
 	default_videomode.resizable = false;
 


### PR DESCRIPTION
Takes into account the ratio between the screen size and the default window dimensions, which allows to get rid of cropping issues.

Address cropping issue for the Godot Android Editor following https://github.com/godotengine/godot/pull/70863

Fixes https://github.com/godotengine/godot/issues/71198
Fixes https://github.com/godotengine/godot/issues/65889
Fixes https://github.com/godotengine/godot/issues/71246

[main version](https://github.com/godotengine/godot/pull/71836)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
