### PR TITLE
Use `String.repeat()` to optimize several String methods

### DIFF
--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -34,13 +34,7 @@
 
 void FileAccessCompressed::configure(const String &p_magic, Compression::Mode p_mode, uint32_t p_block_size) {
 	magic = p_magic.ascii().get_data();
-	if (magic.length() > 4) {
-		magic = magic.substr(0, 4);
-	} else {
-		while (magic.length() < 4) {
-			magic += " ";
-		}
-	}
+	magic = (magic + "    ").substr(0, 4);
 
 	cmode = p_mode;
 	block_size = p_block_size;

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -47,13 +47,7 @@ const char *JSON::tk_name[TK_MAX] = {
 };
 
 String JSON::_make_indent(const String &p_indent, int p_size) {
-	String indent_text = "";
-	if (!p_indent.is_empty()) {
-		for (int i = 0; i < p_size; i++) {
-			indent_text += p_indent;
-		}
-	}
-	return indent_text;
+	return p_indent.repeat(p_size);
 }
 
 String JSON::_stringify(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, HashSet<const void *> &p_markers, bool p_full_precision) {

--- a/core/math/bvh_debug.inc
+++ b/core/math/bvh_debug.inc
@@ -30,11 +30,7 @@ String _debug_aabb_to_string(const BVHABB_CLASS &aabb) const {
 void _debug_recursive_print_tree_node(uint32_t p_node_id, int depth = 0) const {
 	const TNode &tnode = _nodes[p_node_id];
 
-	String sz = "";
-	for (int n = 0; n < depth; n++) {
-		sz += "\t";
-	}
-	sz += itos(p_node_id);
+	String sz = String("\t").repeat(depth) + itos(p_node_id);
 
 	if (tnode.is_leaf()) {
 		sz += " L";

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -909,18 +909,11 @@ String TranslationServer::wrap_with_fakebidi_characters(String &p_message) const
 }
 
 String TranslationServer::add_padding(const String &p_message, int p_length) const {
-	String res;
-	String prefix = pseudolocalization_prefix;
-	String suffix;
-	for (int i = 0; i < p_length * expansion_ratio / 2; i++) {
-		prefix += "_";
-		suffix += "_";
-	}
-	suffix += pseudolocalization_suffix;
-	res += prefix;
-	res += p_message;
-	res += suffix;
-	return res;
+	String underscores = String("_").repeat(p_length * expansion_ratio / 2);
+	String prefix = pseudolocalization_prefix + underscores;
+	String suffix = underscores + pseudolocalization_suffix;
+
+	return prefix + p_message + suffix;
 }
 
 const char32_t *TranslationServer::get_accented_version(char32_t p_character) const {

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3470,6 +3470,14 @@ String String::replacen(const String &p_key, const String &p_with) const {
 String String::repeat(int p_count) const {
 	ERR_FAIL_COND_V_MSG(p_count < 0, "", "Parameter count should be a positive number.");
 
+	if (p_count == 0) {
+		return "";
+	}
+
+	if (p_count == 1) {
+		return *this;
+	}
+
 	int len = length();
 	String new_string = *this;
 	new_string.resize(p_count * len + 1);
@@ -4107,13 +4115,11 @@ String String::pad_decimals(int p_digits) const {
 	}
 
 	if (s.length() - (c + 1) > p_digits) {
-		s = s.substr(0, c + p_digits + 1);
+		return s.substr(0, c + p_digits + 1);
 	} else {
-		while (s.length() - (c + 1) < p_digits) {
-			s += "0";
-		}
+		int zeros_to_add = p_digits - s.length() + (c + 1);
+		return s + String("0").repeat(zeros_to_add);
 	}
-	return s;
 }
 
 String String::pad_zeros(int p_digits) const {
@@ -4138,12 +4144,8 @@ String String::pad_zeros(int p_digits) const {
 		return s;
 	}
 
-	while (end - begin < p_digits) {
-		s = s.insert(begin, "0");
-		end++;
-	}
-
-	return s;
+	int zeros_to_add = p_digits - (end - begin);
+	return s.insert(begin, String("0").repeat(zeros_to_add));
 }
 
 String String::trim_prefix(const String &p_prefix) const {
@@ -4322,11 +4324,8 @@ String String::path_to(const String &p_path) const {
 
 	common_parent--;
 
-	String dir;
-
-	for (int i = src_dirs.size() - 1; i > common_parent; i--) {
-		dir += "../";
-	}
+	int dirs_to_backtrack = (src_dirs.size() - 1) - common_parent;
+	String dir = String("../").repeat(dirs_to_backtrack);
 
 	for (int i = common_parent + 1; i < dst_dirs.size(); i++) {
 		dir += dst_dirs[i] + "/";
@@ -4547,11 +4546,8 @@ String String::rpad(int min_length, const String &character) const {
 	String s = *this;
 	int padding = min_length - s.length();
 	if (padding > 0) {
-		for (int i = 0; i < padding; i++) {
-			s = s + character;
-		}
+		s += character.repeat(padding);
 	}
-
 	return s;
 }
 
@@ -4560,11 +4556,8 @@ String String::lpad(int min_length, const String &character) const {
 	String s = *this;
 	int padding = min_length - s.length();
 	if (padding > 0) {
-		for (int i = 0; i < padding; i++) {
-			s = character + s;
-		}
+		s = character.repeat(padding) + s;
 	}
-
 	return s;
 }
 

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1138,11 +1138,7 @@ void CodeTextEditor::insert_final_newline() {
 
 void CodeTextEditor::convert_indent_to_spaces() {
 	int indent_size = EDITOR_GET("text_editor/behavior/indent/size");
-	String indent = "";
-
-	for (int i = 0; i < indent_size; i++) {
-		indent += " ";
-	}
+	String indent = String(" ").repeat(indent_size);
 
 	Vector<int> cursor_columns;
 	cursor_columns.resize(text_editor->get_caret_count());

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -1353,10 +1353,7 @@ static void _write_string(Ref<FileAccess> f, int p_tablevel, const String &p_str
 	if (p_string.is_empty()) {
 		return;
 	}
-	String tab;
-	for (int i = 0; i < p_tablevel; i++) {
-		tab += "\t";
-	}
+	String tab = String("\t").repeat(p_tablevel);
 	f->store_string(tab + p_string + "\n");
 }
 

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -894,9 +894,9 @@ ScriptLanguage::ScriptTemplate ScriptCreateDialog::_parse_template(const ScriptL
 				if (line.begins_with("space-indent")) {
 					String indent_value = line.substr(17, -1).strip_edges();
 					if (indent_value.is_valid_int()) {
-						space_indent = "";
-						for (int i = 0; i < indent_value.to_int(); i++) {
-							space_indent += " ";
+						int indent_size = indent_value.to_int();
+						if (indent_size >= 0) {
+							space_indent = String(" ").repeat(indent_size);
 						}
 					} else {
 						WARN_PRINT(vformat("Template meta-use_space_indent need to be a valid integer value. Found %s.", indent_value));

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3040,12 +3040,7 @@ String GDScriptLanguage::_get_indentation() const {
 
 		if (use_space_indentation) {
 			int indent_size = EDITOR_GET("text_editor/behavior/indent/size");
-
-			String space_indent = "";
-			for (int i = 0; i < indent_size; i++) {
-				space_indent += " ";
-			}
-			return space_indent;
+			return String(" ").repeat(indent_size);
 		}
 	}
 #endif
@@ -3092,12 +3087,7 @@ void GDScriptLanguage::auto_indent_code(String &p_code, int p_from_line, int p_t
 		}
 
 		if (i >= p_from_line) {
-			l = "";
-			for (int j = 0; j < indent_stack.size(); j++) {
-				l += indent;
-			}
-			l += st;
-
+			l = indent.repeat(indent_stack.size()) + st;
 		} else if (i > p_to_line) {
 			break;
 		}

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6839,9 +6839,9 @@ PackedByteArray GLTFDocument::_serialize_glb_buffer(Ref<GLTFState> p_state, Erro
 	const int32_t header_size = 12;
 	const int32_t chunk_header_size = 8;
 
-	for (int32_t pad_i = 0; pad_i < (chunk_header_size + json.utf8().length()) % 4; pad_i++) {
-		json += " ";
-	}
+	int32_t padding = (chunk_header_size + json.utf8().length()) % 4;
+	json += String(" ").repeat(padding);
+
 	CharString cs = json.utf8();
 	const uint32_t text_chunk_length = cs.length();
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -524,12 +524,7 @@ String CSharpLanguage::_get_indentation() const {
 
 		if (use_space_indentation) {
 			int indent_size = EDITOR_GET("text_editor/behavior/indent/size");
-
-			String space_indent = "";
-			for (int i = 0; i < indent_size; i++) {
-				space_indent += " ";
-			}
-			return space_indent;
+			return String(" ").repeat(indent_size);
 		}
 	}
 #endif

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -38,12 +38,7 @@
 #define SL ShaderLanguage
 
 static String _mktab(int p_level) {
-	String tb;
-	for (int i = 0; i < p_level; i++) {
-		tb += "\t";
-	}
-
-	return tb;
+	return String("\t").repeat(p_level);
 }
 
 static String _typestr(SL::DataType p_type) {


### PR DESCRIPTION
kleonc and I optimized `String.repeat()` in #64489, so I wondered if there there is any engine code that is using iterative addition instead of this method. Nice surprise though, I found that even some user-exposed String methods could be optimized this way, namely `pad_zeros()`, `pad_decimals()`, `rpad()`, and `lpad()`. The latter two are even used in `String::sprintf()` - I have no idea what sprintf does, but it looks important!

~~The optimization should always result in performance gain, though I haven't benchmarked it extensively.~~

Edit: It wasn't always a performance gain. It's just that the old `repeat()` was really slow, but the new one is still slower than a manual loop if it has 1 or 2 iterations. For a single iteration, the performance reduction was 15%, which I wasn't happy with, so I altered `String::repeat()` a bit to return the string directly if `p_count` is 1. This doesn't affect performance for other cases in any noticeable way.

Testing new vs. old `rpad()` after that:

Test | Performance boost/reduction
--- | ---
0 repeats | +20%
1 repeat | +8%
2 repeats | -3%
3 repeats | +12%
4 repeats | +30%
10 repeats | +150%
16 repeats | +420%

RegEx used: `for \(.*\) {\n((\t)*).* \+= .*;\n((\t)*)}` and lots of manual sifting. A few I found with slightly different regexes too.