### PR TITLE
[3.x] Deferred NOTIFICATION_MOVED_IN_PARENT and register interest

### DIFF
--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -1287,6 +1287,7 @@ CanvasItem::CanvasItem() :
 	light_mask = 1;
 
 	C = nullptr;
+	_set_observe_notification_moved_in_parent(true);
 }
 
 CanvasItem::~CanvasItem() {

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -411,6 +411,7 @@ CanvasLayer::CanvasLayer() {
 	follow_viewport = false;
 	follow_viewport_scale = 1.0;
 	_layer_order_in_tree = 0;
+	_set_observe_notification_moved_in_parent(true);
 }
 
 CanvasLayer::~CanvasLayer() {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -134,6 +134,13 @@ private:
 
 		int process_priority;
 
+		// In order to prevent sending NOTIFICATION_MOVED_IN_PARENT multiple
+		// times per tick / frame, we defer this to once per tick, and maintain a range of moved
+		// children to send the notification.
+		// If "last_child_moved_plus_one" is set to zero, no children were moved this tick.
+		uint32_t first_child_moved;
+		uint32_t last_child_moved_plus_one;
+
 		// Keep bitpacked values together to get better packing
 		PauseMode pause_mode : 2;
 		PhysicsInterpolationMode physics_interpolation_mode : 2;
@@ -180,6 +187,8 @@ private:
 		bool inside_tree : 1;
 		bool ready_notified : 1; //this is a small hack, so if a node is added during _ready() to the tree, it correctly gets the _ready() notification
 		bool ready_first : 1;
+
+		bool observe_notification_moved_in_parent : 1;
 
 		mutable NodePath *path_cache;
 
@@ -257,6 +266,7 @@ protected:
 	bool _is_physics_interpolation_reset_requested() const { return data.physics_interpolation_reset_requested; }
 	void _set_use_identity_transform(bool p_enable);
 	bool _is_using_identity_transform() const { return data.use_identity_transform; }
+	void _set_observe_notification_moved_in_parent(bool p_enable) { data.observe_notification_moved_in_parent = p_enable; }
 
 public:
 	enum {

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -280,7 +280,15 @@ private:
 	static int idle_callback_count;
 	void _call_idle_callbacks();
 
+	// List of parent nodes that have children moved within,
+	// that are in need of a deferred NOTIFICATION_MOVED_IN_PARENT.
+	LocalVector<ObjectID> _pending_children_moved_parents;
+	void notify_children_moved(Node &p_parent, uint32_t p_first_child, uint32_t p_last_child_plus_one);
+	void notify_child_count_reduced(Node &p_parent);
+
 protected:
+	void flush_children_moved();
+
 	void _notification(int p_notification);
 	static void _bind_methods();
 


### PR DESCRIPTION
Adds the ability to defer sending `NOTIFICATION_MOVED_IN_PARENT` to the next flush, instead of sending notifications immediately. This system allows the prevention of duplicate notifications on the same frame, which can result in large numbers of notifications and slowdown.

For efficiency, stores the range of children moved on the parent node, rather than storing each child individually.

Additionally 2D nodes register an interest in observing `NOTIFICATION_MOVED_IN_PARENT`, this is tested before sending the final notification.

Use in conjunction with #65581
Helps address #61929 (specifically the non-deletion cases)

## Flushes
As this PR is only concerned with `MOVED_IN_PARENT` I've experimentally tried only flushing the notifications once prior to rendering, rather than every physics tick as in #65581 . The notification is used in three areas, and I'm not convinced yet it requires flushing except prior to rendering (and no testing so far suggests this).

Given that it is easy enough to add the flushes in during physics tick (one line), it is probably worth trying this out for a beta with a single flush. The reasoning is that we do flush each tick, if items are moved several times during multiple physics ticks before a frame, their canvas_item order ID will be sent multiple times (needlessly) to `VisualServer`.

## Notes
* As currently the only notification responsible for "notification explosion" problems, this is a more targetted alternative to the approach in #65581
* I first mentioned this approach in https://github.com/godotengine/godot/issues/61929#issuecomment-1354351264 .
* This has the advantage that a range is stored on the parent node, instead of individually checking each child node whether it already has a deferred notification pending. This is more efficient for this particular notification, but in return it doesn't work in the general case, hence the difference between the two PRs (deferred notifications is more general if any future notifications required the same).
*  This also includes the check for interest before sending the notification that I first mentioned in https://github.com/godotengine/godot/pull/65581#issue-1368085497 , which @Zylann later made a PR for in #70265 . On reflection, it does seem worth using in conjunction with the other methods, because the `notification()` call is rather heavyweight, calling functions on each class in the inheritance hierarchy as well as potentially script.
* I did have some concerns that checking for interest may not be backward compatible, however it does seem unlikely that many users will have created 2D nodes outside of inheriting `canvas_item`. Even in this case in a heavily modded version of Godot, then a call to `_set_observe_notification_moved_in_parent()` is enough to re-establish the old behaviour, so on balance it seems worth doing, given the benefits.

## Performance
As with #65581 this drastically reduces notifications, and even more so because of the range optimization specific to `NOTIFICATION_MOVED_IN_PARENT`.

## Which alternative
Both versions address the problem pretty well - #65581 is more generic and future proof, whereas this PR is more efficient but only designed for this single problematic notification.
Personally I would probably be tempted to go for this version, as we are unlikely to need more deferred notification types in 3.x, and it should be more efficient.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
