### PR TITLE
Fix wobbly sky in stereoscopic OpenGL

### DIFF
--- a/drivers/gles3/shaders/sky.glsl
+++ b/drivers/gles3/shaders/sky.glsl
@@ -21,12 +21,13 @@ out vec2 uv_interp;
 /* clang-format on */
 
 void main() {
-	uv_interp = vertex_attrib;
 #ifdef USE_INVERTED_Y
-	gl_Position = vec4(uv_interp, 1.0, 1.0);
+	uv_interp = vertex_attrib;
 #else
-	gl_Position = vec4(uv_interp.x, uv_interp.y * -1.0, 1.0, 1.0);
+	// We're doing clockwise culling so flip the order
+	uv_interp = vec2(vertex_attrib.x, vertex_attrib.y * -1.0);
 #endif
+	gl_Position = vec4(uv_interp, 1.0, 1.0);
 }
 
 /* clang-format off */
@@ -144,9 +145,6 @@ void main() {
 	cube_normal.z = -1.0;
 	cube_normal.x = (uv_interp.x + projection.x) / projection.y;
 	cube_normal.y = (-uv_interp.y - projection.z) / projection.w;
-#endif
-#ifndef USE_INVERTED_Y
-	cube_normal.y *= -1.0;
 #endif
 	cube_normal = mat3(orientation) * cube_normal;
 	cube_normal = normalize(cube_normal);


### PR DESCRIPTION
In OpenGL we're by default "rendering upside down". For XR purposes we have an overrule where we're rendering rightside up so that frames are presented correctly to the XR compositor. This also results in culling clockwise instead of counter clockwise

The adjustments done in the sky shader attempted to deal with this but as the Y-flip is already encoded into the projection matrix, the code was just flipping things a few times coming back to the same orientation.

Doing this double Y-flip went mostly unnoticed for (vertically) symmetrical view frustums. However with asymmetrical or slanted frustums as is possible with certain brands of headsets, we ended up with the wrong Y component and a noticeable nauseating wobble was introduced when the player turns their head.

This PR removes all the unnecessary steps. We do invert the inputs in the vertex shader to make the culling logic happy. 
