### PR TITLE
Fix glTF mesh importer not freeing nodes correctly on import

### DIFF
--- a/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.cpp
+++ b/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.cpp
@@ -70,7 +70,7 @@ Error GLTFDocumentExtensionConvertImporterMesh::import_post(Ref<GLTFState> p_sta
 		}
 		queue.pop_front();
 	}
-	while (!queue.is_empty()) {
+	while (!delete_queue.is_empty()) {
 		List<Node *>::Element *E = delete_queue.front();
 		Node *node = E->get();
 		memdelete(node);


### PR DESCRIPTION
While browsing code relating to #69814, I noticed that the nodes replaced in `GLTFDocumentExtensionConvertImporterMesh` are gathered in a delete_queue but are not actually freed because the loop is done on another variable.

If I'm understanding this correctly its just a simple typo that caused a minor memory leak.