### PR TITLE
Warn that autotiles from 3.x cannot be converted automatically to 4.x

### DIFF
--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -2608,6 +2608,7 @@ void TileSet::_compatibility_conversion() {
 			} break;
 			case COMPATIBILITY_TILE_MODE_AUTO_TILE: {
 				// Not supported. It would need manual conversion.
+				WARN_PRINT_ONCE("Could not convert 3.x autotiles to 4.x. This operation cannot be done automatically, autotiles must be re-created using the terrain system.");
 			} break;
 			case COMPATIBILITY_TILE_MODE_ATLAS_TILE: {
 				atlas_source->set_margins(ctd->region.get_position());


### PR DESCRIPTION
May close https://github.com/godotengine/godot/issues/64006 if I have confirmation that the original project was using autotiles, like the MRP.