### PR TITLE
Improve SplitContainer bar styling: hover/pressed, full bar graphic

### DIFF
--- a/doc/classes/HSplitContainer.xml
+++ b/doc/classes/HSplitContainer.xml
@@ -10,17 +10,41 @@
 		<link title="GUI containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>
 	</tutorials>
 	<theme_items>
-		<theme_item name="autohide" data_type="constant" type="int" default="1">
-			Boolean value. If 1 ([code]true[/code]), the grabber will hide automatically when it isn't under the cursor. If 0 ([code]false[/code]), it's always visible.
+		<theme_item name="bar_thickness" data_type="constant" type="int" default="-1">
+			Splitting line thickness. Set to [code]-1[/code] to automatically fill the separation. If thickness is greater than separation, the splitting line overflows on both sides.
+		</theme_item>
+		<theme_item name="grabber_hidden" data_type="constant" type="int" default="1">
+			If set to a value different than [code]0[/code], hide the grabber icon when not hovered or pressed.
+		</theme_item>
+		<theme_item name="grabber_hidden_hover" data_type="constant" type="int" default="0">
+			If set to a value different than [code]0[/code], hide the grabber icon when hovered.
+		</theme_item>
+		<theme_item name="grabber_hidden_pressed" data_type="constant" type="int" default="0">
+			If set to a value different than [code]0[/code], hide the grabber icon when pressed / dragged.
 		</theme_item>
 		<theme_item name="minimum_grab_thickness" data_type="constant" type="int" default="6">
-			The minimum thickness of the area users can click on to grab the splitting line. If [theme_item separation] or [theme_item grabber]'s thickness are too small, this ensure that the splitting line can still be dragged.
+			The minimum thickness of the area users can click on to grab the splitting line. If [theme_item separation] is low, this ensures the splitting line can still be dragged.
 		</theme_item>
 		<theme_item name="separation" data_type="constant" type="int" default="12">
 			The space between sides of the container.
 		</theme_item>
 		<theme_item name="grabber" data_type="icon" type="Texture2D">
 			The icon used for the grabber drawn in the middle area.
+		</theme_item>
+		<theme_item name="grabber_hover" data_type="icon" type="Texture2D">
+			The icon used for the grabber drawn in the middle area, when the bar is hovered.
+		</theme_item>
+		<theme_item name="grabber_pressed" data_type="icon" type="Texture2D">
+			The icon used for the grabber drawn in the middle area, when the bar is pressed / being dragged.
+		</theme_item>
+		<theme_item name="bar" data_type="style" type="StyleBox">
+			The [StyleBox] used for the splitting line graphic.
+		</theme_item>
+		<theme_item name="bar_hover" data_type="style" type="StyleBox">
+			The [StyleBox] used for the splitting line graphic, when the bar is hovered.
+		</theme_item>
+		<theme_item name="bar_pressed" data_type="style" type="StyleBox">
+			The [StyleBox] used for the splitting line graphic, when the bar is pressed / being dragged.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/SplitContainer.xml
+++ b/doc/classes/SplitContainer.xml
@@ -52,11 +52,20 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="autohide" data_type="constant" type="int" default="1">
-			Boolean value. If 1 ([code]true[/code]), the grabber will hide automatically when it isn't under the cursor. If 0 ([code]false[/code]), it's always visible.
+		<theme_item name="bar_thickness" data_type="constant" type="int" default="-1">
+			Splitting line thickness. Set to [code]-1[/code] to automatically fill the separation. If thickness is greater than separation, the splitting line overflows on both sides.
+		</theme_item>
+		<theme_item name="grabber_hidden" data_type="constant" type="int" default="1">
+			If set to a value different than [code]0[/code], hide the grabber icon when not hovered or pressed.
+		</theme_item>
+		<theme_item name="grabber_hidden_hover" data_type="constant" type="int" default="0">
+			If set to a value different than [code]0[/code], hide the grabber icon when hovered.
+		</theme_item>
+		<theme_item name="grabber_hidden_pressed" data_type="constant" type="int" default="0">
+			If set to a value different than [code]0[/code], hide the grabber icon when pressed / dragged.
 		</theme_item>
 		<theme_item name="minimum_grab_thickness" data_type="constant" type="int" default="6">
-			The minimum thickness of the area users can click on to grab the splitting line. If [theme_item separation] or [theme_item h_grabber] / [theme_item v_grabber]'s thickness are too small, this ensure that the splitting line can still be dragged.
+			The minimum thickness of the area users can click on to grab the splitting line. If [theme_item separation] is low, this ensures the splitting line can still be dragged.
 		</theme_item>
 		<theme_item name="separation" data_type="constant" type="int" default="12">
 			The space between sides of the container.
@@ -64,8 +73,38 @@
 		<theme_item name="h_grabber" data_type="icon" type="Texture2D">
 			The icon used for the grabber drawn in the middle area when [member vertical] is [code]false[/code].
 		</theme_item>
+		<theme_item name="h_grabber_hover" data_type="icon" type="Texture2D">
+			The icon used for the grabber drawn in the middle area when [member vertical] is [code]false[/code] and bar is hovered.
+		</theme_item>
+		<theme_item name="h_grabber_pressed" data_type="icon" type="Texture2D">
+			The icon used for the grabber drawn in the middle area when [member vertical] is [code]false[/code] and bar is being dragged / mouse button is pressed.
+		</theme_item>
 		<theme_item name="v_grabber" data_type="icon" type="Texture2D">
 			The icon used for the grabber drawn in the middle area when [member vertical] is [code]true[/code].
+		</theme_item>
+		<theme_item name="v_grabber_hover" data_type="icon" type="Texture2D">
+			The icon used for the grabber drawn in the middle area when [member vertical] is [code]true[/code] and bar is hovered.
+		</theme_item>
+		<theme_item name="v_grabber_pressed" data_type="icon" type="Texture2D">
+			The icon used for the grabber drawn in the middle area when [member vertical] is [code]true[/code] and bar is being dragged / mouse button is pressed.
+		</theme_item>
+		<theme_item name="h_bar" data_type="style" type="StyleBox">
+			The [StyleBox] used for the splitting line graphic when [member vertical] is [code]false[/code].
+		</theme_item>
+		<theme_item name="h_bar_hover" data_type="style" type="StyleBox">
+			The [StyleBox] used for the splitting line graphic, when [member vertical] is [code]false[/code] and the bar is hovered.
+		</theme_item>
+		<theme_item name="h_bar_pressed" data_type="style" type="StyleBox">
+			The [StyleBox] used for the splitting line graphic, when [member vertical] is [code]false[/code] and the bar is pressed / being dragged.
+		</theme_item>
+		<theme_item name="v_bar" data_type="style" type="StyleBox">
+			The [StyleBox] used for the splitting line graphic when [member vertical] is [code]true[/code].
+		</theme_item>
+		<theme_item name="v_bar_hover" data_type="style" type="StyleBox">
+			The [StyleBox] used for the splitting line graphic, when [member vertical] is [code]true[/code] and the bar is hovered.
+		</theme_item>
+		<theme_item name="v_bar_pressed" data_type="style" type="StyleBox">
+			The [StyleBox] used for the splitting line graphic, when [member vertical] is [code]true[/code] and the bar is pressed / being dragged.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/VSplitContainer.xml
+++ b/doc/classes/VSplitContainer.xml
@@ -10,17 +10,41 @@
 		<link title="GUI containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>
 	</tutorials>
 	<theme_items>
-		<theme_item name="autohide" data_type="constant" type="int" default="1">
-			Boolean value. If 1 ([code]true[/code]), the grabber will hide automatically when it isn't under the cursor. If 0 ([code]false[/code]), it's always visible.
+		<theme_item name="bar_thickness" data_type="constant" type="int" default="-1">
+			Splitting line thickness. Set to -1 to automatically fill the separation. If thickness is greater than separation, the splitting line overflows on both sides.
+		</theme_item>
+		<theme_item name="grabber_hidden" data_type="constant" type="int" default="1">
+			If set to a value different than [code]0[/code], hide the grabber icon when not hovered or pressed.
+		</theme_item>
+		<theme_item name="grabber_hidden_hover" data_type="constant" type="int" default="0">
+			If set to a value different than [code]0[/code], hide the grabber icon when hovered.
+		</theme_item>
+		<theme_item name="grabber_hidden_pressed" data_type="constant" type="int" default="0">
+			If set to a value different than [code]0[/code], hide the grabber icon when pressed / dragged.
 		</theme_item>
 		<theme_item name="minimum_grab_thickness" data_type="constant" type="int" default="6">
-			The minimum thickness of the area users can click on to grab the splitting line. If [theme_item separation] or [theme_item grabber]'s thickness are too small, this ensure that the splitting line can still be dragged.
+			The minimum thickness of the area users can click on to grab the splitting line. If [theme_item separation] is small, this ensure that the splitting line can still be dragged.
 		</theme_item>
 		<theme_item name="separation" data_type="constant" type="int" default="12">
 			The space between sides of the container.
 		</theme_item>
 		<theme_item name="grabber" data_type="icon" type="Texture2D">
 			The icon used for the grabber drawn in the middle area.
+		</theme_item>
+		<theme_item name="grabber_hover" data_type="icon" type="Texture2D">
+			The icon used for the grabber drawn in the middle area, when the bar is hovered.
+		</theme_item>
+		<theme_item name="grabber_pressed" data_type="icon" type="Texture2D">
+			The icon used for the grabber drawn in the middle area, when the bar is pressed / being dragged.
+		</theme_item>
+		<theme_item name="bar" data_type="style" type="StyleBox">
+			The [StyleBox] used for the splitting line graphic.
+		</theme_item>
+		<theme_item name="bar_hover" data_type="style" type="StyleBox">
+			The [StyleBox] used for the splitting line graphic, when the bar is hovered.
+		</theme_item>
+		<theme_item name="bar_pressed" data_type="style" type="StyleBox">
+			The [StyleBox] used for the splitting line graphic, when the bar is pressed / being dragged.
 		</theme_item>
 	</theme_items>
 </class>

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1469,10 +1469,46 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_constant("outline_size", "TextEdit", 0);
 	theme->set_constant("caret_width", "TextEdit", 1);
 
+	// Split containers
+
+	theme->set_constant("grabber_hidden", "SplitContainer", 1);
+	theme->set_constant("grabber_hidden", "HSplitContainer", 1);
+	theme->set_constant("grabber_hidden", "VSplitContainer", 1);
+	theme->set_constant("grabber_hidden_hover", "SplitContainer", 0);
+	theme->set_constant("grabber_hidden_hover", "HSplitContainer", 0);
+	theme->set_constant("grabber_hidden_hover", "VSplitContainer", 0);
+	theme->set_constant("grabber_hidden_pressed", "SplitContainer", 1);
+	theme->set_constant("grabber_hidden_pressed", "HSplitContainer", 1);
+	theme->set_constant("grabber_hidden_pressed", "VSplitContainer", 1);
 	theme->set_icon("h_grabber", "SplitContainer", theme->get_icon(SNAME("GuiHsplitter"), SNAME("EditorIcons")));
 	theme->set_icon("v_grabber", "SplitContainer", theme->get_icon(SNAME("GuiVsplitter"), SNAME("EditorIcons")));
 	theme->set_icon("grabber", "VSplitContainer", theme->get_icon(SNAME("GuiVsplitter"), SNAME("EditorIcons")));
 	theme->set_icon("grabber", "HSplitContainer", theme->get_icon(SNAME("GuiHsplitter"), SNAME("EditorIcons")));
+	theme->set_icon("h_grabber_hover", "SplitContainer", theme->get_icon(SNAME("GuiHsplitter"), SNAME("EditorIcons")));
+	theme->set_icon("v_grabber_hover", "SplitContainer", theme->get_icon(SNAME("GuiVsplitter"), SNAME("EditorIcons")));
+	theme->set_icon("grabber_hover", "VSplitContainer", theme->get_icon(SNAME("GuiVsplitter"), SNAME("EditorIcons")));
+	theme->set_icon("grabber_hover", "HSplitContainer", theme->get_icon(SNAME("GuiHsplitter"), SNAME("EditorIcons")));
+	theme->set_icon("h_grabber_pressed", "SplitContainer", theme->get_icon(SNAME("GuiHsplitter"), SNAME("EditorIcons")));
+	theme->set_icon("v_grabber_pressed", "SplitContainer", theme->get_icon(SNAME("GuiVsplitter"), SNAME("EditorIcons")));
+	theme->set_icon("grabber_pressed", "VSplitContainer", theme->get_icon(SNAME("GuiVsplitter"), SNAME("EditorIcons")));
+	theme->set_icon("grabber_pressed", "HSplitContainer", theme->get_icon(SNAME("GuiHsplitter"), SNAME("EditorIcons")));
+
+	Ref<StyleBoxFlat> style_splitter_bar = make_flat_stylebox(Color(0, 0, 0, 0), 0, 0, 0, 0, 0);
+	Ref<StyleBoxFlat> style_splitter_bar_hover = make_flat_stylebox(highlight_color * Color(1, 1, 1, 0.2), 0, 0, 0, 0, 0);
+	Ref<StyleBoxFlat> style_splitter_bar_pressed = make_flat_stylebox(accent_color, 0, 0, 0, 0, 0);
+
+	theme->set_stylebox("h_bar", "SplitContainer", style_splitter_bar);
+	theme->set_stylebox("v_bar", "SplitContainer", style_splitter_bar);
+	theme->set_stylebox("bar", "HSplitContainer", style_splitter_bar);
+	theme->set_stylebox("bar", "VSplitContainer", style_splitter_bar);
+	theme->set_stylebox("h_bar_hover", "SplitContainer", style_splitter_bar_hover);
+	theme->set_stylebox("v_bar_hover", "SplitContainer", style_splitter_bar_hover);
+	theme->set_stylebox("bar_hover", "HSplitContainer", style_splitter_bar_hover);
+	theme->set_stylebox("bar_hover", "VSplitContainer", style_splitter_bar_hover);
+	theme->set_stylebox("h_bar_pressed", "SplitContainer", style_splitter_bar_pressed);
+	theme->set_stylebox("v_bar_pressed", "SplitContainer", style_splitter_bar_pressed);
+	theme->set_stylebox("bar_pressed", "HSplitContainer", style_splitter_bar_pressed);
+	theme->set_stylebox("bar_pressed", "VSplitContainer", style_splitter_bar_pressed);
 
 	theme->set_constant("separation", "SplitContainer", default_margin_size * 2 * EDSCALE);
 	theme->set_constant("separation", "HSplitContainer", default_margin_size * 2 * EDSCALE);
@@ -1481,6 +1517,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_constant("minimum_grab_thickness", "SplitContainer", 6 * EDSCALE);
 	theme->set_constant("minimum_grab_thickness", "HSplitContainer", 6 * EDSCALE);
 	theme->set_constant("minimum_grab_thickness", "VSplitContainer", 6 * EDSCALE);
+
+	theme->set_constant("bar_thickness", "SplitContainer", 2 * EDSCALE);
+	theme->set_constant("bar_thickness", "HSplitContainer", 2 * EDSCALE);
+	theme->set_constant("bar_thickness", "VSplitContainer", 2 * EDSCALE);
 
 	// Containers
 	theme->set_constant("separation", "BoxContainer", default_margin_size * EDSCALE);

--- a/scene/gui/split_container.h
+++ b/scene/gui/split_container.h
@@ -73,15 +73,38 @@ private:
 	struct ThemeCache {
 		int separation = 0;
 		int minimum_grab_thickness = 0;
-		int autohide = 0;
+		int bar_thickness = 0;
+		int grabber_hidden = 0;
+		int grabber_hidden_hover = 0;
+		int grabber_hidden_pressed = 0;
 		Ref<Texture2D> grabber_icon;
 		Ref<Texture2D> grabber_icon_h;
 		Ref<Texture2D> grabber_icon_v;
+		Ref<Texture2D> grabber_hover_icon;
+		Ref<Texture2D> grabber_hover_icon_h;
+		Ref<Texture2D> grabber_hover_icon_v;
+		Ref<Texture2D> grabber_pressed_icon;
+		Ref<Texture2D> grabber_pressed_icon_h;
+		Ref<Texture2D> grabber_pressed_icon_v;
+		Ref<StyleBox> bar_style;
+		Ref<StyleBox> bar_style_h;
+		Ref<StyleBox> bar_style_v;
+		Ref<StyleBox> bar_hover_style;
+		Ref<StyleBox> bar_hover_style_h;
+		Ref<StyleBox> bar_hover_style_v;
+		Ref<StyleBox> bar_pressed_style;
+		Ref<StyleBox> bar_pressed_style_h;
+		Ref<StyleBox> bar_pressed_style_v;
 	} theme_cache;
 
 	Control *_getch(int p_idx) const;
 
 	Ref<Texture2D> _get_grabber_icon() const;
+	Ref<Texture2D> _get_grabber_icon_hover() const;
+	Ref<Texture2D> _get_grabber_icon_pressed() const;
+	Ref<StyleBox> _get_bar_stylebox() const;
+	Ref<StyleBox> _get_bar_stylebox_hover() const;
+	Ref<StyleBox> _get_bar_stylebox_pressed() const;
 	void _compute_middle_sep(bool p_clamp);
 	void _resort();
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -1060,10 +1060,39 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	// Containers
 
+	// Split containers
 	theme->set_icon("h_grabber", "SplitContainer", icons["hsplitter"]);
 	theme->set_icon("v_grabber", "SplitContainer", icons["vsplitter"]);
 	theme->set_icon("grabber", "VSplitContainer", icons["vsplitter"]);
 	theme->set_icon("grabber", "HSplitContainer", icons["hsplitter"]);
+	theme->set_icon("h_grabber_hover", "SplitContainer", icons["hsplitter"]);
+	theme->set_icon("v_grabber_hover", "SplitContainer", icons["vsplitter"]);
+	theme->set_icon("grabber_hover", "VSplitContainer", icons["vsplitter"]);
+	theme->set_icon("grabber_hover", "HSplitContainer", icons["hsplitter"]);
+	theme->set_icon("h_grabber_pressed", "SplitContainer", icons["hsplitter"]);
+	theme->set_icon("v_grabber_pressed", "SplitContainer", icons["vsplitter"]);
+	theme->set_icon("grabber_pressed", "VSplitContainer", icons["vsplitter"]);
+	theme->set_icon("grabber_pressed", "HSplitContainer", icons["hsplitter"]);
+
+	Ref<StyleBoxFlat> style_splitter_bar = make_flat_stylebox(Color(0, 0, 0, 0.1), 0, 0, 0, 0, 0);
+	Ref<StyleBoxFlat> style_splitter_bar_hover = make_flat_stylebox(style_hover_color, 0, 0, 0, 0, 0);
+	Ref<StyleBoxFlat> style_splitter_bar_pressed = make_flat_stylebox(style_focus_color, 0, 0, 0, 0, 0);
+
+	theme->set_stylebox("h_bar", "SplitContainer", style_splitter_bar);
+	theme->set_stylebox("v_bar", "SplitContainer", style_splitter_bar);
+	theme->set_stylebox("bar", "HSplitContainer", style_splitter_bar);
+	theme->set_stylebox("bar", "VSplitContainer", style_splitter_bar);
+	theme->set_stylebox("h_bar_hover", "SplitContainer", style_splitter_bar_hover);
+	theme->set_stylebox("v_bar_hover", "SplitContainer", style_splitter_bar_hover);
+	theme->set_stylebox("bar_hover", "HSplitContainer", style_splitter_bar_hover);
+	theme->set_stylebox("bar_hover", "VSplitContainer", style_splitter_bar_hover);
+	theme->set_stylebox("h_bar_pressed", "SplitContainer", style_splitter_bar_pressed);
+	theme->set_stylebox("v_bar_pressed", "SplitContainer", style_splitter_bar_pressed);
+	theme->set_stylebox("bar_pressed", "HSplitContainer", style_splitter_bar_pressed);
+	theme->set_stylebox("bar_pressed", "VSplitContainer", style_splitter_bar_pressed);
+	theme->set_constant("bar_thickness", "SplitContainer", -1);
+	theme->set_constant("bar_thickness", "HSplitContainer", -1);
+	theme->set_constant("bar_thickness", "VSplitContainer", -1);
 
 	theme->set_constant("separation", "BoxContainer", 4 * scale);
 	theme->set_constant("separation", "HBoxContainer", 4 * scale);
@@ -1080,9 +1109,15 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("minimum_grab_thickness", "SplitContainer", 6 * scale);
 	theme->set_constant("minimum_grab_thickness", "HSplitContainer", 6 * scale);
 	theme->set_constant("minimum_grab_thickness", "VSplitContainer", 6 * scale);
-	theme->set_constant("autohide", "SplitContainer", 1);
-	theme->set_constant("autohide", "HSplitContainer", 1);
-	theme->set_constant("autohide", "VSplitContainer", 1);
+	theme->set_constant("grabber_hidden", "SplitContainer", 1);
+	theme->set_constant("grabber_hidden", "HSplitContainer", 1);
+	theme->set_constant("grabber_hidden", "VSplitContainer", 1);
+	theme->set_constant("grabber_hidden_hover", "SplitContainer", 0);
+	theme->set_constant("grabber_hidden_hover", "HSplitContainer", 0);
+	theme->set_constant("grabber_hidden_hover", "VSplitContainer", 0);
+	theme->set_constant("grabber_hidden_pressed", "SplitContainer", 0);
+	theme->set_constant("grabber_hidden_pressed", "HSplitContainer", 0);
+	theme->set_constant("grabber_hidden_pressed", "VSplitContainer", 0);
 	theme->set_constant("h_separation", "FlowContainer", 4 * scale);
 	theme->set_constant("v_separation", "FlowContainer", 4 * scale);
 	theme->set_constant("h_separation", "HFlowContainer", 4 * scale);


### PR DESCRIPTION
Improvement of the HSplitContainer and VSplitContainer styling possibilities!

This adds a StyleBox to render the full bar with a configurable style available in normal, hover and pressed (being dragged) styles. Support for hover and pressed states is also added to the grabber icon.

As the separation parameter is now governing the splitter bar width, the minimum thickness enforcement based on the grabber image size is removed. This opens up new ways of styling the splitter where the grabber icon can be wider than the bar itself and overlap on the sides.

A new parameter is added to choose the thickness of the rendered bar background, independently from the separation. If left to -1, the bar background thickness is automatically adjusted to the separation i.e. the apparent space between the two panels.

By combining these parameters, it is possible to render
- a splitter bar that thickens on hover or drag start
- a splitter without apparent separation (both panels next to each other without any pixels in between) on which the bar appears on hover or drag start

Default and editor themes are adjusted to use the new possibilities.

Proposal being written, visual examples coming soon

Backporting to 3.5: theoretically possible, but relies on the presence of other SplitContainer improvements, such as the "virtual" minimum grabber width, and needs to be adjusted to the 3.5 themes

*Bugsquad edit:* Close https://github.com/godotengine/godot-proposals/issues/6496