### PR TITLE
Register XRServer as a singleton earlier.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2108,8 +2108,10 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	audio_server = memnew(AudioServer);
 	audio_server->init();
 
-	// also init our xr_server from here
+	// Also init our xr_server from here
 	xr_server = memnew(XRServer);
+	// We register this right away so GDExternal plugins can interact with the XRServer to register XRInterfaces
+	Engine::get_singleton()->add_singleton(Engine::Singleton("XRServer", XRServer::get_singleton(), "XRServer"));
 
 	register_core_singletons();
 

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -303,6 +303,5 @@ void register_server_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PhysicsServer3D", PhysicsServer3D::get_singleton(), "PhysicsServer3D"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer2D", NavigationServer2D::get_singleton(), "NavigationServer2D"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer3D", NavigationServer3D::get_singleton(), "NavigationServer3D"));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("XRServer", XRServer::get_singleton(), "XRServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("CameraServer", CameraServer::get_singleton(), "CameraServer"));
 }


### PR DESCRIPTION
Register XRServer as a singleton earlier so it is accessible in GDExternals where it is needed

When XRInterfaces are implemented as a GDExternal, interfaces have to be registered with the XRServer. This is currently not possible as the singleton is not registered in time.

This PR changes this HOWEVER DO NOT MERGE THIS

This is a temporary solution to get around this problem for people who are currently building and testing such externals. Discussions within the core team so far have gone down the path that this method of solving this is unwanted. Singletons are registered late due to inter-dependencies between the various servers. 

Also the current methodology Godot has for XRInterfaces stems from the limitations in Godot 3. There is actually no need to register interfaces this early on and we can prevent instancing interfaces until they are actually needed now that GDExternals properly register classes in the ClassDB.

We can do away with this solution and instead levy the ClassDB solution.
