### PR TITLE
Add support for associating Navigation Link positions with nodes

### DIFF
--- a/doc/classes/NavigationLink2D.xml
+++ b/doc/classes/NavigationLink2D.xml
@@ -59,6 +59,10 @@
 		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">
 			Whether this link is currently active. If [code]false[/code], [method NavigationServer2D.map_get_path] will ignore this link.
 		</member>
+		<member name="end_node_path" type="NodePath" setter="set_end_node_path" getter="get_end_node_path" default="NodePath(&quot;&quot;)">
+			Use the node's position at the passed in path to determine the [member end_position] of the link.
+			Changes to [member end_position] will be ignored while this is set and the node's position will be used instead.
+		</member>
 		<member name="end_position" type="Vector2" setter="set_end_position" getter="get_end_position" default="Vector2(0, 0)">
 			Ending position of the link.
 			This position will search out the nearest polygon in the navigation mesh to attach to.
@@ -69,6 +73,10 @@
 		</member>
 		<member name="navigation_layers" type="int" setter="set_navigation_layers" getter="get_navigation_layers" default="1">
 			A bitfield determining all navigation layers the link belongs to. These navigation layers will be checked when requesting a path with [method NavigationServer2D.map_get_path].
+		</member>
+		<member name="start_node_path" type="NodePath" setter="set_start_node_path" getter="get_start_node_path" default="NodePath(&quot;&quot;)">
+			Use the node's position at the passed in path to determine the [member start_position] of the link.
+			Changes to [member start_position] will be ignored while this is set and the node's position will be used instead.
 		</member>
 		<member name="start_position" type="Vector2" setter="set_start_position" getter="get_start_position" default="Vector2(0, 0)">
 			Starting position of the link.

--- a/doc/classes/NavigationLink3D.xml
+++ b/doc/classes/NavigationLink3D.xml
@@ -59,6 +59,10 @@
 		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">
 			Whether this link is currently active. If [code]false[/code], [method NavigationServer3D.map_get_path] will ignore this link.
 		</member>
+		<member name="end_node_path" type="NodePath" setter="set_end_node_path" getter="get_end_node_path" default="NodePath(&quot;&quot;)">
+			Use the node's position at the passed in path to determine the [member end_position] of the link.
+			Changes to [member end_position] will be ignored while this is set and the node's position will be used instead.
+		</member>
 		<member name="end_position" type="Vector3" setter="set_end_position" getter="get_end_position" default="Vector3(0, 0, 0)">
 			Ending position of the link.
 			This position will search out the nearest polygon in the navigation mesh to attach to.
@@ -69,6 +73,10 @@
 		</member>
 		<member name="navigation_layers" type="int" setter="set_navigation_layers" getter="get_navigation_layers" default="1">
 			A bitfield determining all navigation layers the link belongs to. These navigation layers will be checked when requesting a path with [method NavigationServer3D.map_get_path].
+		</member>
+		<member name="start_node_path" type="NodePath" setter="set_start_node_path" getter="get_start_node_path" default="NodePath(&quot;&quot;)">
+			Use the node's position at the passed in path to determine the [member start_position] of the link.
+			Changes to [member start_position] will be ignored while this is set and the node's position will be used instead.
 		</member>
 		<member name="start_position" type="Vector3" setter="set_start_position" getter="get_start_position" default="Vector3(0, 0, 0)">
 			Starting position of the link.

--- a/editor/plugins/navigation_link_2d_editor_plugin.cpp
+++ b/editor/plugins/navigation_link_2d_editor_plugin.cpp
@@ -66,23 +66,27 @@ bool NavigationLink2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_e
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT) {
 		if (mb->is_pressed()) {
 			// Start position
-			if (xform.xform(node->get_start_position()).distance_to(mb->get_position()) < grab_threshold) {
-				start_grabbed = true;
-				original_start_position = node->get_start_position();
+			if (node->get_start_node_path().is_empty()) {
+				if (xform.xform(node->get_start_position()).distance_to(mb->get_position()) < grab_threshold) {
+					start_grabbed = true;
+					original_start_position = node->get_start_position();
 
-				return true;
-			} else {
-				start_grabbed = false;
+					return true;
+				} else {
+					start_grabbed = false;
+				}
 			}
 
 			// End position
-			if (xform.xform(node->get_end_position()).distance_to(mb->get_position()) < grab_threshold) {
-				end_grabbed = true;
-				original_end_position = node->get_end_position();
+			if (node->get_end_node_path().is_empty()) {
+				if (xform.xform(node->get_end_position()).distance_to(mb->get_position()) < grab_threshold) {
+					end_grabbed = true;
+					original_end_position = node->get_end_position();
 
-				return true;
-			} else {
-				end_grabbed = false;
+					return true;
+				} else {
+					end_grabbed = false;
+				}
 			}
 		} else {
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
@@ -148,8 +152,12 @@ void NavigationLink2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 
 	// Only drawing the handles here, since the debug rendering will fill in the rest.
 	const Ref<Texture2D> handle = get_theme_icon(SNAME("EditorHandle"), SNAME("EditorIcons"));
-	p_overlay->draw_texture(handle, global_start_position - handle->get_size() / 2);
-	p_overlay->draw_texture(handle, global_end_position - handle->get_size() / 2);
+	if (node->get_start_node_path().is_empty()) {
+		p_overlay->draw_texture(handle, global_start_position - handle->get_size() / 2);
+	}
+	if (node->get_end_node_path().is_empty()) {
+		p_overlay->draw_texture(handle, global_end_position - handle->get_size() / 2);
+	}
 }
 
 void NavigationLink2DEditor::edit(NavigationLink2D *p_node) {

--- a/editor/plugins/node_3d_editor_gizmos.h
+++ b/editor/plugins/node_3d_editor_gizmos.h
@@ -39,6 +39,7 @@
 
 class Timer;
 class EditorNode3DGizmoPlugin;
+class NavigationLink3D;
 
 class EditorNode3DGizmo : public Node3DGizmo {
 	GDCLASS(EditorNode3DGizmo, Node3DGizmo);
@@ -635,6 +636,8 @@ public:
 
 class NavigationLink3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(NavigationLink3DGizmoPlugin, EditorNode3DGizmoPlugin);
+
+	int map_handle_index_to_link_index(const NavigationLink3D *p_link, int p_id) const;
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;

--- a/scene/2d/navigation_link_2d.h
+++ b/scene/2d/navigation_link_2d.h
@@ -40,7 +40,9 @@ class NavigationLink2D : public Node2D {
 	RID link;
 	bool bidirectional = true;
 	uint32_t navigation_layers = 1;
+	NodePath end_node_path;
 	Vector2 end_position;
+	NodePath start_node_path;
 	Vector2 start_position;
 	real_t enter_cost = 0.0;
 	real_t travel_cost = 1.0;
@@ -48,6 +50,7 @@ class NavigationLink2D : public Node2D {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	void _validate_property(PropertyInfo &p_property) const;
 
 #ifndef DISABLE_DEPRECATED
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -83,6 +86,12 @@ public:
 
 	void set_global_end_position(Vector2 p_position);
 	Vector2 get_global_end_position() const;
+
+	void set_start_node_path(const NodePath &p_path);
+	NodePath get_start_node_path() const { return start_node_path; }
+
+	void set_end_node_path(const NodePath &p_path);
+	NodePath get_end_node_path() const { return end_node_path; }
 
 	void set_enter_cost(real_t p_enter_cost);
 	real_t get_enter_cost() const { return enter_cost; }

--- a/scene/3d/navigation_link_3d.h
+++ b/scene/3d/navigation_link_3d.h
@@ -40,7 +40,9 @@ class NavigationLink3D : public Node3D {
 	RID link;
 	bool bidirectional = true;
 	uint32_t navigation_layers = 1;
+	NodePath end_node_path;
 	Vector3 end_position;
+	NodePath start_node_path;
 	Vector3 start_position;
 	real_t enter_cost = 0.0;
 	real_t travel_cost = 1.0;
@@ -55,6 +57,7 @@ class NavigationLink3D : public Node3D {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	void _validate_property(PropertyInfo &p_property) const;
 
 #ifndef DISABLE_DEPRECATED
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -88,6 +91,12 @@ public:
 
 	void set_global_end_position(Vector3 p_position);
 	Vector3 get_global_end_position() const;
+
+	void set_start_node_path(const NodePath &p_path);
+	NodePath get_start_node_path() const { return start_node_path; }
+
+	void set_end_node_path(const NodePath &p_path);
+	NodePath get_end_node_path() const { return end_node_path; }
 
 	void set_enter_cost(real_t p_enter_cost);
 	real_t get_enter_cost() const { return enter_cost; }


### PR DESCRIPTION
Addresses: https://github.com/godotengine/godot-proposals/discussions/6099

Adds a pair of `NodePath` properties which allow fixing the start or end position of a `NavigationLink` to a node.  Once set, that end of the link will follow the node's global position, updating during the physics interval.

This should help users setup links between moving portions of the world and allow those which would like a dedicated node to control the end point of a link to use `Marker` to do so.

New properties in the inspector:
![image](https://user-images.githubusercontent.com/1929107/221766395-aa244368-e869-481c-807c-3cfa25b23f9f.png)

Inspector when node paths are filled (positions are hidden and gizmos update to hide handles):
![image](https://user-images.githubusercontent.com/1929107/221766298-b791bb3c-bae7-4a94-96f2-aff26fa9c2d7.png)

Currently working on fixing some issues that occur when moving the link while both positions remain fixed, but I think this is close enough for some early review.