### PR TITLE
Add a project setting to control wireframe thickness

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1980,6 +1980,9 @@
 		<member name="rendering/driver/threads/thread_model" type="int" setter="" getter="" default="1">
 			Thread model for rendering. Rendering on a thread can vastly improve performance, but synchronizing to the main thread can cause a bit more jitter.
 		</member>
+		<member name="rendering/driver/wireframe/width" type="float" setter="" getter="" default="1.0">
+			Render wireframes using the specified value as a thickness (in pixels). Wire thickness does not depend on distance from the camera.
+		</member>
 		<member name="rendering/environment/defaults/default_clear_color" type="Color" setter="" getter="" default="Color(0.3, 0.3, 0.3, 1)">
 			Default background clear color. Overridable per [Viewport] using its [Environment]. See [member Environment.background_mode] and [member Environment.background_color] in particular. To change this default color programmatically, use [method RenderingServer.set_default_clear_color].
 		</member>

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -40,6 +40,9 @@ using namespace RendererSceneRenderImplementation;
 void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 	//compile
 
+	bool depth_pre_pass_enabled = bool(GLOBAL_GET("rendering/driver/depth_prepass/enable"));
+	float wireframe_width = float(GLOBAL_GET("rendering/driver/wireframe/width"));
+
 	code = p_code;
 	valid = false;
 	ubo_size = 0;
@@ -253,7 +256,6 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 		depth_stencil_state.depth_compare_operator = RD::COMPARE_OP_LESS_OR_EQUAL;
 		depth_stencil_state.enable_depth_write = depth_draw != DEPTH_DRAW_DISABLED ? true : false;
 	}
-	bool depth_pre_pass_enabled = bool(GLOBAL_GET("rendering/driver/depth_prepass/enable"));
 
 	for (int i = 0; i < CULL_VARIANT_MAX; i++) {
 		RD::PolygonCullMode cull_mode_rd_table[CULL_VARIANT_MAX][3] = {
@@ -298,6 +300,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 				RD::PipelineRasterizationState raster_state;
 				raster_state.cull_mode = cull_mode_rd;
 				raster_state.wireframe = wireframe;
+				raster_state.line_width = wireframe_width;
 
 				if (k == PIPELINE_VERSION_COLOR_PASS) {
 					for (int l = 0; l < PIPELINE_COLOR_PASS_FLAG_COUNT; l++) {

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -42,6 +42,8 @@ using namespace RendererSceneRenderImplementation;
 void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 	//compile
 
+	float wireframe_width = float(GLOBAL_GET("rendering/driver/wireframe/width"));
+
 	code = p_code;
 	valid = false;
 	ubo_size = 0;
@@ -292,6 +294,7 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 				RD::PipelineRasterizationState raster_state;
 				raster_state.cull_mode = cull_mode_rd;
 				raster_state.wireframe = wireframe;
+				raster_state.line_width = wireframe_width;
 
 				RD::PipelineColorBlendState blend_state;
 				RD::PipelineDepthStencilState depth_stencil = depth_stencil_state;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2909,6 +2909,7 @@ void RenderingServer::init() {
 
 	GLOBAL_DEF("rendering/driver/depth_prepass/enable", true);
 	GLOBAL_DEF("rendering/driver/depth_prepass/disable_for_vendors", "PowerVR,Mali,Adreno,Apple");
+	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "rendering/driver/wireframe/width", PROPERTY_HINT_RANGE, "1.0,128.0,0.5"), 1.0f);
 
 	GLOBAL_DEF_RST("rendering/textures/default_filters/use_nearest_mipmap_filter", false);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/textures/default_filters/anisotropic_filtering_level", PROPERTY_HINT_ENUM, String::utf8("Disabled (Fastest),2× (Faster),4× (Fast),8× (Average),16× (Slow)")), 2);


### PR DESCRIPTION
Makes wireframes easier to see on high resolution displays. A previous version of this setting force-enabled wireframes, but this has been retired in favor of finding ways to reuse `Viewport::DEBUG_DRAW_WIREFRAME`.