### PR TITLE
Downgrade the vulkan abort logic to a warning

### DIFF
--- a/platform/android/java/editor/src/main/res/values/dimens.xml
+++ b/platform/android/java/editor/src/main/res/values/dimens.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<dimen name="editor_default_window_height">600dp</dimen>
-	<dimen name="editor_default_window_width">800dp</dimen>
+	<dimen name="editor_default_window_width">1024dp</dimen>
 </resources>

--- a/platform/android/java/lib/res/values/strings.xml
+++ b/platform/android/java/lib/res/values/strings.xml
@@ -14,7 +14,7 @@
     <string name="text_button_cancel_verify">Cancel Verification</string>
     <string name="text_error_title">Error!</string>
     <string name="error_engine_setup_message">Unable to setup the Godot Engine! Aborting…</string>
-    <string name="error_missing_vulkan_requirements_message">This device does not meet the requirements for Vulkan support! Aborting…</string>
+    <string name="error_missing_vulkan_requirements_message">Warning - this device does not meet the requirements for Vulkan support</string>
 
     <!-- APK Expansion Strings -->
 

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -83,6 +83,7 @@ import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.CallSuper;
 import androidx.annotation.Keep;
@@ -277,9 +278,7 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 
 		if (usesVulkan()) {
 			if (!meetsVulkanRequirements(activity.getPackageManager())) {
-				Log.e(TAG, "Missing requirements for vulkan support! Aborting...");
-				alert(R.string.error_missing_vulkan_requirements_message, R.string.text_error_title, this::forceQuit);
-				return false;
+				Log.w(TAG, "Missing requirements for vulkan support!");
 			}
 			mRenderView = new GodotVulkanRenderView(activity, this);
 		} else {


### PR DESCRIPTION
This addresses issues where some drivers are reporting they don't meet the vulkan hardware level 1 support requirements even though they render as expected when the check is removed.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
