### PR TITLE
C#: Rename export settings `mono` -> `dotnet` and remove unused AOT settings

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -24,19 +24,7 @@ namespace GodotTools.Export
         public void RegisterExportSettings()
         {
             // TODO: These would be better as export preset options, but that doesn't seem to be supported yet
-
-            GlobalDef("mono/export/include_scripts_content", false);
-
-            GlobalDef("mono/export/aot/enabled", false);
-            GlobalDef("mono/export/aot/full_aot", false);
-            GlobalDef("mono/export/aot/use_interpreter", true);
-
-            // --aot or --aot=opt1,opt2 (use 'mono --aot=help AuxAssembly.dll' to list AOT options)
-            GlobalDef("mono/export/aot/extra_aot_options", Array.Empty<string>());
-            // --optimize/-O=opt1,opt2 (use 'mono --list-opt'' to list optimize options)
-            GlobalDef("mono/export/aot/extra_optimizer_options", Array.Empty<string>());
-
-            GlobalDef("mono/export/aot/android_toolchain_path", "");
+            GlobalDef("dotnet/export/include_scripts_content", false);
         }
 
         private string _maybeLastExportError;
@@ -56,7 +44,7 @@ namespace GodotTools.Export
 
             // TODO What if the source file is not part of the game's C# project
 
-            bool includeScriptsContent = (bool)ProjectSettings.GetSetting("mono/export/include_scripts_content");
+            bool includeScriptsContent = (bool)ProjectSettings.GetSetting("dotnet/export/include_scripts_content");
 
             if (!includeScriptsContent)
             {


### PR DESCRIPTION
This removes the `mono` section from project settings, so that everything is in the `dotnet` section.

The AOT settings currently do nothing, so remove them to avoid any confusion.