### PR TITLE
Fix code editor moving lines without selected characters

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1314,6 +1314,10 @@ void CodeTextEditor::move_lines_up() {
 		if (text_editor->has_selection(c)) {
 			group_border.first = text_editor->get_selection_from_line(c);
 			group_border.second = text_editor->get_selection_to_line(c);
+			// Don't move a line with no selected characters
+			if (text_editor->get_selection_to_column(c) == 0) {
+				group_border.second--;
+			}
 		} else {
 			group_border.first = text_editor->get_caret_line(c);
 			group_border.second = text_editor->get_caret_line(c);
@@ -1325,6 +1329,9 @@ void CodeTextEditor::move_lines_up() {
 
 			int next_start_pos = text_editor->has_selection(c_next) ? text_editor->get_selection_from_line(c_next) : text_editor->get_caret_line(c_next);
 			int next_end_pos = text_editor->has_selection(c_next) ? text_editor->get_selection_to_line(c_next) : text_editor->get_caret_line(c_next);
+			if (text_editor->get_selection_to_column(c_next) == 0 && text_editor->has_selection(c_next)) {
+				next_end_pos--;
+			}
 
 			int current_start_pos = text_editor->has_selection(c_current) ? text_editor->get_selection_from_line(c_current) : text_editor->get_caret_line(c_current);
 
@@ -1414,6 +1421,10 @@ void CodeTextEditor::move_lines_down() {
 		if (text_editor->has_selection(c)) {
 			group_border.first = text_editor->get_selection_from_line(c);
 			group_border.second = text_editor->get_selection_to_line(c);
+			// Don't move a line with no selected characters
+			if (text_editor->get_selection_to_column(c) == 0) {
+				group_border.second--;
+			}
 		} else {
 			group_border.first = text_editor->get_caret_line(c);
 			group_border.second = text_editor->get_caret_line(c);
@@ -1425,6 +1436,9 @@ void CodeTextEditor::move_lines_down() {
 
 			int next_start_pos = text_editor->has_selection(c_next) ? text_editor->get_selection_from_line(c_next) : text_editor->get_caret_line(c_next);
 			int next_end_pos = text_editor->has_selection(c_next) ? text_editor->get_selection_to_line(c_next) : text_editor->get_caret_line(c_next);
+			if (text_editor->has_selection(c_next) && text_editor->get_selection_to_column(c_next) == 0) {
+				next_end_pos--;
+			}
 
 			int current_start_pos = text_editor->has_selection(c_current) ? text_editor->get_selection_from_line(c_current) : text_editor->get_caret_line(c_current);
 


### PR DESCRIPTION
Fixes #54362
Supersedes #54392

When the selection ends at the start of new line, move_lines_up/down shouldn't affect that line.

A question was raised in https://github.com/godotengine/godot/pull/54392#pullrequestreview-796888504, if line should be moved when the selection covers only carriage return of a line. As an answer @jmb462 noticed that there's a visual difference, which could warrant different behaviour. I opened an issue to fix peculiar and ambiguous selection visuals: #72265
This pr handles the problem in line with other code editors, so that only selections ending at new line will be affected.