### PR TITLE
Prevent off-screen controls in editor

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1408,6 +1408,10 @@ SceneTree::SceneTree() {
 	root->set_name("root");
 	root->set_title(GLOBAL_GET("application/config/name"));
 
+	if (Engine::get_singleton()->is_editor_hint()) {
+		root->set_wrap_controls(true);
+	}
+
 #ifndef _3D_DISABLED
 	if (!root->get_world_3d().is_valid()) {
 		root->set_world_3d(Ref<World3D>(memnew(World3D)));


### PR DESCRIPTION
Fixes #31133

Everyone was occupied with lack of space, while the original issue was about the fact that making the window too small would cover part of the interface:

https://user-images.githubusercontent.com/2223172/220185402-e47fdec8-865c-4090-928d-0e5179cae6e8.mp4

The solution was to enable `wrap_controls` on the main window 🤷‍♂️

https://user-images.githubusercontent.com/2223172/220185450-7b0782ce-b951-4048-b72d-3086c244faba.mp4

Half of the rightmost scrollbar is still cut for some reason, but this prevents making the window too small.