### PR TITLE
Defer invalidation on FileDialog nodes

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -593,8 +593,8 @@ void EditorFileDialog::_item_dc_selected(int p_item) {
 
 	if (d["dir"]) {
 		dir_access->change_dir(d["name"]);
-		call_deferred(SNAME("_update_file_list"));
-		call_deferred(SNAME("_update_dir"));
+		callable_mp(this, &EditorFileDialog::update_file_list).call_deferred();
+		callable_mp(this, &EditorFileDialog::update_dir).call_deferred();
 
 		_push_history();
 
@@ -1146,14 +1146,24 @@ void EditorFileDialog::set_access(Access p_access) {
 }
 
 void EditorFileDialog::invalidate() {
-	if (is_visible()) {
-		update_file_list();
-		_update_favorites();
-		_update_recent();
-		invalidated = false;
-	} else {
-		invalidated = true;
+	if (!is_visible() || is_invalidating) {
+		return;
 	}
+
+	is_invalidating = true;
+	callable_mp(this, &EditorFileDialog::_invalidate).call_deferred();
+}
+
+void EditorFileDialog::_invalidate() {
+	if (!is_invalidating) {
+		return;
+	}
+
+	update_file_list();
+	_update_favorites();
+	_update_recent();
+
+	is_invalidating = false;
 }
 
 EditorFileDialog::Access EditorFileDialog::get_access() const {
@@ -1599,9 +1609,6 @@ void EditorFileDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_access"), &EditorFileDialog::get_access);
 	ClassDB::bind_method(D_METHOD("set_show_hidden_files", "show"), &EditorFileDialog::set_show_hidden_files);
 	ClassDB::bind_method(D_METHOD("is_showing_hidden_files"), &EditorFileDialog::is_showing_hidden_files);
-	ClassDB::bind_method(D_METHOD("_update_file_name"), &EditorFileDialog::update_file_name);
-	ClassDB::bind_method(D_METHOD("_update_dir"), &EditorFileDialog::update_dir);
-	ClassDB::bind_method(D_METHOD("_update_file_list"), &EditorFileDialog::update_file_list);
 	ClassDB::bind_method(D_METHOD("_thumbnail_done"), &EditorFileDialog::_thumbnail_done);
 	ClassDB::bind_method(D_METHOD("set_display_mode", "mode"), &EditorFileDialog::set_display_mode);
 	ClassDB::bind_method(D_METHOD("get_display_mode"), &EditorFileDialog::get_display_mode);

--- a/editor/editor_file_dialog.h
+++ b/editor/editor_file_dialog.h
@@ -143,7 +143,7 @@ private:
 	DisplayMode display_mode;
 
 	bool disable_overwrite_warning = false;
-	bool invalidated = true;
+	bool is_invalidating = false;
 
 	struct ThemeCache {
 		Ref<Texture2D> parent_folder;
@@ -215,6 +215,8 @@ private:
 	void _go_up();
 	void _go_back();
 	void _go_forward();
+
+	void _invalidate();
 
 	virtual void _post_popup() override;
 

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -126,6 +126,8 @@ void FileDialog::_notification(int p_what) {
 			show_hidden->add_theme_color_override("icon_hover_color", theme_cache.icon_hover_color);
 			show_hidden->add_theme_color_override("icon_focus_color", theme_cache.icon_focus_color);
 			show_hidden->add_theme_color_override("icon_pressed_color", theme_cache.icon_pressed_color);
+
+			invalidate();
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {
@@ -863,12 +865,22 @@ void FileDialog::set_access(Access p_access) {
 }
 
 void FileDialog::invalidate() {
-	if (is_visible()) {
-		update_file_list();
-		invalidated = false;
-	} else {
-		invalidated = true;
+	if (!is_visible() || is_invalidating) {
+		return;
 	}
+
+	is_invalidating = true;
+	callable_mp(this, &FileDialog::_invalidate).call_deferred();
+}
+
+void FileDialog::_invalidate() {
+	if (!is_invalidating) {
+		return;
+	}
+
+	update_file_list();
+
+	is_invalidating = false;
 }
 
 FileDialog::Access FileDialog::get_access() const {
@@ -966,9 +978,6 @@ void FileDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_root_subfolder"), &FileDialog::get_root_subfolder);
 	ClassDB::bind_method(D_METHOD("set_show_hidden_files", "show"), &FileDialog::set_show_hidden_files);
 	ClassDB::bind_method(D_METHOD("is_showing_hidden_files"), &FileDialog::is_showing_hidden_files);
-	ClassDB::bind_method(D_METHOD("_update_file_name"), &FileDialog::update_file_name);
-	ClassDB::bind_method(D_METHOD("_update_dir"), &FileDialog::update_dir);
-	ClassDB::bind_method(D_METHOD("_update_file_list"), &FileDialog::update_file_list);
 	ClassDB::bind_method(D_METHOD("deselect_all"), &FileDialog::deselect_all);
 
 	ClassDB::bind_method(D_METHOD("invalidate"), &FileDialog::invalidate);

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -106,7 +106,7 @@ private:
 	static bool default_show_hidden_files;
 	bool show_hidden_files = false;
 
-	bool invalidated = true;
+	bool is_invalidating = false;
 
 	struct ThemeCache {
 		Ref<Texture2D> parent_folder;
@@ -153,6 +153,8 @@ private:
 
 	void _change_dir(const String &p_new_dir);
 	void _update_drives(bool p_select = true);
+
+	void _invalidate();
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 


### PR DESCRIPTION
Now, when calling `invalidate()` on `(Editor)FileDialog`, said invalidation will be deferred and executed only once. This helps with two things:
- Allows calling `invalidate()` on `FileDialog`'s theme change, which fixes it not updating theme elements related to the file tree immediately.
- Makes the `invalidated` variable (now renamed to `is_invalidating`) have an actual purpose.