### PR TITLE
SCons: Cleanup pulseaudio defines for Linux

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -307,11 +307,12 @@ def configure(env: "Environment"):
         if not env["use_sowrap"]:
             if os.system("pkg-config --exists libpulse") == 0:  # 0 means found
                 env.ParseConfig("pkg-config libpulse --cflags --libs")
-                env.Append(CPPDEFINES=["PULSEAUDIO_ENABLED", "_REENTRANT"])
+                env.Append(CPPDEFINES=["PULSEAUDIO_ENABLED"])
             else:
                 print("Warning: PulseAudio development libraries not found. Disabling the PulseAudio audio driver.")
                 env["pulseaudio"] = False
-        env.Append(CPPDEFINES=["PULSEAUDIO_ENABLED", "_REENTRANT"])
+        else:
+            env.Append(CPPDEFINES=["PULSEAUDIO_ENABLED", "_REENTRANT"])
 
     if env["dbus"]:
         if not env["use_sowrap"]:


### PR DESCRIPTION
No need to define _REENTRANT manually when using the system lib, it's part of the pkgconfig cflags.
And we were then defining PULSEAUDIO_ENABLED twice.