### PR TITLE
[InputEventKey] Avoid setting both key and modifier to the same value.

### DIFF
--- a/platform/android/android_input_handler.cpp
+++ b/platform/android/android_input_handler.cpp
@@ -49,11 +49,19 @@ void AndroidInputHandler::process_joy_event(AndroidInputHandler::JoypadEvent p_e
 	}
 }
 
-void AndroidInputHandler::_set_key_modifier_state(Ref<InputEventWithModifiers> ev) {
-	ev->set_shift_pressed(shift_mem);
-	ev->set_alt_pressed(alt_mem);
-	ev->set_meta_pressed(meta_mem);
-	ev->set_ctrl_pressed(control_mem);
+void AndroidInputHandler::_set_key_modifier_state(Ref<InputEventWithModifiers> ev, Key p_keycode) {
+	if (p_keycode != Key::SHIFT) {
+		ev->set_shift_pressed(shift_mem);
+	}
+	if (p_keycode != Key::ALT) {
+		ev->set_alt_pressed(alt_mem);
+	}
+	if (p_keycode != Key::META) {
+		ev->set_meta_pressed(meta_mem);
+	}
+	if (p_keycode != Key::CTRL) {
+		ev->set_ctrl_pressed(control_mem);
+	}
 }
 
 void AndroidInputHandler::process_key_event(int p_physical_keycode, int p_unicode, int p_key_label, bool p_pressed) {
@@ -118,7 +126,7 @@ void AndroidInputHandler::process_key_event(int p_physical_keycode, int p_unicod
 	ev->set_unicode(fix_unicode(unicode));
 	ev->set_pressed(p_pressed);
 
-	_set_key_modifier_state(ev);
+	_set_key_modifier_state(ev, keycode);
 
 	if (p_physical_keycode == AKEYCODE_BACK) {
 		if (DisplayServerAndroid *dsa = Object::cast_to<DisplayServerAndroid>(DisplayServer::get_singleton())) {
@@ -260,7 +268,7 @@ void AndroidInputHandler::_parse_mouse_event_info(BitField<MouseButtonMask> even
 
 	Ref<InputEventMouseButton> ev;
 	ev.instantiate();
-	_set_key_modifier_state(ev);
+	_set_key_modifier_state(ev, Key::NONE);
 	if (p_source_mouse_relative) {
 		ev->set_position(hover_prev_pos);
 		ev->set_global_position(hover_prev_pos);
@@ -294,7 +302,7 @@ void AndroidInputHandler::process_mouse_event(int p_event_action, int p_event_an
 			// https://developer.android.com/reference/android/view/MotionEvent.html#ACTION_HOVER_ENTER
 			Ref<InputEventMouseMotion> ev;
 			ev.instantiate();
-			_set_key_modifier_state(ev);
+			_set_key_modifier_state(ev, Key::NONE);
 			ev->set_position(p_event_pos);
 			ev->set_global_position(p_event_pos);
 			ev->set_relative(p_event_pos - hover_prev_pos);
@@ -329,7 +337,7 @@ void AndroidInputHandler::process_mouse_event(int p_event_action, int p_event_an
 
 			Ref<InputEventMouseMotion> ev;
 			ev.instantiate();
-			_set_key_modifier_state(ev);
+			_set_key_modifier_state(ev, Key::NONE);
 			if (p_source_mouse_relative) {
 				ev->set_position(hover_prev_pos);
 				ev->set_global_position(hover_prev_pos);
@@ -348,7 +356,7 @@ void AndroidInputHandler::process_mouse_event(int p_event_action, int p_event_an
 		case AMOTION_EVENT_ACTION_SCROLL: {
 			Ref<InputEventMouseButton> ev;
 			ev.instantiate();
-			_set_key_modifier_state(ev);
+			_set_key_modifier_state(ev, Key::NONE);
 			if (p_source_mouse_relative) {
 				ev->set_position(hover_prev_pos);
 				ev->set_global_position(hover_prev_pos);
@@ -375,7 +383,7 @@ void AndroidInputHandler::process_mouse_event(int p_event_action, int p_event_an
 
 void AndroidInputHandler::_wheel_button_click(BitField<MouseButtonMask> event_buttons_mask, const Ref<InputEventMouseButton> &ev, MouseButton wheel_button, float factor) {
 	Ref<InputEventMouseButton> evd = ev->duplicate();
-	_set_key_modifier_state(evd);
+	_set_key_modifier_state(evd, Key::NONE);
 	evd->set_button_index(wheel_button);
 	evd->set_button_mask(BitField<MouseButtonMask>(event_buttons_mask.operator int64_t() ^ int64_t(mouse_button_to_mask(wheel_button))));
 	evd->set_factor(factor);
@@ -389,7 +397,7 @@ void AndroidInputHandler::_wheel_button_click(BitField<MouseButtonMask> event_bu
 void AndroidInputHandler::process_magnify(Point2 p_pos, float p_factor) {
 	Ref<InputEventMagnifyGesture> magnify_event;
 	magnify_event.instantiate();
-	_set_key_modifier_state(magnify_event);
+	_set_key_modifier_state(magnify_event, Key::NONE);
 	magnify_event->set_position(p_pos);
 	magnify_event->set_factor(p_factor);
 	Input::get_singleton()->parse_input_event(magnify_event);
@@ -398,7 +406,7 @@ void AndroidInputHandler::process_magnify(Point2 p_pos, float p_factor) {
 void AndroidInputHandler::process_pan(Point2 p_pos, Vector2 p_delta) {
 	Ref<InputEventPanGesture> pan_event;
 	pan_event.instantiate();
-	_set_key_modifier_state(pan_event);
+	_set_key_modifier_state(pan_event, Key::NONE);
 	pan_event->set_position(p_pos);
 	pan_event->set_delta(p_delta);
 	Input::get_singleton()->parse_input_event(pan_event);

--- a/platform/android/android_input_handler.h
+++ b/platform/android/android_input_handler.h
@@ -76,7 +76,7 @@ private:
 	MouseEventInfo mouse_event_info;
 	Point2 hover_prev_pos; // needed to calculate the relative position on hover events
 
-	void _set_key_modifier_state(Ref<InputEventWithModifiers> ev);
+	void _set_key_modifier_state(Ref<InputEventWithModifiers> ev, Key p_keycode);
 
 	static MouseButton _button_index_from_mask(BitField<MouseButtonMask> button_mask);
 	static BitField<MouseButtonMask> _android_button_mask_to_godot_button_mask(int android_button_mask);

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -108,11 +108,19 @@ void DisplayServerWeb::request_quit_callback() {
 
 // Keys
 
-void DisplayServerWeb::dom2godot_mod(Ref<InputEventWithModifiers> ev, int p_mod) {
-	ev->set_shift_pressed(p_mod & 1);
-	ev->set_alt_pressed(p_mod & 2);
-	ev->set_ctrl_pressed(p_mod & 4);
-	ev->set_meta_pressed(p_mod & 8);
+void DisplayServerWeb::dom2godot_mod(Ref<InputEventWithModifiers> ev, int p_mod, Key p_keycode) {
+	if (p_keycode != Key::SHIFT) {
+		ev->set_shift_pressed(p_mod & 1);
+	}
+	if (p_keycode != Key::ALT) {
+		ev->set_alt_pressed(p_mod & 2);
+	}
+	if (p_keycode != Key::CTRL) {
+		ev->set_ctrl_pressed(p_mod & 4);
+	}
+	if (p_keycode != Key::META) {
+		ev->set_meta_pressed(p_mod & 8);
+	}
 }
 
 void DisplayServerWeb::key_callback(int p_pressed, int p_repeat, int p_modifiers) {
@@ -138,7 +146,7 @@ void DisplayServerWeb::key_callback(int p_pressed, int p_repeat, int p_modifiers
 	ev->set_key_label(fix_key_label(c, keycode));
 	ev->set_unicode(fix_unicode(c));
 	ev->set_pressed(p_pressed);
-	dom2godot_mod(ev, p_modifiers);
+	dom2godot_mod(ev, p_modifiers, fix_keycode(c, keycode));
 
 	Input::get_singleton()->parse_input_event(ev);
 
@@ -157,7 +165,7 @@ int DisplayServerWeb::mouse_button_callback(int p_pressed, int p_button, double 
 	ev->set_position(pos);
 	ev->set_global_position(pos);
 	ev->set_pressed(p_pressed);
-	dom2godot_mod(ev, p_modifiers);
+	dom2godot_mod(ev, p_modifiers, Key::NONE);
 
 	switch (p_button) {
 		case DOM_BUTTON_LEFT:
@@ -235,7 +243,7 @@ void DisplayServerWeb::mouse_move_callback(double p_x, double p_y, double p_rel_
 	Point2 pos(p_x, p_y);
 	Ref<InputEventMouseMotion> ev;
 	ev.instantiate();
-	dom2godot_mod(ev, p_modifiers);
+	dom2godot_mod(ev, p_modifiers, Key::NONE);
 	ev->set_button_mask(input_mask);
 
 	ev->set_position(pos);

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -81,7 +81,7 @@ private:
 	bool swap_cancel_ok = false;
 
 	// utilities
-	static void dom2godot_mod(Ref<InputEventWithModifiers> ev, int p_mod);
+	static void dom2godot_mod(Ref<InputEventWithModifiers> ev, int p_mod, Key p_keycode);
 	static const char *godot2dom_cursor(DisplayServer::CursorShape p_shape);
 
 	// events

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3668,10 +3668,18 @@ void DisplayServerWindows::_process_key_events() {
 					}
 
 					k->set_window_id(ke.window_id);
-					k->set_shift_pressed(ke.shift);
-					k->set_alt_pressed(ke.alt);
-					k->set_ctrl_pressed(ke.control);
-					k->set_meta_pressed(ke.meta);
+					if (keycode != Key::SHIFT) {
+						k->set_shift_pressed(ke.shift);
+					}
+					if (keycode != Key::ALT) {
+						k->set_alt_pressed(ke.alt);
+					}
+					if (keycode != Key::CTRL) {
+						k->set_ctrl_pressed(ke.control);
+					}
+					if (keycode != Key::META) {
+						k->set_meta_pressed(ke.meta);
+					}
 					k->set_pressed(true);
 					k->set_keycode(keycode);
 					k->set_physical_keycode(physical_keycode);
@@ -3693,11 +3701,6 @@ void DisplayServerWindows::_process_key_events() {
 				k.instantiate();
 
 				k->set_window_id(ke.window_id);
-				k->set_shift_pressed(ke.shift);
-				k->set_alt_pressed(ke.alt);
-				k->set_ctrl_pressed(ke.control);
-				k->set_meta_pressed(ke.meta);
-
 				k->set_pressed(ke.uMsg == WM_KEYDOWN);
 
 				Key keycode = KeyMappingWindows::get_keysym(ke.wParam);
@@ -3719,6 +3722,18 @@ void DisplayServerWindows::_process_key_events() {
 					}
 				}
 
+				if (keycode != Key::SHIFT) {
+					k->set_shift_pressed(ke.shift);
+				}
+				if (keycode != Key::ALT) {
+					k->set_alt_pressed(ke.alt);
+				}
+				if (keycode != Key::CTRL) {
+					k->set_ctrl_pressed(ke.control);
+				}
+				if (keycode != Key::META) {
+					k->set_meta_pressed(ke.meta);
+				}
 				k->set_keycode(keycode);
 				k->set_physical_keycode(physical_keycode);
 				k->set_key_label(key_label);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/73105

Similar checks already exist on other platforms.