### PR TITLE
Fix mouse/drag/touch InputEvents having no device id

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -533,6 +533,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 			touch_event->set_pressed(mb->is_pressed());
 			touch_event->set_position(mb->get_position());
 			touch_event->set_double_tap(mb->is_double_click());
+			touch_event->set_device(InputEvent::DEVICE_ID_EMULATION);
 			event_dispatch_function(touch_event);
 		}
 	}
@@ -557,6 +558,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 			drag_event->set_pen_inverted(mm->get_pen_inverted());
 			drag_event->set_pressure(mm->get_pressure());
 			drag_event->set_velocity(get_last_mouse_velocity());
+			drag_event->set_device(InputEvent::DEVICE_ID_EMULATION);
 
 			event_dispatch_function(drag_event);
 		}
@@ -592,7 +594,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 				Ref<InputEventMouseButton> button_event;
 				button_event.instantiate();
 
-				button_event->set_device(InputEvent::DEVICE_ID_TOUCH_MOUSE);
+				button_event->set_device(InputEvent::DEVICE_ID_EMULATION);
 				button_event->set_position(st->get_position());
 				button_event->set_global_position(st->get_position());
 				button_event->set_pressed(st->is_pressed());
@@ -623,7 +625,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 			Ref<InputEventMouseMotion> motion_event;
 			motion_event.instantiate();
 
-			motion_event->set_device(InputEvent::DEVICE_ID_TOUCH_MOUSE);
+			motion_event->set_device(InputEvent::DEVICE_ID_EMULATION);
 			motion_event->set_tilt(sd->get_tilt());
 			motion_event->set_pen_inverted(sd->get_pen_inverted());
 			motion_event->set_pressure(sd->get_pressure());
@@ -832,7 +834,7 @@ void Input::ensure_touch_mouse_raised() {
 		Ref<InputEventMouseButton> button_event;
 		button_event.instantiate();
 
-		button_event->set_device(InputEvent::DEVICE_ID_TOUCH_MOUSE);
+		button_event->set_device(InputEvent::DEVICE_ID_EMULATION);
 		button_event->set_position(mouse_pos);
 		button_event->set_global_position(mouse_pos);
 		button_event->set_pressed(false);
@@ -869,6 +871,7 @@ void Input::set_default_cursor_shape(CursorShape p_shape) {
 	mm.instantiate();
 	mm->set_position(mouse_pos);
 	mm->set_global_position(mouse_pos);
+	mm->set_device(InputEvent::DEVICE_ID_INTERNAL);
 	parse_input_event(mm);
 }
 

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -34,7 +34,7 @@
 #include "core/input/shortcut.h"
 #include "core/os/keyboard.h"
 
-const int InputEvent::DEVICE_ID_TOUCH_MOUSE = -1;
+const int InputEvent::DEVICE_ID_EMULATION = -1;
 const int InputEvent::DEVICE_ID_INTERNAL = -2;
 
 void InputEvent::set_device(int p_device) {

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -59,7 +59,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	static const int DEVICE_ID_TOUCH_MOUSE;
+	static const int DEVICE_ID_EMULATION;
 	static const int DEVICE_ID_INTERNAL;
 
 	void set_device(int p_device);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -614,7 +614,7 @@ void Viewport::_process_picking() {
 				physics_last_mouse_state.mouse_mask.clear_flag(mouse_button_to_mask(mb->get_button_index()));
 
 				// If touch mouse raised, assume we don't know last mouse pos until new events come
-				if (mb->get_device() == InputEvent::DEVICE_ID_TOUCH_MOUSE) {
+				if (mb->get_device() == InputEvent::DEVICE_ID_EMULATION) {
 					physics_has_last_mousepos = false;
 				}
 			}
@@ -2290,6 +2290,7 @@ void Viewport::_drop_mouse_focus() {
 			mb->set_global_position(c->get_local_mouse_position());
 			mb->set_button_index(MouseButton(i + 1));
 			mb->set_pressed(false);
+			mb->set_device(InputEvent::DEVICE_ID_INTERNAL);
 			c->_call_gui_input(mb);
 		}
 	}
@@ -2401,6 +2402,7 @@ void Viewport::_post_gui_grab_click_focus() {
 				mb->set_position(click);
 				mb->set_button_index(MouseButton(i + 1));
 				mb->set_pressed(false);
+				mb->set_device(InputEvent::DEVICE_ID_INTERNAL);
 				gui.mouse_focus->_call_gui_input(mb);
 			}
 		}
@@ -2418,6 +2420,7 @@ void Viewport::_post_gui_grab_click_focus() {
 				mb->set_position(click);
 				mb->set_button_index(MouseButton(i + 1));
 				mb->set_pressed(true);
+				mb->set_device(InputEvent::DEVICE_ID_INTERNAL);
 				MessageQueue::get_singleton()->push_callable(callable_mp(gui.mouse_focus, &Control::_call_gui_input), mb);
 			}
 		}

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -647,6 +647,7 @@ void Window::update_mouse_cursor_shape() {
 	mm.instantiate();
 	mm->set_position(pos);
 	mm->set_global_position(xform.xform(pos));
+	mm->set_device(InputEvent::DEVICE_ID_INTERNAL);
 	push_input(mm);
 }
 


### PR DESCRIPTION
Some created emulated/instantiated events didn't have a device id. This PR sets for these cases a device id.

I used `DEVICE_ID_INTERNAL` in cases where the event is created in order to fulfill an engine-internal goal.

Implements https://github.com/godotengine/godot/issues/71650#issuecomment-1397987722