### PR TITLE
Add conversion for common Theme Overrides

### DIFF
--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -165,6 +165,7 @@ public:
 	LocalVector<RegEx *> gdscript_signals_regexes;
 	LocalVector<RegEx *> shaders_regexes;
 	LocalVector<RegEx *> builtin_types_regexes;
+	LocalVector<RegEx *> theme_override_regexes;
 	LocalVector<RegEx *> csharp_function_regexes;
 	LocalVector<RegEx *> csharp_properties_regexes;
 	LocalVector<RegEx *> csharp_signal_regexes;
@@ -207,6 +208,10 @@ public:
 			// Builtin types.
 			for (unsigned int current_index = 0; RenamesMap3To4::builtin_types_renames[current_index][0]; current_index++) {
 				builtin_types_regexes.push_back(memnew(RegEx(String("\\b") + RenamesMap3To4::builtin_types_renames[current_index][0] + "\\b")));
+			}
+			// Theme overrides.
+			for (unsigned int current_index = 0; RenamesMap3To4::theme_override_renames[current_index][0]; current_index++) {
+				theme_override_regexes.push_back(memnew(RegEx(String("\\b") + RenamesMap3To4::theme_override_renames[current_index][0] + "\\b")));
 			}
 			// CSharp function renames.
 			for (unsigned int current_index = 0; RenamesMap3To4::csharp_function_renames[current_index][0]; current_index++) {
@@ -280,6 +285,9 @@ public:
 			memdelete(regex);
 		}
 		for (RegEx *regex : builtin_types_regexes) {
+			memdelete(regex);
+		}
+		for (RegEx *regex : theme_override_regexes) {
 			memdelete(regex);
 		}
 		for (RegEx *regex : csharp_function_regexes) {
@@ -387,6 +395,7 @@ bool ProjectConverter3To4::convert() {
 				rename_common(RenamesMap3To4::gdscript_signals_renames, reg_container.gdscript_signals_regexes, source_lines);
 				rename_common(RenamesMap3To4::shaders_renames, reg_container.shaders_regexes, source_lines);
 				rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, source_lines);
+				rename_common(RenamesMap3To4::theme_override_renames, reg_container.theme_override_regexes, source_lines);
 
 				custom_rename(source_lines, "\\.shader", ".gdshader");
 			} else if (file_name.ends_with(".tscn")) {
@@ -404,6 +413,7 @@ bool ProjectConverter3To4::convert() {
 				rename_common(RenamesMap3To4::gdscript_signals_renames, reg_container.gdscript_signals_regexes, source_lines);
 				rename_common(RenamesMap3To4::shaders_renames, reg_container.shaders_regexes, source_lines);
 				rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, source_lines);
+				rename_common(RenamesMap3To4::theme_override_renames, reg_container.theme_override_regexes, source_lines);
 
 				custom_rename(source_lines, "\\.shader", ".gdshader");
 			} else if (file_name.ends_with(".cs")) { // TODO, C# should use different methods.
@@ -566,6 +576,7 @@ bool ProjectConverter3To4::validate_conversion() {
 				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::gdscript_signals_renames, reg_container.gdscript_signals_regexes, lines));
 				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::shaders_renames, reg_container.shaders_regexes, lines));
 				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::theme_override_renames, reg_container.theme_override_regexes, lines));
 
 				changed_elements.append_array(check_for_custom_rename(lines, "\\.shader", ".gdshader"));
 			} else if (file_name.ends_with(".tscn")) {
@@ -583,6 +594,7 @@ bool ProjectConverter3To4::validate_conversion() {
 				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::gdscript_signals_renames, reg_container.gdscript_signals_regexes, lines));
 				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::shaders_renames, reg_container.shaders_regexes, lines));
 				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, lines));
+				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::theme_override_renames, reg_container.theme_override_regexes, lines));
 
 				changed_elements.append_array(check_for_custom_rename(lines, "\\.shader", ".gdshader"));
 			} else if (file_name.ends_with(".cs")) {
@@ -767,6 +779,8 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 	valid = valid && test_conversion_basic("\"device\":-1,\"alt\":false,\"shift\":false,\"control\":false,\"meta\":false,\"doubleclick\":false,\"scancode\":0,\"physical_scancode\":16777254,\"script\":null", "\"device\":-1,\"alt_pressed\":false,\"shift_pressed\":false,\"ctrl_pressed\":false,\"meta_pressed\":false,\"double_click\":false,\"keycode\":0,\"physical_keycode\":16777254,\"script\":null", RenamesMap3To4::input_map_renames, reg_container.input_map_regexes, "input map");
 
 	valid = valid && test_conversion_basic("Transform", "Transform3D", RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, "builtin type");
+
+	valid = valid && test_conversion_basic("custom_constants/margin_right", "theme_override_constants/margin_right", RenamesMap3To4::theme_override_renames, reg_container.theme_override_regexes, "theme overrides");
 
 	// Custom Renames.
 

--- a/editor/renames_map_3_to_4.cpp
+++ b/editor/renames_map_3_to_4.cpp
@@ -1791,4 +1791,49 @@ const char *RenamesMap3To4::color_renames[][2] = {
 	{ nullptr, nullptr },
 };
 
+const char *RenamesMap3To4::theme_override_renames[][2] = {
+	// First rename the generic prefixes.
+	{ "custom_colors/", "theme_override_colors/" },
+	{ "custom_constants/", "theme_override_constants/" },
+	{ "custom_fonts/", "theme_override_fonts/" },
+	{ "custom_icons/", "theme_override_icons/" },
+	{ "custom_styles/", "theme_override_styles/" },
+
+	// MarginContainer
+	// The margin_* properties are renamed to offset_* in a previous conversion step.
+	// This is fine everywhere except for the MarginContainer theme_override_constants.
+	{ "theme_override_constants/offset_right", "theme_override_constants/margin_right" },
+	{ "theme_override_constants/offset_top", "theme_override_constants/margin_top" },
+	{ "theme_override_constants/offset_left", "theme_override_constants/margin_left" },
+	{ "theme_override_constants/offset_bottom", "theme_override_constants/margin_bottom" },
+
+	// Panel/PanelContainer/TabContainer/PopupPanel/PopupMenu
+	{ "theme_override_styles/panel", "theme_override_styles/panel" },
+
+	// TabContainer/Tabs(TabBar)
+	{ "theme_override_styles/tab_bg", "theme_override_styles/tab_unselected" },
+	{ "theme_override_styles/tab_fg", "theme_override_styles/tab_selected" },
+
+	// { "theme_override_styles/bg", "theme_override_styles/bg" }, // GraphEdit
+	// { "theme_override_styles/bg", "theme_override_styles/panel" }, // ScrollContainer
+	// { "theme_override_styles/bg", "theme_override_styles/background" }, // ProgressBar
+	// { "theme_override_styles/fg", "theme_override_styles/fill" }, // ProgressBar
+
+	{ "theme_override_colors/font_color_hover", "theme_override_colors/font_hover_color" },
+	{ "theme_override_colors/font_color_pressed", "theme_override_colors/font_pressed_color" },
+	{ "theme_override_colors/font_color_disabled", "theme_override_colors/font_disabled_color" },
+	{ "theme_override_colors/font_color_focus", "theme_override_colors/font_focus_color" },
+	{ "theme_override_colors/font_color_hover_pressed", "theme_override_colors/font_hover_pressed_color" },
+
+	{ "theme_override_colors/font_outline_modulate", "theme_override_colors/font_outline_color" },
+	{ "theme_override_colors/font_color_shadow", "theme_override_colors/font_shadow_color" },
+
+	{ "theme_override_constants/shadow_as_outline", "theme_override_constants/shadow_outline_size" }, // 0 or 1
+
+	{ "theme_override_constants/table_vseparation", "theme_override_constants/table_v_separation" },
+	{ "theme_override_constants/table_hseparation", "theme_override_constants/table_h_separation" },
+
+	{ nullptr, nullptr },
+};
+
 #endif // DISABLE_DEPRECATED

--- a/editor/renames_map_3_to_4.h
+++ b/editor/renames_map_3_to_4.h
@@ -48,6 +48,7 @@ struct RenamesMap3To4 {
 	static const char *shaders_renames[][2];
 	static const char *class_renames[][2];
 	static const char *color_renames[][2];
+	static const char *theme_override_renames[][2];
 };
 
 #endif // DISABLE_DEPRECATED


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/66052
This PR adds conversion for the most commonly used theme overrides.
This includes:
- Styles (StyleBoxes)
- Icons
- Font colors
- Spacing, Separation, Offsets

-> Margins, StyleBoxes etc. will still work after the migration.

