### PR TITLE
Remove unnecessary `stdio.h` from gdextension interface

### DIFF
--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -37,7 +37,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
 
 #ifndef __cplusplus
 typedef uint32_t char32_t;


### PR DESCRIPTION
Nothing in `gdextension_interface.h` depends on `stdio.h`.