### PR TITLE
Fix duplicating imported blendshape tracks

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6072,6 +6072,7 @@ void GLTFDocument::_import_animation(Ref<GLTFState> p_state, AnimationPlayer *p_
 			const int track_idx = animation->get_track_count();
 			animation->add_track(Animation::TYPE_BLEND_SHAPE);
 			animation->track_set_path(track_idx, blend_path);
+			animation->track_set_imported(track_idx, true); //helps merging later
 
 			// Only LINEAR and STEP (NEAREST) can be supported out of the box by Godot's Animation,
 			// the other modes have to be baked.


### PR DESCRIPTION
Prevents blendshape tracks from creating duplicates by setting the 'imported' flag when importing from a GLTF.

Closes #68588