### PR TITLE
Remove methods in header removed in c7eb814

### DIFF
--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -623,9 +623,6 @@ public:
 	void set_hint_underline(bool p_underline);
 	bool is_hint_underlined() const;
 
-	void set_override_selected_font_color(bool p_override_selected_font_color);
-	bool is_overriding_selected_font_color() const;
-
 	void set_scroll_active(bool p_active);
 	bool is_scroll_active() const;
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -851,9 +851,6 @@ public:
 	void set_drag_and_drop_selection_enabled(const bool p_enabled);
 	bool is_drag_and_drop_selection_enabled() const;
 
-	void set_override_selected_font_color(bool p_override_selected_font_color);
-	bool is_overriding_selected_font_color() const;
-
 	void set_selection_mode(SelectionMode p_mode, int p_line = -1, int p_column = -1, int p_caret = 0);
 	SelectionMode get_selection_mode() const;
 


### PR DESCRIPTION
See #67888
c7eb814 missed these methods in the RichTextLabel's header
Remove set_override_selected_font_color from rich_text_label.h
Remove is_override_selected_font_color from rich_text_label.h
c7eb814 missed these methods in the TextEdit's header
Remove set_override_selected_font_color from text_edit.h
Remove is_override_selected_font_color from text_edit.h

As it stands, without a source file, all these methods can accomplish in this state is erroring in linkage if used anyway. Noticed this on one of my PRs and was curious why I wasn't getting an intellisense error but got a linkage error, this prevents that strange case.
