### PR TITLE
fix ReflectionProbe rendering extents for (10,10,10)

### DIFF
--- a/drivers/gles3/storage/light_storage.h
+++ b/drivers/gles3/storage/light_storage.h
@@ -113,7 +113,7 @@ struct ReflectionProbe {
 	Color ambient_color;
 	float ambient_color_energy = 1.0;
 	float max_distance = 0;
-	Vector3 extents = Vector3(1, 1, 1);
+	Vector3 extents = Vector3(10, 10, 10);
 	Vector3 origin_offset;
 	bool interior = false;
 	bool box_projection = false;

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -226,7 +226,7 @@ private:
 		Color ambient_color;
 		float ambient_color_energy = 1.0;
 		float max_distance = 0;
-		Vector3 extents = Vector3(1, 1, 1);
+		Vector3 extents = Vector3(10, 10, 10);
 		Vector3 origin_offset;
 		bool interior = false;
 		bool box_projection = false;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

This PR fixes [#66624](https://github.com/godotengine/godot/issues/66624)

## extent = (10.1, 10.1, 10.1)
<img width="1432" alt="image" src="https://user-images.githubusercontent.com/95585633/214032432-12781bc3-ee42-4dd9-a434-b574a6f97b8b.png">

## extent = (10, 10, 10) [before scene reload]
<img width="1432" alt="image" src="https://user-images.githubusercontent.com/95585633/214032621-0e5dbb96-a79d-46e1-be82-61c0cc741039.png">


## extent = (10, 10, 10) [after scene reload]
<img width="1434" alt="image" src="https://user-images.githubusercontent.com/95585633/214032695-770524dd-9996-43d6-89c2-48862ece2d48.png">
