### PR TITLE
Don't use saved editor dialog size in single-window-mode.

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -457,7 +457,7 @@ void CreateDialog::_notification(int p_what) {
 				search_box->call_deferred(SNAME("grab_focus")); // still not visible
 				search_box->select_all();
 			} else {
-				EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "create_new_node", Rect2(get_position(), get_size()));
+				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "create_new_node", Rect2(get_position(), get_size()));
 			}
 		} break;
 
@@ -805,4 +805,5 @@ CreateDialog::CreateDialog() {
 
 	register_text_enter(search_box);
 	set_hide_on_ok(false);
+	set_clamp_to_embedder(true);
 }

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -182,6 +182,7 @@ void EditorHelpSearch::popup_dialog(const String &p_term) {
 
 EditorHelpSearch::EditorHelpSearch() {
 	set_hide_on_ok(false);
+	set_clamp_to_embedder(true);
 
 	set_title(TTR("Search Help"));
 

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -698,6 +698,7 @@ void EditorSettingsDialog::_bind_methods() {
 
 EditorSettingsDialog::EditorSettingsDialog() {
 	set_title(TTR("Editor Settings"));
+	set_clamp_to_embedder(true);
 
 	tabs = memnew(TabContainer);
 	tabs->set_theme_type_variation("TabContainerOdd");

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1078,6 +1078,7 @@ void ProjectExportDialog::_bind_methods() {
 
 ProjectExportDialog::ProjectExportDialog() {
 	set_title(TTR("Export"));
+	set_clamp_to_embedder(true);
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
 	main_vb->connect("theme_changed", callable_mp(this, &ProjectExportDialog::_theme_changed));

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -582,6 +582,7 @@ void ProjectSettingsEditor::_bind_methods() {
 ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	singleton = this;
 	set_title(TTR("Project Settings (project.godot)"));
+	set_clamp_to_embedder(true);
 
 	ps = ProjectSettings::get_singleton();
 	data = p_data;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1554,9 +1554,36 @@ void Window::popup(const Rect2i &p_screen_rect) {
 		ERR_PRINT(vformat("Window %d spawned at invalid position: %s.", get_window_id(), position));
 		set_position((parent_rect.size - size) / 2);
 	}
+	if (parent_rect != Rect2i() && is_clamped_to_embedder()) {
+		Rect2i new_rect = fit_rect_in_parent(Rect2i(position, size), parent_rect);
+		set_position(new_rect.position);
+		set_size(new_rect.size);
+	}
 
 	_post_popup();
 	notification(NOTIFICATION_POST_POPUP);
+}
+
+Rect2i Window::fit_rect_in_parent(Rect2i p_rect, const Rect2i &p_parent_rect) const {
+	Size2i limit = p_parent_rect.size;
+	if (p_rect.position.x + p_rect.size.x > limit.x) {
+		p_rect.position.x = limit.x - p_rect.size.x;
+	}
+	if (p_rect.position.y + p_rect.size.y > limit.y) {
+		p_rect.position.y = limit.y - p_rect.size.y;
+	}
+
+	if (p_rect.position.x < 0) {
+		p_rect.position.x = 0;
+	}
+
+	int title_height = get_flag(Window::FLAG_BORDERLESS) ? 0 : get_theme_constant(SNAME("title_height"));
+
+	if (p_rect.position.y < title_height) {
+		p_rect.position.y = title_height;
+	}
+
+	return p_rect;
 }
 
 Size2 Window::get_contents_minimum_size() const {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -310,6 +310,7 @@ public:
 	void popup_centered(const Size2i &p_minsize = Size2i());
 	void popup_centered_clamped(const Size2i &p_size = Size2i(), float p_fallback_ratio = 0.75);
 
+	Rect2i fit_rect_in_parent(Rect2i p_rect, const Rect2i &p_parent_rect) const;
 	Size2 get_contents_minimum_size() const;
 	Size2 get_clamped_minimum_size() const;
 


### PR DESCRIPTION
Fixes #75084.

If single_window_mode is enabled, trying to place editor dialogs with a saved size
often looks wrong if the main editor window has been resized.
This can result in windows being partially (or mostly) off-screen,
or just off-centered.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
