### PR TITLE
Added render target size multiplier option

### DIFF
--- a/modules/openxr/doc_classes/OpenXRInterface.xml
+++ b/modules/openxr/doc_classes/OpenXRInterface.xml
@@ -43,6 +43,9 @@
 		<member name="display_refresh_rate" type="float" setter="set_display_refresh_rate" getter="get_display_refresh_rate" default="0.0">
 			The display refresh rate for the current HMD. Only functional if this feature is supported by the OpenXR runtime and after the interface has been initialized.
 		</member>
+		<member name="render_target_size_multiplier" type="float" setter="set_render_target_size_multiplier" getter="get_render_target_size_multiplier" default="1.0">
+			The render size multiplier for the current HMD. Must be set before the interface has been initialized.
+		</member>
 	</members>
 	<signals>
 		<signal name="pose_recentered">

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -1418,8 +1418,8 @@ Size2 OpenXRAPI::get_recommended_target_size() {
 
 	Size2 target_size;
 
-	target_size.width = view_configuration_views[0].recommendedImageRectWidth;
-	target_size.height = view_configuration_views[0].recommendedImageRectHeight;
+	target_size.width = view_configuration_views[0].recommendedImageRectWidth * render_target_size_multiplier;
+	target_size.height = view_configuration_views[0].recommendedImageRectHeight * render_target_size_multiplier;
 
 	return target_size;
 }
@@ -1951,6 +1951,14 @@ Array OpenXRAPI::get_available_display_refresh_rates() const {
 	}
 
 	return Array();
+}
+
+double OpenXRAPI::get_render_target_size_multiplier() const {
+	return render_target_size_multiplier;
+}
+
+void OpenXRAPI::set_render_target_size_multiplier(double multiplier) {
+	render_target_size_multiplier = multiplier;
 }
 
 OpenXRAPI::OpenXRAPI() {

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -116,6 +116,7 @@ private:
 	XrSessionState session_state = XR_SESSION_STATE_UNKNOWN;
 	bool running = false;
 	XrFrameState frame_state = { XR_TYPE_FRAME_STATE, NULL, 0, 0, false };
+	double render_target_size_multiplier = 1.0;
 
 	OpenXRGraphicsExtensionWrapper *graphics_extension = nullptr;
 	XrSystemGraphicsProperties graphics_properties;
@@ -361,6 +362,10 @@ public:
 	float get_display_refresh_rate() const;
 	void set_display_refresh_rate(float p_refresh_rate);
 	Array get_available_display_refresh_rates() const;
+
+	// Render Target size multiplier
+	double get_render_target_size_multiplier() const;
+	void set_render_target_size_multiplier(double multiplier);
 
 	// action map
 	String get_default_action_map_resource_name();

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -47,6 +47,11 @@ void OpenXRInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_display_refresh_rate", "refresh_rate"), &OpenXRInterface::set_display_refresh_rate);
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "display_refresh_rate"), "set_display_refresh_rate", "get_display_refresh_rate");
 
+	// Render Target size multiplier
+	ClassDB::bind_method(D_METHOD("get_render_target_size_multiplier"), &OpenXRInterface::get_render_target_size_multiplier);
+	ClassDB::bind_method(D_METHOD("set_render_target_size_multiplier", "multiplier"), &OpenXRInterface::set_render_target_size_multiplier);
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "render_target_size_multiplier"), "set_render_target_size_multiplier", "get_render_target_size_multiplier");
+
 	ClassDB::bind_method(D_METHOD("is_action_set_active", "name"), &OpenXRInterface::is_action_set_active);
 	ClassDB::bind_method(D_METHOD("set_action_set_active", "name", "active"), &OpenXRInterface::set_action_set_active);
 	ClassDB::bind_method(D_METHOD("get_action_sets"), &OpenXRInterface::get_action_sets);
@@ -655,6 +660,22 @@ Array OpenXRInterface::get_action_sets() const {
 	}
 
 	return arr;
+}
+
+double OpenXRInterface::get_render_target_size_multiplier() const {
+	if (openxr_api == nullptr) {
+		return 1.0;
+	} else {
+		return openxr_api->get_render_target_size_multiplier();
+	}
+}
+
+void OpenXRInterface::set_render_target_size_multiplier(double multiplier) {
+	if (openxr_api == nullptr) {
+		return;
+	} else {
+		openxr_api->set_render_target_size_multiplier(multiplier);
+	}
 }
 
 Size2 OpenXRInterface::get_render_target_size() {

--- a/modules/openxr/openxr_interface.h
+++ b/modules/openxr/openxr_interface.h
@@ -127,6 +127,9 @@ public:
 	void set_action_set_active(const String &p_action_set, bool p_active);
 	Array get_action_sets() const;
 
+	double get_render_target_size_multiplier() const;
+	void set_render_target_size_multiplier(double multiplier);
+
 	virtual Size2 get_render_target_size() override;
 	virtual uint32_t get_view_count() override;
 	virtual Transform3D get_camera_transform() override;


### PR DESCRIPTION
This pull request adds the render target size multiplier options. This matches the API from the godot_openxr implementation used for Godot 3.x