### PR TITLE
Add "filesRoot" path to Android provider paths xml

### DIFF
--- a/platform/android/java/lib/res/xml/godot_provider_paths.xml
+++ b/platform/android/java/lib/res/xml/godot_provider_paths.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
 
+	<files-path
+		name="filesRoot"
+		path="/" />
+
 	<external-path
 		name="public"
 		path="." />


### PR DESCRIPTION
Adds a `filesRoot` provider path to the Android build `godot_provider_paths.xml` file.

See: https://github.com/godotengine/godot/pull/72495#issuecomment-1455241402

This allows custom Android plugins to register the project as a `androidx.core.content.FileProvider` for sharing capabilities in a compatible way with the changes in #72495.

@Derektamente has tested it with their [Godroid plugin](https://github.com/Derektamente/Godroid) and verified that it works.