### PR TITLE
[3.5+] Fix agents with disabled avoidance getting added to avoidance simulation

### DIFF
--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -506,6 +506,7 @@ void NavMap::set_agent_as_controlled(RvoAgent *agent) {
 	if (!exist) {
 		ERR_FAIL_COND(!has_agent(agent));
 		controlled_agents.push_back(agent);
+		agents_dirty = true;
 	}
 }
 
@@ -669,9 +670,9 @@ void NavMap::sync() {
 	if (agents_dirty) {
 		// cannot use LocalVector here as RVO library expects std::vector to build KdTree
 		std::vector<RVO::Agent *> raw_agents;
-		raw_agents.reserve(agents.size());
-		for (size_t i(0); i < agents.size(); i++) {
-			raw_agents.push_back(agents[i]->get_agent());
+		raw_agents.reserve(controlled_agents.size());
+		for (size_t i(0); i < controlled_agents.size(); i++) {
+			raw_agents.push_back(controlled_agents[i]->get_agent());
 		}
 		rvo.buildAgentTree(raw_agents);
 	}


### PR DESCRIPTION
Fixes that agents with disabled avoidance were getting added to avoidance simulation.

Backport of https://github.com/godotengine/godot/pull/74893

Should be added to all 3.x versions with the new NavigationServer starting with 3.5.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
