### PR TITLE
C#: Implement `IEquatable` in `Rid`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rid.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rid.cs
@@ -6,13 +6,17 @@ using Godot.NativeInterop;
 namespace Godot
 {
     /// <summary>
-    /// The Rid type is used to access the unique integer ID of a resource.
-    /// They are opaque, which means they do not grant access to the associated
-    /// resource by themselves. They are used by and with the low-level Server
-    /// classes such as <see cref="RenderingServer"/>.
+    /// The RID type is used to access a low-level resource by its unique ID.
+    /// RIDs are opaque, which means they do not grant access to the resource
+    /// by themselves. They are used by the low-level server classes, such as
+    /// <see cref="DisplayServer"/>, <see cref="RenderingServer"/>,
+    /// <see cref="TextServer"/>, etc.
+    ///
+    /// A low-level resource may correspond to a high-level <see cref="Resource"/>,
+    /// such as <see cref="Texture"/> or <see cref="Mesh"/>
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public readonly struct Rid
+    public readonly struct Rid : IEquatable<Rid>
     {
         private readonly ulong _id; // Default is 0
 
@@ -28,15 +32,73 @@ namespace Godot
             => _id = from is Resource res ? res.GetRid()._id : default;
 
         /// <summary>
-        /// Returns the ID of the referenced resource.
+        /// Returns the ID of the referenced low-level resource.
         /// </summary>
         /// <returns>The ID of the referenced resource.</returns>
         public ulong Id => _id;
 
         /// <summary>
+        /// Returns <see langword="true"/> if the <see cref="Rid"/> is not <c>0</c>.
+        /// </summary>
+        /// <returns>Whether or not the ID is valid.</returns>
+        public bool IsValid => _id != 0;
+
+        /// <summary>
+        /// Returns <see langword="true"/> if both <see cref="Rid"/>s are equal,
+        /// which means they both refer to the same low-level resource.
+        /// </summary>
+        /// <param name="left">The left RID.</param>
+        /// <param name="right">The right RID.</param>
+        /// <returns>Whether or not the RIDs are equal.</returns>
+        public static bool operator ==(Rid left, Rid right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> if the <see cref="Rid"/>s are not equal.
+        /// </summary>
+        /// <param name="left">The left RID.</param>
+        /// <param name="right">The right RID.</param>
+        /// <returns>Whether or not the RIDs are equal.</returns>
+        public static bool operator !=(Rid left, Rid right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> if this RID and <paramref name="obj"/> are equal.
+        /// </summary>
+        /// <param name="obj">The other object to compare.</param>
+        /// <returns>Whether or not the color and the other object are equal.</returns>
+        public override readonly bool Equals(object obj)
+        {
+            return obj is Rid other && Equals(other);
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> if the RIDs are equal.
+        /// </summary>
+        /// <param name="other">The other RID.</param>
+        /// <returns>Whether or not the RIDs are equal.</returns>
+        public readonly bool Equals(Rid other)
+        {
+            return _id == other.Id;
+        }
+
+        /// <summary>
+        /// Serves as the hash function for <see cref="Rid"/>.
+        /// </summary>
+        /// <returns>A hash code for this RID.</returns>
+        public override readonly int GetHashCode()
+        {
+            return HashCode.Combine(_id);
+        }
+
+        /// <summary>
         /// Converts this <see cref="Rid"/> to a string.
         /// </summary>
         /// <returns>A string representation of this Rid.</returns>
-        public override string ToString() => $"Rid({Id})";
+        public override string ToString() => $"RID({Id})";
     }
 }


### PR DESCRIPTION
- Implement `IEquatable` interface.
- Implement `==` and `!=` operators.
- Override `Equals` and `GetHashCode`.
- Add `IsValid` method.
- Fix `ToString` to follow Core.
- Sync documentation with Core.