### PR TITLE
Fix `RichTextLabel` context menu not customizable

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -106,6 +106,45 @@
 			<return type="PopupMenu" />
 			<description>
 				Returns the [PopupMenu] of this [RichTextLabel]. By default, this menu is displayed when right-clicking on the [RichTextLabel].
+				You can add custom menu items or remove standard ones. Make sure your IDs don't conflict with the standard ones (see [enum MenuItems]). For example:
+				[codeblocks]
+				[gdscript]
+				func _ready():
+				    var menu = get_menu()
+				    # Remove "Select All" item.
+				    menu.remove_item(MENU_SELECT_ALL)
+				    # Add custom items.
+				    menu.add_separator()
+				    menu.add_item("Duplicate Text", MENU_MAX + 1)
+				    # Connect callback.
+				    menu.id_pressed.connect(_on_item_pressed)
+
+				func _on_item_pressed(id):
+				    if id == MENU_MAX + 1:
+				        add_text("\n" + get_parsed_text())
+				[/gdscript]
+				[csharp]
+				public override void _Ready()
+				{
+				    var menu = GetMenu();
+				    // Remove "Select All" item.
+				    menu.RemoveItem(RichTextLabel.MenuItems.SelectAll);
+				    // Add custom items.
+				    menu.AddSeparator();
+				    menu.AddItem("Duplicate Text", RichTextLabel.MenuItems.Max + 1);
+				    // Add event handler.
+				    menu.IdPressed += OnItemPressed;
+				}
+
+				public void OnItemPressed(int id)
+				{
+				    if (id == TextEdit.MenuItems.Max + 1)
+				    {
+				        AddText("\n" + GetParsedText());
+				    }
+				}
+				[/csharp]
+				[/codeblocks]
 				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member Window.visible] property.
 			</description>
 		</method>
@@ -191,6 +230,13 @@
 			<return type="bool" />
 			<description>
 				If [member threaded] is enabled, returns [code]true[/code] if the background thread has finished text processing, otherwise always return [code]true[/code].
+			</description>
+		</method>
+		<method name="menu_option">
+			<return type="void" />
+			<param index="0" name="option" type="int" />
+			<description>
+				Executes a given action as defined in the [enum MenuItems] enum.
 			</description>
 		</method>
 		<method name="newline">
@@ -632,6 +678,15 @@
 		<constant name="ITEM_DROPCAP" value="25" enum="ItemType">
 		</constant>
 		<constant name="ITEM_CUSTOMFX" value="26" enum="ItemType">
+		</constant>
+		<constant name="MENU_COPY" value="0" enum="MenuItems">
+			Copies the selected text.
+		</constant>
+		<constant name="MENU_SELECT_ALL" value="1" enum="MenuItems">
+			Selects the whole [RichTextLabel] text.
+		</constant>
+		<constant name="MENU_MAX" value="2" enum="MenuItems">
+			Represents the size of the [enum MenuItems] enum.
 		</constant>
 	</constants>
 	<theme_items>

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -81,6 +81,7 @@ public:
 	enum MenuItems {
 		MENU_COPY,
 		MENU_SELECT_ALL,
+		MENU_MAX
 	};
 
 	enum DefaultFont {
@@ -454,8 +455,8 @@ private:
 	// Context menu.
 	PopupMenu *menu = nullptr;
 	void _generate_context_menu();
+	void _update_context_menu();
 	Key _get_menu_action_accelerator(const String &p_action);
-	void _menu_option(int p_option);
 
 	int visible_characters = -1;
 	float visible_ratio = 1.0;
@@ -688,6 +689,7 @@ public:
 	// Context menu.
 	PopupMenu *get_menu() const;
 	bool is_menu_visible() const;
+	void menu_option(int p_option);
 
 	void parse_bbcode(const String &p_bbcode);
 	void append_text(const String &p_bbcode);
@@ -739,5 +741,6 @@ public:
 
 VARIANT_ENUM_CAST(RichTextLabel::ListType);
 VARIANT_ENUM_CAST(RichTextLabel::ItemType);
+VARIANT_ENUM_CAST(RichTextLabel::MenuItems);
 
 #endif // RICH_TEXT_LABEL_H


### PR DESCRIPTION
Follow-up #72167.

This PR makes the `RichTextLabel` context menu API consistent with `LineEdit` and `TextEdit`.
