### PR TITLE
DisplayServerWindows: Fix mouse capture when button up message is missed

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3266,7 +3266,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 						SetCapture(hWnd);
 					}
 				} else {
-					if (--pressrc <= 0) {
+					if (--pressrc <= 0 || last_button_state.is_empty()) {
 						if (mouse_mode != MOUSE_MODE_CAPTURED) {
 							ReleaseCapture();
 						}


### PR DESCRIPTION
Fixes #72719

In theory, calling `SetCapture()` should cause Godot to continue to receive mouse messages even after the cursor leaves the window. However, despite commenting out the calls to `ReleaseCapture()` in the `WM_KILLFOCUS` handler and in `_set_mouse_mode_impl`, I still managed to find a situation where Windows would stop sending mouse events.

Therefore, something extra is required to ensure that `pressrc` can't get stuck in a permanently bugged state. If Godot misses a mouse button up event, this fix (checking if all mouse buttons are released) will reset `pressrc` the next time that button is clicked.

A very simple fix for an elusive bug which took me forever to track down.