### PR TITLE
Allow to reference a class constructor as a `Callable`

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3264,7 +3264,7 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 		base = *p_base;
 	}
 
-	const StringName &name = p_identifier->name;
+	StringName name = p_identifier->name;
 
 	if (base.kind == GDScriptParser::DataType::ENUM) {
 		if (base.is_meta_type) {
@@ -3359,10 +3359,16 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 		get_class_node_current_scope_classes(base_class, &script_classes);
 	}
 
+	bool is_constructor = base.is_meta_type && p_identifier->name == SNAME("new");
+
 	for (GDScriptParser::ClassNode *script_class : script_classes) {
 		if (p_base == nullptr && script_class->identifier && script_class->identifier->name == name) {
 			reduce_identifier_from_base_set_class(p_identifier, script_class->get_datatype());
 			return;
+		}
+
+		if (is_constructor) {
+			name = "_init";
 		}
 
 		if (script_class->has_member(name)) {
@@ -3443,6 +3449,10 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 	const StringName &native = base.native_type;
 
 	if (class_exists(native)) {
+		if (is_constructor) {
+			name = "_init";
+		}
+
 		MethodInfo method_info;
 		if (ClassDB::has_property(native, name)) {
 			StringName getter_name = ClassDB::get_property_getter(native, name);

--- a/modules/gdscript/tests/scripts/runtime/features/ctor_as_callable.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/ctor_as_callable.gd
@@ -1,0 +1,10 @@
+# https://github.com/godotengine/godot/issues/70319
+
+class InnerClass:
+    pass
+
+func test():
+    var inner_ctor : Callable = InnerClass.new
+    print(inner_ctor)
+    var native_ctor : Callable = Node.new
+    print(native_ctor)

--- a/modules/gdscript/tests/scripts/runtime/features/ctor_as_callable.out
+++ b/modules/gdscript/tests/scripts/runtime/features/ctor_as_callable.out
@@ -1,0 +1,3 @@
+GDTEST_OK
+GDScript::new
+GDScriptNativeClass::new


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/70319

Now constructors of Scripts and Native objects can be retrieved as a `Callable`.