### PR TITLE
GDScript: Remove function of `continue` for match statement

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -1543,28 +1543,6 @@ void GDScriptByteCodeGenerator::write_endwhile() {
 	current_breaks_to_patch.pop_back();
 }
 
-void GDScriptByteCodeGenerator::start_match() {
-	match_continues_to_patch.push_back(List<int>());
-}
-
-void GDScriptByteCodeGenerator::start_match_branch() {
-	// Patch continue statements.
-	for (const int &E : match_continues_to_patch.back()->get()) {
-		patch_jump(E);
-	}
-	match_continues_to_patch.pop_back();
-	// Start a new list for next branch.
-	match_continues_to_patch.push_back(List<int>());
-}
-
-void GDScriptByteCodeGenerator::end_match() {
-	// Patch continue statements.
-	for (const int &E : match_continues_to_patch.back()->get()) {
-		patch_jump(E);
-	}
-	match_continues_to_patch.pop_back();
-}
-
 void GDScriptByteCodeGenerator::write_break() {
 	append_opcode(GDScriptFunction::OPCODE_JUMP);
 	current_breaks_to_patch.back()->get().push_back(opcodes.size());
@@ -1574,12 +1552,6 @@ void GDScriptByteCodeGenerator::write_break() {
 void GDScriptByteCodeGenerator::write_continue() {
 	append_opcode(GDScriptFunction::OPCODE_JUMP);
 	append(continue_addrs.back()->get());
-}
-
-void GDScriptByteCodeGenerator::write_continue_match() {
-	append_opcode(GDScriptFunction::OPCODE_JUMP);
-	match_continues_to_patch.back()->get().push_back(opcodes.size());
-	append(0);
 }
 
 void GDScriptByteCodeGenerator::write_breakpoint() {

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -113,7 +113,6 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	List<int> ternary_jump_skip_pos;
 
 	List<List<int>> current_breaks_to_patch;
-	List<List<int>> match_continues_to_patch;
 
 	void add_stack_identifier(const StringName &p_id, int p_stackpos) {
 		if (locals.size() > max_locals) {
@@ -496,12 +495,8 @@ public:
 	virtual void start_while_condition() override;
 	virtual void write_while(const Address &p_condition) override;
 	virtual void write_endwhile() override;
-	virtual void start_match() override;
-	virtual void start_match_branch() override;
-	virtual void end_match() override;
 	virtual void write_break() override;
 	virtual void write_continue() override;
-	virtual void write_continue_match() override;
 	virtual void write_breakpoint() override;
 	virtual void write_newline(int p_line) override;
 	virtual void write_return(const Address &p_return_value) override;

--- a/modules/gdscript/gdscript_codegen.h
+++ b/modules/gdscript/gdscript_codegen.h
@@ -148,12 +148,8 @@ public:
 	virtual void start_while_condition() = 0; // Used to allow a jump to the expression evaluation.
 	virtual void write_while(const Address &p_condition) = 0;
 	virtual void write_endwhile() = 0;
-	virtual void start_match() = 0;
-	virtual void start_match_branch() = 0;
-	virtual void end_match() = 0;
 	virtual void write_break() = 0;
 	virtual void write_continue() = 0;
-	virtual void write_continue_match() = 0;
 	virtual void write_breakpoint() = 0;
 	virtual void write_newline(int p_line) = 0;
 	virtual void write_return(const Address &p_return_value) = 0;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1679,7 +1679,6 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 			case GDScriptParser::Node::MATCH: {
 				const GDScriptParser::MatchNode *match = static_cast<const GDScriptParser::MatchNode *>(s);
 
-				gen->start_match();
 				codegen.start_block();
 
 				// Evaluate the match expression.
@@ -1718,7 +1717,6 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 
 					const GDScriptParser::MatchBranchNode *branch = match->branches[j];
 
-					gen->start_match_branch(); // Need so lower level code can patch 'continue' jumps.
 					codegen.start_block(); // Create an extra block around for binds.
 
 					// Add locals in block before patterns, so temporaries don't use the stack address for binds.
@@ -1756,8 +1754,6 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 				for (int j = 0; j < match->branches.size(); j++) {
 					gen->write_endif();
 				}
-
-				gen->end_match();
 			} break;
 			case GDScriptParser::Node::IF: {
 				const GDScriptParser::IfNode *if_n = static_cast<const GDScriptParser::IfNode *>(s);
@@ -1845,12 +1841,7 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 				gen->write_break();
 			} break;
 			case GDScriptParser::Node::CONTINUE: {
-				const GDScriptParser::ContinueNode *cont = static_cast<const GDScriptParser::ContinueNode *>(s);
-				if (cont->is_for_match) {
-					gen->write_continue_match();
-				} else {
-					gen->write_continue();
-				}
+				gen->write_continue();
 			} break;
 			case GDScriptParser::Node::RETURN: {
 				const GDScriptParser::ReturnNode *return_n = static_cast<const GDScriptParser::ReturnNode *>(s);

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -758,7 +758,6 @@ public:
 	};
 
 	struct ContinueNode : public Node {
-		bool is_for_match = false;
 		ContinueNode() {
 			type = CONTINUE;
 		}
@@ -1254,7 +1253,6 @@ private:
 	bool panic_mode = false;
 	bool can_break = false;
 	bool can_continue = false;
-	bool is_continue_match = false; // Whether a `continue` will act on a `match`.
 	List<bool> multiline_stack;
 
 	ClassNode *head = nullptr;

--- a/modules/gdscript/tests/scripts/parser/features/match.gd
+++ b/modules/gdscript/tests/scripts/parser/features/match.gd
@@ -3,8 +3,6 @@ func test():
 	match i:
 		"Hello":
 			print("hello")
-			# This will fall through to the default case below.
-			continue
 		"Good bye":
 			print("bye")
 		_:

--- a/modules/gdscript/tests/scripts/parser/features/match.out
+++ b/modules/gdscript/tests/scripts/parser/features/match.out
@@ -1,4 +1,3 @@
 GDTEST_OK
 hello
-default
 This will match

--- a/modules/gdscript/tests/scripts/parser/features/nested_match.gd
+++ b/modules/gdscript/tests/scripts/parser/features/nested_match.gd
@@ -8,11 +8,10 @@ func test():
 				1234:
 					print("2")
 					match number:
-						1234:
-							print("3")
-							continue
+						4321:
+							print("Should not be printed")
 						_:
-							print("Should also be printed")
+							print("3")
 							match number:
 								1234:
 									print("4")

--- a/modules/gdscript/tests/scripts/parser/features/nested_match.out
+++ b/modules/gdscript/tests/scripts/parser/features/nested_match.out
@@ -2,7 +2,6 @@ GDTEST_OK
 1
 2
 3
-Should also be printed
 4
 5
 6


### PR DESCRIPTION
The keyword is confusing and rarely is used in the intended way. It is removed now in favor of a future feature ([pattern guards](https://github.com/godotengine/godot-proposals/issues/4775)) to avoid breaking compatibility later.