### PR TITLE
Fix missing avoidance updates when using same velocity

### DIFF
--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -436,9 +436,8 @@ real_t NavigationAgent2D::get_path_max_distance() {
 }
 
 void NavigationAgent2D::set_target_position(Vector2 p_position) {
-	if (target_position.is_equal_approx(p_position)) {
-		return;
-	}
+	// Intentionally not checking for equality of the parameter, as we want to update the path even if the target position is the same in case the world changed.
+	// Revisit later when the navigation server can update the path without requesting a new path.
 
 	target_position = p_position;
 	target_position_submitted = true;
@@ -491,9 +490,9 @@ Vector2 NavigationAgent2D::get_final_position() {
 }
 
 void NavigationAgent2D::set_velocity(Vector2 p_velocity) {
-	if (target_velocity.is_equal_approx(p_velocity)) {
-		return;
-	}
+	// Intentionally not checking for equality of the parameter.
+	// We need to always submit the velocity to the navigation server, even when it is the same, in order to run avoidance every frame.
+	// Revisit later when the navigation server can update avoidance without users resubmitting the velocity.
 
 	target_velocity = p_velocity;
 	velocity_submitted = true;

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -461,9 +461,8 @@ real_t NavigationAgent3D::get_path_max_distance() {
 }
 
 void NavigationAgent3D::set_target_position(Vector3 p_position) {
-	if (target_position.is_equal_approx(p_position)) {
-		return;
-	}
+	// Intentionally not checking for equality of the parameter, as we want to update the path even if the target position is the same in case the world changed.
+	// Revisit later when the navigation server can update the path without requesting a new path.
 
 	target_position = p_position;
 	target_position_submitted = true;
@@ -516,9 +515,9 @@ Vector3 NavigationAgent3D::get_final_position() {
 }
 
 void NavigationAgent3D::set_velocity(Vector3 p_velocity) {
-	if (target_velocity.is_equal_approx(p_velocity)) {
-		return;
-	}
+	// Intentionally not checking for equality of the parameter.
+	// We need to always submit the velocity to the navigation server, even when it is the same, in order to run avoidance every frame.
+	// Revisit later when the navigation server can update avoidance without users resubmitting the velocity.
 
 	target_velocity = p_velocity;
 	velocity_submitted = true;


### PR DESCRIPTION
When using avoidance, if you set the same velocity for the agent as a previous frame, you won't get an update from the avoidance system.

This PR changes both the `set_target_position` and `set_velocity` setters to always accept user provided values, even if they are the same. This ensures that pathing and avoidance logic is always run when the user expects.

This change is intended to go into 4.0 as a bug fix.  Issue was first introduced in RC1 as part of #72570.  Thanks to @Scony for finding it.