### PR TITLE
RenderingDeviceVulkan: Make draw command labels thread safe

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -8462,14 +8462,17 @@ void RenderingDeviceVulkan::set_resource_name(RID p_id, const String p_name) {
 }
 
 void RenderingDeviceVulkan::draw_command_begin_label(String p_label_name, const Color p_color) {
+	_THREAD_SAFE_METHOD_
 	context->command_begin_label(frames[frame].draw_command_buffer, p_label_name, p_color);
 }
 
 void RenderingDeviceVulkan::draw_command_insert_label(String p_label_name, const Color p_color) {
+	_THREAD_SAFE_METHOD_
 	context->command_insert_label(frames[frame].draw_command_buffer, p_label_name, p_color);
 }
 
 void RenderingDeviceVulkan::draw_command_end_label() {
+	_THREAD_SAFE_METHOD_
 	context->command_end_label(frames[frame].draw_command_buffer);
 }
 


### PR DESCRIPTION
This PR fixes the following thread safety validation errors triggered during the TPS demo loading screen:

> UNASSIGNED-Threading-MultipleThreads(ERROR / SPEC): msgNum: 337425955 - Validation Error: [ UNASSIGNED-Threading-MultipleThreads ] Object 0: handle = 0x2382a729190, type = VK_OBJECT_TYPE_COMMAND_POOL; | MessageID = 0x141cb623 | THREADING ERROR : vkCmdBeginDebugUtilsLabelEXT(): object of type VkCommandPool is simultaneously used in thread 5064 and thread 16372

>UNASSIGNED-Threading-MultipleThreads(ERROR / SPEC): msgNum: 337425955 - Validation Error: [ UNASSIGNED-Threading-MultipleThreads ] Object 0: handle = 0x2382ab2e5f0, type = VK_OBJECT_TYPE_COMMAND_POOL; | MessageID = 0x141cb623 | THREADING ERROR : vkCmdPipelineBarrier(): object of type VkCommandPool is simultaneously used in thread 16372 and thread 5064

Thread 16372 is the main thread
Thread 5064 is a resource loader thread

![threads2](https://user-images.githubusercontent.com/2487152/218193697-0bc96ce9-3a27-4f03-8014-1333344a8b9e.PNG)


_Bugsquad edit: Fixes https://github.com/godotengine/godot/issues/51955_