### PR TITLE
Fix a crash in the GLB importer

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -561,6 +561,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 	bool isroot = p_node == p_root;
 
 	if (!isroot && _teststr(name, "noimp")) {
+		p_node->set_owner(nullptr);
 		memdelete(p_node);
 		return nullptr;
 	}
@@ -690,6 +691,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 					col->set_transform(mi->get_transform());
 					col->set_name(fixed_name);
 					p_node->replace_by(col);
+					p_node->set_owner(nullptr);
 					memdelete(p_node);
 					p_node = col;
 
@@ -703,6 +705,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 			sb->set_name(fixed_name);
 			Object::cast_to<Node3D>(sb)->set_transform(Object::cast_to<Node3D>(p_node)->get_transform());
 			p_node->replace_by(sb);
+			p_node->set_owner(nullptr);
 			memdelete(p_node);
 			p_node = sb;
 			CollisionShape3D *colshape = memnew(CollisionShape3D);
@@ -810,6 +813,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 		nmi->set_navigation_mesh(nmesh);
 		Object::cast_to<Node3D>(nmi)->set_transform(mi->get_transform());
 		p_node->replace_by(nmi);
+		p_node->set_owner(nullptr);
 		memdelete(p_node);
 		p_node = nmi;
 	} else if (_teststr(name, "occ") || _teststr(name, "occonly")) {
@@ -832,6 +836,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 						}
 					}
 				} else {
+					p_node->set_owner(nullptr);
 					memdelete(p_node);
 					p_node = nullptr;
 				}
@@ -1103,6 +1108,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 	}
 
 	if (!isroot && (node_settings.has("import/skip_import") && bool(node_settings["import/skip_import"]))) {
+		p_node->set_owner(nullptr);
 		memdelete(p_node);
 		return nullptr;
 	}
@@ -1263,6 +1269,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 								col->set_position(p_applied_root_scale * col->get_position());
 								col->set_name(p_node->get_name());
 								p_node->replace_by(col);
+								p_node->set_owner(nullptr);
 								memdelete(p_node);
 								p_node = col;
 								base = col;
@@ -1273,6 +1280,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 								area->set_position(p_applied_root_scale * area->get_position());
 								area->set_name(p_node->get_name());
 								p_node->replace_by(area);
+								p_node->set_owner(nullptr);
 								memdelete(p_node);
 								p_node = area;
 								base = area;
@@ -1312,6 +1320,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 					if (navmesh_mode == NAVMESH_NAVMESH_ONLY) {
 						nmi->set_transform(mi->get_transform());
 						p_node->replace_by(nmi);
+						p_node->set_owner(nullptr);
 						memdelete(p_node);
 						p_node = nmi;
 					} else {
@@ -1341,6 +1350,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 					OccluderInstance3D::bake_single_node(mi, simplification_dist, r_occluder_arrays.first, r_occluder_arrays.second);
 
 					if (occluder_mode == OCCLUDER_OCCLUDER_ONLY) {
+						p_node->set_owner(nullptr);
 						memdelete(p_node);
 						p_node = nullptr;
 					}
@@ -2092,6 +2102,7 @@ void ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_m
 		}
 
 		p_node->replace_by(mesh_node);
+		p_node->set_owner(nullptr);
 		memdelete(p_node);
 		p_node = mesh_node;
 	}
@@ -2427,6 +2438,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 
 		if (base_node) {
 			scene->replace_by(base_node);
+			scene->set_owner(nullptr);
 			memdelete(scene);
 			scene = base_node;
 		}


### PR DESCRIPTION
Might close, but to be tested:
https://github.com/godotengine/godot/issues/73830
https://github.com/godotengine/godot/issues/65514
https://github.com/godotengine/godot/issues/65014
https://github.com/godotengine/godot/issues/72555

The issue was that we were freeing a node without calling `set_owner(nullptr)` on it. This caused the owner's `owned` list to contain freed nodes, which caused a crash.

I am not 100% sold on this implementation being the right solution to the problem. 
Like, right now, a node cannot be freed using `memdelete` if it has a parent (it works but triggers an error), but it can be freed if it has an owner. In the importer, it seems that nodes are correctly set to have no parent (as expected) but still have an owner. 

I see other possibilities/things to do to solve the issue in a maybe cleaner way:
- make it so `replace_by` sets the owner to `null` by default ? That kind of makes sense, as replacing a node makes it so the replaced one gets out of the tree.
- set the owner as `null` (and thus notify the parent so the `owned` list is wrong)  in the `Node` destructor.
- or add a check for owner to be null before destroying a node.

Put it as 4.0 as it is quite blocking for some project (the crash is happening for the TPS demo)