### PR TITLE
Fix settings not appearing for Animation Libraries in the Scene Import window

### DIFF
--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -594,6 +594,9 @@ void SceneImportSettings::open_settings(const String &p_path, bool p_for_animati
 	// Visibility
 	data_mode->set_tab_hidden(1, p_for_animation);
 	data_mode->set_tab_hidden(2, p_for_animation);
+	if (p_for_animation) {
+		data_mode->set_current_tab(0);
+	}
 
 	action_menu->get_popup()->set_item_disabled(action_menu->get_popup()->get_item_id(ACTION_EXTRACT_MATERIALS), p_for_animation);
 	action_menu->get_popup()->set_item_disabled(action_menu->get_popup()->get_item_id(ACTION_CHOOSE_MESH_SAVE_PATHS), p_for_animation);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes https://github.com/godotengine/godot/issues/73849

![Before (Video)](https://user-images.githubusercontent.com/32441086/221078068-dc575ed2-770f-4823-b3ec-55165aa4371d.webm)

After:
![After (Video)](https://user-images.githubusercontent.com/32441086/221078013-841997ad-9acb-4ea6-8648-9d83726cc5c2.webm)
