### PR TITLE
Fix for AABB methods with wrong description

### DIFF
--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -188,7 +188,7 @@
 			<param index="0" name="from" type="Vector3" />
 			<param index="1" name="dir" type="Vector3" />
 			<description>
-				Returns [code]true[/code] if the given ray intersects with this [AABB]. Ray length is infinite.
+				Returns the point of intersection of the given ray with this [AABB] or [code]null[/code] if there is no intersection. Ray length is infinite.
 			</description>
 		</method>
 		<method name="intersects_segment" qualifiers="const">
@@ -196,7 +196,7 @@
 			<param index="0" name="from" type="Vector3" />
 			<param index="1" name="to" type="Vector3" />
 			<description>
-				Returns [code]true[/code] if the [AABB] intersects the line segment between [param from] and [param to].
+				Returns the point of intersection between [param from] and [param to] with this [AABB] or [code]null[/code] if there is no intersection.
 			</description>
 		</method>
 		<method name="is_equal_approx" qualifiers="const">


### PR DESCRIPTION
Those two particular methods in the AABB class have wrong descriptions.
This happens on godot master ~~and also on the 3.x branches .~~
~~If this one is is approved, I'll make a PR backporting the documentation change to 3.x as well.~~