### PR TITLE
Fix jumping to function definition using `Ctrl+LMB` or the "Lookup Symbol" button

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -237,10 +237,18 @@
 				Returns the full text with char [code]0xFFFF[/code] at the caret location.
 			</description>
 		</method>
-		<method name="get_text_for_symbol_lookup">
+		<method name="get_text_for_symbol_lookup" qualifiers="const">
 			<return type="String" />
 			<description>
 				Returns the full text with char [code]0xFFFF[/code] at the cursor location.
+			</description>
+		</method>
+		<method name="get_text_with_cursor_char" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="line" type="int" />
+			<param index="1" name="column" type="int" />
+			<description>
+				Returns the full text with char [code]0xFFFF[/code] at the specified location.
 			</description>
 		</method>
 		<method name="has_auto_brace_completion_close_key" qualifiers="const">

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -814,6 +814,8 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 	}
 
 	ScriptLanguage::LookupResult result;
+	String code_text = code_editor->get_text_editor()->get_text_with_cursor_char(p_row, p_column);
+	Error lc_error = script->get_language()->lookup_code(code_text, p_symbol, script->get_path(), base, result);
 	if (ScriptServer::is_global_class(p_symbol)) {
 		EditorNode::get_singleton()->load_resource(ScriptServer::get_global_class_path(p_symbol));
 	} else if (p_symbol.is_resource_file()) {
@@ -826,7 +828,7 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 			EditorNode::get_singleton()->load_resource(p_symbol);
 		}
 
-	} else if (script->get_language()->lookup_code(code_editor->get_text_editor()->get_text_for_symbol_lookup(), p_symbol, script->get_path(), base, result) == OK) {
+	} else if (lc_error == OK) {
 		_goto_line(p_row);
 
 		switch (result.type) {
@@ -947,7 +949,10 @@ void ScriptTextEditor::_validate_symbol(const String &p_symbol) {
 	}
 
 	ScriptLanguage::LookupResult result;
-	if (ScriptServer::is_global_class(p_symbol) || p_symbol.is_resource_file() || script->get_language()->lookup_code(code_editor->get_text_editor()->get_text_for_symbol_lookup(), p_symbol, script->get_path(), base, result) == OK || (ProjectSettings::get_singleton()->has_autoload(p_symbol) && ProjectSettings::get_singleton()->get_autoload(p_symbol).is_singleton)) {
+	String lc_text = code_editor->get_text_editor()->get_text_for_symbol_lookup();
+	Error lc_error = script->get_language()->lookup_code(lc_text, p_symbol, script->get_path(), base, result);
+	bool is_singleton = ProjectSettings::get_singleton()->has_autoload(p_symbol) && ProjectSettings::get_singleton()->get_autoload(p_symbol).is_singleton;
+	if (ScriptServer::is_global_class(p_symbol) || p_symbol.is_resource_file() || lc_error == OK || is_singleton) {
 		text_edit->set_symbol_lookup_word_as_valid(true);
 	} else if (p_symbol.is_relative_path()) {
 		String path = _get_absolute_path(p_symbol);
@@ -1827,7 +1832,7 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 		bool open_docs = false;
 		bool goto_definition = false;
 
-		if (word_at_pos.is_resource_file()) {
+		if (ScriptServer::is_global_class(word_at_pos) || word_at_pos.is_resource_file()) {
 			open_docs = true;
 		} else {
 			Node *base = get_tree()->get_edited_scene_root();

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1401,11 +1401,11 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 			} break;
 			case GDScriptParser::Node::SELF: {
 				if (p_context.current_class) {
-					r_type.type.kind = GDScriptParser::DataType::CLASS;
-					r_type.type.type_source = GDScriptParser::DataType::INFERRED;
-					r_type.type.is_constant = true;
-					r_type.type.class_type = p_context.current_class;
-					r_type.value = p_context.base;
+					if (p_context.type != GDScriptParser::COMPLETION_SUPER_METHOD) {
+						r_type.type = p_context.current_class->get_datatype();
+					} else {
+						r_type.type = p_context.current_class->base_type;
+					}
 					found = true;
 				}
 			} break;

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2105,9 +2105,8 @@ bool CodeEdit::is_symbol_lookup_on_click_enabled() const {
 	return symbol_lookup_on_click_enabled;
 }
 
-String CodeEdit::get_text_for_symbol_lookup() {
+String CodeEdit::get_text_for_symbol_lookup() const {
 	Point2i mp = get_local_mouse_pos();
-
 	Point2i pos = get_line_column_at_pos(mp, false);
 	int line = pos.y;
 	int col = pos.x;
@@ -2116,25 +2115,29 @@ String CodeEdit::get_text_for_symbol_lookup() {
 		return String();
 	}
 
-	StringBuilder lookup_text;
+	return get_text_with_cursor_char(line, col);
+}
+
+String CodeEdit::get_text_with_cursor_char(int p_line, int p_column) const {
 	const int text_size = get_line_count();
+	StringBuilder result;
 	for (int i = 0; i < text_size; i++) {
 		String line_text = get_line(i);
-
-		if (i == line) {
-			lookup_text += line_text.substr(0, col);
+		if (i == p_line && p_column >= 0 && p_column <= line_text.size()) {
+			result += line_text.substr(0, p_column);
 			/* Not unicode, represents the cursor. */
-			lookup_text += String::chr(0xFFFF);
-			lookup_text += line_text.substr(col, line_text.size());
+			result += String::chr(0xFFFF);
+			result += line_text.substr(p_column, line_text.size());
 		} else {
-			lookup_text += line_text;
+			result += line_text;
 		}
 
 		if (i != text_size - 1) {
-			lookup_text += "\n";
+			result += "\n";
 		}
 	}
-	return lookup_text.as_string();
+
+	return result.as_string();
 }
 
 void CodeEdit::set_symbol_lookup_word_as_valid(bool p_valid) {
@@ -2312,6 +2315,7 @@ void CodeEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_symbol_lookup_on_click_enabled"), &CodeEdit::is_symbol_lookup_on_click_enabled);
 
 	ClassDB::bind_method(D_METHOD("get_text_for_symbol_lookup"), &CodeEdit::get_text_for_symbol_lookup);
+	ClassDB::bind_method(D_METHOD("get_text_with_cursor_char", "line", "column"), &CodeEdit::get_text_with_cursor_char);
 
 	ClassDB::bind_method(D_METHOD("set_symbol_lookup_word_as_valid", "valid"), &CodeEdit::set_symbol_lookup_word_as_valid);
 

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -424,7 +424,8 @@ public:
 	void set_symbol_lookup_on_click_enabled(bool p_enabled);
 	bool is_symbol_lookup_on_click_enabled() const;
 
-	String get_text_for_symbol_lookup();
+	String get_text_for_symbol_lookup() const;
+	String get_text_with_cursor_char(int p_line, int p_column) const;
 
 	void set_symbol_lookup_word_as_valid(bool p_valid);
 


### PR DESCRIPTION
Fixes #72353.
Fixes #73167.
Fixes #73480.

I found the cause of bug #73167. The problem is that when we click on the `Lookup Symbol` button in the context menu, the method `String CodeEdit::get_text_for_symbol_lookup()` returns position of cursor which is located on the `Lookup Symbol` and wrong for code parsing.

![bug](https://user-images.githubusercontent.com/96838551/218628996-2c1bbc55-81ed-4760-ac35-dea94f7633a1.png)

Such a bug found in the `3.5.1.stable` too.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
