### PR TITLE
Editor: Handle null in ThemeEditor

### DIFF
--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -3335,8 +3335,11 @@ void ThemeTypeEditor::set_edited_theme(const Ref<Theme> &p_theme) {
 	}
 
 	edited_theme = p_theme;
-	edited_theme->connect("changed", callable_mp(this, &ThemeTypeEditor::_update_type_list_debounced));
-	_update_type_list();
+
+	if (edited_theme.is_valid()) {
+		edited_theme->connect("changed", callable_mp(this, &ThemeTypeEditor::_update_type_list_debounced));
+		_update_type_list();
+	}
 
 	add_type_dialog->set_edited_theme(edited_theme);
 }
@@ -3496,7 +3499,9 @@ void ThemeEditor::edit(const Ref<Theme> &p_theme) {
 		preview_tab->set_preview_theme(p_theme);
 	}
 
-	theme_name->set_text(TTR("Theme:") + " " + theme->get_path().get_file());
+	if (theme.is_valid()) {
+		theme_name->set_text(TTR("Theme:") + " " + theme->get_path().get_file());
+	}
 }
 
 Ref<Theme> ThemeEditor::get_edited_theme() {


### PR DESCRIPTION
Connected to #71770.

Handle null in `ThemeEditor::edit` and `ThemeTypeEditor::set_edited_theme` to prevent a crash.

In `ThemeTypeEditor` if the theme is not null then `_update_type_list` is called. I assume that there is no need to call some clean up for that if the theme is null (like `theme_type_list->clear()`), right?