### PR TITLE
Prevent crashing on startup if project has scripted theme types

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -42,7 +42,6 @@
 
 #ifdef TOOLS_ENABLED
 #include "core/os/keyboard.h"
-#include "editor/bindings_generator.h"
 #include "editor/editor_internal_calls.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
@@ -101,13 +100,6 @@ void CSharpLanguage::init() {
 		class_db_api_to_json("user://class_db_api_editor.json", ClassDB::API_EDITOR);
 #endif
 	}
-#endif
-
-#if defined(TOOLS_ENABLED) && defined(DEBUG_METHODS_ENABLED)
-	// Generate the bindings here, before loading assemblies. The Godot assemblies
-	// may be missing if the glue wasn't generated yet in order to build them.
-	List<String> cmdline_args = OS::get_singleton()->get_cmdline_args();
-	BindingsGenerator::handle_cmdline_args(cmdline_args);
 #endif
 
 	GLOBAL_DEF("dotnet/project/assembly_name", "");


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/74267.

The crash happens because scripting languages are not ready, but we are trying to load their scripts and it fails for one reason or another. Changing the order like that seems safe to me, and the project now loads without issues both in editor and when running scenes.