### PR TITLE
Add root motion accumulator to fix broken RootMotionView

### DIFF
--- a/doc/classes/AnimationTree.xml
+++ b/doc/classes/AnimationTree.xml
@@ -33,7 +33,7 @@
 		<method name="get_root_motion_position" qualifiers="const">
 			<return type="Vector3" />
 			<description>
-				Retrieve the motion of position with the [member root_motion_track] as a [Vector3] that can be used elsewhere.
+				Retrieve the motion delta of position with the [member root_motion_track] as a [Vector3] that can be used elsewhere.
 				If [member root_motion_track] is not a path to a track of type [constant Animation.TYPE_POSITION_3D], returns [code]Vector3(0, 0, 0)[/code].
 				See also [member root_motion_track] and [RootMotionView].
 				The most basic example is applying position to [CharacterBody3D]:
@@ -50,12 +50,46 @@
 				    move_and_slide()
 				[/gdscript]
 				[/codeblocks]
+				By using this in combination with [method get_root_motion_position_accumulator], you can apply the root motion position more correctly to account for the rotation of the node.
+				[codeblocks]
+				[gdscript]
+				func _process(delta):
+				    if Input.is_action_just_pressed("animate"):
+				        state_machine.travel("Animate")
+				    set_quaternion(get_quaternion() * animation_tree.get_root_motion_rotation())
+				    var velocity: Vector3 = (animation_tree.get_root_motion_rotation_accumulator().inverse() * get_quaternion()) * animation_tree.get_root_motion_position() / delta
+				    set_velocity(velocity)
+				    move_and_slide()
+				[/gdscript]
+				[/codeblocks]
+			</description>
+		</method>
+		<method name="get_root_motion_position_accumulator" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Retrieve the blended value of the position tracks with the [member root_motion_track] as a [Vector3] that can be used elsewhere.
+				This is useful in cases where you want to respect the initial key values of the animation.
+				For example, if an animation with only one key [code]Vector3(0, 0, 0)[/code] is played in the previous frame and then an animation with only one key [code]Vector3(1, 0, 1)[/code] is played in the next frame, the difference can be calculated as follows:
+				[codeblocks]
+				[gdscript]
+				var prev_root_motion_position_accumulator: Vector3
+
+				func _process(delta):
+				    if Input.is_action_just_pressed("animate"):
+				        state_machine.travel("Animate")
+				    var current_root_motion_position_accumulator: Vector3 = animation_tree.get_root_motion_position_accumulator()
+				    var difference: Vector3 = current_root_motion_position_accumulator - prev_root_motion_position_accumulator
+				    prev_root_motion_position_accumulator = current_root_motion_position_accumulator
+				    transform.origin += difference
+				[/gdscript]
+				[/codeblocks]
+				However, if the animation loops, an unintended discrete change may occur, so this is only useful for some simple use cases.
 			</description>
 		</method>
 		<method name="get_root_motion_rotation" qualifiers="const">
 			<return type="Quaternion" />
 			<description>
-				Retrieve the motion of rotation with the [member root_motion_track] as a [Quaternion] that can be used elsewhere.
+				Retrieve the motion delta of rotation with the [member root_motion_track] as a [Quaternion] that can be used elsewhere.
 				If [member root_motion_track] is not a path to a track of type [constant Animation.TYPE_ROTATION_3D], returns [code]Quaternion(0, 0, 0, 1)[/code].
 				See also [member root_motion_track] and [RootMotionView].
 				The most basic example is applying rotation to [CharacterBody3D]:
@@ -69,10 +103,33 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="get_root_motion_rotation_accumulator" qualifiers="const">
+			<return type="Quaternion" />
+			<description>
+				Retrieve the blended value of the rotation tracks with the [member root_motion_track] as a [Quaternion] that can be used elsewhere.
+				This is necessary to apply the root motion position correctly, taking rotation into account. See also [method get_root_motion_position].
+				Also, this is useful in cases where you want to respect the initial key values of the animation.
+				For example, if an animation with only one key [code]Quaternion(0, 0, 0, 1)[/code] is played in the previous frame and then an animation with only one key [code]Quaternion(0, 0.707, 0, 0.707)[/code] is played in the next frame, the difference can be calculated as follows:
+				[codeblocks]
+				[gdscript]
+				var prev_root_motion_rotation_accumulator: Quaternion
+
+				func _process(delta):
+				    if Input.is_action_just_pressed("animate"):
+				        state_machine.travel("Animate")
+				    var current_root_motion_rotation_accumulator: Quaternion = animation_tree.get_root_motion_Quaternion_accumulator()
+				    var difference: Quaternion = prev_root_motion_rotation_accumulator.inverse() * current_root_motion_rotation_accumulator
+				    prev_root_motion_rotation_accumulator = current_root_motion_rotation_accumulator
+				    transform.basis *= difference
+				[/gdscript]
+				[/codeblocks]
+				However, if the animation loops, an unintended discrete change may occur, so this is only useful for some simple use cases.
+			</description>
+		</method>
 		<method name="get_root_motion_scale" qualifiers="const">
 			<return type="Vector3" />
 			<description>
-				Retrieve the motion of scale with the [member root_motion_track] as a [Vector3] that can be used elsewhere.
+				Retrieve the motion delta of scale with the [member root_motion_track] as a [Vector3] that can be used elsewhere.
 				If [member root_motion_track] is not a path to a track of type [constant Animation.TYPE_SCALE_3D], returns [code]Vector3(0, 0, 0)[/code].
 				See also [member root_motion_track] and [RootMotionView].
 				The most basic example is applying scale to [CharacterBody3D]:
@@ -90,6 +147,27 @@
 				    set_scale(current_scale * scale_accum)
 				[/gdscript]
 				[/codeblocks]
+			</description>
+		</method>
+		<method name="get_root_motion_scale_accumulator" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Retrieve the blended value of the scale tracks with the [member root_motion_track] as a [Vector3] that can be used elsewhere.
+				For example, if an animation with only one key [code]Vector3(1, 1, 1)[/code] is played in the previous frame and then an animation with only one key [code]Vector3(2, 2, 2)[/code] is played in the next frame, the difference can be calculated as follows:
+				[codeblocks]
+				[gdscript]
+				var prev_root_motion_scale_accumulator: Vector3
+
+				func _process(delta):
+				    if Input.is_action_just_pressed("animate"):
+				        state_machine.travel("Animate")
+				    var current_root_motion_scale_accumulator: Vector3 = animation_tree.get_root_motion_scale_accumulator()
+				    var difference: Vector3 = current_root_motion_scale_accumulator - prev_root_motion_scale_accumulator
+				    prev_root_motion_scale_accumulator = current_root_motion_scale_accumulator
+				    transform.basis = transform.basis.scaled(difference)
+				[/gdscript]
+				[/codeblocks]
+				However, if the animation loops, an unintended discrete change may occur, so this is only useful for some simple use cases.
 			</description>
 		</method>
 	</methods>

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -228,6 +228,12 @@ private:
 		}
 	};
 
+	struct RootMotionCache {
+		Vector3 loc = Vector3(0, 0, 0);
+		Quaternion rot = Quaternion(0, 0, 0, 1);
+		Vector3 scale = Vector3(1, 1, 1);
+	};
+
 	struct TrackCacheBlendShape : public TrackCache {
 		MeshInstance3D *mesh_3d = nullptr;
 		float init_value = 0;
@@ -294,6 +300,7 @@ private:
 		}
 	};
 
+	RootMotionCache root_motion_cache;
 	HashMap<NodePath, TrackCache *> track_cache;
 	HashSet<TrackCache *> playing_caches;
 	Vector<Node *> playing_audio_stream_players;
@@ -327,6 +334,9 @@ private:
 	Vector3 root_motion_position = Vector3(0, 0, 0);
 	Quaternion root_motion_rotation = Quaternion(0, 0, 0, 1);
 	Vector3 root_motion_scale = Vector3(0, 0, 0);
+	Vector3 root_motion_position_accumulator = Vector3(0, 0, 0);
+	Quaternion root_motion_rotation_accumulator = Quaternion(0, 0, 0, 1);
+	Vector3 root_motion_scale_accumulator = Vector3(1, 1, 1);
 
 	friend class AnimationNode;
 	bool properties_dirty = true;
@@ -393,6 +403,10 @@ public:
 	Vector3 get_root_motion_position() const;
 	Quaternion get_root_motion_rotation() const;
 	Vector3 get_root_motion_scale() const;
+
+	Vector3 get_root_motion_position_accumulator() const;
+	Quaternion get_root_motion_rotation_accumulator() const;
+	Vector3 get_root_motion_scale_accumulator() const;
 
 	real_t get_connection_activity(const StringName &p_path, int p_connection) const;
 	void advance(double p_time);

--- a/scene/animation/root_motion_view.cpp
+++ b/scene/animation/root_motion_view.cpp
@@ -88,6 +88,7 @@ void RootMotionView::_notification(int p_what) {
 		case NOTIFICATION_INTERNAL_PROCESS:
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			Transform3D transform;
+			Basis diff;
 
 			if (has_node(path)) {
 				Node *node = get_node(path);
@@ -103,9 +104,9 @@ void RootMotionView::_notification(int p_what) {
 						set_process_internal(true);
 						set_physics_process_internal(false);
 					}
-
 					transform.origin = tree->get_root_motion_position();
 					transform.basis = tree->get_root_motion_rotation(); // Scale is meaningless.
+					diff = tree->get_root_motion_rotation_accumulator();
 				}
 			}
 
@@ -115,8 +116,10 @@ void RootMotionView::_notification(int p_what) {
 
 			first = false;
 
-			accumulated.origin += transform.origin;
 			accumulated.basis *= transform.basis;
+			transform.origin = (diff.inverse() * accumulated.basis).xform(transform.origin);
+			accumulated.origin += transform.origin;
+
 			accumulated.origin.x = Math::fposmod(accumulated.origin.x, cell_size);
 			if (zero_y) {
 				accumulated.origin.y = 0;


### PR DESCRIPTION
Fixes #72930.

https://user-images.githubusercontent.com/61938263/217677744-5bca45b4-5bda-461c-80e4-9971b818b598.mp4

Now we can get the actual blended rotation of the rotation with `get_root_motion_rotation_accumulator()`, not just the delta value.

The following would allow the root motion position to be correctly applied while taking the object's orientation into account, without keeping the current rotation at the start of the animation. Now we can close #58061 completely.

```gdscript
func _process(delta):
	if Input.is_action_just_pressed("animate"):
		state_machine.travel("Animate")
	set_quaternion(get_quaternion() * animation_tree.get_root_motion_rotation())
	var velocity: Vector3 = (animation_tree.get_root_motion_rotation_accumulator().inverse() * get_quaternion()) * animation_tree.get_root_motion_position() / delta
	set_velocity(velocity)
	move_and_slide()
```

I added a explanation of this code to the documentation. This should work even if the animation is Xfade or interrupted.

Also, using `get_root_motion_rotation_accumulator()` should be able to solve issue #67125. Closes #67125.

---

We should discuss whether this is the good naming for the methods.

I think `get_root_motion_rotation_delta()` and `get_root_motion_rotation()` would be better, but it would be breaks compat; This means to rename the current `get_root_motion_rotation()` to `get_root_motion_rotation_delta()` and to rename this PR's `get_root_motion_rotation_accumulator()` to `get_root_motion_rotation()`.

Probably it is a better naming like `get_root_motion_rotation_base()` or `get_root_motion_rotation_source()`?

What do you think? @reduz @fire @lyuma @SaracenOne 