### PR TITLE
Fix autocomplete persisting at the beginning of a line and throwing errors

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2856,7 +2856,7 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 	const int caret_line = get_caret_line();
 	const int caret_column = get_caret_column();
 	const String line = get_line(caret_line);
-	ERR_FAIL_INDEX_MSG(caret_column - 1, line.length(), "Caret column exceeds line length.");
+	ERR_FAIL_INDEX_MSG(caret_column, line.length() + 1, "Caret column exceeds line length.");
 
 	if (caret_column > 0 && line[caret_column - 1] == '(' && !code_completion_forced) {
 		cancel_code_completion();


### PR DESCRIPTION
The index check is done incorrectly and errors out when the caret is in the 0th column. In fact, all of the logic below ensures that the caret isn't at column 0 when checking the previous char.

Fix #73341