### PR TITLE
Add missing period for sentences in classref

### DIFF
--- a/doc/classes/CPUParticles3D.xml
+++ b/doc/classes/CPUParticles3D.xml
@@ -143,7 +143,7 @@
 			Maximum damping.
 		</member>
 		<member name="damping_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
-			Minimum damping
+			Minimum damping.
 		</member>
 		<member name="direction" type="Vector3" setter="set_direction" getter="get_direction" default="Vector3(1, 0, 0)">
 			Unit vector specifying the particles' emission direction.

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -486,7 +486,7 @@
 			Sets whether line folding is allowed.
 		</member>
 		<member name="line_length_guidelines" type="int[]" setter="set_line_length_guidelines" getter="get_line_length_guidelines" default="[]">
-			Draws vertical lines at the provided columns. The first entry is considered a main hard guideline and is draw more prominently
+			Draws vertical lines at the provided columns. The first entry is considered a main hard guideline and is draw more prominently.
 		</member>
 		<member name="symbol_lookup_on_click" type="bool" setter="set_symbol_lookup_on_click_enabled" getter="is_symbol_lookup_on_click_enabled" default="false">
 			Set when a validated word from [signal symbol_validate] is clicked, the [signal symbol_lookup] should be emitted.

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -651,7 +651,7 @@
 			<param index="1" name="idx" type="int" />
 			<param index="2" name="checkable" type="bool" />
 			<description>
-				Sets the type of the item at the specified index [param idx] to radio button. If [code]false[/code], sets the type of the item to plain text
+				Sets the type of the item at the specified index [param idx] to radio button. If [code]false[/code], sets the type of the item to plain text.
 				[b]Note:[/b] This is purely cosmetic; you must add the logic for checking/unchecking items in radio groups.
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
@@ -1615,7 +1615,7 @@
 			I-beam cursor shape. This is used by default when hovering a control that accepts text input, such as [LineEdit] or [TextEdit].
 		</constant>
 		<constant name="CURSOR_POINTING_HAND" value="2" enum="CursorShape">
-			Pointing hand cursor shape. This is used by default when hovering a [LinkButton] or an URL tag in a [RichTextLabel].⋅
+			Pointing hand cursor shape. This is used by default when hovering a [LinkButton] or an URL tag in a [RichTextLabel].
 		</constant>
 		<constant name="CURSOR_CROSS" value="3" enum="CursorShape">
 			Crosshair cursor. This is intended to be displayed when the user needs precise aim over an element, such as a rectangle selection tool or a color picker.

--- a/doc/classes/FontVariation.xml
+++ b/doc/classes/FontVariation.xml
@@ -49,7 +49,7 @@
 			Extra spacing at the bottom of the line in pixels.
 		</member>
 		<member name="spacing_glyph" type="int" setter="set_spacing" getter="get_spacing" default="0">
-			Extra spacing between graphical glyphs
+			Extra spacing between graphical glyphs.
 		</member>
 		<member name="spacing_space" type="int" setter="set_spacing" getter="get_spacing" default="0">
 			Extra width of the space glyphs.

--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="NavigationServer2D" inherits="Object" is_experimental="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Server interface for low-level 2D navigation access
+		Server interface for low-level 2D navigation access.
 	</brief_description>
 	<description>
 		NavigationServer2D is the server responsible for all 2D navigation. It handles several objects, namely maps, regions and agents.

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="NavigationServer3D" inherits="Object" is_experimental="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Server interface for low-level 3D navigation access
+		Server interface for low-level 3D navigation access.
 	</brief_description>
 	<description>
 		NavigationServer3D is the server responsible for all 3D navigation. It handles several objects, namely maps, regions and agents.

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -345,7 +345,7 @@
 				node.Callv(Node3D.MethodName.Rotate, new Godot.Collections.Array { new Vector3(1f, 0f, 0f), 1.571f });
 				[/csharp]
 				[/codeblocks]
-				[b]Note:[/b] In C#, [param method] must be in snake_case when referring to built-in Godot methods. Prefer using the names exposed in the [code]MethodName[/code] class to avoid allocating a new [StringName] on each call
+				[b]Note:[/b] In C#, [param method] must be in snake_case when referring to built-in Godot methods. Prefer using the names exposed in the [code]MethodName[/code] class to avoid allocating a new [StringName] on each call.
 			</description>
 		</method>
 		<method name="can_translate_messages" qualifiers="const">

--- a/doc/classes/PointLight2D.xml
+++ b/doc/classes/PointLight2D.xml
@@ -4,7 +4,7 @@
 		Positional 2D light source.
 	</brief_description>
 	<description>
-		Casts light in a 2D environment. This light's shape is defined by a (usually grayscale) texture
+		Casts light in a 2D environment. This light's shape is defined by a (usually grayscale) texture.
 	</description>
 	<tutorials>
 		<link title="2D lights and shadows">$DOCS_URL/tutorials/2d/2d_lights_and_shadows.html</link>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -803,7 +803,7 @@
 			Path to a custom [Font] resource to use as default for all GUI elements of the project.
 		</member>
 		<member name="gui/theme/default_font_antialiasing" type="int" setter="" getter="" default="1">
-			Font anti-aliasing mode. See [member FontFile.antialiasing],
+			Font anti-aliasing mode. See [member FontFile.antialiasing].
 		</member>
 		<member name="gui/theme/default_font_generate_mipmaps" type="bool" setter="" getter="" default="false">
 			If set to [code]true[/code], the default font will have mipmaps generated. This prevents text from looking grainy when a [Control] is scaled down, or when a [Label3D] is viewed from a long distance (if [member Label3D.texture_filter] is set to a mode that displays mipmaps).
@@ -957,16 +957,16 @@
 			macOS specific override for the shortcut to delete a word.
 		</member>
 		<member name="input/ui_text_caret_add_above" type="Dictionary" setter="" getter="">
-			Default [InputEventAction] to add an additional caret above every caret of a text
+			Default [InputEventAction] to add an additional caret above every caret of a text.
 		</member>
 		<member name="input/ui_text_caret_add_above.macos" type="Dictionary" setter="" getter="">
-			macOS specific override for the shortcut to add a caret above every caret
+			macOS specific override for the shortcut to add a caret above every caret.
 		</member>
 		<member name="input/ui_text_caret_add_below" type="Dictionary" setter="" getter="">
-			Default [InputEventAction] to add an additional caret below every caret of a text
+			Default [InputEventAction] to add an additional caret below every caret of a text.
 		</member>
 		<member name="input/ui_text_caret_add_below.macos" type="Dictionary" setter="" getter="">
-			macOS specific override for the shortcut to add a caret below every caret
+			macOS specific override for the shortcut to add a caret below every caret.
 		</member>
 		<member name="input/ui_text_caret_document_end" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to move the text cursor the the end of the text.
@@ -1663,7 +1663,7 @@
 			Optional name for the 3D render layer 13. If left empty, the layer will display as "Layer 13".
 		</member>
 		<member name="layer_names/3d_render/layer_14" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 14. If left empty, the layer will display as "Layer 14"
+			Optional name for the 3D render layer 14. If left empty, the layer will display as "Layer 14".
 		</member>
 		<member name="layer_names/3d_render/layer_15" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D render layer 15. If left empty, the layer will display as "Layer 15".

--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -240,7 +240,7 @@
 			<description>
 				Sets the global pose transform, [param pose], for the bone at [param bone_idx].
 				[param amount] is the interpolation strength that will be used when applying the pose, and [param persistent] determines if the applied pose will remain.
-				[b]Note:[/b] The pose transform needs to be a global pose! To convert a world transform from a [Node3D] to a global bone pose, multiply the [method Transform3D.affine_inverse] of the node's [member Node3D.global_transform] by the desired world transform
+				[b]Note:[/b] The pose transform needs to be a global pose! To convert a world transform from a [Node3D] to a global bone pose, multiply the [method Transform3D.affine_inverse] of the node's [member Node3D.global_transform] by the desired world transform.
 			</description>
 		</method>
 		<method name="set_bone_name">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -436,7 +436,7 @@
 			<return type="int" />
 			<param index="0" name="position" type="Vector2i" />
 			<description>
-				Returns the equivalent minimap line at [param position]
+				Returns the equivalent minimap line at [param position].
 			</description>
 		</method>
 		<method name="get_minimap_visible_lines" qualifiers="const">
@@ -483,7 +483,7 @@
 		<method name="get_saved_version" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the last tagged saved version from [method tag_saved_version]
+				Returns the last tagged saved version from [method tag_saved_version].
 			</description>
 		</method>
 		<method name="get_scroll_pos_for_line" qualifiers="const">
@@ -1054,7 +1054,7 @@
 			<return type="void" />
 			<param index="0" name="callback" type="Callable" />
 			<description>
-				Provide custom tooltip text. The callback method must take the following args: [code]hovered_word: String[/code]
+				Provide custom tooltip text. The callback method must take the following args: [code]hovered_word: String[/code].
 			</description>
 		</method>
 		<method name="start_action">

--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -188,7 +188,7 @@
 			<return type="Vector2i[]" />
 			<param index="0" name="coords" type="Vector2i" />
 			<description>
-				Returns the list of all neighbourings cells to the one at [param coords]
+				Returns the list of all neighbourings cells to the one at [param coords].
 			</description>
 		</method>
 		<method name="get_used_cells" qualifiers="const">
@@ -243,7 +243,7 @@
 			<param index="1" name="coords_in_pattern" type="Vector2i" />
 			<param index="2" name="pattern" type="TileMapPattern" />
 			<description>
-				Returns for the given coordinate [param coords_in_pattern] in a [TileMapPattern] the corresponding cell coordinates if the pattern was pasted at the [param position_in_tilemap] coordinates (see [method set_pattern]). This mapping is required as in half-offset tile shapes, the mapping might not work by calculating [code]position_in_tile_map + coords_in_pattern[/code]
+				Returns for the given coordinate [param coords_in_pattern] in a [TileMapPattern] the corresponding cell coordinates if the pattern was pasted at the [param position_in_tilemap] coordinates (see [method set_pattern]). This mapping is required as in half-offset tile shapes, the mapping might not work by calculating [code]position_in_tile_map + coords_in_pattern[/code].
 			</description>
 		</method>
 		<method name="map_to_local" qualifiers="const">


### PR DESCRIPTION
Found some missing periods when translating the classref.

Went through all XML files roughly. Should have found most similar cases.