### PR TITLE
Handle RID validator overflow

### DIFF
--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -117,6 +117,7 @@ class RID_Alloc : public RID_AllocBase {
 		uint32_t free_element = free_index % elements_in_chunk;
 
 		uint32_t validator = (uint32_t)(_gen_id() & 0x7FFFFFFF);
+		CRASH_COND_MSG(validator == 0x7FFFFFFF, "Overflow in RID validator");
 		uint64_t id = validator;
 		id <<= 32;
 		id |= free_index;
@@ -238,7 +239,7 @@ public:
 
 		uint32_t validator = uint32_t(id >> 32);
 
-		bool owned = (validator_chunks[idx_chunk][idx_element] & 0x7FFFFFFF) == validator;
+		bool owned = (validator != 0x7FFFFFFF) && (validator_chunks[idx_chunk][idx_element] & 0x7FFFFFFF) == validator;
 
 		if (THREAD_SAFE) {
 			spin_lock.unlock();


### PR DESCRIPTION
If the RID validator index reaches the maximum value of a 31 bit integer it will register as an invalid entry and break the RID, this crashes the engine on reaching that.

My reasoning is that the likelihood of reaching this in normal usage of the engine is extremely low and it's safe to just crash on the exception, as in, it shouldn't disrupt normal usage but crash on exceptional one

I can instead have it generate a new validator by calling the increment again, possibly skipping over 0 to avoid an RID of 0, but I don't think it's safe to reuse validators. If someone can confirm it is safe to do so I will change to that approach.

* Fixes: #74728
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->