### PR TITLE
Added methods to OpenXR interface to set which action sets are active

### DIFF
--- a/modules/openxr/doc_classes/OpenXRInterface.xml
+++ b/modules/openxr/doc_classes/OpenXRInterface.xml
@@ -11,10 +11,31 @@
 		<link title="Setting up XR">$DOCS_URL/tutorials/xr/setting_up_xr.html</link>
 	</tutorials>
 	<methods>
+		<method name="get_action_sets" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns a list of action sets registered with Godot (loaded from the action map at runtime).
+			</description>
+		</method>
 		<method name="get_available_display_refresh_rates" qualifiers="const">
 			<return type="Array" />
 			<description>
 				Returns display refresh rates supported by the current HMD. Only returned if this feature is supported by the OpenXR runtime and after the interface has been initialized.
+			</description>
+		</method>
+		<method name="is_action_set_active" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="name" type="String" />
+			<description>
+				Returns [code]true[/code] if the given action set is active.
+			</description>
+		</method>
+		<method name="set_action_set_active">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="active" type="bool" />
+			<description>
+				Sets the given action set as active or inactive.
 			</description>
 		</method>
 	</methods>

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -47,6 +47,10 @@ void OpenXRInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_display_refresh_rate", "refresh_rate"), &OpenXRInterface::set_display_refresh_rate);
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "display_refresh_rate"), "set_display_refresh_rate", "get_display_refresh_rate");
 
+	ClassDB::bind_method(D_METHOD("is_action_set_active", "name"), &OpenXRInterface::is_action_set_active);
+	ClassDB::bind_method(D_METHOD("set_action_set_active", "name", "active"), &OpenXRInterface::set_action_set_active);
+	ClassDB::bind_method(D_METHOD("get_action_sets"), &OpenXRInterface::get_action_sets);
+
 	ClassDB::bind_method(D_METHOD("get_available_display_refresh_rates"), &OpenXRInterface::get_available_display_refresh_rates);
 }
 
@@ -619,6 +623,38 @@ Array OpenXRInterface::get_available_display_refresh_rates() const {
 	} else {
 		return openxr_api->get_available_display_refresh_rates();
 	}
+}
+
+bool OpenXRInterface::is_action_set_active(const String &p_action_set) const {
+	for (ActionSet *action_set : action_sets) {
+		if (action_set->action_set_name == p_action_set) {
+			return action_set->is_active;
+		}
+	}
+
+	WARN_PRINT("OpenXR: Unknown action set " + p_action_set);
+	return false;
+}
+
+void OpenXRInterface::set_action_set_active(const String &p_action_set, bool p_active) {
+	for (ActionSet *action_set : action_sets) {
+		if (action_set->action_set_name == p_action_set) {
+			action_set->is_active = p_active;
+			return;
+		}
+	}
+
+	WARN_PRINT("OpenXR: Unknown action set " + p_action_set);
+}
+
+Array OpenXRInterface::get_action_sets() const {
+	Array arr;
+
+	for (ActionSet *action_set : action_sets) {
+		arr.push_back(action_set->action_set_name);
+	}
+
+	return arr;
 }
 
 Size2 OpenXRInterface::get_render_target_size() {

--- a/modules/openxr/openxr_interface.h
+++ b/modules/openxr/openxr_interface.h
@@ -123,6 +123,10 @@ public:
 	void set_display_refresh_rate(float p_refresh_rate);
 	Array get_available_display_refresh_rates() const;
 
+	bool is_action_set_active(const String &p_action_set) const;
+	void set_action_set_active(const String &p_action_set, bool p_active);
+	Array get_action_sets() const;
+
 	virtual Size2 get_render_target_size() override;
 	virtual uint32_t get_view_count() override;
 	virtual Transform3D get_camera_transform() override;


### PR DESCRIPTION
In writing the manual about the action sets I realized I had forgotten to add this into the interface.

In OpenXR only one action can be assigned to an input. If you want your trigger to shoot your gun in the game, but select a menu option in a menu, you need an action set for your game, and an action set for your menu and only one of the two action sets should be active.

If both are active the action belonging to the action set with the highest priority will react to the trigger.

However there was no mechanism to activate/deactivate action sets.. Now there is :)