### PR TITLE
Allow .gdshader files in 3to4 conversion

### DIFF
--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -2404,7 +2404,7 @@ Vector<String> ProjectConverter3To4::check_for_files() {
 					directories_to_check.append(current_dir.path_join(file_name) + "/");
 				} else {
 					bool proper_extension = false;
-					if (file_name.ends_with(".gd") || file_name.ends_with(".shader") || file_name.ends_with(".tscn") || file_name.ends_with(".tres") || file_name.ends_with(".godot") || file_name.ends_with(".cs") || file_name.ends_with(".csproj"))
+					if (file_name.ends_with(".gd") || file_name.ends_with(".shader") || file_name.ends_with(".gdshader") || file_name.ends_with(".tscn") || file_name.ends_with(".tres") || file_name.ends_with(".godot") || file_name.ends_with(".cs") || file_name.ends_with(".csproj"))
 						proper_extension = true;
 
 					if (proper_extension) {


### PR DESCRIPTION
I added a check for ".gdshader" files in this line, as proposed by @qarmin in #69597 

https://github.com/godotengine/godot/blob/44c0bfc94d81e758b39a8ee43df5915d64200ed6/editor/project_converter_3_to_4.cpp#L2391

*Bugsquad edit: This closes https://github.com/godotengine/godot/issues/69597.*