### PR TITLE
Document using `String.percent_encode()` with `OS.shell_open()` (3.x)

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -1037,6 +1037,7 @@
 				- [code]OS.shell_open("https://godotengine.org")[/code] opens the default web browser on the official Godot website.
 				- [code]OS.shell_open("mailto:example@example.com")[/code] opens the default email client with the "To" field set to [code]example@example.com[/code]. See [url=https://datatracker.ietf.org/doc/html/rfc2368]RFC 2368 - The [code]mailto[/code] URL scheme[/url] for a list of fields that can be added.
 				Use [method ProjectSettings.globalize_path] to convert a [code]res://[/code] or [code]user://[/code] path into a system path for use with this method.
+				[b]Note:[/b] Use [method String.percent_encode] to encode characters within URLs in a URL-safe, portable way. This is especially required for line breaks. Otherwise, [method shell_open] may not work correctly in a project exported to the Web platform.
 				[b]Note:[/b] This method is implemented on Android, iOS, HTML5, Linux, macOS and Windows.
 			</description>
 		</method>

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -626,13 +626,13 @@
 		<method name="percent_decode">
 			<return type="String" />
 			<description>
-				Decode a percent-encoded string. See [method percent_encode].
+				Decode a percent-encoded string (also called URI-encoded string). See also [method percent_encode].
 			</description>
 		</method>
 		<method name="percent_encode">
 			<return type="String" />
 			<description>
-				Percent-encodes a string. Encodes parameters in a URL when sending a HTTP GET request (and bodies of form-urlencoded POST requests).
+				Percent-encodes a string (also called URI-encoded string). Encodes parameters in a URL when sending a HTTP GET request (and bodies of form-urlencoded POST requests). See also [method percent_decode].
 			</description>
 		</method>
 		<method name="plus_file">


### PR DESCRIPTION
- `3.x` version of https://github.com/godotengine/godot/pull/74283.
- See https://github.com/godotengine/godot/issues/74279.