### PR TITLE
Use `GDExtensionBool` in GDExtension interface

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -54,22 +54,22 @@ static void gdextension_free(void *p_mem) {
 }
 
 // Helper print functions.
-static void gdextension_print_error(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify) {
+static void gdextension_print_error(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify) {
 	_err_print_error(p_function, p_file, p_line, p_description, p_editor_notify, ERR_HANDLER_ERROR);
 }
-static void gdextension_print_error_with_message(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify) {
+static void gdextension_print_error_with_message(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify) {
 	_err_print_error(p_function, p_file, p_line, p_description, p_message, p_editor_notify, ERR_HANDLER_ERROR);
 }
-static void gdextension_print_warning(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify) {
+static void gdextension_print_warning(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify) {
 	_err_print_error(p_function, p_file, p_line, p_description, p_editor_notify, ERR_HANDLER_WARNING);
 }
-static void gdextension_print_warning_with_message(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify) {
+static void gdextension_print_warning_with_message(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify) {
 	_err_print_error(p_function, p_file, p_line, p_description, p_message, p_editor_notify, ERR_HANDLER_WARNING);
 }
-static void gdextension_print_script_error(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify) {
+static void gdextension_print_script_error(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify) {
 	_err_print_error(p_function, p_file, p_line, p_description, p_editor_notify, ERR_HANDLER_SCRIPT);
 }
-static void gdextension_print_script_error_with_message(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify) {
+static void gdextension_print_script_error_with_message(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify) {
 	_err_print_error(p_function, p_file, p_line, p_description, p_message, p_editor_notify, ERR_HANDLER_SCRIPT);
 }
 

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -414,12 +414,12 @@ typedef struct {
 	void *(*mem_realloc)(void *p_ptr, size_t p_bytes);
 	void (*mem_free)(void *p_ptr);
 
-	void (*print_error)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify);
-	void (*print_error_with_message)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify);
-	void (*print_warning)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify);
-	void (*print_warning_with_message)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify);
-	void (*print_script_error)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify);
-	void (*print_script_error_with_message)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify);
+	void (*print_error)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
+	void (*print_error_with_message)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
+	void (*print_warning)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
+	void (*print_warning_with_message)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
+	void (*print_script_error)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
+	void (*print_script_error_with_message)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
 
 	uint64_t (*get_native_struct_size)(GDExtensionConstStringNamePtr p_name);
 


### PR DESCRIPTION
`bool` parameter was recently added to `gdextension_interface.h`. This produces an error when using the header in a C program.

<details><summary>GCC Error Output</summary>

```
In file included from test.c:1:
/home/timothy/repos/godot-master/core/extension/gdextension_interface.h:417:116: error: unknown type name 'bool'
  417 |         void (*print_error)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify);
      |                                                                                                                    ^~~~
/home/timothy/repos/godot-master/core/extension/gdextension_interface.h:40:1: note: 'bool' is defined in header '<stdbool.h>'; did you forget to '#include <stdbool.h>'?
   39 | #include <stdint.h>
  +++ |+#include <stdbool.h>
   40 | 
/home/timothy/repos/godot-master/core/extension/gdextension_interface.h:418:152: error: unknown type name 'bool'
  418 |         void (*print_error_with_message)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify);
      |                                                                                                                                                        ^~~~
/home/timothy/repos/godot-master/core/extension/gdextension_interface.h:418:152: note: 'bool' is defined in header '<stdbool.h>'; did you forget to '#include <stdbool.h>'?
/home/timothy/repos/godot-master/core/extension/gdextension_interface.h:419:118: error: unknown type name 'bool'
  419 |         void (*print_warning)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify);
      |                                                                                                                      ^~~~
/home/timothy/repos/godot-master/core/extension/gdextension_interface.h:419:118: note: 'bool' is defined in header '<stdbool.h>'; did you forget to '#include <stdbool.h>'?
/home/timothy/repos/godot-master/core/extension/gdextension_interface.h:420:154: error: unknown type name 'bool'
  420 |         void (*print_warning_with_message)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify);
      |                                                                                                                                                          ^~~~
/home/timothy/repos/godot-master/core/extension/gdextension_interface.h:420:154: note: 'bool' is defined in header '<stdbool.h>'; did you forget to '#include <stdbool.h>'?
/home/timothy/repos/godot-master/core/extension/gdextension_interface.h:421:123: error: unknown type name 'bool'
  421 |         void (*print_script_error)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify);
      |                                                                                                                           ^~~~
/home/timothy/repos/godot-master/core/extension/gdextension_interface.h:421:123: note: 'bool' is defined in header '<stdbool.h>'; did you forget to '#include <stdbool.h>'?
/home/timothy/repos/godot-master/core/extension/gdextension_interface.h:422:159: error: unknown type name 'bool'
  422 |         void (*print_script_error_with_message)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, bool p_editor_notify);
      |                                                                                                                                                               ^~~~
/home/timothy/repos/godot-master/core/extension/gdextension_interface.h:422:159: note: 'bool' is defined in header '<stdbool.h>'; did you forget to '#include <stdbool.h>'?
```

</details>

Didn't use the suggested `stdbool.h` approach because other boolean parameters in the header use `GDExtensionBool`.