### PR TITLE
[3.x] Improve the clarity of Viewport's documentation

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -6,7 +6,7 @@
 	<description>
 		A Viewport creates a different view into the screen, or a sub-view inside another viewport. Children 2D Nodes will display on it, and children Camera 3D nodes will render on it too.
 		Optionally, a viewport can have its own 2D or 3D world, so they don't share what they draw with other viewports.
-		If a viewport is a child of a [ViewportContainer], it will automatically take up its size, otherwise it must be set manually.
+		If a viewport is a child of a [ViewportContainer], the viewport will automatically take up the container's size, otherwise it must be set manually.
 		Viewports can also choose to be audio listeners, so they generate positional audio depending on a 2D or 3D camera child of it.
 		Also, viewports can be assigned to different screens in case the devices have multiple screens.
 		Finally, viewports can also behave as render targets, in which case they will not be visible unless the associated texture is used to draw.

--- a/doc/classes/ViewportContainer.xml
+++ b/doc/classes/ViewportContainer.xml
@@ -4,7 +4,7 @@
 		Control for holding [Viewport]s.
 	</brief_description>
 	<description>
-		A [Container] node that holds a [Viewport], automatically setting its size.
+		A [Container] node that holds a [Viewport], automatically setting the viewport's size.
 		[b]Note:[/b] Changing a ViewportContainer's [member Control.rect_scale] will cause its contents to appear distorted. To change its visual size without causing distortion, adjust the node's margins instead (if it's not already in a container).
 	</description>
 	<tutorials>


### PR DESCRIPTION
Salvage of #73023. The author does not have a public email and they deleted their repo so I can't properly credit them as co-author.

This change is only relevant for 3.x, because the 4.x Viewport/SubViewport documentation is completely different. It could be backported to 3.5 I guess, it's pretty minor either way.