### PR TITLE
ProjectManager: Also set `gl_compatibility` for mobile override

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -510,6 +510,8 @@ private:
 					ProjectSettings::CustomMap initial_settings;
 
 					// Be sure to change this code if/when renderers are changed.
+					// Default values are "forward_plus" for the main setting, "mobile" for the mobile override,
+					// and "gl_compatibility" for the web override.
 					String renderer_type = renderer_button_group->get_pressed_button()->get_meta(SNAME("rendering_method"));
 					initial_settings["rendering/renderer/rendering_method"] = renderer_type;
 
@@ -522,6 +524,8 @@ private:
 						project_features.push_back("Mobile");
 					} else if (renderer_type == "gl_compatibility") {
 						project_features.push_back("GL Compatibility");
+						// Also change the default rendering method for the mobile override.
+						initial_settings["rendering/renderer/rendering_method.mobile"] = "gl_compatibility";
 					} else {
 						WARN_PRINT("Unknown renderer type. Please report this as a bug on GitHub.");
 					}


### PR DESCRIPTION
It's a bit hacky as the choice mainly impacts the main setting, but there are pre-existing overrides which supersede it. We should treat this checkbox as the highest allowed rendering method, and replace the ones which would be higher end (here replace `mobile` with the chosen `gl_compatibility`).