### PR TITLE
Expose `_err_print_error` with message parameter to GDExtension

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -54,14 +54,23 @@ static void gdextension_free(void *p_mem) {
 }
 
 // Helper print functions.
-static void gdextension_print_error(const char *p_description, const char *p_function, const char *p_file, int32_t p_line) {
-	_err_print_error(p_function, p_file, p_line, p_description, false, ERR_HANDLER_ERROR);
+static void gdextension_print_error(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify) {
+	_err_print_error(p_function, p_file, p_line, p_description, p_editor_notify, ERR_HANDLER_ERROR);
 }
-static void gdextension_print_warning(const char *p_description, const char *p_function, const char *p_file, int32_t p_line) {
-	_err_print_error(p_function, p_file, p_line, p_description, false, ERR_HANDLER_WARNING);
+static void gdextension_print_error_with_message(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify) {
+	_err_print_error(p_function, p_file, p_line, p_description, p_message, p_editor_notify, ERR_HANDLER_ERROR);
 }
-static void gdextension_print_script_error(const char *p_description, const char *p_function, const char *p_file, int32_t p_line) {
-	_err_print_error(p_function, p_file, p_line, p_description, false, ERR_HANDLER_SCRIPT);
+static void gdextension_print_warning(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify) {
+	_err_print_error(p_function, p_file, p_line, p_description, p_editor_notify, ERR_HANDLER_WARNING);
+}
+static void gdextension_print_warning_with_message(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify) {
+	_err_print_error(p_function, p_file, p_line, p_description, p_message, p_editor_notify, ERR_HANDLER_WARNING);
+}
+static void gdextension_print_script_error(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify) {
+	_err_print_error(p_function, p_file, p_line, p_description, p_editor_notify, ERR_HANDLER_SCRIPT);
+}
+static void gdextension_print_script_error_with_message(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify) {
+	_err_print_error(p_function, p_file, p_line, p_description, p_message, p_editor_notify, ERR_HANDLER_SCRIPT);
 }
 
 uint64_t gdextension_get_native_struct_size(GDExtensionConstStringNamePtr p_name) {
@@ -1014,8 +1023,11 @@ void gdextension_setup_interface(GDExtensionInterface *p_interface) {
 	gde_interface.mem_free = gdextension_free;
 
 	gde_interface.print_error = gdextension_print_error;
+	gde_interface.print_error_with_message = gdextension_print_error_with_message;
 	gde_interface.print_warning = gdextension_print_warning;
+	gde_interface.print_warning_with_message = gdextension_print_warning_with_message;
 	gde_interface.print_script_error = gdextension_print_script_error;
+	gde_interface.print_script_error_with_message = gdextension_print_script_error_with_message;
 
 	gde_interface.get_native_struct_size = gdextension_get_native_struct_size;
 

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -414,9 +414,12 @@ typedef struct {
 	void *(*mem_realloc)(void *p_ptr, size_t p_bytes);
 	void (*mem_free)(void *p_ptr);
 
-	void (*print_error)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line);
-	void (*print_warning)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line);
-	void (*print_script_error)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line);
+	void (*print_error)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify);
+	void (*print_error_with_message)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify);
+	void (*print_warning)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify);
+	void (*print_warning_with_message)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify);
+	void (*print_script_error)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify);
+	void (*print_script_error_with_message)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify);
 
 	uint64_t (*get_native_struct_size)(GDExtensionConstStringNamePtr p_name);
 


### PR DESCRIPTION
This adds GDExtension functions for the overloads of `_err_print_error` that takes a message along with the error description.

This is required for godotengine/godot-cpp#1011. See that PR for details on why this is needed.

This PR also changes the signature of the existing print functions, by adding the `bool p_editor_notify` parameter, which is used to create toast notifications. I suppose that makes this a `breaks compat` change, if the ABI breakage wasn't enough already.