### PR TITLE
Implement a polished floating UI for standard Web Editor wrapper

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -87,16 +87,28 @@ a:active {
 }
 
 #tabs-buttons {
-	/* Match the default background color of the editor window for a seamless appearance. */
-	background-color: #202531;
+	position: absolute;
+	width: 100%;
+	/* Match to height of contained buttons. Non-hardcoded solution would be preferable. */
+	height: 27px;
+	/* Keep above the canvas when floating. */
+	z-index: 1;
 }
 
-#tab-game {
+#tabs-buttons.relative {
+	position: relative;
+}
+
+#tab-game, #tabs-buttons.relative {
 	/* Use a pure black background to better distinguish the running project */
 	/* from the editor window, and to use a more neutral background color (no tint). */
 	background-color: black;
 	/* Make the background span the entire page height. */
 	min-height: 100vh;
+}
+
+#game-canvas {
+	background: #202531;
 }
 
 #canvas, #gameCanvas {
@@ -124,7 +136,7 @@ a:active {
 .btn {
 	appearance: none;
 	color: #e0e0e0;
-	background-color: #262c3b;
+	background-color: hsl(223 22% 19%);
 	border: 1px solid #202531;
 	padding: 0.5rem 1rem;
 	margin: 0 0.5rem;
@@ -145,8 +157,55 @@ a:active {
 	border-color: #242937;
 }
 
+.container.tab-btn {
+	position: absolute;
+	/* Hide unremovable space between each button */
+	font-size: 0;
+}
+
+.container.tab-btn-editor {
+	left: 28%;
+}
+
+.container.tab-btn-game {
+	right: 35%;
+}
+
+.container.tab-btn > .btn {
+	margin: 0;
+	border: 0 solid hsl(223 22% 30%);
+	border-block-width: 2px;
+	border-top: none;
+	outline: 2px none;
+	outline-offset: -2px;
+}
+
+.container.tab-btn > .btn:disabled {
+	visibility: hidden;
+}
+
+.container.tab-btn > .btn:not(:disabled):hover {
+	outline-style: solid;
+	outline-color: hsl(223 22% 40%);
+}
+
+.container.tab-btn > .btn:not(:disabled):active {
+	outline-style: solid;
+	outline-color: hsl(223 22% 60%);
+}
+
+.container.tab-btn > .btn:first-child {
+	border-bottom-left-radius: 12px;
+	border-left-width: 2px;
+}
+
+.container.tab-btn > .btn:last-child {
+	border-bottom-right-radius: 12px;
+	border-right-width: 2px;
+}
+
 .btn.tab-btn {
-	padding: 0.3rem 1rem;
+	padding: 0.3rem 0.6rem;
 }
 
 .btn.close-btn {
@@ -281,12 +340,20 @@ a:active {
 			</div>
 		</div>
 		<div id="tabs-buttons">
-			<button id="btn-tab-loader" class="btn tab-btn" onclick="showTab('loader')">Loader</button>
-			<button id="btn-tab-editor" class="btn tab-btn" disabled="disabled" onclick="showTab('editor')">Editor</button>
-			<button id="btn-close-editor" class="btn close-btn" disabled="disabled" onclick="closeEditor()">×</button>
-			<button id="btn-tab-game" class="btn tab-btn" disabled="disabled" onclick="showTab('game')">Game</button>
-			<button id="btn-close-game" class="btn close-btn" disabled="disabled" onclick="closeGame()">×</button>
-			<button id="btn-tab-update" class="btn tab-btn" style="display: none;">Update</button>
+			<div class="container tab-btn tab-btn-loader" style="display: none;">
+				<button id="btn-tab-loader" class="btn tab-btn" onclick="showTab('loader')">Loader</button>
+			</div>
+			<div class="container tab-btn tab-btn-editor">
+				<button id="btn-tab-editor" class="btn tab-btn" disabled="disabled" onclick="showTab('editor')">Editor</button>
+				<button id="btn-close-editor" class="btn close-btn" disabled="disabled" onclick="closeEditor()">×</button>
+			</div>
+			<div class="container tab-btn tab-btn-game">
+				<button id="btn-tab-game" class="btn tab-btn" disabled="disabled" onclick="showTab('game')">Game</button>
+				<button id="btn-close-game" class="btn close-btn" disabled="disabled" onclick="closeGame()">×</button>
+			</div>
+			<div class="container tab-btn tab-btn-update" style="display: none;">
+				<button id="btn-tab-update" class="btn tab-btn">Update</button>
+			</div>
 		</div>
 		<div id="tabs">
 			<div id="tab-loader">
@@ -469,6 +536,8 @@ function showTab(name) {
 			elem.style.display = 'none';
 		}
 	});
+	const tabsContainer = document.getElementById('tabs-buttons');
+	tabsContainer.classList.toggle('relative', name === 'game');
 }
 
 function setButtonEnabled(id, enabled) {
@@ -480,7 +549,7 @@ function setButtonEnabled(id, enabled) {
 }
 
 function setLoaderEnabled(enabled) {
-	setButtonEnabled('btn-tab-loader', enabled);
+	//setButtonEnabled('btn-tab-loader', enabled);
 	setButtonEnabled('btn-tab-editor', !enabled);
 	setButtonEnabled('btn-close-editor', !enabled);
 }


### PR DESCRIPTION
Fix https://github.com/godotengine/godot-proposals/issues/6405

- Prevent Web Editor tab buttons from taking up space on screens, particularly for those with little space.
- Add large responsive borders, with rounded corners to differentiate them from the editor UI.
- Hide buttons in cases when they're obsolete; Launcher is never useful, and [ Game x ] is only needed when a game is running.

Part of my reasoning for this is that users will be encouraged to use Godot's unified theming, which otherwise is discredited - any theme other than the default looks a bit silly and sad when there's a permanent top bar in the default colour.

![image](https://user-images.githubusercontent.com/66553618/226067797-1541fcd2-e049-4c5a-ae0c-856a8fc7990c.png)

![image](https://user-images.githubusercontent.com/66553618/226067601-1b987f59-fb64-4607-8a5c-dd649261330a.png)

![image](https://user-images.githubusercontent.com/66553618/226067733-654114e5-9be7-4f7a-ab13-28227b5bd9d5.png)

Compatible with 3.x, but would benefit from slight tweaks.