### PR TITLE
Fix bad OGG importer's name inside .import files during project conversion

### DIFF
--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -436,6 +436,8 @@ bool ProjectConverter3To4::convert() {
 					String &line = source_line.line;
 					if (line.contains("nodes/root_type=\"Spatial\"")) {
 						line = "nodes/root_type=\"Node3D\"";
+					} else if (line == "importer=\"ogg_vorbis\"") {
+						line = "importer=\"oggvorbisstr\"";
 					}
 				}
 			} else {


### PR DESCRIPTION
This PR fixes the initial scene loading popup error from #73393.
I've implemented a small fix based on the observations of @gotnospirit about the OGG Vorbis importer's name change between Godot 3.x and 4.x.
Thus changing each 

> importer="ogg_vorbis"

 line into 

> importer="oggvorbisstr"

 inside "*.import" files, while in the conversion process, seem to prevent the scene loading error from occurring.

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/73393