### PR TITLE
[X11] Fix IME subwindow in the popup not getting input focus.

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4897,7 +4897,7 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 	//   handling decorations and placement.
 	//   On the other hand, focus changes need to be handled manually when this is set.
 	// - save_under is a hint for the WM to keep the content of windows behind to avoid repaint.
-	if (wd.is_popup || wd.no_focus) {
+	if (wd.no_focus) {
 		windowAttributes.override_redirect = True;
 		windowAttributes.save_under = True;
 		valuemask |= CWOverrideRedirect | CWSaveUnder;

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -840,6 +840,9 @@ void PopupMenu::_notification(int p_what) {
 				float pm_delay = pm->get_submenu_popup_delay();
 				set_submenu_popup_delay(pm_delay);
 			}
+			if (!is_embedded()) {
+				set_flag(FLAG_NO_FOCUS, true);
+			}
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED:


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/72074

Probably not the best solution, might cause input popups to fully take focus (parent window title bar turning gray while popup is active), but I have not found a better one.
