### PR TITLE
FBX: Disable importer when canceling FBX2glTF setup

### DIFF
--- a/editor/fbx_importer_manager.h
+++ b/editor/fbx_importer_manager.h
@@ -38,6 +38,8 @@
 class FBXImporterManager : public ConfirmationDialog {
 	GDCLASS(FBXImporterManager, ConfirmationDialog)
 
+	bool is_importing = false;
+
 	Label *message = nullptr;
 	LineEdit *fbx_path = nullptr;
 	Button *fbx_path_browse = nullptr;
@@ -47,6 +49,7 @@ class FBXImporterManager : public ConfirmationDialog {
 	void _validate_path(const String &p_path);
 	void _select_file(const String &p_path);
 	void _path_confirmed();
+	void _cancel_setup();
 	void _browse_install();
 	void _link_clicked();
 

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -143,8 +143,8 @@ void initialize_gltf_module(ModuleInitializationLevel p_level) {
 		EditorPlugins::add_by_type<SceneExporterGLTFPlugin>();
 
 		// Project settings defined here so doctool finds them.
-		GLOBAL_DEF_RST("filesystem/import/blender/enabled", true);
-		GLOBAL_DEF_RST("filesystem/import/fbx/enabled", true);
+		GLOBAL_DEF_RST_BASIC("filesystem/import/blender/enabled", true);
+		GLOBAL_DEF_RST_BASIC("filesystem/import/fbx/enabled", true);
 		GDREGISTER_CLASS(EditorSceneFormatImporterBlend);
 		GDREGISTER_CLASS(EditorSceneFormatImporterFBX);
 		// Can't (a priori) run external app on these platforms.

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -243,11 +243,12 @@ void LinkButton::_notification(int p_what) {
 			if (do_underline) {
 				int underline_spacing = theme_cache.underline_spacing + text_buf->get_line_underline_position();
 				int y = text_buf->get_line_ascent() + underline_spacing;
+				int underline_thickness = MAX(1, text_buf->get_line_underline_thickness());
 
 				if (is_layout_rtl()) {
-					draw_line(Vector2(size.width - width, y), Vector2(size.width, y), color, text_buf->get_line_underline_thickness());
+					draw_line(Vector2(size.width - width, y), Vector2(size.width, y), color, underline_thickness);
 				} else {
-					draw_line(Vector2(0, y), Vector2(width, y), color, text_buf->get_line_underline_thickness());
+					draw_line(Vector2(0, y), Vector2(width, y), color, underline_thickness);
 				}
 			}
 		} break;


### PR DESCRIPTION
Pretty hacky solution but it's better than an infinite loop.

All this import setup needs to be redone, it's very difficult to properly bail out from an invalid import without triggering reimport loops.

Also fix underline not visible at default editor scale in LinkButton.

- Fixes #73319.
- Fixes #74368.