### PR TITLE
Allow `AnimationTree` property base paths to be retrieved with `AnimationNode`

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -287,7 +287,7 @@
 			</description>
 		</signal>
 		<signal name="animation_finished">
-			<param index="0" name="anim_name" type="StringName" />
+			<param index="0" name="animation_name" type="StringName" />
 			<description>
 				Notifies when an animation finished playing.
 				[b]Note:[/b] This signal is not emitted if an animation is looping.
@@ -304,7 +304,7 @@
 			</description>
 		</signal>
 		<signal name="animation_started">
-			<param index="0" name="anim_name" type="StringName" />
+			<param index="0" name="animation_name" type="StringName" />
 			<description>
 				Notifies when an animation starts playing.
 			</description>

--- a/doc/classes/AnimationTree.xml
+++ b/doc/classes/AnimationTree.xml
@@ -30,6 +30,14 @@
 				Manually advance the animations by the specified time (in seconds).
 			</description>
 		</method>
+		<method name="get_property_base_path" qualifiers="const">
+			<return type="StringName" />
+			<param index="0" name="animation_node" type="AnimationNode" />
+			<description>
+				Returns the base path of the properties that [AnimationTree] assigns to manage the state of each animation node.
+				[b]Note:[/b] The path is returned only if the object's instance ID matches the map key for the property that [AnimationTree] has internally.
+			</description>
+		</method>
 		<method name="get_root_motion_position" qualifiers="const">
 			<return type="Vector3" />
 			<description>
@@ -198,9 +206,10 @@
 	</members>
 	<signals>
 		<signal name="animation_finished">
-			<param index="0" name="anim_name" type="StringName" />
+			<param index="0" name="animation_name" type="StringName" />
+			<param index="1" name="animation_node" type="Object" />
 			<description>
-				Notifies when an animation finished playing.
+				Notifies when an animation finished playing. You can get the actual path of the animation node as the property base path by passing [param animation_node] to [method get_property_base_path].
 				[b]Note:[/b] This signal is not emitted if an animation is looping or aborted. Also be aware of the possibility of unseen playback by sync and xfade.
 			</description>
 		</signal>
@@ -210,9 +219,10 @@
 			</description>
 		</signal>
 		<signal name="animation_started">
-			<param index="0" name="anim_name" type="StringName" />
+			<param index="0" name="animation_name" type="StringName" />
+			<param index="1" name="animation_node" type="Object" />
 			<description>
-				Notifies when an animation starts playing.
+				Notifies when an animation starts playing. You can get the actual path of the animation node as the property base path by passing [param animation_node] to [method get_property_base_path].
 				[b]Note:[/b] This signal is not emitted if an animation is looping or playbacked from the middle. Also be aware of the possibility of unseen playback by sync and xfade.
 			</description>
 		</signal>

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -150,11 +150,11 @@ double AnimationNodeAnimation::process(double p_time, bool p_seek, bool p_is_ext
 		if (state->tree) {
 			// AnimationTree uses seek to 0 "internally" to process the first key of the animation, which is used as the start detection.
 			if (p_seek && !p_is_external_seeking && cur_time == 0) {
-				state->tree->call_deferred(SNAME("emit_signal"), "animation_started", animation);
+				state->tree->call_deferred(SNAME("emit_signal"), "animation_started", animation, this);
 			}
 			// Finished.
 			if (prev_time < anim_size && cur_time >= anim_size) {
-				state->tree->call_deferred(SNAME("emit_signal"), "animation_finished", animation);
+				state->tree->call_deferred(SNAME("emit_signal"), "animation_finished", animation, this);
 			}
 		}
 	}

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -2296,9 +2296,9 @@ void AnimationPlayer::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "movie_quit_on_finish"), "set_movie_quit_on_finish_enabled", "is_movie_quit_on_finish_enabled");
 
-	ADD_SIGNAL(MethodInfo("animation_finished", PropertyInfo(Variant::STRING_NAME, "anim_name")));
+	ADD_SIGNAL(MethodInfo("animation_finished", PropertyInfo(Variant::STRING_NAME, "animation_name")));
 	ADD_SIGNAL(MethodInfo("animation_changed", PropertyInfo(Variant::STRING_NAME, "old_name"), PropertyInfo(Variant::STRING_NAME, "new_name")));
-	ADD_SIGNAL(MethodInfo("animation_started", PropertyInfo(Variant::STRING_NAME, "anim_name")));
+	ADD_SIGNAL(MethodInfo("animation_started", PropertyInfo(Variant::STRING_NAME, "animation_name")));
 	ADD_SIGNAL(MethodInfo("animation_list_changed"));
 	ADD_SIGNAL(MethodInfo("animation_libraries_updated"));
 	ADD_SIGNAL(MethodInfo("caches_cleared"));

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -2019,6 +2019,12 @@ Vector3 AnimationTree::get_root_motion_scale_accumulator() const {
 	return root_motion_scale_accumulator;
 }
 
+StringName AnimationTree::get_property_base_path(const Ref<AnimationNode> &p_animation_node) const {
+	ObjectID oid = p_animation_node->get_instance_id();
+	ERR_FAIL_COND_V(!property_reference_map.has(oid), StringName());
+	return property_reference_map[oid];
+}
+
 void AnimationTree::_tree_changed() {
 	if (properties_dirty) {
 		return;
@@ -2212,6 +2218,8 @@ void AnimationTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_root_motion_rotation_accumulator"), &AnimationTree::get_root_motion_rotation_accumulator);
 	ClassDB::bind_method(D_METHOD("get_root_motion_scale_accumulator"), &AnimationTree::get_root_motion_scale_accumulator);
 
+	ClassDB::bind_method(D_METHOD("get_property_base_path", "animation_node"), &AnimationTree::get_property_base_path);
+
 	ClassDB::bind_method(D_METHOD("_update_properties"), &AnimationTree::_update_properties);
 
 	ClassDB::bind_method(D_METHOD("advance", "delta"), &AnimationTree::advance);
@@ -2236,8 +2244,8 @@ void AnimationTree::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("animation_player_changed"));
 
 	// Signals from AnimationNodes.
-	ADD_SIGNAL(MethodInfo("animation_started", PropertyInfo(Variant::STRING_NAME, "anim_name")));
-	ADD_SIGNAL(MethodInfo("animation_finished", PropertyInfo(Variant::STRING_NAME, "anim_name")));
+	ADD_SIGNAL(MethodInfo("animation_started", PropertyInfo(Variant::STRING_NAME, "animation_name"), PropertyInfo(Variant::OBJECT, "animation_node")));
+	ADD_SIGNAL(MethodInfo("animation_finished", PropertyInfo(Variant::STRING_NAME, "animation_name"), PropertyInfo(Variant::OBJECT, "animation_node")));
 }
 
 AnimationTree::AnimationTree() {

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -187,6 +187,8 @@ class AnimationNodeEndState : public AnimationRootNode {
 class AnimationTree : public Node {
 	GDCLASS(AnimationTree, Node);
 
+	friend class AnimationNodeAnimation;
+
 public:
 	enum AnimationProcessCallback {
 		ANIMATION_PROCESS_PHYSICS,
@@ -410,6 +412,8 @@ public:
 
 	real_t get_connection_activity(const StringName &p_path, int p_connection) const;
 	void advance(double p_time);
+
+	StringName get_property_base_path(const Ref<AnimationNode> &p_animation_node) const;
 
 	uint64_t get_last_process_pass() const;
 	AnimationTree();


### PR DESCRIPTION
Make the signal `animation_started` and `animation_finished` in AnimationTree return `AnimationNode`.

Add `StringName get_property_base_path(const Ref<AnimationNode> &p_animation_node) const;` to `AnimationTree ` so that the property base path can be retrieved by instance ID lookup. This is made possible by #72722.

This allows us to identify which of the `NodeAnimations` with the same animation fired the signal. In the future, it should also be possible to retrieve changes in the state of `NodeTransition` and `NodeOneShot`.

The reason for the label `breaks compat` is that the number of the signal argument increases.