### PR TITLE
iOS: Increase max simultaneous touches to 32

### DIFF
--- a/platform/ios/godot_view.mm
+++ b/platform/ios/godot_view.mm
@@ -39,7 +39,7 @@
 
 #import <CoreMotion/CoreMotion.h>
 
-static const int max_touches = 8;
+static const int max_touches = 32;
 static const float earth_gravity = 9.80665;
 
 @interface GodotView () {


### PR DESCRIPTION
Increased the max touches for ios to support more than 8 simultaneous touches, because modern ios devices can support more than 8 simultaneous touches.

*Bugsquad edit:*
- Fixes #34424
