### PR TITLE
fix ambiguous wording in `Object` signal documentation

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -362,7 +362,7 @@
 			<description>
 				Connects a [param signal] by name to a [param callable]. Optional [param flags] can be also added to configure the connection's behavior (see [enum ConnectFlags] constants).
 				A signal can only be connected once to the same [Callable]. If the signal is already connected, this method returns [constant ERR_INVALID_PARAMETER] and pushes an error message, unless the signal is connected with [constant CONNECT_REFERENCE_COUNTED]. To prevent this, use [method is_connected] first to check for existing connections.
-				If the [param callable]'s object is freed, the connection will be lost.
+				The connection will be detatched when [param callable]'s object is freed.
 				[b]Examples with recommended syntax:[/b]
 				Connecting signals is one of the most common operations in Godot and the API gives many options to do so, which are described further down. The code block below shows the recommended approach.
 				[codeblocks]


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
The wording could be clarified, "lost" makes it seem like something bad would happen when you emit and there's a lost connection