### PR TITLE
C#: Implement `IEquatable<>` and equality operators in `NodePath`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -459,6 +459,10 @@ namespace Godot.NativeInterop
 
         public static partial godot_bool godotsharp_node_path_is_absolute(in godot_node_path p_self);
 
+        public static partial godot_bool godotsharp_node_path_equals(in godot_node_path p_self, in godot_node_path p_other);
+
+        public static partial int godotsharp_node_path_hash(in godot_node_path p_self);
+
         // GD, etc
 
         internal static partial void godotsharp_bytes_to_var(in godot_packed_byte_array p_bytes,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NodePath.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NodePath.cs
@@ -39,7 +39,7 @@ namespace Godot
     /// new NodePath("/root/MyAutoload"); // If you have an autoloaded node or scene.
     /// </code>
     /// </example>
-    public sealed class NodePath : IDisposable
+    public sealed class NodePath : IDisposable, IEquatable<NodePath>
     {
         internal godot_node_path.movable NativeValue;
 
@@ -288,5 +288,37 @@ namespace Godot
         /// </summary>
         /// <returns>If the <see cref="NodePath"/> is empty.</returns>
         public bool IsEmpty => NativeValue.DangerousSelfRef.IsEmpty;
+
+        public static bool operator ==(NodePath left, NodePath right)
+        {
+            if (left is null)
+                return right is null;
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(NodePath left, NodePath right)
+        {
+            return !(left == right);
+        }
+
+        public bool Equals(NodePath other)
+        {
+            if (other is null)
+                return false;
+            var self = (godot_node_path)NativeValue;
+            var otherNative = (godot_node_path)other.NativeValue;
+            return NativeFuncs.godotsharp_node_path_equals(self, otherNative).ToBool();
+        }
+
+        public override bool Equals(object obj)
+        {
+            return ReferenceEquals(this, obj) || (obj is NodePath other && Equals(other));
+        }
+
+        public override int GetHashCode()
+        {
+            var self = (godot_node_path)NativeValue;
+            return NativeFuncs.godotsharp_node_path_hash(self);
+        }
     }
 }

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -1141,6 +1141,14 @@ bool godotsharp_node_path_is_absolute(const NodePath *p_self) {
 	return p_self->is_absolute();
 }
 
+bool godotsharp_node_path_equals(const NodePath *p_self, const NodePath *p_other) {
+	return *p_self == *p_other;
+}
+
+int godotsharp_node_path_hash(const NodePath *p_self) {
+	return p_self->hash();
+}
+
 void godotsharp_randomize() {
 	Math::randomize();
 }
@@ -1477,6 +1485,8 @@ static const void *unmanaged_callbacks[]{
 	(void *)godotsharp_node_path_get_subname,
 	(void *)godotsharp_node_path_get_subname_count,
 	(void *)godotsharp_node_path_is_absolute,
+	(void *)godotsharp_node_path_equals,
+	(void *)godotsharp_node_path_hash,
 	(void *)godotsharp_bytes_to_var,
 	(void *)godotsharp_convert,
 	(void *)godotsharp_hash,


### PR DESCRIPTION
- Implement `IEquatable<>` interface.
- Implement `==` and `!=` operators.
- Override `Equals` and `GetHashCode`.

Fixes #72137