### PR TITLE
Support NavigationObstacle2D tracking RigidBody2D

### DIFF
--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -105,6 +105,13 @@ void NavigationObstacle2D::_notification(int p_what) {
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (parent_node2d && parent_node2d->is_inside_tree()) {
 				NavigationServer2D::get_singleton()->agent_set_position(agent, parent_node2d->get_global_position());
+
+				RigidBody2D *rigid = Object::cast_to<RigidBody2D>(get_parent());
+				if (rigid) {
+					Vector2 v = rigid->get_linear_velocity();
+					NavigationServer2D::get_singleton()->agent_set_velocity(agent, v);
+					NavigationServer2D::get_singleton()->agent_set_target_velocity(agent, v);
+				}
 			}
 		} break;
 	}


### PR DESCRIPTION
Since #34776, `NavigationObstacle3D` had the feature to automatically track the velocity of its parent physics body.  However, `NavigationObstacle2D` appears to have been overlooked and didn't get this feature.

This PR adds that feature to bring both 2D and 3D versions of the navigation obstacle to parity with each other.

Since `PhysicsBody2D` doesn't have `get_linear_velocity()`, I'm casting to `RigidBody2D` here, but I could add the method to the base physics body class in a similar manner to the 3D classes. I'd like the input of the physics team on whether this is worth it at this stage.