### PR TITLE
Reordering emitted signals in PopupMenu

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1715,12 +1715,12 @@ void PopupMenu::activate_item(int p_item) {
 		need_hide = false;
 	}
 
+	emit_signal(SNAME("id_pressed"), id);
+	emit_signal(SNAME("index_pressed"), p_item);
+
 	if (need_hide) {
 		hide();
 	}
-
-	emit_signal(SNAME("id_pressed"), id);
-	emit_signal(SNAME("index_pressed"), p_item);
 }
 
 void PopupMenu::remove_item(int p_idx) {


### PR DESCRIPTION
Fixes: #73473 

As soon as the pop-up menu disappears.
https://github.com/godotengine/godot/blob/f84479fe5a0a3c34c1d0217527ae08dd24543243/scene/gui/popup_menu.cpp#L1718-L1723

The `Node3DEditorViewport` will immediately clear the `selection_results`.
https://github.com/godotengine/godot/blob/f84479fe5a0a3c34c1d0217527ae08dd24543243/editor/plugins/node_3d_editor_plugin.cpp#L3623-L3627

The signal emitted afterward will invoke `Node3DEditorViewport::_selection_result_pressed`, but since the state of `selection_results`  is empty, this method will return:
https://github.com/godotengine/godot/blob/f84479fe5a0a3c34c1d0217527ae08dd24543243/editor/plugins/node_3d_editor_plugin.cpp#L3611-L3614