### PR TITLE
Don't unset local_coords on starting transform.

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1110,7 +1110,6 @@ void Node3DEditorViewport::_compute_edit(const Point2 &p_point) {
 	_edit.click_ray = _get_ray(p_point);
 	_edit.click_ray_pos = _get_ray_pos(p_point);
 	_edit.plane = TRANSFORM_VIEW;
-	spatial_editor->set_local_coords_enabled(false);
 	spatial_editor->update_transform_gizmo();
 	_edit.center = spatial_editor->get_gizmo_transform().origin;
 
@@ -4866,9 +4865,9 @@ void Node3DEditorViewport::update_transform(Point2 p_mousepos, bool p_shift) {
 
 void Node3DEditorViewport::finish_transform() {
 	spatial_editor->set_local_coords_enabled(_edit.original_local);
-	spatial_editor->update_transform_gizmo();
 	_edit.mode = TRANSFORM_NONE;
 	_edit.instant = false;
+	spatial_editor->update_transform_gizmo();
 	surface->queue_redraw();
 }
 


### PR DESCRIPTION
This fixes a bug introduced by 806425621cfa3daba3ba9f6b020726490a3152a4 (mentioned at https://github.com/godotengine/godot/issues/59392#issuecomment-1458888436), where dragging the gizmo no longer respected local transforms.

I'm not sure why I called set_local_coords_enabled(false) in _compute_edit. Removing this line seems to fix gizmo-dragging local transforms, without breaking anything else.

I also noticed that confirming a transform leaves the gizmo axis lines on the screen. This is fixed by calling update_transform_gizmo after clearing the edit mode/instant flags, so update_transform_gizmo knows not to render any axes.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
