### PR TITLE
Enable single-window mode by default in the editor

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -435,7 +435,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/editor/unfocused_low_processor_mode_sleep_usec", 100000, "1,1000000,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	_initial_set("interface/editor/separate_distraction_mode", false);
 	_initial_set("interface/editor/automatically_open_screenshots", true);
-	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/single_window_mode", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/single_window_mode", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	_initial_set("interface/editor/mouse_extra_buttons_navigate_history", true);
 	_initial_set("interface/editor/save_each_scene_on_quit", true); // Regression
 	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/accept_dialog_cancel_ok_buttons", 0,

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -151,7 +151,7 @@ static int audio_driver_idx = -1;
 
 // Engine config/tools
 
-static bool single_window = false;
+static bool single_window = true;
 static bool editor = false;
 static bool project_manager = false;
 static bool cmdline_tool = false;


### PR DESCRIPTION
Resurrects #38647 (wow, the number has nearly doubled since then!)

See also the discussion here: https://github.com/godotengine/godot/pull/50680#issuecomment-947864507

With 4.0 RC imminent, we should make single-window mode the default. Multi-window mode still has bugs. It has been beneficial to have multi-window mode up until now so that we have more users testing it, but for release, we should use the option that is fully working, single-window mode. I'm labeling this PR as a bug because having multi-window mode enabled in the release candidate should be considered a bug due to multi-window mode's bugginess.

Also, even if multi-window mode was bug-free, I am still in favor of having single-window mode by the default. But this is a subjective argument. The more pressing argument here is the bugginess.

Users who want multi-window mode can simply change this setting.