### PR TITLE
[Input] Do not add key labels to the default actions, to display it correctly in the UI.

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -478,7 +478,6 @@ Ref<InputEventKey> InputEventKey::create_reference(Key p_keycode) {
 	Ref<InputEventKey> ie;
 	ie.instantiate();
 	ie->set_keycode(p_keycode & KeyModifierMask::CODE_MASK);
-	ie->set_key_label(p_keycode & KeyModifierMask::CODE_MASK);
 	ie->set_unicode(char32_t(p_keycode & KeyModifierMask::CODE_MASK));
 
 	if ((p_keycode & KeyModifierMask::SHIFT) != Key::NONE) {


### PR DESCRIPTION
Fixes regression from #70052 causing default actions to be displayed as `Key Label` actions instead of `Keycode` action in the editor UI.