### PR TITLE
Fix builtin alsa headers building on musl

### DIFF
--- a/thirdparty/linuxbsd_headers/README.md
+++ b/thirdparty/linuxbsd_headers/README.md
@@ -11,6 +11,7 @@ readability.
 - Version: 1.1.3-5
 - License: LPGL-2.1+
 
+Patches in the `patches` directory should be re-applied after updates.
 
 ## dbus
 

--- a/thirdparty/linuxbsd_headers/alsa/asoundlib.h
+++ b/thirdparty/linuxbsd_headers/alsa/asoundlib.h
@@ -35,7 +35,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <assert.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <errno.h>
 #include <stdarg.h>
 #include <endian.h>

--- a/thirdparty/linuxbsd_headers/alsa/patches/use-standard-poll-h.diff
+++ b/thirdparty/linuxbsd_headers/alsa/patches/use-standard-poll-h.diff
@@ -1,0 +1,11 @@
+--- a/asoundlib.h
++++ b/asoundlib.h
+@@ -35,7 +35,7 @@
+ #include <string.h>
+ #include <fcntl.h>
+ #include <assert.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <errno.h>
+ #include <stdarg.h>
+ #include <endian.h>


### PR DESCRIPTION
For some reason it doesn't use the POSIX `poll.h`, instead resorting to `sys/poll.h`. Musl doesn't really like this at all, throwing a warning and, thus, halting compilation.

I made the patch file and edited the README. I wonder whether we should send this patch to upstream since it's trivial.