### PR TITLE
Improve Vector2 / 3 / 4 normalized() classref.

### DIFF
--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -288,6 +288,7 @@
 			<return type="Vector2" />
 			<description>
 				Returns the result of scaling the vector to unit length. Equivalent to [code]v / v.length()[/code]. See also [method is_normalized].
+				[b]Note:[/b] This function may return incorrect values if the initial vector length is near zero.
 			</description>
 		</method>
 		<method name="orthogonal" qualifiers="const">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -256,6 +256,7 @@
 			<return type="Vector3" />
 			<description>
 				Returns the result of scaling the vector to unit length. Equivalent to [code]v / v.length()[/code]. See also [method is_normalized].
+				[b]Note:[/b] This function may return incorrect values if the input vector length is near zero.
 			</description>
 		</method>
 		<method name="octahedron_decode" qualifiers="static">

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -191,6 +191,7 @@
 			<return type="Vector4" />
 			<description>
 				Returns the result of scaling the vector to unit length. Equivalent to [code]v / v.length()[/code]. See also [method is_normalized].
+				[b]Note:[/b] This function may return incorrect values if the input vector length is near zero.
 			</description>
 		</method>
 		<method name="posmod" qualifiers="const">


### PR DESCRIPTION
Mention that the results will be unreliable with initial vector near zero.

Helps address #74852

## Notes
* The alternative is to add an epsilon to `normalized()`, and e.g. return zero in these cases and note this in classref.

Doing the above would technically be borderline compat breaking, although we may get away with it (you could argue that values that low were giving spurious results anyway). `normalized()` isn't an ideal function to be using on input that could be near zero, because of the difficulty involved in detecting failure ( see https://github.com/godotengine/godot/issues/74852#issuecomment-1465709454 )

We probably just have to pick our poison with this, we can do another PR with an epsilon for `normalized()`.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
