### PR TITLE
Document how to use the global animation library in GDScript

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -94,6 +94,7 @@
 			<param index="0" name="name" type="StringName" />
 			<description>
 				Returns the first [AnimationLibrary] with key [param name] or [code]null[/code] if not found.
+				To get the [AnimationPlayer]'s global animation library, use [code]get_animation_library("")[/code].
 			</description>
 		</method>
 		<method name="get_animation_library_list" qualifiers="const">


### PR DESCRIPTION
I was running into problems with adding animations and animation libraries via pure gdscript. I would create an animation library but then to play the animation I was getting the error "animation not found", it turned out I needed to write `play("animationlibrary/animation")` instead of just `play("animation")`. By returning the global animation library we can add animations that can be played using `play("animation")`.

(By the way if you click Manage Animations it does seem to be called "[Global]")