### PR TITLE
GraphNode ignore non-visible children for minimum size.

### DIFF
--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -664,7 +664,7 @@ Size2 GraphNode::get_minimum_size() const {
 
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *c = Object::cast_to<Control>(get_child(i));
-		if (!c) {
+		if (!c || !c->is_visible()) {
 			continue;
 		}
 		if (c->is_set_as_top_level()) {


### PR DESCRIPTION
Gives more flexibility when creating custom GraphNodes, by allowing the user to hide elements of choice when it gets small.
