### PR TITLE
Add keycode project conversion

### DIFF
--- a/editor/project_converter_3_to_4.h
+++ b/editor/project_converter_3_to_4.h
@@ -86,6 +86,9 @@ class ProjectConverter3To4 {
 	void rename_gdscript_keywords(Vector<String> &lines, const RegExContainer &reg_container);
 	Vector<String> check_for_rename_gdscript_keywords(Vector<String> &lines, const RegExContainer &reg_container);
 
+	void rename_input_map_scancode(Vector<String> &lines, const RegExContainer &reg_container);
+	Vector<String> check_for_rename_input_map_scancode(Vector<String> &lines, const RegExContainer &reg_container);
+
 	void custom_rename(Vector<String> &lines, String from, String to);
 	Vector<String> check_for_custom_rename(Vector<String> &lines, String from, String to);
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Because of an overlap in keycodes between 3.x and 4.x conversion of special keys do not work, treating the `SPKEY` of 3.x as `CMD_OR_CTRL`, this fixes that.