### PR TITLE
[MacOS] Fix so that the main window is displayed before the splash screen minimum display time starts counting

### DIFF
--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3920,6 +3920,7 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 		}
 	}
 	show_window(MAIN_WINDOW_ID);
+	force_process_and_drop_events();
 
 #if defined(GLES3_ENABLED)
 	if (rendering_driver == "opengl3") {


### PR DESCRIPTION
This fixes issue #68798 where the "Minimum Display Time" setting doesn't work on MacOS. In my testing on MacOS the window isn't displayed until the `DisplayServer->process_events()` method is called. This doesn't happen until the main loop has begun and that occurs after the "Minimum Display Time" has passed. Presumably the act of creating a window is itself an event that has to be processed?

The fix I found was to call the `DisplayServer->force_process_and_drop_events()` method after the `show_window()` method is called for the main window. It's also possible to fix by calling `DisplayServer->process_events()`, but since we aren't processing input yet it seems that `force_process_and_drop_events` is suitable since it ignores input events. Perhaps someone who has more experience with the codebase knows if `process_events()` would be better or if I should place the call elsewhere?

With this change the window is displayed with the background color for the amount of time specified and then the logo is shown for a split second before the game is shown. This makes the behaviour the same as on Windows, the logo not being displayed until the end of the display time is reported in issue #71350 and likely not related to this since it isn't MacOS specific.

*Bugsquad edit:*
- Fixes #68798