### PR TITLE
Default update_vital_only to true for Android and Web editor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6044,9 +6044,14 @@ EditorNode::EditorNode() {
 	EDITOR_DEF("interface/editor/save_on_focus_loss", false);
 	EDITOR_DEF_RST("interface/editor/save_each_scene_on_quit", true);
 	EDITOR_DEF("interface/editor/quit_confirmation", true);
-	EDITOR_DEF("interface/editor/show_update_spinner", false);
 	EDITOR_DEF("interface/editor/update_continuously", false);
+#if defined(ANDROID_ENABLED) || defined(JAVASCRIPT_ENABLED)
+	EDITOR_DEF("interface/editor/show_update_spinner", true);
+	EDITOR_DEF("interface/editor/update_vital_only", true);
+#else
+	EDITOR_DEF("interface/editor/show_update_spinner", false);
 	EDITOR_DEF("interface/editor/update_vital_only", false);
+#endif
 	EDITOR_DEF("interface/editor/localize_settings", true);
 	EDITOR_DEF_RST("interface/scene_tabs/restore_scenes_on_load", false);
 	EDITOR_DEF_RST("interface/scene_tabs/show_thumbnail_on_hover", true);


### PR DESCRIPTION
Android devices will typically be powered from battery. This PR defaults the editor on Android to use `update_vital_only` mode, using as little power as possible, in order to conserve battery.

Also shows the update spinner by default, to emphasize that vital updates only is occurring, and allow easy switching out of the mode.

## Notes
* Now that the editor is downloadable from google play and a lot more people may be using it on Android, it does make some sense to default the editor in modes that use the least power possible, so that Godot does not drain the battery excessively.
* Vital updates was introduced in #53463 , see that PR for more details.
* It significantly reduces CPU use (often by about 10x).
_(The other CPU hog is audio thread, which #63458 is designed to deal with, and reduces CPU use by a further approx 5x)._
* The main trade off here is that in `vital_updates_only` mode, the cursor does not flash.
* I've also shown the update spinner by default. This makes it easier to switch in and out of `vital_updates_only` mode, and more apparent that there are update options, which are particularly relevant on mobile.

Deciding whether to default in this mode has pros and cons, so I will leave it up to reviewers to decide whether this is the best action.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
