### PR TITLE
Sync C# Dictionary with Core

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -409,6 +409,10 @@ namespace Godot.NativeInterop
         public static partial void godotsharp_dictionary_duplicate(ref godot_dictionary p_self, godot_bool p_deep,
             out godot_dictionary r_dest);
 
+        public static partial void godotsharp_dictionary_merge(ref godot_dictionary p_self, in godot_dictionary p_dictionary, godot_bool p_overwrite);
+
+        public static partial godot_bool godotsharp_dictionary_recursive_equal(ref godot_dictionary p_self, in godot_dictionary p_other);
+
         public static partial godot_bool godotsharp_dictionary_remove_key(ref godot_dictionary p_self,
             in godot_variant p_key);
 

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -1066,6 +1066,14 @@ void godotsharp_dictionary_duplicate(const Dictionary *p_self, bool p_deep, Dict
 	memnew_placement(r_dest, Dictionary(p_self->duplicate(p_deep)));
 }
 
+void godotsharp_dictionary_merge(Dictionary *p_self, const Dictionary *p_dictionary, bool p_overwrite) {
+	p_self->merge(*p_dictionary, p_overwrite);
+}
+
+bool godotsharp_dictionary_recursive_equal(const Dictionary *p_self, const Dictionary *p_other) {
+	return p_self->recursive_equal(*p_other, 0);
+}
+
 bool godotsharp_dictionary_remove_key(Dictionary *p_self, const Variant *p_key) {
 	return p_self->erase(*p_key);
 }
@@ -1455,6 +1463,8 @@ static const void *unmanaged_callbacks[]{
 	(void *)godotsharp_dictionary_clear,
 	(void *)godotsharp_dictionary_contains_key,
 	(void *)godotsharp_dictionary_duplicate,
+	(void *)godotsharp_dictionary_merge,
+	(void *)godotsharp_dictionary_recursive_equal,
 	(void *)godotsharp_dictionary_remove_key,
 	(void *)godotsharp_dictionary_to_string,
 	(void *)godotsharp_string_simplify_path,


### PR DESCRIPTION
- Implement `ICollection` methods explicitly.
  - This hides methods that take `KeyValuePair` as it's not a very convenient way to use dictionaries.
  - These methods are also implemented explicitly in `System.Collections.Generic.Dictionary`.
- Add `Merge` method.
  - Added to Core in https://github.com/godotengine/godot/pull/59883.
  - Should offer better performance than implementing it manually in C# due to marshaling.
- Add `RecursiveEqual` method.
  - Serves as the equivalent of GDScript's `==` and `!=` operators which compare by value. These operators still compare by reference in .NET since that's likely the users expectation as all .NET collections work like this.
  - Should offer better performance than comparing iterating and comparing the array items from C# or using LINQ as that would require marshaling every item.
  - Matches the `RecursiveEqual` method implemented in `Godot.Collections.Array` in https://github.com/godotengine/godot/pull/71786.
- Updates documentation.