### PR TITLE
Fix GridMap free navigation RID error spam

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -557,10 +557,14 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 	}
 
 	//erase navigation
-	for (const KeyValue<IndexKey, Octant::NavigationCell> &E : g.navigation_cell_ids) {
-		NavigationServer3D::get_singleton()->free(E.value.region);
+	for (KeyValue<IndexKey, Octant::NavigationCell> &E : g.navigation_cell_ids) {
+		if (E.value.region.is_valid()) {
+			NavigationServer3D::get_singleton()->free(E.value.region);
+			E.value.region = RID();
+		}
 		if (E.value.navigation_mesh_debug_instance.is_valid()) {
 			RS::get_singleton()->free(E.value.navigation_mesh_debug_instance);
+			E.value.navigation_mesh_debug_instance = RID();
 		}
 	}
 	g.navigation_cell_ids.clear();


### PR DESCRIPTION
Fixes GridMap free navigation RID error spam.

Fixes https://github.com/godotengine/godot/issues/74429

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
