### PR TITLE
Improve POT Generation dialog

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1355,6 +1355,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_INTERNAL("application/config/features", PackedStringArray());
 	GLOBAL_DEF_INTERNAL("internationalization/locale/translation_remaps", PackedStringArray());
 	GLOBAL_DEF_INTERNAL("internationalization/locale/translations", PackedStringArray());
+	GLOBAL_DEF_INTERNAL("internationalization/locale/translations_pot_files", PackedStringArray());
 }
 
 ProjectSettings::~ProjectSettings() {

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -576,20 +576,20 @@ void LocalizationEditor::update_translations() {
 	translation_pot_list->clear();
 	root = translation_pot_list->create_item(nullptr);
 	translation_pot_list->set_hide_root(true);
-	if (ProjectSettings::get_singleton()->has_setting("internationalization/locale/translations_pot_files")) {
-		PackedStringArray pot_translations = GLOBAL_GET("internationalization/locale/translations_pot_files");
-		for (int i = 0; i < pot_translations.size(); i++) {
-			TreeItem *t = translation_pot_list->create_item(root);
-			t->set_editable(0, false);
-			t->set_text(0, pot_translations[i].replace_first("res://", ""));
-			t->set_tooltip_text(0, pot_translations[i]);
-			t->set_metadata(0, i);
-			t->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), 0, false, TTR("Remove"));
-		}
+	PackedStringArray pot_translations = GLOBAL_GET("internationalization/locale/translations_pot_files");
+	for (int i = 0; i < pot_translations.size(); i++) {
+		TreeItem *t = translation_pot_list->create_item(root);
+		t->set_editable(0, false);
+		t->set_text(0, pot_translations[i].replace_first("res://", ""));
+		t->set_tooltip_text(0, pot_translations[i]);
+		t->set_metadata(0, i);
+		t->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), 0, false, TTR("Remove"));
 	}
 
 	// New translation parser plugin might extend possible file extensions in POT generation.
 	_update_pot_file_extensions();
+
+	pot_generate_button->set_disabled(pot_translations.is_empty());
 
 	updating_translations = false;
 }
@@ -726,9 +726,9 @@ LocalizationEditor::LocalizationEditor() {
 		addtr->connect("pressed", callable_mp(this, &LocalizationEditor::_pot_file_open));
 		thb->add_child(addtr);
 
-		Button *generate = memnew(Button(TTR("Generate POT")));
-		generate->connect("pressed", callable_mp(this, &LocalizationEditor::_pot_generate_open));
-		thb->add_child(generate);
+		pot_generate_button = memnew(Button(TTR("Generate POT")));
+		pot_generate_button->connect("pressed", callable_mp(this, &LocalizationEditor::_pot_generate_open));
+		thb->add_child(pot_generate_button);
 
 		VBoxContainer *tmc = memnew(VBoxContainer);
 		tmc->set_v_size_flags(Control::SIZE_EXPAND_FILL);

--- a/editor/localization_editor.h
+++ b/editor/localization_editor.h
@@ -54,6 +54,7 @@ class LocalizationEditor : public VBoxContainer {
 	Tree *translation_pot_list = nullptr;
 	EditorFileDialog *pot_file_open_dialog = nullptr;
 	EditorFileDialog *pot_generate_dialog = nullptr;
+	Button *pot_generate_button = nullptr;
 
 	bool updating_translations = false;
 	String localization_changed;

--- a/editor/pot_generator.cpp
+++ b/editor/pot_generator.cpp
@@ -55,15 +55,15 @@ void POTGenerator::_print_all_translation_strings() {
 #endif
 
 void POTGenerator::generate_pot(const String &p_file) {
-	if (!ProjectSettings::get_singleton()->has_setting("internationalization/locale/translations_pot_files")) {
+	Vector<String> files = GLOBAL_GET("internationalization/locale/translations_pot_files");
+
+	if (files.is_empty()) {
 		WARN_PRINT("No files selected for POT generation.");
 		return;
 	}
 
 	// Clear all_translation_strings of the previous round.
 	all_translation_strings.clear();
-
-	Vector<String> files = GLOBAL_GET("internationalization/locale/translations_pot_files");
 
 	// Collect all translatable strings according to files order in "POT Generation" setting.
 	for (int i = 0; i < files.size(); i++) {


### PR DESCRIPTION
When no file is added for POT generation, clicking the Generate POT button prints a warning:

> core/config/project_settings.cpp:367 - Property not found: internationalization/locale/translations_pot_files

I see a few users, including myself, missed this warning and get confused about the POT file not generated. The Generate POT button is now disabled when the list is empty, like buttons for other lists in the dialog.

There are also two "property not found" warnings when adding a file for the first time:

> core/config/project_settings.cpp:367 - Property not found: internationalization/locale/translations_pot_files
> core/config/project_settings.cpp:367 - Property not found: internationalization/locale/translations_pot_files

This is fixed by defining it first with `GLOBAL_DEF_INTERNAL()` in project settings.