### PR TITLE
Fix PhysicsDirectSpaceState3D `collide_shape` return type

### DIFF
--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -21,7 +21,7 @@
 			</description>
 		</method>
 		<method name="collide_shape">
-			<return type="PackedVector2Array[]" />
+			<return type="PackedVector3Array[]" />
 			<param index="0" name="parameters" type="PhysicsShapeQueryParameters3D" />
 			<param index="1" name="max_results" type="int" default="32" />
 			<description>

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -429,7 +429,7 @@ Vector<real_t> PhysicsDirectSpaceState3D::_cast_motion(const Ref<PhysicsShapeQue
 	return ret;
 }
 
-TypedArray<PackedVector2Array> PhysicsDirectSpaceState3D::_collide_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results) {
+TypedArray<PackedVector3Array> PhysicsDirectSpaceState3D::_collide_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results) {
 	ERR_FAIL_COND_V(!p_shape_query.is_valid(), Array());
 
 	Vector<Vector3> ret;
@@ -437,9 +437,9 @@ TypedArray<PackedVector2Array> PhysicsDirectSpaceState3D::_collide_shape(const R
 	int rc = 0;
 	bool res = collide_shape(p_shape_query->get_parameters(), ret.ptrw(), p_max_results, rc);
 	if (!res) {
-		return TypedArray<PackedVector2Array>();
+		return TypedArray<PackedVector3Array>();
 	}
-	TypedArray<PackedVector2Array> r;
+	TypedArray<PackedVector3Array> r;
 	r.resize(rc * 2);
 	for (int i = 0; i < rc * 2; i++) {
 		r[i] = ret[i];

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -125,7 +125,7 @@ private:
 	TypedArray<Dictionary> _intersect_point(const Ref<PhysicsPointQueryParameters3D> &p_point_query, int p_max_results = 32);
 	TypedArray<Dictionary> _intersect_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results = 32);
 	Vector<real_t> _cast_motion(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query);
-	TypedArray<PackedVector2Array> _collide_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results = 32);
+	TypedArray<PackedVector3Array> _collide_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results = 32);
 	Dictionary _get_rest_info(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query);
 
 protected:


### PR DESCRIPTION
Use the `PackedVector3Array` return type for the 3D `collide_shape` method as that seems to be what it's actually returning. 

I'm not sure if I should update the [PhysicsDirectSpaceState3DExtension docs](https://github.com/godotengine/godot/blob/master/doc/classes/PhysicsDirectSpaceState3DExtension.xml#L34) that reference `"void*"`? But I've updated PhysicsDirectSpaceState3D docs anyway.

I feel it was a find a replace error in https://github.com/godotengine/godot/pull/64009. Let me know if this is totally wrong!

---

Fixes: https://github.com/godotengine/godot/issues/73182