### PR TITLE
C#: Add option to disable exporting debug symbols

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -279,11 +279,18 @@ namespace GodotTools.Build
             [DisallowNull] string configuration,
             [DisallowNull] string platform,
             [DisallowNull] string runtimeIdentifier,
-            [DisallowNull] string publishOutputDir
+            [DisallowNull] string publishOutputDir,
+            bool includeDebugSymbols = true
         )
         {
             var buildInfo = new BuildInfo(GodotSharpDirs.ProjectSlnPath, GodotSharpDirs.ProjectCsProjPath, configuration,
                 runtimeIdentifier, publishOutputDir, restore: true, rebuild: false, onlyClean: false);
+
+            if (!includeDebugSymbols)
+            {
+                buildInfo.CustomProperties.Add("DebugType=None");
+                buildInfo.CustomProperties.Add("DebugSymbols=false");
+            }
 
             buildInfo.CustomProperties.Add($"GodotTargetPlatform={platform}");
 
@@ -308,9 +315,10 @@ namespace GodotTools.Build
             [DisallowNull] string configuration,
             [DisallowNull] string platform,
             [DisallowNull] string runtimeIdentifier,
-            string publishOutputDir
+            string publishOutputDir,
+            bool includeDebugSymbols = true
         ) => PublishProjectBlocking(CreatePublishBuildInfo(configuration,
-            platform, runtimeIdentifier, publishOutputDir));
+            platform, runtimeIdentifier, publishOutputDir, includeDebugSymbols));
 
         public static bool EditorBuildCallback()
         {


### PR DESCRIPTION
- Add export option to configure if the exported game should include debug symbols (PDB).
	- Fixes https://github.com/godotengine/godot/issues/42436.
- Remove unused `outputDir` local variable.
- Replace `Process.GetCurrentProcess().Id` with `System.Environment.ProcessId` ([CA1837](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1837)).

~Marked as draft since it depends on https://github.com/godotengine/godot/pull/72895 which should be merged first.~ Already merged.