### PR TITLE
Restore script class cache if removed

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1137,7 +1137,7 @@ Array ProjectSettings::get_global_class_list() {
 
 	Ref<ConfigFile> cf;
 	cf.instantiate();
-	if (cf->load(get_project_data_path().path_join("global_script_class_cache.cfg")) == OK) {
+	if (cf->load(get_global_class_list_path()) == OK) {
 		script_classes = cf->get_value("", "list");
 	} else {
 #ifndef TOOLS_ENABLED
@@ -1148,11 +1148,15 @@ Array ProjectSettings::get_global_class_list() {
 	return script_classes;
 }
 
+String ProjectSettings::get_global_class_list_path() const {
+	return get_project_data_path().path_join("global_script_class_cache.cfg");
+}
+
 void ProjectSettings::store_global_class_list(const Array &p_classes) {
 	Ref<ConfigFile> cf;
 	cf.instantiate();
 	cf->set_value("", "list", p_classes);
-	cf->save(get_project_data_path().path_join("global_script_class_cache.cfg"));
+	cf->save(get_global_class_list_path());
 }
 
 bool ProjectSettings::has_custom_feature(const String &p_feature) const {

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -143,6 +143,7 @@ public:
 	Variant get_setting(const String &p_setting, const Variant &p_default_value = Variant()) const;
 	Array get_global_class_list();
 	void store_global_class_list(const Array &p_classes);
+	String get_global_class_list_path() const;
 
 	bool has_setting(String p_var) const;
 	String localize_path(const String &p_path) const;

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -369,6 +369,14 @@ void ScriptServer::save_global_classes() {
 	ProjectSettings::get_singleton()->store_global_class_list(gcarr);
 }
 
+bool ScriptServer::has_global_classes() {
+	return !global_classes.is_empty();
+}
+
+String ScriptServer::get_global_class_cache_file_path() {
+	return ProjectSettings::get_singleton()->get_global_class_list_path();
+}
+
 ////////////////////
 
 Variant ScriptInstance::call_const(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -91,6 +91,8 @@ public:
 	static void get_global_class_list(List<StringName> *r_global_classes);
 	static void get_inheriters_list(const StringName &p_base_type, List<StringName> *r_classes);
 	static void save_global_classes();
+	static bool has_global_classes();
+	static String get_global_class_cache_file_path();
 
 	static void init_languages();
 	static void finish_languages();

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1591,6 +1591,11 @@ void EditorFileSystem::_update_script_classes() {
 void EditorFileSystem::_update_pending_script_classes() {
 	if (!update_script_paths.is_empty()) {
 		_update_script_classes();
+	} else {
+		// In case the class cache file was removed somehow, regenerate it.
+		if (ScriptServer::has_global_classes() && !FileAccess::exists(ScriptServer::get_global_class_cache_file_path())) {
+			ScriptServer::save_global_classes();
+		}
 	}
 }
 

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -814,7 +814,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	HashSet<String> paths;
 	Vector<String> path_remaps;
 
-	paths.insert(ProjectSettings::get_singleton()->get_project_data_path().path_join("global_script_class_cache.cfg"));
+	paths.insert(ProjectSettings::get_singleton()->get_global_class_list_path());
 	if (p_preset->get_export_filter() == EditorExportPreset::EXPORT_ALL_RESOURCES) {
 		//find stuff
 		_export_find_resources(EditorFileSystem::get_singleton()->get_filesystem(), paths);


### PR DESCRIPTION
I have no idea why anyone would do this, but this fixes it.

Fixes #72154. Depends on #72444 being merged to function properly.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
