### PR TITLE
Enable dependency fixer for missing InstancePlaceholder paths

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1049,7 +1049,14 @@ void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, const 
 					fi->script_class_name = _get_global_script_class(fi->type, path, &fi->script_class_extends, &fi->script_class_icon_path);
 					fi->import_valid = fi->type == "TextFile" ? true : ResourceLoader::is_import_valid(path);
 					fi->import_group_file = ResourceLoader::get_import_group_file(path);
-
+					ResourceUID::ID file_uid = ResourceLoader::get_resource_uid(path);
+					if (file_uid != ResourceUID::INVALID_ID) {
+						fi->uid = ResourceLoader::get_resource_uid(path);
+						if (ResourceUID::get_singleton()->has_id(file_uid)) {
+							ResourceUID::get_singleton()->set_id(file_uid, path);
+						}
+						fi->uid = file_uid;
+					}
 					{
 						ItemAction ia;
 						ia.action = ItemAction::ACTION_FILE_ADD;

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -825,7 +825,7 @@ Error ResourceLoaderText::load() {
 			return error;
 		}
 
-		for(List<String>::Element *E = placeholder_paths.front(); E; E = E->next()) {
+		for (List<String>::Element *E = placeholder_paths.front(); E; E = E->next()) {
 			String path = E->get();
 			if (!ResourceLoader::exists(path)) {
 				if (ResourceLoader::get_abort_on_missing_resources()) {

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -939,7 +939,9 @@ void ResourceLoaderText::get_dependencies(Ref<FileAccess> p_f, List<String> *p_d
 					if (p_add_types) {
 						path += "::PackedScene"; // Probably not necessary
 					}
-					p_dependencies->push_back(path);
+					if (p_dependencies->find(path) == nullptr) {
+						p_dependencies->push_back(path);
+					}
 				}
 			}
 		}

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -113,7 +113,7 @@ class ResourceLoaderText {
 
 	Ref<Resource> resource;
 
-	Ref<PackedScene> _parse_node_tag(VariantParser::ResourceParser &parser);
+	Ref<PackedScene> _parse_node_tag(VariantParser::ResourceParser &parser, List<String> *p_placeholder_paths = nullptr);
 
 public:
 	Ref<Resource> get_resource();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/37818. Fixes https://github.com/godotengine/godot/issues/44720.

This treats placeholder paths as a dependency to invoke the regular ext_resource dependency fixer.
This also fixes file-reimport not retaining existing uids for resources that were renamed, and resource dependency renaming also not transitioning existing uids.

I chose to string-replace occurrences, as it was much more straightforward than parsing and rewriting everything and to not duplicate a lot of code in the process.

