### PR TITLE
Refactor how `CowData` manages its allocations

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -35,6 +35,7 @@
 #include "core/os/memory.h"
 #include "core/templates/safe_refcount.h"
 
+#include <limits.h>
 #include <string.h>
 #include <type_traits>
 
@@ -46,13 +47,21 @@ class CharString;
 template <class T, class V>
 class VMap;
 
-SAFE_NUMERIC_TYPE_PUN_GUARANTEES(uint32_t)
+struct CowDataPrefix {
+	SafeNumeric<uint32_t> refcount;
+	int capacity;
+	int size;
+};
+static_assert(std::is_trivially_destructible<CowDataPrefix>::value, "");
 
-// Silence a false positive warning (see GH-52119).
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wplacement-new"
-#endif
+#define ERR_PROPAGATE(m_expr) \
+	if (true) {               \
+		Error err = m_expr;   \
+		if (unlikely(err)) {  \
+			return err;       \
+		}                     \
+	} else                    \
+		((void)0)
 
 template <class T>
 class CowData {
@@ -67,59 +76,56 @@ class CowData {
 private:
 	mutable T *_ptr = nullptr;
 
-	// internal helpers
+	// The values below are modeled as functions instead of constants
+	// because otherwise compilation would fail in cases where T is
+	// forward-declared (and therefore of unknown size and alignment).
 
-	_FORCE_INLINE_ SafeNumeric<uint32_t> *_get_refcount() const {
+	// Offset in bytes from the start of the prefix to the start of the first element.
+	static constexpr size_t prefix_offset() {
+		return ALIGN_AT(sizeof(CowDataPrefix), alignof(T));
+	}
+
+	// Maximum number of elements, so that:
+	// - Can be allocated (not bigger than half the address space).
+	// - Indices stay within the range of signed integers.
+	// - There's space for the allocator pre-padding and the prefix.
+	static constexpr int max_size() {
+		return MIN((size_t)INT_MAX, (((SIZE_MAX >> 1) - PAD_ALIGN - prefix_offset()) / sizeof(T)));
+	}
+
+	// Minimum capacity to allocate.
+	static constexpr int min_capacity() {
+		// TODO: Gather some data about typical usage patterns with small arrays and improve this.
+		// Current guess is preallocate a 32 byte buffer, but no more than 8 elements.
+		return CLAMP(32 / (int)sizeof(T), 1, 8);
+	}
+
+	_FORCE_INLINE_ CowDataPrefix *_get_prefix() const {
 		if (!_ptr) {
 			return nullptr;
 		}
 
-		return reinterpret_cast<SafeNumeric<uint32_t> *>(_ptr) - 2;
+		return reinterpret_cast<CowDataPrefix *>(reinterpret_cast<char *>(_ptr) - prefix_offset());
 	}
 
-	_FORCE_INLINE_ uint32_t *_get_size() const {
-		if (!_ptr) {
-			return nullptr;
-		}
-
-		return reinterpret_cast<uint32_t *>(_ptr) - 1;
+	static _FORCE_INLINE_ T *_get_data(CowDataPrefix *prefix) {
+		return reinterpret_cast<T *>(reinterpret_cast<char *>(prefix) + prefix_offset());
 	}
 
-	_FORCE_INLINE_ size_t _get_alloc_size(size_t p_elements) const {
-		return next_power_of_2(p_elements * sizeof(T));
-	}
-
-	_FORCE_INLINE_ bool _get_alloc_size_checked(size_t p_elements, size_t *out) const {
-#if defined(__GNUC__)
-		size_t o;
-		size_t p;
-		if (__builtin_mul_overflow(p_elements, sizeof(T), &o)) {
-			*out = 0;
-			return false;
-		}
-		*out = next_power_of_2(o);
-		if (__builtin_add_overflow(o, static_cast<size_t>(32), &p)) {
-			return false; // No longer allocated here.
-		}
-		return true;
-#else
-		// Speed is more important than correctness here, do the operations unchecked
-		// and hope for the best.
-		*out = _get_alloc_size(p_elements);
-		return true;
-#endif
-	}
-
-	void _unref(void *p_data);
+	void _unref(CowDataPrefix *p_data);
 	void _ref(const CowData *p_from);
 	void _ref(const CowData &p_from);
-	uint32_t _copy_on_write();
+	Error _copy_from(CowDataPrefix *p_from, int p_count, int p_capacity);
+	Error _realloc(int p_new_capacity);
+	Error _copy_on_write();
+	Error _reserve(int p_capacity);
+	bool _trim_capacity(int p_size, int &r_capacity);
 
 public:
 	void operator=(const CowData<T> &p_from) { _ref(p_from); }
 
 	_FORCE_INLINE_ T *ptrw() {
-		_copy_on_write();
+		ERR_FAIL_COND_V(_copy_on_write(), nullptr);
 		return _ptr;
 	}
 
@@ -128,9 +134,9 @@ public:
 	}
 
 	_FORCE_INLINE_ int size() const {
-		uint32_t *size = (uint32_t *)_get_size();
-		if (size) {
-			return *size;
+		CowDataPrefix *data = _get_prefix();
+		if (data) {
+			return data->size;
 		} else {
 			return 0;
 		}
@@ -141,13 +147,13 @@ public:
 
 	_FORCE_INLINE_ void set(int p_index, const T &p_elem) {
 		ERR_FAIL_INDEX(p_index, size());
-		_copy_on_write();
+		ERR_FAIL_COND(_copy_on_write());
 		_ptr[p_index] = p_elem;
 	}
 
 	_FORCE_INLINE_ T &get_m(int p_index) {
 		CRASH_BAD_INDEX(p_index, size());
-		_copy_on_write();
+		CRASH_COND(_copy_on_write());
 		return _ptr[p_index];
 	}
 
@@ -160,24 +166,42 @@ public:
 	template <bool p_ensure_zero = false>
 	Error resize(int p_size);
 
-	_FORCE_INLINE_ void remove_at(int p_index) {
-		ERR_FAIL_INDEX(p_index, size());
-		T *p = ptrw();
+	Error remove_at(int p_index) {
+		ERR_FAIL_INDEX_V(p_index, size(), ERR_INVALID_PARAMETER);
+
 		int len = size();
-		for (int i = p_index; i < len - 1; i++) {
-			p[i] = p[i + 1];
+
+		if (len == p_index + 1) {
+			// Remove the last element by simply resizing.
+			return resize(len - 1);
 		}
 
-		resize(len - 1);
+		T last = _ptr[len - 1];
+
+		ERR_PROPAGATE(resize(len - 1));
+		// After the resize (which changes the size) we will always be the only
+		// reference and no more copying is required.
+
+		T *p = _ptr;
+		for (int i = p_index; i < len - 2; i++) {
+			p[i] = p[i + 1];
+		}
+		p[len - 2] = last;
+
+		return OK;
 	}
 
 	Error insert(int p_pos, const T &p_val) {
 		ERR_FAIL_INDEX_V(p_pos, size() + 1, ERR_INVALID_PARAMETER);
-		resize(size() + 1);
+		ERR_PROPAGATE(resize(size() + 1));
+		// After the resize (which changes the size) we will always be the only
+		// reference and no more copying is required.
+
+		T *p = _ptr;
 		for (int i = (size() - 1); i > p_pos; i--) {
-			set(i, get(i - 1));
+			p[i] = p[i - 1];
 		}
-		set(p_pos, p_val);
+		p[p_pos] = p_val;
 
 		return OK;
 	}
@@ -192,148 +216,208 @@ public:
 };
 
 template <class T>
-void CowData<T>::_unref(void *p_data) {
-	if (!p_data) {
+void CowData<T>::_unref(CowDataPrefix *p_prefix) {
+	if (!p_prefix) {
 		return;
 	}
 
-	SafeNumeric<uint32_t> *refc = _get_refcount();
-
-	if (refc->decrement() > 0) {
-		return; // still in use
+	// Check, if the data is still in use or if it should be cleaned up now.
+	if (p_prefix->refcount.decrement() > 0) {
+		return;
 	}
-	// clean up
 
-	if (!std::is_trivially_destructible<T>::value) {
-		uint32_t *count = _get_size();
-		T *data = (T *)(count + 1);
+	// Call destructors, if necessary.
+	if constexpr (!std::is_trivially_destructible<T>::value) {
+		int count = p_prefix->size;
+		T *ptr = _get_data(p_prefix);
 
-		for (uint32_t i = 0; i < *count; ++i) {
-			// call destructors
-			data[i].~T();
+		for (int i = 0; i < count; ++i) {
+			ptr[i].~T();
 		}
 	}
 
-	// free mem
-	Memory::free_static((uint8_t *)p_data, true);
+	// Free the underlying memory.
+	Memory::free_static(p_prefix);
 }
 
 template <class T>
-uint32_t CowData<T>::_copy_on_write() {
-	if (!_ptr) {
-		return 0;
+Error CowData<T>::_copy_on_write() {
+	CowDataPrefix *prefix = _get_prefix();
+
+	if (!prefix) {
+		return OK;
 	}
 
-	SafeNumeric<uint32_t> *refc = _get_refcount();
+	if (unlikely(prefix->refcount.get() > 1)) {
+		return _copy_from(prefix, prefix->size, prefix->capacity);
+	}
 
-	uint32_t rc = refc->get();
-	if (unlikely(rc > 1)) {
-		/* in use by more than me */
-		uint32_t current_size = *_get_size();
+	return OK;
+}
 
-		uint32_t *mem_new = (uint32_t *)Memory::alloc_static(_get_alloc_size(current_size), true);
+// Allocates a new backing memory with the given capacity and size and
+// initialized with the given data (if any).
+template <class T>
+Error CowData<T>::_copy_from(CowDataPrefix *p_from, int p_size, int p_capacity) {
+	ERR_FAIL_COND_V(p_size < 0, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_capacity < 0, ERR_INVALID_PARAMETER);
 
-		new (mem_new - 2) SafeNumeric<uint32_t>(1); //refcount
-		*(mem_new - 1) = current_size; //size
+	CowDataPrefix *mem_new = (CowDataPrefix *)Memory::alloc_static(size_t(p_capacity) * sizeof(T) + prefix_offset());
+	ERR_FAIL_COND_V_MSG(!mem_new, ERR_OUT_OF_MEMORY, "Insufficient memory to allocate CowData");
 
-		T *_data = (T *)(mem_new);
+	new (&mem_new->refcount) SafeNumeric<uint32_t>(1);
+	mem_new->size = p_size;
+	mem_new->capacity = p_capacity;
 
-		// initialize new elements
-		if (std::is_trivially_copyable<T>::value) {
-			memcpy(mem_new, _ptr, current_size * sizeof(T));
+	T *_data = _get_data(mem_new);
 
+	if (p_from) {
+		DEV_ASSERT(p_from->size >= p_size);
+
+		T *ptr = _get_data(p_from);
+
+		// Copy the existing elements.
+		if constexpr (std::is_trivially_copyable<T>::value) {
+			memcpy(_data, ptr, p_size * sizeof(T));
 		} else {
-			for (uint32_t i = 0; i < current_size; i++) {
-				memnew_placement(&_data[i], T(_ptr[i]));
+			for (int i = 0; i < p_size; i++) {
+				memnew_placement(&_data[i], T(ptr[i]));
 			}
 		}
-
-		_unref(_ptr);
-		_ptr = _data;
-
-		rc = 1;
 	}
-	return rc;
+
+	_unref(_get_prefix());
+	_ptr = _data;
+	return OK;
+}
+
+// Resize the backing allocation to the provided capacity.
+template <class T>
+Error CowData<T>::_realloc(int p_new_capacity) {
+	ERR_FAIL_COND_V(p_new_capacity < 0, ERR_INVALID_PARAMETER);
+
+	CowDataPrefix *prefix = _get_prefix();
+
+	// realloc cannot be used if
+	// - copying the elements require using the copy constructor
+	// - no allocation exists yet (we would have to do more initializations here)
+	// - the existing allocation is shared with other CowData
+	if (!std::is_trivially_destructible_v<T> || !std::is_trivially_copy_constructible_v<T> || !prefix || prefix->refcount.get() > 1) {
+		return _copy_from(prefix, prefix ? prefix->size : 0, p_new_capacity);
+	}
+
+	CowDataPrefix *mem_new = (CowDataPrefix *)Memory::realloc_static(prefix, size_t(p_new_capacity) * sizeof(T) + prefix_offset());
+	ERR_FAIL_COND_V_MSG(!mem_new, ERR_OUT_OF_MEMORY, "Insufficient memory to allocate CowData");
+	mem_new->capacity = p_new_capacity;
+
+	_ptr = _get_data(mem_new);
+	return OK;
+}
+
+// Ensures that the backing memory has at least the given capacity.
+// This does not guarantee that the backing memory is exclusively owned when returning.
+template <class T>
+Error CowData<T>::_reserve(int p_capacity) {
+	ERR_FAIL_INDEX_V(p_capacity, max_size(), ERR_INVALID_PARAMETER);
+
+	CowDataPrefix *prefix = _get_prefix();
+
+	if (!prefix) {
+		return _copy_from(nullptr, 0, MAX(min_capacity(), p_capacity));
+	}
+
+	int capacity = prefix->capacity;
+
+	if (capacity >= p_capacity) {
+		return OK;
+	}
+
+	int new_capacity = CLAMP(prefix->capacity * 2, p_capacity, max_size());
+	return _copy_from(prefix, prefix->size, new_capacity);
+}
+
+// Returns true, if the backing memory should be trimmed when reducing to the
+// given size. r_capacity is set to the capacity that it should be reduced to or
+// the current capacity if it should not be reduced.
+template <class T>
+bool CowData<T>::_trim_capacity(int p_size, int &r_capacity) {
+	CowDataPrefix *prefix = _get_prefix();
+	if (!prefix) {
+		r_capacity = 0;
+		return false;
+	}
+
+	int new_capacity = prefix->capacity;
+
+	while (p_size < new_capacity / 4 && new_capacity > min_capacity()) {
+		new_capacity /= 2;
+	}
+
+	new_capacity = MAX(new_capacity, min_capacity());
+
+	r_capacity = new_capacity;
+
+	return new_capacity != prefix->capacity;
 }
 
 template <class T>
 template <bool p_ensure_zero>
 Error CowData<T>::resize(int p_size) {
-	ERR_FAIL_COND_V(p_size < 0, ERR_INVALID_PARAMETER);
+	ERR_FAIL_INDEX_V(p_size, max_size(), ERR_INVALID_PARAMETER);
 
-	int current_size = size();
+	CowDataPrefix *prefix = _get_prefix();
+
+	// Clean up the referenced memory when resizing to zero.
+	if (p_size == 0) {
+		_unref(prefix);
+		_ptr = nullptr;
+		return OK;
+	}
+
+	int current_size = prefix ? prefix->size : 0;
 
 	if (p_size == current_size) {
 		return OK;
 	}
 
-	if (p_size == 0) {
-		// wants to clean up
-		_unref(_ptr);
-		_ptr = nullptr;
-		return OK;
-	}
-
-	// possibly changing size, copy on write
-	uint32_t rc = _copy_on_write();
-
-	size_t current_alloc_size = _get_alloc_size(current_size);
-	size_t alloc_size;
-	ERR_FAIL_COND_V(!_get_alloc_size_checked(p_size, &alloc_size), ERR_OUT_OF_MEMORY);
-
 	if (p_size > current_size) {
-		if (alloc_size != current_alloc_size) {
-			if (current_size == 0) {
-				// alloc from scratch
-				uint32_t *ptr = (uint32_t *)Memory::alloc_static(alloc_size, true);
-				ERR_FAIL_COND_V(!ptr, ERR_OUT_OF_MEMORY);
-				*(ptr - 1) = 0; //size, currently none
-				new (ptr - 2) SafeNumeric<uint32_t>(1); //refcount
+		ERR_PROPAGATE(_reserve(p_size));
+		ERR_PROPAGATE(_copy_on_write());
 
-				_ptr = (T *)ptr;
+		// The backing memory may have been reallocated, so fetch the pointer again.
+		prefix = _get_prefix();
 
-			} else {
-				uint32_t *_ptrnew = (uint32_t *)Memory::realloc_static(_ptr, alloc_size, true);
-				ERR_FAIL_COND_V(!_ptrnew, ERR_OUT_OF_MEMORY);
-				new (_ptrnew - 2) SafeNumeric<uint32_t>(rc); //refcount
-
-				_ptr = (T *)(_ptrnew);
-			}
-		}
-
-		// construct the newly created elements
-
-		if (!std::is_trivially_constructible<T>::value) {
-			for (int i = *_get_size(); i < p_size; i++) {
+		// Construct the newly created elements.
+		if constexpr (!std::is_trivially_constructible<T>::value) {
+			for (int i = prefix->size; i < p_size; i++) {
 				memnew_placement(&_ptr[i], T);
 			}
 		} else if (p_ensure_zero) {
 			memset((void *)(_ptr + current_size), 0, (p_size - current_size) * sizeof(T));
 		}
 
-		*_get_size() = p_size;
+		prefix->size = p_size;
+		return OK;
+	} else {
+		DEV_ASSERT(p_size < current_size);
 
-	} else if (p_size < current_size) {
-		if (!std::is_trivially_destructible<T>::value) {
-			// deinitialize no longer needed elements
-			for (uint32_t i = p_size; i < *_get_size(); i++) {
-				T *t = &_ptr[i];
-				t->~T();
+		int capacity = 0;
+
+		if (_trim_capacity(p_size, capacity) || prefix->refcount.get() > 1) {
+			return _copy_from(prefix, p_size, capacity);
+		} else {
+			// Deinitialize no longer needed elements.
+			if constexpr (!std::is_trivially_destructible<T>::value) {
+				for (int i = p_size; i < prefix->size; i++) {
+					T *t = &_ptr[i];
+					t->~T();
+				}
 			}
+			prefix->size = p_size;
+
+			return OK;
 		}
-
-		if (alloc_size != current_alloc_size) {
-			uint32_t *_ptrnew = (uint32_t *)Memory::realloc_static(_ptr, alloc_size, true);
-			ERR_FAIL_COND_V(!_ptrnew, ERR_OUT_OF_MEMORY);
-			new (_ptrnew - 2) SafeNumeric<uint32_t>(rc); //refcount
-
-			_ptr = (T *)(_ptrnew);
-		}
-
-		*_get_size() = p_size;
 	}
-
-	return OK;
 }
 
 template <class T>
@@ -392,28 +476,28 @@ void CowData<T>::_ref(const CowData *p_from) {
 template <class T>
 void CowData<T>::_ref(const CowData &p_from) {
 	if (_ptr == p_from._ptr) {
-		return; // self assign, do nothing.
+		return; // Self assign, do nothing.
 	}
 
-	_unref(_ptr);
+	_unref(_get_prefix());
 	_ptr = nullptr;
 
 	if (!p_from._ptr) {
-		return; //nothing to do
+		return; // Nothing to do.
 	}
 
-	if (p_from._get_refcount()->conditional_increment() > 0) { // could reference
-		_ptr = p_from._ptr;
+	CowDataPrefix *prefix = p_from._get_prefix();
+	if (prefix->refcount.conditional_increment() > 0) {
+		// Only update _ptr if the refcount of that object was successfully incremented.
+		_ptr = _get_data(prefix);
 	}
 }
 
 template <class T>
 CowData<T>::~CowData() {
-	_unref(_ptr);
+	_unref(_get_prefix());
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+#undef ERR_PROPAGATE
 
 #endif // COWDATA_H

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -127,6 +127,11 @@ constexpr auto CLAMP(const T m_a, const T2 m_min, const T3 m_max) {
 	return m_a < m_min ? m_min : (m_a > m_max ? m_max : m_a);
 }
 
+template <typename T>
+constexpr auto ALIGN_AT(const T m_number, const T m_alignment) {
+	return ((m_number + (m_alignment - 1)) / m_alignment) * m_alignment;
+}
+
 // Generic swap template.
 #ifndef SWAP
 #define SWAP(m_x, m_y) __swap_tmpl((m_x), (m_y))


### PR DESCRIPTION
Context: I was looking into making CowData use 64-bit indices to solve the various crashes / issues caused by too large arrays, and found that the internal structure of CowData is fundamentally not suited for such a thing (and also really weird) so I went and reworked how the internal data storage is managed.

To the outside this PR shouldn't change any behavior, except that allocating somewhat larger arrays works now (and also on MSVC there are no longer cases where operations return OK but actually failed).

There are a few more improvements that could / should be done, but I stopped before feature creep completely overtook this.

~~Needs https://github.com/godotengine/godot/pull/74555 to pass CI.~~

- Use an explicit type for the data prefix to enable easier changes.
- Explicitly store the capacity instead of using the next power of two.
- If resizing to a significantly larger size (more 2x the current capacity), assume that the caller has just resized to their final size and don't allocate any excess capacity.
- Trim the capacity less aggressively to fix edge cases when repeatedly adding and removing elements causing extreme performance issues.
- Do not rely on overflow checked operations to determine the maximum size, to avoid crashes with some compilers when using too large sizes.
- On 64-bit system increase the the maximum size to 0x7ffffff0, generally by a factor of the size of the elements.
- On 32-bit system the maximum size remains limited by the size of the address space / memory, but in some cases it may still be possible to allocate larger arrays compared to before.
- Add a minimum capacity of 4 elements to remove some unnecessary reallocation for small arrays.
- Remove a few unnecessary potential copies when resizing, adding or removing elements.

---

What to do with the `ERR_PROPAGATE` macro?
I added this to check an `Error` return value and to return it from the current method if it is not OK, is this usefull for other places in the engine as well and should be added to the other ERR macros? Should I just inline that check everywhere? Or can it just stay as is?

---

What about alignment?
The old version of this just didn't care about alignment and just returned what it got from the allocator (which is malloc aligned + 16 bytes).
This assumes that the allocator pointer is aligned correctly and then offsets the first element by an multiple of the alignment, but I am not sure if the alignment is correct for types with large alignments, ie simd types. Should this be extended to ensure correct alignment for such types?

---

About the buffers in `max_size`:
The 64 bytes buffer to filling the entire address space with one array is arbitrary and not going to matter beyond preventing overflows when computing the size of the allocation as way more than that are going to be filled with godot, so such allocations are going to fail anyways.
The 15 indices buffer is similarly arbitrary and serves to prevent overflows when computing `size()+1` and similar things.
For reference in C# the maximum array size is `0x7fffffc7` bytes regardless of element size. (Buffer of 56).

---

About that performance hole in the current implementation:
When repeatedly increasing and decreasing the size of the allocation across a power of 2, on every operation the entire backing array will be reallocated, causing (in constructed examples 1000x+) slowdowns compared to doing the same with just a few more or less elements.
```gdscript
func _ready():
	perf(43689)
	perf(43690)
	perf(43691)
func perf(size):
	var start = Time.get_ticks_msec()
	var arr = []
	arr.resize(size)
	for i in range(10000):
		arr.push_back(null)
		arr.pop_back()
	var end = Time.get_ticks_msec()
	print("%d took %dms" % [size, end - start])
	pass
```

Before: (on a production build)
```
43689 took 2ms
43690 took 4467ms
43691 took 1ms
```
After: (on a debug build)
```
43689 took 9ms
43690 took 9ms
43691 took 9ms
```
(And no this didn't just move where this happens)

---

Allowed array sizes:
Previously (unpacked) arrays with 100 million + elements would fail to allocate / crash
Now all Arrays can have 2 billion elements (if you have the 50GB ram needed for that) and all failures will correctly return error codes.
Unfortunately allocating arrays with over 4 billion elements will appear to work, but the size actually gets truncated to 32bit and thus the result is actually smaller. ~~This happens at the gdscript to native boundary tho, so I am not sure if this can easily be fixed without breaking lots of things or actually making the index/size 64 bit large.~~ See https://github.com/godotengine/godot/pull/74676

---

Memory savings:
Because this PR doesn't over-allocate when resizing to the required maximum size, this saves quite a bit of memory.
https://github.com/Calinou/godot-reflection goes from 20MiB+9MiB (30% waste) to 20MiB+800KiB (4% waste)
See https://github.com/RedworkDE/godot/tree/resource-mon-cowdata and https://github.com/RedworkDE/godot/tree/resource-mon-cowdata-64 for adding a resource monitor for this.

---

Potential issues:
- This touches a pretty core element of the engine
- This tries to not over-allocate memory if possible, so buffer overruns are more likely to overrun the allocation entirely
- It is no longer possible to marshal all PackedArray instances into C# arrays, but this issue previously already existed into the other direction.
- ....

Potential advantages:
- Allows bigger arrays
- Paves the way for even bigger arrays
- Probably decreases the overall memory use a bit
- The whole code is no longer super weird
- ....

---

- *Bugsquad edit: This closes (author edit: not really) https://github.com/godotengine/godot/issues/54679.*