### PR TITLE
Fix broken bottom panel switching

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -581,6 +581,7 @@ void EditorNode::_notification(int p_what) {
 
 			ResourceImporterTexture::get_singleton()->update_imports();
 
+			bottom_panel_updating = false;
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
@@ -5601,12 +5602,16 @@ void EditorNode::remove_bottom_panel_item(Control *p_item) {
 }
 
 void EditorNode::_bottom_panel_switch(bool p_enable, int p_idx) {
+	if (bottom_panel_updating) {
+		return;
+	}
 	ERR_FAIL_INDEX(p_idx, bottom_panel_items.size());
 
 	if (bottom_panel_items[p_idx].control->is_visible() == p_enable) {
 		return;
 	}
 
+	bottom_panel_updating = true;
 	if (p_enable) {
 		for (int i = 0; i < bottom_panel_items.size(); i++) {
 			bottom_panel_items[i].button->set_pressed(i == p_idx);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -460,6 +460,7 @@ private:
 	EditorToaster *editor_toaster = nullptr;
 	LinkButton *version_btn = nullptr;
 	Button *bottom_panel_raise = nullptr;
+	bool bottom_panel_updating = false;
 
 	Tree *disk_changed_list = nullptr;
 	ConfirmationDialog *disk_changed = nullptr;


### PR DESCRIPTION
- Fixes #72389
- Fixes #72332
- Fixes #70705

The cause of the crash is simple recursion. Switching events bound to buttons on the bottom panel were being called recursively by inspector updates.

The inability to transition to the animation tab is due to the inspector update, which can be resolved by the restriction that bottom tab switching is allowed only once in the same frame. This means that the pending update method of #68498 cannot be used.
