### PR TITLE
Fix `Image.convert()` overwriting custom mipmaps

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -516,21 +516,31 @@ void Image::convert(Format p_new_format) {
 		return;
 	}
 
+	// Includes the main image.
+	const int mipmap_count = get_mipmap_count() + 1;
+
 	if (format > FORMAT_RGBE9995 || p_new_format > FORMAT_RGBE9995) {
 		ERR_FAIL_MSG("Cannot convert to <-> from compressed formats. Use compress() and decompress() instead.");
 
 	} else if (format > FORMAT_RGBA8 || p_new_format > FORMAT_RGBA8) {
 		//use put/set pixel which is slower but works with non byte formats
-		Image new_img(width, height, false, p_new_format);
+		Image new_img(width, height, mipmaps, p_new_format);
 
-		for (int i = 0; i < width; i++) {
-			for (int j = 0; j < height; j++) {
-				new_img.set_pixel(i, j, get_pixel(i, j));
+		for (int mip = 0; mip < mipmap_count; mip++) {
+			Ref<Image> src_mip = get_image_from_mipmap(mip);
+			Ref<Image> new_mip = new_img.get_image_from_mipmap(mip);
+
+			for (int y = 0; y < src_mip->height; y++) {
+				for (int x = 0; x < src_mip->width; x++) {
+					new_mip->set_pixel(x, y, src_mip->get_pixel(x, y));
+				}
 			}
-		}
 
-		if (has_mipmaps()) {
-			new_img.generate_mipmaps();
+			int mip_offset = 0;
+			int mip_size = 0;
+			new_img.get_mipmap_offset_and_size(mip, mip_offset, mip_size);
+
+			memcpy(new_img.data.ptrw() + mip_offset, new_mip->data.ptr(), mip_size);
 		}
 
 		_copy_internals_from(new_img);
@@ -538,113 +548,115 @@ void Image::convert(Format p_new_format) {
 		return;
 	}
 
-	Image new_img(width, height, false, p_new_format);
-
-	const uint8_t *rptr = data.ptr();
-	uint8_t *wptr = new_img.data.ptrw();
+	Image new_img(width, height, mipmaps, p_new_format);
 
 	int conversion_type = format | p_new_format << 8;
 
-	switch (conversion_type) {
-		case FORMAT_L8 | (FORMAT_LA8 << 8):
-			_convert<1, false, 1, true, true, true>(width, height, rptr, wptr);
-			break;
-		case FORMAT_L8 | (FORMAT_R8 << 8):
-			_convert<1, false, 1, false, true, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_L8 | (FORMAT_RG8 << 8):
-			_convert<1, false, 2, false, true, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_L8 | (FORMAT_RGB8 << 8):
-			_convert<1, false, 3, false, true, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_L8 | (FORMAT_RGBA8 << 8):
-			_convert<1, false, 3, true, true, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_LA8 | (FORMAT_L8 << 8):
-			_convert<1, true, 1, false, true, true>(width, height, rptr, wptr);
-			break;
-		case FORMAT_LA8 | (FORMAT_R8 << 8):
-			_convert<1, true, 1, false, true, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_LA8 | (FORMAT_RG8 << 8):
-			_convert<1, true, 2, false, true, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_LA8 | (FORMAT_RGB8 << 8):
-			_convert<1, true, 3, false, true, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_LA8 | (FORMAT_RGBA8 << 8):
-			_convert<1, true, 3, true, true, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_R8 | (FORMAT_L8 << 8):
-			_convert<1, false, 1, false, false, true>(width, height, rptr, wptr);
-			break;
-		case FORMAT_R8 | (FORMAT_LA8 << 8):
-			_convert<1, false, 1, true, false, true>(width, height, rptr, wptr);
-			break;
-		case FORMAT_R8 | (FORMAT_RG8 << 8):
-			_convert<1, false, 2, false, false, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_R8 | (FORMAT_RGB8 << 8):
-			_convert<1, false, 3, false, false, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_R8 | (FORMAT_RGBA8 << 8):
-			_convert<1, false, 3, true, false, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_RG8 | (FORMAT_L8 << 8):
-			_convert<2, false, 1, false, false, true>(width, height, rptr, wptr);
-			break;
-		case FORMAT_RG8 | (FORMAT_LA8 << 8):
-			_convert<2, false, 1, true, false, true>(width, height, rptr, wptr);
-			break;
-		case FORMAT_RG8 | (FORMAT_R8 << 8):
-			_convert<2, false, 1, false, false, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_RG8 | (FORMAT_RGB8 << 8):
-			_convert<2, false, 3, false, false, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_RG8 | (FORMAT_RGBA8 << 8):
-			_convert<2, false, 3, true, false, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_RGB8 | (FORMAT_L8 << 8):
-			_convert<3, false, 1, false, false, true>(width, height, rptr, wptr);
-			break;
-		case FORMAT_RGB8 | (FORMAT_LA8 << 8):
-			_convert<3, false, 1, true, false, true>(width, height, rptr, wptr);
-			break;
-		case FORMAT_RGB8 | (FORMAT_R8 << 8):
-			_convert<3, false, 1, false, false, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_RGB8 | (FORMAT_RG8 << 8):
-			_convert<3, false, 2, false, false, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_RGB8 | (FORMAT_RGBA8 << 8):
-			_convert<3, false, 3, true, false, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_RGBA8 | (FORMAT_L8 << 8):
-			_convert<3, true, 1, false, false, true>(width, height, rptr, wptr);
-			break;
-		case FORMAT_RGBA8 | (FORMAT_LA8 << 8):
-			_convert<3, true, 1, true, false, true>(width, height, rptr, wptr);
-			break;
-		case FORMAT_RGBA8 | (FORMAT_R8 << 8):
-			_convert<3, true, 1, false, false, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_RGBA8 | (FORMAT_RG8 << 8):
-			_convert<3, true, 2, false, false, false>(width, height, rptr, wptr);
-			break;
-		case FORMAT_RGBA8 | (FORMAT_RGB8 << 8):
-			_convert<3, true, 3, false, false, false>(width, height, rptr, wptr);
-			break;
-	}
+	for (int mip = 0; mip < mipmap_count; mip++) {
+		int mip_offset = 0;
+		int mip_size = 0;
+		int mip_width = 0;
+		int mip_height = 0;
+		get_mipmap_offset_size_and_dimensions(mip, mip_offset, mip_size, mip_width, mip_height);
 
-	bool gen_mipmaps = mipmaps;
+		const uint8_t *rptr = data.ptr() + mip_offset;
+		uint8_t *wptr = new_img.data.ptrw() + new_img.get_mipmap_offset(mip);
+
+		switch (conversion_type) {
+			case FORMAT_L8 | (FORMAT_LA8 << 8):
+				_convert<1, false, 1, true, true, true>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_L8 | (FORMAT_R8 << 8):
+				_convert<1, false, 1, false, true, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_L8 | (FORMAT_RG8 << 8):
+				_convert<1, false, 2, false, true, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_L8 | (FORMAT_RGB8 << 8):
+				_convert<1, false, 3, false, true, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_L8 | (FORMAT_RGBA8 << 8):
+				_convert<1, false, 3, true, true, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_LA8 | (FORMAT_L8 << 8):
+				_convert<1, true, 1, false, true, true>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_LA8 | (FORMAT_R8 << 8):
+				_convert<1, true, 1, false, true, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_LA8 | (FORMAT_RG8 << 8):
+				_convert<1, true, 2, false, true, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_LA8 | (FORMAT_RGB8 << 8):
+				_convert<1, true, 3, false, true, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_LA8 | (FORMAT_RGBA8 << 8):
+				_convert<1, true, 3, true, true, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_R8 | (FORMAT_L8 << 8):
+				_convert<1, false, 1, false, false, true>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_R8 | (FORMAT_LA8 << 8):
+				_convert<1, false, 1, true, false, true>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_R8 | (FORMAT_RG8 << 8):
+				_convert<1, false, 2, false, false, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_R8 | (FORMAT_RGB8 << 8):
+				_convert<1, false, 3, false, false, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_R8 | (FORMAT_RGBA8 << 8):
+				_convert<1, false, 3, true, false, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_RG8 | (FORMAT_L8 << 8):
+				_convert<2, false, 1, false, false, true>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_RG8 | (FORMAT_LA8 << 8):
+				_convert<2, false, 1, true, false, true>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_RG8 | (FORMAT_R8 << 8):
+				_convert<2, false, 1, false, false, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_RG8 | (FORMAT_RGB8 << 8):
+				_convert<2, false, 3, false, false, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_RG8 | (FORMAT_RGBA8 << 8):
+				_convert<2, false, 3, true, false, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_RGB8 | (FORMAT_L8 << 8):
+				_convert<3, false, 1, false, false, true>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_RGB8 | (FORMAT_LA8 << 8):
+				_convert<3, false, 1, true, false, true>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_RGB8 | (FORMAT_R8 << 8):
+				_convert<3, false, 1, false, false, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_RGB8 | (FORMAT_RG8 << 8):
+				_convert<3, false, 2, false, false, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_RGB8 | (FORMAT_RGBA8 << 8):
+				_convert<3, false, 3, true, false, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_RGBA8 | (FORMAT_L8 << 8):
+				_convert<3, true, 1, false, false, true>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_RGBA8 | (FORMAT_LA8 << 8):
+				_convert<3, true, 1, true, false, true>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_RGBA8 | (FORMAT_R8 << 8):
+				_convert<3, true, 1, false, false, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_RGBA8 | (FORMAT_RG8 << 8):
+				_convert<3, true, 2, false, false, false>(mip_width, mip_height, rptr, wptr);
+				break;
+			case FORMAT_RGBA8 | (FORMAT_RGB8 << 8):
+				_convert<3, true, 3, false, false, false>(mip_width, mip_height, rptr, wptr);
+				break;
+		}
+	}
 
 	_copy_internals_from(new_img);
-
-	if (gen_mipmaps) {
-		generate_mipmaps();
-	}
 }
 
 Image::Format Image::get_format() const {

--- a/tests/core/io/test_image.h
+++ b/tests/core/io/test_image.h
@@ -304,6 +304,86 @@ TEST_CASE("[Image] Modifying pixels of an image") {
 			image3->get_pixel(1, 0).is_equal_approx(Color(0, 0, 0, 0)),
 			"flip_y() should not leave old pixels behind.");
 }
+
+TEST_CASE("[Image] Custom mipmaps") {
+	Ref<Image> image = memnew(Image(100, 100, false, Image::FORMAT_RGBA8));
+
+	REQUIRE(!image->has_mipmaps());
+	image->generate_mipmaps();
+	REQUIRE(image->has_mipmaps());
+
+	const int mipmaps = image->get_mipmap_count() + 1;
+	REQUIRE(mipmaps == 7);
+
+	// Initialize reference mipmap data.
+	// Each byte is given value "mipmap_index * 5".
+
+	{
+		PackedByteArray data = image->get_data();
+		uint8_t *data_ptr = data.ptrw();
+
+		for (int mip = 0; mip < mipmaps; mip++) {
+			int mip_offset = 0;
+			int mip_size = 0;
+			image->get_mipmap_offset_and_size(mip, mip_offset, mip_size);
+
+			for (int i = 0; i < mip_size; i++) {
+				data_ptr[mip_offset + i] = mip * 5;
+			}
+		}
+		image->set_data(image->get_width(), image->get_height(), image->has_mipmaps(), image->get_format(), data);
+	}
+
+	// Byte format conversion.
+
+	for (int format = Image::FORMAT_L8; format <= Image::FORMAT_RGBA8; format++) {
+		Ref<Image> image_bytes = memnew(Image());
+		image_bytes->copy_internals_from(image);
+		image_bytes->convert((Image::Format)format);
+		REQUIRE(image_bytes->has_mipmaps());
+
+		PackedByteArray data = image_bytes->get_data();
+		const uint8_t *data_ptr = data.ptr();
+
+		for (int mip = 0; mip < mipmaps; mip++) {
+			int mip_offset = 0;
+			int mip_size = 0;
+			image_bytes->get_mipmap_offset_and_size(mip, mip_offset, mip_size);
+
+			for (int i = 0; i < mip_size; i++) {
+				if (data_ptr[mip_offset + i] != mip * 5) {
+					REQUIRE_MESSAGE(false, "Byte format conversion error.");
+				}
+			}
+		}
+	}
+
+	// Floating point format conversion.
+
+	for (int format = Image::FORMAT_RF; format <= Image::FORMAT_RGBAF; format++) {
+		Ref<Image> image_rgbaf = memnew(Image());
+		image_rgbaf->copy_internals_from(image);
+		image_rgbaf->convert((Image::Format)format);
+		REQUIRE(image_rgbaf->has_mipmaps());
+
+		PackedByteArray data = image_rgbaf->get_data();
+		const uint8_t *data_ptr = data.ptr();
+
+		for (int mip = 0; mip < mipmaps; mip++) {
+			int mip_offset = 0;
+			int mip_size = 0;
+			image_rgbaf->get_mipmap_offset_and_size(mip, mip_offset, mip_size);
+
+			for (int i = 0; i < mip_size; i += 4) {
+				float value = *(float *)(data_ptr + mip_offset + i);
+				if (!Math::is_equal_approx(value * 255.0f, mip * 5)) {
+					REQUIRE_MESSAGE(false, "Floating point conversion error.");
+				}
+			}
+		}
+	}
+}
+
 } // namespace TestImage
 
 #endif // TEST_IMAGE_H


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/66848, but this probably should not be merged without some discussion and maybe some more testing.

Currently, using custom Image mipmaps doesn't work reliably. You can write custom mipmaps in the Image data, but some renderer code paths with certain image formats can cause a call to `Image.convert()`. The way image format conversion is currently implemented converts only the largest main image mipmap and then generates downsampled mipmaps from that by calling `Image.generate_mipmaps()`. Naturally, this overwrites any custom mipmaps the image had before.

The fix that this PR implements is to simply convert all mipmap levels individually, this way conversion preserves all custom mipmaps.

This PR breaks compatibility to some degree as calling `Image.convert()` will no longer forcefully update all image mipmap levels which some code might have (incorrectly in my opinion) relied on, so this might cause some new bugs to surface. The image results can also differ by a very small amount, as the previous `convert()` averaged the main image down to smaller mipmap levels.

I also ran some benchmarks. Release editor build, clang+mingw on Windows 10, Intel i7-4790 @4.0GHz. The new convert() is usually from x1.5 to x2.6 faster when processing large non-byte images, especially floating point images where the memory bandwidth and CPU processing required by generate_mipmaps() pixel averaging is significant. When converting small images or fast byte formats the speed differences between versions are very small.

Old Image.convert() that uses generate_mipmaps():

```
benchmark_convert_slow_format (129x129): 5 passes, average 0.4564 ms (total=2.282, min=0.449, max=0.473)
benchmark_convert_slow_format (515x515): 5 passes, average 11.0614 ms (total=55.307, min=9.766, max=11.704)
benchmark_convert_slow_format (1024x1024): 5 passes, average 62.882 ms (total=314.41, min=60.522, max=65.581)
benchmark_convert_slow_format (2047x2047): 5 passes, average 299.9408 ms (total=1499.704, min=295.363, max=304.546)
benchmark_convert_slow_format (4096x4096): 5 passes, average 2012.0606 ms (total=10060.303, min=2003.167, max=2029.163)

benchmark_convert_fast_format (129x129): 5 passes, average 0.0298 ms (total=0.149, min=0.028, max=0.037)
benchmark_convert_fast_format (515x515): 5 passes, average 0.971 ms (total=4.855, min=0.884, max=1.1)
benchmark_convert_fast_format (1024x1024): 5 passes, average 3.6168 ms (total=18.084, min=3.53, max=3.736)
benchmark_convert_fast_format (2047x2047): 5 passes, average 15.7818 ms (total=78.909, min=15.687, max=15.911)
benchmark_convert_fast_format (4096x4096): 5 passes, average 62.6828 ms (total=313.414, min=58.137, max=68.799)
```

This PR, which converts each mip level individually:

```
benchmark_convert_slow_format (129x129): 5 passes, average 0.5898 ms (total=2.949, min=0.526, max=0.75)
benchmark_convert_slow_format (515x515): 5 passes, average 11.1374 ms (total=55.687, min=10.78, max=11.568)
benchmark_convert_slow_format (1024x1024): 5 passes, average 46.716 ms (total=233.58, min=45.05, max=49.615)
benchmark_convert_slow_format (2047x2047): 5 passes, average 187.4274 ms (total=937.137, min=180.513, max=192.586)
benchmark_convert_slow_format (4096x4096): 5 passes, average 772.2734 ms (total=3861.367, min=761.192, max=794.856)

benchmark_convert_fast_format (129x129): 5 passes, average 0.0304 ms (total=0.152, min=0.027, max=0.041)
benchmark_convert_fast_format (515x515): 5 passes, average 0.9296 ms (total=4.648, min=0.884, max=0.965)
benchmark_convert_fast_format (1024x1024): 5 passes, average 3.533 ms (total=17.665, min=3.404, max=3.576)
benchmark_convert_fast_format (2047x2047): 5 passes, average 14.4464 ms (total=72.232, min=14.388, max=14.556)
benchmark_convert_fast_format (4096x4096): 5 passes, average 63.7272 ms (total=318.636, min=57.488, max=69.749)
```