### PR TITLE
Fix timing of the splash screen

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -194,6 +194,7 @@ static bool init_always_on_top = false;
 static bool init_use_custom_pos = false;
 static bool init_use_custom_screen = false;
 static Vector2 init_custom_pos;
+uint64_t time_before_splash = 0;
 
 // Debug
 
@@ -2193,6 +2194,11 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	DisplayServer::set_early_window_clear_color_override(false);
 
+	// show the main window
+	DisplayServer::get_singleton()->show_window(DisplayServer::MAIN_WINDOW_ID);
+	DisplayServer::get_singleton()->force_process_and_drop_events();
+	time_before_splash = OS::get_singleton()->get_ticks_usec();
+
 	MAIN_PRINT("Main: DCC");
 	RenderingServer::get_singleton()->set_default_clear_color(
 			GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
@@ -3020,7 +3026,7 @@ bool Main::start() {
 
 	if (minimum_time_msec) {
 		uint64_t minimum_time = 1000 * minimum_time_msec;
-		uint64_t elapsed_time = OS::get_singleton()->get_ticks_usec();
+		uint64_t elapsed_time = OS::get_singleton()->get_ticks_usec() - time_before_splash;
 		if (elapsed_time < minimum_time) {
 			OS::get_singleton()->delay_usec(minimum_time - elapsed_time);
 		}

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5553,7 +5553,6 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 			window_set_flag(WindowFlags(i), true, main_window);
 		}
 	}
-	show_window(main_window);
 
 #if defined(VULKAN_ENABLED)
 	if (rendering_driver == "vulkan") {

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3921,8 +3921,6 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 			window_set_flag(WindowFlags(i), true, main_window);
 		}
 	}
-	show_window(MAIN_WINDOW_ID);
-	force_process_and_drop_events();
 
 #if defined(GLES3_ENABLED)
 	if (rendering_driver == "opengl3") {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4248,8 +4248,6 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 		}
 	}
 
-	show_window(MAIN_WINDOW_ID);
-
 #if defined(VULKAN_ENABLED)
 
 	if (rendering_driver == "vulkan") {


### PR DESCRIPTION
This PR aims to fix #71350 by waiting with displaying the main window until we are ready to render the splash screen. It also fixes how the "Minimum display time" setting is implemented by taking the time before the splash was first displayed into account. 

I have tested this on MacOS but should hopefully work the same on other desktop OSs like Windows and Linux. From what I can tell the remaining platforms don't use the concept of windows so I'm not entirely sure what the impact is on that type of platform.