### PR TITLE
[3.x] Fix the issue causing long-press on a selected node on the scene tree to trigger both the context menu and the rename functionality

### DIFF
--- a/platform/android/android_input_handler.h
+++ b/platform/android/android_input_handler.h
@@ -90,9 +90,13 @@ private:
 
 	void _release_mouse_event_info(bool p_source_mouse_relative = false);
 
-	void _parse_all_touch(bool p_pressed, bool p_double_tap);
+	void _cancel_mouse_event_info(bool p_source_mouse_relative = false);
+
+	void _parse_all_touch(bool p_pressed, bool p_double_tap, bool reset_index = false);
 
 	void _release_all_touch();
+
+	void _cancel_all_touch();
 
 public:
 	void process_joy_event(const JoypadEvent &p_event);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/6273

[main version](https://github.com/godotengine/godot/pull/73197)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
