### PR TITLE
[Windows] Use `GetFileTime` for `FileAccess`

### DIFF
--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -412,15 +412,40 @@ uint64_t FileAccessWindows::_get_modified_time(const String &p_file) {
 		file = file.substr(0, file.length() - 1);
 	}
 
-	struct _stat st;
-	int rv = _wstat((LPCWSTR)(file.utf16().get_data()), &st);
+	HANDLE handle = CreateFileW((LPCWSTR)(file.utf16().get_data()), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
 
-	if (rv == 0) {
-		return st.st_mtime;
-	} else {
-		print_verbose("Failed to get modified time for: " + p_file + "");
-		return 0;
+	if (handle != INVALID_HANDLE_VALUE) {
+		FILETIME ft_create, ft_write;
+
+		bool status = GetFileTime(handle, &ft_create, nullptr, &ft_write);
+
+		CloseHandle(handle);
+
+		if (status) {
+			uint64_t ret = 0;
+
+			// If write time is invalid, fallback to creation time.
+			if (ft_write.dwHighDateTime == 0 && ft_write.dwLowDateTime == 0) {
+				ret = ft_create.dwHighDateTime;
+				ret <<= 32;
+				ret |= ft_create.dwLowDateTime;
+			} else {
+				ret = ft_write.dwHighDateTime;
+				ret <<= 32;
+				ret |= ft_write.dwLowDateTime;
+			}
+
+			const uint64_t WINDOWS_TICKS_PER_SECOND = 10000000;
+			const uint64_t TICKS_TO_UNIX_EPOCH = 116444736000000000LL;
+
+			if (ret >= TICKS_TO_UNIX_EPOCH) {
+				return (ret - TICKS_TO_UNIX_EPOCH) / WINDOWS_TICKS_PER_SECOND;
+			}
+		}
 	}
+
+	print_verbose("Failed to get modified time for: " + p_file);
+	return 0;
 }
 
 BitField<FileAccess::UnixPermissionFlags> FileAccessWindows::_get_unix_permissions(const String &p_file) {


### PR DESCRIPTION
Prevents DST from rearranging file times.

`_wstat` does weird things with DST, which from I can find does not apply to Unix

Internally the same function is used but `_wstat` converts it to local time, without indicating DST, the approach here is based on that in Windows CRT, using creation time as fallback, and here ensuring the epoch is valid.

For all except DST overlap times this gives the same result, in UTC

Edit: Also resolves an inconsistency between MinGW and MSVC builds, see #92911

Fixes #74816
Fixes #92911
Fixes #96810
Fixes #96828
Fixes #96812

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
