### PR TITLE
Provide theme properties to limit icon size for Button.

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -116,6 +116,12 @@
 		<theme_item name="h_separation" data_type="constant" type="int" default="2">
 			The horizontal space between [Button]'s icon and text. Negative values will be treated as [code]0[/code] when used.
 		</theme_item>
+		<theme_item name="icon_maximum_height" data_type="constant" type="int" default="0">
+			The maximum height of icon. Negative and zero values mean that button unlimit the height of icon.
+		</theme_item>
+		<theme_item name="icon_maximum_width" data_type="constant" type="int" default="0">
+			The maximum width of icon. Negative and zero values mean that button unlimit the width of icon.
+		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 			[b]Note:[/b] If using a font with [member FontFile.multichannel_signed_distance_field] enabled, its [member FontFile.msdf_pixel_range] must be set to at least [i]twice[/i] the value of [theme_item outline_size] for outline rendering to look correct. Otherwise, the outline may appear to be cut off earlier than intended.

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -83,6 +83,8 @@ void Button::_update_theme_item_cache() {
 	theme_cache.icon = get_theme_icon(SNAME("icon"));
 
 	theme_cache.h_separation = get_theme_constant(SNAME("h_separation"));
+	theme_cache.icon_maximum_width = get_theme_constant(SNAME("icon_maximum_width"));
+	theme_cache.icon_maximum_height = get_theme_constant(SNAME("icon_maximum_height"));
 }
 
 void Button::_notification(int p_what) {
@@ -286,6 +288,13 @@ void Button::_notification(int p_what) {
 					icon_size = Size2(icon_width, icon_height);
 				}
 
+				if (theme_cache.icon_maximum_width > 0) {
+					icon_size.x = MIN(theme_cache.icon_maximum_width, icon_size.width);
+				}
+				if (theme_cache.icon_maximum_height > 0) {
+					icon_size.y = MIN(theme_cache.icon_maximum_height, icon_size.height);
+				}
+
 				if (icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_LEFT) {
 					icon_region = Rect2(style_offset + Point2(icon_ofs_region, Math::floor((valign - icon_size.y) * 0.5)), icon_size);
 				} else if (icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_CENTER) {
@@ -380,15 +389,17 @@ Size2 Button::get_minimum_size_for_text_and_icon(const String &p_text, Ref<Textu
 	}
 
 	if (!expand_icon && p_icon.is_valid()) {
-		minsize.height = MAX(minsize.height, p_icon->get_height());
+		auto max_icon_height = theme_cache.icon_maximum_height > 0 ? theme_cache.icon_maximum_height : p_icon->get_height();
+		minsize.height = MAX(minsize.height, MIN(p_icon->get_height(), max_icon_height));
 
+		auto max_icon_width = theme_cache.icon_maximum_width > 0 ? theme_cache.icon_maximum_width : p_icon->get_width();
 		if (icon_alignment != HORIZONTAL_ALIGNMENT_CENTER) {
-			minsize.width += p_icon->get_width();
+			minsize.width += MIN(p_icon->get_width(), max_icon_width);
 			if (!xl_text.is_empty() || !p_text.is_empty()) {
 				minsize.width += MAX(0, theme_cache.h_separation);
 			}
 		} else {
-			minsize.width = MAX(minsize.width, p_icon->get_width());
+			minsize.width = MAX(minsize.width, MIN(p_icon->get_width(), max_icon_height));
 		}
 	}
 

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -89,6 +89,8 @@ private:
 		Ref<Texture2D> icon;
 
 		int h_separation = 0;
+		int icon_maximum_width = 0;
+		int icon_maximum_height = 0;
 	} theme_cache;
 
 	void _shape(Ref<TextParagraph> p_paragraph = Ref<TextParagraph>(), String p_text = "");

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -174,6 +174,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("icon_hover_pressed_color", "Button", Color(1, 1, 1, 1));
 	theme->set_color("icon_focus_color", "Button", Color(1, 1, 1, 1));
 	theme->set_color("icon_disabled_color", "Button", Color(1, 1, 1, 0.4));
+	theme->set_constant("icon_maximum_width", "Button", 0);
+	theme->set_constant("icon_maximum_height", "Button", 0);
 
 	theme->set_constant("h_separation", "Button", 2 * scale);
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
I think a way to limite the icon size of `Button` is necessary.

This pr relevant to #71818 , to handle the icon size of `EditorResourcePicker`.

https://user-images.githubusercontent.com/61624558/213931482-7349090a-c10c-4529-a85e-da2adaa9a6fd.mp4

