### PR TITLE
Project scan validations mirror editor

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -610,15 +610,31 @@ void ProjectList::_scan_folder_recursive(const String &p_path, List<String> *r_p
 
 	da->list_dir_begin();
 	String n = da->get_next();
+	PackedStringArray dirs = {};
+	bool project = false;
+	bool ignore = false;
+
 	while (!n.is_empty()) {
 		if (da->current_is_dir() && n[0] != '.') {
-			_scan_folder_recursive(da->get_current_dir().path_join(n), r_projects);
+			dirs.append(da->get_current_dir().path_join(n));
 		} else if (n == "project.godot") {
-			r_projects->push_back(da->get_current_dir());
+			project = true;
+		} else if (n == ".gdignore") {
+			ignore = true;
+			break;
 		}
 		n = da->get_next();
 	}
 	da->list_dir_end();
+
+	if (!ignore) {
+		if (project) {
+			r_projects->push_back(da->get_current_dir());
+		}
+		for (String &dir : dirs) {
+			_scan_folder_recursive(dir, r_projects);
+		}
+	}
 }
 
 // Project list items.


### PR DESCRIPTION
Adjusted Project Manager scan functionality to mirror the editor's validations. It now will skip searching a directory if a `.gdignore` file is present, and won't search subdirectories if `project.godot` is present. These premptive checks add a slight increase in scan time with a generic directory, but ultimately speeds up timing for dedicated repositories as it won't have nearly as many recursive loops

One specific use-case this would help with is a gdextension project featuring a godot-cpp submodule. Its "test" project will no longer automatically appear after a scan, as godot-cpp has a `.gdignore` in its repository root