### PR TITLE
Clear filter in Project Settings when opening Layer Names

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1210,7 +1210,7 @@ void EditorPropertyLayers::_button_pressed() {
 
 void EditorPropertyLayers::_menu_pressed(int p_menu) {
 	if (p_menu == grid->layer_count) {
-		ProjectSettingsEditor::get_singleton()->popup_project_settings();
+		ProjectSettingsEditor::get_singleton()->popup_project_settings(true);
 		ProjectSettingsEditor::get_singleton()->set_general_page(basename);
 	} else {
 		if (grid->value & (1 << p_menu)) {

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1398,7 +1398,7 @@ void EditorAssetLibrary::_asset_open() {
 }
 
 void EditorAssetLibrary::_manage_plugins() {
-	ProjectSettingsEditor::get_singleton()->popup_project_settings();
+	ProjectSettingsEditor::get_singleton()->popup_project_settings(true);
 	ProjectSettingsEditor::get_singleton()->set_plugins_page();
 }
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -45,7 +45,7 @@ void ProjectSettingsEditor::connect_filesystem_dock_signals(FileSystemDock *p_fs
 	localization_editor->connect_filesystem_dock_signals(p_fs_dock);
 }
 
-void ProjectSettingsEditor::popup_project_settings() {
+void ProjectSettingsEditor::popup_project_settings(bool p_clear_filter) {
 	// Restore valid window bounds or pop up at default size.
 	Rect2 saved_size = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "project_settings", Rect2());
 	if (saved_size != Rect2()) {
@@ -62,6 +62,10 @@ void ProjectSettingsEditor::popup_project_settings() {
 	autoload_settings->update_autoload();
 	plugin_settings->update_plugins();
 	import_defaults_editor->clear();
+
+	if (p_clear_filter) {
+		search_box->clear();
+	}
 }
 
 void ProjectSettingsEditor::queue_save() {

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -116,7 +116,7 @@ protected:
 
 public:
 	static ProjectSettingsEditor *get_singleton() { return singleton; }
-	void popup_project_settings();
+	void popup_project_settings(bool p_clear_filter = false);
 	void set_plugins_page();
 	void set_general_page(const String &p_category);
 	void update_plugins();


### PR DESCRIPTION
## Current behaviour

- open Project Settings
- type anything into the input "Filter Settings" (eg. "xxx") -> all settings are hidden
- close Settings
- select any node in scene
- go to Inspector -> Collision -> "..." -> "Edit Layer Names"
- Project Settings will be opened, but since the previous filter value ("xxx") remains in the input, the "Layer Names" is not shown

## Expected Behaviour
- "Edit Layer Names" button should open the Layer Names in Project Settings no matter what the previous state of Project Settings was


not sure what is the best approach to achieve this...