### PR TITLE
Perform early exit in Input::is_anything_pressed

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -231,14 +231,17 @@ Input::VelocityTrack::VelocityTrack() {
 bool Input::is_anything_pressed() const {
 	_THREAD_SAFE_METHOD_
 
+	if (!keys_pressed.is_empty() || !joy_buttons_pressed.is_empty() || !mouse_button_mask.is_empty()) {
+		return true;
+	}
+
 	for (const KeyValue<StringName, Input::Action> &E : action_state) {
 		if (E.value.pressed) {
 			return true;
 		}
 	}
-	return !keys_pressed.is_empty() ||
-			!joy_buttons_pressed.is_empty() ||
-			!mouse_button_mask.is_empty();
+
+	return false;
 }
 
 bool Input::is_key_pressed(Key p_keycode) const {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
The iterative check is only needed if there are events not based on keys, joy or mouse buttons, like events from scripts, axes, or touch. Probably not performance critical but minor change and worth doing imo.