### PR TITLE
Fix description and argument name in `Control._has_point`

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -144,11 +144,11 @@
 		</method>
 		<method name="_has_point" qualifiers="virtual const">
 			<return type="bool" />
-			<param index="0" name="position" type="Vector2" />
+			<param index="0" name="point" type="Vector2" />
 			<description>
-				Virtual method to be implemented by the user. Returns whether the given [param position] is inside this control.
+				Virtual method to be implemented by the user. Returns whether the given [param point] is inside this control.
 				If not overridden, default behavior is checking if the point is within control's Rect.
-				[b]Note:[/b] If you want to check if a point is inside the control, you can use [code]get_rect().has_point(point)[/code].
+				[b]Note:[/b] If you want to check if a point is inside the control, you can use [code]Rect2(Vector2.ZERO, size).has_point(point)[/code].
 			</description>
 		</method>
 		<method name="_make_custom_tooltip" qualifiers="virtual const">

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3392,7 +3392,7 @@ void Control::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("minimum_size_changed"));
 	ADD_SIGNAL(MethodInfo("theme_changed"));
 
-	GDVIRTUAL_BIND(_has_point, "position");
+	GDVIRTUAL_BIND(_has_point, "point");
 	GDVIRTUAL_BIND(_structured_text_parser, "args", "text");
 	GDVIRTUAL_BIND(_get_minimum_size);
 


### PR DESCRIPTION
Hi,

**Edit:** as suggested, editing the original message
Making this PR to fix https://github.com/godotengine/godot/issues/72283

W.r.t Issue #72283  raised by @Lielay9,
Change the name of the ```position``` parameter to ```point``` in ```Control._has_point(position)```. Please refer screenshot below showing the change.

#### Methods Section
![image](https://user-images.githubusercontent.com/16386226/216839636-bb1cbcdb-ae1f-4625-b79c-bc6df0ae3422.png)

#### Method Descriptions section
![image](https://user-images.githubusercontent.com/16386226/216839698-02cf8127-2798-4699-853e-eab9c028b1af.png)


Let me know if any other change needs to be done in this PR. Thanks &

Regards,
Kabiir Krishna

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
