### PR TITLE
Avoid unnecessary binding of occlusion polygon vertex array

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1951,11 +1951,12 @@ void RasterizerCanvasGLES3::occluder_polygon_set_shape(RID p_occluder, const Vec
 			glBufferData(GL_ELEMENT_ARRAY_BUFFER, 3 * lc * sizeof(uint16_t), indices.ptr(), GL_STATIC_DRAW);
 			glBindVertexArray(0);
 		} else {
-			glBindVertexArray(oc->vertex_array);
 			glBindBuffer(GL_ARRAY_BUFFER, oc->vertex_buffer);
 			glBufferData(GL_ARRAY_BUFFER, lc * 6 * sizeof(float), geometry.ptr(), GL_STATIC_DRAW);
 			glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, oc->index_buffer);
 			glBufferData(GL_ELEMENT_ARRAY_BUFFER, 3 * lc * sizeof(uint16_t), indices.ptr(), GL_STATIC_DRAW);
+			glBindBuffer(GL_ARRAY_BUFFER, 0);
+			glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 		}
 	}
 


### PR DESCRIPTION
By binding the vertex array here and not unbinding it, the state was getting modified in other parts of the pipeline. Since we don't need the vertex array to update the buffers, we can just not bind it. We should also unbind the buffers just in case. 

Fixes: https://github.com/godotengine/godot/issues/73487
