### PR TITLE
Allow `DEBUG_ENABLED` to be toggled independently of `TOOLS_ENABLED`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -169,6 +169,14 @@ opts.Add(EnumVariable("arch", "CPU architecture", "auto", ["auto"] + architectur
 opts.Add(BoolVariable("dev_build", "Developer build with dev-only debugging code (DEV_ENABLED)", False))
 opts.Add(
     EnumVariable(
+        "debug_features",
+        "Enable warnings and debug apis (DEBUG_ENABLED). By default unless template_release",
+        "auto",
+        ("auto", "yes", "no")
+    )
+)
+opts.Add(
+    EnumVariable(
         "optimize", "Optimization level", "speed_trace", ("none", "custom", "debug", "speed", "speed_trace", "size")
     )
 )
@@ -392,7 +400,10 @@ env_base.platform_apis = platform_apis
 
 env_base.editor_build = env_base["target"] == "editor"
 env_base.dev_build = env_base["dev_build"]
-env_base.debug_features = env_base["target"] in ["editor", "template_debug"]
+if env_base["debug_features"] == "auto":
+    env_base.debug_features = env_base["target"] in ["editor", "template_debug"]
+else:
+    env_base.debug_features = env_base["debug_features"] == "yes"
 
 if env_base.dev_build:
     opt_level = "none"

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -37,7 +37,7 @@
 #include "core/templates/pair.h"
 #include "core/version.h"
 
-#ifdef TOOLS_ENABLED
+#ifdef DEBUG_METHODS_ENABLED
 
 static String get_builtin_or_variant_type_name(const Variant::Type p_type) {
 	if (p_type == Variant::NIL) {

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -961,7 +961,7 @@ void ClassDB::set_property_default_value(const StringName &p_class, const String
 }
 
 void ClassDB::add_linked_property(const StringName &p_class, const String &p_property, const String &p_linked_property) {
-#ifdef TOOLS_ENABLED
+#ifdef DEBUG_METHODS_ENABLED
 	OBJTYPE_WLOCK;
 	ClassInfo *type = classes.getptr(p_class);
 	ERR_FAIL_COND(!type);
@@ -1002,7 +1002,7 @@ void ClassDB::get_property_list(const StringName &p_class, List<PropertyInfo> *p
 }
 
 void ClassDB::get_linked_properties_info(const StringName &p_class, const StringName &p_property, List<StringName> *r_properties, bool p_no_inheritance) {
-#ifdef TOOLS_ENABLED
+#ifdef DEBUG_METHODS_ENABLED
 	ClassInfo *check = classes.getptr(p_class);
 	while (check) {
 		if (!check->linked_properties.has(p_property)) {

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -125,6 +125,7 @@ void EditorDebuggerInspector::_object_selected(ObjectID p_object) {
 }
 
 ObjectID EditorDebuggerInspector::add_object(const Array &p_arr) {
+#ifdef DEBUG_ENABLED
 	EditorDebuggerRemoteObject *debug_obj = nullptr;
 
 	SceneDebuggerObject obj;
@@ -202,6 +203,10 @@ ObjectID EditorDebuggerInspector::add_object(const Array &p_arr) {
 		debug_obj->update();
 	}
 	return obj.id;
+
+#else // DEBUG_ENABLED
+	return ObjectID();
+#endif
 }
 
 void EditorDebuggerInspector::clear_cache() {

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -593,7 +593,9 @@ void EditorDebuggerNode::_remote_tree_updated(int p_debugger) {
 		return;
 	}
 	remote_scene_tree->clear();
+#ifdef DEBUG_ENABLED
 	remote_scene_tree->update_scene_tree(get_current_debugger()->get_remote_tree(), p_debugger);
+#endif
 }
 
 void EditorDebuggerNode::_remote_tree_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button) {

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -136,6 +136,7 @@ void EditorDebuggerTree::_scene_tree_rmb_selected(const Vector2 &p_position, Mou
 /// |
 /// |-E
 ///
+#ifdef DEBUG_ENABLED
 void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int p_debugger) {
 	updating_scene_tree = true;
 	const String last_path = get_selected_path();
@@ -258,6 +259,7 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 	last_filter = filter;
 	updating_scene_tree = false;
 }
+#endif // DEBUG_ENABLED
 
 Variant EditorDebuggerTree::get_drag_data(const Point2 &p_point) {
 	if (get_button_id_at_position(p_point) != -1) {

--- a/editor/debugger/editor_debugger_tree.h
+++ b/editor/debugger/editor_debugger_tree.h
@@ -75,7 +75,9 @@ public:
 	String get_selected_path();
 	ObjectID get_selected_object();
 	int get_current_debugger(); // Would love to have one tree for every debugger.
+#ifdef DEBUG_ENABLED
 	void update_scene_tree(const SceneDebuggerTree *p_tree, int p_debugger);
+#endif
 	EditorDebuggerTree();
 };
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -244,9 +244,11 @@ void ScriptEditorDebugger::request_remote_tree() {
 	_put_msg("scene:request_scene_tree", Array());
 }
 
+#ifdef DEBUG_ENABLED
 const SceneDebuggerTree *ScriptEditorDebugger::get_remote_tree() {
 	return scene_tree;
 }
+#endif
 
 void ScriptEditorDebugger::update_remote_object(ObjectID p_obj_id, const String &p_prop, const Variant &p_value) {
 	Array msg;
@@ -344,15 +346,19 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		clicked_ctrl->set_text(p_data[0]);
 		clicked_ctrl_type->set_text(p_data[1]);
 	} else if (p_msg == "scene:scene_tree") {
+#ifdef DEBUG_ENABLED
 		scene_tree->nodes.clear();
 		scene_tree->deserialize(p_data);
 		emit_signal(SNAME("remote_tree_updated"));
 		_update_buttons_state();
+#endif
 	} else if (p_msg == "scene:inspect_object") {
+#ifdef DEBUG_ENABLED
 		ObjectID id = inspector->add_object(p_data);
 		if (id.is_valid()) {
 			emit_signal(SNAME("remote_object_updated"), id);
 		}
+#endif
 	} else if (p_msg == "servers:memory_usage") {
 		vmem_tree->clear();
 		TreeItem *root = vmem_tree->create_item();
@@ -1983,7 +1989,9 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		info_left->add_child(memnew(Label(TTR("Clicked Control Type:"))));
 		info_left->add_child(clicked_ctrl_type);
 
+#ifdef DEBUG_ENABLED
 		scene_tree = memnew(SceneDebuggerTree);
+#endif
 		live_edit_root = memnew(LineEdit);
 		live_edit_root->set_editable(false);
 		live_edit_root->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -2027,5 +2035,7 @@ ScriptEditorDebugger::~ScriptEditorDebugger() {
 		peer->close();
 		peer.unref();
 	}
+#ifdef DEBUG_ENABLED
 	memdelete(scene_tree);
+#endif
 }

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -139,7 +139,9 @@ private:
 	Tree *stack_dump = nullptr;
 	LineEdit *search = nullptr;
 	EditorDebuggerInspector *inspector = nullptr;
+#ifdef DEBUG_ENABLED
 	SceneDebuggerTree *scene_tree = nullptr;
+#endif
 
 	Ref<RemoteDebuggerPeer> peer;
 
@@ -226,7 +228,9 @@ public:
 	void set_editor_remote_tree(const Tree *p_tree) { editor_remote_tree = p_tree; }
 
 	void request_remote_tree();
+#ifdef DEBUG_ENABLED
 	const SceneDebuggerTree *get_remote_tree();
+#endif
 
 	void start(Ref<RemoteDebuggerPeer> p_peer);
 	void stop();

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -496,6 +496,7 @@ void ScriptTextEditor::_update_warnings() {
 	warnings_panel->clear();
 
 	bool has_connections_table = false;
+#ifdef DEBUG_ENABLED
 	// Add missing connections.
 	if (GLOBAL_GET("debug/gdscript/warnings/enable").booleanize()) {
 		Node *base = get_tree()->get_edited_scene_root();
@@ -518,6 +519,7 @@ void ScriptTextEditor::_update_warnings() {
 			warning_nb += missing_connections.size();
 		}
 	}
+#endif // DEBUG_ENABLED
 
 	code_editor->set_warning_count(warning_nb);
 

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -86,10 +86,12 @@ void GDShaderSyntaxHighlighter::set_disabled_branch_color(const Color &p_color) 
 
 /*** SHADER SCRIPT EDITOR ****/
 
+#ifdef DEBUG_ENABLED
 static bool saved_warnings_enabled = false;
 static bool saved_treat_warning_as_errors = false;
 static HashMap<ShaderWarning::Code, bool> saved_warnings;
 static uint32_t saved_warning_flags = 0U;
+#endif
 
 void ShaderTextEditor::_notification(int p_what) {
 	switch (p_what) {
@@ -489,6 +491,7 @@ void ShaderTextEditor::_validate_script() {
 	} else {
 		ShaderLanguage sl;
 
+#ifdef DEBUG_ENABLED
 		sl.enable_warning_checking(saved_warnings_enabled);
 		uint32_t flags = saved_warning_flags;
 		if (shader.is_null()) {
@@ -509,7 +512,7 @@ void ShaderTextEditor::_validate_script() {
 			}
 		}
 		sl.set_warning_flags(flags);
-
+#endif
 		ShaderLanguage::ShaderCompileInfo comp_info;
 		comp_info.global_shader_uniform_type_func = _get_global_shader_uniform_type;
 
@@ -551,6 +554,7 @@ void ShaderTextEditor::_validate_script() {
 			warnings_panel->clear();
 		}
 		warnings.clear();
+#ifdef DEBUG_ENABLED
 		for (List<ShaderWarning>::Element *E = sl.get_warnings_ptr(); E; E = E->next()) {
 			warnings.push_back(E->get());
 		}
@@ -560,12 +564,14 @@ void ShaderTextEditor::_validate_script() {
 		} else {
 			set_warning_count(0);
 		}
+#endif
 	}
 
 	emit_signal(SNAME("script_validated"), last_compile_result == OK); // Notify that validation finished, to update the list of scripts
 }
 
 void ShaderTextEditor::_update_warning_panel() {
+#ifdef DEBUG_ENABLED
 	int warning_count = 0;
 
 	warnings_panel->push_table(2);
@@ -606,6 +612,7 @@ void ShaderTextEditor::_update_warning_panel() {
 	warnings_panel->pop(); // Table.
 
 	set_warning_count(warning_count);
+#endif
 }
 
 void ShaderTextEditor::_bind_methods() {
@@ -761,6 +768,7 @@ void TextShaderEditor::_project_settings_changed() {
 }
 
 void TextShaderEditor::_update_warnings(bool p_validate) {
+#ifdef DEBUG_ENABLED
 	bool changed = false;
 
 	bool warnings_enabled = GLOBAL_GET("debug/shader_language/warnings/enable").booleanize();
@@ -795,6 +803,7 @@ void TextShaderEditor::_update_warnings(bool p_validate) {
 	if (p_validate && changed && shader_editor && shader_editor->get_edited_shader().is_valid()) {
 		shader_editor->validate_script();
 	}
+#endif
 }
 
 void TextShaderEditor::_check_for_external_edit() {
@@ -1051,11 +1060,13 @@ void TextShaderEditor::_make_context_menu(bool p_selection, Vector2 p_position) 
 }
 
 TextShaderEditor::TextShaderEditor() {
+#ifdef DEBUG_ENABLED
 	GLOBAL_DEF("debug/shader_language/warnings/enable", true);
 	GLOBAL_DEF("debug/shader_language/warnings/treat_warnings_as_errors", false);
 	for (int i = 0; i < (int)ShaderWarning::WARNING_MAX; i++) {
 		GLOBAL_DEF("debug/shader_language/warnings/" + ShaderWarning::get_name_from_code((ShaderWarning::Code)i).to_lower(), true);
 	}
+#endif
 	_update_warnings(false);
 
 	shader_editor = memnew(ShaderTextEditor);

--- a/editor/plugins/text_shader_editor.h
+++ b/editor/plugins/text_shader_editor.h
@@ -57,15 +57,21 @@ class ShaderTextEditor : public CodeTextEditor {
 
 	Color marked_line_color = Color(1, 1, 1);
 
+#ifdef DEBUG_ENABLED
 	struct WarningsComparator {
 		_ALWAYS_INLINE_ bool operator()(const ShaderWarning &p_a, const ShaderWarning &p_b) const { return (p_a.get_line() < p_b.get_line()); }
 	};
+#endif // DEBUG_ENABLED
 
 	Ref<GDShaderSyntaxHighlighter> syntax_highlighter;
 	RichTextLabel *warnings_panel = nullptr;
 	Ref<Shader> shader;
 	Ref<ShaderInclude> shader_inc;
+#ifdef DEBUG_ENABLED
 	List<ShaderWarning> warnings;
+#else // DEBUG_ENABLED
+	List<int> warnings;
+#endif // DEBUG_ENABLED
 	Error last_compile_result = Error::OK;
 
 	void _check_shader_mode();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2565,10 +2565,13 @@ bool Main::start() {
 		GDExtensionInterfaceDump::generate_gdextension_interface_file("gdextension_interface.h");
 	}
 
+#endif // TOOLS_ENABLED
+#ifdef DEBUG_ENABLED
 	if (dump_extension_api) {
 		GDExtensionAPIDump::generate_extension_json_file("extension_api.json");
 	}
-
+#endif // DEBUG_ENABLED
+#ifdef TOOLS_ENABLED
 	if (dump_gdextension_interface || dump_extension_api) {
 		OS::get_singleton()->set_exit_code(EXIT_SUCCESS);
 		return false;

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -43,7 +43,7 @@
 #include "gdscript_utility_functions.h"
 #include "scene/resources/packed_scene.h"
 
-#if defined(TOOLS_ENABLED) && !defined(DISABLE_DEPRECATED)
+#if defined(TOOLS_ENABLED) && defined(DEBUG_ENABLED) && !defined(DISABLE_DEPRECATED)
 #define SUGGEST_GODOT4_RENAMES
 #include "editor/renames_map_3_to_4.h"
 #endif

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -795,11 +795,13 @@ static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_a
 			r_result.insert(option.display, option);
 		}
 	} else if (p_annotation->name == SNAME("@warning_ignore")) {
+#ifdef DEBUG_ENABLED
 		for (int warning_code = 0; warning_code < GDScriptWarning::WARNING_MAX; warning_code++) {
 			ScriptLanguage::CodeCompletionOption warning(GDScriptWarning::get_name_from_code((GDScriptWarning::Code)warning_code).to_lower(), ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
 			warning.insert_text = warning.display.quote(p_quote_style);
 			r_result.insert(warning.display, warning);
 		}
+#endif
 	} else if (p_annotation->name == SNAME("@rpc")) {
 		if (p_argument == 0 || p_argument == 1 || p_argument == 2) {
 			static const char *options[7] = { "call_local", "call_remote", "any_peer", "authority", "reliable", "unreliable", "unreliable_ordered" };

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -59,6 +59,7 @@ void ExtendGDScriptParser::update_diagnostics() {
 		diagnostics.push_back(diagnostic);
 	}
 
+#ifdef DEBUG_ENABLED
 	const List<GDScriptWarning> &parser_warnings = get_warnings();
 	for (const GDScriptWarning &warning : parser_warnings) {
 		lsp::Diagnostic diagnostic;
@@ -78,6 +79,7 @@ void ExtendGDScriptParser::update_diagnostics() {
 		diagnostic.range = range;
 		diagnostics.push_back(diagnostic);
 	}
+#endif
 }
 
 void ExtendGDScriptParser::update_symbols() {

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -160,111 +160,60 @@ bool NavigationServer2D::get_debug_enabled() const {
 	return NavigationServer3D::get_singleton()->get_debug_enabled();
 }
 
-#ifdef DEBUG_ENABLED
-void NavigationServer2D::set_debug_navigation_edge_connection_color(const Color &p_color) {
-	NavigationServer3D::get_singleton()->set_debug_navigation_edge_connection_color(p_color);
-}
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 
 Color NavigationServer2D::get_debug_navigation_edge_connection_color() const {
 	return NavigationServer3D::get_singleton()->get_debug_navigation_edge_connection_color();
-}
-
-void NavigationServer2D::set_debug_navigation_geometry_face_color(const Color &p_color) {
-	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_face_color(p_color);
 }
 
 Color NavigationServer2D::get_debug_navigation_geometry_face_color() const {
 	return NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_color();
 }
 
-void NavigationServer2D::set_debug_navigation_geometry_face_disabled_color(const Color &p_color) {
-	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_face_disabled_color(p_color);
-}
-
 Color NavigationServer2D::get_debug_navigation_geometry_face_disabled_color() const {
 	return NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_disabled_color();
-}
-
-void NavigationServer2D::set_debug_navigation_link_connection_color(const Color &p_color) {
-	NavigationServer3D::get_singleton()->set_debug_navigation_link_connection_color(p_color);
 }
 
 Color NavigationServer2D::get_debug_navigation_link_connection_color() const {
 	return NavigationServer3D::get_singleton()->get_debug_navigation_link_connection_color();
 }
 
-void NavigationServer2D::set_debug_navigation_link_connection_disabled_color(const Color &p_color) {
-	NavigationServer3D::get_singleton()->set_debug_navigation_link_connection_disabled_color(p_color);
-}
-
 Color NavigationServer2D::get_debug_navigation_link_connection_disabled_color() const {
 	return NavigationServer3D::get_singleton()->get_debug_navigation_link_connection_disabled_color();
-}
-
-void NavigationServer2D::set_debug_navigation_geometry_edge_color(const Color &p_color) {
-	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_edge_color(p_color);
 }
 
 Color NavigationServer2D::get_debug_navigation_geometry_edge_color() const {
 	return NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_color();
 }
 
-void NavigationServer2D::set_debug_navigation_geometry_edge_disabled_color(const Color &p_color) {
-	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_edge_disabled_color(p_color);
-}
-
 Color NavigationServer2D::get_debug_navigation_geometry_edge_disabled_color() const {
 	return NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_disabled_color();
-}
-
-void NavigationServer2D::set_debug_navigation_enable_edge_connections(const bool p_value) {
-	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_connections(p_value);
 }
 
 bool NavigationServer2D::get_debug_navigation_enable_edge_connections() const {
 	return NavigationServer3D::get_singleton()->get_debug_navigation_enable_edge_connections();
 }
 
-void NavigationServer2D::set_debug_navigation_enable_geometry_face_random_color(const bool p_value) {
-	NavigationServer3D::get_singleton()->set_debug_navigation_enable_geometry_face_random_color(p_value);
-}
-
 bool NavigationServer2D::get_debug_navigation_enable_geometry_face_random_color() const {
 	return NavigationServer3D::get_singleton()->get_debug_navigation_enable_geometry_face_random_color();
-}
-
-void NavigationServer2D::set_debug_navigation_enable_edge_lines(const bool p_value) {
-	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_lines(p_value);
 }
 
 bool NavigationServer2D::get_debug_navigation_enable_edge_lines() const {
 	return NavigationServer3D::get_singleton()->get_debug_navigation_enable_edge_lines();
 }
 
-void NavigationServer2D::set_debug_navigation_agent_path_color(const Color &p_color) {
-	NavigationServer3D::get_singleton()->set_debug_navigation_agent_path_color(p_color);
-}
-
 Color NavigationServer2D::get_debug_navigation_agent_path_color() const {
 	return NavigationServer3D::get_singleton()->get_debug_navigation_agent_path_color();
-}
-
-void NavigationServer2D::set_debug_navigation_enable_agent_paths(const bool p_value) {
-	NavigationServer3D::get_singleton()->set_debug_navigation_enable_agent_paths(p_value);
 }
 
 bool NavigationServer2D::get_debug_navigation_enable_agent_paths() const {
 	return NavigationServer3D::get_singleton()->get_debug_navigation_enable_agent_paths();
 }
 
-void NavigationServer2D::set_debug_navigation_agent_path_point_size(float p_point_size) {
-	NavigationServer3D::get_singleton()->set_debug_navigation_agent_path_point_size(p_point_size);
-}
-
 float NavigationServer2D::get_debug_navigation_agent_path_point_size() const {
 	return NavigationServer3D::get_singleton()->get_debug_navigation_agent_path_point_size();
 }
-#endif // DEBUG_ENABLED
+#endif // defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 
 void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_maps"), &NavigationServer2D::get_maps);

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -237,7 +237,7 @@ public:
 	void set_debug_enabled(bool p_enabled);
 	bool get_debug_enabled() const;
 
-#ifdef DEBUG_ENABLED
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	void set_debug_navigation_edge_connection_color(const Color &p_color);
 	Color get_debug_navigation_edge_connection_color() const;
 
@@ -276,12 +276,12 @@ public:
 
 	void set_debug_navigation_agent_path_point_size(float p_point_size);
 	float get_debug_navigation_agent_path_point_size() const;
-#endif // DEBUG_ENABLED
+#endif // defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 
-#ifdef DEBUG_ENABLED
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 private:
 	void _emit_navigation_debug_changed_signal();
-#endif // DEBUG_ENABLED
+#endif // defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 };
 
 #endif // NAVIGATION_SERVER_2D_H

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -152,7 +152,7 @@ NavigationServer3D::NavigationServer3D() {
 	GLOBAL_DEF("navigation/3d/default_edge_connection_margin", 0.25);
 	GLOBAL_DEF("navigation/3d/default_link_connection_radius", 1.0);
 
-#ifdef DEBUG_ENABLED
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	debug_navigation_edge_connection_color = GLOBAL_DEF("debug/shapes/navigation/edge_connection_color", Color(1.0, 0.0, 1.0, 1.0));
 	debug_navigation_geometry_edge_color = GLOBAL_DEF("debug/shapes/navigation/geometry_edge_color", Color(0.5, 1.0, 1.0, 1.0));
 	debug_navigation_geometry_face_color = GLOBAL_DEF("debug/shapes/navigation/geometry_face_color", Color(0.5, 1.0, 1.0, 0.4));
@@ -180,7 +180,7 @@ NavigationServer3D::NavigationServer3D() {
 		// on runtime tests SceneTree has "Visible Navigation" set and main iteration takes care of this
 		set_debug_enabled(true);
 	}
-#endif // DEBUG_ENABLED
+#endif // defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 }
 
 NavigationServer3D::~NavigationServer3D() {
@@ -188,7 +188,7 @@ NavigationServer3D::~NavigationServer3D() {
 }
 
 void NavigationServer3D::set_debug_enabled(bool p_enabled) {
-#ifdef DEBUG_ENABLED
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	if (debug_enabled != p_enabled) {
 		debug_dirty = true;
 	}
@@ -198,23 +198,21 @@ void NavigationServer3D::set_debug_enabled(bool p_enabled) {
 	if (debug_dirty) {
 		call_deferred("_emit_navigation_debug_changed_signal");
 	}
-#endif // DEBUG_ENABLED
+#endif // defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 }
 
 bool NavigationServer3D::get_debug_enabled() const {
 	return debug_enabled;
 }
 
-#ifdef DEBUG_ENABLED
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 void NavigationServer3D::_emit_navigation_debug_changed_signal() {
 	if (debug_dirty) {
 		debug_dirty = false;
 		emit_signal(SNAME("navigation_debug_changed"));
 	}
 }
-#endif // DEBUG_ENABLED
 
-#ifdef DEBUG_ENABLED
 Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_geometry_face_material() {
 	if (debug_navigation_geometry_face_material.is_valid()) {
 		return debug_navigation_geometry_face_material;
@@ -584,7 +582,7 @@ bool NavigationServer3D::get_debug_navigation_enable_agent_paths_xray() const {
 	return debug_navigation_enable_agent_paths_xray;
 }
 
-#endif // DEBUG_ENABLED
+#endif // defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 
 void NavigationServer3D::query_path(const Ref<NavigationPathQueryParameters3D> &p_query_parameters, Ref<NavigationPathQueryResult3D> p_query_result) const {
 	ERR_FAIL_COND(!p_query_parameters.is_valid());

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -280,7 +280,7 @@ public:
 private:
 	bool debug_enabled = false;
 
-#ifdef DEBUG_ENABLED
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	bool debug_dirty = true;
 	void _emit_navigation_debug_changed_signal();
 
@@ -315,8 +315,10 @@ private:
 
 	Ref<StandardMaterial3D> debug_navigation_agent_path_line_material;
 	Ref<StandardMaterial3D> debug_navigation_agent_path_point_material;
+#endif // defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 
 public:
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	void set_debug_navigation_edge_connection_color(const Color &p_color);
 	Color get_debug_navigation_edge_connection_color() const;
 
@@ -381,7 +383,7 @@ public:
 
 	Ref<StandardMaterial3D> get_debug_navigation_agent_path_line_material();
 	Ref<StandardMaterial3D> get_debug_navigation_agent_path_point_material();
-#endif // DEBUG_ENABLED
+#endif // defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 };
 
 typedef NavigationServer3D *(*NavigationServer3DCallback)();


### PR DESCRIPTION
Makes debugging of unusual release-only issues such as godotengine/godot-cpp#842 easier from an editor build without needing to make a separate template build to reproduce them.

This is mostly useful for `target=editor` since there is at present no way to make a "release editor".

For example, these will build debug builds without the `DEBUG_ENABLED` macro (perhaps to allow debugging of release-specific crashes)
```
scons target=editor debug_features=no
scons target=template_debug debug_features=no
```

or build a release build with optimizations, but with `DEBUG_ENABLED` turned on.
```
scons target=template_release debug_features=yes
```

`debug_features` defaults to `auto` which is `yes` for `target=template_release` and `no` for `target=editor` or `target=template_debug`

There could be usecases for building a debuggable template, but it's unclear what the difference is between my proposed `target=template_debug debug_features=no` and `target=template_release optimization=debug debug_symbols=yes`

I'd be open to adding `target=editor_release` instead if it makes more sense.

Regarding the changes in the PR, they are to make checks consistent across the codebase.

As one example, ClassDB metadata and argument info are enabled when `DEBUG_METHODS_ENABLED` (which means the same thing as `DEBUG_ENABLED`, I think?), so it makes sense to permit `--dump-gdextension-api` when `DEBUG_ENABLED`.