### PR TITLE
Fix char offset calculation when processing RichTextLabel line caches

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2808,7 +2808,7 @@ void RichTextLabel::_process_line_caches() {
 
 	int ctrl_height = get_size().height;
 	int fi = main->first_invalid_line.load();
-	int total_chars = (fi == 0) ? 0 : (main->lines[fi].char_offset + main->lines[fi].char_count);
+	int total_chars = main->lines[fi].char_offset;
 
 	float total_height = (fi == 0) ? 0 : _calculate_line_vertical_offset(main->lines[fi - 1]);
 	for (int i = fi; i < (int)main->lines.size(); i++) {


### PR DESCRIPTION
Fixes #67435

When processing line caches for the RichTextLabel node, the default value of `total_chars` should not contain the invalidated line's char count, we only need to get the current char offset of this line.