### PR TITLE
Move tool declarations to top in 3to4.

### DIFF
--- a/editor/project_converter_3_to_4.h
+++ b/editor/project_converter_3_to_4.h
@@ -71,6 +71,8 @@ class ProjectConverter3To4 {
 	uint64_t maximum_file_size;
 	uint64_t maximum_line_length;
 
+	void fix_tool_declaration(Vector<SourceLine> &source_lines, const RegExContainer &reg_container);
+
 	void rename_colors(Vector<SourceLine> &source_lines, const RegExContainer &reg_container);
 	Vector<String> check_for_rename_colors(Vector<String> &lines, const RegExContainer &reg_container);
 


### PR DESCRIPTION
In godot3, `tool` can follow keywords like `extends` and `class_name`
In godot4, `@tool` must be the first line in the file.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
