### PR TITLE
Fix commenting collapsed function issue

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1584,11 +1584,17 @@ void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 	Vector<int> caret_edit_order = text_editor->get_caret_index_edit_order();
 	caret_edit_order.reverse();
 	int last_line = -1;
+	int folded_to = 0;
 	for (const int &c1 : caret_edit_order) {
 		int from = _get_affected_lines_from(c1);
-		from += from == last_line ? 1 : 0;
+		from += from == last_line ? 1 + folded_to : 0;
 		int to = _get_affected_lines_to(c1);
 		last_line = to;
+		// If last line is folded, extends to the end of the folded section
+		if (text_editor->is_line_folded(to)) {
+			folded_to = text_editor->get_next_visible_line_offset_from(to + 1, 1) - 1;
+			to += folded_to;
+		}
 		// Check first if there's any uncommented lines in selection.
 		bool is_commented = true;
 		for (int line = from; line <= to; line++) {


### PR DESCRIPTION
Fix #74802

### Issue fixed

Commenting a folded function didn't comment the content of the function if at last line of the selection.

![bug](https://user-images.githubusercontent.com/3649998/226114298-04a1684e-0559-42c3-87ca-959a290a6dc6.gif)

### Fix proposal

If last commented line  via CTRL+K is a folded, also comment inner folded content.

![comment_folded_function](https://user-images.githubusercontent.com/3649998/226114350-0168d19f-3b25-4cb1-84b9-09864bcc2e2f.gif)

Note : If selection was not ending on a folded line but contains a folded part, comment inside was correctly commented.