### PR TITLE
embree: Allow use of embree4 as distro package

### DIFF
--- a/modules/raycast/lightmap_raycaster_embree.h
+++ b/modules/raycast/lightmap_raycaster_embree.h
@@ -37,7 +37,11 @@
 #include "core/object/object.h"
 #include "scene/3d/lightmapper.h"
 
+#ifdef USE_EMBREE4
+#include <embree4/rtcore.h>
+#else
 #include <embree3/rtcore.h>
+#endif
 
 class LightmapRaycasterEmbree : public LightmapRaycaster {
 	GDCLASS(LightmapRaycasterEmbree, LightmapRaycaster);

--- a/modules/raycast/raycast_occlusion_cull.h
+++ b/modules/raycast/raycast_occlusion_cull.h
@@ -40,7 +40,11 @@
 #include "scene/resources/mesh.h"
 #include "servers/rendering/renderer_scene_occlusion_cull.h"
 
+#ifdef USE_EMBREE4
+#include <embree4/rtcore.h>
+#else
 #include <embree3/rtcore.h>
+#endif
 
 class RaycastOcclusionCull : public RendererSceneOcclusionCull {
 	typedef RTCRayHit16 CameraRayTile;

--- a/modules/raycast/static_raycaster_embree.h
+++ b/modules/raycast/static_raycaster_embree.h
@@ -35,7 +35,11 @@
 
 #include "core/math/static_raycaster.h"
 
+#ifdef USE_EMBREE4
+#include <embree4/rtcore.h>
+#else
 #include <embree3/rtcore.h>
+#endif
 
 class StaticRaycasterEmbree : public StaticRaycaster {
 	GDCLASS(StaticRaycasterEmbree, StaticRaycaster);

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -53,6 +53,7 @@ def get_opts():
         BoolVariable("x11", "Enable X11 display", True),
         BoolVariable("touch", "Enable touch events", True),
         BoolVariable("execinfo", "Use libexecinfo on systems where glibc is not available", False),
+        BoolVariable("use_embree4", "Use Embree 4 instead of Embree 3", False),
     ]
 
 
@@ -279,7 +280,11 @@ def configure(env: "Environment"):
 
     if not env["builtin_embree"]:
         # No pkgconfig file so far, hardcode expected lib name.
-        env.Append(LIBS=["embree3"])
+        if env["use_embree4"]:
+            env.Append(LIBS=["embree4"])
+            env.Append(CPPDEFINES=["USE_EMBREE4"])
+        else:
+            env.Append(LIBS=["embree3"])
 
     ## Flags
     if env["fontconfig"]:


### PR DESCRIPTION
Sadly embree changes its library name and include paths on new majors, and doesn't provide any pkgconfig file we can rely on to query this info.

So this is a manual process for now to select embree4 with `use_embree4=yes`.

This is needed for Fedora which is upgrading its embree package to embree4 and needs Godot rebuilt against it.

We might consider moving our vendored version to embree4 too eventually, but it was just released as 4.0.0 and we're about to release Godot 4.0 ourselves, so there's no rush testing a new major release of a dependency.

`3.x` version: #73630