### PR TITLE
Fix FileAccess.get_open_error() flag update

### DIFF
--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -133,8 +133,8 @@ Ref<FileAccess> FileAccess::open_encrypted(const String &p_path, ModeFlags p_mod
 	Ref<FileAccessEncrypted> fae;
 	fae.instantiate();
 	Error err = fae->open_and_parse(fa, p_key, (p_mode_flags == WRITE) ? FileAccessEncrypted::MODE_WRITE_AES256 : FileAccessEncrypted::MODE_READ);
+	last_file_open_error = err;
 	if (err) {
-		last_file_open_error = err;
 		return Ref<FileAccess>();
 	}
 	return fae;
@@ -149,8 +149,8 @@ Ref<FileAccess> FileAccess::open_encrypted_pass(const String &p_path, ModeFlags 
 	Ref<FileAccessEncrypted> fae;
 	fae.instantiate();
 	Error err = fae->open_and_parse_password(fa, p_pass, (p_mode_flags == WRITE) ? FileAccessEncrypted::MODE_WRITE_AES256 : FileAccessEncrypted::MODE_READ);
+	last_file_open_error = err;
 	if (err) {
-		last_file_open_error = err;
 		return Ref<FileAccess>();
 	}
 	return fae;
@@ -161,9 +161,8 @@ Ref<FileAccess> FileAccess::open_compressed(const String &p_path, ModeFlags p_mo
 	fac.instantiate();
 	fac->configure("GCPF", (Compression::Mode)p_compress_mode);
 	Error err = fac->open_internal(p_path, p_mode_flags);
-
+	last_file_open_error = err;
 	if (err) {
-		last_file_open_error = err;
 		return Ref<FileAccess>();
 	}
 


### PR DESCRIPTION
Fixes an unreported issue I encountered where `FileAccess::open_compressed()` did not correctly update the last open error flag returned by  `FileAccess.get_open_error()`. It only updated it if `open_compressed()` failed, otherwise it would retain whatever value it previously had. `open_encrypted()` and `open_encrypted_pass()` did no have this bug, but I also changed them to update the flag always because currently they partly rely on `_open()` to update this flag as a side effect. Better make it an explicit update on both failure and success cases. This also makes all error flag update code paths look similar to `_open()` for better readability.

This code snippet will report an error even though `open_compressed()` succeeded because it also checks `get_open_error()`, as the previous failed open error flag is not correctly cleared.

``` gdscript
func test_open_compressed():
	var e = FileAccess.open("non-existent-file", FileAccess.READ)

	var file = FileAccess.open_compressed("res://temp.compressed",
		FileAccess.WRITE, FileAccess.COMPRESSION_ZSTD)
	var error = FileAccess.get_open_error()
	if file == null or error != OK:
		print("open_compressed() error: %s" % error)
	else:
		print("open_compressed() OK")
```
