### PR TITLE
Add Curve2D/tessellate_even_length description class-reference

### DIFF
--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -162,6 +162,8 @@
 			<param index="0" name="max_stages" type="int" default="5" />
 			<param index="1" name="tolerance_length" type="float" default="20.0" />
 			<description>
+				Returns a list of points along the curve, with almost uniform density. [param max_stages] controls how many subdivisions a curve segment may face before it is considered approximate enough. Each subdivision splits the segment in half, so the default 5 stages may mean up to 32 subdivisions per curve segment. Increase with care!
+				[param tolerance_length] controls the maximal distance between two neighboring points, before the segment has to be subdivided.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Copied description from Curve3D's corresponding method, as it does the same thing and is well written.

[Docs](https://docs.godotengine.org/en/latest/classes/class_curve2d.html)