### PR TITLE
Only include emission when enabled in material during VoxelGI bake

### DIFF
--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -346,25 +346,29 @@ Voxelizer::MaterialCache Voxelizer::_get_material_cache(Ref<Material> p_material
 		} else {
 			mc.albedo = _get_bake_texture(img_albedo, Color(1, 1, 1), mat->get_albedo()); // no albedo texture, color is additive
 		}
+		if (mat->get_feature(BaseMaterial3D::FEATURE_EMISSION)) {
+			Ref<Texture2D> emission_tex = mat->get_texture(BaseMaterial3D::TEXTURE_EMISSION);
 
-		Ref<Texture2D> emission_tex = mat->get_texture(BaseMaterial3D::TEXTURE_EMISSION);
+			Color emission_col = mat->get_emission();
+			float emission_energy = mat->get_emission_energy_multiplier() * exposure_normalization;
+			if (GLOBAL_GET("rendering/lights_and_shadows/use_physical_light_units")) {
+				emission_energy *= mat->get_emission_intensity();
+			}
 
-		Color emission_col = mat->get_emission();
-		float emission_energy = mat->get_emission_energy_multiplier() * exposure_normalization;
-		if (GLOBAL_GET("rendering/lights_and_shadows/use_physical_light_units")) {
-			emission_energy *= mat->get_emission_intensity();
-		}
+			Ref<Image> img_emission;
 
-		Ref<Image> img_emission;
+			if (emission_tex.is_valid()) {
+				img_emission = emission_tex->get_image();
+			}
 
-		if (emission_tex.is_valid()) {
-			img_emission = emission_tex->get_image();
-		}
-
-		if (mat->get_emission_operator() == BaseMaterial3D::EMISSION_OP_ADD) {
-			mc.emission = _get_bake_texture(img_emission, Color(1, 1, 1) * emission_energy, emission_col * emission_energy);
+			if (mat->get_emission_operator() == BaseMaterial3D::EMISSION_OP_ADD) {
+				mc.emission = _get_bake_texture(img_emission, Color(1, 1, 1) * emission_energy, emission_col * emission_energy);
+			} else {
+				mc.emission = _get_bake_texture(img_emission, emission_col * emission_energy, Color(0, 0, 0));
+			}
 		} else {
-			mc.emission = _get_bake_texture(img_emission, emission_col * emission_energy, Color(0, 0, 0));
+			Ref<Image> empty;
+			mc.emission = _get_bake_texture(empty, Color(0, 0, 0), Color(0, 0, 0));
 		}
 
 	} else {


### PR DESCRIPTION
Previously, if you had an emission color or emission texture set, they would be baked into VoxelGI, even if emission was set to disabled. In order to actually disable emission you needed to turn emission on in the material, remove the texture and change color to black. With this change, VoxelGI will actually respect the ``emission_enabled`` property.

This is a low risk bug fix. But it isn't urgently needed, so I am labelling it as 4.x. It can be merged anytime.