### PR TITLE
Fold resources when non-main inspector exits tree

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -414,6 +414,18 @@ StringName EditorProperty::get_edited_property() const {
 	return property;
 }
 
+EditorInspector *EditorProperty::get_parent_inspector() const {
+	Node *parent = get_parent();
+	while (parent) {
+		EditorInspector *ei = Object::cast_to<EditorInspector>(parent);
+		if (ei) {
+			return ei;
+		}
+		parent = parent->get_parent();
+	}
+	ERR_FAIL_V_MSG(nullptr, "EditorProperty is outside inspector.");
+}
+
 void EditorProperty::set_doc_path(const String &p_doc_path) {
 	doc_path = p_doc_path;
 }
@@ -2484,6 +2496,10 @@ Button *EditorInspector::create_inspector_action_button(const String &p_text) {
 	return button;
 }
 
+bool EditorInspector::is_main_editor_inspector() const {
+	return InspectorDock::get_singleton() && InspectorDock::get_inspector_singleton() == this;
+}
+
 String EditorInspector::get_selected_path() const {
 	return property_selected;
 }
@@ -3286,7 +3302,7 @@ void EditorInspector::update_tree() {
 		_parse_added_editors(main_vbox, nullptr, ped);
 	}
 
-	if (_is_main_editor_inspector()) {
+	if (is_main_editor_inspector()) {
 		// Updating inspector might invalidate some editing owners.
 		EditorNode::get_singleton()->hide_unused_editors();
 	}
@@ -3316,7 +3332,7 @@ void EditorInspector::_clear(bool p_hide_plugins) {
 	pending.clear();
 	restart_request_props.clear();
 
-	if (p_hide_plugins && _is_main_editor_inspector()) {
+	if (p_hide_plugins && is_main_editor_inspector()) {
 		EditorNode::get_singleton()->hide_unused_editors(this);
 	}
 }
@@ -3650,10 +3666,6 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 			E->update_editor_property_status();
 		}
 	}
-}
-
-bool EditorInspector::_is_main_editor_inspector() const {
-	return InspectorDock::get_singleton() && InspectorDock::get_inspector_singleton() == this;
 }
 
 void EditorInspector::_property_changed(const String &p_path, const Variant &p_value, const String &p_name, bool p_changing, bool p_update_all) {

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -38,6 +38,7 @@
 class AcceptDialog;
 class Button;
 class ConfirmationDialog;
+class EditorInspector;
 class LineEdit;
 class OptionButton;
 class PanelContainer;
@@ -147,6 +148,7 @@ public:
 
 	Object *get_edited_object();
 	StringName get_edited_property() const;
+	EditorInspector *get_parent_inspector() const;
 
 	void set_doc_path(const String &p_doc_path);
 
@@ -498,7 +500,6 @@ class EditorInspector : public ScrollContainer {
 	bool restrict_to_basic = false;
 
 	void _edit_set(const String &p_name, const Variant &p_value, bool p_refresh_all, const String &p_changed_field);
-	bool _is_main_editor_inspector() const;
 
 	void _property_changed(const String &p_path, const Variant &p_value, const String &p_name = "", bool p_changing = false, bool p_update_all = false);
 	void _multiple_properties_changed(Vector<String> p_paths, Array p_values, bool p_changing = false);
@@ -552,6 +553,7 @@ public:
 
 	static EditorProperty *instantiate_property_editor(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide = false);
 
+	bool is_main_editor_inspector() const;
 	String get_selected_path() const;
 
 	void update_tree();

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -4141,6 +4141,13 @@ void EditorPropertyResource::_notification(int p_what) {
 				_update_property_bg();
 			}
 		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			const EditorInspector *ei = get_parent_inspector();
+			if (ei && !ei->is_main_editor_inspector()) {
+				fold_resource();
+			}
+		} break;
 	}
 }
 


### PR DESCRIPTION
Fixes #72262

https://user-images.githubusercontent.com/2223172/219100924-90d85480-1bda-4a35-a36f-32693a6db04a.mp4

