### PR TITLE
[3.x] Add `set_value_no_signal()` to Range

### DIFF
--- a/doc/classes/Range.xml
+++ b/doc/classes/Range.xml
@@ -9,6 +9,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="set_value_no_signal">
+			<return type="void" />
+			<argument index="0" name="value" type="float" />
+			<description>
+				Sets the [Range]'s current value to the specified [member value], without emitting the [signal value_changed] signal.
+			</description>
+		</method>
 		<method name="share">
 			<return type="void" />
 			<argument index="0" name="with" type="Node" />
@@ -52,7 +59,7 @@
 			If greater than 0, [code]value[/code] will always be rounded to a multiple of [code]step[/code]. If [code]rounded[/code] is also [code]true[/code], [code]value[/code] will first be rounded to a multiple of [code]step[/code] then rounded to the nearest integer.
 		</member>
 		<member name="value" type="float" setter="set_value" getter="get_value" default="0.0">
-			Range's current value.
+			Range's current value. Changing this property (even via code) will trigger [signal value_changed] signal. Use [method set_value_no_signal] if you want to avoid it.
 		</member>
 	</members>
 	<signals>

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -211,14 +211,13 @@ bool BaseButton::is_disabled() const {
 }
 
 void BaseButton::set_pressed(bool p_pressed) {
-	if (!toggle_mode) {
-		return;
-	}
-	if (status.pressed == p_pressed) {
+	bool prev_pressed = status.pressed;
+	set_pressed_no_signal(p_pressed);
+
+	if (status.pressed == prev_pressed) {
 		return;
 	}
 	_change_notify("pressed");
-	status.pressed = p_pressed;
 
 	if (p_pressed) {
 		_unpress_group();

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -77,6 +77,15 @@ void Range::Shared::emit_changed(const char *p_what) {
 }
 
 void Range::set_value(double p_val) {
+	double prev_val = shared->val;
+	set_value_no_signal(p_val);
+
+	if (shared->val != prev_val) {
+		shared->emit_value_changed();
+	}
+}
+
+void Range::set_value_no_signal(double p_val) {
 	if (shared->step > 0) {
 		p_val = Math::round((p_val - shared->min) / shared->step) * shared->step + shared->min;
 	}
@@ -98,8 +107,6 @@ void Range::set_value(double p_val) {
 	}
 
 	shared->val = p_val;
-
-	shared->emit_value_changed();
 }
 void Range::set_min(double p_min) {
 	shared->min = p_min;
@@ -237,6 +244,7 @@ void Range::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_page"), &Range::get_page);
 	ClassDB::bind_method(D_METHOD("get_as_ratio"), &Range::get_as_ratio);
 	ClassDB::bind_method(D_METHOD("set_value", "value"), &Range::set_value);
+	ClassDB::bind_method(D_METHOD("set_value_no_signal", "value"), &Range::set_value_no_signal);
 	ClassDB::bind_method(D_METHOD("set_min", "minimum"), &Range::set_min);
 	ClassDB::bind_method(D_METHOD("set_max", "maximum"), &Range::set_max);
 	ClassDB::bind_method(D_METHOD("set_step", "step"), &Range::set_step);

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -66,6 +66,7 @@ protected:
 
 public:
 	void set_value(double p_val);
+	void set_value_no_signal(double p_val);
 	void set_min(double p_min);
 	void set_max(double p_max);
 	void set_step(double p_step);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Backport of https://github.com/godotengine/godot/pull/68097 for the `3.x` branch.