### PR TITLE
Clamp return value of SceneTreeTimer::get_time_left to 0.0

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -78,7 +78,7 @@ void SceneTreeTimer::set_time_left(double p_time) {
 }
 
 double SceneTreeTimer::get_time_left() const {
-	return time_left;
+	return MAX(time_left, 0.0);
 }
 
 void SceneTreeTimer::set_process_always(bool p_process_always) {


### PR DESCRIPTION
This changes alters ```SceneTreeTimer::get_time_left``` to clamp to zero when negative, to match the behavior of ```Timer::get_time_left```. Timer sets time_left to negative in certain circumstances (i.e. stopping the timer), but ```get_time_left``` always returns positive values (or zero). This fix assumes that the **SceneTreeTimer** and **Timer** APIs are intended to be orthogonal.

Fixes #73607