### PR TITLE
Improve error messages and classref for occluders and portals

### DIFF
--- a/doc/classes/OccluderShapePolygon.xml
+++ b/doc/classes/OccluderShapePolygon.xml
@@ -17,7 +17,8 @@
 			<argument index="0" name="index" type="int" />
 			<argument index="1" name="position" type="Vector2" />
 			<description>
-				Sets an individual hole point position.
+				Sets an individual hole point position. Primarily for use by the editor.
+				[b]Note:[/b] This function will not resize the hole point array. Set [member hole_points] to set the number of points.
 			</description>
 		</method>
 		<method name="set_polygon_point">
@@ -25,7 +26,8 @@
 			<argument index="0" name="index" type="int" />
 			<argument index="1" name="position" type="Vector2" />
 			<description>
-				Sets an individual polygon point position.
+				Sets an individual polygon point position. Primarily for use by the editor.
+				[b]Note:[/b] This function will not resize the polygon point array. Set [member polygon_points] to set the number of points.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/OccluderShapeSphere.xml
+++ b/doc/classes/OccluderShapeSphere.xml
@@ -15,7 +15,7 @@
 			<argument index="0" name="index" type="int" />
 			<argument index="1" name="position" type="Vector3" />
 			<description>
-				Sets an individual sphere's position.
+				Sets an individual sphere's position. Primarily for use by the editor.
 			</description>
 		</method>
 		<method name="set_sphere_radius">
@@ -23,7 +23,7 @@
 			<argument index="0" name="index" type="int" />
 			<argument index="1" name="radius" type="float" />
 			<description>
-				Sets an individual sphere's radius.
+				Sets an individual sphere's radius. Primarily for use by the editor.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Portal.xml
+++ b/doc/classes/Portal.xml
@@ -18,6 +18,7 @@
 			<argument index="1" name="position" type="Vector2" />
 			<description>
 				Sets individual points. Primarily for use by the editor.
+				[b]Note:[/b] This function will not resize the point array. Set [member points] to set the number of points.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Room.xml
+++ b/doc/classes/Room.xml
@@ -19,6 +19,7 @@
 			<argument index="1" name="position" type="Vector3" />
 			<description>
 				Sets individual points. Primarily for use by the editor.
+				[b]Note:[/b] This function will not resize the point array. Set [member points] to set the number of points.
 			</description>
 		</method>
 	</methods>

--- a/scene/3d/portal.cpp
+++ b/scene/3d/portal.cpp
@@ -115,9 +115,7 @@ String Portal::get_configuration_warning() const {
 }
 
 void Portal::set_point(int p_idx, const Vector2 &p_point) {
-	if (p_idx >= _pts_local_raw.size()) {
-		return;
-	}
+	ERR_FAIL_INDEX_MSG(p_idx, _pts_local_raw.size(), "Index out of bounds. Call set_points() to set the size of the array.");
 
 	_pts_local_raw.set(p_idx, p_point);
 	_sanitize_points();

--- a/scene/3d/room.cpp
+++ b/scene/3d/room.cpp
@@ -131,9 +131,7 @@ void Room::set_use_default_simplify(bool p_use) {
 }
 
 void Room::set_point(int p_idx, const Vector3 &p_point) {
-	if (p_idx >= _bound_pts.size()) {
-		return;
-	}
+	ERR_FAIL_INDEX_MSG(p_idx, _bound_pts.size(), "Index out of bounds. Call set_points() to set the size of the array.");
 
 	_bound_pts.set(p_idx, p_point);
 

--- a/scene/resources/occluder_shape.cpp
+++ b/scene/resources/occluder_shape.cpp
@@ -210,29 +210,29 @@ void OccluderShapeSphere::set_spheres(const Vector<Plane> &p_spheres) {
 }
 
 void OccluderShapeSphere::set_sphere_position(int p_idx, const Vector3 &p_position) {
-	if ((p_idx >= 0) && (p_idx < _spheres.size())) {
-		Plane p = _spheres[p_idx];
-		p.normal = p_position;
-		_spheres.set(p_idx, p);
+	ERR_FAIL_INDEX(p_idx, _spheres.size());
+
+	Plane p = _spheres[p_idx];
+	p.normal = p_position;
+	_spheres.set(p_idx, p);
 #ifdef TOOLS_ENABLED
-		_update_aabb();
+	_update_aabb();
 #endif
-		update_shape_to_visual_server();
-		notify_change_to_owners();
-	}
+	update_shape_to_visual_server();
+	notify_change_to_owners();
 }
 
 void OccluderShapeSphere::set_sphere_radius(int p_idx, real_t p_radius) {
-	if ((p_idx >= 0) && (p_idx < _spheres.size())) {
-		Plane p = _spheres[p_idx];
-		p.d = MAX(p_radius, _min_radius);
-		_spheres.set(p_idx, p);
+	ERR_FAIL_INDEX(p_idx, _spheres.size());
+
+	Plane p = _spheres[p_idx];
+	p.d = MAX(p_radius, _min_radius);
+	_spheres.set(p_idx, p);
 #ifdef TOOLS_ENABLED
-		_update_aabb();
+	_update_aabb();
 #endif
-		update_shape_to_visual_server();
-		notify_change_to_owners();
-	}
+	update_shape_to_visual_server();
+	notify_change_to_owners();
 }
 
 OccluderShapeSphere::OccluderShapeSphere() {

--- a/scene/resources/occluder_shape_polygon.cpp
+++ b/scene/resources/occluder_shape_polygon.cpp
@@ -102,9 +102,7 @@ void OccluderShapePolygon::_sanitize_points() {
 }
 
 void OccluderShapePolygon::set_polygon_point(int p_idx, const Vector2 &p_point) {
-	if (p_idx >= _poly_pts_local_raw.size()) {
-		return;
-	}
+	ERR_FAIL_INDEX_MSG(p_idx, _poly_pts_local_raw.size(), "Index out of bounds. Call set_polygon_points() to set the size of the array.");
 
 	_poly_pts_local_raw.set(p_idx, p_point);
 	_sanitize_points();
@@ -113,9 +111,7 @@ void OccluderShapePolygon::set_polygon_point(int p_idx, const Vector2 &p_point) 
 }
 
 void OccluderShapePolygon::set_hole_point(int p_idx, const Vector2 &p_point) {
-	if (p_idx >= _hole_pts_local_raw.size()) {
-		return;
-	}
+	ERR_FAIL_INDEX_MSG(p_idx, _hole_pts_local_raw.size(), "Index out of bounds. Call set_hole_points() to set the size of the array.");
 
 	_hole_pts_local_raw.set(p_idx, p_point);
 	_sanitize_points();


### PR DESCRIPTION
Misused functions would previously produce no error messages which was confusing for users.

Fixes #71908

## Notes
* The same lack of error message was present in portals so I fixed that too.
* Let me know any improvements on wording.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
