### PR TITLE
Disable incompatible rendering methods in the project manager

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -742,7 +742,16 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// TRANSLATORS: Project Manager here refers to the tool used to create/manage Godot projects.
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "project_manager/sorting_order", 0, "Last Edited,Name,Path")
+
+#if defined(WEB_ENABLED)
+	// Web platform only supports `gl_compatibility`.
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_NONE, "project_manager/default_renderer", "gl_compatibility", "forward_plus,mobile,gl_compatibility")
+#elif defined(ANDROID_ENABLED)
+	// Use more suitable rendering method by default.
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_NONE, "project_manager/default_renderer", "mobile", "forward_plus,mobile,gl_compatibility")
+#else
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_NONE, "project_manager/default_renderer", "forward_plus", "forward_plus,mobile,gl_compatibility")
+#endif
 
 	if (p_extra_config.is_valid()) {
 		if (p_extra_config->has_section("init_projects") && p_extra_config->has_section_key("init_projects", "list")) {

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -907,33 +907,41 @@ public:
 		Button *rs_button = memnew(CheckBox);
 		rs_button->set_button_group(renderer_button_group);
 		rs_button->set_text(TTR("Forward+"));
+#if defined(WEB_ENABLED)
+		rs_button->set_disabled(true);
+#endif
 		rs_button->set_meta(SNAME("rendering_method"), "forward_plus");
 		rs_button->connect("pressed", callable_mp(this, &ProjectDialog::_renderer_selected));
 		rvb->add_child(rs_button);
 		if (default_renderer_type == "forward_plus") {
 			rs_button->set_pressed(true);
 		}
-
 		rs_button = memnew(CheckBox);
 		rs_button->set_button_group(renderer_button_group);
 		rs_button->set_text(TTR("Mobile"));
+#if defined(WEB_ENABLED)
+		rs_button->set_disabled(true);
+#endif
 		rs_button->set_meta(SNAME("rendering_method"), "mobile");
 		rs_button->connect("pressed", callable_mp(this, &ProjectDialog::_renderer_selected));
 		rvb->add_child(rs_button);
 		if (default_renderer_type == "mobile") {
 			rs_button->set_pressed(true);
 		}
-
 		rs_button = memnew(CheckBox);
 		rs_button->set_button_group(renderer_button_group);
 		rs_button->set_text(TTR("Compatibility"));
+#if !defined(GLES3_ENABLED)
+		rs_button->set_disabled(true);
+#endif
 		rs_button->set_meta(SNAME("rendering_method"), "gl_compatibility");
 		rs_button->connect("pressed", callable_mp(this, &ProjectDialog::_renderer_selected));
 		rvb->add_child(rs_button);
+#if defined(GLES3_ENABLED)
 		if (default_renderer_type == "gl_compatibility") {
 			rs_button->set_pressed(true);
 		}
-
+#endif
 		rshc->add_child(memnew(VSeparator));
 
 		// Right hand side, used for text explaining each choice.


### PR DESCRIPTION
The project manager can now only create projects that use a rendering method compatible with the current platform. Rendering methods that are disabled at build-time are also grayed out.

While it is possible in theory to create a project using Forward+ on Android or HTML5 (thanks to the automatic fallback), it will look different once edited on a desktop platform.

## Preview

Desktop | Mobile | Web
-|-|-
![Screenshot_20230131_172311](https://user-images.githubusercontent.com/180032/215820110-9171a9a4-7476-494a-8f34-2310a4258016.png) | ![Screenshot_20230131_172241](https://user-images.githubusercontent.com/180032/215820105-71b0cab3-ab52-441a-87e3-98d0df354172.png) | ![Screenshot_20230131_172331](https://user-images.githubusercontent.com/180032/215820112-cd3b631e-56e4-4160-9675-bec76e1482f5.png)