### PR TITLE
C#: Fix AppContext.BaseDirectory

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotPlugins/PluginLoadContext.cs
+++ b/modules/mono/glue/GodotSharp/GodotPlugins/PluginLoadContext.cs
@@ -30,7 +30,7 @@ namespace GodotPlugins
                 if (baseDirectory != null)
                 {
                     if (!Path.EndsInDirectorySeparator(baseDirectory))
-                        baseDirectory += Path.PathSeparator;
+                        baseDirectory += Path.DirectorySeparatorChar;
                     // This SetData call effectively sets AppContext.BaseDirectory
                     // See https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/System.Private.CoreLib/src/System/AppContext.cs#L21-L25
                     AppDomain.CurrentDomain.SetData("APP_CONTEXT_BASE_DIRECTORY", baseDirectory);


### PR DESCRIPTION
Followup to #72554

Not sure how this has happened, but that path is obviously supposed to end with `\` / `/` and not `;` / `:`.
