### PR TITLE
Fix visible_lines calculation (reverted)

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -209,10 +209,7 @@ bool Label::_shape() {
 
 				// Fill after min_size calculation.
 
-				int visible_lines = lines_rid.size();
-				if (max_lines_visible >= 0 && visible_lines > max_lines_visible) {
-					visible_lines = max_lines_visible;
-				}
+				int visible_lines = get_visible_line_count();
 				if (autowrap_mode != TextServer::AUTOWRAP_OFF) {
 					bool lines_hidden = visible_lines > 0 && visible_lines < lines_rid.size();
 					if (lines_hidden) {


### PR DESCRIPTION
If some wrapped lines are hidden then the last visible wrapped line must have enforced ellipsis. Recent changes to label.cpp broke this behaviour. 
