### PR TITLE
Fix shader failure when using non-const initializer on a constant

### DIFF
--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -953,7 +953,7 @@ private:
 
 	StringName shader_type_identifier;
 	StringName current_function;
-	bool last_const = false;
+	bool is_const_decl = false;
 	StringName last_name;
 	bool is_shader_inc = false;
 


### PR DESCRIPTION
Prevent using non-const (or uniform) expression in constant initializers:

```
uniform float scalar_uniform;

const float scalar = test; // INCORRECT
```

```
uniform float scalar_uniform;
const float scalar_constant = 1.0;

const vec3 v= vec3(0, 0, scalar_uniform); // INCORRECT
const vec3 v2= vec3(0, 0, scalar_constant); // CORRECT
```

That will also prevent using them in a local constants:

```
uniform float scalar_uniform;

void fragment() {
	const vec3 v= vec3(0, 0, scalar_uniform); // INCORRECT
}
```
That would lead to a compatibility breakage, because shaders like this seems working correctly (at least on Vulkan renderer) - but, for example, [SHADERed](https://shadered.org/) accept it as error:

![image](https://user-images.githubusercontent.com/3036176/215990721-6991b6e4-8368-4fcf-aab7-3fd58e2a6739.png)

- Fix https://github.com/godotengine/godot/issues/72466
