### PR TITLE
Add `copy_file()` method to ZIPPacker

### DIFF
--- a/modules/zip/doc_classes/ZIPPacker.xml
+++ b/modules/zip/doc_classes/ZIPPacker.xml
@@ -35,6 +35,14 @@
 				It will fail if there is no open file.
 			</description>
 		</method>
+		<method name="copy_file">
+			<return type="int" enum="Error" />
+			<param index="0" name="source" type="String" />
+			<param index="1" name="path" type="String" />
+			<description>
+				Copies an external file at path [param source] to the archive. It's a shorthand that internally uses [method write_file] and writes the file's bytes.
+			</description>
+		</method>
 		<method name="open">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />

--- a/modules/zip/zip_packer.cpp
+++ b/modules/zip/zip_packer.cpp
@@ -86,10 +86,33 @@ Error ZIPPacker::close_file() {
 	return zipCloseFileInZip(zf) == ZIP_OK ? OK : FAILED;
 }
 
+Error ZIPPacker::copy_file(String p_source, String p_target_path) {
+	Error err = start_file(p_target_path);
+	if (err != OK) {
+		return err;
+	}
+
+	const PackedByteArray bytes = FileAccess::get_file_as_bytes(p_source, &err);
+	if (err != OK) {
+		close_file();
+		return err;
+	}
+
+	err = write_file(bytes);
+	if (err != OK) {
+		close_file();
+		return err;
+	}
+
+	err = close_file();
+	return err;
+}
+
 void ZIPPacker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("open", "path", "append"), &ZIPPacker::open, DEFVAL(Variant(APPEND_CREATE)));
 	ClassDB::bind_method(D_METHOD("start_file", "path"), &ZIPPacker::start_file);
 	ClassDB::bind_method(D_METHOD("write_file", "data"), &ZIPPacker::write_file);
+	ClassDB::bind_method(D_METHOD("copy_file", "source", "path"), &ZIPPacker::copy_file);
 	ClassDB::bind_method(D_METHOD("close_file"), &ZIPPacker::close_file);
 	ClassDB::bind_method(D_METHOD("close"), &ZIPPacker::close);
 

--- a/modules/zip/zip_packer.h
+++ b/modules/zip/zip_packer.h
@@ -59,6 +59,8 @@ public:
 	Error write_file(Vector<uint8_t> p_data);
 	Error close_file();
 
+	Error copy_file(String p_source, String p_target_path);
+
 	ZIPPacker();
 	~ZIPPacker();
 };


### PR DESCRIPTION
I think when packing a ZIP file, it's more common to add an existing file, not write a new one. This PR adds a `copy_file()` method to ZIPPacker, which is a shorthand for opening a file and writing its bytes to ZIP.