### PR TITLE
Prevent cache corruption when saving resources in the editor

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -486,6 +486,7 @@ private:
 	Object *current = nullptr;
 
 	Ref<Resource> saving_resource;
+	HashSet<Ref<Resource>> saving_resources_in_path;
 
 	uint64_t update_spinner_step_msec = 0;
 	uint64_t update_spinner_step_frame = 0;

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1010,12 +1010,14 @@ void GDScript::_bind_methods() {
 }
 
 void GDScript::set_path(const String &p_path, bool p_take_over) {
-	String old_path = path;
 	if (is_root_script()) {
 		Script::set_path(p_path, p_take_over);
 	}
-	this->path = p_path;
+
+	String old_path = path;
+	path = p_path;
 	GDScriptCache::move_script(old_path, p_path);
+
 	for (KeyValue<StringName, Ref<GDScript>> &kv : subclasses) {
 		kv.value->set_path(p_path, p_take_over);
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/74069.

See my comment there for what's going on and how this is not a GDScript module issue. Basically, I make sure that the editor doesn't handle resource saving too soon and that in turn prevents all of the following issues. This is a hack, and something that should be better addressed when we are going to rework `EditorNode`, but it prevents this crash for now, and it should also prevent some of those "Another resource is loaded from path" errors sometimes, I guess.

The change in GDScript is just cosmetic, a remnant of my investigation. But I did feel it made the method a bit clearer, so I kept it.