### PR TITLE
Validate another case of using DATA_FORMAT_A2B10G10R10_UNORM_PACK32 texture with storage flag

### DIFF
--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -1648,7 +1648,10 @@ void SkyRD::update_dirty_skys() {
 				tf.mipmaps = MIN(mipmaps, layers);
 				tf.width = w;
 				tf.height = h;
-				tf.usage_bits = RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT;
+				tf.usage_bits = RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_SAMPLING_BIT;
+				if (RendererSceneRenderRD::get_singleton()->_render_buffers_can_be_storage()) {
+					tf.usage_bits |= RD::TEXTURE_USAGE_STORAGE_BIT;
+				}
 
 				sky->radiance = RD::get_singleton()->texture_create(tf, RD::TextureView());
 


### PR DESCRIPTION
Might fix: https://github.com/godotengine/godot/issues/67430
Follow up to https://github.com/godotengine/godot/pull/71939


This time I went through every usage of ``TEXTURE_USAGE_STORAGE_BIT`` to see if it was possible that it could be called with a texture format that is not guaranteed by the Vulkan spec. 

I found two places where it could happen. One is here, and it is likely the condition that OP is hitting. This is a branch that only runs when [``rendering/reflections/sky_reflections/texture_array_reflections``](https://docs.godotengine.org/en/latest/classes/class_projectsettings.html#class-projectsettings-property-rendering-reflections-sky-reflections-texture-array-reflections) is false.

The other is when using the CanvasItem screen SDF. It requests a R16G16_UINT texture with the storage flag, but that also requires the ``shaderStorageImageExtendedFormats`` feature. We need to implement a fallback for that so it falls back to an R16G16B16A16_UINT texture on such devices (or R32G32_UINT), but that will take a bit of refactoring and is better left for another PR