### PR TITLE
Fix TileMap dragging selection

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8116,6 +8116,7 @@ void EditorPluginList::forward_3d_force_draw_over_viewport(Control *p_overlay) {
 }
 
 void EditorPluginList::add_plugin(EditorPlugin *p_plugin) {
+	ERR_FAIL_COND(plugins_list.has(p_plugin));
 	plugins_list.push_back(p_plugin);
 }
 


### PR DESCRIPTION
So, this PR is a bit of an hotfix as it seems that there's some underlying things that is wrong in EditorNode's logic.
It seems a tricky problem to solve, so I decided to PR this hotfix for now.

This prevent an EditorPlugin to be added twice to the editor plugin list. Having the TileMap plugin twice in the list caused the TileMap editor to receive the same mouse button event twice, which, when dragging the TileMap selection, basically made it "resample" the selection once the underlying tiles have been removed already.

I think the plugin should likely never be added twice in the first place, but that's for later investigations.

Ah and the plugin list is usually super short, so it should not have any performance impact.

Fixes #73469