### PR TITLE
[3.x] Add error messages for collision exception functions

### DIFF
--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -256,9 +256,7 @@ void RayCast2D::add_exception_rid(const RID &p_rid) {
 void RayCast2D::add_exception(const Object *p_object) {
 	ERR_FAIL_NULL(p_object);
 	const CollisionObject2D *co = Object::cast_to<CollisionObject2D>(p_object);
-	if (!co) {
-		return;
-	}
+	ERR_FAIL_COND_MSG(!co, "The passed Node must be an instance of CollisionObject2D.");
 	add_exception_rid(co->get_rid());
 }
 
@@ -269,9 +267,7 @@ void RayCast2D::remove_exception_rid(const RID &p_rid) {
 void RayCast2D::remove_exception(const Object *p_object) {
 	ERR_FAIL_NULL(p_object);
 	const CollisionObject2D *co = Object::cast_to<CollisionObject2D>(p_object);
-	if (!co) {
-		return;
-	}
+	ERR_FAIL_COND_MSG(!co, "The passed Node must be an instance of CollisionObject2D.");
 	remove_exception_rid(co->get_rid());
 }
 

--- a/scene/2d/shape_cast_2d.cpp
+++ b/scene/2d/shape_cast_2d.cpp
@@ -323,9 +323,7 @@ void ShapeCast2D::add_exception_rid(const RID &p_rid) {
 void ShapeCast2D::add_exception(const Object *p_object) {
 	ERR_FAIL_NULL(p_object);
 	const CollisionObject2D *co = Object::cast_to<CollisionObject2D>(p_object);
-	if (!co) {
-		return;
-	}
+	ERR_FAIL_COND_MSG(!co, "The passed Node must be an instance of CollisionObject2D.");
 	add_exception_rid(co->get_rid());
 }
 
@@ -336,9 +334,7 @@ void ShapeCast2D::remove_exception_rid(const RID &p_rid) {
 void ShapeCast2D::remove_exception(const Object *p_object) {
 	ERR_FAIL_NULL(p_object);
 	const CollisionObject2D *co = Object::cast_to<CollisionObject2D>(p_object);
-	if (!co) {
-		return;
-	}
+	ERR_FAIL_COND_MSG(!co, "The passed Node must be an instance of CollisionObject2D.");
 	remove_exception_rid(co->get_rid());
 }
 

--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -797,9 +797,7 @@ void ClippedCamera::add_exception_rid(const RID &p_rid) {
 void ClippedCamera::add_exception(const Object *p_object) {
 	ERR_FAIL_NULL(p_object);
 	const CollisionObject *co = Object::cast_to<CollisionObject>(p_object);
-	if (!co) {
-		return;
-	}
+	ERR_FAIL_COND_MSG(!co, "The passed Node must be an instance of CollisionObject.");
 	add_exception_rid(co->get_rid());
 }
 
@@ -810,9 +808,7 @@ void ClippedCamera::remove_exception_rid(const RID &p_rid) {
 void ClippedCamera::remove_exception(const Object *p_object) {
 	ERR_FAIL_NULL(p_object);
 	const CollisionObject *co = Object::cast_to<CollisionObject>(p_object);
-	if (!co) {
-		return;
-	}
+	ERR_FAIL_COND_MSG(!co, "The passed Node must be an instance of CollisionObject.");
 	remove_exception_rid(co->get_rid());
 }
 

--- a/scene/3d/ray_cast.cpp
+++ b/scene/3d/ray_cast.cpp
@@ -235,9 +235,7 @@ void RayCast::add_exception_rid(const RID &p_rid) {
 void RayCast::add_exception(const Object *p_object) {
 	ERR_FAIL_NULL(p_object);
 	const CollisionObject *co = Object::cast_to<CollisionObject>(p_object);
-	if (!co) {
-		return;
-	}
+	ERR_FAIL_COND_MSG(!co, "The passed Node must be an instance of CollisionObject.");
 	add_exception_rid(co->get_rid());
 }
 
@@ -248,9 +246,7 @@ void RayCast::remove_exception_rid(const RID &p_rid) {
 void RayCast::remove_exception(const Object *p_object) {
 	ERR_FAIL_NULL(p_object);
 	const CollisionObject *co = Object::cast_to<CollisionObject>(p_object);
-	if (!co) {
-		return;
-	}
+	ERR_FAIL_COND_MSG(!co, "The passed Node must be an instance of CollisionObject.");
 	remove_exception_rid(co->get_rid());
 }
 

--- a/scene/3d/shape_cast.cpp
+++ b/scene/3d/shape_cast.cpp
@@ -427,9 +427,7 @@ void ShapeCast::add_exception_rid(const RID &p_rid) {
 void ShapeCast::add_exception(const Object *p_object) {
 	ERR_FAIL_NULL(p_object);
 	const CollisionObject *co = Object::cast_to<CollisionObject>(p_object);
-	if (!co) {
-		return;
-	}
+	ERR_FAIL_COND_MSG(!co, "The passed Node must be an instance of CollisionObject.");
 	add_exception_rid(co->get_rid());
 }
 
@@ -440,9 +438,7 @@ void ShapeCast::remove_exception_rid(const RID &p_rid) {
 void ShapeCast::remove_exception(const Object *p_object) {
 	ERR_FAIL_NULL(p_object);
 	const CollisionObject *co = Object::cast_to<CollisionObject>(p_object);
-	if (!co) {
-		return;
-	}
+	ERR_FAIL_COND_MSG(!co, "The passed Node must be an instance of CollisionObject.");
 	remove_exception_rid(co->get_rid());
 }
 


### PR DESCRIPTION
Adds error messages to collision exception functions when used with the wrong object/node instead of failing silently.

Related issues #27282 and #17090.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
