### PR TITLE
Prevent crash in ImmediateMesh.create_outline

### DIFF
--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -526,6 +526,9 @@ Ref<Mesh> Mesh::create_outline(float p_margin) const {
 			vc = indices.size();
 			ir = indices.ptrw();
 			has_indices = true;
+		} else {
+			// Ensure there are enough vertices to construct at least one triangle.
+			ERR_FAIL_COND_V(vertices.size() % 3 != 0, Ref<ArrayMesh>());
 		}
 
 		HashMap<Vector3, Vector3> normal_accum;


### PR DESCRIPTION
Prevents a crash in ```ImmediateMesh.create_outline``` by ensuring that when no indices are specified, the number of vertices is divisible by 3 without residue. We must check if the vertices vector is divisible by 3 because the outline method constructs normal vectors from a triangle (in other words, there are 3 accesses per iteration)

Fixes #73201 