### PR TITLE
StringName: fix returning dangling data from char constructor.

### DIFF
--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -226,19 +226,16 @@ StringName::StringName(const char *p_name, bool p_static) {
 		_data = _data->next;
 	}
 
-	if (_data) {
-		if (_data->refcount.ref()) {
-			// exists
-			if (p_static) {
-				_data->static_count.increment();
-			}
-#ifdef DEBUG_ENABLED
-			if (unlikely(debug_stringname)) {
-				_data->debug_references++;
-			}
-#endif
+	if (_data && _data->refcount.ref()) {
+		// exists
+		if (p_static) {
+			_data->static_count.increment();
 		}
-
+#ifdef DEBUG_ENABLED
+		if (unlikely(debug_stringname)) {
+			_data->debug_references++;
+		}
+#endif
 		return;
 	}
 
@@ -288,19 +285,17 @@ StringName::StringName(const StaticCString &p_static_string, bool p_static) {
 		_data = _data->next;
 	}
 
-	if (_data) {
-		if (_data->refcount.ref()) {
-			// exists
-			if (p_static) {
-				_data->static_count.increment();
-			}
-#ifdef DEBUG_ENABLED
-			if (unlikely(debug_stringname)) {
-				_data->debug_references++;
-			}
-#endif
-			return;
+	if (_data && _data->refcount.ref()) {
+		// exists
+		if (p_static) {
+			_data->static_count.increment();
 		}
+#ifdef DEBUG_ENABLED
+		if (unlikely(debug_stringname)) {
+			_data->debug_references++;
+		}
+#endif
+		return;
 	}
 
 	_data = memnew(_Data);
@@ -348,19 +343,17 @@ StringName::StringName(const String &p_name, bool p_static) {
 		_data = _data->next;
 	}
 
-	if (_data) {
-		if (_data->refcount.ref()) {
-			// exists
-			if (p_static) {
-				_data->static_count.increment();
-			}
-#ifdef DEBUG_ENABLED
-			if (unlikely(debug_stringname)) {
-				_data->debug_references++;
-			}
-#endif
-			return;
+	if (_data && _data->refcount.ref()) {
+		// exists
+		if (p_static) {
+			_data->static_count.increment();
 		}
+#ifdef DEBUG_ENABLED
+		if (unlikely(debug_stringname)) {
+			_data->debug_references++;
+		}
+#endif
+		return;
 	}
 
 	_data = memnew(_Data);


### PR DESCRIPTION
Fixes a copy paste mistake in the `StringName(const char *,bool)` constructor, to match the same form as the other two constrcutors. This fixes a case where this constructor can return a dangling pointer and cause use-after-free.

I believe this misplaced return causes the StringName constructor to return early with a dangling (failed to `ref()`) `data_` member, causing a use-after-free in the event that a `StringName(char*)` is called right in between the `if (_data->unref())` and `mutex.lock()` in `StringName::unref()`.

Fixes #72676
This is an alternative to the proposed fix PR #72678.

I would still keep PR #72696 open as it may still be relevant as a performance fix, but hopefully is not pertinent to solving a correctness violation. We need to do benchmarks to decide if that approach is better.