### PR TITLE
Node3D: Add `get_branch_transform()` and `set_branch_transform()`

### DIFF
--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -38,6 +38,13 @@
 				Forces the transform to update. Transform changes in physics are not instant for performance reasons. Transforms are accumulated and then set. Use this if you need an up-to-date transform when doing physics operations.
 			</description>
 		</method>
+		<method name="get_branch_transform" qualifiers="const">
+			<return type="Transform3D" />
+			<description>
+				Returns the transform of this [code]Node3D[/code] relative to the root node of the branch that holds it.
+				[b]Note:[/b] If the branch holding the node is the [SceneTree], the result will be the same as [member global_transform].
+			</description>
+		</method>
 		<method name="get_gizmos" qualifiers="const">
 			<return type="Node3DGizmo[]" />
 			<description>
@@ -176,6 +183,14 @@
 			<param index="0" name="scale" type="Vector3" />
 			<description>
 				Scales the local transformation by given 3D scale factors in object-local coordinate system.
+			</description>
+		</method>
+		<method name="set_branch_transform">
+			<return type="void" />
+			<param index="0" name="transform" type="Transform3D" />
+			<description>
+				Sets the transform of this [code]Node3D[/code] in the coordinate space of the branch root node.
+				[b]Note:[/b] If the branch holding the node is the [SceneTree], the result will be the same as setting [member global_transform].
 			</description>
 		</method>
 		<method name="set_disable_scale">

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -194,11 +194,13 @@ public:
 	void set_basis(const Basis &p_basis);
 	void set_quaternion(const Quaternion &p_quaternion);
 	void set_global_transform(const Transform3D &p_transform);
+	void set_branch_transform(const Transform3D &p_transform);
 
 	Transform3D get_transform() const;
 	Basis get_basis() const;
 	Quaternion get_quaternion() const;
 	Transform3D get_global_transform() const;
+	Transform3D get_branch_transform() const;
 
 #ifdef TOOLS_ENABLED
 	virtual Transform3D get_global_gizmo_transform() const;


### PR DESCRIPTION
Effectively allows the use of global transform in out-of-tree branches, relative to the local root node.

Alternative to #70443
Fixes #30445

## Node3D `data.parent`
When testing #70443 and this PR we noticed a bug in the initial implementation:
https://github.com/godotengine/godot/pull/70443#issuecomment-1463433293

Although the `Node` parent was set correctly when adding and removing children out of tree, the `Node3D` parent was _only_ set when inside the tree. This meant that calculating the `branch_transform` when out of tree would fail, because it depended on the `Node3D` parent being set.

The solution here is to change the paradigm, and have the `Node3D` parent set and unset with `NOTIFICATION_PARENTED` and `NOTIFICATION_UNPARENTED`, rather than `NOTIFICATION_ENTER_TREE` and `NOTIFICATION_EXIT_TREE`. This is thus a significant change to the paradigm, and there is the possibility of bugs where other areas are expecting this to be NULL outside the tree.

## Notes
* Putting this up for some discussion as an alternative to allowing global transform to work in out-of-tree branches.
* Although simply allowing `global_transform()` to work outside the scene tree is technically easy, this can potentially be confusing for users, as seen in https://github.com/godotengine/godot/pull/70443#issuecomment-1461843261 . This occurs because allowing the `global` functions to work outside the scene tree, they are no longer in the same `global space` (world space).
* This suggests an argument for providing a new function names, to avoid the confusion.
* The disadvantage here is that there are a bunch of shortcut functions for setting the `global_transform` (such as `set_global_position()`) which would be excessive to duplicate.
* This means that users would have to manipulate the transform directly in order to use the branch version. On the other hand most users needing this functionality would be "power users" and this is unlikely to be a problem for them.
* The current situation is that when people need this functionality, they need to write it themselves, which is cumbersome and error prone, not to mention slow if done outside c++.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
