### PR TITLE
Simplify AudioStreamPolyphonic

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -391,10 +391,8 @@ bool AudioStreamPlayer2D::get_stream_paused() const {
 }
 
 Ref<AudioStreamPlayback> AudioStreamPlayer2D::get_stream_playback() {
-	if (!stream_playbacks.is_empty()) {
-		return stream_playbacks[stream_playbacks.size() - 1];
-	}
-	return nullptr;
+	ERR_FAIL_COND_V_MSG(stream_playbacks.is_empty(), Ref<AudioStreamPlayback>(), "Player is inactive. Call play() before requesting get_stream_playback().");
+	return stream_playbacks[stream_playbacks.size() - 1];
 }
 
 void AudioStreamPlayer2D::set_max_polyphony(int p_max_polyphony) {

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -784,10 +784,8 @@ bool AudioStreamPlayer3D::get_stream_paused() const {
 }
 
 Ref<AudioStreamPlayback> AudioStreamPlayer3D::get_stream_playback() {
-	if (!stream_playbacks.is_empty()) {
-		return stream_playbacks[stream_playbacks.size() - 1];
-	}
-	return nullptr;
+	ERR_FAIL_COND_V_MSG(stream_playbacks.is_empty(), Ref<AudioStreamPlayback>(), "Player is inactive. Call play() before requesting get_stream_playback().");
+	return stream_playbacks[stream_playbacks.size() - 1];
 }
 
 void AudioStreamPlayer3D::set_max_polyphony(int p_max_polyphony) {

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -308,10 +308,8 @@ void AudioStreamPlayer::_bus_layout_changed() {
 }
 
 Ref<AudioStreamPlayback> AudioStreamPlayer::get_stream_playback() {
-	if (!stream_playbacks.is_empty()) {
-		return stream_playbacks[stream_playbacks.size() - 1];
-	}
-	return nullptr;
+	ERR_FAIL_COND_V_MSG(stream_playbacks.is_empty(), Ref<AudioStreamPlayback>(), "Player is inactive. Call play() before requesting get_stream_playback().");
+	return stream_playbacks[stream_playbacks.size() - 1];
 }
 
 void AudioStreamPlayer::_bind_methods() {

--- a/scene/resources/audio_stream_polyphonic.h
+++ b/scene/resources/audio_stream_polyphonic.h
@@ -63,7 +63,6 @@ class AudioStreamPlaybackPolyphonic : public AudioStreamPlayback {
 		SafeFlag active;
 		SafeFlag pending_play;
 		SafeFlag finish_request;
-		SafeFlag finalizing;
 		float play_offset = 0;
 		float pitch_scale = 1.0;
 		Ref<AudioStream> stream;
@@ -73,7 +72,7 @@ class AudioStreamPlaybackPolyphonic : public AudioStreamPlayback {
 		uint32_t id = 0;
 
 		Stream() :
-				active(false), pending_play(false), finish_request(false), finalizing(false) {}
+				active(false), pending_play(false), finish_request(false) {}
 	};
 
 	LocalVector<Stream> streams;
@@ -83,8 +82,6 @@ class AudioStreamPlaybackPolyphonic : public AudioStreamPlayback {
 	uint32_t id_counter = 1;
 
 	_FORCE_INLINE_ Stream *_find_stream(int64_t p_id);
-
-	void _check_finalized_streams();
 
 	friend class AudioStreamPolyphonic;
 


### PR DESCRIPTION
* Make AudioStreamPolyphonic not requre a polling thread (simpler, faster)
* Improve error reporting in AudioStreamPlayer*::get_stream_playback() error reporting to improve usability.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
