### PR TITLE
Add feature check to require min Vulkan api version 1.0 on Android

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1068,6 +1068,11 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 						feature_names.push_back("android.hardware.vulkan.level");
 						feature_required_list.push_back(true);
 						feature_versions.push_back(1);
+
+						// Require vulkan version 1.0
+						feature_names.push_back("android.hardware.vulkan.version");
+						feature_required_list.push_back(true);
+						feature_versions.push_back(0x400003); // Encoded value for api version 1.0
 					}
 
 					if (feature_names.size() > 0) {

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -276,6 +276,7 @@ String _get_xr_features_tag(const Ref<EditorExportPreset> &p_preset, bool p_uses
 
 	if (p_uses_vulkan) {
 		manifest_xr_features += "    <uses-feature tools:node=\"replace\" android:name=\"android.hardware.vulkan.level\" android:required=\"true\" android:version=\"1\" />\n";
+		manifest_xr_features += "    <uses-feature tools:node=\"replace\" android:name=\"android.hardware.vulkan.version\" android:required=\"true\" android:version=\"0x400003\" />\n";
 	}
 	return manifest_xr_features;
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -278,7 +278,8 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 
 		if (usesVulkan()) {
 			if (!meetsVulkanRequirements(activity.getPackageManager())) {
-				Log.w(TAG, "Missing requirements for vulkan support!");
+				alert(R.string.error_missing_vulkan_requirements_message, R.string.text_error_title, this::forceQuit);
+				return false;
 			}
 			mRenderView = new GodotVulkanRenderView(activity, this);
 		} else {
@@ -338,7 +339,17 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 			return false;
 		}
 
-		return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && packageManager.hasSystemFeature(PackageManager.FEATURE_VULKAN_HARDWARE_LEVEL, 1);
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+			if (!packageManager.hasSystemFeature(PackageManager.FEATURE_VULKAN_HARDWARE_LEVEL, 1)) {
+				// Optional requirements.. log as warning if missing
+				Log.w(TAG, "The vulkan hardware level does not meet the minimum requirement: 1");
+			}
+
+			// Check for api version 1.0
+			return packageManager.hasSystemFeature(PackageManager.FEATURE_VULKAN_HARDWARE_VERSION, 0x400003);
+		}
+
+		return false;
 	}
 
 	public void setKeepScreenOn(final boolean p_enabled) {


### PR DESCRIPTION
Follow up on the discussion in https://github.com/godotengine/godot/pull/72816#issuecomment-1422831556;

Adds a check specifying the min supported vulkan api version (1.0).

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
