### PR TITLE
Completion of parameters not described in some animation resources

### DIFF
--- a/doc/classes/AnimationNodeAnimation.xml
+++ b/doc/classes/AnimationNodeAnimation.xml
@@ -21,8 +21,10 @@
 	</members>
 	<constants>
 		<constant name="PLAY_MODE_FORWARD" value="0" enum="PlayMode">
+			Plays animation in forward direction.
 		</constant>
 		<constant name="PLAY_MODE_BACKWARD" value="1" enum="PlayMode">
+			Plays animation in backward direction.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/AnimationNodeOneShot.xml
+++ b/doc/classes/AnimationNodeOneShot.xml
@@ -46,7 +46,7 @@
 			The fade-in duration. For example, setting this to [code]1.0[/code] for a 5 second length animation will produce a crossfade that starts at 0 second and ends at 1 second during the animation.
 		</member>
 		<member name="fadeout_time" type="float" setter="set_fadeout_time" getter="get_fadeout_time" default="0.0">
-			The fade-in duration. For example, setting this to [code]1.0[/code] for a 5 second length animation will produce a crossfade that starts at 4 second and ends at 5 second during the animation.
+			The fade-out duration. For example, setting this to [code]1.0[/code] for a 5 second length animation will produce a crossfade that starts at 4 second and ends at 5 second during the animation.
 		</member>
 		<member name="mix_mode" type="int" setter="set_mix_mode" getter="get_mix_mode" enum="AnimationNodeOneShot.MixMode" default="0">
 			The blend type.

--- a/doc/classes/AnimationNodeStateMachineTransition.xml
+++ b/doc/classes/AnimationNodeStateMachineTransition.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimationNodeStateMachineTransition" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		A resource to connect each node to make a path for [AnimationNodeStateMachine].
 	</brief_description>
 	<description>
+		The path generated when using [method AnimationNodeStateMachinePlayback.travel] is limited to the nodes connected by [AnimationNodeStateMachineTransition].
+		You can set the timing and conditions of the transition in detail.
 	</description>
 	<tutorials>
 		<link title="AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>


### PR DESCRIPTION
- Add description to `AnimationNodeAnimation.PlayMode`
- Add brief description to `AnimationNodeStateMachineTransition`
- Fix #73014 docs error