### PR TITLE
Add a subframes option to Movie Maker mode to improve rendering quality

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -312,6 +312,14 @@ void Engine::set_write_movie_path(const String &p_path) {
 	write_movie_path = p_path;
 }
 
+int Engine::get_write_movie_subframes() const {
+	return write_movie_subframes;
+}
+
+void Engine::set_write_movie_subframes(int p_subframes) {
+	write_movie_subframes = p_subframes;
+}
+
 void Engine::set_shader_cache_path(const String &p_path) {
 	shader_cache_path = p_path;
 }

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -83,6 +83,7 @@ private:
 	static Engine *singleton;
 
 	String write_movie_path;
+	int write_movie_subframes = 0;
 	String shader_cache_path;
 
 public:
@@ -153,6 +154,9 @@ public:
 
 	void set_write_movie_path(const String &p_path);
 	String get_write_movie_path() const;
+
+	void set_write_movie_subframes(int p_subframes);
+	int get_write_movie_subframes() const;
 
 	String get_architecture_name() const;
 

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1710,6 +1710,10 @@ String Engine::get_write_movie_path() const {
 	return ::Engine::get_singleton()->get_write_movie_path();
 }
 
+int Engine::get_write_movie_subframes() const {
+	return ::Engine::get_singleton()->get_write_movie_subframes();
+}
+
 void Engine::set_print_error_messages(bool p_enabled) {
 	::Engine::get_singleton()->set_print_error_messages(p_enabled);
 }
@@ -1765,6 +1769,7 @@ void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_editor_hint"), &Engine::is_editor_hint);
 
 	ClassDB::bind_method(D_METHOD("get_write_movie_path"), &Engine::get_write_movie_path);
+	ClassDB::bind_method(D_METHOD("get_write_movie_subframes"), &Engine::get_write_movie_subframes);
 
 	ClassDB::bind_method(D_METHOD("set_print_error_messages", "enabled"), &Engine::set_print_error_messages);
 	ClassDB::bind_method(D_METHOD("is_printing_error_messages"), &Engine::is_printing_error_messages);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -523,6 +523,9 @@ public:
 	// `set_write_movie_path()` is not exposed to the scripting API as changing it at run-time has no effect.
 	String get_write_movie_path() const;
 
+	// `set_write_movie_subframes()` is not exposed to the scripting API as changing it at run-time has no effect.
+	int get_write_movie_subframes() const;
+
 	void set_print_error_messages(bool p_enabled);
 	bool is_printing_error_messages() const;
 

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -205,7 +205,13 @@
 		<method name="get_write_movie_path" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the path to the [MovieWriter]'s output file, or an empty string if the engine wasn't started in Movie Maker mode. This path can be absolute or relative depending on how the user specified it.
+				Returns the path to the [MovieWriter]'s output file, or an empty string if the engine wasn't started in Movie Maker mode. This path can be absolute or relative depending on how the user specified it. See [member ProjectSettings.editor/movie_writer/movie_file].
+			</description>
+		</method>
+		<method name="get_write_movie_subframes" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of subframes will be rendered by the engine between every frame sent to the [MovieWriter] for saving. See [member ProjectSettings.editor/movie_writer/subframes].
 			</description>
 		</method>
 		<method name="has_singleton" qualifiers="const">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -875,6 +875,9 @@
 		<member name="editor/movie_writer/speaker_mode" type="int" setter="" getter="" default="0">
 			The speaker mode to use in the recorded audio when writing a movie. See [enum AudioServer.SpeakerMode] for possible values.
 		</member>
+		<member name="editor/movie_writer/subframes" type="int" setter="" getter="" default="0">
+			If set to a value greater than [code]0[/code], enables sub-frame generation. This will render more frames than will be recorded in the given video by the factor [code]1 + subframes[/code]. For example, setting [member editor/movie_writer/subframes] to [code]3[/code] will render 4 times as many frames as will be present in the final video file. This will improve rendering quality in 3D by allowing temporal effects (TAA, volumetric fog, SDFGI) to converge faster and more accurately.
+		</member>
 		<member name="editor/naming/default_signal_callback_name" type="String" setter="" getter="" default="&quot;_on_{node_name}_{signal_name}&quot;">
 			The format of the default signal callback name (in the Signal Connection Dialog). The following substitutions are available: [code]{NodeName}[/code], [code]{nodeName}[/code], [code]{node_name}[/code], [code]{SignalName}[/code], [code]{signalName}[/code], and [code]{signal_name}[/code].
 		</member>

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -134,6 +134,10 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 		if (bool(GLOBAL_GET("editor/movie_writer/disable_vsync"))) {
 			args.push_back("--disable-vsync");
 		}
+		if (int(GLOBAL_GET("editor/movie_writer/subframes")) >= 1) {
+			args.push_back("--write-movie-subframes");
+			args.push_back(GLOBAL_GET("editor/movie_writer/subframes"));
+		}
 	}
 
 	int screen = EDITOR_GET("run/window_placement/screen");

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -438,6 +438,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("                                    --fixed-fps is forced when enabled, but it can be used to change movie FPS.\n");
 	OS::get_singleton()->print("                                    --disable-vsync can speed up movie writing but makes interaction more difficult.\n");
 	OS::get_singleton()->print("                                    --quit-after can be used to specify the number of frames to write.\n");
+	OS::get_singleton()->print("  --write-movie-subframes <N>       Number of subframes to render for each frame recorded (requires --write-movie).\n");
 
 	OS::get_singleton()->print("\n");
 
@@ -1460,6 +1461,14 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing write-movie argument, aborting.\n");
 				goto error;
 			}
+		} else if (I->get() == "--write-movie-subframes") {
+			if (I->next()) {
+				Engine::get_singleton()->set_write_movie_subframes(I->next()->get().to_int());
+				N = I->next()->next();
+			} else {
+				OS::get_singleton()->print("Missing movie-subframes argument, aborting.\n");
+				goto error;
+			}
 		} else if (I->get() == "--disable-vsync") {
 			disable_vsync = true;
 		} else if (I->get() == "--print-fps") {
@@ -1509,6 +1518,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		}
 
 		I = N;
+	}
+
+	if (OS::get_singleton()->_writing_movie) {
+		// Automatically adjust fixed FPS to take subframes into account, so that the *output* video FPS is the same.
+		fixed_fps *= 1 + Engine::get_singleton()->get_write_movie_subframes();
 	}
 
 #ifdef TOOLS_ENABLED
@@ -3357,7 +3371,7 @@ bool Main::start() {
 	}
 
 	if (movie_writer) {
-		movie_writer->begin(DisplayServer::get_singleton()->window_get_size(), fixed_fps, Engine::get_singleton()->get_write_movie_path());
+		movie_writer->begin(DisplayServer::get_singleton()->window_get_size(), fixed_fps / (1 + Engine::get_singleton()->get_write_movie_subframes()), Engine::get_singleton()->get_write_movie_path());
 	}
 
 	if (minimum_time_msec) {
@@ -3570,7 +3584,9 @@ bool Main::iteration() {
 	}
 
 	if (movie_writer) {
-		movie_writer->add_frame();
+		if (Engine::get_singleton()->_process_frames % (1 + Engine::get_singleton()->get_write_movie_subframes()) == 0) {
+			movie_writer->add_frame();
+		}
 	}
 
 	if ((quit_after > 0) && (Engine::get_singleton()->_process_frames >= quit_after)) {

--- a/misc/dist/shell/_godot.zsh-completion
+++ b/misc/dist/shell/_godot.zsh-completion
@@ -52,6 +52,7 @@ _arguments \
   '--tablet-driver[set the pen tablet input driver]:tablet driver name' \
   '--headless[enable headless mode (--display-driver headless --audio-driver Dummy), useful for servers and with --script]' \
   '--write-movie[writes a video to the specified path (usually with .avi or .png extension)]:path to output video file' \
+  '--write-movie-subframes[number of subframes to render for each frame recorded (requires --write-movie)]:number of subframes per frame' \
   '(-f --fullscreen)'{-f,--fullscreen}'[request fullscreen mode]' \
   '(-m --maximized)'{-m,--maximized}'[request a maximized window]' \
   '(-w --windowed)'{-w,--windowed}'[request windowed mode]' \

--- a/misc/dist/shell/godot.bash-completion
+++ b/misc/dist/shell/godot.bash-completion
@@ -55,6 +55,7 @@ _complete_godot_options() {
 --tablet-driver
 --headless
 --write-movie
+--write-movie-subframes
 --fullscreen
 --maximized
 --windowed

--- a/servers/movie_writer/movie_writer.h
+++ b/servers/movie_writer/movie_writer.h
@@ -39,6 +39,7 @@ class MovieWriter : public Object {
 	GDCLASS(MovieWriter, Object);
 
 	uint64_t fps = 0;
+	uint32_t subframes = 0;
 	uint64_t mix_rate = 0;
 	uint32_t audio_channels = 0;
 


### PR DESCRIPTION
If set to a value greater than 0, enables sub-frame generation. This will render more frames than will be recorded in the given video by the factor `1 + subframes`. For example, setting `--write-movie-subframes 3` will render 4 times as many frames as will be present in the final video file.

This will improve rendering quality in 3D by allowing temporal effects (TAA, volumetric fog, SDFGI) to converge faster and more accurately.

- This closes https://github.com/godotengine/godot-proposals/issues/6543.

## Preview

### Subframes disabled

Notice how antialiasing is less stable (especially on the reflective spheres) and SDFGI visibly takes time to converge when the scene loads.

https://user-images.githubusercontent.com/180032/226412511-3e36af73-227c-40c7-b116-6349ab5eb122.mp4

### With 99 subframes (highest value you can set in project settings)

Recording is much slower to perform, but temporal features appear to converge instantly. You don't *need* 99 subframes for optimal rendering quality (3-7 subframes will get you pretty far already), but this is to show an extreme example.

https://user-images.githubusercontent.com/180032/226412231-5254883f-b1f4-42fa-a995-daceadd41231.mp4