### PR TITLE
Enhance EditorPath button by allowing to go back to the previous resources

### DIFF
--- a/editor/editor_path.h
+++ b/editor/editor_path.h
@@ -49,12 +49,20 @@ class EditorPath : public Button {
 	TextureRect *sub_objects_icon = nullptr;
 	PopupMenu *sub_objects_menu = nullptr;
 
-	Vector<ObjectID> objects;
+	struct Property {
+		String name;
+		ObjectID value;
+		int depth = 0;
+	};
+	Vector<Property> objects;
 
-	void _show_popup();
-	void _id_pressed(int p_idx);
+	String _get_human_readable_name(Object *p_obj, String p_prop_name = "") const;
+	void _add_object_properties(Object *p_obj, int p_depth = 1);
+
+	void _toggle_popup();
+	void _id_pressed(int p_id);
 	void _about_to_show();
-	void _add_children_to_popup(Object *p_obj, int p_depth = 0);
+	void _add_children_to_popup();
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
Navigating between nested resources is a bit tedious because we can't go back to the previous resources we visited in a good visual way (you can use the history arrows but it's not extremely intuitive to some people).

So, this PR allows the EditorPath dropdown to show the whole property tree, with the base object shown on top, and with the currently selected resource being disabled so you can easily see where you currently are in the tree.

| Before | After |
|--------|-------|
| ![Video: before](https://user-images.githubusercontent.com/13206601/215398814-98c1510f-681e-411c-a875-8853835c018c.gif) | ![Video: after](https://user-images.githubusercontent.com/13206601/215398817-4c8a4346-8520-4135-9d01-268735fdb60e.gif) |