### PR TITLE
[3.x] C#: Fix crash when errors occur before language initialization.

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -563,7 +563,7 @@ Vector<ScriptLanguage::StackInfo> CSharpLanguage::debug_get_current_stack_info()
 	_TLS_RECURSION_GUARD_V_(Vector<StackInfo>());
 	GD_MONO_SCOPE_THREAD_ATTACH;
 
-	if (!gdmono->is_runtime_initialized() || !GDMono::get_singleton()->get_core_api_assembly() || !GDMonoCache::cached_data.corlib_cache_updated)
+	if (!gdmono || !gdmono->is_runtime_initialized() || !GDMono::get_singleton()->get_core_api_assembly() || !GDMonoCache::cached_data.corlib_cache_updated)
 		return Vector<StackInfo>();
 
 	MonoObject *stack_trace = mono_object_new(mono_domain_get(), CACHED_CLASS(System_Diagnostics_StackTrace)->get_mono_ptr());
@@ -716,7 +716,7 @@ void CSharpLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_soft
 
 #ifdef GD_MONO_HOT_RELOAD
 bool CSharpLanguage::is_assembly_reloading_needed() {
-	if (!gdmono->is_runtime_initialized())
+	if (!gdmono || !gdmono->is_runtime_initialized())
 		return false;
 
 	GDMonoAssembly *proj_assembly = gdmono->get_project_assembly();
@@ -755,7 +755,7 @@ bool CSharpLanguage::is_assembly_reloading_needed() {
 }
 
 void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
-	if (!gdmono->is_runtime_initialized())
+	if (!gdmono || !gdmono->is_runtime_initialized())
 		return;
 
 	// There is no soft reloading with Mono. It's always hard reloading.
@@ -1116,7 +1116,7 @@ bool CSharpLanguage::overrides_external_editor() {
 
 void CSharpLanguage::thread_enter() {
 #if 0
-	if (gdmono->is_runtime_initialized()) {
+	if (gdmono && gdmono->is_runtime_initialized()) {
 		GDMonoUtils::attach_current_thread();
 	}
 #endif
@@ -1124,7 +1124,7 @@ void CSharpLanguage::thread_enter() {
 
 void CSharpLanguage::thread_exit() {
 #if 0
-	if (gdmono->is_runtime_initialized()) {
+	if (gdmono && gdmono->is_runtime_initialized()) {
 		GDMonoUtils::detach_current_thread();
 	}
 #endif

--- a/modules/mono/mono_gc_handle.cpp
+++ b/modules/mono/mono_gc_handle.cpp
@@ -61,7 +61,7 @@ void MonoGCHandle::release() {
 	CRASH_COND(!released && GDMono::get_singleton() == NULL);
 #endif
 
-	if (!released && GDMono::get_singleton()->is_runtime_initialized()) {
+	if (!released && GDMono::get_singleton() && GDMono::get_singleton()->is_runtime_initialized()) {
 		free_handle(handle);
 		released = true;
 	}

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -1342,7 +1342,7 @@ int32_t _GodotSharp::get_scripts_domain_id() {
 }
 
 bool _GodotSharp::is_scripts_domain_loaded() {
-	return GDMono::get_singleton()->is_runtime_initialized() && GDMono::get_singleton()->get_scripts_domain() != NULL;
+	return GDMono::get_singleton() && GDMono::get_singleton()->is_runtime_initialized() && GDMono::get_singleton()->get_scripts_domain() != NULL;
 }
 
 bool _GodotSharp::_is_domain_finalizing_for_unload(int32_t p_domain_id) {
@@ -1370,7 +1370,7 @@ bool _GodotSharp::is_runtime_shutting_down() {
 }
 
 bool _GodotSharp::is_runtime_initialized() {
-	return GDMono::get_singleton()->is_runtime_initialized();
+	return GDMono::get_singleton() && GDMono::get_singleton()->is_runtime_initialized();
 }
 
 void _GodotSharp::_reload_assemblies(bool p_soft_reload) {

--- a/modules/mono/mono_gd/gd_mono_utils.cpp
+++ b/modules/mono/mono_gd/gd_mono_utils.cpp
@@ -125,7 +125,7 @@ void set_main_thread(MonoThread *p_thread) {
 }
 
 MonoThread *attach_current_thread() {
-	ERR_FAIL_COND_V(!GDMono::get_singleton()->is_runtime_initialized(), NULL);
+	ERR_FAIL_COND_V(!GDMono::get_singleton() || !GDMono::get_singleton()->is_runtime_initialized(), NULL);
 	MonoDomain *scripts_domain = GDMono::get_singleton()->get_scripts_domain();
 #ifndef GD_MONO_SINGLE_APPDOMAIN
 	MonoThread *mono_thread = mono_thread_attach(scripts_domain ? scripts_domain : mono_get_root_domain());
@@ -138,14 +138,14 @@ MonoThread *attach_current_thread() {
 }
 
 void detach_current_thread() {
-	ERR_FAIL_COND(!GDMono::get_singleton()->is_runtime_initialized());
+	ERR_FAIL_COND(!GDMono::get_singleton() || !GDMono::get_singleton()->is_runtime_initialized());
 	MonoThread *mono_thread = mono_thread_current();
 	ERR_FAIL_NULL(mono_thread);
 	mono_thread_detach(mono_thread);
 }
 
 void detach_current_thread(MonoThread *p_mono_thread) {
-	ERR_FAIL_COND(!GDMono::get_singleton()->is_runtime_initialized());
+	ERR_FAIL_COND(!GDMono::get_singleton() || !GDMono::get_singleton()->is_runtime_initialized());
 	ERR_FAIL_NULL(p_mono_thread);
 	mono_thread_detach(p_mono_thread);
 }
@@ -633,7 +633,7 @@ GDMonoClass *make_generic_dictionary_type(MonoReflectionType *p_key_reftype, Mon
 
 ScopeThreadAttach::ScopeThreadAttach() :
 		mono_thread(NULL) {
-	if (likely(GDMono::get_singleton()->is_runtime_initialized()) && unlikely(!mono_domain_get())) {
+	if (likely(GDMono::get_singleton()) && likely(GDMono::get_singleton()->is_runtime_initialized()) && unlikely(!mono_domain_get())) {
 		mono_thread = GDMonoUtils::attach_current_thread();
 	}
 }


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/35740
- `master` version: https://github.com/godotengine/godot/pull/74127
