### PR TITLE
Implement inactive properties

### DIFF
--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -216,6 +216,7 @@ typedef struct {
 	uint32_t hint; // Bitfield of `PropertyHint` (defined in `extension_api.json`).
 	GDExtensionStringPtr hint_string;
 	uint32_t usage; // Bitfield of `PropertyUsageFlags` (defined in `extension_api.json`).
+	GDExtensionStringNamePtr property_dependency;
 } GDExtensionPropertyInfo;
 
 typedef struct {

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -70,6 +70,7 @@ PropertyInfo::operator Dictionary() const {
 	d["hint"] = hint;
 	d["hint_string"] = hint_string;
 	d["usage"] = usage;
+	d["property_dependency"] = property_dependency;
 	return d;
 }
 
@@ -98,6 +99,10 @@ PropertyInfo PropertyInfo::from_dict(const Dictionary &p_dict) {
 
 	if (p_dict.has("usage")) {
 		pi.usage = p_dict["usage"];
+	}
+
+	if (p_dict.has("property_dependency")) {
+		pi.property_dependency = p_dict["property_dependency"];
 	}
 
 	return pi;

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -119,6 +119,7 @@ enum PropertyUsageFlags {
 	PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT = 1 << 26, // For Object properties, instantiate them when creating in editor.
 	PROPERTY_USAGE_EDITOR_BASIC_SETTING = 1 << 27, //for project or editor settings, show when basic settings are selected.
 	PROPERTY_USAGE_READ_ONLY = 1 << 28, // Mark a property as read-only in the inspector.
+	PROPERTY_USAGE_INACTIVE = 1 << 29, // Used for inactive properties that depend on other properties.
 
 	PROPERTY_USAGE_DEFAULT = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR,
 	PROPERTY_USAGE_NO_EDITOR = PROPERTY_USAGE_STORAGE,
@@ -149,6 +150,7 @@ struct PropertyInfo {
 	PropertyHint hint = PROPERTY_HINT_NONE;
 	String hint_string;
 	uint32_t usage = PROPERTY_USAGE_DEFAULT;
+	String property_dependency;
 
 	// If you are thinking about adding another member to this class, ask the maintainer (Juan) first.
 
@@ -164,12 +166,13 @@ struct PropertyInfo {
 
 	PropertyInfo() {}
 
-	PropertyInfo(const Variant::Type p_type, const String p_name, const PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = "", const uint32_t p_usage = PROPERTY_USAGE_DEFAULT, const StringName &p_class_name = StringName()) :
+	PropertyInfo(const Variant::Type p_type, const String p_name, const PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = "", const uint32_t p_usage = PROPERTY_USAGE_DEFAULT, const StringName &p_class_name = StringName(), const String &p_property_dependency = "") :
 			type(p_type),
 			name(p_name),
 			hint(p_hint),
 			hint_string(p_hint_string),
-			usage(p_usage) {
+			usage(p_usage),
+			property_dependency(p_property_dependency) {
 		if (hint == PROPERTY_HINT_RESOURCE_TYPE) {
 			class_name = hint_string;
 		} else {
@@ -187,7 +190,8 @@ struct PropertyInfo {
 			class_name(*reinterpret_cast<StringName *>(pinfo.class_name)),
 			hint((PropertyHint)pinfo.hint),
 			hint_string(*reinterpret_cast<String *>(pinfo.hint_string)),
-			usage(pinfo.usage) {}
+			usage(pinfo.usage),
+			property_dependency(*reinterpret_cast<String *>(pinfo.property_dependency)) {}
 
 	bool operator==(const PropertyInfo &p_info) const {
 		return ((type == p_info.type) &&
@@ -195,7 +199,8 @@ struct PropertyInfo {
 				(class_name == p_info.class_name) &&
 				(hint == p_info.hint) &&
 				(hint_string == p_info.hint_string) &&
-				(usage == p_info.usage));
+				(usage == p_info.usage)) &&
+				(property_dependency == p_info.property_dependency);
 	}
 
 	bool operator<(const PropertyInfo &p_info) const {

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2838,6 +2838,9 @@
 		<constant name="PROPERTY_USAGE_READ_ONLY" value="268435456" enum="PropertyUsageFlags" is_bitfield="true">
 			The property is read-only in the [EditorInspector].
 		</constant>
+		<constant name="PROPERTY_USAGE_INACTIVE" value="536870912" enum="PropertyUsageFlags" is_bitfield="true">
+			The property is inactive. It will be colored differently and display a warning in tooltip. The warning is configured with the property_dependency property.
+		</constant>
 		<constant name="PROPERTY_USAGE_DEFAULT" value="6" enum="PropertyUsageFlags" is_bitfield="true">
 			Default usage (storage, editor and network).
 		</constant>

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -260,9 +260,13 @@ void EditorProperty::_notification(int p_what) {
 
 			Color color;
 			if (draw_warning) {
-				color = get_theme_color(is_read_only() ? SNAME("readonly_warning_color") : SNAME("warning_color"));
+				color = get_theme_color((is_read_only() || is_inactive()) ? SNAME("readonly_warning_color") : SNAME("warning_color"));
 			} else {
-				color = get_theme_color(is_read_only() ? SNAME("readonly_color") : SNAME("property_color"));
+				if (is_inactive()) {
+					color = get_theme_color(SNAME("inactive_color"));
+				} else {
+					color = get_theme_color(is_read_only() ? SNAME("readonly_color") : SNAME("property_color"));
+				}
 			}
 			if (label.contains(".")) {
 				// FIXME: Move this to the project settings editor, as this is only used
@@ -447,6 +451,14 @@ void EditorProperty::set_read_only(bool p_read_only) {
 
 bool EditorProperty::is_read_only() const {
 	return read_only;
+}
+
+void EditorProperty::set_inactive(bool p_inactive) {
+	inactive = p_inactive;
+}
+
+bool EditorProperty::is_inactive() const {
+	return inactive;
 }
 
 Variant EditorPropertyRevert::get_property_revert_value(Object *p_object, const StringName &p_property, bool *r_is_valid) {
@@ -915,7 +927,7 @@ static Control *make_help_bit(const String &p_text, bool p_property) {
 	}
 	text += "[u][b]" + property_name + "[/b][/u]";
 
-	if (slices.size() > 1) {
+	if (slices.size() > 1 && slices[1] != "") {
 		String property_doc = slices[1].strip_edges();
 		if (property_name != property_doc) {
 			text += "\n" + property_doc;
@@ -923,6 +935,12 @@ static Control *make_help_bit(const String &p_text, bool p_property) {
 	} else {
 		text += "\n[i]" + TTR("No description.") + "[/i]";
 	}
+
+	// Add inactive warning.
+	if (slices.size() > 2 && slices[2] != "") {
+		text += "\n[b][color=yellow]" + TTR("Warning: This property does not have effect, because it doesn't meet dependency: %s.", slices[2].strip_edges()) + "[/color][/b]";
+	}
+
 	help_bit->set_text(text);
 
 	return help_bit;
@@ -3098,6 +3116,7 @@ void EditorInspector::update_tree() {
 		}
 
 		bool property_read_only = (p.usage & PROPERTY_USAGE_READ_ONLY) || read_only;
+		bool property_inactive = p.usage & PROPERTY_USAGE_INACTIVE;
 
 		// Mark properties that would require an editor restart (mostly when editing editor settings).
 		if (p.usage & PROPERTY_USAGE_RESTART_IF_CHANGED) {
@@ -3246,6 +3265,7 @@ void EditorInspector::update_tree() {
 				ep->set_checked(checked);
 				ep->set_keying(keying);
 				ep->set_read_only(property_read_only || all_read_only);
+				ep->set_inactive(property_inactive);
 				ep->set_deletable(deletable_properties || p.name.begins_with("metadata/"));
 			}
 
@@ -3264,10 +3284,16 @@ void EditorInspector::update_tree() {
 				ep->connect("multiple_properties_changed", callable_mp(this, &EditorInspector::_multiple_properties_changed));
 				ep->connect("resource_selected", callable_mp(this, &EditorInspector::_resource_selected), CONNECT_DEFERRED);
 				ep->connect("object_id_selected", callable_mp(this, &EditorInspector::_object_id_selected), CONNECT_DEFERRED);
+
+				StringName property_dependency = "";
+				if (property_inactive) {
+					property_dependency = p.property_dependency;
+				}
+
 				if (!doc_info.description.is_empty()) {
-					ep->set_tooltip_text(property_prefix + p.name + "::" + doc_info.description);
+					ep->set_tooltip_text(property_prefix + p.name + "::" + doc_info.description + "::" + property_dependency);
 				} else {
-					ep->set_tooltip_text(property_prefix + p.name);
+					ep->set_tooltip_text(property_prefix + p.name + "::" + "" + "::" + property_dependency);
 				}
 				ep->set_doc_path(doc_info.path);
 				ep->update_property();

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -76,6 +76,7 @@ private:
 	int property_usage;
 
 	bool read_only = false;
+	bool inactive = false;
 	bool checkable = false;
 	bool checked = false;
 	bool draw_warning = false;
@@ -145,6 +146,9 @@ public:
 
 	void set_read_only(bool p_read_only);
 	bool is_read_only() const;
+
+	void set_inactive(bool p_inactive);
+	bool is_inactive() const;
 
 	Object *get_edited_object();
 	StringName get_edited_property() const;

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -568,6 +568,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Color property_color = font_color.lerp(Color(0.5, 0.5, 0.5), 0.5);
 	Color readonly_color = property_color.lerp(dark_theme ? Color(0, 0, 0) : Color(1, 1, 1), 0.25);
 	Color readonly_warning_color = error_color.lerp(dark_theme ? Color(0, 0, 0) : Color(1, 1, 1), 0.25);
+	Color inactive_color = Color(0.9, 0.9, 0.05);
 
 	if (!dark_theme) {
 		// Darken some colors to be readable on a light background.
@@ -1142,6 +1143,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("property_color", "EditorProperty", property_color);
 	theme->set_color("readonly_color", "EditorProperty", readonly_color);
 	theme->set_color("readonly_warning_color", "EditorProperty", readonly_warning_color);
+	theme->set_color("inactive_color", "EditorProperty", inactive_color);
 
 	Ref<StyleBoxFlat> style_property_group_note = style_default->duplicate();
 	Color property_group_note_color = accent_color;

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -700,10 +700,12 @@ bool Camera2D::is_margin_drawing_enabled() const {
 
 void Camera2D::_validate_property(PropertyInfo &p_property) const {
 	if (!position_smoothing_enabled && p_property.name == "position_smoothing_speed") {
-		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		p_property.usage |= PROPERTY_USAGE_INACTIVE;
+		p_property.property_dependency = RTR("[i]position_smoothing_enabled[/i] to be true");
 	}
 	if (!rotation_smoothing_enabled && p_property.name == "rotation_smoothing_speed") {
-		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		p_property.usage |= PROPERTY_USAGE_INACTIVE;
+		p_property.property_dependency = RTR("[i]rotation_smoothing_enabled[/i] to be true");
 	}
 }
 


### PR DESCRIPTION
An attempt to implement https://github.com/godotengine/godot-proposals/issues/4823.

![image](https://user-images.githubusercontent.com/19669673/224476739-6e25ebd8-9025-44b9-b6f0-05925b7f2646.png)

Currently an early draft to start the discussion. Imo some solution for dependent properties would improve the usability a lot, as it's currently a bit confusing what properties have an effect, and which don't. Currently it's implemented using a new PROPERTY_HINT that is changed in validate property, should a separate method like suggested in the proposal be used instead?

**TODO:**
- Fix errors
- ~~Support translation~~ Done
- ~~Use a custom theme colour for invalid properties~~ Done
- Decide visuals
- Decide which properties to use this on
- Expose to gdscript tool scripts?