### PR TITLE
Avoid leaking texture->tex_id when clearing render targets

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1822,6 +1822,10 @@ void TextureStorage::_clear_render_target(RenderTarget *rt) {
 		rt->overridden.color = RID();
 	} else if (rt->color) {
 		glDeleteTextures(1, &rt->color);
+		if (rt->texture.is_valid()) {
+			Texture *tex = get_texture(rt->texture);
+			tex->tex_id = 0;
+		}
 	}
 	rt->color = 0;
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/71951

Might help: https://github.com/godotengine/godot/issues/68814
Might help: https://github.com/godotengine/godot/issues/72224

When a texture is attached to a render target its ``tex_id`` is just a copy of ``rt->color`` so when ``color`` is freed the ``tex_id`` is no longer valid. When freeing a render target ``texture_free()`` is called so the ``tex_id`` would get reset to ``0``, but in some rare cases ``_clear_render_target`` would free ``color`` and the ``tex_id`` reference would get left. 

The bug occured in the following situation:
1. A render target is allocated (for a PopupMenu)
2. The render target is cleared but not freed (perhaps is size is set to 0,0)
3. The tex_id used by the render target is given to a new resource (i.e. the Sprite's texture)
4. The render target is freed which also frees the texture. Since the id is a valid GL_id it frees the Sprite's texture and leaves a dangling GL_id on the sprite.
5. When the Sprite is renderered it uses an invalid GL_id which results in undefined behaviour