### PR TITLE
Fix "Download Project Source" for Web Editor

### DIFF
--- a/platform/web/api/web_tools_editor_plugin.cpp
+++ b/platform/web/api/web_tools_editor_plugin.cpp
@@ -75,7 +75,7 @@ void WebToolsEditorPlugin::_download_zip() {
 	const String project_name_safe = project_name.to_lower().replace(" ", "_");
 	const String datetime_safe =
 			Time::get_singleton()->get_datetime_string_from_system(false, true).replace(" ", "_");
-	const String output_name = OS::get_singleton()->get_safe_dir_name(vformat("%s_%s.zip"));
+	const String output_name = OS::get_singleton()->get_safe_dir_name(vformat("%s_%s.zip", project_name_safe, datetime_safe));
 	const String output_path = String("/tmp").path_join(output_name);
 
 	zipFile zip = zipOpen2(output_path.utf8().get_data(), APPEND_STATUS_CREATE, nullptr, &io);


### PR DESCRIPTION
Fix #74818 

- Correctly pass safe project name and safe datetime to `vformat()`

**Important:** @akien-mga added the issue to the **4.1** milestone, but this is entirely a regression fix. If it is delayed until 4.1, my Godot club will not be able to operate (I know we could downgrade to 3, but it made coding concepts a lot harder to teach). I was hoping this could be added to 4.0.2 instead?