### PR TITLE
Make GDScript Number highlighting stricter

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -294,17 +294,27 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 					!(str[j] == '_' && (prev_is_digit || str[j - 1] == 'b' || str[j - 1] == 'x' || str[j - 1] == '.')) &&
 					!(str[j] == 'e' && (prev_is_digit || str[j - 1] == '_')) &&
 					!(str[j] == '.' && (prev_is_digit || (!prev_is_binary_op && (j > 0 && (str[j - 1] == '-' || str[j - 1] == '+' || str[j - 1] == '~'))))) &&
-					!((str[j] == '-' || str[j] == '+' || str[j] == '~') && !prev_is_binary_op && str[j - 1] != 'e')) {
-				/* This condition continues Number highlighting in special cases.
-				1st row: '+' or '-' after scientific notation;
+					!((str[j] == '-' || str[j] == '+' || str[j] == '~') && !is_binary_op && !prev_is_binary_op && str[j - 1] != 'e')) {
+				/* This condition continues number highlighting in special cases.
+				1st row: '+' or '-' after scientific notation (like 3e-4);
 				2nd row: '_' as a numeric separator;
 				3rd row: Scientific notation 'e' and floating points;
 				4th row: Floating points inside the number, or leading if after a unary mathematical operator;
-				5th row: Multiple unary mathematical operators */
+				5th row: Multiple unary mathematical operators (like ~-7)*/
 				in_number = false;
 			}
-		} else if (!is_binary_op && (str[j] == '-' || str[j] == '+' || str[j] == '~' || (str[j] == '.' && str[j + 1] != '.' && (j == 0 || (j > 0 && str[j - 1] != '.'))))) {
+		} else if (str[j] == '.' && !is_binary_op && is_digit(str[j + 1]) && (j == 0 || (j > 0 && str[j - 1] != '.'))) {
+			// Start number highlighting from leading decimal points (like .42)
 			in_number = true;
+		} else if ((str[j] == '-' || str[j] == '+' || str[j] == '~') && !is_binary_op) {
+			// Only start number highlighting on unary operators if a digit follows them.
+			int non_op = j + 1;
+			while (str[non_op] == '-' || str[non_op] == '+' || str[non_op] == '~') {
+				non_op++;
+			}
+			if (is_digit(str[non_op]) || (str[non_op] == '.' && non_op < line_length && is_digit(str[non_op + 1]))) {
+				in_number = true;
+			}
 		}
 
 		if (!in_word && is_unicode_identifier_start(str[j]) && !in_number) {


### PR DESCRIPTION
I previously made number highlighting start when `+ - ~` are unary operators, but I think this is too broad as number highlighting is probably expected to only show up for numbers, not for i.e. `-size`. So I made it peek if the next symbol is a digit.

Fixes bug where binary operators are highlighted like numbers if there's no spacing, i.e. in `4+ 2`