### PR TITLE
Make it clearer that file modes propagate to children in the dedicated server export

### DIFF
--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -118,6 +118,7 @@ private:
 	void _fill_resource_tree();
 	void _setup_item_for_file_mode(TreeItem *p_item, EditorExportPreset::FileExportMode p_mode);
 	bool _fill_tree(EditorFileSystemDirectory *p_dir, TreeItem *p_item, Ref<EditorExportPreset> &current, EditorExportPreset::ExportFilter p_export_filter);
+	void _propagate_file_export_mode(TreeItem *p_item, EditorExportPreset::FileExportMode p_inherited_export_mode);
 	void _tree_changed();
 	void _check_propagated_to_item(Object *p_obj, int column);
 	void _tree_popup_edited(bool p_arrow_clicked);


### PR DESCRIPTION
Per issue #72156, there is some confusion about how file/directory customization works in the dedicated server export. This PR attempts to make it clearer that child files/directories inherit the mode selected for their parents (unless overridden).

Before screenshot:

![Selection_486](https://user-images.githubusercontent.com/191561/214120684-06174333-4df6-46a5-a673-19d3d9de004d.png)

After screenshot:

![Selection_005](https://user-images.githubusercontent.com/191561/215589784-34ef533f-0a8b-48b5-b2c2-7a797d110f4d.png)

As you can see above, it's putting the inherited mode (in the disabled color) next to any files/directories that don't have their mode customized.

Fixes #72156