### PR TITLE
C#: Always decode `dotnet` output as UTF-8

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -41,6 +41,12 @@ namespace GodotTools.Build
             startInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"]
                 = ((string)editorSettings.GetSetting("interface/editor/editor_language")).Replace('_', '-');
 
+            if (OperatingSystem.IsWindows())
+            {
+                startInfo.StandardOutputEncoding = Encoding.UTF8;
+                startInfo.StandardErrorEncoding = Encoding.UTF8;
+            }
+
             // Needed when running from Developer Command Prompt for VS
             RemovePlatformVariable(startInfo.EnvironmentVariables);
 
@@ -104,6 +110,12 @@ namespace GodotTools.Build
             startInfo.UseShellExecute = false;
             startInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"]
                 = ((string)editorSettings.GetSetting("interface/editor/editor_language")).Replace('_', '-');
+
+            if (OperatingSystem.IsWindows())
+            {
+                startInfo.StandardOutputEncoding = Encoding.UTF8;
+                startInfo.StandardErrorEncoding = Encoding.UTF8;
+            }
 
             // Needed when running from Developer Command Prompt for VS
             RemovePlatformVariable(startInfo.EnvironmentVariables);

--- a/modules/mono/editor/GodotTools/GodotTools/Build/DotNetFinder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/DotNetFinder.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 using JetBrains.Annotations;
 using OS = GodotTools.Utils.OS;
 
@@ -57,6 +58,11 @@ namespace GodotTools.Build
                 UseShellExecute = false,
                 RedirectStandardOutput = true
             };
+
+            if (OperatingSystem.IsWindows())
+            {
+                process.StartInfo.StandardOutputEncoding = Encoding.UTF8;
+            }
 
             process.StartInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"] = "en-US";
 


### PR DESCRIPTION
Even tho this seems like a straight forward fix and testing shows that this appears correct, but console handling on Windows is *complicated* and as far as I can tell this shouldn't work as is, so I am not sure what I am missing here and if this can cause issues in some cases.

<details>
<summary>SPOILER: One quick run through the Windows console complications</summary>

- A console is supposed to represent a virtual VGA text mode display, most oddities of the system are because of this.
- Every console is associated with 1 or more processes and every process with 0 or 1 console, e.g. multiple process can share a console
- Every console has a input and an output encoding that can only be get and set by processes that use that console
- Sub processes use their parent console (there are ways to change that, but they are not used here)
- If the parent doesn't have a console, and the child uses the console subsystem, a new console is allocated.
- Now for the relevant .NET bits:
- Writing to stdout uses the console output encoding by default.
- Reading from the redirected stdout of a child process uses the console output encoding by default.
- Thus as long as the parent & child process use the same console / didn't change their encoding from the system default everything should be passed correctly
- The failure mode I would expect with this is that the localized string contains characters that cannot be encoded and thus get replaced with the fallback char (generally question marks)
- But in reality it looks like `dotnet` always writes UTF8 output, and thus Godot decodes things incorrectly (unless the system default encoding also is UTF8)

</details>

If anyone has an idea what causes the `dotnet` output to be UTF-8 encoded, that would be great to know, so that we can ensure that this doesn't cause any regressions anywhere.

The upstream change is not relevant for the issues, as it it only include in the .NET 8 previews.

If not, changing the windows default code page to utf-8 also fixes the issues, both without the fix and any potential regressions with this fix. (also it's probably a good things to do regardless)

- Supersedes: https://github.com/godotengine/godot/pull/73861 / https://github.com/godotengine/godot/pull/73865 
- Related upstream change: https://github.com/dotnet/sdk/pull/29755
- Fixes #71326
- Workaround: https://superuser.com/a/1435645