### PR TITLE
Add `GodotTypeInfo::Metadata` to `MethodInfo`

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -82,6 +82,11 @@ static String get_property_info_type_name(const PropertyInfo &p_info) {
 	return get_builtin_or_variant_type_name(p_info.type);
 }
 
+static String get_type_meta_name(const GodotTypeInfo::Metadata metadata) {
+	static const char *argmeta[11] = { "none", "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64", "float", "double" };
+	return argmeta[metadata];
+}
+
 Dictionary GDExtensionAPIDump::generate_extension_api() {
 	Dictionary api_dump;
 
@@ -840,6 +845,10 @@ Dictionary GDExtensionAPIDump::generate_extension_api() {
 
 							d3["type"] = get_property_info_type_name(pinfo);
 
+							if (mi.get_argument_meta(i) > 0) {
+								d3["meta"] = get_type_meta_name((GodotTypeInfo::Metadata)mi.get_argument_meta(i));
+							}
+
 							if (i == -1) {
 								d2["return_value"] = d3;
 							} else {
@@ -884,8 +893,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api() {
 							d3["type"] = get_property_info_type_name(pinfo);
 
 							if (method->get_argument_meta(i) > 0) {
-								static const char *argmeta[11] = { "none", "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64", "float", "double" };
-								d3["meta"] = argmeta[method->get_argument_meta(i)];
+								d3["meta"] = get_type_meta_name(method->get_argument_meta(i));
 							}
 
 							if (i >= 0 && i >= (method->get_argument_count() - default_args.size())) {
@@ -929,6 +937,9 @@ Dictionary GDExtensionAPIDump::generate_extension_api() {
 						Dictionary d3;
 						d3["name"] = F.arguments[i].name;
 						d3["type"] = get_property_info_type_name(F.arguments[i]);
+						if (F.get_argument_meta(i) > 0) {
+							d3["meta"] = get_type_meta_name((GodotTypeInfo::Metadata)F.get_argument_meta(i));
+						}
 						arguments.push_back(d3);
 					}
 					if (arguments.size()) {

--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -72,6 +72,7 @@ def generate_version(argcount, const=False, returns=False):
         s = s.replace("$RVOID", "(void)r_ret;")  # If required, may lead to uninitialized errors
         s = s.replace("$CALLPTRRETDEF", "PtrToArg<m_ret>::EncodeT ret;")
         method_info += "\tmethod_info.return_val = GetTypeInfo<m_ret>::get_class_info();\\\n"
+        method_info += "\tmethod_info.return_val_metadata = GetTypeInfo<m_ret>::METADATA;\\\n"
     else:
         s = s.replace("$RET", "")
         s = s.replace("$RVOID", "")
@@ -113,6 +114,9 @@ def generate_version(argcount, const=False, returns=False):
         )
         callptrargsptr += "&argval" + str(i + 1)
         method_info += "\tmethod_info.arguments.push_back(GetTypeInfo<m_type" + str(i + 1) + ">::get_class_info());\\\n"
+        method_info += (
+            "\tmethod_info.arguments_metadata.push_back(GetTypeInfo<m_type" + str(i + 1) + ">::METADATA);\\\n"
+        )
 
     if argcount:
         callsiargs += "};\\\n"

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1549,7 +1549,9 @@ void Object::_bind_methods() {
 #define BIND_OBJ_CORE_METHOD(m_method) \
 	::ClassDB::add_virtual_method(get_class_static(), m_method, true, Vector<String>(), true);
 
-	BIND_OBJ_CORE_METHOD(MethodInfo("_notification", PropertyInfo(Variant::INT, "what")));
+	MethodInfo notification_mi("_notification", PropertyInfo(Variant::INT, "what"));
+	notification_mi.arguments_metadata.push_back(GodotTypeInfo::Metadata::METADATA_INT_IS_INT32);
+	BIND_OBJ_CORE_METHOD(notification_mi);
 	BIND_OBJ_CORE_METHOD(MethodInfo(Variant::BOOL, "_set", PropertyInfo(Variant::STRING_NAME, "property"), PropertyInfo(Variant::NIL, "value")));
 #ifdef TOOLS_ENABLED
 	MethodInfo miget("_get", PropertyInfo(Variant::STRING_NAME, "property"));

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -222,6 +222,16 @@ struct MethodInfo {
 	int id = 0;
 	List<PropertyInfo> arguments;
 	Vector<Variant> default_arguments;
+	int return_val_metadata = 0;
+	Vector<int> arguments_metadata;
+
+	int get_argument_meta(int p_arg) const {
+		ERR_FAIL_COND_V(p_arg < -1 || p_arg > arguments.size(), 0);
+		if (p_arg == -1) {
+			return return_val_metadata;
+		}
+		return arguments_metadata.size() > p_arg ? arguments_metadata[p_arg] : 0;
+	}
 
 	inline bool operator==(const MethodInfo &p_method) const { return id == p_method.id; }
 	inline bool operator<(const MethodInfo &p_method) const { return id == p_method.id ? (name < p_method.name) : (id < p_method.id); }

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -175,7 +175,7 @@ namespace GodotTools.Build
             AddChild(BuildOutputView);
         }
 
-        public override void _Notification(long what)
+        public override void _Notification(int what)
         {
             base._Notification(what);
 

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -71,7 +71,7 @@ namespace GodotTools.Export
             }
         }
 
-        public override void _ExportBegin(string[] features, bool isDebug, string path, long flags)
+        public override void _ExportBegin(string[] features, bool isDebug, string path, uint flags)
         {
             base._ExportBegin(features, isDebug, path, flags);
 

--- a/modules/mono/editor/GodotTools/GodotTools/HotReloadAssemblyWatcher.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/HotReloadAssemblyWatcher.cs
@@ -9,7 +9,7 @@ namespace GodotTools
     {
         private Timer _watchTimer;
 
-        public override void _Notification(long what)
+        public override void _Notification(int what)
         {
             if (what == Node.NotificationWmWindowFocusIn)
             {

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -2979,7 +2979,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 			} else if (return_info.type == Variant::NIL) {
 				imethod.return_type.cname = name_cache.type_void;
 			} else {
-				imethod.return_type.cname = _get_type_name_from_meta(return_info.type, m ? m->get_argument_meta(-1) : GodotTypeInfo::METADATA_NONE);
+				imethod.return_type.cname = _get_type_name_from_meta(return_info.type, m ? m->get_argument_meta(-1) : (GodotTypeInfo::Metadata)method_info.return_val_metadata);
 			}
 
 			for (int i = 0; i < argc; i++) {
@@ -3003,7 +3003,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 				} else if (arginfo.type == Variant::NIL) {
 					iarg.type.cname = name_cache.type_Variant;
 				} else {
-					iarg.type.cname = _get_type_name_from_meta(arginfo.type, m ? m->get_argument_meta(i) : GodotTypeInfo::METADATA_NONE);
+					iarg.type.cname = _get_type_name_from_meta(arginfo.type, m ? m->get_argument_meta(i) : (GodotTypeInfo::Metadata)method_info.get_argument_meta(i));
 				}
 
 				iarg.name = escape_csharp_keyword(snake_to_camel_case(iarg.name));
@@ -3103,7 +3103,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 				} else if (arginfo.type == Variant::NIL) {
 					iarg.type.cname = name_cache.type_Variant;
 				} else {
-					iarg.type.cname = _get_type_name_from_meta(arginfo.type, GodotTypeInfo::METADATA_NONE);
+					iarg.type.cname = _get_type_name_from_meta(arginfo.type, (GodotTypeInfo::Metadata)method_info.get_argument_meta(i));
 				}
 
 				iarg.name = escape_csharp_keyword(snake_to_camel_case(iarg.name));


### PR DESCRIPTION
- Add metadata to virtual method parameters.
- Fixes https://github.com/godotengine/godot/issues/66460.