### PR TITLE
Fix panning via InputEventPanGesture

### DIFF
--- a/scene/gui/view_panner.cpp
+++ b/scene/gui/view_panner.cpp
@@ -125,7 +125,7 @@ bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) 
 
 	Ref<InputEventPanGesture> pan_gesture = p_event;
 	if (pan_gesture.is_valid()) {
-		callback_helper(pan_callback, varray(-pan_gesture->get_delta(), p_event));
+		callback_helper(pan_callback, varray(-pan_gesture->get_delta() * scroll_speed, p_event));
 	}
 
 	Ref<InputEventScreenDrag> screen_drag = p_event;


### PR DESCRIPTION
From my understanding, the `InputEventPanGesture::get_delta()` function returns a value that is supposed to be close to 1.0 when we want it to be an equivalent of a mouse scroll event.

Multiplying the value by scroll_speed should consequently make sense.

Needs testing, but should fix https://github.com/godotengine/godot/issues/72242
I added @bruvzg  as co-author as he mentioned that fix in the issue.