### PR TITLE
Enable searching for assets supported by the community

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1426,10 +1426,6 @@ void EditorAssetLibrary::_update_asset_items_columns() {
 	}
 }
 
-void EditorAssetLibrary::disable_community_support() {
-	support->get_popup()->set_item_checked(SUPPORT_COMMUNITY, false);
-}
-
 void EditorAssetLibrary::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("install_asset", PropertyInfo(Variant::STRING, "zip_path"), PropertyInfo(Variant::STRING, "name")));
 }

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -316,8 +316,6 @@ protected:
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 public:
-	void disable_community_support();
-
 	EditorAssetLibrary(bool p_templates_only = false);
 };
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2614,7 +2614,6 @@ void ProjectManager::_bind_methods() {
 }
 
 void ProjectManager::_open_asset_library() {
-	asset_library->disable_community_support();
 	tabs->set_current_tab(1);
 }
 
@@ -2998,7 +2997,7 @@ ProjectManager::ProjectManager() {
 
 		if (asset_library) {
 			open_templates = memnew(ConfirmationDialog);
-			open_templates->set_text(TTR("You currently don't have any projects.\nWould you like to explore official example projects in the Asset Library?"));
+			open_templates->set_text(TTR("You currently don't have any projects.\nWould you like to explore example projects in the Asset Library?"));
 			open_templates->set_ok_button_text(TTR("Open Asset Library"));
 			open_templates->connect("confirmed", callable_mp(this, &ProjectManager::_open_asset_library));
 			add_child(open_templates);


### PR DESCRIPTION
Juan added c6f2db393e8d939dc0378826513ca09943660f31 in 2017. By that time, it is probably too soon for the community to build assets.

To enable consistency between `Asset Library Project`  and `Open Asset Library` buttons. I removed the disable community support method.

Fixes: #74704