### PR TITLE
Remove `Viewport::_get_input_pre_xform`

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1052,7 +1052,7 @@ Camera2D *Viewport::get_camera_2d() const {
 }
 
 Transform2D Viewport::get_final_transform() const {
-	return _get_input_pre_xform().affine_inverse() * stretch_transform * global_canvas_transform;
+	return stretch_transform * global_canvas_transform;
 }
 
 void Viewport::assign_next_enabled_camera_2d(const StringName &p_camera_group) {
@@ -1136,14 +1136,6 @@ void Viewport::set_positional_shadow_atlas_quadrant_subdiv(int p_quadrant, Posit
 Viewport::PositionalShadowAtlasQuadrantSubdiv Viewport::get_positional_shadow_atlas_quadrant_subdiv(int p_quadrant) const {
 	ERR_FAIL_INDEX_V(p_quadrant, 4, SHADOW_ATLAS_QUADRANT_SUBDIV_DISABLED);
 	return positional_shadow_atlas_quadrant_subdiv[p_quadrant];
-}
-
-Transform2D Viewport::_get_input_pre_xform() const {
-	const Window *this_window = Object::cast_to<Window>(this);
-	if (this_window) {
-		return this_window->window_transform.affine_inverse();
-	}
-	return Transform2D();
 }
 
 Ref<InputEvent> Viewport::_make_input_local(const Ref<InputEvent> &ev) {
@@ -4207,7 +4199,7 @@ Transform2D SubViewport::get_screen_transform() const {
 	} else {
 		WARN_PRINT_ONCE("SubViewport is not a child of a SubViewportContainer. get_screen_transform doesn't return the actual screen position.");
 	}
-	return container_transform * Viewport::get_screen_transform();
+	return container_transform * get_final_transform();
 }
 
 Transform2D SubViewport::get_popup_base_transform() const {
@@ -4216,13 +4208,13 @@ Transform2D SubViewport::get_popup_base_transform() const {
 	}
 	SubViewportContainer *c = Object::cast_to<SubViewportContainer>(get_parent());
 	if (!c) {
-		return Viewport::get_screen_transform();
+		return get_final_transform();
 	}
 	Transform2D container_transform;
 	if (c->is_stretch_enabled()) {
 		container_transform.scale(Vector2(c->get_stretch_shrink(), c->get_stretch_shrink()));
 	}
-	return c->get_screen_transform() * container_transform * Viewport::get_screen_transform();
+	return c->get_screen_transform() * container_transform * get_final_transform();
 }
 
 void SubViewport::_notification(int p_what) {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -407,8 +407,6 @@ private:
 	void _perform_drop(Control *p_control = nullptr, Point2 p_pos = Point2());
 	void _gui_cleanup_internal_state(Ref<InputEvent> p_event);
 
-	_FORCE_INLINE_ Transform2D _get_input_pre_xform() const;
-
 	Ref<InputEvent> _make_input_local(const Ref<InputEvent> &ev);
 
 	friend class Control;
@@ -509,7 +507,7 @@ public:
 	void set_global_canvas_transform(const Transform2D &p_transform);
 	Transform2D get_global_canvas_transform() const;
 
-	Transform2D get_final_transform() const;
+	virtual Transform2D get_final_transform() const;
 	void assign_next_enabled_camera_2d(const StringName &p_camera_group);
 
 	void gui_set_root_order_dirty();

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2115,13 +2115,17 @@ bool Window::is_auto_translating() const {
 	return auto_translate;
 }
 
+Transform2D Window::get_final_transform() const {
+	return window_transform * stretch_transform * global_canvas_transform;
+}
+
 Transform2D Window::get_screen_transform() const {
 	Transform2D embedder_transform;
 	if (_get_embedder()) {
 		embedder_transform.translate_local(get_position());
 		embedder_transform = _get_embedder()->get_screen_transform() * embedder_transform;
 	}
-	return embedder_transform * Viewport::get_screen_transform();
+	return embedder_transform * get_final_transform();
 }
 
 Transform2D Window::get_popup_base_transform() const {
@@ -2130,7 +2134,7 @@ Transform2D Window::get_popup_base_transform() const {
 	}
 	Transform2D popup_base_transform;
 	popup_base_transform.set_origin(get_position());
-	popup_base_transform *= Viewport::get_screen_transform();
+	popup_base_transform *= get_final_transform();
 	if (_get_embedder()) {
 		return _get_embedder()->get_popup_base_transform() * popup_base_transform;
 	}

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -376,6 +376,7 @@ public:
 
 	//
 
+	virtual Transform2D get_final_transform() const override;
 	virtual Transform2D get_screen_transform() const override;
 	virtual Transform2D get_popup_base_transform() const override;
 


### PR DESCRIPTION
This function is only relevant for `Window`. So this PR moves the functionality to the `Window`-class.
Also simplify `get_final_transform` calls.

followup on #59310