### PR TITLE
Optimize StringName in terms of threading

### DIFF
--- a/core/os/spin_lock.h
+++ b/core/os/spin_lock.h
@@ -49,4 +49,17 @@ public:
 	}
 };
 
+class ScopedSpinLock {
+	SpinLock &spin_lock;
+
+public:
+	_ALWAYS_INLINE_ ScopedSpinLock(SpinLock &p_spin_lock) :
+			spin_lock(p_spin_lock) {
+		spin_lock.lock();
+	}
+	_ALWAYS_INLINE_ ~ScopedSpinLock() {
+		spin_lock.unlock();
+	}
+};
+
 #endif // SPIN_LOCK_H

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -31,9 +31,8 @@
 #ifndef STRING_NAME_H
 #define STRING_NAME_H
 
-#include "core/os/mutex.h"
+#include "core/os/spin_lock.h"
 #include "core/string/ustring.h"
-#include "core/templates/safe_refcount.h"
 
 #define UNIQUE_NODE_PREFIX "%"
 
@@ -52,8 +51,8 @@ class StringName {
 	};
 
 	struct _Data {
-		SafeRefCount refcount;
-		SafeNumeric<uint32_t> static_count;
+		uint32_t refcount = 0;
+		uint32_t static_count = 0;
 		const char *cname = nullptr;
 		String name;
 #ifdef DEBUG_ENABLED
@@ -77,10 +76,11 @@ class StringName {
 	};
 
 	void unref();
+	void unref_impl();
 	friend void register_core_types();
 	friend void unregister_core_types();
 	friend class Main;
-	static Mutex mutex;
+	static SpinLock spin_lock;
 	static void setup();
 	static void cleanup();
 	static bool configured;


### PR DESCRIPTION
#72678 inspired me to try this.

- Given the ref counts are protected by mutex/lock, they don't need to be atomics.
- A `SpinLock` looks an interesting choice for this class, instead of `Mutex`.

Performance should be measured (including using `Mutex` but this the other change). This is not urgent. Just an experiment that may end up being good for producion.