### PR TITLE
docs: reintroduce FileAccess.close()

### DIFF
--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -37,7 +37,9 @@
 		[codeblocks]
 		[gdscript]
 		var file = FileAccess.open("res://something") # File is opened and locked for use.
-		file = null # File is closed.
+		# file is closed when the variable goes out of scope
+		# although the cleaner approach would be to call file.close()
+		file = null
 		[/gdscript]
 		[csharp]
 		using var file = FileAccess.Open("res://something"); // File is opened and locked for use.


### PR DESCRIPTION
`FileAccess.close()` was reintroduced in #73435, this PR updates examples in docs to reflect it.