### PR TITLE
Improve consistency of NavigationAgent setters

### DIFF
--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -57,7 +57,6 @@ class NavigationAgent2D : public Node {
 	int max_neighbors = 10;
 	real_t time_horizon = 1.0;
 	real_t max_speed = 100.0;
-
 	real_t path_max_distance = 100.0;
 
 	Vector2 target_position;

--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -185,6 +185,10 @@ real_t NavigationObstacle2D::estimate_agent_radius() const {
 }
 
 void NavigationObstacle2D::set_agent_parent(Node *p_agent_parent) {
+	if (parent_node2d == p_agent_parent) {
+		return;
+	}
+
 	if (Object::cast_to<Node2D>(p_agent_parent) != nullptr) {
 		parent_node2d = Object::cast_to<Node2D>(p_agent_parent);
 		if (map_override.is_valid()) {
@@ -200,7 +204,12 @@ void NavigationObstacle2D::set_agent_parent(Node *p_agent_parent) {
 }
 
 void NavigationObstacle2D::set_navigation_map(RID p_navigation_map) {
+	if (map_override == p_navigation_map) {
+		return;
+	}
+
 	map_override = p_navigation_map;
+
 	NavigationServer2D::get_singleton()->agent_set_map(agent, map_override);
 }
 
@@ -214,13 +223,23 @@ RID NavigationObstacle2D::get_navigation_map() const {
 }
 
 void NavigationObstacle2D::set_estimate_radius(bool p_estimate_radius) {
+	if (estimate_radius == p_estimate_radius) {
+		return;
+	}
+
 	estimate_radius = p_estimate_radius;
+
 	notify_property_list_changed();
 	reevaluate_agent_radius();
 }
 
 void NavigationObstacle2D::set_radius(real_t p_radius) {
 	ERR_FAIL_COND_MSG(p_radius <= 0.0, "Radius must be greater than 0.");
+	if (Math::is_equal_approx(radius, p_radius)) {
+		return;
+	}
+
 	radius = p_radius;
+
 	reevaluate_agent_radius();
 }

--- a/scene/3d/navigation_agent_3d.h
+++ b/scene/3d/navigation_agent_3d.h
@@ -52,14 +52,13 @@ class NavigationAgent3D : public Node {
 
 	real_t path_desired_distance = 1.0;
 	real_t target_desired_distance = 1.0;
-	real_t radius = 0.0;
+	real_t radius = 1.0;
 	real_t navigation_height_offset = 0.0;
-	bool ignore_y = false;
-	real_t neighbor_distance = 0.0;
-	int max_neighbors = 0;
-	real_t time_horizon = 0.0;
-	real_t max_speed = 0.0;
-
+	bool ignore_y = true;
+	real_t neighbor_distance = 50.0;
+	int max_neighbors = 10;
+	real_t time_horizon = 5.0;
+	real_t max_speed = 10.0;
 	real_t path_max_distance = 3.0;
 
 	Vector3 target_position;

--- a/scene/3d/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation_obstacle_3d.cpp
@@ -192,6 +192,10 @@ real_t NavigationObstacle3D::estimate_agent_radius() const {
 }
 
 void NavigationObstacle3D::set_agent_parent(Node *p_agent_parent) {
+	if (parent_node3d == p_agent_parent) {
+		return;
+	}
+
 	if (Object::cast_to<Node3D>(p_agent_parent) != nullptr) {
 		parent_node3d = Object::cast_to<Node3D>(p_agent_parent);
 		if (map_override.is_valid()) {
@@ -207,7 +211,12 @@ void NavigationObstacle3D::set_agent_parent(Node *p_agent_parent) {
 }
 
 void NavigationObstacle3D::set_navigation_map(RID p_navigation_map) {
+	if (map_override == p_navigation_map) {
+		return;
+	}
+
 	map_override = p_navigation_map;
+
 	NavigationServer3D::get_singleton()->agent_set_map(agent, map_override);
 }
 
@@ -221,13 +230,23 @@ RID NavigationObstacle3D::get_navigation_map() const {
 }
 
 void NavigationObstacle3D::set_estimate_radius(bool p_estimate_radius) {
+	if (estimate_radius == p_estimate_radius) {
+		return;
+	}
+
 	estimate_radius = p_estimate_radius;
+
 	notify_property_list_changed();
 	reevaluate_agent_radius();
 }
 
 void NavigationObstacle3D::set_radius(real_t p_radius) {
 	ERR_FAIL_COND_MSG(p_radius <= 0.0, "Radius must be greater than 0.");
+	if (Math::is_equal_approx(radius, p_radius)) {
+		return;
+	}
+
 	radius = p_radius;
+
 	reevaluate_agent_radius();
 }


### PR DESCRIPTION
Version of #64679 for `NavigationAgent` and `NavigationObstacle`.

Now all navigation nodes follow the standard format for setters, caching values locally and only updating the server as necessary.