### PR TITLE
Disable AMD switchable graphics on Windows with Vulkan to fix driver issue

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -151,11 +151,6 @@ static void _error_handler(void *p_self, const char *p_func, const char *p_file,
 void OS_Windows::initialize() {
 	crash_handler.initialize();
 
-	// Workaround for Vulkan not working on setups with AMD integrated graphics + NVIDIA dedicated GPU (GH-57708).
-	// This prevents using AMD integrated graphics with Vulkan entirely, but it allows the engine to start
-	// even on outdated/broken driver setups.
-	OS::get_singleton()->set_environment("DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1", "1");
-
 #ifdef WINDOWS_DEBUG_OUTPUT_ENABLED
 	error_handlers.errfunc = _error_handler;
 	error_handlers.userdata = this;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -151,6 +151,11 @@ static void _error_handler(void *p_self, const char *p_func, const char *p_file,
 void OS_Windows::initialize() {
 	crash_handler.initialize();
 
+	// Workaround for Vulkan not working on setups with AMD integrated graphics + NVIDIA dedicated GPU (GH-57708).
+	// This prevents using AMD integrated graphics with Vulkan entirely, but it allows the engine to start
+	// even on outdated/broken driver setups.
+	OS::get_singleton()->set_environment("DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1", "1");
+
 #ifdef WINDOWS_DEBUG_OUTPUT_ENABLED
 	error_handlers.errfunc = _error_handler;
 	error_handlers.userdata = this;

--- a/platform/windows/vulkan_context_win.cpp
+++ b/platform/windows/vulkan_context_win.cpp
@@ -55,6 +55,10 @@ Error VulkanContextWindows::window_create(DisplayServer::WindowID p_window_id, D
 }
 
 VulkanContextWindows::VulkanContextWindows() {
+	// Workaround for Vulkan not working on setups with AMD integrated graphics + NVIDIA dedicated GPU (GH-57708).
+	// This prevents using AMD integrated graphics with Vulkan entirely, but it allows the engine to start
+	// even on outdated/broken driver setups.
+	OS::get_singleton()->set_environment("DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1", "1");
 }
 
 VulkanContextWindows::~VulkanContextWindows() {


### PR DESCRIPTION
This is a required workaround on setups with AMD integrated graphics + NVIDIA dedicated GPU to be able to start the engine with the Forward+ or Forward Mobile rendering methods.

While a AMD driver update can resolve this issue, it still gets reported regularly and is likely to become a source of support headache for people distributing projects made with Godot (as this also affects exported projects).

The only case where disabling integrated graphics is really a problem is for non-game applications, but these are likely to use OpenGL anyway due to the lower rendering base cost and system requirements.

Please test, as I have no setup to test this locally. This targets a merge for 4.1 with a backport to 4.0.x.

- This closes https://github.com/godotengine/godot/issues/57708.

**Windows 64-bit editor binary for testing this PR:** https://0x0.st/HrFk.exe.zip <sub>(link expires in late 2023)</sub>

<details>
<summary>Older build</summary>

**Windows 64-bit editor binary for testing this PR:** https://0x0.st/HrGR.exe.zip <sub>(link expires in late 2023)</sub>
</details>