### PR TITLE
Set properties of ImageTexture3D when creating

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1232,6 +1232,12 @@ Error ImageTexture3D::create(Image::Format p_format, int p_width, int p_height, 
 		texture = tex;
 	}
 
+	format = p_format;
+	width = p_width;
+	height = p_height;
+	depth = p_depth;
+	mipmaps = p_mipmaps;
+
 	return OK;
 }
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/74062

These properties never got changed from the defaults. I ran into this while debugging another issue as I noticed that missing these properties had the side effect of breaking the editor preview information.

Testing with an RG8 texture of size 512x256x256:

_Image preview in 4.0 stable_
![Screenshot from 2023-03-06 14-59-25](https://user-images.githubusercontent.com/16521339/223275954-179377b2-6d78-4d58-9a7e-be7f004d5776.png)

_Image preview with this PR_
![Screenshot from 2023-03-06 14-58-49](https://user-images.githubusercontent.com/16521339/223275957-35b8af61-afb0-4e39-9da4-19e347ced270.png)

