### PR TITLE
Add theming support for hovered ItemList items

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -439,6 +439,9 @@
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.65, 0.65, 0.65, 1)">
 			Default text [Color] of the item.
 		</theme_item>
+		<theme_item name="font_hovered_color" data_type="color" type="Color" default="Color(0.95, 0.95, 0.95, 1)">
+			Text [Color] used when the item is hovered and not selected yet.
+		</theme_item>
 		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the item.
 		</theme_item>
@@ -478,6 +481,9 @@
 		</theme_item>
 		<theme_item name="focus" data_type="style" type="StyleBox">
 			The focused style for the [ItemList], drawn on top of the background, but below everything else.
+		</theme_item>
+		<theme_item name="hovered" data_type="style" type="StyleBox">
+			[StyleBox] for the hovered, but not selected items.
 		</theme_item>
 		<theme_item name="panel" data_type="style" type="StyleBox">
 			The background style for the [ItemList].

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1296,13 +1296,20 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_itemlist_cursor->set_draw_center(false);
 	style_itemlist_cursor->set_border_width_all(border_width);
 	style_itemlist_cursor->set_border_color(highlight_color);
+
+	Ref<StyleBoxFlat> style_itemlist_hover = style_tree_selected->duplicate();
+	style_itemlist_hover->set_bg_color(highlight_color * Color(1, 1, 1, 0.3));
+	style_itemlist_hover->set_border_width_all(0);
+
 	theme->set_stylebox("panel", "ItemList", style_itemlist_bg);
 	theme->set_stylebox("focus", "ItemList", style_widget_focus);
 	theme->set_stylebox("cursor", "ItemList", style_itemlist_cursor);
 	theme->set_stylebox("cursor_unfocused", "ItemList", style_itemlist_cursor);
 	theme->set_stylebox("selected_focus", "ItemList", style_tree_focus);
 	theme->set_stylebox("selected", "ItemList", style_tree_selected);
+	theme->set_stylebox("hovered", "ItemList", style_itemlist_hover);
 	theme->set_color("font_color", "ItemList", font_color);
+	theme->set_color("font_hovered_color", "ItemList", mono_color);
 	theme->set_color("font_selected_color", "ItemList", mono_color);
 	theme->set_color("font_outline_color", "ItemList", font_outline_color);
 	theme->set_color("guide_color", "ItemList", guide_color);

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -84,6 +84,7 @@ private:
 	};
 
 	int current = -1;
+	int hovered = -1;
 
 	bool shape_changed = true;
 
@@ -130,12 +131,14 @@ private:
 		Ref<Font> font;
 		int font_size = 0;
 		Color font_color;
+		Color font_hovered_color;
 		Color font_selected_color;
 		int font_outline_size = 0;
 		Color font_outline_color;
 
 		int line_separation = 0;
 		int icon_margin = 0;
+		Ref<StyleBox> hovered_style;
 		Ref<StyleBox> selected_style;
 		Ref<StyleBox> selected_focus_style;
 		Ref<StyleBox> cursor_style;
@@ -146,6 +149,7 @@ private:
 	void _scroll_changed(double);
 	void _check_shape_changed();
 	void _shape_text(int p_idx);
+	void _mouse_exited();
 
 protected:
 	virtual void _update_theme_item_cache() override;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -803,9 +803,11 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font_size("font_size", "ItemList", -1);
 
 	theme->set_color("font_color", "ItemList", control_font_lower_color);
+	theme->set_color("font_hovered_color", "ItemList", control_font_hover_color);
 	theme->set_color("font_selected_color", "ItemList", control_font_pressed_color);
 	theme->set_color("font_outline_color", "ItemList", Color(1, 1, 1));
 	theme->set_color("guide_color", "ItemList", Color(0.7, 0.7, 0.7, 0.25));
+	theme->set_stylebox("hovered", "ItemList", make_flat_stylebox(Color(1, 1, 1, 0.07)));
 	theme->set_stylebox("selected", "ItemList", make_flat_stylebox(style_selected_color));
 	theme->set_stylebox("selected_focus", "ItemList", make_flat_stylebox(style_selected_color));
 	theme->set_stylebox("cursor", "ItemList", focus);


### PR DESCRIPTION
Addition of a distinct styling for the hovered item in ItemList controls.

Comes with the corresponding changes in default and editor themes.

Feature proposal with visuals: https://github.com/godotengine/godot-proposals/issues/6478

Can be backported to 3.x with adaptations to the branch themes.

_Production edit: Closes https://github.com/godotengine/godot-proposals/issues/6478_