### PR TITLE
Add remove immutable tracks option to glTF importer

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1865,6 +1865,7 @@ void ResourceImporterScene::get_import_options(const String &p_path, List<Import
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "animation/import"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "animation/fps", PROPERTY_HINT_RANGE, "1,120,1"), 30));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "animation/trimming"), false));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "animation/remove_immutable_tracks"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "import_script/path", PROPERTY_HINT_FILE, script_ext_hint), ""));
 
 	r_options->push_back(ImportOption(PropertyInfo(Variant::DICTIONARY, "_subresources", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), Dictionary()));

--- a/modules/gltf/doc_classes/GLTFDocument.xml
+++ b/modules/gltf/doc_classes/GLTFDocument.xml
@@ -51,6 +51,7 @@
 			<param index="0" name="state" type="GLTFState" />
 			<param index="1" name="bake_fps" type="float" default="30" />
 			<param index="2" name="trimming" type="bool" default="false" />
+			<param index="3" name="remove_immutable_tracks" type="bool" default="true" />
 			<description>
 				Takes a [GLTFState] object through the [param state] parameter and returns a Godot Engine scene node.
 			</description>

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -233,7 +233,7 @@ Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_
 		}
 		return nullptr;
 	}
-	return gltf->generate_scene(state, (float)p_options["animation/fps"], (bool)p_options["animation/trimming"]);
+	return gltf->generate_scene(state, (float)p_options["animation/fps"], (bool)p_options["animation/trimming"], (bool)p_options["animation/remove_immutable_tracks"]);
 }
 
 Variant EditorSceneFormatImporterBlend::get_option_visibility(const String &p_path, bool p_for_animation, const String &p_option,

--- a/modules/gltf/editor/editor_scene_importer_fbx.cpp
+++ b/modules/gltf/editor/editor_scene_importer_fbx.cpp
@@ -100,7 +100,7 @@ Node *EditorSceneFormatImporterFBX::import_scene(const String &p_path, uint32_t 
 		}
 		return nullptr;
 	}
-	return gltf->generate_scene(state, (float)p_options["animation/fps"], (bool)p_options["animation/trimming"]);
+	return gltf->generate_scene(state, (float)p_options["animation/fps"], (bool)p_options["animation/trimming"], (bool)p_options["animation/remove_immutable_tracks"]);
 }
 
 Variant EditorSceneFormatImporterFBX::get_option_visibility(const String &p_path, bool p_for_animation,

--- a/modules/gltf/editor/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor/editor_scene_importer_gltf.cpp
@@ -66,11 +66,23 @@ Node *EditorSceneFormatImporterGLTF::import_scene(const String &p_path, uint32_t
 		state->set_create_animations(bool(p_options["animation/import"]));
 	}
 
+#ifndef DISABLE_DEPRECATED
 	if (p_options.has("animation/trimming")) {
-		return doc->generate_scene(state, (float)p_options["animation/fps"], (bool)p_options["animation/trimming"]);
+		if (p_options.has("animation/remove_immutable_tracks")) {
+			return doc->generate_scene(state, (float)p_options["animation/fps"], (bool)p_options["animation/trimming"], (bool)p_options["animation/remove_immutable_tracks"]);
+		} else {
+			return doc->generate_scene(state, (float)p_options["animation/fps"], (bool)p_options["animation/trimming"], true);
+		}
 	} else {
-		return doc->generate_scene(state, (float)p_options["animation/fps"], false);
+		if (p_options.has("animation/remove_immutable_tracks")) {
+			return doc->generate_scene(state, (float)p_options["animation/fps"], false, (bool)p_options["animation/remove_immutable_tracks"]);
+		} else {
+			return doc->generate_scene(state, (float)p_options["animation/fps"], false, true);
+		}
 	}
+#else
+	return doc->generate_scene(state, (float)p_options["animation/fps"], (bool)p_options["animation/trimming"], (bool)p_options["animation/remove_immutable_tracks"]);
+#endif
 }
 
 void EditorSceneFormatImporterGLTF::get_import_options(const String &p_path,

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -296,7 +296,7 @@ public:
 	Error append_from_scene(Node *p_node, Ref<GLTFState> r_state, uint32_t p_flags = 0);
 
 public:
-	Node *generate_scene(Ref<GLTFState> p_state, float p_bake_fps = 30.0f, bool p_trimming = false);
+	Node *generate_scene(Ref<GLTFState> p_state, float p_bake_fps = 30.0f, bool p_trimming = false, bool p_remove_immutable_tracks = true);
 	PackedByteArray generate_buffer(Ref<GLTFState> p_state);
 	Error write_to_filesystem(Ref<GLTFState> p_state, const String &p_path);
 
@@ -309,7 +309,7 @@ public:
 			const GLTFNodeIndex p_node_index);
 	void _generate_skeleton_bone_node(Ref<GLTFState> p_state, Node *p_scene_parent, Node3D *p_scene_root, const GLTFNodeIndex p_node_index);
 	void _import_animation(Ref<GLTFState> p_state, AnimationPlayer *p_animation_player,
-			const GLTFAnimationIndex p_index, const float p_bake_fps, const bool p_trimming);
+			const GLTFAnimationIndex p_index, const float p_bake_fps, const bool p_trimming, const bool p_remove_immutable_tracks);
 	void _convert_mesh_instances(Ref<GLTFState> p_state);
 	GLTFCameraIndex _convert_camera(Ref<GLTFState> p_state, Camera3D *p_camera);
 	void _convert_light_to_gltf(Light3D *p_light, Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node);


### PR DESCRIPTION
Co-authored-by: Lyuma <xn.lyuma@gmail.com>

Supersedes #72007. Fixes #71525.

In some cases, this rest-match optimization can be a bad thing, but in most cases it should not be a problem. It should be optional. As I mentioned in https://github.com/godotengine/godot/pull/72007#issuecomment-1407785433, it is hard work to associate Skeleton with Animation in the Scene importer (Post import), so it is reasonable to have this in the glTF importer.

Also, it is recommended that optimization be done by default, since the problematic case should be rare.

![image](https://user-images.githubusercontent.com/61938263/215363297-056a0b2c-a5b6-4ab2-b100-ae404a0f9b2f.png)