### PR TITLE
Create default World navigation maps on demand only

### DIFF
--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -47,6 +47,13 @@ RID World2D::get_space() const {
 }
 
 RID World2D::get_navigation_map() const {
+	if (navigation_map.is_null()) {
+		navigation_map = NavigationServer2D::get_singleton()->map_create();
+		NavigationServer2D::get_singleton()->map_set_active(navigation_map, true);
+		NavigationServer2D::get_singleton()->map_set_cell_size(navigation_map, GLOBAL_GET("navigation/2d/default_cell_size"));
+		NavigationServer2D::get_singleton()->map_set_edge_connection_margin(navigation_map, GLOBAL_GET("navigation/2d/default_edge_connection_margin"));
+		NavigationServer2D::get_singleton()->map_set_link_connection_radius(navigation_map, GLOBAL_GET("navigation/2d/default_link_connection_radius"));
+	}
 	return navigation_map;
 }
 
@@ -77,13 +84,6 @@ World2D::World2D() {
 	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_GRAVITY_VECTOR, GLOBAL_DEF_BASIC("physics/2d/default_gravity_vector", Vector2(0, 1)));
 	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_LINEAR_DAMP, GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/default_linear_damp", PROPERTY_HINT_RANGE, "-1,100,0.001,or_greater"), 0.1));
 	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_ANGULAR_DAMP, GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/default_angular_damp", PROPERTY_HINT_RANGE, "-1,100,0.001,or_greater"), 1.0));
-
-	// Create and configure the navigation_map to be more friendly with pixels than meters.
-	navigation_map = NavigationServer2D::get_singleton()->map_create();
-	NavigationServer2D::get_singleton()->map_set_active(navigation_map, true);
-	NavigationServer2D::get_singleton()->map_set_cell_size(navigation_map, GLOBAL_DEF("navigation/2d/default_cell_size", 1));
-	NavigationServer2D::get_singleton()->map_set_edge_connection_margin(navigation_map, GLOBAL_DEF("navigation/2d/default_edge_connection_margin", 1));
-	NavigationServer2D::get_singleton()->map_set_link_connection_radius(navigation_map, GLOBAL_DEF("navigation/2d/default_link_connection_radius", 4));
 }
 
 World2D::~World2D() {
@@ -92,5 +92,7 @@ World2D::~World2D() {
 	ERR_FAIL_NULL(NavigationServer2D::get_singleton());
 	RenderingServer::get_singleton()->free(canvas);
 	PhysicsServer2D::get_singleton()->free(space);
-	NavigationServer2D::get_singleton()->free(navigation_map);
+	if (navigation_map.is_valid()) {
+		NavigationServer2D::get_singleton()->free(navigation_map);
+	}
 }

--- a/scene/resources/world_2d.h
+++ b/scene/resources/world_2d.h
@@ -44,7 +44,7 @@ class World2D : public Resource {
 
 	RID canvas;
 	RID space;
-	RID navigation_map;
+	mutable RID navigation_map;
 
 	HashSet<Viewport *> viewports;
 

--- a/scene/resources/world_3d.cpp
+++ b/scene/resources/world_3d.cpp
@@ -55,6 +55,13 @@ RID World3D::get_space() const {
 }
 
 RID World3D::get_navigation_map() const {
+	if (navigation_map.is_null()) {
+		navigation_map = NavigationServer3D::get_singleton()->map_create();
+		NavigationServer3D::get_singleton()->map_set_active(navigation_map, true);
+		NavigationServer3D::get_singleton()->map_set_cell_size(navigation_map, GLOBAL_GET("navigation/3d/default_cell_size"));
+		NavigationServer3D::get_singleton()->map_set_edge_connection_margin(navigation_map, GLOBAL_GET("navigation/3d/default_edge_connection_margin"));
+		NavigationServer3D::get_singleton()->map_set_link_connection_radius(navigation_map, GLOBAL_GET("navigation/3d/default_link_connection_radius"));
+	}
 	return navigation_map;
 }
 
@@ -146,12 +153,6 @@ World3D::World3D() {
 	PhysicsServer3D::get_singleton()->area_set_param(space, PhysicsServer3D::AREA_PARAM_GRAVITY_VECTOR, GLOBAL_DEF_BASIC("physics/3d/default_gravity_vector", Vector3(0, -1, 0)));
 	PhysicsServer3D::get_singleton()->area_set_param(space, PhysicsServer3D::AREA_PARAM_LINEAR_DAMP, GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/3d/default_linear_damp", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater"), 0.1));
 	PhysicsServer3D::get_singleton()->area_set_param(space, PhysicsServer3D::AREA_PARAM_ANGULAR_DAMP, GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/3d/default_angular_damp", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater"), 0.1));
-
-	navigation_map = NavigationServer3D::get_singleton()->map_create();
-	NavigationServer3D::get_singleton()->map_set_active(navigation_map, true);
-	NavigationServer3D::get_singleton()->map_set_cell_size(navigation_map, GLOBAL_DEF("navigation/3d/default_cell_size", 0.25));
-	NavigationServer3D::get_singleton()->map_set_edge_connection_margin(navigation_map, GLOBAL_DEF("navigation/3d/default_edge_connection_margin", 0.25));
-	NavigationServer3D::get_singleton()->map_set_link_connection_radius(navigation_map, GLOBAL_DEF("navigation/3d/default_link_connection_radius", 1.0));
 }
 
 World3D::~World3D() {
@@ -160,5 +161,7 @@ World3D::~World3D() {
 	ERR_FAIL_NULL(NavigationServer3D::get_singleton());
 	PhysicsServer3D::get_singleton()->free(space);
 	RenderingServer::get_singleton()->free(scenario);
-	NavigationServer3D::get_singleton()->free(navigation_map);
+	if (navigation_map.is_valid()) {
+		NavigationServer3D::get_singleton()->free(navigation_map);
+	}
 }

--- a/scene/resources/world_3d.h
+++ b/scene/resources/world_3d.h
@@ -46,8 +46,8 @@ class World3D : public Resource {
 
 private:
 	RID space;
-	RID navigation_map;
 	RID scenario;
+	mutable RID navigation_map;
 
 	Ref<Environment> environment;
 	Ref<Environment> fallback_environment;

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -30,9 +30,7 @@
 
 #include "navigation_server_3d.h"
 
-#ifdef DEBUG_ENABLED
 #include "core/config/project_settings.h"
-#endif // DEBUG_ENABLED
 
 NavigationServer3D *NavigationServer3D::singleton = nullptr;
 
@@ -144,6 +142,14 @@ NavigationServer3D *NavigationServer3D::get_singleton() {
 NavigationServer3D::NavigationServer3D() {
 	ERR_FAIL_COND(singleton != nullptr);
 	singleton = this;
+
+	GLOBAL_DEF("navigation/2d/default_cell_size", 1);
+	GLOBAL_DEF("navigation/2d/default_edge_connection_margin", 1);
+	GLOBAL_DEF("navigation/2d/default_link_connection_radius", 4);
+
+	GLOBAL_DEF("navigation/3d/default_cell_size", 0.25);
+	GLOBAL_DEF("navigation/3d/default_edge_connection_margin", 0.25);
+	GLOBAL_DEF("navigation/3d/default_link_connection_radius", 1.0);
 
 #ifdef DEBUG_ENABLED
 	debug_navigation_edge_connection_color = GLOBAL_DEF("debug/shapes/navigation/edge_connection_color", Color(1.0, 0.0, 1.0, 1.0));


### PR DESCRIPTION
Changes that the default navigation maps of World resources are only created on first use e.g. similar to how many textures are only created on first use when the RID is requested.

As @Scony pointed out in his RTS demo that uses a lot of overhead 3D status bars rendered with SubViewports ... every single Viewport spawns two navigation maps. If a 3D game has 100+ RTS units with SubViewports (which is not an extraordinary amount) it runs with 200+ navigation maps that do nothing except consuming a little processing and cluttering the debug navigation monitor statistic.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
