### PR TITLE
[4.0] Ensure that editor color map is initialized in the project manager

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2682,10 +2682,11 @@ ProjectManager::ProjectManager() {
 		AcceptDialog::set_swap_cancel_ok(swap_cancel_ok == 2);
 	}
 
+	EditorColorMap::create();
 	Ref<Theme> theme = create_custom_theme();
-	set_theme(theme);
 	DisplayServer::set_early_window_clear_color_override(true, theme->get_color(SNAME("background"), SNAME("Editor")));
 
+	set_theme(theme);
 	set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 
 	Panel *panel = memnew(Panel);


### PR DESCRIPTION
A simple extraction from https://github.com/godotengine/godot/pull/74729, that directly addresses the core of the linked issues without major code improvements. This PR targets `4.0` instead of `master`, as this is a safe backport that can be applied to 4.0.x.