### PR TITLE
Implement an `AB_TEST()` macro for automated performance comparisons between alternative versions of a code block

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -519,6 +519,9 @@
 		<member name="debug/gdscript/warnings/unused_variable" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a local variable is unused.
 		</member>
+		<member name="debug/performance/include_ab_tests" type="String" setter="" getter="" default="&quot;&quot;">
+			Enable A/B testing of engine code matching the supplied glob pattern.
+		</member>
 		<member name="debug/settings/crash_handler/message" type="String" setter="" getter="" default="&quot;Please include this when reporting the bug to the project developer.&quot;">
 			Message to be displayed before the backtrace when the engine crashes. By default, this message is only used in exported projects due to the editor-only override applied to this setting.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1799,6 +1799,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	Engine::get_singleton()->set_physics_jitter_fix(GLOBAL_DEF("physics/common/physics_jitter_fix", 0.5));
 	Engine::get_singleton()->set_max_fps(GLOBAL_DEF(PropertyInfo(Variant::INT, "application/run/max_fps", PROPERTY_HINT_RANGE, "0,1000,1"), 0));
 
+	GLOBAL_DEF("debug/performance/include_ab_tests", "");
+
 	GLOBAL_DEF("debug/settings/stdout/print_fps", false);
 	GLOBAL_DEF("debug/settings/stdout/print_gpu_profile", false);
 	GLOBAL_DEF("debug/settings/stdout/verbose_stdout", false);


### PR DESCRIPTION
This macro creates two copies of the supplied code block, one with the `constexpr bool VERSION_A` set to true, and one with it set to false.

Example usage:
```diff
index c6fdd71f52..637aa6047e 100644
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3079,7 +3179,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 
 	scene_cull_result.clear();
 
-	{
+	AB_TEST(true, {
 		uint64_t cull_from = 0;
 		uint64_t cull_to = scenario->instance_data.size();
 
@@ -3095,11 +3195,8 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 		cull_data.occlusion_buffer = RendererSceneOcclusionCull::get_singleton()->buffer_get_ptr(p_viewport);
 		cull_data.camera_matrix = &p_camera_data->main_projection;
 		cull_data.visibility_viewport_mask = scenario->viewport_visibility_masks.has(p_viewport) ? scenario->viewport_visibility_masks[p_viewport] : 0;
-		if (WorkerThreadPool::get_singleton()->should_multithread(cull_to / 4)) {
+		if (VERSION_A) {
 			//multiple threads
			for (InstanceCullResult &thread : scene_cull_result_threads) {
				thread.clear();
			}

			WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &RendererSceneCull::_scene_cull_threaded, &cull_data, scene_cull_result_threads.size(), -1, true, SNAME("RenderCullInstances"));
			WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);

			for (InstanceCullResult &thread : scene_cull_result_threads) {
				scene_cull_result.append_from(thread);
			}

		} else {
			//single threaded
			_scene_cull(cull_data, scene_cull_result, cull_from, cull_to);
		}
@@ -3117,21 +3214,13 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 		if (scene_cull_result.mesh_instances.size()) {
 			for (uint64_t i = 0; i < scene_cull_result.mesh_instances.size(); i++) {
 				RSG::mesh_storage->mesh_instance_check_for_update(scene_cull_result.mesh_instances[i]);
 			}
 			RSG::mesh_storage->update_mesh_instances();
 		}
-	}
+	});
 
 	//render shadows
```

At runtime, it will repeatedly alternate between running the two versions, reporting the average performance difference every few seconds and emitting a warning if the slower version was configured to run by default.

Sample output, `GODOT_THREADING_WORKER_POOL_MAX_THREADS=4`
```shell
found GODOT_DEBUG_PERFORMANCE_INCLUDE_AB_TESTS=*
* matched servers/rendering/renderer_scene_cull.cpp: y

_render_scene()    servers/rendering/renderer_scene_cull.cpp:3223
    A=2.61 ms    B=3.47 ms    Version A is 32.61% faster

_render_scene()    servers/rendering/renderer_scene_cull.cpp:3223
    A=2.50 ms    B=3.50 ms    Version A is 40.13% faster

_render_scene()    servers/rendering/renderer_scene_cull.cpp:3223
    A=2.67 ms    B=4.19 ms    Version A is 56.67% faster
```

Sample output, `GODOT_THREADING_WORKER_POOL_MAX_THREADS=1`
```shell
found GODOT_DEBUG_PERFORMANCE_INCLUDE_AB_TESTS=*
* matched servers/rendering/renderer_scene_cull.cpp: y

_render_scene()    servers/rendering/renderer_scene_cull.cpp:3223
    A=3.53 ms    B=3.36 ms    Version B is 4.97% faster
WARNING: The default version is slower. Please swap the first parameter to AB_TEST(false, ...)
     at: ~ABTester (servers/rendering/renderer_scene_cull.cpp:3039)

_render_scene()    servers/rendering/renderer_scene_cull.cpp:3223
    A=3.50 ms    B=3.48 ms    Version B is 0.60% faster
WARNING: The default version is slower. Please swap the first parameter to AB_TEST(false, ...)
     at: ~ABTester (servers/rendering/renderer_scene_cull.cpp:3039)

_render_scene()    servers/rendering/renderer_scene_cull.cpp:3223
    A=3.57 ms    B=3.45 ms    Version B is 3.39% faster
WARNING: The default version is slower. Please swap the first parameter to AB_TEST(false, ...)
     at: ~ABTester (servers/rendering/renderer_scene_cull.cpp:3039)
```

As a side benefit, any flickering caused by this swapping would act as a simple indicator that one of the versions likely has a bug.

To configure this behavior, this creates a new project setting `debug/performance/include_ab_tests`, which accepts a glob string. Only matching AB tests will behave as above, otherwise it will simply run the configured default version.
