### PR TITLE
Windows: Ask user before permanently deleting files with `move_to_trash`

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1486,7 +1486,7 @@ Error OS_Windows::move_to_trash(const String &p_path) {
 	sf.wFunc = FO_DELETE;
 	sf.pFrom = from;
 	sf.pTo = nullptr;
-	sf.fFlags = FOF_ALLOWUNDO | FOF_NOCONFIRMATION;
+	sf.fFlags = FOF_ALLOWUNDO;
 	sf.fAnyOperationsAborted = FALSE;
 	sf.hNameMappings = nullptr;
 	sf.lpszProgressTitle = nullptr;


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/issues/74678 and the question why the Documents folder did not end up in the trash. (I tried in a VM and was surprised to find that windows does nothing to prevent you from doing this, not even when using the explorer; tho I found the folder in the trash just fine there)

Makes windows pop up this confirmation dialog when recycling items that are too large for the trash (by default more than 5% of the disk size):
![image](https://user-images.githubusercontent.com/10944644/225893493-507977e5-b7f9-4ca7-8f8a-6a93abd2a34c.png)

It is still possible to disable the recycling bin entirely for a disk, i which case the items will always be deleted permanently without a confirmation dialog (from the OS)