### PR TITLE
chore: wrong namespace on document element fix

### DIFF
--- a/misc/dist/linux/org.godotengine.Godot.xml
+++ b/misc/dist/linux/org.godotengine.Godot.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<mime-info xmlns="https://specifications.freedesktop.org/shared-mime-info-spec">
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
   <mime-type type="application/x-godot-project">
     <comment>Godot Engine project</comment>
     <sub-class-of type="text/plain"/>


### PR DESCRIPTION
Wrong namespace on document element in '/usr/share/mime/packages/org.godotengine.Godot.xml' (should be http://www.freedesktop.org/standards/shared-mime-info)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
