### PR TITLE
GDScript: Fix and improve annotation parsing

### DIFF
--- a/modules/gdscript/tests/scripts/parser/errors/annotation_extra_comma.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/annotation_extra_comma.gd
@@ -1,0 +1,4 @@
+@export_enum("A",, "B", "C") var a
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/parser/errors/annotation_extra_comma.out
+++ b/modules/gdscript/tests/scripts/parser/errors/annotation_extra_comma.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected expression as the annotation argument.

--- a/modules/gdscript/tests/scripts/parser/features/annotations.gd
+++ b/modules/gdscript/tests/scripts/parser/features/annotations.gd
@@ -1,0 +1,48 @@
+extends Node
+
+@export_enum("A", "B", "C") var a0
+@export_enum("A", "B", "C",) var a1
+
+@export_enum(
+	"A",
+	"B",
+	"C"
+) var a2
+
+@export_enum(
+	"A",
+	"B",
+	"C",
+) var a3
+
+@export
+var a4: int
+
+@export()
+var a5: int
+
+@export() var a6: int
+@warning_ignore("onready_with_export") @onready @export var a7: int
+@warning_ignore("onready_with_export") @onready() @export() var a8: int
+
+@warning_ignore("onready_with_export")
+@onready
+@export
+var a9: int
+
+@warning_ignore("onready_with_export")
+@onready()
+@export()
+var a10: int
+
+@warning_ignore("onready_with_export")
+@onready()
+@export()
+
+var a11: int
+
+
+func test():
+	for property in get_property_list():
+		if property.usage & PROPERTY_USAGE_SCRIPT_VARIABLE:
+			print(property)

--- a/modules/gdscript/tests/scripts/parser/features/annotations.out
+++ b/modules/gdscript/tests/scripts/parser/features/annotations.out
@@ -1,0 +1,13 @@
+GDTEST_OK
+{ "name": "a0", "class_name": &"", "type": 2, "hint": 2, "hint_string": "A,B,C", "usage": 4102 }
+{ "name": "a1", "class_name": &"", "type": 2, "hint": 2, "hint_string": "A,B,C", "usage": 4102 }
+{ "name": "a2", "class_name": &"", "type": 2, "hint": 2, "hint_string": "A,B,C", "usage": 4102 }
+{ "name": "a3", "class_name": &"", "type": 2, "hint": 2, "hint_string": "A,B,C", "usage": 4102 }
+{ "name": "a4", "class_name": &"", "type": 2, "hint": 0, "hint_string": "int", "usage": 4102 }
+{ "name": "a5", "class_name": &"", "type": 2, "hint": 0, "hint_string": "int", "usage": 4102 }
+{ "name": "a6", "class_name": &"", "type": 2, "hint": 0, "hint_string": "int", "usage": 4102 }
+{ "name": "a7", "class_name": &"", "type": 2, "hint": 0, "hint_string": "int", "usage": 4102 }
+{ "name": "a8", "class_name": &"", "type": 2, "hint": 0, "hint_string": "int", "usage": 4102 }
+{ "name": "a9", "class_name": &"", "type": 2, "hint": 0, "hint_string": "int", "usage": 4102 }
+{ "name": "a10", "class_name": &"", "type": 2, "hint": 0, "hint_string": "int", "usage": 4102 }
+{ "name": "a11", "class_name": &"", "type": 2, "hint": 0, "hint_string": "int", "usage": 4102 }


### PR DESCRIPTION
* Fix multiline mode not working up to the first argument.
* Disallow empty arguments.
* Allow empty parentheses.

Before:
![](https://user-images.githubusercontent.com/47700418/217864193-75e38111-432e-4a05-a141-2b9feb4782f3.png)
![](https://user-images.githubusercontent.com/47700418/217864915-ea81e628-5a63-488e-86cb-50269f7ae443.png)
![](https://user-images.githubusercontent.com/47700418/217866828-52025340-8df7-4b6e-9f03-1f7589062ff0.png)

After:
![](https://user-images.githubusercontent.com/47700418/217864547-3c00a2a4-1eaa-4a37-8cfa-6988dd1302d5.png)
![](https://user-images.githubusercontent.com/47700418/217866048-696b7eee-3945-4011-8831-841969fd86a2.png)
![](https://user-images.githubusercontent.com/47700418/217866433-41e3ada8-a4ba-415a-af30-24f2164845ec.png)

Closes #54279.
Closes #66322.
