### PR TITLE
Add some missing translatable editor strings

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1186,14 +1186,14 @@ static const char *_joy_button_descriptions[(size_t)JoyButton::SDL_MAX] = {
 };
 
 String InputEventJoypadButton::as_text() const {
-	String text = "Joypad Button " + itos((int64_t)button_index);
+	String text = vformat(RTR("Joypad Button %d"), (int64_t)button_index);
 
 	if (button_index > JoyButton::INVALID && button_index < JoyButton::SDL_MAX) {
-		text += vformat(" (%s)", _joy_button_descriptions[(size_t)button_index]);
+		text += vformat(" (%s)", TTRGET(_joy_button_descriptions[(size_t)button_index]));
 	}
 
 	if (pressure != 0) {
-		text += ", Pressure:" + String(Variant(pressure));
+		text += ", " + RTR("Pressure:") + " " + String(Variant(pressure));
 	}
 
 	return text;

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -890,7 +890,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	hbc->add_child(autoload_add_path);
 	autoload_add_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	autoload_add_path->set_clear_button_enabled(true);
-	autoload_add_path->set_placeholder(vformat(TTR(R"(Set path or press "%s" to create a script.)"), TTR("Add")));
+	autoload_add_path->set_placeholder(vformat(TTR("Set path or press \"%s\" to create a script."), TTR("Add")));
 	autoload_add_path->connect("text_changed", callable_mp(this, &EditorAutoloadSettings::_autoload_path_text_changed));
 
 	browse_button = memnew(Button);

--- a/editor/editor_locale_dialog.cpp
+++ b/editor/editor_locale_dialog.cpp
@@ -294,7 +294,7 @@ void EditorLocaleDialog::_update_tree() {
 
 	if (!is_edit_mode) {
 		TreeItem *t = script_list->create_item(s_root);
-		t->set_text(0, "[Default]");
+		t->set_text(0, TTR("[Default]"));
 		t->set_metadata(0, "");
 	}
 
@@ -404,7 +404,7 @@ EditorLocaleDialog::EditorLocaleDialog() {
 		}
 		{
 			edit_filters = memnew(CheckButton);
-			edit_filters->set_text("Edit Filters");
+			edit_filters->set_text(TTR("Edit Filters"));
 			edit_filters->set_toggle_mode(true);
 			edit_filters->set_pressed(false);
 			edit_filters->connect("toggled", callable_mp(this, &EditorLocaleDialog::_edit_filters));
@@ -412,7 +412,7 @@ EditorLocaleDialog::EditorLocaleDialog() {
 		}
 		{
 			advanced = memnew(CheckButton);
-			advanced->set_text("Advanced");
+			advanced->set_text(TTR("Advanced"));
 			advanced->set_toggle_mode(true);
 			advanced->set_pressed(false);
 			advanced->connect("toggled", callable_mp(this, &EditorLocaleDialog::_toggle_advanced));

--- a/editor/event_listener_line_edit.cpp
+++ b/editor/event_listener_line_edit.cpp
@@ -105,7 +105,8 @@ String EventListenerLineEdit::get_event_text(const Ref<InputEvent> &p_event, boo
 			desc = RTR(_joy_axis_descriptions[2 * (size_t)jp_motion->get_axis() + (jp_motion->get_axis_value() < 0 ? 0 : 1)]);
 		}
 
-		text = vformat("Joypad Axis %s %s (%s)", itos((int64_t)jp_motion->get_axis()), jp_motion->get_axis_value() < 0 ? "-" : "+", desc);
+		// TRANSLATORS: %d is the axis number, the first %s is either "-" or "+", and the second %s is the description of the axis.
+		text = vformat(TTR("Joypad Axis %d %s (%s)"), (int64_t)jp_motion->get_axis(), jp_motion->get_axis_value() < 0 ? "-" : "+", desc);
 	}
 	if (p_include_device && (mouse.is_valid() || jp_button.is_valid() || jp_motion.is_valid())) {
 		String device_string = get_device_string(p_event->get_device());

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -36,7 +36,9 @@
 #include "editor/editor_inspector.h"
 #include "editor/editor_locale_dialog.h"
 #include "editor/editor_node.h"
+#include "editor/editor_property_name_processor.h"
 #include "editor/editor_scale.h"
+#include "editor/editor_settings.h"
 
 /*************************************************************************/
 /* Settings data                                                         */
@@ -926,6 +928,15 @@ void DynamicFontImportSettings::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			add_var->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 		} break;
+
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/localize_settings")) {
+				EditorPropertyNameProcessor::Style style = EditorPropertyNameProcessor::get_singleton()->get_settings_style();
+				inspector_general->set_property_name_style(style);
+				inspector_vars->set_property_name_style(style);
+				inspector_text->set_property_name_style(style);
+			}
+		} break;
 	}
 }
 
@@ -1334,6 +1345,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	inspector_general->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector_general->set_custom_minimum_size(Size2(300 * EDSCALE, 250 * EDSCALE));
 	inspector_general->connect("property_edited", callable_mp(this, &DynamicFontImportSettings::_main_prop_changed));
+	inspector_general->set_property_name_style(EditorPropertyNameProcessor::get_singleton()->get_settings_style());
 	page1_hb->add_child(inspector_general);
 
 	// Page 2 layout: Configurations
@@ -1386,6 +1398,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	inspector_vars = memnew(EditorInspector);
 	inspector_vars->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector_vars->connect("property_edited", callable_mp(this, &DynamicFontImportSettings::_variation_changed));
+	inspector_vars->set_property_name_style(EditorPropertyNameProcessor::get_singleton()->get_settings_style());
 	page2_side_vb->add_child(inspector_vars);
 
 	VBoxContainer *preload_pages_vb = memnew(VBoxContainer);
@@ -1461,6 +1474,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	inspector_text->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector_text->set_custom_minimum_size(Size2(300 * EDSCALE, 250 * EDSCALE));
 	inspector_text->connect("property_edited", callable_mp(this, &DynamicFontImportSettings::_change_text_opts));
+	inspector_text->set_property_name_style(EditorPropertyNameProcessor::get_singleton()->get_settings_style());
 	page2_1_hb->add_child(inspector_text);
 
 	text_edit = memnew(TextEdit);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -961,8 +961,8 @@ public:
 		default_files_container->add_child(l);
 		vcs_metadata_selection = memnew(OptionButton);
 		vcs_metadata_selection->set_custom_minimum_size(Size2(100, 20));
-		vcs_metadata_selection->add_item("None", (int)EditorVCSInterface::VCSMetadata::NONE);
-		vcs_metadata_selection->add_item("Git", (int)EditorVCSInterface::VCSMetadata::GIT);
+		vcs_metadata_selection->add_item(TTR("None"), (int)EditorVCSInterface::VCSMetadata::NONE);
+		vcs_metadata_selection->add_item(TTR("Git"), (int)EditorVCSInterface::VCSMetadata::GIT);
 		vcs_metadata_selection->select((int)EditorVCSInterface::VCSMetadata::GIT);
 		default_files_container->add_child(vcs_metadata_selection);
 		Control *spacer = memnew(Control);

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -199,7 +199,7 @@ void AnimationPlayer::_validate_property(PropertyInfo &p_property) const {
 void AnimationPlayer::_get_property_list(List<PropertyInfo> *p_list) const {
 	List<PropertyInfo> anim_names;
 
-	anim_names.push_back(PropertyInfo(Variant::DICTIONARY, "libraries"));
+	anim_names.push_back(PropertyInfo(Variant::DICTIONARY, PNAME("libraries")));
 
 	for (const KeyValue<StringName, AnimationData> &E : animation_set) {
 		if (E.value.next != StringName()) {


### PR DESCRIPTION
I did a proofread of the editor since the Chinese translation for editor strings reached 100%. I noticed errors like strings missing `TTR` macros.

A new discovery is that C++ raw string literals can't be used for extraction because the extraction script needs pre-escaped strings.

Note for `InputEventJoypadButton::as_text()`: This function assembles a sentence according to event properties. It's hard to i18n it properly without changing how the text is structured I think. But fortunately, it's only used as button description in the Event Configuration dialog. So it's probably fine to translate segment by segment for now.

https://github.com/godotengine/godot/blob/929ee61170ec4d431d6d2cfeddccdec2a59a11b7/core/input/input_event.cpp#L1188-L1200

Also made inspectors in Dynamic Font Import Settings respect "Localize Settings" editor setting.
