### PR TITLE
Fix crash when dumping extension API in a non-writable directory

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -1052,6 +1052,7 @@ void GDExtensionAPIDump::generate_extension_json_file(const String &p_path) {
 
 	String text = json->stringify(api, "\t", false) + "\n";
 	Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::WRITE);
+	ERR_FAIL_COND_MSG(fa.is_null(), vformat("Cannot open file '%s' for writing.", p_path));
 	fa->store_string(text);
 }
 

--- a/core/extension/make_interface_dumper.py
+++ b/core/extension/make_interface_dumper.py
@@ -27,6 +27,7 @@ class GDExtensionInterfaceDump {
     public:
         static void generate_gdextension_interface_file(const String &p_path) {
             Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::WRITE);
+            ERR_FAIL_COND_MSG(fa.is_null(), vformat("Cannot open file '%s' for writing.", p_path));
             CharString cs(gdextension_interface_dump);
             fa->store_buffer((const uint8_t *)cs.ptr(), cs.length());
         };


### PR DESCRIPTION
Fixes #74534