### PR TITLE
Add viewport override to 2D editor

### DIFF
--- a/editor/icons/ViewportOverride.svg
+++ b/editor/icons/ViewportOverride.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect width="12" height="10" x="2" y="3" fill="none" stroke="#e0e0e0" stroke-width="2" rx="1.425" ry="1.425"/></svg>

--- a/editor/scene/2d/abstract_polygon_2d_editor.cpp
+++ b/editor/scene/2d/abstract_polygon_2d_editor.cpp
@@ -367,11 +367,11 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 	}
 
 	if (mb.is_valid()) {
-		Transform2D xform = canvas_item_editor->get_canvas_transform() * _get_node()->get_screen_transform();
+		Transform2D xform = canvas_item_editor->get_canvas_transform() * CanvasItemEditor::get_canvas_item_transform(_get_node());
 
 		Vector2 gpoint = mb->get_position();
 		Vector2 cpoint = canvas_item_editor->snap_point(canvas_item_editor->get_canvas_transform().affine_inverse().xform(gpoint));
-		cpoint = _get_node()->get_screen_transform().affine_inverse().xform(cpoint);
+		cpoint = CanvasItemEditor::get_canvas_item_transform(_get_node()).affine_inverse().xform(cpoint);
 
 		if (mode == MODE_EDIT || (_is_line() && mode == MODE_CREATE)) {
 			if (mb->get_button_index() == MouseButton::LEFT) {
@@ -532,7 +532,7 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 
 		if (center_drag) {
 			Vector2 cpoint = canvas_item_editor->snap_point(canvas_item_editor->get_canvas_transform().affine_inverse().xform(gpoint));
-			cpoint = _get_node()->get_screen_transform().affine_inverse().xform(cpoint);
+			cpoint = CanvasItemEditor::get_canvas_item_transform(_get_node()).affine_inverse().xform(cpoint);
 			Vector2 delta = center_drag_origin - cpoint;
 
 			int n_polygons = _get_polygon_count();
@@ -550,7 +550,7 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 			center_drag_origin = cpoint;
 		} else if (edited_point.valid() && (wip_active || mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
 			Vector2 cpoint = canvas_item_editor->snap_point(canvas_item_editor->get_canvas_transform().affine_inverse().xform(gpoint));
-			cpoint = _get_node()->get_screen_transform().affine_inverse().xform(cpoint);
+			cpoint = CanvasItemEditor::get_canvas_item_transform(_get_node()).affine_inverse().xform(cpoint);
 
 			//Move the point in a single axis. Should only work when editing a polygon and while holding shift.
 			if (mode == MODE_EDIT && mm->is_shift_pressed()) {
@@ -642,7 +642,7 @@ void AbstractPolygon2DEditor::forward_canvas_draw_over_viewport(Control *p_overl
 		return;
 	}
 
-	Transform2D xform = canvas_item_editor->get_canvas_transform() * _get_node()->get_screen_transform();
+	Transform2D xform = canvas_item_editor->get_canvas_transform() * CanvasItemEditor::get_canvas_item_transform(_get_node());
 	// All polygon points are sharp, so use the sharp handle icon
 	const Ref<Texture2D> handle = get_editor_theme_icon(SNAME("EditorPathSharpHandle"));
 	const Ref<Texture2D> nhandle = get_editor_theme_icon(SNAME("EditorPathNullHandle"));
@@ -825,7 +825,7 @@ AbstractPolygon2DEditor::PosVertex AbstractPolygon2DEditor::closest_point(const 
 	const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
 
 	const int n_polygons = _get_polygon_count();
-	const Transform2D xform = canvas_item_editor->get_canvas_transform() * _get_node()->get_screen_transform();
+	const Transform2D xform = canvas_item_editor->get_canvas_transform() * CanvasItemEditor::get_canvas_item_transform(_get_node());
 
 	PosVertex closest;
 	real_t closest_dist = 1e10;
@@ -855,7 +855,7 @@ AbstractPolygon2DEditor::PosVertex AbstractPolygon2DEditor::closest_edge_point(c
 	const real_t eps2 = eps * eps;
 
 	const int n_polygons = _get_polygon_count();
-	const Transform2D xform = canvas_item_editor->get_canvas_transform() * _get_node()->get_screen_transform();
+	const Transform2D xform = canvas_item_editor->get_canvas_transform() * CanvasItemEditor::get_canvas_item_transform(_get_node());
 
 	PosVertex closest;
 	real_t closest_dist = 1e10;

--- a/editor/scene/2d/path_2d_editor_plugin.cpp
+++ b/editor/scene/2d/path_2d_editor_plugin.cpp
@@ -86,7 +86,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid()) {
-		Transform2D xform = canvas_item_editor->get_canvas_transform() * node->get_screen_transform();
+		Transform2D xform = canvas_item_editor->get_canvas_transform() * CanvasItemEditor::get_canvas_item_transform(node);
 
 		Vector2 gpoint = mb->get_position();
 		Vector2 cpoint = canvas_item_editor->snap_point(canvas_item_editor->get_canvas_transform().affine_inverse().xform(gpoint));
@@ -311,7 +311,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 		if (control_points_in_range == 2) {
 			control_points_in_range = 0;
 			Ref<Curve2D> curve = node->get_curve();
-			Transform2D xform = canvas_item_editor->get_canvas_transform() * node->get_screen_transform();
+			Transform2D xform = canvas_item_editor->get_canvas_transform() * CanvasItemEditor::get_canvas_item_transform(node);
 			Point2 relative = xform.affine_inverse().basis_xform(mm->get_relative());
 			real_t angle_in = relative.angle_to(curve->get_point_position(action_point - 1) - curve->get_point_position(action_point));
 			real_t angle_out = relative.angle_to(curve->get_point_position(action_point + 1) - curve->get_point_position(action_point));
@@ -331,7 +331,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 			// Handle Edge Follow
 			bool old_edge = on_edge;
 
-			Transform2D xform = canvas_item_editor->get_canvas_transform() * node->get_screen_transform();
+			Transform2D xform = canvas_item_editor->get_canvas_transform() * CanvasItemEditor::get_canvas_item_transform(node);
 			Vector2 gpoint = mm->get_position();
 
 			Ref<Curve2D> curve = node->get_curve();
@@ -376,7 +376,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
 		if (action != ACTION_NONE) {
 			// Handle point/control movement.
-			Transform2D xform = canvas_item_editor->get_canvas_transform() * node->get_screen_transform();
+			Transform2D xform = canvas_item_editor->get_canvas_transform() * CanvasItemEditor::get_canvas_item_transform(node);
 			Vector2 gpoint = mm->get_position();
 			Vector2 cpoint = canvas_item_editor->snap_point(canvas_item_editor->get_canvas_transform().affine_inverse().xform(gpoint));
 			cpoint = node->to_local(node->get_viewport()->get_popup_base_transform().affine_inverse().xform(cpoint));
@@ -431,7 +431,7 @@ void Path2DEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 		return;
 	}
 
-	Transform2D xform = canvas_item_editor->get_canvas_transform() * node->get_screen_transform();
+	Transform2D xform = canvas_item_editor->get_canvas_transform() * CanvasItemEditor::get_canvas_item_transform(node);
 
 	const Ref<Texture2D> path_sharp_handle = get_editor_theme_icon(SNAME("EditorPathSharpHandle"));
 	const Ref<Texture2D> path_smooth_handle = get_editor_theme_icon(SNAME("EditorPathSmoothHandle"));

--- a/editor/scene/2d/physics/cast_2d_editor_plugin.cpp
+++ b/editor/scene/2d/physics/cast_2d_editor_plugin.cpp
@@ -67,7 +67,7 @@ bool Cast2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_event) {
 		return false;
 	}
 
-	Transform2D xform = canvas_item_editor->get_canvas_transform() * node->get_screen_transform();
+	Transform2D xform = canvas_item_editor->get_canvas_transform() * CanvasItemEditor::get_canvas_item_transform(node);
 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT) {
@@ -106,7 +106,7 @@ bool Cast2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid() && pressed) {
 		Vector2 point = canvas_item_editor->snap_point(canvas_item_editor->get_canvas_transform().affine_inverse().xform(mm->get_position()));
-		point = node->get_screen_transform().affine_inverse().xform(point);
+		point = CanvasItemEditor::get_canvas_item_transform(node).affine_inverse().xform(point);
 
 		node->set("target_position", point);
 		canvas_item_editor->update_viewport();
@@ -127,7 +127,7 @@ void Cast2DEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 		return;
 	}
 
-	Transform2D gt = canvas_item_editor->get_canvas_transform() * node->get_screen_transform();
+	Transform2D gt = canvas_item_editor->get_canvas_transform() * CanvasItemEditor::get_canvas_item_transform(node);
 
 	const Ref<Texture2D> handle = get_editor_theme_icon(SNAME("EditorHandle"));
 	p_overlay->draw_texture(handle, gt.xform((Vector2)node->get("target_position")) - handle->get_size() / 2);

--- a/editor/scene/2d/physics/collision_shape_2d_editor_plugin.cpp
+++ b/editor/scene/2d/physics/collision_shape_2d_editor_plugin.cpp
@@ -362,7 +362,7 @@ bool CollisionShape2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_e
 	}
 
 	Ref<InputEventMouseButton> mb = p_event;
-	Transform2D xform = canvas_item_editor->get_canvas_transform() * node->get_screen_transform();
+	Transform2D xform = canvas_item_editor->get_canvas_transform() * CanvasItemEditor::get_canvas_item_transform(node);
 
 	if (mb.is_valid()) {
 		Vector2 gpoint = mb->get_position();
@@ -512,7 +512,7 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 		return;
 	}
 
-	Transform2D gt = canvas_item_editor->get_canvas_transform() * node->get_screen_transform();
+	Transform2D gt = canvas_item_editor->get_canvas_transform() * CanvasItemEditor::get_canvas_item_transform(node);
 
 	Ref<Texture2D> h = get_editor_theme_icon(SNAME("EditorHandle"));
 	Vector2 size = h->get_size() * 0.5;

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -36,6 +36,7 @@
 #include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "core/object/object.h"
 #include "core/os/keyboard.h"
 #include "core/string/translation_server.h"
 #include "editor/animation/animation_player_editor_plugin.h"
@@ -71,6 +72,7 @@
 #include "scene/gui/split_container.h"
 #include "scene/gui/subviewport_container.h"
 #include "scene/gui/texture_button.h"
+#include "scene/gui/texture_rect.h"
 #include "scene/gui/view_panner.h"
 #include "scene/main/canvas_layer.h"
 #include "scene/main/scene_tree.h"
@@ -355,7 +357,7 @@ void CanvasItemEditor::_snap_other_nodes(
 	};
 
 	if (ci && !exception) {
-		Transform2D ci_transform = ci->get_screen_transform();
+		Transform2D ci_transform = get_canvas_item_transform(ci);
 		if (std::fmod(ci_transform.get_rotation() - p_transform_to_snap.get_rotation(), (real_t)360.0) == 0.0) {
 			if (ci->_edit_use_rect()) {
 				Point2 begin = ci_transform.xform(ci->_edit_get_rect().get_position());
@@ -385,13 +387,13 @@ Point2 CanvasItemEditor::snap_point(Point2 p_target, unsigned int p_modes, unsig
 	real_t rotation = 0.0;
 
 	if (p_self_canvas_item) {
-		rotation = p_self_canvas_item->get_screen_transform().get_rotation();
+		rotation = get_canvas_item_transform(p_self_canvas_item).get_rotation();
 
 		// Parent sides and center
 		if ((is_snap_active && snap_node_parent && (p_modes & SNAP_NODE_PARENT)) || (p_forced_modes & SNAP_NODE_PARENT)) {
 			if (const Control *c = Object::cast_to<Control>(p_self_canvas_item)) {
-				Point2 begin = p_self_canvas_item->get_screen_transform().xform(_anchor_to_position(c, Point2(0, 0)));
-				Point2 end = p_self_canvas_item->get_screen_transform().xform(_anchor_to_position(c, Point2(1, 1)));
+				Point2 begin = get_canvas_item_transform(p_self_canvas_item).xform(_anchor_to_position(c, Point2(0, 0)));
+				Point2 end = get_canvas_item_transform(p_self_canvas_item).xform(_anchor_to_position(c, Point2(1, 1)));
 				_snap_if_closer_point(p_target, output, snap_target, begin, SNAP_TARGET_PARENT, rotation);
 				_snap_if_closer_point(p_target, output, snap_target, (begin + end) / 2.0, SNAP_TARGET_PARENT, rotation);
 				_snap_if_closer_point(p_target, output, snap_target, end, SNAP_TARGET_PARENT, rotation);
@@ -412,8 +414,8 @@ Point2 CanvasItemEditor::snap_point(Point2 p_target, unsigned int p_modes, unsig
 		// Self anchors
 		if ((is_snap_active && snap_node_anchors && (p_modes & SNAP_NODE_ANCHORS)) || (p_forced_modes & SNAP_NODE_ANCHORS)) {
 			if (const Control *c = Object::cast_to<Control>(p_self_canvas_item)) {
-				Point2 begin = p_self_canvas_item->get_screen_transform().xform(_anchor_to_position(c, Point2(c->get_anchor(SIDE_LEFT), c->get_anchor(SIDE_TOP))));
-				Point2 end = p_self_canvas_item->get_screen_transform().xform(_anchor_to_position(c, Point2(c->get_anchor(SIDE_RIGHT), c->get_anchor(SIDE_BOTTOM))));
+				Point2 begin = get_canvas_item_transform(p_self_canvas_item).xform(_anchor_to_position(c, Point2(c->get_anchor(SIDE_LEFT), c->get_anchor(SIDE_TOP))));
+				Point2 end = get_canvas_item_transform(p_self_canvas_item).xform(_anchor_to_position(c, Point2(c->get_anchor(SIDE_RIGHT), c->get_anchor(SIDE_BOTTOM))));
 				_snap_if_closer_point(p_target, output, snap_target, begin, SNAP_TARGET_SELF_ANCHORS, rotation);
 				_snap_if_closer_point(p_target, output, snap_target, end, SNAP_TARGET_SELF_ANCHORS, rotation);
 			}
@@ -422,8 +424,8 @@ Point2 CanvasItemEditor::snap_point(Point2 p_target, unsigned int p_modes, unsig
 		// Self sides
 		if ((is_snap_active && snap_node_sides && (p_modes & SNAP_NODE_SIDES)) || (p_forced_modes & SNAP_NODE_SIDES)) {
 			if (p_self_canvas_item->_edit_use_rect()) {
-				Point2 begin = p_self_canvas_item->get_screen_transform().xform(p_self_canvas_item->_edit_get_rect().get_position());
-				Point2 end = p_self_canvas_item->get_screen_transform().xform(p_self_canvas_item->_edit_get_rect().get_position() + p_self_canvas_item->_edit_get_rect().get_size());
+				Point2 begin = get_canvas_item_transform(p_self_canvas_item).xform(p_self_canvas_item->_edit_get_rect().get_position());
+				Point2 end = get_canvas_item_transform(p_self_canvas_item).xform(p_self_canvas_item->_edit_get_rect().get_position() + p_self_canvas_item->_edit_get_rect().get_size());
 				_snap_if_closer_point(p_target, output, snap_target, begin, SNAP_TARGET_SELF, rotation);
 				_snap_if_closer_point(p_target, output, snap_target, end, SNAP_TARGET_SELF, rotation);
 			}
@@ -432,10 +434,10 @@ Point2 CanvasItemEditor::snap_point(Point2 p_target, unsigned int p_modes, unsig
 		// Self center
 		if ((is_snap_active && snap_node_center && (p_modes & SNAP_NODE_CENTER)) || (p_forced_modes & SNAP_NODE_CENTER)) {
 			if (p_self_canvas_item->_edit_use_rect()) {
-				Point2 center = p_self_canvas_item->get_screen_transform().xform(p_self_canvas_item->_edit_get_rect().get_center());
+				Point2 center = get_canvas_item_transform(p_self_canvas_item).xform(p_self_canvas_item->_edit_get_rect().get_center());
 				_snap_if_closer_point(p_target, output, snap_target, center, SNAP_TARGET_SELF, rotation);
 			} else {
-				Point2 position = p_self_canvas_item->get_screen_transform().xform(Point2());
+				Point2 position = get_canvas_item_transform(p_self_canvas_item).xform(Point2());
 				_snap_if_closer_point(p_target, output, snap_target, position, SNAP_TARGET_SELF, rotation);
 			}
 		}
@@ -450,7 +452,7 @@ Point2 CanvasItemEditor::snap_point(Point2 p_target, unsigned int p_modes, unsig
 		}
 		if (p_self_canvas_item) {
 			exceptions.push_back(p_self_canvas_item);
-			to_snap_transform = p_self_canvas_item->get_screen_transform();
+			to_snap_transform = get_canvas_item_transform(p_self_canvas_item);
 		}
 
 		_snap_other_nodes(
@@ -513,6 +515,10 @@ real_t CanvasItemEditor::snap_angle(real_t p_target, real_t p_start) const {
 	} else {
 		return p_target;
 	}
+}
+
+Transform2D CanvasItemEditor::get_canvas_item_transform(const CanvasItem *p_item) {
+	return (singleton->_is_viewport_overridden() && p_item->get_viewport() == singleton->current_viewport) ? p_item->get_global_transform() : p_item->get_screen_transform();
 }
 
 void CanvasItemEditor::shortcut_input(const Ref<InputEvent> &p_ev) {
@@ -642,6 +648,21 @@ Rect2 CanvasItemEditor::_get_encompassing_rect(const Node *p_node) {
 	return rect;
 }
 
+Vector2 CanvasItemEditor::_get_screen_size() const {
+	if (!_is_viewport_overridden()) {
+		return Vector2(GLOBAL_GET("display/window/size/viewport_width"), GLOBAL_GET("display/window/size/viewport_height"));
+	}
+	SubViewport *svp = Object::cast_to<SubViewport>(current_viewport);
+	if (svp) {
+		return svp->get_size();
+	}
+	Window *w = Object::cast_to<Window>(current_viewport);
+	if (w) {
+		return w->get_size();
+	}
+	return Vector2();
+}
+
 void CanvasItemEditor::find_canvas_items_at_pos(const Point2 &p_pos, Node *p_node, Vector<SelectResult> &r_items, const Transform2D &p_parent_xform, const Transform2D &p_canvas_xform) {
 	if (!p_node) {
 		return;
@@ -653,7 +674,7 @@ void CanvasItemEditor::find_canvas_items_at_pos(const Point2 &p_pos, Node *p_nod
 	if (CanvasLayer *cl = Object::cast_to<CanvasLayer>(p_node)) {
 		xform = cl->get_transform();
 	} else if (Viewport *vp = Object::cast_to<Viewport>(p_node)) {
-		if (!vp->is_visible_subviewport()) {
+		if (!_is_usable_viewport(vp)) {
 			return;
 		}
 		xform = vp->get_popup_base_transform();
@@ -672,6 +693,10 @@ void CanvasItemEditor::find_canvas_items_at_pos(const Point2 &p_pos, Node *p_nod
 		} else {
 			find_canvas_items_at_pos(p_pos, p_node->get_child(i), r_items, Transform2D(), xform);
 		}
+	}
+
+	if (_is_viewport_overridden() && p_node->get_viewport() != current_viewport) {
+		return;
 	}
 
 	if (ci && ci->is_visible_in_tree()) {
@@ -756,7 +781,7 @@ void CanvasItemEditor::_find_canvas_items_in_rect(const Rect2 &p_rect, Node *p_n
 	if (CanvasLayer *cl = Object::cast_to<CanvasLayer>(p_node)) {
 		xform = cl->get_transform();
 	} else if (Viewport *vp = Object::cast_to<Viewport>(p_node)) {
-		if (!vp->is_visible_subviewport()) {
+		if (!_is_usable_viewport(vp)) {
 			return;
 		}
 		xform = vp->get_popup_base_transform();
@@ -840,7 +865,7 @@ List<CanvasItem *> CanvasItemEditor::_get_edited_canvas_items(bool p_retrieve_lo
 		if (ci) {
 			if (ci->is_visible_in_tree() && (p_retrieve_locked || !_is_node_locked(ci))) {
 				Viewport *vp = ci->get_viewport();
-				if (vp && !vp->is_visible_subviewport()) {
+				if (!_is_usable_viewport(vp)) {
 					continue;
 				}
 				CanvasItemEditorSelectedItem *se = editor_selection->get_node_editor_data<CanvasItemEditorSelectedItem>(ci);
@@ -912,7 +937,7 @@ void CanvasItemEditor::_save_canvas_item_state(const List<CanvasItem *> &p_canva
 			}
 
 			se->undo_state = ci->_edit_get_state();
-			se->pre_drag_xform = ci->get_screen_transform();
+			se->pre_drag_xform = get_canvas_item_transform(ci);
 			if (ci->_edit_use_rect()) {
 				se->pre_drag_rect = ci->_edit_get_rect();
 			} else {
@@ -1167,6 +1192,80 @@ void CanvasItemEditor::_reset_transform(TransformType p_type) {
 		}
 	}
 	undo_redo->commit_action();
+}
+
+void CanvasItemEditor::_set_viewport_override(Viewport *p_viewport) {
+	if (p_viewport && p_viewport == current_viewport) {
+		return;
+	}
+
+	const Callable update_size = callable_mp(this, &CanvasItemEditor::_update_viewport_size);
+	const Callable redraw = callable_mp((CanvasItem *)viewport, &CanvasItem::queue_redraw);
+	const Callable reset_override = callable_mp(this, &CanvasItemEditor::set_viewport_override).bind((Viewport *)nullptr);
+
+	if (current_viewport && _is_viewport_overridden()) {
+		current_viewport->disconnect("size_changed", update_size);
+		current_viewport->disconnect("size_changed", redraw);
+		current_viewport->disconnect("tree_exited", reset_override);
+		if (Object::cast_to<Window>(current_viewport)) {
+			current_viewport->disconnect("visibility_changed", reset_override);
+		}
+		current_viewport->emit_signal("editor_state_changed");
+	}
+
+	if (p_viewport && !_is_viewport_valid(p_viewport)) {
+		ERR_PRINT("The selected viewport is not valid for override.");
+		p_viewport = nullptr;
+	}
+
+	if (p_viewport) {
+		p_viewport->connect("size_changed", update_size);
+		p_viewport->connect("size_changed", redraw);
+		p_viewport->connect("tree_exited", reset_override);
+		if (Object::cast_to<Window>(p_viewport)) {
+			p_viewport->connect("visibility_changed", reset_override);
+		}
+		p_viewport->emit_signal("editor_state_changed");
+		scene_view_display->set_global_canvas_transform(EditorNode::get_singleton()->get_scene_root()->get_global_canvas_transform());
+	} else {
+		p_viewport = EditorNode::get_singleton()->get_scene_root();
+		p_viewport->set_global_canvas_transform(scene_view_display->get_global_canvas_transform());
+		scene_view_display->set_global_canvas_transform(Transform2D());
+	}
+
+	current_viewport = p_viewport;
+	scene_view->set_texture(p_viewport->get_texture());
+	_update_viewport_size();
+	viewport->queue_redraw();
+}
+
+void CanvasItemEditor::_update_viewport_size() {
+	EditorNode::get_singleton()->get_scene_root()->set_size(scene_tree->get_size());
+}
+
+bool CanvasItemEditor::_is_usable_viewport(const Viewport *p_viewport) const {
+	if (!p_viewport) {
+		return false;
+	}
+	if (_is_viewport_overridden()) {
+		return p_viewport == current_viewport;
+	}
+	return p_viewport == EditorNode::get_singleton()->get_scene_root() || p_viewport->is_visible_subviewport();
+}
+
+bool CanvasItemEditor::_is_viewport_valid(Viewport *p_viewport) const {
+	if (!p_viewport || !p_viewport->is_inside_tree()) {
+		return false;
+	}
+	Window *wnd = Object::cast_to<Window>(p_viewport);
+	if (wnd && !wnd->is_visible()) {
+		return false;
+	}
+	return true;
+}
+
+bool CanvasItemEditor::_is_viewport_overridden() const {
+	return current_viewport != EditorNode::get_singleton()->get_scene_root();
 }
 
 void CanvasItemEditor::_switch_theme_preview(int p_mode) {
@@ -1509,7 +1608,7 @@ bool CanvasItemEditor::_gui_input_pivot(const Ref<InputEvent> &p_event) {
 					new_pos = snap_point(drag_from, SNAP_OTHER_NODES | SNAP_GRID | SNAP_PIXEL, 0, nullptr, drag_selection);
 				}
 				for (CanvasItem *ci : drag_selection) {
-					ci->_edit_set_pivot(ci->get_screen_transform().affine_inverse().xform(new_pos));
+					ci->_edit_set_pivot(get_canvas_item_transform(ci).affine_inverse().xform(new_pos));
 				}
 
 				drag_type = DRAG_PIVOT;
@@ -1530,7 +1629,7 @@ bool CanvasItemEditor::_gui_input_pivot(const Ref<InputEvent> &p_event) {
 				new_pos = snap_point(drag_to, SNAP_OTHER_NODES | SNAP_GRID | SNAP_PIXEL);
 			}
 			for (CanvasItem *ci : drag_selection) {
-				ci->_edit_set_pivot(ci->get_screen_transform().affine_inverse().xform(new_pos));
+				ci->_edit_set_pivot(get_canvas_item_transform(ci).affine_inverse().xform(new_pos));
 			}
 			return true;
 		}
@@ -1600,9 +1699,9 @@ bool CanvasItemEditor::_gui_input_rotate(const Ref<InputEvent> &p_event) {
 					if (!Math::is_inf(temp_pivot.x) || !Math::is_inf(temp_pivot.y)) {
 						drag_rotation_center = temp_pivot;
 					} else if (ci->_edit_use_pivot()) {
-						drag_rotation_center = ci->get_screen_transform().xform(ci->_edit_get_pivot());
+						drag_rotation_center = get_canvas_item_transform(ci).xform(ci->_edit_get_pivot());
 					} else {
-						drag_rotation_center = ci->get_screen_transform().get_origin();
+						drag_rotation_center = get_canvas_item_transform(ci).get_origin();
 					}
 					_save_canvas_item_state(drag_selection);
 					return true;
@@ -1629,7 +1728,7 @@ bool CanvasItemEditor::_gui_input_rotate(const Ref<InputEvent> &p_event) {
 
 				ci->_edit_set_rotation(new_rotation);
 				if (!Math::is_inf(temp_pivot.x) || !Math::is_inf(temp_pivot.y)) {
-					Transform2D xform = ci->get_screen_transform() * ci->get_transform().affine_inverse();
+					Transform2D xform = get_canvas_item_transform(ci) * ci->get_transform().affine_inverse();
 					Vector2 radius = xform.xform(ci->_edit_get_position()) - temp_pivot;
 					radius = radius.rotated(new_rotation - prev_rotation);
 					ci->_edit_set_position(xform.affine_inverse().xform(temp_pivot + radius));
@@ -1692,7 +1791,7 @@ bool CanvasItemEditor::_gui_input_anchors(const Ref<InputEvent> &p_event) {
 
 					Rect2 anchor_rects[4];
 					for (int i = 0; i < 4; i++) {
-						anchor_pos[i] = (transform * control->get_screen_transform()).xform(_anchor_to_position(control, anchor_pos[i]));
+						anchor_pos[i] = (transform * get_canvas_item_transform(control)).xform(_anchor_to_position(control, anchor_pos[i]));
 						anchor_rects[i] = Rect2(anchor_pos[i], anchor_handle->get_size());
 						if (control->is_layout_rtl()) {
 							anchor_rects[i].position -= anchor_handle->get_size() * Vector2(real_t(i == 1 || i == 2), real_t(i <= 1));
@@ -1735,7 +1834,7 @@ bool CanvasItemEditor::_gui_input_anchors(const Ref<InputEvent> &p_event) {
 
 			drag_to = transform.affine_inverse().xform(m->get_position());
 
-			Transform2D xform = control->get_screen_transform().affine_inverse();
+			Transform2D xform = get_canvas_item_transform(control).affine_inverse();
 
 			Point2 previous_anchor;
 			previous_anchor.x = (drag_type == DRAG_ANCHOR_TOP_LEFT || drag_type == DRAG_ANCHOR_BOTTOM_LEFT) ? control->get_anchor(SIDE_LEFT) : control->get_anchor(SIDE_RIGHT);
@@ -1829,7 +1928,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 				CanvasItem *ci = selection.front()->get();
 				if (ci->_edit_use_rect() && _is_node_movable(ci)) {
 					Rect2 rect = ci->_edit_get_rect();
-					Transform2D xform = transform * ci->get_screen_transform();
+					Transform2D xform = transform * get_canvas_item_transform(ci);
 
 					const Vector2 endpoints[4] = {
 						xform.xform(rect.position),
@@ -1905,7 +2004,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 
 			drag_to = transform.affine_inverse().xform(m->get_position());
 
-			Transform2D xform = ci->get_screen_transform();
+			Transform2D xform = get_canvas_item_transform(ci);
 
 			Point2 drag_to_snapped_begin;
 			Point2 drag_to_snapped_end;
@@ -2030,7 +2129,7 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 					edit_transform = ci->_edit_get_transform();
 				}
 
-				Transform2D xform = transform * ci->get_screen_transform();
+				Transform2D xform = transform * get_canvas_item_transform(ci);
 				Transform2D unscaled_transform = (xform * ci->get_transform().affine_inverse() * edit_transform).orthonormalized();
 				Transform2D simple_xform;
 				if (use_local_space) {
@@ -2094,7 +2193,7 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 				edit_transform = drag_selection.front()->get()->_edit_get_transform();
 			}
 			for (CanvasItem *ci : drag_selection) {
-				Transform2D parent_xform = ci->get_screen_transform() * ci->get_transform().affine_inverse();
+				Transform2D parent_xform = get_canvas_item_transform(ci) * ci->get_transform().affine_inverse();
 				Transform2D unscaled_transform = (transform * parent_xform * edit_transform).orthonormalized();
 				Transform2D simple_xform;
 
@@ -2226,7 +2325,7 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 					drag_type = DRAG_MOVE;
 
 					CanvasItem *ci = selection.front()->get();
-					Transform2D parent_xform = ci->get_screen_transform() * ci->get_transform().affine_inverse();
+					Transform2D parent_xform = get_canvas_item_transform(ci) * ci->get_transform().affine_inverse();
 					Transform2D unscaled_transform = (transform * parent_xform * ci->_edit_get_transform()).orthonormalized();
 					Transform2D simple_xform;
 					if (use_local_space) {
@@ -2270,7 +2369,7 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 			drag_to = transform.affine_inverse().xform(m->get_position());
 			Point2 previous_pos;
 			if (drag_selection.size() == 1) {
-				Transform2D parent_xform = drag_selection.front()->get()->get_screen_transform() * drag_selection.front()->get()->get_transform().affine_inverse();
+				Transform2D parent_xform = get_canvas_item_transform(drag_selection.front()->get()) * drag_selection.front()->get()->get_transform().affine_inverse();
 				previous_pos = parent_xform.xform(drag_selection.front()->get()->_edit_get_position());
 			} else {
 				previous_pos = _get_encompassing_rect_from_list(drag_selection).position;
@@ -2279,7 +2378,7 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 			Point2 drag_delta = drag_to - drag_from;
 			if (drag_type == DRAG_MOVE_X || drag_type == DRAG_MOVE_Y) {
 				const CanvasItem *selected = drag_selection.front()->get();
-				Transform2D parent_xform = selected->get_screen_transform() * selected->get_transform().affine_inverse();
+				Transform2D parent_xform = get_canvas_item_transform(selected) * selected->get_transform().affine_inverse();
 				Transform2D unscaled_transform = (transform * parent_xform * selected->_edit_get_transform()).orthonormalized();
 				Transform2D simple_xform;
 				if (use_local_space) {
@@ -2308,7 +2407,7 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 			}
 
 			for (CanvasItem *ci : drag_selection) {
-				Transform2D parent_xform_inv = ci->get_transform() * ci->get_screen_transform().affine_inverse();
+				Transform2D parent_xform_inv = ci->get_transform() * get_canvas_item_transform(ci).affine_inverse();
 				ci->_edit_set_position(ci->_edit_get_position() + parent_xform_inv.basis_xform(new_pos - previous_pos));
 			}
 			return true;
@@ -2727,7 +2826,7 @@ bool CanvasItemEditor::_gui_input_hover(const Ref<InputEvent> &p_event) {
 			}
 
 			_HoverResult hover_result;
-			hover_result.position = ci->get_screen_transform().get_origin();
+			hover_result.position = get_canvas_item_transform(ci).get_origin();
 			hover_result.icon = EditorNode::get_singleton()->get_object_icon(ci);
 			hover_result.name = ci->get_name();
 
@@ -3058,6 +3157,11 @@ void CanvasItemEditor::_update_lock_and_group_button() {
 	group_button->set_disabled(!has_canvas_item);
 	ungroup_button->set_visible(all_group);
 	ungroup_button->set_disabled(!has_canvas_item);
+}
+
+void CanvasItemEditor::set_viewport_override(Viewport *p_viewport) {
+	_set_viewport_override(p_viewport);
+	_update_override_viewport_button(edited_viewport);
 }
 
 void CanvasItemEditor::set_cursor_shape_override(CursorShape p_shape) {
@@ -3563,7 +3667,7 @@ void CanvasItemEditor::_draw_ruler_tool() {
 }
 
 void CanvasItemEditor::_draw_control_anchors(Control *control) {
-	Transform2D xform = transform * control->get_screen_transform();
+	Transform2D xform = transform * get_canvas_item_transform(control);
 	RID ci = viewport->get_canvas_item();
 	if (tool == TOOL_SELECT && !Object::cast_to<Container>(control->get_parent())) {
 		// Compute the anchors
@@ -3600,7 +3704,7 @@ void CanvasItemEditor::_draw_control_anchors(Control *control) {
 }
 
 void CanvasItemEditor::_draw_control_helpers(Control *control) {
-	Transform2D xform = transform * control->get_screen_transform();
+	Transform2D xform = transform * get_canvas_item_transform(control);
 	if (tool == TOOL_SELECT && show_helpers && !Object::cast_to<Container>(control->get_parent())) {
 		// Draw the helpers
 		Color color_base = Color(0.8, 0.8, 0.8, 0.5);
@@ -3812,7 +3916,7 @@ void CanvasItemEditor::_draw_selection() {
 		}
 
 		bool item_locked = ci->has_meta("_edit_lock_");
-		Transform2D xform = transform * ci->get_screen_transform();
+		Transform2D xform = transform * get_canvas_item_transform(ci);
 
 		// Draw the selected items position / surrounding boxes
 		if (ci->_edit_use_rect()) {
@@ -3906,7 +4010,7 @@ void CanvasItemEditor::_draw_selection() {
 	if (!selection.is_empty() && transform_tool && show_transformation_gizmos) {
 		CanvasItem *ci = selection.front()->get();
 
-		Transform2D xform = transform * ci->get_screen_transform();
+		Transform2D xform = transform * get_canvas_item_transform(ci);
 		bool is_ctrl = Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL);
 		bool is_alt = Input::get_singleton()->is_key_pressed(Key::ALT);
 
@@ -4072,13 +4176,13 @@ void CanvasItemEditor::_draw_axis() {
 
 		Color area_axis_color = EDITOR_GET("editors/2d/viewport_border_color");
 
-		Size2 screen_size = Size2(GLOBAL_GET("display/window/size/viewport_width"), GLOBAL_GET("display/window/size/viewport_height"));
+		Size2 viewport_size = _get_screen_size();
 
 		Vector2 screen_endpoints[4] = {
 			transform.xform(Vector2(0, 0)),
-			transform.xform(Vector2(screen_size.width, 0)),
-			transform.xform(Vector2(screen_size.width, screen_size.height)),
-			transform.xform(Vector2(0, screen_size.height))
+			transform.xform(Vector2(viewport_size.width, 0)),
+			transform.xform(Vector2(viewport_size.width, viewport_size.height)),
+			transform.xform(Vector2(0, viewport_size.height))
 		};
 
 		for (int i = 0; i < 4; i++) {
@@ -4108,7 +4212,7 @@ void CanvasItemEditor::_draw_invisible_nodes_positions(Node *p_node, const Trans
 		parent_xform = Transform2D();
 		canvas_xform = cl->get_transform();
 	} else if (Viewport *vp = Object::cast_to<Viewport>(p_node)) {
-		if (!vp->is_visible_subviewport()) {
+		if (_is_usable_viewport(vp)) {
 			return;
 		}
 		parent_xform = Transform2D();
@@ -4119,7 +4223,7 @@ void CanvasItemEditor::_draw_invisible_nodes_positions(Node *p_node, const Trans
 		_draw_invisible_nodes_positions(p_node->get_child(i), parent_xform, canvas_xform);
 	}
 
-	if (show_position_gizmos && ci && !ci->_edit_use_rect() && (!editor_selection->is_selected(ci) || _is_node_locked(ci))) {
+	if (show_position_gizmos && ci && ci->get_viewport() == current_viewport && !ci->_edit_use_rect() && (!editor_selection->is_selected(ci) || _is_node_locked(ci))) {
 		Transform2D xform = transform * canvas_xform * parent_xform;
 
 		// Draw the node's position
@@ -4251,7 +4355,7 @@ void CanvasItemEditor::_draw_locks_and_groups(Node *p_node, const Transform2D &p
 		parent_xform = Transform2D();
 		canvas_xform = cl->get_transform();
 	} else if (Viewport *vp = Object::cast_to<Viewport>(p_node)) {
-		if (!vp->is_visible_subviewport()) {
+		if (!_is_usable_viewport(vp)) {
 			return;
 		}
 		parent_xform = Transform2D();
@@ -4285,7 +4389,11 @@ void CanvasItemEditor::_draw_viewport() {
 	transform = Transform2D();
 	transform.scale_basis(Size2(zoom, zoom));
 	transform.columns[2] = -view_offset * zoom;
-	EditorNode::get_singleton()->get_scene_root()->set_global_canvas_transform(transform);
+	if (_is_viewport_overridden()) {
+		scene_view_display->set_global_canvas_transform(transform);
+	} else {
+		current_viewport->set_global_canvas_transform(transform);
+	}
 
 	_draw_grid();
 	_draw_ruler_tool();
@@ -4337,6 +4445,7 @@ void CanvasItemEditor::_update_editor_settings() {
 	grid_snap_button->set_button_icon(get_editor_theme_icon(SNAME("SnapGrid")));
 	snap_config_menu->set_button_icon(get_editor_theme_icon(SNAME("GuiTabMenuHl")));
 	skeleton_menu->set_button_icon(get_editor_theme_icon(SNAME("Bone")));
+	override_viewport_button->set_button_icon(get_editor_theme_icon(SNAME("ViewportOverride")));
 	pan_button->set_button_icon(get_editor_theme_icon(SNAME("ToolPan")));
 	ruler_button->set_button_icon(get_editor_theme_icon(SNAME("Ruler")));
 	pivot_button->set_button_icon(get_editor_theme_icon(SNAME("EditPivot")));
@@ -4382,7 +4491,7 @@ void CanvasItemEditor::_update_editor_settings() {
 }
 
 void CanvasItemEditor::_project_settings_changed() {
-	EditorNode::get_singleton()->get_scene_root()->set_snap_controls_to_pixels(GLOBAL_GET("gui/common/snap_controls_to_pixels"));
+	current_viewport->set_snap_controls_to_pixels(GLOBAL_GET("gui/common/snap_controls_to_pixels"));
 }
 
 void CanvasItemEditor::_notification(int p_what) {
@@ -4397,6 +4506,10 @@ void CanvasItemEditor::_notification(int p_what) {
 			pivot_button->set_tooltip_text(TTR("Click to change object's pivot.") + "\n" + TTR("Shift: Set temporary pivot.") + "\n" + TTR("Click this button while holding Shift to put the temporary pivot in the center of the selected nodes.") + "\n" + show_list_tooltip);
 			pan_button->set_tooltip_text(TTR("You can also use Pan View shortcut (Space by default) to pan in any mode.") + "\n" + show_list_tooltip);
 			ruler_button->set_tooltip_text(TTR("LMB+Drag: Measure the distance between two points in 2D space.") + "\n" + show_list_tooltip);
+
+			if (_is_viewport_overridden()) {
+				_update_override_viewport_button(edited_viewport);
+			}
 		} break;
 
 		case NOTIFICATION_READY: {
@@ -4523,6 +4636,9 @@ void CanvasItemEditor::_selection_changed() {
 		temp_pivot = Vector2(Math::INF, Math::INF);
 		viewport->queue_redraw();
 	}
+	if (edited_viewport && editor_selection->get_selection().is_empty()) {
+		edit_viewport(nullptr);
+	}
 
 	// Check to redraw to clear anything drawn from visible selections if no selections are visible.
 	bool has_visible = false;
@@ -4562,6 +4678,11 @@ void CanvasItemEditor::edit(CanvasItem *p_canvas_item) {
 	}
 }
 
+void CanvasItemEditor::edit_viewport(Viewport *p_viewport) {
+	edited_viewport = p_viewport;
+	_update_override_viewport_button(p_viewport);
+}
+
 void CanvasItemEditor::_update_scrollbars() {
 	updating_scroll = true;
 
@@ -4574,7 +4695,7 @@ void CanvasItemEditor::_update_scrollbars() {
 	Size2 vmin = v_scroll->get_minimum_size();
 
 	// Get the visible frame.
-	Size2 screen_rect = Size2(GLOBAL_GET("display/window/size/viewport_width"), GLOBAL_GET("display/window/size/viewport_height"));
+	Size2 screen_rect = _get_screen_size();
 	Rect2 local_rect = Rect2(Point2(), viewport->get_size() - Size2(vmin.width, hmin.height));
 
 	// Calculate scrollable area.
@@ -4698,6 +4819,15 @@ void CanvasItemEditor::_button_toggle_grid_snap(bool p_status) {
 	emit_signal("grid_visibility_changed", is_grid_visible());
 }
 
+void CanvasItemEditor::_button_override_viewport(bool p_pressed) {
+	if (p_pressed) {
+		_set_viewport_override(edited_viewport);
+	} else {
+		_set_viewport_override(nullptr);
+	}
+	_update_override_viewport_button(edited_viewport);
+}
+
 void CanvasItemEditor::_button_tool_select(int p_index) {
 	if (drag_type != DRAG_NONE) {
 		_commit_drag();
@@ -4816,6 +4946,41 @@ void CanvasItemEditor::_prepare_view_menu() {
 	Node *root = EditorNode::get_singleton()->get_edited_scene();
 	bool has_guides = root && (root->has_meta("_edit_horizontal_guides_") || root->has_meta("_edit_vertical_guides_"));
 	popup->set_item_disabled(popup->get_item_index(CLEAR_GUIDES), !has_guides);
+}
+
+void CanvasItemEditor::_update_override_viewport_button(Viewport *p_viewport) {
+	const String override_message = vformat(TTR("Editor Viewport Override\nEditor viewport is overridden by \"%s\". Press to disable override."), current_viewport->get_name());
+	if (_is_viewport_valid(p_viewport)) {
+		override_viewport_button->set_disabled(false);
+		if (p_viewport == current_viewport) {
+			override_viewport_button->set_pressed_no_signal(true);
+			override_viewport_button->set_tooltip_text(override_message);
+		} else {
+			override_viewport_button->set_pressed_no_signal(false);
+			override_viewport_button->set_tooltip_text(TTRC("Editor Viewport Override\nMakes editor use the selected Viewport instead of the main viewport, allowing to edit nodes inside it."));
+		}
+	} else {
+		if (_is_viewport_overridden()) {
+			override_viewport_button->set_disabled(false);
+			override_viewport_button->set_pressed_no_signal(true);
+			override_viewport_button->set_tooltip_text(override_message);
+		} else {
+			override_viewport_button->set_disabled(true);
+			override_viewport_button->set_pressed_no_signal(false);
+			if (p_viewport) {
+				override_viewport_button->set_tooltip_text(TTRC("Editor Viewport Override\nThe selected Viewport is not suitable for overriding.\nSelect a SubViewport or a visible Window to allow overriding editor viewport."));
+			} else {
+				override_viewport_button->set_tooltip_text(TTRC("Editor Viewport Override\nNo Viewport node selected. Select one to allow overriding editor viewport."));
+			}
+		}
+	}
+}
+
+void CanvasItemEditor::_cleanup_scene() {
+	if (_is_viewport_overridden()) {
+		_set_viewport_override(nullptr);
+	}
+	viewport->queue_redraw();
 }
 
 void CanvasItemEditor::_popup_callback(int p_op) {
@@ -5508,6 +5673,11 @@ void CanvasItemEditor::set_state(const Dictionary &p_state) {
 	if (update_scrollbars) {
 		_update_scrollbars();
 	}
+
+	// Turn off viewport override when changing scenes etc.
+	_set_viewport_override(nullptr);
+	_update_override_viewport_button(nullptr);
+
 	viewport->queue_redraw();
 }
 
@@ -5533,6 +5703,7 @@ void CanvasItemEditor::clear() {
 			_update_oversampling();
 		}
 	}
+	edit_viewport(nullptr);
 }
 
 void CanvasItemEditor::add_control_to_menu_panel(Control *p_control) {
@@ -5612,7 +5783,7 @@ void CanvasItemEditor::focus_selection() {
 }
 
 void CanvasItemEditor::center_at(const Point2 &p_pos) {
-	Vector2 offset = viewport->get_size() / 2 - EditorNode::get_singleton()->get_scene_root()->get_global_canvas_transform().xform(p_pos);
+	Vector2 offset = viewport->get_size() / 2 - current_viewport->get_global_canvas_transform().xform(p_pos);
 	view_offset = (view_offset - offset / zoom).round();
 	update_viewport();
 }
@@ -5662,11 +5833,19 @@ CanvasItemEditor::CanvasItemEditor() {
 	viewport_scrollable->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	viewport_scrollable->connect(SceneStringName(draw), callable_mp(this, &CanvasItemEditor::_update_scrollbars));
 
-	SubViewportContainer *scene_tree = memnew(SubViewportContainer);
+	scene_tree = memnew(SubViewportContainer);
 	viewport_scrollable->add_child(scene_tree);
 	scene_tree->set_stretch(true);
 	scene_tree->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
-	scene_tree->add_child(EditorNode::get_singleton()->get_scene_root());
+	scene_tree->connect(SceneStringName(item_rect_changed), callable_mp(this, &CanvasItemEditor::_update_viewport_size));
+
+	scene_view_display = memnew(SubViewport);
+	scene_tree->add_child(scene_view_display);
+
+	scene_view = memnew(TextureRect);
+	scene_view_display->add_child(scene_view);
+	scene_view->set_clip_contents(true);
+	scene_view->add_child(EditorNode::get_singleton()->get_scene_root());
 
 	controls_vb = memnew(VBoxContainer);
 	controls_vb->set_begin(Point2(5, 5));
@@ -5739,6 +5918,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	viewport->connect(SceneStringName(draw), callable_mp(this, &CanvasItemEditor::_draw_viewport));
 	viewport->connect(SceneStringName(gui_input), callable_mp(this, &CanvasItemEditor::_gui_input_viewport));
 	viewport->connect(SceneStringName(focus_exited), callable_mp(panner.ptr(), &ViewPanner::release_pan_key));
+	_set_viewport_override(nullptr);
 
 	h_scroll = memnew(HScrollBar);
 	viewport->add_child(h_scroll);
@@ -5953,6 +6133,16 @@ CanvasItemEditor::CanvasItemEditor() {
 
 	main_menu_hbox->add_child(memnew(VSeparator));
 
+	override_viewport_button = memnew(Button);
+	override_viewport_button->set_theme_type_variation(SceneStringName(FlatButton));
+	override_viewport_button->set_toggle_mode(true);
+	override_viewport_button->set_disabled(true);
+	main_menu_hbox->add_child(override_viewport_button);
+	override_viewport_button->connect(SceneStringName(toggled), callable_mp(this, &CanvasItemEditor::_button_override_viewport));
+	_update_override_viewport_button(nullptr);
+
+	main_menu_hbox->add_child(memnew(VSeparator));
+
 	view_menu = memnew(MenuButton);
 	view_menu->set_flat(false);
 	view_menu->set_theme_type_variation("FlatMenuButton");
@@ -6141,10 +6331,11 @@ CanvasItemEditor *CanvasItemEditor::singleton = nullptr;
 
 void CanvasItemEditorPlugin::edit(Object *p_object) {
 	canvas_item_editor->edit(Object::cast_to<CanvasItem>(p_object));
+	canvas_item_editor->edit_viewport(Object::cast_to<Viewport>(p_object));
 }
 
 bool CanvasItemEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("CanvasItem");
+	return Object::cast_to<CanvasItem>(p_object) || Object::cast_to<SubViewport>(p_object) || Object::cast_to<Window>(p_object);
 }
 
 void CanvasItemEditorPlugin::make_visible(bool p_visible) {
@@ -6177,8 +6368,8 @@ void CanvasItemEditorPlugin::clear() {
 void CanvasItemEditorPlugin::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			connect("scene_changed", callable_mp((CanvasItem *)canvas_item_editor->get_viewport_control(), &CanvasItem::queue_redraw).unbind(1));
-			connect("scene_closed", callable_mp((CanvasItem *)canvas_item_editor->get_viewport_control(), &CanvasItem::queue_redraw).unbind(1));
+			connect("scene_changed", callable_mp(canvas_item_editor, &CanvasItemEditor::_cleanup_scene).unbind(1));
+			connect("scene_closed", callable_mp(canvas_item_editor, &CanvasItemEditor::_cleanup_scene).unbind(1));
 		} break;
 	}
 }

--- a/editor/scene/canvas_item_editor_plugin.h
+++ b/editor/scene/canvas_item_editor_plugin.h
@@ -48,7 +48,11 @@ class PanelContainer;
 class RichTextLabel;
 class StyleBoxTexture;
 class Timer;
+class SubViewport;
+class SubViewportContainer;
+class TextureRect;
 class ViewPanner;
+class Viewport;
 class VScrollBar;
 class VSeparator;
 class VSplitContainer;
@@ -203,6 +207,12 @@ private:
 	Tool tool = TOOL_SELECT;
 	Control *viewport = nullptr;
 	Control *viewport_scrollable = nullptr;
+	SubViewportContainer *scene_tree = nullptr;
+	SubViewport *scene_view_display = nullptr;
+	TextureRect *scene_view = nullptr;
+
+	Viewport *edited_viewport = nullptr;
+	Viewport *current_viewport = nullptr;
 
 	HScrollBar *h_scroll = nullptr;
 	VScrollBar *v_scroll = nullptr;
@@ -361,6 +371,7 @@ private:
 	Button *group_button = nullptr;
 	Button *ungroup_button = nullptr;
 
+	Button *override_viewport_button = nullptr;
 	MenuButton *view_menu = nullptr;
 	PopupMenu *grid_menu = nullptr;
 	PopupMenu *theme_menu = nullptr;
@@ -447,6 +458,13 @@ private:
 	void _on_grid_menu_id_pressed(int p_id);
 	void _reset_transform(TransformType p_type);
 	void _update_oversampling();
+
+	void _set_viewport_override(Viewport *p_viewport);
+	void _update_viewport_size();
+	bool _is_usable_viewport(const Viewport *p_viewport) const;
+	bool _is_viewport_valid(Viewport *p_viewport) const;
+	bool _is_viewport_overridden() const;
+	Vector2 _get_screen_size() const;
 
 public:
 	enum ThemePreviewMode {
@@ -550,7 +568,11 @@ private:
 	void _button_toggle_local_space(bool p_status);
 	void _button_toggle_smart_snap(bool p_status);
 	void _button_toggle_grid_snap(bool p_status);
+	void _button_override_viewport(bool p_pressed);
 	void _button_tool_select(int p_index);
+
+	void _update_override_viewport_button(Viewport *p_viewport);
+	void _cleanup_scene();
 
 	HSplitContainer *left_panel_split = nullptr;
 	HSplitContainer *right_panel_split = nullptr;
@@ -587,6 +609,7 @@ public:
 	real_t snap_angle(real_t p_target, real_t p_start = 0) const;
 
 	Transform2D get_canvas_transform() const { return transform; }
+	static Transform2D get_canvas_item_transform(const CanvasItem *p_item);
 
 	static CanvasItemEditor *get_singleton() { return singleton; }
 	Dictionary get_state() const;
@@ -605,6 +628,7 @@ public:
 	VSplitContainer *get_bottom_split();
 
 	Control *get_viewport_control() { return viewport; }
+	Viewport *get_current_viewport() { return current_viewport; }
 
 	Control *get_controls_container() { return controls_vb; }
 
@@ -619,10 +643,12 @@ public:
 	Vector2 get_grid_step() const { return grid_step; }
 
 	void edit(CanvasItem *p_canvas_item);
+	void edit_viewport(Viewport *p_viewport);
 
 	void focus_selection();
 	void center_at(const Point2 &p_pos);
 
+	void set_viewport_override(Viewport *p_viewport);
 	void set_cursor_shape_override(CursorShape p_shape = CURSOR_ARROW);
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -57,6 +57,7 @@
 #include "scene/gui/label.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/main/scene_tree.h"
+#include "scene/main/viewport.h"
 #include "scene/main/window.h"
 #include "scene/resources/packed_scene.h"
 
@@ -322,6 +323,8 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		} else {
 			_revoke_unique_name();
 		}
+	} else if (p_id == BUTTON_VIEWPORT) {
+		CanvasItemEditor::get_singleton()->set_viewport_override(nullptr);
 	}
 }
 
@@ -710,6 +713,10 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 		}
 		if (p_node->has_meta("_edit_group_")) {
 			p_item->add_button(0, get_editor_theme_icon(SNAME("Group")), BUTTON_GROUP, false, TTR("Children are not selectable.\nClick to make them selectable."));
+		}
+
+		if (_is_overriding_viewport(p_node)) {
+			p_item->add_button(0, get_editor_theme_icon(SNAME("ViewportOverride")), BUTTON_VIEWPORT, false, TTR("This viewport overrides the editor's viewport.\nClick to disable override."));
 		}
 
 		if (p_node->has_method("is_visible") && p_node->has_method("set_visible") && p_node->has_signal(SceneStringName(visibility_changed))) {
@@ -1472,6 +1479,14 @@ void SceneTreeEditor::_reset_visibility_drag() {
 	visibility_drag_start_pos = Vector2();
 	visibility_drag_start_node = ObjectID();
 	visibility_drag_nodes.clear();
+}
+
+bool SceneTreeEditor::_is_overriding_viewport(Node *p_node) const {
+	Viewport *vp = Object::cast_to<Viewport>(p_node);
+	if (!vp) {
+		return false;
+	}
+	return CanvasItemEditor::get_singleton()->get_current_viewport() == vp;
 }
 
 void SceneTreeEditor::_notification(int p_what) {

--- a/editor/scene/scene_tree_editor.h
+++ b/editor/scene/scene_tree_editor.h
@@ -57,6 +57,7 @@ class SceneTreeEditor : public Control {
 		BUTTON_GROUPS = 7,
 		BUTTON_PIN = 8,
 		BUTTON_UNIQUE = 9,
+		BUTTON_VIEWPORT = 10,
 	};
 
 	struct CachedNode {
@@ -210,6 +211,7 @@ class SceneTreeEditor : public Control {
 	void _queue_update_node_tooltip(Node *p_node, TreeItem *p_item);
 	void _tree_scroll_to_item(ObjectID p_item_id);
 	void _reset_visibility_drag();
+	bool _is_overriding_viewport(Node *p_node) const;
 
 	void _selection_changed();
 	Node *get_scene_node() const;

--- a/modules/navigation_2d/editor/navigation_link_2d_editor_plugin.cpp
+++ b/modules/navigation_2d/editor/navigation_link_2d_editor_plugin.cpp
@@ -67,7 +67,7 @@ bool NavigationLink2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_e
 	}
 
 	real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
-	Transform2D xform = canvas_item_editor->get_canvas_transform() * node->get_screen_transform();
+	Transform2D xform = canvas_item_editor->get_canvas_transform() * CanvasItemEditor::get_canvas_item_transform(node);
 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT) {
@@ -124,7 +124,7 @@ bool NavigationLink2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_e
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid()) {
 		Vector2 point = canvas_item_editor->snap_point(canvas_item_editor->get_canvas_transform().affine_inverse().xform(mm->get_position()));
-		point = node->get_screen_transform().affine_inverse().xform(point);
+		point = CanvasItemEditor::get_canvas_item_transform(node).affine_inverse().xform(point);
 
 		if (start_grabbed) {
 			node->set_start_position(point);
@@ -154,7 +154,7 @@ void NavigationLink2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 		return;
 	}
 
-	Transform2D gt = canvas_item_editor->get_canvas_transform() * node->get_screen_transform();
+	Transform2D gt = canvas_item_editor->get_canvas_transform() * CanvasItemEditor::get_canvas_item_transform(node);
 	Vector2 global_start_position = gt.xform(node->get_start_position());
 	Vector2 global_end_position = gt.xform(node->get_end_position());
 


### PR DESCRIPTION
This PR supersedes #61873 with alternative approach.
Instead of enabling other viewports and fighting with the editor to make it work properly, I added a button that allows to override the default 2D editor viewport with another one.

https://user-images.githubusercontent.com/2223172/223558255-e3a3c033-6b92-4f7d-b116-c56c1124a6a5.mp4

I have one unresolved problem though - the overriding viewport's size must match the editor's size to display properly. Right now I'm just displaying its content with a TextureRect, but maybe I should use some different approach, idk.
I didn't make much progress for some time, so I'm opening a draft.

Closes https://github.com/godotengine/godot-proposals/issues/2139
Closes https://github.com/godotengine/godot-proposals/issues/5422
Closes #39387