### PR TITLE
Internal renames and cleanup in resource importer scene

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -477,48 +477,45 @@ void _rescale_animation(Vector3 p_scale, Ref<Animation> p_animation) {
 	}
 }
 
-void _apply_basis_to_scalable_node_collection(ScalableNodeCollection &p_dictionary, Vector3 p_scale) {
-	for (Node3D *node_3d : p_dictionary.node_3ds) {
-		if (node_3d) {
-			node_3d->set_position(p_scale * node_3d->get_position());
-
-			Skeleton3D *skeleton_3d = Object::cast_to<Skeleton3D>(node_3d);
-			if (skeleton_3d) {
-				for (int i = 0; i < skeleton_3d->get_bone_count(); i++) {
-					Transform3D rest = skeleton_3d->get_bone_rest(i);
-					skeleton_3d->set_bone_rest(i, Transform3D(rest.basis, p_scale * rest.origin));
-					skeleton_3d->set_bone_pose_position(i, p_scale * rest.origin);
-				}
+void _apply_scale_to_scalable_node_collection(ScalableNodeCollection &p_collection, Vector3 p_scale) {
+	for (Node3D *node_3d : p_collection.node_3ds) {
+		node_3d->set_position(p_scale * node_3d->get_position());
+		Skeleton3D *skeleton_3d = Object::cast_to<Skeleton3D>(node_3d);
+		if (skeleton_3d) {
+			for (int i = 0; i < skeleton_3d->get_bone_count(); i++) {
+				Transform3D rest = skeleton_3d->get_bone_rest(i);
+				skeleton_3d->set_bone_rest(i, Transform3D(rest.basis, p_scale * rest.origin));
+				skeleton_3d->set_bone_pose_position(i, p_scale * rest.origin);
 			}
 		}
 	}
-	for (Ref<ImporterMesh> mesh : p_dictionary.importer_meshes) {
+	for (Ref<ImporterMesh> mesh : p_collection.importer_meshes) {
 		_rescale_importer_mesh(p_scale, mesh, false);
 	}
-	for (Ref<Skin> skin : p_dictionary.skins) {
+	for (Ref<Skin> skin : p_collection.skins) {
 		_rescale_skin(p_scale, skin);
 	}
-	for (Ref<Animation> animation : p_dictionary.animations) {
+	for (Ref<Animation> animation : p_collection.animations) {
 		_rescale_animation(p_scale, animation);
 	}
 }
 
-void _populate_scalable_nodes_collection(Node *p_node, ScalableNodeCollection &p_dictionary) {
+void _populate_scalable_nodes_collection(Node *p_node, ScalableNodeCollection &p_collection) {
 	if (!p_node) {
 		return;
 	}
 	Node3D *node_3d = Object::cast_to<Node3D>(p_node);
 	if (node_3d) {
-		p_dictionary.node_3ds.insert(node_3d);
+		p_collection.node_3ds.insert(node_3d);
 		ImporterMeshInstance3D *mesh_instance_3d = Object::cast_to<ImporterMeshInstance3D>(p_node);
 		if (mesh_instance_3d) {
 			Ref<ImporterMesh> mesh = mesh_instance_3d->get_mesh();
 			if (mesh.is_valid()) {
-				p_dictionary.importer_meshes.insert(mesh);
+				p_collection.importer_meshes.insert(mesh);
 			}
 			Ref<Skin> skin = mesh_instance_3d->get_skin();
 			if (skin.is_valid()) {
-				p_dictionary.skins.insert(skin);
+				p_collection.skins.insert(skin);
 			}
 		}
 	}
@@ -529,21 +526,20 @@ void _populate_scalable_nodes_collection(Node *p_node, ScalableNodeCollection &p
 
 		for (const StringName &E : animation_list) {
 			Ref<Animation> animation = animation_player->get_animation(E);
-			p_dictionary.animations.insert(animation);
+			p_collection.animations.insert(animation);
 		}
 	}
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		Node *child = p_node->get_child(i);
-		_populate_scalable_nodes_collection(child, p_dictionary);
+		_populate_scalable_nodes_collection(child, p_collection);
 	}
 }
 
-void _apply_permanent_rotation_scale_to_node(Node *p_node) {
-	Transform3D transform = Object::cast_to<Node3D>(p_node)->get_transform();
+void _apply_permanent_scale_to_descendants(Node *p_root_node, Vector3 p_scale) {
 	ScalableNodeCollection scalable_node_collection;
-	_populate_scalable_nodes_collection(p_node, scalable_node_collection);
-	_apply_basis_to_scalable_node_collection(scalable_node_collection, transform.basis.get_scale());
+	_populate_scalable_nodes_collection(p_root_node, scalable_node_collection);
+	_apply_scale_to_scalable_node_collection(scalable_node_collection, p_scale);
 }
 
 Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<Ref<ImporterMesh>, Vector<Ref<Shape3D>>> &r_collision_map, Pair<PackedVector3Array, PackedInt32Array> *r_occluder_arrays, List<Pair<NodePath, Node *>> &r_node_renames) {
@@ -2382,11 +2378,13 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 		root_scale = p_options["nodes/root_scale"];
 	}
 	if (Object::cast_to<Node3D>(scene)) {
-		Object::cast_to<Node3D>(scene)->scale(Vector3(root_scale, root_scale, root_scale));
-	}
-	if (apply_root) {
-		_apply_permanent_rotation_scale_to_node(scene);
-		Object::cast_to<Node3D>(scene)->scale(Vector3(root_scale, root_scale, root_scale).inverse());
+		Node3D *scene_3d = Object::cast_to<Node3D>(scene);
+		Vector3 scale = Vector3(root_scale, root_scale, root_scale);
+		if (apply_root) {
+			_apply_permanent_scale_to_descendants(scene, scale);
+		} else {
+			scene_3d->scale(scale);
+		}
 	}
 	Dictionary subresources = p_options["_subresources"];
 


### PR DESCRIPTION
While I was working on #72753, the cleanups I was doing was making it hard to track the actual behavior changes, so this PR splits off the cleanup work for easy reviewability. This PR does NOT change behavior.

* Rename `_apply_basis_to_scalable_node_collection` to `_apply_scale_to_scalable_node_collection`
* Rename `_apply_permanent_rotation_scale_to_node` to `_apply_permanent_scale_to_descendants`
* Rename the `ScalableNodeCollection` parameter `p_dictionary` to `p_collection`
* Only construct `Vector3(root_scale, root_scale, root_scale)` once.
* Pass the scale to `_apply_permanent_scale_to_descendants` instead of re-calculating it later.
* When applying the root scale, don't needlessly scale and then un-scale the root node.
* In `_apply_scale_to_scalable_node_collection`, remove a useless `if (node_3d) {` check (it's always true).