### PR TITLE
Correct docs for keep_scale in BaseMaterial3D

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -121,7 +121,7 @@
 			Texture used to control the backlight effect per-pixel. Added to [member backlight].
 		</member>
 		<member name="billboard_keep_scale" type="bool" setter="set_flag" getter="get_flag" default="false">
-			If [code]true[/code], the shader will keep the scale set for the mesh. Otherwise, the scale is lost when billboarding. Only applies when [member billboard_mode] is [constant BILLBOARD_ENABLED].
+			If [code]true[/code], the shader will keep the scale set for the mesh. Otherwise, the scale is lost when billboarding. Only applies when [member billboard_mode] is not [constant BILLBOARD_DISABLED].
 		</member>
 		<member name="billboard_mode" type="int" setter="set_billboard_mode" getter="get_billboard_mode" enum="BaseMaterial3D.BillboardMode" default="0">
 			Controls how the object faces the camera. See [enum BillboardMode].


### PR DESCRIPTION
Depends on: https://github.com/godotengine/godot/pull/65353

While reviewing https://github.com/godotengine/godot/pull/65353 I noticed the doc entry for ``keep_scale`` is not accurate as ``keep_scale`` currently applies when either ``BILLBOARD_ENABLED`` or ``BILLBOARD_FIXED_Y`` is used. With https://github.com/godotengine/godot/pull/65353 it will be applied as long as the billboard mode is not ``BILLBOARD_DISABLED``
