### PR TITLE
Improve Connect Dialog navigation

### DIFF
--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -106,6 +106,7 @@ public:
 private:
 	Label *connect_to_label = nullptr;
 	LineEdit *from_signal = nullptr;
+	LineEdit *filter_nodes = nullptr;
 	Node *source = nullptr;
 	ConnectionData source_connection_data;
 	StringName signal;
@@ -142,6 +143,7 @@ private:
 	void _item_activated();
 	void _text_submitted(const String &p_text);
 	void _tree_node_selected();
+	void _focus_currently_connected();
 
 	void _method_selected();
 	void _create_method_tree_items(const List<MethodInfo> &p_methods, TreeItem *p_parent_item);


### PR DESCRIPTION
- Adds node filter
- Adds "Goto Source" button

https://user-images.githubusercontent.com/2223172/216792420-17d94d00-cda5-4d91-9195-f3ee919abe88.mp4

Closes https://github.com/godotengine/godot-proposals/issues/4848

There is a minor issue where nodes can become selectable unexpectedly when filter is changed, but this is probably SceneTreeEditor or Tree bug.