### PR TITLE
Fix `Array.slice()` rounding for `abs(step) != 1`

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -466,7 +466,7 @@ Array Array::slice(int p_begin, int p_end, int p_step, bool p_deep) const {
 	ERR_FAIL_COND_V_MSG(p_step > 0 && begin > end, result, "Slice is positive, but bounds is decreasing.");
 	ERR_FAIL_COND_V_MSG(p_step < 0 && begin < end, result, "Slice is negative, but bounds is increasing.");
 
-	int result_size = (end - begin) / p_step;
+	int result_size = (end - begin) / p_step + (((end - begin) % p_step != 0) ? 1 : 0);
 	result.resize(result_size);
 
 	for (int src_idx = begin, dest_idx = 0; dest_idx < result_size; ++dest_idx) {

--- a/tests/core/variant/test_array.h
+++ b/tests/core/variant/test_array.h
@@ -253,6 +253,7 @@ TEST_CASE("[Array] slice()") {
 	array.push_back(2);
 	array.push_back(3);
 	array.push_back(4);
+	array.push_back(5);
 
 	Array slice0 = array.slice(0, 0);
 	CHECK(slice0.size() == 0);
@@ -263,42 +264,52 @@ TEST_CASE("[Array] slice()") {
 	CHECK(slice1[1] == Variant(2));
 
 	Array slice2 = array.slice(1, -1);
-	CHECK(slice2.size() == 3);
+	CHECK(slice2.size() == 4);
 	CHECK(slice2[0] == Variant(1));
 	CHECK(slice2[1] == Variant(2));
 	CHECK(slice2[2] == Variant(3));
+	CHECK(slice2[3] == Variant(4));
 
 	Array slice3 = array.slice(3);
-	CHECK(slice3.size() == 2);
+	CHECK(slice3.size() == 3);
 	CHECK(slice3[0] == Variant(3));
 	CHECK(slice3[1] == Variant(4));
+	CHECK(slice3[2] == Variant(5));
 
 	Array slice4 = array.slice(2, -2);
-	CHECK(slice4.size() == 1);
+	CHECK(slice4.size() == 2);
 	CHECK(slice4[0] == Variant(2));
+	CHECK(slice4[1] == Variant(3));
 
 	Array slice5 = array.slice(-2);
 	CHECK(slice5.size() == 2);
-	CHECK(slice5[0] == Variant(3));
-	CHECK(slice5[1] == Variant(4));
+	CHECK(slice5[0] == Variant(4));
+	CHECK(slice5[1] == Variant(5));
 
 	Array slice6 = array.slice(2, 42);
-	CHECK(slice6.size() == 3);
+	CHECK(slice6.size() == 4);
 	CHECK(slice6[0] == Variant(2));
 	CHECK(slice6[1] == Variant(3));
 	CHECK(slice6[2] == Variant(4));
+	CHECK(slice6[3] == Variant(5));
 
 	Array slice7 = array.slice(4, 0, -2);
 	CHECK(slice7.size() == 2);
 	CHECK(slice7[0] == Variant(4));
 	CHECK(slice7[1] == Variant(2));
 
-	ERR_PRINT_OFF;
-	Array slice8 = array.slice(4, 1);
-	CHECK(slice8.size() == 0);
+	Array slice8 = array.slice(5, 0, -2);
+	CHECK(slice8.size() == 3);
+	CHECK(slice8[0] == Variant(5));
+	CHECK(slice8[1] == Variant(3));
+	CHECK(slice8[2] == Variant(1));
 
-	Array slice9 = array.slice(3, -4);
+	ERR_PRINT_OFF;
+	Array slice9 = array.slice(4, 1);
 	CHECK(slice9.size() == 0);
+
+	Array slice10 = array.slice(3, -4);
+	CHECK(slice10.size() == 0);
 	ERR_PRINT_ON;
 }
 


### PR DESCRIPTION
Size of the result was rounded down with no consideration for the step, making some array slices impossible though they should have been, added test for this case as well

Edit: Added a more elegant rounding method, and realized my second method might be susceptible to overflow so changed just to be safe

Fixes #74905
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
