### PR TITLE
Fix using arrow keys to move object when move tool is selected causes changed of focus

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2646,6 +2646,7 @@ void CanvasItemEditor::_update_cursor() {
 		case DRAG_BOTTOM_LEFT:
 			c = rotation_array[(rotation_array_index + 1) % 4];
 			break;
+		case DRAG_KEY_MOVE:
 		case DRAG_MOVE:
 			c = CURSOR_MOVE;
 			break;


### PR DESCRIPTION
Fixes #70789

What a goose chase this was. Turns out inside the `_gui_input` handling, we call `_update_cursor()`, which in turn pushes a mouse motion event to the viewport. This **RESETS** the `gui.key_event_accepted` to false, when the move tool already accepted the event and set it to true!

So the fix here is actually to ensure `viewport->set_default_cursor_shape(c);` (at the bottom of `_update_cursor()`) never gets called because the new cursor is same as current.

This might need to be looked into as this was quite a hard bug to find due to that interaction. Simplfied, this was happening:

* _gui_input 
* handle move tool 
* move calls accept_event() 
* **viewport sets gui.key_event_accepted to true**
* move calls update_cursor()
* `update_cursor()` dispatches an event to the viewport via `viewport->set_default_cursor_shape(c);`
* **viewport sets gui.key_event_accepted to false**
* handling move tool finished
* viewport checks `gui.key_event_accepted` - it is now false! When it should be true since move tool handled the event