### PR TITLE
Add conversion for `Vector2` `tangent()` -> `orthogonal()`

### DIFF
--- a/editor/renames_map_3_to_4.cpp
+++ b/editor/renames_map_3_to_4.cpp
@@ -1132,6 +1132,7 @@ const char *RenamesMap3To4::gdscript_properties_renames[][2] = {
 	{ "tab_align", "tab_alignment" }, // TabContainer
 	{ "table_hseparation", "table_h_separation" }, // Theme
 	{ "table_vseparation", "table_v_separation" }, // Theme
+	{ "tangent", "orthogonal" }, // Vector2
 	{ "toplevel", "top_level" }, // Node
 	{ "translation", "position" }, // Node3D
 	{ "unit_db", "volume_db" }, // AudioStreamPlayer3D
@@ -1195,6 +1196,7 @@ const char *RenamesMap3To4::csharp_properties_renames[][2] = {
 	{ "Oneshot", "OneShot" }, // AnimatedTexture
 	{ "OutOfRangeMode", "MaxPolyphony" }, // AudioStreamPlayer3D
 	{ "PauseMode", "ProcessMode" }, // Node
+	{ "Perpendicular", "Orthogonal" }, // Vector2 - Only exists in C#
 	{ "PhysicalScancode", "PhysicalKeycode" }, // InputEventKey
 	{ "PopupExclusive", "Exclusive" }, // Window
 	{ "ProximityFadeEnable", "ProximityFadeEnabled" }, // Material
@@ -1225,6 +1227,7 @@ const char *RenamesMap3To4::csharp_properties_renames[][2] = {
 	{ "TabAlign", "TabAlignment" }, // TabContainer
 	{ "TableHseparation", "TableHSeparation" }, // Theme
 	{ "TableVseparation", "TableVSeparation" }, // Theme
+	{ "Tangent", "Orthogonal" }, // Vector2
 	{ "Toplevel", "TopLevel" }, // Node
 	{ "Translation", "Position" }, // Node3D
 	{ "UnitDb", "VolumeDb" }, // AudioStreamPlayer3D


### PR DESCRIPTION
The method `tangent()` was renamed to `orthogonal()` here: https://github.com/godotengine/godot/pull/44149
For C# here: https://github.com/godotengine/godot/pull/48952

Note: In 3.5, C# `Tangent()` is deprecated and `Perpendicular()` exists as replacement, so I added both in here.