### PR TITLE
Fix AudioStreamGenerator stopping playback after a buffer underrun

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -354,7 +354,7 @@ void AudioServer::_mix_step() {
 			playback->stream_playback->tag_used_streams();
 		}
 
-		if (mixed_frames != buffer_size) {
+		if (!playback->stream_playback->is_playing()) {
 			// We know we have at least the size of our lookahead buffer for fade-out purposes.
 
 			float fadeout_base = 0.94;


### PR DESCRIPTION
Fixes #65155

Tweaked repro project: [generator_repro.zip](https://github.com/godotengine/godot/files/10716445/generator_repro.zip)

The rationale here is that the number of samples mixed by a playback doesn't give us enough information to make a decision about whether to continue with that playback. I tested this with an ogg to make sure that it doesn't break playback of other streams, but it wouldn't hurt to test with other formats.