### PR TITLE
Clean up the XR export logic

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -899,10 +899,6 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 	bool screen_support_large = p_preset->get("screen/support_large");
 	bool screen_support_xlarge = p_preset->get("screen/support_xlarge");
 
-	int xr_mode_index = p_preset->get("xr_features/xr_mode");
-	int hand_tracking_index = p_preset->get("xr_features/hand_tracking");
-	int hand_tracking_frequency_index = p_preset->get("xr_features/hand_tracking_frequency");
-
 	bool backup_allowed = p_preset->get("user_data_backup/allow");
 	int app_category = p_preset->get("package/app_category");
 	bool retain_data_on_uninstall = p_preset->get("package/retain_data_on_uninstall");
@@ -1046,25 +1042,6 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 						}
 					}
 
-					// Hand tracking related configurations
-					if (xr_mode_index == XR_MODE_OPENXR && hand_tracking_index > XR_HAND_TRACKING_NONE) {
-						if (tname == "meta-data" && attrname == "name" && value == "xr_hand_tracking_metadata_name") {
-							string_table.write[attr_value] = "com.oculus.handtracking.frequency";
-						}
-
-						if (tname == "meta-data" && attrname == "value" && value == "xr_hand_tracking_metadata_value") {
-							string_table.write[attr_value] = (hand_tracking_frequency_index == XR_HAND_TRACKING_FREQUENCY_LOW ? "LOW" : "HIGH");
-						}
-
-						if (tname == "meta-data" && attrname == "name" && value == "xr_hand_tracking_version_name") {
-							string_table.write[attr_value] = "com.oculus.handtracking.version";
-						}
-
-						if (tname == "meta-data" && attrname == "value" && value == "xr_hand_tracking_version_value") {
-							string_table.write[attr_value] = "V2.0";
-						}
-					}
-
 					iofs += 20;
 				}
 
@@ -1078,23 +1055,6 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 					Vector<String> feature_names;
 					Vector<bool> feature_required_list;
 					Vector<int> feature_versions;
-
-					if (xr_mode_index == XR_MODE_OPENXR) {
-						// Check for hand tracking
-						if (hand_tracking_index > XR_HAND_TRACKING_NONE) {
-							feature_names.push_back("oculus.software.handtracking");
-							feature_required_list.push_back(hand_tracking_index == XR_HAND_TRACKING_REQUIRED);
-							feature_versions.push_back(-1); // no version attribute should be added.
-						}
-
-						// Check for passthrough
-						int passthrough_mode = p_preset->get("xr_features/passthrough");
-						if (passthrough_mode > XR_PASSTHROUGH_NONE) {
-							feature_names.push_back("com.oculus.feature.PASSTHROUGH");
-							feature_required_list.push_back(passthrough_mode == XR_PASSTHROUGH_REQUIRED);
-							feature_versions.push_back(-1);
-						}
-					}
 
 					if (feature_names.size() > 0) {
 						ofs += 24; // skip over end tag
@@ -2334,6 +2294,12 @@ bool EditorExportPlatformAndroid::has_valid_project_configuration(const Ref<Edit
 	int xr_mode_index = p_preset->get("xr_features/xr_mode");
 	int hand_tracking = p_preset->get("xr_features/hand_tracking");
 	int passthrough_mode = p_preset->get("xr_features/passthrough");
+	if (xr_mode_index == XR_MODE_OPENXR && !custom_build_enabled) {
+		valid = false;
+		err += TTR("OpenXR requires \"Use Custom Build\" to be enabled");
+		err += "\n";
+	}
+
 	if (xr_mode_index != XR_MODE_OPENXR) {
 		if (hand_tracking > XR_HAND_TRACKING_NONE) {
 			valid = false;

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -276,17 +276,39 @@ String _get_xr_features_tag(const Ref<EditorExportPreset> &p_preset) {
 	return manifest_xr_features;
 }
 
-String _get_activity_tag(const Ref<EditorExportPreset> &p_preset) {
+String _get_activity_tag(const Ref<EditorExportPreset> &p_preset, bool p_uses_xr) {
 	String orientation = _get_android_orientation_label(DisplayServer::ScreenOrientation(int(GLOBAL_GET("display/window/handheld/orientation"))));
 	String manifest_activity_text = vformat(
 			"        <activity android:name=\"com.godot.game.GodotApp\" "
 			"tools:replace=\"android:screenOrientation,android:excludeFromRecents,android:resizeableActivity\" "
+			"tools:node=\"mergeOnlyAttributes\" "
 			"android:excludeFromRecents=\"%s\" "
 			"android:screenOrientation=\"%s\" "
 			"android:resizeableActivity=\"%s\">\n",
 			bool_to_string(p_preset->get("package/exclude_from_recents")),
 			orientation,
 			bool_to_string(bool(GLOBAL_GET("display/window/size/resizable"))));
+
+	if (p_uses_xr) {
+		manifest_activity_text += "            <intent-filter>\n"
+								  "                <action android:name=\"android.intent.action.MAIN\" />\n"
+								  "                <category android:name=\"android.intent.category.LAUNCHER\" />\n"
+								  "\n"
+								  "                <!-- Enable access to OpenXR on Oculus mobile devices, no-op on other Android\n"
+								  "                platforms. -->\n"
+								  "                <category android:name=\"com.oculus.intent.category.VR\" />\n"
+								  "\n"
+								  "                <!-- OpenXR category tag to indicate the activity starts in an immersive OpenXR mode. \n"
+								  "                See https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#android-runtime-category. -->\n"
+								  "                <category android:name=\"org.khronos.openxr.intent.category.IMMERSIVE_HMD\" />\n"
+								  "            </intent-filter>\n";
+	} else {
+		manifest_activity_text += "            <intent-filter>\n"
+								  "                <action android:name=\"android.intent.action.MAIN\" />\n"
+								  "                <category android:name=\"android.intent.category.LAUNCHER\" />\n"
+								  "            </intent-filter>\n";
+	}
+
 	manifest_activity_text += "        </activity>\n";
 	return manifest_activity_text;
 }
@@ -307,9 +329,7 @@ String _get_application_tag(const Ref<EditorExportPreset> &p_preset, bool p_has_
 			"        android:hasFragileUserData=\"%s\"\n"
 			"        android:requestLegacyExternalStorage=\"%s\"\n"
 			"        tools:replace=\"android:allowBackup,android:appCategory,android:isGame,android:hasFragileUserData,android:requestLegacyExternalStorage\"\n"
-			"        tools:ignore=\"GoogleAppIndexingWarning\">\n\n"
-			"        <meta-data tools:node=\"remove\" android:name=\"xr_hand_tracking_version_name\" />\n"
-			"        <meta-data tools:node=\"remove\" android:name=\"xr_hand_tracking_metadata_name\" />\n",
+			"        tools:ignore=\"GoogleAppIndexingWarning\">\n\n",
 			bool_to_string(p_preset->get("user_data_backup/allow")),
 			_get_app_category_label(app_category_index),
 			bool_to_string(is_game),
@@ -327,7 +347,7 @@ String _get_application_tag(const Ref<EditorExportPreset> &p_preset, bool p_has_
 			manifest_application_text += "        <meta-data tools:node=\"replace\" android:name=\"com.oculus.handtracking.version\" android:value=\"V2.0\" />\n";
 		}
 	}
-	manifest_application_text += _get_activity_tag(p_preset);
+	manifest_application_text += _get_activity_tag(p_preset, uses_xr);
 	manifest_application_text += "    </application>\n";
 	return manifest_application_text;
 }

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -118,7 +118,7 @@ String _get_screen_sizes_tag(const Ref<EditorExportPreset> &p_preset);
 
 String _get_xr_features_tag(const Ref<EditorExportPreset> &p_preset);
 
-String _get_activity_tag(const Ref<EditorExportPreset> &p_preset);
+String _get_activity_tag(const Ref<EditorExportPreset> &p_preset, bool p_uses_xr);
 
 String _get_application_tag(const Ref<EditorExportPreset> &p_preset, bool p_has_read_write_storage_permission);
 

--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -31,23 +31,6 @@
             android:name="org.godotengine.editor.version"
             android:value="${godotEditorVersion}" />
 
-        <!-- The following metadata values are replaced when Godot exports, modifying them here has no effect. -->
-        <!-- Do these changes in the export preset. Adding new ones is fine. -->
-
-        <!-- XR hand tracking metadata -->
-        <!-- This is modified by the exporter based on the selected xr mode. DO NOT CHANGE the values here. -->
-        <!-- Removed at export time if the xr mode is not VR or hand tracking is disabled. -->
-        <meta-data
-            android:name="xr_hand_tracking_metadata_name"
-            android:value="xr_hand_tracking_metadata_value"/>
-
-        <!-- XR hand tracking version -->
-        <!-- This is modified by the exporter based on the selected xr mode. DO NOT CHANGE the values here. -->
-        <!-- Removed at export time if the xr mode is not VR or hand tracking is disabled. -->
-        <meta-data
-            android:name="xr_hand_tracking_version_name"
-            android:value="xr_hand_tracking_version_value"/>
-
         <activity
             android:name=".GodotApp"
             android:label="@string/godot_project_name_string"
@@ -63,10 +46,6 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
-
-                <!-- Enable access to OpenXR on Oculus mobile devices, no-op on other Android
-                platforms. -->
-                <category android:name="com.oculus.intent.category.VR" />
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
Remove the XR export logic from the Android legacy build system:
- On Android, Godot 4 export requires the use of Android plugins which are not supported by the legacy build system
- Provides added flexibility for configuring the Android manifest for XR specific capabilities.

Supersedes https://github.com/godotengine/godot/pull/72533

- When `OpenXR` is enabled, this is what the activity's intent-filter looks like:
![Screenshot 2023-02-01 at 2 45 12 PM](https://user-images.githubusercontent.com/914968/216181583-7614b9ee-9588-4eae-a768-d17c045081bf.png)

- This is what is looks like when `OpenXR` is disabled:
![Screenshot 2023-02-01 at 2 46 08 PM](https://user-images.githubusercontent.com/914968/216181944-ef826ecf-2c09-4ba2-ba1f-85f076ecdcd0.png)


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
