### PR TITLE
[TextServer] Ensure ICU data is initialised only one and cleaned only at exit.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -334,6 +334,8 @@ _FORCE_INLINE_ bool is_connected_to_prev(char32_t p_chr, char32_t p_pchr) {
 
 /*************************************************************************/
 
+bool TextServerAdvanced::icu_data_loaded = false;
+
 bool TextServerAdvanced::_has_feature(Feature p_feature) const {
 	switch (p_feature) {
 		case FEATURE_SIMPLE_LAYOUT:
@@ -6599,5 +6601,6 @@ TextServerAdvanced::~TextServerAdvanced() {
 		uset_close(allowed);
 		allowed = nullptr;
 	}
-	u_cleanup();
+
+	std::atexit(u_cleanup);
 }

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -158,7 +158,7 @@ class TextServerAdvanced : public TextServerExtension {
 
 	// ICU support data.
 
-	bool icu_data_loaded = false;
+	static bool icu_data_loaded;
 	mutable USet *allowed = nullptr;
 	mutable USpoofChecker *sc_spoof = nullptr;
 	mutable USpoofChecker *sc_conf = nullptr;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/73665
