### PR TITLE
Expose RenderingServer.canvas_light_blend_mode

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -630,6 +630,14 @@
 				Sets a light occluder's [Transform2D].
 			</description>
 		</method>
+		<method name="canvas_light_set_blend_mode">
+			<return type="void" />
+			<param index="0" name="light" type="RID" />
+			<param index="1" name="mode" type="int" enum="RenderingServer.CanvasLightBlendMode" />
+			<description>
+				Sets the blend mode for the given canvas light. See [enum CanvasLightBlendMode] for options. Equivalent to [member Light2D.blend_mode].
+			</description>
+		</method>
 		<method name="canvas_light_set_color">
 			<return type="void" />
 			<param index="0" name="light" type="RID" />

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2675,6 +2675,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_light_set_shadow_filter", "light", "filter"), &RenderingServer::canvas_light_set_shadow_filter);
 	ClassDB::bind_method(D_METHOD("canvas_light_set_shadow_color", "light", "color"), &RenderingServer::canvas_light_set_shadow_color);
 	ClassDB::bind_method(D_METHOD("canvas_light_set_shadow_smooth", "light", "smooth"), &RenderingServer::canvas_light_set_shadow_smooth);
+	ClassDB::bind_method(D_METHOD("canvas_light_set_blend_mode", "light", "mode"), &RenderingServer::canvas_light_set_blend_mode);
 
 	BIND_ENUM_CONSTANT(CANVAS_LIGHT_MODE_POINT);
 	BIND_ENUM_CONSTANT(CANVAS_LIGHT_MODE_DIRECTIONAL);


### PR DESCRIPTION
This appears to have been missed in the refactor

This is needed for users to setup lights through the RenderingServer

