### PR TITLE
Fix loading of binary resources with typed arrays

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -832,6 +832,18 @@ Error ResourceLoaderBinary::load() {
 				}
 			}
 
+			if (value.get_type() == Variant::ARRAY) {
+				Array set_array = value;
+				bool is_get_valid = false;
+				Variant get_value = res->get(name, &is_get_valid);
+				if (is_get_valid && get_value.get_type() == Variant::ARRAY) {
+					Array get_array = get_value;
+					if (!set_array.is_same_typed(get_array)) {
+						value = Array(set_array, get_array.get_typed_builtin(), get_array.get_typed_class_name(), get_array.get_typed_script());
+					}
+				}
+			}
+
 			if (set_valid) {
 				res->set(name, value);
 			}


### PR DESCRIPTION
Fixes a regression introduced by #69248 where binary resources with typed arrays would fail to have those arrays set upon load. Uses fix mentioned in https://github.com/godotengine/godot/pull/69248#issuecomment-1410028605.