### PR TITLE
GDScript: Don't allow @onready without inheriting Node

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3611,6 +3611,10 @@ bool GDScriptParser::icon_annotation(const AnnotationNode *p_annotation, Node *p
 bool GDScriptParser::onready_annotation(const AnnotationNode *p_annotation, Node *p_node) {
 	ERR_FAIL_COND_V_MSG(p_node->type != Node::VARIABLE, false, R"("@onready" annotation can only be applied to class variables.)");
 
+	if (head && !ClassDB::is_parent_class(head->get_datatype().native_type, SNAME("Node"))) {
+		push_error(R"("@onready" can only be used in classes that inherit "Node".)", p_annotation);
+	}
+
 	VariableNode *variable = static_cast<VariableNode *>(p_node);
 	if (variable->onready) {
 		push_error(R"("@onready" annotation can only be used once per variable.)");

--- a/modules/gdscript/tests/scripts/analyzer/errors/get_node_shorthand_within_non_node.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/get_node_shorthand_within_non_node.gd
@@ -1,0 +1,5 @@
+extends RefCounted
+
+func test():
+	var nope := $Node
+	print("Cannot use $ without a Node base")

--- a/modules/gdscript/tests/scripts/analyzer/errors/get_node_shorthand_within_non_node.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/get_node_shorthand_within_non_node.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot use shorthand "get_node()" notation ("$") on a class that isn't a node.

--- a/modules/gdscript/tests/scripts/analyzer/errors/onready_within_non_node.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/onready_within_non_node.gd
@@ -1,0 +1,6 @@
+extends RefCounted
+
+@onready var nope := 0
+
+func test():
+	print("Cannot use @onready without a Node base")

--- a/modules/gdscript/tests/scripts/analyzer/errors/onready_within_non_node.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/onready_within_non_node.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+"@onready" can only be used in classes that inherit "Node".


### PR DESCRIPTION
Fix #48643