### PR TITLE
Fix editor resource preview deadlocking with --headless mode

### DIFF
--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -424,8 +424,10 @@ void EditorResourcePreview::check_for_invalidation(const String &p_path) {
 }
 
 void EditorResourcePreview::start() {
-	ERR_FAIL_COND_MSG(thread.is_started(), "Thread already started.");
-	thread.start(_thread_func, this);
+	if (DisplayServer::get_singleton()->get_name() != "headless") {
+		ERR_FAIL_COND_MSG(thread.is_started(), "Thread already started.");
+		thread.start(_thread_func, this);
+	}
 }
 
 void EditorResourcePreview::stop() {


### PR DESCRIPTION
Added & Implemented:
- OS::get_current_rendering_is_headless() for when NULL_DISPLAY_DRIVER is used
- EditorResourcePreview now checks the value I added to OS. This means it wont start its thread unless it is non headless.

How to reproduce the bug I had:
```./godot.editor.bin --headless --editor --quit --path C:\Users\<yourusername>\Projects\tps-demo```

I debugged for a few hours:
- the icon generation fails when you are using headless mode because it relies upon using some hooks in the renderer that weren't available with headless, so the engine would not close and it would never exit.


Kindly sponsored by The Mirror