### PR TITLE
Converter: Rename 3.x Vector2 `clamped` to `limit_length`

### DIFF
--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -1055,20 +1055,20 @@ bool ProjectConverter3To4::test_array_names() {
 
 		// List of excluded functions from builtin types and global namespace, because currently it is not possible to get list of functions from them.
 		// This will be available when https://github.com/godotengine/godot/pull/49053 or similar will be included into Godot.
-		static const char *builtin_types_excluded_functions[] = { "dict_to_inst", "inst_to_dict", "bytes_to_var", "bytes_to_var_with_objects", "db_to_linear", "deg_to_rad", "linear_to_db", "rad_to_deg", "randf_range", "snapped", "str_to_var", "var_to_str", "var_to_bytes", "var_to_bytes_with_objects", "move_toward", "uri_encode", "uri_decode", "remove_at", "get_rotation_quaternion", "clamp", "grow_side", "is_absolute_path", "is_valid_int", "lerp", "to_ascii_buffer", "to_utf8_buffer", "to_utf32_buffer", "snapped", "remap", "rfind", nullptr };
+		static const char *builtin_types_excluded_functions[] = { "dict_to_inst", "inst_to_dict", "bytes_to_var", "bytes_to_var_with_objects", "db_to_linear", "deg_to_rad", "linear_to_db", "rad_to_deg", "randf_range", "snapped", "str_to_var", "var_to_str", "var_to_bytes", "var_to_bytes_with_objects", "move_toward", "uri_encode", "uri_decode", "remove_at", "get_rotation_quaternion", "limit_length", "grow_side", "is_absolute_path", "is_valid_int", "lerp", "to_ascii_buffer", "to_utf8_buffer", "to_utf32_buffer", "snapped", "remap", "rfind", nullptr };
 		for (int current_index = 0; builtin_types_excluded_functions[current_index]; current_index++) {
 			all_functions.insert(builtin_types_excluded_functions[current_index]);
 		}
 
-		//			for (int type = Variant::Type::NIL + 1; type < Variant::Type::VARIANT_MAX; type++) {
-		//				List<MethodInfo> method_list;
-		//				Variant::get_method_list_by_type(&method_list, Variant::Type(type));
-		//				for (MethodInfo &function_data : method_list) {
-		//					if (!all_functions.has(function_data.name)) {
-		//						all_functions.insert(function_data.name);
-		//					}
-		//				}
-		//			}
+		//for (int type = Variant::Type::NIL + 1; type < Variant::Type::VARIANT_MAX; type++) {
+		//	List<MethodInfo> method_list;
+		//	Variant::get_method_list_by_type(&method_list, Variant::Type(type));
+		//	for (MethodInfo &function_data : method_list) {
+		//		if (!all_functions.has(function_data.name)) {
+		//			all_functions.insert(function_data.name);
+		//		}
+		//	}
+		//}
 
 		List<StringName> classes_list;
 		ClassDB::get_class_list(&classes_list);

--- a/editor/renames_map_3_to_4.cpp
+++ b/editor/renames_map_3_to_4.cpp
@@ -577,9 +577,9 @@ const char *RenamesMap3To4::gdscript_function_renames[][2] = {
 
 	// Builtin types
 	// Remember to add them to the builtin_types_excluded_functions variable, because for now these functions cannot be listed.
-	//	{ "empty", "is_empty" }, // Array -- Used as custom rule. Be careful, this will be used everywhere.
-	//	{ "remove", "remove_at" }, // Array -- Breaks Directory and several more.
-	{ "clamped", "clamp" }, // Vector2 -- Be careful, this will be used everywhere.
+	//{ "empty", "is_empty" }, // Array -- Used as custom rule. Be careful, this will be used everywhere.
+	//{ "remove", "remove_at" }, // Array -- Breaks Directory and several more.
+	{ "clamped", "limit_length" }, // Vector2
 	{ "get_rotation_quat", "get_rotation_quaternion" }, // Basis
 	{ "grow_margin", "grow_side" }, // Rect2
 	{ "invert", "reverse" }, // Array -- Give it a check. Be careful, this will be used everywhere.
@@ -1024,9 +1024,9 @@ const char *RenamesMap3To4::csharp_function_renames[][2] = {
 	{ "GetUniformName", "GetParameterName" }, // ParameterRef
 
 	// Builtin types
-	//	{ "Empty", "IsEmpty" }, // Array -- Used as custom rule. Be careful, this will be used everywhere.
-	//	{ "Remove", "RemoveAt" }, // Array -- Breaks Directory and several more.
-	{ "Clamped", "Clamp" }, // Vector2 -- Be careful, this will be used everywhere.
+	// { "Empty", "IsEmpty" }, // Array -- Used as custom rule. Be careful, this will be used everywhere.
+	// { "Remove", "RemoveAt" }, // Array -- Breaks Directory and several more.
+	{ "Clamped", "LimitLength" }, // Vector2
 	{ "GetRotationQuat", "GetRotationQuaternion" }, // Basis
 	{ "GrowMargin", "GrowSide" }, // Rect2
 	{ "Invert", "Reverse" }, // Array -- Give it a check. Be careful, this will be used everywhere.


### PR DESCRIPTION
Doc already said for 3.5 clamped is deprecated and limit_lenght should be used, clamp is the wrong function

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
