### PR TITLE
Tweak the name for duplicated animations in the editor

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1105,9 +1105,24 @@ void AnimationPlayerEditor::_animation_duplicate() {
 		return;
 	}
 
+	int count = 2;
 	String new_name = current;
-	while (player->has_animation(new_name)) {
-		new_name = new_name + " (copy)";
+	PackedStringArray split = new_name.split("_");
+	int last_index = split.size() - 1;
+	if (last_index > 0 && split[last_index].is_valid_int() && split[last_index].to_int() >= 0) {
+		count = split[last_index].to_int();
+		split.remove_at(last_index);
+		new_name = String("_").join(split);
+	}
+	while (true) {
+		String attempt = new_name;
+		attempt += vformat("_%d", count);
+		if (player->has_animation(attempt)) {
+			count++;
+			continue;
+		}
+		new_name = attempt;
+		break;
 	}
 
 	if (new_name.contains("/")) {


### PR DESCRIPTION
Counter PR to #69442; the increasing method used by #69442 should be avoided, because there is never any code in the core that parses trailing digits as index without using a delimiter.

#48570 has made the new animation name to be a snake case, so the duplicated animation name is made to follow suit.

The existing index is increased only in the case of a snake case, for example:

`new_animation` - duplicate -> `new_animation_2`
`new_animation_2` - duplicate -> `new_animation_3`
`new_animation2` - duplicate -> `new_animation2_2`

This will help users to notice the correct naming rules.