### PR TITLE
[Input] Use BRACKET_ instead of BRACE_ for physical keys.

### DIFF
--- a/platform/linuxbsd/x11/key_mapping_x11.cpp
+++ b/platform/linuxbsd/x11/key_mapping_x11.cpp
@@ -217,8 +217,8 @@ void KeyMappingX11::initialize() {
 	scancode_map[0x1F] = Key::I;
 	scancode_map[0x20] = Key::O;
 	scancode_map[0x21] = Key::P;
-	scancode_map[0x22] = Key::BRACELEFT;
-	scancode_map[0x23] = Key::BRACERIGHT;
+	scancode_map[0x22] = Key::BRACKETLEFT;
+	scancode_map[0x23] = Key::BRACKETRIGHT;
 	scancode_map[0x24] = Key::ENTER;
 	scancode_map[0x25] = Key::CTRL;
 	scancode_map[0x26] = Key::A;

--- a/platform/macos/key_mapping_macos.mm
+++ b/platform/macos/key_mapping_macos.mm
@@ -98,10 +98,10 @@ void KeyMappingMacOS::initialize() {
 	keysym_map[0x1b] = Key::MINUS;
 	keysym_map[0x1c] = Key::KEY_8;
 	keysym_map[0x1d] = Key::KEY_0;
-	keysym_map[0x1e] = Key::BRACERIGHT;
+	keysym_map[0x1e] = Key::BRACKETRIGHT;
 	keysym_map[0x1f] = Key::O;
 	keysym_map[0x20] = Key::U;
-	keysym_map[0x21] = Key::BRACELEFT;
+	keysym_map[0x21] = Key::BRACKETLEFT;
 	keysym_map[0x22] = Key::I;
 	keysym_map[0x23] = Key::P;
 	keysym_map[0x24] = Key::ENTER;

--- a/platform/windows/key_mapping_windows.cpp
+++ b/platform/windows/key_mapping_windows.cpp
@@ -257,8 +257,8 @@ void KeyMappingWindows::initialize() {
 	scansym_map[0x17] = Key::I;
 	scansym_map[0x18] = Key::O;
 	scansym_map[0x19] = Key::P;
-	scansym_map[0x1A] = Key::BRACELEFT;
-	scansym_map[0x1B] = Key::BRACERIGHT;
+	scansym_map[0x1A] = Key::BRACKETLEFT;
+	scansym_map[0x1B] = Key::BRACKETRIGHT;
 	scansym_map[0x1C] = Key::ENTER;
 	scansym_map[0x1D] = Key::CTRL;
 	scansym_map[0x1E] = Key::A;


### PR DESCRIPTION
Use `BRACKET_LEFT`/`BRACKET_RIGHT` as a physical keycode for the `[{`, `}]` keys.