### PR TITLE
GDScript: Fix type certainty for result of ternary operator

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3988,7 +3988,6 @@ void GDScriptAnalyzer::reduce_ternary_op(GDScriptParser::TernaryOpNode *p_ternar
 		if (!is_type_compatible(true_type, false_type)) {
 			result = false_type;
 			if (!is_type_compatible(false_type, true_type)) {
-				result.type_source = GDScriptParser::DataType::UNDETECTED;
 				result.kind = GDScriptParser::DataType::VARIANT;
 #ifdef DEBUG_ENABLED
 				parser->push_warning(p_ternary_op, GDScriptWarning::INCOMPATIBLE_TERNARY);
@@ -3996,6 +3995,7 @@ void GDScriptAnalyzer::reduce_ternary_op(GDScriptParser::TernaryOpNode *p_ternar
 			}
 		}
 	}
+	result.type_source = true_type.is_hard_type() && false_type.is_hard_type() ? GDScriptParser::DataType::ANNOTATED_INFERRED : GDScriptParser::DataType::INFERRED;
 
 	p_ternary_op->set_datatype(result);
 }

--- a/modules/gdscript/tests/scripts/analyzer/errors/ternary_weak_infer.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/ternary_weak_infer.gd
@@ -1,0 +1,6 @@
+func test():
+	var left_hard_int := 1
+	var right_weak_int = 2
+	var result_hm_int := left_hard_int if true else right_weak_int
+
+	print('not ok')

--- a/modules/gdscript/tests/scripts/analyzer/errors/ternary_weak_infer.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/ternary_weak_infer.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot infer the type of "result_hm_int" variable because the value doesn't have a set type.

--- a/modules/gdscript/tests/scripts/analyzer/features/ternary_hard_infer.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/ternary_hard_infer.gd
@@ -1,0 +1,12 @@
+func test():
+	var left_hard_int := 1
+	var right_hard_int := 2
+	var result_hard_int := left_hard_int if true else right_hard_int
+	assert(result_hard_int == 1)
+
+	var left_hard_variant := 1 as Variant
+	var right_hard_variant := 2.0 as Variant
+	var result_hard_variant := left_hard_variant if true else right_hard_variant
+	assert(result_hard_variant == 1)
+
+	print('ok')

--- a/modules/gdscript/tests/scripts/analyzer/features/ternary_hard_infer.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/ternary_hard_infer.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok


### PR DESCRIPTION
```gdscript
var left_hard_int := 1
var right_weak_int = 2
var result_hm_int := left_hard_int if true else right_weak_int # after PR will produce an error
```
Before `type_source` for a ternary result was taken either from left or right operand without taking into account certainty of opposition. So now: 
```
hard int + weak int = weak int
hard int + hard string = hard variant (with INCOMPATIBLE_TERNARY warning)
hard variant + hard variant = hard variant
```
