### PR TITLE
Select the newly duplicated file

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1286,6 +1286,7 @@ void FileSystemDock::_try_duplicate_item(const FileOrFolder &p_item, const Strin
 		EditorNode::get_singleton()->add_io_error(TTR("Cannot move a folder into itself.") + "\n" + old_path + "\n");
 		return;
 	}
+	const_cast<FileSystemDock *>(this)->path = new_path;
 
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 


### PR DESCRIPTION
When you duplicate a file, the old one retains the selection. This is especially confusing when you duplicate a file to some faraway folder and then try to edit it, only to discover that you are editing the old file.

This PR makes the newly duplicated file selected.

https://user-images.githubusercontent.com/2223172/223872333-8f51548c-c6f5-4298-acf6-455cb640f3dd.mp4

