### PR TITLE
Don't warn when using `TTRN()` in a language without plurals

### DIFF
--- a/core/string/translation_po.cpp
+++ b/core/string/translation_po.cpp
@@ -254,11 +254,6 @@ StringName TranslationPO::get_plural_message(const StringName &p_src_text, const
 	}
 	ERR_FAIL_COND_V_MSG(translation_map[p_context][p_src_text].is_empty(), StringName(), "Source text \"" + String(p_src_text) + "\" is registered but doesn't have a translation. Please report this bug.");
 
-	if (translation_map[p_context][p_src_text].size() == 1) {
-		WARN_PRINT("Source string \"" + String(p_src_text) + "\" doesn't have plural translations. Use singular translation API for such as tr(), TTR() to translate \"" + String(p_src_text) + "\"");
-		return translation_map[p_context][p_src_text][0];
-	}
-
 	int plural_index = _get_plural_index(p_n);
 	ERR_FAIL_COND_V_MSG(plural_index < 0 || translation_map[p_context][p_src_text].size() < plural_index + 1, StringName(), "Plural index returned or number of plural translations is not valid. Please report this bug.");
 


### PR DESCRIPTION
The current implementation warns when there is only one entry in the po file for the `TTRN()` message.