### PR TITLE
Documentation: BoxMesh UV scaling for vertex shader

### DIFF
--- a/doc/classes/BoxMesh.xml
+++ b/doc/classes/BoxMesh.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		Generate an axis-aligned box [PrimitiveMesh].
-		The box's UV layout is arranged in a 3×2 layout that allows texturing each face individually. To apply the same texture on all faces, change the material's UV property to [code]Vector3(3, 2, 1)[/code].
+		The box's UV layout is arranged in a 3×2 layout that allows texturing each face individually. To apply the same texture on all faces, change the material's UV property to [code]Vector3(3, 2, 1)[/code]. This is equivalent to adding [code]UV *= vec2(3.0, 2.0)[/code] in a vertex shader.
 		[b]Note:[/b] When using a large textured [BoxMesh] (e.g. as a floor), you may stumble upon UV jittering issues depending on the camera angle. To solve this, increase [member subdivide_depth], [member subdivide_height] and [member subdivide_width] until you no longer notice UV jittering.
 	</description>
 	<tutorials>


### PR DESCRIPTION
Added a comment that translates the UV scaling from the standard shader properties to how that is done in a vertex shader. New text:
"This is equivalent to adding [code]UV *= vec2(3.0,2.0)[/code] in a vertex shader."

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
