### PR TITLE
Fix StyleBoxTexture to allow make it smaller than texture size

### DIFF
--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -233,17 +233,6 @@ bool StyleBoxTexture::is_draw_center_enabled() const {
 
 Size2 StyleBoxTexture::get_minimum_size() const {
 	Size2 min_size = StyleBox::get_minimum_size();
-
-	// Make sure that the min size is no smaller than the used texture region.
-	if (texture.is_valid()) {
-		if (min_size.x < region_rect.size.x) {
-			min_size.x = region_rect.size.x;
-		}
-		if (min_size.y < region_rect.size.y) {
-			min_size.y = region_rect.size.y;
-		}
-	}
-
 	return min_size;
 }
 


### PR DESCRIPTION
Revert part of https://github.com/godotengine/godot/pull/71686 to fix https://github.com/godotengine/godot/issues/71913.
