### PR TITLE
Fix `texture_format/bptc` export option

### DIFF
--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -33,6 +33,9 @@
 #include "core/config/project_settings.h"
 
 void EditorExportPlatformPC::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
+	if (p_preset->get("texture_format/bptc")) {
+		r_features->push_back("bptc");
+	}
 	if (p_preset->get("texture_format/s3tc")) {
 		r_features->push_back("s3tc");
 	}


### PR DESCRIPTION
This option apparently has never done anything.

This fixes (some cases of?) exporting VRAM compressed textures, as long as the option is toggled on (it is off by default)
 
Fixes #72856
Fixes #73267