### PR TITLE
Allow EditorExportPlugins to provide export options

### DIFF
--- a/doc/classes/EditorExportPlugin.xml
+++ b/doc/classes/EditorExportPlugin.xml
@@ -99,11 +99,29 @@
 				Return a [PackedStringArray] of additional features this preset, for the given [param platform], should have.
 			</description>
 		</method>
+		<method name="_get_export_options" qualifiers="virtual const">
+			<return type="Dictionary[]" />
+			<param index="0" name="platform" type="EditorExportPlatform" />
+			<description>
+				Return a list of export options that can be configured for this export plugin.
+				Each element in the return value is a [Dictionary] with the following keys:
+				- [code]option[/code]: A dictionary with the structure documented by [method Object.get_property_list], but all keys are optional.
+				- [code]default_value[/code]: The default value for this option.
+				- [code]update_visibility[/code]: An optional boolean value. If set to [code]true[/code], the preset will emit [signal Object.property_list_changed] when the option is changed.
+			</description>
+		</method>
 		<method name="_get_name" qualifiers="virtual const">
 			<return type="String" />
 			<description>
 				Return the name identifier of this plugin (for future identification by the exporter). The plugins are sorted by name before exporting.
 				Implementing this method is required.
+			</description>
+		</method>
+		<method name="_should_update_export_options" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="platform" type="EditorExportPlatform" />
+			<description>
+				Return [code]true[/code], if the result of [method _get_export_options] has changed and the export options of preset corresponding to [param platform] should be updated.
 			</description>
 		</method>
 		<method name="add_file">
@@ -183,6 +201,13 @@
 				Adds a shared object or a directory containing only shared objects with the given [param tags] and destination [param path].
 				[b]Note:[/b] In case of macOS exports, those shared objects will be added to [code]Frameworks[/code] directory of app bundle.
 				In case of a directory code-sign will error if you place non code object in directory.
+			</description>
+		</method>
+		<method name="get_option" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Returns the current value of an export option supplied by [method _get_export_options].
 			</description>
 		</method>
 		<method name="skip">

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -313,9 +313,18 @@ void EditorExport::update_export_presets() {
 	for (int i = 0; i < export_platforms.size(); i++) {
 		Ref<EditorExportPlatform> platform = export_platforms[i];
 
-		if (platform->should_update_export_options()) {
+		bool should_update = platform->should_update_export_options();
+		for (int j = 0; j < export_plugins.size(); j++) {
+			should_update |= export_plugins.write[j]->_should_update_export_options(platform);
+		}
+
+		if (should_update) {
 			List<EditorExportPlatform::ExportOption> options;
 			platform->get_export_options(&options);
+
+			for (int j = 0; j < export_plugins.size(); j++) {
+				export_plugins.write[j]->_get_export_options(platform, &options);
+			}
 
 			platform_options[platform->get_name()] = options;
 		}

--- a/editor/export/editor_export_plugin.cpp
+++ b/editor/export/editor_export_plugin.cpp
@@ -127,6 +127,11 @@ Vector<String> EditorExportPlugin::get_ios_project_static_libs() const {
 	return ios_project_static_libs;
 }
 
+Variant EditorExportPlugin::get_option(const StringName &p_name) const {
+	ERR_FAIL_NULL_V(export_preset, Variant());
+	return export_preset->get(p_name);
+}
+
 void EditorExportPlugin::_export_file_script(const String &p_path, const String &p_type, const Vector<String> &p_features) {
 	GDVIRTUAL_CALL(_export_file, p_path, p_type, p_features);
 }
@@ -191,6 +196,26 @@ PackedStringArray EditorExportPlugin::_get_export_features(const Ref<EditorExpor
 	return ret;
 }
 
+void EditorExportPlugin::_get_export_options(const Ref<EditorExportPlatform> &p_platform, List<EditorExportPlatform::ExportOption> *r_options) const {
+	TypedArray<Dictionary> ret;
+	GDVIRTUAL_CALL(_get_export_options, p_platform, ret);
+	for (int i = 0; i < ret.size(); i++) {
+		Dictionary option = ret[i];
+		ERR_CONTINUE_MSG(!option.has("option"), "Missing required element 'option'");
+		ERR_CONTINUE_MSG(!option.has("default_value"), "Missing required element 'default_value'");
+		PropertyInfo property_info = PropertyInfo::from_dict(option["option"]);
+		Variant default_value = option["default_value"];
+		bool update_visibility = option.has("update_visibility") && option["update_visibility"];
+		r_options->push_back(EditorExportPlatform::ExportOption(property_info, default_value, update_visibility));
+	}
+}
+
+bool EditorExportPlugin::_should_update_export_options(const Ref<EditorExportPlatform> &p_platform) const {
+	bool ret = false;
+	GDVIRTUAL_CALL(_should_update_export_options, p_platform, ret);
+	return ret;
+}
+
 void EditorExportPlugin::_export_file(const String &p_path, const String &p_type, const HashSet<String> &p_features) {
 }
 
@@ -213,6 +238,7 @@ void EditorExportPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_ios_cpp_code", "code"), &EditorExportPlugin::add_ios_cpp_code);
 	ClassDB::bind_method(D_METHOD("add_macos_plugin_file", "path"), &EditorExportPlugin::add_macos_plugin_file);
 	ClassDB::bind_method(D_METHOD("skip"), &EditorExportPlugin::skip);
+	ClassDB::bind_method(D_METHOD("get_option", "name"), &EditorExportPlugin::get_option);
 
 	GDVIRTUAL_BIND(_export_file, "path", "type", "features");
 	GDVIRTUAL_BIND(_export_begin, "features", "is_debug", "path", "flags");
@@ -228,6 +254,9 @@ void EditorExportPlugin::_bind_methods() {
 
 	GDVIRTUAL_BIND(_end_customize_scenes);
 	GDVIRTUAL_BIND(_end_customize_resources);
+
+	GDVIRTUAL_BIND(_get_export_options, "platform");
+	GDVIRTUAL_BIND(_should_update_export_options, "platform");
 
 	GDVIRTUAL_BIND(_get_export_features, "platform", "debug");
 	GDVIRTUAL_BIND(_get_name);

--- a/editor/export/editor_export_plugin.h
+++ b/editor/export/editor_export_plugin.h
@@ -32,6 +32,7 @@
 #define EDITOR_EXPORT_PLUGIN_H
 
 #include "core/extension/gdextension.h"
+#include "editor_export_platform.h"
 #include "editor_export_preset.h"
 #include "editor_export_shared_object.h"
 #include "scene/main/node.h"
@@ -39,6 +40,7 @@
 class EditorExportPlugin : public RefCounted {
 	GDCLASS(EditorExportPlugin, RefCounted);
 
+	friend class EditorExport;
 	friend class EditorExportPlatform;
 
 	Ref<EditorExportPreset> export_preset;
@@ -121,6 +123,8 @@ protected:
 	GDVIRTUAL0(_end_customize_resources)
 
 	GDVIRTUAL2RC(PackedStringArray, _get_export_features, const Ref<EditorExportPlatform> &, bool);
+	GDVIRTUAL1RC(TypedArray<Dictionary>, _get_export_options, const Ref<EditorExportPlatform> &);
+	GDVIRTUAL1RC(bool, _should_update_export_options, const Ref<EditorExportPlatform> &);
 
 	GDVIRTUAL0RC(String, _get_name)
 
@@ -136,6 +140,8 @@ protected:
 	virtual void _end_customize_resources();
 
 	virtual PackedStringArray _get_export_features(const Ref<EditorExportPlatform> &p_export_platform, bool p_debug) const;
+	virtual void _get_export_options(const Ref<EditorExportPlatform> &p_export_platform, List<EditorExportPlatform::ExportOption> *r_options) const;
+	virtual bool _should_update_export_options(const Ref<EditorExportPlatform> &p_export_platform) const;
 
 	virtual String _get_name() const;
 
@@ -148,6 +154,7 @@ public:
 	Vector<String> get_ios_bundle_files() const;
 	String get_ios_cpp_code() const;
 	const Vector<String> &get_macos_plugin_files() const;
+	Variant get_option(const StringName &p_name) const;
 
 	EditorExportPlugin();
 };


### PR DESCRIPTION
Basically duplicates `get_export_options` from `EditorExportPlatform` to `EditorExportPlugin` and sets things up for scripting.

This allows export plugins to to have export preset specific options that also show up in the export dialog.

Example (the Dotnet options are added from from the CSharpExport plugin):
![image](https://user-images.githubusercontent.com/10944644/218338580-2b25e2ca-d994-47ed-8bc6-ee033d0b0c63.png)

Open issue: From scripts the options are always added to the very end of the options list so users always have to scroll to the very end to access them