### PR TITLE
Fix crash with AspectRatioContainer and TextureRect

### DIFF
--- a/doc/classes/TextureRect.xml
+++ b/doc/classes/TextureRect.xml
@@ -10,8 +10,9 @@
 		<link title="3D Voxel Demo">https://godotengine.org/asset-library/asset/676</link>
 	</tutorials>
 	<members>
-		<member name="expand_mode" type="int" setter="set_expand_mode" getter="get_expand_mode" enum="TextureRect.ExpandMode" default="0">
+		<member name="expand_mode" type="int" setter="set_expand_mode" getter="get_expand_mode" enum="TextureRect.ExpandMode" default="0" is_experimental="true">
 			Defines how minimum size is determined based on the texture's size. See [enum ExpandMode] for options.
+			[b]Note:[/b] Using [constant EXPAND_FIT_WIDTH], [constant EXPAND_FIT_WIDTH_PROPORTIONAL], [constant EXPAND_FIT_HEIGHT] or [constant EXPAND_FIT_HEIGHT_PROPORTIONAL] may result in unstable behavior in some containers. This functionality is being re-evaluated and will change in the future.
 		</member>
 		<member name="flip_h" type="bool" setter="set_flip_h" getter="is_flipped_h" default="false">
 			If [code]true[/code], texture is flipped horizontally.

--- a/scene/gui/aspect_ratio_container.cpp
+++ b/scene/gui/aspect_ratio_container.cpp
@@ -30,6 +30,8 @@
 
 #include "aspect_ratio_container.h"
 
+#include "scene/gui/texture_rect.h"
+
 Size2 AspectRatioContainer::get_minimum_size() const {
 	Size2 ms;
 	for (int i = 0; i < get_child_count(); i++) {
@@ -113,6 +115,16 @@ void AspectRatioContainer::_notification(int p_what) {
 				if (c->is_set_as_top_level()) {
 					continue;
 				}
+
+				// Temporary fix for editor crash.
+				TextureRect *trect = Object::cast_to<TextureRect>(c);
+				if (trect) {
+					if (trect->get_expand_mode() == TextureRect::EXPAND_FIT_WIDTH_PROPORTIONAL || trect->get_expand_mode() == TextureRect::EXPAND_FIT_HEIGHT_PROPORTIONAL) {
+						WARN_PRINT_ONCE("Proportional TextureRect is currently not supported inside AspectRatioContainer");
+						continue;
+					}
+				}
+
 				Size2 child_minsize = c->get_combined_minimum_size();
 				Size2 child_size = Size2(ratio, 1.0);
 				float scale_factor = 1.0;


### PR DESCRIPTION
Fixes crash part of #73071

This is a temporary solution, and the only case that crashes the editor. Proportional TextureRect does not make sense with AspectRatioContainer anyway, because both functionalities solve the same problem.