### PR TITLE
Allow unbundling OpenXR (for Linux distros)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -244,6 +244,7 @@ opts.Add(BoolVariable("builtin_libwebp", "Use the built-in libwebp library", Tru
 opts.Add(BoolVariable("builtin_wslay", "Use the built-in wslay library", True))
 opts.Add(BoolVariable("builtin_mbedtls", "Use the built-in mbedTLS library", True))
 opts.Add(BoolVariable("builtin_miniupnpc", "Use the built-in miniupnpc library", True))
+opts.Add(BoolVariable("builtin_openxr", "Use the built-in OpenXR library", True))
 opts.Add(BoolVariable("builtin_pcre2", "Use the built-in PCRE2 library", True))
 opts.Add(BoolVariable("builtin_pcre2_with_jit", "Use JIT compiler for the built-in PCRE2 library", True))
 opts.Add(BoolVariable("builtin_recastnavigation", "Use the built-in Recast navigation library", True))

--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -5,22 +5,13 @@ Import("env_modules")
 
 env_openxr = env_modules.Clone()
 
-#################################################
-# Add in our Khronos OpenXR loader
+# Thirdparty source files
 
 thirdparty_obj = []
-thirdparty_dir = "#thirdparty/openxr"
 
-env_openxr.Prepend(
-    CPPPATH=[
-        thirdparty_dir,
-        thirdparty_dir + "/include",
-        thirdparty_dir + "/src",
-        thirdparty_dir + "/src/common",
-        thirdparty_dir + "/src/external/jsoncpp/include",
-    ]
-)
+# Khronos OpenXR loader
 
+# Needs even for build against shared library, at least the defines used in public headers.
 if env["platform"] == "android":
     # may need to set OPENXR_ANDROID_VERSION_SUFFIX
     env_openxr.AppendUnique(CPPDEFINES=["XR_OS_ANDROID", "XR_USE_PLATFORM_ANDROID"])
@@ -41,43 +32,57 @@ elif env["platform"] == "windows":
 # may need to check and set:
 # - XR_USE_TIMESPEC
 
-env_thirdparty = env_openxr.Clone()
-env_thirdparty.disable_warnings()
-env_thirdparty.AppendUnique(CPPDEFINES=["DISABLE_STD_FILESYSTEM"])
+if env["builtin_openxr"]:
+    thirdparty_dir = "#thirdparty/openxr"
 
-if "-fno-exceptions" in env_thirdparty["CXXFLAGS"]:
-    env_thirdparty["CXXFLAGS"].remove("-fno-exceptions")
-env_thirdparty.Append(CPPPATH=[thirdparty_dir + "/src/loader"])
+    env_openxr.Prepend(
+        CPPPATH=[
+            thirdparty_dir,
+            thirdparty_dir + "/include",
+            thirdparty_dir + "/src",
+            thirdparty_dir + "/src/common",
+            thirdparty_dir + "/src/external/jsoncpp/include",
+        ]
+    )
 
-# add in external jsoncpp dependency
-env_thirdparty.add_source_files(thirdparty_obj, thirdparty_dir + "/src/external/jsoncpp/src/lib_json/json_reader.cpp")
-env_thirdparty.add_source_files(thirdparty_obj, thirdparty_dir + "/src/external/jsoncpp/src/lib_json/json_value.cpp")
-env_thirdparty.add_source_files(thirdparty_obj, thirdparty_dir + "/src/external/jsoncpp/src/lib_json/json_writer.cpp")
+    env_thirdparty = env_openxr.Clone()
+    env_thirdparty.disable_warnings()
+    env_thirdparty.AppendUnique(CPPDEFINES=["DISABLE_STD_FILESYSTEM"])
 
-# add in load
-if env["platform"] != "android":
-    # On Android the openxr_loader is provided by separate plugins for each device
-    # Build the engine using object files
-    khrloader_obj = []
-    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/xr_generated_dispatch_table.c")
+    if "-fno-exceptions" in env_thirdparty["CXXFLAGS"]:
+        env_thirdparty["CXXFLAGS"].remove("-fno-exceptions")
+    env_thirdparty.Append(CPPPATH=[thirdparty_dir + "/src/loader"])
 
-    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/common/filesystem_utils.cpp")
-    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/common/object_info.cpp")
+    # add in external jsoncpp dependency
+    thirdparty_jsoncpp_dir = thirdparty_dir + "/src/external/jsoncpp/src/lib_json/"
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_jsoncpp_dir + "json_reader.cpp")
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_jsoncpp_dir + "json_value.cpp")
+    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_jsoncpp_dir + "json_writer.cpp")
 
-    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/api_layer_interface.cpp")
-    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_core.cpp")
-    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_instance.cpp")
-    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_logger_recorders.cpp")
-    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_logger.cpp")
-    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/manifest_file.cpp")
-    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/runtime_interface.cpp")
-    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/xr_generated_loader.cpp")
-    env.modules_sources += khrloader_obj
+    # add in load
+    if env["platform"] != "android":
+        # On Android the openxr_loader is provided by separate plugins for each device
+        # Build the engine using object files
+        khrloader_obj = []
+        env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/xr_generated_dispatch_table.c")
 
-env.modules_sources += thirdparty_obj
+        env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/common/filesystem_utils.cpp")
+        env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/common/object_info.cpp")
 
-#################################################
-# And include our module source
+        env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/api_layer_interface.cpp")
+        env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_core.cpp")
+        env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_instance.cpp")
+        env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_logger_recorders.cpp")
+        env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_logger.cpp")
+        env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/manifest_file.cpp")
+        env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/runtime_interface.cpp")
+        env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/xr_generated_loader.cpp")
+        env.modules_sources += khrloader_obj
+
+    env.modules_sources += thirdparty_obj
+
+
+# Godot source files
 
 module_obj = []
 

--- a/modules/openxr/extensions/openxr_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper.h
@@ -36,8 +36,6 @@
 #include "core/templates/hash_map.h"
 #include "core/templates/rid.h"
 
-#include "thirdparty/openxr/src/common/xr_linear.h"
-
 #include <openxr/openxr.h>
 
 class OpenXRAPI;

--- a/modules/openxr/extensions/openxr_opengl_extension.cpp
+++ b/modules/openxr/extensions/openxr_opengl_extension.cpp
@@ -278,8 +278,8 @@ bool OpenXROpenGLExtension::get_swapchain_image_data(XrSwapchain p_swapchain, in
 }
 
 bool OpenXROpenGLExtension::create_projection_fov(const XrFovf p_fov, double p_z_near, double p_z_far, Projection &r_camera_matrix) {
-	XrMatrix4x4f matrix;
-	XrMatrix4x4f_CreateProjectionFov(&matrix, GRAPHICS_OPENGL, p_fov, (float)p_z_near, (float)p_z_far);
+	OpenXRUtil::XrMatrix4x4f matrix;
+	OpenXRUtil::XrMatrix4x4f_CreateProjectionFov(&matrix, OpenXRUtil::GRAPHICS_OPENGL, p_fov, (float)p_z_near, (float)p_z_far);
 
 	for (int j = 0; j < 4; j++) {
 		for (int i = 0; i < 4; i++) {

--- a/modules/openxr/extensions/openxr_vulkan_extension.cpp
+++ b/modules/openxr/extensions/openxr_vulkan_extension.cpp
@@ -381,8 +381,8 @@ bool OpenXRVulkanExtension::get_swapchain_image_data(XrSwapchain p_swapchain, in
 
 bool OpenXRVulkanExtension::create_projection_fov(const XrFovf p_fov, double p_z_near, double p_z_far, Projection &r_camera_matrix) {
 	// Even though this is a Vulkan renderer we're using OpenGL coordinate systems
-	XrMatrix4x4f matrix;
-	XrMatrix4x4f_CreateProjectionFov(&matrix, GRAPHICS_OPENGL, p_fov, (float)p_z_near, (float)p_z_far);
+	OpenXRUtil::XrMatrix4x4f matrix;
+	OpenXRUtil::XrMatrix4x4f_CreateProjectionFov(&matrix, OpenXRUtil::GRAPHICS_OPENGL, p_fov, (float)p_z_near, (float)p_z_far);
 
 	for (int j = 0; j < 4; j++) {
 		for (int i = 0; i < 4; i++) {

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -48,8 +48,6 @@
 #include "core/templates/vector.h"
 #include "servers/xr/xr_pose.h"
 
-#include "thirdparty/openxr/src/common/xr_linear.h"
-
 #include <openxr/openxr.h>
 
 // Note, OpenXR code that we wrote for our plugin makes use of C++20 notation for initializing structs which ensures zeroing out unspecified members.

--- a/modules/openxr/openxr_util.h
+++ b/modules/openxr/openxr_util.h
@@ -44,6 +44,27 @@ public:
 	static String get_action_type_name(XrActionType p_action_type);
 	static String get_environment_blend_mode_name(XrEnvironmentBlendMode p_blend_mode);
 	static String make_xr_version_string(XrVersion p_version);
+
+	// Copied from OpenXR xr_linear.h private header, so we can still link against
+	// system-provided packages without relying on our `thirdparty` code.
+
+	// Column-major, pre-multiplied. This type does not exist in the OpenXR API and is provided for convenience.
+	typedef struct XrMatrix4x4f {
+		float m[16];
+	} XrMatrix4x4f;
+
+	typedef enum GraphicsAPI {
+		GRAPHICS_VULKAN,
+		GRAPHICS_OPENGL,
+		GRAPHICS_OPENGL_ES,
+		GRAPHICS_D3D
+	} GraphicsAPI;
+
+	static void XrMatrix4x4f_CreateProjection(XrMatrix4x4f *result, GraphicsAPI graphicsApi, const float tanAngleLeft,
+			const float tanAngleRight, const float tanAngleUp, float const tanAngleDown,
+			const float nearZ, const float farZ);
+	static void XrMatrix4x4f_CreateProjectionFov(XrMatrix4x4f *result, GraphicsAPI graphicsApi, const XrFovf fov,
+			const float nearZ, const float farZ);
 };
 
 #endif // OPENXR_UTIL_H

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -291,6 +291,9 @@ def configure(env: "Environment"):
         # No pkgconfig file so far, hardcode expected lib name.
         env.Append(LIBS=["embree3"])
 
+    if not env["builtin_openxr"]:
+        env.ParseConfig("pkg-config openxr --cflags --libs")
+
     if env["fontconfig"]:
         if not env["use_sowrap"]:
             if os.system("pkg-config --exists fontconfig") == 0:  # 0 means found


### PR DESCRIPTION
Linux distros typically like to link dynamically against system libraries when packaging software, which applies to Godot packages too.

Like we do for other libraries which are usually available as system library, we add a `builtin_openxr` option which can be turned off to link to system libraries on Linux. Note that the system is a bit brittle, if someone tries to turn off this option on other platforms they'll likely get a build error - but the same applies to all other `builtin_*` options we have currently, one day I'll clean up all this.

I have an issue preventing me from finalizing this, which is that we actually use `XrMatrix4x4f` which is not part of the public API of OpenXR, but included in one of the private source headers. So to be able to building against system headers, we'd need to either use a different, public API, or copy the relevant bits of code (maybe port them to Godot's `Projection` matrix?).