### PR TITLE
Fix remaining fade doesn't clear when reset in AnimationNodeTransition

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -825,6 +825,7 @@ double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_is_ex
 
 	bool switched = false;
 	bool restart = false;
+	bool clear_remaining_fade = false;
 
 	if (pending_update) {
 		if (cur_current_index < 0 || cur_current_index >= get_input_count()) {
@@ -842,6 +843,10 @@ double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_is_ex
 		pending_update = false;
 	}
 
+	if (p_time == 0 && p_seek && !p_is_external_seeking) {
+		clear_remaining_fade = true; // Reset occurs.
+	}
+
 	if (!cur_transition_request.is_empty()) {
 		int new_idx = find_input(cur_transition_request);
 		if (new_idx >= 0) {
@@ -849,10 +854,7 @@ double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_is_ex
 				if (allow_transition_to_self) {
 					// Transition to same state.
 					restart = input_data[cur_current_index].reset;
-					cur_prev_xfading = 0;
-					set_parameter(prev_xfading, 0);
-					cur_prev_index = -1;
-					set_parameter(prev_index, -1);
+					clear_remaining_fade = true;
 				}
 			} else {
 				switched = true;
@@ -867,6 +869,13 @@ double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_is_ex
 		}
 		cur_transition_request = String();
 		set_parameter(transition_request, cur_transition_request);
+	}
+
+	if (clear_remaining_fade) {
+		cur_prev_xfading = 0;
+		set_parameter(prev_xfading, 0);
+		cur_prev_index = -1;
+		set_parameter(prev_index, -1);
 	}
 
 	// Special case for restart.


### PR DESCRIPTION
Fixes - #73113 *partially*.

https://user-images.githubusercontent.com/61938263/218278262-79e0cf58-8a82-4a5a-9a0a-efd2324c6004.mp4

For now, only NodeTransition has been fixed.

NodeOneShot has a fundamental problem with the way of transition (#53947), and StateMachine needs to be considered in combination with SubStateMachine implementation (https://github.com/godotengine/godot-proposals/issues/6130). Probably they need to be fixed in 4.1.
