### PR TITLE
Implement Rect2.grow_corner()

### DIFF
--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -238,6 +238,19 @@ struct _NO_DISCARD_ Rect2 {
 		return grow_side(Side(p_side), p_amount);
 	}
 
+	inline Rect2 grow_corner(Corner p_corner, Vector2 p_amount) const {
+		Rect2 g = *this;
+		g = g.grow_individual((p_corner == CORNER_TOP_LEFT || p_corner == CORNER_BOTTOM_LEFT) ? p_amount.x : 0,
+				(p_corner == CORNER_TOP_LEFT || p_corner == CORNER_TOP_RIGHT) ? p_amount.y : 0,
+				(p_corner == CORNER_TOP_RIGHT || p_corner == CORNER_BOTTOM_RIGHT) ? p_amount.x : 0,
+				(p_corner == CORNER_BOTTOM_LEFT || p_corner == CORNER_BOTTOM_RIGHT) ? p_amount.y : 0);
+		return g;
+	}
+
+	inline Rect2 grow_corner_bind(uint32_t p_corner, Vector2 p_amount) const {
+		return grow_corner(Corner(p_corner), p_amount);
+	}
+
 	inline Rect2 grow_individual(real_t p_left, real_t p_top, real_t p_right, real_t p_bottom) const {
 		Rect2 g = *this;
 		g.position.x -= p_left;

--- a/core/math/rect2i.h
+++ b/core/math/rect2i.h
@@ -173,6 +173,19 @@ struct _NO_DISCARD_ Rect2i {
 		return grow_side(Side(p_side), p_amount);
 	}
 
+	inline Rect2i grow_corner(Corner p_corner, Vector2i p_amount) const {
+		Rect2i g = *this;
+		g = g.grow_individual((p_corner == CORNER_TOP_LEFT || p_corner == CORNER_BOTTOM_LEFT) ? p_amount.x : 0,
+				(p_corner == CORNER_TOP_LEFT || p_corner == CORNER_TOP_RIGHT) ? p_amount.y : 0,
+				(p_corner == CORNER_TOP_RIGHT || p_corner == CORNER_BOTTOM_RIGHT) ? p_amount.x : 0,
+				(p_corner == CORNER_BOTTOM_LEFT || p_corner == CORNER_BOTTOM_RIGHT) ? p_amount.y : 0);
+		return g;
+	}
+
+	inline Rect2i grow_corner_bind(uint32_t p_corner, Vector2i p_amount) const {
+		return grow_corner(Corner(p_corner), p_amount);
+	}
+
 	inline Rect2i grow_individual(int p_left, int p_top, int p_right, int p_bottom) const {
 		Rect2i g = *this;
 		g.position.x -= p_left;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1806,6 +1806,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Rect2, expand, sarray("to"), varray());
 	bind_method(Rect2, grow, sarray("amount"), varray());
 	bind_methodv(Rect2, grow_side, &Rect2::grow_side_bind, sarray("side", "amount"), varray());
+	bind_methodv(Rect2, grow_corner, &Rect2::grow_corner_bind, sarray("corner", "amount"), varray());
 	bind_method(Rect2, grow_individual, sarray("left", "top", "right", "bottom"), varray());
 	bind_method(Rect2, abs, sarray(), varray());
 
@@ -1822,6 +1823,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Rect2i, expand, sarray("to"), varray());
 	bind_method(Rect2i, grow, sarray("amount"), varray());
 	bind_methodv(Rect2i, grow_side, &Rect2i::grow_side_bind, sarray("side", "amount"), varray());
+	bind_methodv(Rect2i, grow_corner, &Rect2i::grow_corner_bind, sarray("corner", "amount"), varray());
 	bind_method(Rect2i, grow_individual, sarray("left", "top", "right", "bottom"), varray());
 	bind_method(Rect2i, abs, sarray(), varray());
 

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -109,6 +109,14 @@
 				Returns a copy of the [Rect2] grown by the specified [param amount] on all sides.
 			</description>
 		</method>
+		<method name="grow_corner" qualifiers="const">
+			<return type="Rect2" />
+			<param index="0" name="corner" type="int" />
+			<param index="1" name="amount" type="Vector2" />
+			<description>
+				Returns a copy of the [Rect2] grown by the specified [param amount] at the specified [enum Corner].
+			</description>
+		</method>
 		<method name="grow_individual" qualifiers="const">
 			<return type="Rect2" />
 			<param index="0" name="left" type="float" />

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -107,6 +107,14 @@
 				Returns a copy of the [Rect2i] grown by the specified [param amount] on all sides.
 			</description>
 		</method>
+		<method name="grow_corner" qualifiers="const">
+			<return type="Rect2i" />
+			<param index="0" name="corner" type="int" />
+			<param index="1" name="amount" type="Vector2i" />
+			<description>
+				Returns a copy of the [Rect2i] grown by the specified [param amount] at the specified [enum Corner].
+			</description>
+		</method>
 		<method name="grow_individual" qualifiers="const">
 			<return type="Rect2i" />
 			<param index="0" name="left" type="int" />

--- a/tests/core/math/test_rect2.h
+++ b/tests/core/math/test_rect2.h
@@ -204,6 +204,13 @@ TEST_CASE("[Rect2] Growing") {
 	CHECK_MESSAGE(
 			Rect2(0, 100, 1280, 720).grow_side(SIDE_TOP, -500).is_equal_approx(Rect2(0, 600, 1280, 220)),
 			"grow_side() with negative value should return the expected Rect2.");
+
+	CHECK_MESSAGE(
+			Rect2(0, 100, 1280, 720).grow_corner(CORNER_TOP_RIGHT, Vector2(300, 200)).is_equal_approx(Rect2(0, -100, 1580, 920)),
+			"grow_corner() with positive values should return the expected Rect2.");
+	CHECK_MESSAGE(
+			Rect2(0, 100, 1280, 720).grow_corner(CORNER_TOP_LEFT, Vector2(-300, -200)).is_equal_approx(Rect2(300, 300, 980, 520)),
+			"grow_corner() with negative values should return the expected Rect2.");
 }
 
 TEST_CASE("[Rect2] Has point") {

--- a/tests/core/math/test_rect2i.h
+++ b/tests/core/math/test_rect2i.h
@@ -207,6 +207,13 @@ TEST_CASE("[Rect2i] Growing") {
 	CHECK_MESSAGE(
 			Rect2i(0, 100, 1280, 720).grow_side(SIDE_TOP, -500) == Rect2i(0, 600, 1280, 220),
 			"grow_side() with negative value should return the expected Rect2i.");
+
+	CHECK_MESSAGE(
+			Rect2i(0, 100, 1280, 720).grow_corner(CORNER_TOP_RIGHT, Vector2i(300, 200)) == Rect2i(0, -100, 1580, 920),
+			"grow_corner() with positive values should return the expected Rect2i.");
+	CHECK_MESSAGE(
+			Rect2i(0, 100, 1280, 720).grow_corner(CORNER_TOP_LEFT, Vector2i(-300, -200)) == Rect2i(300, 300, 980, 520),
+			"grow_corner() with negative values should return the expected Rect2i.");
 }
 
 TEST_CASE("[Rect2i] Has point") {


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/6472

For example, `Rect2.grow_corner(CORNER_TOP_RIGHT, Vector2(20, 40))` will grow the top side by 40 and the right side by 20. Can be a bit confusing with the vertical side being mentioned first in the Corner enum, while the vertical component is second in the vector, but ah well nothing that can be done about that.

I should note nothing like this exists in AABB either, so one might argue we should have gotten rid of `grow_side()` in Godot 4 in the first place. This is a change in core, so it shouldn't be added lightly.