### PR TITLE
InputEventJoypadMotion axis_value description is wrong in the documentation

### DIFF
--- a/doc/classes/InputEventJoypadMotion.xml
+++ b/doc/classes/InputEventJoypadMotion.xml
@@ -13,8 +13,8 @@
 		<member name="axis" type="int" setter="set_axis" getter="get_axis" enum="JoyAxis" default="0">
 			Axis identifier. Use one of the [enum JoyAxis] axis constants.
 		</member>
-		<member name="axis_value" type="float" setter="set_axis_value" getter="get_axis_value" default="0.0">
-			Current position of the joystick on the given axis. The value ranges from [code]-1.0[/code] to [code]1.0[/code]. A value of [code]0[/code] means the axis is in its resting position.
+		<member name="axis_value" type="float" setter="set_axis_value" getter="get_axis_value" default="1.0">
+			Direction identifier. [code]-1.0[/code] for a negitive axis or [code]1.0[/code] for a positive axis.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
This is an example of a action from a the project.godot file. The axis value shows what direction it will take a InputEventJoypadMotion in. In this case the negative left joystick x axis, meaning that it will look for the range from -1 to 0 instead of 0 to 1.

Test={
"deadzone": 0.5,
"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":-1.0,"script":null) ]
}

This is helpful for people trying to make controls through code.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
