### PR TITLE
Fix toplevel nomenclature

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -692,7 +692,7 @@ Transform2D Control::get_transform() const {
 	return xform;
 }
 
-void Control::_toplevel_changed_on_parent() {
+void Control::_top_level_changed_on_parent() {
 	// Update root control status.
 	_notification(NOTIFICATION_EXIT_CANVAS);
 	_notification(NOTIFICATION_ENTER_CANVAS);

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -292,8 +292,8 @@ private:
 	void _update_minimum_size();
 	void _size_changed();
 
-	void _toplevel_changed() override{}; // Controls don't need to do anything, only other CanvasItems.
-	void _toplevel_changed_on_parent() override;
+	void _top_level_changed() override {} // Controls don't need to do anything, only other CanvasItems.
+	void _top_level_changed_on_parent() override;
 
 	void _clear_size_warning();
 

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -185,7 +185,7 @@ void CanvasItem::_top_level_raise_self() {
 }
 
 void CanvasItem::_enter_canvas() {
-	// Resolves to nullptr if the node is toplevel.
+	// Resolves to nullptr if the node is top_level.
 	CanvasItem *parent_item = get_parent_item();
 
 	if (parent_item) {
@@ -400,26 +400,26 @@ void CanvasItem::set_as_top_level(bool p_top_level) {
 
 	_exit_canvas();
 	top_level = p_top_level;
-	_toplevel_changed();
+	_top_level_changed();
 	_enter_canvas();
 
 	_notify_transform();
 }
 
-void CanvasItem::_toplevel_changed() {
-	// Inform children that toplevel status has changed on a parent.
+void CanvasItem::_top_level_changed() {
+	// Inform children that top_level status has changed on a parent.
 	int children = get_child_count();
 	for (int i = 0; i < children; i++) {
 		CanvasItem *child = Object::cast_to<CanvasItem>(get_child(i));
 		if (child) {
-			child->_toplevel_changed_on_parent();
+			child->_top_level_changed_on_parent();
 		}
 	}
 }
 
-void CanvasItem::_toplevel_changed_on_parent() {
-	// Inform children that toplevel status has changed on a parent.
-	_toplevel_changed();
+void CanvasItem::_top_level_changed_on_parent() {
+	// Inform children that top_level status has changed on a parent.
+	_top_level_changed();
 }
 
 bool CanvasItem::is_set_as_top_level() const {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -125,8 +125,8 @@ private:
 	void _propagate_visibility_changed(bool p_parent_visible_in_tree);
 	void _handle_visibility_change(bool p_visible);
 
-	virtual void _toplevel_changed();
-	virtual void _toplevel_changed_on_parent();
+	virtual void _top_level_changed();
+	virtual void _top_level_changed_on_parent();
 
 	void _redraw_callback();
 


### PR DESCRIPTION
`toplevel` was 3.x
`top_level` is 4.x

implement https://github.com/godotengine/godot/pull/67507#issuecomment-1413915359