### PR TITLE
Clarify return value for InputEvent.is_echo()

### DIFF
--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -74,7 +74,7 @@
 		<method name="is_echo" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if this input event is an echo event (only for events of type [InputEventKey]).
+				Returns [code]true[/code] if this input event is an echo event (only for events of type [InputEventKey]). Any other event type returns [code]false[/code].
 			</description>
 		</method>
 		<method name="is_match" qualifiers="const">


### PR DESCRIPTION
*Moved from https://github.com/godotengine/godot-docs/pull/6786*

I didn't look at other documentation to see whether they write the "default" return value or not. While it might be "obvious", I don't think the user should need to assume what the default value should probably be.
And while it might be irrelevant for other event types, IMO this one is useful in cases like

```cs
if (e.IsActionPressed("main_action") && !e.IsEcho())
{ ... }
```

where `main_action` might not be a key and `e` might not be an InputEventKey