### PR TITLE
Rewrite the Backspace operation

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -724,12 +724,8 @@ void CodeEdit::_handle_unicode_input_internal(const uint32_t p_unicode, int p_ca
 }
 
 void CodeEdit::_backspace_internal(int p_caret) {
+	ERR_FAIL_COND(p_caret > get_caret_count());
 	if (!is_editable()) {
-		return;
-	}
-
-	if (has_selection(p_caret)) {
-		delete_selection(p_caret);
 		return;
 	}
 
@@ -737,6 +733,11 @@ void CodeEdit::_backspace_internal(int p_caret) {
 	Vector<int> caret_edit_order = get_caret_index_edit_order();
 	for (const int &i : caret_edit_order) {
 		if (p_caret != -1 && p_caret != i) {
+			continue;
+		}
+
+		if (has_selection(i)) {
+			delete_selection(i);
 			continue;
 		}
 


### PR DESCRIPTION
Up for grabs if you want to finish it! It's 90% done but I don't feel like doing the rest of the work right now.

-----

(This PR doesn't fix the various unreported issues when carets are at the start of lines when using Backspace or at the end of lines when using Delete.)

**Backspace**

- Fixes bug where the editor throws errors and skips the operation for certain carets when two carets are 1 character apart

**Backspace word:**

- Fixes deleting words if there are multiple whitespace characters between the word and the caret (Also applied this fix to `_delete()`, Fixes #76093)
- Fixes overlapping carets if one was at the end of a word and the other was at its beginning.
- Fixes undo being broken after making an operation with a selection inside the removed word
- Fixes bug where the editor throws errors and displaces a caret if a selection is inside the removed word and the caret of that selection is at the start of the word, and said removed word is the last one on the line.
- Fixes carets getting displaced after making an operation on adjacent words

**Backspace all to left:**

- Preserves the position of all carets on undo

-----

This is just a list of bugs of Backspace, I didn't actually apply fixes to them individually, I just rewrote the code of the operation.