### PR TITLE
Remove cap on number of items drawn in frame in 2D gl_compatibility renderer

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -113,16 +113,19 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 	// Clear out any state that may have been left from the 3D pass.
 	reset_canvas();
 
-	if (state.canvas_instance_data_buffers[state.current_buffer].fence != GLsync()) {
+	if (state.canvas_instance_data_buffers[state.current_data_buffer_index].fence != GLsync()) {
 		GLint syncStatus;
-		glGetSynciv(state.canvas_instance_data_buffers[state.current_buffer].fence, GL_SYNC_STATUS, sizeof(GLint), nullptr, &syncStatus);
+		glGetSynciv(state.canvas_instance_data_buffers[state.current_data_buffer_index].fence, GL_SYNC_STATUS, sizeof(GLint), nullptr, &syncStatus);
 		if (syncStatus == GL_UNSIGNALED) {
 			// If older than 2 frames, wait for sync OpenGL can have up to 3 frames in flight, any more and we need to sync anyway.
-			if (state.canvas_instance_data_buffers[state.current_buffer].last_frame_used < RSG::rasterizer->get_frame_number() - 2) {
+			if (state.canvas_instance_data_buffers[state.current_data_buffer_index].last_frame_used < RSG::rasterizer->get_frame_number() - 2) {
 #ifndef WEB_ENABLED
 				// On web, we do nothing as the glSubBufferData will force a sync anyway and WebGL does not like waiting.
-				glClientWaitSync(state.canvas_instance_data_buffers[state.current_buffer].fence, 0, 100000000); // wait for up to 100ms
+				glClientWaitSync(state.canvas_instance_data_buffers[state.current_data_buffer_index].fence, 0, 100000000); // wait for up to 100ms
 #endif
+				state.canvas_instance_data_buffers[state.current_data_buffer_index].last_frame_used = RSG::rasterizer->get_frame_number();
+				glDeleteSync(state.canvas_instance_data_buffers[state.current_data_buffer_index].fence);
+				state.canvas_instance_data_buffers[state.current_data_buffer_index].fence = GLsync();
 			} else {
 				// Used in last frame or frame before that. OpenGL can get up to two frames behind, so these buffers may still be in use
 				// Allocate a new buffer and use that.
@@ -130,9 +133,9 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 			}
 		} else {
 			// Already finished all rendering commands, we can use it.
-			state.canvas_instance_data_buffers[state.current_buffer].last_frame_used = RSG::rasterizer->get_frame_number();
-			glDeleteSync(state.canvas_instance_data_buffers[state.current_buffer].fence);
-			state.canvas_instance_data_buffers[state.current_buffer].fence = GLsync();
+			state.canvas_instance_data_buffers[state.current_data_buffer_index].last_frame_used = RSG::rasterizer->get_frame_number();
+			glDeleteSync(state.canvas_instance_data_buffers[state.current_data_buffer_index].fence);
+			state.canvas_instance_data_buffers[state.current_data_buffer_index].fence = GLsync();
 		}
 	}
 
@@ -279,7 +282,7 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 	}
 
 	if (light_count > 0) {
-		glBindBufferBase(GL_UNIFORM_BUFFER, LIGHT_UNIFORM_LOCATION, state.canvas_instance_data_buffers[state.current_buffer].light_ubo);
+		glBindBufferBase(GL_UNIFORM_BUFFER, LIGHT_UNIFORM_LOCATION, state.canvas_instance_data_buffers[state.current_data_buffer_index].light_ubo);
 
 #ifdef WEB_ENABLED
 		glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(LightUniform) * light_count, state.light_uniforms);
@@ -361,7 +364,7 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 
 		state_buffer.tex_to_sdf = 1.0 / ((canvas_scale.x + canvas_scale.y) * 0.5);
 
-		glBindBufferBase(GL_UNIFORM_BUFFER, BASE_UNIFORM_LOCATION, state.canvas_instance_data_buffers[state.current_buffer].state_ubo);
+		glBindBufferBase(GL_UNIFORM_BUFFER, BASE_UNIFORM_LOCATION, state.canvas_instance_data_buffers[state.current_data_buffer_index].state_ubo);
 		glBufferData(GL_UNIFORM_BUFFER, sizeof(StateBuffer), &state_buffer, GL_STREAM_DRAW);
 
 		GLuint global_buffer = material_storage->global_shader_parameters_get_uniform_buffer();
@@ -395,7 +398,7 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 	Item *ci = p_item_list;
 	Item *canvas_group_owner = nullptr;
 
-	uint32_t starting_index = 0;
+	state.last_item_index = 0;
 
 	while (ci) {
 		if (ci->copy_back_buffer && canvas_group_owner == nullptr) {
@@ -454,7 +457,7 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 					update_skeletons = false;
 				}
 				// Canvas group begins here, render until before this item
-				_render_items(p_to_render_target, item_count, canvas_transform_inverse, p_light_list, starting_index, r_sdf_used);
+				_render_items(p_to_render_target, item_count, canvas_transform_inverse, p_light_list, r_sdf_used);
 				item_count = 0;
 
 				if (ci->canvas_group_owner->canvas_group->mode != RS::CANVAS_GROUP_MODE_TRANSPARENT) {
@@ -485,7 +488,7 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 				mesh_storage->update_mesh_instances();
 				update_skeletons = false;
 			}
-			_render_items(p_to_render_target, item_count, canvas_transform_inverse, p_light_list, starting_index, r_sdf_used, true);
+			_render_items(p_to_render_target, item_count, canvas_transform_inverse, p_light_list, r_sdf_used, true);
 			item_count = 0;
 
 			if (ci->canvas_group->blur_mipmaps) {
@@ -504,7 +507,7 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 			}
 			//render anything pending, including clearing if no items
 
-			_render_items(p_to_render_target, item_count, canvas_transform_inverse, p_light_list, starting_index, r_sdf_used);
+			_render_items(p_to_render_target, item_count, canvas_transform_inverse, p_light_list, r_sdf_used);
 			item_count = 0;
 
 			texture_storage->render_target_copy_to_back_buffer(p_to_render_target, back_buffer_rect, backbuffer_gen_mipmaps);
@@ -530,7 +533,7 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 				mesh_storage->update_mesh_instances();
 				update_skeletons = false;
 			}
-			_render_items(p_to_render_target, item_count, canvas_transform_inverse, p_light_list, starting_index, r_sdf_used);
+			_render_items(p_to_render_target, item_count, canvas_transform_inverse, p_light_list, r_sdf_used);
 			//then reset
 			item_count = 0;
 		}
@@ -542,14 +545,15 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 		RenderingServerDefault::redraw_request();
 	}
 
-	state.canvas_instance_data_buffers[state.current_buffer].fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+	state.canvas_instance_data_buffers[state.current_data_buffer_index].fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
 
 	// Clear out state used in 2D pass
 	reset_canvas();
-	state.current_buffer = (state.current_buffer + 1) % state.canvas_instance_data_buffers.size();
+	state.current_data_buffer_index = (state.current_data_buffer_index + 1) % state.canvas_instance_data_buffers.size();
+	state.current_instance_buffer_index = 0;
 }
 
-void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_count, const Transform2D &p_canvas_transform_inverse, Light *p_lights, uint32_t &r_last_index, bool &r_sdf_used, bool p_to_backbuffer) {
+void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_count, const Transform2D &p_canvas_transform_inverse, Light *p_lights, bool &r_sdf_used, bool p_to_backbuffer) {
 	GLES3::MaterialStorage *material_storage = GLES3::MaterialStorage::get_singleton();
 
 	canvas_begin(p_to_render_target, p_to_backbuffer);
@@ -565,17 +569,17 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 	// Record Batches.
 	// First item always forms its own batch.
 	bool batch_broken = false;
-	_new_batch(batch_broken, index);
+	_new_batch(batch_broken);
 
 	// Override the start position and index as we want to start from where we finished off last time.
-	state.canvas_instance_batches[state.current_batch_index].start = r_last_index;
+	state.canvas_instance_batches[state.current_batch_index].start = state.last_item_index;
 	index = 0;
 
 	for (int i = 0; i < p_item_count; i++) {
 		Item *ci = items[i];
 
 		if (ci->final_clip_owner != state.canvas_instance_batches[state.current_batch_index].clip) {
-			_new_batch(batch_broken, index);
+			_new_batch(batch_broken);
 			state.canvas_instance_batches[state.current_batch_index].clip = ci->final_clip_owner;
 			current_clip = ci->final_clip_owner;
 		}
@@ -599,7 +603,7 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 
 		GLES3::CanvasShaderData *shader_data_cache = nullptr;
 		if (material != state.canvas_instance_batches[state.current_batch_index].material) {
-			_new_batch(batch_broken, index);
+			_new_batch(batch_broken);
 
 			GLES3::CanvasMaterialData *material_data = nullptr;
 			if (material.is_valid()) {
@@ -629,12 +633,12 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 	}
 
 	// Copy over all data needed for rendering.
-	glBindBuffer(GL_ARRAY_BUFFER, state.canvas_instance_data_buffers[state.current_buffer].buffer);
+	glBindBuffer(GL_ARRAY_BUFFER, state.canvas_instance_data_buffers[state.current_data_buffer_index].instance_buffers[state.current_instance_buffer_index]);
 #ifdef WEB_ENABLED
-	glBufferSubData(GL_ARRAY_BUFFER, r_last_index * sizeof(InstanceData), sizeof(InstanceData) * index, state.instance_data_array);
+	glBufferSubData(GL_ARRAY_BUFFER, state.last_item_index * sizeof(InstanceData), sizeof(InstanceData) * index, state.instance_data_array);
 #else
 	// On Desktop and mobile we map the memory without synchronizing for maximum speed.
-	void *buffer = glMapBufferRange(GL_ARRAY_BUFFER, r_last_index * sizeof(InstanceData), index * sizeof(InstanceData), GL_MAP_WRITE_BIT | GL_MAP_UNSYNCHRONIZED_BIT);
+	void *buffer = glMapBufferRange(GL_ARRAY_BUFFER, state.last_item_index * sizeof(InstanceData), index * sizeof(InstanceData), GL_MAP_WRITE_BIT | GL_MAP_UNSYNCHRONIZED_BIT);
 	memcpy(buffer, state.instance_data_array, index * sizeof(InstanceData));
 	glUnmapBuffer(GL_ARRAY_BUFFER);
 #endif
@@ -757,14 +761,14 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 
 	state.current_batch_index = 0;
 	state.canvas_instance_batches.clear();
-	r_last_index += index;
+	state.last_item_index += index;
 }
 
 void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_render_target, const Transform2D &p_canvas_transform_inverse, Item *&current_clip, GLES3::CanvasShaderData::BlendMode p_blend_mode, Light *p_lights, uint32_t &r_index, bool &r_batch_broken, bool &r_sdf_used) {
 	RenderingServer::CanvasItemTextureFilter texture_filter = p_item->texture_filter == RS::CANVAS_ITEM_TEXTURE_FILTER_DEFAULT ? state.default_filter : p_item->texture_filter;
 
 	if (texture_filter != state.canvas_instance_batches[state.current_batch_index].filter) {
-		_new_batch(r_batch_broken, r_index);
+		_new_batch(r_batch_broken);
 
 		state.canvas_instance_batches[state.current_batch_index].filter = texture_filter;
 	}
@@ -772,7 +776,7 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 	RenderingServer::CanvasItemTextureRepeat texture_repeat = p_item->texture_repeat == RS::CANVAS_ITEM_TEXTURE_REPEAT_DEFAULT ? state.default_repeat : p_item->texture_repeat;
 
 	if (texture_repeat != state.canvas_instance_batches[state.current_batch_index].repeat) {
-		_new_batch(r_batch_broken, r_index);
+		_new_batch(r_batch_broken);
 
 		state.canvas_instance_batches[state.current_batch_index].repeat = texture_repeat;
 	}
@@ -816,7 +820,7 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 	bool lights_disabled = light_count == 0 && !state.using_directional_lights;
 
 	if (lights_disabled != state.canvas_instance_batches[state.current_batch_index].lights_disabled) {
-		_new_batch(r_batch_broken, r_index);
+		_new_batch(r_batch_broken);
 		state.canvas_instance_batches[state.current_batch_index].lights_disabled = lights_disabled;
 	}
 
@@ -864,7 +868,7 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 		}
 
 		if (blend_mode != state.canvas_instance_batches[state.current_batch_index].blend_mode || blend_color != state.canvas_instance_batches[state.current_batch_index].blend_color) {
-			_new_batch(r_batch_broken, r_index);
+			_new_batch(r_batch_broken);
 			state.canvas_instance_batches[state.current_batch_index].blend_mode = blend_mode;
 			state.canvas_instance_batches[state.current_batch_index].blend_color = blend_color;
 		}
@@ -874,12 +878,12 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 				const Item::CommandRect *rect = static_cast<const Item::CommandRect *>(c);
 
 				if (rect->flags & CANVAS_RECT_TILE && state.canvas_instance_batches[state.current_batch_index].repeat != RenderingServer::CanvasItemTextureRepeat::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED) {
-					_new_batch(r_batch_broken, r_index);
+					_new_batch(r_batch_broken);
 					state.canvas_instance_batches[state.current_batch_index].repeat = RenderingServer::CanvasItemTextureRepeat::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED;
 				}
 
 				if (rect->texture != state.canvas_instance_batches[state.current_batch_index].tex || state.canvas_instance_batches[state.current_batch_index].command_type != Item::Command::TYPE_RECT) {
-					_new_batch(r_batch_broken, r_index);
+					_new_batch(r_batch_broken);
 					state.canvas_instance_batches[state.current_batch_index].tex = rect->texture;
 					state.canvas_instance_batches[state.current_batch_index].command_type = Item::Command::TYPE_RECT;
 					state.canvas_instance_batches[state.current_batch_index].command = c;
@@ -969,7 +973,7 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 				const Item::CommandNinePatch *np = static_cast<const Item::CommandNinePatch *>(c);
 
 				if (np->texture != state.canvas_instance_batches[state.current_batch_index].tex || state.canvas_instance_batches[state.current_batch_index].command_type != Item::Command::TYPE_NINEPATCH) {
-					_new_batch(r_batch_broken, r_index);
+					_new_batch(r_batch_broken);
 					state.canvas_instance_batches[state.current_batch_index].tex = np->texture;
 					state.canvas_instance_batches[state.current_batch_index].command_type = Item::Command::TYPE_NINEPATCH;
 					state.canvas_instance_batches[state.current_batch_index].command = c;
@@ -1034,7 +1038,7 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 				const Item::CommandPolygon *polygon = static_cast<const Item::CommandPolygon *>(c);
 
 				// Polygon's can't be batched, so always create a new batch
-				_new_batch(r_batch_broken, r_index);
+				_new_batch(r_batch_broken);
 
 				state.canvas_instance_batches[state.current_batch_index].tex = polygon->texture;
 				state.canvas_instance_batches[state.current_batch_index].command_type = Item::Command::TYPE_POLYGON;
@@ -1061,7 +1065,7 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 				const Item::CommandPrimitive *primitive = static_cast<const Item::CommandPrimitive *>(c);
 
 				if (primitive->point_count != state.canvas_instance_batches[state.current_batch_index].primitive_points || state.canvas_instance_batches[state.current_batch_index].command_type != Item::Command::TYPE_PRIMITIVE) {
-					_new_batch(r_batch_broken, r_index);
+					_new_batch(r_batch_broken);
 					state.canvas_instance_batches[state.current_batch_index].tex = primitive->texture;
 					state.canvas_instance_batches[state.current_batch_index].primitive_points = primitive->point_count;
 					state.canvas_instance_batches[state.current_batch_index].command_type = Item::Command::TYPE_PRIMITIVE;
@@ -1086,10 +1090,7 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 				if (primitive->point_count == 4) {
 					// Reset base data.
 					_update_transform_2d_to_mat2x3(base_transform * draw_transform, state.instance_data_array[r_index].world);
-					state.instance_data_array[r_index].color_texture_pixel_size[0] = 0.0;
-					state.instance_data_array[r_index].color_texture_pixel_size[1] = 0.0;
-
-					state.instance_data_array[r_index].flags = base_flags | (state.instance_data_array[r_index - 1].flags & (FLAGS_DEFAULT_NORMAL_MAP_USED | FLAGS_DEFAULT_SPECULAR_MAP_USED)); //reset on each command for sanity, keep canvastexture binding config
+					_prepare_canvas_texture(state.canvas_instance_batches[state.current_batch_index].tex, state.canvas_instance_batches[state.current_batch_index].filter, state.canvas_instance_batches[state.current_batch_index].repeat, r_index, texpixel_size);
 
 					for (uint32_t j = 0; j < 3; j++) {
 						int offset = j == 0 ? 0 : 1;
@@ -1111,7 +1112,7 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 			case Item::Command::TYPE_MULTIMESH:
 			case Item::Command::TYPE_PARTICLES: {
 				// Mesh's can't be batched, so always create a new batch
-				_new_batch(r_batch_broken, r_index);
+				_new_batch(r_batch_broken);
 
 				Color modulate(1, 1, 1, 1);
 				state.canvas_instance_batches[state.current_batch_index].shader_variant = CanvasShaderGLES3::MODE_ATTRIBUTES;
@@ -1183,7 +1184,7 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 				const Item::CommandClipIgnore *ci = static_cast<const Item::CommandClipIgnore *>(c);
 				if (current_clip) {
 					if (ci->ignore != reclip) {
-						_new_batch(r_batch_broken, r_index);
+						_new_batch(r_batch_broken);
 						if (ci->ignore) {
 							state.canvas_instance_batches[state.current_batch_index].clip = nullptr;
 							reclip = true;
@@ -1227,7 +1228,7 @@ void RasterizerCanvasGLES3::_render_batch(Light *p_lights, uint32_t p_index) {
 		case Item::Command::TYPE_RECT:
 		case Item::Command::TYPE_NINEPATCH: {
 			glBindVertexArray(data.indexed_quad_array);
-			glBindBuffer(GL_ARRAY_BUFFER, state.canvas_instance_data_buffers[state.current_buffer].buffer);
+			glBindBuffer(GL_ARRAY_BUFFER, state.canvas_instance_data_buffers[state.current_data_buffer_index].instance_buffers[state.canvas_instance_batches[p_index].instance_buffer_index]);
 			uint32_t range_start = state.canvas_instance_batches[p_index].start * sizeof(InstanceData);
 			_enable_attributes(range_start, false);
 
@@ -1243,7 +1244,7 @@ void RasterizerCanvasGLES3::_render_batch(Light *p_lights, uint32_t p_index) {
 			ERR_FAIL_COND(!pb);
 
 			glBindVertexArray(pb->vertex_array);
-			glBindBuffer(GL_ARRAY_BUFFER, state.canvas_instance_data_buffers[state.current_buffer].buffer);
+			glBindBuffer(GL_ARRAY_BUFFER, state.canvas_instance_data_buffers[state.current_data_buffer_index].instance_buffers[state.canvas_instance_batches[p_index].instance_buffer_index]);
 
 			uint32_t range_start = state.canvas_instance_batches[p_index].start * sizeof(InstanceData);
 			_enable_attributes(range_start, false);
@@ -1267,7 +1268,7 @@ void RasterizerCanvasGLES3::_render_batch(Light *p_lights, uint32_t p_index) {
 
 		case Item::Command::TYPE_PRIMITIVE: {
 			glBindVertexArray(data.canvas_quad_array);
-			glBindBuffer(GL_ARRAY_BUFFER, state.canvas_instance_data_buffers[state.current_buffer].buffer);
+			glBindBuffer(GL_ARRAY_BUFFER, state.canvas_instance_data_buffers[state.current_data_buffer_index].instance_buffers[state.canvas_instance_batches[p_index].instance_buffer_index]);
 			uint32_t range_start = state.canvas_instance_batches[p_index].start * sizeof(InstanceData);
 			_enable_attributes(range_start, true);
 
@@ -1370,7 +1371,7 @@ void RasterizerCanvasGLES3::_render_batch(Light *p_lights, uint32_t p_index) {
 				index_array_gl = mesh_storage->mesh_surface_get_index_buffer(surface, 0);
 				bool use_index_buffer = false;
 				glBindVertexArray(vertex_array_gl);
-				glBindBuffer(GL_ARRAY_BUFFER, state.canvas_instance_data_buffers[state.current_buffer].buffer);
+				glBindBuffer(GL_ARRAY_BUFFER, state.canvas_instance_data_buffers[state.current_data_buffer_index].instance_buffers[state.canvas_instance_batches[p_index].instance_buffer_index]);
 
 				uint32_t range_start = state.canvas_instance_batches[p_index].start * sizeof(InstanceData);
 				_enable_attributes(range_start, false, instance_count);
@@ -1427,20 +1428,30 @@ void RasterizerCanvasGLES3::_render_batch(Light *p_lights, uint32_t p_index) {
 }
 
 void RasterizerCanvasGLES3::_add_to_batch(uint32_t &r_index, bool &r_batch_broken) {
-	if (r_index >= data.max_instances_per_buffer - 1) {
-		ERR_PRINT_ONCE("Trying to draw too many items. Please increase maximum number of items in the project settings 'rendering/gl_compatibility/item_buffer_size'");
-		return;
-	}
-
-	if (state.canvas_instance_batches[state.current_batch_index].instance_count >= data.max_instances_per_batch) {
-		_new_batch(r_batch_broken, r_index);
-	}
-
 	state.canvas_instance_batches[state.current_batch_index].instance_count++;
 	r_index++;
+	if (r_index >= data.max_instances_per_buffer) {
+		// Copy over all data needed for rendering right away
+		// then go back to recording item commands.
+		glBindBuffer(GL_ARRAY_BUFFER, state.canvas_instance_data_buffers[state.current_data_buffer_index].instance_buffers[state.current_instance_buffer_index]);
+#ifdef WEB_ENABLED
+		glBufferSubData(GL_ARRAY_BUFFER, state.last_item_index * sizeof(InstanceData), sizeof(InstanceData) * r_index, state.instance_data_array);
+#else
+		// On Desktop and mobile we map the memory without synchronizing for maximum speed.
+		void *buffer = glMapBufferRange(GL_ARRAY_BUFFER, state.last_item_index * sizeof(InstanceData), r_index * sizeof(InstanceData), GL_MAP_WRITE_BIT | GL_MAP_UNSYNCHRONIZED_BIT);
+		memcpy(buffer, state.instance_data_array, r_index * sizeof(InstanceData));
+		glUnmapBuffer(GL_ARRAY_BUFFER);
+#endif
+		_allocate_instance_buffer();
+		r_index = 0;
+		state.last_item_index = 0;
+		r_batch_broken = false; // Force a new batch to be created
+		_new_batch(r_batch_broken);
+		state.canvas_instance_batches[state.current_batch_index].start = 0;
+	}
 }
 
-void RasterizerCanvasGLES3::_new_batch(bool &r_batch_broken, uint32_t &r_index) {
+void RasterizerCanvasGLES3::_new_batch(bool &r_batch_broken) {
 	if (state.canvas_instance_batches.size() == 0) {
 		state.canvas_instance_batches.push_back(Batch());
 		return;
@@ -1456,7 +1467,7 @@ void RasterizerCanvasGLES3::_new_batch(bool &r_batch_broken, uint32_t &r_index) 
 	Batch new_batch = state.canvas_instance_batches[state.current_batch_index];
 	new_batch.instance_count = 0;
 	new_batch.start = state.canvas_instance_batches[state.current_batch_index].start + state.canvas_instance_batches[state.current_batch_index].instance_count;
-
+	new_batch.instance_buffer_index = state.current_instance_buffer_index;
 	state.current_batch_index++;
 	state.canvas_instance_batches.push_back(new_batch);
 }
@@ -2433,16 +2444,34 @@ void RasterizerCanvasGLES3::_allocate_instance_data_buffer() {
 	glBindBuffer(GL_UNIFORM_BUFFER, new_buffers[2]);
 	glBufferData(GL_UNIFORM_BUFFER, sizeof(StateBuffer), nullptr, GL_STREAM_DRAW);
 
-	state.current_buffer = (state.current_buffer + 1);
+	state.current_data_buffer_index = (state.current_data_buffer_index + 1);
 	DataBuffer db;
-	db.buffer = new_buffers[0];
+	db.instance_buffers.push_back(new_buffers[0]);
 	db.light_ubo = new_buffers[1];
 	db.state_ubo = new_buffers[2];
 	db.last_frame_used = RSG::rasterizer->get_frame_number();
-	state.canvas_instance_data_buffers.insert(state.current_buffer, db);
-	state.current_buffer = state.current_buffer % state.canvas_instance_data_buffers.size();
+	state.canvas_instance_data_buffers.insert(state.current_data_buffer_index, db);
+	state.current_data_buffer_index = state.current_data_buffer_index % state.canvas_instance_data_buffers.size();
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 	glBindBuffer(GL_UNIFORM_BUFFER, 0);
+}
+void RasterizerCanvasGLES3::_allocate_instance_buffer() {
+	state.current_instance_buffer_index++;
+
+	if (int(state.current_instance_buffer_index) < state.canvas_instance_data_buffers[state.current_data_buffer_index].instance_buffers.size()) {
+		// We already allocated another buffer in a previous frame, so we can just use it.
+		return;
+	}
+
+	GLuint new_buffer;
+	glGenBuffers(1, &new_buffer);
+
+	glBindBuffer(GL_ARRAY_BUFFER, new_buffer);
+	glBufferData(GL_ARRAY_BUFFER, data.max_instance_buffer_size, nullptr, GL_STREAM_DRAW);
+
+	state.canvas_instance_data_buffers[state.current_data_buffer_index].instance_buffers.push_back(new_buffer);
+
+	glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void RasterizerCanvasGLES3::set_time(double p_time) {
@@ -2586,14 +2615,12 @@ RasterizerCanvasGLES3::RasterizerCanvasGLES3() {
 	int uniform_max_size = config->max_uniform_buffer_size;
 	if (uniform_max_size < 65536) {
 		data.max_lights_per_render = 64;
-		data.max_instances_per_batch = 128;
 	} else {
 		data.max_lights_per_render = 256;
-		data.max_instances_per_batch = 2048;
 	}
 
 	// Reserve 3 Uniform Buffers for instance data Frame N, N+1 and N+2
-	data.max_instances_per_buffer = MAX(data.max_instances_per_batch, uint32_t(GLOBAL_GET("rendering/gl_compatibility/item_buffer_size")));
+	data.max_instances_per_buffer = uint32_t(GLOBAL_GET("rendering/gl_compatibility/item_buffer_size"));
 	data.max_instance_buffer_size = data.max_instances_per_buffer * sizeof(InstanceData); // 16,384 instances * 128 bytes = 2,097,152 bytes = 2,048 kb
 	state.canvas_instance_data_buffers.resize(3);
 	state.canvas_instance_batches.reserve(200);
@@ -2611,7 +2638,7 @@ RasterizerCanvasGLES3::RasterizerCanvasGLES3() {
 		glBindBuffer(GL_UNIFORM_BUFFER, new_buffers[2]);
 		glBufferData(GL_UNIFORM_BUFFER, sizeof(StateBuffer), nullptr, GL_STREAM_DRAW);
 		DataBuffer db;
-		db.buffer = new_buffers[0];
+		db.instance_buffers.push_back(new_buffers[0]);
 		db.light_ubo = new_buffers[1];
 		db.state_ubo = new_buffers[2];
 		db.last_frame_used = 0;
@@ -2638,7 +2665,6 @@ RasterizerCanvasGLES3::RasterizerCanvasGLES3() {
 	String global_defines;
 	global_defines += "#define MAX_GLOBAL_SHADER_UNIFORMS 256\n"; // TODO: this is arbitrary for now
 	global_defines += "#define MAX_LIGHTS " + itos(data.max_lights_per_render) + "\n";
-	global_defines += "#define MAX_DRAW_DATA_INSTANCES " + itos(data.max_instances_per_batch) + "\n";
 
 	GLES3::MaterialStorage::get_singleton()->shaders.canvas_shader.initialize(global_defines, 1);
 	data.canvas_shader_default_version = GLES3::MaterialStorage::get_singleton()->shaders.canvas_shader.version_create();

--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -247,7 +247,6 @@ public:
 
 		uint32_t max_lights_per_render = 256;
 		uint32_t max_lights_per_item = 16;
-		uint32_t max_instances_per_batch = 512;
 		uint32_t max_instances_per_buffer = 16384;
 		uint32_t max_instance_buffer_size = 16384 * 128;
 	} data;
@@ -256,6 +255,7 @@ public:
 		// Position in the UBO measured in bytes
 		uint32_t start = 0;
 		uint32_t instance_count = 0;
+		uint32_t instance_buffer_index = 0;
 
 		RID tex;
 		RS::CanvasItemTextureFilter filter = RS::CANVAS_ITEM_TEXTURE_FILTER_MAX;
@@ -281,7 +281,7 @@ public:
 	// We track them and ensure that they don't get reused until at least 2 frames have passed
 	// to avoid the GPU stalling to wait for a resource to become available.
 	struct DataBuffer {
-		GLuint buffer = 0;
+		Vector<GLuint> instance_buffers;
 		GLuint light_ubo = 0;
 		GLuint state_ubo = 0;
 		uint64_t last_frame_used = -3;
@@ -291,9 +291,10 @@ public:
 	struct State {
 		LocalVector<DataBuffer> canvas_instance_data_buffers;
 		LocalVector<Batch> canvas_instance_batches;
-		uint32_t current_buffer = 0;
-		uint32_t current_buffer_index = 0;
+		uint32_t current_data_buffer_index = 0;
+		uint32_t current_instance_buffer_index = 0;
 		uint32_t current_batch_index = 0;
+		uint32_t last_item_index = 0;
 
 		InstanceData *instance_data_array = nullptr;
 
@@ -354,14 +355,14 @@ public:
 	void _prepare_canvas_texture(RID p_texture, RS::CanvasItemTextureFilter p_base_filter, RS::CanvasItemTextureRepeat p_base_repeat, uint32_t &r_index, Size2 &r_texpixel_size);
 
 	void canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used) override;
-	void _render_items(RID p_to_render_target, int p_item_count, const Transform2D &p_canvas_transform_inverse, Light *p_lights, uint32_t &r_last_index, bool &r_sdf_used, bool p_to_backbuffer = false);
+	void _render_items(RID p_to_render_target, int p_item_count, const Transform2D &p_canvas_transform_inverse, Light *p_lights, bool &r_sdf_used, bool p_to_backbuffer = false);
 	void _record_item_commands(const Item *p_item, RID p_render_target, const Transform2D &p_canvas_transform_inverse, Item *&current_clip, GLES3::CanvasShaderData::BlendMode p_blend_mode, Light *p_lights, uint32_t &r_index, bool &r_break_batch, bool &r_sdf_used);
 	void _render_batch(Light *p_lights, uint32_t p_index);
 	bool _bind_material(GLES3::CanvasMaterialData *p_material_data, CanvasShaderGLES3::ShaderVariant p_variant, uint64_t p_specialization);
-	void _new_batch(bool &r_batch_broken, uint32_t &r_index);
+	void _new_batch(bool &r_batch_broken);
 	void _add_to_batch(uint32_t &r_index, bool &r_batch_broken);
 	void _allocate_instance_data_buffer();
-	void _align_instance_data_buffer(uint32_t &r_index);
+	void _allocate_instance_buffer();
 	void _enable_attributes(uint32_t p_start, bool p_primitive, uint32_t p_rate = 1);
 
 	void set_time(double p_time);

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2875,7 +2875,7 @@ void RenderingServer::init() {
 	GLOBAL_DEF("rendering/2d/shadow_atlas/size", 2048);
 
 	// Number of commands that can be drawn per frame.
-	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/gl_compatibility/item_buffer_size", PROPERTY_HINT_RANGE, "1024,1048576,1"), 16384);
+	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/gl_compatibility/item_buffer_size", PROPERTY_HINT_RANGE, "128,1048576,1"), 16384);
 
 	GLOBAL_DEF("rendering/shader_compiler/shader_cache/enabled", true);
 	GLOBAL_DEF("rendering/shader_compiler/shader_cache/compress", true);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/72181

Previously a [similar issue](https://github.com/godotengine/godot/issues/67942) came up for tilesets of size 703x703. In that case I fixed the issue by reducing the number of batches needed which in turn reduced the amount of space taken in the instance buffer. 

This time, it looks like the issue is a combination of the size of the tileset (contains 2500 tiles) and the logic used to draw the tileset editor (each tile needs multiple lines drawn and multiple rects). 

The old behaviour was to limit the number of items that could be drawn in a frame to the amount defined by ``rendering/gl_compatibility/item_buffer_size`` which defaults to ``16384``. If you go beyond that amount you get an error and nothing else will draw. The limit came from the fact that each frame was only given a single large buffer to upload all the per-instance data. Once that buffer was full it stopped accepting new instances. This was nice and simple, but https://github.com/godotengine/godot/issues/72181 and https://github.com/godotengine/godot/issues/67942 show that users will eventually bump up against any limit we place even if reasonable. So a better solution is to remove the limit entirely. 

This PR allows each frame data object to allocate more instance buffers if it needs to. It will take more memory, but never free it. So we only pay the cost of allocation in the frame where we exceed the per-buffer limit. 

I have left the per-buffer limit as configurable as smaller allocations may be preferable on certain devices especially when memory is constrained. 

The second change in this PR is removing the limit on number of items per batch. That should have been removed in https://github.com/godotengine/godot/pull/70065 as there is no corresponding OpenGL limit anymore. This removal may result in a small performance benefit for large batches. In the [linked issue](https://github.com/godotengine/godot/issues/72181) this change saved about 100us.
