### PR TITLE
Fixes gutter set width results in receiving only half of the desired size

### DIFF
--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -108,7 +108,7 @@ private:
 
 	/* Line numbers */
 	int line_number_gutter = -1;
-	int line_number_digits = 0;
+	int line_number_digits = 1;
 	String line_number_padding = " ";
 	Color line_number_color = Color(1, 1, 1);
 	void _line_number_draw_callback(int p_line, int p_gutter, const Rect2 &p_region);


### PR DESCRIPTION
Fixes: #74458

At the beginning, `CodeEdit::line_number_digits` holds the value 0. But in `CodeEdit::_text_changed()` the value start from 1:
https://github.com/godotengine/godot/blob/c82948af870e96bfc6c985dcc9bc256d4034e4da/scene/gui/code_edit.cpp#L3147