### PR TITLE
GDScript: Fix handling of temporary addresses in ternary operator

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -834,29 +834,29 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			}
 			gen->write_ternary_condition(condition);
 
-			if (condition.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-				gen->pop_temporary();
-			}
-
 			GDScriptCodeGenerator::Address true_expr = _parse_expression(codegen, r_error, ternary->true_expr);
 			if (r_error) {
 				return GDScriptCodeGenerator::Address();
 			}
 			gen->write_ternary_true_expr(true_expr);
-			if (true_expr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-				gen->pop_temporary();
-			}
 
 			GDScriptCodeGenerator::Address false_expr = _parse_expression(codegen, r_error, ternary->false_expr);
 			if (r_error) {
 				return GDScriptCodeGenerator::Address();
 			}
 			gen->write_ternary_false_expr(false_expr);
+
+			gen->write_end_ternary();
+
 			if (false_expr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
 				gen->pop_temporary();
 			}
-
-			gen->write_end_ternary();
+			if (true_expr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+				gen->pop_temporary();
+			}
+			if (condition.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+				gen->pop_temporary();
+			}
 
 			return result;
 		} break;


### PR DESCRIPTION
Currently ternary will produce:
```
OPCODE_JUMP_IF_NOT // to FALSE position
// a) pops condition temporary
OPCODE_ASSIGN // true value
OPCODE_JUMP // to END position
// b) pops true value temporary
// FALSE position
OPCODE_ASSIGN // false value
// END position
// c) pops false value temporary
```

The problem here is with `pops` - for temporary addresses of a object type `OPCODE_ASSIGN_FALSE` will be added at the place of call to clear references. 

From that you can see that such reference clearing is skipped for a condition if its false and is always skipped for true value.

The fix is to move all pops after ternary end (location `c`).

As I understand it is not big deal, just keeps some objects longer alive then needed.