### PR TITLE
Fix NavigationAgent debug functions bindings in release builds

### DIFF
--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -108,7 +108,6 @@ void NavigationAgent2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "time_horizon", PROPERTY_HINT_RANGE, "0.1,10,0.01,suffix:s"), "set_time_horizon", "get_time_horizon");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_speed", PROPERTY_HINT_RANGE, "0.1,10000,0.01,suffix:px/s"), "set_max_speed", "get_max_speed");
 
-#ifdef DEBUG_ENABLED
 	ClassDB::bind_method(D_METHOD("set_debug_enabled", "enabled"), &NavigationAgent2D::set_debug_enabled);
 	ClassDB::bind_method(D_METHOD("get_debug_enabled"), &NavigationAgent2D::get_debug_enabled);
 	ClassDB::bind_method(D_METHOD("set_debug_use_custom", "enabled"), &NavigationAgent2D::set_debug_use_custom);
@@ -126,7 +125,6 @@ void NavigationAgent2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "debug_path_custom_color"), "set_debug_path_custom_color", "get_debug_path_custom_color");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "debug_path_custom_point_size", PROPERTY_HINT_RANGE, "1,50,1,suffix:px"), "set_debug_path_custom_point_size", "get_debug_path_custom_point_size");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "debug_path_custom_line_width", PROPERTY_HINT_RANGE, "1,50,1,suffix:px"), "set_debug_path_custom_line_width", "get_debug_path_custom_line_width");
-#endif // DEBUG_ENABLED
 
 	ADD_SIGNAL(MethodInfo("path_changed"));
 	ADD_SIGNAL(MethodInfo("target_reached"));
@@ -670,14 +668,15 @@ void NavigationAgent2D::_check_distance_to_target() {
 
 ////////DEBUG////////////////////////////////////////////////////////////
 
-#ifdef DEBUG_ENABLED
 void NavigationAgent2D::set_debug_enabled(bool p_enabled) {
+#ifdef DEBUG_ENABLED
 	if (debug_enabled == p_enabled) {
 		return;
 	}
 
 	debug_enabled = p_enabled;
 	debug_path_dirty = true;
+#endif // DEBUG_ENABLED
 }
 
 bool NavigationAgent2D::get_debug_enabled() const {
@@ -685,12 +684,14 @@ bool NavigationAgent2D::get_debug_enabled() const {
 }
 
 void NavigationAgent2D::set_debug_use_custom(bool p_enabled) {
+#ifdef DEBUG_ENABLED
 	if (debug_use_custom == p_enabled) {
 		return;
 	}
 
 	debug_use_custom = p_enabled;
 	debug_path_dirty = true;
+#endif // DEBUG_ENABLED
 }
 
 bool NavigationAgent2D::get_debug_use_custom() const {
@@ -698,12 +699,14 @@ bool NavigationAgent2D::get_debug_use_custom() const {
 }
 
 void NavigationAgent2D::set_debug_path_custom_color(Color p_color) {
+#ifdef DEBUG_ENABLED
 	if (debug_path_custom_color == p_color) {
 		return;
 	}
 
 	debug_path_custom_color = p_color;
 	debug_path_dirty = true;
+#endif // DEBUG_ENABLED
 }
 
 Color NavigationAgent2D::get_debug_path_custom_color() const {
@@ -711,12 +714,14 @@ Color NavigationAgent2D::get_debug_path_custom_color() const {
 }
 
 void NavigationAgent2D::set_debug_path_custom_point_size(float p_point_size) {
+#ifdef DEBUG_ENABLED
 	if (Math::is_equal_approx(debug_path_custom_point_size, p_point_size)) {
 		return;
 	}
 
 	debug_path_custom_point_size = MAX(0.1, p_point_size);
 	debug_path_dirty = true;
+#endif // DEBUG_ENABLED
 }
 
 float NavigationAgent2D::get_debug_path_custom_point_size() const {
@@ -724,18 +729,21 @@ float NavigationAgent2D::get_debug_path_custom_point_size() const {
 }
 
 void NavigationAgent2D::set_debug_path_custom_line_width(float p_line_width) {
+#ifdef DEBUG_ENABLED
 	if (Math::is_equal_approx(debug_path_custom_line_width, p_line_width)) {
 		return;
 	}
 
 	debug_path_custom_line_width = p_line_width;
 	debug_path_dirty = true;
+#endif // DEBUG_ENABLED
 }
 
 float NavigationAgent2D::get_debug_path_custom_line_width() const {
 	return debug_path_custom_line_width;
 }
 
+#ifdef DEBUG_ENABLED
 void NavigationAgent2D::_navigation_debug_changed() {
 	debug_path_dirty = true;
 }

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -73,14 +73,16 @@ class NavigationAgent2D : public Node {
 	// No initialized on purpose
 	uint32_t update_frame_id = 0;
 
-#ifdef DEBUG_ENABLED
+	// Debug properties for exposed bindings
 	bool debug_enabled = false;
-	bool debug_path_dirty = true;
-	RID debug_path_instance;
 	float debug_path_custom_point_size = 4.0;
 	float debug_path_custom_line_width = 1.0;
 	bool debug_use_custom = false;
 	Color debug_path_custom_color = Color(1.0, 1.0, 1.0, 1.0);
+#ifdef DEBUG_ENABLED
+	// Debug properties internal only
+	bool debug_path_dirty = true;
+	RID debug_path_instance;
 
 private:
 	void _navigation_debug_changed();
@@ -182,7 +184,6 @@ public:
 
 	PackedStringArray get_configuration_warnings() const override;
 
-#ifdef DEBUG_ENABLED
 	void set_debug_enabled(bool p_enabled);
 	bool get_debug_enabled() const;
 
@@ -197,7 +198,6 @@ public:
 
 	void set_debug_path_custom_line_width(float p_line_width);
 	float get_debug_path_custom_line_width() const;
-#endif // DEBUG_ENABLED
 
 private:
 	void update_navigation();

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -121,7 +121,6 @@ void NavigationAgent3D::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("navigation_finished"));
 	ADD_SIGNAL(MethodInfo("velocity_computed", PropertyInfo(Variant::VECTOR3, "safe_velocity")));
 
-#ifdef DEBUG_ENABLED
 	ClassDB::bind_method(D_METHOD("set_debug_enabled", "enabled"), &NavigationAgent3D::set_debug_enabled);
 	ClassDB::bind_method(D_METHOD("get_debug_enabled"), &NavigationAgent3D::get_debug_enabled);
 	ClassDB::bind_method(D_METHOD("set_debug_use_custom", "enabled"), &NavigationAgent3D::set_debug_use_custom);
@@ -136,7 +135,6 @@ void NavigationAgent3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_use_custom"), "set_debug_use_custom", "get_debug_use_custom");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "debug_path_custom_color"), "set_debug_path_custom_color", "get_debug_path_custom_color");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "debug_path_custom_point_size", PROPERTY_HINT_RANGE, "1,50,1,suffix:px"), "set_debug_path_custom_point_size", "get_debug_path_custom_point_size");
-#endif // DEBUG_ENABLED
 }
 
 void NavigationAgent3D::_notification(int p_what) {
@@ -696,14 +694,15 @@ void NavigationAgent3D::_check_distance_to_target() {
 
 ////////DEBUG////////////////////////////////////////////////////////////
 
-#ifdef DEBUG_ENABLED
 void NavigationAgent3D::set_debug_enabled(bool p_enabled) {
+#ifdef DEBUG_ENABLED
 	if (debug_enabled == p_enabled) {
 		return;
 	}
 
 	debug_enabled = p_enabled;
 	debug_path_dirty = true;
+#endif // DEBUG_ENABLED
 }
 
 bool NavigationAgent3D::get_debug_enabled() const {
@@ -711,12 +710,14 @@ bool NavigationAgent3D::get_debug_enabled() const {
 }
 
 void NavigationAgent3D::set_debug_use_custom(bool p_enabled) {
+#ifdef DEBUG_ENABLED
 	if (debug_use_custom == p_enabled) {
 		return;
 	}
 
 	debug_use_custom = p_enabled;
 	debug_path_dirty = true;
+#endif // DEBUG_ENABLED
 }
 
 bool NavigationAgent3D::get_debug_use_custom() const {
@@ -724,12 +725,14 @@ bool NavigationAgent3D::get_debug_use_custom() const {
 }
 
 void NavigationAgent3D::set_debug_path_custom_color(Color p_color) {
+#ifdef DEBUG_ENABLED
 	if (debug_path_custom_color == p_color) {
 		return;
 	}
 
 	debug_path_custom_color = p_color;
 	debug_path_dirty = true;
+#endif // DEBUG_ENABLED
 }
 
 Color NavigationAgent3D::get_debug_path_custom_color() const {
@@ -737,18 +740,21 @@ Color NavigationAgent3D::get_debug_path_custom_color() const {
 }
 
 void NavigationAgent3D::set_debug_path_custom_point_size(float p_point_size) {
+#ifdef DEBUG_ENABLED
 	if (Math::is_equal_approx(debug_path_custom_point_size, p_point_size)) {
 		return;
 	}
 
 	debug_path_custom_point_size = p_point_size;
 	debug_path_dirty = true;
+#endif // DEBUG_ENABLED
 }
 
 float NavigationAgent3D::get_debug_path_custom_point_size() const {
 	return debug_path_custom_point_size;
 }
 
+#ifdef DEBUG_ENABLED
 void NavigationAgent3D::_navigation_debug_changed() {
 	debug_path_dirty = true;
 }

--- a/scene/3d/navigation_agent_3d.h
+++ b/scene/3d/navigation_agent_3d.h
@@ -75,14 +75,16 @@ class NavigationAgent3D : public Node {
 	// No initialized on purpose
 	uint32_t update_frame_id = 0;
 
-#ifdef DEBUG_ENABLED
+	// Debug properties for exposed bindings
 	bool debug_enabled = false;
-	bool debug_path_dirty = true;
-	RID debug_path_instance;
-	Ref<ArrayMesh> debug_path_mesh;
 	float debug_path_custom_point_size = 4.0;
 	bool debug_use_custom = false;
 	Color debug_path_custom_color = Color(1.0, 1.0, 1.0, 1.0);
+#ifdef DEBUG_ENABLED
+	// Debug properties internal only
+	bool debug_path_dirty = true;
+	RID debug_path_instance;
+	Ref<ArrayMesh> debug_path_mesh;
 	Ref<StandardMaterial3D> debug_agent_path_line_custom_material;
 	Ref<StandardMaterial3D> debug_agent_path_point_custom_material;
 
@@ -196,7 +198,6 @@ public:
 
 	PackedStringArray get_configuration_warnings() const override;
 
-#ifdef DEBUG_ENABLED
 	void set_debug_enabled(bool p_enabled);
 	bool get_debug_enabled() const;
 
@@ -208,7 +209,6 @@ public:
 
 	void set_debug_path_custom_point_size(float p_point_size);
 	float get_debug_path_custom_point_size() const;
-#endif // DEBUG_ENABLED
 
 private:
 	void update_navigation();


### PR DESCRIPTION
Fixes that certain NavigationAgent debug functions with bindings were not available in release builds.

Fixes https://github.com/godotengine/godot/issues/72864

While it is intentional that debug only functions do not work in release builds the problem is that generated bindings for secondary languages make no distinction between debug and release, so e.g. C# errored out. Now those properties and functions with bindings are always available but turned into "functionless" dummies on release builds.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
