### PR TITLE
GDScript: Fix address type for coroutine results

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -85,7 +85,7 @@ void GDScriptCompiler::_set_error(const String &p_error, const GDScriptParser::N
 }
 
 GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::DataType &p_datatype, GDScript *p_owner) {
-	if (!p_datatype.is_set() || !p_datatype.is_hard_type()) {
+	if (!p_datatype.is_set() || !p_datatype.is_hard_type() || p_datatype.is_coroutine) {
 		return GDScriptDataType();
 	}
 


### PR DESCRIPTION
Type of a result of a coroutine call is not equal to bare declared return type (so it is not simply `int` or `String` even if a function has that as a specified return type).

Wrong type was causing issues because temporary addresses are split by types and results of coroutine calls were writing their things into addresses that were not meant for this.

Closes #73258.

_Bugsquad edit:_ Fix #70637