### PR TITLE
Force update AnimationTree player cache when AnimationPlayer changes.

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1861,6 +1861,8 @@ void AnimationTree::_setup_animation_player() {
 		return;
 	}
 
+	cache_valid = false;
+
 	AnimationPlayer *new_player = nullptr;
 	if (!animation_player.is_empty()) {
 		new_player = Object::cast_to<AnimationPlayer>(get_node_or_null(animation_player));


### PR DESCRIPTION
Updates the cache if the AnimationTree node's AnimationPlayer changes to another, which should address a bug of the AnimationTree not playing animations.

May fix this issue, but not sure
#53357