### PR TITLE
Improve TileSet 3to4 conversion, avoiding some data loss

### DIFF
--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -198,6 +198,7 @@ private:
 	HashMap<int, CompatibilityTileData *> compatibility_data;
 	HashMap<int, int> compatibility_tilemap_mapping_tile_modes;
 	HashMap<int, RBMap<Array, Array>> compatibility_tilemap_mapping;
+	HashMap<Vector2i, int> compatibility_size_count;
 
 	void _compatibility_conversion();
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/70784.

Does:
- Convert the 3.x "<tile_id>/occluder" and "<tile_id>/navigation" properties
- Take into account H flip, V flip and transpose flag for recreating occlusions, collision and navigation shapes.
- Fix those polygons being offset
- Adds a way to find the best tile size to use according to existing 3.x tiles. It does so by building an histogram of all used sizes and uses the most common one.