### PR TITLE
Implement vertical icon alignment for buttons

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -58,7 +58,7 @@
 			To edit margin and spacing of the icon, use [theme_item h_separation] theme property and [code]content_margin_*[/code] properties of the used [StyleBox]es.
 		</member>
 		<member name="icon_alignment" type="int" setter="set_icon_alignment" getter="get_icon_alignment" enum="HorizontalAlignment" default="0">
-			Specifies if the icon should be aligned to the left, right, or center of a button. Uses the same [enum HorizontalAlignment] constants as the text alignment. If centered, text will draw on top of the icon.
+			Specifies if the icon should be aligned horizontally to the left, right, or center of a button. Uses the same [enum HorizontalAlignment] constants as the text alignment. If centered horizontally and vertically, text will draw on top of the icon.
 		</member>
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
@@ -71,6 +71,9 @@
 		</member>
 		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextServer.OverrunBehavior" default="0">
 			Sets the clipping behavior when the text exceeds the node's bounding rectangle. See [enum TextServer.OverrunBehavior] for a description of all modes.
+		</member>
+		<member name="vertical_icon_alignment" type="int" setter="set_vertical_icon_alignment" getter="get_vertical_icon_alignment" enum="VerticalAlignment" default="1">
+			Specifies if the icon should be aligned vertically to the top, bottom, or center of a button. Uses the same [enum VerticalAlignment] constants as the text alignment. If centered horizontally and vertically, text will draw on top of the icon.
 		</member>
 	</members>
 	<theme_items>

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -51,7 +51,8 @@ private:
 	bool expand_icon = false;
 	bool clip_text = false;
 	HorizontalAlignment alignment = HORIZONTAL_ALIGNMENT_CENTER;
-	HorizontalAlignment icon_alignment = HORIZONTAL_ALIGNMENT_LEFT;
+	HorizontalAlignment horizontal_icon_alignment = HORIZONTAL_ALIGNMENT_LEFT;
+	VerticalAlignment vertical_icon_alignment = VERTICAL_ALIGNMENT_CENTER;
 	float _internal_margin[4] = {};
 
 	struct ThemeCache {
@@ -135,7 +136,9 @@ public:
 	HorizontalAlignment get_text_alignment() const;
 
 	void set_icon_alignment(HorizontalAlignment p_alignment);
+	void set_vertical_icon_alignment(VerticalAlignment p_alignment);
 	HorizontalAlignment get_icon_alignment() const;
+	VerticalAlignment get_vertical_icon_alignment() const;
 
 	Button(const String &p_text = String());
 	~Button();


### PR DESCRIPTION
Buttons already support aligning the icon to the left/right of the text. However this is a bit limiting, as it may also be desired to have the text above/below the icon.

This PR therefore adds the option to align the icon vertically by adding a `vertical_icon_alignment` property to the button class.

Here is an example image showing all combinations:
![20230303_21h53m07s_grim](https://user-images.githubusercontent.com/11162205/222918001-6f7fc0e6-6e2e-405d-8f65-97928e36649c.png)

Here's the same image with `expand_icon` turned on:
![20230303_21h53m23s_grim](https://user-images.githubusercontent.com/11162205/222918014-9300c3d4-c9d5-4dc2-a6da-6856621c3ea1.png)

Feel free to test the button behavior on my test project:
[vertical_button_test.zip](https://github.com/godotengine/godot/files/10889167/vertical_button_test.zip)
