### PR TITLE
Fixed incorrect ERROR message when setting new PrimitiveMesh

### DIFF
--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -117,8 +117,10 @@ void MeshInstance3D::set_mesh(const Ref<Mesh> &p_mesh) {
 	mesh = p_mesh;
 
 	if (mesh.is_valid()) {
-		mesh->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &MeshInstance3D::_mesh_changed));
+		// If mesh is a PrimitiveMesh, calling get_rid on it can trigger a changed callback
+		// so do this before connecting _mesh_changed.
 		set_base(mesh->get_rid());
+		mesh->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &MeshInstance3D::_mesh_changed));
 		_mesh_changed();
 	} else {
 		blend_shape_tracks.clear();


### PR DESCRIPTION
If calling set_mesh with a PrimitiveMesh that has pending update, the _mesh_changed function would be called twice. The first time before set_base had been called, which could lead to an ERROR message about trying to set an invalid surface override material.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
