### PR TITLE
Fix unset getter return types resulting in strange behavior

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -254,7 +254,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				if (codegen.script->member_indices.has(identifier)) {
 					if (codegen.script->member_indices[identifier].getter != StringName() && codegen.script->member_indices[identifier].getter != codegen.function_name) {
 						// Perform getter.
-						GDScriptCodeGenerator::Address temp = codegen.add_temporary();
+						GDScriptCodeGenerator::Address temp = codegen.add_temporary(codegen.script->member_indices[identifier].data_type);
 						Vector<GDScriptCodeGenerator::Address> args; // No argument needed.
 						gen->write_call_self(temp, codegen.script->member_indices[identifier].getter, args);
 						return temp;

--- a/modules/gdscript/tests/scripts/analyzer/features/getter_return_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/getter_return_type.gd
@@ -1,0 +1,9 @@
+var Value:int = 8 :
+	get:
+		return Value
+	set(v):
+		Value = v
+
+func test():
+	var f:float = Value
+	print(int(f))

--- a/modules/gdscript/tests/scripts/analyzer/features/getter_return_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/getter_return_type.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+8


### PR DESCRIPTION
Fixes #65675.

Simply sets the type of the temporary address used to return the value of a getter. This prevents situations where the compiler thinks the getter doesn't return anything, and therefore doesn't perform necessary checks on assignments/operations based off the result of the getter.

There's a few things that I still generally don't understand. When using `OPCODE_ASSIGN`, nothing was being checked, which is how the `float` variable in the linked issue ended up with an `int` inside. I feel like that might still be possible elsewhere. Also, I'm still not sure how `int()` of something that's not 0 became 0.

I also suspect that it might still somehow be possible to fool the compiler into assigning the `int` into a `float` with no runtime checks for types.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
