### PR TITLE
Properly remember snapping options per-project

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -891,6 +891,14 @@ void CanvasItemEditor::_commit_canvas_item_state(List<CanvasItem *> p_canvas_ite
 
 void CanvasItemEditor::_snap_changed() {
 	static_cast<SnapDialog *>(snap_dialog)->get_fields(grid_offset, grid_step, primary_grid_steps, snap_rotation_offset, snap_rotation_step, snap_scale_step);
+
+	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "grid_offset", grid_offset);
+	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "grid_step", grid_step);
+	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "primary_grid_steps", primary_grid_steps);
+	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "snap_rotation_offset", snap_rotation_offset);
+	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "snap_rotation_step", snap_rotation_step);
+	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "snap_scale_step", snap_scale_step);
+
 	grid_step_multiplier = 0;
 	viewport->queue_redraw();
 }
@@ -4892,6 +4900,15 @@ void CanvasItemEditor::set_state(const Dictionary &p_state) {
 	viewport->queue_redraw();
 }
 
+void CanvasItemEditor::clear() {
+	grid_offset = EditorSettings::get_singleton()->get_project_metadata("2d_editor", "grid_offset", Vector2());
+	grid_step = EditorSettings::get_singleton()->get_project_metadata("2d_editor", "grid_step", Vector2(8, 8));
+	primary_grid_steps = EditorSettings::get_singleton()->get_project_metadata("2d_editor", "primary_grid_steps", 8);
+	snap_rotation_step = EditorSettings::get_singleton()->get_project_metadata("2d_editor", "snap_rotation_step", Math::deg_to_rad(15.0));
+	snap_rotation_offset = EditorSettings::get_singleton()->get_project_metadata("2d_editor", "snap_rotation_offset", 0.0);
+	snap_scale_step = EditorSettings::get_singleton()->get_project_metadata("2d_editor", "snap_scale_step", 0.1);
+}
+
 void CanvasItemEditor::add_control_to_menu_panel(Control *p_control) {
 	ERR_FAIL_COND(!p_control);
 
@@ -5420,6 +5437,10 @@ Dictionary CanvasItemEditorPlugin::get_state() const {
 
 void CanvasItemEditorPlugin::set_state(const Dictionary &p_state) {
 	canvas_item_editor->set_state(p_state);
+}
+
+void CanvasItemEditorPlugin::clear() {
+	canvas_item_editor->clear();
 }
 
 void CanvasItemEditorPlugin::_notification(int p_what) {

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -211,15 +211,15 @@ private:
 
 	bool selected_from_canvas = false;
 
+	// Defaults are defined in clear().
 	Point2 grid_offset;
-	// A power-of-two value works better as a default grid size.
-	Point2 grid_step = Point2(8, 8);
-	int primary_grid_steps = 8;
+	Point2 grid_step;
+	int primary_grid_steps = 0;
 	int grid_step_multiplier = 0;
 
-	real_t snap_rotation_step = Math::deg_to_rad(15.0);
+	real_t snap_rotation_step = 0.0;
 	real_t snap_rotation_offset = 0.0;
-	real_t snap_scale_step = 0.1f;
+	real_t snap_scale_step = 0.0;
 	bool smart_snap_active = false;
 	bool grid_snap_active = false;
 
@@ -526,6 +526,7 @@ public:
 	static CanvasItemEditor *get_singleton() { return singleton; }
 	Dictionary get_state() const;
 	void set_state(const Dictionary &p_state);
+	void clear();
 
 	void add_control_to_menu_panel(Control *p_control);
 	void remove_control_from_menu_panel(Control *p_control);
@@ -575,6 +576,7 @@ public:
 	virtual void make_visible(bool p_visible) override;
 	virtual Dictionary get_state() const override;
 	virtual void set_state(const Dictionary &p_state) override;
+	virtual void clear() override;
 
 	CanvasItemEditor *get_canvas_item_editor() { return canvas_item_editor; }
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -5995,6 +5995,10 @@ void Node3DEditor::_snap_changed() {
 	snap_translate_value = snap_translate->get_text().to_float();
 	snap_rotate_value = snap_rotate->get_text().to_float();
 	snap_scale_value = snap_scale->get_text().to_float();
+
+	EditorSettings::get_singleton()->set_project_metadata("3d_editor", "snap_translate_value", snap_translate_value);
+	EditorSettings::get_singleton()->set_project_metadata("3d_editor", "snap_rotate_value", snap_rotate_value);
+	EditorSettings::get_singleton()->set_project_metadata("3d_editor", "snap_scale_value", snap_scale_value);
 }
 
 void Node3DEditor::_snap_update() {
@@ -7853,6 +7857,11 @@ void Node3DEditor::clear() {
 	settings_znear->set_value(EDITOR_GET("editors/3d/default_z_near"));
 	settings_zfar->set_value(EDITOR_GET("editors/3d/default_z_far"));
 
+	snap_translate_value = EditorSettings::get_singleton()->get_project_metadata("3d_editor", "snap_translate_value", 1);
+	snap_rotate_value = EditorSettings::get_singleton()->get_project_metadata("3d_editor", "snap_rotate_value", 15);
+	snap_scale_value = EditorSettings::get_singleton()->get_project_metadata("3d_editor", "snap_scale_value", 10);
+	_snap_update();
+
 	for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {
 		viewports[i]->reset();
 	}
@@ -8306,10 +8315,6 @@ Node3DEditor::Node3DEditor() {
 	}
 
 	/* SNAP DIALOG */
-
-	snap_translate_value = 1;
-	snap_rotate_value = 15;
-	snap_scale_value = 10;
 
 	snap_dialog = memnew(ConfirmationDialog);
 	snap_dialog->set_title(TTR("Snap Settings"));

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -848,6 +848,12 @@ void TextureRegionEditor::_notification(int p_what) {
 			if (snap_mode == SNAP_AUTOSLICE && is_visible() && autoslice_is_dirty) {
 				_update_autoslice();
 			}
+
+			if (!is_visible()) {
+				EditorSettings::get_singleton()->set_project_metadata("texture_region_editor", "snap_step", snap_step);
+				EditorSettings::get_singleton()->set_project_metadata("texture_region_editor", "snap_separation", snap_separation);
+				EditorSettings::get_singleton()->set_project_metadata("texture_region_editor", "snap_mode", snap_mode);
+			}
 		} break;
 
 		case NOTIFICATION_WM_WINDOW_FOCUS_IN: {
@@ -1076,9 +1082,9 @@ TextureRegionEditor::TextureRegionEditor() {
 	preview_tex = Ref<CanvasTexture>(memnew(CanvasTexture));
 
 	// A power-of-two value works better as a default grid size.
-	snap_step = Vector2(8, 8);
-	snap_separation = Vector2(0, 0);
-	snap_mode = SNAP_NONE;
+	snap_step = EditorSettings::get_singleton()->get_project_metadata("texture_region_editor", "snap_step", Vector2(8, 8));
+	snap_separation = EditorSettings::get_singleton()->get_project_metadata("texture_region_editor", "snap_separation", Vector2());
+	snap_mode = EditorSettings::get_singleton()->get_project_metadata("texture_region_editor", "snap_mode", SNAP_NONE);
 	edited_margin = -1;
 	drag_index = -1;
 	drag = false;


### PR DESCRIPTION
This PR makes snapping options properly remembered and re-used. No more resetting the grid to 8x8 for no reason, the editor will remember the settings you set last time and use it for each new scene (both for 2D and 3D.
TextureRegionEditor will also remember its snapping settings.

Closes https://github.com/godotengine/godot-proposals/issues/1348 and closes https://github.com/godotengine/godot-proposals/issues/4362 (if these options are remembered properly within the project then a setting isn't really necessary anymore, but idk)

*Edit by Akien:* Confirmed this is a sufficient fix for those proposals, so changed to closing keywords.