### PR TITLE
Fix GLES3 rendering on Android studio emulator

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -300,12 +300,13 @@ void RasterizerGLES3::_blit_render_target_to_screen(RID p_render_target, Display
 	}
 
 	GLuint read_fbo = 0;
+	glGenFramebuffers(1, &read_fbo);
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, read_fbo);
+
 	if (rt->view_count > 1) {
-		glGenFramebuffers(1, &read_fbo);
-		glBindFramebuffer(GL_READ_FRAMEBUFFER, read_fbo);
 		glFramebufferTextureLayer(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, rt->color, 0, p_layer);
 	} else {
-		glBindFramebuffer(GL_READ_FRAMEBUFFER, rt->fbo);
+		glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->color, 0);
 	}
 
 	glReadBuffer(GL_COLOR_ATTACHMENT0);


### PR DESCRIPTION
Use a temporary framebuffer for screen copy from rendertarget to screen.

This solves GLES3 rendering in android studio emulator (before this change there is just a black screen)

Based on discussion in:
https://github.com/godotengine/godot/issues/74828

*Bugsquad edit:*
- Fixes #74828.