### PR TITLE
Use 8×8 default grid size for TextureRegion and 2D polygon editors

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -212,7 +212,8 @@ private:
 	bool selected_from_canvas = false;
 
 	Point2 grid_offset;
-	Point2 grid_step = Point2(8, 8); // A power-of-two value works better as a default.
+	// A power-of-two value works better as a default grid size.
+	Point2 grid_step = Point2(8, 8);
 	int primary_grid_steps = 8;
 	int grid_step_multiplier = 0;
 

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -1232,7 +1232,8 @@ Vector2 Polygon2DEditor::snap_point(Vector2 p_target) const {
 
 Polygon2DEditor::Polygon2DEditor() {
 	snap_offset = EditorSettings::get_singleton()->get_project_metadata("polygon_2d_uv_editor", "snap_offset", Vector2());
-	snap_step = EditorSettings::get_singleton()->get_project_metadata("polygon_2d_uv_editor", "snap_step", Vector2(10, 10));
+	// A power-of-two value works better as a default grid size.
+	snap_step = EditorSettings::get_singleton()->get_project_metadata("polygon_2d_uv_editor", "snap_step", Vector2(8, 8));
 	use_snap = EditorSettings::get_singleton()->get_project_metadata("polygon_2d_uv_editor", "snap_enabled", false);
 	snap_show_grid = EditorSettings::get_singleton()->get_project_metadata("polygon_2d_uv_editor", "show_grid", false);
 

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -1075,7 +1075,8 @@ TextureRegionEditor::TextureRegionEditor() {
 
 	preview_tex = Ref<CanvasTexture>(memnew(CanvasTexture));
 
-	snap_step = Vector2(10, 10);
+	// A power-of-two value works better as a default grid size.
+	snap_step = Vector2(8, 8);
 	snap_separation = Vector2(0, 0);
 	snap_mode = SNAP_NONE;
 	edited_margin = -1;


### PR DESCRIPTION
Power-of-two grid sizes are more suited to most game assets.

- This closes https://github.com/godotengine/godot-proposals/issues/6331.
- Follow up to #34802.