### PR TITLE
Propagate errors when creating an OpenGL context fails in X11

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4873,7 +4873,9 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 
 #ifdef GLES3_ENABLED
 	if (gl_manager) {
-		visualInfo = gl_manager->get_vi(x11_display);
+		Error err;
+		visualInfo = gl_manager->get_vi(x11_display, err);
+		ERR_FAIL_COND_V_MSG(err != OK, INVALID_WINDOW_ID, "Can't acquire visual info from display.");
 		vi_selected = true;
 	}
 #endif

--- a/platform/linuxbsd/x11/gl_manager_x11.cpp
+++ b/platform/linuxbsd/x11/gl_manager_x11.cpp
@@ -83,8 +83,13 @@ int GLManager_X11::_find_or_create_display(Display *p_x11_display) {
 	d.context = memnew(GLManager_X11_Private);
 	d.context->glx_context = nullptr;
 
-	//Error err = _create_context(d);
-	_create_context(d);
+	Error err = _create_context(d);
+
+	if (err != OK) {
+		_displays.remove_at(new_display_id);
+		return -1;
+	}
+
 	return new_display_id;
 }
 
@@ -191,8 +196,14 @@ Error GLManager_X11::_create_context(GLDisplay &gl_display) {
 	return OK;
 }
 
-XVisualInfo GLManager_X11::get_vi(Display *p_display) {
-	return _displays[_find_or_create_display(p_display)].x_vi;
+XVisualInfo GLManager_X11::get_vi(Display *p_display, Error &r_error) {
+	int display_id = _find_or_create_display(p_display);
+	if (display_id < 0) {
+		r_error = FAILED;
+		return XVisualInfo();
+	}
+	r_error = OK;
+	return _displays[display_id].x_vi;
 }
 
 Error GLManager_X11::window_create(DisplayServer::WindowID p_window_id, ::Window p_window, Display *p_display, int p_width, int p_height) {
@@ -210,6 +221,10 @@ Error GLManager_X11::window_create(DisplayServer::WindowID p_window_id, ::Window
 	win.height = p_height;
 	win.x11_window = p_window;
 	win.gldisplay_id = _find_or_create_display(p_display);
+
+	if (win.gldisplay_id == -1) {
+		return FAILED;
+	}
 
 	// the display could be invalid .. check NYI
 	GLDisplay &gl_display = _displays[win.gldisplay_id];

--- a/platform/linuxbsd/x11/gl_manager_x11.h
+++ b/platform/linuxbsd/x11/gl_manager_x11.h
@@ -114,7 +114,7 @@ private:
 	Error _create_context(GLDisplay &gl_display);
 
 public:
-	XVisualInfo get_vi(Display *p_display);
+	XVisualInfo get_vi(Display *p_display, Error &r_error);
 	Error window_create(DisplayServer::WindowID p_window_id, ::Window p_window, Display *p_display, int p_width, int p_height);
 	void window_destroy(DisplayServer::WindowID p_window_id);
 	void window_resize(DisplayServer::WindowID p_window_id, int p_width, int p_height);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/74522

We silently ignored the error return by ``_create_context()`` so window initialization continued even when we failed to create an OpenGL 3.3 context. This PR propagates the error up the chain so that our existing error handling can properly stop initialization and alert the user. 

So now, instead of crashing, users will see:

![Screenshot from 2023-03-07 09-22-58](https://user-images.githubusercontent.com/16521339/223500518-5c7101f2-0269-4f31-9f3a-76cd3ee7bdb5.png)

