### PR TITLE
Stop toaster notification circle flickering

### DIFF
--- a/editor/editor_toaster.cpp
+++ b/editor/editor_toaster.cpp
@@ -90,10 +90,10 @@ void EditorToaster::_notification(int p_what) {
 				}
 
 				// Hide element if it is not visible anymore.
-				if (modulate_fade.a <= 0 && element.key->is_visible()) {
+				if (modulate_fade.a <= 0.0 && element.key->is_visible()) {
 					element.key->hide();
 					needs_update = true;
-				} else if (modulate_fade.a >= 0 && !element.key->is_visible()) {
+				} else if (modulate_fade.a > 0.0 && !element.key->is_visible()) {
 					element.key->show();
 					needs_update = true;
 				}


### PR DESCRIPTION
Fixes an annoying visual glitch where the circle indicating the highest notification severity would rapidly flicker on and off once all the notifications had faded out.

Closes #74016