### PR TITLE
Pace debugger draw requests

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -308,6 +308,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		String error = p_data[1];
 		bool has_stackdump = p_data[2];
 		breaked = true;
+		can_request_idle_draw = true;
 		can_debug = can_continue;
 		_update_buttons_state();
 		_set_reason_text(error, MESSAGE_ERROR);
@@ -378,6 +379,8 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		vmem_total->set_tooltip_text(TTR("Bytes:") + " " + itos(total));
 		vmem_total->set_text(String::humanize_size(total));
 
+	} else if (p_msg == "servers:drawn") {
+		can_request_idle_draw = true;
 	} else if (p_msg == "stack_dump") {
 		DebuggerMarshalls::ScriptStackDump stack;
 		stack.deserialize(p_data);
@@ -843,8 +846,9 @@ void ScriptEditorDebugger::_notification(int p_what) {
 					msg.push_back(cam->get_far());
 					_put_msg("scene:override_camera_3D:transform", msg);
 				}
-				if (breaked) {
+				if (breaked && can_request_idle_draw) {
 					_put_msg("servers:draw", Array());
+					can_request_idle_draw = false;
 				}
 			}
 

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -155,6 +155,7 @@ private:
 	bool breaked = false;
 	bool can_debug = false;
 	bool move_to_foreground = true;
+	bool can_request_idle_draw = false;
 
 	bool live_debug;
 

--- a/servers/debugger/servers_debugger.cpp
+++ b/servers/debugger/servers_debugger.cpp
@@ -409,6 +409,7 @@ Error ServersDebugger::_capture(void *p_user, const String &p_cmd, const Array &
 		if (RenderingServer::get_singleton()->has_changed()) {
 			RenderingServer::get_singleton()->draw(true, delta);
 		}
+		EngineDebugger::get_singleton()->send_message("servers:drawn", Array());
 	} else if (p_cmd == "foreground") {
 		singleton->last_draw_time = 0.0;
 		DisplayServer::get_singleton()->window_move_to_foreground();


### PR DESCRIPTION
This avoids the editor side from sending redraw requests at a faster rate than the remote side can process. The remote side may have its frame rate limited for reasons such as low CPU mode and we need to let it breathe.

Not entirely happy about adding bidirectionality here, but until someone can rework this in another way that both sides have their timing properly in sync by other means, this is clean enough.

Fixes #67696.