### PR TITLE
C#: Make editor respect runtime configuration of projects

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
@@ -18,6 +18,16 @@ namespace GodotTools.Internals
             }
         }
 
+        public static string ResTempAssembliesDir
+        {
+            get
+            {
+                Internal.godot_icall_GodotSharpDirs_ResTempAssembliesDir(out godot_string dest);
+                using (dest)
+                    return Marshaling.ConvertStringToManaged(dest);
+            }
+        }
+
         public static string MonoUserDir
         {
             get

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/Internal.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/Internal.cs
@@ -95,6 +95,8 @@ namespace GodotTools.Internals
 
         public static partial void godot_icall_GodotSharpDirs_ResMetadataDir(out godot_string r_dest);
 
+        public static partial void godot_icall_GodotSharpDirs_ResTempAssembliesDir(out godot_string r_dest);
+
         public static partial void godot_icall_GodotSharpDirs_MonoUserDir(out godot_string r_dest);
 
         public static partial void godot_icall_GodotSharpDirs_BuildLogsDirs(out godot_string r_dest);

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -61,6 +61,10 @@ void godot_icall_GodotSharpDirs_ResMetadataDir(godot_string *r_dest) {
 	memnew_placement(r_dest, String(GodotSharpDirs::get_res_metadata_dir()));
 }
 
+void godot_icall_GodotSharpDirs_ResTempAssembliesDir(godot_string *r_dest) {
+	memnew_placement(r_dest, String(GodotSharpDirs::get_res_temp_assemblies_dir()));
+}
+
 void godot_icall_GodotSharpDirs_MonoUserDir(godot_string *r_dest) {
 	memnew_placement(r_dest, String(GodotSharpDirs::get_mono_user_dir()));
 }
@@ -232,6 +236,7 @@ bool godot_icall_Utils_OS_UnixFileHasExecutableAccess(const godot_string *p_file
 // the methods in 'GodotTools/Internals/Internal.cs'.
 static const void *unmanaged_callbacks[]{
 	(void *)godot_icall_GodotSharpDirs_ResMetadataDir,
+	(void *)godot_icall_GodotSharpDirs_ResTempAssembliesDir,
 	(void *)godot_icall_GodotSharpDirs_MonoUserDir,
 	(void *)godot_icall_GodotSharpDirs_BuildLogsDirs,
 	(void *)godot_icall_GodotSharpDirs_DataEditorToolsDir,


### PR DESCRIPTION
- Followup to https://github.com/godotengine/godot/pull/71825#discussion_r1083564614
- Fixes https://github.com/godotengine/godot/issues/72428
- Fixes https://github.com/godotengine/godot/issues/75095

This makes the editor use the the runtime version targeted by the project for tool scripts and running the project in the editor.
If the target framework is changed / after the first build of a project a message pops up to ask the user to restart Godot to load the correct runtime.

This should prevent any issues that could come up from using a different runtime than what the project intends to use.

Additionally this allows the using the .NET 8 previews with godot, by changing the target framework to `net8.0`, rebuilding, and restarting.

Limitations:
- Before the first build of a project the target framework cannot be determined and thus the latest installed runtime is used.
- If a project targets .NET 6 but only the .NET 7 sdk is installed, the editor will fail to load the .net6 runtime and fall back to the .net7, with a message like the following being printed to stdout:
```text
You must install or update .NET to run this application.

App: <...>\godot.windows.editor.dev.x86_64.mono.exe
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '6.0.0' (x64)
.NET location: C:\Program Files\dotnet\

The following frameworks were found:
  2.1.19 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  3.1.5 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  7.0.2 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]

Learn about framework resolution:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=6.0.0&arch=x64&rid=win10-x64
```
- After the first build of a project, users will always be asked to restart the editor, even when the current runtime is actually the correct one. I tried to fix this but manually computing the correct target runtime quickly became a mess and it is not that big of an issue, so the restart prompt now appears whenever the runtime configuration has changed in any way.
