### PR TITLE
Update PCK embedding SCons warning message to mention mold linker

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -346,7 +346,7 @@ def configure(env: "Environment"):
         gnu_ld_version = re.search("^GNU ld [^$]*(\d+\.\d+)$", linker_version_str, re.MULTILINE)
         if not gnu_ld_version:
             print(
-                "Warning: Creating template binaries enabled for PCK embedding is currently only supported with GNU ld, not gold or LLD."
+                "Warning: Creating export template binaries enabled for PCK embedding is currently only supported with GNU ld, not gold, LLD or mold."
             )
         else:
             if float(gnu_ld_version.group(1)) >= 2.30:


### PR DESCRIPTION
mold is now part of the SCons `linker` option.
