### PR TITLE
OptionButton: allow reselection of selected item

### DIFF
--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -204,6 +204,9 @@
 	<members>
 		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" overrides="BaseButton" enum="BaseButton.ActionMode" default="0" />
 		<member name="alignment" type="int" setter="set_text_alignment" getter="get_text_alignment" overrides="Button" enum="HorizontalAlignment" default="0" />
+		<member name="allow_reselect" type="bool" setter="set_allow_reselect" getter="get_allow_reselect" default="false">
+			If [code]true[/code], the currently selected item can be selected again.
+		</member>
 		<member name="fit_to_longest_item" type="bool" setter="set_fit_to_longest_item" getter="is_fit_to_longest_item" default="true">
 			If [code]true[/code], minimum size will be determined by the longest item's text, instead of the currently selected one's.
 			[b]Note:[/b] For performance reasons, the minimum size doesn't update immediately when adding, removing or modifying items.
@@ -227,6 +230,7 @@
 			<param index="0" name="index" type="int" />
 			<description>
 				Emitted when the current item has been changed by the user. The index of the item selected is passed as argument.
+				[member allow_reselect] must be enabled to reselect an item.
 			</description>
 		</signal>
 	</signals>

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -383,6 +383,14 @@ bool OptionButton::is_fit_to_longest_item() const {
 	return fit_to_longest_item;
 }
 
+void OptionButton::set_allow_reselect(bool p_allow) {
+	allow_reselect = p_allow;
+}
+
+bool OptionButton::get_allow_reselect() const {
+	return allow_reselect;
+}
+
 void OptionButton::add_separator(const String &p_text) {
 	popup->add_separator(p_text);
 }
@@ -395,7 +403,7 @@ void OptionButton::clear() {
 }
 
 void OptionButton::_select(int p_which, bool p_emit) {
-	if (p_which == current) {
+	if (p_which == current && !allow_reselect) {
 		return;
 	}
 
@@ -560,11 +568,14 @@ void OptionButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_selectable_item", "from_last"), &OptionButton::get_selectable_item, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("set_fit_to_longest_item", "fit"), &OptionButton::set_fit_to_longest_item);
 	ClassDB::bind_method(D_METHOD("is_fit_to_longest_item"), &OptionButton::is_fit_to_longest_item);
+	ClassDB::bind_method(D_METHOD("set_allow_reselect", "allow"), &OptionButton::set_allow_reselect);
+	ClassDB::bind_method(D_METHOD("get_allow_reselect"), &OptionButton::get_allow_reselect);
 
 	// "selected" property must come after "item_count", otherwise GH-10213 occurs.
 	ADD_ARRAY_COUNT("Items", "item_count", "set_item_count", "get_item_count", "popup/item_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "selected"), "_select_int", "get_selected");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fit_to_longest_item"), "set_fit_to_longest_item", "is_fit_to_longest_item");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_reselect"), "set_allow_reselect", "get_allow_reselect");
 	ADD_SIGNAL(MethodInfo("item_selected", PropertyInfo(Variant::INT, "index")));
 	ADD_SIGNAL(MethodInfo("item_focused", PropertyInfo(Variant::INT, "index")));
 }

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -42,6 +42,7 @@ class OptionButton : public Button {
 	bool fit_to_longest_item = true;
 	Vector2 _cached_size;
 	bool cache_refresh_pending = false;
+	bool allow_reselect = false;
 
 	struct ThemeCache {
 		Ref<StyleBox> normal;
@@ -110,6 +111,9 @@ public:
 	int get_item_count() const;
 	void set_fit_to_longest_item(bool p_fit);
 	bool is_fit_to_longest_item() const;
+
+	void set_allow_reselect(bool p_allow);
+	bool get_allow_reselect() const;
 
 	void add_separator(const String &p_text = "");
 


### PR DESCRIPTION
Implementation of https://github.com/godotengine/godot-proposals/issues/4539

Adds an allow_reselect flag that works like the one in ItemList. When marked true, selecting the currently selected item will emit the item_selected signal, otherwise works as before.

*Bugsquad edit:*
- Closes https://github.com/godotengine/godot-proposals/issues/4539