### PR TITLE
Hide internal settings from the classref

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -401,6 +401,10 @@ void ProjectSettings::_get_property_list(List<PropertyInfo> *p_list) const {
 			vc.flags = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE;
 		}
 
+		if (v->internal) {
+			vc.flags |= PROPERTY_USAGE_INTERNAL;
+		}
+
 		if (v->basic) {
 			vc.flags |= PROPERTY_USAGE_EDITOR_BASIC_SETTING;
 		}
@@ -1242,7 +1246,7 @@ void ProjectSettings::_add_builtin_input_map() {
 			action["events"] = events;
 
 			String action_name = "input/" + E.key;
-			GLOBAL_DEF_INTERNAL(action_name, action);
+			GLOBAL_DEF(action_name, action);
 			input_presets.push_back(action_name);
 		}
 	}

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2773,6 +2773,7 @@
 			The property is shown in the [EditorInspector] (default).
 		</constant>
 		<constant name="PROPERTY_USAGE_INTERNAL" value="8" enum="PropertyUsageFlags" is_bitfield="true">
+			The property is excluded from the class reference.
 		</constant>
 		<constant name="PROPERTY_USAGE_CHECKABLE" value="16" enum="PropertyUsageFlags" is_bitfield="true">
 			The property can be checked in the [EditorInspector].

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -248,9 +248,6 @@
 		<member name="application/config/description" type="String" setter="" getter="" default="&quot;&quot;">
 			The project's description, displayed as a tooltip in the Project Manager when hovering the project.
 		</member>
-		<member name="application/config/features" type="PackedStringArray" setter="" getter="">
-			List of internal features associated with the project, like [code]Double Precision[/code] or [code]C#[/code]. Not to be confused with feature tags.
-		</member>
 		<member name="application/config/icon" type="String" setter="" getter="" default="&quot;&quot;">
 			Icon used for the project, set when project loads. Exporters will also use this icon when possible.
 		</member>
@@ -1160,12 +1157,6 @@
 		</member>
 		<member name="internationalization/locale/test" type="String" setter="" getter="" default="&quot;&quot;">
 			If non-empty, this locale will be used when running the project from the editor.
-		</member>
-		<member name="internationalization/locale/translation_remaps" type="PackedStringArray" setter="" getter="">
-			Locale-dependent resource remaps. Edit them in the "Localization" tab of Project Settings editor.
-		</member>
-		<member name="internationalization/locale/translations" type="PackedStringArray" setter="" getter="">
-			List of translation files available in the project. Edit them in the "Localization" tab of Project Settings editor.
 		</member>
 		<member name="internationalization/pseudolocalization/double_vowels" type="bool" setter="" getter="" default="false">
 			Double vowels in strings during pseudolocalization to simulate the lengthening of text due to localization.


### PR DESCRIPTION
Settings defined with `GLOBAL_DEF_INTERNAL` are supposed to be storage only according to this comment:

https://github.com/godotengine/godot/blob/1c1524a651e6d670d0d591b050d8c4bbb721d6e9/core/config/project_settings.cpp#L1350-L1353

Default input actions are no longer marked as internal since it makes sense to document them. They are still hidden from the Project Settings dialog because we hid the whole `input/` group manually.

**Note:** Since this PR makes all internal settings hidden from the classref, CI will break if both #74213 and this one are merged as-is. I'll rebase the other once one of them is merged.