### PR TITLE
Fix editor language dropdown incomplete in some locales

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -384,9 +384,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 			if (score > 0 && score >= best_score) {
 				best = locale;
 				best_score = score;
-				if (score == 10) {
-					break; // Exact match, skip the rest.
-				}
 			}
 		}
 		if (best_score == 0) {


### PR DESCRIPTION
In the editor language dropdown, when the host locale matches one entry exactly, the rest of the list is missing.

e.g. The dropdown list has only two entires if your `LANG` is `ar`:
![ksnip_20230215-090120](https://user-images.githubusercontent.com/372476/218898251-b9ccb6a9-dd55-4f97-b60a-f2bd2a651c31.png)

This PR removes the early break because that loop is used for both determining the default locale and generating the locale list.