### PR TITLE
C#: Fix line position when opening file in VSCode

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -279,7 +279,7 @@ namespace GodotTools
                     if (line >= 0)
                     {
                         args.Add("-g");
-                        args.Add($"{scriptPath}:{line}:{col}");
+                        args.Add($"{scriptPath}:{line + 1}:{col + 1}");
                     }
                     else
                     {


### PR DESCRIPTION
Fixes #73576

Line and column use 1 based indices in VSCode.

This leaves MonoDevelop as the only external C# editor that doesn't have the +1 for the column (every editor now has it for the line). I am can't test to confirm if this is correct, but since column 0 is the only one ever used by godot and thus it doesn't actually matter, so I left that bit alone.