### PR TITLE
GDScript: Be more lenient with identifiers

### DIFF
--- a/modules/gdscript/tests/scripts/parser/features/allow_id_similar_to_keyword_in_ascii.gd
+++ b/modules/gdscript/tests/scripts/parser/features/allow_id_similar_to_keyword_in_ascii.gd
@@ -1,0 +1,3 @@
+func test():
+	var P1 = "ok" # Technically it is visually similar to keyword "PI" but allowed since it's in ASCII range.
+	print(P1)

--- a/modules/gdscript/tests/scripts/parser/features/allow_id_similar_to_keyword_in_ascii.out
+++ b/modules/gdscript/tests/scripts/parser/features/allow_id_similar_to_keyword_in_ascii.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok

--- a/modules/gdscript/tests/scripts/parser/features/allowed_keywords_as_identifiers.gd
+++ b/modules/gdscript/tests/scripts/parser/features/allowed_keywords_as_identifiers.gd
@@ -1,0 +1,16 @@
+func test():
+	# The following keywords are allowed as identifiers:
+	var match = "match"
+	print(match)
+
+	var PI = "PI"
+	print(PI)
+
+	var INF = "INF"
+	print(INF)
+
+	var NAN = "NAN"
+	print(NAN)
+
+	var TAU = "TAU"
+	print(TAU)

--- a/modules/gdscript/tests/scripts/parser/features/allowed_keywords_as_identifiers.out
+++ b/modules/gdscript/tests/scripts/parser/features/allowed_keywords_as_identifiers.out
@@ -1,0 +1,6 @@
+GDTEST_OK
+match
+PI
+INF
+NAN
+TAU

--- a/modules/gdscript/tests/scripts/parser/warnings/confusable_identifier.gd
+++ b/modules/gdscript/tests/scripts/parser/warnings/confusable_identifier.gd
@@ -1,5 +1,12 @@
+extends Node
+
 func test():
 	var port = 0 # Only latin characters.
 	var pοrt = 1 # The "ο" is Greek omicron.
 
 	prints(port, pοrt)
+
+# Do not call this since nodes aren't in the tree. It is just a parser check.
+func nodes():
+	var _node1 = $port # Only latin characters.
+	var _node2 = $pοrt # The "ο" is Greek omicron.

--- a/modules/gdscript/tests/scripts/parser/warnings/confusable_identifier.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/confusable_identifier.out
@@ -1,6 +1,10 @@
 GDTEST_OK
 >> WARNING
->> Line: 3
+>> Line: 5
+>> CONFUSABLE_IDENTIFIER
+>> The identifier "pοrt" has misleading characters and might be confused with something else.
+>> WARNING
+>> Line: 12
 >> CONFUSABLE_IDENTIFIER
 >> The identifier "pοrt" has misleading characters and might be confused with something else.
 0 1


### PR DESCRIPTION
- Allow identifiers similar to keywords if they are in ASCII range.
- Allow constants to be treated as regular identifiers.
- Allow keywords that can be used as identifiers in expressions.

