### PR TITLE
Expose `fading_from` from StateMachine

### DIFF
--- a/doc/classes/AnimationNodeStateMachinePlayback.xml
+++ b/doc/classes/AnimationNodeStateMachinePlayback.xml
@@ -38,6 +38,12 @@
 				Returns the playback position within the current animation state.
 			</description>
 		</method>
+		<method name="get_fading_from_node" qualifiers="const">
+			<return type="StringName" />
+			<description>
+				Returns the starting state of currently fading animation.
+			</description>
+		</method>
 		<method name="get_travel_path" qualifiers="const">
 			<return type="PackedStringArray" />
 			<description>

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1237,7 +1237,7 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 	if (playback.is_valid()) {
 		playing = playback->is_playing();
 		current = playback->get_current_node();
-		blend_from = playback->get_blend_from_node();
+		blend_from = playback->get_fading_from_node();
 		travel_path = playback->get_travel_path();
 	}
 
@@ -1695,7 +1695,7 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 				tp = playback->get_travel_path();
 				is_playing = playback->is_playing();
 				current_node = playback->get_current_node();
-				blend_from_node = playback->get_blend_from_node();
+				blend_from_node = playback->get_fading_from_node();
 				play_pos = playback->get_current_play_pos();
 				current_length = playback->get_current_length();
 			}

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -212,7 +212,7 @@ StringName AnimationNodeStateMachinePlayback::get_current_node() const {
 	return current;
 }
 
-StringName AnimationNodeStateMachinePlayback::get_blend_from_node() const {
+StringName AnimationNodeStateMachinePlayback::get_fading_from_node() const {
 	return fading_from;
 }
 
@@ -703,6 +703,7 @@ void AnimationNodeStateMachinePlayback::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_current_node"), &AnimationNodeStateMachinePlayback::get_current_node);
 	ClassDB::bind_method(D_METHOD("get_current_play_position"), &AnimationNodeStateMachinePlayback::get_current_play_pos);
 	ClassDB::bind_method(D_METHOD("get_current_length"), &AnimationNodeStateMachinePlayback::get_current_length);
+	ClassDB::bind_method(D_METHOD("get_fading_from_node"), &AnimationNodeStateMachinePlayback::get_fading_from_node);
 	ClassDB::bind_method(D_METHOD("get_travel_path"), &AnimationNodeStateMachinePlayback::get_travel_path);
 }
 

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -159,7 +159,7 @@ public:
 	void stop();
 	bool is_playing() const;
 	StringName get_current_node() const;
-	StringName get_blend_from_node() const;
+	StringName get_fading_from_node() const;
 	Vector<StringName> get_travel_path() const;
 	float get_current_play_pos() const;
 	float get_current_length() const;


### PR DESCRIPTION
It existed on CPP as `get_blend_from_node()`, but now it is exposed. And the word `blend` is ambiguous in StateMachine, so it has been renamed to `get_fading_from_node()`.