### PR TITLE
Define shader language project settings before creation of `TextShaderEditor` object.

### DIFF
--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -1051,11 +1051,6 @@ void TextShaderEditor::_make_context_menu(bool p_selection, Vector2 p_position) 
 }
 
 TextShaderEditor::TextShaderEditor() {
-	GLOBAL_DEF("debug/shader_language/warnings/enable", true);
-	GLOBAL_DEF("debug/shader_language/warnings/treat_warnings_as_errors", false);
-	for (int i = 0; i < (int)ShaderWarning::WARNING_MAX; i++) {
-		GLOBAL_DEF("debug/shader_language/warnings/" + ShaderWarning::get_name_from_code((ShaderWarning::Code)i).to_lower(), true);
-	}
 	_update_warnings(false);
 
 	shader_editor = memnew(ShaderTextEditor);

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -35,6 +35,7 @@
 #include "core/variant/typed_array.h"
 #include "servers/rendering/rendering_server_globals.h"
 #include "servers/rendering/shader_language.h"
+#include "servers/rendering/shader_warnings.h"
 
 RenderingServer *RenderingServer::singleton = nullptr;
 RenderingServer *(*RenderingServer::create_func)() = nullptr;
@@ -2978,6 +2979,15 @@ void RenderingServer::init() {
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/limits/opengl/max_lights_per_object", PROPERTY_HINT_RANGE, "2,1024,1"), 8);
 
 	GLOBAL_DEF_RST_BASIC("xr/shaders/enabled", false);
+
+	GLOBAL_DEF("debug/shader_language/warnings/enable", true);
+	GLOBAL_DEF("debug/shader_language/warnings/treat_warnings_as_errors", false);
+
+#ifdef DEBUG_ENABLED
+	for (int i = 0; i < (int)ShaderWarning::WARNING_MAX; i++) {
+		GLOBAL_DEF("debug/shader_language/warnings/" + ShaderWarning::get_name_from_code((ShaderWarning::Code)i).to_lower(), true);
+	}
+#endif
 }
 
 RenderingServer::~RenderingServer() {


### PR DESCRIPTION
Fix #73336 

Preamble: this is my first _contribution_. From the description and the comment from @Calinou , I have moved the `GLOBAL_DEF` for `shader_language` settings into the `ProjectSettings` contstructor.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
