### PR TITLE
GDScript: Fix usage of enum value as range argument

### DIFF
--- a/modules/gdscript/tests/scripts/analyzer/features/enums_in_range_call.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/enums_in_range_call.gd
@@ -1,0 +1,9 @@
+enum E { E0 = 0, E3 = 3 }
+
+func test():
+	var total := 0
+	for value in range(E.E0, E.E3):
+		var inferable := value
+		total += inferable
+	assert(total == 0 + 1 + 2)
+	print('ok')

--- a/modules/gdscript/tests/scripts/analyzer/features/enums_in_range_call.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/enums_in_range_call.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok


### PR DESCRIPTION
Look at a type of a reduced value, not at a type of a constant. Solves two things: 
- Allows enum values.
- Validates constants with a declared type of Variant, before they were skipped.

Closes #73779.