### PR TITLE
Fix Toggle Fold for multiple carets

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1225,8 +1225,8 @@ void ScriptTextEditor::_edit_option(int p_op) {
 			code_editor->duplicate_selection();
 		} break;
 		case EDIT_TOGGLE_FOLD_LINE: {
-			for (int caret_idx = 0; caret_idx < tx->get_caret_count(); caret_idx++) {
-				tx->toggle_foldable_line(tx->get_caret_line(caret_idx));
+			for (int caret_line : tx->get_caret_lines()) {
+				tx->toggle_foldable_line(caret_line);
 			}
 			tx->queue_redraw();
 		} break;

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -397,8 +397,8 @@ void TextEditor::_edit_option(int p_op) {
 			code_editor->duplicate_selection();
 		} break;
 		case EDIT_TOGGLE_FOLD_LINE: {
-			for (int caret_idx = 0; caret_idx < tx->get_caret_count(); caret_idx++) {
-				tx->toggle_foldable_line(tx->get_caret_line(caret_idx));
+			for (int caret_line : tx->get_caret_lines()) {
+				tx->toggle_foldable_line(caret_line);
 			}
 			tx->queue_redraw();
 		} break;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4889,6 +4889,14 @@ String TextEdit::get_word_under_caret(int p_caret) const {
 	return selected_text.as_string();
 }
 
+HashSet<int> TextEdit::get_caret_lines() const {
+	HashSet<int> caret_lines;
+	for (int caret_idx = 0; caret_idx < get_caret_count(); caret_idx++) {
+		caret_lines.insert(get_caret_line(caret_idx));
+	}
+	return caret_lines;
+}
+
 /* Selection. */
 void TextEdit::set_selecting_enabled(const bool p_enabled) {
 	if (selecting_enabled == p_enabled) {

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -839,6 +839,8 @@ public:
 
 	int get_caret_wrap_index(int p_caret = 0) const;
 
+	HashSet<int> get_caret_lines() const;
+
 	String get_word_under_caret(int p_caret = -1) const;
 
 	/* Selection. */


### PR DESCRIPTION
Fixes #73414

The new function `get_caret_lines()` returns a list of line numbers with carets on them, excluding any duplicates.

BTW as an aside, I noticed toggle fold doesn't support selection ranges (e.g. Ctrl+A -> Alt+F doesn't work).