### PR TITLE
C#: Declare `IEquatable<>` interface for `StringName`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
@@ -10,7 +10,7 @@ namespace Godot
     /// Comparing them is much faster than with regular strings, because only the pointers are compared,
     /// not the whole strings.
     /// </summary>
-    public sealed class StringName : IDisposable
+    public sealed class StringName : IDisposable, IEquatable<StringName>
     {
         internal godot_string_name.movable NativeValue;
 


### PR DESCRIPTION
The implementation already existed, just the actual interface declaration was missing.