### PR TITLE
macOS export: Fix validation of codesigning certificate password

### DIFF
--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -768,7 +768,7 @@ Error EditorExportPlatformMacOS::_code_sign(const Ref<EditorExportPreset> &p_pre
 
 			String certificate_file = p_preset->get("codesign/certificate_file");
 			String certificate_pass = p_preset->get("codesign/certificate_password");
-			if (!certificate_file.is_empty() && !certificate_file.is_empty()) {
+			if (!certificate_file.is_empty() && !certificate_pass.is_empty()) {
 				args.push_back("--p12-file");
 				args.push_back(certificate_file);
 				args.push_back("--p12-password");


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
