### PR TITLE
Fix error spam when naming a func at the end of the script

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1521,7 +1521,7 @@ GDScriptParser::SuiteNode *GDScriptParser::parse_suite(const String &p_context, 
 	int error_count = 0;
 
 	do {
-		if (!multiline && previous.type == GDScriptTokenizer::Token::SEMICOLON && check(GDScriptTokenizer::Token::NEWLINE)) {
+		if (is_at_end() || (!multiline && previous.type == GDScriptTokenizer::Token::SEMICOLON && check(GDScriptTokenizer::Token::NEWLINE))) {
 			break;
 		}
 		Node *statement = parse_statement();


### PR DESCRIPTION
An attempt at fixes #63946. At least I couldn't think of something better.

First tackling with the parser, so an experienced review would be neat. To my understanding, here's what's going on:

As you're writing the name of a function at the end of a file, you have:
* **Coke:** `func` causes multiline parsing, since brackets must be able to be parsed even if they are on different lines. Because of this, the parser considers that the next token is EOF.
* **Mentos:** `func` can declare a function or a lambda, so there doesn't exist a prefix rule and the expression has to advance here to avoid an infinite loop.

So when these properties of `func` mix together, you get an explosion of errors.

I'm thinking there might be a nicer way to do this than a condition for expression statements. If you GDScript folk come up with a better but far more complex way, I'll probably not implement it because I'd need too much handholding.