### PR TITLE
GDScript: Fix missing warning for shadowing of built-in types

### DIFF
--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -131,7 +131,7 @@ class GDScriptAnalyzer {
 	Ref<GDScriptParserRef> get_parser_for(const String &p_path);
 	void reduce_identifier_from_base_set_class(GDScriptParser::IdentifierNode *p_identifier, GDScriptParser::DataType p_identifier_datatype);
 #ifdef DEBUG_ENABLED
-	bool is_shadowing(GDScriptParser::IdentifierNode *p_local, const String &p_context);
+	void is_shadowing(GDScriptParser::IdentifierNode *p_local, const String &p_context);
 #endif
 
 public:

--- a/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.gd
@@ -1,0 +1,12 @@
+var member: int = 0
+
+@warning_ignore("unused_variable")
+func test():
+	var Array := 'Array'
+	var Node := 'Node'
+	var is_same := 'is_same'
+	var sqrt := 'sqrt'
+	var member := 'member'
+	var reference := 'reference'
+
+	print('warn')

--- a/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.out
@@ -1,0 +1,26 @@
+GDTEST_OK
+>> WARNING
+>> Line: 5
+>> SHADOWED_GLOBAL_IDENTIFIER
+>> The variable 'Array' has the same name as a built-in type.
+>> WARNING
+>> Line: 6
+>> SHADOWED_GLOBAL_IDENTIFIER
+>> The variable 'Node' has the same name as a global class.
+>> WARNING
+>> Line: 7
+>> SHADOWED_GLOBAL_IDENTIFIER
+>> The variable 'is_same' has the same name as a built-in function.
+>> WARNING
+>> Line: 8
+>> SHADOWED_GLOBAL_IDENTIFIER
+>> The variable 'sqrt' has the same name as a built-in function.
+>> WARNING
+>> Line: 9
+>> SHADOWED_VARIABLE
+>> The local variable "member" is shadowing an already-declared variable at line 1.
+>> WARNING
+>> Line: 10
+>> SHADOWED_VARIABLE_BASE_CLASS
+>> The local variable "reference" is shadowing an already-declared method at the base class "RefCounted".
+warn


### PR DESCRIPTION
```gdscript
func _ready():
  var Array := 3 # before: ok, after: warning
```

Extracted from #74618.