### PR TITLE
[3.x] Implement UWP version of `OS.get_unique_id` function.

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -550,7 +550,7 @@
 			<description>
 				Returns a string that is unique to the device.
 				[b]Note:[/b] This string may change without notice if the user reinstalls/upgrades their operating system or changes their hardware. This means it should generally not be used to encrypt persistent data as the data saved before an unexpected ID change would become inaccessible. The returned string may also be falsified using external programs, so do not rely on the string returned by [method get_unique_id] for security purposes.
-				[b]Note:[/b] Returns an empty string on HTML5 and UWP, as this method isn't implemented on those platforms yet.
+				[b]Note:[/b] Returns an empty string on HTML5, as this method isn't implemented on this platform yet.
 			</description>
 		</method>
 		<method name="get_unix_time" qualifiers="const">

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -59,6 +59,8 @@ using namespace Windows::UI::ViewManagement;
 using namespace Windows::Devices::Input;
 using namespace Windows::Devices::Sensors;
 using namespace Windows::ApplicationModel::DataTransfer;
+using namespace Windows::System::Profile;
+using namespace Windows::Storage::Streams;
 using namespace concurrency;
 
 int OS_UWP::get_video_driver_count() const {
@@ -705,6 +707,36 @@ String OS_UWP::get_executable_path() const {
 }
 
 void OS_UWP::set_icon(const Ref<Image> &p_icon) {
+}
+
+String OS_UWP::get_unique_id() const {
+	// Get the hardware token and read it into an array of bytes.
+	HardwareToken ^ token = HardwareIdentification::GetPackageSpecificToken(nullptr);
+	IBuffer hwId = token->Id;
+	DataReader ^ dr = DataReader::FromBuffer(hwId);
+	uint8_t *data = new uint8_t[hwId->Length];
+	dr->ReadBytes(Platform::ArrayReference<uint8_t>(data, hwId->Length));
+
+	// Convert the byte array to hexadecimal.
+	String id;
+	char hexStr[3] = "00";
+
+	for (int i = 0; i < hwId->Length; i++) {
+		// Convert next byte to hexadecimal.
+		sprintf(hexStr, "%x", (int)data[i]);
+
+		if (data[i] < 16) {
+			hexStr[1] = hexStr[0];
+			hexStr[0] = '0';
+		}
+
+		// Add the next 2 hexits to the ID string.
+		id += hexStr;
+	}
+
+	// Free the temporary data array and return the device ID.
+	delete[] data;
+	return id;
 }
 
 bool OS_UWP::has_environment(const String &p_var) const {

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -217,6 +217,8 @@ public:
 	virtual void set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot);
 	void set_icon(const Ref<Image> &p_icon);
 
+	virtual String get_unique_id() const;
+
 	virtual String get_executable_path() const;
 
 	virtual String get_locale() const;


### PR DESCRIPTION
I have successfully implemented the `OS.get_unique_id` function for 
Universal Windows builds of Godot.

Here is a basic overview of how it works:
1. fetch package specific token
2. get an IBuffer interface for the hardware specific ID of the package 
3. create a data reader to read the hardware ID data
4. allocate a buffer to hold the hardware ID data
5. read the hardware ID data into the buffer
6. convert the hardware ID data into a hexadecimal string
7. free the buffer
8. return the hexadecimal ID string