### PR TITLE
C#: Unify project name handling and fix issues with the handling of some special characters

### DIFF
--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -166,7 +166,6 @@ public:
 	String get_project_data_dir_name() const;
 	String get_project_data_path() const;
 	String get_resource_path() const;
-	String get_safe_project_name() const;
 	String get_imported_files_path() const;
 
 	static ProjectSettings *get_singleton();

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -62,6 +62,7 @@
 #include "signal_awaiter_utils.h"
 #include "utils/macros.h"
 #include "utils/naming_utils.h"
+#include "utils/path_utils.h"
 #include "utils/string_utils.h"
 
 #define CACHED_STRING_NAME(m_var) (CSharpLanguage::get_singleton()->get_string_names().m_var)
@@ -740,11 +741,7 @@ bool CSharpLanguage::is_assembly_reloading_needed() {
 			return false; // Already up to date
 		}
 	} else {
-		String assembly_name = GLOBAL_GET("dotnet/project/assembly_name");
-
-		if (assembly_name.is_empty()) {
-			assembly_name = ProjectSettings::get_singleton()->get_safe_project_name();
-		}
+		String assembly_name = path::get_csharp_project_name();
 
 		assembly_path = GodotSharpDirs::get_res_temp_assemblies_dir()
 								.path_join(assembly_name + ".dll");

--- a/modules/mono/editor/GodotTools/GodotTools.Core/StringExtensions.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.Core/StringExtensions.cs
@@ -57,27 +57,5 @@ namespace GodotTools.Core
                    path.StartsWith("\\", StringComparison.Ordinal) ||
                    path.StartsWith(_driveRoot, StringComparison.Ordinal);
         }
-
-        public static string ToSafeDirName(this string dirName, bool allowDirSeparator = false)
-        {
-            var invalidChars = new List<string> { ":", "*", "?", "\"", "<", ">", "|" };
-
-            if (allowDirSeparator)
-            {
-                // Directory separators are allowed, but disallow ".." to avoid going up the filesystem
-                invalidChars.Add("..");
-            }
-            else
-            {
-                invalidChars.Add("/");
-            }
-
-            string safeDirName = dirName.Replace("\\", "/").Trim();
-
-            foreach (string invalidChar in invalidChars)
-                safeDirName = safeDirName.Replace(invalidChar, "-");
-
-            return safeDirName;
-        }
     }
 }

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -151,7 +151,7 @@ namespace GodotTools.Export
                 string ridOS = DetermineRuntimeIdentifierOS(platform);
                 string ridArch = DetermineRuntimeIdentifierArch(arch);
                 string runtimeIdentifier = $"{ridOS}-{ridArch}";
-                string projectDataDirName = $"{DetermineDataDirNameForProject()}_{arch}";
+                string projectDataDirName = $"data_{GodotSharpDirs.CSharpProjectName}_{arch}";
                 if (platform == OS.Platforms.MacOS)
                 {
                     projectDataDirName = Path.Combine("Contents", "Resources", projectDataDirName);
@@ -257,13 +257,6 @@ namespace GodotTools.Export
 
             platform = null;
             return false;
-        }
-
-        private static string DetermineDataDirNameForProject()
-        {
-            string appName = (string)ProjectSettings.GetSetting("application/config/name");
-            string appNameSafe = appName.ToSafeDirName();
-            return $"data_{appNameSafe}";
         }
     }
 }

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
@@ -48,21 +48,23 @@ namespace GodotTools.Internals
             }
         }
 
+
+        public static string CSharpProjectName
+        {
+            get
+            {
+                Internal.godot_icall_GodotSharpDirs_CSharpProjectName(out godot_string dest);
+                using (dest)
+                    return Marshaling.ConvertStringToManaged(dest);
+            }
+        }
+
         public static void DetermineProjectLocation()
         {
-            static string DetermineProjectName()
-            {
-                string projectAssemblyName = (string)ProjectSettings.GetSetting("application/config/name");
-                projectAssemblyName = projectAssemblyName.ToSafeDirName();
-                if (string.IsNullOrEmpty(projectAssemblyName))
-                    projectAssemblyName = "UnnamedProject";
-                return projectAssemblyName;
-            }
-
             _projectAssemblyName = (string)ProjectSettings.GetSetting("dotnet/project/assembly_name");
             if (string.IsNullOrEmpty(_projectAssemblyName))
             {
-                _projectAssemblyName = DetermineProjectName();
+                _projectAssemblyName = CSharpProjectName;
                 ProjectSettings.SetSetting("dotnet/project/assembly_name", _projectAssemblyName);
             }
 

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/Internal.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/Internal.cs
@@ -101,6 +101,8 @@ namespace GodotTools.Internals
 
         public static partial void godot_icall_GodotSharpDirs_DataEditorToolsDir(out godot_string r_dest);
 
+        public static partial void godot_icall_GodotSharpDirs_CSharpProjectName(out godot_string r_dest);
+
         public static partial void godot_icall_EditorProgress_Create(in godot_string task, in godot_string label,
             int amount, bool canCancel);
 

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -49,6 +49,7 @@
 #include "../csharp_script.h"
 #include "../godotsharp_dirs.h"
 #include "../utils/macos_utils.h"
+#include "../utils/path_utils.h"
 #include "code_completion.h"
 
 #include "../interop_types.h"
@@ -79,6 +80,10 @@ void godot_icall_GodotSharpDirs_DataEditorToolsDir(godot_string *r_dest) {
 #else
 	return nullptr;
 #endif
+}
+
+void godot_icall_GodotSharpDirs_CSharpProjectName(godot_string *r_dest) {
+	memnew_placement(r_dest, String(path::get_csharp_project_name()));
 }
 
 void godot_icall_EditorProgress_Create(const godot_string *p_task, const godot_string *p_label, int32_t p_amount, bool p_can_cancel) {
@@ -231,6 +236,7 @@ static const void *unmanaged_callbacks[]{
 	(void *)godot_icall_GodotSharpDirs_MonoUserDir,
 	(void *)godot_icall_GodotSharpDirs_BuildLogsDirs,
 	(void *)godot_icall_GodotSharpDirs_DataEditorToolsDir,
+	(void *)godot_icall_GodotSharpDirs_CSharpProjectName,
 	(void *)godot_icall_EditorProgress_Create,
 	(void *)godot_icall_EditorProgress_Dispose,
 	(void *)godot_icall_EditorProgress_Step,

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -44,6 +44,7 @@
 #endif
 
 #include "mono_gd/gd_mono.h"
+#include "utils/path_utils.h"
 
 namespace GodotSharpDirs {
 
@@ -139,8 +140,7 @@ private:
 		api_assemblies_dir = api_assemblies_base_dir.path_join(GDMono::get_expected_api_build_config());
 #else // TOOLS_ENABLED
 		String arch = Engine::get_singleton()->get_architecture_name();
-		String appname = GLOBAL_GET("application/config/name");
-		String appname_safe = OS::get_singleton()->get_safe_dir_name(appname);
+		String appname_safe = path::get_csharp_project_name();
 		String data_dir_root = exe_dir.path_join("data_" + appname_safe + "_" + arch);
 		if (!DirAccess::exists(data_dir_root)) {
 			data_dir_root = exe_dir.path_join("data_Godot_" + arch);

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -293,20 +293,10 @@ godot_plugins_initialize_fn initialize_hostfxr_and_godot_plugins(bool &r_runtime
 	return godot_plugins_initialize;
 }
 #else
-static String get_assembly_name() {
-	String assembly_name = GLOBAL_GET("dotnet/project/assembly_name");
-
-	if (assembly_name.is_empty()) {
-		assembly_name = ProjectSettings::get_singleton()->get_safe_project_name();
-	}
-
-	return assembly_name;
-}
-
 godot_plugins_initialize_fn initialize_hostfxr_and_godot_plugins(bool &r_runtime_initialized) {
 	godot_plugins_initialize_fn godot_plugins_initialize = nullptr;
 
-	String assembly_name = get_assembly_name();
+	String assembly_name = path::get_csharp_project_name();
 
 	HostFxrCharString assembly_path = str_to_hostfxr(GodotSharpDirs::get_api_assemblies_dir()
 															 .path_join(assembly_name + ".dll"));
@@ -331,7 +321,7 @@ godot_plugins_initialize_fn initialize_hostfxr_and_godot_plugins(bool &r_runtime
 }
 
 godot_plugins_initialize_fn try_load_native_aot_library(void *&r_aot_dll_handle) {
-	String assembly_name = get_assembly_name();
+	String assembly_name = path::get_csharp_project_name();
 
 #if defined(WINDOWS_ENABLED)
 	String native_aot_so_path = GodotSharpDirs::get_api_assemblies_dir().path_join(assembly_name + ".dll");
@@ -476,11 +466,7 @@ void GDMono::_init_godot_api_hashes() {
 
 #ifdef TOOLS_ENABLED
 bool GDMono::_load_project_assembly() {
-	String assembly_name = GLOBAL_GET("dotnet/project/assembly_name");
-
-	if (assembly_name.is_empty()) {
-		assembly_name = ProjectSettings::get_singleton()->get_safe_project_name();
-	}
+	String assembly_name = path::get_csharp_project_name();
 
 	String assembly_path = GodotSharpDirs::get_res_temp_assemblies_dir()
 								   .path_join(assembly_name + ".dll");

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -231,4 +231,27 @@ String relative_to(const String &p_path, const String &p_relative_to) {
 
 	return relative_to_impl(path_abs_norm, relative_to_abs_norm);
 }
+
+String get_csharp_project_name() {
+	String name = ProjectSettings::get_singleton()->get_setting_with_override("dotnet/project/assembly_name");
+	if (name.is_empty()) {
+		name = ProjectSettings::get_singleton()->get_setting_with_override("application/config/name");
+		Vector<String> invalid_chars = Vector<String>({ //
+				// Windows reserved filename chars.
+				":", "*", "?", "\"", "<", ">", "|",
+				// Directory separators.
+				"/", "\\",
+				// Other chars that have been found to break assembly loading.
+				";", "'", "=", "," });
+		name = name.strip_edges();
+		for (int i = 0; i < invalid_chars.size(); i++) {
+			name = name.replace(invalid_chars[i], "-");
+		}
+	}
+	if (name.is_empty()) {
+		name = "UnnamedProject";
+	}
+	return name;
+}
+
 } // namespace path

--- a/modules/mono/utils/path_utils.h
+++ b/modules/mono/utils/path_utils.h
@@ -31,7 +31,6 @@
 #ifndef MONO_PATH_UTILS_H
 #define MONO_PATH_UTILS_H
 
-#include "core/string/string_builder.h"
 #include "core/string/ustring.h"
 
 namespace path {
@@ -58,6 +57,8 @@ String abspath(const String &p_path);
 String realpath(const String &p_path);
 
 String relative_to(const String &p_path, const String &p_relative_to);
+
+String get_csharp_project_name();
 } // namespace path
 
 #endif // MONO_PATH_UTILS_H


### PR DESCRIPTION
- Resolves https://github.com/godotengine/godot/pull/74479#discussion_r1126752744
- Fixes https://github.com/godotengine/godot/issues/75619
- Instead of just adding a native version, I got rid of the C# version entirely and replaced it with a call to the native version.
- ~The native version should probably be moved into the mono module, but it is used in ProjectSettings for managing the C# feature to projects, so I left it there.~
- Also made the function directly take the assembly_name setting into account, so that it properly works everywhere.