### PR TITLE
[MP] Add a "synchronized" signal to MultiplayerSynchronized.

### DIFF
--- a/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
+++ b/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
@@ -69,6 +69,11 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="synchronized">
+			<description>
+				Emitted when a new synchronization state is received by this synchronizer after the variables have been updated.
+			</description>
+		</signal>
 		<signal name="visibility_changed">
 			<param index="0" name="for_peer" type="int" />
 			<description>

--- a/modules/multiplayer/multiplayer_synchronizer.cpp
+++ b/modules/multiplayer/multiplayer_synchronizer.cpp
@@ -268,6 +268,7 @@ void MultiplayerSynchronizer::_bind_methods() {
 	BIND_ENUM_CONSTANT(VISIBILITY_PROCESS_PHYSICS);
 	BIND_ENUM_CONSTANT(VISIBILITY_PROCESS_NONE);
 
+	ADD_SIGNAL(MethodInfo("synchronized"));
 	ADD_SIGNAL(MethodInfo("visibility_changed", PropertyInfo(Variant::INT, "for_peer")));
 }
 

--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -775,6 +775,7 @@ Error SceneReplicationInterface::on_sync_receive(int p_from, const uint8_t *p_bu
 		err = MultiplayerSynchronizer::set_state(props, node, vars);
 		ERR_FAIL_COND_V(err, err);
 		ofs += size;
+		sync->emit_signal(SNAME("synchronized"));
 #ifdef DEBUG_ENABLED
 		_profile_node_data("sync_in", sync->get_instance_id(), size);
 #endif


### PR DESCRIPTION
Emitted upon receiving a valid sync packet after setting the variables state.

See discussion in https://github.com/godotengine/godot/pull/55950#issuecomment-1436668471

Note to reviewers:
This a feature? Should it be `4.1`? It's a really tiny change (with a potential performance impact? how performant are signals with no connections? Likely quite fast).