### PR TITLE
Fix navigation support for multilayered TileMaps

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -168,6 +168,15 @@
 				Returns the number of layers in the TileMap.
 			</description>
 		</method>
+		<method name="get_navigation_map" qualifiers="const">
+			<return type="RID" />
+			<param index="0" name="layer" type="int" />
+			<description>
+				Returns the [NavigationServer2D] navigation map [RID] currently assigned to the specified TileMap [param layer].
+				By default the TileMap uses the default [World2D] navigation map for the first TileMap layer. For each additional TileMap layer a new navigation map is created for the additional layer.
+				In order to make [NavigationAgent2D] switch between TileMap layer navigation maps use [method NavigationAgent2D.set_navigation_map] with the navigation map received from [method get_navigation_map].
+			</description>
+		</method>
 		<method name="get_neighbor_cell" qualifiers="const">
 			<return type="Vector2i" />
 			<param index="0" name="coords" type="Vector2i" />
@@ -364,6 +373,16 @@
 			<description>
 				Sets a layers Z-index value. This Z-index is added to each tile's Z-index value.
 				If [code]layer[/code] is negative, the layers are accessed from the last one.
+			</description>
+		</method>
+		<method name="set_navigation_map">
+			<return type="void" />
+			<param index="0" name="layer" type="int" />
+			<param index="1" name="map" type="RID" />
+			<description>
+				Assigns a [NavigationServer2D] navigation map [RID] to the specified TileMap [param layer].
+				By default the TileMap uses the default [World2D] navigation map for the first TileMap layer. For each additional TileMap layer a new navigation map is created for the additional layer.
+				In order to make [NavigationAgent2D] switch between TileMap layer navigation maps use [method NavigationAgent2D.set_navigation_map] with the navigation map received from [method get_navigation_map].
 			</description>
 		</method>
 		<method name="set_pattern">

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -752,6 +752,20 @@ TileMap::VisibilityMode TileMap::get_navigation_visibility_mode() {
 	return navigation_visibility_mode;
 }
 
+void TileMap::set_navigation_map(int p_layer, RID p_map) {
+	ERR_FAIL_INDEX(p_layer, (int)layers.size());
+
+	layers[p_layer].navigation_map = p_map;
+}
+
+RID TileMap::get_navigation_map(int p_layer) const {
+	ERR_FAIL_INDEX_V(p_layer, (int)layers.size(), RID());
+	if (layers[p_layer].navigation_map.is_valid()) {
+		return layers[p_layer].navigation_map;
+	}
+	return RID();
+}
+
 void TileMap::set_y_sort_enabled(bool p_enable) {
 	Node2D::set_y_sort_enabled(p_enable);
 	_clear_internals();
@@ -897,6 +911,9 @@ void TileMap::_recreate_layer_internals(int p_layer) {
 	// Update the layer internals.
 	_rendering_update_layer(p_layer);
 
+	// Update the layer internal navigation maps.
+	_navigation_update_layer(p_layer);
+
 	// Recreate the quadrants.
 	const HashMap<Vector2i, TileMapCell> &tile_map = layers[p_layer].tile_map;
 	for (const KeyValue<Vector2i, TileMapCell> &E : tile_map) {
@@ -958,6 +975,9 @@ void TileMap::_clear_layer_internals(int p_layer) {
 
 	// Clear the layers internals.
 	_rendering_cleanup_layer(p_layer);
+
+	// Clear the layers internal navigation maps.
+	_navigation_cleanup_layer(p_layer);
 
 	// Clear the dirty quadrants list.
 	while (layers[p_layer].dirty_quadrant_list.first()) {
@@ -1080,6 +1100,36 @@ void TileMap::_rendering_notification(int p_what) {
 				}
 			}
 		} break;
+	}
+}
+
+void TileMap::_navigation_update_layer(int p_layer) {
+	ERR_FAIL_INDEX(p_layer, (int)layers.size());
+	ERR_FAIL_NULL(NavigationServer2D::get_singleton());
+
+	if (!layers[p_layer].navigation_map.is_valid()) {
+		if (p_layer == 0 && is_inside_tree()) {
+			// Use the default World2D navigation map for the first layer when empty.
+			layers[p_layer].navigation_map = get_world_2d()->get_navigation_map();
+		} else {
+			RID new_layer_map = NavigationServer2D::get_singleton()->map_create();
+			NavigationServer2D::get_singleton()->map_set_active(new_layer_map, true);
+			layers[p_layer].navigation_map = new_layer_map;
+		}
+	}
+}
+
+void TileMap::_navigation_cleanup_layer(int p_layer) {
+	ERR_FAIL_INDEX(p_layer, (int)layers.size());
+	ERR_FAIL_NULL(NavigationServer2D::get_singleton());
+
+	if (layers[p_layer].navigation_map.is_valid()) {
+		if (is_inside_tree() && layers[p_layer].navigation_map == get_world_2d()->get_navigation_map()) {
+			// Do not delete the World2D default navigation map.
+			return;
+		}
+		NavigationServer2D::get_singleton()->free(layers[p_layer].navigation_map);
+		layers[p_layer].navigation_map = RID();
 	}
 }
 
@@ -1732,6 +1782,9 @@ void TileMap::_navigation_update_dirty_quadrants(SelfList<TileMapQuadrant>::List
 					q.navigation_regions[E_cell].resize(tile_set->get_navigation_layers_count());
 
 					for (int layer_index = 0; layer_index < tile_set->get_navigation_layers_count(); layer_index++) {
+						if (layer_index >= (int)layers.size() || !layers[layer_index].navigation_map.is_valid()) {
+							continue;
+						}
 						Ref<NavigationPolygon> navigation_polygon;
 						navigation_polygon = tile_data->get_navigation_polygon(layer_index);
 
@@ -1741,7 +1794,7 @@ void TileMap::_navigation_update_dirty_quadrants(SelfList<TileMapQuadrant>::List
 
 							RID region = NavigationServer2D::get_singleton()->region_create();
 							NavigationServer2D::get_singleton()->region_set_owner_id(region, get_instance_id());
-							NavigationServer2D::get_singleton()->region_set_map(region, get_world_2d()->get_navigation_map());
+							NavigationServer2D::get_singleton()->region_set_map(region, layers[layer_index].navigation_map);
 							NavigationServer2D::get_singleton()->region_set_transform(region, tilemap_xform * tile_transform);
 							NavigationServer2D::get_singleton()->region_set_navigation_layers(region, tile_set->get_navigation_layer_layers(layer_index));
 							NavigationServer2D::get_singleton()->region_set_navigation_polygon(region, navigation_polygon);
@@ -4030,6 +4083,9 @@ void TileMap::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_navigation_visibility_mode", "navigation_visibility_mode"), &TileMap::set_navigation_visibility_mode);
 	ClassDB::bind_method(D_METHOD("get_navigation_visibility_mode"), &TileMap::get_navigation_visibility_mode);
+
+	ClassDB::bind_method(D_METHOD("set_navigation_map", "layer", "map"), &TileMap::set_navigation_map);
+	ClassDB::bind_method(D_METHOD("get_navigation_map", "layer"), &TileMap::get_navigation_map);
 
 	ClassDB::bind_method(D_METHOD("set_cell", "layer", "coords", "source_id", "atlas_coords", "alternative_tile"), &TileMap::set_cell, DEFVAL(TileSet::INVALID_SOURCE), DEFVAL(TileSetSource::INVALID_ATLAS_COORDS), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("erase_cell", "layer", "coords"), &TileMap::erase_cell);

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -211,6 +211,7 @@ private:
 		HashMap<Vector2i, TileMapCell> tile_map;
 		HashMap<Vector2i, TileMapQuadrant> quadrant_map;
 		SelfList<TileMapQuadrant>::List dirty_quadrant_list;
+		RID navigation_map;
 	};
 	LocalVector<TileMapLayer> layers;
 	int selected_layer = -1;
@@ -259,6 +260,8 @@ private:
 	void _physics_draw_quadrant_debug(TileMapQuadrant *p_quadrant);
 
 	void _navigation_notification(int p_what);
+	void _navigation_update_layer(int p_layer);
+	void _navigation_cleanup_layer(int p_layer);
 	void _navigation_update_dirty_quadrants(SelfList<TileMapQuadrant>::List &r_dirty_quadrant_list);
 	void _navigation_cleanup_quadrant(TileMapQuadrant *p_quadrant);
 	void _navigation_draw_quadrant_debug(TileMapQuadrant *p_quadrant);
@@ -338,6 +341,9 @@ public:
 
 	void set_navigation_visibility_mode(VisibilityMode p_show_navigation);
 	VisibilityMode get_navigation_visibility_mode();
+
+	void set_navigation_map(int p_layer, RID p_map);
+	RID get_navigation_map(int p_layer) const;
 
 	// Cells accessors.
 	void set_cell(int p_layer, const Vector2i &p_coords, int p_source_id = TileSet::INVALID_SOURCE, const Vector2i p_atlas_coords = TileSetSource::INVALID_ATLAS_COORDS, int p_alternative_tile = 0);


### PR DESCRIPTION
Fixes navigation support for multilayered TileMaps by automatically creating dedicated navigation maps for each layer. Each navigation map holds the TileSet designed navigation polygons for navigation regions on that specific TileMap layer.

Fixes https://github.com/godotengine/godot/issues/69743 and properly other TileMap navigation issues that expected the TileMap layer layers system to work with navigation.

Mesh based navigation compared to pure point graphs like e.g. AStar2D has the core limitation that edges can not overlap or intersect, at least not when they should be merged and the navigation should make any sense. The TileMap was throwing every navigation polygon from all TileMap layers on the same navigation map creating conflicts between all the polygons.

Now with dedicated navigation maps for each layer this conflict problem does no longer exist and users can quickly receive the map for a layer from the TileMap and assign it for usage to a NavigationAgent2D whenever they switch their 2D actors logically  between the "vertical" TileMap layers.

``` gdscript
var navigation_agent : NavigationAgent2D
var tile_map : TileMap

var tile_map_layer_lower_level : int = 0
var tile_map_layer_upper_level : int = 1

...

func use_stair_to_upper_level_function(): 
    navigation_agent.set_navigation_map(tile_map.get_navigation_map(tile_map_layer_upper_level))

...

func jump_down_to_lower_level_function():
    navigation_agent.set_navigation_map(tile_map.get_navigation_map(tile_map_layer_lower_level))

```

This solution has the added bonus that it not only works for navigation pathfinding and server region sync but also for avoidance. Agents on different navigation maps will not avoid each other through "floors" even if they are close or on top of each other on the "vertical TileMap layers. Since the NavigationServer does not process update unchanged maps it can also help with navigation map sync performance when regions are changed at runtime.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
