### PR TITLE
Fix crash when switching to a different node from AnimationTree

### DIFF
--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1138,7 +1138,7 @@ void AnimationNodeStateMachineEditor::_connection_draw(const Vector2 &p_from, co
 		accent.a *= 0.6;
 	}
 
-	const Ref<Texture2D> icons[6] = {
+	const Ref<Texture2D> icons[] = {
 		get_theme_icon(SNAME("TransitionImmediateBig"), SNAME("EditorIcons")),
 		get_theme_icon(SNAME("TransitionSyncBig"), SNAME("EditorIcons")),
 		get_theme_icon(SNAME("TransitionEndBig"), SNAME("EditorIcons")),
@@ -1146,6 +1146,7 @@ void AnimationNodeStateMachineEditor::_connection_draw(const Vector2 &p_from, co
 		get_theme_icon(SNAME("TransitionSyncAutoBig"), SNAME("EditorIcons")),
 		get_theme_icon(SNAME("TransitionEndAutoBig"), SNAME("EditorIcons"))
 	};
+	const int ICON_COUNT = sizeof(icons) / sizeof(*icons);
 
 	if (p_selected) {
 		state_machine_draw->draw_line(p_from, p_to, accent, 6);
@@ -1162,7 +1163,9 @@ void AnimationNodeStateMachineEditor::_connection_draw(const Vector2 &p_from, co
 		fade_linecolor.set_hsv(1.0, fade_linecolor.get_s(), fade_linecolor.get_v());
 		state_machine_draw->draw_line(p_from, p_from.lerp(p_to, p_fade_ratio), fade_linecolor, 2);
 	}
-	Ref<Texture2D> icon = icons[p_mode + (p_auto_advance ? 3 : 0)];
+	int icon_index = p_mode + (p_auto_advance ? ICON_COUNT / 2 : 0);
+	ERR_FAIL_COND(icon_index >= ICON_COUNT);
+	Ref<Texture2D> icon = icons[icon_index];
 
 	Transform2D xf;
 	xf.columns[0] = (p_to - p_from).normalized();

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -65,13 +65,14 @@ void AnimationTreeEditor::edit(AnimationTree *p_tree) {
 	tree = p_tree;
 
 	Vector<String> path;
-	if (tree && tree->has_meta("_tree_edit_path")) {
-		path = tree->get_meta("_tree_edit_path");
-	} else {
-		current_root = ObjectID();
+	if (tree) {
+		if (tree->has_meta("_tree_edit_path")) {
+			path = tree->get_meta("_tree_edit_path");
+		} else {
+			current_root = ObjectID();
+		}
+		edit_path(path);
 	}
-
-	edit_path(path);
 }
 
 void AnimationTreeEditor::_node_removed(Node *p_node) {


### PR DESCRIPTION
Fixes a nullptr crash when switch from an AnimationTree node to another node. Also includes a fix to not crash the editor if a state machine transition mode is using an invalid integer (this isn't really something that happens in normal use, but it was happening enough with some experimental stuff I'm doing and a crash is a crash, so might as well check for it)

Closes #72044