### PR TITLE
Fix CodeTextEditor.toggle_bookmark with multiple selections

### DIFF
--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -201,6 +201,10 @@ class CodeTextEditor : public VBoxContainer {
 	void _delete_line(int p_line, int p_caret);
 	void _toggle_scripts_pressed();
 
+	int _get_affected_lines_from(int p_caret);
+	int _get_affected_lines_to(int p_caret);
+	Vector<int> _get_affected_lines();
+
 protected:
 	virtual void _load_theme_settings() {}
 	virtual void _validate_script() {}


### PR DESCRIPTION
Partially fixes https://github.com/godotengine/godot/issues/72410
Fix bug if you toggle bookmarks when 2 carets are on the same line.
A cool side effect, and maybe the more important feature is that you can now remove all bookmarks in selected lines (so you can clear all bookmarks in script simply by `ctrl+A` + `ctrl+alt+B`). This works in inverse too, altough bookmarking multiple lines at once isn't all that useful, I would expect that to happen if I make a selection and press toggle bookmark.

![Bookmark lines](https://user-images.githubusercontent.com/1621768/216676668-bac0ffe0-93e4-4932-8435-2344688c30f1.gif)

Add helper functions to get lines that are affected by line operations. These are used in other similiar operations (#72675, #72671, #72672). These likely need to be rebased after one of them gets merged.