### PR TITLE
Fix GDScript code style regarding colon

### DIFF
--- a/doc/classes/DTLSServer.xml
+++ b/doc/classes/DTLSServer.xml
@@ -23,8 +23,8 @@
 
 		func _process(delta):
 		    while server.is_connection_available():
-		        var peer : PacketPeerUDP = server.take_connection()
-		        var dtls_peer : PacketPeerDTLS = dtls.take_connection(peer)
+		        var peer: PacketPeerUDP = server.take_connection()
+		        var dtls_peer: PacketPeerDTLS = dtls.take_connection(peer)
 		        if dtls_peer.get_status() != PacketPeerDTLS.STATUS_HANDSHAKING:
 		            continue # It is normal that 50% of the connections fails due to cookie exchange.
 		        print("Peer connected!")

--- a/doc/classes/EditorResourceConversionPlugin.xml
+++ b/doc/classes/EditorResourceConversionPlugin.xml
@@ -10,13 +10,13 @@
 		[gdscript]
 		extends EditorResourceConversionPlugin
 
-		func _handles(resource : Resource):
+		func _handles(resource: Resource):
 		    return resource is ImageTexture
 
 		func _converts_to():
 		    return "PortableCompressedTexture2D"
 
-		func _convert(itex : Resource):
+		func _convert(itex: Resource):
 		    var ptex = PortableCompressedTexture2D.new()
 		    ptex.create_from_image(itex.get_image(), PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)
 		    return ptex

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -31,8 +31,8 @@
 				Below is a sample code to help get started:
 				[codeblock]
 				func _is_in_input_hotzone(in_node, in_port, mouse_position):
-				    var port_size : Vector2 = Vector2(get_theme_constant("port_grab_distance_horizontal"), get_theme_constant("port_grab_distance_vertical"))
-				    var port_pos : Vector2 = in_node.get_position() + in_node.get_connection_input_position(in_port) - port_size / 2
+				    var port_size: Vector2 = Vector2(get_theme_constant("port_grab_distance_horizontal"), get_theme_constant("port_grab_distance_vertical"))
+				    var port_pos: Vector2 = in_node.get_position() + in_node.get_connection_input_position(in_port) - port_size / 2
 				    var rect = Rect2(port_pos, port_size)
 
 				    return rect.has_point(mouse_position)
@@ -49,8 +49,8 @@
 				Below is a sample code to help get started:
 				[codeblock]
 				func _is_in_output_hotzone(in_node, in_port, mouse_position):
-				    var port_size : Vector2 = Vector2(get_theme_constant("port_grab_distance_horizontal"), get_theme_constant("port_grab_distance_vertical"))
-				    var port_pos : Vector2 = in_node.get_position() + in_node.get_connection_output_position(in_port) - port_size / 2
+				    var port_size: Vector2 = Vector2(get_theme_constant("port_grab_distance_horizontal"), get_theme_constant("port_grab_distance_vertical"))
+				    var port_pos: Vector2 = in_node.get_position() + in_node.get_connection_output_position(in_port) - port_size / 2
 				    var rect = Rect2(port_pos, port_size)
 
 				    return rect.has_point(mouse_position)

--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -20,7 +20,7 @@
 		[b]Note:[/b] The image can be retrieved from an imported texture using the [method Texture2D.get_image] method, which returns a copy of the image:
 		[codeblock]
 		var texture = load("res://icon.svg")
-		var image : Image = texture.get_image()
+		var image: Image = texture.get_image()
 		[/codeblock]
 		An [ImageTexture] is not meant to be operated from within the editor interface directly, and is mostly useful for rendering images on screen dynamically via code. If you need to generate images procedurally from within the editor, consider saving and importing images as custom texture resources implementing a new [EditorImportPlugin].
 		[b]Note:[/b] The maximum texture size is 16384×16384 pixels due to graphics hardware limitations.

--- a/doc/classes/UDPServer.xml
+++ b/doc/classes/UDPServer.xml
@@ -22,7 +22,7 @@
 		func _process(delta):
 		    server.poll() # Important!
 		    if server.is_connection_available():
-		        var peer : PacketPeerUDP = server.take_connection()
+		        var peer: PacketPeerUDP = server.take_connection()
 		        var packet = peer.get_packet()
 		        print("Accepted peer: %s:%s" % [peer.get_packet_ip(), peer.get_packet_port()])
 		        print("Received data: %s" % [packet.get_string_from_utf8()])

--- a/doc/classes/XRInterface.xml
+++ b/doc/classes/XRInterface.xml
@@ -116,9 +116,9 @@
 				[b]Note:[/b] Not all runtimes support all environment blend modes, so it is important to check this at startup. For example:
 				[codeblock]
 				                func _ready():
-				                    var xr_interface : XRInterface = XRServer.find_interface("OpenXR")
+				                    var xr_interface: XRInterface = XRServer.find_interface("OpenXR")
 				                    if xr_interface and xr_interface.is_initialized():
-				                        var vp : Viewport = get_viewport()
+				                        var vp: Viewport = get_viewport()
 				                        vp.use_xr = true
 				                        var acceptable_modes = [ XRInterface.XR_ENV_BLEND_MODE_OPAQUE, XRInterface.XR_ENV_BLEND_MODE_ADDITIVE ]
 				                        var modes = xr_interface.get_supported_environment_blend_modes()

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -70,9 +70,9 @@ public:
 	RegEx reg_json_print = RegEx("\\bJSON\\b\\.print\\(");
 	RegEx reg_export = RegEx("export\\(([a-zA-Z0-9_]+)\\)[ ]+var[ ]+([a-zA-Z0-9_]+)");
 	RegEx reg_export_advanced = RegEx("export\\(([^)^\n]+)\\)[ ]+var[ ]+([a-zA-Z0-9_]+)([^\n]+)");
-	RegEx reg_setget_setget = RegEx("var[ ]+([a-zA-Z0-9_]+)([^\n]+)setget[ \t]+([a-zA-Z0-9_]+)[ \t]*,[ \t]*([a-zA-Z0-9_]+)");
-	RegEx reg_setget_set = RegEx("var[ ]+([a-zA-Z0-9_]+)([^\n]+)setget[ \t]+([a-zA-Z0-9_]+)[ \t]*[,]*[^a-z^A-Z^0-9^_]*$");
-	RegEx reg_setget_get = RegEx("var[ ]+([a-zA-Z0-9_]+)([^\n]+)setget[ \t]+,[ \t]*([a-zA-Z0-9_]+)[ \t]*$");
+	RegEx reg_setget_setget = RegEx("var[ ]+([a-zA-Z0-9_]+)([^\n]+?)[ \t]*setget[ \t]+([a-zA-Z0-9_]+)[ \t]*,[ \t]*([a-zA-Z0-9_]+)");
+	RegEx reg_setget_set = RegEx("var[ ]+([a-zA-Z0-9_]+)([^\n]+?)[ \t]*setget[ \t]+([a-zA-Z0-9_]+)[ \t]*[,]*[^\n]*$");
+	RegEx reg_setget_get = RegEx("var[ ]+([a-zA-Z0-9_]+)([^\n]+?)[ \t]*setget[ \t]+,[ \t]*([a-zA-Z0-9_]+)[ \t]*$");
 	RegEx reg_join = RegEx("([\\(\\)a-zA-Z0-9_]+)\\.join\\(([^\n^\\)]+)\\)");
 	RegEx reg_image_lock = RegEx("([a-zA-Z0-9_\\.]+)\\.lock\\(\\)");
 	RegEx reg_image_unlock = RegEx("([a-zA-Z0-9_\\.]+)\\.unlock\\(\\)");
@@ -833,10 +833,10 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 	valid = valid && test_conversion_with_regex("\n\nmaster func", "\n\nThe master and mastersync rpc behavior is not officially supported anymore. Try using another keyword or making custom logic using get_multiplayer().get_remote_sender_id()\n@rpc func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
 	valid = valid && test_conversion_with_regex("\n\nmastersync func", "\n\nThe master and mastersync rpc behavior is not officially supported anymore. Try using another keyword or making custom logic using get_multiplayer().get_remote_sender_id()\n@rpc(\"call_local\") func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
 
-	valid = valid && test_conversion_gdscript_builtin("var size : Vector2 = Vector2() setget set_function , get_function", "var size : Vector2 = Vector2() : get = get_function, set = set_function", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid && test_conversion_gdscript_builtin("var size : Vector2 = Vector2() setget set_function , ", "var size : Vector2 = Vector2() : set = set_function", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid && test_conversion_gdscript_builtin("var size : Vector2 = Vector2() setget set_function", "var size : Vector2 = Vector2() : set = set_function", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid && test_conversion_gdscript_builtin("var size : Vector2 = Vector2() setget  , get_function", "var size : Vector2 = Vector2() : get = get_function", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("var size: Vector2 = Vector2() setget set_function, get_function", "var size: Vector2 = Vector2(): get = get_function, set = set_function", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("var size: Vector2 = Vector2() setget set_function, ", "var size: Vector2 = Vector2(): set = set_function", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("var size: Vector2 = Vector2() setget set_function", "var size: Vector2 = Vector2(): set = set_function", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("var size: Vector2 = Vector2() setget , get_function", "var size: Vector2 = Vector2(): get = get_function", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
 	valid = valid && test_conversion_gdscript_builtin("get_node(@", "get_node(", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -285,7 +285,7 @@
 				@export var string = ""
 				@export var int_number = 5
 				@export var float_number: float = 5
-				@export var image : Image
+				@export var image: Image
 				[/codeblock]
 			</description>
 		</annotation>
@@ -309,7 +309,7 @@
 				Export a [Color] property without allowing its transparency ([member Color.a]) to be edited.
 				See also [constant PROPERTY_HINT_COLOR_NO_ALPHA].
 				[codeblock]
-				@export_color_no_alpha var dye_color : Color
+				@export_color_no_alpha var dye_color: Color
 				[/codeblock]
 			</description>
 		</annotation>

--- a/modules/gdscript/tests/scripts/analyzer/errors/enum_function_parameter_wrong_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/enum_function_parameter_wrong_type.gd
@@ -1,7 +1,7 @@
 enum MyEnum { ENUM_VALUE_1, ENUM_VALUE_2 }
 enum MyOtherEnum { OTHER_ENUM_VALUE_1, OTHER_ENUM_VALUE_2 }
 
-func enum_func(e : MyEnum) -> void:
+func enum_func(e: MyEnum) -> void:
 	print(e)
 
 func test():

--- a/modules/gdscript/tests/scripts/analyzer/errors/native_freed_instance.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/native_freed_instance.gd
@@ -4,4 +4,4 @@ func test():
 	x.free()
 
 	var ok = x
-	var bad : Node = x
+	var bad: Node = x

--- a/modules/gdscript/tests/scripts/analyzer/errors/preload_enum_error.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/preload_enum_error.gd
@@ -2,5 +2,5 @@ enum LocalNamed { VALUE_A, VALUE_B, VALUE_C = 42 }
 
 func test():
 	const P = preload("../features/enum_from_outer.gd")
-	var x : LocalNamed
+	var x: LocalNamed
 	x = P.Named.VALUE_A

--- a/modules/gdscript/tests/scripts/analyzer/errors/property_function_get_type_error.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/property_function_get_type_error.gd
@@ -1,7 +1,7 @@
-var _prop : int
+var _prop: int
 
 # Getter function has wrong return type.
-var prop : String:
+var prop: String:
 	get = get_prop
 
 func get_prop():

--- a/modules/gdscript/tests/scripts/analyzer/errors/property_function_set_type_error.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/property_function_set_type_error.gd
@@ -1,10 +1,10 @@
-var _prop : int
+var _prop: int
 
 # Setter function has wrong argument type.
-var prop : String:
+var prop: String:
 	set = set_prop
 
-func set_prop(value : int):
+func set_prop(value: int):
 	_prop = value
 
 func test():

--- a/modules/gdscript/tests/scripts/analyzer/errors/property_inline_get_type_error.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/property_inline_get_type_error.gd
@@ -1,7 +1,7 @@
-var _prop : int
+var _prop: int
 
 # Inline getter returns int instead of String.
-var prop : String:
+var prop: String:
 	get:
 		return _prop
 

--- a/modules/gdscript/tests/scripts/analyzer/errors/property_inline_set_type_error.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/property_inline_set_type_error.gd
@@ -1,7 +1,7 @@
-var _prop : int
+var _prop: int
 
 # Inline setter assigns String to int.
-var prop : String:
+var prop: String:
 	set(value):
 		_prop = value
 

--- a/modules/gdscript/tests/scripts/analyzer/errors/script_freed_instance.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/script_freed_instance.gd
@@ -7,4 +7,4 @@ func test():
 	x.free()
 
 	var ok = x
-	var bad : A = x
+	var bad: A = x

--- a/modules/gdscript/tests/scripts/analyzer/features/enum_duplicate_into_dict.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/enum_duplicate_into_dict.gd
@@ -1,7 +1,7 @@
 enum Enum {V1, V2}
 
 func test():
-	var enumAsDict : Dictionary = Enum.duplicate()
+	var enumAsDict: Dictionary = Enum.duplicate()
 	var enumAsVariant = Enum.duplicate()
 	print(Enum.has("V1"))
 	print(enumAsDict.has("V1"))

--- a/modules/gdscript/tests/scripts/analyzer/features/enum_function_typecheck.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/enum_function_typecheck.gd
@@ -5,19 +5,19 @@ enum MyEnum { V0, V1, V2 }
 class InnerClass:
 	enum MyEnum { V0, V2, V1 }
 
-	func inner_inner_no_class(e : MyEnum) -> MyEnum:
+	func inner_inner_no_class(e: MyEnum) -> MyEnum:
 		print(e)
 		return e
 
-	func inner_inner_class(e : InnerClass.MyEnum) -> InnerClass.MyEnum:
+	func inner_inner_class(e: InnerClass.MyEnum) -> InnerClass.MyEnum:
 		print(e)
 		return e
 
-	func inner_inner_class_class(e : EnumFunctionTypecheckOuterClass.InnerClass.MyEnum) -> EnumFunctionTypecheckOuterClass.InnerClass.MyEnum:
+	func inner_inner_class_class(e: EnumFunctionTypecheckOuterClass.InnerClass.MyEnum) -> EnumFunctionTypecheckOuterClass.InnerClass.MyEnum:
 		print(e)
 		return e
 
-	func inner_outer(e : EnumFunctionTypecheckOuterClass.MyEnum) -> EnumFunctionTypecheckOuterClass.MyEnum:
+	func inner_outer(e: EnumFunctionTypecheckOuterClass.MyEnum) -> EnumFunctionTypecheckOuterClass.MyEnum:
 		print(e)
 		return e
 
@@ -59,19 +59,19 @@ class InnerClass:
 		print()
 
 
-func outer_outer_no_class(e : MyEnum) -> MyEnum:
+func outer_outer_no_class(e: MyEnum) -> MyEnum:
 	print(e)
 	return e
 
-func outer_outer_class(e : EnumFunctionTypecheckOuterClass.MyEnum) -> EnumFunctionTypecheckOuterClass.MyEnum:
+func outer_outer_class(e: EnumFunctionTypecheckOuterClass.MyEnum) -> EnumFunctionTypecheckOuterClass.MyEnum:
 	print(e)
 	return e
 
-func outer_inner_class(e : InnerClass.MyEnum) -> InnerClass.MyEnum:
+func outer_inner_class(e: InnerClass.MyEnum) -> InnerClass.MyEnum:
 	print(e)
 	return e
 
-func outer_inner_class_class(e : EnumFunctionTypecheckOuterClass.InnerClass.MyEnum) -> EnumFunctionTypecheckOuterClass.InnerClass.MyEnum:
+func outer_inner_class_class(e: EnumFunctionTypecheckOuterClass.InnerClass.MyEnum) -> EnumFunctionTypecheckOuterClass.InnerClass.MyEnum:
 	print(e)
 	return e
 

--- a/modules/gdscript/tests/scripts/analyzer/features/enum_native_access_types.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/enum_native_access_types.gd
@@ -1,9 +1,9 @@
-func print_enum(e : TileSet.TileShape) -> TileSet.TileShape:
+func print_enum(e: TileSet.TileShape) -> TileSet.TileShape:
 	print(e)
 	return e
 
 func test():
-	var v : TileSet.TileShape
+	var v: TileSet.TileShape
 	v = TileSet.TILE_SHAPE_SQUARE
 	v = print_enum(v)
 	v = print_enum(TileSet.TILE_SHAPE_SQUARE)

--- a/modules/gdscript/tests/scripts/analyzer/features/enum_typecheck_inner_class.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/enum_typecheck_inner_class.gd
@@ -7,9 +7,9 @@ class InnerClass:
 
 	static func test_inner_from_inner():
 		print("Inner - Inner")
-		var e1 : MyEnum
-		var e2 : InnerClass.MyEnum
-		var e3 : EnumTypecheckOuterClass.InnerClass.MyEnum
+		var e1: MyEnum
+		var e2: InnerClass.MyEnum
+		var e3: EnumTypecheckOuterClass.InnerClass.MyEnum
 
 		print("Self ", e1, e2, e3)
 		e1 = MyEnum.V1
@@ -36,7 +36,7 @@ class InnerClass:
 
 	static func test_outer_from_inner():
 		print("Inner - Outer")
-		var e : EnumTypecheckOuterClass.MyEnum
+		var e: EnumTypecheckOuterClass.MyEnum
 
 		e = EnumTypecheckOuterClass.MyEnum.V1
 		print("Outer.MyEnum ", e)
@@ -45,8 +45,8 @@ class InnerClass:
 
 func test_outer_from_outer():
 	print("Outer - Outer")
-	var e1 : MyEnum
-	var e2 : EnumTypecheckOuterClass.MyEnum
+	var e1: MyEnum
+	var e2: EnumTypecheckOuterClass.MyEnum
 
 	print("Self ", e1, e2)
 	e1 = MyEnum.V1
@@ -63,8 +63,8 @@ func test_outer_from_outer():
 
 func test_inner_from_outer():
 	print("Outer - Inner")
-	var e1 : InnerClass.MyEnum
-	var e2 : EnumTypecheckOuterClass.InnerClass.MyEnum
+	var e1: InnerClass.MyEnum
+	var e2: EnumTypecheckOuterClass.InnerClass.MyEnum
 
 	print("Inner ", e1, e2)
 	e1 = InnerClass.MyEnum.V1

--- a/modules/gdscript/tests/scripts/analyzer/features/getter_return_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/getter_return_type.gd
@@ -1,4 +1,4 @@
-var Value:int = 8 :
+var Value:int = 8:
 	get:
 		return Value
 	set(v):

--- a/modules/gdscript/tests/scripts/analyzer/features/property_inline.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/property_inline.gd
@@ -6,21 +6,21 @@ var prop1:
 		prop1 = value
 
 # Typed inline property
-var prop2 : int:
+var prop2: int:
 	get:
 		return prop2
 	set(value):
 		prop2 = value
 
 # Typed inline property with default value
-var prop3 : int = 1:
+var prop3: int = 1:
 	get:
 		return prop3
 	set(value):
 		prop3 = value
 
 # Typed inline property with backing variable
-var _prop4 : int = 2
+var _prop4: int = 2
 var prop4: int:
 	get:
 		return _prop4

--- a/modules/gdscript/tests/scripts/analyzer/features/use_preload_script_as_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/use_preload_script_as_type.gd
@@ -1,4 +1,4 @@
-const preloaded : GDScript = preload("gdscript_to_preload.notest.gd")
+const preloaded: GDScript = preload("gdscript_to_preload.notest.gd")
 
 func test():
 	var preloaded_instance: preloaded = preloaded.new()

--- a/modules/gdscript/tests/scripts/parser/features/static_typing.gd
+++ b/modules/gdscript/tests/scripts/parser/features/static_typing.gd
@@ -1,3 +1,5 @@
+# Do not fix code style here!
+
 func test():
 	# The following lines are equivalent:
 	var _integer: int = 1

--- a/modules/gdscript/tests/scripts/parser/features/static_typing.out
+++ b/modules/gdscript/tests/scripts/parser/features/static_typing.out
@@ -1,21 +1,21 @@
 GDTEST_OK
 >> WARNING
->> Line: 9
+>> Line: 11
 >> UNUSED_LOCAL_CONSTANT
 >> The local constant '_INTEGER' is declared but never used in the block. If this is intended, prefix it with an underscore: '__INTEGER'
 >> WARNING
->> Line: 10
+>> Line: 12
 >> UNUSED_LOCAL_CONSTANT
 >> The local constant '_INTEGER_REDUNDANT_TYPED' is declared but never used in the block. If this is intended, prefix it with an underscore: '__INTEGER_REDUNDANT_TYPED'
 >> WARNING
->> Line: 11
+>> Line: 13
 >> UNUSED_LOCAL_CONSTANT
 >> The local constant '_INTEGER_REDUNDANT_TYPED2' is declared but never used in the block. If this is intended, prefix it with an underscore: '__INTEGER_REDUNDANT_TYPED2'
 >> WARNING
->> Line: 12
+>> Line: 14
 >> UNUSED_LOCAL_CONSTANT
 >> The local constant '_INTEGER_REDUNDANT_INFERRED' is declared but never used in the block. If this is intended, prefix it with an underscore: '__INTEGER_REDUNDANT_INFERRED'
 >> WARNING
->> Line: 13
+>> Line: 15
 >> UNUSED_LOCAL_CONSTANT
 >> The local constant '_INTEGER_REDUNDANT_INFERRED2' is declared but never used in the block. If this is intended, prefix it with an underscore: '__INTEGER_REDUNDANT_INFERRED2'

--- a/modules/gdscript/tests/scripts/runtime/features/default_set_beforehand.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/default_set_beforehand.gd
@@ -1,8 +1,8 @@
 extends Node
 
 @onready var later_inferred := [1]
-@onready var later_static : Array
-@onready var later_static_with_init : Array = [1]
+@onready var later_static: Array
+@onready var later_static_with_init: Array = [1]
 @onready var later_untyped = [1]
 
 func test():

--- a/modules/gdscript/tests/scripts/runtime/features/property_with_operator_assignment.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/property_with_operator_assignment.gd
@@ -1,5 +1,5 @@
 #GDTEST_OK
-var prop : int = 0:
+var prop: int = 0:
 	get:
 		return prop
 	set(value):

--- a/modules/gdscript/tests/scripts/runtime/features/use_conversion_assign_with_variant_value.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/use_conversion_assign_with_variant_value.gd
@@ -4,6 +4,6 @@ func test():
 	@warning_ignore("narrowing_conversion")
 	var foo: int = 0.0
 	print(typeof(foo) == TYPE_INT)
-	var dict : Dictionary = {"a":0.0}
+	var dict: Dictionary = {"a": 0.0}
 	foo = dict.get("a")
 	print(typeof(foo) == TYPE_INT)


### PR DESCRIPTION
[GDScript style guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html) recommends the `var name: Type` style (no space before the colon). The same goes for [properties](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_basics.html#properties-setters-and-getters) (it's not in the style guide yet, but vnen confirmed it in Rocket Chat).

* Fix examples in the docs.
* Fix tests (except parser test).
* Fix strings in converter (I'm not sure about that).

Related:

* godotengine/godot-docs#6896
* godotengine/godot-demo-projects#874