### PR TITLE
Allow defining default importers per file extension

### DIFF
--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -416,6 +416,11 @@ Ref<ResourceImporter> ResourceFormatImporter::get_importer_by_extension(const St
 	Ref<ResourceImporter> importer;
 	float priority = 0;
 
+	importer = get_default_importer_by_extension(p_extension);
+	if (importer.is_valid()) {
+		return importer;
+	}
+
 	for (int i = 0; i < importers.size(); i++) {
 		List<String> local_exts;
 		importers[i]->get_recognized_extensions(&local_exts);
@@ -428,6 +433,27 @@ Ref<ResourceImporter> ResourceFormatImporter::get_importer_by_extension(const St
 	}
 
 	return importer;
+}
+
+Ref<ResourceImporter> ResourceFormatImporter::get_default_importer_by_extension(const String &p_extension) const {
+	const String extension = p_extension.to_lower(); // Make sure the extension is in lowercase.
+
+	// Early return if the setting doesn't exist.
+	if (!ProjectSettings::get_singleton()->has_setting("default_resource_importers/" + extension)) {
+		return Ref<ResourceImporter>();
+	}
+	const String importer_name = (String)GLOBAL_GET("default_resource_importers/" + extension);
+
+	Ref<ResourceImporter> importer = get_importer_by_name(importer_name);
+	if (importer.is_valid()) {
+		List<String> extensions;
+		importer->get_recognized_extensions(&extensions);
+		if (extensions.find(extension)) {
+			return importer;
+		}
+	}
+
+	return Ref<ResourceImporter>();
 }
 
 String ResourceFormatImporter::get_import_base_path(const String &p_for_file) const {

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -86,6 +86,7 @@ public:
 	void remove_importer(const Ref<ResourceImporter> &p_importer) { importers.erase(p_importer); }
 	Ref<ResourceImporter> get_importer_by_name(const String &p_name) const;
 	Ref<ResourceImporter> get_importer_by_extension(const String &p_extension) const;
+	Ref<ResourceImporter> get_default_importer_by_extension(const String &p_extension) const;
 	void get_importers_for_extension(const String &p_extension, List<Ref<ResourceImporter>> *r_importers);
 	void get_importers(List<Ref<ResourceImporter>> *r_importers);
 

--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -84,11 +84,11 @@ void ImportDefaultsEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			inspector->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
+			settings_inspector->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
 		} break;
 
 		case NOTIFICATION_PREDELETE: {
-			inspector->edit(nullptr);
+			settings_inspector->edit(nullptr);
 		} break;
 	}
 }
@@ -153,24 +153,24 @@ void ImportDefaultsEditor::_update_importer() {
 			settings->default_values[E.option.name] = E.default_value;
 		}
 
-		save_defaults->set_disabled(false);
-		reset_defaults->set_disabled(false);
+		save_default_settings->set_disabled(false);
+		reset_default_settings->set_disabled(false);
 
 	} else {
-		save_defaults->set_disabled(true);
-		reset_defaults->set_disabled(true);
+		save_default_settings->set_disabled(true);
+		reset_default_settings->set_disabled(true);
 	}
 
 	settings->notify_property_list_changed();
 
-	inspector->edit(settings);
+	settings_inspector->edit(settings);
 }
 
 void ImportDefaultsEditor::_importer_selected(int p_index) {
 	_update_importer();
 }
 
-void ImportDefaultsEditor::clear() {
+void ImportDefaultsEditor::initialize() {
 	String last_selected;
 	if (importers->get_selected() > 0) {
 		last_selected = importers->get_item_text(importers->get_selected());
@@ -210,20 +210,20 @@ ImportDefaultsEditor::ImportDefaultsEditor() {
 	hb->add_child(importers);
 	hb->add_spacer();
 	importers->connect("item_selected", callable_mp(this, &ImportDefaultsEditor::_importer_selected));
-	reset_defaults = memnew(Button);
-	reset_defaults->set_text(TTR("Reset to Defaults"));
-	reset_defaults->set_disabled(true);
-	reset_defaults->connect("pressed", callable_mp(this, &ImportDefaultsEditor::_reset));
-	hb->add_child(reset_defaults);
+	reset_default_settings = memnew(Button);
+	reset_default_settings->set_text(TTR("Reset to Defaults"));
+	reset_default_settings->set_disabled(true);
+	reset_default_settings->connect("pressed", callable_mp(this, &ImportDefaultsEditor::_reset));
+	hb->add_child(reset_default_settings);
 	add_child(hb);
-	inspector = memnew(EditorInspector);
-	add_child(inspector);
-	inspector->set_v_size_flags(SIZE_EXPAND_FILL);
+	settings_inspector = memnew(EditorInspector);
+	add_child(settings_inspector);
+	settings_inspector->set_v_size_flags(SIZE_EXPAND_FILL);
 	CenterContainer *cc = memnew(CenterContainer);
-	save_defaults = memnew(Button);
-	save_defaults->set_text(TTR("Save"));
-	save_defaults->connect("pressed", callable_mp(this, &ImportDefaultsEditor::_save));
-	cc->add_child(save_defaults);
+	save_default_settings = memnew(Button);
+	save_default_settings->set_text(TTR("Save"));
+	save_default_settings->connect("pressed", callable_mp(this, &ImportDefaultsEditor::_save));
+	cc->add_child(save_default_settings);
 	add_child(cc);
 
 	settings = memnew(ImportDefaultsEditorSettings);

--- a/editor/import_defaults_editor.h
+++ b/editor/import_defaults_editor.h
@@ -36,6 +36,7 @@
 #include "scene/gui/option_button.h"
 
 class ImportDefaultsEditorSettings;
+class DefaultImportersEditorSettings;
 class EditorInspector;
 
 class ImportDefaultsEditor : public VBoxContainer {
@@ -47,13 +48,17 @@ class ImportDefaultsEditor : public VBoxContainer {
 	Button *save_default_settings = nullptr;
 	Button *reset_default_settings = nullptr;
 
+	EditorInspector *importers_inspector = nullptr;
+
 	ImportDefaultsEditorSettings *settings = nullptr;
+	DefaultImportersEditorSettings *default_importers = nullptr;
 
 	void _update_importer();
 	void _importer_selected(int p_index);
 
 	void _reset();
 	void _save();
+	void _save_default_importer(const String &);
 
 protected:
 	void _notification(int p_what);

--- a/editor/import_defaults_editor.h
+++ b/editor/import_defaults_editor.h
@@ -42,10 +42,10 @@ class ImportDefaultsEditor : public VBoxContainer {
 	GDCLASS(ImportDefaultsEditor, VBoxContainer)
 
 	OptionButton *importers = nullptr;
-	Button *save_defaults = nullptr;
-	Button *reset_defaults = nullptr;
 
-	EditorInspector *inspector = nullptr;
+	EditorInspector *settings_inspector = nullptr;
+	Button *save_default_settings = nullptr;
+	Button *reset_default_settings = nullptr;
 
 	ImportDefaultsEditorSettings *settings = nullptr;
 
@@ -60,7 +60,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void clear();
+	void initialize();
 
 	ImportDefaultsEditor();
 	~ImportDefaultsEditor();

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -61,7 +61,7 @@ void ProjectSettingsEditor::popup_project_settings() {
 	localization_editor->update_translations();
 	autoload_settings->update_autoload();
 	plugin_settings->update_plugins();
-	import_defaults_editor->clear();
+	import_defaults_editor->initialize();
 }
 
 void ProjectSettingsEditor::queue_save() {

--- a/modules/vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/vorbis/resource_importer_ogg_vorbis.cpp
@@ -45,7 +45,7 @@ String ResourceImporterOggVorbis::get_importer_name() const {
 }
 
 String ResourceImporterOggVorbis::get_visible_name() const {
-	return "oggvorbisstr";
+	return "Ogg Vorbis";
 }
 
 void ResourceImporterOggVorbis::get_recognized_extensions(List<String> *p_extensions) const {


### PR DESCRIPTION
I'm opening this as a draft to be able to discuss part of it on 🚀.

---

This is implementing godotengine/godot-proposals#2500.

- Settings are read from a new `[default_resource_importers]` section
  - Key is the extension and value is the importer name
  - The section should probably have a better name
- When first importing a resource, if we have an importer defined for its extension, use it instead of relying on the priority selection
- Add a window to edit these settings
  - It's under `Project Settings > Import Defaults`
  - The window lists all the extensions recognized by Godot, for each you can choose between nothing (current behaviour) and one of the valid importers for said extension.
- **TODO:** It's impossible to select the `keep` importer from the UI, and writing it directly in the settings won't work.

As an aside, if anyone has a UI/UX mind and ideas on how to make this screen better, I'm all ears. I especially don't like the **Save** button down low, feels very weird.
![godot windows editor dev x86_64 mono_oCI6QHJnuu](https://user-images.githubusercontent.com/437025/217315570-eb7441e8-e944-44ba-b62d-b95cd4a5a837.png)

_Production edit: Closes https://github.com/godotengine/godot-proposals/issues/2500._