### PR TITLE
Fix replace_by segfault with invalid input

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2453,6 +2453,7 @@ void Node::replace_by(Node *p_node, bool p_keep_groups) {
 	List<Node *> owned = data.owned;
 	List<Node *> owned_by_owner;
 	Node *owner = (data.owner == this) ? p_node : data.owner;
+	ERR_FAIL_COND_MSG(!owner, "Invalid owner for new node or current node.");
 
 	if (p_keep_groups) {
 		List<GroupInfo> groups;

--- a/tests/scene/test_node.h
+++ b/tests/scene/test_node.h
@@ -365,8 +365,6 @@ TEST_CASE("[SceneTree][Node] Testing node operations with a more complex simple 
 	}
 
 	SUBCASE("Replaced nodes should be be removed and the replacing node added") {
-		SceneTree::get_singleton()->get_root()->remove_child(node2);
-
 		node1->replace_by(node2);
 
 		CHECK_EQ(SceneTree::get_singleton()->get_root()->get_child_count(), 1);
@@ -382,8 +380,6 @@ TEST_CASE("[SceneTree][Node] Testing node operations with a more complex simple 
 	}
 
 	SUBCASE("Replacing nodes should keep the groups of the replaced nodes") {
-		SceneTree::get_singleton()->get_root()->remove_child(node2);
-
 		node1->add_to_group("nodes");
 		node1->replace_by(node2, true);
 


### PR DESCRIPTION
Resolves a crash when opening the tps demo project headlessly and quitting.
P.S: Initialized missing member initialization.

I have properly compensated for the fix in https://github.com/godotengine/godot/pull/73725 but we should patch both as we may ingress more bad data from changes in the future :rocket: 
