### PR TITLE
Mark dirty flags when shaped texts are invalidated

### DIFF
--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -418,6 +418,18 @@ void Label3D::_generate_glyph_surfaces(const Glyph &p_glyph, Vector2 &r_offset, 
 }
 
 void Label3D::_shape() {
+	// When a shaped text is invalidated by an external source, we want to reshape it.
+	if (!TS->shaped_text_is_ready(text_rid)) {
+		dirty_text = true;
+	}
+
+	for (const RID &line_rid : lines_rid) {
+		if (!TS->shaped_text_is_ready(line_rid)) {
+			dirty_lines = true;
+			break;
+		}
+	}
+
 	// Clear mesh.
 	RS::get_singleton()->mesh_clear(mesh);
 	aabb = AABB();

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -345,6 +345,18 @@ void Label::_notification(int p_what) {
 				RenderingServer::get_singleton()->canvas_item_set_clip(get_canvas_item(), true);
 			}
 
+			// When a shaped text is invalidated by an external source, we want to reshape it.
+			if (!TS->shaped_text_is_ready(text_rid)) {
+				dirty = true;
+			}
+
+			for (const RID &line_rid : lines_rid) {
+				if (!TS->shaped_text_is_ready(line_rid)) {
+					lines_dirty = true;
+					break;
+				}
+			}
+
 			if (dirty || font_dirty || lines_dirty) {
 				_shape();
 			}

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -3340,7 +3340,7 @@ void TextMesh::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pixel_size", PROPERTY_HINT_RANGE, "0.0001,128,0.0001,suffix:m"), "set_pixel_size", "get_pixel_size");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "curve_step", PROPERTY_HINT_RANGE, "0.1,10,0.1,suffix:px"), "set_curve_step", "get_curve_step");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "depth", PROPERTY_HINT_RANGE, "0.0,100.0,0.001,or_greater,suffix:m"), "set_depth", "get_depth");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "width", PROPERTY_HINT_NONE, "suffix:m"), "set_width", "get_width");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "width", PROPERTY_HINT_NONE, "suffix:px"), "set_width", "get_width");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "offset", PROPERTY_HINT_NONE, "suffix:px"), "set_offset", "get_offset");
 
 	ADD_GROUP("BiDi", "");

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -2890,6 +2890,18 @@ void TextMesh::_create_mesh_array(Array &p_arr) const {
 		dirty_cache = false;
 	}
 
+	// When a shaped text is invalidated by an external source, we want to reshape it.
+	if (!TS->shaped_text_is_ready(text_rid)) {
+		dirty_text = true;
+	}
+
+	for (const RID &line_rid : lines_rid) {
+		if (!TS->shaped_text_is_ready(line_rid)) {
+			dirty_lines = true;
+			break;
+		}
+	}
+
 	// Update text buffer.
 	if (dirty_text) {
 		TS->shaped_text_clear(text_rid);

--- a/scene/resources/text_line.cpp
+++ b/scene/resources/text_line.cpp
@@ -101,6 +101,11 @@ void TextLine::_bind_methods() {
 }
 
 void TextLine::_shape() {
+	// When a shaped text is invalidated by an external source, we want to reshape it.
+	if (!TS->shaped_text_is_ready(rid)) {
+		dirty = true;
+	}
+
 	if (dirty) {
 		if (!tab_stops.is_empty()) {
 			TS->shaped_text_tab_align(rid, tab_stops);

--- a/scene/resources/text_paragraph.cpp
+++ b/scene/resources/text_paragraph.cpp
@@ -134,6 +134,18 @@ void TextParagraph::_bind_methods() {
 }
 
 void TextParagraph::_shape_lines() {
+	// When a shaped text is invalidated by an external source, we want to reshape it.
+	if (!TS->shaped_text_is_ready(rid) || !TS->shaped_text_is_ready(dropcap_rid)) {
+		lines_dirty = true;
+	}
+
+	for (const RID &line_rid : lines_rid) {
+		if (!TS->shaped_text_is_ready(line_rid)) {
+			lines_dirty = true;
+			break;
+		}
+	}
+
 	if (lines_dirty) {
 		for (const RID &line_rid : lines_rid) {
 			TS->free_rid(line_rid);


### PR DESCRIPTION
- Fixes #69006
- Fixes #68721

Shaped texts can be invalidated in some cases, notably when the screen is resized, causing the global oversampling to change because it is calculated using the screen size when the scale mode is "Canvas Items". In these cases, we want all the texts to be reshaped using the node behavior, or else lot of information will be lost (like tab aligns, tab/space icons, justification, etc...), so I did this by checking if the texts are invalidated, and marking them dirty when they are.

(Bonus: TextMesh width property suffix is now `px` instead of `m`)

*I would also like to note that text nodes (Label, TextEdit, TextMesh, ...) each use their own implementation of how to draw text, leading to a lot of inconsistencies between them (for instance `\t` is not always handled the same way), I think it might be important to do some refactor, to make them share a common base.*