### PR TITLE
Print name of Vulkan rendering method on startup

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -179,7 +179,7 @@ typedef void (*DEBUGPROCARB)(GLenum source,
 typedef void (*DebugMessageCallbackARB)(DEBUGPROCARB callback, const void *userParam);
 
 void RasterizerGLES3::initialize() {
-	print_line("OpenGL Renderer: " + RS::get_singleton()->get_video_adapter_name());
+	print_line(vformat("OpenGL API %s - Compatibility - Using Device: %s - %s", RS::get_singleton()->get_video_adapter_api_version(), RS::get_singleton()->get_video_adapter_vendor(), RS::get_singleton()->get_video_adapter_name()));
 }
 
 void RasterizerGLES3::finalize() {

--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -1299,8 +1299,15 @@ Error VulkanContext::_create_physical_device(VkSurfaceKHR p_surface) {
 	// Get device version
 	device_api_version = gpu_props.apiVersion;
 
+	String rendering_method;
+	if (OS::get_singleton()->get_current_rendering_method() == "mobile") {
+		rendering_method = "Forward Mobile";
+	} else {
+		rendering_method = "Forward+";
+	}
+
 	// Output our device version
-	print_line("Vulkan API " + get_device_api_version() + " - " + "Using Vulkan Device #" + itos(device_index) + ": " + device_vendor + " - " + device_name);
+	print_line(vformat("Vulkan API %s - %s - Using Vulkan Device #%d: %s - %s", get_device_api_version(), rendering_method, device_index, device_vendor, device_name));
 
 	{
 		Error _err = _initialize_device_extensions();


### PR DESCRIPTION
This helps troubleshooting as the CLI logs now distinguish between Forward+ and Forward Mobile.

## Preview

### Forward+

```
Godot Engine v4.0.beta.custom_build.54346e94a - https://godotengine.org
Vulkan API 1.3.224 - Forward+ - Using Vulkan Device #0: NVIDIA - NVIDIA GeForce RTX 4090
```

### Forward Mobile

```
Godot Engine v4.0.beta.custom_build.54346e94a - https://godotengine.org
Vulkan API 1.3.224 - Forward Mobile - Using Vulkan Device #0: NVIDIA - NVIDIA GeForce RTX 4090
```

### Compatibility (not changed in this PR)

```
Godot Engine v4.0.beta.custom_build.c2b14df5b - https://godotengine.org
OpenGL API 3.3.0 NVIDIA 525.85.05 - Compatibility - Using Device: NVIDIA Corporation - NVIDIA GeForce RTX 4090/PCIe/SSE2
```