### PR TITLE
Fix auto-translations in editor

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1378,7 +1378,12 @@ String Object::tr(const StringName &p_message, const StringName &p_context) cons
 	if (!_can_translate || !TranslationServer::get_singleton()) {
 		return p_message;
 	}
-	return TranslationServer::get_singleton()->translate(p_message, p_context);
+
+	if (Engine::get_singleton()->is_editor_hint()) {
+		return TranslationServer::get_singleton()->tool_translate(p_message, p_context);
+	} else {
+		return TranslationServer::get_singleton()->translate(p_message, p_context);
+	}
 }
 
 String Object::tr_n(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
@@ -1389,7 +1394,12 @@ String Object::tr_n(const StringName &p_message, const StringName &p_message_plu
 		}
 		return p_message_plural;
 	}
-	return TranslationServer::get_singleton()->translate_plural(p_message, p_message_plural, p_n, p_context);
+
+	if (Engine::get_singleton()->is_editor_hint()) {
+		return TranslationServer::get_singleton()->tool_translate_plural(p_message, p_message_plural, p_n, p_context);
+	} else {
+		return TranslationServer::get_singleton()->translate_plural(p_message, p_message_plural, p_n, p_context);
+	}
 }
 
 void Object::_clear_internal_resource_paths(const Variant &p_var) {

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2912,6 +2912,13 @@ void Control::_notification(int p_notification) {
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
+#ifdef TOOLS_ENABLED
+			if (is_part_of_edited_scene()) {
+				// Don't translate Controls on scene when inside editor.
+				set_message_translation(false);
+				notification(NOTIFICATION_TRANSLATION_CHANGED);
+			}
+#endif
 			notification(NOTIFICATION_THEME_CHANGED);
 		} break;
 

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -249,9 +249,11 @@ void MenuBar::_update_submenu(const String &p_menu_name, PopupMenu *p_child) {
 }
 
 bool MenuBar::is_native_menu() const {
-	if (Engine::get_singleton()->is_editor_hint() && is_inside_tree() && get_tree()->get_edited_scene_root() && (get_tree()->get_edited_scene_root()->is_ancestor_of(this) || get_tree()->get_edited_scene_root() == this)) {
+#ifdef TOOLS_ENABLED
+	if (is_part_of_edited_scene()) {
 		return false;
 	}
+#endif
 
 	return (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_GLOBAL_MENU) && is_native);
 }

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2073,6 +2073,11 @@ bool Node::is_property_pinned(const StringName &p_property) const {
 StringName Node::get_property_store_alias(const StringName &p_property) const {
 	return p_property;
 }
+
+bool Node::is_part_of_edited_scene() const {
+	return Engine::get_singleton()->is_editor_hint() && is_inside_tree() && get_tree()->get_edited_scene_root() &&
+			(get_tree()->get_edited_scene_root() == this || get_tree()->get_edited_scene_root()->is_ancestor_of(this));
+}
 #endif
 
 void Node::get_storable_properties(HashSet<StringName> &r_storable_properties) const {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -382,6 +382,7 @@ public:
 	void set_property_pinned(const String &p_property, bool p_pinned);
 	bool is_property_pinned(const StringName &p_property) const;
 	virtual StringName get_property_store_alias(const StringName &p_property) const;
+	bool is_part_of_edited_scene() const;
 #endif
 	void get_storable_properties(HashSet<StringName> &r_storable_properties) const;
 

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -35,7 +35,7 @@ void Timer::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			if (autostart) {
 #ifdef TOOLS_ENABLED
-				if (Engine::get_singleton()->is_editor_hint() && get_tree()->get_edited_scene_root() && (get_tree()->get_edited_scene_root() == this || get_tree()->get_edited_scene_root()->is_ancestor_of(this))) {
+				if (is_part_of_edited_scene()) {
 					break;
 				}
 #endif

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -490,7 +490,7 @@ bool Window::is_embedded() const {
 
 bool Window::is_in_edited_scene_root() const {
 #ifdef TOOLS_ENABLED
-	return (Engine::get_singleton()->is_editor_hint() && get_tree()->get_edited_scene_root() && (get_tree()->get_edited_scene_root()->is_ancestor_of(this) || get_tree()->get_edited_scene_root() == this));
+	return is_part_of_edited_scene();
 #else
 	return false;
 #endif
@@ -1138,6 +1138,13 @@ void Window::_notification(int p_what) {
 				RS::get_singleton()->viewport_set_active(get_viewport_rid(), true);
 			}
 
+#ifdef TOOLS_ENABLED
+			if (is_part_of_edited_scene()) {
+				// Don't translate Windows on scene when inside editor.
+				set_message_translation(false);
+				notification(NOTIFICATION_TRANSLATION_CHANGED);
+			}
+#endif
 			notification(NOTIFICATION_THEME_CHANGED);
 		} break;
 


### PR DESCRIPTION
This PR enables auto-translation of Windows and Controls inside the editor, if they are not part of the edited scene.
Fixes #50650
Technically `TTR()` can now be retired in favor of `TTRC()`, probably.

I use `get_viewport() != get_tree()->get_root()` to determine whether a node is part of the scene tree, but this might yield some false-positives. A more reliable condition is
```C++
if (Engine::get_singleton()->is_editor_hint() && get_tree()->get_edited_scene_root() &&
		(get_tree()->get_edited_scene_root()->get_viewport() == get_viewport() || get_tree()->get_edited_scene_root()->get_viewport()->is_ancestor_of(get_viewport())))
```
and for Window
```C++
if (Engine::get_singleton()->is_editor_hint() && get_tree()->get_edited_scene_root() &&
		(get_tree()->get_edited_scene_root()->get_viewport() == get_parent_viewport() || get_tree()->get_edited_scene_root()->get_viewport()->is_ancestor_of(get_parent_viewport()))) {
```
but not sure if it's necessary 🤔