### PR TITLE
Handle gltf case when the gltf node is both a bone and a mesh.

### DIFF
--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -89,6 +89,7 @@ class GLTFState : public Resource {
 	HashMap<GLTFSkeletonIndex, GLTFNodeIndex> skeleton_to_node;
 	Vector<Ref<GLTFAnimation>> animations;
 	HashMap<GLTFNodeIndex, Node *> scene_nodes;
+	HashMap<GLTFNodeIndex, ImporterMeshInstance3D *> scene_mesh_instances;
 
 	HashMap<ObjectID, GLTFSkeletonIndex> skeleton3d_to_gltf_skeleton;
 	HashMap<ObjectID, HashMap<ObjectID, GLTFSkinIndex>> skin_and_skeleton3d_to_gltf_skin;
@@ -182,6 +183,7 @@ public:
 	void set_animations(TypedArray<GLTFAnimation> p_animations);
 
 	Node *get_scene_node(GLTFNodeIndex idx);
+	ImporterMeshInstance3D *get_scene_mesh_instance(GLTFNodeIndex idx);
 
 	int get_animation_players_count(int idx);
 


### PR DESCRIPTION
> From Lyuma:
> If a skinned mesh has a child node, we should create a virtual child node with the skinned mesh itself, and leave the original node as a plain node 
> this is what blender does. it calls this virtual node "Mesh_1"
> _parse_meshes() reads the mesh data
> The case we need to handle is: "does a skinned mesh have a child gltf node?"

Fixes: https://github.com/godotengine/godot/issues/67773

![image](https://user-images.githubusercontent.com/32321/214368579-4d1a4c70-55e2-429b-b6be-fc67b2906666.png)



