### PR TITLE
Core: Fix typed array hash

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -123,6 +123,10 @@ bool Array::recursive_equal(const Array &p_array, int recursion_count) const {
 	if (_p == p_array._p) {
 		return true;
 	}
+	if (_p->typed != p_array._p->typed) {
+		return false;
+	}
+
 	const Vector<Variant> &a1 = _p->array;
 	const Vector<Variant> &a2 = p_array._p->array;
 	const int size = a1.size();
@@ -183,6 +187,9 @@ uint32_t Array::recursive_hash(int recursion_count) const {
 	}
 
 	uint32_t h = hash_murmur3_one_32(Variant::ARRAY);
+	h = hash_murmur3_one_32(_p->typed.type, h);
+	h = hash_murmur3_one_32(_p->typed.class_name.hash(), h);
+	h = hash_murmur3_one_32(hash_one_uint64(hash_make_uint64_t(_p->typed.script.ptr())), h);
 
 	recursion_count++;
 	for (int i = 0; i < _p->array.size(); i++) {

--- a/modules/gdscript/tests/scripts/analyzer/features/typed_array_usage.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/typed_array_usage.gd
@@ -136,9 +136,11 @@ func test():
 	var empty_bools: Array[bool] = []
 	var empty_basic_one := []
 	var empty_basic_two := []
-	assert(empty_strings == empty_bools)
+	assert(empty_strings.get_typed_builtin() == TYPE_STRING)
+	assert(empty_bools.get_typed_builtin() == TYPE_BOOL)
+	assert(empty_strings != empty_bools)
 	assert(empty_basic_one == empty_basic_two)
-	assert(empty_strings.hash() == empty_bools.hash())
+	assert(empty_strings.hash() != empty_bools.hash())
 	assert(empty_basic_one.hash() == empty_basic_two.hash())
 
 


### PR DESCRIPTION
Continuation of #69248.

Constants are compared by hash, so to store arrays of different types but with same contents they need to include type info into hash and equality considerations.

This was a part of the linked PR, but was [removed](https://github.com/godotengine/godot/pull/69248#discussion_r1089145537) after discussion because I forgot [why](https://github.com/godotengine/godot/pull/69248#issuecomment-1379846221) I've added it...

@reduz, @vnen, are there any alternatives?