### PR TITLE
[Noise/NoiseTexture2D] Allow disabling normalization

### DIFF
--- a/modules/noise/doc_classes/Noise.xml
+++ b/modules/noise/doc_classes/Noise.xml
@@ -17,8 +17,10 @@
 			<param index="1" name="height" type="int" />
 			<param index="2" name="invert" type="bool" default="false" />
 			<param index="3" name="in_3d_space" type="bool" default="false" />
+			<param index="4" name="normalize" type="bool" default="true" />
 			<description>
 				Returns a 2D [Image] noise image.
+				Note: With [param normalize] set to [code]false[/code] the default implementation expects the noise generator to return values in the range [code]-1.0[/code] to [code]1.0[/code].
 			</description>
 		</method>
 		<method name="get_noise_1d" qualifiers="const">
@@ -66,8 +68,10 @@
 			<param index="2" name="invert" type="bool" default="false" />
 			<param index="3" name="in_3d_space" type="bool" default="false" />
 			<param index="4" name="skirt" type="float" default="0.1" />
+			<param index="5" name="normalize" type="bool" default="true" />
 			<description>
 				Returns a seamless 2D [Image] noise image.
+				Note: With [param normalize] set to [code]false[/code] the default implementation expects the noise generator to return values in the range [code]-1.0[/code] to [code]1.0[/code].
 			</description>
 		</method>
 	</methods>

--- a/modules/noise/doc_classes/NoiseTexture2D.xml
+++ b/modules/noise/doc_classes/NoiseTexture2D.xml
@@ -44,6 +44,10 @@
 		<member name="noise" type="Noise" setter="set_noise" getter="get_noise">
 			The instance of the [Noise] object.
 		</member>
+		<member name="normalize" type="bool" setter="set_normalize" getter="is_normalized" default="true">
+			If [code]true[/code], the noise image coming from the noise generator is normalized to the range [code]0.0[/code] to [code]1.0[/code].
+			Turning normalization off can affect the contrast and allows you to generate non repeating tileable noise textures.
+		</member>
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
 		<member name="seamless" type="bool" setter="set_seamless" getter="get_seamless" default="false">
 			If [code]true[/code], a seamless texture is requested from the [Noise] resource.

--- a/modules/noise/noise.h
+++ b/modules/noise/noise.h
@@ -233,8 +233,8 @@ public:
 	virtual real_t get_noise_3dv(Vector3 p_v) const = 0;
 	virtual real_t get_noise_3d(real_t p_x, real_t p_y, real_t p_z) const = 0;
 
-	virtual Ref<Image> get_image(int p_width, int p_height, bool p_invert = false, bool p_in_3d_space = false) const;
-	virtual Ref<Image> get_seamless_image(int p_width, int p_height, bool p_invert = false, bool p_in_3d_space = false, real_t p_blend_skirt = 0.1) const;
+	virtual Ref<Image> get_image(int p_width, int p_height, bool p_invert = false, bool p_in_3d_space = false, bool p_normalize = true) const;
+	virtual Ref<Image> get_seamless_image(int p_width, int p_height, bool p_invert = false, bool p_in_3d_space = false, real_t p_blend_skirt = 0.1, bool p_normalize = true) const;
 };
 
 #endif // NOISE_H

--- a/modules/noise/noise_texture_2d.cpp
+++ b/modules/noise/noise_texture_2d.cpp
@@ -76,6 +76,9 @@ void NoiseTexture2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_bump_strength", "bump_strength"), &NoiseTexture2D::set_bump_strength);
 	ClassDB::bind_method(D_METHOD("get_bump_strength"), &NoiseTexture2D::get_bump_strength);
 
+	ClassDB::bind_method(D_METHOD("set_normalize", "normalize"), &NoiseTexture2D::set_normalize);
+	ClassDB::bind_method(D_METHOD("is_normalized"), &NoiseTexture2D::is_normalized);
+
 	ClassDB::bind_method(D_METHOD("set_color_ramp", "gradient"), &NoiseTexture2D::set_color_ramp);
 	ClassDB::bind_method(D_METHOD("get_color_ramp"), &NoiseTexture2D::get_color_ramp);
 
@@ -91,6 +94,7 @@ void NoiseTexture2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "seamless_blend_skirt", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_seamless_blend_skirt", "get_seamless_blend_skirt");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "as_normal_map"), "set_as_normal_map", "is_normal_map");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bump_strength", PROPERTY_HINT_RANGE, "0,32,0.1,or_greater"), "set_bump_strength", "get_bump_strength");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "normalize"), "set_normalize", "is_normalized");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "color_ramp", PROPERTY_HINT_RESOURCE_TYPE, "Gradient"), "set_color_ramp", "get_color_ramp");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "noise", PROPERTY_HINT_RESOURCE_TYPE, "Noise"), "set_noise", "get_noise");
 }
@@ -156,9 +160,9 @@ Ref<Image> NoiseTexture2D::_generate_texture() {
 	Ref<Image> new_image;
 
 	if (seamless) {
-		new_image = ref_noise->get_seamless_image(size.x, size.y, invert, in_3d_space, seamless_blend_skirt);
+		new_image = ref_noise->get_seamless_image(size.x, size.y, invert, in_3d_space, seamless_blend_skirt, normalize);
 	} else {
-		new_image = ref_noise->get_image(size.x, size.y, invert, in_3d_space);
+		new_image = ref_noise->get_image(size.x, size.y, invert, in_3d_space, normalize);
 	}
 	if (color_ramp.is_valid()) {
 		new_image = _modulate_with_gradient(new_image, color_ramp);
@@ -347,6 +351,18 @@ void NoiseTexture2D::set_color_ramp(const Ref<Gradient> &p_gradient) {
 		color_ramp->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NoiseTexture2D::_queue_update));
 	}
 	_queue_update();
+}
+
+void NoiseTexture2D::set_normalize(bool p_normalize) {
+	if (normalize == p_normalize) {
+		return;
+	}
+	normalize = p_normalize;
+	_queue_update();
+}
+
+bool NoiseTexture2D::is_normalized() const {
+	return normalize;
 }
 
 Ref<Gradient> NoiseTexture2D::get_color_ramp() const {

--- a/modules/noise/noise_texture_2d.h
+++ b/modules/noise/noise_texture_2d.h
@@ -59,6 +59,7 @@ private:
 	real_t seamless_blend_skirt = 0.1;
 	bool as_normal_map = false;
 	float bump_strength = 8.0;
+	bool normalize = true;
 
 	Ref<Gradient> color_ramp;
 	Ref<Noise> noise;
@@ -104,6 +105,9 @@ public:
 
 	void set_bump_strength(float p_bump_strength);
 	float get_bump_strength();
+
+	void set_normalize(bool p_normalize);
+	bool is_normalized() const;
 
 	void set_color_ramp(const Ref<Gradient> &p_gradient);
 	Ref<Gradient> get_color_ramp() const;


### PR DESCRIPTION
Closes #72267.

Detailed changes:
- Add a `normalize` property to `NoiseTexture2D`
- Add a `normalize` parameter to `get_image(...)`/`get_seamless_image(...)` of `Noise`

Normalization is enabled by default. 
Only breaks compatibility on a module/gdextension level.

![image](https://user-images.githubusercontent.com/50084500/215332622-ed4f2ef1-5ae6-4b1d-af0b-567a5e2e8412.png)