### PR TITLE
Put KeyMappingX11 stuff inside its own scope

### DIFF
--- a/platform/linuxbsd/x11/key_mapping_x11.cpp
+++ b/platform/linuxbsd/x11/key_mapping_x11.cpp
@@ -30,20 +30,6 @@
 
 #include "key_mapping_x11.h"
 
-#include "core/templates/hash_map.h"
-
-struct HashMapHasherKeys {
-	static _FORCE_INLINE_ uint32_t hash(const Key p_key) { return hash_fmix32(static_cast<uint32_t>(p_key)); }
-	static _FORCE_INLINE_ uint32_t hash(const char32_t p_uchar) { return hash_fmix32(p_uchar); }
-	static _FORCE_INLINE_ uint32_t hash(const unsigned p_key) { return hash_fmix32(p_key); }
-	static _FORCE_INLINE_ uint32_t hash(const KeySym p_key) { return hash_fmix32(p_key); }
-};
-
-HashMap<KeySym, Key, HashMapHasherKeys> xkeysym_map;
-HashMap<unsigned int, Key, HashMapHasherKeys> scancode_map;
-HashMap<Key, unsigned int, HashMapHasherKeys> scancode_map_inv;
-HashMap<KeySym, char32_t, HashMapHasherKeys> xkeysym_unicode_map;
-
 void KeyMappingX11::initialize() {
 	// X11 Keysym to Godot Key map.
 

--- a/platform/linuxbsd/x11/key_mapping_x11.h
+++ b/platform/linuxbsd/x11/key_mapping_x11.h
@@ -39,8 +39,21 @@
 #include <X11/keysymdef.h>
 
 #include "core/os/keyboard.h"
+#include "core/templates/hash_map.h"
 
 class KeyMappingX11 {
+	struct HashMapHasherKeys {
+		static _FORCE_INLINE_ uint32_t hash(const Key p_key) { return hash_fmix32(static_cast<uint32_t>(p_key)); }
+		static _FORCE_INLINE_ uint32_t hash(const char32_t p_uchar) { return hash_fmix32(p_uchar); }
+		static _FORCE_INLINE_ uint32_t hash(const unsigned p_key) { return hash_fmix32(p_key); }
+		static _FORCE_INLINE_ uint32_t hash(const KeySym p_key) { return hash_fmix32(p_key); }
+	};
+
+	static inline HashMap<KeySym, Key, HashMapHasherKeys> xkeysym_map;
+	static inline HashMap<unsigned int, Key, HashMapHasherKeys> scancode_map;
+	static inline HashMap<Key, unsigned int, HashMapHasherKeys> scancode_map_inv;
+	static inline HashMap<KeySym, char32_t, HashMapHasherKeys> xkeysym_unicode_map;
+
 	KeyMappingX11() {}
 
 public:


### PR DESCRIPTION
This avoids collisions with other "concurrent" key mappers.

More details:

I stumbled on this while rebasing #57025 when I added a new `KeyMappingXKB` based on `KeyMappingX11` and got linking errors. Without this approach the maps would be sitting there in global space, allowing stuff like duplicate symbols to happen and, since they seem to only be meant to be used by `KeyMappingX11`'s methods, I just made them private and static members, which seems to work fine.

Marking as a draft until I get this tested, just in case.

(is scope the right word? :P)