### PR TITLE
Improve vulkan capability detection on Android

### DIFF
--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -273,6 +273,12 @@ String _get_xr_features_tag(const Ref<EditorExportPreset> &p_preset) {
 			manifest_xr_features += "    <uses-feature tools:node=\"replace\" android:name=\"com.oculus.feature.PASSTHROUGH\" android:required=\"true\" />\n";
 		}
 	}
+
+	String current_renderer = GLOBAL_GET("rendering/renderer/rendering_method.mobile");
+	bool has_vulkan = current_renderer == "forward_plus" || current_renderer == "mobile";
+	if (has_vulkan) {
+		manifest_xr_features += "    <uses-feature tools:node=\"replace\" android:name=\"android.hardware.vulkan.level\" android:required=\"true\" android:version=\"1\" />\n";
+	}
 	return manifest_xr_features;
 }
 

--- a/platform/android/java/lib/res/values/strings.xml
+++ b/platform/android/java/lib/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="text_button_cancel_verify">Cancel Verification</string>
     <string name="text_error_title">Error!</string>
     <string name="error_engine_setup_message">Unable to setup the Godot Engine! Aborting…</string>
+    <string name="error_missing_vulkan_requirements_message">This device does not meet the requirements for Vulkan support! Aborting…</string>
 
     <!-- APK Expansion Strings -->
 

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -258,13 +258,13 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 	 */
 	@Keep
 	private boolean onVideoInit() {
-		final Activity activity = getActivity();
+		final Activity activity = requireActivity();
 		containerLayout = new FrameLayout(activity);
 		containerLayout.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
 
 		// GodotEditText layout
 		GodotEditText editText = new GodotEditText(activity);
-		editText.setLayoutParams(new ViewGroup.LayoutParams(LayoutParams.MATCH_PARENT,
+		editText.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT,
 				(int)getResources().getDimension(R.dimen.text_edit_height)));
 		// ...add to FrameLayout
 		containerLayout.addView(editText);
@@ -279,6 +279,11 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		if (renderer.equals("gl_compatibility")) {
 			mRenderView = new GodotGLRenderView(activity, this, xrMode, use_debug_opengl);
 		} else {
+			if (!meetsVulkanRequirements(activity.getPackageManager())) {
+				Log.e(TAG, "Missing requirements for vulkan support! Aborting...");
+				alert(R.string.error_missing_vulkan_requirements_message, R.string.text_error_title, this::forceQuit);
+				return false;
+			}
 			mRenderView = new GodotVulkanRenderView(activity, this);
 		}
 
@@ -315,6 +320,17 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * Returns true if the device meets the base requirements for Vulkan support, false otherwise.
+	 */
+	private boolean meetsVulkanRequirements(@Nullable PackageManager packageManager) {
+		if (packageManager == null) {
+			return false;
+		}
+
+		return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && packageManager.hasSystemFeature(PackageManager.FEATURE_VULKAN_HARDWARE_LEVEL, 1);
 	}
 
 	public void setKeepScreenOn(final boolean p_enabled) {


### PR DESCRIPTION
- Add runtime check and abort when the device doesn't meet the requirements for vulkan support
![Screenshot_20230205_173034](https://user-images.githubusercontent.com/914968/216861765-dcdd4cf1-963e-49ff-be4f-bd8be4e02670.png)


- Add filters to the AndroidManifest when exporting with a vulkan renderer
<img width="564" alt="Screenshot 2023-02-05 at 5 21 25 PM" src="https://user-images.githubusercontent.com/914968/216861621-3ef851f0-56f6-4760-9f00-d9d8b30b9d07.png">



<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
