### PR TITLE
Avoid overflow when calculating ptr address for 3D textures in RenderingDevice texture update

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -2530,7 +2530,7 @@ Error RenderingDeviceVulkan::_texture_update(RID p_texture, uint32_t p_layer, co
 
 		for (uint32_t z = 0; z < depth; z++) { // For 3D textures, depth may be > 0.
 
-			const uint8_t *read_ptr = read_ptr_mipmap + image_size * z / depth;
+			const uint8_t *read_ptr = read_ptr_mipmap + (image_size / depth) * z;
 
 			for (uint32_t y = 0; y < height; y += region_size) {
 				for (uint32_t x = 0; x < width; x += region_size) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/74173

``image_size * z`` could easily overflow with 3D textures even at modest sizes. For 2D textures z is always 0 so this never overflowed. This bug essentially breaks all 3D textures with a size larger than 256x256x256 with FORMAT_L8.

In the linked issue image size was ``33,554,432`` (W x H x D x 1bit) since all values were ``uint32_t``s this caused the calculation to overflow whenever z was a multiple of 64. With higher bit depths the overflow happens more frequently. Since ``z / depth`` is always less than one and ``image_size`` is always a multiple of ``depth`` we can swap the order of operations to keep the values within a manageable range.