### PR TITLE
Allow right and middle click focus

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1746,7 +1746,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			}
 #endif
 
-			if (mb->get_button_index() == MouseButton::LEFT) { // Assign focus.
+			if (mb->get_button_index() == MouseButton::LEFT || mb->get_button_index() == MouseButton::RIGHT || mb->get_button_index() == MouseButton::MIDDLE) { // Assign focus.
 				CanvasItem *ci = gui.mouse_focus;
 				while (ci) {
 					Control *control = Object::cast_to<Control>(ci);

--- a/tests/scene/test_viewport.h
+++ b/tests/scene/test_viewport.h
@@ -317,12 +317,16 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 				SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(on_d, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 			}
 
-			SUBCASE("[Viewport][GuiInputEvent] RMB doesn't grab focus.") {
+			SUBCASE("[Viewport][GuiInputEvent] Side Mouse Buttons don't grab focus.") {
 				node_a->grab_focus();
 				CHECK(node_a->has_focus());
 
-				SEND_GUI_MOUSE_BUTTON_EVENT(on_d, MouseButton::RIGHT, MouseButtonMask::RIGHT, Key::NONE);
-				SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(on_d, MouseButton::RIGHT, MouseButtonMask::NONE, Key::NONE);
+				SEND_GUI_MOUSE_BUTTON_EVENT(on_d, MouseButton::MB_XBUTTON1, MouseButtonMask::MB_XBUTTON1, Key::NONE);
+				SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(on_d, MouseButton::MB_XBUTTON1, MouseButtonMask::NONE, Key::NONE);
+				CHECK(node_a->has_focus());
+
+				SEND_GUI_MOUSE_BUTTON_EVENT(on_d, MouseButton::MB_XBUTTON2, MouseButtonMask::MB_XBUTTON2, Key::NONE);
+				SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(on_d, MouseButton::MB_XBUTTON2, MouseButtonMask::NONE, Key::NONE);
 				CHECK(node_a->has_focus());
 			}
 


### PR DESCRIPTION
Imagine if in Godot editor, you had to first left click on a node before right clicking to bring up a context menu referencing that node. Or in a web browser, if you had to left click a link before middle clicking to open the link in a new tab. This is the limitation in projects. This PR fixes this problem.
closes #33016.