### PR TITLE
Fix incorrect claim in RemoteTransform2D class reference

### DIFF
--- a/doc/classes/RemoteTransform2D.xml
+++ b/doc/classes/RemoteTransform2D.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RemoteTransform2D" inherits="Node2D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		RemoteTransform2D pushes its own [Transform2D] to another [CanvasItem] derived Node in the scene.
+		RemoteTransform2D pushes its own [Transform2D] to another [Node2D] derived node in the scene.
 	</brief_description>
 	<description>
-		RemoteTransform2D pushes its own [Transform2D] to another [CanvasItem] derived Node (called the remote node) in the scene.
-		It can be set to update another Node's position, rotation and/or scale. It can use either global or local coordinates.
+		RemoteTransform2D pushes its own [Transform2D] to another [Node2D] derived node (called the remote node) in the scene.
+		It can be set to update another node's position, rotation and/or scale. It can use either global or local coordinates.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Fixes #71723

Changes reference to `CanvasItem` into `Node2D`, because this is the actual use case ([docs](https://docs.godotengine.org/en/latest/classes/class_remotetransform2d.html))

Also changed some references to nodes in lowercase, I believe that's the correct way to refer some generic node (in contrast to `Node`, from which `Node2D` and `Node3D` inherit).
