### PR TITLE
Rework code editor's multiline operations

### DIFF
--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -198,8 +198,10 @@ class CodeTextEditor : public VBoxContainer {
 
 	void _update_status_bar_theme();
 
-	void _delete_line(int p_line, int p_caret);
 	void _toggle_scripts_pressed();
+
+	int _get_affected_lines_from(int p_caret);
+	int _get_affected_lines_to(int p_caret);
 
 protected:
 	virtual void _load_theme_settings() {}


### PR DESCRIPTION
Fixes #54362
Partially fixes #72410

This pr aims to rework multiple code editor's line operations for more consistent behavior. Main takeaways are:
* Fix mixed behavior when there are multiple carets or selections on same line. 
* Unify behaviour when operation is toggleable, ie. affect all the selections same way instead of handling them separately. This is also the main cause of the first point.
* Fix some operations affect line, on which the selection ends but no characters are selected. For this to make more sense, see also #72265.

### Delete lines
There were some issues with delete lines operation, fixing them separately would likely end up filling the function with more band-aid than anything, so rewrite seemed more appropriate.
Issues fixed:

* Deleting 2 lines if 2 selections were at the same line (partially fixes #72410).
* Delete lines operation would delete one extra line if selection ends at new line. I didn't open a separate issue for this, but it's similiar to https://github.com/godotengine/godot/issues/54362.
* After the operation carets would jump in unexpected ways (sometimes at the start of the line, sometimes end). Now they stay at the same place.
<img src="https://user-images.githubusercontent.com/1621768/216655872-bc37b1d8-e7a0-421e-9456-93518c241005.gif" width="500">

### Toggle comments
Fix a bug where multiple selections affect one line. Rearranges the flow of the function, but takes largely the same steps as original.
**Changed behavior**: handle all selections as one instead of separately. I'm not sure if there's a reason to toggle some selections on and some off, and this helped to simplify the logic, so I went with it.
<img src="https://user-images.githubusercontent.com/1621768/216668631-135117c6-85f2-417c-8ea0-1de21c5b5ee8.gif" width="500">

### Toggle breakpoints
Fix a bug if you toggle breakpoints when 2 carets are on the same line.
**Changed behavior**: The operation now removes all breakpoints in selection if there is any. This is useful after you have done debugging a certain part of the code (but don't want to clear breakpoints from the whole file). For consistency this works in inverse too, breakpoints are for every line selected if there's none currently in selection.
<img src="https://user-images.githubusercontent.com/1621768/216699620-4582d8c6-db63-40ae-92e9-7006145834af.gif" width="500">

### Toggle bookmarks
Similiar to toggle breakpoints.
<img src="https://user-images.githubusercontent.com/1621768/216676668-bac0ffe0-93e4-4932-8435-2344688c30f1.gif" width="500">

### Move lines up/down
Fix the bug when the selection ends at the start of new line, move lines up/down shouldn't affect that line.

