### PR TITLE
[3.x] Fix docs on multiplayer peer signals.

### DIFF
--- a/doc/classes/NetworkedMultiplayerPeer.xml
+++ b/doc/classes/NetworkedMultiplayerPeer.xml
@@ -67,13 +67,13 @@
 		<signal name="peer_connected">
 			<argument index="0" name="id" type="int" />
 			<description>
-				Emitted by the server when a client connects.
+				Emitted when a remote peer connects.
 			</description>
 		</signal>
 		<signal name="peer_disconnected">
 			<argument index="0" name="id" type="int" />
 			<description>
-				Emitted by the server when a client disconnects.
+				Emitted when a remote peer has disconnected.
 			</description>
 		</signal>
 		<signal name="server_disconnected">


### PR DESCRIPTION
NetworkedMultiplayerPeerENet emits peer_connected and peer_disconnected
on both the client and the server:
https://github.com/godotengine/godot/blob/6fed1ffa313c6760fa88b368ae580378daaef0f0/modules/enet/networked_multiplayer_enet.cpp#L268

When trying to implement `NetworkedMultiplayerCustom`, I followed the
documentation and only emitted this signal on the server.
I ended up getting errors like:

```
Invalid packet received. Unabled to find requested cached node
```

While I didn't check other peer implementations, it seems that emitting
on both the client and server is required.

I copied the wording from the `master` branch documentation.
This PR is deliberately targeted at 3.x, as `master` is correct.

Here's some output from a test program with all the signals connected:
```
1948301815 got multiplayer.network_peer_connected from  1
1948301815 got peer.peer_connected from 1
1948301815 got multiplayer.connected_to_server
1948301815 got peer.connection_succeeded
1413532890 got multiplayer.network_peer_connected from  1
1413532890 got peer.peer_connected from 1
1413532890 got multiplayer.connected_to_server
1413532890 got peer.connection_succeeded
1 got multiplayer.network_peer_connected from  1413532890
1 got peer.peer_connected from 1413532890
1 got multiplayer.network_peer_connected from  1948301815
1 got peer.peer_connected from 1948301815
1413532890 got multiplayer.network_peer_connected from  1948301815
1413532890 got peer.peer_connected from 1948301815
1948301815 got multiplayer.network_peer_connected from  1413532890
1948301815 got peer.peer_connected from 1413532890
1 got multiplayer.network_peer_disconnected from  1948301815
1 got peer.peer_disconnected from 1948301815
1413532890 got multiplayer.network_peer_disconnected from  1948301815
1413532890 got peer.peer_disconnected from 1948301815
1 got multiplayer.network_peer_disconnected from  1413532890
1 got peer.peer_disconnected from 1413532890
```

I tested with the following program:

```
extends Node

const ADDRESS := "127.0.0.1"
const PORT := 34561

func _fail(msg: String) -> void:
	push_error(msg)
	get_tree().quit()

func _ready():
	var args := OS.get_cmdline_args()
	if len(args) < 2:
		_fail("Usage: godot Main.tscn <host|join>")
		return

	var peer := ENetMultiplayerPeer.new()
	peer.peer_connected.connect(_on_peer_connected)
	peer.peer_disconnected.connect(_on_peer_disconnected)

	match args[1]:
		"host":
			var err := peer.create_server(PORT, 2)
			if err != OK:
				_fail("Failed to host")
		"join":
			var err := peer.create_client(ADDRESS, PORT)
			if err:
				_fail("Failed to connect")
		_:
			_fail("Usage: godot Main.tscn <host|join>")

	get_tree().get_multiplayer().multiplayer_peer = peer
	multiplayer.connected_to_server.connect(_on_connected_to_server)
	multiplayer.connection_failed.connect(_on_connection_failed)
	multiplayer.peer_connected.connect(_on_network_peer_connected)
	multiplayer.peer_disconnected.connect(_on_network_peer_disconnected)

func _on_connection_succeeded() -> void:
	prints(multiplayer.get_unique_id(), "got peer.connection_succeeded")

func _on_peer_connected(id: int) -> void:
	prints(multiplayer.get_unique_id(), "got peer.peer_connected from", id)

func _on_peer_disconnected(id: int) -> void:
	prints(multiplayer.get_unique_id(), "got peer.peer_disconnected from", id)

func _on_connected_to_server() -> void:
	prints(multiplayer.get_unique_id(), "got multiplayer.connected_to_server")

func _on_connection_failed() -> void:
	prints(multiplayer.get_unique_id(), "got multiplayer.connection_failed")

func _on_network_peer_connected(id: int) -> void:
	prints(multiplayer.get_unique_id(), "got multiplayer.peer_connected from ", id)

func _on_network_peer_disconnected(id: int) -> void:
	prints(multiplayer.get_unique_id(), "got multiplayer.peer_disconnected from ", id)
```

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
