### PR TITLE
C#: Implement disposable pattern and seal `GodotSynchronizationContext` class and related

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dispatcher.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dispatcher.cs
@@ -9,7 +9,10 @@ namespace Godot
         internal static GodotTaskScheduler DefaultGodotTaskScheduler;
 
         internal static void InitializeDefaultGodotTaskScheduler()
-            => DefaultGodotTaskScheduler = new GodotTaskScheduler();
+        {
+            DefaultGodotTaskScheduler?.Dispose();
+            DefaultGodotTaskScheduler = new GodotTaskScheduler();
+        }
 
         public static GodotSynchronizationContext SynchronizationContext => DefaultGodotTaskScheduler.Context;
     }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotSynchronizationContext.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotSynchronizationContext.cs
@@ -1,13 +1,13 @@
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 
 namespace Godot
 {
-    public class GodotSynchronizationContext : SynchronizationContext
+    public sealed class GodotSynchronizationContext : SynchronizationContext, IDisposable
     {
-        private readonly BlockingCollection<KeyValuePair<SendOrPostCallback, object>> _queue =
-            new BlockingCollection<KeyValuePair<SendOrPostCallback, object>>();
+        private readonly BlockingCollection<KeyValuePair<SendOrPostCallback, object>> _queue = new();
 
         public override void Post(SendOrPostCallback d, object state)
         {
@@ -23,6 +23,11 @@ namespace Godot
             {
                 workItem.Key(workItem.Value);
             }
+        }
+
+        public void Dispose()
+        {
+            _queue.Dispose();
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTaskScheduler.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTaskScheduler.cs
@@ -10,7 +10,7 @@ namespace Godot
     /// GodotTaskScheduler contains a linked list of tasks to perform as a queue. Methods
     /// within the class are used to control the queue and perform the contained tasks.
     /// </summary>
-    public class GodotTaskScheduler : TaskScheduler
+    public sealed class GodotTaskScheduler : TaskScheduler, IDisposable
     {
         /// <summary>
         /// The current synchronization context.
@@ -107,6 +107,11 @@ namespace Godot
                     }
                 }
             }
+        }
+
+        public void Dispose()
+        {
+            Context.Dispose();
         }
     }
 }


### PR DESCRIPTION
This PR extracts the breaking changes from https://github.com/godotengine/godot/pull/65532 so it can be reviewed and merged separately.

- `GodotSynchronizationContext`
  - Implements `IDisposable` to dispose of the disposable field `_queue`.
  - Makes the class sealed.
- `GodotTaskScheduler`
  - Implements `IDisposable` to dispose of the disposable property `Context`.
  - Makes the class sealed.
- `Dispatcher`
  - Dispose of previous `GodotTaskScheduler` instances before creating a new one.
