### PR TITLE
[iOS] Restore OpenGLES3 renderer support.

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1596,9 +1596,13 @@ void TextureStorage::_update_render_target(RenderTarget *rt) {
 			glTexParameteri(texture_target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 			glTexParameteri(texture_target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 		}
+#ifndef IOS_ENABLED
 		if (use_multiview) {
 			glFramebufferTextureMultiviewOVR(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, rt->color, 0, 0, rt->view_count);
 		} else {
+#else
+		{
+#endif
 			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->color, 0);
 		}
 
@@ -1623,9 +1627,13 @@ void TextureStorage::_update_render_target(RenderTarget *rt) {
 			glTexParameteri(texture_target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 			glTexParameteri(texture_target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 		}
+#ifndef IOS_ENABLED
 		if (use_multiview) {
 			glFramebufferTextureMultiviewOVR(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, rt->depth, 0, 0, rt->view_count);
 		} else {
+#else
+		{
+#endif
 			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, rt->depth, 0);
 		}
 

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -99,8 +99,8 @@ def configure(env: "Environment"):
 
     if env["ios_simulator"]:
         detect_darwin_sdk_path("iossimulator", env)
-        env.Append(ASFLAGS=["-mios-simulator-version-min=13.0"])
-        env.Append(CCFLAGS=["-mios-simulator-version-min=13.0"])
+        env.Append(ASFLAGS=["-mios-simulator-version-min=11.0"])
+        env.Append(CCFLAGS=["-mios-simulator-version-min=11.0"])
         env.extra_suffix = ".simulator" + env.extra_suffix
     else:
         detect_darwin_sdk_path("ios", env)
@@ -153,3 +153,11 @@ def configure(env: "Environment"):
 
     if env["vulkan"]:
         env.Append(CPPDEFINES=["VULKAN_ENABLED"])
+
+    if env["opengl3"]:
+        env.Append(CPPDEFINES=["GLES3_ENABLED"])
+        env.Prepend(
+            CPPPATH=[
+                "$IOS_SDK_PATH/System/Library/Frameworks/OpenGLES.framework/Headers",
+            ]
+        )

--- a/platform/ios/display_layer.h
+++ b/platform/ios/display_layer.h
@@ -33,7 +33,8 @@
 
 @protocol DisplayLayer <NSObject>
 
-- (void)renderDisplayLayer;
+- (void)startRenderDisplayLayer;
+- (void)stopRenderDisplayLayer;
 - (void)initializeDisplayLayer;
 - (void)layoutDisplayLayer;
 

--- a/platform/ios/display_layer.mm
+++ b/platform/ios/display_layer.mm
@@ -60,7 +60,10 @@
 - (void)layoutDisplayLayer {
 }
 
-- (void)renderDisplayLayer {
+- (void)startRenderDisplayLayer {
+}
+
+- (void)stopRenderDisplayLayer {
 }
 
 @end
@@ -76,8 +79,6 @@
 }
 
 - (void)initializeDisplayLayer {
-	// Get our backing layer
-
 	// Configure it so that it is opaque, does not retain the contents of the backbuffer when displayed, and uses RGBA8888 color.
 	self.opaque = YES;
 	self.drawableProperties = [NSDictionary
@@ -86,8 +87,6 @@
 			kEAGLColorFormatRGBA8,
 			kEAGLDrawablePropertyColorFormat,
 			nil];
-
-	// FIXME: Add Vulkan support via MoltenVK. Add fallback code back?
 
 	// Create GL ES 3 context
 	if (GLOBAL_GET("rendering/renderer/rendering_method") == "gl_compatibility") {
@@ -115,8 +114,22 @@
 	[self createFramebuffer];
 }
 
-- (void)renderDisplayLayer {
+- (void)startRenderDisplayLayer {
 	[EAGLContext setCurrentContext:context];
+
+	glBindFramebufferOES(GL_FRAMEBUFFER_OES, viewFramebuffer);
+}
+
+- (void)stopRenderDisplayLayer {
+	glBindRenderbufferOES(GL_RENDERBUFFER_OES, viewRenderbuffer);
+	[context presentRenderbuffer:GL_RENDERBUFFER_OES];
+
+#ifdef DEBUG_ENABLED
+	GLenum err = glGetError();
+	if (err) {
+		NSLog(@"DrawView: %x error", err);
+	}
+#endif
 }
 
 - (void)dealloc {
@@ -154,11 +167,15 @@
 		return NO;
 	}
 
+	GLES3::TextureStorage::system_fbo = viewFramebuffer;
+
 	return YES;
 }
 
 // Clean up any buffers we have allocated.
 - (void)destroyFramebuffer {
+	GLES3::TextureStorage::system_fbo = 0;
+
 	glDeleteFramebuffersOES(1, &viewFramebuffer);
 	viewFramebuffer = 0;
 	glDeleteRenderbuffersOES(1, &viewRenderbuffer);

--- a/platform/ios/display_server_ios.h
+++ b/platform/ios/display_server_ios.h
@@ -47,6 +47,10 @@
 #endif
 #endif
 
+#if defined(GLES3_ENABLED)
+#include "drivers/gles3/rasterizer_gles3.h"
+#endif // GLES3_ENABLED
+
 #import <Foundation/Foundation.h>
 #import <QuartzCore/CAMetalLayer.h>
 
@@ -216,6 +220,7 @@ public:
 	virtual bool screen_is_kept_on() const override;
 
 	void resize_window(CGSize size);
+	virtual void swap_buffers() override {}
 };
 
 #endif // DISPLAY_SERVER_IOS_H

--- a/platform/ios/godot_view.mm
+++ b/platform/ios/godot_view.mm
@@ -74,16 +74,20 @@ static const float earth_gravity = 9.80665;
 	CALayer<DisplayLayer> *layer;
 
 	if ([driverName isEqualToString:@"vulkan"]) {
+#if defined(TARGET_OS_SIMULATOR) && TARGET_OS_SIMULATOR
+		if (@available(iOS 13, *)) {
+			layer = [GodotMetalLayer layer];
+		} else {
+			return nil;
+		}
+#else
 		layer = [GodotMetalLayer layer];
+#endif
 	} else if ([driverName isEqualToString:@"opengl3"]) {
 		if (@available(iOS 13, *)) {
 			NSLog(@"OpenGL ES is deprecated on iOS 13");
 		}
-#if defined(TARGET_OS_SIMULATOR) && TARGET_OS_SIMULATOR
-		return nil;
-#else
 		layer = [GodotOpenGLLayer layer];
-#endif
 	} else {
 		return nil;
 	}
@@ -238,7 +242,7 @@ static const float earth_gravity = 9.80665;
 		[self.displayLink setPaused:NO];
 	}
 
-	[self.renderingLayer renderDisplayLayer];
+	[self.renderingLayer startRenderDisplayLayer];
 
 	if (!self.renderer) {
 		return;
@@ -258,6 +262,8 @@ static const float earth_gravity = 9.80665;
 
 	[self handleMotion];
 	[self.renderer renderOnView:self];
+
+	[self.renderingLayer stopRenderDisplayLayer];
 }
 
 - (BOOL)canRender {

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -230,7 +230,7 @@ def configure(env: "Environment"):
     env.Append(LIBS=["pthread", "z"])
 
     if env["opengl3"]:
-        env.Append(CPPDEFINES=["GLES_ENABLED", "GLES3_ENABLED"])
+        env.Append(CPPDEFINES=["GLES3_ENABLED"])
         env.Append(LINKFLAGS=["-framework", "OpenGL"])
 
     env.Append(LINKFLAGS=["-rpath", "@executable_path/../Frameworks", "-rpath", "@executable_path"])

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3142,7 +3142,9 @@ ObjectID DisplayServerMacOS::window_get_attached_instance_id(WindowID p_window) 
 
 void DisplayServerMacOS::gl_window_make_current(DisplayServer::WindowID p_window_id) {
 #if defined(GLES3_ENABLED)
-	gl_manager->window_make_current(p_window_id);
+	if (gl_manager) {
+		gl_manager->window_make_current(p_window_id);
+	}
 #endif
 }
 


### PR DESCRIPTION
OpenGL is deprecated, but might be still useful for old devices.