### PR TITLE
Remove unused `ScriptLanguage` methods

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -249,7 +249,6 @@ public:
 	virtual void init() = 0;
 	virtual String get_type() const = 0;
 	virtual String get_extension() const = 0;
-	virtual Error execute_file(const String &p_path) = 0;
 	virtual void finish() = 0;
 
 	/* EDITOR FUNCTIONS */
@@ -427,11 +426,6 @@ public:
 
 	virtual int profiling_get_accumulated_data(ProfilingInfo *p_info_arr, int p_info_max) = 0;
 	virtual int profiling_get_frame_data(ProfilingInfo *p_info_arr, int p_info_max) = 0;
-
-	virtual void *alloc_instance_binding_data(Object *p_object) { return nullptr; } //optional, not used by all languages
-	virtual void free_instance_binding_data(void *p_data) {} //optional, not used by all languages
-	virtual void refcount_incremented_instance_binding(Object *p_object) {} //optional, not used by all languages
-	virtual bool refcount_decremented_instance_binding(Object *p_object) { return true; } //return true if it can die //optional, not used by all languages
 
 	virtual void frame();
 

--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -84,7 +84,6 @@ void ScriptLanguageExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_init);
 	GDVIRTUAL_BIND(_get_type);
 	GDVIRTUAL_BIND(_get_extension);
-	GDVIRTUAL_BIND(_execute_file, "path");
 	GDVIRTUAL_BIND(_finish);
 
 	GDVIRTUAL_BIND(_get_reserved_words);
@@ -143,12 +142,6 @@ void ScriptLanguageExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_profiling_get_accumulated_data, "info_array", "info_max");
 	GDVIRTUAL_BIND(_profiling_get_frame_data, "info_array", "info_max");
-
-	GDVIRTUAL_BIND(_alloc_instance_binding_data, "object");
-	GDVIRTUAL_BIND(_free_instance_binding_data, "data");
-
-	GDVIRTUAL_BIND(_refcount_incremented_instance_binding, "object");
-	GDVIRTUAL_BIND(_refcount_decremented_instance_binding, "object");
 
 	GDVIRTUAL_BIND(_frame);
 

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -202,7 +202,6 @@ public:
 	EXBIND0(init)
 	EXBIND0RC(String, get_type)
 	EXBIND0RC(String, get_extension)
-	EXBIND1R(Error, execute_file, const String &)
 	EXBIND0(finish)
 
 	/* EDITOR FUNCTIONS */
@@ -595,23 +594,6 @@ public:
 		GDVIRTUAL_REQUIRED_CALL(_profiling_get_accumulated_data, p_info_arr, p_info_max, ret);
 		return ret;
 	}
-
-	GDVIRTUAL1R(GDExtensionPtr<void>, _alloc_instance_binding_data, Object *)
-
-	virtual void *alloc_instance_binding_data(Object *p_object) override {
-		GDExtensionPtr<void> ret = nullptr;
-		GDVIRTUAL_REQUIRED_CALL(_alloc_instance_binding_data, p_object, ret);
-		return ret.operator void *();
-	}
-
-	GDVIRTUAL1(_free_instance_binding_data, GDExtensionPtr<void>)
-
-	virtual void free_instance_binding_data(void *p_data) override {
-		GDVIRTUAL_REQUIRED_CALL(_free_instance_binding_data, p_data);
-	}
-
-	EXBIND1(refcount_incremented_instance_binding, Object *)
-	EXBIND1R(bool, refcount_decremented_instance_binding, Object *)
 
 	EXBIND0(frame)
 

--- a/doc/classes/ScriptLanguageExtension.xml
+++ b/doc/classes/ScriptLanguageExtension.xml
@@ -21,12 +21,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="_alloc_instance_binding_data" qualifiers="virtual">
-			<return type="void*" />
-			<param index="0" name="object" type="Object" />
-			<description>
-			</description>
-		</method>
 		<method name="_auto_indent_code" qualifiers="virtual const">
 			<return type="String" />
 			<param index="0" name="code" type="String" />
@@ -118,12 +112,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="_execute_file" qualifiers="virtual">
-			<return type="int" enum="Error" />
-			<param index="0" name="path" type="String" />
-			<description>
-			</description>
-		</method>
 		<method name="_find_function" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="class_name" type="String" />
@@ -138,12 +126,6 @@
 		</method>
 		<method name="_frame" qualifiers="virtual">
 			<return type="void" />
-			<description>
-			</description>
-		</method>
-		<method name="_free_instance_binding_data" qualifiers="virtual">
-			<return type="void" />
-			<param index="0" name="data" type="void*" />
 			<description>
 			</description>
 		</method>
@@ -295,18 +277,6 @@
 		</method>
 		<method name="_profiling_stop" qualifiers="virtual">
 			<return type="void" />
-			<description>
-			</description>
-		</method>
-		<method name="_refcount_decremented_instance_binding" qualifiers="virtual">
-			<return type="bool" />
-			<param index="0" name="object" type="Object" />
-			<description>
-			</description>
-		</method>
-		<method name="_refcount_incremented_instance_binding" qualifiers="virtual">
-			<return type="void" />
-			<param index="0" name="object" type="Object" />
 			<description>
 			</description>
 		</method>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2027,11 +2027,6 @@ String GDScriptLanguage::get_extension() const {
 	return "gd";
 }
 
-Error GDScriptLanguage::execute_file(const String &p_path) {
-	// ??
-	return OK;
-}
-
 void GDScriptLanguage::finish() {
 	if (_call_stack) {
 		memdelete_arr(_call_stack);

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -473,7 +473,6 @@ public:
 	virtual void init() override;
 	virtual String get_type() const override;
 	virtual String get_extension() const override;
-	virtual Error execute_file(const String &p_path) override;
 	virtual void finish() override;
 
 	/* EDITOR FUNCTIONS */

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -92,11 +92,6 @@ String CSharpLanguage::get_extension() const {
 	return "cs";
 }
 
-Error CSharpLanguage::execute_file(const String &p_path) {
-	// ??
-	return OK;
-}
-
 void CSharpLanguage::init() {
 #ifdef DEBUG_METHODS_ENABLED
 	if (OS::get_singleton()->get_cmdline_args().find("--class-db-json")) {

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -413,7 +413,6 @@ public:
 	/* LANGUAGE FUNCTIONS */
 	String get_type() const override;
 	String get_extension() const override;
-	Error execute_file(const String &p_path) override;
 	void init() override;
 	void finish() override;
 


### PR DESCRIPTION
Will remove a bit of confusion for `ScriptLanguage`/`ScriptLanguageExtension` authors.

* `execute_file` has always been `??`.
* The old instance binding methods are unused as of https://github.com/godotengine/godot/commit/44691448911f1d29d4d79dbdd5553734761e57c4.