### PR TITLE
Fix threading issues in resource loading (slimmer)

### DIFF
--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -92,6 +92,8 @@ typedef void (*DependencyErrorNotify)(void *p_ud, const String &p_loading, const
 typedef Error (*ResourceLoaderImport)(const String &p_path);
 typedef void (*ResourceLoadedCallback)(Ref<Resource> p_resource, const String &p_path);
 
+struct RCSemaphore;
+
 class ResourceLoader {
 	enum {
 		MAX_LOADERS = 64
@@ -136,7 +138,7 @@ private:
 	struct ThreadLoadTask {
 		Thread *thread = nullptr;
 		Thread::ID loader_id = 0;
-		Semaphore *semaphore = nullptr;
+		Ref<RCSemaphore> semaphore;
 		String local_path;
 		String remapped_path;
 		String type_hint;


### PR DESCRIPTION
- Race condition related to semaphore when a task is switching to another resource.
- Lack of a way to await for load tasks started in non-thread-aware contextxs.

Slimmer alternative to #73647. That one was likely more efficient, but it probably will not be noticeable in practice.

Fixes #71726.