### PR TITLE
Fix get_tiles_count on ScenesCollectionSource

### DIFF
--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -4734,7 +4734,7 @@ void TileSetScenesCollectionSource::_compute_next_alternative_id() {
 }
 
 int TileSetScenesCollectionSource::get_tiles_count() const {
-	return 1;
+	return scenes_ids.size();
 }
 
 Vector2i TileSetScenesCollectionSource::get_tile_id(int p_tile_index) const {


### PR DESCRIPTION
Fixes #73645

This is same implementation as in [`AtlasSource.get_tiles_count()`](https://github.com/godotengine/godot/blob/master/scene/resources/tile_set.cpp#L4295-L4297)