### PR TITLE
Remove the meaningless API `rename_parameter()` in AnimationTree

### DIFF
--- a/doc/classes/AnimationTree.xml
+++ b/doc/classes/AnimationTree.xml
@@ -92,13 +92,6 @@
 				[/codeblocks]
 			</description>
 		</method>
-		<method name="rename_parameter">
-			<return type="void" />
-			<param index="0" name="old_name" type="String" />
-			<param index="1" name="new_name" type="String" />
-			<description>
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="active" type="bool" setter="set_active" getter="is_active" default="false">

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -985,8 +985,6 @@ void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<Anima
 	undo_redo->create_action(TTR("Node Renamed"));
 	undo_redo->add_do_method(blend_tree.ptr(), "rename_node", prev_name, name);
 	undo_redo->add_undo_method(blend_tree.ptr(), "rename_node", name, prev_name);
-	undo_redo->add_do_method(tree, "rename_parameter", base_path + prev_name, base_path + name);
-	undo_redo->add_undo_method(tree, "rename_parameter", base_path + name, base_path + prev_name);
 	undo_redo->add_do_method(this, "update_graph");
 	undo_redo->add_undo_method(this, "update_graph");
 	undo_redo->commit_action();

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -2084,20 +2084,6 @@ void AnimationTree::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
-void AnimationTree::rename_parameter(const String &p_base, const String &p_new_base) {
-	//rename values first
-	for (const PropertyInfo &E : properties) {
-		if (E.name.begins_with(p_base)) {
-			String new_name = E.name.replace_first(p_base, p_new_base);
-			property_map[new_name] = property_map[E.name];
-		}
-	}
-
-	//update tree second
-	properties_dirty = true;
-	_update_properties();
-}
-
 real_t AnimationTree::get_connection_activity(const StringName &p_path, int p_connection) const {
 	if (!input_activity_map_get.has(p_path)) {
 		return 0;
@@ -2142,8 +2128,6 @@ void AnimationTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_root_motion_scale"), &AnimationTree::get_root_motion_scale);
 
 	ClassDB::bind_method(D_METHOD("_update_properties"), &AnimationTree::_update_properties);
-
-	ClassDB::bind_method(D_METHOD("rename_parameter", "old_name", "new_name"), &AnimationTree::rename_parameter);
 
 	ClassDB::bind_method(D_METHOD("advance", "delta"), &AnimationTree::advance);
 

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -389,8 +389,6 @@ public:
 	real_t get_connection_activity(const StringName &p_path, int p_connection) const;
 	void advance(double p_time);
 
-	void rename_parameter(const String &p_base, const String &p_new_base);
-
 	uint64_t get_last_process_pass() const;
 	AnimationTree();
 	~AnimationTree();


### PR DESCRIPTION
Fixes #72141

The entities of the `AnimationNode` parameters are stored in the `AnimationTree`'s HashMap.

This API probably existed to reassign properties to that HashMap.

However, the HashMap is rebuilt in `AnimationTree::_update_properties()`.

A `tree_changed` signal is propagated to the AnimationTree when renaming the AnimationNode. And `AnimationTree::_update_properties()` is executed by the `tree_changed` signal.

As a result, this API has proven to be unnecessary and we can remove it.