### PR TITLE
Fix buffer overrun in `CPUParticles3D` in `precision=double` builds

### DIFF
--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -1207,7 +1207,7 @@ void CPUParticles3D::_update_particle_data_buffer() {
 			ptr[10] = t.basis.rows[2][2];
 			ptr[11] = t.origin.z;
 		} else {
-			memset(ptr, 0, sizeof(Transform3D));
+			memset(ptr, 0, sizeof(float) * 12);
 		}
 
 		Color c = r[idx].color;


### PR DESCRIPTION
`ptr` are always `float`s so on `double` builds this line would clear 24 elements instead of 12. Normally this doesn't change anything, except that a few entries get cleared, just to be overwritten later / in the next iteration, but for the last element this zeros 16 bytes past the end of the valid data of the vector.