### PR TITLE
Clarify error message if icon is after class_name

### DIFF
--- a/modules/gdscript/tests/scripts/parser/errors/class_name_after_annotation.out
+++ b/modules/gdscript/tests/scripts/parser/errors/class_name_after_annotation.out
@@ -1,2 +1,2 @@
 GDTEST_PARSER_ERROR
-Annotation "@icon" is not allowed in this level.
+Annotation "@icon" must be before "class_name".


### PR DESCRIPTION
Fixes #71947

I haven't yet got around to compile Godot from source, so I hope this is right, seemed like a simple fix 🤔 