### PR TITLE
[3.x] Allow rendering of 3d content at lower resolution

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1645,6 +1645,13 @@
 			Uses a simplified method of generating PVS (potentially visible set) data. The results may not be accurate where more than one portal join adjacent rooms.
 			[b]Note:[/b] Generally you should only use this option if you encounter bugs when it is set to [code]false[/code], i.e. there are problems with the default method.
 		</member>
+		<member name="rendering/quality/3d/resolution_scale" type="float" setter="" getter="" default="1.0">
+			If set to a value lower than 1.0 the 3D rendering occurs at a lower resolution. 2D is still rendered at full resolution. This setting only applies if MSAA is disabled for the current viewport.
+			[b]Note:[/b] This changes the width and the height of the 3D resolution. So if you set this setting to 0.5 you only render 1/4 the pixels.
+		</member>
+		<member name="rendering/quality/3d/resolution_scale_filter_method" type="int" setter="" getter="" default="1">
+			The fitlering method that is used when upscaling the 3D image.
+		</member>
 		<member name="rendering/quality/depth/hdr" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], allocates the root [Viewport]'s framebuffer with high dynamic range. High dynamic range allows the use of [Color] values greater than 1. This must be set to [code]true[/code] for glow rendering to work if [member Environment.glow_hdr_threshold] is greater than or equal to [code]1.0[/code].
 			[b]Note:[/b] Only available on the GLES3 backend.

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -262,6 +262,15 @@
 		<member name="render_target_v_flip" type="bool" setter="set_vflip" getter="get_vflip" default="false">
 			If [code]true[/code], the result of rendering will be flipped vertically. Since Viewports in Godot 3.x render upside-down, it's recommended to set this to [code]true[/code] in most situations.
 		</member>
+		<member name="resolution_scale_factor" type="float" setter="set_resolution_scale_factor" getter="get_resolution_scale_factor" default="1.0">
+			Sets a resolution scale factor for the viewport. This makes it possible to render 3d content at a fraction of the original resolution.
+		</member>
+		<member name="resolution_scale_filter" type="int" setter="set_resolution_scale_filter" getter="get_resolution_scale_filter" enum="Viewport.ResolutionScaleFilter" default="0">
+			This changes how the rendered image is filtered when it is upscaled. This defaults to whatever has been configured in the project settings.
+		</member>
+		<member name="resolution_scale_mix" type="bool" setter="set_resolution_scale_mix" getter="get_resolution_scale_mix" default="true">
+			If this is enabled the viewport specific scale factor is multiplied with the global scale factor that has been set in the project settings. If this is disabled the viewport scale overrides the global one for this viewport.
+		</member>
 		<member name="shadow_atlas_quad_0" type="int" setter="set_shadow_atlas_quadrant_subdiv" getter="get_shadow_atlas_quadrant_subdiv" enum="Viewport.ShadowAtlasQuadrantSubdiv" default="2">
 			The subdivision amount of the first quadrant on the shadow atlas.
 		</member>
@@ -430,6 +439,12 @@
 		</constant>
 		<constant name="CLEAR_MODE_ONLY_NEXT_FRAME" value="2" enum="ClearMode">
 			Clear the render target next frame, then switch to [constant CLEAR_MODE_NEVER].
+		</constant>
+		<constant name="RESOLUTION_SCALE_FILTER_DEFAULT" value="0" enum="ResolutionScaleFilter">
+		</constant>
+		<constant name="RESOLUTION_SCALE_FILTER_LINEAR" value="1" enum="ResolutionScaleFilter">
+		</constant>
+		<constant name="RESOLUTION_SCALE_FILTER_NEAREST" value="2" enum="ResolutionScaleFilter">
 		</constant>
 	</constants>
 </class>

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -709,6 +709,9 @@ public:
 	RID render_target_create() { return RID(); }
 	void render_target_set_position(RID p_render_target, int p_x, int p_y) {}
 	void render_target_set_size(RID p_render_target, int p_width, int p_height) {}
+	void render_target_set_resolution_scale_mix(RID p_render_target, bool p_mix){};
+	void render_target_set_resolution_scale_filter(RID p_render_target, VS::ResolutionScaleFilter p_method){};
+	void render_target_set_resolution_scale_factor(RID p_render_target, float p_factor){};
 	RID render_target_get_texture(RID p_render_target) const { return RID(); }
 	uint32_t render_target_get_depth_texture_id(RID p_render_target) const { return 0; }
 	void render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id, unsigned int p_depth_id) {}

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -3255,9 +3255,19 @@ void RasterizerSceneGLES2::render_scene(const Transform &p_cam_transform, const 
 	bool probe_interior = false;
 	bool reverse_cull = false;
 
-	if (storage->frame.current_rt && storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_VFLIP]) {
-		cam_transform.basis.set_axis(1, -cam_transform.basis.get_axis(1));
-		reverse_cull = true;
+	bool use_resolution_scale = false;
+	float final_resolution_scale = global_spatial_resolution_factor;
+	if (storage->frame.current_rt) {
+		if (storage->frame.current_rt->spatial_resolution_scale_mix) {
+			final_resolution_scale = global_spatial_resolution_factor * storage->frame.current_rt->spatial_resolution_scale_factor;
+		} else {
+			final_resolution_scale = storage->frame.current_rt->spatial_resolution_scale_factor;
+		}
+
+		if (storage->frame.current_rt && storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_VFLIP]) {
+			cam_transform.basis.set_axis(1, -cam_transform.basis.get_axis(1));
+			reverse_cull = true;
+		}
 	}
 
 	if (p_reflection_probe.is_valid()) {
@@ -3282,6 +3292,9 @@ void RasterizerSceneGLES2::render_scene(const Transform &p_cam_transform, const 
 			current_fb = storage->frame.current_rt->multisample_fbo;
 		} else if (storage->frame.current_rt->external.fbo != 0) {
 			current_fb = storage->frame.current_rt->external.fbo;
+		} else if (final_resolution_scale < 0.95 && !storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_DIRECT_TO_SCREEN] && storage->frame.current_rt->msaa == VS::VIEWPORT_MSAA_DISABLED) {
+			use_resolution_scale = true;
+			current_fb = storage->frame.current_rt->fbo_small;
 		} else {
 			current_fb = storage->frame.current_rt->fbo;
 		}
@@ -3296,6 +3309,11 @@ void RasterizerSceneGLES2::render_scene(const Transform &p_cam_transform, const 
 		} else {
 			viewport_y = storage->frame.current_rt->y;
 		}
+	}
+
+	if (use_resolution_scale) {
+		viewport_width = floor(viewport_width * final_resolution_scale);
+		viewport_height = floor(viewport_height * final_resolution_scale);
 	}
 
 	state.used_screen_texture = false;
@@ -3604,6 +3622,41 @@ void RasterizerSceneGLES2::render_scene(const Transform &p_cam_transform, const 
 	if (p_reflection_probe.is_valid()) {
 		// Rendering to a probe so no need for post_processing
 		return;
+	}
+
+	if (use_resolution_scale) {
+		// copy over to default fbo
+		glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->fbo);
+		glViewport(0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height);
+#ifdef XXX_GLES_OVER_GL // broken when using anything other than NEAREST
+
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, storage->frame.current_rt->fbo_small);
+		glReadBuffer(GL_COLOR_ATTACHMENT0);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, storage->frame.current_rt->fbo);
+		glBlitFramebuffer(0, 0, viewport_width, viewport_height, 0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+#else
+		glDepthMask(GL_FALSE);
+		glDisable(GL_DEPTH_TEST);
+		glDisable(GL_CULL_FACE);
+		glDisable(GL_BLEND);
+		glDepthFunc(GL_LEQUAL);
+		glColorMask(1, 1, 1, 1);
+
+		glActiveTexture(GL_TEXTURE0);
+		glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->color_small);
+
+		storage->shaders.copy.set_conditional(CopyShaderGLES2::USE_DISPLAY_TRANSFORM, true);
+		storage->shaders.copy.bind();
+		storage->shaders.copy.set_uniform(CopyShaderGLES2::DISPLAY_TRANSFORM, Transform(final_resolution_scale, 0.0, 0.0, 0.0, final_resolution_scale, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0));
+
+		storage->bind_quad_array();
+		glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
+		storage->shaders.copy.set_conditional(CopyShaderGLES2::USE_DISPLAY_TRANSFORM, false);
+#endif
 	}
 
 	//post process
@@ -4108,6 +4161,8 @@ void RasterizerSceneGLES2::initialize() {
 }
 
 void RasterizerSceneGLES2::iteration() {
+	global_spatial_resolution_factor = float(GLOBAL_GET("rendering/quality/3d/resolution_scale"));
+
 	shadow_filter_mode = ShadowFilterMode(int(GLOBAL_GET("rendering/quality/shadows/filter_mode")));
 
 	const int directional_shadow_size_new = next_power_of_2(int(GLOBAL_GET("rendering/quality/directional_shadow/size")));

--- a/drivers/gles2/rasterizer_scene_gles2.h
+++ b/drivers/gles2/rasterizer_scene_gles2.h
@@ -64,6 +64,8 @@ public:
 		INSTANCE_BONE_BASE = 13,
 	};
 
+	float global_spatial_resolution_factor;
+
 	ShadowFilterMode shadow_filter_mode;
 
 	RID default_material;

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -5114,6 +5114,68 @@ void RasterizerStorageGLES2::_render_target_allocate(RenderTarget *rt) {
 		texture_set_flags(rt->texture, texture->flags);
 	}
 
+	{
+		/* Small Front FBO */
+
+		// framebuffer
+		glGenFramebuffers(1, &rt->fbo_small);
+		glBindFramebuffer(GL_FRAMEBUFFER, rt->fbo_small);
+
+		// color
+		glGenTextures(1, &rt->color_small);
+		glBindTexture(GL_TEXTURE_2D, rt->color_small);
+
+		glTexImage2D(GL_TEXTURE_2D, 0, color_internal_format, rt->width, rt->height, 0, color_format, color_type, nullptr);
+
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->color_small, 0);
+
+		// depth
+
+		if (config.support_depth_texture) {
+			glGenTextures(1, &rt->depth_small);
+			glBindTexture(GL_TEXTURE_2D, rt->depth_small);
+			glTexImage2D(GL_TEXTURE_2D, 0, config.depth_internalformat, rt->width, rt->height, 0, GL_DEPTH_COMPONENT, config.depth_type, nullptr);
+
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, rt->depth_small, 0);
+		} else {
+			glGenRenderbuffers(1, &rt->depth_small);
+			glBindRenderbuffer(GL_RENDERBUFFER, rt->depth_small);
+
+			glRenderbufferStorage(GL_RENDERBUFFER, config.depth_buffer_internalformat, rt->width, rt->height);
+
+			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, rt->depth_small);
+		}
+
+		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+
+		if (status != GL_FRAMEBUFFER_COMPLETE) {
+			glDeleteFramebuffers(1, &rt->fbo_small);
+			if (config.support_depth_texture) {
+				glDeleteTextures(1, &rt->depth_small);
+			} else {
+				glDeleteRenderbuffers(1, &rt->depth_small);
+			}
+
+			glDeleteTextures(1, &rt->color_small);
+			rt->fbo_small = 0;
+			rt->color_small = 0;
+			rt->depth_small = 0;
+			WARN_PRINT("Could not create alternative small framebuffer!!");
+			return;
+		}
+	}
+
 	/* BACK FBO */
 	/* For MSAA */
 
@@ -5361,6 +5423,12 @@ void RasterizerStorageGLES2::_render_target_clear(RenderTarget *rt) {
 		rt->fbo = 0;
 	}
 
+	if (rt->fbo_small) {
+		glDeleteFramebuffers(1, &rt->fbo_small);
+		glDeleteTextures(1, &rt->color_small);
+		rt->fbo = 0;
+	}
+
 	Texture *tex = texture_owner.get(rt->texture);
 	tex->alloc_height = 0;
 	tex->alloc_width = 0;
@@ -5388,8 +5456,10 @@ void RasterizerStorageGLES2::_render_target_clear(RenderTarget *rt) {
 	if (rt->depth) {
 		if (config.support_depth_texture) {
 			glDeleteTextures(1, &rt->depth);
+			glDeleteTextures(1, &rt->depth_small);
 		} else {
 			glDeleteRenderbuffers(1, &rt->depth);
+			glDeleteRenderbuffers(1, &rt->depth_small);
 		}
 
 		rt->depth = 0;
@@ -5713,6 +5783,38 @@ void RasterizerStorageGLES2::render_target_set_sharpen_intensity(RID p_render_ta
 	}
 
 	rt->sharpen_intensity = p_intensity;
+}
+
+void RasterizerStorageGLES2::render_target_set_resolution_scale_mix(RID p_render_target, bool p_mix) {
+	RenderTarget *rt = render_target_owner.getornull(p_render_target);
+	ERR_FAIL_COND(!rt);
+
+	rt->spatial_resolution_scale_mix = p_mix;
+}
+
+void RasterizerStorageGLES2::render_target_set_resolution_scale_filter(RID p_render_target, VS::ResolutionScaleFilter p_method) {
+	RenderTarget *rt = render_target_owner.getornull(p_render_target);
+	ERR_FAIL_COND(!rt);
+
+	switch (p_method) {
+		case VS::ResolutionScaleFilter::NEAREST:
+			rt->spatial_resolution_scale_filter = GL_NEAREST;
+			break;
+		case VS::ResolutionScaleFilter::LINEAR:
+			rt->spatial_resolution_scale_filter = GL_LINEAR;
+			break;
+		case VS::ResolutionScaleFilter::DEFAULT:
+		default:
+			rt->spatial_resolution_scale_filter = 0;
+			break;
+	}
+}
+
+void RasterizerStorageGLES2::render_target_set_resolution_scale_factor(RID p_render_target, float p_factor) {
+	RenderTarget *rt = render_target_owner.getornull(p_render_target);
+	ERR_FAIL_COND(!rt);
+
+	rt->spatial_resolution_scale_factor = p_factor;
 }
 
 /* CANVAS SHADOW */

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -1182,6 +1182,14 @@ public:
 		GLuint color;
 		GLuint depth;
 
+		bool spatial_resolution_scale_mix;
+		unsigned int spatial_resolution_scale_filter;
+		float spatial_resolution_scale_factor;
+
+		GLuint fbo_small;
+		GLuint color_small;
+		GLuint depth_small;
+
 		GLuint multisample_fbo;
 		GLuint multisample_color;
 		GLuint multisample_depth;
@@ -1258,6 +1266,12 @@ public:
 				fbo(0),
 				color(0),
 				depth(0),
+				spatial_resolution_scale_mix(true),
+				spatial_resolution_scale_filter(0),
+				spatial_resolution_scale_factor(1.0),
+				fbo_small(0),
+				color_small(0),
+				depth_small(0),
 				multisample_fbo(0),
 				multisample_color(0),
 				multisample_depth(0),
@@ -1299,6 +1313,10 @@ public:
 	virtual void render_target_set_use_fxaa(RID p_render_target, bool p_fxaa);
 	virtual void render_target_set_use_debanding(RID p_render_target, bool p_debanding);
 	virtual void render_target_set_sharpen_intensity(RID p_render_target, float p_intensity);
+
+	virtual void render_target_set_resolution_scale_mix(RID p_render_target, bool p_mix);
+	virtual void render_target_set_resolution_scale_filter(RID p_render_target, VS::ResolutionScaleFilter p_method);
+	virtual void render_target_set_resolution_scale_factor(RID p_render_target, float p_factor);
 
 	/* CANVAS SHADOW */
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3579,30 +3579,6 @@ void RasterizerSceneGLES3::_render_mrts(Environment *env, const CameraMatrix &p_
 }
 
 void RasterizerSceneGLES3::_post_process(Environment *env, const CameraMatrix &p_cam_projection) {
-	//copy to front buffer
-
-	glDepthMask(GL_FALSE);
-	glDisable(GL_DEPTH_TEST);
-	glDisable(GL_CULL_FACE);
-	glDisable(GL_BLEND);
-	glDepthFunc(GL_LEQUAL);
-	glColorMask(1, 1, 1, 1);
-
-	//turn off everything used
-
-	//copy specular to front buffer
-	//copy diffuse to effect buffer
-
-	if (storage->frame.current_rt->buffers.active) {
-		//transfer to effect buffer if using buffers, also resolve MSAA
-		glBindFramebuffer(GL_READ_FRAMEBUFFER, storage->frame.current_rt->buffers.fbo);
-		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, storage->frame.current_rt->effects.mip_maps[0].sizes[0].fbo);
-		glBlitFramebuffer(0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, 0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
-
-		glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-	}
-
 	if ((!env || storage->frame.current_rt->width < 4 || storage->frame.current_rt->height < 4) && !storage->frame.current_rt->use_fxaa && !storage->frame.current_rt->use_debanding && storage->frame.current_rt->sharpen_intensity < 0.001) { //no post process on small render targets
 		//no environment or transparent render, simply return and convert to SRGB
 		if (storage->frame.current_rt->external.fbo != 0) {
@@ -4110,6 +4086,25 @@ void RasterizerSceneGLES3::render_scene(const Transform &p_cam_transform, const 
 	ShadowAtlas *shadow_atlas = shadow_atlas_owner.getornull(p_shadow_atlas);
 	ReflectionAtlas *reflection_atlas = reflection_atlas_owner.getornull(p_reflection_atlas);
 
+	bool use_resolution_scale = false;
+	float final_resolution_scale = global_spatial_resolution_factor;
+	GLenum resolution_scale_filter = global_spatial_resolution_filter;
+
+	if (storage->frame.current_rt) {
+		if (storage->frame.current_rt->spatial_resolution_scale_mix) {
+			final_resolution_scale = global_spatial_resolution_factor * storage->frame.current_rt->spatial_resolution_scale_factor;
+		} else {
+			final_resolution_scale = storage->frame.current_rt->spatial_resolution_scale_factor;
+		}
+		if (storage->frame.current_rt->spatial_resolution_scale_filter) {
+			resolution_scale_filter = storage->frame.current_rt->spatial_resolution_scale_filter;
+		}
+
+		if (final_resolution_scale < 0.95 && storage->frame.current_rt->external.fbo == 0 && !p_reflection_probe.is_valid() && storage->frame.current_rt->msaa == VS::VIEWPORT_MSAA_DISABLED) {
+			use_resolution_scale = true;
+		}
+	}
+
 	bool use_shadows = shadow_atlas && shadow_atlas->size;
 
 	state.scene_shader.set_conditional(SceneShaderGLES3::USE_SHADOW, use_shadows);
@@ -4149,9 +4144,16 @@ void RasterizerSceneGLES3::render_scene(const Transform &p_cam_transform, const 
 	state.ubo_data.shadow_dual_paraboloid_render_zfar = 0;
 	state.ubo_data.opaque_prepass_threshold = 0.99;
 
+	int viewport_width_pixels = 0;
+	int viewport_height_pixels = 0;
+
 	if (storage->frame.current_rt) {
-		int viewport_width_pixels = storage->frame.current_rt->width;
-		int viewport_height_pixels = storage->frame.current_rt->height;
+		viewport_width_pixels = storage->frame.current_rt->width;
+		viewport_height_pixels = storage->frame.current_rt->height;
+		if (use_resolution_scale) {
+			viewport_width_pixels = floor(viewport_width_pixels * final_resolution_scale);
+			viewport_height_pixels = floor(viewport_height_pixels * final_resolution_scale);
+		}
 
 		state.ubo_data.viewport_size[0] = viewport_width_pixels;
 		state.ubo_data.viewport_size[1] = viewport_height_pixels;
@@ -4199,7 +4201,7 @@ void RasterizerSceneGLES3::render_scene(const Transform &p_cam_transform, const 
 		glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->buffers.fbo);
 		glDrawBuffers(0, nullptr);
 
-		glViewport(0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height);
+		glViewport(0, 0, viewport_width_pixels, viewport_height_pixels);
 
 		glColorMask(0, 0, 0, 0);
 		glClearDepth(1.0f);
@@ -4276,7 +4278,7 @@ void RasterizerSceneGLES3::render_scene(const Transform &p_cam_transform, const 
 		use_mrt = use_mrt && state.debug_draw != VS::VIEWPORT_DEBUG_DRAW_OVERDRAW;
 		use_mrt = use_mrt && (env->bg_mode != VS::ENV_BG_KEEP && env->bg_mode != VS::ENV_BG_CANVAS);
 
-		glViewport(0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height);
+		glViewport(0, 0, viewport_width_pixels, viewport_height_pixels);
 
 		if (use_mrt) {
 			current_fbo = storage->frame.current_rt->buffers.fbo;
@@ -4524,7 +4526,9 @@ void RasterizerSceneGLES3::render_scene(const Transform &p_cam_transform, const 
 	//state.scene_shader.set_conditional( SceneShaderGLES3::USE_FOG,false);
 
 	if (use_mrt) {
+		glViewport(0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height);
 		_render_mrts(env, p_cam_projection);
+		glViewport(0, 0, viewport_width_pixels, viewport_height_pixels);
 	} else {
 		// Here we have to do the blits/resolves that otherwise are done in the MRT rendering, in particular
 		// - prepare screen texture for any geometry that uses a shader with screen texture
@@ -4536,7 +4540,7 @@ void RasterizerSceneGLES3::render_scene(const Transform &p_cam_transform, const 
 			glBindFramebuffer(GL_READ_FRAMEBUFFER, storage->frame.current_rt->buffers.fbo);
 			glReadBuffer(GL_COLOR_ATTACHMENT0);
 			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, storage->frame.current_rt->effects.mip_maps[0].sizes[0].fbo);
-			glBlitFramebuffer(0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, 0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+			glBlitFramebuffer(0, 0, viewport_width_pixels, viewport_height_pixels, 0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT, resolution_scale_filter);
 			glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
 			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
 			_blur_effect_buffer();
@@ -4551,7 +4555,7 @@ void RasterizerSceneGLES3::render_scene(const Transform &p_cam_transform, const 
 		if (framebuffer_dirty) {
 			// Restore framebuffer
 			glBindFramebuffer(GL_FRAMEBUFFER, storage->frame.current_rt->buffers.fbo);
-			glViewport(0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height);
+			glViewport(0, 0, viewport_width_pixels, viewport_height_pixels);
 		}
 	}
 
@@ -4623,8 +4627,73 @@ void RasterizerSceneGLES3::render_scene(const Transform &p_cam_transform, const 
 		return;
 	}
 
-	if (env && (env->dof_blur_far_enabled || env->dof_blur_near_enabled) && storage->frame.current_rt && storage->frame.current_rt->buffers.active) {
-		_prepare_depth_texture();
+	// Move stuff to the buffers where post processing expects them
+
+	if (env && (env->dof_blur_far_enabled || env->dof_blur_near_enabled) && storage->frame.current_rt) {
+		if (storage->frame.current_rt->buffers.active) {
+			if (use_resolution_scale) {
+				// We need custom logic to scale the texture up
+				if (!state.prepared_depth_texture) {
+					//resolve depth buffer
+					glBindFramebuffer(GL_READ_FRAMEBUFFER, storage->frame.current_rt->buffers.fbo);
+					glReadBuffer(GL_COLOR_ATTACHMENT0);
+					glBindFramebuffer(GL_DRAW_FRAMEBUFFER, storage->frame.current_rt->fbo);
+					glBlitFramebuffer(0, 0, viewport_width_pixels, viewport_height_pixels, 0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, GL_DEPTH_BUFFER_BIT, resolution_scale_filter);
+					glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+					glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+					state.prepared_depth_texture = true;
+				}
+
+			} else {
+				_prepare_depth_texture();
+			}
+		} else if (use_resolution_scale) {
+			// the depth texture is already were we need it but has the wrong scale
+			glBindFramebuffer(GL_READ_FRAMEBUFFER, storage->frame.current_rt->fbo);
+			glReadBuffer(GL_COLOR_ATTACHMENT0);
+			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, storage->frame.current_rt->effects.mip_maps[0].sizes[0].fbo);
+			glBlitFramebuffer(0, 0, viewport_width_pixels, viewport_height_pixels, 0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, GL_DEPTH_BUFFER_BIT, resolution_scale_filter);
+
+			glBindFramebuffer(GL_READ_FRAMEBUFFER, storage->frame.current_rt->effects.mip_maps[0].sizes[0].fbo);
+			glReadBuffer(GL_COLOR_ATTACHMENT0);
+			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, storage->frame.current_rt->fbo);
+			glBlitFramebuffer(0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, 0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+			glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+
+			state.prepared_depth_texture = true;
+		}
+	}
+
+	glViewport(0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height);
+	glDepthMask(GL_FALSE);
+	glDisable(GL_DEPTH_TEST);
+	glDisable(GL_CULL_FACE);
+	glDisable(GL_BLEND);
+	glDepthFunc(GL_LEQUAL);
+	glColorMask(1, 1, 1, 1);
+	//turn off everything used
+
+	//copy diffuse to effect buffer
+	if (storage->frame.current_rt->buffers.active) {
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, storage->frame.current_rt->buffers.fbo);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, storage->frame.current_rt->effects.mip_maps[0].sizes[0].fbo);
+		glBlitFramebuffer(0, 0, viewport_width_pixels, viewport_height_pixels, 0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, GL_COLOR_BUFFER_BIT, resolution_scale_filter);
+
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+	} else {
+		// all the rendering already happened the the effects buffer, but to scale it we need to blit it to another buffer & back
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, storage->frame.current_rt->effects.mip_maps[0].sizes[0].fbo);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, storage->frame.current_rt->fbo);
+		glBlitFramebuffer(0, 0, viewport_width_pixels, viewport_height_pixels, 0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, GL_COLOR_BUFFER_BIT, resolution_scale_filter);
+
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, storage->frame.current_rt->fbo);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, storage->frame.current_rt->effects.mip_maps[0].sizes[0].fbo);
+		glBlitFramebuffer(0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, 0, 0, storage->frame.current_rt->width, storage->frame.current_rt->height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
 	}
 	_post_process(env, p_cam_projection);
 	// Needed only for debugging
@@ -5015,6 +5084,11 @@ void RasterizerSceneGLES3::set_debug_draw_mode(VS::ViewportDebugDraw p_debug_dra
 	state.debug_draw = p_debug_draw;
 }
 
+void set_spatial_resolution_multiplier(float factor) {
+	factor = CLAMP(factor, 0.1, 1.0);
+	//TODO: continue me
+}
+
 void RasterizerSceneGLES3::initialize() {
 	render_pass = 0;
 
@@ -5326,6 +5400,13 @@ void RasterizerSceneGLES3::initialize() {
 }
 
 void RasterizerSceneGLES3::iteration() {
+	global_spatial_resolution_factor = float(GLOBAL_GET("rendering/quality/3d/resolution_scale"));
+	if (int(GLOBAL_GET("rendering/quality/3d/resolution_scale_filter_method"))) {
+		global_spatial_resolution_filter = GL_LINEAR;
+	} else {
+		global_spatial_resolution_filter = GL_NEAREST;
+	}
+
 	shadow_filter_mode = ShadowFilterMode(int(GLOBAL_GET("rendering/quality/shadows/filter_mode")));
 
 	const int directional_shadow_size_new = next_power_of_2(int(GLOBAL_GET("rendering/quality/directional_shadow/size")));

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -64,6 +64,9 @@ public:
 		SSS_QUALITY_HIGH,
 	};
 
+	float global_spatial_resolution_factor;
+	GLenum global_spatial_resolution_filter;
+
 	SubSurfaceScatterQuality subsurface_scatter_quality;
 	float subsurface_scatter_size;
 	bool subsurface_scatter_follow_surface;

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -7512,6 +7512,38 @@ void RasterizerStorageGLES3::render_target_set_sharpen_intensity(RID p_render_ta
 	rt->sharpen_intensity = p_intensity;
 }
 
+void RasterizerStorageGLES3::render_target_set_resolution_scale_mix(RID p_render_target, bool p_mix) {
+	RenderTarget *rt = render_target_owner.getornull(p_render_target);
+	ERR_FAIL_COND(!rt);
+
+	rt->spatial_resolution_scale_mix = p_mix;
+}
+
+void RasterizerStorageGLES3::render_target_set_resolution_scale_filter(RID p_render_target, VS::ResolutionScaleFilter p_method) {
+	RenderTarget *rt = render_target_owner.getornull(p_render_target);
+	ERR_FAIL_COND(!rt);
+
+	switch (p_method) {
+		case VS::ResolutionScaleFilter::NEAREST:
+			rt->spatial_resolution_scale_filter = GL_NEAREST;
+			break;
+		case VS::ResolutionScaleFilter::LINEAR:
+			rt->spatial_resolution_scale_filter = GL_LINEAR;
+			break;
+		case VS::ResolutionScaleFilter::DEFAULT:
+		default:
+			rt->spatial_resolution_scale_filter = 0;
+			break;
+	}
+}
+
+void RasterizerStorageGLES3::render_target_set_resolution_scale_factor(RID p_render_target, float p_factor) {
+	RenderTarget *rt = render_target_owner.getornull(p_render_target);
+	ERR_FAIL_COND(!rt);
+
+	rt->spatial_resolution_scale_factor = p_factor;
+}
+
 /* CANVAS SHADOW */
 
 RID RasterizerStorageGLES3::canvas_light_shadow_buffer_create(int p_width) {

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1322,6 +1322,10 @@ public:
 		GLuint color;
 		GLuint depth;
 
+		bool spatial_resolution_scale_mix;
+		unsigned int spatial_resolution_scale_filter;
+		float spatial_resolution_scale_factor;
+
 		struct Buffers {
 			bool active;
 			bool effects_active;
@@ -1415,6 +1419,9 @@ public:
 		RenderTarget() :
 				fbo(0),
 				depth(0),
+				spatial_resolution_scale_mix(true),
+				spatial_resolution_scale_filter(0),
+				spatial_resolution_scale_factor(1.0),
 				last_exposure_tick(0),
 				width(0),
 				height(0),
@@ -1454,6 +1461,10 @@ public:
 	virtual void render_target_set_use_fxaa(RID p_render_target, bool p_fxaa);
 	virtual void render_target_set_use_debanding(RID p_render_target, bool p_debanding);
 	virtual void render_target_set_sharpen_intensity(RID p_render_target, float p_intensity);
+
+	virtual void render_target_set_resolution_scale_mix(RID p_render_target, bool p_mix);
+	virtual void render_target_set_resolution_scale_filter(RID p_render_target, VS::ResolutionScaleFilter p_method);
+	virtual void render_target_set_resolution_scale_factor(RID p_render_target, float p_factor);
 
 	/* CANVAS SHADOW */
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -757,6 +757,29 @@ Size2 Viewport::get_size() const {
 	return size;
 }
 
+void Viewport::set_resolution_scale_mix(bool p_mix) {
+	resolution_scale_mix = p_mix;
+	VS::get_singleton()->viewport_set_resolution_scale_mix(viewport, p_mix);
+}
+
+bool Viewport::get_resolution_scale_mix() {
+	return resolution_scale_mix;
+}
+void Viewport::set_resolution_scale_filter(ResolutionScaleFilter p_method) {
+	resolution_scale_filter = p_method;
+	VS::get_singleton()->viewport_set_resolution_scale_filter(viewport, VS::ResolutionScaleFilter(p_method));
+}
+Viewport::ResolutionScaleFilter Viewport::get_resolution_scale_filter() {
+	return resolution_scale_filter;
+}
+void Viewport::set_resolution_scale_factor(float p_factor) {
+	resolution_scale_factor = p_factor;
+	VS::get_singleton()->viewport_set_resolution_scale_factor(viewport, p_factor);
+}
+float Viewport::get_resolution_scale_factor() {
+	return resolution_scale_factor;
+}
+
 void Viewport::_update_listener() {
 	/*
 	if (is_inside_tree() && audio_listener && (camera || listener) && (!get_parent() || (Object::cast_to<Control>(get_parent()) && Object::cast_to<Control>(get_parent())->is_visible_in_tree())))  {
@@ -3239,6 +3262,13 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_world"), &Viewport::get_world);
 	ClassDB::bind_method(D_METHOD("find_world"), &Viewport::find_world);
 
+	ClassDB::bind_method(D_METHOD("set_resolution_scale_mix", "resolution_scale_mix"), &Viewport::set_resolution_scale_mix);
+	ClassDB::bind_method(D_METHOD("get_resolution_scale_mix"), &Viewport::get_resolution_scale_mix);
+	ClassDB::bind_method(D_METHOD("set_resolution_scale_filter", "resolution_scale_filter"), &Viewport::set_resolution_scale_filter);
+	ClassDB::bind_method(D_METHOD("get_resolution_scale_filter"), &Viewport::get_resolution_scale_filter);
+	ClassDB::bind_method(D_METHOD("set_resolution_scale_factor", "resolution_scale_factor"), &Viewport::set_resolution_scale_factor);
+	ClassDB::bind_method(D_METHOD("get_resolution_scale_factor"), &Viewport::get_resolution_scale_factor);
+
 	ClassDB::bind_method(D_METHOD("set_canvas_transform", "xform"), &Viewport::set_canvas_transform);
 	ClassDB::bind_method(D_METHOD("get_canvas_transform"), &Viewport::get_canvas_transform);
 
@@ -3373,6 +3403,10 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "world_2d", PROPERTY_HINT_RESOURCE_TYPE, "World2D", 0), "set_world_2d", "get_world_2d");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "transparent_bg"), "set_transparent_background", "has_transparent_background");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "handle_input_locally"), "set_handle_input_locally", "is_handling_input_locally");
+	ADD_GROUP("3D Resolution Scale", "resolution_scale_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "resolution_scale_mix"), "set_resolution_scale_mix", "get_resolution_scale_mix");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "resolution_scale_filter", PROPERTY_HINT_ENUM, "Default,Linear,Nearest"), "set_resolution_scale_filter", "get_resolution_scale_filter");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "resolution_scale_factor", PROPERTY_HINT_RANGE, "0.1,1.0,0.01"), "set_resolution_scale_factor", "get_resolution_scale_factor");
 	ADD_GROUP("Rendering", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "msaa", PROPERTY_HINT_ENUM, "Disabled,2x,4x,8x,16x,AndroidVR 2x,AndroidVR 4x"), "set_msaa", "get_msaa");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fxaa"), "set_use_fxaa", "get_use_fxaa");
@@ -3452,6 +3486,10 @@ void Viewport::_bind_methods() {
 	BIND_ENUM_CONSTANT(CLEAR_MODE_ALWAYS);
 	BIND_ENUM_CONSTANT(CLEAR_MODE_NEVER);
 	BIND_ENUM_CONSTANT(CLEAR_MODE_ONLY_NEXT_FRAME);
+
+	BIND_ENUM_CONSTANT(RESOLUTION_SCALE_FILTER_DEFAULT);
+	BIND_ENUM_CONSTANT(RESOLUTION_SCALE_FILTER_LINEAR);
+	BIND_ENUM_CONSTANT(RESOLUTION_SCALE_FILTER_NEAREST);
 }
 
 void Viewport::_subwindow_visibility_changed() {
@@ -3534,6 +3572,10 @@ Viewport::Viewport() {
 	gui.roots_order_dirty = false;
 	gui.mouse_focus = nullptr;
 	gui.last_mouse_focus = nullptr;
+
+	resolution_scale_mix = true;
+	resolution_scale_filter = ResolutionScaleFilter::RESOLUTION_SCALE_FILTER_DEFAULT;
+	resolution_scale_factor = 1.0;
 
 	msaa = MSAA_DISABLED;
 	use_fxaa = false;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -152,6 +152,12 @@ public:
 		CLEAR_MODE_ONLY_NEXT_FRAME
 	};
 
+	enum ResolutionScaleFilter {
+		RESOLUTION_SCALE_FILTER_DEFAULT,
+		RESOLUTION_SCALE_FILTER_LINEAR,
+		RESOLUTION_SCALE_FILTER_NEAREST
+	};
+
 private:
 	friend class ViewportTexture;
 
@@ -204,6 +210,10 @@ private:
 	Size2 size;
 	Rect2 to_screen_rect;
 	bool render_direct_to_screen;
+
+	bool resolution_scale_mix;
+	ResolutionScaleFilter resolution_scale_filter;
+	float resolution_scale_factor;
 
 	RID contact_2d_debug;
 	RID contact_3d_debug_multimesh;
@@ -460,6 +470,13 @@ public:
 	Rect2 get_visible_rect() const;
 	RID get_viewport_rid() const;
 
+	void set_resolution_scale_mix(bool p_mix);
+	bool get_resolution_scale_mix();
+	void set_resolution_scale_filter(ResolutionScaleFilter p_method);
+	ResolutionScaleFilter get_resolution_scale_filter();
+	void set_resolution_scale_factor(float p_factor);
+	float get_resolution_scale_factor();
+
 	void set_world(const Ref<World> &p_world);
 	void set_world_2d(const Ref<World2D> &p_world_2d);
 	Ref<World> get_world() const;
@@ -599,5 +616,6 @@ VARIANT_ENUM_CAST(Viewport::Usage);
 VARIANT_ENUM_CAST(Viewport::DebugDraw);
 VARIANT_ENUM_CAST(Viewport::ClearMode);
 VARIANT_ENUM_CAST(Viewport::RenderInfo);
+VARIANT_ENUM_CAST(Viewport::ResolutionScaleFilter);
 
 #endif // VIEWPORT_H

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -664,6 +664,10 @@ public:
 	virtual void render_target_set_use_debanding(RID p_render_target, bool p_debanding) = 0;
 	virtual void render_target_set_sharpen_intensity(RID p_render_target, float p_intensity) = 0;
 
+	virtual void render_target_set_resolution_scale_mix(RID p_render_target, bool p_mix) = 0;
+	virtual void render_target_set_resolution_scale_filter(RID p_render_target, VS::ResolutionScaleFilter p_method) = 0;
+	virtual void render_target_set_resolution_scale_factor(RID p_render_target, float p_factor) = 0;
+
 	/* CANVAS SHADOW */
 
 	virtual RID canvas_light_shadow_buffer_create(int p_width) = 0;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -481,6 +481,10 @@ public:
 	BIND2(viewport_set_use_arvr, RID, bool)
 	BIND3(viewport_set_size, RID, int, int)
 
+	BIND2(viewport_set_resolution_scale_mix, RID, bool)
+	BIND2(viewport_set_resolution_scale_filter, RID, VS::ResolutionScaleFilter)
+	BIND2(viewport_set_resolution_scale_factor, RID, float)
+
 	BIND2(viewport_set_active, RID, bool)
 	BIND2(viewport_set_parent_viewport, RID, RID)
 

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -408,6 +408,25 @@ void VisualServerViewport::viewport_set_size(RID p_viewport, int p_width, int p_
 	}
 }
 
+void VisualServerViewport::viewport_set_resolution_scale_mix(RID p_viewport, bool p_mix) {
+	Viewport *viewport = viewport_owner.getornull(p_viewport);
+	ERR_FAIL_COND(!viewport);
+
+	VSG::storage->render_target_set_resolution_scale_mix(viewport->render_target, p_mix);
+}
+void VisualServerViewport::viewport_set_resolution_scale_filter(RID p_viewport, VS::ResolutionScaleFilter p_method) {
+	Viewport *viewport = viewport_owner.getornull(p_viewport);
+	ERR_FAIL_COND(!viewport);
+
+	VSG::storage->render_target_set_resolution_scale_filter(viewport->render_target, p_method);
+}
+void VisualServerViewport::viewport_set_resolution_scale_factor(RID p_viewport, float p_factor) {
+	Viewport *viewport = viewport_owner.getornull(p_viewport);
+	ERR_FAIL_COND(!viewport);
+
+	VSG::storage->render_target_set_resolution_scale_factor(viewport->render_target, p_factor);
+}
+
 void VisualServerViewport::viewport_set_active(RID p_viewport, bool p_active) {
 	Viewport *viewport = viewport_owner.getornull(p_viewport);
 	ERR_FAIL_COND(!viewport);

--- a/servers/visual/visual_server_viewport.h
+++ b/servers/visual/visual_server_viewport.h
@@ -153,6 +153,10 @@ public:
 
 	void viewport_set_size(RID p_viewport, int p_width, int p_height);
 
+	void viewport_set_resolution_scale_mix(RID p_viewport, bool p_mix);
+	void viewport_set_resolution_scale_filter(RID p_viewport, VS::ResolutionScaleFilter p_method);
+	void viewport_set_resolution_scale_factor(RID p_viewport, float p_factor);
+
 	void viewport_attach_to_screen(RID p_viewport, const Rect2 &p_rect = Rect2(), int p_screen = 0);
 	void viewport_set_render_direct_to_screen(RID p_viewport, bool p_enable);
 	void viewport_detach(RID p_viewport);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -389,6 +389,10 @@ public:
 
 	FUNC3(viewport_set_size, RID, int, int)
 
+	FUNC2(viewport_set_resolution_scale_mix, RID, bool)
+	FUNC2(viewport_set_resolution_scale_filter, RID, VS::ResolutionScaleFilter)
+	FUNC2(viewport_set_resolution_scale_factor, RID, float)
+
 	FUNC2(viewport_set_active, RID, bool)
 	FUNC2(viewport_set_parent_viewport, RID, RID)
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2674,6 +2674,12 @@ VisualServer::VisualServer() {
 
 	GLOBAL_DEF_RST("rendering/quality/shading/use_physical_light_attenuation", false);
 
+	GLOBAL_DEF("rendering/quality/3d/resolution_scale", 1.0);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/3d/resolution_scale", PropertyInfo(Variant::REAL, "rendering/quality/3d/resolution_scale", PROPERTY_HINT_RANGE, "0.1,1.0,0.01"));
+
+	GLOBAL_DEF("rendering/quality/3d/resolution_scale_filter_method", 1);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/3d/resolution_scale_filter_method", PropertyInfo(Variant::INT, "rendering/quality/3d/resolution_scale_filter_method", PROPERTY_HINT_ENUM, "Nearest, Linear"));
+
 	GLOBAL_DEF("rendering/quality/depth_prepass/enable", true);
 	GLOBAL_DEF("rendering/quality/depth_prepass/disable_for_vendors", "PowerVR,Mali,Adreno,Apple");
 

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -652,6 +652,16 @@ public:
 	virtual void viewport_set_active(RID p_viewport, bool p_active) = 0;
 	virtual void viewport_set_parent_viewport(RID p_viewport, RID p_parent_viewport) = 0;
 
+	enum ResolutionScaleFilter {
+		DEFAULT,
+		LINEAR,
+		NEAREST
+	};
+
+	virtual void viewport_set_resolution_scale_mix(RID p_viewport, bool p_mix) = 0;
+	virtual void viewport_set_resolution_scale_filter(RID p_viewport, ResolutionScaleFilter p_method) = 0;
+	virtual void viewport_set_resolution_scale_factor(RID p_viewport, float p_factor) = 0;
+
 	virtual void viewport_attach_to_screen(RID p_viewport, const Rect2 &p_rect = Rect2(), int p_screen = 0) = 0;
 	virtual void viewport_set_render_direct_to_screen(RID p_viewport, bool p_enable) = 0;
 	virtual void viewport_detach(RID p_viewport) = 0;


### PR DESCRIPTION
This makes it possible to dynamically adjust the rendering resolution of 3D content. 2D content and UI stuff are still rendered at full resolution.

The user can adjust the target resolution with the `Rendering/Quality/3D/Lower Resolution` project setting. 

The editor displaying a scene at 1/4 the resolution
![image](https://user-images.githubusercontent.com/6329420/225271236-becc112c-415c-421b-b823-7e9942e9b357.png)


---
This PR was sponsored by Ramatak with 💚