### PR TITLE
Linux: Fix build with `x11=no`

### DIFF
--- a/modules/openxr/config.py
+++ b/modules/openxr/config.py
@@ -1,9 +1,14 @@
 def can_build(env, platform):
-    if platform in ("linuxbsd", "windows", "android"):
-        return env["openxr"] and not env["disable_3d"]
-    else:
-        # not supported on these platforms
+    if not env["openxr"] or env["disable_3d"]:
         return False
+
+    if platform not in ("linuxbsd", "windows", "android"):
+        return False
+
+    if platform == "linuxbsd" and env["opengl3"] and not env["x11"]:  # Needs Xlib for OpenGL
+        return False
+
+    return True
 
 
 def configure(env):

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -33,6 +33,7 @@
 #include "core/io/dir_access.h"
 #include "main/main.h"
 #include "servers/display_server.h"
+#include "servers/rendering_server.h"
 
 #include "modules/modules_enabled.gen.h" // For regex.
 #ifdef MODULE_REGEX_ENABLED


### PR DESCRIPTION
- Fixes #70199.
- Supersedes #70930.

OpenXR OpenGL extension requires Xlib thus X11, so it's disabled.