### PR TITLE
Change looking_at in Transform2D to work with skew

### DIFF
--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -173,10 +173,9 @@ bool Transform2D::is_finite() const {
 }
 
 Transform2D Transform2D::looking_at(const Vector2 &p_target) const {
-	Transform2D return_trans = Transform2D(get_rotation(), get_origin());
-	Vector2 target_position = affine_inverse().xform(p_target);
-	return_trans.set_rotation(return_trans.get_rotation() + (target_position * get_scale()).angle());
-	return return_trans;
+	const Vector2 origin = get_origin();
+	real_t target_angle = (p_target - get_origin()).angle();
+	return Transform2D(target_angle, origin);
 }
 
 bool Transform2D::operator==(const Transform2D &p_transform) const {


### PR DESCRIPTION
As raised in #74966, Transform2D currently produces a wrong matrix with skew and changes both scale and skew after applied, failing the tests in mentioned in #74999. This new version produces the correct matrix with skew and keeps scale and skew the same after applied. 
