### PR TITLE
Fix threading issues in resource loading

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_importer.h"
+#include "core/os/condition_variable.h"
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 #include "core/string/translation.h"
@@ -233,7 +234,7 @@ void ResourceLoader::_thread_load_function(void *p_userdata) {
 	ThreadLoadTask &load_task = *(ThreadLoadTask *)p_userdata;
 	load_task.loader_id = Thread::get_caller_id();
 
-	if (load_task.semaphore) {
+	if (load_task.cond_var) {
 		//this is an actual thread, so wait for Ok from semaphore
 		thread_load_semaphore->wait(); //wait until its ok to start loading
 	}
@@ -247,7 +248,7 @@ void ResourceLoader::_thread_load_function(void *p_userdata) {
 	} else {
 		load_task.status = THREAD_LOAD_LOADED;
 	}
-	if (load_task.semaphore) {
+	if (load_task.cond_var) {
 		if (load_task.start_next && thread_waiting_count > 0) {
 			thread_waiting_count--;
 			//thread loading count remains constant, this ends but another one begins
@@ -258,11 +259,9 @@ void ResourceLoader::_thread_load_function(void *p_userdata) {
 
 		print_lt("END: load count: " + itos(thread_loading_count) + " / wait count: " + itos(thread_waiting_count) + " / suspended count: " + itos(thread_suspended_count) + " / active: " + itos(thread_loading_count - thread_suspended_count));
 
-		for (int i = 0; i < load_task.poll_requests; i++) {
-			load_task.semaphore->post();
-		}
-		memdelete(load_task.semaphore);
-		load_task.semaphore = nullptr;
+		load_task.cond_var->notify_all();
+		memdelete(load_task.cond_var);
+		load_task.cond_var = nullptr;
 	}
 
 	if (load_task.resource.is_valid()) {
@@ -373,7 +372,7 @@ Error ResourceLoader::load_threaded_request(const String &p_path, const String &
 
 	if (load_task.resource.is_null()) { //needs to be loaded in thread
 
-		load_task.semaphore = memnew(Semaphore);
+		load_task.cond_var = memnew(ConditionVariable);
 		if (thread_loading_count < thread_load_max) {
 			thread_loading_count++;
 			thread_load_semaphore->post(); //we have free threads, so allow one
@@ -438,9 +437,8 @@ ResourceLoader::ThreadLoadStatus ResourceLoader::load_threaded_get_status(const 
 Ref<Resource> ResourceLoader::load_threaded_get(const String &p_path, Error *r_error) {
 	String local_path = _validate_local_path(p_path);
 
-	thread_load_mutex->lock();
+	MutexLock thread_load_lock(*thread_load_mutex);
 	if (!thread_load_tasks.has(local_path)) {
-		thread_load_mutex->unlock();
 		if (r_error) {
 			*r_error = ERR_INVALID_PARAMETER;
 		}
@@ -449,13 +447,10 @@ Ref<Resource> ResourceLoader::load_threaded_get(const String &p_path, Error *r_e
 
 	ThreadLoadTask &load_task = thread_load_tasks[local_path];
 
-	//semaphore still exists, meaning it's still loading, request poll
-	Semaphore *semaphore = load_task.semaphore;
-	if (semaphore) {
-		load_task.poll_requests++;
-
+	//cond var still exists, meaning it's still loading, request poll
+	if (load_task.cond_var) {
 		{
-			// As we got a semaphore, this means we are going to have to wait
+			// As we got a cond var, this means we are going to have to wait
 			// until the sub-resource is done loading
 			//
 			// As this thread will become 'blocked' we should "exchange" its
@@ -477,14 +472,13 @@ Ref<Resource> ResourceLoader::load_threaded_get(const String &p_path, Error *r_e
 			print_lt("GET: load count: " + itos(thread_loading_count) + " / wait count: " + itos(thread_waiting_count) + " / suspended count: " + itos(thread_suspended_count) + " / active: " + itos(thread_loading_count - thread_suspended_count));
 		}
 
-		thread_load_mutex->unlock();
-		semaphore->wait();
-		thread_load_mutex->lock();
+		do {
+			load_task.cond_var->wait(thread_load_lock);
+		} while (load_task.cond_var); // In case of spurious wakeup.
 
 		thread_suspended_count--;
 
 		if (!thread_load_tasks.has(local_path)) { //may have been erased during unlock and this was always an invalid call
-			thread_load_mutex->unlock();
 			if (r_error) {
 				*r_error = ERR_INVALID_PARAMETER;
 			}
@@ -506,8 +500,6 @@ Ref<Resource> ResourceLoader::load_threaded_get(const String &p_path, Error *r_e
 		}
 		thread_load_tasks.erase(local_path);
 	}
-
-	thread_load_mutex->unlock();
 
 	return resource;
 }
@@ -1067,7 +1059,7 @@ void ResourceLoader::remove_custom_loaders() {
 }
 
 void ResourceLoader::initialize() {
-	thread_load_mutex = memnew(Mutex);
+	thread_load_mutex = memnew(SafeBinaryMutex<BINARY_MUTEX_TAG>);
 	thread_load_max = OS::get_singleton()->get_processor_count();
 	thread_loading_count = 0;
 	thread_waiting_count = 0;
@@ -1090,7 +1082,9 @@ bool ResourceLoader::create_missing_resources_if_class_unavailable = false;
 bool ResourceLoader::abort_on_missing_resource = true;
 bool ResourceLoader::timestamp_on_load = false;
 
-Mutex *ResourceLoader::thread_load_mutex = nullptr;
+template <>
+thread_local uint32_t SafeBinaryMutex<ResourceLoader::BINARY_MUTEX_TAG>::count = 0;
+SafeBinaryMutex<ResourceLoader::BINARY_MUTEX_TAG> *ResourceLoader::thread_load_mutex = nullptr;
 HashMap<String, ResourceLoader::ThreadLoadTask> ResourceLoader::thread_load_tasks;
 Semaphore *ResourceLoader::thread_load_semaphore = nullptr;
 

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -37,6 +37,8 @@
 #include "core/os/semaphore.h"
 #include "core/os/thread.h"
 
+class ConditionVariable;
+
 class ResourceFormatLoader : public RefCounted {
 	GDCLASS(ResourceFormatLoader, RefCounted);
 
@@ -105,6 +107,8 @@ public:
 		THREAD_LOAD_LOADED
 	};
 
+	static const int BINARY_MUTEX_TAG = 1;
+
 private:
 	static Ref<ResourceFormatLoader> loader[MAX_LOADERS];
 	static int loader_count;
@@ -136,7 +140,7 @@ private:
 	struct ThreadLoadTask {
 		Thread *thread = nullptr;
 		Thread::ID loader_id = 0;
-		Semaphore *semaphore = nullptr;
+		ConditionVariable *cond_var = nullptr;
 		String local_path;
 		String remapped_path;
 		String type_hint;
@@ -149,12 +153,11 @@ private:
 		bool use_sub_threads = false;
 		bool start_next = true;
 		int requests = 0;
-		int poll_requests = 0;
 		HashSet<String> sub_tasks;
 	};
 
 	static void _thread_load_function(void *p_userdata);
-	static Mutex *thread_load_mutex;
+	static SafeBinaryMutex<BINARY_MUTEX_TAG> *thread_load_mutex;
 	static HashMap<String, ThreadLoadTask> thread_load_tasks;
 	static Semaphore *thread_load_semaphore;
 	static int thread_waiting_count;

--- a/core/os/condition_variable.h
+++ b/core/os/condition_variable.h
@@ -1,0 +1,60 @@
+/**************************************************************************/
+/*  condition_variable.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef CONDITION_VARIABLE_H
+#define CONDITION_VARIABLE_H
+
+#include <condition_variable>
+
+// An object one or multiple threads can wait on a be notified by some other.
+// Normally, you want to use a semaphore for such scenarios, but when the
+// condition is something different than a count being greater than zero
+// (which is the built-in logic in a semaphore) or you want to provide your
+// own mutex to tie the wait-notify to some other behavior, you need to use this.
+
+class ConditionVariable {
+	mutable std::condition_variable condition;
+
+public:
+	template <class BinaryMutexT>
+	_ALWAYS_INLINE_ void wait(const MutexLock<BinaryMutexT> &p_lock) const {
+		condition.wait(const_cast<std::unique_lock<std::mutex> &>(p_lock.lock));
+	}
+
+	_ALWAYS_INLINE_ void notify_one() const {
+		condition.notify_one();
+	}
+
+	_ALWAYS_INLINE_ void notify_all() const {
+		condition.notify_all();
+	}
+};
+
+#endif // CONDITION_VARIABLE_H

--- a/core/os/mutex.h
+++ b/core/os/mutex.h
@@ -31,12 +31,20 @@
 #ifndef MUTEX_H
 #define MUTEX_H
 
+#include "core/error/error_macros.h"
 #include "core/typedefs.h"
 
 #include <mutex>
 
+template <class MutexT>
+class MutexLock;
+
 template <class StdMutexT>
 class MutexImpl {
+	friend class MutexLock<MutexImpl<StdMutexT>>;
+
+	using StdMutexType = StdMutexT;
+
 	mutable StdMutexT mutex;
 
 public:
@@ -53,18 +61,65 @@ public:
 	}
 };
 
+// A very special kind of mutex, used in scenarios where these
+// requirements hold at the same time:
+// - Must be used with a condition variable (only binary mutexes are suitable).
+// - Must have recursive semnantics (or simulate, as this one does).
+// The implementation keeps the lock count in TS. Therefore, only
+// one object of each version of the template can exists; hence the Tag argument.
+// Tags must be unique across the Godot codebase.
+// Also, don't forget to declare the thread_local variable on each use.
+template <int Tag>
+class SafeBinaryMutex {
+	friend class MutexLock<SafeBinaryMutex>;
+
+	using StdMutexType = std::mutex;
+
+	mutable std::mutex mutex;
+	static thread_local uint32_t count;
+
+public:
+	_ALWAYS_INLINE_ void lock() const {
+		if (++count == 1) {
+			mutex.lock();
+		}
+	}
+
+	_ALWAYS_INLINE_ void unlock() const {
+		DEV_ASSERT(count);
+		if (--count == 0) {
+			mutex.unlock();
+		}
+	}
+
+	_ALWAYS_INLINE_ bool try_lock() const {
+		if (count) {
+			count++;
+			return true;
+		} else {
+			if (mutex.try_lock()) {
+				count++;
+				return true;
+			} else {
+				return false;
+			}
+		}
+	}
+
+	~SafeBinaryMutex() {
+		DEV_ASSERT(!count);
+	}
+};
+
 template <class MutexT>
 class MutexLock {
-	const MutexT &mutex;
+	friend class ConditionVariable;
+
+	std::unique_lock<typename MutexT::StdMutexType> lock;
 
 public:
 	_ALWAYS_INLINE_ explicit MutexLock(const MutexT &p_mutex) :
-			mutex(p_mutex) {
-		mutex.lock();
-	}
-
-	_ALWAYS_INLINE_ ~MutexLock() {
-		mutex.unlock();
+			lock(p_mutex.mutex) {
 	}
 };
 


### PR DESCRIPTION
This PR is an alternative to #73623, aiming to fix the same issues spotted there, but in a different way; namely:
- The race condition where the task semaphore has a chance of being destroyed before the other thread can wait on it is solved here by using the sync primitive that can naturally fix the problem, which is a condition variable. In the current implementation, the problem is that a mutex is unlocked and then a semaphore is awaited. Those operations should make an atomic operation, which is precisely what a condition variable does. Therefore `ConditionVariable` is introduced, together with a new flavor of binary mutex needed to be used with it.
- The problem that a load task has been initiated in a non-thready context (regular resource load or load in thread, but with no subthreads) and then involved in load threads created later is solved here by allowing the condition variable (formerly, a semaphore) needed to await on the task to be created lazily. Such approach keeps the current benefit of having one-threaded cases free of having to create and deal with the condition variable.

This needs testing. And I beg a thorough review of this code, since this is slippery ground.

**NOTE:** Given the complex nature of the changes, I'm keeping them in separate commits.

- Fixes #66023.
- Fixes #71726.