### PR TITLE
Shader editor trims trailing whitespace if set in editor settings

### DIFF
--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -267,18 +267,26 @@ void ShaderEditorPlugin::_menu_item_pressed(int p_index) {
 		case FILE_SAVE: {
 			int index = shader_tabs->get_current_tab();
 			ERR_FAIL_INDEX(index, shader_tabs->get_tab_count());
+			TextShaderEditor *editor = edited_shaders[index].shader_editor;
+			if (editor && editor->get_trim_trailing_whitespace_on_save()) {
+				editor->trim_trailing_whitespace();
+			}
 			if (edited_shaders[index].shader.is_valid()) {
 				EditorNode::get_singleton()->save_resource(edited_shaders[index].shader);
 			} else {
 				EditorNode::get_singleton()->save_resource(edited_shaders[index].shader_inc);
 			}
-			if (edited_shaders[index].shader_editor) {
-				edited_shaders[index].shader_editor->tag_saved_version();
+			if (editor) {
+				editor->tag_saved_version();
 			}
 		} break;
 		case FILE_SAVE_AS: {
 			int index = shader_tabs->get_current_tab();
 			ERR_FAIL_INDEX(index, shader_tabs->get_tab_count());
+			TextShaderEditor *editor = edited_shaders[index].shader_editor;
+			if (editor && editor->get_trim_trailing_whitespace_on_save()) {
+				editor->trim_trailing_whitespace();
+			}
 			String path;
 			if (edited_shaders[index].shader.is_valid()) {
 				path = edited_shaders[index].shader->get_path();
@@ -293,8 +301,8 @@ void ShaderEditorPlugin::_menu_item_pressed(int p_index) {
 				}
 				EditorNode::get_singleton()->save_resource_as(edited_shaders[index].shader_inc, path);
 			}
-			if (edited_shaders[index].shader_editor) {
-				edited_shaders[index].shader_editor->tag_saved_version();
+			if (editor) {
+				editor->tag_saved_version();
 			}
 		} break;
 		case FILE_INSPECT: {

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -730,6 +730,8 @@ void TextShaderEditor::_editor_settings_changed() {
 	shader_editor->get_text_editor()->add_theme_constant_override("line_spacing", EDITOR_GET("text_editor/appearance/whitespace/line_spacing"));
 	shader_editor->get_text_editor()->set_draw_breakpoints_gutter(false);
 	shader_editor->get_text_editor()->set_draw_executing_lines_gutter(false);
+
+	trim_trailing_whitespace_on_save = EDITOR_GET("text_editor/behavior/files/trim_trailing_whitespace_on_save");
 }
 
 void TextShaderEditor::_show_warnings_panel(bool p_show) {
@@ -890,6 +892,10 @@ void TextShaderEditor::save_external_data(const String &p_str) {
 		return;
 	}
 
+	if (trim_trailing_whitespace_on_save) {
+		trim_trailing_whitespace();
+	}
+
 	apply_shaders();
 
 	Ref<Shader> edited_shader = shader_editor->get_edited_shader();
@@ -910,6 +916,10 @@ void TextShaderEditor::save_external_data(const String &p_str) {
 	shader_editor->get_text_editor()->tag_saved_version();
 
 	disk_changed->hide();
+}
+
+void TextShaderEditor::trim_trailing_whitespace() {
+	shader_editor->trim_trailing_whitespace();
 }
 
 void TextShaderEditor::validate_script() {
@@ -1192,6 +1202,8 @@ TextShaderEditor::TextShaderEditor() {
 
 	disk_changed->add_button(TTR("Resave"), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "resave");
 	disk_changed->connect("custom_action", callable_mp(this, &TextShaderEditor::save_external_data));
+
+	trim_trailing_whitespace_on_save = EDITOR_GET("text_editor/behavior/files/trim_trailing_whitespace_on_save");
 
 	add_child(disk_changed);
 

--- a/editor/plugins/text_shader_editor.h
+++ b/editor/plugins/text_shader_editor.h
@@ -171,6 +171,8 @@ class TextShaderEditor : public MarginContainer {
 
 	uint32_t dependencies_version = 0xFFFFFFFF;
 
+	bool trim_trailing_whitespace_on_save;
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -182,12 +184,14 @@ protected:
 
 public:
 	bool was_compilation_successful() const { return compilation_success; }
+	bool get_trim_trailing_whitespace_on_save() const { return trim_trailing_whitespace_on_save; }
 	void apply_shaders();
 	void ensure_select_current();
 	void edit(const Ref<Shader> &p_shader);
 	void edit(const Ref<ShaderInclude> &p_shader_inc);
 	void goto_line_selection(int p_line, int p_begin, int p_end);
 	void save_external_data(const String &p_str = "");
+	void trim_trailing_whitespace();
 	void validate_script();
 	bool is_unsaved() const;
 	void tag_saved_version();


### PR DESCRIPTION
Fixes #74484 

The shader editor wasn't hooked up to the `trim trailing whitespace on save` editor setting before, so whitespace was never trimmed. Now it does and it is.