### PR TITLE
Apply root scale to 3d shapes on import

### DIFF
--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -279,7 +279,7 @@ public:
 
 	Node *_pre_fix_node(Node *p_node, Node *p_root, HashMap<Ref<ImporterMesh>, Vector<Ref<Shape3D>>> &r_collision_map, Pair<PackedVector3Array, PackedInt32Array> *r_occluder_arrays, List<Pair<NodePath, Node *>> &r_node_renames);
 	Node *_pre_fix_animations(Node *p_node, Node *p_root, const Dictionary &p_node_data, const Dictionary &p_animation_data, float p_animation_fps);
-	Node *_post_fix_node(Node *p_node, Node *p_root, HashMap<Ref<ImporterMesh>, Vector<Ref<Shape3D>>> &collision_map, Pair<PackedVector3Array, PackedInt32Array> &r_occluder_arrays, HashSet<Ref<ImporterMesh>> &r_scanned_meshes, const Dictionary &p_node_data, const Dictionary &p_material_data, const Dictionary &p_animation_data, float p_animation_fps);
+	Node *_post_fix_node(Node *p_node, Node *p_root, HashMap<Ref<ImporterMesh>, Vector<Ref<Shape3D>>> &collision_map, Pair<PackedVector3Array, PackedInt32Array> &r_occluder_arrays, HashSet<Ref<ImporterMesh>> &r_scanned_meshes, const Dictionary &p_node_data, const Dictionary &p_material_data, const Dictionary &p_animation_data, float p_animation_fps, float p_applied_root_scale);
 	Node *_post_fix_animations(Node *p_node, Node *p_root, const Dictionary &p_node_data, const Dictionary &p_animation_data, float p_animation_fps);
 
 	Ref<Animation> _save_animation_to_file(Ref<Animation> anim, bool p_save_to_file, String p_save_to_path, bool p_keep_custom_tracks);
@@ -298,7 +298,7 @@ public:
 	ResourceImporterScene(bool p_animation_import = false);
 
 	template <class M>
-	static Vector<Ref<Shape3D>> get_collision_shapes(const Ref<Mesh> &p_mesh, const M &p_options);
+	static Vector<Ref<Shape3D>> get_collision_shapes(const Ref<Mesh> &p_mesh, const M &p_options, float p_applied_root_scale);
 
 	template <class M>
 	static Transform3D get_collision_shapes_transform(const M &p_options);
@@ -314,7 +314,7 @@ public:
 };
 
 template <class M>
-Vector<Ref<Shape3D>> ResourceImporterScene::get_collision_shapes(const Ref<Mesh> &p_mesh, const M &p_options) {
+Vector<Ref<Shape3D>> ResourceImporterScene::get_collision_shapes(const Ref<Mesh> &p_mesh, const M &p_options, float p_applied_root_scale) {
 	ShapeType generate_shape_type = SHAPE_TYPE_DECOMPOSE_CONVEX;
 	if (p_options.has(SNAME("physics/shape_type"))) {
 		generate_shape_type = (ShapeType)p_options[SNAME("physics/shape_type")].operator int();
@@ -409,7 +409,7 @@ Vector<Ref<Shape3D>> ResourceImporterScene::get_collision_shapes(const Ref<Mesh>
 		Ref<BoxShape3D> box;
 		box.instantiate();
 		if (p_options.has(SNAME("primitive/size"))) {
-			box->set_size(p_options[SNAME("primitive/size")]);
+			box->set_size(p_options[SNAME("primitive/size")].operator Vector3() * p_applied_root_scale);
 		}
 
 		Vector<Ref<Shape3D>> shapes;
@@ -420,7 +420,7 @@ Vector<Ref<Shape3D>> ResourceImporterScene::get_collision_shapes(const Ref<Mesh>
 		Ref<SphereShape3D> sphere;
 		sphere.instantiate();
 		if (p_options.has(SNAME("primitive/radius"))) {
-			sphere->set_radius(p_options[SNAME("primitive/radius")]);
+			sphere->set_radius(p_options[SNAME("primitive/radius")].operator float() * p_applied_root_scale);
 		}
 
 		Vector<Ref<Shape3D>> shapes;
@@ -430,10 +430,10 @@ Vector<Ref<Shape3D>> ResourceImporterScene::get_collision_shapes(const Ref<Mesh>
 		Ref<CylinderShape3D> cylinder;
 		cylinder.instantiate();
 		if (p_options.has(SNAME("primitive/height"))) {
-			cylinder->set_height(p_options[SNAME("primitive/height")]);
+			cylinder->set_height(p_options[SNAME("primitive/height")].operator float() * p_applied_root_scale);
 		}
 		if (p_options.has(SNAME("primitive/radius"))) {
-			cylinder->set_radius(p_options[SNAME("primitive/radius")]);
+			cylinder->set_radius(p_options[SNAME("primitive/radius")].operator float() * p_applied_root_scale);
 		}
 
 		Vector<Ref<Shape3D>> shapes;
@@ -443,10 +443,10 @@ Vector<Ref<Shape3D>> ResourceImporterScene::get_collision_shapes(const Ref<Mesh>
 		Ref<CapsuleShape3D> capsule;
 		capsule.instantiate();
 		if (p_options.has(SNAME("primitive/height"))) {
-			capsule->set_height(p_options[SNAME("primitive/height")]);
+			capsule->set_height(p_options[SNAME("primitive/height")].operator float() * p_applied_root_scale);
 		}
 		if (p_options.has(SNAME("primitive/radius"))) {
-			capsule->set_radius(p_options[SNAME("primitive/radius")]);
+			capsule->set_radius(p_options[SNAME("primitive/radius")].operator float() * p_applied_root_scale);
 		}
 
 		Vector<Ref<Shape3D>> shapes;

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -441,7 +441,7 @@ void SceneImportSettings::_update_view_gizmos() {
 			// This collider_view doesn't have a mesh so we need to generate a new one.
 
 			// Generate the mesh collider.
-			Vector<Ref<Shape3D>> shapes = ResourceImporterScene::get_collision_shapes(mesh_node->get_mesh(), e.value.settings);
+			Vector<Ref<Shape3D>> shapes = ResourceImporterScene::get_collision_shapes(mesh_node->get_mesh(), e.value.settings, 1.0);
 			const Transform3D transform = ResourceImporterScene::get_collision_shapes_transform(e.value.settings);
 
 			Ref<ArrayMesh> collider_view_mesh;


### PR DESCRIPTION
Fixes  #72049

If `apply_root_scale` is ticked on import, apply the scale to generated shape (box, cylinder, capsule and sphere).

_Not sure if it's the best way to implement it since the  `_post_fix_node` method seems a bit bloated with parameters. I'm open to advice for a better implementation._