### PR TITLE
Set a fixed number of worker threads in debug mode to make race conditions more reproducible

### DIFF
--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -537,6 +537,9 @@ void WorkerThreadPool::init(int p_thread_count, bool p_use_native_threads_low_pr
 	ERR_FAIL_COND(threads.size() > 0);
 	if (p_thread_count < 0) {
 		p_thread_count = OS::get_singleton()->get_default_thread_pool_size();
+#ifdef DEBUG_ENABLED
+		p_thread_count = 16;
+#endif
 	}
 
 	if (p_use_native_threads_low_priority) {

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -196,7 +196,7 @@ void RendererViewport::_draw_3d(Viewport *p_viewport) {
 	if (p_viewport->use_occlusion_culling) {
 		if (p_viewport->occlusion_buffer_dirty) {
 			float aspect = p_viewport->size.aspect();
-			int max_size = occlusion_rays_per_thread * WorkerThreadPool::get_singleton()->get_thread_count();
+			int max_size = occlusion_rays_per_thread * OS::get_singleton()->get_processor_count();
 
 			int viewport_size = p_viewport->size.width * p_viewport->size.height;
 			max_size = CLAMP(max_size, viewport_size / (32 * 32), viewport_size / (2 * 2)); // At least one depth pixel for every 16x16 region. At most one depth pixel for every 2x2 region.


### PR DESCRIPTION
Makes multithreading behavior more consistent, [see here for an example of an issue that was made more difficult to reproduce due to differing behavior between machines with different core counts.](https://github.com/godotengine/godot/issues/73166#issuecomment-1432531199)

Having a higher number of threads by default also makes race condition bugs easier to detect by normal users at almost no overhead, without having to resort to compiling a custom build with ThreadSanitizer enabled. This is especially helpful on low core count systems where such bugs would come up much less often with the default behavior, as race conditions only manifest more often with an increased number of threads.

Note that this does not affect any decisions on when to take single vs multithreaded paths and that the number of worker threads can still be overridden with `threading/worker_pool/max_threads` when necessary.

Also note that this has been edited to incorporate feedback and address concerns, so most points raised below are outdated.