### PR TITLE
Add GDExtension function to get Object class name

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -314,6 +314,7 @@ void GDExtension::_register_extension_class(GDExtensionClassLibraryPtr p_library
 		parent_extension->gdextension.children.push_back(&extension->gdextension);
 	}
 
+	extension->gdextension.library = self;
 	extension->gdextension.parent_class_name = parent_class_name;
 	extension->gdextension.class_name = class_name;
 	extension->gdextension.editor_class = self->level_initialized == INITIALIZATION_LEVEL_EDITOR;

--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -992,6 +992,19 @@ static GDExtensionObjectPtr gdextension_object_get_instance_from_id(GDObjectInst
 	return (GDExtensionObjectPtr)ObjectDB::get_instance(ObjectID(p_instance_id));
 }
 
+static GDExtensionBool gdextension_object_get_class_name(GDExtensionConstObjectPtr p_object, GDExtensionClassLibraryPtr p_library, GDExtensionUninitializedStringNamePtr r_class_name) {
+	if (!p_object) {
+		return false;
+	}
+	const Object *o = (const Object *)p_object;
+
+	memnew_placement(r_class_name, StringName);
+	StringName *class_name = reinterpret_cast<StringName *>(r_class_name);
+	*class_name = o->get_class_name_for_extension((GDExtension *)p_library);
+
+	return true;
+}
+
 static GDExtensionObjectPtr gdextension_object_cast_to(GDExtensionConstObjectPtr p_object, void *p_class_tag) {
 	if (!p_object) {
 		return nullptr;
@@ -1176,6 +1189,7 @@ void gdextension_setup_interface() {
 	REGISTER_INTERFACE_FUNC(object_get_instance_binding);
 	REGISTER_INTERFACE_FUNC(object_set_instance_binding);
 	REGISTER_INTERFACE_FUNC(object_set_instance);
+	REGISTER_INTERFACE_FUNC(object_get_class_name);
 	REGISTER_INTERFACE_FUNC(object_cast_to);
 	REGISTER_INTERFACE_FUNC(object_get_instance_from_id);
 	REGISTER_INTERFACE_FUNC(object_get_instance_id);

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -1902,6 +1902,19 @@ typedef void (*GDExtensionInterfaceObjectSetInstanceBinding)(GDExtensionObjectPt
 typedef void (*GDExtensionInterfaceObjectSetInstance)(GDExtensionObjectPtr p_o, GDExtensionConstStringNamePtr p_classname, GDExtensionClassInstancePtr p_instance); /* p_classname should be a registered extension class and should extend the p_o object's class. */
 
 /**
+ * @name object_get_class_name
+ *
+ * Gets the class name of an Object.
+ *
+ * @param p_object A pointer to the Object.
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param r_class_name A pointer to a String to receive the class name.
+ *
+ * @return true if successful in getting the class name; otherwise false.
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceObjectGetClassName)(GDExtensionConstObjectPtr p_object, GDExtensionClassLibraryPtr p_library, GDExtensionUninitializedStringNamePtr r_class_name);
+
+/**
  * @name object_cast_to
  *
  * Casts an Object to a different type.

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1739,7 +1739,7 @@ void *Object::get_instance_binding(void *p_token, const GDExtensionInstanceBindi
 			break;
 		}
 	}
-	if (unlikely(!binding)) {
+	if (unlikely(!binding && p_callbacks)) {
 		uint32_t current_size = next_power_of_2(_instance_binding_count);
 		uint32_t new_size = next_power_of_2(_instance_binding_count + 1);
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -304,8 +304,10 @@ struct MethodInfo {
 
 // API used to extend in GDExtension and other C compatible compiled languages.
 class MethodBind;
+class GDExtension;
 
 struct ObjectGDExtension {
+	GDExtension *library = nullptr;
 	ObjectGDExtension *parent = nullptr;
 	List<ObjectGDExtension *> children;
 	StringName parent_class_name;
@@ -793,6 +795,18 @@ public:
 		if (unlikely(!_class_name_ptr)) {
 			// While class is initializing / deinitializing, constructors and destructurs
 			// need access to the proper class at the proper stage.
+			return *_get_class_namev();
+		}
+		return *_class_name_ptr;
+	}
+
+	_FORCE_INLINE_ const StringName &get_class_name_for_extension(const GDExtension *p_library) const {
+		// Only return the class name per the extension if it matches the given p_library.
+		if (_extension && _extension->library == p_library) {
+			return _extension->class_name;
+		}
+		// Otherwise, return the name of the built-in class.
+		if (unlikely(!_class_name_ptr)) {
 			return *_get_class_namev();
 		}
 		return *_class_name_ptr;


### PR DESCRIPTION
This adds a function for GDExtension to get the class name of an Object, in order to support a fix to godot-cpp: https://github.com/godotengine/godot-cpp/pull/1050

Please see that PR for the full details!

~~This is draft, because that PR is still a draft, and this PR may be updated before it's ready.~~

~~The other PR is out of draft, so taking this one out of draft too!~~

~~Back in draft, since I'm rebasing this on https://github.com/godotengine/godot/pull/76406~~

UPDATE: https://github.com/godotengine/godot/pull/76406 was merged, so I'm taking this out of draft!