### PR TITLE
Fix mouse-button-mask on button release in unit test

### DIFF
--- a/core/input/input_enums.h
+++ b/core/input/input_enums.h
@@ -122,6 +122,7 @@ enum class MouseButton {
 };
 
 enum class MouseButtonMask {
+	NONE = 0,
 	LEFT = (1 << (int(MouseButton::LEFT) - 1)),
 	RIGHT = (1 << (int(MouseButton::RIGHT) - 1)),
 	MIDDLE = (1 << (int(MouseButton::MIDDLE) - 1)),

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -1161,7 +1161,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit, line_0, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
 
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit, line_0, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit, line_0, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "");


### PR DESCRIPTION
On mouse-button release, the mask is `0`.
