### PR TITLE
[CI] Remove packages that are no longer necessary.

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -82,10 +82,8 @@ jobs:
           sudo cp -f misc/ci/sources.list /etc/apt/sources.list
           sudo apt-get update
           # The actual dependencies
-          sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
-              libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev \
-              libdbus-1-dev libudev-dev libxi-dev libxrandr-dev yasm xvfb wget unzip \
-              llvm libspeechd-dev speech-dispatcher fontconfig libfontconfig-dev libxkbcommon-dev
+          sudo apt-get install build-essential pkg-config libgl1-mesa-dev libglu-dev \
+              xvfb wget unzip llvm
 
       - name: Setup Godot build cache
         uses: ./.github/actions/godot-cache


### PR DESCRIPTION
Bunch or `-dev` packages should be unnecessary after https://github.com/godotengine/godot/pull/71263
Also, `yasm` is not used anywhere.