### PR TITLE
Make Area physics priority consistently int and allow negative numbers

### DIFF
--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -107,8 +107,8 @@
 		<member name="monitoring" type="bool" setter="set_monitoring" getter="is_monitoring" default="true">
 			If [code]true[/code], the area detects bodies or areas entering and exiting it.
 		</member>
-		<member name="priority" type="float" setter="set_priority" getter="get_priority" default="0.0">
-			The area's priority. Higher priority areas are processed first.
+		<member name="priority" type="int" setter="set_priority" getter="get_priority" default="0">
+			The area's priority. Higher priority areas are processed first. The [World2D]'s physics is always processed last, after all areas.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/Area3D.xml
+++ b/doc/classes/Area3D.xml
@@ -106,8 +106,8 @@
 		<member name="monitoring" type="bool" setter="set_monitoring" getter="is_monitoring" default="true">
 			If [code]true[/code], the area detects bodies or areas entering and exiting it.
 		</member>
-		<member name="priority" type="float" setter="set_priority" getter="get_priority" default="0.0">
-			The area's priority. Higher priority areas are processed first.
+		<member name="priority" type="int" setter="set_priority" getter="get_priority" default="0">
+			The area's priority. Higher priority areas are processed first. The [World3D]'s physics is always processed last, after all areas.
 		</member>
 		<member name="reverb_bus_amount" type="float" setter="set_reverb_amount" getter="get_reverb_amount" default="0.0">
 			The degree to which this area applies reverb to its associated audio. Ranges from [code]0[/code] to [code]1[/code] with [code]0.1[/code] precision.

--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -123,12 +123,12 @@ real_t Area2D::get_angular_damp() const {
 	return angular_damp;
 }
 
-void Area2D::set_priority(real_t p_priority) {
+void Area2D::set_priority(int p_priority) {
 	priority = p_priority;
 	PhysicsServer2D::get_singleton()->area_set_param(get_rid(), PhysicsServer2D::AREA_PARAM_PRIORITY, p_priority);
 }
 
-real_t Area2D::get_priority() const {
+int Area2D::get_priority() const {
 	return priority;
 }
 
@@ -617,7 +617,7 @@ void Area2D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "monitoring"), "set_monitoring", "is_monitoring");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "monitorable"), "set_monitorable", "is_monitorable");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "priority", PROPERTY_HINT_RANGE, "0,128,1"), "set_priority", "get_priority");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "priority", PROPERTY_HINT_RANGE, "0,100000,1,or_greater,or_less"), "set_priority", "get_priority");
 
 	ADD_GROUP("Gravity", "gravity_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "gravity_space_override", PROPERTY_HINT_ENUM, "Disabled,Combine,Combine-Replace,Replace,Replace-Combine", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), "set_gravity_space_override_mode", "get_gravity_space_override_mode");

--- a/scene/2d/area_2d.h
+++ b/scene/2d/area_2d.h
@@ -168,8 +168,8 @@ public:
 	void set_angular_damp(real_t p_angular_damp);
 	real_t get_angular_damp() const;
 
-	void set_priority(real_t p_priority);
-	real_t get_priority() const;
+	void set_priority(int p_priority);
+	int get_priority() const;
 
 	void set_monitoring(bool p_enable);
 	bool is_monitoring() const;

--- a/scene/3d/area_3d.cpp
+++ b/scene/3d/area_3d.cpp
@@ -123,12 +123,12 @@ real_t Area3D::get_angular_damp() const {
 	return angular_damp;
 }
 
-void Area3D::set_priority(real_t p_priority) {
+void Area3D::set_priority(int p_priority) {
 	priority = p_priority;
 	PhysicsServer3D::get_singleton()->area_set_param(get_rid(), PhysicsServer3D::AREA_PARAM_PRIORITY, p_priority);
 }
 
-real_t Area3D::get_priority() const {
+int Area3D::get_priority() const {
 	return priority;
 }
 
@@ -736,7 +736,7 @@ void Area3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "monitoring"), "set_monitoring", "is_monitoring");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "monitorable"), "set_monitorable", "is_monitorable");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "priority", PROPERTY_HINT_RANGE, "0,128,1"), "set_priority", "get_priority");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "priority", PROPERTY_HINT_RANGE, "0,100000,1,or_greater,or_less"), "set_priority", "get_priority");
 
 	ADD_GROUP("Gravity", "gravity_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "gravity_space_override", PROPERTY_HINT_ENUM, "Disabled,Combine,Combine-Replace,Replace,Replace-Combine", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), "set_gravity_space_override_mode", "get_gravity_space_override_mode");

--- a/scene/3d/area_3d.h
+++ b/scene/3d/area_3d.h
@@ -179,8 +179,8 @@ public:
 	void set_linear_damp(real_t p_linear_damp);
 	real_t get_linear_damp() const;
 
-	void set_priority(real_t p_priority);
-	real_t get_priority() const;
+	void set_priority(int p_priority);
+	int get_priority() const;
 
 	void set_wind_force_magnitude(real_t p_wind_force_magnitude);
 	real_t get_wind_force_magnitude() const;


### PR DESCRIPTION
In the current API, Area2D/3D had the priority property bound as `Variant::INT` but the setters and getters used floats. Then the float was truncated to an int inside of the method call. The docs showed the `priority` property as a float. So the API was not consistent.

Due to feedback, this PR changes the API to be consistently int.

The only place that the priority is used is in AreaCMP for these lines (one in 2D and one in 3D):

```cpp
_FORCE_INLINE_ bool operator<(const AreaCMP &p_cmp) const { return area->get_priority() < p_cmp.area->get_priority(); }
```

Also, change the range hint in the editor to increase the range and add allow_greater and allow_less.

Also, I improved the documentation to explain that the world's physics (gravity/etc) is always processed last. And yes, I tested this, it's always true, even though the area has `area->set_priority(-1);` in the physics server constructor, areas with priorities less than -1 are still processed first, before the world's physics.