### PR TITLE
Fix several clang-tidy bool literal conversion warnings

### DIFF
--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -305,9 +305,9 @@ struct BuildIndexSequence<0, Is...> : IndexSequence<Is...> {};
 #endif
 
 // Macro GD_IS_DEFINED() allows to check if a macro is defined. It needs to be defined to anything (say 1) to work.
-#define __GDARG_PLACEHOLDER_1 0,
+#define __GDARG_PLACEHOLDER_1 false,
 #define __gd_take_second_arg(__ignored, val, ...) val
-#define ____gd_is_defined(arg1_or_junk) __gd_take_second_arg(arg1_or_junk 1, 0)
+#define ____gd_is_defined(arg1_or_junk) __gd_take_second_arg(arg1_or_junk true, false)
 #define ___gd_is_defined(val) ____gd_is_defined(__GDARG_PLACEHOLDER_##val)
 #define GD_IS_DEFINED(x) ___gd_is_defined(x)
 


### PR DESCRIPTION
Fixes many warnings caused by the `GD_IS_DEFINED()` macro. Normally, this wouldn't be that bad, but in this case that macros is used in a very important place: inside `GDCLASS()` macro. This macro is used by every class in Godot that inherits some another Godot class, which is a lot of classes and which causes a lot of clang-tidy warnings, one warning for each class.

Alternatively, we could disable [modernize-use-bool-literals](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-bool-literals.html) check from .clang-tidy, but as we excplicitly enabled it this might be a better solution.