### PR TITLE
Enable non mono builds for linux binaries

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -21,6 +21,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: Editor (target=editor)
+            cache-name: linux-editor
+            target: editor
+            tests: false # Disabled due freeze caused by mix Mono build and CI
+            sconsflags: module_mono_enabled=no
+            doc-test: true
+            bin: "./bin/godot.linuxbsd.editor.x86_64.mono"
+            build-mono: false
+            proj-conv: true
+            artifact: true
+
           - name: Editor w/ Mono (target=editor)
             cache-name: linux-editor-mono
             target: editor
@@ -62,6 +73,14 @@ jobs:
             target: template_release
             tests: false
             sconsflags: module_mono_enabled=yes
+            build-mono: false
+            artifact: true
+
+          - name: Template (target=template_release)
+            cache-name: linux-template
+            target: template_release
+            tests: false
+            sconsflags: module_mono_enabled=no
             build-mono: false
             artifact: true
 


### PR DESCRIPTION
### Why:
- This allows you to use github actions run on a machine without mono/net framework
- It means another repository can ingest the non mono binaries from godotengine/godot

### Why I am changing it back:
- I am making a CICD reproduction project and the mono runtimes do not work correctly on github runners, which a lot of FOSS games will use. Example TPS demo.

Example of why this is needed:

Another repository can re-use our built binaries!
```yaml
      - name: Download editor artifact
        uses: dawidd6/action-download-artifact@v2
        with:
          workflow: ${{ matrix.workflow }}
          workflow_conclusion: success
          name: linux-editor
          repo: godotengine/godot

      - name: Download export template artifact
        uses: dawidd6/action-download-artifact@v2
        with:
          workflow: ${{ matrix.workflow }}
          workflow_conclusion: success
          name: linux-templates-release
          repo: godotengine/godot
```

This is sponsored by the mirror, we are making a reproduction test project which can be found here:
https://github.com/the-mirror-megaverse/Minimal-Reproduction-Project-CICD-Exports