### PR TITLE
[3.x] Use hash table for GDScript parsing

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2095,6 +2095,8 @@ GDScriptWarning::Code GDScriptWarning::get_code_from_name(const String &p_name) 
 #endif // DEBUG_ENABLED
 
 GDScriptLanguage::GDScriptLanguage() {
+	GDScriptTokenizer::initialize();
+
 	calls = 0;
 	ERR_FAIL_COND(singleton);
 	singleton = this;
@@ -2139,6 +2141,8 @@ GDScriptLanguage::GDScriptLanguage() {
 }
 
 GDScriptLanguage::~GDScriptLanguage() {
+	GDScriptTokenizer::terminate();
+
 	if (_call_stack) {
 		memdelete_arr(_call_stack);
 	}

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -31,6 +31,7 @@
 #ifndef GDSCRIPT_TOKENIZER_H
 #define GDSCRIPT_TOKENIZER_H
 
+#include "core/oa_hash_map.h"
 #include "core/pair.h"
 #include "core/string_name.h"
 #include "core/ustring.h"
@@ -154,8 +155,19 @@ protected:
 
 	static const char *token_names[TK_MAX];
 
+	enum {
+		TOKEN_HASH_TABLE_TYPE_START = 3,
+		TOKEN_HASH_TABLE_BUILTIN_START = TOKEN_HASH_TABLE_TYPE_START + Variant::VARIANT_MAX,
+		TOKEN_HASH_TABLE_KEYWORD_START = TOKEN_HASH_TABLE_BUILTIN_START + GDScriptFunctions::FUNC_MAX,
+	};
+
+	static OAHashMap<String, int> *token_hashtable;
+
 public:
 	static const char *get_token_name(Token p_token);
+
+	static void initialize();
+	static void terminate();
 
 	bool is_token_literal(int p_offset = 0, bool variable_safe = false) const;
 	StringName get_token_literal(int p_offset = 0) const;
@@ -177,7 +189,7 @@ public:
 	virtual bool is_ignoring_warnings() const = 0;
 #endif // DEBUG_ENABLED
 
-	virtual ~GDScriptTokenizer(){};
+	virtual ~GDScriptTokenizer() {}
 };
 
 class GDScriptTokenizerText : public GDScriptTokenizer {
@@ -230,6 +242,7 @@ class GDScriptTokenizerText : public GDScriptTokenizer {
 #endif // DEBUG_ENABLED
 
 	void _advance();
+	bool _parse_identifier(const String &p_str);
 
 public:
 	void set_code(const String &p_code);


### PR DESCRIPTION
GDScript now uses hash table for lookup of type lists / functions / keywords, instead of linear String comparisons.

Helps fix #74733

HashTable lookup during parsing seems approx 20x faster than linear search.

## Notes
* Profiling reveals after the other fixes, looking up keywords / functions using a linear search with lots of `String ==` comparisons is very slow, this is better suited to a hash table.
* I'm not super familiar with the parser so this could do with double checking by GDScript guy.
* Using an `OAHashMap` here, welcome suggestions if there is a better container, can be slow insertion but needs fast lookup.
* Using dynamic allocation just to be super safe - reduz mentioned previously that some of the Variant / possibly String stuff might not be safe to store as globals due to order of construction / destruction.
I couldn't immediately see a good place to put them as member variables (`GDScriptTokenizer` gets reconstructed often so not a good candidate, as we want to set up the hash table only once), but would welcome any suggestions.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
