### PR TITLE
Update WebXR tutorial link to point at the Godot 4 version

### DIFF
--- a/modules/webxr/doc_classes/WebXRInterface.xml
+++ b/modules/webxr/doc_classes/WebXRInterface.xml
@@ -90,7 +90,7 @@
 		You can use both methods to allow your game or app to support a wider or narrower set of devices and input methods, or to allow more advanced interactions with more advanced devices.
 	</description>
 	<tutorials>
-		<link title="How to make a VR game for WebXR with Godot">https://www.snopekgames.com/blog/2020/how-make-vr-game-webxr-godot</link>
+		<link title="How to make a VR game for WebXR with Godot 4">https://www.snopekgames.com/tutorial/2023/how-make-vr-game-webxr-godot-4</link>
 	</tutorials>
 	<methods>
 		<method name="get_input_source_target_ray_mode" qualifiers="const">


### PR DESCRIPTION
The title says it all!

Currently, the tutorial link is pointing at the Godot 3 version of the tutorial.
