### PR TITLE
Fix AnimationTree MethodTrack discards all process

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1411,7 +1411,7 @@ void AnimationTree::_process_graph(double p_delta) {
 					case Animation::TYPE_METHOD: {
 #ifdef TOOLS_ENABLED
 						if (!can_call) {
-							return;
+							continue;
 						}
 #endif // TOOLS_ENABLED
 						TrackCacheMethod *t = static_cast<TrackCacheMethod *>(track);


### PR DESCRIPTION
Follow up #72096.

Sorry, it must be `continue`, not `return`...