### PR TITLE
Emit reimport signal in reimport_file_with_custom_parameters method

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2167,6 +2167,11 @@ void EditorFileSystem::_find_group_files(EditorFileSystemDirectory *efd, HashMap
 
 void EditorFileSystem::reimport_file_with_custom_parameters(const String &p_file, const String &p_importer, const HashMap<StringName, Variant> &p_custom_params) {
 	_reimport_file(p_file, p_custom_params, p_importer);
+
+	// Emit the resource_reimported signal for the single file we just reimported.
+	Vector<String> reloads;
+	reloads.append(p_file);
+	emit_signal(SNAME("resources_reimported"), reloads);
 }
 
 void EditorFileSystem::_reimport_thread(uint32_t p_index, ImportThreadData *p_import_data) {


### PR DESCRIPTION
Fixes an issue where the new runtime reimporting of scenes would not occur when updating from the advanced import window, only from the basic import dock.

Closes #72536