### PR TITLE
Fix range loop iteration regressions

### DIFF
--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -151,7 +151,7 @@ void Geometry3D::MeshData::optimize_vertices() {
 		}
 	}
 
-	for (MeshData::Edge edge : edges) {
+	for (MeshData::Edge &edge : edges) {
 		int a = edge.vertex_a;
 		int b = edge.vertex_b;
 

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -842,7 +842,7 @@ void MeshStorage::mesh_instance_set_blend_shape_weight(RID p_mesh_instance, int 
 }
 
 void MeshStorage::_mesh_instance_clear(MeshInstance *mi) {
-	for (const RendererRD::MeshStorage::MeshInstance::Surface surface : mi->surfaces) {
+	for (const RendererRD::MeshStorage::MeshInstance::Surface &surface : mi->surfaces) {
 		if (surface.versions) {
 			for (uint32_t j = 0; j < surface.version_count; j++) {
 				RD::get_singleton()->free(surface.versions[j].vertex_array);


### PR DESCRIPTION
I think this PR (https://github.com/godotengine/godot/pull/70773) accidentally broke the vertex remapping. The old code wrote back the values (edge.vertex_a and edge.vertex_b), but the new code writes the values to a copy that is then thrown away. Haven't really fully figured how this affects the mesh optimization but I think this is a correct fix. @KoBeWi 