### PR TITLE
Remove deprecated methods from Bone2D

### DIFF
--- a/doc/classes/Bone2D.xml
+++ b/doc/classes/Bone2D.xml
@@ -31,12 +31,6 @@
 				[b]Note:[/b] This is different from the [code]Bone2D[/code]'s rotation. The bone angle is the rotation of the bone shown by the [code]Bone2D[/code] gizmo, and because [code]Bone2D[/code] bones are based on positions, this can vary from the actual rotation of the [code]Bone2D[/code] node.
 			</description>
 		</method>
-		<method name="get_default_length" qualifiers="const">
-			<return type="float" />
-			<description>
-				Deprecated. Please use [method get_length] instead.
-			</description>
-		</method>
 		<method name="get_index_in_skeleton" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -68,13 +62,6 @@
 			<description>
 				Sets the bone angle for the [code]Bone2D[/code] node. This is typically set to the rotation from the [code]Bone2D[/code] node to a child [code]Bone2D[/code] node.
 				[b]Note:[/b] This is different from the [code]Bone2D[/code]'s rotation. The bone angle is the rotation of the bone shown by the [code]Bone2D[/code] gizmo, and because [code]Bone2D[/code] bones are based on positions, this can vary from the actual rotation of the [code]Bone2D[/code] node.
-			</description>
-		</method>
-		<method name="set_default_length">
-			<return type="void" />
-			<param index="0" name="default_length" type="float" />
-			<description>
-				Deprecated. Please use [method set_length] instead.
 			</description>
 		</method>
 		<method name="set_length">

--- a/editor/renames_map_3_to_4.cpp
+++ b/editor/renames_map_3_to_4.cpp
@@ -291,6 +291,7 @@ const char *RenamesMap3To4::gdscript_function_renames[][2] = {
 	{ "get_cull_mask_bit", "get_cull_mask_value" }, // Camera3D
 	{ "get_cursor_position", "get_caret_column" }, // LineEdit
 	{ "get_d", "get_distance" }, // LineShape2D
+	{ "get_default_length", "get_length" }, // Bone2D
 	{ "get_depth_bias_enable", "get_depth_bias_enabled" }, // RDPipelineRasterizationState
 	{ "get_device", "get_output_device" }, // AudioServer
 	{ "get_device_list", "get_output_device_list" }, // AudioServer
@@ -490,6 +491,7 @@ const char *RenamesMap3To4::gdscript_function_renames[][2] = {
 	{ "set_cull_mask_bit", "set_cull_mask_value" }, // Camera3D
 	{ "set_cursor_position", "set_caret_column" }, // LineEdit
 	{ "set_d", "set_distance" }, // WorldMarginShape2D
+	{ "set_default_length", "set_length" }, // Bone2D
 	{ "set_depth_bias_enable", "set_depth_bias_enabled" }, // RDPipelineRasterizationState
 	{ "set_device", "set_output_device" }, // AudioServer
 	{ "set_doubleclick", "set_double_click" }, // InputEventMouseButton
@@ -749,6 +751,7 @@ const char *RenamesMap3To4::csharp_function_renames[][2] = {
 	{ "GetCullMaskBit", "GetCullMaskValue" }, // Camera3D
 	{ "GetCursorPosition", "GetCaretColumn" }, // LineEdit
 	{ "GetD", "GetDistance" }, // LineShape2D
+	{ "GetDefaultLength", "GetLength" }, // Bone2D
 	{ "GetDepthBiasEnable", "GetDepthBiasEnabled" }, // RDPipelineRasterizationState
 	{ "GetDevice", "GetOutputDevice" }, // AudioServer
 	{ "GetDeviceList", "GetOutputDeviceList" }, // AudioServer
@@ -938,6 +941,7 @@ const char *RenamesMap3To4::csharp_function_renames[][2] = {
 	{ "SetCullMaskBit", "SetCullMaskValue" }, // Camera3D
 	{ "SetCursorPosition", "SetCaretColumn" }, // LineEdit
 	{ "SetD", "SetDistance" }, // WorldMarginShape2D
+	{ "SetDefaultLength", "SetLength" }, // Bone2D
 	{ "SetDepthBiasEnable", "SetDepthBiasEnabled" }, // RDPipelineRasterizationState
 	{ "SetDevice", "SetOutputDevice" }, // AudioServer
 	{ "SetDoubleclick", "SetDoubleClick" }, // InputEventMouseButton

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -378,9 +378,6 @@ void Bone2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_skeleton_rest"), &Bone2D::get_skeleton_rest);
 	ClassDB::bind_method(D_METHOD("get_index_in_skeleton"), &Bone2D::get_index_in_skeleton);
 
-	ClassDB::bind_method(D_METHOD("set_default_length", "default_length"), &Bone2D::set_default_length);
-	ClassDB::bind_method(D_METHOD("get_default_length"), &Bone2D::get_default_length);
-
 	ClassDB::bind_method(D_METHOD("set_autocalculate_length_and_angle", "auto_calculate"), &Bone2D::set_autocalculate_length_and_angle);
 	ClassDB::bind_method(D_METHOD("get_autocalculate_length_and_angle"), &Bone2D::get_autocalculate_length_and_angle);
 	ClassDB::bind_method(D_METHOD("set_length", "length"), &Bone2D::set_length);
@@ -414,16 +411,6 @@ Transform2D Bone2D::get_skeleton_rest() const {
 
 void Bone2D::apply_rest() {
 	set_transform(rest);
-}
-
-void Bone2D::set_default_length(real_t p_length) {
-	WARN_DEPRECATED_MSG("set_default_length is deprecated. Please use set_length instead!");
-	set_length(p_length);
-}
-
-real_t Bone2D::get_default_length() const {
-	WARN_DEPRECATED_MSG("get_default_length is deprecated. Please use get_length instead!");
-	return get_length();
 }
 
 int Bone2D::get_index_in_skeleton() const {

--- a/scene/2d/skeleton_2d.h
+++ b/scene/2d/skeleton_2d.h
@@ -80,9 +80,6 @@ public:
 
 	PackedStringArray get_configuration_warnings() const override;
 
-	void set_default_length(real_t p_length);
-	real_t get_default_length() const;
-
 	void set_autocalculate_length_and_angle(bool p_autocalculate);
 	bool get_autocalculate_length_and_angle() const;
 	void set_length(real_t p_length);


### PR DESCRIPTION
As noticed in https://github.com/godotengine/godot/pull/73507, this has been "deprecated" for [quite a bit of time](https://github.com/godotengine/godot/pull/47872) in 4.0 lifecycle, and keeping these methods for the stable release doesn't seem beneficial. We can use the project convertor to update the code that still relies on the old ones, but otherwise they are completely redundant.