### PR TITLE
Fix sub-resource IDs resetting when preloaded

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -601,9 +601,11 @@ Error ResourceLoaderText::load() {
 			*progress = resource_current / float(resources_total);
 		}
 
-		int_resources[id] = res; //always assign int resources
-		if (do_assign && cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
-			res->set_path(path, cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE);
+		int_resources[id] = res; // Always assign int resources.
+		if (do_assign) {
+			if (cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
+				res->set_path(path, cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE);
+			}
 			res->set_scene_unique_id(id);
 		}
 


### PR DESCRIPTION
*Probably* fixes #62258, idk what the issue is about at this point

I had a case in my project where I had a scene A preloading scene B. If I opened A first and then opened B, all B's sub-resource IDs would reset and the built-in script would show as `[unsaved][*]`. It *might* be the clue of all sub-resource issues reported in the issue.

The fix I did is not probably correct (the code seems to have been like this for a very long time, so changing it might have some unwanted side-effects), but it fixes the issue.

EDIT:
I came upon this comment
https://github.com/godotengine/godot/pull/71171#issue-1527805339
which basically confirms that it isn't the right fix. But if the cache is ignored, loading the same resource again should replace the resource from ignored load (to make sure it has a path this time).