### PR TITLE
.NET: Clicking "Clean solution" should clean, not build

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -302,7 +302,7 @@ namespace GodotTools.Build
         public static bool CleanProjectBlocking(
             [DisallowNull] string configuration,
             [AllowNull] string platform = null
-        ) => CleanProjectBlocking(CreateBuildInfo(configuration, platform, rebuild: false));
+        ) => CleanProjectBlocking(CreateBuildInfo(configuration, platform, rebuild: false, onlyClean: true));
 
         public static bool PublishProjectBlocking(
             [DisallowNull] string configuration,


### PR DESCRIPTION
Currently, clicking the *Clean solution* button doesn't clean anything and instead triggers a build command.