### PR TITLE
Make max() and min() global functions only accept numbers

### DIFF
--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -543,6 +543,13 @@ struct VariantUtilityFunctions {
 		Variant base = *p_args[0];
 		Variant ret;
 		for (int i = 1; i < p_argcount; i++) {
+			Variant::Type arg_type = p_args[i]->get_type();
+			if (arg_type != Variant::INT && arg_type != Variant::FLOAT) {
+				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+				r_error.expected = Variant::FLOAT;
+				r_error.argument = i;
+				return Variant();
+			}
 			bool valid;
 			Variant::evaluate(Variant::OP_LESS, base, *p_args[i], ret, valid);
 			if (!valid) {
@@ -576,6 +583,13 @@ struct VariantUtilityFunctions {
 		Variant base = *p_args[0];
 		Variant ret;
 		for (int i = 1; i < p_argcount; i++) {
+			Variant::Type arg_type = p_args[i]->get_type();
+			if (arg_type != Variant::INT && arg_type != Variant::FLOAT) {
+				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+				r_error.expected = Variant::FLOAT;
+				r_error.argument = i;
+				return Variant();
+			}
 			bool valid;
 			Variant::evaluate(Variant::OP_GREATER, base, *p_args[i], ret, valid);
 			if (!valid) {

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -656,7 +656,7 @@
 		<method name="max" qualifiers="vararg">
 			<return type="Variant" />
 			<description>
-				Returns the maximum of the given values. This function can take any number of arguments.
+				Returns the maximum of the given numeric values. This function can take any number of arguments.
 				[codeblock]
 				max(1, 7, 3, -6, 5) # Returns 7
 				[/codeblock]
@@ -689,7 +689,7 @@
 		<method name="min" qualifiers="vararg">
 			<return type="Variant" />
 			<description>
-				Returns the minimum of the given values. This function can take any number of arguments.
+				Returns the minimum of the given numeric values. This function can take any number of arguments.
 				[codeblock]
 				min(1, 7, 3, -6, 5) # Returns -6
 				[/codeblock]

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -1058,7 +1058,7 @@ void GDScriptByteCodeGenerator::write_call_gdscript_utility(const Address &p_tar
 void GDScriptByteCodeGenerator::write_call_utility(const Address &p_target, const StringName &p_function, const Vector<Address> &p_arguments) {
 	bool is_validated = true;
 	if (Variant::is_utility_function_vararg(p_function)) {
-		is_validated = true; // Vararg works fine with any argument, since they can be any type.
+		is_validated = false; // Vararg needs runtime checks, can't use validated call.
 	} else if (p_arguments.size() == Variant::get_utility_function_argument_count(p_function)) {
 		bool all_types_exact = true;
 		for (int i = 0; i < p_arguments.size(); i++) {
@@ -1107,7 +1107,7 @@ void GDScriptByteCodeGenerator::write_call_builtin_type(const Address &p_target,
 
 	// Check if all types are correct.
 	if (Variant::is_builtin_method_vararg(p_type, p_method)) {
-		is_validated = true; // Vararg works fine with any argument, since they can be any type.
+		is_validated = false; // Vararg needs runtime checks, can't use validated call.
 	} else if (p_arguments.size() == Variant::get_builtin_method_argument_count(p_type, p_method)) {
 		bool all_types_exact = true;
 		for (int i = 0; i < p_arguments.size(); i++) {

--- a/modules/gdscript/tests/scripts/analyzer/warnings/lambda_unused_arg.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/lambda_unused_arg.gd
@@ -1,4 +1,4 @@
 func test():
 	var lambda := func(unused: Variant) -> void:
 		pass
-	lambda.call()
+	lambda.call("something")


### PR DESCRIPTION
The behavior for those are not well defined for non-numeric arguments. To avoid confusion the other types are forbidden.

Incidentally, this fix a problem with vararg methods in GDScript, as they shouldn't use validated call (I may move this fix to a different PR if this one isn't accepted). 

Closes #45320