### PR TITLE
C#: Add global class support

### DIFF
--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -62,6 +62,7 @@ class CSharpScript : public Script {
 	friend class CSharpLanguage;
 
 	bool tool = false;
+	bool global_class = false;
 	bool valid = false;
 	bool reload_invalidated = false;
 
@@ -86,6 +87,8 @@ class CSharpScript : public Script {
 #endif
 
 	String source;
+	String class_name;
+	String icon_path;
 
 	SelfList<CSharpScript> script_list = this;
 
@@ -441,6 +444,10 @@ public:
 	virtual String _get_indentation() const;
 	/* TODO? */ void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const override {}
 	/* TODO */ void add_global_constant(const StringName &p_variable, const Variant &p_value) override {}
+
+	/* SCRIPT GLOBAL CLASS FUNCTIONS */
+	virtual bool handles_global_class_type(const String &p_type) const override;
+	virtual String get_global_class_name(const String &p_path, String *r_base_type = nullptr, String *r_icon_path = nullptr) const override;
 
 	/* DEBUGGER FUNCTIONS */
 	String debug_get_error() const override;

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -241,6 +241,9 @@ namespace Godot.SourceGenerators
         public static bool IsGodotClassNameAttribute(this INamedTypeSymbol symbol)
             => symbol.ToString() == GodotClasses.GodotClassNameAttr;
 
+        public static bool IsGodotGlobalClassAttribute(this INamedTypeSymbol symbol)
+            => symbol.ToString() == GodotClasses.GlobalClassAttr;
+
         public static bool IsSystemFlagsAttribute(this INamedTypeSymbol symbol)
             => symbol.ToString() == GodotClasses.SystemFlagsAttr;
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotClasses.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotClasses.cs
@@ -11,6 +11,7 @@ namespace Godot.SourceGenerators
         public const string SignalAttr = "Godot.SignalAttribute";
         public const string MustBeVariantAttr = "Godot.MustBeVariantAttribute";
         public const string GodotClassNameAttr = "Godot.GodotClassNameAttribute";
+        public const string GlobalClassAttr = "Godot.GlobalClassAttribute";
         public const string SystemFlagsAttr = "System.FlagsAttribute";
     }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -547,23 +547,30 @@ namespace Godot.SourceGenerators
             {
                 if (memberNamedType.InheritsFrom("GodotSharp", "Godot.Resource"))
                 {
-                    string nativeTypeName = memberNamedType.GetGodotScriptNativeClassName()!;
-
                     hint = PropertyHint.ResourceType;
-                    hintString = nativeTypeName;
+                    hintString = GetTypeName(memberNamedType);
 
                     return true;
                 }
 
                 if (memberNamedType.InheritsFrom("GodotSharp", "Godot.Node"))
                 {
-                    string nativeTypeName = memberNamedType.GetGodotScriptNativeClassName()!;
-
                     hint = PropertyHint.NodeType;
-                    hintString = nativeTypeName;
+                    hintString = GetTypeName(memberNamedType);
 
                     return true;
                 }
+            }
+
+            static string GetTypeName(INamedTypeSymbol memberSymbol)
+            {
+                if (memberSymbol.GetAttributes()
+                    .Any(a => a.AttributeClass?.IsGodotGlobalClassAttribute() ?? false))
+                {
+                    return memberSymbol.Name;
+                }
+
+                return memberSymbol.GetGodotScriptNativeClassName()!;
             }
 
             static bool GetStringArrayEnumHint(VariantType elementVariantType,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GlobalClassAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GlobalClassAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+#nullable enable
+
+namespace Godot
+{
+    /// <summary>
+    /// Exposes the target class as a global script class to Godot Engine.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class GlobalClassAttribute : Attribute { }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/IconAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/IconAttribute.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Godot
+{
+    /// <summary>
+    /// Specifies a custom icon for representing this class in the Godot Editor.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class IconAttribute : Attribute
+    {
+        /// <summary>
+        /// File path to a custom icon for representing this class in the Godot Editor.
+        /// </summary>
+        public string Path { get; }
+
+        /// <summary>
+        /// Specify the custom icon that represents the class.
+        /// </summary>
+        /// <param name="path">File path to the custom icon.</param>
+        public IconAttribute(string path)
+        {
+            Path = path;
+        }
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
@@ -25,7 +25,7 @@ namespace Godot.Bridge
         public delegate* unmanaged<godot_string*, godot_ref*, void> ScriptManagerBridge_GetOrCreateScriptBridgeForPath;
         public delegate* unmanaged<IntPtr, void> ScriptManagerBridge_RemoveScriptBridge;
         public delegate* unmanaged<IntPtr, godot_bool> ScriptManagerBridge_TryReloadRegisteredScriptWithClass;
-        public delegate* unmanaged<IntPtr, godot_bool*, godot_array*, godot_dictionary*, godot_dictionary*, godot_ref*, void> ScriptManagerBridge_UpdateScriptClassInfo;
+        public delegate* unmanaged<IntPtr, godot_string*, godot_bool*, godot_bool*, godot_string*, godot_array*, godot_dictionary*, godot_dictionary*, godot_ref*, void> ScriptManagerBridge_UpdateScriptClassInfo;
         public delegate* unmanaged<IntPtr, IntPtr*, godot_bool, godot_bool> ScriptManagerBridge_SwapGCHandleForType;
         public delegate* unmanaged<IntPtr, delegate* unmanaged<IntPtr, godot_string*, void*, int, void>, void> ScriptManagerBridge_GetPropertyInfoList;
         public delegate* unmanaged<IntPtr, delegate* unmanaged<IntPtr, void*, int, void>, void> ScriptManagerBridge_GetPropertyDefaultValues;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -37,6 +37,8 @@ namespace Godot.NativeInterop
 
         // Custom functions
 
+        internal static partial godot_bool godotsharp_dotnet_module_is_initialized();
+
         public static partial IntPtr godotsharp_method_bind_get_method(in godot_string_name p_classname,
             in godot_string_name p_methodname);
 
@@ -51,6 +53,8 @@ namespace Godot.NativeInterop
 
         internal static partial void godotsharp_stack_info_vector_destroy(
             ref DebuggingUtils.godot_stack_info_vector p_stack_info_vector);
+
+        internal static partial void godotsharp_internal_editor_file_system_update_file(in godot_string p_script_path);
 
         internal static partial void godotsharp_internal_script_debugger_send_error(in godot_string p_func,
             in godot_string p_file, int p_line, in godot_string p_err, in godot_string p_descr,

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -60,7 +60,9 @@
     <Compile Include="Core\Attributes\ExportCategoryAttribute.cs" />
     <Compile Include="Core\Attributes\ExportGroupAttribute.cs" />
     <Compile Include="Core\Attributes\ExportSubgroupAttribute.cs" />
+    <Compile Include="Core\Attributes\GlobalClassAttribute.cs" />
     <Compile Include="Core\Attributes\GodotClassNameAttribute.cs" />
+    <Compile Include="Core\Attributes\IconAttribute.cs" />
     <Compile Include="Core\Attributes\MustBeVariantAttribute.cs" />
     <Compile Include="Core\Attributes\RpcAttribute.cs" />
     <Compile Include="Core\Attributes\ScriptPathAttribute.cs" />

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -40,6 +40,10 @@
 #include "core/os/os.h"
 #include "core/string/string_name.h"
 
+#ifdef TOOLS_ENABLED
+#include "editor/editor_file_system.h"
+#endif
+
 #include "../interop_types.h"
 
 #include "modules/mono/csharp_script.h"
@@ -56,6 +60,10 @@ extern "C" {
 static_assert(sizeof(SafeRefCount) == sizeof(uint32_t));
 
 typedef Object *(*godotsharp_class_creation_func)();
+
+bool godotsharp_dotnet_module_is_initialized() {
+	return GDMono::get_singleton()->is_initialized();
+}
 
 MethodBind *godotsharp_method_bind_get_method(const StringName *p_classname, const StringName *p_methodname) {
 	return ClassDB::get_method(*p_classname, *p_methodname);
@@ -302,6 +310,20 @@ void godotsharp_internal_tie_managed_to_unmanaged_with_pre_setup(GCHandleIntPtr 
 
 void godotsharp_internal_new_csharp_script(Ref<CSharpScript> *r_dest) {
 	memnew_placement(r_dest, Ref<CSharpScript>(memnew(CSharpScript)));
+}
+
+void godotsharp_internal_editor_file_system_update_file(const String *p_script_path) {
+#if TOOLS_ENABLED
+	// If the EditorFileSystem singleton is available, update the file;
+	// otherwise, the file will be updated when the singleton becomes available.
+	EditorFileSystem *efs = EditorFileSystem::get_singleton();
+	if (efs) {
+		efs->update_file(*p_script_path);
+	}
+#else
+	// EditorFileSystem is only available when running in the Godot editor.
+	DEV_ASSERT(false);
+#endif
 }
 
 bool godotsharp_internal_script_load(const String *p_path, Ref<CSharpScript> *r_dest) {
@@ -1391,11 +1413,13 @@ void godotsharp_object_to_string(Object *p_ptr, godot_string *r_str) {
 // The order in this array must match the declaration order of
 // the methods in 'GodotSharp/Core/NativeInterop/NativeFuncs.cs'.
 static const void *unmanaged_callbacks[]{
+	(void *)godotsharp_dotnet_module_is_initialized,
 	(void *)godotsharp_method_bind_get_method,
 	(void *)godotsharp_get_class_constructor,
 	(void *)godotsharp_engine_get_singleton,
 	(void *)godotsharp_stack_info_vector_resize,
 	(void *)godotsharp_stack_info_vector_destroy,
+	(void *)godotsharp_internal_editor_file_system_update_file,
 	(void *)godotsharp_internal_script_debugger_send_error,
 	(void *)godotsharp_internal_script_debugger_is_active,
 	(void *)godotsharp_internal_object_get_associated_gchandle,

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -443,6 +443,8 @@ void GDMono::initialize() {
 	print_verbose(".NET: GodotPlugins initialized");
 
 	_on_core_api_assembly_loaded();
+
+	initialized = true;
 }
 
 #ifdef TOOLS_ENABLED
@@ -527,14 +529,6 @@ Error GDMono::reload_project_assemblies() {
 
 GDMono::GDMono() {
 	singleton = this;
-
-	runtime_initialized = false;
-	finalizing_scripts_domain = false;
-
-	api_core_hash = 0;
-#ifdef TOOLS_ENABLED
-	api_editor_hash = 0;
-#endif
 }
 
 GDMono::~GDMono() {

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -59,8 +59,9 @@ struct PluginCallbacks {
 } // namespace gdmono
 
 class GDMono {
-	bool runtime_initialized;
-	bool finalizing_scripts_domain;
+	bool initialized = false;
+	bool runtime_initialized = false;
+	bool finalizing_scripts_domain = false;
 
 	void *hostfxr_dll_handle = nullptr;
 	bool is_native_aot = false;
@@ -72,9 +73,9 @@ class GDMono {
 	bool _load_project_assembly();
 #endif
 
-	uint64_t api_core_hash;
+	uint64_t api_core_hash = 0;
 #ifdef TOOLS_ENABLED
-	uint64_t api_editor_hash;
+	uint64_t api_editor_hash = 0;
 #endif
 	void _init_godot_api_hashes();
 
@@ -119,6 +120,9 @@ public:
 		return singleton;
 	}
 
+	_FORCE_INLINE_ bool is_initialized() const {
+		return initialized;
+	}
 	_FORCE_INLINE_ bool is_runtime_initialized() const {
 		return runtime_initialized;
 	}

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -90,7 +90,7 @@ struct ManagedCallbacks {
 	using FuncScriptManagerBridge_GetOrCreateScriptBridgeForPath = void(GD_CLR_STDCALL *)(const String *, Ref<CSharpScript> *);
 	using FuncScriptManagerBridge_RemoveScriptBridge = void(GD_CLR_STDCALL *)(const CSharpScript *);
 	using FuncScriptManagerBridge_TryReloadRegisteredScriptWithClass = bool(GD_CLR_STDCALL *)(const CSharpScript *);
-	using FuncScriptManagerBridge_UpdateScriptClassInfo = void(GD_CLR_STDCALL *)(const CSharpScript *, bool *, Array *, Dictionary *, Dictionary *, Ref<CSharpScript> *);
+	using FuncScriptManagerBridge_UpdateScriptClassInfo = void(GD_CLR_STDCALL *)(const CSharpScript *, String *, bool *, bool *, String *, Array *, Dictionary *, Dictionary *, Ref<CSharpScript> *);
 	using FuncScriptManagerBridge_SwapGCHandleForType = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, GCHandleIntPtr *, bool);
 	using FuncScriptManagerBridge_GetPropertyInfoList = void(GD_CLR_STDCALL *)(CSharpScript *, Callback_ScriptManagerBridge_GetPropertyInfoList_Add);
 	using FuncScriptManagerBridge_GetPropertyDefaultValues = void(GD_CLR_STDCALL *)(CSharpScript *, Callback_ScriptManagerBridge_GetPropertyDefaultValues_Add);


### PR DESCRIPTION
Port of https://github.com/godotengine/godot/pull/63126 originally implemented by @willnationsdev to the current `master`.

Adds support for C# to be able to define global classes using the `[GlobalClass]` attribute and export global script classes using the `[Export]` attribute.

### Differences from the original PR

- The additional `ExportAttribute` constructor is not included.
	- It seems this did not make it in the GDScript version either and I think it may be better as a separate attribute anyway.
- The `[Global]` attribute was renamed to `[GlobalClass]`.
	- I think the original name was a bit too vague, but to be honest I'm also not very happy with the new name either. I'll gladly take suggestions.
- The `[GlobalClass]` attribute always uses the name of the C# class.
	- The original implementation allowed specifying a different name but I don't think that's useful in C# where classes already have names.
- The `[GlobalClass]` attribute does not contain the icon path, a separate `[Icon]` attribute is provided.
	-  The `[Icon]` attribute allows specifying the path to the icon of a C# class similar to the `@icon` annotation in GDScript.
	- This allows specifying an icon even when the class is not registered as a global class.
- The `EditorFileSystem::update_file` call was moved from `CSharpLanguage::reload_assemblies` to `ScriptManagerBridge.LookupScriptsInAssembly`.
	- The original implementation wasn't working properly, global script classes weren't getting registered when they should.
	- @neikeq helped me figure out how to make it work.

### Related issues and PRs

- Fixes https://github.com/godotengine/godot-proposals/issues/18 for C#.
- Closes https://github.com/godotengine/godot/pull/63126 as superseded.
- Fixes https://github.com/godotengine/godot/issues/69795.
- Fixes https://github.com/godotengine/godot/issues/26875.
- Closes https://github.com/godotengine/godot/pull/48056 as superseded.