### PR TITLE
Store blend mode between CanvasItems to preserve batching

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -566,6 +566,7 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 
 	uint32_t index = 0;
 	Item *current_clip = nullptr;
+	GLES3::CanvasShaderData *shader_data_cache = nullptr;
 
 	// Record Batches.
 	// First item always forms its own batch.
@@ -602,7 +603,6 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 			}
 		}
 
-		GLES3::CanvasShaderData *shader_data_cache = nullptr;
 		if (material != state.canvas_instance_batches[state.current_batch_index].material) {
 			_new_batch(batch_broken);
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/73231

ShaderData was being reset for every CanvasItem even if the ShaderData was shared by subsequent CanvasItems. The logic should actually be that the ShaderData is shared by subsequent CanvasItems unless they have a different material. 

Accordingly, ShaderData is set to null within the ``material != state.canvas_instance_batches[state.current_batch_index].material`` block

_Before: incorrect batching_
![Screenshot from 2023-02-13 14-48-02](https://user-images.githubusercontent.com/16521339/218592164-99ff0534-d332-4ce8-b0c2-b10c2be40f77.png)
![Screenshot from 2023-02-13 14-47-49](https://user-images.githubusercontent.com/16521339/218592167-f239d924-ab7a-4fef-9f0f-139a9eebf769.png)

_After: correct batching_
![Screenshot from 2023-02-13 14-47-18](https://user-images.githubusercontent.com/16521339/218592174-659198b4-c1c8-46fc-847f-35e306f61534.png)
![Screenshot from 2023-02-13 14-47-28](https://user-images.githubusercontent.com/16521339/218592170-b38e353b-2a23-413d-8751-cdee4ce44c83.png)

