### PR TITLE
Fix offset rounding for odd-sized tiles

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -854,7 +854,7 @@ void TileMap::_update_dirty_quadrants() {
 			q->self()->local_to_map.clear();
 			for (const Vector2i &E : q->self()->cells) {
 				Vector2i pk = E;
-				Vector2i pk_local_coords = map_to_local(pk);
+				Vector2i pk_local_coords = map_to_local(pk).floor();
 				q->self()->map_to_local[pk] = pk_local_coords;
 				q->self()->local_to_map[pk_local_coords] = pk;
 			}
@@ -1244,6 +1244,8 @@ void TileMap::_rendering_update_dirty_quadrants(SelfList<TileMapQuadrant>::List 
 						// When Y-sorting, the quandrant size is sure to be 1, we can thus offset the CanvasItem.
 						tile_position.y += layers[q.layer].y_sort_origin + tile_data->get_y_sort_origin();
 					}
+
+					tile_position = tile_position.floor();
 
 					// --- CanvasItems ---
 					// Create two canvas items, for rendering and debug.


### PR DESCRIPTION
Bug: https://github.com/godotengine/godot/issues/62911

The issue had two causes.

1. The quadrant provides coordinates from the center of the first tile as a float (so with a .5), then subtracted the tile origin as an integer (rounded down). If the tile position is floored before drawing the tile, this fixes the offset.
2. Negative signed quadrants were positioned by truncating their coordinates in the map_to_local hashmap, causing them to be rounded towards zero. This needs to be floored to prevent a 1 pixel offset for quadrants positioned behind 0,0.

<i>Bugsquad edit: </i>
- Fix #62911 