### PR TITLE
GDScript: Fix override signature check of script inheritance

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1534,6 +1534,7 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 		// Check if the function signature matches the parent. If not it's an error since it breaks polymorphism.
 		// Not for the constructor which can vary in signature.
 		GDScriptParser::DataType base_type = parser->current_class->base_type;
+		base_type.is_meta_type = false;
 		GDScriptParser::DataType parent_return_type;
 		List<GDScriptParser::DataType> parameters_types;
 		int default_par_count = 0;

--- a/modules/gdscript/tests/scripts/analyzer/features/inheritance_signature_check_no_meta.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/inheritance_signature_check_no_meta.gd
@@ -1,0 +1,10 @@
+func test():
+	print("ok")
+
+# https://github.com/godotengine/godot/issues/71994
+class A:
+	extends RefCounted
+class B:
+	extends A
+	func duplicate():
+		pass

--- a/modules/gdscript/tests/scripts/analyzer/features/inheritance_signature_check_no_meta.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/inheritance_signature_check_no_meta.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok


### PR DESCRIPTION
Avoid treating the super class as a meta type for signature check, since it is looking at the instance level for that.

Fix #71994
