### PR TITLE
Ensure that Particles have fully initialized before doing view axis pass in RD renderers

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1145,7 +1145,7 @@ void ParticlesStorage::particles_set_view_axis(RID p_particles, const Vector3 &p
 		return;
 	}
 
-	if (particles->particle_buffer.is_null()) {
+	if (particles->particle_buffer.is_null() || particles->trail_bind_pose_uniform_set.is_null()) {
 		return; //particles have not processed yet
 	}
 


### PR DESCRIPTION
Fixes the first reported issue in https://github.com/godotengine/godot/issues/70607 but not the second

``trail_bind_pose_uniform_set`` is initialized when the particles are processed for the first time. This code runs each frame and is used when the particles require camera-based effects or custom sorting. So it is possible for this to be called without the particles having been processed. So we need a more comprehensive early out. 

This change isn't needed in the GL_Compatibility renderer as it doesn't have support for trails. 