### PR TITLE
DisplayServerWindows: Update `last_focused_window` when the focused subwindow is deleted

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -829,6 +829,10 @@ void DisplayServerWindows::delete_sub_window(WindowID p_window) {
 	}
 	DestroyWindow(windows[p_window].hWnd);
 	windows.erase(p_window);
+
+	if (last_focused_window == p_window) {
+		last_focused_window = INVALID_WINDOW_ID;
+	}
 }
 
 void DisplayServerWindows::gl_window_make_current(DisplayServer::WindowID p_window_id) {


### PR DESCRIPTION
Fixes #72623

When a focused subwindow is deleted and another window is not immediately focused, this fix will cause mouse motion events to be sent to a valid window instead of producing errors.