### PR TITLE
Unbind NavigationServer3D.process()

### DIFF
--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -422,15 +422,6 @@
 				Sets the map up direction.
 			</description>
 		</method>
-		<method name="process">
-			<return type="void" />
-			<param index="0" name="delta_time" type="float" />
-			<description>
-				Process the collision avoidance agents.
-				The result of this process is needed by the physics server, so this must be called in the main thread.
-				[b]Note:[/b] This function is not thread safe.
-			</description>
-		</method>
 		<method name="query_path" qualifiers="const">
 			<return type="void" />
 			<param index="0" name="parameters" type="NavigationPathQueryParameters3D" />

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -115,7 +115,6 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &NavigationServer3D::free);
 
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &NavigationServer3D::set_active);
-	ClassDB::bind_method(D_METHOD("process", "delta_time"), &NavigationServer3D::process);
 
 	ADD_SIGNAL(MethodInfo("map_changed", PropertyInfo(Variant::RID, "map")));
 


### PR DESCRIPTION
Unbinds NavigationServer3D.process().

I have no idea why this was even (left) exposed for the NavigationServer, it is not as if RenderingServer or PhysicsServer are allowed to be processed like this. The NavigationServer2D also never had an equivalent.

In the original server implementation this was the avoidance `step()` function but soon it was renamed to `process()` and became the dedicated loop function of the entire server. It now always does the entire NavigationServer sync which should be done by the main loop. The only purpose of a manual function call would be to break the server on purpose. If there is a real desire to step the avoidance manually this should have been implemented very differently a while ago.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
