### PR TITLE
Fix window focus loss inconsistency

### DIFF
--- a/scene/gui/popup.h
+++ b/scene/gui/popup.h
@@ -49,9 +49,6 @@ class Popup : public Window {
 
 	void _input_from_window(const Ref<InputEvent> &p_event);
 
-	void _initialize_visible_parents();
-	void _deinitialize_visible_parents();
-
 protected:
 	void _close_pressed();
 	virtual Rect2i _popup_adjust_rect() const override;
@@ -60,8 +57,6 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;
-
-	virtual void _parent_focused();
 
 	virtual void _post_popup() override;
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -244,7 +244,12 @@ void PopupMenu::_activate_submenu(int p_over, bool p_by_keyboard) {
 	Rect2 safe_area = this_rect;
 	safe_area.position.y += items[p_over]._ofs_cache + scroll_offset + theme_cache.panel_style->get_offset().height - theme_cache.v_separation / 2;
 	safe_area.size.y = items[p_over]._height_cache + theme_cache.v_separation;
-	DisplayServer::get_singleton()->window_set_popup_safe_rect(submenu_popup->get_window_id(), safe_area);
+	Viewport *vp = get_embedder();
+	if (vp) {
+		vp->window_set_popup_safe_rect(this, safe_area);
+	} else {
+		DisplayServer::get_singleton()->window_set_popup_safe_rect(submenu_popup->get_window_id(), safe_area);
+	}
 
 	// Make the position of the parent popup relative to submenu popup.
 	this_rect.position = this_rect.position - submenu_pum->get_position();
@@ -257,29 +262,6 @@ void PopupMenu::_activate_submenu(int p_over, bool p_by_keyboard) {
 	if (items[p_over]._ofs_cache + items[p_over]._height_cache + scroll_offset <= control->get_size().height) {
 		int from = items[p_over]._ofs_cache + items[p_over]._height_cache + scroll_offset + theme_cache.v_separation / 2 + theme_cache.panel_style->get_offset().height;
 		submenu_pum->add_autohide_area(Rect2(this_rect.position.x, this_rect.position.y + from, this_rect.size.x, this_rect.size.y - from));
-	}
-}
-
-void PopupMenu::_parent_focused() {
-	if (is_embedded()) {
-		Point2 mouse_pos_adjusted;
-		Window *window_parent = Object::cast_to<Window>(get_parent()->get_viewport());
-		while (window_parent) {
-			if (!window_parent->is_embedded()) {
-				mouse_pos_adjusted += window_parent->get_position();
-				break;
-			}
-
-			window_parent = Object::cast_to<Window>(window_parent->get_parent()->get_viewport());
-		}
-
-		Rect2 safe_area = DisplayServer::get_singleton()->window_get_popup_safe_rect(get_window_id());
-		Point2 pos = DisplayServer::get_singleton()->mouse_get_position() - mouse_pos_adjusted;
-		if (safe_area == Rect2i() || !safe_area.has_point(pos)) {
-			Popup::_parent_focused();
-		} else {
-			grab_focus();
-		}
 	}
 }
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -204,8 +204,6 @@ public:
 	// this value should be updated to reflect the new size.
 	static const int ITEM_PROPERTY_SIZE = 10;
 
-	virtual void _parent_focused() override;
-
 	void add_item(const String &p_label, int p_id = -1, Key p_accel = Key::NONE);
 	void add_icon_item(const Ref<Texture2D> &p_icon, const String &p_label, int p_id = -1, Key p_accel = Key::NONE);
 	void add_check_item(const String &p_label, int p_id = -1, Key p_accel = Key::NONE);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -338,6 +338,7 @@ private:
 	struct SubWindow {
 		Window *window = nullptr;
 		RID canvas_item;
+		Rect2i parent_safe_rect;
 	};
 
 	// VRS
@@ -647,6 +648,7 @@ public:
 
 	Viewport *get_parent_viewport() const;
 	Window *get_base_window() const;
+	void window_set_popup_safe_rect(Window *p_window, const Rect2i &p_rect);
 
 	void pass_mouse_focus_to(Viewport *p_viewport, Control *p_control);
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1624,7 +1624,15 @@ void Window::popup(const Rect2i &p_screen_rect) {
 		// Send a focus-out notification when opening a Window Manager Popup.
 		SceneTree *scene_tree = get_tree();
 		if (scene_tree) {
-			scene_tree->notify_group_flags(SceneTree::GROUP_CALL_DEFERRED, "_viewports", NOTIFICATION_WM_WINDOW_FOCUS_OUT);
+			List<Node *> list;
+			scene_tree->get_nodes_in_group("_viewports", &list);
+			for (Node *n : list) {
+				Window *w = Object::cast_to<Window>(n);
+				if (w && !w->get_embedder() && w->has_focus()) {
+					w->_event_callback(DisplayServer::WINDOW_EVENT_FOCUS_OUT);
+					break;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Consider the following scene-tree:
- Root Window
  - outer embedded Window
    - inner embedded Window

A mouse-click inside the inner embedded Window causes a `WINDOW_EVENT_FOCUS_OUT` event for the outer embedded Window, so that the outer embedded Window has as state, that it isn't focused.

However the Root-Window still lists the outer embedded Window as the focused Window (otherwise event-propagation would not work).

This PR fixes this inconsistency by removing the code that causes the `WINDOW_EVENT_FOCUS_OUT` event.

This event doesn't make sense, because the outer embedded Window doesn't lose focus.

I stumbled over this inconsistency while investigating https://github.com/godotengine/godot/issues/72409#issuecomment-1415234755

resolve no longer #78346