### PR TITLE
[3.x] Add an option to show a `TextEdit` caret in readonly mode

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -738,7 +738,7 @@ void TextEdit::_notification(int p_what) {
 			cache.style_normal->draw(ci, Rect2(Point2(), size));
 			if (readonly) {
 				cache.style_readonly->draw(ci, Rect2(Point2(), size));
-				draw_caret = false;
+        draw_caret = is_caret_on_readonly();
 			}
 			if (has_focus()) {
 				cache.style_focus->draw(ci, Rect2(Point2(), size));
@@ -6036,6 +6036,10 @@ void TextEdit::clear_executing_line() {
 	update();
 }
 
+void TextEdit::set_caret_on_readonly(bool p_value) {
+  caret_on_readonly = p_value;
+}
+
 bool TextEdit::is_line_set_as_bookmark(int p_line) const {
 	ERR_FAIL_INDEX_V(p_line, text.size(), false);
 	return text.is_bookmark(p_line);
@@ -6279,6 +6283,10 @@ bool TextEdit::is_line_comment(int p_line) const {
 		}
 	}
 	return false;
+}
+
+bool TextEdit::is_caret_on_readonly() {
+  return caret_on_readonly;
 }
 
 bool TextEdit::can_fold(int p_line) const {
@@ -7535,6 +7543,9 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("redo"), &TextEdit::redo);
 	ClassDB::bind_method(D_METHOD("clear_undo_history"), &TextEdit::clear_undo_history);
 
+	ClassDB::bind_method(D_METHOD("set_caret_on_readonly", "enable"), &TextEdit::set_caret_on_readonly);
+  ClassDB::bind_method(D_METHOD("is_caret_on_readonly"), &TextEdit::is_caret_on_readonly);
+
 	ClassDB::bind_method(D_METHOD("set_show_line_numbers", "enable"), &TextEdit::set_show_line_numbers);
 	ClassDB::bind_method(D_METHOD("is_show_line_numbers_enabled"), &TextEdit::is_show_line_numbers_enabled);
 	ClassDB::bind_method(D_METHOD("set_draw_tabs", "enable"), &TextEdit::set_draw_tabs);
@@ -7635,6 +7646,7 @@ void TextEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_blink"), "cursor_set_blink_enabled", "cursor_get_blink_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "caret_blink_speed", PROPERTY_HINT_RANGE, "0.1,10,0.01"), "cursor_set_blink_speed", "cursor_get_blink_speed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_moving_by_right_click"), "set_right_click_moves_caret", "is_right_click_moving_caret");
+  ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_on_readonly"), "set_caret_on_readonly", "is_caret_on_readonly");
 
 	ADD_SIGNAL(MethodInfo("cursor_changed"));
 	ADD_SIGNAL(MethodInfo("text_changed"));
@@ -7661,6 +7673,7 @@ void TextEdit::_bind_methods() {
 TextEdit::TextEdit() {
 	setting_row = false;
 	draw_tabs = false;
+  caret_on_readonly = false;
 	draw_spaces = false;
 	override_selected_font_color = false;
 	draw_caret = true;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -738,7 +738,7 @@ void TextEdit::_notification(int p_what) {
 			cache.style_normal->draw(ci, Rect2(Point2(), size));
 			if (readonly) {
 				cache.style_readonly->draw(ci, Rect2(Point2(), size));
-        draw_caret = is_caret_on_readonly();
+				draw_caret = is_caret_on_readonly();
 			}
 			if (has_focus()) {
 				cache.style_focus->draw(ci, Rect2(Point2(), size));
@@ -6037,7 +6037,7 @@ void TextEdit::clear_executing_line() {
 }
 
 void TextEdit::set_caret_on_readonly(bool p_value) {
-  caret_on_readonly = p_value;
+	caret_on_readonly = p_value;
 }
 
 bool TextEdit::is_line_set_as_bookmark(int p_line) const {
@@ -6286,7 +6286,7 @@ bool TextEdit::is_line_comment(int p_line) const {
 }
 
 bool TextEdit::is_caret_on_readonly() {
-  return caret_on_readonly;
+	return caret_on_readonly;
 }
 
 bool TextEdit::can_fold(int p_line) const {
@@ -7544,7 +7544,7 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear_undo_history"), &TextEdit::clear_undo_history);
 
 	ClassDB::bind_method(D_METHOD("set_caret_on_readonly", "enable"), &TextEdit::set_caret_on_readonly);
-  ClassDB::bind_method(D_METHOD("is_caret_on_readonly"), &TextEdit::is_caret_on_readonly);
+	ClassDB::bind_method(D_METHOD("is_caret_on_readonly"), &TextEdit::is_caret_on_readonly);
 
 	ClassDB::bind_method(D_METHOD("set_show_line_numbers", "enable"), &TextEdit::set_show_line_numbers);
 	ClassDB::bind_method(D_METHOD("is_show_line_numbers_enabled"), &TextEdit::is_show_line_numbers_enabled);
@@ -7646,7 +7646,7 @@ void TextEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_blink"), "cursor_set_blink_enabled", "cursor_get_blink_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "caret_blink_speed", PROPERTY_HINT_RANGE, "0.1,10,0.01"), "cursor_set_blink_speed", "cursor_get_blink_speed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_moving_by_right_click"), "set_right_click_moves_caret", "is_right_click_moving_caret");
-  ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_on_readonly"), "set_caret_on_readonly", "is_caret_on_readonly");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_on_readonly"), "set_caret_on_readonly", "is_caret_on_readonly");
 
 	ADD_SIGNAL(MethodInfo("cursor_changed"));
 	ADD_SIGNAL(MethodInfo("text_changed"));
@@ -7673,7 +7673,7 @@ void TextEdit::_bind_methods() {
 TextEdit::TextEdit() {
 	setting_row = false;
 	draw_tabs = false;
-  caret_on_readonly = false;
+	caret_on_readonly = false;
 	draw_spaces = false;
 	override_selected_font_color = false;
 	draw_caret = true;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -356,6 +356,7 @@ private:
 	Timer *caret_blink_timer;
 	bool caret_blink_enabled;
 	bool draw_caret;
+  bool caret_on_readonly;
 	bool window_has_focus;
 	bool block_caret;
 	bool right_click_moves_caret;
@@ -628,6 +629,9 @@ public:
 	bool is_line_set_as_bookmark(int p_line) const;
 	void get_bookmarks(List<int> *p_bookmarks) const;
 	Array get_bookmarks_array() const;
+
+  bool is_caret_on_readonly();
+  void set_caret_on_readonly(bool p_value);
 
 	void set_line_as_breakpoint(int p_line, bool p_breakpoint);
 	bool is_line_set_as_breakpoint(int p_line) const;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -356,7 +356,7 @@ private:
 	Timer *caret_blink_timer;
 	bool caret_blink_enabled;
 	bool draw_caret;
-  bool caret_on_readonly;
+	bool caret_on_readonly;
 	bool window_has_focus;
 	bool block_caret;
 	bool right_click_moves_caret;
@@ -630,8 +630,8 @@ public:
 	void get_bookmarks(List<int> *p_bookmarks) const;
 	Array get_bookmarks_array() const;
 
-  bool is_caret_on_readonly();
-  void set_caret_on_readonly(bool p_value);
+	bool is_caret_on_readonly();
+	void set_caret_on_readonly(bool p_value);
 
 	void set_line_as_breakpoint(int p_line, bool p_breakpoint);
 	bool is_line_set_as_breakpoint(int p_line) const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

It's a very simple feature: A property to set if the caret should be shown in readonly or not on the TextEdit node.

The reason I've done it is because it opens some possibilities - my specific need is to vimify the code editor later (and to learn c++ of course, 'cause I'm a noob and all).