### PR TITLE
Provide ability to override `EditorExportPlugin::_export_end()` in C++

### DIFF
--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -512,8 +512,10 @@ EditorExportPlatform::ExportNotifier::~ExportNotifier() {
 	for (int i = 0; i < export_plugins.size(); i++) {
 		if (export_plugins[i]->get_script_instance()) {
 			export_plugins.write[i]->_export_end_script();
+		} else {
+			export_plugins.write[i]->_export_end();
 		}
-		export_plugins.write[i]->_export_end();
+		export_plugins.write[i]->_export_end_clear();
 		export_plugins.write[i]->set_export_preset(Ref<EditorExportPlugin>());
 	}
 }

--- a/editor/export/editor_export_plugin.cpp
+++ b/editor/export/editor_export_plugin.cpp
@@ -222,6 +222,8 @@ void EditorExportPlugin::_export_file(const String &p_path, const String &p_type
 void EditorExportPlugin::_export_begin(const HashSet<String> &p_features, bool p_debug, const String &p_path, int p_flags) {
 }
 
+void EditorExportPlugin::_export_end() {}
+
 void EditorExportPlugin::skip() {
 	skipped = true;
 }

--- a/editor/export/editor_export_plugin.h
+++ b/editor/export/editor_export_plugin.h
@@ -70,7 +70,7 @@ class EditorExportPlugin : public RefCounted {
 		skipped = false;
 	}
 
-	_FORCE_INLINE_ void _export_end() {
+	_FORCE_INLINE_ void _export_end_clear() {
 		ios_frameworks.clear();
 		ios_embedded_frameworks.clear();
 		ios_bundle_files.clear();
@@ -105,6 +105,7 @@ protected:
 
 	virtual void _export_file(const String &p_path, const String &p_type, const HashSet<String> &p_features);
 	virtual void _export_begin(const HashSet<String> &p_features, bool p_debug, const String &p_path, int p_flags);
+	virtual void _export_end();
 
 	static void _bind_methods();
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

I working on a custom godot engine which needing a custom exporter plugin in cpp.
However, unlike `EditorExportPlugin::_export_file()` and `EditorExportPlugin::_export_begin()`, `EditorExportPlugin::_export_end()` is private and can't be overrided to implement my logic directly in cpp.

I don't know this is intended or not, but in GDScript, these 3 methods can be override directly.
So I do a little change to let `EditorExportPlugin::_export_end()` can be overrided in cpp.