### PR TITLE
[3.x] Backport Tree::set_selected

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -202,6 +202,14 @@
 				Sets the title of a column.
 			</description>
 		</method>
+		<method name="set_selected">
+			<return type="void" />
+			<argument index="0" name="item" type="Object" />
+			<argument index="1" name="column" type="int" />
+			<description>
+				Selects the specified [TreeItem] and column.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="allow_reselect" type="bool" setter="set_allow_reselect" getter="get_allow_reselect" default="false">

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3157,6 +3157,12 @@ TreeItem *Tree::get_selected() const {
 	return selected_item;
 }
 
+void Tree::set_selected(TreeItem *p_item, int p_column) {
+	ERR_FAIL_INDEX(p_column, columns.size());
+	ERR_FAIL_COND(!p_item);
+	select_single_item(p_item, get_root(), p_column);
+}
+
 int Tree::get_selected_column() const {
 	return selected_col;
 }
@@ -3832,6 +3838,7 @@ void Tree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_root_hidden"), &Tree::is_root_hidden);
 	ClassDB::bind_method(D_METHOD("get_next_selected", "from"), &Tree::_get_next_selected);
 	ClassDB::bind_method(D_METHOD("get_selected"), &Tree::get_selected);
+	ClassDB::bind_method(D_METHOD("set_selected", "item", "column"), &Tree::_set_selected);
 	ClassDB::bind_method(D_METHOD("get_selected_column"), &Tree::get_selected_column);
 	ClassDB::bind_method(D_METHOD("get_pressed_button"), &Tree::get_pressed_button);
 	ClassDB::bind_method(D_METHOD("set_select_mode", "mode"), &Tree::set_select_mode);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -527,6 +527,10 @@ protected:
 		scroll_to_item(Object::cast_to<TreeItem>(p_item));
 	}
 
+	void _set_selected(Object *p_item, int p_column) {
+		set_selected(Object::cast_to<TreeItem>(p_item), p_column);
+	}
+
 public:
 	virtual String get_tooltip(const Point2 &p_pos) const;
 
@@ -549,6 +553,7 @@ public:
 	bool is_root_hidden() const;
 	TreeItem *get_next_selected(TreeItem *p_item);
 	TreeItem *get_selected() const;
+	void set_selected(TreeItem *p_item, int p_column = 0);
 	int get_selected_column() const;
 	int get_pressed_button() const;
 	void set_select_mode(SelectMode p_mode);


### PR DESCRIPTION
Backport function from godotengine#68448

Edit: This can be cherry-picked for 3.5 if desired

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
