### PR TITLE
Add MultiplayerAPI.is_offline() to detect if it's using OfflineMultiplayerPeer

### DIFF
--- a/doc/classes/MultiplayerAPI.xml
+++ b/doc/classes/MultiplayerAPI.xml
@@ -43,10 +43,17 @@
 				Returns the unique peer ID of this MultiplayerAPI's [member multiplayer_peer].
 			</description>
 		</method>
-		<method name="has_multiplayer_peer">
+		<method name="has_multiplayer_peer" is_deprecated="true">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if there is a [member multiplayer_peer] set.
+				Returns [code]true[/code] if there is a [member multiplayer_peer] set and it isn't [OfflineMultiplayerPeer].
+				This method is deprecated - use [method is_offline] instead.
+			</description>
+		</method>
+		<method name="is_offline">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if [member multiplayer_peer] is [code]null[/code], or if it is [OfflineMultiplayerPeer].
 			</description>
 		</method>
 		<method name="is_server">

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -37,31 +37,6 @@
 #include "scene_replication_interface.h"
 #include "scene_rpc_interface.h"
 
-class OfflineMultiplayerPeer : public MultiplayerPeer {
-	GDCLASS(OfflineMultiplayerPeer, MultiplayerPeer);
-
-public:
-	virtual int get_available_packet_count() const override { return 0; }
-	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override {
-		*r_buffer = nullptr;
-		r_buffer_size = 0;
-		return OK;
-	}
-	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override { return OK; }
-	virtual int get_max_packet_size() const override { return 0; }
-
-	virtual void set_target_peer(int p_peer_id) override {}
-	virtual int get_packet_peer() const override { return 0; }
-	virtual TransferMode get_packet_mode() const override { return TRANSFER_MODE_RELIABLE; };
-	virtual int get_packet_channel() const override { return 0; }
-	virtual void disconnect_peer(int p_peer, bool p_force = false) override {}
-	virtual bool is_server() const override { return true; }
-	virtual void poll() override {}
-	virtual void close() override {}
-	virtual int get_unique_id() const override { return TARGET_PEER_SERVER; }
-	virtual ConnectionStatus get_connection_status() const override { return CONNECTION_CONNECTED; };
-};
-
 class SceneMultiplayer : public MultiplayerAPI {
 	GDCLASS(SceneMultiplayer, MultiplayerAPI);
 

--- a/scene/main/multiplayer_api.cpp
+++ b/scene/main/multiplayer_api.cpp
@@ -300,6 +300,7 @@ void MultiplayerAPI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_multiplayer_peer"), &MultiplayerAPI::get_multiplayer_peer);
 	ClassDB::bind_method(D_METHOD("set_multiplayer_peer", "peer"), &MultiplayerAPI::set_multiplayer_peer);
 	ClassDB::bind_method(D_METHOD("get_unique_id"), &MultiplayerAPI::get_unique_id);
+	ClassDB::bind_method(D_METHOD("is_offline"), &MultiplayerAPI::is_offline);
 	ClassDB::bind_method(D_METHOD("is_server"), &MultiplayerAPI::is_server);
 	ClassDB::bind_method(D_METHOD("get_remote_sender_id"), &MultiplayerAPI::get_remote_sender_id);
 	ClassDB::bind_method(D_METHOD("poll"), &MultiplayerAPI::poll);

--- a/scene/main/multiplayer_api.h
+++ b/scene/main/multiplayer_api.h
@@ -72,7 +72,14 @@ public:
 	virtual Error object_configuration_add(Object *p_object, Variant p_config) = 0;
 	virtual Error object_configuration_remove(Object *p_object, Variant p_config) = 0;
 
-	bool has_multiplayer_peer() { return get_multiplayer_peer().is_valid(); }
+	bool has_multiplayer_peer() {
+		WARN_DEPRECATED_MSG("Use is_offline() instead.");
+		return !is_offline();
+	}
+	bool is_offline() {
+		Ref<MultiplayerPeer> multiplayer_peer = get_multiplayer_peer();
+		return multiplayer_peer.is_null() || Object::cast_to<OfflineMultiplayerPeer>(*multiplayer_peer) != nullptr;
+	}
 	bool is_server() { return get_unique_id() == MultiplayerPeer::TARGET_PEER_SERVER; }
 
 	MultiplayerAPI() {}

--- a/scene/main/multiplayer_peer.h
+++ b/scene/main/multiplayer_peer.h
@@ -148,4 +148,29 @@ public:
 	EXBIND0RC(ConnectionStatus, get_connection_status);
 };
 
+class OfflineMultiplayerPeer : public MultiplayerPeer {
+	GDCLASS(OfflineMultiplayerPeer, MultiplayerPeer);
+
+public:
+	virtual int get_available_packet_count() const override { return 0; }
+	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override {
+		*r_buffer = nullptr;
+		r_buffer_size = 0;
+		return OK;
+	}
+	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override { return OK; }
+	virtual int get_max_packet_size() const override { return 0; }
+
+	virtual void set_target_peer(int p_peer_id) override {}
+	virtual int get_packet_peer() const override { return 0; }
+	virtual TransferMode get_packet_mode() const override { return TRANSFER_MODE_RELIABLE; };
+	virtual int get_packet_channel() const override { return 0; }
+	virtual void disconnect_peer(int p_peer, bool p_force = false) override {}
+	virtual bool is_server() const override { return true; }
+	virtual void poll() override {}
+	virtual void close() override {}
+	virtual int get_unique_id() const override { return TARGET_PEER_SERVER; }
+	virtual ConnectionStatus get_connection_status() const override { return CONNECTION_CONNECTED; };
+};
+
 #endif // MULTIPLAYER_PEER_H


### PR DESCRIPTION
Currently, `MultiplayerAPI.multiplayer_peer` will be set to `OfflineMultiplayerPeer` when offline (as opposed to being `null`). This makes the `MultiplayerAPI.has_multiplayer_peer()` method less useful, and it's not totally clear how developers are supposed to check if they are offline.

So, this PR adds a new `MultiplayerAPI.is_offline()` to check for that, and also deprecates `MultiplayerAPI.has_multiplayer_peer()` (while also modifying it to do a similar check).

I'm not totally confident about adding the new method and deprecating `has_multiplayer_peer()`. I could also see an argument for just changing the behavior of `has_multiplayer_peer()` instead, but I'm putting this out there to see what others think!

This is an alternative to PR #75121