### PR TITLE
Prevent Reimport with old settings after Advanced dialog

### DIFF
--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -502,6 +502,9 @@ void ImportDock::_reimport_and_restart() {
 void ImportDock::_advanced_options() {
 	if (params->paths.size() == 1 && params->importer.is_valid()) {
 		params->importer->show_advanced_options(params->paths[0]);
+		// Workaround bug that causes Godot to reuse stale settings if Reimport is clicked.
+		import->set_disabled(true);
+		import_as->set_disabled(true);
 	}
 }
 void ImportDock::_reimport() {


### PR DESCRIPTION
Disables the Reimport button so users cannot accidentally reimport a model with old settings after opening the Advanced... dialog.
The import_dock naturally already disables these buttons on Clear() and re-enables the Reimport button when a new file is selected, so this change should not leave any buttons stuck in a disabled state.

Fixes #70255