### PR TITLE
Fix AnimatableBody3D not being movable in editor

### DIFF
--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -333,6 +333,11 @@ void AnimatableBody3D::_body_state_changed(PhysicsDirectBodyState3D *p_state) {
 }
 
 void AnimatableBody3D::_notification(int p_what) {
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
+#endif
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			last_valid_transform = get_global_transform();


### PR DESCRIPTION
Fixes #72416

This bug was introduced in #67847, which enables transform notifications in editor for collision objects, but AnimatableBody3D has logic in place which reverts the position. The proposed solution is to disable AnimatableBody3D's handling of notifications when running in editor.

Here's the relevant snippets that causes the problem in the first place:
https://github.com/godotengine/godot/blob/0810ecaafdbee3ea747219e6ab3a8de5d2216a09/scene/3d/collision_object_3d.cpp#L47-L49
https://github.com/godotengine/godot/blob/0810ecaafdbee3ea747219e6ab3a8de5d2216a09/scene/3d/physics_body_3d.cpp#L347-L358