### PR TITLE
Fix inability to assign null regression

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1245,21 +1245,19 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					OPCODE_BREAK;
 				}
 
-				bool was_freed = false;
-				Object *src_obj = src->get_validated_object_with_check(was_freed);
-				if (!src_obj) {
-					if (was_freed) {
+				if (src->get_type() == Variant::OBJECT) {
+					bool was_freed = false;
+					Object *src_obj = src->get_validated_object_with_check(was_freed);
+					if (!src_obj && was_freed) {
 						err_text = "Trying to assign invalid previously freed instance.";
-					} else {
-						err_text = "Trying to assign invalid null variable.";
+						OPCODE_BREAK;
 					}
-					OPCODE_BREAK;
-				}
 
-				if (src_obj && !ClassDB::is_parent_class(src_obj->get_class_name(), nc->get_name())) {
-					err_text = "Trying to assign value of type '" + src_obj->get_class_name() +
-							"' to a variable of type '" + nc->get_name() + "'.";
-					OPCODE_BREAK;
+					if (src_obj && !ClassDB::is_parent_class(src_obj->get_class_name(), nc->get_name())) {
+						err_text = "Trying to assign value of type '" + src_obj->get_class_name() +
+								"' to a variable of type '" + nc->get_name() + "'.";
+						OPCODE_BREAK;
+					}
 				}
 #endif // DEBUG_ENABLED
 				*dst = *src;
@@ -1284,15 +1282,11 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					OPCODE_BREAK;
 				}
 
-				if (src->get_type() != Variant::NIL) {
+				if (src->get_type() == Variant::OBJECT) {
 					bool was_freed = false;
 					Object *val_obj = src->get_validated_object_with_check(was_freed);
-					if (!val_obj) {
-						if (was_freed) {
-							err_text = "Trying to assign invalid previously freed instance.";
-						} else {
-							err_text = "Trying to assign invalid null variable.";
-						}
+					if (!val_obj && was_freed) {
+						err_text = "Trying to assign invalid previously freed instance.";
 						OPCODE_BREAK;
 					}
 

--- a/modules/gdscript/tests/scripts/analyzer/features/native_typed_assign_null.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/native_typed_assign_null.gd
@@ -1,0 +1,15 @@
+extends Node
+
+func test():
+	var typed: Variant = get_node_or_null("does_not_exist")
+	var untyped = null
+	var node_1: Node = typed
+	var node_2: Node = untyped
+	var node_3 = typed
+	var node_4 = untyped
+	print(typed)
+	print(untyped)
+	print(node_1)
+	print(node_2)
+	print(node_3)
+	print(node_4)

--- a/modules/gdscript/tests/scripts/analyzer/features/native_typed_assign_null.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/native_typed_assign_null.out
@@ -1,0 +1,7 @@
+GDTEST_OK
+<Object#null>
+<null>
+<Object#null>
+<null>
+<Object#null>
+<null>


### PR DESCRIPTION
Fix #73488.

Between the typed script and typed native assignment changes, I forgot to add a guard to only do checks when the variable is an object (and not NIL).

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
