### PR TITLE
[WIP] Stop Area2D from emitting exited signals when quitting

### DIFF
--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -123,10 +123,25 @@ void Area2D::_body_exit_tree(ObjectID p_id) {
 	ERR_FAIL_COND(!E);
 	ERR_FAIL_COND(!E->get().in_tree);
 	E->get().in_tree = false;
-	emit_signal(SceneStringNames::get_singleton()->body_exited, node);
+	_emit_exited(SceneStringNames::get_singleton()->body_exited, node);
 	for (int i = 0; i < E->get().shapes.size(); i++) {
-		emit_signal(SceneStringNames::get_singleton()->body_shape_exited, E->get().rid, node, E->get().shapes[i].body_shape, E->get().shapes[i].area_shape);
+		_emit_shape_exited(SceneStringNames::get_singleton()->body_shape_exited, E->get().rid, node, E->get().shapes[i].body_shape, E->get().shapes[i].area_shape);
 	}
+}
+
+void Area2D::_emit_exited(const StringName &p_signal, Object* p_obj)
+{
+	if (unlikely(get_tree() && get_tree()->is_quitting())) {
+		return;
+	}
+	emit_signal(p_signal, p_obj);
+}
+
+void Area2D::_emit_shape_exited(const StringName &p_signal, const RID &p_rid, Object *p_obj, int p_shape, int p_self_shape) {
+	if (unlikely(get_tree() && get_tree()->is_quitting())) {
+		return;
+	}
+	emit_signal(p_signal, p_rid, p_obj, p_shape, p_self_shape);
 }
 
 void Area2D::_body_inout(int p_status, const RID &p_body, int p_instance, int p_body_shape, int p_area_shape) {
@@ -181,12 +196,12 @@ void Area2D::_body_inout(int p_status, const RID &p_body, int p_instance, int p_
 				node->disconnect(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_body_enter_tree);
 				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_body_exit_tree);
 				if (in_tree) {
-					emit_signal(SceneStringNames::get_singleton()->body_exited, obj);
+					_emit_exited(SceneStringNames::get_singleton()->body_exited, obj);
 				}
 			}
 		}
 		if (!node || in_tree) {
-			emit_signal(SceneStringNames::get_singleton()->body_shape_exited, p_body, obj, p_body_shape, p_area_shape);
+			_emit_shape_exited(SceneStringNames::get_singleton()->body_shape_exited, p_body, obj, p_body_shape, p_area_shape);
 		}
 	}
 
@@ -217,9 +232,9 @@ void Area2D::_area_exit_tree(ObjectID p_id) {
 	ERR_FAIL_COND(!E);
 	ERR_FAIL_COND(!E->get().in_tree);
 	E->get().in_tree = false;
-	emit_signal(SceneStringNames::get_singleton()->area_exited, node);
+	_emit_exited(SceneStringNames::get_singleton()->area_exited, node);
 	for (int i = 0; i < E->get().shapes.size(); i++) {
-		emit_signal(SceneStringNames::get_singleton()->area_shape_exited, E->get().rid, node, E->get().shapes[i].area_shape, E->get().shapes[i].self_shape);
+		_emit_shape_exited(SceneStringNames::get_singleton()->area_shape_exited, E->get().rid, node, E->get().shapes[i].area_shape, E->get().shapes[i].self_shape);
 	}
 }
 
@@ -274,12 +289,12 @@ void Area2D::_area_inout(int p_status, const RID &p_area, int p_instance, int p_
 				node->disconnect(SceneStringNames::get_singleton()->tree_entered, this, SceneStringNames::get_singleton()->_area_enter_tree);
 				node->disconnect(SceneStringNames::get_singleton()->tree_exiting, this, SceneStringNames::get_singleton()->_area_exit_tree);
 				if (in_tree) {
-					emit_signal(SceneStringNames::get_singleton()->area_exited, obj);
+					_emit_exited(SceneStringNames::get_singleton()->area_exited, obj);
 				}
 			}
 		}
 		if (!node || in_tree) {
-			emit_signal(SceneStringNames::get_singleton()->area_shape_exited, p_area, obj, p_area_shape, p_self_shape);
+			_emit_shape_exited(SceneStringNames::get_singleton()->area_shape_exited, p_area, obj, p_area_shape, p_self_shape);
 		}
 	}
 
@@ -311,10 +326,10 @@ void Area2D::_clear_monitoring() {
 			}
 
 			for (int i = 0; i < E->get().shapes.size(); i++) {
-				emit_signal(SceneStringNames::get_singleton()->body_shape_exited, E->get().rid, node, E->get().shapes[i].body_shape, E->get().shapes[i].area_shape);
+				_emit_shape_exited(SceneStringNames::get_singleton()->body_shape_exited, E->get().rid, node, E->get().shapes[i].body_shape, E->get().shapes[i].area_shape);
 			}
 
-			emit_signal(SceneStringNames::get_singleton()->body_exited, obj);
+			_emit_exited(SceneStringNames::get_singleton()->body_exited, obj);
 		}
 	}
 
@@ -340,10 +355,10 @@ void Area2D::_clear_monitoring() {
 			}
 
 			for (int i = 0; i < E->get().shapes.size(); i++) {
-				emit_signal(SceneStringNames::get_singleton()->area_shape_exited, E->get().rid, node, E->get().shapes[i].area_shape, E->get().shapes[i].self_shape);
+				_emit_shape_exited(SceneStringNames::get_singleton()->area_shape_exited, E->get().rid, node, E->get().shapes[i].area_shape, E->get().shapes[i].self_shape);
 			}
 
-			emit_signal(SceneStringNames::get_singleton()->area_exited, obj);
+			_emit_exited(SceneStringNames::get_singleton()->area_exited, obj);
 		}
 	}
 }

--- a/scene/2d/area_2d.h
+++ b/scene/2d/area_2d.h
@@ -64,6 +64,9 @@ private:
 	void _body_enter_tree(ObjectID p_id);
 	void _body_exit_tree(ObjectID p_id);
 
+	void _emit_exited(const StringName &p_signal, Object* p_obj);
+	void _emit_shape_exited(const StringName &p_signal, const RID& p_rid, Object* p_obj, int p_shape, int p_self_shape);
+
 	struct ShapePair {
 		int body_shape;
 		int area_shape;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -785,6 +785,10 @@ void SceneTree::finish() {
 	tweens.clear();
 }
 
+bool SceneTree::is_quitting() const {
+	return _quit;
+}
+
 void SceneTree::quit(int p_exit_code) {
 	if (p_exit_code >= 0) {
 		// Override the exit code if a positive argument is given (the default is `-1`).

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -324,6 +324,7 @@ public:
 	bool is_quit_on_go_back() const;
 	void set_quit_on_go_back(bool p_enable);
 
+	bool is_quitting() const;
 	void quit(int p_exit_code = -1);
 
 	void set_input_as_handled();


### PR DESCRIPTION
I'm putting this PR up for discussion, as I'm not sure if this is a good idea to merge upstream.

When quitting the scene tree, objects are deleted and areas still emit their body_exited/area_exited/... signals, calling code that might rely on other nodes in the hierachy that also have been deleted already, hence causing crashes.

With this patch, Area2D now checks if the scene tree is quitting and does not emit XY_exited signals in that case.

I'm using this in my own build of Godot and it has been working fine so far. I don't know if there are any cases where the old behavior is desirable.

The PR is also not fully complete. 3D Areas probably have the same problem and it only supports 3.x so far.
I also haven't created a minimal reproduction project, yet.

I didn't want to waste time on this PR before I'm not sure that this is actually useful.
