### PR TITLE
MultiMesh: automatically realloc MultiMesh when changing properties in editor

### DIFF
--- a/doc/classes/MultiMesh.xml
+++ b/doc/classes/MultiMesh.xml
@@ -110,13 +110,13 @@
 			See [method set_instance_transform].
 		</member>
 		<member name="transform_format" type="int" setter="set_transform_format" getter="get_transform_format" enum="MultiMesh.TransformFormat" default="0">
-			Format of transform used to transform mesh, either 2D or 3D.
+			Format of transform used to transform mesh, either 2D or 3D. Outside the editor, can only be set when [member instance_count] is [code]0[/code] or less. This means that you need to call this method before setting the instance count, or temporarily reset it to [code]0[/code].
 		</member>
 		<member name="use_colors" type="bool" setter="set_use_colors" getter="is_using_colors" default="false">
-			If [code]true[/code], the [MultiMesh] will use color data (see [method set_instance_color]). Can only be set when [member instance_count] is [code]0[/code] or less. This means that you need to call this method before setting the instance count, or temporarily reset it to [code]0[/code].
+			If [code]true[/code], the [MultiMesh] will use color data (see [method set_instance_color]). Outside the editor, can only be set when [member instance_count] is [code]0[/code] or less. This means that you need to call this method before setting the instance count, or temporarily reset it to [code]0[/code].
 		</member>
 		<member name="use_custom_data" type="bool" setter="set_use_custom_data" getter="is_using_custom_data" default="false">
-			If [code]true[/code], the [MultiMesh] will use custom data (see [method set_instance_custom_data]). Can only be set when [member instance_count] is [code]0[/code] or less. This means that you need to call this method before setting the instance count, or temporarily reset it to [code]0[/code].
+			If [code]true[/code], the [MultiMesh] will use custom data (see [method set_instance_custom_data]). Outside the editor, can only be set when [member instance_count] is [code]0[/code] or less. This means that you need to call this method before setting the instance count, or temporarily reset it to [code]0[/code].
 		</member>
 		<member name="visible_instance_count" type="int" setter="set_visible_instance_count" getter="get_visible_instance_count" default="-1">
 			Limits the number of instances drawn, -1 draws all instances. Changing this does not change the sizes of the buffers.

--- a/scene/resources/multimesh.cpp
+++ b/scene/resources/multimesh.cpp
@@ -278,7 +278,11 @@ RID MultiMesh::get_rid() const {
 }
 
 void MultiMesh::set_use_colors(bool p_enable) {
-	ERR_FAIL_COND(instance_count > 0);
+	if (Engine::get_singleton()->is_editor_hint()) {
+		RenderingServer::get_singleton()->multimesh_allocate_data(multimesh, instance_count, RS::MultimeshTransformFormat(transform_format), p_enable, use_custom_data);
+	} else {
+		ERR_FAIL_COND(instance_count > 0);
+	}
 	use_colors = p_enable;
 }
 
@@ -287,7 +291,11 @@ bool MultiMesh::is_using_colors() const {
 }
 
 void MultiMesh::set_use_custom_data(bool p_enable) {
-	ERR_FAIL_COND(instance_count > 0);
+	if (Engine::get_singleton()->is_editor_hint()) {
+		RenderingServer::get_singleton()->multimesh_allocate_data(multimesh, instance_count, RS::MultimeshTransformFormat(transform_format), use_colors, p_enable);
+	} else {
+		ERR_FAIL_COND(instance_count > 0);
+	}
 	use_custom_data = p_enable;
 }
 
@@ -296,7 +304,11 @@ bool MultiMesh::is_using_custom_data() const {
 }
 
 void MultiMesh::set_transform_format(TransformFormat p_transform_format) {
-	ERR_FAIL_COND(instance_count > 0);
+	if (Engine::get_singleton()->is_editor_hint()) {
+		RenderingServer::get_singleton()->multimesh_allocate_data(multimesh, instance_count, RS::MultimeshTransformFormat(p_transform_format), use_colors, use_custom_data);
+	} else {
+		ERR_FAIL_COND(instance_count > 0);
+	}
 	transform_format = p_transform_format;
 }
 


### PR DESCRIPTION
Allows `MultiMesh::set_transform_format`, `MultiMesh::set_use_colors`, and `MultiMesh::set_use_custom_data` to be used in the editor without setting `instance_count` to 0 beforehand.