### PR TITLE
Report argument error when calling variant utility methods with a wrong type

### DIFF
--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -182,17 +182,18 @@ typedef const void *GDExtensionConstRefPtr;
 typedef enum {
 	GDEXTENSION_CALL_OK,
 	GDEXTENSION_CALL_ERROR_INVALID_METHOD,
-	GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT, // Expected a different variant type.
-	GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS, // Expected lower number of arguments.
-	GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS, // Expected higher number of arguments.
+	GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT, // GDExtensionCallError.expected contains a variant type.
+	GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS, // GDExtensionCallError.expected contains a number of arguments.
+	GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS, // GDExtensionCallError.expected contains a number of arguments.
 	GDEXTENSION_CALL_ERROR_INSTANCE_IS_NULL,
-	GDEXTENSION_CALL_ERROR_METHOD_NOT_CONST, // Used for const call.
+	GDEXTENSION_CALL_ERROR_METHOD_NOT_CONST,
+	GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT_MULTI, // GDExtensionCallError.expected contains a bitmask of variant types.
 } GDExtensionCallErrorType;
 
 typedef struct {
 	GDExtensionCallErrorType error;
 	int32_t argument;
-	int32_t expected;
+	int64_t expected;
 } GDExtensionCallError;
 
 typedef void (*GDExtensionVariantFromTypeConstructorFunc)(GDExtensionUninitializedVariantPtr, GDExtensionTypePtr);

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -724,6 +724,7 @@ Variant Object::callp(const StringName &p_method, const Variant **p_args, int p_
 			case Callable::CallError::CALL_ERROR_INVALID_METHOD:
 				break;
 			case Callable::CallError::CALL_ERROR_INVALID_ARGUMENT:
+			case Callable::CallError::CALL_ERROR_INVALID_ARGUMENT_MULTI:
 			case Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS:
 			case Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS:
 			case Callable::CallError::CALL_ERROR_METHOD_NOT_CONST:
@@ -769,6 +770,7 @@ Variant Object::call_const(const StringName &p_method, const Variant **p_args, i
 			case Callable::CallError::CALL_ERROR_METHOD_NOT_CONST:
 				break;
 			case Callable::CallError::CALL_ERROR_INVALID_ARGUMENT:
+			case Callable::CallError::CALL_ERROR_INVALID_ARGUMENT_MULTI:
 			case Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS:
 			case Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS:
 				return ret;

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -58,15 +58,16 @@ public:
 		enum Error {
 			CALL_OK,
 			CALL_ERROR_INVALID_METHOD,
-			CALL_ERROR_INVALID_ARGUMENT, // expected is variant type
-			CALL_ERROR_TOO_MANY_ARGUMENTS, // expected is number of arguments
-			CALL_ERROR_TOO_FEW_ARGUMENTS, // expected is number of arguments
+			CALL_ERROR_INVALID_ARGUMENT, // CallError.expected contains a variant type.
+			CALL_ERROR_TOO_MANY_ARGUMENTS, // CallError.expected contains a number of arguments.
+			CALL_ERROR_TOO_FEW_ARGUMENTS, // CallError.expected contains a number of arguments.
 			CALL_ERROR_INSTANCE_IS_NULL,
 			CALL_ERROR_METHOD_NOT_CONST,
+			CALL_ERROR_INVALID_ARGUMENT_MULTI, // CallError.expected contains a bitmask of variant types.
 		};
 		Error error = Error::CALL_OK;
 		int argument = 0;
-		int expected = 0;
+		int64_t expected = 0;
 	};
 
 	void callp(const Variant **p_arguments, int p_argcount, Variant &r_return_value, CallError &r_call_error) const;

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -116,7 +116,9 @@ Variant VariantUtilityFunctions::floor(Variant x, Callable::CallError &r_error) 
 			return VariantInternalAccessor<Vector4>::get(&x).floor();
 		} break;
 		default: {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT_MULTI;
+			r_error.argument = 0;
+			r_error.expected = (1ULL << Variant::INT) | (1ULL << Variant::FLOAT) | (1ULL << Variant::VECTOR2) | (1ULL << Variant::VECTOR3) | (1ULL << Variant::VECTOR4);
 			return Variant();
 		}
 	}
@@ -149,7 +151,9 @@ Variant VariantUtilityFunctions::ceil(Variant x, Callable::CallError &r_error) {
 			return VariantInternalAccessor<Vector4>::get(&x).ceil();
 		} break;
 		default: {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT_MULTI;
+			r_error.argument = 0;
+			r_error.expected = (1ULL << Variant::INT) | (1ULL << Variant::FLOAT) | (1ULL << Variant::VECTOR2) | (1ULL << Variant::VECTOR3) | (1ULL << Variant::VECTOR4);
 			return Variant();
 		}
 	}
@@ -182,7 +186,9 @@ Variant VariantUtilityFunctions::round(Variant x, Callable::CallError &r_error) 
 			return VariantInternalAccessor<Vector4>::get(&x).round();
 		} break;
 		default: {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT_MULTI;
+			r_error.argument = 0;
+			r_error.expected = (1ULL << Variant::INT) | (1ULL << Variant::FLOAT) | (1ULL << Variant::VECTOR2) | (1ULL << Variant::VECTOR3) | (1ULL << Variant::VECTOR4);
 			return Variant();
 		}
 	}
@@ -224,7 +230,9 @@ Variant VariantUtilityFunctions::abs(const Variant &x, Callable::CallError &r_er
 			return VariantInternalAccessor<Vector4i>::get(&x).abs();
 		} break;
 		default: {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT_MULTI;
+			r_error.argument = 0;
+			r_error.expected = (1ULL << Variant::INT) | (1ULL << Variant::FLOAT) | (1ULL << Variant::VECTOR2) | (1ULL << Variant::VECTOR2I) | (1ULL << Variant::VECTOR3) | (1ULL << Variant::VECTOR3I) | (1ULL << Variant::VECTOR4) | (1ULL << Variant::VECTOR4I);
 			return Variant();
 		}
 	}
@@ -266,7 +274,9 @@ Variant VariantUtilityFunctions::sign(const Variant &x, Callable::CallError &r_e
 			return VariantInternalAccessor<Vector4i>::get(&x).sign();
 		} break;
 		default: {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT_MULTI;
+			r_error.argument = 0;
+			r_error.expected = (1ULL << Variant::INT) | (1ULL << Variant::FLOAT) | (1ULL << Variant::VECTOR2) | (1ULL << Variant::VECTOR2I) | (1ULL << Variant::VECTOR3) | (1ULL << Variant::VECTOR3I) | (1ULL << Variant::VECTOR4) | (1ULL << Variant::VECTOR4I);
 			return Variant();
 		}
 	}
@@ -325,6 +335,7 @@ Variant VariantUtilityFunctions::snapped(const Variant &x, const Variant &step, 
 	if (x.get_type() != step.get_type() && !((x.get_type() == Variant::INT && step.get_type() == Variant::FLOAT) || (x.get_type() == Variant::FLOAT && step.get_type() == Variant::INT))) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 1;
+		r_error.expected = x.get_type();
 		return Variant();
 	}
 
@@ -354,7 +365,9 @@ Variant VariantUtilityFunctions::snapped(const Variant &x, const Variant &step, 
 			return VariantInternalAccessor<Vector4i>::get(&x).snapped(VariantInternalAccessor<Vector4i>::get(&step));
 		} break;
 		default: {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT_MULTI;
+			r_error.argument = 0;
+			r_error.expected = (1ULL << Variant::INT) | (1ULL << Variant::FLOAT) | (1ULL << Variant::VECTOR2) | (1ULL << Variant::VECTOR2I) | (1ULL << Variant::VECTOR3) | (1ULL << Variant::VECTOR3I) | (1ULL << Variant::VECTOR4) | (1ULL << Variant::VECTOR4I);
 			return Variant();
 		}
 	}
@@ -372,8 +385,8 @@ Variant VariantUtilityFunctions::lerp(const Variant &from, const Variant &to, do
 	r_error.error = Callable::CallError::CALL_OK;
 	if (from.get_type() != to.get_type()) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-		r_error.expected = from.get_type();
 		r_error.argument = 1;
+		r_error.expected = from.get_type();
 		return Variant();
 	}
 
@@ -403,7 +416,9 @@ Variant VariantUtilityFunctions::lerp(const Variant &from, const Variant &to, do
 			return VariantInternalAccessor<Color>::get(&from).lerp(VariantInternalAccessor<Color>::get(&to), weight);
 		} break;
 		default: {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT_MULTI;
+			r_error.argument = 0;
+			r_error.expected = (1ULL << Variant::INT) | (1ULL << Variant::FLOAT) | (1ULL << Variant::VECTOR2) | (1ULL << Variant::VECTOR3) | (1ULL << Variant::VECTOR4) | (1ULL << Variant::QUATERNION) | (1ULL << Variant::BASIS) | (1ULL << Variant::COLOR);
 			return Variant();
 		}
 	}
@@ -478,25 +493,25 @@ double VariantUtilityFunctions::db_to_linear(double db) {
 Variant VariantUtilityFunctions::wrap(const Variant &p_x, const Variant &p_min, const Variant &p_max, Callable::CallError &r_error) {
 	Variant::Type x_type = p_x.get_type();
 	if (x_type != Variant::INT && x_type != Variant::FLOAT) {
-		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT_MULTI;
 		r_error.argument = 0;
-		r_error.expected = x_type;
+		r_error.expected = (1ULL << Variant::INT) | (1ULL << Variant::FLOAT);
 		return Variant();
 	}
 
 	Variant::Type min_type = p_min.get_type();
 	if (min_type != Variant::INT && min_type != Variant::FLOAT) {
-		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT_MULTI;
 		r_error.argument = 1;
-		r_error.expected = x_type;
+		r_error.expected = (1ULL << Variant::INT) | (1ULL << Variant::FLOAT);
 		return Variant();
 	}
 
 	Variant::Type max_type = p_max.get_type();
 	if (max_type != Variant::INT && max_type != Variant::FLOAT) {
-		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT_MULTI;
 		r_error.argument = 2;
-		r_error.expected = x_type;
+		r_error.expected = (1ULL << Variant::INT) | (1ULL << Variant::FLOAT);
 		return Variant();
 	}
 
@@ -545,9 +560,9 @@ Variant VariantUtilityFunctions::max(const Variant **p_args, int p_argcount, Cal
 	for (int i = 0; i < p_argcount; i++) {
 		Variant::Type arg_type = p_args[i]->get_type();
 		if (arg_type != Variant::INT && arg_type != Variant::FLOAT) {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.expected = Variant::FLOAT;
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT_MULTI;
 			r_error.argument = i;
+			r_error.expected = (1ULL << Variant::INT) | (1ULL << Variant::FLOAT);
 			return Variant();
 		}
 		if (i == 0) {
@@ -589,9 +604,9 @@ Variant VariantUtilityFunctions::min(const Variant **p_args, int p_argcount, Cal
 	for (int i = 0; i < p_argcount; i++) {
 		Variant::Type arg_type = p_args[i]->get_type();
 		if (arg_type != Variant::INT && arg_type != Variant::FLOAT) {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.expected = Variant::FLOAT;
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT_MULTI;
 			r_error.argument = i;
+			r_error.expected = (1ULL << Variant::INT) | (1ULL << Variant::FLOAT);
 			return Variant();
 		}
 		if (i == 0) {

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2889,6 +2889,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 					case Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS:
 						push_error(vformat(R"(Too few arguments for %s constructor. Received %d but expected %d.)", Variant::get_type_name(builtin_type), p_call->arguments.size(), err.expected), p_call);
 						break;
+					case Callable::CallError::CALL_ERROR_INVALID_ARGUMENT_MULTI:
 					case Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL:
 					case Callable::CallError::CALL_ERROR_METHOD_NOT_CONST:
 						break; // Can't happen in a builtin constructor.
@@ -3002,6 +3003,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 					case Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS:
 						push_error(vformat(R"*(Too few arguments for "%s()" call. Expected at least %d but received %d.)*", function_name, err.expected, p_call->arguments.size()), p_call);
 						break;
+					case Callable::CallError::CALL_ERROR_INVALID_ARGUMENT_MULTI:
 					case Callable::CallError::CALL_ERROR_METHOD_NOT_CONST:
 					case Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL:
 						break; // Can't happen in a builtin constructor.
@@ -3043,6 +3045,21 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 						}
 
 						push_error(vformat(R"*(Invalid argument for "%s()" function: argument %d should be "%s" but is "%s".)*", function_name, err.argument + 1,
+										   expected_type_name, p_call->arguments[err.argument]->get_datatype().to_string()),
+								p_call->arguments[err.argument]);
+					} break;
+					case Callable::CallError::CALL_ERROR_INVALID_ARGUMENT_MULTI: {
+						String expected_type_name;
+						for (int i = 0; i < Variant::Type::VARIANT_MAX; i++) {
+							if (err.expected & (1ULL << i)) {
+								if (!expected_type_name.is_empty()) {
+									expected_type_name += "\", \"";
+								}
+								expected_type_name += Variant::get_type_name(Variant::Type(i));
+							}
+						}
+
+						push_error(vformat(R"*(Invalid argument for "%s()" function: argument %d should be one of "%s" but is "%s".)*", function_name, err.argument + 1,
 										   expected_type_name, p_call->arguments[err.argument]->get_datatype().to_string()),
 								p_call->arguments[err.argument]);
 					} break;

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -127,6 +127,20 @@ String GDScriptFunction::_get_call_error(const Callable::CallError &p_err, const
 		{
 			err_text = "Invalid type in " + p_where + ". Cannot convert argument " + itos(errorarg + 1) + " from " + Variant::get_type_name(argptrs[errorarg]->get_type()) + " to " + Variant::get_type_name(Variant::Type(p_err.expected)) + ".";
 		}
+	} else if (p_err.error == Callable::CallError::CALL_ERROR_INVALID_ARGUMENT_MULTI) {
+		int errorarg = p_err.argument;
+		String arg_text;
+
+		for (int i = 0; i < Variant::Type::VARIANT_MAX; i++) {
+			if (p_err.expected & (1ULL << i)) {
+				if (!arg_text.is_empty()) {
+					arg_text += ", ";
+				}
+				arg_text += Variant::get_type_name(Variant::Type(i));
+			}
+		}
+
+		err_text = "Invalid type in " + p_where + ". Cannot convert argument " + itos(errorarg + 1) + " from " + Variant::get_type_name(argptrs[errorarg]->get_type()) + " to one of the following: " + arg_text + ".";
 	} else if (p_err.error == Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS) {
 		err_text = "Invalid call to " + p_where + ". Expected " + itos(p_err.argument) + " arguments.";
 	} else if (p_err.error == Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS) {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/6294.

So, right now we have `floor`, `ceil`, `round`, `abs`, `sign`, `snapped`, and `lerp` which take a variant argument of any kind, but only accept a certain subset of variants. When you pass to them an unsupported type of variant, they err with an "invalid method" error. Which leads to two kinds of messages. If GDScript analyzer can resolve the expression inside of the method call, it reports "Invalid call for function". If it doesn't and we try to run the script, it reports "Invalid call. Nonexistent utility function" (which you have to admit carries a bit of a different meaning, worth rewording perhaps?).

We have an error type for invalid arguments, though, and both `snapped` and `lerp` use it for the second argument, but not for the first one. So that's a simple change. However, this error wants us to supply the expected type, which can only be a single type. `snapped` and `lerp` simply ignore that fact, supply nothing, which means they supply `Variant::NIL`. So the error reads to the users "Cannot convert <type> to Nil", which is very wrong. But then again, there is no support for a purely right way either.

So I try to fix that by passing `Variant::VARIANT_MAX`, which is then converted to string as simply "Variant". Still wrong, but _less_ wrong. Which is the best I can offer without disturbing the core codebase.

New runtime error:
> Invalid type in utility function 'floor'. Cannot convert argument 1 from bool to Variant.

New analyzer error:
> Parse Error: Invalid argument for "floor()" function: argument 1 should be "Variant" but is "bool".