### PR TITLE
Fix Camera2D crashes

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -250,7 +250,7 @@ void Camera2D::_notification(int p_what) {
 			add_to_group(group_name);
 			add_to_group(canvas_group_name);
 
-			if (enabled && !viewport->get_camera_2d()) {
+			if (!Engine::get_singleton()->is_editor_hint() && enabled && !viewport->get_camera_2d()) {
 				make_current();
 			}
 
@@ -260,11 +260,11 @@ void Camera2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
+			remove_from_group(group_name);
+			remove_from_group(canvas_group_name);
 			if (is_current()) {
 				clear_current();
 			}
-			remove_from_group(group_name);
-			remove_from_group(canvas_group_name);
 			viewport = nullptr;
 		} break;
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1061,10 +1061,10 @@ void Viewport::assign_next_enabled_camera_2d(const StringName &p_camera_group) {
 	get_tree()->get_nodes_in_group(p_camera_group, &camera_list);
 
 	Camera2D *new_camera = nullptr;
-	for (const Node *E : camera_list) {
-		const Camera2D *cam = Object::cast_to<Camera2D>(E);
+	for (Node *E : camera_list) {
+		Camera2D *cam = Object::cast_to<Camera2D>(E);
 		if (cam->is_enabled()) {
-			new_camera = const_cast<Camera2D *>(cam);
+			new_camera = cam;
 			break;
 		}
 	}


### PR DESCRIPTION
Fixes #72529
The camera was doing `call_group()` after getting de-assigned, which assigned it again just before freeing 🙃

Fixes #72534
Camera could be made active inside editor, which led to bugs.

I also fixed some weird code style in viewport.