### PR TITLE
Qualify Console's namespace to avoid mixup with plugin's objects

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotPluginsInitializerGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotPluginsInitializerGenerator.cs
@@ -48,7 +48,7 @@ namespace GodotPlugins.Game
             }
             catch (Exception e)
             {
-                Console.Error.WriteLine(e);
+                System.Console.Error.WriteLine(e);
                 return false.ToGodotBool();
             }
         }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotPluginsInitializerGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotPluginsInitializerGenerator.cs
@@ -48,7 +48,7 @@ namespace GodotPlugins.Game
             }
             catch (Exception e)
             {
-                System.Console.Error.WriteLine(e);
+                global::System.Console.Error.WriteLine(e);
                 return false.ToGodotBool();
             }
         }


### PR DESCRIPTION
Avoid project compilation error when a plugin contains a class called "Console":

    Godot.SourceGenerators\Godot.SourceGenerators.GodotPluginsInitializerGenerator\GodotPlugins.Game.generated.cs(32,25): error CS0117: 'Console' does not contain a definition for 'Error'


I believe this will fix an issue I had getting [godot-console](https://github.com/quentincaffeino/godot-console) to run on godot 4.

It's *very* minor as it will affect hardly any plugins(!), and I can hack around it on the godot-console side by adding
`public static TextWriter Error => System.Console.Error;` to its `Console` class.  Go wild with the triage.
