### PR TITLE
Enable fast saving mode for PNGs

### DIFF
--- a/drivers/png/png_driver_common.cpp
+++ b/drivers/png/png_driver_common.cpp
@@ -138,6 +138,7 @@ Error image_to_png(const Ref<Image> &p_image, Vector<uint8_t> &p_buffer) {
 	png_img.version = PNG_IMAGE_VERSION;
 	png_img.width = source_image->get_width();
 	png_img.height = source_image->get_height();
+	png_img.flags = PNG_IMAGE_FLAG_FAST;
 
 	switch (source_image->get_format()) {
 		case Image::FORMAT_L8:


### PR DESCRIPTION
Makes saving PNGs 2.5x faster for me at only 2% (!) increase in filesize, although please note that I only did basic testing. Presumably, more compressible images would end up with a bigger filesize penalty.

Helps with Movie Maker, see godotengine/godot-proposals#4751

Fixes #51868