### PR TITLE
Add option to toggle visibility of Position gizmos in 2D editor, organize existing options

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -126,7 +126,9 @@ private:
 		SHOW_GUIDES,
 		SHOW_ORIGIN,
 		SHOW_VIEWPORT,
-		SHOW_EDIT_LOCKS,
+		SHOW_POSITION_GIZMOS,
+		SHOW_LOCK_GIZMOS,
+		SHOW_GROUP_GIZMOS,
 		SHOW_TRANSFORMATION_GIZMOS,
 		LOCK_SELECTED,
 		UNLOCK_SELECTED,
@@ -209,7 +211,9 @@ private:
 	bool show_origin = true;
 	bool show_viewport = true;
 	bool show_helpers = false;
-	bool show_edit_locks = true;
+	bool show_position_gizmos = true;
+	bool show_lock_gizmos = true;
+	bool show_group_gizmos = true;
 	bool show_transformation_gizmos = true;
 
 	real_t zoom = 1.0;
@@ -331,6 +335,7 @@ private:
 	MenuButton *view_menu = nullptr;
 	PopupMenu *grid_menu = nullptr;
 	PopupMenu *theme_menu = nullptr;
+	PopupMenu *gizmos_menu = nullptr;
 	HBoxContainer *animation_hb = nullptr;
 	MenuButton *animation_menu = nullptr;
 


### PR DESCRIPTION
This change lets you hide Position gizmos on 2D nodes
allowing you to make clean screenshots in the editor without crosses everywhere, among other things.

In order to avoid clutter in 2D > View menu, "Show Group And Lock Icons" and "Show Gizmos"
were moved to "Gizmos" submenu along with the newly added option.

Before:

![4](https://user-images.githubusercontent.com/127793256/225105554-4b6f5230-c216-4913-839e-169112dee29d.png)

After:

https://user-images.githubusercontent.com/127793256/225758780-4f5ce8be-785f-499a-8c9c-6ce9dac04b5c.mp4

Related proposal: https://github.com/godotengine/godot-proposals/issues/6344

show_edit_locks (which actually referred to showing locks _and groups_)
was renamed to show_lock_gizmos to be consistent with the existing show_transformation_gizmos;
and was decoupled from group gizmos.

I would like have this in 3.x as well.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
