### PR TITLE
Add `recovery_as_collision` to extension binding of `_body_test_motion`

### DIFF
--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -606,7 +606,8 @@
 			<param index="3" name="margin" type="float" />
 			<param index="4" name="max_collisions" type="int" />
 			<param index="5" name="collide_separation_ray" type="bool" />
-			<param index="6" name="result" type="PhysicsServer3DExtensionMotionResult*" />
+			<param index="6" name="recovery_as_collision" type="bool" />
+			<param index="7" name="result" type="PhysicsServer3DExtensionMotionResult*" />
 			<description>
 			</description>
 		</method>

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -298,7 +298,7 @@ void PhysicsServer3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_body_set_ray_pickable, "body", "enable");
 
-	GDVIRTUAL_BIND(_body_test_motion, "body", "from", "motion", "margin", "max_collisions", "collide_separation_ray", "result");
+	GDVIRTUAL_BIND(_body_test_motion, "body", "from", "motion", "margin", "max_collisions", "collide_separation_ray", "recovery_as_collision", "result");
 
 	GDVIRTUAL_BIND(_body_get_direct_state, "body");
 

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -382,7 +382,7 @@ public:
 
 	EXBIND2(body_set_ray_pickable, RID, bool)
 
-	GDVIRTUAL7RC(bool, _body_test_motion, RID, const Transform3D &, const Vector3 &, real_t, int, bool, GDExtensionPtr<PhysicsServer3DExtensionMotionResult>)
+	GDVIRTUAL8RC(bool, _body_test_motion, RID, const Transform3D &, const Vector3 &, real_t, int, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionMotionResult>)
 
 	thread_local static const HashSet<RID> *exclude_bodies;
 	thread_local static const HashSet<ObjectID> *exclude_objects;
@@ -394,7 +394,7 @@ public:
 		bool ret = false;
 		exclude_bodies = &p_parameters.exclude_bodies;
 		exclude_objects = &p_parameters.exclude_objects;
-		GDVIRTUAL_REQUIRED_CALL(_body_test_motion, p_body, p_parameters.from, p_parameters.motion, p_parameters.margin, p_parameters.max_collisions, p_parameters.collide_separation_ray, r_result, ret);
+		GDVIRTUAL_REQUIRED_CALL(_body_test_motion, p_body, p_parameters.from, p_parameters.motion, p_parameters.margin, p_parameters.max_collisions, p_parameters.collide_separation_ray, p_parameters.recovery_as_collision, r_result, ret);
 		exclude_bodies = nullptr;
 		exclude_objects = nullptr;
 		return ret;


### PR DESCRIPTION
Currently, when implementing support for `PhysicsServer3D::body_test_motion` from a GDExtension, the `recovery_as_collision` field of `PhysicsServer3D::MotionParameters` is not passed on as a parameter to `PhysicsServer3DExtension::_body_test_motion`, making it impossible to implement full support for things like `PhysicsBody3D.move_and_collide` or `PhysicsBody3D.test_move`.

This PR adds that parameter.