### PR TITLE
C#: Preserve directories in output during export

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -185,7 +185,9 @@ namespace GodotTools.Export
 
                 foreach (string file in Directory.GetFiles(publishOutputTempDir, "*", SearchOption.AllDirectories))
                 {
-                    AddSharedObject(file, tags: null, projectDataDirName);
+                    AddSharedObject(file, tags: null,
+                        Path.Join(projectDataDirName,
+                            Path.GetRelativePath(publishOutputTempDir, Path.GetDirectoryName(file))));
                 }
             }
         }


### PR DESCRIPTION
If a C# build emits files into a sub directory of the output path, these files would end up in the data directory directly during export, instead of remaining in a sub directory. This PR makes the export preserve these sub directories.

Test project: [OutputTest.zip](https://github.com/godotengine/godot/files/10562787/OutputTest.zip)
When building the C# project the `data.txt` file ends up as `.../bin/dir/data.txt` while before after export it would be `data_.../data.txt` and with the patch it correctly ends up as `data_.../dir/data.txt`

Fixes (for exported projects) #72373