### PR TITLE
XR: When an sRGB target is used, check hardware sRGB conversion

### DIFF
--- a/modules/openxr/extensions/openxr_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper.h
@@ -80,7 +80,9 @@ public:
 	// this happens right before physics process and normal processing is run.
 	// This is when controller data is queried and made available to game logic.
 	virtual void on_process() {}
-	virtual void on_pre_render() {} // `on_pre_render` is called right before we start rendering our XR viewport.
+	virtual void on_pre_render() {} // `on_pre_render` is called right before we start rendering our XR viewports.
+	virtual void on_pre_draw_viewport(RID p_render_target) {} // `on_pre_draw_viewport` is called right before we start rendering this viewport
+	virtual void on_post_draw_viewport(RID p_render_target) {} // `on_port_draw_viewport` is called right after we start rendering this viewport (note that on Vulkan draw commands may only be queued)
 
 	virtual void on_state_idle() {} // `on_state_idle` is called when the OpenXR session state is changed to idle.
 	virtual void on_state_ready() {} // `on_state_ready` is called when the OpenXR session state is changed to ready, this means OpenXR is ready to setup our session.

--- a/modules/openxr/extensions/openxr_opengl_extension.cpp
+++ b/modules/openxr/extensions/openxr_opengl_extension.cpp
@@ -37,6 +37,28 @@
 #include "servers/rendering/rendering_server_globals.h"
 #include "servers/rendering_server.h"
 
+// OpenXR requires us to submit sRGB textures so that it recognises the content
+// as being in sRGB color space. We do fall back on "normal" textures but this
+// will likely result in incorrect colors as OpenXR will double the sRGB conversion.
+// All major XR runtimes support sRGB textures.
+
+// In OpenGL output of the fragment shader is assumed to be in the color space of
+// the developers choice, however a linear to sRGB HW conversion can be enabled
+// through enabling GL_FRAMEBUFFER_SRGB if an sRGB color attachment is used.
+// This is a global setting.
+// See: https://www.khronos.org/opengl/wiki/Framebuffer
+
+// In OpenGLES output of the fragment shader is assumed to be in linear color space
+// and will be converted by default to sRGB if an sRGB color attachment is used.
+// The extension GL_EXT_sRGB_write_control was introduced to enable turning this
+// feature off.
+// See: https://registry.khronos.org/OpenGL/extensions/EXT/EXT_sRGB_write_control.txt
+
+// On OpenGLES this is not defined in our standard headers..
+#ifndef GL_FRAMEBUFFER_SRGB
+#define GL_FRAMEBUFFER_SRGB 0x8DB9
+#endif
+
 HashMap<String, bool *> OpenXROpenGLExtension::get_requested_extensions() {
 	HashMap<String, bool *> request_extensions;
 
@@ -157,8 +179,8 @@ void *OpenXROpenGLExtension::set_session_create_and_get_next_pointer(void *p_nex
 }
 
 void OpenXROpenGLExtension::get_usable_swapchain_formats(Vector<int64_t> &p_usable_swap_chains) {
-	p_usable_swap_chains.push_back(GL_RGBA8);
 	p_usable_swap_chains.push_back(GL_SRGB8_ALPHA8);
+	p_usable_swap_chains.push_back(GL_RGBA8);
 }
 
 void OpenXROpenGLExtension::get_usable_depth_formats(Vector<int64_t> &p_usable_depth_formats) {
@@ -166,6 +188,23 @@ void OpenXROpenGLExtension::get_usable_depth_formats(Vector<int64_t> &p_usable_d
 	p_usable_depth_formats.push_back(GL_DEPTH24_STENCIL8);
 	p_usable_depth_formats.push_back(GL_DEPTH32F_STENCIL8);
 	p_usable_depth_formats.push_back(GL_DEPTH_COMPONENT24);
+}
+
+void OpenXROpenGLExtension::on_pre_draw_viewport(RID p_render_target) {
+	if (srgb_ext_is_available) {
+		hw_linear_to_srgb_is_enabled = glIsEnabled(GL_FRAMEBUFFER_SRGB);
+		if (hw_linear_to_srgb_is_enabled) {
+			// Disable this.
+			glDisable(GL_FRAMEBUFFER_SRGB);
+		}
+	}
+}
+
+void OpenXROpenGLExtension::on_post_draw_viewport(RID p_render_target) {
+	if (srgb_ext_is_available && hw_linear_to_srgb_is_enabled) {
+		// Re-enable this.
+		glEnable(GL_FRAMEBUFFER_SRGB);
+	}
 }
 
 bool OpenXROpenGLExtension::get_swapchain_image_data(XrSwapchain p_swapchain, int64_t p_swapchain_format, uint32_t p_width, uint32_t p_height, uint32_t p_sample_count, uint32_t p_array_size, void **r_swapchain_graphics_data) {

--- a/modules/openxr/extensions/openxr_opengl_extension.h
+++ b/modules/openxr/extensions/openxr_opengl_extension.h
@@ -79,6 +79,9 @@ public:
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void *set_session_create_and_get_next_pointer(void *p_next_pointer) override;
 
+	virtual void on_pre_draw_viewport(RID p_render_target) override;
+	virtual void on_post_draw_viewport(RID p_render_target) override;
+
 	virtual void get_usable_swapchain_formats(Vector<int64_t> &p_usable_swap_chains) override;
 	virtual void get_usable_depth_formats(Vector<int64_t> &p_usable_swap_chains) override;
 	virtual String get_swapchain_format_name(int64_t p_swapchain_format) const override;
@@ -102,6 +105,9 @@ private:
 		bool is_multiview;
 		Vector<RID> texture_rids;
 	};
+
+	bool srgb_ext_is_available = true;
+	bool hw_linear_to_srgb_is_enabled = false;
 
 	bool check_graphics_api_support(XrVersion p_desired_version);
 

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -1815,6 +1815,10 @@ bool OpenXRAPI::pre_draw_viewport(RID p_render_target) {
 		}
 	}
 
+	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
+		wrapper->on_pre_draw_viewport(p_render_target);
+	}
+
 	return true;
 }
 
@@ -1839,7 +1843,9 @@ void OpenXRAPI::post_draw_viewport(RID p_render_target) {
 		return;
 	}
 
-	// Nothing to do here at this point in time...
+	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
+		wrapper->on_post_draw_viewport(p_render_target);
+	}
 };
 
 void OpenXRAPI::end_frame() {


### PR DESCRIPTION
In XR situations such as with OpenXR we are overriding our render target as we need to use proper sRGB textures to submit to the XR compositor.

There turns out to be a problem when using OpenGL ES that OpenGL ES **always** expects the output of fragment shaders to be in linear color space, while on OpenGL this is optional but globally turned on. We thus need to suppress our linear to sRGB conversion when applicable.

This PR adds a check to see if an sRGB render target is used, and whether HW sRGB conversion is active and if so, disables our own conversion. There is a slight mismatch at this point where color correction is now done before sRGB conversion.

Note that these changes **only** effect the 3D render pipeline. The use cases where this is needed don't render 2D elements to the viewport that is effected by this.

Fixes #74857