### PR TITLE
[TextServer] Cleanup text server interlocking.

### DIFF
--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -112,7 +112,6 @@ using namespace godot;
 
 class TextServerFallback : public TextServerExtension {
 	GDCLASS(TextServerFallback, TextServerExtension);
-	_THREAD_SAFE_CLASS_
 
 	HashMap<StringName, int32_t> feature_sets;
 	HashMap<int32_t, StringName> feature_sets_inv;
@@ -235,18 +234,21 @@ class TextServerFallback : public TextServerExtension {
 #ifdef MODULE_FREETYPE_ENABLED
 		FT_Face face = nullptr;
 		FT_StreamRec stream;
+		const Mutex *ft_mutex = nullptr;
 #endif
 
 		~FontForSizeFallback() {
 #ifdef MODULE_FREETYPE_ENABLED
 			if (face != nullptr) {
+				ft_mutex->lock();
 				FT_Done_Face(face);
+				ft_mutex->unlock();
 			}
 #endif
 		}
 	};
 
-	struct FontFallback {
+	struct FontFallback : public RefCounted {
 		Mutex mutex;
 
 		TextServer::FontAntialiasing antialiasing = TextServer::FONT_ANTIALIASING_GRAY;
@@ -293,19 +295,19 @@ class TextServerFallback : public TextServerExtension {
 		}
 	};
 
-	_FORCE_INLINE_ FontTexturePosition find_texture_pos_for_glyph(FontForSizeFallback *p_data, int p_color_size, Image::Format p_image_format, int p_width, int p_height, bool p_msdf) const;
+	_FORCE_INLINE_ FontTexturePosition _find_texture_pos_for_glyph(FontForSizeFallback *p_data, int p_color_size, Image::Format p_image_format, int p_width, int p_height, bool p_msdf) const;
 #ifdef MODULE_MSDFGEN_ENABLED
-	_FORCE_INLINE_ FontGlyph rasterize_msdf(FontFallback *p_font_data, FontForSizeFallback *p_data, int p_pixel_range, int p_rect_margin, FT_Outline *outline, const Vector2 &advance) const;
+	_FORCE_INLINE_ FontGlyph _rasterize_msdf(Ref<FontFallback> &p_font_data, FontForSizeFallback *p_data, int p_pixel_range, int p_rect_margin, FT_Outline *outline, const Vector2 &advance) const;
 #endif
 #ifdef MODULE_FREETYPE_ENABLED
-	_FORCE_INLINE_ FontGlyph rasterize_bitmap(FontForSizeFallback *p_data, int p_rect_margin, FT_Bitmap bitmap, int yofs, int xofs, const Vector2 &advance, bool p_bgra) const;
+	_FORCE_INLINE_ FontGlyph _rasterize_bitmap(FontForSizeFallback *p_data, int p_rect_margin, FT_Bitmap bitmap, int yofs, int xofs, const Vector2 &advance, bool p_bgra) const;
 #endif
-	_FORCE_INLINE_ bool _ensure_glyph(FontFallback *p_font_data, const Vector2i &p_size, int32_t p_glyph) const;
-	_FORCE_INLINE_ bool _ensure_cache_for_size(FontFallback *p_font_data, const Vector2i &p_size) const;
-	_FORCE_INLINE_ void _font_clear_cache(FontFallback *p_font_data);
+	_FORCE_INLINE_ bool _ensure_glyph(Ref<FontFallback> &p_font_data, const Vector2i &p_size, int32_t p_glyph) const;
+	_FORCE_INLINE_ bool _ensure_cache_for_size(Ref<FontFallback> &p_font_data, const Vector2i &p_size) const;
+	_FORCE_INLINE_ void _font_clear_cache(Ref<FontFallback> &p_font_data);
 	static void _generateMTSDF_threaded(void *p_td, uint32_t p_y);
 
-	_FORCE_INLINE_ Vector2i _get_size(const FontFallback *p_font_data, int p_size) const {
+	_FORCE_INLINE_ Vector2i _get_size(const Ref<FontFallback> &p_font_data, int p_size) const {
 		if (p_font_data->msdf) {
 			return Vector2i(p_font_data->msdf_source_size, 0);
 		} else if (p_font_data->fixed_size > 0) {
@@ -315,7 +317,7 @@ class TextServerFallback : public TextServerExtension {
 		}
 	}
 
-	_FORCE_INLINE_ Vector2i _get_size_outline(const FontFallback *p_font_data, const Vector2i &p_size) const {
+	_FORCE_INLINE_ Vector2i _get_size_outline(const Ref<FontFallback> &p_font_data, const Vector2i &p_size) const {
 		if (p_font_data->msdf) {
 			return Vector2i(p_font_data->msdf_source_size, 0);
 		} else if (p_font_data->fixed_size > 0) {
@@ -384,7 +386,7 @@ class TextServerFallback : public TextServerExtension {
 		Vector<Glyph> ellipsis_glyph_buf;
 	};
 
-	struct ShapedTextDataFallback {
+	struct ShapedTextDataFallback : public RefCounted {
 		Mutex mutex;
 
 		/* Source data */
@@ -452,7 +454,19 @@ class TextServerFallback : public TextServerExtension {
 
 	double oversampling = 1.0;
 	mutable RID_PtrOwner<FontFallback> font_owner;
+	mutable Mutex font_owner_mutex;
 	mutable RID_PtrOwner<ShapedTextDataFallback> shaped_owner;
+	mutable Mutex shaped_owner_mutex;
+
+	_FORCE_INLINE_ Ref<FontFallback> _get_font_safe_ref(const RID &p_rid) const {
+		MutexLock lock(font_owner_mutex);
+		return Ref<FontFallback>(font_owner.get_or_null(p_rid));
+	}
+
+	_FORCE_INLINE_ Ref<ShapedTextDataFallback> _get_shaped_safe_ref(const RID &p_rid) const {
+		MutexLock lock(shaped_owner_mutex);
+		return Ref<ShapedTextDataFallback>(shaped_owner.get_or_null(p_rid));
+	}
 
 	struct SystemFontKey {
 		String font_name;
@@ -527,17 +541,17 @@ class TextServerFallback : public TextServerExtension {
 		}
 	};
 	mutable HashMap<SystemFontKey, SystemFontCache, SystemFontKeyHasher> system_fonts;
+	mutable Mutex system_font_mutex;
 	mutable HashMap<String, PackedByteArray> system_font_data;
 
-	void _realign(ShapedTextDataFallback *p_sd) const;
+	void _realign(Ref<ShapedTextDataFallback> &p_sd) const;
+	void _full_copy(Ref<ShapedTextDataFallback> &p_shaped);
+	void _invalidate(Ref<ShapedTextDataFallback> &p_shaped);
 
 	Mutex ft_mutex;
 
 protected:
 	static void _bind_methods(){};
-
-	void full_copy(ShapedTextDataFallback *p_shaped);
-	void invalidate(ShapedTextDataFallback *p_shaped);
 
 public:
 	MODBIND1RC(bool, has_feature, Feature);


### PR DESCRIPTION
- Removes global text server locks in favor of locking individual internal objects.
- Makes some text server internal objects ref. counted.