### PR TITLE
Add option to print filenames in GDScript unit testing

### DIFF
--- a/modules/gdscript/tests/gdscript_test_runner.h
+++ b/modules/gdscript/tests/gdscript_test_runner.h
@@ -92,6 +92,7 @@ public:
 	bool generate_output();
 
 	const String &get_source_file() const { return source_file; }
+	const String get_source_relative_filepath() const { return source_file.trim_prefix(base_dir); }
 	const String &get_output_file() const { return output_file; }
 
 	GDScriptTest(const String &p_source_path, const String &p_output_path, const String &p_base_dir);
@@ -105,6 +106,7 @@ class GDScriptTestRunner {
 
 	bool is_generating = false;
 	bool do_init_languages = false;
+	bool print_filenames; // Whether filenames should be printed when generated/running tests
 
 	bool make_tests();
 	bool make_tests_for_dir(const String &p_dir);
@@ -117,7 +119,7 @@ public:
 	int run_tests();
 	bool generate_outputs();
 
-	GDScriptTestRunner(const String &p_source_dir, bool p_init_language);
+	GDScriptTestRunner(const String &p_source_dir, bool p_init_language, bool p_print_filenames = false);
 	~GDScriptTestRunner();
 };
 

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -41,7 +41,8 @@ TEST_SUITE("[Modules][GDScript]") {
 	// Allow the tests to fail, but do not ignore errors during development.
 	// Update the scripts and expected output as needed.
 	TEST_CASE("Script compilation and runtime") {
-		GDScriptTestRunner runner("modules/gdscript/tests/scripts", true);
+		bool print_filenames = OS::get_singleton()->get_cmdline_args().find("--print-filenames") != nullptr;
+		GDScriptTestRunner runner("modules/gdscript/tests/scripts", true, print_filenames);
 		int fail_count = runner.run_tests();
 		INFO("Make sure `*.out` files have expected results.");
 		REQUIRE_MESSAGE(fail_count == 0, "All GDScript tests should pass.");


### PR DESCRIPTION
Allows using the `--print-filenames` option when running or generating GDScript tests. This should make it easier to identify which file is causing the segfault with whatever new amazing feature the GDScript folks are implementing :)

![image](https://user-images.githubusercontent.com/1133892/215222116-d64b7390-9b0f-4d16-b299-df75a9409b16.png)


Also removed the legacy test option `--gdscript-test`.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
