### PR TITLE
Don't mark all input as handled when subwindow is focused

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2789,6 +2789,10 @@ bool Viewport::_sub_windows_forward_input(const Ref<InputEvent> &p_event) {
 
 	gui.subwindow_focused->_window_input(ev);
 
+	if (gui.subwindow_focused) {
+		return gui.subwindow_focused->is_input_handled() || gui.subwindow_focused->is_handling_input_locally();
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
Currently, Godot will mark all input as handled as soon as a subwindow is focused, even if local input handling of that window is off. This causes issues with input handling like #61758.
