### PR TITLE
Fix documentation for ArrayMesh `regen_normal_maps()` function.

### DIFF
--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -112,7 +112,7 @@
 		<method name="regen_normal_maps">
 			<return type="void" />
 			<description>
-				Regenerates tangents for each of the [ArrayMesh]'s surfaces.
+				Regenerates normals for each of the [ArrayMesh]'s surfaces.
 			</description>
 		</method>
 		<method name="set_blend_shape_name">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
