### PR TITLE
Fix TileMap patterns creation

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -1277,7 +1277,7 @@ void TileMapEditorTilesPlugin::_stop_dragging() {
 					tile_map->set_cell(tile_map_layer, kv.key, kv.value.source_id, kv.value.get_atlas_coords(), kv.value.alternative_tile);
 				}
 
-				if (EditorNode::get_singleton()->is_resource_read_only(tile_set)) {
+				if (!EditorNode::get_singleton()->is_resource_read_only(tile_set)) {
 					// Creating a pattern in the pattern list.
 					select_last_pattern = true;
 					int new_pattern_index = tile_set->get_patterns_count();

--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -117,7 +117,7 @@ void TilesEditorPlugin::_thread() {
 				tile_map->set_position(-(scale * encompassing_rect.get_center()) + thumbnail_size2 / 2);
 
 				// Add the viewport at the last moment to avoid rendering too early.
-				EditorNode::get_singleton()->add_child(viewport);
+				EditorNode::get_singleton()->call_deferred("add_child", viewport);
 
 				RS::get_singleton()->connect(SNAME("frame_pre_draw"), callable_mp(const_cast<TilesEditorPlugin *>(this), &TilesEditorPlugin::_preview_frame_started), Object::CONNECT_ONE_SHOT);
 


### PR DESCRIPTION
Fixes issues with TileMap patterns previews not being rendered correctly, or producing broken textures.
Also fixes a mistake introduced in https://github.com/godotengine/godot/pull/65419, that would prevent creating pattern with drag&drop.