### PR TITLE
Redraw 2D viewport when guides are cleared

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4558,6 +4558,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 				}
 				undo_redo->add_undo_method(viewport, "queue_redraw");
 				undo_redo->commit_action();
+				viewport->queue_redraw();
 			}
 
 		} break;


### PR DESCRIPTION
``queue_redraw()`` wasn't being called after the "View > Clear Guides" menu option was pressed, leading to guides remaining on screen until some other action requests a redraw (such as focus changing or clicking in on the viewport).

Fixes #72940