### PR TITLE
Make MenuButton not flat by default

### DIFF
--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -34,7 +34,6 @@
 	</methods>
 	<members>
 		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" overrides="BaseButton" enum="BaseButton.ActionMode" default="0" />
-		<member name="flat" type="bool" setter="set_flat" getter="is_flat" overrides="Button" default="true" />
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="0" />
 		<member name="item_count" type="int" setter="set_item_count" getter="get_item_count" default="0">
 			The number of items currently in the list.

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1750,6 +1750,7 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 	play_position->connect("draw", callable_mp(this, &AnimationTimelineEdit::_play_position_draw));
 
 	add_track = memnew(MenuButton);
+	add_track->set_flat(true);
 	add_track->set_position(Vector2(0, 0));
 	add_child(add_track);
 	add_track->set_text(TTR("Add Track"));

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -934,6 +934,7 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	bus_options->set_h_size_flags(SIZE_SHRINK_END);
 	bus_options->set_anchor(SIDE_RIGHT, 0.0);
 	bus_options->set_tooltip_text(TTR("Bus Options"));
+	bus_options->set_flat(true);
 	hbc->add_child(bus_options);
 
 	bus_popup = bus_options->get_popup();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7528,6 +7528,7 @@ EditorNode::EditorNode() {
 	layout_dialog->connect("name_confirmed", callable_mp(this, &EditorNode::_dialog_action));
 
 	update_spinner = memnew(MenuButton);
+	update_spinner->set_flat(true);
 	right_menu_hb->add_child(update_spinner);
 	update_spinner->set_icon(gui_base->get_theme_icon(SNAME("Progress1"), SNAME("EditorIcons")));
 	update_spinner->get_popup()->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));

--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -157,6 +157,7 @@ EditorRunNative::EditorRunNative() {
 	remote_debug->get_popup()->connect("id_pressed", callable_mp(this, &EditorRunNative::run_native));
 	remote_debug->set_icon(get_theme_icon(SNAME("PlayRemote"), SNAME("EditorIcons")));
 	remote_debug->set_tooltip_text(TTR("Remote Debug"));
+	remote_debug->set_flat(true);
 	remote_debug->set_disabled(true);
 
 	add_child(remote_debug);

--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -907,6 +907,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	request_mirrors->connect("request_completed", callable_mp(this, &ExportTemplateManager::_refresh_mirrors_completed));
 
 	mirror_options_button = memnew(MenuButton);
+	mirror_options_button->set_flat(true);
 	mirror_options_button->get_popup()->add_item(TTR("Open in Web Browser"), VISIT_WEB_MIRROR);
 	mirror_options_button->get_popup()->add_item(TTR("Copy Mirror URL"), COPY_MIRROR_URL);
 	download_install_hb->add_child(mirror_options_button);

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1077,6 +1077,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	preset_vb->add_child(preset_hb);
 
 	add_preset = memnew(MenuButton);
+	add_preset->set_flat(true);
 	add_preset->set_text(TTR("Add..."));
 	add_preset->get_popup()->connect("index_pressed", callable_mp(this, &ProjectExportDialog::_add_preset));
 	preset_hb->add_child(add_preset);

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -636,6 +636,7 @@ ImportDock::ImportDock() {
 	import_as->set_h_size_flags(SIZE_EXPAND_FILL);
 	preset = memnew(MenuButton);
 	preset->set_text(TTR("Preset"));
+	preset->set_flat(true);
 	preset->set_disabled(true);
 	preset->get_popup()->connect("index_pressed", callable_mp(this, &ImportDock::_preset_selected));
 	hb->add_child(preset);

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -654,9 +654,11 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	resource_save_button->get_popup()->add_item(TTR("Save As..."), RESOURCE_SAVE_AS);
 	resource_save_button->get_popup()->connect("id_pressed", callable_mp(this, &InspectorDock::_menu_option));
 	resource_save_button->set_focus_mode(Control::FOCUS_NONE);
+	resource_save_button->set_flat(true);
 	resource_save_button->set_disabled(true);
 
 	resource_extra_button = memnew(MenuButton);
+	resource_extra_button->set_flat(true);
 	resource_extra_button->set_tooltip_text(TTR("Extra resource options."));
 	general_options_hb->add_child(resource_extra_button);
 	resource_extra_button->connect("about_to_popup", callable_mp(this, &InspectorDock::_prepare_resource_extra_popup));
@@ -686,6 +688,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	forward_button->connect("pressed", callable_mp(this, &InspectorDock::_edit_forward));
 
 	history_menu = memnew(MenuButton);
+	history_menu->set_flat(true);
 	history_menu->set_tooltip_text(TTR("History of recently edited objects."));
 	general_options_hb->add_child(history_menu);
 	history_menu->connect("about_to_popup", callable_mp(this, &InspectorDock::_prepare_history));
@@ -720,6 +723,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	property_tools_hb->add_child(search);
 
 	object_menu = memnew(MenuButton);
+	object_menu->set_flat(true);
 	object_menu->set_shortcut_context(this);
 	property_tools_hb->add_child(object_menu);
 	object_menu->set_tooltip_text(TTR("Manage object properties."));

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -228,6 +228,7 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 			MenuButton *mb = memnew(MenuButton);
 			mb->set_text(anim->get_animation());
 			mb->set_icon(get_theme_icon(SNAME("Animation"), SNAME("EditorIcons")));
+			mb->set_flat(true);
 			mb->set_disabled(read_only);
 			Array options;
 
@@ -1097,6 +1098,7 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	graph->get_zoom_hbox()->move_child(vs, 0);
 
 	add_node = memnew(MenuButton);
+	add_node->set_flat(true);
 	graph->get_zoom_hbox()->add_child(add_node);
 	add_node->set_text(TTR("Add Node..."));
 	graph->get_zoom_hbox()->move_child(add_node, 0);

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1770,6 +1770,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 	hb->add_child(onion_toggle);
 
 	onion_skinning = memnew(MenuButton);
+	onion_skinning->set_flat(true);
 	onion_skinning->set_tooltip_text(TTR("Onion Skinning Options"));
 	onion_skinning->get_popup()->add_separator(TTR("Directions"));
 	// TRANSLATORS: Opposite of "Future", refers to a direction in animation onion skinning.

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1527,6 +1527,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
 	support = memnew(MenuButton);
 	search_hb2->add_child(support);
+	support->set_flat(true);
 	support->set_text(TTR("Support"));
 	support->get_popup()->set_hide_on_checkable_item_selection(false);
 	support->get_popup()->add_check_item(TTRGET(support_text[SUPPORT_OFFICIAL]), SUPPORT_OFFICIAL);

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5221,7 +5221,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	main_menu_hbox->add_child(memnew(VSeparator));
 
 	skeleton_menu = memnew(MenuButton);
-	skelton_menu->set_flat(true);
+	skeleton_menu->set_flat(true);
 	skeleton_menu->set_shortcut_context(this);
 	main_menu_hbox->add_child(skeleton_menu);
 	skeleton_menu->set_tooltip_text(TTR("Skeleton Options"));

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5152,6 +5152,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	grid_snap_button->set_shortcut_context(this);
 
 	snap_config_menu = memnew(MenuButton);
+	snap_config_menu->set_flat(true);
 	snap_config_menu->set_shortcut_context(this);
 	main_menu_hbox->add_child(snap_config_menu);
 	snap_config_menu->set_h_size_flags(SIZE_SHRINK_END);
@@ -5220,6 +5221,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	main_menu_hbox->add_child(memnew(VSeparator));
 
 	skeleton_menu = memnew(MenuButton);
+	skelton_menu->set_flat(true);
 	skeleton_menu->set_shortcut_context(this);
 	main_menu_hbox->add_child(skeleton_menu);
 	skeleton_menu->set_tooltip_text(TTR("Skeleton Options"));
@@ -5245,6 +5247,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	main_menu_hbox->add_child(memnew(VSeparator));
 
 	view_menu = memnew(MenuButton);
+	view_menu->set_flat(true);
 	// TRANSLATORS: Noun, name of the 2D/3D View menus.
 	view_menu->set_text(TTR("View"));
 	view_menu->set_switch_on_hover(true);
@@ -5341,6 +5344,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	animation_hb->add_child(key_auto_insert_button);
 
 	animation_menu = memnew(MenuButton);
+	animation_menu->set_flat(true);
 	animation_menu->set_shortcut_context(this);
 	animation_menu->set_tooltip_text(TTR("Animation Key and Pose Options"));
 	animation_hb->add_child(animation_menu);

--- a/editor/plugins/cpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_2d_editor_plugin.cpp
@@ -250,6 +250,7 @@ CPUParticles2DEditorPlugin::CPUParticles2DEditorPlugin() {
 	toolbar->add_child(memnew(VSeparator));
 
 	menu = memnew(MenuButton);
+	menu->set_flat(true);
 	menu->get_popup()->add_item(TTR("Restart"), MENU_RESTART);
 	menu->get_popup()->add_item(TTR("Load Emission Mask"), MENU_LOAD_EMISSION_MASK);
 	menu->set_text(TTR("CPUParticles2D"));

--- a/editor/plugins/cpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_3d_editor_plugin.cpp
@@ -95,6 +95,7 @@ CPUParticles3DEditor::CPUParticles3DEditor() {
 	particles_editor_hb = memnew(HBoxContainer);
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(particles_editor_hb);
 	options = memnew(MenuButton);
+	options->set_flat(true);
 	options->set_switch_on_hover(true);
 	particles_editor_hb->add_child(options);
 	particles_editor_hb->hide();

--- a/editor/plugins/gpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.cpp
@@ -369,6 +369,7 @@ GPUParticles2DEditorPlugin::GPUParticles2DEditorPlugin() {
 	toolbar->add_child(memnew(VSeparator));
 
 	menu = memnew(MenuButton);
+	menu->set_flat(true);
 	menu->get_popup()->add_item(TTR("Restart"), MENU_RESTART);
 	menu->get_popup()->add_item(TTR("Generate Visibility Rect"), MENU_GENERATE_VISIBILITY_RECT);
 	menu->get_popup()->add_item(TTR("Load Emission Mask"), MENU_LOAD_EMISSION_MASK);

--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -408,6 +408,7 @@ GPUParticles3DEditor::GPUParticles3DEditor() {
 	particles_editor_hb = memnew(HBoxContainer);
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(particles_editor_hb);
 	options = memnew(MenuButton);
+	options->set_flat(true);
 	options->set_switch_on_hover(true);
 	particles_editor_hb->add_child(options);
 	particles_editor_hb->hide();

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -511,6 +511,7 @@ void MeshInstance3DEditor::_bind_methods() {
 
 MeshInstance3DEditor::MeshInstance3DEditor() {
 	options = memnew(MenuButton);
+	options->set_flat(true);
 	options->set_switch_on_hover(true);
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(options);
 

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -271,6 +271,7 @@ MeshLibraryEditor::MeshLibraryEditor() {
 	file->connect("file_selected", callable_mp(this, &MeshLibraryEditor::_import_scene_cbk));
 
 	menu = memnew(MenuButton);
+	menu->set_flat(true);
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(menu);
 	menu->set_position(Point2(1, 1));
 	menu->set_text(TTR("MeshLibrary"));

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -268,6 +268,7 @@ void MultiMeshEditor::_bind_methods() {
 
 MultiMeshEditor::MultiMeshEditor() {
 	options = memnew(MenuButton);
+	options->set_flat(true);
 	options->set_switch_on_hover(true);
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(options);
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -8212,6 +8212,7 @@ Node3DEditor::Node3DEditor() {
 	PopupMenu *p;
 
 	transform_menu = memnew(MenuButton);
+	transform_menu->set_flat(true);
 	transform_menu->set_text(TTR("Transform"));
 	transform_menu->set_switch_on_hover(true);
 	transform_menu->set_shortcut_context(this);
@@ -8229,6 +8230,7 @@ Node3DEditor::Node3DEditor() {
 	view_menu = memnew(MenuButton);
 	// TRANSLATORS: Noun, name of the 2D/3D View menus.
 	view_menu->set_text(TTR("View"));
+	view_menu->set_flat(true);
 	view_menu->set_switch_on_hover(true);
 	view_menu->set_shortcut_context(this);
 	main_menu_hbox->add_child(view_menu);

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -580,7 +580,7 @@ Path2DEditor::Path2DEditor() {
 	PopupMenu *menu;
 
 	handle_menu = memnew(MenuButton);
-	nandle_menu->set_flat(true);
+	handle_menu->set_flat(true);
 	handle_menu->set_text(TTR("Options"));
 	base_hb->add_child(handle_menu);
 

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -580,6 +580,7 @@ Path2DEditor::Path2DEditor() {
 	PopupMenu *menu;
 
 	handle_menu = memnew(MenuButton);
+	nandle_menu->set_flat(true);
 	handle_menu->set_text(TTR("Options"));
 	base_hb->add_child(handle_menu);
 

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -649,6 +649,7 @@ Path3DEditorPlugin::Path3DEditorPlugin() {
 	PopupMenu *menu;
 
 	handle_menu = memnew(MenuButton);
+	handle_menu->set_flat(true);
 	handle_menu->set_text(TTR("Options"));
 	handle_menu->hide();
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(handle_menu);

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -1352,7 +1352,7 @@ Polygon2DEditor::Polygon2DEditor() {
 
 	uv_menu = memnew(MenuButton);
 	uv_mode_hb->add_child(uv_menu);
-	uv_mode_hb->set_flat(true);
+	uv_menu->set_flat(true);
 	uv_menu->set_text(TTR("Edit"));
 	uv_menu->get_popup()->add_item(TTR("Copy Polygon to UV"), UVEDIT_POLYGON_TO_UV);
 	uv_menu->get_popup()->add_item(TTR("Copy UV to Polygon"), UVEDIT_UV_TO_POLYGON);

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -1352,6 +1352,7 @@ Polygon2DEditor::Polygon2DEditor() {
 
 	uv_menu = memnew(MenuButton);
 	uv_mode_hb->add_child(uv_menu);
+	uv_mode_hb->set_flat(true);
 	uv_menu->set_text(TTR("Edit"));
 	uv_menu->get_popup()->add_item(TTR("Copy Polygon to UV"), UVEDIT_POLYGON_TO_UV);
 	uv_menu->get_popup()->add_item(TTR("Copy UV to Polygon"), UVEDIT_UV_TO_POLYGON);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3746,6 +3746,7 @@ ScriptEditor::ScriptEditor() {
 
 	file_menu = memnew(MenuButton);
 	file_menu->set_text(TTR("File"));
+	file_menu->set_flat(true);
 	file_menu->set_switch_on_hover(true);
 	file_menu->set_shortcut_context(this);
 	menu_hb->add_child(file_menu);
@@ -3805,12 +3806,14 @@ ScriptEditor::ScriptEditor() {
 
 	script_search_menu = memnew(MenuButton);
 	script_search_menu->set_text(TTR("Search"));
+	script_search_menu->set_flat(true);
 	script_search_menu->set_switch_on_hover(true);
 	script_search_menu->set_shortcut_context(this);
 	script_search_menu->get_popup()->connect("id_pressed", callable_mp(this, &ScriptEditor::_menu_option));
 	menu_hb->add_child(script_search_menu);
 
 	MenuButton *debug_menu_btn = memnew(MenuButton);
+	debug_menu_btn->set_flat(true);
 	menu_hb->add_child(debug_menu_btn);
 	debug_menu_btn->hide(); // Handled by EditorDebuggerNode below.
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -2128,6 +2128,7 @@ ScriptTextEditor::ScriptTextEditor() {
 
 	edit_menu = memnew(MenuButton);
 	edit_menu->set_text(TTR("Edit"));
+	edit_menu->set_flat(true);
 	edit_menu->set_switch_on_hover(true);
 	edit_menu->set_shortcut_context(this);
 
@@ -2145,11 +2146,13 @@ ScriptTextEditor::ScriptTextEditor() {
 
 	search_menu = memnew(MenuButton);
 	search_menu->set_text(TTR("Search"));
+	search_menu->set_flat(true);
 	search_menu->set_switch_on_hover(true);
 	search_menu->set_shortcut_context(this);
 
 	goto_menu = memnew(MenuButton);
 	goto_menu->set_text(TTR("Go To"));
+	goto_menu->set_flat(true);
 	goto_menu->set_switch_on_hover(true);
 	goto_menu->set_shortcut_context(this);
 

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -425,6 +425,7 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	HBoxContainer *file_hb = memnew(HBoxContainer);
 	vb->add_child(file_hb);
 	file_menu = memnew(MenuButton);
+	file_menu->set_flat(true);
 	file_menu->set_text(TTR("File"));
 	file_menu->get_popup()->add_item(TTR("New Shader"), FILE_NEW);
 	file_menu->get_popup()->add_item(TTR("New Shader Include"), FILE_NEW_INCLUDE);

--- a/editor/plugins/skeleton_2d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_2d_editor_plugin.cpp
@@ -98,6 +98,7 @@ Skeleton2DEditor::Skeleton2DEditor() {
 
 	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(options);
 
+	options->set_flat(true);
 	options->set_text(TTR("Skeleton2D"));
 	options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Skeleton2D"), SNAME("EditorIcons")));
 

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -718,6 +718,7 @@ void Skeleton3DEditor::create_editors() {
 	skeleton_options = memnew(MenuButton);
 	ne->add_control_to_menu_panel(skeleton_options);
 
+	skeleton_options->set_flat(true);
 	skeleton_options->set_text(TTR("Skeleton3D"));
 
 	// Skeleton options.

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -528,6 +528,7 @@ Sprite2DEditor::Sprite2DEditor() {
 
 	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(options);
 
+	options->set_flat(true);
 	options->set_text(TTR("Sprite2D"));
 
 	options->get_popup()->add_item(TTR("Convert to MeshInstance2D"), MENU_OPTION_CONVERT_TO_MESH_2D);

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -562,6 +562,7 @@ TextEditor::TextEditor() {
 	search_menu->set_shortcut_context(this);
 	edit_hb->add_child(search_menu);
 	search_menu->set_text(TTR("Search"));
+	search_menu->set_flat(true);
 	search_menu->set_switch_on_hover(true);
 	search_menu->get_popup()->connect("id_pressed", callable_mp(this, &TextEditor::_edit_option));
 
@@ -577,6 +578,7 @@ TextEditor::TextEditor() {
 	edit_menu->set_shortcut_context(this);
 	edit_hb->add_child(edit_menu);
 	edit_menu->set_text(TTR("Edit"));
+	edit_menu->set_flat(true);
 	edit_menu->set_switch_on_hover(true);
 	edit_menu->connect("about_to_popup", callable_mp(this, &TextEditor::_prepare_edit_menu));
 	edit_menu->get_popup()->connect("id_pressed", callable_mp(this, &TextEditor::_edit_option));
@@ -633,6 +635,7 @@ TextEditor::TextEditor() {
 	goto_menu->set_shortcut_context(this);
 	edit_hb->add_child(goto_menu);
 	goto_menu->set_text(TTR("Go To"));
+	goto_menu->set_flat(true);
 	goto_menu->set_switch_on_hover(true);
 	goto_menu->get_popup()->connect("id_pressed", callable_mp(this, &TextEditor::_edit_option));
 

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -1089,6 +1089,7 @@ TextShaderEditor::TextShaderEditor() {
 	edit_menu = memnew(MenuButton);
 	edit_menu->set_shortcut_context(this);
 	edit_menu->set_text(TTR("Edit"));
+	edit_menu->set_flat(true);
 	edit_menu->set_switch_on_hover(true);
 
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_undo"), EDIT_UNDO);
@@ -1114,6 +1115,7 @@ TextShaderEditor::TextShaderEditor() {
 	search_menu = memnew(MenuButton);
 	search_menu->set_shortcut_context(this);
 	search_menu->set_text(TTR("Search"));
+	search_menu->set_flat(true);
 	search_menu->set_switch_on_hover(true);
 
 	search_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/find"), SEARCH_FIND);
@@ -1125,6 +1127,7 @@ TextShaderEditor::TextShaderEditor() {
 	MenuButton *goto_menu = memnew(MenuButton);
 	goto_menu->set_shortcut_context(this);
 	goto_menu->set_text(TTR("Go To"));
+	goto_menu->set_flat(true);
 	goto_menu->set_switch_on_hover(true);
 	goto_menu->get_popup()->connect("id_pressed", callable_mp(this, &TextShaderEditor::_menu_option));
 
@@ -1141,6 +1144,7 @@ TextShaderEditor::TextShaderEditor() {
 
 	help_menu = memnew(MenuButton);
 	help_menu->set_text(TTR("Help"));
+	help_menu->set_flat(true);
 	help_menu->set_switch_on_hover(true);
 	help_menu->get_popup()->add_item(TTR("Online Docs"), HELP_DOCS);
 	help_menu->get_popup()->connect("id_pressed", callable_mp(this, &TextShaderEditor::_menu_option));

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -1430,6 +1430,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	menu_bar->add_child(push_button);
 
 	extra_options = memnew(MenuButton);
+	extra_options->set_flat(true);
 	extra_options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 	extra_options->get_popup()->connect(SNAME("about_to_popup"), callable_mp(this, &VersionControlEditorPlugin::_update_extra_options));
 	extra_options->get_popup()->connect(SNAME("id_pressed"), callable_mp(this, &VersionControlEditorPlugin::_extra_option_selected));

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -5161,6 +5161,7 @@ VisualShaderEditor::VisualShaderEditor() {
 
 	varying_button = memnew(MenuButton);
 	varying_button->set_text(TTR("Manage Varyings"));
+	varying_button->set_flat(true);
 	varying_button->set_switch_on_hover(true);
 	graph->get_zoom_hbox()->add_child(varying_button);
 
@@ -5243,6 +5244,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	tools = memnew(MenuButton);
 	filter_hb->add_child(tools);
 	tools->set_tooltip_text(TTR("Options"));
+	tools->set_flat(true);
 	tools->get_popup()->connect("id_pressed", callable_mp(this, &VisualShaderEditor::_tools_menu_option));
 	tools->get_popup()->add_item(TTR("Expand All"), EXPAND_ALL);
 	tools->get_popup()->add_item(TTR("Collapse All"), COLLAPSE_ALL);

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -243,7 +243,6 @@ void MenuButton::set_disable_shortcuts(bool p_disabled) {
 
 MenuButton::MenuButton(const String &p_text) :
 		Button(p_text) {
-	set_flat(true);
 	set_toggle_mode(true);
 	set_disable_shortcuts(false);
 	set_process_shortcut_input(true);


### PR DESCRIPTION
This fixes behavior that is confusing to end users (evidenced by existence of #30768 and related issues) where MenuButtons don't work/look like other buttons by default.

~~I've only removed the default setting without changing the editor theme/appearance at all, so this PR does change how MenuButtons look in the editor.
With this PR, when hovered they go from this:~~
![image](https://user-images.githubusercontent.com/66881186/215602376-63381661-8d5d-4a7e-9b54-8bbbce3179a4.png)
~~To this:~~
![image](https://user-images.githubusercontent.com/66881186/215602002-8cd261f9-cfb8-405d-99f2-05c5c81750f3.png)
~~In master they go from this:~~
![image](https://user-images.githubusercontent.com/66881186/215602160-e92500e1-b965-4434-99f3-7b97090a7f7d.png)
~~To this (the "View" text brightened up a little):~~
![image](https://user-images.githubusercontent.com/66881186/215602081-6df1907d-2d06-4f74-b9e1-6fdee1b4e8a8.png)

~~At a glance this doesn't look easy to fix just by changing the editor theme, maybe setting `flat=false` on the editor menu buttons in code is a better way to fix it?~~

Added code to manually give every MenuButton the correct `flat` value, this PR no longer changes the look of the editor in any way.