### PR TITLE
Add `--quit-after <number-of-iterations>`

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -162,7 +162,7 @@ static bool project_manager = false;
 static bool cmdline_tool = false;
 static String locale;
 static bool show_help = false;
-static bool auto_quit = false;
+static uint64_t quit_after = 0;
 static OS::ProcessID editor_pid = 0;
 #ifdef TOOLS_ENABLED
 static bool found_project = false;
@@ -351,6 +351,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  --debug-server <uri>              Start the editor debug server (<protocol>://<host/IP>[:<port>], e.g. tcp://127.0.0.1:6007)\n");
 #endif
 	OS::get_singleton()->print("  --quit                            Quit after the first iteration.\n");
+	OS::get_singleton()->print("  --quit-after <int>                Quit after the given number of iterations. Set to 0 to disable.\n");
 	OS::get_singleton()->print("  -l, --language <locale>           Use a specific locale (<locale> being a two-letter code).\n");
 	OS::get_singleton()->print("  --path <directory>                Path to a project (<directory> must contain a 'project.godot' file).\n");
 	OS::get_singleton()->print("  -u, --upwards                     Scan folders upwards for project.godot file.\n");
@@ -394,6 +395,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  --write-movie <file>              Writes a video to the specified path (usually with .avi or .png extension).\n");
 	OS::get_singleton()->print("                                    --fixed-fps is forced when enabled, but it can be used to change movie FPS.\n");
 	OS::get_singleton()->print("                                    --disable-vsync can speed up movie writing but makes interaction more difficult.\n");
+	OS::get_singleton()->print("                                    --quit-after can be used to specify the number of frames to write.\n");
 
 	OS::get_singleton()->print("\n");
 
@@ -1188,7 +1190,15 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (I->get() == "-u" || I->get() == "--upwards") { // scan folders upwards
 			upwards = true;
 		} else if (I->get() == "--quit") { // Auto quit at the end of the first main loop iteration
-			auto_quit = true;
+			quit_after = 1;
+		} else if (I->get() == "--quit-after") { // Quit after the given number of iterations
+			if (I->next()) {
+				quit_after = I->next()->get().to_int();
+				N = I->next()->next();
+			} else {
+				OS::get_singleton()->print("Missing number of iterations, aborting.\n");
+				goto error;
+			}
 		} else if (I->get().ends_with("project.godot")) {
 			String path;
 			String file = I->get();
@@ -3234,6 +3244,10 @@ bool Main::iteration() {
 		movie_writer->add_frame(vp_tex);
 	}
 
+	if ((quit_after > 0) && (Engine::get_singleton()->_process_frames >= quit_after)) {
+		exit = true;
+	}
+
 	if (fixed_fps != -1) {
 		return exit;
 	}
@@ -3257,7 +3271,7 @@ bool Main::iteration() {
 	}
 #endif
 
-	return exit || auto_quit;
+	return exit;
 }
 
 void Main::force_redraw() {


### PR DESCRIPTION
Combined with #73564 , this would allow pixel-perfect reproducible movie captures to be automatically recorded from nearly any public Godot project for regression testing,[^can] greatly expanding the potential test coverage of Godot rendering.
[^can]:Notable candidates being [godot-benchmarks](https://github.com/godotengine/godot-benchmarks/) and [godot-demo-projects](https://github.com/godotengine/godot-demo-projects)

Note that as OpenGL/Vulkan renders are not consistent across hardware, captures will need to be made and compared in the same script to work.

Example shell script:
```bash
$GODOT_BIN_A --random-seed 5 --fixed-fps 10 --quit-after 20 --write-movie /tmp/capture.avi
shasum /tmp/capture.avi >/tmp/capture.sha

$GODOT_BIN_B --random-seed 5 --fixed-fps 10 --quit-after 20 --write-movie /tmp/capture.avi
shasum -c /tmp/capture.avi
```
