### PR TITLE
[DisplayServer] Add an option for GDExtension to extend DisplayServer window creation.

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1462,6 +1462,9 @@
 		<member name="DisplayServer" type="DisplayServer" setter="" getter="">
 			The [DisplayServer] singleton.
 		</member>
+		<member name="DisplayServerExtensionManager" type="DisplayServerExtensionManager" setter="" getter="">
+			The [DisplayServerExtensionManager] singleton.
+		</member>
 		<member name="Engine" type="Engine" setter="" getter="">
 			The [Engine] singleton.
 		</member>

--- a/doc/classes/DisplayServerExtension.xml
+++ b/doc/classes/DisplayServerExtension.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DisplayServerExtension" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Base class for [DisplayServer] plugins.
+	</brief_description>
+	<description>
+		[DisplayServer] plugin implementations should inherit from this class.
+		Implementations should register a derived class during [code]SERVERS[/code] initialization step, create a single instance of it and pass it the [method DisplayServerExtensionManager.add_interface] method. It's automatically unregistered and deleted before [code]SERVERS[/code] deinitialization step.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_cleanup" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				This method is called before all [DisplayServer] plugins are unregistered and deleted.
+			</description>
+		</method>
+		<method name="_create_window" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="window_id" type="int" />
+			<param index="1" name="native_display_handle" type="int" />
+			<param index="2" name="native_window_handle" type="int" />
+			<param index="3" name="native_view_handle" type="int" />
+			<description>
+				This method is called immediately after native window is created by [DisplayServer], allowing to subclass and modify it.
+			</description>
+		</method>
+		<method name="_destroy_window" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="window_id" type="int" />
+			<param index="1" name="native_display_handle" type="int" />
+			<param index="2" name="native_window_handle" type="int" />
+			<param index="3" name="native_view_handle" type="int" />
+			<description>
+				This method is called immediately before native window is destroyed by [DisplayServer].
+			</description>
+		</method>
+		<method name="_get_name" qualifiers="virtual const">
+			<return type="String" />
+			<description>
+				When this method is called, implementation should retun readable plugin name.
+			</description>
+		</method>
+		<method name="_node_tree_changed" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="id" type="int" />
+			<description>
+				If [method _requires_node_tree_updates] returns [code]true[/code], this method should be called when node enters/exits tree (done automatically), or node information relevant for the plugin is changed (use [method Node.emit_tree_update]).
+			</description>
+		</method>
+		<method name="_process_events" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				This method is called at the end of every [DisplayServer]'s event processing loop iteration.
+			</description>
+		</method>
+		<method name="_requires_node_tree_updates" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code], if this plugin requires notifications about node tree changes.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/DisplayServerExtensionManager.xml
+++ b/doc/classes/DisplayServerExtensionManager.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DisplayServerExtensionManager" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Manager for the [DisplayServer] extensions.
+	</brief_description>
+	<description>
+		[DisplayServerExtensionManager] is the API backend for loading and enumeration of the [DisplayServerExtension]s.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="add_interface">
+			<return type="void" />
+			<param index="0" name="interface" type="DisplayServerExtension" />
+			<description>
+				Registers an [DisplayServerExtension] interface.
+			</description>
+		</method>
+		<method name="find_interface" qualifiers="const">
+			<return type="DisplayServerExtension" />
+			<param index="0" name="name" type="String" />
+			<description>
+				Finds an interface by its name.
+			</description>
+		</method>
+		<method name="get_interface" qualifiers="const">
+			<return type="DisplayServerExtension" />
+			<param index="0" name="idx" type="int" />
+			<description>
+				Returns the interface registered at a given index.
+			</description>
+		</method>
+		<method name="get_interface_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of interfaces currently registered.
+			</description>
+		</method>
+		<method name="get_interfaces" qualifiers="const">
+			<return type="Dictionary[]" />
+			<description>
+				Returns a list of available interfaces the index and name of each interface.
+			</description>
+		</method>
+		<method name="remove_interface">
+			<return type="void" />
+			<param index="0" name="interface" type="DisplayServerExtension" />
+			<description>
+				Removes interface.
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="interface_added">
+			<param index="0" name="interface_name" type="StringName" />
+			<description>
+				Emitted when a new interface has been added.
+			</description>
+		</signal>
+		<signal name="interface_removed">
+			<param index="0" name="interface_name" type="StringName" />
+			<description>
+				Emitted when an interface is removed.
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -212,6 +212,12 @@
 				[b]Note:[/b] It will not work properly if the node contains a script with constructor arguments (i.e. needs to supply arguments to [method Object._init] method). In that case, the node will be duplicated without a script.
 			</description>
 		</method>
+		<method name="emit_tree_update">
+			<return type="void" />
+			<description>
+				Sends notification about node tree changes to the [DisplayServerExtension]s.
+			</description>
+		</method>
 		<method name="find_child" qualifiers="const">
 			<return type="Node" />
 			<param index="0" name="pattern" type="String" />

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		External TextServer implementations should inherit from this class.
+		Implementations should register a derived class during [code]SERVERS[/code] initialization step, create a single instance of it and pass it the [method TextServerManager.add_interface] method. It's automatically unregistered and deleted before [code]SERVERS[/code] deinitialization step.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -194,6 +194,12 @@
 				See [method Control.get_theme_color] for details.
 			</description>
 		</method>
+		<method name="get_window_id" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns window id of the native window.
+			</description>
+		</method>
 		<method name="grab_focus">
 			<return type="void" />
 			<description>

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -1349,6 +1349,10 @@ void DisplayServerX11::delete_sub_window(WindowID p_id) {
 	}
 #endif
 
+	for (int i = 0; i < DisplayServerExtensionManager::get_singleton()->get_interface_count(); i++) {
+		DisplayServerExtensionManager::get_singleton()->get_interface(i)->destroy_window(p_id, (int64_t)(x11_display), (int64_t)(wd.x11_window), 0);
+	}
+
 	if (wd.xic) {
 		XDestroyIC(wd.xic);
 		wd.xic = nullptr;
@@ -4659,6 +4663,10 @@ void DisplayServerX11::process_events() {
 	}
 
 	Input::get_singleton()->flush_buffered_events();
+
+	for (int i = 0; i < DisplayServerExtensionManager::get_singleton()->get_interface_count(); i++) {
+		DisplayServerExtensionManager::get_singleton()->get_interface(i)->process_events();
+	}
 }
 
 void DisplayServerX11::release_rendering_thread() {
@@ -4998,6 +5006,11 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 		window_attributes_ime.event_mask = KeyPressMask | KeyReleaseMask | StructureNotifyMask | ExposureMask;
 
 		wd.x11_xim_window = XCreateWindow(x11_display, wd.x11_window, 0, 0, 1, 1, 0, CopyFromParent, InputOnly, CopyFromParent, CWEventMask, &window_attributes_ime);
+
+		for (int i = 0; i < DisplayServerExtensionManager::get_singleton()->get_interface_count(); i++) {
+			DisplayServerExtensionManager::get_singleton()->get_interface(i)->create_window(id, (int64_t)(x11_display), (int64_t)(wd.x11_window), 0);
+		}
+
 #ifdef XKB_ENABLED
 		if (dead_tbl && xkb_loaded_v05p) {
 			wd.xkb_state = xkb_compose_state_new(dead_tbl, XKB_COMPOSE_STATE_NO_FLAGS);
@@ -5854,6 +5867,11 @@ DisplayServerX11::~DisplayServerX11() {
 #endif
 
 		WindowData &wd = E.value;
+
+		for (int i = 0; i < DisplayServerExtensionManager::get_singleton()->get_interface_count(); i++) {
+			DisplayServerExtensionManager::get_singleton()->get_interface(i)->destroy_window(E.key, (int64_t)(x11_display), (int64_t)(wd.x11_window), 0);
+		}
+
 		if (wd.xic) {
 			XDestroyIC(wd.xic);
 			wd.xic = nullptr;

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -355,6 +355,7 @@ class DisplayServerWindows : public DisplayServer {
 	TTS_Windows *tts = nullptr;
 
 	struct WindowData {
+		WindowID id;
 		HWND hWnd;
 
 		Vector<Vector2> mpath;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -532,6 +532,8 @@ public:
 
 	void update_configuration_warnings();
 
+	void emit_tree_update();
+
 	void set_display_folded(bool p_folded);
 	bool is_displayed_folded() const;
 	/* NETWORK */

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2432,6 +2432,8 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("popup_centered", "minsize"), &Window::popup_centered, DEFVAL(Size2i()));
 	ClassDB::bind_method(D_METHOD("popup_centered_clamped", "minsize", "fallback_ratio"), &Window::popup_centered_clamped, DEFVAL(Size2i()), DEFVAL(0.75));
 
+	ClassDB::bind_method(D_METHOD("get_window_id"), &Window::get_window_id);
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "initial_position", PROPERTY_HINT_ENUM, "Absolute,Center of Primary Screen,Center of Other Screen,Center of Screen With Mouse Pointer,Center of Screen With Keyboard Focus"), "set_initial_position", "get_initial_position");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "title"), "set_title", "get_title");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "position", PROPERTY_HINT_NONE, "suffix:px"), "set_position", "get_position");

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -532,6 +532,68 @@ public:
 	~DisplayServer();
 };
 
+/*************************************************************************/
+
+class DisplayServerExtension : public RefCounted {
+	GDCLASS(DisplayServerExtension, RefCounted);
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual String get_name() const;
+	GDVIRTUAL0RC(String, _get_name);
+
+	virtual void create_window(DisplayServer::WindowID p_window_id, int64_t p_native_display_handle, int64_t p_native_window_handle, int64_t p_native_view_handle);
+	virtual void destroy_window(DisplayServer::WindowID p_window_id, int64_t p_native_display_handle, int64_t p_native_window_handle, int64_t p_native_view_handle);
+	GDVIRTUAL4(_create_window, DisplayServer::WindowID, int64_t, int64_t, int64_t);
+	GDVIRTUAL4(_destroy_window, DisplayServer::WindowID, int64_t, int64_t, int64_t);
+
+	virtual bool requires_node_tree_updates() const;
+	GDVIRTUAL0RC(bool, _requires_node_tree_updates);
+
+	virtual void node_tree_changed(const ObjectID &p_id);
+	GDVIRTUAL1(_node_tree_changed, ObjectID);
+
+	virtual void process_events();
+	GDVIRTUAL0(_process_events);
+
+	virtual void cleanup();
+	GDVIRTUAL0(_cleanup);
+
+	DisplayServerExtension() {}
+	~DisplayServerExtension() {}
+};
+
+/*************************************************************************/
+
+class DisplayServerExtensionManager : public Object {
+	GDCLASS(DisplayServerExtensionManager, Object);
+
+protected:
+	static void _bind_methods();
+
+private:
+	static DisplayServerExtensionManager *singleton;
+
+	Vector<Ref<DisplayServerExtension>> interfaces;
+
+public:
+	_FORCE_INLINE_ static DisplayServerExtensionManager *get_singleton() {
+		return singleton;
+	}
+
+	void add_interface(const Ref<DisplayServerExtension> &p_interface);
+	void remove_interface(const Ref<DisplayServerExtension> &p_interface);
+	int get_interface_count() const;
+	Ref<DisplayServerExtension> get_interface(int p_index) const;
+	Ref<DisplayServerExtension> find_interface(const String &p_name) const;
+	TypedArray<Dictionary> get_interfaces() const;
+
+	DisplayServerExtensionManager();
+	~DisplayServerExtensionManager();
+};
+
 VARIANT_ENUM_CAST(DisplayServer::WindowEvent)
 VARIANT_ENUM_CAST(DisplayServer::Feature)
 VARIANT_ENUM_CAST(DisplayServer::MouseMode)

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -129,7 +129,12 @@ void register_server_types() {
 
 	OS::get_singleton()->set_has_server_feature_callback(has_server_feature_callback);
 
+	GDREGISTER_CLASS(DisplayServerExtensionManager);
+	GDREGISTER_CLASS(DisplayServerExtension);
 	GDREGISTER_ABSTRACT_CLASS(DisplayServer);
+
+	Engine::get_singleton()->add_singleton(Engine::Singleton("DisplayServerExtensionManager", DisplayServerExtensionManager::get_singleton(), "DisplayServerExtensionManager"));
+
 	GDREGISTER_ABSTRACT_CLASS(RenderingServer);
 	GDREGISTER_CLASS(AudioServer);
 


### PR DESCRIPTION
Allow early native window subclassing (immediately after creation) required by AccessKit.

See https://github.com/godotengine/godot/issues/58074#issuecomment-1356799871 and https://github.com/bruvzg/godot_accesskit_demo