### PR TITLE
RenderForwardMobile - add dependency tracker info on geometry create

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -2237,6 +2237,9 @@ RenderGeometryInstance *RenderForwardMobile::geometry_instance_create(RID p_base
 
 	ginstance->data->base = p_base;
 	ginstance->data->base_type = type;
+	ginstance->data->dependency_tracker.userdata = ginstance;
+	ginstance->data->dependency_tracker.changed_callback = _geometry_instance_dependency_changed;
+	ginstance->data->dependency_tracker.deleted_callback = _geometry_instance_dependency_deleted;
 
 	ginstance->_mark_dirty();
 


### PR DESCRIPTION
After a few hours investigating https://github.com/godotengine/godot/issues/69454, I realized for `RenderForwardMobile` on `geometry_instance_create` the `ginstance` didn't have it's callbacks set on dependency tracker, thus when you would change the mesh of a `GPUParticles3D` node, the instance wouldn't mark itself dirty resulting in a crash. Probably fixes other issues as well.

I am wondering why these lines are missing giving the similarity to the same forward cluster function: https://github.com/godotengine/godot/blob/master/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp#L3787

Closes: https://github.com/godotengine/godot/issues/69454