### PR TITLE
GDScript: Fix implicit conversions for function returns

### DIFF
--- a/modules/gdscript/tests/scripts/analyzer/features/return_conversions.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/return_conversions.gd
@@ -1,0 +1,34 @@
+func convert_literal_int_to_float() -> float: return 76
+func convert_arg_int_to_float(arg: int) -> float: return arg
+func convert_var_int_to_float() -> float: var number := 59; return number
+
+func convert_literal_array_to_packed() -> PackedStringArray: return ['46']
+func convert_arg_array_to_packed(arg: Array) -> PackedStringArray: return arg
+func convert_var_array_to_packed() -> PackedStringArray: var array := ['79']; return array
+
+func test():
+	var converted_literal_int := convert_literal_int_to_float()
+	assert(typeof(converted_literal_int) == TYPE_FLOAT)
+	assert(converted_literal_int == 76.0)
+
+	var converted_arg_int := convert_arg_int_to_float(36)
+	assert(typeof(converted_arg_int) == TYPE_FLOAT)
+	assert(converted_arg_int == 36.0)
+
+	var converted_var_int := convert_var_int_to_float()
+	assert(typeof(converted_var_int) == TYPE_FLOAT)
+	assert(converted_var_int == 59.0)
+
+	var converted_literal_array := convert_literal_array_to_packed()
+	assert(typeof(converted_literal_array) == TYPE_PACKED_STRING_ARRAY)
+	assert(str(converted_literal_array) == '["46"]')
+
+	var converted_arg_array := convert_arg_array_to_packed(['91'])
+	assert(typeof(converted_arg_array) == TYPE_PACKED_STRING_ARRAY)
+	assert(str(converted_arg_array) == '["91"]')
+
+	var converted_var_array := convert_var_array_to_packed()
+	assert(typeof(converted_var_array) == TYPE_PACKED_STRING_ARRAY)
+	assert(str(converted_var_array) == '["79"]')
+
+	print('ok')

--- a/modules/gdscript/tests/scripts/analyzer/features/return_conversions.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/return_conversions.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok


### PR DESCRIPTION
VM supports conversions of returned values in functions to a specified return type but a check for compatibility in `resolve_return` was not allowing implicit conversions. Fixed it.

```gdscript
func returns_float() -> float:
  return 1
  
func returns_packed_array() -> PackedStringArray:
  return ['a'] 
```

Did not know that such conversions were not allowed already. #71844 makes conversions for constant return values (like in `returns_float` here) to happen only once and during compilation.

Also made handling of untyped/variants - marking of unsafe lines and weak source downgrades - consistent with initializers and assignments. Theoretically it is possible to unify all cases where "value type meets specified type" - initializers/assignments/returns/casts/arguments.

Fixes #65286.
Fixes #71971.