### PR TITLE
Improve function detection to avoid accidental conversion

### DIFF
--- a/editor/project_converter_3_to_4.h
+++ b/editor/project_converter_3_to_4.h
@@ -109,6 +109,7 @@ class ProjectConverter3To4 {
 	String connect_arguments(const Vector<String> &line, int from, int to = -1) const;
 	String get_starting_space(const String &line) const;
 	String get_object_of_execution(const String &line) const;
+	bool contains_function_call(String &line, String function) const;
 
 	String line_formatter(int current_line, String from, String to, String line);
 	String simple_line_formatter(int current_line, String old_line, String line);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/74650

This PR improves the function detection in the project converter by checking if the function really is standalone and not part of a method or similar.
E.g. when checking and converting a function like `connect(`, we do not want to detect and convert a function like `reconnect(`.

We achieve this by checking the previous character when the function name is detected in a line.
To recognize the function as standalone and not as part of a name, the following previous characters are checked:
- `A-Za-z0-9` -> `econnect` or `9connect` - not a function call
- `_` -> `_connect` - not a function call
- `$`-> `$connect` - not a function call
- `@`-> `@connect` - not a function call

Or in other words:
- `connect()` is a function call
- `   connect()` is a function call
- `object.connect()` is a function call
