### PR TITLE
Keep NavigationServer active while SceneTree is paused

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -825,7 +825,6 @@ void SceneTree::set_pause(bool p_enabled) {
 		return;
 	}
 	paused = p_enabled;
-	NavigationServer3D::get_singleton()->set_active(!p_enabled);
 	PhysicsServer3D::get_singleton()->set_active(!p_enabled);
 	PhysicsServer2D::get_singleton()->set_active(!p_enabled);
 	if (get_root()) {


### PR DESCRIPTION
Can't speak for physics that shares a similar faith but deactivating the entire NavigationServer on a SceneTree pause is wrong.

The NavigationAgents already react to SceneTree pauses on their own.

Related to https://github.com/godotengine/godot/issues/73655

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
