### PR TITLE
Remember directory when installing templates file

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -529,6 +529,7 @@ bool ExportTemplateManager::_install_file_selected(const String &p_file, bool p_
 	unzClose(pkg);
 
 	_update_template_status();
+	EditorSettings::get_singleton()->set_meta("export_template_download_directory", p_file.get_base_dir());
 	return true;
 }
 
@@ -992,6 +993,7 @@ ExportTemplateManager::ExportTemplateManager() {
 	install_file_dialog->set_title(TTR("Select Template File"));
 	install_file_dialog->set_access(FileDialog::ACCESS_FILESYSTEM);
 	install_file_dialog->set_file_mode(FileDialog::FILE_MODE_OPEN_FILE);
+	install_file_dialog->set_current_dir(EditorSettings::get_singleton()->get_meta("export_template_download_directory", ""));
 	install_file_dialog->add_filter("*.tpz", TTR("Godot Export Templates"));
 	install_file_dialog->connect("file_selected", callable_mp(this, &ExportTemplateManager::_install_file_selected).bind(false));
 	add_child(install_file_dialog);


### PR DESCRIPTION
Every single time when I install new export templates I have to manually navigate to the downloads directory. Copying the path isn't always easily accessible due to some Windows weirdness.

With this PR the "Install From File" option will automatically open the previously used directory.