### PR TITLE
Remove device-id restriction from `TouchScreenButton` input events

### DIFF
--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -194,10 +194,6 @@ void TouchScreenButton::input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
-	if (p_event->get_device() != 0) {
-		return;
-	}
-
 	const InputEventScreenTouch *st = Object::cast_to<InputEventScreenTouch>(*p_event);
 
 	if (passby_press) {


### PR DESCRIPTION
Remove the restriction that only devices with id 0 are used for `TouchScreenButton`-Input events.
This allows emulated events to be used for `TouchScreenButton`.

fix #73457

I don't understand the reason for this device-id-restriction in the first place. I had a look at the commit, where it was introduced, but that didn't help. So please review carefully.