### PR TITLE
GPUParticles3D: Translate inactive particles to -INF

### DIFF
--- a/drivers/gles3/shaders/particles_copy.glsl
+++ b/drivers/gles3/shaders/particles_copy.glsl
@@ -44,8 +44,12 @@ uniform highp mat4 inv_emission_transform;
 
 #define PARTICLE_FLAG_ACTIVE uint(1)
 
+#define FLT_MAX float(3.402823466e+38)
+
 void main() {
-	mat4 txform = mat4(vec4(0.0), vec4(0.0), vec4(0.0), vec4(0.0)); // zero scale, becomes invisible.
+	// Set scale to zero and translate to -INF so particle will be invisible
+	// even for materials that ignore rotation/scale (i.e. billboards).
+	mat4 txform = mat4(vec4(0.0), vec4(0.0), vec4(0.0), vec4(-FLT_MAX, -FLT_MAX, -FLT_MAX, 0.0));
 	if (bool(floatBitsToUint(velocity_flags.w) & PARTICLE_FLAG_ACTIVE)) {
 #ifdef MODE_3D
 		txform = transpose(mat4(xform_1, xform_2, xform_3, vec4(0.0, 0.0, 0.0, 1.0)));
@@ -102,9 +106,8 @@ void main() {
 		// as they will be drawn with the node position as origin.
 		txform = inv_emission_transform * txform;
 #endif
-
-		txform = transpose(txform);
 	}
+	txform = transpose(txform);
 
 	instance_color_custom_data = uvec4(packHalf2x16(color.xy), packHalf2x16(color.zw), packHalf2x16(custom.xy), packHalf2x16(custom.zw));
 	out_xform_1 = txform[0];

--- a/servers/rendering/renderer_rd/shaders/particles_copy.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles_copy.glsl
@@ -206,11 +206,12 @@ void main() {
 			// as they will be drawn with the node position as origin.
 			txform = params.inv_emission_transform * txform;
 		}
-
-		txform = transpose(txform);
 	} else {
-		txform = mat4(vec4(0.0), vec4(0.0), vec4(0.0), vec4(0.0)); //zero scale, becomes invisible
+		// Set scale to zero and translate to -INF so particle will be invisible
+		// even for materials that ignore rotation/scale (i.e. billboards).
+		txform = mat4(vec4(0.0), vec4(0.0), vec4(0.0), vec4(-1.0 / 0.0, -1.0 / 0.0, -1.0 / 0.0, 0.0));
 	}
+	txform = transpose(txform);
 
 	if (params.copy_mode_2d) {
 		uint write_offset = gl_GlobalInvocationID.x * (2 + 1 + 1); //xform + color + custom


### PR DESCRIPTION
Resolves #72650 by translating inactive particles to negative infinity. This solution was proposed by @Calinou in [this comment](https://github.com/godotengine/godot/issues/72650#issuecomment-1475087225). Note that this is an alternate to #75090 and only one is needed.

![gpuparticles_billboarding_resolution2](https://user-images.githubusercontent.com/6766142/226495440-6d67b6b7-5c03-46d1-866d-b1eb5971b92b.gif)