### PR TITLE
Fix 2D navigation debug visuals ignoring half the ProjectSettings

### DIFF
--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -167,58 +167,78 @@ void NavigationRegion2D::_notification(int p_what) {
 
 		case NOTIFICATION_DRAW: {
 #ifdef DEBUG_ENABLED
-			if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || NavigationServer3D::get_singleton()->get_debug_enabled()) && navigation_polygon.is_valid()) {
-				Vector<Vector2> verts = navigation_polygon->get_vertices();
-				if (verts.size() < 3) {
+			if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || NavigationServer2D::get_singleton()->get_debug_enabled()) && navigation_polygon.is_valid()) {
+				Vector<Vector2> navigation_polygon_vertices = navigation_polygon->get_vertices();
+				if (navigation_polygon_vertices.size() < 3) {
 					return;
 				}
 
-				Color color;
-				if (enabled) {
-					color = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_color();
-				} else {
-					color = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_disabled_color();
+				const NavigationServer2D *ns2d = NavigationServer2D::get_singleton();
+
+				bool enabled_geometry_face_random_color = ns2d->get_debug_navigation_enable_geometry_face_random_color();
+				bool enabled_edge_lines = ns2d->get_debug_navigation_enable_edge_lines();
+				bool enable_edge_connections = ns2d->get_debug_navigation_enable_edge_connections();
+
+				Color debug_face_color = ns2d->get_debug_navigation_geometry_face_color();
+				Color debug_edge_color = ns2d->get_debug_navigation_geometry_edge_color();
+				Color debug_edge_connection_color = ns2d->get_debug_navigation_edge_connection_color();
+
+				if (!enabled) {
+					debug_face_color = ns2d->get_debug_navigation_geometry_face_disabled_color();
+					debug_edge_color = ns2d->get_debug_navigation_geometry_edge_disabled_color();
 				}
-				Color doors_color = NavigationServer3D::get_singleton()->get_debug_navigation_edge_connection_color();
 
 				RandomPCG rand;
 
 				for (int i = 0; i < navigation_polygon->get_polygon_count(); i++) {
 					// An array of vertices for this polygon.
 					Vector<int> polygon = navigation_polygon->get_polygon(i);
-					Vector<Vector2> vertices;
-					vertices.resize(polygon.size());
+					Vector<Vector2> debug_polygon_vertices;
+					debug_polygon_vertices.resize(polygon.size());
 					for (int j = 0; j < polygon.size(); j++) {
-						ERR_FAIL_INDEX(polygon[j], verts.size());
-						vertices.write[j] = verts[polygon[j]];
+						ERR_FAIL_INDEX(polygon[j], navigation_polygon_vertices.size());
+						debug_polygon_vertices.write[j] = navigation_polygon_vertices[polygon[j]];
 					}
 
 					// Generate the polygon color, slightly randomly modified from the settings one.
-					Color random_variation_color;
-					random_variation_color.set_hsv(color.get_h() + rand.random(-1.0, 1.0) * 0.1, color.get_s(), color.get_v() + rand.random(-1.0, 1.0) * 0.2);
-					random_variation_color.a = color.a;
-					Vector<Color> colors;
-					colors.push_back(random_variation_color);
+					Color random_variation_color = debug_face_color;
+					if (enabled_geometry_face_random_color) {
+						random_variation_color.set_hsv(
+								debug_face_color.get_h() + rand.random(-1.0, 1.0) * 0.1,
+								debug_face_color.get_s(),
+								debug_face_color.get_v() + rand.random(-1.0, 1.0) * 0.2);
+					}
+					random_variation_color.a = debug_face_color.a;
 
-					RS::get_singleton()->canvas_item_add_polygon(get_canvas_item(), vertices, colors);
+					Vector<Color> debug_face_colors;
+					debug_face_colors.push_back(random_variation_color);
+					RS::get_singleton()->canvas_item_add_polygon(get_canvas_item(), debug_polygon_vertices, debug_face_colors);
+
+					if (enabled_edge_lines) {
+						Vector<Color> debug_edge_colors;
+						debug_edge_colors.push_back(debug_edge_color);
+						debug_polygon_vertices.push_back(debug_polygon_vertices[0]); // Add first again for closing polyline.
+						RS::get_singleton()->canvas_item_add_polyline(get_canvas_item(), debug_polygon_vertices, debug_edge_colors);
+					}
 				}
 
-				// Draw the region
-				Transform2D xform = get_global_transform();
-				const NavigationServer2D *ns = NavigationServer2D::get_singleton();
-				real_t radius = ns->map_get_edge_connection_margin(get_world_2d()->get_navigation_map()) / 2.0;
-				for (int i = 0; i < ns->region_get_connections_count(region); i++) {
-					// Two main points
-					Vector2 a = ns->region_get_connection_pathway_start(region, i);
-					a = xform.affine_inverse().xform(a);
-					Vector2 b = ns->region_get_connection_pathway_end(region, i);
-					b = xform.affine_inverse().xform(b);
-					draw_line(a, b, doors_color);
+				if (enable_edge_connections) {
+					// Draw the region edge connections.
+					Transform2D xform = get_global_transform();
+					real_t radius = ns2d->map_get_edge_connection_margin(get_world_2d()->get_navigation_map()) / 2.0;
+					for (int i = 0; i < ns2d->region_get_connections_count(region); i++) {
+						// Two main points
+						Vector2 a = ns2d->region_get_connection_pathway_start(region, i);
+						a = xform.affine_inverse().xform(a);
+						Vector2 b = ns2d->region_get_connection_pathway_end(region, i);
+						b = xform.affine_inverse().xform(b);
+						draw_line(a, b, debug_edge_connection_color);
 
-					// Draw a circle to illustrate the margins.
-					real_t angle = a.angle_to_point(b);
-					draw_arc(a, radius, angle + Math_PI / 2.0, angle - Math_PI / 2.0 + Math_TAU, 10, doors_color);
-					draw_arc(b, radius, angle - Math_PI / 2.0, angle + Math_PI / 2.0, 10, doors_color);
+						// Draw a circle to illustrate the margins.
+						real_t angle = a.angle_to_point(b);
+						draw_arc(a, radius, angle + Math_PI / 2.0, angle - Math_PI / 2.0 + Math_TAU, 10, debug_edge_connection_color);
+						draw_arc(b, radius, angle - Math_PI / 2.0, angle + Math_PI / 2.0, 10, debug_edge_connection_color);
+					}
 				}
 			}
 #endif // DEBUG_ENABLED

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -200,12 +200,44 @@ Color NavigationServer2D::get_debug_navigation_link_connection_disabled_color() 
 	return NavigationServer3D::get_singleton()->get_debug_navigation_link_connection_disabled_color();
 }
 
+void NavigationServer2D::set_debug_navigation_geometry_edge_color(const Color &p_color) {
+	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_edge_color(p_color);
+}
+
+Color NavigationServer2D::get_debug_navigation_geometry_edge_color() const {
+	return NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_color();
+}
+
+void NavigationServer2D::set_debug_navigation_geometry_edge_disabled_color(const Color &p_color) {
+	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_edge_disabled_color(p_color);
+}
+
+Color NavigationServer2D::get_debug_navigation_geometry_edge_disabled_color() const {
+	return NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_disabled_color();
+}
+
 void NavigationServer2D::set_debug_navigation_enable_edge_connections(const bool p_value) {
 	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_connections(p_value);
 }
 
 bool NavigationServer2D::get_debug_navigation_enable_edge_connections() const {
 	return NavigationServer3D::get_singleton()->get_debug_navigation_enable_edge_connections();
+}
+
+void NavigationServer2D::set_debug_navigation_enable_geometry_face_random_color(const bool p_value) {
+	NavigationServer3D::get_singleton()->set_debug_navigation_enable_geometry_face_random_color(p_value);
+}
+
+bool NavigationServer2D::get_debug_navigation_enable_geometry_face_random_color() const {
+	return NavigationServer3D::get_singleton()->get_debug_navigation_enable_geometry_face_random_color();
+}
+
+void NavigationServer2D::set_debug_navigation_enable_edge_lines(const bool p_value) {
+	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_lines(p_value);
+}
+
+bool NavigationServer2D::get_debug_navigation_enable_edge_lines() const {
+	return NavigationServer3D::get_singleton()->get_debug_navigation_enable_edge_lines();
 }
 
 void NavigationServer2D::set_debug_navigation_agent_path_color(const Color &p_color) {

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -247,6 +247,12 @@ public:
 	void set_debug_navigation_geometry_face_disabled_color(const Color &p_color);
 	Color get_debug_navigation_geometry_face_disabled_color() const;
 
+	void set_debug_navigation_geometry_edge_color(const Color &p_color);
+	Color get_debug_navigation_geometry_edge_color() const;
+
+	void set_debug_navigation_geometry_edge_disabled_color(const Color &p_color);
+	Color get_debug_navigation_geometry_edge_disabled_color() const;
+
 	void set_debug_navigation_link_connection_color(const Color &p_color);
 	Color get_debug_navigation_link_connection_color() const;
 
@@ -255,6 +261,12 @@ public:
 
 	void set_debug_navigation_enable_edge_connections(const bool p_value);
 	bool get_debug_navigation_enable_edge_connections() const;
+
+	void set_debug_navigation_enable_geometry_face_random_color(const bool p_value);
+	bool get_debug_navigation_enable_geometry_face_random_color() const;
+
+	void set_debug_navigation_enable_edge_lines(const bool p_value);
+	bool get_debug_navigation_enable_edge_lines() const;
 
 	void set_debug_navigation_agent_path_color(const Color &p_color);
 	Color get_debug_navigation_agent_path_color() const;


### PR DESCRIPTION
Fixes that NavigationRegion2D and TileMap debug visuals ignored more or less half the ProjectSettings.

E.g. mesh random face color could not be disabled, mesh edges did not display, edge connections were always enabled, ...

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
