### PR TITLE
[3.x] Fix TextEdit `color_region_cache` bug

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5488,7 +5488,7 @@ int TextEdit::_is_line_in_region(int p_line) {
 	// If not find the closest line we have.
 	int previous_line = p_line - 1;
 	for (; previous_line > -1; previous_line--) {
-		if (color_region_cache.has(p_line)) {
+		if (color_region_cache.has(previous_line)) {
 			break;
 		}
 	}


### PR DESCRIPTION
Due to a single error, `_is_line_in_region` was previously iterating over the color highlighting for the entire document repeatedly for each line in the script.

This is now fixed, which should make the editor much faster with large scripts.

## Explanation
The loop is meant to find the first line that is in the cache, but due to the error, it repeatedly checks whether the same line is in the cache, so it never breaks, and always reaches the beginning, so `previous_line` is incorrect throughout the rest of the routine.

Partially fixes #74733

## Notes
This bug was really bad for performance - debug logging revealed that for each line of script the syntax highlighter evaluated every previous line, each time, so the performance drop was with the square of the number of lines, something like that.
i.e.
```
_is_line_in_region(5)
... evaluates 0, 1, 2, 3, 4
_is_line_in_region(6)
... evaluates 0, 1, 2, 3, 4 AGAIN and then 5
etc etc
```
* I'll have a look if the same bug exists in master - no, looks like the `CodeHighlighter` there is correct in the same place.
* Bug was introduced in #18040 so has been present for 5 years. :grinning: 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
