### PR TITLE
Fix shader preprocessor include resource check

### DIFF
--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -679,6 +679,11 @@ void ShaderPreprocessor::process_include(Tokenizer *p_tokenizer) {
 		path = state->current_filename.get_base_dir().path_join(path);
 	}
 
+	if (!ResourceLoader::exists(path)) {
+		set_error(RTR("Shader include file does not exist: ") + path, line);
+		return;
+	}
+
 	Ref<Resource> res = ResourceLoader::load(path);
 	if (res.is_null()) {
 		set_error(RTR("Shader include load failed. Does the shader include exist? Is there a cyclic dependency?"), line);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/73925

This extra check is needed because both Shader and ShaderInclude implement their resource loader (which gets eventually called by `ResourceLoader::load()`) in a somewhat strange way comapred to many other loaders. Neither loader can never really "fail" and they don't check for any errors, they will always return a valid resource, but with empty text content. In short, previously almost all include paths "worked" even if the file did not even exist and these places simply included an empty string without raising any erros.

A more fundamental fix would be to add error checking to both resource loaders, but that would be a high-risk fix as much of the exisiting codebase might not be prepared for these loaders to suddenly start returning null resources.

I can make a separarete PR to add error checking if that sounds like a good idea. It could be tested and merged later when 4.0 is out and there is more room for risky changes.