### PR TITLE
Recreate swap chain when suboptimal to avoid error spam

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -2268,8 +2268,8 @@ Error VulkanContext::prepare_buffers() {
 			} else if (err == VK_SUBOPTIMAL_KHR) {
 				// Swapchain is not as optimal as it could be, but the platform's
 				// presentation engine will still present the image correctly.
-				print_verbose("Vulkan: Early suboptimal swapchain.");
-				break;
+				print_verbose("Vulkan: Early suboptimal swapchain, recreating.");
+				_update_swap_chain(w);
 			} else if (err != VK_SUCCESS) {
 				ERR_BREAK_MSG(err != VK_SUCCESS, "Vulkan: Did not create swapchain successfully.");
 			} else {


### PR DESCRIPTION
The spec is pretty vague about when VK_SUBOPTIMAL_KHR can be produced by ``vkAcquireNextImageKHR``. But it means that the swapchain format no longer matches the window format, but the driver can use it anyway. For some windowing system/driver combinations this can take place on a resize of the window, or a change in format, or just from focus being lost. The presence of the error _may_ indicate that performance will be impacted, but in some cases performance won't be impacted. In any case, the error doesn't go away until a new swap chain is constructed. 

On my development device I regularly get the error spammed when running projects. With this change the swapchain is updated once and the error is not printed again. 

CC @RandomShaper 

Tagged as 4.x as this isn't fixing a known bug but is rather cleaning up an annoyance. It should be merged after 4.0 stable