### PR TITLE
Check for type mismatch in `PropertyTweener.from()`

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -489,6 +489,11 @@ Tween::Tween(bool p_valid) {
 }
 
 Ref<PropertyTweener> PropertyTweener::from(Variant p_value) {
+	ERR_FAIL_COND_V(tween.is_null(), nullptr);
+	if (!tween->_validate_type_match(p_value, final_val)) {
+		return nullptr;
+	}
+
 	initial_val = p_value;
 	do_continue = false;
 	return this;

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -61,6 +61,8 @@ class MethodTweener;
 class Tween : public RefCounted {
 	GDCLASS(Tween, RefCounted);
 
+	friend class PropertyTweener;
+
 public:
 	enum TweenProcessMode {
 		TWEEN_PROCESS_PHYSICS,


### PR DESCRIPTION
Fixes #74102