### PR TITLE
[3.x] Add Color + alpha constructor for Color

### DIFF
--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -1103,11 +1103,8 @@ struct _VariantCall {
 	}
 
 	static void Color_init3(Variant &r_ret, const Variant **p_args) {
-		r_ret = Color::html(*p_args[0]);
-	}
-
-	static void Color_init4(Variant &r_ret, const Variant **p_args) {
-		r_ret = Color::hex(*p_args[0]);
+		Color c = *p_args[0];
+		r_ret = Color(c.r, c.g, c.b, *p_args[1]);
 	}
 
 	static void AABB_init1(Variant &r_ret, const Variant **p_args) {
@@ -2212,6 +2209,7 @@ void register_variant_methods() {
 
 	_VariantCall::add_constructor(_VariantCall::Color_init1, Variant::COLOR, "r", Variant::REAL, "g", Variant::REAL, "b", Variant::REAL, "a", Variant::REAL);
 	_VariantCall::add_constructor(_VariantCall::Color_init2, Variant::COLOR, "r", Variant::REAL, "g", Variant::REAL, "b", Variant::REAL);
+	_VariantCall::add_constructor(_VariantCall::Color_init3, Variant::COLOR, "from", Variant::COLOR, "alpha", Variant::REAL);
 
 	_VariantCall::add_constructor(_VariantCall::AABB_init1, Variant::AABB, "position", Variant::VECTOR3, "size", Variant::VECTOR3);
 

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -42,6 +42,17 @@
 		</method>
 		<method name="Color">
 			<return type="Color" />
+			<argument index="0" name="from" type="Color" />
+			<argument index="1" name="alpha" type="float" />
+			<description>
+				Constructs a color from the existing color, with [member a] set to the given [code]alpha[/code] value.
+				[codeblock]
+				var red = Color(Color.red, 0.2) # 20% opaque red.
+				[/codeblock]
+			</description>
+		</method>
+		<method name="Color">
+			<return type="Color" />
 			<argument index="0" name="r" type="float" />
 			<argument index="1" name="g" type="float" />
 			<argument index="2" name="b" type="float" />


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/6492

Note: the existing `Color_init3` and `Color_init4` seems unused.