### PR TITLE
Fixed the jumping to function definition using 'Ctrl+LMB' (reverted)

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3480,6 +3480,14 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				break;
 			}
 
+			if (context.current_class) {
+				if (context.type != GDScriptParser::COMPLETION_SUPER_METHOD) {
+					base.type = context.current_class->get_datatype();
+				} else {
+					base.type = context.current_class->base_type;
+				}
+			}
+
 			if (_lookup_symbol_from_base(base.type, p_symbol, is_function, r_result) == OK) {
 				return OK;
 			}


### PR DESCRIPTION
Fixes #72353.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
