### PR TITLE
Fix guide button detection with XInput and Xbox Series controllers

### DIFF
--- a/core/input/godotcontrollerdb.txt
+++ b/core/input/godotcontrollerdb.txt
@@ -2,7 +2,7 @@
 # Source: https://github.com/godotengine/godot
 
 # Windows
-__XINPUT_DEVICE__,XInput Gamepad,a:b12,b:b13,x:b14,y:b15,start:b4,back:b5,leftstick:b6,rightstick:b7,leftshoulder:b8,rightshoulder:b9,dpup:b0,dpdown:b1,dpleft:b2,dpright:b3,leftx:a0,lefty:a1,rightx:a2,righty:a3,lefttrigger:a4,righttrigger:a5,platform:Windows,
+__XINPUT_DEVICE__,XInput Gamepad,a:b12,b:b13,x:b14,y:b15,start:b4,guide:b10,back:b5,leftstick:b6,rightstick:b7,leftshoulder:b8,rightshoulder:b9,dpup:b0,dpdown:b1,dpleft:b2,dpright:b3,leftx:a0,lefty:a1,rightx:a2,righty:a3,lefttrigger:a4,righttrigger:a5,platform:Windows,
 
 # Android
 Default Android Gamepad,Default Controller,leftx:a0,lefty:a1,dpdown:h0.4,rightstick:b8,rightshoulder:b10,rightx:a2,start:b6,righty:a3,dpleft:h0.8,lefttrigger:a4,x:b2,dpup:h0.1,back:b4,leftstick:b7,leftshoulder:b9,y:b3,a:b0,dpright:h0.2,righttrigger:a5,b:b1,platform:Android,

--- a/platform/windows/joypad_windows.cpp
+++ b/platform/windows/joypad_windows.cpp
@@ -516,11 +516,13 @@ void JoypadWindows::joypad_vibration_stop_xinput(int p_device, uint64_t p_timest
 void JoypadWindows::load_xinput() {
 	xinput_get_state = &_xinput_get_state;
 	xinput_set_state = &_xinput_set_state;
+	bool legacy_xinput = false;
 	xinput_dll = LoadLibrary("XInput1_4.dll");
 	if (!xinput_dll) {
 		xinput_dll = LoadLibrary("XInput1_3.dll");
 		if (!xinput_dll) {
 			xinput_dll = LoadLibrary("XInput9_1_0.dll");
+			legacy_xinput = true;
 		}
 	}
 
@@ -529,7 +531,9 @@ void JoypadWindows::load_xinput() {
 		return;
 	}
 
-	XInputGetState_t func = (XInputGetState_t)GetProcAddress((HMODULE)xinput_dll, "XInputGetState");
+	// (LPCSTR)100 is the magic number to get XInputGetStateEx, which also provides the state for the guide button
+	LPCSTR get_state_func_name = legacy_xinput ? "XInputGetState" : (LPCSTR)100;
+	XInputGetState_t func = (XInputGetState_t)GetProcAddress((HMODULE)xinput_dll, get_state_func_name);
 	XInputSetState_t set_func = (XInputSetState_t)GetProcAddress((HMODULE)xinput_dll, "XInputSetState");
 	if (!func || !set_func) {
 		unload_xinput();


### PR DESCRIPTION
This PR lets Godot detect the guide button when running on windows and using the XInput API.
Changes the call of the XInputGetState function with some undocumented function that returns the same thing, but with an extra bit that corresponds to the guide button state. 
see https://github.com/higan-emu/higan/blob/master/ruby/input/joypad/xinput.cpp as an example for another place where they use the undocumented feature 
I think this feels kinda hacky, so let me know if I should fix it with better naming, some documentation comments or maybe put it behind a compile flag. 

The PR also adds the guide button to the controller db for the Xbox Series gamepad (maybe works with others, didn't test)