### PR TITLE
Don't generate CSGPolygon3D shape before the assigned path is inside tree

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -558,7 +558,7 @@ void CSGShape3D::_notification(int p_what) {
 				set_collision_layer(collision_layer);
 				set_collision_mask(collision_mask);
 				set_collision_priority(collision_priority);
-				_update_collision_faces();
+				_make_dirty();
 			}
 		} break;
 
@@ -1763,7 +1763,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 			}
 		}
 
-		if (!path) {
+		if (!path || !path->is_inside_tree()) {
 			return new_brush;
 		}
 


### PR DESCRIPTION
Fixes #71240

Within the `NOTIFICATION_ENTER_TREE`, we don't know at this point if the assigned `path` node has actually entered the tree. So I removed the `_update_collision_faces()` call here, and replaced it by a `_make_dirty()` call, like it's done in the `set_use_collision` method, so the update is deferred.

Also I added a small check inside the `_build_brush()` to return an empty brush if the `path` node is not inside tree.