### PR TITLE
C#: Synchronize adding ScriptInstances

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1533,7 +1533,10 @@ CSharpInstance *CSharpInstance::create_for_managed_type(Object *p_owner, CSharpS
 		instance->_reference_owner_unsafe();
 	}
 
-	p_script->instances.insert(p_owner);
+	{
+		MutexLock lock(CSharpLanguage::get_singleton()->get_script_instances_mutex());
+		p_script->instances.insert(p_owner);
+	}
 
 	return instance;
 }


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/70449

This is the same lock as in the `tie_managed_to_unmanaged_with_pre_setup` method directly above.

There are no other unsynchronized modifying operations to this field, tho the read operations are not synchronized, no sure if this can be an issue or if an RW lock should be used here.

The MRP usually crashes in 30s after creating less then 50'000 instance, with this PR I could not reproduce the crash after 15 min and creating over 3'000'000 instances.