### PR TITLE
[Windows] Improve non-exclusive full-screen mode.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1259,9 +1259,10 @@ void DisplayServerWindows::_get_window_style(bool p_main_window, bool p_fullscre
 	}
 
 	if (p_fullscreen || p_borderless) {
-		r_style |= WS_POPUP; // p_borderless was WS_EX_TOOLWINDOW in the past.
 		if (p_fullscreen && p_multiwindow_fs) {
-			r_style |= WS_BORDER; // Allows child windows to be displayed on top of full screen.
+			r_style |= WS_OVERLAPPED; // Allows child windows to be displayed on top of full screen.
+		} else {
+			r_style |= WS_POPUP; // p_borderless was WS_EX_TOOLWINDOW in the past.
 		}
 	} else {
 		if (p_resizable) {


### PR DESCRIPTION
Removes single pixel border in the non-exclusive full-screen mode.

Fixes https://github.com/godotengine/godot/issues/63500

Note: needs testing on a different GPUs to make sure it's not triggering exclusive full-screen, I have tested it on NVIDIA only. Testing on AMD and Intel is highly appreciated. The easiest way to test it is to use <kbd>Shift</kbd>+<kbd>F11</kbd> combination in the editor and checking if menus are working fine, without blinking/fading to black (editor should be in multi window mode).