### PR TITLE
Add XRServer.world_origin property

### DIFF
--- a/doc/classes/XRServer.xml
+++ b/doc/classes/XRServer.xml
@@ -108,6 +108,10 @@
 		<member name="primary_interface" type="XRInterface" setter="set_primary_interface" getter="get_primary_interface">
 			The primary [XRInterface] currently bound to the [XRServer].
 		</member>
+		<member name="world_origin" type="Transform3D" setter="set_world_origin" getter="get_world_origin" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
+			The current origin of our tracking space in the virtual world. This is used by the renderer to properly position the camera with new tracking data.
+			[b]Note:[/b] This property is managed by the current [XROrigin3D] node. It is exposed for access from GDExtensions.
+		</member>
 		<member name="world_scale" type="float" setter="set_world_scale" getter="get_world_scale" default="1.0">
 			Allows you to adjust the scale to your game's units. Most AR/VR platforms assume a scale of 1 game world unit = 1 real world meter.
 		</member>

--- a/servers/xr_server.cpp
+++ b/servers/xr_server.cpp
@@ -52,11 +52,14 @@ XRServer *XRServer::get_singleton() {
 void XRServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_world_scale"), &XRServer::get_world_scale);
 	ClassDB::bind_method(D_METHOD("set_world_scale", "scale"), &XRServer::set_world_scale);
+	ClassDB::bind_method(D_METHOD("get_world_origin"), &XRServer::get_world_origin);
+	ClassDB::bind_method(D_METHOD("set_world_origin", "world_origin"), &XRServer::set_world_origin);
 	ClassDB::bind_method(D_METHOD("get_reference_frame"), &XRServer::get_reference_frame);
 	ClassDB::bind_method(D_METHOD("center_on_hmd", "rotation_mode", "keep_height"), &XRServer::center_on_hmd);
 	ClassDB::bind_method(D_METHOD("get_hmd_transform"), &XRServer::get_hmd_transform);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "world_scale"), "set_world_scale", "get_world_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "world_origin"), "set_world_origin", "get_world_origin");
 
 	ClassDB::bind_method(D_METHOD("add_interface", "interface"), &XRServer::add_interface);
 	ClassDB::bind_method(D_METHOD("get_interface_count"), &XRServer::get_interface_count);


### PR DESCRIPTION
This PR exposes the `XRServer::set_world_origin` and `XRServer::get_world_origin` methods and adds a `world_origin` property to give access to this data.

The world_origin is used by the renderer to correctly position the camera using the latest tracking data (this overrides the current location of the camera though they should be near identical). 

While the current `XROrigin3D` node is meant to manage this value and this value on the XRServer wasn't previously exposed, there are situations where this needs to be accessed from GDExternals hence the add. The help page information reflects this.
