### PR TITLE
Change @export_range example values to be more obviously degrees.

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -530,7 +530,7 @@
 				@export_range(0, 100, 1, "or_greater") var power_percent
 				@export_range(0, 100, 1, "or_greater", "or_less") var health_delta
 
-				@export_range(-3.14, 3.14, 0.001, "radians") var angle_radians
+				@export_range(-180, 180, 1, "radians") var angle_radians
 				@export_range(0, 360, 1, "degrees") var angle_degrees
 				@export_range(-8, 8, 2, "suffix:px") var target_offset
 				[/codeblock]


### PR DESCRIPTION
This is a tiny change to the example values (which appear to be in radians, even though degrees are expected). The new values, `-180, 180` should be more obviously in degrees.

Fixes #73170