### PR TITLE
Generate empty textures for theme icons if the SVG module is disabled

### DIFF
--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -86,6 +86,10 @@ static Ref<ImageTexture> generate_icon(int p_index) {
 	ImageLoaderSVG img_loader;
 	Error err = img_loader.create_image_from_string(img, default_theme_icons_sources[p_index], scale, upsample, HashMap<Color, Color>());
 	ERR_FAIL_COND_V_MSG(err != OK, Ref<ImageTexture>(), "Failed generating icon, unsupported or invalid SVG data in default theme.");
+#else
+	// If the SVG module is disabled, we can't really display the UI well, but at least we won't crash.
+	// 16 pixels is used as it's the most common base size for Godot icons.
+	img = Image::create_empty(16 * scale, 16 * scale, false, Image::FORMAT_RGBA8);
 #endif
 
 	return ImageTexture::create_from_image(img);


### PR DESCRIPTION
This fixes https://github.com/godotengine/godot/issues/66124, so the engine no longer crashes on load. Though without the module you wouldn't be able to use the default theme, or the editor.

It's completely unusable in the minimal build state, with every possible module disabled. I was not able to load into my sandbox project, though the Godot window remained responsive, albeit very laggy. It looked like it was loading something for a very very long time (perhaps shader cache?). I was able to load into the project manager, but naturally it looks like this:

![godot windows editor dev x86_64_2023-03-07_15-28-26](https://user-images.githubusercontent.com/11782833/223453180-8f07f25b-e85a-4412-83b4-de7ee7bee1eb.png)

Though at least it should be possible to disable the SVG module now for export templates, if you provide a complete theme with rasterized replacements for every texture and icon.