### PR TITLE
Hide `clip_children` for some non-drawn CanvasItems

### DIFF
--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -652,6 +652,7 @@ Area2D::Area2D() :
 	set_gravity_direction(Vector2(0, 1));
 	set_monitoring(true);
 	set_monitorable(true);
+	set_hide_clip_children(true);
 }
 
 Area2D::~Area2D() {

--- a/scene/2d/audio_listener_2d.cpp
+++ b/scene/2d/audio_listener_2d.cpp
@@ -110,3 +110,7 @@ void AudioListener2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear_current"), &AudioListener2D::clear_current);
 	ClassDB::bind_method(D_METHOD("is_current"), &AudioListener2D::is_current);
 }
+
+AudioListener2D::AudioListener2D() {
+	set_hide_clip_children(true);
+}

--- a/scene/2d/audio_listener_2d.h
+++ b/scene/2d/audio_listener_2d.h
@@ -54,6 +54,8 @@ public:
 	void make_current();
 	void clear_current();
 	bool is_current() const;
+
+	AudioListener2D();
 };
 
 #endif // AUDIO_LISTENER_2D_H

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -479,6 +479,7 @@ void AudioStreamPlayer2D::_bind_methods() {
 AudioStreamPlayer2D::AudioStreamPlayer2D() {
 	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &AudioStreamPlayer2D::_bus_layout_changed));
 	cached_global_panning_strength = GLOBAL_GET("audio/general/2d_panning_strength");
+	set_hide_clip_children(true);
 }
 
 AudioStreamPlayer2D::~AudioStreamPlayer2D() {

--- a/scene/2d/back_buffer_copy.cpp
+++ b/scene/2d/back_buffer_copy.cpp
@@ -101,6 +101,7 @@ void BackBufferCopy::_bind_methods() {
 
 BackBufferCopy::BackBufferCopy() {
 	_update_copy_mode();
+	set_hide_clip_children(true);
 }
 
 BackBufferCopy::~BackBufferCopy() {

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -832,4 +832,5 @@ Camera2D::Camera2D() {
 	drag_margin[SIDE_BOTTOM] = 0.2;
 
 	set_notify_transform(true);
+	set_hide_clip_children(true);
 }

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -651,6 +651,7 @@ CollisionObject2D::CollisionObject2D(RID p_rid, bool p_area) {
 	area = p_area;
 	pickable = true;
 	set_notify_transform(true);
+	set_hide_clip_children(true);
 	total_subshapes = 0;
 	only_update_transform_changes = false;
 

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -323,4 +323,5 @@ void CollisionPolygon2D::_bind_methods() {
 
 CollisionPolygon2D::CollisionPolygon2D() {
 	set_notify_local_transform(true);
+	set_hide_clip_children(true);
 }

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -288,5 +288,6 @@ void CollisionShape2D::_bind_methods() {
 
 CollisionShape2D::CollisionShape2D() {
 	set_notify_local_transform(true);
+	set_hide_clip_children(true);
 	debug_color = _get_default_debug_color();
 }

--- a/scene/2d/joint_2d.cpp
+++ b/scene/2d/joint_2d.cpp
@@ -243,6 +243,7 @@ void Joint2D::_bind_methods() {
 
 Joint2D::Joint2D() {
 	joint = PhysicsServer2D::get_singleton()->joint_create();
+	set_hide_clip_children(true);
 }
 
 Joint2D::~Joint2D() {

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -443,6 +443,7 @@ void PointLight2D::_bind_methods() {
 
 PointLight2D::PointLight2D() {
 	RS::get_singleton()->canvas_light_set_mode(_get_light(), RS::CANVAS_LIGHT_MODE_POINT);
+	set_hide_clip_children(true);
 }
 
 //////////
@@ -467,4 +468,5 @@ void DirectionalLight2D::_bind_methods() {
 DirectionalLight2D::DirectionalLight2D() {
 	RS::get_singleton()->canvas_light_set_mode(_get_light(), RS::CANVAS_LIGHT_MODE_DIRECTIONAL);
 	set_max_distance(max_distance); // Update RenderingServer.
+	set_hide_clip_children(true);
 }

--- a/scene/2d/marker_2d.cpp
+++ b/scene/2d/marker_2d.cpp
@@ -117,4 +117,5 @@ void Marker2D::_bind_methods() {
 }
 
 Marker2D::Marker2D() {
+	set_hide_clip_children(true);
 }

--- a/scene/2d/navigation_link_2d.cpp
+++ b/scene/2d/navigation_link_2d.cpp
@@ -282,6 +282,7 @@ NavigationLink2D::NavigationLink2D() {
 	NavigationServer2D::get_singleton()->link_set_owner_id(link, get_instance_id());
 
 	set_notify_transform(true);
+	set_hide_clip_children(true);
 }
 
 NavigationLink2D::~NavigationLink2D() {

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -330,6 +330,7 @@ bool NavigationRegion2D::_get(const StringName &p_name, Variant &r_ret) const {
 
 NavigationRegion2D::NavigationRegion2D() {
 	set_notify_transform(true);
+	set_hide_clip_children(true);
 
 	region = NavigationServer2D::get_singleton()->region_create();
 	NavigationServer2D::get_singleton()->region_set_owner_id(region, get_instance_id());

--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -370,4 +370,5 @@ void RayCast2D::_bind_methods() {
 }
 
 RayCast2D::RayCast2D() {
+	set_hide_clip_children(true);
 }

--- a/scene/2d/remote_transform_2d.cpp
+++ b/scene/2d/remote_transform_2d.cpp
@@ -219,4 +219,5 @@ void RemoteTransform2D::_bind_methods() {
 
 RemoteTransform2D::RemoteTransform2D() {
 	set_notify_transform(true);
+	set_hide_clip_children(true);
 }

--- a/scene/2d/shape_cast_2d.cpp
+++ b/scene/2d/shape_cast_2d.cpp
@@ -472,3 +472,7 @@ void ShapeCast2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_areas", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collide_with_areas", "is_collide_with_areas_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_bodies", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collide_with_bodies", "is_collide_with_bodies_enabled");
 }
+
+ShapeCast2D::ShapeCast2D() {
+	set_hide_clip_children(true);
+}

--- a/scene/2d/shape_cast_2d.h
+++ b/scene/2d/shape_cast_2d.h
@@ -119,6 +119,8 @@ public:
 	void clear_exceptions();
 
 	PackedStringArray get_configuration_warnings() const override;
+
+	ShapeCast2D();
 };
 
 #endif // SHAPE_CAST_2D_H

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -519,6 +519,7 @@ Bone2D::Bone2D() {
 	bone_angle = 0;
 	autocalculate_length_and_angle = true;
 	set_notify_local_transform(true);
+	set_hide_clip_children(true);
 	//this is a clever hack so the bone knows no rest has been set yet, allowing to show an error.
 	for (int i = 0; i < 3; i++) {
 		rest[i] = Vector2(0, 0);
@@ -801,6 +802,7 @@ void Skeleton2D::_bind_methods() {
 Skeleton2D::Skeleton2D() {
 	skeleton = RS::get_singleton()->skeleton_create();
 	set_notify_transform(true);
+	set_hide_clip_children(true);
 }
 
 Skeleton2D::~Skeleton2D() {

--- a/scene/2d/visible_on_screen_notifier_2d.cpp
+++ b/scene/2d/visible_on_screen_notifier_2d.cpp
@@ -110,6 +110,7 @@ void VisibleOnScreenNotifier2D::_bind_methods() {
 
 VisibleOnScreenNotifier2D::VisibleOnScreenNotifier2D() {
 	rect = Rect2(-10, -10, 20, 20);
+	set_hide_clip_children(true);
 }
 
 //////////////////////////////////////

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -927,6 +927,12 @@ void CanvasItem::force_update_transform() {
 	notification(NOTIFICATION_TRANSFORM_CHANGED);
 }
 
+void CanvasItem::_validate_property(PropertyInfo &p_property) const {
+	if (hide_clip_children && p_property.name == "clip_children") {
+		p_property.usage = PROPERTY_USAGE_NONE;
+	}
+}
+
 void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_top_level_raise_self"), &CanvasItem::_top_level_raise_self);
 

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -106,6 +106,7 @@ private:
 	bool use_parent_material = false;
 	bool notify_local_transform = false;
 	bool notify_transform = false;
+	bool hide_clip_children = false;
 
 	ClipChildrenMode clip_children_mode = CLIP_CHILDREN_DISABLED;
 
@@ -155,6 +156,9 @@ protected:
 
 	void _notification(int p_what);
 	static void _bind_methods();
+	void _validate_property(PropertyInfo &p_property) const;
+
+	_FORCE_INLINE_ void set_hide_clip_children(bool p_value) { hide_clip_children = p_value; }
 
 	GDVIRTUAL0(_draw)
 public:


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #72073 

Added for:
* AudioListener2D
* AudioStreamPlayer2D
* PointLight2D
* DirectionalLight2D
* RemoteTransform2D

Additionally:
* Area2D
* BackBufferCopy2D
* Bone2D
* Camera2D
* CollisionObject2D/Polygon2D/Shape2D
* Joint2D
* Marker2D
* NavigationLink2D/Region2D
* Ray/ShapeCast2D
* Skeleton2D
* VisibleOnScreenNotifier2D

If any of these aren't proper for this I'll just remove them

Also added an alternative method handling it as a property in CanvasItem, can expose the method for controlling too but have left it for now