### PR TITLE
Fix ctrl+backspace crash with multicarets on the same line

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2681,6 +2681,7 @@ void TextEdit::_do_backspace(bool p_word, bool p_all_to_left) {
 
 			set_caret_line(get_caret_line(caret_idx), false, true, 0, caret_idx);
 			set_caret_column(column, caret_idx == 0, caret_idx);
+			adjust_carets_after_edit(caret_idx, get_caret_line(caret_idx), column, get_caret_line(caret_idx), from_column);
 
 			// Now we can clean up the overlapping caret.
 			if (overlapping_caret_index != -1) {

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -1779,6 +1779,50 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 		}
 
+		SUBCASE("[TextEdit] ui_text_backspace_word same line") {
+			text_edit->set_text("test test test");
+			text_edit->set_caret_column(4);
+			text_edit->add_caret(0, 9);
+			text_edit->add_caret(0, 15);
+
+			// For the second caret.
+			Array args2;
+			args2.push_back(0);
+			lines_edited_args.push_front(args2);
+
+			// For the third caret.
+			Array args3;
+			args2.push_back(0);
+			lines_edited_args.push_front(args2);
+
+			CHECK(text_edit->get_caret_count() == 3);
+			MessageQueue::get_singleton()->flush();
+
+			SIGNAL_DISCARD("text_set");
+			SIGNAL_DISCARD("text_changed");
+			SIGNAL_DISCARD("lines_edited_from");
+			SIGNAL_DISCARD("caret_changed");
+
+			SEND_GUI_ACTION("ui_text_backspace_word");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_text() == "  ");
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 0);
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 1);
+			CHECK_FALSE(text_edit->has_selection(1));
+
+			CHECK(text_edit->get_caret_line(2) == 0);
+			CHECK(text_edit->get_caret_column(2) == 2);
+			CHECK_FALSE(text_edit->has_selection(1));
+
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+		}
+
 		SUBCASE("[TextEdit] ui_text_backspace") {
 			text_edit->set_text("\nthis is some test text.\n\nthis is some test text.");
 			text_edit->select(1, 0, 1, 4);


### PR DESCRIPTION
Silly mistake, TextEdit was not adjusting carets after removing the text, leaving the previous carets in an invalid position.

closes #73476