### PR TITLE
Fixed Whitescreen Issue in GLES2.0 Glow Setting

### DIFF
--- a/drivers/gles2/shaders/tonemap.glsl
+++ b/drivers/gles2/shaders/tonemap.glsl
@@ -237,10 +237,10 @@ vec4 apply_fxaa(vec4 color, vec2 uv_interp, vec2 pixel_size) {
 	const float FXAA_SPAN_MAX = 8.0;
 	const vec3 luma = vec3(0.299, 0.587, 0.114);
 
-	vec4 rgbNW = textureLod(source, uv_interp + vec2(-0.5, -0.5) * pixel_size, 0.0);
-	vec4 rgbNE = textureLod(source, uv_interp + vec2(0.5, -0.5) * pixel_size, 0.0);
-	vec4 rgbSW = textureLod(source, uv_interp + vec2(-0.5, 0.5) * pixel_size, 0.0);
-	vec4 rgbSE = textureLod(source, uv_interp + vec2(0.5, 0.5) * pixel_size, 0.0);
+	vec4 rgbNW = texture2DLod(source, uv_interp + vec2(-0.5, -0.5) * pixel_size, 0.0);
+	vec4 rgbNE = texture2DLod(source, uv_interp + vec2(0.5, -0.5) * pixel_size, 0.0);
+	vec4 rgbSW = texture2DLod(source, uv_interp + vec2(-0.5, 0.5) * pixel_size, 0.0);
+	vec4 rgbSE = texture2DLod(source, uv_interp + vec2(0.5, 0.5) * pixel_size, 0.0);
 	vec3 rgbM = color.rgb;
 
 #ifdef DISABLE_ALPHA


### PR DESCRIPTION
Fixes #74932 
Replaced textureLod with texture2DLod in the tonemapping.glsl shader file