### PR TITLE
Enhance expression with duplicate function

### DIFF
--- a/doc/classes/Expression.xml
+++ b/doc/classes/Expression.xml
@@ -51,6 +51,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="duplicate" qualifiers="const">
+			<return type="Expression" />
+			<description>
+				Creates and returns a new copy of the expression.
+			</description>
+		</method>
 		<method name="execute">
 			<return type="Variant" />
 			<param index="0" name="inputs" type="Array" default="[]" />


### PR DESCRIPTION
`Expression` is not thread-safe to execute. I added a `duplicate` function to `Expression` so a thread can create and own its own copy and safely run.

The expression tree is now refcounted and shared with the cloned `Expression` to avoid costly copy.

There's also a few dead variables/methods in the `Expression` class that I removed.