### PR TITLE
Add Button icon height property (max or fixed)

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -60,6 +60,10 @@
 		<member name="icon_alignment" type="int" setter="set_icon_alignment" getter="get_icon_alignment" enum="HorizontalAlignment" default="0">
 			Specifies if the icon should be aligned to the left, right, or center of a button. Uses the same [enum HorizontalAlignment] constants as the text alignment. If centered, text will draw on top of the icon.
 		</member>
+		<member name="icon_height" type="int" setter="set_icon_height" getter="get_icon_height" default="0">
+			When set to greater than [code]0[/code], sets the icon maximum height if [member expand_icon] is enabled, or the icon fixed height (max and min) if [member expand_icon] is not enabled.
+			To create a button that looks the same on a standard display and an HiDPI display but with a higher, 2X resolution, use an icon that's twice the standard display resolution, for example, 32x32 for a 16x16 target icon size, then set the [member icon_height] to 16px, and disable [member expand_icon].
+		</member>
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
 		</member>

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -286,6 +286,15 @@ void Button::_notification(int p_what) {
 					icon_size = Size2(icon_width, icon_height);
 				}
 
+				if (icon_set_height > 0) {
+					if (expand_icon) {
+						float icon_new_height = MIN(icon_size.height, icon_set_height);
+						icon_size = Size2(icon_new_height * icon_size.aspect(), icon_new_height);
+					} else {
+						icon_size = Size2(icon_set_height * icon_size.aspect(), icon_set_height);
+					}
+				}
+
 				if (icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_LEFT) {
 					icon_region = Rect2(style_offset + Point2(icon_ofs_region, Math::floor((valign - icon_size.y) * 0.5)), icon_size);
 				} else if (icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_CENTER) {
@@ -380,15 +389,16 @@ Size2 Button::get_minimum_size_for_text_and_icon(const String &p_text, Ref<Textu
 	}
 
 	if (!expand_icon && p_icon.is_valid()) {
-		minsize.height = MAX(minsize.height, p_icon->get_height());
+		Size2 icon_size = icon_set_height <= 0 ? p_icon->get_size() : Size2(icon_set_height * p_icon->get_size().aspect(), icon_set_height);
+		minsize.height = MAX(minsize.height, icon_size.height);
 
 		if (icon_alignment != HORIZONTAL_ALIGNMENT_CENTER) {
-			minsize.width += p_icon->get_width();
+			minsize.width += icon_size.width;
 			if (!xl_text.is_empty() || !p_text.is_empty()) {
 				minsize.width += MAX(0, theme_cache.h_separation);
 			}
 		} else {
-			minsize.width = MAX(minsize.width, p_icon->get_width());
+			minsize.width = MAX(minsize.width, icon_size.width);
 		}
 	}
 
@@ -433,8 +443,8 @@ void Button::set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior) {
 		overrun_behavior = p_behavior;
 		_shape();
 
-		queue_redraw();
 		update_minimum_size();
+		queue_redraw();
 	}
 }
 
@@ -448,8 +458,8 @@ void Button::set_text(const String &p_text) {
 		xl_text = atr(text);
 		_shape();
 
-		queue_redraw();
 		update_minimum_size();
+		queue_redraw();
 	}
 }
 
@@ -485,8 +495,8 @@ String Button::get_language() const {
 void Button::set_icon(const Ref<Texture2D> &p_icon) {
 	if (icon != p_icon) {
 		icon = p_icon;
-		queue_redraw();
 		update_minimum_size();
+		queue_redraw();
 	}
 }
 
@@ -497,8 +507,8 @@ Ref<Texture2D> Button::get_icon() const {
 void Button::set_expand_icon(bool p_enabled) {
 	if (expand_icon != p_enabled) {
 		expand_icon = p_enabled;
-		queue_redraw();
 		update_minimum_size();
+		queue_redraw();
 	}
 }
 
@@ -520,8 +530,8 @@ bool Button::is_flat() const {
 void Button::set_clip_text(bool p_enabled) {
 	if (clip_text != p_enabled) {
 		clip_text = p_enabled;
-		queue_redraw();
 		update_minimum_size();
+		queue_redraw();
 	}
 }
 
@@ -550,6 +560,16 @@ HorizontalAlignment Button::get_icon_alignment() const {
 	return icon_alignment;
 }
 
+void Button::set_icon_height(int p_height) {
+	icon_set_height = p_height;
+	update_minimum_size();
+	queue_redraw();
+}
+
+int Button::get_icon_height() const {
+	return icon_set_height;
+}
+
 void Button::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_text", "text"), &Button::set_text);
 	ClassDB::bind_method(D_METHOD("get_text"), &Button::get_text);
@@ -571,6 +591,8 @@ void Button::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_icon_alignment"), &Button::get_icon_alignment);
 	ClassDB::bind_method(D_METHOD("set_expand_icon", "enabled"), &Button::set_expand_icon);
 	ClassDB::bind_method(D_METHOD("is_expand_icon"), &Button::is_expand_icon);
+	ClassDB::bind_method(D_METHOD("set_icon_height", "icon_height"), &Button::set_icon_height);
+	ClassDB::bind_method(D_METHOD("get_icon_height"), &Button::get_icon_height);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "text", PROPERTY_HINT_MULTILINE_TEXT), "set_text", "get_text");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_button_icon", "get_button_icon");
@@ -584,6 +606,7 @@ void Button::_bind_methods() {
 	ADD_GROUP("Icon Behavior", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "icon_alignment", PROPERTY_HINT_ENUM, "Left,Center,Right"), "set_icon_alignment", "get_icon_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "expand_icon"), "set_expand_icon", "is_expand_icon");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "icon_height", PROPERTY_HINT_NONE, "suffix:px"), "set_icon_height", "get_icon_height");
 
 	ADD_GROUP("BiDi", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_direction", PROPERTY_HINT_ENUM, "Auto,Left-to-Right,Right-to-Left,Inherited"), "set_text_direction", "get_text_direction");

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -49,6 +49,7 @@ private:
 
 	Ref<Texture2D> icon;
 	bool expand_icon = false;
+	int icon_set_height = 0;
 	bool clip_text = false;
 	HorizontalAlignment alignment = HORIZONTAL_ALIGNMENT_CENTER;
 	HorizontalAlignment icon_alignment = HORIZONTAL_ALIGNMENT_LEFT;
@@ -121,6 +122,9 @@ public:
 
 	void set_expand_icon(bool p_enabled);
 	bool is_expand_icon() const;
+
+	void set_icon_height(int p_height);
+	int get_icon_height() const;
 
 	void set_flat(bool p_enabled);
 	bool is_flat() const;


### PR DESCRIPTION
Sets the `Button` icon height regardless of the button height, so you don't have to carefully tune the button height to get the icon size desired.

For HiDPI multi-display window dragging, it makes it easy to configure button icons that look identical but at a higher resolution when transitioning from 1X to 2X displays. This is done by importing an SVG icon and setting the scale to 2X, then using the new `icon_height` property, set the height to the original size, i.e. 16, which will look correct on the 1X display. If the window is dragged onto a HiDPI display, the button will then use the 32-pixel resolution.

If the button's `expand_icon` property is enabled, `icon_height` sets the maximum height of the icon if not set to `0`. If `expand_icon` is _not_ enabled, `icon_height` sets the fixed height for the icon.
