### PR TITLE
Always show caret when moving in LineEdit

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -84,6 +84,7 @@ void LineEdit::_move_caret_left(bool p_select, bool p_move_by_word) {
 	}
 
 	shift_selection_check_post(p_select);
+	_reset_caret_blink_timer();
 }
 
 void LineEdit::_move_caret_right(bool p_select, bool p_move_by_word) {
@@ -116,6 +117,7 @@ void LineEdit::_move_caret_right(bool p_select, bool p_move_by_word) {
 	}
 
 	shift_selection_check_post(p_select);
+	_reset_caret_blink_timer();
 }
 
 void LineEdit::_move_caret_start(bool p_select) {


### PR DESCRIPTION
This just resets the blinking timer and shows the caret when moving left/right, so that you know exactly where you are when moving with the arrow keys.

**Old behaviour:**

https://user-images.githubusercontent.com/8750135/215870661-a1009a0c-f7ae-4db0-848f-55860c7fd115.mp4

**New behaviour:**

https://user-images.githubusercontent.com/8750135/215870696-3d79c18f-9e0e-4917-a4ce-80e6dbc1e7d0.mp4


