### PR TITLE
Fix code style and consistency of RWLock and Semaphore

### DIFF
--- a/core/os/rw_lock.h
+++ b/core/os/rw_lock.h
@@ -31,39 +31,41 @@
 #ifndef RW_LOCK_H
 #define RW_LOCK_H
 
+#include "core/typedefs.h"
+
 #include <shared_mutex>
 
 class RWLock {
 	mutable std::shared_timed_mutex mutex;
 
 public:
-	// Lock the rwlock, block if locked by someone else
-	void read_lock() const {
+	// Lock the RWLock, block if locked by someone else.
+	_ALWAYS_INLINE_ void read_lock() const {
 		mutex.lock_shared();
 	}
 
-	// Unlock the rwlock, let other threads continue
-	void read_unlock() const {
+	// Unlock the RWLock, let other threads continue.
+	_ALWAYS_INLINE_ void read_unlock() const {
 		mutex.unlock_shared();
 	}
 
 	// Attempt to lock the RWLock for reading. True on success, false means it can't lock.
-	bool read_try_lock() const {
+	_ALWAYS_INLINE_ bool read_try_lock() const {
 		return mutex.try_lock_shared();
 	}
 
-	// Lock the rwlock, block if locked by someone else
-	void write_lock() {
+	// Lock the RWLock, block if locked by someone else.
+	_ALWAYS_INLINE_ void write_lock() {
 		mutex.lock();
 	}
 
-	// Unlock the rwlock, let other thwrites continue
-	void write_unlock() {
+	// Unlock the RWLock, let other threads continue.
+	_ALWAYS_INLINE_ void write_unlock() {
 		mutex.unlock();
 	}
 
 	// Attempt to lock the RWLock for writing. True on success, false means it can't lock.
-	bool write_try_lock() {
+	_ALWAYS_INLINE_ bool write_try_lock() {
 		return mutex.try_lock();
 	}
 };
@@ -72,11 +74,11 @@ class RWLockRead {
 	const RWLock &lock;
 
 public:
-	RWLockRead(const RWLock &p_lock) :
+	_ALWAYS_INLINE_ RWLockRead(const RWLock &p_lock) :
 			lock(p_lock) {
 		lock.read_lock();
 	}
-	~RWLockRead() {
+	_ALWAYS_INLINE_ ~RWLockRead() {
 		lock.read_unlock();
 	}
 };
@@ -85,11 +87,11 @@ class RWLockWrite {
 	RWLock &lock;
 
 public:
-	RWLockWrite(RWLock &p_lock) :
+	_ALWAYS_INLINE_ RWLockWrite(RWLock &p_lock) :
 			lock(p_lock) {
 		lock.write_lock();
 	}
-	~RWLockWrite() {
+	_ALWAYS_INLINE_ ~RWLockWrite() {
 		lock.write_unlock();
 	}
 };

--- a/core/os/semaphore.h
+++ b/core/os/semaphore.h
@@ -39,32 +39,33 @@
 
 class Semaphore {
 private:
-	mutable std::mutex mutex_;
-	mutable std::condition_variable condition_;
-	mutable unsigned long count_ = 0; // Initialized as locked.
+	mutable std::mutex mutex;
+	mutable std::condition_variable condition;
+	mutable uint32_t count = 0; // Initialized as locked.
 
 public:
 	_ALWAYS_INLINE_ void post() const {
-		std::lock_guard<decltype(mutex_)> lock(mutex_);
-		++count_;
-		condition_.notify_one();
+		std::lock_guard lock(mutex);
+		count++;
+		condition.notify_one();
 	}
 
 	_ALWAYS_INLINE_ void wait() const {
-		std::unique_lock<decltype(mutex_)> lock(mutex_);
-		while (!count_) { // Handle spurious wake-ups.
-			condition_.wait(lock);
+		std::unique_lock lock(mutex);
+		while (!count) { // Handle spurious wake-ups.
+			condition.wait(lock);
 		}
-		--count_;
+		count--;
 	}
 
 	_ALWAYS_INLINE_ bool try_wait() const {
-		std::lock_guard<decltype(mutex_)> lock(mutex_);
-		if (count_) {
-			--count_;
+		std::lock_guard lock(mutex);
+		if (count) {
+			count--;
 			return true;
+		} else {
+			return false;
 		}
-		return false;
 	}
 };
 


### PR DESCRIPTION
~Depends on #72168. Reviewers, please cehck only the second commit, or wait until the other PR is merged.~

- Makes the code style of `Semaphore` more in line with the rest of the codebase.
- Updates the code style of comments (basically, adding periods).
- Removes the template arguments from `std::unique_lock` and `std::lock_guard`, which are not needed since C++14 (or was it C++17?).
- Adds `_ALWAYS_INLINE_` to `RWLock` and related classes, for consistency with other sync primitives. Probably this isn't taking this PR beyond pure cosmetic changes, since compilers are most likely inlining those functions anyway.

**UPDATE:** Back-ported to 3.x in #72251.