### PR TITLE
GDScript: Fix broken export group annotations

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1062,7 +1062,7 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 		resolve_class_body(base_class, p_class);
 	}
 
-	// Do functions and properties now.
+	// Do functions, properties, and groups now.
 	for (int i = 0; i < p_class->members.size(); i++) {
 		GDScriptParser::ClassNode::Member member = p_class->members[i];
 		if (member.type == GDScriptParser::ClassNode::Member::FUNCTION) {
@@ -1102,6 +1102,10 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 					resolve_function_body(member.variable->setter);
 				}
 			}
+		} else if (member.type == GDScriptParser::ClassNode::Member::GROUP) {
+			// Apply annotation (`@export_{category,group,subgroup}`).
+			resolve_annotation(member.annotation);
+			member.annotation->apply(parser, nullptr);
 		}
 	}
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -840,14 +840,19 @@ void GDScriptParser::parse_class_body(bool p_is_multiline) {
 			case GDScriptTokenizer::Token::ANNOTATION: {
 				advance();
 
-				// Check for class-level annotations.
+				// Check for standalone and class-level annotations.
 				AnnotationNode *annotation = parse_annotation(AnnotationInfo::STANDALONE | AnnotationInfo::CLASS_LEVEL);
 				if (annotation != nullptr) {
 					if (annotation->applies_to(AnnotationInfo::STANDALONE)) {
 						if (previous.type != GDScriptTokenizer::Token::NEWLINE) {
 							push_error(R"(Expected newline after a standalone annotation.)");
 						}
-						head->annotations.push_back(annotation);
+						if (annotation->name == "@export_category" || annotation->name == "@export_group" || annotation->name == "@export_subgroup") {
+							current_class->add_member_group(annotation);
+						} else {
+							// For potential non-group standalone annotations.
+							push_error(R"(Unexpected standalone annotation in class body.)");
+						}
 					} else {
 						annotation_stack.push_back(annotation);
 					}
@@ -3849,7 +3854,6 @@ bool GDScriptParser::export_group_annotations(const AnnotationNode *p_annotation
 		} break;
 	}
 
-	current_class->add_member_group(annotation);
 	return true;
 }
 


### PR DESCRIPTION
Perhaps the name `STANDALONE` is not very successful. Currently, only export group annotations are such, but perhaps in the future other standalone annotations will appear, and we will need to distinguish between `STANDALONE` and `GROUP`.

**Note 1:** Export group annotations are class pseudo-members. Therefore, they are resolved in the analyzer individually, as an independent entity, unlike other annotations.

**Note 2:** Groups are still broken in the remote inspector, but this bug was introduced before #71634.

Fixes #72151.
