### PR TITLE
make code hint properly show whenever needed

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -877,6 +877,14 @@ void CodeTextEditor::_reset_zoom() {
 }
 
 void CodeTextEditor::_line_col_changed() {
+	text_editor->set_code_hint("");
+	code_complete_timer_line = text_editor->get_caret_line();
+	if (code_complete_timer->is_inside_tree()) {
+		code_complete_timer->start();
+	} else { // if not in tree (most likely we are just opening the script) we can't start it yet so we wait for it to be inside tree and start it then thanks to autostart.
+		code_complete_timer->set_autostart(true);
+	}
+
 	if (!code_complete_timer->is_stopped() && code_complete_timer_line != text_editor->get_caret_line()) {
 		code_complete_timer->stop();
 	}
@@ -909,11 +917,6 @@ void CodeTextEditor::_line_col_changed() {
 }
 
 void CodeTextEditor::_text_changed() {
-	if (text_editor->is_insert_text_operation()) {
-		code_complete_timer_line = text_editor->get_caret_line();
-		code_complete_timer->start();
-	}
-
 	idle->start();
 
 	if (find_replace_bar) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2939,13 +2939,14 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_call(ExpressionNode *p_pre
 	push_completion_call(call);
 	int argument_index = 0;
 	do {
-		make_completion_context(ct, call, argument_index++, true);
+		make_completion_context(ct, call, argument_index, true);
 		if (check(GDScriptTokenizer::Token::PARENTHESIS_CLOSE)) {
 			// Allow for trailing comma.
 			break;
 		}
 		bool use_identifier_completion = current.cursor_place == GDScriptTokenizer::CURSOR_END || current.cursor_place == GDScriptTokenizer::CURSOR_MIDDLE;
 		ExpressionNode *argument = parse_expression(false);
+		make_completion_context(ct, call, argument_index++, true);
 		if (argument == nullptr) {
 			push_error(R"(Expected expression as the function argument.)");
 		} else {

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -326,7 +326,6 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		}
 
 		cancel_code_completion();
-		set_code_hint("");
 
 		if (mb->is_pressed()) {
 			Vector2i mpos = mb->get_position();
@@ -535,9 +534,6 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		set_code_hint("");
 		accept_event();
 		return;
-	}
-	if (allow_unicode_handling && k->get_unicode() == ')') {
-		set_code_hint("");
 	}
 
 	/* Indentation */
@@ -1886,6 +1882,55 @@ void CodeEdit::request_code_completion(bool p_force) {
 		emit_signal(SNAME("code_completion_requested"));
 	} else if (ofs > 1 && line[ofs - 1] == ' ' && code_completion_prefixes.has(line[ofs - 2])) {
 		emit_signal(SNAME("code_completion_requested"));
+	} else {
+		// try to find an opening bracket indicating we are between two brackets.
+		int stack = 1;
+		bool found_match = false;
+		char32_t closec = '(';
+		char32_t c = ')';
+		for (int i = get_caret_line(); i >= 0 && !found_match; i--) {
+			// if a line is empty (not even a tab) stop looking for an opening bracket
+			if (get_line(i).length() == 0) {
+				break;
+			}
+			int from = i == get_caret_line() ? get_caret_column() - 2 : get_line(i).length() - 1;
+			for (int j = from; j >= 0; j--) {
+				char32_t cc = get_line(i)[j];
+				// Ignore any brackets inside a string.
+				if (cc == '"' || cc == '\'') {
+					char32_t quotation = cc;
+					do {
+						j--;
+						if (!(j >= 0)) {
+							break;
+						}
+						cc = get_line(i)[j];
+						// Skip over escaped quotation marks inside strings.
+						if (cc == quotation) {
+							bool escaped = false;
+							while (j - 1 >= 0 && get_line(i)[j - 1] == '\\') {
+								escaped = !escaped;
+								j--;
+							}
+							if (escaped) {
+								cc = '\\';
+								continue;
+							}
+						}
+					} while (cc != quotation);
+				} else if (cc == c) {
+					stack++;
+				} else if (cc == closec) {
+					stack--;
+				}
+
+				if (stack == 0) {
+					found_match = true;
+					emit_signal(SNAME("code_completion_requested"));
+					break;
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #67108 
might fixes #66672 (needs checking, might not be mark it as fully completed)
related to #49498

This PR moves refreshing code hint from only adding characters to any action that move the caret.
Secondly it added that code hint will be called whenever you are between to parenthesis delimiter.
Lastly as it revealed a bug that was more linked to gdscript analyzer in itself but was still something requested in #67108 I added a completion context at the end of each argument of a method and not just before. so that when you close the parenthesis of a method nested in an argument code hint of the larger method reappears.
<img width="424" alt="Capture d’écran 2023-02-14 à 21 17 31" src="https://user-images.githubusercontent.com/66184050/218852236-a2584c48-2f1f-4591-b12b-699db44d07bf.png">
