### PR TITLE
Avoid shading CanvasGroup nodes twice

### DIFF
--- a/doc/classes/CanvasGroup.xml
+++ b/doc/classes/CanvasGroup.xml
@@ -8,6 +8,7 @@
 		[b]Note:[/b] The [CanvasGroup] uses a custom shader to read from the backbuffer to draw its children. Assigning a [Material] to the [CanvasGroup] overrides the builtin shader. To duplicate the behavior of the builtin shader in a custom [Shader] use the following:
 		[codeblock]
 		shader_type canvas_item;
+		render_mode unshaded;
 
 		uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_nearest;
 

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -2684,6 +2684,7 @@ RasterizerCanvasGLES3::RasterizerCanvasGLES3() {
 // Default CanvasGroup shader.
 
 shader_type canvas_item;
+render_mode unshaded;
 
 uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_nearest;
 
@@ -2711,6 +2712,7 @@ void fragment() {
 // Default clip children shader.
 
 shader_type canvas_item;
+render_mode unshaded;
 
 uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_nearest;
 

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -645,7 +645,7 @@ void main() {
 
 #ifdef MODE_LIGHT_ONLY
 	color = vec4(0.0);
-#else
+#elif !defined(MODE_UNSHADED)
 	color *= canvas_modulation;
 #endif
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2634,6 +2634,7 @@ RendererCanvasRenderRD::RendererCanvasRenderRD() {
 // Default CanvasGroup shader.
 
 shader_type canvas_item;
+render_mode unshaded;
 
 uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_nearest;
 
@@ -2661,6 +2662,7 @@ void fragment() {
 // Default clip children shader.
 
 shader_type canvas_item;
+render_mode unshaded;
 
 uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_nearest;
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/70252

CanvasGroup nodes (and CanvasItems with ``clip_children``) were being shaded twice, once when the child nodes were drawn to the back buffer and once when they were drawn to the front buffer. Setting the canvas_group material to ``unshaded`` is enough to ensure that neither lights nor CanvasModulate affect them. 

_Before:_
![Screenshot from 2023-02-03 15-42-34](https://user-images.githubusercontent.com/16521339/216730946-1faaf5a7-16d7-45b2-92bf-82c2be9196ce.png)

_After:_
![Screenshot from 2023-02-03 15-42-07](https://user-images.githubusercontent.com/16521339/216730950-7c5b36fc-64b3-4deb-8bc7-2607f5863e38.png)

