### PR TITLE
Allow the Reset option of NodeTransition to be set for each Input

### DIFF
--- a/doc/classes/AnimationNodeTransition.xml
+++ b/doc/classes/AnimationNodeTransition.xml
@@ -12,6 +12,13 @@
 		<link title="Third Person Shooter Demo">https://godotengine.org/asset-library/asset/678</link>
 	</tutorials>
 	<methods>
+		<method name="is_input_reset" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="input" type="int" />
+			<description>
+				Returns whether the animation restarts when the animation transitions from the other animation.
+			</description>
+		</method>
 		<method name="is_input_set_as_auto_advance" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="input" type="int" />
@@ -27,13 +34,18 @@
 				Enables or disables auto-advance for the given [param input] index. If enabled, state changes to the next input after playing the animation once. If enabled for the last input state, it loops to the first.
 			</description>
 		</method>
+		<method name="set_input_reset">
+			<return type="void" />
+			<param index="0" name="input" type="int" />
+			<param index="1" name="enable" type="bool" />
+			<description>
+				If [code]true[/code], the destination animation is restarted when the animation transitions.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="input_count" type="int" setter="set_input_count" getter="get_input_count" default="0">
 			The number of enabled input ports for this node.
-		</member>
-		<member name="reset" type="bool" setter="set_reset" getter="is_reset" default="true">
-			If [code]true[/code], the destination animation is played back from the beginning when switched.
 		</member>
 		<member name="xfade_curve" type="Curve" setter="set_xfade_curve" getter="get_xfade_curve">
 			Determines how cross-fading between animations is eased. If empty, the transition will be linear.

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -276,7 +276,11 @@ public:
 class AnimationNodeTransition : public AnimationNodeSync {
 	GDCLASS(AnimationNodeTransition, AnimationNodeSync);
 
-	Vector<bool> input_as_auto_advance;
+	struct InputData {
+		bool auto_advance = false;
+		bool reset = true;
+	};
+	Vector<InputData> input_data;
 
 	StringName time = "time";
 	StringName prev_xfading = "prev_xfading";
@@ -290,7 +294,6 @@ class AnimationNodeTransition : public AnimationNodeSync {
 
 	double xfade_time = 0.0;
 	Ref<Curve> xfade_curve;
-	bool reset = true;
 
 protected:
 	bool _get(const StringName &p_path, Variant &r_ret) const;
@@ -313,14 +316,14 @@ public:
 	void set_input_as_auto_advance(int p_input, bool p_enable);
 	bool is_input_set_as_auto_advance(int p_input) const;
 
+	void set_input_reset(int p_input, bool p_enable);
+	bool is_input_reset(int p_input) const;
+
 	void set_xfade_time(double p_fade);
 	double get_xfade_time() const;
 
 	void set_xfade_curve(const Ref<Curve> &p_curve);
 	Ref<Curve> get_xfade_curve() const;
-
-	void set_reset(bool p_reset);
-	bool is_reset() const;
 
 	double process(double p_time, bool p_seek, bool p_is_external_seeking) override;
 


### PR DESCRIPTION
Allow the Reset option of AnimationNodeTransition to be set for each Input.

![image](https://user-images.githubusercontent.com/61938263/215529289-730ca8f0-474e-4e9a-bae6-1b5e61301fa3.png)

The Reset option was also implemented in AnimationStateMachine in #71418, but while it could be set for each transition in AnimationStateMachine, only one could be set for the entire AnimationNodeTransition.

This is useful for preventing to restart if a transition is spammed in any "looped"[^1] animation. It can also be used as an alternative to NodeOneShot.

I believe that Xfade time/curve can be implemented for each Input as well, but it may be too much. I will consider it according to the demand in the future.

[^1]: For Non-looping animations, it is not so useful. An option should be implemented to keep an ended flag somewhere and "restart if the animation has finished", but due to AnimationTree's iterating algorithm, it is difficult to get the ended flag for a specific animation, so it will not be implemented for now.