### PR TITLE
[3.x] embree: Allow use of embree4 as distro package

### DIFF
--- a/modules/raycast/lightmap_raycaster.h
+++ b/modules/raycast/lightmap_raycaster.h
@@ -32,7 +32,11 @@
 #include "scene/3d/lightmapper.h"
 #include "scene/resources/mesh.h"
 
+#ifdef USE_EMBREE4
+#include <embree4/rtcore.h>
+#else
 #include <embree3/rtcore.h>
+#endif
 
 class LightmapRaycasterEmbree : public LightmapRaycaster {
 	GDCLASS(LightmapRaycasterEmbree, LightmapRaycaster);

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -43,6 +43,7 @@ def get_opts():
         BoolVariable("use_msan", "Use LLVM/GCC compiler memory sanitizer (MSAN))", False),
         BoolVariable("separate_debug_symbols", "Create a separate file containing debugging symbols", False),
         BoolVariable("execinfo", "Use libexecinfo on systems where glibc is not available", False),
+        BoolVariable("use_embree4", "Use Embree 4 instead of Embree 3", False),
     ]
 
 
@@ -260,12 +261,14 @@ def configure(env):
     if not env["builtin_pcre2"]:
         env.ParseConfig("pkg-config libpcre2-32 --cflags --libs")
 
-    # Embree is only compatible with x86_64. Yet another unreliable hack that will break
-    # cross-compilation, this will really need to be handle better. Thankfully only affects
-    # people who disable builtin_embree (likely distro packagers).
-    if env["tools"] and not env["builtin_embree"] and (is64 and platform.machine() == "x86_64"):
+    # Embree is only used in tools build on x86_64 and aarch64.
+    if env["tools"] and not env["builtin_embree"] and is64:
         # No pkgconfig file so far, hardcode expected lib name.
-        env.Append(LIBS=["embree3"])
+        if env["use_embree4"]:
+            env.Append(LIBS=["embree4"])
+            env.Append(CPPDEFINES=["USE_EMBREE4"])
+        else:
+            env.Append(LIBS=["embree3"])
 
     ## Flags
 

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -79,6 +79,7 @@ def get_opts():
         BoolVariable("separate_debug_symbols", "Create a separate file containing debugging symbols", False),
         BoolVariable("touch", "Enable touch events", True),
         BoolVariable("execinfo", "Use libexecinfo on systems where glibc is not available", False),
+        BoolVariable("use_embree4", "Use Embree 4 instead of Embree 3", False),
     ]
 
 
@@ -347,7 +348,11 @@ def configure(env):
     # Embree is only used in tools build on x86_64 and aarch64.
     if env["tools"] and not env["builtin_embree"] and is64:
         # No pkgconfig file so far, hardcode expected lib name.
-        env.Append(LIBS=["embree3"])
+        if env["use_embree4"]:
+            env.Append(LIBS=["embree4"])
+            env.Append(CPPDEFINES=["USE_EMBREE4"])
+        else:
+            env.Append(LIBS=["embree3"])
 
     ## Flags
 


### PR DESCRIPTION
Sadly embree changes its library name and include paths on new majors, and doesn't provide any pkgconfig file we can rely on to query this info.

So this is a manual process for now to select embree4 with `use_embree4=yes`.

This is needed for Fedora which is upgrading its embree package to embree4 and needs Godot rebuilt against it.

Haven't tested yet as I don't have embree4 on my Linux setup yet.
(Compiling now but it takes forever so I won't get to test it today.)

`master` version: #73631