### PR TITLE
Fix using the right `tile_set` in `TilesEditorPlugin::_thread`

### DIFF
--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -101,7 +101,7 @@ void TilesEditorPlugin::_thread() {
 					encompassing_rect.expand_to(world_pos);
 
 					// Texture.
-					Ref<TileSetAtlasSource> atlas_source = tile_set->get_source(tile_map->get_cell_source_id(0, cell));
+					Ref<TileSetAtlasSource> atlas_source = item.tile_set->get_source(tile_map->get_cell_source_id(0, cell));
 					if (atlas_source.is_valid()) {
 						Vector2i coords = tile_map->get_cell_atlas_coords(0, cell);
 						int alternative = tile_map->get_cell_alternative_tile(0, cell);


### PR DESCRIPTION
Instead of using the class member, use the item's tile set, as is the intent.

This fixes an almost immediate crash in the editor for me, that appeared in beta 14 or 15 or so.
