### PR TITLE
C#: Move `LinearToDb` and `DbToLinear` to Mathf

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
@@ -49,17 +49,6 @@ namespace Godot
             return Variant.CreateTakingOwnershipOfDisposableValue(ret);
         }
 
-        /// <summary>
-        /// Converts from decibels to linear energy (audio).
-        /// </summary>
-        /// <seealso cref="LinearToDb(real_t)"/>
-        /// <param name="db">Decibels to convert.</param>
-        /// <returns>Audio volume as linear energy.</returns>
-        public static real_t DbToLinear(real_t db)
-        {
-            return (real_t)Math.Exp(db * 0.11512925464970228420089957273422);
-        }
-
         private static string[] GetPrintParams(object[] parameters)
         {
             if (parameters == null)
@@ -109,26 +98,6 @@ namespace Godot
         public static Object InstanceFromId(ulong instanceId)
         {
             return InteropUtils.UnmanagedGetManaged(NativeFuncs.godotsharp_instance_from_id(instanceId));
-        }
-
-        /// <summary>
-        /// Converts from linear energy to decibels (audio).
-        /// This can be used to implement volume sliders that behave as expected (since volume isn't linear).
-        /// </summary>
-        /// <seealso cref="DbToLinear(real_t)"/>
-        /// <example>
-        /// <code>
-        /// // "slider" refers to a node that inherits Range such as HSlider or VSlider.
-        /// // Its range must be configured to go from 0 to 1.
-        /// // Change the bus name if you'd like to change the volume of a specific bus only.
-        /// AudioServer.SetBusVolumeDb(AudioServer.GetBusIndex("Master"), GD.LinearToDb(slider.value));
-        /// </code>
-        /// </example>
-        /// <param name="linear">The linear energy to convert.</param>
-        /// <returns>Audio as decibels.</returns>
-        public static real_t LinearToDb(real_t linear)
-        {
-            return (real_t)(Math.Log(linear) * 8.6858896380650365530225783783321);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -324,6 +324,17 @@ namespace Godot
         }
 
         /// <summary>
+        /// Converts from decibels to linear energy (audio).
+        /// </summary>
+        /// <seealso cref="LinearToDb(real_t)"/>
+        /// <param name="db">Decibels to convert.</param>
+        /// <returns>Audio volume as linear energy.</returns>
+        public static real_t DbToLinear(real_t db)
+        {
+            return (real_t)Math.Exp(db * 0.11512925464970228420089957273422);
+        }
+
+        /// <summary>
         /// Converts an angle expressed in degrees to radians.
         /// </summary>
         /// <param name="deg">An angle expressed in degrees.</param>
@@ -512,6 +523,26 @@ namespace Godot
             real_t difference = (to - from) % Mathf.Tau;
             real_t distance = ((2 * difference) % Mathf.Tau) - difference;
             return from + (distance * weight);
+        }
+
+        /// <summary>
+        /// Converts from linear energy to decibels (audio).
+        /// This can be used to implement volume sliders that behave as expected (since volume isn't linear).
+        /// </summary>
+        /// <seealso cref="DbToLinear(real_t)"/>
+        /// <example>
+        /// <code>
+        /// // "slider" refers to a node that inherits Range such as HSlider or VSlider.
+        /// // Its range must be configured to go from 0 to 1.
+        /// // Change the bus name if you'd like to change the volume of a specific bus only.
+        /// AudioServer.SetBusVolumeDb(AudioServer.GetBusIndex("Master"), GD.LinearToDb(slider.value));
+        /// </code>
+        /// </example>
+        /// <param name="linear">The linear energy to convert.</param>
+        /// <returns>Audio as decibels.</returns>
+        public static real_t LinearToDb(real_t linear)
+        {
+            return (real_t)(Math.Log(linear) * 8.6858896380650365530225783783321);
         }
 
         /// <summary>


### PR DESCRIPTION
Move `LinearToDb` and `DbToLinear` methods from GD to Mathf.