### PR TITLE
Clean up ProjectConverter3To4 architecture, move renames map to separate file

### DIFF
--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -32,1781 +32,19 @@
 
 #ifndef DISABLE_DEPRECATED
 
-const int ERROR_CODE = 77;
-
 #include "modules/modules_enabled.gen.h" // For regex.
 
 #ifdef MODULE_REGEX_ENABLED
 
-#include "modules/regex/regex.h"
-
+#include "core/error/error_macros.h"
 #include "core/io/dir_access.h"
+#include "core/io/file_access.h"
+#include "core/object/ref_counted.h"
 #include "core/os/time.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/list.h"
-#include "core/templates/local_vector.h"
-
-const char *ProjectConverter3To4::enum_renames[][2] = {
-	//// constants
-	{ "TYPE_COLOR_ARRAY", "TYPE_PACKED_COLOR_ARRAY" },
-	{ "TYPE_FLOAT64_ARRAY", "TYPE_PACKED_FLOAT64_ARRAY" },
-	{ "TYPE_INT64_ARRAY", "TYPE_PACKED_INT64_ARRAY" },
-	{ "TYPE_INT_ARRAY", "TYPE_PACKED_INT32_ARRAY" },
-	{ "TYPE_QUAT", "TYPE_QUATERNION" },
-	{ "TYPE_RAW_ARRAY", "TYPE_PACKED_BYTE_ARRAY" },
-	{ "TYPE_REAL", "TYPE_FLOAT" },
-	{ "TYPE_REAL_ARRAY", "TYPE_PACKED_FLOAT32_ARRAY" },
-	{ "TYPE_STRING_ARRAY", "TYPE_PACKED_STRING_ARRAY" },
-	{ "TYPE_TRANSFORM", "TYPE_TRANSFORM3D" },
-	{ "TYPE_VECTOR2_ARRAY", "TYPE_PACKED_VECTOR2_ARRAY" },
-	{ "TYPE_VECTOR3_ARRAY", "TYPE_PACKED_VECTOR3_ARRAY" },
-
-	// {"FLAG_MAX", "PARTICLE_FLAG_MAX"}, // CPUParticles2D - used in more classes
-	{ "ALIGN_BEGIN", "ALIGNMENT_BEGIN" }, //AspectRatioContainer
-	{ "ALIGN_CENTER", "ALIGNMENT_CENTER" }, //AspectRatioContainer
-	{ "ALIGN_END", "ALIGNMENT_END" }, //AspectRatioContainer
-	{ "ARRAY_COMPRESS_BASE", "ARRAY_COMPRESS_FLAGS_BASE" }, // Mesh
-	{ "ARVR_AR", "XR_AR" }, // XRInterface
-	{ "ARVR_EXCESSIVE_MOTION", "XR_EXCESSIVE_MOTION" }, // XRInterface
-	{ "ARVR_EXTERNAL", "XR_EXTERNAL" }, // XRInterface
-	{ "ARVR_INSUFFICIENT_FEATURES", "XR_INSUFFICIENT_FEATURES" }, // XRInterface
-	{ "ARVR_MONO", "XR_MONO" }, // XRInterface
-	{ "ARVR_NONE", "XR_NONE" }, // XRInterface
-	{ "ARVR_NORMAL_TRACKING", "XR_NORMAL_TRACKING" }, // XRInterface
-	{ "ARVR_NOT_TRACKING", "XR_NOT_TRACKING" }, // XRInterface
-	{ "ARVR_STEREO", "XR_STEREO" }, // XRInterface
-	{ "ARVR_UNKNOWN_TRACKING", "XR_UNKNOWN_TRACKING" }, // XRInterface
-	{ "BAKE_ERROR_INVALID_MESH", "BAKE_ERROR_MESHES_INVALID" }, // LightmapGI
-	{ "BODY_MODE_CHARACTER", "BODY_MODE_RIGID_LINEAR" }, // PhysicsServer
-	{ "BUTTON_LEFT", "MOUSE_BUTTON_LEFT" }, // Globals
-	{ "BUTTON_MASK_LEFT", "MOUSE_BUTTON_MASK_LEFT" }, // Globals
-	{ "BUTTON_MASK_MIDDLE", "MOUSE_BUTTON_MASK_MIDDLE" }, // Globals
-	{ "BUTTON_MASK_RIGHT", "MOUSE_BUTTON_MASK_RIGHT" }, // Globals
-	{ "BUTTON_MASK_XBUTTON1", "MOUSE_BUTTON_MASK_XBUTTON1" }, // Globals
-	{ "BUTTON_MASK_XBUTTON2", "MOUSE_BUTTON_MASK_XBUTTON2" }, // Globals
-	{ "BUTTON_MIDDLE", "MOUSE_BUTTON_MIDDLE" }, // Globals
-	{ "BUTTON_RIGHT", "MOUSE_BUTTON_RIGHT" }, // Globals
-	{ "BUTTON_WHEEL_DOWN", "MOUSE_BUTTON_WHEEL_DOWN" }, // Globals
-	{ "BUTTON_WHEEL_LEFT", "MOUSE_BUTTON_WHEEL_LEFT" }, // Globals
-	{ "BUTTON_WHEEL_RIGHT", "MOUSE_BUTTON_WHEEL_RIGHT" }, // Globals
-	{ "BUTTON_WHEEL_UP", "MOUSE_BUTTON_WHEEL_UP" }, // Globals
-	{ "BUTTON_XBUTTON1", "MOUSE_BUTTON_XBUTTON1" }, // Globals
-	{ "BUTTON_XBUTTON2", "MOUSE_BUTTON_XBUTTON2" }, // Globals
-	{ "CLEAR_MODE_ONLY_NEXT_FRAME", "CLEAR_MODE_ONCE" }, // SubViewport
-	{ "COMPRESS_PVRTC4", "COMPRESS_PVRTC1_4" }, // Image
-	{ "CONNECT_ONESHOT", "CONNECT_ONE_SHOT" }, // Object
-	{ "CONTAINER_PROPERTY_EDITOR_BOTTOM", "CONTAINER_INSPECTOR_BOTTOM" }, // EditorPlugin
-	{ "CUBEMAP_BACK", "CUBEMAP_LAYER_BACK" }, // RenderingServer
-	{ "CUBEMAP_BOTTOM", "CUBEMAP_LAYER_BOTTOM" }, // RenderingServer
-	{ "CUBEMAP_FRONT", "CUBEMAP_LAYER_FRONT" }, // RenderingServer
-	{ "CUBEMAP_LEFT", "CUBEMAP_LAYER_LEFT" }, // RenderingServer
-	{ "CUBEMAP_RIGHT", "CUBEMAP_LAYER_RIGHT" }, // RenderingServer
-	{ "CUBEMAP_TOP", "CUBEMAP_LAYER_TOP" }, // RenderingServer
-	{ "DAMPED_STRING_DAMPING", "DAMPED_SPRING_DAMPING" }, // PhysicsServer2D
-	{ "DAMPED_STRING_REST_LENGTH", "DAMPED_SPRING_REST_LENGTH" }, // PhysicsServer2D
-	{ "DAMPED_STRING_STIFFNESS", "DAMPED_SPRING_STIFFNESS" }, // PhysicsServer2D
-	{ "FLAG_ALIGN_Y_TO_VELOCITY", "PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY" }, // CPUParticles2D
-	{ "FLAG_DISABLE_Z", "PARTICLE_FLAG_DISABLE_Z" }, // CPUParticles2D
-	{ "FLAG_ROTATE_Y", "PARTICLE_FLAG_ROTATE_Y" }, // CPUParticles2D
-	{ "FLAG_USE_BAKED_LIGHT", "GI_MODE_BAKED" }, // GeometryInstance3D
-	{ "FORMAT_PVRTC2", "FORMAT_PVRTC1_2" }, // Image
-	{ "FORMAT_PVRTC2A", "FORMAT_PVRTC1_2A" }, // Image
-	{ "FORMAT_PVRTC4", "FORMAT_PVRTC1_4" }, // Image
-	{ "FORMAT_PVRTC4A", "FORMAT_PVRTC1_4A" }, // Image
-	{ "FUNC_FRAC", "FUNC_FRACT" }, // VisualShaderNodeVectorFunc
-	{ "INSTANCE_LIGHTMAP_CAPTURE", "INSTANCE_LIGHTMAP" }, // RenderingServer
-	{ "JOINT_6DOF", "JOINT_TYPE_6DOF" }, // PhysicsServer3D
-	{ "JOINT_CONE_TWIST", "JOINT_TYPE_CONE_TWIST" }, // PhysicsServer3D
-	{ "JOINT_DAMPED_SPRING", "JOINT_TYPE_DAMPED_SPRING" }, // PhysicsServer2D
-	{ "JOINT_GROOVE", "JOINT_TYPE_GROOVE" }, // PhysicsServer2D
-	{ "JOINT_HINGE", "JOINT_TYPE_HINGE" }, // PhysicsServer3D
-	{ "JOINT_PIN", "JOINT_TYPE_PIN" }, // PhysicsServer2D
-	{ "JOINT_SLIDER", "JOINT_TYPE_SLIDER" }, // PhysicsServer3D
-	{ "KEY_CONTROL", "KEY_CTRL" }, // Globals
-	{ "LOOP_PING_PONG", "LOOP_PINGPONG" }, // AudioStreamWAV
-	{ "MODE_KINEMATIC", "FREEZE_MODE_KINEMATIC" }, // RigidBody
-	{ "MODE_OPEN_ANY", "FILE_MODE_OPEN_ANY" }, // FileDialog
-	{ "MODE_OPEN_DIR", "FILE_MODE_OPEN_DIR" }, // FileDialog
-	{ "MODE_OPEN_FILE", "FILE_MODE_OPEN_FILE" }, // FileDialog
-	{ "MODE_OPEN_FILES", "FILE_MODE_OPEN_FILES" }, // FileDialog
-	{ "MODE_SAVE_FILE", "FILE_MODE_SAVE_FILE" }, // FileDialog
-	{ "MODE_STATIC", "FREEZE_MODE_STATIC" }, // RigidBody
-	{ "NOTIFICATION_APP_PAUSED", "NOTIFICATION_APPLICATION_PAUSED" }, // MainLoop
-	{ "NOTIFICATION_APP_RESUMED", "NOTIFICATION_APPLICATION_RESUMED" }, // MainLoop
-	{ "NOTIFICATION_INSTANCED", "NOTIFICATION_SCENE_INSTANTIATED" }, // Node
-	{ "NOTIFICATION_PATH_CHANGED", "NOTIFICATION_PATH_RENAMED" }, //Node
-	{ "NOTIFICATION_WM_FOCUS_IN", "NOTIFICATION_APPLICATION_FOCUS_IN" }, // MainLoop
-	{ "NOTIFICATION_WM_FOCUS_OUT", "NOTIFICATION_APPLICATION_FOCUS_OUT" }, // MainLoop
-	{ "NOTIFICATION_WM_UNFOCUS_REQUEST", "NOTIFICATION_WM_WINDOW_FOCUS_OUT" }, //Node
-	{ "PAUSE_MODE_INHERIT", "PROCESS_MODE_INHERIT" }, // Node
-	{ "PAUSE_MODE_PROCESS", "PROCESS_MODE_ALWAYS" }, // Node
-	{ "PAUSE_MODE_STOP", "PROCESS_MODE_PAUSABLE" }, // Node
-	{ "RENDER_DRAW_CALLS_IN_FRAME", "RENDER_TOTAL_DRAW_CALLS_IN_FRAME" }, // Performance
-	{ "RENDER_OBJECTS_IN_FRAME", "RENDER_TOTAL_OBJECTS_IN_FRAME" }, // Performance
-	{ "SIDE_BOTTOM", "MARGIN_BOTTOM" }, // Globals
-	{ "SIDE_LEFT", "MARGIN_LEFT" }, // Globals
-	{ "SIDE_RIGHT", "MARGIN_RIGHT" }, // Globals
-	{ "SIDE_TOP", "MARGIN_TOP" }, // Globals
-	{ "TEXTURE_TYPE_2D_ARRAY", "TEXTURE_LAYERED_2D_ARRAY" }, // RenderingServer
-	{ "TEXTURE_TYPE_CUBEMAP", "TEXTURE_LAYERED_CUBEMAP_ARRAY" }, // RenderingServer
-	{ "TRACKER_LEFT_HAND", "TRACKER_HAND_LEFT" }, // XRPositionalTracker
-	{ "TRACKER_RIGHT_HAND", "TRACKER_HAND_RIGHT" }, // XRPositionalTracker
-	{ "TYPE_NORMALMAP", "TYPE_NORMAL_MAP" }, // VisualShaderNodeCubemap
-
-	/// enums
-	{ "AlignMode", "AlignmentMode" }, //AspectRatioContainer
-	{ "AnimationProcessMode", "AnimationProcessCallback" }, // AnimationTree, AnimationPlayer
-	{ "Camera2DProcessMode", "Camera2DProcessCallback" }, // Camera2D
-	{ "CubeMapSide", "CubeMapLayer" }, // RenderingServer
-	{ "DampedStringParam", "DampedSpringParam" }, // PhysicsServer2D
-	{ "FFT_Size", "FFTSize" }, // AudioEffectPitchShift,AudioEffectSpectrumAnalyzer
-	{ "PauseMode", "ProcessMode" }, // Node
-	{ "TimerProcessMode", "TimerProcessCallback" }, // Timer
-	{ "Tracking_status", "TrackingStatus" }, // XRInterface
-	{ nullptr, nullptr },
-};
-
-const char *ProjectConverter3To4::gdscript_function_renames[][2] = {
-	// { "_set_name", "get_tracker_name"}, // XRPositionalTracker - CameraFeed use this
-	// { "_unhandled_input", "_unhandled_key_input"}, // BaseButton, ViewportContainer broke Node, FileDialog,SubViewportContainer
-	// { "create_gizmo", "_create_gizmo"}, // EditorNode3DGizmoPlugin - may be used
-	// { "get_dependencies", "_get_dependencies" }, // ResourceFormatLoader broke ResourceLoader
-	// { "get_extents", "get_size" }, // BoxShape, RectangleShape broke Decal, VoxelGI, GPUParticlesCollisionBox, GPUParticlesCollisionSDF, GPUParticlesCollisionHeightField, GPUParticlesAttractorBox, GPUParticlesAttractorVectorField, FogVolume
-	// { "get_h_offset", "get_drag_horizontal_offset"}, // Camera2D, broke PathFollow, Camera
-	// { "get_mode", "get_file_mode"}, // FileDialog broke Panel, Shader, CSGPolygon, Tilemap
-	// { "get_motion", "get_travel"}, // PhysicsTestMotionResult2D broke ParalaxLayer
-	// { "get_name", "get_tracker_name"}, // XRPositionalTracker broke OS, Node
-	// { "get_network_connected_peers", "get_peers"}, // MultiplayerAPI broke SceneTree
-	// { "get_network_peer", "has_multiplayer_peer"}, // MultiplayerAPI broke SceneTree
-	// { "get_network_unique_id", "get_unique_id"}, // MultiplayerAPI broke SceneTree
-	// { "get_offset", "get_position_offset" }, // GraphNode broke Gradient
-	// { "get_peer_port", "get_peer" }, // ENetMultiplayerPeer broke WebSocketServer
-	// { "get_process_mode", "get_process_callback" }, // ClippedCamera3D broke Node, Sky
-	// { "get_render_info", "get_rendering_info" }, // RenderingServer broke Viewport
-	// { "get_type", "get_tracker_type"}, // XRPositionalTracker broke GLTFAccessor, GLTFLight
-	// { "get_v_offset", "get_drag_vertical_offset"}, // Camera2D, broke PathFollow, Camera
-	// { "has_network_peer", "has_multiplayer_peer"}, // MultiplayerAPI broke SceneTree
-	// { "instance", "instantiate" }, // PackedScene, ClassDB - Broke FileSystemDock signal and also tscn files - [instance=ExtResource( 17 )] - this is implemented as custom rule
-	// { "is_listening", "is_bound"}, // PacketPeerUDP broke TCPServer, UDPServer
-	// { "is_refusing_new_network_connections", "is_refusing_new_connections"}, // MultiplayerAPI broke SceneTree
-	// { "is_valid", "has_valid_event" }, // Shortcut broke e.g. Callable
-	// { "listen", "bound"}, // PacketPeerUDP broke TCPServer, UDPServer
-	// { "load", "_load"}, // ResourceFormatLoader broke ConfigFile, Image, StreamTexture2D
-	// { "make_current", "set_current" }, // Camera2D broke Camera3D, Listener2D
-	// { "process", "_process" }, // AnimationNode - This word is commonly used
-	// { "save", "_save"}, // ResourceFormatLoader broke ConfigFile, Image, StreamTexture2D
-	// { "set_autowrap", "set_autowrap_mode" }, // AcceptDialog broke Label - Cyclic Rename
-	// { "set_color", "surface_set_color"}, // ImmediateMesh broke Light2D, Theme, SurfaceTool
-	// { "set_event", "set_shortcut" }, // BaseButton - Cyclic Rename
-	// { "set_extents", "set_size"}, // BoxShape, RectangleShape broke ReflectionProbe
-	// { "set_flag", "set_particle_flag"}, // ParticleProcessMaterial broke Window, HingeJoint3D
-	// { "set_h_offset", "set_drag_horizontal_offset" }, // Camera2D broke Camera3D, PathFollow3D, PathFollow2D
-	// { "set_margin", "set_offset" }, // Control broke Shape3D, AtlasTexture
-	// { "set_mode", "set_mode_file_mode" }, // FileDialog broke Panel, Shader, CSGPolygon, Tilemap
-	// { "set_normal", "surface_set_normal"}, // ImmediateGeometry broke SurfaceTool, WorldMarginShape2D
-	// { "set_offset", "set_progress" }, // PathFollow2D, PathFollow3D - Too common
-	// { "set_process_mode", "set_process_callback" }, // AnimationTree broke Node, Tween, Sky
-	// { "set_refuse_new_network_connections", "set_refuse_new_connections"}, // MultiplayerAPI broke SceneTree
-	// { "set_tooltip", "set_tooltip_text" }, // Control, breaks TreeItem, at least for now.
-	// { "set_uv", "surface_set_uv" }, // ImmediateMesh broke Polygon2D
-	// { "set_v_offset", "set_drag_vertical_offset" }, // Camera2D broke Camera3D, PathFollow3D, PathFollow2D
-	// {"get_points","get_points_id"},// Astar, broke Line2D, Convexpolygonshape
-	// {"get_v_scroll","get_v_scroll_bar"},//ItemList, broke TextView
-	// { "get_stylebox", "get_theme_stylebox" }, // Control - Will rename the method in Theme as well, skipping
-	{ "_about_to_show", "_about_to_popup" }, // ColorPickerButton
-	{ "_get_configuration_warning", "_get_configuration_warnings" }, // Node
-	{ "_set_current", "set_current" }, // Camera2D
-	{ "_set_editor_description", "set_editor_description" }, // Node
-	{ "_toplevel_raise_self", "_top_level_raise_self" }, // CanvasItem
-	{ "_update_wrap_at", "_update_wrap_at_column" }, // TextEdit
-	{ "add_animation", "add_animation_library" }, // AnimationPlayer
-	{ "add_cancel", "add_cancel_button" }, // AcceptDialog
-	{ "add_central_force", "apply_central_force" }, //RigidBody2D
-	{ "add_child_below_node", "add_sibling" }, // Node
-	{ "add_color_override", "add_theme_color_override" }, // Control
-	{ "add_constant_override", "add_theme_constant_override" }, // Control
-	{ "add_font_override", "add_theme_font_override" }, // Control
-	{ "add_force", "apply_force" }, //RigidBody2D
-	{ "add_icon_override", "add_theme_icon_override" }, // Control
-	{ "add_scene_import_plugin", "add_scene_format_importer_plugin" }, //EditorPlugin
-	{ "add_spatial_gizmo_plugin", "add_node_3d_gizmo_plugin" }, // EditorPlugin
-	{ "add_stylebox_override", "add_theme_stylebox_override" }, // Control
-	{ "add_torque", "apply_torque" }, //RigidBody2D
-	{ "agent_set_neighbor_dist", "agent_set_neighbor_distance" }, // NavigationServer2D, NavigationServer3D
-	{ "apply_changes", "_apply_changes" }, // EditorPlugin
-	{ "body_add_force", "body_apply_force" }, // PhysicsServer2D
-	{ "body_add_torque", "body_apply_torque" }, // PhysicsServer2D
-	{ "bumpmap_to_normalmap", "bump_map_to_normal_map" }, // Image
-	{ "can_be_hidden", "_can_be_hidden" }, // EditorNode3DGizmoPlugin
-	{ "can_drop_data", "_can_drop_data" }, // Control
-	{ "can_generate_small_preview", "_can_generate_small_preview" }, // EditorResourcePreviewGenerator
-	{ "can_instance", "can_instantiate" }, // PackedScene, Script
-	{ "canvas_light_set_scale", "canvas_light_set_texture_scale" }, // RenderingServer
-	{ "capture_get_device", "get_input_device" }, // AudioServer
-	{ "capture_get_device_list", "get_input_device_list" }, // AudioServer
-	{ "capture_set_device", "set_input_device" }, // AudioServer
-	{ "center_viewport_to_cursor", "center_viewport_to_caret" }, // TextEdit
-	{ "change_scene", "change_scene_to_file" }, // SceneTree
-	{ "change_scene_to", "change_scene_to_packed" }, // SceneTree
-	{ "clip_polygons_2d", "clip_polygons" }, // Geometry2D
-	{ "clip_polyline_with_polygon_2d", "clip_polyline_with_polygon" }, //Geometry2D
-	{ "commit_handle", "_commit_handle" }, // EditorNode3DGizmo
-	{ "convex_hull_2d", "convex_hull" }, // Geometry2D
-	{ "create_gizmo", "_create_gizmo" }, // EditorNode3DGizmoPlugin
-	{ "cursor_get_blink_speed", "get_caret_blink_interval" }, // TextEdit
-	{ "cursor_get_column", "get_caret_column" }, // TextEdit
-	{ "cursor_get_line", "get_caret_line" }, // TextEdit
-	{ "cursor_set_blink_enabled", "set_caret_blink_enabled" }, // TextEdit
-	{ "cursor_set_blink_speed", "set_caret_blink_interval" }, // TextEdit
-	{ "cursor_set_column", "set_caret_column" }, // TextEdit
-	{ "cursor_set_line", "set_caret_line" }, // TextEdit
-	{ "damped_spring_joint_create", "joint_make_damped_spring" }, // PhysicsServer2D
-	{ "damped_string_joint_get_param", "damped_spring_joint_get_param" }, // PhysicsServer2D
-	{ "damped_string_joint_set_param", "damped_spring_joint_set_param" }, // PhysicsServer2D
-	{ "dectime", "move_toward" }, // GDScript, Math functions
-	{ "delete_char_at_cursor", "delete_char_at_caret" }, // LineEdit
-	{ "deselect_items", "deselect_all" }, // FileDialog
-	{ "disable_plugin", "_disable_plugin" }, // EditorPlugin
-	{ "drop_data", "_drop_data" }, // Control
-	{ "exclude_polygons_2d", "exclude_polygons" }, // Geometry2D
-	{ "find_node", "find_child" }, // Node
-	{ "find_scancode_from_string", "find_keycode_from_string" }, // OS
-	{ "forward_canvas_draw_over_viewport", "_forward_canvas_draw_over_viewport" }, // EditorPlugin
-	{ "forward_canvas_force_draw_over_viewport", "_forward_canvas_force_draw_over_viewport" }, // EditorPlugin
-	{ "forward_canvas_gui_input", "_forward_canvas_gui_input" }, // EditorPlugin
-	{ "forward_spatial_draw_over_viewport", "_forward_3d_draw_over_viewport" }, // EditorPlugin
-	{ "forward_spatial_force_draw_over_viewport", "_forward_3d_force_draw_over_viewport" }, // EditorPlugin
-	{ "forward_spatial_gui_input", "_forward_3d_gui_input" }, // EditorPlugin
-	{ "generate_from_path", "_generate_from_path" }, // EditorResourcePreviewGenerator
-	{ "generate_small_preview_automatically", "_generate_small_preview_automatically" }, // EditorResourcePreviewGenerator
-	{ "get_action_list", "action_get_events" }, // InputMap
-	{ "get_alt", "is_alt_pressed" }, // InputEventWithModifiers
-	{ "get_animation_process_mode", "get_process_callback" }, // AnimationPlayer
-	{ "get_applied_force", "get_constant_force" }, //RigidBody2D
-	{ "get_applied_torque", "get_constant_torque" }, //RigidBody2D
-	{ "get_audio_bus", "get_audio_bus_name" }, // Area3D
-	{ "get_bound_child_nodes_to_bone", "get_bone_children" }, // Skeleton3D
-	{ "get_camera", "get_camera_3d" }, // Viewport -> this is also convertible to get_camera_2d, broke GLTFNode
-	{ "get_cancel", "get_cancel_button" }, // ConfirmationDialog
-	{ "get_caption", "_get_caption" }, // AnimationNode
-	{ "get_cast_to", "get_target_position" }, // RayCast2D, RayCast3D
-	{ "get_child_by_name", "_get_child_by_name" }, // AnimationNode
-	{ "get_child_nodes", "_get_child_nodes" }, // AnimationNode
-	{ "get_closest_point_to_segment_2d", "get_closest_point_to_segment" }, // Geometry2D
-	{ "get_closest_point_to_segment_uncapped_2d", "get_closest_point_to_segment_uncapped" }, // Geometry2D
-	{ "get_closest_points_between_segments_2d", "get_closest_point_to_segment" }, // Geometry2D
-	{ "get_collision_layer_bit", "get_collision_layer_value" }, // CSGShape3D and a lot of others like GridMap
-	{ "get_collision_mask_bit", "get_collision_mask_value" }, // CSGShape3D and a lot of others like GridMap
-	{ "get_color_types", "get_color_type_list" }, // Theme
-	{ "get_command", "is_command_or_control_pressed" }, // InputEventWithModifiers
-	{ "get_constant_types", "get_constant_type_list" }, // Theme
-	{ "get_control", "is_ctrl_pressed" }, // InputEventWithModifiers
-	{ "get_cull_mask_bit", "get_cull_mask_value" }, // Camera3D
-	{ "get_cursor_position", "get_caret_column" }, // LineEdit
-	{ "get_d", "get_distance" }, // LineShape2D
-	{ "get_depth_bias_enable", "get_depth_bias_enabled" }, // RDPipelineRasterizationState
-	{ "get_device", "get_output_device" }, // AudioServer
-	{ "get_device_list", "get_output_device_list" }, // AudioServer
-	{ "get_drag_data", "_get_drag_data" }, // Control
-	{ "get_editor_viewport", "get_editor_main_screen" }, // EditorPlugin
-	{ "get_enabled_focus_mode", "get_focus_mode" }, // BaseButton
-	{ "get_endian_swap", "is_big_endian" }, // File
-	{ "get_error_string", "get_error_message" }, // JSON
-	{ "get_filename", "get_scene_file_path" }, // Node, WARNING, this may be used in a lot of other places
-	{ "get_focus_neighbour", "get_focus_neighbor" }, // Control
-	{ "get_follow_smoothing", "get_position_smoothing_speed" }, // Camera2D
-	{ "get_font_types", "get_font_type_list" }, // Theme
-	{ "get_frame_color", "get_color" }, // ColorRect
-	{ "get_global_rate_scale", "get_playback_speed_scale" }, // AudioServer
-	{ "get_gravity_distance_scale", "get_gravity_point_unit_distance" }, // Area(2D/3D)
-	{ "get_gravity_vector", "get_gravity_direction" }, // Area(2D/3D)
-	{ "get_h_scrollbar", "get_h_scroll_bar" }, //ScrollContainer
-	{ "get_hand", "get_tracker_hand" }, // XRPositionalTracker
-	{ "get_handle_name", "_get_handle_name" }, // EditorNode3DGizmo
-	{ "get_handle_value", "_get_handle_value" }, // EditorNode3DGizmo
-	{ "get_icon_align", "get_icon_alignment" }, // Button
-	{ "get_icon_types", "get_icon_type_list" }, // Theme
-	{ "get_idle_frames", "get_process_frames" }, // Engine
-	{ "get_import_options", "_get_import_options" }, // EditorImportPlugin
-	{ "get_import_order", "_get_import_order" }, // EditorImportPlugin
-	{ "get_importer_name", "_get_importer_name" }, // EditorImportPlugin
-	{ "get_interior_ambient", "get_ambient_color" }, // ReflectionProbe
-	{ "get_interior_ambient_energy", "get_ambient_color_energy" }, // ReflectionProbe
-	{ "get_iterations_per_second", "get_physics_ticks_per_second" }, // Engine
-	{ "get_last_mouse_speed", "get_last_mouse_velocity" }, // Input
-	{ "get_layer_mask_bit", "get_layer_mask_value" }, // VisualInstance3D
-	{ "get_len", "get_length" }, // File
-	{ "get_max_atlas_size", "get_max_texture_size" }, // LightmapGI
-	{ "get_metakey", "is_meta_pressed" }, // InputEventWithModifiers
-	{ "get_mid_height", "get_height" }, // CapsuleMesh
-	{ "get_motion_remainder", "get_remainder" }, // PhysicsTestMotionResult2D
-	{ "get_neighbor_dist", "get_neighbor_distance" }, // NavigationAgent2D, NavigationAgent3D
-	{ "get_network_connected_peers", "get_peers" }, // Multiplayer API
-	{ "get_network_master", "get_multiplayer_authority" }, // Node
-	{ "get_network_peer", "get_multiplayer_peer" }, // Multiplayer API
-	{ "get_network_unique_id", "get_unique_id" }, // Multiplayer API
-	{ "get_ok", "get_ok_button" }, // AcceptDialog
-	{ "get_oneshot", "get_one_shot" }, // AnimatedTexture
-	{ "get_option_visibility", "_get_option_visibility" }, // EditorImportPlugin
-	{ "get_parameter_default_value", "_get_parameter_default_value" }, // AnimationNode
-	{ "get_parameter_list", "_get_parameter_list" }, // AnimationNode
-	{ "get_parent_spatial", "get_parent_node_3d" }, // Node3D
-	{ "get_pause_mode", "get_process_mode" }, // Node
-	{ "get_physical_scancode", "get_physical_keycode" }, // InputEventKey
-	{ "get_physical_scancode_with_modifiers", "get_physical_keycode_with_modifiers" }, // InputEventKey
-	{ "get_plugin_icon", "_get_plugin_icon" }, // EditorPlugin
-	{ "get_plugin_name", "_get_plugin_name" }, // EditorPlugin
-	{ "get_preset_count", "_get_preset_count" }, // EditorImportPlugin
-	{ "get_preset_name", "_get_preset_name" }, // EditorImportPlugin
-	{ "get_recognized_extensions", "_get_recognized_extensions" }, // ResourceFormatLoader, EditorImportPlugin broke ResourceSaver
-	{ "get_render_info", "get_rendering_info" }, // RenderingServer
-	{ "get_render_targetsize", "get_render_target_size" }, // XRInterface
-	{ "get_resource_type", "_get_resource_type" }, // ResourceFormatLoader
-	{ "get_result", "get_data" }, //JSON
-	{ "get_reverb_bus", "set_reverb_bus_name" }, // Area3D
-	{ "get_rpc_sender_id", "get_remote_sender_id" }, // Multiplayer API
-	{ "get_save_extension", "_get_save_extension" }, // EditorImportPlugin
-	{ "get_scancode", "get_keycode" }, // InputEventKey
-	{ "get_scancode_string", "get_keycode_string" }, // OS
-	{ "get_scancode_with_modifiers", "get_keycode_with_modifiers" }, // InputEventKey
-	{ "get_selected_path", "get_current_directory" }, // EditorInterface
-	{ "get_shift", "is_shift_pressed" }, // InputEventWithModifiers
-	{ "get_size_override", "get_size_2d_override" }, // SubViewport
-	{ "get_slide_count", "get_slide_collision_count" }, // CharacterBody2D, CharacterBody3D
-	{ "get_slips_on_slope", "get_slide_on_slope" }, // SeparationRayShape2D, SeparationRayShape3D
-	{ "get_space_override_mode", "get_gravity_space_override_mode" }, // Area2D
-	{ "get_spatial_node", "get_node_3d" }, // EditorNode3DGizmo
-	{ "get_speed", "get_velocity" }, // InputEventMouseMotion
-	{ "get_stylebox_types", "get_stylebox_type_list" }, // Theme
-	{ "get_surface_material", "get_surface_override_material" }, // MeshInstance3D broke ImporterMesh
-	{ "get_surface_material_count", "get_surface_override_material_count" }, // MeshInstance3D
-	{ "get_tab_disabled", "is_tab_disabled" }, // Tab
-	{ "get_tab_hidden", "is_tab_hidden" }, // Tab
-	{ "get_text_align", "get_text_alignment" }, // Button
-	{ "get_theme_item_types", "get_theme_item_type_list" }, // Theme
-	{ "get_timer_process_mode", "get_timer_process_callback" }, // Timer
-	{ "get_translation", "get_position" }, // Node3D broke GLTFNode which is used rarely
-	{ "get_unit_db", "get_volume_db" }, // AudioStreamPlayer3D
-	{ "get_unit_offset", "get_progress_ratio" }, // PathFollow2D, PathFollow3D
-	{ "get_use_in_baked_light", "is_baking_navigation" }, // GridMap
-	{ "get_used_cells_by_id", "get_used_cells" }, // TileMap
-	{ "get_v_scrollbar", "get_v_scroll_bar" }, //ScrollContainer
-	{ "get_visible_name", "_get_visible_name" }, // EditorImportPlugin
-	{ "get_window_layout", "_get_window_layout" }, // EditorPlugin
-	{ "get_word_under_cursor", "get_word_under_caret" }, // TextEdit
-	{ "get_world", "get_world_3d" }, // Viewport, Spatial
-	{ "get_zfar", "get_far" }, // Camera3D broke GLTFCamera
-	{ "get_znear", "get_near" }, // Camera3D broke GLTFCamera
-	{ "groove_joint_create", "joint_make_groove" }, // PhysicsServer2D
-	{ "handle_menu_selected", "_handle_menu_selected" }, // EditorResourcePicker
-	{ "handles_type", "_handles_type" }, // ResourceFormatLoader
-	{ "has_color", "has_theme_color" }, //  Control broke Theme
-	{ "has_color_override", "has_theme_color_override" }, // Control broke Theme
-	{ "has_constant", "has_theme_constant" }, // Control
-	{ "has_constant_override", "has_theme_constant_override" }, // Control
-	{ "has_filter", "_has_filter" }, // AnimationNode
-	{ "has_font", "has_theme_font" }, // Control broke Theme
-	{ "has_font_override", "has_theme_font_override" }, // Control
-	{ "has_icon", "has_theme_icon" }, // Control broke Theme
-	{ "has_icon_override", "has_theme_icon_override" }, // Control
-	{ "has_main_screen", "_has_main_screen" }, // EditorPlugin
-	{ "has_network_peer", "has_multiplayer_peer" }, // Multiplayer API
-	{ "has_stylebox", "has_theme_stylebox" }, // Control broke Theme
-	{ "has_stylebox_override", "has_theme_stylebox_override" }, // Control
-	{ "http_escape", "uri_encode" }, // String
-	{ "http_unescape", "uri_decode" }, // String
-	{ "import_scene_from_other_importer", "_import_scene" }, //EditorSceneFormatImporter
-	{ "instance_set_surface_material", "instance_set_surface_override_material" }, // RenderingServer
-	{ "interpolate", "sample" }, // Curve, Curve2D, Curve3D, Gradient
-	{ "intersect_polygons_2d", "intersect_polygons" }, // Geometry2D
-	{ "intersect_polyline_with_polygon_2d", "intersect_polyline_with_polygon" }, // Geometry2D
-	{ "is_a_parent_of", "is_ancestor_of" }, // Node
-	{ "is_commiting_action", "is_committing_action" }, // UndoRedo
-	{ "is_doubleclick", "is_double_click" }, // InputEventMouseButton
-	{ "is_draw_red", "is_draw_warning" }, // EditorProperty
-	{ "is_follow_smoothing_enabled", "is_position_smoothing_enabled" }, // Camera2D
-	{ "is_h_drag_enabled", "is_drag_horizontal_enabled" }, // Camera2D
-	{ "is_handle_highlighted", "_is_handle_highlighted" }, // EditorNode3DGizmo, EditorNode3DGizmoPlugin
-	{ "is_inverting_faces", "get_flip_faces" }, // CSGPrimitive3D
-	{ "is_network_master", "is_multiplayer_authority" }, // Node
-	{ "is_network_server", "is_server" }, // Multiplayer API
-	{ "is_normalmap", "is_normal_map" }, // NoiseTexture
-	{ "is_refusing_new_network_connections", "is_refusing_new_connections" }, // Multiplayer API
-	{ "is_region", "is_region_enabled" }, // Sprite2D
-	{ "is_rotating", "is_ignoring_rotation" }, // Camera2D
-	{ "is_scancode_unicode", "is_keycode_unicode" }, // OS
-	{ "is_selectable_when_hidden", "_is_selectable_when_hidden" }, // EditorNode3DGizmoPlugin
-	{ "is_set_as_toplevel", "is_set_as_top_level" }, // CanvasItem
-	{ "is_shortcut", "matches_event" }, // Shortcut
-	{ "is_size_override_stretch_enabled", "is_size_2d_override_stretch_enabled" }, // SubViewport
-	{ "is_sort_enabled", "is_y_sort_enabled" }, // Node2D
-	{ "is_static_body", "is_able_to_sleep" }, // PhysicalBone3D - TODO - not sure
-	{ "is_v_drag_enabled", "is_drag_vertical_enabled" }, // Camera2D
-	{ "joint_create_cone_twist", "joint_make_cone_twist" }, // PhysicsServer3D
-	{ "joint_create_generic_6dof", "joint_make_generic_6dof" }, // PhysicsServer3D
-	{ "joint_create_hinge", "joint_make_hinge" }, // PhysicsServer3D
-	{ "joint_create_pin", "joint_make_pin" }, // PhysicsServer3D
-	{ "joint_create_slider", "joint_make_slider" }, // PhysicsServer3D
-	{ "line_intersects_line_2d", "line_intersects_line" }, // Geometry2D
-	{ "load_from_globals", "load_from_project_settings" }, // InputMap
-	{ "load_interactive", "load_threaded_request" }, // ResourceLoader - load_threaded_request is alternative, but is used differently
-	{ "make_convex_from_brothers", "make_convex_from_siblings" }, // CollisionShape3D
-	{ "make_visible", "_make_visible" }, // EditorPlugin
-	{ "merge_polygons_2d", "merge_polygons" }, // Geometry2D
-	{ "mesh_surface_get_format", "mesh_surface_get_format_attribute_stride" }, // RenderingServer
-	{ "mesh_surface_update_region", "mesh_surface_update_attribute_region" }, // RenderingServer
-	{ "move_to_bottom", "move_after" }, // Skeleton3D
-	{ "move_to_top", "move_before" }, // Skeleton3D
-	{ "multimesh_allocate", "multimesh_allocate_data" }, // RenderingServer
-	{ "normalmap_to_xy", "normal_map_to_xy" }, // Image
-	{ "offset_polygon_2d", "offset_polygon" }, // Geometry2D
-	{ "offset_polyline_2d", "offset_polyline" }, // Geometry2D
-	{ "percent_decode", "uri_decode" }, // String
-	{ "percent_encode", "uri_encode" }, // String
-	{ "pin_joint_create", "joint_make_pin" }, // PhysicsServer2D
-	{ "popup_centered_minsize", "popup_centered_clamped" }, // Window
-	{ "post_import", "_post_import" }, // EditorScenePostImport
-	{ "print_stray_nodes", "print_orphan_nodes" }, // Node
-	{ "property_list_changed_notify", "notify_property_list_changed" }, // Object
-	{ "raise", "move_to_front" }, // CanvasItem
-	{ "recognize", "_recognize" }, // ResourceFormatLoader
-	{ "regen_normalmaps", "regen_normal_maps" }, // ArrayMesh
-	{ "remove", "remove_at" }, // Array, broke Directory
-	{ "remove_animation", "remove_animation_library" }, // AnimationPlayer
-	{ "remove_color_override", "remove_theme_color_override" }, // Control
-	{ "remove_constant_override", "remove_theme_constant_override" }, // Control
-	{ "remove_font_override", "remove_theme_font_override" }, // Control
-	{ "remove_icon_override", "remove_theme_icon_override" }, // Control
-	{ "remove_scene_import_plugin", "remove_scene_format_importer_plugin" }, //EditorPlugin
-	{ "remove_spatial_gizmo_plugin", "remove_node_3d_gizmo_plugin" }, // EditorPlugin
-	{ "remove_stylebox_override", "remove_theme_stylebox_override" }, // Control
-	{ "rename_animation", "rename_animation_library" }, // AnimationPlayer
-	{ "rename_dependencies", "_rename_dependencies" }, // ResourceFormatLoader
-	{ "save_external_data", "_save_external_data" }, // EditorPlugin
-	{ "segment_intersects_segment_2d", "segment_intersects_segment" }, // Geometry2D
-	{ "set_adjustment_enable", "set_adjustment_enabled" }, // Environment
-	{ "set_alt", "set_alt_pressed" }, // InputEventWithModifiers
-	{ "set_anchor_and_margin", "set_anchor_and_offset" }, // Control
-	{ "set_anchors_and_margins_preset", "set_anchors_and_offsets_preset" }, // Control
-	{ "set_animation_process_mode", "set_process_callback" }, // AnimationPlayer
-	{ "set_as_bulk_array", "set_buffer" }, // MultiMesh
-	{ "set_as_normalmap", "set_as_normal_map" }, // NoiseTexture
-	{ "set_as_toplevel", "set_as_top_level" }, // CanvasItem
-	{ "set_audio_bus", "set_audio_bus_name" }, // Area3D
-	{ "set_autowrap", "set_autowrap_mode" }, // Label broke AcceptDialog
-	{ "set_cast_to", "set_target_position" }, // RayCast2D, RayCast3D
-	{ "set_collision_layer_bit", "set_collision_layer_value" }, // CSGShape3D and a lot of others like GridMap
-	{ "set_collision_mask_bit", "set_collision_mask_value" }, // CSGShape3D and a lot of others like GridMap
-	{ "set_column_min_width", "set_column_custom_minimum_width" }, // Tree
-	{ "set_command", "set_meta_pressed" }, // InputEventWithModifiers
-	{ "set_control", "set_ctrl_pressed" }, // InputEventWithModifiers
-	{ "set_create_options", "_set_create_options" }, //  EditorResourcePicker
-	{ "set_cull_mask_bit", "set_cull_mask_value" }, // Camera3D
-	{ "set_cursor_position", "set_caret_column" }, // LineEdit
-	{ "set_d", "set_distance" }, // WorldMarginShape2D
-	{ "set_depth_bias_enable", "set_depth_bias_enabled" }, // RDPipelineRasterizationState
-	{ "set_device", "set_output_device" }, // AudioServer
-	{ "set_doubleclick", "set_double_click" }, // InputEventMouseButton
-	{ "set_draw_red", "set_draw_warning" }, // EditorProperty
-	{ "set_enable_follow_smoothing", "set_position_smoothing_enabled" }, // Camera2D
-	{ "set_enabled_focus_mode", "set_focus_mode" }, // BaseButton
-	{ "set_endian_swap", "set_big_endian" }, // File
-	{ "set_expand_to_text_length", "set_expand_to_text_length_enabled" }, // LineEdit
-	{ "set_filename", "set_scene_file_path" }, // Node, WARNING, this may be used in a lot of other places
-	{ "set_focus_neighbour", "set_focus_neighbor" }, // Control
-	{ "set_follow_smoothing", "set_position_smoothing_speed" }, // Camera2D
-	{ "set_frame_color", "set_color" }, // ColorRect
-	{ "set_global_rate_scale", "set_playback_speed_scale" }, // AudioServer
-	{ "set_gravity_distance_scale", "set_gravity_point_unit_distance" }, // Area(2D/3D)
-	{ "set_gravity_vector", "set_gravity_direction" }, // Area(2D/3D)
-	{ "set_h_drag_enabled", "set_drag_horizontal_enabled" }, // Camera2D
-	{ "set_icon_align", "set_icon_alignment" }, // Button
-	{ "set_interior_ambient", "set_ambient_color" }, // ReflectionProbe
-	{ "set_interior_ambient_energy", "set_ambient_color_energy" }, // ReflectionProbe
-	{ "set_invert_faces", "set_flip_faces" }, // CSGPrimitive3D
-	{ "set_is_initialized", "_is_initialized" }, // XRInterface
-	{ "set_is_primary", "set_primary" }, // XRInterface
-	{ "set_iterations_per_second", "set_physics_ticks_per_second" }, // Engine
-	{ "set_layer_mask_bit", "set_layer_mask_value" }, // VisualInstance3D
-	{ "set_margins_preset", "set_offsets_preset" }, //  Control
-	{ "set_max_atlas_size", "set_max_texture_size" }, // LightmapGI
-	{ "set_metakey", "set_meta_pressed" }, // InputEventWithModifiers
-	{ "set_mid_height", "set_height" }, // CapsuleMesh
-	{ "set_neighbor_dist", "set_neighbor_distance" }, // NavigationAgent2D, NavigationAgent3D
-	{ "set_network_master", "set_multiplayer_authority" }, // Node
-	{ "set_network_peer", "set_multiplayer_peer" }, // Multiplayer API
-	{ "set_oneshot", "set_one_shot" }, // AnimatedTexture
-	{ "set_pause_mode", "set_process_mode" }, // Node
-	{ "set_physical_scancode", "set_physical_keycode" }, // InputEventKey
-	{ "set_proximity_fade", "set_proximity_fade_enabled" }, // Material
-	{ "set_refuse_new_network_connections", "set_refuse_new_connections" }, // Multiplayer API
-	{ "set_region", "set_region_enabled" }, // Sprite2D, Sprite broke AtlasTexture
-	{ "set_region_filter_clip", "set_region_filter_clip_enabled" }, // Sprite2D
-	{ "set_reverb_bus", "set_reverb_bus_name" }, // Area3D
-	{ "set_rotate", "set_rotates" }, // PathFollow2D
-	{ "set_scancode", "set_keycode" }, // InputEventKey
-	{ "set_shift", "set_shift_pressed" }, // InputEventWithModifiers
-	{ "set_size_override", "set_size_2d_override" }, // SubViewport broke ImageTexture
-	{ "set_size_override_stretch", "set_size_2d_override_stretch" }, // SubViewport
-	{ "set_slips_on_slope", "set_slide_on_slope" }, // SeparationRayShape2D, SeparationRayShape3D
-	{ "set_sort_enabled", "set_y_sort_enabled" }, // Node2D
-	{ "set_space_override_mode", "set_gravity_space_override_mode" }, // Area2D
-	{ "set_spatial_node", "set_node_3d" }, // EditorNode3DGizmo
-	{ "set_speed", "set_velocity" }, // InputEventMouseMotion
-	{ "set_ssao_edge_sharpness", "set_ssao_sharpness" }, // Environment
-	{ "set_surface_material", "set_surface_override_material" }, // MeshInstance3D broke ImporterMesh
-	{ "set_tab_align", "set_tab_alignment" }, //TabContainer
-	{ "set_tangent", "surface_set_tangent" }, // ImmediateGeometry broke SurfaceTool
-	{ "set_text_align", "set_text_alignment" }, // Button
-	{ "set_timer_process_mode", "set_timer_process_callback" }, // Timer
-	{ "set_translation", "set_position" }, // Node3D - this broke GLTFNode which is used rarely
-	{ "set_unit_db", "set_volume_db" }, // AudioStreamPlayer3D
-	{ "set_unit_offset", "set_progress_ratio" }, // PathFollow2D, PathFollow3D
-	{ "set_uv2", "surface_set_uv2" }, // ImmediateMesh broke Surffacetool
-	{ "set_v_drag_enabled", "set_drag_vertical_enabled" }, // Camera2D
-	{ "set_valign", "set_vertical_alignment" }, // Label
-	{ "set_window_layout", "_set_window_layout" }, // EditorPlugin
-	{ "set_zfar", "set_far" }, // Camera3D broke GLTFCamera
-	{ "set_znear", "set_near" }, // Camera3D broke GLTFCamera
-	{ "shortcut_match", "is_match" }, // InputEvent
-	{ "skeleton_allocate", "skeleton_allocate_data" }, // RenderingServer
-	{ "surface_update_region", "surface_update_attribute_region" }, // ArrayMesh
-	{ "targeting_method", "tween_method" }, // Tween
-	{ "targeting_property", "tween_property" }, // Tween
-	{ "track_remove_key_at_position", "track_remove_key_at_time" }, // Animation
-	{ "triangulate_delaunay_2d", "triangulate_delaunay" }, // Geometry2D
-	{ "unselect", "deselect" }, // ItemList
-	{ "unselect_all", "deselect_all" }, // ItemList
-	{ "update_configuration_warning", "update_configuration_warnings" }, // Node
-	{ "update_gizmo", "update_gizmos" }, // Node3D
-	{ "viewport_set_use_arvr", "viewport_set_use_xr" }, // RenderingServer
-	{ "warp_mouse_position", "warp_mouse" }, // Input
-	{ "world_to_map", "local_to_map" }, // TileMap, GridMap
-	{ "set_shader_param", "set_shader_parameter" }, // ShaderMaterial
-	{ "get_shader_param", "get_shader_parameter" }, // ShaderMaterial
-	{ "set_uniform_name", "set_parameter_name" }, // ParameterRef
-	{ "get_uniform_name", "get_parameter_name" }, // ParameterRef
-
-	// Builtin types
-	// Remember to add them to builtin_types_excluded_functions variable, because for now this functions cannot be listed
-	//	{ "empty", "is_empty" }, // Array - Used as custom rule  // Be careful, this will be used everywhere
-	{ "clamped", "clamp" }, // Vector2  // Be careful, this will be used everywhere
-	{ "get_rotation_quat", "get_rotation_quaternion" }, // Basis
-	{ "grow_margin", "grow_side" }, // Rect2
-	{ "invert", "reverse" }, // Array - TODO check  // Be careful, this will be used everywhere
-	{ "is_abs_path", "is_absolute_path" }, // String
-	{ "is_valid_integer", "is_valid_int" }, // String
-	{ "linear_interpolate", "lerp" }, // Color
-	{ "find_last", "rfind" }, // Array, String
-	{ "to_ascii", "to_ascii_buffer" }, // String
-	{ "to_utf8", "to_utf8_buffer" }, // String
-	{ "to_wchar", "to_utf32_buffer" }, // String // TODO - utf32 or utf16?
-
-	// @GlobalScope
-	// Remember to add them to builtin_types_excluded_functions variable, because for now this functions cannot be listed
-	{ "bytes2var", "bytes_to_var" },
-	{ "bytes2var_with_objects", "bytes_to_var_with_objects" },
-	{ "db2linear", "db_to_linear" },
-	{ "deg2rad", "deg_to_rad" },
-	{ "linear2db", "linear_to_db" },
-	{ "rad2deg", "rad_to_deg" },
-	{ "rand_range", "randf_range" },
-	{ "range_lerp", "remap" },
-	{ "stepify", "snapped" },
-	{ "str2var", "str_to_var" },
-	{ "var2str", "var_to_str" },
-	{ "var2bytes", "var_to_bytes" },
-	{ "var2bytes_with_objects", "var_to_bytes_with_objects" },
-
-	// @GDScript
-	// Remember to add them to builtin_types_excluded_functions variable, because for now this functions cannot be listed
-	{ "dict2inst", "dict_to_inst" },
-	{ "inst2dict", "inst_to_dict" },
-
-	{ nullptr, nullptr },
-};
-
-// gdscript_function_renames clone with CamelCase
-const char *ProjectConverter3To4::csharp_function_renames[][2] = {
-	// { "_SetName", "GetTrackerName"}, // XRPositionalTracker - CameraFeed use this
-	// { "_UnhandledInput", "_UnhandledKeyInput"}, // BaseButton, ViewportContainer broke Node, FileDialog,SubViewportContainer
-	// { "CreateGizmo", "_CreateGizmo"}, // EditorNode3DGizmoPlugin - may be used
-	// { "GetDependencies", "_GetDependencies" }, // ResourceFormatLoader broke ResourceLoader
-	// { "GetExtents", "GetSize" }, // BoxShape, RectangleShape broke Decal, VoxelGI, GPUParticlesCollisionBox, GPUParticlesCollisionSDF, GPUParticlesCollisionHeightField, GPUParticlesAttractorBox, GPUParticlesAttractorVectorField, FogVolume
-	// { "GetHOffset", "GetDragHorizontalOffset"}, // Camera2D, broke PathFollow, Camera
-	// { "GetMode", "GetFileMode"}, // FileDialog broke Panel, Shader, CSGPolygon, Tilemap
-	// { "GetMotion", "GetTravel"}, // PhysicsTestMotionResult2D broke ParalaxLayer
-	// { "GetName", "GetTrackerName"}, // XRPositionalTracker broke OS, Node
-	// { "GetNetworkConnectedPeers", "GetPeers"}, // MultiplayerAPI broke SceneTree
-	// { "GetNetworkPeer", "HasMultiplayerPeer"}, // MultiplayerAPI broke SceneTree
-	// { "GetNetworkUniqueId", "GetUniqueId"}, // MultiplayerAPI broke SceneTree
-	// { "GetOffset", "GetPositionOffset" }, // GraphNode broke Gradient
-	// { "GetPeerPort", "GetPeer" }, // ENetMultiplayerPeer broke WebSocketServer
-	// { "GetProcessMode", "GetProcessCallback" }, // ClippedCamera3D broke Node, Sky
-	// { "GetRenderInfo", "GetRenderingInfo" }, // RenderingServer broke Viewport
-	// { "GetType", "GetTrackerType"}, // XRPositionalTracker broke GLTFAccessor, GLTFLight
-	// { "GetVOffset", "GetDragVerticalOffset"}, // Camera2D, broke PathFollow, Camera
-	// { "HasNetworkPeer", "HasMultiplayerPeer"}, // MultiplayerAPI broke SceneTree
-	// { "Instance", "Instantiate" }, // PackedScene, ClassDB - Broke FileSystemDock signal and also tscn files - [instance=ExtResource( 17 )] - this is implemented as custom rule
-	// { "IsListening", "IsBound"}, // PacketPeerUDP broke TCPServer, UDPServer
-	// { "IsRefusingNewNetworkConnections", "IsRefusingNewConnections"}, // MultiplayerAPI broke SceneTree
-	// { "IsValid", "HasValidEvent" }, // Shortcut broke e.g. Callable
-	// { "Listen", "Bound"}, // PacketPeerUDP broke TCPServer, UDPServer
-	// { "Load", "_Load"}, // ResourceFormatLoader broke ConfigFile, Image, StreamTexture2D
-	// { "MakeCurrent", "SetCurrent" }, // Camera2D broke Camera3D, Listener2D
-	// { "Process", "_Process" }, // AnimationNode - This word is commonly used
-	// { "Save", "_Save"}, // ResourceFormatLoader broke ConfigFile, Image, StreamTexture2D
-	// { "SetAutowrap", "SetAutowrapMode" }, // AcceptDialog broke Label - Cyclic Rename
-	// { "SetColor", "SurfaceSetColor"}, // ImmediateMesh broke Light2D, Theme, SurfaceTool
-	// { "SetEvent", "SetShortcut" }, // BaseButton - Cyclic Rename
-	// { "SetExtents", "SetSize"}, // BoxShape, RectangleShape broke ReflectionProbe
-	// { "SetFlag", "SetParticleFlag"}, // ParticleProcessMaterial broke Window, HingeJoint3D
-	// { "SetHOffset", "SetDragHorizontalOffset" }, // Camera2D broke Camera3D, PathFollow3D, PathFollow2D
-	// { "SetMargin", "SetOffset" }, // Control broke Shape3D, AtlasTexture
-	// { "SetMode", "SetModeFileMode" }, // FileDialog broke Panel, Shader, CSGPolygon, Tilemap
-	// { "SetNormal", "SurfaceSetNormal"}, // ImmediateGeometry broke SurfaceTool, WorldMarginShape2D
-	// { "SetOffset", "SetProgress" }, // PathFollow2D, PathFollow3D - Too common
-	// { "SetProcessMode", "SetProcessCallback" }, // AnimationTree broke Node, Tween, Sky
-	// { "SetRefuseNewNetworkConnections", "SetRefuseNewConnections"}, // MultiplayerAPI broke SceneTree
-	// { "SetTooltip", "SetTooltipText" }, // Control, breaks TreeItem, at least for now.
-	// { "SetUv", "SurfaceSetUv" }, // ImmediateMesh broke Polygon2D
-	// { "SetVOffset", "SetDragVerticalOffset" }, // Camera2D broke Camera3D, PathFollow3D, PathFollow2D
-	// {"GetPoints","GetPointsId"},// Astar, broke Line2D, Convexpolygonshape
-	// {"GetVScroll","GetVScrollBar"},//ItemList, broke TextView
-	// { "GetStylebox", "GetThemeStylebox" }, // Control - Will rename the method in Theme as well, skipping
-	{ "AddSpatialGizmoPlugin", "AddNode3dGizmoPlugin" }, // EditorPlugin
-	{ "RenderingServer", "GetTabAlignment" }, // Tab
-	{ "_AboutToShow", "_AboutToPopup" }, // ColorPickerButton
-	{ "_GetConfigurationWarning", "_GetConfigurationWarnings" }, // Node
-	{ "_SetCurrent", "SetCurrent" }, // Camera2D
-	{ "_SetEditorDescription", "SetEditorDescription" }, // Node
-	{ "_SetPlaying", "SetPlaying" }, // AnimatedSprite3D
-	{ "_ToplevelRaiseSelf", "_TopLevelRaiseSelf" }, // CanvasItem
-	{ "_UpdateWrapAt", "_UpdateWrapAtColumn" }, // TextEdit
-	{ "AddAnimation", "AddAnimationLibrary" }, // AnimationPlayer
-	{ "AddCancel", "AddCancelButton" }, // AcceptDialog
-	{ "AddCentralForce", "AddConstantCentralForce" }, //RigidBody2D
-	{ "AddChildBelowNode", "AddSibling" }, // Node
-	{ "AddColorOverride", "AddThemeColorOverride" }, // Control
-	{ "AddConstantOverride", "AddThemeConstantOverride" }, // Control
-	{ "AddFontOverride", "AddThemeFontOverride" }, // Control
-	{ "AddForce", "AddConstantForce" }, //RigidBody2D
-	{ "AddIconOverride", "AddThemeIconOverride" }, // Control
-	{ "AddSceneImportPlugin", "AddSceneFormatImporterPlugin" }, //EditorPlugin
-	{ "AddStyleboxOverride", "AddThemeStyleboxOverride" }, // Control
-	{ "AddTorque", "AddConstantTorque" }, //RigidBody2D
-	{ "AgentSetNeighborDist", "AgentSetNeighborDistance" }, // NavigationServer2D, NavigationServer3D
-	{ "BindChildNodeToBone", "SetBoneChildren" }, // Skeleton3D
-	{ "BumpmapToNormalmap", "BumpMapToNormalMap" }, // Image
-	{ "CanBeHidden", "_CanBeHidden" }, // EditorNode3DGizmoPlugin
-	{ "CanDropData", "_CanDropData" }, // Control
-	{ "CanDropDataFw", "_CanDropDataFw" }, // ScriptEditor
-	{ "CanGenerateSmallPreview", "_CanGenerateSmallPreview" }, // EditorResourcePreviewGenerator
-	{ "CanInstance", "CanInstantiate" }, // PackedScene, Script
-	{ "CanvasLightSetScale", "CanvasLightSetTextureScale" }, // RenderingServer
-	{ "CaptureGetDevice", "GetInputDevice" }, // AudioServer
-	{ "CaptureGetDeviceList", "GetInputDeviceList" }, // AudioServer
-	{ "CaptureSetDevice", "SetInputDevice" }, // AudioServer
-	{ "CenterViewportToCursor", "CenterViewportToCaret" }, // TextEdit
-	{ "ChangeScene", "ChangeSceneToFile" }, // SceneTree
-	{ "ChangeSceneTo", "ChangeSceneToPacked" }, // SceneTree
-	{ "ClipPolygons2d", "ClipPolygons" }, // Geometry2D
-	{ "ClipPolylineWithPolygon2d", "ClipPolylineWithPolygon" }, //Geometry2D
-	{ "CommitHandle", "_CommitHandle" }, // EditorNode3DGizmo
-	{ "ConvexHull2d", "ConvexHull" }, // Geometry2D
-	{ "CursorGetBlinkSpeed", "GetCaretBlinkInterval" }, // TextEdit
-	{ "CursorGetColumn", "GetCaretColumn" }, // TextEdit
-	{ "CursorGetLine", "GetCaretLine" }, // TextEdit
-	{ "CursorSetBlinkEnabled", "SetCaretBlinkEnabled" }, // TextEdit
-	{ "CursorSetBlinkSpeed", "SetCaretBlinkInterval" }, // TextEdit
-	{ "CursorSetColumn", "SetCaretColumn" }, // TextEdit
-	{ "CursorSetLine", "SetCaretLine" }, // TextEdit
-	{ "DampedSpringJointCreate", "JointMakeDampedSpring" }, // PhysicsServer2D
-	{ "DampedStringJointGetParam", "DampedSpringJointGetParam" }, // PhysicsServer2D
-	{ "DampedStringJointSetParam", "DampedSpringJointSetParam" }, // PhysicsServer2D
-	{ "DeleteCharAtCursor", "DeleteCharAtCaret" }, // LineEdit
-	{ "DeselectItems", "DeselectAll" }, // FileDialog
-	{ "DropData", "_DropData" }, // Control
-	{ "DropDataFw", "_DropDataFw" }, // ScriptEditor
-	{ "ExcludePolygons2d", "ExcludePolygons" }, // Geometry2D
-	{ "FindScancodeFromString", "FindKeycodeFromString" }, // OS
-	{ "ForwardCanvasDrawOverViewport", "_ForwardCanvasDrawOverViewport" }, // EditorPlugin
-	{ "ForwardCanvasForceDrawOverViewport", "_ForwardCanvasForceDrawOverViewport" }, // EditorPlugin
-	{ "ForwardCanvasGuiInput", "_ForwardCanvasGuiInput" }, // EditorPlugin
-	{ "ForwardSpatialDrawOverViewport", "_Forward3dDrawOverViewport" }, // EditorPlugin
-	{ "ForwardSpatialForceDrawOverViewport", "_Forward3dForceDrawOverViewport" }, // EditorPlugin
-	{ "ForwardSpatialGuiInput", "_Forward3dGuiInput" }, // EditorPlugin
-	{ "GenerateFromPath", "_GenerateFromPath" }, // EditorResourcePreviewGenerator
-	{ "GenerateSmallPreviewAutomatically", "_GenerateSmallPreviewAutomatically" }, // EditorResourcePreviewGenerator
-	{ "GetActionList", "ActionGetEvents" }, // InputMap
-	{ "GetAlt", "IsAltPressed" }, // InputEventWithModifiers
-	{ "GetAnimationProcessMode", "GetProcessCallback" }, // AnimationPlayer
-	{ "GetAppliedForce", "GetConstantForce" }, //RigidBody2D
-	{ "GetAppliedTorque", "GetConstantTorque" }, //RigidBody2D
-	{ "GetAudioBus", "GetAudioBusName" }, // Area3D
-	{ "GetBoundChildNodesToBone", "GetBoneChildren" }, // Skeleton3D
-	{ "GetCamera", "GetCamera3d" }, // Viewport -> this is also convertible to getCamera2d, broke GLTFNode
-	{ "GetCancel", "GetCancelButton" }, // ConfirmationDialog
-	{ "GetCaption", "_GetCaption" }, // AnimationNode
-	{ "GetCastTo", "GetTargetPosition" }, // RayCast2D, RayCast3D
-	{ "GetChildByName", "_GetChildByName" }, // AnimationNode
-	{ "GetChildNodes", "_GetChildNodes" }, // AnimationNode
-	{ "GetClosestPointToSegment2d", "GetClosestPointToSegment" }, // Geometry2D
-	{ "GetClosestPointToSegmentUncapped2d", "GetClosestPointToSegmentUncapped" }, // Geometry2D
-	{ "GetClosestPointsBetweenSegments2d", "GetClosestPointToSegment" }, // Geometry2D
-	{ "GetCollisionLayerBit", "GetCollisionLayerValue" }, // CSGShape3D and a lot of others like GridMap
-	{ "GetCollisionMaskBit", "GetCollisionMaskValue" }, // CSGShape3D and a lot of others like GridMap
-	{ "GetColorTypes", "GetColorTypeList" }, // Theme
-	{ "GetCommand", "IsCommandPressed" }, // InputEventWithModifiers
-	{ "GetConstantTypes", "GetConstantTypeList" }, // Theme
-	{ "GetControl", "IsCtrlPressed" }, // InputEventWithModifiers
-	{ "GetCullMaskBit", "GetCullMaskValue" }, // Camera3D
-	{ "GetCursorPosition", "GetCaretColumn" }, // LineEdit
-	{ "GetD", "GetDistance" }, // LineShape2D
-	{ "GetDepthBiasEnable", "GetDepthBiasEnabled" }, // RDPipelineRasterizationState
-	{ "GetDevice", "GetOutputDevice" }, // AudioServer
-	{ "GetDeviceList", "GetOutputDeviceList" }, // AudioServer
-	{ "GetDragDataFw", "_GetDragDataFw" }, // ScriptEditor
-	{ "GetEditorViewport", "GetViewport" }, // EditorPlugin
-	{ "GetEnabledFocusMode", "GetFocusMode" }, // BaseButton
-	{ "GetEndianSwap", "IsBigEndian" }, // File
-	{ "GetErrorString", "GetErrorMessage" }, // JSON
-	{ "GetFocusNeighbour", "GetFocusNeighbor" }, // Control
-	{ "GetFollowSmoothing", "GetFollowSmoothingSpeed" }, // Camera2D
-	{ "GetFontTypes", "GetFontTypeList" }, // Theme
-	{ "GetFrameColor", "GetColor" }, // ColorRect
-	{ "GetGlobalRateScale", "GetPlaybackSpeedScale" }, // AudioServer
-	{ "GetGravityDistanceScale", "GetGravityPointDistanceScale" }, //Area2D
-	{ "GetGravityVector", "GetGravityDirection" }, //Area2D
-	{ "GetHScrollbar", "GetHScrollBar" }, //ScrollContainer
-	{ "GetHand", "GetTrackerHand" }, // XRPositionalTracker
-	{ "GetHandleName", "_GetHandleName" }, // EditorNode3DGizmo
-	{ "GetHandleValue", "_GetHandleValue" }, // EditorNode3DGizmo
-	{ "GetIconAlign", "GetIconAlignment" }, // Button
-	{ "GetIconTypes", "GetIconTypeList" }, // Theme
-	{ "GetIdleFrames", "GetProcessFrames" }, // Engine
-	{ "GetImportOptions", "_GetImportOptions" }, // EditorImportPlugin
-	{ "GetImportOrder", "_GetImportOrder" }, // EditorImportPlugin
-	{ "GetImporterName", "_GetImporterName" }, // EditorImportPlugin
-	{ "GetInteriorAmbient", "GetAmbientColor" }, // ReflectionProbe
-	{ "GetInteriorAmbientEnergy", "GetAmbientColorEnergy" }, // ReflectionProbe
-	{ "GetIterationsPerSecond", "GetPhysicsTicksPerSecond" }, // Engine
-	{ "GetLastMouseSpeed", "GetLastMouseVelocity" }, // Input
-	{ "GetLayerMaskBit", "GetLayerMaskValue" }, // VisualInstance3D
-	{ "GetLen", "GetLength" }, // File
-	{ "GetMaxAtlasSize", "GetMaxTextureSize" }, // LightmapGI
-	{ "GetMetakey", "IsMetaPressed" }, // InputEventWithModifiers
-	{ "GetMidHeight", "GetHeight" }, // CapsuleMesh
-	{ "GetMotionRemainder", "GetRemainder" }, // PhysicsTestMotionResult2D
-	{ "GetNeighborDist", "GetNeighborDistance" }, // NavigationAgent2D, NavigationAgent3D
-	{ "GetNetworkConnectedPeers", "GetPeers" }, // Multiplayer API
-	{ "GetNetworkMaster", "GetMultiplayerAuthority" }, // Node
-	{ "GetNetworkPeer", "GetMultiplayerPeer" }, // Multiplayer API
-	{ "GetNetworkUniqueId", "GetUniqueId" }, // Multiplayer API
-	{ "GetOneshot", "GetOneShot" }, // AnimatedTexture
-	{ "GetOk", "GetOkButton" }, // AcceptDialog
-	{ "GetOptionVisibility", "_GetOptionVisibility" }, // EditorImportPlugin
-	{ "GetParameterDefaultValue", "_GetParameterDefaultValue" }, // AnimationNode
-	{ "GetParameterList", "_GetParameterList" }, // AnimationNode
-	{ "GetParentSpatial", "GetParentNode3d" }, // Node3D
-	{ "GetPhysicalScancode", "GetPhysicalKeycode" }, // InputEventKey
-	{ "GetPhysicalScancodeWithModifiers", "GetPhysicalKeycodeWithModifiers" }, // InputEventKey
-	{ "GetPluginIcon", "_GetPluginIcon" }, // EditorPlugin
-	{ "GetPluginName", "_GetPluginName" }, // EditorPlugin
-	{ "GetPresetCount", "_GetPresetCount" }, // EditorImportPlugin
-	{ "GetPresetName", "_GetPresetName" }, // EditorImportPlugin
-	{ "GetRecognizedExtensions", "_GetRecognizedExtensions" }, // ResourceFormatLoader, EditorImportPlugin broke ResourceSaver
-	{ "GetRenderInfo", "GetRenderingInfo" }, // RenderingServer
-	{ "GetRenderTargetsize", "GetRenderTargetSize" }, // XRInterface
-	{ "GetResourceType", "_GetResourceType" }, // ResourceFormatLoader
-	{ "GetResult", "GetData" }, //JSON
-	{ "GetReverbBus", "GetReverbBusName" }, // Area3D
-	{ "GetRpcSenderId", "GetRemoteSenderId" }, // Multiplayer API
-	{ "GetSaveExtension", "_GetSaveExtension" }, // EditorImportPlugin
-	{ "GetScancode", "GetKeycode" }, // InputEventKey
-	{ "GetScancodeString", "GetKeycodeString" }, // OS
-	{ "GetScancodeWithModifiers", "GetKeycodeWithModifiers" }, // InputEventKey
-	{ "GetShift", "IsShiftPressed" }, // InputEventWithModifiers
-	{ "GetSizeOverride", "GetSize2dOverride" }, // SubViewport
-	{ "GetSlipsOnSlope", "GetSlideOnSlope" }, // SeparationRayShape2D, SeparationRayShape3D
-	{ "GetSpaceOverrideMode", "GetGravitySpaceOverrideMode" }, // Area2D
-	{ "GetSpatialNode", "GetNode3d" }, // EditorNode3DGizmo
-	{ "GetSpeed", "GetVelocity" }, // InputEventMouseMotion
-	{ "GetStyleboxTypes", "GetStyleboxTypeList" }, // Theme
-	{ "GetSurfaceMaterial", "GetSurfaceOverrideMaterial" }, // MeshInstance3D broke ImporterMesh
-	{ "GetSurfaceMaterialCount", "GetSurfaceOverrideMaterialCount" }, // MeshInstance3D
-	{ "GetTabDisabled", "IsTabDisabled" }, // Tab
-	{ "GetTabHidden", "IsTabHidden" }, // Tab
-	{ "GetTextAlign", "GetTextAlignment" }, // Button
-	{ "GetThemeItemTypes", "GetThemeItemTypeList" }, // Theme
-	{ "GetTimerProcessMode", "GetTimerProcessCallback" }, // Timer
-	{ "GetTranslation", "GetPosition" }, // Node3D broke GLTFNode which is used rarely
-	{ "GetUnitDb", "GetVolumeDb" }, // AudioStreamPlayer3D
-	{ "GetUnitOffset", "GetProgressRatio" }, // PathFollow2D, PathFollow3D
-	{ "GetUseInBakedLight", "IsBakingNavigation" }, // GridMap
-	{ "GetUsedCellsById", "GetUsedCells" }, // TileMap
-	{ "GetVScrollbar", "GetVScrollBar" }, //ScrollContainer
-	{ "GetVisibleName", "_GetVisibleName" }, // EditorImportPlugin
-	{ "GetWindowLayout", "_GetWindowLayout" }, // EditorPlugin
-	{ "GetWordUnderCursor", "GetWordUnderCaret" }, // TextEdit
-	{ "GetWorld", "GetWorld3d" }, // Viewport, Spatial
-	{ "GetZfar", "GetFar" }, // Camera3D broke GLTFCamera
-	{ "GetZnear", "GetNear" }, // Camera3D broke GLTFCamera
-	{ "GrooveJointCreate", "JointMakeGroove" }, // PhysicsServer2D
-	{ "HandleMenuSelected", "_HandleMenuSelected" }, // EditorResourcePicker
-	{ "HandlesType", "_HandlesType" }, // ResourceFormatLoader
-	{ "HasColor", "HasThemeColor" }, //  Control broke Theme
-	{ "HasColorOverride", "HasThemeColorOverride" }, // Control broke Theme
-	{ "HasConstant", "HasThemeConstant" }, // Control
-	{ "HasConstantOverride", "HasThemeConstantOverride" }, // Control
-	{ "HasFilter", "_HasFilter" }, // AnimationNode
-	{ "HasFont", "HasThemeFont" }, // Control broke Theme
-	{ "HasFontOverride", "HasThemeFontOverride" }, // Control
-	{ "HasIcon", "HasThemeIcon" }, // Control broke Theme
-	{ "HasIconOverride", "HasThemeIconOverride" }, // Control
-	{ "HasMainScreen", "_HasMainScreen" }, // EditorPlugin
-	{ "HasNetworkPeer", "HasMultiplayerPeer" }, // Multiplayer API
-	{ "HasStylebox", "HasThemeStylebox" }, // Control broke Theme
-	{ "HasStyleboxOverride", "HasThemeStyleboxOverride" }, // Control
-	{ "HttpEscape", "UriEncode" }, // String
-	{ "HttpUnescape", "UriDecode" }, // String
-	{ "ImportAnimationFromOtherImporter", "_ImportAnimation" }, //EditorSceneFormatImporter
-	{ "ImportSceneFromOtherImporter", "_ImportScene" }, //EditorSceneFormatImporter
-	{ "InstanceSetSurfaceMaterial", "InstanceSetSurfaceOverrideMaterial" }, // RenderingServer
-	{ "IntersectPolygons2d", "IntersectPolygons" }, // Geometry2D
-	{ "IntersectPolylineWithPolygon2d", "IntersectPolylineWithPolygon" }, // Geometry2D
-	{ "IsAParentOf", "IsAncestorOf" }, // Node
-	{ "IsCommitingAction", "IsCommittingAction" }, // UndoRedo
-	{ "IsDoubleclick", "IsDoubleClick" }, // InputEventMouseButton
-	{ "IsFollowSmoothingEnabled", "IsPositionSmoothingEnabled" }, // Camera2D
-	{ "IsHDragEnabled", "IsDragHorizontalEnabled" }, // Camera2D
-	{ "IsHandleHighlighted", "_IsHandleHighlighted" }, // EditorNode3DGizmo, EditorNode3DGizmoPlugin
-	{ "IsNetworkMaster", "IsMultiplayerAuthority" }, // Node
-	{ "IsNetworkServer", "IsServer" }, // Multiplayer API
-	{ "IsNormalmap", "IsNormalMap" }, // NoiseTexture
-	{ "IsRefusingNewNetworkConnections", "IsRefusingNewConnections" }, // Multiplayer API
-	{ "IsRegion", "IsRegionEnabled" }, // Sprite2D
-	{ "IsRotating", "IsIgnoringRotation" }, // Camera2D
-	{ "IsScancodeUnicode", "IsKeycodeUnicode" }, // OS
-	{ "IsSelectableWhenHidden", "_IsSelectableWhenHidden" }, // EditorNode3DGizmoPlugin
-	{ "IsSetAsToplevel", "IsSetAsTopLevel" }, // CanvasItem
-	{ "IsShortcut", "MatchesEvent" }, // Shortcut
-	{ "IsSizeOverrideStretchEnabled", "IsSize2dOverrideStretchEnabled" }, // SubViewport
-	{ "IsSortEnabled", "IsYSortEnabled" }, // Node2D
-	{ "IsStaticBody", "IsAbleToSleep" }, // PhysicalBone3D - TODO - not sure
-	{ "IsVDragEnabled", "IsDragVerticalEnabled" }, // Camera2D
-	{ "JointCreateConeTwist", "JointMakeConeTwist" }, // PhysicsServer3D
-	{ "JointCreateGeneric6dof", "JointMakeGeneric6dof" }, // PhysicsServer3D
-	{ "JointCreateHinge", "JointMakeHinge" }, // PhysicsServer3D
-	{ "JointCreatePin", "JointMakePin" }, // PhysicsServer3D
-	{ "JointCreateSlider", "JointMakeSlider" }, // PhysicsServer3D
-	{ "LineIntersectsLine2d", "LineIntersectsLine" }, // Geometry2D
-	{ "LoadFromGlobals", "LoadFromProjectSettings" }, // InputMap
-	{ "MakeConvexFromBrothers", "MakeConvexFromSiblings" }, // CollisionShape3D
-	{ "MergePolygons2d", "MergePolygons" }, // Geometry2D
-	{ "MeshSurfaceGetFormat", "MeshSurfaceGetFormatAttributeStride" }, // RenderingServer
-	{ "MeshSurfaceUpdateRegion", "MeshSurfaceUpdateAttributeRegion" }, // RenderingServer
-	{ "MoveToBottom", "MoveAfter" }, // Skeleton3D
-	{ "MoveToTop", "MoveBefore" }, // Skeleton3D
-	{ "MultimeshAllocate", "MultimeshAllocateData" }, // RenderingServer
-	{ "NormalmapToXy", "NormalMapToXy" }, // Image
-	{ "OffsetPolygon2d", "OffsetPolygon" }, // Geometry2D
-	{ "OffsetPolyline2d", "OffsetPolyline" }, // Geometry2D
-	{ "PercentDecode", "UriDecode" }, // String
-	{ "PercentEncode", "UriEncode" }, // String
-	{ "PinJointCreate", "JointMakePin" }, // PhysicsServer2D
-	{ "PopupCenteredMinsize", "PopupCenteredClamped" }, // Window
-	{ "PostImport", "_PostImport" }, // EditorScenePostImport
-	{ "PrintStrayNodes", "PrintOrphanNodes" }, // Node
-	{ "PropertyListChangedNotify", "NotifyPropertyListChanged" }, // Object
-	{ "Recognize", "_Recognize" }, // ResourceFormatLoader
-	{ "RegenNormalmaps", "RegenNormalMaps" }, // ArrayMesh
-	{ "Remove", "RemoveAt" }, // Array, broke Directory
-	{ "RemoveAnimation", "RemoveAnimationLibrary" }, // AnimationPlayer
-	{ "RemoveColorOverride", "RemoveThemeColorOverride" }, // Control
-	{ "RemoveConstantOverride", "RemoveThemeConstantOverride" }, // Control
-	{ "RemoveFontOverride", "RemoveThemeFontOverride" }, // Control
-	{ "RemoveSceneImportPlugin", "RemoveSceneFormatImporterPlugin" }, //EditorPlugin
-	{ "RemoveSpatialGizmoPlugin", "RemoveNode3dGizmoPlugin" }, // EditorPlugin
-	{ "RemoveStyleboxOverride", "RemoveThemeStyleboxOverride" }, // Control
-	{ "RenameAnimation", "RenameAnimationLibrary" }, // AnimationPlayer
-	{ "RenameDependencies", "_RenameDependencies" }, // ResourceFormatLoader
-	{ "SaveExternalData", "_SaveExternalData" }, // EditorPlugin
-	{ "SegmentIntersectsSegment2d", "SegmentIntersectsSegment" }, // Geometry2D
-	{ "SetAdjustmentEnable", "SetAdjustmentEnabled" }, // Environment
-	{ "SetAlt", "SetAltPressed" }, // InputEventWithModifiers
-	{ "SetAnchorAndMargin", "SetAnchorAndOffset" }, // Control
-	{ "SetAnchorsAndMarginsPreset", "SetAnchorsAndOffsetsPreset" }, // Control
-	{ "SetAnimationProcessMode", "SetProcessCallback" }, // AnimationPlayer
-	{ "SetAsBulkArray", "SetBuffer" }, // MultiMesh
-	{ "SetAsNormalmap", "SetAsNormalMap" }, // NoiseTexture
-	{ "SetAsToplevel", "SetAsTopLevel" }, // CanvasItem
-	{ "SetAudioBus", "SetAudioBusName" }, // Area3D
-	{ "SetAutowrap", "SetAutowrapMode" }, // Label broke AcceptDialog
-	{ "SetCastTo", "SetTargetPosition" }, // RayCast2D, RayCast3D
-	{ "SetCollisionLayerBit", "SetCollisionLayerValue" }, // CSGShape3D and a lot of others like GridMap
-	{ "SetCollisionMaskBit", "SetCollisionMaskValue" }, // CSGShape3D and a lot of others like GridMap
-	{ "SetColumnMinWidth", "SetColumnCustomMinimumWidth" }, // Tree
-	{ "SetCommand", "SetCommandPressed" }, // InputEventWithModifiers
-	{ "SetControl", "SetCtrlPressed" }, // InputEventWithModifiers
-	{ "SetCreateOptions", "_SetCreateOptions" }, //  EditorResourcePicker
-	{ "SetCullMaskBit", "SetCullMaskValue" }, // Camera3D
-	{ "SetCursorPosition", "SetCaretColumn" }, // LineEdit
-	{ "SetD", "SetDistance" }, // WorldMarginShape2D
-	{ "SetDepthBiasEnable", "SetDepthBiasEnabled" }, // RDPipelineRasterizationState
-	{ "SetDevice", "SetOutputDevice" }, // AudioServer
-	{ "SetDoubleclick", "SetDoubleClick" }, // InputEventMouseButton
-	{ "SetEnableFollowSmoothing", "SetFollowSmoothingEnabled" }, // Camera2D
-	{ "SetEnabledFocusMode", "SetFocusMode" }, // BaseButton
-	{ "SetEndianSwap", "SetBigEndian" }, // File
-	{ "SetExpandToTextLength", "SetExpandToTextLengthEnabled" }, // LineEdit
-	{ "SetFocusNeighbour", "SetFocusNeighbor" }, // Control
-	{ "SetFollowSmoothing", "SetFollowSmoothingSpeed" }, // Camera2D
-	{ "SetFrameColor", "SetColor" }, // ColorRect
-	{ "SetGlobalRateScale", "SetPlaybackSpeedScale" }, // AudioServer
-	{ "SetGravityDistanceScale", "SetGravityPointDistanceScale" }, // Area2D
-	{ "SetGravityVector", "SetGravityDirection" }, // Area2D
-	{ "SetHDragEnabled", "SetDragHorizontalEnabled" }, // Camera2D
-	{ "SetIconAlign", "SetIconAlignment" }, // Button
-	{ "SetInteriorAmbient", "SetAmbientColor" }, // ReflectionProbe
-	{ "SetInteriorAmbientEnergy", "SetAmbientColorEnergy" }, // ReflectionProbe
-	{ "SetIsInitialized", "_IsInitialized" }, // XRInterface
-	{ "SetIsPrimary", "SetPrimary" }, // XRInterface
-	{ "SetIterationsPerSecond", "SetPhysicsTicksPerSecond" }, // Engine
-	{ "SetLayerMaskBit", "SetLayerMaskValue" }, // VisualInstance3D
-	{ "SetMarginsPreset", "SetOffsetsPreset" }, //  Control
-	{ "SetMaxAtlasSize", "SetMaxTextureSize" }, // LightmapGI
-	{ "SetMetakey", "SetMetaPressed" }, // InputEventWithModifiers
-	{ "SetMidHeight", "SetHeight" }, // CapsuleMesh
-	{ "SetNeighborDist", "SetNeighborDistance" }, // NavigationAgent2D, NavigationAgent3D
-	{ "SetNetworkMaster", "SetMultiplayerAuthority" }, // Node
-	{ "SetNetworkPeer", "SetMultiplayerPeer" }, // Multiplayer API
-	{ "SetOneshot", "SetOneShot" }, // AnimatedTexture
-	{ "SetPhysicalScancode", "SetPhysicalKeycode" }, // InputEventKey
-	{ "SetProximityFade", "SetProximityFadeEnabled" }, // Material
-	{ "SetRefuseNewNetworkConnections", "SetRefuseNewConnections" }, // Multiplayer API
-	{ "SetRegion", "SetRegionEnabled" }, // Sprite2D, Sprite broke AtlasTexture
-	{ "SetRegionFilterClip", "SetRegionFilterClipEnabled" }, // Sprite2D
-	{ "SetReverbBus", "SetReverbBusName" }, // Area3D
-	{ "SetRotate", "SetRotates" }, // PathFollow2D
-	{ "SetScancode", "SetKeycode" }, // InputEventKey
-	{ "SetShift", "SetShiftPressed" }, // InputEventWithModifiers
-	{ "SetSizeOverride", "SetSize2dOverride" }, // SubViewport broke ImageTexture
-	{ "SetSizeOverrideStretch", "SetSize2dOverrideStretch" }, // SubViewport
-	{ "SetSlipsOnSlope", "SetSlideOnSlope" }, // SeparationRayShape2D, SeparationRayShape3D
-	{ "SetSortEnabled", "SetYSortEnabled" }, // Node2D
-	{ "SetSpaceOverrideMode", "SetGravitySpaceOverrideMode" }, // Area2D
-	{ "SetSpatialNode", "SetNode3d" }, // EditorNode3DGizmo
-	{ "SetSpeed", "SetVelocity" }, // InputEventMouseMotion
-	{ "SetSsaoEdgeSharpness", "SetSsaoSharpness" }, // Environment
-	{ "SetSurfaceMaterial", "SetSurfaceOverrideMaterial" }, // MeshInstance3D broke ImporterMesh
-	{ "SetTabAlign", "SetTabAlignment" }, //TabContainer
-	{ "SetTangent", "SurfaceSetTangent" }, // ImmediateGeometry broke SurfaceTool
-	{ "SetTextAlign", "SetTextAlignment" }, // Button
-	{ "SetTimerProcessMode", "SetTimerProcessCallback" }, // Timer
-	{ "SetTonemapAutoExposure", "SetTonemapAutoExposureEnabled" }, // Environment
-	{ "SetTranslation", "SetPosition" }, // Node3D - this broke GLTFNode which is used rarely
-	{ "SetUnitDb", "SetVolumeDb" }, // AudioStreamPlayer3D
-	{ "SetUnitOffset", "SetProgressRatio" }, // PathFollow2D, PathFollow3D
-	{ "SetUv2", "SurfaceSetUv2" }, // ImmediateMesh broke Surffacetool
-	{ "SetVDragEnabled", "SetDragVerticalEnabled" }, // Camera2D
-	{ "SetValign", "SetVerticalAlignment" }, // Label
-	{ "SetWindowLayout", "_SetWindowLayout" }, // EditorPlugin
-	{ "SetZfar", "SetFar" }, // Camera3D broke GLTFCamera
-	{ "SetZnear", "SetNear" }, // Camera3D broke GLTFCamera
-	{ "ShortcutMatch", "IsMatch" }, // InputEvent
-	{ "SkeletonAllocate", "SkeletonAllocateData" }, // RenderingServer
-	{ "SurfaceUpdateRegion", "SurfaceUpdateAttributeRegion" }, // ArrayMesh
-	{ "TargetingMethod", "TweenMethod" }, // Tween
-	{ "TargetingProperty", "TweenProperty" }, // Tween
-	{ "TrackRemoveKeyAtPosition", "TrackRemoveKeyAtTime" }, // Animation
-	{ "TriangulateDelaunay2d", "TriangulateDelaunay" }, // Geometry2D
-	{ "UnbindChildNodeFromBone", "RemoveBoneChild" }, // Skeleton3D
-	{ "Unselect", "Deselect" }, // ItemList
-	{ "UnselectAll", "DeselectAll" }, // ItemList
-	{ "UpdateConfigurationWarning", "UpdateConfigurationWarnings" }, // Node
-	{ "UpdateGizmo", "UpdateGizmos" }, // Node3D
-	{ "ViewportSetUseArvr", "ViewportSetUseXr" }, // RenderingServer
-	{ "WarpMousePosition", "WarpMouse" }, // Input
-	{ "WorldToMap", "LocalToMap" }, // TileMap, GridMap
-	{ "SetShaderParam", "SetShaderParameter" }, // ShaderMaterial
-	{ "GetShaderParam", "GetShaderParameter" }, // ShaderMaterial
-	{ "SetUniformName", "SetParameterName" }, // ParameterRef
-	{ "GetUniformName", "GetParameterName" }, // ParameterRef
-
-	// Builtin types
-	//	{ "Empty", "IsEmpty" }, // Array - Used as custom rule  // Be careful, this will be used everywhere
-	{ "Clamped", "Clamp" }, // Vector2  // Be careful, this will be used everywhere
-	{ "GetRotationQuat", "GetRotationQuaternion" }, // Basis
-	{ "GrowMargin", "GrowSide" }, // Rect2
-	{ "Invert", "Reverse" }, // Array - TODO check  // Be careful, this will be used everywhere
-	{ "IsAbsPath", "IsAbsolutePath" }, // String
-	{ "IsValidInteger", "IsValidInt" }, // String
-	{ "LinearInterpolate", "Lerp" }, // Color
-	{ "ToAscii", "ToAsciiBuffer" }, // String
-	{ "ToUtf8", "ToUtf8Buffer" }, // String
-	{ "ToWchar", "ToUtf32Buffer" }, // String // TODO - utf32 or utf16?
-
-	// @GlobalScope
-	{ "Bytes2Var", "BytesToVar" },
-	{ "Bytes2VarWithObjects", "BytesToVarWithObjects" },
-	{ "Db2Linear", "DbToLinear" },
-	{ "Deg2Rad", "DegToRad" },
-	{ "Linear2Db", "LinearToDb" },
-	{ "Rad2Deg", "RadToDeg" },
-	{ "RandRange", "RandfRange" },
-	{ "RangeLerp", "Remap" },
-	{ "Stepify", "Snapped" },
-	{ "Str2Var", "StrToVar" },
-	{ "Var2Str", "VarToStr" },
-	{ "Var2Bytes", "VarToBytes" },
-	{ "Var2BytesWithObjects", "VarToBytesWithObjects" },
-
-	// @GDScript
-	{ "Dict2Inst", "DictToInst" },
-	{ "Inst2Dict", "InstToDict" },
-
-	{ nullptr, nullptr },
-};
-
-// Some needs to be disabled, because users can use this names as variables
-const char *ProjectConverter3To4::gdscript_properties_renames[][2] = {
-	//	// { "d", "distance" }, //WorldMarginShape2D - TODO, looks that polish letters ą ę are treaten as space, not as letter, so `będą` are renamed to `będistanceą`
-	//	// {"alt","alt_pressed"}, // This may broke a lot of comments and user variables
-	//	// {"command","command_pressed"},// This may broke a lot of comments and user variables
-	//	// {"control","ctrl_pressed"},// This may broke a lot of comments and user variables
-	//	// {"extends","size"}, // BoxShape3D, LightmapGI broke ReflectionProbe
-	//	// {"meta","meta_pressed"},// This may broke a lot of comments and user variables
-	//	// {"pause_mode","process_mode"}, // Node - Cyclic rename, look for others
-	//	// {"rotate","rotates"}, // PathFollow2D - probably function exists with same name
-	// 	// {"offset","progress"}, // PathFollow2D, PathFollow3D - Name is way too vague
-	//	// {"shift","shift_pressed"},// This may broke a lot of comments and user variables
-	//	{ "autowrap", "autowrap_mode" }, // Label
-	//	{ "cast_to", "target_position" }, // RayCast2D, RayCast3D
-	//	{ "device", "output_device"}, // AudioServer - Too vague, most likely breaks comments & variables
-	//	{ "doubleclick", "double_click" }, // InputEventMouseButton
-	//	{ "group", "button_group" }, // BaseButton
-	//	{ "process_mode", "process_callback" }, // AnimationTree, Camera2D
-	//	{ "scancode", "keycode" }, // InputEventKey
-	//	{ "toplevel", "top_level" }, // Node
-	//	{ "window_title", "title" }, // Window
-	//	{ "wrap_enabled", "wrap_mode" }, // TextEdit
-	//	{ "zfar", "far" }, // Camera3D
-	//	{ "znear", "near" }, // Camera3D
-	//	{ "filename", "scene_file_path" }, // Node
-	//	{ "pressed", "button_pressed" }, // BaseButton - Will also rename the signal, skipping for now
-	{ "as_normalmap", "as_normal_map" }, // NoiseTexture
-	{ "bbcode_text", "text" }, // RichTextLabel
-	{ "bg", "panel" }, // Theme
-	{ "bg_focus", "focus" }, // Theme
-	{ "capture_device", "input_device" }, // AudioServer
-	{ "caret_blink_speed", "caret_blink_interval" }, // TextEdit, LineEdit
-	{ "caret_moving_by_right_click", "caret_move_on_right_click" }, // TextEdit
-	{ "caret_position", "caret_column" }, // LineEdit
-	{ "check_vadjust", "check_v_offset" }, // Theme
-	{ "close_h_ofs", "close_h_offset" }, // Theme
-	{ "close_v_ofs", "close_v_offset" }, // Theme
-	{ "commentfocus", "comment_focus" }, // Theme
-	{ "contacts_reported", "max_contacts_reported" }, // RigidBody
-	{ "depth_bias_enable", "depth_bias_enabled" }, // RDPipelineRasterizationState
-	{ "drag_margin_bottom", "drag_bottom_margin" }, // Camera2D
-	{ "drag_margin_h_enabled", "drag_horizontal_enabled" }, // Camera2D
-	{ "drag_margin_left", "drag_left_margin" }, // Camera2D
-	{ "drag_margin_right", "drag_right_margin" }, // Camera2D
-	{ "drag_margin_top", "drag_top_margin" }, // Camera2D
-	{ "drag_margin_v_enabled", "drag_vertical_enabled" }, // Camera2D
-	{ "enabled_focus_mode", "focus_mode" }, // BaseButton - Removed
-	{ "extra_spacing_bottom", "spacing_bottom" }, // Font
-	{ "extra_spacing_top", "spacing_top" }, // Font
-	{ "focus_neighbour_bottom", "focus_neighbor_bottom" }, // Control
-	{ "focus_neighbour_left", "focus_neighbor_left" }, // Control
-	{ "focus_neighbour_right", "focus_neighbor_right" }, // Control
-	{ "focus_neighbour_top", "focus_neighbor_top" }, // Control
-	{ "follow_viewport_enable", "follow_viewport_enabled" }, // CanvasItem
-	{ "file_icon_modulate", "file_icon_color" }, // Theme
-	{ "files_disabled", "file_disabled_color" }, // Theme
-	{ "folder_icon_modulate", "folder_icon_color" }, // Theme
-	{ "global_rate_scale", "playback_speed_scale" }, // AudioServer
-	{ "gravity_distance_scale", "gravity_point_unit_distance" }, // Area(2D/3D)
-	{ "gravity_vec", "gravity_direction" }, // Area(2D/3D)
-	{ "hint_tooltip", "tooltip_text" }, // Control
-	{ "hseparation", "h_separation" }, // Theme
-	{ "icon_align", "icon_alignment" }, // Button
-	{ "iterations_per_second", "physics_ticks_per_second" }, // Engine
-	{ "invert_enable", "invert_enabled" }, // Polygon2D
-	{ "margin_bottom", "offset_bottom" }, // Control broke NinePatchRect, StyleBox
-	{ "margin_left", "offset_left" }, // Control broke NinePatchRect, StyleBox
-	{ "margin_right", "offset_right" }, // Control broke NinePatchRect, StyleBox
-	{ "margin_top", "offset_top" }, // Control broke NinePatchRect, StyleBox
-	{ "mid_height", "height" }, // CapsuleMesh
-	{ "neighbor_dist", "neighbor_distance" }, // NavigationAgent2D, NavigationAgent3D
-	{ "offset_h", "drag_horizontal_offset" }, // Camera2D
-	{ "offset_v", "drag_vertical_offset" }, // Camera2D
-	{ "off", "unchecked" }, // Theme
-	{ "off_disabled", "unchecked_disabled" }, // Theme
-	{ "ofs", "offset" }, // Theme
-	{ "on", "checked" }, // Theme
-	{ "on_disabled", "checked_disabled" }, // Theme
-	{ "oneshot", "one_shot" }, // AnimatedTexture
-	{ "out_of_range_mode", "max_polyphony" }, // AudioStreamPlayer3D
-	{ "pause_mode", "process_mode" }, // Node
-	{ "physical_scancode", "physical_keycode" }, // InputEventKey
-	{ "popup_exclusive", "exclusive" }, // Window
-	{ "proximity_fade_enable", "proximity_fade_enabled" }, // Material
-	{ "rect_position", "position" }, // Control
-	{ "rect_global_position", "global_position" }, // Control
-	{ "rect_size", "size" }, // Control
-	{ "rect_min_size", "custom_minimum_size" }, // Control
-	{ "rect_rotation", "rotation" }, // Control
-	{ "rect_scale", "scale" }, // Control
-	{ "rect_pivot_offset", "pivot_offset" }, // Control
-	{ "rect_clip_content", "clip_contents" }, // Control
-	{ "refuse_new_network_connections", "refuse_new_connections" }, // MultiplayerAPI
-	{ "region_filter_clip", "region_filter_clip_enabled" }, // Sprite2D
-	{ "reverb_bus_enable", "reverb_bus_enabled" }, // Area3D
-	{ "selectedframe", "selected_frame" }, // Theme
-	{ "size_override_stretch", "size_2d_override_stretch" }, // SubViewport
-	{ "slips_on_slope", "slide_on_slope" }, // SeparationRayShape2D
-	{ "smoothing_enabled", "follow_smoothing_enabled" }, // Camera2D
-	{ "smoothing_speed", "position_smoothing_speed" }, // Camera2D
-	{ "ss_reflections_depth_tolerance", "ssr_depth_tolerance" }, // Environment
-	{ "ss_reflections_enabled", "ssr_enabled" }, // Environment
-	{ "ss_reflections_fade_in", "ssr_fade_in" }, // Environment
-	{ "ss_reflections_fade_out", "ssr_fade_out" }, // Environment
-	{ "ss_reflections_max_steps", "ssr_max_steps" }, // Environment
-	{ "state_machine_selectedframe", "state_machine_selected_frame" }, // Theme
-	{ "syntax_highlighting", "syntax_highlighter" }, // TextEdit
-	{ "tab_align", "tab_alignment" }, // TabContainer
-	{ "table_hseparation", "table_h_separation" }, // Theme
-	{ "table_vseparation", "table_v_separation" }, // Theme
-	{ "translation", "position" }, // Node3D - broke GLTFNode
-	{ "unit_db", "volume_db" }, // AudioStreamPlayer3D
-	{ "unit_offset", "progress_ratio" }, // PathFollow2D, PathFollow3D
-	{ "vseparation", "v_separation" }, // Theme
-	{ "frames", "sprite_frames" }, // AnimatedSprite2D, AnimatedSprite3D
-
-	{ nullptr, nullptr },
-};
-
-// Some needs to be disabled, because users can use this names as variables
-const char *ProjectConverter3To4::csharp_properties_renames[][2] = {
-	//	// { "D", "Distance" }, //WorldMarginShape2D - TODO, looks that polish letters ą ę are treaten as space, not as letter, so `będą` are renamed to `będistanceą`
-	//	// {"Alt","AltPressed"}, // This may broke a lot of comments and user variables
-	//	// {"Command","CommandPressed"},// This may broke a lot of comments and user variables
-	//	// {"Control","CtrlPressed"},// This may broke a lot of comments and user variables
-	//	// {"Extends","Size"}, // BoxShape3D, LightmapGI broke ReflectionProbe
-	//	// {"Meta","MetaPressed"},// This may broke a lot of comments and user variables
-	//	// {"PauseMode","ProcessMode"}, // Node - Cyclic rename, look for others
-	//	// {"Rotate","Rotates"}, // PathFollow2D - probably function exists with same name
-	// 	// {"Offset","Progress"}, // PathFollow2D, PathFollow3D - Name is way too vague
-	//	// {"Shift","ShiftPressed"},// This may broke a lot of comments and user variables
-	//	{ "Autowrap", "AutowrapMode" }, // Label
-	//	{ "CastTo", "TargetPosition" }, // RayCast2D, RayCast3D
-	//	{ "Doubleclick", "DoubleClick" }, // InputEventMouseButton
-	//	{ "Group", "ButtonGroup" }, // BaseButton
-	//  { "PercentVisible, "ShowPercentage}, // ProgressBar, conflicts with Label and RichTextLabel, but may be a worth it.
-	//	{ "ProcessMode", "ProcessCallback" }, // AnimationTree, Camera2D
-	//	{ "Scancode", "Keycode" }, // InputEventKey
-	//	{ "Toplevel", "TopLevel" }, // Node
-	//	{ "WindowTitle", "Title" }, // Window
-	//	{ "WrapEnabled", "WrapMode" }, // TextEdit
-	//	{ "Zfar", "Far" }, // Camera3D
-	//	{ "Znear", "Near" }, // Camera3D
-	//	{ "Pressed", "ButtonPressed" }, // BaseButton - Will also rename the signal, skipping for now
-	{ "AsNormalmap", "AsNormalMap" }, // NoiseTexture
-	{ "BbcodeText", "Text" }, // RichTextLabel
-	{ "CaretBlinkSpeed", "CaretBlinkInterval" }, // TextEdit, LineEdit
-	{ "CaretMovingByRightClick", "CaretMoveOnRightClick" }, // TextEdit
-	{ "CaretPosition", "CaretColumn" }, // LineEdit
-	{ "CheckVadjust", "CheckVAdjust" }, // Theme
-	{ "CloseHOfs", "CloseHOffset" }, // Theme
-	{ "CloseVOfs", "CloseVOffset" }, // Theme
-	{ "Commentfocus", "CommentFocus" }, // Theme
-	{ "DepthBiasEnable", "DepthBiasEnabled" }, // RDPipelineRasterizationState
-	{ "DragMarginBottom", "DragBottomMargin" }, // Camera2D
-	{ "DragMarginHEnabled", "DragHorizontalEnabled" }, // Camera2D
-	{ "DragMarginLeft", "DragLeftMargin" }, // Camera2D
-	{ "DragMarginRight", "DragRightMargin" }, // Camera2D
-	{ "DragMarginTop", "DragTopMargin" }, // Camera2D
-	{ "DragMarginVEnabled", "DragVerticalEnabled" }, // Camera2D
-	{ "EnabledFocusMode", "FocusMode" }, // BaseButton - Removed
-	{ "ExtraSpacingBottom", "SpacingBottom" }, // Font
-	{ "ExtraSpacingTop", "SpacingTop" }, // Font
-	{ "FocusNeighbourBottom", "FocusNeighborBottom" }, // Control
-	{ "FocusNeighbourLeft", "FocusNeighborLeft" }, // Control
-	{ "FocusNeighbourRight", "FocusNeighborRight" }, // Control
-	{ "FocusNeighbourTop", "FocusNeighborTop" }, // Control
-	{ "FollowViewportEnable", "FollowViewportEnabled" }, // CanvasItem
-	{ "GlobalRateScale", "PlaybackSpeedScale" }, // AudioServer
-	{ "GravityDistanceScale", "GravityPointDistanceScale" }, // Area2D
-	{ "GravityVec", "GravityDirection" }, // Area2D
-	{ "HintTooltip", "TooltipText" }, // Control
-	{ "Hseparation", "HSeparation" }, // Theme
-	{ "IconAlign", "IconAlignment" }, // Button
-	{ "IterationsPerSecond", "PhysicsTicksPerSecond" }, // Engine
-	{ "InvertEnable", "InvertEnabled" }, // Polygon2D
-	{ "MarginBottom", "OffsetBottom" }, // Control broke NinePatchRect, StyleBox
-	{ "MarginLeft", "OffsetLeft" }, // Control broke NinePatchRect, StyleBox
-	{ "MarginRight", "OffsetRight" }, // Control broke NinePatchRect, StyleBox
-	{ "MarginTop", "OffsetTop" }, // Control broke NinePatchRect, StyleBox
-	{ "MidHeight", "Height" }, // CapsuleMesh
-	{ "NeighborDist", "NeighborDistance" }, // NavigationAgent2D, NavigationAgent3D
-	{ "OffsetH", "DragHorizontalOffset" }, // Camera2D
-	{ "OffsetV", "DragVerticalOffset" }, // Camera2D
-	{ "Ofs", "Offset" }, // Theme
-	{ "Oneshot", "OneShot" }, // AnimatedTexture
-	{ "OutOfRangeMode", "MaxPolyphony" }, // AudioStreamPlayer3D
-	{ "PauseMode", "ProcessMode" }, // Node
-	{ "PhysicalScancode", "PhysicalKeycode" }, // InputEventKey
-	{ "PopupExclusive", "Exclusive" }, // Window
-	{ "ProximityFadeEnable", "ProximityFadeEnabled" }, // Material
-	{ "RectPosition", "Position" }, // Control
-	{ "RectGlobalPosition", "GlobalPosition" }, // Control
-	{ "RectSize", "Size" }, // Control
-	{ "RectMinSize", "CustomMinimumSize" }, // Control
-	{ "RectRotation", "Rotation" }, // Control
-	{ "RectScale", "Scale" }, // Control
-	{ "RectPivotOffset", "PivotOffset" }, // Control
-	{ "RectClipContent", "ClipContents" }, // Control
-	{ "RefuseNewNetworkConnections", "RefuseNewConnections" }, // MultiplayerAPI
-	{ "RegionFilterClip", "RegionFilterClipEnabled" }, // Sprite2D
-	{ "ReverbBusEnable", "ReverbBusEnabled" }, // Area3D
-	{ "Selectedframe", "SelectedFrame" }, // Theme
-	{ "SizeOverrideStretch", "Size2dOverrideStretch" }, // SubViewport
-	{ "SlipsOnSlope", "SlideOnSlope" }, // SeparationRayShape2D
-	{ "SmoothingEnabled", "FollowSmoothingEnabled" }, // Camera2D
-	{ "SmoothingSpeed", "FollowSmoothingSpeed" }, // Camera2D
-	{ "SsReflectionsDepthTolerance", "SsrDepthTolerance" }, // Environment
-	{ "SsReflectionsEnabled", "SsrEnabled" }, // Environment
-	{ "SsReflectionsFadeIn", "SsrFadeIn" }, // Environment
-	{ "SsReflectionsFadeOut", "SsrFadeOut" }, // Environment
-	{ "SsReflectionsMaxSteps", "SsrMaxSteps" }, // Environment
-	{ "StateMachineSelectedframe", "StateMachineSelectedFrame" }, // Theme
-	{ "SyntaxHighlighting", "SyntaxHighlighter" }, // TextEdit
-	{ "TabAlign", "TabAlignment" }, // TabContainer
-	{ "TableHseparation", "TableHSeparation" }, // Theme
-	{ "TableVseparation", "TableVSeparation" }, // Theme
-	{ "Translation", "Position" }, // Node3D - broke GLTFNode
-	{ "UnitDb", "VolumeDb" }, // AudioStreamPlayer3D
-	{ "UnitOffset", "ProgressRatio" }, // PathFollow2D, PathFollow3D
-	{ "Vseparation", "VSeparation" }, // Theme
-
-	{ nullptr, nullptr },
-};
-
-const char *ProjectConverter3To4::gdscript_signals_renames[][2] = {
-	//  {"instantiate","instance"}, // FileSystemDock
-	// { "hide", "hidden" }, // CanvasItem - function with same name exists
-	// { "tween_all_completed","loop_finished"}, // Tween - TODO, not sure
-	// {"changed","settings_changed"}, // EditorSettings
-	{ "about_to_show", "about_to_popup" }, // Popup
-	{ "button_release", "button_released" }, // XRController3D
-	{ "cancelled", "canceled" }, // AcceptDialog
-	{ "item_double_clicked", "item_icon_double_clicked" }, // Tree
-	{ "network_peer_connected", "peer_connected" }, // MultiplayerAPI
-	{ "network_peer_disconnected", "peer_disconnected" }, // MultiplayerAPI
-	{ "network_peer_packet", "peer_packet" }, // MultiplayerAPI
-	{ "node_unselected", "node_deselected" }, // GraphEdit
-	{ "offset_changed", "position_offset_changed" }, // GraphNode
-	{ "settings_changed", "changed" }, // TileMap broke EditorSettings
-	{ "skeleton_updated", "pose_updated" }, //
-	{ "tab_close", "tab_closed" }, // TextEdit
-	{ "tab_hover", "tab_hovered" }, // TextEdit
-	{ "text_entered", "text_submitted" }, // LineEdit
-	{ "tween_completed", "finished" }, // Tween
-	{ "tween_step", "step_finished" }, // Tween
-
-	{ nullptr, nullptr },
-};
-
-const char *ProjectConverter3To4::csharp_signals_renames[][2] = {
-	//  {"Instantiate","Instance"}, // FileSystemDock
-	// { "Hide", "Hidden" }, // CanvasItem - function with same name exists
-	// { "TweenAllCompleted","LoopFinished"}, // Tween - TODO, not sure
-	// {"Changed","SettingsChanged"}, // EditorSettings
-	{ "AboutToShow", "AboutToPopup" }, // Popup
-	{ "ButtonRelease", "ButtonReleased" }, // XRController3D
-	{ "NetworkPeerConnected", "PeerConnected" }, // MultiplayerAPI
-	{ "NetworkPeerDisconnected", "PeerDisconnected" }, // MultiplayerAPI
-	{ "NetworkPeerPacket", "PeerPacket" }, // MultiplayerAPI
-	{ "NodeUnselected", "NodeDeselected" }, // GraphEdit
-	{ "OffsetChanged", "PositionOffsetChanged" }, // GraphNode
-	{ "SettingsChanged", "Changed" }, // TileMap broke EditorSettings
-	{ "SkeletonUpdated", "PoseUpdated" }, //
-	{ "TabClose", "TabClosed" }, // TextEdit
-	{ "TabHover", "TabHovered" }, // TextEdit
-	{ "TextEntered", "TextSubmitted" }, // LineEdit
-	{ "TweenCompleted", "Finished" }, // Tween
-	{ "TweenStep", "StepFinished" }, // Tween
-
-	{ nullptr, nullptr },
-
-};
-
-const char *ProjectConverter3To4::project_settings_renames[][2] = {
-	{ "audio/channel_disable_threshold_db", "audio/buses/channel_disable_threshold_db" },
-	{ "audio/channel_disable_time", "audio/buses/channel_disable_time" },
-	{ "audio/default_bus_layout", "audio/buses/default_bus_layout" },
-	{ "audio/driver", "audio/driver/driver" },
-	{ "audio/enable_audio_input", "audio/driver/enable_input" },
-	{ "audio/mix_rate", "audio/driver/mix_rate" },
-	{ "audio/output_latency", "audio/driver/output_latency" },
-	{ "audio/output_latency.web", "audio/driver/output_latency.web" },
-	{ "audio/video_delay_compensation_ms", "audio/video/video_delay_compensation_ms" },
-	{ "display/window/vsync/use_vsync", "display/window/vsync/vsync_mode" },
-	{ "editor/main_run_args", "editor/run/main_run_args" },
-	{ "gui/common/swap_ok_cancel", "gui/common/swap_cancel_ok" },
-	{ "network/limits/debugger_stdout/max_chars_per_second", "network/limits/debugger/max_chars_per_second" },
-	{ "network/limits/debugger_stdout/max_errors_per_second", "network/limits/debugger/max_errors_per_second" },
-	{ "network/limits/debugger_stdout/max_messages_per_frame", "network/limits/debugger/max_queued_messages" },
-	{ "network/limits/debugger_stdout/max_warnings_per_second", "network/limits/debugger/max_warnings_per_second" },
-	{ "network/ssl/certificates", "network/tls/certificate_bundle_override" },
-	{ "physics/2d/thread_model", "physics/2d/run_on_thread" }, // TODO not sure
-	{ "rendering/environment/default_clear_color", "rendering/environment/defaults/default_clear_color" },
-	{ "rendering/environment/default_environment", "rendering/environment/defaults/default_environment" },
-	{ "rendering/quality/depth_prepass/disable_for_vendors", "rendering/driver/depth_prepass/disable_for_vendors" },
-	{ "rendering/quality/depth_prepass/enable", "rendering/driver/depth_prepass/enable" },
-	{ "rendering/quality/shading/force_blinn_over_ggx", "rendering/shading/overrides/force_blinn_over_ggx" },
-	{ "rendering/quality/shading/force_blinn_over_ggx.mobile", "rendering/shading/overrides/force_blinn_over_ggx.mobile" },
-	{ "rendering/quality/shading/force_lambert_over_burley", "rendering/shading/overrides/force_lambert_over_burley" },
-	{ "rendering/quality/shading/force_lambert_over_burley.mobile", "rendering/shading/overrides/force_lambert_over_burley.mobile" },
-	{ "rendering/quality/shading/force_vertex_shading", "rendering/shading/overrides/force_vertex_shading" },
-	{ "rendering/quality/shading/force_vertex_shading.mobile", "rendering/shading/overrides/force_vertex_shading.mobile" },
-	{ "rendering/quality/shadow_atlas/quadrant_0_subdiv", "rendering/lights_and_shadows/shadow_atlas/quadrant_0_subdiv" },
-	{ "rendering/quality/shadow_atlas/quadrant_1_subdiv", "rendering/lights_and_shadows/shadow_atlas/quadrant_1_subdiv" },
-	{ "rendering/quality/shadow_atlas/quadrant_2_subdiv", "rendering/lights_and_shadows/shadow_atlas/quadrant_2_subdiv" },
-	{ "rendering/quality/shadow_atlas/quadrant_3_subdiv", "rendering/lights_and_shadows/shadow_atlas/quadrant_3_subdiv" },
-	{ "rendering/quality/shadow_atlas/size", "rendering/lights_and_shadows/shadow_atlas/size" },
-	{ "rendering/quality/shadow_atlas/size.mobile", "rendering/lights_and_shadows/shadow_atlas/size.mobile" },
-	{ "rendering/vram_compression/import_etc2", "rendering/textures/vram_compression/import_etc2_astc" },
-	{ "rendering/vram_compression/import_s3tc", "rendering/textures/vram_compression/import_s3tc_bptc" },
-	{ "window/size/width", "window/size/viewport_width" },
-	{ "window/size/height", "window/size/viewport_height" },
-	{ "window/size/test_width", "window/size/window_width_override" },
-	{ "window/size/test_height", "window/size/window_height_override" },
-
-	{ nullptr, nullptr },
-};
-
-const char *ProjectConverter3To4::input_map_renames[][2] = {
-	{ ",\"alt\":", ",\"alt_pressed\":" },
-	{ ",\"shift\":", ",\"shift_pressed\":" },
-	{ ",\"control\":", ",\"ctrl_pressed\":" },
-	{ ",\"meta\":", ",\"meta_pressed\":" },
-	{ ",\"scancode\":", ",\"keycode\":" },
-	{ ",\"physical_scancode\":", ",\"physical_keycode\":" },
-	{ ",\"doubleclick\":", ",\"double_click\":" },
-
-	{ nullptr, nullptr },
-};
-
-const char *ProjectConverter3To4::builtin_types_renames[][2] = {
-	{ "PoolByteArray", "PackedByteArray" },
-	{ "PoolColorArray", "PackedColorArray" },
-	{ "PoolIntArray", "PackedInt32Array" },
-	{ "PoolRealArray", "PackedFloat32Array" },
-	{ "PoolStringArray", "PackedStringArray" },
-	{ "PoolVector2Array", "PackedVector2Array" },
-	{ "PoolVector3Array", "PackedVector3Array" },
-	{ "Quat", "Quaternion" },
-	{ "Transform", "Transform3D" },
-
-	{ nullptr, nullptr },
-};
-
-const char *ProjectConverter3To4::shaders_renames[][2] = {
-	{ "ALPHA_SCISSOR", "ALPHA_SCISSOR_THRESHOLD" },
-	{ "CAMERA_MATRIX", "INV_VIEW_MATRIX" },
-	{ "INV_CAMERA_MATRIX", "VIEW_MATRIX" },
-	{ "NORMALMAP", "NORMAL_MAP" },
-	{ "NORMALMAP_DEPTH", "NORMAL_MAP_DEPTH" },
-	{ "TRANSMISSION", "BACKLIGHT" },
-	{ "WORLD_MATRIX", "MODEL_MATRIX" },
-	{ "depth_draw_alpha_prepass", "depth_draw_opaque" },
-	{ "hint_albedo", "source_color" },
-	{ "hint_aniso", "hint_anisotropy" },
-	{ "hint_black", "hint_default_black" },
-	{ "hint_black_albedo", "hint_default_black" },
-	{ "hint_color", "source_color" },
-	{ "hint_white", "hint_default_white" },
-	{ nullptr, nullptr },
-};
-
-const char *ProjectConverter3To4::class_renames[][2] = {
-	// { "BulletPhysicsDirectBodyState", "BulletPhysicsDirectBodyState3D" }, // Class is not visible in ClassDB
-	// { "BulletPhysicsServer", "BulletPhysicsServer3D" }, // Class is not visible in ClassDB
-	// { "GDScriptFunctionState", "Node3D" }, // TODO - not sure to which should be changed
-	// { "GDScriptNativeClass", "Node3D" }, // TODO - not sure to which should be changed
-	// { "InputDefault",""}, // TODO ?
-	// { "Physics2DDirectBodyStateSW", "GodotPhysicsDirectBodyState2D" }, // Class is not visible in ClassDB
-	// { "Physics2DShapeQueryResult", "PhysicsShapeQueryResult2D" }, // Class is not visible in ClassDB
-	// { "PhysicsShapeQueryResult", "PhysicsShapeQueryResult3D" }, // Class is not visible in ClassDB
-	// { "NativeScript","GDExtension"}, ??
-	{ "ARVRAnchor", "XRAnchor3D" },
-	{ "ARVRCamera", "XRCamera3D" },
-	{ "ARVRController", "XRController3D" },
-	{ "ARVRInterface", "XRInterface" },
-	{ "ARVRInterfaceGDNative", "Node3D" },
-	{ "ARVROrigin", "XROrigin3D" },
-	{ "ARVRPositionalTracker", "XRPositionalTracker" },
-	{ "ARVRServer", "XRServer" },
-	{ "AStar", "AStar3D" },
-	{ "AnimatedSprite", "AnimatedSprite2D" },
-	{ "AnimationTreePlayer", "AnimationTree" },
-	{ "Area", "Area3D" }, // Be careful, this will be used everywhere
-	{ "AudioStreamOGGVorbis", "AudioStreamOggVorbis" },
-	{ "AudioStreamRandomPitch", "AudioStreamRandomizer" },
-	{ "AudioStreamSample", "AudioStreamWAV" },
-	{ "BakedLightmap", "LightmapGI" },
-	{ "BakedLightmapData", "LightmapGIData" },
-	{ "BitmapFont", "FontFile" },
-	{ "BoneAttachment", "BoneAttachment3D" },
-	{ "BoxShape", "BoxShape3D" },
-	{ "CPUParticles", "CPUParticles3D" },
-	{ "CSGBox", "CSGBox3D" },
-	{ "CSGCombiner", "CSGCombiner3D" },
-	{ "CSGCylinder", "CSGCylinder3D" },
-	{ "CSGMesh", "CSGMesh3D" },
-	{ "CSGPolygon", "CSGPolygon3D" },
-	{ "CSGPrimitive", "CSGPrimitive3D" },
-	{ "CSGShape", "CSGShape3D" },
-	{ "CSGSphere", "CSGSphere3D" },
-	{ "CSGTorus", "CSGTorus3D" },
-	{ "Camera", "Camera3D" }, // Be careful, this will be used everywhere
-	{ "CapsuleShape", "CapsuleShape3D" },
-	{ "ClippedCamera", "Camera3D" },
-	{ "CollisionObject", "CollisionObject3D" },
-	{ "CollisionPolygon", "CollisionPolygon3D" },
-	{ "CollisionShape", "CollisionShape3D" },
-	{ "ConcavePolygonShape", "ConcavePolygonShape3D" },
-	{ "ConeTwistJoint", "ConeTwistJoint3D" },
-	{ "ConvexPolygonShape", "ConvexPolygonShape3D" },
-	{ "CubeMap", "Cubemap" },
-	{ "CubeMesh", "BoxMesh" },
-	{ "CylinderShape", "CylinderShape3D" },
-	{ "DirectionalLight", "DirectionalLight3D" },
-	{ "DynamicFont", "FontFile" },
-	{ "DynamicFontData", "FontFile" },
-	{ "EditorNavigationMeshGenerator", "NavigationMeshGenerator" },
-	{ "EditorSceneImporter", "EditorSceneFormatImporter" },
-	{ "EditorSceneImporterFBX", "EditorSceneFormatImporterFBX" },
-	{ "EditorSceneImporterGLTF", "EditorSceneFormatImporterGLTF" },
-	{ "EditorSpatialGizmo", "EditorNode3DGizmo" },
-	{ "EditorSpatialGizmoPlugin", "EditorNode3DGizmoPlugin" },
-	{ "ExternalTexture", "ImageTexture" },
-	{ "FuncRef", "Callable" },
-	{ "GIProbe", "VoxelGI" },
-	{ "GIProbeData", "VoxelGIData" },
-	{ "Generic6DOFJoint", "Generic6DOFJoint3D" },
-	{ "Geometry", "Geometry2D" }, // Geometry class is split between Geometry2D and Geometry3D so we need to choose one
-	{ "GeometryInstance", "GeometryInstance3D" },
-	{ "GradientTexture", "GradientTexture2D" },
-	{ "HeightMapShape", "HeightMapShape3D" },
-	{ "HingeJoint", "HingeJoint3D" },
-	{ "IP_Unix", "IPUnix" },
-	{ "ImmediateGeometry", "ImmediateMesh" },
-	{ "ImmediateGeometry3D", "ImmediateMesh" },
-	{ "InterpolatedCamera", "Camera3D" },
-	{ "InterpolatedCamera3D", "Camera3D" },
-	{ "JSONParseResult", "JSON" },
-	{ "Joint", "Joint3D" },
-	{ "KinematicBody", "CharacterBody3D" },
-	{ "KinematicBody2D", "CharacterBody2D" },
-	{ "KinematicCollision", "KinematicCollision3D" },
-	{ "LargeTexture", "ImageTexture" },
-	{ "Light", "Light3D" },
-	{ "Light2D", "PointLight2D" },
-	{ "LineShape2D", "WorldBoundaryShape2D" },
-	{ "Listener", "AudioListener3D" },
-	{ "Listener2D", "AudioListener2D" },
-	{ "MeshInstance", "MeshInstance3D" },
-	{ "MultiMeshInstance", "MultiMeshInstance3D" },
-	{ "MultiplayerPeerGDNative", "MultiplayerPeerExtension" },
-	{ "Navigation", "Node3D" },
-	{ "Navigation2D", "Node2D" },
-	{ "Navigation2DServer", "NavigationServer2D" },
-	{ "Navigation3D", "Node3D" },
-	{ "NavigationAgent", "NavigationAgent3D" },
-	{ "NavigationMeshInstance", "NavigationRegion3D" },
-	{ "NavigationObstacle", "NavigationObstacle3D" },
-	{ "NavigationPolygonInstance", "NavigationRegion2D" },
-	{ "NavigationRegion", "NavigationRegion3D" },
-	{ "NavigationServer", "NavigationServer3D" },
-	{ "NetworkedMultiplayerENet", "ENetMultiplayerPeer" },
-	{ "NetworkedMultiplayerPeer", "MultiplayerPeer" },
-	{ "Occluder", "OccluderInstance3D" },
-	{ "OmniLight", "OmniLight3D" },
-	{ "PHashTranslation", "OptimizedTranslation" },
-	{ "PacketPeerGDNative", "PacketPeerExtension" },
-	{ "PanoramaSky", "Sky" },
-	{ "Particles", "GPUParticles3D" }, // Be careful, this will be used everywhere
-	{ "Particles2D", "GPUParticles2D" },
-	{ "ParticlesMaterial", "ParticleProcessMaterial" },
-	{ "Path", "Path3D" }, // Be careful, this will be used everywhere
-	{ "PathFollow", "PathFollow3D" },
-	{ "PhysicalBone", "PhysicalBone3D" },
-	{ "Physics2DDirectBodyState", "PhysicsDirectBodyState2D" },
-	{ "Physics2DDirectSpaceState", "PhysicsDirectSpaceState2D" },
-	{ "Physics2DServer", "PhysicsServer2D" },
-	{ "Physics2DServerSW", "GodotPhysicsServer2D" },
-	{ "Physics2DShapeQueryParameters", "PhysicsShapeQueryParameters2D" },
-	{ "Physics2DTestMotionResult", "PhysicsTestMotionResult2D" },
-	{ "PhysicsBody", "PhysicsBody3D" },
-	{ "PhysicsDirectBodyState", "PhysicsDirectBodyState3D" },
-	{ "PhysicsDirectSpaceState", "PhysicsDirectSpaceState3D" },
-	{ "PhysicsServer", "PhysicsServer3D" },
-	{ "PhysicsShapeQueryParameters", "PhysicsShapeQueryParameters3D" },
-	{ "PhysicsTestMotionResult", "PhysicsTestMotionResult3D" },
-	{ "PinJoint", "PinJoint3D" },
-	{ "PlaneShape", "WorldBoundaryShape3D" },
-	{ "PopupDialog", "Popup" },
-	{ "Position2D", "Marker2D" },
-	{ "Position3D", "Marker3D" },
-	{ "ProceduralSky", "Sky" },
-	{ "RayCast", "RayCast3D" },
-	{ "RayShape", "SeparationRayShape3D" },
-	{ "RayShape2D", "SeparationRayShape2D" },
-	{ "Reference", "RefCounted" }, // Be careful, this will be used everywhere
-	{ "RemoteTransform", "RemoteTransform3D" },
-	{ "ResourceInteractiveLoader", "ResourceLoader" },
-	{ "RigidBody", "RigidBody3D" },
-	{ "SceneTreeTween", "Tween" },
-	{ "Shape", "Shape3D" }, // Be careful, this will be used everywhere
-	{ "ShortCut", "Shortcut" },
-	{ "Skeleton", "Skeleton3D" },
-	{ "SkeletonIK", "SkeletonIK3D" },
-	{ "SliderJoint", "SliderJoint3D" },
-	{ "SoftBody", "SoftBody3D" },
-	{ "Spatial", "Node3D" },
-	{ "SpatialGizmo", "Node3DGizmo" },
-	{ "SpatialMaterial", "StandardMaterial3D" },
-	{ "SphereShape", "SphereShape3D" },
-	{ "SpotLight", "SpotLight3D" },
-	{ "SpringArm", "SpringArm3D" },
-	{ "Sprite", "Sprite2D" },
-	{ "StaticBody", "StaticBody3D" },
-	{ "StreamCubemap", "CompressedCubemap" },
-	{ "StreamCubemapArray", "CompressedCubemapArray" },
-	{ "StreamPeerGDNative", "StreamPeerExtension" },
-	{ "StreamPeerSSL", "StreamPeerTLS" },
-	{ "StreamTexture", "CompressedTexture2D" },
-	{ "StreamTexture2D", "CompressedTexture2D" },
-	{ "StreamTexture2DArray", "CompressedTexture2DArray" },
-	{ "StreamTextureLayered", "CompressedTextureLayered" },
-	{ "TCP_Server", "TCPServer" },
-	{ "Tabs", "TabBar" }, // Be careful, this will be used everywhere
-	{ "TextFile", "Node3D" },
-	{ "Texture", "Texture2D" }, // May broke TextureRect
-	{ "TextureArray", "Texture2DArray" },
-	{ "TextureProgress", "TextureProgressBar" },
-	{ "ToolButton", "Button" },
-	{ "VehicleBody", "VehicleBody3D" },
-	{ "VehicleWheel", "VehicleWheel3D" },
-	{ "VideoPlayer", "VideoStreamPlayer" },
-	{ "Viewport", "SubViewport" },
-	{ "ViewportContainer", "SubViewportContainer" },
-	{ "VisibilityEnabler", "VisibleOnScreenEnabler3D" },
-	{ "VisibilityEnabler2D", "VisibleOnScreenEnabler2D" },
-	{ "VisibilityNotifier", "VisibleOnScreenNotifier3D" },
-	{ "VisibilityNotifier2D", "VisibleOnScreenNotifier2D" },
-	{ "VisibilityNotifier3D", "VisibleOnScreenNotifier3D" },
-	{ "VisualInstance", "VisualInstance3D" },
-	{ "VisualServer", "RenderingServer" },
-	{ "VisualShaderNodeCubeMap", "VisualShaderNodeCubemap" },
-	{ "VisualShaderNodeScalarClamp", "VisualShaderNodeClamp" },
-	{ "VisualShaderNodeScalarConstant", "VisualShaderNodeFloatConstant" },
-	{ "VisualShaderNodeScalarFunc", "VisualShaderNodeFloatFunc" },
-	{ "VisualShaderNodeScalarInterp", "VisualShaderNodeMix" },
-	{ "VisualShaderNodeScalarOp", "VisualShaderNodeFloatOp" },
-	{ "VisualShaderNodeScalarSmoothStep", "VisualShaderNodeSmoothStep" },
-	{ "VisualShaderNodeScalarSwitch", "VisualShaderNodeSwitch" },
-	{ "VisualShaderNodeScalarTransformMult", "VisualShaderNodeTransformOp" },
-	{ "VisualShaderNodeTransformMult", "VisualShaderNode" },
-	{ "VisualShaderNodeVectorClamp", "VisualShaderNodeClamp" },
-	{ "VisualShaderNodeVectorInterp", "VisualShaderNodeMix" },
-	{ "VisualShaderNodeVectorScalarMix", "VisualShaderNodeMix" },
-	{ "VisualShaderNodeVectorScalarSmoothStep", "VisualShaderNodeSmoothStep" },
-	{ "VisualShaderNodeVectorScalarStep", "VisualShaderNodeStep" },
-	{ "VisualShaderNodeVectorSmoothStep", "VisualShaderNodeSmoothStep" },
-	{ "VisualShaderNodeBooleanUniform", "VisualShaderNodeBooleanParameter" },
-	{ "VisualShaderNodeColorUniform", "VisualShaderNodeColorParameter" },
-	{ "VisualShaderNodeScalarUniform", "VisualShaderNodeFloatParameter" },
-	{ "VisualShaderNodeCubemapUniform", "VisualShaderNodeCubemapParameter" },
-	{ "VisualShaderNodeTextureUniform", "VisualShaderNodeTexture2DParameter" },
-	{ "VisualShaderNodeTextureUniformTriplanar", "VisualShaderNodeTextureParameterTriplanar" },
-	{ "VisualShaderNodeTransformUniform", "VisualShaderNodeTransformParameter" },
-	{ "VisualShaderNodeVec3Uniform", "VisualShaderNodeVec3Parameter" },
-	{ "VisualShaderNodeUniform", "VisualShaderNodeParameter" },
-	{ "VisualShaderNodeUniformRef", "VisualShaderNodeParameterRef" },
-	{ "WebRTCDataChannelGDNative", "WebRTCDataChannelExtension" },
-	{ "WebRTCMultiplayer", "WebRTCMultiplayerPeer" },
-	{ "WebRTCPeerConnectionGDNative", "WebRTCPeerConnectionExtension" },
-	{ "WindowDialog", "Window" },
-	{ "World", "World3D" }, // Be careful, this will be used everywhere
-	{ "XRAnchor", "XRAnchor3D" },
-	{ "XRController", "XRController3D" },
-	{ "XROrigin", "XROrigin3D" },
-	{ "YSort", "Node2D" },
-
-	{ "CullInstance", "Node3D" }, // Probably this type needs to be added to Godot 4.0, since it is for now only available only in Godot 3.x
-	{ "RoomGroup", "Node3D" }, // Probably this type needs to be added to Godot 4.0, since it is for now only available only in Godot 3.x
-	{ "Room", "Node3D" }, // Probably this type needs to be added to Godot 4.0, since it is for now only available only in Godot 3.x
-	{ "RoomManager", "Node3D" }, // Probably this type needs to be added to Godot 4.0, since it is for now only available only in Godot 3.x
-	{ "Portal", "Node3D" }, // Probably this type needs to be added to Godot 4.0, since it is for now only available only in Godot 3.x
-
-	{ nullptr, nullptr },
-};
-
-const char *ProjectConverter3To4::ProjectConverter3To4::color_renames[][2] = {
-	{ "aliceblue", "ALICE_BLUE" },
-	{ "antiquewhite", "ANTIQUE_WHITE" },
-	{ "aqua", "AQUA" },
-	{ "aquamarine", "AQUAMARINE" },
-	{ "azure", "AZURE" },
-	{ "beige", "BEIGE" },
-	{ "bisque", "BISQUE" },
-	{ "black", "BLACK" },
-	{ "blanchedalmond", "BLANCHED_ALMOND" },
-	{ "blue", "BLUE" },
-	{ "blueviolet", "BLUE_VIOLET" },
-	{ "brown", "BROWN" },
-	{ "burlywood", "BURLYWOOD" },
-	{ "cadetblue", "CADET_BLUE" },
-	{ "chartreuse", "CHARTREUSE" },
-	{ "chocolate", "CHOCOLATE" },
-	{ "coral", "CORAL" },
-	{ "cornflowerblue", "CORNFLOWER_BLUE" },
-	{ "cornsilk", "CORNSILK" },
-	{ "crimson", "CRIMSON" },
-	{ "cyan", "CYAN" },
-	{ "darkblue", "DARK_BLUE" },
-	{ "darkcyan", "DARK_CYAN" },
-	{ "darkgoldenrod", "DARK_GOLDENROD" },
-	{ "darkgray", "DARK_GRAY" },
-	{ "darkgreen", "DARK_GREEN" },
-	{ "darkkhaki", "DARK_KHAKI" },
-	{ "darkmagenta", "DARK_MAGENTA" },
-	{ "darkolivegreen", "DARK_OLIVE_GREEN" },
-	{ "darkorange", "DARK_ORANGE" },
-	{ "darkorchid", "DARK_ORCHID" },
-	{ "darkred", "DARK_RED" },
-	{ "darksalmon", "DARK_SALMON" },
-	{ "darkseagreen", "DARK_SEA_GREEN" },
-	{ "darkslateblue", "DARK_SLATE_BLUE" },
-	{ "darkslategray", "DARK_SLATE_GRAY" },
-	{ "darkturquoise", "DARK_TURQUOISE" },
-	{ "darkviolet", "DARK_VIOLET" },
-	{ "deeppink", "DEEP_PINK" },
-	{ "deepskyblue", "DEEP_SKY_BLUE" },
-	{ "dimgray", "DIM_GRAY" },
-	{ "dodgerblue", "DODGER_BLUE" },
-	{ "firebrick", "FIREBRICK" },
-	{ "floralwhite", "FLORAL_WHITE" },
-	{ "forestgreen", "FOREST_GREEN" },
-	{ "fuchsia", "FUCHSIA" },
-	{ "gainsboro", "GAINSBORO" },
-	{ "ghostwhite", "GHOST_WHITE" },
-	{ "gold", "GOLD" },
-	{ "goldenrod", "GOLDENROD" },
-	{ "gray", "GRAY" },
-	{ "green", "GREEN" },
-	{ "greenyellow", "GREEN_YELLOW" },
-	{ "honeydew", "HONEYDEW" },
-	{ "hotpink", "HOT_PINK" },
-	{ "indianred", "INDIAN_RED" },
-	{ "indigo", "INDIGO" },
-	{ "ivory", "IVORY" },
-	{ "khaki", "KHAKI" },
-	{ "lavender", "LAVENDER" },
-	{ "lavenderblush", "LAVENDER_BLUSH" },
-	{ "lawngreen", "LAWN_GREEN" },
-	{ "lemonchiffon", "LEMON_CHIFFON" },
-	{ "lightblue", "LIGHT_BLUE" },
-	{ "lightcoral", "LIGHT_CORAL" },
-	{ "lightcyan", "LIGHT_CYAN" },
-	{ "lightgoldenrod", "LIGHT_GOLDENROD" },
-	{ "lightgray", "LIGHT_GRAY" },
-	{ "lightgreen", "LIGHT_GREEN" },
-	{ "lightpink", "LIGHT_PINK" },
-	{ "lightsalmon", "LIGHT_SALMON" },
-	{ "lightseagreen", "LIGHT_SEA_GREEN" },
-	{ "lightskyblue", "LIGHT_SKY_BLUE" },
-	{ "lightslategray", "LIGHT_SLATE_GRAY" },
-	{ "lightsteelblue", "LIGHT_STEEL_BLUE" },
-	{ "lightyellow", "LIGHT_YELLOW" },
-	{ "lime", "LIME" },
-	{ "limegreen", "LIME_GREEN" },
-	{ "linen", "LINEN" },
-	{ "magenta", "MAGENTA" },
-	{ "maroon", "MAROON" },
-	{ "mediumaquamarine", "MEDIUM_AQUAMARINE" },
-	{ "mediumblue", "MEDIUM_BLUE" },
-	{ "mediumorchid", "MEDIUM_ORCHID" },
-	{ "mediumpurple", "MEDIUM_PURPLE" },
-	{ "mediumseagreen", "MEDIUM_SEA_GREEN" },
-	{ "mediumslateblue", "MEDIUM_SLATE_BLUE" },
-	{ "mediumspringgreen", "MEDIUM_SPRING_GREEN" },
-	{ "mediumturquoise", "MEDIUM_TURQUOISE" },
-	{ "mediumvioletred", "MEDIUM_VIOLET_RED" },
-	{ "midnightblue", "MIDNIGHT_BLUE" },
-	{ "mintcream", "MINT_CREAM" },
-	{ "mistyrose", "MISTY_ROSE" },
-	{ "moccasin", "MOCCASIN" },
-	{ "navajowhite", "NAVAJO_WHITE" },
-	{ "navyblue", "NAVY_BLUE" },
-	{ "oldlace", "OLD_LACE" },
-	{ "olive", "OLIVE" },
-	{ "olivedrab", "OLIVE_DRAB" },
-	{ "orange", "ORANGE" },
-	{ "orangered", "ORANGE_RED" },
-	{ "orchid", "ORCHID" },
-	{ "palegoldenrod", "PALE_GOLDENROD" },
-	{ "palegreen", "PALE_GREEN" },
-	{ "paleturquoise", "PALE_TURQUOISE" },
-	{ "palevioletred", "PALE_VIOLET_RED" },
-	{ "papayawhip", "PAPAYA_WHIP" },
-	{ "peachpuff", "PEACH_PUFF" },
-	{ "peru", "PERU" },
-	{ "pink", "PINK" },
-	{ "plum", "PLUM" },
-	{ "powderblue", "POWDER_BLUE" },
-	{ "purple", "PURPLE" },
-	{ "rebeccapurple", "REBECCA_PURPLE" },
-	{ "red", "RED" },
-	{ "rosybrown", "ROSY_BROWN" },
-	{ "royalblue", "ROYAL_BLUE" },
-	{ "saddlebrown", "SADDLE_BROWN" },
-	{ "salmon", "SALMON" },
-	{ "sandybrown", "SANDY_BROWN" },
-	{ "seagreen", "SEA_GREEN" },
-	{ "seashell", "SEASHELL" },
-	{ "sienna", "SIENNA" },
-	{ "silver", "SILVER" },
-	{ "skyblue", "SKY_BLUE" },
-	{ "slateblue", "SLATE_BLUE" },
-	{ "slategray", "SLATE_GRAY" },
-	{ "snow", "SNOW" },
-	{ "springgreen", "SPRING_GREEN" },
-	{ "steelblue", "STEEL_BLUE" },
-	{ "tan", "TAN" },
-	{ "teal", "TEAL" },
-	{ "thistle", "THISTLE" },
-	{ "tomato", "TOMATO" },
-	{ "transparent", "TRANSPARENT" },
-	{ "turquoise", "TURQUOISE" },
-	{ "violet", "VIOLET" },
-	{ "webgray", "WEB_GRAY" },
-	{ "webgreen", "WEB_GREEN" },
-	{ "webmaroon", "WEB_MAROON" },
-	{ "webpurple", "WEB_PURPLE" },
-	{ "wheat", "WHEAT" },
-	{ "white", "WHITE" },
-	{ "whitesmoke", "WHITE_SMOKE" },
-	{ "yellow", "YELLOW" },
-	{ "yellowgreen", "YELLOW_GREEN" },
-
-	{ nullptr, nullptr },
-};
+#include "editor/renames_map_3_to_4.h"
+#include "modules/regex/regex.h"
 
 // Find "OS.set_property(x)", capturing x into $1.
 static String make_regex_gds_os_property_set(String name_set) {
@@ -1928,70 +166,71 @@ public:
 		// Common.
 		{
 			// Enum.
-			for (unsigned int current_index = 0; enum_renames[current_index][0]; current_index++) {
-				enum_regexes.push_back(memnew(RegEx(String("\\b") + enum_renames[current_index][0] + "\\b")));
+			for (unsigned int current_index = 0; RenamesMap3To4::enum_renames[current_index][0]; current_index++) {
+				enum_regexes.push_back(memnew(RegEx(String("\\b") + RenamesMap3To4::enum_renames[current_index][0] + "\\b")));
 			}
 			// GDScript functions.
-			for (unsigned int current_index = 0; gdscript_function_renames[current_index][0]; current_index++) {
-				gdscript_function_regexes.push_back(memnew(RegEx(String("\\b") + gdscript_function_renames[current_index][0] + "\\b")));
+			for (unsigned int current_index = 0; RenamesMap3To4::gdscript_function_renames[current_index][0]; current_index++) {
+				gdscript_function_regexes.push_back(memnew(RegEx(String("\\b") + RenamesMap3To4::gdscript_function_renames[current_index][0] + "\\b")));
 			}
 			// Project Settings.
-			for (unsigned int current_index = 0; project_settings_renames[current_index][0]; current_index++) {
-				project_settings_regexes.push_back(memnew(RegEx(String("\\b") + project_settings_renames[current_index][0] + "\\b")));
+			for (unsigned int current_index = 0; RenamesMap3To4::project_settings_renames[current_index][0]; current_index++) {
+				project_settings_regexes.push_back(memnew(RegEx(String("\\b") + RenamesMap3To4::project_settings_renames[current_index][0] + "\\b")));
 			}
 			// Input Map.
-			for (unsigned int current_index = 0; input_map_renames[current_index][0]; current_index++) {
-				input_map_regexes.push_back(memnew(RegEx(String("\\b") + input_map_renames[current_index][0] + "\\b")));
+			for (unsigned int current_index = 0; RenamesMap3To4::input_map_renames[current_index][0]; current_index++) {
+				input_map_regexes.push_back(memnew(RegEx(String("\\b") + RenamesMap3To4::input_map_renames[current_index][0] + "\\b")));
 			}
 			// GDScript properties.
-			for (unsigned int current_index = 0; gdscript_properties_renames[current_index][0]; current_index++) {
-				gdscript_properties_regexes.push_back(memnew(RegEx(String("\\b") + gdscript_properties_renames[current_index][0] + "\\b")));
+			for (unsigned int current_index = 0; RenamesMap3To4::gdscript_properties_renames[current_index][0]; current_index++) {
+				gdscript_properties_regexes.push_back(memnew(RegEx(String("\\b") + RenamesMap3To4::gdscript_properties_renames[current_index][0] + "\\b")));
 			}
 			// GDScript Signals.
-			for (unsigned int current_index = 0; gdscript_signals_renames[current_index][0]; current_index++) {
-				gdscript_signals_regexes.push_back(memnew(RegEx(String("\\b") + gdscript_signals_renames[current_index][0] + "\\b")));
+			for (unsigned int current_index = 0; RenamesMap3To4::gdscript_signals_renames[current_index][0]; current_index++) {
+				gdscript_signals_regexes.push_back(memnew(RegEx(String("\\b") + RenamesMap3To4::gdscript_signals_renames[current_index][0] + "\\b")));
 			}
 			// Shaders.
-			for (unsigned int current_index = 0; shaders_renames[current_index][0]; current_index++) {
-				shaders_regexes.push_back(memnew(RegEx(String("\\b") + shaders_renames[current_index][0] + "\\b")));
+			for (unsigned int current_index = 0; RenamesMap3To4::shaders_renames[current_index][0]; current_index++) {
+				shaders_regexes.push_back(memnew(RegEx(String("\\b") + RenamesMap3To4::shaders_renames[current_index][0] + "\\b")));
 			}
 			// Builtin types.
-			for (unsigned int current_index = 0; builtin_types_renames[current_index][0]; current_index++) {
-				builtin_types_regexes.push_back(memnew(RegEx(String("\\b") + builtin_types_renames[current_index][0] + "\\b")));
+			for (unsigned int current_index = 0; RenamesMap3To4::builtin_types_renames[current_index][0]; current_index++) {
+				builtin_types_regexes.push_back(memnew(RegEx(String("\\b") + RenamesMap3To4::builtin_types_renames[current_index][0] + "\\b")));
 			}
 			// CSharp function renames.
-			for (unsigned int current_index = 0; csharp_function_renames[current_index][0]; current_index++) {
-				csharp_function_regexes.push_back(memnew(RegEx(String("\\b") + csharp_function_renames[current_index][0] + "\\b")));
+			for (unsigned int current_index = 0; RenamesMap3To4::csharp_function_renames[current_index][0]; current_index++) {
+				csharp_function_regexes.push_back(memnew(RegEx(String("\\b") + RenamesMap3To4::csharp_function_renames[current_index][0] + "\\b")));
 			}
 			// CSharp properties renames.
-			for (unsigned int current_index = 0; csharp_properties_renames[current_index][0]; current_index++) {
-				csharp_properties_regexes.push_back(memnew(RegEx(String("\\b") + csharp_properties_renames[current_index][0] + "\\b")));
+			for (unsigned int current_index = 0; RenamesMap3To4::csharp_properties_renames[current_index][0]; current_index++) {
+				csharp_properties_regexes.push_back(memnew(RegEx(String("\\b") + RenamesMap3To4::csharp_properties_renames[current_index][0] + "\\b")));
 			}
 			// CSharp signals renames.
-			for (unsigned int current_index = 0; csharp_signals_renames[current_index][0]; current_index++) {
-				csharp_signal_regexes.push_back(memnew(RegEx(String("\\b") + csharp_signals_renames[current_index][0] + "\\b")));
+			for (unsigned int current_index = 0; RenamesMap3To4::csharp_signals_renames[current_index][0]; current_index++) {
+				csharp_signal_regexes.push_back(memnew(RegEx(String("\\b") + RenamesMap3To4::csharp_signals_renames[current_index][0] + "\\b")));
 			}
 		}
 
 		// Colors.
 		{
-			for (unsigned int current_index = 0; color_renames[current_index][0]; current_index++) {
-				color_regexes.push_back(memnew(RegEx(String("\\bColor.") + color_renames[current_index][0] + "\\b")));
-				color_renamed.push_back(String("Color.") + color_renames[current_index][1]);
+			for (unsigned int current_index = 0; RenamesMap3To4::color_renames[current_index][0]; current_index++) {
+				color_regexes.push_back(memnew(RegEx(String("\\bColor.") + RenamesMap3To4::color_renames[current_index][0] + "\\b")));
+				color_renamed.push_back(String("Color.") + RenamesMap3To4::color_renames[current_index][1]);
 			}
 		}
 		// Classes.
 		{
-			for (unsigned int current_index = 0; class_renames[current_index][0]; current_index++) {
-				class_tscn_regexes.push_back(memnew(RegEx(String("\\b") + class_renames[current_index][0] + ".tscn\\b")));
-				class_gd_regexes.push_back(memnew(RegEx(String("\\b") + class_renames[current_index][0] + ".gd\\b")));
-				class_shader_regexes.push_back(memnew(RegEx(String("\\b") + class_renames[current_index][0] + ".shader\\b")));
+			for (unsigned int current_index = 0; RenamesMap3To4::class_renames[current_index][0]; current_index++) {
+				const String class_name = RenamesMap3To4::class_renames[current_index][0];
+				class_tscn_regexes.push_back(memnew(RegEx(String("\\b") + class_name + ".tscn\\b")));
+				class_gd_regexes.push_back(memnew(RegEx(String("\\b") + class_name + ".gd\\b")));
+				class_shader_regexes.push_back(memnew(RegEx(String("\\b") + class_name + ".shader\\b")));
 
-				class_regexes.push_back(memnew(RegEx(String("\\b") + class_renames[current_index][0] + "\\b")));
+				class_regexes.push_back(memnew(RegEx(String("\\b") + class_name + "\\b")));
 
-				class_temp_tscn_renames.push_back(String(class_renames[current_index][0]) + ".tscn");
-				class_temp_gd_renames.push_back(String(class_renames[current_index][0]) + ".gd");
-				class_temp_shader_renames.push_back(String(class_renames[current_index][0]) + ".shader");
+				class_temp_tscn_renames.push_back(class_name + ".tscn");
+				class_temp_gd_renames.push_back(class_name + ".gd");
+				class_temp_shader_renames.push_back(class_name + ".shader");
 			}
 		}
 	}
@@ -2047,7 +286,7 @@ ProjectConverter3To4::ProjectConverter3To4(int p_maximum_file_size_kb, int p_max
 }
 
 // Function responsible for converting project.
-int ProjectConverter3To4::convert() {
+bool ProjectConverter3To4::convert() {
 	print_line("Starting conversion.");
 	uint64_t conversion_start_time = Time::get_singleton()->get_ticks_msec();
 
@@ -2056,8 +295,8 @@ int ProjectConverter3To4::convert() {
 	int cached_maximum_line_length = maximum_line_length;
 	maximum_line_length = 10000; // Use only for tests bigger value, to not break them.
 
-	ERR_FAIL_COND_V_MSG(!test_array_names(), ERROR_CODE, "Cannot start converting due to problems with data in arrays.");
-	ERR_FAIL_COND_V_MSG(!test_conversion(reg_container), ERROR_CODE, "Cannot start converting due to problems with converting arrays.");
+	ERR_FAIL_COND_V_MSG(!test_array_names(), false, "Cannot start converting due to problems with data in arrays.");
+	ERR_FAIL_COND_V_MSG(!test_conversion(reg_container), false, "Cannot start converting due to problems with converting arrays.");
 
 	maximum_line_length = cached_maximum_line_length;
 
@@ -2066,16 +305,16 @@ int ProjectConverter3To4::convert() {
 	{
 		String converter_text = "; Project was converted by built-in tool to Godot 4.0";
 
-		ERR_FAIL_COND_V_MSG(!FileAccess::exists("project.godot"), ERROR_CODE, "Current working directory doesn't contain a \"project.godot\" file for a Godot 3 project.");
+		ERR_FAIL_COND_V_MSG(!FileAccess::exists("project.godot"), false, "Current working directory doesn't contain a \"project.godot\" file for a Godot 3 project.");
 
 		Error err = OK;
 		String project_godot_content = FileAccess::get_file_as_string("project.godot", &err);
 
-		ERR_FAIL_COND_V_MSG(err != OK, ERROR_CODE, "Unable to read \"project.godot\".");
-		ERR_FAIL_COND_V_MSG(project_godot_content.contains(converter_text), ERROR_CODE, "Project was already converted with this tool.");
+		ERR_FAIL_COND_V_MSG(err != OK, false, "Unable to read \"project.godot\".");
+		ERR_FAIL_COND_V_MSG(project_godot_content.contains(converter_text), false, "Project was already converted with this tool.");
 
 		Ref<FileAccess> file = FileAccess::open("project.godot", FileAccess::WRITE);
-		ERR_FAIL_COND_V_MSG(file.is_null(), ERROR_CODE, "Unable to open \"project.godot\".");
+		ERR_FAIL_COND_V_MSG(file.is_null(), false, "Unable to open \"project.godot\".");
 
 		file->store_string(converter_text + "\n" + project_godot_content);
 	}
@@ -2116,59 +355,59 @@ int ProjectConverter3To4::convert() {
 			if (file_name.ends_with(".gd")) {
 				rename_classes(lines, reg_container); // Using only specialized function.
 
-				rename_common(enum_renames, reg_container.enum_regexes, lines);
+				rename_common(RenamesMap3To4::enum_renames, reg_container.enum_regexes, lines);
 				rename_colors(lines, reg_container); // Require to additional rename.
 
-				rename_common(gdscript_function_renames, reg_container.gdscript_function_regexes, lines);
+				rename_common(RenamesMap3To4::gdscript_function_renames, reg_container.gdscript_function_regexes, lines);
 				rename_gdscript_functions(lines, reg_container, false); // Require to additional rename.
 
-				rename_common(project_settings_renames, reg_container.project_settings_regexes, lines);
+				rename_common(RenamesMap3To4::project_settings_renames, reg_container.project_settings_regexes, lines);
 				rename_gdscript_keywords(lines, reg_container);
-				rename_common(gdscript_properties_renames, reg_container.gdscript_properties_regexes, lines);
-				rename_common(gdscript_signals_renames, reg_container.gdscript_signals_regexes, lines);
-				rename_common(shaders_renames, reg_container.shaders_regexes, lines);
-				rename_common(builtin_types_renames, reg_container.builtin_types_regexes, lines);
+				rename_common(RenamesMap3To4::gdscript_properties_renames, reg_container.gdscript_properties_regexes, lines);
+				rename_common(RenamesMap3To4::gdscript_signals_renames, reg_container.gdscript_signals_regexes, lines);
+				rename_common(RenamesMap3To4::shaders_renames, reg_container.shaders_regexes, lines);
+				rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, lines);
 
 				custom_rename(lines, "\\.shader", ".gdshader");
 			} else if (file_name.ends_with(".tscn")) {
 				rename_classes(lines, reg_container); // Using only specialized function.
 
-				rename_common(enum_renames, reg_container.enum_regexes, lines);
+				rename_common(RenamesMap3To4::enum_renames, reg_container.enum_regexes, lines);
 				rename_colors(lines, reg_container); // Require to do additional renames.
 
-				rename_common(gdscript_function_renames, reg_container.gdscript_function_regexes, lines);
+				rename_common(RenamesMap3To4::gdscript_function_renames, reg_container.gdscript_function_regexes, lines);
 				rename_gdscript_functions(lines, reg_container, true); // Require to do additional renames.
 
-				rename_common(project_settings_renames, reg_container.project_settings_regexes, lines);
+				rename_common(RenamesMap3To4::project_settings_renames, reg_container.project_settings_regexes, lines);
 				rename_gdscript_keywords(lines, reg_container);
-				rename_common(gdscript_properties_renames, reg_container.gdscript_properties_regexes, lines);
-				rename_common(gdscript_signals_renames, reg_container.gdscript_signals_regexes, lines);
-				rename_common(shaders_renames, reg_container.shaders_regexes, lines);
-				rename_common(builtin_types_renames, reg_container.builtin_types_regexes, lines);
+				rename_common(RenamesMap3To4::gdscript_properties_renames, reg_container.gdscript_properties_regexes, lines);
+				rename_common(RenamesMap3To4::gdscript_signals_renames, reg_container.gdscript_signals_regexes, lines);
+				rename_common(RenamesMap3To4::shaders_renames, reg_container.shaders_regexes, lines);
+				rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, lines);
 
 				custom_rename(lines, "\\.shader", ".gdshader");
 			} else if (file_name.ends_with(".cs")) { // TODO, C# should use different methods.
 				rename_classes(lines, reg_container); // Using only specialized function.
-				rename_common(csharp_function_renames, reg_container.csharp_function_regexes, lines);
-				rename_common(builtin_types_renames, reg_container.builtin_types_regexes, lines);
-				rename_common(csharp_properties_renames, reg_container.csharp_properties_regexes, lines);
-				rename_common(csharp_signals_renames, reg_container.csharp_signal_regexes, lines);
+				rename_common(RenamesMap3To4::csharp_function_renames, reg_container.csharp_function_regexes, lines);
+				rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, lines);
+				rename_common(RenamesMap3To4::csharp_properties_renames, reg_container.csharp_properties_regexes, lines);
+				rename_common(RenamesMap3To4::csharp_signals_renames, reg_container.csharp_signal_regexes, lines);
 				rename_csharp_functions(lines, reg_container);
 				rename_csharp_attributes(lines, reg_container);
 				custom_rename(lines, "public class ", "public partial class ");
 			} else if (file_name.ends_with(".gdshader") || file_name.ends_with(".shader")) {
-				rename_common(shaders_renames, reg_container.shaders_regexes, lines);
+				rename_common(RenamesMap3To4::shaders_renames, reg_container.shaders_regexes, lines);
 			} else if (file_name.ends_with("tres")) {
 				rename_classes(lines, reg_container); // Using only specialized function.
 
-				rename_common(shaders_renames, reg_container.shaders_regexes, lines);
-				rename_common(builtin_types_renames, reg_container.builtin_types_regexes, lines);
+				rename_common(RenamesMap3To4::shaders_renames, reg_container.shaders_regexes, lines);
+				rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, lines);
 
 				custom_rename(lines, "\\.shader", ".gdshader");
 			} else if (file_name.ends_with("project.godot")) {
-				rename_common(project_settings_renames, reg_container.project_settings_regexes, lines);
-				rename_common(builtin_types_renames, reg_container.builtin_types_regexes, lines);
-				rename_common(input_map_renames, reg_container.input_map_regexes, lines);
+				rename_common(RenamesMap3To4::project_settings_renames, reg_container.project_settings_regexes, lines);
+				rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, lines);
+				rename_common(RenamesMap3To4::input_map_renames, reg_container.input_map_regexes, lines);
 			} else if (file_name.ends_with(".csproj")) {
 				// TODO
 			} else {
@@ -2216,11 +455,11 @@ int ProjectConverter3To4::convert() {
 	print_line(vformat("Conversion ended - all files(%d), converted files: (%d), not converted files: (%d).", collected_files.size(), converted_files, collected_files.size() - converted_files));
 	uint64_t conversion_end_time = Time::get_singleton()->get_ticks_msec();
 	print_line(vformat("Conversion of all files took %10.3f seconds.", (conversion_end_time - conversion_start_time) / 1000.0));
-	return 0;
-};
+	return true;
+}
 
 // Function responsible for validating project conversion.
-int ProjectConverter3To4::validate_conversion() {
+bool ProjectConverter3To4::validate_conversion() {
 	print_line("Starting checking if project conversion can be done.");
 	uint64_t conversion_start_time = Time::get_singleton()->get_ticks_msec();
 
@@ -2229,8 +468,8 @@ int ProjectConverter3To4::validate_conversion() {
 	int cached_maximum_line_length = maximum_line_length;
 	maximum_line_length = 10000; // To avoid breaking the tests, only use this for the their larger value.
 
-	ERR_FAIL_COND_V_MSG(!test_array_names(), ERROR_CODE, "Cannot start converting due to problems with data in arrays.");
-	ERR_FAIL_COND_V_MSG(!test_conversion(reg_container), ERROR_CODE, "Cannot start converting due to problems with converting arrays.");
+	ERR_FAIL_COND_V_MSG(!test_array_names(), false, "Cannot start converting due to problems with data in arrays.");
+	ERR_FAIL_COND_V_MSG(!test_conversion(reg_container), false, "Cannot start converting due to problems with converting arrays.");
 
 	maximum_line_length = cached_maximum_line_length;
 
@@ -2239,13 +478,13 @@ int ProjectConverter3To4::validate_conversion() {
 	{
 		String conventer_text = "; Project was converted by built-in tool to Godot 4.0";
 
-		ERR_FAIL_COND_V_MSG(!FileAccess::exists("project.godot"), ERROR_CODE, "Current directory doesn't contains any Godot 3 project");
+		ERR_FAIL_COND_V_MSG(!FileAccess::exists("project.godot"), false, "Current directory doesn't contains any Godot 3 project");
 
 		Error err = OK;
 		String project_godot_content = FileAccess::get_file_as_string("project.godot", &err);
 
-		ERR_FAIL_COND_V_MSG(err != OK, ERROR_CODE, "Failed to read content of \"project.godot\" file.");
-		ERR_FAIL_COND_V_MSG(project_godot_content.contains(conventer_text), ERROR_CODE, "Project already was converted with this tool.");
+		ERR_FAIL_COND_V_MSG(err != OK, false, "Failed to read content of \"project.godot\" file.");
+		ERR_FAIL_COND_V_MSG(project_godot_content.contains(conventer_text), false, "Project already was converted with this tool.");
 	}
 
 	Vector<String> collected_files = check_for_files();
@@ -2282,59 +521,59 @@ int ProjectConverter3To4::validate_conversion() {
 			if (file_name.ends_with(".gd")) {
 				changed_elements.append_array(check_for_rename_classes(lines, reg_container));
 
-				changed_elements.append_array(check_for_rename_common(enum_renames, reg_container.enum_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::enum_renames, reg_container.enum_regexes, lines));
 				changed_elements.append_array(check_for_rename_colors(lines, reg_container));
 
-				changed_elements.append_array(check_for_rename_common(gdscript_function_renames, reg_container.gdscript_function_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::gdscript_function_renames, reg_container.gdscript_function_regexes, lines));
 				changed_elements.append_array(check_for_rename_gdscript_functions(lines, reg_container, false));
 
-				changed_elements.append_array(check_for_rename_common(project_settings_renames, reg_container.project_settings_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::project_settings_renames, reg_container.project_settings_regexes, lines));
 				changed_elements.append_array(check_for_rename_gdscript_keywords(lines, reg_container));
-				changed_elements.append_array(check_for_rename_common(gdscript_properties_renames, reg_container.gdscript_properties_regexes, lines));
-				changed_elements.append_array(check_for_rename_common(gdscript_signals_renames, reg_container.gdscript_signals_regexes, lines));
-				changed_elements.append_array(check_for_rename_common(shaders_renames, reg_container.shaders_regexes, lines));
-				changed_elements.append_array(check_for_rename_common(builtin_types_renames, reg_container.builtin_types_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::gdscript_properties_renames, reg_container.gdscript_properties_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::gdscript_signals_renames, reg_container.gdscript_signals_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::shaders_renames, reg_container.shaders_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, lines));
 
 				changed_elements.append_array(check_for_custom_rename(lines, "\\.shader", ".gdshader"));
 			} else if (file_name.ends_with(".tscn")) {
 				changed_elements.append_array(check_for_rename_classes(lines, reg_container));
 
-				changed_elements.append_array(check_for_rename_common(enum_renames, reg_container.enum_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::enum_renames, reg_container.enum_regexes, lines));
 				changed_elements.append_array(check_for_rename_colors(lines, reg_container));
 
-				changed_elements.append_array(check_for_rename_common(gdscript_function_renames, reg_container.gdscript_function_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::gdscript_function_renames, reg_container.gdscript_function_regexes, lines));
 				changed_elements.append_array(check_for_rename_gdscript_functions(lines, reg_container, true));
 
-				changed_elements.append_array(check_for_rename_common(project_settings_renames, reg_container.project_settings_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::project_settings_renames, reg_container.project_settings_regexes, lines));
 				changed_elements.append_array(check_for_rename_gdscript_keywords(lines, reg_container));
-				changed_elements.append_array(check_for_rename_common(gdscript_properties_renames, reg_container.gdscript_properties_regexes, lines));
-				changed_elements.append_array(check_for_rename_common(gdscript_signals_renames, reg_container.gdscript_signals_regexes, lines));
-				changed_elements.append_array(check_for_rename_common(shaders_renames, reg_container.shaders_regexes, lines));
-				changed_elements.append_array(check_for_rename_common(builtin_types_renames, reg_container.builtin_types_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::gdscript_properties_renames, reg_container.gdscript_properties_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::gdscript_signals_renames, reg_container.gdscript_signals_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::shaders_renames, reg_container.shaders_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, lines));
 
 				changed_elements.append_array(check_for_custom_rename(lines, "\\.shader", ".gdshader"));
 			} else if (file_name.ends_with(".cs")) {
 				changed_elements.append_array(check_for_rename_classes(lines, reg_container));
-				changed_elements.append_array(check_for_rename_common(csharp_function_renames, reg_container.csharp_function_regexes, lines));
-				changed_elements.append_array(check_for_rename_common(builtin_types_renames, reg_container.builtin_types_regexes, lines));
-				changed_elements.append_array(check_for_rename_common(csharp_properties_renames, reg_container.csharp_properties_regexes, lines));
-				changed_elements.append_array(check_for_rename_common(csharp_signals_renames, reg_container.csharp_signal_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::csharp_function_renames, reg_container.csharp_function_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::csharp_properties_renames, reg_container.csharp_properties_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::csharp_signals_renames, reg_container.csharp_signal_regexes, lines));
 				changed_elements.append_array(check_for_rename_csharp_functions(lines, reg_container));
 				changed_elements.append_array(check_for_rename_csharp_attributes(lines, reg_container));
 				changed_elements.append_array(check_for_custom_rename(lines, "public class ", "public partial class "));
 			} else if (file_name.ends_with(".gdshader") || file_name.ends_with(".shader")) {
-				changed_elements.append_array(check_for_rename_common(shaders_renames, reg_container.shaders_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::shaders_renames, reg_container.shaders_regexes, lines));
 			} else if (file_name.ends_with("tres")) {
 				changed_elements.append_array(check_for_rename_classes(lines, reg_container));
 
-				changed_elements.append_array(check_for_rename_common(shaders_renames, reg_container.shaders_regexes, lines));
-				changed_elements.append_array(check_for_rename_common(builtin_types_renames, reg_container.builtin_types_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::shaders_renames, reg_container.shaders_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, lines));
 
 				changed_elements.append_array(check_for_custom_rename(lines, "\\.shader", ".gdshader"));
 			} else if (file_name.ends_with("project.godot")) {
-				changed_elements.append_array(check_for_rename_common(project_settings_renames, reg_container.project_settings_regexes, lines));
-				changed_elements.append_array(check_for_rename_common(builtin_types_renames, reg_container.builtin_types_regexes, lines));
-				changed_elements.append_array(check_for_rename_common(input_map_renames, reg_container.input_map_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::project_settings_renames, reg_container.project_settings_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::input_map_renames, reg_container.input_map_regexes, lines));
 			} else if (file_name.ends_with(".csproj")) {
 				// TODO
 			} else {
@@ -2375,7 +614,7 @@ int ProjectConverter3To4::validate_conversion() {
 	print_line(vformat("Checking for valid conversion ended - all files(%d), files which would be converted(%d), files which would not be converted(%d).", collected_files.size(), converted_files, collected_files.size() - converted_files));
 	uint64_t conversion_end_time = Time::get_singleton()->get_ticks_msec();
 	print_line(vformat("Conversion of all files took %10.3f seconds.", (conversion_end_time - conversion_start_time) / 1000.0));
-	return 0;
+	return true;
 }
 
 // Collect files which will be checked, excluding ".txt", ".mp4", ".wav" etc. files.
@@ -2453,27 +692,27 @@ bool ProjectConverter3To4::test_conversion_basic(String name, String expected, c
 bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 	bool valid = true;
 
-	valid = valid && test_conversion_basic("TYPE_REAL", "TYPE_FLOAT", enum_renames, reg_container.enum_regexes, "enum");
+	valid = valid && test_conversion_basic("TYPE_REAL", "TYPE_FLOAT", RenamesMap3To4::enum_renames, reg_container.enum_regexes, "enum");
 
-	valid = valid && test_conversion_basic("can_instance", "can_instantiate", gdscript_function_renames, reg_container.gdscript_function_regexes, "gdscript function");
+	valid = valid && test_conversion_basic("can_instance", "can_instantiate", RenamesMap3To4::gdscript_function_renames, reg_container.gdscript_function_regexes, "gdscript function");
 
-	valid = valid && test_conversion_basic("CanInstance", "CanInstantiate", csharp_function_renames, reg_container.csharp_function_regexes, "csharp function");
+	valid = valid && test_conversion_basic("CanInstance", "CanInstantiate", RenamesMap3To4::csharp_function_renames, reg_container.csharp_function_regexes, "csharp function");
 
-	valid = valid && test_conversion_basic("translation", "position", gdscript_properties_renames, reg_container.gdscript_properties_regexes, "gdscript property");
+	valid = valid && test_conversion_basic("translation", "position", RenamesMap3To4::gdscript_properties_renames, reg_container.gdscript_properties_regexes, "gdscript property");
 
-	valid = valid && test_conversion_basic("Translation", "Position", csharp_properties_renames, reg_container.csharp_properties_regexes, "csharp property");
+	valid = valid && test_conversion_basic("Translation", "Position", RenamesMap3To4::csharp_properties_renames, reg_container.csharp_properties_regexes, "csharp property");
 
-	valid = valid && test_conversion_basic("NORMALMAP", "NORMAL_MAP", shaders_renames, reg_container.shaders_regexes, "shader");
+	valid = valid && test_conversion_basic("NORMALMAP", "NORMAL_MAP", RenamesMap3To4::shaders_renames, reg_container.shaders_regexes, "shader");
 
-	valid = valid && test_conversion_basic("text_entered", "text_submitted", gdscript_signals_renames, reg_container.gdscript_signals_regexes, "gdscript signal");
+	valid = valid && test_conversion_basic("text_entered", "text_submitted", RenamesMap3To4::gdscript_signals_renames, reg_container.gdscript_signals_regexes, "gdscript signal");
 
-	valid = valid && test_conversion_basic("TextEntered", "TextSubmitted", csharp_signals_renames, reg_container.csharp_signal_regexes, "csharp signal");
+	valid = valid && test_conversion_basic("TextEntered", "TextSubmitted", RenamesMap3To4::csharp_signals_renames, reg_container.csharp_signal_regexes, "csharp signal");
 
-	valid = valid && test_conversion_basic("audio/channel_disable_threshold_db", "audio/buses/channel_disable_threshold_db", project_settings_renames, reg_container.project_settings_regexes, "project setting");
+	valid = valid && test_conversion_basic("audio/channel_disable_threshold_db", "audio/buses/channel_disable_threshold_db", RenamesMap3To4::project_settings_renames, reg_container.project_settings_regexes, "project setting");
 
-	valid = valid && test_conversion_basic("\"device\":-1,\"alt\":false,\"shift\":false,\"control\":false,\"meta\":false,\"doubleclick\":false,\"scancode\":0,\"physical_scancode\":16777254,\"script\":null", "\"device\":-1,\"alt_pressed\":false,\"shift_pressed\":false,\"ctrl_pressed\":false,\"meta_pressed\":false,\"double_click\":false,\"keycode\":0,\"physical_keycode\":16777254,\"script\":null", input_map_renames, reg_container.input_map_regexes, "input map");
+	valid = valid && test_conversion_basic("\"device\":-1,\"alt\":false,\"shift\":false,\"control\":false,\"meta\":false,\"doubleclick\":false,\"scancode\":0,\"physical_scancode\":16777254,\"script\":null", "\"device\":-1,\"alt_pressed\":false,\"shift_pressed\":false,\"ctrl_pressed\":false,\"meta_pressed\":false,\"double_click\":false,\"keycode\":0,\"physical_keycode\":16777254,\"script\":null", RenamesMap3To4::input_map_renames, reg_container.input_map_regexes, "input map");
 
-	valid = valid && test_conversion_basic("Transform", "Transform3D", builtin_types_renames, reg_container.builtin_types_regexes, "builtin type");
+	valid = valid && test_conversion_basic("Transform", "Transform3D", RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, "builtin type");
 
 	// Custom Renames.
 
@@ -2787,9 +1026,9 @@ bool ProjectConverter3To4::test_array_names() {
 
 	// Validate if all classes are valid.
 	{
-		for (unsigned int current_index = 0; class_renames[current_index][0]; current_index++) {
-			const String old_class = class_renames[current_index][0];
-			const String new_class = class_renames[current_index][1];
+		for (unsigned int current_index = 0; RenamesMap3To4::class_renames[current_index][0]; current_index++) {
+			const String old_class = RenamesMap3To4::class_renames[current_index][0];
+			const String new_class = RenamesMap3To4::class_renames[current_index][1];
 
 			// Light2D, Texture, Viewport are special classes(probably virtual ones).
 			if (ClassDB::class_exists(StringName(old_class)) && old_class != "Light2D" && old_class != "Texture" && old_class != "Viewport") {
@@ -2838,10 +1077,10 @@ bool ProjectConverter3To4::test_array_names() {
 		}
 
 		int current_element = 0;
-		while (gdscript_function_renames[current_element][0] != nullptr) {
-			String name_3_x = gdscript_function_renames[current_element][0];
-			String name_4_0 = gdscript_function_renames[current_element][1];
-			if (!all_functions.has(gdscript_function_renames[current_element][1])) {
+		while (RenamesMap3To4::gdscript_function_renames[current_element][0] != nullptr) {
+			String name_3_x = RenamesMap3To4::gdscript_function_renames[current_element][0];
+			String name_4_0 = RenamesMap3To4::gdscript_function_renames[current_element][1];
+			if (!all_functions.has(name_4_0)) {
 				ERR_PRINT(vformat("Missing GDScript function in pair (%s - ===> %s <===)", name_3_x, name_4_0));
 				valid = false;
 			}
@@ -2852,18 +1091,18 @@ bool ProjectConverter3To4::test_array_names() {
 		ERR_PRINT("Found function which is used in the converter, but it cannot be found in Godot 4. Rename this element or remove its entry if it's obsolete.");
 	}
 
-	valid = valid && test_single_array(enum_renames);
-	valid = valid && test_single_array(class_renames, true);
-	valid = valid && test_single_array(gdscript_function_renames, true);
-	valid = valid && test_single_array(csharp_function_renames, true);
-	valid = valid && test_single_array(gdscript_properties_renames, true);
-	valid = valid && test_single_array(csharp_properties_renames, true);
-	valid = valid && test_single_array(shaders_renames, true);
-	valid = valid && test_single_array(gdscript_signals_renames);
-	valid = valid && test_single_array(project_settings_renames);
-	valid = valid && test_single_array(input_map_renames);
-	valid = valid && test_single_array(builtin_types_renames);
-	valid = valid && test_single_array(color_renames);
+	valid = valid && test_single_array(RenamesMap3To4::enum_renames);
+	valid = valid && test_single_array(RenamesMap3To4::class_renames, true);
+	valid = valid && test_single_array(RenamesMap3To4::gdscript_function_renames, true);
+	valid = valid && test_single_array(RenamesMap3To4::csharp_function_renames, true);
+	valid = valid && test_single_array(RenamesMap3To4::gdscript_properties_renames, true);
+	valid = valid && test_single_array(RenamesMap3To4::csharp_properties_renames, true);
+	valid = valid && test_single_array(RenamesMap3To4::shaders_renames, true);
+	valid = valid && test_single_array(RenamesMap3To4::gdscript_signals_renames);
+	valid = valid && test_single_array(RenamesMap3To4::project_settings_renames);
+	valid = valid && test_single_array(RenamesMap3To4::input_map_renames);
+	valid = valid && test_single_array(RenamesMap3To4::builtin_types_renames);
+	valid = valid && test_single_array(RenamesMap3To4::color_renames);
 
 	return valid;
 }
@@ -3092,7 +1331,7 @@ void ProjectConverter3To4::rename_colors(Vector<String> &lines, const RegExConta
 	for (String &line : lines) {
 		if (uint64_t(line.length()) <= maximum_line_length) {
 			if (line.contains("Color.")) {
-				for (unsigned int current_index = 0; color_renames[current_index][0]; current_index++) {
+				for (unsigned int current_index = 0; RenamesMap3To4::color_renames[current_index][0]; current_index++) {
 					line = reg_container.color_regexes[current_index]->sub(line, reg_container.color_renamed[current_index], true);
 				}
 			}
@@ -3107,10 +1346,10 @@ Vector<String> ProjectConverter3To4::check_for_rename_colors(Vector<String> &lin
 	for (String &line : lines) {
 		if (uint64_t(line.length()) <= maximum_line_length) {
 			if (line.contains("Color.")) {
-				for (unsigned int current_index = 0; color_renames[current_index][0]; current_index++) {
+				for (unsigned int current_index = 0; RenamesMap3To4::color_renames[current_index][0]; current_index++) {
 					TypedArray<RegExMatch> reg_match = reg_container.color_regexes[current_index]->search_all(line);
 					if (reg_match.size() > 0) {
-						found_renames.append(line_formatter(current_line, color_renames[current_index][0], color_renames[current_index][1], line));
+						found_renames.append(line_formatter(current_line, RenamesMap3To4::color_renames[current_index][0], RenamesMap3To4::color_renames[current_index][1], line));
 					}
 				}
 			}
@@ -3124,11 +1363,11 @@ Vector<String> ProjectConverter3To4::check_for_rename_colors(Vector<String> &lin
 void ProjectConverter3To4::rename_classes(Vector<String> &lines, const RegExContainer &reg_container) {
 	for (String &line : lines) {
 		if (uint64_t(line.length()) <= maximum_line_length) {
-			for (unsigned int current_index = 0; class_renames[current_index][0]; current_index++) {
-				if (line.contains(class_renames[current_index][0])) {
+			for (unsigned int current_index = 0; RenamesMap3To4::class_renames[current_index][0]; current_index++) {
+				if (line.contains(RenamesMap3To4::class_renames[current_index][0])) {
 					bool found_ignored_items = false;
 					// Renaming Spatial.tscn to TEMP_RENAMED_CLASS.tscn.
-					if (line.contains(String(class_renames[current_index][0]) + ".")) {
+					if (line.contains(String(RenamesMap3To4::class_renames[current_index][0]) + ".")) {
 						found_ignored_items = true;
 						line = reg_container.class_tscn_regexes[current_index]->sub(line, "TEMP_RENAMED_CLASS.tscn", true);
 						line = reg_container.class_gd_regexes[current_index]->sub(line, "TEMP_RENAMED_CLASS.gd", true);
@@ -3136,7 +1375,7 @@ void ProjectConverter3To4::rename_classes(Vector<String> &lines, const RegExCont
 					}
 
 					// Causal renaming Spatial -> Node3D.
-					line = reg_container.class_regexes[current_index]->sub(line, class_renames[current_index][1], true);
+					line = reg_container.class_regexes[current_index]->sub(line, RenamesMap3To4::class_renames[current_index][1], true);
 
 					// Restore Spatial.tscn from TEMP_RENAMED_CLASS.tscn.
 					if (found_ignored_items) {
@@ -3157,12 +1396,12 @@ Vector<String> ProjectConverter3To4::check_for_rename_classes(Vector<String> &li
 
 	for (String &line : lines) {
 		if (uint64_t(line.length()) <= maximum_line_length) {
-			for (unsigned int current_index = 0; class_renames[current_index][0]; current_index++) {
-				if (line.contains(class_renames[current_index][0])) {
+			for (unsigned int current_index = 0; RenamesMap3To4::class_renames[current_index][0]; current_index++) {
+				if (line.contains(RenamesMap3To4::class_renames[current_index][0])) {
 					String old_line = line;
 					bool found_ignored_items = false;
 					// Renaming Spatial.tscn to TEMP_RENAMED_CLASS.tscn.
-					if (line.contains(String(class_renames[current_index][0]) + ".")) {
+					if (line.contains(String(RenamesMap3To4::class_renames[current_index][0]) + ".")) {
 						found_ignored_items = true;
 						line = reg_container.class_tscn_regexes[current_index]->sub(line, "TEMP_RENAMED_CLASS.tscn", true);
 						line = reg_container.class_gd_regexes[current_index]->sub(line, "TEMP_RENAMED_CLASS.gd", true);
@@ -3172,7 +1411,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_classes(Vector<String> &li
 					// Causal renaming Spatial -> Node3D.
 					TypedArray<RegExMatch> reg_match = reg_container.class_regexes[current_index]->search_all(line);
 					if (reg_match.size() > 0) {
-						found_renames.append(line_formatter(current_line, class_renames[current_index][0], class_renames[current_index][1], old_line));
+						found_renames.append(line_formatter(current_line, RenamesMap3To4::class_renames[current_index][0], RenamesMap3To4::class_renames[current_index][1], old_line));
 					}
 
 					// Restore Spatial.tscn from TEMP_RENAMED_CLASS.tscn.
@@ -4353,17 +2592,6 @@ String ProjectConverter3To4::collect_string_from_vector(Vector<String> &vector) 
 	return string;
 }
 
-#else // No RegEx.
-
-ProjectConverter3To4::ProjectConverter3To4(int _p_maximum_file_size_kb, int _p_maximum_line_length) {}
-
-int ProjectConverter3To4::convert() {
-	ERR_FAIL_V_MSG(ERROR_CODE, "Can't run converter for Godot 3.x projects, because RegEx module is disabled.");
-}
-
-int ProjectConverter3To4::validate_conversion() {
-	ERR_FAIL_V_MSG(ERROR_CODE, "Can't validate conversion for Godot 3.x projects, because RegEx module is disabled.");
-}
-
 #endif // MODULE_REGEX_ENABLED
+
 #endif // DISABLE_DEPRECATED

--- a/editor/project_converter_3_to_4.h
+++ b/editor/project_converter_3_to_4.h
@@ -33,31 +33,36 @@
 
 #ifndef DISABLE_DEPRECATED
 
-#include "core/io/file_access.h"
-#include "core/object/ref_counted.h"
+#include "modules/modules_enabled.gen.h" // For regex.
+
+#ifndef MODULE_REGEX_ENABLED
+
+#include "core/error/error_macros.h"
+
+class ProjectConverter3To4 {
+public:
+	ProjectConverter3To4(int, int) {}
+
+	bool validate_conversion() {
+		ERR_FAIL_V_MSG(false, "Can't validate conversion for Godot 3.x projects, because RegEx module is disabled.");
+	}
+
+	bool convert() {
+		ERR_FAIL_V_MSG(false, "Can't run converter for Godot 3.x projects, because RegEx module is disabled.");
+	}
+};
+
+#else // Has regex.
+
 #include "core/string/ustring.h"
 #include "core/templates/local_vector.h"
+#include "core/templates/vector.h"
 
 class RegEx;
 
 class ProjectConverter3To4 {
-public:
 	class RegExContainer;
-	static const char *enum_renames[][2];
-	static const char *gdscript_function_renames[][2];
-	static const char *csharp_function_renames[][2];
-	static const char *gdscript_properties_renames[][2];
-	static const char *csharp_properties_renames[][2];
-	static const char *gdscript_signals_renames[][2];
-	static const char *csharp_signals_renames[][2];
-	static const char *project_settings_renames[][2];
-	static const char *input_map_renames[][2];
-	static const char *builtin_types_renames[][2];
-	static const char *shaders_renames[][2];
-	static const char *class_renames[][2];
-	static const char *color_renames[][2];
 
-private:
 	uint64_t maximum_file_size;
 	uint64_t maximum_line_length;
 
@@ -108,9 +113,11 @@ private:
 
 public:
 	ProjectConverter3To4(int, int);
-	int validate_conversion();
-	int convert();
+	bool validate_conversion();
+	bool convert();
 };
+
+#endif // MODULE_REGEX_ENABLED
 
 #endif // DISABLE_DEPRECATED
 

--- a/editor/renames_map_3_to_4.cpp
+++ b/editor/renames_map_3_to_4.cpp
@@ -1,0 +1,1797 @@
+/**************************************************************************/
+/*  renames_map_3_to_4.cpp                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "renames_map_3_to_4.h"
+
+#ifndef DISABLE_DEPRECATED
+
+const char *RenamesMap3To4::enum_renames[][2] = {
+	//// constants
+	{ "TYPE_COLOR_ARRAY", "TYPE_PACKED_COLOR_ARRAY" },
+	{ "TYPE_FLOAT64_ARRAY", "TYPE_PACKED_FLOAT64_ARRAY" },
+	{ "TYPE_INT64_ARRAY", "TYPE_PACKED_INT64_ARRAY" },
+	{ "TYPE_INT_ARRAY", "TYPE_PACKED_INT32_ARRAY" },
+	{ "TYPE_QUAT", "TYPE_QUATERNION" },
+	{ "TYPE_RAW_ARRAY", "TYPE_PACKED_BYTE_ARRAY" },
+	{ "TYPE_REAL", "TYPE_FLOAT" },
+	{ "TYPE_REAL_ARRAY", "TYPE_PACKED_FLOAT32_ARRAY" },
+	{ "TYPE_STRING_ARRAY", "TYPE_PACKED_STRING_ARRAY" },
+	{ "TYPE_TRANSFORM", "TYPE_TRANSFORM3D" },
+	{ "TYPE_VECTOR2_ARRAY", "TYPE_PACKED_VECTOR2_ARRAY" },
+	{ "TYPE_VECTOR3_ARRAY", "TYPE_PACKED_VECTOR3_ARRAY" },
+
+	// {"FLAG_MAX", "PARTICLE_FLAG_MAX"}, // CPUParticles2D - used in more classes
+	{ "ALIGN_BEGIN", "ALIGNMENT_BEGIN" }, //AspectRatioContainer
+	{ "ALIGN_CENTER", "ALIGNMENT_CENTER" }, //AspectRatioContainer
+	{ "ALIGN_END", "ALIGNMENT_END" }, //AspectRatioContainer
+	{ "ARRAY_COMPRESS_BASE", "ARRAY_COMPRESS_FLAGS_BASE" }, // Mesh
+	{ "ARVR_AR", "XR_AR" }, // XRInterface
+	{ "ARVR_EXCESSIVE_MOTION", "XR_EXCESSIVE_MOTION" }, // XRInterface
+	{ "ARVR_EXTERNAL", "XR_EXTERNAL" }, // XRInterface
+	{ "ARVR_INSUFFICIENT_FEATURES", "XR_INSUFFICIENT_FEATURES" }, // XRInterface
+	{ "ARVR_MONO", "XR_MONO" }, // XRInterface
+	{ "ARVR_NONE", "XR_NONE" }, // XRInterface
+	{ "ARVR_NORMAL_TRACKING", "XR_NORMAL_TRACKING" }, // XRInterface
+	{ "ARVR_NOT_TRACKING", "XR_NOT_TRACKING" }, // XRInterface
+	{ "ARVR_STEREO", "XR_STEREO" }, // XRInterface
+	{ "ARVR_UNKNOWN_TRACKING", "XR_UNKNOWN_TRACKING" }, // XRInterface
+	{ "BAKE_ERROR_INVALID_MESH", "BAKE_ERROR_MESHES_INVALID" }, // LightmapGI
+	{ "BODY_MODE_CHARACTER", "BODY_MODE_RIGID_LINEAR" }, // PhysicsServer
+	{ "BUTTON_LEFT", "MOUSE_BUTTON_LEFT" }, // Globals
+	{ "BUTTON_MASK_LEFT", "MOUSE_BUTTON_MASK_LEFT" }, // Globals
+	{ "BUTTON_MASK_MIDDLE", "MOUSE_BUTTON_MASK_MIDDLE" }, // Globals
+	{ "BUTTON_MASK_RIGHT", "MOUSE_BUTTON_MASK_RIGHT" }, // Globals
+	{ "BUTTON_MASK_XBUTTON1", "MOUSE_BUTTON_MASK_XBUTTON1" }, // Globals
+	{ "BUTTON_MASK_XBUTTON2", "MOUSE_BUTTON_MASK_XBUTTON2" }, // Globals
+	{ "BUTTON_MIDDLE", "MOUSE_BUTTON_MIDDLE" }, // Globals
+	{ "BUTTON_RIGHT", "MOUSE_BUTTON_RIGHT" }, // Globals
+	{ "BUTTON_WHEEL_DOWN", "MOUSE_BUTTON_WHEEL_DOWN" }, // Globals
+	{ "BUTTON_WHEEL_LEFT", "MOUSE_BUTTON_WHEEL_LEFT" }, // Globals
+	{ "BUTTON_WHEEL_RIGHT", "MOUSE_BUTTON_WHEEL_RIGHT" }, // Globals
+	{ "BUTTON_WHEEL_UP", "MOUSE_BUTTON_WHEEL_UP" }, // Globals
+	{ "BUTTON_XBUTTON1", "MOUSE_BUTTON_XBUTTON1" }, // Globals
+	{ "BUTTON_XBUTTON2", "MOUSE_BUTTON_XBUTTON2" }, // Globals
+	{ "CLEAR_MODE_ONLY_NEXT_FRAME", "CLEAR_MODE_ONCE" }, // SubViewport
+	{ "COMPRESS_PVRTC4", "COMPRESS_PVRTC1_4" }, // Image
+	{ "CONNECT_ONESHOT", "CONNECT_ONE_SHOT" }, // Object
+	{ "CONTAINER_PROPERTY_EDITOR_BOTTOM", "CONTAINER_INSPECTOR_BOTTOM" }, // EditorPlugin
+	{ "CUBEMAP_BACK", "CUBEMAP_LAYER_BACK" }, // RenderingServer
+	{ "CUBEMAP_BOTTOM", "CUBEMAP_LAYER_BOTTOM" }, // RenderingServer
+	{ "CUBEMAP_FRONT", "CUBEMAP_LAYER_FRONT" }, // RenderingServer
+	{ "CUBEMAP_LEFT", "CUBEMAP_LAYER_LEFT" }, // RenderingServer
+	{ "CUBEMAP_RIGHT", "CUBEMAP_LAYER_RIGHT" }, // RenderingServer
+	{ "CUBEMAP_TOP", "CUBEMAP_LAYER_TOP" }, // RenderingServer
+	{ "DAMPED_STRING_DAMPING", "DAMPED_SPRING_DAMPING" }, // PhysicsServer2D
+	{ "DAMPED_STRING_REST_LENGTH", "DAMPED_SPRING_REST_LENGTH" }, // PhysicsServer2D
+	{ "DAMPED_STRING_STIFFNESS", "DAMPED_SPRING_STIFFNESS" }, // PhysicsServer2D
+	{ "FLAG_ALIGN_Y_TO_VELOCITY", "PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY" }, // CPUParticles2D
+	{ "FLAG_DISABLE_Z", "PARTICLE_FLAG_DISABLE_Z" }, // CPUParticles2D
+	{ "FLAG_ROTATE_Y", "PARTICLE_FLAG_ROTATE_Y" }, // CPUParticles2D
+	{ "FLAG_USE_BAKED_LIGHT", "GI_MODE_BAKED" }, // GeometryInstance3D
+	{ "FORMAT_PVRTC2", "FORMAT_PVRTC1_2" }, // Image
+	{ "FORMAT_PVRTC2A", "FORMAT_PVRTC1_2A" }, // Image
+	{ "FORMAT_PVRTC4", "FORMAT_PVRTC1_4" }, // Image
+	{ "FORMAT_PVRTC4A", "FORMAT_PVRTC1_4A" }, // Image
+	{ "FUNC_FRAC", "FUNC_FRACT" }, // VisualShaderNodeVectorFunc
+	{ "INSTANCE_LIGHTMAP_CAPTURE", "INSTANCE_LIGHTMAP" }, // RenderingServer
+	{ "JOINT_6DOF", "JOINT_TYPE_6DOF" }, // PhysicsServer3D
+	{ "JOINT_CONE_TWIST", "JOINT_TYPE_CONE_TWIST" }, // PhysicsServer3D
+	{ "JOINT_DAMPED_SPRING", "JOINT_TYPE_DAMPED_SPRING" }, // PhysicsServer2D
+	{ "JOINT_GROOVE", "JOINT_TYPE_GROOVE" }, // PhysicsServer2D
+	{ "JOINT_HINGE", "JOINT_TYPE_HINGE" }, // PhysicsServer3D
+	{ "JOINT_PIN", "JOINT_TYPE_PIN" }, // PhysicsServer2D
+	{ "JOINT_SLIDER", "JOINT_TYPE_SLIDER" }, // PhysicsServer3D
+	{ "KEY_CONTROL", "KEY_CTRL" }, // Globals
+	{ "LOOP_PING_PONG", "LOOP_PINGPONG" }, // AudioStreamWAV
+	{ "MODE_KINEMATIC", "FREEZE_MODE_KINEMATIC" }, // RigidBody
+	{ "MODE_OPEN_ANY", "FILE_MODE_OPEN_ANY" }, // FileDialog
+	{ "MODE_OPEN_DIR", "FILE_MODE_OPEN_DIR" }, // FileDialog
+	{ "MODE_OPEN_FILE", "FILE_MODE_OPEN_FILE" }, // FileDialog
+	{ "MODE_OPEN_FILES", "FILE_MODE_OPEN_FILES" }, // FileDialog
+	{ "MODE_SAVE_FILE", "FILE_MODE_SAVE_FILE" }, // FileDialog
+	{ "MODE_STATIC", "FREEZE_MODE_STATIC" }, // RigidBody
+	{ "NOTIFICATION_APP_PAUSED", "NOTIFICATION_APPLICATION_PAUSED" }, // MainLoop
+	{ "NOTIFICATION_APP_RESUMED", "NOTIFICATION_APPLICATION_RESUMED" }, // MainLoop
+	{ "NOTIFICATION_INSTANCED", "NOTIFICATION_SCENE_INSTANTIATED" }, // Node
+	{ "NOTIFICATION_PATH_CHANGED", "NOTIFICATION_PATH_RENAMED" }, //Node
+	{ "NOTIFICATION_WM_FOCUS_IN", "NOTIFICATION_APPLICATION_FOCUS_IN" }, // MainLoop
+	{ "NOTIFICATION_WM_FOCUS_OUT", "NOTIFICATION_APPLICATION_FOCUS_OUT" }, // MainLoop
+	{ "NOTIFICATION_WM_UNFOCUS_REQUEST", "NOTIFICATION_WM_WINDOW_FOCUS_OUT" }, //Node
+	{ "PAUSE_MODE_INHERIT", "PROCESS_MODE_INHERIT" }, // Node
+	{ "PAUSE_MODE_PROCESS", "PROCESS_MODE_ALWAYS" }, // Node
+	{ "PAUSE_MODE_STOP", "PROCESS_MODE_PAUSABLE" }, // Node
+	{ "RENDER_DRAW_CALLS_IN_FRAME", "RENDER_TOTAL_DRAW_CALLS_IN_FRAME" }, // Performance
+	{ "RENDER_OBJECTS_IN_FRAME", "RENDER_TOTAL_OBJECTS_IN_FRAME" }, // Performance
+	{ "SIDE_BOTTOM", "MARGIN_BOTTOM" }, // Globals
+	{ "SIDE_LEFT", "MARGIN_LEFT" }, // Globals
+	{ "SIDE_RIGHT", "MARGIN_RIGHT" }, // Globals
+	{ "SIDE_TOP", "MARGIN_TOP" }, // Globals
+	{ "TEXTURE_TYPE_2D_ARRAY", "TEXTURE_LAYERED_2D_ARRAY" }, // RenderingServer
+	{ "TEXTURE_TYPE_CUBEMAP", "TEXTURE_LAYERED_CUBEMAP_ARRAY" }, // RenderingServer
+	{ "TRACKER_LEFT_HAND", "TRACKER_HAND_LEFT" }, // XRPositionalTracker
+	{ "TRACKER_RIGHT_HAND", "TRACKER_HAND_RIGHT" }, // XRPositionalTracker
+	{ "TYPE_NORMALMAP", "TYPE_NORMAL_MAP" }, // VisualShaderNodeCubemap
+
+	/// enums
+	{ "AlignMode", "AlignmentMode" }, //AspectRatioContainer
+	{ "AnimationProcessMode", "AnimationProcessCallback" }, // AnimationTree, AnimationPlayer
+	{ "Camera2DProcessMode", "Camera2DProcessCallback" }, // Camera2D
+	{ "CubeMapSide", "CubeMapLayer" }, // RenderingServer
+	{ "DampedStringParam", "DampedSpringParam" }, // PhysicsServer2D
+	{ "FFT_Size", "FFTSize" }, // AudioEffectPitchShift,AudioEffectSpectrumAnalyzer
+	{ "PauseMode", "ProcessMode" }, // Node
+	{ "TimerProcessMode", "TimerProcessCallback" }, // Timer
+	{ "Tracking_status", "TrackingStatus" }, // XRInterface
+	{ nullptr, nullptr },
+};
+
+const char *RenamesMap3To4::gdscript_function_renames[][2] = {
+	// { "_set_name", "get_tracker_name"}, // XRPositionalTracker - CameraFeed use this
+	// { "_unhandled_input", "_unhandled_key_input"}, // BaseButton, ViewportContainer broke Node, FileDialog,SubViewportContainer
+	// { "create_gizmo", "_create_gizmo"}, // EditorNode3DGizmoPlugin - may be used
+	// { "get_dependencies", "_get_dependencies" }, // ResourceFormatLoader broke ResourceLoader
+	// { "get_extents", "get_size" }, // BoxShape, RectangleShape broke Decal, VoxelGI, GPUParticlesCollisionBox, GPUParticlesCollisionSDF, GPUParticlesCollisionHeightField, GPUParticlesAttractorBox, GPUParticlesAttractorVectorField, FogVolume
+	// { "get_h_offset", "get_drag_horizontal_offset"}, // Camera2D, broke PathFollow, Camera
+	// { "get_mode", "get_file_mode"}, // FileDialog broke Panel, Shader, CSGPolygon, Tilemap
+	// { "get_motion", "get_travel"}, // PhysicsTestMotionResult2D broke ParalaxLayer
+	// { "get_name", "get_tracker_name"}, // XRPositionalTracker broke OS, Node
+	// { "get_network_connected_peers", "get_peers"}, // MultiplayerAPI broke SceneTree
+	// { "get_network_peer", "has_multiplayer_peer"}, // MultiplayerAPI broke SceneTree
+	// { "get_network_unique_id", "get_unique_id"}, // MultiplayerAPI broke SceneTree
+	// { "get_offset", "get_position_offset" }, // GraphNode broke Gradient
+	// { "get_peer_port", "get_peer" }, // ENetMultiplayerPeer broke WebSocketServer
+	// { "get_process_mode", "get_process_callback" }, // ClippedCamera3D broke Node, Sky
+	// { "get_render_info", "get_rendering_info" }, // RenderingServer broke Viewport
+	// { "get_type", "get_tracker_type"}, // XRPositionalTracker broke GLTFAccessor, GLTFLight
+	// { "get_v_offset", "get_drag_vertical_offset"}, // Camera2D, broke PathFollow, Camera
+	// { "has_network_peer", "has_multiplayer_peer"}, // MultiplayerAPI broke SceneTree
+	// { "instance", "instantiate" }, // PackedScene, ClassDB - Broke FileSystemDock signal and also tscn files - [instance=ExtResource( 17 )] - this is implemented as custom rule
+	// { "is_listening", "is_bound"}, // PacketPeerUDP broke TCPServer, UDPServer
+	// { "is_refusing_new_network_connections", "is_refusing_new_connections"}, // MultiplayerAPI broke SceneTree
+	// { "is_valid", "has_valid_event" }, // Shortcut broke e.g. Callable
+	// { "listen", "bound"}, // PacketPeerUDP broke TCPServer, UDPServer
+	// { "load", "_load"}, // ResourceFormatLoader broke ConfigFile, Image, StreamTexture2D
+	// { "make_current", "set_current" }, // Camera2D broke Camera3D, Listener2D
+	// { "process", "_process" }, // AnimationNode - This word is commonly used
+	// { "save", "_save"}, // ResourceFormatLoader broke ConfigFile, Image, StreamTexture2D
+	// { "set_autowrap", "set_autowrap_mode" }, // AcceptDialog broke Label - Cyclic Rename
+	// { "set_color", "surface_set_color"}, // ImmediateMesh broke Light2D, Theme, SurfaceTool
+	// { "set_event", "set_shortcut" }, // BaseButton - Cyclic Rename
+	// { "set_extents", "set_size"}, // BoxShape, RectangleShape broke ReflectionProbe
+	// { "set_flag", "set_particle_flag"}, // ParticleProcessMaterial broke Window, HingeJoint3D
+	// { "set_h_offset", "set_drag_horizontal_offset" }, // Camera2D broke Camera3D, PathFollow3D, PathFollow2D
+	// { "set_margin", "set_offset" }, // Control broke Shape3D, AtlasTexture
+	// { "set_mode", "set_mode_file_mode" }, // FileDialog broke Panel, Shader, CSGPolygon, Tilemap
+	// { "set_normal", "surface_set_normal"}, // ImmediateGeometry broke SurfaceTool, WorldMarginShape2D
+	// { "set_offset", "set_progress" }, // PathFollow2D, PathFollow3D - Too common
+	// { "set_process_mode", "set_process_callback" }, // AnimationTree broke Node, Tween, Sky
+	// { "set_refuse_new_network_connections", "set_refuse_new_connections"}, // MultiplayerAPI broke SceneTree
+	// { "set_tooltip", "set_tooltip_text" }, // Control, breaks TreeItem, at least for now.
+	// { "set_uv", "surface_set_uv" }, // ImmediateMesh broke Polygon2D
+	// { "set_v_offset", "set_drag_vertical_offset" }, // Camera2D broke Camera3D, PathFollow3D, PathFollow2D
+	// {"get_points","get_points_id"},// Astar, broke Line2D, Convexpolygonshape
+	// {"get_v_scroll","get_v_scroll_bar"},//ItemList, broke TextView
+	// { "get_stylebox", "get_theme_stylebox" }, // Control - Will rename the method in Theme as well, skipping
+	{ "_about_to_show", "_about_to_popup" }, // ColorPickerButton
+	{ "_get_configuration_warning", "_get_configuration_warnings" }, // Node
+	{ "_set_current", "set_current" }, // Camera2D
+	{ "_set_editor_description", "set_editor_description" }, // Node
+	{ "_toplevel_raise_self", "_top_level_raise_self" }, // CanvasItem
+	{ "_update_wrap_at", "_update_wrap_at_column" }, // TextEdit
+	{ "add_animation", "add_animation_library" }, // AnimationPlayer
+	{ "add_cancel", "add_cancel_button" }, // AcceptDialog
+	{ "add_central_force", "apply_central_force" }, //RigidBody2D
+	{ "add_child_below_node", "add_sibling" }, // Node
+	{ "add_color_override", "add_theme_color_override" }, // Control
+	{ "add_constant_override", "add_theme_constant_override" }, // Control
+	{ "add_font_override", "add_theme_font_override" }, // Control
+	{ "add_force", "apply_force" }, //RigidBody2D
+	{ "add_icon_override", "add_theme_icon_override" }, // Control
+	{ "add_scene_import_plugin", "add_scene_format_importer_plugin" }, //EditorPlugin
+	{ "add_spatial_gizmo_plugin", "add_node_3d_gizmo_plugin" }, // EditorPlugin
+	{ "add_stylebox_override", "add_theme_stylebox_override" }, // Control
+	{ "add_torque", "apply_torque" }, //RigidBody2D
+	{ "agent_set_neighbor_dist", "agent_set_neighbor_distance" }, // NavigationServer2D, NavigationServer3D
+	{ "apply_changes", "_apply_changes" }, // EditorPlugin
+	{ "body_add_force", "body_apply_force" }, // PhysicsServer2D
+	{ "body_add_torque", "body_apply_torque" }, // PhysicsServer2D
+	{ "bumpmap_to_normalmap", "bump_map_to_normal_map" }, // Image
+	{ "can_be_hidden", "_can_be_hidden" }, // EditorNode3DGizmoPlugin
+	{ "can_drop_data", "_can_drop_data" }, // Control
+	{ "can_generate_small_preview", "_can_generate_small_preview" }, // EditorResourcePreviewGenerator
+	{ "can_instance", "can_instantiate" }, // PackedScene, Script
+	{ "canvas_light_set_scale", "canvas_light_set_texture_scale" }, // RenderingServer
+	{ "capture_get_device", "get_input_device" }, // AudioServer
+	{ "capture_get_device_list", "get_input_device_list" }, // AudioServer
+	{ "capture_set_device", "set_input_device" }, // AudioServer
+	{ "center_viewport_to_cursor", "center_viewport_to_caret" }, // TextEdit
+	{ "change_scene", "change_scene_to_file" }, // SceneTree
+	{ "change_scene_to", "change_scene_to_packed" }, // SceneTree
+	{ "clip_polygons_2d", "clip_polygons" }, // Geometry2D
+	{ "clip_polyline_with_polygon_2d", "clip_polyline_with_polygon" }, //Geometry2D
+	{ "commit_handle", "_commit_handle" }, // EditorNode3DGizmo
+	{ "convex_hull_2d", "convex_hull" }, // Geometry2D
+	{ "create_gizmo", "_create_gizmo" }, // EditorNode3DGizmoPlugin
+	{ "cursor_get_blink_speed", "get_caret_blink_interval" }, // TextEdit
+	{ "cursor_get_column", "get_caret_column" }, // TextEdit
+	{ "cursor_get_line", "get_caret_line" }, // TextEdit
+	{ "cursor_set_blink_enabled", "set_caret_blink_enabled" }, // TextEdit
+	{ "cursor_set_blink_speed", "set_caret_blink_interval" }, // TextEdit
+	{ "cursor_set_column", "set_caret_column" }, // TextEdit
+	{ "cursor_set_line", "set_caret_line" }, // TextEdit
+	{ "damped_spring_joint_create", "joint_make_damped_spring" }, // PhysicsServer2D
+	{ "damped_string_joint_get_param", "damped_spring_joint_get_param" }, // PhysicsServer2D
+	{ "damped_string_joint_set_param", "damped_spring_joint_set_param" }, // PhysicsServer2D
+	{ "dectime", "move_toward" }, // GDScript, Math functions
+	{ "delete_char_at_cursor", "delete_char_at_caret" }, // LineEdit
+	{ "deselect_items", "deselect_all" }, // FileDialog
+	{ "disable_plugin", "_disable_plugin" }, // EditorPlugin
+	{ "drop_data", "_drop_data" }, // Control
+	{ "exclude_polygons_2d", "exclude_polygons" }, // Geometry2D
+	{ "find_node", "find_child" }, // Node
+	{ "find_scancode_from_string", "find_keycode_from_string" }, // OS
+	{ "forward_canvas_draw_over_viewport", "_forward_canvas_draw_over_viewport" }, // EditorPlugin
+	{ "forward_canvas_force_draw_over_viewport", "_forward_canvas_force_draw_over_viewport" }, // EditorPlugin
+	{ "forward_canvas_gui_input", "_forward_canvas_gui_input" }, // EditorPlugin
+	{ "forward_spatial_draw_over_viewport", "_forward_3d_draw_over_viewport" }, // EditorPlugin
+	{ "forward_spatial_force_draw_over_viewport", "_forward_3d_force_draw_over_viewport" }, // EditorPlugin
+	{ "forward_spatial_gui_input", "_forward_3d_gui_input" }, // EditorPlugin
+	{ "generate_from_path", "_generate_from_path" }, // EditorResourcePreviewGenerator
+	{ "generate_small_preview_automatically", "_generate_small_preview_automatically" }, // EditorResourcePreviewGenerator
+	{ "get_action_list", "action_get_events" }, // InputMap
+	{ "get_alt", "is_alt_pressed" }, // InputEventWithModifiers
+	{ "get_animation_process_mode", "get_process_callback" }, // AnimationPlayer
+	{ "get_applied_force", "get_constant_force" }, //RigidBody2D
+	{ "get_applied_torque", "get_constant_torque" }, //RigidBody2D
+	{ "get_audio_bus", "get_audio_bus_name" }, // Area3D
+	{ "get_bound_child_nodes_to_bone", "get_bone_children" }, // Skeleton3D
+	{ "get_camera", "get_camera_3d" }, // Viewport -> this is also convertible to get_camera_2d, broke GLTFNode
+	{ "get_cancel", "get_cancel_button" }, // ConfirmationDialog
+	{ "get_caption", "_get_caption" }, // AnimationNode
+	{ "get_cast_to", "get_target_position" }, // RayCast2D, RayCast3D
+	{ "get_child_by_name", "_get_child_by_name" }, // AnimationNode
+	{ "get_child_nodes", "_get_child_nodes" }, // AnimationNode
+	{ "get_closest_point_to_segment_2d", "get_closest_point_to_segment" }, // Geometry2D
+	{ "get_closest_point_to_segment_uncapped_2d", "get_closest_point_to_segment_uncapped" }, // Geometry2D
+	{ "get_closest_points_between_segments_2d", "get_closest_point_to_segment" }, // Geometry2D
+	{ "get_collision_layer_bit", "get_collision_layer_value" }, // CSGShape3D and a lot of others like GridMap
+	{ "get_collision_mask_bit", "get_collision_mask_value" }, // CSGShape3D and a lot of others like GridMap
+	{ "get_color_types", "get_color_type_list" }, // Theme
+	{ "get_command", "is_command_or_control_pressed" }, // InputEventWithModifiers
+	{ "get_constant_types", "get_constant_type_list" }, // Theme
+	{ "get_control", "is_ctrl_pressed" }, // InputEventWithModifiers
+	{ "get_cull_mask_bit", "get_cull_mask_value" }, // Camera3D
+	{ "get_cursor_position", "get_caret_column" }, // LineEdit
+	{ "get_d", "get_distance" }, // LineShape2D
+	{ "get_depth_bias_enable", "get_depth_bias_enabled" }, // RDPipelineRasterizationState
+	{ "get_device", "get_output_device" }, // AudioServer
+	{ "get_device_list", "get_output_device_list" }, // AudioServer
+	{ "get_drag_data", "_get_drag_data" }, // Control
+	{ "get_editor_viewport", "get_editor_main_screen" }, // EditorPlugin
+	{ "get_enabled_focus_mode", "get_focus_mode" }, // BaseButton
+	{ "get_endian_swap", "is_big_endian" }, // File
+	{ "get_error_string", "get_error_message" }, // JSON
+	{ "get_filename", "get_scene_file_path" }, // Node, WARNING, this may be used in a lot of other places
+	{ "get_focus_neighbour", "get_focus_neighbor" }, // Control
+	{ "get_follow_smoothing", "get_position_smoothing_speed" }, // Camera2D
+	{ "get_font_types", "get_font_type_list" }, // Theme
+	{ "get_frame_color", "get_color" }, // ColorRect
+	{ "get_global_rate_scale", "get_playback_speed_scale" }, // AudioServer
+	{ "get_gravity_distance_scale", "get_gravity_point_unit_distance" }, // Area(2D/3D)
+	{ "get_gravity_vector", "get_gravity_direction" }, // Area(2D/3D)
+	{ "get_h_scrollbar", "get_h_scroll_bar" }, //ScrollContainer
+	{ "get_hand", "get_tracker_hand" }, // XRPositionalTracker
+	{ "get_handle_name", "_get_handle_name" }, // EditorNode3DGizmo
+	{ "get_handle_value", "_get_handle_value" }, // EditorNode3DGizmo
+	{ "get_icon_align", "get_icon_alignment" }, // Button
+	{ "get_icon_types", "get_icon_type_list" }, // Theme
+	{ "get_idle_frames", "get_process_frames" }, // Engine
+	{ "get_import_options", "_get_import_options" }, // EditorImportPlugin
+	{ "get_import_order", "_get_import_order" }, // EditorImportPlugin
+	{ "get_importer_name", "_get_importer_name" }, // EditorImportPlugin
+	{ "get_interior_ambient", "get_ambient_color" }, // ReflectionProbe
+	{ "get_interior_ambient_energy", "get_ambient_color_energy" }, // ReflectionProbe
+	{ "get_iterations_per_second", "get_physics_ticks_per_second" }, // Engine
+	{ "get_last_mouse_speed", "get_last_mouse_velocity" }, // Input
+	{ "get_layer_mask_bit", "get_layer_mask_value" }, // VisualInstance3D
+	{ "get_len", "get_length" }, // File
+	{ "get_max_atlas_size", "get_max_texture_size" }, // LightmapGI
+	{ "get_metakey", "is_meta_pressed" }, // InputEventWithModifiers
+	{ "get_mid_height", "get_height" }, // CapsuleMesh
+	{ "get_motion_remainder", "get_remainder" }, // PhysicsTestMotionResult2D
+	{ "get_neighbor_dist", "get_neighbor_distance" }, // NavigationAgent2D, NavigationAgent3D
+	{ "get_network_connected_peers", "get_peers" }, // Multiplayer API
+	{ "get_network_master", "get_multiplayer_authority" }, // Node
+	{ "get_network_peer", "get_multiplayer_peer" }, // Multiplayer API
+	{ "get_network_unique_id", "get_unique_id" }, // Multiplayer API
+	{ "get_ok", "get_ok_button" }, // AcceptDialog
+	{ "get_oneshot", "get_one_shot" }, // AnimatedTexture
+	{ "get_option_visibility", "_get_option_visibility" }, // EditorImportPlugin
+	{ "get_parameter_default_value", "_get_parameter_default_value" }, // AnimationNode
+	{ "get_parameter_list", "_get_parameter_list" }, // AnimationNode
+	{ "get_parent_spatial", "get_parent_node_3d" }, // Node3D
+	{ "get_pause_mode", "get_process_mode" }, // Node
+	{ "get_physical_scancode", "get_physical_keycode" }, // InputEventKey
+	{ "get_physical_scancode_with_modifiers", "get_physical_keycode_with_modifiers" }, // InputEventKey
+	{ "get_plugin_icon", "_get_plugin_icon" }, // EditorPlugin
+	{ "get_plugin_name", "_get_plugin_name" }, // EditorPlugin
+	{ "get_preset_count", "_get_preset_count" }, // EditorImportPlugin
+	{ "get_preset_name", "_get_preset_name" }, // EditorImportPlugin
+	{ "get_recognized_extensions", "_get_recognized_extensions" }, // ResourceFormatLoader, EditorImportPlugin broke ResourceSaver
+	{ "get_render_info", "get_rendering_info" }, // RenderingServer
+	{ "get_render_targetsize", "get_render_target_size" }, // XRInterface
+	{ "get_resource_type", "_get_resource_type" }, // ResourceFormatLoader
+	{ "get_result", "get_data" }, //JSON
+	{ "get_reverb_bus", "set_reverb_bus_name" }, // Area3D
+	{ "get_rpc_sender_id", "get_remote_sender_id" }, // Multiplayer API
+	{ "get_save_extension", "_get_save_extension" }, // EditorImportPlugin
+	{ "get_scancode", "get_keycode" }, // InputEventKey
+	{ "get_scancode_string", "get_keycode_string" }, // OS
+	{ "get_scancode_with_modifiers", "get_keycode_with_modifiers" }, // InputEventKey
+	{ "get_selected_path", "get_current_directory" }, // EditorInterface
+	{ "get_shift", "is_shift_pressed" }, // InputEventWithModifiers
+	{ "get_size_override", "get_size_2d_override" }, // SubViewport
+	{ "get_slide_count", "get_slide_collision_count" }, // CharacterBody2D, CharacterBody3D
+	{ "get_slips_on_slope", "get_slide_on_slope" }, // SeparationRayShape2D, SeparationRayShape3D
+	{ "get_space_override_mode", "get_gravity_space_override_mode" }, // Area2D
+	{ "get_spatial_node", "get_node_3d" }, // EditorNode3DGizmo
+	{ "get_speed", "get_velocity" }, // InputEventMouseMotion
+	{ "get_stylebox_types", "get_stylebox_type_list" }, // Theme
+	{ "get_surface_material", "get_surface_override_material" }, // MeshInstance3D broke ImporterMesh
+	{ "get_surface_material_count", "get_surface_override_material_count" }, // MeshInstance3D
+	{ "get_tab_disabled", "is_tab_disabled" }, // Tab
+	{ "get_tab_hidden", "is_tab_hidden" }, // Tab
+	{ "get_text_align", "get_text_alignment" }, // Button
+	{ "get_theme_item_types", "get_theme_item_type_list" }, // Theme
+	{ "get_timer_process_mode", "get_timer_process_callback" }, // Timer
+	{ "get_translation", "get_position" }, // Node3D broke GLTFNode which is used rarely
+	{ "get_unit_db", "get_volume_db" }, // AudioStreamPlayer3D
+	{ "get_unit_offset", "get_progress_ratio" }, // PathFollow2D, PathFollow3D
+	{ "get_use_in_baked_light", "is_baking_navigation" }, // GridMap
+	{ "get_used_cells_by_id", "get_used_cells" }, // TileMap
+	{ "get_v_scrollbar", "get_v_scroll_bar" }, //ScrollContainer
+	{ "get_visible_name", "_get_visible_name" }, // EditorImportPlugin
+	{ "get_window_layout", "_get_window_layout" }, // EditorPlugin
+	{ "get_word_under_cursor", "get_word_under_caret" }, // TextEdit
+	{ "get_world", "get_world_3d" }, // Viewport, Spatial
+	{ "get_zfar", "get_far" }, // Camera3D broke GLTFCamera
+	{ "get_znear", "get_near" }, // Camera3D broke GLTFCamera
+	{ "groove_joint_create", "joint_make_groove" }, // PhysicsServer2D
+	{ "handle_menu_selected", "_handle_menu_selected" }, // EditorResourcePicker
+	{ "handles_type", "_handles_type" }, // ResourceFormatLoader
+	{ "has_color", "has_theme_color" }, //  Control broke Theme
+	{ "has_color_override", "has_theme_color_override" }, // Control broke Theme
+	{ "has_constant", "has_theme_constant" }, // Control
+	{ "has_constant_override", "has_theme_constant_override" }, // Control
+	{ "has_filter", "_has_filter" }, // AnimationNode
+	{ "has_font", "has_theme_font" }, // Control broke Theme
+	{ "has_font_override", "has_theme_font_override" }, // Control
+	{ "has_icon", "has_theme_icon" }, // Control broke Theme
+	{ "has_icon_override", "has_theme_icon_override" }, // Control
+	{ "has_main_screen", "_has_main_screen" }, // EditorPlugin
+	{ "has_network_peer", "has_multiplayer_peer" }, // Multiplayer API
+	{ "has_stylebox", "has_theme_stylebox" }, // Control broke Theme
+	{ "has_stylebox_override", "has_theme_stylebox_override" }, // Control
+	{ "http_escape", "uri_encode" }, // String
+	{ "http_unescape", "uri_decode" }, // String
+	{ "import_scene_from_other_importer", "_import_scene" }, //EditorSceneFormatImporter
+	{ "instance_set_surface_material", "instance_set_surface_override_material" }, // RenderingServer
+	{ "interpolate", "sample" }, // Curve, Curve2D, Curve3D, Gradient
+	{ "intersect_polygons_2d", "intersect_polygons" }, // Geometry2D
+	{ "intersect_polyline_with_polygon_2d", "intersect_polyline_with_polygon" }, // Geometry2D
+	{ "is_a_parent_of", "is_ancestor_of" }, // Node
+	{ "is_commiting_action", "is_committing_action" }, // UndoRedo
+	{ "is_doubleclick", "is_double_click" }, // InputEventMouseButton
+	{ "is_draw_red", "is_draw_warning" }, // EditorProperty
+	{ "is_follow_smoothing_enabled", "is_position_smoothing_enabled" }, // Camera2D
+	{ "is_h_drag_enabled", "is_drag_horizontal_enabled" }, // Camera2D
+	{ "is_handle_highlighted", "_is_handle_highlighted" }, // EditorNode3DGizmo, EditorNode3DGizmoPlugin
+	{ "is_inverting_faces", "get_flip_faces" }, // CSGPrimitive3D
+	{ "is_network_master", "is_multiplayer_authority" }, // Node
+	{ "is_network_server", "is_server" }, // Multiplayer API
+	{ "is_normalmap", "is_normal_map" }, // NoiseTexture
+	{ "is_refusing_new_network_connections", "is_refusing_new_connections" }, // Multiplayer API
+	{ "is_region", "is_region_enabled" }, // Sprite2D
+	{ "is_rotating", "is_ignoring_rotation" }, // Camera2D
+	{ "is_scancode_unicode", "is_keycode_unicode" }, // OS
+	{ "is_selectable_when_hidden", "_is_selectable_when_hidden" }, // EditorNode3DGizmoPlugin
+	{ "is_set_as_toplevel", "is_set_as_top_level" }, // CanvasItem
+	{ "is_shortcut", "matches_event" }, // Shortcut
+	{ "is_size_override_stretch_enabled", "is_size_2d_override_stretch_enabled" }, // SubViewport
+	{ "is_sort_enabled", "is_y_sort_enabled" }, // Node2D
+	{ "is_static_body", "is_able_to_sleep" }, // PhysicalBone3D - TODO - not sure
+	{ "is_v_drag_enabled", "is_drag_vertical_enabled" }, // Camera2D
+	{ "joint_create_cone_twist", "joint_make_cone_twist" }, // PhysicsServer3D
+	{ "joint_create_generic_6dof", "joint_make_generic_6dof" }, // PhysicsServer3D
+	{ "joint_create_hinge", "joint_make_hinge" }, // PhysicsServer3D
+	{ "joint_create_pin", "joint_make_pin" }, // PhysicsServer3D
+	{ "joint_create_slider", "joint_make_slider" }, // PhysicsServer3D
+	{ "line_intersects_line_2d", "line_intersects_line" }, // Geometry2D
+	{ "load_from_globals", "load_from_project_settings" }, // InputMap
+	{ "load_interactive", "load_threaded_request" }, // ResourceLoader - load_threaded_request is alternative, but is used differently
+	{ "make_convex_from_brothers", "make_convex_from_siblings" }, // CollisionShape3D
+	{ "make_visible", "_make_visible" }, // EditorPlugin
+	{ "merge_polygons_2d", "merge_polygons" }, // Geometry2D
+	{ "mesh_surface_get_format", "mesh_surface_get_format_attribute_stride" }, // RenderingServer
+	{ "mesh_surface_update_region", "mesh_surface_update_attribute_region" }, // RenderingServer
+	{ "move_to_bottom", "move_after" }, // Skeleton3D
+	{ "move_to_top", "move_before" }, // Skeleton3D
+	{ "multimesh_allocate", "multimesh_allocate_data" }, // RenderingServer
+	{ "normalmap_to_xy", "normal_map_to_xy" }, // Image
+	{ "offset_polygon_2d", "offset_polygon" }, // Geometry2D
+	{ "offset_polyline_2d", "offset_polyline" }, // Geometry2D
+	{ "percent_decode", "uri_decode" }, // String
+	{ "percent_encode", "uri_encode" }, // String
+	{ "pin_joint_create", "joint_make_pin" }, // PhysicsServer2D
+	{ "popup_centered_minsize", "popup_centered_clamped" }, // Window
+	{ "post_import", "_post_import" }, // EditorScenePostImport
+	{ "print_stray_nodes", "print_orphan_nodes" }, // Node
+	{ "property_list_changed_notify", "notify_property_list_changed" }, // Object
+	{ "raise", "move_to_front" }, // CanvasItem
+	{ "recognize", "_recognize" }, // ResourceFormatLoader
+	{ "regen_normalmaps", "regen_normal_maps" }, // ArrayMesh
+	{ "remove", "remove_at" }, // Array, broke Directory
+	{ "remove_animation", "remove_animation_library" }, // AnimationPlayer
+	{ "remove_color_override", "remove_theme_color_override" }, // Control
+	{ "remove_constant_override", "remove_theme_constant_override" }, // Control
+	{ "remove_font_override", "remove_theme_font_override" }, // Control
+	{ "remove_icon_override", "remove_theme_icon_override" }, // Control
+	{ "remove_scene_import_plugin", "remove_scene_format_importer_plugin" }, //EditorPlugin
+	{ "remove_spatial_gizmo_plugin", "remove_node_3d_gizmo_plugin" }, // EditorPlugin
+	{ "remove_stylebox_override", "remove_theme_stylebox_override" }, // Control
+	{ "rename_animation", "rename_animation_library" }, // AnimationPlayer
+	{ "rename_dependencies", "_rename_dependencies" }, // ResourceFormatLoader
+	{ "save_external_data", "_save_external_data" }, // EditorPlugin
+	{ "segment_intersects_segment_2d", "segment_intersects_segment" }, // Geometry2D
+	{ "set_adjustment_enable", "set_adjustment_enabled" }, // Environment
+	{ "set_alt", "set_alt_pressed" }, // InputEventWithModifiers
+	{ "set_anchor_and_margin", "set_anchor_and_offset" }, // Control
+	{ "set_anchors_and_margins_preset", "set_anchors_and_offsets_preset" }, // Control
+	{ "set_animation_process_mode", "set_process_callback" }, // AnimationPlayer
+	{ "set_as_bulk_array", "set_buffer" }, // MultiMesh
+	{ "set_as_normalmap", "set_as_normal_map" }, // NoiseTexture
+	{ "set_as_toplevel", "set_as_top_level" }, // CanvasItem
+	{ "set_audio_bus", "set_audio_bus_name" }, // Area3D
+	{ "set_autowrap", "set_autowrap_mode" }, // Label broke AcceptDialog
+	{ "set_cast_to", "set_target_position" }, // RayCast2D, RayCast3D
+	{ "set_collision_layer_bit", "set_collision_layer_value" }, // CSGShape3D and a lot of others like GridMap
+	{ "set_collision_mask_bit", "set_collision_mask_value" }, // CSGShape3D and a lot of others like GridMap
+	{ "set_column_min_width", "set_column_custom_minimum_width" }, // Tree
+	{ "set_command", "set_meta_pressed" }, // InputEventWithModifiers
+	{ "set_control", "set_ctrl_pressed" }, // InputEventWithModifiers
+	{ "set_create_options", "_set_create_options" }, //  EditorResourcePicker
+	{ "set_cull_mask_bit", "set_cull_mask_value" }, // Camera3D
+	{ "set_cursor_position", "set_caret_column" }, // LineEdit
+	{ "set_d", "set_distance" }, // WorldMarginShape2D
+	{ "set_depth_bias_enable", "set_depth_bias_enabled" }, // RDPipelineRasterizationState
+	{ "set_device", "set_output_device" }, // AudioServer
+	{ "set_doubleclick", "set_double_click" }, // InputEventMouseButton
+	{ "set_draw_red", "set_draw_warning" }, // EditorProperty
+	{ "set_enable_follow_smoothing", "set_position_smoothing_enabled" }, // Camera2D
+	{ "set_enabled_focus_mode", "set_focus_mode" }, // BaseButton
+	{ "set_endian_swap", "set_big_endian" }, // File
+	{ "set_expand_to_text_length", "set_expand_to_text_length_enabled" }, // LineEdit
+	{ "set_filename", "set_scene_file_path" }, // Node, WARNING, this may be used in a lot of other places
+	{ "set_focus_neighbour", "set_focus_neighbor" }, // Control
+	{ "set_follow_smoothing", "set_position_smoothing_speed" }, // Camera2D
+	{ "set_frame_color", "set_color" }, // ColorRect
+	{ "set_global_rate_scale", "set_playback_speed_scale" }, // AudioServer
+	{ "set_gravity_distance_scale", "set_gravity_point_unit_distance" }, // Area(2D/3D)
+	{ "set_gravity_vector", "set_gravity_direction" }, // Area(2D/3D)
+	{ "set_h_drag_enabled", "set_drag_horizontal_enabled" }, // Camera2D
+	{ "set_icon_align", "set_icon_alignment" }, // Button
+	{ "set_interior_ambient", "set_ambient_color" }, // ReflectionProbe
+	{ "set_interior_ambient_energy", "set_ambient_color_energy" }, // ReflectionProbe
+	{ "set_invert_faces", "set_flip_faces" }, // CSGPrimitive3D
+	{ "set_is_initialized", "_is_initialized" }, // XRInterface
+	{ "set_is_primary", "set_primary" }, // XRInterface
+	{ "set_iterations_per_second", "set_physics_ticks_per_second" }, // Engine
+	{ "set_layer_mask_bit", "set_layer_mask_value" }, // VisualInstance3D
+	{ "set_margins_preset", "set_offsets_preset" }, //  Control
+	{ "set_max_atlas_size", "set_max_texture_size" }, // LightmapGI
+	{ "set_metakey", "set_meta_pressed" }, // InputEventWithModifiers
+	{ "set_mid_height", "set_height" }, // CapsuleMesh
+	{ "set_neighbor_dist", "set_neighbor_distance" }, // NavigationAgent2D, NavigationAgent3D
+	{ "set_network_master", "set_multiplayer_authority" }, // Node
+	{ "set_network_peer", "set_multiplayer_peer" }, // Multiplayer API
+	{ "set_oneshot", "set_one_shot" }, // AnimatedTexture
+	{ "set_pause_mode", "set_process_mode" }, // Node
+	{ "set_physical_scancode", "set_physical_keycode" }, // InputEventKey
+	{ "set_proximity_fade", "set_proximity_fade_enabled" }, // Material
+	{ "set_refuse_new_network_connections", "set_refuse_new_connections" }, // Multiplayer API
+	{ "set_region", "set_region_enabled" }, // Sprite2D, Sprite broke AtlasTexture
+	{ "set_region_filter_clip", "set_region_filter_clip_enabled" }, // Sprite2D
+	{ "set_reverb_bus", "set_reverb_bus_name" }, // Area3D
+	{ "set_rotate", "set_rotates" }, // PathFollow2D
+	{ "set_scancode", "set_keycode" }, // InputEventKey
+	{ "set_shift", "set_shift_pressed" }, // InputEventWithModifiers
+	{ "set_size_override", "set_size_2d_override" }, // SubViewport broke ImageTexture
+	{ "set_size_override_stretch", "set_size_2d_override_stretch" }, // SubViewport
+	{ "set_slips_on_slope", "set_slide_on_slope" }, // SeparationRayShape2D, SeparationRayShape3D
+	{ "set_sort_enabled", "set_y_sort_enabled" }, // Node2D
+	{ "set_space_override_mode", "set_gravity_space_override_mode" }, // Area2D
+	{ "set_spatial_node", "set_node_3d" }, // EditorNode3DGizmo
+	{ "set_speed", "set_velocity" }, // InputEventMouseMotion
+	{ "set_ssao_edge_sharpness", "set_ssao_sharpness" }, // Environment
+	{ "set_surface_material", "set_surface_override_material" }, // MeshInstance3D broke ImporterMesh
+	{ "set_tab_align", "set_tab_alignment" }, //TabContainer
+	{ "set_tangent", "surface_set_tangent" }, // ImmediateGeometry broke SurfaceTool
+	{ "set_text_align", "set_text_alignment" }, // Button
+	{ "set_timer_process_mode", "set_timer_process_callback" }, // Timer
+	{ "set_translation", "set_position" }, // Node3D - this broke GLTFNode which is used rarely
+	{ "set_unit_db", "set_volume_db" }, // AudioStreamPlayer3D
+	{ "set_unit_offset", "set_progress_ratio" }, // PathFollow2D, PathFollow3D
+	{ "set_uv2", "surface_set_uv2" }, // ImmediateMesh broke Surffacetool
+	{ "set_v_drag_enabled", "set_drag_vertical_enabled" }, // Camera2D
+	{ "set_valign", "set_vertical_alignment" }, // Label
+	{ "set_window_layout", "_set_window_layout" }, // EditorPlugin
+	{ "set_zfar", "set_far" }, // Camera3D broke GLTFCamera
+	{ "set_znear", "set_near" }, // Camera3D broke GLTFCamera
+	{ "shortcut_match", "is_match" }, // InputEvent
+	{ "skeleton_allocate", "skeleton_allocate_data" }, // RenderingServer
+	{ "surface_update_region", "surface_update_attribute_region" }, // ArrayMesh
+	{ "targeting_method", "tween_method" }, // Tween
+	{ "targeting_property", "tween_property" }, // Tween
+	{ "track_remove_key_at_position", "track_remove_key_at_time" }, // Animation
+	{ "triangulate_delaunay_2d", "triangulate_delaunay" }, // Geometry2D
+	{ "unselect", "deselect" }, // ItemList
+	{ "unselect_all", "deselect_all" }, // ItemList
+	{ "update_configuration_warning", "update_configuration_warnings" }, // Node
+	{ "update_gizmo", "update_gizmos" }, // Node3D
+	{ "viewport_set_use_arvr", "viewport_set_use_xr" }, // RenderingServer
+	{ "warp_mouse_position", "warp_mouse" }, // Input
+	{ "world_to_map", "local_to_map" }, // TileMap, GridMap
+	{ "set_shader_param", "set_shader_parameter" }, // ShaderMaterial
+	{ "get_shader_param", "get_shader_parameter" }, // ShaderMaterial
+	{ "set_uniform_name", "set_parameter_name" }, // ParameterRef
+	{ "get_uniform_name", "get_parameter_name" }, // ParameterRef
+
+	// Builtin types
+	// Remember to add them to builtin_types_excluded_functions variable, because for now this functions cannot be listed
+	//	{ "empty", "is_empty" }, // Array - Used as custom rule  // Be careful, this will be used everywhere
+	{ "clamped", "clamp" }, // Vector2  // Be careful, this will be used everywhere
+	{ "get_rotation_quat", "get_rotation_quaternion" }, // Basis
+	{ "grow_margin", "grow_side" }, // Rect2
+	{ "invert", "reverse" }, // Array - TODO check  // Be careful, this will be used everywhere
+	{ "is_abs_path", "is_absolute_path" }, // String
+	{ "is_valid_integer", "is_valid_int" }, // String
+	{ "linear_interpolate", "lerp" }, // Color
+	{ "find_last", "rfind" }, // Array, String
+	{ "to_ascii", "to_ascii_buffer" }, // String
+	{ "to_utf8", "to_utf8_buffer" }, // String
+	{ "to_wchar", "to_utf32_buffer" }, // String // TODO - utf32 or utf16?
+
+	// @GlobalScope
+	// Remember to add them to builtin_types_excluded_functions variable, because for now this functions cannot be listed
+	{ "bytes2var", "bytes_to_var" },
+	{ "bytes2var_with_objects", "bytes_to_var_with_objects" },
+	{ "db2linear", "db_to_linear" },
+	{ "deg2rad", "deg_to_rad" },
+	{ "linear2db", "linear_to_db" },
+	{ "rad2deg", "rad_to_deg" },
+	{ "rand_range", "randf_range" },
+	{ "range_lerp", "remap" },
+	{ "stepify", "snapped" },
+	{ "str2var", "str_to_var" },
+	{ "var2str", "var_to_str" },
+	{ "var2bytes", "var_to_bytes" },
+	{ "var2bytes_with_objects", "var_to_bytes_with_objects" },
+
+	// @GDScript
+	// Remember to add them to builtin_types_excluded_functions variable, because for now this functions cannot be listed
+	{ "dict2inst", "dict_to_inst" },
+	{ "inst2dict", "inst_to_dict" },
+
+	{ nullptr, nullptr },
+};
+
+// gdscript_function_renames clone with CamelCase
+const char *RenamesMap3To4::csharp_function_renames[][2] = {
+	// { "_SetName", "GetTrackerName"}, // XRPositionalTracker - CameraFeed use this
+	// { "_UnhandledInput", "_UnhandledKeyInput"}, // BaseButton, ViewportContainer broke Node, FileDialog,SubViewportContainer
+	// { "CreateGizmo", "_CreateGizmo"}, // EditorNode3DGizmoPlugin - may be used
+	// { "GetDependencies", "_GetDependencies" }, // ResourceFormatLoader broke ResourceLoader
+	// { "GetExtents", "GetSize" }, // BoxShape, RectangleShape broke Decal, VoxelGI, GPUParticlesCollisionBox, GPUParticlesCollisionSDF, GPUParticlesCollisionHeightField, GPUParticlesAttractorBox, GPUParticlesAttractorVectorField, FogVolume
+	// { "GetHOffset", "GetDragHorizontalOffset"}, // Camera2D, broke PathFollow, Camera
+	// { "GetMode", "GetFileMode"}, // FileDialog broke Panel, Shader, CSGPolygon, Tilemap
+	// { "GetMotion", "GetTravel"}, // PhysicsTestMotionResult2D broke ParalaxLayer
+	// { "GetName", "GetTrackerName"}, // XRPositionalTracker broke OS, Node
+	// { "GetNetworkConnectedPeers", "GetPeers"}, // MultiplayerAPI broke SceneTree
+	// { "GetNetworkPeer", "HasMultiplayerPeer"}, // MultiplayerAPI broke SceneTree
+	// { "GetNetworkUniqueId", "GetUniqueId"}, // MultiplayerAPI broke SceneTree
+	// { "GetOffset", "GetPositionOffset" }, // GraphNode broke Gradient
+	// { "GetPeerPort", "GetPeer" }, // ENetMultiplayerPeer broke WebSocketServer
+	// { "GetProcessMode", "GetProcessCallback" }, // ClippedCamera3D broke Node, Sky
+	// { "GetRenderInfo", "GetRenderingInfo" }, // RenderingServer broke Viewport
+	// { "GetType", "GetTrackerType"}, // XRPositionalTracker broke GLTFAccessor, GLTFLight
+	// { "GetVOffset", "GetDragVerticalOffset"}, // Camera2D, broke PathFollow, Camera
+	// { "HasNetworkPeer", "HasMultiplayerPeer"}, // MultiplayerAPI broke SceneTree
+	// { "Instance", "Instantiate" }, // PackedScene, ClassDB - Broke FileSystemDock signal and also tscn files - [instance=ExtResource( 17 )] - this is implemented as custom rule
+	// { "IsListening", "IsBound"}, // PacketPeerUDP broke TCPServer, UDPServer
+	// { "IsRefusingNewNetworkConnections", "IsRefusingNewConnections"}, // MultiplayerAPI broke SceneTree
+	// { "IsValid", "HasValidEvent" }, // Shortcut broke e.g. Callable
+	// { "Listen", "Bound"}, // PacketPeerUDP broke TCPServer, UDPServer
+	// { "Load", "_Load"}, // ResourceFormatLoader broke ConfigFile, Image, StreamTexture2D
+	// { "MakeCurrent", "SetCurrent" }, // Camera2D broke Camera3D, Listener2D
+	// { "Process", "_Process" }, // AnimationNode - This word is commonly used
+	// { "Save", "_Save"}, // ResourceFormatLoader broke ConfigFile, Image, StreamTexture2D
+	// { "SetAutowrap", "SetAutowrapMode" }, // AcceptDialog broke Label - Cyclic Rename
+	// { "SetColor", "SurfaceSetColor"}, // ImmediateMesh broke Light2D, Theme, SurfaceTool
+	// { "SetEvent", "SetShortcut" }, // BaseButton - Cyclic Rename
+	// { "SetExtents", "SetSize"}, // BoxShape, RectangleShape broke ReflectionProbe
+	// { "SetFlag", "SetParticleFlag"}, // ParticleProcessMaterial broke Window, HingeJoint3D
+	// { "SetHOffset", "SetDragHorizontalOffset" }, // Camera2D broke Camera3D, PathFollow3D, PathFollow2D
+	// { "SetMargin", "SetOffset" }, // Control broke Shape3D, AtlasTexture
+	// { "SetMode", "SetModeFileMode" }, // FileDialog broke Panel, Shader, CSGPolygon, Tilemap
+	// { "SetNormal", "SurfaceSetNormal"}, // ImmediateGeometry broke SurfaceTool, WorldMarginShape2D
+	// { "SetOffset", "SetProgress" }, // PathFollow2D, PathFollow3D - Too common
+	// { "SetProcessMode", "SetProcessCallback" }, // AnimationTree broke Node, Tween, Sky
+	// { "SetRefuseNewNetworkConnections", "SetRefuseNewConnections"}, // MultiplayerAPI broke SceneTree
+	// { "SetTooltip", "SetTooltipText" }, // Control, breaks TreeItem, at least for now.
+	// { "SetUv", "SurfaceSetUv" }, // ImmediateMesh broke Polygon2D
+	// { "SetVOffset", "SetDragVerticalOffset" }, // Camera2D broke Camera3D, PathFollow3D, PathFollow2D
+	// {"GetPoints","GetPointsId"},// Astar, broke Line2D, Convexpolygonshape
+	// {"GetVScroll","GetVScrollBar"},//ItemList, broke TextView
+	// { "GetStylebox", "GetThemeStylebox" }, // Control - Will rename the method in Theme as well, skipping
+	{ "AddSpatialGizmoPlugin", "AddNode3dGizmoPlugin" }, // EditorPlugin
+	{ "RenderingServer", "GetTabAlignment" }, // Tab
+	{ "_AboutToShow", "_AboutToPopup" }, // ColorPickerButton
+	{ "_GetConfigurationWarning", "_GetConfigurationWarnings" }, // Node
+	{ "_SetCurrent", "SetCurrent" }, // Camera2D
+	{ "_SetEditorDescription", "SetEditorDescription" }, // Node
+	{ "_SetPlaying", "SetPlaying" }, // AnimatedSprite3D
+	{ "_ToplevelRaiseSelf", "_TopLevelRaiseSelf" }, // CanvasItem
+	{ "_UpdateWrapAt", "_UpdateWrapAtColumn" }, // TextEdit
+	{ "AddAnimation", "AddAnimationLibrary" }, // AnimationPlayer
+	{ "AddCancel", "AddCancelButton" }, // AcceptDialog
+	{ "AddCentralForce", "AddConstantCentralForce" }, //RigidBody2D
+	{ "AddChildBelowNode", "AddSibling" }, // Node
+	{ "AddColorOverride", "AddThemeColorOverride" }, // Control
+	{ "AddConstantOverride", "AddThemeConstantOverride" }, // Control
+	{ "AddFontOverride", "AddThemeFontOverride" }, // Control
+	{ "AddForce", "AddConstantForce" }, //RigidBody2D
+	{ "AddIconOverride", "AddThemeIconOverride" }, // Control
+	{ "AddSceneImportPlugin", "AddSceneFormatImporterPlugin" }, //EditorPlugin
+	{ "AddStyleboxOverride", "AddThemeStyleboxOverride" }, // Control
+	{ "AddTorque", "AddConstantTorque" }, //RigidBody2D
+	{ "AgentSetNeighborDist", "AgentSetNeighborDistance" }, // NavigationServer2D, NavigationServer3D
+	{ "BindChildNodeToBone", "SetBoneChildren" }, // Skeleton3D
+	{ "BumpmapToNormalmap", "BumpMapToNormalMap" }, // Image
+	{ "CanBeHidden", "_CanBeHidden" }, // EditorNode3DGizmoPlugin
+	{ "CanDropData", "_CanDropData" }, // Control
+	{ "CanDropDataFw", "_CanDropDataFw" }, // ScriptEditor
+	{ "CanGenerateSmallPreview", "_CanGenerateSmallPreview" }, // EditorResourcePreviewGenerator
+	{ "CanInstance", "CanInstantiate" }, // PackedScene, Script
+	{ "CanvasLightSetScale", "CanvasLightSetTextureScale" }, // RenderingServer
+	{ "CaptureGetDevice", "GetInputDevice" }, // AudioServer
+	{ "CaptureGetDeviceList", "GetInputDeviceList" }, // AudioServer
+	{ "CaptureSetDevice", "SetInputDevice" }, // AudioServer
+	{ "CenterViewportToCursor", "CenterViewportToCaret" }, // TextEdit
+	{ "ChangeScene", "ChangeSceneToFile" }, // SceneTree
+	{ "ChangeSceneTo", "ChangeSceneToPacked" }, // SceneTree
+	{ "ClipPolygons2d", "ClipPolygons" }, // Geometry2D
+	{ "ClipPolylineWithPolygon2d", "ClipPolylineWithPolygon" }, //Geometry2D
+	{ "CommitHandle", "_CommitHandle" }, // EditorNode3DGizmo
+	{ "ConvexHull2d", "ConvexHull" }, // Geometry2D
+	{ "CursorGetBlinkSpeed", "GetCaretBlinkInterval" }, // TextEdit
+	{ "CursorGetColumn", "GetCaretColumn" }, // TextEdit
+	{ "CursorGetLine", "GetCaretLine" }, // TextEdit
+	{ "CursorSetBlinkEnabled", "SetCaretBlinkEnabled" }, // TextEdit
+	{ "CursorSetBlinkSpeed", "SetCaretBlinkInterval" }, // TextEdit
+	{ "CursorSetColumn", "SetCaretColumn" }, // TextEdit
+	{ "CursorSetLine", "SetCaretLine" }, // TextEdit
+	{ "DampedSpringJointCreate", "JointMakeDampedSpring" }, // PhysicsServer2D
+	{ "DampedStringJointGetParam", "DampedSpringJointGetParam" }, // PhysicsServer2D
+	{ "DampedStringJointSetParam", "DampedSpringJointSetParam" }, // PhysicsServer2D
+	{ "DeleteCharAtCursor", "DeleteCharAtCaret" }, // LineEdit
+	{ "DeselectItems", "DeselectAll" }, // FileDialog
+	{ "DropData", "_DropData" }, // Control
+	{ "DropDataFw", "_DropDataFw" }, // ScriptEditor
+	{ "ExcludePolygons2d", "ExcludePolygons" }, // Geometry2D
+	{ "FindScancodeFromString", "FindKeycodeFromString" }, // OS
+	{ "ForwardCanvasDrawOverViewport", "_ForwardCanvasDrawOverViewport" }, // EditorPlugin
+	{ "ForwardCanvasForceDrawOverViewport", "_ForwardCanvasForceDrawOverViewport" }, // EditorPlugin
+	{ "ForwardCanvasGuiInput", "_ForwardCanvasGuiInput" }, // EditorPlugin
+	{ "ForwardSpatialDrawOverViewport", "_Forward3dDrawOverViewport" }, // EditorPlugin
+	{ "ForwardSpatialForceDrawOverViewport", "_Forward3dForceDrawOverViewport" }, // EditorPlugin
+	{ "ForwardSpatialGuiInput", "_Forward3dGuiInput" }, // EditorPlugin
+	{ "GenerateFromPath", "_GenerateFromPath" }, // EditorResourcePreviewGenerator
+	{ "GenerateSmallPreviewAutomatically", "_GenerateSmallPreviewAutomatically" }, // EditorResourcePreviewGenerator
+	{ "GetActionList", "ActionGetEvents" }, // InputMap
+	{ "GetAlt", "IsAltPressed" }, // InputEventWithModifiers
+	{ "GetAnimationProcessMode", "GetProcessCallback" }, // AnimationPlayer
+	{ "GetAppliedForce", "GetConstantForce" }, //RigidBody2D
+	{ "GetAppliedTorque", "GetConstantTorque" }, //RigidBody2D
+	{ "GetAudioBus", "GetAudioBusName" }, // Area3D
+	{ "GetBoundChildNodesToBone", "GetBoneChildren" }, // Skeleton3D
+	{ "GetCamera", "GetCamera3d" }, // Viewport -> this is also convertible to getCamera2d, broke GLTFNode
+	{ "GetCancel", "GetCancelButton" }, // ConfirmationDialog
+	{ "GetCaption", "_GetCaption" }, // AnimationNode
+	{ "GetCastTo", "GetTargetPosition" }, // RayCast2D, RayCast3D
+	{ "GetChildByName", "_GetChildByName" }, // AnimationNode
+	{ "GetChildNodes", "_GetChildNodes" }, // AnimationNode
+	{ "GetClosestPointToSegment2d", "GetClosestPointToSegment" }, // Geometry2D
+	{ "GetClosestPointToSegmentUncapped2d", "GetClosestPointToSegmentUncapped" }, // Geometry2D
+	{ "GetClosestPointsBetweenSegments2d", "GetClosestPointToSegment" }, // Geometry2D
+	{ "GetCollisionLayerBit", "GetCollisionLayerValue" }, // CSGShape3D and a lot of others like GridMap
+	{ "GetCollisionMaskBit", "GetCollisionMaskValue" }, // CSGShape3D and a lot of others like GridMap
+	{ "GetColorTypes", "GetColorTypeList" }, // Theme
+	{ "GetCommand", "IsCommandPressed" }, // InputEventWithModifiers
+	{ "GetConstantTypes", "GetConstantTypeList" }, // Theme
+	{ "GetControl", "IsCtrlPressed" }, // InputEventWithModifiers
+	{ "GetCullMaskBit", "GetCullMaskValue" }, // Camera3D
+	{ "GetCursorPosition", "GetCaretColumn" }, // LineEdit
+	{ "GetD", "GetDistance" }, // LineShape2D
+	{ "GetDepthBiasEnable", "GetDepthBiasEnabled" }, // RDPipelineRasterizationState
+	{ "GetDevice", "GetOutputDevice" }, // AudioServer
+	{ "GetDeviceList", "GetOutputDeviceList" }, // AudioServer
+	{ "GetDragDataFw", "_GetDragDataFw" }, // ScriptEditor
+	{ "GetEditorViewport", "GetViewport" }, // EditorPlugin
+	{ "GetEnabledFocusMode", "GetFocusMode" }, // BaseButton
+	{ "GetEndianSwap", "IsBigEndian" }, // File
+	{ "GetErrorString", "GetErrorMessage" }, // JSON
+	{ "GetFocusNeighbour", "GetFocusNeighbor" }, // Control
+	{ "GetFollowSmoothing", "GetFollowSmoothingSpeed" }, // Camera2D
+	{ "GetFontTypes", "GetFontTypeList" }, // Theme
+	{ "GetFrameColor", "GetColor" }, // ColorRect
+	{ "GetGlobalRateScale", "GetPlaybackSpeedScale" }, // AudioServer
+	{ "GetGravityDistanceScale", "GetGravityPointDistanceScale" }, //Area2D
+	{ "GetGravityVector", "GetGravityDirection" }, //Area2D
+	{ "GetHScrollbar", "GetHScrollBar" }, //ScrollContainer
+	{ "GetHand", "GetTrackerHand" }, // XRPositionalTracker
+	{ "GetHandleName", "_GetHandleName" }, // EditorNode3DGizmo
+	{ "GetHandleValue", "_GetHandleValue" }, // EditorNode3DGizmo
+	{ "GetIconAlign", "GetIconAlignment" }, // Button
+	{ "GetIconTypes", "GetIconTypeList" }, // Theme
+	{ "GetIdleFrames", "GetProcessFrames" }, // Engine
+	{ "GetImportOptions", "_GetImportOptions" }, // EditorImportPlugin
+	{ "GetImportOrder", "_GetImportOrder" }, // EditorImportPlugin
+	{ "GetImporterName", "_GetImporterName" }, // EditorImportPlugin
+	{ "GetInteriorAmbient", "GetAmbientColor" }, // ReflectionProbe
+	{ "GetInteriorAmbientEnergy", "GetAmbientColorEnergy" }, // ReflectionProbe
+	{ "GetIterationsPerSecond", "GetPhysicsTicksPerSecond" }, // Engine
+	{ "GetLastMouseSpeed", "GetLastMouseVelocity" }, // Input
+	{ "GetLayerMaskBit", "GetLayerMaskValue" }, // VisualInstance3D
+	{ "GetLen", "GetLength" }, // File
+	{ "GetMaxAtlasSize", "GetMaxTextureSize" }, // LightmapGI
+	{ "GetMetakey", "IsMetaPressed" }, // InputEventWithModifiers
+	{ "GetMidHeight", "GetHeight" }, // CapsuleMesh
+	{ "GetMotionRemainder", "GetRemainder" }, // PhysicsTestMotionResult2D
+	{ "GetNeighborDist", "GetNeighborDistance" }, // NavigationAgent2D, NavigationAgent3D
+	{ "GetNetworkConnectedPeers", "GetPeers" }, // Multiplayer API
+	{ "GetNetworkMaster", "GetMultiplayerAuthority" }, // Node
+	{ "GetNetworkPeer", "GetMultiplayerPeer" }, // Multiplayer API
+	{ "GetNetworkUniqueId", "GetUniqueId" }, // Multiplayer API
+	{ "GetOneshot", "GetOneShot" }, // AnimatedTexture
+	{ "GetOk", "GetOkButton" }, // AcceptDialog
+	{ "GetOptionVisibility", "_GetOptionVisibility" }, // EditorImportPlugin
+	{ "GetParameterDefaultValue", "_GetParameterDefaultValue" }, // AnimationNode
+	{ "GetParameterList", "_GetParameterList" }, // AnimationNode
+	{ "GetParentSpatial", "GetParentNode3d" }, // Node3D
+	{ "GetPhysicalScancode", "GetPhysicalKeycode" }, // InputEventKey
+	{ "GetPhysicalScancodeWithModifiers", "GetPhysicalKeycodeWithModifiers" }, // InputEventKey
+	{ "GetPluginIcon", "_GetPluginIcon" }, // EditorPlugin
+	{ "GetPluginName", "_GetPluginName" }, // EditorPlugin
+	{ "GetPresetCount", "_GetPresetCount" }, // EditorImportPlugin
+	{ "GetPresetName", "_GetPresetName" }, // EditorImportPlugin
+	{ "GetRecognizedExtensions", "_GetRecognizedExtensions" }, // ResourceFormatLoader, EditorImportPlugin broke ResourceSaver
+	{ "GetRenderInfo", "GetRenderingInfo" }, // RenderingServer
+	{ "GetRenderTargetsize", "GetRenderTargetSize" }, // XRInterface
+	{ "GetResourceType", "_GetResourceType" }, // ResourceFormatLoader
+	{ "GetResult", "GetData" }, //JSON
+	{ "GetReverbBus", "GetReverbBusName" }, // Area3D
+	{ "GetRpcSenderId", "GetRemoteSenderId" }, // Multiplayer API
+	{ "GetSaveExtension", "_GetSaveExtension" }, // EditorImportPlugin
+	{ "GetScancode", "GetKeycode" }, // InputEventKey
+	{ "GetScancodeString", "GetKeycodeString" }, // OS
+	{ "GetScancodeWithModifiers", "GetKeycodeWithModifiers" }, // InputEventKey
+	{ "GetShift", "IsShiftPressed" }, // InputEventWithModifiers
+	{ "GetSizeOverride", "GetSize2dOverride" }, // SubViewport
+	{ "GetSlipsOnSlope", "GetSlideOnSlope" }, // SeparationRayShape2D, SeparationRayShape3D
+	{ "GetSpaceOverrideMode", "GetGravitySpaceOverrideMode" }, // Area2D
+	{ "GetSpatialNode", "GetNode3d" }, // EditorNode3DGizmo
+	{ "GetSpeed", "GetVelocity" }, // InputEventMouseMotion
+	{ "GetStyleboxTypes", "GetStyleboxTypeList" }, // Theme
+	{ "GetSurfaceMaterial", "GetSurfaceOverrideMaterial" }, // MeshInstance3D broke ImporterMesh
+	{ "GetSurfaceMaterialCount", "GetSurfaceOverrideMaterialCount" }, // MeshInstance3D
+	{ "GetTabDisabled", "IsTabDisabled" }, // Tab
+	{ "GetTabHidden", "IsTabHidden" }, // Tab
+	{ "GetTextAlign", "GetTextAlignment" }, // Button
+	{ "GetThemeItemTypes", "GetThemeItemTypeList" }, // Theme
+	{ "GetTimerProcessMode", "GetTimerProcessCallback" }, // Timer
+	{ "GetTranslation", "GetPosition" }, // Node3D broke GLTFNode which is used rarely
+	{ "GetUnitDb", "GetVolumeDb" }, // AudioStreamPlayer3D
+	{ "GetUnitOffset", "GetProgressRatio" }, // PathFollow2D, PathFollow3D
+	{ "GetUseInBakedLight", "IsBakingNavigation" }, // GridMap
+	{ "GetUsedCellsById", "GetUsedCells" }, // TileMap
+	{ "GetVScrollbar", "GetVScrollBar" }, //ScrollContainer
+	{ "GetVisibleName", "_GetVisibleName" }, // EditorImportPlugin
+	{ "GetWindowLayout", "_GetWindowLayout" }, // EditorPlugin
+	{ "GetWordUnderCursor", "GetWordUnderCaret" }, // TextEdit
+	{ "GetWorld", "GetWorld3d" }, // Viewport, Spatial
+	{ "GetZfar", "GetFar" }, // Camera3D broke GLTFCamera
+	{ "GetZnear", "GetNear" }, // Camera3D broke GLTFCamera
+	{ "GrooveJointCreate", "JointMakeGroove" }, // PhysicsServer2D
+	{ "HandleMenuSelected", "_HandleMenuSelected" }, // EditorResourcePicker
+	{ "HandlesType", "_HandlesType" }, // ResourceFormatLoader
+	{ "HasColor", "HasThemeColor" }, //  Control broke Theme
+	{ "HasColorOverride", "HasThemeColorOverride" }, // Control broke Theme
+	{ "HasConstant", "HasThemeConstant" }, // Control
+	{ "HasConstantOverride", "HasThemeConstantOverride" }, // Control
+	{ "HasFilter", "_HasFilter" }, // AnimationNode
+	{ "HasFont", "HasThemeFont" }, // Control broke Theme
+	{ "HasFontOverride", "HasThemeFontOverride" }, // Control
+	{ "HasIcon", "HasThemeIcon" }, // Control broke Theme
+	{ "HasIconOverride", "HasThemeIconOverride" }, // Control
+	{ "HasMainScreen", "_HasMainScreen" }, // EditorPlugin
+	{ "HasNetworkPeer", "HasMultiplayerPeer" }, // Multiplayer API
+	{ "HasStylebox", "HasThemeStylebox" }, // Control broke Theme
+	{ "HasStyleboxOverride", "HasThemeStyleboxOverride" }, // Control
+	{ "HttpEscape", "UriEncode" }, // String
+	{ "HttpUnescape", "UriDecode" }, // String
+	{ "ImportAnimationFromOtherImporter", "_ImportAnimation" }, //EditorSceneFormatImporter
+	{ "ImportSceneFromOtherImporter", "_ImportScene" }, //EditorSceneFormatImporter
+	{ "InstanceSetSurfaceMaterial", "InstanceSetSurfaceOverrideMaterial" }, // RenderingServer
+	{ "IntersectPolygons2d", "IntersectPolygons" }, // Geometry2D
+	{ "IntersectPolylineWithPolygon2d", "IntersectPolylineWithPolygon" }, // Geometry2D
+	{ "IsAParentOf", "IsAncestorOf" }, // Node
+	{ "IsCommitingAction", "IsCommittingAction" }, // UndoRedo
+	{ "IsDoubleclick", "IsDoubleClick" }, // InputEventMouseButton
+	{ "IsFollowSmoothingEnabled", "IsPositionSmoothingEnabled" }, // Camera2D
+	{ "IsHDragEnabled", "IsDragHorizontalEnabled" }, // Camera2D
+	{ "IsHandleHighlighted", "_IsHandleHighlighted" }, // EditorNode3DGizmo, EditorNode3DGizmoPlugin
+	{ "IsNetworkMaster", "IsMultiplayerAuthority" }, // Node
+	{ "IsNetworkServer", "IsServer" }, // Multiplayer API
+	{ "IsNormalmap", "IsNormalMap" }, // NoiseTexture
+	{ "IsRefusingNewNetworkConnections", "IsRefusingNewConnections" }, // Multiplayer API
+	{ "IsRegion", "IsRegionEnabled" }, // Sprite2D
+	{ "IsRotating", "IsIgnoringRotation" }, // Camera2D
+	{ "IsScancodeUnicode", "IsKeycodeUnicode" }, // OS
+	{ "IsSelectableWhenHidden", "_IsSelectableWhenHidden" }, // EditorNode3DGizmoPlugin
+	{ "IsSetAsToplevel", "IsSetAsTopLevel" }, // CanvasItem
+	{ "IsShortcut", "MatchesEvent" }, // Shortcut
+	{ "IsSizeOverrideStretchEnabled", "IsSize2dOverrideStretchEnabled" }, // SubViewport
+	{ "IsSortEnabled", "IsYSortEnabled" }, // Node2D
+	{ "IsStaticBody", "IsAbleToSleep" }, // PhysicalBone3D - TODO - not sure
+	{ "IsVDragEnabled", "IsDragVerticalEnabled" }, // Camera2D
+	{ "JointCreateConeTwist", "JointMakeConeTwist" }, // PhysicsServer3D
+	{ "JointCreateGeneric6dof", "JointMakeGeneric6dof" }, // PhysicsServer3D
+	{ "JointCreateHinge", "JointMakeHinge" }, // PhysicsServer3D
+	{ "JointCreatePin", "JointMakePin" }, // PhysicsServer3D
+	{ "JointCreateSlider", "JointMakeSlider" }, // PhysicsServer3D
+	{ "LineIntersectsLine2d", "LineIntersectsLine" }, // Geometry2D
+	{ "LoadFromGlobals", "LoadFromProjectSettings" }, // InputMap
+	{ "MakeConvexFromBrothers", "MakeConvexFromSiblings" }, // CollisionShape3D
+	{ "MergePolygons2d", "MergePolygons" }, // Geometry2D
+	{ "MeshSurfaceGetFormat", "MeshSurfaceGetFormatAttributeStride" }, // RenderingServer
+	{ "MeshSurfaceUpdateRegion", "MeshSurfaceUpdateAttributeRegion" }, // RenderingServer
+	{ "MoveToBottom", "MoveAfter" }, // Skeleton3D
+	{ "MoveToTop", "MoveBefore" }, // Skeleton3D
+	{ "MultimeshAllocate", "MultimeshAllocateData" }, // RenderingServer
+	{ "NormalmapToXy", "NormalMapToXy" }, // Image
+	{ "OffsetPolygon2d", "OffsetPolygon" }, // Geometry2D
+	{ "OffsetPolyline2d", "OffsetPolyline" }, // Geometry2D
+	{ "PercentDecode", "UriDecode" }, // String
+	{ "PercentEncode", "UriEncode" }, // String
+	{ "PinJointCreate", "JointMakePin" }, // PhysicsServer2D
+	{ "PopupCenteredMinsize", "PopupCenteredClamped" }, // Window
+	{ "PostImport", "_PostImport" }, // EditorScenePostImport
+	{ "PrintStrayNodes", "PrintOrphanNodes" }, // Node
+	{ "PropertyListChangedNotify", "NotifyPropertyListChanged" }, // Object
+	{ "Recognize", "_Recognize" }, // ResourceFormatLoader
+	{ "RegenNormalmaps", "RegenNormalMaps" }, // ArrayMesh
+	{ "Remove", "RemoveAt" }, // Array, broke Directory
+	{ "RemoveAnimation", "RemoveAnimationLibrary" }, // AnimationPlayer
+	{ "RemoveColorOverride", "RemoveThemeColorOverride" }, // Control
+	{ "RemoveConstantOverride", "RemoveThemeConstantOverride" }, // Control
+	{ "RemoveFontOverride", "RemoveThemeFontOverride" }, // Control
+	{ "RemoveSceneImportPlugin", "RemoveSceneFormatImporterPlugin" }, //EditorPlugin
+	{ "RemoveSpatialGizmoPlugin", "RemoveNode3dGizmoPlugin" }, // EditorPlugin
+	{ "RemoveStyleboxOverride", "RemoveThemeStyleboxOverride" }, // Control
+	{ "RenameAnimation", "RenameAnimationLibrary" }, // AnimationPlayer
+	{ "RenameDependencies", "_RenameDependencies" }, // ResourceFormatLoader
+	{ "SaveExternalData", "_SaveExternalData" }, // EditorPlugin
+	{ "SegmentIntersectsSegment2d", "SegmentIntersectsSegment" }, // Geometry2D
+	{ "SetAdjustmentEnable", "SetAdjustmentEnabled" }, // Environment
+	{ "SetAlt", "SetAltPressed" }, // InputEventWithModifiers
+	{ "SetAnchorAndMargin", "SetAnchorAndOffset" }, // Control
+	{ "SetAnchorsAndMarginsPreset", "SetAnchorsAndOffsetsPreset" }, // Control
+	{ "SetAnimationProcessMode", "SetProcessCallback" }, // AnimationPlayer
+	{ "SetAsBulkArray", "SetBuffer" }, // MultiMesh
+	{ "SetAsNormalmap", "SetAsNormalMap" }, // NoiseTexture
+	{ "SetAsToplevel", "SetAsTopLevel" }, // CanvasItem
+	{ "SetAudioBus", "SetAudioBusName" }, // Area3D
+	{ "SetAutowrap", "SetAutowrapMode" }, // Label broke AcceptDialog
+	{ "SetCastTo", "SetTargetPosition" }, // RayCast2D, RayCast3D
+	{ "SetCollisionLayerBit", "SetCollisionLayerValue" }, // CSGShape3D and a lot of others like GridMap
+	{ "SetCollisionMaskBit", "SetCollisionMaskValue" }, // CSGShape3D and a lot of others like GridMap
+	{ "SetColumnMinWidth", "SetColumnCustomMinimumWidth" }, // Tree
+	{ "SetCommand", "SetCommandPressed" }, // InputEventWithModifiers
+	{ "SetControl", "SetCtrlPressed" }, // InputEventWithModifiers
+	{ "SetCreateOptions", "_SetCreateOptions" }, //  EditorResourcePicker
+	{ "SetCullMaskBit", "SetCullMaskValue" }, // Camera3D
+	{ "SetCursorPosition", "SetCaretColumn" }, // LineEdit
+	{ "SetD", "SetDistance" }, // WorldMarginShape2D
+	{ "SetDepthBiasEnable", "SetDepthBiasEnabled" }, // RDPipelineRasterizationState
+	{ "SetDevice", "SetOutputDevice" }, // AudioServer
+	{ "SetDoubleclick", "SetDoubleClick" }, // InputEventMouseButton
+	{ "SetEnableFollowSmoothing", "SetFollowSmoothingEnabled" }, // Camera2D
+	{ "SetEnabledFocusMode", "SetFocusMode" }, // BaseButton
+	{ "SetEndianSwap", "SetBigEndian" }, // File
+	{ "SetExpandToTextLength", "SetExpandToTextLengthEnabled" }, // LineEdit
+	{ "SetFocusNeighbour", "SetFocusNeighbor" }, // Control
+	{ "SetFollowSmoothing", "SetFollowSmoothingSpeed" }, // Camera2D
+	{ "SetFrameColor", "SetColor" }, // ColorRect
+	{ "SetGlobalRateScale", "SetPlaybackSpeedScale" }, // AudioServer
+	{ "SetGravityDistanceScale", "SetGravityPointDistanceScale" }, // Area2D
+	{ "SetGravityVector", "SetGravityDirection" }, // Area2D
+	{ "SetHDragEnabled", "SetDragHorizontalEnabled" }, // Camera2D
+	{ "SetIconAlign", "SetIconAlignment" }, // Button
+	{ "SetInteriorAmbient", "SetAmbientColor" }, // ReflectionProbe
+	{ "SetInteriorAmbientEnergy", "SetAmbientColorEnergy" }, // ReflectionProbe
+	{ "SetIsInitialized", "_IsInitialized" }, // XRInterface
+	{ "SetIsPrimary", "SetPrimary" }, // XRInterface
+	{ "SetIterationsPerSecond", "SetPhysicsTicksPerSecond" }, // Engine
+	{ "SetLayerMaskBit", "SetLayerMaskValue" }, // VisualInstance3D
+	{ "SetMarginsPreset", "SetOffsetsPreset" }, //  Control
+	{ "SetMaxAtlasSize", "SetMaxTextureSize" }, // LightmapGI
+	{ "SetMetakey", "SetMetaPressed" }, // InputEventWithModifiers
+	{ "SetMidHeight", "SetHeight" }, // CapsuleMesh
+	{ "SetNeighborDist", "SetNeighborDistance" }, // NavigationAgent2D, NavigationAgent3D
+	{ "SetNetworkMaster", "SetMultiplayerAuthority" }, // Node
+	{ "SetNetworkPeer", "SetMultiplayerPeer" }, // Multiplayer API
+	{ "SetOneshot", "SetOneShot" }, // AnimatedTexture
+	{ "SetPhysicalScancode", "SetPhysicalKeycode" }, // InputEventKey
+	{ "SetProximityFade", "SetProximityFadeEnabled" }, // Material
+	{ "SetRefuseNewNetworkConnections", "SetRefuseNewConnections" }, // Multiplayer API
+	{ "SetRegion", "SetRegionEnabled" }, // Sprite2D, Sprite broke AtlasTexture
+	{ "SetRegionFilterClip", "SetRegionFilterClipEnabled" }, // Sprite2D
+	{ "SetReverbBus", "SetReverbBusName" }, // Area3D
+	{ "SetRotate", "SetRotates" }, // PathFollow2D
+	{ "SetScancode", "SetKeycode" }, // InputEventKey
+	{ "SetShift", "SetShiftPressed" }, // InputEventWithModifiers
+	{ "SetSizeOverride", "SetSize2dOverride" }, // SubViewport broke ImageTexture
+	{ "SetSizeOverrideStretch", "SetSize2dOverrideStretch" }, // SubViewport
+	{ "SetSlipsOnSlope", "SetSlideOnSlope" }, // SeparationRayShape2D, SeparationRayShape3D
+	{ "SetSortEnabled", "SetYSortEnabled" }, // Node2D
+	{ "SetSpaceOverrideMode", "SetGravitySpaceOverrideMode" }, // Area2D
+	{ "SetSpatialNode", "SetNode3d" }, // EditorNode3DGizmo
+	{ "SetSpeed", "SetVelocity" }, // InputEventMouseMotion
+	{ "SetSsaoEdgeSharpness", "SetSsaoSharpness" }, // Environment
+	{ "SetSurfaceMaterial", "SetSurfaceOverrideMaterial" }, // MeshInstance3D broke ImporterMesh
+	{ "SetTabAlign", "SetTabAlignment" }, //TabContainer
+	{ "SetTangent", "SurfaceSetTangent" }, // ImmediateGeometry broke SurfaceTool
+	{ "SetTextAlign", "SetTextAlignment" }, // Button
+	{ "SetTimerProcessMode", "SetTimerProcessCallback" }, // Timer
+	{ "SetTonemapAutoExposure", "SetTonemapAutoExposureEnabled" }, // Environment
+	{ "SetTranslation", "SetPosition" }, // Node3D - this broke GLTFNode which is used rarely
+	{ "SetUnitDb", "SetVolumeDb" }, // AudioStreamPlayer3D
+	{ "SetUnitOffset", "SetProgressRatio" }, // PathFollow2D, PathFollow3D
+	{ "SetUv2", "SurfaceSetUv2" }, // ImmediateMesh broke Surffacetool
+	{ "SetVDragEnabled", "SetDragVerticalEnabled" }, // Camera2D
+	{ "SetValign", "SetVerticalAlignment" }, // Label
+	{ "SetWindowLayout", "_SetWindowLayout" }, // EditorPlugin
+	{ "SetZfar", "SetFar" }, // Camera3D broke GLTFCamera
+	{ "SetZnear", "SetNear" }, // Camera3D broke GLTFCamera
+	{ "ShortcutMatch", "IsMatch" }, // InputEvent
+	{ "SkeletonAllocate", "SkeletonAllocateData" }, // RenderingServer
+	{ "SurfaceUpdateRegion", "SurfaceUpdateAttributeRegion" }, // ArrayMesh
+	{ "TargetingMethod", "TweenMethod" }, // Tween
+	{ "TargetingProperty", "TweenProperty" }, // Tween
+	{ "TrackRemoveKeyAtPosition", "TrackRemoveKeyAtTime" }, // Animation
+	{ "TriangulateDelaunay2d", "TriangulateDelaunay" }, // Geometry2D
+	{ "UnbindChildNodeFromBone", "RemoveBoneChild" }, // Skeleton3D
+	{ "Unselect", "Deselect" }, // ItemList
+	{ "UnselectAll", "DeselectAll" }, // ItemList
+	{ "UpdateConfigurationWarning", "UpdateConfigurationWarnings" }, // Node
+	{ "UpdateGizmo", "UpdateGizmos" }, // Node3D
+	{ "ViewportSetUseArvr", "ViewportSetUseXr" }, // RenderingServer
+	{ "WarpMousePosition", "WarpMouse" }, // Input
+	{ "WorldToMap", "LocalToMap" }, // TileMap, GridMap
+	{ "SetShaderParam", "SetShaderParameter" }, // ShaderMaterial
+	{ "GetShaderParam", "GetShaderParameter" }, // ShaderMaterial
+	{ "SetUniformName", "SetParameterName" }, // ParameterRef
+	{ "GetUniformName", "GetParameterName" }, // ParameterRef
+
+	// Builtin types
+	//	{ "Empty", "IsEmpty" }, // Array - Used as custom rule  // Be careful, this will be used everywhere
+	{ "Clamped", "Clamp" }, // Vector2  // Be careful, this will be used everywhere
+	{ "GetRotationQuat", "GetRotationQuaternion" }, // Basis
+	{ "GrowMargin", "GrowSide" }, // Rect2
+	{ "Invert", "Reverse" }, // Array - TODO check  // Be careful, this will be used everywhere
+	{ "IsAbsPath", "IsAbsolutePath" }, // String
+	{ "IsValidInteger", "IsValidInt" }, // String
+	{ "LinearInterpolate", "Lerp" }, // Color
+	{ "ToAscii", "ToAsciiBuffer" }, // String
+	{ "ToUtf8", "ToUtf8Buffer" }, // String
+	{ "ToWchar", "ToUtf32Buffer" }, // String // TODO - utf32 or utf16?
+
+	// @GlobalScope
+	{ "Bytes2Var", "BytesToVar" },
+	{ "Bytes2VarWithObjects", "BytesToVarWithObjects" },
+	{ "Db2Linear", "DbToLinear" },
+	{ "Deg2Rad", "DegToRad" },
+	{ "Linear2Db", "LinearToDb" },
+	{ "Rad2Deg", "RadToDeg" },
+	{ "RandRange", "RandfRange" },
+	{ "RangeLerp", "Remap" },
+	{ "Stepify", "Snapped" },
+	{ "Str2Var", "StrToVar" },
+	{ "Var2Str", "VarToStr" },
+	{ "Var2Bytes", "VarToBytes" },
+	{ "Var2BytesWithObjects", "VarToBytesWithObjects" },
+
+	// @GDScript
+	{ "Dict2Inst", "DictToInst" },
+	{ "Inst2Dict", "InstToDict" },
+
+	{ nullptr, nullptr },
+};
+
+// Some needs to be disabled, because users can use this names as variables
+const char *RenamesMap3To4::gdscript_properties_renames[][2] = {
+	//	// { "d", "distance" }, //WorldMarginShape2D - TODO, looks that polish letters ą ę are treaten as space, not as letter, so `będą` are renamed to `będistanceą`
+	//	// {"alt","alt_pressed"}, // This may broke a lot of comments and user variables
+	//	// {"command","command_pressed"},// This may broke a lot of comments and user variables
+	//	// {"control","ctrl_pressed"},// This may broke a lot of comments and user variables
+	//	// {"extends","size"}, // BoxShape3D, LightmapGI broke ReflectionProbe
+	//	// {"meta","meta_pressed"},// This may broke a lot of comments and user variables
+	//	// {"pause_mode","process_mode"}, // Node - Cyclic rename, look for others
+	//	// {"rotate","rotates"}, // PathFollow2D - probably function exists with same name
+	// 	// {"offset","progress"}, // PathFollow2D, PathFollow3D - Name is way too vague
+	//	// {"shift","shift_pressed"},// This may broke a lot of comments and user variables
+	//	{ "autowrap", "autowrap_mode" }, // Label
+	//	{ "cast_to", "target_position" }, // RayCast2D, RayCast3D
+	//	{ "device", "output_device"}, // AudioServer - Too vague, most likely breaks comments & variables
+	//	{ "doubleclick", "double_click" }, // InputEventMouseButton
+	//	{ "group", "button_group" }, // BaseButton
+	//	{ "process_mode", "process_callback" }, // AnimationTree, Camera2D
+	//	{ "scancode", "keycode" }, // InputEventKey
+	//	{ "toplevel", "top_level" }, // Node
+	//	{ "window_title", "title" }, // Window
+	//	{ "wrap_enabled", "wrap_mode" }, // TextEdit
+	//	{ "zfar", "far" }, // Camera3D
+	//	{ "znear", "near" }, // Camera3D
+	//	{ "filename", "scene_file_path" }, // Node
+	//	{ "pressed", "button_pressed" }, // BaseButton - Will also rename the signal, skipping for now
+	{ "as_normalmap", "as_normal_map" }, // NoiseTexture
+	{ "bbcode_text", "text" }, // RichTextLabel
+	{ "bg", "panel" }, // Theme
+	{ "bg_focus", "focus" }, // Theme
+	{ "capture_device", "input_device" }, // AudioServer
+	{ "caret_blink_speed", "caret_blink_interval" }, // TextEdit, LineEdit
+	{ "caret_moving_by_right_click", "caret_move_on_right_click" }, // TextEdit
+	{ "caret_position", "caret_column" }, // LineEdit
+	{ "check_vadjust", "check_v_offset" }, // Theme
+	{ "close_h_ofs", "close_h_offset" }, // Theme
+	{ "close_v_ofs", "close_v_offset" }, // Theme
+	{ "commentfocus", "comment_focus" }, // Theme
+	{ "contacts_reported", "max_contacts_reported" }, // RigidBody
+	{ "depth_bias_enable", "depth_bias_enabled" }, // RDPipelineRasterizationState
+	{ "drag_margin_bottom", "drag_bottom_margin" }, // Camera2D
+	{ "drag_margin_h_enabled", "drag_horizontal_enabled" }, // Camera2D
+	{ "drag_margin_left", "drag_left_margin" }, // Camera2D
+	{ "drag_margin_right", "drag_right_margin" }, // Camera2D
+	{ "drag_margin_top", "drag_top_margin" }, // Camera2D
+	{ "drag_margin_v_enabled", "drag_vertical_enabled" }, // Camera2D
+	{ "enabled_focus_mode", "focus_mode" }, // BaseButton - Removed
+	{ "extra_spacing_bottom", "spacing_bottom" }, // Font
+	{ "extra_spacing_top", "spacing_top" }, // Font
+	{ "focus_neighbour_bottom", "focus_neighbor_bottom" }, // Control
+	{ "focus_neighbour_left", "focus_neighbor_left" }, // Control
+	{ "focus_neighbour_right", "focus_neighbor_right" }, // Control
+	{ "focus_neighbour_top", "focus_neighbor_top" }, // Control
+	{ "follow_viewport_enable", "follow_viewport_enabled" }, // CanvasItem
+	{ "file_icon_modulate", "file_icon_color" }, // Theme
+	{ "files_disabled", "file_disabled_color" }, // Theme
+	{ "folder_icon_modulate", "folder_icon_color" }, // Theme
+	{ "global_rate_scale", "playback_speed_scale" }, // AudioServer
+	{ "gravity_distance_scale", "gravity_point_unit_distance" }, // Area(2D/3D)
+	{ "gravity_vec", "gravity_direction" }, // Area(2D/3D)
+	{ "hint_tooltip", "tooltip_text" }, // Control
+	{ "hseparation", "h_separation" }, // Theme
+	{ "icon_align", "icon_alignment" }, // Button
+	{ "iterations_per_second", "physics_ticks_per_second" }, // Engine
+	{ "invert_enable", "invert_enabled" }, // Polygon2D
+	{ "margin_bottom", "offset_bottom" }, // Control broke NinePatchRect, StyleBox
+	{ "margin_left", "offset_left" }, // Control broke NinePatchRect, StyleBox
+	{ "margin_right", "offset_right" }, // Control broke NinePatchRect, StyleBox
+	{ "margin_top", "offset_top" }, // Control broke NinePatchRect, StyleBox
+	{ "mid_height", "height" }, // CapsuleMesh
+	{ "neighbor_dist", "neighbor_distance" }, // NavigationAgent2D, NavigationAgent3D
+	{ "offset_h", "drag_horizontal_offset" }, // Camera2D
+	{ "offset_v", "drag_vertical_offset" }, // Camera2D
+	{ "off", "unchecked" }, // Theme
+	{ "off_disabled", "unchecked_disabled" }, // Theme
+	{ "ofs", "offset" }, // Theme
+	{ "on", "checked" }, // Theme
+	{ "on_disabled", "checked_disabled" }, // Theme
+	{ "oneshot", "one_shot" }, // AnimatedTexture
+	{ "out_of_range_mode", "max_polyphony" }, // AudioStreamPlayer3D
+	{ "pause_mode", "process_mode" }, // Node
+	{ "physical_scancode", "physical_keycode" }, // InputEventKey
+	{ "popup_exclusive", "exclusive" }, // Window
+	{ "proximity_fade_enable", "proximity_fade_enabled" }, // Material
+	{ "rect_position", "position" }, // Control
+	{ "rect_global_position", "global_position" }, // Control
+	{ "rect_size", "size" }, // Control
+	{ "rect_min_size", "custom_minimum_size" }, // Control
+	{ "rect_rotation", "rotation" }, // Control
+	{ "rect_scale", "scale" }, // Control
+	{ "rect_pivot_offset", "pivot_offset" }, // Control
+	{ "rect_clip_content", "clip_contents" }, // Control
+	{ "refuse_new_network_connections", "refuse_new_connections" }, // MultiplayerAPI
+	{ "region_filter_clip", "region_filter_clip_enabled" }, // Sprite2D
+	{ "reverb_bus_enable", "reverb_bus_enabled" }, // Area3D
+	{ "selectedframe", "selected_frame" }, // Theme
+	{ "size_override_stretch", "size_2d_override_stretch" }, // SubViewport
+	{ "slips_on_slope", "slide_on_slope" }, // SeparationRayShape2D
+	{ "smoothing_enabled", "follow_smoothing_enabled" }, // Camera2D
+	{ "smoothing_speed", "position_smoothing_speed" }, // Camera2D
+	{ "ss_reflections_depth_tolerance", "ssr_depth_tolerance" }, // Environment
+	{ "ss_reflections_enabled", "ssr_enabled" }, // Environment
+	{ "ss_reflections_fade_in", "ssr_fade_in" }, // Environment
+	{ "ss_reflections_fade_out", "ssr_fade_out" }, // Environment
+	{ "ss_reflections_max_steps", "ssr_max_steps" }, // Environment
+	{ "state_machine_selectedframe", "state_machine_selected_frame" }, // Theme
+	{ "syntax_highlighting", "syntax_highlighter" }, // TextEdit
+	{ "tab_align", "tab_alignment" }, // TabContainer
+	{ "table_hseparation", "table_h_separation" }, // Theme
+	{ "table_vseparation", "table_v_separation" }, // Theme
+	{ "translation", "position" }, // Node3D - broke GLTFNode
+	{ "unit_db", "volume_db" }, // AudioStreamPlayer3D
+	{ "unit_offset", "progress_ratio" }, // PathFollow2D, PathFollow3D
+	{ "vseparation", "v_separation" }, // Theme
+	{ "frames", "sprite_frames" }, // AnimatedSprite2D, AnimatedSprite3D
+
+	{ nullptr, nullptr },
+};
+
+// Some needs to be disabled, because users can use this names as variables
+const char *RenamesMap3To4::csharp_properties_renames[][2] = {
+	//	// { "D", "Distance" }, //WorldMarginShape2D - TODO, looks that polish letters ą ę are treaten as space, not as letter, so `będą` are renamed to `będistanceą`
+	//	// {"Alt","AltPressed"}, // This may broke a lot of comments and user variables
+	//	// {"Command","CommandPressed"},// This may broke a lot of comments and user variables
+	//	// {"Control","CtrlPressed"},// This may broke a lot of comments and user variables
+	//	// {"Extends","Size"}, // BoxShape3D, LightmapGI broke ReflectionProbe
+	//	// {"Meta","MetaPressed"},// This may broke a lot of comments and user variables
+	//	// {"PauseMode","ProcessMode"}, // Node - Cyclic rename, look for others
+	//	// {"Rotate","Rotates"}, // PathFollow2D - probably function exists with same name
+	// 	// {"Offset","Progress"}, // PathFollow2D, PathFollow3D - Name is way too vague
+	//	// {"Shift","ShiftPressed"},// This may broke a lot of comments and user variables
+	//	{ "Autowrap", "AutowrapMode" }, // Label
+	//	{ "CastTo", "TargetPosition" }, // RayCast2D, RayCast3D
+	//	{ "Doubleclick", "DoubleClick" }, // InputEventMouseButton
+	//	{ "Group", "ButtonGroup" }, // BaseButton
+	//  { "PercentVisible, "ShowPercentage}, // ProgressBar, conflicts with Label and RichTextLabel, but may be a worth it.
+	//	{ "ProcessMode", "ProcessCallback" }, // AnimationTree, Camera2D
+	//	{ "Scancode", "Keycode" }, // InputEventKey
+	//	{ "Toplevel", "TopLevel" }, // Node
+	//	{ "WindowTitle", "Title" }, // Window
+	//	{ "WrapEnabled", "WrapMode" }, // TextEdit
+	//	{ "Zfar", "Far" }, // Camera3D
+	//	{ "Znear", "Near" }, // Camera3D
+	//	{ "Pressed", "ButtonPressed" }, // BaseButton - Will also rename the signal, skipping for now
+	{ "AsNormalmap", "AsNormalMap" }, // NoiseTexture
+	{ "BbcodeText", "Text" }, // RichTextLabel
+	{ "CaretBlinkSpeed", "CaretBlinkInterval" }, // TextEdit, LineEdit
+	{ "CaretMovingByRightClick", "CaretMoveOnRightClick" }, // TextEdit
+	{ "CaretPosition", "CaretColumn" }, // LineEdit
+	{ "CheckVadjust", "CheckVAdjust" }, // Theme
+	{ "CloseHOfs", "CloseHOffset" }, // Theme
+	{ "CloseVOfs", "CloseVOffset" }, // Theme
+	{ "Commentfocus", "CommentFocus" }, // Theme
+	{ "DepthBiasEnable", "DepthBiasEnabled" }, // RDPipelineRasterizationState
+	{ "DragMarginBottom", "DragBottomMargin" }, // Camera2D
+	{ "DragMarginHEnabled", "DragHorizontalEnabled" }, // Camera2D
+	{ "DragMarginLeft", "DragLeftMargin" }, // Camera2D
+	{ "DragMarginRight", "DragRightMargin" }, // Camera2D
+	{ "DragMarginTop", "DragTopMargin" }, // Camera2D
+	{ "DragMarginVEnabled", "DragVerticalEnabled" }, // Camera2D
+	{ "EnabledFocusMode", "FocusMode" }, // BaseButton - Removed
+	{ "ExtraSpacingBottom", "SpacingBottom" }, // Font
+	{ "ExtraSpacingTop", "SpacingTop" }, // Font
+	{ "FocusNeighbourBottom", "FocusNeighborBottom" }, // Control
+	{ "FocusNeighbourLeft", "FocusNeighborLeft" }, // Control
+	{ "FocusNeighbourRight", "FocusNeighborRight" }, // Control
+	{ "FocusNeighbourTop", "FocusNeighborTop" }, // Control
+	{ "FollowViewportEnable", "FollowViewportEnabled" }, // CanvasItem
+	{ "GlobalRateScale", "PlaybackSpeedScale" }, // AudioServer
+	{ "GravityDistanceScale", "GravityPointDistanceScale" }, // Area2D
+	{ "GravityVec", "GravityDirection" }, // Area2D
+	{ "HintTooltip", "TooltipText" }, // Control
+	{ "Hseparation", "HSeparation" }, // Theme
+	{ "IconAlign", "IconAlignment" }, // Button
+	{ "IterationsPerSecond", "PhysicsTicksPerSecond" }, // Engine
+	{ "InvertEnable", "InvertEnabled" }, // Polygon2D
+	{ "MarginBottom", "OffsetBottom" }, // Control broke NinePatchRect, StyleBox
+	{ "MarginLeft", "OffsetLeft" }, // Control broke NinePatchRect, StyleBox
+	{ "MarginRight", "OffsetRight" }, // Control broke NinePatchRect, StyleBox
+	{ "MarginTop", "OffsetTop" }, // Control broke NinePatchRect, StyleBox
+	{ "MidHeight", "Height" }, // CapsuleMesh
+	{ "NeighborDist", "NeighborDistance" }, // NavigationAgent2D, NavigationAgent3D
+	{ "OffsetH", "DragHorizontalOffset" }, // Camera2D
+	{ "OffsetV", "DragVerticalOffset" }, // Camera2D
+	{ "Ofs", "Offset" }, // Theme
+	{ "Oneshot", "OneShot" }, // AnimatedTexture
+	{ "OutOfRangeMode", "MaxPolyphony" }, // AudioStreamPlayer3D
+	{ "PauseMode", "ProcessMode" }, // Node
+	{ "PhysicalScancode", "PhysicalKeycode" }, // InputEventKey
+	{ "PopupExclusive", "Exclusive" }, // Window
+	{ "ProximityFadeEnable", "ProximityFadeEnabled" }, // Material
+	{ "RectPosition", "Position" }, // Control
+	{ "RectGlobalPosition", "GlobalPosition" }, // Control
+	{ "RectSize", "Size" }, // Control
+	{ "RectMinSize", "CustomMinimumSize" }, // Control
+	{ "RectRotation", "Rotation" }, // Control
+	{ "RectScale", "Scale" }, // Control
+	{ "RectPivotOffset", "PivotOffset" }, // Control
+	{ "RectClipContent", "ClipContents" }, // Control
+	{ "RefuseNewNetworkConnections", "RefuseNewConnections" }, // MultiplayerAPI
+	{ "RegionFilterClip", "RegionFilterClipEnabled" }, // Sprite2D
+	{ "ReverbBusEnable", "ReverbBusEnabled" }, // Area3D
+	{ "Selectedframe", "SelectedFrame" }, // Theme
+	{ "SizeOverrideStretch", "Size2dOverrideStretch" }, // SubViewport
+	{ "SlipsOnSlope", "SlideOnSlope" }, // SeparationRayShape2D
+	{ "SmoothingEnabled", "FollowSmoothingEnabled" }, // Camera2D
+	{ "SmoothingSpeed", "FollowSmoothingSpeed" }, // Camera2D
+	{ "SsReflectionsDepthTolerance", "SsrDepthTolerance" }, // Environment
+	{ "SsReflectionsEnabled", "SsrEnabled" }, // Environment
+	{ "SsReflectionsFadeIn", "SsrFadeIn" }, // Environment
+	{ "SsReflectionsFadeOut", "SsrFadeOut" }, // Environment
+	{ "SsReflectionsMaxSteps", "SsrMaxSteps" }, // Environment
+	{ "StateMachineSelectedframe", "StateMachineSelectedFrame" }, // Theme
+	{ "SyntaxHighlighting", "SyntaxHighlighter" }, // TextEdit
+	{ "TabAlign", "TabAlignment" }, // TabContainer
+	{ "TableHseparation", "TableHSeparation" }, // Theme
+	{ "TableVseparation", "TableVSeparation" }, // Theme
+	{ "Translation", "Position" }, // Node3D - broke GLTFNode
+	{ "UnitDb", "VolumeDb" }, // AudioStreamPlayer3D
+	{ "UnitOffset", "ProgressRatio" }, // PathFollow2D, PathFollow3D
+	{ "Vseparation", "VSeparation" }, // Theme
+
+	{ nullptr, nullptr },
+};
+
+const char *RenamesMap3To4::gdscript_signals_renames[][2] = {
+	//  {"instantiate","instance"}, // FileSystemDock
+	// { "hide", "hidden" }, // CanvasItem - function with same name exists
+	// { "tween_all_completed","loop_finished"}, // Tween - TODO, not sure
+	// {"changed","settings_changed"}, // EditorSettings
+	{ "about_to_show", "about_to_popup" }, // Popup
+	{ "button_release", "button_released" }, // XRController3D
+	{ "cancelled", "canceled" }, // AcceptDialog
+	{ "item_double_clicked", "item_icon_double_clicked" }, // Tree
+	{ "network_peer_connected", "peer_connected" }, // MultiplayerAPI
+	{ "network_peer_disconnected", "peer_disconnected" }, // MultiplayerAPI
+	{ "network_peer_packet", "peer_packet" }, // MultiplayerAPI
+	{ "node_unselected", "node_deselected" }, // GraphEdit
+	{ "offset_changed", "position_offset_changed" }, // GraphNode
+	{ "settings_changed", "changed" }, // TileMap broke EditorSettings
+	{ "skeleton_updated", "pose_updated" }, //
+	{ "tab_close", "tab_closed" }, // TextEdit
+	{ "tab_hover", "tab_hovered" }, // TextEdit
+	{ "text_entered", "text_submitted" }, // LineEdit
+	{ "tween_completed", "finished" }, // Tween
+	{ "tween_step", "step_finished" }, // Tween
+
+	{ nullptr, nullptr },
+};
+
+const char *RenamesMap3To4::csharp_signals_renames[][2] = {
+	//  {"Instantiate","Instance"}, // FileSystemDock
+	// { "Hide", "Hidden" }, // CanvasItem - function with same name exists
+	// { "TweenAllCompleted","LoopFinished"}, // Tween - TODO, not sure
+	// {"Changed","SettingsChanged"}, // EditorSettings
+	{ "AboutToShow", "AboutToPopup" }, // Popup
+	{ "ButtonRelease", "ButtonReleased" }, // XRController3D
+	{ "NetworkPeerConnected", "PeerConnected" }, // MultiplayerAPI
+	{ "NetworkPeerDisconnected", "PeerDisconnected" }, // MultiplayerAPI
+	{ "NetworkPeerPacket", "PeerPacket" }, // MultiplayerAPI
+	{ "NodeUnselected", "NodeDeselected" }, // GraphEdit
+	{ "OffsetChanged", "PositionOffsetChanged" }, // GraphNode
+	{ "SettingsChanged", "Changed" }, // TileMap broke EditorSettings
+	{ "SkeletonUpdated", "PoseUpdated" }, //
+	{ "TabClose", "TabClosed" }, // TextEdit
+	{ "TabHover", "TabHovered" }, // TextEdit
+	{ "TextEntered", "TextSubmitted" }, // LineEdit
+	{ "TweenCompleted", "Finished" }, // Tween
+	{ "TweenStep", "StepFinished" }, // Tween
+
+	{ nullptr, nullptr },
+
+};
+
+const char *RenamesMap3To4::project_settings_renames[][2] = {
+	{ "audio/channel_disable_threshold_db", "audio/buses/channel_disable_threshold_db" },
+	{ "audio/channel_disable_time", "audio/buses/channel_disable_time" },
+	{ "audio/default_bus_layout", "audio/buses/default_bus_layout" },
+	{ "audio/driver", "audio/driver/driver" },
+	{ "audio/enable_audio_input", "audio/driver/enable_input" },
+	{ "audio/mix_rate", "audio/driver/mix_rate" },
+	{ "audio/output_latency", "audio/driver/output_latency" },
+	{ "audio/output_latency.web", "audio/driver/output_latency.web" },
+	{ "audio/video_delay_compensation_ms", "audio/video/video_delay_compensation_ms" },
+	{ "display/window/vsync/use_vsync", "display/window/vsync/vsync_mode" },
+	{ "editor/main_run_args", "editor/run/main_run_args" },
+	{ "gui/common/swap_ok_cancel", "gui/common/swap_cancel_ok" },
+	{ "network/limits/debugger_stdout/max_chars_per_second", "network/limits/debugger/max_chars_per_second" },
+	{ "network/limits/debugger_stdout/max_errors_per_second", "network/limits/debugger/max_errors_per_second" },
+	{ "network/limits/debugger_stdout/max_messages_per_frame", "network/limits/debugger/max_queued_messages" },
+	{ "network/limits/debugger_stdout/max_warnings_per_second", "network/limits/debugger/max_warnings_per_second" },
+	{ "network/ssl/certificates", "network/tls/certificate_bundle_override" },
+	{ "physics/2d/thread_model", "physics/2d/run_on_thread" }, // TODO not sure
+	{ "rendering/environment/default_clear_color", "rendering/environment/defaults/default_clear_color" },
+	{ "rendering/environment/default_environment", "rendering/environment/defaults/default_environment" },
+	{ "rendering/quality/depth_prepass/disable_for_vendors", "rendering/driver/depth_prepass/disable_for_vendors" },
+	{ "rendering/quality/depth_prepass/enable", "rendering/driver/depth_prepass/enable" },
+	{ "rendering/quality/shading/force_blinn_over_ggx", "rendering/shading/overrides/force_blinn_over_ggx" },
+	{ "rendering/quality/shading/force_blinn_over_ggx.mobile", "rendering/shading/overrides/force_blinn_over_ggx.mobile" },
+	{ "rendering/quality/shading/force_lambert_over_burley", "rendering/shading/overrides/force_lambert_over_burley" },
+	{ "rendering/quality/shading/force_lambert_over_burley.mobile", "rendering/shading/overrides/force_lambert_over_burley.mobile" },
+	{ "rendering/quality/shading/force_vertex_shading", "rendering/shading/overrides/force_vertex_shading" },
+	{ "rendering/quality/shading/force_vertex_shading.mobile", "rendering/shading/overrides/force_vertex_shading.mobile" },
+	{ "rendering/quality/shadow_atlas/quadrant_0_subdiv", "rendering/lights_and_shadows/shadow_atlas/quadrant_0_subdiv" },
+	{ "rendering/quality/shadow_atlas/quadrant_1_subdiv", "rendering/lights_and_shadows/shadow_atlas/quadrant_1_subdiv" },
+	{ "rendering/quality/shadow_atlas/quadrant_2_subdiv", "rendering/lights_and_shadows/shadow_atlas/quadrant_2_subdiv" },
+	{ "rendering/quality/shadow_atlas/quadrant_3_subdiv", "rendering/lights_and_shadows/shadow_atlas/quadrant_3_subdiv" },
+	{ "rendering/quality/shadow_atlas/size", "rendering/lights_and_shadows/shadow_atlas/size" },
+	{ "rendering/quality/shadow_atlas/size.mobile", "rendering/lights_and_shadows/shadow_atlas/size.mobile" },
+	{ "rendering/vram_compression/import_etc2", "rendering/textures/vram_compression/import_etc2_astc" },
+	{ "rendering/vram_compression/import_s3tc", "rendering/textures/vram_compression/import_s3tc_bptc" },
+	{ "window/size/width", "window/size/viewport_width" },
+	{ "window/size/height", "window/size/viewport_height" },
+	{ "window/size/test_width", "window/size/window_width_override" },
+	{ "window/size/test_height", "window/size/window_height_override" },
+
+	{ nullptr, nullptr },
+};
+
+const char *RenamesMap3To4::input_map_renames[][2] = {
+	{ ",\"alt\":", ",\"alt_pressed\":" },
+	{ ",\"shift\":", ",\"shift_pressed\":" },
+	{ ",\"control\":", ",\"ctrl_pressed\":" },
+	{ ",\"meta\":", ",\"meta_pressed\":" },
+	{ ",\"scancode\":", ",\"keycode\":" },
+	{ ",\"physical_scancode\":", ",\"physical_keycode\":" },
+	{ ",\"doubleclick\":", ",\"double_click\":" },
+
+	{ nullptr, nullptr },
+};
+
+const char *RenamesMap3To4::builtin_types_renames[][2] = {
+	{ "PoolByteArray", "PackedByteArray" },
+	{ "PoolColorArray", "PackedColorArray" },
+	{ "PoolIntArray", "PackedInt32Array" },
+	{ "PoolRealArray", "PackedFloat32Array" },
+	{ "PoolStringArray", "PackedStringArray" },
+	{ "PoolVector2Array", "PackedVector2Array" },
+	{ "PoolVector3Array", "PackedVector3Array" },
+	{ "Quat", "Quaternion" },
+	{ "Transform", "Transform3D" },
+
+	{ nullptr, nullptr },
+};
+
+const char *RenamesMap3To4::shaders_renames[][2] = {
+	{ "ALPHA_SCISSOR", "ALPHA_SCISSOR_THRESHOLD" },
+	{ "CAMERA_MATRIX", "INV_VIEW_MATRIX" },
+	{ "INV_CAMERA_MATRIX", "VIEW_MATRIX" },
+	{ "NORMALMAP", "NORMAL_MAP" },
+	{ "NORMALMAP_DEPTH", "NORMAL_MAP_DEPTH" },
+	{ "TRANSMISSION", "BACKLIGHT" },
+	{ "WORLD_MATRIX", "MODEL_MATRIX" },
+	{ "depth_draw_alpha_prepass", "depth_draw_opaque" },
+	{ "hint_albedo", "source_color" },
+	{ "hint_aniso", "hint_anisotropy" },
+	{ "hint_black", "hint_default_black" },
+	{ "hint_black_albedo", "hint_default_black" },
+	{ "hint_color", "source_color" },
+	{ "hint_white", "hint_default_white" },
+	{ nullptr, nullptr },
+};
+
+const char *RenamesMap3To4::class_renames[][2] = {
+	// { "BulletPhysicsDirectBodyState", "BulletPhysicsDirectBodyState3D" }, // Class is not visible in ClassDB
+	// { "BulletPhysicsServer", "BulletPhysicsServer3D" }, // Class is not visible in ClassDB
+	// { "GDScriptFunctionState", "Node3D" }, // TODO - not sure to which should be changed
+	// { "GDScriptNativeClass", "Node3D" }, // TODO - not sure to which should be changed
+	// { "InputDefault",""}, // TODO ?
+	// { "Physics2DDirectBodyStateSW", "GodotPhysicsDirectBodyState2D" }, // Class is not visible in ClassDB
+	// { "Physics2DShapeQueryResult", "PhysicsShapeQueryResult2D" }, // Class is not visible in ClassDB
+	// { "PhysicsShapeQueryResult", "PhysicsShapeQueryResult3D" }, // Class is not visible in ClassDB
+	// { "NativeScript","GDExtension"}, ??
+	{ "ARVRAnchor", "XRAnchor3D" },
+	{ "ARVRCamera", "XRCamera3D" },
+	{ "ARVRController", "XRController3D" },
+	{ "ARVRInterface", "XRInterface" },
+	{ "ARVRInterfaceGDNative", "Node3D" },
+	{ "ARVROrigin", "XROrigin3D" },
+	{ "ARVRPositionalTracker", "XRPositionalTracker" },
+	{ "ARVRServer", "XRServer" },
+	{ "AStar", "AStar3D" },
+	{ "AnimatedSprite", "AnimatedSprite2D" },
+	{ "AnimationTreePlayer", "AnimationTree" },
+	{ "Area", "Area3D" }, // Be careful, this will be used everywhere
+	{ "AudioStreamOGGVorbis", "AudioStreamOggVorbis" },
+	{ "AudioStreamRandomPitch", "AudioStreamRandomizer" },
+	{ "AudioStreamSample", "AudioStreamWAV" },
+	{ "BakedLightmap", "LightmapGI" },
+	{ "BakedLightmapData", "LightmapGIData" },
+	{ "BitmapFont", "FontFile" },
+	{ "BoneAttachment", "BoneAttachment3D" },
+	{ "BoxShape", "BoxShape3D" },
+	{ "CPUParticles", "CPUParticles3D" },
+	{ "CSGBox", "CSGBox3D" },
+	{ "CSGCombiner", "CSGCombiner3D" },
+	{ "CSGCylinder", "CSGCylinder3D" },
+	{ "CSGMesh", "CSGMesh3D" },
+	{ "CSGPolygon", "CSGPolygon3D" },
+	{ "CSGPrimitive", "CSGPrimitive3D" },
+	{ "CSGShape", "CSGShape3D" },
+	{ "CSGSphere", "CSGSphere3D" },
+	{ "CSGTorus", "CSGTorus3D" },
+	{ "Camera", "Camera3D" }, // Be careful, this will be used everywhere
+	{ "CapsuleShape", "CapsuleShape3D" },
+	{ "ClippedCamera", "Camera3D" },
+	{ "CollisionObject", "CollisionObject3D" },
+	{ "CollisionPolygon", "CollisionPolygon3D" },
+	{ "CollisionShape", "CollisionShape3D" },
+	{ "ConcavePolygonShape", "ConcavePolygonShape3D" },
+	{ "ConeTwistJoint", "ConeTwistJoint3D" },
+	{ "ConvexPolygonShape", "ConvexPolygonShape3D" },
+	{ "CubeMap", "Cubemap" },
+	{ "CubeMesh", "BoxMesh" },
+	{ "CylinderShape", "CylinderShape3D" },
+	{ "DirectionalLight", "DirectionalLight3D" },
+	{ "DynamicFont", "FontFile" },
+	{ "DynamicFontData", "FontFile" },
+	{ "EditorNavigationMeshGenerator", "NavigationMeshGenerator" },
+	{ "EditorSceneImporter", "EditorSceneFormatImporter" },
+	{ "EditorSceneImporterFBX", "EditorSceneFormatImporterFBX" },
+	{ "EditorSceneImporterGLTF", "EditorSceneFormatImporterGLTF" },
+	{ "EditorSpatialGizmo", "EditorNode3DGizmo" },
+	{ "EditorSpatialGizmoPlugin", "EditorNode3DGizmoPlugin" },
+	{ "ExternalTexture", "ImageTexture" },
+	{ "FuncRef", "Callable" },
+	{ "GIProbe", "VoxelGI" },
+	{ "GIProbeData", "VoxelGIData" },
+	{ "Generic6DOFJoint", "Generic6DOFJoint3D" },
+	{ "Geometry", "Geometry2D" }, // Geometry class is split between Geometry2D and Geometry3D so we need to choose one
+	{ "GeometryInstance", "GeometryInstance3D" },
+	{ "GradientTexture", "GradientTexture2D" },
+	{ "HeightMapShape", "HeightMapShape3D" },
+	{ "HingeJoint", "HingeJoint3D" },
+	{ "IP_Unix", "IPUnix" },
+	{ "ImmediateGeometry", "ImmediateMesh" },
+	{ "ImmediateGeometry3D", "ImmediateMesh" },
+	{ "InterpolatedCamera", "Camera3D" },
+	{ "InterpolatedCamera3D", "Camera3D" },
+	{ "JSONParseResult", "JSON" },
+	{ "Joint", "Joint3D" },
+	{ "KinematicBody", "CharacterBody3D" },
+	{ "KinematicBody2D", "CharacterBody2D" },
+	{ "KinematicCollision", "KinematicCollision3D" },
+	{ "LargeTexture", "ImageTexture" },
+	{ "Light", "Light3D" },
+	{ "Light2D", "PointLight2D" },
+	{ "LineShape2D", "WorldBoundaryShape2D" },
+	{ "Listener", "AudioListener3D" },
+	{ "Listener2D", "AudioListener2D" },
+	{ "MeshInstance", "MeshInstance3D" },
+	{ "MultiMeshInstance", "MultiMeshInstance3D" },
+	{ "MultiplayerPeerGDNative", "MultiplayerPeerExtension" },
+	{ "Navigation", "Node3D" },
+	{ "Navigation2D", "Node2D" },
+	{ "Navigation2DServer", "NavigationServer2D" },
+	{ "Navigation3D", "Node3D" },
+	{ "NavigationAgent", "NavigationAgent3D" },
+	{ "NavigationMeshInstance", "NavigationRegion3D" },
+	{ "NavigationObstacle", "NavigationObstacle3D" },
+	{ "NavigationPolygonInstance", "NavigationRegion2D" },
+	{ "NavigationRegion", "NavigationRegion3D" },
+	{ "NavigationServer", "NavigationServer3D" },
+	{ "NetworkedMultiplayerENet", "ENetMultiplayerPeer" },
+	{ "NetworkedMultiplayerPeer", "MultiplayerPeer" },
+	{ "Occluder", "OccluderInstance3D" },
+	{ "OmniLight", "OmniLight3D" },
+	{ "PHashTranslation", "OptimizedTranslation" },
+	{ "PacketPeerGDNative", "PacketPeerExtension" },
+	{ "PanoramaSky", "Sky" },
+	{ "Particles", "GPUParticles3D" }, // Be careful, this will be used everywhere
+	{ "Particles2D", "GPUParticles2D" },
+	{ "ParticlesMaterial", "ParticleProcessMaterial" },
+	{ "Path", "Path3D" }, // Be careful, this will be used everywhere
+	{ "PathFollow", "PathFollow3D" },
+	{ "PhysicalBone", "PhysicalBone3D" },
+	{ "Physics2DDirectBodyState", "PhysicsDirectBodyState2D" },
+	{ "Physics2DDirectSpaceState", "PhysicsDirectSpaceState2D" },
+	{ "Physics2DServer", "PhysicsServer2D" },
+	{ "Physics2DServerSW", "GodotPhysicsServer2D" },
+	{ "Physics2DShapeQueryParameters", "PhysicsShapeQueryParameters2D" },
+	{ "Physics2DTestMotionResult", "PhysicsTestMotionResult2D" },
+	{ "PhysicsBody", "PhysicsBody3D" },
+	{ "PhysicsDirectBodyState", "PhysicsDirectBodyState3D" },
+	{ "PhysicsDirectSpaceState", "PhysicsDirectSpaceState3D" },
+	{ "PhysicsServer", "PhysicsServer3D" },
+	{ "PhysicsShapeQueryParameters", "PhysicsShapeQueryParameters3D" },
+	{ "PhysicsTestMotionResult", "PhysicsTestMotionResult3D" },
+	{ "PinJoint", "PinJoint3D" },
+	{ "PlaneShape", "WorldBoundaryShape3D" },
+	{ "PopupDialog", "Popup" },
+	{ "Position2D", "Marker2D" },
+	{ "Position3D", "Marker3D" },
+	{ "ProceduralSky", "Sky" },
+	{ "RayCast", "RayCast3D" },
+	{ "RayShape", "SeparationRayShape3D" },
+	{ "RayShape2D", "SeparationRayShape2D" },
+	{ "Reference", "RefCounted" }, // Be careful, this will be used everywhere
+	{ "RemoteTransform", "RemoteTransform3D" },
+	{ "ResourceInteractiveLoader", "ResourceLoader" },
+	{ "RigidBody", "RigidBody3D" },
+	{ "SceneTreeTween", "Tween" },
+	{ "Shape", "Shape3D" }, // Be careful, this will be used everywhere
+	{ "ShortCut", "Shortcut" },
+	{ "Skeleton", "Skeleton3D" },
+	{ "SkeletonIK", "SkeletonIK3D" },
+	{ "SliderJoint", "SliderJoint3D" },
+	{ "SoftBody", "SoftBody3D" },
+	{ "Spatial", "Node3D" },
+	{ "SpatialGizmo", "Node3DGizmo" },
+	{ "SpatialMaterial", "StandardMaterial3D" },
+	{ "SphereShape", "SphereShape3D" },
+	{ "SpotLight", "SpotLight3D" },
+	{ "SpringArm", "SpringArm3D" },
+	{ "Sprite", "Sprite2D" },
+	{ "StaticBody", "StaticBody3D" },
+	{ "StreamCubemap", "CompressedCubemap" },
+	{ "StreamCubemapArray", "CompressedCubemapArray" },
+	{ "StreamPeerGDNative", "StreamPeerExtension" },
+	{ "StreamPeerSSL", "StreamPeerTLS" },
+	{ "StreamTexture", "CompressedTexture2D" },
+	{ "StreamTexture2D", "CompressedTexture2D" },
+	{ "StreamTexture2DArray", "CompressedTexture2DArray" },
+	{ "StreamTextureLayered", "CompressedTextureLayered" },
+	{ "TCP_Server", "TCPServer" },
+	{ "Tabs", "TabBar" }, // Be careful, this will be used everywhere
+	{ "TextFile", "Node3D" },
+	{ "Texture", "Texture2D" }, // May broke TextureRect
+	{ "TextureArray", "Texture2DArray" },
+	{ "TextureProgress", "TextureProgressBar" },
+	{ "ToolButton", "Button" },
+	{ "VehicleBody", "VehicleBody3D" },
+	{ "VehicleWheel", "VehicleWheel3D" },
+	{ "VideoPlayer", "VideoStreamPlayer" },
+	{ "Viewport", "SubViewport" },
+	{ "ViewportContainer", "SubViewportContainer" },
+	{ "VisibilityEnabler", "VisibleOnScreenEnabler3D" },
+	{ "VisibilityEnabler2D", "VisibleOnScreenEnabler2D" },
+	{ "VisibilityNotifier", "VisibleOnScreenNotifier3D" },
+	{ "VisibilityNotifier2D", "VisibleOnScreenNotifier2D" },
+	{ "VisibilityNotifier3D", "VisibleOnScreenNotifier3D" },
+	{ "VisualInstance", "VisualInstance3D" },
+	{ "VisualServer", "RenderingServer" },
+	{ "VisualShaderNodeCubeMap", "VisualShaderNodeCubemap" },
+	{ "VisualShaderNodeScalarClamp", "VisualShaderNodeClamp" },
+	{ "VisualShaderNodeScalarConstant", "VisualShaderNodeFloatConstant" },
+	{ "VisualShaderNodeScalarFunc", "VisualShaderNodeFloatFunc" },
+	{ "VisualShaderNodeScalarInterp", "VisualShaderNodeMix" },
+	{ "VisualShaderNodeScalarOp", "VisualShaderNodeFloatOp" },
+	{ "VisualShaderNodeScalarSmoothStep", "VisualShaderNodeSmoothStep" },
+	{ "VisualShaderNodeScalarSwitch", "VisualShaderNodeSwitch" },
+	{ "VisualShaderNodeScalarTransformMult", "VisualShaderNodeTransformOp" },
+	{ "VisualShaderNodeTransformMult", "VisualShaderNode" },
+	{ "VisualShaderNodeVectorClamp", "VisualShaderNodeClamp" },
+	{ "VisualShaderNodeVectorInterp", "VisualShaderNodeMix" },
+	{ "VisualShaderNodeVectorScalarMix", "VisualShaderNodeMix" },
+	{ "VisualShaderNodeVectorScalarSmoothStep", "VisualShaderNodeSmoothStep" },
+	{ "VisualShaderNodeVectorScalarStep", "VisualShaderNodeStep" },
+	{ "VisualShaderNodeVectorSmoothStep", "VisualShaderNodeSmoothStep" },
+	{ "VisualShaderNodeBooleanUniform", "VisualShaderNodeBooleanParameter" },
+	{ "VisualShaderNodeColorUniform", "VisualShaderNodeColorParameter" },
+	{ "VisualShaderNodeScalarUniform", "VisualShaderNodeFloatParameter" },
+	{ "VisualShaderNodeCubemapUniform", "VisualShaderNodeCubemapParameter" },
+	{ "VisualShaderNodeTextureUniform", "VisualShaderNodeTexture2DParameter" },
+	{ "VisualShaderNodeTextureUniformTriplanar", "VisualShaderNodeTextureParameterTriplanar" },
+	{ "VisualShaderNodeTransformUniform", "VisualShaderNodeTransformParameter" },
+	{ "VisualShaderNodeVec3Uniform", "VisualShaderNodeVec3Parameter" },
+	{ "VisualShaderNodeUniform", "VisualShaderNodeParameter" },
+	{ "VisualShaderNodeUniformRef", "VisualShaderNodeParameterRef" },
+	{ "WebRTCDataChannelGDNative", "WebRTCDataChannelExtension" },
+	{ "WebRTCMultiplayer", "WebRTCMultiplayerPeer" },
+	{ "WebRTCPeerConnectionGDNative", "WebRTCPeerConnectionExtension" },
+	{ "WindowDialog", "Window" },
+	{ "World", "World3D" }, // Be careful, this will be used everywhere
+	{ "XRAnchor", "XRAnchor3D" },
+	{ "XRController", "XRController3D" },
+	{ "XROrigin", "XROrigin3D" },
+	{ "YSort", "Node2D" },
+
+	{ "CullInstance", "Node3D" }, // Probably this type needs to be added to Godot 4.0, since it is for now only available only in Godot 3.x
+	{ "RoomGroup", "Node3D" }, // Probably this type needs to be added to Godot 4.0, since it is for now only available only in Godot 3.x
+	{ "Room", "Node3D" }, // Probably this type needs to be added to Godot 4.0, since it is for now only available only in Godot 3.x
+	{ "RoomManager", "Node3D" }, // Probably this type needs to be added to Godot 4.0, since it is for now only available only in Godot 3.x
+	{ "Portal", "Node3D" }, // Probably this type needs to be added to Godot 4.0, since it is for now only available only in Godot 3.x
+
+	{ nullptr, nullptr },
+};
+
+const char *RenamesMap3To4::color_renames[][2] = {
+	{ "aliceblue", "ALICE_BLUE" },
+	{ "antiquewhite", "ANTIQUE_WHITE" },
+	{ "aqua", "AQUA" },
+	{ "aquamarine", "AQUAMARINE" },
+	{ "azure", "AZURE" },
+	{ "beige", "BEIGE" },
+	{ "bisque", "BISQUE" },
+	{ "black", "BLACK" },
+	{ "blanchedalmond", "BLANCHED_ALMOND" },
+	{ "blue", "BLUE" },
+	{ "blueviolet", "BLUE_VIOLET" },
+	{ "brown", "BROWN" },
+	{ "burlywood", "BURLYWOOD" },
+	{ "cadetblue", "CADET_BLUE" },
+	{ "chartreuse", "CHARTREUSE" },
+	{ "chocolate", "CHOCOLATE" },
+	{ "coral", "CORAL" },
+	{ "cornflowerblue", "CORNFLOWER_BLUE" },
+	{ "cornsilk", "CORNSILK" },
+	{ "crimson", "CRIMSON" },
+	{ "cyan", "CYAN" },
+	{ "darkblue", "DARK_BLUE" },
+	{ "darkcyan", "DARK_CYAN" },
+	{ "darkgoldenrod", "DARK_GOLDENROD" },
+	{ "darkgray", "DARK_GRAY" },
+	{ "darkgreen", "DARK_GREEN" },
+	{ "darkkhaki", "DARK_KHAKI" },
+	{ "darkmagenta", "DARK_MAGENTA" },
+	{ "darkolivegreen", "DARK_OLIVE_GREEN" },
+	{ "darkorange", "DARK_ORANGE" },
+	{ "darkorchid", "DARK_ORCHID" },
+	{ "darkred", "DARK_RED" },
+	{ "darksalmon", "DARK_SALMON" },
+	{ "darkseagreen", "DARK_SEA_GREEN" },
+	{ "darkslateblue", "DARK_SLATE_BLUE" },
+	{ "darkslategray", "DARK_SLATE_GRAY" },
+	{ "darkturquoise", "DARK_TURQUOISE" },
+	{ "darkviolet", "DARK_VIOLET" },
+	{ "deeppink", "DEEP_PINK" },
+	{ "deepskyblue", "DEEP_SKY_BLUE" },
+	{ "dimgray", "DIM_GRAY" },
+	{ "dodgerblue", "DODGER_BLUE" },
+	{ "firebrick", "FIREBRICK" },
+	{ "floralwhite", "FLORAL_WHITE" },
+	{ "forestgreen", "FOREST_GREEN" },
+	{ "fuchsia", "FUCHSIA" },
+	{ "gainsboro", "GAINSBORO" },
+	{ "ghostwhite", "GHOST_WHITE" },
+	{ "gold", "GOLD" },
+	{ "goldenrod", "GOLDENROD" },
+	{ "gray", "GRAY" },
+	{ "green", "GREEN" },
+	{ "greenyellow", "GREEN_YELLOW" },
+	{ "honeydew", "HONEYDEW" },
+	{ "hotpink", "HOT_PINK" },
+	{ "indianred", "INDIAN_RED" },
+	{ "indigo", "INDIGO" },
+	{ "ivory", "IVORY" },
+	{ "khaki", "KHAKI" },
+	{ "lavender", "LAVENDER" },
+	{ "lavenderblush", "LAVENDER_BLUSH" },
+	{ "lawngreen", "LAWN_GREEN" },
+	{ "lemonchiffon", "LEMON_CHIFFON" },
+	{ "lightblue", "LIGHT_BLUE" },
+	{ "lightcoral", "LIGHT_CORAL" },
+	{ "lightcyan", "LIGHT_CYAN" },
+	{ "lightgoldenrod", "LIGHT_GOLDENROD" },
+	{ "lightgray", "LIGHT_GRAY" },
+	{ "lightgreen", "LIGHT_GREEN" },
+	{ "lightpink", "LIGHT_PINK" },
+	{ "lightsalmon", "LIGHT_SALMON" },
+	{ "lightseagreen", "LIGHT_SEA_GREEN" },
+	{ "lightskyblue", "LIGHT_SKY_BLUE" },
+	{ "lightslategray", "LIGHT_SLATE_GRAY" },
+	{ "lightsteelblue", "LIGHT_STEEL_BLUE" },
+	{ "lightyellow", "LIGHT_YELLOW" },
+	{ "lime", "LIME" },
+	{ "limegreen", "LIME_GREEN" },
+	{ "linen", "LINEN" },
+	{ "magenta", "MAGENTA" },
+	{ "maroon", "MAROON" },
+	{ "mediumaquamarine", "MEDIUM_AQUAMARINE" },
+	{ "mediumblue", "MEDIUM_BLUE" },
+	{ "mediumorchid", "MEDIUM_ORCHID" },
+	{ "mediumpurple", "MEDIUM_PURPLE" },
+	{ "mediumseagreen", "MEDIUM_SEA_GREEN" },
+	{ "mediumslateblue", "MEDIUM_SLATE_BLUE" },
+	{ "mediumspringgreen", "MEDIUM_SPRING_GREEN" },
+	{ "mediumturquoise", "MEDIUM_TURQUOISE" },
+	{ "mediumvioletred", "MEDIUM_VIOLET_RED" },
+	{ "midnightblue", "MIDNIGHT_BLUE" },
+	{ "mintcream", "MINT_CREAM" },
+	{ "mistyrose", "MISTY_ROSE" },
+	{ "moccasin", "MOCCASIN" },
+	{ "navajowhite", "NAVAJO_WHITE" },
+	{ "navyblue", "NAVY_BLUE" },
+	{ "oldlace", "OLD_LACE" },
+	{ "olive", "OLIVE" },
+	{ "olivedrab", "OLIVE_DRAB" },
+	{ "orange", "ORANGE" },
+	{ "orangered", "ORANGE_RED" },
+	{ "orchid", "ORCHID" },
+	{ "palegoldenrod", "PALE_GOLDENROD" },
+	{ "palegreen", "PALE_GREEN" },
+	{ "paleturquoise", "PALE_TURQUOISE" },
+	{ "palevioletred", "PALE_VIOLET_RED" },
+	{ "papayawhip", "PAPAYA_WHIP" },
+	{ "peachpuff", "PEACH_PUFF" },
+	{ "peru", "PERU" },
+	{ "pink", "PINK" },
+	{ "plum", "PLUM" },
+	{ "powderblue", "POWDER_BLUE" },
+	{ "purple", "PURPLE" },
+	{ "rebeccapurple", "REBECCA_PURPLE" },
+	{ "red", "RED" },
+	{ "rosybrown", "ROSY_BROWN" },
+	{ "royalblue", "ROYAL_BLUE" },
+	{ "saddlebrown", "SADDLE_BROWN" },
+	{ "salmon", "SALMON" },
+	{ "sandybrown", "SANDY_BROWN" },
+	{ "seagreen", "SEA_GREEN" },
+	{ "seashell", "SEASHELL" },
+	{ "sienna", "SIENNA" },
+	{ "silver", "SILVER" },
+	{ "skyblue", "SKY_BLUE" },
+	{ "slateblue", "SLATE_BLUE" },
+	{ "slategray", "SLATE_GRAY" },
+	{ "snow", "SNOW" },
+	{ "springgreen", "SPRING_GREEN" },
+	{ "steelblue", "STEEL_BLUE" },
+	{ "tan", "TAN" },
+	{ "teal", "TEAL" },
+	{ "thistle", "THISTLE" },
+	{ "tomato", "TOMATO" },
+	{ "transparent", "TRANSPARENT" },
+	{ "turquoise", "TURQUOISE" },
+	{ "violet", "VIOLET" },
+	{ "webgray", "WEB_GRAY" },
+	{ "webgreen", "WEB_GREEN" },
+	{ "webmaroon", "WEB_MAROON" },
+	{ "webpurple", "WEB_PURPLE" },
+	{ "wheat", "WHEAT" },
+	{ "white", "WHITE" },
+	{ "whitesmoke", "WHITE_SMOKE" },
+	{ "yellow", "YELLOW" },
+	{ "yellowgreen", "YELLOW_GREEN" },
+
+	{ nullptr, nullptr },
+};
+
+#endif // DISABLE_DEPRECATED

--- a/editor/renames_map_3_to_4.h
+++ b/editor/renames_map_3_to_4.h
@@ -1,0 +1,54 @@
+/**************************************************************************/
+/*  renames_map_3_to_4.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef RENAMES_MAP_3_TO_4_H
+#define RENAMES_MAP_3_TO_4_H
+
+#ifndef DISABLE_DEPRECATED
+
+struct RenamesMap3To4 {
+	static const char *enum_renames[][2];
+	static const char *gdscript_function_renames[][2];
+	static const char *csharp_function_renames[][2];
+	static const char *gdscript_properties_renames[][2];
+	static const char *csharp_properties_renames[][2];
+	static const char *gdscript_signals_renames[][2];
+	static const char *csharp_signals_renames[][2];
+	static const char *project_settings_renames[][2];
+	static const char *input_map_renames[][2];
+	static const char *builtin_types_renames[][2];
+	static const char *shaders_renames[][2];
+	static const char *class_renames[][2];
+	static const char *color_renames[][2];
+};
+
+#endif // DISABLE_DEPRECATED
+
+#endif // RENAMES_MAP_3_TO_4_H

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -93,13 +93,17 @@
 #include "editor/editor_settings.h"
 #include "editor/editor_translation.h"
 #include "editor/progress_dialog.h"
-#include "editor/project_converter_3_to_4.h"
 #include "editor/project_manager.h"
 #include "editor/register_editor_types.h"
+
 #ifndef NO_EDITOR_SPLASH
 #include "main/splash_editor.gen.h"
 #endif
-#endif
+
+#ifndef DISABLE_DEPRECATED
+#include "editor/project_converter_3_to_4.h"
+#endif // DISABLE_DEPRECATED
+#endif // TOOLS_ENABLED
 
 #include "modules/modules_enabled.gen.h" // For mono.
 
@@ -163,8 +167,10 @@ static OS::ProcessID editor_pid = 0;
 static bool found_project = false;
 static bool auto_build_solutions = false;
 static String debug_server_uri;
+#ifndef DISABLE_DEPRECATED
 static int converter_max_kb_file = 4 * 1024; // 4MB
 static int converter_max_line_length = 100000;
+#endif // DISABLE_DEPRECATED
 
 HashMap<Main::CLIScope, Vector<String>> forwardable_cli_arguments;
 #endif
@@ -423,10 +429,12 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("                                    The target directory must exist.\n");
 	OS::get_singleton()->print("  --export-debug <preset> <path>    Export the project in debug mode using the given preset and output path. See --export-release description for other considerations.\n");
 	OS::get_singleton()->print("  --export-pack <preset> <path>     Export the project data only using the given preset and output path. The <path> extension determines whether it will be in PCK or ZIP format.\n");
+#ifndef DISABLE_DEPRECATED
 	OS::get_singleton()->print("  --convert-3to4 [<max_file_kb>] [<max_line_size>]\n");
 	OS::get_singleton()->print("                                    Converts project from Godot 3.x to Godot 4.x.\n");
 	OS::get_singleton()->print("  --validate-conversion-3to4 [<max_file_kb>] [<max_line_size>]\n");
 	OS::get_singleton()->print("                                    Shows what elements will be renamed when converting project from Godot 3.x to Godot 4.x.\n");
+#endif // DISABLE_DEPRECATED
 	OS::get_singleton()->print("  --doctool [<path>]                Dump the engine API reference to the given <path> (defaults to current dir) in XML format, merging if existing files are found.\n");
 	OS::get_singleton()->print("  --no-docbase                      Disallow dumping the base types (used with --doctool).\n");
 	OS::get_singleton()->print("  --build-solutions                 Build the scripting solutions (e.g. for C# projects). Implies --editor and requires a valid project to edit.\n");
@@ -1108,6 +1116,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			editor = true;
 			cmdline_tool = true;
 			main_args.push_back(I->get());
+#ifndef DISABLE_DEPRECATED
 		} else if (I->get() == "--convert-3to4") {
 			// Actually handling is done in start().
 			cmdline_tool = true;
@@ -1138,6 +1147,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 					}
 				}
 			}
+#endif // DISABLE_DEPRECATED
 		} else if (I->get() == "--doctool") {
 			// Actually handling is done in start().
 			cmdline_tool = true;
@@ -1147,7 +1157,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			audio_driver = NULL_AUDIO_DRIVER;
 			display_driver = NULL_DISPLAY_DRIVER;
 			main_args.push_back(I->get());
-#endif
+#endif // TOOLS_ENABLED
 		} else if (I->get() == "--path") { // set path of project to start or edit
 
 			if (I->next()) {
@@ -2370,7 +2380,7 @@ bool Main::start() {
 	bool converting_project = false;
 	bool validating_converting_project = false;
 #endif // DISABLE_DEPRECATED
-#endif
+#endif // TOOLS_ENABLED
 
 	main_timer_sync.init(OS::get_singleton()->get_ticks_usec());
 	List<String> args = OS::get_singleton()->get_cmdline_args();
@@ -2395,7 +2405,7 @@ bool Main::start() {
 			editor = true;
 		} else if (args[i] == "-p" || args[i] == "--project-manager") {
 			project_manager = true;
-#endif
+#endif // TOOLS_ENABLED
 		} else if (args[i].length() && args[i][0] != '-' && positional_arg.is_empty()) {
 			positional_arg = args[i];
 
@@ -2553,18 +2563,22 @@ bool Main::start() {
 
 #ifndef DISABLE_DEPRECATED
 	if (converting_project) {
-		int exit_code = ProjectConverter3To4(converter_max_kb_file, converter_max_line_length).convert();
-		OS::get_singleton()->set_exit_code(exit_code);
+		int ret = ProjectConverter3To4(converter_max_kb_file, converter_max_line_length).convert();
+		if (ret) {
+			OS::get_singleton()->set_exit_code(EXIT_SUCCESS);
+		}
 		return false;
 	}
 	if (validating_converting_project) {
-		int exit_code = ProjectConverter3To4(converter_max_kb_file, converter_max_line_length).validate_conversion();
-		OS::get_singleton()->set_exit_code(exit_code);
+		bool ret = ProjectConverter3To4(converter_max_kb_file, converter_max_line_length).validate_conversion();
+		if (ret) {
+			OS::get_singleton()->set_exit_code(EXIT_SUCCESS);
+		}
 		return false;
 	}
 #endif // DISABLE_DEPRECATED
 
-#endif
+#endif // TOOLS_ENABLED
 
 	if (script.is_empty() && game_path.is_empty() && String(GLOBAL_GET("application/run/main_scene")) != "") {
 		game_path = GLOBAL_GET("application/run/main_scene");

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -37,10 +37,6 @@
 #include "gdscript_cache.h"
 #include "gdscript_parser.h"
 
-#ifdef TOOLS_ENABLED
-#include "editor/project_converter_3_to_4.h"
-#endif
-
 class GDScriptAnalyzer {
 	GDScriptParser *parser = nullptr;
 	HashMap<String, Ref<GDScriptParserRef>> depended_parsers;
@@ -136,13 +132,6 @@ class GDScriptAnalyzer {
 #ifdef DEBUG_ENABLED
 	bool is_shadowing(GDScriptParser::IdentifierNode *p_local, const String &p_context);
 #endif
-
-#ifdef TOOLS_ENABLED
-#ifndef DISABLE_DEPRECATED
-	const char *get_rename_from_map(const char *map[][2], String key);
-	const char *check_for_renamed_identifier(String identifier, GDScriptParser::Node::Type type);
-#endif // DISABLE_DEPRECATED
-#endif // TOOLS_ENABLED
 
 public:
 	Error resolve_inheritance();


### PR DESCRIPTION
This allows properly limiting what features depend on the RegEx module
(doing the actual conversion) and what features only require the renames
data (GDScript suggestions).

Also better excludes the conversion command line options when actually
disabling deprecated code.

Fixes #73029.
