### PR TITLE
Fix ShapeCast3D add and remove exception functions

### DIFF
--- a/doc/classes/ShapeCast3D.xml
+++ b/doc/classes/ShapeCast3D.xml
@@ -14,7 +14,7 @@
 	<methods>
 		<method name="add_exception">
 			<return type="void" />
-			<param index="0" name="node" type="Object" />
+			<param index="0" name="node" type="CollisionObject3D" />
 			<description>
 				Adds a collision exception so the shape does not report collisions with the specified [CollisionObject3D] node.
 			</description>
@@ -108,7 +108,7 @@
 		</method>
 		<method name="remove_exception">
 			<return type="void" />
-			<param index="0" name="node" type="Object" />
+			<param index="0" name="node" type="CollisionObject3D" />
 			<description>
 				Removes a collision exception so the shape does report collisions with the specified [CollisionObject3D] node.
 			</description>

--- a/scene/3d/shape_cast_3d.cpp
+++ b/scene/3d/shape_cast_3d.cpp
@@ -437,26 +437,18 @@ void ShapeCast3D::add_exception_rid(const RID &p_rid) {
 	exclude.insert(p_rid);
 }
 
-void ShapeCast3D::add_exception(const Object *p_object) {
-	ERR_FAIL_NULL(p_object);
-	const CollisionObject3D *co = Object::cast_to<CollisionObject3D>(p_object);
-	if (!co) {
-		return;
-	}
-	add_exception_rid(co->get_rid());
+void ShapeCast3D::add_exception(const CollisionObject3D *p_node) {
+	ERR_FAIL_NULL_MSG(p_node, "The passed Node must be an instance of CollisionObject3D.");
+	add_exception_rid(p_node->get_rid());
 }
 
 void ShapeCast3D::remove_exception_rid(const RID &p_rid) {
 	exclude.erase(p_rid);
 }
 
-void ShapeCast3D::remove_exception(const Object *p_object) {
-	ERR_FAIL_NULL(p_object);
-	const CollisionObject3D *co = Object::cast_to<CollisionObject3D>(p_object);
-	if (!co) {
-		return;
-	}
-	remove_exception_rid(co->get_rid());
+void ShapeCast3D::remove_exception(const CollisionObject3D *p_node) {
+	ERR_FAIL_NULL_MSG(p_node, "The passed Node must be an instance of CollisionObject3D.");
+	remove_exception_rid(p_node->get_rid());
 }
 
 void ShapeCast3D::clear_exceptions() {

--- a/scene/3d/shape_cast_3d.h
+++ b/scene/3d/shape_cast_3d.h
@@ -34,6 +34,8 @@
 #include "scene/3d/node_3d.h"
 #include "scene/resources/shape_3d.h"
 
+class CollisionObject3D;
+
 class ShapeCast3D : public Node3D {
 	GDCLASS(ShapeCast3D, Node3D);
 
@@ -133,9 +135,9 @@ public:
 	bool is_colliding() const;
 
 	void add_exception_rid(const RID &p_rid);
-	void add_exception(const Object *p_object);
+	void add_exception(const CollisionObject3D *p_node);
 	void remove_exception_rid(const RID &p_rid);
-	void remove_exception(const Object *p_object);
+	void remove_exception(const CollisionObject3D *p_node);
 	void clear_exceptions();
 
 	virtual PackedStringArray get_configuration_warnings() const override;


### PR DESCRIPTION
Fixes that `ShapeCast3D` would accept any parameter object and silently return when it was not a `CollisionObject3D`.

Someone really did not like ShapeCast3D cause all similar objects with exception functions like RayCast2D/3D or QueryParameters2D/3D were updated, even the ShapeCast3D documentation was already updated to mention the CollisionObject3D requirement. Related to https://github.com/godotengine/godot/issues/27282 that prompted me to check all those raycasters with exceptions cause with silent error users try to add unsupported nodes.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
