### PR TITLE
Change .gitignore's `bin/` to `bin`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ misc/hooks/pre-commit-custom-*
 #############################
 
 # Buildsystem
-bin/
+bin
 *.gen.*
 compile_commands.json
 platform/windows/godot_res.res


### PR DESCRIPTION
Allows `bin/` to be ignored even when it's a symlink.