### PR TITLE
Add description for ArrayMesh.shadow_mesh class reference

### DIFF
--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -206,6 +206,7 @@
 			Overrides the [AABB] with one defined by user for use with frustum culling. Especially useful to avoid unexpected culling when using a shader to offset vertices.
 		</member>
 		<member name="shadow_mesh" type="ArrayMesh" setter="set_shadow_mesh" getter="get_shadow_mesh">
+			An optional mesh which is used for rendering shadows and can be used for the depth prepass. Can be used to increase performance of shadow rendering by using a mesh that only contains vertex position data (without normals, UVs, colors, etc.).
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
Adds description for `ArrayMesh.shadow_mesh` ([docs](https://docs.godotengine.org/en/latest/classes/class_arraymesh.html)).
Documents the behaviour found in #72071
