### PR TITLE
Reorganize context menu in FileSystem dock to put more used options higher

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2589,27 +2589,39 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 			p_popup->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Open"), FILE_OPEN);
 			p_popup->add_separator();
 		}
-	}
 
-	if (p_paths.size() >= 1) {
-		if (!all_favorites) {
-			p_popup->add_icon_item(get_theme_icon(SNAME("Favorites"), SNAME("EditorIcons")), TTR("Add to Favorites"), FILE_ADD_FAVORITE);
-		}
-		if (!all_not_favorites) {
-			p_popup->add_icon_item(get_theme_icon(SNAME("NonFavorite"), SNAME("EditorIcons")), TTR("Remove from Favorites"), FILE_REMOVE_FAVORITE);
-		}
-		p_popup->add_separator();
-	}
-
-	if (all_files) {
 		if (filenames.size() == 1) {
 			p_popup->add_item(TTR("Edit Dependencies..."), FILE_DEPENDENCIES);
 			p_popup->add_item(TTR("View Owners..."), FILE_OWNERS);
 			p_popup->add_separator();
 		}
+	}
 
-	} else if (all_folders && foldernames.size() > 0) {
-		p_popup->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Open"), FILE_OPEN);
+	if (p_paths.size() == 1 && p_display_path_dependent_options) {
+		PopupMenu *new_menu = memnew(PopupMenu);
+		new_menu->set_name("New");
+		new_menu->connect("id_pressed", callable_mp(this, &FileSystemDock::_tree_rmb_option));
+
+		p_popup->add_child(new_menu);
+		p_popup->add_submenu_item(TTR("Create New"), "New", FILE_NEW);
+		p_popup->set_item_icon(p_popup->get_item_index(FILE_NEW), get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+
+		new_menu->add_icon_item(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")), TTR("Folder..."), FILE_NEW_FOLDER);
+		new_menu->add_icon_item(get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons")), TTR("Scene..."), FILE_NEW_SCENE);
+		new_menu->add_icon_item(get_theme_icon(SNAME("Script"), SNAME("EditorIcons")), TTR("Script..."), FILE_NEW_SCRIPT);
+		new_menu->add_icon_item(get_theme_icon(SNAME("Object"), SNAME("EditorIcons")), TTR("Resource..."), FILE_NEW_RESOURCE);
+		new_menu->add_icon_item(get_theme_icon(SNAME("TextFile"), SNAME("EditorIcons")), TTR("TextFile..."), FILE_NEW_TEXTFILE);
+		p_popup->add_separator();
+	}
+
+	if (all_folders && foldernames.size() > 0) {
+		p_popup->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Expand Folder"), FILE_OPEN);
+
+		if (foldernames.size() == 1) {
+			p_popup->add_icon_item(get_theme_icon(SNAME("GuiTreeArrowDown"), SNAME("EditorIcons")), TTR("Expand Hierarchy"), FOLDER_EXPAND_ALL);
+			p_popup->add_icon_item(get_theme_icon(SNAME("GuiTreeArrowRight"), SNAME("EditorIcons")), TTR("Collapse Hierarchy"), FOLDER_COLLAPSE_ALL);
+		}
+
 		p_popup->add_separator();
 	}
 
@@ -2629,29 +2641,23 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 		p_popup->add_icon_shortcut(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ED_GET_SHORTCUT("filesystem_dock/delete"), FILE_REMOVE);
 	}
 
-	if (p_paths.size() == 1) {
-		p_popup->add_separator();
-		if (p_display_path_dependent_options) {
-			PopupMenu *new_menu = memnew(PopupMenu);
-			new_menu->set_name("New");
-			new_menu->connect("id_pressed", callable_mp(this, &FileSystemDock::_tree_rmb_option));
+	p_popup->add_separator();
 
-			p_popup->add_child(new_menu);
-			p_popup->add_submenu_item(TTR("New"), "New", FILE_NEW);
-
-			new_menu->add_icon_item(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")), TTR("Folder..."), FILE_NEW_FOLDER);
-			new_menu->add_icon_item(get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons")), TTR("Scene..."), FILE_NEW_SCENE);
-			new_menu->add_icon_item(get_theme_icon(SNAME("Script"), SNAME("EditorIcons")), TTR("Script..."), FILE_NEW_SCRIPT);
-			new_menu->add_icon_item(get_theme_icon(SNAME("Object"), SNAME("EditorIcons")), TTR("Resource..."), FILE_NEW_RESOURCE);
-			new_menu->add_icon_item(get_theme_icon(SNAME("TextFile"), SNAME("EditorIcons")), TTR("TextFile..."), FILE_NEW_TEXTFILE);
-#if !defined(ANDROID_ENABLED) && !defined(WEB_ENABLED)
-			p_popup->add_separator();
-#endif
+	if (p_paths.size() >= 1) {
+		if (!all_favorites) {
+			p_popup->add_icon_item(get_theme_icon(SNAME("Favorites"), SNAME("EditorIcons")), TTR("Add to Favorites"), FILE_ADD_FAVORITE);
 		}
+		if (!all_not_favorites) {
+			p_popup->add_icon_item(get_theme_icon(SNAME("NonFavorite"), SNAME("EditorIcons")), TTR("Remove from Favorites"), FILE_REMOVE_FAVORITE);
+		}
+	}
 
+	if (p_paths.size() == 1) {
 		const String fpath = p_paths[0];
 
 #if !defined(ANDROID_ENABLED) && !defined(WEB_ENABLED)
+		p_popup->add_separator();
+
 		// Opening the system file manager is not supported on the Android and web editors.
 		const bool is_directory = fpath.ends_with("/");
 		const String item_text = is_directory ? TTR("Open in File Manager") : TTR("Show in File Manager");
@@ -2674,13 +2680,6 @@ void FileSystemDock::_tree_rmb_select(const Vector2 &p_pos, MouseButton p_button
 	Vector<String> paths = _tree_get_selected(false);
 
 	tree_popup->clear();
-	if (paths.size() == 1) {
-		if (paths[0].ends_with("/")) {
-			tree_popup->add_icon_item(get_theme_icon(SNAME("GuiTreeArrowDown"), SNAME("EditorIcons")), TTR("Expand All"), FOLDER_EXPAND_ALL);
-			tree_popup->add_icon_item(get_theme_icon(SNAME("GuiTreeArrowRight"), SNAME("EditorIcons")), TTR("Collapse All"), FOLDER_COLLAPSE_ALL);
-			tree_popup->add_separator();
-		}
-	}
 
 	// Popup.
 	if (!paths.is_empty()) {


### PR DESCRIPTION
So during these last few weeks I've been using the editor quite a lot to test various PRs and reports, and was constantly feeling awkward about the position of the "New" context menu item in the FileSystem dock.

![Godot_v4 0-rc2_win64_2023-02-17_19-44-12](https://user-images.githubusercontent.com/11782833/219772582-4877cb3b-0bba-418d-9b6b-85bc1c4edc37.png)

For some reason, it's at the bottom while I expect useful items to be at the top. So it always takes a bit of time to scan the context menu from the top to find it. I started to get used to it, but I don't think that this position ideal, or makes sense. There is an argument to be made that this matches File Explorer in Windows (and maybe similar tools on other platforms), but that's not a great comparison IMO. A better comparison is a code editor or an IDE, a professional creator's tool that operates on a "project". So, for example, in VS Code "New" items are [at the top of the list](https://user-images.githubusercontent.com/11782833/219773386-ab4c63a2-cb7b-499d-a16d-1eec0e372565.png), and it feels very intuitive.

At the same time, an arguably less useful option, "Add to Favorites" (and its "Remove" counterpart) are located very high, always getting in the way.

Additionally, folders have this "Open" option which only expands selected folders, and it's located in the middle. At the same time we have "Expand/Collapse All" at the top (for a single folder). So it felt very natural for the "Open" option to be renamed to "Expand" and put to the top, next to its cousins.

Overall, the new context menu for a folder looks like this:

![godot windows editor dev x86_64_2023-02-17_20-34-54](https://user-images.githubusercontent.com/11782833/219774490-a7a8426d-28a4-4017-88ec-71409a27c7cd.png)

I think it's very reasonable like that, and provides quicker and more intuitive access to the most used items. 

-----

Interestingly, single items also have the "New" menu option available, likely to make it easier to create new items in their parent folder. Not all apps do that, but I didn't want to change any functionality, so I kept it as is. That means, however, that the new position of this item is in between various file options. But I don't think it's too bad. The "New" option should be high, as I established above, so it wouldn't make sense to move it anywhere else.

![godot windows editor dev x86_64_2023-02-17_20-35-07](https://user-images.githubusercontent.com/11782833/219775712-7cac349d-223a-4aa8-834f-984c201fa334.png)

-----

The menu you see when clicking on an empty space is exactly as it was. When you have multiple items selected, the menu is only slightly different:

![godot windows editor dev x86_64_2023-02-17_20-35-43](https://user-images.githubusercontent.com/11782833/219776074-768a005b-9552-4c6b-806a-f4967c25d5d8.png)

-----

As mentioned, some renames were made for clarity and consistency (items describe actions). Some icons were also adjusted. This PR also does a bit of a clean-up in the relevant FileSystem dock code.

As a closing note, I fully expect this to be controversial, but I think it makes more sense this way, and is in line with what is expected from such tools. There was a bit of support in the contributors chat to these ideas, so I'm hoping we can merge it quickly.