### PR TITLE
Fix error when opening Inspector's dots menu

### DIFF
--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -298,8 +298,7 @@ void InspectorDock::_prepare_resource_extra_popup() {
 	popup->set_item_disabled(popup->get_item_index(RESOURCE_EDIT_CLIPBOARD), r.is_null());
 
 	Ref<Resource> current_res = _get_current_resource();
-	ERR_FAIL_COND(current_res.is_null());
-	popup->set_item_disabled(popup->get_item_index(RESOURCE_SHOW_IN_FILESYSTEM), current_res->is_built_in());
+	popup->set_item_disabled(popup->get_item_index(RESOURCE_SHOW_IN_FILESYSTEM), current_res.is_null() || current_res->is_built_in());
 }
 
 Ref<Resource> InspectorDock::_get_current_resource() const {


### PR DESCRIPTION
When the inspector is empty, opening the "extra resource options" menu produces an error:

> Condition "current_res.is_null()" is true.

Opening the mneu with no current resource is valid use case, so `ERR_FAIL_COND` should not be used.

