### PR TITLE
Fix some cases where color picker closed itself by a mouse-click in single window mode caused by IME-window activation

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2508,6 +2508,10 @@ void DisplayServerX11::window_set_ime_active(const bool p_active, WindowID p_win
 		return;
 	}
 
+	if (p_active == wd.ime_active) {
+		return;
+	}
+
 	// Block events polling while changing input focus
 	// because it triggers some event polling internally.
 	if (p_active) {
@@ -5105,6 +5109,7 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 			if (wt_atom != None && type_atom != None) {
 				XChangeProperty(x11_display, wd.x11_window, wt_atom, XA_ATOM, 32, PropModeReplace, (unsigned char *)&type_atom, 1);
 			}
+			window_set_ime_active(true, id);
 		}
 
 		_update_size_hints(id);


### PR DESCRIPTION
In `DisplayServerX11::window_set_ime_active` a window, that is already IME-active, can be reactivated again.
This leads to a pair of `FocusOut`-`FocusIn` events. The second event had the effect that embedded Windows lost focus and in effect the closing of the color picker.

This PR introduces a check, that prohibits this situation.

During Window-creation the Window is not set as IME-active. This PR IME-activates the Window during creation.

fix parts of #72409