### PR TITLE
Allow changing feature profile via `EditorInterface`

### DIFF
--- a/doc/classes/EditorFeatureProfile.xml
+++ b/doc/classes/EditorFeatureProfile.xml
@@ -51,6 +51,7 @@
 			<param index="0" name="path" type="String" />
 			<description>
 				Loads an editor feature profile from a file. The file must follow the JSON format obtained by using the feature profile manager's [b]Export[/b] button or the [method save_to_file] method.
+				[b]Note:[/b] Feature profiles created via the user interface are loaded from the [code]feature_profiles[/code] directory, as a file with the [code].profile[/code] extension. The editor configuration folder can be found by using [method EditorPaths.get_config_dir].
 			</description>
 		</method>
 		<method name="save_to_file">
@@ -58,6 +59,7 @@
 			<param index="0" name="path" type="String" />
 			<description>
 				Saves the editor feature profile to a file in JSON format. It can then be imported using the feature profile manager's [b]Import[/b] button or the [method load_from_file] method.
+				[b]Note:[/b] Feature profiles created via the user interface are saved in the [code]feature_profiles[/code] directory, as a file with the [code].profile[/code] extension. The editor configuration folder can be found by using [method EditorPaths.get_config_dir].
 			</description>
 		</method>
 		<method name="set_disable_class">

--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -54,6 +54,14 @@
 				Returns the current directory being viewed in the [FileSystemDock]. If a file is selected, its base directory will be returned using [method String.get_base_dir] instead.
 			</description>
 		</method>
+		<method name="get_current_feature_profile" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the name of the currently activated feature profile. If the default profile is currently active, an empty string is returned instead.
+				In order to get a reference to the [EditorFeatureProfile], you must load the feature profile using [method EditorFeatureProfile.load_from_file].
+				[b]Note:[/b] Feature profiles created via the user interface are loaded from the [code]feature_profiles[/code] directory, as a file with the [code].profile[/code] extension. The editor configuration folder can be found by using [method EditorPaths.get_config_dir].
+			</description>
+		</method>
 		<method name="get_current_path" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -281,6 +289,15 @@
 			<param index="0" name="file" type="String" />
 			<description>
 				Selects the file, with the path provided by [param file], in the FileSystem dock.
+			</description>
+		</method>
+		<method name="set_current_feature_profile">
+			<return type="void" />
+			<param index="0" name="profile_name" type="String" />
+			<description>
+				Selects and activates the specified feature profile with the given [param profile_name]. Set [param profile_name] to an empty string to reset to the default feature profile.
+				A feature profile can be created programmatically using the [EditorFeatureProfile] class.
+				[b]Note:[/b] The feature profile that gets activated must be located in the [code]feature_profiles[/code] directory, as a file with the [code].profile[/code] extension. If a profile could not be found, an error occurs. The editor configuration folder can be found by using [method EditorPaths.get_config_dir].
 			</description>
 		</method>
 		<method name="set_main_screen_editor">

--- a/editor/editor_feature_profile.h
+++ b/editor/editor_feature_profile.h
@@ -177,6 +177,8 @@ protected:
 
 public:
 	Ref<EditorFeatureProfile> get_current_profile();
+	String get_current_profile_name() const;
+	void set_current_profile(const String &p_profile_name, bool p_validate_profile);
 	void notify_changed();
 
 	static EditorFeatureProfileManager *get_singleton() { return singleton; }

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -31,6 +31,7 @@
 #include "editor_interface.h"
 
 #include "editor/editor_command_palette.h"
+#include "editor/editor_feature_profile.h"
 #include "editor/editor_node.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_resource_preview.h"
@@ -239,6 +240,14 @@ void EditorInterface::popup_dialog_centered_clamped(Window *p_dialog, const Size
 	p_dialog->popup_exclusive_centered_clamped(EditorNode::get_singleton(), p_size, p_fallback_ratio);
 }
 
+String EditorInterface::get_current_feature_profile() const {
+	return EditorFeatureProfileManager::get_singleton()->get_current_profile_name();
+}
+
+void EditorInterface::set_current_feature_profile(const String &p_profile_name) {
+	EditorFeatureProfileManager::get_singleton()->set_current_profile(p_profile_name, true);
+}
+
 // Editor docks.
 
 FileSystemDock *EditorInterface::get_file_system_dock() const {
@@ -406,6 +415,9 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("popup_dialog_centered", "dialog", "minsize"), &EditorInterface::popup_dialog_centered, DEFVAL(Size2i()));
 	ClassDB::bind_method(D_METHOD("popup_dialog_centered_ratio", "dialog", "ratio"), &EditorInterface::popup_dialog_centered_ratio, DEFVAL(0.8));
 	ClassDB::bind_method(D_METHOD("popup_dialog_centered_clamped", "dialog", "minsize", "fallback_ratio"), &EditorInterface::popup_dialog_centered_clamped, DEFVAL(Size2i()), DEFVAL(0.75));
+
+	ClassDB::bind_method(D_METHOD("get_current_feature_profile"), &EditorInterface::get_current_feature_profile);
+	ClassDB::bind_method(D_METHOD("set_current_feature_profile", "profile_name"), &EditorInterface::set_current_feature_profile);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "distraction_free_mode"), "set_distraction_free_mode", "is_distraction_free_mode_enabled");
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -104,6 +104,9 @@ public:
 	void popup_dialog_centered_ratio(Window *p_dialog, float p_ratio = 0.8);
 	void popup_dialog_centered_clamped(Window *p_dialog, const Size2i &p_size = Size2i(), float p_fallback_ratio = 0.75);
 
+	String get_current_feature_profile() const;
+	void set_current_feature_profile(const String &p_profile_name);
+
 	// Editor docks.
 
 	FileSystemDock *get_file_system_dock() const;


### PR DESCRIPTION
- Add `EditorInterface.set_current_feature_profile(profile_name: String)` method to load a feature profile by name.
    - Validate the specified feature profile (ensures the profile file exists).
- Add complementary `EditorInterface.get_current_feature_profile()` method. This returns a string, but you can easily retrieve the `EditorFeatureProfile` instance from it (see example project).
- Add documentation hints for how to programmatically register feature profiles.
- Refactor UI code (since the current feature profile is fully determined by the UI...).

This allows creating a plugin or editor script which can automatically generate and/or change feature profiles. [Example project here.](https://github.com/godotengine/godot/pull/74382#issuecomment-1648203524)