### PR TITLE
Removes declarations of removed methods of the EditorPropertyRevert class

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -47,11 +47,7 @@ class TextureRect;
 
 class EditorPropertyRevert {
 public:
-	static bool get_instantiated_node_original_property(Node *p_node, const StringName &p_prop, Variant &value, bool p_check_class_default = true);
-	static bool is_node_property_different(Node *p_node, const Variant &p_current, const Variant &p_orig);
-	static bool is_property_value_different(const Variant &p_a, const Variant &p_b);
 	static Variant get_property_revert_value(Object *p_object, const StringName &p_property, bool *r_is_valid);
-
 	static bool can_property_revert(Object *p_object, const StringName &p_property, const Variant *p_custom_current_value = nullptr);
 };
 
@@ -331,7 +327,7 @@ class EditorInspectorArray : public EditorInspectorSection {
 	AcceptDialog *resize_dialog = nullptr;
 	SpinBox *new_size_spin_box = nullptr;
 
-	// Pagination
+	// Pagination.
 	int page_length = 5;
 	int page = 0;
 	int max_page = 0;
@@ -495,7 +491,7 @@ class EditorInspector : public ScrollContainer {
 
 	HashMap<ObjectID, int> scroll_cache;
 
-	String property_prefix; //used for sectioned inspector
+	String property_prefix; // Used for sectioned inspector.
 	String object_class;
 	Variant property_clipboard;
 


### PR DESCRIPTION
…lass.

The implementation of these methods was removed in 1806ec7c14a8f038c0ff33a88d19087225c8d7ab.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
