### PR TITLE
Simplify Viewport::_set_size

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -524,7 +524,7 @@ void Viewport::_process_picking() {
 	if (!physics_object_picking) {
 		return;
 	}
-	if (to_screen_rect != Rect2i() && Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_CAPTURED) {
+	if (Object::cast_to<Window>(this) && Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_CAPTURED) {
 		return;
 	}
 	if (!gui.mouse_in_viewport) {
@@ -796,14 +796,14 @@ void Viewport::update_canvas_items() {
 	_update_canvas_items(this);
 }
 
-void Viewport::_set_size(const Size2i &p_size, const Size2i &p_size_2d_override, const Rect2i &p_to_screen_rect, bool p_allocated) {
+void Viewport::_set_size(const Size2i &p_size, const Size2i &p_size_2d_override, bool p_allocated) {
 	Transform2D stretch_transform_new = Transform2D();
 	if (is_size_2d_override_stretch_enabled() && p_size_2d_override.width > 0 && p_size_2d_override.height > 0) {
 		Size2 scale = Size2(p_size) / Size2(p_size_2d_override);
 		stretch_transform_new.scale(scale);
 	}
 
-	if (size == p_size && size_allocated == p_allocated && stretch_transform == stretch_transform_new && p_size_2d_override == size_2d_override && to_screen_rect == p_to_screen_rect) {
+	if (size == p_size && size_allocated == p_allocated && stretch_transform == stretch_transform_new && p_size_2d_override == size_2d_override) {
 		return;
 	}
 
@@ -811,7 +811,6 @@ void Viewport::_set_size(const Size2i &p_size, const Size2i &p_size_2d_override,
 	size_allocated = p_allocated;
 	size_2d_override = p_size_2d_override;
 	stretch_transform = stretch_transform_new;
-	to_screen_rect = p_to_screen_rect;
 
 #ifndef _3D_DISABLED
 	if (!use_xr) {
@@ -4143,7 +4142,7 @@ void SubViewport::_internal_set_size(const Size2i &p_size, bool p_force) {
 		return;
 	}
 
-	_set_size(p_size, _get_size_2d_override(), Rect2i(), true);
+	_set_size(p_size, _get_size_2d_override(), true);
 
 	if (c) {
 		c->update_minimum_size();
@@ -4155,7 +4154,7 @@ Size2i SubViewport::get_size() const {
 }
 
 void SubViewport::set_size_2d_override(const Size2i &p_size) {
-	_set_size(_get_size(), p_size, Rect2i(), true);
+	_set_size(_get_size(), p_size, true);
 }
 
 Size2i SubViewport::get_size_2d_override() const {
@@ -4168,7 +4167,7 @@ void SubViewport::set_size_2d_override_stretch(bool p_enable) {
 	}
 
 	size_2d_override_stretch = p_enable;
-	_set_size(_get_size(), _get_size_2d_override(), Rect2i(), true);
+	_set_size(_get_size(), _get_size_2d_override(), true);
 }
 
 bool SubViewport::is_size_2d_override_stretch_enabled() const {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -275,7 +275,6 @@ private:
 
 	Ref<World2D> world_2d;
 
-	Rect2i to_screen_rect;
 	StringName input_group;
 	StringName gui_input_group;
 	StringName shortcut_input_group;
@@ -471,7 +470,7 @@ private:
 	uint64_t event_count = 0;
 
 protected:
-	void _set_size(const Size2i &p_size, const Size2i &p_size_2d_override, const Rect2i &p_to_screen_rect, bool p_allocated);
+	void _set_size(const Size2i &p_size, const Size2i &p_size_2d_override, bool p_allocated);
 
 	Size2i _get_size() const;
 	Size2i _get_size_2d_override() const;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1004,7 +1004,7 @@ void Window::_update_viewport_size() {
 	}
 
 	bool allocate = is_inside_tree() && visible && (window_id != DisplayServer::INVALID_WINDOW_ID || embedder != nullptr);
-	_set_size(final_size, final_size_override, attach_to_screen_rect, allocate);
+	_set_size(final_size, final_size_override, allocate);
 
 	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
 		RenderingServer::get_singleton()->viewport_attach_to_screen(get_viewport_rid(), attach_to_screen_rect, window_id);


### PR DESCRIPTION
`Viewport.to_screen_rect` is used only in a single location to compare it to `Rect2i()`.

When called from `SubViewport`, `to_screen_rect` is always equal to `Rect2i()`. When called from `Window`, `to_screen_rect` is always different from `Rect2i()`.

So the comparison `to_screen_rect != Rect2i()` can be replaced by `Object::cast_to<Window>(this)`.

This allows the removal of `Viewport.to_screen_rect` and the simplification of `Viewport::_set_size`.
