### PR TITLE
Update the Godot Android Editor name from `Godot Editor` to `Godot Editor 3`

### DIFF
--- a/platform/android/java/editor/src/dev/res/values/strings.xml
+++ b/platform/android/java/editor/src/dev/res/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="godot_editor_name_string">Godot Editor (dev)</string>
+	<string name="godot_editor_name_string">Godot Editor 3 (dev)</string>
 </resources>

--- a/platform/android/java/editor/src/main/res/values/strings.xml
+++ b/platform/android/java/editor/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="godot_editor_name_string">Godot Editor</string>
+	<string name="godot_editor_name_string">Godot Editor 3</string>
 
 	<string name="denied_storage_permission_error_msg">Missing storage access permission!</string>
 </resources>


### PR DESCRIPTION
Keep things consistent with the label used for `Godot Editor 4`, and avoid user confusion regarding the different versions of the engine.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
