### PR TITLE
GDScript: Fix error about enum typed arrays

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4264,18 +4264,22 @@ Variant GDScriptAnalyzer::make_subscript_reduced_value(GDScriptParser::Subscript
 Array GDScriptAnalyzer::make_array_from_element_datatype(const GDScriptParser::DataType &p_element_datatype, const GDScriptParser::Node *p_source_node) {
 	Array array;
 
-	Ref<Script> script_type = p_element_datatype.script_type;
-	if (p_element_datatype.kind == GDScriptParser::DataType::CLASS && script_type.is_null()) {
-		Error err = OK;
-		Ref<GDScript> scr = GDScriptCache::get_shallow_script(p_element_datatype.script_path, err);
-		if (err) {
-			push_error(vformat(R"(Error while getting cache for script "%s".)", p_element_datatype.script_path), p_source_node);
-			return array;
+	if (p_element_datatype.builtin_type == Variant::OBJECT) {
+		Ref<Script> script_type = p_element_datatype.script_type;
+		if (p_element_datatype.kind == GDScriptParser::DataType::CLASS && script_type.is_null()) {
+			Error err = OK;
+			Ref<GDScript> scr = GDScriptCache::get_shallow_script(p_element_datatype.script_path, err);
+			if (err) {
+				push_error(vformat(R"(Error while getting cache for script "%s".)", p_element_datatype.script_path), p_source_node);
+				return array;
+			}
+			script_type.reference_ptr(scr->find_class(p_element_datatype.class_type->fqcn));
 		}
-		script_type.reference_ptr(scr->find_class(p_element_datatype.class_type->fqcn));
-	}
 
-	array.set_typed(p_element_datatype.builtin_type, p_element_datatype.native_type, script_type);
+		array.set_typed(p_element_datatype.builtin_type, p_element_datatype.native_type, script_type);
+	} else {
+		array.set_typed(p_element_datatype.builtin_type, StringName(), Variant());
+	}
 
 	return array;
 }

--- a/modules/gdscript/tests/scripts/analyzer/features/typed_array_usage.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/typed_array_usage.gd
@@ -200,6 +200,10 @@ func test():
 	assert(str(typed_enums) == '[391]')
 	assert(typed_enums.get_typed_builtin() == TYPE_INT)
 
+	const const_enums: Array[E] = []
+	assert(const_enums.get_typed_builtin() == TYPE_INT)
+	assert(const_enums.get_typed_class_name() == &'')
+
 
 	var a := A.new()
 	var typed_natives: Array[RefCounted] = [a]


### PR DESCRIPTION
The error in question:
```
Class names can only be set for type OBJECT
```

Fixes #72909.
