### PR TITLE
Make signals and coroutines thread safe

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -595,6 +595,7 @@ private:
 
 	HashMap<StringName, SignalData> signal_map;
 	List<Connection> connections;
+	Mutex signal_mutex;
 #ifdef DEBUG_ENABLED
 	SafeRefCount _lock_index;
 #endif

--- a/core/os/mutex.h
+++ b/core/os/mutex.h
@@ -39,9 +39,14 @@
 template <class MutexT>
 class MutexLock;
 
+template <class... MutexTs>
+class MutexMultiLock;
+
 template <class StdMutexT>
 class MutexImpl {
 	friend class MutexLock<MutexImpl<StdMutexT>>;
+	template <class... MutexTs>
+	friend class MutexMultiLock;
 
 	using StdMutexType = StdMutexT;
 
@@ -120,6 +125,16 @@ class MutexLock {
 public:
 	_ALWAYS_INLINE_ explicit MutexLock(const MutexT &p_mutex) :
 			lock(p_mutex.mutex) {
+	}
+};
+
+template <class... MutexTs>
+class MutexMultiLock {
+	std::scoped_lock<typename MutexTs::StdMutexType...> lock;
+
+public:
+	_ALWAYS_INLINE_ explicit MutexMultiLock(const MutexTs &...p_mutex) :
+			lock(p_mutex.mutex...) {
 	}
 };
 


### PR DESCRIPTION
This fixes #34752.
Functions that read or modify signal_map or its contents are protected by a mutex. Signal emission now copies the relevant callables before emission so that the mutex can be unlocked while the signal is being emitted. This allows multiple signals to be emitted simultaneously, from different threads. As a side effect, coroutines are now thread safe too, allowing you to use await on a thread, or to await a signal emitted on a thread.

Performance of the relevant functions is slightly impacted. Using [this](https://github.com/Trantarius/godot/tree/threadsafe-signals-test-project) project to test the speed:

- add_user_signal takes 8% longer
- connect takes 8% longer
- emit takes 11% longer
- disconnect takes 18% longer
- free takes 16% longer