### PR TITLE
Add increment and decrement buttons missing from process priority input-box

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3013,7 +3013,7 @@ void Node::_bind_methods() {
 
 	ADD_GROUP("Process", "process_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_mode", PROPERTY_HINT_ENUM, "Inherit,Pausable,When Paused,Always,Disabled"), "set_process_mode", "get_process_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_priority"), "set_process_priority", "get_process_priority");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_priority", PROPERTY_HINT_RANGE, "-4096,4096,1,or_less,or_greater"), "set_process_priority", "get_process_priority");
 
 	ADD_GROUP("Editor Description", "editor_");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "editor_description", PROPERTY_HINT_MULTILINE_TEXT), "set_editor_description", "get_editor_description");


### PR DESCRIPTION
## Description

Adds increment and decrement buttons to the process priority input-box, with the recommended ranges from @Calinou `-4096,4096,1,or_less,or_greater`. Currently, the buttons are missing from it.

## Related Issue

Fixes #73192

Thanks for your time
