### PR TITLE
SVG: Fix `tvg::Picture->size()` and scale based errors.

### DIFF
--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -79,8 +79,8 @@ Error ImageLoaderSVG::create_image_from_utf8_buffer(Ref<Image> p_image, const Pa
 	float fw, fh;
 	picture->size(&fw, &fh);
 
-	uint32_t width = round(fw * p_scale);
-	uint32_t height = round(fh * p_scale);
+	uint32_t width = MAX(1, round(fw * p_scale));
+	uint32_t height = MAX(1, round(fh * p_scale));
 
 	const uint32_t max_dimension = 16384;
 	if (width > max_dimension || height > max_dimension) {


### PR DESCRIPTION
Useful in some cases for Web Canvas (for example, to hide the image and avoid its rendering), tvg::Picture->size() returns width and/or height 0. In this case, we will render an image of 1 px width and/or height.

The svg size might be scaled down and rounded to 0 as an import option as well.  **Godot 3.x** has the same scale issue.
 <details><summary>godot 3.x errors</summary>

3.5.2.stable: Import->Scale 0.001
``` The Image width specified (0 pixels) must be greater than 0 pixels.
core/image.cpp:1475 - Condition "data.size() == 0" is true.
modules/webp/image_loader_webp.cpp:79 - 
Condition "p_image.is_null() || p_image->empty()" is true. 
Returned: PoolVector<uint8_t>()
modules/webp/image_loader_webp.cpp:146 - Condition "size <= 0" is true. 
Returned: Ref<Image>()
scene/resources/texture.cpp:570 - 
Condition "img.is_null() || img->empty()" is true. Returned: ERR_FILE_CORRUPT
```
</details>

See the discussion on this topic:
https://github.com/godotengine/godot/issues/72478

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
