### PR TITLE
Windows: Workaround missing DWRITE_FONT_WEIGHT value in old MinGW

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -645,7 +645,7 @@ if selected_platform in platform_list:
             print(
                 "Detected mingw version is not using posix threads. Only posix "
                 "version of mingw is supported. "
-                'Use "update-alternatives --config <platform>-w64-mingw32-[gcc|g++]" '
+                'Use "update-alternatives --config x86_64-w64-mingw32-g++" '
                 "to switch to posix threads."
             )
             Exit(255)

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -69,6 +69,11 @@ __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 #define WM_POINTERUPDATE 0x0245
 #endif
 
+// Missing in MinGW headers before 8.0.
+#ifndef DWRITE_FONT_WEIGHT_SEMI_LIGHT
+#define DWRITE_FONT_WEIGHT_SEMI_LIGHT (DWRITE_FONT_WEIGHT)350
+#endif
+
 #if defined(__GNUC__)
 // Workaround GCC warning from -Wcast-function-type.
 #define GetProcAddress (void *)GetProcAddress


### PR DESCRIPTION
Fixes #74339.