### PR TITLE
Clear Window before blitting Viewport in gl_compatibility renderer

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -306,6 +306,15 @@ void RasterizerGLES3::_blit_render_target_to_screen(RID p_render_target, Display
 
 	glReadBuffer(GL_COLOR_ATTACHMENT0);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
+
+	if (p_screen_rect.position != Vector2()) {
+		// Viewport doesn't cover entire window so clear window to black before blitting.
+		Size2i win_size = DisplayServer::get_singleton()->window_get_size();
+		glViewport(0, 0, win_size.width, win_size.height);
+		glClearColor(0.0, 0.0, 0.0, 1.0);
+		glClear(GL_COLOR_BUFFER_BIT);
+	}
+
 	Vector2i screen_rect_end = p_screen_rect.get_end();
 	glBlitFramebuffer(0, 0, rt->size.x, rt->size.y,
 			p_screen_rect.position.x, flip_y ? screen_rect_end.y : p_screen_rect.position.y, screen_rect_end.x, flip_y ? p_screen_rect.position.y : screen_rect_end.y,

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -984,17 +984,13 @@ void Window::_update_viewport_size() {
 
 		Size2 margin;
 		Size2 offset;
-		//black bars and margin
+
 		if (content_scale_aspect != CONTENT_SCALE_ASPECT_EXPAND && screen_size.x < video_mode.x) {
 			margin.x = Math::round((video_mode.x - screen_size.x) / 2.0);
-			//RenderingServer::get_singleton()->black_bars_set_margins(margin.x, 0, margin.x, 0);
 			offset.x = Math::round(margin.x * viewport_size.y / screen_size.y);
 		} else if (content_scale_aspect != CONTENT_SCALE_ASPECT_EXPAND && screen_size.y < video_mode.y) {
 			margin.y = Math::round((video_mode.y - screen_size.y) / 2.0);
-			//RenderingServer::get_singleton()->black_bars_set_margins(0, margin.y, 0, margin.y);
 			offset.y = Math::round(margin.y * viewport_size.x / screen_size.x);
-		} else {
-			//RenderingServer::get_singleton()->black_bars_set_margins(0, 0, 0, 0);
 		}
 
 		switch (content_scale_mode) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/71799

In Godot 3.x we had an API to draw black bars on the side of the window if some amount of the window was left uncovered by the Viewport. This covered up the leftover colored pixels from previous frames. In Godot 4.0 we got rid of that API as it is not needed for Vulkan which has to recreate the swapchain each time the window resizes. 

Instead of bringing back the black bars we just clear the window if any section is left uncovered. Clearing to zero is a special operation on most drivers and is much faster than issuing 2 draw calls, plus the full screen clear signals that we don't care about the previous contents which can be a performance benefit in some cases. 

A potential optimization would be to track window size and only clear on window size changes. However, I do not think it is worth the added complexity. 
