### PR TITLE
not to trim possible indentation

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1096,6 +1096,7 @@ void CodeTextEditor::trim_trailing_whitespace() {
 	for (int i = 0; i < text_editor->get_line_count(); i++) {
 		String line = text_editor->get_line(i);
 		if (line.ends_with(" ") || line.ends_with("\t")) {
+			if (line.rstrip("\t").is_empty()) continue;
 			if (!trimed_whitespace) {
 				text_editor->begin_complex_operation();
 				trimed_whitespace = true;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Fix https://github.com/godotengine/godot-proposals/issues/6300.

![image](https://user-images.githubusercontent.com/28104173/219306853-1d30f5f1-ba77-4800-9cea-1b1ee27cee3f.png)

If `Autosave` and `TrimTrailingWhiteSpaceOnSave` are both checked, when the script triggers an autosave event, it removes all the TABs (which can be user's indentation placeholder) and moves the caret unexpectedly.
