### PR TITLE
GDScript: Allow usage of literal false in assert without a warning

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2007,7 +2007,7 @@ void GDScriptAnalyzer::resolve_assert(GDScriptParser::AssertNode *p_assert) {
 	if (p_assert->condition->is_constant) {
 		if (p_assert->condition->reduced_value.booleanize()) {
 			parser->push_warning(p_assert->condition, GDScriptWarning::ASSERT_ALWAYS_TRUE);
-		} else {
+		} else if (!(p_assert->condition->type == GDScriptParser::Node::LITERAL && static_cast<GDScriptParser::LiteralNode *>(p_assert->condition)->value.get_type() == Variant::BOOL)) {
 			parser->push_warning(p_assert->condition, GDScriptWarning::ASSERT_ALWAYS_FALSE);
 		}
 	}

--- a/modules/gdscript/tests/scripts/analyzer/features/assert_literal_false.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/assert_literal_false.gd
@@ -1,0 +1,6 @@
+func test():
+	var never: Variant = false
+	if never:
+		assert(false)
+		assert(false, 'message')
+	print('ok')

--- a/modules/gdscript/tests/scripts/analyzer/features/assert_literal_false.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/assert_literal_false.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+ok


### PR DESCRIPTION
```gdscript
func never():
  assert(false) # before: warning assert_always_false, after: no such warning
```

Closes #58087.