### PR TITLE
Allow compiling out the navigation module

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -72,6 +72,7 @@
 #include "servers/movie_writer/movie_writer_mjpeg.h"
 #include "servers/navigation_server_2d.h"
 #include "servers/navigation_server_3d.h"
+#include "servers/navigation_server_3d_dummy.h"
 #include "servers/physics_server_2d.h"
 #include "servers/physics_server_3d.h"
 #include "servers/register_server_types.h"
@@ -278,8 +279,21 @@ void finalize_display() {
 void initialize_navigation_server() {
 	ERR_FAIL_COND(navigation_server_3d != nullptr);
 
+	// Init 3D Navigation Server
 	navigation_server_3d = NavigationServer3DManager::new_default_server();
+
+	// Fall back to dummy if no default server has been registered.
+	if (!navigation_server_3d) {
+		WARN_PRINT_ONCE("No NavigationServer3D implementation has been registered! Falling back to a dummy implementation: navigation features will be unavailable.");
+		navigation_server_3d = memnew(NavigationServer3DDummy);
+	}
+
+	// Should be impossible, but make sure it's not null.
+	ERR_FAIL_NULL_MSG(navigation_server_3d, "Failed to initialize NavigationServer3D.");
+
+	// Init 2D Navigation Server
 	navigation_server_2d = memnew(NavigationServer2D);
+	ERR_FAIL_NULL_MSG(navigation_server_2d, "Failed to initialize NavigationServer2D.");
 }
 
 void finalize_navigation_server() {

--- a/servers/navigation/navigation_utilities.h
+++ b/servers/navigation/navigation_utilities.h
@@ -69,10 +69,10 @@ struct PathQueryParameters {
 };
 
 struct PathQueryResult {
-	Vector<Vector3> path;
-	Vector<int32_t> path_types;
+	PackedVector3Array path;
+	PackedInt32Array path_types;
 	TypedArray<RID> path_rids;
-	Vector<int64_t> path_owner_ids;
+	PackedInt64Array path_owner_ids;
 };
 
 } //namespace NavigationUtilities

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -225,6 +225,7 @@ public:
 	/// Callback called at the end of the RVO process
 	virtual void agent_set_callback(RID p_agent, Callable p_callback);
 
+	/// Returns a customized navigation path using a query parameters object
 	virtual void query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result) const;
 
 	/// Destroy the `RID`

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -29,7 +29,6 @@
 /**************************************************************************/
 
 #include "navigation_server_3d.h"
-
 #include "core/config/project_settings.h"
 
 NavigationServer3D *NavigationServer3D::singleton = nullptr;
@@ -184,17 +183,6 @@ NavigationServer3D::NavigationServer3D() {
 
 NavigationServer3D::~NavigationServer3D() {
 	singleton = nullptr;
-}
-
-NavigationServer3DCallback NavigationServer3DManager::create_callback = nullptr;
-
-void NavigationServer3DManager::set_default_server(NavigationServer3DCallback p_callback) {
-	create_callback = p_callback;
-}
-
-NavigationServer3D *NavigationServer3DManager::new_default_server() {
-	ERR_FAIL_COND_V(create_callback == nullptr, nullptr);
-	return create_callback();
 }
 
 #ifdef DEBUG_ENABLED
@@ -594,8 +582,6 @@ bool NavigationServer3D::get_debug_navigation_enable_agent_paths_xray() const {
 
 #endif // DEBUG_ENABLED
 
-///////////////////////////////////////////////////////
-
 void NavigationServer3D::query_path(const Ref<NavigationPathQueryParameters3D> &p_query_parameters, Ref<NavigationPathQueryResult3D> p_query_result) const {
 	ERR_FAIL_COND(!p_query_parameters.is_valid());
 	ERR_FAIL_COND(!p_query_result.is_valid());
@@ -606,4 +592,20 @@ void NavigationServer3D::query_path(const Ref<NavigationPathQueryParameters3D> &
 	p_query_result->set_path_types(_query_result.path_types);
 	p_query_result->set_path_rids(_query_result.path_rids);
 	p_query_result->set_path_owner_ids(_query_result.path_owner_ids);
+}
+
+///////////////////////////////////////////////////////
+
+NavigationServer3DCallback NavigationServer3DManager::create_callback = nullptr;
+
+void NavigationServer3DManager::set_default_server(NavigationServer3DCallback p_callback) {
+	create_callback = p_callback;
+}
+
+NavigationServer3D *NavigationServer3DManager::new_default_server() {
+	if (create_callback == nullptr) {
+		return nullptr;
+	}
+
+	return create_callback();
 }

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -253,12 +253,12 @@ public:
 	virtual void process(real_t delta_time) = 0;
 
 	/// Returns a customized navigation path using a query parameters object
-	void query_path(const Ref<NavigationPathQueryParameters3D> &p_query_parameters, Ref<NavigationPathQueryResult3D> p_query_result) const;
+	virtual void query_path(const Ref<NavigationPathQueryParameters3D> &p_query_parameters, Ref<NavigationPathQueryResult3D> p_query_result) const;
 
 	virtual NavigationUtilities::PathQueryResult _query_path(const NavigationUtilities::PathQueryParameters &p_parameters) const = 0;
 
 	NavigationServer3D();
-	virtual ~NavigationServer3D();
+	~NavigationServer3D() override;
 
 	enum ProcessInfo {
 		INFO_ACTIVE_MAPS,

--- a/servers/navigation_server_3d_dummy.h
+++ b/servers/navigation_server_3d_dummy.h
@@ -1,0 +1,117 @@
+/**************************************************************************/
+/*  navigation_server_3d_dummy.h                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef NAVIGATION_SERVER_3D_DUMMY_H
+#define NAVIGATION_SERVER_3D_DUMMY_H
+
+#include "servers/navigation_server_3d.h"
+
+class NavigationServer3DDummy : public NavigationServer3D {
+	GDCLASS(NavigationServer3DDummy, NavigationServer3D);
+
+public:
+	TypedArray<RID> get_maps() const override { return TypedArray<RID>(); }
+	RID map_create() override { return RID(); }
+	void map_set_active(RID p_map, bool p_active) override {}
+	bool map_is_active(RID p_map) const override { return false; }
+	void map_set_up(RID p_map, Vector3 p_up) override {}
+	Vector3 map_get_up(RID p_map) const override { return Vector3(); }
+	void map_set_cell_size(RID p_map, real_t p_cell_size) override {}
+	real_t map_get_cell_size(RID p_map) const override { return 0; }
+	void map_set_edge_connection_margin(RID p_map, real_t p_connection_margin) override {}
+	real_t map_get_edge_connection_margin(RID p_map) const override { return 0; }
+	void map_set_link_connection_radius(RID p_map, real_t p_connection_radius) override {}
+	real_t map_get_link_connection_radius(RID p_map) const override { return 0; }
+	Vector<Vector3> map_get_path(RID p_map, Vector3 p_origin, Vector3 p_destination, bool p_optimize, uint32_t p_navigation_layers) const override { return Vector<Vector3>(); }
+	Vector3 map_get_closest_point_to_segment(RID p_map, const Vector3 &p_from, const Vector3 &p_to, const bool p_use_collision) const override { return Vector3(); }
+	Vector3 map_get_closest_point(RID p_map, const Vector3 &p_point) const override { return Vector3(); }
+	Vector3 map_get_closest_point_normal(RID p_map, const Vector3 &p_point) const override { return Vector3(); }
+	RID map_get_closest_point_owner(RID p_map, const Vector3 &p_point) const override { return RID(); }
+	TypedArray<RID> map_get_links(RID p_map) const override { return TypedArray<RID>(); }
+	TypedArray<RID> map_get_regions(RID p_map) const override { return TypedArray<RID>(); }
+	TypedArray<RID> map_get_agents(RID p_map) const override { return TypedArray<RID>(); }
+	void map_force_update(RID p_map) override {}
+	RID region_create() override { return RID(); }
+	void region_set_enter_cost(RID p_region, real_t p_enter_cost) override {}
+	real_t region_get_enter_cost(RID p_region) const override { return 0; }
+	void region_set_travel_cost(RID p_region, real_t p_travel_cost) override {}
+	real_t region_get_travel_cost(RID p_region) const override { return 0; }
+	void region_set_owner_id(RID p_region, ObjectID p_owner_id) override {}
+	ObjectID region_get_owner_id(RID p_region) const override { return ObjectID(); }
+	bool region_owns_point(RID p_region, const Vector3 &p_point) const override { return false; }
+	void region_set_map(RID p_region, RID p_map) override {}
+	RID region_get_map(RID p_region) const override { return RID(); }
+	void region_set_navigation_layers(RID p_region, uint32_t p_navigation_layers) override {}
+	uint32_t region_get_navigation_layers(RID p_region) const override { return 0; }
+	void region_set_transform(RID p_region, Transform3D p_transform) override {}
+	void region_set_navigation_mesh(RID p_region, Ref<NavigationMesh> p_navigation_mesh) override {}
+	void region_bake_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node) override {}
+	int region_get_connections_count(RID p_region) const override { return 0; }
+	Vector3 region_get_connection_pathway_start(RID p_region, int p_connection_id) const override { return Vector3(); }
+	Vector3 region_get_connection_pathway_end(RID p_region, int p_connection_id) const override { return Vector3(); }
+	RID link_create() override { return RID(); }
+	void link_set_map(RID p_link, RID p_map) override {}
+	RID link_get_map(RID p_link) const override { return RID(); }
+	void link_set_bidirectional(RID p_link, bool p_bidirectional) override {}
+	bool link_is_bidirectional(RID p_link) const override { return false; }
+	void link_set_navigation_layers(RID p_link, uint32_t p_navigation_layers) override {}
+	uint32_t link_get_navigation_layers(RID p_link) const override { return 0; }
+	void link_set_start_position(RID p_link, Vector3 p_position) override {}
+	Vector3 link_get_start_position(RID p_link) const override { return Vector3(); }
+	void link_set_end_position(RID p_link, Vector3 p_position) override {}
+	Vector3 link_get_end_position(RID p_link) const override { return Vector3(); }
+	void link_set_enter_cost(RID p_link, real_t p_enter_cost) override {}
+	real_t link_get_enter_cost(RID p_link) const override { return 0; }
+	void link_set_travel_cost(RID p_link, real_t p_travel_cost) override {}
+	real_t link_get_travel_cost(RID p_link) const override { return 0; }
+	void link_set_owner_id(RID p_link, ObjectID p_owner_id) override {}
+	ObjectID link_get_owner_id(RID p_link) const override { return ObjectID(); }
+	RID agent_create() override { return RID(); }
+	void agent_set_map(RID p_agent, RID p_map) override {}
+	RID agent_get_map(RID p_agent) const override { return RID(); }
+	void agent_set_neighbor_distance(RID p_agent, real_t p_distance) override {}
+	void agent_set_max_neighbors(RID p_agent, int p_count) override {}
+	void agent_set_time_horizon(RID p_agent, real_t p_time) override {}
+	void agent_set_radius(RID p_agent, real_t p_radius) override {}
+	void agent_set_max_speed(RID p_agent, real_t p_max_speed) override {}
+	void agent_set_velocity(RID p_agent, Vector3 p_velocity) override {}
+	void agent_set_target_velocity(RID p_agent, Vector3 p_velocity) override {}
+	void agent_set_position(RID p_agent, Vector3 p_position) override {}
+	void agent_set_ignore_y(RID p_agent, bool p_ignore) override {}
+	bool agent_is_map_changed(RID p_agent) const override { return false; }
+	void agent_set_callback(RID p_agent, Callable p_callback) override {}
+	void free(RID p_object) override {}
+	void set_active(bool p_active) override {}
+	void process(real_t delta_time) override {}
+	NavigationUtilities::PathQueryResult _query_path(const NavigationUtilities::PathQueryParameters &p_parameters) const override { return NavigationUtilities::PathQueryResult(); }
+	int get_process_info(ProcessInfo p_info) const override { return 0; }
+};
+
+#endif // NAVIGATION_SERVER_3D_DUMMY_H


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/36091

Alternative to #69881 

This is a stripped down version of #69881 which addresses the core problem of not being able to compile Godot without the navigation module, without the complexity of supporting GDExtension nor introducing a project setting for changing the server implementation.

It leaves the existing system for registering navigation servers alone and mainly updates `main.cpp` to check if no server has been registered and if so, swapping it out for a dummy implementation instead of throwing an error.  Since there is always a dummy implementation compiled, the linker will always find an implementation of `NavigationServer3D` and won't fail to link if the module is missing.

There are a few housekeeping items also in this PR, mostly swaps to equivalent types for readability, additional comments, missing `override` keywords, and a missing `virtual` keyword.

All changes are backwards compatible, with no changes to ClassDB nor any changes to the C++ API shape. We'd like to include this change in 4.0 if possible.