### PR TITLE
Add support for depth function in spatial materials

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -150,6 +150,10 @@
 		<member name="depth_draw_mode" type="int" setter="set_depth_draw_mode" getter="get_depth_draw_mode" enum="BaseMaterial3D.DepthDrawMode" default="0">
 			Determines when depth rendering takes place. See [enum DepthDrawMode]. See also [member transparency].
 		</member>
+		<member name="depth_function" type="int" setter="set_depth_function" getter="get_depth_function" enum="BaseMaterial3D.DepthFunction" default="0">
+			Determines which comparison operator is used when testing depth. See [enum DepthFunction].
+			[b]Note:[/b] Changing [member depth_function] to a non-default value only has a visible effect when used on a transparent material, or a material that has [member depth_draw_mode] set to [constant DEPTH_DRAW_DISABLED].
+		</member>
 		<member name="detail_albedo" type="Texture2D" setter="set_texture" getter="get_texture">
 			Texture that specifies the color of the detail overlay. [member detail_albedo]'s alpha channel is used as a mask, even when the material is opaque. To use a dedicated texture as a mask, see [member detail_mask].
 			[b]Note:[/b] [member detail_albedo] is [i]not[/i] modulated by [member albedo_color].
@@ -629,6 +633,30 @@
 		</constant>
 		<constant name="DEPTH_DRAW_DISABLED" value="2" enum="DepthDrawMode">
 			Objects will not write their depth to the depth buffer, even during the depth prepass (if enabled).
+		</constant>
+		<constant name="DEPTH_FUNCTION_GREATER_OR_EQUAL" value="0" enum="DepthFunction">
+			Default depth function. Depth check succeeds if greater than or equal to existing depth.
+		</constant>
+		<constant name="DEPTH_FUNCTION_LESS_OR_EQUAL" value="1" enum="DepthFunction">
+			Depth check succeeds if less than or equal to existing depth.
+		</constant>
+		<constant name="DEPTH_FUNCTION_LESS" value="2" enum="DepthFunction">
+			Depth check succeeds if less than existing depth.
+		</constant>
+		<constant name="DEPTH_FUNCTION_EQUAL" value="3" enum="DepthFunction">
+			Depth check succeeds if equal to existing depth.
+		</constant>
+		<constant name="DEPTH_FUNCTION_GREATER" value="4" enum="DepthFunction">
+			Depth check succeeds if greater than existing depth.
+		</constant>
+		<constant name="DEPTH_FUNCTION_NOT_EQUAL" value="5" enum="DepthFunction">
+			Depth check succeeds if not equal to existing depth.
+		</constant>
+		<constant name="DEPTH_FUNCTION_ALWAYS" value="6" enum="DepthFunction">
+			Depth check always succeeds.
+		</constant>
+		<constant name="DEPTH_FUNCTION_NEVER" value="7" enum="DepthFunction">
+			Depth check never succeeds.
 		</constant>
 		<constant name="CULL_BACK" value="0" enum="CullMode">
 			Default cull mode. The back of the object is culled when not visible. Back face triangles will be culled when facing the camera. This results in only the front side of triangles being drawn. For closed-surface meshes, this means that only the exterior of the mesh will be visible.

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2181,7 +2181,7 @@ void RasterizerSceneGLES3::_render_shadow_pass(RID p_light, RID p_shadow_atlas, 
 	scene_state.reset_gl_state();
 	scene_state.enable_gl_depth_test(true);
 	scene_state.enable_gl_depth_draw(true);
-	glDepthFunc(GL_GREATER);
+	scene_state.set_gl_depth_func(GLES3::SceneShaderData::DEPTH_FUNCTION_GREATER);
 
 	glColorMask(0, 0, 0, 0);
 	glDrawBuffers(0, nullptr);
@@ -2500,7 +2500,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 		scene_state.enable_gl_depth_test(true);
 		scene_state.enable_gl_depth_draw(true);
 		scene_state.enable_gl_blend(false);
-		glDepthFunc(GL_GEQUAL);
+		scene_state.set_gl_depth_func(GLES3::SceneShaderData::DEPTH_FUNCTION_GREATER_OR_EQUAL);
 		scene_state.enable_gl_scissor_test(false);
 
 		glColorMask(0, 0, 0, 0);
@@ -2538,7 +2538,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	scene_state.enable_gl_scissor_test(false);
 	scene_state.enable_gl_depth_test(true);
 	scene_state.enable_gl_depth_draw(true);
-	glDepthFunc(GL_GEQUAL);
+	scene_state.set_gl_depth_func(GLES3::SceneShaderData::DEPTH_FUNCTION_GREATER_OR_EQUAL);
 
 	{
 		GLuint db = GL_COLOR_ATTACHMENT0;
@@ -2632,6 +2632,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 		RENDER_TIMESTAMP("Render Sky");
 
 		scene_state.enable_gl_depth_test(true);
+		scene_state.set_gl_depth_func(GLES3::SceneShaderData::DEPTH_FUNCTION_GREATER_OR_EQUAL);
 		scene_state.enable_gl_blend(false);
 		scene_state.set_gl_cull_mode(RS::CULL_MODE_BACK);
 
@@ -3015,6 +3016,8 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 		if constexpr (p_pass_mode == PASS_MODE_COLOR_TRANSPARENT) {
 			scene_state.enable_gl_depth_test(shader->depth_test == GLES3::SceneShaderData::DEPTH_TEST_ENABLED);
 		}
+
+		scene_state.set_gl_depth_func(shader->depth_function);
 
 		if constexpr (p_pass_mode != PASS_MODE_SHADOW) {
 			if (shader->depth_draw == GLES3::SceneShaderData::DEPTH_DRAW_OPAQUE) {
@@ -3710,7 +3713,7 @@ void RasterizerSceneGLES3::render_particle_collider_heightfield(RID p_collider, 
 	scene_state.reset_gl_state();
 	scene_state.enable_gl_depth_test(true);
 	scene_state.enable_gl_depth_draw(true);
-	glDepthFunc(GL_GREATER);
+	scene_state.set_gl_depth_func(GLES3::SceneShaderData::DEPTH_FUNCTION_GREATER);
 
 	glDrawBuffers(0, nullptr);
 
@@ -3756,7 +3759,7 @@ void RasterizerSceneGLES3::_render_uv2(const PagedArray<RenderGeometryInstance *
 		scene_state.reset_gl_state();
 		scene_state.enable_gl_depth_test(true);
 		scene_state.enable_gl_depth_draw(true);
-		glDepthFunc(GL_GREATER);
+		scene_state.set_gl_depth_func(GLES3::SceneShaderData::DEPTH_FUNCTION_GREATER);
 
 		TightLocalVector<GLenum> draw_buffers;
 		draw_buffers.push_back(GL_COLOR_ATTACHMENT0);
@@ -3849,7 +3852,7 @@ void RasterizerSceneGLES3::_render_buffers_debug_draw(Ref<RenderSceneBuffersGLES
 			glViewport(0, 0, shadow_atlas_size, shadow_atlas_size);
 			glActiveTexture(GL_TEXTURE0);
 			scene_state.enable_gl_depth_draw(true);
-			glDepthFunc(GL_ALWAYS);
+			scene_state.set_gl_depth_func(GLES3::SceneShaderData::DEPTH_FUNCTION_ALWAYS);
 			scene_state.set_gl_cull_mode(RS::CULL_MODE_DISABLED);
 
 			// Loop through quadrants and copy shadows over.

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -462,6 +462,7 @@ private:
 
 		GLES3::SceneShaderData::BlendMode current_blend_mode = GLES3::SceneShaderData::BLEND_MODE_MIX;
 		RS::CullMode cull_mode = RS::CULL_MODE_BACK;
+		GLES3::SceneShaderData::DepthFunction current_depth_function = GLES3::SceneShaderData::DEPTH_FUNCTION_GREATER_OR_EQUAL;
 
 		bool current_blend_enabled = false;
 		bool current_depth_draw_enabled = false;
@@ -483,6 +484,9 @@ private:
 			current_depth_draw_enabled = false;
 			glDisable(GL_DEPTH_TEST);
 			current_depth_test_enabled = false;
+
+			glDepthFunc(GL_GEQUAL);
+			current_depth_function = GLES3::SceneShaderData::DEPTH_FUNCTION_GREATER_OR_EQUAL;
 		}
 
 		void set_gl_cull_mode(RS::CullMode p_mode) {
@@ -537,6 +541,24 @@ private:
 					glDisable(GL_DEPTH_TEST);
 				}
 				current_depth_test_enabled = p_enabled;
+			}
+		}
+
+		void set_gl_depth_func(GLES3::SceneShaderData::DepthFunction p_depth_func) {
+			if (current_depth_function != p_depth_func) {
+				GLenum depth_function_table[GLES3::SceneShaderData::DEPTH_FUNCTION_MAX] = {
+					GL_GEQUAL,
+					GL_LEQUAL,
+					GL_LESS,
+					GL_EQUAL,
+					GL_GREATER,
+					GL_NOTEQUAL,
+					GL_ALWAYS,
+					GL_NEVER,
+				};
+
+				glDepthFunc(depth_function_table[p_depth_func]);
+				current_depth_function = p_depth_func;
 			}
 		}
 

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2923,6 +2923,7 @@ void SceneShaderData::set_code(const String &p_code) {
 	// Actual enums set further down after compilation.
 	int blend_modei = BLEND_MODE_MIX;
 	int depth_testi = DEPTH_TEST_ENABLED;
+	int depth_functioni = DEPTH_FUNCTION_GREATER_OR_EQUAL;
 	int alpha_antialiasing_modei = ALPHA_ANTIALIASING_OFF;
 	int cull_modei = RS::CULL_MODE_BACK;
 	int depth_drawi = DEPTH_DRAW_OPAQUE;
@@ -2950,6 +2951,15 @@ void SceneShaderData::set_code(const String &p_code) {
 	actions.render_mode_values["cull_disabled"] = Pair<int *, int>(&cull_modei, RS::CULL_MODE_DISABLED);
 	actions.render_mode_values["cull_front"] = Pair<int *, int>(&cull_modei, RS::CULL_MODE_FRONT);
 	actions.render_mode_values["cull_back"] = Pair<int *, int>(&cull_modei, RS::CULL_MODE_BACK);
+
+	actions.render_mode_values["depth_function_greater_or_equal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_GREATER_OR_EQUAL);
+	actions.render_mode_values["depth_function_less_or_equal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_LESS_OR_EQUAL);
+	actions.render_mode_values["depth_function_less"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_LESS);
+	actions.render_mode_values["depth_function_equal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_EQUAL);
+	actions.render_mode_values["depth_function_greater"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_GREATER);
+	actions.render_mode_values["depth_function_not_equal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_NOT_EQUAL);
+	actions.render_mode_values["depth_function_always"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_ALWAYS);
+	actions.render_mode_values["depth_function_never"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_NEVER);
 
 	actions.render_mode_flags["unshaded"] = &unshaded;
 	actions.render_mode_flags["wireframe"] = &wireframe;
@@ -3008,6 +3018,7 @@ void SceneShaderData::set_code(const String &p_code) {
 	depth_draw = DepthDraw(depth_drawi);
 	depth_test = DepthTest(depth_testi);
 	cull_mode = RS::CullMode(cull_modei);
+	depth_function = DepthFunction(depth_functioni);
 
 	vertex_input_mask = RS::ARRAY_FORMAT_VERTEX | RS::ARRAY_FORMAT_NORMAL; // We can always read vertices and normals.
 	vertex_input_mask |= uses_tangent << RS::ARRAY_TANGENT;

--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -260,6 +260,18 @@ struct SceneShaderData : public ShaderData {
 		DEPTH_TEST_ENABLED
 	};
 
+	enum DepthFunction {
+		DEPTH_FUNCTION_GREATER_OR_EQUAL,
+		DEPTH_FUNCTION_LESS_OR_EQUAL,
+		DEPTH_FUNCTION_LESS,
+		DEPTH_FUNCTION_EQUAL,
+		DEPTH_FUNCTION_GREATER,
+		DEPTH_FUNCTION_NOT_EQUAL,
+		DEPTH_FUNCTION_ALWAYS,
+		DEPTH_FUNCTION_NEVER,
+		DEPTH_FUNCTION_MAX
+	};
+
 	enum AlphaAntiAliasing {
 		ALPHA_ANTIALIASING_OFF,
 		ALPHA_ANTIALIASING_ALPHA_TO_COVERAGE,
@@ -284,6 +296,7 @@ struct SceneShaderData : public ShaderData {
 	DepthDraw depth_draw;
 	DepthTest depth_test;
 	RS::CullMode cull_mode;
+	DepthFunction depth_function;
 
 	bool uses_point_size;
 	bool uses_alpha;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -794,6 +794,35 @@ void BaseMaterial3D::_update_shader() {
 			break; // Internal value, skip.
 	}
 
+	switch (depth_function) {
+		case DEPTH_FUNCTION_GREATER_OR_EQUAL:
+			code += ", depth_function_greater_or_equal";
+			break;
+		case DEPTH_FUNCTION_LESS_OR_EQUAL:
+			code += ", depth_function_less_or_equal";
+			break;
+		case DEPTH_FUNCTION_LESS:
+			code += ", depth_function_less";
+			break;
+		case DEPTH_FUNCTION_EQUAL:
+			code += ", depth_function_equal";
+			break;
+		case DEPTH_FUNCTION_GREATER:
+			code += ", depth_function_greater";
+			break;
+		case DEPTH_FUNCTION_NOT_EQUAL:
+			code += ", depth_function_not_equal";
+			break;
+		case DEPTH_FUNCTION_ALWAYS:
+			code += ", depth_function_always";
+			break;
+		case DEPTH_FUNCTION_NEVER:
+			code += ", depth_function_never";
+			break;
+		case DEPTH_FUNCTION_MAX:
+			break; // Internal value, skip.
+	}
+
 	switch (cull_mode) {
 		case CULL_BACK:
 			code += ", cull_back";
@@ -2272,6 +2301,19 @@ BaseMaterial3D::DepthDrawMode BaseMaterial3D::get_depth_draw_mode() const {
 	return depth_draw_mode;
 }
 
+void BaseMaterial3D::set_depth_function(DepthFunction p_func) {
+	if (depth_function == p_func) {
+		return;
+	}
+
+	depth_function = p_func;
+	_queue_shader_change();
+}
+
+BaseMaterial3D::DepthFunction BaseMaterial3D::get_depth_function() const {
+	return depth_function;
+}
+
 void BaseMaterial3D::set_cull_mode(CullMode p_mode) {
 	if (cull_mode == p_mode) {
 		return;
@@ -3038,6 +3080,9 @@ void BaseMaterial3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_depth_draw_mode", "depth_draw_mode"), &BaseMaterial3D::set_depth_draw_mode);
 	ClassDB::bind_method(D_METHOD("get_depth_draw_mode"), &BaseMaterial3D::get_depth_draw_mode);
 
+	ClassDB::bind_method(D_METHOD("set_depth_function", "depth_function"), &BaseMaterial3D::set_depth_function);
+	ClassDB::bind_method(D_METHOD("get_depth_function"), &BaseMaterial3D::get_depth_function);
+
 	ClassDB::bind_method(D_METHOD("set_cull_mode", "cull_mode"), &BaseMaterial3D::set_cull_mode);
 	ClassDB::bind_method(D_METHOD("get_cull_mode"), &BaseMaterial3D::get_cull_mode);
 
@@ -3167,6 +3212,7 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "blend_mode", PROPERTY_HINT_ENUM, "Mix,Add,Subtract,Multiply,Premultiplied Alpha"), "set_blend_mode", "get_blend_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "cull_mode", PROPERTY_HINT_ENUM, "Back,Front,Disabled"), "set_cull_mode", "get_cull_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "depth_draw_mode", PROPERTY_HINT_ENUM, "Opaque Only,Always,Never"), "set_depth_draw_mode", "get_depth_draw_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "depth_function", PROPERTY_HINT_ENUM, "Greater or Equal,Less or Equal,Less,Equal,Greater,Not Equal,Always,Never"), "set_depth_function", "get_depth_function");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "no_depth_test"), "set_flag", "get_flag", FLAG_DISABLE_DEPTH_TEST);
 
 	ADD_GROUP("Shading", "");
@@ -3402,6 +3448,15 @@ void BaseMaterial3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(DEPTH_DRAW_OPAQUE_ONLY);
 	BIND_ENUM_CONSTANT(DEPTH_DRAW_ALWAYS);
 	BIND_ENUM_CONSTANT(DEPTH_DRAW_DISABLED);
+
+	BIND_ENUM_CONSTANT(DEPTH_FUNCTION_GREATER_OR_EQUAL);
+	BIND_ENUM_CONSTANT(DEPTH_FUNCTION_LESS_OR_EQUAL);
+	BIND_ENUM_CONSTANT(DEPTH_FUNCTION_LESS);
+	BIND_ENUM_CONSTANT(DEPTH_FUNCTION_EQUAL);
+	BIND_ENUM_CONSTANT(DEPTH_FUNCTION_GREATER);
+	BIND_ENUM_CONSTANT(DEPTH_FUNCTION_NOT_EQUAL);
+	BIND_ENUM_CONSTANT(DEPTH_FUNCTION_ALWAYS);
+	BIND_ENUM_CONSTANT(DEPTH_FUNCTION_NEVER);
 
 	BIND_ENUM_CONSTANT(CULL_BACK);
 	BIND_ENUM_CONSTANT(CULL_FRONT);

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -237,6 +237,18 @@ public:
 		DEPTH_DRAW_MAX
 	};
 
+	enum DepthFunction {
+		DEPTH_FUNCTION_GREATER_OR_EQUAL,
+		DEPTH_FUNCTION_LESS_OR_EQUAL,
+		DEPTH_FUNCTION_LESS,
+		DEPTH_FUNCTION_EQUAL,
+		DEPTH_FUNCTION_GREATER,
+		DEPTH_FUNCTION_NOT_EQUAL,
+		DEPTH_FUNCTION_ALWAYS,
+		DEPTH_FUNCTION_NEVER,
+		DEPTH_FUNCTION_MAX
+	};
+
 	enum CullMode {
 		CULL_BACK,
 		CULL_FRONT,
@@ -326,6 +338,7 @@ private:
 		uint64_t shading_mode : get_num_bits(SHADING_MODE_MAX - 1);
 		uint64_t blend_mode : get_num_bits(BLEND_MODE_MAX - 1);
 		uint64_t depth_draw_mode : get_num_bits(DEPTH_DRAW_MAX - 1);
+		uint64_t depth_function : get_num_bits(DEPTH_FUNCTION_MAX - 1);
 		uint64_t cull_mode : get_num_bits(CULL_MAX - 1);
 		uint64_t diffuse_mode : get_num_bits(DIFFUSE_MAX - 1);
 		uint64_t specular_mode : get_num_bits(SPECULAR_MAX - 1);
@@ -377,6 +390,7 @@ private:
 		mk.detail_uv = detail_uv;
 		mk.blend_mode = blend_mode;
 		mk.depth_draw_mode = depth_draw_mode;
+		mk.depth_function = depth_function;
 		mk.cull_mode = cull_mode;
 		mk.texture_filter = texture_filter;
 		mk.transparency = transparency;
@@ -547,6 +561,7 @@ private:
 	BlendMode blend_mode = BLEND_MODE_MIX;
 	BlendMode detail_blend_mode = BLEND_MODE_MIX;
 	DepthDrawMode depth_draw_mode = DEPTH_DRAW_OPAQUE_ONLY;
+	DepthFunction depth_function = DEPTH_FUNCTION_GREATER_OR_EQUAL;
 	CullMode cull_mode = CULL_BACK;
 	bool flags[FLAG_MAX] = {};
 	SpecularMode specular_mode = SPECULAR_SCHLICK_GGX;
@@ -681,6 +696,9 @@ public:
 	void set_depth_draw_mode(DepthDrawMode p_mode);
 	DepthDrawMode get_depth_draw_mode() const;
 
+	void set_depth_function(DepthFunction p_func);
+	DepthFunction get_depth_function() const;
+
 	void set_cull_mode(CullMode p_mode);
 	CullMode get_cull_mode() const;
 
@@ -804,6 +822,7 @@ VARIANT_ENUM_CAST(BaseMaterial3D::DetailUV)
 VARIANT_ENUM_CAST(BaseMaterial3D::Feature)
 VARIANT_ENUM_CAST(BaseMaterial3D::BlendMode)
 VARIANT_ENUM_CAST(BaseMaterial3D::DepthDrawMode)
+VARIANT_ENUM_CAST(BaseMaterial3D::DepthFunction)
 VARIANT_ENUM_CAST(BaseMaterial3D::CullMode)
 VARIANT_ENUM_CAST(BaseMaterial3D::Flags)
 VARIANT_ENUM_CAST(BaseMaterial3D::DiffuseMode)

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -55,6 +55,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 	depth_testi = DEPTH_TEST_ENABLED;
 	alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF;
 	int cull_modei = RS::CULL_MODE_BACK;
+	int depth_functioni = DEPTH_FUNCTION_GREATER_OR_EQUAL;
 
 	uses_point_size = false;
 	uses_alpha = false;
@@ -104,6 +105,15 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 	actions.render_mode_values["cull_disabled"] = Pair<int *, int>(&cull_modei, RS::CULL_MODE_DISABLED);
 	actions.render_mode_values["cull_front"] = Pair<int *, int>(&cull_modei, RS::CULL_MODE_FRONT);
 	actions.render_mode_values["cull_back"] = Pair<int *, int>(&cull_modei, RS::CULL_MODE_BACK);
+
+	actions.render_mode_values["depth_function_greater_or_equal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_GREATER_OR_EQUAL);
+	actions.render_mode_values["depth_function_less_or_equal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_LESS_OR_EQUAL);
+	actions.render_mode_values["depth_function_less"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_LESS);
+	actions.render_mode_values["depth_function_equal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_EQUAL);
+	actions.render_mode_values["depth_function_greater"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_GREATER);
+	actions.render_mode_values["depth_function_not_equal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_NOT_EQUAL);
+	actions.render_mode_values["depth_function_always"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_ALWAYS);
+	actions.render_mode_values["depth_function_never"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_NEVER);
 
 	actions.render_mode_flags["unshaded"] = &unshaded;
 	actions.render_mode_flags["wireframe"] = &wireframe;
@@ -159,6 +169,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 	depth_draw = DepthDraw(depth_drawi);
 	depth_test = DepthTest(depth_testi);
 	cull_mode = RS::CullMode(cull_modei);
+	depth_function = DepthFunction(depth_functioni);
 	uses_screen_texture_mipmaps = gen_code.uses_screen_texture_mipmaps;
 	uses_screen_texture = gen_code.uses_screen_texture;
 	uses_depth_texture = gen_code.uses_depth_texture;
@@ -302,8 +313,20 @@ void SceneShaderForwardClustered::ShaderData::_create_pipeline(PipelineKey p_pip
 
 	if (depth_test != DEPTH_TEST_DISABLED) {
 		depth_stencil_state.enable_depth_test = true;
-		depth_stencil_state.depth_compare_operator = RD::COMPARE_OP_GREATER_OR_EQUAL;
 		depth_stencil_state.enable_depth_write = depth_draw != DEPTH_DRAW_DISABLED ? true : false;
+
+		static const RD::CompareOperator depth_function_rd_table[DEPTH_FUNCTION_MAX] = {
+			RD::COMPARE_OP_GREATER_OR_EQUAL,
+			RD::COMPARE_OP_LESS_OR_EQUAL,
+			RD::COMPARE_OP_LESS,
+			RD::COMPARE_OP_EQUAL,
+			RD::COMPARE_OP_GREATER,
+			RD::COMPARE_OP_NOT_EQUAL,
+			RD::COMPARE_OP_ALWAYS,
+			RD::COMPARE_OP_NEVER,
+		};
+
+		depth_stencil_state.depth_compare_operator = depth_function_rd_table[depth_function];
 	}
 	bool depth_pre_pass_enabled = bool(GLOBAL_GET("rendering/driver/depth_prepass/enable"));
 

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -153,6 +153,18 @@ public:
 			DEPTH_TEST_ENABLED
 		};
 
+		enum DepthFunction {
+			DEPTH_FUNCTION_GREATER_OR_EQUAL,
+			DEPTH_FUNCTION_LESS_OR_EQUAL,
+			DEPTH_FUNCTION_LESS,
+			DEPTH_FUNCTION_EQUAL,
+			DEPTH_FUNCTION_GREATER,
+			DEPTH_FUNCTION_NOT_EQUAL,
+			DEPTH_FUNCTION_ALWAYS,
+			DEPTH_FUNCTION_NEVER,
+			DEPTH_FUNCTION_MAX
+		};
+
 		enum CullVariant {
 			CULL_VARIANT_NORMAL,
 			CULL_VARIANT_REVERSED,
@@ -210,6 +222,7 @@ public:
 		String code;
 
 		DepthDraw depth_draw = DEPTH_DRAW_OPAQUE;
+		DepthFunction depth_function = DEPTH_FUNCTION_GREATER_OR_EQUAL;
 		DepthTest depth_test = DEPTH_TEST_ENABLED;
 
 		int blend_mode = BLEND_MODE_MIX;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -57,6 +57,7 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 	depth_testi = DEPTH_TEST_ENABLED;
 	alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF;
 	cull_mode = RS::CULL_MODE_BACK;
+	int depth_functioni = DEPTH_FUNCTION_GREATER_OR_EQUAL;
 
 	uses_point_size = false;
 	uses_alpha = false;
@@ -105,6 +106,15 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 	actions.render_mode_values["cull_disabled"] = Pair<int *, int>(&cull_mode, RS::CULL_MODE_DISABLED);
 	actions.render_mode_values["cull_front"] = Pair<int *, int>(&cull_mode, RS::CULL_MODE_FRONT);
 	actions.render_mode_values["cull_back"] = Pair<int *, int>(&cull_mode, RS::CULL_MODE_BACK);
+
+	actions.render_mode_values["depth_function_greater_or_equal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_GREATER_OR_EQUAL);
+	actions.render_mode_values["depth_function_less_or_equal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_LESS_OR_EQUAL);
+	actions.render_mode_values["depth_function_less"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_LESS);
+	actions.render_mode_values["depth_function_equal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_EQUAL);
+	actions.render_mode_values["depth_function_greater"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_GREATER);
+	actions.render_mode_values["depth_function_not_equal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_NOT_EQUAL);
+	actions.render_mode_values["depth_function_always"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_ALWAYS);
+	actions.render_mode_values["depth_function_never"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_NEVER);
 
 	actions.render_mode_flags["unshaded"] = &unshaded;
 	actions.render_mode_flags["wireframe"] = &wireframe;
@@ -158,6 +168,7 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 
 	depth_draw = DepthDraw(depth_drawi);
 	depth_test = DepthTest(depth_testi);
+	depth_function = DepthFunction(depth_functioni);
 	uses_vertex_time = gen_code.uses_vertex_time;
 	uses_fragment_time = gen_code.uses_fragment_time;
 	uses_screen_texture_mipmaps = gen_code.uses_screen_texture_mipmaps;
@@ -264,8 +275,20 @@ void SceneShaderForwardMobile::ShaderData::_create_pipeline(PipelineKey p_pipeli
 
 	if (depth_test != DEPTH_TEST_DISABLED) {
 		depth_stencil_state.enable_depth_test = true;
-		depth_stencil_state.depth_compare_operator = RD::COMPARE_OP_GREATER_OR_EQUAL;
 		depth_stencil_state.enable_depth_write = depth_draw != DEPTH_DRAW_DISABLED ? true : false;
+
+		static const RD::CompareOperator depth_function_rd_table[DEPTH_FUNCTION_MAX] = {
+			RD::COMPARE_OP_GREATER_OR_EQUAL,
+			RD::COMPARE_OP_LESS_OR_EQUAL,
+			RD::COMPARE_OP_LESS,
+			RD::COMPARE_OP_EQUAL,
+			RD::COMPARE_OP_GREATER,
+			RD::COMPARE_OP_NOT_EQUAL,
+			RD::COMPARE_OP_ALWAYS,
+			RD::COMPARE_OP_NEVER,
+		};
+
+		depth_stencil_state.depth_compare_operator = depth_function_rd_table[depth_function];
 	}
 
 	RD::RenderPrimitive primitive_rd_table[RS::PRIMITIVE_MAX] = {

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -135,6 +135,18 @@ public:
 			DEPTH_DRAW_ALWAYS
 		};
 
+		enum DepthFunction {
+			DEPTH_FUNCTION_GREATER_OR_EQUAL,
+			DEPTH_FUNCTION_LESS_OR_EQUAL,
+			DEPTH_FUNCTION_LESS,
+			DEPTH_FUNCTION_EQUAL,
+			DEPTH_FUNCTION_GREATER,
+			DEPTH_FUNCTION_NOT_EQUAL,
+			DEPTH_FUNCTION_ALWAYS,
+			DEPTH_FUNCTION_NEVER,
+			DEPTH_FUNCTION_MAX
+		};
+
 		enum DepthTest {
 			DEPTH_TEST_DISABLED,
 			DEPTH_TEST_ENABLED
@@ -198,6 +210,7 @@ public:
 		String code;
 
 		DepthDraw depth_draw;
+		DepthFunction depth_function;
 		DepthTest depth_test;
 
 		int blend_mode = BLEND_MODE_MIX;

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -932,6 +932,13 @@ public:
 			options.push_back(p_arg5);
 			options.push_back(p_arg6);
 		}
+
+		ModeInfo(const StringName &p_name, std::initializer_list<StringName> p_args) :
+				name(p_name) {
+			for (const StringName &arg : p_args) {
+				options.push_back(arg);
+			}
+		}
 	};
 
 	struct FunctionInfo {

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -209,6 +209,7 @@ ShaderTypes::ShaderTypes() {
 	{
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("blend"), "mix", "add", "sub", "mul", "premul_alpha" });
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("depth_draw"), "opaque", "always", "never" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("depth_function"), { "less_or_equal", "less", "equal", "greater", "not_equal", "greater_or_equal", "always", "never" } });
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("depth_prepass_alpha") });
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("depth_test_disabled") });
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("sss_mode_skin") });


### PR DESCRIPTION
Adds "Depth Function" property to spatial materials, which controls the depth comparison operator.

Resolves https://github.com/godotengine/godot-proposals/issues/1298.

Test project: https://github.com/apples/DepthFunctionTest

Seems to work fine in all three rendering modes in my simple testing, but more testing is likely necessary as this touches core rendering logic. I'm a little unsure about the GLES3 implementation, but I tried my best.

Currently only useful for alpha pass materials, due to https://github.com/godotengine/godot/issues/73158.

![image](https://user-images.githubusercontent.com/2352020/219801224-c7326415-8b2c-4dfd-8392-144cb36244ac.png)
