### PR TITLE
CI: Remove custom Linux deps and SwiftShader

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -19,13 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # Azure repositories are not reliable, we need to prevent azure giving us packages.
-      - name: Make apt sources.list use the default Ubuntu repositories
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/*
-          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
-          sudo apt-get update
-
       - name: Set up Java 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -74,16 +74,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Linux dependencies
-        shell: bash
+      # Need newer mesa for lavapipe to work properly.
+      - name: Linux dependencies for tests
+        if: ${{ matrix.proj-test }}
         run: |
-          # Azure repositories are not reliable, we need to prevent azure giving us packages.
-          sudo rm -f /etc/apt/sources.list.d/*
-          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
+          sudo add-apt-repository ppa:kisak/kisak-mesa
           sudo apt-get update
-          # The actual dependencies
-          sudo apt-get install build-essential pkg-config libgl1-mesa-dev libglu-dev \
-              xvfb wget unzip llvm
+          sudo apt-get install -qq mesa-vulkan-drivers
 
       - name: Setup Godot build cache
         uses: ./.github/actions/godot-cache
@@ -138,16 +135,6 @@ jobs:
           ${{ matrix.bin }} --doctool --headless 2>&1 > /dev/null || true
           git diff --color --exit-code && ! git ls-files --others --exclude-standard | sed -e 's/^/New doc file missing in PR: /' | grep 'xml$'
 
-      # Download, unzip and setup SwiftShader library
-      # See https://github.com/godotengine/regression-test-project/releases/tag/_ci-deps for details
-      - name: Download SwiftShader
-        if: ${{ matrix.tests }}
-        run: |
-          wget https://github.com/godotengine/regression-test-project/releases/download/_ci-deps/swiftshader-ubuntu20.04-20211002.zip
-          unzip swiftshader-ubuntu20.04-20211002.zip
-          curr="$(pwd)/libvk_swiftshader.so"
-          sed -i "s|PATH_TO_CHANGE|$curr|" vk_swiftshader_icd.json
-
       # Test 3.x -> 4.x project converter
       - name: Test project converter
         if: ${{ matrix.proj-conv }}
@@ -155,7 +142,7 @@ jobs:
           mkdir converter_test
           cd converter_test
           touch project.godot
-          ../${{ matrix.bin }} --headless --audio-driver Dummy --validate-conversion-3to4
+          ../${{ matrix.bin }} --headless --validate-conversion-3to4
           cd ..
           rm converter_test -rf
 
@@ -171,7 +158,7 @@ jobs:
       - name: Open and close editor (Vulkan)
         if: ${{ matrix.proj-test }}
         run: |
-          VK_ICD_FILENAMES=$(pwd)/vk_swiftshader_icd.json DRI_PRIME=0 xvfb-run ${{ matrix.bin }} --audio-driver Dummy --editor --quit --path test_project 2>&1 | tee sanitizers_log.txt || true
+          xvfb-run ${{ matrix.bin }} --audio-driver Dummy --editor --quit --path test_project 2>&1 | tee sanitizers_log.txt || true
           misc/scripts/check_ci_log.py sanitizers_log.txt
 
       - name: Open and close editor (GLES3)
@@ -184,7 +171,7 @@ jobs:
       - name: Run project
         if: ${{ matrix.proj-test }}
         run: |
-          VK_ICD_FILENAMES=$(pwd)/vk_swiftshader_icd.json DRI_PRIME=0 xvfb-run ${{ matrix.bin }} 40 --audio-driver Dummy --path test_project 2>&1 | tee sanitizers_log.txt || true
+          xvfb-run ${{ matrix.bin }} 40 --audio-driver Dummy --path test_project 2>&1 | tee sanitizers_log.txt || true
           misc/scripts/check_ci_log.py sanitizers_log.txt
 
       # Checkout godot-cpp

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -13,17 +13,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # Azure repositories are not reliable, we need to prevent Azure giving us packages.
-      - name: Make apt sources.list use the default Ubuntu repositories
+      - name: Install dependencies
         run: |
-          sudo rm -f /etc/apt/sources.list.d/*
-          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main"
           sudo apt-get update
-
-      - name: Install dependencies
-        run: |
           sudo apt-get install -qq dos2unix clang-format-15 libxml2-utils python3-pip moreutils
           sudo update-alternatives --remove-all clang-format || true
           sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-15 100

--- a/misc/ci/sources.list
+++ b/misc/ci/sources.list
@@ -1,4 +1,0 @@
-deb http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse
-deb http://archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse
-deb http://archive.ubuntu.com/ubuntu/ focal-security main restricted universe multiverse
-deb http://archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse


### PR DESCRIPTION
The default environment already includes everything we need to build all our configurations.

Remove custom SwiftShader setup as lavapipe should now be good enough, but we need to install the latest one.