### PR TITLE
Release DisplayServer's rendering resources before destroying the associated RenderingServer

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -276,6 +276,8 @@ void finalize_physics() {
 }
 
 void finalize_display() {
+	display_server->release_rendering_resources();
+
 	rendering_server->finish();
 	memdelete(rendering_server);
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4662,6 +4662,10 @@ void DisplayServerX11::process_events() {
 	Input::get_singleton()->flush_buffered_events();
 }
 
+void DisplayServerX11::release_rendering_resources() {
+	cursors_cache.clear();
+}
+
 void DisplayServerX11::release_rendering_thread() {
 #if defined(GLES3_ENABLED)
 	if (gl_manager) {
@@ -5758,6 +5762,8 @@ DisplayServerX11::~DisplayServerX11() {
 
 	events_thread_done.set();
 	events_thread.wait_to_finish();
+
+	ERR_FAIL_COND_MSG(!cursors_cache.is_empty(), "Cursor cache not cleared, call release_rendering_resources before destroying the related RenderingServer.");
 
 	//destroy all windows
 	for (KeyValue<WindowID, WindowData> &E : windows) {

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -500,6 +500,7 @@ public:
 
 	virtual void process_events() override;
 
+	virtual void release_rendering_resources() override;
 	virtual void release_rendering_thread() override;
 	virtual void make_rendering_thread() override;
 	virtual void swap_buffers() override;

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -432,6 +432,7 @@ public:
 	virtual void process_events() override;
 	virtual void force_process_and_drop_events() override;
 
+	virtual void release_rendering_resources() override;
 	virtual void release_rendering_thread() override;
 	virtual void make_rendering_thread() override;
 	virtual void swap_buffers() override;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3568,6 +3568,10 @@ void DisplayServerMacOS::force_process_and_drop_events() {
 	drop_events = false;
 }
 
+void DisplayServerMacOS::release_rendering_resources() {
+	cursors_cache.clear();
+}
+
 void DisplayServerMacOS::release_rendering_thread() {
 }
 
@@ -3976,6 +3980,8 @@ DisplayServerMacOS::~DisplayServerMacOS() {
 		IOPMAssertionRelease(screen_keep_on_assertion);
 		screen_keep_on_assertion = kIOPMNullAssertionID;
 	}
+
+	ERR_FAIL_COND_MSG(!cursors_cache.is_empty(), "Cursor cache not cleared, call release_rendering_resources before destroying the related RenderingServer.");
 
 	// Destroy all windows.
 	for (HashMap<WindowID, WindowData>::Iterator E = windows.begin(); E;) {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2040,6 +2040,10 @@ void DisplayServerWindows::force_process_and_drop_events() {
 	drop_events = false;
 }
 
+void DisplayServerWindows::release_rendering_resources() {
+	cursors_cache.clear();
+}
+
 void DisplayServerWindows::release_rendering_thread() {
 }
 
@@ -4359,7 +4363,7 @@ DisplayServerWindows::~DisplayServerWindows() {
 	delete joypad;
 	touch_state.clear();
 
-	cursors_cache.clear();
+	ERR_FAIL_COND_MSG(!cursors_cache.is_empty(), "Cursor cache not cleared, call release_rendering_resources before destroying the related RenderingServer.");
 
 	if (mouse_monitor) {
 		UnhookWindowsHookEx(mouse_monitor);

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -630,6 +630,7 @@ public:
 
 	virtual void force_process_and_drop_events() override;
 
+	virtual void release_rendering_resources() override;
 	virtual void release_rendering_thread() override;
 	virtual void make_rendering_thread() override;
 	virtual void swap_buffers() override;

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -523,6 +523,9 @@ Key DisplayServer::keyboard_get_keycode_from_physical(Key p_keycode) const {
 void DisplayServer::force_process_and_drop_events() {
 }
 
+void DisplayServer::release_rendering_resources() {
+}
+
 void DisplayServer::release_rendering_thread() {
 	WARN_PRINT("Rendering thread not supported by this display server.");
 }

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -483,6 +483,7 @@ public:
 
 	virtual void force_process_and_drop_events();
 
+	virtual void release_rendering_resources();
 	virtual void release_rendering_thread();
 	virtual void make_rendering_thread();
 	virtual void swap_buffers();


### PR DESCRIPTION
Currently this seems to only affect textures related to custom cursors.

X11 and macOS implementations were not tested.

fixes #68472

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
