### PR TITLE
Register `EditorExportPlatform` derived types for scripting

### DIFF
--- a/doc/classes/EditorExportPlatformAndroid.xml
+++ b/doc/classes/EditorExportPlatformAndroid.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorExportPlatformAndroid" inherits="EditorExportPlatform" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Identifies the Android export platform.
+	</brief_description>
+	<description>
+		Resource that provides the functionality of exporting a release build of a project to the Android platform, from the editor.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/EditorExportPlatformIOS.xml
+++ b/doc/classes/EditorExportPlatformIOS.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorExportPlatformIOS" inherits="EditorExportPlatform" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Identifies the iOS export platform.
+	</brief_description>
+	<description>
+		Resource that provides the functionality of exporting a release build of a project to the iOS platform, from the editor.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/EditorExportPlatformLinuxBSD.xml
+++ b/doc/classes/EditorExportPlatformLinuxBSD.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorExportPlatformLinuxBSD" inherits="EditorExportPlatformPC" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Identifies the LinuxBSD export platform.
+	</brief_description>
+	<description>
+		Resource that provides the functionality of exporting a release build of a project to the LinuxBSD platform, from the editor.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/EditorExportPlatformMacOS.xml
+++ b/doc/classes/EditorExportPlatformMacOS.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorExportPlatformMacOS" inherits="EditorExportPlatform" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Identifies the MacOS export platform.
+	</brief_description>
+	<description>
+		Resource that provides the functionality of exporting a release build of a project to the MacOS platform, from the editor.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/EditorExportPlatformPC.xml
+++ b/doc/classes/EditorExportPlatformPC.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorExportPlatformPC" inherits="EditorExportPlatform" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Identifies PC export platforms.
+	</brief_description>
+	<description>
+		Base resource that provides the functionality of exporting a release build of a project to a PC platform, from the editor.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/EditorExportPlatformUWP.xml
+++ b/doc/classes/EditorExportPlatformUWP.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorExportPlatformUWP" inherits="EditorExportPlatform" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Identifies the UWP export platform.
+	</brief_description>
+	<description>
+		Resource that provides the functionality of exporting a release build of a project to the UWP platform, from the editor.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/EditorExportPlatformWeb.xml
+++ b/doc/classes/EditorExportPlatformWeb.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorExportPlatformWeb" inherits="EditorExportPlatform" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Identifies the web export platform.
+	</brief_description>
+	<description>
+		Resource that provides the functionality of exporting a release build of a project to the web platform, from the editor.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/EditorExportPlatformWindows.xml
+++ b/doc/classes/EditorExportPlatformWindows.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorExportPlatformWindows" inherits="EditorExportPlatformPC" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Identifies the Windows export platform.
+	</brief_description>
+	<description>
+		Resource that provides the functionality of exporting a release build of a project to the Windows platform, from the editor.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -106,6 +106,14 @@
 #include "editor/plugins/version_control_editor_plugin.h"
 #include "editor/plugins/visual_shader_editor_plugin.h"
 #include "editor/plugins/voxel_gi_editor_plugin.h"
+#include "export/export_plugin.h"
+#include "platform/android/export/export_plugin.h"
+#include "platform/ios/export/export_plugin.h"
+#include "platform/linuxbsd/export/export_plugin.h"
+#include "platform/macos/export/export_plugin.h"
+#include "platform/uwp/export/export_plugin.h"
+#include "platform/web/export/export_plugin.h"
+#include "platform/windows/export/export_plugin.h"
 
 void register_editor_types() {
 	ResourceLoader::set_timestamp_on_load(true);
@@ -132,6 +140,14 @@ void register_editor_types() {
 	GDREGISTER_ABSTRACT_CLASS(EditorInterface);
 	GDREGISTER_CLASS(EditorExportPlugin);
 	GDREGISTER_ABSTRACT_CLASS(EditorExportPlatform);
+	GDREGISTER_ABSTRACT_CLASS(EditorExportPlatformAndroid);
+	GDREGISTER_ABSTRACT_CLASS(EditorExportPlatformIOS);
+	GDREGISTER_ABSTRACT_CLASS(EditorExportPlatformMacOS);
+	GDREGISTER_ABSTRACT_CLASS(EditorExportPlatformUWP);
+	GDREGISTER_ABSTRACT_CLASS(EditorExportPlatformWeb);
+	GDREGISTER_ABSTRACT_CLASS(EditorExportPlatformPC);
+	GDREGISTER_ABSTRACT_CLASS(EditorExportPlatformLinuxBSD);
+	GDREGISTER_ABSTRACT_CLASS(EditorExportPlatformWindows);
 	GDREGISTER_CLASS(EditorResourceConversionPlugin);
 	GDREGISTER_CLASS(EditorSceneFormatImporter);
 	GDREGISTER_CLASS(EditorScenePostImportPlugin);

--- a/platform/linuxbsd/export/export_plugin.h
+++ b/platform/linuxbsd/export/export_plugin.h
@@ -37,6 +37,8 @@
 #include "scene/resources/texture.h"
 
 class EditorExportPlatformLinuxBSD : public EditorExportPlatformPC {
+	GDCLASS(EditorExportPlatformLinuxBSD, EditorExportPlatformPC);
+
 	HashMap<String, String> extensions;
 
 	struct SSHCleanupCommand {

--- a/platform/windows/export/export_plugin.h
+++ b/platform/windows/export/export_plugin.h
@@ -37,6 +37,8 @@
 #include "editor/export/editor_export_platform_pc.h"
 
 class EditorExportPlatformWindows : public EditorExportPlatformPC {
+	GDCLASS(EditorExportPlatformWindows, EditorExportPlatformPC);
+
 	struct SSHCleanupCommand {
 		String host;
 		String port;


### PR DESCRIPTION
`EditorExportPlugin._begin_customize_resources`, `EditorExportPlugin._begin_customize_scenes`, as well as #72895 have a `platform` parameter of type `EditorExportPlatform` that is intended to allow determining the platform an export targets, but the type has no members or derived types exposed for scripting, so it is actually completely useless (for scripting).

This PR exposes the derived types so that type checks on the platform parameter can be used to determine the current platform.

I am not sure if `GDREGISTER_ABSTRACT_CLASS` is the correct macro for types that can only be instantiated by the engine, but there does not appear to be a better one and things appear to be working just fine.