### PR TITLE
Eliminate collision checks between geometry in rendering BVH.

### DIFF
--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -184,8 +184,8 @@ VisualServerScene::SpatialPartitionID VisualServerScene::SpatialPartitioningScen
 	p_userdata->bvh_pairable_mask = p_pairable_mask;
 	p_userdata->bvh_pairable_type = p_pairable_type;
 
-	uint32_t tree_id = p_pairable ? 1 : 0;
-	uint32_t tree_collision_mask = 3;
+	uint32_t tree_collision_mask = 0;
+	uint32_t tree_id = find_tree_id_and_collision_mask(p_pairable, tree_collision_mask);
 
 	return _bvh.create(p_userdata, p_userdata->visible, tree_id, tree_collision_mask, p_aabb, p_subindex) + 1;
 }
@@ -227,8 +227,8 @@ void VisualServerScene::SpatialPartitioningScene_BVH::set_pairable(Instance *p_i
 	p_instance->bvh_pairable_mask = p_pairable_mask;
 	p_instance->bvh_pairable_type = p_pairable_type;
 
-	uint32_t tree_id = p_pairable ? 1 : 0;
-	uint32_t tree_collision_mask = 3;
+	uint32_t tree_collision_mask = 0;
+	uint32_t tree_id = find_tree_id_and_collision_mask(p_pairable, tree_collision_mask);
 
 	_bvh.set_tree(handle - 1, tree_id, tree_collision_mask);
 }


### PR DESCRIPTION
Later logic using the `pairable_mask` would catch cases preventing pairing callbacks between geometry. However the collision checks were still taking place, wasting performance.

Here we utilize the `tree_mask` feature of BVH to totally eliminate unnecessary collision checks between geometry.

## Notes
* I noticed when profiling benchmarks of rotating cubes that BVH collision checks were occurring with no lights in the scene. This did not seem necessary.
* I worked out from the logic that geometry always has a `pairable_mask` of zero, so is eliminated from pairing with other geometry in the templated `UserCullTestFunction()` callback used by the BVH, which happens near the end of the collision pipeline.
* However it was simple to totally remove these collision checks from taking place by changing the tree collision mask (which was maybe introduced with the templated trees?).
* The performance gains typically aren't *massive* from eliminating these checks, but are well worth doing as it is free speedup. More likely to be beneficial in scenes with lots of moving objects.
* Will need a beta to check for regressions, I don't think there should be, based on the logic, but something could be unforeseen.
* This improvement can eventually be also added to Godot 4.x (after 4.0 release) as the longterm intention has been to use the new BVH there too for rendering (it currently still uses the old `dynamic_bvh.h` by reduz for rendering).
* I also removed the default parameters from the functions involved. These weren't used, and made it more complicated to work out what was going on.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
