### PR TITLE
Expose `WebSocketMultiplayerPeer::is_server`

### DIFF
--- a/modules/websocket/doc_classes/WebSocketMultiplayerPeer.xml
+++ b/modules/websocket/doc_classes/WebSocketMultiplayerPeer.xml
@@ -49,6 +49,13 @@
 				Returns the remote port of the given peer.
 			</description>
 		</method>
+		<method name="is_server" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns whether the [WebSocketMultiplayerPeer] is initialized as a server or as a client.
+				Returns [code]false[/code] when the connection is closed.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="handshake_headers" type="PackedStringArray" setter="set_handshake_headers" getter="get_handshake_headers" default="PackedStringArray()">

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -74,6 +74,8 @@ void WebSocketMultiplayerPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_client", "url", "tls_client_options"), &WebSocketMultiplayerPeer::create_client, DEFVAL(Ref<TLSOptions>()));
 	ClassDB::bind_method(D_METHOD("create_server", "port", "bind_address", "tls_server_options"), &WebSocketMultiplayerPeer::create_server, DEFVAL("*"), DEFVAL(Ref<TLSOptions>()));
 
+	ClassDB::bind_method(D_METHOD("is_server"), &WebSocketMultiplayerPeer::is_server);
+
 	ClassDB::bind_method(D_METHOD("get_peer", "peer_id"), &WebSocketMultiplayerPeer::get_peer);
 	ClassDB::bind_method(D_METHOD("get_peer_address", "id"), &WebSocketMultiplayerPeer::get_peer_address);
 	ClassDB::bind_method(D_METHOD("get_peer_port", "id"), &WebSocketMultiplayerPeer::get_peer_port);


### PR DESCRIPTION
Expose `WebSocketMultiplayerPeer::is_server` since it is useful for GDScript code paths that are shared between client and server.