### PR TITLE
Check if Skeleton exists before reading when calculating blend shapes

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -986,7 +986,10 @@ void MeshStorage::update_mesh_instances() {
 			push_constant.skin_stride = (mi->mesh->surfaces[i]->skin_buffer_size / mi->mesh->surfaces[i]->vertex_count) / 4;
 			push_constant.skin_weight_offset = (mi->mesh->surfaces[i]->format & RS::ARRAY_FLAG_USE_8_BONE_WEIGHTS) ? 4 : 2;
 
-			Transform2D transform = mi->canvas_item_transform_2d.affine_inverse() * sk->base_transform_2d;
+			Transform2D transform = Transform2D();
+			if (sk && sk->use_2d) {
+				transform = mi->canvas_item_transform_2d.affine_inverse() * sk->base_transform_2d;
+			}
 			push_constant.skeleton_transform_x[0] = transform.columns[0][0];
 			push_constant.skeleton_transform_x[1] = transform.columns[0][1];
 			push_constant.skeleton_transform_y[0] = transform.columns[1][0];


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/72424

In the RD backend ``sk`` may not be valid as we may be updating blend shapes but not Skeleton. We also check if 2D so we avoid the calculation when doing 3D