### PR TITLE
Improve code structure, layout, and theming of the project manager

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1888,6 +1888,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Ref<StyleBoxEmpty> vshader_label_style = make_empty_stylebox(2, 1, 2, 1);
 	theme->set_stylebox("label_style", "VShaderEditor", vshader_label_style);
 
+	// Project manager.
+	theme->set_stylebox("search_panel", "ProjectManager", style_tree_bg);
+	theme->set_constant("sidebar_button_icon_separation", "ProjectManager", int(6 * EDSCALE));
+
 	// adaptive script theme constants
 	// for comments and elements with lower relevance
 	const Color dim_color = Color(font_color.r, font_color.g, font_color.b, 0.5);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -47,6 +47,7 @@
 #include "editor/editor_settings.h"
 #include "editor/editor_themes.h"
 #include "editor/editor_vcs_interface.h"
+#include "editor/plugins/asset_library_editor_plugin.h"
 #include "main/main.h"
 #include "scene/gui/center_container.h"
 #include "scene/gui/check_box.h"
@@ -62,1118 +63,936 @@
 
 constexpr int GODOT4_CONFIG_VERSION = 5;
 
-class ProjectDialog : public ConfirmationDialog {
-	GDCLASS(ProjectDialog, ConfirmationDialog);
+/// Project Dialog.
 
-public:
-	bool is_folder_empty = true;
-	enum Mode {
-		MODE_NEW,
-		MODE_IMPORT,
-		MODE_INSTALL,
-		MODE_RENAME,
-	};
+void ProjectDialog::_set_message(const String &p_msg, MessageType p_type, InputType input_type) {
+	msg->set_text(p_msg);
+	Ref<Texture2D> current_path_icon = status_rect->get_texture();
+	Ref<Texture2D> current_install_icon = install_status_rect->get_texture();
+	Ref<Texture2D> new_icon;
 
-private:
-	enum MessageType {
-		MESSAGE_ERROR,
-		MESSAGE_WARNING,
-		MESSAGE_SUCCESS,
-	};
+	switch (p_type) {
+		case MESSAGE_ERROR: {
+			msg->add_theme_color_override("font_color", msg->get_theme_color(SNAME("error_color"), SNAME("Editor")));
+			msg->set_modulate(Color(1, 1, 1, 1));
+			new_icon = msg->get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons"));
 
-	enum InputType {
-		PROJECT_PATH,
-		INSTALL_PATH,
-	};
+		} break;
+		case MESSAGE_WARNING: {
+			msg->add_theme_color_override("font_color", msg->get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+			msg->set_modulate(Color(1, 1, 1, 1));
+			new_icon = msg->get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons"));
 
-	Mode mode;
-	Button *browse;
-	Button *install_browse;
-	Button *create_dir;
-	Container *name_container;
-	Container *path_container;
-	Container *install_path_container;
-	Container *renderer_container;
-	Label *renderer_info;
-	HBoxContainer *default_files_container;
-	Ref<ButtonGroup> renderer_button_group;
-	Label *msg;
-	LineEdit *project_path;
-	LineEdit *project_name;
-	LineEdit *install_path;
-	TextureRect *status_rect;
-	TextureRect *install_status_rect;
-	EditorFileDialog *fdialog;
-	EditorFileDialog *fdialog_install;
-	OptionButton *vcs_metadata_selection;
-	String zip_path;
-	String zip_title;
-	AcceptDialog *dialog_error;
-	String fav_dir;
+		} break;
+		case MESSAGE_SUCCESS: {
+			msg->set_modulate(Color(1, 1, 1, 0));
+			new_icon = msg->get_theme_icon(SNAME("StatusSuccess"), SNAME("EditorIcons"));
 
-	String created_folder_path;
+		} break;
+	}
 
-	void set_message(const String &p_msg, MessageType p_type = MESSAGE_SUCCESS, InputType input_type = PROJECT_PATH) {
-		msg->set_text(p_msg);
-		Ref<Texture2D> current_path_icon = status_rect->get_texture();
-		Ref<Texture2D> current_install_icon = install_status_rect->get_texture();
-		Ref<Texture2D> new_icon;
+	if (current_path_icon != new_icon && input_type == PROJECT_PATH) {
+		status_rect->set_texture(new_icon);
+	} else if (current_install_icon != new_icon && input_type == INSTALL_PATH) {
+		install_status_rect->set_texture(new_icon);
+	}
 
-		switch (p_type) {
-			case MESSAGE_ERROR: {
-				msg->add_theme_color_override("font_color", msg->get_theme_color(SNAME("error_color"), SNAME("Editor")));
-				msg->set_modulate(Color(1, 1, 1, 1));
-				new_icon = msg->get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons"));
+	Size2i window_size = get_size();
+	Size2 contents_min_size = get_contents_minimum_size();
+	if (window_size.x < contents_min_size.x || window_size.y < contents_min_size.y) {
+		set_size(window_size.max(contents_min_size));
+	}
+}
 
-			} break;
-			case MESSAGE_WARNING: {
-				msg->add_theme_color_override("font_color", msg->get_theme_color(SNAME("warning_color"), SNAME("Editor")));
-				msg->set_modulate(Color(1, 1, 1, 1));
-				new_icon = msg->get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons"));
-
-			} break;
-			case MESSAGE_SUCCESS: {
-				msg->set_modulate(Color(1, 1, 1, 0));
-				new_icon = msg->get_theme_icon(SNAME("StatusSuccess"), SNAME("EditorIcons"));
-
-			} break;
+String ProjectDialog::_test_path() {
+	Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	String valid_path, valid_install_path;
+	if (d->change_dir(project_path->get_text()) == OK) {
+		valid_path = project_path->get_text();
+	} else if (d->change_dir(project_path->get_text().strip_edges()) == OK) {
+		valid_path = project_path->get_text().strip_edges();
+	} else if (project_path->get_text().ends_with(".zip")) {
+		if (d->file_exists(project_path->get_text())) {
+			valid_path = project_path->get_text();
 		}
-
-		if (current_path_icon != new_icon && input_type == PROJECT_PATH) {
-			status_rect->set_texture(new_icon);
-		} else if (current_install_icon != new_icon && input_type == INSTALL_PATH) {
-			install_status_rect->set_texture(new_icon);
-		}
-
-		Size2i window_size = get_size();
-		Size2 contents_min_size = get_contents_minimum_size();
-		if (window_size.x < contents_min_size.x || window_size.y < contents_min_size.y) {
-			set_size(window_size.max(contents_min_size));
+	} else if (project_path->get_text().strip_edges().ends_with(".zip")) {
+		if (d->file_exists(project_path->get_text().strip_edges())) {
+			valid_path = project_path->get_text().strip_edges();
 		}
 	}
 
-	String _test_path() {
-		Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-		String valid_path, valid_install_path;
-		if (d->change_dir(project_path->get_text()) == OK) {
-			valid_path = project_path->get_text();
-		} else if (d->change_dir(project_path->get_text().strip_edges()) == OK) {
-			valid_path = project_path->get_text().strip_edges();
-		} else if (project_path->get_text().ends_with(".zip")) {
-			if (d->file_exists(project_path->get_text())) {
-				valid_path = project_path->get_text();
-			}
-		} else if (project_path->get_text().strip_edges().ends_with(".zip")) {
-			if (d->file_exists(project_path->get_text().strip_edges())) {
-				valid_path = project_path->get_text().strip_edges();
-			}
+	if (valid_path.is_empty()) {
+		_set_message(TTR("The path specified doesn't exist."), MESSAGE_ERROR);
+		get_ok_button()->set_disabled(true);
+		return "";
+	}
+
+	if (mode == MODE_IMPORT && valid_path.ends_with(".zip")) {
+		if (d->change_dir(install_path->get_text()) == OK) {
+			valid_install_path = install_path->get_text();
+		} else if (d->change_dir(install_path->get_text().strip_edges()) == OK) {
+			valid_install_path = install_path->get_text().strip_edges();
 		}
 
-		if (valid_path.is_empty()) {
-			set_message(TTR("The path specified doesn't exist."), MESSAGE_ERROR);
+		if (valid_install_path.is_empty()) {
+			_set_message(TTR("The path specified doesn't exist."), MESSAGE_ERROR, INSTALL_PATH);
+			get_ok_button()->set_disabled(true);
+			return "";
+		}
+	}
+
+	if (mode == MODE_IMPORT || mode == MODE_RENAME) {
+		if (!valid_path.is_empty() && !d->file_exists("project.godot")) {
+			if (valid_path.ends_with(".zip")) {
+				Ref<FileAccess> io_fa;
+				zlib_filefunc_def io = zipio_create_io(&io_fa);
+
+				unzFile pkg = unzOpen2(valid_path.utf8().get_data(), &io);
+				if (!pkg) {
+					_set_message(TTR("Error opening package file (it's not in ZIP format)."), MESSAGE_ERROR);
+					get_ok_button()->set_disabled(true);
+					unzClose(pkg);
+					return "";
+				}
+
+				int ret = unzGoToFirstFile(pkg);
+				while (ret == UNZ_OK) {
+					unz_file_info info;
+					char fname[16384];
+					ret = unzGetCurrentFileInfo(pkg, &info, fname, 16384, nullptr, 0, nullptr, 0);
+					if (ret != UNZ_OK) {
+						break;
+					}
+
+					if (String::utf8(fname).ends_with("project.godot")) {
+						break;
+					}
+
+					ret = unzGoToNextFile(pkg);
+				}
+
+				if (ret == UNZ_END_OF_LIST_OF_FILE) {
+					_set_message(TTR("Invalid \".zip\" project file; it doesn't contain a \"project.godot\" file."), MESSAGE_ERROR);
+					get_ok_button()->set_disabled(true);
+					unzClose(pkg);
+					return "";
+				}
+
+				unzClose(pkg);
+
+				// check if the specified install folder is empty, even though this is not an error, it is good to check here
+				d->list_dir_begin();
+				is_folder_empty = true;
+				String n = d->get_next();
+				while (!n.is_empty()) {
+					if (!n.begins_with(".")) {
+						// Allow `.`, `..` (reserved current/parent folder names)
+						// and hidden files/folders to be present.
+						// For instance, this lets users initialize a Git repository
+						// and still be able to create a project in the directory afterwards.
+						is_folder_empty = false;
+						break;
+					}
+					n = d->get_next();
+				}
+				d->list_dir_end();
+
+				if (!is_folder_empty) {
+					_set_message(TTR("Please choose an empty folder."), MESSAGE_WARNING, INSTALL_PATH);
+					get_ok_button()->set_disabled(true);
+					return "";
+				}
+
+			} else {
+				_set_message(TTR("Please choose a \"project.godot\" or \".zip\" file."), MESSAGE_ERROR);
+				install_path_container->hide();
+				get_ok_button()->set_disabled(true);
+				return "";
+			}
+
+		} else if (valid_path.ends_with("zip")) {
+			_set_message(TTR("This directory already contains a Godot project."), MESSAGE_ERROR, INSTALL_PATH);
 			get_ok_button()->set_disabled(true);
 			return "";
 		}
 
-		if (mode == MODE_IMPORT && valid_path.ends_with(".zip")) {
-			if (d->change_dir(install_path->get_text()) == OK) {
-				valid_install_path = install_path->get_text();
-			} else if (d->change_dir(install_path->get_text().strip_edges()) == OK) {
-				valid_install_path = install_path->get_text().strip_edges();
+	} else {
+		// Check if the specified folder is empty, even though this is not an error, it is good to check here.
+		d->list_dir_begin();
+		is_folder_empty = true;
+		String n = d->get_next();
+		while (!n.is_empty()) {
+			if (!n.begins_with(".")) {
+				// Allow `.`, `..` (reserved current/parent folder names)
+				// and hidden files/folders to be present.
+				// For instance, this lets users initialize a Git repository
+				// and still be able to create a project in the directory afterwards.
+				is_folder_empty = false;
+				break;
 			}
-
-			if (valid_install_path.is_empty()) {
-				set_message(TTR("The path specified doesn't exist."), MESSAGE_ERROR, INSTALL_PATH);
-				get_ok_button()->set_disabled(true);
-				return "";
-			}
+			n = d->get_next();
 		}
+		d->list_dir_end();
 
-		if (mode == MODE_IMPORT || mode == MODE_RENAME) {
-			if (!valid_path.is_empty() && !d->file_exists("project.godot")) {
-				if (valid_path.ends_with(".zip")) {
-					Ref<FileAccess> io_fa;
-					zlib_filefunc_def io = zipio_create_io(&io_fa);
-
-					unzFile pkg = unzOpen2(valid_path.utf8().get_data(), &io);
-					if (!pkg) {
-						set_message(TTR("Error opening package file (it's not in ZIP format)."), MESSAGE_ERROR);
-						get_ok_button()->set_disabled(true);
-						unzClose(pkg);
-						return "";
-					}
-
-					int ret = unzGoToFirstFile(pkg);
-					while (ret == UNZ_OK) {
-						unz_file_info info;
-						char fname[16384];
-						ret = unzGetCurrentFileInfo(pkg, &info, fname, 16384, nullptr, 0, nullptr, 0);
-						if (ret != UNZ_OK) {
-							break;
-						}
-
-						if (String::utf8(fname).ends_with("project.godot")) {
-							break;
-						}
-
-						ret = unzGoToNextFile(pkg);
-					}
-
-					if (ret == UNZ_END_OF_LIST_OF_FILE) {
-						set_message(TTR("Invalid \".zip\" project file; it doesn't contain a \"project.godot\" file."), MESSAGE_ERROR);
-						get_ok_button()->set_disabled(true);
-						unzClose(pkg);
-						return "";
-					}
-
-					unzClose(pkg);
-
-					// check if the specified install folder is empty, even though this is not an error, it is good to check here
-					d->list_dir_begin();
-					is_folder_empty = true;
-					String n = d->get_next();
-					while (!n.is_empty()) {
-						if (!n.begins_with(".")) {
-							// Allow `.`, `..` (reserved current/parent folder names)
-							// and hidden files/folders to be present.
-							// For instance, this lets users initialize a Git repository
-							// and still be able to create a project in the directory afterwards.
-							is_folder_empty = false;
-							break;
-						}
-						n = d->get_next();
-					}
-					d->list_dir_end();
-
-					if (!is_folder_empty) {
-						set_message(TTR("Please choose an empty folder."), MESSAGE_WARNING, INSTALL_PATH);
-						get_ok_button()->set_disabled(true);
-						return "";
-					}
-
-				} else {
-					set_message(TTR("Please choose a \"project.godot\" or \".zip\" file."), MESSAGE_ERROR);
-					install_path_container->hide();
-					get_ok_button()->set_disabled(true);
-					return "";
-				}
-
-			} else if (valid_path.ends_with("zip")) {
-				set_message(TTR("This directory already contains a Godot project."), MESSAGE_ERROR, INSTALL_PATH);
+		if (!is_folder_empty) {
+			if (valid_path == OS::get_singleton()->get_environment("HOME") || valid_path == OS::get_singleton()->get_system_dir(OS::SYSTEM_DIR_DOCUMENTS) || valid_path == OS::get_singleton()->get_executable_path().get_base_dir()) {
+				_set_message(TTR("You cannot save a project in the selected path. Please make a new folder or choose a new path."), MESSAGE_ERROR);
 				get_ok_button()->set_disabled(true);
 				return "";
 			}
 
+			_set_message(TTR("The selected path is not empty. Choosing an empty folder is highly recommended."), MESSAGE_WARNING);
+			get_ok_button()->set_disabled(false);
+			return valid_path;
+		}
+	}
+
+	_set_message("");
+	_set_message("", MESSAGE_SUCCESS, INSTALL_PATH);
+	get_ok_button()->set_disabled(false);
+	return valid_path;
+}
+
+void ProjectDialog::_path_text_changed(const String &p_path) {
+	String sp = _test_path();
+	if (!sp.is_empty()) {
+		// If the project name is empty or default, infer the project name from the selected folder name
+		if (project_name->get_text().strip_edges().is_empty() || project_name->get_text().strip_edges() == TTR("New Game Project")) {
+			sp = sp.replace("\\", "/");
+			int lidx = sp.rfind("/");
+
+			if (lidx != -1) {
+				sp = sp.substr(lidx + 1, sp.length()).capitalize();
+			}
+			if (sp.is_empty() && mode == MODE_IMPORT) {
+				sp = TTR("Imported Project");
+			}
+
+			project_name->set_text(sp);
+			_text_changed(sp);
+		}
+	}
+
+	if (!created_folder_path.is_empty() && created_folder_path != p_path) {
+		_remove_created_folder();
+	}
+}
+
+void ProjectDialog::_file_selected(const String &p_path) {
+	String p = p_path;
+	if (mode == MODE_IMPORT) {
+		if (p.ends_with("project.godot")) {
+			p = p.get_base_dir();
+			install_path_container->hide();
+			get_ok_button()->set_disabled(false);
+		} else if (p.ends_with(".zip")) {
+			install_path->set_text(p.get_base_dir());
+			install_path_container->show();
+			get_ok_button()->set_disabled(false);
 		} else {
-			// Check if the specified folder is empty, even though this is not an error, it is good to check here.
-			d->list_dir_begin();
-			is_folder_empty = true;
-			String n = d->get_next();
-			while (!n.is_empty()) {
-				if (!n.begins_with(".")) {
-					// Allow `.`, `..` (reserved current/parent folder names)
-					// and hidden files/folders to be present.
-					// For instance, this lets users initialize a Git repository
-					// and still be able to create a project in the directory afterwards.
-					is_folder_empty = false;
-					break;
-				}
-				n = d->get_next();
-			}
-			d->list_dir_end();
-
-			if (!is_folder_empty) {
-				if (valid_path == OS::get_singleton()->get_environment("HOME") || valid_path == OS::get_singleton()->get_system_dir(OS::SYSTEM_DIR_DOCUMENTS) || valid_path == OS::get_singleton()->get_executable_path().get_base_dir()) {
-					set_message(TTR("You cannot save a project in the selected path. Please make a new folder or choose a new path."), MESSAGE_ERROR);
-					get_ok_button()->set_disabled(true);
-					return "";
-				}
-
-				set_message(TTR("The selected path is not empty. Choosing an empty folder is highly recommended."), MESSAGE_WARNING);
-				get_ok_button()->set_disabled(false);
-				return valid_path;
-			}
-		}
-
-		set_message("");
-		set_message("", MESSAGE_SUCCESS, INSTALL_PATH);
-		get_ok_button()->set_disabled(false);
-		return valid_path;
-	}
-
-	void _path_text_changed(const String &p_path) {
-		String sp = _test_path();
-		if (!sp.is_empty()) {
-			// If the project name is empty or default, infer the project name from the selected folder name
-			if (project_name->get_text().strip_edges().is_empty() || project_name->get_text().strip_edges() == TTR("New Game Project")) {
-				sp = sp.replace("\\", "/");
-				int lidx = sp.rfind("/");
-
-				if (lidx != -1) {
-					sp = sp.substr(lidx + 1, sp.length()).capitalize();
-				}
-				if (sp.is_empty() && mode == MODE_IMPORT) {
-					sp = TTR("Imported Project");
-				}
-
-				project_name->set_text(sp);
-				_text_changed(sp);
-			}
-		}
-
-		if (!created_folder_path.is_empty() && created_folder_path != p_path) {
-			_remove_created_folder();
-		}
-	}
-
-	void _file_selected(const String &p_path) {
-		String p = p_path;
-		if (mode == MODE_IMPORT) {
-			if (p.ends_with("project.godot")) {
-				p = p.get_base_dir();
-				install_path_container->hide();
-				get_ok_button()->set_disabled(false);
-			} else if (p.ends_with(".zip")) {
-				install_path->set_text(p.get_base_dir());
-				install_path_container->show();
-				get_ok_button()->set_disabled(false);
-			} else {
-				set_message(TTR("Please choose a \"project.godot\" or \".zip\" file."), MESSAGE_ERROR);
-				get_ok_button()->set_disabled(true);
-				return;
-			}
-		}
-
-		String sp = p.simplify_path();
-		project_path->set_text(sp);
-		_path_text_changed(sp);
-		if (p.ends_with(".zip")) {
-			install_path->call_deferred(SNAME("grab_focus"));
-		} else {
-			get_ok_button()->call_deferred(SNAME("grab_focus"));
-		}
-	}
-
-	void _path_selected(const String &p_path) {
-		String sp = p_path.simplify_path();
-		project_path->set_text(sp);
-		_path_text_changed(sp);
-		get_ok_button()->call_deferred(SNAME("grab_focus"));
-	}
-
-	void _install_path_selected(const String &p_path) {
-		String sp = p_path.simplify_path();
-		install_path->set_text(sp);
-		_path_text_changed(sp);
-		get_ok_button()->call_deferred(SNAME("grab_focus"));
-	}
-
-	void _browse_path() {
-		fdialog->set_current_dir(project_path->get_text());
-
-		if (mode == MODE_IMPORT) {
-			fdialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
-			fdialog->clear_filters();
-			fdialog->add_filter("project.godot", vformat("%s %s", VERSION_NAME, TTR("Project")));
-			fdialog->add_filter("*.zip", TTR("ZIP File"));
-		} else {
-			fdialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_DIR);
-		}
-		fdialog->popup_file_dialog();
-	}
-
-	void _browse_install_path() {
-		fdialog_install->set_current_dir(install_path->get_text());
-		fdialog_install->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_DIR);
-		fdialog_install->popup_file_dialog();
-	}
-
-	void _create_folder() {
-		const String project_name_no_edges = project_name->get_text().strip_edges();
-		if (project_name_no_edges.is_empty() || !created_folder_path.is_empty() || project_name_no_edges.ends_with(".")) {
-			set_message(TTR("Invalid project name."), MESSAGE_WARNING);
+			_set_message(TTR("Please choose a \"project.godot\" or \".zip\" file."), MESSAGE_ERROR);
+			get_ok_button()->set_disabled(true);
 			return;
 		}
+	}
 
-		Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-		if (d->change_dir(project_path->get_text()) == OK) {
-			if (!d->dir_exists(project_name_no_edges)) {
-				if (d->make_dir(project_name_no_edges) == OK) {
-					d->change_dir(project_name_no_edges);
-					String dir_str = d->get_current_dir();
-					project_path->set_text(dir_str);
-					_path_text_changed(dir_str);
-					created_folder_path = d->get_current_dir();
-					create_dir->set_disabled(true);
-				} else {
-					dialog_error->set_text(TTR("Couldn't create folder."));
-					dialog_error->popup_centered();
-				}
+	String sp = p.simplify_path();
+	project_path->set_text(sp);
+	_path_text_changed(sp);
+	if (p.ends_with(".zip")) {
+		install_path->call_deferred(SNAME("grab_focus"));
+	} else {
+		get_ok_button()->call_deferred(SNAME("grab_focus"));
+	}
+}
+
+void ProjectDialog::_path_selected(const String &p_path) {
+	String sp = p_path.simplify_path();
+	project_path->set_text(sp);
+	_path_text_changed(sp);
+	get_ok_button()->call_deferred(SNAME("grab_focus"));
+}
+
+void ProjectDialog::_install_path_selected(const String &p_path) {
+	String sp = p_path.simplify_path();
+	install_path->set_text(sp);
+	_path_text_changed(sp);
+	get_ok_button()->call_deferred(SNAME("grab_focus"));
+}
+
+void ProjectDialog::_browse_path() {
+	fdialog->set_current_dir(project_path->get_text());
+
+	if (mode == MODE_IMPORT) {
+		fdialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
+		fdialog->clear_filters();
+		fdialog->add_filter("project.godot", vformat("%s %s", VERSION_NAME, TTR("Project")));
+		fdialog->add_filter("*.zip", TTR("ZIP File"));
+	} else {
+		fdialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_DIR);
+	}
+	fdialog->popup_file_dialog();
+}
+
+void ProjectDialog::_browse_install_path() {
+	fdialog_install->set_current_dir(install_path->get_text());
+	fdialog_install->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_DIR);
+	fdialog_install->popup_file_dialog();
+}
+
+void ProjectDialog::_create_folder() {
+	const String project_name_no_edges = project_name->get_text().strip_edges();
+	if (project_name_no_edges.is_empty() || !created_folder_path.is_empty() || project_name_no_edges.ends_with(".")) {
+		_set_message(TTR("Invalid project name."), MESSAGE_WARNING);
+		return;
+	}
+
+	Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	if (d->change_dir(project_path->get_text()) == OK) {
+		if (!d->dir_exists(project_name_no_edges)) {
+			if (d->make_dir(project_name_no_edges) == OK) {
+				d->change_dir(project_name_no_edges);
+				String dir_str = d->get_current_dir();
+				project_path->set_text(dir_str);
+				_path_text_changed(dir_str);
+				created_folder_path = d->get_current_dir();
+				create_dir->set_disabled(true);
 			} else {
-				dialog_error->set_text(TTR("There is already a folder in this path with the specified name."));
+				dialog_error->set_text(TTR("Couldn't create folder."));
 				dialog_error->popup_centered();
 			}
+		} else {
+			dialog_error->set_text(TTR("There is already a folder in this path with the specified name."));
+			dialog_error->popup_centered();
 		}
 	}
+}
 
-	void _text_changed(const String &p_text) {
-		if (mode != MODE_NEW) {
+void ProjectDialog::_text_changed(const String &p_text) {
+	if (mode != MODE_NEW) {
+		return;
+	}
+
+	_test_path();
+
+	if (p_text.strip_edges().is_empty()) {
+		_set_message(TTR("It would be a good idea to name your project."), MESSAGE_ERROR);
+	}
+}
+
+void ProjectDialog::_nonempty_confirmation_ok_pressed() {
+	is_folder_empty = true;
+	ok_pressed();
+}
+
+void ProjectDialog::_renderer_selected() {
+	String renderer_type = renderer_button_group->get_pressed_button()->get_meta(SNAME("rendering_method"));
+
+	if (renderer_type == "forward_plus") {
+		renderer_info->set_text(
+				String::utf8("•  ") + TTR("Supports desktop platforms only.") +
+				String::utf8("\n•  ") + TTR("Advanced 3D graphics available.") +
+				String::utf8("\n•  ") + TTR("Can scale to large complex scenes.") +
+				String::utf8("\n•  ") + TTR("Uses RenderingDevice backend.") +
+				String::utf8("\n•  ") + TTR("Slower rendering of simple scenes."));
+	} else if (renderer_type == "mobile") {
+		renderer_info->set_text(
+				String::utf8("•  ") + TTR("Supports desktop + mobile platforms.") +
+				String::utf8("\n•  ") + TTR("Less advanced 3D graphics.") +
+				String::utf8("\n•  ") + TTR("Less scalable for complex scenes.") +
+				String::utf8("\n•  ") + TTR("Uses RenderingDevice backend.") +
+				String::utf8("\n•  ") + TTR("Fast rendering of simple scenes."));
+	} else if (renderer_type == "gl_compatibility") {
+		renderer_info->set_text(
+				String::utf8("•  ") + TTR("Supports desktop, mobile + web platforms.") +
+				String::utf8("\n•  ") + TTR("Least advanced 3D graphics (currently work-in-progress).") +
+				String::utf8("\n•  ") + TTR("Intended for low-end/older devices.") +
+				String::utf8("\n•  ") + TTR("Uses OpenGL 3 backend (OpenGL 3.3/ES 3.0/WebGL2).") +
+				String::utf8("\n•  ") + TTR("Fastest rendering of simple scenes."));
+	} else {
+		WARN_PRINT("Unknown renderer type. Please report this as a bug on GitHub.");
+	}
+}
+
+void ProjectDialog::_remove_created_folder() {
+	if (!created_folder_path.is_empty()) {
+		Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+		d->remove(created_folder_path);
+
+		create_dir->set_disabled(false);
+		created_folder_path = "";
+	}
+}
+
+void ProjectDialog::ok_pressed() {
+	String dir = project_path->get_text();
+
+	if (mode == MODE_RENAME) {
+		String dir2 = _test_path();
+		if (dir2.is_empty()) {
+			_set_message(TTR("Invalid project path (changed anything?)."), MESSAGE_ERROR);
 			return;
 		}
 
-		_test_path();
-
-		if (p_text.strip_edges().is_empty()) {
-			set_message(TTR("It would be a good idea to name your project."), MESSAGE_ERROR);
-		}
-	}
-
-	void _nonempty_confirmation_ok_pressed() {
-		is_folder_empty = true;
-		ok_pressed();
-	}
-
-	void _renderer_selected() {
-		String renderer_type = renderer_button_group->get_pressed_button()->get_meta(SNAME("rendering_method"));
-
-		if (renderer_type == "forward_plus") {
-			renderer_info->set_text(
-					String::utf8("•  ") + TTR("Supports desktop platforms only.") +
-					String::utf8("\n•  ") + TTR("Advanced 3D graphics available.") +
-					String::utf8("\n•  ") + TTR("Can scale to large complex scenes.") +
-					String::utf8("\n•  ") + TTR("Uses RenderingDevice backend.") +
-					String::utf8("\n•  ") + TTR("Slower rendering of simple scenes."));
-		} else if (renderer_type == "mobile") {
-			renderer_info->set_text(
-					String::utf8("•  ") + TTR("Supports desktop + mobile platforms.") +
-					String::utf8("\n•  ") + TTR("Less advanced 3D graphics.") +
-					String::utf8("\n•  ") + TTR("Less scalable for complex scenes.") +
-					String::utf8("\n•  ") + TTR("Uses RenderingDevice backend.") +
-					String::utf8("\n•  ") + TTR("Fast rendering of simple scenes."));
-		} else if (renderer_type == "gl_compatibility") {
-			renderer_info->set_text(
-					String::utf8("•  ") + TTR("Supports desktop, mobile + web platforms.") +
-					String::utf8("\n•  ") + TTR("Least advanced 3D graphics (currently work-in-progress).") +
-					String::utf8("\n•  ") + TTR("Intended for low-end/older devices.") +
-					String::utf8("\n•  ") + TTR("Uses OpenGL 3 backend (OpenGL 3.3/ES 3.0/WebGL2).") +
-					String::utf8("\n•  ") + TTR("Fastest rendering of simple scenes."));
+		// Load project.godot as ConfigFile to set the new name.
+		ConfigFile cfg;
+		String project_godot = dir2.path_join("project.godot");
+		Error err = cfg.load(project_godot);
+		if (err != OK) {
+			_set_message(vformat(TTR("Couldn't load project at '%s' (error %d). It may be missing or corrupted."), project_godot, err), MESSAGE_ERROR);
 		} else {
-			WARN_PRINT("Unknown renderer type. Please report this as a bug on GitHub.");
+			cfg.set_value("application", "config/name", project_name->get_text().strip_edges());
+			err = cfg.save(project_godot);
+			if (err != OK) {
+				_set_message(vformat(TTR("Couldn't save project at '%s' (error %d)."), project_godot, err), MESSAGE_ERROR);
+			}
 		}
-	}
 
-	void ok_pressed() override {
-		String dir = project_path->get_text();
+		hide();
+		emit_signal(SNAME("projects_updated"));
 
-		if (mode == MODE_RENAME) {
-			String dir2 = _test_path();
-			if (dir2.is_empty()) {
-				set_message(TTR("Invalid project path (changed anything?)."), MESSAGE_ERROR);
+	} else {
+		if (mode == MODE_IMPORT) {
+			if (project_path->get_text().ends_with(".zip")) {
+				mode = MODE_INSTALL;
+				ok_pressed();
+
 				return;
 			}
 
-			// Load project.godot as ConfigFile to set the new name.
-			ConfigFile cfg;
-			String project_godot = dir2.path_join("project.godot");
-			Error err = cfg.load(project_godot);
-			if (err != OK) {
-				set_message(vformat(TTR("Couldn't load project at '%s' (error %d). It may be missing or corrupted."), project_godot, err), MESSAGE_ERROR);
-			} else {
-				cfg.set_value("application", "config/name", project_name->get_text().strip_edges());
-				err = cfg.save(project_godot);
-				if (err != OK) {
-					set_message(vformat(TTR("Couldn't save project at '%s' (error %d)."), project_godot, err), MESSAGE_ERROR);
-				}
-			}
-
-			hide();
-			emit_signal(SNAME("projects_updated"));
-
 		} else {
-			if (mode == MODE_IMPORT) {
-				if (project_path->get_text().ends_with(".zip")) {
-					mode = MODE_INSTALL;
-					ok_pressed();
+			if (mode == MODE_NEW) {
+				// Before we create a project, check that the target folder is empty.
+				// If not, we need to ask the user if they're sure they want to do this.
+				if (!is_folder_empty) {
+					ConfirmationDialog *cd = memnew(ConfirmationDialog);
+					cd->set_title(TTR("Warning: This folder is not empty"));
+					cd->set_text(TTR("You are about to create a Godot project in a non-empty folder.\nThe entire contents of this folder will be imported as project resources!\n\nAre you sure you wish to continue?"));
+					cd->get_ok_button()->connect("pressed", callable_mp(this, &ProjectDialog::_nonempty_confirmation_ok_pressed));
+					get_parent()->add_child(cd);
+					cd->popup_centered();
+					cd->grab_focus();
+					return;
+				}
+				PackedStringArray project_features = ProjectSettings::get_required_features();
+				ProjectSettings::CustomMap initial_settings;
 
+				// Be sure to change this code if/when renderers are changed.
+				// Default values are "forward_plus" for the main setting, "mobile" for the mobile override,
+				// and "gl_compatibility" for the web override.
+				String renderer_type = renderer_button_group->get_pressed_button()->get_meta(SNAME("rendering_method"));
+				initial_settings["rendering/renderer/rendering_method"] = renderer_type;
+
+				EditorSettings::get_singleton()->set("project_manager/default_renderer", renderer_type);
+				EditorSettings::get_singleton()->save();
+
+				if (renderer_type == "forward_plus") {
+					project_features.push_back("Forward Plus");
+				} else if (renderer_type == "mobile") {
+					project_features.push_back("Mobile");
+				} else if (renderer_type == "gl_compatibility") {
+					project_features.push_back("GL Compatibility");
+					// Also change the default rendering method for the mobile override.
+					initial_settings["rendering/renderer/rendering_method.mobile"] = "gl_compatibility";
+				} else {
+					WARN_PRINT("Unknown renderer type. Please report this as a bug on GitHub.");
+				}
+
+				project_features.sort();
+				initial_settings["application/config/features"] = project_features;
+				initial_settings["application/config/name"] = project_name->get_text().strip_edges();
+				initial_settings["application/config/icon"] = "res://icon.svg";
+
+				if (ProjectSettings::get_singleton()->save_custom(dir.path_join("project.godot"), initial_settings, Vector<String>(), false) != OK) {
+					_set_message(TTR("Couldn't create project.godot in project path."), MESSAGE_ERROR);
+				} else {
+					// Store default project icon in SVG format.
+					Error err;
+					Ref<FileAccess> fa_icon = FileAccess::open(dir.path_join("icon.svg"), FileAccess::WRITE, &err);
+					fa_icon->store_string(get_default_project_icon());
+
+					if (err != OK) {
+						_set_message(TTR("Couldn't create icon.svg in project path."), MESSAGE_ERROR);
+					}
+
+					EditorVCSInterface::create_vcs_metadata_files(EditorVCSInterface::VCSMetadata(vcs_metadata_selection->get_selected()), dir);
+				}
+			} else if (mode == MODE_INSTALL) {
+				if (project_path->get_text().ends_with(".zip")) {
+					dir = install_path->get_text();
+					zip_path = project_path->get_text();
+				}
+
+				Ref<FileAccess> io_fa;
+				zlib_filefunc_def io = zipio_create_io(&io_fa);
+
+				unzFile pkg = unzOpen2(zip_path.utf8().get_data(), &io);
+				if (!pkg) {
+					dialog_error->set_text(TTR("Error opening package file, not in ZIP format."));
+					dialog_error->popup_centered();
 					return;
 				}
 
-			} else {
-				if (mode == MODE_NEW) {
-					// Before we create a project, check that the target folder is empty.
-					// If not, we need to ask the user if they're sure they want to do this.
-					if (!is_folder_empty) {
-						ConfirmationDialog *cd = memnew(ConfirmationDialog);
-						cd->set_title(TTR("Warning: This folder is not empty"));
-						cd->set_text(TTR("You are about to create a Godot project in a non-empty folder.\nThe entire contents of this folder will be imported as project resources!\n\nAre you sure you wish to continue?"));
-						cd->get_ok_button()->connect("pressed", callable_mp(this, &ProjectDialog::_nonempty_confirmation_ok_pressed));
-						get_parent()->add_child(cd);
-						cd->popup_centered();
-						cd->grab_focus();
-						return;
+				// Find the zip_root
+				String zip_root;
+				int ret = unzGoToFirstFile(pkg);
+				while (ret == UNZ_OK) {
+					unz_file_info info;
+					char fname[16384];
+					unzGetCurrentFileInfo(pkg, &info, fname, 16384, nullptr, 0, nullptr, 0);
+
+					String name = String::utf8(fname);
+					if (name.ends_with("project.godot")) {
+						zip_root = name.substr(0, name.rfind("project.godot"));
+						break;
 					}
-					PackedStringArray project_features = ProjectSettings::get_required_features();
-					ProjectSettings::CustomMap initial_settings;
 
-					// Be sure to change this code if/when renderers are changed.
-					// Default values are "forward_plus" for the main setting, "mobile" for the mobile override,
-					// and "gl_compatibility" for the web override.
-					String renderer_type = renderer_button_group->get_pressed_button()->get_meta(SNAME("rendering_method"));
-					initial_settings["rendering/renderer/rendering_method"] = renderer_type;
+					ret = unzGoToNextFile(pkg);
+				}
 
-					EditorSettings::get_singleton()->set("project_manager/default_renderer", renderer_type);
-					EditorSettings::get_singleton()->save();
+				ret = unzGoToFirstFile(pkg);
 
-					if (renderer_type == "forward_plus") {
-						project_features.push_back("Forward Plus");
-					} else if (renderer_type == "mobile") {
-						project_features.push_back("Mobile");
-					} else if (renderer_type == "gl_compatibility") {
-						project_features.push_back("GL Compatibility");
-						// Also change the default rendering method for the mobile override.
-						initial_settings["rendering/renderer/rendering_method.mobile"] = "gl_compatibility";
+				Vector<String> failed_files;
+
+				while (ret == UNZ_OK) {
+					//get filename
+					unz_file_info info;
+					char fname[16384];
+					ret = unzGetCurrentFileInfo(pkg, &info, fname, 16384, nullptr, 0, nullptr, 0);
+					if (ret != UNZ_OK) {
+						break;
+					}
+
+					String path = String::utf8(fname);
+
+					if (path.is_empty() || path == zip_root || !zip_root.is_subsequence_of(path)) {
+						//
+					} else if (path.ends_with("/")) { // a dir
+						path = path.substr(0, path.length() - 1);
+						String rel_path = path.substr(zip_root.length());
+
+						Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+						da->make_dir(dir.path_join(rel_path));
 					} else {
-						WARN_PRINT("Unknown renderer type. Please report this as a bug on GitHub.");
-					}
+						Vector<uint8_t> uncomp_data;
+						uncomp_data.resize(info.uncompressed_size);
+						String rel_path = path.substr(zip_root.length());
 
-					project_features.sort();
-					initial_settings["application/config/features"] = project_features;
-					initial_settings["application/config/name"] = project_name->get_text().strip_edges();
-					initial_settings["application/config/icon"] = "res://icon.svg";
+						//read
+						unzOpenCurrentFile(pkg);
+						ret = unzReadCurrentFile(pkg, uncomp_data.ptrw(), uncomp_data.size());
+						ERR_BREAK_MSG(ret < 0, vformat("An error occurred while attempting to read from file: %s. This file will not be used.", rel_path));
+						unzCloseCurrentFile(pkg);
 
-					if (ProjectSettings::get_singleton()->save_custom(dir.path_join("project.godot"), initial_settings, Vector<String>(), false) != OK) {
-						set_message(TTR("Couldn't create project.godot in project path."), MESSAGE_ERROR);
-					} else {
-						// Store default project icon in SVG format.
-						Error err;
-						Ref<FileAccess> fa_icon = FileAccess::open(dir.path_join("icon.svg"), FileAccess::WRITE, &err);
-						fa_icon->store_string(get_default_project_icon());
-
-						if (err != OK) {
-							set_message(TTR("Couldn't create icon.svg in project path."), MESSAGE_ERROR);
-						}
-
-						EditorVCSInterface::create_vcs_metadata_files(EditorVCSInterface::VCSMetadata(vcs_metadata_selection->get_selected()), dir);
-					}
-				} else if (mode == MODE_INSTALL) {
-					if (project_path->get_text().ends_with(".zip")) {
-						dir = install_path->get_text();
-						zip_path = project_path->get_text();
-					}
-
-					Ref<FileAccess> io_fa;
-					zlib_filefunc_def io = zipio_create_io(&io_fa);
-
-					unzFile pkg = unzOpen2(zip_path.utf8().get_data(), &io);
-					if (!pkg) {
-						dialog_error->set_text(TTR("Error opening package file, not in ZIP format."));
-						dialog_error->popup_centered();
-						return;
-					}
-
-					// Find the zip_root
-					String zip_root;
-					int ret = unzGoToFirstFile(pkg);
-					while (ret == UNZ_OK) {
-						unz_file_info info;
-						char fname[16384];
-						unzGetCurrentFileInfo(pkg, &info, fname, 16384, nullptr, 0, nullptr, 0);
-
-						String name = String::utf8(fname);
-						if (name.ends_with("project.godot")) {
-							zip_root = name.substr(0, name.rfind("project.godot"));
-							break;
-						}
-
-						ret = unzGoToNextFile(pkg);
-					}
-
-					ret = unzGoToFirstFile(pkg);
-
-					Vector<String> failed_files;
-
-					while (ret == UNZ_OK) {
-						//get filename
-						unz_file_info info;
-						char fname[16384];
-						ret = unzGetCurrentFileInfo(pkg, &info, fname, 16384, nullptr, 0, nullptr, 0);
-						if (ret != UNZ_OK) {
-							break;
-						}
-
-						String path = String::utf8(fname);
-
-						if (path.is_empty() || path == zip_root || !zip_root.is_subsequence_of(path)) {
-							//
-						} else if (path.ends_with("/")) { // a dir
-							path = path.substr(0, path.length() - 1);
-							String rel_path = path.substr(zip_root.length());
-
-							Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-							da->make_dir(dir.path_join(rel_path));
+						Ref<FileAccess> f = FileAccess::open(dir.path_join(rel_path), FileAccess::WRITE);
+						if (f.is_valid()) {
+							f->store_buffer(uncomp_data.ptr(), uncomp_data.size());
 						} else {
-							Vector<uint8_t> uncomp_data;
-							uncomp_data.resize(info.uncompressed_size);
-							String rel_path = path.substr(zip_root.length());
-
-							//read
-							unzOpenCurrentFile(pkg);
-							ret = unzReadCurrentFile(pkg, uncomp_data.ptrw(), uncomp_data.size());
-							ERR_BREAK_MSG(ret < 0, vformat("An error occurred while attempting to read from file: %s. This file will not be used.", rel_path));
-							unzCloseCurrentFile(pkg);
-
-							Ref<FileAccess> f = FileAccess::open(dir.path_join(rel_path), FileAccess::WRITE);
-							if (f.is_valid()) {
-								f->store_buffer(uncomp_data.ptr(), uncomp_data.size());
-							} else {
-								failed_files.push_back(rel_path);
-							}
+							failed_files.push_back(rel_path);
 						}
-
-						ret = unzGoToNextFile(pkg);
 					}
 
-					unzClose(pkg);
+					ret = unzGoToNextFile(pkg);
+				}
 
-					if (failed_files.size()) {
-						String err_msg = TTR("The following files failed extraction from package:") + "\n\n";
-						for (int i = 0; i < failed_files.size(); i++) {
-							if (i > 15) {
-								err_msg += "\nAnd " + itos(failed_files.size() - i) + " more files.";
-								break;
-							}
-							err_msg += failed_files[i] + "\n";
+				unzClose(pkg);
+
+				if (failed_files.size()) {
+					String err_msg = TTR("The following files failed extraction from package:") + "\n\n";
+					for (int i = 0; i < failed_files.size(); i++) {
+						if (i > 15) {
+							err_msg += "\nAnd " + itos(failed_files.size() - i) + " more files.";
+							break;
 						}
-
-						dialog_error->set_text(err_msg);
-						dialog_error->popup_centered();
-
-					} else if (!project_path->get_text().ends_with(".zip")) {
-						dialog_error->set_text(TTR("Package installed successfully!"));
-						dialog_error->popup_centered();
+						err_msg += failed_files[i] + "\n";
 					}
+
+					dialog_error->set_text(err_msg);
+					dialog_error->popup_centered();
+
+				} else if (!project_path->get_text().ends_with(".zip")) {
+					dialog_error->set_text(TTR("Package installed successfully!"));
+					dialog_error->popup_centered();
 				}
 			}
-
-			dir = dir.replace("\\", "/");
-			if (dir.ends_with("/")) {
-				dir = dir.substr(0, dir.length() - 1);
-			}
-
-			hide();
-			emit_signal(SNAME("project_created"), dir);
 		}
+
+		dir = dir.replace("\\", "/");
+		if (dir.ends_with("/")) {
+			dir = dir.substr(0, dir.length() - 1);
+		}
+
+		hide();
+		emit_signal(SNAME("project_created"), dir);
+	}
+}
+
+void ProjectDialog::cancel_pressed() {
+	_remove_created_folder();
+
+	project_path->clear();
+	_path_text_changed("");
+	project_name->clear();
+	_text_changed("");
+
+	if (status_rect->get_texture() == msg->get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons"))) {
+		msg->show();
 	}
 
-	void _remove_created_folder() {
-		if (!created_folder_path.is_empty()) {
+	if (install_status_rect->get_texture() == msg->get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons"))) {
+		msg->show();
+	}
+}
+
+void ProjectDialog::set_zip_path(const String &p_path) {
+	zip_path = p_path;
+}
+
+void ProjectDialog::set_zip_title(const String &p_title) {
+	zip_title = p_title;
+}
+
+void ProjectDialog::set_mode(Mode p_mode) {
+	mode = p_mode;
+}
+
+void ProjectDialog::set_project_path(const String &p_path) {
+	project_path->set_text(p_path);
+}
+
+void ProjectDialog::show_dialog() {
+	if (mode == MODE_RENAME) {
+		project_path->set_editable(false);
+		browse->hide();
+		install_browse->hide();
+
+		set_title(TTR("Rename Project"));
+		set_ok_button_text(TTR("Rename"));
+		name_container->show();
+		status_rect->hide();
+		msg->hide();
+		install_path_container->hide();
+		install_status_rect->hide();
+		renderer_container->hide();
+		default_files_container->hide();
+		get_ok_button()->set_disabled(false);
+
+		// Fetch current name from project.godot to prefill the text input.
+		ConfigFile cfg;
+		String project_godot = project_path->get_text().path_join("project.godot");
+		Error err = cfg.load(project_godot);
+		if (err != OK) {
+			_set_message(vformat(TTR("Couldn't load project at '%s' (error %d). It may be missing or corrupted."), project_godot, err), MESSAGE_ERROR);
+			status_rect->show();
+			msg->show();
+			get_ok_button()->set_disabled(true);
+		} else {
+			String cur_name = cfg.get_value("application", "config/name", "");
+			project_name->set_text(cur_name);
+			_text_changed(cur_name);
+		}
+
+		project_name->call_deferred(SNAME("grab_focus"));
+
+		create_dir->hide();
+
+	} else {
+		fav_dir = EDITOR_GET("filesystem/directories/default_project_path");
+		if (!fav_dir.is_empty()) {
+			project_path->set_text(fav_dir);
+			fdialog->set_current_dir(fav_dir);
+		} else {
 			Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-			d->remove(created_folder_path);
-
-			create_dir->set_disabled(false);
-			created_folder_path = "";
+			project_path->set_text(d->get_current_dir());
+			fdialog->set_current_dir(d->get_current_dir());
 		}
-	}
+		String proj = TTR("New Game Project");
+		project_name->set_text(proj);
+		_text_changed(proj);
 
-	void cancel_pressed() override {
-		_remove_created_folder();
+		project_path->set_editable(true);
+		browse->set_disabled(false);
+		browse->show();
+		install_browse->set_disabled(false);
+		install_browse->show();
+		create_dir->show();
+		status_rect->show();
+		install_status_rect->show();
+		msg->show();
 
-		project_path->clear();
-		_path_text_changed("");
-		project_name->clear();
-		_text_changed("");
-
-		if (status_rect->get_texture() == msg->get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons"))) {
-			msg->show();
-		}
-
-		if (install_status_rect->get_texture() == msg->get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons"))) {
-			msg->show();
-		}
-	}
-
-	void _notification(int p_what) {
-		switch (p_what) {
-			case NOTIFICATION_WM_CLOSE_REQUEST: {
-				_remove_created_folder();
-			} break;
-		}
-	}
-
-protected:
-	static void _bind_methods() {
-		ADD_SIGNAL(MethodInfo("project_created"));
-		ADD_SIGNAL(MethodInfo("projects_updated"));
-	}
-
-public:
-	void set_zip_path(const String &p_path) {
-		zip_path = p_path;
-	}
-	void set_zip_title(const String &p_title) {
-		zip_title = p_title;
-	}
-
-	void set_mode(Mode p_mode) {
-		mode = p_mode;
-	}
-
-	void set_project_path(const String &p_path) {
-		project_path->set_text(p_path);
-	}
-
-	void show_dialog() {
-		if (mode == MODE_RENAME) {
-			project_path->set_editable(false);
-			browse->hide();
-			install_browse->hide();
-
-			set_title(TTR("Rename Project"));
-			set_ok_button_text(TTR("Rename"));
-			name_container->show();
-			status_rect->hide();
-			msg->hide();
+		if (mode == MODE_IMPORT) {
+			set_title(TTR("Import Existing Project"));
+			set_ok_button_text(TTR("Import & Edit"));
+			name_container->hide();
 			install_path_container->hide();
-			install_status_rect->hide();
 			renderer_container->hide();
 			default_files_container->hide();
-			get_ok_button()->set_disabled(false);
+			project_path->grab_focus();
 
-			// Fetch current name from project.godot to prefill the text input.
-			ConfigFile cfg;
-			String project_godot = project_path->get_text().path_join("project.godot");
-			Error err = cfg.load(project_godot);
-			if (err != OK) {
-				set_message(vformat(TTR("Couldn't load project at '%s' (error %d). It may be missing or corrupted."), project_godot, err), MESSAGE_ERROR);
-				status_rect->show();
-				msg->show();
-				get_ok_button()->set_disabled(true);
-			} else {
-				String cur_name = cfg.get_value("application", "config/name", "");
-				project_name->set_text(cur_name);
-				_text_changed(cur_name);
-			}
-
+		} else if (mode == MODE_NEW) {
+			set_title(TTR("Create New Project"));
+			set_ok_button_text(TTR("Create & Edit"));
+			name_container->show();
+			install_path_container->hide();
+			renderer_container->show();
+			default_files_container->show();
 			project_name->call_deferred(SNAME("grab_focus"));
+			project_name->call_deferred(SNAME("select_all"));
 
-			create_dir->hide();
-
-		} else {
-			fav_dir = EDITOR_GET("filesystem/directories/default_project_path");
-			if (!fav_dir.is_empty()) {
-				project_path->set_text(fav_dir);
-				fdialog->set_current_dir(fav_dir);
-			} else {
-				Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-				project_path->set_text(d->get_current_dir());
-				fdialog->set_current_dir(d->get_current_dir());
-			}
-			String proj = TTR("New Game Project");
-			project_name->set_text(proj);
-			_text_changed(proj);
-
-			project_path->set_editable(true);
-			browse->set_disabled(false);
-			browse->show();
-			install_browse->set_disabled(false);
-			install_browse->show();
-			create_dir->show();
-			status_rect->show();
-			install_status_rect->show();
-			msg->show();
-
-			if (mode == MODE_IMPORT) {
-				set_title(TTR("Import Existing Project"));
-				set_ok_button_text(TTR("Import & Edit"));
-				name_container->hide();
-				install_path_container->hide();
-				renderer_container->hide();
-				default_files_container->hide();
-				project_path->grab_focus();
-
-			} else if (mode == MODE_NEW) {
-				set_title(TTR("Create New Project"));
-				set_ok_button_text(TTR("Create & Edit"));
-				name_container->show();
-				install_path_container->hide();
-				renderer_container->show();
-				default_files_container->show();
-				project_name->call_deferred(SNAME("grab_focus"));
-				project_name->call_deferred(SNAME("select_all"));
-
-			} else if (mode == MODE_INSTALL) {
-				set_title(TTR("Install Project:") + " " + zip_title);
-				set_ok_button_text(TTR("Install & Edit"));
-				project_name->set_text(zip_title);
-				name_container->show();
-				install_path_container->hide();
-				renderer_container->hide();
-				default_files_container->hide();
-				project_path->grab_focus();
-			}
-
-			_test_path();
+		} else if (mode == MODE_INSTALL) {
+			set_title(TTR("Install Project:") + " " + zip_title);
+			set_ok_button_text(TTR("Install & Edit"));
+			project_name->set_text(zip_title);
+			name_container->show();
+			install_path_container->hide();
+			renderer_container->hide();
+			default_files_container->hide();
+			project_path->grab_focus();
 		}
 
-		popup_centered(Size2(500, 0) * EDSCALE);
+		_test_path();
 	}
 
-	ProjectDialog() {
-		VBoxContainer *vb = memnew(VBoxContainer);
-		add_child(vb);
+	popup_centered(Size2(500, 0) * EDSCALE);
+}
 
-		name_container = memnew(VBoxContainer);
-		vb->add_child(name_container);
+void ProjectDialog::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_WM_CLOSE_REQUEST: {
+			_remove_created_folder();
+		} break;
+	}
+}
 
-		Label *l = memnew(Label);
-		l->set_text(TTR("Project Name:"));
-		name_container->add_child(l);
+void ProjectDialog::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("project_created"));
+	ADD_SIGNAL(MethodInfo("projects_updated"));
+}
 
-		HBoxContainer *pnhb = memnew(HBoxContainer);
-		name_container->add_child(pnhb);
+ProjectDialog::ProjectDialog() {
+	VBoxContainer *vb = memnew(VBoxContainer);
+	add_child(vb);
 
-		project_name = memnew(LineEdit);
-		project_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		pnhb->add_child(project_name);
+	name_container = memnew(VBoxContainer);
+	vb->add_child(name_container);
 
-		create_dir = memnew(Button);
-		pnhb->add_child(create_dir);
-		create_dir->set_text(TTR("Create Folder"));
-		create_dir->connect("pressed", callable_mp(this, &ProjectDialog::_create_folder));
+	Label *l = memnew(Label);
+	l->set_text(TTR("Project Name:"));
+	name_container->add_child(l);
 
-		path_container = memnew(VBoxContainer);
-		vb->add_child(path_container);
+	HBoxContainer *pnhb = memnew(HBoxContainer);
+	name_container->add_child(pnhb);
 
-		l = memnew(Label);
-		l->set_text(TTR("Project Path:"));
-		path_container->add_child(l);
+	project_name = memnew(LineEdit);
+	project_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	pnhb->add_child(project_name);
 
-		HBoxContainer *pphb = memnew(HBoxContainer);
-		path_container->add_child(pphb);
+	create_dir = memnew(Button);
+	pnhb->add_child(create_dir);
+	create_dir->set_text(TTR("Create Folder"));
+	create_dir->connect("pressed", callable_mp(this, &ProjectDialog::_create_folder));
 
-		project_path = memnew(LineEdit);
-		project_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		project_path->set_structured_text_bidi_override(TextServer::STRUCTURED_TEXT_FILE);
-		pphb->add_child(project_path);
+	path_container = memnew(VBoxContainer);
+	vb->add_child(path_container);
 
-		install_path_container = memnew(VBoxContainer);
-		vb->add_child(install_path_container);
+	l = memnew(Label);
+	l->set_text(TTR("Project Path:"));
+	path_container->add_child(l);
 
-		l = memnew(Label);
-		l->set_text(TTR("Project Installation Path:"));
-		install_path_container->add_child(l);
+	HBoxContainer *pphb = memnew(HBoxContainer);
+	path_container->add_child(pphb);
 
-		HBoxContainer *iphb = memnew(HBoxContainer);
-		install_path_container->add_child(iphb);
+	project_path = memnew(LineEdit);
+	project_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	project_path->set_structured_text_bidi_override(TextServer::STRUCTURED_TEXT_FILE);
+	pphb->add_child(project_path);
 
-		install_path = memnew(LineEdit);
-		install_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		install_path->set_structured_text_bidi_override(TextServer::STRUCTURED_TEXT_FILE);
-		iphb->add_child(install_path);
+	install_path_container = memnew(VBoxContainer);
+	vb->add_child(install_path_container);
 
-		// status icon
-		status_rect = memnew(TextureRect);
-		status_rect->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
-		pphb->add_child(status_rect);
+	l = memnew(Label);
+	l->set_text(TTR("Project Installation Path:"));
+	install_path_container->add_child(l);
 
-		browse = memnew(Button);
-		browse->set_text(TTR("Browse"));
-		browse->connect("pressed", callable_mp(this, &ProjectDialog::_browse_path));
-		pphb->add_child(browse);
+	HBoxContainer *iphb = memnew(HBoxContainer);
+	install_path_container->add_child(iphb);
 
-		// install status icon
-		install_status_rect = memnew(TextureRect);
-		install_status_rect->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
-		iphb->add_child(install_status_rect);
+	install_path = memnew(LineEdit);
+	install_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	install_path->set_structured_text_bidi_override(TextServer::STRUCTURED_TEXT_FILE);
+	iphb->add_child(install_path);
 
-		install_browse = memnew(Button);
-		install_browse->set_text(TTR("Browse"));
-		install_browse->connect("pressed", callable_mp(this, &ProjectDialog::_browse_install_path));
-		iphb->add_child(install_browse);
+	// status icon
+	status_rect = memnew(TextureRect);
+	status_rect->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
+	pphb->add_child(status_rect);
 
-		msg = memnew(Label);
-		msg->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
-		vb->add_child(msg);
+	browse = memnew(Button);
+	browse->set_text(TTR("Browse"));
+	browse->connect("pressed", callable_mp(this, &ProjectDialog::_browse_path));
+	pphb->add_child(browse);
 
-		// Renderer selection.
-		renderer_container = memnew(VBoxContainer);
-		vb->add_child(renderer_container);
-		l = memnew(Label);
-		l->set_text(TTR("Renderer:"));
-		renderer_container->add_child(l);
-		HBoxContainer *rshc = memnew(HBoxContainer);
-		renderer_container->add_child(rshc);
-		renderer_button_group.instantiate();
+	// install status icon
+	install_status_rect = memnew(TextureRect);
+	install_status_rect->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
+	iphb->add_child(install_status_rect);
 
-		// Left hand side, used for checkboxes to select renderer.
-		Container *rvb = memnew(VBoxContainer);
-		rshc->add_child(rvb);
+	install_browse = memnew(Button);
+	install_browse->set_text(TTR("Browse"));
+	install_browse->connect("pressed", callable_mp(this, &ProjectDialog::_browse_install_path));
+	iphb->add_child(install_browse);
 
-		String default_renderer_type = "forward_plus";
-		if (EditorSettings::get_singleton()->has_setting("project_manager/default_renderer")) {
-			default_renderer_type = EditorSettings::get_singleton()->get_setting("project_manager/default_renderer");
-		}
+	msg = memnew(Label);
+	msg->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	vb->add_child(msg);
 
-		Button *rs_button = memnew(CheckBox);
-		rs_button->set_button_group(renderer_button_group);
-		rs_button->set_text(TTR("Forward+"));
+	// Renderer selection.
+	renderer_container = memnew(VBoxContainer);
+	vb->add_child(renderer_container);
+	l = memnew(Label);
+	l->set_text(TTR("Renderer:"));
+	renderer_container->add_child(l);
+	HBoxContainer *rshc = memnew(HBoxContainer);
+	renderer_container->add_child(rshc);
+	renderer_button_group.instantiate();
+
+	// Left hand side, used for checkboxes to select renderer.
+	Container *rvb = memnew(VBoxContainer);
+	rshc->add_child(rvb);
+
+	String default_renderer_type = "forward_plus";
+	if (EditorSettings::get_singleton()->has_setting("project_manager/default_renderer")) {
+		default_renderer_type = EditorSettings::get_singleton()->get_setting("project_manager/default_renderer");
+	}
+
+	Button *rs_button = memnew(CheckBox);
+	rs_button->set_button_group(renderer_button_group);
+	rs_button->set_text(TTR("Forward+"));
 #if defined(WEB_ENABLED)
-		rs_button->set_disabled(true);
+	rs_button->set_disabled(true);
 #endif
-		rs_button->set_meta(SNAME("rendering_method"), "forward_plus");
-		rs_button->connect("pressed", callable_mp(this, &ProjectDialog::_renderer_selected));
-		rvb->add_child(rs_button);
-		if (default_renderer_type == "forward_plus") {
-			rs_button->set_pressed(true);
-		}
-		rs_button = memnew(CheckBox);
-		rs_button->set_button_group(renderer_button_group);
-		rs_button->set_text(TTR("Mobile"));
+	rs_button->set_meta(SNAME("rendering_method"), "forward_plus");
+	rs_button->connect("pressed", callable_mp(this, &ProjectDialog::_renderer_selected));
+	rvb->add_child(rs_button);
+	if (default_renderer_type == "forward_plus") {
+		rs_button->set_pressed(true);
+	}
+	rs_button = memnew(CheckBox);
+	rs_button->set_button_group(renderer_button_group);
+	rs_button->set_text(TTR("Mobile"));
 #if defined(WEB_ENABLED)
-		rs_button->set_disabled(true);
+	rs_button->set_disabled(true);
 #endif
-		rs_button->set_meta(SNAME("rendering_method"), "mobile");
-		rs_button->connect("pressed", callable_mp(this, &ProjectDialog::_renderer_selected));
-		rvb->add_child(rs_button);
-		if (default_renderer_type == "mobile") {
-			rs_button->set_pressed(true);
-		}
-		rs_button = memnew(CheckBox);
-		rs_button->set_button_group(renderer_button_group);
-		rs_button->set_text(TTR("Compatibility"));
+	rs_button->set_meta(SNAME("rendering_method"), "mobile");
+	rs_button->connect("pressed", callable_mp(this, &ProjectDialog::_renderer_selected));
+	rvb->add_child(rs_button);
+	if (default_renderer_type == "mobile") {
+		rs_button->set_pressed(true);
+	}
+	rs_button = memnew(CheckBox);
+	rs_button->set_button_group(renderer_button_group);
+	rs_button->set_text(TTR("Compatibility"));
 #if !defined(GLES3_ENABLED)
-		rs_button->set_disabled(true);
+	rs_button->set_disabled(true);
 #endif
-		rs_button->set_meta(SNAME("rendering_method"), "gl_compatibility");
-		rs_button->connect("pressed", callable_mp(this, &ProjectDialog::_renderer_selected));
-		rvb->add_child(rs_button);
+	rs_button->set_meta(SNAME("rendering_method"), "gl_compatibility");
+	rs_button->connect("pressed", callable_mp(this, &ProjectDialog::_renderer_selected));
+	rvb->add_child(rs_button);
 #if defined(GLES3_ENABLED)
-		if (default_renderer_type == "gl_compatibility") {
-			rs_button->set_pressed(true);
-		}
+	if (default_renderer_type == "gl_compatibility") {
+		rs_button->set_pressed(true);
+	}
 #endif
-		rshc->add_child(memnew(VSeparator));
+	rshc->add_child(memnew(VSeparator));
 
-		// Right hand side, used for text explaining each choice.
-		rvb = memnew(VBoxContainer);
-		rvb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		rshc->add_child(rvb);
-		renderer_info = memnew(Label);
-		renderer_info->set_modulate(Color(1, 1, 1, 0.7));
-		rvb->add_child(renderer_info);
-		_renderer_selected();
+	// Right hand side, used for text explaining each choice.
+	rvb = memnew(VBoxContainer);
+	rvb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	rshc->add_child(rvb);
+	renderer_info = memnew(Label);
+	renderer_info->set_modulate(Color(1, 1, 1, 0.7));
+	rvb->add_child(renderer_info);
+	_renderer_selected();
 
-		l = memnew(Label);
-		l->set_text(TTR("The renderer can be changed later, but scenes may need to be adjusted."));
-		// Add some extra spacing to separate it from the list above and the buttons below.
-		l->set_custom_minimum_size(Size2(0, 40) * EDSCALE);
-		l->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
-		l->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
-		l->set_modulate(Color(1, 1, 1, 0.7));
-		renderer_container->add_child(l);
+	l = memnew(Label);
+	l->set_text(TTR("The renderer can be changed later, but scenes may need to be adjusted."));
+	// Add some extra spacing to separate it from the list above and the buttons below.
+	l->set_custom_minimum_size(Size2(0, 40) * EDSCALE);
+	l->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	l->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
+	l->set_modulate(Color(1, 1, 1, 0.7));
+	renderer_container->add_child(l);
 
-		default_files_container = memnew(HBoxContainer);
-		vb->add_child(default_files_container);
-		l = memnew(Label);
-		l->set_text(TTR("Version Control Metadata:"));
-		default_files_container->add_child(l);
-		vcs_metadata_selection = memnew(OptionButton);
-		vcs_metadata_selection->set_custom_minimum_size(Size2(100, 20));
-		vcs_metadata_selection->add_item(TTR("None"), (int)EditorVCSInterface::VCSMetadata::NONE);
-		vcs_metadata_selection->add_item(TTR("Git"), (int)EditorVCSInterface::VCSMetadata::GIT);
-		vcs_metadata_selection->select((int)EditorVCSInterface::VCSMetadata::GIT);
-		default_files_container->add_child(vcs_metadata_selection);
-		Control *spacer = memnew(Control);
-		spacer->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		default_files_container->add_child(spacer);
+	default_files_container = memnew(HBoxContainer);
+	vb->add_child(default_files_container);
+	l = memnew(Label);
+	l->set_text(TTR("Version Control Metadata:"));
+	default_files_container->add_child(l);
+	vcs_metadata_selection = memnew(OptionButton);
+	vcs_metadata_selection->set_custom_minimum_size(Size2(100, 20));
+	vcs_metadata_selection->add_item(TTR("None"), (int)EditorVCSInterface::VCSMetadata::NONE);
+	vcs_metadata_selection->add_item(TTR("Git"), (int)EditorVCSInterface::VCSMetadata::GIT);
+	vcs_metadata_selection->select((int)EditorVCSInterface::VCSMetadata::GIT);
+	default_files_container->add_child(vcs_metadata_selection);
+	Control *spacer = memnew(Control);
+	spacer->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	default_files_container->add_child(spacer);
 
-		fdialog = memnew(EditorFileDialog);
-		fdialog->set_previews_enabled(false); //Crucial, otherwise the engine crashes.
-		fdialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
-		fdialog_install = memnew(EditorFileDialog);
-		fdialog_install->set_previews_enabled(false); //Crucial, otherwise the engine crashes.
-		fdialog_install->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
-		add_child(fdialog);
-		add_child(fdialog_install);
+	fdialog = memnew(EditorFileDialog);
+	fdialog->set_previews_enabled(false); //Crucial, otherwise the engine crashes.
+	fdialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
+	fdialog_install = memnew(EditorFileDialog);
+	fdialog_install->set_previews_enabled(false); //Crucial, otherwise the engine crashes.
+	fdialog_install->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
+	add_child(fdialog);
+	add_child(fdialog_install);
 
-		project_name->connect("text_changed", callable_mp(this, &ProjectDialog::_text_changed));
-		project_path->connect("text_changed", callable_mp(this, &ProjectDialog::_path_text_changed));
-		install_path->connect("text_changed", callable_mp(this, &ProjectDialog::_path_text_changed));
-		fdialog->connect("dir_selected", callable_mp(this, &ProjectDialog::_path_selected));
-		fdialog->connect("file_selected", callable_mp(this, &ProjectDialog::_file_selected));
-		fdialog_install->connect("dir_selected", callable_mp(this, &ProjectDialog::_install_path_selected));
-		fdialog_install->connect("file_selected", callable_mp(this, &ProjectDialog::_install_path_selected));
+	project_name->connect("text_changed", callable_mp(this, &ProjectDialog::_text_changed));
+	project_path->connect("text_changed", callable_mp(this, &ProjectDialog::_path_text_changed));
+	install_path->connect("text_changed", callable_mp(this, &ProjectDialog::_path_text_changed));
+	fdialog->connect("dir_selected", callable_mp(this, &ProjectDialog::_path_selected));
+	fdialog->connect("file_selected", callable_mp(this, &ProjectDialog::_file_selected));
+	fdialog_install->connect("dir_selected", callable_mp(this, &ProjectDialog::_install_path_selected));
+	fdialog_install->connect("file_selected", callable_mp(this, &ProjectDialog::_install_path_selected));
 
-		set_hide_on_ok(false);
-		mode = MODE_NEW;
+	set_hide_on_ok(false);
 
-		dialog_error = memnew(AcceptDialog);
-		add_child(dialog_error);
+	dialog_error = memnew(AcceptDialog);
+	add_child(dialog_error);
+}
+
+/// Project List and friends.
+
+void ProjectListItemControl::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_MOUSE_ENTER: {
+			hover = true;
+			queue_redraw();
+		} break;
+
+		case NOTIFICATION_MOUSE_EXIT: {
+			hover = false;
+			queue_redraw();
+		} break;
+
+		case NOTIFICATION_DRAW: {
+			if (hover) {
+				draw_style_box(get_theme_stylebox(SNAME("hover"), SNAME("Tree")), Rect2(Point2(), get_size()));
+			}
+		} break;
 	}
-};
+}
 
-class ProjectListItemControl : public HBoxContainer {
-	GDCLASS(ProjectListItemControl, HBoxContainer)
-public:
-	TextureButton *favorite_button;
-	TextureRect *icon;
-	bool icon_needs_reload;
-	bool hover;
+void ProjectListItemControl::set_is_favorite(bool fav) {
+	favorite_button->set_modulate(fav ? Color(1, 1, 1, 1) : Color(1, 1, 1, 0.2));
+}
 
-	ProjectListItemControl() {
-		favorite_button = nullptr;
-		icon = nullptr;
-		icon_needs_reload = true;
-		hover = false;
-
-		set_focus_mode(FocusMode::FOCUS_ALL);
-	}
-
-	void set_is_favorite(bool fav) {
-		favorite_button->set_modulate(fav ? Color(1, 1, 1, 1) : Color(1, 1, 1, 0.2));
-	}
-
-	void _notification(int p_what) {
-		switch (p_what) {
-			case NOTIFICATION_MOUSE_ENTER: {
-				hover = true;
-				queue_redraw();
-			} break;
-
-			case NOTIFICATION_MOUSE_EXIT: {
-				hover = false;
-				queue_redraw();
-			} break;
-
-			case NOTIFICATION_DRAW: {
-				if (hover) {
-					draw_style_box(get_theme_stylebox(SNAME("hover"), SNAME("Tree")), Rect2(Point2(), get_size()));
-				}
-			} break;
-		}
-	}
-};
-
-class ProjectList : public ScrollContainer {
-	GDCLASS(ProjectList, ScrollContainer)
-public:
-	static const char *SIGNAL_SELECTION_CHANGED;
-	static const char *SIGNAL_PROJECT_ASK_OPEN;
-
-	enum MenuOptions {
-		GLOBAL_NEW_WINDOW,
-		GLOBAL_OPEN_PROJECT
-	};
-
-	// Can often be passed by copy
-	struct Item {
-		String project_name;
-		String description;
-		String path;
-		String icon;
-		String main_scene;
-		PackedStringArray unsupported_features;
-		uint64_t last_edited = 0;
-		bool favorite = false;
-		bool grayed = false;
-		bool missing = false;
-		int version = 0;
-
-		ProjectListItemControl *control = nullptr;
-
-		Item() {}
-
-		Item(const String &p_name,
-				const String &p_description,
-				const String &p_path,
-				const String &p_icon,
-				const String &p_main_scene,
-				const PackedStringArray &p_unsupported_features,
-				uint64_t p_last_edited,
-				bool p_favorite,
-				bool p_grayed,
-				bool p_missing,
-				int p_version) {
-			project_name = p_name;
-			description = p_description;
-			path = p_path;
-			icon = p_icon;
-			main_scene = p_main_scene;
-			unsupported_features = p_unsupported_features;
-			last_edited = p_last_edited;
-			favorite = p_favorite;
-			grayed = p_grayed;
-			missing = p_missing;
-			version = p_version;
-			control = nullptr;
-		}
-
-		_FORCE_INLINE_ bool operator==(const Item &l) const {
-			return path == l.path;
-		}
-	};
-
-	bool project_opening_initiated;
-
-	ProjectList();
-	~ProjectList();
-
-	void _global_menu_new_window(const Variant &p_tag);
-	void _global_menu_open_project(const Variant &p_tag);
-
-	void update_dock_menu();
-	void migrate_config();
-	void load_projects();
-	void set_search_term(String p_search_term);
-	void set_order_option(int p_option);
-	void sort_projects();
-	int get_project_count() const;
-	void select_project(int p_index);
-	void select_first_visible_project();
-	void erase_selected_projects(bool p_delete_project_contents);
-	Vector<Item> get_selected_projects() const;
-	const HashSet<String> &get_selected_project_keys() const;
-	void ensure_project_visible(int p_index);
-	int get_single_selected_index() const;
-	bool is_any_project_missing() const;
-	void erase_missing_projects();
-	int refresh_project(const String &dir_path);
-	void add_project(const String &dir_path, bool favorite);
-	void save_config();
-	void set_project_version(const String &p_project_path, int version);
-
-private:
-	static void _bind_methods();
-	void _notification(int p_what);
-
-	void _panel_draw(Node *p_hb);
-	void _panel_input(const Ref<InputEvent> &p_ev, Node *p_hb);
-	void _favorite_pressed(Node *p_hb);
-	void _show_project(const String &p_path);
-
-	void select_range(int p_begin, int p_end);
-	void toggle_select(int p_index);
-	void create_project_item_control(int p_index);
-	void remove_project(int p_index, bool p_update_settings);
-	void update_icons_async();
-	void load_project_icon(int p_index);
-	static Item load_project_data(const String &p_property_key, bool p_favorite);
-
-	String _search_term;
-	FilterOption _order_option;
-	HashSet<String> _selected_project_paths;
-	String _last_clicked; // Project key
-	VBoxContainer *_scroll_children;
-	int _icon_load_index;
-
-	Vector<Item> _projects;
-
-	ConfigFile _config;
-	String _config_path;
-};
+ProjectListItemControl::ProjectListItemControl() {
+	set_focus_mode(FocusMode::FOCUS_ALL);
+}
 
 struct ProjectListComparator {
-	FilterOption order_option = FilterOption::EDIT_DATE;
+	ProjectList::FilterOption order_option = ProjectList::FilterOption::EDIT_DATE;
 
 	// operator<
 	_FORCE_INLINE_ bool operator()(const ProjectList::Item &a, const ProjectList::Item &b) const {
@@ -1184,9 +1003,9 @@ struct ProjectListComparator {
 			return false;
 		}
 		switch (order_option) {
-			case PATH:
+			case ProjectList::PATH:
 				return a.path < b.path;
-			case EDIT_DATE:
+			case ProjectList::EDIT_DATE:
 				return a.last_edited > b.last_edited;
 			default:
 				return a.project_name < b.project_name;
@@ -1194,24 +1013,8 @@ struct ProjectListComparator {
 	}
 };
 
-ProjectList::ProjectList() {
-	_order_option = FilterOption::EDIT_DATE;
-	_scroll_children = memnew(VBoxContainer);
-	_scroll_children->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	add_child(_scroll_children);
-
-	_icon_load_index = 0;
-	project_opening_initiated = false;
-	_config_path = EditorPaths::get_singleton()->get_data_dir().path_join("projects.cfg");
-}
-
-ProjectList::~ProjectList() {
-}
-
-void ProjectList::update_icons_async() {
-	_icon_load_index = 0;
-	set_process(true);
-}
+const char *ProjectList::SIGNAL_SELECTION_CHANGED = "selection_changed";
+const char *ProjectList::SIGNAL_PROJECT_ASK_OPEN = "project_ask_open";
 
 void ProjectList::_notification(int p_what) {
 	switch (p_what) {
@@ -1229,6 +1032,11 @@ void ProjectList::_notification(int p_what) {
 			}
 		} break;
 	}
+}
+
+void ProjectList::update_icons_async() {
+	_icon_load_index = 0;
+	set_process(true);
 }
 
 void ProjectList::load_project_icon(int p_index) {
@@ -1259,7 +1067,8 @@ void ProjectList::load_project_icon(int p_index) {
 	item.control->icon_needs_reload = false;
 }
 
-// Load project data from p_property_key and return it in a ProjectList::Item. p_favorite is passed directly into the Item.
+// Load project data from p_property_key and return it in a ProjectList::Item.
+// p_favorite is passed directly into the Item.
 ProjectList::Item ProjectList::load_project_data(const String &p_path, bool p_favorite) {
 	String conf = p_path.path_join("project.godot");
 	bool grayed = false;
@@ -1853,7 +1662,7 @@ void ProjectList::erase_selected_projects(bool p_delete_project_contents) {
 	update_dock_menu();
 }
 
-// Draws selected project highlight
+// Draws selected project highlight.
 void ProjectList::_panel_draw(Node *p_hb) {
 	Control *hb = Object::cast_to<Control>(p_hb);
 
@@ -1870,7 +1679,7 @@ void ProjectList::_panel_draw(Node *p_hb) {
 	}
 }
 
-// Input for each item in the list
+// Input for each item in the list.
 void ProjectList::_panel_input(const Ref<InputEvent> &p_ev, Node *p_hb) {
 	Ref<InputEventMouseButton> mb = p_ev;
 	int clicked_index = p_hb->get_index();
@@ -1940,13 +1749,20 @@ void ProjectList::_show_project(const String &p_path) {
 	OS::get_singleton()->shell_open(String("file://") + p_path);
 }
 
-const char *ProjectList::SIGNAL_SELECTION_CHANGED = "selection_changed";
-const char *ProjectList::SIGNAL_PROJECT_ASK_OPEN = "project_ask_open";
-
 void ProjectList::_bind_methods() {
 	ADD_SIGNAL(MethodInfo(SIGNAL_SELECTION_CHANGED));
 	ADD_SIGNAL(MethodInfo(SIGNAL_PROJECT_ASK_OPEN));
 }
+
+ProjectList::ProjectList() {
+	_scroll_children = memnew(VBoxContainer);
+	_scroll_children->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	add_child(_scroll_children);
+
+	_config_path = EditorPaths::get_singleton()->get_data_dir().path_join("projects.cfg");
+}
+
+/// Project Manager.
 
 ProjectManager *ProjectManager::singleton = nullptr;
 
@@ -2438,6 +2254,7 @@ void ProjectManager::_scan_dir(const String &path) {
 	}
 	da->list_dir_end();
 }
+
 void ProjectManager::_scan_begin(const String &p_base) {
 	print_line("Scanning projects at: " + p_base);
 	_scan_dir(p_base);

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -137,18 +137,39 @@ public:
 class ProjectListItemControl : public HBoxContainer {
 	GDCLASS(ProjectListItemControl, HBoxContainer)
 
-	friend class ProjectList;
-
+	VBoxContainer *main_vbox = nullptr;
 	TextureButton *favorite_button = nullptr;
-	TextureRect *icon = nullptr;
+	Button *explore_button = nullptr;
+
+	TextureRect *project_icon = nullptr;
+	Label *project_title = nullptr;
+	Label *project_path = nullptr;
+	Label *project_unsupported_features = nullptr;
+
+	bool project_is_missing = false;
 	bool icon_needs_reload = true;
-	bool hover = false;
+	bool is_selected = false;
+	bool is_hovering = false;
+
+	void _favorite_button_pressed();
+	void _explore_button_pressed();
 
 protected:
 	void _notification(int p_what);
+	static void _bind_methods();
 
 public:
-	void set_is_favorite(bool fav);
+	void set_project_title(const String &p_title);
+	void set_project_path(const String &p_path);
+	void set_project_icon(const Ref<Texture2D> &p_icon);
+	void set_unsupported_features(const PackedStringArray &p_features);
+
+	bool should_load_project_icon() const;
+	void set_selected(bool p_selected);
+
+	void set_is_favorite(bool p_favorite);
+	void set_is_missing(bool p_missing);
+	void set_is_grayed(bool p_grayed);
 
 	ProjectListItemControl();
 };

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -40,6 +40,7 @@
 class CheckBox;
 class EditorAssetLibrary;
 class EditorFileDialog;
+class PanelContainer;
 
 class ProjectDialog : public ConfirmationDialog {
 	GDCLASS(ProjectDialog, ConfirmationDialog);
@@ -289,13 +290,14 @@ class ProjectManager : public Control {
 
 	static ProjectManager *singleton;
 
+	Panel *background_panel = nullptr;
 	TabContainer *tabs = nullptr;
-
 	ProjectList *_project_list = nullptr;
 
 	LineEdit *search_box = nullptr;
 	Label *loading_label = nullptr;
 	OptionButton *filter_option = nullptr;
+	PanelContainer *search_panel = nullptr;
 
 	Button *create_btn = nullptr;
 	Button *import_btn = nullptr;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/74214. Fixes https://github.com/godotengine/godot/issues/65734.
Builds on top of changes done in https://github.com/godotengine/godot/pull/30735.

The first commit contains a restructuring of the changes done in https://github.com/godotengine/godot/pull/30735, to bring them closer to our codestyle:
* Classes were moved out of the CPP file and into the header;
* Access modifiers were corrected, property and method order was changed to respect our normal structure (including access modifier block order);
  * As this commit aimed to do the least damage possible, I had to resort to befriending some classes. Some of that is resolved with the follow-up commits.
* Some includes and names were cleaned up.

The second commit addresses https://github.com/godotengine/godot/issues/74214 and https://github.com/godotengine/godot/issues/65734 directly. It makes sure that the initial theme creation is properly set up, and it moves all the theme item fetching code to the correct notification, so changes can be picked up (not that there should be any, but still, code quality). Some properties were moved to the editor theme.

The third commit reworks the project list structure. While the earlier work in this component factored out some elements into their own control, layout was still generated out of that control and inside of the parent control. And it heavily relied on having access to the private properties of the class (effectively using it as a Node-based struct). So I reworked all of the relevant code and moved all of the layout of the list item component inside of that component, and for the list itself I exposed all the necessary API, cleaning up some weirdness and possible mistakes in the process. Theming was also centralized in the process.

-----

I didn't use the manual theme cache system because, well, this is already a lot and there is probably not a lot of benefit from doing this right now. It can still be implemented in the future, alongside more useful changes to these components, but the current state should suffice as is.

Light mode works now, and that's what's important :)

![godot windows editor dev x86_64_2023-03-10_16-39-47](https://user-images.githubusercontent.com/11782833/224367308-ae19e375-5316-48e8-b5a8-bc5486ca88da.png)
![image](https://user-images.githubusercontent.com/11782833/224368536-800f55e6-6d71-44ae-a0ab-a450fd343a0d.png)

