### PR TITLE
fbx: Set base_dir correctly in append_from_scene

### DIFF
--- a/modules/gltf/editor/editor_scene_importer_fbx.cpp
+++ b/modules/gltf/editor/editor_scene_importer_fbx.cpp
@@ -93,7 +93,7 @@ Node *EditorSceneFormatImporterFBX::import_scene(const String &p_path, uint32_t 
 	Ref<GLTFState> state;
 	state.instantiate();
 	print_verbose(vformat("glTF path: %s", sink));
-	Error err = gltf->append_from_file(sink, state, p_flags);
+	Error err = gltf->append_from_file(sink, state, p_flags, p_path.get_base_dir());
 	if (err != OK) {
 		if (r_err) {
 			*r_err = FAILED;


### PR DESCRIPTION
Fixes #72503. I verified the bug and the fix in the MRP.

Basically, the `editor_scene_importer_gltf.cpp` does not need to pass `base_dir`, because the filename of the .gltf can be used to get its base directory. But in FBX, the generated fbx file lives in .godot/imported, so we need to pass the original directory in.

Thanks to @fire who found the cause of the issue and pointed it out.