### PR TITLE
Ensure that SceneTree is initialized and finalized at correct time

### DIFF
--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -138,7 +138,6 @@ private:
 
 	HashMap<StringName, Group> group_map;
 	bool _quit = false;
-	bool initialized = false;
 
 	StringName tree_changed_name = "tree_changed";
 	StringName node_added_name = "node_added";


### PR DESCRIPTION
SceneTree should be fully initialized before any tree operation with any node and finalized only after all nodes exited tree.

Accounts only for in-tree operations, not constructors. After fix init-deinit order will be:

1. constructors (_init) in unspecified order
2. SceneTree native _initialize
3. SceneTree script _initialize
4. All nodes in-tree lifecycle (_enter_tree ->_ready -> ...-> _exit_tree)
5. SceneTree script _finalize
6. SceneTree native _finalize

Partially fixes https://github.com/godotengine/godot/issues/71695