### PR TITLE
Fix CharacterBody3D slide

### DIFF
--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -1427,7 +1427,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 					const PhysicsServer3D::MotionCollision &collision = result.collisions[0];
 
 					Vector3 slide_motion = result.remainder.slide(collision.normal);
-					if (collision_state.floor && !collision_state.wall && !motion_slide_up.is_zero_approx()) {
+					if (collision_state.floor && !collision_state.wall && !motion_slide_up.is_zero_approx() && !sliding_enabled) {
 						// Slide using the intersection between the motion plane and the floor plane,
 						// in order to keep the direction intact.
 						real_t motion_length = slide_motion.length();
@@ -1439,7 +1439,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 						slide_motion *= motion_length;
 					}
 
-					if (slide_motion.dot(velocity) > 0.0) {
+					if (slide_motion.dot(velocity) > 0.0 || sliding_enabled) {
 						motion = slide_motion;
 					} else {
 						motion = Vector3();

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -1427,7 +1427,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 					const PhysicsServer3D::MotionCollision &collision = result.collisions[0];
 
 					Vector3 slide_motion = result.remainder.slide(collision.normal);
-					if (collision_state.floor && !collision_state.wall && !motion_slide_up.is_zero_approx() && !sliding_enabled) {
+					if (collision_state.floor && !collision_state.wall && !motion_slide_up.is_zero_approx()) {
 						// Slide using the intersection between the motion plane and the floor plane,
 						// in order to keep the direction intact.
 						real_t motion_length = slide_motion.length();
@@ -1439,7 +1439,11 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 						slide_motion *= motion_length;
 					}
 
-					if (slide_motion.dot(velocity) > 0.0 || sliding_enabled) {
+					if (sliding_enabled) {
+						slide_motion = result.remainder.slide(collision.normal);
+					}
+
+					if (slide_motion.dot(velocity) > 0.0) {
 						motion = slide_motion;
 					} else {
 						motion = Vector3();


### PR DESCRIPTION
Fix not being able to slide when jumping up a slope even if "stop on slope" is set to false Fixes bug: https://github.com/godotengine/godot/issues/74333

<i>Bugsquad edit</i>:
- Fix #74333

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
