### PR TITLE
[macOS export] Add support for embedded provisioning profile and Installer PKG format and macOS min version.

### DIFF
--- a/misc/dist/macos_template.app/Contents/Info.plist
+++ b/misc/dist/macos_template.app/Contents/Info.plist
@@ -24,6 +24,22 @@
 	<string>$signature</string>
 	<key>CFBundleVersion</key>
 	<string>$version</string>
+	<key>DTCompiler</key>
+	<string>com.apple.compilers.llvm.clang.1_0</string>
+	<key>DTPlatformBuild</key>
+	<string>$platfbuild</string>
+	<key>DTPlatformName</key>
+	<string>macosx</string>
+	<key>DTPlatformVersion</key>
+	<string>$sdkver</string>
+	<key>DTSDKBuild</key>
+	<string>$sdkbuild</string>
+	<key>DTSDKName</key>
+	<string>$sdkname</string>
+	<key>DTXcode</key>
+	<string>$xcodever</string>
+	<key>DTXcodeBuild</key>
+	<string>$xcodebuild</string>
 $usage_descriptions
 	<key>NSHumanReadableCopyright</key>
 	<string>$copyright</string>
@@ -36,11 +52,11 @@ $usage_descriptions
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.$app_category</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.12</string>
+	<string>$min_version</string>
 	<key>LSMinimumSystemVersionByArchitecture</key>
 	<dict>
 		<key>x86_64</key>
-		<string>10.12</string>
+		<string>$min_version</string>
 	</dict>
 	<key>NSHighResolutionCapable</key>
 $highres

--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -86,16 +86,17 @@ class EditorExportPlatformMacOS : public EditorExportPlatform {
 	Error _export_macos_plugins_for(Ref<EditorExportPlugin> p_editor_export_plugin, const String &p_app_path_name,
 			Ref<DirAccess> &dir_access, bool p_sign_enabled, const Ref<EditorExportPreset> &p_preset,
 			const String &p_ent_path);
+	Error _create_pkg(const Ref<EditorExportPreset> &p_preset, const String &p_pkg_path, const String &p_app_path_name);
 	Error _create_dmg(const String &p_dmg_path, const String &p_pkg_name, const String &p_app_path_name);
 	Error _export_debug_script(const Ref<EditorExportPreset> &p_preset, const String &p_app_name, const String &p_pkg_name, const String &p_path);
 
 	bool use_codesign() const { return true; }
 #ifdef MACOS_ENABLED
-	bool use_dmg() const {
+	bool use_dmg_or_pkg() const {
 		return true;
 	}
 #else
-	bool use_dmg() const {
+	bool use_dmg_or_pkg() const {
 		return false;
 	}
 #endif
@@ -143,8 +144,9 @@ public:
 	virtual bool is_executable(const String &p_path) const override;
 	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const override {
 		List<String> list;
-		if (use_dmg()) {
+		if (use_dmg_or_pkg()) {
 			list.push_back("dmg");
+			list.push_back("pkg");
 		}
 		list.push_back("zip");
 		list.push_back("app");


### PR DESCRIPTION
- Adds support for embedded provisioning profile.
- Adds support for Installer PKG export format (without Notarization).
- Adds export option to set macOS min. version.

Fixes https://github.com/godotengine/godot-proposals/issues/6360
Fixes https://github.com/godotengine/godot/issues/73876
Fixes https://github.com/godotengine/godot/issues/74154
