### PR TITLE
Add restrictions to MultiplayerSynchronizer editor and documentation

### DIFF
--- a/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
+++ b/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
@@ -8,6 +8,7 @@
 		Visibility can be handled directly with [method set_visibility_for] or as-needed with [method add_visibility_filter] and [method update_visibility].
 		[MultiplayerSpawner]s will handle nodes according to visibility of synchronizers as long as the node at [member root_path] was spawned by one.
 		Internally, [MultiplayerSynchronizer] uses [method MultiplayerAPI.object_configuration_add] to notify synchronization start passing the [Node] at [member root_path] as the [code]object[/code] and itself as the [code]configuration[/code], and uses [method MultiplayerAPI.object_configuration_remove] to notify synchronization end in a similar way.
+		[b]Note:[/b] Synchronization is not supported for [Object] type properties, like [Resource]. Properties that are unique to each peer, like the instance IDs of [Object]s (see [method Object.get_instance_id]) or [RID]s, will also not work in synchronization.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/multiplayer/doc_classes/SceneReplicationConfig.xml
+++ b/modules/multiplayer/doc_classes/SceneReplicationConfig.xml
@@ -14,6 +14,7 @@
 			<param index="1" name="index" type="int" default="-1" />
 			<description>
 				Adds the property identified by the given [param path] to the list of the properties being synchronized, optionally passing an [param index].
+				[b]Note:[/b] For details on restrictions and limitations on property synchronization, see [MultiplayerSynchronizer].
 			</description>
 		</method>
 		<method name="get_properties" qualifiers="const">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
`Object` based properties won't be synchronized properly, this restricts them being picked, and documents this limitation.

Also preventing and warning on `RIDs` as they won't work either, properties holding `ObjectID` or similar, mainly aiming to prevent errors that might not be obvious to users.

Note that this does not give any errors on running or prevent the creation of such property syncing, it continues to "fail" silently as before.

Fixes #74325