### PR TITLE
GDScript: Fix default value of exported enum variable

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4278,11 +4278,15 @@ Variant GDScriptAnalyzer::make_variable_default_value(GDScriptParser::VariableNo
 		}
 	} else {
 		GDScriptParser::DataType datatype = p_variable->get_datatype();
-		if (datatype.is_hard_type() && datatype.kind == GDScriptParser::DataType::BUILTIN && datatype.builtin_type != Variant::OBJECT) {
-			if (datatype.builtin_type == Variant::ARRAY && datatype.has_container_element_type()) {
-				result = make_array_from_element_datatype(datatype.get_container_element_type());
-			} else {
-				VariantInternal::initialize(&result, datatype.builtin_type);
+		if (datatype.is_hard_type()) {
+			if (datatype.kind == GDScriptParser::DataType::BUILTIN && datatype.builtin_type != Variant::OBJECT) {
+				if (datatype.builtin_type == Variant::ARRAY && datatype.has_container_element_type()) {
+					result = make_array_from_element_datatype(datatype.get_container_element_type());
+				} else {
+					VariantInternal::initialize(&result, datatype.builtin_type);
+				}
+			} else if (datatype.kind == GDScriptParser::DataType::ENUM) {
+				result = 0;
 			}
 		}
 	}


### PR DESCRIPTION
```gdscript
enum Test {A, B, C}
@export var test: Test
```

The default value of enum typed variables is 0 (as well as `int` typed).

Before:
![](https://user-images.githubusercontent.com/47700418/218779049-f12f2abb-3e63-4bd7-ad81-650bd1e25c25.png)

After:
![](https://user-images.githubusercontent.com/47700418/218777985-055fea1b-cded-42a3-8e0c-4c6761bf9718.png)

Closes #54040.

---

I noticed that the inspector does not work correctly for the following example:

```gdscript
enum Test {A = 1, B, C}
@export var test: Test

func _ready() -> void:
    print(test) # 0
    for prop in get_property_list():
        if prop.name == "test":
            print(prop)
    # { "name": "test", "class_name": &"", "type": 2, "hint": 2,
    # "hint_string": "A:1,B:2,C:3", "usage": 4102 }
```

But this is not relevant to this PR, since `hint_string` is correct.

---

See also #72925. I guess after that `@export var test: Array[Test]` will work like this too (but I haven't tested).