### PR TITLE
Make label sizing algorithm more robust

### DIFF
--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -50,7 +50,6 @@ private:
 	bool uppercase = false;
 
 	bool lines_dirty = true;
-
 	bool dirty = true;
 	bool font_dirty = true;
 	RID text_rid;
@@ -66,6 +65,7 @@ private:
 	float visible_ratio = 1.0;
 	int lines_skipped = 0;
 	int max_lines_visible = -1;
+	bool draw_pending = false;
 
 	Ref<LabelSettings> settings;
 
@@ -83,7 +83,7 @@ private:
 		int font_shadow_outline_size;
 	} theme_cache;
 
-	void _shape();
+	bool _shape();
 	void _invalidate();
 
 protected:


### PR DESCRIPTION
Fixes #73296.
Fixes https://github.com/godotengine/godot/issues/73385.

This `Label` thing has been about to take me out of the few vestiges of sanity I still possess.

I've reworked the algorithm once more, in a way that it does everything needed to get the expected results while at the same time still looking sensible (not just a hardwire of contrived checks and bookkeeping to alleviate regressions.)

I've once more tested this to ensure the bugs in this unfortunate chain of issues are still dead like true poetry; namely:
- Catastrophic layout dance that freezes the editor upon an error in the Godot internal shaders.
- From https://github.com/godotengine/godot/pull/72387#issuecomment-1415344761:
  - Extremely tall script create dialog.
  - Project manager as it could look in a dream; that is, mostly normal, but with a lot of text missing.
- #73230.
- #72339.
- #73385.
- #73296, obviously.

I've also done some smoke testing by browsing different parts of the editor (help, some dialogs, etc.) to rule out potential new regressions. I have the impression that some user will be able to find one, though, but my gut feeling about the correctness of the code is now better than last time.

**UPDATE:** Added some related fixed bugs to the list.