### PR TITLE
Fix GridMap 'cell_size_changed' signal not disconnecting properly

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -913,7 +913,7 @@ void GridMapEditor::update_palette() {
 }
 
 void GridMapEditor::edit(GridMap *p_gridmap) {
-	if (!p_gridmap && node) {
+	if (node) {
 		node->disconnect("cell_size_changed", callable_mp(this, &GridMapEditor::_draw_grids));
 	}
 


### PR DESCRIPTION
Fixes that a GridMap node would not disconnect from the '`cell_size_changed`' signal when the new selected node is another valid GridMap.

Fixes https://github.com/godotengine/godot/issues/73695

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
