### PR TITLE
C#: Annotate API with `[MustBeVariant]`

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MustBeVariantAnalyzer.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MustBeVariantAnalyzer.cs
@@ -26,6 +26,10 @@ namespace Godot.SourceGenerators
 
         private void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
+            // Ignore syntax inside comments
+            if (IsInsideDocumentation(context.Node))
+                return;
+
             var typeArgListSyntax = (TypeArgumentListSyntax)context.Node;
 
             // Method invocation or variable declaration that contained the type arguments
@@ -71,6 +75,26 @@ namespace Godot.SourceGenerators
                     continue;
                 }
             }
+        }
+
+        /// <summary>
+        /// Check if the syntax node is inside a documentation syntax.
+        /// </summary>
+        /// <param name="syntax">Syntax node to check.</param>
+        /// <returns><see langword="true"/> if the syntax node is inside a documentation syntax.</returns>
+        private bool IsInsideDocumentation(SyntaxNode? syntax)
+        {
+            while (syntax != null)
+            {
+                if (syntax is DocumentationCommentTriviaSyntax)
+                {
+                    return true;
+                }
+
+                syntax = syntax.Parent;
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Callable.generics.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Callable.generics.cs
@@ -45,7 +45,7 @@ public readonly partial struct Callable
     }
 
     /// <inheritdoc cref="From(Action)"/>
-    public static unsafe Callable From<T0>(
+    public static unsafe Callable From<[MustBeVariant] T0>(
         Action<T0> action
     )
     {
@@ -64,7 +64,7 @@ public readonly partial struct Callable
     }
 
     /// <inheritdoc cref="From(Action)"/>
-    public static unsafe Callable From<T0, T1>(
+    public static unsafe Callable From<[MustBeVariant] T0, [MustBeVariant] T1>(
         Action<T0, T1> action
     )
     {
@@ -84,7 +84,7 @@ public readonly partial struct Callable
     }
 
     /// <inheritdoc cref="From(Action)"/>
-    public static unsafe Callable From<T0, T1, T2>(
+    public static unsafe Callable From<[MustBeVariant] T0, [MustBeVariant] T1, [MustBeVariant] T2>(
         Action<T0, T1, T2> action
     )
     {
@@ -105,7 +105,7 @@ public readonly partial struct Callable
     }
 
     /// <inheritdoc cref="From(Action)"/>
-    public static unsafe Callable From<T0, T1, T2, T3>(
+    public static unsafe Callable From<[MustBeVariant] T0, [MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3>(
         Action<T0, T1, T2, T3> action
     )
     {
@@ -127,7 +127,7 @@ public readonly partial struct Callable
     }
 
     /// <inheritdoc cref="From(Action)"/>
-    public static unsafe Callable From<T0, T1, T2, T3, T4>(
+    public static unsafe Callable From<[MustBeVariant] T0, [MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3, [MustBeVariant] T4>(
         Action<T0, T1, T2, T3, T4> action
     )
     {
@@ -150,7 +150,7 @@ public readonly partial struct Callable
     }
 
     /// <inheritdoc cref="From(Action)"/>
-    public static unsafe Callable From<T0, T1, T2, T3, T4, T5>(
+    public static unsafe Callable From<[MustBeVariant] T0, [MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3, [MustBeVariant] T4, [MustBeVariant] T5>(
         Action<T0, T1, T2, T3, T4, T5> action
     )
     {
@@ -174,7 +174,7 @@ public readonly partial struct Callable
     }
 
     /// <inheritdoc cref="From(Action)"/>
-    public static unsafe Callable From<T0, T1, T2, T3, T4, T5, T6>(
+    public static unsafe Callable From<[MustBeVariant] T0, [MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3, [MustBeVariant] T4, [MustBeVariant] T5, [MustBeVariant] T6>(
         Action<T0, T1, T2, T3, T4, T5, T6> action
     )
     {
@@ -199,7 +199,7 @@ public readonly partial struct Callable
     }
 
     /// <inheritdoc cref="From(Action)"/>
-    public static unsafe Callable From<T0, T1, T2, T3, T4, T5, T6, T7>(
+    public static unsafe Callable From<[MustBeVariant] T0, [MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3, [MustBeVariant] T4, [MustBeVariant] T5, [MustBeVariant] T6, [MustBeVariant] T7>(
         Action<T0, T1, T2, T3, T4, T5, T6, T7> action
     )
     {
@@ -225,7 +225,7 @@ public readonly partial struct Callable
     }
 
     /// <inheritdoc cref="From(Action)"/>
-    public static unsafe Callable From<T0, T1, T2, T3, T4, T5, T6, T7, T8>(
+    public static unsafe Callable From<[MustBeVariant] T0, [MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3, [MustBeVariant] T4, [MustBeVariant] T5, [MustBeVariant] T6, [MustBeVariant] T7, [MustBeVariant] T8>(
         Action<T0, T1, T2, T3, T4, T5, T6, T7, T8> action
     )
     {
@@ -255,7 +255,7 @@ public readonly partial struct Callable
     /// Constructs a new <see cref="Callable"/> for the given <paramref name="func"/>.
     /// </summary>
     /// <param name="func">Action method that will be called.</param>
-    public static unsafe Callable From<TResult>(
+    public static unsafe Callable From<[MustBeVariant] TResult>(
         Func<TResult> func
     )
     {
@@ -272,7 +272,7 @@ public readonly partial struct Callable
     }
 
     /// <inheritdoc cref="From{TResult}(Func{TResult})"/>
-    public static unsafe Callable From<T0, TResult>(
+    public static unsafe Callable From<[MustBeVariant] T0, [MustBeVariant] TResult>(
         Func<T0, TResult> func
     )
     {
@@ -291,7 +291,7 @@ public readonly partial struct Callable
     }
 
     /// <inheritdoc cref="From{TResult}(Func{TResult})"/>
-    public static unsafe Callable From<T0, T1, TResult>(
+    public static unsafe Callable From<[MustBeVariant] T0, [MustBeVariant] T1, [MustBeVariant] TResult>(
         Func<T0, T1, TResult> func
     )
     {
@@ -311,7 +311,7 @@ public readonly partial struct Callable
     }
 
     /// <inheritdoc cref="From{TResult}(Func{TResult})"/>
-    public static unsafe Callable From<T0, T1, T2, TResult>(
+    public static unsafe Callable From<[MustBeVariant] T0, [MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] TResult>(
         Func<T0, T1, T2, TResult> func
     )
     {
@@ -332,7 +332,7 @@ public readonly partial struct Callable
     }
 
     /// <inheritdoc cref="From{TResult}(Func{TResult})"/>
-    public static unsafe Callable From<T0, T1, T2, T3, TResult>(
+    public static unsafe Callable From<[MustBeVariant] T0, [MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3, [MustBeVariant] TResult>(
         Func<T0, T1, T2, T3, TResult> func
     )
     {
@@ -354,7 +354,7 @@ public readonly partial struct Callable
     }
 
     /// <inheritdoc cref="From{TResult}(Func{TResult})"/>
-    public static unsafe Callable From<T0, T1, T2, T3, T4, TResult>(
+    public static unsafe Callable From<[MustBeVariant] T0, [MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3, [MustBeVariant] T4, [MustBeVariant] TResult>(
         Func<T0, T1, T2, T3, T4, TResult> func
     )
     {
@@ -377,7 +377,7 @@ public readonly partial struct Callable
     }
 
     /// <inheritdoc cref="From{TResult}(Func{TResult})"/>
-    public static unsafe Callable From<T0, T1, T2, T3, T4, T5, TResult>(
+    public static unsafe Callable From<[MustBeVariant] T0, [MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3, [MustBeVariant] T4, [MustBeVariant] T5, [MustBeVariant] TResult>(
         Func<T0, T1, T2, T3, T4, T5, TResult> func
     )
     {
@@ -401,7 +401,7 @@ public readonly partial struct Callable
     }
 
     /// <inheritdoc cref="From{TResult}(Func{TResult})"/>
-    public static unsafe Callable From<T0, T1, T2, T3, T4, T5, T6, TResult>(
+    public static unsafe Callable From<[MustBeVariant] T0, [MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3, [MustBeVariant] T4, [MustBeVariant] T5, [MustBeVariant] T6, [MustBeVariant] TResult>(
         Func<T0, T1, T2, T3, T4, T5, T6, TResult> func
     )
     {
@@ -426,7 +426,7 @@ public readonly partial struct Callable
     }
 
     /// <inheritdoc cref="From{TResult}(Func{TResult})"/>
-    public static unsafe Callable From<T0, T1, T2, T3, T4, T5, T6, T7, TResult>(
+    public static unsafe Callable From<[MustBeVariant] T0, [MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3, [MustBeVariant] T4, [MustBeVariant] T5, [MustBeVariant] T6, [MustBeVariant] T7, [MustBeVariant] TResult>(
         Func<T0, T1, T2, T3, T4, T5, T6, T7, TResult> func
     )
     {
@@ -452,7 +452,7 @@ public readonly partial struct Callable
     }
 
     /// <inheritdoc cref="From{TResult}(Func{TResult})"/>
-    public static unsafe Callable From<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(
+    public static unsafe Callable From<[MustBeVariant] T0, [MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3, [MustBeVariant] T4, [MustBeVariant] T5, [MustBeVariant] T6, [MustBeVariant] T7, [MustBeVariant] T8, [MustBeVariant] TResult>(
         Func<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult> func
     )
     {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
@@ -260,7 +260,7 @@ namespace Godot.NativeInterop
             => from != null ? CreateFromArray((godot_array)from.NativeValue) : default;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromArray<T>(Array<T>? from)
+        public static godot_variant CreateFromArray<[MustBeVariant] T>(Array<T>? from)
             => from != null ? CreateFromArray((godot_array)((Collections.Array)from).NativeValue) : default;
 
         public static godot_variant CreateFromDictionary(godot_dictionary from)
@@ -274,7 +274,7 @@ namespace Godot.NativeInterop
             => from != null ? CreateFromDictionary((godot_dictionary)from.NativeValue) : default;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromDictionary<TKey, TValue>(Dictionary<TKey, TValue>? from)
+        public static godot_variant CreateFromDictionary<[MustBeVariant] TKey, [MustBeVariant] TValue>(Dictionary<TKey, TValue>? from)
             => from != null ? CreateFromDictionary((godot_dictionary)((Dictionary)from).NativeValue) : default;
 
         public static godot_variant CreateFromStringName(godot_string_name from)
@@ -526,7 +526,7 @@ namespace Godot.NativeInterop
             => Collections.Array.CreateTakingOwnershipOfDisposableValue(ConvertToNativeArray(p_var));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Array<T> ConvertToArray<T>(in godot_variant p_var)
+        public static Array<T> ConvertToArray<[MustBeVariant] T>(in godot_variant p_var)
             => Array<T>.CreateTakingOwnershipOfDisposableValue(ConvertToNativeArray(p_var));
 
         public static godot_dictionary ConvertToNativeDictionary(in godot_variant p_var)
@@ -539,7 +539,7 @@ namespace Godot.NativeInterop
             => Dictionary.CreateTakingOwnershipOfDisposableValue(ConvertToNativeDictionary(p_var));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Dictionary<TKey, TValue> ConvertToDictionary<TKey, TValue>(in godot_variant p_var)
+        public static Dictionary<TKey, TValue> ConvertToDictionary<[MustBeVariant] TKey, [MustBeVariant] TValue>(in godot_variant p_var)
             => Dictionary<TKey, TValue>.CreateTakingOwnershipOfDisposableValue(ConvertToNativeDictionary(p_var));
 
         public static byte[] ConvertAsPackedByteArrayToSystemArray(in godot_variant p_var)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Variant.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Variant.cs
@@ -328,11 +328,11 @@ public partial struct Variant : IDisposable
         VariantUtils.ConvertToSystemArrayOfGodotObject<T>((godot_variant)NativeVar);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Collections.Dictionary<TKey, TValue> AsGodotDictionary<TKey, TValue>() =>
+    public Collections.Dictionary<TKey, TValue> AsGodotDictionary<[MustBeVariant] TKey, [MustBeVariant] TValue>() =>
         VariantUtils.ConvertToDictionary<TKey, TValue>((godot_variant)NativeVar);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Collections.Array<T> AsGodotArray<T>() =>
+    public Collections.Array<T> AsGodotArray<[MustBeVariant] T>() =>
         VariantUtils.ConvertToArray<T>((godot_variant)NativeVar);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -647,11 +647,11 @@ public partial struct Variant : IDisposable
     public static Variant CreateFrom(Godot.Object[] from) => from;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Variant CreateFrom<TKey, TValue>(Collections.Dictionary<TKey, TValue> from) =>
+    public static Variant CreateFrom<[MustBeVariant] TKey, [MustBeVariant] TValue>(Collections.Dictionary<TKey, TValue> from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromDictionary(from));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Variant CreateFrom<T>(Collections.Array<T> from) =>
+    public static Variant CreateFrom<[MustBeVariant] T>(Collections.Array<T> from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromArray(from));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
I ran the MustBeVariant analyzer in the GodotSharp assembly and found there were some generic methods that were missing the attribute, this is a breaking change because it restricts the types that users can use for `T` in these APIs.

Today a user can write `Callable.From<NonVariantCompatibleType>(...)` which compiles but results in exceptions during runtime, adding the attribute would allow the analyzer to emit a diagnostic during compile time. This means code that compiled before now no longer does, but the code that compiled before would cause exceptions during runtime anyway.

Note that the MustBeVariant analyzer is currently not being used in the GodotSharp assembly, this PR doesn't change that, I'd love to do it at some point, but I probably won't have time for 4.0 and that change wouldn't break compat anyway.

#### Summary

- Add `[MustBeVariant]` attribute to generic parameters that are used in a Variant context.
- Fix MustBeVariant analyzer to avoid generics in documentation syntax.
