### PR TITLE
Prevent project manager from deleting files when removing projects

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2466,7 +2466,7 @@ void ProjectManager::_rename_project() {
 }
 
 void ProjectManager::_erase_project_confirm() {
-	_project_list->erase_selected_projects(delete_project_contents->is_pressed());
+	_project_list->erase_selected_projects(false);
 	_update_project_buttons();
 }
 
@@ -2484,13 +2484,12 @@ void ProjectManager::_erase_project() {
 
 	String confirm_message;
 	if (selected_list.size() >= 2) {
-		confirm_message = vformat(TTR("Remove %d projects from the list?"), selected_list.size());
+		confirm_message = vformat(TTR("Remove %d projects from the list?\nThe project folders' contents won't be modified."), selected_list.size());
 	} else {
-		confirm_message = TTR("Remove this project from the list?");
+		confirm_message = TTR("Remove this project from the list?\nThe project folders' contents won't be modified.");
 	}
 
 	erase_ask_label->set_text(confirm_message);
-	delete_project_contents->set_pressed(false);
 	erase_ask->popup_centered();
 }
 
@@ -2952,10 +2951,6 @@ ProjectManager::ProjectManager() {
 
 		erase_ask_label = memnew(Label);
 		erase_ask_vb->add_child(erase_ask_label);
-
-		delete_project_contents = memnew(CheckBox);
-		delete_project_contents->set_text(TTR("Also delete project contents (no undo!)"));
-		erase_ask_vb->add_child(delete_project_contents);
 
 		multi_open_ask = memnew(ConfirmationDialog);
 		multi_open_ask->set_ok_button_text(TTR("Edit"));

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -82,7 +82,6 @@ class ProjectManager : public Control {
 
 	ConfirmationDialog *erase_ask = nullptr;
 	Label *erase_ask_label = nullptr;
-	CheckBox *delete_project_contents = nullptr;
 
 	ConfirmationDialog *erase_missing_ask = nullptr;
 	ConfirmationDialog *multi_open_ask = nullptr;


### PR DESCRIPTION
Fixes #74678 

This is a quick fix for the immediate problem. The project manager doesn't provide the option to move the directory contents to the trash anymore. I also added some words making it clear that nothing will be deleted. The larger issue of the projet manager UX probably requires a separate proposal.

As an aside: I think the sentence "The project folders' contents won't be modified." could be replaced with something more to the point, like "This will not delete any files." May be worth discussing.