### PR TITLE
Fix for unphysical rotation behavior of 3D rigid bodies and an API function for entering the Inertia tensor directly.

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -127,6 +127,8 @@ bool Basis::is_symmetric() const {
 Basis Basis::diagonalize() {
 // NOTE: only implemented for symmetric matrices
 // with the Jacobi iterative method
+// this method diagonalises the original matrix and
+// returns a matrix with eigenvectors as its columns
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V(!is_symmetric(), Basis());
 #endif

--- a/doc/classes/RigidBody3D.xml
+++ b/doc/classes/RigidBody3D.xml
@@ -117,7 +117,7 @@
 		<method name="get_inverse_inertia_tensor" qualifiers="const">
 			<return type="Basis" />
 			<description>
-				Returns the inverse inertia tensor basis. This is used to calculate the angular acceleration resulting from a torque applied to the [RigidBody3D].
+				Returns the inverse inertia tensor basis relative to the world basis. This is used to calculate the angular acceleration resulting from a torque applied to the [RigidBody3D].
 			</description>
 		</method>
 		<method name="set_axis_velocity">
@@ -125,6 +125,14 @@
 			<param index="0" name="axis_velocity" type="Vector3" />
 			<description>
 				Sets an axis velocity. The velocity in the given vector axis will be set as the given vector length. This is useful for jumping behavior.
+			</description>
+		</method>
+		<method name="set_inertia_tensor">
+			<return type="void" />
+			<param index="0" name="inertia_tensor" type="Basis" />
+			<description>
+				Sets the inertia tensor relative to the body-frame coordinate system. This is used in case the body's principal axes does not align with the object-local coordinate axes.
+				Body-frame coordinate axes have their origin at the center of mass and are parallel to the object-local coordinate axes.
 			</description>
 		</method>
 	</methods>

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -682,6 +682,12 @@ void RigidBody3D::set_inertia(const Vector3 &p_inertia) {
 	PhysicsServer3D::get_singleton()->body_set_param(get_rid(), PhysicsServer3D::BODY_PARAM_INERTIA, inertia);
 }
 
+void RigidBody3D::set_inertia_tensor(const Basis &p_inertia) {
+	PhysicsServer3D* singleton = PhysicsServer3D::get_singleton();
+	singleton->body_set_param(get_rid(), PhysicsServer3D::BODY_PARAM_INERTIA, p_inertia);
+	inertia = singleton->body_get_param(get_rid(), PhysicsServer3D::BODY_PARAM_INERTIA);
+}
+
 const Vector3 &RigidBody3D::get_inertia() const {
 	return inertia;
 }
@@ -997,6 +1003,7 @@ void RigidBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_mass"), &RigidBody3D::get_mass);
 
 	ClassDB::bind_method(D_METHOD("set_inertia", "inertia"), &RigidBody3D::set_inertia);
+	ClassDB::bind_method(D_METHOD("set_inertia_tensor", "inertia_tensor"), &RigidBody3D::set_inertia_tensor);
 	ClassDB::bind_method(D_METHOD("get_inertia"), &RigidBody3D::get_inertia);
 
 	ClassDB::bind_method(D_METHOD("set_center_of_mass_mode", "mode"), &RigidBody3D::set_center_of_mass_mode);

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -250,6 +250,7 @@ public:
 	virtual real_t get_inverse_mass() const override { return 1.0 / mass; }
 
 	void set_inertia(const Vector3 &p_inertia);
+	void set_inertia_tensor(const Basis &p_inertia);
 	const Vector3 &get_inertia() const;
 
 	void set_center_of_mass_mode(CenterOfMassMode p_mode);

--- a/servers/physics_3d/godot_body_3d.h
+++ b/servers/physics_3d/godot_body_3d.h
@@ -56,7 +56,7 @@ class GodotBody3D : public GodotCollisionObject3D {
 	real_t mass = 1.0;
 	real_t bounce = 0.0;
 	real_t friction = 1.0;
-	Vector3 inertia;
+	Vector3 inertia; // Relative to the principal axes of inertia
 
 	PhysicsServer3D::BodyDampMode linear_damp_mode = PhysicsServer3D::BODY_DAMP_MODE_COMBINE;
 	PhysicsServer3D::BodyDampMode angular_damp_mode = PhysicsServer3D::BODY_DAMP_MODE_COMBINE;
@@ -77,6 +77,7 @@ class GodotBody3D : public GodotCollisionObject3D {
 	// Relative to the local frame of reference
 	Basis principal_inertia_axes_local;
 	Vector3 center_of_mass_local;
+	Basis inertia_tensor_local;
 
 	// In world orientation with local origin
 	Basis _inv_inertia_tensor;
@@ -146,6 +147,7 @@ class GodotBody3D : public GodotCollisionObject3D {
 	uint64_t island_step = 0;
 
 	void _update_transform_dependent();
+	Vector3 _local_angular_acceleration(Vector3 local_torque, Vector3 local_ang_vel);
 
 	friend class GodotPhysicsDirectBodyState3D; // i give up, too many functions to expose
 

--- a/servers/physics_3d/godot_body_3d.h
+++ b/servers/physics_3d/godot_body_3d.h
@@ -78,6 +78,7 @@ class GodotBody3D : public GodotCollisionObject3D {
 	Basis principal_inertia_axes_local;
 	Vector3 center_of_mass_local;
 	Basis inertia_tensor_local;
+	Basis inv_inertia_tensor_local;
 
 	// In world orientation with local origin
 	Basis _inv_inertia_tensor;
@@ -147,7 +148,8 @@ class GodotBody3D : public GodotCollisionObject3D {
 	uint64_t island_step = 0;
 
 	void _update_transform_dependent();
-	Vector3 _local_angular_acceleration(Vector3 local_torque, Vector3 local_ang_vel);
+	Vector3 _local_angular_acceleration(const Vector3 &local_torque, const Vector3 &local_ang_vel);
+	void _update_inertia_tensor_local(const Basis &inertia);
 
 	friend class GodotPhysicsDirectBodyState3D; // i give up, too many functions to expose
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
## Premise
Originally, Godot's Rigid body physics engine used the following equation to update its rotation:
```math
\mathbf{\tau} = \mathbf{I}\frac{d\mathbf{\omega}}{dt}
```
This, of course, assumes that the inertia tensor of the body is constant in the inertial frame. However, that is not the case. Newton's second law for rotation in an inertial frame is:
```math
\mathbf{\tau} = \frac{d\mathbf{L}}{dt} = \mathbf{I}\frac{d\mathbf{\omega}}{dt}+\mathbf{\omega}\left(\frac{d}{dt}\mathbf{I} \right)
```
In the body-centric coordinates (rotating body's frame of reference), the equation of motion becomes:
```math
\mathbf{\tau}_b = \mathbf{I}_b\frac{d\omega_b}{dt}+\omega_b \times \mathbf{I}_b\omega_b
```
Here, $\mathbf{I}_b$ is constant unless the internal properties of the rigid body change. 
## Changes made
- The integrand is now calculated in the local coordinates with the local inertia tensor. As the forward Euler method is unstable, RK4 is used as the integration scheme.
- An API function is also provided to enter the inertia tensor directly. Documentation is also updated.
## Effects
The new change accurately simulates well-known phenomena such as the Dzhanibekov effect and torque-free precession which was previously not depicted.
## Uses
Could be beneficial for any game that employs realism, such as realistic space or aircraft games/simulators.

https://user-images.githubusercontent.com/37753945/224391750-98d9a2c8-5705-4404-a654-fa3a3da2d9a4.mp4
