### PR TITLE
`TileMap` Fix rendering odd-sized tiles

### DIFF
--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -247,7 +247,7 @@ void TileAtlasView::_draw_base_tiles() {
 			for (int frame = 0; frame < tile_set_atlas_source->get_tile_animation_frames_count(atlas_coords); frame++) {
 				// Update the y to max value.
 				Rect2i base_frame_rect = tile_set_atlas_source->get_tile_texture_region(atlas_coords, frame);
-				Vector2i offset_pos = base_frame_rect.get_center() + tile_set_atlas_source->get_tile_data(atlas_coords, 0)->get_texture_origin();
+				Vector2 offset_pos = Rect2(base_frame_rect).get_center() + Vector2(tile_set_atlas_source->get_tile_data(atlas_coords, 0)->get_texture_origin());
 
 				// Draw the tile.
 				TileMap::draw_tile(base_tiles_draw->get_canvas_item(), offset_pos, tile_set, source_id, atlas_coords, 0, frame);
@@ -331,7 +331,7 @@ void TileAtlasView::_draw_base_tiles_shape_grid() {
 				}
 				Rect2i texture_region = tile_set_atlas_source->get_tile_texture_region(tile_id, frame);
 				Transform2D tile_xform;
-				tile_xform.set_origin(texture_region.get_center() + in_tile_base_offset);
+				tile_xform.set_origin(Rect2(texture_region).get_center() + in_tile_base_offset);
 				tile_xform.set_scale(tile_shape_size);
 				tile_set->draw_tile_shape(base_tiles_shape_grid, tile_xform, color);
 			}

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -854,7 +854,7 @@ void TileMap::_update_dirty_quadrants() {
 			q->self()->local_to_map.clear();
 			for (const Vector2i &E : q->self()->cells) {
 				Vector2i pk = E;
-				Vector2i pk_local_coords = map_to_local(pk);
+				Vector2 pk_local_coords = map_to_local(pk);
 				q->self()->map_to_local[pk] = pk_local_coords;
 				q->self()->local_to_map[pk_local_coords] = pk;
 			}
@@ -1056,7 +1056,7 @@ void TileMap::_rendering_notification(int p_what) {
 					TileMapQuadrant &q = E_quadrant.value;
 
 					// Update occluders transform.
-					for (const KeyValue<Vector2i, Vector2i> &E_cell : q.local_to_map) {
+					for (const KeyValue<Vector2, Vector2i> &E_cell : q.local_to_map) {
 						Transform2D xform;
 						xform.set_origin(E_cell.key);
 						for (const KeyValue<Vector2i, RID> &kv : q.occluders) {
@@ -1214,7 +1214,7 @@ void TileMap::_rendering_update_dirty_quadrants(SelfList<TileMapQuadrant>::List 
 		RID prev_ci;
 
 		// Iterate over the cells of the quadrant.
-		for (const KeyValue<Vector2i, Vector2i> &E_cell : q.local_to_map) {
+		for (const KeyValue<Vector2, Vector2i> &E_cell : q.local_to_map) {
 			TileMapCell c = get_cell(q.layer, E_cell.value, true);
 
 			TileSetSource *source;
@@ -1312,13 +1312,13 @@ void TileMap::_rendering_update_dirty_quadrants(SelfList<TileMapQuadrant>::List 
 
 		for (TileMapLayer &layer : layers) {
 			// Sort the quadrants coords per local coordinates.
-			RBMap<Vector2i, Vector2i, TileMapQuadrant::CoordsWorldComparator> local_to_map;
+			RBMap<Vector2, Vector2i, TileMapQuadrant::CoordsWorldComparator> local_to_map;
 			for (const KeyValue<Vector2i, TileMapQuadrant> &E : layer.quadrant_map) {
 				local_to_map[map_to_local(E.key)] = E.key;
 			}
 
 			// Sort the quadrants.
-			for (const KeyValue<Vector2i, Vector2i> &E : local_to_map) {
+			for (const KeyValue<Vector2, Vector2i> &E : local_to_map) {
 				TileMapQuadrant &q = layer.quadrant_map[E.value];
 				for (const RID &ci : q.canvas_items) {
 					RS::get_singleton()->canvas_item_set_draw_index(ci, index++);
@@ -1400,7 +1400,7 @@ void TileMap::_rendering_draw_quadrant_debug(TileMapQuadrant *p_quadrant) {
 	}
 }
 
-void TileMap::draw_tile(RID p_canvas_item, const Vector2i &p_position, const Ref<TileSet> p_tile_set, int p_atlas_source_id, const Vector2i &p_atlas_coords, int p_alternative_tile, int p_frame, Color p_modulation, const TileData *p_tile_data_override) {
+void TileMap::draw_tile(RID p_canvas_item, const Vector2 &p_position, const Ref<TileSet> p_tile_set, int p_atlas_source_id, const Vector2i &p_atlas_coords, int p_alternative_tile, int p_frame, Color p_modulation, const TileData *p_tile_data_override) {
 	ERR_FAIL_COND(!p_tile_set.is_valid());
 	ERR_FAIL_COND(!p_tile_set->has_source(p_atlas_source_id));
 	ERR_FAIL_COND(!p_tile_set->get_source(p_atlas_source_id)->has_tile(p_atlas_coords));
@@ -1432,7 +1432,7 @@ void TileMap::draw_tile(RID p_canvas_item, const Vector2i &p_position, const Ref
 		Color modulate = tile_data->get_modulate() * p_modulation;
 
 		// Compute the offset.
-		Vector2i tile_offset = tile_data->get_texture_origin();
+		Vector2 tile_offset = tile_data->get_texture_origin();
 
 		// Get destination rect.
 		Rect2 dest_rect;
@@ -3023,7 +3023,7 @@ void TileMap::_build_runtime_update_tile_data(SelfList<TileMapQuadrant>::List &r
 		while (q_list_element) {
 			TileMapQuadrant &q = *q_list_element->self();
 			// Iterate over the cells of the quadrant.
-			for (const KeyValue<Vector2i, Vector2i> &E_cell : q.local_to_map) {
+			for (const KeyValue<Vector2, Vector2i> &E_cell : q.local_to_map) {
 				TileMapCell c = get_cell(q.layer, E_cell.value, true);
 
 				TileSetSource *source;

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -39,7 +39,7 @@ class TileSetAtlasSource;
 
 struct TileMapQuadrant {
 	struct CoordsWorldComparator {
-		_ALWAYS_INLINE_ bool operator()(const Vector2i &p_a, const Vector2i &p_b) const {
+		_ALWAYS_INLINE_ bool operator()(const Vector2 &p_a, const Vector2 &p_b) const {
 			// We sort the cells by their local coords, as it is needed by rendering.
 			if (p_a.y == p_b.y) {
 				return p_a.x > p_b.x;
@@ -60,8 +60,8 @@ struct TileMapQuadrant {
 	RBSet<Vector2i> cells;
 	// We need those two maps to sort by local position for rendering
 	// This is kind of workaround, it would be better to sort the cells directly in the "cells" set instead.
-	RBMap<Vector2i, Vector2i> map_to_local;
-	RBMap<Vector2i, Vector2i, CoordsWorldComparator> local_to_map;
+	RBMap<Vector2i, Vector2> map_to_local;
+	RBMap<Vector2, Vector2i, CoordsWorldComparator> local_to_map;
 
 	// Debug.
 	RID debug_canvas_item;
@@ -311,7 +311,7 @@ public:
 	void set_quadrant_size(int p_size);
 	int get_quadrant_size() const;
 
-	static void draw_tile(RID p_canvas_item, const Vector2i &p_position, const Ref<TileSet> p_tile_set, int p_atlas_source_id, const Vector2i &p_atlas_coords, int p_alternative_tile, int p_frame = -1, Color p_modulation = Color(1.0, 1.0, 1.0, 1.0), const TileData *p_tile_data_override = nullptr);
+	static void draw_tile(RID p_canvas_item, const Vector2 &p_position, const Ref<TileSet> p_tile_set, int p_atlas_source_id, const Vector2i &p_atlas_coords, int p_alternative_tile, int p_frame = -1, Color p_modulation = Color(1.0, 1.0, 1.0, 1.0), const TileData *p_tile_data_override = nullptr);
 
 	// Layers management.
 	int get_layers_count() const;


### PR DESCRIPTION
Each `TileMapQuadrant` was storing local positions within the `map_to_local`/`local_to_map` maps cached for rendering as `Vector2i`s instead of `Vector2`s. This is incorrect, local positions can be non-int. Using float vectors for keys is fine in here, as what's being used for these are the results of `TileMap::map_to_local(cell_map_coords)` calls which are per-cell unique and always the same for each cell.

Cells are rendered relative to the per quadrant CanvasItem(s) (`ci` below; `E_cell.key - tile_position` being the relative position):
https://github.com/godotengine/godot/blob/550a7798510810d238b733a54f69da71b2a2d152/scene/2d/tile_map.cpp#L1284-L1285
and quadrant's own position can also be non-int: it's calculated as the position of its first cell's position (its center and hence can be non-int), possibly offsetted according to the Y-sorting:
https://github.com/godotengine/godot/blob/550a7798510810d238b733a54f69da71b2a2d152/scene/2d/tile_map.cpp#L1241-L1246
Meaning the relative cell-in-quadrant position (`E_cell.key - tile_position`) can be non-int, hence this PR changes `draw_tile` to take in `Vector2` instead of `Vector2i` to avoid truncating such passed relative positions to ints.


On top of the above fixes the in-editor plugin rendering as in some places `Rect2i::get_center()` was used which returns a center truncated to ints (a `Vector2i`) instead of an actual center which is needed. This resulted in another possible misalignment by half unit.

Fixes #62911.
Supersedes #74773. Thanks @Portponky for pointing at the cause

|Before|After|
|-|-|
|![Godot_v4 0-stable_win64_I8ezii2ASO](https://user-images.githubusercontent.com/9283098/224542744-abd87a7d-3e4b-42fb-b220-54d0f0cb7637.png)|![qSVdRHhfFS](https://user-images.githubusercontent.com/9283098/224542752-696fc7b6-f7f3-4a5c-9237-374b174e5fcb.png)|
|![YSxB2iPHX3](https://user-images.githubusercontent.com/9283098/224542793-30944e24-0600-48e1-a951-64b6735357fd.png)|![Qdui5T2PmK](https://user-images.githubusercontent.com/9283098/224542769-cd53d77e-e342-4b35-8767-c3e986adfab8.png)|
|![FMGxXxrnyH](https://user-images.githubusercontent.com/9283098/224542799-26b51913-acd3-4acb-a792-9ab566994595.png)|![mqIVM94mGc](https://user-images.githubusercontent.com/9283098/224542778-edcdf644-c894-4e70-b980-760b0513438b.png)|
|![17T8sbsJBS](https://user-images.githubusercontent.com/9283098/224542292-5d4c47c5-e4ac-449f-9680-67aa03f43641.png)|![godot windows editor dev x86_64_YMsmDOG03M](https://user-images.githubusercontent.com/9283098/224542296-3f9ae01f-1111-4496-b55f-354d9723ea85.png)|

