### PR TITLE
Create a safe temporary file with is_backup_save_enabled

### DIFF
--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -100,6 +100,11 @@ Error FileAccessUnix::open_internal(const String &p_path, int p_mode_flags) {
 
 	if (is_backup_save_enabled() && (p_mode_flags == WRITE)) {
 		save_path = path;
+		// Create a temporary file in the same directory as the target file.
+		path = path + "-XXXXXX";
+		if (!mkstemp(path.utf8().ptrw())) {
+			return ERR_FILE_CANT_OPEN;
+		}
 		path = path + ".tmp";
 	}
 
@@ -143,7 +148,7 @@ void FileAccessUnix::_close() {
 	}
 
 	if (!save_path.is_empty()) {
-		int rename_error = rename((save_path + ".tmp").utf8().get_data(), save_path.utf8().get_data());
+		int rename_error = rename(path.utf8().get_data(), save_path.utf8().get_data());
 
 		if (rename_error && close_fail_notify) {
 			close_fail_notify(save_path);


### PR DESCRIPTION
The current implementation of safe save can still corrupt the file if multiple processes are trying to write to it at the same time. Especially because the file is opened with shared write. This PR addresses this by generating a unique temp file name. 

This is a non-breaking change as it only changes how the temporary file is created internally.

Note that this method does introduce a different issue where the temp file is not deleted if the process crashes. On Linux, this could be avoided by unlinking the file directly after opening it. I am not too sure how to achieve the same effect on Windows though.