### PR TITLE
GDScript: Fix usage of ints with typed array of floats

### DIFF
--- a/core/variant/container_type_validate.h
+++ b/core/variant/container_type_validate.h
@@ -73,7 +73,7 @@ struct ContainerTypeValidate {
 		return type != p_type.type || class_name != p_type.class_name || script != p_type.script;
 	}
 
-	// Coerces String and StringName into each other when needed.
+	// Coerces String and StringName into each other and int into float when needed.
 	_FORCE_INLINE_ bool validate(Variant &inout_variant, const char *p_operation = "use") const {
 		if (type == Variant::NIL) {
 			return true;
@@ -88,6 +88,9 @@ struct ContainerTypeValidate {
 				return true;
 			} else if (type == Variant::STRING_NAME && inout_variant.get_type() == Variant::STRING) {
 				inout_variant = StringName(inout_variant);
+				return true;
+			} else if (type == Variant::FLOAT && inout_variant.get_type() == Variant::INT) {
+				inout_variant = (float)inout_variant;
 				return true;
 			}
 

--- a/modules/gdscript/tests/scripts/analyzer/features/typed_array_usage.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/typed_array_usage.gd
@@ -86,7 +86,8 @@ func test():
 
 	var typed_int := 556
 	var converted_floats: Array[float] = [typed_int]
-	assert(str(converted_floats) == '[556]')
+	converted_floats.push_back(498)
+	assert(str(converted_floats) == '[556, 498]')
 	assert(converted_floats.get_typed_builtin() == TYPE_FLOAT)
 
 


### PR DESCRIPTION
Allows using ints in method calls for typed array of floats.

Any other future desired conversions should be implemented in `ContainerTypeValidate::validate` too, it is used in 13 methods in `Array` so covers all bases. `String` <-> `StringName` was added there and the argument is `inout_variant` because of that (so it not only validates, but converts too).

Fixes #66789.
