### PR TITLE
Add a method to construct a NodePath from a StringName

### DIFF
--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -360,6 +360,27 @@ NodePath NodePath::simplified() const {
 	return np;
 }
 
+NodePath NodePath::from_string_name(const StringName &p_string_name) {
+	const int size = p_string_name.length();
+	if (size == 0) {
+		return NodePath();
+	}
+	// Check if p_string_name contains a slash or colon. If so, we need to parse it.
+	const char32_t *chars = p_string_name.get_data();
+	for (int i = 0; i < size; i++) {
+		if (unlikely(chars[i] == '/' || chars[i] == ':')) {
+			return NodePath(String(p_string_name));
+		}
+	}
+	// If there is no colon or slash, the desired NodePath has one StringName.
+	// Therefore we can avoid all the String parsing and StringName re-creation.
+	Vector<StringName> path;
+	path.push_back(p_string_name);
+	NodePath ret = NodePath(path, false);
+	ret.data->concatenated_path = p_string_name;
+	return ret;
+}
+
 NodePath::NodePath(const Vector<StringName> &p_path, bool p_absolute) {
 	if (p_path.is_empty() && !p_absolute) {
 		return;

--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -385,6 +385,27 @@ NodePath NodePath::simplified() const {
 	return np;
 }
 
+NodePath NodePath::from_string_name(const StringName &p_string_name) {
+	const int size = p_string_name.length();
+	if (size == 0) {
+		return NodePath();
+	}
+	// Check if p_string_name contains a slash or colon. If so, we need to parse it.
+	const char32_t *chars = p_string_name.get_data();
+	for (int i = 0; i < size; i++) {
+		if (unlikely(chars[i] == '/' || chars[i] == ':')) {
+			return NodePath(String(p_string_name));
+		}
+	}
+	// If there is no colon or slash, the desired NodePath has one StringName.
+	// Therefore we can avoid all the String parsing and StringName re-creation.
+	Vector<StringName> path;
+	path.push_back(p_string_name);
+	NodePath ret = NodePath(path, false);
+	ret.data->concatenated_path = p_string_name;
+	return ret;
+}
+
 NodePath::NodePath(const Vector<StringName> &p_path, bool p_absolute) {
 	if (p_path.is_empty() && !p_absolute) {
 		return;

--- a/core/string/node_path.h
+++ b/core/string/node_path.h
@@ -90,6 +90,8 @@ public:
 	void simplify();
 	NodePath simplified() const;
 
+	static NodePath from_string_name(const StringName &p_string_name);
+
 	NodePath(const Vector<StringName> &p_path, bool p_absolute);
 	NodePath(const Vector<StringName> &p_path, const Vector<StringName> &p_subpath, bool p_absolute);
 	NodePath(const NodePath &p_path);

--- a/core/string/node_path.h
+++ b/core/string/node_path.h
@@ -98,6 +98,8 @@ public:
 	void simplify();
 	NodePath simplified() const;
 
+	static NodePath from_string_name(const StringName &p_string_name);
+
 	NodePath(const Vector<StringName> &p_path, bool p_absolute);
 	NodePath(const Vector<StringName> &p_path, const Vector<StringName> &p_subpath, bool p_absolute);
 	NodePath(const NodePath &p_path);

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2465,6 +2465,7 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(NodePath, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(NodePath, get_as_property_path, sarray(), varray());
 	bind_method(NodePath, is_empty, sarray(), varray());
+	bind_static_method(NodePath, from_string_name, sarray("string_name"), varray());
 
 	/* Callable */
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2419,6 +2419,7 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(NodePath, slice, sarray("begin", "end"), varray(INT_MAX));
 	bind_method(NodePath, get_as_property_path, sarray(), varray());
 	bind_method(NodePath, is_empty, sarray(), varray());
+	bind_static_method(NodePath, from_string_name, sarray("string_name"), varray());
 
 	/* Callable */
 

--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -81,6 +81,13 @@
 		</constructor>
 	</constructors>
 	<methods>
+		<method name="from_string_name" qualifiers="static">
+			<return type="NodePath" />
+			<param index="0" name="string_name" type="StringName" />
+			<description>
+				Constructs a NodePath from a [StringName]. This method will be faster than constructing from a String if the StringName does not contain any slashes or colons.
+			</description>
+		</method>
 		<method name="get_as_property_path" qualifiers="const">
 			<return type="NodePath" />
 			<description>

--- a/tests/core/string/test_node_path.cpp
+++ b/tests/core/string/test_node_path.cpp
@@ -167,6 +167,75 @@ TEST_CASE("[NodePath] Empty path") {
 			"The node path should be considered empty.");
 }
 
+TEST_CASE("[NodePath] From StringName") {
+	const StringName sname = StringName("Path2D");
+
+	// Test the case where the StringName has no slash or colon and uses the StringName directly.
+	const NodePath node_path_sname = NodePath::from_string_name(sname);
+	const NodePath node_path_string = NodePath("Path2D");
+
+	CHECK_MESSAGE(
+			!node_path_sname.is_absolute(),
+			"The StringName version should not be absolute.");
+
+	CHECK_MESSAGE(
+			!node_path_string.is_absolute(),
+			"The String version should not be absolute.");
+
+	CHECK_MESSAGE(
+			node_path_sname.get_name(0) == sname,
+			"The StringName version should have the expected StringName as the first name.");
+
+	CHECK_MESSAGE(
+			node_path_string.get_name(0) == sname,
+			"The String version should have the expected StringName as the first name.");
+
+	CHECK_MESSAGE(
+			node_path_sname.get_concatenated_names() == sname,
+			"The StringName version should give the expected StringName.");
+
+	CHECK_MESSAGE(
+			node_path_string.get_concatenated_names() == sname,
+			"The String version should give the expected StringName.");
+
+	CHECK_MESSAGE(
+			node_path_string.get_concatenated_names() == node_path_sname.get_concatenated_names(),
+			"The String and StringName versions should give the same result.");
+
+	// Test the case where the StringName has a slash or colon and uses String parsing.
+	const NodePath node_path_abs_sname = NodePath::from_string_name("/Path2D");
+	const NodePath node_path_abs_string = NodePath("/Path2D");
+
+	CHECK_MESSAGE(
+			node_path_abs_sname.is_absolute(),
+			"The StringName version should be absolute.");
+
+	CHECK_MESSAGE(
+			node_path_abs_string.is_absolute(),
+			"The String version should be absolute.");
+
+	CHECK_MESSAGE(
+			node_path_abs_sname.get_name(0) == sname,
+			"The StringName version should have the expected StringName as the first name.");
+
+	CHECK_MESSAGE(
+			node_path_abs_string.get_name(0) == sname,
+			"The String version should have the expected StringName as the first name.");
+
+	// Absolute paths do not include a leading slash in the concatenated names.
+	CHECK_MESSAGE(
+			node_path_abs_sname.get_concatenated_names() == sname,
+			"The StringName version should give the expected StringName.");
+
+	CHECK_MESSAGE(
+			node_path_abs_string.get_concatenated_names() == sname,
+			"The String version should give the expected StringName.");
+
+	CHECK_MESSAGE(
+			node_path_abs_string.get_concatenated_names() == node_path_abs_sname.get_concatenated_names(),
+			"The String and StringName versions should give the same result.");
+}
+
 TEST_CASE("[NodePath] Slice") {
 	const NodePath node_path_relative = NodePath("Parent/Child:prop:subprop");
 	const NodePath node_path_absolute = NodePath("/root/Parent/Child:prop");


### PR DESCRIPTION
This allows constructing a NodePath directly from a StringName, which skips the String parsing logic, if the given StringName does not contain a slash or colon and can be used as-is.

I considered a constructor, but this would break all uses in the C++ code that construct NodePath from `char *` literals, and we need to depend on two other constructors anyway, so this uses a static method instead.