### PR TITLE
Allow loading custom ProjectSettings instance

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1017,7 +1017,7 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 		}
 	}
 	// Check for the existence of a csproj file.
-	if (_csproj_exists(get_resource_path())) {
+	if (_csproj_exists(p_path.get_base_dir())) {
 		// If there is a csproj file, add the C# feature if it doesn't already exist.
 		if (!project_features.has("C#")) {
 			project_features.append("C#");
@@ -1568,6 +1568,14 @@ ProjectSettings::ProjectSettings() {
 	ProjectSettings::get_singleton()->add_hidden_prefix("input/");
 }
 
+ProjectSettings::ProjectSettings(const String &p_path) {
+	if (load_custom(p_path) == OK) {
+		project_loaded = true;
+	}
+}
+
 ProjectSettings::~ProjectSettings() {
-	singleton = nullptr;
+	if (singleton == this) {
+		singleton = nullptr;
+	}
 }

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -224,6 +224,7 @@ public:
 #endif
 
 	ProjectSettings();
+	ProjectSettings(const String &p_path);
 	~ProjectSettings();
 };
 


### PR DESCRIPTION
This PR allows loading ProjectSettings like a normal resource (even though it's an Object...). It's accomplished using a special constructor that bypasses creating singleton etc.

This fixes an issue introduced by #69338 where renaming project would remove comments from `project.godot`.
Also needed for #75047, because it has the same problem.

tbh the original issue could've been fixed by a simple return if a singleton already exists. All the stuff in the constructor does not need to run for the project settings to load and save correctly.