### PR TITLE
Avoid branch in half2float in gl_compatibility renderer

### DIFF
--- a/drivers/gles3/shaders/stdlib_inc.glsl
+++ b/drivers/gles3/shaders/stdlib_inc.glsl
@@ -14,11 +14,7 @@ uint float2half(uint f) {
 
 uint half2float(uint h) {
 	uint h_e = h & uint(0x7c00);
-	if (h_e == uint(0x0000)) {
-		return uint(0);
-	} else {
-		return ((h & uint(0x8000)) << uint(16)) | ((h_e + uint(0x1c000)) << uint(13)) | ((h & uint(0x03ff)) << uint(13));
-	}
+	return ((h & uint(0x8000)) << uint(16)) | uint((h_e >> uint(10)) != uint(0)) * (((h_e + uint(0x1c000)) << uint(13)) | ((h & uint(0x03ff)) << uint(13)));
 }
 
 uint packHalf2x16(vec2 v) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/73320

This is a regression from https://github.com/godotengine/godot/pull/72914. 

For some reason the radeon drivers really don't like the ``h_e == uint(0x0000)`` comparison. Replacing it with ``(h_e >> uint(10)) == uint(0)`` works though.

Also, when running it through Radeon GPUAnalyzer I noticed that this was actually generating a branch. So I made the code branchless. Logically this code does almost exactly the same thing as the old code (it can now return -0 but couldn't before) but it works on more hardware, so oh well.

CC @JonqsGames you may be interested in this