### PR TITLE
Move Array:set_typed to internal GDExtension structure and unexposed it.

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -856,6 +856,13 @@ static GDExtensionVariantPtr gdextension_array_operator_index_const(GDExtensionC
 	return (GDExtensionVariantPtr)&self->operator[](p_index);
 }
 
+void gdextension_array_set_typed(GDExtensionTypePtr p_self, uint32_t p_type, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstVariantPtr p_script) {
+	Array *self = reinterpret_cast<Array *>(p_self);
+	const StringName *class_name = reinterpret_cast<const StringName *>(p_class_name);
+	const Variant *script = reinterpret_cast<const Variant *>(p_script);
+	self->set_typed(p_type, *class_name, *script);
+}
+
 /* Dictionary functions */
 
 static GDExtensionVariantPtr gdextension_dictionary_operator_index(GDExtensionTypePtr p_self, GDExtensionConstVariantPtr p_key) {
@@ -1129,6 +1136,7 @@ void gdextension_setup_interface(GDExtensionInterface *p_interface) {
 
 	gde_interface.array_operator_index = gdextension_array_operator_index;
 	gde_interface.array_operator_index_const = gdextension_array_operator_index_const;
+	gde_interface.array_set_typed = gdextension_array_set_typed;
 
 	/* Dictionary functions */
 

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -551,6 +551,7 @@ typedef struct {
 
 	GDExtensionVariantPtr (*array_operator_index)(GDExtensionTypePtr p_self, GDExtensionInt p_index); // p_self should be an Array ptr
 	GDExtensionVariantPtr (*array_operator_index_const)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index); // p_self should be an Array ptr
+	void (*array_set_typed)(GDExtensionTypePtr p_self, uint32_t p_type, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstVariantPtr p_script); // p_self should be an Array ptr
 
 	/* Dictionary functions */
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2224,7 +2224,6 @@ static void _register_variant_builtin_methods() {
 	bind_method(Array, max, sarray(), varray());
 	bind_method(Array, min, sarray(), varray());
 	bind_method(Array, typed_assign, sarray("array"), varray());
-	bind_method(Array, set_typed, sarray("type", "class_name", "script"), varray());
 	bind_method(Array, is_typed, sarray(), varray());
 	bind_method(Array, get_typed_builtin, sarray(), varray());
 	bind_method(Array, get_typed_class_name, sarray(), varray());

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -59,7 +59,7 @@
 			<param index="2" name="class_name" type="StringName" />
 			<param index="3" name="script" type="Variant" />
 			<description>
-				Creates a typed array from the [param base] array. The base array can't be already typed. See [method set_typed] for more details.
+				Creates a typed array from the [param base] array. The base array can't be already typed.
 			</description>
 		</constructor>
 		<constructor name="Array">
@@ -528,16 +528,6 @@
 			<param index="1" name="from" type="int" default="-1" />
 			<description>
 				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array.
-			</description>
-		</method>
-		<method name="set_typed">
-			<return type="void" />
-			<param index="0" name="type" type="int" />
-			<param index="1" name="class_name" type="StringName" />
-			<param index="2" name="script" type="Variant" />
-			<description>
-				Makes the [Array] typed. The [param type] should be one of the [enum Variant.Type] constants. [param class_name] is optional and can only be provided for [constant TYPE_OBJECT]. [param script] can only be provided if [param class_name] is not empty.
-				The method fails if an array is already typed.
 			</description>
 		</method>
 		<method name="shuffle">


### PR DESCRIPTION
Alternative to https://github.com/godotengine/godot/pull/69441

Depends on godot-cpp part - https://github.com/godotengine/godot-cpp/pull/1013