### PR TITLE
Fix `InputEventConfigurationDialog` modifies original event

### DIFF
--- a/editor/input_event_configuration_dialog.cpp
+++ b/editor/input_event_configuration_dialog.cpp
@@ -547,7 +547,7 @@ void InputEventConfigurationDialog::_notification(int p_what) {
 
 void InputEventConfigurationDialog::popup_and_configure(const Ref<InputEvent> &p_event) {
 	if (p_event.is_valid()) {
-		_set_event(p_event, p_event->duplicate());
+		_set_event(p_event->duplicate(), p_event);
 	} else {
 		// Clear Event
 		_set_event(Ref<InputEvent>(), Ref<InputEvent>());


### PR DESCRIPTION
The bug is due to swapped arguments.

https://github.com/godotengine/godot/blob/550a7798510810d238b733a54f69da71b2a2d152/editor/input_event_configuration_dialog.h#L102

https://github.com/godotengine/godot/blob/550a7798510810d238b733a54f69da71b2a2d152/editor/input_event_configuration_dialog.cpp#L550

Closes #74389.