### PR TITLE
Project Converter: Do not convert lines that start with a comment

### DIFF
--- a/editor/project_converter_3_to_4.h
+++ b/editor/project_converter_3_to_4.h
@@ -58,6 +58,11 @@ public:
 #include "core/templates/local_vector.h"
 #include "core/templates/vector.h"
 
+struct SourceLine {
+	String line;
+	bool is_comment;
+};
+
 class RegEx;
 
 class ProjectConverter3To4 {
@@ -66,33 +71,33 @@ class ProjectConverter3To4 {
 	uint64_t maximum_file_size;
 	uint64_t maximum_line_length;
 
-	void rename_colors(Vector<String> &lines, const RegExContainer &reg_container);
+	void rename_colors(Vector<SourceLine> &source_lines, const RegExContainer &reg_container);
 	Vector<String> check_for_rename_colors(Vector<String> &lines, const RegExContainer &reg_container);
 
-	void rename_classes(Vector<String> &lines, const RegExContainer &reg_container);
+	void rename_classes(Vector<SourceLine> &source_lines, const RegExContainer &reg_container);
 	Vector<String> check_for_rename_classes(Vector<String> &lines, const RegExContainer &reg_container);
 
-	void rename_gdscript_functions(Vector<String> &lines, const RegExContainer &reg_container, bool builtin);
+	void rename_gdscript_functions(Vector<SourceLine> &source_lines, const RegExContainer &reg_container, bool builtin);
 	Vector<String> check_for_rename_gdscript_functions(Vector<String> &lines, const RegExContainer &reg_container, bool builtin);
 	void process_gdscript_line(String &line, const RegExContainer &reg_container, bool builtin);
 
-	void rename_csharp_functions(Vector<String> &lines, const RegExContainer &reg_container);
+	void rename_csharp_functions(Vector<SourceLine> &source_lines, const RegExContainer &reg_container);
 	Vector<String> check_for_rename_csharp_functions(Vector<String> &lines, const RegExContainer &reg_container);
 	void process_csharp_line(String &line, const RegExContainer &reg_container);
 
-	void rename_csharp_attributes(Vector<String> &lines, const RegExContainer &reg_container);
+	void rename_csharp_attributes(Vector<SourceLine> &source_lines, const RegExContainer &reg_container);
 	Vector<String> check_for_rename_csharp_attributes(Vector<String> &lines, const RegExContainer &reg_container);
 
-	void rename_gdscript_keywords(Vector<String> &lines, const RegExContainer &reg_container);
+	void rename_gdscript_keywords(Vector<SourceLine> &source_lines, const RegExContainer &reg_container);
 	Vector<String> check_for_rename_gdscript_keywords(Vector<String> &lines, const RegExContainer &reg_container);
 
-	void rename_input_map_scancode(Vector<String> &lines, const RegExContainer &reg_container);
+	void rename_input_map_scancode(Vector<SourceLine> &source_lines, const RegExContainer &reg_container);
 	Vector<String> check_for_rename_input_map_scancode(Vector<String> &lines, const RegExContainer &reg_container);
 
-	void custom_rename(Vector<String> &lines, String from, String to);
+	void custom_rename(Vector<SourceLine> &source_lines, String from, String to);
 	Vector<String> check_for_custom_rename(Vector<String> &lines, String from, String to);
 
-	void rename_common(const char *array[][2], LocalVector<RegEx *> &cached_regexes, Vector<String> &lines);
+	void rename_common(const char *array[][2], LocalVector<RegEx *> &cached_regexes, Vector<SourceLine> &source_lines);
 	Vector<String> check_for_rename_common(const char *array[][2], LocalVector<RegEx *> &cached_regexes, Vector<String> &lines);
 
 	Vector<String> check_for_files();
@@ -105,11 +110,12 @@ class ProjectConverter3To4 {
 
 	String line_formatter(int current_line, String from, String to, String line);
 	String simple_line_formatter(int current_line, String old_line, String line);
-	String collect_string_from_vector(Vector<String> &vector);
+	String collect_string_from_vector(Vector<SourceLine> &vector);
+	Vector<SourceLine> split_lines(const String &text);
 
 	bool test_single_array(const char *array[][2], bool ignore_second_check = false);
-	bool test_conversion_gdscript_builtin(String name, String expected, void (ProjectConverter3To4::*func)(Vector<String> &, const RegExContainer &, bool), String what, const RegExContainer &reg_container, bool builtin);
-	bool test_conversion_with_regex(String name, String expected, void (ProjectConverter3To4::*func)(Vector<String> &, const RegExContainer &), String what, const RegExContainer &reg_container);
+	bool test_conversion_gdscript_builtin(String name, String expected, void (ProjectConverter3To4::*func)(Vector<SourceLine> &, const RegExContainer &, bool), String what, const RegExContainer &reg_container, bool builtin);
+	bool test_conversion_with_regex(String name, String expected, void (ProjectConverter3To4::*func)(Vector<SourceLine> &, const RegExContainer &), String what, const RegExContainer &reg_container);
 	bool test_conversion_basic(String name, String expected, const char *array[][2], LocalVector<RegEx *> &regex_cache, String what);
 	bool test_array_names();
 	bool test_conversion(RegExContainer &reg_container);


### PR DESCRIPTION
Partially fixes: - https://github.com/godotengine/godot/issues/66061
Partially fixes: - https://github.com/godotengine/godot/issues/70983

This PR adds detection of lines that start with a comment. 
Those lines are ignored so that the text inside the comments remains untouched.
E.g. `# Reference` is not converted to `# RefCounted`.
Lines that do not start with a comment, e.g. `func _ready(): # Reference` will still be converted.

Same applies to C# comments: `// Reference`