### PR TITLE
Sync tutorial paths for GI classes with online documentation changes

### DIFF
--- a/doc/classes/ReflectionProbe.xml
+++ b/doc/classes/ReflectionProbe.xml
@@ -11,7 +11,7 @@
 		[b]Note:[/b] When using the Mobile rendering method, reflection probes will only correctly affect meshes whose visibility AABB intersects with the reflection probe's AABB. If using a shader to deform the mesh in a way that makes it go outside its AABB, [member GeometryInstance3D.extra_cull_margin] must be increased on the mesh. Otherwise, the reflection probe may not be visible on the mesh.
 	</description>
 	<tutorials>
-		<link title="Reflection probes">$DOCS_URL/tutorials/3d/reflection_probes.html</link>
+		<link title="Reflection probes">$DOCS_URL/tutorials/3d/global_illumination/reflection_probes.html</link>
 	</tutorials>
 	<members>
 		<member name="ambient_color" type="Color" setter="set_ambient_color" getter="get_ambient_color" default="Color(0, 0, 0, 1)">

--- a/doc/classes/VoxelGI.xml
+++ b/doc/classes/VoxelGI.xml
@@ -11,7 +11,7 @@
 		[b]Note:[/b] Meshes should have sufficiently thick walls to avoid light leaks (avoid one-sided walls). For interior levels, enclose your level geometry in a sufficiently large box and bridge the loops to close the mesh. To further prevent light leaks, you can also strategically place temporary [MeshInstance3D] nodes with their [member GeometryInstance3D.gi_mode] set to [constant GeometryInstance3D.GI_MODE_STATIC]. These temporary nodes can then be hidden after baking the [VoxelGI] node.
 	</description>
 	<tutorials>
-		<link title="VoxelGI">$DOCS_URL/tutorials/3d/using_voxel_gi.html</link>
+		<link title="VoxelGI">$DOCS_URL/tutorials/3d/global_illumination/using_voxel_gi.html</link>
 		<link title="Third Person Shooter Demo">https://godotengine.org/asset-library/asset/678</link>
 	</tutorials>
 	<methods>


### PR DESCRIPTION
This is a counterpart of https://github.com/godotengine/godot-docs/pull/6826. I'm putting it on 4.0 in case we merge the docs changes before the release.