### PR TITLE
Fix SplitContainer rendering and theming

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1422,9 +1422,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("grabber", "VSplitContainer", theme->get_icon(SNAME("GuiVsplitter"), SNAME("EditorIcons")));
 	theme->set_icon("grabber", "HSplitContainer", theme->get_icon(SNAME("GuiHsplitter"), SNAME("EditorIcons")));
 
+	theme->set_constant("separation", "SplitContainer", default_margin_size * 2 * EDSCALE);
 	theme->set_constant("separation", "HSplitContainer", default_margin_size * 2 * EDSCALE);
 	theme->set_constant("separation", "VSplitContainer", default_margin_size * 2 * EDSCALE);
 
+	theme->set_constant("minimum_grab_thickness", "SplitContainer", 6 * EDSCALE);
 	theme->set_constant("minimum_grab_thickness", "HSplitContainer", 6 * EDSCALE);
 	theme->set_constant("minimum_grab_thickness", "VSplitContainer", 6 * EDSCALE);
 

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -115,7 +115,7 @@ void SplitContainerDragger::_notification(int p_what) {
 				return;
 			}
 
-			Ref<Texture2D> tex = sc->get_theme_icon(SNAME("grabber"));
+			Ref<Texture2D> tex = sc->_get_grabber_icon();
 			draw_texture(tex, (get_size() - tex->get_size()) / 2);
 		} break;
 	}


### PR DESCRIPTION
Fix #71861 grabber icon not rendering properly.

Also add missing theme constants in the editor theme.