### PR TITLE
Only customize resources during export if there are any export plugins in use

### DIFF
--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -785,10 +785,10 @@ String EditorExportPlatform::_export_customize(const String &p_path, LocalVector
 					break;
 				}
 			}
-		}
 
-		if (_export_customize_object(res.ptr(), customize_resources_plugins)) {
-			modified = true;
+			if (_export_customize_object(res.ptr(), customize_resources_plugins)) {
+				modified = true;
+			}
 		}
 
 		if (modified || p_force_save) {


### PR DESCRIPTION
Fixes #72263

This bug was introduced during PR #70377 when changing the approach to use an export plugin: this tiny bit of code should have been reverted during the change, but I missed it. Sorry, Everyone!
