### PR TITLE
Serialize shader parameters even if not remapped

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -200,6 +200,12 @@ bool ShaderMaterial::_get(const StringName &p_name, Variant &r_ret) const {
 			r_ret = get_shader_parameter(*sn);
 			return true;
 		}
+		String s = p_name;
+		if (s.begins_with("shader_parameter/")) {
+			String param = s.replace_first("shader_parameter/", "");
+			r_ret = get_shader_parameter(param);
+			return true;
+		}
 	}
 
 	return false;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/72538
Fixes: https://github.com/godotengine/godot/issues/72923

The root causes of these issues are that the remap hashmap does not necessarily contain all the remappings between "shader_parameter/name" and "name" (i.e. if a shader parameter is set with just its name, it won't be added to the remap hash table). So when retrieving the value for serialization, we need to check if we have stored the name minus the prefix. 

My understanding is that ShaderMaterials always serialize with "shader_parameter/name" instead of just "name" this PR maintains that behaviour

This PR needs a review from @reduz as it reintroduces a string operation which I know he was keen to get rid of. 