### PR TITLE
[3.x] Fix GridMap free navigation RID error spam

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -473,7 +473,10 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 
 	//erase navigation
 	for (Map<IndexKey, Octant::NavMesh>::Element *E = g.navmesh_ids.front(); E; E = E->next()) {
-		NavigationServer::get_singleton()->free(E->get().region);
+		if (E->get().region.is_valid()) {
+			NavigationServer::get_singleton()->free(E->get().region);
+			E->get().region = RID();
+		}
 		if (E->get().navmesh_debug_instance.is_valid()) {
 			VS::get_singleton()->free(E->get().navmesh_debug_instance);
 		}


### PR DESCRIPTION
Fixes GridMap free navigation RID error spam.

Backport of https://github.com/godotengine/godot/pull/74889

Should be added to all 3.x versions with the new NavigationServer starting with 3.5.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
