### PR TITLE
Set  .net compilation output stream to utf8

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -38,6 +38,7 @@ namespace GodotTools.Build
             startInfo.RedirectStandardError = true;
             startInfo.UseShellExecute = false;
             startInfo.CreateNoWindow = true;
+            startInfo.StandardOutputEncoding = Encoding.UTF8;
             startInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"]
                 = ((string)editorSettings.GetSetting("interface/editor/editor_language")).Replace('_', '-');
 
@@ -102,6 +103,7 @@ namespace GodotTools.Build
             startInfo.RedirectStandardOutput = true;
             startInfo.RedirectStandardError = true;
             startInfo.UseShellExecute = false;
+            startInfo.StandardOutputEncoding = Encoding.UTF8;
             startInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"]
                 = ((string)editorSettings.GetSetting("interface/editor/editor_language")).Replace('_', '-');
 
@@ -114,7 +116,6 @@ namespace GodotTools.Build
                 process.OutputDataReceived += (_, e) => stdOutHandler.Invoke(e.Data);
             if (stdErrHandler != null)
                 process.ErrorDataReceived += (_, e) => stdErrHandler.Invoke(e.Data);
-
             process.Start();
 
             process.BeginOutputReadLine();

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -50,7 +50,7 @@ namespace GodotTools.Build
                 process.OutputDataReceived += (_, e) => stdOutHandler.Invoke(e.Data);
             if (stdErrHandler != null)
                 process.ErrorDataReceived += (_, e) => stdErrHandler.Invoke(e.Data);
-
+            process.StartInfo.StandardOutputEncoding = Encoding.UTF8;
             process.Start();
 
             process.BeginOutputReadLine();
@@ -114,7 +114,7 @@ namespace GodotTools.Build
                 process.OutputDataReceived += (_, e) => stdOutHandler.Invoke(e.Data);
             if (stdErrHandler != null)
                 process.ErrorDataReceived += (_, e) => stdErrHandler.Invoke(e.Data);
-
+            process.StartInfo.StandardOutputEncoding = Encoding.UTF8;
             process.Start();
 
             process.BeginOutputReadLine();

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -38,6 +38,7 @@ namespace GodotTools.Build
             startInfo.RedirectStandardError = true;
             startInfo.UseShellExecute = false;
             startInfo.CreateNoWindow = true;
+            startInfo.StandardOutputEncoding = Encoding.UTF8;
             startInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"]
                 = ((string)editorSettings.GetSetting("interface/editor/editor_language")).Replace('_', '-');
 
@@ -102,6 +103,7 @@ namespace GodotTools.Build
             startInfo.RedirectStandardOutput = true;
             startInfo.RedirectStandardError = true;
             startInfo.UseShellExecute = false;
+            startInfo.StandardOutputEncoding = Encoding.UTF8;
             startInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"]
                 = ((string)editorSettings.GetSetting("interface/editor/editor_language")).Replace('_', '-');
 

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -38,6 +38,7 @@ namespace GodotTools.Build
             startInfo.RedirectStandardError = true;
             startInfo.UseShellExecute = false;
             startInfo.CreateNoWindow = true;
+            startInfo.StandardOutputEncoding = Encoding.UTF8;
             startInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"]
                 = ((string)editorSettings.GetSetting("interface/editor/editor_language")).Replace('_', '-');
 
@@ -50,7 +51,7 @@ namespace GodotTools.Build
                 process.OutputDataReceived += (_, e) => stdOutHandler.Invoke(e.Data);
             if (stdErrHandler != null)
                 process.ErrorDataReceived += (_, e) => stdErrHandler.Invoke(e.Data);
-            process.StartInfo.StandardOutputEncoding = Encoding.UTF8;
+
             process.Start();
 
             process.BeginOutputReadLine();
@@ -102,6 +103,7 @@ namespace GodotTools.Build
             startInfo.RedirectStandardOutput = true;
             startInfo.RedirectStandardError = true;
             startInfo.UseShellExecute = false;
+            startInfo.StandardOutputEncoding = Encoding.UTF8;
             startInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"]
                 = ((string)editorSettings.GetSetting("interface/editor/editor_language")).Replace('_', '-');
 
@@ -114,7 +116,6 @@ namespace GodotTools.Build
                 process.OutputDataReceived += (_, e) => stdOutHandler.Invoke(e.Data);
             if (stdErrHandler != null)
                 process.ErrorDataReceived += (_, e) => stdErrHandler.Invoke(e.Data);
-            process.StartInfo.StandardOutputEncoding = Encoding.UTF8;
             process.Start();
 
             process.BeginOutputReadLine();

--- a/modules/mono/editor/GodotTools/GodotTools/Build/DotNetFinder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/DotNetFinder.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 using JetBrains.Annotations;
 using OS = GodotTools.Utils.OS;
 
@@ -55,13 +56,13 @@ namespace GodotTools.Build
             process.StartInfo = new ProcessStartInfo(dotNetExe, "--list-sdks")
             {
                 UseShellExecute = false,
-                RedirectStandardOutput = true
+                RedirectStandardOutput = true,
+                StandardOutputEncoding = Encoding.UTF8,
             };
 
             process.StartInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"] = "en-US";
 
             var lines = new List<string>();
-
             process.OutputDataReceived += (_, e) =>
             {
                 if (!string.IsNullOrWhiteSpace(e.Data))

--- a/modules/mono/editor/GodotTools/GodotTools/Build/DotNetFinder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/DotNetFinder.cs
@@ -61,7 +61,7 @@ namespace GodotTools.Build
             process.StartInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"] = "en-US";
 
             var lines = new List<string>();
-
+            process.StartInfo.StandardOutputEncoding = Encoding.UTF8;
             process.OutputDataReceived += (_, e) =>
             {
                 if (!string.IsNullOrWhiteSpace(e.Data))

--- a/modules/mono/editor/GodotTools/GodotTools/Build/DotNetFinder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/DotNetFinder.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 using JetBrains.Annotations;
 using OS = GodotTools.Utils.OS;
 

--- a/modules/mono/editor/GodotTools/GodotTools/Build/DotNetFinder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/DotNetFinder.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 using JetBrains.Annotations;
 using OS = GodotTools.Utils.OS;
 
@@ -61,7 +62,7 @@ namespace GodotTools.Build
             process.StartInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"] = "en-US";
 
             var lines = new List<string>();
-
+            process.StartInfo.StandardOutputEncoding = Encoding.UTF8;
             process.OutputDataReceived += (_, e) =>
             {
                 if (!string.IsNullOrWhiteSpace(e.Data))

--- a/modules/mono/editor/GodotTools/GodotTools/Build/DotNetFinder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/DotNetFinder.cs
@@ -56,13 +56,13 @@ namespace GodotTools.Build
             process.StartInfo = new ProcessStartInfo(dotNetExe, "--list-sdks")
             {
                 UseShellExecute = false,
-                RedirectStandardOutput = true
+                RedirectStandardOutput = true,
+                StandardOutputEncoding = Encoding.UTF8,
             };
 
             process.StartInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"] = "en-US";
 
             var lines = new List<string>();
-            process.StartInfo.StandardOutputEncoding = Encoding.UTF8;
             process.OutputDataReceived += (_, e) =>
             {
                 if (!string.IsNullOrWhiteSpace(e.Data))


### PR DESCRIPTION
Set the .net compilation output stream to utf8 to prevent garbled characters in other languages


![20230224145959](https://user-images.githubusercontent.com/17066147/221117819-1ea39c2d-34bf-4422-8eac-c9941e950230.png)
