### PR TITLE
Work around a race condition with ScriptServer during initialization

### DIFF
--- a/core/os/thread.cpp
+++ b/core/os/thread.cpp
@@ -58,13 +58,19 @@ void Thread::callback(Thread *p_self, const Settings &p_settings, Callback p_cal
 	if (platform_functions.init) {
 		platform_functions.init();
 	}
-	ScriptServer::thread_enter(); // Scripts may need to attach a stack.
+
+	// Currently causes a race condition due to the fact that threads are
+	// spawned before ScriptServer is even initialized.
+	// This is currently unused since neither GDScript nor C# require
+	// attaching a stack to new threads, so we just disable for now.
+
+	//ScriptServer::thread_enter();
 	if (platform_functions.wrapper) {
 		platform_functions.wrapper(p_callback, p_userdata);
 	} else {
 		p_callback(p_userdata);
 	}
-	ScriptServer::thread_exit();
+	//ScriptServer::thread_exit();
 	if (platform_functions.term) {
 		platform_functions.term();
 	}


### PR DESCRIPTION
Split off from #73793 

Currently, `WorkerThreadPool` is initialized before `ScriptServer`, so there's a race condition where worker threads call into `ScriptServer::thread_enter()` before languages are registered. Since `ScriptServer` isn't always initialized (for example, when Godot is run with `--help`), there's no synchronization point where threads can wait for languages to be registered before proceeding, so we just disable it for now.

The proper fix is of course to rearrange `main()` so that threads and `WorkerThreadPool` are initialized last, which should probably wait until after #49362 (or possibly even be done there). This can be reverted afterwards.

Needed for ThreadSanitizer #73777 