### PR TITLE
Remove the max input limit & cleanup `AnimationNodeTransition` API

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -68,10 +68,10 @@
 			</description>
 		</method>
 		<method name="add_input">
-			<return type="void" />
+			<return type="bool" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Adds an input to the node. This is only useful for nodes created for use in an [AnimationNodeBlendTree].
+				Adds an input to the node. This is only useful for nodes created for use in an [AnimationNodeBlendTree]. If the addition fails, returns [code]false[/code].
 			</description>
 		</method>
 		<method name="blend_animation">
@@ -115,13 +115,20 @@
 				Blend another animation node (in case this node contains children animation nodes). This function is only useful if you inherit from [AnimationRootNode] instead, else editors will not display your node for addition.
 			</description>
 		</method>
+		<method name="find_input" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="name" type="String" />
+			<description>
+				Returns the input index which corresponds to [param name]. If not found, returns [code]-1[/code].
+			</description>
+		</method>
 		<method name="get_input_count" qualifiers="const">
 			<return type="int" />
 			<description>
 				Amount of inputs in this node, only useful for nodes that go into [AnimationNodeBlendTree].
 			</description>
 		</method>
-		<method name="get_input_name">
+		<method name="get_input_name" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="input" type="int" />
 			<description>
@@ -155,6 +162,14 @@
 			<param index="1" name="enable" type="bool" />
 			<description>
 				Adds or removes a path for the filter.
+			</description>
+		</method>
+		<method name="set_input_name">
+			<return type="bool" />
+			<param index="0" name="input" type="int" />
+			<param index="1" name="name" type="String" />
+			<description>
+				Sets the name of the input at the given [param input] index. If the setting fails, returns [code]false[/code].
 			</description>
 		</method>
 		<method name="set_parameter">

--- a/doc/classes/AnimationNodeTransition.xml
+++ b/doc/classes/AnimationNodeTransition.xml
@@ -12,20 +12,6 @@
 		<link title="Third Person Shooter Demo">https://godotengine.org/asset-library/asset/678</link>
 	</tutorials>
 	<methods>
-		<method name="find_input_caption" qualifiers="const">
-			<return type="int" />
-			<param index="0" name="caption" type="String" />
-			<description>
-				Returns the input index which corresponds to [param caption]. If not found, returns [code]-1[/code].
-			</description>
-		</method>
-		<method name="get_input_caption" qualifiers="const">
-			<return type="String" />
-			<param index="0" name="input" type="int" />
-			<description>
-				Returns the name of the input at the given [param input] index. This name is displayed in the editor next to the node input.
-			</description>
-		</method>
 		<method name="is_input_set_as_auto_advance" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="input" type="int" />
@@ -41,18 +27,10 @@
 				Enables or disables auto-advance for the given [param input] index. If enabled, state changes to the next input after playing the animation once. If enabled for the last input state, it loops to the first.
 			</description>
 		</method>
-		<method name="set_input_caption">
-			<return type="void" />
-			<param index="0" name="input" type="int" />
-			<param index="1" name="caption" type="String" />
-			<description>
-				Sets the name of the input at the given [param input] index. This name is displayed in the editor next to the node input.
-			</description>
-		</method>
 	</methods>
 	<members>
-		<member name="enabled_inputs" type="int" setter="set_enabled_inputs" getter="get_enabled_inputs" default="0">
-			The number of enabled input ports for this node. The maximum is [code]31[/code].
+		<member name="input_count" type="int" setter="set_input_count" getter="get_input_count" default="0">
+			The number of enabled input ports for this node.
 		</member>
 		<member name="reset" type="bool" setter="set_reset" getter="is_reset" default="true">
 			If [code]true[/code], the destination animation is played back from the beginning when switched.

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -276,16 +276,7 @@ public:
 class AnimationNodeTransition : public AnimationNodeSync {
 	GDCLASS(AnimationNodeTransition, AnimationNodeSync);
 
-	enum {
-		MAX_INPUTS = 32
-	};
-	struct InputData {
-		String name;
-		bool auto_advance = false;
-	};
-
-	InputData inputs[MAX_INPUTS];
-	int enabled_inputs = 0;
+	Vector<bool> input_as_auto_advance;
 
 	StringName time = "time";
 	StringName prev_xfading = "prev_xfading";
@@ -301,11 +292,11 @@ class AnimationNodeTransition : public AnimationNodeSync {
 	Ref<Curve> xfade_curve;
 	bool reset = true;
 
-	void _update_inputs();
-
 protected:
+	bool _get(const StringName &p_path, Variant &r_ret) const;
+	bool _set(const StringName &p_path, const Variant &p_value);
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &p_property) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
 
 public:
 	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
@@ -314,15 +305,13 @@ public:
 
 	virtual String get_caption() const override;
 
-	void set_enabled_inputs(int p_inputs);
-	int get_enabled_inputs();
+	void set_input_count(int p_inputs);
+
+	virtual bool add_input(const String &p_name) override;
+	virtual void remove_input(int p_index) override;
 
 	void set_input_as_auto_advance(int p_input, bool p_enable);
 	bool is_input_set_as_auto_advance(int p_input) const;
-
-	void set_input_caption(int p_input, const String &p_name);
-	String get_input_caption(int p_input) const;
-	int find_input_caption(const String &p_name) const;
 
 	void set_xfade_time(double p_fade);
 	double get_xfade_time() const;

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -141,12 +141,12 @@ public:
 	virtual double process(double p_time, bool p_seek, bool p_is_external_seeking);
 	virtual String get_caption() const;
 
+	virtual bool add_input(const String &p_name);
+	virtual void remove_input(int p_index);
+	virtual bool set_input_name(int p_input, const String &p_name);
+	virtual String get_input_name(int p_input) const;
 	int get_input_count() const;
-	String get_input_name(int p_input);
-
-	void add_input(const String &p_name);
-	void set_input_name(int p_input, const String &p_name);
-	void remove_input(int p_index);
+	int find_input(const String &p_name) const;
 
 	void set_filter_path(const NodePath &p_path, bool p_enable);
 	bool is_path_filtered(const NodePath &p_path) const;


### PR DESCRIPTION
Fixes #60307. Supersedes #72314.

- Remove redundant (duplicated) APIs from `AnimationNodeTransition`
- Move `find_input()` to `NodeAnimation` from `AnimationNodeTransition`
- Make the `input_count` property an array and remove the maximum limit (no worry, previous tres can be loaded)

![image](https://user-images.githubusercontent.com/61938263/215346218-017ac558-e16c-42de-95f2-1f96d21da982.png)