### PR TITLE
fix fog color inversion if density is set 0

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1079,8 +1079,8 @@ void main() {
 #endif // !DISABLE_FOG
 #endif // !CUSTOM_FOG_USED
 
-	uint fog_rg = packHalf2x16(fog.rg);
-	uint fog_ba = packHalf2x16(fog.ba);
+	uint fog_rg = packUnorm2x16(fog.rg);
+	uint fog_ba = packUnorm2x16(fog.ba);
 
 	// Convert colors to linear
 	albedo = srgb_to_linear(albedo);
@@ -1294,7 +1294,7 @@ void main() {
 	frag_color.rgb += emission + ambient_light;
 #endif
 #endif //MODE_UNSHADED
-	fog = vec4(unpackHalf2x16(fog_rg), unpackHalf2x16(fog_ba));
+	fog = vec4(unpackUnorm2x16(fog_rg), unpackUnorm2x16(fog_ba));
 
 #ifndef DISABLE_FOG
 	if (scene_data.fog_enabled) {


### PR DESCRIPTION
This PR fixes [#66462](https://github.com/godotengine/godot/issues/66462) and fixes [#66459](https://github.com/godotengine/godot/issues/66459). 

## Non-zero density
<img width="1427" alt="image" src="https://user-images.githubusercontent.com/95585633/215349728-577abfe0-c2f1-4901-8c8e-bbd0712b5e61.png">

## Zero density
<img width="1430" alt="image" src="https://user-images.githubusercontent.com/95585633/215349746-715fabb3-f38b-406a-aaba-ce51e72ccd27.png">

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
