### PR TITLE
Prevent wrong unedit when clicking editor viewport

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2136,6 +2136,13 @@ void EditorNode::edit_item(Object *p_object, Object *p_editing_owner) {
 	}
 }
 
+void EditorNode::push_node_item(Node *p_node) {
+	if (p_node || Object::cast_to<Node>(InspectorDock::get_inspector_singleton()->get_edited_object())) {
+		// Don't push null if the currently edited object is not a Node.
+		push_item(p_node);
+	}
+}
+
 void EditorNode::push_item(Object *p_object, const String &p_property, bool p_inspector_only) {
 	if (!p_object) {
 		InspectorDock::get_inspector_singleton()->edit(nullptr);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -798,6 +798,7 @@ public:
 
 	void push_item(Object *p_object, const String &p_property = "", bool p_inspector_only = false);
 	void edit_item(Object *p_object, Object *p_editing_owner);
+	void push_node_item(Node *p_node);
 	void hide_unused_editors(const Object *p_editing_owner = nullptr);
 
 	void select_editor_by_name(const String &p_name);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1427,7 +1427,14 @@ void SceneTreeDock::_script_open_request(const Ref<Script> &p_script) {
 }
 
 void SceneTreeDock::_push_item(Object *p_object) {
-	EditorNode::get_singleton()->push_item(p_object);
+	Node *node = Object::cast_to<Node>(p_object);
+	if (node || !p_object) {
+		// Assume that null object is a Node.
+		EditorNode::get_singleton()->push_node_item(node);
+	} else {
+		EditorNode::get_singleton()->push_item(p_object);
+	}
+
 	if (p_object == nullptr) {
 		EditorNode::get_singleton()->hide_unused_editors(this);
 	}


### PR DESCRIPTION
Fixes part of #72271

This code prevents clearing the inspector in these two cases:
- user edited an external resource (e.g. Theme file) and clicks 2D viewport
- user selected a node, and then did the same as above

When you click in empty space in the editor viewport, the SceneTreeDock receives empty selection and pushes null node to edit. However in the two cases I mentioned above, the "null edit" could result in some editors getting closed (in case of the mentioned issue - the Theme editor), even though the event had nothing to do with their editing context. After this PR, the inspector will be cleared only if the selection is cleared while a node is currently being inspected.