### PR TITLE
Make the request to redraw when clearing guides a part of UndoRedo

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4556,9 +4556,9 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 					undo_redo->add_do_method(root, "remove_meta", "_edit_vertical_guides_");
 					undo_redo->add_undo_method(root, "set_meta", "_edit_vertical_guides_", vguides);
 				}
+				undo_redo->add_do_method(viewport, "queue_redraw");
 				undo_redo->add_undo_method(viewport, "queue_redraw");
 				undo_redo->commit_action();
-				viewport->queue_redraw();
 			}
 
 		} break;


### PR DESCRIPTION
A minor change to the implementation of https://github.com/godotengine/godot/pull/74068, see the discussion. Fixed for 4.0 as a part of the cherry-pick.