### PR TITLE
Allow reducing SplitContainer drag bar thickness using the default themes

### DIFF
--- a/editor/icons/GuiHsplitter.svg
+++ b/editor/icons/GuiHsplitter.svg
@@ -1,1 +1,1 @@
-<svg height="64" viewBox="0 0 8 64" width="8" xmlns="http://www.w3.org/2000/svg"><path d="m4 990.36v60" fill="none" stroke="#fff" stroke-linecap="round" stroke-opacity=".39216" stroke-width="2" transform="translate(0 -988.36)"/></svg>
+<svg height="64" viewBox="0 0 2 64" width="2" xmlns="http://www.w3.org/2000/svg"><path d="m1 990.36v60" fill="none" stroke="#fff" stroke-linecap="round" stroke-opacity=".39216" stroke-width="2" transform="translate(0 -988.36)"/></svg>

--- a/editor/icons/GuiViewportHdiagsplitter.svg
+++ b/editor/icons/GuiViewportHdiagsplitter.svg
@@ -1,1 +1,1 @@
-<svg height="34" viewBox="0 0 64 34" width="64" xmlns="http://www.w3.org/2000/svg"><path d="m4.0307 1048.4h29.969m-30 30v-60" fill="none" stroke="#fff" stroke-linecap="round" stroke-opacity=".39216" stroke-width="2" transform="matrix(0 1 -1 0 1080.4 -2)"/></svg>
+<svg height="64" viewBox="0 0 64 64" width="64" xmlns="http://www.w3.org/2000/svg"><path d="m4 1048.4h30m-30 30v-60" fill="none" stroke="#fff" stroke-linecap="round" stroke-opacity=".39216" stroke-width="2" transform="matrix(0 1 -1 0 1080.4 28)"/></svg>

--- a/editor/icons/GuiViewportVdiagsplitter.svg
+++ b/editor/icons/GuiViewportVdiagsplitter.svg
@@ -1,1 +1,1 @@
-<svg height="64" viewBox="0 0 34 64" width="34" xmlns="http://www.w3.org/2000/svg"><path d="m4.0307 1048.4h29.969m-30 30v-60" fill="none" stroke="#fff" stroke-linecap="round" stroke-opacity=".39216" stroke-width="2" transform="matrix(-1 0 0 -1 36.008 1080.4)"/></svg>
+<svg height="64" viewBox="0 0 64 64" width="64" xmlns="http://www.w3.org/2000/svg"><path d="m-26 1048.4h60m-30 30v-30" fill="none" stroke="#fff" stroke-linecap="round" stroke-opacity=".39216" stroke-width="2" transform="matrix(0 1 -1 0 1080.4 28)"/></svg>

--- a/editor/icons/GuiVsplitter.svg
+++ b/editor/icons/GuiVsplitter.svg
@@ -1,1 +1,1 @@
-<svg height="8" viewBox="0 0 64 8" width="64" xmlns="http://www.w3.org/2000/svg"><path d="m2 1048.4h60" fill="none" stroke="#fff" stroke-linecap="round" stroke-opacity=".39216" stroke-width="2" transform="translate(0 -1044.4)"/></svg>
+<svg height="2" viewBox="0 0 64 2" width="64" xmlns="http://www.w3.org/2000/svg"><path d="m2 1045.4h60" fill="none" stroke="#fff" stroke-linecap="round" stroke-opacity=".39216" stroke-width="2" transform="translate(0 -1044.4)"/></svg>

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -5363,7 +5363,7 @@ void Node3DEditorViewportContainer::_notification(int p_what) {
 					} break;
 					case VIEW_USE_3_VIEWPORTS: {
 						if ((hovering_v && hovering_h && !dragging_v && !dragging_h) || (dragging_v && dragging_h)) {
-							draw_texture(hdiag_grabber, Vector2(mid_w - hdiag_grabber->get_width() / 2, mid_h - v_grabber->get_height() / 4));
+							draw_texture(hdiag_grabber, Vector2(mid_w - hdiag_grabber->get_width() / 2, mid_h - hdiag_grabber->get_height() / 2));
 							set_default_cursor_shape(CURSOR_DRAG);
 						} else if ((hovering_v && !dragging_h) || dragging_v) {
 							draw_texture(v_grabber, Vector2((size.width - v_grabber->get_width()) / 2, mid_h - v_grabber->get_height() / 2));
@@ -5376,7 +5376,7 @@ void Node3DEditorViewportContainer::_notification(int p_what) {
 					} break;
 					case VIEW_USE_3_VIEWPORTS_ALT: {
 						if ((hovering_v && hovering_h && !dragging_v && !dragging_h) || (dragging_v && dragging_h)) {
-							draw_texture(vdiag_grabber, Vector2(mid_w - vdiag_grabber->get_width() + v_grabber->get_height() / 4, mid_h - vdiag_grabber->get_height() / 2));
+							draw_texture(vdiag_grabber, Vector2(mid_w - vdiag_grabber->get_width() / 2, mid_h - vdiag_grabber->get_height() / 2));
 							set_default_cursor_shape(CURSOR_DRAG);
 						} else if ((hovering_v && !dragging_h) || dragging_v) {
 							draw_texture(v_grabber, Vector2((size_left - v_grabber->get_width()) / 2, mid_h - v_grabber->get_height() / 2));

--- a/scene/resources/default_theme/hsplitter.svg
+++ b/scene/resources/default_theme/hsplitter.svg
@@ -1,1 +1,1 @@
-<svg clip-rule="evenodd" fill-rule="evenodd" stroke-linecap="round" viewBox="0 0 8 48" xmlns="http://www.w3.org/2000/svg"><path d="m4 4.012v39.976" fill="none" stroke="#808080" stroke-opacity=".65" stroke-width="1.7"/></svg>
+<svg clip-rule="evenodd" fill-rule="evenodd" stroke-linecap="round" viewBox="0 0 2 48" xmlns="http://www.w3.org/2000/svg"><path d="m1 4.012v39.976" fill="none" stroke="#808080" stroke-opacity=".65" stroke-width="1.7"/></svg>

--- a/scene/resources/default_theme/vsplitter.svg
+++ b/scene/resources/default_theme/vsplitter.svg
@@ -1,1 +1,1 @@
-<svg clip-rule="evenodd" fill-rule="evenodd" stroke-linecap="round" viewBox="0 0 48 8" xmlns="http://www.w3.org/2000/svg"><path d="m4 4h40" fill="none" stroke="#808080" stroke-opacity=".65" stroke-width="1.7"/></svg>
+<svg clip-rule="evenodd" fill-rule="evenodd" stroke-linecap="round" viewBox="0 0 48 2" xmlns="http://www.w3.org/2000/svg"><path d="m4 1h40" fill="none" stroke="#808080" stroke-opacity=".65" stroke-width="1.7"/></svg>


### PR DESCRIPTION
Using the default themes, the grabber handles of SplitContainers have some white space, making them 8px thick although the actual drawn area is 2px wide only.

Due to a minimum size enforcement based on the grabber graphic size, it is impossible to have a splitter bar thinner 
than 8px without providing an alternate grabber graphic. 
I discovered this when experimenting with the Godot theme to have thinner separators between panels.

This fixes both the default and editor themes.

The default splitter bar separation remains 8px to avoid breaking changes. But it can now be reduced down to 2px without the need to provide an alternate graphic.

Experimenting with the editor unveiled an issue in the alignment of the T-shaped center grabbers on the 3D editor.
Happens when the view is split in 3 and the separation is something else than 8px. 
This commit also fixes this point, simplifying the approach by centering those specific grabber graphics in all cases and adjusting the whitespaces in the graphics.

Compatibility with 3.x: needs adjustement to the 3.x default and editor themes.

