### PR TITLE
Allow enabling tinyexr module compilation in export templates

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -208,6 +208,13 @@ opts.Add(BoolVariable("modules_enabled_by_default", "If no, disable all modules 
 opts.Add(BoolVariable("no_editor_splash", "Don't use the custom splash screen for the editor", True))
 opts.Add("system_certs_path", "Use this path as SSL certificates default for editor (for package maintainers)", "")
 opts.Add(BoolVariable("use_precise_math_checks", "Math checks use very precise epsilon (debug option)", False))
+opts.Add(
+    BoolVariable(
+        "tinyexr_export_templates",
+        "Enable saving and loading OpenEXR images in export template builds (increases binary size)",
+        False,
+    )
+)
 
 # Thirdparty libraries
 opts.Add(BoolVariable("builtin_certs", "Use the built-in SSL certificates bundles", True))

--- a/SConstruct
+++ b/SConstruct
@@ -208,13 +208,6 @@ opts.Add(BoolVariable("modules_enabled_by_default", "If no, disable all modules 
 opts.Add(BoolVariable("no_editor_splash", "Don't use the custom splash screen for the editor", True))
 opts.Add("system_certs_path", "Use this path as SSL certificates default for editor (for package maintainers)", "")
 opts.Add(BoolVariable("use_precise_math_checks", "Math checks use very precise epsilon (debug option)", False))
-opts.Add(
-    BoolVariable(
-        "tinyexr_export_templates",
-        "Enable saving and loading OpenEXR images in export template builds (increases binary size)",
-        False,
-    )
-)
 
 # Thirdparty libraries
 opts.Add(BoolVariable("builtin_certs", "Use the built-in SSL certificates bundles", True))

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -401,7 +401,7 @@
 			<param index="1" name="grayscale" type="bool" default="false" />
 			<description>
 				Saves the image as an EXR file to [param path]. If [param grayscale] is [code]true[/code] and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. This function will return [constant ERR_UNAVAILABLE] if Godot was compiled without the TinyEXR module.
-				[b]Note:[/b] The TinyEXR module is disabled in non-editor builds, which means [method save_exr] will return [constant ERR_UNAVAILABLE] when it is called from an exported project.
+				[b]Note:[/b] The TinyEXR module is disabled in official non-editor builds, which means [method save_exr] will return [constant ERR_UNAVAILABLE] when it is called from an exported project. In self-compiled export template builds, [method save_exr] will be functional if the export template was compiled with the [code]tinyexr_export_templates=yes[/code] SCons option.
 			</description>
 		</method>
 		<method name="save_exr_to_buffer" qualifiers="const">
@@ -409,7 +409,7 @@
 			<param index="0" name="grayscale" type="bool" default="false" />
 			<description>
 				Saves the image as an EXR file to a byte array. If [param grayscale] is [code]true[/code] and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. This function will return an empty byte array if Godot was compiled without the TinyEXR module.
-				[b]Note:[/b] The TinyEXR module is disabled in non-editor builds, which means [method save_exr] will return an empty byte array when it is called from an exported project.
+				[b]Note:[/b] The TinyEXR module is disabled in official non-editor builds, which means [method save_exr] will return an empty byte array when it is called from an exported project. In self-compiled export template builds, [method save_exr_to_buffer] will be functional if the export template was compiled with the [code]tinyexr_export_templates=yes[/code] SCons option.
 			</description>
 		</method>
 		<method name="save_jpg" qualifiers="const">
@@ -448,7 +448,7 @@
 			<param index="1" name="lossy" type="bool" default="false" />
 			<param index="2" name="quality" type="float" default="0.75" />
 			<description>
-				Saves the image as a WebP (Web Picture) file to the file at [param path]. By default it will save lossless. If [param lossy] is true, the image will be saved lossy, using the [param quality] setting between 0.0 and 1.0 (inclusive).
+				Saves the image as a WebP (Web Picture) file to the file at [param path]. This format generally provides a better file-size-to-quality ratio compared to JPEG and PNG, but is slower to write. By default, [method save_webp] saves with lossless compression. If [param lossy] is [code]true[/code], the image will be saved with lossy compression using the specified [param quality] between [code]0.0[/code] and [code]1.0[/code] (inclusive). Note that lossy compression at quality [code]1.0[/code] still has visible degradation, unlike lossless compression.
 			</description>
 		</method>
 		<method name="save_webp_to_buffer" qualifiers="const">
@@ -456,7 +456,7 @@
 			<param index="0" name="lossy" type="bool" default="false" />
 			<param index="1" name="quality" type="float" default="0.75" />
 			<description>
-				Saves the image as a WebP (Web Picture) file to a byte array. By default it will save lossless. If [param lossy] is true, the image will be saved lossy, using the [param quality] setting between 0.0 and 1.0 (inclusive).
+				Saves the image as a WebP (Web Picture) file to a byte array. This format generally provides a better file-size-to-quality ratio compared to JPEG and PNG. By default, [method save_webp_to_buffer] saves with lossless compression. If [param lossy] is [code]true[/code], the image will be saved with lossy compression using the specified [param quality] between [code]0.0[/code] and [code]1.0[/code] (inclusive). Note that lossy compression at quality [code]1.0[/code] still has visible degradation, unlike lossless compression.
 			</description>
 		</method>
 		<method name="set_data">

--- a/modules/tinyexr/config.py
+++ b/modules/tinyexr/config.py
@@ -3,4 +3,15 @@ def can_build(env, platform):
 
 
 def configure(env):
-    pass
+    from SCons.Script import BoolVariable, Variables, Help
+
+    envvars = Variables()
+    envvars.Add(
+        BoolVariable(
+            "tinyexr_export_templates",
+            "Enable saving and loading OpenEXR images in export template builds (increases binary size)",
+            False,
+        )
+    )
+    envvars.Update(env)
+    Help(envvars.GenerateHelpText(env))

--- a/modules/tinyexr/config.py
+++ b/modules/tinyexr/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return env.editor_build
+    return env.editor_build or env["tinyexr_export_templates"]
 
 
 def configure(env):


### PR DESCRIPTION
- Related to https://github.com/godotengine/godot/pull/72729.

After enabling the tinyexr module at build-time by passing the `tinyexr_export_templates=yes` SCons option, this makes it possible to use `Image.save_exr()` in export templates. When the module is enabled, `Image.load()` can also be used to load images in OpenEXR format.

When tinyexr is enabled in an export template, binary size is about 100 KB larger (stripped on Linux x86_64). As a result, this remains disabled by default.

- See https://github.com/godotengine/godot/issues/71505.
