### PR TITLE
GDExtension: `array_set_typed` now accepts enum instead of `uint32_t`

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -871,11 +871,11 @@ void gdextension_array_ref(GDExtensionTypePtr p_self, GDExtensionConstTypePtr p_
 	self->_ref(*from);
 }
 
-void gdextension_array_set_typed(GDExtensionTypePtr p_self, uint32_t p_type, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstVariantPtr p_script) {
+void gdextension_array_set_typed(GDExtensionTypePtr p_self, GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstVariantPtr p_script) {
 	Array *self = reinterpret_cast<Array *>(p_self);
 	const StringName *class_name = reinterpret_cast<const StringName *>(p_class_name);
 	const Variant *script = reinterpret_cast<const Variant *>(p_script);
-	self->set_typed(p_type, *class_name, *script);
+	self->set_typed((uint32_t)p_type, *class_name, *script);
 }
 
 /* Dictionary functions */

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -554,7 +554,7 @@ typedef struct {
 	GDExtensionVariantPtr (*array_operator_index)(GDExtensionTypePtr p_self, GDExtensionInt p_index); // p_self should be an Array ptr
 	GDExtensionVariantPtr (*array_operator_index_const)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index); // p_self should be an Array ptr
 	void (*array_ref)(GDExtensionTypePtr p_self, GDExtensionConstTypePtr p_from); // p_self should be an Array ptr
-	void (*array_set_typed)(GDExtensionTypePtr p_self, uint32_t p_type, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstVariantPtr p_script); // p_self should be an Array ptr
+	void (*array_set_typed)(GDExtensionTypePtr p_self, GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstVariantPtr p_script); // p_self should be an Array ptr
 
 	/* Dictionary functions */
 


### PR DESCRIPTION
The GDExtension function `array_set_typed` currently takes `uint32_t`, although it could benefit from a more type-safe `GDExtensionVariantType` enum.

Found through a `int32_t` (Linux) vs. `uint32_t` (Windows) inconsistency of the mapped enum, see [this CI run](https://github.com/godot-rust/gdextension/actions/runs/4127848914/jobs/7131561659#step:7:115).