### PR TITLE
Allow more flexible adjustments of VisualInstance3D Lightmap Scale

### DIFF
--- a/doc/classes/GeometryInstance3D.xml
+++ b/doc/classes/GeometryInstance3D.xml
@@ -39,8 +39,12 @@
 		<member name="extra_cull_margin" type="float" setter="set_extra_cull_margin" getter="get_extra_cull_margin" default="0.0">
 			The extra distance added to the GeometryInstance3D's bounding box ([AABB]) to increase its cull box.
 		</member>
-		<member name="gi_lightmap_scale" type="int" setter="set_lightmap_scale" getter="get_lightmap_scale" enum="GeometryInstance3D.LightmapScale" default="0">
+		<member name="gi_lightmap_scale" type="int" setter="set_lightmap_scale" getter="get_lightmap_scale" enum="GeometryInstance3D.LightmapScale" default="0" deprecated="Use [member gi_lightmap_texel_scale] instead.">
+			The texel density to use for lightmapping in [LightmapGI].
+		</member>
+		<member name="gi_lightmap_texel_scale" type="float" setter="set_lightmap_texel_scale" getter="get_lightmap_texel_scale" default="1.0">
 			The texel density to use for lightmapping in [LightmapGI]. Greater scale values provide higher resolution in the lightmap, which can result in sharper shadows for lights that have both direct and indirect light baked. However, greater scale values will also increase the space taken by the mesh in the lightmap texture, which increases the memory, storage, and bake time requirements. When using a single mesh at different scales, consider adjusting this value to keep the lightmap texel density consistent across meshes.
+			For example, doubling [member gi_lightmap_texel_scale] doubles the lightmap texture resolution for this object [i]on each axis[/i], so it will [i]quadruple[/i] the texel count.
 		</member>
 		<member name="gi_mode" type="int" setter="set_gi_mode" getter="get_gi_mode" enum="GeometryInstance3D.GIMode" default="1" keywords="global_illumination_mode, light_bake_mode">
 			The global illumination mode to use for the whole geometry. To avoid inconsistent results, use a mode that matches the purpose of the mesh during gameplay (static/dynamic).
@@ -111,19 +115,19 @@
 		<constant name="GI_MODE_DYNAMIC" value="2" enum="GIMode">
 			Dynamic global illumination mode. Use for dynamic objects that contribute to global illumination. This GI mode is only effective when using [VoxelGI], but it has a higher performance impact than [constant GI_MODE_STATIC]. When using other GI methods, this will act the same as [constant GI_MODE_DISABLED]. When using [LightmapGI], the object will receive indirect lighting using lightmap probes instead of using the baked lightmap texture.
 		</constant>
-		<constant name="LIGHTMAP_SCALE_1X" value="0" enum="LightmapScale">
+		<constant name="LIGHTMAP_SCALE_1X" value="0" enum="LightmapScale" deprecated="Use [member gi_lightmap_texel_scale] instead.">
 			The standard texel density for lightmapping with [LightmapGI].
 		</constant>
-		<constant name="LIGHTMAP_SCALE_2X" value="1" enum="LightmapScale">
+		<constant name="LIGHTMAP_SCALE_2X" value="1" enum="LightmapScale" deprecated="Use [member gi_lightmap_texel_scale] instead.">
 			Multiplies texel density by 2× for lightmapping with [LightmapGI]. To ensure consistency in texel density, use this when scaling a mesh by a factor between 1.5 and 3.0.
 		</constant>
-		<constant name="LIGHTMAP_SCALE_4X" value="2" enum="LightmapScale">
+		<constant name="LIGHTMAP_SCALE_4X" value="2" enum="LightmapScale" deprecated="Use [member gi_lightmap_texel_scale] instead.">
 			Multiplies texel density by 4× for lightmapping with [LightmapGI]. To ensure consistency in texel density, use this when scaling a mesh by a factor between 3.0 and 6.0.
 		</constant>
-		<constant name="LIGHTMAP_SCALE_8X" value="3" enum="LightmapScale">
+		<constant name="LIGHTMAP_SCALE_8X" value="3" enum="LightmapScale" deprecated="Use [member gi_lightmap_texel_scale] instead.">
 			Multiplies texel density by 8× for lightmapping with [LightmapGI]. To ensure consistency in texel density, use this when scaling a mesh by a factor greater than 6.0.
 		</constant>
-		<constant name="LIGHTMAP_SCALE_MAX" value="4" enum="LightmapScale">
+		<constant name="LIGHTMAP_SCALE_MAX" value="4" enum="LightmapScale" deprecated="Use [member gi_lightmap_texel_scale] instead.">
 			Represents the size of the [enum LightmapScale] enum.
 		</constant>
 		<constant name="VISIBILITY_RANGE_FADE_DISABLED" value="0" enum="VisibilityRangeFadeMode">

--- a/doc/classes/LightmapGI.xml
+++ b/doc/classes/LightmapGI.xml
@@ -70,6 +70,7 @@
 		</member>
 		<member name="texel_scale" type="float" setter="set_texel_scale" getter="get_texel_scale" default="1.0">
 			Scales the lightmap texel density of all meshes for the current bake. This is a multiplier that builds upon the existing lightmap texel size defined in each imported 3D scene, along with the per-mesh density multiplier (which is designed to be used when the same mesh is used at different scales). Lower values will result in faster bake times.
+			For example, doubling [member texel_scale] doubles the lightmap texture resolution for all objects [i]on each axis[/i], so it will [i]quadruple[/i] the texel count.
 		</member>
 		<member name="use_denoiser" type="bool" setter="set_use_denoiser" getter="is_using_denoiser" default="true">
 			If [code]true[/code], uses a GPU-based denoising algorithm on the generated lightmap. This eliminates most noise within the generated lightmap at the cost of longer bake times. File sizes are generally not impacted significantly by the use of a denoiser, although lossless compression may do a better job at compressing a denoised image.

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -333,9 +333,7 @@ void LightmapGI::_find_meshes_and_lights(Node *p_at_node, Vector<MeshesFound> &m
 				mf.node_path = get_path_to(mi);
 				mf.subindex = -1;
 				mf.mesh = mesh;
-
-				static const int lightmap_scale[GeometryInstance3D::LIGHTMAP_SCALE_MAX] = { 1, 2, 4, 8 };
-				mf.lightmap_scale = lightmap_scale[mi->get_lightmap_scale()];
+				mf.lightmap_scale = mi->get_lightmap_texel_scale();
 
 				Ref<Material> all_override = mi->get_material_override();
 				for (int i = 0; i < mesh->get_surface_count(); i++) {
@@ -369,7 +367,7 @@ void LightmapGI::_find_meshes_and_lights(Node *p_at_node, Vector<MeshesFound> &m
 				mf.xform = xf * mesh_xf;
 				mf.node_path = get_path_to(s);
 				mf.subindex = i / 2;
-				mf.lightmap_scale = 1;
+				mf.lightmap_scale = 1.0;
 				mf.mesh = mesh;
 
 				meshes.push_back(mf);

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -194,7 +194,7 @@ private:
 		NodePath node_path;
 		int32_t subindex = 0;
 		Ref<Mesh> mesh;
-		int32_t lightmap_scale = 0;
+		float lightmap_scale = 0.0;
 		Vector<Ref<Material>> overrides;
 	};
 

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -454,14 +454,48 @@ AABB GeometryInstance3D::get_custom_aabb() const {
 	return custom_aabb;
 }
 
+void GeometryInstance3D::set_lightmap_texel_scale(float p_scale) {
+	lightmap_texel_scale = p_scale;
+}
+
+float GeometryInstance3D::get_lightmap_texel_scale() const {
+	return lightmap_texel_scale;
+}
+
+#ifndef DISABLE_DEPRECATED
 void GeometryInstance3D::set_lightmap_scale(LightmapScale p_scale) {
 	ERR_FAIL_INDEX(p_scale, LIGHTMAP_SCALE_MAX);
-	lightmap_scale = p_scale;
+	switch (p_scale) {
+		case GeometryInstance3D::LIGHTMAP_SCALE_1X:
+			lightmap_texel_scale = 1.0f;
+			break;
+		case GeometryInstance3D::LIGHTMAP_SCALE_2X:
+			lightmap_texel_scale = 2.0f;
+			break;
+		case GeometryInstance3D::LIGHTMAP_SCALE_4X:
+			lightmap_texel_scale = 4.0f;
+			break;
+		case GeometryInstance3D::LIGHTMAP_SCALE_8X:
+			lightmap_texel_scale = 8.0f;
+			break;
+		case GeometryInstance3D::LIGHTMAP_SCALE_MAX:
+			break; // Can't happen, but silences warning.
+	}
 }
 
 GeometryInstance3D::LightmapScale GeometryInstance3D::get_lightmap_scale() const {
-	return lightmap_scale;
+	// Return closest approximation.
+	if (lightmap_texel_scale < 1.5f) {
+		return GeometryInstance3D::LIGHTMAP_SCALE_1X;
+	} else if (lightmap_texel_scale < 3.0f) {
+		return GeometryInstance3D::LIGHTMAP_SCALE_2X;
+	} else if (lightmap_texel_scale < 6.0f) {
+		return GeometryInstance3D::LIGHTMAP_SCALE_4X;
+	}
+
+	return GeometryInstance3D::LIGHTMAP_SCALE_8X;
 }
+#endif // DISABLE_DEPRECATED
 
 void GeometryInstance3D::set_gi_mode(GIMode p_mode) {
 	switch (p_mode) {
@@ -565,8 +599,13 @@ void GeometryInstance3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_extra_cull_margin", "margin"), &GeometryInstance3D::set_extra_cull_margin);
 	ClassDB::bind_method(D_METHOD("get_extra_cull_margin"), &GeometryInstance3D::get_extra_cull_margin);
 
+	ClassDB::bind_method(D_METHOD("set_lightmap_texel_scale", "scale"), &GeometryInstance3D::set_lightmap_texel_scale);
+	ClassDB::bind_method(D_METHOD("get_lightmap_texel_scale"), &GeometryInstance3D::get_lightmap_texel_scale);
+
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_lightmap_scale", "scale"), &GeometryInstance3D::set_lightmap_scale);
 	ClassDB::bind_method(D_METHOD("get_lightmap_scale"), &GeometryInstance3D::get_lightmap_scale);
+#endif // DISABLE_DEPRECATED
 
 	ClassDB::bind_method(D_METHOD("set_gi_mode", "mode"), &GeometryInstance3D::set_gi_mode);
 	ClassDB::bind_method(D_METHOD("get_gi_mode"), &GeometryInstance3D::get_gi_mode);
@@ -591,7 +630,10 @@ void GeometryInstance3D::_bind_methods() {
 
 	ADD_GROUP("Global Illumination", "gi_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "gi_mode", PROPERTY_HINT_ENUM, "Disabled,Static,Dynamic"), "set_gi_mode", "get_gi_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "gi_lightmap_scale", PROPERTY_HINT_ENUM, String::utf8("1×,2×,4×,8×")), "set_lightmap_scale", "get_lightmap_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "gi_lightmap_texel_scale", PROPERTY_HINT_RANGE, "0.01,10,0.0001,or_greater"), "set_lightmap_texel_scale", "get_lightmap_texel_scale");
+#ifndef DISABLE_DEPRECATED
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "gi_lightmap_scale", PROPERTY_HINT_ENUM, String::utf8("1×,2×,4×,8×"), PROPERTY_USAGE_NONE), "set_lightmap_scale", "get_lightmap_scale");
+#endif // DISABLE_DEPRECATED
 
 	ADD_GROUP("Visibility Range", "visibility_range_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "visibility_range_begin", PROPERTY_HINT_RANGE, "0.0,4096.0,0.01,or_greater,suffix:m"), "set_visibility_range_begin", "get_visibility_range_begin");

--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -134,7 +134,7 @@ private:
 
 	float extra_cull_margin = 0.0;
 	AABB custom_aabb;
-	LightmapScale lightmap_scale = LIGHTMAP_SCALE_1X;
+	float lightmap_texel_scale = 1.0f;
 	GIMode gi_mode = GI_MODE_STATIC;
 	bool ignore_occlusion_culling = false;
 
@@ -185,8 +185,13 @@ public:
 	void set_gi_mode(GIMode p_mode);
 	GIMode get_gi_mode() const;
 
-	void set_lightmap_scale(LightmapScale p_scale);
+	void set_lightmap_texel_scale(float p_scale);
+	float get_lightmap_texel_scale() const;
+
+#ifndef DISABLE_DEPRECATED
+	void set_lightmap_scale(GeometryInstance3D::LightmapScale p_scale);
 	LightmapScale get_lightmap_scale() const;
+#endif // DISABLE_DEPRECATED
 
 	void set_instance_shader_parameter(const StringName &p_name, const Variant &p_value);
 	Variant get_instance_shader_parameter(const StringName &p_name) const;
@@ -203,8 +208,8 @@ public:
 };
 
 VARIANT_ENUM_CAST(GeometryInstance3D::ShadowCastingSetting);
-VARIANT_ENUM_CAST(GeometryInstance3D::LightmapScale);
 VARIANT_ENUM_CAST(GeometryInstance3D::GIMode);
+VARIANT_ENUM_CAST(GeometryInstance3D::LightmapScale);
 VARIANT_ENUM_CAST(GeometryInstance3D::VisibilityRangeFadeMode);
 
 #endif // VISUAL_INSTANCE_3D_H


### PR DESCRIPTION
Any floating-point value greater than 0.01 can now be used. Prior to this change, only factors of 1×, 2× and 4× and 8× could be used.

I haven't spotted negative side effects from this change so far, but please test this in more complex scenes. cc @jcostello @wickedinsignia

- This closes https://github.com/godotengine/godot-proposals/issues/3233. See also https://github.com/godotengine/godot-proposals/issues/6544.

**Testing project:** [test_lightmap_scale_float.zip](https://github.com/godotengine/godot/files/11024200/test_lightmap_scale_float.zip)

## TODO

- [x] Rename the property to something else and add a compatibility handler.

## Preview

*Lightmap Scale from left to right: 0.5×, 1×, 2×, 45×.*

![Screenshot_20230321_022141](https://user-images.githubusercontent.com/180032/226498653-0b3d54fa-4805-4fa9-a0a7-f5580c7be1a8.png)

