### PR TITLE
Theme Editor: fix crash when editing leading/main-style style boxes

### DIFF
--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -3223,6 +3223,7 @@ void ThemeTypeEditor::_update_stylebox_from_leading() {
 	if (!leading_stylebox.pinned || leading_stylebox.stylebox.is_null()) {
 		return;
 	}
+	ERR_FAIL_COND_MSG(edited_theme.is_null(), "Leading stylebox does not have an edited theme to update");
 
 	// Prevent changes from immediately being reported while the operation is still ongoing.
 	edited_theme->_freeze_change_propagation();
@@ -3706,7 +3707,11 @@ void ThemeEditorPlugin::edit(Object *p_node) {
 	if (Object::cast_to<Theme>(p_node)) {
 		theme_editor->edit(Object::cast_to<Theme>(p_node));
 	} else {
-		theme_editor->edit(Ref<Theme>());
+		// We intentionally keep a reference to the last used theme to work around
+		// the the editor being hidden while base resources are edited. Uncomment
+		// the following line again and remove this comment once that bug has been
+		// fixed (scheduled for Godot 4.1 in PR 73098):
+		// theme_editor->edit(Ref<Theme>());
 	}
 }
 


### PR DESCRIPTION
Recent changes in Godot cause the theme editor to become hidden when editing a child resource. This causes a crash when editing style box resources marked as "main styles" (= leading styleboxes in the code), as they try to reference the currently edited theme.

This PR works around the issue by permitting the Theme Editor to keep a reference to the most recently edited Theme. Furthermore, it adds an assertion to avoid a similar crash in the future.

Long-term, the workaround should probably be removed when the theme editor is fixed to remain visible while editing child resources (mentioned in #73098 to be planned for 4.1), but I'd keep the assertion.

*This is likely a regression from #71770*

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
