### PR TITLE
Web Editor: Only show Compatibility renderer in Project Manager

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -746,7 +746,14 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// TRANSLATORS: Project Manager here refers to the tool used to create/manage Godot projects.
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "project_manager/sorting_order", 0, "Last Edited,Name,Path")
+
+#if defined(WEB_ENABLED)
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_NONE, "project_manager/default_renderer", "gl_compatibility", "gl_compatibility")
+#elif defined(ANDROID_ENABLED) || defined(IOS_ENABLED)
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_NONE, "project_manager/default_renderer", "mobile", "forward_plus,mobile,gl_compatibility")
+#else
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_NONE, "project_manager/default_renderer", "forward_plus", "forward_plus,mobile,gl_compatibility")
+#endif
 
 	if (p_extra_config.is_valid()) {
 		if (p_extra_config->has_section("init_projects") && p_extra_config->has_section_key("init_projects", "list")) {

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -908,7 +908,9 @@ public:
 			default_renderer_type = EditorSettings::get_singleton()->get_setting("project_manager/default_renderer");
 		}
 
-		Button *rs_button = memnew(CheckBox);
+		Button *rs_button = nullptr;
+#ifndef WEB_ENABLED
+		rs_button = memnew(CheckBox);
 		rs_button->set_button_group(renderer_button_group);
 		rs_button->set_text(TTR("Forward+"));
 		rs_button->set_meta(SNAME("rendering_method"), "forward_plus");
@@ -927,6 +929,7 @@ public:
 		if (default_renderer_type == "mobile") {
 			rs_button->set_pressed(true);
 		}
+#endif
 
 		rs_button = memnew(CheckBox);
 		rs_button->set_button_group(renderer_button_group);


### PR DESCRIPTION
Also default to `mobile` renderer for the Android editor (and iOS for good measure, even though there's no iOS editor build for now).

Should look like this (testing on Linux by temporarily inverting the condition, didn't test a Web build):
![image](https://user-images.githubusercontent.com/4701338/220634695-90716b80-ec13-43f8-8de0-cc3845e77554.png)