### PR TITLE
Add hints to some drag actions

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1379,6 +1379,60 @@ void SceneTreeDock::_notification(int p_what) {
 					scene_tree->show();
 				}
 			}
+
+			if (get_viewport()->gui_is_dragging()) {
+				bool mouse_inside = get_screen_rect().has_point(Input::get_singleton()->get_mouse_position());
+				if (mouse_inside && drag_preview_extension_handled) {
+					return;
+				} else if (!mouse_inside && drag_preview_extension_handled) {
+					drag_preview_extension_handled = false;
+					if (drag_preview_extension.is_valid()) {
+						Control *control = Object::cast_to<Control>(ObjectDB::get_instance(drag_preview_extension));
+						if (control) {
+							memdelete(control);
+						}
+						drag_preview_extension = ObjectID();
+					}
+				} else if (mouse_inside && !drag_preview_extension_handled) {
+					drag_preview_extension_handled = true;
+					Label *extension_label = nullptr;
+					Dictionary drag_data = get_viewport()->gui_get_drag_data();
+
+					bool is_data_script = false;
+					String data_type = drag_data.get("type", "");
+					if (data_type == "nodes") {
+						extension_label = memnew(Label(TTR("Hold Shift to keep local transform when reparenting.")));
+					} else if (data_type == "files") {
+						Array files = drag_data.get("files", Array());
+						if (!files.is_empty()) {
+							String file_path = files[0];
+							if (ClassDB::is_parent_class(ResourceLoader::get_resource_type(file_path), "Script")) {
+								is_data_script = true;
+							}
+						}
+					} else if (data_type == "script_list_element") {
+						is_data_script = true;
+					}
+
+					if (is_data_script) {
+						extension_label = memnew(Label(TTR("Hold Control to instantiate the script as a child node.")));
+					}
+
+					if (extension_label) {
+						extension_label->add_theme_style_override(SNAME("normal"), get_theme_stylebox(SNAME("panel"), SNAME("TooltipPanel")));
+						drag_preview_extension = extension_label->get_instance_id();
+
+						Control *current_drag = get_viewport()->gui_get_drag_preview();
+						if (current_drag) {
+							current_drag->add_child(extension_label);
+						} else {
+							get_viewport()->gui_set_drag_preview(this, extension_label);
+						}
+					}
+				}
+			} else {
+				drag_preview_extension_handled = false;
+			}
 		} break;
 	}
 }

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -102,6 +102,8 @@ class SceneTreeDock : public VBoxContainer {
 	Vector<ObjectID> subresources;
 
 	bool reset_create_dialog = false;
+	bool drag_preview_extension_handled = false;
+	ObjectID drag_preview_extension;
 
 	int current_option = 0;
 	CreateDialog *create_dialog = nullptr;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1876,7 +1876,7 @@ void Control::force_drag(const Variant &p_data, Control *p_control) {
 void Control::set_drag_preview(Control *p_control) {
 	ERR_FAIL_COND(!is_inside_tree());
 	ERR_FAIL_COND(!get_viewport()->gui_is_dragging());
-	get_viewport()->_gui_set_drag_preview(this, p_control);
+	get_viewport()->gui_set_drag_preview(this, p_control);
 }
 
 bool Control::is_drag_successful() const {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1439,7 +1439,7 @@ Control *Viewport::_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_
 		return nullptr;
 	}
 
-	Control *drag_preview = _gui_get_drag_preview();
+	Control *drag_preview = gui_get_drag_preview();
 	if (!drag_preview || (c != drag_preview && !drag_preview->is_ancestor_of(c))) {
 		return c;
 	}
@@ -1622,7 +1622,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 								gui.mouse_focus_mask.clear();
 								break;
 							} else {
-								Control *drag_preview = _gui_get_drag_preview();
+								Control *drag_preview = gui_get_drag_preview();
 								if (drag_preview) {
 									ERR_PRINT("Don't set a drag preview and return null data. Preview was deleted and drag request ignored.");
 									memdelete(drag_preview);
@@ -1764,7 +1764,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		if (gui.dragging) {
 			// Handle drag & drop.
 
-			Control *drag_preview = _gui_get_drag_preview();
+			Control *drag_preview = gui_get_drag_preview();
 			if (drag_preview) {
 				drag_preview->set_position(mpos);
 			}
@@ -2056,7 +2056,7 @@ void Viewport::_perform_drop(Control *p_control, Point2 p_pos) {
 		gui.drag_successful = false;
 	}
 
-	Control *drag_preview = _gui_get_drag_preview();
+	Control *drag_preview = gui_get_drag_preview();
 	if (drag_preview) {
 		memdelete(drag_preview);
 		gui.drag_preview_id = ObjectID();
@@ -2097,18 +2097,18 @@ void Viewport::_gui_force_drag(Control *p_base, const Variant &p_data, Control *
 	gui.mouse_focus = nullptr;
 
 	if (p_control) {
-		_gui_set_drag_preview(p_base, p_control);
+		gui_set_drag_preview(p_base, p_control);
 	}
 	_propagate_viewport_notification(this, NOTIFICATION_DRAG_BEGIN);
 }
 
-void Viewport::_gui_set_drag_preview(Control *p_base, Control *p_control) {
+void Viewport::gui_set_drag_preview(Control *p_base, Control *p_control) {
 	ERR_FAIL_NULL(p_control);
 	ERR_FAIL_COND(!Object::cast_to<Control>((Object *)p_control));
 	ERR_FAIL_COND(p_control->is_inside_tree());
 	ERR_FAIL_COND(p_control->get_parent() != nullptr);
 
-	Control *drag_preview = _gui_get_drag_preview();
+	Control *drag_preview = gui_get_drag_preview();
 	if (drag_preview) {
 		memdelete(drag_preview);
 	}
@@ -2120,7 +2120,7 @@ void Viewport::_gui_set_drag_preview(Control *p_base, Control *p_control) {
 	gui.drag_preview_id = p_control->get_instance_id();
 }
 
-Control *Viewport::_gui_get_drag_preview() {
+Control *Viewport::gui_get_drag_preview() {
 	if (gui.drag_preview_id.is_null()) {
 		return nullptr;
 	} else {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -426,8 +426,6 @@ private:
 	void _gui_hide_control(Control *p_control);
 
 	void _gui_force_drag(Control *p_base, const Variant &p_data, Control *p_control);
-	void _gui_set_drag_preview(Control *p_base, Control *p_control);
-	Control *_gui_get_drag_preview();
 
 	void _gui_remove_focus_for_window(Node *p_window);
 	void _gui_unfocus_control(Control *p_control);
@@ -578,6 +576,8 @@ public:
 	bool get_physics_object_picking();
 
 	Variant gui_get_drag_data() const;
+	void gui_set_drag_preview(Control *p_base, Control *p_control);
+	Control *gui_get_drag_preview();
 
 	void gui_reset_canvas_sort_index();
 	int gui_get_canvas_sort_index();


### PR DESCRIPTION
We have many hidden drag and drop modifiers and it would be nice to indicate them somehow. Here's an idea:

https://user-images.githubusercontent.com/2223172/215130526-1f81797c-a794-4f31-ae1b-7734ec8cc328.mp4

I grab the drag preview and add a label that displays actions. This is not a perfect solution, because it requires the drag preview to be VBoxContainer to look good. I also had to make the drag preview functions public to make this possible.

We could think of some better place to display this information. Creating the label is the most complex part and it can be easily moved anywhere else.