### PR TITLE
Fix CharacterBody2D get_slide_collision docs

### DIFF
--- a/doc/classes/CharacterBody2D.xml
+++ b/doc/classes/CharacterBody2D.xml
@@ -73,8 +73,8 @@
 				[codeblocks]
 				[gdscript]
 				for i in get_slide_collision_count():
-				var collision = get_slide_collision(i)
-				print("Collided with: ", collision.collider.name)
+				    var collision = get_slide_collision(i)
+				    print("Collided with: ", collision.get_collider().name)
 				[/gdscript]
 				[csharp]
 				for (int i = 0; i &lt; GetSlideCollisionCount(); i++)


### PR DESCRIPTION
The indentation was off and the code usage was incorrect for Godot 4.0 GDScript.