### PR TITLE
GDScript: Fix wrong unsafety mark for binary operator

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2618,7 +2618,7 @@ void GDScriptAnalyzer::reduce_binary_op(GDScriptParser::BinaryOpNode *p_binary_o
 		result = get_operation_type(p_binary_op->variant_op, left_type, right_type, valid, p_binary_op);
 		if (!valid) {
 			push_error(vformat(R"(Invalid operands "%s" and "%s" for "%s" operator.)", left_type.to_string(), right_type.to_string(), Variant::get_operator_name(p_binary_op->variant_op)), p_binary_op);
-		} else if (result.type_source != GDScriptParser::DataType::ANNOTATED_EXPLICIT) {
+		} else if (!result.is_hard_type()) {
 			mark_node_unsafe(p_binary_op);
 		}
 	} else {


### PR DESCRIPTION
```gdscript
var a := 1
var b := 1 + a # should be safe
```

In #73291 it should have been `ANNOTATED_INFERRED` instead of `ANNOTATED_EXPLICIT`...

Closes #73951.