### PR TITLE
Fix AudioEffectRecord circular reference

### DIFF
--- a/servers/audio/effects/audio_effect_record.cpp
+++ b/servers/audio/effects/audio_effect_record.cpp
@@ -72,13 +72,7 @@ bool AudioEffectRecordInstance::process_silence() const {
 
 void AudioEffectRecordInstance::_io_thread_process() {
 	while (is_recording) {
-		//Check: The current recording has been requested to stop
-		if (!base->recording_active) {
-			is_recording = false;
-		}
-
 		_update_buffer();
-
 		if (is_recording) {
 			//Wait to avoid too much busy-wait
 			OS::get_singleton()->delay_usec(500);
@@ -120,19 +114,15 @@ void AudioEffectRecordInstance::init() {
 }
 
 void AudioEffectRecordInstance::finish() {
+	is_recording = false;
 	if (io_thread.is_started()) {
 		io_thread.wait_to_finish();
 	}
 }
 
-AudioEffectRecordInstance::~AudioEffectRecordInstance() {
-	finish();
-}
-
 Ref<AudioEffectInstance> AudioEffectRecord::instantiate() {
 	Ref<AudioEffectRecordInstance> ins;
 	ins.instantiate();
-	ins->base = Ref<AudioEffectRecord>(this);
 	ins->is_recording = false;
 
 	//Re-using the buffer size calculations from audio_effect_delay.cpp
@@ -158,16 +148,19 @@ Ref<AudioEffectInstance> AudioEffectRecord::instantiate() {
 	ins->ring_buffer_read_pos = 0;
 
 	ensure_thread_stopped();
-	current_instance = ins;
-	if (recording_active) {
+	bool is_currently_recording = false;
+	if (current_instance != nullptr) {
+		is_currently_recording = current_instance->is_recording;
+	}
+	if (is_currently_recording) {
 		ins->init();
 	}
+	current_instance = ins;
 
 	return ins;
 }
 
 void AudioEffectRecord::ensure_thread_stopped() {
-	recording_active = false;
 	if (current_instance != nullptr) {
 		current_instance->finish();
 	}
@@ -177,20 +170,23 @@ void AudioEffectRecord::set_recording_active(bool p_record) {
 	if (p_record) {
 		if (current_instance == nullptr) {
 			WARN_PRINT("Recording should not be set as active before Godot has initialized.");
-			recording_active = false;
 			return;
 		}
-
 		ensure_thread_stopped();
-		recording_active = true;
 		current_instance->init();
 	} else {
-		recording_active = false;
+		if (current_instance != nullptr) {
+			current_instance->is_recording = false;
+		}
 	}
 }
 
 bool AudioEffectRecord::is_recording_active() const {
-	return recording_active;
+	if (current_instance == nullptr) {
+		return false;
+	} else {
+		return current_instance->is_recording;
+	}
 }
 
 void AudioEffectRecord::set_format(AudioStreamWAV::Format p_format) {
@@ -292,5 +288,8 @@ void AudioEffectRecord::_bind_methods() {
 
 AudioEffectRecord::AudioEffectRecord() {
 	format = AudioStreamWAV::FORMAT_16_BITS;
-	recording_active = false;
+}
+
+AudioEffectRecord::~AudioEffectRecord() {
+	ensure_thread_stopped();
 }

--- a/servers/audio/effects/audio_effect_record.h
+++ b/servers/audio/effects/audio_effect_record.h
@@ -44,7 +44,6 @@ class AudioEffectRecord;
 class AudioEffectRecordInstance : public AudioEffectInstance {
 	GDCLASS(AudioEffectRecordInstance, AudioEffectInstance);
 	friend class AudioEffectRecord;
-	Ref<AudioEffectRecord> base;
 
 	bool is_recording;
 	Thread io_thread;
@@ -68,9 +67,6 @@ public:
 	void finish();
 	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) override;
 	virtual bool process_silence() const override;
-
-	AudioEffectRecordInstance() {}
-	~AudioEffectRecordInstance();
 };
 
 class AudioEffectRecord : public AudioEffect {
@@ -82,7 +78,6 @@ class AudioEffectRecord : public AudioEffect {
 		IO_BUFFER_SIZE_MS = 1500
 	};
 
-	bool recording_active;
 	Ref<AudioEffectRecordInstance> current_instance;
 
 	AudioStreamWAV::Format format;
@@ -99,8 +94,8 @@ public:
 	void set_format(AudioStreamWAV::Format p_format);
 	AudioStreamWAV::Format get_format() const;
 	Ref<AudioStreamWAV> get_recording() const;
-
 	AudioEffectRecord();
+	~AudioEffectRecord();
 };
 
 #endif // AUDIO_EFFECT_RECORD_H


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Currently `AudioEffectRecord` creates an `AudioEffectRecordInstance`, both of which reference each other which prevents both objects from being freed.

~This patch makes `AudioEffectRecordInstance` hold a weak reference to `AudioEffectRecord` to prevent this circular reference.~

This patch removes the reference from `AudioEffectRecordInstance` altogether.

Fixes #34495