### PR TITLE
Fix `TabBar` not redrawing on locale change

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -342,6 +342,8 @@ void TabBar::_notification(int p_what) {
 				_shape(i);
 			}
 
+			queue_redraw();
+
 			[[fallthrough]];
 		}
 		case NOTIFICATION_RESIZED: {


### PR DESCRIPTION
Fix `TabBar` not immediately redrawn on locale change. I'm not sure if `TabBar` should be redrawn on every `NOTIFICATION_RESIZED`, but it looks like it shouldn't be a problem.

Test project: [tab_bar_bug.zip](https://github.com/godotengine/godot/files/10742281/tab_bar_bug.zip)
