### PR TITLE
SDF particles collider baking in exported project

### DIFF
--- a/doc/classes/GPUParticlesCollisionSDF3D.xml
+++ b/doc/classes/GPUParticlesCollisionSDF3D.xml
@@ -7,7 +7,7 @@
 		Baked signed distance field 3D particle attractor affecting [GPUParticles3D] nodes.
 		Signed distance fields (SDF) allow for efficiently representing approximate collision shapes for convex and concave objects of any shape. This is more flexible than [GPUParticlesCollisionHeightField3D], but it requires a baking step.
 		[b]Baking:[/b] The signed distance field texture can be baked by selecting the [GPUParticlesCollisionSDF3D] node in the editor, then clicking [b]Bake SDF[/b] at the top of the 3D viewport. Any [i]visible[/i] [MeshInstance3D]s within the [member size] will be taken into account for baking, regardless of their [member GeometryInstance3D.gi_mode].
-		[b]Note:[/b] Baking a [GPUParticlesCollisionSDF3D]'s [member texture] is only possible within the editor, as there is no bake method exposed for use in exported projects. However, it's still possible to load pre-baked [Texture3D]s into its [member texture] property in an exported project.
+		[b]Note:[/b] Baking a [GPUParticlesCollisionSDF3D]'s [member texture] in an exported project is possible with the [method bake_in_memory] method. it's also possible to load pre-baked [Texture3D]s into its [member texture] property in an exported project.
 		[b]Note:[/b] [member ParticleProcessMaterial.collision_mode] must be [constant ParticleProcessMaterial.COLLISION_RIGID] or [constant ParticleProcessMaterial.COLLISION_HIDE_ON_CONTACT] on the [GPUParticles3D]'s process material for collision to work.
 		[b]Note:[/b] Particle collision only affects [GPUParticles3D], not [CPUParticles3D].
 	</description>
@@ -27,6 +27,12 @@
 			<param index="1" name="value" type="bool" />
 			<description>
 				Based on [param value], enables or disables the specified layer in the [member bake_mask], given a [param layer_number] between 1 and 32.
+			</description>
+		</method>
+		<method name="bake_in_memory">
+			<return type="void" />
+			<description>
+				Bakes the geometry to the [member texture] member. It won't compress the texture. Only use this method when generating the SDF in-game.
 			</description>
 		</method>
 	</methods>

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -522,6 +522,24 @@ Ref<Image> GPUParticlesCollisionSDF3D::bake() {
 	return ret;
 }
 
+void GPUParticlesCollisionSDF3D::bake_in_memory() {
+	Ref<Image> image = bake();
+	uint32_t width = image->get_width();
+	uint32_t depth = image->get_meta("depth");
+	uint32_t height = image->get_height() / depth;
+
+	Vector<Ref<Image>> images;
+	for (uint32_t i = 0; i < depth; i++) {
+		Ref<Image> sub_image = image->get_region(Rect2i(0, height * i, width, height));
+		images.push_back(sub_image);
+	}
+
+	Ref<ImageTexture3D> texture;
+	texture.instantiate();
+	texture->create(image->get_format(), width, height, depth, false, images);
+	set_texture(texture);
+}
+
 PackedStringArray GPUParticlesCollisionSDF3D::get_configuration_warnings() const {
 	PackedStringArray warnings = Node::get_configuration_warnings();
 
@@ -549,6 +567,8 @@ void GPUParticlesCollisionSDF3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_bake_mask"), &GPUParticlesCollisionSDF3D::get_bake_mask);
 	ClassDB::bind_method(D_METHOD("set_bake_mask_value", "layer_number", "value"), &GPUParticlesCollisionSDF3D::set_bake_mask_value);
 	ClassDB::bind_method(D_METHOD("get_bake_mask_value", "layer_number"), &GPUParticlesCollisionSDF3D::get_bake_mask_value);
+
+	ClassDB::bind_method(D_METHOD("bake_in_memory"), &GPUParticlesCollisionSDF3D::bake_in_memory);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "size", PROPERTY_HINT_RANGE, "0.01,1024,0.01,or_greater,suffix:m"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "resolution", PROPERTY_HINT_ENUM, "16,32,64,128,256,512"), "set_resolution", "get_resolution");

--- a/scene/3d/gpu_particles_collision_3d.h
+++ b/scene/3d/gpu_particles_collision_3d.h
@@ -192,6 +192,7 @@ public:
 
 	Vector3i get_estimated_cell_size() const;
 	Ref<Image> bake();
+	void bake_in_memory();
 
 	virtual AABB get_aabb() const override;
 


### PR DESCRIPTION
Allow baking of GPUParticlesCollisionSDF3D textures in exported projects with the bake_in_memory() method.

I worked on this after opening this proposal https://github.com/godotengine/godot-proposals/issues/6468
