### PR TITLE
[TextServer] Make sure Freetype is enabled for ot-svg

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -73,7 +73,9 @@ using namespace godot;
 #endif
 
 #ifdef MODULE_SVG_ENABLED
+#ifdef MODULE_FREETYPE_ENABLED
 #include "thorvg_svg_in_ot.h"
+#endif
 #endif
 
 /*************************************************************************/

--- a/modules/text_server_adv/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_adv/thorvg_svg_in_ot.cpp
@@ -49,10 +49,11 @@ using namespace godot;
 #include "core/typedefs.h"
 #include "core/variant/variant.h"
 
-#include "modules/modules_enabled.gen.h" // For svg.
+#include "modules/modules_enabled.gen.h" // For svg, freetype.
 #endif
 
 #ifdef MODULE_SVG_ENABLED
+#ifdef MODULE_FREETYPE_ENABLED
 
 #include "thorvg_bounds_iterator.h"
 #include "thorvg_svg_in_ot.h"
@@ -284,4 +285,5 @@ SVG_RendererHooks *get_tvg_svg_in_ot_hooks() {
 	return &tvg_svg_in_ot_hooks;
 }
 
+#endif // MODULE_FREETYPE_ENABLED
 #endif // MODULE_SVG_ENABLED

--- a/modules/text_server_adv/thorvg_svg_in_ot.h
+++ b/modules/text_server_adv/thorvg_svg_in_ot.h
@@ -47,10 +47,11 @@ using namespace godot;
 #include "core/templates/hash_map.h"
 #include "core/typedefs.h"
 
-#include "modules/modules_enabled.gen.h" // For svg.
+#include "modules/modules_enabled.gen.h" // For svg, freetype.
 #endif
 
 #ifdef MODULE_SVG_ENABLED
+#ifdef MODULE_FREETYPE_ENABLED
 
 #include <freetype/freetype.h>
 #include <freetype/otsvg.h>
@@ -81,6 +82,7 @@ FT_Error tvg_svg_in_ot_render(FT_GlyphSlot p_slot, FT_Pointer *p_state);
 
 SVG_RendererHooks *get_tvg_svg_in_ot_hooks();
 
+#endif // MODULE_FREETYPE_ENABLED
 #endif // MODULE_SVG_ENABLED
 
 #endif // THORVG_SVG_IN_OT_H

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -66,7 +66,9 @@ using namespace godot;
 #endif
 
 #ifdef MODULE_SVG_ENABLED
+#ifdef MODULE_FREETYPE_ENABLED
 #include "thorvg_svg_in_ot.h"
+#endif
 #endif
 
 /*************************************************************************/

--- a/modules/text_server_fb/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_fb/thorvg_svg_in_ot.cpp
@@ -53,6 +53,7 @@ using namespace godot;
 #endif
 
 #ifdef MODULE_SVG_ENABLED
+#ifdef MODULE_FREETYPE_ENABLED
 
 #include "thorvg_bounds_iterator.h"
 #include "thorvg_svg_in_ot.h"
@@ -284,4 +285,5 @@ SVG_RendererHooks *get_tvg_svg_in_ot_hooks() {
 	return &tvg_svg_in_ot_hooks;
 }
 
+#endif // MODULE_FREETYPE_ENABLED
 #endif // MODULE_SVG_ENABLED

--- a/modules/text_server_fb/thorvg_svg_in_ot.h
+++ b/modules/text_server_fb/thorvg_svg_in_ot.h
@@ -47,10 +47,11 @@ using namespace godot;
 #include "core/templates/hash_map.h"
 #include "core/typedefs.h"
 
-#include "modules/modules_enabled.gen.h" // For svg.
+#include "modules/modules_enabled.gen.h" // For svg, freetype.
 #endif
 
 #ifdef MODULE_SVG_ENABLED
+#ifdef MODULE_FREETYPE_ENABLED
 
 #include <freetype/freetype.h>
 #include <freetype/otsvg.h>
@@ -81,6 +82,7 @@ FT_Error tvg_svg_in_ot_render(FT_GlyphSlot p_slot, FT_Pointer *p_state);
 
 SVG_RendererHooks *get_tvg_svg_in_ot_hooks();
 
+#endif // MODULE_FREETYPE_ENABLED
 #endif // MODULE_SVG_ENABLED
 
 #endif // THORVG_SVG_IN_OT_H


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Disabling Freetype but not SVG causes text_server_adv/_fb to fail to compile due to incorrect module detection, as ot-svg requires both.

Issue #74546 (this is not the only problem in that so not "fixed" necessarily)