### PR TITLE
GDScript: Fix wrong increment for disassembly of lambda

### DIFF
--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -851,7 +851,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				}
 				text += ")";
 
-				incr = 3 + captures_count;
+				incr = 4 + captures_count;
 			} break;
 			case OPCODE_CREATE_SELF_LAMBDA: {
 				int instr_var_args = _code_ptr[++ip];
@@ -871,7 +871,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				}
 				text += ")";
 
-				incr = 3 + captures_count;
+				incr = 4 + captures_count;
 			} break;
 			case OPCODE_JUMP: {
 				text += "jump ";


### PR DESCRIPTION
Fix a crash that happens when disassembling lambda instructions.