### PR TITLE
Added check for null objects in gdscript typed assign.

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1326,28 +1326,30 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						OPCODE_BREAK;
 					}
 
-					ScriptInstance *scr_inst = val_obj->get_script_instance();
-					if (!scr_inst) {
-						err_text = "Trying to assign value of type '" + val_obj->get_class_name() +
-								"' to a variable of type '" + base_type->get_path().get_file() + "'.";
-						OPCODE_BREAK;
-					}
-
-					Script *src_type = val_obj->get_script_instance()->get_script().ptr();
-					bool valid = false;
-
-					while (src_type) {
-						if (src_type == base_type) {
-							valid = true;
-							break;
+					if (val_obj) { // src is not null
+						ScriptInstance *scr_inst = val_obj->get_script_instance();
+						if (!scr_inst) {
+							err_text = "Trying to assign value of type '" + val_obj->get_class_name() +
+									"' to a variable of type '" + base_type->get_path().get_file() + "'.";
+							OPCODE_BREAK;
 						}
-						src_type = src_type->get_base_script().ptr();
-					}
 
-					if (!valid) {
-						err_text = "Trying to assign value of type '" + val_obj->get_script_instance()->get_script()->get_path().get_file() +
-								"' to a variable of type '" + base_type->get_path().get_file() + "'.";
-						OPCODE_BREAK;
+						Script *src_type = scr_inst->get_script().ptr();
+						bool valid = false;
+
+						while (src_type) {
+							if (src_type == base_type) {
+								valid = true;
+								break;
+							}
+							src_type = src_type->get_base_script().ptr();
+						}
+
+						if (!valid) {
+							err_text = "Trying to assign value of type '" + val_obj->get_script_instance()->get_script()->get_path().get_file() +
+									"' to a variable of type '" + base_type->get_path().get_file() + "'.";
+							OPCODE_BREAK;
+						}
 					}
 				}
 #endif // DEBUG_ENABLED

--- a/modules/gdscript/tests/scripts/analyzer/features/script_typed_assign_null.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/script_typed_assign_null.gd
@@ -1,0 +1,18 @@
+extends Node
+
+class LocalClass extends Node:
+	pass
+
+func test():
+	var typed: LocalClass = get_node_or_null("does_not_exist")
+	var untyped = null
+	var node_1: LocalClass = typed
+	var node_2: LocalClass = untyped
+	var node_3 = typed
+	var node_4 = untyped
+	print(typed)
+	print(untyped)
+	print(node_1)
+	print(node_2)
+	print(node_3)
+	print(node_4)

--- a/modules/gdscript/tests/scripts/analyzer/features/script_typed_assign_null.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/script_typed_assign_null.out
@@ -1,0 +1,7 @@
+GDTEST_OK
+<Object#null>
+<null>
+<Object#null>
+<null>
+<Object#null>
+<null>


### PR DESCRIPTION
Fixes a regression that made it impossible to assign `null` to a typed variable of a custom gdscript class.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
