### PR TITLE
Add a shader error when trying to using hint_normal_roughness_texture in the gl_compatibility renderer

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -8759,6 +8759,10 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 									new_hint = ShaderNode::Uniform::HINT_NORMAL_ROUGHNESS_TEXTURE;
 									--texture_uniforms;
 									--texture_binding;
+									if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
+										_set_error(RTR("'hint_normal_roughness_texture is not supported in gl_compatibility shaders."));
+										return ERR_PARSE_ERROR;
+									}
 								} break;
 								case TK_HINT_DEPTH_TEXTURE: {
 									new_hint = ShaderNode::Uniform::HINT_DEPTH_TEXTURE;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/72364

The GL_Compatibility renderer does not support using the normal roughness texture. So we need to provide an error in the shader compiler when users try to access it.

This is different from the screen texture and the depth texture which will be supported eventually. 