### PR TITLE
Change to_utf8 to to_utf8_buffer in remaining docs

### DIFF
--- a/doc/classes/AESContext.xml
+++ b/doc/classes/AESContext.xml
@@ -15,27 +15,27 @@
 		    var key = "My secret key!!!" # Key must be either 16 or 32 bytes.
 		    var data = "My secret text!!" # Data size must be multiple of 16 bytes, apply padding if needed.
 		    # Encrypt ECB
-		    aes.start(AESContext.MODE_ECB_ENCRYPT, key.to_utf8())
-		    var encrypted = aes.update(data.to_utf8())
+		    aes.start(AESContext.MODE_ECB_ENCRYPT, key.to_utf8_buffer())
+		    var encrypted = aes.update(data.to_utf8_buffer())
 		    aes.finish()
 		    # Decrypt ECB
-		    aes.start(AESContext.MODE_ECB_DECRYPT, key.to_utf8())
+		    aes.start(AESContext.MODE_ECB_DECRYPT, key.to_utf8_buffer())
 		    var decrypted = aes.update(encrypted)
 		    aes.finish()
 		    # Check ECB
-		    assert(decrypted == data.to_utf8())
+		    assert(decrypted == data.to_utf8_buffer())
 
 		    var iv = "My secret iv!!!!" # IV must be of exactly 16 bytes.
 		    # Encrypt CBC
-		    aes.start(AESContext.MODE_CBC_ENCRYPT, key.to_utf8(), iv.to_utf8())
-		    encrypted = aes.update(data.to_utf8())
+		    aes.start(AESContext.MODE_CBC_ENCRYPT, key.to_utf8_buffer(), iv.to_utf8_buffer())
+		    encrypted = aes.update(data.to_utf8_buffer())
 		    aes.finish()
 		    # Decrypt CBC
-		    aes.start(AESContext.MODE_CBC_DECRYPT, key.to_utf8(), iv.to_utf8())
+		    aes.start(AESContext.MODE_CBC_DECRYPT, key.to_utf8_buffer(), iv.to_utf8_buffer())
 		    decrypted = aes.update(encrypted)
 		    aes.finish()
 		    # Check CBC
-		    assert(decrypted == data.to_utf8())
+		    assert(decrypted == data.to_utf8_buffer())
 		[/gdscript]
 		[csharp]
 		using Godot;
@@ -50,27 +50,27 @@
 		        string key = "My secret key!!!"; // Key must be either 16 or 32 bytes.
 		        string data = "My secret text!!"; // Data size must be multiple of 16 bytes, apply padding if needed.
 		        // Encrypt ECB
-		        _aes.Start(AesContext.Mode.EcbEncrypt, key.ToUtf8());
-		        byte[] encrypted = _aes.Update(data.ToUtf8());
+		        _aes.Start(AesContext.Mode.EcbEncrypt, key.ToUtf8Buffer());
+		        byte[] encrypted = _aes.Update(data.ToUtf8Buffer());
 		        _aes.Finish();
 		        // Decrypt ECB
-		        _aes.Start(AesContext.Mode.EcbDecrypt, key.ToUtf8());
+		        _aes.Start(AesContext.Mode.EcbDecrypt, key.ToUtf8Buffer());
 		        byte[] decrypted = _aes.Update(encrypted);
 		        _aes.Finish();
 		        // Check ECB
-		        Debug.Assert(decrypted == data.ToUtf8());
+		        Debug.Assert(decrypted == data.ToUtf8Buffer());
 
 		        string iv = "My secret iv!!!!"; // IV must be of exactly 16 bytes.
 		        // Encrypt CBC
-		        _aes.Start(AesContext.Mode.EcbEncrypt, key.ToUtf8(), iv.ToUtf8());
-		        encrypted = _aes.Update(data.ToUtf8());
+		        _aes.Start(AesContext.Mode.EcbEncrypt, key.ToUtf8Buffer(), iv.ToUtf8Buffer());
+		        encrypted = _aes.Update(data.ToUtf8Buffer());
 		        _aes.Finish();
 		        // Decrypt CBC
-		        _aes.Start(AesContext.Mode.EcbDecrypt, key.ToUtf8(), iv.ToUtf8());
+		        _aes.Start(AesContext.Mode.EcbDecrypt, key.ToUtf8Buffer(), iv.ToUtf8Buffer());
 		        decrypted = _aes.Update(encrypted);
 		        _aes.Finish();
 		        // Check CBC
-		        Debug.Assert(decrypted == data.ToUtf8());
+		        Debug.Assert(decrypted == data.ToUtf8Buffer());
 		    }
 		}
 		[/csharp]

--- a/doc/classes/Crypto.xml
+++ b/doc/classes/Crypto.xml
@@ -24,7 +24,7 @@
 		    cert.save("user://generated.crt")
 		    # Encryption
 		    var data = "Some data"
-		    var encrypted = crypto.encrypt(key, data.to_utf8())
+		    var encrypted = crypto.encrypt(key, data.to_utf8_buffer())
 		    # Decryption
 		    var decrypted = crypto.decrypt(key, encrypted)
 		    # Signing
@@ -33,7 +33,7 @@
 		    var verified = crypto.verify(HashingContext.HASH_SHA256, data.sha256_buffer(), signature, key)
 		    # Checks
 		    assert(verified)
-		    assert(data.to_utf8() == decrypted)
+		    assert(data.to_utf8_buffer() == decrypted)
 		[/gdscript]
 		[csharp]
 		using Godot;
@@ -56,7 +56,7 @@
 		        _cert.Save("user://generated.crt");
 		        // Encryption
 		        string data = "Some data";
-		        byte[] encrypted = _crypto.Encrypt(_key, data.ToUtf8());
+		        byte[] encrypted = _crypto.Encrypt(_key, data.ToUtf8Buffer());
 		        // Decryption
 		        byte[] decrypted = _crypto.Decrypt(_key, encrypted);
 		        // Signing
@@ -65,7 +65,7 @@
 		        bool verified = _crypto.Verify(HashingContext.HashType.Sha256, Data.Sha256Buffer(), signature, _key);
 		        // Checks
 		        Debug.Assert(verified);
-		        Debug.Assert(data.ToUtf8() == decrypted);
+		        Debug.Assert(data.ToUtf8Buffer() == decrypted);
 		    }
 		}
 		[/csharp]

--- a/doc/classes/DTLSServer.xml
+++ b/doc/classes/DTLSServer.xml
@@ -35,7 +35,7 @@
 		        if p.get_status() == PacketPeerDTLS.STATUS_CONNECTED:
 		            while p.get_available_packet_count() &gt; 0:
 		                print("Received message from client: %s" % p.get_packet().get_string_from_utf8())
-		                p.put_packet("Hello DTLS client".to_utf8())
+		                p.put_packet("Hello DTLS client".to_utf8_buffer())
 		[/gdscript]
 		[csharp]
 		// ServerNode.cs
@@ -77,7 +77,7 @@
 		                while (p.GetAvailablePacketCount() &gt; 0)
 		                {
 		                    GD.Print($"Received Message From Client: {p.GetPacket().GetStringFromUtf8()}");
-		                    p.PutPacket("Hello DTLS Client".ToUtf8());
+		                    p.PutPacket("Hello DTLS Client".ToUtf8Buffer());
 		                }
 		            }
 		        }
@@ -103,7 +103,7 @@
 		    if dtls.get_status() == PacketPeerDTLS.STATUS_CONNECTED:
 		        if !connected:
 		            # Try to contact server
-		            dtls.put_packet("The answer is... 42!".to_utf8())
+		            dtls.put_packet("The answer is... 42!".to_utf8_buffer())
 		        while dtls.get_available_packet_count() &gt; 0:
 		            print("Connected: %s" % dtls.get_packet().get_string_from_utf8())
 		            connected = true
@@ -133,7 +133,7 @@
 		            if (!_connected)
 		            {
 		                // Try to contact server
-		                _dtls.PutPacket("The Answer Is..42!".ToUtf8());
+		                _dtls.PutPacket("The Answer Is..42!".ToUtf8Buffer());
 		            }
 		            while (_dtls.GetAvailablePacketCount() &gt; 0)
 		            {

--- a/doc/classes/HMACContext.xml
+++ b/doc/classes/HMACContext.xml
@@ -11,11 +11,11 @@
 		var ctx = HMACContext.new()
 
 		func _ready():
-		    var key = "supersecret".to_utf8()
+		    var key = "supersecret".to_utf8_buffer()
 		    var err = ctx.start(HashingContext.HASH_SHA256, key)
 		    assert(err == OK)
-		    var msg1 = "this is ".to_utf8()
-		    var msg2 = "super duper secret".to_utf8()
+		    var msg1 = "this is ".to_utf8_buffer()
+		    var msg2 = "super duper secret".to_utf8_buffer()
 		    err = ctx.update(msg1)
 		    assert(err == OK)
 		    err = ctx.update(msg2)
@@ -34,11 +34,11 @@
 
 		    public override void _Ready()
 		    {
-		        byte[] key = "supersecret".ToUtf8();
+		        byte[] key = "supersecret".ToUtf8Buffer();
 		        Error err = _ctx.Start(HashingContext.HashType.Sha256, key);
 		        Debug.Assert(err == Error.Ok);
-		        byte[] msg1 = "this is ".ToUtf8();
-		        byte[] msg2 = "super duper secret".ToUtf8();
+		        byte[] msg1 = "this is ".ToUtf8Buffer();
+		        byte[] msg2 = "super duper secret".ToUtf8Buffer();
 		        err = _ctx.Update(msg1);
 		        Debug.Assert(err == Error.Ok);
 		        err = _ctx.Update(msg2);

--- a/doc/classes/PacketPeerUDP.xml
+++ b/doc/classes/PacketPeerUDP.xml
@@ -112,7 +112,7 @@
 				socket = PacketPeerUDP.new()
 				# Server
 				socket.set_dest_address("127.0.0.1", 789)
-				socket.put_packet("Time to stop".to_ascii())
+				socket.put_packet("Time to stop".to_ascii_buffer())
 
 				# Client
 				while socket.wait() == OK:
@@ -124,7 +124,7 @@
 				var socket = new PacketPeerUDP();
 				// Server
 				socket.SetDestAddress("127.0.0.1", 789);
-				socket.PutPacket("Time to stop".ToAscii());
+				socket.PutPacket("Time to stop".ToAsciiBuffer());
 
 				// Client
 				while (socket.Wait() == OK)

--- a/doc/classes/StreamPeer.xml
+++ b/doc/classes/StreamPeer.xml
@@ -177,10 +177,10 @@
 				[b]Note:[/b] To put an ASCII string without prepending its size, you can use [method put_data]:
 				[codeblocks]
 				[gdscript]
-				put_data("Hello world".to_ascii())
+				put_data("Hello world".to_ascii_buffer())
 				[/gdscript]
 				[csharp]
-				PutData("Hello World".ToAscii());
+				PutData("Hello World".ToAsciiBuffer());
 				[/csharp]
 				[/codeblocks]
 			</description>
@@ -221,10 +221,10 @@
 				[b]Note:[/b] To put an UTF-8 string without prepending its size, you can use [method put_data]:
 				[codeblocks]
 				[gdscript]
-				put_data("Hello world".to_utf8())
+				put_data("Hello world".to_utf8_buffer())
 				[/gdscript]
 				[csharp]
-				PutData("Hello World".ToUtf8());
+				PutData("Hello World".ToUtf8Buffer());
 				[/csharp]
 				[/codeblocks]
 			</description>

--- a/doc/classes/UDPServer.xml
+++ b/doc/classes/UDPServer.xml
@@ -86,7 +86,7 @@
 		func _process(delta):
 		    if !connected:
 		        # Try to contact server
-		        udp.put_packet("The answer is... 42!".to_utf8())
+		        udp.put_packet("The answer is... 42!".to_utf8_buffer())
 		    if udp.get_available_packet_count() &gt; 0:
 		        print("Connected: %s" % udp.get_packet().get_string_from_utf8())
 		        connected = true
@@ -110,7 +110,7 @@
 		        if (!_connected)
 		        {
 		            // Try to contact server
-		            _udp.PutPacket("The Answer Is..42!".ToUtf8());
+		            _udp.PutPacket("The Answer Is..42!".ToUtf8Buffer());
 		        }
 		        if (_udp.GetAvailablePacketCount() &gt; 0)
 		        {


### PR DESCRIPTION
The method `to_utf8` doesn't exist in Godot 4, but is still mentioned in the documentation in some places. Replace it with the new name `to_utf8_buffer`.

I've done the same for `to_ascii`. I also checked `to_utf16` and `to_utf32` but they appear to have no uses in this repository.