### PR TITLE
Fix race conditions in PhysicsServers wrappers

### DIFF
--- a/servers/physics_server_2d_wrap_mt.h
+++ b/servers/physics_server_2d_wrap_mt.h
@@ -261,10 +261,7 @@ public:
 
 	FUNC2(body_set_pickable, RID, bool);
 
-	bool body_test_motion(RID p_body, const MotionParameters &p_parameters, MotionResult *r_result = nullptr) override {
-		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), false);
-		return physics_server_2d->body_test_motion(p_body, p_parameters, r_result);
-	}
+	FUNC3R(bool, body_test_motion, RID, const MotionParameters &, MotionResult *);
 
 	// this function only works on physics process, errors and returns null otherwise
 	PhysicsDirectBodyState2D *body_get_direct_state(RID p_body) override {

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -260,10 +260,7 @@ public:
 
 	FUNC2(body_set_ray_pickable, RID, bool);
 
-	bool body_test_motion(RID p_body, const MotionParameters &p_parameters, MotionResult *r_result = nullptr) override {
-		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), false);
-		return physics_server_3d->body_test_motion(p_body, p_parameters, r_result);
-	}
+	FUNC3R(bool, body_test_motion, RID, const MotionParameters &, MotionResult *);
 
 	// this function only works on physics process, errors and returns null otherwise
 	PhysicsDirectBodyState3D *body_get_direct_state(RID p_body) override {


### PR DESCRIPTION
When Physics runs in a separated thread, a race condition may occur in ``GodotCollisionObjectXD::_update_shapes()``, causing two nodes of the same shape to be created in BVH tree.

This PR solves this by adding ``PhysicsServerXDWrapMT::physics_server_xd->body_test_motion()`` in the ``PhysicsServerXDWrapMT::command_queue``, avoiding ``_update_shapes()`` to run in the main thread.

Fixes #70491 