### PR TITLE
GDScript: Add `Self` to reference a class from inside

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2481,7 +2481,7 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 						subclass = nullptr;
 						break;
 					} else {
-						Vector<StringName> extend_classes = subclass->extends;
+						Vector<GDScriptParser::IdentifierNode *> extend_classes = subclass->extends;
 
 						Ref<FileAccess> subfile = FileAccess::open(subclass->extends_path, FileAccess::READ);
 						if (subfile.is_null()) {
@@ -2511,7 +2511,7 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 								}
 
 								const GDScriptParser::ClassNode *inner_class = subclass->members[i].m_class;
-								if (inner_class->identifier->name == extend_classes[0]) {
+								if (inner_class->identifier->name == extend_classes[0]->name) {
 									extend_classes.remove_at(0);
 									found = true;
 									subclass = inner_class;
@@ -2525,7 +2525,7 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 						}
 					}
 				} else if (subclass->extends.size() == 1) {
-					*r_base_type = subclass->extends[0];
+					*r_base_type = subclass->extends[0]->name;
 					subclass = nullptr;
 				} else {
 					break;

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -131,7 +131,7 @@ class GDScriptAnalyzer {
 	Ref<GDScriptParserRef> get_parser_for(const String &p_path);
 	void reduce_identifier_from_base_set_class(GDScriptParser::IdentifierNode *p_identifier, GDScriptParser::DataType p_identifier_datatype);
 #ifdef DEBUG_ENABLED
-	bool is_shadowing(GDScriptParser::IdentifierNode *p_local, const String &p_context);
+	void is_shadowing(GDScriptParser::IdentifierNode *p_local, const String &p_context);
 #endif
 
 public:

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -329,6 +329,10 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				}
 			}
 
+			if (identifier == SNAME("Self")) {
+				return codegen.add_constant(codegen.script);
+			}
+
 			// Try globals.
 			if (GDScriptLanguage::get_singleton()->get_global_map().has(identifier)) {
 				// If it's an autoload singleton, we postpone to load it at runtime.

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3368,10 +3368,10 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 
 	if (context.current_class && context.current_class->extends.size() > 0) {
 		bool success = false;
-		ClassDB::get_integer_constant(context.current_class->extends[0], p_symbol, &success);
+		ClassDB::get_integer_constant(context.current_class->extends[0]->name, p_symbol, &success);
 		if (success) {
 			r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
-			r_result.class_name = context.current_class->extends[0];
+			r_result.class_name = context.current_class->extends[0]->name;
 			r_result.class_member = p_symbol;
 			return OK;
 		}

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -712,14 +712,14 @@ void GDScriptParser::parse_extends() {
 	if (!consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected superclass name after "extends".)")) {
 		return;
 	}
-	current_class->extends.push_back(previous.literal);
+	current_class->extends.push_back(parse_identifier());
 
 	while (match(GDScriptTokenizer::Token::PERIOD)) {
 		make_completion_context(COMPLETION_INHERIT_TYPE, current_class, chain_index++);
 		if (!consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected superclass name after ".".)")) {
 			return;
 		}
-		current_class->extends.push_back(previous.literal);
+		current_class->extends.push_back(parse_identifier());
 	}
 }
 
@@ -4479,7 +4479,7 @@ void GDScriptParser::TreePrinter::print_class(ClassNode *p_class) {
 			} else {
 				first = false;
 			}
-			push_text(p_class->extends[i]);
+			push_text(p_class->extends[i]->name);
 		}
 	}
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -710,7 +710,7 @@ public:
 		bool extends_used = false;
 		bool onready_used = false;
 		String extends_path;
-		Vector<StringName> extends; // List for indexing: extends A.B.C
+		Vector<IdentifierNode *> extends; // List for indexing: extends A.B.C
 		DataType base_type;
 		String fqcn; // Fully-qualified class name. Identifies uniquely any class in the project.
 #ifdef TOOLS_ENABLED

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -717,7 +717,7 @@ Dictionary ExtendGDScriptParser::dump_class_api(const GDScriptParser::ClassNode 
 	class_api["path"] = path;
 	Array extends_class;
 	for (int i = 0; i < p_class->extends.size(); i++) {
-		extends_class.append(String(p_class->extends[i]));
+		extends_class.append(String(p_class->extends[i]->name));
 	}
 	class_api["extends_class"] = extends_class;
 	class_api["extends_file"] = String(p_class->extends_path);

--- a/modules/gdscript/tests/scripts/analyzer/errors/extend_self_class_top.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/extend_self_class_top.gd
@@ -1,0 +1,4 @@
+extends Self
+
+func test():
+	print('not ok')

--- a/modules/gdscript/tests/scripts/analyzer/errors/extend_self_class_top.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/extend_self_class_top.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot extend "Self" in a non-nested class.

--- a/modules/gdscript/tests/scripts/analyzer/features/self_class_reference.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/self_class_reference.gd
@@ -1,0 +1,48 @@
+class_name SelfClassReference
+
+
+const Constant := Self
+
+class Extended extends Self:
+	pass
+
+static func static_func(instance: Self) -> Self:
+	return instance
+
+func instance_func() -> Self:
+	return self
+
+
+func test():
+	@warning_ignore("assert_always_true")
+	assert(Self == Constant)
+
+	@warning_ignore("assert_always_true")
+	assert(Self == SelfClassReference)
+
+	var extended := Extended.new()
+	assert(extended is Self)
+	assert(extended is Constant)
+	assert(extended is SelfClassReference)
+
+	var constructed := Self.new()
+	assert(constructed is Self)
+	assert(constructed is Constant)
+	assert(constructed is SelfClassReference)
+
+	var static_funced := Self.static_func(self)
+	assert(static_funced is Self)
+	assert(static_funced is Constant)
+	assert(static_funced is SelfClassReference)
+
+	var instance_funced := instance_func()
+	assert(instance_funced is Self)
+	assert(instance_funced is Constant)
+	assert(instance_funced is SelfClassReference)
+
+	var variable: Self = self
+	assert(variable is Self)
+	assert(variable is Constant)
+	assert(variable is SelfClassReference)
+
+	print('ok')

--- a/modules/gdscript/tests/scripts/analyzer/features/self_class_reference.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/self_class_reference.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok

--- a/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.gd
@@ -1,0 +1,13 @@
+var member: int = 0
+
+@warning_ignore("unused_variable")
+func test():
+	var Array := 'Array'
+	var Self := 'Self'
+	var Node := 'Node'
+	var is_same := 'is_same'
+	var sqrt := 'sqrt'
+	var member := 'member'
+	var reference := 'reference'
+
+	print('warn')

--- a/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.out
@@ -1,0 +1,30 @@
+GDTEST_OK
+>> WARNING
+>> Line: 5
+>> SHADOWED_GLOBAL_IDENTIFIER
+>> The variable 'Array' has the same name as a built-in type.
+>> WARNING
+>> Line: 6
+>> SHADOWED_GLOBAL_IDENTIFIER
+>> The variable 'Self' has the same name as a current class reference.
+>> WARNING
+>> Line: 7
+>> SHADOWED_GLOBAL_IDENTIFIER
+>> The variable 'Node' has the same name as a global class.
+>> WARNING
+>> Line: 8
+>> SHADOWED_GLOBAL_IDENTIFIER
+>> The variable 'is_same' has the same name as a built-in function.
+>> WARNING
+>> Line: 9
+>> SHADOWED_GLOBAL_IDENTIFIER
+>> The variable 'sqrt' has the same name as a built-in function.
+>> WARNING
+>> Line: 10
+>> SHADOWED_VARIABLE
+>> The local variable "member" is shadowing an already-declared variable at line 1.
+>> WARNING
+>> Line: 11
+>> SHADOWED_VARIABLE_BASE_CLASS
+>> The local variable "reference" is shadowing an already-declared method at the base class "RefCounted".
+warn


### PR DESCRIPTION
Add `Self` as a way to reference a class from inside its script.
```gdscript
class_name Global

const Constant := Self

class Extended extends Self:
  pass

static func static_func(instance: Self) -> Self:
  return instance

func instance_func() -> Self:
  return self

func test():
  assert(Self == Constant)
  assert(Self == Global)

  var extended := Extended.new()
  assert(extended is Self)

  var constructed := Self.new()
  assert(constructed is Self)

  var static_funced := Self.static_func(self)
  assert(static_funced is Self)

  var instance_funced := instance_func()
  assert(instance_funced is Self)

  var variable: Self = self
  assert(variable is Self)
```

While at it converted `extends` in `ClassNode` from `Vector<StringName>` to `Vector<IdentifierNode *>` - for better error placement.

And in `is_shadowing` removed bool return type and added a check for shadowing built-in types (`var Array := 3`, such check was done only for members before).

Implements proposal [#391](https://github.com/godotengine/godot-proposals/issues/391).

This is a simple implementation and `Self` here always points to the class where it is used, but it does not change its meaning with inheritance:
```gdscript
class A:
  static func create() -> Self:
    return Self.new()
    
class B extends A:
  pass
  
func _ready():
  var x := B.create()
```
Here `x` will be `A`, not `B`. I think that maybe it is desirable for it to be `B` - to match context dependent behavior of (potential future) type `self`. In that case there is a need for a separate name for simple type presented here. 

_Production edit: closes https://github.com/godotengine/godot-proposals/issues/391_