### PR TITLE
Allow EditorInspector to change its property name style when necessary

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3441,6 +3441,16 @@ void EditorInspector::set_property_name_style(EditorPropertyNameProcessor::Style
 	update_tree();
 }
 
+void EditorInspector::set_use_settings_name_style(bool p_enable) {
+	if (use_settings_name_style == p_enable) {
+		return;
+	}
+	use_settings_name_style = p_enable;
+	if (use_settings_name_style) {
+		set_property_name_style(EditorPropertyNameProcessor::get_singleton()->get_settings_style());
+	}
+}
+
 void EditorInspector::set_autoclear(bool p_enable) {
 	autoclear = p_enable;
 }
@@ -3973,7 +3983,20 @@ void EditorInspector::_notification(int p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			_update_inspector_bg();
 
+			bool needs_update = false;
+
+			if (use_settings_name_style && EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/localize_settings")) {
+				EditorPropertyNameProcessor::Style style = EditorPropertyNameProcessor::get_settings_style();
+				if (property_name_style != style) {
+					property_name_style = style;
+					needs_update = true;
+				}
+			}
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/inspector")) {
+				needs_update = true;
+			}
+
+			if (needs_update) {
 				update_tree();
 			}
 		} break;
@@ -4158,4 +4181,7 @@ EditorInspector::EditorInspector() {
 	ED_SHORTCUT("property_editor/copy_value", TTR("Copy Value"), KeyModifierMask::CMD_OR_CTRL | Key::C);
 	ED_SHORTCUT("property_editor/paste_value", TTR("Paste Value"), KeyModifierMask::CMD_OR_CTRL | Key::V);
 	ED_SHORTCUT("property_editor/copy_property_path", TTR("Copy Property Path"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::C);
+
+	// `use_settings_name_style` is true by default, set the name style accordingly.
+	set_property_name_style(EditorPropertyNameProcessor::get_singleton()->get_settings_style());
 }

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -465,6 +465,7 @@ class EditorInspector : public ScrollContainer {
 	bool hide_metadata = true;
 	bool use_doc_hints = false;
 	EditorPropertyNameProcessor::Style property_name_style = EditorPropertyNameProcessor::STYLE_CAPITALIZED;
+	bool use_settings_name_style = true;
 	bool use_filter = false;
 	bool autoclear = false;
 	bool use_folding = false;
@@ -569,6 +570,9 @@ public:
 
 	EditorPropertyNameProcessor::Style get_property_name_style() const;
 	void set_property_name_style(EditorPropertyNameProcessor::Style p_style);
+
+	// If true, the inspector will update its property name style according to the current editor settings.
+	void set_use_settings_name_style(bool p_enable);
 
 	void set_autoclear(bool p_enable);
 

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -310,16 +310,6 @@ void SectionedInspector::_search_changed(const String &p_what) {
 	update_category_list();
 }
 
-void SectionedInspector::_notification(int p_what) {
-	switch (p_what) {
-		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/localize_settings")) {
-				inspector->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
-			}
-		} break;
-	}
-}
-
 EditorInspector *SectionedInspector::get_inspector() {
 	return inspector;
 }
@@ -353,7 +343,6 @@ SectionedInspector::SectionedInspector() :
 	inspector->set_v_size_flags(SIZE_EXPAND_FILL);
 	right_vb->add_child(inspector, true);
 	inspector->set_use_doc_hints(true);
-	inspector->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
 
 	sections->connect("cell_selected", callable_mp(this, &SectionedInspector::_section_selected));
 }

--- a/editor/editor_sectioned_inspector.h
+++ b/editor/editor_sectioned_inspector.h
@@ -58,9 +58,6 @@ class SectionedInspector : public HSplitContainer {
 
 	void _search_changed(const String &p_what);
 
-protected:
-	void _notification(int p_what);
-
 public:
 	void register_search_box(LineEdit *p_box);
 	EditorInspector *get_inspector();

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -70,10 +70,6 @@ void ProjectExportDialog::_notification(int p_what) {
 			connect("confirmed", callable_mp(this, &ProjectExportDialog::_export_pck_zip));
 			_update_export_all();
 		} break;
-
-		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			parameters->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
-		} break;
 	}
 }
 
@@ -1161,7 +1157,6 @@ ProjectExportDialog::ProjectExportDialog() {
 	sections->add_child(parameters);
 	parameters->set_name(TTR("Options"));
 	parameters->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	parameters->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
 	parameters->set_use_doc_hints(true);
 	parameters->connect("property_edited", callable_mp(this, &ProjectExportDialog::_update_parameters));
 	EditorExport::get_singleton()->connect("export_presets_updated", callable_mp(this, &ProjectExportDialog::_force_update_current_preset_parameters));

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -928,15 +928,6 @@ void DynamicFontImportSettings::_notification(int p_what) {
 			add_var->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 			label_warn->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 		} break;
-
-		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/localize_settings")) {
-				EditorPropertyNameProcessor::Style style = EditorPropertyNameProcessor::get_singleton()->get_settings_style();
-				inspector_general->set_property_name_style(style);
-				inspector_vars->set_property_name_style(style);
-				inspector_text->set_property_name_style(style);
-			}
-		} break;
 	}
 }
 
@@ -1342,7 +1333,6 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	inspector_general->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector_general->set_custom_minimum_size(Size2(300 * EDSCALE, 250 * EDSCALE));
 	inspector_general->connect("property_edited", callable_mp(this, &DynamicFontImportSettings::_main_prop_changed));
-	inspector_general->set_property_name_style(EditorPropertyNameProcessor::get_singleton()->get_settings_style());
 	page1_hb->add_child(inspector_general);
 
 	// Page 2 layout: Configurations
@@ -1394,7 +1384,6 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	inspector_vars = memnew(EditorInspector);
 	inspector_vars->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector_vars->connect("property_edited", callable_mp(this, &DynamicFontImportSettings::_variation_changed));
-	inspector_vars->set_property_name_style(EditorPropertyNameProcessor::get_singleton()->get_settings_style());
 	page2_side_vb->add_child(inspector_vars);
 
 	VBoxContainer *preload_pages_vb = memnew(VBoxContainer);
@@ -1470,7 +1459,6 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	inspector_text->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector_text->set_custom_minimum_size(Size2(300 * EDSCALE, 250 * EDSCALE));
 	inspector_text->connect("property_edited", callable_mp(this, &DynamicFontImportSettings::_change_text_opts));
-	inspector_text->set_property_name_style(EditorPropertyNameProcessor::get_singleton()->get_settings_style());
 	page2_1_hb->add_child(inspector_text);
 
 	text_edit = memnew(TextEdit);

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -1006,10 +1006,6 @@ void SceneImportSettings::_notification(int p_what) {
 			action_menu->add_theme_style_override("hover", get_theme_stylebox("hover", "Button"));
 			action_menu->add_theme_style_override("pressed", get_theme_stylebox("pressed", "Button"));
 		} break;
-
-		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			inspector->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
-		} break;
 	}
 }
 
@@ -1410,7 +1406,6 @@ SceneImportSettings::SceneImportSettings() {
 
 	inspector = memnew(EditorInspector);
 	inspector->set_custom_minimum_size(Size2(300 * EDSCALE, 0));
-	inspector->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
 
 	property_split->add_child(inspector);
 

--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -36,7 +36,6 @@
 #include "editor/editor_autoload_settings.h"
 #include "editor/editor_plugin_settings.h"
 #include "editor/editor_sectioned_inspector.h"
-#include "editor/editor_settings.h"
 #include "editor/localization_editor.h"
 #include "editor/shader_globals_editor.h"
 #include "scene/gui/center_container.h"
@@ -82,11 +81,6 @@ protected:
 
 void ImportDefaultsEditor::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE:
-		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			inspector->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
-		} break;
-
 		case NOTIFICATION_PREDELETE: {
 			inspector->edit(nullptr);
 		} break;

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -565,7 +565,6 @@ void ImportDock::_notification(int p_what) {
 	switch (p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			imported->add_theme_style_override("normal", get_theme_stylebox(SNAME("normal"), SNAME("LineEdit")));
-			import_opts->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
@@ -643,7 +642,6 @@ ImportDock::ImportDock() {
 	import_opts = memnew(EditorInspector);
 	content->add_child(import_opts);
 	import_opts->set_v_size_flags(SIZE_EXPAND_FILL);
-	import_opts->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
 	import_opts->connect("property_edited", callable_mp(this, &ImportDock::_property_edited));
 	import_opts->connect("property_toggled", callable_mp(this, &ImportDock::_property_toggled));
 

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -767,7 +767,8 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	inspector->set_use_doc_hints(true);
 	inspector->set_hide_script(false);
 	inspector->set_hide_metadata(false);
-	inspector->set_property_name_style(EditorPropertyNameProcessor::get_default_inspector_style());
+	inspector->set_use_settings_name_style(false);
+	inspector->set_property_name_style(property_name_style);
 	inspector->set_use_folding(!bool(EDITOR_GET("interface/inspector/disable_folding")));
 	inspector->register_text_enter(search);
 

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -34,7 +34,6 @@
 
 #include "editor/editor_inspector.h"
 #include "editor/editor_node.h"
-#include "editor/editor_property_name_processor.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_undo_redo_manager.h"
@@ -2415,14 +2414,6 @@ void TileSetAtlasSourceEditor::_notification(int p_what) {
 				}
 			}
 		} break;
-
-		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/localize_settings")) {
-				EditorPropertyNameProcessor::Style style = EditorPropertyNameProcessor::get_singleton()->get_settings_style();
-				atlas_source_inspector->set_property_name_style(style);
-				tile_inspector->set_property_name_style(style);
-			}
-		} break;
 	}
 }
 
@@ -2492,7 +2483,6 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	tile_inspector->edit(tile_proxy_object);
 	tile_inspector->set_use_folding(true);
 	tile_inspector->connect("property_selected", callable_mp(this, &TileSetAtlasSourceEditor::_inspector_property_selected));
-	tile_inspector->set_property_name_style(EditorPropertyNameProcessor::get_singleton()->get_settings_style());
 	middle_vbox_container->add_child(tile_inspector);
 
 	tile_inspector_no_tile_selected_label = memnew(Label);
@@ -2544,7 +2534,6 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	atlas_source_inspector->set_v_size_flags(SIZE_EXPAND_FILL);
 	atlas_source_inspector->set_show_categories(true);
 	atlas_source_inspector->edit(atlas_source_proxy_object);
-	atlas_source_inspector->set_property_name_style(EditorPropertyNameProcessor::get_singleton()->get_settings_style());
 	middle_vbox_container->add_child(atlas_source_inspector);
 
 	// -- Right side --

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -32,7 +32,6 @@
 
 #include "editor/editor_file_system.h"
 #include "editor/editor_node.h"
-#include "editor/editor_property_name_processor.h"
 #include "editor/editor_resource_preview.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
@@ -365,14 +364,6 @@ void TileSetScenesCollectionSourceEditor::_notification(int p_what) {
 			_update_scenes_list();
 			_update_action_buttons();
 		} break;
-
-		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			if (EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/localize_settings")) {
-				EditorPropertyNameProcessor::Style style = EditorPropertyNameProcessor::get_singleton()->get_settings_style();
-				scenes_collection_source_inspector->set_property_name_style(style);
-				tile_inspector->set_property_name_style(style);
-			}
-		} break;
 	}
 }
 
@@ -514,7 +505,6 @@ TileSetScenesCollectionSourceEditor::TileSetScenesCollectionSourceEditor() {
 	scenes_collection_source_inspector = memnew(EditorInspector);
 	scenes_collection_source_inspector->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 	scenes_collection_source_inspector->edit(scenes_collection_source_proxy_object);
-	scenes_collection_source_inspector->set_property_name_style(EditorPropertyNameProcessor::get_singleton()->get_settings_style());
 	middle_vbox_container->add_child(scenes_collection_source_inspector);
 
 	// Tile inspector.
@@ -531,7 +521,6 @@ TileSetScenesCollectionSourceEditor::TileSetScenesCollectionSourceEditor() {
 	tile_inspector->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 	tile_inspector->edit(tile_proxy_object);
 	tile_inspector->set_use_folding(true);
-	tile_inspector->set_property_name_style(EditorPropertyNameProcessor::get_singleton()->get_settings_style());
 	middle_vbox_container->add_child(tile_inspector);
 
 	// Scenes list.


### PR DESCRIPTION
Previously, an EditorInspector's property name style can only be set from outside. Inspectors used for settings need to respond to changes in editor settings. So a few boilerplate code is almost always needed, including watching for a certain editor setting in `_notification()`.

This PR simplifies the setup by adding a `set_use_settings_style()` function to tell the inspector to watch for editor settings changes on its own.