### PR TITLE
Clarify Thread documentation

### DIFF
--- a/doc/classes/Thread.xml
+++ b/doc/classes/Thread.xml
@@ -16,13 +16,13 @@
 		<method name="get_id" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the current [Thread]'s ID, uniquely identifying it among all threads. If the [Thread] is not running this returns an empty string.
+				Returns the current [Thread]'s ID, uniquely identifying it among all threads. If the [Thread] has not started running or if [method wait_to_finish] has been called, this returns an empty string.
 			</description>
 		</method>
 		<method name="is_alive" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if this [Thread] is currently running. This is useful for determining if [method wait_to_finish] can be called without blocking the calling thread.
+				Returns [code]true[/code] if this [Thread] is currently running the provided function. This is useful for determining if [method wait_to_finish] can be called without blocking the calling thread.
 				To check if a [Thread] is joinable, use [method is_started].
 			</description>
 		</method>


### PR DESCRIPTION
The current documentation uses the term "running" for two different things.

In the description of get_id() it claims "it will return empty string if the thread is not running", but it actually will return the thread id until wait_to_finish is called.

In the description of is_alive() it claims "it will return true if the thread is running", but in this case it means "the provided function hasn't finished running yet".

Updated the functions documentation slighly to make this clear.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
