### PR TITLE
Fix: Resource encoding to dict

### DIFF
--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -281,17 +281,6 @@ struct GDScriptUtilityFunctionsDefinitions {
 				}
 				sname.reverse();
 
-				if (!path.is_resource_file()) {
-					r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-					r_error.argument = 0;
-					r_error.expected = Variant::DICTIONARY;
-					*r_ret = Variant();
-
-					*r_ret = RTR("Not based on a resource file");
-
-					return;
-				}
-
 				NodePath cp(sname, Vector<StringName>(), false);
 
 				Dictionary d;

--- a/modules/gdscript/tests/scripts/runtime/features/duplicate_and_encode_resources.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/duplicate_and_encode_resources.gd
@@ -1,0 +1,16 @@
+# https://github.com/godotengine/godot/issues/64202
+
+class Example extends Resource:
+    pass
+
+func test():
+    var example = Example.new()
+    var shallow_copy = example.duplicate()
+    var deep_copy = example.duplicate(true)
+
+    print_resource(inst_to_dict(example))
+    print_resource(inst_to_dict(shallow_copy))
+    print_resource(inst_to_dict(deep_copy))
+
+func print_resource(resource: Dictionary):
+    prints(resource["@subpath"], String(resource["@path"]).get_file())

--- a/modules/gdscript/tests/scripts/runtime/features/duplicate_and_encode_resources.out
+++ b/modules/gdscript/tests/scripts/runtime/features/duplicate_and_encode_resources.out
@@ -1,0 +1,4 @@
+GDTEST_OK
+Example duplicate_and_encode_resources.gd
+Example duplicate_and_encode_resources.gd
+Example duplicate_and_encode_resources.gd


### PR DESCRIPTION
Addressing https://github.com/godotengine/godot/issues/64202. Unless there is some technical reason to keep this logic of forcing only resource files being encoded then maybe this check can be removed.

The error before said: `Invalid type in GDScript utility function '<unknown function>'. Cannot convert argument 1 from Object to Dictionary`

*Bugsquad edit:*
- Fixes #64202