### PR TITLE
Avoid crash when adjusting a node tree that is not in the tree

### DIFF
--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -236,6 +236,8 @@ private:
 	void _release_unique_name_in_owner();
 	void _acquire_unique_name_in_owner();
 
+	void _clean_up_owner();
+
 	_FORCE_INLINE_ void _update_children_cache() const {
 		if (unlikely(data.children_cache_dirty)) {
 			_update_children_cache_impl();


### PR DESCRIPTION
When node tree `A` is not in the `SceneTree` and  node `B` is in tree `A`, `remove_child(B)` will not automatically clean up the owners of `B` and `B`'s child nodes (Crucially, the owner will not clean up the cached `data.owned`, which leaves hidden dangers). This is convenient for implementing operations like `replace_by()`, but may have hidden dangers when manipulating the rest of the tree `A` (May fire when iterating over outdated `data.owned`).
    
This commit makes it safe to manipulate the rest of `A` after freeing `B` (and `B`'s child nodes).

Fixes  #65514, fixes #72555.
Supersedes #74011.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
