### PR TITLE
Don't change region_rect when setting texture

### DIFF
--- a/doc/classes/StyleBoxTexture.xml
+++ b/doc/classes/StyleBoxTexture.xml
@@ -82,6 +82,7 @@
 		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" default="Rect2(0, 0, 0, 0)">
 			Species a sub-region of the texture to use.
 			This is equivalent to first wrapping the texture in an [AtlasTexture] with the same region.
+			If empty ([code]Rect2(0, 0, 0, 0)[/code]), the whole texture will be used.
 		</member>
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			The texture to use when drawing this style box.

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -740,6 +740,9 @@ void TextureRegionEditor::_update_rect() {
 		}
 	} else if (obj_styleBox.is_valid()) {
 		rect = obj_styleBox->get_region_rect();
+		if (rect == Rect2()) {
+			rect = Rect2(Vector2(), obj_styleBox->get_texture()->get_size());
+		}
 	}
 }
 

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -151,11 +151,6 @@ void StyleBoxTexture::set_texture(Ref<Texture2D> p_texture) {
 		return;
 	}
 	texture = p_texture;
-	if (p_texture.is_null()) {
-		region_rect = Rect2(0, 0, 0, 0);
-	} else {
-		region_rect = Rect2(Point2(), texture->get_size());
-	}
 	emit_changed();
 }
 


### PR DESCRIPTION
StyleBoxTexture's `set_texture()` was setting `region_rect` to (0, 0, 0, 0) if there was no texture and to (0, 0, texture, size) if there was texture, which was modifying the property and resulted in needlessly saved region in every resource (I didn't test, but I think it would also cause issues if you change the texture size). I made the behavior implicit, i.e. the full texture will be automatically used if region is 0, without modifying the property. This is effectively the same as the old behavior, just prevents property noise.