### PR TITLE
Add a get_system_info method to XRInterface

### DIFF
--- a/doc/classes/XRInterface.xml
+++ b/doc/classes/XRInterface.xml
@@ -57,6 +57,13 @@
 				Returns the an array of supported environment blend modes, see [enum XRInterface.EnvironmentBlendMode].
 			</description>
 		</method>
+		<method name="get_system_info">
+			<return type="Dictionary" />
+			<description>
+				Returns a [Dictionary] with extra system info. Interfaces are expected to return [code]XRRuntimeName[/code] and [code]XRRuntimeVersion[/code] providing info about the used XR runtime. Additional entries may be provided specific to an interface.
+				[b]Note:[/b]This information may only be available after [method initialize] was successfully called.
+			</description>
+		</method>
 		<method name="get_tracking_status" qualifiers="const">
 			<return type="int" enum="XRInterface.TrackingStatus" />
 			<description>

--- a/doc/classes/XRInterfaceExtension.xml
+++ b/doc/classes/XRInterfaceExtension.xml
@@ -98,6 +98,12 @@
 				Returns a [PackedStringArray] with tracker names configured by this interface. Note that user configuration can override this list.
 			</description>
 		</method>
+		<method name="_get_system_info" qualifiers="virtual const">
+			<return type="Dictionary" />
+			<description>
+				Returns a [Dictionary] with system informationr elated to this interface.
+			</description>
+		</method>
 		<method name="_get_tracking_status" qualifiers="virtual const">
 			<return type="int" enum="XRInterface.TrackingStatus" />
 			<description>

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -372,6 +372,15 @@ void MobileVRInterface::uninitialize() {
 	};
 };
 
+Dictionary MobileVRInterface::get_system_info() {
+	Dictionary dict;
+
+	dict[SNAME("XRRuntimeName")] = String("Godot mobile VR interface");
+	dict[SNAME("XRRuntimeVersion")] = String("");
+
+	return dict;
+}
+
 bool MobileVRInterface::supports_play_area_mode(XRInterface::PlayAreaMode p_mode) {
 	// This interface has no positional tracking so fix this to 3DOF
 	return p_mode == XR_PLAY_AREA_3DOF;

--- a/modules/mobile_vr/mobile_vr_interface.h
+++ b/modules/mobile_vr/mobile_vr_interface.h
@@ -141,6 +141,7 @@ public:
 	virtual bool is_initialized() const override;
 	virtual bool initialize() override;
 	virtual void uninitialize() override;
+	virtual Dictionary get_system_info() override;
 
 	virtual bool supports_play_area_mode(XRInterface::PlayAreaMode p_mode) override;
 	virtual XRInterface::PlayAreaMode get_play_area_mode() const override;

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -385,8 +385,13 @@ bool OpenXRAPI::create_instance() {
 	if (XR_FAILED(result)) {
 		// not fatal probably
 		print_line("OpenXR: Failed to get XR instance properties [", get_error_string(result), "]");
+
+		runtime_name = "";
+		runtime_version = "";
 	} else {
-		print_line("OpenXR: Running on OpenXR runtime: ", instanceProps.runtimeName, " ", OpenXRUtil::make_xr_version_string(instanceProps.runtimeVersion));
+		runtime_name = instanceProps.runtimeName;
+		runtime_version = OpenXRUtil::make_xr_version_string(instanceProps.runtimeVersion);
+		print_line("OpenXR: Running on OpenXR runtime: ", runtime_name, " ", runtime_version);
 	}
 
 	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -95,6 +95,10 @@ private:
 	uint32_t num_swapchain_formats = 0;
 	int64_t *supported_swapchain_formats = nullptr;
 
+	// system info
+	String runtime_name;
+	String runtime_version;
+
 	// configuration
 	XrFormFactor form_factor = XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY;
 	XrViewConfigurationType view_configuration = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
@@ -294,6 +298,8 @@ public:
 	XrInstance get_instance() const { return instance; };
 	XrSystemId get_system_id() const { return system_id; };
 	XrSession get_session() const { return session; };
+	String get_runtime_name() const { return runtime_name; };
+	String get_runtime_version() const { return runtime_version; };
 
 	// helper method to convert an XrPosef to a Transform3D
 	Transform3D transform_from_pose(const XrPosef &p_pose);

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -583,6 +583,17 @@ void OpenXRInterface::uninitialize() {
 	initialized = false;
 }
 
+Dictionary OpenXRInterface::get_system_info() {
+	Dictionary dict;
+
+	if (openxr_api) {
+		dict[SNAME("XRRuntimeName")] = openxr_api->get_runtime_name();
+		dict[SNAME("XRRuntimeVersion")] = openxr_api->get_runtime_version();
+	}
+
+	return dict;
+}
+
 bool OpenXRInterface::supports_play_area_mode(XRInterface::PlayAreaMode p_mode) {
 	return false;
 }

--- a/modules/openxr/openxr_interface.h
+++ b/modules/openxr/openxr_interface.h
@@ -112,6 +112,7 @@ public:
 	virtual bool is_initialized() const override;
 	virtual bool initialize() override;
 	virtual void uninitialize() override;
+	virtual Dictionary get_system_info() override;
 
 	virtual void trigger_haptic_pulse(const String &p_action_name, const StringName &p_tracker_name, double p_frequency, double p_amplitude, double p_duration_sec, double p_delay_sec = 0) override;
 

--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -301,6 +301,16 @@ void WebXRInterfaceJS::uninitialize() {
 	};
 };
 
+Dictionary WebXRInterfaceJS::get_system_info() {
+	Dictionary dict;
+
+	// TODO get actual information from WebXR to return here
+	dict[SNAME("XRRuntimeName")] = String("WebXR");
+	dict[SNAME("XRRuntimeVersion")] = String("");
+
+	return dict;
+}
+
 Transform3D WebXRInterfaceJS::_js_matrix_to_transform(float *p_js_matrix) {
 	Transform3D transform;
 

--- a/modules/webxr/webxr_interface_js.h
+++ b/modules/webxr/webxr_interface_js.h
@@ -108,6 +108,7 @@ public:
 	virtual bool is_initialized() const override;
 	virtual bool initialize() override;
 	virtual void uninitialize() override;
+	virtual Dictionary get_system_info() override;
 
 	virtual Size2 get_render_target_size() override;
 	virtual uint32_t get_view_count() override;

--- a/servers/xr/xr_interface.cpp
+++ b/servers/xr/xr_interface.cpp
@@ -43,6 +43,7 @@ void XRInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_initialized"), &XRInterface::is_initialized);
 	ClassDB::bind_method(D_METHOD("initialize"), &XRInterface::initialize);
 	ClassDB::bind_method(D_METHOD("uninitialize"), &XRInterface::uninitialize);
+	ClassDB::bind_method(D_METHOD("get_system_info"), &XRInterface::get_system_info);
 
 	ClassDB::bind_method(D_METHOD("get_tracking_status"), &XRInterface::get_tracking_status);
 

--- a/servers/xr/xr_interface.h
+++ b/servers/xr/xr_interface.h
@@ -100,6 +100,7 @@ public:
 	virtual bool is_initialized() const = 0; /* returns true if we've initialized this interface */
 	virtual bool initialize() = 0; /* initialize this interface, if this has an HMD it becomes the primary interface */
 	virtual void uninitialize() = 0; /* deinitialize this interface */
+	virtual Dictionary get_system_info() = 0; /* return a dictionary with info about our system */
 
 	/** input and output **/
 

--- a/servers/xr/xr_interface_extension.cpp
+++ b/servers/xr/xr_interface_extension.cpp
@@ -39,6 +39,7 @@ void XRInterfaceExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_is_initialized);
 	GDVIRTUAL_BIND(_initialize);
 	GDVIRTUAL_BIND(_uninitialize);
+	GDVIRTUAL_BIND(_get_system_info);
 
 	GDVIRTUAL_BIND(_supports_play_area_mode, "mode");
 	GDVIRTUAL_BIND(_get_play_area_mode);
@@ -117,6 +118,12 @@ bool XRInterfaceExtension::initialize() {
 
 void XRInterfaceExtension::uninitialize() {
 	GDVIRTUAL_CALL(_uninitialize);
+}
+
+Dictionary XRInterfaceExtension::get_system_info() {
+	Dictionary dict;
+	GDVIRTUAL_CALL(_get_system_info, dict);
+	return dict;
 }
 
 PackedStringArray XRInterfaceExtension::get_suggested_tracker_names() const {

--- a/servers/xr/xr_interface_extension.h
+++ b/servers/xr/xr_interface_extension.h
@@ -57,10 +57,12 @@ public:
 	virtual bool is_initialized() const override;
 	virtual bool initialize() override;
 	virtual void uninitialize() override;
+	virtual Dictionary get_system_info() override;
 
 	GDVIRTUAL0RC(bool, _is_initialized);
 	GDVIRTUAL0R(bool, _initialize);
 	GDVIRTUAL0(_uninitialize);
+	GDVIRTUAL0RC(Dictionary, _get_system_info);
 
 	/** input and output **/
 


### PR DESCRIPTION
XR runtimes such as OpenXR and webXR work on multiple platforms. We already gather information about this in OpenXR, we had a request to make this available to the developer which makes sense.

Decided to add a method to the `XRInterface` base class that can be implemented on each Interface and returns this interface. We're returning it as a dictionary so we can easily extend it with interface specific entries.
