### PR TITLE
Better error display in debugger panel

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -519,7 +519,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		String error_title;
 		if (oe.callstack.size() > 0) {
 			// If available, use the script's stack in the error title.
-			error_title = oe.callstack[oe.callstack.size() - 1].func + ": ";
+			error_title = _format_frame_text(&oe.callstack[0]) + ": ";
 		} else if (!oe.source_func.is_empty()) {
 			// Otherwise try to use the C++ source function.
 			error_title += oe.source_func + ": ";
@@ -530,13 +530,25 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		error->set_text(1, error_title);
 		tooltip += " " + error_title + "\n";
 
+		// Find the language of the error's source file.
+		String source_language_name = "C++"; // Default value is the old hard-coded one.
+		const String source_file_extension = oe.source_file.get_extension();
+		for (int i = 0; i < ScriptServer::get_language_count(); ++i) {
+			ScriptLanguage *script_language = ScriptServer::get_language(i);
+			if (source_file_extension == script_language->get_extension()) {
+				source_language_name = script_language->get_name();
+				break;
+			}
+		}
+
 		if (!oe.error_descr.is_empty()) {
 			// Add item for C++ error condition.
 			TreeItem *cpp_cond = error_tree->create_item(error);
-			cpp_cond->set_text(0, "<" + TTR("C++ Error") + ">");
+			// TRANSLATORS: %s is the name of a language, e.g. C++.
+			cpp_cond->set_text(0, "<" + vformat(TTR("%s Error"), source_language_name) + ">");
 			cpp_cond->set_text(1, oe.error);
 			cpp_cond->set_text_alignment(0, HORIZONTAL_ALIGNMENT_LEFT);
-			tooltip += TTR("C++ Error:") + " " + oe.error + "\n";
+			tooltip += vformat(TTR("%s Error:"), source_language_name) + "\n";
 			if (source_is_project_file) {
 				cpp_cond->set_metadata(0, source_meta);
 			}
@@ -547,14 +559,18 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		// Source of the error.
 		String source_txt = (source_is_project_file ? oe.source_file.get_file() : oe.source_file) + ":" + itos(oe.source_line);
 		if (!oe.source_func.is_empty()) {
-			source_txt += " @ " + oe.source_func + "()";
+			source_txt += " @ " + oe.source_func;
+			if (!oe.source_func.ends_with(")")) {
+				source_txt += "()";
+			}
 		}
 
 		TreeItem *cpp_source = error_tree->create_item(error);
-		cpp_source->set_text(0, "<" + (source_is_project_file ? TTR("Source") : TTR("C++ Source")) + ">");
+		// TRANSLATORS: %s is the name of a language, e.g. C++.
+		cpp_source->set_text(0, "<" + vformat(TTR("%s Source"), source_language_name) + ">");
 		cpp_source->set_text(1, source_txt);
 		cpp_source->set_text_alignment(0, HORIZONTAL_ALIGNMENT_LEFT);
-		tooltip += (source_is_project_file ? TTR("Source:") : TTR("C++ Source:")) + " " + source_txt + "\n";
+		tooltip += vformat(TTR("%s Source:"), source_language_name) + source_txt + "\n";
 
 		// Set metadata to highlight error line in scripts.
 		if (source_is_project_file) {
@@ -581,7 +597,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 				tooltip += TTR("Stack Trace:") + "\n";
 			}
 
-			String frame_txt = infos[i].file.get_file() + ":" + itos(infos[i].line) + " @ " + infos[i].func + "()";
+			String frame_txt = _format_frame_text(&infos[i]);
 			tooltip += frame_txt + "\n";
 			stack_trace->set_text(1, frame_txt);
 		}
@@ -899,6 +915,14 @@ void ScriptEditorDebugger::_breakpoint_tree_clicked() {
 	if (selected->has_meta("line")) {
 		emit_signal(SNAME("breakpoint_selected"), selected->get_parent()->get_text(0), int(selected->get_meta("line")));
 	}
+}
+
+String ScriptEditorDebugger::_format_frame_text(const ScriptLanguage::StackInfo *info) {
+	String text = info->file.get_file() + ":" + itos(info->line) + " @ " + info->func;
+	if (!text.ends_with(")")) {
+		text += "()";
+	}
+	return text;
 }
 
 void ScriptEditorDebugger::start(Ref<RemoteDebuggerPeer> p_peer) {

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -210,6 +210,8 @@ private:
 
 	void _breakpoint_tree_clicked();
 
+	String _format_frame_text(const ScriptLanguage::StackInfo *info);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
@@ -68,7 +68,7 @@ namespace Godot.NativeInterop
             string file = globalFrames.Count > 0 ? globalFrames[0].File ?? "" : "";
             string func = globalFrames.Count > 0 ? globalFrames[0].Func : "";
             int line = globalFrames.Count > 0 ? globalFrames[0].Line : 0;
-            string errorMsg = "Exception";
+            string errorMsg = e.GetType().FullName ?? "";
 
             using godot_string nFile = Marshaling.ConvertStringToNative(file);
             using godot_string nFunc = Marshaling.ConvertStringToNative(func);

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -31,6 +31,7 @@
 #include "runtime_interop.h"
 
 #include "core/config/engine.h"
+#include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
 #include "core/io/marshalls.h"
@@ -45,6 +46,7 @@
 #include "modules/mono/managed_callable.h"
 #include "modules/mono/mono_gd/gd_mono_cache.h"
 #include "modules/mono/signal_awaiter_utils.h"
+#include "modules/mono/utils/path_utils.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -84,7 +86,8 @@ void godotsharp_stack_info_vector_destroy(
 void godotsharp_internal_script_debugger_send_error(const String *p_func,
 		const String *p_file, int32_t p_line, const String *p_err, const String *p_descr,
 		bool p_warning, const Vector<ScriptLanguage::StackInfo> *p_stack_info_vector) {
-	EngineDebugger::get_script_debugger()->send_error(*p_func, *p_file, p_line, *p_err, *p_descr,
+	const String file = ProjectSettings::get_singleton()->localize_path(p_file->simplify_path());
+	EngineDebugger::get_script_debugger()->send_error(*p_func, file, p_line, *p_err, *p_descr,
 			true, p_warning ? ERR_HANDLER_WARNING : ERR_HANDLER_ERROR, *p_stack_info_vector);
 }
 


### PR DESCRIPTION
For starters, I found it very weird that we were using the least deep stack frame as the main error message in red (and only info when the stack is closed), so I used the right (IMHO) one instead.  
I also got rid of the odd doubled parenthesis we had in C# errors, so I got rid of them. I imagine it's here for other languages that don't have them already baked in the error.  
Last, for C# exceptions, I added the actual exception type where we simply had "Exception" hard coded before.  

I'd like to change the **C++ Error** and **C++ Source** labels when we're not dealing with C++ errors, but I didn't find a way to do it that didn't feel too hacky. I'm open to suggestions if someone wants to push me in the right direction.

Before:
![godot windows editor dev x86_64 mono_gbBklhVeAS](https://user-images.githubusercontent.com/437025/214162695-73874c02-1a84-4119-98cb-9aef1888143f.png)
After:
![godot windows editor dev x86_64 mono_1G61NJ8Rwc](https://user-images.githubusercontent.com/437025/214162708-ad1d88b5-430c-41e2-b340-4969a7d9cd04.png)

- Closes https://github.com/godotengine/godot/issues/67451
