### PR TITLE
Fix Graph Node close rect default position

### DIFF
--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -342,7 +342,7 @@
 		<theme_item name="title_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Color of the title text.
 		</theme_item>
-		<theme_item name="close_h_offset" data_type="constant" type="int" default="22">
+		<theme_item name="close_h_offset" data_type="constant" type="int" default="12">
 		</theme_item>
 		<theme_item name="close_offset" data_type="constant" type="int" default="22">
 			The vertical offset of the close button.

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -720,7 +720,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("title_offset", "GraphNode", 26 * scale);
 	theme->set_constant("title_h_offset", "GraphNode", 0);
 	theme->set_constant("close_offset", "GraphNode", 22 * scale);
-	theme->set_constant("close_h_offset", "GraphNode", 22 * scale);
+	theme->set_constant("close_h_offset", "GraphNode", 12 * scale);
 	theme->set_constant("port_offset", "GraphNode", 0);
 
 	// Tree


### PR DESCRIPTION
The Graph Node has an optional close button that can be shown or hidden. When the close button is shown, it's positioned in a way where it visibly extends over the outer right edge of the node. This can be fixed by using theme overrides in the inspector, but by default, it's positioned awkwardly.

It would appear that the button is positioned so that its center aligns with the outer margin of the node when in reality, it should be the right edge of the button that's aligned with the right margin of the node.

Current default behavior:
<img width="602" alt="Graph Node" src="https://user-images.githubusercontent.com/62965063/220461550-b1cd8271-357b-4246-acf1-4b7612fc2144.png">

New behavior:
<img width="601" alt="Graph Node 2" src="https://user-images.githubusercontent.com/62965063/220461926-3e047559-e1fe-4b98-b63b-51cd6510a903.png">

This makes more sense as the default position than the current behavior. Having the close icon properly aligned means it won't have to be realigned by the user for every new node.