### PR TITLE
Add error when get_parent() is used in GDScript variable initializers

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -883,11 +883,11 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 							expr = static_cast<GDScriptParser::CastNode *>(expr)->operand;
 						}
 						bool is_get_node = expr->type == GDScriptParser::Node::GET_NODE;
-						bool is_using_shorthand = is_get_node;
+						String get_node_string = "$";
 						if (!is_get_node && expr->type == GDScriptParser::Node::CALL) {
-							is_using_shorthand = false;
 							GDScriptParser::CallNode *call = static_cast<GDScriptParser::CallNode *>(expr);
-							if (call->function_name == SNAME("get_node")) {
+							if (call->function_name == SNAME("get_node") || call->function_name == SNAME("get_parent")) {
+								get_node_string = call->function_name.operator String() + "()";
 								switch (call->get_callee_type()) {
 									case GDScriptParser::Node::IDENTIFIER: {
 										is_get_node = true;
@@ -902,7 +902,7 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 							}
 						}
 						if (is_get_node) {
-							parser->push_warning(member.variable, GDScriptWarning::GET_NODE_DEFAULT_WITHOUT_ONREADY, is_using_shorthand ? "$" : "get_node()");
+							parser->push_warning(member.variable, GDScriptWarning::GET_NODE_DEFAULT_WITHOUT_ONREADY, get_node_string);
 						}
 					}
 				}

--- a/modules/gdscript/tests/scripts/analyzer/warnings/get_node_without_onready.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/get_node_without_onready.gd
@@ -8,6 +8,10 @@ var without_self = get_node(^"Node")
 var with_cast = get_node(^"Node") as Node
 var shorthand_with_cast = $Node as Node
 
+var parent_with_self = self.get_parent()
+var parent_without_self = get_parent()
+var parent_with_cast = get_parent() as Node
+
 func test():
 	print("warn")
 

--- a/modules/gdscript/tests/scripts/analyzer/warnings/get_node_without_onready.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/get_node_without_onready.out
@@ -19,4 +19,16 @@ GDTEST_OK
 >> Line: 9
 >> GET_NODE_DEFAULT_WITHOUT_ONREADY
 >> The default value is using "$" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
+>> WARNING
+>> Line: 11
+>> GET_NODE_DEFAULT_WITHOUT_ONREADY
+>> The default value is using "get_parent()" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
+>> WARNING
+>> Line: 12
+>> GET_NODE_DEFAULT_WITHOUT_ONREADY
+>> The default value is using "get_parent()" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
+>> WARNING
+>> Line: 13
+>> GET_NODE_DEFAULT_WITHOUT_ONREADY
+>> The default value is using "get_parent()" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.
 warn


### PR DESCRIPTION
This brings using `get_parent()` in line with using `get_node()` in initializers. Presumably, accessing other nodes in the scene tree should only be possible after all objects have been initialized.

This might not be the best solution. Parents seem to instantiate children, so by the time an object is instantiated (even before `_ready`, it might be possible to get access to it, removing the crash instead? I'm not sure.

Fixes #73822.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
