### PR TITLE
Move mutex in StringName unref function

### DIFF
--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -121,9 +121,8 @@ void StringName::cleanup() {
 void StringName::unref() {
 	ERR_FAIL_COND(!configured);
 
+	MutexLock lock(mutex);
 	if (_data && _data->refcount.unref()) {
-		MutexLock lock(mutex);
-
 		if (_data->static_count.get() > 0) {
 			if (_data->cname) {
 				ERR_PRINT("BUG: Unreferenced static string to 0: " + String(_data->cname));


### PR DESCRIPTION
This PR may be able to fix the bug I filed here. Testing it multiple times with this change, I have so far not been able to reproduce the crash on my system, though a broader audit of thread safety on the StringName class may be worth considering too.

For the sake of *my* specific example of this issue and test case, I'll simply say that merging closes #72676, but it is possible the issue could be much deeper.