### PR TITLE
[3.x] Configure maven central snapshot versions for the Godot Android library

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -186,6 +186,9 @@ ext.getGodotPublishVersion = { ->
     String versionName = ""
     int versionCode = 1
     (versionName, versionCode) = generateGodotLibraryVersion(requiredKeys)
+    if (!versionName.endsWith("stable")) {
+        versionName += "-SNAPSHOT"
+    }
     return versionName
 }
 

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -20,6 +20,13 @@ plugins {
 apply from: 'app/config.gradle'
 apply from: 'scripts/publish-root.gradle'
 
+ext {
+    PUBLISH_VERSION = getGodotPublishVersion()
+}
+
+group = ossrhGroupId
+version = PUBLISH_VERSION
+
 allprojects {
     repositories {
         google()

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 ext {
-    PUBLISH_VERSION = getGodotPublishVersion()
     PUBLISH_ARTIFACT_ID = 'godot'
 }
 


### PR DESCRIPTION
A snapshot version is a version that has not yet been released which allows us to deploy the same transient version incrementally, without requiring projects to upgrade the artifact version they're consuming. Those projects can use the same version to get an updated snapshot version.

Address task 3 of https://github.com/godotengine/godot-proposals/issues/4230

[main version](https://github.com/godotengine/godot/pull/74470)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
