### PR TITLE
[X11] Fix incorrect keycodes from non-QWERTY layouts.

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2933,6 +2933,7 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 	xkeyevent_no_mod.state &= ~ShiftMask;
 	xkeyevent_no_mod.state &= ~ControlMask;
 	XLookupString(xkeyevent, str, 255, &keysym_unicode, nullptr);
+	XLookupString(&xkeyevent_no_mod, nullptr, 0, &keysym_keycode, nullptr);
 
 	String keysym;
 	if (xkb_keysym_to_utf32 && xkb_keysym_to_upper) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/72026
