### PR TITLE
GDScript: Fix range regression

### DIFF
--- a/modules/gdscript/tests/scripts/analyzer/features/for_range_usage.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/for_range_usage.gd
@@ -1,0 +1,7 @@
+func test():
+	var array := [3, 6, 9]
+	var result := ''
+	for i in range(array.size(), 0, -1):
+		result += str(array[i - 1])
+	assert(result == '963')
+	print('ok')

--- a/modules/gdscript/tests/scripts/analyzer/features/for_range_usage.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/for_range_usage.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok


### PR DESCRIPTION
Fixes regression from #73796: arguments still need to be reduced even if some of them are not constants.

There were no tests with `for x in range(non_const_arg)`, added one with snippet from the issue.

Mark variant and weak variables as unsafe. Downgrade weak variables if their inferred type is not int/float.

Closes #73837.