### PR TITLE
Remove extra spaces and correct crosslinks in some documentation

### DIFF
--- a/doc/classes/AStar2D.xml
+++ b/doc/classes/AStar2D.xml
@@ -175,7 +175,7 @@
 		<method name="get_point_capacity" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the capacity of the structure backing the points, useful in conjunction with [code]reserve_space[/code].
+				Returns the capacity of the structure backing the points, useful in conjunction with [method reserve_space].
 			</description>
 		</method>
 		<method name="get_point_connections">

--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -108,7 +108,7 @@
 			<return type="bool" />
 			<param index="0" name="track_idx" type="int" />
 			<description>
-				Returns [code]true[/code] if the track at [code]idx[/code] will be blended with other animations.
+				Returns [code]true[/code] if the track at [param track_idx] will be blended with other animations.
 			</description>
 		</method>
 		<method name="audio_track_set_key_end_offset">

--- a/doc/classes/Bone2D.xml
+++ b/doc/classes/Bone2D.xml
@@ -34,7 +34,7 @@
 		<method name="get_default_length" qualifiers="const">
 			<return type="float" />
 			<description>
-				Deprecated. Please use  [code]get_length[/code] instead.
+				Deprecated. Please use [method get_length] instead.
 			</description>
 		</method>
 		<method name="get_index_in_skeleton" qualifiers="const">
@@ -74,7 +74,7 @@
 			<return type="void" />
 			<param index="0" name="default_length" type="float" />
 			<description>
-				Deprecated. Please use [code]set_length[/code] instead.
+				Deprecated. Please use [method set_length] instead.
 			</description>
 		</method>
 		<method name="set_length">

--- a/doc/classes/BoneAttachment3D.xml
+++ b/doc/classes/BoneAttachment3D.xml
@@ -33,14 +33,14 @@
 			<return type="void" />
 			<param index="0" name="external_skeleton" type="NodePath" />
 			<description>
-				Sets the [NodePath] to the external skeleton that the BoneAttachment3D node should use. The external [Skeleton3D] node is only used when [code]use_external_skeleton[/code] is set to [code]true[/code].
+				Sets the [NodePath] to the external skeleton that the BoneAttachment3D node should use. See [method set_use_external_skeleton] to enable the external [Skeleton3D] node.
 			</description>
 		</method>
 		<method name="set_use_external_skeleton">
 			<return type="void" />
 			<param index="0" name="use_external_skeleton" type="bool" />
 			<description>
-				Sets whether the BoneAttachment3D node will use an extenral [Skeleton3D] node rather than attenpting to use its parent node as the [Skeleton3D]. When set to [code]true[/code], the BoneAttachment3D node will use the external [Skeleton3D] node set in [code]set_external_skeleton[/code].
+				Sets whether the BoneAttachment3D node will use an extenral [Skeleton3D] node rather than attenpting to use its parent node as the [Skeleton3D]. When set to [code]true[/code], the BoneAttachment3D node will use the external [Skeleton3D] node set in [method set_external_skeleton].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/EditorNode3DGizmoPlugin.xml
+++ b/doc/classes/EditorNode3DGizmoPlugin.xml
@@ -138,7 +138,7 @@
 			<param index="1" name="subgizmo_id" type="int" />
 			<param index="2" name="transform" type="Transform3D" />
 			<description>
-				Override this method to update the node properties during subgizmo editing (see [method _subgizmos_intersect_ray] and [method _subgizmos_intersect_frustum]). The [param transform] is given in the Node3D's local coordinate system.  Called for this plugin's active gizmos.
+				Override this method to update the node properties during subgizmo editing (see [method _subgizmos_intersect_ray] and [method _subgizmos_intersect_frustum]). The [param transform] is given in the Node3D's local coordinate system. Called for this plugin's active gizmos.
 			</description>
 		</method>
 		<method name="_subgizmos_intersect_frustum" qualifiers="virtual const">
@@ -147,7 +147,7 @@
 			<param index="1" name="camera" type="Camera3D" />
 			<param index="2" name="frustum_planes" type="Plane[]" />
 			<description>
-				Override this method to allow selecting subgizmos using mouse drag box selection. Given a [param camera] and [param frustum_planes], this method should return which subgizmos are contained within the frustums. The [param frustum_planes] argument consists of an [code]Array[/code] with all the [code]Plane[/code]s that make up the selection frustum. The returned value should contain a list of unique subgizmo identifiers, these identifiers can have any non-negative value and will be used in other virtual methods like [method _get_subgizmo_transform] or [method _commit_subgizmos].  Called for this plugin's active gizmos.
+				Override this method to allow selecting subgizmos using mouse drag box selection. Given a [param camera] and [param frustum_planes], this method should return which subgizmos are contained within the frustums. The [param frustum_planes] argument consists of an [code]Array[/code] with all the [code]Plane[/code]s that make up the selection frustum. The returned value should contain a list of unique subgizmo identifiers, these identifiers can have any non-negative value and will be used in other virtual methods like [method _get_subgizmo_transform] or [method _commit_subgizmos]. Called for this plugin's active gizmos.
 			</description>
 		</method>
 		<method name="_subgizmos_intersect_ray" qualifiers="virtual const">

--- a/doc/classes/GeometryInstance3D.xml
+++ b/doc/classes/GeometryInstance3D.xml
@@ -46,10 +46,10 @@
 			[b]Note:[/b] Lights' bake mode will also affect the global illumination rendering. See [member Light3D.light_bake_mode].
 		</member>
 		<member name="ignore_occlusion_culling" type="bool" setter="set_ignore_occlusion_culling" getter="is_ignoring_occlusion_culling" default="false">
-			If [code]true[/code], disables occlusion culling for this instance.  Useful for gizmos that must be rendered even when occlusion culling is in use.
+			If [code]true[/code], disables occlusion culling for this instance. Useful for gizmos that must be rendered even when occlusion culling is in use.
 		</member>
 		<member name="lod_bias" type="float" setter="set_lod_bias" getter="get_lod_bias" default="1.0">
-			Changes how quickly the mesh transitions to a lower level of detail.  A value of 0 will force the mesh to its lowest level of detail, a value of 1 will use the default settings, and larger values will keep the mesh in a higher level of detail at farther distances.
+			Changes how quickly the mesh transitions to a lower level of detail. A value of 0 will force the mesh to its lowest level of detail, a value of 1 will use the default settings, and larger values will keep the mesh in a higher level of detail at farther distances.
 			Useful for testing level of detail transitions in the editor.
 		</member>
 		<member name="material_overlay" type="Material" setter="set_material_overlay" getter="get_material_overlay">

--- a/doc/classes/NavigationLink2D.xml
+++ b/doc/classes/NavigationLink2D.xml
@@ -4,7 +4,7 @@
 		Creates a link between two positions that [NavigationServer2D] can route agents through.
 	</brief_description>
 	<description>
-		Creates a link between two positions that [NavigationServer2D] can route agents through.  Links can be used to express navigation methods that aren't just traveling along the surface of the navigation mesh, like zip-lines, teleporters, or jumping across gaps.
+		Creates a link between two positions that [NavigationServer2D] can route agents through. Links can be used to express navigation methods that aren't just traveling along the surface of the navigation mesh, like zip-lines, teleporters, or jumping across gaps.
 	</description>
 	<tutorials>
 		<link title="Using NavigationLinks">$DOCS_URL/tutorials/navigation/navigation_using_navigationlinks.html</link>

--- a/doc/classes/NavigationLink3D.xml
+++ b/doc/classes/NavigationLink3D.xml
@@ -4,7 +4,7 @@
 		Creates a link between two positions that [NavigationServer3D] can route agents through.
 	</brief_description>
 	<description>
-		Creates a link between two positions that [NavigationServer3D] can route agents through.  Links can be used to express navigation methods that aren't just traveling along the surface of the navigation mesh, like zip-lines, teleporters, or jumping across gaps.
+		Creates a link between two positions that [NavigationServer3D] can route agents through. Links can be used to express navigation methods that aren't just traveling along the surface of the navigation mesh, like zip-lines, teleporters, or jumping across gaps.
 	</description>
 	<tutorials>
 		<link title="Using NavigationLinks">$DOCS_URL/tutorials/navigation/navigation_using_navigationlinks.html</link>

--- a/doc/classes/NavigationPathQueryResult2D.xml
+++ b/doc/classes/NavigationPathQueryResult2D.xml
@@ -13,7 +13,7 @@
 		<method name="reset">
 			<return type="void" />
 			<description>
-				Reset the result object to its initial state.  This is useful to reuse the object across multiple queries.
+				Reset the result object to its initial state. This is useful to reuse the object across multiple queries.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/NavigationPathQueryResult3D.xml
+++ b/doc/classes/NavigationPathQueryResult3D.xml
@@ -13,7 +13,7 @@
 		<method name="reset">
 			<return type="void" />
 			<description>
-				Reset the result object to its initial state.  This is useful to reuse the object across multiple queries.
+				Reset the result object to its initial state. This is useful to reuse the object across multiple queries.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Checked the docs for extra spaces between words, and also noticed some cross references to methods and method parameters were incorrect. Not a complete pass, just a few clean-up tweaks.
