### PR TITLE
Prevent crash in `ItemList` when checking for visible items

### DIFF
--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -70,6 +70,7 @@ private:
 		Color custom_fg;
 		Color custom_bg = Color(0.0, 0.0, 0.0, 0.0);
 
+		int column = 0;
 		Rect2 rect_cache;
 		Rect2 min_rect_cache;
 
@@ -143,7 +144,8 @@ private:
 	} theme_cache;
 
 	void _scroll_changed(double);
-	void _shape(int p_idx);
+	void _check_shape_changed();
+	void _shape_text(int p_idx);
 
 protected:
 	virtual void _update_theme_item_cache() override;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/73372. Fixes https://github.com/godotengine/godot/issues/74498.

So what happens is under some conditions our binary search for the first visible item leads us to reach the upper bound of the possible item number. And the following code does not handle it correctly. While the conditions for this are unclear to me, logically it's still a possible scenario (perhaps it happens when all the caches are set to no size?). So I made sure that if we get there, we simply do nothing, as we have nothing to draw anyway. It seems to me that the system should only be in this weird state temporarily and should quickly fix itself.

I also refactored a bit of the code while I was there, because huge NOTIFICATION_DRAW handlers are a pain to work with. In particular, the bit that resets the caches was factored out. We also now store item's column in its struct, so we can check that instead of comparing `position.y`.

PS. This code has been like that since https://github.com/godotengine/godot/pull/15306, so there might've been some other crashes caused by it, but not identified as related to ItemList.