### PR TITLE
Add methods to query the list of methods and properties required to run an Expression

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -31,6 +31,7 @@
 #include "expression.h"
 
 #include "core/object/class_db.h"
+#include "core/templates/hash_set.h"
 
 Error Expression::_get_token(Token &r_token) {
 	while (true) {
@@ -1511,11 +1512,62 @@ String Expression::get_error_text() const {
 	return error_str;
 }
 
+String Expression::get_method_literal(const Expression::ENode *node) {
+	if (node->type == Expression::ENode::TYPE_CALL) {
+		const Expression::CallNode *callNode = static_cast<const Expression::CallNode *>(node);
+		if (callNode->base->type == Expression::ENode::TYPE_SELF) {
+			return callNode->method;
+		}
+	}
+	return {};
+}
+
+String Expression::get_property_literal(const Expression::ENode *node) {
+	if (node->type == Expression::ENode::TYPE_NAMED_INDEX) {
+		const Expression::NamedIndexNode *namedIndexNode = static_cast<const Expression::NamedIndexNode *>(node);
+		if (namedIndexNode->base->type == Expression::ENode::TYPE_SELF) {
+			return namedIndexNode->name;
+		}
+	}
+	return {};
+}
+
+PackedStringArray Expression::get_required_literals(const Expression::ENode *node, String (*get_literal)(const Expression::ENode *node)) {
+	PackedStringArray required_literals;
+	HashSet<String> unique_literals;
+
+	while (node != nullptr) {
+		String literal = get_literal(node);
+		if (!literal.is_empty() && !unique_literals.has(literal)) {
+			required_literals.push_back(literal);
+			unique_literals.insert(literal);
+		}
+
+		node = node->next;
+	}
+	return required_literals;
+}
+
+PackedStringArray Expression::get_input_names() const {
+	return input_names;
+}
+
+PackedStringArray Expression::get_required_methods() const {
+	return get_required_literals(nodes, get_method_literal);
+}
+
+PackedStringArray Expression::get_required_properties() const {
+	return get_required_literals(nodes, get_property_literal);
+}
+
 void Expression::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("parse", "expression", "input_names"), &Expression::parse, DEFVAL(Vector<String>()));
 	ClassDB::bind_method(D_METHOD("execute", "inputs", "base_instance", "show_error", "const_calls_only"), &Expression::execute, DEFVAL(Array()), DEFVAL(Variant()), DEFVAL(true), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("has_execute_failed"), &Expression::has_execute_failed);
 	ClassDB::bind_method(D_METHOD("get_error_text"), &Expression::get_error_text);
+	ClassDB::bind_method(D_METHOD("get_input_names"), &Expression::get_input_names);
+	ClassDB::bind_method(D_METHOD("get_required_methods"), &Expression::get_required_methods);
+	ClassDB::bind_method(D_METHOD("get_required_properties"), &Expression::get_required_properties);
 }
 
 Expression::~Expression() {

--- a/core/math/expression.h
+++ b/core/math/expression.h
@@ -138,6 +138,9 @@ protected:
 	};
 
 	ENode *_parse_expression();
+	static String get_method_literal(const Expression::ENode *node);
+	static String get_property_literal(const Expression::ENode *node);
+	static PackedStringArray get_required_literals(const Expression::ENode *node, String (*get_literal)(const Expression::ENode *node));
 
 	struct InputNode : public ENode {
 		int index = 0;
@@ -252,6 +255,9 @@ public:
 	Variant execute(const Array &p_inputs = Array(), Object *p_base = nullptr, bool p_show_error = true, bool p_const_calls_only = false);
 	bool has_execute_failed() const;
 	String get_error_text() const;
+	PackedStringArray get_input_names() const;
+	PackedStringArray get_required_methods() const;
+	PackedStringArray get_required_properties() const;
 
 	~Expression();
 };

--- a/doc/classes/Expression.xml
+++ b/doc/classes/Expression.xml
@@ -69,6 +69,24 @@
 				Returns the error text if [method parse] or [method execute] has failed.
 			</description>
 		</method>
+		<method name="get_input_names" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Returns the input names supplied when [method parse] was called.
+			</description>
+		</method>
+		<method name="get_required_methods" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Scans the parsed expression and returns a [PackedStringArray] of method literals that must exist on the base instance for this expression to execute successfully.
+			</description>
+		</method>
+		<method name="get_required_properties" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+				Scans the parsed expression and returns a [PackedStringArray] of property literals that must exist on the base instance for this expression to execute successfully.
+			</description>
+		</method>
 		<method name="has_execute_failed" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/tests/core/math/test_expression.cpp
+++ b/tests/core/math/test_expression.cpp
@@ -488,4 +488,208 @@ TEST_CASE("[Expression] Unusual expressions") {
 	//		"`(-9223372036854775807 - 1) / -1` should return the expected result.");
 }
 
+TEST_CASE("[Expression] Input names") {
+	Expression expression;
+
+	CHECK_MESSAGE(
+			expression.get_input_names().size() == 0,
+			"There should be 0 input names before parsing.");
+
+	CHECK_MESSAGE(
+			expression.parse("a") == OK,
+			"The expression should parse successfully.");
+
+	CHECK_MESSAGE(
+			expression.get_input_names().size() == 0,
+			"There were 0 input names supplied during parsing.");
+
+	PackedStringArray input_names;
+	input_names.push_back("a");
+
+	CHECK_MESSAGE(
+			expression.parse("a", input_names) == OK,
+			"The expression should parse successfully.");
+
+	CHECK_MESSAGE(
+			expression.get_input_names() == input_names,
+			"There was 1 input name supplied during parsing.");
+
+	CHECK_MESSAGE(
+			expression.execute() == Variant(),
+			"No result expected from invalid expression.");
+
+	CHECK_MESSAGE(
+			expression.has_execute_failed(),
+			"Execute should fail due to missing inputs.");
+
+	Array inputs;
+	inputs.push_back(42);
+	CHECK_MESSAGE(
+			int(expression.execute(inputs)) == 42,
+			"Expected 42 to be returned from execution");
+}
+
+TEST_CASE("[Expression] Getting required literals") {
+	Expression expression;
+	PackedStringArray required_methods;
+	PackedStringArray required_properties;
+
+	// Not parsed
+	required_methods = expression.get_required_methods();
+	required_properties = expression.get_required_properties();
+	CHECK_MESSAGE(
+			required_methods.size() == 0,
+			"There should be no required methods.");
+	CHECK_MESSAGE(
+			required_properties.size() == 0,
+			"There should be no required properties.");
+
+	// No literals
+	CHECK_MESSAGE(
+			expression.parse("5") == OK,
+			"The expression should parse successfully.");
+	required_methods = expression.get_required_methods();
+	required_properties = expression.get_required_properties();
+	CHECK_MESSAGE(
+			required_methods.size() == 0,
+			"There should be no required methods.");
+	CHECK_MESSAGE(
+			required_properties.size() == 0,
+			"There should be no required properties.");
+
+	// One of each
+	CHECK_MESSAGE(
+			expression.parse("a + b()") == OK,
+			"The expression should parse successfully.");
+	required_methods = expression.get_required_methods();
+	required_properties = expression.get_required_properties();
+	CHECK_MESSAGE(
+			required_methods.size() == 1,
+			"There should be one required method.");
+	CHECK_MESSAGE(
+			required_methods[0] == "b",
+			"Expected method b to exist.");
+	CHECK_MESSAGE(
+			required_properties.size() == 1,
+			"There should be one required property.");
+	CHECK_MESSAGE(
+			required_properties[0] == "a",
+			"Expected property a to exist.");
+
+	// Explicit self
+	CHECK_MESSAGE(
+			expression.parse("self.a + self.b()") == OK,
+			"The expression should parse successfully.");
+	required_methods = expression.get_required_methods();
+	required_properties = expression.get_required_properties();
+	CHECK_MESSAGE(
+			required_methods.size() == 1,
+			"There should be one required method.");
+	CHECK_MESSAGE(
+			required_methods[0] == "b",
+			"Expected method b to exist.");
+	CHECK_MESSAGE(
+			required_properties.size() == 1,
+			"There should be one required property.");
+	CHECK_MESSAGE(
+			required_properties[0] == "a",
+			"Expected property a to exist.");
+
+	// Duplicates
+	CHECK_MESSAGE(
+			expression.parse("a + b() + a + b()") == OK,
+			"The expression should parse successfully.");
+	required_methods = expression.get_required_methods();
+	required_properties = expression.get_required_properties();
+	CHECK_MESSAGE(
+			required_methods.size() == 1,
+			"There should be one required method.");
+	CHECK_MESSAGE(
+			required_methods[0] == "b",
+			"Expected method b to exist.");
+	CHECK_MESSAGE(
+			required_properties.size() == 1,
+			"There should be one required property.");
+	CHECK_MESSAGE(
+			required_properties[0] == "a",
+			"Expected property a to exist.");
+
+	// Nested
+	CHECK_MESSAGE(
+			expression.parse("[a, b()] == {a(): b}") == OK,
+			"The expression should parse successfully.");
+	required_methods = expression.get_required_methods();
+	required_properties = expression.get_required_properties();
+	CHECK_MESSAGE(
+			required_methods.size() == 2,
+			"There should be two required methods.");
+	CHECK_MESSAGE(
+			required_methods[0] == "a",
+			"Expected method a to exist.");
+	CHECK_MESSAGE(
+			required_methods[1] == "b",
+			"Expected method b to exist.");
+	CHECK_MESSAGE(
+			required_properties.size() == 2,
+			"There should be two required properties.");
+	CHECK_MESSAGE(
+			required_properties[0] == "b",
+			"Expected property b to exist.");
+	CHECK_MESSAGE(
+			required_properties[1] == "a",
+			"Expected property a to exist.");
+
+	// Members
+	CHECK_MESSAGE(
+			expression.parse("a.b.c.d() == a().b().c().d") == OK,
+			"The expression should parse successfully.");
+	required_methods = expression.get_required_methods();
+	required_properties = expression.get_required_properties();
+	CHECK_MESSAGE(
+			required_methods.size() == 1,
+			"There should be one required method.");
+	CHECK_MESSAGE(
+			required_methods[0] == "a",
+			"Expected method a to exist.");
+	CHECK_MESSAGE(
+			required_properties.size() == 1,
+			"There should be one required property.");
+	CHECK_MESSAGE(
+			required_properties[0] == "a",
+			"Expected property a to exist.");
+
+	// Input Names
+	PackedStringArray input_names;
+	input_names.push_back("a");
+	CHECK_MESSAGE(
+			expression.parse("a", input_names) == OK,
+			"The expression should parse successfully.");
+	required_properties = expression.get_required_properties();
+	CHECK_MESSAGE(
+			required_properties.size() == 0,
+			"Input names should not be required properties.");
+
+	// Constructor
+	CHECK_MESSAGE(
+			expression.parse("Vector2(1, 1)") == OK,
+			"The expression should parse successfully.");
+	required_methods = expression.get_required_methods();
+	CHECK_MESSAGE(
+			required_methods.size() == 0,
+			"Constructors should not be required methods.");
+
+	// Builtin func
+	CHECK_MESSAGE(
+			expression.parse("sin(PI)") == OK,
+			"The expression should parse successfully.");
+	required_methods = expression.get_required_methods();
+	required_properties = expression.get_required_properties();
+	CHECK_MESSAGE(
+			required_methods.size() == 0,
+			"Builtin funcs should not be required methods.");
+	CHECK_MESSAGE(
+			required_properties.size() == 0,
+			"Constants should not be required properties.");
+}
+
 } // namespace TestExpression


### PR DESCRIPTION
Added 2 functions to `Expression` to check which methods or properties are required in the "base instance" in order for the `Expression` to `execute` properly. It scans through the tree to collect `CallNode` or `NamedIndexNode` respectively and returns a set of unique names.

Additionally `get_input_names` is now implemented to get more details of the `Expression`. Added tests to cover `input_names` functionality and required literals.

Resolves https://github.com/godotengine/godot-proposals/issues/6796