### PR TITLE
Fix Camera2D position smoothing properties not being grouped

### DIFF
--- a/editor/renames_map_3_to_4.cpp
+++ b/editor/renames_map_3_to_4.cpp
@@ -721,7 +721,7 @@ const char *RenamesMap3To4::csharp_function_renames[][2] = {
 	{ "GetEndianSwap", "IsBigEndian" }, // File
 	{ "GetErrorString", "GetErrorMessage" }, // JSON
 	{ "GetFocusNeighbour", "GetFocusNeighbor" }, // Control
-	{ "GetFollowSmoothing", "GetFollowSmoothingSpeed" }, // Camera2D
+	{ "GetFollowSmoothing", "GetPositionSmoothingSpeed" }, // Camera2D
 	{ "GetFontTypes", "GetFontTypeList" }, // Theme
 	{ "GetFrameColor", "GetColor" }, // ColorRect
 	{ "GetGlobalRateScale", "GetPlaybackSpeedScale" }, // AudioServer
@@ -907,12 +907,12 @@ const char *RenamesMap3To4::csharp_function_renames[][2] = {
 	{ "SetDepthBiasEnable", "SetDepthBiasEnabled" }, // RDPipelineRasterizationState
 	{ "SetDevice", "SetOutputDevice" }, // AudioServer
 	{ "SetDoubleclick", "SetDoubleClick" }, // InputEventMouseButton
-	{ "SetEnableFollowSmoothing", "SetFollowSmoothingEnabled" }, // Camera2D
+	{ "SetEnableFollowSmoothing", "SetPositionSmoothingEnabled" }, // Camera2D
 	{ "SetEnabledFocusMode", "SetFocusMode" }, // BaseButton
 	{ "SetEndianSwap", "SetBigEndian" }, // File
 	{ "SetExpandToTextLength", "SetExpandToTextLengthEnabled" }, // LineEdit
 	{ "SetFocusNeighbour", "SetFocusNeighbor" }, // Control
-	{ "SetFollowSmoothing", "SetFollowSmoothingSpeed" }, // Camera2D
+	{ "SetFollowSmoothing", "SetPositionSmoothingSpeed" }, // Camera2D
 	{ "SetFrameColor", "SetColor" }, // ColorRect
 	{ "SetGlobalRateScale", "SetPlaybackSpeedScale" }, // AudioServer
 	{ "SetGravityDistanceScale", "SetGravityPointDistanceScale" }, // Area2D
@@ -1122,7 +1122,7 @@ const char *RenamesMap3To4::gdscript_properties_renames[][2] = {
 	{ "selectedframe", "selected_frame" }, // Theme
 	{ "size_override_stretch", "size_2d_override_stretch" }, // SubViewport
 	{ "slips_on_slope", "slide_on_slope" }, // SeparationRayShape2D
-	{ "smoothing_enabled", "follow_smoothing_enabled" }, // Camera2D
+	{ "smoothing_enabled", "position_smoothing_enabled" }, // Camera2D
 	{ "smoothing_speed", "position_smoothing_speed" }, // Camera2D
 	{ "ss_reflections_depth_tolerance", "ssr_depth_tolerance" }, // Environment
 	{ "ss_reflections_enabled", "ssr_enabled" }, // Environment
@@ -1215,8 +1215,8 @@ const char *RenamesMap3To4::csharp_properties_renames[][2] = {
 	{ "Selectedframe", "SelectedFrame" }, // Theme
 	{ "SizeOverrideStretch", "Size2dOverrideStretch" }, // SubViewport
 	{ "SlipsOnSlope", "SlideOnSlope" }, // SeparationRayShape2D
-	{ "SmoothingEnabled", "FollowSmoothingEnabled" }, // Camera2D
-	{ "SmoothingSpeed", "FollowSmoothingSpeed" }, // Camera2D
+	{ "SmoothingEnabled", "PositionSmoothingEnabled" }, // Camera2D
+	{ "SmoothingSpeed", "PositionSmoothingSpeed" }, // Camera2D
 	{ "SsReflectionsDepthTolerance", "SsrDepthTolerance" }, // Environment
 	{ "SsReflectionsEnabled", "SsrEnabled" }, // Environment
 	{ "SsReflectionsFadeIn", "SsrFadeIn" }, // Environment

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -158,7 +158,7 @@ Transform2D Camera2D::get_camera_transform() {
 			}
 		}
 
-		if (follow_smoothing_enabled && !Engine::get_singleton()->is_editor_hint()) {
+		if (position_smoothing_enabled && !Engine::get_singleton()->is_editor_hint()) {
 			real_t c = position_smoothing_speed * (process_callback == CAMERA2D_PROCESS_PHYSICS ? get_physics_process_delta_time() : get_process_delta_time());
 			smoothed_camera_pos = ((camera_pos - smoothed_camera_pos) * c) + smoothed_camera_pos;
 			ret_camera_pos = smoothed_camera_pos;
@@ -186,7 +186,7 @@ Transform2D Camera2D::get_camera_transform() {
 
 	Rect2 screen_rect(-screen_offset + ret_camera_pos, screen_size * zoom_scale);
 
-	if (!follow_smoothing_enabled || !limit_smoothing_enabled) {
+	if (!position_smoothing_enabled || !limit_smoothing_enabled) {
 		if (screen_rect.position.x < limit[SIDE_LEFT]) {
 			screen_rect.position.x = limit[SIDE_LEFT];
 		}
@@ -617,18 +617,18 @@ real_t Camera2D::get_drag_horizontal_offset() const {
 void Camera2D::_set_old_smoothing(real_t p_enable) {
 	//compatibility
 	if (p_enable > 0) {
-		follow_smoothing_enabled = true;
+		position_smoothing_enabled = true;
 		set_position_smoothing_speed(p_enable);
 	}
 }
 
 void Camera2D::set_position_smoothing_enabled(bool p_enabled) {
-	follow_smoothing_enabled = p_enabled;
+	position_smoothing_enabled = p_enabled;
 	notify_property_list_changed();
 }
 
 bool Camera2D::is_position_smoothing_enabled() const {
-	return follow_smoothing_enabled;
+	return position_smoothing_enabled;
 }
 
 void Camera2D::set_custom_viewport(Node *p_viewport) {
@@ -699,7 +699,7 @@ bool Camera2D::is_margin_drawing_enabled() const {
 }
 
 void Camera2D::_validate_property(PropertyInfo &p_property) const {
-	if (!follow_smoothing_enabled && p_property.name == "smoothing_speed") {
+	if (!position_smoothing_enabled && p_property.name == "position_smoothing_speed") {
 		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 	if (!rotation_smoothing_enabled && p_property.name == "rotation_smoothing_speed") {
@@ -801,7 +801,7 @@ void Camera2D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "limit_bottom", PROPERTY_HINT_NONE, "suffix:px"), "set_limit", "get_limit", SIDE_BOTTOM);
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "limit_smoothed"), "set_limit_smoothing_enabled", "is_limit_smoothing_enabled");
 
-	ADD_GROUP("Follow Smoothing", "follow_smoothing_");
+	ADD_GROUP("Position Smoothing", "position_smoothing_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "position_smoothing_enabled"), "set_position_smoothing_enabled", "is_position_smoothing_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "position_smoothing_speed", PROPERTY_HINT_NONE, "suffix:px/s"), "set_position_smoothing_speed", "get_position_smoothing_speed");
 

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -67,7 +67,7 @@ protected:
 	bool ignore_rotation = true;
 	bool enabled = true;
 	real_t position_smoothing_speed = 5.0;
-	bool follow_smoothing_enabled = false;
+	bool position_smoothing_enabled = false;
 
 	real_t camera_angle = 0.0;
 	real_t rotation_smoothing_speed = 5.0;


### PR DESCRIPTION
#65779 introduced a bug where Camera2D position smoothing properties aren't grouped due to the property names not matching the group name. This pr fixes that.

**Before:**
![image](https://user-images.githubusercontent.com/19669673/222537960-48f0f6f1-40f1-4b93-acaa-ef58f2bfd74c.png)

**After:**
![image](https://user-images.githubusercontent.com/19669673/222792487-03803e74-07e9-4be9-badc-42ca825dde5b.png)

EDIT: Also fixed the 3to4 project upgrader upgrading to invalid follow_smoothing property names