### PR TITLE
Fix TileMap NavigationServer 'Invalid ID' error

### DIFF
--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -212,6 +212,7 @@ private:
 		HashMap<Vector2i, TileMapQuadrant> quadrant_map;
 		SelfList<TileMapQuadrant>::List dirty_quadrant_list;
 		RID navigation_map;
+		bool uses_world_navigation_map = false;
 	};
 	LocalVector<TileMapLayer> layers;
 	int selected_layer = -1;


### PR DESCRIPTION
Fixes NavigationServer 'Invalid ID' harmless error of the TileMap.

The issue was not caused directly by the TileMap but with the late call to `get_world_2d()->get_navigation_map()` that protected the default world navigation map from unwanted deletion.

The error msg was triggered when everything was shut down abruptly e.g. game window closed or Editor "Reload Saved Scene" function.

Fixes the missing navigation part mentioned in https://github.com/godotengine/godot/pull/73259.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
