### PR TITLE
Update property/documentation of shape margins

### DIFF
--- a/doc/classes/Shape3D.xml
+++ b/doc/classes/Shape3D.xml
@@ -23,7 +23,7 @@
 			When set to [code]0[/code], the default value from [member ProjectSettings.physics/3d/solver/default_contact_bias] is used.
 		</member>
 		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.04">
-			The collision margin for the shape. Used in Bullet Physics only.
+			The collision margin for the shape. This is not used in Godot Physics.
 			Collision margins allow collision detection to be more efficient by adding an extra shell around shapes. Collision algorithms are more expensive when objects overlap by more than their margin, so a higher value for margins is better for performance, at the cost of accuracy around edges as it makes them less sharp.
 		</member>
 	</members>

--- a/scene/resources/shape_3d.cpp
+++ b/scene/resources/shape_3d.cpp
@@ -117,7 +117,7 @@ void Shape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_debug_mesh"), &Shape3D::get_debug_mesh);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "custom_solver_bias", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_custom_solver_bias", "get_custom_solver_bias");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "margin", PROPERTY_HINT_RANGE, "0.001,10,0.001,suffix:m"), "set_margin", "get_margin");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "margin", PROPERTY_HINT_RANGE, "0,10,0.001,or_greater,suffix:m"), "set_margin", "get_margin");
 }
 
 Shape3D::Shape3D() {


### PR DESCRIPTION
Seeing as how the `margin` property of `Shape3D` managed to make its way into 4.0-stable, despite not being used by Godot Physics, I figured we might as well make some changes to better support other physics engines.

I rephrased the documentation to reflect that it's not only Bullet Physics that uses this, since it's also a thing in other GJK-based physics engines such as Havok, Jolt, Rapier, etc.

I also opened up the bounds of the property by changing the lower bound from 0.001 to 0 and adding the `or_greater` hint to allow for values greater than its upper bound. Jolt Physics (for example) has no issues using a margin of 0, apart from the performance drawbacks, and having 10 be a hard upper bound seemed somewhat arbitrary.