### PR TITLE
Allow the runtime clearing of GLTFDocumentExtensionConvertImporterMesh.

### DIFF
--- a/modules/gltf/doc_classes/GLTFDocument.xml
+++ b/modules/gltf/doc_classes/GLTFDocument.xml
@@ -56,6 +56,12 @@
 				Takes a [GLTFState] object through the [param state] parameter and returns a Godot Engine scene node.
 			</description>
 		</method>
+		<method name="list_all_gltf_documentation_extensions" qualifiers="static">
+			<return type="GLTFDocumentExtension[]" />
+			<description>
+				Lists all the [GLTFDocumentExtension] instances.
+			</description>
+		</method>
 		<method name="register_gltf_document_extension" qualifiers="static">
 			<return type="void" />
 			<param index="0" name="extension" type="GLTFDocumentExtension" />
@@ -63,6 +69,12 @@
 			<description>
 				Registers the given [GLTFDocumentExtension] instance with GLTFDocument. If [param first_priority] is true, this extension will be run first. Otherwise, it will be run last.
 				[b]Note:[/b] Like GLTFDocument itself, all GLTFDocumentExtension classes must be stateless in order to function properly. If you need to store data, use the [code]set_additional_data[/code] and [code]get_additional_data[/code] methods in [GLTFState] or [GLTFNode].
+			</description>
+		</method>
+		<method name="unregister_all_gltf_document_extensions" qualifiers="static">
+			<return type="void" />
+			<description>
+				Unregisters all [GLTFDocumentExtension] instances.
 			</description>
 		</method>
 		<method name="unregister_gltf_document_extension" qualifiers="static">

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -7123,6 +7123,10 @@ void GLTFDocument::_bind_methods() {
 			&GLTFDocument::register_gltf_document_extension, DEFVAL(false));
 	ClassDB::bind_static_method("GLTFDocument", D_METHOD("unregister_gltf_document_extension", "extension"),
 			&GLTFDocument::unregister_gltf_document_extension);
+	ClassDB::bind_static_method("GLTFDocument", D_METHOD("unregister_all_gltf_document_extensions"),
+			&GLTFDocument::unregister_all_gltf_document_extensions);
+	ClassDB::bind_static_method("GLTFDocument", D_METHOD("list_all_gltf_documentation_extensions"),
+			&GLTFDocument::list_all_gltf_documentation_extensions);
 }
 
 void GLTFDocument::_build_parent_hierachy(Ref<GLTFState> p_state) {
@@ -7455,4 +7459,12 @@ Error GLTFDocument::_parse_gltf_extensions(Ref<GLTFState> p_state) {
 		}
 	}
 	return ret;
+}
+
+TypedArray<GLTFDocumentExtension> GLTFDocument::list_all_gltf_documentation_extensions() {
+	TypedArray<GLTFDocumentExtension> extensions;
+	for (Ref<GLTFDocumentExtension> e : all_document_extensions) {
+		extensions.push_back(e);
+	}
+	return extensions;
 }

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -76,6 +76,7 @@ public:
 	static void register_gltf_document_extension(Ref<GLTFDocumentExtension> p_extension, bool p_first_priority = false);
 	static void unregister_gltf_document_extension(Ref<GLTFDocumentExtension> p_extension);
 	static void unregister_all_gltf_document_extensions();
+	static TypedArray<GLTFDocumentExtension> list_all_gltf_documentation_extensions();
 
 private:
 	void _build_parent_hierachy(Ref<GLTFState> p_state);


### PR DESCRIPTION
Expose the relevant apis in GLTFDocument. This is useful for the VRM extensions.

The unregister_all_gltf_document_extensions wasn't exposed and added list_all_gltf_documentation_extensions.

The problem being solved is that during the importer time, there is a gltf_document_extension_convert_importer_mesh that converts the importer mesh 3d to a mesh instance 3d. It is impossible to remove that extension from gdscript.

We can add a new extension by using a priority that will force the conversion extension to the back, but can't remove it.

@ExpiredPopsicle 