### PR TITLE
Fix sub-inherited scene proper node update

### DIFF
--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -120,6 +120,7 @@ public:
 		NodePath live_edit_root;
 		int history_id = 0;
 		uint64_t last_checked_version = 0;
+		HashSet<NodePath> inherited_nodes;
 	};
 
 private:
@@ -196,6 +197,8 @@ public:
 	Node *get_edited_scene_root(int p_idx = -1);
 	int get_edited_scene_count() const;
 	Vector<EditedScene> get_edited_scenes() const;
+	void update_edited_scene_inherited_nodes(int p_edited_scene);
+	void clear_edited_scene_inherited_nodes(int p_edited_scene);
 	String get_scene_title(int p_idx, bool p_always_strip_extension = false) const;
 	String get_scene_path(int p_idx) const;
 	String get_scene_type(int p_idx) const;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1743,6 +1743,24 @@ void EditorNode::_save_scene(String p_file, int idx) {
 
 	_set_scene_metadata(p_file, idx);
 
+	//tell (sub)inherited edited scenes to keep track of nodes inherited
+	//the states are still in their old versions, this allows for knowing which nodes were deleted when updating an inherited scene
+	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
+		//only update for edited scenes that has just been reloaded to avoid issues when saving more than once
+		if (editor_data.get_edited_scenes()[i].inherited_nodes.size() > 0) {
+			continue;
+		}
+		Ref<SceneState> ss = editor_data.get_edited_scene_root(i)->get_scene_inherited_state();
+		//update for edited scenes that inherit the saved scene
+		while (ss.is_valid()) {
+			if (ss->get_path() == p_file) {
+				editor_data.update_edited_scene_inherited_nodes(i);
+				break;
+			}
+			ss = ss->get_base_scene_state();
+		}
+	}
+
 	Ref<PackedScene> sdata;
 
 	if (ResourceCache::has(p_file)) {
@@ -3718,6 +3736,7 @@ bool EditorNode::is_changing_scene() const {
 }
 
 void EditorNode::set_current_scene(int p_idx) {
+	HashSet<String> checked_scenes;
 	// Save the folding in case the scene gets reloaded.
 	if (editor_data.get_scene_path(p_idx) != "" && editor_data.get_edited_scene_root(p_idx)) {
 		editor_folding.save_scene_folding(editor_data.get_edited_scene_root(p_idx), editor_data.get_scene_path(p_idx));

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -43,6 +43,7 @@ class SceneState : public RefCounted {
 	Vector<NodePath> editable_instances;
 	mutable HashMap<NodePath, int> node_path_cache;
 	mutable HashMap<int, int> base_scene_node_remap;
+	HashSet<NodePath> inherited_nodes;
 
 	int base_scene_idx = -1;
 
@@ -182,6 +183,9 @@ public:
 	bool has_connection(const NodePath &p_node_from, const StringName &p_signal, const NodePath &p_node_to, const StringName &p_method, bool p_no_inheritance = false);
 
 	Vector<NodePath> get_editable_instances() const;
+
+	void set_inherited_nodes(HashSet<NodePath> p_inherited_node_paths) { inherited_nodes = p_inherited_node_paths; }
+	HashSet<NodePath> get_inherited_nodes() const { return inherited_nodes; }
 
 	//build API
 


### PR DESCRIPTION
Fixes #7984 sub-inherited scenes aren't updating properly because of two reasons:

1. It doesn't detect a need to reload after switching to sub-inherited scenes
2. Even if it reloads, phantom nodes that were deleted in an ancestor scene still remain

The problem appears to be that somehow after saving a parent scene, the inherited state is still has old version of the parent scene which allows inherited scenes to check for changes. However, this is not the case for some reason with the ancestor scene states.

So during check_and_update_scene(), the edited scene root is packed so user changes are kept, but the editor doesn't know which nodes that are there were 'original' and which were inherited from an ancestor scene, so it just keeps all the nodes.

For it to detect changes and update properly, the packed scene needs to know which nodes are inherited. This fix adds to edited scenes a set of node paths that only needs to be updated right before an ancestor scene is saved so it knows which nodes are inherited. The set is cleared after each reload of the sub-inherited scene to signal that it's up to date.

(I suspect there is a way to make the base scene states update properly which solves the problem but haven't had time to look at it)