### PR TITLE
Loop over the last mipmap lod in basis universal

### DIFF
--- a/modules/basis_universal/register_types.cpp
+++ b/modules/basis_universal/register_types.cpp
@@ -74,7 +74,7 @@ static Vector<uint8_t> basis_universal_packer(const Ref<Image> &p_image, Image::
 				params.m_source_images.push_back(buimg_image);
 			}
 			basisu::vector<basisu::image> images;
-			for (int32_t mip_map_i = 1; mip_map_i < image->get_mipmap_count(); mip_map_i++) {
+			for (int32_t mip_map_i = 1; mip_map_i <= image->get_mipmap_count(); mip_map_i++) {
 				Ref<Image> mip_map = image->get_image_from_mipmap(mip_map_i);
 				Vector<uint8_t> mip_map_vec = mip_map->get_data();
 				basisu::image buimg_mipmap(mip_map->get_width(), mip_map->get_height());
@@ -247,7 +247,7 @@ static Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size
 		dst[i] = 0x00;
 	}
 	uint32_t mip_count = Image::get_image_required_mipmaps(info.m_orig_width, info.m_orig_height, imgfmt);
-	for (uint32_t level_i = 0; level_i < mip_count; level_i++) {
+	for (uint32_t level_i = 0; level_i <= mip_count; level_i++) {
 		basist::basisu_image_level_info level;
 		tr.get_image_level_info(ptr, size, level, 0, level_i);
 		int ofs = Image::get_image_mipmap_offset(info.m_width, info.m_height, imgfmt, level_i);


### PR DESCRIPTION
Followup for #73948
Fixes #72237 at steep angles and far away.

We weren't generating the last LOD. Godot's `Image` class expects mipmap levels to be looped up to `Image::get_image_required_mipmaps` inclusively. Most other code in Godot uses `<= mm_count` or `< get_mipmap_count() + 1` but that was missing in this case.

Modified test project to show the last LOD on the left half of SCREEN_UV.
[Basis Universal MipMapping.zip](https://github.com/godotengine/godot/files/10835088/Basis.Universal.MipMapping.zip)
But it's also easy to test from the original MRP at a very steep angle (due to anisotropic mipmaps) or at far distances.

Before:
![image](https://user-images.githubusercontent.com/39946030/221445493-9c8d1324-5e4a-47ad-9dcc-6df3feb2122c.png)

After:
![image](https://user-images.githubusercontent.com/39946030/221445430-52f740f8-bb30-4347-b217-5d89c859ce2e.png)
