### PR TITLE
Add missing virtual bind for `ScriptExtension::_get_global_name`

### DIFF
--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -36,6 +36,7 @@ void ScriptExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_can_instantiate);
 	GDVIRTUAL_BIND(_get_base_script);
+	GDVIRTUAL_BIND(_get_global_name);
 	GDVIRTUAL_BIND(_inherits_script, "script");
 
 	GDVIRTUAL_BIND(_get_instance_base_type);

--- a/doc/classes/ScriptExtension.xml
+++ b/doc/classes/ScriptExtension.xml
@@ -32,6 +32,11 @@
 			<description>
 			</description>
 		</method>
+		<method name="_get_global_name" qualifiers="virtual const">
+			<return type="StringName" />
+			<description>
+			</description>
+		</method>
 		<method name="_get_instance_base_type" qualifiers="virtual const">
 			<return type="StringName" />
 			<description>


### PR DESCRIPTION
Missing from #71687.