### PR TITLE
Ignore instance color and instance custom_data when not used in the OpenGL renderer

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1128,6 +1128,12 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 					state.canvas_instance_batches[state.current_batch_index].tex = mm->texture;
 					state.canvas_instance_batches[state.current_batch_index].shader_variant = CanvasShaderGLES3::MODE_INSTANCED;
 
+					if (GLES3::MeshStorage::get_singleton()->multimesh_uses_colors(mm->multimesh)) {
+						state.instance_data_array[r_index].flags |= FLAGS_INSTANCING_HAS_COLORS;
+					}
+					if (GLES3::MeshStorage::get_singleton()->multimesh_uses_custom_data(mm->multimesh)) {
+						state.instance_data_array[r_index].flags |= FLAGS_INSTANCING_HAS_CUSTOM_DATA;
+					}
 				} else if (c->type == Item::Command::TYPE_PARTICLES) {
 					GLES3::ParticlesStorage *particles_storage = GLES3::ParticlesStorage::get_singleton();
 					GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -162,9 +162,13 @@ void main() {
 	vec2 uv = uv_attrib;
 
 #ifdef USE_INSTANCING
-	vec4 instance_color = vec4(unpackHalf2x16(instance_color_custom_data.x), unpackHalf2x16(instance_color_custom_data.y));
-	color *= instance_color;
-	instance_custom = vec4(unpackHalf2x16(instance_color_custom_data.z), unpackHalf2x16(instance_color_custom_data.w));
+	if (bool(read_draw_data_flags & FLAGS_INSTANCING_HAS_COLORS)) {
+		vec4 instance_color = vec4(unpackHalf2x16(instance_color_custom_data.x), unpackHalf2x16(instance_color_custom_data.y));
+		color *= instance_color;
+	}
+	if (bool(read_draw_data_flags & FLAGS_INSTANCING_HAS_CUSTOM_DATA)) {
+		instance_custom = vec4(unpackHalf2x16(instance_color_custom_data.z), unpackHalf2x16(instance_color_custom_data.w));
+	}
 #endif
 
 #else


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/72658

The issue was that color was always used regardless of whether it was set or not. If it was not set, it was Color(0,0,0,0) which resulted in the instances all rendering transparent. 
