### PR TITLE
Fix missing/incorrect autocomplete on nested types

### DIFF
--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1233,7 +1233,7 @@ public:
 		FunctionNode *current_function = nullptr;
 		SuiteNode *current_suite = nullptr;
 		int current_line = -1;
-		int current_argument = -1;
+		int current_argument = -1; // Also used for type-chain index
 		Variant::Type builtin_type = Variant::VARIANT_MAX;
 		Node *node = nullptr;
 		Object *base = nullptr;


### PR DESCRIPTION
Fix #71734

1. Fix nested classes not being suggested for global classes
![image](https://user-images.githubusercontent.com/74857873/213905707-c77e6fb2-df5e-41c3-9566-0240ca192723.png)

2. Remove various invalid suggestions (functions, constants, parent classes/enums) for when suggesting types from nested classes.
![image](https://user-images.githubusercontent.com/74857873/213905751-d5f8f4fc-5095-4e11-a673-215a526d7f15.png)

*User signals are still being suggested, but this should be fixed by #70002

## Technical Details
Changes:
- When auto-completing `COMPLETION_TYPE_ATTRIBUTE`, use `_guess_identifier_type` for the first type in the type chain to account for global classes.
- Added `p_only_types` parameter in `_find_identifiers_in_base` and `_find_identifiers_in_class` to filter for only type identifiers.
- Added `is_meta_type` for found classes in `_guess_identifier_type` and `_guess_identifier_type_from_base`. Correct me if I'm wrong, but `is_meta_type` should be for identifiers that represents it's own type (like a class identifier) rather than being an instance of said type. If that's true, then all found class identifiers should be a meta type. 