### PR TITLE
Fix crash when changing VideoStreamPlayer.Stream

### DIFF
--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -251,8 +251,12 @@ void VideoStreamPlaybackTheora::set_file(const String &p_file) {
 
 	/* we're expecting more header packets. */
 	while ((theora_p && theora_p < 3) || (vorbis_p && vorbis_p < 3)) {
+		int ret = 0;
+
 		/* look for further theora headers */
-		int ret = ogg_stream_packetout(&to, &op);
+		if (theora_p && theora_p < 3) {
+			ret = ogg_stream_packetout(&to, &op);
+		}
 		while (theora_p && theora_p < 3 && ret) {
 			if (ret < 0) {
 				fprintf(stderr, "Error parsing Theora stream headers; corrupt stream?\n");
@@ -269,7 +273,9 @@ void VideoStreamPlaybackTheora::set_file(const String &p_file) {
 		}
 
 		/* look for more vorbis header packets */
-		ret = ogg_stream_packetout(&vo, &op);
+		if (vorbis_p && vorbis_p < 3) {
+			ret = ogg_stream_packetout(&vo, &op);
+		}
 		while (vorbis_p && vorbis_p < 3 && ret) {
 			if (ret < 0) {
 				fprintf(stderr, "Error parsing Vorbis stream headers; corrupt stream?\n");


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Closes #72976.
