### PR TITLE
Add `CONNECT_NO_EDITOR`

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1344,6 +1344,12 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 		const Callable &callable = slot_callables[i];
 		const uint32_t &flags = slot_flags[i];
 
+#ifdef TOOLS_ENABLED
+		if (flags & CONNECT_NO_EDITOR && Engine::get_singleton()->is_editor_hint() && is_class("Node") && call(SNAME("is_part_of_edited_scene"))) {
+			continue;
+		}
+#endif
+
 		if (!callable.is_valid()) {
 			// Target might have been deleted during signal callback, this is expected and OK.
 			continue;

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -578,6 +578,7 @@ public:
 		CONNECT_REFERENCE_COUNTED = 8,
 		CONNECT_APPEND_SOURCE_OBJECT = 16,
 		CONNECT_INHERITED = 32, // Used in editor builds.
+		CONNECT_NO_EDITOR = 64, // The signal won't be emitted from nodes in the currently edited scene.
 	};
 
 	// Store on each object a bitfield to quickly test whether it is derived from some "key" classes

--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -988,7 +988,7 @@ void ConnectionsDock::_make_or_edit_connection() {
 	bool b_deferred = connect_dialog->get_deferred();
 	bool b_oneshot = connect_dialog->get_one_shot();
 	bool b_append_source = connect_dialog->get_append_source();
-	cd.flags = CONNECT_PERSIST | (b_deferred ? CONNECT_DEFERRED : 0) | (b_oneshot ? CONNECT_ONE_SHOT : 0) | (b_append_source ? CONNECT_APPEND_SOURCE_OBJECT : 0);
+	cd.flags = CONNECT_PERSIST | (b_deferred ? CONNECT_DEFERRED : 0) | (b_oneshot ? CONNECT_ONE_SHOT : 0) | (b_append_source ? CONNECT_APPEND_SOURCE_OBJECT : 0) | CONNECT_NO_EDITOR;
 
 	// If the function is found in target's own script, check the editor setting
 	// to determine if the script should be opened.
@@ -1227,6 +1227,8 @@ void ConnectionsDock::_open_connection_dialog(TreeItem &p_item) {
 	cd.target = dst_node;
 	cd.signal = signal_name;
 	cd.method = ConnectDialog::generate_method_callback_name(cd.source, signal_name, cd.target);
+	// Always enable CONNECT_NO_EDITOR when connecting in the editor, to prevent unwanted emissions from nodes in the edited scene (e.g. from AnimationPlayer).
+	cd.flags = CONNECT_NO_EDITOR;
 	connect_dialog->init(cd, signal_args);
 	connect_dialog->set_title(TTR("Connect a Signal to a Method"));
 	connect_dialog->popup_dialog(signal_name.operator String() + "(" + String(", ").join(signal_args) + ")");


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/4850
Resolves #67864
Resolces #98808

~~The flag appears as a third checkbox:
![image](https://user-images.githubusercontent.com/2223172/224513911-b8350ac1-c4bf-4b84-869c-9fe8f61bbbe6.png)
It's enabled by default (up to discussion I guess; it prevents crashes, but might cause confusing when making plugins)~~

I removed the checkbox and made it enabled by default. The flag takes effect only for nodes in edited scene, so it won't affect plugins.