### PR TITLE
`ResourceLoader`: every `ThreadLoadTask` needs a semaphore

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -242,8 +242,7 @@ void ResourceLoader::_thread_load_function(void *p_userdata) {
 	Ref<Resource> existing = ResourceCache::get_ref(load_task.local_path);
 	if (existing.is_valid()) {
 		load_task.resource = existing;
-	}
-	else {
+	} else {
 		load_task.resource = _load(load_task.remapped_path, load_task.remapped_path != load_task.local_path ? load_task.local_path : String(), load_task.type_hint, load_task.cache_mode, &load_task.error, load_task.use_sub_threads, &load_task.progress);
 	}
 
@@ -266,7 +265,7 @@ void ResourceLoader::_thread_load_function(void *p_userdata) {
 		print_lt("END: load count: " + itos(thread_loading_count) + " / wait count: " + itos(thread_waiting_count) + " / suspended count: " + itos(thread_suspended_count) + " / active: " + itos(thread_loading_count - thread_suspended_count));
 	}
 	if (load_task.semaphore) {
-		if(load_task.poll_requests > 0) {
+		if (load_task.poll_requests > 0) {
 			// make sure that we don't slip between the thread_load_mutex->unlock()
 			// and semaphore->wait() of someone waiting for this task
 			OS::get_singleton()->delay_usec(1);
@@ -280,7 +279,7 @@ void ResourceLoader::_thread_load_function(void *p_userdata) {
 	}
 
 	if (load_task.resource.is_valid()) {
-		if(!existing.is_valid()) {
+		if (!existing.is_valid()) {
 			load_task.resource->set_path(load_task.local_path);
 		}
 


### PR DESCRIPTION
When a resource is loaded via `ResourceLoader::load` it doesn't get a semaphore, because it didn't start a new thread. But it is possible that other threads also have to load the same resource (especially with external resources, like scripts on nodes in a scene). The other threads then cannot wait for the loading to be finished (because there is no semaphore) and the loading fails with `Parse Error: [ext_resource] referenced nonexistent resource`. (more infos in this issue: https://github.com/godotengine/godot/issues/71726 )

With this pull request every `ThreadLoadTask` gets a semaphore and the distinction if that task really is a threaded task is done via `ThreadLoadTask::thread` instead of `ThreadLoadTask::semaphore`.
We used the ResourceLoader like this for a few weeks in our game "Halls of Torment" now and haven't had problems with it.

There is an additional, but very related fix in this pull request: We sometimes encountered a problem in `ResourceLoader::load_threaded_get()`: the semaphore was null when waiting on it:
```cpp
Ref<Resource> ResourceLoader::load_threaded_get(const String &p_path, Error *r_error) {
	...
	thread_load_mutex->lock();			// <---- the whole section is locked, so changes to
	...						//       the semaphore should be impossible
	Semaphore *semaphore = load_task.semaphore;
	if (semaphore) {				// <---- there is a null check here
		load_task.poll_requests++;
		...
		thread_load_mutex->unlock();		// <---- after this, changes to the semaphore are possible
		semaphore->wait();			// <---- semaphore sometimes is null here!
		thread_load_mutex->lock();
		...
	}
	...
}
```
I am no threading expert, but my guess is that inbetween `thread_load_mutex->unlock();` and `semaphore->wait();` the loading thread can in some rare cases get enough cycles from the scheduler to `post` the semaphore before the `wait`:

```cpp
void ResourceLoader::_thread_load_function(void *p_userdata) {
	...
	thread_load_mutex->lock();
	...
	if (load_task.semaphore) {
		...
		for (int i = 0; i < load_task.poll_requests; i++) {
			load_task.semaphore->post();
		}
		memdelete(load_task.semaphore);
		load_task.semaphore = nullptr;
	}
	...
}
```
That is why I introduced a microsleep when there are other threads waiting, right before the `semaphore->post()`:
```cpp
		if(load_task.poll_requests > 0) {
			// make sure that we don't slip between the thread_load_mutex->unlock()
			// and semaphore->wait() of someone waiting for this task
			OS::get_singleton()->delay_usec(1);
		}

		for (int i = 0; i < load_task.poll_requests; i++) {
			load_task.semaphore->post();
		}
```
Btw: This problem doesn't occur when `DEBUG_LOAD_THREADED` is defined. Probably because right before posting the semaphore there is a log output, delaying the `post` enough so that the timing issue is no more.

That whole mutex protected semaphore wait/post timing issue sounds like it should be a common problem in threaded C++, so maybe there is a better solution/pattern for this?

fixes https://github.com/godotengine/godot/issues/71726 