### PR TITLE
Don't overflow the stack when freeing deeply nested nodes

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -164,10 +164,20 @@ void Node::_notification(int p_notification) {
 				data.parent->remove_child(this);
 			}
 
-			// kill children as cleanly as possible
-			while (data.children.size()) {
-				Node *child = data.children[data.children.size() - 1]; //begin from the end because its faster and more consistent with creation
-				memdelete(child);
+			Vector<Node *> to_delete;
+			to_delete.push_back(this);
+
+			while (!to_delete.is_empty()) {
+				Node *n = to_delete[to_delete.size() - 1];
+				// begin from the end because its faster and more consistent with creation
+				if (n->data.children.size()) {
+					to_delete.push_back(n->data.children[n->data.children.size() - 1]);
+				} else {
+					to_delete.resize(to_delete.size() - 1);
+					if (this != n) {
+						memdelete(n);
+					}
+				}
 			}
 		} break;
 	}

--- a/tests/scene/test_node.h
+++ b/tests/scene/test_node.h
@@ -415,6 +415,16 @@ TEST_CASE("[SceneTree][Node] Testing node operations with a more complex simple 
 		memdelete(duplicate1);
 	}
 
+	SUBCASE("Deleting deeply nested nodes should not overflow the stack") {
+		Node *top = memnew(Node);
+		for (int i = 0; i < 100000; i++) {
+			Node *tmp = memnew(Node);
+			tmp->add_child(top);
+			top = tmp;
+		}
+		memdelete(top);
+	}
+
 	memdelete(node1_1);
 	memdelete(node1);
 	memdelete(node2);


### PR DESCRIPTION
Although realistically speaking, I don't know if there's any real-world use case that would need a tree 100,000 nodes deep.

Fixes #72235