### PR TITLE
Clarify when Expression `get_error_text()` is updated

### DIFF
--- a/doc/classes/Expression.xml
+++ b/doc/classes/Expression.xml
@@ -65,7 +65,7 @@
 		<method name="get_error_text" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the error text if [method parse] has failed.
+				Returns the error text if [method parse] or [method execute] has failed.
 			</description>
 		</method>
 		<method name="has_execute_failed" qualifiers="const">


### PR DESCRIPTION
The description for Expression.get_error_text() reads like it only returns the error text on failure parsing the expression string. However, it also returns the error text if the expression fails to execute for some reason. This should be mentioned in the docs as it's a very useful feature.