### PR TITLE
Fix ownership bug on ancestor nodes when scene is reimported

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -832,6 +832,8 @@ public:
 		// Used if the original parent node is lost
 		Transform2D transform_2d;
 		Transform3D transform_3d;
+		// Used to keep track of the ownership of all ancestor nodes so they can be restored later.
+		HashMap<Node *, Node *> ownership_table;
 	};
 
 	struct ConnectionWithNodePath {
@@ -845,6 +847,8 @@ public:
 		List<Connection> connections_from;
 		List<Node::GroupInfo> groups;
 	};
+
+	void update_ownership_table_for_addition_node_ancestors(Node *p_current_node, HashMap<Node *, Node *> &p_ownership_table);
 
 	void update_diff_data_for_node(
 			Node *p_edited_scene,


### PR DESCRIPTION
Fixes an edge case where the ancestors of nodes added as additional ancestors to scenes which get reimported would lose their ownership. For example, if you brought in a model with a skeleton, turned on Editable Children for it, added a BoneAttachment3D to its skeleton, then added a child to that BoneAttachment3D, that node would become unselectable if the initial model was updated. This was caused by oversight considering the fact that the ownership of all nodes becomes null once they leave the scene tree. This PR fixes it by maintaining a HashMap for every node classified as an 'AdditionNode' on update which trackers the owners for its ancestors, and then using this to restore the ownership once these nodes have been added back to the scene tree. It will also account for situation where the owner is the node being replaced in the process (for example, if the current edited scene is inheriting the model we are reimporting.)

Closes #72264