### PR TITLE
Fix windowsize for fullscreen windows on windowcreation on Windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3959,10 +3959,19 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 
 		wd.im_position = Vector2();
 
-		// FIXME this is wrong in cases where the window coordinates were changed due to full screen mode; use WindowRect
-		wd.last_pos = p_rect.position;
-		wd.width = p_rect.size.width;
-		wd.height = p_rect.size.height;
+		if (p_mode == WINDOW_MODE_FULLSCREEN || p_mode == WINDOW_MODE_EXCLUSIVE_FULLSCREEN || p_mode == WINDOW_MODE_MAXIMIZED) {
+			RECT r;
+			GetClientRect(wd.hWnd, &r);
+			ClientToScreen(wd.hWnd, (POINT *)&r.left);
+			ClientToScreen(wd.hWnd, (POINT *)&r.right);
+			wd.last_pos = Point2i(r.left, r.top) - _get_screens_origin();
+			wd.width = r.right - r.left;
+			wd.height = r.bottom - r.top;
+		} else {
+			wd.last_pos = p_rect.position;
+			wd.width = p_rect.size.width;
+			wd.height = p_rect.size.height;
+		}
 
 		window_id_counter++;
 	}


### PR DESCRIPTION
Fixes #72596

Thanks to the writer of the FIXME comment. It helped a lot!
