### PR TITLE
GDScript: Fix conversions from native members accessed by identifier

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -242,7 +242,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			// Try class members.
 			if (_is_class_member_property(codegen, identifier)) {
 				// Get property.
-				GDScriptCodeGenerator::Address temp = codegen.add_temporary(); // TODO: Could get the type of the class member here.
+				GDScriptCodeGenerator::Address temp = codegen.add_temporary(_gdtype_from_datatype(p_expression->get_datatype(), codegen.script));
 				gen->write_get_member(temp, identifier);
 				return temp;
 			}

--- a/modules/gdscript/tests/scripts/runtime/features/conversions_from_native_members.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/conversions_from_native_members.gd
@@ -1,0 +1,11 @@
+class Foo extends Node:
+	func _init():
+		name = 'f'
+		var string: String = name
+		assert(typeof(string) == TYPE_STRING)
+		assert(string == 'f')
+		print('ok')
+
+func test():
+	var foo := Foo.new()
+	foo.free()

--- a/modules/gdscript/tests/scripts/runtime/features/conversions_from_native_members.out
+++ b/modules/gdscript/tests/scripts/runtime/features/conversions_from_native_members.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok


### PR DESCRIPTION
```gdscript
extends Node

func _ready():
  var string: String = name
  print(typeof(string) == TYPE_STRING) # before: false, after: true
```

Getting a member from a native base directly by a single identifier (`name` in the example) did not have an address type set. Because of that codegen could not see whenever a conversion was needed or not (for an assignment in the example).

Fixes the issue in [this comment](https://github.com/godotengine/godot/issues/73258#issuecomment-1445023176) of #73258.
