### PR TITLE
UWP: Fix app crash when `managed_object->update_clipboard()` is called

### DIFF
--- a/platform/uwp/app.cpp
+++ b/platform/uwp/app.cpp
@@ -108,6 +108,9 @@ void App::SetWindow(CoreWindow ^ p_window) {
 	window->VisibilityChanged +=
 			ref new TypedEventHandler<CoreWindow ^, VisibilityChangedEventArgs ^>(this, &App::OnVisibilityChanged);
 
+	window->Activated +=
+			ref new TypedEventHandler<CoreWindow ^, WindowActivatedEventArgs ^>(this, &App::OnWindowActivated);
+
 	window->Closed +=
 			ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &App::OnWindowClosed);
 
@@ -445,6 +448,10 @@ void App::OnActivated(CoreApplicationView ^ applicationView, IActivatedEventArgs
 // Window event handlers.
 void App::OnVisibilityChanged(CoreWindow ^ sender, VisibilityChangedEventArgs ^ args) {
 	mWindowVisible = args->Visible;
+}
+
+void App::OnWindowActivated(CoreWindow ^ sender, WindowActivatedEventArgs ^ args) {
+	os->update_clipboard();
 }
 
 void App::OnWindowClosed(CoreWindow ^ sender, CoreWindowEventArgs ^ args) {

--- a/platform/uwp/app.h
+++ b/platform/uwp/app.h
@@ -69,6 +69,7 @@ namespace GodotUWP
 		// Window event handlers.
 		void OnWindowSizeChanged(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::WindowSizeChangedEventArgs^ args);
 		void OnVisibilityChanged(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::VisibilityChangedEventArgs^ args);
+		void OnWindowActivated(CoreWindow ^ sender, WindowActivatedEventArgs ^ args);
 		void OnWindowClosed(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::CoreWindowEventArgs^ args);
 
 		void pointer_event(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::PointerEventArgs^ args, bool p_pressed, bool p_is_wheel = false);

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -284,8 +284,6 @@ Error OS_UWP::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 
 	power_manager = memnew(PowerUWP);
 
-	managed_object->update_clipboard();
-
 	Clipboard::ContentChanged += ref new EventHandler<Platform::Object ^>(managed_object, &ManagedType::on_clipboard_changed);
 
 	accelerometer = Accelerometer::GetDefault();
@@ -385,6 +383,11 @@ void OS_UWP::alert(const String &p_alert, const String &p_title) {
 	managed_object->alert_close_handle = true;
 
 	msg->ShowAsync();
+}
+
+void OS_UWP::update_clipboard() {
+	// See https://stackoverflow.com/questions/58660743/uwp-app-crashes-when-clipboard-getcontent-is-called-from-inside-onnavigatedto
+	managed_object->update_clipboard();
 }
 
 void OS_UWP::ManagedType::alert_close(IUICommand ^ command) {

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -226,6 +226,7 @@ public:
 
 	virtual bool _check_internal_feature_support(const String &p_feature);
 
+	void update_clipboard();
 	void set_window(Windows::UI::Core::CoreWindow ^ p_window);
 	void screen_size_changed();
 


### PR DESCRIPTION
Extracted from #51157 for the `3.x` branch, as UWP is currently not maintained nor working in `master`.