### PR TITLE
[MP] Fix orphan StringName on close.

### DIFF
--- a/scene/main/multiplayer_api.cpp
+++ b/scene/main/multiplayer_api.cpp
@@ -43,7 +43,7 @@ StringName MultiplayerAPI::default_interface;
 
 void MultiplayerAPI::set_default_interface(const StringName &p_interface) {
 	ERR_FAIL_COND_MSG(!ClassDB::is_parent_class(p_interface, MultiplayerAPI::get_class_static()), vformat("Can't make %s the default multiplayer interface since it does not extend MultiplayerAPI.", p_interface));
-	default_interface = p_interface;
+	default_interface = StringName(p_interface, true);
 }
 
 StringName MultiplayerAPI::get_default_interface() {


### PR DESCRIPTION
Use a static StringName for the registered default interface name.

Fixes #64591