### PR TITLE
Fix some TileMap errors and crashes

### DIFF
--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -404,13 +404,16 @@ void TileAtlasView::_draw_background_right() {
 }
 
 void TileAtlasView::set_atlas_source(TileSet *p_tile_set, TileSetAtlasSource *p_tile_set_atlas_source, int p_source_id) {
-	ERR_FAIL_COND(!p_tile_set);
-	ERR_FAIL_COND(!p_tile_set_atlas_source);
+	tile_set = p_tile_set;
+	tile_set_atlas_source = p_tile_set_atlas_source;
+
+	if (!tile_set) {
+		return;
+	}
+
 	ERR_FAIL_COND(p_source_id < 0);
 	ERR_FAIL_COND(p_tile_set->get_source(p_source_id) != p_tile_set_atlas_source);
 
-	tile_set = p_tile_set;
-	tile_set_atlas_source = p_tile_set_atlas_source;
 	source_id = p_source_id;
 
 	// Show or hide the view.

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -120,10 +120,9 @@ void TileSetAtlasSourceEditor::TileSetAtlasSourceProxyObject::_bind_methods() {
 }
 
 void TileSetAtlasSourceEditor::TileSetAtlasSourceProxyObject::edit(Ref<TileSet> p_tile_set, TileSetAtlasSource *p_tile_set_atlas_source, int p_source_id) {
-	ERR_FAIL_COND(!p_tile_set.is_valid());
 	ERR_FAIL_COND(!p_tile_set_atlas_source);
 	ERR_FAIL_COND(p_source_id < 0);
-	ERR_FAIL_COND(p_tile_set->get_source(p_source_id) != p_tile_set_atlas_source);
+	ERR_FAIL_COND(p_tile_set.is_valid() && p_tile_set->get_source(p_source_id) != p_tile_set_atlas_source);
 
 	if (p_tile_set == tile_set && p_tile_set_atlas_source == tile_set_atlas_source && p_source_id == source_id) {
 		return;
@@ -611,6 +610,10 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 
 	tile_data_editors_tree->clear();
 
+	if (tile_set.is_null()) {
+		return;
+	}
+
 	TreeItem *root = tile_data_editors_tree->create_item();
 
 	TreeItem *group;
@@ -917,6 +920,10 @@ void TileSetAtlasSourceEditor::_update_atlas_view() {
 	// Create a bunch of buttons to add alternative tiles.
 	for (int i = 0; i < alternative_tiles_control->get_child_count(); i++) {
 		alternative_tiles_control->get_child(i)->queue_free();
+	}
+
+	if (tile_set.is_null()) {
+		return;
 	}
 
 	Vector2i pos;


### PR DESCRIPTION
With these steps:
1. Create TileMap
2. Create TileSet
3. Drag any texture to add atlas
4. Save
5. Make sure TileMap is selected
6. Reload

You get a crash due to null tileset in `_update_tile_data_editors()`. If I fixed the crash alone, I still got multiple errors when reloading the scene, so I added some null checks here and there.

One remaining error is
```
modules\navigation\godot_navigation_server.cpp:760 - Condition ""Invalid ID."" is true.
```
but I can't determine what triggers it.

And once you reload and select the TileMap again, there is a weird error about invalid tileset. But I think overall it's an improvement.

I think the main issue is that the tileset editor doesn't handle null tileset properly. I'd expect that it should work, because the editor is empty after launch, so it should be able to go back to that state.