### PR TITLE
Fix `OS.get_video_adapter_driver_info()` on OpenGL

### DIFF
--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -246,13 +246,19 @@ String OS_LinuxBSD::get_version() const {
 }
 
 Vector<String> OS_LinuxBSD::get_video_adapter_driver_info() const {
-	if (RenderingServer::get_singleton()->get_rendering_device() == nullptr) {
+	if (RenderingServer::get_singleton() == nullptr) {
 		return Vector<String>();
 	}
 
-	const String rendering_device_name = RenderingServer::get_singleton()->get_rendering_device()->get_device_name(); // e.g. `NVIDIA GeForce GTX 970`
-	const String rendering_device_vendor = RenderingServer::get_singleton()->get_rendering_device()->get_device_vendor_name(); // e.g. `NVIDIA`
-	const String card_name = rendering_device_name.trim_prefix(rendering_device_vendor).strip_edges(); // -> `GeForce GTX 970`
+	const String rendering_device_name = RenderingServer::get_singleton()->get_video_adapter_name(); // e.g. `NVIDIA GeForce GTX 970`
+	String rendering_device_vendor = RenderingServer::get_singleton()->get_video_adapter_vendor(); // e.g. `NVIDIA`
+	if (rendering_device_vendor == "NVIDIA Corporation") {
+		// Required to correctly match the lspci output when using OpenGL.
+		rendering_device_vendor = "NVIDIA";
+	}
+	// NVIDIA suffixes all GPU model names with "/PCIe/SSE2" in OpenGL (but not Vulkan).
+	// This suffix breaks parsing `lspci` output, so it must be trimmed.
+	const String card_name = rendering_device_name.trim_prefix(rendering_device_vendor).strip_edges().trim_suffix("/PCIe/SSE2"); // -> `GeForce GTX 970`
 
 	String vendor_device_id_mappings;
 	List<String> lspci_args;


### PR DESCRIPTION
`OS.get_video_adapter_driver_info()` was previously not working in OpenGL for 2 reasons:

- RenderingDevice was used (which doesn't exist in OpenGL), but there is no need to use it (to my knowledge).
- The NVIDIA vendor string and device name string need further processing to match their Vulkan analogs, which are used to parse `lspci` output on Linux.

cc @MJacred, as they implemented this feature in https://github.com/godotengine/godot/pull/66102.

This begs the question of whether we should perform the "NVIDIA Corporation" -> "NVIDIA" replacement directly in RenderingServer on startup, and [trimming "/PCIe/SSE2"](https://github.com/godotengine/godot/pull/72690) as well. Having consistent names across APIs is probably better in terms of overall usability (if you want to target a specific setting to a single vendor or GPU model).

**Testing project:** [test_driver_info.zip](https://github.com/godotengine/godot/files/10772096/test_driver_info.zip)

## TODO

- [ ] Port the fix to other platforms.

## Preview

### OpenGL

*Previously, **Driver info** would have been an empty array.*

```
Godot Engine v4.0.rc.custom_build.0c27edf3d - https://godotengine.org
OpenGL API 3.3.0 NVIDIA 525.85.05 - Compatibility - Using Device: NVIDIA Corporation - NVIDIA GeForce RTX 4090
 
       Name: NVIDIA GeForce RTX 4090/PCIe/SSE2
     Vendor: NVIDIA Corporation
API version: 3.3.0 NVIDIA 525.85.05
Driver info: ["nvidia", "525.85.05"]
```

### Vulkan

```
Godot Engine v4.0.rc.custom_build.0c27edf3d - https://godotengine.org
Vulkan API 1.3.224 - Forward+ - Using Vulkan Device #0: NVIDIA - NVIDIA GeForce RTX 4090
 
       Name: NVIDIA GeForce RTX 4090
     Vendor: NVIDIA
API version: 1.3.224
Driver info: ["nvidia", "525.85.05"]
```
