### PR TITLE
Add build option to enable MP1 and MP2 support in minimp3

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -375,6 +375,8 @@ for name, path in modules_detected.items():
     else:
         enabled = False
 
+    opts.Add(BoolVariable("module_" + name + "_enabled", "Enable module '%s'" % (name,), enabled))
+
     # Add module-specific options.
     try:
         for opt in config.get_opts(selected_platform):
@@ -384,7 +386,6 @@ for name, path in modules_detected.items():
 
     sys.path.remove(path)
     sys.modules.pop("config")
-    opts.Add(BoolVariable("module_" + name + "_enabled", "Enable module '%s'" % (name,), enabled))
 
 methods.write_modules(modules_detected)
 

--- a/modules/minimp3/SCsub
+++ b/modules/minimp3/SCsub
@@ -13,5 +13,8 @@ if not env.msvc:
 else:
     env_minimp3.Prepend(CPPPATH=[thirdparty_dir])
 
+if not env["minimp3_extra_formats"]:
+    env_minimp3.Append(CPPDEFINES=["MINIMP3_ONLY_MP3"])
+
 # Godot source files
 env_minimp3.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/minimp3/audio_stream_mp3.cpp
+++ b/modules/minimp3/audio_stream_mp3.cpp
@@ -28,7 +28,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#define MINIMP3_ONLY_MP3
 #define MINIMP3_FLOAT_OUTPUT
 #define MINIMP3_IMPLEMENTATION
 #define MINIMP3_NO_STDIO

--- a/modules/minimp3/config.py
+++ b/modules/minimp3/config.py
@@ -2,6 +2,14 @@ def can_build(env, platform):
     return True
 
 
+def get_opts(platform):
+    from SCons.Variables import BoolVariable
+
+    return [
+        BoolVariable("minimp3_extra_formats", "Build minimp3 with MP1/MP2 decoding support", False),
+    ]
+
+
 def configure(env):
     pass
 

--- a/modules/minimp3/resource_importer_mp3.cpp
+++ b/modules/minimp3/resource_importer_mp3.cpp
@@ -47,6 +47,10 @@ String ResourceImporterMP3::get_visible_name() const {
 }
 
 void ResourceImporterMP3::get_recognized_extensions(List<String> *p_extensions) const {
+#ifndef MINIMP3_ONLY_MP3
+	p_extensions->push_back("mp1");
+	p_extensions->push_back("mp2");
+#endif
 	p_extensions->push_back("mp3");
 }
 


### PR DESCRIPTION
This adds only 3.5k to the template size (Win/64bits).

fixes #72688 