### PR TITLE
Add option to reverse FlowContainer fill direction (HFlow bottom-to-top, VFlow right-to-left)

### DIFF
--- a/doc/classes/FlowContainer.xml
+++ b/doc/classes/FlowContainer.xml
@@ -21,6 +21,10 @@
 		<member name="alignment" type="int" setter="set_alignment" getter="get_alignment" enum="FlowContainer.AlignmentMode" default="0">
 			The alignment of the container's children (must be one of [constant ALIGNMENT_BEGIN], [constant ALIGNMENT_CENTER], or [constant ALIGNMENT_END]).
 		</member>
+		<member name="reverse_fill" type="bool" setter="set_reverse_fill" getter="is_reverse_fill" default="false">
+			If [code]true[/code], reverses fill direction. Horizontal [FlowContainer]s will fill rows bottom to top, vertical [FlowContainer]s will fill columns right to left.
+			When using a vertical [FlowContainer] with a right to left [member Control.layout_direction], columns will fill left to right instead.
+		</member>
 		<member name="vertical" type="bool" setter="set_vertical" getter="is_vertical" default="false">
 			If [code]true[/code], the [FlowContainer] will arrange its children vertically, rather than horizontally.
 			Can't be changed when using [HFlowContainer] and [VFlowContainer].

--- a/scene/gui/flow_container.cpp
+++ b/scene/gui/flow_container.cpp
@@ -198,7 +198,10 @@ void FlowContainer::_resort() {
 		}
 
 		Rect2 child_rect = Rect2(ofs, child_size);
-		if (rtl) {
+		if (reverse_fill && !vertical) {
+			child_rect.position.y = get_rect().size.y - child_rect.position.y - child_rect.size.height;
+		}
+		if ((rtl && !vertical) || ((rtl != reverse_fill) && vertical)) {
 			child_rect.position.x = get_rect().size.x - child_rect.position.x - child_rect.size.width;
 		}
 
@@ -322,6 +325,18 @@ bool FlowContainer::is_vertical() const {
 	return vertical;
 }
 
+void FlowContainer::set_reverse_fill(bool p_reverse_fill) {
+	if (reverse_fill == p_reverse_fill) {
+		return;
+	}
+	reverse_fill = p_reverse_fill;
+	_resort();
+}
+
+bool FlowContainer::is_reverse_fill() const {
+	return reverse_fill;
+}
+
 FlowContainer::FlowContainer(bool p_vertical) {
 	vertical = p_vertical;
 }
@@ -333,6 +348,8 @@ void FlowContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_alignment"), &FlowContainer::get_alignment);
 	ClassDB::bind_method(D_METHOD("set_vertical", "vertical"), &FlowContainer::set_vertical);
 	ClassDB::bind_method(D_METHOD("is_vertical"), &FlowContainer::is_vertical);
+	ClassDB::bind_method(D_METHOD("set_reverse_fill", "reverse_fill"), &FlowContainer::set_reverse_fill);
+	ClassDB::bind_method(D_METHOD("is_reverse_fill"), &FlowContainer::is_reverse_fill);
 
 	BIND_ENUM_CONSTANT(ALIGNMENT_BEGIN);
 	BIND_ENUM_CONSTANT(ALIGNMENT_CENTER);
@@ -340,6 +357,7 @@ void FlowContainer::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "alignment", PROPERTY_HINT_ENUM, "Begin,Center,End"), "set_alignment", "get_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "vertical"), "set_vertical", "is_vertical");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "reverse_fill"), "set_reverse_fill", "is_reverse_fill");
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, FlowContainer, h_separation);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, FlowContainer, v_separation);

--- a/scene/gui/flow_container.h
+++ b/scene/gui/flow_container.h
@@ -48,6 +48,7 @@ private:
 	int cached_line_count = 0;
 
 	bool vertical = false;
+	bool reverse_fill = false;
 	AlignmentMode alignment = ALIGNMENT_BEGIN;
 
 	struct ThemeCache {
@@ -72,6 +73,9 @@ public:
 
 	void set_vertical(bool p_vertical);
 	bool is_vertical() const;
+
+	void set_reverse_fill(bool p_reverse_fill);
+	bool is_reverse_fill() const;
 
 	virtual Size2 get_minimum_size() const override;
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Adds an option to make horizontal FlowContainers add lines starting from the bottom instead of the top or vertical flow containers add lines starting from the right instead of left. 
Video:

https://user-images.githubusercontent.com/66881186/222279524-b493f57e-2a49-45ad-b5f2-9cfcaae50ff3.mp4

- Implements and closes https://github.com/godotengine/godot-proposals/issues/6386