### PR TITLE
Silence `warp_mouse()` warning in favor of documentation

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -895,6 +895,7 @@
 			<param index="0" name="position" type="Vector2" />
 			<description>
 				Moves the mouse cursor to [param position], relative to [member position] of this [Control].
+				[b]Note:[/b] [method warp_mouse] is only supported on Windows, macOS and Linux. It has no effect on Android, iOS and Web.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1090,6 +1090,7 @@
 			<param index="0" name="position" type="Vector2i" />
 			<description>
 				Sets the mouse cursor position to the given [param position] relative to an origin at the upper left corner of the currently focused game Window Manager window.
+				[b]Note:[/b] [method warp_mouse] is only supported on Windows, macOS and Linux. It has no effect on Android, iOS and Web.
 			</description>
 		</method>
 		<method name="window_can_draw" qualifiers="const">

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -375,6 +375,7 @@
 			<description>
 				Sets the mouse position to the specified vector, provided in pixels and relative to an origin at the upper left corner of the currently focused Window Manager game window.
 				Mouse position is clipped to the limits of the screen resolution, or to the limits of the game window if [enum MouseMode] is set to [constant MOUSE_MODE_CONFINED] or [constant MOUSE_MODE_CONFINED_HIDDEN].
+				[b]Note:[/b] [method warp_mouse] is only supported on Windows, macOS and Linux. It has no effect on Android, iOS and Web.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -210,6 +210,7 @@
 			<param index="0" name="position" type="Vector2" />
 			<description>
 				Moves the mouse pointer to the specified position in this [Viewport] using the coordinate system of this [Viewport].
+				[b]Note:[/b] [method warp_mouse] is only supported on Windows, macOS and Linux. It has no effect on Android, iOS and Web.
 			</description>
 		</method>
 	</methods>

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -344,7 +344,6 @@ DisplayServer::MouseMode DisplayServer::mouse_get_mode() const {
 }
 
 void DisplayServer::warp_mouse(const Point2i &p_position) {
-	WARN_PRINT("Mouse warping is not supported by this display server.");
 }
 
 Point2i DisplayServer::mouse_get_position() const {


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/70116.

This warning was spammed in the Android editor when using the navigation joysticks in the 3D viewport when the finger slid over the viewport's edges.
