### PR TITLE
Export: Default to exporting S3TC + BPTC for PC platforms

### DIFF
--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -59,11 +59,10 @@ void EditorExportPlatformPC::get_export_options(List<ExportOption> *r_options) {
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "binary_format/embed_pck"), false));
 
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/bptc"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/bptc"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/s3tc"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/etc"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/etc2"), false));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/no_bptc_fallbacks"), true));
 }
 
 String EditorExportPlatformPC::get_name() const {
@@ -242,11 +241,6 @@ void EditorExportPlatformPC::get_platform_features(List<String> *r_features) con
 }
 
 void EditorExportPlatformPC::resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) {
-	if (p_features.has("bptc")) {
-		if (p_preset->has("texture_format/no_bptc_fallbacks")) {
-			p_features.erase("s3tc");
-		}
-	}
 }
 
 int EditorExportPlatformPC::get_chmod_flags() const {


### PR DESCRIPTION
This is now required after #72031 when using HDRs.

Could have further cleanup as I think these import options may not be needed at all anymore, and etc/etc2 support doesn't seem to make much sense. Likewise, the hardcoded "s3tc" in `get_platform_features` could maybe be removed. But this is material for after 4.1.

Fixes #73789.