### PR TITLE
Fix code editor moving lines without selected characters

### DIFF
--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -201,6 +201,10 @@ class CodeTextEditor : public VBoxContainer {
 	void _delete_line(int p_line, int p_caret);
 	void _toggle_scripts_pressed();
 
+	int _get_affected_lines_from(int p_caret);
+	int _get_affected_lines_to(int p_caret);
+	Vector<int> _get_affected_lines();
+
 protected:
 	virtual void _load_theme_settings() {}
 	virtual void _validate_script() {}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/54362
Supersedes #72270 and #54392

When the selection ends at the start of new line, move_lines_up/down shouldn't affect that line. Makes more sense with empty lines once https://github.com/godotengine/godot/issues/72265 gets fixed.
Function and code logic is the same as #72270, but this refactors line selection logic to a separate function.

Add helper functions to get lines that are affected by line operations. These are used in other similiar operations (#72679, #72675, #72671). These likely need to be rebased after one of them gets merged.