### PR TITLE
Don't save scripts when exiting editor

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -4058,7 +4058,9 @@ void ScriptEditorPlugin::selected_notify() {
 }
 
 void ScriptEditorPlugin::save_external_data() {
-	script_editor->save_all_scripts();
+	if (!EditorNode::get_singleton()->is_exiting()) {
+		script_editor->save_all_scripts();
+	}
 }
 
 void ScriptEditorPlugin::apply_changes() {


### PR DESCRIPTION
Fixes #18010

The script editor properly tracks saved/unsaved scripts, so only unsaved scripts will get discarded.
Unfortunately the user won't be warned, see #55026