### PR TITLE
Fix agents with disabled avoidance getting added to avoidance simulation

### DIFF
--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -894,9 +894,9 @@ void NavMap::sync() {
 	if (agents_dirty) {
 		// cannot use LocalVector here as RVO library expects std::vector to build KdTree
 		std::vector<RVO::Agent *> raw_agents;
-		raw_agents.reserve(agents.size());
-		for (NavAgent *agent : agents) {
-			raw_agents.push_back(agent->get_agent());
+		raw_agents.reserve(controlled_agents.size());
+		for (NavAgent *controlled_agent : controlled_agents) {
+			raw_agents.push_back(controlled_agent->get_agent());
 		}
 		rvo.buildAgentTree(raw_agents);
 	}


### PR DESCRIPTION
Fixes that agents with disabled avoidance were getting added to avoidance simulation.

This is a small fix for 4.0 only (and 3.5+) backported from the avoidance rework (that no longer has the `controlled_agent` array).

The avoidance step was always only calculated for the "controlled_agents" with enabled avoidance but all agents were added to the avoidance simulation. The issue is that those "disabled" agents are still processed by the RVO avoidance in the neighbor search and stuck at their origin position. This causes problems with the avoidance calculation around that positions and also costs performance for nothing.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
