### PR TITLE
Steering on VehicleBody is in radians in code, degrees in UI, adjusted property tooltip to clear this up

### DIFF
--- a/doc/classes/VehicleBody3D.xml
+++ b/doc/classes/VehicleBody3D.xml
@@ -23,7 +23,8 @@
 		</member>
 		<member name="mass" type="float" setter="set_mass" getter="get_mass" overrides="RigidBody3D" default="40.0" />
 		<member name="steering" type="float" setter="set_steering" getter="get_steering" default="0.0">
-			The steering angle for the vehicle, in radians. Setting this to a non-zero value will result in the vehicle turning when it's moving. Wheels that have [member VehicleWheel3D.use_as_steering] set to [code]true[/code] will automatically be rotated.
+			The steering angle for the vehicle. Setting this to a non-zero value will result in the vehicle turning when it's moving. Wheels that have [member VehicleWheel3D.use_as_steering] set to [code]true[/code] will automatically be rotated.
+			[b]Note:[/b] This property is edited in the inspector in degrees. In code the property is set in radians.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
Small improvement to prevent confusion like in #65652, steering is in radians while the property is edited in degrees.

After discussing in chat, decided to clear this up in the documentation:

![image](https://user-images.githubusercontent.com/1945449/221445522-e5172111-ff19-403d-b05d-79a371385329.png)

