### PR TITLE
Print a message when starting editor or project manager

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6756,6 +6756,8 @@ int EditorNode::execute_and_show_output(const String &p_title, const String &p_p
 }
 
 EditorNode::EditorNode() {
+	print_line("Opening editor.");
+
 	DEV_ASSERT(!singleton);
 	singleton = this;
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2785,6 +2785,8 @@ void ProjectList::add_search_tag(const String &p_tag) {
 }
 
 ProjectManager::ProjectManager() {
+	print_line("Opening project manager.");
+
 	singleton = this;
 
 	// load settings


### PR DESCRIPTION
This serves two purposes:

- This helps understand when the project manager or editor CLI arguments are parsed (as opposed to user arguments).
- When using an editor binary in headless mode, you can see if the project manager or editor was started. This can explain why your project's logic isn't being run and the process appears to freeze (even though it's running).
