### PR TITLE
Avoid race conditions in `EditorFileSystem` that cause issues with reimporting

### DIFF
--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -247,6 +247,8 @@ class EditorFileSystem : public Node {
 
 	bool _test_for_reimport(const String &p_path, bool p_only_imported_files);
 
+	bool _is_marked_for_reimport(EditorFileSystemDirectory *p_dir, const String &p_file);
+
 	bool reimport_on_missing_imported_files;
 
 	Vector<String> _get_dependencies(const String &p_path);

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -163,6 +163,7 @@ class EditorFileSystem : public Node {
 		String file;
 		EditorFileSystemDirectory *new_dir = nullptr;
 		EditorFileSystemDirectory::FileInfo *new_file = nullptr;
+		bool processing = false;
 	};
 
 	bool use_threads = true;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/53871. Maybe some other reimporting issues as well (perhaps, https://github.com/godotengine/godot/issues/73053).

I identified two issues with the current process, and I am pretty green with threading so I may be missing something important. But here it goes.

1. `EditorFileSystem` has a stack of "scan actions", which are created when we need to react to various file system and file changes. One of those actions is `ACTION_FILE_TEST_REIMPORT`, which attempts to reimport resource that seems like it needs a reimport (we assume it based on some general clues, but it is checked more strictly while processing `ACTION_FILE_TEST_REIMPORT` itself). Actions are added per file, and currently any file can have an infinite amount of `ACTION_FILE_TEST_REIMPORT` actions associated with it. This confuses the importer (possibly due to threading), and causes a conflict when we try to process them at the same time.

There possibly many ways to trigger this situation, but the one that happens in the linked issue is caused by two things happening at once:
  - We start by dropping a file from outside of the Godot Editor's window, when this window is not in focus;
  - This causes a file dropped routine to happen, which adds a new file and puts it into the queue for `ACTION_FILE_TEST_REIMPORT`;
  - At the same time the editor regains focus, and sees a new file without a corresponding `.import` file, so it adds it into the queue again. (There are several other conditions that can trigger a rescan here, but this is the one that gets met.)

This causes some kind of deadlock, brings an empty popup and hangs the editor. The file is in fact correctly imported upon the restart (probably thanks to a scan action during the editor startup routine). To prevent that I'm adding a check to avoid adding `ACTION_FILE_TEST_REIMPORT` actions to the queue for the same file more than once. This removes the deadlock and the empty popup, but makes the second issue more obvious. 👇

2. The stack itself can be processed multiple times, due to the same circumstances, or a direct request to do so from other engine components. The code that does the processing, `EditorFileSystem::_update_scan_actions()`, takes the current stack, performs everything, and then flushes it. But the methods itself can be called multiple times, before the stack is flushed. So even if we remove duplicated actions from the queue, the existing actions can be processed over and over again, causing all sorts of incorrect states.

To fix this I'm adding a boolean flag that is set immediately for each action to indicate that it is already being handled, so subsequent calls to `EditorFileSystem::_update_scan_actions()` should no longer attempt to process them. This leaves one problem with the code, but I don't see it causing any issues at the moment. At the end of the call, the entire queue is flushed with `scan_actions.clear();`. So even if there are multiple calls to update scan actions going at the same time, the first one of them will remove all pending and processed actions. I could add a bit of logic to remove only the actions each particular call has handled, but... we are still modifying the queue that other actions may be iterating over. Which is very problematic.

But, again, I don't see any immediate problem during the execution, and it is something that already happens, just with more bugs on top. We should probably delay the flushing until after all `EditorFileSystem::_update_scan_actions()` calls are done. I can think about a way to do that, but I'm not sure my overall solution in this PR is permanent. Once again, I'm not even close to an expert on threading, and `EditorFileSystem` is maintained by @reduz for many reasons. So maybe in a follow-up, if we're okay with this?

-----
I have two commits here, one for each problem, because of my uncertainty if this is a good solution, any part of it. So reverting each should be easier this way.

-----
### PLEASE DO TEST THIS!