### PR TITLE
Warn on excessive HashMap/HashSet collisions

### DIFF
--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -141,6 +141,11 @@ private:
 
 				num_elements++;
 
+#ifdef DEV_ENABLED
+				if ((capacity > 100) && (distance * 2 > capacity)) {
+					WARN_PRINT("Excessive collision count (" + itos(distance) + "), is the right hash function being used?");
+				}
+#endif
 				return;
 			}
 

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -122,6 +122,12 @@ private:
 				hashes[pos] = hash;
 				key_to_hash[index] = pos;
 				hash_to_key[pos] = index;
+
+#ifdef DEV_ENABLED
+				if ((capacity > 100) && (distance * 2 > capacity)) {
+					WARN_PRINT("Excessive collision count (" + itos(distance) + "), is the right hash function being used?");
+				}
+#endif
 				return pos;
 			}
 

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -296,6 +296,15 @@ static _FORCE_INLINE_ uint64_t hash_make_uint64_t(T p_in) {
 template <class T>
 class Ref;
 
+struct BadHasher {
+	template <class T>
+	static _FORCE_INLINE_ uint32_t hash(const T &v) {
+		// Chosen by fair dice roll. Guaranteed to be random.
+		// https://xkcd.com/221/
+		return 4;
+	}
+};
+
 struct HashMapHasherDefault {
 	// Generic hash function for any type.
 	template <class T>

--- a/tests/core/templates/test_hash_map.h
+++ b/tests/core/templates/test_hash_map.h
@@ -34,6 +34,7 @@
 #include "core/templates/hash_map.h"
 
 #include "tests/test_macros.h"
+#include "tests/test_tools.h"
 
 namespace TestHashMap {
 
@@ -128,6 +129,42 @@ TEST_CASE("[HashMap] Const iteration") {
 		++idx;
 	}
 }
+
+TEST_CASE("[HashMap] Collision warnings") {
+	ErrorDetector ed;
+
+	{
+		HashMap<int, int> map;
+		for (int i = 0; i < 100; i++) {
+			map.insert(i, i);
+		}
+		CHECK(map.size() == 100);
+		CHECK_FALSE(ed.has_error);
+	}
+
+	HashMap<int, int, BadHasher> map;
+
+	for (int i = 0; i < 10; i++) {
+		map.insert(i, i);
+	}
+	CHECK(map.size() == 10);
+	CHECK_FALSE(ed.has_error);
+
+	ERR_PRINT_OFF;
+	for (int i = 0; i < 100; i++) {
+		map.insert(i, i);
+	}
+	ERR_PRINT_ON;
+
+	CHECK(map.size() == 100);
+
+#ifdef DEV_ENABLED
+	CHECK(ed.has_error);
+#else
+	CHECK_FALSE(ed.has_error);
+#endif
+}
+
 } // namespace TestHashMap
 
 #endif // TEST_HASH_MAP_H

--- a/tests/core/templates/test_hash_set.h
+++ b/tests/core/templates/test_hash_set.h
@@ -34,6 +34,7 @@
 #include "core/templates/hash_set.h"
 
 #include "tests/test_macros.h"
+#include "tests/test_tools.h"
 
 namespace TestHashSet {
 
@@ -219,6 +220,41 @@ TEST_CASE("[HashSet] Copy") {
 		CHECK(expected[idx] == E);
 		++idx;
 	}
+}
+
+TEST_CASE("[HashSet] Collision warnings") {
+	ErrorDetector ed;
+
+	{
+		HashSet<int> set;
+		for (int i = 0; i < 100; i++) {
+			set.insert(i);
+		}
+		CHECK(set.size() == 100);
+		CHECK_FALSE(ed.has_error);
+	}
+
+	HashSet<int, BadHasher> set;
+
+	for (int i = 0; i < 10; i++) {
+		set.insert(i);
+	}
+	CHECK(set.size() == 10);
+	CHECK_FALSE(ed.has_error);
+
+	ERR_PRINT_OFF;
+	for (int i = 0; i < 100; i++) {
+		set.insert(i);
+	}
+	ERR_PRINT_ON;
+
+	CHECK(set.size() == 100);
+
+#ifdef DEV_ENABLED
+	CHECK(ed.has_error);
+#else
+	CHECK_FALSE(ed.has_error);
+#endif
 }
 
 } // namespace TestHashSet


### PR DESCRIPTION
Fix a papercut I encountered when working on #72421 , where `HashMapHasherDefault` was accepting `Callable` but coercing it into an empty String for hashing.

This should make it easier to catch accidents where incorrect hash function usage turns a hashmap into a glorified array.