### PR TITLE
Enhance label sizing algorithm (a.k.a. prevent infinite GUI re-layout)

### DIFF
--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -46,10 +46,10 @@ private:
 	bool clip = false;
 	TextServer::OverrunBehavior overrun_behavior = TextServer::OVERRUN_NO_TRIMMING;
 	Size2 minsize;
+	real_t stable_width = -1;
 	bool uppercase = false;
 
 	bool lines_dirty = true;
-	int lines_shaped_last_width = -1;
 
 	bool dirty = true;
 	bool font_dirty = true;
@@ -83,7 +83,6 @@ private:
 		int font_shadow_outline_size;
 	} theme_cache;
 
-	void _update_visible();
 	void _shape();
 	void _invalidate();
 


### PR DESCRIPTION
This reverts commit ed8c5cd52f7914daf6f1aa309581ca3b9b048a2e (from #71553) and implements a more ~focused~ intelligent approach.

It fixes the original issue (@clayjohn, please confirm) and prevents the regression reported in https://github.com/godotengine/godot/pull/71553#issuecomment-1400296547.

~There's a little risk of behavior changes, in cases where there's a layout "dance", where two elements' sizes depend on each other, but it's very hard to test. I smoke tested the editor and saw no regressions.~

**UPDATE:**
Now this PR re-implements part of the logic. One of the key points is that previously the number of lines visible even in modes that could expand the height was gotten from functions that constrained that quantity to the current height. That led to cases where the label was reshaped once per each newly visible line, which was also a performance killer.

The key thing is that, as far as my testing says, fixes the original issue and doesn't cause the regression reported below.

I've gotten much more familiar with the internals of `Label`. ~However, I've based my changes in one assumption that I'd need to confirm: the only settings that allow a label to grow, and therefore set a minimum size beyond its current height, is auto-wrap enabled (any value besides off). Please let me know if overrun or something other mode affects the logic.~

**UPDATE 2:**
The algorithm has been enhanced and it now causes none of the reported regressions, nor any other, as far as my testing went. However, it'd be nice that someone familiar reviews and re-tests. Now it's built on top of #71644, which ensures correct validation of the queued callable to `_shape()`, to avoid crash when the label has already been deleted.

**UPDATE 3:**
Improved logic a bit to fix CI issue. This no longer depends on the PR mentioned in the update 2, provided CI passes.

*Bugsquad edit:*
- Fixes #72339