### PR TITLE
Add shader preprocessor singleton access

### DIFF
--- a/servers/rendering/shader_preprocessor.h
+++ b/servers/rendering/shader_preprocessor.h
@@ -200,6 +200,7 @@ private:
 	void add_region(int p_line, bool p_enabled, Region *p_parent_region);
 	void start_branch_condition(Tokenizer *p_tokenizer, bool p_success, bool p_continue = false);
 
+	Error execute_condition(const String &p_code, int p_line, Variant &p_result);
 	Error expand_condition(const String &p_string, int p_line, String &r_result);
 	void expand_output_macros(int p_start, int p_line);
 	Error expand_macros(const String &p_string, int p_line, String &r_result);


### PR DESCRIPTION
Implements part 6 of https://github.com/godotengine/godot-proposals/issues/5062, but in a bit more powerful and flexible way.

This PR exposes ClassDB singletons (like OS, Engine, ProjectSettings etc.) for preprocessor condition evaluation. This makes it possible to use more complex logic to control how the shaders are preprocessed and compiled. For example, it is now possible to use Engine.is_editor_hint() to draw extra debug stuff while in editor, checking OS.get_environment() or OS.has_feature() for special flags or doing special processing if some ProjectSettings.get_setting() is set. Possibilities are almost endless.

And in case you didn't know yet, the preprocessor `#if` and `#elif` code evaluation has always been done using the GDScript expression parser, although many have not noticed it because usually those conditions are pretty simple and &&, || etc. operators work in GDScript, too. You can replace && with "and" and things will work just the same. If this PR is accepted, I can update the preprocessor docs to be explicit about this and give some examples.

Naturally, it is possible to use these together to make more complex conditions and it is still possible to mix functions and macros in expressions. Here is a code example to demonstrate the syntax:

``` cpp
#define ENABLED true
#define DEBUG_MODE OS.has_feature("debug") || "force_debug" in OS.get_cmdline_args()
#define GET_SETTING(name) ProjectSettings.get_setting(name)

#if (OS.has_feature("release") && Engine.is_editor_hint()) || OS.get_environment("FORCE_DEBUG") == "1"
    ALBEDO *= 1.0;
#elif (ENABLED && OS.get_name() == "Android") || (defined(TEST_MODE) || DEBUG_MODE)
    ALBEDO *= 2.0;
#endif

#if GET_SETTING("rendering/anti_aliasing/quality/use_taa")
    ALBEDO *= 3.0;
#else
    ALBEDO *= 4.0;
#endif
```