### PR TITLE
Add disable_minimum_window_size editor setting

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -504,6 +504,10 @@
 			If [code]true[/code], lengthens the editor's localizable strings and replaces their characters with accented variants. This allows spotting non-localizable strings easily, while also ensuring the UI layout doesn't break when strings are made longer (as many languages require strings to be longer).
 			This is a debugging feature and should only be enabled when working on the editor itself.
 		</member>
+		<member name="interface/editor/disable_minimum_window_size" type="bool" setter="" getter="">
+			Disables the minimum size of main editor window, allowing it to shrink smaller than the default, and gives full control over sizing to the window manager.
+			[b]Note:[/b] The minimum window size prevents UI elements from overlapping or being cut off. Disabling the minimum size may make some parts of the editor inaccessible.
+		</member>
 		<member name="interface/editor/display_scale" type="int" setter="" getter="">
 			The display scale factor to use for the editor interface. Higher values are more suited to hiDPI/Retina displays.
 			If set to [b]Auto[/b], the editor scale is automatically determined based on the screen resolution and reported display DPI. This heuristic is not always ideal, which means you can get better results by setting the editor scale manually.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6776,7 +6776,7 @@ EditorNode::EditorNode() {
 
 	// Define a minimum window size to prevent UI elements from overlapping or being cut off.
 	Window *w = Object::cast_to<Window>(SceneTree::get_singleton()->get_root());
-	if (w) {
+	if (w && !(bool)EDITOR_GET("interface/editor/disable_minimum_window_size")) {
 		w->set_min_size(Size2(1024, 600) * EDSCALE);
 	}
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -407,6 +407,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/expand_to_title", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 
 	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/editor/custom_display_scale", 1.0, "0.5,3,0.01", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/disable_minimum_window_size", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/editor/main_font_size", 14, "8,48,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/editor/code_font_size", 14, "8,48,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/code_font_contextual_ligatures", 1, "Enabled,Disable Contextual Alternates (Coding Ligatures),Use Custom OpenType Feature Set")


### PR DESCRIPTION
Allows disabling of the main editor window minimum size, which interferes normal behavior of some window managers. Disabling may make some parts of the editor inaccessible.

Addresses #74456. May not be the best solution as some elements are partly cut off, but allows the use case of snapping the editor to the sides of the screen.