### PR TITLE
Replace half-pixel snapping with grid snapping in tile polygon editor

### DIFF
--- a/editor/plugins/tiles/tile_data_editors.h
+++ b/editor/plugins/tiles/tile_data_editors.h
@@ -36,10 +36,10 @@
 #include "editor/editor_properties.h"
 #include "scene/2d/tile_map.h"
 #include "scene/gui/box_container.h"
-#include "scene/gui/control.h"
-#include "scene/gui/label.h"
 
 class MenuButton;
+class SpinBox;
+class Label;
 class EditorUndoRedoManager;
 
 class TileDataEditor : public VBoxContainer {
@@ -120,8 +120,9 @@ private:
 	Button *button_create = nullptr;
 	Button *button_edit = nullptr;
 	Button *button_delete = nullptr;
-	Button *button_pixel_snap = nullptr;
 	MenuButton *button_advanced_menu = nullptr;
+	Button *button_grid_snap = nullptr;
+	SpinBox *grid_snap = nullptr;
 
 	Vector<Point2> in_creation_polygon;
 
@@ -157,7 +158,7 @@ private:
 	void _base_control_gui_input(Ref<InputEvent> p_event);
 
 	void _snap_to_tile_shape(Point2 &r_point, float &r_current_snapped_dist, float p_snap_dist);
-	void _snap_to_half_pixel(Point2 &r_point);
+	void _snap_to_grid(Point2 &r_point);
 	void _grab_polygon_point(Vector2 p_pos, const Transform2D &p_polygon_xform, int &r_polygon_index, int &r_point_index);
 	void _grab_polygon_segment_point(Vector2 p_pos, const Transform2D &p_polygon_xform, int &r_polygon_index, int &r_segment_index, Vector2 &r_point);
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5847

Similar to #70488, but uses subdivisions instead of raw pixel counts.

there's p much no instances where you would want to free-hand the collisions, as it results in very inconsistent movement. the half-pixel snapping doesn't really help in that regard, and is indistinguishable from free-handing when working with most sprites above 32x32

![snap_to_grid](https://user-images.githubusercontent.com/70084790/219846126-46e04d92-02ad-4365-872a-878e91880b4f.gif)