### PR TITLE
Remove `m_object` parameter from unit test macros

### DIFF
--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -189,7 +189,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			arg2.push_back(1);
 			args.push_back(arg2);
 
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line_count() == 2);
 			CHECK_FALSE(code_edit->is_line_breakpointed(0));
 			CHECK(code_edit->is_line_breakpointed(1));
@@ -198,7 +198,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			/* Non-Breaking. */
 			((Array)args[0])[0] = 1;
 			((Array)args[1])[0] = 2;
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_blank");
+			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(code_edit->get_line_count() == 3);
 			CHECK_FALSE(code_edit->is_line_breakpointed(1));
 			CHECK(code_edit->is_line_breakpointed(2));
@@ -207,7 +207,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			/* Above. */
 			((Array)args[0])[0] = 2;
 			((Array)args[1])[0] = 3;
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_above");
+			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(code_edit->get_line_count() == 4);
 			CHECK_FALSE(code_edit->is_line_breakpointed(2));
 			CHECK(code_edit->is_line_breakpointed(3));
@@ -227,7 +227,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
 			/* Normal. */
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line_count() == 2);
 			CHECK(code_edit->is_line_breakpointed(0));
 			CHECK_FALSE(code_edit->is_line_breakpointed(1));
@@ -235,7 +235,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 
 			/* Non-Breaking. */
 			code_edit->set_caret_line(0);
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_blank");
+			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(code_edit->get_line_count() == 3);
 			CHECK(code_edit->is_line_breakpointed(0));
 			CHECK_FALSE(code_edit->is_line_breakpointed(1));
@@ -248,7 +248,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			args.push_back(arg2);
 
 			code_edit->set_caret_line(0);
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_above");
+			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(code_edit->get_line_count() == 4);
 			CHECK_FALSE(code_edit->is_line_breakpointed(0));
 			CHECK(code_edit->is_line_breakpointed(1));
@@ -269,12 +269,12 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			code_edit->set_caret_line(2);
 
 			/* backspace onto line does not remove breakpoint */
-			SEND_GUI_ACTION(code_edit, "ui_text_backspace");
+			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(code_edit->is_line_breakpointed(1));
 			SIGNAL_CHECK_FALSE("breakpoint_toggled");
 
 			/* backspace on breakpointed line removes it */
-			SEND_GUI_ACTION(code_edit, "ui_text_backspace");
+			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK_FALSE(code_edit->is_line_breakpointed(0));
 			ERR_PRINT_OFF;
 			CHECK_FALSE(code_edit->is_line_breakpointed(1));
@@ -294,7 +294,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			Array arg2;
 			arg2.push_back(1);
 			args.push_back(arg2);
-			SEND_GUI_ACTION(code_edit, "ui_text_backspace");
+			SEND_GUI_ACTION("ui_text_backspace");
 			ERR_PRINT_OFF;
 			CHECK_FALSE(code_edit->is_line_breakpointed(2));
 			ERR_PRINT_ON;
@@ -315,14 +315,14 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			code_edit->set_caret_line(1);
 
 			/* Delete onto breakpointed lines does not remove it. */
-			SEND_GUI_ACTION(code_edit, "ui_text_delete");
+			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(code_edit->get_line_count() == 2);
 			CHECK(code_edit->is_line_breakpointed(1));
 			SIGNAL_CHECK_FALSE("breakpoint_toggled");
 
 			/* Delete moving breakpointed line up removes it. */
 			code_edit->set_caret_line(0);
-			SEND_GUI_ACTION(code_edit, "ui_text_delete");
+			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(code_edit->get_line_count() == 1);
 			ERR_PRINT_OFF;
 			CHECK_FALSE(code_edit->is_line_breakpointed(1));
@@ -342,7 +342,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			Array arg2;
 			arg2.push_back(1);
 			args.push_back(arg2);
-			SEND_GUI_ACTION(code_edit, "ui_text_delete");
+			SEND_GUI_ACTION("ui_text_delete");
 			ERR_PRINT_OFF;
 			CHECK_FALSE(code_edit->is_line_breakpointed(2));
 			ERR_PRINT_ON;
@@ -380,7 +380,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			Array arg2;
 			arg2.push_back(4);
 			args.push_back(arg2);
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			ERR_PRINT_OFF;
 			CHECK_FALSE(code_edit->is_line_breakpointed(9));
 			ERR_PRINT_ON;
@@ -524,19 +524,19 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			CHECK(code_edit->is_line_bookmarked(0));
 
 			/* Normal. */
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line_count() == 2);
 			CHECK_FALSE(code_edit->is_line_bookmarked(0));
 			CHECK(code_edit->is_line_bookmarked(1));
 
 			/* Non-Breaking. */
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_blank");
+			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(code_edit->get_line_count() == 3);
 			CHECK_FALSE(code_edit->is_line_bookmarked(1));
 			CHECK(code_edit->is_line_bookmarked(2));
 
 			/* Above. */
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_above");
+			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(code_edit->get_line_count() == 4);
 			CHECK_FALSE(code_edit->is_line_bookmarked(2));
 			CHECK(code_edit->is_line_bookmarked(3));
@@ -549,21 +549,21 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			CHECK(code_edit->is_line_bookmarked(0));
 
 			/* Normal. */
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line_count() == 2);
 			CHECK(code_edit->is_line_bookmarked(0));
 			CHECK_FALSE(code_edit->is_line_bookmarked(1));
 
 			/* Non-Breaking. */
 			code_edit->set_caret_line(0);
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_blank");
+			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(code_edit->get_line_count() == 3);
 			CHECK(code_edit->is_line_bookmarked(0));
 			CHECK_FALSE(code_edit->is_line_bookmarked(1));
 
 			/* Above does move. */
 			code_edit->set_caret_line(0);
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_above");
+			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(code_edit->get_line_count() == 4);
 			CHECK_FALSE(code_edit->is_line_bookmarked(0));
 			CHECK(code_edit->is_line_bookmarked(1));
@@ -577,11 +577,11 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			code_edit->set_caret_line(2);
 
 			/* backspace onto line does not remove bookmark */
-			SEND_GUI_ACTION(code_edit, "ui_text_backspace");
+			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(code_edit->is_line_bookmarked(1));
 
 			/* backspace on bookmarked line removes it */
-			SEND_GUI_ACTION(code_edit, "ui_text_backspace");
+			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK_FALSE(code_edit->is_line_bookmarked(0));
 			ERR_PRINT_OFF;
 			CHECK_FALSE(code_edit->is_line_bookmarked(1));
@@ -595,13 +595,13 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			code_edit->set_caret_line(1);
 
 			/* Delete onto bookmarked lines does not remove it. */
-			SEND_GUI_ACTION(code_edit, "ui_text_delete");
+			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(code_edit->get_line_count() == 2);
 			CHECK(code_edit->is_line_bookmarked(1));
 
 			/* Delete moving bookmarked line up removes it. */
 			code_edit->set_caret_line(0);
-			SEND_GUI_ACTION(code_edit, "ui_text_delete");
+			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(code_edit->get_line_count() == 1);
 			ERR_PRINT_OFF;
 			CHECK_FALSE(code_edit->is_line_bookmarked(1));
@@ -730,19 +730,19 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			CHECK(code_edit->is_line_executing(0));
 
 			/* Normal. */
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line_count() == 2);
 			CHECK_FALSE(code_edit->is_line_executing(0));
 			CHECK(code_edit->is_line_executing(1));
 
 			/* Non-Breaking. */
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_blank");
+			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(code_edit->get_line_count() == 3);
 			CHECK_FALSE(code_edit->is_line_executing(1));
 			CHECK(code_edit->is_line_executing(2));
 
 			/* Above. */
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_above");
+			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(code_edit->get_line_count() == 4);
 			CHECK_FALSE(code_edit->is_line_executing(2));
 			CHECK(code_edit->is_line_executing(3));
@@ -755,21 +755,21 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			CHECK(code_edit->is_line_executing(0));
 
 			/* Normal. */
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line_count() == 2);
 			CHECK(code_edit->is_line_executing(0));
 			CHECK_FALSE(code_edit->is_line_executing(1));
 
 			/* Non-Breaking. */
 			code_edit->set_caret_line(0);
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_blank");
+			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(code_edit->get_line_count() == 3);
 			CHECK(code_edit->is_line_executing(0));
 			CHECK_FALSE(code_edit->is_line_executing(1));
 
 			/* Above does move. */
 			code_edit->set_caret_line(0);
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_above");
+			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(code_edit->get_line_count() == 4);
 			CHECK_FALSE(code_edit->is_line_executing(0));
 			CHECK(code_edit->is_line_executing(1));
@@ -783,11 +783,11 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			code_edit->set_caret_line(2);
 
 			/* backspace onto line does not remove executing lines. */
-			SEND_GUI_ACTION(code_edit, "ui_text_backspace");
+			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(code_edit->is_line_executing(1));
 
 			/* backspace on executing line removes it */
-			SEND_GUI_ACTION(code_edit, "ui_text_backspace");
+			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK_FALSE(code_edit->is_line_executing(0));
 			ERR_PRINT_OFF;
 			CHECK_FALSE(code_edit->is_line_executing(1));
@@ -801,13 +801,13 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			code_edit->set_caret_line(1);
 
 			/* Delete onto executing lines does not remove it. */
-			SEND_GUI_ACTION(code_edit, "ui_text_delete");
+			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(code_edit->get_line_count() == 2);
 			CHECK(code_edit->is_line_executing(1));
 
 			/* Delete moving executing line up removes it. */
 			code_edit->set_caret_line(0);
-			SEND_GUI_ACTION(code_edit, "ui_text_delete");
+			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(code_edit->get_line_count() == 1);
 			ERR_PRINT_OFF;
 			CHECK_FALSE(code_edit->is_line_executing(1));
@@ -1814,7 +1814,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		CHECK(code_edit->get_line(0) == "\t");
 
 		/* Check input action. */
-		SEND_GUI_ACTION(code_edit, "ui_text_indent");
+		SEND_GUI_ACTION("ui_text_indent");
 		CHECK(code_edit->get_line(0) == "\t\t");
 
 		/* Insert in place. */
@@ -1887,7 +1887,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		CHECK(code_edit->get_line(0) == "    ");
 
 		/* Check input action. */
-		SEND_GUI_ACTION(code_edit, "ui_text_indent");
+		SEND_GUI_ACTION("ui_text_indent");
 		CHECK(code_edit->get_line(0) == "        ");
 
 		/* Insert in place. */
@@ -1985,7 +1985,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 
 		/* Check input action. */
 		code_edit->set_text("\t\ttest");
-		SEND_GUI_ACTION(code_edit, "ui_text_dedent");
+		SEND_GUI_ACTION("ui_text_dedent");
 		CHECK(code_edit->get_line(0) == "\ttest");
 
 		/* Selection does entire line. */
@@ -2076,7 +2076,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 
 		/* Check input action. */
 		code_edit->set_text("        test");
-		SEND_GUI_ACTION(code_edit, "ui_text_dedent");
+		SEND_GUI_ACTION("ui_text_dedent");
 		CHECK(code_edit->get_line(0) == "    test");
 
 		/* Selection does entire line. */
@@ -2124,28 +2124,28 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			/* Simple indent on new line. */
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test:");
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test:");
 			CHECK(code_edit->get_line(1) == "\t");
 
 			/* new blank line should still indent. */
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test:");
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_blank");
+			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(code_edit->get_line(0) == "test:");
 			CHECK(code_edit->get_line(1) == "\t");
 
 			/* new line above should not indent. */
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test:");
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_above");
+			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(code_edit->get_line(0) == "");
 			CHECK(code_edit->get_line(1) == "test:");
 
 			/* Whitespace between symbol and caret is okay. */
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test:  ");
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test:  ");
 			CHECK(code_edit->get_line(1) == "\t");
 
@@ -2153,7 +2153,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			code_edit->add_comment_delimiter("#", "");
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test: # comment");
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test: # comment");
 			CHECK(code_edit->get_line(1) == "\t");
 			code_edit->remove_comment_delimiter("#");
@@ -2162,7 +2162,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			code_edit->add_string_delimiter("#", "");
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test: # string");
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test: # string");
 			CHECK(code_edit->get_line(1) == "");
 			code_edit->remove_string_delimiter("#");
@@ -2171,7 +2171,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			code_edit->add_comment_delimiter("#", "");
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test := 0 # comment");
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test := 0 # comment");
 			CHECK(code_edit->get_line(1) == "");
 			code_edit->remove_comment_delimiter("#");
@@ -2179,7 +2179,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			/* Even when there's no comments. */
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test := 0");
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test := 0");
 			CHECK(code_edit->get_line(1) == "");
 
@@ -2187,7 +2187,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test{}");
 			code_edit->set_caret_column(5);
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test{");
 			CHECK(code_edit->get_line(1) == "\t");
 			CHECK(code_edit->get_line(2) == "}");
@@ -2196,7 +2196,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test{}");
 			code_edit->set_caret_column(5);
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_above");
+			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(code_edit->get_line(0) == "");
 			CHECK(code_edit->get_line(1) == "test{}");
 
@@ -2204,7 +2204,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test{}");
 			code_edit->set_caret_column(5);
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_blank");
+			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(code_edit->get_line(0) == "test{}");
 			CHECK(code_edit->get_line(1) == "");
 		}
@@ -2217,28 +2217,28 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			/* Simple indent on new line. */
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test:");
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test:");
 			CHECK(code_edit->get_line(1) == "    ");
 
 			/* new blank line should still indent. */
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test:");
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_blank");
+			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(code_edit->get_line(0) == "test:");
 			CHECK(code_edit->get_line(1) == "    ");
 
 			/* new line above should not indent. */
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test:");
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_above");
+			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(code_edit->get_line(0) == "");
 			CHECK(code_edit->get_line(1) == "test:");
 
 			/* Whitespace between symbol and caret is okay. */
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test:  ");
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test:  ");
 			CHECK(code_edit->get_line(1) == "    ");
 
@@ -2246,7 +2246,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			code_edit->add_comment_delimiter("#", "");
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test: # comment");
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test: # comment");
 			CHECK(code_edit->get_line(1) == "    ");
 			code_edit->remove_comment_delimiter("#");
@@ -2255,7 +2255,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			code_edit->add_string_delimiter("#", "");
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test: # string");
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test: # string");
 			CHECK(code_edit->get_line(1) == "");
 			code_edit->remove_string_delimiter("#");
@@ -2264,7 +2264,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			code_edit->add_comment_delimiter("#", "");
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test := 0 # comment");
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test := 0 # comment");
 			CHECK(code_edit->get_line(1) == "");
 			code_edit->remove_comment_delimiter("#");
@@ -2272,7 +2272,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			/* Even when there's no comments. */
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test := 0");
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test := 0");
 			CHECK(code_edit->get_line(1) == "");
 
@@ -2280,7 +2280,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test{}");
 			code_edit->set_caret_column(5);
-			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test{");
 			CHECK(code_edit->get_line(1) == "    ");
 			CHECK(code_edit->get_line(2) == "}");
@@ -2289,7 +2289,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test{}");
 			code_edit->set_caret_column(5);
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_above");
+			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(code_edit->get_line(0) == "");
 			CHECK(code_edit->get_line(1) == "test{}");
 
@@ -2297,7 +2297,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			code_edit->set_text("");
 			code_edit->insert_text_at_caret("test{}");
 			code_edit->set_caret_column(5);
-			SEND_GUI_ACTION(code_edit, "ui_text_newline_blank");
+			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(code_edit->get_line(0) == "test{}");
 			CHECK(code_edit->get_line(1) == "");
 		}
@@ -2764,57 +2764,57 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 
 		/* Check typing inserts closing pair. */
 		code_edit->clear();
-		SEND_GUI_KEY_EVENT(code_edit, Key::BRACKETLEFT);
+		SEND_GUI_KEY_EVENT(Key::BRACKETLEFT);
 		CHECK(code_edit->get_line(0) == "[]");
 
 		/* Should first match and insert smaller key. */
 		code_edit->clear();
-		SEND_GUI_KEY_EVENT(code_edit, Key::APOSTROPHE);
+		SEND_GUI_KEY_EVENT(Key::APOSTROPHE);
 		CHECK(code_edit->get_line(0) == "''");
 		CHECK(code_edit->get_caret_column() == 1);
 
 		/* Move out from center, Should match and insert larger key. */
-		SEND_GUI_ACTION(code_edit, "ui_text_caret_right");
-		SEND_GUI_KEY_EVENT(code_edit, Key::APOSTROPHE);
+		SEND_GUI_ACTION("ui_text_caret_right");
+		SEND_GUI_KEY_EVENT(Key::APOSTROPHE);
 		CHECK(code_edit->get_line(0) == "''''''");
 		CHECK(code_edit->get_caret_column() == 3);
 
 		/* Backspace should remove all. */
-		SEND_GUI_ACTION(code_edit, "ui_text_backspace");
+		SEND_GUI_ACTION("ui_text_backspace");
 		CHECK(code_edit->get_line(0).is_empty());
 
 		/* If in between and typing close key should "skip". */
-		SEND_GUI_KEY_EVENT(code_edit, Key::BRACKETLEFT);
+		SEND_GUI_KEY_EVENT(Key::BRACKETLEFT);
 		CHECK(code_edit->get_line(0) == "[]");
 		CHECK(code_edit->get_caret_column() == 1);
-		SEND_GUI_KEY_EVENT(code_edit, Key::BRACKETRIGHT);
+		SEND_GUI_KEY_EVENT(Key::BRACKETRIGHT);
 		CHECK(code_edit->get_line(0) == "[]");
 		CHECK(code_edit->get_caret_column() == 2);
 
 		/* If current is char and inserting a string, do not autocomplete. */
 		code_edit->clear();
-		SEND_GUI_KEY_EVENT(code_edit, Key::A);
-		SEND_GUI_KEY_EVENT(code_edit, Key::APOSTROPHE);
+		SEND_GUI_KEY_EVENT(Key::A);
+		SEND_GUI_KEY_EVENT(Key::APOSTROPHE);
 		CHECK(code_edit->get_line(0) == "A'");
 
 		/* If in comment, do not complete. */
 		code_edit->add_comment_delimiter("#", "");
 		code_edit->clear();
-		SEND_GUI_KEY_EVENT(code_edit, Key::NUMBERSIGN);
-		SEND_GUI_KEY_EVENT(code_edit, Key::APOSTROPHE);
+		SEND_GUI_KEY_EVENT(Key::NUMBERSIGN);
+		SEND_GUI_KEY_EVENT(Key::APOSTROPHE);
 		CHECK(code_edit->get_line(0) == "#'");
 
 		/* If in string, and inserting string do not complete. */
 		code_edit->clear();
-		SEND_GUI_KEY_EVENT(code_edit, Key::APOSTROPHE);
-		SEND_GUI_KEY_EVENT(code_edit, Key::QUOTEDBL);
+		SEND_GUI_KEY_EVENT(Key::APOSTROPHE);
+		SEND_GUI_KEY_EVENT(Key::QUOTEDBL);
 		CHECK(code_edit->get_line(0) == "'\"'");
 
 		/* Wrap single line selection with brackets */
 		code_edit->clear();
 		code_edit->insert_text_at_caret("abc");
 		code_edit->select_all();
-		SEND_GUI_KEY_EVENT(code_edit, Key::BRACKETLEFT);
+		SEND_GUI_KEY_EVENT(Key::BRACKETLEFT);
 		CHECK(code_edit->get_line(0) == "[abc]");
 
 		/* Caret should be after the last character of the single line selection */
@@ -2824,7 +2824,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 		code_edit->clear();
 		code_edit->insert_text_at_caret("abc\nabc");
 		code_edit->select_all();
-		SEND_GUI_KEY_EVENT(code_edit, Key::BRACKETLEFT);
+		SEND_GUI_KEY_EVENT(Key::BRACKETLEFT);
 		CHECK(code_edit->get_text() == "[abc\nabc]");
 
 		/* Caret should be after the last character of the multi line selection */
@@ -2835,14 +2835,14 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 		code_edit->clear();
 		code_edit->insert_text_at_caret("abc");
 		code_edit->select_all();
-		SEND_GUI_KEY_EVENT(code_edit, Key::KEY_1);
+		SEND_GUI_KEY_EVENT(Key::KEY_1);
 		CHECK(code_edit->get_text() == "1");
 
 		/* If potential multichar and single brace completion is matched, it should wrap the single.  */
 		code_edit->clear();
 		code_edit->insert_text_at_caret("\'\'abc");
 		code_edit->select(0, 2, 0, 5);
-		SEND_GUI_KEY_EVENT(code_edit, Key::APOSTROPHE);
+		SEND_GUI_KEY_EVENT(Key::APOSTROPHE);
 		CHECK(code_edit->get_text() == "\'\'\'abc\'");
 
 		/* If only the potential multichar brace completion is matched, it does not wrap or complete. */
@@ -2853,7 +2853,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 		code_edit->clear();
 		code_edit->insert_text_at_caret("\'\'abc");
 		code_edit->select(0, 2, 0, 5);
-		SEND_GUI_KEY_EVENT(code_edit, Key::APOSTROPHE);
+		SEND_GUI_KEY_EVENT(Key::APOSTROPHE);
 		CHECK(code_edit->get_text() == "\'\'\'");
 	}
 
@@ -2977,7 +2977,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 		SIGNAL_CHECK("code_completion_requested", signal_args);
 
 		/* Manual request should force. */
-		SEND_GUI_ACTION(code_edit, "ui_text_completion_query");
+		SEND_GUI_ACTION("ui_text_completion_query");
 		SIGNAL_CHECK("code_completion_requested", signal_args);
 
 		/* Insert prefix. */
@@ -3042,7 +3042,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			CHECK(code_edit->get_code_completion_options().size() == 1);
 
 			/* Check cancel closes completion. */
-			SEND_GUI_ACTION(code_edit, "ui_cancel");
+			SEND_GUI_ACTION("ui_cancel");
 			CHECK(code_edit->get_code_completion_selected_index() == -1);
 
 			code_edit->update_code_completion_options();
@@ -3065,51 +3065,51 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_size(Size2(100, 100));
 
 			/* Check input. */
-			SEND_GUI_ACTION(code_edit, "ui_end");
+			SEND_GUI_ACTION("ui_end");
 			CHECK(code_edit->get_code_completion_selected_index() == 2);
 
-			SEND_GUI_ACTION(code_edit, "ui_home");
+			SEND_GUI_ACTION("ui_home");
 			CHECK(code_edit->get_code_completion_selected_index() == 0);
 
-			SEND_GUI_ACTION(code_edit, "ui_page_down");
+			SEND_GUI_ACTION("ui_page_down");
 			CHECK(code_edit->get_code_completion_selected_index() == 2);
 
-			SEND_GUI_ACTION(code_edit, "ui_page_up");
+			SEND_GUI_ACTION("ui_page_up");
 			CHECK(code_edit->get_code_completion_selected_index() == 0);
 
-			SEND_GUI_ACTION(code_edit, "ui_up");
+			SEND_GUI_ACTION("ui_up");
 			CHECK(code_edit->get_code_completion_selected_index() == 2);
 
-			SEND_GUI_ACTION(code_edit, "ui_down");
+			SEND_GUI_ACTION("ui_down");
 			CHECK(code_edit->get_code_completion_selected_index() == 0);
 
-			SEND_GUI_KEY_EVENT(code_edit, Key::T);
+			SEND_GUI_KEY_EVENT(Key::T);
 			CHECK(code_edit->get_code_completion_selected_index() == 0);
 
-			SEND_GUI_ACTION(code_edit, "ui_left");
+			SEND_GUI_ACTION("ui_left");
 			CHECK(code_edit->get_code_completion_selected_index() == 0);
 
-			SEND_GUI_ACTION(code_edit, "ui_right");
+			SEND_GUI_ACTION("ui_right");
 			CHECK(code_edit->get_code_completion_selected_index() == 0);
 
-			SEND_GUI_ACTION(code_edit, "ui_text_backspace");
+			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(code_edit->get_code_completion_selected_index() == 0);
 
 			Point2 caret_pos = code_edit->get_caret_draw_pos();
 			caret_pos.y += code_edit->get_line_height();
-			SEND_GUI_MOUSE_BUTTON_EVENT(code_edit, caret_pos, MouseButton::WHEEL_DOWN, 0, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(caret_pos, MouseButton::WHEEL_DOWN, 0, Key::NONE);
 			CHECK(code_edit->get_code_completion_selected_index() == 1);
 
-			SEND_GUI_MOUSE_BUTTON_EVENT(code_edit, caret_pos, MouseButton::WHEEL_UP, 0, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(caret_pos, MouseButton::WHEEL_UP, 0, Key::NONE);
 			CHECK(code_edit->get_code_completion_selected_index() == 0);
 
 			/* Single click selects. */
 			caret_pos.y += code_edit->get_line_height() * 2;
-			SEND_GUI_MOUSE_BUTTON_EVENT(code_edit, caret_pos, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(caret_pos, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(code_edit->get_code_completion_selected_index() == 2);
 
 			/* Double click inserts. */
-			SEND_GUI_DOUBLE_CLICK(code_edit, caret_pos, Key::NONE);
+			SEND_GUI_DOUBLE_CLICK(caret_pos, Key::NONE);
 			CHECK(code_edit->get_code_completion_selected_index() == -1);
 			CHECK(code_edit->get_line(0) == "item_2");
 
@@ -3130,7 +3130,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_caret_column(2);
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0.", "item_0");
 			code_edit->update_code_completion_options();
-			SEND_GUI_ACTION(code_edit, "ui_text_completion_replace");
+			SEND_GUI_ACTION("ui_text_completion_replace");
 			CHECK(code_edit->get_line(0) == "item_0 test");
 
 			/* Replace string. */
@@ -3139,7 +3139,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_caret_column(2);
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0.", "item_0");
 			code_edit->update_code_completion_options();
-			SEND_GUI_ACTION(code_edit, "ui_text_completion_replace");
+			SEND_GUI_ACTION("ui_text_completion_replace");
 			CHECK(code_edit->get_line(0) == "\"item_0\"");
 
 			/* Normal replace if no end is given. */
@@ -3148,7 +3148,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_caret_column(2);
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0.", "item_0");
 			code_edit->update_code_completion_options();
-			SEND_GUI_ACTION(code_edit, "ui_text_completion_replace");
+			SEND_GUI_ACTION("ui_text_completion_replace");
 			CHECK(code_edit->get_line(0) == "\"item_0\" test");
 
 			/* Insert at completion. */
@@ -3157,7 +3157,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_caret_column(2);
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0.", "item_0");
 			code_edit->update_code_completion_options();
-			SEND_GUI_ACTION(code_edit, "ui_text_completion_accept");
+			SEND_GUI_ACTION("ui_text_completion_accept");
 			CHECK(code_edit->get_line(0) == "item_01 test");
 
 			/* Insert at completion with string should have same output. */
@@ -3166,7 +3166,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_caret_column(2);
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0.", "item_0");
 			code_edit->update_code_completion_options();
-			SEND_GUI_ACTION(code_edit, "ui_text_completion_accept");
+			SEND_GUI_ACTION("ui_text_completion_accept");
 			CHECK(code_edit->get_line(0) == "\"item_0\"1 test\"");
 
 			/* Merge symbol at end on insert text. */
@@ -3176,7 +3176,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_caret_column(2);
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0(", "item_0(");
 			code_edit->update_code_completion_options();
-			SEND_GUI_ACTION(code_edit, "ui_text_completion_replace");
+			SEND_GUI_ACTION("ui_text_completion_replace");
 			CHECK(code_edit->get_line(0) == "item_0( test");
 			CHECK(code_edit->get_caret_column() == 7);
 
@@ -3186,7 +3186,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_caret_column(2);
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0", "item_0");
 			code_edit->update_code_completion_options();
-			SEND_GUI_ACTION(code_edit, "ui_text_completion_replace");
+			SEND_GUI_ACTION("ui_text_completion_replace");
 			CHECK(code_edit->get_line(0) == "item_0( test");
 			CHECK(code_edit->get_caret_column() == 6);
 
@@ -3196,7 +3196,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_caret_column(2);
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0(", "item_0(");
 			code_edit->update_code_completion_options();
-			SEND_GUI_ACTION(code_edit, "ui_text_completion_replace");
+			SEND_GUI_ACTION("ui_text_completion_replace");
 			CHECK(code_edit->get_line(0) == "item_0( test");
 			CHECK(code_edit->get_caret_column() == 7);
 
@@ -3207,7 +3207,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_caret_column(2);
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0()", "item_0()");
 			code_edit->update_code_completion_options();
-			SEND_GUI_ACTION(code_edit, "ui_text_completion_replace");
+			SEND_GUI_ACTION("ui_text_completion_replace");
 			CHECK(code_edit->get_line(0) == "item_0() test");
 			CHECK(code_edit->get_caret_column() == 8);
 
@@ -3217,7 +3217,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_caret_column(2);
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0", "item_0");
 			code_edit->update_code_completion_options();
-			SEND_GUI_ACTION(code_edit, "ui_text_completion_replace");
+			SEND_GUI_ACTION("ui_text_completion_replace");
 			CHECK(code_edit->get_line(0) == "item_0() test");
 			CHECK(code_edit->get_caret_column() == 6);
 
@@ -3227,7 +3227,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_caret_column(2);
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0()", "item_0()");
 			code_edit->update_code_completion_options();
-			SEND_GUI_ACTION(code_edit, "ui_text_completion_replace");
+			SEND_GUI_ACTION("ui_text_completion_replace");
 			CHECK(code_edit->get_line(0) == "item_0() test");
 			CHECK(code_edit->get_caret_column() == 8);
 
@@ -3240,7 +3240,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_caret_column(2);
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0(", "item_0(");
 			code_edit->update_code_completion_options();
-			SEND_GUI_ACTION(code_edit, "ui_text_completion_replace");
+			SEND_GUI_ACTION("ui_text_completion_replace");
 			CHECK(code_edit->get_line(0) == "item_0() test");
 			CHECK(code_edit->get_caret_column() == 7);
 
@@ -3250,7 +3250,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_caret_column(2);
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0", "item_0");
 			code_edit->update_code_completion_options();
-			SEND_GUI_ACTION(code_edit, "ui_text_completion_replace");
+			SEND_GUI_ACTION("ui_text_completion_replace");
 			CHECK(code_edit->get_line(0) == "item_0( test");
 			CHECK(code_edit->get_caret_column() == 6);
 
@@ -3260,7 +3260,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_caret_column(2);
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0(", "item_0(");
 			code_edit->update_code_completion_options();
-			SEND_GUI_ACTION(code_edit, "ui_text_completion_replace");
+			SEND_GUI_ACTION("ui_text_completion_replace");
 			CHECK(code_edit->get_line(0) == "item_0( test");
 			CHECK(code_edit->get_caret_column() == 7);
 
@@ -3271,7 +3271,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_caret_column(2);
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0()", "item_0()");
 			code_edit->update_code_completion_options();
-			SEND_GUI_ACTION(code_edit, "ui_text_completion_replace");
+			SEND_GUI_ACTION("ui_text_completion_replace");
 			CHECK(code_edit->get_line(0) == "item_0() test");
 			CHECK(code_edit->get_caret_column() == 8);
 
@@ -3281,7 +3281,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_caret_column(2);
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0", "item_0");
 			code_edit->update_code_completion_options();
-			SEND_GUI_ACTION(code_edit, "ui_text_completion_replace");
+			SEND_GUI_ACTION("ui_text_completion_replace");
 			CHECK(code_edit->get_line(0) == "item_0() test");
 			CHECK(code_edit->get_caret_column() == 6);
 
@@ -3291,7 +3291,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_caret_column(2);
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0()", "item_0()");
 			code_edit->update_code_completion_options();
-			SEND_GUI_ACTION(code_edit, "ui_text_completion_replace");
+			SEND_GUI_ACTION("ui_text_completion_replace");
 			CHECK(code_edit->get_line(0) == "item_0() test");
 			CHECK(code_edit->get_caret_column() == 8);
 		}
@@ -3316,15 +3316,15 @@ TEST_CASE("[SceneTree][CodeEdit] symbol lookup") {
 
 		Point2 caret_pos = code_edit->get_caret_draw_pos();
 		caret_pos.x += 60;
-		SEND_GUI_MOUSE_BUTTON_EVENT(code_edit, caret_pos, MouseButton::NONE, 0, Key::NONE);
+		SEND_GUI_MOUSE_BUTTON_EVENT(caret_pos, MouseButton::NONE, 0, Key::NONE);
 		CHECK(code_edit->get_text_for_symbol_lookup() == "this is s" + String::chr(0xFFFF) + "ome text");
 
 		SIGNAL_WATCH(code_edit, "symbol_validate");
 
 #ifdef MACOS_ENABLED
-		SEND_GUI_KEY_EVENT(code_edit, Key::META);
+		SEND_GUI_KEY_EVENT(Key::META);
 #else
-		SEND_GUI_KEY_EVENT(code_edit, Key::CTRL);
+		SEND_GUI_KEY_EVENT(Key::CTRL);
 #endif
 
 		Array signal_args;
@@ -3418,7 +3418,7 @@ TEST_CASE("[SceneTree][CodeEdit] New Line") {
 	code_edit->insert_text_at_caret("test new line");
 	code_edit->set_caret_line(0);
 	code_edit->set_caret_column(13);
-	SEND_GUI_ACTION(code_edit, "ui_text_newline");
+	SEND_GUI_ACTION("ui_text_newline");
 	CHECK(code_edit->get_line(0) == "test new line");
 	CHECK(code_edit->get_line(1) == "");
 
@@ -3427,7 +3427,7 @@ TEST_CASE("[SceneTree][CodeEdit] New Line") {
 	code_edit->insert_text_at_caret("test new line");
 	code_edit->set_caret_line(0);
 	code_edit->set_caret_column(5);
-	SEND_GUI_ACTION(code_edit, "ui_text_newline");
+	SEND_GUI_ACTION("ui_text_newline");
 	CHECK(code_edit->get_line(0) == "test ");
 	CHECK(code_edit->get_line(1) == "new line");
 
@@ -3435,7 +3435,7 @@ TEST_CASE("[SceneTree][CodeEdit] New Line") {
 	code_edit->set_text("");
 	code_edit->insert_text_at_caret("test new line");
 	code_edit->select(0, 0, 0, 5);
-	SEND_GUI_ACTION(code_edit, "ui_text_newline");
+	SEND_GUI_ACTION("ui_text_newline");
 	CHECK(code_edit->get_line(0) == "");
 	CHECK(code_edit->get_line(1) == "new line");
 
@@ -3443,7 +3443,7 @@ TEST_CASE("[SceneTree][CodeEdit] New Line") {
 	code_edit->set_text("");
 	code_edit->insert_text_at_caret("test new line");
 	code_edit->select(0, 0, 0, 5);
-	SEND_GUI_ACTION(code_edit, "ui_text_newline_blank");
+	SEND_GUI_ACTION("ui_text_newline_blank");
 	CHECK(code_edit->get_line(0) == "test new line");
 	CHECK(code_edit->get_line(1) == "");
 
@@ -3451,7 +3451,7 @@ TEST_CASE("[SceneTree][CodeEdit] New Line") {
 	code_edit->set_text("");
 	code_edit->insert_text_at_caret("test new line");
 	code_edit->select(0, 0, 0, 5);
-	SEND_GUI_ACTION(code_edit, "ui_text_newline_above");
+	SEND_GUI_ACTION("ui_text_newline_above");
 	CHECK(code_edit->get_line(0) == "");
 	CHECK(code_edit->get_line(1) == "test new line");
 

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -607,7 +607,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			ERR_PRINT_ON;
 
 			text_edit->set_text("test\nselection");
-			SEND_GUI_ACTION(text_edit, "ui_text_select_all");
+			SEND_GUI_ACTION("ui_text_select_all");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_selected_text() == "test\nselection");
@@ -678,7 +678,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "");
 
-			SEND_GUI_ACTION(text_edit, "ui_text_select_word_under_caret");
+			SEND_GUI_ACTION("ui_text_select_word_under_caret");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->has_selection(0));
@@ -836,48 +836,48 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_text("test");
 
 			text_edit->grab_focus();
-			SEND_GUI_KEY_EVENT(text_edit, Key::RIGHT | KeyModifierMask::SHIFT)
+			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::SHIFT)
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "t");
 
 #ifdef MACOS_ENABLED
-			SEND_GUI_KEY_EVENT(text_edit, Key::RIGHT | KeyModifierMask::SHIFT | KeyModifierMask::ALT)
+			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::SHIFT | KeyModifierMask::ALT)
 #else
-			SEND_GUI_KEY_EVENT(text_edit, Key::RIGHT | KeyModifierMask::SHIFT | KeyModifierMask::CMD_OR_CTRL)
+			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::SHIFT | KeyModifierMask::CMD_OR_CTRL)
 #endif
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "test");
 
-			SEND_GUI_KEY_EVENT(text_edit, Key::LEFT | KeyModifierMask::SHIFT)
+			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::SHIFT)
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "tes");
 
 #ifdef MACOS_ENABLED
-			SEND_GUI_KEY_EVENT(text_edit, Key::LEFT | KeyModifierMask::SHIFT | KeyModifierMask::ALT)
+			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::SHIFT | KeyModifierMask::ALT)
 #else
-			SEND_GUI_KEY_EVENT(text_edit, Key::LEFT | KeyModifierMask::SHIFT | KeyModifierMask::CMD_OR_CTRL)
+			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::SHIFT | KeyModifierMask::CMD_OR_CTRL)
 #endif
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "");
 
-			SEND_GUI_KEY_EVENT(text_edit, Key::RIGHT | KeyModifierMask::SHIFT)
+			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::SHIFT)
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "t");
 
-			SEND_GUI_KEY_EVENT(text_edit, Key::RIGHT)
+			SEND_GUI_KEY_EVENT(Key::RIGHT)
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "");
 
-			SEND_GUI_KEY_EVENT(text_edit, Key::LEFT | KeyModifierMask::SHIFT)
+			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::SHIFT)
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "t");
 
-			SEND_GUI_KEY_EVENT(text_edit, Key::LEFT)
+			SEND_GUI_KEY_EVENT(Key::LEFT)
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "");
 
 			text_edit->set_selecting_enabled(false);
-			SEND_GUI_KEY_EVENT(text_edit, Key::RIGHT | KeyModifierMask::SHIFT)
+			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::SHIFT)
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "");
 			text_edit->set_selecting_enabled(true);
@@ -891,8 +891,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->grab_focus();
 			MessageQueue::get_singleton()->flush();
 
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, text_edit->get_pos_at_line_column(0, 1), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit, text_edit->get_pos_at_line_column(0, 7), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 1), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_pos_at_line_column(0, 7), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "for s");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
@@ -903,12 +903,12 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 5);
 
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, text_edit->get_pos_at_line_column(0, 9), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 9), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 
 			text_edit->set_selecting_enabled(false);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, text_edit->get_pos_at_line_column(0, 1), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit, text_edit->get_pos_at_line_column(0, 7), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 1), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_pos_at_line_column(0, 7), MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 5);
@@ -923,7 +923,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
 
-			SEND_GUI_DOUBLE_CLICK(text_edit, text_edit->get_pos_at_line_column(0, 2), Key::NONE);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_pos_at_line_column(0, 2), Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "for");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
@@ -935,7 +935,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_column() == 3);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit, text_edit->get_pos_at_line_column(0, 7), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_pos_at_line_column(0, 7), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "for selection");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_WORD);
@@ -949,11 +949,11 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			Point2i line_0 = text_edit->get_pos_at_line_column(0, 0);
 			line_0.y /= 2;
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, line_0, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(line_0, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 
 			text_edit->set_selecting_enabled(false);
-			SEND_GUI_DOUBLE_CLICK(text_edit, text_edit->get_pos_at_line_column(0, 2), Key::NONE);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_pos_at_line_column(0, 2), Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 3);
@@ -967,8 +967,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_text("this is some text\nfor selection");
 			MessageQueue::get_singleton()->flush();
 
-			SEND_GUI_DOUBLE_CLICK(text_edit, text_edit->get_pos_at_line_column(0, 2), Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, text_edit->get_pos_at_line_column(0, 2), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_pos_at_line_column(0, 2), Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 2), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "for selection");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_LINE);
@@ -981,12 +981,12 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			Point2i line_0 = text_edit->get_pos_at_line_column(0, 0);
 			line_0.y /= 2;
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, line_0, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(line_0, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 
 			text_edit->set_selecting_enabled(false);
-			SEND_GUI_DOUBLE_CLICK(text_edit, text_edit->get_pos_at_line_column(0, 2), Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, text_edit->get_pos_at_line_column(0, 2), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_DOUBLE_CLICK(text_edit->get_pos_at_line_column(0, 2), Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 2), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
@@ -1000,8 +1000,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_text("this is some text\nfor selection");
 			MessageQueue::get_singleton()->flush();
 
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, text_edit->get_pos_at_line_column(0, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, text_edit->get_pos_at_line_column(0, 7), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 7), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "for s");
 			CHECK(text_edit->get_selection_mode() == TextEdit::SELECTION_MODE_POINTER);
@@ -1012,12 +1012,12 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 5);
 
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, text_edit->get_pos_at_line_column(0, 9), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 9), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK_FALSE(text_edit->has_selection());
 
 			text_edit->set_selecting_enabled(false);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, text_edit->get_pos_at_line_column(0, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, text_edit->get_pos_at_line_column(0, 7), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 0), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_pos_at_line_column(0, 7), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE | KeyModifierMask::SHIFT);
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 5);
@@ -1061,7 +1061,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			text_edit->select(0, 8, 0, 4);
 			CHECK(text_edit->has_selection());
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_right");
+			SEND_GUI_ACTION("ui_text_caret_right");
 			CHECK_FALSE(text_edit->has_selection());
 
 			text_edit->delete_selection();
@@ -1071,7 +1071,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			text_edit->select(0, 8, 0, 4);
 			CHECK(text_edit->has_selection());
-			SEND_GUI_ACTION(text_edit, "ui_text_backspace");
+			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_text() == "thissome text\nfor selection");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 4);
@@ -1149,19 +1149,19 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			Point2i line_0 = text_edit->get_pos_at_line_column(0, 0);
 			line_0.y /= 2;
-			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, line_0, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_EVENT(line_0, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->is_mouse_over_selection());
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit, text_edit->get_pos_at_line_column(0, 7), MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_pos_at_line_column(0, 7), MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_viewport()->gui_get_drag_data() == "drag me");
 
 			line_0 = target_text_edit->get_pos_at_line_column(0, 0);
 			line_0.y /= 2;
 			line_0.x += 401; // As empty add one.
-			SEND_GUI_MOUSE_MOTION_EVENT(target_text_edit, line_0, MouseButtonMask::LEFT, Key::NONE);
+			SEND_GUI_MOUSE_MOTION_EVENT(line_0, MouseButtonMask::LEFT, Key::NONE);
 			CHECK(text_edit->get_viewport()->gui_is_dragging());
 
-			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(target_text_edit, line_0, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(line_0, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == "");
@@ -1324,7 +1324,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			((Array)lines_edited_args[0])[0] = 0;
 			text_edit->select(0, 5, 0, 7);
 			ERR_PRINT_OFF;
-			SEND_GUI_ACTION(text_edit, "ui_cut");
+			SEND_GUI_ACTION("ui_cut");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			MessageQueue::get_singleton()->flush();
 			ERR_PRINT_ON; // Can't check display server content.
@@ -1401,7 +1401,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			lines_edited_args.push_front(args2);
 
 			((Array)lines_edited_args[1])[1] = 1;
-			SEND_GUI_ACTION(text_edit, "ui_text_newline_above");
+			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "\nthis is some test text.\n\nthis is some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -1424,7 +1424,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("caret_changed");
 
 			text_edit->set_editable(false);
-			SEND_GUI_ACTION(text_edit, "ui_text_newline_above");
+			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "\nthis is some test text.\n\nthis is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
@@ -1442,7 +1442,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			((Array)lines_edited_args[0])[0] = 2;
 			((Array)lines_edited_args[0])[1] = 3;
 
-			SEND_GUI_ACTION(text_edit, "ui_text_newline_above");
+			SEND_GUI_ACTION("ui_text_newline_above");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "\n\nthis is some test text.\n\n\nthis is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
@@ -1480,7 +1480,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			lines_edited_args.push_front(args2);
 
 			((Array)lines_edited_args[1])[1] = 1;
-			SEND_GUI_ACTION(text_edit, "ui_text_newline_blank");
+			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "this is some test text.\n\nthis is some test text.\n");
 			CHECK(text_edit->get_caret_line() == 1);
@@ -1495,7 +1495,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			text_edit->set_editable(false);
-			SEND_GUI_ACTION(text_edit, "ui_text_newline_blank");
+			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "this is some test text.\n\nthis is some test text.\n");
 			CHECK(text_edit->get_caret_line() == 1);
@@ -1538,7 +1538,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			lines_edited_args.push_back(lines_edited_args[2].duplicate());
 			((Array)lines_edited_args[3])[1] = 1;
 
-			SEND_GUI_ACTION(text_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "\n is some test text.\n\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
@@ -1553,7 +1553,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			text_edit->set_editable(false);
-			SEND_GUI_ACTION(text_edit, "ui_text_newline");
+			SEND_GUI_ACTION("ui_text_newline");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "\n is some test text.\n\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
@@ -1599,7 +1599,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			((Array)lines_edited_args[1])[0] = 1;
 			((Array)lines_edited_args[1])[1] = 1;
 
-			SEND_GUI_ACTION(text_edit, "ui_text_backspace_all_to_left");
+			SEND_GUI_ACTION("ui_text_backspace_all_to_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "\n is some test text.\n\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
@@ -1617,7 +1617,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			((Array)lines_edited_args[1])[1] = 0;
 
 			// Start of line should also be a normal backspace.
-			SEND_GUI_ACTION(text_edit, "ui_text_backspace_all_to_left");
+			SEND_GUI_ACTION("ui_text_backspace_all_to_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " is some test text.\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -1641,7 +1641,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("caret_changed");
 
 			text_edit->set_editable(false);
-			SEND_GUI_ACTION(text_edit, "ui_text_backspace_all_to_left");
+			SEND_GUI_ACTION("ui_text_backspace_all_to_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " is some test text.\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -1660,7 +1660,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			((Array)lines_edited_args[0])[1] = 1;
 			((Array)lines_edited_args[1])[0] = 0;
 
-			SEND_GUI_ACTION(text_edit, "ui_text_backspace_all_to_left");
+			SEND_GUI_ACTION("ui_text_backspace_all_to_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "\n");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -1703,7 +1703,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			((Array)lines_edited_args[1])[0] = 1;
 			((Array)lines_edited_args[1])[1] = 1;
 
-			SEND_GUI_ACTION(text_edit, "ui_text_backspace_word");
+			SEND_GUI_ACTION("ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "\n is some test text.\n\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
@@ -1722,7 +1722,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			((Array)lines_edited_args[1])[1] = 0;
 
 			// Start of line should also be a normal backspace.
-			SEND_GUI_ACTION(text_edit, "ui_text_backspace_word");
+			SEND_GUI_ACTION("ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " is some test text.\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -1737,7 +1737,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			text_edit->set_editable(false);
-			SEND_GUI_ACTION(text_edit, "ui_text_backspace_word");
+			SEND_GUI_ACTION("ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " is some test text.\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -1765,7 +1765,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			((Array)lines_edited_args[0])[1] = 1;
 			((Array)lines_edited_args[1])[0] = 0;
 
-			SEND_GUI_ACTION(text_edit, "ui_text_backspace_word");
+			SEND_GUI_ACTION("ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " is some test \n is some test ");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -1807,7 +1807,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			((Array)lines_edited_args[1])[0] = 1;
 			((Array)lines_edited_args[1])[1] = 1;
 
-			SEND_GUI_ACTION(text_edit, "ui_text_backspace");
+			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "\n is some test text.\n\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
@@ -1825,7 +1825,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			((Array)lines_edited_args[1])[1] = 0;
 
 			// Start of line should also be a normal backspace.
-			SEND_GUI_ACTION(text_edit, "ui_text_backspace");
+			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " is some test text.\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -1849,7 +1849,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("caret_changed");
 
 			text_edit->set_editable(false);
-			SEND_GUI_ACTION(text_edit, "ui_text_backspace");
+			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " is some test text.\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -1868,7 +1868,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			((Array)lines_edited_args[0])[1] = 1;
 			((Array)lines_edited_args[1])[0] = 0;
 
-			SEND_GUI_ACTION(text_edit, "ui_text_backspace");
+			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " is some test text\n is some test text");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -1897,7 +1897,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			SEND_GUI_ACTION(text_edit, "ui_text_backspace");
+			SEND_GUI_ACTION("ui_text_backspace");
 			CHECK(text_edit->get_text() == "\n");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
@@ -1935,7 +1935,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			lines_edited_args.push_front(args2);
 
 			// With selection should be a normal delete.
-			SEND_GUI_ACTION(text_edit, "ui_text_delete_all_to_right");
+			SEND_GUI_ACTION("ui_text_delete_all_to_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " is some test text.\n is some test text.\n");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -1959,7 +1959,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			SEND_GUI_ACTION(text_edit, "ui_text_delete_all_to_right");
+			SEND_GUI_ACTION("ui_text_delete_all_to_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " is some test text.\n is some test text.\n");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -1983,7 +1983,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("caret_changed");
 
 			text_edit->set_editable(false);
-			SEND_GUI_ACTION(text_edit, "ui_text_delete_all_to_right");
+			SEND_GUI_ACTION("ui_text_delete_all_to_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " is some test text.\n is some test text.\n");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -1998,7 +1998,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
 
-			SEND_GUI_ACTION(text_edit, "ui_text_delete_all_to_right");
+			SEND_GUI_ACTION("ui_text_delete_all_to_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "\n\n");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -2042,7 +2042,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			lines_edited_args.push_front(args2);
 
 			// With selection should be a normal delete.
-			SEND_GUI_ACTION(text_edit, "ui_text_delete_word");
+			SEND_GUI_ACTION("ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " ffi some test text.\n\n ffi some test text.\n");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -2068,7 +2068,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			SEND_GUI_ACTION(text_edit, "ui_text_delete_word");
+			SEND_GUI_ACTION("ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " ffi some test text.\n ffi some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -2095,7 +2095,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("caret_changed");
 
 			text_edit->set_editable(false);
-			SEND_GUI_ACTION(text_edit, "ui_text_delete_word");
+			SEND_GUI_ACTION("ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " ffi some test text.\n ffi some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -2110,7 +2110,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
 
-			SEND_GUI_ACTION(text_edit, "ui_text_delete_word");
+			SEND_GUI_ACTION("ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " some test text.\n some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -2152,7 +2152,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			lines_edited_args.push_front(args2);
 
 			// With selection should be a normal delete.
-			SEND_GUI_ACTION(text_edit, "ui_text_delete");
+			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " ffi some test text.\n ffi some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -2178,7 +2178,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			SEND_GUI_ACTION(text_edit, "ui_text_delete");
+			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " ffi some test text. ffi some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -2207,7 +2207,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("caret_changed");
 
 			text_edit->set_editable(false);
-			SEND_GUI_ACTION(text_edit, "ui_text_delete");
+			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " ffi some test text. ffi some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -2224,7 +2224,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			text_edit->start_action(TextEdit::EditAction::ACTION_NONE);
 
-			SEND_GUI_ACTION(text_edit, "ui_text_delete");
+			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "ffi some test text.ffi some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -2240,7 +2240,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			text_edit->start_action(TextEdit::EditAction::ACTION_NONE);
 
-			SEND_GUI_ACTION(text_edit, "ui_text_delete");
+			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "fi some test text.fi some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -2268,7 +2268,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			SEND_GUI_ACTION(text_edit, "ui_text_delete");
+			SEND_GUI_ACTION("ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == " some test text. some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -2299,9 +2299,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			// Shift should select.
 #ifdef MACOS_ENABLED
-			SEND_GUI_KEY_EVENT(text_edit, Key::LEFT | KeyModifierMask::ALT | KeyModifierMask::SHIFT);
+			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::ALT | KeyModifierMask::SHIFT);
 #else
-			SEND_GUI_KEY_EVENT(text_edit, Key::LEFT | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
+			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
 #endif
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 1);
@@ -2319,7 +2319,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
 			// Should still move caret with selection.
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_word_left");
+			SEND_GUI_ACTION("ui_text_caret_word_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
@@ -2334,7 +2334,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
 			// Normal word left.
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_word_left");
+			SEND_GUI_ACTION("ui_text_caret_word_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
@@ -2366,7 +2366,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("caret_changed");
 
 			// Normal left should deselect and place at selection start.
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_left");
+			SEND_GUI_ACTION("ui_text_caret_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 
 			CHECK(text_edit->get_caret_line() == 1);
@@ -2382,7 +2382,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
 			// With shift should select.
-			SEND_GUI_KEY_EVENT(text_edit, Key::LEFT | KeyModifierMask::SHIFT);
+			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::SHIFT);
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 1);
@@ -2399,7 +2399,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
 			// All ready at select left, should only deselect.
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_left");
+			SEND_GUI_ACTION("ui_text_caret_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 1);
@@ -2414,7 +2414,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
 			// Normal left.
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_left");
+			SEND_GUI_ACTION("ui_text_caret_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
@@ -2428,7 +2428,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
 			// Left at col 0 should go up a line.
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_left");
+			SEND_GUI_ACTION("ui_text_caret_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
@@ -2459,9 +2459,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			// Shift should select.
 #ifdef MACOS_ENABLED
-			SEND_GUI_KEY_EVENT(text_edit, Key::RIGHT | KeyModifierMask::ALT | KeyModifierMask::SHIFT);
+			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::ALT | KeyModifierMask::SHIFT);
 #else
-			SEND_GUI_KEY_EVENT(text_edit, Key::RIGHT | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
+			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
 #endif
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
@@ -2479,7 +2479,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
 			// Should still move caret with selection.
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_word_right");
+			SEND_GUI_ACTION("ui_text_caret_word_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 22);
@@ -2494,7 +2494,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
 			// Normal word right.
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_word_right");
+			SEND_GUI_ACTION("ui_text_caret_word_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
@@ -2526,7 +2526,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("caret_changed");
 
 			// Normal right should deselect and place at selection start.
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_right");
+			SEND_GUI_ACTION("ui_text_caret_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 20);
@@ -2541,7 +2541,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
 			// With shift should select.
-			SEND_GUI_KEY_EVENT(text_edit, Key::RIGHT | KeyModifierMask::SHIFT);
+			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::SHIFT);
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 21);
@@ -2558,7 +2558,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
 			// All ready at select right, should only deselect.
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_right");
+			SEND_GUI_ACTION("ui_text_caret_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 21);
@@ -2572,7 +2572,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
 			// Normal right.
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_right");
+			SEND_GUI_ACTION("ui_text_caret_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 22);
@@ -2586,7 +2586,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
 			// Right at end col should go down a line.
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_right");
+			SEND_GUI_ACTION("ui_text_caret_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
@@ -2620,7 +2620,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("caret_changed");
 
 			// Select + up should select everything to the left on that line.
-			SEND_GUI_KEY_EVENT(text_edit, Key::UP | KeyModifierMask::SHIFT);
+			SEND_GUI_KEY_EVENT(Key::UP | KeyModifierMask::SHIFT);
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 2);
 			CHECK(text_edit->get_caret_column() == 5);
@@ -2636,7 +2636,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
 			// Should deselect and move up.
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_up");
+			SEND_GUI_ACTION("ui_text_caret_up");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 8);
@@ -2650,7 +2650,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
 			// Normal up over wrapped line.
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_up");
+			SEND_GUI_ACTION("ui_text_caret_up");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 12);
@@ -2665,7 +2665,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(12, false);
 
 			// Normal up over wrapped line to line 0.
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_up");
+			SEND_GUI_ACTION("ui_text_caret_up");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 7);
@@ -2699,7 +2699,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("caret_changed");
 
 			// Select + down should select everything to the right on that line.
-			SEND_GUI_KEY_EVENT(text_edit, Key::DOWN | KeyModifierMask::SHIFT);
+			SEND_GUI_KEY_EVENT(Key::DOWN | KeyModifierMask::SHIFT);
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 5);
@@ -2715,7 +2715,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
 			// Should deselect and move down.
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_down");
+			SEND_GUI_ACTION("ui_text_caret_down");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 2);
 			CHECK(text_edit->get_caret_column() == 8);
@@ -2729,7 +2729,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
 			// Normal down over wrapped line.
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_down");
+			SEND_GUI_ACTION("ui_text_caret_down");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 3);
 			CHECK(text_edit->get_caret_column() == 7);
@@ -2744,7 +2744,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_column(7, false);
 
 			// Normal down over wrapped line to last wrapped line.
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_down");
+			SEND_GUI_ACTION("ui_text_caret_down");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 3);
 			CHECK(text_edit->get_caret_column() == 12);
@@ -2778,9 +2778,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("caret_changed");
 
 #ifdef MACOS_ENABLED
-			SEND_GUI_KEY_EVENT(text_edit, Key::UP | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
+			SEND_GUI_KEY_EVENT(Key::UP | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
 #else
-			SEND_GUI_KEY_EVENT(text_edit, Key::HOME | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
+			SEND_GUI_KEY_EVENT(Key::HOME | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
 #endif
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "this is some\nother test\nlines\ngo here");
@@ -2793,7 +2793,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			CHECK(text_edit->get_caret_count() == 1);
 
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_document_start");
+			SEND_GUI_ACTION("ui_text_caret_document_start");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "this is some\nother test\nlines\ngo here");
 			CHECK(text_edit->get_caret_line() == 0);
@@ -2823,9 +2823,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("caret_changed");
 
 #ifdef MACOS_ENABLED
-			SEND_GUI_KEY_EVENT(text_edit, Key::DOWN | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
+			SEND_GUI_KEY_EVENT(Key::DOWN | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
 #else
-			SEND_GUI_KEY_EVENT(text_edit, Key::END | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
+			SEND_GUI_KEY_EVENT(Key::END | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
 #endif
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "go here\nlines\nother test\nthis is some");
@@ -2838,7 +2838,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			CHECK(text_edit->get_caret_count() == 1);
 
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_document_end");
+			SEND_GUI_ACTION("ui_text_caret_document_end");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "go here\nlines\nother test\nthis is some");
 			CHECK(text_edit->get_caret_line() == 3);
@@ -2868,9 +2868,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("caret_changed");
 
 #ifdef MACOS_ENABLED
-			SEND_GUI_KEY_EVENT(text_edit, Key::LEFT | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
+			SEND_GUI_KEY_EVENT(Key::LEFT | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
 #else
-			SEND_GUI_KEY_EVENT(text_edit, Key::HOME | KeyModifierMask::SHIFT);
+			SEND_GUI_KEY_EVENT(Key::HOME | KeyModifierMask::SHIFT);
 #endif
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
@@ -2886,7 +2886,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_line_start");
+			SEND_GUI_ACTION("ui_text_caret_line_start");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 2);
@@ -2899,7 +2899,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_line_start");
+			SEND_GUI_ACTION("ui_text_caret_line_start");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
@@ -2912,7 +2912,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_line_start");
+			SEND_GUI_ACTION("ui_text_caret_line_start");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 2);
@@ -2945,9 +2945,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("caret_changed");
 
 #ifdef MACOS_ENABLED
-			SEND_GUI_KEY_EVENT(text_edit, Key::RIGHT | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
+			SEND_GUI_KEY_EVENT(Key::RIGHT | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
 #else
-			SEND_GUI_KEY_EVENT(text_edit, Key::END | KeyModifierMask::SHIFT);
+			SEND_GUI_KEY_EVENT(Key::END | KeyModifierMask::SHIFT);
 #endif
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
@@ -2963,7 +2963,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
-			SEND_GUI_ACTION(text_edit, "ui_text_caret_line_end");
+			SEND_GUI_ACTION("ui_text_caret_line_end");
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == text_edit->get_line(0).length());
@@ -2999,7 +2999,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			args2.push_back(1);
 			lines_edited_args.push_front(args2);
 
-			SEND_GUI_KEY_EVENT(text_edit, Key::A);
+			SEND_GUI_KEY_EVENT(Key::A);
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "aA\naA");
 			CHECK(text_edit->get_caret_column() == 2);
@@ -3009,7 +3009,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			text_edit->set_editable(false);
-			SEND_GUI_KEY_EVENT(text_edit, Key::A);
+			SEND_GUI_KEY_EVENT(Key::A);
 			CHECK_FALSE(text_edit->get_viewport()->is_input_handled()); // Should this be handled?
 			CHECK(text_edit->get_text() == "aA\naA");
 			CHECK(text_edit->get_caret_column() == 2);
@@ -3024,7 +3024,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			text_edit->select(0, 0, 0, 1);
 			text_edit->select(1, 0, 1, 1, 1);
-			SEND_GUI_KEY_EVENT(text_edit, Key::B);
+			SEND_GUI_KEY_EVENT(Key::B);
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "BA\nBA");
 			CHECK(text_edit->get_caret_column() == 1);
@@ -3033,10 +3033,10 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			SEND_GUI_ACTION(text_edit, "ui_text_toggle_insert_mode");
+			SEND_GUI_ACTION("ui_text_toggle_insert_mode");
 			CHECK(text_edit->is_overtype_mode_enabled());
 
-			SEND_GUI_KEY_EVENT(text_edit, Key::B);
+			SEND_GUI_KEY_EVENT(Key::B);
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "BB\nBB");
 			CHECK(text_edit->get_caret_column() == 2);
@@ -3046,7 +3046,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			text_edit->select(0, 0, 0, 1);
 			text_edit->select(1, 0, 1, 1, 1);
-			SEND_GUI_KEY_EVENT(text_edit, Key::A);
+			SEND_GUI_KEY_EVENT(Key::A);
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "AB\nAB");
 			CHECK(text_edit->get_caret_column() == 1);
@@ -3060,7 +3060,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			lines_edited_args.remove_at(0);
 			lines_edited_args.remove_at(1);
 
-			SEND_GUI_KEY_EVENT(text_edit, Key::TAB);
+			SEND_GUI_KEY_EVENT(Key::TAB);
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_text() == "A\tB\nA\tB");
 			CHECK(text_edit->get_caret_column() == 2);
@@ -3093,14 +3093,14 @@ TEST_CASE("[SceneTree][TextEdit] context menu") {
 	CHECK_FALSE(text_edit->is_context_menu_enabled());
 
 	CHECK_FALSE(text_edit->is_menu_visible());
-	SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, Point2i(600, 10), MouseButton::RIGHT, MouseButtonMask::RIGHT, Key::NONE);
+	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(600, 10), MouseButton::RIGHT, MouseButtonMask::RIGHT, Key::NONE);
 	CHECK_FALSE(text_edit->is_menu_visible());
 
 	text_edit->set_context_menu_enabled(true);
 	CHECK(text_edit->is_context_menu_enabled());
 
 	CHECK_FALSE(text_edit->is_menu_visible());
-	SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, Point2i(700, 10), MouseButton::RIGHT, MouseButtonMask::RIGHT, Key::NONE);
+	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(700, 10), MouseButton::RIGHT, MouseButtonMask::RIGHT, Key::NONE);
 	CHECK(text_edit->is_menu_visible());
 
 	memdelete(text_edit);
@@ -3281,28 +3281,28 @@ TEST_CASE("[SceneTree][TextEdit] caret") {
 	text_edit->set_caret_mid_grapheme_enabled(true);
 	CHECK(text_edit->is_caret_mid_grapheme_enabled());
 
-	SEND_GUI_ACTION(text_edit, "ui_text_caret_right");
+	SEND_GUI_ACTION("ui_text_caret_right");
 	CHECK(text_edit->get_caret_column() == 1);
 
-	SEND_GUI_ACTION(text_edit, "ui_text_caret_right");
+	SEND_GUI_ACTION("ui_text_caret_right");
 	CHECK(text_edit->get_caret_column() == 2);
 
-	SEND_GUI_ACTION(text_edit, "ui_text_caret_right");
+	SEND_GUI_ACTION("ui_text_caret_right");
 	CHECK(text_edit->get_caret_column() == 3);
 
-	SEND_GUI_ACTION(text_edit, "ui_text_caret_left");
+	SEND_GUI_ACTION("ui_text_caret_left");
 	CHECK(text_edit->get_caret_column() == 2);
 
 	text_edit->set_caret_mid_grapheme_enabled(false);
 	CHECK_FALSE(text_edit->is_caret_mid_grapheme_enabled());
 
-	SEND_GUI_ACTION(text_edit, "ui_text_caret_left");
+	SEND_GUI_ACTION("ui_text_caret_left");
 	CHECK(text_edit->get_caret_column() == 0);
 
-	SEND_GUI_ACTION(text_edit, "ui_text_caret_right");
+	SEND_GUI_ACTION("ui_text_caret_right");
 	CHECK(text_edit->get_caret_column() == 3);
 
-	SEND_GUI_ACTION(text_edit, "ui_text_caret_left");
+	SEND_GUI_ACTION("ui_text_caret_left");
 	CHECK(text_edit->get_caret_column() == 0);
 
 	text_edit->set_line(0, "Lorem  ipsum dolor sit amet, consectetur adipiscing elit. Donec vasius mattis leo, sed porta ex lacinia bibendum. Nunc bibendum pellentesque.");
@@ -3341,13 +3341,13 @@ TEST_CASE("[SceneTree][TextEdit] caret") {
 	text_edit->set_move_caret_on_right_click_enabled(false);
 	CHECK_FALSE(text_edit->is_move_caret_on_right_click_enabled());
 
-	SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, Point2i(100, 1), MouseButton::RIGHT, MouseButtonMask::RIGHT, Key::NONE);
+	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(100, 1), MouseButton::RIGHT, MouseButtonMask::RIGHT, Key::NONE);
 	CHECK(text_edit->get_caret_column() == caret_col);
 
 	text_edit->set_move_caret_on_right_click_enabled(true);
 	CHECK(text_edit->is_move_caret_on_right_click_enabled());
 
-	SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, Point2i(100, 1), MouseButton::RIGHT, MouseButtonMask::RIGHT, Key::NONE);
+	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(100, 1), MouseButton::RIGHT, MouseButtonMask::RIGHT, Key::NONE);
 	CHECK(text_edit->get_caret_column() != caret_col);
 
 	text_edit->set_move_caret_on_right_click_enabled(false);
@@ -3861,28 +3861,28 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 
 	// Scroll.
 	int v_scroll = text_edit->get_v_scroll();
-	SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, Point2i(10, 10), MouseButton::WHEEL_DOWN, 0, Key::NONE);
+	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_DOWN, 0, Key::NONE);
 	CHECK(text_edit->get_v_scroll() > v_scroll);
-	SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, Point2i(10, 10), MouseButton::WHEEL_UP, 0, Key::NONE);
+	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_UP, 0, Key::NONE);
 	CHECK(text_edit->get_v_scroll() == v_scroll);
 
 	// smooth scroll speed.
 	text_edit->set_smooth_scroll_enabled(true);
 
 	v_scroll = text_edit->get_v_scroll();
-	SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, Point2i(10, 10), MouseButton::WHEEL_DOWN, 0, Key::NONE);
+	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_DOWN, 0, Key::NONE);
 	text_edit->notification(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 	CHECK(text_edit->get_v_scroll() >= v_scroll);
-	SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, Point2i(10, 10), MouseButton::WHEEL_UP, 0, Key::NONE);
+	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_UP, 0, Key::NONE);
 	text_edit->notification(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 	CHECK(text_edit->get_v_scroll() == v_scroll);
 
 	v_scroll = text_edit->get_v_scroll();
 	text_edit->set_v_scroll_speed(10000);
-	SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, Point2i(10, 10), MouseButton::WHEEL_DOWN, 0, Key::NONE);
+	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_DOWN, 0, Key::NONE);
 	text_edit->notification(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 	CHECK(text_edit->get_v_scroll() >= v_scroll);
-	SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, Point2i(10, 10), MouseButton::WHEEL_UP, 0, Key::NONE);
+	SEND_GUI_MOUSE_BUTTON_EVENT(Point2i(10, 10), MouseButton::WHEEL_UP, 0, Key::NONE);
 	text_edit->notification(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 	CHECK(text_edit->get_v_scroll() == v_scroll);
 
@@ -3910,7 +3910,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 
 	text_edit->grab_focus();
-	SEND_GUI_ACTION(text_edit, "ui_text_scroll_down");
+	SEND_GUI_ACTION("ui_text_scroll_down");
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 1);
 	CHECK(text_edit->get_first_visible_line() == 1);
@@ -3919,7 +3919,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
 
-	SEND_GUI_ACTION(text_edit, "ui_text_scroll_up");
+	SEND_GUI_ACTION("ui_text_scroll_up");
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 1);
 	CHECK(text_edit->get_first_visible_line() == 0);
@@ -3929,7 +3929,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_caret_wrap_index() == 0);
 
 	// Page down, similar to VSCode, to end of page then scroll.
-	SEND_GUI_ACTION(text_edit, "ui_text_caret_page_down");
+	SEND_GUI_ACTION("ui_text_caret_page_down");
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 21);
 	CHECK(text_edit->get_first_visible_line() == 0);
@@ -3938,7 +3938,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
 
-	SEND_GUI_ACTION(text_edit, "ui_text_caret_page_down");
+	SEND_GUI_ACTION("ui_text_caret_page_down");
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 41);
 	CHECK(text_edit->get_first_visible_line() == 20);
@@ -3947,7 +3947,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
 
-	SEND_GUI_ACTION(text_edit, "ui_text_caret_page_up");
+	SEND_GUI_ACTION("ui_text_caret_page_up");
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 21);
 	CHECK(text_edit->get_first_visible_line() == 20);
@@ -3956,7 +3956,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
 
-	SEND_GUI_ACTION(text_edit, "ui_text_caret_page_up");
+	SEND_GUI_ACTION("ui_text_caret_page_up");
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 1);
 	CHECK(text_edit->get_first_visible_line() == 1);
@@ -3969,7 +3969,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	MessageQueue::get_singleton()->flush();
 
 	text_edit->grab_focus();
-	SEND_GUI_ACTION(text_edit, "ui_text_scroll_down");
+	SEND_GUI_ACTION("ui_text_scroll_down");
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 2);
 	CHECK(text_edit->get_first_visible_line() == 2);
@@ -3978,7 +3978,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
 
-	SEND_GUI_ACTION(text_edit, "ui_text_scroll_up");
+	SEND_GUI_ACTION("ui_text_scroll_up");
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 2);
 	CHECK(text_edit->get_first_visible_line() == 1);
@@ -3988,7 +3988,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_caret_wrap_index() == 0);
 
 	// Page down, similar to VSCode, to end of page then scroll.
-	SEND_GUI_ACTION(text_edit, "ui_text_caret_page_down");
+	SEND_GUI_ACTION("ui_text_caret_page_down");
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 22);
 	CHECK(text_edit->get_first_visible_line() == 1);
@@ -3997,7 +3997,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
 
-	SEND_GUI_ACTION(text_edit, "ui_text_caret_page_down");
+	SEND_GUI_ACTION("ui_text_caret_page_down");
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 42);
 	CHECK(text_edit->get_first_visible_line() == 21);
@@ -4006,7 +4006,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
 
-	SEND_GUI_ACTION(text_edit, "ui_text_caret_page_up");
+	SEND_GUI_ACTION("ui_text_caret_page_up");
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 22);
 	CHECK(text_edit->get_first_visible_line() == 21);
@@ -4015,7 +4015,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	CHECK(text_edit->get_last_full_visible_line_wrap_index() == 0);
 	CHECK(text_edit->get_caret_wrap_index() == 0);
 
-	SEND_GUI_ACTION(text_edit, "ui_text_caret_page_up");
+	SEND_GUI_ACTION("ui_text_caret_page_up");
 	CHECK(text_edit->get_viewport()->is_input_handled());
 	CHECK(text_edit->get_caret_line() == 2);
 	CHECK(text_edit->get_first_visible_line() == 2);
@@ -4031,7 +4031,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	MessageQueue::get_singleton()->flush();
 	CHECK(text_edit->get_first_visible_line() == 5);
 
-	SEND_GUI_KEY_EVENT(text_edit, Key::A);
+	SEND_GUI_KEY_EVENT(Key::A);
 	CHECK(text_edit->get_first_visible_line() == 0);
 
 	text_edit->set_line_as_first_visible(5);

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -134,16 +134,16 @@ int register_test_command(String p_command, TestFunc p_function);
 
 // Utility macros to send an event actions to a given object
 // Requires Message Queue and InputMap to be setup.
-// SEND_GUI_ACTION    - takes an object and a input map key. e.g SEND_GUI_ACTION(code_edit, "ui_text_newline").
-// SEND_GUI_KEY_EVENT - takes an object and a keycode set.   e.g SEND_GUI_KEY_EVENT(code_edit, Key::A | KeyModifierMask::META).
-// SEND_GUI_MOUSE_BUTTON_EVENT - takes an object, position, mouse button, mouse mask and modifiers e.g SEND_GUI_MOUSE_BUTTON_EVENT(code_edit, Vector2(50, 50), MOUSE_BUTTON_NONE, MOUSE_BUTTON_NONE, Key::None);
-// SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT - takes an object, position, mouse button, mouse mask and modifiers e.g SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(code_edit, Vector2(50, 50), MOUSE_BUTTON_NONE, MOUSE_BUTTON_NONE, Key::None);
-// SEND_GUI_MOUSE_MOTION_EVENT - takes an object, position, mouse mask and modifiers e.g SEND_GUI_MOUSE_MOTION_EVENT(code_edit, Vector2(50, 50), MouseButtonMask::LEFT, KeyModifierMask::META);
-// SEND_GUI_DOUBLE_CLICK - takes an object, position and modifiers. e.g SEND_GUI_DOUBLE_CLICK(code_edit, Vector2(50, 50), KeyModifierMask::META);
+// SEND_GUI_ACTION    - takes an input map key. e.g SEND_GUI_ACTION("ui_text_newline").
+// SEND_GUI_KEY_EVENT - takes a keycode set.   e.g SEND_GUI_KEY_EVENT(Key::A | KeyModifierMask::META).
+// SEND_GUI_MOUSE_BUTTON_EVENT - takes a position, mouse button, mouse mask and modifiers e.g SEND_GUI_MOUSE_BUTTON_EVENT(Vector2(50, 50), MOUSE_BUTTON_NONE, MOUSE_BUTTON_NONE, Key::None);
+// SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT - takes a position, mouse button, mouse mask and modifiers e.g SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Vector2(50, 50), MOUSE_BUTTON_NONE, MOUSE_BUTTON_NONE, Key::None);
+// SEND_GUI_MOUSE_MOTION_EVENT - takes a position, mouse mask and modifiers e.g SEND_GUI_MOUSE_MOTION_EVENT(Vector2(50, 50), MouseButtonMask::LEFT, KeyModifierMask::META);
+// SEND_GUI_DOUBLE_CLICK - takes a position and modifiers. e.g SEND_GUI_DOUBLE_CLICK(Vector2(50, 50), KeyModifierMask::META);
 
 #define _SEND_DISPLAYSERVER_EVENT(m_event) ((DisplayServerMock *)(DisplayServer::get_singleton()))->simulate_event(m_event);
 
-#define SEND_GUI_ACTION(m_object, m_action)                                                           \
+#define SEND_GUI_ACTION(m_action)                                                                     \
 	{                                                                                                 \
 		const List<Ref<InputEvent>> *events = InputMap::get_singleton()->action_get_events(m_action); \
 		const List<Ref<InputEvent>>::Element *first_event = events->front();                          \
@@ -153,7 +153,7 @@ int register_test_command(String p_command, TestFunc p_function);
 		MessageQueue::get_singleton()->flush();                                                       \
 	}
 
-#define SEND_GUI_KEY_EVENT(m_object, m_input)                                \
+#define SEND_GUI_KEY_EVENT(m_input)                                          \
 	{                                                                        \
 		Ref<InputEventKey> event = InputEventKey::create_reference(m_input); \
 		event->set_pressed(true);                                            \
@@ -167,53 +167,53 @@ int register_test_command(String p_command, TestFunc p_function);
 	m_event->set_ctrl_pressed(((m_modifers)&KeyModifierMask::CTRL) != Key::NONE);   \
 	m_event->set_meta_pressed(((m_modifers)&KeyModifierMask::META) != Key::NONE);
 
-#define _CREATE_GUI_MOUSE_EVENT(m_object, m_local_pos, m_input, m_mask, m_modifers) \
-	Ref<InputEventMouseButton> event;                                               \
-	event.instantiate();                                                            \
-	event->set_position(m_local_pos);                                               \
-	event->set_button_index(m_input);                                               \
-	event->set_button_mask(m_mask);                                                 \
-	event->set_factor(1);                                                           \
-	_UPDATE_EVENT_MODIFERS(event, m_modifers);                                      \
+#define _CREATE_GUI_MOUSE_EVENT(m_screen_pos, m_input, m_mask, m_modifers) \
+	Ref<InputEventMouseButton> event;                                      \
+	event.instantiate();                                                   \
+	event->set_position(m_screen_pos);                                     \
+	event->set_button_index(m_input);                                      \
+	event->set_button_mask(m_mask);                                        \
+	event->set_factor(1);                                                  \
+	_UPDATE_EVENT_MODIFERS(event, m_modifers);                             \
 	event->set_pressed(true);
 
-#define SEND_GUI_MOUSE_BUTTON_EVENT(m_object, m_local_pos, m_input, m_mask, m_modifers) \
+#define SEND_GUI_MOUSE_BUTTON_EVENT(m_screen_pos, m_input, m_mask, m_modifers) \
+	{                                                                          \
+		_CREATE_GUI_MOUSE_EVENT(m_screen_pos, m_input, m_mask, m_modifers);    \
+		_SEND_DISPLAYSERVER_EVENT(event);                                      \
+		MessageQueue::get_singleton()->flush();                                \
+	}
+
+#define SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(m_screen_pos, m_input, m_mask, m_modifers) \
 	{                                                                                   \
-		_CREATE_GUI_MOUSE_EVENT(m_object, m_local_pos, m_input, m_mask, m_modifers);    \
+		_CREATE_GUI_MOUSE_EVENT(m_screen_pos, m_input, m_mask, m_modifers);             \
+		event->set_pressed(false);                                                      \
 		_SEND_DISPLAYSERVER_EVENT(event);                                               \
 		MessageQueue::get_singleton()->flush();                                         \
 	}
 
-#define SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(m_object, m_local_pos, m_input, m_mask, m_modifers) \
-	{                                                                                            \
-		_CREATE_GUI_MOUSE_EVENT(m_object, m_local_pos, m_input, m_mask, m_modifers);             \
-		event->set_pressed(false);                                                               \
-		_SEND_DISPLAYSERVER_EVENT(event);                                                        \
-		MessageQueue::get_singleton()->flush();                                                  \
-	}
-
-#define SEND_GUI_DOUBLE_CLICK(m_object, m_local_pos, m_modifers)                          \
-	{                                                                                     \
-		_CREATE_GUI_MOUSE_EVENT(m_object, m_local_pos, MouseButton::LEFT, 0, m_modifers); \
-		event->set_double_click(true);                                                    \
-		_SEND_DISPLAYSERVER_EVENT(event);                                                 \
-		MessageQueue::get_singleton()->flush();                                           \
+#define SEND_GUI_DOUBLE_CLICK(m_screen_pos, m_modifers)                          \
+	{                                                                            \
+		_CREATE_GUI_MOUSE_EVENT(m_screen_pos, MouseButton::LEFT, 0, m_modifers); \
+		event->set_double_click(true);                                           \
+		_SEND_DISPLAYSERVER_EVENT(event);                                        \
+		MessageQueue::get_singleton()->flush();                                  \
 	}
 
 // We toggle _print_error_enabled to prevent display server not supported warnings.
-#define SEND_GUI_MOUSE_MOTION_EVENT(m_object, m_local_pos, m_mask, m_modifers) \
-	{                                                                          \
-		bool errors_enabled = CoreGlobals::print_error_enabled;                \
-		CoreGlobals::print_error_enabled = false;                              \
-		Ref<InputEventMouseMotion> event;                                      \
-		event.instantiate();                                                   \
-		event->set_position(m_local_pos);                                      \
-		event->set_button_mask(m_mask);                                        \
-		event->set_relative(Vector2(10, 10));                                  \
-		_UPDATE_EVENT_MODIFERS(event, m_modifers);                             \
-		_SEND_DISPLAYSERVER_EVENT(event);                                      \
-		MessageQueue::get_singleton()->flush();                                \
-		CoreGlobals::print_error_enabled = errors_enabled;                     \
+#define SEND_GUI_MOUSE_MOTION_EVENT(m_screen_pos, m_mask, m_modifers) \
+	{                                                                 \
+		bool errors_enabled = CoreGlobals::print_error_enabled;       \
+		CoreGlobals::print_error_enabled = false;                     \
+		Ref<InputEventMouseMotion> event;                             \
+		event.instantiate();                                          \
+		event->set_position(m_screen_pos);                            \
+		event->set_button_mask(m_mask);                               \
+		event->set_relative(Vector2(10, 10));                         \
+		_UPDATE_EVENT_MODIFERS(event, m_modifers);                    \
+		_SEND_DISPLAYSERVER_EVENT(event);                             \
+		MessageQueue::get_singleton()->flush();                       \
+		CoreGlobals::print_error_enabled = errors_enabled;            \
 	}
 
 // Utility class / macros for testing signals


### PR DESCRIPTION
This parameter serves since #71972 no longer any purpose and can be removed.
