### PR TITLE
GDScript: Improve usability of setter chains

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3601,15 +3601,6 @@ bool Variant::is_type_shared(Variant::Type p_type) {
 		case OBJECT:
 		case ARRAY:
 		case DICTIONARY:
-		case PACKED_BYTE_ARRAY:
-		case PACKED_INT32_ARRAY:
-		case PACKED_INT64_ARRAY:
-		case PACKED_FLOAT32_ARRAY:
-		case PACKED_FLOAT64_ARRAY:
-		case PACKED_STRING_ARRAY:
-		case PACKED_VECTOR2_ARRAY:
-		case PACKED_VECTOR3_ARRAY:
-		case PACKED_COLOR_ARRAY:
 			return true;
 		default: {
 		}

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -115,7 +115,7 @@ class GDScriptAnalyzer {
 	Array make_array_from_element_datatype(const GDScriptParser::DataType &p_element_datatype, const GDScriptParser::Node *p_source_node = nullptr);
 	GDScriptParser::DataType type_from_variant(const Variant &p_value, const GDScriptParser::Node *p_source);
 	static GDScriptParser::DataType type_from_metatype(const GDScriptParser::DataType &p_meta_type);
-	GDScriptParser::DataType type_from_property(const PropertyInfo &p_property, bool p_is_arg = false) const;
+	GDScriptParser::DataType type_from_property(const PropertyInfo &p_property, bool p_is_arg = false, bool p_is_readonly = false) const;
 	GDScriptParser::DataType make_global_class_meta_type(const StringName &p_class_name, const GDScriptParser::Node *p_source);
 	bool get_function_signature(GDScriptParser::Node *p_source, bool p_is_constructor, GDScriptParser::DataType base_type, const StringName &p_function, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, bool &r_static, bool &r_vararg);
 	bool function_signature_from_info(const MethodInfo &p_info, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, bool &r_static, bool &r_vararg);

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -122,6 +122,7 @@ public:
 		TypeSource type_source = UNDETECTED;
 
 		bool is_constant = false;
+		bool is_read_only = false;
 		bool is_meta_type = false;
 		bool is_coroutine = false; // For function calls.
 
@@ -206,6 +207,7 @@ public:
 		void operator=(const DataType &p_other) {
 			kind = p_other.kind;
 			type_source = p_other.type_source;
+			is_read_only = p_other.is_read_only;
 			is_constant = p_other.is_constant;
 			is_meta_type = p_other.is_meta_type;
 			is_coroutine = p_other.is_coroutine;

--- a/modules/gdscript/tests/scripts/analyzer/errors/assign_to_read_only_property.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/assign_to_read_only_property.gd
@@ -1,0 +1,4 @@
+func test():
+	var tree := SceneTree.new()
+	tree.root = Window.new()
+	tree.free()

--- a/modules/gdscript/tests/scripts/analyzer/errors/assign_to_read_only_property.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/assign_to_read_only_property.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot assign a new value to a read-only property.

--- a/modules/gdscript/tests/scripts/analyzer/errors/assign_to_read_only_property_indirectly.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/assign_to_read_only_property_indirectly.gd
@@ -1,0 +1,4 @@
+func test():
+	var state := PhysicsDirectBodyState3DExtension.new()
+	state.center_of_mass.x += 1.0
+	state.free()

--- a/modules/gdscript/tests/scripts/analyzer/errors/assign_to_read_only_property_indirectly.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/assign_to_read_only_property_indirectly.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot assign a new value to a read-only property.

--- a/modules/gdscript/tests/scripts/runtime/assign_to_read_only_property.gd
+++ b/modules/gdscript/tests/scripts/runtime/assign_to_read_only_property.gd
@@ -1,0 +1,7 @@
+func test():
+	var state = PhysicsDirectBodyState3DExtension.new()
+	assign(state)
+	state.free()
+
+func assign(state):
+	state.center_of_mass.x -= 1.0

--- a/modules/gdscript/tests/scripts/runtime/assign_to_read_only_property.out
+++ b/modules/gdscript/tests/scripts/runtime/assign_to_read_only_property.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: assign()
+>> runtime/assign_to_read_only_property.gd
+>> 7
+>> Cannot set value into property "center_of_mass" (on base "PhysicsDirectBodyState3DExtension") because it is read-only.

--- a/modules/gdscript/tests/scripts/runtime/assign_to_read_only_property_with_variable_index.gd
+++ b/modules/gdscript/tests/scripts/runtime/assign_to_read_only_property_with_variable_index.gd
@@ -1,0 +1,8 @@
+func test():
+	var state = PhysicsDirectBodyState3DExtension.new()
+	var prop = &"center_of_mass"
+	assign(state, prop)
+	state.free()
+
+func assign(state, prop):
+	state[prop].x = 1.0

--- a/modules/gdscript/tests/scripts/runtime/assign_to_read_only_property_with_variable_index.out
+++ b/modules/gdscript/tests/scripts/runtime/assign_to_read_only_property_with_variable_index.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: assign()
+>> runtime/assign_to_read_only_property_with_variable_index.gd
+>> 8
+>> Cannot set value into property "center_of_mass" (on base "PhysicsDirectBodyState3DExtension") because it is read-only.


### PR DESCRIPTION
- Consider PackedArrays non-shared since they are copied on C++/script boundaries.
- Add error messages in the analyzer when assigning to read-only properties.
- Add specific error message at runtime when assignment fails because the property is read-only.

Fix #62857