### PR TITLE
Use a "warning" icon in `OS.alert()` on Linux/*BSD

### DIFF
--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -81,7 +81,7 @@ void OS_LinuxBSD::alert(const String &p_alert, const String &p_title) {
 	List<String> args;
 
 	if (program.ends_with("zenity")) {
-		args.push_back("--error");
+		args.push_back("--warning");
 		args.push_back("--width");
 		args.push_back("500");
 		args.push_back("--title");
@@ -91,7 +91,9 @@ void OS_LinuxBSD::alert(const String &p_alert, const String &p_title) {
 	}
 
 	if (program.ends_with("kdialog")) {
-		args.push_back("--error");
+		// `--sorry` uses the same icon as `--warning` in Zenity.
+		// As of KDialog 22.12.1, its `--warning` options are only available for yes/no questions.
+		args.push_back("--sorry");
 		args.push_back(p_alert);
 		args.push_back("--title");
 		args.push_back(p_title);


### PR DESCRIPTION
This is the same icon as used on Windows.

## Preview

*Using Fedora 37 and KDE Breeze Dark theme.*

### Zenity

![image](https://user-images.githubusercontent.com/180032/216351660-c2e741a2-f11e-44cd-ad62-b734990b829a.png)

### KDialog

![Screenshot_20230202_151537](https://user-images.githubusercontent.com/180032/216349380-fe7ba7cb-ad4e-4aef-8214-879092f961b0.png)