### PR TITLE
More class reference fixes

### DIFF
--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -181,7 +181,7 @@
 			<return type="Color" />
 			<param index="0" name="rgbe" type="int" />
 			<description>
-				Encodes a [Color] from a RGBE9995 format integer. See [constant Image.FORMAT_RGBE9995].
+				Decodes a [Color] from a RGBE9995 format integer. See [constant Image.FORMAT_RGBE9995].
 			</description>
 		</method>
 		<method name="from_string" qualifiers="static">

--- a/doc/classes/LightmapGI.xml
+++ b/doc/classes/LightmapGI.xml
@@ -9,7 +9,7 @@
 		[b]Performance:[/b] [LightmapGI] provides the best possible run-time performance for global illumination. It is suitable for low-end hardware including integrated graphics and mobile devices.
 		[b]Note:[/b] Due to how lightmaps work, most properties only have a visible effect once lightmaps are baked again.
 		[b]Note:[/b] Lightmap baking on [CSGShape3D]s and [PrimitiveMesh]es is not supported, as these cannot store UV2 data required for baking.
-		[b]Note:[/b] If no custom lightmappers are installed, [LightmapGI] can only be baked when using the Vulkan backend (Clustered or Mobile), not OpenGL.
+		[b]Note:[/b] If no custom lightmappers are installed, [LightmapGI] can only be baked when using the Vulkan backend (Forward+ or Mobile), not OpenGL.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -73,7 +73,7 @@
 			High bake quality (slow bake times). The quality of this preset can be adjusted by changing [member ProjectSettings.rendering/lightmapping/bake_quality/high_quality_ray_count] and [member ProjectSettings.rendering/lightmapping/bake_quality/high_quality_probe_ray_count].
 		</constant>
 		<constant name="BAKE_QUALITY_ULTRA" value="3" enum="BakeQuality">
-			Highest bake quality (slowest bake times). The quality of this preset can be adjusted by changing [member ProjectSettings.rendering/lightmapping/bake_quality/high_quality_ray_count] and [member ProjectSettings.rendering/lightmapping/bake_quality/ultra_quality_probe_ray_count].
+			Highest bake quality (slowest bake times). The quality of this preset can be adjusted by changing [member ProjectSettings.rendering/lightmapping/bake_quality/ultra_quality_ray_count] and [member ProjectSettings.rendering/lightmapping/bake_quality/ultra_quality_probe_ray_count].
 		</constant>
 		<constant name="GENERATE_PROBES_DISABLED" value="0" enum="GenerateProbes">
 			Don't generate lightmap probes for lighting dynamic objects.

--- a/doc/classes/LightmapperRD.xml
+++ b/doc/classes/LightmapperRD.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		LightmapperRD ("RD" stands for [RenderingDevice]) is the built-in GPU-based lightmapper for use with [LightmapGI]. On most dedicated GPUs, it can bake lightmaps much faster than most CPU-based lightmappers. LightmapperRD uses compute shaders to bake lightmaps, so it does not require CUDA or OpenCL libraries to be installed to be usable.
-		[b]Note:[/b] Only usable when using the Vulkan backend (Clustered or Mobile), not OpenGL.
+		[b]Note:[/b] Only usable when using the Vulkan backend (Forward+ or Mobile), not OpenGL.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -258,7 +258,7 @@
 			Indicates this custom channel contains half precision float colors, encoded as [PackedByteArray].
 		</constant>
 		<constant name="ARRAY_CUSTOM_R_FLOAT" value="4" enum="ArrayCustomFormat">
-			Indicates this custom channel contains full float colors, in a [PackedFloat32Array]. Only the red green channel is used.
+			Indicates this custom channel contains full float colors, in a [PackedFloat32Array]. Only the red channel is used.
 		</constant>
 		<constant name="ARRAY_CUSTOM_RG_FLOAT" value="5" enum="ArrayCustomFormat">
 			Indicates this custom channel contains full float colors, in a [PackedFloat32Array]. Only red and green channels are used.

--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -155,7 +155,7 @@
 			<return type="float" />
 			<param index="0" name="link" type="RID" />
 			<description>
-				Returns the [code]enter_cost[/code] of this [code]link[/code].
+				Returns the enter cost of this [param link].
 			</description>
 		</method>
 		<method name="link_get_map" qualifiers="const">
@@ -190,7 +190,7 @@
 			<return type="float" />
 			<param index="0" name="link" type="RID" />
 			<description>
-				Returns the [code]travel_cost[/code] of this [code]link[/code].
+				Returns the travel cost of this [param link].
 			</description>
 		</method>
 		<method name="link_is_bidirectional" qualifiers="const">
@@ -429,7 +429,7 @@
 			<return type="float" />
 			<param index="0" name="region" type="RID" />
 			<description>
-				Returns the [code]enter_cost[/code] of this [param region].
+				Returns the enter cost of this [param region].
 			</description>
 		</method>
 		<method name="region_get_map" qualifiers="const">
@@ -457,7 +457,7 @@
 			<return type="float" />
 			<param index="0" name="region" type="RID" />
 			<description>
-				Returns the [code]travel_cost[/code] of this [param region].
+				Returns the travel cost of this [param region].
 			</description>
 		</method>
 		<method name="region_owns_point" qualifiers="const">

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -162,7 +162,7 @@
 			<return type="float" />
 			<param index="0" name="link" type="RID" />
 			<description>
-				Returns the [code]enter_cost[/code] of this [code]link[/code].
+				Returns the enter cost of this [param link].
 			</description>
 		</method>
 		<method name="link_get_map" qualifiers="const">
@@ -197,7 +197,7 @@
 			<return type="float" />
 			<param index="0" name="link" type="RID" />
 			<description>
-				Returns the [code]travel_cost[/code] of this [code]link[/code].
+				Returns the travel cost of this [param link].
 			</description>
 		</method>
 		<method name="link_is_bidirectional" qualifiers="const">
@@ -477,7 +477,7 @@
 			<return type="float" />
 			<param index="0" name="region" type="RID" />
 			<description>
-				Returns the [code]enter_cost[/code] of this [param region].
+				Returns the enter cost of this [param region].
 			</description>
 		</method>
 		<method name="region_get_map" qualifiers="const">
@@ -505,7 +505,7 @@
 			<return type="float" />
 			<param index="0" name="region" type="RID" />
 			<description>
-				Returns the [code]travel_cost[/code] of this [param region].
+				Returns the travel cost of this [param region].
 			</description>
 		</method>
 		<method name="region_owns_point" qualifiers="const">

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -300,7 +300,7 @@
 			<param index="1" name="coords_from" type="Vector2i" />
 			<param index="2" name="alternative_from" type="int" />
 			<description>
-				Returns if there is and alternative-level proxy for the given identifiers.
+				Returns if there is an alternative-level proxy for the given identifiers.
 			</description>
 		</method>
 		<method name="has_coords_level_tile_proxy">


### PR DESCRIPTION
Mostly typos. Also renamed the remaining Vulkan "Clustered" to "Forward+".


