### PR TITLE
Add missing handler for removing font sizes in Themes

### DIFF
--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -2952,6 +2952,10 @@ void ThemeTypeEditor::_item_remove_cbk(int p_data_type, String p_item_name) {
 				ur->add_undo_method(*edited_theme, "set_font", p_item_name, edited_type, Ref<Font>());
 			}
 		} break;
+		case Theme::DATA_TYPE_FONT_SIZE: {
+			ur->add_do_method(*edited_theme, "clear_font_size", p_item_name, edited_type);
+			ur->add_undo_method(*edited_theme, "set_font_size", p_item_name, edited_type, edited_theme->get_font_size(p_item_name, edited_type));
+		} break;
 		case Theme::DATA_TYPE_ICON: {
 			ur->add_do_method(*edited_theme, "clear_icon", p_item_name, edited_type);
 			if (edited_theme->has_icon(p_item_name, edited_type)) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/74377.

Seems to be a regression from https://github.com/godotengine/godot/pull/62108, where this specific block was removed. I don't see any particular reason for that, and every other piece of code handling font sizes in the theme editor is intact. So probably just a silly mistake. cc @bruvzg though.