### PR TITLE
Fix nullptr dereference in AnimationTimelineEdit

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4299,6 +4299,8 @@ void AnimationTrackEditor::_update_tracks() {
 		memdelete(track_vbox->get_child(0));
 	}
 
+	timeline->set_track_edit(nullptr);
+
 	track_edits.clear();
 	groups.clear();
 


### PR DESCRIPTION
I open this PR as a starting point for a better solution,
I have noticed various crashes when using the AnimationPlayer node; after debugging for a bit one problem I have found is this nullptr deref, but I cannot for the life of me figure out why it is null in the first place as it should always be set at some point.

**There are more related crashes in this code**, but I could not yet find anything conclusive, so lets say this fixes a symptom rather than the root cause.

To replicate the crash for this particular patch, create some animation, add a property track and try to increment the value of the property you have chosen while the animation track at the bottom is open and press the little key icon next to it (to add a new frame).

fixes #72397