### PR TITLE
Fix `draw_multiline_colors()` for `width < 0`

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -257,6 +257,16 @@
 				See also [method CanvasItem.draw_msdf_texture_rect_region].
 			</description>
 		</method>
+		<method name="canvas_item_add_multiline">
+			<return type="void" />
+			<param index="0" name="item" type="RID" />
+			<param index="1" name="points" type="PackedVector2Array" />
+			<param index="2" name="colors" type="PackedColorArray" />
+			<param index="3" name="width" type="float" default="-1.0" />
+			<description>
+				Draws a 2D multiline on the [CanvasItem] pointed to by the [param item] [RID]. See also [method CanvasItem.draw_multiline] and [method CanvasItem.draw_multiline_colors].
+			</description>
+		</method>
 		<method name="canvas_item_add_multimesh">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
@@ -310,7 +320,7 @@
 			<param index="3" name="width" type="float" default="-1.0" />
 			<param index="4" name="antialiased" type="bool" default="false" />
 			<description>
-				Draws a 2D polyline on the [CanvasItem] pointed to by the [param item] [RID]. See also [method CanvasItem.draw_polyline].
+				Draws a 2D polyline on the [CanvasItem] pointed to by the [param item] [RID]. See also [method CanvasItem.draw_polyline] and [method CanvasItem.draw_polyline_colors].
 			</description>
 		</method>
 		<method name="canvas_item_add_primitive">

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -555,8 +555,7 @@ void CanvasItem::draw_line(const Point2 &p_from, const Point2 &p_to, const Color
 void CanvasItem::draw_polyline(const Vector<Point2> &p_points, const Color &p_color, real_t p_width, bool p_antialiased) {
 	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
-	Vector<Color> colors;
-	colors.push_back(p_color);
+	Vector<Color> colors = { p_color };
 	RenderingServer::get_singleton()->canvas_item_add_polyline(canvas_item, p_points, colors, p_width, p_antialiased);
 }
 
@@ -584,8 +583,7 @@ void CanvasItem::draw_arc(const Vector2 &p_center, real_t p_radius, real_t p_sta
 void CanvasItem::draw_multiline(const Vector<Point2> &p_points, const Color &p_color, real_t p_width) {
 	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
-	Vector<Color> colors;
-	colors.push_back(p_color);
+	Vector<Color> colors = { p_color };
 	RenderingServer::get_singleton()->canvas_item_add_multiline(canvas_item, p_points, colors, p_width);
 }
 
@@ -713,8 +711,7 @@ void CanvasItem::draw_polygon(const Vector<Point2> &p_points, const Vector<Color
 void CanvasItem::draw_colored_polygon(const Vector<Point2> &p_points, const Color &p_color, const Vector<Point2> &p_uvs, Ref<Texture2D> p_texture) {
 	ERR_FAIL_COND_MSG(!drawing, "Drawing is only allowed inside NOTIFICATION_DRAW, _draw() function or 'draw' signal.");
 
-	Vector<Color> colors;
-	colors.push_back(p_color);
+	Vector<Color> colors = { p_color };
 	RID rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
 	RenderingServer::get_singleton()->canvas_item_add_polygon(canvas_item, p_points, colors, p_uvs, rid);
 }

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -1177,17 +1177,31 @@ void RendererCanvasCull::canvas_item_add_polyline(RID p_item, const Vector<Point
 }
 
 void RendererCanvasCull::canvas_item_add_multiline(RID p_item, const Vector<Point2> &p_points, const Vector<Color> &p_colors, float p_width) {
-	ERR_FAIL_COND(p_points.size() < 2);
+	ERR_FAIL_COND(p_points.is_empty() || p_points.size() % 2 != 0);
+	ERR_FAIL_COND(p_colors.size() != 1 && p_colors.size() * 2 != p_points.size());
 
 	// TODO: `canvas_item_add_line`(`multiline`, `polyline`) share logic, should factor out.
 	if (p_width < 0) {
 		Item *canvas_item = canvas_item_owner.get_or_null(p_item);
 		ERR_FAIL_COND(!canvas_item);
 
+		Vector<Color> colors;
+		if (p_colors.size() == 1) {
+			colors = p_colors;
+		} else { //} else if (p_colors.size() << 1 == p_points.size()) {
+			colors.resize(p_points.size());
+			Color *colors_ptr = colors.ptrw();
+			for (int i = 0; i < p_colors.size(); i++) {
+				Color color = p_colors[i];
+				colors_ptr[i * 2 + 0] = color;
+				colors_ptr[i * 2 + 1] = color;
+			}
+		}
+
 		Item::CommandPolygon *pline = canvas_item->alloc_command<Item::CommandPolygon>();
 		ERR_FAIL_COND(!pline);
 		pline->primitive = RS::PRIMITIVE_LINES;
-		pline->polygon.create(Vector<int>(), p_points, p_colors);
+		pline->polygon.create(Vector<int>(), p_points, colors);
 	} else {
 		if (p_colors.size() == 1) {
 			Color color = p_colors[0];
@@ -1197,16 +1211,14 @@ void RendererCanvasCull::canvas_item_add_multiline(RID p_item, const Vector<Poin
 
 				canvas_item_add_line(p_item, from, to, color, p_width);
 			}
-		} else if (p_colors.size() == p_points.size() >> 1) {
-			for (int i = 0; i < p_points.size() >> 1; i++) {
+		} else { //} else if (p_colors.size() << 1 == p_points.size()) {
+			for (int i = 0; i < p_colors.size(); i++) {
 				Color color = p_colors[i];
 				Vector2 from = p_points[i * 2 + 0];
 				Vector2 to = p_points[i * 2 + 1];
 
 				canvas_item_add_line(p_item, from, to, color, p_width);
 			}
-		} else {
-			ERR_FAIL_MSG("Length of p_colors is invalid.");
 		}
 	}
 }

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2602,6 +2602,7 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("canvas_item_add_line", "item", "from", "to", "color", "width", "antialiased"), &RenderingServer::canvas_item_add_line, DEFVAL(-1.0), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("canvas_item_add_polyline", "item", "points", "colors", "width", "antialiased"), &RenderingServer::canvas_item_add_polyline, DEFVAL(-1.0), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("canvas_item_add_multiline", "item", "points", "colors", "width"), &RenderingServer::canvas_item_add_multiline, DEFVAL(-1.0));
 	ClassDB::bind_method(D_METHOD("canvas_item_add_rect", "item", "rect", "color"), &RenderingServer::canvas_item_add_rect);
 	ClassDB::bind_method(D_METHOD("canvas_item_add_circle", "item", "pos", "radius", "color"), &RenderingServer::canvas_item_add_circle);
 	ClassDB::bind_method(D_METHOD("canvas_item_add_texture_rect", "item", "rect", "texture", "tile", "modulate", "transpose"), &RenderingServer::canvas_item_add_texture_rect, DEFVAL(false), DEFVAL(Color(1, 1, 1)), DEFVAL(false));


### PR DESCRIPTION
* Fix `draw_multiline_colors()` always draws white lines when `width < 0`.
* Expose `canvas_item_add_multiline()` for consistency.
* And a couple of other minor fixes.