### PR TITLE
[3.x] GDScriptParser: Don't use index operator on linked list

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -8632,8 +8632,8 @@ void GDScriptParser::_check_block_types(BlockNode *p_block) {
 	}
 
 	// Parse sub blocks
-	for (int i = 0; i < p_block->sub_blocks.size(); i++) {
-		current_block = p_block->sub_blocks[i];
+	for (const List<BlockNode *>::Element *E = p_block->sub_blocks.front(); E; E = E->next()) {
+		current_block = E->get();
 		_check_block_types(current_block);
 		current_block = p_block;
 		if (error_set) {


### PR DESCRIPTION
Index operators are super slow with linked lists. This came up in profiling the parsing, iterating sequentially using iterator is much faster.

Helps fix #74733.

## Notes
* This fixes one of the bottlenecks in parsing but there are more.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
