### PR TITLE
Set Default compression to VRAM uncompressed for LightmapGI

### DIFF
--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -163,7 +163,8 @@ Array LightmapGIData::_get_light_textures_data() const {
 		config->set_value("remap", "importer", "2d_array_texture");
 		config->set_value("remap", "type", "CompressedTexture2DArray");
 		if (!config->has_section_key("params", "compress/mode")) {
-			config->set_value("params", "compress/mode", 2); //user may want another compression, so leave it be
+			// User may want another compression, so leave it be, but default to VRAM uncompressed.
+			config->set_value("params", "compress/mode", 3);
 		}
 		config->set_value("params", "compress/channel_pack", 1);
 		config->set_value("params", "mipmaps/generate", false);


### PR DESCRIPTION
This increases the speed to be near instant and removes the perceived lightmap bake speed regression

We need to investigate the speed and quality issues with BPTC and re-enable compression when we can

This will fix the perceived regression for new lightmap bakes, but existing scenes will need to delete the ``.import`` files

Fixes: https://github.com/godotengine/godot/issues/72666
Fixes: https://github.com/godotengine/godot/issues/73122

