### PR TITLE
Fix LineEdit not consuming events

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -272,6 +272,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 				}
 			}
 			grab_focus();
+			accept_event();
 			return;
 		}
 
@@ -381,6 +382,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		queue_redraw();
+		return;
 	}
 
 	Ref<InputEventMouseMotion> m = p_event;
@@ -405,6 +407,8 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			drag_caret_force_displayed = true;
 			set_caret_at_pixel_pos(m->get_position().x);
 		}
+
+		return;
 	}
 
 	Ref<InputEventKey> k = p_event;
@@ -458,6 +462,9 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 				menu->reset_size();
 				menu->popup();
 				menu->grab_focus();
+
+				accept_event();
+				return;
 			}
 		}
 
@@ -467,6 +474,8 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_VIRTUAL_KEYBOARD) && virtual_keyboard_enabled) {
 				DisplayServer::get_singleton()->virtual_keyboard_hide();
 			}
+			accept_event();
+			return;
 		}
 
 		if (is_shortcut_keys_enabled()) {
@@ -606,6 +615,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 				_text_changed();
 			}
 			accept_event();
+			return;
 		}
 	}
 }


### PR DESCRIPTION
The most important issue is LineEdit not consuming "ui_text_submit" action event which makes pressing Enter after editing escape to other components causing unwanted interactions (like starting a Node rename in SceneTree).

Also fix handling mouse button interactions not consuming some events.

Also implement early return in case we know which event type it is and there is no point in checking other event types.

PS I'm also suspicious that mouse motion events also need to be consumed, but haven't explored those cases.

Fixes #69160
