### PR TITLE
Seal C# attributes

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/AssemblyHasScriptsAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/AssemblyHasScriptsAttribute.cs
@@ -10,7 +10,7 @@ namespace Godot
     /// collection of types that implement scripts; otherwise, retrieving the types requires lookup.
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly)]
-    public class AssemblyHasScriptsAttribute : Attribute
+    public sealed class AssemblyHasScriptsAttribute : Attribute
     {
         /// <summary>
         /// If the Godot scripts contained in the assembly require lookup

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/MustBeVariantAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/MustBeVariantAttribute.cs
@@ -7,5 +7,5 @@ namespace Godot
     /// that can be marshaled from/to a <see cref="Variant"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.GenericParameter)]
-    public class MustBeVariantAttribute : Attribute { }
+    public sealed class MustBeVariantAttribute : Attribute { }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/RPCAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/RPCAttribute.cs
@@ -9,7 +9,7 @@ namespace Godot
     /// By default, methods are not exposed to networking (and RPCs).
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    public class RPCAttribute : Attribute
+    public sealed class RPCAttribute : Attribute
     {
         /// <summary>
         /// RPC mode for the annotated method.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ScriptPathAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ScriptPathAttribute.cs
@@ -6,7 +6,7 @@ namespace Godot
     /// An attribute that contains the path to the object's script.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    public class ScriptPathAttribute : Attribute
+    public sealed class ScriptPathAttribute : Attribute
     {
         /// <summary>
         /// File path to the script.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/SignalAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/SignalAttribute.cs
@@ -3,5 +3,5 @@ using System;
 namespace Godot
 {
     [AttributeUsage(AttributeTargets.Delegate)]
-    public class SignalAttribute : Attribute { }
+    public sealed class SignalAttribute : Attribute { }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ToolAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ToolAttribute.cs
@@ -3,5 +3,5 @@ using System;
 namespace Godot
 {
     [AttributeUsage(AttributeTargets.Class)]
-    public class ToolAttribute : Attribute { }
+    public sealed class ToolAttribute : Attribute { }
 }


### PR DESCRIPTION
This prevents users from inhering these classes, doing so has no effect anyway since our source generators only look for the exact class. I don't expect any users would be inheriting them so it's likely safe, but it's probably better to do this before 4.0 anyway to avoid breaking compat later.