### PR TITLE
GDScript: Remove `treat_warnings_as_errors` project setting

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -474,9 +474,6 @@
 		<member name="debug/gdscript/warnings/static_called_on_instance" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when calling a static method from an instance of a class instead of from the class directly.
 		</member>
-		<member name="debug/gdscript/warnings/treat_warnings_as_errors" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], all warnings will be reported as if they are errors.
-		</member>
 		<member name="debug/gdscript/warnings/unassigned_variable" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when using a variable that wasn't previously assigned.
 		</member>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2578,7 +2578,6 @@ GDScriptLanguage::GDScriptLanguage() {
 
 #ifdef DEBUG_ENABLED
 	GLOBAL_DEF("debug/gdscript/warnings/enable", true);
-	GLOBAL_DEF("debug/gdscript/warnings/treat_warnings_as_errors", false);
 	GLOBAL_DEF("debug/gdscript/warnings/exclude_addons", true);
 	for (int i = 0; i < (int)GDScriptWarning::WARNING_MAX; i++) {
 		GDScriptWarning::Code code = (GDScriptWarning::Code)i;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -175,7 +175,7 @@ void GDScriptParser::push_warning(const Node *p_source, GDScriptWarning::Code p_
 	warning.leftmost_column = p_source->leftmost_column;
 	warning.rightmost_column = p_source->rightmost_column;
 
-	if (warn_level == GDScriptWarning::WarnLevel::ERROR || bool(GLOBAL_GET("debug/gdscript/warnings/treat_warnings_as_errors"))) {
+	if (warn_level == GDScriptWarning::WarnLevel::ERROR) {
 		push_error(warning.get_message() + String(" (Warning treated as error.)"), p_source);
 		return;
 	}


### PR DESCRIPTION
Remove `debug/gdscript/warnings/treat_warnings_as_errors` project setting because it has confusing name and is mostly useless.

1. Some users read this setting as "**allow** warnings to be treated as errors" and not as "treat **all** warnings as errors".
2. This setting is mostly useless as after #59943 each warning can be configured individually.

![](https://user-images.githubusercontent.com/47700418/218029126-391ff2d6-e55d-4f70-bc33-bc7d0808c3b5.png)

3.x for comparison:
![](https://user-images.githubusercontent.com/47700418/218029482-d8f79a68-aee0-41b7-a814-c6012a86ea4d.png)

Closes #72982.