### PR TITLE
Allow unicode identifier in GDScript syntax highlighter

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -307,7 +307,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 			in_number = true;
 		}
 
-		if (!in_word && (is_ascii_char(str[j]) || is_underscore(str[j])) && !in_number) {
+		if (!in_word && is_unicode_identifier_start(str[j]) && !in_number) {
 			in_word = true;
 		}
 


### PR DESCRIPTION
The detection of the beginning of an identifier needs to be updated.

| Before | After |
|---|---|
| ![before](https://user-images.githubusercontent.com/372476/215306785-41247965-8663-4265-b1f6-57f0d31a1d32.png) | ![after](https://user-images.githubusercontent.com/372476/215306787-23865262-3f5c-4716-95c2-de0803719c6c.png) |

<details><summary>Code used in the screenshot</summary>

```gdscript
extends Node2D

enum Enum { VALUE_A, VALUE_B }
enum 枚举 { 值_甲, 值_乙 }

var variable: Enum = Enum.VALUE_A
var 变量: 枚举 = 枚举.值_甲

func function():
	pass

func another_function():
	function()

func 函数():
	pass

func 另一个_函数():
	函数()
```

</details>
