### PR TITLE
Improve editor layout dialog

### DIFF
--- a/editor/editor_layouts_dialog.h
+++ b/editor/editor_layouts_dialog.h
@@ -44,6 +44,8 @@ class EditorLayoutsDialog : public ConfirmationDialog {
 	VBoxContainer *makevb = nullptr;
 
 	void _line_gui_input(const Ref<InputEvent> &p_event);
+	void _update_ok_disable_state();
+	void _deselect_layout_names();
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Helps with confusion as written in: https://github.com/godotengine/godot/issues/72540
So I guess -> Fixes: https://github.com/godotengine/godot/issues/72540

- Disable the 'Save'/'Delete' button in the dialog if no layout name is selected and no text is set (if visible)
- Use a small min height for the layout names list to make the dialog more clear if no layout has been created yet

Screenshots:
| Before | After (Note also the disabled 'Save'/'Delete' button) |
| - | - |
| ![image](https://user-images.githubusercontent.com/66004280/216200686-23964b03-ce31-4900-8f5c-fb58e676acf8.png) | ![image](https://user-images.githubusercontent.com/66004280/216200704-53f193ba-eae7-4bf3-82ef-cc353e8370d9.png) |
| ![image](https://user-images.githubusercontent.com/66004280/216201412-17c1c8b8-2933-4cac-a67e-362383aec066.png) | ![image](https://user-images.githubusercontent.com/66004280/216201381-1e134d29-90db-4c1d-9d37-71a05b1ebf52.png) |

