### PR TITLE
Fix Variant hashing for floats

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -2941,7 +2941,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 			return hash_one_uint64((uint64_t)_data._int);
 		} break;
 		case FLOAT: {
-			return hash_murmur3_one_float(_data._float);
+			return hash_murmur3_one_double(_data._float);
 		} break;
 		case STRING: {
 			return reinterpret_cast<const String *>(_data._mem)->hash();
@@ -3158,7 +3158,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 				}
 				return hash_fmix32(h);
 			} else {
-				return hash_murmur3_one_float(0.0);
+				return hash_murmur3_one_double(0.0);
 			}
 
 		} break;


### PR DESCRIPTION
Incorrectly hashed floats as single precision

Probably missed when migrating from `djb2` as the function there is `hash_djb2_one_float` despite taking a double.

Before `1.0000000000000002` and `1.0000000000000004` would hash to the same value, now they hash differently.

The change in `PACKED_FLOAT64_ARRAY` might be irrelevant but added it for completeness.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
