### PR TITLE
Fixed typos in Transform2D and Transform3D class reference

### DIFF
--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -120,7 +120,7 @@
 			<return type="bool" />
 			<param index="0" name="xform" type="Transform2D" />
 			<description>
-				Returns [code]true[/code] if this transform and [code]transform[/code] are approximately equal, by calling [code]is_equal_approx[/code] on each component.
+				Returns [code]true[/code] if this transform and [param xform] are approximately equal, by calling [code]is_equal_approx[/code] on each component.
 			</description>
 		</method>
 		<method name="is_finite" qualifiers="const">
@@ -133,7 +133,7 @@
 			<return type="Transform2D" />
 			<param index="0" name="target" type="Vector2" default="Vector2(0, 0)" />
 			<description>
-				Returns a copy of the transform rotated such that it's rotation on the X-axis points towards the [param target] position.
+				Returns a copy of the transform rotated such that the rotated X-axis points towards the [param target] position.
 				Operations take place in global space.
 			</description>
 		</method>

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -80,7 +80,7 @@
 			<return type="bool" />
 			<param index="0" name="xform" type="Transform3D" />
 			<description>
-				Returns [code]true[/code] if this transform and [code]transform[/code] are approximately equal, by calling [code]is_equal_approx[/code] on each component.
+				Returns [code]true[/code] if this transform and [param xform] are approximately equal, by calling [code]is_equal_approx[/code] on each component.
 			</description>
 		</method>
 		<method name="is_finite" qualifiers="const">


### PR DESCRIPTION
1. In Transform2D and Transform3D method `is_equal_approx(Transform2D xform)`: 
"Returns true if this transform and transform are approximately equal" 
-> 
"Returnst true if this transform and xform are approximately equal".
2. In Transform2D method `looking_at(Vector2 target)`: 
"Returns a copy of the transform rotated such that it's rotation on the X-axis points towards the target position." 
-> 
"Returns a copy of the transform rotated such that the rotated X-axis points towards the target position."

The first one contained a typo and the second one also contained a typo (should be "its" not "it's) but I also rewrote it to be a little more clear.