### PR TITLE
GDScript: Fix disassembly of typed array assignment and construction

### DIFF
--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -317,7 +317,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				text += " = ";
 				text += DADDR(2);
 
-				incr += 3;
+				incr += 6;
 			} break;
 			case OPCODE_ASSIGN_TYPED_NATIVE: {
 				text += "assign typed native (";
@@ -434,7 +434,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				int instr_var_args = _code_ptr[++ip];
 				int argc = _code_ptr[ip + 1 + instr_var_args];
 
-				Ref<Script> script_type = get_constant(_code_ptr[ip + argc + 2]);
+				Ref<Script> script_type = get_constant(_code_ptr[ip + argc + 2] & GDScriptFunction::ADDR_MASK);
 				Variant::Type builtin_type = (Variant::Type)_code_ptr[ip + argc + 4];
 				StringName native_type = get_global_name(_code_ptr[ip + argc + 5]);
 
@@ -463,7 +463,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 				text += "]";
 
-				incr += 4 + instr_var_args;
+				incr += 6 + argc;
 			} break;
 			case OPCODE_CONSTRUCT_DICTIONARY: {
 				int instr_var_args = _code_ptr[++ip];


### PR DESCRIPTION
Continuation of #69248 and #72490.

In `OPCODE_ASSIGN_TYPED_ARRAY` size was changed to include typed array info.

In `OPCODE_CONSTRUCT_TYPED_ARRAY` use `ADDR_MASK` on script address.

In `OPCODE_CONSTRUCT_TYPED_ARRAY` use `6 + argc` instead of `4 + instr_var_args` (which is the same as `instr_var_args` because it is `2 + argc`, but consistent with `OPCODE_CONSTRUCT_ARRAY` and majority of others).