### PR TITLE
GDScript: Fix parsing unexpected break/continue in lambda

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3138,6 +3138,14 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_lambda(ExpressionNode *p_p
 	bool previous_in_lambda = in_lambda;
 	in_lambda = true;
 
+	// Save break/continue state.
+	bool could_break = can_break;
+	bool could_continue = can_continue;
+
+	// Disallow break/continue.
+	can_break = false;
+	can_continue = false;
+
 	function->body = parse_suite("lambda declaration", body, true);
 	complete_extents(function);
 	complete_extents(lambda);
@@ -3155,6 +3163,11 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_lambda(ExpressionNode *p_p
 	current_function = previous_function;
 	in_lambda = previous_in_lambda;
 	lambda->function = function;
+
+	// Reset break/continue state.
+	can_break = could_break;
+	can_continue = could_continue;
+
 	return lambda;
 }
 

--- a/modules/gdscript/tests/scripts/parser/errors/bad_continue_in_lambda.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/bad_continue_in_lambda.gd
@@ -1,0 +1,5 @@
+func test():
+	for index in range(0, 1):
+		var lambda := func():
+			continue
+	print('not ok')

--- a/modules/gdscript/tests/scripts/parser/errors/bad_continue_in_lambda.out
+++ b/modules/gdscript/tests/scripts/parser/errors/bad_continue_in_lambda.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Cannot use "continue" outside of a loop.

--- a/modules/gdscript/tests/scripts/parser/features/good_continue_in_lambda.gd
+++ b/modules/gdscript/tests/scripts/parser/features/good_continue_in_lambda.gd
@@ -1,0 +1,13 @@
+func test():
+	var i_string := ''
+	for i in 3:
+		if i == 1: continue
+		var lambda := func():
+			var j_string := ''
+			for j in 3:
+				if j == 1: continue
+				j_string += str(j)
+			return j_string
+		i_string += lambda.call()
+	assert(i_string == '0202')
+	print('ok')

--- a/modules/gdscript/tests/scripts/parser/features/good_continue_in_lambda.out
+++ b/modules/gdscript/tests/scripts/parser/features/good_continue_in_lambda.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok


### PR DESCRIPTION
```gdscript
for index in range(0, 1):
  var lambda := func():
    continue # no longer a crash, just an error
```

Closes #73795.