### PR TITLE
Fix `scroll_offset_changed` signal doesn't fired when panning `GraphEdit`

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -264,10 +264,6 @@ void GraphEdit::_scroll_moved(double) {
 	top_layer->queue_redraw();
 	minimap->queue_redraw();
 	queue_redraw();
-
-	if (!setting_scroll_ofs) { //in godot, signals on change value are avoided as a convention
-		emit_signal(SNAME("scroll_offset_changed"), get_scroll_ofs());
-	}
 }
 
 void GraphEdit::_update_scroll_offset() {
@@ -290,6 +286,10 @@ void GraphEdit::_update_scroll_offset() {
 	connections_layer->set_position(-Point2(h_scroll->get_value(), v_scroll->get_value()));
 	set_block_minimum_size_adjust(false);
 	awaiting_scroll_offset_update = false;
+
+	if (!setting_scroll_ofs) { //in godot, signals on change value are avoided as a convention
+		emit_signal(SNAME("scroll_offset_changed"), get_scroll_ofs());
+	}
 }
 
 void GraphEdit::_update_scroll() {


### PR DESCRIPTION
Fixes #72479.

This is causing a bug where scroll_offset is not recorded and the AnimationBlendTreeEditor position is reset every time a node is connected.