### PR TITLE
Rename NavigationServer internal RvoAgent to NavAgent

### DIFF
--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -262,7 +262,7 @@ TypedArray<RID> GodotNavigationServer::map_get_agents(RID p_map) const {
 	const NavMap *map = map_owner.get_or_null(p_map);
 	ERR_FAIL_COND_V(map == nullptr, agents_rids);
 
-	const LocalVector<RvoAgent *> agents = map->get_agents();
+	const LocalVector<NavAgent *> agents = map->get_agents();
 	agents_rids.resize(agents.size());
 
 	for (uint32_t i = 0; i < agents.size(); i++) {
@@ -282,7 +282,7 @@ RID GodotNavigationServer::region_get_map(RID p_region) const {
 }
 
 RID GodotNavigationServer::agent_get_map(RID p_agent) const {
-	RvoAgent *agent = agent_owner.get_or_null(p_agent);
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_COND_V(agent == nullptr, RID());
 
 	if (agent->get_map()) {
@@ -579,13 +579,13 @@ RID GodotNavigationServer::agent_create() {
 	MutexLock lock(operations_mutex);
 
 	RID rid = agent_owner.make_rid();
-	RvoAgent *agent = agent_owner.get_or_null(rid);
+	NavAgent *agent = agent_owner.get_or_null(rid);
 	agent->set_self(rid);
 	return rid;
 }
 
 COMMAND_2(agent_set_map, RID, p_agent, RID, p_map) {
-	RvoAgent *agent = agent_owner.get_or_null(p_agent);
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_COND(agent == nullptr);
 
 	if (agent->get_map()) {
@@ -612,77 +612,77 @@ COMMAND_2(agent_set_map, RID, p_agent, RID, p_map) {
 }
 
 COMMAND_2(agent_set_neighbor_distance, RID, p_agent, real_t, p_distance) {
-	RvoAgent *agent = agent_owner.get_or_null(p_agent);
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_COND(agent == nullptr);
 
 	agent->get_agent()->neighborDist_ = p_distance;
 }
 
 COMMAND_2(agent_set_max_neighbors, RID, p_agent, int, p_count) {
-	RvoAgent *agent = agent_owner.get_or_null(p_agent);
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_COND(agent == nullptr);
 
 	agent->get_agent()->maxNeighbors_ = p_count;
 }
 
 COMMAND_2(agent_set_time_horizon, RID, p_agent, real_t, p_time) {
-	RvoAgent *agent = agent_owner.get_or_null(p_agent);
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_COND(agent == nullptr);
 
 	agent->get_agent()->timeHorizon_ = p_time;
 }
 
 COMMAND_2(agent_set_radius, RID, p_agent, real_t, p_radius) {
-	RvoAgent *agent = agent_owner.get_or_null(p_agent);
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_COND(agent == nullptr);
 
 	agent->get_agent()->radius_ = p_radius;
 }
 
 COMMAND_2(agent_set_max_speed, RID, p_agent, real_t, p_max_speed) {
-	RvoAgent *agent = agent_owner.get_or_null(p_agent);
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_COND(agent == nullptr);
 
 	agent->get_agent()->maxSpeed_ = p_max_speed;
 }
 
 COMMAND_2(agent_set_velocity, RID, p_agent, Vector3, p_velocity) {
-	RvoAgent *agent = agent_owner.get_or_null(p_agent);
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_COND(agent == nullptr);
 
 	agent->get_agent()->velocity_ = RVO::Vector3(p_velocity.x, p_velocity.y, p_velocity.z);
 }
 
 COMMAND_2(agent_set_target_velocity, RID, p_agent, Vector3, p_velocity) {
-	RvoAgent *agent = agent_owner.get_or_null(p_agent);
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_COND(agent == nullptr);
 
 	agent->get_agent()->prefVelocity_ = RVO::Vector3(p_velocity.x, p_velocity.y, p_velocity.z);
 }
 
 COMMAND_2(agent_set_position, RID, p_agent, Vector3, p_position) {
-	RvoAgent *agent = agent_owner.get_or_null(p_agent);
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_COND(agent == nullptr);
 
 	agent->get_agent()->position_ = RVO::Vector3(p_position.x, p_position.y, p_position.z);
 }
 
 COMMAND_2(agent_set_ignore_y, RID, p_agent, bool, p_ignore) {
-	RvoAgent *agent = agent_owner.get_or_null(p_agent);
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_COND(agent == nullptr);
 
 	agent->get_agent()->ignore_y_ = p_ignore;
 }
 
 bool GodotNavigationServer::agent_is_map_changed(RID p_agent) const {
-	RvoAgent *agent = agent_owner.get_or_null(p_agent);
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_COND_V(agent == nullptr, false);
 
 	return agent->is_map_changed();
 }
 
 COMMAND_2(agent_set_callback, RID, p_agent, Callable, p_callback) {
-	RvoAgent *agent = agent_owner.get_or_null(p_agent);
+	NavAgent *agent = agent_owner.get_or_null(p_agent);
 	ERR_FAIL_COND(agent == nullptr);
 
 	agent->set_callback(p_callback);
@@ -713,7 +713,7 @@ COMMAND_1(free, RID, p_object) {
 		}
 
 		// Remove any assigned agent
-		for (RvoAgent *agent : map->get_agents()) {
+		for (NavAgent *agent : map->get_agents()) {
 			map->remove_agent(agent);
 			agent->set_map(nullptr);
 		}
@@ -746,7 +746,7 @@ COMMAND_1(free, RID, p_object) {
 		link_owner.free(p_object);
 
 	} else if (agent_owner.owns(p_object)) {
-		RvoAgent *agent = agent_owner.get_or_null(p_object);
+		NavAgent *agent = agent_owner.get_or_null(p_object);
 
 		// Removes this agent from the map if assigned
 		if (agent->get_map() != nullptr) {

--- a/modules/navigation/godot_navigation_server.h
+++ b/modules/navigation/godot_navigation_server.h
@@ -36,10 +36,10 @@
 #include "core/templates/rid_owner.h"
 #include "servers/navigation_server_3d.h"
 
+#include "nav_agent.h"
 #include "nav_link.h"
 #include "nav_map.h"
 #include "nav_region.h"
-#include "rvo_agent.h"
 
 /// The commands are functions executed during the `sync` phase.
 
@@ -71,7 +71,7 @@ class GodotNavigationServer : public NavigationServer3D {
 	mutable RID_Owner<NavLink> link_owner;
 	mutable RID_Owner<NavMap> map_owner;
 	mutable RID_Owner<NavRegion> region_owner;
-	mutable RID_Owner<RvoAgent> agent_owner;
+	mutable RID_Owner<NavAgent> agent_owner;
 
 	bool active = true;
 	LocalVector<NavMap *> active_maps;

--- a/modules/navigation/nav_agent.cpp
+++ b/modules/navigation/nav_agent.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  rvo_agent.cpp                                                         */
+/*  nav_agent.cpp                                                         */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,15 +28,15 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "rvo_agent.h"
+#include "nav_agent.h"
 
 #include "nav_map.h"
 
-void RvoAgent::set_map(NavMap *p_map) {
+void NavAgent::set_map(NavMap *p_map) {
 	map = p_map;
 }
 
-bool RvoAgent::is_map_changed() {
+bool NavAgent::is_map_changed() {
 	if (map) {
 		bool is_changed = map->get_map_update_id() != map_update_id;
 		map_update_id = map->get_map_update_id();
@@ -46,15 +46,15 @@ bool RvoAgent::is_map_changed() {
 	}
 }
 
-void RvoAgent::set_callback(Callable p_callback) {
+void NavAgent::set_callback(Callable p_callback) {
 	callback = p_callback;
 }
 
-bool RvoAgent::has_callback() const {
+bool NavAgent::has_callback() const {
 	return callback.is_valid();
 }
 
-void RvoAgent::dispatch_callback() {
+void NavAgent::dispatch_callback() {
 	if (!callback.is_valid()) {
 		return;
 	}

--- a/modules/navigation/nav_agent.h
+++ b/modules/navigation/nav_agent.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  rvo_agent.h                                                           */
+/*  nav_agent.h                                                           */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef RVO_AGENT_H
-#define RVO_AGENT_H
+#ifndef NAV_AGENT_H
+#define NAV_AGENT_H
 
 #include "core/object/class_db.h"
 #include "nav_rid.h"
@@ -38,7 +38,7 @@
 
 class NavMap;
 
-class RvoAgent : public NavRid {
+class NavAgent : public NavRid {
 	NavMap *map = nullptr;
 	RVO::Agent agent;
 	Callable callback = Callable();
@@ -62,4 +62,4 @@ public:
 	void dispatch_callback();
 };
 
-#endif // RVO_AGENT_H
+#endif // NAV_AGENT_H

--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -31,9 +31,9 @@
 #include "nav_map.h"
 
 #include "core/object/worker_thread_pool.h"
+#include "nav_agent.h"
 #include "nav_link.h"
 #include "nav_region.h"
-#include "rvo_agent.h"
 #include <algorithm>
 
 #define THREE_POINTS_CROSS_PRODUCT(m_a, m_b, m_c) (((m_c) - (m_a)).cross((m_b) - (m_a)))
@@ -568,18 +568,18 @@ void NavMap::remove_link(NavLink *p_link) {
 	}
 }
 
-bool NavMap::has_agent(RvoAgent *agent) const {
+bool NavMap::has_agent(NavAgent *agent) const {
 	return (agents.find(agent) != -1);
 }
 
-void NavMap::add_agent(RvoAgent *agent) {
+void NavMap::add_agent(NavAgent *agent) {
 	if (!has_agent(agent)) {
 		agents.push_back(agent);
 		agents_dirty = true;
 	}
 }
 
-void NavMap::remove_agent(RvoAgent *agent) {
+void NavMap::remove_agent(NavAgent *agent) {
 	remove_agent_as_controlled(agent);
 	int64_t agent_index = agents.find(agent);
 	if (agent_index != -1) {
@@ -588,7 +588,7 @@ void NavMap::remove_agent(RvoAgent *agent) {
 	}
 }
 
-void NavMap::set_agent_as_controlled(RvoAgent *agent) {
+void NavMap::set_agent_as_controlled(NavAgent *agent) {
 	const bool exist = (controlled_agents.find(agent) != -1);
 	if (!exist) {
 		ERR_FAIL_COND(!has_agent(agent));
@@ -596,7 +596,7 @@ void NavMap::set_agent_as_controlled(RvoAgent *agent) {
 	}
 }
 
-void NavMap::remove_agent_as_controlled(RvoAgent *agent) {
+void NavMap::remove_agent_as_controlled(NavAgent *agent) {
 	int64_t active_avoidance_agent_index = controlled_agents.find(agent);
 	if (active_avoidance_agent_index != -1) {
 		controlled_agents.remove_at_unordered(active_avoidance_agent_index);
@@ -895,7 +895,7 @@ void NavMap::sync() {
 		// cannot use LocalVector here as RVO library expects std::vector to build KdTree
 		std::vector<RVO::Agent *> raw_agents;
 		raw_agents.reserve(agents.size());
-		for (RvoAgent *agent : agents) {
+		for (NavAgent *agent : agents) {
 			raw_agents.push_back(agent->get_agent());
 		}
 		rvo.buildAgentTree(raw_agents);
@@ -916,7 +916,7 @@ void NavMap::sync() {
 	pm_edge_free_count = _new_pm_edge_free_count;
 }
 
-void NavMap::compute_single_step(uint32_t index, RvoAgent **agent) {
+void NavMap::compute_single_step(uint32_t index, NavAgent **agent) {
 	(*(agent + index))->get_agent()->computeNeighbors(&rvo);
 	(*(agent + index))->get_agent()->computeNewVelocity(deltatime);
 }
@@ -930,7 +930,7 @@ void NavMap::step(real_t p_deltatime) {
 }
 
 void NavMap::dispatch_callbacks() {
-	for (RvoAgent *agent : controlled_agents) {
+	for (NavAgent *agent : controlled_agents) {
 		agent->dispatch_callback();
 	}
 }

--- a/modules/navigation/nav_map.h
+++ b/modules/navigation/nav_map.h
@@ -42,7 +42,7 @@
 
 class NavLink;
 class NavRegion;
-class RvoAgent;
+class NavAgent;
 
 class NavMap : public NavRid {
 	/// Map Up
@@ -78,10 +78,10 @@ class NavMap : public NavRid {
 	bool agents_dirty = false;
 
 	/// All the Agents (even the controlled one)
-	LocalVector<RvoAgent *> agents;
+	LocalVector<NavAgent *> agents;
 
 	/// Controlled agents
-	LocalVector<RvoAgent *> controlled_agents;
+	LocalVector<NavAgent *> controlled_agents;
 
 	/// Physics delta time
 	real_t deltatime = 0.0;
@@ -144,15 +144,15 @@ public:
 		return links;
 	}
 
-	bool has_agent(RvoAgent *agent) const;
-	void add_agent(RvoAgent *agent);
-	void remove_agent(RvoAgent *agent);
-	const LocalVector<RvoAgent *> &get_agents() const {
+	bool has_agent(NavAgent *agent) const;
+	void add_agent(NavAgent *agent);
+	void remove_agent(NavAgent *agent);
+	const LocalVector<NavAgent *> &get_agents() const {
 		return agents;
 	}
 
-	void set_agent_as_controlled(RvoAgent *agent);
-	void remove_agent_as_controlled(RvoAgent *agent);
+	void set_agent_as_controlled(NavAgent *agent);
+	void remove_agent_as_controlled(NavAgent *agent);
 
 	uint32_t get_map_update_id() const {
 		return map_update_id;
@@ -173,7 +173,7 @@ public:
 	int get_pm_edge_free_count() const { return pm_edge_free_count; }
 
 private:
-	void compute_single_step(uint32_t index, RvoAgent **agent);
+	void compute_single_step(uint32_t index, NavAgent **agent);
 	void clip_path(const LocalVector<gd::NavigationPoly> &p_navigation_polys, Vector<Vector3> &path, const gd::NavigationPoly *from_poly, const Vector3 &p_to_point, const gd::NavigationPoly *p_to_poly, Vector<int32_t> *r_path_types, TypedArray<RID> *r_path_rids, Vector<int64_t> *r_path_owners) const;
 };
 


### PR DESCRIPTION
Internal restructuring change only.

Renames the NavigationServer internal `RvoAgent` to `NavAgent`.

Why rename? That class is not something specific to RVO avoidance and should be the NavigationServer equivalent to the NavigationAgent node. The future navigation feature branches already switched to `NavAgent` and git is constantly confused on rebases and branch switches.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
