### PR TITLE
Fix AnimationEditor ignoring region of Sprite2D

### DIFF
--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -389,7 +389,7 @@ Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_se
 
 		size = texture->get_size();
 
-		if (bool(object->call("is_region"))) {
+		if (bool(object->call("is_region_enabled"))) {
 			size = Rect2(object->call("get_region_rect")).size;
 		}
 
@@ -479,7 +479,7 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 
 		region.size = texture->get_size();
 
-		if (bool(object->call("is_region"))) {
+		if (bool(object->call("is_region_enabled"))) {
 			region = Rect2(object->call("get_region_rect"));
 		}
 


### PR DESCRIPTION
Changes "is_region" to "is_region_enabled" to match with the function name change in 4.0, fixing #72781.

_Production edit: Fixes https://github.com/godotengine/godot/issues/72781_