### PR TITLE
Fix bind `" convergence_dist"` containing space

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2135,7 +2135,7 @@ static void _register_variant_builtin_methods() {
 	bind_static_method(Projection, create_depth_correction, sarray("flip_y"), varray());
 	bind_static_method(Projection, create_light_atlas_rect, sarray("rect"), varray());
 	bind_static_method(Projection, create_perspective, sarray("fovy", "aspect", "z_near", "z_far", "flip_fov"), varray(false));
-	bind_static_method(Projection, create_perspective_hmd, sarray("fovy", "aspect", "z_near", "z_far", "flip_fov", "eye", "intraocular_dist", " convergence_dist"), varray());
+	bind_static_method(Projection, create_perspective_hmd, sarray("fovy", "aspect", "z_near", "z_far", "flip_fov", "eye", "intraocular_dist", "convergence_dist"), varray());
 	bind_static_method(Projection, create_for_hmd, sarray("eye", "aspect", "intraocular_dist", "display_width", "display_to_lens", "oversample", "z_near", "z_far"), varray());
 	bind_static_method(Projection, create_orthogonal, sarray("left", "right", "bottom", "top", "z_near", "z_far"), varray());
 	bind_static_method(Projection, create_orthogonal_aspect, sarray("size", "aspect", "z_near", "z_far", "flip_fov"), varray(false));

--- a/doc/classes/Projection.xml
+++ b/doc/classes/Projection.xml
@@ -149,7 +149,7 @@
 			<param index="4" name="flip_fov" type="bool" />
 			<param index="5" name="eye" type="int" />
 			<param index="6" name="intraocular_dist" type="float" />
-			<param index="7" name=" convergence_dist" type="float" />
+			<param index="7" name="convergence_dist" type="float" />
 			<description>
 				Creates a new [Projection] that projects positions using a perspective projection with the given Y-axis field of view (in degrees), X:Y aspect ratio, and clipping distances. The projection is adjusted for a head-mounted display with the given distance between eyes and distance to a point that can be focused on.
 				[param eye] creates the projection for the left eye when set to 1, or the right eye when set to 2.

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -559,6 +559,8 @@ void add_exposed_classes(Context &r_context) {
 
 			MethodData method;
 			method.name = method_info.name;
+			TEST_FAIL_COND(!String(method.name).is_valid_identifier(),
+					"Method name is not a valid identifier: '", exposed_class.name, ".", method.name, "'.");
 
 			if (method_info.flags & METHOD_FLAG_VIRTUAL) {
 				method.is_virtual = true;
@@ -682,6 +684,8 @@ void add_exposed_classes(Context &r_context) {
 			const MethodInfo &method_info = signal_map.get(K.key);
 
 			signal.name = method_info.name;
+			TEST_FAIL_COND(!String(signal.name).is_valid_identifier(),
+					"Signal name is not a valid identifier: '", exposed_class.name, ".", signal.name, "'.");
 
 			int argc = method_info.arguments.size();
 


### PR DESCRIPTION
Tiny change: exported method accidentally contains a leading space: `" convergence_dist"`
