### PR TITLE
Draw Camera2D outlines as 2 point primitives instead of 4 (consistent with how origin is drawn in 2D editor)

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -278,7 +278,7 @@ void Camera2D::_notification(int p_what) {
 
 			if (screen_drawing_enabled) {
 				Color area_axis_color(1, 0.4, 1, 0.63);
-				real_t area_axis_width = 1;
+				real_t area_axis_width = -1;
 				if (is_current()) {
 					area_axis_width = 3;
 				}
@@ -302,7 +302,7 @@ void Camera2D::_notification(int p_what) {
 
 			if (limit_drawing_enabled) {
 				Color limit_drawing_color(1, 1, 0.25, 0.63);
-				real_t limit_drawing_width = 1;
+				real_t limit_drawing_width = -1;
 				if (is_current()) {
 					limit_drawing_width = 3;
 				}
@@ -323,7 +323,7 @@ void Camera2D::_notification(int p_what) {
 
 			if (margin_drawing_enabled) {
 				Color margin_drawing_color(0.25, 1, 1, 0.63);
-				real_t margin_drawing_width = 1;
+				real_t margin_drawing_width = -1;
 				if (is_current()) {
 					margin_drawing_width = 3;
 				}


### PR DESCRIPTION
This just makes Camera2D outlines draw as 2 point primitives to improve consistency and appearance. Currently zooming out can cause parts of the camera outline to jitter and pop in and out randomly.

Jitter before:

https://user-images.githubusercontent.com/66881186/222281207-18de4efe-be31-4f29-bf48-3ff3798087e8.mp4

Jitter after:

https://user-images.githubusercontent.com/66881186/224836595-e96295e5-3368-408d-a878-45f6f6d2e257.mp4



Close up before:
<img width="960" alt="camera_outline_zoom_before" src="https://user-images.githubusercontent.com/66881186/222281443-3e9cc2e7-5d20-4f39-9698-bbf55c7ea280.PNG">
Close up after:
<img width="960" alt="camera_outline_zoom_after" src="https://user-images.githubusercontent.com/66881186/224836121-a9a434bf-3f30-42a3-bd10-a16c056b66b6.PNG">
