### PR TITLE
import: Prevent _Wheel nodes not parented to VehicleBody3D

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -857,11 +857,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 		s->set_transform(Transform3D());
 
 		p_node = bv;
-	} else if (_teststr(name, "wheel")) {
-		if (isroot) {
-			return p_node;
-		}
-
+	} else if (_teststr(name, "wheel") && !isroot && Object::cast_to<VehicleBody3D>(p_node->get_parent())) {
 		Node *owner = p_node->get_owner();
 		Node3D *s = Object::cast_to<Node3D>(p_node);
 		VehicleWheel3D *bv = memnew(VehicleWheel3D);


### PR DESCRIPTION
Check that `_Wheel` node satisfies the requirement of being a direct child of a `VehicleBody3D` before converting to a `VehicleWheel3D`.

This seems like a reasonable fix, since the current behavior will cause an error by adding the `VehicleWheel3D` without complying with the node's constraint of being a direct child of a vehicle.
![image](https://user-images.githubusercontent.com/39946030/215871493-905ab753-0ccc-4d10-8e8e-1a4c2fce1b07.png)

This is also one of the few suffixes recognized by Godot that is also a common english word, so it is more likely to be encountered by users.
The other two english word node types are "vehicle" and "rigid", but these also have specific meaning in terms of physics.


Fixes #72419

