### PR TITLE
GDScript: Fix error message for unfound type

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -731,7 +731,7 @@ GDScriptParser::DataType GDScriptAnalyzer::resolve_datatype(GDScriptParser::Type
 		}
 	}
 	if (!result.is_set()) {
-		push_error(vformat(R"("%s" was not found in the current scope.)", first), p_type);
+		push_error(vformat(R"(Could not find type "%s" in the current scope.)", first), p_type);
 		return bad_type;
 	}
 

--- a/modules/gdscript/tests/scripts/analyzer/errors/not_found_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/not_found_type.gd
@@ -1,0 +1,3 @@
+func test():
+	var foo: Foo
+	print('not ok')

--- a/modules/gdscript/tests/scripts/analyzer/errors/not_found_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/not_found_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Could not find type "Foo" in the current scope.


### PR DESCRIPTION
```
old: "Foo" was not found in the current scope.
vs
new: Could not find type "Foo" in the current scope.
```

Make the message consistent with other errors in  `resolve_datatype`, now it is more clear that a search subject is a type.

Related to #73663.