### PR TITLE
Improve some editor strings for localization

### DIFF
--- a/editor/editor_locale_dialog.cpp
+++ b/editor/editor_locale_dialog.cpp
@@ -446,7 +446,8 @@ EditorLocaleDialog::EditorLocaleDialog() {
 			vb_script_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 			{
 				Label *script_lbl = memnew(Label);
-				script_lbl->set_text(TTR("Script:"));
+				// TRANSLATORS: This is the label for a list of writing systems.
+				script_lbl->set_text(TTR("Script:", "Locale"));
 				vb_script_list->add_child(script_lbl);
 			}
 			{
@@ -504,7 +505,8 @@ EditorLocaleDialog::EditorLocaleDialog() {
 				vb_script->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 				{
 					Label *script_lbl = memnew(Label);
-					script_lbl->set_text(TTR("Script"));
+					// TRANSLATORS: This refers to a writing system.
+					script_lbl->set_text(TTR("Script", "Locale"));
 					vb_script->add_child(script_lbl);
 				}
 				{

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -528,7 +528,7 @@ void DynamicFontImportSettings::_variation_selected() {
 		inspector_vars->edit(import_variation_data.ptr());
 		import_variation_data->notify_property_list_changed();
 
-		label_glyphs->set_text(TTR("Preloaded glyphs: ") + itos(import_variation_data->selected_glyphs.size()));
+		label_glyphs->set_text(vformat(TTR("Preloaded glyphs: %d"), import_variation_data->selected_glyphs.size()));
 		_range_selected();
 		_change_text_opts();
 
@@ -659,7 +659,7 @@ void DynamicFontImportSettings::_glyph_update_lbl() {
 		}
 	}
 	int unlinked_glyphs = import_variation_data->selected_glyphs.size() - linked_glyphs;
-	label_glyphs->set_text(TTR("Preloaded glyphs:") + " " + itos(unlinked_glyphs + import_variation_data->selected_chars.size()));
+	label_glyphs->set_text(vformat(TTR("Preloaded glyphs: %d"), unlinked_glyphs + import_variation_data->selected_chars.size()));
 }
 
 void DynamicFontImportSettings::_glyph_clear() {
@@ -1403,7 +1403,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 
 	label_glyphs = memnew(Label);
 	gl_hb->add_child(label_glyphs);
-	label_glyphs->set_text(TTR("Preloaded glyphs:") + " " + itos(0));
+	label_glyphs->set_text(vformat(TTR("Preloaded glyphs: %d"), 0));
 	label_glyphs->set_custom_minimum_size(Size2(50 * EDSCALE, 0));
 
 	Button *btn_clear = memnew(Button);

--- a/editor/plugins/debugger_editor_plugin.cpp
+++ b/editor/plugins/debugger_editor_plugin.cpp
@@ -97,14 +97,10 @@ DebuggerEditorPlugin::DebuggerEditorPlugin(PopupMenu *p_debug_menu) {
 	debug_menu->add_separator();
 	debug_menu->add_submenu_item(TTR("Run Multiple Instances"), "run_instances");
 
-	instances_menu->add_radio_check_item(TTR("Run 1 Instance"));
-	instances_menu->set_item_metadata(0, 1);
-	instances_menu->add_radio_check_item(TTR("Run 2 Instances"));
-	instances_menu->set_item_metadata(1, 2);
-	instances_menu->add_radio_check_item(TTR("Run 3 Instances"));
-	instances_menu->set_item_metadata(2, 3);
-	instances_menu->add_radio_check_item(TTR("Run 4 Instances"));
-	instances_menu->set_item_metadata(3, 4);
+	for (int i = 1; i <= 4; i++) {
+		instances_menu->add_radio_check_item(vformat(TTRN("Run %d Instance", "Run %d Instances", i), i));
+		instances_menu->set_item_metadata(i - 1, i);
+	}
 	instances_menu->set_item_checked(0, true);
 	instances_menu->connect("index_pressed", callable_mp(this, &DebuggerEditorPlugin::_select_run_count));
 	debug_menu->connect("id_pressed", callable_mp(this, &DebuggerEditorPlugin::_menu_option));

--- a/editor/plugins/font_config_plugin.cpp
+++ b/editor/plugins/font_config_plugin.cpp
@@ -310,7 +310,8 @@ void EditorPropertyFontMetaOverride::update_property() {
 		}
 
 		if (script_editor) {
-			button_add = EditorInspector::create_inspector_action_button(TTR("Add Script"));
+			// TRANSLATORS: Script refers to a writing system.
+			button_add = EditorInspector::create_inspector_action_button(TTR("Add Script", "Locale"));
 		} else {
 			button_add = EditorInspector::create_inspector_action_button(TTR("Add Locale"));
 		}

--- a/modules/multiplayer/editor/editor_network_profiler.cpp
+++ b/modules/multiplayer/editor/editor_network_profiler.cpp
@@ -253,7 +253,8 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	hb->add_spacer();
 
 	Label *lb = memnew(Label);
-	lb->set_text(TTR("Down"));
+	// TRANSLATORS: This is the label for the network profiler's incoming bandwidth.
+	lb->set_text(TTR("Down", "Network"));
 	hb->add_child(lb);
 
 	incoming_bandwidth_text = memnew(LineEdit);
@@ -267,7 +268,8 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	hb->add_child(down_up_spacer);
 
 	lb = memnew(Label);
-	lb->set_text(TTR("Up"));
+	// TRANSLATORS: This is the label for the network profiler's outgoing bandwidth.
+	lb->set_text(TTR("Up", "Network"));
 	hb->add_child(lb);
 
 	outgoing_bandwidth_text = memnew(LineEdit);

--- a/scene/3d/collision_shape_3d.cpp
+++ b/scene/3d/collision_shape_3d.cpp
@@ -124,7 +124,7 @@ PackedStringArray CollisionShape3D::get_configuration_warnings() const {
 	PackedStringArray warnings = Node::get_configuration_warnings();
 
 	if (!Object::cast_to<CollisionObject3D>(get_parent())) {
-		warnings.push_back(RTR("CollisionShape3D only serves to provide a collision shape to a CollisionObject3D derived node. Please only use it as a child of Area3D, StaticBody3D, RigidBody3D, CharacterBody3D, etc. to give them a shape."));
+		warnings.push_back(RTR("CollisionShape3D only serves to provide a collision shape to a CollisionObject3D derived node.\nPlease only use it as a child of Area3D, StaticBody3D, RigidBody3D, CharacterBody3D, etc. to give them a shape."));
 	}
 
 	if (!shape.is_valid()) {

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -6553,7 +6553,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 				OperatorNode *op = alloc_node<OperatorNode>();
 				op->op = expression[i].op;
 				if ((op->op == OP_INCREMENT || op->op == OP_DECREMENT) && !_validate_assign(expression[i + 1].node, p_function_info)) {
-					_set_error(RTR("Can't use increment/decrement operator in a constant expression."));
+					_set_error(RTR("Invalid use of increment/decrement operator in a constant expression."));
 					return nullptr;
 				}
 				op->arguments.push_back(expression[i + 1].node);
@@ -8421,7 +8421,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 						_set_error(vformat(RTR("The '%s' data type is not supported for uniforms."), "struct"));
 						return ERR_PARSE_ERROR;
 					} else {
-						_set_error(vformat(RTR("The '%s' data type not allowed here."), "struct"));
+						_set_error(vformat(RTR("The '%s' data type is not allowed here."), "struct"));
 						return ERR_PARSE_ERROR;
 					}
 				}

--- a/servers/rendering/shader_preprocessor.h
+++ b/servers/rendering/shader_preprocessor.h
@@ -182,7 +182,7 @@ private:
 	}
 
 	void _set_unexpected_token_error(const String &p_what, int p_line) {
-		set_error(vformat(RTR("Unexpected token '%s'."), p_what), p_line);
+		set_error(vformat(RTR("Unexpected token: '%s'."), p_what), p_line);
 	}
 
 	void process_directive(Tokenizer *p_tokenizer);


### PR DESCRIPTION
* "Script" in locale editor means a writing system, i.e. the set of letters in which a language is written. It is put into its own context and a translator comment is added.
* "Up" and "Down" in network profiler mean the outgoing and incoming bandwidth. They are put into their own context and a translator comment is added.
* A newline is added to a warning in CollisionShape3D. This makes it consistent with its CollisionPolygon3D counterpart and other long warnings nearby.
* Unified several message strings that are similar (e.g. differ by only a space or colon).
* Use `TTRN()` for "Run N Instances".