### PR TITLE
Project Setting properties can be set in generated GDScript Template Header

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -1,4 +1,3 @@
-/**************************************************************************/
 /*  project_settings.cpp                                                  */
 /**************************************************************************/
 /*                         This file is part of:                          */
@@ -1064,6 +1063,12 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("application/config/name", "");
 	GLOBAL_DEF("application/config/description", "");
 	custom_prop_info["application/config/description"] = PropertyInfo(Variant::STRING, "application/config/description", PROPERTY_HINT_MULTILINE_TEXT);
+	
+	GLOBAL_DEF("application/config/user", "");
+	GLOBAL_DEF("application/config/company_name", "");
+	GLOBAL_DEF("application/config/project_name", "");
+	GLOBAL_DEF("application/config/version", "");
+	
 	GLOBAL_DEF("application/run/main_scene", "");
 	custom_prop_info["application/run/main_scene"] = PropertyInfo(Variant::STRING, "application/run/main_scene", PROPERTY_HINT_FILE, "*.tscn,*.scn,*.res");
 	GLOBAL_DEF("application/run/disable_stdout", false);

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -479,13 +479,13 @@ public:
 	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value);
 	virtual void add_named_global_constant(const StringName &p_name, const Variant &p_value);
 	virtual void remove_named_global_constant(const StringName &p_name);
-	
-	virtual String _get_current_system_date() const;
-	virtual String _get_current_app_user() const;
-	virtual String _get_current_user_company() const;
-	virtual String _get_current_project_name() const;
-	virtual String _get_current_project_version() const;
-
+#ifdef TOOLS_ENABLED	
+	virtual String get_current_system_date() const;
+	virtual String get_current_app_user() const;
+	virtual String get_current_user_company() const;
+	virtual String get_current_project_name() const;
+	virtual String get_current_project_version() const;
+#endif
 	/* DEBUGGER FUNCTIONS */
 
 	virtual String debug_get_error() const;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -479,6 +479,12 @@ public:
 	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value);
 	virtual void add_named_global_constant(const StringName &p_name, const Variant &p_value);
 	virtual void remove_named_global_constant(const StringName &p_name);
+	
+	virtual String _get_current_system_date() const;
+	virtual String _get_current_app_user() const;
+	virtual String _get_current_user_company() const;
+	virtual String _get_current_project_name() const;
+	virtual String _get_current_project_version() const;
 
 	/* DEBUGGER FUNCTIONS */
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -74,13 +74,13 @@ String GDScriptLanguage::_get_processed_template(const String &p_template, const
 
 	processed_template = processed_template.replace("%BASE%", p_base_class_name);
 	processed_template = processed_template.replace("%TS%", _get_indentation());
-
-	processed_template = processed_template.replace("%DATE%", _get_current_system_date());
-	processed_template = processed_template.replace("%USER%", _get_current_app_user());
-	processed_template = processed_template.replace("%COMPANY%", _get_current_user_company());
-	processed_template = processed_template.replace("%PROJECT%", _get_current_project_name());
-	processed_template = processed_template.replace("%VERSION%", _get_current_project_version());
-
+#ifdef TOOLS_ENABLED
+	processed_template = processed_template.replace("%DATE%", get_current_system_date());
+	processed_template = processed_template.replace("%USER%", get_current_app_user());
+	processed_template = processed_template.replace("%COMPANY%", get_current_user_company());
+	processed_template = processed_template.replace("%PROJECT%", get_current_project_name());
+	processed_template = processed_template.replace("%VERSION%", get_current_project_version());
+#endif
 	return processed_template;
 }
 
@@ -3067,7 +3067,7 @@ String GDScriptLanguage::_get_indentation() const {
 }
 
 #ifdef TOOLS_ENABLED
-String GDScriptLanguage::_get_current_system_date() const {
+String GDScriptLanguage::get_current_system_date() const {
 	time_t currTime = time(NULL);
 	struct tm buf;
 	char dateString[100];
@@ -3077,19 +3077,19 @@ String GDScriptLanguage::_get_current_system_date() const {
 	return dateString;
 }
 
-String GDScriptLanguage::_get_current_app_user() const {
+String GDScriptLanguage::get_current_app_user() const {
 	return (String)ProjectSettings::get_singleton()->get("application/config/user");
 }
 
-String GDScriptLanguage::_get_current_user_company() const {
+String GDScriptLanguage::get_current_user_company() const {
 	return (String)ProjectSettings::get_singleton()->get("application/config/company_name");
 }
 
-String GDScriptLanguage::_get_current_project_name() const {
+String GDScriptLanguage::get_current_project_name() const {
 	return (String)ProjectSettings::get_singleton()->get("application/config/project_name");
 }
 
-String GDScriptLanguage::_get_current_project_version() const {
+String GDScriptLanguage::get_current_project_version() const {
 	return (String)ProjectSettings::get_singleton()->get("application/config/version");
 }
 #endif

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -75,6 +75,12 @@ String GDScriptLanguage::_get_processed_template(const String &p_template, const
 	processed_template = processed_template.replace("%BASE%", p_base_class_name);
 	processed_template = processed_template.replace("%TS%", _get_indentation());
 
+	processed_template = processed_template.replace("%DATE%", _get_current_system_date());
+	processed_template = processed_template.replace("%USER%", _get_current_app_user());
+	processed_template = processed_template.replace("%COMPANY%", _get_current_user_company());
+	processed_template = processed_template.replace("%PROJECT%", _get_current_project_name());
+	processed_template = processed_template.replace("%VERSION%", _get_current_project_version());
+
 	return processed_template;
 }
 
@@ -3059,6 +3065,34 @@ String GDScriptLanguage::_get_indentation() const {
 #endif
 	return "\t";
 }
+
+#ifdef TOOLS_ENABLED
+String GDScriptLanguage::_get_current_system_date() const {
+	time_t currTime = time(NULL);
+	struct tm buf;
+	char dateString[100];
+	time(&currTime);
+	localtime_s(&buf, &currTime);
+	strftime(dateString, 100, "%d/%m/%Y", &buf);
+	return dateString;
+}
+
+String GDScriptLanguage::_get_current_app_user() const {
+	return (String)ProjectSettings::get_singleton()->get("application/config/user");
+}
+
+String GDScriptLanguage::_get_current_user_company() const {
+	return (String)ProjectSettings::get_singleton()->get("application/config/company_name");
+}
+
+String GDScriptLanguage::_get_current_project_name() const {
+	return (String)ProjectSettings::get_singleton()->get("application/config/project_name");
+}
+
+String GDScriptLanguage::_get_current_project_version() const {
+	return (String)ProjectSettings::get_singleton()->get("application/config/version");
+}
+#endif
 
 void GDScriptLanguage::auto_indent_code(String &p_code, int p_from_line, int p_to_line) const {
 	String indent = _get_indentation();


### PR DESCRIPTION
Created 4 new project setting properties.
![image](https://user-images.githubusercontent.com/7473994/215346812-fc820a87-c984-4a1f-b0ab-c40634585e36.png)


While generating new scripts from custom template these fields will be auto populated in the header.

@date		%DATE%
@author	%USER%
@company	%COMPANY%
@project	%PROJECT%
@company  %VERSION%

![image](https://user-images.githubusercontent.com/7473994/215347974-dfcf30ed-6f27-4cf5-be70-7bed7a38cff7.png)

**used template:**
```
""" 
#
# @date		%DATE%
# @author	%USER%
# @company	%COMPANY%
# @project	%PROJECT%
# @version  %VERSION%
#
"""

extends %BASE%


func _ready()%VOID_RETURN%:
%TS%pass

```
