### PR TITLE
Bind `EditorExportPlugin::_get_export_features`

### DIFF
--- a/doc/classes/EditorExportPlugin.xml
+++ b/doc/classes/EditorExportPlugin.xml
@@ -87,6 +87,14 @@
 				Return a hash based on the configuration passed (for both scenes and resources). This helps keep separate caches for separate export configurations.
 			</description>
 		</method>
+		<method name="_get_export_features" qualifiers="virtual const">
+			<return type="PackedStringArray" />
+			<param index="0" name="platform" type="EditorExportPlatform" />
+			<param index="1" name="debug" type="bool" />
+			<description>
+				Return a [PackedStringArray] of additional features this preset, for the given [param platform], should have.
+			</description>
+		</method>
 		<method name="_get_name" qualifiers="virtual const">
 			<return type="String" />
 			<description>

--- a/editor/export/editor_export_plugin.cpp
+++ b/editor/export/editor_export_plugin.cpp
@@ -229,6 +229,7 @@ void EditorExportPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_end_customize_scenes);
 	GDVIRTUAL_BIND(_end_customize_resources);
 
+	GDVIRTUAL_BIND(_get_export_features, "platform", "debug");
 	GDVIRTUAL_BIND(_get_name);
 }
 


### PR DESCRIPTION
The function was added in #70377 and setup for implementation by scripts, but the bind was missed.

(There also seems to be an issue where the added features do not show up in the features tab, but the fix appears to not be very easy and quickly run into circular requirements of what function needs to be called first)