### PR TITLE
Clear resource load tasks at exit

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1079,6 +1079,7 @@ void ResourceLoader::initialize() {
 }
 
 void ResourceLoader::finalize() {
+	clear_thread_load_tasks();
 	memdelete(thread_load_mutex);
 	memdelete(thread_load_semaphore);
 }


### PR DESCRIPTION
I wouldn't call this a bug, but without this the engine can leak threads, condition variables and resources at engine exit if resource loads were in progress.