### PR TITLE
GDScript: Fix marking of line with unsafe property access as unsafe

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3534,6 +3534,7 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 				}
 #endif
 				result_type.kind = GDScriptParser::DataType::VARIANT;
+				mark_node_unsafe(p_subscript);
 			}
 		}
 		if (!valid) {


### PR DESCRIPTION
Fixes #51142.