### PR TITLE
Fix reset_state() in TileSet

### DIFF
--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -2527,6 +2527,11 @@ void TileSet::reset_state() {
 	while (!source_ids.is_empty()) {
 		remove_source(source_ids[0]);
 	}
+
+	tile_shape = TILE_SHAPE_SQUARE;
+	tile_layout = TILE_LAYOUT_STACKED;
+	tile_offset_axis = TILE_OFFSET_AXIS_HORIZONTAL;
+	tile_size = Size2i(16, 16);
 }
 
 const Vector2i TileSetSource::INVALID_ATLAS_COORDS = Vector2i(-1, -1);

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -308,7 +308,6 @@ private:
 	TileLayout tile_layout = TILE_LAYOUT_STACKED;
 	TileOffsetAxis tile_offset_axis = TILE_OFFSET_AXIS_HORIZONTAL;
 	Size2i tile_size = Size2i(16, 16); //Size2(64, 64);
-	Vector2 tile_skew = Vector2(0, 0);
 
 	// Rendering.
 	bool uv_clipping = false;


### PR DESCRIPTION
Fixes #70847
Apparently every Resource is supposed to implement `reset_state()` like this.

Although as I mentioned in the comment, the issue wouldn't have happened if the reference to TileSet was released properly.