### PR TITLE
Pass indices to trimesh collision shapes; optimize CSG collision

### DIFF
--- a/doc/classes/ConcavePolygonShape3D.xml
+++ b/doc/classes/ConcavePolygonShape3D.xml
@@ -18,6 +18,19 @@
 			<return type="PackedVector3Array" />
 			<description>
 				Returns the faces of the trimesh shape as an array of vertices. The array (of length divisible by three) is naturally divided into triples; each triple of vertices defines a triangle.
+				[b]Note:[/b] This array is computed based on the shape's vertices and indices.
+			</description>
+		</method>
+		<method name="get_indices" qualifiers="const">
+			<return type="PackedInt32Array" />
+			<description>
+				Returns the array of indices of the trimesh shape. The array (of length divisible by three) is naturally divided into triples; the elements of each triple are indices into the array of vertices (see [method get_vertices]), hence each triple defines a triangle.
+			</description>
+		</method>
+		<method name="get_vertices" qualifiers="const">
+			<return type="PackedVector3Array" />
+			<description>
+				Returns the array of points which appear as vertices of the triangles in the trimesh shape. To get the actual triangles, see [method get_indices] and [method get_faces].
 			</description>
 		</method>
 		<method name="set_faces">
@@ -25,6 +38,22 @@
 			<param index="0" name="faces" type="PackedVector3Array" />
 			<description>
 				Sets the faces of the trimesh shape from an array of vertices. The [param faces] array should be composed of triples such that each triple of vertices defines a triangle.
+				[b]Note:[/b] This method sets the shape's vertices and indices in a maximally inefficient way (one index for each vertex). If possible, use [method set_vertices] followed by [method set_indices] instead.
+			</description>
+		</method>
+		<method name="set_indices">
+			<return type="void" />
+			<param index="0" name="indices" type="PackedInt32Array" />
+			<description>
+				Sets the array of indices of the trimesh shape. The [param indices] array should be composed of triples such that each element is an index into the array of vertices (see [method get_vertices]), hence each triple defines a triangle.
+			</description>
+		</method>
+		<method name="set_vertices">
+			<return type="void" />
+			<param index="0" name="vertices" type="PackedVector3Array" />
+			<description>
+				Sets the points of the trimesh shape which can appear as triangle vertices. To set the actual triangles, see [method set_indices] and [method set_faces].
+				[b]Note:[/b] This method resets the indices of the trimesh shape to an empty array.
 			</description>
 		</method>
 	</methods>

--- a/modules/navigation/navigation_mesh_generator.cpp
+++ b/modules/navigation/navigation_mesh_generator.cpp
@@ -264,6 +264,7 @@ void NavigationMeshGenerator::_parse_geometry(const Transform3D &p_navmesh_trans
 
 					ConcavePolygonShape3D *concave_polygon = Object::cast_to<ConcavePolygonShape3D>(*s);
 					if (concave_polygon) {
+						// TODO: Use _add_mesh_array instead of _add_faces in this case.
 						_add_faces(concave_polygon->get_faces(), transform, p_vertices, p_indices);
 					}
 
@@ -414,7 +415,15 @@ void NavigationMeshGenerator::_parse_geometry(const Transform3D &p_navmesh_trans
 					} break;
 					case PhysicsServer3D::SHAPE_CONCAVE_POLYGON: {
 						Dictionary dict = data;
-						PackedVector3Array faces = Variant(dict["faces"]);
+						Vector<Vector3> vertices = dict["vertices"];
+						Vector<int> indices = dict["indices"];
+						// TODO: Use _add_mesh_array instead of _add_faces in this case.
+						Vector<Vector3> faces;
+						faces.resize(indices.size());
+						Vector3 *facesw = faces.ptrw();
+						for (int j = 0; j < indices.size(); j++) {
+							facesw[j] = vertices[indices[j]];
+						}
 						_add_faces(faces, shapes[i], p_vertices, p_indices);
 					} break;
 					case PhysicsServer3D::SHAPE_HEIGHTMAP: {

--- a/scene/resources/concave_polygon_shape_3d.h
+++ b/scene/resources/concave_polygon_shape_3d.h
@@ -36,7 +36,8 @@
 class ConcavePolygonShape3D : public Shape3D {
 	GDCLASS(ConcavePolygonShape3D, Shape3D);
 
-	Vector<Vector3> faces;
+	Vector<Vector3> vertices;
+	Vector<int> indices;
 	bool backface_collision = false;
 
 	struct DrawEdge {
@@ -65,6 +66,12 @@ protected:
 	virtual void _update_shape() override;
 
 public:
+	void set_vertices(const Vector<Vector3> &p_vertices);
+	Vector<Vector3> get_vertices() const;
+
+	void set_indices(const Vector<int> &p_indices);
+	Vector<int> get_indices() const;
+
 	void set_faces(const Vector<Vector3> &p_faces);
 	Vector<Vector3> get_faces() const;
 

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -559,23 +559,16 @@ Ref<ConvexPolygonShape3D> Mesh::create_convex_shape(bool p_clean, bool p_simplif
 }
 
 Ref<ConcavePolygonShape3D> Mesh::create_trimesh_shape() const {
-	Vector<Face3> faces = get_faces();
-	if (faces.size() == 0) {
-		return Ref<ConcavePolygonShape3D>();
-	}
+	Ref<TriangleMesh> tm = generate_triangle_mesh();
+	ERR_FAIL_COND_V(!tm.is_valid(), Ref<ConcavePolygonShape3D>());
 
-	Vector<Vector3> face_points;
-	face_points.resize(faces.size() * 3);
-
-	for (int i = 0; i < face_points.size(); i += 3) {
-		Face3 f = faces.get(i / 3);
-		face_points.set(i, f.vertex[0]);
-		face_points.set(i + 1, f.vertex[1]);
-		face_points.set(i + 2, f.vertex[2]);
-	}
+	Vector<Vector3> vertices = tm->get_vertices();
+	Vector<int> indices;
+	tm->get_indices(&indices);
 
 	Ref<ConcavePolygonShape3D> shape = memnew(ConcavePolygonShape3D);
-	shape->set_faces(face_points);
+	shape->set_vertices(vertices);
+	shape->set_indices(indices);
 	return shape;
 }
 

--- a/servers/physics_3d/godot_shape_3d.h
+++ b/servers/physics_3d/godot_shape_3d.h
@@ -358,7 +358,7 @@ struct GodotConcavePolygonShape3D : public GodotConcaveShape3D {
 
 	void _fill_bvh(_Volume_BVH *p_bvh_tree, BVH *p_bvh_array, int &p_idx);
 
-	void _setup(const Vector<Vector3> &p_faces, bool p_backface_collision);
+	void _setup(const Vector<Vector3> &p_vertices, const Vector<int> &p_indices, bool p_backface_collision);
 
 public:
 	Vector<Vector3> get_faces() const;


### PR DESCRIPTION
In Godot Physics the trimesh collision shape (`ConcavePolygonShape3D`) always had the ability to store triangles by storing vertices and (triples of) indices (into the list of vertices), but this ability was only ever used like this:

https://github.com/godotengine/godot/blob/a05670c617abc1df93ebac5afacf3e6c48008a99/servers/physics_3d/godot_shape_3d.cpp#L1631-L1633

By adding the ability to pass custom indices, we also gain the ability to run the mesh optimizer (via the static method `SurfaceTool::strip_mesh_arrays`) in the editor (on import, or when generating a collision shape from a mesh). This has the positive effect of eliminating degenerate triangles, which are known to cause collision issues, see e.g. https://github.com/godotengine/godot/pull/47214#issuecomment-803557907. This PR applies that optimization to CSG collision shapes; it could also be exposed (as an option) to meshes and the mesh importer.

This also paves the way to fixing https://github.com/godotengine/godot/issues/69683 (for `ConcavePolygonShape3D`) via the algorithm described in [*Contact generation for meshes* by Pierre Terdiman](https://www.codercorner.com/MeshContacts.pdf).

Breaks compatibility very slightly, only on the physics server level: the format of [`shape_get_data`](https://docs.godotengine.org/en/latest/classes/class_physicsserver3d.html#class-physicsserver3d-method-shape-get-data) / [`shape_set_data`](https://docs.godotengine.org/en/latest/classes/class_physicsserver3d.html#class-physicsserver3d-method-shape-set-data) changed from a dictionary with a `"faces"` key (`PackedVector3Array` value) to a dictionary with a `"vertices"` key (`PackedVector3Array` value) and an `"indices"` key (`PackedInt32Array` value).

Supersedes https://github.com/godotengine/godot/pull/47214.

_Production edit: closes godotengine/internal-team-priorities#54_