### PR TITLE
Prevent passing events from CodeEdit to TextEdit when code completion is active

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -261,7 +261,6 @@ void CodeEdit::_notification(int p_what) {
 
 void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	Ref<InputEventMouseButton> mb = p_gui_input;
-
 	if (mb.is_valid()) {
 		/* Ignore mouse clicks in IME input mode. */
 		if (has_ime_text()) {
@@ -270,14 +269,24 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 		if (is_code_completion_scroll_pressed && mb->get_button_index() == MouseButton::LEFT) {
 			is_code_completion_scroll_pressed = false;
+			accept_event();
+			queue_redraw();
+			return;
+		}
+
+		if (is_code_completion_drag_started && !mb->is_pressed()) {
+			is_code_completion_drag_started = false;
+			accept_event();
 			queue_redraw();
 			return;
 		}
 
 		if (code_completion_active && code_completion_rect.has_point(mb->get_position())) {
 			if (!mb->is_pressed()) {
+				accept_event();
 				return;
 			}
+			is_code_completion_drag_started = true;
 
 			switch (mb->get_button_index()) {
 				case MouseButton::WHEEL_UP: {
@@ -309,19 +318,23 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					break;
 			}
 
+			accept_event();
 			return;
 		} else if (code_completion_active && code_completion_scroll_rect.has_point(mb->get_position())) {
 			if (mb->get_button_index() != MouseButton::LEFT) {
+				accept_event();
 				return;
 			}
 
 			if (mb->is_pressed()) {
+				is_code_completion_drag_started = true;
 				is_code_completion_scroll_pressed = true;
 
 				_update_scroll_selected_line(mb->get_position().y);
 				queue_redraw();
 			}
 
+			accept_event();
 			return;
 		}
 
@@ -394,12 +407,19 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		bool scroll_hovered = code_completion_scroll_rect.has_point(mpos);
 		if (is_code_completion_scroll_hovered != scroll_hovered) {
 			is_code_completion_scroll_hovered = scroll_hovered;
+			accept_event();
 			queue_redraw();
 		}
 
 		if (is_code_completion_scroll_pressed) {
 			_update_scroll_selected_line(mpos.y);
+			accept_event();
 			queue_redraw();
+			return;
+		}
+
+		if (code_completion_active && code_completion_rect.has_point(mm->get_position())) {
+			accept_event();
 			return;
 		}
 	}
@@ -412,7 +432,11 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 	bool update_code_completion = false;
 	if (!k.is_valid()) {
-		TextEdit::gui_input(p_gui_input);
+		// MouseMotion events should not be handled by TextEdit logic if we're
+		// currently clicking and dragging from the code completion panel.
+		if (!mm.is_valid() || !is_code_completion_drag_started) {
+			TextEdit::gui_input(p_gui_input);
+		}
 		return;
 	}
 
@@ -2084,6 +2108,7 @@ void CodeEdit::cancel_code_completion() {
 	}
 	code_completion_forced = false;
 	code_completion_active = false;
+	is_code_completion_drag_started = false;
 	queue_redraw();
 }
 

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -211,6 +211,7 @@ private:
 	bool code_completion_active = false;
 	bool is_code_completion_scroll_hovered = false;
 	bool is_code_completion_scroll_pressed = false;
+	bool is_code_completion_drag_started = false;
 	Vector<ScriptLanguage::CodeCompletionOption> code_completion_options;
 	int code_completion_line_ofs = 0;
 	int code_completion_current_selected = 0;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/63726. Fixes https://github.com/godotengine/godot/issues/72114.
Supersedes https://github.com/godotengine/godot/pull/63876.

The same idea as https://github.com/godotengine/godot/pull/63876, but covering even more cases. We now prevent mouse button events from passing as well as mouse motion. On top of that, we keep track of drag activity starting from the completion panel and don't pass those events either, preventing TextEdit from consuming them as selection.

Typing, code completion, and normal selection seem to still work as expected. Do note that it's a bit tricky to reproduce the issue. Sometimes you type the text to bring up the completion panel, move your mouse and attempt to drag, and there is no problem. And sometimes you can consistently keep doing the same and get erroneous selection to appear every time. For whatever reason, keeping your cursor over the same line you type on gives me a smaller chance to trigger the error, while having your cursor a line or a few above was more consistent. Perhaps it's some weird timing issue.