### PR TITLE
add 'is_offline_peer' function to MultiplayerAPI

### DIFF
--- a/doc/classes/MultiplayerPeer.xml
+++ b/doc/classes/MultiplayerPeer.xml
@@ -39,6 +39,12 @@
 				Returns the current state of the connection. See [enum ConnectionStatus].
 			</description>
 		</method>
+		<method name="is_offline_peer" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns the offline status of this [MultiplayerPeer].
+			</description>
+		</method>
 		<method name="get_packet_channel" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -60,6 +60,7 @@ public:
 	virtual void close() override {}
 	virtual int get_unique_id() const override { return TARGET_PEER_SERVER; }
 	virtual ConnectionStatus get_connection_status() const override { return CONNECTION_CONNECTED; };
+	virtual bool is_offline_peer() const override { return true; }
 };
 
 class SceneMultiplayer : public MultiplayerAPI {

--- a/scene/main/multiplayer_peer.cpp
+++ b/scene/main/multiplayer_peer.cpp
@@ -98,6 +98,7 @@ void MultiplayerPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("disconnect_peer", "peer", "force"), &MultiplayerPeer::disconnect_peer, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("get_connection_status"), &MultiplayerPeer::get_connection_status);
+	ClassDB::bind_method(D_METHOD("is_offline_peer"), &MultiplayerPeer::is_offline_peer);
 	ClassDB::bind_method(D_METHOD("get_unique_id"), &MultiplayerPeer::get_unique_id);
 	ClassDB::bind_method(D_METHOD("generate_unique_id"), &MultiplayerPeer::generate_unique_id);
 

--- a/scene/main/multiplayer_peer.h
+++ b/scene/main/multiplayer_peer.h
@@ -92,6 +92,7 @@ public:
 	virtual int get_unique_id() const = 0;
 
 	virtual ConnectionStatus get_connection_status() const = 0;
+	virtual bool is_offline_peer() const { return false; }
 
 	uint32_t generate_unique_id() const;
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

addresses #75049

to-do: add documentation for function

might be a good idea to remove/deprecate `has_multiplayer_peer` as it will only ever return true
