### PR TITLE
Add `--random-seed` option to specify a fixed seed for better reproducibility

### DIFF
--- a/core/math/random_pcg.cpp
+++ b/core/math/random_pcg.cpp
@@ -39,7 +39,16 @@ RandomPCG::RandomPCG(uint64_t p_seed, uint64_t p_inc) :
 }
 
 void RandomPCG::randomize() {
-	seed(((uint64_t)OS::get_singleton()->get_unix_time() + OS::get_singleton()->get_ticks_usec()) * pcg.state + PCG_DEFAULT_INC_64);
+	// Not thread safe, but there probably isn't a way to get this function
+	// to behave deterministically from multithreaded code anyway.
+	union {
+		uint32_t seed32[2];
+		uint64_t seed64 = 0;
+	};
+
+	seed32[0] = hash_murmur3_one_32(Math::rand());
+	seed32[1] = hash_murmur3_one_32(Math::rand());
+	seed(seed64);
 }
 
 double RandomPCG::random(double p_from, double p_to) {

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1691,7 +1691,6 @@ SceneTree::SceneTree() {
 	GLOBAL_DEF("debug/shapes/collision/draw_2d_outlines", true);
 
 	process_group_call_queue_allocator = memnew(CallQueue::Allocator(64));
-	Math::randomize();
 
 	// Create with mainloop.
 


### PR DESCRIPTION
Streamlines the process of rolling for a good fixed seed when debugging games that have randomization:

https://github.com/godotengine/godot/issues/70406#issuecomment-1399112562
https://github.com/godotengine/godot/issues/73431#issuecomment-1435456566

Also has benefits for benchmarking:

https://github.com/godotengine/godot-benchmarks/blob/234bd8ecc0c7c59a12519cfc6d60d82efa8eaaac/main.gd#L14-L17
