### PR TITLE
[TextServer] Preload USpoofChecker to speed up GDScript parsing.

### DIFF
--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -159,6 +159,9 @@ class TextServerAdvanced : public TextServerExtension {
 	// ICU support data.
 
 	bool icu_data_loaded = false;
+	mutable USet *allowed = nullptr;
+	mutable USpoofChecker *sc_spoof = nullptr;
+	mutable USpoofChecker *sc_conf = nullptr;
 
 	// Font cache data.
 


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/72448 (but it's likely not a main reason of performance issues).