### PR TITLE
Expose and document `Image.get_mipmap_count()`

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3412,6 +3412,7 @@ void Image::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("convert", "format"), &Image::convert);
 
+	ClassDB::bind_method(D_METHOD("get_mipmap_count"), &Image::get_mipmap_count);
 	ClassDB::bind_method(D_METHOD("get_mipmap_offset", "mipmap"), &Image::get_mipmap_offset);
 
 	ClassDB::bind_method(D_METHOD("resize_to_po2", "square", "interpolation"), &Image::resize_to_po2, DEFVAL(false), DEFVAL(INTERPOLATE_BILINEAR));

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -201,7 +201,8 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="renormalize" type="bool" default="false" />
 			<description>
-				Generates mipmaps for the image. Mipmaps are precalculated lower-resolution copies of the image that are automatically used if the image needs to be scaled down when rendered. They help improve image quality and performance when rendering. This method returns an error if the image is compressed, in a custom format, or if the image's width/height is [code]0[/code].
+				Generates mipmaps for the image. Mipmaps are precalculated lower-resolution copies of the image that are automatically used if the image needs to be scaled down when rendered. They help improve image quality and performance when rendering. This method returns an error if the image is compressed, in a custom format, or if the image's width/height is [code]0[/code]. Enabling [param renormalize] when generating mipmaps for normal textures will make sure all resulting vector values are normalized.
+				It is possible to check if the image has mipmaps by calling [method has_mipmaps] or [method get_mipmap_count].
 			</description>
 		</method>
 		<method name="get_data" qualifiers="const">
@@ -220,6 +221,12 @@
 			<return type="int" />
 			<description>
 				Returns the image's height.
+			</description>
+		</method>
+		<method name="get_mipmap_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of mipmap levels or 0 if the image has no mipmaps. The largest main level image is not counted as a mipmap level by this method, so if you want to include it you can add 1 to this count.
 			</description>
 		</method>
 		<method name="get_mipmap_offset" qualifiers="const">


### PR DESCRIPTION
Adds a new method `Image.get_mipmap_details()` and exposes an already existing method `Image.get_mipmap_count()`. Also documents both. This makes it possible to efficiently manipulate raw mipmap data. It was technically possible before, but the calculations required are not trivial to do and very error prone.