### PR TITLE
[3.x] BVH - fix lockguards for multithread mode

### DIFF
--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -55,7 +55,7 @@
 #include "core/os/mutex.h"
 
 #define BVHTREE_CLASS BVH_Tree<T, NUM_TREES, 2, MAX_ITEMS, USER_PAIR_TEST_FUNCTION, USER_CULL_TEST_FUNCTION, USE_PAIRS, BOUNDS, POINT>
-#define BVH_LOCKED_FUNCTION BVHLockedFunction(&_mutex, BVH_THREAD_SAFE &&_thread_safe);
+#define BVH_LOCKED_FUNCTION BVHLockedFunction _lock_guard(&_mutex, BVH_THREAD_SAFE &&_thread_safe);
 
 template <class T, int NUM_TREES = 1, bool USE_PAIRS = false, int MAX_ITEMS = 32, class USER_PAIR_TEST_FUNCTION = BVH_DummyPairTestFunction<T>, class USER_CULL_TEST_FUNCTION = BVH_DummyCullTestFunction<T>, class BOUNDS = AABB, class POINT = Vector3, bool BVH_THREAD_SAFE = true>
 class BVH_Manager {
@@ -776,7 +776,7 @@ private:
 				_mutex = p_mutex;
 
 				if (_mutex->try_lock() != OK) {
-					WARN_PRINT("Info : multithread BVH access detected (benign)");
+					WARN_PRINT_ONCE("Info : multithread BVH access detected (benign)");
 					_mutex->lock();
 				}
 


### PR DESCRIPTION
Due to a lack of variable name, the BVH lock guards lifetimes previously did not cover the whole function call.

## Notes
* Version of #73628 for 3.x.
* Does not remove the contention message, as multithread mode is not designed for production use in 3.x. Does change it to a `WARN_PRINT_ONCE` as that is probably a better option.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
