### PR TITLE
C#: Open the solution directory when using VSCode

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -272,8 +272,7 @@ namespace GodotTools
                         }
                     }
 
-                    string resourcePath = ProjectSettings.GlobalizePath("res://");
-                    args.Add(resourcePath);
+                    args.Add(Path.GetDirectoryName(GodotSharpDirs.ProjectSlnPath));
 
                     string scriptPath = ProjectSettings.GlobalizePath(script.ResourcePath);
 


### PR DESCRIPTION
The solution directory used to be the same as the project directory (`res://`). We now allow specifying a different path for the solution and the other external editors already use that (which seems more convenient for multi-project scenarios).
