### PR TITLE
Make `AnimatedSprite`'s playback API consistent with `AnimationPlayer`

### DIFF
--- a/doc/classes/AnimatedSprite2D.xml
+++ b/doc/classes/AnimatedSprite2D.xml
@@ -5,34 +5,82 @@
 	</brief_description>
 	<description>
 		[AnimatedSprite2D] is similar to the [Sprite2D] node, except it carries multiple textures as animation frames. Animations are created using a [SpriteFrames] resource, which allows you to import image files (or a folder containing said files) to provide the animation frames for the sprite. The [SpriteFrames] resource can be configured in the editor via the SpriteFrames bottom panel.
-		After setting up [member frames], [method play] may be called. It's also possible to select an [member animation] and toggle [member playing], even within the editor.
-		To pause the current animation, set [member playing] to [code]false[/code]. Alternatively, setting [member speed_scale] to [code]0[/code] also preserves the current frame's elapsed time.
 	</description>
 	<tutorials>
 		<link title="2D Sprite animation">$DOCS_URL/tutorials/2d/2d_sprite_animation.html</link>
 		<link title="2D Dodge The Creeps Demo">https://godotengine.org/asset-library/asset/515</link>
 	</tutorials>
 	<methods>
+		<method name="get_playing_speed" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the actual playing speed of current animation or [code]0[/code] if not playing. This speed is the [member speed_scale] property multiplied by [code]custom_speed[/code] argument specified when calling the [method play] method.
+				Returns a negative value if the current animation is playing backwards.
+			</description>
+		</method>
+		<method name="is_playing" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if an animation is currently playing (even if [member speed_scale] and/or [code]custom_speed[/code] are [code]0[/code]).
+			</description>
+		</method>
+		<method name="pause">
+			<return type="void" />
+			<description>
+				Pauses the currently playing animation. The [member frame] and [member frame_progress] will be kept and calling [method play] or [method play_backwards] without arguments will resume the animation from the current playback position.
+				See also [method stop].
+			</description>
+		</method>
 		<method name="play">
 			<return type="void" />
-			<param index="0" name="anim" type="StringName" default="&amp;&quot;&quot;" />
-			<param index="1" name="backwards" type="bool" default="false" />
+			<param index="0" name="name" type="StringName" default="&amp;&quot;&quot;" />
+			<param index="1" name="custom_speed" type="float" default="1.0" />
+			<param index="2" name="from_end" type="bool" default="false" />
 			<description>
-				Plays the animation named [param anim]. If no [param anim] is provided, the current animation is played. If [param backwards] is [code]true[/code], the animation is played in reverse.
-				[b]Note:[/b] If [member speed_scale] is negative, the animation direction specified by [param backwards] will be inverted.
+				Plays the animation with key [param name]. If [param custom_speed] is negative and [param from_end] is [code]true[/code], the animation will play backwards (which is equivalent to calling [method play_backwards]).
+				If this method is called with that same animation [param name], or with no [param name] parameter, the assigned animation will resume playing if it was paused.
+			</description>
+		</method>
+		<method name="play_backwards">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" default="&amp;&quot;&quot;" />
+			<description>
+				Plays the animation with key [param name] in reverse.
+				This method is a shorthand for [method play] with [code]custom_speed = -1.0[/code] and [code]from_end = true[/code], so see its description for more information.
+			</description>
+		</method>
+		<method name="set_frame_and_progress">
+			<return type="void" />
+			<param index="0" name="frame" type="int" />
+			<param index="1" name="progress" type="float" />
+			<description>
+				The setter of [member frame] resets the [member frame_progress] to [code]0.0[/code] implicitly, but this method avoids that.
+				This is useful when you want to carry over the current [member frame_progress] to another [member frame].
+				[b]Example:[/b]
+				[codeblocks]
+				[gdscript]
+				# Change the animation with keeping the frame index and progress.
+				var current_frame = animated_sprite.get_frame()
+				var current_progress = animated_sprite.get_frame_progress()
+				animated_sprite.play("walk_another_skin")
+				animated_sprite.set_frame_and_progress(current_frame, current_progress)
+				[/gdscript]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="stop">
 			<return type="void" />
 			<description>
-				Stops the current [member animation] at the current [member frame].
-				[b]Note:[/b] This method resets the current frame's elapsed time and removes the [code]backwards[/code] flag from the current [member animation] (if it was previously set by [method play]). If this behavior is undesired, set [member playing] to [code]false[/code] instead.
+				Stops the currently playing animation. The animation position is reset to [code]0[/code] and the [code]custom_speed[/code] is reset to [code]1.0[/code]. See also [method pause].
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="animation" type="StringName" setter="set_animation" getter="get_animation" default="&amp;&quot;default&quot;">
-			The current animation from the [member frames] resource. If this value changes, the [code]frame[/code] counter is reset.
+			The current animation from the [member sprite_frames] resource. If this value is changed, the [member frame] counter and the [member frame_progress] are reset.
+		</member>
+		<member name="autoplay" type="String" setter="set_autoplay" getter="get_autoplay" default="&quot;&quot;">
+			The key of the animation to play when the scene loads.
 		</member>
 		<member name="centered" type="bool" setter="set_centered" getter="is_centered" default="true">
 			If [code]true[/code], texture will be centered.
@@ -44,32 +92,46 @@
 			If [code]true[/code], texture is flipped vertically.
 		</member>
 		<member name="frame" type="int" setter="set_frame" getter="get_frame" default="0">
-			The displayed animation frame's index.
+			The displayed animation frame's index. Setting this property also resets [member frame_progress]. If this is not desired, use [method set_frame_and_progress].
 		</member>
-		<member name="frames" type="SpriteFrames" setter="set_sprite_frames" getter="get_sprite_frames">
-			The [SpriteFrames] resource containing the animation(s). Allows you the option to load, edit, clear, make unique and save the states of the [SpriteFrames] resource.
+		<member name="frame_progress" type="float" setter="set_frame_progress" getter="get_frame_progress" default="0.0">
+			The progress value between [code]0.0[/code] and [code]1.0[/code] until the current frame transitions to the next frame. If the animation is playing backwards, the value transitions from [code]1.0[/code] to [code]0.0[/code].
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The texture's drawing offset.
 		</member>
-		<member name="playing" type="bool" setter="set_playing" getter="is_playing" default="false">
-			If [code]true[/code], the [member animation] is currently playing. Setting this property to [code]false[/code] pauses the current animation. Use [method stop] to stop the animation at the current frame instead.
-			[b]Note:[/b] Unlike [method stop], changing this property to [code]false[/code] preserves the current frame's elapsed time and the [code]backwards[/code] flag of the current [member animation] (if it was previously set by [method play]).
-			[b]Note:[/b] After a non-looping animation finishes, the property still remains [code]true[/code].
-		</member>
 		<member name="speed_scale" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
-			The animation speed is multiplied by this value. If set to a negative value, the animation is played in reverse. If set to [code]0[/code], the animation is paused, preserving the current frame's elapsed time.
+			The speed scaling ratio. For example, if this value is [code]1[/code], then the animation plays at normal speed. If it's [code]0.5[/code], then it plays at half speed. If it's [code]2[/code], then it plays at double speed.
+			If set to a negative value, the animation is played in reverse. If set to [code]0[/code], the animation will not advance.
+		</member>
+		<member name="sprite_frames" type="SpriteFrames" setter="set_sprite_frames" getter="get_sprite_frames">
+			The [SpriteFrames] resource containing the animation(s). Allows you the option to load, edit, clear, make unique and save the states of the [SpriteFrames] resource.
 		</member>
 	</members>
 	<signals>
+		<signal name="animation_changed">
+			<description>
+				Emitted when [member animation] changes.
+			</description>
+		</signal>
 		<signal name="animation_finished">
 			<description>
-				Emitted when the animation reaches the end, or the start if it is played in reverse. If the animation is looping, this signal is emitted at the end of each loop.
+				Emitted when the animation reaches the end, or the start if it is played in reverse. When the animation finishes, it pauses the playback.
+			</description>
+		</signal>
+		<signal name="animation_looped">
+			<description>
+				Emitted when the animation loops.
 			</description>
 		</signal>
 		<signal name="frame_changed">
 			<description>
-				Emitted when [member frame] changed.
+				Emitted when [member frame] changes.
+			</description>
+		</signal>
+		<signal name="sprite_frames_changed">
+			<description>
+				Emitted when [member sprite_frames] changes.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/AnimatedSprite3D.xml
+++ b/doc/classes/AnimatedSprite3D.xml
@@ -4,59 +4,121 @@
 		2D sprite node in 3D world, that can use multiple 2D textures for animation.
 	</brief_description>
 	<description>
-		[AnimatedSprite3D] is similar to the [Sprite3D] node, except it carries multiple textures as animation [member frames]. Animations are created using a [SpriteFrames] resource, which allows you to import image files (or a folder containing said files) to provide the animation frames for the sprite. The [SpriteFrames] resource can be configured in the editor via the SpriteFrames bottom panel.
-		After setting up [member frames], [method play] may be called. It's also possible to select an [member animation] and toggle [member playing], even within the editor.
-		To pause the current animation, set [member playing] to [code]false[/code]. Alternatively, setting [member speed_scale] to [code]0[/code] also preserves the current frame's elapsed time.
+		[AnimatedSprite3D] is similar to the [Sprite3D] node, except it carries multiple textures as animation [member sprite_frames]. Animations are created using a [SpriteFrames] resource, which allows you to import image files (or a folder containing said files) to provide the animation frames for the sprite. The [SpriteFrames] resource can be configured in the editor via the SpriteFrames bottom panel.
 	</description>
 	<tutorials>
 		<link title="2D Sprite animation (also applies to 3D)">$DOCS_URL/tutorials/2d/2d_sprite_animation.html</link>
 	</tutorials>
 	<methods>
+		<method name="get_playing_speed" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the actual playing speed of current animation or [code]0[/code] if not playing. This speed is the [member speed_scale] property multiplied by [code]custom_speed[/code] argument specified when calling the [method play] method.
+				Returns a negative value if the current animation is playing backwards.
+			</description>
+		</method>
+		<method name="is_playing" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if an animation is currently playing (even if [member speed_scale] and/or [code]custom_speed[/code] are [code]0[/code]).
+			</description>
+		</method>
+		<method name="pause">
+			<return type="void" />
+			<description>
+				Pauses the currently playing animation. The [member frame] and [member frame_progress] will be kept and calling [method play] or [method play_backwards] without arguments will resume the animation from the current playback position.
+				See also [method stop].
+			</description>
+		</method>
 		<method name="play">
 			<return type="void" />
-			<param index="0" name="anim" type="StringName" default="&amp;&quot;&quot;" />
-			<param index="1" name="backwards" type="bool" default="false" />
+			<param index="0" name="name" type="StringName" default="&amp;&quot;&quot;" />
+			<param index="1" name="custom_speed" type="float" default="1.0" />
+			<param index="2" name="from_end" type="bool" default="false" />
 			<description>
-				Plays the animation named [param anim]. If no [param anim] is provided, the current animation is played. If [param backwards] is [code]true[/code], the animation is played in reverse.
-				[b]Note:[/b] If [member speed_scale] is negative, the animation direction specified by [param backwards] will be inverted.
+				Plays the animation with key [param name]. If [param custom_speed] is negative and [param from_end] is [code]true[/code], the animation will play backwards (which is equivalent to calling [method play_backwards]).
+				If this method is called with that same animation [param name], or with no [param name] parameter, the assigned animation will resume playing if it was paused.
+			</description>
+		</method>
+		<method name="play_backwards">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" default="&amp;&quot;&quot;" />
+			<description>
+				Plays the animation with key [param name] in reverse.
+				This method is a shorthand for [method play] with [code]custom_speed = -1.0[/code] and [code]from_end = true[/code], so see its description for more information.
+			</description>
+		</method>
+		<method name="set_frame_and_progress">
+			<return type="void" />
+			<param index="0" name="frame" type="int" />
+			<param index="1" name="progress" type="float" />
+			<description>
+				The setter of [member frame] resets the [member frame_progress] to [code]0.0[/code] implicitly, but this method avoids that.
+				This is useful when you want to carry over the current [member frame_progress] to another [member frame].
+				[b]Example:[/b]
+				[codeblocks]
+				[gdscript]
+				# Change the animation with keeping the frame index and progress.
+				var current_frame = animated_sprite.get_frame()
+				var current_progress = animated_sprite.get_frame_progress()
+				animated_sprite.play("walk_another_skin")
+				animated_sprite.set_frame_and_progress(current_frame, current_progress)
+				[/gdscript]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="stop">
 			<return type="void" />
 			<description>
-				Stops the current [member animation] at the current [member frame].
-				[b]Note:[/b] This method resets the current frame's elapsed time and removes the [code]backwards[/code] flag from the current [member animation] (if it was previously set by [method play]). If this behavior is undesired, set [member playing] to [code]false[/code] instead.
+				Stops the currently playing animation. The animation position is reset to [code]0[/code] and the [code]custom_speed[/code] is reset to [code]1.0[/code]. See also [method pause].
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="animation" type="StringName" setter="set_animation" getter="get_animation" default="&amp;&quot;default&quot;">
-			The current animation from the [code]frames[/code] resource. If this value changes, the [code]frame[/code] counter is reset.
+			The current animation from the [member sprite_frames] resource. If this value is changed, the [member frame] counter and the [member frame_progress] are reset.
+		</member>
+		<member name="autoplay" type="String" setter="set_autoplay" getter="get_autoplay" default="&quot;&quot;">
+			The key of the animation to play when the scene loads.
 		</member>
 		<member name="frame" type="int" setter="set_frame" getter="get_frame" default="0">
-			The displayed animation frame's index.
+			The displayed animation frame's index. Setting this property also resets [member frame_progress]. If this is not desired, use [method set_frame_and_progress].
 		</member>
-		<member name="frames" type="SpriteFrames" setter="set_sprite_frames" getter="get_sprite_frames">
-			The [SpriteFrames] resource containing the animation(s).
-		</member>
-		<member name="playing" type="bool" setter="set_playing" getter="is_playing" default="false">
-			If [code]true[/code], the [member animation] is currently playing. Setting this property to [code]false[/code] pauses the current animation. Use [method stop] to stop the animation at the current frame instead.
-			[b]Note:[/b] Unlike [method stop], changing this property to [code]false[/code] preserves the current frame's elapsed time and the [code]backwards[/code] flag of the current [member animation] (if it was previously set by [method play]).
-			[b]Note:[/b] After a non-looping animation finishes, the property still remains [code]true[/code].
+		<member name="frame_progress" type="float" setter="set_frame_progress" getter="get_frame_progress" default="0.0">
+			The progress value between [code]0.0[/code] and [code]1.0[/code] until the current frame transitions to the next frame. If the animation is playing backwards, the value transitions from [code]1.0[/code] to [code]0.0[/code].
 		</member>
 		<member name="speed_scale" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
-			The animation speed is multiplied by this value. If set to a negative value, the animation is played in reverse. If set to [code]0[/code], the animation is paused, preserving the current frame's elapsed time.
+			The speed scaling ratio. For example, if this value is [code]1[/code], then the animation plays at normal speed. If it's [code]0.5[/code], then it plays at half speed. If it's [code]2[/code], then it plays at double speed.
+			If set to a negative value, the animation is played in reverse. If set to [code]0[/code], the animation will not advance.
+		</member>
+		<member name="sprite_frames" type="SpriteFrames" setter="set_sprite_frames" getter="get_sprite_frames">
+			The [SpriteFrames] resource containing the animation(s). Allows you the option to load, edit, clear, make unique and save the states of the [SpriteFrames] resource.
 		</member>
 	</members>
 	<signals>
+		<signal name="animation_changed">
+			<description>
+				Emitted when [member animation] changes.
+			</description>
+		</signal>
 		<signal name="animation_finished">
 			<description>
-				Emitted when the animation reaches the end, or the start if it is played in reverse. If the animation is looping, this signal is emitted at the end of each loop.
+				Emitted when the animation reaches the end, or the start if it is played in reverse. When the animation finishes, it pauses the playback.
+			</description>
+		</signal>
+		<signal name="animation_looped">
+			<description>
+				Emitted when the animation loops.
 			</description>
 		</signal>
 		<signal name="frame_changed">
 			<description>
-				Emitted when [member frame] changed.
+				Emitted when [member frame] changes.
+			</description>
+		</signal>
+		<signal name="sprite_frames_changed">
+			<description>
+				Emitted when [member sprite_frames] changes.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -102,13 +102,14 @@
 			<param index="0" name="anim_from" type="StringName" />
 			<param index="1" name="anim_to" type="StringName" />
 			<description>
-				Gets the blend time (in seconds) between two animations, referenced by their keys.
+				Returns the blend time (in seconds) between two animations, referenced by their keys.
 			</description>
 		</method>
 		<method name="get_playing_speed" qualifiers="const">
 			<return type="float" />
 			<description>
-				Gets the actual playing speed of current animation or 0 if not playing. This speed is the [member playback_speed] property multiplied by [code]custom_speed[/code] argument specified when calling the [method play] method.
+				Returns the actual playing speed of current animation or [code]0[/code] if not playing. This speed is the [member speed_scale] property multiplied by [code]custom_speed[/code] argument specified when calling the [method play] method.
+				Returns a negative value if the current animation is playing backwards.
 			</description>
 		</method>
 		<method name="get_queue">
@@ -134,7 +135,7 @@
 		<method name="is_playing" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if playing an animation.
+				Returns [code]true[/code] if an animation is currently playing (even if [member speed_scale] and/or [code]custom_speed[/code] are [code]0[/code]).
 			</description>
 		</method>
 		<method name="pause">
@@ -152,7 +153,7 @@
 			<param index="3" name="from_end" type="bool" default="false" />
 			<description>
 				Plays the animation with key [param name]. Custom blend times and speed can be set. If [param custom_speed] is negative and [param from_end] is [code]true[/code], the animation will play backwards (which is equivalent to calling [method play_backwards]).
-				The [AnimationPlayer] keeps track of its current or last played animation with [member assigned_animation]. If this method is called with that same animation [param name], or with no [param name] parameter, the assigned animation will resume playing if it was paused, or restart if it was stopped (see [method stop] for both pause and stop). If the animation was already playing, it will keep playing.
+				The [AnimationPlayer] keeps track of its current or last played animation with [member assigned_animation]. If this method is called with that same animation [param name], or with no [param name] parameter, the assigned animation will resume playing if it was paused.
 				[b]Note:[/b] The animation will be updated the next time the [AnimationPlayer] is processed. If other variables are updated at the same time this is called, they may be updated too early. To perform the update immediately, call [code]advance(0)[/code].
 			</description>
 		</method>
@@ -210,7 +211,7 @@
 			<return type="void" />
 			<param index="0" name="keep_state" type="bool" default="false" />
 			<description>
-				Stops the currently playing animation. The animation position is reset to [code]0[/code] and the playback speed is reset to [code]1.0[/code]. See also [method pause].
+				Stops the currently playing animation. The animation position is reset to [code]0[/code] and the [code]custom_speed[/code] is reset to [code]1.0[/code]. See also [method pause].
 				If [param keep_state] is [code]true[/code], the animation state is not updated visually.
 				[b]Note:[/b] The method / audio / animation playback tracks will not be processed by this method.
 			</description>
@@ -249,15 +250,16 @@
 		<member name="playback_process_mode" type="int" setter="set_process_callback" getter="get_process_callback" enum="AnimationPlayer.AnimationProcessCallback" default="1">
 			The process notification in which to update animations.
 		</member>
-		<member name="playback_speed" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
-			The speed scaling ratio. For example, if this value is 1, then the animation plays at normal speed. If it's 0.5, then it plays at half speed. If it's 2, then it plays at double speed.
-		</member>
 		<member name="reset_on_save" type="bool" setter="set_reset_on_save_enabled" getter="is_reset_on_save_enabled" default="true">
 			This is used by the editor. If set to [code]true[/code], the scene will be saved with the effects of the reset animation (the animation with the key [code]"RESET"[/code]) applied as if it had been seeked to time 0, with the editor keeping the values that the scene had before saving.
 			This makes it more convenient to preview and edit animations in the editor, as changes to the scene will not be saved as long as they are set in the reset animation.
 		</member>
 		<member name="root_node" type="NodePath" setter="set_root" getter="get_root" default="NodePath(&quot;..&quot;)">
 			The node from which node path references will travel.
+		</member>
+		<member name="speed_scale" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
+			The speed scaling ratio. For example, if this value is [code]1[/code], then the animation plays at normal speed. If it's [code]0.5[/code], then it plays at half speed. If it's [code]2[/code], then it plays at double speed.
+			If set to a negative value, the animation is played in reverse. If set to [code]0[/code], the animation will not advance.
 		</member>
 	</members>
 	<signals>

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -245,7 +245,7 @@ void AnimationPlayerEditor::_play_bw_pressed() {
 			player->stop(); //so it won't blend with itself
 		}
 		ERR_FAIL_COND_EDMSG(!_validate_tracks(player->get_animation(current)), "Animation tracks may have any invalid key, abort playing.");
-		player->play(current, -1, -1, true);
+		player->play_backwards(current);
 	}
 
 	//unstop
@@ -262,7 +262,7 @@ void AnimationPlayerEditor::_play_bw_from_pressed() {
 		}
 		ERR_FAIL_COND_EDMSG(!_validate_tracks(player->get_animation(current)), "Animation tracks may have any invalid key, abort playing.");
 		player->seek(time);
-		player->play(current, -1, -1, true);
+		player->play_backwards(current);
 	}
 
 	//unstop
@@ -452,7 +452,9 @@ float AnimationPlayerEditor::_get_editor_step() const {
 }
 
 void AnimationPlayerEditor::_animation_name_edited() {
-	player->stop();
+	if (player->is_playing()) {
+		player->stop();
+	}
 
 	String new_name = name->get_text();
 	if (!AnimationLibrary::is_valid_animation_name(new_name)) {
@@ -1675,7 +1677,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 	stop = memnew(Button);
 	stop->set_flat(true);
 	hb->add_child(stop);
-	stop->set_tooltip_text(TTR("Stop animation playback. (S)"));
+	stop->set_tooltip_text(TTR("Pause/stop animation playback. (S)"));
 
 	play = memnew(Button);
 	play->set_flat(true);

--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -33,6 +33,7 @@
 
 #include "editor/editor_plugin.h"
 #include "scene/2d/animated_sprite_2d.h"
+#include "scene/3d/sprite_3d.h"
 #include "scene/gui/button.h"
 #include "scene/gui/check_button.h"
 #include "scene/gui/dialogs.h"
@@ -57,6 +58,9 @@ public:
 class SpriteFramesEditor : public HSplitContainer {
 	GDCLASS(SpriteFramesEditor, HSplitContainer);
 
+	Ref<SpriteFrames> frames;
+	Node *animated_sprite = nullptr;
+
 	enum {
 		PARAM_USE_CURRENT, // Used in callbacks to indicate `dominant_param` should be not updated.
 		PARAM_FRAME_COUNT, // Keep "Horizontal" & "Vertical" values.
@@ -65,6 +69,17 @@ class SpriteFramesEditor : public HSplitContainer {
 	int dominant_param = PARAM_FRAME_COUNT;
 
 	bool read_only = false;
+
+	Ref<Texture2D> autoplay_icon;
+	Ref<Texture2D> stop_icon;
+	Ref<Texture2D> pause_icon;
+
+	HBoxContainer *playback_container = nullptr;
+	Button *stop = nullptr;
+	Button *play = nullptr;
+	Button *play_from = nullptr;
+	Button *play_bw = nullptr;
+	Button *play_bw_from = nullptr;
 
 	Button *load = nullptr;
 	Button *load_sheet = nullptr;
@@ -85,6 +100,8 @@ class SpriteFramesEditor : public HSplitContainer {
 
 	Button *add_anim = nullptr;
 	Button *delete_anim = nullptr;
+	HBoxContainer *autoplay_container = nullptr;
+	Button *autoplay = nullptr;
 	LineEdit *anim_search_box = nullptr;
 
 	Tree *animations = nullptr;
@@ -94,8 +111,6 @@ class SpriteFramesEditor : public HSplitContainer {
 	EditorFileDialog *file = nullptr;
 
 	AcceptDialog *dialog = nullptr;
-
-	SpriteFrames *frames = nullptr;
 
 	StringName edited_anim;
 
@@ -146,7 +161,15 @@ class SpriteFramesEditor : public HSplitContainer {
 	void _frame_duration_changed(double p_value);
 	void _update_library(bool p_skip_selector = false);
 
-	void _animation_select();
+	void _update_stop_icon();
+	void _play_pressed();
+	void _play_from_pressed();
+	void _play_bw_pressed();
+	void _play_bw_from_pressed();
+	void _autoplay_pressed();
+	void _stop_pressed();
+
+	void _animation_selected();
 	void _animation_name_edited();
 	void _animation_add();
 	void _animation_remove();
@@ -183,12 +206,24 @@ class SpriteFramesEditor : public HSplitContainer {
 	void _sheet_zoom_reset();
 	void _sheet_select_clear_all_frames();
 
+	void _edit();
+	void _regist_scene_undo(EditorUndoRedoManager *undo_redo);
+	void _fetch_sprite_node();
+	void _remove_sprite_node();
+
+	bool sprite_node_updating = false;
+	void _sync_animation();
+
+	void _select_animation(const String &p_name, bool p_update_node = true);
+	void _rename_node_animation(EditorUndoRedoManager *undo_redo, bool is_undo, const String &p_filter, const String &p_new_animation, const String &p_new_autoplay);
+
 protected:
 	void _notification(int p_what);
+	void _node_removed(Node *p_node);
 	static void _bind_methods();
 
 public:
-	void edit(SpriteFrames *p_frames);
+	void edit(Ref<SpriteFrames> p_frames);
 	SpriteFramesEditor();
 };
 

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -215,7 +215,6 @@ static const char *gdscript_function_renames[][2] = {
 	{ "_get_configuration_warning", "_get_configuration_warnings" }, // Node
 	{ "_set_current", "set_current" }, // Camera2D
 	{ "_set_editor_description", "set_editor_description" }, // Node
-	{ "_set_playing", "set_playing" }, // AnimatedSprite3D
 	{ "_toplevel_raise_self", "_top_level_raise_self" }, // CanvasItem
 	{ "_update_wrap_at", "_update_wrap_at_column" }, // TextEdit
 	{ "add_animation", "add_animation_library" }, // AnimationPlayer
@@ -1168,6 +1167,7 @@ static const char *gdscript_properties_renames[][2] = {
 	{ "unit_db", "volume_db" }, // AudioStreamPlayer3D
 	{ "unit_offset", "progress_ratio" }, // PathFollow2D, PathFollow3D
 	{ "vseparation", "v_separation" }, // Theme
+	{ "frames", "sprite_frames" }, // AnimatedSprite2D, AnimatedSprite3D
 
 	{ nullptr, nullptr },
 };

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -117,7 +117,6 @@ void AnimatedSprite2D::_validate_property(PropertyInfo &p_property) const {
 	}
 
 	if (p_property.name == "animation") {
-		p_property.hint = PROPERTY_HINT_ENUM;
 		List<StringName> names;
 		frames->get_animation_list(&names);
 		names.sort_custom<StringName::AlphCompare>();
@@ -167,6 +166,12 @@ void AnimatedSprite2D::_validate_property(PropertyInfo &p_property) const {
 
 void AnimatedSprite2D::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_READY: {
+			if (!Engine::get_singleton()->is_editor_hint() && !frames.is_null() && frames->has_animation(autoplay)) {
+				play(autoplay);
+			}
+		} break;
+
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (frames.is_null() || !frames->has_animation(animation)) {
 				return;
@@ -176,7 +181,8 @@ void AnimatedSprite2D::_notification(int p_what) {
 			int i = 0;
 			while (remaining) {
 				// Animation speed may be changed by animation_finished or frame_changed signals.
-				double speed = frames->get_animation_speed(animation) * Math::abs(speed_scale);
+				double speed = frames->get_animation_speed(animation) * speed_scale * custom_speed_scale * frame_speed_scale;
+				double abs_speed = Math::abs(speed);
 
 				if (speed == 0) {
 					return; // Do nothing.
@@ -185,52 +191,56 @@ void AnimatedSprite2D::_notification(int p_what) {
 				// Frame count may be changed by animation_finished or frame_changed signals.
 				int fc = frames->get_frame_count(animation);
 
-				if (timeout <= 0) {
-					int last_frame = fc - 1;
-					if (!playing_backwards) {
-						// Forward.
+				int last_frame = fc - 1;
+				if (!signbit(speed)) {
+					// Forwards.
+					if (frame_progress >= 1.0) {
 						if (frame >= last_frame) {
 							if (frames->get_animation_loop(animation)) {
 								frame = 0;
-								emit_signal(SceneStringNames::get_singleton()->animation_finished);
+								emit_signal("animation_looped");
 							} else {
 								frame = last_frame;
-								if (!is_over) {
-									is_over = true;
-									emit_signal(SceneStringNames::get_singleton()->animation_finished);
-								}
+								pause();
+								emit_signal(SceneStringNames::get_singleton()->animation_finished);
+								return;
 							}
 						} else {
 							frame++;
 						}
-					} else {
-						// Reversed.
+						_calc_frame_speed_scale();
+						frame_progress = 0.0;
+						queue_redraw();
+						emit_signal(SceneStringNames::get_singleton()->frame_changed);
+					}
+					double to_process = MIN((1.0 - frame_progress) / abs_speed, remaining);
+					frame_progress += to_process * abs_speed;
+					remaining -= to_process;
+				} else {
+					// Backwards.
+					if (frame_progress <= 0) {
 						if (frame <= 0) {
 							if (frames->get_animation_loop(animation)) {
 								frame = last_frame;
-								emit_signal(SceneStringNames::get_singleton()->animation_finished);
+								emit_signal("animation_looped");
 							} else {
 								frame = 0;
-								if (!is_over) {
-									is_over = true;
-									emit_signal(SceneStringNames::get_singleton()->animation_finished);
-								}
+								pause();
+								emit_signal(SceneStringNames::get_singleton()->animation_finished);
+								return;
 							}
 						} else {
 							frame--;
 						}
+						_calc_frame_speed_scale();
+						frame_progress = 1.0;
+						queue_redraw();
+						emit_signal(SceneStringNames::get_singleton()->frame_changed);
 					}
-
-					timeout = _get_frame_duration();
-
-					queue_redraw();
-
-					emit_signal(SceneStringNames::get_singleton()->frame_changed);
+					double to_process = MIN(frame_progress / abs_speed, remaining);
+					frame_progress -= to_process * abs_speed;
+					remaining -= to_process;
 				}
-
-				double to_process = MIN(timeout / speed, remaining);
-				timeout -= to_process * speed;
-				remaining -= to_process;
 
 				i++;
 				if (i > fc) {
@@ -275,25 +285,37 @@ void AnimatedSprite2D::_notification(int p_what) {
 }
 
 void AnimatedSprite2D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
+	if (frames == p_frames) {
+		return;
+	}
+
 	if (frames.is_valid()) {
 		frames->disconnect(SceneStringNames::get_singleton()->changed, callable_mp(this, &AnimatedSprite2D::_res_changed));
 	}
-
+	stop();
 	frames = p_frames;
 	if (frames.is_valid()) {
 		frames->connect(SceneStringNames::get_singleton()->changed, callable_mp(this, &AnimatedSprite2D::_res_changed));
-	}
 
-	if (frames.is_null()) {
-		frame = 0;
-	} else {
-		set_frame(frame);
+		List<StringName> al;
+		frames->get_animation_list(&al);
+		if (al.size() == 0) {
+			set_animation(StringName());
+			set_autoplay(String());
+		} else {
+			if (!frames->has_animation(animation)) {
+				set_animation(al[0]);
+			}
+			if (!frames->has_animation(autoplay)) {
+				set_autoplay(String());
+			}
+		}
 	}
 
 	notify_property_list_changed();
-	_reset_timeout();
 	queue_redraw();
 	update_configuration_warnings();
+	emit_signal("sprite_frames_changed");
 }
 
 Ref<SpriteFrames> AnimatedSprite2D::get_sprite_frames() const {
@@ -301,42 +323,61 @@ Ref<SpriteFrames> AnimatedSprite2D::get_sprite_frames() const {
 }
 
 void AnimatedSprite2D::set_frame(int p_frame) {
-	if (frames.is_null()) {
-		return;
-	}
-
-	if (frames->has_animation(animation)) {
-		int limit = frames->get_frame_count(animation);
-		if (p_frame >= limit) {
-			p_frame = limit - 1;
-		}
-	}
-
-	if (p_frame < 0) {
-		p_frame = 0;
-	}
-
-	if (frame == p_frame) {
-		return;
-	}
-
-	frame = p_frame;
-	_reset_timeout();
-	queue_redraw();
-	emit_signal(SceneStringNames::get_singleton()->frame_changed);
+	set_frame_and_progress(p_frame, signbit(get_playing_speed()) ? 1.0 : 0.0);
 }
 
 int AnimatedSprite2D::get_frame() const {
 	return frame;
 }
 
+void AnimatedSprite2D::set_frame_progress(real_t p_progress) {
+	frame_progress = p_progress;
+}
+
+real_t AnimatedSprite2D::get_frame_progress() const {
+	return frame_progress;
+}
+
+void AnimatedSprite2D::set_frame_and_progress(int p_frame, real_t p_progress) {
+	if (frames.is_null()) {
+		return;
+	}
+
+	bool has_animation = frames->has_animation(animation);
+	int end_frame = has_animation ? MAX(0, frames->get_frame_count(animation) - 1) : 0;
+	bool is_changed = frame != p_frame;
+
+	if (p_frame < 0) {
+		frame = 0;
+	} else if (has_animation && p_frame > end_frame) {
+		frame = end_frame;
+	} else {
+		frame = p_frame;
+	}
+
+	_calc_frame_speed_scale();
+	frame_progress = p_progress;
+
+	if (!is_changed) {
+		return; // No change, don't redraw.
+	}
+	queue_redraw();
+	emit_signal(SceneStringNames::get_singleton()->frame_changed);
+}
+
 void AnimatedSprite2D::set_speed_scale(float p_speed_scale) {
 	speed_scale = p_speed_scale;
-	playing_backwards = signbit(speed_scale) != backwards;
 }
 
 float AnimatedSprite2D::get_speed_scale() const {
 	return speed_scale;
+}
+
+float AnimatedSprite2D::get_playing_speed() const {
+	if (!playing) {
+		return 0;
+	}
+	return speed_scale * custom_speed_scale;
 }
 
 void AnimatedSprite2D::set_centered(bool p_center) {
@@ -378,18 +419,8 @@ bool AnimatedSprite2D::is_flipped_v() const {
 }
 
 void AnimatedSprite2D::_res_changed() {
-	set_frame(frame);
+	set_frame_and_progress(frame, frame_progress);
 	queue_redraw();
-	notify_property_list_changed();
-}
-
-void AnimatedSprite2D::set_playing(bool p_playing) {
-	if (playing == p_playing) {
-		return;
-	}
-	playing = p_playing;
-	playing_backwards = signbit(speed_scale) != backwards;
-	set_process_internal(playing);
 	notify_property_list_changed();
 }
 
@@ -397,50 +428,121 @@ bool AnimatedSprite2D::is_playing() const {
 	return playing;
 }
 
-void AnimatedSprite2D::play(const StringName &p_animation, bool p_backwards) {
-	backwards = p_backwards;
-	playing_backwards = signbit(speed_scale) != backwards;
+void AnimatedSprite2D::set_autoplay(const String &p_name) {
+	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint()) {
+		WARN_PRINT("Setting autoplay after the node has been added to the scene has no effect.");
+	}
 
-	if (p_animation) {
-		set_animation(p_animation);
-		if (frames.is_valid() && playing_backwards && get_frame() == 0) {
-			set_frame(frames->get_frame_count(p_animation) - 1);
+	autoplay = p_name;
+}
+
+String AnimatedSprite2D::get_autoplay() const {
+	return autoplay;
+}
+
+void AnimatedSprite2D::play(const StringName &p_name, float p_custom_scale, bool p_from_end) {
+	StringName name = p_name;
+
+	if (name == StringName()) {
+		name = animation;
+	}
+
+	ERR_FAIL_COND_MSG(frames == nullptr, vformat("There is no animation with name '%s'.", name));
+	ERR_FAIL_COND_MSG(!frames->get_animation_names().has(name), vformat("There is no animation with name '%s'.", name));
+
+	if (frames->get_frame_count(name) == 0) {
+		return;
+	}
+
+	playing = true;
+	custom_speed_scale = p_custom_scale;
+
+	int end_frame = MAX(0, frames->get_frame_count(animation) - 1);
+	if (name != animation) {
+		animation = name;
+		if (p_from_end) {
+			set_frame_and_progress(end_frame, 1.0);
+		} else {
+			set_frame_and_progress(0, 0.0);
+		}
+		emit_signal("animation_changed");
+	} else {
+		bool is_backward = signbit(speed_scale * custom_speed_scale);
+		if (p_from_end && is_backward && frame == 0 && frame_progress <= 0.0) {
+			set_frame_and_progress(end_frame, 1.0);
+		} else if (!p_from_end && !is_backward && frame == end_frame && frame_progress >= 1.0) {
+			set_frame_and_progress(0, 0.0);
 		}
 	}
 
-	is_over = false;
-	set_playing(true);
+	notify_property_list_changed();
+	set_process_internal(true);
+}
+
+void AnimatedSprite2D::play_backwards(const StringName &p_name) {
+	play(p_name, -1, true);
+}
+
+void AnimatedSprite2D::_stop_internal(bool p_reset) {
+	playing = false;
+	if (p_reset) {
+		custom_speed_scale = 1.0;
+		set_frame_and_progress(0, 0.0);
+	}
+	notify_property_list_changed();
+	set_process_internal(false);
+}
+
+void AnimatedSprite2D::pause() {
+	_stop_internal(false);
 }
 
 void AnimatedSprite2D::stop() {
-	set_playing(false);
-	backwards = false;
-	_reset_timeout();
+	_stop_internal(true);
 }
 
 double AnimatedSprite2D::_get_frame_duration() {
 	if (frames.is_valid() && frames->has_animation(animation)) {
 		return frames->get_frame_duration(animation, frame);
 	}
-	return 0.0;
+	return 1.0;
 }
 
-void AnimatedSprite2D::_reset_timeout() {
-	timeout = _get_frame_duration();
-	is_over = false;
+void AnimatedSprite2D::_calc_frame_speed_scale() {
+	frame_speed_scale = 1.0 / _get_frame_duration();
 }
 
-void AnimatedSprite2D::set_animation(const StringName &p_animation) {
-	ERR_FAIL_COND_MSG(frames == nullptr, vformat("There is no animation with name '%s'.", p_animation));
-	ERR_FAIL_COND_MSG(!frames->get_animation_names().has(p_animation), vformat("There is no animation with name '%s'.", p_animation));
-
-	if (animation == p_animation) {
+void AnimatedSprite2D::set_animation(const StringName &p_name) {
+	if (animation == p_name) {
 		return;
 	}
 
-	animation = p_animation;
-	set_frame(0);
-	_reset_timeout();
+	animation = p_name;
+
+	emit_signal("animation_changed");
+
+	if (frames == nullptr) {
+		animation = StringName();
+		stop();
+		ERR_FAIL_MSG(vformat("There is no animation with name '%s'.", p_name));
+	}
+
+	int frame_count = frames->get_frame_count(animation);
+	if (animation == StringName() || frame_count == 0) {
+		stop();
+		return;
+	} else if (!frames->get_animation_names().has(animation)) {
+		animation = StringName();
+		stop();
+		ERR_FAIL_MSG(vformat("There is no animation with name '%s'.", p_name));
+	}
+
+	if (signbit(get_playing_speed())) {
+		set_frame_and_progress(frame_count - 1, 1.0);
+	} else {
+		set_frame_and_progress(0, 0.0);
+	}
+
 	notify_property_list_changed();
 	queue_redraw();
 }
@@ -468,17 +570,30 @@ void AnimatedSprite2D::get_argument_options(const StringName &p_function, int p_
 	Node::get_argument_options(p_function, p_idx, r_options);
 }
 
+#ifndef DISABLE_DEPRECATED
+bool AnimatedSprite2D::_set(const StringName &p_name, const Variant &p_value) {
+	if ((p_name == SNAME("frames"))) {
+		set_sprite_frames(p_value);
+		return true;
+	}
+	return false;
+}
+#endif
 void AnimatedSprite2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_sprite_frames", "sprite_frames"), &AnimatedSprite2D::set_sprite_frames);
 	ClassDB::bind_method(D_METHOD("get_sprite_frames"), &AnimatedSprite2D::get_sprite_frames);
 
-	ClassDB::bind_method(D_METHOD("set_animation", "animation"), &AnimatedSprite2D::set_animation);
+	ClassDB::bind_method(D_METHOD("set_animation", "name"), &AnimatedSprite2D::set_animation);
 	ClassDB::bind_method(D_METHOD("get_animation"), &AnimatedSprite2D::get_animation);
 
-	ClassDB::bind_method(D_METHOD("set_playing", "playing"), &AnimatedSprite2D::set_playing);
+	ClassDB::bind_method(D_METHOD("set_autoplay", "name"), &AnimatedSprite2D::set_autoplay);
+	ClassDB::bind_method(D_METHOD("get_autoplay"), &AnimatedSprite2D::get_autoplay);
+
 	ClassDB::bind_method(D_METHOD("is_playing"), &AnimatedSprite2D::is_playing);
 
-	ClassDB::bind_method(D_METHOD("play", "anim", "backwards"), &AnimatedSprite2D::play, DEFVAL(StringName()), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("play", "name", "custom_speed", "from_end"), &AnimatedSprite2D::play, DEFVAL(StringName()), DEFVAL(1.0), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("play_backwards", "name"), &AnimatedSprite2D::play_backwards, DEFVAL(StringName()));
+	ClassDB::bind_method(D_METHOD("pause"), &AnimatedSprite2D::pause);
 	ClassDB::bind_method(D_METHOD("stop"), &AnimatedSprite2D::stop);
 
 	ClassDB::bind_method(D_METHOD("set_centered", "centered"), &AnimatedSprite2D::set_centered);
@@ -496,18 +611,28 @@ void AnimatedSprite2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_frame", "frame"), &AnimatedSprite2D::set_frame);
 	ClassDB::bind_method(D_METHOD("get_frame"), &AnimatedSprite2D::get_frame);
 
+	ClassDB::bind_method(D_METHOD("set_frame_progress", "progress"), &AnimatedSprite2D::set_frame_progress);
+	ClassDB::bind_method(D_METHOD("get_frame_progress"), &AnimatedSprite2D::get_frame_progress);
+
+	ClassDB::bind_method(D_METHOD("set_frame_and_progress", "frame", "progress"), &AnimatedSprite2D::set_frame_and_progress);
+
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "speed_scale"), &AnimatedSprite2D::set_speed_scale);
 	ClassDB::bind_method(D_METHOD("get_speed_scale"), &AnimatedSprite2D::get_speed_scale);
+	ClassDB::bind_method(D_METHOD("get_playing_speed"), &AnimatedSprite2D::get_playing_speed);
 
+	ADD_SIGNAL(MethodInfo("sprite_frames_changed"));
+	ADD_SIGNAL(MethodInfo("animation_changed"));
 	ADD_SIGNAL(MethodInfo("frame_changed"));
+	ADD_SIGNAL(MethodInfo("animation_looped"));
 	ADD_SIGNAL(MethodInfo("animation_finished"));
 
 	ADD_GROUP("Animation", "");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "frames", PROPERTY_HINT_RESOURCE_TYPE, "SpriteFrames"), "set_sprite_frames", "get_sprite_frames");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "animation"), "set_animation", "get_animation");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "sprite_frames", PROPERTY_HINT_RESOURCE_TYPE, "SpriteFrames"), "set_sprite_frames", "get_sprite_frames");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "animation", PROPERTY_HINT_ENUM, ""), "set_animation", "get_animation");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "autoplay", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_autoplay", "get_autoplay");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "frame"), "set_frame", "get_frame");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "frame_progress", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_frame_progress", "get_frame_progress");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_scale"), "set_speed_scale", "get_speed_scale");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing"), "set_playing", "is_playing");
 	ADD_GROUP("Offset", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "centered"), "set_centered", "is_centered");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "offset", PROPERTY_HINT_NONE, "suffix:px"), "set_offset", "get_offset");

--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -38,18 +38,19 @@ class AnimatedSprite2D : public Node2D {
 	GDCLASS(AnimatedSprite2D, Node2D);
 
 	Ref<SpriteFrames> frames;
+	String autoplay;
+
 	bool playing = false;
-	bool playing_backwards = false;
-	bool backwards = false;
 	StringName animation = "default";
 	int frame = 0;
 	float speed_scale = 1.0;
+	float custom_speed_scale = 1.0;
 
 	bool centered = true;
 	Point2 offset;
 
-	bool is_over = false;
-	float timeout = 0.0;
+	real_t frame_speed_scale = 1.0;
+	real_t frame_progress = 0.0;
 
 	bool hflip = false;
 	bool vflip = false;
@@ -57,10 +58,15 @@ class AnimatedSprite2D : public Node2D {
 	void _res_changed();
 
 	double _get_frame_duration();
-	void _reset_timeout();
+	void _calc_frame_speed_scale();
+	void _stop_internal(bool p_reset);
+
 	Rect2 _get_rect() const;
 
 protected:
+#ifndef DISABLE_DEPRECATED
+	bool _set(const StringName &p_name, const Variant &p_value);
+#endif
 	static void _bind_methods();
 	void _notification(int p_what);
 	void _validate_property(PropertyInfo &p_property) const;
@@ -82,20 +88,30 @@ public:
 	void set_sprite_frames(const Ref<SpriteFrames> &p_frames);
 	Ref<SpriteFrames> get_sprite_frames() const;
 
-	void play(const StringName &p_animation = StringName(), bool p_backwards = false);
+	void play(const StringName &p_name = StringName(), float p_custom_scale = 1.0, bool p_from_end = false);
+	void play_backwards(const StringName &p_name = StringName());
+	void pause();
 	void stop();
 
-	void set_playing(bool p_playing);
 	bool is_playing() const;
 
-	void set_animation(const StringName &p_animation);
+	void set_animation(const StringName &p_name);
 	StringName get_animation() const;
+
+	void set_autoplay(const String &p_name);
+	String get_autoplay() const;
 
 	void set_frame(int p_frame);
 	int get_frame() const;
 
+	void set_frame_progress(real_t p_progress);
+	real_t get_frame_progress() const;
+
+	void set_frame_and_progress(int p_frame, real_t p_progress);
+
 	void set_speed_scale(float p_speed_scale);
 	float get_speed_scale() const;
+	float get_playing_speed() const;
 
 	void set_centered(bool p_center);
 	bool is_centered() const;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -866,7 +866,6 @@ void AnimatedSprite3D::_validate_property(PropertyInfo &p_property) const {
 	}
 
 	if (p_property.name == "animation") {
-		p_property.hint = PROPERTY_HINT_ENUM;
 		List<StringName> names;
 		frames->get_animation_list(&names);
 		names.sort_custom<StringName::AlphCompare>();
@@ -916,6 +915,12 @@ void AnimatedSprite3D::_validate_property(PropertyInfo &p_property) const {
 
 void AnimatedSprite3D::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_READY: {
+			if (!Engine::get_singleton()->is_editor_hint() && !frames.is_null() && frames->has_animation(autoplay)) {
+				play(autoplay);
+			}
+		} break;
+
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (frames.is_null() || !frames->has_animation(animation)) {
 				return;
@@ -925,7 +930,8 @@ void AnimatedSprite3D::_notification(int p_what) {
 			int i = 0;
 			while (remaining) {
 				// Animation speed may be changed by animation_finished or frame_changed signals.
-				double speed = frames->get_animation_speed(animation) * Math::abs(speed_scale);
+				double speed = frames->get_animation_speed(animation) * speed_scale * custom_speed_scale * frame_speed_scale;
+				double abs_speed = Math::abs(speed);
 
 				if (speed == 0) {
 					return; // Do nothing.
@@ -934,52 +940,56 @@ void AnimatedSprite3D::_notification(int p_what) {
 				// Frame count may be changed by animation_finished or frame_changed signals.
 				int fc = frames->get_frame_count(animation);
 
-				if (timeout <= 0) {
-					int last_frame = fc - 1;
-					if (!playing_backwards) {
-						// Forward.
+				int last_frame = fc - 1;
+				if (!signbit(speed)) {
+					// Forwards.
+					if (frame_progress >= 1.0) {
 						if (frame >= last_frame) {
 							if (frames->get_animation_loop(animation)) {
 								frame = 0;
-								emit_signal(SceneStringNames::get_singleton()->animation_finished);
+								emit_signal("animation_looped");
 							} else {
 								frame = last_frame;
-								if (!is_over) {
-									is_over = true;
-									emit_signal(SceneStringNames::get_singleton()->animation_finished);
-								}
+								pause();
+								emit_signal(SceneStringNames::get_singleton()->animation_finished);
+								return;
 							}
 						} else {
 							frame++;
 						}
-					} else {
-						// Reversed.
+						_calc_frame_speed_scale();
+						frame_progress = 0.0;
+						_queue_redraw();
+						emit_signal(SceneStringNames::get_singleton()->frame_changed);
+					}
+					double to_process = MIN((1.0 - frame_progress) / abs_speed, remaining);
+					frame_progress += to_process * abs_speed;
+					remaining -= to_process;
+				} else {
+					// Backwards.
+					if (frame_progress <= 0) {
 						if (frame <= 0) {
 							if (frames->get_animation_loop(animation)) {
 								frame = last_frame;
-								emit_signal(SceneStringNames::get_singleton()->animation_finished);
+								emit_signal("animation_looped");
 							} else {
 								frame = 0;
-								if (!is_over) {
-									is_over = true;
-									emit_signal(SceneStringNames::get_singleton()->animation_finished);
-								}
+								pause();
+								emit_signal(SceneStringNames::get_singleton()->animation_finished);
+								return;
 							}
 						} else {
 							frame--;
 						}
+						_calc_frame_speed_scale();
+						frame_progress = 1.0;
+						_queue_redraw();
+						emit_signal(SceneStringNames::get_singleton()->frame_changed);
 					}
-
-					timeout = _get_frame_duration();
-
-					_queue_redraw();
-
-					emit_signal(SceneStringNames::get_singleton()->frame_changed);
+					double to_process = MIN(frame_progress / abs_speed, remaining);
+					frame_progress -= to_process * abs_speed;
+					remaining -= to_process;
 				}
-
-				double to_process = MIN(timeout / speed, remaining);
-				timeout -= to_process * speed;
-				remaining -= to_process;
 
 				i++;
 				if (i > fc) {
@@ -991,25 +1001,37 @@ void AnimatedSprite3D::_notification(int p_what) {
 }
 
 void AnimatedSprite3D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
+	if (frames == p_frames) {
+		return;
+	}
+
 	if (frames.is_valid()) {
 		frames->disconnect(SceneStringNames::get_singleton()->changed, callable_mp(this, &AnimatedSprite3D::_res_changed));
 	}
-
+	stop();
 	frames = p_frames;
 	if (frames.is_valid()) {
 		frames->connect(SceneStringNames::get_singleton()->changed, callable_mp(this, &AnimatedSprite3D::_res_changed));
-	}
 
-	if (frames.is_null()) {
-		frame = 0;
-	} else {
-		set_frame(frame);
+		List<StringName> al;
+		frames->get_animation_list(&al);
+		if (al.size() == 0) {
+			set_animation(StringName());
+			set_autoplay(String());
+		} else {
+			if (!frames->has_animation(animation)) {
+				set_animation(al[0]);
+			}
+			if (!frames->has_animation(autoplay)) {
+				set_autoplay(String());
+			}
+		}
 	}
 
 	notify_property_list_changed();
-	_reset_timeout();
 	_queue_redraw();
 	update_configuration_warnings();
+	emit_signal("sprite_frames_changed");
 }
 
 Ref<SpriteFrames> AnimatedSprite3D::get_sprite_frames() const {
@@ -1017,42 +1039,61 @@ Ref<SpriteFrames> AnimatedSprite3D::get_sprite_frames() const {
 }
 
 void AnimatedSprite3D::set_frame(int p_frame) {
-	if (frames.is_null()) {
-		return;
-	}
-
-	if (frames->has_animation(animation)) {
-		int limit = frames->get_frame_count(animation);
-		if (p_frame >= limit) {
-			p_frame = limit - 1;
-		}
-	}
-
-	if (p_frame < 0) {
-		p_frame = 0;
-	}
-
-	if (frame == p_frame) {
-		return;
-	}
-
-	frame = p_frame;
-	_reset_timeout();
-	_queue_redraw();
-	emit_signal(SceneStringNames::get_singleton()->frame_changed);
+	set_frame_and_progress(p_frame, signbit(get_playing_speed()) ? 1.0 : 0.0);
 }
 
 int AnimatedSprite3D::get_frame() const {
 	return frame;
 }
 
+void AnimatedSprite3D::set_frame_progress(real_t p_progress) {
+	frame_progress = p_progress;
+}
+
+real_t AnimatedSprite3D::get_frame_progress() const {
+	return frame_progress;
+}
+
+void AnimatedSprite3D::set_frame_and_progress(int p_frame, real_t p_progress) {
+	if (frames.is_null()) {
+		return;
+	}
+
+	bool has_animation = frames->has_animation(animation);
+	int end_frame = has_animation ? MAX(0, frames->get_frame_count(animation) - 1) : 0;
+	bool is_changed = frame != p_frame;
+
+	if (p_frame < 0) {
+		frame = 0;
+	} else if (has_animation && p_frame > end_frame) {
+		frame = end_frame;
+	} else {
+		frame = p_frame;
+	}
+
+	_calc_frame_speed_scale();
+	frame_progress = p_progress;
+
+	if (!is_changed) {
+		return; // No change, don't redraw.
+	}
+	_queue_redraw();
+	emit_signal(SceneStringNames::get_singleton()->frame_changed);
+}
+
 void AnimatedSprite3D::set_speed_scale(float p_speed_scale) {
 	speed_scale = p_speed_scale;
-	playing_backwards = signbit(speed_scale) != backwards;
 }
 
 float AnimatedSprite3D::get_speed_scale() const {
 	return speed_scale;
+}
+
+float AnimatedSprite3D::get_playing_speed() const {
+	if (!playing) {
+		return 0;
+	}
+	return speed_scale * custom_speed_scale;
 }
 
 Rect2 AnimatedSprite3D::get_item_rect() const {
@@ -1085,18 +1126,8 @@ Rect2 AnimatedSprite3D::get_item_rect() const {
 }
 
 void AnimatedSprite3D::_res_changed() {
-	set_frame(frame);
+	set_frame_and_progress(frame, frame_progress);
 	_queue_redraw();
-	notify_property_list_changed();
-}
-
-void AnimatedSprite3D::set_playing(bool p_playing) {
-	if (playing == p_playing) {
-		return;
-	}
-	playing = p_playing;
-	playing_backwards = signbit(speed_scale) != backwards;
-	set_process_internal(playing);
 	notify_property_list_changed();
 }
 
@@ -1104,50 +1135,121 @@ bool AnimatedSprite3D::is_playing() const {
 	return playing;
 }
 
-void AnimatedSprite3D::play(const StringName &p_animation, bool p_backwards) {
-	backwards = p_backwards;
-	playing_backwards = signbit(speed_scale) != backwards;
+void AnimatedSprite3D::set_autoplay(const String &p_name) {
+	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint()) {
+		WARN_PRINT("Setting autoplay after the node has been added to the scene has no effect.");
+	}
 
-	if (p_animation) {
-		set_animation(p_animation);
-		if (frames.is_valid() && playing_backwards && get_frame() == 0) {
-			set_frame(frames->get_frame_count(p_animation) - 1);
+	autoplay = p_name;
+}
+
+String AnimatedSprite3D::get_autoplay() const {
+	return autoplay;
+}
+
+void AnimatedSprite3D::play(const StringName &p_name, float p_custom_scale, bool p_from_end) {
+	StringName name = p_name;
+
+	if (name == StringName()) {
+		name = animation;
+	}
+
+	ERR_FAIL_COND_MSG(frames == nullptr, vformat("There is no animation with name '%s'.", name));
+	ERR_FAIL_COND_MSG(!frames->get_animation_names().has(name), vformat("There is no animation with name '%s'.", name));
+
+	if (frames->get_frame_count(name) == 0) {
+		return;
+	}
+
+	playing = true;
+	custom_speed_scale = p_custom_scale;
+
+	int end_frame = MAX(0, frames->get_frame_count(animation) - 1);
+	if (name != animation) {
+		animation = name;
+		if (p_from_end) {
+			set_frame_and_progress(end_frame, 1.0);
+		} else {
+			set_frame_and_progress(0, 0.0);
+		}
+		emit_signal("animation_changed");
+	} else {
+		bool is_backward = signbit(speed_scale * custom_speed_scale);
+		if (p_from_end && is_backward && frame == 0 && frame_progress <= 0.0) {
+			set_frame_and_progress(end_frame, 1.0);
+		} else if (!p_from_end && !is_backward && frame == end_frame && frame_progress >= 1.0) {
+			set_frame_and_progress(0, 0.0);
 		}
 	}
 
-	is_over = false;
-	set_playing(true);
+	notify_property_list_changed();
+	set_process_internal(true);
+}
+
+void AnimatedSprite3D::play_backwards(const StringName &p_name) {
+	play(p_name, -1, true);
+}
+
+void AnimatedSprite3D::_stop_internal(bool p_reset) {
+	playing = false;
+	if (p_reset) {
+		custom_speed_scale = 1.0;
+		set_frame_and_progress(0, 0.0);
+	}
+	notify_property_list_changed();
+	set_process_internal(false);
+}
+
+void AnimatedSprite3D::pause() {
+	_stop_internal(false);
 }
 
 void AnimatedSprite3D::stop() {
-	set_playing(false);
-	backwards = false;
-	_reset_timeout();
+	_stop_internal(true);
 }
 
 double AnimatedSprite3D::_get_frame_duration() {
 	if (frames.is_valid() && frames->has_animation(animation)) {
 		return frames->get_frame_duration(animation, frame);
 	}
-	return 0.0;
+	return 1.0;
 }
 
-void AnimatedSprite3D::_reset_timeout() {
-	timeout = _get_frame_duration();
-	is_over = false;
+void AnimatedSprite3D::_calc_frame_speed_scale() {
+	frame_speed_scale = 1.0 / _get_frame_duration();
 }
 
-void AnimatedSprite3D::set_animation(const StringName &p_animation) {
-	ERR_FAIL_COND_MSG(frames == nullptr, vformat("There is no animation with name '%s'.", p_animation));
-	ERR_FAIL_COND_MSG(!frames->get_animation_names().has(p_animation), vformat("There is no animation with name '%s'.", p_animation));
-
-	if (animation == p_animation) {
+void AnimatedSprite3D::set_animation(const StringName &p_name) {
+	if (animation == p_name) {
 		return;
 	}
 
-	animation = p_animation;
-	set_frame(0);
-	_reset_timeout();
+	animation = p_name;
+
+	emit_signal("animation_changed");
+
+	if (frames == nullptr) {
+		animation = StringName();
+		stop();
+		ERR_FAIL_MSG(vformat("There is no animation with name '%s'.", p_name));
+	}
+
+	int frame_count = frames->get_frame_count(animation);
+	if (animation == StringName() || frame_count == 0) {
+		stop();
+		return;
+	} else if (!frames->get_animation_names().has(animation)) {
+		animation = StringName();
+		stop();
+		ERR_FAIL_MSG(vformat("There is no animation with name '%s'.", p_name));
+	}
+
+	if (signbit(get_playing_speed())) {
+		set_frame_and_progress(frame_count - 1, 1.0);
+	} else {
+		set_frame_and_progress(0, 0.0);
+	}
+
 	notify_property_list_changed();
 	_queue_redraw();
 }
@@ -1175,35 +1277,58 @@ void AnimatedSprite3D::get_argument_options(const StringName &p_function, int p_
 	Node::get_argument_options(p_function, p_idx, r_options);
 }
 
+#ifndef DISABLE_DEPRECATED
+bool AnimatedSprite3D::_set(const StringName &p_name, const Variant &p_value) {
+	if ((p_name == SNAME("frames"))) {
+		set_sprite_frames(p_value);
+		return true;
+	}
+	return false;
+}
+#endif
 void AnimatedSprite3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_sprite_frames", "sprite_frames"), &AnimatedSprite3D::set_sprite_frames);
 	ClassDB::bind_method(D_METHOD("get_sprite_frames"), &AnimatedSprite3D::get_sprite_frames);
 
-	ClassDB::bind_method(D_METHOD("set_animation", "animation"), &AnimatedSprite3D::set_animation);
+	ClassDB::bind_method(D_METHOD("set_animation", "name"), &AnimatedSprite3D::set_animation);
 	ClassDB::bind_method(D_METHOD("get_animation"), &AnimatedSprite3D::get_animation);
 
-	ClassDB::bind_method(D_METHOD("set_playing", "playing"), &AnimatedSprite3D::set_playing);
+	ClassDB::bind_method(D_METHOD("set_autoplay", "name"), &AnimatedSprite3D::set_autoplay);
+	ClassDB::bind_method(D_METHOD("get_autoplay"), &AnimatedSprite3D::get_autoplay);
+
 	ClassDB::bind_method(D_METHOD("is_playing"), &AnimatedSprite3D::is_playing);
 
-	ClassDB::bind_method(D_METHOD("play", "anim", "backwards"), &AnimatedSprite3D::play, DEFVAL(StringName()), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("play", "name", "custom_speed", "from_end"), &AnimatedSprite3D::play, DEFVAL(StringName()), DEFVAL(1.0), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("play_backwards", "name"), &AnimatedSprite3D::play_backwards, DEFVAL(StringName()));
+	ClassDB::bind_method(D_METHOD("pause"), &AnimatedSprite3D::pause);
 	ClassDB::bind_method(D_METHOD("stop"), &AnimatedSprite3D::stop);
 
 	ClassDB::bind_method(D_METHOD("set_frame", "frame"), &AnimatedSprite3D::set_frame);
 	ClassDB::bind_method(D_METHOD("get_frame"), &AnimatedSprite3D::get_frame);
 
+	ClassDB::bind_method(D_METHOD("set_frame_progress", "progress"), &AnimatedSprite3D::set_frame_progress);
+	ClassDB::bind_method(D_METHOD("get_frame_progress"), &AnimatedSprite3D::get_frame_progress);
+
+	ClassDB::bind_method(D_METHOD("set_frame_and_progress", "frame", "progress"), &AnimatedSprite3D::set_frame_and_progress);
+
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "speed_scale"), &AnimatedSprite3D::set_speed_scale);
 	ClassDB::bind_method(D_METHOD("get_speed_scale"), &AnimatedSprite3D::get_speed_scale);
+	ClassDB::bind_method(D_METHOD("get_playing_speed"), &AnimatedSprite3D::get_playing_speed);
 
 	ClassDB::bind_method(D_METHOD("_res_changed"), &AnimatedSprite3D::_res_changed);
 
+	ADD_SIGNAL(MethodInfo("sprite_frames_changed"));
+	ADD_SIGNAL(MethodInfo("animation_changed"));
 	ADD_SIGNAL(MethodInfo("frame_changed"));
+	ADD_SIGNAL(MethodInfo("animation_looped"));
 	ADD_SIGNAL(MethodInfo("animation_finished"));
 
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "frames", PROPERTY_HINT_RESOURCE_TYPE, "SpriteFrames"), "set_sprite_frames", "get_sprite_frames");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "animation"), "set_animation", "get_animation");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "sprite_frames", PROPERTY_HINT_RESOURCE_TYPE, "SpriteFrames"), "set_sprite_frames", "get_sprite_frames");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "animation", PROPERTY_HINT_ENUM, ""), "set_animation", "get_animation");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "autoplay", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_autoplay", "get_autoplay");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "frame"), "set_frame", "get_frame");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "frame_progress", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_frame_progress", "get_frame_progress");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_scale"), "set_speed_scale", "get_speed_scale");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing"), "set_playing", "is_playing");
 }
 
 AnimatedSprite3D::AnimatedSprite3D() {

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -209,24 +209,29 @@ class AnimatedSprite3D : public SpriteBase3D {
 	GDCLASS(AnimatedSprite3D, SpriteBase3D);
 
 	Ref<SpriteFrames> frames;
+	String autoplay;
+
 	bool playing = false;
-	bool playing_backwards = false;
-	bool backwards = false;
 	StringName animation = "default";
 	int frame = 0;
 	float speed_scale = 1.0;
+	float custom_speed_scale = 1.0;
 
 	bool centered = false;
 
-	bool is_over = false;
-	double timeout = 0.0;
+	real_t frame_speed_scale = 1.0;
+	real_t frame_progress = 0.0;
 
 	void _res_changed();
 
 	double _get_frame_duration();
-	void _reset_timeout();
+	void _calc_frame_speed_scale();
+	void _stop_internal(bool p_reset);
 
 protected:
+#ifndef DISABLE_DEPRECATED
+	bool _set(const StringName &p_name, const Variant &p_value);
+#endif
 	virtual void _draw() override;
 	static void _bind_methods();
 	void _notification(int p_what);
@@ -236,20 +241,30 @@ public:
 	void set_sprite_frames(const Ref<SpriteFrames> &p_frames);
 	Ref<SpriteFrames> get_sprite_frames() const;
 
-	void play(const StringName &p_animation = StringName(), bool p_backwards = false);
+	void play(const StringName &p_name = StringName(), float p_custom_scale = 1.0, bool p_from_end = false);
+	void play_backwards(const StringName &p_name = StringName());
+	void pause();
 	void stop();
 
-	void set_playing(bool p_playing);
 	bool is_playing() const;
 
-	void set_animation(const StringName &p_animation);
+	void set_animation(const StringName &p_name);
 	StringName get_animation() const;
+
+	void set_autoplay(const String &p_name);
+	String get_autoplay() const;
 
 	void set_frame(int p_frame);
 	int get_frame() const;
 
+	void set_frame_progress(real_t p_progress);
+	real_t get_frame_progress() const;
+
+	void set_frame_and_progress(int p_frame, real_t p_progress);
+
 	void set_speed_scale(float p_speed_scale);
 	float get_speed_scale() const;
+	float get_playing_speed() const;
 
 	virtual Rect2 get_item_rect() const override;
 

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1709,8 +1709,11 @@ bool AnimationPlayer::is_playing() const {
 void AnimationPlayer::set_current_animation(const String &p_anim) {
 	if (p_anim == "[stop]" || p_anim.is_empty()) {
 		stop();
-	} else if (!is_playing() || playback.assigned != p_anim) {
+	} else if (!is_playing()) {
 		play(p_anim);
+	} else if (playback.assigned != p_anim) {
+		float speed = get_playing_speed();
+		play(p_anim, -1.0, speed, signbit(speed));
 	} else {
 		// Same animation, do not replay from start
 	}
@@ -1722,7 +1725,8 @@ String AnimationPlayer::get_current_animation() const {
 
 void AnimationPlayer::set_assigned_animation(const String &p_anim) {
 	if (is_playing()) {
-		play(p_anim);
+		float speed = get_playing_speed();
+		play(p_anim, -1.0, speed, signbit(speed));
 	} else {
 		ERR_FAIL_COND_MSG(!animation_set.has(p_anim), vformat("Animation not found: %s.", p_anim));
 		playback.current.pos = 0;
@@ -2202,7 +2206,7 @@ void AnimationPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "playback_process_mode", PROPERTY_HINT_ENUM, "Physics,Idle,Manual"), "set_process_callback", "get_process_callback");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "playback_default_blend_time", PROPERTY_HINT_RANGE, "0,4096,0.01,suffix:s"), "set_default_blend_time", "get_default_blend_time");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playback_active", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_active", "is_active");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "playback_speed", PROPERTY_HINT_RANGE, "-64,64,0.01"), "set_speed_scale", "get_speed_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_scale", PROPERTY_HINT_RANGE, "-64,64,0.01"), "set_speed_scale", "get_speed_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "method_call_mode", PROPERTY_HINT_ENUM, "Deferred,Immediate"), "set_method_call_mode", "get_method_call_mode");
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "movie_quit_on_finish"), "set_movie_quit_on_finish_enabled", "is_movie_quit_on_finish_enabled");

--- a/scene/resources/sprite_frames.cpp
+++ b/scene/resources/sprite_frames.cpp
@@ -36,7 +36,7 @@ void SpriteFrames::add_frame(const StringName &p_anim, const Ref<Texture2D> &p_t
 	HashMap<StringName, Anim>::Iterator E = animations.find(p_anim);
 	ERR_FAIL_COND_MSG(!E, "Animation '" + String(p_anim) + "' doesn't exist.");
 
-	p_duration = MAX(0.0, p_duration);
+	p_duration = MAX(SPRITE_FRAME_MINIMUM_DURATION, p_duration);
 
 	Frame frame = { p_texture, p_duration };
 
@@ -57,7 +57,7 @@ void SpriteFrames::set_frame(const StringName &p_anim, int p_idx, const Ref<Text
 		return;
 	}
 
-	p_duration = MAX(0.0, p_duration);
+	p_duration = MAX(SPRITE_FRAME_MINIMUM_DURATION, p_duration);
 
 	Frame frame = { p_texture, p_duration };
 
@@ -214,7 +214,7 @@ void SpriteFrames::_set_animations(const Array &p_animations) {
 			ERR_CONTINUE(!f.has("texture"));
 			ERR_CONTINUE(!f.has("duration"));
 
-			Frame frame = { f["texture"], f["duration"] };
+			Frame frame = { f["texture"], MAX(SPRITE_FRAME_MINIMUM_DURATION, (float)f["duration"]) };
 			anim.frames.push_back(frame);
 		}
 

--- a/scene/resources/sprite_frames.h
+++ b/scene/resources/sprite_frames.h
@@ -33,6 +33,8 @@
 
 #include "scene/resources/texture.h"
 
+static const float SPRITE_FRAME_MINIMUM_DURATION = 0.01;
+
 class SpriteFrames : public Resource {
 	GDCLASS(SpriteFrames, Resource);
 
@@ -89,10 +91,10 @@ public:
 
 	_FORCE_INLINE_ float get_frame_duration(const StringName &p_anim, int p_idx) const {
 		HashMap<StringName, Anim>::ConstIterator E = animations.find(p_anim);
-		ERR_FAIL_COND_V_MSG(!E, 0.0, "Animation '" + String(p_anim) + "' doesn't exist.");
-		ERR_FAIL_COND_V(p_idx < 0, 0.0);
+		ERR_FAIL_COND_V_MSG(!E, 1.0, "Animation '" + String(p_anim) + "' doesn't exist.");
+		ERR_FAIL_COND_V(p_idx < 0, 1.0);
 		if (p_idx >= E->value.frames.size()) {
-			return 0.0;
+			return 1.0;
 		}
 
 		return E->value.frames[p_idx].duration;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/6043.

- The SpriteEditor now has a playback buttons for preview. They are visible only if the node is valid. Now the `playing` property will only have a getter and `autoplay` property is added to play animation automaticaly when the scene is loaded.
	- Closes https://github.com/godotengine/godot-proposals/issues/5286
	- Closes https://github.com/godotengine/godot-proposals/issues/1390
- Adds / splits some playback methods `play()`, `play_backward()`, `pause()`, `stop()`.
	- Closes https://github.com/godotengine/godot-proposals/issues/287
	- Closes https://github.com/godotengine/godot/pull/66264
- Adds `get_playing_speed()`.
	- Closes https://github.com/godotengine/godot-proposals/issues/4506
	- Closes https://github.com/godotengine/godot/pull/41821
	- Closes https://github.com/godotengine/godot/pull/65985
- Adds some signals `animation_changed`, `animation_looped`, `sprite_frames_changed`.
	- Closes https://github.com/godotengine/godot-proposals/issues/5146
	- Closes https://github.com/godotengine/godot/pull/65548
- Expose `frame_progress` property and adds `set_frame_and_progress(int p_frame, float p_progress)`
	- Closes https://github.com/godotengine/godot/pull/65986
	- Closes https://github.com/godotengine/godot/pull/66219

https://user-images.githubusercontent.com/61938263/214019532-16bb4b52-e8fb-485f-aeb8-e093a312c8ec.mp4
