### PR TITLE
Fix crash by freed object assign to typed variable

### DIFF
--- a/modules/gdscript/tests/scripts/analyzer/errors/native_freed_instance.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/native_freed_instance.gd
@@ -1,0 +1,7 @@
+func test():
+	var x = Node.new()
+
+	x.free()
+
+	var ok = x
+	var bad : Node = x

--- a/modules/gdscript/tests/scripts/analyzer/errors/native_freed_instance.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/native_freed_instance.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: test()
+>> analyzer/errors/native_freed_instance.gd
+>> 7
+>> Trying to assign invalid previously freed instance.

--- a/modules/gdscript/tests/scripts/analyzer/errors/script_freed_instance.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/script_freed_instance.gd
@@ -1,0 +1,10 @@
+class A extends Node:
+	pass
+
+func test():
+	var x = A.new()
+
+	x.free()
+
+	var ok = x
+	var bad : A = x

--- a/modules/gdscript/tests/scripts/analyzer/errors/script_freed_instance.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/script_freed_instance.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: test()
+>> analyzer/errors/script_freed_instance.gd
+>> 10
+>> Trying to assign invalid previously freed instance.


### PR DESCRIPTION
Fixes #71771. Also ascertained that this issue will only occur in debug mode, since the offending code is only for generating error messages.

However, I have not made the behavior similar to with untyped variables, which don't crash/throw errors and simply copy the freed instance information. Instead, the code will throw an error now:

![image](https://user-images.githubusercontent.com/1133892/219062663-dc691a87-6e35-4f1a-8dba-2a6e02a0d64c.png)

In release mode, it should behave as untyped variables since no checks are made.

If we want the behavior to be similar to untyped variables, where we simply copy the reference to the previously freed object, we can also make that happen!

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
