### PR TITLE
Trim "/PCIe/SSE2" from GPU names when starting the OpenGL renderer

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -179,7 +179,8 @@ typedef void (*DEBUGPROCARB)(GLenum source,
 typedef void (*DebugMessageCallbackARB)(DEBUGPROCARB callback, const void *userParam);
 
 void RasterizerGLES3::initialize() {
-	print_line(vformat("OpenGL API %s - Compatibility - Using Device: %s - %s", RS::get_singleton()->get_video_adapter_api_version(), RS::get_singleton()->get_video_adapter_vendor(), RS::get_singleton()->get_video_adapter_name()));
+	// NVIDIA suffixes all GPU model names with "/PCIe/SSE2" in OpenGL (but not Vulkan). This isn't necessary to display nowadays, so it can be trimmed.
+	print_line(vformat("OpenGL API %s - Compatibility - Using Device: %s - %s", RS::get_singleton()->get_video_adapter_api_version(), RS::get_singleton()->get_video_adapter_vendor(), RS::get_singleton()->get_video_adapter_name().trim_suffix("/PCIe/SSE2")));
 }
 
 void RasterizerGLES3::finalize() {


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/72625.

This makes the command line print consistent with the Vulkan renderer.

Note that alternatively, we could modify `get_video_adapter_name()` to do this. I'm not sure if it's better to only modify this print, or change the reported GPU model name entirely (including when it's queried from a script).

## Preview

### Before

```
Godot Engine v4.0.beta.custom_build.b0598dcdb - https://godotengine.org
OpenGL API 3.3.0 NVIDIA 525.85.05 - Compatibility - Using Device: NVIDIA Corporation - NVIDIA GeForce RTX 4090/PCIe/SSE2
```

### After

```
Godot Engine v4.0.beta.custom_build.b0598dcdb - https://godotengine.org
OpenGL API 3.3.0 NVIDIA 525.85.05 - Compatibility - Using Device: NVIDIA Corporation - NVIDIA GeForce RTX 4090
```