### PR TITLE
Cleanup  `AnimationNode` and `AnimationNodeTransition` APIs

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -115,13 +115,20 @@
 				Blend another animation node (in case this node contains children animation nodes). This function is only useful if you inherit from [AnimationRootNode] instead, else editors will not display your node for addition.
 			</description>
 		</method>
+		<method name="find_input" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="name" type="String" />
+			<description>
+				Returns the input index which corresponds to [param name]. If not found, returns [code]-1[/code].
+			</description>
+		</method>
 		<method name="get_input_count" qualifiers="const">
 			<return type="int" />
 			<description>
 				Amount of inputs in this node, only useful for nodes that go into [AnimationNodeBlendTree].
 			</description>
 		</method>
-		<method name="get_input_name">
+		<method name="get_input_name" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="input" type="int" />
 			<description>
@@ -155,6 +162,14 @@
 			<param index="1" name="enable" type="bool" />
 			<description>
 				Adds or removes a path for the filter.
+			</description>
+		</method>
+		<method name="set_input_name">
+			<return type="void" />
+			<param index="0" name="input" type="int" />
+			<param index="1" name="name" type="String" />
+			<description>
+				Sets the name of the input at the given [param input] index.
 			</description>
 		</method>
 		<method name="set_parameter">

--- a/doc/classes/AnimationNodeTransition.xml
+++ b/doc/classes/AnimationNodeTransition.xml
@@ -12,20 +12,6 @@
 		<link title="Third Person Shooter Demo">https://godotengine.org/asset-library/asset/678</link>
 	</tutorials>
 	<methods>
-		<method name="find_input_caption" qualifiers="const">
-			<return type="int" />
-			<param index="0" name="caption" type="String" />
-			<description>
-				Returns the input index which corresponds to [param caption]. If not found, returns [code]-1[/code].
-			</description>
-		</method>
-		<method name="get_input_caption" qualifiers="const">
-			<return type="String" />
-			<param index="0" name="input" type="int" />
-			<description>
-				Returns the name of the input at the given [param input] index. This name is displayed in the editor next to the node input.
-			</description>
-		</method>
 		<method name="is_input_set_as_auto_advance" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="input" type="int" />
@@ -39,14 +25,6 @@
 			<param index="1" name="enable" type="bool" />
 			<description>
 				Enables or disables auto-advance for the given [param input] index. If enabled, state changes to the next input after playing the animation once. If enabled for the last input state, it loops to the first.
-			</description>
-		</method>
-		<method name="set_input_caption">
-			<return type="void" />
-			<param index="0" name="input" type="int" />
-			<param index="1" name="caption" type="String" />
-			<description>
-				Sets the name of the input at the given [param input] index. This name is displayed in the editor next to the node input.
 			</description>
 		</method>
 	</methods>

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -714,28 +714,6 @@ bool AnimationNodeTransition::is_input_set_as_auto_advance(int p_input) const {
 	return inputs[p_input].auto_advance;
 }
 
-void AnimationNodeTransition::set_input_caption(int p_input, const String &p_name) {
-	ERR_FAIL_INDEX(p_input, MAX_INPUTS);
-	inputs[p_input].name = p_name;
-	set_input_name(p_input, p_name);
-}
-
-String AnimationNodeTransition::get_input_caption(int p_input) const {
-	ERR_FAIL_INDEX_V(p_input, MAX_INPUTS, String());
-	return inputs[p_input].name;
-}
-
-int AnimationNodeTransition::find_input_caption(const String &p_name) const {
-	int idx = -1;
-	for (int i = 0; i < MAX_INPUTS; i++) {
-		if (inputs[i].name == p_name) {
-			idx = i;
-			break;
-		}
-	}
-	return idx;
-}
-
 void AnimationNodeTransition::set_xfade_time(double p_fade) {
 	xfade_time = p_fade;
 }
@@ -772,7 +750,7 @@ double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_is_ex
 	bool restart = false;
 
 	if (!cur_transition_request.is_empty()) {
-		int new_idx = find_input_caption(cur_transition_request);
+		int new_idx = find_input(cur_transition_request);
 		if (new_idx >= 0) {
 			if (cur_current_index == new_idx) {
 				// Transition to same state.
@@ -832,7 +810,7 @@ double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_is_ex
 		}
 
 		if (inputs[cur_current_index].auto_advance && rem <= xfade_time) {
-			set_parameter(transition_request, get_input_caption((cur_current_index + 1) % enabled_inputs));
+			set_parameter(transition_request, get_input_name((cur_current_index + 1) % enabled_inputs));
 		}
 
 	} else { // cross-fading from prev to current
@@ -888,10 +866,6 @@ void AnimationNodeTransition::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_input_as_auto_advance", "input", "enable"), &AnimationNodeTransition::set_input_as_auto_advance);
 	ClassDB::bind_method(D_METHOD("is_input_set_as_auto_advance", "input"), &AnimationNodeTransition::is_input_set_as_auto_advance);
 
-	ClassDB::bind_method(D_METHOD("set_input_caption", "input", "caption"), &AnimationNodeTransition::set_input_caption);
-	ClassDB::bind_method(D_METHOD("get_input_caption", "input"), &AnimationNodeTransition::get_input_caption);
-	ClassDB::bind_method(D_METHOD("find_input_caption", "caption"), &AnimationNodeTransition::find_input_caption);
-
 	ClassDB::bind_method(D_METHOD("set_xfade_time", "time"), &AnimationNodeTransition::set_xfade_time);
 	ClassDB::bind_method(D_METHOD("get_xfade_time"), &AnimationNodeTransition::get_xfade_time);
 
@@ -907,7 +881,7 @@ void AnimationNodeTransition::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "reset"), "set_reset", "is_reset");
 
 	for (int i = 0; i < MAX_INPUTS; i++) {
-		ADD_PROPERTYI(PropertyInfo(Variant::STRING, "input_" + itos(i) + "/name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_input_caption", "get_input_caption", i);
+		ADD_PROPERTYI(PropertyInfo(Variant::STRING, "input_" + itos(i) + "/name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_input_name", "get_input_name", i);
 		ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "input_" + itos(i) + "/auto_advance", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_input_as_auto_advance", "is_input_set_as_auto_advance", i);
 	}
 }

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -320,10 +320,6 @@ public:
 	void set_input_as_auto_advance(int p_input, bool p_enable);
 	bool is_input_set_as_auto_advance(int p_input) const;
 
-	void set_input_caption(int p_input, const String &p_name);
-	String get_input_caption(int p_input) const;
-	int find_input_caption(const String &p_name) const;
-
 	void set_xfade_time(double p_fade);
 	double get_xfade_time() const;
 

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -303,15 +303,6 @@ double AnimationNode::_blend_node(const StringName &p_subpath, const Vector<Stri
 	return p_node->_pre_process(new_path, new_parent, state, p_time, p_seek, p_is_external_seeking, p_connections);
 }
 
-int AnimationNode::get_input_count() const {
-	return inputs.size();
-}
-
-String AnimationNode::get_input_name(int p_input) {
-	ERR_FAIL_INDEX_V(p_input, inputs.size(), String());
-	return inputs[p_input].name;
-}
-
 String AnimationNode::get_caption() const {
 	String ret = "Node";
 	GDVIRTUAL_CALL(_get_caption, ret);
@@ -328,6 +319,27 @@ void AnimationNode::add_input(const String &p_name) {
 	emit_changed();
 }
 
+void AnimationNode::remove_input(int p_index) {
+	ERR_FAIL_INDEX(p_index, inputs.size());
+	inputs.remove_at(p_index);
+	emit_changed();
+}
+
+int AnimationNode::get_input_count() const {
+	return inputs.size();
+}
+
+int AnimationNode::find_input(const String &p_name) const {
+	int idx = -1;
+	for (int i = 0; i < inputs.size(); i++) {
+		if (inputs[i].name == p_name) {
+			idx = i;
+			break;
+		}
+	}
+	return idx;
+}
+
 void AnimationNode::set_input_name(int p_input, const String &p_name) {
 	ERR_FAIL_INDEX(p_input, inputs.size());
 	ERR_FAIL_COND(p_name.contains(".") || p_name.contains("/"));
@@ -335,10 +347,9 @@ void AnimationNode::set_input_name(int p_input, const String &p_name) {
 	emit_changed();
 }
 
-void AnimationNode::remove_input(int p_index) {
-	ERR_FAIL_INDEX(p_index, inputs.size());
-	inputs.remove_at(p_index);
-	emit_changed();
+String AnimationNode::get_input_name(int p_input) const {
+	ERR_FAIL_INDEX_V(p_input, inputs.size(), String());
+	return inputs[p_input].name;
 }
 
 double AnimationNode::process(double p_time, bool p_seek, bool p_is_external_seeking) {
@@ -404,11 +415,12 @@ Ref<AnimationNode> AnimationNode::get_child_by_name(const StringName &p_name) {
 }
 
 void AnimationNode::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_input_count"), &AnimationNode::get_input_count);
-	ClassDB::bind_method(D_METHOD("get_input_name", "input"), &AnimationNode::get_input_name);
-
 	ClassDB::bind_method(D_METHOD("add_input", "name"), &AnimationNode::add_input);
 	ClassDB::bind_method(D_METHOD("remove_input", "index"), &AnimationNode::remove_input);
+	ClassDB::bind_method(D_METHOD("get_input_count"), &AnimationNode::get_input_count);
+	ClassDB::bind_method(D_METHOD("find_input", "name"), &AnimationNode::find_input);
+	ClassDB::bind_method(D_METHOD("set_input_name", "input", "name"), &AnimationNode::set_input_name);
+	ClassDB::bind_method(D_METHOD("get_input_name", "input"), &AnimationNode::get_input_name);
 
 	ClassDB::bind_method(D_METHOD("set_filter_path", "path", "enable"), &AnimationNode::set_filter_path);
 	ClassDB::bind_method(D_METHOD("is_path_filtered", "path"), &AnimationNode::is_path_filtered);

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -141,12 +141,12 @@ public:
 	virtual double process(double p_time, bool p_seek, bool p_is_external_seeking);
 	virtual String get_caption() const;
 
-	int get_input_count() const;
-	String get_input_name(int p_input);
-
 	void add_input(const String &p_name);
-	void set_input_name(int p_input, const String &p_name);
 	void remove_input(int p_index);
+	int get_input_count() const;
+	int find_input(const String &p_name) const;
+	void set_input_name(int p_input, const String &p_name);
+	String get_input_name(int p_input) const;
 
 	void set_filter_path(const NodePath &p_path, bool p_enable);
 	bool is_path_filtered(const NodePath &p_path) const;


### PR DESCRIPTION
- Remove redundant (duplicated) APIs from `AnimationNodeTransition`
- Move `find_input()` to `NodeAnimation` from `AnimationNodeTransition`
- Sort lines
