### PR TITLE
Bias octahedral tangent y axis to avoid errors around 0

### DIFF
--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -108,7 +108,9 @@ Vector3 Vector3::octahedron_decode(const Vector2 &p_oct) {
 }
 
 Vector2 Vector3::octahedron_tangent_encode(const float sign) const {
+	const float bias = 1.0f / 32767.0f;
 	Vector2 res = this->octahedron_encode();
+	res.y = MAX(res.y, bias);
 	res.y = res.y * 0.5f + 0.5f;
 	res.y = sign >= 0.0f ? res.y : 1 - res.y;
 	return res;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/71571

This also fixes the simplified MRP in https://github.com/godotengine/godot/issues/71221#issuecomment-1426813320 but I am unsure if it fixes the OP of https://github.com/godotengine/godot/issues/71221

In 3.x we applied a small bias to the tangent y axis while it was in the range [0, 1] to avoid discontinuities around 0
https://github.com/godotengine/godot/blob/810441633782dcbc0ab08b5c5174ac706a4bb90c/servers/visual_server.cpp#L369-L375

In 4.0 the code is a little different because the output from ``octahedron_encode`` is already in [0,1] space.

Somehow we missed the bias when converting to 4.0, but it is still needed in some very rare cases.

Big thanks to @stoofin who narrowed the issue down to tangents with y-values very close to 0