### PR TITLE
Print extended hardware information when running in verbose mode

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3391,6 +3391,117 @@ Error Main::setup2(bool p_show_boot_logo) {
 
 	register_core_singletons();
 
+	if (OS::get_singleton()->is_stdout_verbose()) {
+		print_line("System information:\n");
+		// Print hardware information for easier troubleshooting (other than GPU name, as rendering drivers already handle this).
+		// Only evaluate functions if needed, as some of these may be relatively slow.
+		print_line(vformat("Operating system: %s %s", OS::get_singleton()->get_distribution_name(), OS::get_singleton()->get_version_alias()));
+		print_line(vformat("Device model: %s", OS::get_singleton()->get_model_name()));
+		print_line(vformat("CPU model: %s (%s threads)", OS::get_singleton()->get_processor_name(), OS::get_singleton()->get_processor_count()));
+		const Dictionary memory_info = OS::get_singleton()->get_memory_info();
+		print_line(vformat("Total memory size: %s", int64_t(memory_info["physical"]) > 0 ? String::humanize_size(memory_info["physical"]) : "N/A"));
+		String graphics_driver = "GPU driver version: ";
+		const Vector<String> video_adapter_driver_info = OS::get_singleton()->get_video_adapter_driver_info();
+		if (video_adapter_driver_info.size() == 2) { // This vector is always either of length 0 or 2.
+			const String &vad_name = video_adapter_driver_info[0];
+			const String &vad_version = video_adapter_driver_info[1]; // Version could be potentially empty on Linux/BSD.
+			if (!vad_version.is_empty()) {
+				graphics_driver += vformat("%s; %s", vad_name, vad_version);
+			} else if (!vad_name.is_empty()) {
+				graphics_driver += vad_name;
+			}
+		}
+		print_line(graphics_driver);
+		print_line(vformat("Audio driver: %s", AudioServer::get_singleton()->get_driver_name()));
+
+		print_line(vformat("Audio output mix rate: %d Hz", AudioServer::get_singleton()->get_mix_rate()));
+		if (!AudioServer::get_singleton()->get_output_device_list().is_empty()) {
+			print_line("Audio output devices:");
+			int output_device_id = 0;
+			for (String output_device : AudioServer::get_singleton()->get_output_device_list()) {
+				print_line(vformat("  #%d: %s%s", output_device_id, output_device, AudioServer::get_singleton()->get_output_device() == output_device ? " (selected)" : ""));
+				output_device_id += 1;
+			}
+		} else {
+			print_line("Audio output devices: (none)");
+		}
+
+		print_line(vformat("Audio input mix rate: %d Hz", AudioServer::get_singleton()->get_input_mix_rate()));
+		if (!AudioServer::get_singleton()->get_input_device_list().is_empty()) {
+			print_line("Audio input devices:");
+			int input_device_id = 0;
+			for (String input_device : AudioServer::get_singleton()->get_input_device_list()) {
+				print_line(vformat("  #%d: %s%s", input_device_id, input_device, AudioServer::get_singleton()->get_input_device() == input_device ? " (selected)" : ""));
+				input_device_id += 1;
+			}
+		} else {
+			print_line("Audio input devices: (none)");
+		}
+
+		if (AudioServer::get_singleton()->get_driver_name() != "Dummy") {
+			OS::get_singleton()->open_midi_inputs();
+			if (!OS::get_singleton()->get_connected_midi_inputs().is_empty()) {
+				print_line("Input MIDI devices:");
+				int midi_device_id = 0;
+				for (String midi_device : OS::get_singleton()->get_connected_midi_inputs()) {
+					print_line(vformat("  #%d: %s", midi_device_id, midi_device));
+					midi_device_id += 1;
+				}
+			} else {
+				print_line("Input MIDI devices: (none)");
+			}
+			OS::get_singleton()->close_midi_inputs();
+		}
+
+		if (!Input::get_singleton()->get_connected_joypads().is_empty()) {
+			print_line("Connected gamepads:");
+			for (int32_t joypad_id : Input::get_singleton()->get_connected_joypads()) {
+				const Dictionary joy_info = Input::get_singleton()->get_joy_info(joypad_id);
+				const String joy_info_string = !joy_info.is_empty() ? vformat("\n    %s", joy_info) : "";
+				print_line(vformat("  #%d: %s%s", joypad_id, Input::get_singleton()->get_joy_name(joypad_id), joy_info_string));
+			}
+		} else {
+			print_line("Connected gamepads: (none)");
+		}
+
+		print_line(vformat("Tablet driver: %s", DisplayServer::get_singleton()->tablet_get_current_driver()));
+
+		print_line("Displays:");
+		for (int i = 0; i < DisplayServer::get_singleton()->get_screen_count(); i++) {
+			const Rect2i usable_rect = DisplayServer::get_singleton()->screen_get_usable_rect();
+			print_line(
+					vformat("  #%d: (%d, %d), %dx%d, %.2f Hz, %d dpi, scale factor: %.2f, usable rect: (%d, %d), %dx%d",
+							i,
+							DisplayServer::get_singleton()->screen_get_position(i).x,
+							DisplayServer::get_singleton()->screen_get_position(i).y,
+							DisplayServer::get_singleton()->screen_get_size(i).x,
+							DisplayServer::get_singleton()->screen_get_size(i).y,
+							DisplayServer::get_singleton()->screen_get_refresh_rate(i),
+							DisplayServer::get_singleton()->screen_get_dpi(i),
+							DisplayServer::get_singleton()->screen_get_scale(i),
+							usable_rect.position.x,
+							usable_rect.position.y,
+							usable_rect.size.x,
+							usable_rect.size.y));
+		}
+
+		print_line("\nEngine information:\n");
+		print_line(vformat("Engine compiled for architecture: %s", Engine::get_singleton()->get_architecture_name()));
+		String physics_engine_2d = GLOBAL_GET("physics/2d/physics_engine");
+		if (physics_engine_2d == "DEFAULT") {
+			physics_engine_2d = "GodotPhysics2D";
+		}
+		print_line(vformat("2D physics server: %s", physics_engine_2d));
+		String physics_engine_3d = GLOBAL_GET("physics/3d/physics_engine");
+		if (physics_engine_3d == "DEFAULT") {
+			physics_engine_3d = "GodotPhysics3D";
+		}
+		print_line(vformat("3D physics server: %s", physics_engine_3d));
+
+		// Add a blank line after verbose information for readability.
+		print_line("");
+	}
+
 	/* Initialize the main window and boot screen */
 
 	{


### PR DESCRIPTION
This is useful for troubleshooting, especially for player-submitted reports in exported projects. This complements https://github.com/godotengine/godot-proposals/issues/4732, but a dedicated dialog should still be added to the editor as not every user can easily run Godot from a terminal (e.g. Android/HTML5).

This is the generated output on my system when running with `--verbose`:

```
System information:

Operating system: Fedora Linux 42 (KDE Plasma Desktop Edition)
Device model: GenericDevice
CPU model: 13th Gen Intel(R) Core(TM) i9-13900K (32 threads)
Total memory size: 62.54 GiB
GPU driver version: nvidia; 570.133.07
Audio driver: PulseAudio
Audio output mix rate: 44100 Hz
Audio output devices:
  #0: Default (selected)
  #1: alsa_output.pci-0000_01_00.1.hdmi-stereo
  #2: alsa_output.usb-Sony_Interactive_Entertainment_DualSense_Wireless_Controller-00.analog-surround-40
Audio input mix rate: 44100 Hz
Audio input devices:
  #0: Default
  #1: alsa_input.usb-C-Media_Electronics_Inc._USB_Advanced_Audio_Device-00.analog-stereo
  #2: alsa_input.usb-Sony_Interactive_Entertainment_DualSense_Wireless_Controller-00.analog-stereo
Input MIDI devices: (none)
Connected gamepads:
  #0: PS5 Controller
    { "vendor_id": 1356, "product_id": 3302, "raw_name": "Sony Interactive Entertainment DualSense Wireless Controller" }
Tablet driver: default
Displays:
  #0: (0, 0), 3840x2160, 119.88 Hz, 60 dpi, scale factor: 1.00, usable rect: (0, 0), 3840x2160

Engine information:

Engine compiled for architecture: x86_64
2D physics server: GodotPhysics2D
3D physics server: GodotPhysics3D
```
