### PR TITLE
Improve EditorHelp theming and make font size settings work

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -45,15 +45,30 @@
 
 DocTools *EditorHelp::doc = nullptr;
 
-void EditorHelp::_update_theme() {
-	text_color = get_theme_color(SNAME("text_color"), SNAME("EditorHelp"));
-	title_color = get_theme_color(SNAME("title_color"), SNAME("EditorHelp"));
-	headline_color = get_theme_color(SNAME("headline_color"), SNAME("EditorHelp"));
-	comment_color = get_theme_color(SNAME("comment_color"), SNAME("EditorHelp"));
-	symbol_color = get_theme_color(SNAME("symbol_color"), SNAME("EditorHelp"));
-	value_color = get_theme_color(SNAME("value_color"), SNAME("EditorHelp"));
-	qualifier_color = get_theme_color(SNAME("qualifier_color"), SNAME("EditorHelp"));
-	type_color = get_theme_color(SNAME("type_color"), SNAME("EditorHelp"));
+void EditorHelp::_update_theme_item_cache() {
+	VBoxContainer::_update_theme_item_cache();
+
+	theme_cache.text_color = get_theme_color(SNAME("text_color"), SNAME("EditorHelp"));
+	theme_cache.title_color = get_theme_color(SNAME("title_color"), SNAME("EditorHelp"));
+	theme_cache.headline_color = get_theme_color(SNAME("headline_color"), SNAME("EditorHelp"));
+	theme_cache.comment_color = get_theme_color(SNAME("comment_color"), SNAME("EditorHelp"));
+	theme_cache.symbol_color = get_theme_color(SNAME("symbol_color"), SNAME("EditorHelp"));
+	theme_cache.value_color = get_theme_color(SNAME("value_color"), SNAME("EditorHelp"));
+	theme_cache.qualifier_color = get_theme_color(SNAME("qualifier_color"), SNAME("EditorHelp"));
+	theme_cache.type_color = get_theme_color(SNAME("type_color"), SNAME("EditorHelp"));
+
+	theme_cache.doc_font = get_theme_font(SNAME("doc"), SNAME("EditorFonts"));
+	theme_cache.doc_bold_font = get_theme_font(SNAME("doc_bold"), SNAME("EditorFonts"));
+	theme_cache.doc_title_font = get_theme_font(SNAME("doc_title"), SNAME("EditorFonts"));
+	theme_cache.doc_code_font = get_theme_font(SNAME("doc_source"), SNAME("EditorFonts"));
+	theme_cache.doc_kbd_font = get_theme_font(SNAME("doc_keyboard"), SNAME("EditorFonts"));
+
+	theme_cache.doc_font_size = get_theme_font_size(SNAME("doc_size"), SNAME("EditorFonts"));
+	theme_cache.doc_title_font_size = get_theme_font_size(SNAME("doc_title_size"), SNAME("EditorFonts"));
+	theme_cache.doc_code_font_size = get_theme_font_size(SNAME("doc_source_size"), SNAME("EditorFonts"));
+	theme_cache.doc_kbd_font_size = get_theme_font_size(SNAME("doc_keyboard_size"), SNAME("EditorFonts"));
+
+	theme_cache.background_style = get_theme_stylebox(SNAME("background"), SNAME("EditorHelp"));
 
 	class_desc->add_theme_color_override("selection_color", get_theme_color(SNAME("selection_color"), SNAME("EditorHelp")));
 	class_desc->add_theme_constant_override("line_separation", get_theme_constant(SNAME("line_separation"), SNAME("EditorHelp")));
@@ -61,13 +76,6 @@ void EditorHelp::_update_theme() {
 	class_desc->add_theme_constant_override("table_v_separation", get_theme_constant(SNAME("table_v_separation"), SNAME("EditorHelp")));
 	class_desc->add_theme_constant_override("text_highlight_h_padding", get_theme_constant(SNAME("text_highlight_h_padding"), SNAME("EditorHelp")));
 	class_desc->add_theme_constant_override("text_highlight_v_padding", get_theme_constant(SNAME("text_highlight_v_padding"), SNAME("EditorHelp")));
-
-	doc_font = get_theme_font(SNAME("doc"), SNAME("EditorFonts"));
-	doc_bold_font = get_theme_font(SNAME("doc_bold"), SNAME("EditorFonts"));
-	doc_title_font = get_theme_font(SNAME("doc_title"), SNAME("EditorFonts"));
-	doc_code_font = get_theme_font(SNAME("doc_source"), SNAME("EditorFonts"));
-
-	doc_title_font_size = get_theme_font_size(SNAME("doc_title_size"), SNAME("EditorFonts"));
 }
 
 void EditorHelp::_search(bool p_search_previous) {
@@ -187,14 +195,12 @@ void EditorHelp::_class_desc_input(const Ref<InputEvent> &p_input) {
 void EditorHelp::_class_desc_resized(bool p_force_update_theme) {
 	// Add extra horizontal margins for better readability.
 	// The margins increase as the width of the editor help container increases.
-	Ref<Font> font = get_theme_font(SNAME("doc_source"), SNAME("EditorFonts"));
-	int font_size = get_theme_font_size(SNAME("doc_source_size"), SNAME("EditorFonts"));
-	real_t char_width = font->get_char_size('x', font_size).width;
+	real_t char_width = theme_cache.doc_code_font->get_char_size('x', theme_cache.doc_code_font_size).width;
 	const int new_display_margin = MAX(30 * EDSCALE, get_parent_anchorable_rect().size.width - char_width * 120 * EDSCALE) * 0.5;
 	if (display_margin != new_display_margin || p_force_update_theme) {
 		display_margin = new_display_margin;
 
-		Ref<StyleBox> class_desc_stylebox = EditorNode::get_singleton()->get_theme_base()->get_theme_stylebox(SNAME("background"), SNAME("EditorHelp"))->duplicate();
+		Ref<StyleBox> class_desc_stylebox = theme_cache.background_style->duplicate();
 		class_desc_stylebox->set_content_margin(SIDE_LEFT, display_margin);
 		class_desc_stylebox->set_content_margin(SIDE_RIGHT, display_margin);
 		class_desc->add_theme_style_override("normal", class_desc_stylebox);
@@ -204,7 +210,7 @@ void EditorHelp::_class_desc_resized(bool p_force_update_theme) {
 
 void EditorHelp::_add_type(const String &p_type, const String &p_enum) {
 	if (p_type.is_empty() || p_type == "void") {
-		class_desc->push_color(Color(type_color, 0.5));
+		class_desc->push_color(Color(theme_cache.type_color, 0.5));
 		class_desc->push_hint(TTR("No return value."));
 		class_desc->add_text("void");
 		class_desc->pop();
@@ -224,7 +230,7 @@ void EditorHelp::_add_type(const String &p_type, const String &p_enum) {
 		}
 	}
 
-	class_desc->push_color(type_color);
+	class_desc->push_color(theme_cache.type_color);
 	bool add_array = false;
 	if (can_ref) {
 		if (t.ends_with("[]")) {
@@ -333,7 +339,7 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 		class_desc->push_meta("@method " + p_method.name);
 	}
 
-	class_desc->push_color(headline_color);
+	class_desc->push_color(theme_cache.headline_color);
 	_add_text(p_method.name);
 	class_desc->pop();
 
@@ -341,12 +347,12 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 		class_desc->pop(); //meta
 	}
 
-	class_desc->push_color(symbol_color);
+	class_desc->push_color(theme_cache.symbol_color);
 	class_desc->add_text("(");
 	class_desc->pop();
 
 	for (int j = 0; j < p_method.arguments.size(); j++) {
-		class_desc->push_color(text_color);
+		class_desc->push_color(theme_cache.text_color);
 		if (j > 0) {
 			class_desc->add_text(", ");
 		}
@@ -355,10 +361,10 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 		class_desc->add_text(": ");
 		_add_type(p_method.arguments[j].type, p_method.arguments[j].enumeration);
 		if (!p_method.arguments[j].default_value.is_empty()) {
-			class_desc->push_color(symbol_color);
+			class_desc->push_color(theme_cache.symbol_color);
 			class_desc->add_text(" = ");
 			class_desc->pop();
-			class_desc->push_color(value_color);
+			class_desc->push_color(theme_cache.value_color);
 			_add_text(_fix_constant(p_method.arguments[j].default_value));
 			class_desc->pop();
 		}
@@ -367,21 +373,21 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 	}
 
 	if (is_vararg) {
-		class_desc->push_color(text_color);
+		class_desc->push_color(theme_cache.text_color);
 		if (p_method.arguments.size()) {
 			class_desc->add_text(", ");
 		}
-		class_desc->push_color(symbol_color);
+		class_desc->push_color(theme_cache.symbol_color);
 		class_desc->add_text("...");
 		class_desc->pop();
 		class_desc->pop();
 	}
 
-	class_desc->push_color(symbol_color);
+	class_desc->push_color(theme_cache.symbol_color);
 	class_desc->add_text(")");
 	class_desc->pop();
 	if (!p_method.qualifiers.is_empty()) {
-		class_desc->push_color(qualifier_color);
+		class_desc->push_color(theme_cache.qualifier_color);
 
 		PackedStringArray qualifiers = p_method.qualifiers.split_spaces();
 		for (const String &qualifier : qualifiers) {
@@ -447,13 +453,12 @@ Error EditorHelp::_goto_desc(const String &p_class, int p_vscr) {
 }
 
 void EditorHelp::_update_method_list(const Vector<DocData::MethodDoc> p_methods) {
-	Ref<Font> font = get_theme_font(SNAME("doc_source"), SNAME("EditorFonts"));
 	class_desc->pop(); // title font size
 	class_desc->pop(); // title font
 	class_desc->pop(); // title color
 
 	class_desc->add_newline();
-	class_desc->push_font(font);
+	class_desc->push_font(theme_cache.doc_code_font);
 	class_desc->push_indent(1);
 	class_desc->push_table(2);
 	class_desc->set_table_column_expand(1, true);
@@ -510,9 +515,7 @@ void EditorHelp::_update_method_list(const Vector<DocData::MethodDoc> p_methods)
 }
 
 void EditorHelp::_update_method_descriptions(const DocData::ClassDoc p_classdoc, const Vector<DocData::MethodDoc> p_methods, const String &p_method_type) {
-	Ref<Font> font = get_theme_font(SNAME("doc"), SNAME("EditorFonts"));
-	Ref<Font> code_font = get_theme_font(SNAME("doc_source"), SNAME("EditorFonts"));
-	String link_color_text = title_color.to_html(false);
+	String link_color_text = theme_cache.title_color.to_html(false);
 	class_desc->pop(); // title font size
 	class_desc->pop(); // title font
 	class_desc->pop(); // title color
@@ -531,15 +534,15 @@ void EditorHelp::_update_method_descriptions(const DocData::ClassDoc p_classdoc,
 		}
 
 		for (int i = 0; i < methods_filtered.size(); i++) {
-			class_desc->push_font(code_font);
+			class_desc->push_font(theme_cache.doc_code_font);
 			_add_method(methods_filtered[i], false);
 			class_desc->pop();
 
 			class_desc->add_newline();
 			class_desc->add_newline();
 
-			class_desc->push_color(text_color);
-			class_desc->push_font(font);
+			class_desc->push_color(theme_cache.text_color);
+			class_desc->push_font(theme_cache.doc_font);
 			class_desc->push_indent(1);
 			if (methods_filtered[i].errors_returned.size()) {
 				class_desc->append_text(TTR("Error codes returned:"));
@@ -571,7 +574,7 @@ void EditorHelp::_update_method_descriptions(const DocData::ClassDoc p_classdoc,
 			} else {
 				class_desc->add_image(get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
 				class_desc->add_text(" ");
-				class_desc->push_color(comment_color);
+				class_desc->push_color(theme_cache.comment_color);
 				if (p_classdoc.is_script_doc) {
 					class_desc->append_text(vformat(TTR("There is currently no description for this %s."), p_method_type));
 				} else {
@@ -601,20 +604,19 @@ void EditorHelp::_update_doc() {
 	method_line.clear();
 	section_line.clear();
 
-	_update_theme();
-	String link_color_text = title_color.to_html(false);
+	String link_color_text = theme_cache.title_color.to_html(false);
 
 	DocData::ClassDoc cd = doc->class_list[edited_class]; // Make a copy, so we can sort without worrying.
 
 	// Class name
 	section_line.push_back(Pair<String, int>(TTR("Top"), 0));
-	class_desc->push_font(doc_title_font);
-	class_desc->push_font_size(doc_title_font_size);
-	class_desc->push_color(title_color);
+	class_desc->push_font(theme_cache.doc_title_font);
+	class_desc->push_font_size(theme_cache.doc_title_font_size);
+	class_desc->push_color(theme_cache.title_color);
 	class_desc->add_text(TTR("Class:") + " ");
-	_add_type_icon(edited_class, doc_title_font_size);
+	_add_type_icon(edited_class, theme_cache.doc_title_font_size);
 	class_desc->add_text(" ");
-	class_desc->push_color(headline_color);
+	class_desc->push_color(theme_cache.headline_color);
 	_add_text(edited_class);
 	class_desc->pop(); // color
 	class_desc->pop(); // color
@@ -639,8 +641,8 @@ void EditorHelp::_update_doc() {
 
 	// Ascendents
 	if (!cd.inherits.is_empty()) {
-		class_desc->push_color(title_color);
-		class_desc->push_font(doc_font);
+		class_desc->push_color(theme_cache.title_color);
+		class_desc->push_font(theme_cache.doc_font);
 		class_desc->add_text(TTR("Inherits:") + " ");
 
 		String inherits = cd.inherits;
@@ -667,11 +669,11 @@ void EditorHelp::_update_doc() {
 		bool found = false;
 		bool prev = false;
 
-		class_desc->push_font(doc_font);
+		class_desc->push_font(theme_cache.doc_font);
 		for (const KeyValue<String, DocData::ClassDoc> &E : doc->class_list) {
 			if (E.value.inherits == cd.name) {
 				if (!found) {
-					class_desc->push_color(title_color);
+					class_desc->push_color(theme_cache.title_color);
 					class_desc->add_text(TTR("Inherited by:") + " ");
 					found = true;
 				}
@@ -722,8 +724,8 @@ void EditorHelp::_update_doc() {
 	if (!cd.brief_description.strip_edges().is_empty()) {
 		has_description = true;
 
-		class_desc->push_color(text_color);
-		class_desc->push_font(doc_bold_font);
+		class_desc->push_color(theme_cache.text_color);
+		class_desc->push_font(theme_cache.doc_bold_font);
 		class_desc->push_indent(1);
 		_add_text(DTR(cd.brief_description));
 		class_desc->pop();
@@ -740,9 +742,9 @@ void EditorHelp::_update_doc() {
 
 		section_line.push_back(Pair<String, int>(TTR("Description"), class_desc->get_paragraph_count() - 2));
 		description_line = class_desc->get_paragraph_count() - 2;
-		class_desc->push_color(title_color);
-		class_desc->push_font(doc_title_font);
-		class_desc->push_font_size(doc_title_font_size);
+		class_desc->push_color(theme_cache.title_color);
+		class_desc->push_font(theme_cache.doc_title_font);
+		class_desc->push_font_size(theme_cache.doc_title_font_size);
 		class_desc->add_text(TTR("Description"));
 		class_desc->pop(); // font size
 		class_desc->pop(); // font
@@ -750,8 +752,8 @@ void EditorHelp::_update_doc() {
 
 		class_desc->add_newline();
 		class_desc->add_newline();
-		class_desc->push_color(text_color);
-		class_desc->push_font(doc_font);
+		class_desc->push_color(theme_cache.text_color);
+		class_desc->push_font(theme_cache.doc_font);
 		class_desc->push_indent(1);
 		_add_text(DTR(cd.description));
 		class_desc->pop();
@@ -765,7 +767,7 @@ void EditorHelp::_update_doc() {
 	if (!has_description) {
 		class_desc->add_image(get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
 		class_desc->add_text(" ");
-		class_desc->push_color(comment_color);
+		class_desc->push_color(theme_cache.comment_color);
 
 		if (cd.is_script_doc) {
 			class_desc->append_text(TTR("There is currently no description for this class."));
@@ -780,16 +782,16 @@ void EditorHelp::_update_doc() {
 
 	// Online tutorials
 	if (cd.tutorials.size()) {
-		class_desc->push_color(title_color);
-		class_desc->push_font(doc_title_font);
-		class_desc->push_font_size(doc_title_font_size);
+		class_desc->push_color(theme_cache.title_color);
+		class_desc->push_font(theme_cache.doc_title_font);
+		class_desc->push_font_size(theme_cache.doc_title_font_size);
 		class_desc->add_text(TTR("Online Tutorials"));
 		class_desc->pop(); // font size
 		class_desc->pop(); // font
 		class_desc->pop(); // color
 
 		class_desc->push_indent(1);
-		class_desc->push_font(doc_code_font);
+		class_desc->push_font(theme_cache.doc_code_font);
 		class_desc->add_newline();
 
 		for (int i = 0; i < cd.tutorials.size(); i++) {
@@ -800,7 +802,7 @@ void EditorHelp::_update_doc() {
 				linktxt = link.substr(seppos + 2);
 			}
 
-			class_desc->push_color(symbol_color);
+			class_desc->push_color(theme_cache.symbol_color);
 			class_desc->append_text("[url=" + link + "]" + linktxt + "[/url]");
 			class_desc->pop();
 			class_desc->add_newline();
@@ -829,16 +831,16 @@ void EditorHelp::_update_doc() {
 
 	if (has_properties) {
 		section_line.push_back(Pair<String, int>(TTR("Properties"), class_desc->get_paragraph_count() - 2));
-		class_desc->push_color(title_color);
-		class_desc->push_font(doc_title_font);
-		class_desc->push_font_size(doc_title_font_size);
+		class_desc->push_color(theme_cache.title_color);
+		class_desc->push_font(theme_cache.doc_title_font);
+		class_desc->push_font_size(theme_cache.doc_title_font_size);
 		class_desc->add_text(TTR("Properties"));
 		class_desc->pop(); // font size
 		class_desc->pop(); // font
 		class_desc->pop(); // color
 
 		class_desc->add_newline();
-		class_desc->push_font(doc_code_font);
+		class_desc->push_font(theme_cache.doc_code_font);
 		class_desc->push_indent(1);
 		class_desc->push_table(4);
 		class_desc->set_table_column_expand(1, true);
@@ -853,7 +855,7 @@ void EditorHelp::_update_doc() {
 			// Property type.
 			class_desc->push_cell();
 			class_desc->push_paragraph(HORIZONTAL_ALIGNMENT_RIGHT, Control::TEXT_DIRECTION_AUTO, "");
-			class_desc->push_font(doc_code_font);
+			class_desc->push_font(theme_cache.doc_code_font);
 			_add_type(cd.properties[i].type, cd.properties[i].enumeration);
 			class_desc->pop();
 			class_desc->pop();
@@ -880,8 +882,8 @@ void EditorHelp::_update_doc() {
 
 			// Property name.
 			class_desc->push_cell();
-			class_desc->push_font(doc_code_font);
-			class_desc->push_color(headline_color);
+			class_desc->push_font(theme_cache.doc_code_font);
+			class_desc->push_color(theme_cache.headline_color);
 
 			if (describe) {
 				class_desc->push_meta("@member " + cd.properties[i].name);
@@ -899,10 +901,10 @@ void EditorHelp::_update_doc() {
 
 			// Property value.
 			class_desc->push_cell();
-			class_desc->push_font(doc_code_font);
+			class_desc->push_font(theme_cache.doc_code_font);
 
 			if (!cd.properties[i].default_value.is_empty()) {
-				class_desc->push_color(symbol_color);
+				class_desc->push_color(theme_cache.symbol_color);
 				if (cd.properties[i].overridden) {
 					class_desc->add_text(" [");
 					class_desc->push_meta("@member " + cd.properties[i].overrides + "." + cd.properties[i].name);
@@ -914,11 +916,11 @@ void EditorHelp::_update_doc() {
 				}
 				class_desc->pop();
 
-				class_desc->push_color(value_color);
+				class_desc->push_color(theme_cache.value_color);
 				_add_text(_fix_constant(cd.properties[i].default_value));
 				class_desc->pop();
 
-				class_desc->push_color(symbol_color);
+				class_desc->push_color(theme_cache.symbol_color);
 				class_desc->add_text("]");
 				class_desc->pop();
 			}
@@ -935,30 +937,30 @@ void EditorHelp::_update_doc() {
 
 			// Property setters and getters.
 			class_desc->push_cell();
-			class_desc->push_font(doc_code_font);
+			class_desc->push_font(theme_cache.doc_code_font);
 
 			if (cd.is_script_doc && (!cd.properties[i].setter.is_empty() || !cd.properties[i].getter.is_empty())) {
-				class_desc->push_color(symbol_color);
+				class_desc->push_color(theme_cache.symbol_color);
 				class_desc->add_text(" [" + TTR("property:") + " ");
 				class_desc->pop(); // color
 
 				if (!cd.properties[i].setter.is_empty()) {
-					class_desc->push_color(value_color);
+					class_desc->push_color(theme_cache.value_color);
 					class_desc->add_text("setter");
 					class_desc->pop(); // color
 				}
 				if (!cd.properties[i].getter.is_empty()) {
 					if (!cd.properties[i].setter.is_empty()) {
-						class_desc->push_color(symbol_color);
+						class_desc->push_color(theme_cache.symbol_color);
 						class_desc->add_text(", ");
 						class_desc->pop(); // color
 					}
-					class_desc->push_color(value_color);
+					class_desc->push_color(theme_cache.value_color);
 					class_desc->add_text("getter");
 					class_desc->pop(); // color
 				}
 
-				class_desc->push_color(symbol_color);
+				class_desc->push_color(theme_cache.symbol_color);
 				class_desc->add_text("]");
 				class_desc->pop(); // color
 			}
@@ -998,9 +1000,9 @@ void EditorHelp::_update_doc() {
 		}
 
 		section_line.push_back(Pair<String, int>(TTR("Constructors"), class_desc->get_paragraph_count() - 2));
-		class_desc->push_color(title_color);
-		class_desc->push_font(doc_title_font);
-		class_desc->push_font_size(doc_title_font_size);
+		class_desc->push_color(theme_cache.title_color);
+		class_desc->push_font(theme_cache.doc_title_font);
+		class_desc->push_font_size(theme_cache.doc_title_font_size);
 		class_desc->add_text(TTR("Constructors"));
 		_update_method_list(cd.constructors);
 	}
@@ -1011,9 +1013,9 @@ void EditorHelp::_update_doc() {
 		}
 
 		section_line.push_back(Pair<String, int>(TTR("Methods"), class_desc->get_paragraph_count() - 2));
-		class_desc->push_color(title_color);
-		class_desc->push_font(doc_title_font);
-		class_desc->push_font_size(doc_title_font_size);
+		class_desc->push_color(theme_cache.title_color);
+		class_desc->push_font(theme_cache.doc_title_font);
+		class_desc->push_font_size(theme_cache.doc_title_font_size);
 		class_desc->add_text(TTR("Methods"));
 		_update_method_list(methods);
 	}
@@ -1024,9 +1026,9 @@ void EditorHelp::_update_doc() {
 		}
 
 		section_line.push_back(Pair<String, int>(TTR("Operators"), class_desc->get_paragraph_count() - 2));
-		class_desc->push_color(title_color);
-		class_desc->push_font(doc_title_font);
-		class_desc->push_font_size(doc_title_font_size);
+		class_desc->push_color(theme_cache.title_color);
+		class_desc->push_font(theme_cache.doc_title_font);
+		class_desc->push_font_size(theme_cache.doc_title_font_size);
 		class_desc->add_text(TTR("Operators"));
 		_update_method_list(cd.operators);
 	}
@@ -1034,9 +1036,9 @@ void EditorHelp::_update_doc() {
 	// Theme properties
 	if (!cd.theme_properties.is_empty()) {
 		section_line.push_back(Pair<String, int>(TTR("Theme Properties"), class_desc->get_paragraph_count() - 2));
-		class_desc->push_color(title_color);
-		class_desc->push_font(doc_title_font);
-		class_desc->push_font_size(doc_title_font_size);
+		class_desc->push_color(theme_cache.title_color);
+		class_desc->push_font(theme_cache.doc_title_font);
+		class_desc->push_font_size(theme_cache.doc_title_font_size);
 		class_desc->add_text(TTR("Theme Properties"));
 		class_desc->pop(); // font size
 		class_desc->pop(); // font
@@ -1062,9 +1064,9 @@ void EditorHelp::_update_doc() {
 			if (theme_data_type != cd.theme_properties[i].data_type) {
 				theme_data_type = cd.theme_properties[i].data_type;
 
-				class_desc->push_color(title_color);
-				class_desc->push_font(doc_title_font);
-				class_desc->push_font_size(doc_title_font_size);
+				class_desc->push_color(theme_cache.title_color);
+				class_desc->push_font(theme_cache.doc_title_font);
+				class_desc->push_font_size(theme_cache.doc_title_font_size);
 				if (data_type_names.has(theme_data_type)) {
 					class_desc->add_text(data_type_names[theme_data_type]);
 				} else {
@@ -1079,27 +1081,27 @@ void EditorHelp::_update_doc() {
 			}
 
 			// Theme item header.
-			class_desc->push_font(doc_code_font);
+			class_desc->push_font(theme_cache.doc_code_font);
 			_add_bulletpoint();
 
 			// Theme item object type.
 			_add_type(cd.theme_properties[i].type);
 
 			// Theme item name.
-			class_desc->push_color(headline_color);
+			class_desc->push_color(theme_cache.headline_color);
 			class_desc->add_text(" ");
 			_add_text(cd.theme_properties[i].name);
 			class_desc->pop();
 
 			// Theme item default value.
 			if (!cd.theme_properties[i].default_value.is_empty()) {
-				class_desc->push_color(symbol_color);
+				class_desc->push_color(theme_cache.symbol_color);
 				class_desc->add_text(" [" + TTR("default:") + " ");
 				class_desc->pop();
-				class_desc->push_color(value_color);
+				class_desc->push_color(theme_cache.value_color);
 				_add_text(_fix_constant(cd.theme_properties[i].default_value));
 				class_desc->pop();
-				class_desc->push_color(symbol_color);
+				class_desc->push_color(theme_cache.symbol_color);
 				class_desc->add_text("]");
 				class_desc->pop();
 			}
@@ -1108,8 +1110,8 @@ void EditorHelp::_update_doc() {
 
 			// Theme item description.
 			if (!cd.theme_properties[i].description.strip_edges().is_empty()) {
-				class_desc->push_font(doc_font);
-				class_desc->push_color(comment_color);
+				class_desc->push_font(theme_cache.doc_font);
+				class_desc->push_color(theme_cache.comment_color);
 				class_desc->push_indent(1);
 				_add_text(DTR(cd.theme_properties[i].description));
 				class_desc->pop(); // indent
@@ -1132,9 +1134,9 @@ void EditorHelp::_update_doc() {
 		}
 
 		section_line.push_back(Pair<String, int>(TTR("Signals"), class_desc->get_paragraph_count() - 2));
-		class_desc->push_color(title_color);
-		class_desc->push_font(doc_title_font);
-		class_desc->push_font_size(doc_title_font_size);
+		class_desc->push_color(theme_cache.title_color);
+		class_desc->push_font(theme_cache.doc_title_font);
+		class_desc->push_font_size(theme_cache.doc_title_font_size);
 		class_desc->add_text(TTR("Signals"));
 		class_desc->pop(); // font size
 		class_desc->pop(); // font
@@ -1148,16 +1150,16 @@ void EditorHelp::_update_doc() {
 		for (int i = 0; i < cd.signals.size(); i++) {
 			signal_line[cd.signals[i].name] = class_desc->get_paragraph_count() - 2; // Gets overridden if description.
 
-			class_desc->push_font(doc_code_font); // monofont
+			class_desc->push_font(theme_cache.doc_code_font); // monofont
 			_add_bulletpoint();
-			class_desc->push_color(headline_color);
+			class_desc->push_color(theme_cache.headline_color);
 			_add_text(cd.signals[i].name);
 			class_desc->pop();
-			class_desc->push_color(symbol_color);
+			class_desc->push_color(theme_cache.symbol_color);
 			class_desc->add_text("(");
 			class_desc->pop();
 			for (int j = 0; j < cd.signals[i].arguments.size(); j++) {
-				class_desc->push_color(text_color);
+				class_desc->push_color(theme_cache.text_color);
 				if (j > 0) {
 					class_desc->add_text(", ");
 				}
@@ -1166,7 +1168,7 @@ void EditorHelp::_update_doc() {
 				class_desc->add_text(": ");
 				_add_type(cd.signals[i].arguments[j].type);
 				if (!cd.signals[i].arguments[j].default_value.is_empty()) {
-					class_desc->push_color(symbol_color);
+					class_desc->push_color(theme_cache.symbol_color);
 					class_desc->add_text(" = ");
 					class_desc->pop();
 					_add_text(cd.signals[i].arguments[j].default_value);
@@ -1175,7 +1177,7 @@ void EditorHelp::_update_doc() {
 				class_desc->pop();
 			}
 
-			class_desc->push_color(symbol_color);
+			class_desc->push_color(theme_cache.symbol_color);
 			class_desc->add_text(")");
 
 			if (cd.signals[i].is_deprecated) {
@@ -1188,8 +1190,8 @@ void EditorHelp::_update_doc() {
 			class_desc->pop();
 			class_desc->pop(); // end monofont
 			if (!cd.signals[i].description.strip_edges().is_empty()) {
-				class_desc->push_font(doc_font);
-				class_desc->push_color(comment_color);
+				class_desc->push_font(theme_cache.doc_font);
+				class_desc->push_color(theme_cache.comment_color);
 				class_desc->push_indent(1);
 				_add_text(DTR(cd.signals[i].description));
 				class_desc->pop(); // indent
@@ -1228,9 +1230,9 @@ void EditorHelp::_update_doc() {
 		// Enums
 		if (enums.size()) {
 			section_line.push_back(Pair<String, int>(TTR("Enumerations"), class_desc->get_paragraph_count() - 2));
-			class_desc->push_color(title_color);
-			class_desc->push_font(doc_title_font);
-			class_desc->push_font_size(doc_title_font_size);
+			class_desc->push_color(theme_cache.title_color);
+			class_desc->push_font(theme_cache.doc_title_font);
+			class_desc->push_font_size(theme_cache.doc_title_font_size);
 			class_desc->add_text(TTR("Enumerations"));
 			class_desc->pop(); // font size
 			class_desc->pop(); // font
@@ -1242,8 +1244,8 @@ void EditorHelp::_update_doc() {
 			for (KeyValue<String, Vector<DocData::ConstantDoc>> &E : enums) {
 				enum_line[E.key] = class_desc->get_paragraph_count() - 2;
 
-				class_desc->push_font(doc_code_font);
-				class_desc->push_color(title_color);
+				class_desc->push_font(theme_cache.doc_code_font);
+				class_desc->push_color(theme_cache.title_color);
 				if (E.value.size() && E.value[0].is_bitfield) {
 					class_desc->add_text("flags  ");
 				} else {
@@ -1255,11 +1257,11 @@ void EditorHelp::_update_doc() {
 					e = e.get_slice(".", 1);
 				}
 
-				class_desc->push_color(headline_color);
+				class_desc->push_color(theme_cache.headline_color);
 				class_desc->add_text(e);
 				class_desc->pop();
 				class_desc->pop();
-				class_desc->push_color(symbol_color);
+				class_desc->push_color(theme_cache.symbol_color);
 				class_desc->add_text(":");
 				class_desc->pop();
 
@@ -1268,8 +1270,8 @@ void EditorHelp::_update_doc() {
 
 				// Enum description.
 				if (e != "@unnamed_enums" && cd.enums.has(e)) {
-					class_desc->push_color(text_color);
-					class_desc->push_font(doc_font);
+					class_desc->push_color(theme_cache.text_color);
+					class_desc->push_font(theme_cache.doc_font);
 					class_desc->push_indent(1);
 					_add_text(cd.enums[e]);
 					class_desc->pop();
@@ -1293,15 +1295,15 @@ void EditorHelp::_update_doc() {
 					// Add the enum constant line to the constant_line map so we can locate it as a constant.
 					constant_line[enum_list[i].name] = class_desc->get_paragraph_count() - 2;
 
-					class_desc->push_font(doc_code_font);
+					class_desc->push_font(theme_cache.doc_code_font);
 					_add_bulletpoint();
-					class_desc->push_color(headline_color);
+					class_desc->push_color(theme_cache.headline_color);
 					_add_text(enum_list[i].name);
 					class_desc->pop();
-					class_desc->push_color(symbol_color);
+					class_desc->push_color(theme_cache.symbol_color);
 					class_desc->add_text(" = ");
 					class_desc->pop();
-					class_desc->push_color(value_color);
+					class_desc->push_color(theme_cache.value_color);
 					_add_text(_fix_constant(enum_list[i].value));
 					class_desc->pop();
 					class_desc->pop();
@@ -1317,8 +1319,8 @@ void EditorHelp::_update_doc() {
 					class_desc->add_newline();
 
 					if (!enum_list[i].description.strip_edges().is_empty()) {
-						class_desc->push_font(doc_font);
-						class_desc->push_color(comment_color);
+						class_desc->push_font(theme_cache.doc_font);
+						class_desc->push_color(theme_cache.comment_color);
 						_add_text(DTR(enum_list[i].description));
 						class_desc->pop();
 						class_desc->pop();
@@ -1346,9 +1348,9 @@ void EditorHelp::_update_doc() {
 		// Constants
 		if (constants.size()) {
 			section_line.push_back(Pair<String, int>(TTR("Constants"), class_desc->get_paragraph_count() - 2));
-			class_desc->push_color(title_color);
-			class_desc->push_font(doc_title_font);
-			class_desc->push_font_size(doc_title_font_size);
+			class_desc->push_color(theme_cache.title_color);
+			class_desc->push_font(theme_cache.doc_title_font);
+			class_desc->push_font_size(theme_cache.doc_title_font_size);
 			class_desc->add_text(TTR("Constants"));
 			class_desc->pop(); // font size
 			class_desc->pop(); // font
@@ -1359,7 +1361,7 @@ void EditorHelp::_update_doc() {
 
 			for (int i = 0; i < constants.size(); i++) {
 				constant_line[constants[i].name] = class_desc->get_paragraph_count() - 2;
-				class_desc->push_font(doc_code_font);
+				class_desc->push_font(theme_cache.doc_code_font);
 
 				if (constants[i].value.begins_with("Color(") && constants[i].value.ends_with(")")) {
 					String stripped = constants[i].value.replace(" ", "").replace("Color(", "").replace(")", "");
@@ -1373,13 +1375,13 @@ void EditorHelp::_update_doc() {
 					_add_bulletpoint();
 				}
 
-				class_desc->push_color(headline_color);
+				class_desc->push_color(theme_cache.headline_color);
 				_add_text(constants[i].name);
 				class_desc->pop();
-				class_desc->push_color(symbol_color);
+				class_desc->push_color(theme_cache.symbol_color);
 				class_desc->add_text(" = ");
 				class_desc->pop();
-				class_desc->push_color(value_color);
+				class_desc->push_color(theme_cache.value_color);
 				_add_text(_fix_constant(constants[i].value));
 				class_desc->pop();
 
@@ -1396,8 +1398,8 @@ void EditorHelp::_update_doc() {
 				class_desc->add_newline();
 
 				if (!constants[i].description.strip_edges().is_empty()) {
-					class_desc->push_font(doc_font);
-					class_desc->push_color(comment_color);
+					class_desc->push_font(theme_cache.doc_font);
+					class_desc->push_color(theme_cache.comment_color);
 					_add_text(DTR(constants[i].description));
 					class_desc->pop();
 					class_desc->pop();
@@ -1421,9 +1423,9 @@ void EditorHelp::_update_doc() {
 		}
 
 		section_line.push_back(Pair<String, int>(TTR("Annotations"), class_desc->get_paragraph_count() - 2));
-		class_desc->push_color(title_color);
-		class_desc->push_font(doc_title_font);
-		class_desc->push_font_size(doc_title_font_size);
+		class_desc->push_color(theme_cache.title_color);
+		class_desc->push_font(theme_cache.doc_title_font);
+		class_desc->push_font_size(theme_cache.doc_title_font_size);
 		class_desc->add_text(TTR("Annotations"));
 		class_desc->pop(); // font size
 		class_desc->pop(); // font
@@ -1437,18 +1439,18 @@ void EditorHelp::_update_doc() {
 		for (int i = 0; i < cd.annotations.size(); i++) {
 			annotation_line[cd.annotations[i].name] = class_desc->get_paragraph_count() - 2; // Gets overridden if description.
 
-			class_desc->push_font(doc_code_font); // monofont
+			class_desc->push_font(theme_cache.doc_code_font); // monofont
 			_add_bulletpoint();
-			class_desc->push_color(headline_color);
+			class_desc->push_color(theme_cache.headline_color);
 			_add_text(cd.annotations[i].name);
 			class_desc->pop();
 
 			if (cd.annotations[i].arguments.size() > 0) {
-				class_desc->push_color(symbol_color);
+				class_desc->push_color(theme_cache.symbol_color);
 				class_desc->add_text("(");
 				class_desc->pop();
 				for (int j = 0; j < cd.annotations[i].arguments.size(); j++) {
-					class_desc->push_color(text_color);
+					class_desc->push_color(theme_cache.text_color);
 					if (j > 0) {
 						class_desc->add_text(", ");
 					}
@@ -1457,7 +1459,7 @@ void EditorHelp::_update_doc() {
 					class_desc->add_text(": ");
 					_add_type(cd.annotations[i].arguments[j].type);
 					if (!cd.annotations[i].arguments[j].default_value.is_empty()) {
-						class_desc->push_color(symbol_color);
+						class_desc->push_color(theme_cache.symbol_color);
 						class_desc->add_text(" = ");
 						class_desc->pop();
 						_add_text(cd.annotations[i].arguments[j].default_value);
@@ -1467,23 +1469,23 @@ void EditorHelp::_update_doc() {
 				}
 
 				if (cd.annotations[i].qualifiers.contains("vararg")) {
-					class_desc->push_color(text_color);
+					class_desc->push_color(theme_cache.text_color);
 					if (cd.annotations[i].arguments.size()) {
 						class_desc->add_text(", ");
 					}
-					class_desc->push_color(symbol_color);
+					class_desc->push_color(theme_cache.symbol_color);
 					class_desc->add_text("...");
 					class_desc->pop();
 					class_desc->pop();
 				}
 
-				class_desc->push_color(symbol_color);
+				class_desc->push_color(theme_cache.symbol_color);
 				class_desc->add_text(")");
 				class_desc->pop();
 			}
 
 			if (!cd.annotations[i].qualifiers.is_empty()) {
-				class_desc->push_color(qualifier_color);
+				class_desc->push_color(theme_cache.qualifier_color);
 				class_desc->add_text(" ");
 				_add_text(cd.annotations[i].qualifiers);
 				class_desc->pop();
@@ -1492,8 +1494,8 @@ void EditorHelp::_update_doc() {
 			class_desc->pop(); // end monofont
 
 			if (!cd.annotations[i].description.strip_edges().is_empty()) {
-				class_desc->push_font(doc_font);
-				class_desc->push_color(comment_color);
+				class_desc->push_font(theme_cache.doc_font);
+				class_desc->push_color(theme_cache.comment_color);
 				class_desc->push_indent(1);
 				_add_text(DTR(cd.annotations[i].description));
 				class_desc->pop(); // indent
@@ -1503,7 +1505,7 @@ void EditorHelp::_update_doc() {
 				class_desc->push_indent(1);
 				class_desc->add_image(get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
 				class_desc->add_text(" ");
-				class_desc->push_color(comment_color);
+				class_desc->push_color(theme_cache.comment_color);
 				if (cd.is_script_doc) {
 					class_desc->append_text(TTR("There is currently no description for this annotation."));
 				} else {
@@ -1523,9 +1525,9 @@ void EditorHelp::_update_doc() {
 	// Property descriptions
 	if (has_properties) {
 		section_line.push_back(Pair<String, int>(TTR("Property Descriptions"), class_desc->get_paragraph_count() - 2));
-		class_desc->push_color(title_color);
-		class_desc->push_font(doc_title_font);
-		class_desc->push_font_size(doc_title_font_size);
+		class_desc->push_color(theme_cache.title_color);
+		class_desc->push_font(theme_cache.doc_title_font);
+		class_desc->push_font_size(theme_cache.doc_title_font_size);
 		class_desc->add_text(TTR("Property Descriptions"));
 		class_desc->pop(); // font size
 		class_desc->pop(); // font
@@ -1545,7 +1547,7 @@ void EditorHelp::_update_doc() {
 			class_desc->set_table_column_expand(1, true);
 
 			class_desc->push_cell();
-			class_desc->push_font(doc_code_font);
+			class_desc->push_font(theme_cache.doc_code_font);
 			_add_bulletpoint();
 
 			_add_type(cd.properties[i].type, cd.properties[i].enumeration);
@@ -1554,21 +1556,21 @@ void EditorHelp::_update_doc() {
 			class_desc->pop(); // cell
 
 			class_desc->push_cell();
-			class_desc->push_font(doc_code_font);
-			class_desc->push_color(headline_color);
+			class_desc->push_font(theme_cache.doc_code_font);
+			class_desc->push_color(theme_cache.headline_color);
 			_add_text(cd.properties[i].name);
 			class_desc->pop(); // color
 
 			if (!cd.properties[i].default_value.is_empty()) {
-				class_desc->push_color(symbol_color);
+				class_desc->push_color(theme_cache.symbol_color);
 				class_desc->add_text(" [" + TTR("default:") + " ");
 				class_desc->pop(); // color
 
-				class_desc->push_color(value_color);
+				class_desc->push_color(theme_cache.value_color);
 				_add_text(_fix_constant(cd.properties[i].default_value));
 				class_desc->pop(); // color
 
-				class_desc->push_color(symbol_color);
+				class_desc->push_color(theme_cache.symbol_color);
 				class_desc->add_text("]");
 				class_desc->pop(); // color
 			}
@@ -1581,27 +1583,27 @@ void EditorHelp::_update_doc() {
 			}
 
 			if (cd.is_script_doc && (!cd.properties[i].setter.is_empty() || !cd.properties[i].getter.is_empty())) {
-				class_desc->push_color(symbol_color);
+				class_desc->push_color(theme_cache.symbol_color);
 				class_desc->add_text(" [" + TTR("property:") + " ");
 				class_desc->pop(); // color
 
 				if (!cd.properties[i].setter.is_empty()) {
-					class_desc->push_color(value_color);
+					class_desc->push_color(theme_cache.value_color);
 					class_desc->add_text("setter");
 					class_desc->pop(); // color
 				}
 				if (!cd.properties[i].getter.is_empty()) {
 					if (!cd.properties[i].setter.is_empty()) {
-						class_desc->push_color(symbol_color);
+						class_desc->push_color(theme_cache.symbol_color);
 						class_desc->add_text(", ");
 						class_desc->pop(); // color
 					}
-					class_desc->push_color(value_color);
+					class_desc->push_color(theme_cache.value_color);
 					class_desc->add_text("getter");
 					class_desc->pop(); // color
 				}
 
-				class_desc->push_color(symbol_color);
+				class_desc->push_color(theme_cache.symbol_color);
 				class_desc->add_text("]");
 				class_desc->pop(); // color
 			}
@@ -1621,8 +1623,8 @@ void EditorHelp::_update_doc() {
 					class_desc->pop(); // cell
 
 					class_desc->push_cell();
-					class_desc->push_font(doc_code_font);
-					class_desc->push_color(text_color);
+					class_desc->push_font(theme_cache.doc_code_font);
+					class_desc->push_color(theme_cache.text_color);
 					if (method_map[cd.properties[i].setter].arguments.size() > 1) {
 						// Setters with additional arguments are exposed in the method list, so we link them here for quick access.
 						class_desc->push_meta("@method " + cd.properties[i].setter);
@@ -1632,7 +1634,7 @@ void EditorHelp::_update_doc() {
 						class_desc->add_text(cd.properties[i].setter + TTR("(value)"));
 					}
 					class_desc->pop(); // color
-					class_desc->push_color(comment_color);
+					class_desc->push_color(theme_cache.comment_color);
 					class_desc->add_text(" setter");
 					class_desc->pop(); // color
 					class_desc->pop(); // font
@@ -1645,8 +1647,8 @@ void EditorHelp::_update_doc() {
 					class_desc->pop(); // cell
 
 					class_desc->push_cell();
-					class_desc->push_font(doc_code_font);
-					class_desc->push_color(text_color);
+					class_desc->push_font(theme_cache.doc_code_font);
+					class_desc->push_color(theme_cache.text_color);
 					if (method_map[cd.properties[i].getter].arguments.size() > 0) {
 						// Getters with additional arguments are exposed in the method list, so we link them here for quick access.
 						class_desc->push_meta("@method " + cd.properties[i].getter);
@@ -1656,7 +1658,7 @@ void EditorHelp::_update_doc() {
 						class_desc->add_text(cd.properties[i].getter + "()");
 					}
 					class_desc->pop(); //color
-					class_desc->push_color(comment_color);
+					class_desc->push_color(theme_cache.comment_color);
 					class_desc->add_text(" getter");
 					class_desc->pop(); //color
 					class_desc->pop(); //font
@@ -1670,15 +1672,15 @@ void EditorHelp::_update_doc() {
 			class_desc->add_newline();
 			class_desc->add_newline();
 
-			class_desc->push_color(text_color);
-			class_desc->push_font(doc_font);
+			class_desc->push_color(theme_cache.text_color);
+			class_desc->push_font(theme_cache.doc_font);
 			class_desc->push_indent(1);
 			if (!cd.properties[i].description.strip_edges().is_empty()) {
 				_add_text(DTR(cd.properties[i].description));
 			} else {
 				class_desc->add_image(get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
 				class_desc->add_text(" ");
-				class_desc->push_color(comment_color);
+				class_desc->push_color(theme_cache.comment_color);
 				if (cd.is_script_doc) {
 					class_desc->append_text(TTR("There is currently no description for this property."));
 				} else {
@@ -1698,9 +1700,9 @@ void EditorHelp::_update_doc() {
 	// Constructor descriptions
 	if (!cd.constructors.is_empty()) {
 		section_line.push_back(Pair<String, int>(TTR("Constructor Descriptions"), class_desc->get_paragraph_count() - 2));
-		class_desc->push_color(title_color);
-		class_desc->push_font(doc_title_font);
-		class_desc->push_font_size(doc_title_font_size);
+		class_desc->push_color(theme_cache.title_color);
+		class_desc->push_font(theme_cache.doc_title_font);
+		class_desc->push_font_size(theme_cache.doc_title_font_size);
 		class_desc->add_text(TTR("Constructor Descriptions"));
 		_update_method_descriptions(cd, cd.constructors, "constructor");
 	}
@@ -1708,9 +1710,9 @@ void EditorHelp::_update_doc() {
 	// Method descriptions
 	if (!methods.is_empty()) {
 		section_line.push_back(Pair<String, int>(TTR("Method Descriptions"), class_desc->get_paragraph_count() - 2));
-		class_desc->push_color(title_color);
-		class_desc->push_font(doc_title_font);
-		class_desc->push_font_size(doc_title_font_size);
+		class_desc->push_color(theme_cache.title_color);
+		class_desc->push_font(theme_cache.doc_title_font);
+		class_desc->push_font_size(theme_cache.doc_title_font_size);
 		class_desc->add_text(TTR("Method Descriptions"));
 		_update_method_descriptions(cd, methods, "method");
 	}
@@ -1718,9 +1720,9 @@ void EditorHelp::_update_doc() {
 	// Operator descriptions
 	if (!cd.operators.is_empty()) {
 		section_line.push_back(Pair<String, int>(TTR("Operator Descriptions"), class_desc->get_paragraph_count() - 2));
-		class_desc->push_color(title_color);
-		class_desc->push_font(doc_title_font);
-		class_desc->push_font_size(doc_title_font_size);
+		class_desc->push_color(theme_cache.title_color);
+		class_desc->push_font(theme_cache.doc_title_font);
+		class_desc->push_font_size(theme_cache.doc_title_font_size);
 		class_desc->add_text(TTR("Operator Descriptions"));
 		_update_method_descriptions(cd, cd.operators, "operator");
 	}
@@ -2163,6 +2165,11 @@ void EditorHelp::_toggle_scripts_pressed() {
 
 void EditorHelp::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_POSTINITIALIZE: {
+			// Requires theme to be up to date.
+			_class_desc_resized(false);
+		} break;
+
 		case NOTIFICATION_READY:
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			_wait_for_thread();
@@ -2275,13 +2282,11 @@ EditorHelp::EditorHelp() {
 	add_child(class_desc);
 	class_desc->set_threaded(true);
 	class_desc->set_v_size_flags(SIZE_EXPAND_FILL);
-	class_desc->add_theme_color_override("selection_color", get_theme_color(SNAME("accent_color"), SNAME("Editor")) * Color(1, 1, 1, 0.4));
 
 	class_desc->connect("finished", callable_mp(this, &EditorHelp::_class_desc_finished));
 	class_desc->connect("meta_clicked", callable_mp(this, &EditorHelp::_class_desc_select));
 	class_desc->connect("gui_input", callable_mp(this, &EditorHelp::_class_desc_input));
 	class_desc->connect("resized", callable_mp(this, &EditorHelp::_class_desc_resized).bind(false));
-	_class_desc_resized(false);
 
 	// Added second so it opens at the bottom so it won't offset the entire widget.
 	find_bar = memnew(FindBar);
@@ -2431,7 +2436,6 @@ void FindBar::popup_search() {
 
 void FindBar::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
 			find_prev->set_icon(get_theme_icon(SNAME("MoveUp"), SNAME("EditorIcons")));
 			find_next->set_icon(get_theme_icon(SNAME("MoveDown"), SNAME("EditorIcons")));

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -125,25 +125,32 @@ class EditorHelp : public VBoxContainer {
 
 	String base_path;
 
-	Color text_color;
-	Color title_color;
-	Color headline_color;
-	Color comment_color;
-	Color symbol_color;
-	Color value_color;
-	Color qualifier_color;
-	Color type_color;
+	struct ThemeCache {
+		Ref<StyleBox> background_style;
 
-	Ref<Font> doc_font;
-	Ref<Font> doc_bold_font;
-	Ref<Font> doc_title_font;
-	Ref<Font> doc_code_font;
+		Color text_color;
+		Color title_color;
+		Color headline_color;
+		Color comment_color;
+		Color symbol_color;
+		Color value_color;
+		Color qualifier_color;
+		Color type_color;
 
-	int doc_title_font_size;
+		Ref<Font> doc_font;
+		Ref<Font> doc_bold_font;
+		Ref<Font> doc_title_font;
+		Ref<Font> doc_code_font;
+		Ref<Font> doc_kbd_font;
+
+		int doc_font_size = 0;
+		int doc_title_font_size = 0;
+		int doc_code_font_size = 0;
+		int doc_kbd_font_size = 0;
+	} theme_cache;
 
 	int scroll_to = -1;
 
-	void _update_theme();
 	void _help_callback(const String &p_topic);
 
 	void _add_text(const String &p_bbcode);
@@ -181,6 +188,8 @@ class EditorHelp : public VBoxContainer {
 	static void _gen_doc_thread(void *p_udata);
 
 protected:
+	virtual void _update_theme_item_cache() override;
+
 	void _notification(int p_what);
 	static void _bind_methods();
 

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -139,6 +139,7 @@ class EditorHelp : public VBoxContainer {
 
 		Ref<Font> doc_font;
 		Ref<Font> doc_bold_font;
+		Ref<Font> doc_italic_font;
 		Ref<Font> doc_title_font;
 		Ref<Font> doc_code_font;
 		Ref<Font> doc_kbd_font;
@@ -162,6 +163,13 @@ class EditorHelp : public VBoxContainer {
 	void _add_method(const DocData::MethodDoc &p_method, bool p_overview = true);
 
 	void _add_bulletpoint();
+
+	void _push_normal_font();
+	void _pop_normal_font();
+	void _push_title_font();
+	void _pop_title_font();
+	void _push_code_font();
+	void _pop_code_font();
 
 	void _class_desc_finished();
 	void _class_list_select(const String &p_select);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -691,10 +691,11 @@ void EditorNode::_notification(int p_what) {
 
 			bool theme_changed =
 					EditorSettings::get_singleton()->check_changed_settings_in_group("interface/theme") ||
-					EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/theme") ||
 					EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/font") ||
 					EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/main_font") ||
 					EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/code_font") ||
+					EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/theme") ||
+					EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/help/help") ||
 					EditorSettings::get_singleton()->check_changed_settings_in_group("filesystem/file_dialog/thumbnail_size");
 
 			if (theme_changed) {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -586,9 +586,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// Help
 	_initial_set("text_editor/help/show_help_index", true);
-	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/help/help_font_size", 15, "8,48,1")
-	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/help/help_source_font_size", 14, "8,48,1")
-	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/help/help_title_font_size", 23, "8,48,1")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/help/help_font_size", 16, "8,48,1")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/help/help_source_font_size", 15, "8,48,1")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/help/help_title_font_size", 23, "8,64,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/help/class_reference_examples", 0, "GDScript,C#,GDScript and C#")
 
 	/* Editors */


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/73094.
Fixes https://github.com/godotengine/godot/issues/69097.
Supersedes https://github.com/godotengine/godot/pull/70032.

Apparently, at some point we started to ignore the font size options for the built-in help. Only title size option was used in code, but even that had issues — the setting would only be applied upon the editor theme regeneration, but changing the setting didn't trigger that. So only restarting the editor, or changing another setting that actually does trigger the theme regeneration would work.

So I made 3 changes (and consequently there are 3 commits for clarity):

1. Migrate to the theme cache struct, make sure everything that should use it does use it.
  - This only affects `EditorHelp`, but there is a shared method between it and `EditorHelpBit` that also uses theme items; unfortunately it is not cached at the moment (which is very inefficient).
  - Here as well I made sure that changing settings triggers the theme regeneration.
2. Make sure that font sizes for normal, title, and code fonts are applied alongside the fonts themselves.
  - To make things cleaner, I added a few helper push/pop methods and moved the necessary calls there. Pop methods are trivial, but make the rest of the code clearer.
3. Since the settings are now respected, the default size turned out to be too small, so I changed it (and also made it possible to increase the title font size up to 64, it's a title after all).

[Here's how it looks with the old defaults, when they actually work](https://user-images.githubusercontent.com/11782833/218270267-88b71733-df56-4934-8525-30cacafd2ddc.png)
[And here's the new defaults](https://user-images.githubusercontent.com/11782833/218270271-83b3083d-1b57-4b9a-be95-a3ee75db928e.png)

It's a pretty big change to this particular part of the codebase for RC, but it does fix issues, and in general it should be safe. But feel free to bump to 4.1, if this is deemed too risky.