### PR TITLE
Use blender executable instead of blender directory

### DIFF
--- a/modules/gltf/editor/editor_import_blend_runner.cpp
+++ b/modules/gltf/editor/editor_import_blend_runner.cpp
@@ -154,13 +154,7 @@ String dict_to_xmlrpc(const Dictionary &p_dict) {
 
 Error EditorImportBlendRunner::start_blender(const String &p_python_script, bool p_blocking) {
 	String blender_path = EDITOR_GET("filesystem/import/blender/blender3_path");
-
-#ifdef WINDOWS_ENABLED
-	blender_path = blender_path.path_join("blender.exe");
-#else
-	blender_path = blender_path.path_join("blender");
-#endif
-
+	
 	List<String> args;
 	args.push_back("--background");
 	args.push_back("--python-expr");

--- a/modules/gltf/editor/editor_import_blend_runner.cpp
+++ b/modules/gltf/editor/editor_import_blend_runner.cpp
@@ -154,8 +154,30 @@ String dict_to_xmlrpc(const Dictionary &p_dict) {
 
 Error EditorImportBlendRunner::start_blender(const String &p_python_script, bool p_blocking) {
 	String blender_path = EDITOR_GET("filesystem/import/blender/blender3_path");
+	String flags = EDITOR_GET("filesystem/import/blender/blender3_flags");
 	
 	List<String> args;
+	if (flags.size()) {
+		int from = 0;
+		int num_chars = 0;
+		bool inside_quotes = false;
+
+		for (int i = 0; i < flags.size(); i++) {
+			if (flags[i] == '"' && (!i || flags[i - 1] != '\\')) {
+				if (!inside_quotes) {
+					from++;
+				}
+				inside_quotes = !inside_quotes;
+			} else if (flags[i] == '\0' || (!inside_quotes && flags[i] == ' ')) {
+				String arg = flags.substr(from, num_chars);
+				args.push_back(arg);
+				from = i + 1;
+				num_chars = 0;
+			} else {
+				num_chars++;
+			}
+		}
+	}
 	args.push_back("--background");
 	args.push_back("--python-expr");
 	args.push_back(p_python_script);

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -427,7 +427,7 @@ bool EditorFileSystemImportFormatSupportQueryBlend::query() {
 		browse_dialog = memnew(EditorFileDialog);
 		browse_dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 		browse_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
-		browse_dialog->connect("dir_selected", callable_mp(this, &EditorFileSystemImportFormatSupportQueryBlend::_select_install));
+		browse_dialog->connect("file_selected", callable_mp(this, &EditorFileSystemImportFormatSupportQueryBlend::_select_install));
 
 		EditorNode::get_singleton()->get_gui_base()->add_child(browse_dialog);
 	}

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -276,7 +276,30 @@ static bool _test_blender_path(const String &p_path, String *r_err = nullptr) {
 		}
 		return false;
 	}
+	String flags = EDITOR_GET("filesystem/import/blender/blender3_flags");
+	
 	List<String> args;
+	if (flags.size()) {
+		int from = 0;
+		int num_chars = 0;
+		bool inside_quotes = false;
+
+		for (int i = 0; i < flags.size(); i++) {
+			if (flags[i] == '"' && (!i || flags[i - 1] != '\\')) {
+				if (!inside_quotes) {
+					from++;
+				}
+				inside_quotes = !inside_quotes;
+			} else if (flags[i] == '\0' || (!inside_quotes && flags[i] == ' ')) {
+				String arg = flags.substr(from, num_chars);
+				args.push_back(arg);
+				from = i + 1;
+				num_chars = 0;
+			} else {
+				num_chars++;
+			}
+		}
+	}
 	args.push_back("--version");
 	String pipe;
 	Error err = OS::get_singleton()->execute(path, args, &pipe);

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -269,21 +269,10 @@ void EditorSceneFormatImporterBlend::get_import_options(const String &p_path, Li
 
 static bool _test_blender_path(const String &p_path, String *r_err = nullptr) {
 	String path = p_path;
-#ifdef WINDOWS_ENABLED
-	path = path.path_join("blender.exe");
-#else
-	path = path.path_join("blender");
-#endif
 
-#if defined(MACOS_ENABLED)
-	if (!FileAccess::exists(path)) {
-		path = path.path_join("Blender");
-	}
-#endif
-
-	if (!FileAccess::exists(path)) {
+	if (path.is_empty()) {
 		if (r_err) {
-			*r_err = TTR("Path does not contain a Blender installation.");
+			*r_err = TTR("Path is not a Blender installation.");
 		}
 		return false;
 	}
@@ -405,7 +394,7 @@ bool EditorFileSystemImportFormatSupportQueryBlend::query() {
 		configure_blender_dialog->set_close_on_escape(false);
 
 		VBoxContainer *vb = memnew(VBoxContainer);
-		vb->add_child(memnew(Label(TTR("Blender 3.0+ is required to import '.blend' files.\nPlease provide a valid path to a Blender installation:"))));
+		vb->add_child(memnew(Label(TTR("Blender 3.0+ is required to import '.blend' files.\nPlease provide a valid path to a Blender executable:"))));
 
 		HBoxContainer *hb = memnew(HBoxContainer);
 
@@ -437,7 +426,7 @@ bool EditorFileSystemImportFormatSupportQueryBlend::query() {
 
 		browse_dialog = memnew(EditorFileDialog);
 		browse_dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
-		browse_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_DIR);
+		browse_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 		browse_dialog->connect("dir_selected", callable_mp(this, &EditorFileSystemImportFormatSupportQueryBlend::_select_install));
 
 		EditorNode::get_singleton()->get_gui_base()->add_child(browse_dialog);
@@ -466,25 +455,25 @@ bool EditorFileSystemImportFormatSupportQueryBlend::query() {
 
 			bool found = false;
 			for (const String &path : mdfind_paths) {
-				found = _autodetect_path(path.path_join("Contents/MacOS"));
+				found = _autodetect_path(path.path_join("Contents/MacOS/blender"));
 				if (found) {
 					break;
 				}
 			}
 			if (!found) {
-				found = _autodetect_path("/opt/homebrew/bin");
+				found = _autodetect_path("/opt/homebrew/bin/blender");
 			}
 			if (!found) {
-				found = _autodetect_path("/opt/local/bin");
+				found = _autodetect_path("/opt/local/bin/blender");
 			}
 			if (!found) {
-				found = _autodetect_path("/usr/local/bin");
+				found = _autodetect_path("/usr/local/bin/blender");
 			}
 			if (!found) {
-				found = _autodetect_path("/usr/local/opt");
+				found = _autodetect_path("/usr/local/opt/blender");
 			}
 			if (!found) {
-				found = _autodetect_path("/Applications/Blender.app/Contents/MacOS");
+				found = _autodetect_path("/Applications/Blender.app/Contents/MacOS/blender");
 			}
 		}
 #elif defined(WINDOWS_ENABLED)
@@ -494,20 +483,20 @@ bool EditorFileSystemImportFormatSupportQueryBlend::query() {
 			HRESULT res = AssocQueryString(0, ASSOCSTR_EXECUTABLE, ".blend", "open", blender_opener_path, &path_len);
 			if (res == S_OK && _autodetect_path(String(blender_opener_path).get_base_dir())) {
 				// Good.
-			} else if (_autodetect_path("C:\\Program Files\\Blender Foundation")) {
+			} else if (_autodetect_path("C:\\Program Files\\Blender Foundation\\blender.exe")) {
 				// Good.
 			} else {
-				_autodetect_path("C:\\Program Files (x86)\\Blender Foundation");
+				_autodetect_path("C:\\Program Files (x86)\\Blender Foundation\\blender.exe");
 			}
 		}
 
 #elif defined(UNIX_ENABLED)
-		if (_autodetect_path("/usr/bin")) {
+		if (_autodetect_path("/usr/bin/blender")) {
 			// Good.
-		} else if (_autodetect_path("/usr/local/bin")) {
+		} else if (_autodetect_path("/usr/local/bin/blender")) {
 			// Good
 		} else {
-			_autodetect_path("/opt/blender/bin");
+			_autodetect_path("/opt/blender/bin/blender");
 		}
 #endif
 		if (auto_detected_path != "") {

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -63,13 +63,13 @@ static void _editor_init() {
 
 	String blender3_path = EDITOR_DEF_RST("filesystem/import/blender/blender3_path", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING,
-			"filesystem/import/blender/blender3_path", PROPERTY_HINT_GLOBAL_DIR));
+			"filesystem/import/blender/blender3_path", PROPERTY_HINT_GLOBAL_FILE));
 	if (blend_enabled) {
 		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 		if (blender3_path.is_empty()) {
 			WARN_PRINT("Blend file import is enabled in the project settings, but no Blender path is configured in the editor settings. Blend files will not be imported.");
-		} else if (!da->dir_exists(blender3_path)) {
-			WARN_PRINT("Blend file import is enabled, but the Blender path doesn't point to an accessible directory. Blend files will not be imported.");
+		} else if (!da->file_exists(blender3_path)) {
+			WARN_PRINT("Blend file import is enabled, but the Blender path doesn't point to an accessible executable. Blend files will not be imported.");
 		} else {
 			Ref<EditorSceneFormatImporterBlend> importer;
 			importer.instantiate();

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -64,6 +64,9 @@ static void _editor_init() {
 	String blender3_path = EDITOR_DEF_RST("filesystem/import/blender/blender3_path", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING,
 			"filesystem/import/blender/blender3_path", PROPERTY_HINT_GLOBAL_FILE));
+	String blender3_flags = EDITOR_DEF_RST("filesystem/import/blender/blender3_flags", "");
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING,
+			"filesystem/import/blender/blender3_flags", PROPERTY_HINT_PLACEHOLDER_TEXT));
 	if (blend_enabled) {
 		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 		if (blender3_path.is_empty()) {


### PR DESCRIPTION
This is an implementation of my proposal [here](https://github.com/godotengine/godot-proposals/issues/6432).

In my very limited testing, it works, but there may be errors that occur on other systems since I'm running Godot in a Fedora 37 container. There may also be files that need to be corrected too, but this should be a good place to start.