### PR TITLE
GDScript: Fix infer on read-only property

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1742,6 +1742,7 @@ void GDScriptAnalyzer::resolve_assignable(GDScriptParser::AssignableNode *p_assi
 	}
 
 	type.is_constant = is_constant;
+	type.is_read_only = false;
 	p_assignable->set_datatype(type);
 }
 


### PR DESCRIPTION
Variables inferring on read-only properties were mistakenly marked as such too. 

Fixes #73209.