### PR TITLE
C#: Set AppContext.BaseDirectory for editor builds

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotPlugins/PluginLoadContext.cs
+++ b/modules/mono/glue/GodotSharp/GodotPlugins/PluginLoadContext.cs
@@ -21,6 +21,26 @@ namespace GodotPlugins
             _resolver = new AssemblyDependencyResolver(pluginPath);
             _sharedAssemblies = sharedAssemblies;
             _mainLoadContext = mainLoadContext;
+
+            if (string.IsNullOrEmpty(AppContext.BaseDirectory))
+            {
+                // See https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/System.Private.CoreLib/src/System/AppContext.AnyOS.cs#L17-L35
+                // but Assembly.Location is unavailable, because we load assemblies from memory.
+                string? baseDirectory = Path.GetDirectoryName(pluginPath);
+                if (baseDirectory != null)
+                {
+                    if (!Path.EndsInDirectorySeparator(baseDirectory))
+                        baseDirectory += Path.PathSeparator;
+                    // This SetData call effectively sets AppContext.BaseDirectory
+                    // See https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/System.Private.CoreLib/src/System/AppContext.cs#L21-L25
+                    AppDomain.CurrentDomain.SetData("APP_CONTEXT_BASE_DIRECTORY", baseDirectory);
+                }
+                else
+                {
+                    // TODO: How to log from GodotPlugins? (delegate pointer?)
+                    Console.Error.WriteLine("Failed to set AppContext.BaseDirectory. Dynamic loading of libraries may fail.");
+                }
+            }
         }
 
         protected override Assembly? Load(AssemblyName assemblyName)


### PR DESCRIPTION
Set [AppContext.BaseDirectory](https://learn.microsoft.com/en-us/dotnet/api/system.appcontext.basedirectory?view=net-7.0) for editor builds. For exported projects the runtime already sets this property automatically.

This property can be used to load assemblies or native libraries at runtime.

(Often [Assembly.Location](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assembly.location?view=net-7.0) is used instead, but that cannot be set when loading assemblies from memory; cf. https://github.com/dotnet/runtime/issues/12822)

Fixes #72373 (for editor builds; the fix for exported projects is already merged)