### PR TITLE
Prevent region_rect incorrect overriding in `StyleBoxTexture`

### DIFF
--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -151,11 +151,6 @@ void StyleBoxTexture::set_texture(Ref<Texture2D> p_texture) {
 		return;
 	}
 	texture = p_texture;
-	if (p_texture.is_null()) {
-		region_rect = Rect2(0, 0, 0, 0);
-	} else {
-		region_rect = Rect2(Point2(), texture->get_size());
-	}
 	emit_changed();
 }
 


### PR DESCRIPTION
Second attempt to fix https://github.com/godotengine/godot/issues/71913, region_rect should be setted only in `set_region_rect` and not by `set_texture`. cc @YuriSizov. Also fixes https://github.com/godotengine/godot/issues/71891