### PR TITLE
[Editor] Enable multithread processing for the editor log.

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -389,6 +389,7 @@ EditorLog::EditorLog() {
 
 	// Log - Rich Text Label.
 	log = memnew(RichTextLabel);
+	log->set_threaded(true);
 	log->set_use_bbcode(true);
 	log->set_scroll_follow(true);
 	log->set_selection_enabled(true);


### PR DESCRIPTION
Should improve editor responsiveness when large amount of messages are printed in the rapid succession.