### PR TITLE
Fix AnimatedSprite play() don't redraw immediately

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -475,8 +475,9 @@ void AnimatedSprite2D::play(const StringName &p_name, float p_custom_scale, bool
 		}
 	}
 
-	notify_property_list_changed();
 	set_process_internal(true);
+	notify_property_list_changed();
+	queue_redraw();
 }
 
 void AnimatedSprite2D::play_backwards(const StringName &p_name) {

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1182,8 +1182,9 @@ void AnimatedSprite3D::play(const StringName &p_name, float p_custom_scale, bool
 		}
 	}
 
-	notify_property_list_changed();
 	set_process_internal(true);
+	notify_property_list_changed();
+	_queue_redraw();
 }
 
 void AnimatedSprite3D::play_backwards(const StringName &p_name) {

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -149,7 +149,7 @@ private:
 		HashMap<StringName, BezierAnim> bezier_anim;
 
 		struct PlayingAudioStreamInfo {
-			int64_t index = -1;
+			AudioStreamPlaybackPolyphonic::ID index = -1;
 			double start = 0.0;
 			double len = 0.0;
 		};

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -253,12 +253,14 @@ private:
 		}
 	};
 
+	// Audio stream information for each audio stream placed on the track.
 	struct PlayingAudioStreamInfo {
-		int64_t index = -1;
+		AudioStreamPlaybackPolyphonic::ID index = -1; // ID retrieved from AudioStreamPlaybackPolyphonic.
 		double start = 0.0;
 		double len = 0.0;
 	};
 
+	// Audio track information for mixng and ending.
 	struct PlayingAudioTrackInfo {
 		HashMap<int, PlayingAudioStreamInfo> stream_info;
 		double length = 0.0;
@@ -272,7 +274,7 @@ private:
 	struct TrackCacheAudio : public TrackCache {
 		Ref<AudioStreamPolyphonic> audio_stream;
 		Ref<AudioStreamPlaybackPolyphonic> audio_stream_playback;
-		HashMap<ObjectID, PlayingAudioTrackInfo> playing_streams; // Animation resource RID & AudioTrack key index: PlayingAudioStreamInfo.
+		HashMap<ObjectID, PlayingAudioTrackInfo> playing_streams; // Key is Animation resource ObjectID.
 
 		TrackCacheAudio() {
 			type = Animation::TYPE_AUDIO;


### PR DESCRIPTION
Fixed #72254.

Previously it was called redraw immediately because set_animation() was called in play(), but I forgot that I should add redraw since the new code changes the animation directly.