### PR TITLE
Replaced OpenXR operating system alert dialog with a warning log message

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2378,6 +2378,9 @@
 		<member name="xr/openxr/reference_space" type="int" setter="" getter="" default="&quot;1&quot;">
 			Specify the default reference space.
 		</member>
+		<member name="xr/openxr/startup_alert" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], Godot will display an alert modal when OpenXR initialization fails on startup.
+		</member>
 		<member name="xr/openxr/submit_depth_buffer" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], OpenXR will manage the depth buffer and use the depth buffer for advanced reprojection provided this is supported by the XR runtime. Note that some rendering features in Godot can't be used with this feature.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1829,6 +1829,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/reference_space", PROPERTY_HINT_ENUM, "Local,Stage"), "1");
 
 	GLOBAL_DEF_BASIC("xr/openxr/submit_depth_buffer", false);
+	GLOBAL_DEF_BASIC("xr/openxr/startup_alert", true);
 
 #ifdef TOOLS_ENABLED
 	// Disabled for now, using XR inside of the editor we'll be working on during the coming months.

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "register_types.h"
+#include "core/config/project_settings.h"
 #include "main/main.h"
 
 #include "openxr_interface.h"
@@ -113,10 +114,19 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 			ERR_FAIL_NULL(openxr_api);
 
 			if (!openxr_api->initialize(Main::get_rendering_driver_name())) {
-				OS::get_singleton()->alert("OpenXR was requested but failed to start.\n"
-										   "Please check if your HMD is connected.\n"
-										   "When using Windows MR please note that WMR only has DirectX support, make sure SteamVR is your default OpenXR runtime.\n"
-										   "Godot will start in normal mode.\n");
+				const char *init_error_message =
+						"OpenXR was requested but failed to start.\n"
+						"Please check if your HMD is connected.\n"
+						"When using Windows MR please note that WMR only has DirectX support, make sure SteamVR is your default OpenXR runtime.\n"
+						"Godot will start in normal mode.\n";
+
+				WARN_PRINT(init_error_message);
+
+				bool init_show_startup_alert = GLOBAL_GET("xr/openxr/startup_alert");
+				if (init_show_startup_alert) {
+					OS::get_singleton()->alert(init_error_message);
+				}
+
 				memdelete(openxr_api);
 				openxr_api = nullptr;
 				return;


### PR DESCRIPTION
Fixes #73141

This pull request replaces (at user discretion) an alert dialog when OpenXR fails to initialize (usually due to StreamVR not running, or an HMD is disconnected or in standby) with a **WARN** log message. A new project setting exists (**Startup Alert**), which defaults to true, and toggles this behavior to account for users with an XR-only device.

### Justification

- Operating system alert dialog is intrusive and harmful to (in my opinion) the development workflow
    - Dialog causes significant delay when starting a project (several seconds)
    - Dialog requires user input before starting the project; making adjustments is painful because the dialog must be dismissed on every run
- The warning message shows up in the Errors tab (editor), in addition to a Console output window (if available), which is consistent behavior when compared to other OpenXR failure modes (eg. **create_instance** failure)
- The impact on the codebase is minimal (one statement, using existing technology)

### Personal Impact

This issue became personal. Godot is incredible software and I was inspired to work on a VR project. The dialog was damaging to my workflow, which I argue is probably not uncommon: my workflow consists of implementing game logic, behavior, visual effects, environments, etc. and then testing and iterating outside of VR (fast feedback loop). I launch and perform testing in an HMD when new features have gone through some iterations, and are ready for testing and feedback.

### Possible Workarounds

It is possible to workaround this issue to some extent, by disabling OpenXR in the project settings; however, this requires the user to restart the editor which is similarly intrusive. If the user desires to perform testing in VR they must modify the project setting again (and restart). 

Another workaround is to ensure an OpenXR runtime is running (SteamVR), and an HMD is connected. My argument against this is that during development it's not uncommon for the HMD to enter standby mode, or to close StreamVR, or to just open Godot and begin working without initializing SteamVR or plugging in an HMD.

It is my opinion that these workarounds are hostile to the user

### Screenshots

Attached are screenshots depicting the warning message in the console window and in the **Errors** tab.

![log_example](https://user-images.githubusercontent.com/2136005/218293226-52fc619c-b0c1-4436-99a9-3d86a8455571.png)
![openxr_errors_tab_example](https://user-images.githubusercontent.com/2136005/218293237-d8533245-1b0b-4343-9946-c538d8b82938.png)

![image](https://user-images.githubusercontent.com/2136005/218386058-c4ad31ad-5b7d-410b-a65e-d6f352d92ed2.png)

