### PR TITLE
GDScript: Fix vararg method calls with exact arguments

### DIFF
--- a/modules/gdscript/tests/scripts/analyzer/features/vararg_call.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/vararg_call.gd
@@ -1,0 +1,6 @@
+signal ok()
+
+@warning_ignore("return_value_discarded")
+func test():
+	ok.connect(func(): print('ok'))
+	emit_signal(&'ok')

--- a/modules/gdscript/tests/scripts/analyzer/features/vararg_call.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/vararg_call.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok


### PR DESCRIPTION
Fixes #65689.