### PR TITLE
Properly calculate lifetime_split for particles

### DIFF
--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -919,7 +919,7 @@ void ParticlesStorage::_particles_update_instance_buffer(Particles *particles, c
 	glBeginTransformFeedback(GL_POINTS);
 
 	if (particles->draw_order == RS::PARTICLES_DRAW_ORDER_LIFETIME) {
-		uint32_t lifetime_split = MIN(particles->amount * particles->phase, particles->amount - 1);
+		uint32_t lifetime_split = (MIN(int(particles->amount * particles->phase), particles->amount - 1) + 1) % particles->amount;
 		uint32_t stride = particles->process_buffer_stride_cache;
 
 		glBindBuffer(GL_ARRAY_BUFFER, particles->back_process_buffer);
@@ -1135,14 +1135,13 @@ void ParticlesStorage::_particles_reverse_lifetime_sort(Particles *particles) {
 	glGetBufferSubData(GL_ARRAY_BUFFER, 0, buffer_size, particle_array);
 #endif
 
-	uint32_t lifetime_split = MIN(particles->amount * particles->sort_buffer_phase, particles->amount - 1);
-
+	uint32_t lifetime_split = (MIN(int(particles->amount * particles->sort_buffer_phase), particles->amount - 1) + 1) % particles->amount;
 	for (uint32_t i = 0; i < lifetime_split / 2; i++) {
-		SWAP(particle_array[i], particle_array[lifetime_split - i]);
+		SWAP(particle_array[i], particle_array[lifetime_split - i - 1]);
 	}
 
 	for (uint32_t i = 0; i < (particles->amount - lifetime_split) / 2; i++) {
-		SWAP(particle_array[lifetime_split + i + 1], particle_array[particles->amount - 1 - i]);
+		SWAP(particle_array[lifetime_split + i], particle_array[particles->amount - 1 - i]);
 	}
 
 #ifndef __EMSCRIPTEN__

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1193,7 +1193,7 @@ void ParticlesStorage::particles_set_view_axis(RID p_particles, const Vector3 &p
 	}
 
 	copy_push_constant.order_by_lifetime = (particles->draw_order == RS::PARTICLES_DRAW_ORDER_LIFETIME || particles->draw_order == RS::PARTICLES_DRAW_ORDER_REVERSE_LIFETIME);
-	copy_push_constant.lifetime_split = MIN(particles->amount * particles->phase, particles->amount - 1);
+	copy_push_constant.lifetime_split = (MIN(int(particles->amount * particles->phase), particles->amount - 1) + 1) % particles->amount;
 	copy_push_constant.lifetime_reverse = particles->draw_order == RS::PARTICLES_DRAW_ORDER_REVERSE_LIFETIME;
 
 	copy_push_constant.frame_remainder = particles->interpolate ? particles->frame_remainder : 0.0;
@@ -1511,7 +1511,7 @@ void ParticlesStorage::update_particles() {
 			}
 
 			copy_push_constant.order_by_lifetime = (particles->draw_order == RS::PARTICLES_DRAW_ORDER_LIFETIME || particles->draw_order == RS::PARTICLES_DRAW_ORDER_REVERSE_LIFETIME);
-			copy_push_constant.lifetime_split = MIN(particles->amount * particles->phase, particles->amount - 1);
+			copy_push_constant.lifetime_split = (MIN(int(particles->amount * particles->phase), particles->amount - 1) + 1) % particles->amount;
 			copy_push_constant.lifetime_reverse = particles->draw_order == RS::PARTICLES_DRAW_ORDER_REVERSE_LIFETIME;
 
 			RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/50825

Supersedes: https://github.com/godotengine/godot/pull/55382

While evaluating https://github.com/godotengine/godot/pull/55382 I realized that the problem lies elsewhere which is why https://github.com/godotengine/godot/pull/55382 was causing additional artifacts

This PR adjusts the calculating of ``lifetime_split`` by adding one to it and then taking the modulo of the result with the amount of particles. It is difficult to say why this change is needed. I think it is because the nature of the particles means that the first particle emitted is always particle 1 rather than particle 0. But It is difficult to track particles individually. 

Because I am uncertain about the reasoning for the fix, I think this would be better merged after 4.0 and then cherrypicked for 4.0.1

_Before_
![Screenshot from 2023-02-14 14-14-55](https://user-images.githubusercontent.com/16521339/218879299-b218a48f-ddb2-4184-9207-4c5c151cb943.png)
_After_
![Screenshot from 2023-02-14 14-15-31](https://user-images.githubusercontent.com/16521339/218879297-32f6782e-f98a-4b75-9d66-b3d87851018e.png)


_Before_
![Screenshot from 2023-02-14 14-34-41](https://user-images.githubusercontent.com/16521339/218879296-d050c625-5525-456e-80ac-968e0f73524a.png)
_After_
![Screenshot from 2023-02-14 14-35-37](https://user-images.githubusercontent.com/16521339/218879289-2edab6a9-a3f1-47d5-b506-83895a9fc86d.png)

_Before_
![Screenshot from 2023-02-14 14-35-06](https://user-images.githubusercontent.com/16521339/218879294-52f181fe-fa10-4f54-8626-0cf49c0c4ac7.png)
_After_
![Screenshot from 2023-02-14 14-35-30](https://user-images.githubusercontent.com/16521339/218879293-917815ad-3123-4ea2-811b-de8dde4a68cc.png)

I also tested with particle trails enabled but the before and after is not so obvious there
