### PR TITLE
Consistent with NodeTimeSeek parameters OtherNodes

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -1111,7 +1111,7 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	add_options.push_back(AddOption("Add3", "AnimationNodeAdd3", 3));
 	add_options.push_back(AddOption("Blend2", "AnimationNodeBlend2", 2));
 	add_options.push_back(AddOption("Blend3", "AnimationNodeBlend3", 3));
-	add_options.push_back(AddOption("Seek", "AnimationNodeTimeSeek", 1));
+	add_options.push_back(AddOption("TimeSeek", "AnimationNodeTimeSeek", 1));
 	add_options.push_back(AddOption("TimeScale", "AnimationNodeTimeScale", 1));
 	add_options.push_back(AddOption("Transition", "AnimationNodeTransition"));
 	add_options.push_back(AddOption("BlendTree", "AnimationNodeBlendTree"));

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -518,7 +518,7 @@ void AnimationNodeBlend2::get_parameter_list(List<PropertyInfo> *r_list) const {
 }
 
 Variant AnimationNodeBlend2::get_parameter_default_value(const StringName &p_parameter) const {
-	return 0; //for blend amount
+	return 0; // For blend amount.
 }
 
 String AnimationNodeBlend2::get_caption() const {
@@ -531,7 +531,7 @@ double AnimationNodeBlend2::process(double p_time, bool p_seek, bool p_is_extern
 	double rem0 = blend_input(0, p_time, p_seek, p_is_external_seeking, 1.0 - amount, FILTER_BLEND, sync);
 	double rem1 = blend_input(1, p_time, p_seek, p_is_external_seeking, amount, FILTER_PASS, sync);
 
-	return amount > 0.5 ? rem1 : rem0; //hacky but good enough
+	return amount > 0.5 ? rem1 : rem0; // Hacky but good enough.
 }
 
 bool AnimationNodeBlend2::has_filter() const {
@@ -553,7 +553,7 @@ void AnimationNodeBlend3::get_parameter_list(List<PropertyInfo> *r_list) const {
 }
 
 Variant AnimationNodeBlend3::get_parameter_default_value(const StringName &p_parameter) const {
-	return 0; //for blend amount
+	return 0; // For blend amount.
 }
 
 String AnimationNodeBlend3::get_caption() const {
@@ -566,7 +566,7 @@ double AnimationNodeBlend3::process(double p_time, bool p_seek, bool p_is_extern
 	double rem1 = blend_input(1, p_time, p_seek, p_is_external_seeking, 1.0 - ABS(amount), FILTER_IGNORE, sync);
 	double rem2 = blend_input(2, p_time, p_seek, p_is_external_seeking, MAX(0, amount), FILTER_IGNORE, sync);
 
-	return amount > 0.5 ? rem2 : (amount < -0.5 ? rem0 : rem1); //hacky but good enough
+	return amount > 0.5 ? rem2 : (amount < -0.5 ? rem0 : rem1); // Hacky but good enough.
 }
 
 void AnimationNodeBlend3::_bind_methods() {
@@ -585,7 +585,7 @@ void AnimationNodeTimeScale::get_parameter_list(List<PropertyInfo> *r_list) cons
 }
 
 Variant AnimationNodeTimeScale::get_parameter_default_value(const StringName &p_parameter) const {
-	return 1.0; //initial timescale
+	return 1.0; // Initial timescale.
 }
 
 String AnimationNodeTimeScale::get_caption() const {
@@ -611,24 +611,24 @@ AnimationNodeTimeScale::AnimationNodeTimeScale() {
 ////////////////////////////////////
 
 void AnimationNodeTimeSeek::get_parameter_list(List<PropertyInfo> *r_list) const {
-	r_list->push_back(PropertyInfo(Variant::FLOAT, seek_pos, PROPERTY_HINT_RANGE, "-1,3600,0.01,or_greater"));
+	r_list->push_back(PropertyInfo(Variant::FLOAT, seek_pos_request, PROPERTY_HINT_RANGE, "-1,3600,0.01,or_greater")); // It will be reset to -1 after seeking the position immediately.
 }
 
 Variant AnimationNodeTimeSeek::get_parameter_default_value(const StringName &p_parameter) const {
-	return 1.0; //initial timescale
+	return -1.0; // Initial seek request.
 }
 
 String AnimationNodeTimeSeek::get_caption() const {
-	return "Seek";
+	return "TimeSeek";
 }
 
 double AnimationNodeTimeSeek::process(double p_time, bool p_seek, bool p_is_external_seeking) {
-	double cur_seek_pos = get_parameter(seek_pos);
+	double cur_seek_pos = get_parameter(seek_pos_request);
 	if (p_seek) {
 		return blend_input(0, p_time, true, p_is_external_seeking, 1.0, FILTER_IGNORE, true);
 	} else if (cur_seek_pos >= 0) {
 		double ret = blend_input(0, cur_seek_pos, true, true, 1.0, FILTER_IGNORE, true);
-		set_parameter(seek_pos, -1.0); //reset
+		set_parameter(seek_pos_request, -1.0); // Reset.
 		return ret;
 	} else {
 		return blend_input(0, p_time, false, p_is_external_seeking, 1.0, FILTER_IGNORE, true);
@@ -871,7 +871,7 @@ double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_is_ex
 		}
 	}
 
-	if (cur_prev_index < 0) { // process current animation, check for transition
+	if (cur_prev_index < 0) { // Process current animation, check for transition.
 
 		rem = blend_input(cur_current_index, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true);
 
@@ -885,7 +885,7 @@ double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_is_ex
 			set_parameter(transition_request, get_input_name((cur_current_index + 1) % get_input_count()));
 		}
 
-	} else { // cross-fading from prev to current
+	} else { // Cross-fading from prev to current.
 
 		real_t blend = xfade_time == 0 ? 0 : (cur_prev_xfading / xfade_time);
 		if (xfade_curve.is_valid()) {
@@ -894,7 +894,7 @@ double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_is_ex
 
 		// Blend values must be more than CMP_EPSILON to process discrete keys in edge.
 		real_t blend_inv = 1.0 - blend;
-		if (input_data[cur_current_index].reset && !p_seek && switched) { //just switched, seek to start of current
+		if (input_data[cur_current_index].reset && !p_seek && switched) { // Just switched, seek to start of current.
 			rem = blend_input(cur_current_index, 0, true, p_is_external_seeking, Math::is_zero_approx(blend_inv) ? CMP_EPSILON : blend_inv, FILTER_IGNORE, true);
 		} else {
 			rem = blend_input(cur_current_index, p_time, p_seek, p_is_external_seeking, Math::is_zero_approx(blend_inv) ? CMP_EPSILON : blend_inv, FILTER_IGNORE, true);
@@ -1052,7 +1052,7 @@ void AnimationNodeBlendTree::remove_node(const StringName &p_name) {
 
 	nodes.erase(p_name);
 
-	//erase connections to name
+	// Erase connections to name.
 	for (KeyValue<StringName, Node> &E : nodes) {
 		for (int i = 0; i < E.value.connections.size(); i++) {
 			if (E.value.connections[i] == p_name) {
@@ -1076,7 +1076,7 @@ void AnimationNodeBlendTree::rename_node(const StringName &p_name, const StringN
 	nodes[p_new_name] = nodes[p_name];
 	nodes.erase(p_name);
 
-	//rename connections
+	// Rename connections.
 	for (KeyValue<StringName, Node> &E : nodes) {
 		for (int i = 0; i < E.value.connections.size(); i++) {
 			if (E.value.connections[i] == p_name) {
@@ -1084,7 +1084,7 @@ void AnimationNodeBlendTree::rename_node(const StringName &p_name, const StringN
 			}
 		}
 	}
-	//connection must be done with new name
+	// Connection must be done with new name.
 	nodes[p_new_name].node->connect("changed", callable_mp(this, &AnimationNodeBlendTree::_node_changed).bind(p_new_name), CONNECT_REFERENCE_COUNTED);
 
 	emit_signal(SNAME("tree_changed"));

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -257,7 +257,7 @@ public:
 class AnimationNodeTimeSeek : public AnimationNode {
 	GDCLASS(AnimationNodeTimeSeek, AnimationNode);
 
-	StringName seek_pos = PNAME("seek_position");
+	StringName seek_pos_request = PNAME("seek_request");
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Only NodeTimeSeek has a strange naming rule...

![image](https://user-images.githubusercontent.com/61938263/216036800-34875cbe-a9da-4473-8104-d001af8bfb2c.png)

Also, rename `TimeSeek/seek_position` to `TimeSeek/seek_request` because the value will be reset to `-1` after seeking the position immediately as same way with `Transition/transition_request` and `OneShot/request`.

Moreover that default value is wrong, it should be `-1.0` not `1.0`, fixed.

Contains fixing caps for some comments.