### PR TITLE
C#: Fix building projects for MSBuild before 17.3

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
@@ -14,7 +14,7 @@
 
     <GodotProjectDir Condition=" '$(GodotProjectDir)' == '' ">$(MSBuildProjectDirectory)</GodotProjectDir>
     <GodotProjectDir>$([MSBuild]::EnsureTrailingSlash('$(GodotProjectDir)'))</GodotProjectDir>
-    <GodotProjectDirBase64>$([MSBuild]::ConvertToBase64('$(GodotProjectDir)'))</GodotProjectDirBase64>
+    <GodotProjectDirBase64 Condition=" $([MSBuild]::VersionGreaterThanOrEquals($(MSBuildAssemblyVersion), '17.3')) ">$([MSBuild]::ConvertToBase64('$(GodotProjectDir)'))</GodotProjectDirBase64>
 
     <!-- Custom output paths for Godot projects. In brief, 'bin\' and 'obj\' are moved to '$(GodotProjectDir)\.godot\mono\temp\'. -->
     <BaseOutputPath>$(GodotProjectDir).godot\mono\temp\bin\</BaseOutputPath>
@@ -29,6 +29,13 @@
     <!-- Do not append the target framework name to the output path. -->
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
+
+  <Target Condition=" $([MSBuild]::VersionLessThan($(MSBuildAssemblyVersion), '17.3')) " Name="GodotProjectDir" BeforeTargets="Build">
+    <Error Text="Cannot build from path containing '%23', move your project or update dotnet to the latest version." Condition="$(GodotProjectDir.Contains('%23'))" /> <!-- # -->
+    <Error Text="Cannot build from path containing '%3B', move your project or update dotnet to the latest version." Condition="$(GodotProjectDir.Contains('%3B'))" /> <!-- ; -->
+    <Error Text="Cannot build from path containing newlines, move your project or update dotnet to the latest version." Condition="$(GodotProjectDir.Contains('%0A'))" /> <!-- \n -->
+    <Error Text="Cannot build from path containing newlines, move your project or update dotnet to the latest version." Condition="$(GodotProjectDir.Contains('%0D'))" /> <!-- \r -->
+  </Target>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" Condition=" '$(GodotSdkImportsMicrosoftNetSdk)' == 'true' " />
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Godot.SourceGenerators.Sample.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Godot.SourceGenerators.Sample.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <!-- $(GodotProjectDir) would normally be defined by the Godot.NET.Sdk -->
     <GodotProjectDir>$(MSBuildProjectDirectory)</GodotProjectDir>
-    <GodotProjectDirBase64>$([MSBuild]::ConvertToBase64('$(GodotProjectDir)'))</GodotProjectDirBase64>
+    <GodotProjectDirBase64 Condition=" $([MSBuild]::VersionGreaterThanOrEquals($(MSBuildAssemblyVersion), '17.3')) ">$([MSBuild]::ConvertToBase64('$(GodotProjectDir)'))</GodotProjectDirBase64>
     <!-- For compiling GetGodotPropertyDefaultValues. -->
     <DefineConstants>$(DefineConstants);TOOLS</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/pull/74312#issuecomment-1455169861
- Only pass the base64 path on compatible MSBuild versions
- Emit a clear build error when using a path with special chars and an old msbuild
<br/>

- ~Needs actually testing with an old msbuild~ works as expected.
- Needs verifying the list of problematic chars:
  - currently using `#` and `;` because they are comment separators
  - `\n` and `\r` because they are mentioned in the roslyn issue
  - ~`'` is mentioned in the original issue, not sure why this is a problem, but I would guess string separator, so I added `"` as well~
- ~Not sure what the sample is actually really used for (other than being a sample) so~ I would probably just keep it simple, so I left out the errors from there (and maybe would just remove the base64 path as well); still leaves the question if these things should be done to the sample.