### PR TITLE
import: Pass the correct defaults to generated collision shapes.

### DIFF
--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -410,6 +410,8 @@ Vector<Ref<Shape3D>> ResourceImporterScene::get_collision_shapes(const Ref<Mesh>
 		box.instantiate();
 		if (p_options.has(SNAME("primitive/size"))) {
 			box->set_size(p_options[SNAME("primitive/size")].operator Vector3() * p_applied_root_scale);
+		} else {
+			box->set_size(Vector3(2, 2, 2) * p_applied_root_scale);
 		}
 
 		Vector<Ref<Shape3D>> shapes;
@@ -421,6 +423,8 @@ Vector<Ref<Shape3D>> ResourceImporterScene::get_collision_shapes(const Ref<Mesh>
 		sphere.instantiate();
 		if (p_options.has(SNAME("primitive/radius"))) {
 			sphere->set_radius(p_options[SNAME("primitive/radius")].operator float() * p_applied_root_scale);
+		} else {
+			sphere->set_radius(1.0f * p_applied_root_scale);
 		}
 
 		Vector<Ref<Shape3D>> shapes;
@@ -431,9 +435,13 @@ Vector<Ref<Shape3D>> ResourceImporterScene::get_collision_shapes(const Ref<Mesh>
 		cylinder.instantiate();
 		if (p_options.has(SNAME("primitive/height"))) {
 			cylinder->set_height(p_options[SNAME("primitive/height")].operator float() * p_applied_root_scale);
+		} else {
+			cylinder->set_height(1.0f * p_applied_root_scale);
 		}
 		if (p_options.has(SNAME("primitive/radius"))) {
 			cylinder->set_radius(p_options[SNAME("primitive/radius")].operator float() * p_applied_root_scale);
+		} else {
+			cylinder->set_radius(1.0f * p_applied_root_scale);
 		}
 
 		Vector<Ref<Shape3D>> shapes;
@@ -444,9 +452,13 @@ Vector<Ref<Shape3D>> ResourceImporterScene::get_collision_shapes(const Ref<Mesh>
 		capsule.instantiate();
 		if (p_options.has(SNAME("primitive/height"))) {
 			capsule->set_height(p_options[SNAME("primitive/height")].operator float() * p_applied_root_scale);
+		} else {
+			capsule->set_height(1.0f * p_applied_root_scale);
 		}
 		if (p_options.has(SNAME("primitive/radius"))) {
 			capsule->set_radius(p_options[SNAME("primitive/radius")].operator float() * p_applied_root_scale);
+		} else {
+			capsule->set_radius(1.0f * p_applied_root_scale);
 		}
 
 		Vector<Ref<Shape3D>> shapes;


### PR DESCRIPTION
Solves incorrect defaults, as well as applied scale failing to apply.
The default values are removed, and they differ from collision shape defaults.
These values must match the defaults defined in resource_importer_scene.cpp

Fixes #54079
Fixes #58289
Solves some problems related to size and position reported in #73548, but not the other issues with area and navmesh.