### PR TITLE
Fix String.split() with empty string and delimeter

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1157,6 +1157,14 @@ Vector<String> String::split_spaces() const {
 
 Vector<String> String::split(const String &p_splitter, bool p_allow_empty, int p_maxsplit) const {
 	Vector<String> ret;
+
+	if (is_empty()) {
+		if (p_allow_empty) {
+			ret.push_back("");
+		}
+		return ret;
+	}
+
 	int from = 0;
 	int len = length();
 

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -512,6 +512,14 @@ TEST_CASE("[String] Splitting") {
 		CHECK(l[i] == slices_3[i]);
 	}
 
+	s = "";
+	l = s.split();
+	CHECK(l.size() == 1);
+	CHECK(l[0] == "");
+
+	l = s.split("", false);
+	CHECK(l.size() == 0);
+
 	s = "Mars Jupiter Saturn Uranus";
 	const char *slices_s[4] = { "Mars", "Jupiter", "Saturn", "Uranus" };
 	l = s.split_spaces();


### PR DESCRIPTION
Fixes #72531 (crash)

I think this behavior makes the most sense.