### PR TITLE
Fix read-only dictionaries adding missing keys

### DIFF
--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -84,13 +84,15 @@ Variant &Dictionary::operator[](const Variant &p_key) {
 		if (p_key.get_type() == Variant::STRING_NAME) {
 			const StringName *sn = VariantInternal::get_string_name(&p_key);
 			const String &key = sn->operator String();
-			if (_p->variant_map.has(key)) {
+			if (likely(_p->variant_map.has(key))) {
 				*_p->read_only = _p->variant_map[key];
 			} else {
 				*_p->read_only = Variant();
 			}
-		} else {
+		} else if (likely(_p->variant_map.has(p_key))) {
 			*_p->read_only = _p->variant_map[p_key];
+		} else {
+			*_p->read_only = Variant();
 		}
 
 		return *_p->read_only;

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -83,7 +83,12 @@ Variant &Dictionary::operator[](const Variant &p_key) {
 	if (unlikely(_p->read_only)) {
 		if (p_key.get_type() == Variant::STRING_NAME) {
 			const StringName *sn = VariantInternal::get_string_name(&p_key);
-			*_p->read_only = _p->variant_map[sn->operator String()];
+			const String &key = sn->operator String();
+			if (_p->variant_map.has(key)) {
+				*_p->read_only = _p->variant_map[key];
+			} else {
+				*_p->read_only = Variant();
+			}
 		} else {
 			*_p->read_only = _p->variant_map[p_key];
 		}

--- a/tests/core/variant/test_dictionary.h
+++ b/tests/core/variant/test_dictionary.h
@@ -88,6 +88,12 @@ TEST_CASE("[Dictionary] Assignment using bracket notation ([])") {
 	CHECK(int(map[0]) == 400);
 	// Check that assigning 0 doesn't overwrite the value for `false`.
 	CHECK(int(map[false]) == 128);
+
+	// Ensure read-only maps aren't modified by non-existing keys.
+	const auto length = map.size();
+	map.make_read_only();
+	CHECK(int(map["This key does not exist"].get_type()) == Variant::NIL);
+	CHECK(map.size() == length);
 }
 
 TEST_CASE("[Dictionary] get_key_lists()") {


### PR DESCRIPTION
When querying a non-existing key on a read-only dictionary, the key was still added (albeit never set).

This fixes #74726.