### PR TITLE
GDScript: Fix groups and categories been seen as members (reverted)

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -211,6 +211,10 @@ static bool _can_use_ptrcall(const MethodBind *p_method, const Vector<GDScriptCo
 	return true;
 }
 
+inline static bool is_category_or_group(const PropertyInfo &p_info) {
+	return p_info.usage & PROPERTY_USAGE_CATEGORY || p_info.usage & PROPERTY_USAGE_GROUP || p_info.usage & PROPERTY_USAGE_SUBGROUP;
+}
+
 GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &codegen, Error &r_error, const GDScriptParser::ExpressionNode *p_expression, bool p_root, bool p_initializer, const GDScriptCodeGenerator::Address &p_index_addr) {
 	if (p_expression->is_constant && !(p_expression->get_datatype().is_meta_type && p_expression->get_datatype().kind == GDScriptParser::DataType::CLASS)) {
 		return codegen.add_constant(p_expression->reduced_value);
@@ -246,7 +250,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			// Try members.
 			if (!codegen.function_node || !codegen.function_node->is_static) {
 				// Try member variables.
-				if (codegen.script->member_indices.has(identifier)) {
+				if (codegen.script->member_indices.has(identifier) && !is_category_or_group(codegen.script->member_info[identifier])) {
 					if (codegen.script->member_indices[identifier].getter != StringName() && codegen.script->member_indices[identifier].getter != codegen.function_name) {
 						// Perform getter.
 						GDScriptCodeGenerator::Address temp = codegen.add_temporary(codegen.script->member_indices[identifier].data_type);

--- a/modules/gdscript/tests/scripts/runtime/features/groups_are_not_properties.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/groups_are_not_properties.gd
@@ -1,0 +1,9 @@
+# https://github.com/godotengine/godot/issues/73843
+extends RefCounted
+
+@export_group("Resource")
+@export_category("RefCounted")
+
+func test():
+	prints("Not shadowed", Resource.new())
+	prints("Not shadowed", RefCounted.new())

--- a/modules/gdscript/tests/scripts/runtime/features/groups_are_not_properties.out
+++ b/modules/gdscript/tests/scripts/runtime/features/groups_are_not_properties.out
@@ -1,0 +1,3 @@
+GDTEST_OK
+Not shadowed <Resource#-9223371975785708326>
+Not shadowed <RefCounted#-9223371975768931110>


### PR DESCRIPTION
Fix #73843