### PR TITLE
Fix jitter when an agent is traveling along a link and the map changes

### DIFF
--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -72,6 +72,9 @@ class NavigationAgent2D : public Node {
 	bool navigation_finished = true;
 	// No initialized on purpose
 	uint32_t update_frame_id = 0;
+	// Used to remember if we are currently in a link.
+	RID active_link_rid;
+	bool active_link_use_start_position = false;
 
 	// Debug properties for exposed bindings
 	bool debug_enabled = false;

--- a/scene/3d/navigation_agent_3d.h
+++ b/scene/3d/navigation_agent_3d.h
@@ -74,6 +74,9 @@ class NavigationAgent3D : public Node {
 	bool navigation_finished = true;
 	// No initialized on purpose
 	uint32_t update_frame_id = 0;
+	// Used to remember if we are currently in a link.
+	RID active_link_rid;
+	bool active_link_use_start_position = false;
 
 	// Debug properties for exposed bindings
 	bool debug_enabled = false;


### PR DESCRIPTION
@smix8 reported this issue in the Contributor Chat where agents would "dance" in place after starting a link whenever the map changed or the agent moved too far away from the original path.

This PR changes the default behavior when traveling along a link to continue traveling to the exit point until the link has been completed.  This should prevent the jitter from happening and allow agents to complete the link using the default navigation logic in simple cases.

This issue can be worked around today by coding custom movement logic when an agent has entered a link, and custom logic will still be required for non-trivial situations.

~~There is a downside to this approach where if the end point of a link moves, the agent will not move to the end point's new location but continue traveling to the original location, as long as that location is a valid location on the map (the agent will not travel to a position outside of the map). I'm not sure if it should follow the link's new endpoint and could use some feedback on whether that behavior is wanted.~~

Also, `path_metadata_flags` on the agent must include `PATH_METADATA_INCLUDE_TYPES` and `PATH_METADATA_INCLUDE_RIDS` in order for this fix to work, otherwise the agent can't know if it has entered a link or follow changes to it.

[EDIT]: Fix now tracks changes to the link's exit position.