### PR TITLE
Fix navigation related nodes not propagating parent class config warnings

### DIFF
--- a/scene/2d/navigation_2d.cpp
+++ b/scene/2d/navigation_2d.cpp
@@ -83,7 +83,14 @@ Vector<Vector2> Navigation2D::get_simple_path(const Vector2 &p_start, const Vect
 }
 
 String Navigation2D::get_configuration_warning() const {
-	return TTR("'Navigation2D' node and 'Navigation2D.get_simple_path()' are deprecated and will be removed in a future version. Use 'Navigation2DServer.map_get_path()' instead.");
+	String warning = Node2D::get_configuration_warning();
+
+	if (warning != String()) {
+		warning += "\n\n";
+	}
+	warning += TTR("'Navigation2D' node and 'Navigation2D.get_simple_path()' are deprecated and will be removed in a future version. Use 'Navigation2DServer.map_get_path()' instead.");
+
+	return warning;
 }
 
 Vector2 Navigation2D::get_closest_point(const Vector2 &p_point) const {

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -398,11 +398,16 @@ void NavigationAgent2D::_avoidance_done(Vector3 p_new_velocity) {
 }
 
 String NavigationAgent2D::get_configuration_warning() const {
+	String warning = Node::get_configuration_warning();
+
 	if (!Object::cast_to<Node2D>(get_parent())) {
-		return TTR("The NavigationAgent2D can be used only under a Node2D inheriting parent node.");
+		if (warning != String()) {
+			warning += "\n\n";
+		}
+		warning += TTR("The NavigationAgent2D can be used only under a Node2D inheriting parent node.");
 	}
 
-	return String();
+	return warning;
 }
 
 void NavigationAgent2D::update_navigation() {

--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -158,16 +158,24 @@ Node *NavigationObstacle2D::get_navigation_node() const {
 }
 
 String NavigationObstacle2D::get_configuration_warning() const {
+	String warning = Node::get_configuration_warning();
+
 	if (!Object::cast_to<Node2D>(get_parent())) {
-		return TTR("The NavigationObstacle2D only serves to provide collision avoidance to a Node2D object.");
+		if (warning != String()) {
+			warning += "\n\n";
+		}
+		warning += TTR("The NavigationObstacle2D only serves to provide collision avoidance to a Node2D object.");
 	}
 
 	if (Object::cast_to<StaticBody2D>(get_parent())) {
-		return TTR("The NavigationObstacle2D is intended for constantly moving bodies like KinematicBody2D or RigidBody2D as it creates only an RVO avoidance radius and does not follow scene geometry exactly."
-				   "\nNot constantly moving or complete static objects should be captured with a refreshed NavigationPolygon so agents can not only avoid them but also move along those objects outline at high detail");
+		if (warning != String()) {
+			warning += "\n\n";
+		}
+		warning += TTR("The NavigationObstacle2D is intended for constantly moving bodies like KinematicBody2D or RigidBody2D as it creates only an RVO avoidance radius and does not follow scene geometry exactly."
+					   "\nNot constantly moving or complete static objects should be (re)baked to a NavigationMesh so agents can not only avoid them but also move along those objects outline at high detail");
 	}
 
-	return String();
+	return warning;
 }
 
 void NavigationObstacle2D::initialize_agent() {

--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -582,11 +582,8 @@ void NavigationPolygonInstance::_map_changed(RID p_map) {
 }
 
 String NavigationPolygonInstance::get_configuration_warning() const {
-	if (!is_visible_in_tree() || !is_inside_tree()) {
-		return String();
-	}
-
 	String warning = Node2D::get_configuration_warning();
+
 	if (!navpoly.is_valid()) {
 		if (warning != String()) {
 			warning += "\n\n";

--- a/scene/3d/navigation.cpp
+++ b/scene/3d/navigation.cpp
@@ -38,7 +38,14 @@ Vector<Vector3> Navigation::get_simple_path(const Vector3 &p_start, const Vector
 }
 
 String Navigation::get_configuration_warning() const {
-	return TTR("'Navigation' node and 'Navigation.get_simple_path()' are deprecated and will be removed in a future version. Use 'NavigationServer.map_get_path()' instead.");
+	String warning = Spatial::get_configuration_warning();
+
+	if (warning != String()) {
+		warning += "\n\n";
+	}
+	warning += TTR("'Navigation' node and 'Navigation.get_simple_path()' are deprecated and will be removed in a future version. Use 'NavigationServer.map_get_path()' instead.");
+
+	return warning;
 }
 
 Vector3 Navigation::get_closest_point_to_segment(const Vector3 &p_from, const Vector3 &p_to, bool p_use_collision) const {

--- a/scene/3d/navigation_agent.cpp
+++ b/scene/3d/navigation_agent.cpp
@@ -407,11 +407,16 @@ void NavigationAgent::_avoidance_done(Vector3 p_new_velocity) {
 }
 
 String NavigationAgent::get_configuration_warning() const {
+	String warning = Node::get_configuration_warning();
+
 	if (!Object::cast_to<Spatial>(get_parent())) {
-		return TTR("The NavigationAgent can be used only under a Spatial inheriting parent node.");
+		if (warning != String()) {
+			warning += "\n\n";
+		}
+		warning += TTR("The NavigationAgent can be used only under a Spatial inheriting parent node.");
 	}
 
-	return String();
+	return warning;
 }
 
 void NavigationAgent::update_navigation() {

--- a/scene/3d/navigation_mesh_instance.cpp
+++ b/scene/3d/navigation_mesh_instance.cpp
@@ -245,15 +245,16 @@ void NavigationMeshInstance::_bake_finished(Ref<NavigationMesh> p_nav_mesh) {
 }
 
 String NavigationMeshInstance::get_configuration_warning() const {
-	if (!is_visible_in_tree() || !is_inside_tree()) {
-		return String();
-	}
+	String warning = Spatial::get_configuration_warning();
 
 	if (!navmesh.is_valid()) {
-		return TTR("A NavigationMesh resource must be set or created for this node to work.");
+		if (warning != String()) {
+			warning += "\n\n";
+		}
+		warning += TTR("A NavigationMesh resource must be set or created for this node to work.");
 	}
 
-	return String();
+	return warning;
 }
 
 void NavigationMeshInstance::_bind_methods() {

--- a/scene/3d/navigation_obstacle.cpp
+++ b/scene/3d/navigation_obstacle.cpp
@@ -164,16 +164,24 @@ Node *NavigationObstacle::get_navigation_node() const {
 }
 
 String NavigationObstacle::get_configuration_warning() const {
+	String warning = Node::get_configuration_warning();
+
 	if (!Object::cast_to<Spatial>(get_parent())) {
-		return TTR("The NavigationObstacle only serves to provide collision avoidance to a Spatial inheriting parent object.");
+		if (warning != String()) {
+			warning += "\n\n";
+		}
+		warning += TTR("The NavigationObstacle only serves to provide collision avoidance to a Spatial inheriting parent object.");
 	}
 
 	if (Object::cast_to<StaticBody>(get_parent())) {
-		return TTR("The NavigationObstacle is intended for constantly moving bodies like KinematicBody3D or RigidBody3D as it creates only an RVO avoidance radius and does not follow scene geometry exactly."
-				   "\nNot constantly moving or complete static objects should be (re)baked to a NavigationMesh so agents can not only avoid them but also move along those objects outline at high detail");
+		if (warning != String()) {
+			warning += "\n\n";
+		}
+		warning += TTR("The NavigationObstacle is intended for constantly moving bodies like KinematicBody or RigidBody as it creates only an RVO avoidance radius and does not follow scene geometry exactly."
+					   "\nNot constantly moving or complete static objects should be (re)baked to a NavigationMesh so agents can not only avoid them but also move along those objects outline at high detail");
 	}
 
-	return String();
+	return warning;
 }
 
 void NavigationObstacle::initialize_agent() {


### PR DESCRIPTION
Fixes that navigation related nodes do not propagate config warnings from their parent classes.

Fixes https://github.com/godotengine/godot/issues/72368

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
