### PR TITLE
Improve stroke drawing on 2D collision shapes

### DIFF
--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -131,15 +131,7 @@ void CollisionPolygon2D::_notification(int p_what) {
 				break;
 			}
 
-			int polygon_count = polygon.size();
-			for (int i = 0; i < polygon_count; i++) {
-				Vector2 p = polygon[i];
-				Vector2 n = polygon[(i + 1) % polygon_count];
-				// draw line with width <= 1, so it does not scale with zoom and break pixel exact editing
-				draw_line(p, n, Color(0.9, 0.2, 0.0, 0.8), 1);
-			}
-
-			if (polygon_count > 2) {
+			if (polygon.size() > 2) {
 #define DEBUG_DECOMPOSE
 #if defined(TOOLS_ENABLED) && defined(DEBUG_DECOMPOSE)
 				Vector<Vector<Vector2>> decomp = _decompose_in_convex();
@@ -152,6 +144,11 @@ void CollisionPolygon2D::_notification(int p_what) {
 #else
 				draw_colored_polygon(polygon, get_tree()->get_debug_collisions_color());
 #endif
+
+				const Color stroke_color = Color(0.9, 0.2, 0.0);
+				draw_polyline(polygon, stroke_color);
+				// Draw the last segment.
+				draw_line(polygon[polygon.size() - 1], polygon[0], stroke_color);
 			}
 
 			if (one_way_collision) {

--- a/scene/resources/capsule_shape_2d.cpp
+++ b/scene/resources/capsule_shape_2d.cpp
@@ -88,8 +88,10 @@ void CapsuleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Vector2> points = _get_points();
 	Vector<Color> col = { p_color };
 	RenderingServer::get_singleton()->canvas_item_add_polygon(p_to_rid, points, col);
+
 	if (is_collision_outline_enabled()) {
 		points.push_back(points[0]);
+		col = { Color(p_color, 1.0) };
 		RenderingServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col);
 	}
 }

--- a/scene/resources/circle_shape_2d.cpp
+++ b/scene/resources/circle_shape_2d.cpp
@@ -84,6 +84,7 @@ void CircleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 
 	if (is_collision_outline_enabled()) {
 		points.push_back(points[0]);
+		col = { Color(p_color, 1.0) };
 		RenderingServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col);
 	}
 }

--- a/scene/resources/convex_polygon_shape_2d.cpp
+++ b/scene/resources/convex_polygon_shape_2d.cpp
@@ -76,13 +76,14 @@ void ConvexPolygonShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 		return;
 	}
 
-	Vector<Color> col;
-	col.push_back(p_color);
+	Vector<Color> col = { p_color };
 	RenderingServer::get_singleton()->canvas_item_add_polygon(p_to_rid, points, col);
+
 	if (is_collision_outline_enabled()) {
+		col = { Color(p_color, 1.0) };
 		RenderingServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col);
-		// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
-		RenderingServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color, 1.0);
+		// Draw the last segment.
+		RenderingServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], Color(p_color, 1.0));
 	}
 }
 

--- a/scene/resources/rectangle_shape_2d.cpp
+++ b/scene/resources/rectangle_shape_2d.cpp
@@ -79,11 +79,7 @@ void RectangleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 		stroke_points.write[3] = Vector2(-size.x, size.y) * 0.5;
 		stroke_points.write[4] = -size * 0.5;
 
-		Vector<Color> stroke_colors;
-		stroke_colors.resize(5);
-		for (int i = 0; i < 5; i++) {
-			stroke_colors.write[i] = (p_color);
-		}
+		Vector<Color> stroke_colors = { Color(p_color, 1.0) };
 
 		RenderingServer::get_singleton()->canvas_item_add_polyline(p_to_rid, stroke_points, stroke_colors);
 	}

--- a/scene/resources/world_boundary_shape_2d.cpp
+++ b/scene/resources/world_boundary_shape_2d.cpp
@@ -76,11 +76,12 @@ real_t WorldBoundaryShape2D::get_distance() const {
 
 void WorldBoundaryShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector2 point = get_distance() * get_normal();
+	real_t line_width = 3.0;
 
 	Vector2 l1[2] = { point - get_normal().orthogonal() * 100, point + get_normal().orthogonal() * 100 };
-	RS::get_singleton()->canvas_item_add_line(p_to_rid, l1[0], l1[1], p_color, 3);
-	Vector2 l2[2] = { point, point + get_normal() * 30 };
-	RS::get_singleton()->canvas_item_add_line(p_to_rid, l2[0], l2[1], p_color, 3);
+	RS::get_singleton()->canvas_item_add_line(p_to_rid, l1[0], l1[1], p_color, line_width);
+	Vector2 l2[2] = { point + get_normal().normalized() * (0.5 * line_width), point + get_normal() * 30 };
+	RS::get_singleton()->canvas_item_add_line(p_to_rid, l2[0], l2[1], p_color, line_width);
 }
 
 Rect2 WorldBoundaryShape2D::get_rect() const {


### PR DESCRIPTION
* Thin lines when scaling `CollisionPolygon2D`.
* Draw a `CollisionPolygon2D` stroke on top of the polygon instead of below it.
* Improve the strokes of `RectangleShape2D`, `CircleShape2D`, `CapsuleShape2D` and `ConvexPolygonShape2D`. Since we can't control the exact position of the thin lines when scaling (and a line of the same color will be drawn next to the shape, not on top of it), I changed the stroke's alpha channel to 1.

Before:
![](https://user-images.githubusercontent.com/47700418/215319397-4f1b3736-dcba-4bde-9825-69221975e454.png)

After:
![](https://user-images.githubusercontent.com/47700418/215319434-f2a2f6ad-5a36-4697-b1f8-2ee98e9f4835.png)