### PR TITLE
GDScript: Fix invalid character error message

### DIFF
--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -1536,9 +1536,9 @@ GDScriptTokenizer::Token GDScriptTokenizer::scan() {
 
 		default:
 			if (is_whitespace(c)) {
-				return make_error(vformat(R"(Invalid white space character "\\u%X".)", static_cast<int32_t>(c)));
+				return make_error(vformat(R"(Invalid white space character U+%04X.)", static_cast<int32_t>(c)));
 			} else {
-				return make_error(vformat(R"(Unknown character "%s".)", String(&c, 1)));
+				return make_error(vformat(R"(Invalid character "%c" (U+%04X).)", c, static_cast<int32_t>(c)));
 			}
 	}
 }


### PR DESCRIPTION
Before:
![](https://user-images.githubusercontent.com/47700418/217180453-7d0456a2-bb2c-43d1-a629-d892848cb9a3.png)

After:
![](https://user-images.githubusercontent.com/47700418/217180922-e4868598-1e85-471b-a7e7-ba78b1198550.png)

---

See [wiki](https://en.wikipedia.org/wiki/Whitespace_character). U+200B is in "Related Unicode characters with property White_Space=no" table, i.e. it's not a whitespace character, so it's not listed here:

https://github.com/godotengine/godot/blob/3f02cf7ced320f25ac5f4f72d7a57d98296bfcd1/core/string/char_utils.h#L96-L98

In KCharSelect this character is marked as "Non-printable", but I don't know if such Unicode attribute/category actually exists. Perhaps we need the `is_invisible_character` function?

![](https://user-images.githubusercontent.com/47700418/217183155-4ffc0bb7-c2ad-4320-8f84-a0a0226458b5.png)

CC @bruvzg