### PR TITLE
[3.x] Fix shadows when using 2 directional lights

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -3697,7 +3697,7 @@ void RasterizerSceneGLES2::render_shadow(RID p_light, RID p_shadow_atlas, int p_
 		} else if (directional_shadow.light_count == 2) {
 			light_instance->directional_rect = Rect2(0, 0, directional_shadow.size, directional_shadow.size / 2);
 			if (light_instance->light_directional_index == 1) {
-				light_instance->directional_rect.position.x += light_instance->directional_rect.size.x;
+				light_instance->directional_rect.position.y += light_instance->directional_rect.size.y;
 			}
 		} else { //3 and 4
 			light_instance->directional_rect = Rect2(0, 0, directional_shadow.size / 2, directional_shadow.size / 2);

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4721,7 +4721,7 @@ void RasterizerSceneGLES3::render_shadow(RID p_light, RID p_shadow_atlas, int p_
 			} else if (directional_shadow.light_count == 2) {
 				light_instance->directional_rect = Rect2(0, 0, directional_shadow.size, directional_shadow.size / 2);
 				if (light_instance->light_directional_index == 1) {
-					light_instance->directional_rect.position.x += light_instance->directional_rect.size.x;
+					light_instance->directional_rect.position.y += light_instance->directional_rect.size.y;
 				}
 			} else { //3 and 4
 				light_instance->directional_rect = Rect2(0, 0, directional_shadow.size / 2, directional_shadow.size / 2);


### PR DESCRIPTION
Currently, the viewport for the second light's shadows is calculated incorrectly, and thus no shadows are drawn during the shadow pass.

Fixes #74299

---

This PR was sponsored by Ramatak with 💚