### PR TITLE
For basisu avoid inserting to the image array twice.

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3285,7 +3285,6 @@ Error GLTFDocument::_parse_images(Ref<GLTFState> p_state, const String &p_base_p
 			tex.instantiate();
 			tex->set_name(img->get_name());
 			tex->set_keep_compressed_buffer(true);
-			p_state->source_images.push_back(img);
 			tex->create_from_image(img, PortableCompressedTexture2D::COMPRESSION_MODE_BASIS_UNIVERSAL);
 			p_state->images.push_back(tex);
 			p_state->source_images.push_back(img);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32321/218901010-18dcc67f-36a6-494d-9546-e32bc554945f.png)

Basisu images were getting referenced incorrectly like set black or set as not transparent in gltf.

TL;DR don't code past midnight.