### PR TITLE
Fix `tween_method()` type validation

### DIFF
--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -47,6 +47,7 @@ public:
 
 protected:
 	static void _bind_methods();
+
 	Ref<Tween> tween;
 	double elapsed_time = 0;
 	bool finished = false;
@@ -125,6 +126,7 @@ private:
 
 	void _start_tweeners();
 	void _stop_internal(bool p_reset);
+	bool _validate_type_match(const Variant &p_from, Variant &r_to);
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Fixes #72808

`tween_method()` will now validate types and auto-convert between int and float, just like `tween_property()`.