### PR TITLE
C#: Remove `GetArea` and `GetVolume` methods

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
@@ -50,6 +50,15 @@ namespace Godot
         }
 
         /// <summary>
+        /// The volume of this <see cref="Aabb"/>.
+        /// See also <see cref="HasVolume"/>.
+        /// </summary>
+        public readonly real_t Volume
+        {
+            get { return _size.X * _size.Y * _size.Z; }
+        }
+
+        /// <summary>
         /// Returns an <see cref="Aabb"/> with equivalent position and size, modified so that
         /// the most-negative corner is the origin and the size is positive.
         /// </summary>
@@ -312,15 +321,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the volume of the <see cref="Aabb"/>.
-        /// </summary>
-        /// <returns>The volume.</returns>
-        public readonly real_t GetVolume()
-        {
-            return _size.X * _size.Y * _size.Z;
-        }
-
-        /// <summary>
         /// Returns a copy of the <see cref="Aabb"/> grown a given amount of units towards all the sides.
         /// </summary>
         /// <param name="by">The amount to grow by.</param>
@@ -383,7 +383,7 @@ namespace Godot
         /// Returns <see langword="true"/> if the <see cref="Aabb"/> has
         /// area, and <see langword="false"/> if the <see cref="Aabb"/>
         /// is linear, empty, or has a negative <see cref="Size"/>.
-        /// See also <see cref="GetVolume"/>.
+        /// See also <see cref="Volume"/>.
         /// </summary>
         /// <returns>
         /// A <see langword="bool"/> for whether or not the <see cref="Aabb"/> has volume.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -51,11 +51,11 @@ namespace Godot
 
         /// <summary>
         /// The area of this <see cref="Rect2"/>.
+        /// See also <see cref="HasArea"/>.
         /// </summary>
-        /// <value>Equivalent to <see cref="GetArea()"/>.</value>
         public readonly real_t Area
         {
-            get { return GetArea(); }
+            get { return _size.X * _size.Y; }
         }
 
         /// <summary>
@@ -161,15 +161,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the area of the <see cref="Rect2"/>.
-        /// </summary>
-        /// <returns>The area.</returns>
-        public readonly real_t GetArea()
-        {
-            return _size.X * _size.Y;
-        }
-
-        /// <summary>
         /// Returns the center of the <see cref="Rect2"/>, which is equal
         /// to <see cref="Position"/> + (<see cref="Size"/> / 2).
         /// </summary>
@@ -247,7 +238,7 @@ namespace Godot
         /// Returns <see langword="true"/> if the <see cref="Rect2"/> has
         /// area, and <see langword="false"/> if the <see cref="Rect2"/>
         /// is linear, empty, or has a negative <see cref="Size"/>.
-        /// See also <see cref="GetArea"/>.
+        /// See also <see cref="Area"/>.
         /// </summary>
         /// <returns>
         /// A <see langword="bool"/> for whether or not the <see cref="Rect2"/> has area.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2I.cs
@@ -51,11 +51,11 @@ namespace Godot
 
         /// <summary>
         /// The area of this <see cref="Rect2I"/>.
+        /// See also <see cref="HasArea"/>.
         /// </summary>
-        /// <value>Equivalent to <see cref="GetArea()"/>.</value>
         public readonly int Area
         {
-            get { return GetArea(); }
+            get { return _size.X * _size.Y; }
         }
 
         /// <summary>
@@ -151,15 +151,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the area of the <see cref="Rect2I"/>.
-        /// </summary>
-        /// <returns>The area.</returns>
-        public readonly int GetArea()
-        {
-            return _size.X * _size.Y;
-        }
-
-        /// <summary>
         /// Returns the center of the <see cref="Rect2I"/>, which is equal
         /// to <see cref="Position"/> + (<see cref="Size"/> / 2).
         /// If <see cref="Size"/> is an odd number, the returned center
@@ -239,7 +230,7 @@ namespace Godot
         /// Returns <see langword="true"/> if the <see cref="Rect2I"/> has
         /// area, and <see langword="false"/> if the <see cref="Rect2I"/>
         /// is linear, empty, or has a negative <see cref="Size"/>.
-        /// See also <see cref="GetArea"/>.
+        /// See also <see cref="Area"/>.
         /// </summary>
         /// <returns>
         /// A <see langword="bool"/> for whether or not the <see cref="Rect2I"/> has area.


### PR DESCRIPTION
- Alternative of https://github.com/godotengine/godot/pull/71457 that keeps the properties instead of the methods.
- Remove `GetArea` method in favor of the `Area` property in `Rect2{i}`.
	- This avoids having 2 members that do the same thing and may confuse users.
- Replace `GetVolume` method with a `Volume` property in `AABB`.
	- To keep consistency with the 2D types.
