### PR TITLE
Core: Identity compare objects by id, not by pointers

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3499,7 +3499,7 @@ bool Variant::identity_compare(const Variant &p_variant) const {
 
 	switch (type) {
 		case OBJECT: {
-			return _get_obj().obj == p_variant._get_obj().obj;
+			return _get_obj().id == p_variant._get_obj().id;
 		} break;
 
 		case DICTIONARY: {

--- a/tests/core/variant/test_variant.h
+++ b/tests/core/variant/test_variant.h
@@ -1056,6 +1056,14 @@ TEST_CASE("[Variant] Identity comparison") {
 	Variant obj_null_two_var = Variant((Object *)nullptr);
 	CHECK(obj_null_one_var.identity_compare(obj_null_one_var));
 	CHECK(obj_null_one_var.identity_compare(obj_null_two_var));
+
+	Object *freed_one = new Object();
+	Variant freed_one_var = freed_one;
+	delete freed_one;
+	Object *freed_two = new Object();
+	Variant freed_two_var = freed_two;
+	delete freed_two;
+	CHECK_FALSE(freed_one_var.identity_compare(freed_two_var));
 }
 
 TEST_CASE("[Variant] Nested array comparison") {


### PR DESCRIPTION
```gdscript
var a := Node.new()
var b := Node.new()
a.free()
b.free()
print(is_same(a, null)) # false
print(is_same(a, b)) # false

var c := Node.new()
c.free()
var d := Node.new()
d.free()
print(is_same(c, null)) # false
print(is_same(c, d)) # before: true, after: false
```

The problem is shown in last line: because `c` is freed before `d` is created `d` receives pointer that `c` has used before. 

The solution is to compare by `id` not by `obj`, since `id` has info about history of reuse.