### PR TITLE
Fix `SpriteFrames` data loss on 3-to-4 conversion

### DIFF
--- a/doc/classes/SpriteFrames.xml
+++ b/doc/classes/SpriteFrames.xml
@@ -73,9 +73,9 @@
 			<description>
 				Returns a relative duration of the frame [param idx] in the [param anim] animation (defaults to [code]1.0[/code]). For example, a frame with a duration of [code]2.0[/code] is displayed twice as long as a frame with a duration of [code]1.0[/code]. You can calculate the absolute duration (in seconds) of a frame using the following formula:
 				[codeblock]
-				absolute_duration = relative_duration / (animation_fps * abs(speed_scale))
+				absolute_duration = relative_duration / (animation_fps * abs(playing_speed))
 				[/codeblock]
-				In this example, [code]speed_scale[/code] refers to either [member AnimatedSprite2D.speed_scale] or [member AnimatedSprite3D.speed_scale].
+				In this example, [code]playing_speed[/code] refers to either [method AnimatedSprite2D.get_playing_speed] or [method AnimatedSprite3D.get_playing_speed].
 			</description>
 		</method>
 		<method name="get_frame_texture" qualifiers="const">

--- a/editor/renames_map_3_to_4.cpp
+++ b/editor/renames_map_3_to_4.cpp
@@ -1174,7 +1174,7 @@ const char *RenamesMap3To4::gdscript_properties_renames[][2] = {
 	{ "unit_db", "volume_db" }, // AudioStreamPlayer3D
 	{ "unit_offset", "progress_ratio" }, // PathFollow2D, PathFollow3D
 	{ "vseparation", "v_separation" }, // Theme
-	{ "frames", "sprite_frames" }, // AnimatedSprite2D, AnimatedSprite3D
+	// { "frames", "sprite_frames" }, // AnimatedSprite2D, AnimatedSprite3D -- GH-73696
 
 	{ nullptr, nullptr },
 };

--- a/scene/resources/sprite_frames.cpp
+++ b/scene/resources/sprite_frames.cpp
@@ -201,6 +201,7 @@ void SpriteFrames::_set_animations(const Array &p_animations) {
 		anim.loop = d["loop"];
 		Array frames = d["frames"];
 		for (int j = 0; j < frames.size(); j++) {
+#ifndef DISABLE_DEPRECATED
 			// For compatibility.
 			Ref<Resource> res = frames[j];
 			if (res.is_valid()) {
@@ -208,6 +209,7 @@ void SpriteFrames::_set_animations(const Array &p_animations) {
 				anim.frames.push_back(frame);
 				continue;
 			}
+#endif
 
 			Dictionary f = frames[j];
 


### PR DESCRIPTION
This error is caused by `frames` being renamed to `sprite_frames` not only for the node property, but also in the dictionary above.

```
[sub_resource type="SpriteFrames" id=4]
animations = [ {
"frames": [ SubResource( 1 ), SubResource( 2 ), SubResource( 3 ) ],
"loop": true,
"name": "default",
"speed": 5.0
} ]

[node name="AnimatedSprite" type="AnimatedSprite"]
frames = SubResource( 4 )
```

This line in `renames_map_3_to_4.cpp` is not needed as there is the following compatibility code:

https://github.com/godotengine/godot/blob/e13fae1414b0369fdd3f51b4e3529fd3f272b0e1/scene/2d/animated_sprite_2d.cpp#L574-L582

https://github.com/godotengine/godot/blob/e13fae1414b0369fdd3f51b4e3529fd3f272b0e1/scene/3d/sprite_3d.cpp#L1359-L1367

Closes #73696.