### PR TITLE
Add a method in Curve to predict insertion index

### DIFF
--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -489,9 +489,7 @@ float CurveEdit::get_offset_without_collision(int p_current_index, float p_offse
 void CurveEdit::add_point(Vector2 p_pos) {
 	ERR_FAIL_COND(curve.is_null());
 
-	// Add a point to get its index, then remove it immediately. Trick to feed the UndoRedo.
-	int new_idx = curve->add_point(p_pos);
-	curve->remove_point(new_idx);
+	int new_idx = curve->predict_insertion_index(p_pos);
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Add Curve Point"));

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -78,6 +78,7 @@ public:
 
 	void set_point_count(int p_count);
 
+	int predict_insertion_index(Vector2 &p_position) const;
 	int add_point(Vector2 p_position,
 			real_t left_tangent = 0,
 			real_t right_tangent = 0,


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Previously, the way to get the index of the point being added was by calling `add_point()` to get its return value. Now it's computed, which may help implement improvements to the Curver editor (like in #74959).

