### PR TITLE
Avoid GDScript bookkeeping from referencing objects longer than necessary

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -48,6 +48,33 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 
 	const static int RESERVED_STACK = 3; // For self, class, and nil.
 
+	struct CallTarget {
+		Address target;
+		bool is_new_temporary = false;
+		GDScriptByteCodeGenerator *codegen = nullptr;
+#ifdef DEV_ENABLED
+		bool cleaned = false;
+#endif
+
+		void cleanup() {
+			DEV_ASSERT(!cleaned);
+			if (is_new_temporary) {
+				codegen->pop_temporary();
+			}
+#ifdef DEV_ENABLED
+			cleaned = true;
+#endif
+		}
+
+		CallTarget(Address p_target, bool p_is_new_temporary, GDScriptByteCodeGenerator *p_codegen) :
+				target(p_target),
+				is_new_temporary(p_is_new_temporary),
+				codegen(p_codegen) {}
+		~CallTarget() { DEV_ASSERT(cleaned); }
+		CallTarget(const CallTarget &) = delete;
+		CallTarget &operator=(CallTarget &) = delete;
+	};
+
 	bool ended = false;
 	GDScriptFunction *function = nullptr;
 	bool debug_stack = false;
@@ -326,7 +353,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 		}
 	}
 
-	Address get_call_target(const Address &p_target, Variant::Type p_type = Variant::NIL);
+	CallTarget get_call_target(const Address &p_target, Variant::Type p_type = Variant::NIL);
 
 	int address_of(const Address &p_address) {
 		switch (p_address.mode) {


### PR DESCRIPTION
I could have added a new opcode hardwired to assign null, which looks kind of more natural for the task, but assigning `false` is fine, since there's already an opcode for that, and any builtin type would do as well as a null object.

This has a potential for optimization; i.e., there's no real need to clean up a temporary that is going to be reused immediately, but I guess that can come in a future iteration. I'd be surprised if this implementation hurted performance badly.

**UPDATE:** Consolidated the list of issues fixed.
Confirmed fixed the following (at least, MRPs work fine):
- Fixes #73355.
- Fixes #73311.
- Fixes #69551.
- Fixes #68614.
- Fixes #66818 (see comment there).
- Fixes #69504 (whether it's a bug it's a bit blurry to me, but with this PR the MRP works as expected).

**NOTE:** Forgot to say that I haven't tested this extensively. It'd be nice that someone run a more or less script intensive project to hunt down issues.