### PR TITLE
Fix shader include dependency handling

### DIFF
--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -42,9 +42,12 @@ Shader::Mode Shader::get_mode() const {
 }
 
 void Shader::_dependency_changed() {
-	RenderingServer::get_singleton()->shader_set_code(shader, RenderingServer::get_singleton()->shader_get_code(shader));
+	// Preprocess and compile the code again because a dependency has changed. It also calls emit_changed() for us.
+	_recompile();
+}
 
-	emit_changed();
+void Shader::_recompile() {
+	set_code(get_code());
 }
 
 void Shader::set_path(const String &p_path, bool p_take_over) {

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -60,6 +60,7 @@ private:
 	HashMap<StringName, HashMap<int, Ref<Texture2D>>> default_textures;
 
 	void _dependency_changed();
+	void _recompile();
 	virtual void _update_shader() const; //used for visual shader
 	Array _get_shader_uniform_list(bool p_get_groups = false);
 


### PR DESCRIPTION
Fix OP case in https://github.com/godotengine/godot/issues/66075

When an include dependency changed, the shader code was sent to the render server but preprocessing step was never done after the first time.  However, viewing the code in the shader text editor or otherwise updating it directly forced a preprocessing and a dependency update.

Should fix the reported issue and probably other issues @TokisanGames reported in the same thread.