### PR TITLE
iOS: Implement missing JoyButton::BACK (Options), START (Menu), and GUIDE (Home)

### DIFF
--- a/platform/ios/joypad_ios.mm
+++ b/platform/ios/joypad_ios.mm
@@ -305,6 +305,25 @@ void JoypadIOS::start_processing() {
 				float value = gamepad.rightTrigger.value;
 				Input::get_singleton()->joy_axis(joy_id, JoyAxis::TRIGGER_RIGHT, value);
 			}
+
+			if (@available(iOS 13, *)) {
+				// iOS uses 'buttonOptions' and 'buttonMenu' names for BACK and START joy buttons.
+				if (element == gamepad.buttonOptions) {
+					Input::get_singleton()->joy_button(joy_id, JoyButton::BACK,
+							gamepad.buttonOptions.isPressed);
+				} else if (element == gamepad.buttonMenu) {
+					Input::get_singleton()->joy_button(joy_id, JoyButton::START,
+							gamepad.buttonMenu.isPressed);
+				}
+			}
+
+			if (@available(iOS 14, *)) {
+				// iOS uses 'buttonHome' for the GUIDE joy button.
+				if (element == gamepad.buttonHome) {
+					Input::get_singleton()->joy_button(joy_id, JoyButton::GUIDE,
+							gamepad.buttonHome.isPressed);
+				}
+			}
 		};
 	} else if (controller.microGamepad != nil) {
 		// micro gamepads were added in OS 9 and feature just 2 buttons and a d-pad


### PR DESCRIPTION
This fixes https://github.com/godotengine/godot/issues/73305 for master branch.

`gamepad.buttonOptions` and `gamepad.buttonMenu` mapping to `JoyButton::BACK` and `JoyButton::START` joy buttons is consistent with the existing behaviour of the macOS version of Godot.

Tested on iPad Mini (iOS 15.6.1) with Xbox Wireless Controller. Test with another controller and/or iOS device is recommended.

Backport to 3.5 and 3.X branches should be simple. The following block should be added to the `- (void)setControllerInputHandler:(GCController *)controller {` function in **platform/iphone/joypad_iphone.mm** file, at the end of the `controller.extendedGamepad.valueChangedHandler = ^(GCExtendedGamepad *gamepad, GCControllerElement *element) {` block:

```
			if (@available(iOS 13, *)) {
				if (element == gamepad.buttonOptions) {
					OSIPhone::get_singleton()->joy_button(joy_id, JOY_BUTTON_10,
							gamepad.buttonOptions.isPressed);
				} else if (element == gamepad.buttonMenu) {
					OSIPhone::get_singleton()->joy_button(joy_id, JOY_BUTTON_11,
							gamepad.buttonMenu.isPressed);
				}
			}

			if (@available(iOS 14, *)) {
				if (element == gamepad.buttonHome) {
					OSIPhone::get_singleton()->joy_button(joy_id, JOY_GUIDE,
							gamepad.buttonHome.isPressed);
				}
			}
```
