### PR TITLE
Add a SCons option to disable editor localization

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -266,6 +266,12 @@ opts.Add(
     "Use this path as TLS certificates default for editor and Linux/BSD export templates (for package maintainers)",
     "",
 )
+opts.Add(BoolVariable(
+        "editor_localization",
+        "Enable localization for the editor and its built-in class reference (disabling reduces binary size)",
+        True,
+    )
+)
 opts.Add(BoolVariable("use_precise_math_checks", "Math checks use very precise epsilon (debug option)", False))
 opts.Add(BoolVariable("strict_checks", "Enforce stricter checks (debug option)", False))
 opts.Add(BoolVariable("scu_build", "Use single compilation unit build", False))

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -97,7 +97,10 @@ void register_exporter_types() {{
     # Generated with `make include-list` for each resource.
 
     # Editor translations
-    tlist = glob.glob(env.Dir("#editor/translations/editor").abspath + "/*.po")
+    if env["editor_localization"]:
+        tlist = glob.glob(env.Dir("#editor/translations/editor").abspath + "/*.po")
+    else:
+        tlist = []
     env.Depends("#editor/editor_translations.gen.h", tlist)
     env.CommandNoCache(
         "#editor/editor_translations.gen.h",
@@ -106,7 +109,10 @@ void register_exporter_types() {{
     )
 
     # Property translations
-    tlist = glob.glob(env.Dir("#editor/translations/properties").abspath + "/*.po")
+    if env["editor_localization"]:
+        tlist = glob.glob(env.Dir("#editor/translations/properties").abspath + "/*.po")
+    else:
+        tlist = []
     env.Depends("#editor/property_translations.gen.h", tlist)
     env.CommandNoCache(
         "#editor/property_translations.gen.h",
@@ -115,7 +121,10 @@ void register_exporter_types() {{
     )
 
     # Documentation translations
-    tlist = glob.glob(env.Dir("#doc/translations").abspath + "/*.po")
+    if env["editor_localization"]:
+        tlist = glob.glob(env.Dir("#doc/translations").abspath + "/*.po")
+    else:
+        tlist = []
     env.Depends("#editor/doc_translations.gen.h", tlist)
     env.CommandNoCache(
         "#editor/doc_translations.gen.h",


### PR DESCRIPTION
This reduces binary size and may speed up compilation and startup slightly, especially on slower CPUs or storage.

A stripped Linux editor binary's size is currently reduced by 3.2 MB after disabling editor localization, but this difference is bound to increase as more languages are added in the editor binary. This may be handy for web editor builds to speed up their initialization, as WASM initialization speeds are largely dependent on file size (along with download speeds).
