### PR TITLE
Fixes revert button on exported node properties on inherited nodes

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -693,7 +693,7 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 			bool is_valid_revert = false;
 			Variant revert_value = EditorPropertyRevert::get_property_revert_value(object, property, &is_valid_revert);
 			ERR_FAIL_COND(!is_valid_revert);
-			emit_changed(property, revert_value);
+			emit_changed(_get_revert_property(), revert_value);
 			update_property();
 		}
 


### PR DESCRIPTION
Fixes an issue where the revert button on a node property with the @export tag would not work. This appears to be down to the usage of 'pointer_mode' on the EditorPropertyNodePath class and the concept of a meta_pointer_property. By explicitly requesting the revert property name with with _get_revert_property function, the signal will emit with correct meta property name and subsequently set it correctly.

This bug is only really noticable if you have a node which inherits from another node which assigns a default property.