### PR TITLE
Fix several shader preprocessor include issues

### DIFF
--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -383,11 +383,12 @@ void ShaderTextEditor::_code_complete_script(const String &p_code, List<ScriptLa
 	List<ScriptLanguage::CodeCompletionOption> pp_defines;
 	ShaderPreprocessor preprocessor;
 	String code;
-	complete_from_path = (shader.is_valid() ? shader->get_path() : shader_inc->get_path()).get_base_dir();
+	String resource_path = (shader.is_valid() ? shader->get_path() : shader_inc->get_path());
+	complete_from_path = resource_path.get_base_dir();
 	if (!complete_from_path.ends_with("/")) {
 		complete_from_path += "/";
 	}
-	preprocessor.preprocess(p_code, "", code, nullptr, nullptr, nullptr, nullptr, &pp_options, &pp_defines, _complete_include_paths);
+	preprocessor.preprocess(p_code, resource_path, code, nullptr, nullptr, nullptr, nullptr, &pp_options, &pp_defines, _complete_include_paths);
 	complete_from_path = String();
 	if (pp_options.size()) {
 		for (const ScriptLanguage::CodeCompletionOption &E : pp_options) {

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -56,6 +56,7 @@ private:
 	Mode mode = MODE_SPATIAL;
 	HashSet<Ref<ShaderInclude>> include_dependencies;
 	String code;
+	String include_path;
 
 	HashMap<StringName, HashMap<int, Ref<Texture2D>>> default_textures;
 
@@ -72,6 +73,7 @@ public:
 	virtual Mode get_mode() const;
 
 	virtual void set_path(const String &p_path, bool p_take_over = false) override;
+	void set_include_path(const String &p_path);
 
 	void set_code(const String &p_code);
 	String get_code() const;

--- a/scene/resources/shader_include.cpp
+++ b/scene/resources/shader_include.cpp
@@ -45,9 +45,14 @@ void ShaderInclude::set_code(const String &p_code) {
 	}
 
 	{
+		String path = get_path();
+		if (path.is_empty()) {
+			path = include_path;
+		}
+
 		String pp_code;
 		ShaderPreprocessor preprocessor;
-		preprocessor.preprocess(p_code, "", pp_code, nullptr, nullptr, nullptr, &new_dependencies);
+		preprocessor.preprocess(p_code, path, pp_code, nullptr, nullptr, nullptr, &new_dependencies);
 	}
 
 	// This ensures previous include resources are not freed and then re-loaded during parse (which would make compiling slower)
@@ -62,6 +67,10 @@ void ShaderInclude::set_code(const String &p_code) {
 
 String ShaderInclude::get_code() const {
 	return code;
+}
+
+void ShaderInclude::set_include_path(const String &p_path) {
+	include_path = p_path;
 }
 
 void ShaderInclude::_bind_methods() {
@@ -86,6 +95,7 @@ Ref<Resource> ResourceFormatLoaderShaderInclude::load(const String &p_path, cons
 	String str;
 	str.parse_utf8((const char *)buffer.ptr(), buffer.size());
 
+	shader_inc->set_include_path(p_path);
 	shader_inc->set_code(str);
 
 	if (r_error) {

--- a/scene/resources/shader_include.h
+++ b/scene/resources/shader_include.h
@@ -42,6 +42,7 @@ class ShaderInclude : public Resource {
 
 private:
 	String code;
+	String include_path;
 	HashSet<Ref<ShaderInclude>> dependencies;
 	void _dependency_changed();
 
@@ -51,6 +52,8 @@ protected:
 public:
 	void set_code(const String &p_text);
 	String get_code() const;
+
+	void set_include_path(const String &p_path);
 };
 
 class ResourceFormatLoaderShaderInclude : public ResourceFormatLoader {

--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -674,6 +674,11 @@ void ShaderPreprocessor::process_include(Tokenizer *p_tokenizer) {
 		return;
 	}
 
+	path = path.simplify_path();
+	if (path.is_relative_path()) {
+		path = state->current_filename.get_base_dir().path_join(path);
+	}
+
 	Ref<Resource> res = ResourceLoader::load(path);
 	if (res.is_null()) {
 		set_error(RTR("Shader include load failed. Does the shader include exist? Is there a cyclic dependency?"), line);


### PR DESCRIPTION
Fix several issues related to shader preprocessor include path handling.

* Close https://github.com/godotengine/godot-proposals/issues/5399. This PR started as a bugfix, so it was a nice surprise to accidentally implement a proposal too.

* Close https://github.com/godotengine/godot/issues/66075, hopefully forever. The issue in the first post was already fixed in my previous PR (https://github.com/godotengine/godot/pull/71878), but the issue was kept open because it might still have relevance. Hopefully this PR will finally slay the other problems discussed in that thread. I was able to reproduce similar shader loading error behavior as @TokisanGames described and this PR fixed it for me, but if they have some complex Godot gigaproject there might be more corner cases lurking somewhere. Fingers crossed.

* Fix https://github.com/godotengine/godot/issues/64792. Because relative paths should now work correctly, that issue will no longer be a problem as the autocomplete relative path suggestion is a now a good one.

* Fix https://github.com/godotengine/godot/issues/72108. The title and first post of that issue are a bit misleading, read the second post in the thread for clarification. Relative paths should now work correctly. The mostly unrelated "Too many arguments for xyz()" issue seems to be tracked here: https://github.com/godotengine/godot/issues/72120.

* Fix https://github.com/godotengine/godot/issues/67811.

This mostly applies to externally saved Shaders and ShaderIncludes resources that have a file path. Shaders stored inside a scene or created programmatically will naturally have to use absolute include paths.

By a relative path I mean paths that are in the same level or below in the directory hierarchy (like "subdir/another/common.gdshaderinc"). Relative paths that would require normalization (like "../../common.gdshaderinc") will not work. Absolute paths like "res://data/common.gdshaderinc" have always worked. Previously, relative paths only worked if the files using #include were in the project root folder.

The problem was that the full resource path to the processed shader or include wasn't always available or even used, which naturally caused relative includes to fail. This was especially common when loading a project, moving files or reimporting stuff as the resource path was sometimes updated too late.