### PR TITLE
Notify child controls when `BackBufferCopy`'s rect changed

### DIFF
--- a/scene/2d/back_buffer_copy.cpp
+++ b/scene/2d/back_buffer_copy.cpp
@@ -62,6 +62,7 @@ Rect2 BackBufferCopy::get_anchorable_rect() const {
 void BackBufferCopy::set_rect(const Rect2 &p_rect) {
 	rect = p_rect;
 	_update_copy_mode();
+	item_rect_changed();
 }
 
 Rect2 BackBufferCopy::get_rect() const {


### PR DESCRIPTION
`BackBufferCopy` uses the `rect` property as its anchorable rect for child controls. But it did not call `item_rect_changed()` when the rect changes, so child controls are not resized properly.