### PR TITLE
Fix tvg picture size

### DIFF
--- a/.github/ISSUE_TEMPLATE/report.yml
+++ b/.github/ISSUE_TEMPLATE/report.yml
@@ -1,0 +1,6 @@
+name: "Report"
+description: Some report
+body:
+- type: textarea
+  attributes:
+    label: Description

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -79,6 +79,12 @@ Error ImageLoaderSVG::create_image_from_utf8_buffer(Ref<Image> p_image, const Pa
 	float fw, fh;
 	picture->size(&fw, &fh);
 
+	// May in some web-based cases return zero size. Render 1x1 px image.
+	if (fw <= 0.0 || fh <= 0.0 ) {
+		fw = 1.0;
+		fh = 1.0;
+	}
+
 	uint32_t width = round(fw * p_scale);
 	uint32_t height = round(fh * p_scale);
 


### PR DESCRIPTION

In some cases, useful for the web canvas but not for an image viewer
 the _tvg::Picture->size()_ returns here width or height zerro.
Render a 1x1 px placeholder image,
 
See the discussion on this topic:
https://github.com/godotengine/godot/issues/72478
