### PR TITLE
Improve Image preview in the inspector

### DIFF
--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -152,11 +152,15 @@ TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
 }
 
 bool EditorInspectorPluginTexture::can_handle(Object *p_object) {
-	return Object::cast_to<ImageTexture>(p_object) != nullptr || Object::cast_to<AtlasTexture>(p_object) != nullptr || Object::cast_to<CompressedTexture2D>(p_object) != nullptr || Object::cast_to<AnimatedTexture>(p_object) != nullptr;
+	return Object::cast_to<ImageTexture>(p_object) != nullptr || Object::cast_to<AtlasTexture>(p_object) != nullptr || Object::cast_to<CompressedTexture2D>(p_object) != nullptr || Object::cast_to<AnimatedTexture>(p_object) != nullptr || Object::cast_to<Image>(p_object) != nullptr;
 }
 
 void EditorInspectorPluginTexture::parse_begin(Object *p_object) {
 	Ref<Texture> texture(Object::cast_to<Texture>(p_object));
+	if (texture.is_null()) {
+		Ref<Image> image(Object::cast_to<Image>(p_object));
+		texture = ImageTexture::create_from_image(image);
+	}
 
 	add_custom_control(memnew(TexturePreview(texture, true)));
 }


### PR DESCRIPTION
This PR reuses the texture inspector plugin to display images.
Before
![image](https://user-images.githubusercontent.com/2223172/218585022-c13d4be2-0070-4890-9438-69179ae08841.png)
After
![image](https://user-images.githubusercontent.com/2223172/218585031-f0784465-d64b-4852-9f97-c886956ca3c0.png)
