### PR TITLE
Remove WARNING "ray: index" for debug from SkeletonEditor

### DIFF
--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -1276,8 +1276,6 @@ int Skeleton3DGizmoPlugin::subgizmos_intersect_ray(const EditorNode3DGizmo *p_gi
 	}
 
 	if (closest_idx >= 0) {
-		WARN_PRINT("ray:");
-		WARN_PRINT(itos(closest_idx));
 		se->select_bone(closest_idx);
 		return closest_idx;
 	}


### PR DESCRIPTION
I remember that @fire or @JFonS added it for debugging or something, but I think it is no longer needed.

![image](https://user-images.githubusercontent.com/61938263/218256640-4318f6d2-4046-4c03-8ab7-70ce4a1d83fe.png)
