### PR TITLE
C#: Add float delta overloads of _Process and _PhysicsProcess

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ScriptBoilerplate.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ScriptBoilerplate.cs
@@ -7,7 +7,7 @@ namespace Godot.SourceGenerators.Sample
         private NodePath _nodePath;
         private int _velocity;
 
-        public override void _Process(double delta)
+        public override void _Process(float delta)
         {
             _ = delta;
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -127,7 +127,8 @@ namespace Godot.SourceGenerators
             var methodSymbols = members
                 .Where(s => !s.IsStatic && s.Kind == SymbolKind.Method && !s.IsImplicitlyDeclared)
                 .Cast<IMethodSymbol>()
-                .Where(m => m.MethodKind == MethodKind.Ordinary);
+                .Where(m => m.MethodKind == MethodKind.Ordinary)
+                .ToArray();
 
             var godotClassMethods = methodSymbols.WhereHasGodotCompatibleSignature(typeCache)
                 .Distinct(new MethodOverloadEqualityComparer())
@@ -193,7 +194,49 @@ namespace Godot.SourceGenerators
 
                 foreach (var method in godotClassMethods)
                 {
-                    GenerateMethodInvoker(method, source);
+                    string methodName = method.Method.Name;
+
+                    switch (methodName)
+                    {
+                        case "_Process":
+                        case "_PhysicsProcess":
+                        {
+                            source.Append("        if (method == MethodName._Process && args.Count == 1) {\n");
+
+                            var overloads = methodSymbols
+                                .Where(m => m.Name == methodName && m.Parameters.Length == 1)
+                                .ToArray();
+
+                            if (overloads.Any(m => m.Parameters[0].Type.ToString() == "double"))
+                            {
+                                source.Append("            ")
+                                    .Append(methodName)
+                                    .Append("(global::Godot.NativeInterop.VariantUtils.ConvertTo<")
+                                    .Append("double")
+                                    .Append(">(args[0]));\n");
+                            }
+
+                            if (overloads.Any(m => m.Parameters[0].Type.ToString() == "float"))
+                            {
+                                source.Append("            ")
+                                    .Append(methodName)
+                                    .Append("(global::Godot.NativeInterop.VariantUtils.ConvertTo<")
+                                    .Append("float")
+                                    .Append(">(args[0]));\n");
+                            }
+
+                            source.Append("            ret = default;\n");
+                            source.Append("            return true;\n");
+                            source.Append("        };\n");
+
+                            break;
+                        }
+                        default:
+                        {
+                            GenerateMethodInvoker(method, source);
+                            break;
+                        }
+                    }
                 }
 
                 source.Append("        return base.InvokeGodotClassMethod(method, args, out ret);\n");

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -616,6 +616,7 @@ class BindingsGenerator {
 		StringName type_Variant = StaticCString::create("Variant");
 		StringName type_VarArg = StaticCString::create("VarArg");
 		StringName type_Object = StaticCString::create("Object");
+		StringName type_Node = StaticCString::create("Node");
 		StringName type_RefCounted = StaticCString::create("RefCounted");
 		StringName type_RID = StaticCString::create("RID");
 		StringName type_Callable = StaticCString::create("Callable");
@@ -647,6 +648,9 @@ class BindingsGenerator {
 		StringName type_Vector3i = StaticCString::create("Vector3i");
 		StringName type_Vector4 = StaticCString::create("Vector4");
 		StringName type_Vector4i = StaticCString::create("Vector4i");
+
+		StringName method_process = StaticCString::create("_process");
+		StringName method_physics_process = StaticCString::create("_physics_process");
 
 		// Object not included as it must be checked for all derived classes
 		static constexpr int nullable_types_count = 18;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace Godot
 {
@@ -194,6 +196,16 @@ namespace Godot
         public T GetParentOrNull<T>() where T : class
         {
             return GetParent() as T;
+        }
+
+        /// <inheritdoc cref="_PhysicsProcess(double)"/>
+        public virtual void _PhysicsProcess(float delta)
+        {
+        }
+
+        /// <inheritdoc cref="_Process(double)"/>
+        public virtual void _Process(float delta)
+        {
         }
     }
 }


### PR DESCRIPTION
The bindings generator is hard-coded to replace the type of the parameter from `double` to `real_t`. This means it's no longer necessary to cast the delta in order to use it in `float` operations.

Math types like `Vector3` use `real_t`, so going with `real_t` instead of `float` means the solution also works for project where `real_t` is 64-bit.

The double precision version of the delta is still available through the `GetProcessDeltaTime()` and `GetPhysicsProcessDeltaTime()`. I optimized the methods to return a cached value instead of going through an internal call. I also added two matching properties to reduce verbosity.

Fixes godotengine/godot-proposals#5403
