### PR TITLE
Booleanize various sync primitives' wait & locking methods

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1105,8 +1105,8 @@ void Semaphore::wait() {
 	semaphore.wait();
 }
 
-Error Semaphore::try_wait() {
-	return semaphore.try_wait() ? OK : ERR_BUSY;
+bool Semaphore::try_wait() {
+	return semaphore.try_wait();
 }
 
 void Semaphore::post() {
@@ -1125,7 +1125,7 @@ void Mutex::lock() {
 	mutex.lock();
 }
 
-Error Mutex::try_lock() {
+bool Mutex::try_lock() {
 	return mutex.try_lock();
 }
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -361,7 +361,7 @@ class Mutex : public RefCounted {
 
 public:
 	void lock();
-	Error try_lock();
+	bool try_lock();
 	void unlock();
 };
 
@@ -373,7 +373,7 @@ class Semaphore : public RefCounted {
 
 public:
 	void wait();
-	Error try_wait();
+	bool try_wait();
 	void post();
 };
 

--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -784,7 +784,7 @@ private:
 			if (p_thread_safe) {
 				_mutex = p_mutex;
 
-				if (_mutex->try_lock() != OK) {
+				if (!_mutex->try_lock()) {
 					WARN_PRINT("Info : multithread BVH access detected (benign)");
 					_mutex->lock();
 				}

--- a/core/os/mutex.h
+++ b/core/os/mutex.h
@@ -31,7 +31,6 @@
 #ifndef MUTEX_H
 #define MUTEX_H
 
-#include "core/error/error_list.h"
 #include "core/typedefs.h"
 
 #include <mutex>
@@ -49,8 +48,8 @@ public:
 		mutex.unlock();
 	}
 
-	_ALWAYS_INLINE_ Error try_lock() const {
-		return mutex.try_lock() ? OK : ERR_BUSY;
+	_ALWAYS_INLINE_ bool try_lock() const {
+		return mutex.try_lock();
 	}
 };
 

--- a/core/os/rw_lock.h
+++ b/core/os/rw_lock.h
@@ -31,8 +31,6 @@
 #ifndef RW_LOCK_H
 #define RW_LOCK_H
 
-#include "core/error/error_list.h"
-
 #include <shared_mutex>
 
 class RWLock {
@@ -49,9 +47,9 @@ public:
 		mutex.unlock_shared();
 	}
 
-	// Attempt to lock the rwlock, OK on success, ERR_BUSY means it can't lock.
-	Error read_try_lock() const {
-		return mutex.try_lock_shared() ? OK : ERR_BUSY;
+	// Attempt to lock the RWLock for reading. True on success, false means it can't lock.
+	bool read_try_lock() const {
+		return mutex.try_lock_shared();
 	}
 
 	// Lock the rwlock, block if locked by someone else
@@ -64,9 +62,9 @@ public:
 		mutex.unlock();
 	}
 
-	// Attempt to lock the rwlock, OK on success, ERR_BUSY means it can't lock.
-	Error write_try_lock() {
-		return mutex.try_lock() ? OK : ERR_BUSY;
+	// Attempt to lock the RWLock for writing. True on success, false means it can't lock.
+	bool write_try_lock() {
+		return mutex.try_lock();
 	}
 };
 

--- a/doc/classes/Mutex.xml
+++ b/doc/classes/Mutex.xml
@@ -18,9 +18,9 @@
 			</description>
 		</method>
 		<method name="try_lock">
-			<return type="int" enum="Error" />
+			<return type="bool" />
 			<description>
-				Tries locking this [Mutex], but does not block. Returns [constant OK] on success, [constant ERR_BUSY] otherwise.
+				Tries locking this [Mutex], but does not block. Returns [code]true[/code] on success, [code]false[/code] otherwise.
 				[b]Note:[/b] This function returns [constant OK] if the thread already has ownership of the mutex.
 			</description>
 		</method>

--- a/doc/classes/Semaphore.xml
+++ b/doc/classes/Semaphore.xml
@@ -17,9 +17,9 @@
 			</description>
 		</method>
 		<method name="try_wait">
-			<return type="int" enum="Error" />
+			<return type="bool" />
 			<description>
-				Like [method wait], but won't block, so if the value is zero, fails immediately and returns [constant ERR_BUSY]. If non-zero, it returns [constant OK] to report success.
+				Like [method wait], but won't block, so if the value is zero, fails immediately and returns [code]false[/code]. If non-zero, it returns [code]true[/code] to report success.
 			</description>
 		</method>
 		<method name="wait">

--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -283,7 +283,7 @@ void AudioDriverCoreAudio::unlock() {
 }
 
 bool AudioDriverCoreAudio::try_lock() {
-	return mutex.try_lock() == OK;
+	return mutex.try_lock();
 }
 
 void AudioDriverCoreAudio::finish() {

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -44,7 +44,7 @@ void AudioDriverOpenSL::_buffer_callback(
 	if (pause) {
 		mix = false;
 	} else {
-		mix = mutex.try_lock() == OK;
+		mix = mutex.try_lock();
 	}
 
 	if (mix) {


### PR DESCRIPTION
The affected methods had an `Error` return type, which no longer made sense after the migration to C++11 sync primitives, with which we don't get detailed information about failures (and, to be honest, what everyone is interested in is in whether the locking succeeded or failed). Therefore, the sensible return type is boolean.

4.0 was the opportunity to do the change because of the compat breakage. Speaking of which, we're already a bit far into the release cycle, but I don't think this will break any projects. If anything, it will avoid future mistakes since it's too tempting to write `if my_mutex.lock()` in GDScript (or in C++ its equivalent) for a reason: it's the most intuitive.