### PR TITLE
Fix issue with clearing screen after part has been drawn

### DIFF
--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -68,7 +68,7 @@ protected:
 	RasterizerCanvasGLES3 *canvas = nullptr;
 	RasterizerSceneGLES3 *scene = nullptr;
 
-	void _blit_render_target_to_screen(RID p_render_target, DisplayServer::WindowID p_screen, const Rect2 &p_screen_rect, uint32_t p_layer);
+	void _blit_render_target_to_screen(RID p_render_target, DisplayServer::WindowID p_screen, const Rect2 &p_screen_rect, uint32_t p_layer, bool p_first = true);
 
 public:
 	RendererUtilities *get_utilities() { return utilities; }


### PR DESCRIPTION
When using the mobile VR interface we are rendering the left eye and right eye on two layers of our render target.

The left eye is then blit to the left side of the screen, the right eye to the right side of the screen.

The problem here is that with OpenGL we were checking if the position of what we're blitting was not `Vector2(0,0)` and clearing the screen to ensure that the part not written was just left over memory junk.
In this scenario, blitting the left eye didn't trigger the clear, but blitting the right eye did resulting in the left eye data being lost.

This PR changes the logic so clearing can only happen when we draw the first element, and checks the full size of our destination. 
I'm not sure of that last bit because this may not account for our title bar.