### PR TITLE
SCons: Add `stack_size` and `default_pthread_stack_size` options to Web target

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -30,6 +30,9 @@ def get_opts():
 
     return [
         ("initial_memory", "Initial WASM memory (in MiB)", 32),
+        # Matches default values from before Emscripten 3.1.27. New defaults are too low for Godot.
+        ("stack_size", "WASM stack size (in KiB)", 5120),
+        ("default_pthread_stack_size", "WASM pthread default stack size (in KiB)", 2048),
         BoolVariable("use_assertions", "Use Emscripten runtime assertions", False),
         BoolVariable("use_ubsan", "Use Emscripten undefined behavior sanitizer (UBSAN)", False),
         BoolVariable("use_asan", "Use Emscripten address sanitizer (ASAN)", False),
@@ -193,11 +196,6 @@ def configure(env: "Environment"):
     env.Prepend(CPPPATH=["#platform/web"])
     env.Append(CPPDEFINES=["WEB_ENABLED", "UNIX_ENABLED"])
 
-    if cc_semver >= (3, 1, 25):
-        env.Append(LINKFLAGS=["-s", "STACK_SIZE=5MB"])
-    else:
-        env.Append(LINKFLAGS=["-s", "TOTAL_STACK=5MB"])
-
     if env["opengl3"]:
         env.AppendUnique(CPPDEFINES=["GLES3_ENABLED"])
         # This setting just makes WebGL 2 APIs available, it does NOT disable WebGL 1.
@@ -208,11 +206,14 @@ def configure(env: "Environment"):
     if env["javascript_eval"]:
         env.Append(CPPDEFINES=["JAVASCRIPT_EVAL_ENABLED"])
 
+    stack_size_opt = "STACK_SIZE" if cc_semver >= (3, 1, 25) else "TOTAL_STACK"
+    env.Append(LINKFLAGS=["-s", "%s=%sKB" % (stack_size_opt, env["stack_size"])])
+
     # Thread support (via SharedArrayBuffer).
     env.Append(CPPDEFINES=["PTHREAD_NO_RENAME"])
     env.Append(CCFLAGS=["-s", "USE_PTHREADS=1"])
     env.Append(LINKFLAGS=["-s", "USE_PTHREADS=1"])
-    env.Append(LINKFLAGS=["-s", "DEFAULT_PTHREAD_STACK_SIZE=2MB"])
+    env.Append(LINKFLAGS=["-s", "DEFAULT_PTHREAD_STACK_SIZE=%sKB" % env["default_pthread_stack_size"]])
     env.Append(LINKFLAGS=["-s", "PTHREAD_POOL_SIZE=8"])
     env.Append(LINKFLAGS=["-s", "WASM_MEM_MAX=2048MB"])
 


### PR DESCRIPTION
This adds the following compile options to web builds with emscripten:
* `stack_size`: the stack size for the main thread (this cannot be adjusted at runtime), defaults to 5MB
* `default_pthread_stack_size`: the default stack size for any pthreads spawned, defaults to 2MB

The reason for these options being added is because versions of emscripten prior to 3.1.27 had the above default values. emscripten 3.1.27 adjusted the defaults of these down to 64KiB. This ended up breaking a lot of things in Godot; the editor would simply crash due to a stack overflow upon load.

We may want to adjust the default values for these downwards for non-editor builds, but I figured I should just set it back to where it was for now.