### PR TITLE
Decrease 3D rendering resolution on mobile by default

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2321,6 +2321,9 @@
 		<member name="rendering/scaling_3d/scale" type="float" setter="" getter="" default="1.0">
 			Scales the 3D render buffer based on the viewport size uses an image filter specified in [member rendering/scaling_3d/mode] to scale the output image to the full viewport size. Values lower than [code]1.0[/code] can be used to speed up 3D rendering at the cost of quality (undersampling). Values greater than [code]1.0[/code] are only valid for bilinear mode and can be used to improve 3D rendering quality at a high performance cost (supersampling). See also [member rendering/anti_aliasing/quality/msaa_3d] for multi-sample antialiasing, which is significantly cheaper but only smooths the edges of polygons.
 		</member>
+		<member name="rendering/scaling_3d/scale.mobile" type="float" setter="" getter="" default="0.5">
+			Mobile override for [member rendering/scaling_3d/scale] to improve 3D rendering performance significantly. Mobile displays often have high DPI, so the loss in quality isn't as noticeable as it would be on a display with lower DPI.
+		</member>
 		<member name="rendering/shader_compiler/shader_cache/compress" type="bool" setter="" getter="" default="true">
 		</member>
 		<member name="rendering/shader_compiler/shader_cache/enabled" type="bool" setter="" getter="" default="true">

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2937,6 +2937,9 @@ void RenderingServer::init() {
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/scaling_3d/mode", PROPERTY_HINT_ENUM, "Bilinear (Fastest),FSR 1.0 (Fast)"), 0);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/scaling_3d/scale", PROPERTY_HINT_RANGE, "0.25,2.0,0.01"), 1.0);
+	// Render 3D at a lower resolution on mobile by default, as mobile displays
+	// often have high DPI but GPUs are very limited in comparison to desktop.
+	GLOBAL_DEF("rendering/scaling_3d/scale.mobile", 0.5);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/scaling_3d/fsr_sharpness", PROPERTY_HINT_RANGE, "0,2,0.1"), 0.2f);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/textures/default_filters/texture_mipmap_bias", PROPERTY_HINT_RANGE, "-2,2,0.001"), 0.0f);
 


### PR DESCRIPTION
This improves performance significantly on mobile GPUs, as mobile devices often have displays with high DPI but without the GPU power to match. This is something most AAA mobile games do by default (even if they offer a slider to adjust the resolution scale).

Note that this change only impacts the Forward+ and Forward Mobile rendering methods, as the Compatibility rendering method doesn't support 3D resolution scaling yet.

The appearance of scaling could be improved once https://github.com/godotengine/godot-proposals/issues/4697 is implemented, as a scale factor of `0.5` is compatible with nearest-neighbor filtering without scaling artifacts.

See https://github.com/godotengine/godot/issues/73991.
