### PR TITLE
C#: Fix internal source generator on the 7.0.200 SDK

### DIFF
--- a/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/UnmanagedCallbacksGenerator.cs
+++ b/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/UnmanagedCallbacksGenerator.cs
@@ -168,7 +168,9 @@ using Godot.NativeInterop;
             {
                 var parameter = callback.Parameters[i];
 
-                source.Append(parameter.ToDisplayString());
+                AppendRefKind(source, parameter.RefKind);
+                source.Append(' ');
+                source.Append(parameter.Type.FullQualifiedNameIncludeGlobal());
                 source.Append(' ');
                 source.Append(parameter.Name);
 


### PR DESCRIPTION
Problem: After installing the 7.0.200 SDK, GodotSharp fails to compile with a whole bunch of errors like:
```
Godot.NativeInterop.NativeFuncs.generated.cs(1546,130): error CS0246: The type or namespace name 'r_str' could not be found (are you missing a using directive or an assembly reference?)
```

https://github.com/dotnet/roslyn/pull/65606 which is included in the 7.0.200 SDK changed `IParameterSymbol.ToDisplayString()` to include the parameter name, after which we add a second parameter name, and the generator output fails to compile.

This PR uses the corresponding `ParameterSyntax` (which actually corresponds to source code and is not just intended for display to the user) instead. `WithAttributeLists(default)` is used to skip custom attributes int the generated output, which would duplicate them and possibly break (if we were to actually use any with the callbacks).

Future work: Audit all uses of `ToDisplayString` and replace them, as they appear to not be intended for generating source.