### PR TITLE
Add a Linux ThreadSanitizer job to CI

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -9,6 +9,7 @@ env:
   SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
+  TSAN_OPTIONS: suppressions=misc/error_suppressions/tsan.txt
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-linux
@@ -54,6 +55,16 @@ jobs:
             target: editor
             tests: true
             sconsflags: dev_build=yes use_asan=yes use_ubsan=yes use_llvm=yes linker=lld
+            bin: "./bin/godot.linuxbsd.editor.dev.x86_64.llvm.san"
+            build-mono: false
+            # Skip 2GiB artifact speeding up action.
+            artifact: false
+
+          - name: Editor with ThreadSanitizer (target=editor, tests=yes, dev_build=yes, use_tsan=yes, use_llvm=yes, linker=lld)
+            cache-name: linux-editor-thread-sanitizer
+            target: editor
+            tests: true
+            sconsflags: dev_build=yes use_tsan=yes use_llvm=yes linker=lld
             bin: "./bin/godot.linuxbsd.editor.dev.x86_64.llvm.san"
             build-mono: false
             # Skip 2GiB artifact speeding up action.

--- a/misc/error_suppressions/tsan.txt
+++ b/misc/error_suppressions/tsan.txt
@@ -1,0 +1,7 @@
+# See the below link for an explanation of this file's format
+# https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+
+deadlock:tests/core/templates/test_command_queue.h
+deadlock:modules/text_server_adv/text_server_adv.cpp
+deadlock:modules/text_server_fb/text_server_fb.cpp
+


### PR DESCRIPTION
Having ThreadSanitizer enabled in CI allows it to automatically catch many types of race conditions (specifically, data races, where a variable is accessed by two threads at the same time). [Since Godot is moving to a fully threaded model](https://twitter.com/reduzio/status/1623253494021988353), this is basically a requirement for stable behavior.

Some errors have been suppressed for now. See the diff for details.