### PR TITLE
Fix the issue causing long-press on a selected node on the scene tree to trigger both the context menu and the rename functionality

### DIFF
--- a/platform/android/android_input_handler.cpp
+++ b/platform/android/android_input_handler.cpp
@@ -129,13 +129,22 @@ void AndroidInputHandler::process_key_event(int p_physical_keycode, int p_unicod
 	Input::get_singleton()->parse_input_event(ev);
 }
 
-void AndroidInputHandler::_parse_all_touch(bool p_pressed, bool p_double_tap) {
+void AndroidInputHandler::_cancel_all_touch() {
+	_parse_all_touch(false, false, true);
+	touch.clear();
+}
+
+void AndroidInputHandler::_parse_all_touch(bool p_pressed, bool p_double_tap, bool reset_index) {
 	if (touch.size()) {
 		//end all if exist
 		for (int i = 0; i < touch.size(); i++) {
 			Ref<InputEventScreenTouch> ev;
 			ev.instantiate();
-			ev->set_index(touch[i].id);
+			if (reset_index) {
+				ev->set_index(-1);
+			} else {
+				ev->set_index(touch[i].id);
+			}
 			ev->set_pressed(p_pressed);
 			ev->set_position(touch[i].pos);
 			ev->set_double_tap(p_double_tap);
@@ -196,7 +205,9 @@ void AndroidInputHandler::process_touch_event(int p_event, int p_pointer, const 
 			}
 
 		} break;
-		case AMOTION_EVENT_ACTION_CANCEL:
+		case AMOTION_EVENT_ACTION_CANCEL: {
+			_cancel_all_touch();
+		} break;
 		case AMOTION_EVENT_ACTION_UP: { //release
 			_release_all_touch();
 		} break;
@@ -234,6 +245,12 @@ void AndroidInputHandler::process_touch_event(int p_event, int p_pointer, const 
 			}
 		} break;
 	}
+}
+
+void AndroidInputHandler::_cancel_mouse_event_info(bool p_source_mouse_relative) {
+	buttons_state = BitField<MouseButtonMask>();
+	_parse_mouse_event_info(BitField<MouseButtonMask>(), false, false, p_source_mouse_relative);
+	mouse_event_info.valid = false;
 }
 
 void AndroidInputHandler::_parse_mouse_event_info(BitField<MouseButtonMask> event_buttons_mask, bool p_pressed, bool p_double_click, bool p_source_mouse_relative) {
@@ -296,8 +313,11 @@ void AndroidInputHandler::process_mouse_event(int p_event_action, int p_event_an
 			_parse_mouse_event_info(event_buttons_mask, true, p_double_click, p_source_mouse_relative);
 		} break;
 
+		case AMOTION_EVENT_ACTION_CANCEL: {
+			_cancel_mouse_event_info(p_source_mouse_relative);
+		} break;
+
 		case AMOTION_EVENT_ACTION_UP:
-		case AMOTION_EVENT_ACTION_CANCEL:
 		case AMOTION_EVENT_ACTION_BUTTON_RELEASE: {
 			_release_mouse_event_info(p_source_mouse_relative);
 		} break;

--- a/platform/android/android_input_handler.h
+++ b/platform/android/android_input_handler.h
@@ -87,9 +87,13 @@ private:
 
 	void _release_mouse_event_info(bool p_source_mouse_relative = false);
 
-	void _parse_all_touch(bool p_pressed, bool p_double_tap);
+	void _cancel_mouse_event_info(bool p_source_mouse_relative = false);
+
+	void _parse_all_touch(bool p_pressed, bool p_double_tap, bool reset_index = false);
 
 	void _release_all_touch();
+
+	void _cancel_all_touch();
 
 public:
 	void process_mouse_event(int p_event_action, int p_event_android_buttons_mask, Point2 p_event_pos, Vector2 p_delta, bool p_double_click, bool p_source_mouse_relative);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/6273

[3.x version](https://github.com/godotengine/godot/pull/73199)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
