### PR TITLE
Clean up stray 'owned' list entries in _pre_fix_node method

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -561,6 +561,8 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 	bool isroot = p_node == p_root;
 
 	if (!isroot && _teststr(name, "noimp")) {
+		p_node->get_parent()->remove_child(p_node);
+		p_node->set_owner(nullptr);
 		memdelete(p_node);
 		return nullptr;
 	}

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2498,6 +2498,9 @@ void Node::replace_by(Node *p_node, bool p_keep_groups) {
 		owned_by_owner[i]->set_owner(owner);
 	}
 
+	// Clears it out of the original owners 'owned' array (may want to move this to the node destructor instead).
+	set_owner(nullptr);
+
 	p_node->set_scene_file_path(get_scene_file_path());
 }
 


### PR DESCRIPTION
This *may* fix the issues raised here #72555 (I'm not entirely sure though since I was able to raise errors, but not able to get the same consistent segfault the issue described), and at the very least, it will silence some errors. The issue seems to be related to Godot not properly cleaning up the 'owned' list unless explicitly specified, which seems like a problem. I kind of wonder if we should do this instead and the Node destructor, but I'm worried about trying that so close to release, and this felt like the safest potential fix the issue raised, with a comment and note that it may need to be evaluated further.