### PR TITLE
Fix missing directories when exporting from cmd

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -656,6 +656,7 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack, bo
 
 	Compression::gzip_level = GLOBAL_GET("compression/formats/gzip/compression_level");
 
+	project_loaded = err == OK;
 	return err;
 }
 
@@ -1104,6 +1105,10 @@ const HashMap<StringName, PropertyInfo> &ProjectSettings::get_custom_property_in
 
 bool ProjectSettings::is_using_datapack() const {
 	return using_datapack;
+}
+
+bool ProjectSettings::is_project_loaded() const {
+	return project_loaded;
 }
 
 bool ProjectSettings::_property_can_revert(const StringName &p_name) const {

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -95,6 +95,7 @@ protected:
 	String resource_path;
 	HashMap<StringName, PropertyInfo> custom_prop_info;
 	bool using_datapack = false;
+	bool project_loaded = false;
 	List<String> input_presets;
 
 	HashSet<String> custom_features;
@@ -190,6 +191,7 @@ public:
 	Variant get_setting_with_override(const StringName &p_name) const;
 
 	bool is_using_datapack() const;
+	bool is_project_loaded() const;
 
 	bool has_custom_feature(const String &p_feature) const;
 

--- a/editor/editor_paths.cpp
+++ b/editor/editor_paths.cpp
@@ -218,7 +218,7 @@ EditorPaths::EditorPaths() {
 
 	// Validate or create project-specific editor data dir,
 	// including shader cache subdir.
-	if (Engine::get_singleton()->is_project_manager_hint() || Main::is_cmdline_tool()) {
+	if (Engine::get_singleton()->is_project_manager_hint() || (Main::is_cmdline_tool() && !ProjectSettings::get_singleton()->is_project_loaded())) {
 		// Nothing to create, use shared editor data dir for shader cache.
 		Engine::get_singleton()->set_shader_cache_path(data_dir);
 	} else {


### PR DESCRIPTION
Fixes #69511
Fixes #72360

While trying to fix the issue, I noticed the errors in the output about missing folders, so I decided to fix them first.
Turns out this was enough to resolve the issue 🙃 Specifically, `.godot/editor` and `.godot/imported` were never created when running from command line.
There still are some errors about missing files, but import/export seems to be working now. Note that I only tested it with a simple project.