### PR TITLE
[3.x] iOS: Implement missing gamepad.buttonOptions, buttonMenu, and buttonHome joy buttons

### DIFF
--- a/platform/iphone/joypad_iphone.mm
+++ b/platform/iphone/joypad_iphone.mm
@@ -309,6 +309,23 @@ void JoypadIPhone::start_processing() {
 				float value = gamepad.rightTrigger.value;
 				OSIPhone::get_singleton()->joy_axis(joy_id, JOY_ANALOG_R2, value);
 			}
+
+			if (@available(iOS 13, *)) {
+				if (element == gamepad.buttonOptions) {
+					OSIPhone::get_singleton()->joy_button(joy_id, JOY_BUTTON_10,
+							gamepad.buttonOptions.isPressed);
+				} else if (element == gamepad.buttonMenu) {
+					OSIPhone::get_singleton()->joy_button(joy_id, JOY_BUTTON_11,
+							gamepad.buttonMenu.isPressed);
+				}
+			}
+
+			if (@available(iOS 14, *)) {
+				if (element == gamepad.buttonHome) {
+					OSIPhone::get_singleton()->joy_button(joy_id, JOY_GUIDE,
+							gamepad.buttonHome.isPressed);
+				}
+			}
 		};
 	} else if (controller.microGamepad != nil) {
 		// micro gamepads were added in OS 9 and feature just 2 buttons and a d-pad


### PR DESCRIPTION
This fixes https://github.com/godotengine/godot/issues/73305 for 3.x branch.

The mapping of the iOS gamepad buttons `gamepad.buttonOptions`, `gamepad.buttonMenu`, and `gamepad.buttonHome`  to Godot's `JOY_BUTTON_10`, `JOY_BUTTON_11`, and `JOY_GUIDE` joy buttons is consistent with the existing behaviour of the macOS version of Godot 3.x.

Tested on iPad Mini (iOS 15.6.1) with Xbox Wireless Controller. Test with another controller and/or iOS device is recommended.

*Bugsquad edit:* `3.x` version of #73462