### PR TITLE
Fix autocomplete filter not including substrings

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -3088,6 +3088,8 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 	}
 
 	code_completion_options.append_array(completion_options_casei);
+	code_completion_options.append_array(completion_options_substr);
+	code_completion_options.append_array(completion_options_substr_casei);
 	code_completion_options.append_array(completion_options_subseq);
 	code_completion_options.append_array(completion_options_subseq_casei);
 


### PR DESCRIPTION
Fixes #71298

The filtering for all auto-complete suggestions filters by exact matches, substrings, and subsequences. However, substring matches weren't being appended to the final array, so their results weren't being shown.

While the specific issue mentioned is about auto-completion for `$`/`get_node`, this PR applies to all types of auto-completion.

Before:
![image](https://user-images.githubusercontent.com/74857873/213967742-649ab07c-b561-4acc-90a5-1048b660a54f.png)

Fixed:
![image](https://user-images.githubusercontent.com/74857873/213967575-2065bcc7-9c54-496e-a0f0-56696693f87e.png)