### PR TITLE
C#: Optimize GetProcessDeltaTime() and GetPhysicsProcessDeltaTime()

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -461,6 +461,12 @@ void ScriptLanguage::get_core_type_words(List<String> *p_core_type_words) const 
 void ScriptLanguage::frame() {
 }
 
+void ScriptLanguage::set_physics_process_delta_time(double p_time) {
+}
+
+void ScriptLanguage::set_process_delta_time(double p_time) {
+}
+
 bool PlaceHolderScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 	if (script->is_placeholder_fallback_enabled()) {
 		return false;

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -428,6 +428,8 @@ public:
 	virtual int profiling_get_frame_data(ProfilingInfo *p_info_arr, int p_info_max) = 0;
 
 	virtual void frame();
+	virtual void set_physics_process_delta_time(double p_time);
+	virtual void set_process_delta_time(double p_time);
 
 	virtual bool handles_global_class_type(const String &p_type) const { return false; }
 	virtual String get_global_class_name(const String &p_path, String *r_base_type = nullptr, String *r_icon_path = nullptr) const { return String(); }

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -631,6 +631,14 @@ void CSharpLanguage::frame() {
 	}
 }
 
+void CSharpLanguage::set_physics_process_delta_time(double p_time) {
+	GDMonoCache::managed_callbacks.ScriptManagerBridge_SetProcessDeltaTime(p_time, /* physics: */ true);
+}
+
+void CSharpLanguage::set_process_delta_time(double p_time) {
+	GDMonoCache::managed_callbacks.ScriptManagerBridge_SetProcessDeltaTime(p_time, /* physics: */ false);
+}
+
 struct CSharpScriptDepSort {
 	// Must support sorting so inheritance works properly (parent must be reloaded first)
 	bool operator()(const Ref<CSharpScript> &A, const Ref<CSharpScript> &B) const {

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -467,6 +467,8 @@ public:
 	}
 
 	void frame() override;
+	void set_physics_process_delta_time(double p_time) override;
+	void set_process_delta_time(double p_time) override;
 
 	/* TODO? */ void get_public_functions(List<MethodInfo> *p_functions) const override {}
 	/* TODO? */ void get_public_constants(List<Pair<String, Variant>> *p_constants) const override {}

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -164,6 +164,12 @@ class BindingsGenerator {
 		 */
 		bool is_internal = false;
 
+		/**
+		 * Declare the C# method with the `partial` keyword, skipping the body. Useful
+		 * when we want to replace the generated method body with a custom implementation.
+		 */
+		bool declare_as_partial = false;
+
 		List<ArgumentInterface> arguments;
 
 		const DocData::MethodDoc *method_doc = nullptr;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
@@ -14,6 +14,7 @@ namespace Godot.Bridge
         public delegate* unmanaged<IntPtr, godot_array*, godot_bool> DelegateUtils_TrySerializeDelegateWithGCHandle;
         public delegate* unmanaged<godot_array*, IntPtr*, godot_bool> DelegateUtils_TryDeserializeDelegateWithGCHandle;
         public delegate* unmanaged<void> ScriptManagerBridge_FrameCallback;
+        public delegate* unmanaged<double, godot_bool, void> ScriptManagerBridge_SetProcessDeltaTime;
         public delegate* unmanaged<godot_string_name*, IntPtr, IntPtr> ScriptManagerBridge_CreateManagedForGodotObjectBinding;
         public delegate* unmanaged<IntPtr, IntPtr, godot_variant**, int, godot_bool> ScriptManagerBridge_CreateManagedForGodotObjectScriptInstance;
         public delegate* unmanaged<IntPtr, godot_string_name*, void> ScriptManagerBridge_GetScriptNativeName;
@@ -53,6 +54,7 @@ namespace Godot.Bridge
                 DelegateUtils_TrySerializeDelegateWithGCHandle = &DelegateUtils.TrySerializeDelegateWithGCHandle,
                 DelegateUtils_TryDeserializeDelegateWithGCHandle = &DelegateUtils.TryDeserializeDelegateWithGCHandle,
                 ScriptManagerBridge_FrameCallback = &ScriptManagerBridge.FrameCallback,
+                ScriptManagerBridge_SetProcessDeltaTime = &ScriptManagerBridge.SetProcessDeltaTime,
                 ScriptManagerBridge_CreateManagedForGodotObjectBinding = &ScriptManagerBridge.CreateManagedForGodotObjectBinding,
                 ScriptManagerBridge_CreateManagedForGodotObjectScriptInstance = &ScriptManagerBridge.CreateManagedForGodotObjectScriptInstance,
                 ScriptManagerBridge_GetScriptNativeName = &ScriptManagerBridge.GetScriptNativeName,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -87,6 +87,19 @@ namespace Godot.Bridge
         }
 
         [UnmanagedCallersOnly]
+        internal static void SetProcessDeltaTime(double deltaTime, godot_bool physics)
+        {
+            if (physics.ToBool())
+            {
+                Node.CachedPhysicsProcessDeltaTime = deltaTime;
+            }
+            else
+            {
+                Node.CachedProcessDeltaTime = deltaTime;
+            }
+        }
+
+        [UnmanagedCallersOnly]
         internal static unsafe IntPtr CreateManagedForGodotObjectBinding(godot_string_name* nativeTypeName,
             IntPtr godotObject)
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace Godot
 {
@@ -194,6 +196,31 @@ namespace Godot
         public T GetParentOrNull<T>() where T : class
         {
             return GetParent() as T;
+        }
+
+        internal static double CachedPhysicsProcessDeltaTime;
+        internal static double CachedProcessDeltaTime;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [SuppressMessage("Performance", "CA1822:Mark members as static")]
+        public partial double GetPhysicsProcessDeltaTime() => CachedPhysicsProcessDeltaTime;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [SuppressMessage("Performance", "CA1822:Mark members as static")]
+        public partial double GetProcessDeltaTime() => CachedProcessDeltaTime;
+
+        /// <inheritdoc cref="GetPhysicsProcessDeltaTime()"/>
+        public static double PhysicsDeltaTime
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => CachedPhysicsProcessDeltaTime;
+        }
+
+        /// <inheritdoc cref="GetProcessDeltaTime()"/>
+        public static double DeltaTime
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => CachedProcessDeltaTime;
         }
     }
 }

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -79,6 +79,7 @@ struct ManagedCallbacks {
 	using FuncDelegateUtils_TrySerializeDelegateWithGCHandle = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, const Array *);
 	using FuncDelegateUtils_TryDeserializeDelegateWithGCHandle = bool(GD_CLR_STDCALL *)(const Array *, GCHandleIntPtr *);
 	using FuncScriptManagerBridge_FrameCallback = void(GD_CLR_STDCALL *)();
+	using FuncScriptManagerBridge_SetProcessDeltaTime = void(GD_CLR_STDCALL *)(double, bool);
 	using FuncScriptManagerBridge_CreateManagedForGodotObjectBinding = GCHandleIntPtr(GD_CLR_STDCALL *)(const StringName *, Object *);
 	using FuncScriptManagerBridge_CreateManagedForGodotObjectScriptInstance = bool(GD_CLR_STDCALL *)(const CSharpScript *, Object *, const Variant **, int32_t);
 	using FuncScriptManagerBridge_GetScriptNativeName = void(GD_CLR_STDCALL *)(const CSharpScript *, StringName *);
@@ -112,6 +113,7 @@ struct ManagedCallbacks {
 	FuncDelegateUtils_TrySerializeDelegateWithGCHandle DelegateUtils_TrySerializeDelegateWithGCHandle;
 	FuncDelegateUtils_TryDeserializeDelegateWithGCHandle DelegateUtils_TryDeserializeDelegateWithGCHandle;
 	FuncScriptManagerBridge_FrameCallback ScriptManagerBridge_FrameCallback;
+	FuncScriptManagerBridge_SetProcessDeltaTime ScriptManagerBridge_SetProcessDeltaTime;
 	FuncScriptManagerBridge_CreateManagedForGodotObjectBinding ScriptManagerBridge_CreateManagedForGodotObjectBinding;
 	FuncScriptManagerBridge_CreateManagedForGodotObjectScriptInstance ScriptManagerBridge_CreateManagedForGodotObjectScriptInstance;
 	FuncScriptManagerBridge_GetScriptNativeName ScriptManagerBridge_GetScriptNativeName;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -421,6 +421,10 @@ bool SceneTree::physics_process(double p_time) {
 	MainLoop::physics_process(p_time);
 	physics_process_time = p_time;
 
+	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+		ScriptServer::get_language(i)->set_physics_process_delta_time(p_time);
+	}
+
 	emit_signal(SNAME("physics_frame"));
 
 	_notify_group_pause(SNAME("_physics_process_internal"), Node::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
@@ -448,6 +452,10 @@ bool SceneTree::process(double p_time) {
 	MainLoop::process(p_time);
 
 	process_time = p_time;
+
+	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+		ScriptServer::get_language(i)->set_process_delta_time(p_time);
+	}
 
 	if (multiplayer_poll) {
 		multiplayer->poll();


### PR DESCRIPTION
Now the methods return a cached value instead of going through an internal call. I also added matching properties to reduce verbosity.
