### PR TITLE
Cleanup Window callbacks before destroying in to avoid callback calls with invalid object.

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -569,6 +569,12 @@ void Window::_update_from_window() {
 void Window::_clear_window() {
 	ERR_FAIL_COND(window_id == DisplayServer::INVALID_WINDOW_ID);
 
+	DisplayServer::get_singleton()->window_set_rect_changed_callback(Callable(), window_id);
+	DisplayServer::get_singleton()->window_set_window_event_callback(Callable(), window_id);
+	DisplayServer::get_singleton()->window_set_input_event_callback(Callable(), window_id);
+	DisplayServer::get_singleton()->window_set_input_text_callback(Callable(), window_id);
+	DisplayServer::get_singleton()->window_set_drop_files_callback(Callable(), window_id);
+
 	if (transient_parent && transient_parent->window_id != DisplayServer::INVALID_WINDOW_ID) {
 		DisplayServer::get_singleton()->window_set_transient(window_id, DisplayServer::INVALID_WINDOW_ID);
 	}


### PR DESCRIPTION
Native window deletion is not instant, and some late events might arrive to the deleted `Window` object if callback are still set.

Fixes https://github.com/godotengine/godot/issues/72707
