### PR TITLE
Fix GraphEdit port hotzone snapping

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -860,7 +860,7 @@ bool GraphEdit::is_in_port_hotzone(const Vector2 &pos, const Vector2 &p_mouse_po
 	}
 
 	for (int i = 0; i < get_child_count(); i++) {
-		Control *child = Object::cast_to<Control>(get_child(i));
+		GraphNode *child = Object::cast_to<GraphNode>(get_child(i));
 		if (!child) {
 			continue;
 		}


### PR DESCRIPTION
The top layer containing controls like the menu bar and the minimap was checked for clickable controls. For that its rect was multiplied with the zoom factor although the top layer is never transformed, resulting in false positives for clickable controls at seemingly arbitrary places. There are many ways to fix this, but I think the easiest and most robust way is to check only GraphNodes and their children since they are the only children of GraphEdit which are transformed.

GIF of the bug since I think a formal issue hasn't been created so far:

![Peek 2023-02-12 02-01](https://user-images.githubusercontent.com/50084500/218287662-65a42259-97d3-43ef-b742-374028512ac3.gif)
