### PR TITLE
Fix broken `scaled_orthogonal()` & subgizmo global scaling

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -239,12 +239,17 @@ void Basis::scale_orthogonal(const Vector3 &p_scale) {
 Basis Basis::scaled_orthogonal(const Vector3 &p_scale) const {
 	Basis m = *this;
 	Vector3 s = Vector3(-1, -1, -1) + p_scale;
+	bool sign = signbit(s.x + s.y + s.z);
+	Basis b = m.orthonormalized();
+	s = b.xform_inv(s);
 	Vector3 dots;
-	Basis b;
 	for (int i = 0; i < 3; i++) {
 		for (int j = 0; j < 3; j++) {
 			dots[j] += s[i] * abs(m.get_column(i).normalized().dot(b.get_column(j)));
 		}
+	}
+	if (sign != signbit(dots.x + dots.y + dots.z)) {
+		dots = -dots;
 	}
 	m.scale_local(Vector3(1, 1, 1) + dots);
 	return m;

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1415,9 +1415,6 @@ Transform3D Node3DEditorViewport::_compute_transform(TransformMode p_mode, const
 				// Recalculate orthogonalized scale without moving origin.
 				if (p_orthogonal) {
 					s.basis = p_original.basis.scaled_orthogonal(p_motion + Vector3(1, 1, 1));
-					// The scaled_orthogonal() does not require orthogonal Basis,
-					// but it may make a bit skew by precision problems.
-					s.basis.orthogonalize();
 				}
 			}
 
@@ -4634,7 +4631,7 @@ void Node3DEditorViewport::update_transform(Point2 p_mousepos, bool p_shift) {
 				if (se->gizmo.is_valid()) {
 					for (KeyValue<int, Transform3D> &GE : se->subgizmos) {
 						Transform3D xform = GE.value;
-						Transform3D new_xform = _compute_transform(TRANSFORM_SCALE, se->original * xform, xform, motion, snap, local_coords, true); // Force orthogonal with subgizmo.
+						Transform3D new_xform = _compute_transform(TRANSFORM_SCALE, se->original * xform, xform, motion, snap, local_coords, _edit.plane != TRANSFORM_VIEW); // Force orthogonal with subgizmo.
 						if (!local_coords) {
 							new_xform = se->original.affine_inverse() * new_xform;
 						}

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -1301,7 +1301,7 @@ void Skeleton3DGizmoPlugin::set_subgizmo_transform(const EditorNode3DGizmo *p_gi
 	Transform3D original_to_local;
 	int parent_idx = skeleton->get_bone_parent(p_id);
 	if (parent_idx >= 0) {
-		original_to_local = original_to_local * skeleton->get_bone_global_pose(parent_idx);
+		original_to_local = skeleton->get_bone_global_pose(parent_idx);
 	}
 	Basis to_local = original_to_local.get_basis().inverse();
 


### PR DESCRIPTION
The same fix for #72362 should be applied to SubGizmo.

Also fixed a bug where `scaled_orthogonal()` did not take local axes into account.

It also removes implicit orthogonalization. This is not the right place to do this, but rather to handle when the parent-child relationship of a node is changed.

For example, if a child object has a shear caused by a parent object, then when the child is moved out of the parent, the shear will remain. This will be added as a separate PR at some point.
