### PR TITLE
Call super in Node Template _ready function

### DIFF
--- a/modules/gdscript/editor/script_templates/Node/default.gd
+++ b/modules/gdscript/editor/script_templates/Node/default.gd
@@ -5,6 +5,7 @@ extends _BASE_
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
+	#super() # Call the base-class _ready() function.
 	pass # Replace with function body.
 
 

--- a/modules/mono/editor/script_templates/Node/default.cs
+++ b/modules/mono/editor/script_templates/Node/default.cs
@@ -8,6 +8,7 @@ public partial class _CLASS_ : _BASE_
     // Called when the node enters the scene tree for the first time.
     public override void _Ready()
     {
+        //base._Ready(); // Call the base-class _Ready() function.
     }
 
     // Called every frame. 'delta' is the elapsed time since the previous frame.


### PR DESCRIPTION
I had 3 bugs because I keep forgetting to call `super` in the `_ready()` function. Usually I use the template and just forget to fill in the `_ready` implementation. This results in the base class's `_ready` function not being called. I am used to this behavior from 3.x and feel it easier to migrate if this is added by default. I believe it's rare that `super` won't be used in this case so adding it to the `Node` template.