### PR TITLE
Convert `SceneTree::GroupCallFlags` enum to `BitField` flags

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -151,7 +151,7 @@
 		</method>
 		<method name="notify_group_flags">
 			<return type="void" />
-			<param index="0" name="call_flags" type="int" />
+			<param index="0" name="call_flags" type="int" enum="SceneTree.GroupCallFlags" is_bitfield="true" />
 			<param index="1" name="group" type="StringName" />
 			<param index="2" name="notification" type="int" />
 			<description>
@@ -195,7 +195,7 @@
 		</method>
 		<method name="set_group_flags">
 			<return type="void" />
-			<param index="0" name="call_flags" type="int" />
+			<param index="0" name="call_flags" type="int" enum="SceneTree.GroupCallFlags" is_bitfield="true" />
 			<param index="1" name="group" type="StringName" />
 			<param index="2" name="property" type="String" />
 			<param index="3" name="value" type="Variant" />
@@ -308,16 +308,16 @@
 		</signal>
 	</signals>
 	<constants>
-		<constant name="GROUP_CALL_DEFAULT" value="0" enum="GroupCallFlags">
+		<constant name="GROUP_CALL_DEFAULT" value="0" enum="GroupCallFlags" is_bitfield="true">
 			Call a group with no flags (default).
 		</constant>
-		<constant name="GROUP_CALL_REVERSE" value="1" enum="GroupCallFlags">
+		<constant name="GROUP_CALL_REVERSE" value="1" enum="GroupCallFlags" is_bitfield="true">
 			Call a group in reverse scene order.
 		</constant>
-		<constant name="GROUP_CALL_DEFERRED" value="2" enum="GroupCallFlags">
+		<constant name="GROUP_CALL_DEFERRED" value="2" enum="GroupCallFlags" is_bitfield="true">
 			Call a group at the end of the current frame (process or physics).
 		</constant>
-		<constant name="GROUP_CALL_UNIQUE" value="4" enum="GroupCallFlags">
+		<constant name="GROUP_CALL_UNIQUE" value="4" enum="GroupCallFlags" is_bitfield="true">
 			Call a group only once even if the call is executed many times.
 			[b]Note:[/b] Arguments are not taken into account when deciding whether the call is unique or not. Therefore when the same method is called with different arguments, only the first call will be performed.
 		</constant>

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -226,7 +226,7 @@ void SceneTree::_update_group_order(Group &g) {
 	g.changed = false;
 }
 
-void SceneTree::call_group_flagsp(uint32_t p_call_flags, const StringName &p_group, const StringName &p_function, const Variant **p_args, int p_argcount) {
+void SceneTree::call_group_flagsp(BitField<GroupCallFlags> p_call_flags, const StringName &p_group, const StringName &p_function, const Variant **p_args, int p_argcount) {
 	Vector<Node *> nodes_copy;
 
 	{
@@ -241,7 +241,7 @@ void SceneTree::call_group_flagsp(uint32_t p_call_flags, const StringName &p_gro
 			return;
 		}
 
-		if (p_call_flags & GROUP_CALL_UNIQUE && p_call_flags & GROUP_CALL_DEFERRED) {
+		if (p_call_flags.has_flag(GROUP_CALL_UNIQUE) && p_call_flags.has_flag(GROUP_CALL_DEFERRED)) {
 			ERR_FAIL_COND(ugc_locked);
 
 			UGCall ug;
@@ -273,13 +273,13 @@ void SceneTree::call_group_flagsp(uint32_t p_call_flags, const StringName &p_gro
 		nodes_removed_on_group_call_lock++;
 	}
 
-	if (p_call_flags & GROUP_CALL_REVERSE) {
+	if (p_call_flags.has_flag(GROUP_CALL_REVERSE)) {
 		for (int i = gr_node_count - 1; i >= 0; i--) {
 			if (nodes_removed_on_group_call_lock && nodes_removed_on_group_call.has(gr_nodes[i])) {
 				continue;
 			}
 
-			if (!(p_call_flags & GROUP_CALL_DEFERRED)) {
+			if (!p_call_flags.has_flag(GROUP_CALL_DEFERRED)) {
 				Callable::CallError ce;
 				gr_nodes[i]->callp(p_function, p_args, p_argcount, ce);
 			} else {
@@ -293,7 +293,7 @@ void SceneTree::call_group_flagsp(uint32_t p_call_flags, const StringName &p_gro
 				continue;
 			}
 
-			if (!(p_call_flags & GROUP_CALL_DEFERRED)) {
+			if (!p_call_flags.has_flag(GROUP_CALL_DEFERRED)) {
 				Callable::CallError ce;
 				gr_nodes[i]->callp(p_function, p_args, p_argcount, ce);
 			} else {
@@ -311,7 +311,7 @@ void SceneTree::call_group_flagsp(uint32_t p_call_flags, const StringName &p_gro
 	}
 }
 
-void SceneTree::notify_group_flags(uint32_t p_call_flags, const StringName &p_group, int p_notification) {
+void SceneTree::notify_group_flags(BitField<GroupCallFlags> p_call_flags, const StringName &p_group, int p_notification) {
 	Vector<Node *> nodes_copy;
 	{
 		_THREAD_SAFE_METHOD_
@@ -337,13 +337,13 @@ void SceneTree::notify_group_flags(uint32_t p_call_flags, const StringName &p_gr
 		nodes_removed_on_group_call_lock++;
 	}
 
-	if (p_call_flags & GROUP_CALL_REVERSE) {
+	if (p_call_flags.has_flag(GROUP_CALL_REVERSE)) {
 		for (int i = gr_node_count - 1; i >= 0; i--) {
 			if (nodes_removed_on_group_call.has(gr_nodes[i])) {
 				continue;
 			}
 
-			if (!(p_call_flags & GROUP_CALL_DEFERRED)) {
+			if (!p_call_flags.has_flag(GROUP_CALL_DEFERRED)) {
 				gr_nodes[i]->notification(p_notification, true);
 			} else {
 				MessageQueue::get_singleton()->push_notification(gr_nodes[i], p_notification);
@@ -356,7 +356,7 @@ void SceneTree::notify_group_flags(uint32_t p_call_flags, const StringName &p_gr
 				continue;
 			}
 
-			if (!(p_call_flags & GROUP_CALL_DEFERRED)) {
+			if (!p_call_flags.has_flag(GROUP_CALL_DEFERRED)) {
 				gr_nodes[i]->notification(p_notification);
 			} else {
 				MessageQueue::get_singleton()->push_notification(gr_nodes[i], p_notification);
@@ -373,7 +373,7 @@ void SceneTree::notify_group_flags(uint32_t p_call_flags, const StringName &p_gr
 	}
 }
 
-void SceneTree::set_group_flags(uint32_t p_call_flags, const StringName &p_group, const String &p_name, const Variant &p_value) {
+void SceneTree::set_group_flags(BitField<GroupCallFlags> p_call_flags, const StringName &p_group, const String &p_name, const Variant &p_value) {
 	Vector<Node *> nodes_copy;
 	{
 		_THREAD_SAFE_METHOD_
@@ -399,13 +399,13 @@ void SceneTree::set_group_flags(uint32_t p_call_flags, const StringName &p_group
 		nodes_removed_on_group_call_lock++;
 	}
 
-	if (p_call_flags & GROUP_CALL_REVERSE) {
+	if (p_call_flags.has_flag(GROUP_CALL_REVERSE)) {
 		for (int i = gr_node_count - 1; i >= 0; i--) {
 			if (nodes_removed_on_group_call.has(gr_nodes[i])) {
 				continue;
 			}
 
-			if (!(p_call_flags & GROUP_CALL_DEFERRED)) {
+			if (!p_call_flags.has_flag(GROUP_CALL_DEFERRED)) {
 				gr_nodes[i]->set(p_name, p_value);
 			} else {
 				MessageQueue::get_singleton()->push_set(gr_nodes[i], p_name, p_value);
@@ -418,7 +418,7 @@ void SceneTree::set_group_flags(uint32_t p_call_flags, const StringName &p_group
 				continue;
 			}
 
-			if (!(p_call_flags & GROUP_CALL_DEFERRED)) {
+			if (!p_call_flags.has_flag(GROUP_CALL_DEFERRED)) {
 				gr_nodes[i]->set(p_name, p_value);
 			} else {
 				MessageQueue::get_singleton()->push_set(gr_nodes[i], p_name, p_value);
@@ -1596,7 +1596,7 @@ void SceneTree::_bind_methods() {
 
 	MethodInfo mi;
 	mi.name = "call_group_flags";
-	mi.arguments.push_back(PropertyInfo(Variant::INT, "flags"));
+	mi.arguments.push_back(PropertyInfo(Variant::INT, "flags", PROPERTY_HINT_FLAGS, "Default:0,Reverse:1,Deferred:2,Unique:4"));
 	mi.arguments.push_back(PropertyInfo(Variant::STRING_NAME, "group"));
 	mi.arguments.push_back(PropertyInfo(Variant::STRING_NAME, "method"));
 
@@ -1653,10 +1653,10 @@ void SceneTree::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("process_frame"));
 	ADD_SIGNAL(MethodInfo("physics_frame"));
 
-	BIND_ENUM_CONSTANT(GROUP_CALL_DEFAULT);
-	BIND_ENUM_CONSTANT(GROUP_CALL_REVERSE);
-	BIND_ENUM_CONSTANT(GROUP_CALL_DEFERRED);
-	BIND_ENUM_CONSTANT(GROUP_CALL_UNIQUE);
+	BIND_BITFIELD_FLAG(GROUP_CALL_DEFAULT);
+	BIND_BITFIELD_FLAG(GROUP_CALL_REVERSE);
+	BIND_BITFIELD_FLAG(GROUP_CALL_DEFERRED);
+	BIND_BITFIELD_FLAG(GROUP_CALL_UNIQUE);
 }
 
 SceneTree *SceneTree::singleton = nullptr;

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -279,9 +279,9 @@ public:
 
 	_FORCE_INLINE_ Window *get_root() const { return root; }
 
-	void call_group_flagsp(uint32_t p_call_flags, const StringName &p_group, const StringName &p_function, const Variant **p_args, int p_argcount);
-	void notify_group_flags(uint32_t p_call_flags, const StringName &p_group, int p_notification);
-	void set_group_flags(uint32_t p_call_flags, const StringName &p_group, const String &p_name, const Variant &p_value);
+	void call_group_flagsp(BitField<GroupCallFlags> p_call_flags, const StringName &p_group, const StringName &p_function, const Variant **p_args, int p_argcount);
+	void notify_group_flags(BitField<GroupCallFlags> p_call_flags, const StringName &p_group, int p_notification);
+	void set_group_flags(BitField<GroupCallFlags> p_call_flags, const StringName &p_group, const String &p_name, const Variant &p_value);
 
 	// `notify_group()` is immediate by default since Godot 4.0.
 	void notify_group(const StringName &p_group, int p_notification);
@@ -300,7 +300,7 @@ public:
 	}
 
 	template <typename... VarArgs>
-	void call_group_flags(uint32_t p_flags, const StringName &p_group, const StringName &p_function, VarArgs... p_args) {
+	void call_group_flags(BitField<GroupCallFlags> p_flags, const StringName &p_group, const StringName &p_function, VarArgs... p_args) {
 		Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
 		const Variant *argptrs[sizeof...(p_args) + 1];
 		for (uint32_t i = 0; i < sizeof...(p_args); i++) {
@@ -426,6 +426,6 @@ public:
 	~SceneTree();
 };
 
-VARIANT_ENUM_CAST(SceneTree::GroupCallFlags);
+VARIANT_BITFIELD_CAST(SceneTree::GroupCallFlags);
 
 #endif // SCENE_TREE_H


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
