### PR TITLE
Fix Line2D UVs when using BOX end cap mode

### DIFF
--- a/scene/2d/line_builder.cpp
+++ b/scene/2d/line_builder.cpp
@@ -393,6 +393,8 @@ void LineBuilder::build() {
 	if (end_cap_mode == Line2D::LINE_CAP_BOX) {
 		pos_up1 += f0 * hw * width_factor;
 		pos_down1 += f0 * hw * width_factor;
+
+		current_distance1 += hw * width_factor;
 	}
 
 	if (texture_mode == Line2D::LINE_TEXTURE_TILE) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Fixes #73067

Before:
![image](https://user-images.githubusercontent.com/95356449/218232280-adefc913-4e9c-4318-8bb7-105c2d4ce709.png)


After:
![image](https://user-images.githubusercontent.com/95356449/218232317-38d981f0-6dd2-4bd8-9e5b-1b70e99e36e0.png)


3.x: #73070