### PR TITLE
BVH - fix lockguards for multithread mode

### DIFF
--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -55,7 +55,7 @@
 #include "core/os/mutex.h"
 
 #define BVHTREE_CLASS BVH_Tree<T, NUM_TREES, 2, MAX_ITEMS, USER_PAIR_TEST_FUNCTION, USER_CULL_TEST_FUNCTION, USE_PAIRS, BOUNDS, POINT>
-#define BVH_LOCKED_FUNCTION BVHLockedFunction(&_mutex, BVH_THREAD_SAFE &&_thread_safe);
+#define BVH_LOCKED_FUNCTION BVHLockedFunction _lock_guard(&_mutex, BVH_THREAD_SAFE &&_thread_safe);
 
 template <class T, int NUM_TREES = 1, bool USE_PAIRS = false, int MAX_ITEMS = 32, class USER_PAIR_TEST_FUNCTION = BVH_DummyPairTestFunction<T>, class USER_CULL_TEST_FUNCTION = BVH_DummyCullTestFunction<T>, class BOUNDS = AABB, class POINT = Vector3, bool BVH_THREAD_SAFE = true>
 class BVH_Manager {
@@ -779,11 +779,7 @@ private:
 			// will be compiled out if not set in template
 			if (p_thread_safe) {
 				_mutex = p_mutex;
-
-				if (!_mutex->try_lock()) {
-					WARN_PRINT("Info : multithread BVH access detected (benign)");
-					_mutex->lock();
-				}
+				_mutex->lock();
 
 			} else {
 				_mutex = nullptr;


### PR DESCRIPTION
Due to an embarrassing lack of variable name, the BVH lock guards lifetimes previously did not cover the whole function call.

This is fixed, and the warning message for contention is removed as multithread mode seems to be desired in production in 4.x.

Fixes #73573

## Notes 
* BVH Multithread mode was added in #48892 for debugging purposes in 3.x, and in classic case of creep this has ended up being used in production in 4.x.
* Due to the debugging nature, this was not highly tested, and it turns out I missed out the variable name and the lifetimes of the lock guard were only for the duration of the line, rather than the function (which is the aim of lock guard).
* Additionally, as multithread mode seems intended to be used in production in 4.x, the warning message is removed.
* There could also potentially be lock guards used for the supplemental functions:

```
	uint32_t item_get_tree_id(BVHHandle p_handle) const { return _get_extra(p_handle).tree_id; }
	T *item_get_userdata(BVHHandle p_handle) const { return _get_extra(p_handle).userdata; }
	int item_get_subindex(BVHHandle p_handle) const { return _get_extra(p_handle).subindex; }
```

These weren't added originally because this was intended to be non-production code. I will try and investigate whether these are necessary to prevent any potential race conditions, but that can be a separate PR if necessary. 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
