### PR TITLE
Fix filtering editor nodes in Create Dialog

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -122,7 +122,7 @@ bool CreateDialog::_should_hide_type(const String &p_type) const {
 		return true;
 	}
 
-	if (base_type == "Node" && p_type.begins_with("Editor")) {
+	if (is_base_type_node && p_type.begins_with("Editor")) {
 		return true; // Do not show editor nodes.
 	}
 
@@ -506,6 +506,11 @@ String CreateDialog::get_selected_type() {
 	}
 
 	return selected->get_text(0);
+}
+
+void CreateDialog::set_base_type(const String &p_base) {
+	base_type = p_base;
+	is_base_type_node = ClassDB::is_parent_class(p_base, "Node");
 }
 
 Variant CreateDialog::instantiate_selected() {

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -51,6 +51,7 @@ class CreateDialog : public ConfirmationDialog {
 	Tree *search_options = nullptr;
 
 	String base_type;
+	bool is_base_type_node = false;
 	String icon_fallback;
 	String preferred_search_result_type;
 
@@ -113,7 +114,7 @@ public:
 	Variant instantiate_selected();
 	String get_selected_type();
 
-	void set_base_type(const String &p_base) { base_type = p_base; }
+	void set_base_type(const String &p_base);
 	String get_base_type() const { return base_type; }
 	void select_base();
 


### PR DESCRIPTION
Fixes #72033

The create dialog opened from 2D editor uses CanvasItem as base type, which wasn't caught by the old condition.