### PR TITLE
Update property keying state without a full Inspector rebuild

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3370,7 +3370,17 @@ void EditorInspector::set_keying(bool p_active) {
 		return;
 	}
 	keying = p_active;
-	update_tree();
+	_keying_changed();
+}
+
+void EditorInspector::_keying_changed() {
+	for (const KeyValue<StringName, List<EditorProperty *>> &F : editor_property_map) {
+		for (EditorProperty *E : F.value) {
+			if (E) {
+				E->set_keying(keying);
+			}
+		}
+	}
 }
 
 void EditorInspector::set_read_only(bool p_read_only) {

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -521,6 +521,8 @@ class EditorInspector : public ScrollContainer {
 	void _changed_callback();
 	void _edit_request_change(Object *p_object, const String &p_prop);
 
+	void _keying_changed();
+
 	void _filter_changed(const String &p_text);
 	void _parse_added_editors(VBoxContainer *current_vbox, EditorInspectorSection *p_section, Ref<EditorInspectorPlugin> ped);
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/74275. There is a race condition that leads to crash, because we are doing two updates at the same time. First, we resetting the dictionary which changes the property editor for that property. But we are also losing the only animation, so the keying status is also reset.

Currently, changing keying state leads to `update_tree` and a full rebuild. This doesn't seem necessary, so I added some code to directly refresh the keying status of each property editor. In the words of the wise KoBeWi, "It can't be this simple?" So please test for regressions. But I don't see why this would be problematic in principle.

In general we should aim to reduce the need for a complete tree rebuild for 4.1. We have a few cases (my favorite is theme updates) where we could just do targeted changes. This is one of them.

-----

There seems to be an issue with the animation editor related to the reported use case. If you hide the Animation tab, crash does not occur, which is good. But when you bring the tab back, the old animation is still displayed in the OptionButton at the top. It doesn't immediately err, but trying to add new animations throws 3 identical error messages, telling you that `old_animation_name` does not exist. It doesn't break anything, but it should be fixed.

But I'll leave it for the animation team to sort out, as it's not critical at the moment 🙃 