### PR TITLE
[Editor] Fix editor progress dialog auto closing on focus loss.

### DIFF
--- a/editor/progress_dialog.cpp
+++ b/editor/progress_dialog.cpp
@@ -257,6 +257,7 @@ ProgressDialog::ProgressDialog() {
 	add_child(main);
 	main->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	set_exclusive(true);
+	set_flag(Window::FLAG_POPUP, false);
 	last_progress_tick = 0;
 	singleton = this;
 	cancel_hb = memnew(HBoxContainer);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/72411
Fixes #72155