### PR TITLE
Fix code editor scrolling experience on track pads

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7466,7 +7466,7 @@ void TextEdit::_scroll_up(real_t p_delta, bool p_animate) {
 		if (target_v_scroll <= 0) {
 			target_v_scroll = 0;
 		}
-		if (Math::abs(target_v_scroll - v_scroll->get_value()) < 1.0 || !p_animate) {
+		if (!p_animate || Math::abs(target_v_scroll - v_scroll->get_value()) < 1.0) {
 			v_scroll->set_value(target_v_scroll);
 		} else {
 			scrolling = true;
@@ -7494,7 +7494,7 @@ void TextEdit::_scroll_down(real_t p_delta, bool p_animate) {
 		if (target_v_scroll > max_v_scroll) {
 			target_v_scroll = max_v_scroll;
 		}
-		if (Math::abs(target_v_scroll - v_scroll->get_value()) < 1.0 || !p_animate) {
+		if (!p_animate || Math::abs(target_v_scroll - v_scroll->get_value()) < 1.0) {
 			v_scroll->set_value(target_v_scroll);
 		} else {
 			scrolling = true;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5473,7 +5473,7 @@ void TextEdit::set_line_as_last_visible(int p_line, int p_wrap_index) {
 		set_v_scroll(0);
 		return;
 	}
-	set_v_scroll(round(get_scroll_pos_for_line(first_line, next_line.y) + _get_visible_lines_offset()));
+	set_v_scroll(Math::round(get_scroll_pos_for_line(first_line, next_line.y) + _get_visible_lines_offset()));
 }
 
 int TextEdit::get_last_full_visible_line() const {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1693,10 +1693,10 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					h_scroll->set_value(h_scroll->get_value() - (100 * mb->get_factor()));
 				} else if (mb->is_alt_pressed()) {
 					// Scroll 5 times as fast as normal (like in Visual Studio Code).
-					_scroll_up(15 * mb->get_factor());
+					_scroll_up(15 * mb->get_factor(), true);
 				} else if (v_scroll->is_visible()) {
 					// Scroll 3 lines.
-					_scroll_up(3 * mb->get_factor());
+					_scroll_up(3 * mb->get_factor(), true);
 				}
 			}
 			if (mb->get_button_index() == MouseButton::WHEEL_DOWN && !mb->is_command_or_control_pressed()) {
@@ -1704,10 +1704,10 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					h_scroll->set_value(h_scroll->get_value() + (100 * mb->get_factor()));
 				} else if (mb->is_alt_pressed()) {
 					// Scroll 5 times as fast as normal (like in Visual Studio Code).
-					_scroll_down(15 * mb->get_factor());
+					_scroll_down(15 * mb->get_factor(), true);
 				} else if (v_scroll->is_visible()) {
 					// Scroll 3 lines.
-					_scroll_down(3 * mb->get_factor());
+					_scroll_down(3 * mb->get_factor(), true);
 				}
 			}
 			if (mb->get_button_index() == MouseButton::WHEEL_LEFT) {
@@ -1941,9 +1941,9 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	if (pan_gesture.is_valid()) {
 		const real_t delta = pan_gesture->get_delta().y;
 		if (delta < 0) {
-			_scroll_up(-delta);
+			_scroll_up(-delta, false);
 		} else {
-			_scroll_down(delta);
+			_scroll_down(delta, false);
 		}
 		h_scroll->set_value(h_scroll->get_value() + pan_gesture->get_delta().x * 100);
 		if (v_scroll->get_value() != prev_v_scroll || h_scroll->get_value() != prev_h_scroll) {
@@ -5473,7 +5473,7 @@ void TextEdit::set_line_as_last_visible(int p_line, int p_wrap_index) {
 		set_v_scroll(0);
 		return;
 	}
-	set_v_scroll(get_scroll_pos_for_line(first_line, next_line.y) + _get_visible_lines_offset());
+	set_v_scroll(round(get_scroll_pos_for_line(first_line, next_line.y) + _get_visible_lines_offset()));
 }
 
 int TextEdit::get_last_full_visible_line() const {
@@ -7357,11 +7357,6 @@ void TextEdit::_update_scrollbars() {
 		v_scroll->show();
 		v_scroll->set_max(total_rows + _get_visible_lines_offset());
 		v_scroll->set_page(visible_rows + _get_visible_lines_offset());
-		if (smooth_scroll_enabled) {
-			v_scroll->set_step(0.25);
-		} else {
-			v_scroll->set_step(1);
-		}
 		set_v_scroll(get_v_scroll());
 
 	} else {
@@ -7455,7 +7450,7 @@ double TextEdit::_get_v_scroll_offset() const {
 	return CLAMP(val, 0, 1);
 }
 
-void TextEdit::_scroll_up(real_t p_delta) {
+void TextEdit::_scroll_up(real_t p_delta, bool p_animate) {
 	if (scrolling && smooth_scroll_enabled && SIGN(target_v_scroll - v_scroll->get_value()) != SIGN(-p_delta)) {
 		scrolling = false;
 		minimap_clicked = false;
@@ -7471,7 +7466,7 @@ void TextEdit::_scroll_up(real_t p_delta) {
 		if (target_v_scroll <= 0) {
 			target_v_scroll = 0;
 		}
-		if (Math::abs(target_v_scroll - v_scroll->get_value()) < 1.0) {
+		if (Math::abs(target_v_scroll - v_scroll->get_value()) < 1.0 || !p_animate) {
 			v_scroll->set_value(target_v_scroll);
 		} else {
 			scrolling = true;
@@ -7482,7 +7477,7 @@ void TextEdit::_scroll_up(real_t p_delta) {
 	}
 }
 
-void TextEdit::_scroll_down(real_t p_delta) {
+void TextEdit::_scroll_down(real_t p_delta, bool p_animate) {
 	if (scrolling && smooth_scroll_enabled && SIGN(target_v_scroll - v_scroll->get_value()) != SIGN(p_delta)) {
 		scrolling = false;
 		minimap_clicked = false;
@@ -7499,7 +7494,7 @@ void TextEdit::_scroll_down(real_t p_delta) {
 		if (target_v_scroll > max_v_scroll) {
 			target_v_scroll = max_v_scroll;
 		}
-		if (Math::abs(target_v_scroll - v_scroll->get_value()) < 1.0) {
+		if (Math::abs(target_v_scroll - v_scroll->get_value()) < 1.0 || !p_animate) {
 			v_scroll->set_value(target_v_scroll);
 		} else {
 			scrolling = true;
@@ -7605,9 +7600,9 @@ void TextEdit::_update_minimap_click() {
 	int first_line = row - next_line.x + 1;
 	double delta = get_scroll_pos_for_line(first_line, next_line.y) - get_v_scroll();
 	if (delta < 0) {
-		_scroll_up(-delta);
+		_scroll_up(-delta, true);
 	} else {
-		_scroll_down(delta);
+		_scroll_down(delta, true);
 	}
 }
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -500,8 +500,8 @@ private:
 	double _get_visible_lines_offset() const;
 	double _get_v_scroll_offset() const;
 
-	void _scroll_up(real_t p_delta);
-	void _scroll_down(real_t p_delta);
+	void _scroll_up(real_t p_delta, bool p_animate);
+	void _scroll_down(real_t p_delta, bool p_animate);
 
 	void _scroll_lines_up();
 	void _scroll_lines_down();


### PR DESCRIPTION
Fixes #28149 

This PR fixes two closely related problems:
- Scrolling slowly in the code editor with a track pad would not do anything;
- Smooth scrolling would animate track pad scrolls, but they are already animated as the pixel deltas are provided on a frame-by-frame basis.

The first problem is caused by the step size that's set on the `VScrollBar`, any scroll event going through `TextEdit::_scroll_up` and `TextEdit::_scroll_down` got rounded down to an integer number of lines. Since scrolling on a track pad happens every frame, the individual deltas are relatively small, and they would be rounded down to zero unless you're scrolling quite fast. This is addressed differently for the smooth scrolling enabled and disabled case:
- When disabled the scrolling deltas are accumulated the same way they were already being accumulated for the smooth scrolling case, so when slow scrolling for long enough the step size threshold is reached;
- When smooth scrolling is enabled the step size is set to 0, allowing all fractional increments. 

The second problem becomes quickly apparent when the first problem is fixed: scroll delta's less than 1 line are applied immediately, while scroll delta's larger than 1 line are animated. This feels really snappy as long as the target scroll value is less than 1 line away from the current scroll value, only to suddenly change to a fixed speed when the delta becomes too big. This has been addressed by directly applying any scroll delta coming from `InputEventPanGesture` events, instead of allowing it to animate.