### PR TITLE
Fix byte packing (and buffer overrun) in godot_webxr_get_bounds_geometry()

### DIFF
--- a/modules/webxr/native/library_godot_webxr.js
+++ b/modules/webxr/native/library_godot_webxr.js
@@ -584,12 +584,11 @@ const GodotWebXR = {
 		}
 
 		const buf = GodotRuntime.malloc(point_count * 3 * 4);
-		GodotRuntime.setHeapValue(buf, point_count, 'i32');
 		for (let i = 0; i < point_count; i++) {
 			const point = GodotWebXR.space.boundsGeometry[i];
-			GodotRuntime.setHeapValue(buf + ((i * 3) + 1) * 4, point.x, 'float');
-			GodotRuntime.setHeapValue(buf + ((i * 3) + 2) * 4, point.y, 'float');
-			GodotRuntime.setHeapValue(buf + ((i * 3) + 3) * 4, point.z, 'float');
+			GodotRuntime.setHeapValue(buf + ((i * 3) + 0) * 4, point.x, 'float');
+			GodotRuntime.setHeapValue(buf + ((i * 3) + 1) * 4, point.y, 'float');
+			GodotRuntime.setHeapValue(buf + ((i * 3) + 2) * 4, point.z, 'float');
 		}
 		GodotRuntime.setHeapValue(r_points, buf, 'i32');
 


### PR DESCRIPTION
While working on PR #72938, I noticed this bug in `godot_webxr_get_bounds_geometry()`.

It's incorrectly byte packing the data to pass it from Javascript to C++, and will actually overrun the buffer by 4 bytes!

Unlike the referenced issue, this one would be good to get in for 4.0.