### PR TITLE
Added component-wise `min` and `max` functions for vectors

### DIFF
--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -76,6 +76,14 @@ struct _NO_DISCARD_ Vector3 {
 		return x < y ? (y < z ? Vector3::AXIS_Z : Vector3::AXIS_Y) : (x < z ? Vector3::AXIS_Z : Vector3::AXIS_X);
 	}
 
+	Vector3 min(const Vector3 &p_vector3) const {
+		return Vector3(MIN(x, p_vector3.x), MIN(y, p_vector3.y), MIN(z, p_vector3.z));
+	}
+
+	Vector3 max(const Vector3 &p_vector3) const {
+		return Vector3(MAX(x, p_vector3.x), MAX(y, p_vector3.y), MAX(z, p_vector3.z));
+	}
+
 	_FORCE_INLINE_ real_t length() const;
 	_FORCE_INLINE_ real_t length_squared() const;
 

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -69,6 +69,14 @@ struct _NO_DISCARD_ Vector3i {
 	Vector3i::Axis min_axis_index() const;
 	Vector3i::Axis max_axis_index() const;
 
+	Vector3i min(const Vector3i &p_vector3i) const {
+		return Vector3i(MIN(x, p_vector3i.x), MIN(y, p_vector3i.y), MIN(z, p_vector3i.z));
+	}
+
+	Vector3i max(const Vector3i &p_vector3i) const {
+		return Vector3i(MAX(x, p_vector3i.x), MAX(y, p_vector3i.y), MAX(z, p_vector3i.z));
+	}
+
 	_FORCE_INLINE_ int64_t length_squared() const;
 	_FORCE_INLINE_ double length() const;
 

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -68,6 +68,14 @@ struct _NO_DISCARD_ Vector4 {
 	Vector4::Axis min_axis_index() const;
 	Vector4::Axis max_axis_index() const;
 
+	Vector4 min(const Vector4 &p_vector4) const {
+		return Vector4(MIN(x, p_vector4.x), MIN(y, p_vector4.y), MIN(z, p_vector4.z), MIN(w, p_vector4.w));
+	}
+
+	Vector4 max(const Vector4 &p_vector4) const {
+		return Vector4(MAX(x, p_vector4.x), MAX(y, p_vector4.y), MAX(z, p_vector4.z), MAX(w, p_vector4.w));
+	}
+
 	_FORCE_INLINE_ real_t length_squared() const;
 	bool is_equal_approx(const Vector4 &p_vec4) const;
 	bool is_zero_approx() const;

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -71,6 +71,14 @@ struct _NO_DISCARD_ Vector4i {
 	Vector4i::Axis min_axis_index() const;
 	Vector4i::Axis max_axis_index() const;
 
+	Vector4i min(const Vector4i &p_vector4i) const {
+		return Vector4i(MIN(x, p_vector4i.x), MIN(y, p_vector4i.y), MIN(z, p_vector4i.z), MIN(w, p_vector4i.w));
+	}
+
+	Vector4i max(const Vector4i &p_vector4i) const {
+		return Vector4i(MAX(x, p_vector4i.x), MAX(y, p_vector4i.y), MAX(z, p_vector4i.z), MAX(w, p_vector4i.w));
+	}
+
 	_FORCE_INLINE_ int64_t length_squared() const;
 	_FORCE_INLINE_ double length() const;
 

--- a/tests/core/math/test_vector3.h
+++ b/tests/core/math/test_vector3.h
@@ -354,6 +354,14 @@ TEST_CASE("[Vector3] Other methods") {
 	CHECK_MESSAGE(
 			vector.snapped(Vector3(0.25, 0.25, 0.25)) == Vector3(1.25, 3.5, 5.5),
 			"Vector3 snapped to 0.25 should give exact results.");
+
+	CHECK_MESSAGE(
+			Vector3(1.2, 2.5, 2.0).is_equal_approx(vector.min(Vector3(3.0, 2.5, 2.0))),
+			"Vector3 min should return expected value.");
+
+	CHECK_MESSAGE(
+			Vector3(5.3, 3.4, 5.6).is_equal_approx(vector.max(Vector3(5.3, 2.0, 3.0))),
+			"Vector3 max should return expected value.");
 }
 
 TEST_CASE("[Vector3] Plane methods") {

--- a/tests/core/math/test_vector3i.h
+++ b/tests/core/math/test_vector3i.h
@@ -131,6 +131,13 @@ TEST_CASE("[Vector3i] Other methods") {
 	const Vector3i vector = Vector3i(1, 3, -7);
 
 	CHECK_MESSAGE(
+			vector.min(Vector3i(3, 2, 5)) == Vector3i(1, 2, -7),
+			"Vector3i min should return expected value.");
+	CHECK_MESSAGE(
+			vector.max(Vector3i(5, 2, 4)) == Vector3i(5, 3, 4),
+			"Vector3i max should return expected value.");
+
+	CHECK_MESSAGE(
 			vector.snapped(Vector3i(4, 2, 5)) == Vector3i(0, 4, -5),
 			"Vector3i snapped should work as expected.");
 }

--- a/tests/core/math/test_vector4.h
+++ b/tests/core/math/test_vector4.h
@@ -255,6 +255,14 @@ TEST_CASE("[Vector4] Other methods") {
 	CHECK_MESSAGE(
 			vector.snapped(Vector4(0.25, 0.25, 0.25, 0.25)) == Vector4(1.25, 3.5, 5.5, 1.5),
 			"Vector4 snapped to 0.25 should give exact results.");
+
+	CHECK_MESSAGE(
+			Vector4(1.2, 2.5, 2.0, 1.6).is_equal_approx(vector.min(Vector4(3.0, 2.5, 2.0, 3.4))),
+			"Vector4 min should return expected value.");
+
+	CHECK_MESSAGE(
+			Vector4(5.3, 3.4, 5.6, 4.2).is_equal_approx(vector.max(Vector4(5.3, 2.0, 3.0, 4.2))),
+			"Vector4 max should return expected value.");
 }
 
 TEST_CASE("[Vector4] Rounding methods") {

--- a/tests/core/math/test_vector4i.h
+++ b/tests/core/math/test_vector4i.h
@@ -134,6 +134,14 @@ TEST_CASE("[Vector3i] Other methods") {
 	const Vector4i vector = Vector4i(1, 3, -7, 13);
 
 	CHECK_MESSAGE(
+			vector.min(Vector4i(3, 2, 5, 8)) == Vector4i(1, 2, -7, 8),
+			"Vector4i min should return expected value.");
+
+	CHECK_MESSAGE(
+			vector.max(Vector4i(5, 2, 4, 8)) == Vector4i(5, 3, 4, 13),
+			"Vector4i max should return expected value.");
+
+	CHECK_MESSAGE(
 			vector.snapped(Vector4i(4, 2, 5, 8)) == Vector4i(0, 4, -5, 16),
 			"Vector4i snapped should work as expected.");
 }


### PR DESCRIPTION
Implements changes needed to solve this issue: https://github.com/godotengine/godot/issues/45320

EDIT:
This PR doesn't solve the issue mentioned above. This PR only implements the min/max functions for the vector classes in the cpp side, but doesn't change the way min/max works in GDScript. That change may come with another PR at a later time.