### PR TITLE
Decrease overhead of WorkerThreadPool task processing

### DIFF
--- a/core/object/worker_thread_pool.h
+++ b/core/object/worker_thread_pool.h
@@ -55,7 +55,7 @@ private:
 
 	struct BaseTemplateUserdata {
 		virtual void callback() {}
-		virtual void callback_indexed(uint32_t p_index) {}
+		virtual void callback_range(uint32_t p_from, uint32_t p_to) {}
 		virtual ~BaseTemplateUserdata() {}
 	};
 
@@ -154,8 +154,10 @@ private:
 		C *instance;
 		M method;
 		U userdata;
-		virtual void callback_indexed(uint32_t p_index) override {
-			(instance->*method)(p_index, userdata);
+		virtual void callback_range(uint32_t p_from, uint32_t p_to) override {
+			for (uint32_t p_index = p_from; p_index < p_to; p_index++) {
+				(instance->*method)(p_index, userdata);
+			}
 		}
 	};
 


### PR DESCRIPTION
Changes threads to accept and process work in batches so that they synchronize less often.

As a bonus, this also hoists the loop for `add_template_group_task()` into the header file so that the loop body can be inlined.

This way, `add_template_group_task()` and its derivatives (namely, [parallel `foreach()`](https://github.com/godotengine/godot/pull/72784)) can have optimal performance, so there is no longer any need to do manual batching like in `RaycastOcclusionCull::Scenario::_transform_vertices_thread()`:

https://github.com/godotengine/godot/blob/13f0158e49676fc5ec8694a40261685596faa3d1/modules/raycast/raycast_occlusion_cull.cpp#L339-L390