### PR TITLE
Enable `RichTextLabel` context menu if selection is enabled

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2343,6 +2343,7 @@ EditorHelp::EditorHelp() {
 	status_bar->add_child(toggle_scripts_button);
 
 	class_desc->set_selection_enabled(true);
+	class_desc->set_context_menu_enabled(true);
 
 	class_desc->hide();
 }

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -380,6 +380,7 @@ EditorLog::EditorLog() {
 	log->set_use_bbcode(true);
 	log->set_scroll_follow(true);
 	log->set_selection_enabled(true);
+	log->set_context_menu_enabled(true);
 	log->set_focus_mode(FOCUS_CLICK);
 	log->set_v_size_flags(SIZE_EXPAND_FILL);
 	log->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8054,6 +8054,7 @@ EditorNode::EditorNode() {
 
 	execute_outputs = memnew(RichTextLabel);
 	execute_outputs->set_selection_enabled(true);
+	execute_outputs->set_context_menu_enabled(true);
 	execute_output_dialog = memnew(AcceptDialogAutoReparent);
 	execute_output_dialog->add_child(execute_outputs);
 	execute_output_dialog->set_title("");

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -245,6 +245,7 @@ void EditorAssetLibraryItemDescription::configure(const String &p_title, int p_a
 	description->add_text("\n" + TTR("Description:") + "\n\n");
 	description->append_text(p_description);
 	description->set_selection_enabled(true);
+	description->set_context_menu_enabled(true);
 	set_title(p_title);
 }
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -2174,6 +2174,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	warnings_panel->set_h_size_flags(SIZE_EXPAND_FILL);
 	warnings_panel->set_meta_underline(true);
 	warnings_panel->set_selection_enabled(true);
+	warnings_panel->set_context_menu_enabled(true);
 	warnings_panel->set_focus_mode(FOCUS_CLICK);
 	warnings_panel->hide();
 
@@ -2182,6 +2183,7 @@ ScriptTextEditor::ScriptTextEditor() {
 	errors_panel->set_h_size_flags(SIZE_EXPAND_FILL);
 	errors_panel->set_meta_underline(true);
 	errors_panel->set_selection_enabled(true);
+	errors_panel->set_context_menu_enabled(true);
 	errors_panel->set_focus_mode(FOCUS_CLICK);
 	errors_panel->hide();
 

--- a/editor/plugins/shader_file_editor_plugin.cpp
+++ b/editor/plugins/shader_file_editor_plugin.cpp
@@ -289,6 +289,7 @@ ShaderFileEditor::ShaderFileEditor() {
 	error_text = memnew(RichTextLabel);
 	error_text->set_v_size_flags(SIZE_EXPAND_FILL);
 	error_text->set_selection_enabled(true);
+	error_text->set_context_menu_enabled(true);
 	main_vb->add_child(error_text);
 }
 

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -1169,6 +1169,7 @@ TextShaderEditor::TextShaderEditor() {
 	warnings_panel->set_h_size_flags(SIZE_EXPAND_FILL);
 	warnings_panel->set_meta_underline(true);
 	warnings_panel->set_selection_enabled(true);
+	warnings_panel->set_context_menu_enabled(true);
 	warnings_panel->set_focus_mode(FOCUS_CLICK);
 	warnings_panel->hide();
 	warnings_panel->connect("meta_clicked", callable_mp(this, &TextShaderEditor::_warning_clicked));

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -1504,6 +1504,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	diff->set_v_size_flags(TextEdit::SIZE_EXPAND_FILL);
 	diff->set_use_bbcode(true);
 	diff->set_selection_enabled(true);
+	diff->set_context_menu_enabled(true);
 	version_control_dock->add_child(diff);
 
 	_update_set_up_warning("");


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/47700418/221867753-46b9cf01-4c52-4dba-8ef4-472e3bdc701e.png)

Related #74109. This is not a fix, but some kind of workaround. But this makes sense regardless of the bug.