### PR TITLE
EXPERIMENTAL/ FOR DISCUSSION separated autoload initialization from normal node initialization

### DIFF
--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -156,6 +156,12 @@ private:
 
 	} data;
 
+	enum class PropagateNodeType {
+		AUTOLOAD,
+		NORMAL_NODE,
+		EVERYONE
+	};
+
 	Ref<MultiplayerAPI> multiplayer;
 
 	void _print_tree_pretty(const String &prefix, const bool last);
@@ -170,8 +176,11 @@ private:
 
 	void _propagate_reverse_notification(int p_notification);
 	void _propagate_deferred_notification(int p_notification, bool p_reverse);
-	void _propagate_enter_tree();
-	void _propagate_ready();
+	Vector<Node *> _get_children_to_propagate(PropagateNodeType propagate_to) const;
+	void _do_enter_tree();
+	void _propagate_enter_tree(PropagateNodeType propagate_to);
+	void _do_ready();
+	void _propagate_ready(PropagateNodeType propagate_to);
 	void _propagate_exit_tree();
 	void _propagate_after_exit_tree();
 	void _propagate_process_owner(Node *p_owner, int p_pause_notification, int p_enabled_notification);


### PR DESCRIPTION
(continuation of https://github.com/godotengine/godot/pull/72248)

**THIS CHANGE IS EXPERIMENTAL AND PROVIDED FOR DISCUSSION FOR https://github.com/godotengine/godot/issues/71695**

Autoload singletons should be accessible from any normal node at any time. Right now singletons init as any other node and thus are not yet initialized during initialization of start scene.

Order is something like this

```
singleton1 _enter_tree
...
singletonN _enter_tree
mainSceneRootNode _enter_tree
   mainSceneChild1 _enter_tree
   ....
   mainSceneChildN _enter_tree
singleton1 _ready
...
singletonN _ready
   mainSceneChild1 _ready
   ....
   mainSceneChildN _ready
mainSceneRootNode _ready
```

As you can see during main scene _enter_tree phase singletons are not yet ready.

This change treats autoloaded singletons (and its descendant) as separate tree which becomes fully _ready before main scene tree.

Like this:

```
singleton1 _enter_tree
...
singletonN _enter_tree
singleton1 _ready
...
singletonN _ready
mainSceneRootNode _enter_tree
   mainSceneChild1 _enter_tree
   ....
   mainSceneChildN _enter_tree
   mainSceneChild1 _ready
   ....
   mainSceneChildN _ready
mainSceneRootNode _ready
```

From documentation https://docs.godotengine.org/en/latest/classes/class_node.html

>This means that when adding a node to the scene tree, the following order will be used for the callbacks: _enter_tree of the parent, _enter_tree of the children, _ready of the children and finally _ready of the parent (recursively for the entire scene tree).

Thus it is slightly(?) breaking change. And it doesn't take into account possible dependencies between autoload singletons (aka singletons can't use each other from _ready in any order).

Some things to discuss:
1. Do autoload nodes need to be registered as singletons in engine? 
2. Do autoload nodes need to be separated from normal nodes to be initialized before them. (thats what this change does)
3. Does each autoload node (and its children) be treated as **separate** tree? This makes sure, that each initialized autoload node can safely access all autoload nodes initialized earlier.


