### PR TITLE
Fix weird behavior of teleporting to self-state when `reset_on_teleport` is `false` in StateMachine

### DIFF
--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -411,9 +411,11 @@ double AnimationNodeStateMachinePlayback::_process(AnimationNodeStateMachine *p_
 				// can't travel, then teleport
 				if (p_state_machine->states.has(travel_request)) {
 					path.clear();
-					current = travel_request;
-					play_start = true;
-					reset_request = reset_request_on_teleport;
+					if (current != travel_request || reset_request_on_teleport) {
+						current = travel_request;
+						play_start = true;
+						reset_request = reset_request_on_teleport;
+					}
 				} else {
 					StringName node = travel_request;
 					travel_request = StringName();


### PR DESCRIPTION
Follow up #71418.

A restart by `travel()` can be thought of as a teleport to itself, so if `reset_on_teleport` is `false`, it is correct to delete path and do nothing.