### PR TITLE
Reload built in script to get its methods on signal connection

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -343,6 +343,9 @@ void ConnectDialog::_update_method_tree() {
 		si_item->set_icon(0, get_theme_icon(SNAME("Script"), SNAME("EditorIcons")));
 		si_item->set_selectable(0, false);
 
+		if (si->get_script()->is_built_in()) {
+			si->get_script()->reload();
+		}
 		List<MethodInfo> methods;
 		si->get_method_list(&methods);
 		methods = _filter_method_list(methods, signal_info, search_string);


### PR DESCRIPTION
Fixes #74453

There is something deeper wrong however with `si->get_script()->is_valid()`
For some reason, when the script is built in, it returns false the first time you try to pick a method, even if the script is valid