### PR TITLE
Fix: Func with typed args error when arg is null

### DIFF
--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -105,9 +105,10 @@ public:
 					return false;
 				}
 
-				Object *obj = p_variant.get_validated_object();
+				bool was_freed = false;
+				Object *obj = p_variant.get_validated_object_with_check(was_freed);
 				if (!obj) {
-					return false;
+					return !was_freed;
 				}
 
 				if (!ClassDB::is_parent_class(obj->get_class_name(), native_type)) {
@@ -124,9 +125,10 @@ public:
 					return false;
 				}
 
-				Object *obj = p_variant.get_validated_object();
+				bool was_freed = false;
+				Object *obj = p_variant.get_validated_object_with_check(was_freed);
 				if (!obj) {
-					return false;
+					return !was_freed;
 				}
 
 				Ref<Script> base = obj && obj->get_script_instance() ? obj->get_script_instance()->get_script() : nullptr;

--- a/modules/gdscript/tests/scripts/runtime/features/typed_argument_is_null.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/typed_argument_is_null.gd
@@ -1,0 +1,27 @@
+# https://github.com/godotengine/godot/issues/72967
+
+class CustomNode:
+	extends Node
+
+	static func test_custom_node(n: CustomNode):
+		if not n:
+			print("null node")
+
+func test():
+	test_typed_argument_is_null()
+
+func get_custom_node() -> CustomNode:
+	return null
+
+func test_typed_argument_is_null():
+	var node: Node = Node.new()
+	print_node_name(node.get_parent())
+	node.free()
+	test_custom_node()
+
+func test_custom_node():
+	CustomNode.test_custom_node(get_custom_node())
+
+func print_node_name(n: Node):
+	if not n:
+		print("null node")

--- a/modules/gdscript/tests/scripts/runtime/features/typed_argument_is_null.out
+++ b/modules/gdscript/tests/scripts/runtime/features/typed_argument_is_null.out
@@ -1,0 +1,3 @@
+GDTEST_OK
+null node
+null node


### PR DESCRIPTION
This fixes https://github.com/godotengine/godot/issues/72967.

When the `get_parent()` function is called it returns a `Variant` with a `type=object` but internally it's address is `0`. The change here is to treat these "empty" objects the same as `null` would be treated. Test included.

_Production edit: Also fixes https://github.com/godotengine/godot/issues/62658_