### PR TITLE
Fix navigation debug not toggleable in scripts

### DIFF
--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -126,6 +126,12 @@
 				Destroys the given RID.
 			</description>
 		</method>
+		<method name="get_debug_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] when the NavigationServer has debug enabled.
+			</description>
+		</method>
 		<method name="get_maps" qualifiers="const">
 			<return type="RID[]" />
 			<description>
@@ -518,6 +524,13 @@
 			<param index="1" name="travel_cost" type="float" />
 			<description>
 				Sets the [param travel_cost] for this [param region].
+			</description>
+		</method>
+		<method name="set_debug_enabled">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				If [code]true[/code] enables debug mode on the NavigationServer.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -126,6 +126,12 @@
 				Destroys the given RID.
 			</description>
 		</method>
+		<method name="get_debug_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] when the NavigationServer has debug enabled.
+			</description>
+		</method>
 		<method name="get_maps" qualifiers="const">
 			<return type="RID[]" />
 			<description>
@@ -573,6 +579,13 @@
 			<param index="0" name="active" type="bool" />
 			<description>
 				Control activation of this server.
+			</description>
+		</method>
+		<method name="set_debug_enabled">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				If [code]true[/code] enables debug mode on the NavigationServer.
 			</description>
 		</method>
 	</methods>

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -152,14 +152,15 @@ void NavigationServer2D::_emit_map_changed(RID p_map) {
 	emit_signal(SNAME("map_changed"), p_map);
 }
 
-#ifdef DEBUG_ENABLED
 void NavigationServer2D::set_debug_enabled(bool p_enabled) {
 	NavigationServer3D::get_singleton()->set_debug_enabled(p_enabled);
 }
+
 bool NavigationServer2D::get_debug_enabled() const {
 	return NavigationServer3D::get_singleton()->get_debug_enabled();
 }
 
+#ifdef DEBUG_ENABLED
 void NavigationServer2D::set_debug_navigation_edge_connection_color(const Color &p_color) {
 	NavigationServer3D::get_singleton()->set_debug_navigation_edge_connection_color(p_color);
 }
@@ -340,6 +341,9 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("agent_set_callback", "agent", "callback"), &NavigationServer2D::agent_set_callback);
 
 	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &NavigationServer2D::free);
+
+	ClassDB::bind_method(D_METHOD("set_debug_enabled", "enabled"), &NavigationServer2D::set_debug_enabled);
+	ClassDB::bind_method(D_METHOD("get_debug_enabled"), &NavigationServer2D::get_debug_enabled);
 
 	ADD_SIGNAL(MethodInfo("map_changed", PropertyInfo(Variant::RID, "map")));
 

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -234,10 +234,10 @@ public:
 	NavigationServer2D();
 	virtual ~NavigationServer2D();
 
-#ifdef DEBUG_ENABLED
 	void set_debug_enabled(bool p_enabled);
 	bool get_debug_enabled() const;
 
+#ifdef DEBUG_ENABLED
 	void set_debug_navigation_edge_connection_color(const Color &p_color);
 	Color get_debug_navigation_edge_connection_color() const;
 

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -116,6 +116,9 @@ void NavigationServer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &NavigationServer3D::set_active);
 
+	ClassDB::bind_method(D_METHOD("set_debug_enabled", "enabled"), &NavigationServer3D::set_debug_enabled);
+	ClassDB::bind_method(D_METHOD("get_debug_enabled"), &NavigationServer3D::get_debug_enabled);
+
 	ADD_SIGNAL(MethodInfo("map_changed", PropertyInfo(Variant::RID, "map")));
 
 	ADD_SIGNAL(MethodInfo("navigation_debug_changed"));
@@ -182,6 +185,24 @@ NavigationServer3D::NavigationServer3D() {
 
 NavigationServer3D::~NavigationServer3D() {
 	singleton = nullptr;
+}
+
+void NavigationServer3D::set_debug_enabled(bool p_enabled) {
+#ifdef DEBUG_ENABLED
+	if (debug_enabled != p_enabled) {
+		debug_dirty = true;
+	}
+
+	debug_enabled = p_enabled;
+
+	if (debug_dirty) {
+		call_deferred("_emit_navigation_debug_changed_signal");
+	}
+#endif // DEBUG_ENABLED
+}
+
+bool NavigationServer3D::get_debug_enabled() const {
+	return debug_enabled;
 }
 
 #ifdef DEBUG_ENABLED
@@ -531,22 +552,6 @@ void NavigationServer3D::set_debug_navigation_enable_link_connections_xray(const
 
 bool NavigationServer3D::get_debug_navigation_enable_link_connections_xray() const {
 	return debug_navigation_enable_link_connections_xray;
-}
-
-void NavigationServer3D::set_debug_enabled(bool p_enabled) {
-	if (debug_enabled != p_enabled) {
-		debug_dirty = true;
-	}
-
-	debug_enabled = p_enabled;
-
-	if (debug_dirty) {
-		call_deferred("_emit_navigation_debug_changed_signal");
-	}
-}
-
-bool NavigationServer3D::get_debug_enabled() const {
-	return debug_enabled;
 }
 
 void NavigationServer3D::set_debug_navigation_enable_agent_paths(const bool p_value) {

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -274,9 +274,13 @@ public:
 
 	virtual int get_process_info(ProcessInfo p_info) const = 0;
 
-#ifdef DEBUG_ENABLED
+	void set_debug_enabled(bool p_enabled);
+	bool get_debug_enabled() const;
+
 private:
 	bool debug_enabled = false;
+
+#ifdef DEBUG_ENABLED
 	bool debug_dirty = true;
 	void _emit_navigation_debug_changed_signal();
 
@@ -313,9 +317,6 @@ private:
 	Ref<StandardMaterial3D> debug_navigation_agent_path_point_material;
 
 public:
-	void set_debug_enabled(bool p_enabled);
-	bool get_debug_enabled() const;
-
 	void set_debug_navigation_edge_connection_color(const Color &p_color);
 	Color get_debug_navigation_edge_connection_color() const;
 

--- a/servers/navigation_server_3d_dummy.h
+++ b/servers/navigation_server_3d_dummy.h
@@ -112,6 +112,8 @@ public:
 	void process(real_t delta_time) override {}
 	NavigationUtilities::PathQueryResult _query_path(const NavigationUtilities::PathQueryParameters &p_parameters) const override { return NavigationUtilities::PathQueryResult(); }
 	int get_process_info(ProcessInfo p_info) const override { return 0; }
+	void set_debug_enabled(bool p_enabled) {}
+	bool get_debug_enabled() const { return false; }
 };
 
 #endif // NAVIGATION_SERVER_3D_DUMMY_H


### PR DESCRIPTION
Fixes that navigation debug was not toggleable in script while even the docs mentioned it.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
