### PR TITLE
GDScript: Avoid calling non-static methods on native classes

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -98,7 +98,7 @@ Variant GDScriptNativeClass::callp(const StringName &p_method, const Variant **p
 		return Object::callp(p_method, p_args, p_argcount, r_error);
 	}
 	MethodBind *method = ClassDB::get_method(name, p_method);
-	if (method) {
+	if (method && method->is_static()) {
 		// Native static method.
 		return method->call(nullptr, p_args, p_argcount, r_error);
 	}

--- a/modules/gdscript/tests/scripts/runtime/errors/non_static_method_call_on_native_class.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/non_static_method_call_on_native_class.gd
@@ -1,0 +1,6 @@
+# https://github.com/godotengine/godot/issues/66675
+func test():
+	example(Node2D)
+
+func example(thing):
+	print(thing.has_method('asdf'))

--- a/modules/gdscript/tests/scripts/runtime/errors/non_static_method_call_on_native_class.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/non_static_method_call_on_native_class.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: example()
+>> runtime/errors/non_static_method_call_on_native_class.gd
+>> 6
+>> Invalid call. Nonexistent function 'has_method' in base 'Node2D'.


### PR DESCRIPTION
Fix #66675
