### PR TITLE
Add handling of script creation/deletion for custom visual shader nodes

### DIFF
--- a/doc/classes/FileSystemDock.xml
+++ b/doc/classes/FileSystemDock.xml
@@ -51,5 +51,10 @@
 			<description>
 			</description>
 		</signal>
+		<signal name="resource_removed">
+			<param index="0" name="resource" type="Resource" />
+			<description>
+			</description>
+		</signal>
 	</signals>
 </class>

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -536,12 +536,17 @@ void DependencyRemoveDialog::show(const Vector<String> &p_folders, const Vector<
 }
 
 void DependencyRemoveDialog::ok_pressed() {
-	for (int i = 0; i < files_to_delete.size(); ++i) {
-		if (ResourceCache::has(files_to_delete[i])) {
-			Ref<Resource> res = ResourceCache::get_ref(files_to_delete[i]);
+	for (const KeyValue<String, String> &E : all_remove_files) {
+		String file = E.key;
+
+		if (ResourceCache::has(file)) {
+			Ref<Resource> res = ResourceCache::get_ref(file);
+			emit_signal(SNAME("resource_removed"), res);
 			res->set_path("");
 		}
+	}
 
+	for (int i = 0; i < files_to_delete.size(); ++i) {
 		// If the file we are deleting for e.g. the main scene, default environment,
 		// or audio bus layout, we must clear its definition in Project Settings.
 		if (files_to_delete[i] == String(GLOBAL_GET("application/config/icon"))) {
@@ -621,6 +626,7 @@ void DependencyRemoveDialog::ok_pressed() {
 }
 
 void DependencyRemoveDialog::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("resource_removed", PropertyInfo(Variant::OBJECT, "obj")));
 	ADD_SIGNAL(MethodInfo("file_removed", PropertyInfo(Variant::STRING, "file")));
 	ADD_SIGNAL(MethodInfo("folder_removed", PropertyInfo(Variant::STRING, "folder")));
 }

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1531,6 +1531,10 @@ void FileSystemDock::_make_scene_confirm() {
 	EditorNode::get_singleton()->save_scene_list({ scene_path });
 }
 
+void FileSystemDock::_resource_removed(const Ref<Resource> &p_resource) {
+	emit_signal(SNAME("resource_removed"), p_resource);
+}
+
 void FileSystemDock::_file_removed(String p_file) {
 	emit_signal(SNAME("file_removed"), p_file);
 
@@ -3077,6 +3081,7 @@ void FileSystemDock::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("inherit", PropertyInfo(Variant::STRING, "file")));
 	ADD_SIGNAL(MethodInfo("instantiate", PropertyInfo(Variant::PACKED_STRING_ARRAY, "files")));
 
+	ADD_SIGNAL(MethodInfo("resource_removed", PropertyInfo(Variant::OBJECT, "resource", PROPERTY_HINT_RESOURCE_TYPE, "Resource")));
 	ADD_SIGNAL(MethodInfo("file_removed", PropertyInfo(Variant::STRING, "file")));
 	ADD_SIGNAL(MethodInfo("folder_removed", PropertyInfo(Variant::STRING, "folder")));
 	ADD_SIGNAL(MethodInfo("files_moved", PropertyInfo(Variant::STRING, "old_file"), PropertyInfo(Variant::STRING, "new_file")));
@@ -3235,6 +3240,7 @@ FileSystemDock::FileSystemDock() {
 	add_child(owners_editor);
 
 	remove_dialog = memnew(DependencyRemoveDialog);
+	remove_dialog->connect("resource_removed", callable_mp(this, &FileSystemDock::_resource_removed));
 	remove_dialog->connect("file_removed", callable_mp(this, &FileSystemDock::_file_removed));
 	remove_dialog->connect("folder_removed", callable_mp(this, &FileSystemDock::_folder_removed));
 	add_child(remove_dialog);

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -227,6 +227,7 @@ private:
 	void _update_favorites_list_after_move(const HashMap<String, String> &p_files_renames, const HashMap<String, String> &p_folders_renames) const;
 	void _update_project_settings_after_move(const HashMap<String, String> &p_renames) const;
 
+	void _resource_removed(const Ref<Resource> &p_resource);
 	void _file_removed(String p_file);
 	void _folder_removed(String p_folder);
 

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -188,6 +188,9 @@ class VisualShaderEditor : public VBoxContainer {
 	PanelContainer *error_panel = nullptr;
 	Label *error_label = nullptr;
 
+	bool pending_custom_scripts_to_delete = false;
+	List<Ref<Script>> custom_scripts_to_delete;
+
 	bool _block_update_options_menu = false;
 	bool _block_rebuild_shader = false;
 
@@ -503,6 +506,13 @@ class VisualShaderEditor : public VBoxContainer {
 
 	void _visibility_changed();
 
+	void _get_current_mode_limits(int &r_begin_type, int &r_end_type) const;
+	void _update_custom_script(const Ref<Script> &p_script);
+	void _script_created(const Ref<Script> &p_script);
+	void _resource_saved(const Ref<Resource> &p_resource);
+	void _resource_removed(const Ref<Resource> &p_resource);
+	void _resources_removed();
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -517,7 +527,6 @@ public:
 	void add_custom_type(const String &p_name, const Ref<Script> &p_script, const String &p_description, int p_return_icon_type, const String &p_category, bool p_highend);
 
 	Dictionary get_custom_node_data(Ref<VisualShaderNodeCustom> &p_custom_node);
-	void update_custom_type(const Ref<Resource> &p_resource);
 
 	virtual Size2 get_minimum_size() const override;
 	void edit(VisualShader *p_visual_shader);


### PR DESCRIPTION
Continuation of https://github.com/godotengine/godot/pull/69738. This PR will add updating of the visual shader editor at the custom visual shader script creation or removal from the FileSystem:

![vs_custom_nodes](https://user-images.githubusercontent.com/3036176/214001305-3a19ebbf-7e22-4c07-9852-178ae03540c3.gif)
