### PR TITLE
Add dedicated setter for `ImageTextureLayered::_images` to fix `create_from_images` being hidden from the C# bindings

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2935,6 +2935,10 @@ TypedArray<Image> ImageTextureLayered::_get_images() const {
 	return images;
 }
 
+void ImageTextureLayered::_set_images(const TypedArray<Image> &p_images) {
+	ERR_FAIL_COND(_create_from_images(p_images) != OK);
+}
+
 Error ImageTextureLayered::create_from_images(Vector<Ref<Image>> p_images) {
 	int new_layers = p_images.size();
 	ERR_FAIL_COND_V(new_layers == 0, ERR_INVALID_PARAMETER);
@@ -3014,8 +3018,9 @@ void ImageTextureLayered::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("update_layer", "image", "layer"), &ImageTextureLayered::update_layer);
 
 	ClassDB::bind_method(D_METHOD("_get_images"), &ImageTextureLayered::_get_images);
+	ClassDB::bind_method(D_METHOD("_set_images", "images"), &ImageTextureLayered::_set_images);
 
-	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "_images", PROPERTY_HINT_ARRAY_TYPE, "Image", PROPERTY_USAGE_INTERNAL), "create_from_images", "_get_images");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "_images", PROPERTY_HINT_ARRAY_TYPE, "Image", PROPERTY_USAGE_INTERNAL), "_set_images", "_get_images");
 }
 
 ImageTextureLayered::ImageTextureLayered(LayeredType p_layered_type) {

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -427,6 +427,7 @@ class ImageTextureLayered : public TextureLayered {
 	Error _create_from_images(const TypedArray<Image> &p_images);
 
 	TypedArray<Image> _get_images() const;
+	void _set_images(const TypedArray<Image> &p_images);
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/74649

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
