### PR TITLE
Add `Variant` conversion constructor for `wchar_t *`

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -2506,6 +2506,11 @@ Variant::Variant(const char32_t *p_wstring) {
 	memnew_placement(_data._mem, String(p_wstring));
 }
 
+Variant::Variant(const wchar_t *p_wstring) {
+	type = STRING;
+	memnew_placement(_data._mem, String(p_wstring));
+}
+
 Variant::Variant(const Vector3 &p_vector3) {
 	type = VECTOR3;
 	memnew_placement(_data._mem, Vector3(p_vector3));

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -445,6 +445,7 @@ public:
 	Variant(const StringName &p_string);
 	Variant(const char *const p_cstring);
 	Variant(const char32_t *p_wstring);
+	Variant(const wchar_t *p_wstring);
 	Variant(const Vector2 &p_vector2);
 	Variant(const Vector2i &p_vector2i);
 	Variant(const Rect2 &p_rect2);


### PR DESCRIPTION
- Maintainer edit, closes #73831

Adds a simple conversion constructor for `wchar_t*` to `Variant`. This enables calling `emit_signal` with `std::wstring::c_str()` and wstring literals eg `L"foo"`.