### PR TITLE
Make `get_buffer()`'s length optional

### DIFF
--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -469,9 +469,11 @@ uint64_t FileAccess::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 }
 
 Vector<uint8_t> FileAccess::get_buffer(int64_t p_length) const {
-	Vector<uint8_t> data;
+	if (p_length < 0) {
+		p_length = get_length() - get_position();
+	}
 
-	ERR_FAIL_COND_V_MSG(p_length < 0, data, "Length of buffer cannot be smaller than 0.");
+	Vector<uint8_t> data;
 	if (p_length == 0) {
 		return data;
 	}
@@ -828,7 +830,7 @@ void FileAccess::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_float"), &FileAccess::get_float);
 	ClassDB::bind_method(D_METHOD("get_double"), &FileAccess::get_double);
 	ClassDB::bind_method(D_METHOD("get_real"), &FileAccess::get_real);
-	ClassDB::bind_method(D_METHOD("get_buffer", "length"), (Vector<uint8_t>(FileAccess::*)(int64_t) const) & FileAccess::get_buffer);
+	ClassDB::bind_method(D_METHOD("get_buffer", "length"), (Vector<uint8_t>(FileAccess::*)(int64_t) const) & FileAccess::get_buffer, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("get_line"), &FileAccess::get_line);
 	ClassDB::bind_method(D_METHOD("get_csv_line", "delim"), &FileAccess::get_csv_line, DEFVAL(","));
 	ClassDB::bind_method(D_METHOD("get_as_text", "skip_cr"), &FileAccess::get_as_text, DEFVAL(false));

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -127,7 +127,7 @@ public:
 	Variant get_var(bool p_allow_objects = false) const;
 
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const; ///< get an array of bytes
-	Vector<uint8_t> get_buffer(int64_t p_length) const;
+	Vector<uint8_t> get_buffer(int64_t p_length = -1) const;
 	virtual String get_line() const;
 	virtual String get_token() const;
 	virtual Vector<String> get_csv_line(const String &p_delim = ",") const;

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -128,9 +128,10 @@
 		</method>
 		<method name="get_buffer" qualifiers="const">
 			<return type="PackedByteArray" />
-			<param index="0" name="length" type="int" />
+			<param index="0" name="length" type="int" default="-1" />
 			<description>
 				Returns next [param length] bytes of the file as a [PackedByteArray].
+				If [param length] is negative, the method will return the remaining file from the current position.
 			</description>
 		</method>
 		<method name="get_csv_line" qualifiers="const">


### PR DESCRIPTION
Very often when using `get_buffer()`, I find myself just wanting the whole file. This PR makes the length argument optional. When passing any negative value, instead of returning error, the function will try to use the remaining file.