### PR TITLE
Fix braces handling when parsing method arguments on project conversion

### DIFF
--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -1217,24 +1217,20 @@ Vector<String> ProjectConverter3To4::parse_arguments(const String &line) {
 	for (int current_index = 0; current_index < string_size; current_index++) {
 		char32_t character = line.get(current_index);
 		switch (character) {
-			case '(': {
+			case '(':
+			case '[':
+			case '{': {
 				parts_counter++;
 				if (parts_counter == 1 && !is_inside_string) {
 					start_part = current_index;
 				}
 				break;
 			};
-			case ')': {
+			case ')':
+			case '}': {
 				parts_counter--;
 				if (parts_counter == 0 && !is_inside_string) {
 					parts.append(line.substr(start_part + 1, current_index - start_part - 1));
-					start_part = current_index;
-				}
-				break;
-			};
-			case '[': {
-				parts_counter++;
-				if (parts_counter == 1 && !is_inside_string) {
 					start_part = current_index;
 				}
 				break;


### PR DESCRIPTION
This PR aims to fix #74171 when converting a Godot 3.x project to Godot 4.x by handling braces arguments like dictionaries.

Note: I forgot to add labels to this PR (it is my very first one). Could someone add the appropriate labels to the PR, please ?
This PR is about the project converter between 3.x and 4.x.