### PR TITLE
Expose some `AudioStreamPlayback` methods

### DIFF
--- a/doc/classes/AudioStreamPlayback.xml
+++ b/doc/classes/AudioStreamPlayback.xml
@@ -55,5 +55,53 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_loop_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of times the stream has looped.
+			</description>
+		</method>
+		<method name="get_playback_position" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the current position in the stream, in seconds.
+			</description>
+		</method>
+		<method name="is_playing" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the stream is playing.
+			</description>
+		</method>
+		<method name="mix">
+			<return type="PackedVector2Array" />
+			<param index="0" name="rate_scale" type="float" />
+			<param index="1" name="frames" type="int" />
+			<description>
+				Mixes up to [param frames] of audio from the stream from the current position, at a rate of [param rate_scale], advancing the stream.
+				Returns a [PackedVector2Array] where each element holds the left and right channel volume levels of each frame.
+				[b]Note:[/b] Can return fewer frames than requested, make sure to use the size of the return value.
+			</description>
+		</method>
+		<method name="seek">
+			<return type="void" />
+			<param index="0" name="position" type="float" />
+			<description>
+				Sets the position from which stream will be played, in seconds.
+			</description>
+		</method>
+		<method name="start">
+			<return type="void" />
+			<param index="0" name="from_position" type="float" default="0.0" />
+			<description>
+				Starts the stream from the given [param from_position], in seconds.
+			</description>
+		</method>
+		<method name="stop">
+			<return type="void" />
+			<description>
+				Stops the stream.
+			</description>
+		</method>
 	</methods>
 </class>

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -76,6 +76,22 @@ int AudioStreamPlayback::mix(AudioFrame *p_buffer, float p_rate_scale, int p_fra
 	return ret;
 }
 
+PackedVector2Array AudioStreamPlayback::_mix_bind(float p_rate_scale, int p_frames) {
+	Vector<AudioFrame> buffer;
+	buffer.resize(p_frames);
+
+	int frames_out = mix(buffer.ptrw(), p_rate_scale, p_frames);
+
+	PackedVector2Array ret;
+	ret.resize(frames_out);
+
+	for (int i = 0; i < frames_out; ++i) {
+		ret.write[i] = Vector2(buffer[i].l, buffer[i].r);
+	}
+
+	return ret;
+}
+
 void AudioStreamPlayback::tag_used_streams() {
 	GDVIRTUAL_CALL(_tag_used_streams);
 }
@@ -89,6 +105,14 @@ void AudioStreamPlayback::_bind_methods() {
 	GDVIRTUAL_BIND(_seek, "position")
 	GDVIRTUAL_BIND(_mix, "buffer", "rate_scale", "frames");
 	GDVIRTUAL_BIND(_tag_used_streams);
+
+	ClassDB::bind_method(D_METHOD("start", "from_position"), &AudioStreamPlayback::start, DEFVAL(0.0));
+	ClassDB::bind_method(D_METHOD("stop"), &AudioStreamPlayback::stop);
+	ClassDB::bind_method(D_METHOD("is_playing"), &AudioStreamPlayback::is_playing);
+	ClassDB::bind_method(D_METHOD("get_loop_count"), &AudioStreamPlayback::get_loop_count);
+	ClassDB::bind_method(D_METHOD("get_playback_position"), &AudioStreamPlayback::get_playback_position);
+	ClassDB::bind_method(D_METHOD("seek", "position"), &AudioStreamPlayback::seek);
+	ClassDB::bind_method(D_METHOD("mix", "rate_scale", "frames"), &AudioStreamPlayback::_mix_bind);
 }
 //////////////////////////////
 

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -55,6 +55,9 @@ protected:
 	GDVIRTUAL1(_seek, double)
 	GDVIRTUAL3R(int, _mix, GDExtensionPtr<AudioFrame>, float, int)
 	GDVIRTUAL0(_tag_used_streams)
+
+	PackedVector2Array _mix_bind(float p_rate_scale, int p_frames);
+
 public:
 	virtual void start(double p_from_pos = 0.0);
 	virtual void stop();


### PR DESCRIPTION
Returning an array with only the size of the return of the original `mix` function to convey that value, which I thinks makes sense

Not exposing `tag_used_streams` as I'm not familiar with how it works and the relevant functionality isn't exposed elsewhere.

Examples of use case of this feature https://github.com/godotengine/godot-proposals/issues/6466, https://github.com/godotengine/godot-proposals/discussions/6385

Closes godotengine/godot-proposals#127

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
