### PR TITLE
Add Curve3D::sample_baked_tilt binding

### DIFF
--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -122,6 +122,14 @@
 				Cubic interpolation tends to follow the curves better, but linear is faster (and often, precise enough).
 			</description>
 		</method>
+		<method name="sample_baked_tilt" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="offset" type="float" default="0.0" />
+			<description>
+				Returns the tilt value within the curve at position [param offset], where [param offset] is measured as a distance in 3D units along the curve.
+				To do that, it finds the two cached points where the [param offset] lies between, then interpolates their tilt values.
+			</description>
+		</method>
 		<method name="sample_baked_up_vector" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="offset" type="float" />
@@ -139,14 +147,6 @@
 			<param index="2" name="apply_tilt" type="bool" default="false" />
 			<description>
 				Similar with [code]interpolate_baked()[/code]. The return value is [code]Transform3D[/code], with [code]origin[/code] as point position, [code]basis.x[/code] as sideway vector, [code]basis.y[/code] as up vector, [code]basis.z[/code] as forward vector. When the curve length is 0, there is no reasonable way to calculate the rotation, all vectors aligned with global space axes.
-			</description>
-		</method>
-		<method name="sample_baked_tilt" qualifiers="const">
-			<return type="float" />
-			<param index="0" name="offset" type="float" default="0.0" />
-			<description>
-				Returns the tilt value within the curve at position [param offset], where [param offset] is measured as a distance in 3D units along the curve.
-				To do that, it finds the two cached points where the [param offset] lies between, then interpolates their tilt values.
 			</description>
 		</method>
 		<method name="samplef" qualifiers="const">

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -138,7 +138,15 @@
 			<param index="1" name="cubic" type="bool" default="false" />
 			<param index="2" name="apply_tilt" type="bool" default="false" />
 			<description>
-				Similar with [code]interpolate_baked()[/code]. The the return value is [code]Transform3D[/code], with [code]origin[/code] as point position, [code]basis.x[/code] as sideway vector, [code]basis.y[/code] as up vector, [code]basis.z[/code] as forward vector. When the curve length is 0, there is no reasonable way to calculate the rotation, all vectors aligned with global space axes.
+				Similar with [code]interpolate_baked()[/code]. The return value is [code]Transform3D[/code], with [code]origin[/code] as point position, [code]basis.x[/code] as sideway vector, [code]basis.y[/code] as up vector, [code]basis.z[/code] as forward vector. When the curve length is 0, there is no reasonable way to calculate the rotation, all vectors aligned with global space axes.
+			</description>
+		</method>
+		<method name="sample_baked_tilt" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="offset" type="float" default="0.0" />
+			<description>
+				Returns the tilt value within the curve at position [param offset], where [param offset] is measured as a distance in 3D units along the curve.
+				To do that, it finds the two cached points where the [param offset] lies between, then interpolates their tilt values.
 			</description>
 		</method>
 		<method name="samplef" qualifiers="const">

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -2225,6 +2225,7 @@ void Curve3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("sample_baked", "offset", "cubic"), &Curve3D::sample_baked, DEFVAL(0.0), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("sample_baked_with_rotation", "offset", "cubic", "apply_tilt"), &Curve3D::sample_baked_with_rotation, DEFVAL(0.0), DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("sample_baked_up_vector", "offset", "apply_tilt"), &Curve3D::sample_baked_up_vector, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("sample_baked_tilt", "offset"), &Curve3D::sample_baked_tilt, DEFVAL(0.0));
 	ClassDB::bind_method(D_METHOD("get_baked_points"), &Curve3D::get_baked_points);
 	ClassDB::bind_method(D_METHOD("get_baked_tilts"), &Curve3D::get_baked_tilts);
 	ClassDB::bind_method(D_METHOD("get_baked_up_vectors"), &Curve3D::get_baked_up_vectors);


### PR DESCRIPTION
- Add GDScript binding for `sample_baked_tilt`
- Fix type-o in `sample_baked_up_vector` description, specifically the `The the return value...`

The main reason for this  (at least for me) is to be able to mimic and /or alter the behavior similar to [PathFollow3D::_update_transform](https://github.com/godotengine/godot/blob/master/scene/3d/path_3d.cpp#L172) where tilt is applied after posture correction. Besides this is a public method and seems like it could be useful considering that the `get_baked_tilts` method is already exported.