### PR TITLE
Workaround basis universal normal map issue for S3TC

### DIFF
--- a/modules/basis_universal/register_types.cpp
+++ b/modules/basis_universal/register_types.cpp
@@ -215,7 +215,7 @@ static Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size
 		case BASIS_DECOMPRESS_RG_AS_RA: {
 			if (RS::get_singleton()->has_os_feature("s3tc")) {
 				format = basist::transcoder_texture_format::cTFBC3; // get this from renderer
-				imgfmt = Image::FORMAT_DXT5_RA_AS_RG;
+				imgfmt = Image::FORMAT_DXT5;
 			} else if (RS::get_singleton()->has_os_feature("etc2")) {
 				format = basist::transcoder_texture_format::cTFETC2; // get this from renderer
 				imgfmt = Image::FORMAT_ETC2_RGBA8;


### PR DESCRIPTION
I'll preface this by saying I have no idea why this works, or how the `RA_AS_RG setting is supposed to work.

Fixes #61039

After this change, the MRP from Calinou shows correctly:
![image](https://user-images.githubusercontent.com/39946030/221528955-72dc0141-f948-4b2c-abff-fb853e45d287.png)

Unknown what happens if `USE_RG_AS_RGBA` is not defined, but it is currently forced on at the top of the file.
I have not tested ETC2 / mobile.

I did test the else case just to see, and it appeared to produce the equivalent of no normal map
```
} else {
//opengl most likely, bad for normal maps, nothing to do about this.
format = basist::transcoder_texture_format::cTFRGBA32;
imgfmt = Image::FORMAT_RGBA8;
```
![image](https://user-images.githubusercontent.com/39946030/221530350-bfafe076-dfc6-48cc-b193-13d7cd89ddc1.png)

This change probably ought to test and address the other cases