### PR TITLE
C#: MSBuild logs and panel enhancements

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildInfo.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildInfo.cs
@@ -22,8 +22,7 @@ namespace GodotTools.Build
         // TODO Use List once we have proper serialization
         public Godot.Collections.Array CustomProperties { get; private set; } = new();
 
-        public string LogsDirPath =>
-            Path.Combine(GodotSharpDirs.BuildLogsDirs, $"{Solution.Md5Text()}_{Configuration}");
+        public string LogsDirPath => GodotSharpDirs.LogsDirPathFor(Solution, Configuration);
 
         public override bool Equals(object? obj)
         {

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -23,9 +23,11 @@ namespace GodotTools.Build
             if (dotnetPath == null)
                 throw new FileNotFoundException("Cannot find the dotnet executable.");
 
+            var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
+
             var startInfo = new ProcessStartInfo(dotnetPath);
 
-            BuildArguments(buildInfo, startInfo.ArgumentList);
+            BuildArguments(buildInfo, startInfo.ArgumentList, editorSettings);
 
             string launchMessage = startInfo.GetCommandLineDisplay(new StringBuilder("Running: ")).ToString();
             stdOutHandler?.Invoke(launchMessage);
@@ -36,6 +38,8 @@ namespace GodotTools.Build
             startInfo.RedirectStandardError = true;
             startInfo.UseShellExecute = false;
             startInfo.CreateNoWindow = true;
+            startInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"]
+                = ((string)editorSettings.GetSetting("interface/editor/editor_language")).Replace('_', '-');
 
             // Needed when running from Developer Command Prompt for VS
             RemovePlatformVariable(startInfo.EnvironmentVariables);
@@ -84,9 +88,11 @@ namespace GodotTools.Build
             if (dotnetPath == null)
                 throw new FileNotFoundException("Cannot find the dotnet executable.");
 
+            var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
+
             var startInfo = new ProcessStartInfo(dotnetPath);
 
-            BuildPublishArguments(buildInfo, startInfo.ArgumentList);
+            BuildPublishArguments(buildInfo, startInfo.ArgumentList, editorSettings);
 
             string launchMessage = startInfo.GetCommandLineDisplay(new StringBuilder("Running: ")).ToString();
             stdOutHandler?.Invoke(launchMessage);
@@ -96,6 +102,8 @@ namespace GodotTools.Build
             startInfo.RedirectStandardOutput = true;
             startInfo.RedirectStandardError = true;
             startInfo.UseShellExecute = false;
+            startInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"]
+                = ((string)editorSettings.GetSetting("interface/editor/editor_language")).Replace('_', '-');
 
             // Needed when running from Developer Command Prompt for VS
             RemovePlatformVariable(startInfo.EnvironmentVariables);
@@ -125,10 +133,9 @@ namespace GodotTools.Build
             }
         }
 
-        private static void BuildArguments(BuildInfo buildInfo, Collection<string> arguments)
+        private static void BuildArguments(BuildInfo buildInfo, Collection<string> arguments,
+            EditorSettings editorSettings)
         {
-            var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
-
             // `dotnet clean` / `dotnet build` commands
             arguments.Add(buildInfo.OnlyClean ? "clean" : "build");
 
@@ -168,10 +175,9 @@ namespace GodotTools.Build
             }
         }
 
-        private static void BuildPublishArguments(BuildInfo buildInfo, Collection<string> arguments)
+        private static void BuildPublishArguments(BuildInfo buildInfo, Collection<string> arguments,
+            EditorSettings editorSettings)
         {
-            var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
-
             arguments.Add("publish"); // `dotnet publish` command
 
             // Solution

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using Godot;
 using GodotTools.Internals;
 using static GodotTools.Internals.Globals;
@@ -14,6 +15,7 @@ namespace GodotTools.Build
         private Button _errorsBtn;
         private Button _warningsBtn;
         private Button _viewLogBtn;
+        private Button _openLogsFolderBtn;
 
         private void WarningsToggled(bool pressed)
         {
@@ -93,6 +95,10 @@ namespace GodotTools.Build
 
         private void ViewLogToggled(bool pressed) => BuildOutputView.LogVisible = pressed;
 
+        private void OpenLogsFolderPressed() => OS.ShellOpen(
+            $"file://{GodotSharpDirs.LogsDirPathFor("Debug")}"
+        );
+
         private void BuildMenuOptionPressed(long id)
         {
             switch ((BuildMenuOptions)id)
@@ -170,6 +176,22 @@ namespace GodotTools.Build
             };
             _viewLogBtn.Toggled += ViewLogToggled;
             toolBarHBox.AddChild(_viewLogBtn);
+
+            // Horizontal spacer, push everything to the right.
+            toolBarHBox.AddChild(new Control
+            {
+                SizeFlagsHorizontal = SizeFlags.ExpandFill,
+            });
+
+            _openLogsFolderBtn = new Button
+            {
+                Text = "Show Logs in File Manager".TTR(),
+                Icon = GetThemeIcon("Filesystem", "EditorIcons"),
+                ExpandIcon = false,
+                FocusMode = FocusModeEnum.None,
+            };
+            _openLogsFolderBtn.Pressed += OpenLogsFolderPressed;
+            toolBarHBox.AddChild(_openLogsFolderBtn);
 
             BuildOutputView = new BuildOutputView();
             AddChild(BuildOutputView);

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -25,6 +25,9 @@ namespace GodotTools
         public static class Settings
         {
             public const string ExternalEditor = "dotnet/editor/external_editor";
+            public const string VerbosityLevel = "dotnet/build/verbosity_level";
+            public const string NoConsoleLogging = "dotnet/build/no_console_logging";
+            public const string CreateBinaryLog = "dotnet/build/create_binary_log";
         }
 
         private EditorSettings _editorSettings;
@@ -458,6 +461,9 @@ namespace GodotTools
 
             // External editor settings
             EditorDef(Settings.ExternalEditor, Variant.From(ExternalEditorId.None));
+            EditorDef(Settings.VerbosityLevel, Variant.From(VerbosityLevelId.Normal));
+            EditorDef(Settings.NoConsoleLogging, false);
+            EditorDef(Settings.CreateBinaryLog, false);
 
             string settingsHintStr = "Disabled";
 
@@ -490,6 +496,18 @@ namespace GodotTools
                 ["hint_string"] = settingsHintStr
             });
 
+            var verbosityLevels = Enum.GetValues<VerbosityLevelId>().Select(level => $"{Enum.GetName(level)}:{(int)level}");
+            _editorSettings.AddPropertyInfo(new Godot.Collections.Dictionary
+            {
+                ["type"] = (int)Variant.Type.Int,
+                ["name"] = Settings.VerbosityLevel,
+                ["hint"] = (int)PropertyHint.Enum,
+                ["hint_string"] = string.Join(",", verbosityLevels),
+            });
+
+            OnSettingsChanged();
+            _editorSettings.SettingsChanged += OnSettingsChanged;
+
             // Export plugin
             var exportPlugin = new ExportPlugin();
             AddExportPlugin(exportPlugin);
@@ -512,6 +530,24 @@ namespace GodotTools
 
             GodotIdeManager = new GodotIdeManager();
             AddChild(GodotIdeManager);
+        }
+
+        public override void _DisablePlugin()
+        {
+            base._DisablePlugin();
+
+            _editorSettings.SettingsChanged -= OnSettingsChanged;
+        }
+
+        private void OnSettingsChanged()
+        {
+            // We want to force NoConsoleLogging to true when the VerbosityLevel is at Detailed or above.
+            // At that point, there's so much info logged that it doesn't make sense to display it in
+            // the tiny editor window, and it'd make the editor hang or crash anyway.
+            var verbosityLevel = _editorSettings.GetSetting(Settings.VerbosityLevel).As<VerbosityLevelId>();
+            var hideConsoleLog = (bool)_editorSettings.GetSetting(Settings.NoConsoleLogging);
+            if (verbosityLevel >= VerbosityLevelId.Detailed && !hideConsoleLog)
+                _editorSettings.SetSetting(Settings.NoConsoleLogging, Variant.From(true));
         }
 
         protected override void Dispose(bool disposing)

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -22,6 +22,11 @@ namespace GodotTools
 {
     public partial class GodotSharpEditor : EditorPlugin, ISerializationListener
     {
+        public static class Settings
+        {
+            public const string ExternalEditor = "dotnet/editor/external_editor";
+        }
+
         private EditorSettings _editorSettings;
 
         private PopupMenu _menuPopup;
@@ -171,7 +176,7 @@ namespace GodotTools
         [UsedImplicitly]
         public Error OpenInExternalEditor(Script script, int line, int col)
         {
-            var editorId = (ExternalEditorId)(int)_editorSettings.GetSetting("mono/editor/external_editor");
+            var editorId = _editorSettings.GetSetting(Settings.ExternalEditor).As<ExternalEditorId>();
 
             switch (editorId)
             {
@@ -323,8 +328,7 @@ namespace GodotTools
         [UsedImplicitly]
         public bool OverridesExternalEditor()
         {
-            return (ExternalEditorId)(int)_editorSettings.GetSetting("mono/editor/external_editor") !=
-                   ExternalEditorId.None;
+            return _editorSettings.GetSetting(Settings.ExternalEditor).As<ExternalEditorId>() != ExternalEditorId.None;
         }
 
         public override bool _Build()
@@ -453,7 +457,7 @@ namespace GodotTools
             _menuPopup.IdPressed += _MenuOptionPressed;
 
             // External editor settings
-            EditorDef("mono/editor/external_editor", Variant.From(ExternalEditorId.None));
+            EditorDef(Settings.ExternalEditor, Variant.From(ExternalEditorId.None));
 
             string settingsHintStr = "Disabled";
 
@@ -481,7 +485,7 @@ namespace GodotTools
             _editorSettings.AddPropertyInfo(new Godot.Collections.Dictionary
             {
                 ["type"] = (int)Variant.Type.Int,
-                ["name"] = "mono/editor/external_editor",
+                ["name"] = Settings.ExternalEditor,
                 ["hint"] = (int)PropertyHint.Enum,
                 ["hint_string"] = settingsHintStr
             });

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
@@ -21,7 +21,8 @@ namespace GodotTools.Ides
                 return _messagingServer;
 
             _messagingServer?.Dispose();
-            _messagingServer = new MessagingServer(OS.GetExecutablePath(), ProjectSettings.GlobalizePath(GodotSharpDirs.ResMetadataDir), new GodotLogger());
+            _messagingServer = new MessagingServer(OS.GetExecutablePath(),
+                ProjectSettings.GlobalizePath(GodotSharpDirs.ResMetadataDir), new GodotLogger());
 
             _ = _messagingServer.Listen();
 
@@ -76,8 +77,8 @@ namespace GodotTools.Ides
 
         public async Task<EditorPick?> LaunchIdeAsync(int millisecondsTimeout = 10000)
         {
-            var editorId = (ExternalEditorId)(int)GodotSharpEditor.Instance.GetEditorInterface()
-                .GetEditorSettings().GetSetting("mono/editor/external_editor");
+            var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
+            var editorId = editorSettings.GetSetting(GodotSharpEditor.Settings.ExternalEditor).As<ExternalEditorId>();
             string editorIdentity = GetExternalEditorIdentity(editorId);
 
             var runningServer = GetRunningOrNewServer();

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
@@ -9,7 +9,7 @@ namespace GodotTools.Ides.Rider
 {
     public static class RiderPathManager
     {
-        public static readonly string EditorPathSettingName = "mono/editor/editor_path_optional";
+        public static readonly string EditorPathSettingName = "dotnet/editor/editor_path_optional";
 
         private static string GetRiderPathFromSettings()
         {
@@ -22,7 +22,7 @@ namespace GodotTools.Ides.Rider
         public static void Initialize()
         {
             var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
-            var editor = (ExternalEditorId)(int)editorSettings.GetSetting("mono/editor/external_editor");
+            var editor = editorSettings.GetSetting(GodotSharpEditor.Settings.ExternalEditor).As<ExternalEditorId>();
             if (editor == ExternalEditorId.Rider)
             {
                 if (!editorSettings.HasSetting(EditorPathSettingName))

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
@@ -115,5 +115,11 @@ namespace GodotTools.Internals
                 return _projectCsProjPath;
             }
         }
+
+        public static string LogsDirPathFor(string solution, string configuration)
+            => Path.Combine(BuildLogsDirs, $"{solution.Md5Text()}_{configuration}");
+
+        public static string LogsDirPathFor(string configuration)
+            => LogsDirPathFor(ProjectSlnPath, configuration);
     }
 }

--- a/modules/mono/editor/GodotTools/GodotTools/VerbosityLevelId.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/VerbosityLevelId.cs
@@ -1,0 +1,11 @@
+namespace GodotTools
+{
+    public enum VerbosityLevelId : long
+    {
+        Quiet,
+        Minimal,
+        Normal,
+        Detailed,
+        Diagnostic,
+    }
+}


### PR DESCRIPTION
I'm continuing my quest about improving the C# experience.

- Rename the current .NET related editor settings from `mono` to `dotnet`, as it become more and more confusing for people to see the word mono in the interface.
  ![image](https://user-images.githubusercontent.com/437025/214638010-27d47872-9940-4882-b010-8c2afee0b949.png)
- Add a button on the right of the MSBuild panel to directly open the logs folder, which is currently quite hard to pinpoint (since it uses an MD5 hash in its path).
  ![image](https://user-images.githubusercontent.com/437025/214638446-90e50f3f-8e29-40b8-91b1-c218f8158139.png)
- Add a few settings, so the user is able to tune how MSBuild logs behave.
  ![image](https://user-images.githubusercontent.com/437025/214638873-5cf92ac1-42e1-4755-83d2-a7603b5281e0.png)
  - **Verbosity Level** is tied to the `-v` flag.
  - **No Console Logging** switches `-noconlog` on or off, basically either print to the console and the logfile or to the logfile alone.
  - **Create Binary Log** switches `-bl` on or off, binary logs being a very useful tool to debug MSBuild issues.
- Finally, as I suggested in #71326, try to tie the language used by MSBuild with the language used by Godot. Won't solve that issue entirely, but is still a step in the right direction IMHO.
  |en|fr|ja|
  |--|--|--|
  |![image](https://user-images.githubusercontent.com/437025/214640344-a1dac804-9ea7-483b-ba4c-37c1d2766947.png)|![image](https://user-images.githubusercontent.com/437025/214640539-8c4e6d12-3a11-4a8b-b5bf-4da6beb92433.png)|![image](https://user-images.githubusercontent.com/437025/214640912-3ae47190-30b5-4a53-9afd-c57db3c82999.png)|

