### PR TITLE
Mention `String.match()` is also called "glob"/"globbing"

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -529,7 +529,7 @@
 			<return type="bool" />
 			<param index="0" name="expr" type="String" />
 			<description>
-				Does a simple expression match, where [code]*[/code] matches zero or more arbitrary characters and [code]?[/code] matches any single character except a period ([code].[/code]). An empty string or empty expression always evaluates to [code]false[/code].
+				Does a simple expression match (also called "glob" or "globbing"), where [code]*[/code] matches zero or more arbitrary characters and [code]?[/code] matches any single character except a period ([code].[/code]). An empty string or empty expression always evaluates to [code]false[/code].
 			</description>
 		</method>
 		<method name="matchn" qualifiers="const">


### PR DESCRIPTION
This is mostly for <kbd>Ctrl + F</kbd> purposes, in case someone is looking how to perform globbing on a string.

See https://github.com/godotengine/godot-proposals/issues/2500#issuecomment-1413758696 (where I originally mentioned a nonexisting `glob()` method).
