### PR TITLE
Properly reset blend mode when resetting canvas in compatibility renderer

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -2259,6 +2259,7 @@ void RasterizerCanvasGLES3::reset_canvas() {
 	glDisable(GL_DEPTH_TEST);
 	glDisable(GL_SCISSOR_TEST);
 	glEnable(GL_BLEND);
+	glBlendEquation(GL_FUNC_ADD);
 	glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
 
 	glActiveTexture(GL_TEXTURE0 + GLES3::Config::get_singleton()->max_texture_image_units - 2);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/72488
Fixes: https://github.com/godotengine/godot/issues/72918

When using BLEND_SUB the blend equation is changed, so it needs to be reset before rendering. In 3D it is already reset before rendering happens