### PR TITLE
Fix CodeTextEditor.toggle_inline_comment when 2 carets on same line

### DIFF
--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -201,6 +201,10 @@ class CodeTextEditor : public VBoxContainer {
 	void _delete_line(int p_line, int p_caret);
 	void _toggle_scripts_pressed();
 
+	int _get_affected_lines_from(int p_caret);
+	int _get_affected_lines_to(int p_caret);
+	Vector<int> _get_affected_lines();
+
 protected:
 	virtual void _load_theme_settings() {}
 	virtual void _validate_script() {}


### PR DESCRIPTION
Partially fixes https://github.com/godotengine/godot/issues/72410
Fix bug where multiple selections affect one line. Rearranges the flow of the function, but takes largely the same steps as original.
**Changed behavior**: handle all selections as one instead of separately. I'm not sure if there's a reason to toggle some selections on and some off, and this helped to simplify the logic, so I went with it.

![Comment lines](https://user-images.githubusercontent.com/1621768/216668631-135117c6-85f2-417c-8ea0-1de21c5b5ee8.gif)

Add helper functions to get lines that are affected by line operations. These are used in other similiar operations (#72679, #72671, #72672). These likely need to be rebased after one of them gets merged.