### PR TITLE
Avoid copying CanvasTexture when updating proxy

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -832,6 +832,8 @@ void TextureStorage::texture_proxy_update(RID p_texture, RID p_proxy_to) {
 	tex->is_render_target = false;
 	tex->is_proxy = true;
 	tex->proxies.clear();
+	tex->canvas_texture = nullptr;
+	tex->tex_id = 0;
 	proxy_to->proxies.push_back(p_texture);
 }
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1193,6 +1193,9 @@ void TextureStorage::texture_proxy_update(RID p_texture, RID p_proxy_to) {
 		prev_tex->proxies.erase(p_texture);
 	}
 
+	// Copy canvas_texture so it doesn't leak.
+	CanvasTexture *canvas_texture = tex->canvas_texture;
+
 	*tex = *proxy_to;
 
 	tex->proxy_to = p_proxy_to;
@@ -1200,6 +1203,7 @@ void TextureStorage::texture_proxy_update(RID p_texture, RID p_proxy_to) {
 	tex->is_proxy = true;
 	tex->proxies.clear();
 	proxy_to->proxies.push_back(p_texture);
+	tex->canvas_texture = canvas_texture;
 
 	tex->rd_view.format_override = tex->rd_format;
 	tex->rd_texture = RD::get_singleton()->texture_create_shared(tex->rd_view, proxy_to->rd_texture);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/74233
Fixes: https://github.com/godotengine/godot/issues/65484
Fixes: https://github.com/godotengine/godot/issues/74562

The cause of the crash was a double free of the ``canvas_texture`` property of the GLES3 internal ``Texture``. 

``canvas_texture``s are allocated as needed when a non ``CanvasTexture`` is used as a texture in 2D rendering. 

https://github.com/godotengine/godot/blob/013a45706897af989703b944c7cd5f4f58a6c060/drivers/gles3/rasterizer_canvas_gles3.cpp#L2205-L2208

When the texture is freed, the ``canvas_texture`` is memdeleted. 
https://github.com/godotengine/godot/blob/013a45706897af989703b944c7cd5f4f58a6c060/drivers/gles3/storage/texture_storage.cpp#L703-L705

This works the same in OpenGL as it does with the RD renderer. The difference between the two is that in the OpenGL renderer, the proxy texture is only used to point at the original texture, while proxy textures in the RD renderer actually have their own resources (they use texture sharing internally). 

In OpenGL when the ``canvas_texture`` is created, it gets assigned to the actual texture (not to the proxy). In the RD renderer, the ``canvas_texture`` is assigned to the proxy directly.

The problem comes from ``texture_proxy_update()`` (which is called every frame by the ``AnimatedTexture``. 
https://github.com/godotengine/godot/blob/013a45706897af989703b944c7cd5f4f58a6c060/drivers/gles3/storage/texture_storage.cpp#L829

The contents of the original texture are copied into the proxy (because we want the format etc. to be copied over). This copies the reference to ``canvas_texture`` causing it to get freed both with the original texture is freed and when the proxy is freed. Setting the property to ``nullptr`` avoids this. This PR also sets ``tex_id`` to 0 for the same reason

The RD renderer avoids the issue because the property is only ever set on the proxy texture. However, on each call to ``texture_proxy_update`` the reference to the ``canvas_texture`` is lost. So each frame a new ``CanvasTexture`` is created causing a memory leak. We solve that by simply copying over the old ``CanvasTexture``
