### PR TITLE
Add warnings for unsupported features in mobile and gl_compatibility backends

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1753,17 +1753,17 @@
 			[b]Note:[/b] This flag is implemented on macOS.
 		</constant>
 		<constant name="VSYNC_DISABLED" value="0" enum="VSyncMode">
-			No vertical synchronization, which means the engine will display frames as fast as possible (tearing may be visible). Framerate is unlimited (nonwithstanding [member Engine.max_fps]). Not supported when using the Compatibility rendering method.
+			No vertical synchronization, which means the engine will display frames as fast as possible (tearing may be visible). Framerate is unlimited (nonwithstanding [member Engine.max_fps]).
 		</constant>
 		<constant name="VSYNC_ENABLED" value="1" enum="VSyncMode">
 			Default vertical synchronization mode, the image is displayed only on vertical blanking intervals (no tearing is visible). Framerate is limited by the monitor refresh rate (nonwithstanding [member Engine.max_fps]).
 		</constant>
 		<constant name="VSYNC_ADAPTIVE" value="2" enum="VSyncMode">
-			Behaves like [constant VSYNC_DISABLED] when the framerate drops below the screen's refresh rate to reduce stuttering (tearing may be visible). Otherwise, vertical synchronization is enabled to avoid tearing. Framerate is limited by the monitor refresh rate (nonwithstanding [member Engine.max_fps]). Not supported when using the Compatibility rendering method.
+			Behaves like [constant VSYNC_DISABLED] when the framerate drops below the screen's refresh rate to reduce stuttering (tearing may be visible). Otherwise, vertical synchronization is enabled to avoid tearing. Framerate is limited by the monitor refresh rate (nonwithstanding [member Engine.max_fps]). Behaves like [constant VSYNC_ENABLED] when using the Compatibility rendering method.
 		</constant>
 		<constant name="VSYNC_MAILBOX" value="3" enum="VSyncMode">
 			Displays the most recent image in the queue on vertical blanking intervals, while rendering to the other images (no tearing is visible). Framerate is unlimited (nonwithstanding [member Engine.max_fps]).
-			Although not guaranteed, the images can be rendered as fast as possible, which may reduce input lag (also called "Fast" V-Sync mode). [constant VSYNC_MAILBOX] works best when at least twice as many frames as the display refresh rate are rendered. Not supported when using the Compatibility rendering method.
+			Although not guaranteed, the images can be rendered as fast as possible, which may reduce input lag (also called "Fast" V-Sync mode). [constant VSYNC_MAILBOX] works best when at least twice as many frames as the display refresh rate are rendered. Behaves like [constant VSYNC_ENABLED] when using the Compatibility rendering method.
 		</constant>
 		<constant name="DISPLAY_HANDLE" value="0" enum="HandleType">
 			Display handle:

--- a/doc/classes/VisualShaderNodeDerivativeFunc.xml
+++ b/doc/classes/VisualShaderNodeDerivativeFunc.xml
@@ -16,7 +16,7 @@
 			A type of operands and returned value. See [enum OpType] for options.
 		</member>
 		<member name="precision" type="int" setter="set_precision" getter="get_precision" enum="VisualShaderNodeDerivativeFunc.Precision" default="0">
-			Sets the level of precision to use for the derivative function. See [enum Precision] for options. When using the GL_Compatibility renderer, this setting has no effect.
+			Sets the level of precision to use for the derivative function. See [enum Precision] for options. When using the GL Compatibility renderer, this setting has no effect.
 		</member>
 	</members>
 	<constants>

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -3373,6 +3373,32 @@ void SceneShaderData::set_code(const String &p_code) {
 	uses_vertex_time = gen_code.uses_vertex_time;
 	uses_fragment_time = gen_code.uses_fragment_time;
 
+#ifdef DEBUG_ENABLED
+	if (uses_particle_trails) {
+		WARN_PRINT_ONCE_ED("Particle trails are only available when using the Forward+ or Mobile rendering backends.");
+	}
+
+	if (uses_sss) {
+		WARN_PRINT_ONCE_ED("Sub-surface scattering is only available when using the Forward+ rendering backend.");
+	}
+
+	if (uses_transmittance) {
+		WARN_PRINT_ONCE_ED("Transmittance is only available when using the Forward+ rendering backend.");
+	}
+
+	if (uses_screen_texture) {
+		WARN_PRINT_ONCE_ED("Reading from the screen texture is not supported when using the GL Compatibility backend yet. Support will be added in a future release.");
+	}
+
+	if (uses_depth_texture) {
+		WARN_PRINT_ONCE_ED("Reading from the depth texture is not supported when using the GL Compatibility backend yet. Support will be added in a future release.");
+	}
+
+	if (uses_normal_texture) {
+		WARN_PRINT_ONCE_ED("Reading from the normal-roughness texture is only available when using the Forward+ or Mobile rendering backends.");
+	}
+#endif
+
 #if 0
 	print_line("**compiling shader:");
 	print_line("**defines:\n");

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7922,7 +7922,9 @@ void Node3DEditor::_load_default_preview_settings() {
 	environ_sky_color->set_pick_color(Color(0.385, 0.454, 0.55));
 	environ_ground_color->set_pick_color(Color(0.2, 0.169, 0.133));
 	environ_energy->set_value(1.0);
-	environ_glow_button->set_pressed(true);
+	if (OS::get_singleton()->get_current_rendering_method() != "gl_compatibility") {
+		environ_glow_button->set_pressed(true);
+	}
 	environ_tonemap_button->set_pressed(true);
 	environ_ao_button->set_pressed(false);
 	environ_gi_button->set_pressed(false);

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -143,6 +143,7 @@ void GPUParticles2D::set_trail_enabled(bool p_enabled) {
 	trail_enabled = p_enabled;
 	RS::get_singleton()->particles_set_trails(particles, trail_enabled, trail_lifetime);
 	queue_redraw();
+	update_configuration_warnings();
 
 	RS::get_singleton()->particles_set_transform_align(particles, p_enabled ? RS::PARTICLES_TRANSFORM_ALIGN_Y_TO_VELOCITY : RS::PARTICLES_TRANSFORM_ALIGN_DISABLED);
 }
@@ -312,6 +313,10 @@ PackedStringArray GPUParticles2D::get_configuration_warnings() const {
 				warnings.push_back(RTR("Particles2D animation requires the usage of a CanvasItemMaterial with \"Particles Animation\" enabled."));
 			}
 		}
+	}
+
+	if (trail_enabled && OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
+		warnings.push_back(RTR("Particle trails are only available when using the Forward+ or Mobile rendering backends."));
 	}
 
 	return warnings;

--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -165,6 +165,11 @@ void Decal::_validate_property(PropertyInfo &p_property) const {
 PackedStringArray Decal::get_configuration_warnings() const {
 	PackedStringArray warnings = Node::get_configuration_warnings();
 
+	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
+		warnings.push_back(RTR("Decals are only available when using the Forward+ or Mobile rendering backends."));
+		return warnings;
+	}
+
 	if (textures[TEXTURE_ALBEDO].is_null() && textures[TEXTURE_NORMAL].is_null() && textures[TEXTURE_ORM].is_null() && textures[TEXTURE_EMISSION].is_null()) {
 		warnings.push_back(RTR("The decal has no textures loaded into any of its texture properties, and will therefore not be visible."));
 	}

--- a/scene/3d/fog_volume.cpp
+++ b/scene/3d/fog_volume.cpp
@@ -122,8 +122,13 @@ PackedStringArray FogVolume::get_configuration_warnings() const {
 
 	Ref<Environment> environment = get_viewport()->find_world_3d()->get_environment();
 
+	if (OS::get_singleton()->get_current_rendering_method() != "forward_plus") {
+		warnings.push_back(RTR("Fog Volumes are only visible when using the Forward+ backend."));
+		return warnings;
+	}
+
 	if (environment.is_valid() && !environment->is_volumetric_fog_enabled()) {
-		warnings.push_back(("Fog Volumes need volumetric fog to be enabled in the scene's Environment in order to be visible."));
+		warnings.push_back(RTR("Fog Volumes need volumetric fog to be enabled in the scene's Environment in order to be visible."));
 	}
 
 	return warnings;

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -358,6 +358,9 @@ PackedStringArray GPUParticles3D::get_configuration_warnings() const {
 		if ((dp_count || !skin.is_null()) && (missing_trails || no_materials)) {
 			warnings.push_back(RTR("Trails enabled, but one or more mesh materials are either missing or not set for trails rendering."));
 		}
+		if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
+			warnings.push_back(RTR("Particle trails are only available when using the Forward+ or Mobile rendering backends."));
+		}
 	}
 
 	return warnings;

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -56,11 +56,8 @@ void Light3D::set_shadow(bool p_enable) {
 	shadow = p_enable;
 	RS::get_singleton()->light_set_shadow(light, p_enable);
 
-	if (type == RenderingServer::LIGHT_SPOT || type == RenderingServer::LIGHT_OMNI) {
-		update_configuration_warnings();
-	}
-
 	notify_property_list_changed();
+	update_configuration_warnings();
 }
 
 bool Light3D::has_shadow() const {
@@ -174,6 +171,10 @@ AABB Light3D::get_aabb() const {
 
 PackedStringArray Light3D::get_configuration_warnings() const {
 	PackedStringArray warnings = VisualInstance3D::get_configuration_warnings();
+
+	if (has_shadow() && OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
+		warnings.push_back(RTR("Shadows are not supported when using the GL Compatibility backend yet. Support will be added in a future release."));
+	}
 
 	if (!get_scale().is_equal_approx(Vector3(1, 1, 1))) {
 		warnings.push_back(RTR("A light's scale does not affect the visual size of the light."));
@@ -603,6 +604,10 @@ PackedStringArray OmniLight3D::get_configuration_warnings() const {
 		warnings.push_back(RTR("Projector texture only works with shadows active."));
 	}
 
+	if (get_projector().is_valid() && OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
+		warnings.push_back(RTR("Projector textures are not supported when using the GL Compatibility backend yet. Support will be added in a future release."));
+	}
+
 	return warnings;
 }
 
@@ -633,6 +638,10 @@ PackedStringArray SpotLight3D::get_configuration_warnings() const {
 
 	if (!has_shadow() && get_projector().is_valid()) {
 		warnings.push_back(RTR("Projector texture only works with shadows active."));
+	}
+
+	if (get_projector().is_valid() && OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
+		warnings.push_back(RTR("Projector textures are not supported when using the GL Compatibility backend yet. Support will be added in a future release."));
 	}
 
 	return warnings;

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1458,6 +1458,17 @@ Ref<CameraAttributes> LightmapGI::get_camera_attributes() const {
 	return camera_attributes;
 }
 
+PackedStringArray LightmapGI::get_configuration_warnings() const {
+	PackedStringArray warnings = Node::get_configuration_warnings();
+
+	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
+		warnings.push_back(RTR("LightmapGI nodes are not supported when using the GL Compatibility backend yet. Support will be added in a future release."));
+		return warnings;
+	}
+
+	return warnings;
+}
+
 void LightmapGI::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name == "environment_custom_sky" && environment_mode != ENVIRONMENT_MODE_CUSTOM_SKY) {
 		p_property.usage = PROPERTY_USAGE_NONE;

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -274,6 +274,9 @@ public:
 	AABB get_aabb() const override;
 
 	BakeError bake(Node *p_from_node, String p_image_data_path = "", Lightmapper::BakeStepFunc p_bake_step = nullptr, void *p_bake_userdata = nullptr);
+
+	virtual PackedStringArray get_configuration_warnings() const override;
+
 	LightmapGI();
 };
 

--- a/scene/3d/reflection_probe.cpp
+++ b/scene/3d/reflection_probe.cpp
@@ -180,6 +180,17 @@ AABB ReflectionProbe::get_aabb() const {
 	return aabb;
 }
 
+PackedStringArray ReflectionProbe::get_configuration_warnings() const {
+	PackedStringArray warnings = Node::get_configuration_warnings();
+
+	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
+		warnings.push_back(RTR("ReflectionProbes are not supported when using the GL Compatibility backend yet. Support will be added in a future release."));
+		return warnings;
+	}
+
+	return warnings;
+}
+
 void ReflectionProbe::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name == "ambient_color" || p_property.name == "ambient_color_energy") {
 		if (ambient_mode != AMBIENT_COLOR) {

--- a/scene/3d/reflection_probe.h
+++ b/scene/3d/reflection_probe.h
@@ -118,6 +118,8 @@ public:
 
 	virtual AABB get_aabb() const override;
 
+	virtual PackedStringArray get_configuration_warnings() const override;
+
 	ReflectionProbe();
 	~ReflectionProbe();
 };

--- a/scene/3d/visible_on_screen_notifier_3d.cpp
+++ b/scene/3d/visible_on_screen_notifier_3d.cpp
@@ -79,6 +79,16 @@ void VisibleOnScreenNotifier3D::_notification(int p_what) {
 	}
 }
 
+PackedStringArray VisibleOnScreenNotifier3D::get_configuration_warnings() const {
+	PackedStringArray warnings = VisualInstance3D::get_configuration_warnings();
+
+	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
+		warnings.push_back(RTR("VisibleOnScreenNotifier3D nodes are not supported when using the GL Compatibility backend yet. Support will be added in a future release."));
+	}
+
+	return warnings;
+}
+
 void VisibleOnScreenNotifier3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_aabb", "rect"), &VisibleOnScreenNotifier3D::set_aabb);
 	ClassDB::bind_method(D_METHOD("is_on_screen"), &VisibleOnScreenNotifier3D::is_on_screen);

--- a/scene/3d/visible_on_screen_notifier_3d.h
+++ b/scene/3d/visible_on_screen_notifier_3d.h
@@ -57,6 +57,8 @@ public:
 	virtual AABB get_aabb() const override;
 	bool is_on_screen() const;
 
+	virtual PackedStringArray get_configuration_warnings() const override;
+
 	VisibleOnScreenNotifier3D();
 	~VisibleOnScreenNotifier3D();
 };

--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -492,8 +492,8 @@ AABB VoxelGI::get_aabb() const {
 PackedStringArray VoxelGI::get_configuration_warnings() const {
 	PackedStringArray warnings = Node::get_configuration_warnings();
 
-	if (RenderingServer::get_singleton()->is_low_end()) {
-		warnings.push_back(RTR("VoxelGIs are not supported by the OpenGL video driver.\nUse a LightmapGI instead."));
+	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
+		warnings.push_back(RTR("VoxelGI nodes are not supported when using the GL Compatibility backend yet. Support will be added in a future release."));
 	} else if (probe_data.is_null()) {
 		warnings.push_back(RTR("No VoxelGI data set, so this node is disabled. Bake static objects to enable GI."));
 	}

--- a/scene/resources/camera_attributes.cpp
+++ b/scene/resources/camera_attributes.cpp
@@ -394,6 +394,13 @@ void CameraAttributesPhysical::_update_frustum() {
 
 	bool use_far = (far < frustum_far) && (far > 0.0);
 	bool use_near = near > frustum_near;
+#ifdef DEBUG_ENABLED
+	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
+		// Force disable DoF in editor builds to suppress warnings.
+		use_far = false;
+		use_near = false;
+	}
+#endif
 	RS::get_singleton()->camera_attributes_set_dof_blur(
 			get_rid(),
 			use_far,

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -1108,13 +1108,6 @@ void Environment::_validate_property(PropertyInfo &p_property) const {
 
 	};
 
-	static const char *high_end_prefixes[] = {
-		"ssr_",
-		"ssao_",
-		nullptr
-
-	};
-
 	const char **prefixes = hide_prefixes;
 	while (*prefixes) {
 		String prefix = String(*prefixes);
@@ -1126,20 +1119,6 @@ void Environment::_validate_property(PropertyInfo &p_property) const {
 		}
 
 		prefixes++;
-	}
-
-	if (RenderingServer::get_singleton()->is_low_end()) {
-		prefixes = high_end_prefixes;
-		while (*prefixes) {
-			String prefix = String(*prefixes);
-
-			if (p_property.name.begins_with(prefix)) {
-				p_property.usage = PROPERTY_USAGE_NO_EDITOR;
-				return;
-			}
-
-			prefixes++;
-		}
 	}
 }
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1914,12 +1914,6 @@ void BaseMaterial3D::_validate_feature(const String &text, Feature feature, Prop
 	}
 }
 
-void BaseMaterial3D::_validate_high_end(const String &text, PropertyInfo &property) const {
-	if (property.name.begins_with(text)) {
-		property.usage |= PROPERTY_USAGE_HIGH_END_GFX;
-	}
-}
-
 void BaseMaterial3D::_validate_property(PropertyInfo &p_property) const {
 	_validate_feature("normal", FEATURE_NORMAL_MAPPING, p_property);
 	_validate_feature("emission", FEATURE_EMISSION, p_property);
@@ -1932,10 +1926,6 @@ void BaseMaterial3D::_validate_property(PropertyInfo &p_property) const {
 	_validate_feature("backlight", FEATURE_BACKLIGHT, p_property);
 	_validate_feature("refraction", FEATURE_REFRACTION, p_property);
 	_validate_feature("detail", FEATURE_DETAIL, p_property);
-
-	_validate_high_end("refraction", p_property);
-	_validate_high_end("subsurf_scatter", p_property);
-	_validate_high_end("heightmap", p_property);
 
 	if (p_property.name == "emission_intensity" && !GLOBAL_GET("rendering/lights_and_shadows/use_physical_light_units")) {
 		p_property.usage = PROPERTY_USAGE_NONE;

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -543,8 +543,6 @@ private:
 
 	static HashMap<uint64_t, Ref<StandardMaterial3D>> materials_for_2d; //used by Sprite3D, Label3D and other stuff
 
-	void _validate_high_end(const String &text, PropertyInfo &property) const;
-
 protected:
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -114,8 +114,8 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 	actions.usage_flag_pointers["ALPHA_TEXTURE_COORDINATE"] = &uses_alpha_antialiasing;
 	actions.render_mode_flags["depth_prepass_alpha"] = &uses_depth_prepass_alpha;
 
-	// actions.usage_flag_pointers["SSS_STRENGTH"] = &uses_sss;
-	// actions.usage_flag_pointers["SSS_TRANSMITTANCE_DEPTH"] = &uses_transmittance;
+	actions.usage_flag_pointers["SSS_STRENGTH"] = &uses_sss;
+	actions.usage_flag_pointers["SSS_TRANSMITTANCE_DEPTH"] = &uses_transmittance;
 
 	actions.usage_flag_pointers["DISCARD"] = &uses_discard;
 	actions.usage_flag_pointers["TIME"] = &uses_time;
@@ -149,6 +149,16 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 	uses_screen_texture = gen_code.uses_screen_texture;
 	uses_depth_texture = gen_code.uses_depth_texture;
 	uses_normal_texture = gen_code.uses_normal_roughness_texture;
+
+#ifdef DEBUG_ENABLED
+	if (uses_sss) {
+		WARN_PRINT_ONCE_ED("Sub-surface scattering is only available when using the Forward+ rendering backend.");
+	}
+
+	if (uses_transmittance) {
+		WARN_PRINT_ONCE_ED("Transmittance is only available when using the Forward+ rendering backend.");
+	}
+#endif
 
 #if 0
 	print_line("**compiling shader:");

--- a/servers/rendering/storage/camera_attributes_storage.cpp
+++ b/servers/rendering/storage/camera_attributes_storage.cpp
@@ -65,7 +65,11 @@ void RendererCameraAttributes::camera_attributes_set_dof_blur_bokeh_shape(RS::DO
 void RendererCameraAttributes::camera_attributes_set_dof_blur(RID p_camera_attributes, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) {
 	CameraAttributes *cam_attributes = camera_attributes_owner.get_or_null(p_camera_attributes);
 	ERR_FAIL_COND(!cam_attributes);
-
+#ifdef DEBUG_ENABLED
+	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility" && (p_far_enable || p_near_enable)) {
+		WARN_PRINT_ONCE_ED("DoF blur is only available when using the Forward+ or Mobile rendering backends.");
+	}
+#endif
 	cam_attributes->dof_blur_far_enabled = p_far_enable;
 	cam_attributes->dof_blur_far_distance = p_far_distance;
 	cam_attributes->dof_blur_far_transition = p_far_transition;
@@ -139,6 +143,11 @@ void RendererCameraAttributes::camera_attributes_set_auto_exposure(RID p_camera_
 	if (!cam_attributes->use_auto_exposure && p_enable) {
 		cam_attributes->auto_exposure_version = ++auto_exposure_counter;
 	}
+#ifdef DEBUG_ENABLED
+	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility" && p_enable) {
+		WARN_PRINT_ONCE_ED("Auto exposure is only available when using the Forward+ or Mobile rendering backends.");
+	}
+#endif
 	cam_attributes->use_auto_exposure = p_enable;
 	cam_attributes->auto_exposure_min_sensitivity = p_min_sensitivity;
 	cam_attributes->auto_exposure_max_sensitivity = p_max_sensitivity;

--- a/servers/rendering/storage/environment_storage.cpp
+++ b/servers/rendering/storage/environment_storage.cpp
@@ -278,6 +278,11 @@ float RendererEnvironmentStorage::environment_get_fog_sky_affect(RID p_env) cons
 void RendererEnvironmentStorage::environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect) {
 	Environment *env = environment_owner.get_or_null(p_env);
 	ERR_FAIL_COND(!env);
+#ifdef DEBUG_ENABLED
+	if (OS::get_singleton()->get_current_rendering_method() != "forward_plus" && p_enable) {
+		WARN_PRINT_ONCE_ED("Volumetric fog can only be enabled when using the Forward+ rendering backend.");
+	}
+#endif
 	env->volumetric_fog_enabled = p_enable;
 	env->volumetric_fog_density = p_density;
 	env->volumetric_fog_scattering = p_albedo;
@@ -377,6 +382,11 @@ void RendererEnvironmentStorage::environment_set_glow(RID p_env, bool p_enable, 
 	Environment *env = environment_owner.get_or_null(p_env);
 	ERR_FAIL_COND(!env);
 	ERR_FAIL_COND_MSG(p_levels.size() != 7, "Size of array of glow levels must be 7");
+#ifdef DEBUG_ENABLED
+	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility" && p_enable) {
+		WARN_PRINT_ONCE_ED("Glow is not supported when using the GL Compatibility backend yet. Support will be added in a future release.");
+	}
+#endif
 	env->glow_enabled = p_enable;
 	env->glow_levels = p_levels;
 	env->glow_intensity = p_intensity;
@@ -468,6 +478,11 @@ RID RendererEnvironmentStorage::environment_get_glow_map(RID p_env) const {
 void RendererEnvironmentStorage::environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_int, float p_fade_out, float p_depth_tolerance) {
 	Environment *env = environment_owner.get_or_null(p_env);
 	ERR_FAIL_COND(!env);
+#ifdef DEBUG_ENABLED
+	if (OS::get_singleton()->get_current_rendering_method() != "forward_plus" && p_enable) {
+		WARN_PRINT_ONCE_ED("Screen-space reflections (SSR) can only be enabled when using the Forward+ rendering backend.");
+	}
+#endif
 	env->ssr_enabled = p_enable;
 	env->ssr_max_steps = p_max_steps;
 	env->ssr_fade_in = p_fade_int;
@@ -510,6 +525,11 @@ float RendererEnvironmentStorage::environment_get_ssr_depth_tolerance(RID p_env)
 void RendererEnvironmentStorage::environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_power, float p_detail, float p_horizon, float p_sharpness, float p_light_affect, float p_ao_channel_affect) {
 	Environment *env = environment_owner.get_or_null(p_env);
 	ERR_FAIL_COND(!env);
+#ifdef DEBUG_ENABLED
+	if (OS::get_singleton()->get_current_rendering_method() != "forward_plus" && p_enable) {
+		WARN_PRINT_ONCE_ED("Screen-space ambient occlusion (SSAO) can only be enabled when using the Forward+ rendering backend.");
+	}
+#endif
 	env->ssao_enabled = p_enable;
 	env->ssao_radius = p_radius;
 	env->ssao_intensity = p_intensity;
@@ -580,6 +600,11 @@ float RendererEnvironmentStorage::environment_get_ssao_ao_channel_affect(RID p_e
 void RendererEnvironmentStorage::environment_set_ssil(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_sharpness, float p_normal_rejection) {
 	Environment *env = environment_owner.get_or_null(p_env);
 	ERR_FAIL_COND(!env);
+#ifdef DEBUG_ENABLED
+	if (OS::get_singleton()->get_current_rendering_method() != "forward_plus" && p_enable) {
+		WARN_PRINT_ONCE_ED("Screen-space indirect lighting (SSIL) can only be enabled when using the Forward+ rendering backend.");
+	}
+#endif
 	env->ssil_enabled = p_enable;
 	env->ssil_radius = p_radius;
 	env->ssil_intensity = p_intensity;
@@ -622,6 +647,11 @@ float RendererEnvironmentStorage::environment_get_ssil_normal_rejection(RID p_en
 void RendererEnvironmentStorage::environment_set_sdfgi(RID p_env, bool p_enable, int p_cascades, float p_min_cell_size, RS::EnvironmentSDFGIYScale p_y_scale, bool p_use_occlusion, float p_bounce_feedback, bool p_read_sky, float p_energy, float p_normal_bias, float p_probe_bias) {
 	Environment *env = environment_owner.get_or_null(p_env);
 	ERR_FAIL_COND(!env);
+#ifdef DEBUG_ENABLED
+	if (OS::get_singleton()->get_current_rendering_method() != "forward_plus" && p_enable) {
+		WARN_PRINT_ONCE_ED("SDFGI can only be enabled when using the Forward+ rendering backend.");
+	}
+#endif
 	env->sdfgi_enabled = p_enable;
 	env->sdfgi_cascades = p_cascades;
 	env->sdfgi_min_cell_size = p_min_cell_size;
@@ -699,6 +729,11 @@ RS::EnvironmentSDFGIYScale RendererEnvironmentStorage::environment_get_sdfgi_y_s
 void RendererEnvironmentStorage::environment_set_adjustment(RID p_env, bool p_enable, float p_brightness, float p_contrast, float p_saturation, bool p_use_1d_color_correction, RID p_color_correction) {
 	Environment *env = environment_owner.get_or_null(p_env);
 	ERR_FAIL_COND(!env);
+#ifdef DEBUG_ENABLED
+	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility" && p_enable) {
+		WARN_PRINT_ONCE_ED("Adjustments are not supported when using the GL Compatibility backend yet. Support will be added in a future release.");
+	}
+#endif
 	env->adjustments_enabled = p_enable;
 	env->adjustments_brightness = p_brightness;
 	env->adjustments_contrast = p_contrast;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/55880

This PR does a few things:
1. Adds compatibility warnings when nodes that are unsupported are used
2. Adds ``WARN_PRINT_ONCE_ED`` messages when features that are unsupported are used
3. Removes the code to hide "high end" features in Environment and BaseMaterial
4. Changes the default Environment to disable glow when using the gl_compatibility backend
5. Fixes the description of Vsync modes in class reference

@BastiaanOlij and I discussed and agreed that we should stop hiding "high end" features in the editor as it was often creating an awkward situation for users where they would enable something, switch to the low end backend, and then they couldn't disable the thing without switching back. Similarly, we often got reports about missing features because the feature didn't appear in the editor. Having a toast pop up with a warning is preferable as it clearly communicates the lack of the feature and allows users to turn the feature off if it is turned on. 
