### PR TITLE
Remove some unused signals

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -410,11 +410,6 @@
 				Emitted when an item is collapsed by a click on the folding arrow.
 			</description>
 		</signal>
-		<signal name="item_custom_button_pressed">
-			<description>
-				Emitted when a custom button is pressed (i.e. in a [constant TreeItem.CELL_MODE_CUSTOM] mode cell).
-			</description>
-		</signal>
 		<signal name="item_edited">
 			<description>
 				Emitted when an item is edited.

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -614,6 +614,12 @@
 				This signal can be used to handle window closing, e.g. by connecting it to [method hide].
 			</description>
 		</signal>
+		<signal name="dpi_changed">
+			<description>
+				Emitted when the [Window]'s DPI changes as a result of OS-level changes (e.g. moving the window from a Retina display to a lower resolution one).
+				[b]Note:[/b] Only implemented on macOS.
+			</description>
+		</signal>
 		<signal name="files_dropped">
 			<param index="0" name="files" type="PackedStringArray" />
 			<description>

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2986,7 +2986,6 @@ bool AnimationTrackEdit::can_drop_data(const Point2 &p_point, const Variant &p_d
 	}
 
 	const_cast<AnimationTrackEdit *>(this)->queue_redraw();
-	const_cast<AnimationTrackEdit *>(this)->emit_signal(SNAME("drop_attempted"), track);
 
 	return true;
 }

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -670,7 +670,6 @@ void FindReplaceBar::set_text_edit(CodeTextEditor *p_text_editor) {
 void FindReplaceBar::_bind_methods() {
 	ClassDB::bind_method("_search_current", &FindReplaceBar::search_current);
 
-	ADD_SIGNAL(MethodInfo("search"));
 	ADD_SIGNAL(MethodInfo("error"));
 }
 

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2448,10 +2448,6 @@ void FindBar::_notification(int p_what) {
 	}
 }
 
-void FindBar::_bind_methods() {
-	ADD_SIGNAL(MethodInfo("search"));
-}
-
 void FindBar::set_rich_text_label(RichTextLabel *p_rich_text_label) {
 	rich_text_label = p_rich_text_label;
 }

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -72,8 +72,6 @@ protected:
 
 	bool _search(bool p_search_previous = false);
 
-	static void _bind_methods();
-
 public:
 	void set_rich_text_label(RichTextLabel *p_rich_text_label);
 

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -360,11 +360,6 @@ void EditorLog::_reset_message_counts() {
 	}
 }
 
-void EditorLog::_bind_methods() {
-	ADD_SIGNAL(MethodInfo("clear_request"));
-	ADD_SIGNAL(MethodInfo("copy_request"));
-}
-
 EditorLog::EditorLog() {
 	save_state_timer = memnew(Timer);
 	save_state_timer->set_wait_time(2);

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -178,7 +178,6 @@ private:
 	void _update_theme();
 
 protected:
-	static void _bind_methods();
 	void _notification(int p_what);
 
 public:

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6467,7 +6467,6 @@ void EditorNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_gui_base"), &EditorNode::get_gui_base);
 
 	ADD_SIGNAL(MethodInfo("play_pressed"));
-	ADD_SIGNAL(MethodInfo("pause_pressed"));
 	ADD_SIGNAL(MethodInfo("stop_pressed"));
 	ADD_SIGNAL(MethodInfo("request_help_search"));
 	ADD_SIGNAL(MethodInfo("script_add_function_request", PropertyInfo(Variant::OBJECT, "obj"), PropertyInfo(Variant::STRING, "function"), PropertyInfo(Variant::PACKED_STRING_ARRAY, "args")));

--- a/modules/webrtc/webrtc_multiplayer_peer.cpp
+++ b/modules/webrtc/webrtc_multiplayer_peer.cpp
@@ -128,7 +128,6 @@ void WebRTCMultiplayerPeer::poll() {
 			// Server connected.
 			connection_status = CONNECTION_CONNECTED;
 			emit_signal(SNAME("peer_connected"), TARGET_PEER_SERVER);
-			emit_signal(SNAME("connection_succeeded"));
 		} else {
 			emit_signal(SNAME("peer_connected"), E);
 		}

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -237,7 +237,6 @@ void WebSocketMultiplayerPeer::_poll_client() {
 				}
 				connection_status = CONNECTION_CONNECTED;
 				emit_signal("peer_connected", 1);
-				emit_signal("connection_succeeded");
 			} else {
 				return; // Still waiting for an ID.
 			}

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -5256,7 +5256,6 @@ void Tree::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("empty_clicked", PropertyInfo(Variant::VECTOR2, "position"), PropertyInfo(Variant::INT, "mouse_button_index")));
 	ADD_SIGNAL(MethodInfo("item_edited"));
 	ADD_SIGNAL(MethodInfo("custom_item_clicked", PropertyInfo(Variant::INT, "mouse_button_index")));
-	ADD_SIGNAL(MethodInfo("item_custom_button_pressed"));
 	ADD_SIGNAL(MethodInfo("item_icon_double_clicked"));
 	ADD_SIGNAL(MethodInfo("item_collapsed", PropertyInfo(Variant::OBJECT, "item", PROPERTY_HINT_RESOURCE_TYPE, "TreeItem")));
 	ADD_SIGNAL(MethodInfo("check_propagated_to_item", PropertyInfo(Variant::OBJECT, "item", PROPERTY_HINT_RESOURCE_TYPE, "TreeItem"), PropertyInfo(Variant::INT, "column")));

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2344,6 +2344,7 @@ void Window::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("visibility_changed"));
 	ADD_SIGNAL(MethodInfo("about_to_popup"));
 	ADD_SIGNAL(MethodInfo("theme_changed"));
+	ADD_SIGNAL(MethodInfo("dpi_changed"));
 	ADD_SIGNAL(MethodInfo("titlebar_changed"));
 
 	BIND_CONSTANT(NOTIFICATION_VISIBILITY_CHANGED);

--- a/scene/resources/bone_map.cpp
+++ b/scene/resources/bone_map.cpp
@@ -152,7 +152,6 @@ void BoneMap::_validate_bone_map() {
 	} else {
 		bone_map.clear();
 	}
-	emit_signal("retarget_option_updated");
 }
 
 void BoneMap::_bind_methods() {


### PR DESCRIPTION
Part of #37604.

Technically "breaks compat" as it removes something from the bindings, but this thing did nothing.

Reviews welcome on the list, notably if some of those signals are actually intended to be implemented / made useful.