### PR TITLE
Add project tags

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1251,6 +1251,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_BASIC("application/config/name", "");
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::DICTIONARY, "application/config/name_localized", PROPERTY_HINT_LOCALIZABLE_STRING), Dictionary());
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/config/description", PROPERTY_HINT_MULTILINE_TEXT), "");
+	GLOBAL_DEF_INTERNAL(PropertyInfo(Variant::STRING, "application/config/tags"), PackedStringArray());
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/run/main_scene", PROPERTY_HINT_FILE, "*.tscn,*.scn,*.res"), "");
 	GLOBAL_DEF("application/run/disable_stdout", false);
 	GLOBAL_DEF("application/run/disable_stderr", false);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -939,6 +939,33 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	editor_log_button_pressed->set_border_color(accent_color);
 	theme->set_stylebox("pressed", "EditorLogFilterButton", editor_log_button_pressed);
 
+	// ProjectTag
+	{
+		theme->set_type_variation("ProjectTag", "Button");
+
+		Ref<StyleBoxFlat> tag = style_widget->duplicate();
+		tag->set_bg_color(dark_theme ? tag->get_bg_color().lightened(0.2) : tag->get_bg_color().darkened(0.2));
+		tag->set_corner_radius(CORNER_TOP_LEFT, 0);
+		tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+		tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
+		tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+		theme->set_stylebox("normal", "ProjectTag", tag);
+
+		tag = style_widget_hover->duplicate();
+		tag->set_corner_radius(CORNER_TOP_LEFT, 0);
+		tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+		tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
+		tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+		theme->set_stylebox("hover", "ProjectTag", tag);
+
+		tag = style_widget_pressed->duplicate();
+		tag->set_corner_radius(CORNER_TOP_LEFT, 0);
+		tag->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+		tag->set_corner_radius(CORNER_TOP_RIGHT, 4);
+		tag->set_corner_radius(CORNER_BOTTOM_RIGHT, 4);
+		theme->set_stylebox("pressed", "ProjectTag", tag);
+	}
+
 	// MenuBar
 	theme->set_stylebox("normal", "MenuBar", style_widget);
 	theme->set_stylebox("hover", "MenuBar", style_widget_hover);


### PR DESCRIPTION
This PR adds ability to assign tags to projects. A project can have any number of tags and they are stored in `project.godot`. Tags are only usable and editable via Project Manager.

![image](https://user-images.githubusercontent.com/2223172/226072283-b91cf886-c3ca-40f3-9c42-1414f09b389b.png)

You can edit tags using the new Manage Tags button.

https://user-images.githubusercontent.com/2223172/226072478-1757fc45-5271-432f-8c0d-5b7c66c2a878.mp4

The dialog includes all tags used by projects on your project list. You can add or remove tags to the project simply by clicking them.

You can filter and sort projects by tag.

https://user-images.githubusercontent.com/2223172/226072789-af348d95-b3e1-4016-96b2-c16f583f5133.mp4

Tag sort works based on the alphabetical order of tags.

Right now tag colors are assigned based on their name and they can't be edited. This is because a tag is a simple String.

Closes https://github.com/godotengine/godot-proposals/issues/2329

~~To consider: Favorite projects can be possibly removed now. You can just slap a `favorite` tag.~~

EDIT:
I added a bit more restrictions to tags, to make them more consistent (when multiple people create the same tag etc.). They can be only lowercase now, but they appear capitalized on project list:
![](https://user-images.githubusercontent.com/2223172/226109462-8b01786d-b8a2-4131-888e-1a3bb2b5afa2.png)

EDIT2:
Redesigned tags after feedback
![](https://user-images.githubusercontent.com/2223172/226139729-8254a936-0c45-4411-b9da-3670be423310.png)