### PR TITLE
Add an option to show a TextEdit caret when editable is disabled

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1093,6 +1093,9 @@
 		<member name="caret_blink_interval" type="float" setter="set_caret_blink_interval" getter="get_caret_blink_interval" default="0.65">
 			Duration (in seconds) of a caret's blinking cycle.
 		</member>
+		<member name="caret_draw_when_editable_disabled" type="bool" setter="set_draw_caret_when_editable_disabled" getter="is_drawing_caret_when_editable_disabled" default="false">
+			If [code]true[/code], caret will be visible when [member editable] is disabled.
+		</member>
 		<member name="caret_mid_grapheme" type="bool" setter="set_caret_mid_grapheme_enabled" getter="is_caret_mid_grapheme_enabled" default="true">
 			Allow moving caret, selecting and removing the individual composite character components.
 			[b]Note:[/b] [kbd]Backspace[/kbd] is always removing individual composite character components.

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -526,7 +526,7 @@ void TextEdit::_notification(int p_what) {
 			theme_cache.style_normal->draw(ci, Rect2(Point2(), size));
 			if (!editable) {
 				theme_cache.style_readonly->draw(ci, Rect2(Point2(), size));
-				draw_caret = false;
+				draw_caret = is_drawing_caret_when_editable_disabled();
 			}
 			if (has_focus()) {
 				theme_cache.style_focus->draw(ci, Rect2(Point2(), size));
@@ -4489,6 +4489,18 @@ void TextEdit::set_caret_blink_interval(const float p_interval) {
 	caret_blink_timer->set_wait_time(p_interval);
 }
 
+void TextEdit::set_draw_caret_when_editable_disabled(bool p_enable) {
+	if (draw_caret_when_editable_disabled == p_enable) {
+		return;
+	}
+	draw_caret_when_editable_disabled = p_enable;
+	queue_redraw();
+}
+
+bool TextEdit::is_drawing_caret_when_editable_disabled() const {
+	return draw_caret_when_editable_disabled;
+}
+
 void TextEdit::set_move_caret_on_right_click_enabled(const bool p_enabled) {
 	move_caret_on_right_click = p_enabled;
 }
@@ -6195,6 +6207,9 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_caret_blink_interval", "interval"), &TextEdit::set_caret_blink_interval);
 	ClassDB::bind_method(D_METHOD("get_caret_blink_interval"), &TextEdit::get_caret_blink_interval);
 
+	ClassDB::bind_method(D_METHOD("set_draw_caret_when_editable_disabled", "enable"), &TextEdit::set_draw_caret_when_editable_disabled);
+	ClassDB::bind_method(D_METHOD("is_drawing_caret_when_editable_disabled"), &TextEdit::is_drawing_caret_when_editable_disabled);
+
 	ClassDB::bind_method(D_METHOD("set_move_caret_on_right_click_enabled", "enable"), &TextEdit::set_move_caret_on_right_click_enabled);
 	ClassDB::bind_method(D_METHOD("is_move_caret_on_right_click_enabled"), &TextEdit::is_move_caret_on_right_click_enabled);
 
@@ -6436,6 +6451,7 @@ void TextEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "caret_type", PROPERTY_HINT_ENUM, "Line,Block"), "set_caret_type", "get_caret_type");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_blink"), "set_caret_blink_enabled", "is_caret_blink_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "caret_blink_interval", PROPERTY_HINT_RANGE, "0.1,10,0.01,suffix:s"), "set_caret_blink_interval", "get_caret_blink_interval");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_draw_when_editable_disabled"), "set_draw_caret_when_editable_disabled", "is_drawing_caret_when_editable_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_move_on_right_click"), "set_move_caret_on_right_click_enabled", "is_move_caret_on_right_click_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_mid_grapheme"), "set_caret_mid_grapheme_enabled", "is_caret_mid_grapheme_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_multiple"), "set_multiple_carets_enabled", "is_multiple_carets_enabled");

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -413,6 +413,7 @@ private:
 	CaretType caret_type = CaretType::CARET_TYPE_LINE;
 
 	bool draw_caret = true;
+	bool draw_caret_when_editable_disabled = false;
 
 	bool caret_blink_enabled = false;
 	Timer *caret_blink_timer = nullptr;
@@ -820,6 +821,9 @@ public:
 
 	void set_caret_blink_interval(const float p_interval);
 	float get_caret_blink_interval() const;
+
+	void set_draw_caret_when_editable_disabled(bool p_enable);
+	bool is_drawing_caret_when_editable_disabled() const;
 
 	void set_move_caret_on_right_click_enabled(const bool p_enabled);
 	bool is_move_caret_on_right_click_enabled() const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

I've created a new PR but this time without messing up (I hope).
The feature is a flag that enables the caret to be shown even in read only/not editable situations.
At first I was writing it as a read only function but I saw it was changed in 4.0 so I changed it.
Anyway, thank you again for your patience and I hope to keep working on the engine more and more as I keep learning.