### PR TITLE
Fix NodeOneShot doesn't respect fade-out when aborting and improvement

### DIFF
--- a/doc/classes/AnimationNodeOneShot.xml
+++ b/doc/classes/AnimationNodeOneShot.xml
@@ -18,10 +18,20 @@
 		# Alternative syntax (same result as above).
 		animation_tree["parameters/OneShot/request"] = AnimationNodeOneShot.ONE_SHOT_REQUEST_ABORT
 
+		# Abort child animation with fading out connected to "shot" port.
+		animation_tree.set("parameters/OneShot/request", AnimationNodeOneShot.ONE_SHOT_REQUEST_FADE_OUT)
+		# Alternative syntax (same result as above).
+		animation_tree["parameters/OneShot/request"] = AnimationNodeOneShot.ONE_SHOT_REQUEST_FADE_OUT
+
 		# Get current state (read-only).
-		animation_tree.get("parameters/OneShot/active"))
+		animation_tree.get("parameters/OneShot/active")
 		# Alternative syntax (same result as above).
 		animation_tree["parameters/OneShot/active"]
+
+		# Get current internal state (read-only).
+		animation_tree.get("parameters/OneShot/internal_active")
+		# Alternative syntax (same result as above).
+		animation_tree["parameters/OneShot/internal_active"]
 		[/gdscript]
 		[csharp]
 		// Play child animation connected to "shot" port.
@@ -30,8 +40,14 @@
 		// Abort child animation connected to "shot" port.
 		animationTree.Set("parameters/OneShot/request", AnimationNodeOneShot.ONE_SHOT_REQUEST_ABORT);
 
+		// Abort child animation with fading out connected to "shot" port.
+		animationTree.Set("parameters/OneShot/request", AnimationNodeOneShot.ONE_SHOT_REQUEST_FADE_OUT);
+
 		// Get current state (read-only).
 		animationTree.Get("parameters/OneShot/active");
+
+		// Get current internal state (read-only).
+		animationTree.Get("parameters/OneShot/internal_active");
 		[/csharp]
 		[/codeblocks]
 	</description>
@@ -50,11 +66,17 @@
 		<member name="autorestart_random_delay" type="float" setter="set_autorestart_random_delay" getter="get_autorestart_random_delay" default="0.0">
 			If [member autorestart] is [code]true[/code], a random additional delay (in seconds) between 0 and this value will be added to [member autorestart_delay].
 		</member>
+		<member name="fadein_curve" type="Curve" setter="set_fadein_curve" getter="get_fadein_curve">
+			Determines how cross-fading between animations is eased. If empty, the transition will be linear.
+		</member>
 		<member name="fadein_time" type="float" setter="set_fadein_time" getter="get_fadein_time" default="0.0">
-			The fade-in duration. For example, setting this to [code]1.0[/code] for a 5 second length animation will produce a crossfade that starts at 0 second and ends at 1 second during the animation.
+			The fade-in duration. For example, setting this to [code]1.0[/code] for a 5 second length animation will produce a cross-fade that starts at 0 second and ends at 1 second during the animation.
+		</member>
+		<member name="fadeout_curve" type="Curve" setter="set_fadeout_curve" getter="get_fadeout_curve">
+			Determines how cross-fading between animations is eased. If empty, the transition will be linear.
 		</member>
 		<member name="fadeout_time" type="float" setter="set_fadeout_time" getter="get_fadeout_time" default="0.0">
-			The fade-out duration. For example, setting this to [code]1.0[/code] for a 5 second length animation will produce a crossfade that starts at 4 second and ends at 5 second during the animation.
+			The fade-out duration. For example, setting this to [code]1.0[/code] for a 5 second length animation will produce a cross-fade that starts at 4 second and ends at 5 second during the animation.
 		</member>
 		<member name="mix_mode" type="int" setter="set_mix_mode" getter="get_mix_mode" enum="AnimationNodeOneShot.MixMode" default="0">
 			The blend type.
@@ -69,6 +91,9 @@
 		</constant>
 		<constant name="ONE_SHOT_REQUEST_ABORT" value="2" enum="OneShotRequest">
 			The request to stop the animation connected to "shot" port.
+		</constant>
+		<constant name="ONE_SHOT_REQUEST_FADE_OUT" value="3" enum="OneShotRequest">
+			The request to fade out the animation connected to "shot" port.
 		</constant>
 		<constant name="MIX_MODE_BLEND" value="0" enum="MixMode">
 			Blends two animations. See also [AnimationNodeBlend2].

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -100,6 +100,7 @@ public:
 		ONE_SHOT_REQUEST_NONE,
 		ONE_SHOT_REQUEST_FIRE,
 		ONE_SHOT_REQUEST_ABORT,
+		ONE_SHOT_REQUEST_FADE_OUT,
 	};
 
 	enum MixMode {
@@ -109,17 +110,21 @@ public:
 
 private:
 	double fade_in = 0.0;
+	Ref<Curve> fade_in_curve;
 	double fade_out = 0.0;
+	Ref<Curve> fade_out_curve;
 
-	bool autorestart = false;
-	double autorestart_delay = 1.0;
-	double autorestart_random_delay = 0.0;
+	bool auto_restart = false;
+	double auto_restart_delay = 1.0;
+	double auto_restart_random_delay = 0.0;
 	MixMode mix = MIX_MODE_BLEND;
 
 	StringName request = PNAME("request");
 	StringName active = PNAME("active");
+	StringName internal_active = PNAME("internal_active");
 	StringName time = "time";
 	StringName remaining = "remaining";
+	StringName fade_out_remaining = "fade_out_remaining";
 	StringName time_to_restart = "time_to_restart";
 
 protected:
@@ -132,19 +137,25 @@ public:
 
 	virtual String get_caption() const override;
 
-	void set_fadein_time(double p_time);
-	void set_fadeout_time(double p_time);
+	void set_fade_in_time(double p_time);
+	double get_fade_in_time() const;
 
-	double get_fadein_time() const;
-	double get_fadeout_time() const;
+	void set_fade_in_curve(const Ref<Curve> &p_curve);
+	Ref<Curve> get_fade_in_curve() const;
 
-	void set_autorestart(bool p_active);
-	void set_autorestart_delay(double p_time);
-	void set_autorestart_random_delay(double p_time);
+	void set_fade_out_time(double p_time);
+	double get_fade_out_time() const;
 
-	bool has_autorestart() const;
-	double get_autorestart_delay() const;
-	double get_autorestart_random_delay() const;
+	void set_fade_out_curve(const Ref<Curve> &p_curve);
+	Ref<Curve> get_fade_out_curve() const;
+
+	void set_auto_restart_enabled(bool p_enabled);
+	void set_auto_restart_delay(double p_time);
+	void set_auto_restart_random_delay(double p_time);
+
+	bool is_auto_restart_enabled() const;
+	double get_auto_restart_delay() const;
+	double get_auto_restart_random_delay() const;
 
 	void set_mix_mode(MixMode p_mix);
 	MixMode get_mix_mode() const;


### PR DESCRIPTION
Fixes: #53947
Fixes: #73113

Apply same fix to NodeOneShot with #73120.

Also, add a request `ONE_SHOT_REQUEST_FADE_OUT` to NodeOneshot to Abort with respect to the fade-out time.

This changes the transition timing of the active state. This means that the transition to the next state will occur at the start of the fade in the same way as NodeTransition and NodeState.

However, for the Active state, it should be true if OneShot is still in effect. Also for compatibility.

Therefore, the display (retrieve-able) active state and the internal active state are separated as: `active` and `internal_active`.

In addition, the xfade curve can be set as in NodeTransition and StateMachine.

https://user-images.githubusercontent.com/61938263/222272844-87771e4a-a212-4f9b-8d77-ceb8a4d2e647.mp4
