### PR TITLE
More fixes to over plugin handling

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -565,6 +565,7 @@ private:
 	void _update_file_menu_closed();
 
 	void _remove_plugin_from_enabled(const String &p_name);
+	void _plugin_over_edit(EditorPlugin *p_plugin, Object *p_object);
 
 	void _fs_changed();
 	void _resources_reimported(const Vector<String> &p_resources);


### PR DESCRIPTION
Fixes yet another issue with "over plugins". I added `_plugin_over_edit()` method, because after checking how these plugins are invoked, they pretty much repeat the same 3 lines every time.

Fixes #72773
Fixes #72738
I can't reproduce #72761 and #72744, but they might get fixed too. CC @smix8 