### PR TITLE
Don't autocomplete numbers in GDScript

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2926,6 +2926,12 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 	code_completion_options.clear();
 	code_completion_base = string_to_complete;
 
+	/* Don't autocomplete setting numerical values. */
+	if (code_completion_base.is_numeric()) {
+		cancel_code_completion();
+		return;
+	}
+
 	Vector<ScriptLanguage::CodeCompletionOption> completion_options_casei;
 	Vector<ScriptLanguage::CodeCompletionOption> completion_options_substr;
 	Vector<ScriptLanguage::CodeCompletionOption> completion_options_substr_casei;


### PR DESCRIPTION
Cancel code autocompletion when a numerical value is entered. Avoids interference when setting numbers

![Animation](https://user-images.githubusercontent.com/48544263/223014573-411e1499-b304-46ce-8510-3392dd4c4fbf.gif)

Closes #72565 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
