### PR TITLE
Fix WebSocketMultiplayerPeer server crash when a client tries to connect.

### DIFF
--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -340,6 +340,7 @@ void WebSocketMultiplayerPeer::_poll_server() {
 					to_remove.insert(id);
 					continue;
 				}
+				peer.connection = tls;
 			}
 			Ref<StreamPeerTLS> tls = static_cast<Ref<StreamPeerTLS>>(peer.connection);
 			tls->poll();


### PR DESCRIPTION
Fixes #73810
I believe this one line change resolves the problem.

I get no problems after the change.