### PR TITLE
Enforce Signal parameter types in Connect

### DIFF
--- a/core/object/callable_method_pointer.cpp
+++ b/core/object/callable_method_pointer.cpp
@@ -74,6 +74,10 @@ CallableCustom::CompareLessFunc CallableCustomMethodPointerBase::get_compare_les
 	return compare_less;
 }
 
+bool CallableCustomMethodPointerBase::get_method_info(MethodInfo *r_method_info) const {
+	return false; // Ignore for C++ method pointers
+}
+
 uint32_t CallableCustomMethodPointerBase::hash() const {
 	return h;
 }

--- a/core/object/callable_method_pointer.h
+++ b/core/object/callable_method_pointer.h
@@ -73,6 +73,7 @@ public:
 #endif
 	virtual CompareEqualFunc get_compare_equal_func() const;
 	virtual CompareLessFunc get_compare_less_func() const;
+	virtual bool get_method_info(MethodInfo *r_method_info) const;
 
 	virtual uint32_t hash() const;
 };

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -578,8 +578,16 @@ private:
 			List<Connection>::Element *cE = nullptr;
 		};
 
-		MethodInfo user;
+		MethodInfo info;
 		VMap<Callable, Slot> slot_map;
+
+		SignalData() {
+
+		}
+
+		SignalData(MethodInfo p_info) {
+			info = p_info;
+		}
 	};
 
 	HashMap<StringName, SignalData> signal_map;
@@ -799,6 +807,7 @@ public:
 	Variant property_get_revert(const StringName &p_name) const;
 
 	bool has_method(const StringName &p_method) const;
+	bool get_method_info(const StringName &p_method, MethodInfo *r_info) const;
 	void get_method_list(List<MethodInfo> *p_list) const;
 	Variant callv(const StringName &p_method, const Array &p_args);
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error);

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -152,6 +152,24 @@ StringName Callable::get_method() const {
 	return method;
 }
 
+bool Callable::get_method_info(MethodInfo *r_method_info) const {
+	if (r_method_info == nullptr) {
+		return false;
+	}
+	if (is_null()) {
+		return false;
+	}
+	if (is_custom()) {
+		return custom->get_method_info(r_method_info);
+	}
+	MethodInfo method_info;
+	if (!get_object()->get_method_info(method, &method_info)) {
+		return false;
+	}
+	*r_method_info = method_info;
+	return true;
+}
+
 int Callable::get_bound_arguments_count() const {
 	if (!is_null() && is_custom()) {
 		return custom->get_bound_arguments_count();
@@ -386,6 +404,10 @@ Error CallableCustom::rpc(int p_peer_id, const Variant **p_arguments, int p_argc
 
 const Callable *CallableCustom::get_base_comparator() const {
 	return nullptr;
+}
+
+bool CallableCustom::get_method_info(MethodInfo *r_method_info) const {
+	return false;
 }
 
 int CallableCustom::get_bound_arguments_count() const {

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -36,6 +36,7 @@
 #include "core/templates/list.h"
 
 class Object;
+struct MethodInfo;
 class Variant;
 class CallableCustom;
 
@@ -106,6 +107,7 @@ public:
 	Object *get_object() const;
 	ObjectID get_object_id() const;
 	StringName get_method() const;
+	bool get_method_info(MethodInfo *r_method_info) const;
 	CallableCustom *get_custom() const;
 	int get_bound_arguments_count() const;
 	void get_bound_arguments_ref(Vector<Variant> &r_arguments, int &r_argcount) const; // Internal engine use, the exposed one is below.
@@ -150,6 +152,7 @@ public:
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const = 0;
 	virtual Error rpc(int p_peer_id, const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) const;
 	virtual const Callable *get_base_comparator() const;
+	virtual bool get_method_info(MethodInfo *r_method_info) const;
 	virtual int get_bound_arguments_count() const;
 	virtual void get_bound_arguments(Vector<Variant> &r_arguments, int &r_argcount) const;
 

--- a/core/variant/callable_bind.cpp
+++ b/core/variant/callable_bind.cpp
@@ -87,6 +87,10 @@ const Callable *CallableCustomBind::get_base_comparator() const {
 	return &callable;
 }
 
+bool CallableCustomBind::get_method_info(MethodInfo *r_method_info) const {
+	return callable.get_method_info(r_method_info);
+}
+
 int CallableCustomBind::get_bound_arguments_count() const {
 	return callable.get_bound_arguments_count() + binds.size();
 }
@@ -203,6 +207,10 @@ ObjectID CallableCustomUnbind::get_object() const {
 
 const Callable *CallableCustomUnbind::get_base_comparator() const {
 	return &callable;
+}
+
+bool CallableCustomUnbind::get_method_info(MethodInfo *r_method_info) const {
+	return callable.get_method_info(r_method_info);
 }
 
 int CallableCustomUnbind::get_bound_arguments_count() const {

--- a/core/variant/callable_bind.h
+++ b/core/variant/callable_bind.h
@@ -51,6 +51,7 @@ public:
 	virtual ObjectID get_object() const override; //must always be able to provide an object
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 	virtual const Callable *get_base_comparator() const override;
+	virtual bool get_method_info(MethodInfo *r_method_info) const override;
 	virtual int get_bound_arguments_count() const override;
 	virtual void get_bound_arguments(Vector<Variant> &r_arguments, int &r_argcount) const override;
 	Callable get_callable() { return callable; }
@@ -77,6 +78,7 @@ public:
 	virtual ObjectID get_object() const override; //must always be able to provide an object
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 	virtual const Callable *get_base_comparator() const override;
+	virtual bool get_method_info(MethodInfo *r_method_info) const override;
 	virtual int get_bound_arguments_count() const override;
 	virtual void get_bound_arguments(Vector<Variant> &r_arguments, int &r_argcount) const override;
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -96,7 +96,7 @@ class GDScript : public Script {
 	HashMap<StringName, GDScriptFunction *> member_functions;
 	HashMap<StringName, MemberInfo> member_indices; //members are just indices to the instantiated script.
 	HashMap<StringName, Ref<GDScript>> subclasses;
-	HashMap<StringName, Vector<StringName>> _signals;
+	HashMap<StringName, MethodInfo> _signals;
 	Dictionary rpc_config;
 
 #ifdef TOOLS_ENABLED

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -126,8 +126,9 @@ class GDScriptAnalyzer {
 	Ref<GDScriptParserRef> get_parser_for(const String &p_path);
 	static void reduce_identifier_from_base_set_class(GDScriptParser::IdentifierNode *p_identifier, GDScriptParser::DataType p_identifier_datatype);
 #ifdef DEBUG_ENABLED
+	bool validate_signal_connection(const GDScriptParser::CallNode *p_call, GDScriptParser::DataType *p_base_type);
 	bool is_shadowing(GDScriptParser::IdentifierNode *p_local, const String &p_context);
-#endif
+#endif // DEBUG_ENABLED
 
 public:
 	Error resolve_inheritance();

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2451,12 +2451,7 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 				const GDScriptParser::SignalNode *signal = member.signal;
 				StringName name = signal->identifier->name;
 
-				Vector<StringName> parameters_names;
-				parameters_names.resize(signal->parameters.size());
-				for (int j = 0; j < signal->parameters.size(); j++) {
-					parameters_names.write[j] = signal->parameters[j]->identifier->name;
-				}
-				p_script->_signals[name] = parameters_names;
+				p_script->_signals[name] = signal->datatype.method_info;
 #ifdef TOOLS_ENABLED
 				if (!signal->doc_description.is_empty()) {
 					p_script->doc_signals[name] = signal->doc_description;

--- a/modules/gdscript/gdscript_lambda_callable.cpp
+++ b/modules/gdscript/gdscript_lambda_callable.cpp
@@ -86,6 +86,21 @@ void GDScriptLambdaCallable::call(const Variant **p_arguments, int p_argcount, V
 	}
 }
 
+bool GDScriptLambdaCallable::get_method_info(MethodInfo *r_method_info) const {
+	MethodInfo l_info = MethodInfo(get_as_text());
+	for (int i = 0; i < function->get_argument_count(); i++) {
+		PropertyInfo arg_info = function->get_argument_type(i).operator PropertyInfo();
+#ifdef TOOLS_ENABLED
+		arg_info.name = function->get_argument_name(i);
+#else
+		arg_info.name = "arg" + itos(i);
+#endif
+		l_info.arguments.push_back(arg_info);
+	}
+	*r_method_info = l_info;
+	return true;
+}
+
 GDScriptLambdaCallable::GDScriptLambdaCallable(Ref<GDScript> p_script, GDScriptFunction *p_function, const Vector<Variant> &p_captures) {
 	script = p_script;
 	function = p_function;

--- a/modules/gdscript/gdscript_lambda_callable.h
+++ b/modules/gdscript/gdscript_lambda_callable.h
@@ -56,6 +56,7 @@ public:
 	CompareEqualFunc get_compare_equal_func() const override;
 	CompareLessFunc get_compare_less_func() const override;
 	ObjectID get_object() const override;
+	bool get_method_info(MethodInfo *r_method_info) const override;
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
 	GDScriptLambdaCallable(Ref<GDScript> p_script, GDScriptFunction *p_function, const Vector<Variant> &p_captures);


### PR DESCRIPTION
Beginning work for Typed signals.
Adds `get_method_info()` to Callable (not exposed to Godot) for retrieving Callable arg info.

Object's `connect` method now checks if the correct amount of non-initialized arguments exist in the callable, and if the types are equal (todo: Check if types are *compatible* instead). Currently only implemented in `connect`

Task list:
- [x] Check if types are compatible instead of doing explicit ==

- [x] Add checks in the analyzer to error ahead of time when `connect` uses a non-compatible Callable
- [x] Rewrite messages for readability
- [ ] Clean-up code
- [ ] Write tests

## Example
```gdscript
extends Node2D

signal typed(arg1:bool, arg2:int);

func incorrect_arg_amount(arg1:Vector2):
	pass

func incorrect_arg_types(arg1:Node, arg2:String):
	pass

func _ready():
	push_warning("Incorrect arg amount");
	typed.connect(incorrect_arg_amount);
	push_warning("Incorrect arg types");
	typed.connect(incorrect_arg_types);
	
	push_warning("Lambdas are also checked, of course.");
	typed.connect(func(arg1:String):
		pass
	);
```

![image](https://user-images.githubusercontent.com/12436824/214220219-1139e9a6-922b-480c-b4f7-ed730efc0a3f.png)

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/2557 and closes https://github.com/godotengine/godot/issues/54333.*
