### PR TITLE
[3.x] Add benchmark logic

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -75,6 +75,12 @@ class OS {
 	bool restart_on_exit;
 	List<String> restart_commandline;
 
+	// For tracking benchmark data
+	bool use_benchmark = false;
+	String benchmark_file;
+	HashMap<String, uint64_t> start_benchmark_from;
+	Dictionary startup_benchmark_json;
+
 protected:
 	bool _update_pending;
 
@@ -662,6 +668,15 @@ public:
 	virtual bool request_permission(const String &p_name) { return true; }
 	virtual bool request_permissions() { return true; }
 	virtual Vector<String> get_granted_permissions() const { return Vector<String>(); }
+
+	// For recording / measuring benchmark data. Only enabled with tools
+	void set_use_benchmark(bool p_use_benchmark);
+	bool is_use_benchmark_set();
+	void set_benchmark_file(const String &p_benchmark_file);
+	String get_benchmark_file();
+	virtual void benchmark_begin_measure(const String &p_what);
+	virtual void benchmark_end_measure(const String &p_what);
+	virtual void benchmark_dump();
 
 	virtual void process_and_drop_events() {}
 	OS();

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -101,6 +101,7 @@ extern void register_variant_methods();
 extern void unregister_variant_methods();
 
 void register_core_types() {
+	OS::get_singleton()->benchmark_begin_measure("register_core_types");
 	MemoryPool::setup();
 
 	StringName::setup();
@@ -225,6 +226,8 @@ void register_core_types() {
 	_classdb = memnew(_ClassDB);
 	_marshalls = memnew(_Marshalls);
 	_json = memnew(_JSON);
+
+	OS::get_singleton()->benchmark_end_measure("register_core_types");
 }
 
 void register_core_settings() {
@@ -272,6 +275,8 @@ void register_core_singletons() {
 }
 
 void unregister_core_types() {
+	OS::get_singleton()->benchmark_begin_measure("unregister_core_types");
+
 	memdelete(_resource_loader);
 	memdelete(_resource_saver);
 	memdelete(_os);
@@ -320,4 +325,6 @@ void unregister_core_types() {
 	StringName::cleanup();
 
 	MemoryPool::cleanup();
+
+	OS::get_singleton()->benchmark_end_measure("unregister_core_types");
 }

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -32,6 +32,7 @@
 
 #include "builtin_fonts.gen.h"
 #include "core/os/dir_access.h"
+#include "core/os/os.h"
 #include "editor_scale.h"
 #include "editor_settings.h"
 #include "scene/resources/default_theme/default_theme.h"
@@ -100,6 +101,7 @@
 	MAKE_FALLBACKS(m_name);
 
 void editor_register_fonts(Ref<Theme> p_theme) {
+	OS::get_singleton()->benchmark_begin_measure("editor_register_fonts");
 	DirAccess *dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 
 	/* Custom font */
@@ -285,4 +287,6 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 
 	MAKE_SOURCE_FONT(df_text_editor_status_code, default_font_size);
 	p_theme->set_font("status_source", "EditorFonts", df_text_editor_status_code);
+
+	OS::get_singleton()->benchmark_end_measure("editor_register_fonts");
 }

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -866,8 +866,11 @@ void EditorNode::_sources_changed(bool p_exist) {
 		_load_docks();
 
 		if (defer_load_scene != "") {
+			OS::get_singleton()->benchmark_begin_measure("editor_load_scene");
 			load_scene(defer_load_scene);
 			defer_load_scene = "";
+			OS::get_singleton()->benchmark_end_measure("editor_load_scene");
+			OS::get_singleton()->benchmark_dump();
 		}
 	}
 }
@@ -3887,6 +3890,8 @@ bool EditorNode::is_scene_in_use(const String &p_path) {
 }
 
 void EditorNode::register_editor_types() {
+	OS::get_singleton()->benchmark_begin_measure("register_editor_types");
+
 	ResourceLoader::set_timestamp_on_load(true);
 	ResourceSaver::set_timestamp_on_save(true);
 
@@ -3922,12 +3927,18 @@ void EditorNode::register_editor_types() {
 	// FIXME: Is this stuff obsolete, or should it be ported to new APIs?
 	ClassDB::register_class<EditorScenePostImport>();
 	//ClassDB::register_type<EditorImportExport>();
+
+	OS::get_singleton()->benchmark_end_measure("register_editor_types");
 }
 
 void EditorNode::unregister_editor_types() {
+	OS::get_singleton()->benchmark_begin_measure("unregister_editor_types");
+
 	_init_callbacks.clear();
 
 	EditorResourcePicker::clear_caches();
+
+	OS::get_singleton()->benchmark_end_measure("unregister_editor_types");
 }
 
 void EditorNode::stop_child_process() {
@@ -5839,6 +5850,7 @@ int EditorNode::execute_and_show_output(const String &p_title, const String &p_p
 }
 
 EditorNode::EditorNode() {
+	OS::get_singleton()->benchmark_begin_measure("editor");
 	EditorPropertyNameProcessor *epnp = memnew(EditorPropertyNameProcessor);
 	add_child(epnp);
 
@@ -7226,6 +7238,8 @@ EditorNode::EditorNode() {
 
 	String exec = OS::get_singleton()->get_executable_path();
 	EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "executable_path", exec); // Save editor executable path for third-party tools
+
+	OS::get_singleton()->benchmark_end_measure("editor");
 }
 
 EditorNode::~EditorNode() {

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -31,6 +31,7 @@
 #include "editor_themes.h"
 
 #include "core/io/resource_loader.h"
+#include "core/os/os.h"
 #include "editor_fonts.h"
 #include "editor_icons.gen.h"
 #include "editor_scale.h"
@@ -134,6 +135,7 @@ static Ref<ImageTexture> editor_generate_icon(int p_index, bool p_convert_color,
 #endif
 
 void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = true, int p_thumb_size = 32, bool p_only_thumbs = false) {
+	OS::get_singleton()->benchmark_begin_measure("editor_register_and_generate_icons_" + String((p_only_thumbs ? "with_only_thumbs" : "all")));
 #ifdef MODULE_SVG_ENABLED
 	// The default icon theme is designed to be used for a dark theme.
 	// This dictionary stores color codes to convert to other colors
@@ -290,9 +292,11 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 #else
 	WARN_PRINT("SVG support disabled, editor icons won't be rendered.");
 #endif
+	OS::get_singleton()->benchmark_end_measure("editor_register_and_generate_icons_" + String((p_only_thumbs ? "with_only_thumbs" : "all")));
 }
 
 Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
+	OS::get_singleton()->benchmark_begin_measure("create_editor_theme");
 	Ref<Theme> theme = Ref<Theme>(memnew(Theme));
 
 	const float default_contrast = 0.25;
@@ -1419,10 +1423,13 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 		setting->load_text_editor_theme();
 	}
 
+	OS::get_singleton()->benchmark_end_measure("create_editor_theme");
+
 	return theme;
 }
 
 Ref<Theme> create_custom_theme(const Ref<Theme> p_theme) {
+	OS::get_singleton()->benchmark_begin_measure("create_custom_theme");
 	Ref<Theme> theme = create_editor_theme(p_theme);
 
 	const String custom_theme_path = EditorSettings::get_singleton()->get("interface/theme/custom_theme");
@@ -1433,6 +1440,7 @@ Ref<Theme> create_custom_theme(const Ref<Theme> p_theme) {
 		}
 	}
 
+	OS::get_singleton()->benchmark_end_measure("create_custom_theme");
 	return theme;
 }
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2391,6 +2391,7 @@ void ProjectManager::_version_button_pressed() {
 }
 
 ProjectManager::ProjectManager() {
+	OS::get_singleton()->benchmark_begin_measure("project_manager");
 	// load settings
 	if (!EditorSettings::get_singleton()) {
 		EditorSettings::create();
@@ -2791,6 +2792,8 @@ ProjectManager::ProjectManager() {
 
 	about = memnew(EditorAbout);
 	add_child(about);
+
+	OS::get_singleton()->benchmark_end_measure("project_manager");
 }
 
 ProjectManager::~ProjectManager() {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -349,6 +349,8 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  --doctool [<path>]               Dump the engine API reference to the given <path> (defaults to current dir) in XML format, merging if existing files are found.\n");
 	OS::get_singleton()->print("  --no-docbase                     Disallow dumping the base types (used with --doctool).\n");
 	OS::get_singleton()->print("  --build-solutions                Build the scripting solutions (e.g. for C# projects). Implies --editor and requires a valid project to edit.\n");
+	OS::get_singleton()->print("  --benchmark                      Benchmark the run time and print it to console.\n");
+	OS::get_singleton()->print("  --benchmark-file <path>          Benchmark the run time and save it to a given file in JSON format. The path should be absolute.\n");
 #ifdef DEBUG_METHODS_ENABLED
 	OS::get_singleton()->print("  --gdnative-generate-json-api     Generate JSON dump of the Godot API for GDNative bindings.\n");
 #endif
@@ -399,9 +401,14 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	OS::get_singleton()->initialize_core();
 
+	// Benchmark tracking must be done after `OS::get_singleton()->initialize_core()` as on some
+	// platforms, it's used to set up the time utilities.
+	OS::get_singleton()->benchmark_begin_measure("startup_begin");
+
 	engine = memnew(Engine);
 
 	MAIN_PRINT("Main: Initialize CORE");
+	OS::get_singleton()->benchmark_begin_measure("core");
 
 	register_core_types();
 	register_core_driver_types();
@@ -921,6 +928,20 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			OS::get_singleton()->disable_crash_handler();
 		} else if (I->get() == "--skip-breakpoints") {
 			skip_breakpoints = true;
+		} else if (I->get() == "--benchmark") {
+			OS::get_singleton()->set_use_benchmark(true);
+		} else if (I->get() == "--benchmark-file") {
+			if (I->next()) {
+				OS::get_singleton()->set_use_benchmark(true);
+				String benchmark_file = I->next()->get();
+				OS::get_singleton()->set_benchmark_file(benchmark_file);
+				N = I->next()->next();
+			} else {
+				OS::get_singleton()->print("Missing <path> argument for --startup-benchmark-file <path>.\n");
+				OS::get_singleton()->print("Missing <path> argument for --benchmark-file <path>.\n");
+				goto error;
+			}
+
 		} else {
 			main_args.push_back(I->get());
 		}
@@ -1299,7 +1320,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	if (p_second_phase) {
 		return setup2();
 	}
-
+	OS::get_singleton()->benchmark_end_measure("core");
 	return OK;
 
 error:
@@ -1352,6 +1373,9 @@ error:
 	if (message_queue) {
 		memdelete(message_queue);
 	}
+
+	OS::get_singleton()->benchmark_end_measure("core");
+
 	OS::get_singleton()->finalize_core();
 	locale = String();
 
@@ -2197,6 +2221,8 @@ bool Main::start() {
 		}
 	}
 
+	OS::get_singleton()->benchmark_end_measure("startup_begin");
+	OS::get_singleton()->benchmark_dump();
 	return true;
 }
 
@@ -2456,6 +2482,7 @@ void Main::force_redraw() {
  * The order matters as some of those steps are linked with each other.
  */
 void Main::cleanup(bool p_force) {
+	OS::get_singleton()->benchmark_begin_measure("Main::cleanup");
 	if (!p_force) {
 		ERR_FAIL_COND(!_start_success);
 	}
@@ -2574,6 +2601,9 @@ void Main::cleanup(bool p_force) {
 
 	unregister_core_driver_types();
 	unregister_core_types();
+
+	OS::get_singleton()->benchmark_end_measure("Main::cleanup");
+	OS::get_singleton()->benchmark_dump();
 
 	OS::get_singleton()->finalize_core();
 

--- a/misc/dist/shell/_godot.zsh-completion
+++ b/misc/dist/shell/_godot.zsh-completion
@@ -74,4 +74,6 @@ _arguments \
   '--no-docbase[disallow dumping the base types (used with --doctool)]' \
   '--build-solutions[build the scripting solutions (e.g. for C# projects)]' \
   '--gdnative-generate-json-api[generate JSON dump of the Godot API for GDNative bindings]' \
+  '--benchmark[benchmark the run time and print it to console]' \
+  '--benchmark-file[benchmark the run time and save it to a given file in JSON format]:path to output JSON file' \
   '--test[run a unit test]:unit test name'

--- a/misc/dist/shell/godot.bash-completion
+++ b/misc/dist/shell/godot.bash-completion
@@ -77,6 +77,8 @@ _complete_godot_options() {
 --no-docbase
 --build-solutions
 --gdnative-generate-json-api
+--benchmark
+--benchmark-file
 --test
 " -- "$1"))
 }

--- a/misc/dist/shell/godot.fish
+++ b/misc/dist/shell/godot.fish
@@ -88,4 +88,6 @@ complete -c godot -l doctool -d "Dump the engine API reference to the given path
 complete -c godot -l no-docbase -d "Disallow dumping the base types (used with --doctool)"
 complete -c godot -l build-solutions -d "Build the scripting solutions (e.g. for C# projects)"
 complete -c godot -l gdnative-generate-json-api -d "Generate JSON dump of the Godot API for GDNative bindings"
+complete -c godot -l benchmark -d "Benchmark the run time and print it to console"
+complete -c godot -l benchmark-file -d "Benchmark the run time and save it to a given file in JSON format" -x
 complete -c godot -l test -d "Run a unit test" -x

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.kt
@@ -104,6 +104,9 @@ open class GodotEditor : FullScreenGodotApp() {
 		if (args != null && args.isNotEmpty()) {
 			commandLineParams.addAll(listOf(*args))
 		}
+		if (BuildConfig.BUILD_TYPE == "dev") {
+			commandLineParams.add("--benchmark")
+		}
 	}
 
 	override fun getCommandLine() = commandLineParams

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -39,6 +39,7 @@ import org.godotengine.godot.io.file.FileAccessHandler;
 import org.godotengine.godot.plugin.GodotPlugin;
 import org.godotengine.godot.plugin.GodotPluginRegistry;
 import org.godotengine.godot.tts.GodotTTS;
+import org.godotengine.godot.utils.BenchmarkUtils;
 import org.godotengine.godot.utils.GodotNetUtils;
 import org.godotengine.godot.utils.PermissionsUtil;
 import org.godotengine.godot.xr.XRMode;
@@ -268,6 +269,8 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 	public GodotIO io;
 	public GodotNetUtils netUtils;
 	public GodotTTS tts;
+	private DirectoryAccessHandler directoryAccessHandler;
+	private FileAccessHandler fileAccessHandler;
 
 	static SingletonBase[] singletons = new SingletonBase[MAX_SINGLETONS];
 	static int singleton_count = 0;
@@ -601,7 +604,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 			}
 			return cmdline;
 		} catch (Exception e) {
-			e.printStackTrace();
+			// The _cl_ file can be missing with no adverse effect
 			return new String[0];
 		}
 	}
@@ -662,8 +665,8 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		netUtils = new GodotNetUtils(activity);
 		tts = new GodotTTS(activity);
 		Context context = getContext();
-		DirectoryAccessHandler directoryAccessHandler = new DirectoryAccessHandler(context);
-		FileAccessHandler fileAccessHandler = new FileAccessHandler(context);
+		directoryAccessHandler = new DirectoryAccessHandler(context);
+		fileAccessHandler = new FileAccessHandler(context);
 		mSensorManager = (SensorManager)activity.getSystemService(Context.SENSOR_SERVICE);
 		mAccelerometer = mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
 		mGravity = mSensorManager.getDefaultSensor(Sensor.TYPE_GRAVITY);
@@ -685,6 +688,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 
 	@Override
 	public void onCreate(Bundle icicle) {
+		BenchmarkUtils.beginBenchmarkMeasure("Godot::onCreate");
 		super.onCreate(icicle);
 
 		final Activity activity = getActivity();
@@ -736,6 +740,18 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 				editor.putString("store_public_key", main_pack_key);
 
 				editor.apply();
+				i++;
+			} else if (command_line[i].equals("--benchmark")) {
+				BenchmarkUtils.setUseBenchmark(true);
+				new_args.add(command_line[i]);
+			} else if (has_extra && command_line[i].equals("--benchmark-file")) {
+				BenchmarkUtils.setUseBenchmark(true);
+				new_args.add(command_line[i]);
+
+				// Retrieve the filepath
+				BenchmarkUtils.setBenchmarkFile(command_line[i + 1]);
+				new_args.add(command_line[i + 1]);
+
 				i++;
 			} else if (command_line[i].trim().length() != 0) {
 				new_args.add(command_line[i]);
@@ -807,6 +823,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		mCurrentIntent = activity.getIntent();
 
 		initializeGodot();
+		BenchmarkUtils.endBenchmarkMeasure("Godot::onCreate");
 	}
 
 	@Override
@@ -1021,22 +1038,6 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		// Do something here if sensor accuracy changes.
 	}
 
-	/*
-	@Override public boolean dispatchKeyEvent(KeyEvent event) {
-
-		if (event.getKeyCode()==KeyEvent.KEYCODE_BACK) {
-
-			System.out.printf("** BACK REQUEST!\n");
-
-			GodotLib.quit();
-			return true;
-		}
-		System.out.printf("** OTHER KEY!\n");
-
-		return false;
-	}
-	*/
-
 	public void onBackPressed() {
 		boolean shouldQuit = true;
 
@@ -1243,10 +1244,35 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 	}
 
 	@Keep
+	public DirectoryAccessHandler getDirectoryAccessHandler() {
+		return directoryAccessHandler;
+	}
+
+	@Keep
+	public FileAccessHandler getFileAccessHandler() {
+		return fileAccessHandler;
+	}
+
+	@Keep
 	private int createNewGodotInstance(String[] args) {
 		if (godotHost != null) {
 			return godotHost.onNewGodotInstanceRequested(args);
 		}
 		return 0;
+	}
+
+	@Keep
+	private void beginBenchmarkMeasure(String label) {
+		BenchmarkUtils.beginBenchmarkMeasure(label);
+	}
+
+	@Keep
+	private void endBenchmarkMeasure(String label) {
+		BenchmarkUtils.endBenchmarkMeasure(label);
+	}
+
+	@Keep
+	private void dumpBenchmark(String benchmarkFile) {
+		BenchmarkUtils.dumpBenchmark(fileAccessHandler, benchmarkFile);
 	}
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/io/directory/DirectoryAccessHandler.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/directory/DirectoryAccessHandler.kt
@@ -79,6 +79,9 @@ class DirectoryAccessHandler(context: Context) {
 	private val assetsDirAccess = AssetsDirectoryAccess(context)
 	private val fileSystemDirAccess = FilesystemDirectoryAccess(context)
 
+	fun assetsFileExists(assetsPath: String) = assetsDirAccess.fileExists(assetsPath)
+	fun filesystemFileExists(path: String) = fileSystemDirAccess.fileExists(path)
+
 	private fun hasDirId(accessType: AccessType, dirId: Int): Boolean {
 		return when (accessType) {
 			ACCESS_RESOURCES -> assetsDirAccess.hasDirId(dirId)

--- a/platform/android/java/lib/src/org/godotengine/godot/io/file/FileAccessHandler.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/file/FileAccessHandler.kt
@@ -46,7 +46,7 @@ class FileAccessHandler(val context: Context) {
 		private val TAG = FileAccessHandler::class.java.simpleName
 
 		private const val FILE_NOT_FOUND_ERROR_ID = -1
-		private const val INVALID_FILE_ID = 0
+		internal const val INVALID_FILE_ID = 0
 		private const val STARTING_FILE_ID = 1
 
 		internal fun fileExists(context: Context, storageScopeIdentifier: StorageScope.Identifier, path: String?): Boolean {
@@ -96,13 +96,17 @@ class FileAccessHandler(val context: Context) {
 	private fun hasFileId(fileId: Int) = files.indexOfKey(fileId) >= 0
 
 	fun fileOpen(path: String?, modeFlags: Int): Int {
+		val accessFlag = FileAccessFlags.fromNativeModeFlags(modeFlags) ?: return INVALID_FILE_ID
+		return fileOpen(path, accessFlag)
+	}
+
+	internal fun fileOpen(path: String?, accessFlag: FileAccessFlags): Int {
 		val storageScope = storageScopeIdentifier.identifyStorageScope(path)
 		if (storageScope == StorageScope.UNKNOWN) {
 			return INVALID_FILE_ID
 		}
 
 		try {
-			val accessFlag = FileAccessFlags.fromNativeModeFlags(modeFlags) ?: return INVALID_FILE_ID
 			val dataAccess = DataAccess.generateDataAccess(storageScope, context, path!!, accessFlag) ?: return INVALID_FILE_ID
 
 			files.put(++lastFileId, dataAccess)

--- a/platform/android/java/lib/src/org/godotengine/godot/utils/BenchmarkUtils.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/utils/BenchmarkUtils.kt
@@ -1,0 +1,122 @@
+/**************************************************************************/
+/*  BenchmarkUtils.kt                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+@file:JvmName("BenchmarkUtils")
+
+package org.godotengine.godot.utils
+
+import android.os.Build
+import android.os.SystemClock
+import android.os.Trace
+import android.util.Log
+import org.godotengine.godot.BuildConfig
+import org.godotengine.godot.io.file.FileAccessFlags
+import org.godotengine.godot.io.file.FileAccessHandler
+import org.json.JSONObject
+import java.nio.ByteBuffer
+import java.util.concurrent.ConcurrentSkipListMap
+
+/**
+ * Contains benchmark related utilities methods
+ */
+private const val TAG = "GodotBenchmark"
+
+var useBenchmark = false
+var benchmarkFile = ""
+
+private val startBenchmarkFrom = ConcurrentSkipListMap<String, Long>()
+private val benchmarkTracker = ConcurrentSkipListMap<String, Double>()
+
+/**
+ * Start measuring and tracing the execution of a given section of code using the given label.
+ *
+ * Must be followed by a call to [endBenchmarkMeasure].
+ *
+ * Note: Only enabled on 'editorDev' build variant.
+ */
+fun beginBenchmarkMeasure(label: String) {
+	if (BuildConfig.FLAVOR != "editor" || BuildConfig.BUILD_TYPE != "dev") {
+		return
+	}
+	startBenchmarkFrom[label] = SystemClock.elapsedRealtime()
+
+	if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+		Trace.beginAsyncSection(label, 0)
+	}
+}
+
+/**
+ * End measuring and tracing of the section of code with the given label.
+ *
+ * Must be preceded by a call [beginBenchmarkMeasure]
+ *
+ * Note: Only enabled on 'editorDev' build variant.
+ */
+fun endBenchmarkMeasure(label: String) {
+	if (BuildConfig.FLAVOR != "editor" || BuildConfig.BUILD_TYPE != "dev") {
+		return
+	}
+	val startTime = startBenchmarkFrom[label] ?: return
+	val total = SystemClock.elapsedRealtime() - startTime
+	benchmarkTracker[label] = total / 1000.0
+
+	if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+		Trace.endAsyncSection(label, 0)
+	}
+}
+
+/**
+ * Dump the benchmark measurements.
+ * If [filepath] is valid, the data is also written in json format to the specified file.
+ *
+ * Note: Only enabled on 'editorDev' build variant.
+ */
+@JvmOverloads
+fun dumpBenchmark(fileAccessHandler: FileAccessHandler?, filepath: String? = benchmarkFile) {
+	if (BuildConfig.FLAVOR != "editor" || BuildConfig.BUILD_TYPE != "dev") {
+		return
+	}
+	if (!useBenchmark) {
+		return
+	}
+
+	val printOut =
+		benchmarkTracker.map { "\t- ${it.key} : ${it.value} sec." }.joinToString("\n")
+	Log.i(TAG, "BENCHMARK:\n$printOut")
+
+	if (fileAccessHandler != null && !filepath.isNullOrBlank()) {
+		val fileId = fileAccessHandler.fileOpen(filepath, FileAccessFlags.WRITE)
+		if (fileId != FileAccessHandler.INVALID_FILE_ID) {
+			val jsonOutput = JSONObject(benchmarkTracker.toMap()).toString(4)
+			fileAccessHandler.fileWrite(fileId, ByteBuffer.wrap(jsonOutput.toByteArray()))
+			fileAccessHandler.fileClose(fileId)
+		}
+	}
+}

--- a/platform/android/java_godot_view_wrapper.cpp
+++ b/platform/android/java_godot_view_wrapper.cpp
@@ -40,6 +40,7 @@ GodotJavaViewWrapper::GodotJavaViewWrapper(jobject godot_view) {
 
 	int android_device_api_level = android_get_device_api_level();
 	if (android_device_api_level >= __ANDROID_API_N__) {
+		_configure_pointer_icon = env->GetMethodID(_cls, "configurePointerIcon", "(ILjava/lang/String;FF)V");
 		_set_pointer_icon = env->GetMethodID(_cls, "setPointerIcon", "(I)V");
 	}
 	if (android_device_api_level >= __ANDROID_API_O__) {
@@ -49,7 +50,7 @@ GodotJavaViewWrapper::GodotJavaViewWrapper(jobject godot_view) {
 }
 
 bool GodotJavaViewWrapper::can_update_pointer_icon() const {
-	return _set_pointer_icon != nullptr;
+	return _configure_pointer_icon != nullptr && _set_pointer_icon != nullptr;
 }
 
 bool GodotJavaViewWrapper::can_capture_pointer() const {
@@ -71,6 +72,16 @@ void GodotJavaViewWrapper::release_pointer_capture() {
 		ERR_FAIL_NULL(env);
 
 		env->CallVoidMethod(_godot_view, _release_pointer_capture);
+	}
+}
+
+void GodotJavaViewWrapper::configure_pointer_icon(int pointer_type, const String &image_path, const Vector2 &p_hotspot) {
+	if (_configure_pointer_icon != nullptr) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL(env);
+
+		jstring jImagePath = env->NewStringUTF(image_path.utf8().get_data());
+		env->CallVoidMethod(_godot_view, _configure_pointer_icon, pointer_type, jImagePath, p_hotspot.x, p_hotspot.y);
 	}
 }
 

--- a/platform/android/java_godot_view_wrapper.h
+++ b/platform/android/java_godot_view_wrapper.h
@@ -31,6 +31,7 @@
 #ifndef JAVA_GODOT_VIEW_WRAPPER_H
 #define JAVA_GODOT_VIEW_WRAPPER_H
 
+#include "core/math/vector2.h"
 #include <android/log.h>
 #include <jni.h>
 
@@ -44,6 +45,8 @@ private:
 
 	jmethodID _request_pointer_capture = 0;
 	jmethodID _release_pointer_capture = 0;
+
+	jmethodID _configure_pointer_icon = 0;
 	jmethodID _set_pointer_icon = 0;
 
 public:
@@ -54,6 +57,8 @@ public:
 
 	void request_pointer_capture();
 	void release_pointer_capture();
+
+	void configure_pointer_icon(int pointer_type, const String &image_path, const Vector2 &p_hotspot);
 	void set_pointer_icon(int pointer_type);
 
 	~GodotJavaViewWrapper();

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -82,6 +82,9 @@ GodotJavaWrapper::GodotJavaWrapper(JNIEnv *p_env, jobject p_activity, jobject p_
 	_on_godot_main_loop_started = p_env->GetMethodID(godot_class, "onGodotMainLoopStarted", "()V");
 	_create_new_godot_instance = p_env->GetMethodID(godot_class, "createNewGodotInstance", "([Ljava/lang/String;)I");
 	_get_render_view = p_env->GetMethodID(godot_class, "getRenderView", "()Lorg/godotengine/godot/GodotView;");
+	_begin_benchmark_measure = p_env->GetMethodID(godot_class, "beginBenchmarkMeasure", "(Ljava/lang/String;)V");
+	_end_benchmark_measure = p_env->GetMethodID(godot_class, "endBenchmarkMeasure", "(Ljava/lang/String;)V");
+	_dump_benchmark = p_env->GetMethodID(godot_class, "dumpBenchmark", "(Ljava/lang/String;)V");
 
 	// get some Activity method pointers...
 	_get_class_loader = p_env->GetMethodID(activity_class, "getClassLoader", "()Ljava/lang/ClassLoader;");
@@ -384,5 +387,32 @@ int GodotJavaWrapper::create_new_godot_instance(List<String> args) {
 		return env->CallIntMethod(godot_instance, _create_new_godot_instance, jargs);
 	} else {
 		return 0;
+	}
+}
+
+void GodotJavaWrapper::begin_benchmark_measure(const String &p_label) {
+	if (_begin_benchmark_measure) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL(env);
+		jstring j_label = env->NewStringUTF(p_label.utf8().get_data());
+		env->CallVoidMethod(godot_instance, _begin_benchmark_measure, j_label);
+	}
+}
+
+void GodotJavaWrapper::end_benchmark_measure(const String &p_label) {
+	if (_end_benchmark_measure) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL(env);
+		jstring j_label = env->NewStringUTF(p_label.utf8().get_data());
+		env->CallVoidMethod(godot_instance, _end_benchmark_measure, j_label);
+	}
+}
+
+void GodotJavaWrapper::dump_benchmark(const String &benchmark_file) {
+	if (_dump_benchmark) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL(env);
+		jstring j_benchmark_file = env->NewStringUTF(benchmark_file.utf8().get_data());
+		env->CallVoidMethod(godot_instance, _dump_benchmark, j_benchmark_file);
 	}
 }

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -76,6 +76,9 @@ private:
 	jmethodID _get_class_loader = nullptr;
 	jmethodID _create_new_godot_instance = nullptr;
 	jmethodID _get_render_view = nullptr;
+	jmethodID _begin_benchmark_measure = nullptr;
+	jmethodID _end_benchmark_measure = nullptr;
+	jmethodID _dump_benchmark = nullptr;
 
 public:
 	GodotJavaWrapper(JNIEnv *p_env, jobject p_activity, jobject p_godot_instance);
@@ -113,6 +116,9 @@ public:
 	void vibrate(int p_duration_ms);
 	String get_input_fallback_mapping();
 	int create_new_godot_instance(List<String> args);
+	void begin_benchmark_measure(const String &p_label);
+	void end_benchmark_measure(const String &p_label);
+	void dump_benchmark(const String &benchmark_file);
 };
 
 #endif // JAVA_GODOT_WRAPPER_H

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -163,8 +163,11 @@ public:
 	virtual void hide_virtual_keyboard();
 	virtual int get_virtual_keyboard_height() const;
 
+	void _set_cursor_shape_helper(CursorShape p_shape, bool force = false);
 	virtual void set_cursor_shape(CursorShape p_shape);
 	virtual CursorShape get_cursor_shape() const;
+	virtual void set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot);
+
 	virtual void set_mouse_mode(MouseMode p_mode);
 	virtual MouseMode get_mouse_mode() const;
 
@@ -216,6 +219,10 @@ public:
 
 	virtual Error execute(const String &p_path, const List<String> &p_arguments, bool p_blocking = true, ProcessID *r_child_id = nullptr, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr, bool p_open_console = false);
 	virtual Error kill(const ProcessID &p_pid);
+
+	virtual void benchmark_begin_measure(const String &p_what);
+	virtual void benchmark_end_measure(const String &p_what);
+	virtual void benchmark_dump();
 
 	virtual bool _check_internal_feature_support(const String &p_feature);
 	OS_Android(GodotJavaWrapper *p_godot_java, GodotIOJavaWrapper *p_godot_io_java, bool p_use_apk_expansion);


### PR DESCRIPTION
Add benchmarking measuring methods to `OS` to allow for platform specific overrides which can be used to hook into platform specific benchmarking and tracing capabilities.

On Android for example, this allows to hook into the Android SDK tracing APIs, which can be used with tools like [systrace](https://developer.android.com/topic/performance/tracing/command-line).

- Opening the Godot Android Editor project manager on a Pixel 5:
```
I/GodotBenchmark: BENCHMARK:
    	- Godot::onCreate : 0.068 sec.
    	- core : 0.072 sec.
    	- create_custom_theme : 2.171 sec.
    	- create_editor_theme : 2.171 sec.
    	- editor_register_and_generate_icons_all : 0.417 sec.
    	- editor_register_fonts : 1.727 sec.
    	- project_manager : 2.338 sec.
    	- startup_begin : 3.213 sec.
```

- Opening a project in the Godot Android Editor on a Pixel 5:
```
I/GodotBenchmark: BENCHMARK:
    	- Godot::onCreate : 0.043 sec.
    	- core : 0.049 sec.
    	- create_custom_theme : 2.002 sec.
    	- create_editor_theme : 2.001 sec.
    	- editor : 5.914 sec.
    	- editor_load_scene : 0.275 sec.
    	- editor_register_and_generate_icons_all : 0.343 sec.
    	- editor_register_fonts : 1.639 sec.
    	- startup_begin : 6.551 sec.
```

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
