### PR TITLE
Add rename_dependencies method to ResourceLoader

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -112,6 +112,17 @@ PackedStringArray ResourceLoader::get_dependencies(const String &p_path) {
 	return ret;
 }
 
+Error ResourceLoader::rename_dependencies(const String &p_path, const Dictionary &p_map) {
+	PackedStringArray dependencies = get_dependencies(p_path); // The dependencies are returned with slices separated by `::`.
+	HashMap<String, String> renames;
+	for (int i = 0; i < p_map.size(); i++) {
+		if (dependencies.has(p_map.keys()[i])) {
+			renames[String(p_map.keys()[i]).get_slice("::", 2)] = p_map[p_map.keys()[i]];
+		}
+	}
+	return ::ResourceLoader::rename_dependencies(p_path, renames); // `renames` is a HashMap with paths only [existing_path:replacement_path, ...] (no UIDs).
+}
+
 bool ResourceLoader::has_cached(const String &p_path) {
 	String local_path = ::ResourceLoader::_validate_local_path(p_path);
 	return ResourceCache::has(local_path);
@@ -145,6 +156,7 @@ void ResourceLoader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_resource_format_loader", "format_loader"), &ResourceLoader::remove_resource_format_loader);
 	ClassDB::bind_method(D_METHOD("set_abort_on_missing_resources", "abort"), &ResourceLoader::set_abort_on_missing_resources);
 	ClassDB::bind_method(D_METHOD("get_dependencies", "path"), &ResourceLoader::get_dependencies);
+	ClassDB::bind_method(D_METHOD("rename_dependencies", "path", "rename_paths_from_to"), &ResourceLoader::rename_dependencies);
 	ClassDB::bind_method(D_METHOD("has_cached", "path"), &ResourceLoader::has_cached);
 	ClassDB::bind_method(D_METHOD("get_cached_ref", "path"), &ResourceLoader::get_cached_ref);
 	ClassDB::bind_method(D_METHOD("exists", "path", "type_hint"), &ResourceLoader::exists, DEFVAL(""));

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -78,6 +78,7 @@ public:
 	void remove_resource_format_loader(Ref<ResourceFormatLoader> p_format_loader);
 	void set_abort_on_missing_resources(bool p_abort);
 	PackedStringArray get_dependencies(const String &p_path);
+	Error rename_dependencies(const String &p_path, const Dictionary &p_map);
 	bool has_cached(const String &p_path);
 	Ref<Resource> get_cached_ref(const String &p_path);
 	bool exists(const String &p_path, const String &p_type_hint = "");

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -140,6 +140,26 @@
 				Unregisters the given [ResourceFormatLoader].
 			</description>
 		</method>
+		<method name="rename_dependencies">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="rename_paths_from_to" type="Dictionary" />
+			<description>
+				Renames resource dependency paths from their current path to a replacement path. Rename paths are confirmed to exist in the resource file before renaming.
+				[param rename_paths_from_to] is a [Dictionary] with each key a [String] that is a path to replace in the exact format as a key returned by [method get_dependencies], and its value a [String] as the replacement path without the UID. See [method get_dependencies] on how to get the path from the dependency [String] slices.
+				[codeblocks]
+				[gdscript]
+				var rename_paths_from_to = {
+				    "uid://cy6m27ymhc1l1::::res://local/my_script_101.gd":"res://migrate/local/my_script_101.gd",
+				    "uid://cprj8dpcbi7f5::::res://local/my_script_202.gd":"res://migrate/local/my_script_202.gd",
+				}
+				[/gdscript]
+				[/codeblocks]
+				If the resource is a file located in the [code]res://[/code] path the rename is performed immediately on the source file.
+				If the resource is located in the [code]user://[/code] path, a new resource file is created at the same location as the original. The original file is not modified. The name of the new, modified resource at [param path] is dependent on the particular [ResourceFormatLoader] used by the resource type. [PackedScene] resources, [code].tscn[/code] and [code].scn[/code] are saved with the original [param path] name appended with [code].depren[/code].
+				[b]Note:[/b] Resources that were saved prior to Godot 4.0 will not show a UID in the dependency key, so the [param rename_paths_from_to] key/value will look like this: [code]"res://local/my_script_303.gd":"res://migrate/local/my_script_303.gd"[/code].
+			</description>
+		</method>
 		<method name="set_abort_on_missing_resources">
 			<return type="void" />
 			<param index="0" name="abort" type="bool" />


### PR DESCRIPTION
Adds a `rename_dependencies` method in `ResourceLoader` that exposes that method in `ResourceFormatLoader`.

This functionality is useful for porting existing packed scenes to a project with a differing file hierarchy, for example porting a project from Godot 3.x to 4.x.

Prior to a rename, you can use the `get_dependencies` method to obtain the dependencies, which is also called internally by this new method to confirm that a dependency path exists before continuing with the rename.

Renames resource dependency paths from their current path to a replacement path and creates a new resource file at the same location as the original. The original file is not modified.

The name of the new, modified resource is dependent on the particular `ResourceFormatLoader` used by the resource type. Godot `PackedScene` resources, .tscn and .scn are saved with the original path name appended with .depren.

Closes [#22480](https://github.com/godotengine/godot/issues/22480)
