### PR TITLE
Connection dialog tweaks

### DIFF
--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -117,8 +117,10 @@ private:
 	SceneTreeEditor *tree = nullptr;
 	AcceptDialog *error = nullptr;
 
+	Button *open_method_tree = nullptr;
 	AcceptDialog *method_popup = nullptr;
 	Tree *method_tree = nullptr;
+	Label *empty_tree_label = nullptr;
 	LineEdit *method_search = nullptr;
 	CheckButton *script_methods_only = nullptr;
 	CheckButton *compatible_methods_only = nullptr;


### PR DESCRIPTION
- remove extra "Advanced" button (it was added by mistake in #66313)
- improve the button opening method picker
- display info label when no method was found

Before:
![godot windows editor dev x86_64_P8ALcDGU3S](https://user-images.githubusercontent.com/2223172/214717029-5314d07d-38cf-4a49-bee1-a5c31195a564.png)

After:
![godot windows editor dev x86_64_Eh2Y3YZgFE](https://user-images.githubusercontent.com/2223172/214717060-bbd0dbfa-6d7a-456b-97fc-7304976f40fb.png)

https://user-images.githubusercontent.com/2223172/214717074-4d00cd17-fe35-4b77-8128-a0a0c43c0006.mp4
