### PR TITLE
Further refactoring to AudioDriver implementations after #69120, fixes PulseAudio microphone input

### DIFF
--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -43,17 +43,17 @@ extern int initialize_pulse(int verbose);
 }
 #endif
 
-Error AudioDriverALSA::init_device() {
+Error AudioDriverALSA::init_output_device() {
 	mix_rate = GLOBAL_GET("audio/driver/mix_rate");
 	speaker_mode = SPEAKER_MODE_STEREO;
 	channels = 2;
 
-	// If there is a specified device check that it is really present
-	if (device_name != "Default") {
-		PackedStringArray list = get_device_list();
-		if (list.find(device_name) == -1) {
-			device_name = "Default";
-			new_device = "Default";
+	// If there is a specified output device check that it is really present
+	if (output_device_name != "Default") {
+		PackedStringArray list = get_output_device_list();
+		if (list.find(output_device_name) == -1) {
+			output_device_name = "Default";
+			new_output_device = "Default";
 		}
 	}
 
@@ -75,10 +75,10 @@ Error AudioDriverALSA::init_device() {
 	//6 chans - "plug:surround51"
 	//4 chans - "plug:surround40";
 
-	if (device_name == "Default") {
+	if (output_device_name == "Default") {
 		status = snd_pcm_open(&pcm_handle, "default", SND_PCM_STREAM_PLAYBACK, SND_PCM_NONBLOCK);
 	} else {
-		String device = device_name;
+		String device = output_device_name;
 		int pos = device.find(";");
 		if (pos != -1) {
 			device = device.substr(0, pos);
@@ -171,7 +171,7 @@ Error AudioDriverALSA::init() {
 	active.clear();
 	exit_thread.clear();
 
-	Error err = init_device();
+	Error err = init_output_device();
 	if (err == OK) {
 		thread.start(AudioDriverALSA::thread_func, this);
 	}
@@ -227,18 +227,18 @@ void AudioDriverALSA::thread_func(void *p_udata) {
 			}
 		}
 
-		// User selected a new device, finish the current one so we'll init the new device
-		if (ad->device_name != ad->new_device) {
-			ad->device_name = ad->new_device;
-			ad->finish_device();
+		// User selected a new output device, finish the current one so we'll init the new device.
+		if (ad->output_device_name != ad->new_output_device) {
+			ad->output_device_name = ad->new_output_device;
+			ad->finish_output_device();
 
-			Error err = ad->init_device();
+			Error err = ad->init_output_device();
 			if (err != OK) {
-				ERR_PRINT("ALSA: init_device error");
-				ad->device_name = "Default";
-				ad->new_device = "Default";
+				ERR_PRINT("ALSA: init_output_device error");
+				ad->output_device_name = "Default";
+				ad->new_output_device = "Default";
 
-				err = ad->init_device();
+				err = ad->init_output_device();
 				if (err != OK) {
 					ad->active.clear();
 					ad->exit_thread.set();
@@ -263,7 +263,7 @@ AudioDriver::SpeakerMode AudioDriverALSA::get_speaker_mode() const {
 	return speaker_mode;
 }
 
-PackedStringArray AudioDriverALSA::get_device_list() {
+PackedStringArray AudioDriverALSA::get_output_device_list() {
 	PackedStringArray list;
 
 	list.push_back("Default");
@@ -298,13 +298,13 @@ PackedStringArray AudioDriverALSA::get_device_list() {
 	return list;
 }
 
-String AudioDriverALSA::get_device() {
-	return device_name;
+String AudioDriverALSA::get_output_device() {
+	return output_device_name;
 }
 
-void AudioDriverALSA::set_device(String device) {
+void AudioDriverALSA::set_output_device(const String &p_name) {
 	lock();
-	new_device = device;
+	new_output_device = p_name;
 	unlock();
 }
 
@@ -316,7 +316,7 @@ void AudioDriverALSA::unlock() {
 	mutex.unlock();
 }
 
-void AudioDriverALSA::finish_device() {
+void AudioDriverALSA::finish_output_device() {
 	if (pcm_handle) {
 		snd_pcm_close(pcm_handle);
 		pcm_handle = nullptr;
@@ -327,7 +327,7 @@ void AudioDriverALSA::finish() {
 	exit_thread.set();
 	thread.wait_to_finish();
 
-	finish_device();
+	finish_output_device();
 }
 
 #endif // ALSA_ENABLED

--- a/drivers/alsa/audio_driver_alsa.h
+++ b/drivers/alsa/audio_driver_alsa.h
@@ -46,14 +46,14 @@ class AudioDriverALSA : public AudioDriver {
 
 	snd_pcm_t *pcm_handle = nullptr;
 
-	String device_name = "Default";
-	String new_device = "Default";
+	String output_device_name = "Default";
+	String new_output_device = "Default";
 
 	Vector<int32_t> samples_in;
 	Vector<int16_t> samples_out;
 
-	Error init_device();
-	void finish_device();
+	Error init_output_device();
+	void finish_output_device();
 
 	static void thread_func(void *p_udata);
 
@@ -69,20 +69,22 @@ class AudioDriverALSA : public AudioDriver {
 	SafeFlag exit_thread;
 
 public:
-	const char *get_name() const {
+	virtual const char *get_name() const override {
 		return "ALSA";
-	};
+	}
 
-	virtual Error init();
-	virtual void start();
-	virtual int get_mix_rate() const;
-	virtual SpeakerMode get_speaker_mode() const;
-	virtual PackedStringArray get_device_list();
-	virtual String get_device();
-	virtual void set_device(String device);
-	virtual void lock();
-	virtual void unlock();
-	virtual void finish();
+	virtual Error init() override;
+	virtual void start() override;
+	virtual int get_mix_rate() const override;
+	virtual SpeakerMode get_speaker_mode() const override;
+
+	virtual void lock() override;
+	virtual void unlock() override;
+	virtual void finish() override;
+
+	virtual PackedStringArray get_output_device_list() override;
+	virtual String get_output_device() override;
+	virtual void set_output_device(const String &p_name) override;
 
 	AudioDriverALSA() {}
 	~AudioDriverALSA() {}

--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -158,7 +158,7 @@ Error AudioDriverCoreAudio::init() {
 	ERR_FAIL_COND_V(result != noErr, FAILED);
 
 	if (GLOBAL_GET("audio/driver/enable_input")) {
-		return capture_init();
+		return init_input_device();
 	}
 	return OK;
 }
@@ -287,7 +287,7 @@ bool AudioDriverCoreAudio::try_lock() {
 }
 
 void AudioDriverCoreAudio::finish() {
-	capture_finish();
+	finish_input_device();
 
 	if (audio_unit) {
 		OSStatus result;
@@ -337,7 +337,7 @@ void AudioDriverCoreAudio::finish() {
 	}
 }
 
-Error AudioDriverCoreAudio::capture_init() {
+Error AudioDriverCoreAudio::init_input_device() {
 	AudioComponentDescription desc;
 	memset(&desc, 0, sizeof(desc));
 	desc.componentType = kAudioUnitType_Output;
@@ -433,7 +433,7 @@ Error AudioDriverCoreAudio::capture_init() {
 	return OK;
 }
 
-void AudioDriverCoreAudio::capture_finish() {
+void AudioDriverCoreAudio::finish_input_device() {
 	if (input_unit) {
 		lock();
 
@@ -471,7 +471,7 @@ void AudioDriverCoreAudio::capture_finish() {
 	}
 }
 
-Error AudioDriverCoreAudio::capture_start() {
+Error AudioDriverCoreAudio::input_start() {
 	input_buffer_init(buffer_frames);
 
 	OSStatus result = AudioOutputUnitStart(input_unit);
@@ -482,7 +482,7 @@ Error AudioDriverCoreAudio::capture_start() {
 	return OK;
 }
 
-Error AudioDriverCoreAudio::capture_stop() {
+Error AudioDriverCoreAudio::input_stop() {
 	if (input_unit) {
 		OSStatus result = AudioOutputUnitStop(input_unit);
 		if (result != noErr) {
@@ -647,17 +647,10 @@ String AudioDriverCoreAudio::get_output_device() {
 	return output_device_name;
 }
 
-void AudioDriverCoreAudio::set_output_device(String output_device) {
-	output_device_name = output_device;
+void AudioDriverCoreAudio::set_output_device(const String &p_name) {
+	output_device_name = p_name;
 	if (active) {
 		_set_device(output_device_name);
-	}
-}
-
-void AudioDriverCoreAudio::set_input_device(const String &p_name) {
-	input_device_name = p_name;
-	if (active) {
-		_set_device(input_device_name, true);
 	}
 }
 
@@ -667,6 +660,13 @@ PackedStringArray AudioDriverCoreAudio::get_input_device_list() {
 
 String AudioDriverCoreAudio::get_input_device() {
 	return input_device_name;
+}
+
+void AudioDriverCoreAudio::set_input_device(const String &p_name) {
+	input_device_name = p_name;
+	if (active) {
+		_set_device(input_device_name, true);
+	}
 }
 
 #endif

--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -83,38 +83,38 @@ class AudioDriverCoreAudio : public AudioDriver {
 			UInt32 inBusNumber, UInt32 inNumberFrames,
 			AudioBufferList *ioData);
 
-	Error capture_init();
-	void capture_finish();
+	Error init_input_device();
+	void finish_input_device();
 
 public:
-	const char *get_name() const {
+	virtual const char *get_name() const override {
 		return "CoreAudio";
 	};
 
-	virtual Error init();
-	virtual void start();
-	virtual int get_mix_rate() const;
-	virtual SpeakerMode get_speaker_mode() const;
+	virtual Error init() override;
+	virtual void start() override;
+	virtual int get_mix_rate() const override;
+	virtual SpeakerMode get_speaker_mode() const override;
 
-	virtual void lock();
-	virtual void unlock();
-	virtual void finish();
+	virtual void lock() override;
+	virtual void unlock() override;
+	virtual void finish() override;
 
-	virtual Error capture_start();
-	virtual Error capture_stop();
+#ifdef MACOS_ENABLED
+	virtual PackedStringArray get_output_device_list() override;
+	virtual String get_output_device() override;
+	virtual void set_output_device(const String &p_name) override;
+
+	virtual PackedStringArray get_input_device_list() override;
+	virtual String get_input_device() override;
+	virtual void set_input_device(const String &p_name) override;
+#endif
+
+	virtual Error input_start() override;
+	virtual Error input_stop() override;
 
 	bool try_lock();
 	void stop();
-
-#ifdef MACOS_ENABLED
-	virtual PackedStringArray get_output_device_list();
-	virtual String get_output_device();
-	virtual void set_output_device(String output_device);
-
-	virtual PackedStringArray get_input_device_list();
-	virtual void set_input_device(const String &p_name);
-	virtual String get_input_device();
-#endif
 
 	AudioDriverCoreAudio();
 	~AudioDriverCoreAudio() {}

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -631,9 +631,9 @@ String AudioDriverPulseAudio::get_output_device() {
 	return output_device_name;
 }
 
-void AudioDriverPulseAudio::set_output_device(String output_device) {
+void AudioDriverPulseAudio::set_output_device(const String &p_name) {
 	lock();
-	new_output_device = output_device;
+	new_output_device = p_name;
 	unlock();
 }
 
@@ -761,12 +761,6 @@ Error AudioDriverPulseAudio::input_stop() {
 	return OK;
 }
 
-void AudioDriverPulseAudio::set_input_device(const String &p_name) {
-	lock();
-	new_input_device = p_name;
-	unlock();
-}
-
 void AudioDriverPulseAudio::pa_sourcelist_cb(pa_context *c, const pa_source_info *l, int eol, void *userdata) {
 	AudioDriverPulseAudio *ad = static_cast<AudioDriverPulseAudio *>(userdata);
 
@@ -819,6 +813,12 @@ String AudioDriverPulseAudio::get_input_device() {
 	unlock();
 
 	return name;
+}
+
+void AudioDriverPulseAudio::set_input_device(const String &p_name) {
+	lock();
+	new_input_device = p_name;
+	unlock();
 }
 
 AudioDriverPulseAudio::AudioDriverPulseAudio() {

--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -94,31 +94,30 @@ class AudioDriverPulseAudio : public AudioDriver {
 	static void thread_func(void *p_udata);
 
 public:
-	const char *get_name() const {
+	virtual const char *get_name() const override {
 		return "PulseAudio";
 	};
 
-	virtual Error init();
-	virtual void start();
-	virtual int get_mix_rate() const;
-	virtual SpeakerMode get_speaker_mode() const;
+	virtual Error init() override;
+	virtual void start() override;
+	virtual int get_mix_rate() const override;
+	virtual SpeakerMode get_speaker_mode() const override;
+	virtual float get_latency() override;
 
-	virtual PackedStringArray get_output_device_list();
-	virtual String get_output_device();
-	virtual void set_output_device(String output_device);
+	virtual void lock() override;
+	virtual void unlock() override;
+	virtual void finish() override;
 
-	virtual PackedStringArray get_input_device_list();
-	virtual void set_input_device(const String &p_name);
-	virtual String get_input_device();
+	virtual PackedStringArray get_output_device_list() override;
+	virtual String get_output_device() override;
+	virtual void set_output_device(const String &p_name) override;
 
-	virtual void lock();
-	virtual void unlock();
-	virtual void finish();
+	virtual Error input_start() override;
+	virtual Error input_stop() override;
 
-	virtual float get_latency();
-
-	virtual Error input_start();
-	virtual Error input_stop();
+	virtual PackedStringArray get_input_device_list() override;
+	virtual String get_input_device() override;
+	virtual void set_input_device(const String &p_name) override;
 
 	AudioDriverPulseAudio();
 	~AudioDriverPulseAudio() {}

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -634,9 +634,9 @@ String AudioDriverWASAPI::get_output_device() {
 	return name;
 }
 
-void AudioDriverWASAPI::set_output_device(String output_device) {
+void AudioDriverWASAPI::set_output_device(const String &p_name) {
 	lock();
-	audio_output.new_device = output_device;
+	audio_output.new_device = p_name;
 	unlock();
 }
 
@@ -964,12 +964,6 @@ Error AudioDriverWASAPI::input_stop() {
 	return FAILED;
 }
 
-void AudioDriverWASAPI::set_input_device(const String &p_name) {
-	lock();
-	audio_input.new_device = p_name;
-	unlock();
-}
-
 PackedStringArray AudioDriverWASAPI::get_input_device_list() {
 	return audio_device_get_list(true);
 }
@@ -980,6 +974,12 @@ String AudioDriverWASAPI::get_input_device() {
 	unlock();
 
 	return name;
+}
+
+void AudioDriverWASAPI::set_input_device(const String &p_name) {
+	lock();
+	audio_input.new_device = p_name;
+	unlock();
 }
 
 AudioDriverWASAPI::AudioDriverWASAPI() {

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -94,27 +94,30 @@ class AudioDriverWASAPI : public AudioDriver {
 	PackedStringArray audio_device_get_list(bool p_input);
 
 public:
-	virtual const char *get_name() const {
+	virtual const char *get_name() const override {
 		return "WASAPI";
 	}
 
-	virtual Error init();
-	virtual void start();
-	virtual int get_mix_rate() const;
-	virtual float get_latency();
-	virtual SpeakerMode get_speaker_mode() const;
-	virtual PackedStringArray get_output_device_list();
-	virtual String get_output_device();
-	virtual void set_output_device(String output_device);
-	virtual void lock();
-	virtual void unlock();
-	virtual void finish();
+	virtual Error init() override;
+	virtual void start() override;
+	virtual int get_mix_rate() const override;
+	virtual SpeakerMode get_speaker_mode() const override;
+	virtual float get_latency() override;
 
-	virtual Error input_start();
-	virtual Error input_stop();
-	virtual PackedStringArray get_input_device_list();
-	virtual void set_input_device(const String &p_name);
-	virtual String get_input_device();
+	virtual void lock() override;
+	virtual void unlock() override;
+	virtual void finish() override;
+
+	virtual PackedStringArray get_output_device_list() override;
+	virtual String get_output_device() override;
+	virtual void set_output_device(const String &p_name) override;
+
+	virtual Error input_start() override;
+	virtual Error input_stop() override;
+
+	virtual PackedStringArray get_input_device_list() override;
+	virtual String get_input_device() override;
+	virtual void set_input_device(const String &p_name) override;
 
 	AudioDriverWASAPI();
 };

--- a/drivers/xaudio2/audio_driver_xaudio2.cpp
+++ b/drivers/xaudio2/audio_driver_xaudio2.cpp
@@ -33,10 +33,6 @@
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 
-const char *AudioDriverXAudio2::get_name() const {
-	return "XAudio2";
-}
-
 Error AudioDriverXAudio2::init() {
 	active.clear();
 	exit_thread.clear();

--- a/drivers/xaudio2/audio_driver_xaudio2.h
+++ b/drivers/xaudio2/audio_driver_xaudio2.h
@@ -91,16 +91,19 @@ class AudioDriverXAudio2 : public AudioDriver {
 	XAudio2DriverVoiceCallback voice_callback;
 
 public:
-	const char *get_name() const;
+	virtual const char *get_name() const override {
+		return "XAudio2";
+	}
 
-	virtual Error init();
-	virtual void start();
-	virtual int get_mix_rate() const;
-	virtual SpeakerMode get_speaker_mode() const;
-	virtual float get_latency();
-	virtual void lock();
-	virtual void unlock();
-	virtual void finish();
+	virtual Error init() override;
+	virtual void start() override;
+	virtual int get_mix_rate() const override;
+	virtual SpeakerMode get_speaker_mode() const override;
+	virtual float get_latency() override;
+
+	virtual void lock() override;
+	virtual void unlock() override;
+	virtual void finish() override;
 
 	AudioDriverXAudio2();
 	~AudioDriverXAudio2() {}

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -80,10 +80,6 @@ void AudioDriverOpenSL::_buffer_callbacks(
 	ad->_buffer_callback(queueItf);
 }
 
-const char *AudioDriverOpenSL::get_name() const {
-	return "Android";
-}
-
 Error AudioDriverOpenSL::init() {
 	SLresult res;
 	SLEngineOption EngineOption[] = {
@@ -204,7 +200,7 @@ void AudioDriverOpenSL::_record_buffer_callbacks(SLAndroidSimpleBufferQueueItf q
 	ad->_record_buffer_callback(queueItf);
 }
 
-Error AudioDriverOpenSL::capture_init_device() {
+Error AudioDriverOpenSL::init_input_device() {
 	SLDataLocator_IODevice loc_dev = {
 		SL_DATALOCATOR_IODEVICE,
 		SL_IODEVICE_AUDIOINPUT,
@@ -271,15 +267,15 @@ Error AudioDriverOpenSL::capture_init_device() {
 	return OK;
 }
 
-Error AudioDriverOpenSL::capture_start() {
+Error AudioDriverOpenSL::input_start() {
 	if (OS::get_singleton()->request_permission("RECORD_AUDIO")) {
-		return capture_init_device();
+		return init_input_device();
 	}
 
 	return OK;
 }
 
-Error AudioDriverOpenSL::capture_stop() {
+Error AudioDriverOpenSL::input_stop() {
 	SLuint32 state;
 	SLresult res = (*recordItf)->GetRecordState(recordItf, &state);
 	ERR_FAIL_COND_V(res != SL_RESULT_SUCCESS, ERR_CANT_OPEN);

--- a/platform/android/audio_driver_opensl.h
+++ b/platform/android/audio_driver_opensl.h
@@ -84,23 +84,26 @@ class AudioDriverOpenSL : public AudioDriver {
 			SLAndroidSimpleBufferQueueItf queueItf,
 			void *pContext);
 
-	virtual Error capture_init_device();
+	Error init_input_device();
 
 public:
-	virtual const char *get_name() const;
+	virtual const char *get_name() const override {
+		return "Android";
+	}
 
-	virtual Error init();
-	virtual void start();
-	virtual int get_mix_rate() const;
-	virtual SpeakerMode get_speaker_mode() const;
-	virtual void lock();
-	virtual void unlock();
-	virtual void finish();
+	virtual Error init() override;
+	virtual void start() override;
+	virtual int get_mix_rate() const override;
+	virtual SpeakerMode get_speaker_mode() const override;
 
-	virtual void set_pause(bool p_pause);
+	virtual void lock() override;
+	virtual void unlock() override;
+	virtual void finish() override;
 
-	virtual Error capture_start();
-	virtual Error capture_stop();
+	virtual Error input_start() override;
+	virtual Error input_stop() override;
+
+	void set_pause(bool p_pause);
 
 	AudioDriverOpenSL();
 };

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -488,7 +488,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_calldeferred(JNIEnv *
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_requestPermissionResult(JNIEnv *env, jclass clazz, jstring p_permission, jboolean p_result) {
 	String permission = jstring_to_string(p_permission, env);
 	if (permission == "android.permission.RECORD_AUDIO" && p_result) {
-		AudioDriver::get_singleton()->capture_start();
+		AudioDriver::get_singleton()->input_start();
 	}
 
 	if (os_android->get_main_loop()) {

--- a/platform/web/audio_driver_web.cpp
+++ b/platform/web/audio_driver_web.cpp
@@ -166,18 +166,18 @@ void AudioDriverWeb::finish() {
 	}
 }
 
-Error AudioDriverWeb::capture_start() {
+Error AudioDriverWeb::input_start() {
 	lock();
 	input_buffer_init(buffer_length);
 	unlock();
-	if (godot_audio_capture_start()) {
+	if (godot_audio_input_start()) {
 		return FAILED;
 	}
 	return OK;
 }
 
-Error AudioDriverWeb::capture_stop() {
-	godot_audio_capture_stop();
+Error AudioDriverWeb::input_stop() {
+	godot_audio_input_stop();
 	lock();
 	input_buffer.clear();
 	unlock();

--- a/platform/web/audio_driver_web.h
+++ b/platform/web/audio_driver_web.h
@@ -77,12 +77,12 @@ public:
 	virtual void start() final;
 	virtual void finish() final;
 
-	virtual float get_latency() override;
 	virtual int get_mix_rate() const override;
 	virtual SpeakerMode get_speaker_mode() const override;
+	virtual float get_latency() override;
 
-	virtual Error capture_start() override;
-	virtual Error capture_stop() override;
+	virtual Error input_start() override;
+	virtual Error input_stop() override;
 
 	static void resume();
 
@@ -111,10 +111,12 @@ protected:
 	virtual void finish_driver() override;
 
 public:
-	virtual const char *get_name() const override { return "AudioWorklet"; }
+	virtual const char *get_name() const override {
+		return "AudioWorklet";
+	}
 
-	void lock() override;
-	void unlock() override;
+	virtual void lock() override;
+	virtual void unlock() override;
 };
 
 #endif // AUDIO_DRIVER_WEB_H

--- a/platform/web/godot_audio.h
+++ b/platform/web/godot_audio.h
@@ -43,8 +43,8 @@ extern int godot_audio_has_script_processor();
 extern int godot_audio_init(int *p_mix_rate, int p_latency, void (*_state_cb)(int), void (*_latency_cb)(float));
 extern void godot_audio_resume();
 
-extern int godot_audio_capture_start();
-extern void godot_audio_capture_stop();
+extern int godot_audio_input_start();
+extern void godot_audio_input_stop();
 
 // Worklet
 typedef int32_t GodotAudioState[4];

--- a/platform/web/js/libs/library_godot_audio.js
+++ b/platform/web/js/libs/library_godot_audio.js
@@ -186,17 +186,17 @@ const GodotAudio = {
 		}
 	},
 
-	godot_audio_capture_start__proxy: 'sync',
-	godot_audio_capture_start__sig: 'i',
-	godot_audio_capture_start: function () {
+	godot_audio_input_start__proxy: 'sync',
+	godot_audio_input_start__sig: 'i',
+	godot_audio_input_start: function () {
 		return GodotAudio.create_input(function (input) {
 			input.connect(GodotAudio.driver.get_node());
 		});
 	},
 
-	godot_audio_capture_stop__proxy: 'sync',
-	godot_audio_capture_stop__sig: 'v',
-	godot_audio_capture_stop: function () {
+	godot_audio_input_stop__proxy: 'sync',
+	godot_audio_input_stop__sig: 'v',
+	godot_audio_input_stop: function () {
 		if (GodotAudio.input) {
 			const tracks = GodotAudio.input['mediaStream']['getTracks']();
 			for (let i = 0; i < tracks.length; i++) {

--- a/servers/audio/audio_driver_dummy.cpp
+++ b/servers/audio/audio_driver_dummy.cpp
@@ -52,7 +52,7 @@ Error AudioDriverDummy::init() {
 	}
 
 	return OK;
-};
+}
 
 void AudioDriverDummy::thread_func(void *p_udata) {
 	AudioDriverDummy *ad = static_cast<AudioDriverDummy *>(p_udata);
@@ -68,31 +68,31 @@ void AudioDriverDummy::thread_func(void *p_udata) {
 
 			ad->stop_counting_ticks();
 			ad->unlock();
-		};
+		}
 
 		OS::get_singleton()->delay_usec(usdelay);
-	};
-};
+	}
+}
 
 void AudioDriverDummy::start() {
 	active.set();
-};
+}
 
 int AudioDriverDummy::get_mix_rate() const {
 	return mix_rate;
-};
+}
 
 AudioDriver::SpeakerMode AudioDriverDummy::get_speaker_mode() const {
 	return speaker_mode;
-};
+}
 
 void AudioDriverDummy::lock() {
 	mutex.lock();
-};
+}
 
 void AudioDriverDummy::unlock() {
 	mutex.unlock();
-};
+}
 
 void AudioDriverDummy::set_use_threads(bool p_use_threads) {
 	use_threads = p_use_threads;
@@ -141,7 +141,7 @@ void AudioDriverDummy::finish() {
 
 	if (samples_in) {
 		memdelete_arr(samples_in);
-	};
+	}
 }
 
 AudioDriverDummy::AudioDriverDummy() {

--- a/servers/audio/audio_driver_dummy.h
+++ b/servers/audio/audio_driver_dummy.h
@@ -59,17 +59,18 @@ class AudioDriverDummy : public AudioDriver {
 	static AudioDriverDummy *singleton;
 
 public:
-	const char *get_name() const {
+	virtual const char *get_name() const override {
 		return "Dummy";
 	};
 
-	virtual Error init();
-	virtual void start();
-	virtual int get_mix_rate() const;
-	virtual SpeakerMode get_speaker_mode() const;
-	virtual void lock();
-	virtual void unlock();
-	virtual void finish();
+	virtual Error init() override;
+	virtual void start() override;
+	virtual int get_mix_rate() const override;
+	virtual SpeakerMode get_speaker_mode() const override;
+
+	virtual void lock() override;
+	virtual void unlock() override;
+	virtual void finish() override;
 
 	void set_use_threads(bool p_use_threads);
 	void set_speaker_mode(SpeakerMode p_mode);

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -367,7 +367,7 @@ void AudioStreamPlaybackMicrophone::start(double p_from_pos) {
 
 	input_ofs = 0;
 
-	if (AudioDriver::get_singleton()->capture_start() == OK) {
+	if (AudioDriver::get_singleton()->input_start() == OK) {
 		active = true;
 		begin_resample();
 	}
@@ -375,7 +375,7 @@ void AudioStreamPlaybackMicrophone::start(double p_from_pos) {
 
 void AudioStreamPlaybackMicrophone::stop() {
 	if (active) {
-		AudioDriver::get_singleton()->capture_stop();
+		AudioDriver::get_singleton()->input_stop();
 		active = false;
 	}
 }

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1640,8 +1640,8 @@ String AudioServer::get_output_device() {
 	return AudioDriver::get_singleton()->get_output_device();
 }
 
-void AudioServer::set_output_device(String output_device) {
-	AudioDriver::get_singleton()->set_output_device(output_device);
+void AudioServer::set_output_device(const String &p_name) {
+	AudioDriver::get_singleton()->set_output_device(p_name);
 }
 
 PackedStringArray AudioServer::get_input_device_list() {
@@ -1711,9 +1711,10 @@ void AudioServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_speaker_mode"), &AudioServer::get_speaker_mode);
 	ClassDB::bind_method(D_METHOD("get_mix_rate"), &AudioServer::get_mix_rate);
+
 	ClassDB::bind_method(D_METHOD("get_output_device_list"), &AudioServer::get_output_device_list);
 	ClassDB::bind_method(D_METHOD("get_output_device"), &AudioServer::get_output_device);
-	ClassDB::bind_method(D_METHOD("set_output_device", "output_device"), &AudioServer::set_output_device);
+	ClassDB::bind_method(D_METHOD("set_output_device", "name"), &AudioServer::set_output_device);
 
 	ClassDB::bind_method(D_METHOD("get_time_to_next_mix"), &AudioServer::get_time_to_next_mix);
 	ClassDB::bind_method(D_METHOD("get_time_since_last_mix"), &AudioServer::get_time_since_last_mix);

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -88,26 +88,32 @@ public:
 	static AudioDriver *get_singleton();
 	void set_singleton();
 
+	// Virtual API to implement.
+
 	virtual const char *get_name() const = 0;
 
 	virtual Error init() = 0;
 	virtual void start() = 0;
 	virtual int get_mix_rate() const = 0;
 	virtual SpeakerMode get_speaker_mode() const = 0;
-	virtual PackedStringArray get_output_device_list();
-	virtual String get_output_device();
-	virtual void set_output_device(String output_device) {}
+	virtual float get_latency() { return 0; }
+
 	virtual void lock() = 0;
 	virtual void unlock() = 0;
 	virtual void finish() = 0;
 
-	virtual Error capture_start() { return FAILED; }
-	virtual Error capture_stop() { return FAILED; }
-	virtual void set_input_device(const String &p_name) {}
-	virtual String get_input_device() { return "Default"; }
-	virtual PackedStringArray get_input_device_list();
+	virtual PackedStringArray get_output_device_list();
+	virtual String get_output_device();
+	virtual void set_output_device(const String &p_name) {}
 
-	virtual float get_latency() { return 0; }
+	virtual Error input_start() { return FAILED; }
+	virtual Error input_stop() { return FAILED; }
+
+	virtual PackedStringArray get_input_device_list();
+	virtual String get_input_device() { return "Default"; }
+	virtual void set_input_device(const String &p_name) {}
+
+	//
 
 	SpeakerMode get_speaker_mode_by_total_channels(int p_channels) const;
 	int get_total_channels_by_speaker_mode(SpeakerMode) const;
@@ -421,7 +427,7 @@ public:
 
 	PackedStringArray get_output_device_list();
 	String get_output_device();
-	void set_output_device(String output_device);
+	void set_output_device(const String &p_name);
 
 	PackedStringArray get_input_device_list();
 	String get_input_device();


### PR DESCRIPTION
*Edited after changes by @akien-mga:*

- Rename all instances of `capture_start()` and `capture_end()` to their new
  names. Fixes https://github.com/godotengine/godot/issues/72892.
- More internal renames to match what was started in https://github.com/godotengine/godot/pull/69120.
- Use `override` consistently so that such refactoring bugs can be caught.
- Harmonize the order of definition of the overridden virtual methods in each
  audio driver.
- Harmonize prototype for `set_output_device` and `set_input_device`

----

*Original description:*

#69120 renamed some instances of `capture_start()` and `capture_stop()` to `input_start()` and `input_stop()` respectively, but only in certain scripts, therefore leaving the old names to co-exist with the new ones. This PR is simply a continuation of these renames. I tested microphone input on Linux (openSUSE Tumbleweed) and it seems to be working fine, but some testing in other platforms would be appreciated.

Let me know if I should add more renames to this PR.

Fixes #72892.