### PR TITLE
GDScript: Fix error message for LUA-style dictionary

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2731,12 +2731,12 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_dictionary(ExpressionNode 
 			switch (dictionary->style) {
 				case DictionaryNode::LUA_TABLE:
 					if (key != nullptr && key->type != Node::IDENTIFIER && key->type != Node::LITERAL) {
-						push_error("Expected identifier or string as LUA-style dictionary key.");
+						push_error(R"(Expected identifier or string as Lua-style dictionary key (e.g "{ key = value }").)");
 						advance();
 						break;
 					}
 					if (key != nullptr && key->type == Node::LITERAL && static_cast<LiteralNode *>(key)->value.get_type() != Variant::STRING) {
-						push_error("Expected identifier or string as LUA-style dictionary key.");
+						push_error(R"(Expected identifier or string as Lua-style dictionary key (e.g "{ key = value }").)");
 						advance();
 						break;
 					}


### PR DESCRIPTION
Changed confusing error message when typing an incorrect dictionary syntax.

Old error message:
```
Expected identifier or string as LUA-style dictionary key.
```

I replaced it with two error messages:

When typing 
```gdscript
var foo = {
  1 = "bar" 
}
```
```
Expected string literal as dictionary key.
```

When typing 
```gdscript
var foo = {
  1+1 = "bar"
}
```
```
Expected identifier or literal as dictionary key.
```
Fixes #74821.