### PR TITLE
Fix spotlight shadows in volumetric fog

### DIFF
--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
@@ -585,23 +585,14 @@ void main() {
 						if (spot_lights.data[light_index].shadow_opacity > 0.001) {
 							//has shadow
 							vec4 uv_rect = spot_lights.data[light_index].atlas_rect;
-							vec2 flip_offset = spot_lights.data[light_index].direction.xy;
 
-							vec3 local_vert = (spot_lights.data[light_index].shadow_matrix * vec4(view_pos, 1.0)).xyz;
+							vec4 v = vec4(view_pos, 1.0);
 
-							float shadow_len = length(local_vert); //need to remember shadow len from here
-							vec3 shadow_sample = normalize(local_vert);
+							vec4 splane = (spot_lights.data[light_index].shadow_matrix * v);
+							splane.z -= spot_lights.data[light_index].shadow_bias / (d * spot_lights.data[light_index].inv_radius);
+							splane /= splane.w;
 
-							if (shadow_sample.z >= 0.0) {
-								uv_rect.xy += flip_offset;
-							}
-
-							shadow_sample.z = 1.0 + abs(shadow_sample.z);
-							vec3 pos = vec3(shadow_sample.xy / shadow_sample.z, shadow_len - spot_lights.data[light_index].shadow_bias);
-							pos.z *= spot_lights.data[light_index].inv_radius;
-
-							pos.xy = pos.xy * 0.5 + 0.5;
-							pos.xy = uv_rect.xy + pos.xy * uv_rect.zw;
+							vec3 pos = vec3(splane.xy * spot_lights.data[light_index].atlas_rect.zw + spot_lights.data[light_index].atlas_rect.xy, splane.z);
 
 							float depth = texture(sampler2D(shadow_atlas, linear_sampler), pos.xy).r;
 


### PR DESCRIPTION
Fixes an issue where Volumetric Fog would incorrectly sample shadows from spotlights, resulting in a broken appearance when one had shadows on. Fixes #57722

Comparison, before:

![image](https://user-images.githubusercontent.com/71602778/221354716-29851629-3948-40e7-9a5a-db76cae037e0.png)

After:
![image](https://user-images.githubusercontent.com/71602778/221354791-d9f57878-43a5-4737-aa99-d51637edb619.png)

Using MRP from #57722:

https://user-images.githubusercontent.com/71602778/221355066-6288776d-ef09-40ef-8f3e-6828d3105e89.mp4


