### PR TITLE
Calling popup_center* with the default size will use the current size

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -358,6 +358,7 @@
 			<description>
 				Popups the [Window] at the center of the current screen, with optionally given minimum size.
 				If the [Window] is embedded, it will be centered in the parent [Viewport] instead.
+				[b]Note:[/b] Calling it with the default value of [param minsize] is equivalent to calling it with [member size].
 			</description>
 		</method>
 		<method name="popup_centered_clamped">
@@ -367,6 +368,7 @@
 			<description>
 				Popups the [Window] centered inside its parent [Window].
 				[code]fallback_ratio[/code] determines the maximum size of the [Window], in relation to its parent.
+				[b]Note:[/b] Calling it with the default value of [param minsize] is equivalent to calling it with [member size].
 			</description>
 		</method>
 		<method name="popup_centered_ratio">

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1422,6 +1422,9 @@ void Window::popup_centered_clamped(const Size2i &p_size, float p_fallback_ratio
 	ERR_FAIL_COND(!is_inside_tree());
 	ERR_FAIL_COND_MSG(window_id == DisplayServer::MAIN_WINDOW_ID, "Can't popup the main window.");
 
+	// Consider the current size when calling with the default value.
+	Size2i expected_size = p_size == Size2i() ? size : p_size;
+
 	Rect2 parent_rect;
 
 	if (is_embedded()) {
@@ -1436,7 +1439,7 @@ void Window::popup_centered_clamped(const Size2i &p_size, float p_fallback_ratio
 	Vector2i size_ratio = parent_rect.size * p_fallback_ratio;
 
 	Rect2i popup_rect;
-	popup_rect.size = Vector2i(MIN(size_ratio.x, p_size.x), MIN(size_ratio.y, p_size.y));
+	popup_rect.size = Vector2i(MIN(size_ratio.x, expected_size.x), MIN(size_ratio.y, expected_size.y));
 	popup_rect.size = _clamp_window_size(popup_rect.size);
 
 	if (parent_rect != Rect2()) {
@@ -1450,6 +1453,9 @@ void Window::popup_centered(const Size2i &p_minsize) {
 	ERR_FAIL_COND(!is_inside_tree());
 	ERR_FAIL_COND_MSG(window_id == DisplayServer::MAIN_WINDOW_ID, "Can't popup the main window.");
 
+	// Consider the current size when calling with the default value.
+	Size2i expected_size = p_minsize == Size2i() ? size : p_minsize;
+
 	Rect2 parent_rect;
 
 	if (is_embedded()) {
@@ -1462,7 +1468,7 @@ void Window::popup_centered(const Size2i &p_minsize) {
 	}
 
 	Rect2i popup_rect;
-	popup_rect.size = _clamp_window_size(get_size().max(p_minsize));
+	popup_rect.size = _clamp_window_size(expected_size);
 
 	if (parent_rect != Rect2()) {
 		popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Implement https://github.com/godotengine/godot/pull/72991#issuecomment-1425781036.