### PR TITLE
Use path instead of file name when updating script classes

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1543,7 +1543,7 @@ void EditorFileSystem::_update_script_classes() {
 
 			ScriptServer::add_global_class(efd->files[index]->script_class_name, efd->files[index]->script_class_extends, lang, path);
 			EditorNode::get_editor_data().script_class_set_icon_path(efd->files[index]->script_class_name, efd->files[index]->script_class_icon_path);
-			EditorNode::get_editor_data().script_class_set_name(efd->files[index]->file, efd->files[index]->script_class_name);
+			EditorNode::get_editor_data().script_class_set_name(path, efd->files[index]->script_class_name);
 		}
 	}
 


### PR DESCRIPTION
The `_script_class_file_to_path` contains a map of paths to classes, but when updating the script classes for new class names, the file name is used instead. This meant new classes weren't able to be used in exported variables until the project is reloaded (as the`_script_class_file_to_path` is initially set with the full path when loading the project)

Fixes #70718
*Bugsquad edit:* Fixes #72989 Fixes #66862

Before the fix:
![godot-bug-before](https://user-images.githubusercontent.com/1323037/213911585-466d7377-4390-4fb4-a546-49e5b0bb83da.gif)

After the fix:
![godot-bug-after](https://user-images.githubusercontent.com/1323037/213911572-722ddef6-910d-4579-bf4d-4704b92c0da9.gif)
