### PR TITLE
GPUParticles3D: Zero modelview matrix of billboard materials when model matrix is zeroes

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -950,6 +950,10 @@ void BaseMaterial3D::_update_shader() {
 
 			if (flags[FLAG_BILLBOARD_KEEP_SCALE]) {
 				code += "	MODELVIEW_MATRIX = MODELVIEW_MATRIX * mat4(vec4(length(MODEL_MATRIX[0].xyz), 0.0, 0.0, 0.0), vec4(0.0, length(MODEL_MATRIX[1].xyz), 0.0, 0.0), vec4(0.0, 0.0, length(MODEL_MATRIX[2].xyz), 0.0), vec4(0.0, 0.0, 0.0, 1.0));\n";
+			} else {
+				// Do not render if model affine matrix has an exactly zero first column: a completely 0 model matrix is used by particle system to indicate an inactive particle
+				code += "	float col_sum = abs(MODEL_MATRIX[0][0]) + abs(MODEL_MATRIX[0][1]) + abs(MODEL_MATRIX[0][2]);\n";
+				code += "	if (col_sum == 0.0) { MODELVIEW_MATRIX = mat4(0.0); }\n";
 			}
 			code += "	MODELVIEW_NORMAL_MATRIX = mat3(MODELVIEW_MATRIX);\n";
 		} break;
@@ -958,6 +962,10 @@ void BaseMaterial3D::_update_shader() {
 
 			if (flags[FLAG_BILLBOARD_KEEP_SCALE]) {
 				code += "	MODELVIEW_MATRIX = MODELVIEW_MATRIX * mat4(vec4(length(MODEL_MATRIX[0].xyz), 0.0, 0.0, 0.0),vec4(0.0, length(MODEL_MATRIX[1].xyz), 0.0, 0.0), vec4(0.0, 0.0, length(MODEL_MATRIX[2].xyz), 0.0), vec4(0.0, 0.0, 0.0, 1.0));\n";
+			} else {
+				// Do not render if model affine matrix has an exactly zero first column: a completely 0 model matrix is used by particle system to indicate an inactive particle
+				code += "	float col_sum = abs(MODEL_MATRIX[0][0]) + abs(MODEL_MATRIX[0][1]) + abs(MODEL_MATRIX[0][2]);\n";
+				code += "	if (col_sum == 0.0) { MODELVIEW_MATRIX = mat4(0.0); }\n";
 			}
 			code += "	MODELVIEW_NORMAL_MATRIX = mat3(MODELVIEW_MATRIX);\n";
 		} break;
@@ -970,6 +978,10 @@ void BaseMaterial3D::_update_shader() {
 			code += "	MODELVIEW_MATRIX = VIEW_MATRIX * mat_world;\n";
 			if (flags[FLAG_BILLBOARD_KEEP_SCALE]) {
 				code += "	MODELVIEW_MATRIX = MODELVIEW_MATRIX * mat4(vec4(length(MODEL_MATRIX[0].xyz), 0.0, 0.0, 0.0),vec4(0.0, length(MODEL_MATRIX[1].xyz), 0.0, 0.0), vec4(0.0, 0.0, length(MODEL_MATRIX[2].xyz), 0.0), vec4(0.0, 0.0, 0.0, 1.0));\n";
+			} else {
+				// Do not render if model affine matrix has an exactly zero first column: a completely 0 model matrix is used by particle system to indicate an inactive particle
+				code += "	float col_sum = abs(MODEL_MATRIX[0][0]) + abs(MODEL_MATRIX[0][1]) + abs(MODEL_MATRIX[0][2]);\n";
+				code += "	if (col_sum == 0.0) { MODELVIEW_MATRIX = mat4(0.0); }\n";
 			}
 			//set modelview normal
 			code += "	MODELVIEW_NORMAL_MATRIX = mat3(MODELVIEW_MATRIX);\n";


### PR DESCRIPTION
Resolves #72650 by zeroing the modelview matrix of billboards when all scales (X, Y, Z) of the model matrix are exactly zero. This was hypothesized to be the issue by @QbieShay in [this comment](https://github.com/godotengine/godot/issues/72650#issuecomment-1441794536): the particle gets a [zero transform when it is inactive](https://github.com/godotengine/godot/blob/a7d0e18a317085068c43be29bca1d280d03423a2/servers/rendering/renderer_rd/shaders/particles_copy.glsl#L212), but since the billboarded material [ignores the rotation/scale of the model matrix](https://github.com/godotengine/godot/blob/a7d0e18a317085068c43be29bca1d280d03423a2/scene/resources/material.cpp#L949), this method of preventing them from being rendered was not working.

![gpuparticles_billboarding_resolution](https://user-images.githubusercontent.com/6766142/226147774-e55a95f7-4842-47b3-ab10-d11fef071b9b.gif)

This implementation introduces a conditional branch to the shader for billboarded materials. An alternative is a non-branching implementation that adds an unconditional 16 multiplications with e.g. the following line:
```
code += "	MODELVIEW_MATRIX = float(scale_sum != 0.0) * MODELVIEW_MATRIX;\n";
```
I chose the branching form since it will nearly always be synchronized across the wavefront, particularly in the non-particle use-case where the scales will all be non-zero, and this will most often avoid the cost of the 16 multiplications.