### PR TITLE
RegEx: Fix handling of unset/unknown capture groups

### DIFF
--- a/modules/regex/regex.h
+++ b/modules/regex/regex.h
@@ -78,6 +78,8 @@ class RegEx : public RefCounted {
 
 	void _pattern_info(uint32_t what, void *where) const;
 
+	int _sub(const String &p_subject, const String &p_replacement, int p_offset, int p_end, uint32_t p_flags, String &r_output) const;
+
 protected:
 	static void _bind_methods();
 

--- a/modules/regex/tests/test_regex.h
+++ b/modules/regex/tests/test_regex.h
@@ -145,6 +145,15 @@ TEST_CASE("[RegEx] Substitution") {
 	CHECK(re5.sub(s5, "cc", true, 0, 2) == "ccccaa");
 	CHECK(re5.sub(s5, "cc", true, 1, 3) == "acccca");
 	CHECK(re5.sub(s5, "", true, 0, 2) == "aa");
+
+	const String s6 = "property get_property set_property";
+
+	RegEx re6("(get_|set_)?property");
+	REQUIRE(re6.is_valid());
+	CHECK(re6.sub(s6, "$1new_property", true) == "new_property get_new_property set_new_property");
+	ERR_PRINT_OFF;
+	CHECK(re6.sub(s6, "$5new_property", true) == "new_property new_property new_property");
+	ERR_PRINT_ON;
 }
 
 TEST_CASE("[RegEx] Substitution with empty input and/or replacement") {


### PR DESCRIPTION
Add the `PCRE2_SUBSTITUTE_UNSET_EMPTY` flag so that unset capture groups do not clear the line.

* Closes godotengine/godot-proposals#6114.
* See also #73954.

https://www.pcre.org/current/doc/html/pcre2api.html

> PCRE2_SUBSTITUTE_UNKNOWN_UNSET causes references to capture groups that do not appear in the pattern to be treated as unset groups. This option should be used with care, because it means that a typo in a group name or number no longer causes the PCRE2_ERROR_NOSUBSTRING error.
>
> PCRE2_SUBSTITUTE_UNSET_EMPTY causes unset capture groups (including unknown groups when PCRE2_SUBSTITUTE_UNKNOWN_UNSET is set) to be treated as empty strings when inserted as described above. If this option is not set, an attempt to insert an unset group causes the PCRE2_ERROR_UNSET error. This option does not influence the extended substitution syntax described below. 

* Add error message output.

Example:

```gdscript
var line := "property get_property set_property"

var re1 := RegEx.new()
re1.compile("((get_|set_)?)property")

var re2 := RegEx.new()
re2.compile("(get_|set_)?property")

print("|", re1.sub(line, "$1new_property", true), "|")
print("|", re2.sub(line, "$1new_property", true), "|")
print("|", re2.sub(line, "$5new_property", true), "|")
```

Before:

```
|new_property get_new_property set_new_property|
||
||
```

After:

```
|new_property get_new_property set_new_property|
|new_property get_new_property set_new_property|
  modules/regex/regex.cpp:332 - PCRE2 Error: unknown substring
|new_property new_property new_property|
```