### PR TITLE
Fix Windows to Windows SSH remote deploy. Fix Windows `execute` exit code.

### DIFF
--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -879,7 +879,11 @@ Error EditorExportPlatformWindows::run(const Ref<EditorExportPreset> &p_preset, 
 	print_line("Creating temporary directory...");
 	ep.step(TTR("Creating temporary directory..."), 2);
 	String temp_dir;
+#ifndef WINDOWS_ENABLED
 	err = ssh_run_on_remote(host, port, extra_args_ssh, "powershell -command \\\"\\$tmp = Join-Path \\$Env:Temp \\$(New-Guid); New-Item -Type Directory -Path \\$tmp | Out-Null; Write-Output \\$tmp\\\"", &temp_dir);
+#else
+	err = ssh_run_on_remote(host, port, extra_args_ssh, "powershell -command \"$tmp = Join-Path $Env:Temp $(New-Guid); New-Item -Type Directory -Path $tmp ^| Out-Null; Write-Output $tmp\"", &temp_dir);
+#endif
 	if (err != OK || temp_dir.is_empty()) {
 		CLEANUP_AND_RETURN(err);
 	}
@@ -889,6 +893,10 @@ Error EditorExportPlatformWindows::run(const Ref<EditorExportPreset> &p_preset, 
 	err = ssh_push_to_remote(host, port, extra_args_scp, basepath + ".zip", temp_dir);
 	if (err != OK) {
 		CLEANUP_AND_RETURN(err);
+	}
+
+	if (cmd_args.is_empty()) {
+		cmd_args = " ";
 	}
 
 	{

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -673,9 +673,8 @@ Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments,
 		}
 
 		CloseHandle(pipe[0]); // Close pipe read handle.
-	} else {
-		WaitForSingleObject(pi.pi.hProcess, INFINITE);
 	}
+	WaitForSingleObject(pi.pi.hProcess, INFINITE);
 
 	if (r_exitcode) {
 		DWORD ret2;


### PR DESCRIPTION
- Fixes remote deploy from Windows to Windows, when running on Windows, SSH command require different escaping.
- Fixes Windows remote execute failing with empty arguments.
- Fixes Windows `execute` exit code sometime set to `STILL_ACTIVE (259)` when using stdout pipe.