### PR TITLE
Fixing issues with SSIL artifacts

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
@@ -151,11 +151,11 @@ void RenderSceneBuffersRD::configure(RID p_render_target, const Size2i p_interna
 		uint32_t usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT;
 
 		if (msaa_3d == RS::VIEWPORT_MSAA_DISABLED) {
-			format = RD::get_singleton()->texture_is_format_supported_for_usage(RD::DATA_FORMAT_D24_UNORM_S8_UINT, (RD::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | RD::TEXTURE_USAGE_SAMPLING_BIT)) ? RD::DATA_FORMAT_D24_UNORM_S8_UINT : RD::DATA_FORMAT_D32_SFLOAT_S8_UINT;
 			usage_bits |= RD::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+			format = RD::get_singleton()->texture_is_format_supported_for_usage(RD::DATA_FORMAT_D24_UNORM_S8_UINT, usage_bits) ? RD::DATA_FORMAT_D24_UNORM_S8_UINT : RD::DATA_FORMAT_D32_SFLOAT_S8_UINT;
 		} else {
 			format = RD::DATA_FORMAT_R32_SFLOAT;
-			usage_bits |= RD::TEXTURE_USAGE_CAN_COPY_TO_BIT | RD::TEXTURE_USAGE_STORAGE_BIT;
+			usage_bits |= RD::TEXTURE_USAGE_CAN_COPY_TO_BIT | (can_be_storage ? RD::TEXTURE_USAGE_STORAGE_BIT : 0);
 		}
 
 		create_texture(RB_SCOPE_BUFFERS, RB_TEX_DEPTH, format, usage_bits);


### PR DESCRIPTION
In SSIL and SSAO we slice our screen up into 4 layers, for this we half the size of the screen, 4 slices at half the resolution makes up our starting size.
If half size is on, we half this size again.

In both cases we round **up** if the screen resolution can't be nicely divided by 2 or 4.

When dispatching our compute shaders however, there are many places where we shift by 1 or 2 to half or quarter the size. This has the result that the resolution is rounded **down**. 
This causes the pixels in the border of our textures to not be written to. When resizing the window the old buffers are freed and new buffers allocated, these buffers often take up the space of the previously freed buffers and we get whatever junk is in there.
This junk then potentially leads to computational errors which causes the artifacts we've seen at the side of the image.

This PR ensures we are using the actual buffer sizes when calling `compute_list_dispatch_threads` ensuring full coverage of the buffers.

Fixes #56724