### PR TITLE
Add `get_tree_string` and `get_tree_string_pretty` methods to Node to complement printing methods

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -415,6 +415,36 @@
 				Returns the [SceneTree] that contains this node.
 			</description>
 		</method>
+		<method name="get_tree_string">
+			<return type="String" />
+			<description>
+				Returns the tree in shape of a String. Used mainly for debugging purposes. This version displays the path relative to the current node, and is good for copy/pasting into the [method get_node] function. It also can be used into the games' UI/UX.
+				[b]Example output:[/b]
+				[codeblock]
+				TheGame
+				TheGame/Menu
+				TheGame/Menu/Label
+				TheGame/Menu/Camera2D
+				TheGame/SplashScreen
+				TheGame/SplashScreen/Camera2D
+				[/codeblock]
+			</description>
+		</method>
+		<method name="get_tree_string_pretty">
+			<return type="String" />
+			<description>
+				Similar to [method get_tree_string], this returns the tree in the shape of a String. This version displays a more graphical representation similar to what is displayed in the Scene Dock. It is useful for inspecting larger trees.
+				[b]Example output:[/b]
+				[codeblock]
+				 ┖╴TheGame
+				    ┠╴Menu
+				    ┃  ┠╴Label
+				    ┃  ┖╴Camera2D
+				    ┖╴SplashScreen
+				       ┖╴Camera2D
+				[/codeblock]
+			</description>
+		</method>
 		<method name="get_viewport" qualifiers="const">
 			<return type="Viewport" />
 			<description>

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1867,28 +1867,40 @@ int Node::get_persistent_group_count() const {
 	return count;
 }
 
-void Node::_print_tree_pretty(const String &prefix, const bool last) {
-	String new_prefix = last ? String::utf8(" ┖╴") : String::utf8(" ┠╴");
-	print_line(prefix + new_prefix + String(get_name()));
-	for (int i = 0; i < data.children.size(); i++) {
-		new_prefix = last ? String::utf8("   ") : String::utf8(" ┃ ");
-		data.children[i]->_print_tree_pretty(prefix + new_prefix, i == data.children.size() - 1);
-	}
-}
-
 void Node::print_tree_pretty() {
-	_print_tree_pretty("", true);
+	print_line(_get_tree_string_pretty("", true));
 }
 
 void Node::print_tree() {
-	_print_tree(this);
+	print_line(_get_tree_string(this));
 }
 
-void Node::_print_tree(const Node *p_node) {
-	print_line(String(p_node->get_path_to(this)));
+String Node::_get_tree_string_pretty(const String &prefix, const bool last) {
+	String new_prefix = last ? String::utf8(" ┖╴") : String::utf8(" ┠╴");
+	String return_tree = "";
+	return_tree += prefix + new_prefix + String(get_name()) + "\n";
 	for (int i = 0; i < data.children.size(); i++) {
-		data.children[i]->_print_tree(p_node);
+		new_prefix = last ? String::utf8("   ") : String::utf8(" ┃ ");
+		return_tree += data.children[i]->_get_tree_string_pretty(prefix + new_prefix, i == data.children.size() - 1);
 	}
+	return return_tree;
+}
+
+String Node::get_tree_string_pretty() {
+	return _get_tree_string_pretty("", true);
+}
+
+String Node::_get_tree_string(const Node *p_node) {
+	String return_tree = "";
+	return_tree += String(p_node->get_path_to(this)) + "\n";
+	for (int i = 0; i < data.children.size(); i++) {
+		return_tree += data.children[i]->_get_tree_string(p_node);
+	}
+	return return_tree;
+}
+
+String Node::get_tree_string() {
+	return _get_tree_string(this);
 }
 
 void Node::_propagate_reverse_notification(int p_notification) {
@@ -2847,6 +2859,8 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_index", "include_internal"), &Node::get_index, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("print_tree"), &Node::print_tree);
 	ClassDB::bind_method(D_METHOD("print_tree_pretty"), &Node::print_tree_pretty);
+	ClassDB::bind_method(D_METHOD("get_tree_string"), &Node::get_tree_string);
+	ClassDB::bind_method(D_METHOD("get_tree_string_pretty"), &Node::get_tree_string_pretty);
 	ClassDB::bind_method(D_METHOD("set_scene_file_path", "scene_file_path"), &Node::set_scene_file_path);
 	ClassDB::bind_method(D_METHOD("get_scene_file_path"), &Node::get_scene_file_path);
 	ClassDB::bind_method(D_METHOD("propagate_notification", "what"), &Node::propagate_notification);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -158,8 +158,8 @@ private:
 
 	Ref<MultiplayerAPI> multiplayer;
 
-	void _print_tree_pretty(const String &prefix, const bool last);
-	void _print_tree(const Node *p_node);
+	String _get_tree_string_pretty(const String &prefix, const bool last);
+	String _get_tree_string(const Node *p_node);
 
 	Node *_get_child_by_name(const StringName &p_name) const;
 
@@ -367,6 +367,8 @@ public:
 
 	void print_tree();
 	void print_tree_pretty();
+	String get_tree_string();
+	String get_tree_string_pretty();
 
 	void set_scene_file_path(const String &p_scene_file_path);
 	String get_scene_file_path() const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Add two methods to Node class:

- `get_tree_string` that allows to return a string containing the tree in shape of a list
- `get_tree_string_pretty` that makes the same thing but in a more convenient shape.
these methods complement the `print_tree` and `print_tree_pretty` methods.

proposal: https://github.com/godotengine/godot-proposals/issues/6288

(succesfully works with the latest code)

