### PR TITLE
Fix typos and inconsistencies in classref

### DIFF
--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -237,7 +237,7 @@
 			<return type="bool" />
 			<param index="0" name="right" type="AABB" />
 			<description>
-				Returns [code]true[/code] if the vectors are not equal.
+				Returns [code]true[/code] if the AABBs are not equal.
 				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>

--- a/doc/classes/CPUParticles3D.xml
+++ b/doc/classes/CPUParticles3D.xml
@@ -294,7 +294,7 @@
 			Particle system's running speed scaling ratio. A value of [code]0[/code] can be used to pause the particles.
 		</member>
 		<member name="split_scale" type="bool" setter="set_split_scale" getter="get_split_scale" default="false">
-			If set to true, three different scale curves can be specified, one per scale axis.
+			If set to [code]true[/code], three different scale curves can be specified, one per scale axis.
 		</member>
 		<member name="spread" type="float" setter="set_spread" getter="get_spread" default="45.0">
 			Each particle's initial direction range from [code]+spread[/code] to [code]-spread[/code] degrees. Applied to X/Z plane and Y/Z planes.

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -952,7 +952,7 @@
 			<return type="void" />
 			<param index="0" name="image" type="Image" />
 			<description>
-				Sets the window icon (usually displayed in the top-left corner) in the operating system's [i]native[/i] format. To use icons in the operating system's native format, use [method set_native_icon] instead.
+				Sets the window icon (usually displayed in the top-left corner) with an [Image]. To use icons in the operating system's native format, use [method set_native_icon] instead.
 			</description>
 		</method>
 		<method name="set_native_icon">
@@ -1046,8 +1046,8 @@
 			<param index="1" name="callable" type="Callable" />
 			<description>
 				Adds a callback, which is called when the utterance has started, finished, canceled or reached a text boundary.
-				- [constant TTS_UTTERANCE_STARTED], [constant TTS_UTTERANCE_ENDED], and [constant TTS_UTTERANCE_CANCELED] callable's method should take one [int] parameter, the utterance id.
-				- [constant TTS_UTTERANCE_BOUNDARY] callable's method should take two [int] parameters, the index of the character and the utterance id.
+				- [constant TTS_UTTERANCE_STARTED], [constant TTS_UTTERANCE_ENDED], and [constant TTS_UTTERANCE_CANCELED] callable's method should take one [int] parameter, the utterance ID.
+				- [constant TTS_UTTERANCE_BOUNDARY] callable's method should take two [int] parameters, the index of the character and the utterance ID.
 				[b]Note:[/b] The granularity of the boundary callbacks is engine dependent.
 				[b]Note:[/b] This method is implemented on Android, iOS, Web, Linux (X11), macOS, and Windows.
 			</description>

--- a/doc/classes/EditorVCSInterface.xml
+++ b/doc/classes/EditorVCSInterface.xml
@@ -124,7 +124,7 @@
 			<param index="0" name="remote" type="String" />
 			<param index="1" name="force" type="bool" />
 			<description>
-				Pushes changes to the [code]remote[/code]. Optionally, if [code]force[/code] is set to true, a force push will override the change history already present on the remote.
+				Pushes changes to the [param remote]. If [param force] is [code]true[/code], a force push will override the change history already present on the remote.
 			</description>
 		</method>
 		<method name="_remove_branch" qualifiers="virtual">

--- a/doc/classes/SkeletonModification2DLookAt.xml
+++ b/doc/classes/SkeletonModification2DLookAt.xml
@@ -81,7 +81,7 @@
 			The [Bone2D] node that the modification will operate on.
 		</member>
 		<member name="bone_index" type="int" setter="set_bone_index" getter="get_bone_index" default="-1">
-			The index of the [Bone2D] node that the modification will oeprate on.
+			The index of the [Bone2D] node that the modification will operate on.
 		</member>
 		<member name="target_nodepath" type="NodePath" setter="set_target_node" getter="get_target_node" default="NodePath(&quot;&quot;)">
 			The NodePath to the node that is the target for the LookAt modification. This node is what the modification will rotate the [Bone2D] to.

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -155,7 +155,7 @@
 			<return type="int" />
 			<param index="0" name="layer_index" type="int" />
 			<description>
-				Returns the navigation layers (as in the Navigation server) of the gives TileSet navigation layer.
+				Returns the navigation layers (as in the Navigation server) of the given TileSet navigation layer.
 			</description>
 		</method>
 		<method name="get_navigation_layers_count" qualifiers="const">
@@ -522,7 +522,7 @@
 			<param index="0" name="layer_index" type="int" />
 			<param index="1" name="layers" type="int" />
 			<description>
-				Sets the navigation layers (as in the navigation server) for navigation regions is the given TileSet navigation layer.
+				Sets the navigation layers (as in the navigation server) for navigation regions in the given TileSet navigation layer.
 			</description>
 		</method>
 		<method name="set_occlusion_layer_light_mask">
@@ -538,7 +538,7 @@
 			<param index="0" name="layer_index" type="int" />
 			<param index="1" name="sdf_collision" type="bool" />
 			<description>
-				Enables or disables sdf collision for occluders in the given TileSet occlusion layer.
+				Enables or disables SDF collision for occluders in the given TileSet occlusion layer.
 			</description>
 		</method>
 		<method name="set_physics_layer_collision_layer">

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -148,8 +148,7 @@
 			<param index="0" name="angle" type="float" />
 			<description>
 				Returns a copy of the transform rotated by the given [param angle] (in radians).
-				This method is an optimized version of multiplying the given transform [code]X[/code]
-				with a corresponding rotation transform [code]R[/code] from the left, i.e., [code]R * X[/code].
+				This method is an optimized version of multiplying the given transform [code]X[/code] with a corresponding rotation transform [code]R[/code] from the left, i.e., [code]R * X[/code].
 				This can be seen as transforming with respect to the global/parent frame.
 			</description>
 		</method>
@@ -158,8 +157,7 @@
 			<param index="0" name="angle" type="float" />
 			<description>
 				Returns a copy of the transform rotated by the given [param angle] (in radians).
-				This method is an optimized version of multiplying the given transform [code]X[/code]
-				with a corresponding rotation transform [code]R[/code] from the right, i.e., [code]X * R[/code].
+				This method is an optimized version of multiplying the given transform [code]X[/code] with a corresponding rotation transform [code]R[/code] from the right, i.e., [code]X * R[/code].
 				This can be seen as transforming with respect to the local frame.
 			</description>
 		</method>
@@ -168,8 +166,7 @@
 			<param index="0" name="scale" type="Vector2" />
 			<description>
 				Returns a copy of the transform scaled by the given [param scale] factor.
-				This method is an optimized version of multiplying the given transform [code]X[/code]
-				with a corresponding scaling transform [code]S[/code] from the left, i.e., [code]S * X[/code].
+				This method is an optimized version of multiplying the given transform [code]X[/code] with a corresponding scaling transform [code]S[/code] from the left, i.e., [code]S * X[/code].
 				This can be seen as transforming with respect to the global/parent frame.
 			</description>
 		</method>
@@ -178,8 +175,7 @@
 			<param index="0" name="scale" type="Vector2" />
 			<description>
 				Returns a copy of the transform scaled by the given [param scale] factor.
-				This method is an optimized version of multiplying the given transform [code]X[/code]
-				with a corresponding scaling transform [code]S[/code] from the right, i.e., [code]X * S[/code].
+				This method is an optimized version of multiplying the given transform [code]X[/code] with a corresponding scaling transform [code]S[/code] from the right, i.e., [code]X * S[/code].
 				This can be seen as transforming with respect to the local frame.
 			</description>
 		</method>
@@ -188,8 +184,7 @@
 			<param index="0" name="offset" type="Vector2" />
 			<description>
 				Returns a copy of the transform translated by the given [param offset].
-				This method is an optimized version of multiplying the given transform [code]X[/code]
-				with a corresponding translation transform [code]T[/code] from the left, i.e., [code]T * X[/code].
+				This method is an optimized version of multiplying the given transform [code]X[/code] with a corresponding translation transform [code]T[/code] from the left, i.e., [code]T * X[/code].
 				This can be seen as transforming with respect to the global/parent frame.
 			</description>
 		</method>
@@ -198,8 +193,7 @@
 			<param index="0" name="offset" type="Vector2" />
 			<description>
 				Returns a copy of the transform translated by the given [param offset].
-				This method is an optimized version of multiplying the given transform [code]X[/code]
-				with a corresponding translation transform [code]T[/code] from the right, i.e., [code]X * T[/code].
+				This method is an optimized version of multiplying the given transform [code]X[/code] with a corresponding translation transform [code]T[/code] from the right, i.e., [code]X * T[/code].
 				This can be seen as transforming with respect to the local frame.
 			</description>
 		</method>

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -111,8 +111,7 @@
 			<description>
 				Returns a copy of the transform rotated around the given [param axis] by the given [param angle] (in radians).
 				The [param axis] must be a normalized vector.
-				This method is an optimized version of multiplying the given transform [code]X[/code]
-				with a corresponding rotation transform [code]R[/code] from the left, i.e., [code]R * X[/code].
+				This method is an optimized version of multiplying the given transform [code]X[/code] with a corresponding rotation transform [code]R[/code] from the left, i.e., [code]R * X[/code].
 				This can be seen as transforming with respect to the global/parent frame.
 			</description>
 		</method>
@@ -123,8 +122,7 @@
 			<description>
 				Returns a copy of the transform rotated around the given [param axis] by the given [param angle] (in radians).
 				The [param axis] must be a normalized vector.
-				This method is an optimized version of multiplying the given transform [code]X[/code]
-				with a corresponding rotation transform [code]R[/code] from the right, i.e., [code]X * R[/code].
+				This method is an optimized version of multiplying the given transform [code]X[/code] with a corresponding rotation transform [code]R[/code] from the right, i.e., [code]X * R[/code].
 				This can be seen as transforming with respect to the local frame.
 			</description>
 		</method>
@@ -133,8 +131,7 @@
 			<param index="0" name="scale" type="Vector3" />
 			<description>
 				Returns a copy of the transform scaled by the given [param scale] factor.
-				This method is an optimized version of multiplying the given transform [code]X[/code]
-				with a corresponding scaling transform [code]S[/code] from the left, i.e., [code]S * X[/code].
+				This method is an optimized version of multiplying the given transform [code]X[/code] with a corresponding scaling transform [code]S[/code] from the left, i.e., [code]S * X[/code].
 				This can be seen as transforming with respect to the global/parent frame.
 			</description>
 		</method>
@@ -143,8 +140,7 @@
 			<param index="0" name="scale" type="Vector3" />
 			<description>
 				Returns a copy of the transform scaled by the given [param scale] factor.
-				This method is an optimized version of multiplying the given transform [code]X[/code]
-				with a corresponding scaling transform [code]S[/code] from the right, i.e., [code]X * S[/code].
+				This method is an optimized version of multiplying the given transform [code]X[/code] with a corresponding scaling transform [code]S[/code] from the right, i.e., [code]X * S[/code].
 				This can be seen as transforming with respect to the local frame.
 			</description>
 		</method>
@@ -153,8 +149,7 @@
 			<param index="0" name="offset" type="Vector3" />
 			<description>
 				Returns a copy of the transform translated by the given [param offset].
-				This method is an optimized version of multiplying the given transform [code]X[/code]
-				with a corresponding translation transform [code]T[/code] from the left, i.e., [code]T * X[/code].
+				This method is an optimized version of multiplying the given transform [code]X[/code] with a corresponding translation transform [code]T[/code] from the left, i.e., [code]T * X[/code].
 				This can be seen as transforming with respect to the global/parent frame.
 			</description>
 		</method>
@@ -163,8 +158,7 @@
 			<param index="0" name="offset" type="Vector3" />
 			<description>
 				Returns a copy of the transform translated by the given [param offset].
-				This method is an optimized version of multiplying the given transform [code]X[/code]
-				with a corresponding translation transform [code]T[/code] from the right, i.e., [code]X * T[/code].
+				This method is an optimized version of multiplying the given transform [code]X[/code] with a corresponding translation transform [code]T[/code] from the right, i.e., [code]X * T[/code].
 				This can be seen as transforming with respect to the local frame.
 			</description>
 		</method>

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -156,7 +156,7 @@
 			<param index="2" name="n" type="int" />
 			<param index="3" name="context" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns the current locale's translation for the given message (key), plural_message and context.
+				Returns the current locale's translation for the given message (key), plural message and context.
 				The number [param n] is the number or quantity of the plural object. It will be used to guide the translation system to fetch the correct plural form for the selected language.
 			</description>
 		</method>

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -143,7 +143,7 @@
 			<param index="2" name="post_b" type="Vector2" />
 			<param index="3" name="weight" type="float" />
 			<description>
-				Cubically interpolates between this vector and [param b] using [param pre_a] and [param post_b] as handles, and returns the result at position [param weight]. [param weight] is on the range of 0.0 to 1.0, representing the amount of interpolation.
+				Performs a cubic interpolation between this vector and [param b] using [param pre_a] and [param post_b] as handles, and returns the result at position [param weight]. [param weight] is on the range of 0.0 to 1.0, representing the amount of interpolation.
 			</description>
 		</method>
 		<method name="cubic_interpolate_in_time" qualifiers="const">
@@ -156,7 +156,7 @@
 			<param index="5" name="pre_a_t" type="float" />
 			<param index="6" name="post_b_t" type="float" />
 			<description>
-				Cubically interpolates between this vector and [param b] using [param pre_a] and [param post_b] as handles, and returns the result at position [param weight]. [param weight] is on the range of 0.0 to 1.0, representing the amount of interpolation.
+				Performs a cubic interpolation between this vector and [param b] using [param pre_a] and [param post_b] as handles, and returns the result at position [param weight]. [param weight] is on the range of 0.0 to 1.0, representing the amount of interpolation.
 				It can perform smoother interpolation than [code]cubic_interpolate()[/code] by the time values.
 			</description>
 		</method>
@@ -254,7 +254,7 @@
 			<param index="0" name="to" type="Vector2" />
 			<param index="1" name="weight" type="float" />
 			<description>
-				Returns the result of the linear interpolation between this vector and [param to] by amount [param weight]. [param weight] is on the range of 0.0 to 1.0, representing the amount of interpolation.
+				Returns the result of the linear interpolation between this vector and [param to] by amount [param weight]. [param weight] is on the range of [code]0.0[/code] to [code]1.0[/code], representing the amount of interpolation.
 			</description>
 		</method>
 		<method name="limit_length" qualifiers="const">
@@ -287,7 +287,7 @@
 		<method name="normalized" qualifiers="const">
 			<return type="Vector2" />
 			<description>
-				Returns a new vector scaled to unit length. Equivalent to [code]v / v.length()[/code].
+				Returns the result of scaling the vector to unit length. Equivalent to [code]v / v.length()[/code]. See also [method is_normalized].
 			</description>
 		</method>
 		<method name="orthogonal" qualifiers="const">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -222,7 +222,7 @@
 			<param index="0" name="to" type="Vector3" />
 			<param index="1" name="weight" type="float" />
 			<description>
-				Returns the result of the linear interpolation between this vector and [param to] by amount [param weight]. [param weight] is on the range of 0.0 to 1.0, representing the amount of interpolation.
+				Returns the result of the linear interpolation between this vector and [param to] by amount [param weight]. [param weight] is on the range of [code]0.0[/code] to [code]1.0[/code], representing the amount of interpolation.
 			</description>
 		</method>
 		<method name="limit_length" qualifiers="const">
@@ -255,7 +255,7 @@
 		<method name="normalized" qualifiers="const">
 			<return type="Vector3" />
 			<description>
-				Returns the vector scaled to unit length. Equivalent to [code]v / v.length()[/code]. See also [method is_normalized].
+				Returns the result of scaling the vector to unit length. Equivalent to [code]v / v.length()[/code]. See also [method is_normalized].
 			</description>
 		</method>
 		<method name="octahedron_decode" qualifiers="static">

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -190,7 +190,7 @@
 		<method name="normalized" qualifiers="const">
 			<return type="Vector4" />
 			<description>
-				Returns the result of scaling the vector to unit length. Equivalent to [code]v / v.length()[/code].
+				Returns the result of scaling the vector to unit length. Equivalent to [code]v / v.length()[/code]. See also [method is_normalized].
 			</description>
 		</method>
 		<method name="posmod" qualifiers="const">

--- a/modules/websocket/doc_classes/WebSocketMultiplayerPeer.xml
+++ b/modules/websocket/doc_classes/WebSocketMultiplayerPeer.xml
@@ -25,7 +25,7 @@
 			<param index="1" name="bind_address" type="String" default="&quot;*&quot;" />
 			<param index="2" name="tls_server_options" type="TLSOptions" default="null" />
 			<description>
-				Starts a new multiplayer server listening on the given [param port]. You can optionally specify a [param bind_address], and provide valiid [param tls_server_options] to use TLS. See [method TLSOptions.server].
+				Starts a new multiplayer server listening on the given [param port]. You can optionally specify a [param bind_address], and provide valid [param tls_server_options] to use TLS. See [method TLSOptions.server].
 			</description>
 		</method>
 		<method name="get_peer" qualifiers="const">


### PR DESCRIPTION
* Fixes simple typos.
* Wraps `true` with `[code]`.
* Capitalize `ID` and `SDF`.
* Fixes unchanged description for `DisplayServer.set_icon()`, was copied from `set_native_icon()`.
* Removes hardcoded line wraps in `Transform{2,3}D` method descriptions.
* Makes description of `normalized()`, `lerp()`, and `cubic_interpolate()` consistent across `Vector{2,3,4}`.