### PR TITLE
Fix potential crash in EditorPlugin.edit()

### DIFF
--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -662,7 +662,7 @@ void EditorPlugin::make_visible(bool p_visible) {
 }
 
 void EditorPlugin::edit(Object *p_object) {
-	if (p_object->is_class("Resource")) {
+	if (Object::cast_to<Resource>(p_object)) {
 		GDVIRTUAL_CALL(_edit, Ref<Resource>(Object::cast_to<Resource>(p_object)));
 	} else {
 		GDVIRTUAL_CALL(_edit, p_object);


### PR DESCRIPTION
Regression from #71770
If `EditorPlugin::edit()` receives null, it will try to call `is_class()` and crashes. Not sure why exactly it happens (because it should always crash, but it's not the case); you can reproduce the crash by selecting 2+ keys in an animation track.