### PR TITLE
Fix renaming/moving nodes in inherited hierarchies causing orphans (by introducing scene-local-ids)

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -333,6 +333,13 @@
 				Returns the [Window] that contains this node, or the last exclusive child in a chain of windows starting with the one that contains this node.
 			</description>
 		</method>
+		<method name="get_local_id" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the scene-local id of the node. A return value of 0 means unassigned and that the node is not tracked for orphan recovery in nested scenes.
+				A value of -1 signifies the default for nodes of imported scenes, as those cannot meaningfully be assigned stable ids (with the exception of using custom scene import scripts, see [method set_local_id] for more info)
+			</description>
+		</method>
 		<method name="get_multiplayer_authority" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -783,6 +790,16 @@
 			<param index="1" name="is_editable" type="bool" />
 			<description>
 				Sets the editable children state of [param node] relative to this node. This method is only intended for use with editor tooling.
+			</description>
+		</method>
+		<method name="set_local_id">
+			<return type="void" />
+			<param index="0" name="value" type="int" />
+			<description>
+				Sets the scene-local id of the node to [param value], which must be greater than 0. This id is used to track hierarchy dependencies and should only be modified when absolutely necessary.
+				One such case is for scene post import scripts. By using custom conditions (for example a name suffix, similar to how automatic collider generation is enabled) it's possible to assign ids to imported nodes which otherwise would not have any.
+				This then allows the contained nodes to also be tracked and benefit from orphan recovery in nested scenes.
+				See [url=$DOCS_URL/tutorials/assets_pipeline/importing_scenes.html#custom-script]Importing Scenes#custom-script[/url] for more info about custom import scripts
 			</description>
 		</method>
 		<method name="set_multiplayer_authority">

--- a/doc/classes/PackedScene.xml
+++ b/doc/classes/PackedScene.xml
@@ -104,7 +104,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="_bundled" type="Dictionary" setter="_set_bundled_scene" getter="_get_bundled_scene" default="{ &quot;conn_count&quot;: 0, &quot;conns&quot;: PackedInt32Array(), &quot;editable_instances&quot;: [], &quot;names&quot;: PackedStringArray(), &quot;node_count&quot;: 0, &quot;node_paths&quot;: [], &quot;nodes&quot;: PackedInt32Array(), &quot;variants&quot;: [], &quot;version&quot;: 3 }">
+		<member name="_bundled" type="Dictionary" setter="_set_bundled_scene" getter="_get_bundled_scene" default="{ &quot;conn_count&quot;: 0, &quot;conns&quot;: PackedInt32Array(), &quot;editable_instances&quot;: [], &quot;local_id_offset&quot;: 0, &quot;names&quot;: PackedStringArray(), &quot;node_count&quot;: 0, &quot;node_paths&quot;: [], &quot;nodes&quot;: PackedInt32Array(), &quot;variants&quot;: [], &quot;version&quot;: 3 }">
 			A dictionary representation of the scene contents.
 			Available keys include "rnames" and "variants" for resources, "node_count", "nodes", "node_paths" for nodes, "editable_instances" for base scene children overrides, "conn_count" and "conns" for signal connections, and "version" for the format style of the PackedScene.
 		</member>

--- a/doc/classes/SceneState.xml
+++ b/doc/classes/SceneState.xml
@@ -101,6 +101,18 @@
 				Returns the path to the represented scene file if the node at [param idx] is an [InstancePlaceholder].
 			</description>
 		</method>
+		<method name="get_node_local_id" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_node_local_parent_owner_id" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="idx" type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="get_node_name" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="idx" type="int" />
@@ -113,6 +125,12 @@
 			<param index="0" name="idx" type="int" />
 			<description>
 				Returns the path to the owner of the node at [param idx], relative to the root node.
+			</description>
+		</method>
+		<method name="get_node_parent_local_id" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="idx" type="int" />
+			<description>
 			</description>
 		</method>
 		<method name="get_node_path" qualifiers="const">

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -2648,7 +2648,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 		// Ensure scene local ids for all contained nodes.
 		List<Node *> id_assign_queue; // Maybe another collection type (queue) might be better suited.
 		id_assign_queue.push_back(scene);
-		scene->set_local_id(INT_MAX); // As root is generated, it gets assigned a default id,
+		scene->set_local_id(INT32_MAX); // As root is generated, it gets assigned a default id,
 		// which is unlikely to occur in post import scripts
 		while (!id_assign_queue.is_empty()) {
 			Node *item = id_assign_queue[0];

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1495,6 +1495,9 @@ void SceneTreeDock::_notification(int p_what) {
 void SceneTreeDock::_node_replace_owner(Node *p_base, Node *p_node, Node *p_root, ReplaceOwnerMode p_mode) {
 	if (p_node->get_owner() == p_base && p_node != p_root) {
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		int previous_local_id = p_node->get_local_id();
+		undo_redo->add_do_method(p_node, "set_local_id", 0);
+		undo_redo->add_undo_method(p_node, "set_local_id", previous_local_id);
 		switch (p_mode) {
 			case MODE_BIDI: {
 				bool disable_unique = p_node->is_unique_name_in_owner() && p_root->get_node_or_null(UNIQUE_NODE_PREFIX + String(p_node->get_name())) != nullptr;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -145,6 +145,7 @@ private:
 	// This Data struct is to avoid namespace pollution in derived classes.
 	struct Data {
 		String scene_file_path;
+		int32_t scene_local_id = 0;
 		Ref<SceneState> instance_state;
 		Ref<SceneState> inherited_state;
 
@@ -386,6 +387,9 @@ public:
 	void set_name(const String &p_name);
 
 	InternalMode get_internal_mode() const;
+
+	int32_t get_local_id() const;
+	void set_local_id(int32_t value);
 
 	void add_child(Node *p_child, bool p_force_readable_name = false, InternalMode p_internal = INTERNAL_MODE_DISABLED);
 	void add_sibling(Node *p_sibling, bool p_force_readable_name = false);

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -149,7 +149,7 @@ NodePath SceneState::adjust_if_replaced_path(NodePath p_path, const NodePath *p_
 }
 
 bool SceneState::adjust_if_replaced_path_recursive(const StringName *p_property_name, const NodePath *p_node_source_path, const List<NodePathRemapData> &p_remapped_paths, Variant &value, int p_current_depth) const {
-	ERR_FAIL_COND_V_MSG(p_current_depth > 5, value, vformat("Property depth limit of 5 exceeded in '%s', further NodePath adjustments will be skipped", p_property_name));
+	ERR_FAIL_COND_V_MSG(p_current_depth > 5, value, vformat("Property depth limit of 5 exceeded in '%s', further NodePath adjustments will be skipped", *p_property_name));
 	if (value.get_type() == Variant::NODE_PATH) {
 		value = adjust_if_replaced_path(value, p_node_source_path, p_remapped_paths);
 	} else if (value.get_type() == Variant::ARRAY) {

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -836,7 +836,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 			print_verbose(vformat("Generating new scene local id for Node '%s'.", p_node->get_name()));
 			int32_t allocated_id = get_scene_local_id_offset() + 1;
 			while (true) { // Find unassigned value.
-				if (allocated_id >= _I32_MAX) { // This case shouldn't happen, but to be safe.
+				if (allocated_id >= INT32_MAX) { // This case shouldn't happen, but to be safe.
 					allocated_id = 0;
 					ERR_PRINT(vformat("Unable to allocate scene local id for '%s'.", p_node->get_name()));
 					break;

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -45,7 +45,7 @@ class SceneState : public RefCounted {
 	mutable HashMap<int, int> base_scene_node_remap;
 
 	int base_scene_idx = -1;
-	int local_node_id_offset = 0;
+	int32_t local_node_id_offset = 0;
 
 	enum {
 		NO_PARENT_SAVED = 0x7FFFFFFF,
@@ -213,7 +213,7 @@ public:
 	int add_name(const StringName &p_name);
 	int add_value(const Variant &p_value);
 	int add_node_path(const NodePath &p_path);
-	int add_node(int p_parent, int p_owner, int p_type, int p_name, int p_instance, int p_index, int p_local_id, int p_parent_id, int p_parent_owner_id);
+	int add_node(int p_parent, int p_owner, int p_type, int p_name, int p_instance, int p_index, int32_t p_local_id, int32_t p_parent_id, int32_t p_parent_owner_id);
 	void add_node_property(int p_node, int p_name, int p_value, bool p_deferred_node_path = false);
 	void add_node_group(int p_node, int p_group);
 	void set_base_scene(int p_idx);

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -199,9 +199,9 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 			int name = -1;
 			int instance = -1;
 			int index = -1;
-			int local_id = 0;
-			int parent_id = 0;
-			int parent_owner_id = 0;
+			int32_t local_id = 0;
+			int32_t parent_id = 0;
+			int32_t parent_owner_id = 0;
 			//int base_scene=-1;
 
 			if (next_tag.fields.has("name")) {
@@ -2243,9 +2243,9 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 			StringName type = state->get_node_type(i);
 			StringName name = state->get_node_name(i);
 			int index = state->get_node_index(i);
-			int local_id = state->get_node_local_id(i);
-			int parent_owner_id = state->get_node_local_parent_owner_id(i);
-			int parent_id = state->get_node_parent_local_id(i);
+			int32_t local_id = state->get_node_local_id(i);
+			int32_t parent_owner_id = state->get_node_local_parent_owner_id(i);
+			int32_t parent_id = state->get_node_parent_local_id(i);
 			NodePath path = state->get_node_path(i, true);
 			NodePath owner = state->get_node_owner_path(i);
 			Ref<PackedScene> instance = state->get_node_instance(i);

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -54,6 +54,7 @@ class ResourceLoaderText {
 	};
 
 	bool is_scene = false;
+	int32_t scene_local_node_id_offset = 0;
 	String res_type;
 
 	bool ignore_resource_parsing = false;


### PR DESCRIPTION
This adresses: https://github.com/godotengine/godot-proposals/issues/6291
And these (closed) issues:
https://github.com/godotengine/godot/issues/72803
https://github.com/godotengine/godot/issues/24817
https://github.com/godotengine/godot/issues/38186
https://github.com/godotengine/godot/issues/16650

I tried my best to comment every line that i deemed necessary so it's easier to understand how everything ties together.
It's actually not that complicated (and for the most part self-contained) which is why i think it's worth considering for inclusion.
It's also VCS friendly, and backwards compatible with a small caveat, but for more details see this post here:

https://github.com/godotengine/godot-proposals/issues/6291#issuecomment-1440644535

All in all it's currently at a point where i don't see more edge cases, but i marked those that i tested in the linked post, so feedback is welcome if there's anything i missed.

And as a preview, here's the illustration from the linked post:

https://user-images.githubusercontent.com/8841352/220732782-644e3088-1209-4637-b8c7-7a30df12e6d3.mp4

___

Disclaimer: I don't have a c++ background, but i tried my best to understand the source and follow formatting and structure of existing code.

___
~~Edit: 
TODO: it looks like larger id value types are required as the sequence of deleting a node and creating another one can wrongly reuse ids. It probably requires actual guids or alternatively some location (maybe as part of each scene) that stores an increasing counter (ulong?).~~ fixed