### PR TITLE
Remove MIN_CAPACITY_INDEX from HashSet and HashMap

### DIFF
--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -67,7 +67,6 @@ template <class TKey, class TValue,
 		class Allocator = DefaultTypedAllocator<HashMapElement<TKey, TValue>>>
 class HashMap {
 public:
-	static constexpr uint32_t MIN_CAPACITY_INDEX = 2; // Use a prime.
 	static constexpr float MAX_OCCUPANCY = 0.75;
 	static constexpr uint32_t EMPTY_HASH = 0;
 
@@ -160,8 +159,7 @@ private:
 	void _resize_and_rehash(uint32_t p_new_capacity_index) {
 		uint32_t old_capacity = hash_table_size_primes[capacity_index];
 
-		// Capacity can't be 0.
-		capacity_index = MAX((uint32_t)MIN_CAPACITY_INDEX, p_new_capacity_index);
+		capacity_index = MAX(uint32_t(0), p_new_capacity_index);
 
 		uint32_t capacity = hash_table_size_primes[capacity_index];
 
@@ -560,7 +558,7 @@ public:
 		reserve(p_initial_capacity);
 	}
 	HashMap() {
-		capacity_index = MIN_CAPACITY_INDEX;
+		capacity_index = 0;
 	}
 
 	uint32_t debug_get_hash(uint32_t p_index) {

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -51,7 +51,6 @@ template <class TKey,
 		class Comparator = HashMapComparatorDefault<TKey>>
 class HashSet {
 public:
-	static constexpr uint32_t MIN_CAPACITY_INDEX = 2; // Use a prime.
 	static constexpr float MAX_OCCUPANCY = 0.75;
 	static constexpr uint32_t EMPTY_HASH = 0;
 
@@ -140,8 +139,7 @@ private:
 	}
 
 	void _resize_and_rehash(uint32_t p_new_capacity_index) {
-		// Capacity can't be 0.
-		capacity_index = MAX((uint32_t)MIN_CAPACITY_INDEX, p_new_capacity_index);
+		capacity_index = MAX(uint32_t(0), p_new_capacity_index);
 
 		uint32_t capacity = hash_table_size_primes[capacity_index];
 
@@ -442,7 +440,7 @@ public:
 		reserve(p_initial_capacity);
 	}
 	HashSet() {
-		capacity_index = MIN_CAPACITY_INDEX;
+		capacity_index = 0;
 	}
 
 	void reset() {
@@ -458,7 +456,7 @@ public:
 			hash_to_key = nullptr;
 			key_to_hash = nullptr;
 		}
-		capacity_index = MIN_CAPACITY_INDEX;
+		capacity_index = 0;
 	}
 
 	~HashSet() {

--- a/tests/core/templates/test_hash_map.h
+++ b/tests/core/templates/test_hash_map.h
@@ -73,8 +73,55 @@ TEST_CASE("[HashMap] Erase via key") {
 	CHECK(!map.find(42));
 }
 
+TEST_CASE("[HashMap] Bulk insert and remove") {
+	HashMap<int, String> map;
+
+	for (int z = 0; z < 5; z++) {
+		for (int i = 0; i < 30; i++) {
+			CHECK(!map.has(29));
+			CHECK(!map.find(29));
+			CHECK(!map.has(i));
+			CHECK(!map.find(i));
+
+			if (z & 1) {
+				map.insert(i, itos(i));
+			} else {
+				map[i] = itos(i);
+			}
+
+			CHECK(map.has(0));
+			CHECK(map.find(0));
+			CHECK(map.has(i));
+			CHECK(map.find(i));
+			CHECK(map[0] == "0");
+			CHECK(map[i] == itos(i));
+		}
+		CHECK(map.size() == 30);
+
+		for (int i = 0; i < 30; i++) {
+			CHECK(map.has(29));
+			CHECK(map.find(29));
+			CHECK(map.has(i));
+			CHECK(map.find(i));
+			CHECK(map[29] == "29");
+			CHECK(map[i] == itos(i));
+
+			map.erase(i);
+
+			CHECK(!map.has(0));
+			CHECK(!map.find(0));
+			CHECK(!map.has(i));
+			CHECK(!map.find(i));
+		}
+		CHECK(map.size() == 0);
+	}
+}
+
 TEST_CASE("[HashMap] Size") {
 	HashMap<int, int> map;
+
+	CHECK(map.get_capacity() < 9);
+
 	map.insert(42, 84);
 	map.insert(123, 84);
 	map.insert(123, 84);

--- a/tests/core/templates/test_hash_set.h
+++ b/tests/core/templates/test_hash_set.h
@@ -162,6 +162,9 @@ TEST_CASE("[HashSet] Insert and erase half elements") {
 
 TEST_CASE("[HashSet] Size") {
 	HashSet<int> set;
+
+	CHECK(set.get_capacity() < 9);
+
 	set.insert(42);
 	set.insert(123);
 	set.insert(123);


### PR DESCRIPTION
Clean up what appears to be vestigial code from a time when HashSets and HashMaps stored capacity values directly. Currently, however, they use "capacity indexes" into a table in `core/templates/hashfuncs.h` that looks something like this:

```
const uint32_t hash_table_size_primes[HASH_TABLE_SIZE_MAX] = {
	5,
	13,
	23,
	47,
	...,
	402653189,
	805306457,
	1610612741,
};
```

In other words, what `MIN_CAPACITY_INDEX = 2` actually does is maintain a minimum capacity of 23 entries.

This patch changes the minimum capacity from 23 to 5, benefiting very small HashSets and HashMaps.