### PR TITLE
Improve NavigationServer.free() error msg when RID not found

### DIFF
--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -757,7 +757,7 @@ COMMAND_1(free, RID, p_object) {
 		agent_owner.free(p_object);
 
 	} else {
-		ERR_FAIL_COND("Invalid ID.");
+		ERR_FAIL_COND("Attempted to free a NavigationServer RID that did not exist (or was already freed).");
 	}
 }
 


### PR DESCRIPTION
Improves the error msg when NavigationServer.free() does not find the RID e.g. because it was already deleted or did never exist in the first place.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
