### PR TITLE
Fix NavigationMesh baking AABB Editor handling and visuals

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -4876,6 +4876,10 @@ NavigationRegion3DGizmoPlugin::NavigationRegion3DGizmoPlugin() {
 	create_material("face_material_disabled", NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_disabled_color(), false, false, true);
 	create_material("edge_material", NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_color());
 	create_material("edge_material_disabled", NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_disabled_color());
+
+	Color baking_aabb_material_color = Color(0.8, 0.5, 0.7);
+	baking_aabb_material_color.a = 0.1;
+	create_material("baking_aabb_material", baking_aabb_material_color);
 }
 
 bool NavigationRegion3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
@@ -4897,6 +4901,16 @@ void NavigationRegion3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	Ref<NavigationMesh> navigationmesh = navigationregion->get_navigation_mesh();
 	if (navigationmesh.is_null()) {
 		return;
+	}
+
+	AABB baking_aabb = navigationmesh->get_filter_baking_aabb();
+	if (baking_aabb.has_volume()) {
+		Vector3 baking_aabb_offset = navigationmesh->get_filter_baking_aabb_offset();
+
+		if (p_gizmo->is_selected()) {
+			Ref<Material> material = get_material("baking_aabb_material", p_gizmo);
+			p_gizmo->add_solid_box(material, baking_aabb.get_size(), baking_aabb.get_center() + baking_aabb_offset);
+		}
 	}
 
 	Vector<Vector3> vertices = navigationmesh->get_vertices();

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -278,7 +278,7 @@ bool NavigationMesh::get_filter_walkable_low_height_spans() const {
 
 void NavigationMesh::set_filter_baking_aabb(const AABB &p_aabb) {
 	filter_baking_aabb = p_aabb;
-	notify_property_list_changed();
+	emit_changed();
 }
 
 AABB NavigationMesh::get_filter_baking_aabb() const {
@@ -287,7 +287,7 @@ AABB NavigationMesh::get_filter_baking_aabb() const {
 
 void NavigationMesh::set_filter_baking_aabb_offset(const Vector3 &p_aabb_offset) {
 	filter_baking_aabb_offset = p_aabb_offset;
-	notify_property_list_changed();
+	emit_changed();
 }
 
 Vector3 NavigationMesh::get_filter_baking_aabb_offset() const {


### PR DESCRIPTION
Fixes handling and visuals for Navigation Mesh baking AABB in the Editor.

Closes https://github.com/godotengine/godot-proposals/issues/3811

![navmesh_bake_aabb_fix](https://user-images.githubusercontent.com/52464204/216584891-1ee9497d-3c61-42bd-aa9b-2281fd464145.gif)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
