### PR TITLE
[3.x] Fix Line2D UVs when using BOX end cap mode

### DIFF
--- a/scene/2d/line_builder.cpp
+++ b/scene/2d/line_builder.cpp
@@ -407,6 +407,8 @@ void LineBuilder::build() {
 	if (end_cap_mode == Line2D::LINE_CAP_BOX) {
 		pos_up1 += f0 * hw * width_factor;
 		pos_down1 += f0 * hw * width_factor;
+
+		current_distance1 += hw * width_factor;
 	}
 
 	if (texture_mode == Line2D::LINE_TEXTURE_TILE) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Fixes #73067


4.0 PR with before/after comparison: #73069