### PR TITLE
Code style improvements to text_edit and related

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -498,7 +498,7 @@
 			<return type="String" />
 			<param index="0" name="caret_index" type="int" default="-1" />
 			<description>
-				Returns the text inside the selection.
+				Returns the text inside the selection of a caret, or all the carets if [param caret_index] is its default value [code]-1[/code].
 			</description>
 		</method>
 		<method name="get_selection_column" qualifiers="const">
@@ -1375,7 +1375,7 @@
 			Select whole words as if the user double clicked.
 		</constant>
 		<constant name="SELECTION_MODE_LINE" value="4" enum="SelectionMode">
-			Select whole lines as if the user tripped clicked.
+			Select whole lines as if the user triple clicked.
 		</constant>
 		<constant name="LINE_WRAPPING_NONE" value="0" enum="LineWrappingMode">
 			Line wrapping is disabled.

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -196,7 +196,8 @@ void FindReplaceBar::_replace() {
 	int search_text_len = get_search_text().length();
 
 	text_editor->begin_complex_operation();
-	if (selection_enabled && is_selection_only()) { // To restrict search_current() to selected region
+	if (selection_enabled && is_selection_only()) {
+		// Restrict search_current() to selected region.
 		text_editor->set_caret_line(selection_begin.width, false, true, 0, 0);
 		text_editor->set_caret_column(selection_begin.height, true, 0);
 	}
@@ -210,7 +211,8 @@ void FindReplaceBar::_replace() {
 			Point2i match_to(result_line, result_col + search_text_len);
 			if (!(match_from < selection_begin || match_to > selection_end)) {
 				text_editor->insert_text_at_caret(repl_text, 0);
-				if (match_to.x == selection_end.x) { // Adjust selection bounds if necessary
+				if (match_to.x == selection_end.x) {
+					// Adjust selection bounds if necessary.
 					selection_end.y += repl_text.length() - search_text_len;
 				}
 			}
@@ -224,7 +226,7 @@ void FindReplaceBar::_replace() {
 	needs_to_count_results = true;
 
 	if (selection_enabled && is_selection_only()) {
-		// Reselect in order to keep 'Replace' restricted to selection
+		// Reselect in order to keep 'Replace' restricted to selection.
 		text_editor->select(selection_begin.x, selection_begin.y, selection_end.x, selection_end.y, 0);
 	} else {
 		text_editor->deselect(0);
@@ -274,7 +276,7 @@ void FindReplaceBar::_replace_all() {
 
 	if (search_current()) {
 		do {
-			// replace area
+			// Replace area.
 			Point2i match_from(result_line, result_col);
 			Point2i match_to(result_line, result_col + search_text_len);
 
@@ -698,7 +700,7 @@ FindReplaceBar::FindReplaceBar() {
 	hbc_option_replace = memnew(HBoxContainer);
 	vbc_option->add_child(hbc_option_replace);
 
-	// search toolbar
+	// Search toolbar
 	search_text = memnew(LineEdit);
 	vbc_lineedit->add_child(search_text);
 	search_text->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
@@ -733,7 +735,7 @@ FindReplaceBar::FindReplaceBar() {
 	whole_words->set_focus_mode(FOCUS_NONE);
 	whole_words->connect("toggled", callable_mp(this, &FindReplaceBar::_search_options_changed));
 
-	// replace toolbar
+	// Replace toolbar
 	replace_text = memnew(LineEdit);
 	vbc_lineedit->add_child(replace_text);
 	replace_text->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
@@ -889,7 +891,7 @@ void CodeTextEditor::_line_col_changed() {
 	int positional_column = 0;
 	for (int i = 0; i < text_editor->get_caret_column(); i++) {
 		if (line[i] == '\t') {
-			positional_column += text_editor->get_indent_size(); //tab size
+			positional_column += text_editor->get_indent_size(); // Tab size
 		} else {
 			positional_column += 1;
 		}
@@ -1127,8 +1129,7 @@ void CodeTextEditor::insert_final_newline() {
 
 	String line = text_editor->get_line(final_line);
 
-	//length 0 means it's already an empty line,
-	//no need to add a newline
+	// Length 0 means it's already an empty line, no need to add a newline.
 	if (line.length() > 0 && !line.ends_with("\n")) {
 		text_editor->begin_complex_operation();
 
@@ -1305,11 +1306,11 @@ void CodeTextEditor::move_lines_up() {
 
 	Vector<int> caret_edit_order = text_editor->get_caret_index_edit_order();
 
-	// Lists of carets representing each group
+	// Lists of carets representing each group.
 	Vector<Vector<int>> caret_groups;
 	Vector<Pair<int, int>> group_borders;
 
-	// Search for groups of carets and their selections residing on the same lines
+	// Search for groups of carets and their selections residing on the same lines.
 	for (int i = 0; i < caret_edit_order.size(); i++) {
 		int c = caret_edit_order[i];
 
@@ -1333,7 +1334,7 @@ void CodeTextEditor::move_lines_up() {
 			}
 			group_border.first = next_start_pos;
 			new_group.push_back(c_next);
-			// If the last caret is added to the current group there is no need to process it again
+			// If the last caret is added to the current group there is no need to process it again.
 			if (j + 1 == caret_edit_order.size() - 1) {
 				i++;
 			}
@@ -1347,12 +1348,12 @@ void CodeTextEditor::move_lines_up() {
 			continue;
 		}
 
-		// If the group starts overlapping with the upper group don't move it
+		// If the group starts overlapping with the upper group don't move it.
 		if (i < group_borders.size() - 1 && group_borders[i].first - 1 <= group_borders[i + 1].second) {
 			continue;
 		}
 
-		// We have to remember caret positions and selections prior to line swapping
+		// We have to remember caret positions and selections prior to line swapping.
 		Vector<Vector<int>> caret_group_parameters;
 
 		for (int j = 0; j < caret_groups[i].size(); j++) {
@@ -1400,11 +1401,11 @@ void CodeTextEditor::move_lines_down() {
 
 	Vector<int> caret_edit_order = text_editor->get_caret_index_edit_order();
 
-	// Lists of carets representing each group
+	// Lists of carets representing each group.
 	Vector<Vector<int>> caret_groups;
 	Vector<Pair<int, int>> group_borders;
 	Vector<int> group_border_ends;
-	// Search for groups of carets and their selections residing on the same lines
+	// Search for groups of carets and their selections residing on the same lines.
 	for (int i = 0; i < caret_edit_order.size(); i++) {
 		int c = caret_edit_order[i];
 
@@ -1426,7 +1427,7 @@ void CodeTextEditor::move_lines_down() {
 			if (next_end_pos == current_start_pos || next_end_pos + 1 == current_start_pos) {
 				group_border.first = next_start_pos;
 				new_group.push_back(c_next);
-				// If the last caret is added to the current group there is no need to process it again
+				// If the last caret is added to the current group there is no need to process it again.
 				if (j + 1 == caret_edit_order.size() - 1) {
 					i++;
 				}
@@ -1444,12 +1445,12 @@ void CodeTextEditor::move_lines_down() {
 			continue;
 		}
 
-		// If the group starts overlapping with the upper group don't move it
+		// If the group starts overlapping with the upper group don't move it.
 		if (i > 0 && group_border_ends[i] + 1 >= group_borders[i - 1].first) {
 			continue;
 		}
 
-		// We have to remember caret positions and selections prior to line swapping
+		// We have to remember caret positions and selections prior to line swapping.
 		Vector<Vector<int>> caret_group_parameters;
 
 		for (int j = 0; j < caret_groups[i].size(); j++) {
@@ -1457,15 +1458,15 @@ void CodeTextEditor::move_lines_down() {
 			int cursor_line = text_editor->get_caret_line(c);
 			int cursor_column = text_editor->get_caret_column(c);
 
-			if (text_editor->has_selection(c)) {
-				int from_line = text_editor->get_selection_from_line(c);
-				int from_col = text_editor->get_selection_from_column(c);
-				int to_line = text_editor->get_selection_to_line(c);
-				int to_column = text_editor->get_selection_to_column(c);
-				caret_group_parameters.push_back(Vector<int>{ from_line, from_col, to_line, to_column, cursor_line, cursor_column });
-			} else {
+			if (!text_editor->has_selection(c)) {
 				caret_group_parameters.push_back(Vector<int>{ -1, -1, -1, -1, cursor_line, cursor_column });
+				continue;
 			}
+			int from_line = text_editor->get_selection_from_line(c);
+			int from_col = text_editor->get_selection_from_column(c);
+			int to_line = text_editor->get_selection_to_line(c);
+			int to_column = text_editor->get_selection_to_column(c);
+			caret_group_parameters.push_back(Vector<int>{ from_line, from_col, to_line, to_column, cursor_line, cursor_column });
 		}
 
 		for (int line_id = group_borders[i].second; line_id >= group_borders[i].first; line_id--) {
@@ -1899,7 +1900,7 @@ int CodeTextEditor::_get_affected_lines_to(int p_caret) {
 		return text_editor->get_caret_line(p_caret);
 	}
 	int line = text_editor->get_selection_to_line(p_caret);
-	// Don't affect a line with no selected characters
+	// Don't affect a line with no selected characters.
 	if (text_editor->get_selection_to_column(p_caret) == 0) {
 		line--;
 	}

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -587,7 +587,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		return;
 	}
 
-	// Override new line actions, for auto indent
+	// Override new line actions, for auto indent.
 	if (k->is_action("ui_text_newline_above", true)) {
 		_new_line(false, true);
 		accept_event();
@@ -604,7 +604,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		return;
 	}
 
-	/* Remove shift otherwise actions will not match. */
+	// Remove shift, otherwise actions will not match.
 	k = k->duplicate();
 	k->set_shift_pressed(false);
 
@@ -777,8 +777,7 @@ void CodeEdit::_backspace_internal(int p_caret) {
 			}
 		}
 
-		// For space indentation we need to do a simple unindent if there are no chars to the left, acting in the
-		// same way as tabs.
+		// For space indentation we need to do a basic unindent if there are no chars to the left, acting the same way as tabs.
 		if (indent_using_spaces && cc != 0) {
 			if (get_first_non_whitespace_column(cl) >= cc) {
 				prev_column = cc - _calculate_spaces_till_next_left_indent(cc);
@@ -1372,7 +1371,7 @@ PackedInt32Array CodeEdit::get_bookmarked_lines() const {
 	return ret;
 }
 
-// executing lines
+// Executing lines
 void CodeEdit::set_line_as_executing(int p_line, bool p_executing) {
 	int mask = get_line_gutter_metadata(p_line, main_gutter);
 	set_line_gutter_metadata(p_line, main_gutter, p_executing ? mask | MAIN_GUTTER_EXECUTING : mask & ~MAIN_GUTTER_EXECUTING);
@@ -2064,7 +2063,7 @@ void CodeEdit::confirm_code_completion(bool p_replace) {
 			insert_text_at_caret(insert_text.substr(matching_chars), i);
 		}
 
-		//* Handle merging of symbols eg strings, brackets.
+		// Handle merging of symbols eg strings, brackets.
 		const String line = get_line(caret_line);
 		char32_t next_char = line[get_caret_column(i)];
 		char32_t last_completion_char = insert_text[insert_text.length() - 1];
@@ -2239,7 +2238,7 @@ void CodeEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear_bookmarked_lines"), &CodeEdit::clear_bookmarked_lines);
 	ClassDB::bind_method(D_METHOD("get_bookmarked_lines"), &CodeEdit::get_bookmarked_lines);
 
-	// executing lines
+	// Executing lines
 	ClassDB::bind_method(D_METHOD("set_line_as_executing", "line", "executing"), &CodeEdit::set_line_as_executing);
 	ClassDB::bind_method(D_METHOD("is_line_executing", "line"), &CodeEdit::is_line_executing);
 	ClassDB::bind_method(D_METHOD("clear_executing_lines"), &CodeEdit::clear_executing_lines);

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -284,7 +284,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 		_reset_caret_blink_timer();
 		if (b->is_pressed()) {
-			accept_event(); // don't pass event further when clicked on text field
+			accept_event(); // Don't pass event further when clicked on text field.
 			if (!text.is_empty() && is_editable() && _is_over_clear_button(b->get_position())) {
 				clear_button_status.press_attempt = true;
 				clear_button_status.pressing_inside = true;
@@ -429,7 +429,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			return;
 		}
 
-		// Alt+ Unicode input:
+		// Alt + Unicode input:
 		if (k->is_alt_pressed()) {
 			if (!alt_start) {
 				if (k->get_keycode() == Key::KP_ADD) {
@@ -470,7 +470,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			}
 		}
 
-		// Default is ENTER and KP_ENTER. Cannot use ui_accept as default includes SPACE
+		// Default is ENTER and KP_ENTER. Cannot use ui_accept as default includes SPACE.
 		if (k->is_action("ui_text_submit", false)) {
 			emit_signal(SNAME("text_submitted"), text);
 			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_VIRTUAL_KEYBOARD) && virtual_keyboard_enabled) {
@@ -608,7 +608,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		bool allow_unicode_handling = !(k->is_command_or_control_pressed() || k->is_ctrl_pressed() || k->is_alt_pressed() || k->is_meta_pressed());
 
 		if (allow_unicode_handling && editable && k->get_unicode() >= 32) {
-			// Handle Unicode (if no modifiers active)
+			// Handle Unicode if no modifiers are active.
 			selection_delete();
 			char32_t ucodestr[2] = { (char32_t)k->get_unicode(), 0 };
 			int prev_len = text.length();
@@ -1116,7 +1116,7 @@ void LineEdit::_notification(int p_what) {
 			ime_text = "";
 			ime_selection = Point2();
 			_shape();
-			set_caret_column(caret_column); // Update scroll_offset
+			set_caret_column(caret_column); // Update scroll_offset.
 
 			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_VIRTUAL_KEYBOARD) && virtual_keyboard_enabled) {
 				DisplayServer::get_singleton()->virtual_keyboard_hide();
@@ -1137,7 +1137,7 @@ void LineEdit::_notification(int p_what) {
 				}
 
 				_shape();
-				set_caret_column(caret_column); // Update scroll_offset
+				set_caret_column(caret_column); // Update scroll_offset.
 
 				queue_redraw();
 			}
@@ -2360,7 +2360,7 @@ Key LineEdit::_get_menu_action_accelerator(const String &p_action) {
 		return Key::NONE;
 	}
 
-	// Use physical keycode if non-zero
+	// Use physical keycode if non-zero.
 	if (event->get_physical_keycode() != Key::NONE) {
 		return event->get_physical_keycode_with_modifiers();
 	} else {

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -63,7 +63,7 @@ void SpinBox::_text_submitted(const String &p_string) {
 	expr.instantiate();
 
 	String num = TS->parse_number(p_string);
-	// Ignore the prefix and suffix in the expression
+	// Ignore the prefix and suffix in the expression.
 	Error err = expr->parse(num.trim_prefix(prefix + " ").trim_suffix(" " + suffix));
 	if (err != OK) {
 		return;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -472,7 +472,7 @@ void TextEdit::_notification(int p_what) {
 				// To ensure minimap is responsive override the speed setting.
 				double vel = ((target_y / dist) * ((minimap_clicked) ? 3000 : v_scroll_speed)) * get_physics_process_delta_time();
 
-				// Prevent too small velocity to block scrolling
+				// Prevent small velocities from blocking scrolling.
 				if (Math::abs(vel) < v_scroll->get_step()) {
 					vel = v_scroll->get_step() * SIGN(vel);
 				}
@@ -712,12 +712,12 @@ void TextEdit::_notification(int p_what) {
 				int minimap_line_height = (minimap_char_size.y + minimap_line_spacing);
 				int minimap_tab_size = minimap_char_size.x * text.get_tab_size();
 
-				// calculate viewport size and y offset
+				// Calculate viewport size and y offset.
 				int viewport_height = (draw_amount - 1) * minimap_line_height;
 				int control_height = _get_control_height() - viewport_height;
 				int viewport_offset_y = round(get_scroll_pos_for_line(first_vis_line + 1) * control_height) / ((v_scroll->get_max() <= minimap_visible_lines) ? (minimap_visible_lines - draw_amount) : (v_scroll->get_max() - draw_amount));
 
-				// calculate the first line.
+				// Calculate the first line.
 				int num_lines_before = round((viewport_offset_y) / minimap_line_height);
 				int minimap_line = (v_scroll->get_max() <= minimap_visible_lines) ? -1 : first_vis_line;
 				if (minimap_line >= 0) {
@@ -851,7 +851,7 @@ void TextEdit::_notification(int p_what) {
 
 							if (characters > 0) {
 								previous_color.a *= 0.6;
-								// take one for zero indexing, and if we hit whitespace / the end of a word.
+								// Take one for zero indexing, and if we hit whitespace / the end of a word.
 								int chars = MAX(0, (j - (characters - 1)) - (whitespace ? 1 : 0)) + 1;
 								int char_x_ofs = indent_px + ((xmargin_end + minimap_char_size.x) + (minimap_char_size.x * chars)) + tabs;
 								if (rtl) {
@@ -1110,7 +1110,7 @@ void TextEdit::_notification(int p_what) {
 					}
 
 					int start = TS->shaped_text_get_range(rid).x;
-					if (!clipped && !search_text.is_empty()) { // Search highhlight
+					if (!clipped && !search_text.is_empty()) { // Search highlight
 						int search_text_col = _get_column_pos_of_word(search_text, str, search_flags, 0);
 						int search_text_len = search_text.length();
 						while (search_text_col != -1) {
@@ -1729,7 +1729,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					left_margin += gutters[i].width;
 				}
 
-				// minimap
+				// Minimap
 				if (draw_minimap) {
 					_update_minimap_click();
 					if (dragging_minimap) {
@@ -1778,7 +1778,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 						carets.write[caret].selection.to_column = carets[caret].column;
 						carets.write[caret].selection.to_line = carets[caret].line;
 
-						if (carets[caret].selection.from_line > carets[caret].selection.to_line || (carets[caret].selection.from_line == carets[caret].selection.to_line && carets[caret].selection.from_column > carets[caret].selection.to_column)) {
+						if (get_selection_from_line(caret) > get_selection_to_line(caret) || (get_selection_from_line(caret) == get_selection_to_line(caret) && get_selection_from_column(caret) > get_selection_to_column(caret))) {
 							SWAP(carets.write[caret].selection.from_column, carets.write[caret].selection.to_column);
 							SWAP(carets.write[caret].selection.from_line, carets.write[caret].selection.to_line);
 							carets.write[caret].selection.shiftclick_left = false;
@@ -1791,14 +1791,14 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 						merge_overlapping_carets();
 						queue_redraw();
 					} else {
-						if (carets[caret].line < carets[caret].selection.selecting_line || (carets[caret].line == carets[caret].selection.selecting_line && carets[caret].column < carets[caret].selection.selecting_column)) {
+						if (carets[caret].line < get_selection_line(caret) || (carets[caret].line == get_selection_line(caret) && carets[caret].column < get_selection_column(caret))) {
 							if (carets[caret].selection.shiftclick_left) {
 								carets.write[caret].selection.shiftclick_left = !carets[caret].selection.shiftclick_left;
 							}
 							carets.write[caret].selection.from_column = carets[caret].column;
 							carets.write[caret].selection.from_line = carets[caret].line;
 
-						} else if (carets[caret].line > carets[caret].selection.selecting_line || (carets[caret].line == carets[caret].selection.selecting_line && carets[caret].column > carets[caret].selection.selecting_column)) {
+						} else if (carets[caret].line > get_selection_line(caret) || (carets[caret].line == get_selection_line(caret) && carets[caret].column > get_selection_column(caret))) {
 							if (!carets[caret].selection.shiftclick_left) {
 								SWAP(carets.write[caret].selection.from_column, carets.write[caret].selection.to_column);
 								SWAP(carets.write[caret].selection.from_line, carets.write[caret].selection.to_line);
@@ -2022,7 +2022,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		// * No modifiers are pressed (except Shift and CapsLock)
 		bool allow_unicode_handling = !(k->is_command_or_control_pressed() || k->is_ctrl_pressed() || k->is_alt_pressed() || k->is_meta_pressed());
 
-		// Check and handle all built in shortcuts.
+		// Check and handle all built-in shortcuts.
 
 		// NEWLINES.
 		if (k->is_action("ui_text_newline_above", true)) {
@@ -2376,11 +2376,11 @@ void TextEdit::_move_caret_left(bool p_select, bool p_move_by_word) {
 
 void TextEdit::_move_caret_right(bool p_select, bool p_move_by_word) {
 	for (int i = 0; i < carets.size(); i++) {
-		// Handle selection
+		// Handle selection.
 		if (p_select) {
 			_pre_shift_selection(i);
 		} else if (has_selection(i) && !p_move_by_word) {
-			// If a selection is active, move caret to end of selection
+			// If a selection is active, move caret to end of selection.
 			set_caret_line(get_selection_to_line(i), false, true, 0, i);
 			set_caret_column(get_selection_to_column(i), i == 0, i);
 			deselect(i);
@@ -2739,7 +2739,7 @@ void TextEdit::_delete(bool p_word, bool p_all_to_right) {
 		int next_column;
 
 		if (p_all_to_right) {
-			// Get caret furthest to the left
+			// Get caret furthest to the left.
 			for (int j = i + 1; j < caret_edit_order.size(); j++) {
 				if (get_caret_line(caret_edit_order[j]) != get_caret_line(caret_idx)) {
 					break;
@@ -2759,7 +2759,7 @@ void TextEdit::_delete(bool p_word, bool p_all_to_right) {
 				continue;
 			}
 
-			// Delete everything to right of caret
+			// Delete everything to right of caret.
 			next_column = curline_len;
 			next_line = get_caret_line(caret_idx);
 
@@ -2772,7 +2772,7 @@ void TextEdit::_delete(bool p_word, bool p_all_to_right) {
 			}
 
 		} else if (p_word && get_caret_column(caret_idx) < curline_len - 1) {
-			// Delete next word to right of caret
+			// Delete next word to right of caret.
 			int line = get_caret_line(caret_idx);
 			int column = get_caret_column(caret_idx);
 
@@ -2799,7 +2799,7 @@ void TextEdit::_delete(bool p_word, bool p_all_to_right) {
 				carets_to_remove.push_back(caret_edit_order[j]);
 			}
 		} else {
-			// Delete one character
+			// Delete one character.
 			if (caret_mid_grapheme_enabled) {
 				next_column = get_caret_column(caret_idx) < curline_len ? (get_caret_column(caret_idx) + 1) : 0;
 			} else {
@@ -2882,7 +2882,7 @@ void TextEdit::_get_above_below_caret_line_column(int p_old_line, int p_old_wrap
 		p_last_fit_x = _get_column_x_offset_for_line(p_old_column, p_old_line, p_old_column);
 	}
 
-	// Calculate the new line and wrap index
+	// Calculate the new line and wrap index.
 	p_new_line = p_old_line;
 	int caret_wrap_index = p_old_wrap_index;
 	if (p_below) {
@@ -2901,7 +2901,7 @@ void TextEdit::_get_above_below_caret_line_column(int p_old_line, int p_old_wrap
 		}
 	}
 
-	// Boundary checks
+	// Boundary checks.
 	if (p_new_line < 0) {
 		p_new_line = 0;
 	}
@@ -3526,15 +3526,15 @@ void TextEdit::insert_line_at(int p_at, const String &p_text) {
 
 	for (int i = 0; i < carets.size(); i++) {
 		if (get_caret_line(i) >= p_at) {
-			// offset caret when located after inserted line
+			// Offset caret when located after inserted line.
 			set_caret_line(get_caret_line(i) + 1, false, true, 0, i);
 		}
 		if (has_selection(i)) {
 			if (get_selection_from_line(i) >= p_at) {
-				// offset selection when located after inserted line
+				// Offset selection when located after inserted line.
 				select(get_selection_from_line(i) + 1, get_selection_from_column(i), get_selection_to_line(i) + 1, get_selection_to_column(i), i);
 			} else if (get_selection_to_line(i) >= p_at) {
-				// extend selection that includes inserted line
+				// Extend selection that includes inserted line.
 				select(get_selection_from_line(i), get_selection_from_column(i), get_selection_to_line(i) + 1, get_selection_to_column(i), i);
 			}
 		}
@@ -4368,7 +4368,7 @@ int TextEdit::get_minimap_line_at_pos(const Point2i &p_pos) const {
 	rows /= (minimap_char_size.y + minimap_line_spacing);
 	rows += _get_v_scroll_offset();
 
-	// calculate visible lines
+	// Calculate visible lines.
 	int minimap_visible_lines = get_minimap_visible_lines();
 	int visible_rows = get_visible_line_count() + 1;
 	int first_vis_line = get_first_visible_line() - 1;
@@ -4376,12 +4376,12 @@ int TextEdit::get_minimap_line_at_pos(const Point2i &p_pos) const {
 	draw_amount += get_line_wrap_count(first_vis_line + 1);
 	int minimap_line_height = (minimap_char_size.y + minimap_line_spacing);
 
-	// calculate viewport size and y offset
+	// Calculate viewport size and y offset.
 	int viewport_height = (draw_amount - 1) * minimap_line_height;
 	int control_height = _get_control_height() - viewport_height;
 	int viewport_offset_y = round(get_scroll_pos_for_line(first_vis_line + 1) * control_height) / ((v_scroll->get_max() <= minimap_visible_lines) ? (minimap_visible_lines - draw_amount) : (v_scroll->get_max() - draw_amount));
 
-	// calculate the first line.
+	// Calculate the first line.
 	int num_lines_before = round((viewport_offset_y) / minimap_line_height);
 	int minimap_line = (v_scroll->get_max() <= minimap_visible_lines) ? -1 : first_vis_line;
 	if (first_vis_line > 0 && minimap_line >= 0) {
@@ -4577,7 +4577,7 @@ void TextEdit::merge_overlapping_carets() {
 				continue;
 			}
 
-			// Save the newest one for click+drag.
+			// Save the newest one for Click + Drag.
 			int caret_to_save = first_caret;
 			int caret_to_remove = second_caret;
 			if (first_caret < second_caret) {
@@ -4630,7 +4630,7 @@ void TextEdit::merge_overlapping_carets() {
 			continue;
 		}
 
-		// Only second has Selection.
+		// Only second has selection.
 		if (has_selection(second_caret)) {
 			if (get_caret_line(first_caret) >= get_selection_from_line(second_caret) && get_caret_line(first_caret) <= get_selection_to_line(second_caret) && (get_caret_line(first_caret) > get_selection_from_line(second_caret) || get_caret_column(first_caret) >= get_selection_from_column(second_caret)) && (get_caret_line(first_caret) < get_selection_to_line(second_caret) || get_caret_column(first_caret) <= get_selection_to_column(second_caret))) {
 				remove_caret(first_caret);
@@ -4642,7 +4642,7 @@ void TextEdit::merge_overlapping_carets() {
 
 		// Both have no selection.
 		if (get_caret_line(first_caret) == get_caret_line(second_caret) && get_caret_column(first_caret) == get_caret_column(second_caret)) {
-			// Save the newest one for click+drag.
+			// Save the newest one for Click + Drag.
 			if (first_caret < second_caret) {
 				remove_caret(first_caret);
 			} else {
@@ -4667,7 +4667,7 @@ void TextEdit::add_caret_at_carets(bool p_below) {
 
 		// The last fit x will be cleared if the caret has a selection,
 		// but if it does not have a selection the last fit x will be
-		// transferred to the new caret
+		// transferred to the new caret.
 		int caret_from_column = 0, caret_to_column = 0, caret_last_fit_x = carets[caret_index].last_fit_x;
 		if (has_selection(caret_index)) {
 			// If the selection goes over multiple lines, deselect it.
@@ -4681,15 +4681,15 @@ void TextEdit::add_caret_at_carets(bool p_below) {
 			}
 		}
 
-		// Get the line and column of the new caret as if you would move the caret by pressing the arrow keys
+		// Get the line and column of the new caret as if you would move the caret by pressing the arrow keys.
 		int new_caret_line, new_caret_column, new_caret_from_column = 0, new_caret_to_column = 0;
 		_get_above_below_caret_line_column(caret_line, get_caret_wrap_index(caret_index), caret_column, p_below, new_caret_line, new_caret_column, caret_last_fit_x);
 
-		// If the caret does have a selection calculate the new from and to columns
+		// If the caret does have a selection calculate the new from and to columns.
 		if (caret_from_column != caret_to_column) {
-			// We only need to calculate the selection columns if the column of the caret changed
+			// We only need to calculate the selection columns if the column of the caret changed.
 			if (caret_column != new_caret_column) {
-				int _; // unused placeholder for p_new_line
+				int _; // Unused placeholder for p_new_line.
 				_get_above_below_caret_line_column(caret_line, get_caret_wrap_index(caret_index), caret_from_column, p_below, _, new_caret_from_column);
 				_get_above_below_caret_line_column(caret_line, get_caret_wrap_index(caret_index), caret_to_column, p_below, _, new_caret_to_column);
 			} else {
@@ -4698,22 +4698,22 @@ void TextEdit::add_caret_at_carets(bool p_below) {
 			}
 		}
 
-		// Add the new caret
+		// Add the new caret.
 		const int new_caret_index = add_caret(new_caret_line, new_caret_column);
 
 		if (new_caret_index == -1) {
 			continue;
 		}
-		// Also add the selection if there should be one
+		// Also add the selection if there should be one.
 		if (new_caret_from_column != new_caret_to_column) {
 			select(new_caret_line, new_caret_from_column, new_caret_line, new_caret_to_column, new_caret_index);
-			// Necessary to properly modify the selection after adding the new caret
+			// Necessary to properly modify the selection after adding the new caret.
 			carets.write[new_caret_index].selection.selecting_line = new_caret_line;
 			carets.write[new_caret_index].selection.selecting_column = new_caret_column == new_caret_from_column ? new_caret_to_column : new_caret_from_column;
 			continue;
 		}
 
-		// Copy the last fit x over
+		// Copy the last fit x over.
 		carets.write[new_caret_index].last_fit_x = carets[caret_index].last_fit_x;
 	}
 
@@ -4731,13 +4731,13 @@ Vector<int> TextEdit::get_caret_index_edit_order() {
 	for (int i = 1; i < carets.size(); i++) {
 		int j = 0;
 
-		int line = carets[i].selection.active ? carets[i].selection.to_line : carets[i].line;
-		int col = carets[i].selection.active ? carets[i].selection.to_column : carets[i].column;
+		int line = has_selection(i) ? get_selection_to_line(i) : carets[i].line;
+		int col = has_selection(i) ? get_selection_to_column(i) : carets[i].column;
 
 		for (; j < caret_index_edit_order.size(); j++) {
 			int idx = caret_index_edit_order[j];
-			int other_line = carets[idx].selection.active ? carets[idx].selection.to_line : carets[idx].line;
-			int other_col = carets[idx].selection.active ? carets[idx].selection.to_column : carets[idx].column;
+			int other_line = has_selection(idx) ? get_selection_to_line(idx) : carets[idx].line;
+			int other_col = has_selection(idx) ? get_selection_to_column(idx) : carets[idx].column;
 			if (line > other_line || (line == other_line && col > other_col)) {
 				break;
 			}
@@ -4776,7 +4776,7 @@ void TextEdit::adjust_carets_after_edit(int p_caret, int p_from_line, int p_from
 			carets.write[caret_edit_order[j]].selection.from_line += edit_height;
 			carets.write[caret_edit_order[j]].selection.to_line += edit_height;
 		}
-		if (get_caret_line(p_caret) == carets[caret_edit_order[j]].selection.from_line) {
+		if (get_caret_line(p_caret) == get_selection_from_line(caret_edit_order[j])) {
 			carets.write[caret_edit_order[j]].selection.from_column += edit_size;
 		}
 	}
@@ -5086,29 +5086,10 @@ void TextEdit::select(int p_from_line, int p_from_column, int p_to_line, int p_t
 		return;
 	}
 
-	if (p_from_line < 0) {
-		p_from_line = 0;
-	} else if (p_from_line >= text.size()) {
-		p_from_line = text.size() - 1;
-	}
-	if (p_from_column >= text[p_from_line].length()) {
-		p_from_column = text[p_from_line].length();
-	}
-	if (p_from_column < 0) {
-		p_from_column = 0;
-	}
-
-	if (p_to_line < 0) {
-		p_to_line = 0;
-	} else if (p_to_line >= text.size()) {
-		p_to_line = text.size() - 1;
-	}
-	if (p_to_column >= text[p_to_line].length()) {
-		p_to_column = text[p_to_line].length();
-	}
-	if (p_to_column < 0) {
-		p_to_column = 0;
-	}
+	p_from_line = CLAMP(p_from_line, 0, text.size() - 1);
+	p_from_column = CLAMP(p_from_column, 0, text[p_from_line].length());
+	p_to_line = CLAMP(p_to_line, 0, text.size() - 1);
+	p_to_column = CLAMP(p_to_column, 0, text[p_to_line].length());
 
 	carets.write[p_caret].selection.from_line = p_from_line;
 	carets.write[p_caret].selection.from_column = p_from_column;
@@ -5117,17 +5098,17 @@ void TextEdit::select(int p_from_line, int p_from_column, int p_to_line, int p_t
 
 	carets.write[p_caret].selection.active = true;
 
-	if (carets[p_caret].selection.from_line == carets[p_caret].selection.to_line) {
-		if (carets[p_caret].selection.from_column == carets[p_caret].selection.to_column) {
+	if (get_selection_from_line(p_caret) == get_selection_to_line(p_caret)) {
+		if (get_selection_from_column(p_caret) == get_selection_to_column(p_caret)) {
 			carets.write[p_caret].selection.active = false;
 
-		} else if (carets[p_caret].selection.from_column > carets[p_caret].selection.to_column) {
+		} else if (get_selection_from_column(p_caret) > get_selection_to_column(p_caret)) {
 			carets.write[p_caret].selection.shiftclick_left = false;
 			SWAP(carets.write[p_caret].selection.from_column, carets.write[p_caret].selection.to_column);
 		} else {
 			carets.write[p_caret].selection.shiftclick_left = true;
 		}
-	} else if (carets[p_caret].selection.from_line > carets[p_caret].selection.to_line) {
+	} else if (get_selection_from_line(p_caret) > get_selection_to_line(p_caret)) {
 		carets.write[p_caret].selection.shiftclick_left = false;
 		SWAP(carets.write[p_caret].selection.from_line, carets.write[p_caret].selection.to_line);
 		SWAP(carets.write[p_caret].selection.from_column, carets.write[p_caret].selection.to_column);
@@ -5239,9 +5220,9 @@ void TextEdit::delete_selection(int p_caret) {
 		}
 
 		selecting_mode = SelectionMode::SELECTION_MODE_NONE;
-		_remove_text(carets[i].selection.from_line, carets[i].selection.from_column, carets[i].selection.to_line, carets[i].selection.to_column);
-		set_caret_line(carets[i].selection.from_line, false, false, 0, i);
-		set_caret_column(carets[i].selection.from_column, i == 0, i);
+		_remove_text(get_selection_from_line(i), get_selection_from_column(i), get_selection_to_line(i), get_selection_to_column(i));
+		set_caret_line(get_selection_from_line(i), false, false, 0, i);
+		set_caret_column(get_selection_from_column(i), i == 0, i);
 		carets.write[i].selection.active = false;
 
 		adjust_carets_after_edit(i, carets[i].selection.from_line, carets[i].selection.from_column, carets[i].selection.to_line, carets[i].selection.to_column);
@@ -5378,7 +5359,7 @@ int TextEdit::get_h_scroll() const {
 }
 
 void TextEdit::set_v_scroll_speed(float p_speed) {
-	// Prevent setting a vertical scroll speed value under 1.0
+	// Prevent setting a vertical scroll speed value under 1.
 	ERR_FAIL_COND(p_speed < 1.0);
 	v_scroll_speed = p_speed;
 }
@@ -5482,12 +5463,12 @@ int TextEdit::get_visible_line_count_in_range(int p_from_line, int p_to_line) co
 	ERR_FAIL_INDEX_V(p_from_line, text.size(), 0);
 	ERR_FAIL_INDEX_V(p_to_line, text.size(), 0);
 
-	// So we can handle inputs in whatever order
+	// So we can handle inputs in whatever order.
 	if (p_from_line > p_to_line) {
 		SWAP(p_from_line, p_to_line);
 	}
 
-	/* Returns the total number of (lines + wrapped - hidden). */
+	// Returns the total number of (lines + wrapped - hidden).
 	if (!_is_hiding_enabled() && get_line_wrapping_mode() == LineWrappingMode::LINE_WRAPPING_NONE) {
 		return (p_to_line - p_from_line) + 1;
 	}
@@ -5506,7 +5487,7 @@ int TextEdit::get_total_visible_line_count() const {
 	return get_visible_line_count_in_range(0, text.size() - 1);
 }
 
-// Auto adjust
+// Auto adjust.
 void TextEdit::adjust_viewport_to_caret(int p_caret) {
 	ERR_FAIL_INDEX(p_caret, carets.size());
 
@@ -6183,7 +6164,7 @@ void TextEdit::_bind_methods() {
 	BIND_ENUM_CONSTANT(CARET_TYPE_LINE);
 	BIND_ENUM_CONSTANT(CARET_TYPE_BLOCK);
 
-	// internal.
+	// Internal.
 	ClassDB::bind_method(D_METHOD("_emit_caret_changed"), &TextEdit::_emit_caret_changed);
 
 	ClassDB::bind_method(D_METHOD("set_caret_type", "type"), &TextEdit::set_caret_type);
@@ -6270,7 +6251,7 @@ void TextEdit::_bind_methods() {
 	BIND_ENUM_CONSTANT(LINE_WRAPPING_NONE);
 	BIND_ENUM_CONSTANT(LINE_WRAPPING_BOUNDARY);
 
-	// internal.
+	// Internal.
 	ClassDB::bind_method(D_METHOD("_update_wrap_at_column", "force"), &TextEdit::_update_wrap_at_column, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("set_line_wrapping_mode", "mode"), &TextEdit::set_line_wrapping_mode);
@@ -6535,9 +6516,9 @@ void TextEdit::_handle_unicode_input_internal(const uint32_t p_unicode, int p_ca
 			continue;
 		}
 
-		/* Remove the old character if in insert mode and no selection. */
+		// Remove the old character if in insert mode and no selection.
 		if (overtype_mode && !has_selection(i)) {
-			/* Make sure we don't try and remove empty space. */
+			// Make sure we don't try and remove empty space.
 			int cl = get_caret_line(i);
 			int cc = get_caret_column(i);
 			if (cc < get_line(cl).length()) {
@@ -6780,7 +6761,7 @@ Key TextEdit::_get_menu_action_accelerator(const String &p_action) {
 		return Key::NONE;
 	}
 
-	// Use physical keycode if non-zero
+	// Use physical keycode if non-zero.
 	if (event->get_physical_keycode() != Key::NONE) {
 		return event->get_physical_keycode_with_modifiers();
 	} else {
@@ -7154,11 +7135,11 @@ void TextEdit::_update_selection_mode_line() {
 
 	col = 0;
 	if (line < carets[caret_idx].selection.selecting_line) {
-		/* Caret is above us. */
+		// Caret is above us.
 		set_caret_line(line - 1, false, true, 0, caret_idx);
 		carets.write[caret_idx].selection.selecting_column = text[get_selection_line(caret_idx)].length();
 	} else {
-		/* Caret is below us. */
+		// Caret is below us.
 		set_caret_line(line + 1, false, true, 0, caret_idx);
 		carets.write[caret_idx].selection.selecting_column = 0;
 		col = text[line].length();


### PR DESCRIPTION
Simplifies a bit of code and adjusts comments to abide by the comment style we use nowadays in `text_edit.cpp`, `code_edit.cpp`, `code_editor.cpp`. Replaces things like `carets[caret_idx].selection.from_line` with `get_selection_from_line(caret_idx)` where appropriate. Fixes a typo in TextEdit docs.

I have a few PRs on TextEdit and I keep adjusting these things along the way and cluttering my diff, making them harder to review, so it would be nice to get this in separately.