### PR TITLE
Fix missing UID handling in Dependency Editor

### DIFF
--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -191,10 +191,16 @@ void DependencyEditor::_update_list() {
 
 		ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id(path);
 		if (uid != ResourceUID::INVALID_ID) {
-			// dependency is in uid format, obtain proper path
-			ERR_CONTINUE(!ResourceUID::get_singleton()->has_id(uid));
-
-			path = ResourceUID::get_singleton()->get_id_path(uid);
+			// Dependency is in uid format, obtain proper path.
+			if (ResourceUID::get_singleton()->has_id(uid)) {
+				path = ResourceUID::get_singleton()->get_id_path(uid);
+			} else if (n.get_slice_count("::") >= 3) {
+				// If uid can't be found, try to use fallback path.
+				path = n.get_slice("::", 2);
+			} else {
+				ERR_PRINT("Invalid dependency UID and fallback path.");
+				continue;
+			}
 		}
 
 		String name = path.get_file();

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -851,25 +851,33 @@ void ResourceLoaderText::get_dependencies(Ref<FileAccess> p_f, List<String> *p_d
 
 		String path = next_tag.fields["path"];
 		String type = next_tag.fields["type"];
+		String fallback_path;
 
 		bool using_uid = false;
 		if (next_tag.fields.has("uid")) {
-			//if uid exists, return uid in text format, not the path
+			// If uid exists, return uid in text format, not the path.
 			String uidt = next_tag.fields["uid"];
 			ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id(uidt);
 			if (uid != ResourceUID::INVALID_ID) {
+				fallback_path = path; // Used by Dependency Editor, in case uid path fails.
 				path = ResourceUID::get_singleton()->id_to_text(uid);
 				using_uid = true;
 			}
 		}
 
 		if (!using_uid && !path.contains("://") && path.is_relative_path()) {
-			// path is relative to file being loaded, so convert to a resource path
+			// Path is relative to file being loaded, so convert to a resource path.
 			path = ProjectSettings::get_singleton()->localize_path(local_path.get_base_dir().path_join(path));
 		}
 
 		if (p_add_types) {
 			path += "::" + type;
+		}
+		if (!fallback_path.is_empty()) {
+			if (!p_add_types) {
+				path += "::"; // Ensure that path comes third, even if there is no type.
+			}
+			path += "::" + fallback_path;
 		}
 
 		p_dependencies->push_back(path);


### PR DESCRIPTION
Fixes #63366
When the scene had UID and path as a dependency, it preferred listing the UID. This can however fail if the UID does not path to any path (not sure if possible normally; it's definitely a problem when copying files between projects).

I made the text loader add path as an optional dependency field and Dependency Editor will use it if UID fails.