### PR TITLE
GDScript: Require type or variable initializer for export annotations

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -352,9 +352,9 @@
 				Export a floating-point property with an easing editor widget. Additional hints can be provided to adjust the behavior of the widget. [code]"attenuation"[/code] flips the curve, which makes it more intuitive for editing attenuation properties. [code]"positive_only"[/code] limits values to only be greater than or equal to zero.
 				See also [constant PROPERTY_HINT_EXP_EASING].
 				[codeblock]
-				@export_exp_easing var transition_speed
-				@export_exp_easing("attenuation") var fading_attenuation
-				@export_exp_easing("positive_only") var effect_power
+				@export_exp_easing var transition_speed: float
+				@export_exp_easing("attenuation") var fading_attenuation: float
+				@export_exp_easing("positive_only") var effect_power: float
 				[/codeblock]
 			</description>
 		</annotation>
@@ -392,7 +392,7 @@
 				[b]Note:[/b] A flag value must be at least [code]1[/code] and at most [code]2 ** 32 - 1[/code].
 				[b]Note:[/b] Unlike [annotation @export_enum], the previous explicit value is not taken into account. In the following example, A is 16, B is 2, C is 4.
 				[codeblock]
-				@export_flags("A:16", "B", "C") var x
+				@export_flags("A:16", "B", "C") var x = 0
 				[/codeblock]
 			</description>
 		</annotation>
@@ -508,7 +508,7 @@
 				Export a [String] property with a large [TextEdit] widget instead of a [LineEdit]. This adds support for multiline content and makes it easier to edit large amount of text stored in the property.
 				See also [constant PROPERTY_HINT_MULTILINE_TEXT].
 				[codeblock]
-				@export_multiline var character_biography
+				@export_multiline var character_biography = ""
 				[/codeblock]
 			</description>
 		</annotation>
@@ -519,7 +519,7 @@
 				Export a [NodePath] property with a filter for allowed node types.
 				See also [constant PROPERTY_HINT_NODE_PATH_VALID_TYPES].
 				[codeblock]
-				@export_node_path("Button", "TouchScreenButton") var some_button
+				@export_node_path("Button", "TouchScreenButton") var some_button: NodePath
 				[/codeblock]
 			</description>
 		</annotation>
@@ -546,16 +546,16 @@
 				Hints also allow to indicate the units for the edited value. Using [code]"radians"[/code] you can specify that the actual value is in radians, but should be displayed in degrees in the Inspector dock. [code]"degrees"[/code] allows to add a degree sign as a unit suffix. Finally, a custom suffix can be provided using [code]"suffix:unit"[/code], where "unit" can be any string.
 				See also [constant PROPERTY_HINT_RANGE].
 				[codeblock]
-				@export_range(0, 20) var number
-				@export_range(-10, 20) var number
+				@export_range(0, 20) var number = 0
+				@export_range(-10, 20) var number: int
 				@export_range(-10, 20, 0.2) var number: float
 
-				@export_range(0, 100, 1, "or_greater") var power_percent
-				@export_range(0, 100, 1, "or_greater", "or_less") var health_delta
+				@export_range(0, 100, 1, "or_greater") var power_percent = 0
+				@export_range(0, 100, 1, "or_greater", "or_less") var health_delta = 0
 
-				@export_range(-3.14, 3.14, 0.001, "radians") var angle_radians
-				@export_range(0, 360, 1, "degrees") var angle_degrees
-				@export_range(-8, 8, 2, "suffix:px") var target_offset
+				@export_range(-3.14, 3.14, 0.001, "radians") var angle_radians = 0.0
+				@export_range(0, 360, 1, "degrees") var angle_degrees = 0.0
+				@export_range(-8, 8, 2, "suffix:px") var target_offset = 0
 				[/codeblock]
 			</description>
 		</annotation>

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3719,6 +3719,11 @@ bool GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node
 
 	variable->exported = true;
 
+	if (variable->datatype_specifier == nullptr && variable->initializer == nullptr) {
+		push_error(vformat(R"(Cannot use annotation "%s" with variable without a specified type or initializer.)", p_annotation->name), p_annotation);
+		return false;
+	}
+
 	variable->export_info.type = t_type;
 	variable->export_info.hint = t_hint;
 
@@ -3809,11 +3814,6 @@ bool GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node
 	}
 
 	if (p_annotation->name == SNAME("@export")) {
-		if (variable->datatype_specifier == nullptr && variable->initializer == nullptr) {
-			push_error(R"(Cannot use simple "@export" annotation with variable without type or initializer, since type can't be inferred.)", p_annotation);
-			return false;
-		}
-
 		bool is_array = false;
 
 		if (export_type.builtin_type == Variant::ARRAY && export_type.has_container_element_type()) {

--- a/modules/gdscript/tests/scripts/analyzer/errors/annotation_non_constant_parameter.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/annotation_non_constant_parameter.gd
@@ -1,6 +1,6 @@
 var num := 1
 
-@export_range(num, 10) var a
+@export_range(num, 10) var a = 5
 
 func test():
 	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/export_var_no_type_no_initializer.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/export_var_no_type_no_initializer.gd
@@ -1,0 +1,6 @@
+# GH-74188
+
+@export_multiline var text
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/export_var_no_type_no_initializer.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/export_var_no_type_no_initializer.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot use annotation "@export_multiline" with variable without a specified type or initializer.

--- a/modules/gdscript/tests/scripts/parser/features/export_enum.gd
+++ b/modules/gdscript/tests/scripts/parser/features/export_enum.gd
@@ -1,15 +1,13 @@
-@export_enum("Red", "Green", "Blue") var untyped
-
 @export_enum("Red", "Green", "Blue") var weak_int = 0
 @export_enum("Red", "Green", "Blue") var weak_string = ""
 
 @export_enum("Red", "Green", "Blue") var hard_int: int
 @export_enum("Red", "Green", "Blue") var hard_string: String
 
-@export_enum("Red:10", "Green:20", "Blue:30") var with_values
+@export_enum("Red:10", "Green:20", "Blue:30") var with_values = 10
 
 func test():
 	for property in get_property_list():
-		if property.name in ["untyped", "weak_int", "weak_string", "hard_int",
+		if property.name in ["weak_int", "weak_string", "hard_int",
 				"hard_string", "with_values"]:
 			prints(property.name, property.type, property.hint_string)

--- a/modules/gdscript/tests/scripts/parser/features/export_enum.out
+++ b/modules/gdscript/tests/scripts/parser/features/export_enum.out
@@ -1,5 +1,4 @@
 GDTEST_OK
-untyped 2 Red,Green,Blue
 weak_int 2 Red,Green,Blue
 weak_string 4 Red,Green,Blue
 hard_int 2 Red,Green,Blue


### PR DESCRIPTION
Closes #74188.