### PR TITLE
C#: Make include scripts contents an export option

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -21,10 +21,22 @@ namespace GodotTools.Export
 
         private List<string> _tempFolders = new List<string>();
 
-        public void RegisterExportSettings()
+        public override Godot.Collections.Array<Godot.Collections.Dictionary> _GetExportOptions(EditorExportPlatform platform)
         {
-            // TODO: These would be better as export preset options, but that doesn't seem to be supported yet
-            GlobalDef("dotnet/export/include_scripts_content", false);
+            return new Godot.Collections.Array<Godot.Collections.Dictionary>()
+            {
+                new Godot.Collections.Dictionary()
+                {
+                    {
+                        "option", new Godot.Collections.Dictionary()
+                        {
+                            { "name", "dotnet/include_scripts_content" },
+                            { "type", (int)Variant.Type.Bool }
+                        }
+                    },
+                    { "default_value", false }
+                }
+            };
         }
 
         private string _maybeLastExportError;
@@ -44,7 +56,7 @@ namespace GodotTools.Export
 
             // TODO What if the source file is not part of the game's C# project
 
-            bool includeScriptsContent = (bool)ProjectSettings.GetSetting("dotnet/export/include_scripts_content");
+            bool includeScriptsContent = (bool)GetOption("dotnet/include_scripts_content");
 
             if (!includeScriptsContent)
             {

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -594,7 +594,6 @@ namespace GodotTools
             // Export plugin
             var exportPlugin = new ExportPlugin();
             AddExportPlugin(exportPlugin);
-            exportPlugin.RegisterExportSettings();
             _exportPluginWeak = WeakRef(exportPlugin);
 
             BuildManager.Initialize();


### PR DESCRIPTION
Includes and requires #72895
Resolves a TODO comment about this, but really this things is just a detour from me looking into embedding the C# outputs into the pck (which really should be such an option).
For backwards compatibility, the sources are preserved if either the project settings or the export option is set. But if this somehow makes it before 4.0 or the minor breakage is acceptable (I don't really think that there is anyone actually depending on having the C# sources available at runtime), the last commit completely removes the project setting. I will either squash or remove it depending on reviews.