### PR TITLE
Fix camera reparenting

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -266,6 +266,8 @@ void Camera2D::_notification(int p_what) {
 				clear_current();
 			}
 			viewport = nullptr;
+			just_exited_tree = true;
+			callable_mp(this, &Camera2D::_reset_just_exited).call_deferred();
 		} break;
 
 #ifdef TOOLS_ENABLED
@@ -438,6 +440,10 @@ void Camera2D::_update_process_internal_for_smoothing() {
 void Camera2D::make_current() {
 	ERR_FAIL_COND(!enabled || !is_inside_tree());
 	get_tree()->call_group(group_name, "_make_current", this);
+	if (just_exited_tree) {
+		// If camera exited the scene tree in the same frame, group call will skip it, so this needs to be called manually.
+		_make_current(this);
+	}
 	_update_scroll();
 }
 

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -51,6 +51,7 @@ protected:
 	Point2 camera_pos;
 	Point2 smoothed_camera_pos;
 	bool first = true;
+	bool just_exited_tree = false;
 
 	ObjectID custom_viewport_id; // to check validity
 	Viewport *custom_viewport = nullptr;
@@ -88,6 +89,7 @@ protected:
 	void _update_scroll();
 
 	void _make_current(Object *p_which);
+	void _reset_just_exited() { just_exited_tree = false; }
 
 	void _set_old_smoothing(real_t p_enable);
 


### PR DESCRIPTION
Fixes #73010
Apparently nodes will ignore group calls if they are reparented, so I had to resort to a little hack.

Fun fact: the issue reporter was right that #72550 was related. Before that PR the reparenting was working correctly due to the same bug that caused invalid camera pointers xd