### PR TITLE
Added `--gpu-index` to `forwardable_cli_arguments`

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -856,6 +856,15 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(I->next()->get());
 			}
 		}
+		// If gpu is specified, both editor and debug instances started from editor will inherit.
+		if (I->get() == "--gpu-index") {
+			if (I->next()) {
+				forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(I->get());
+				forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(I->next()->get());
+				forwardable_cli_arguments[CLI_SCOPE_PROJECT].push_back(I->get());
+				forwardable_cli_arguments[CLI_SCOPE_PROJECT].push_back(I->next()->get());
+			}
+		}
 #endif
 
 		if (adding_user_args) {


### PR DESCRIPTION
when the gpu index is specified through the CLI, that setting will be inherited by both the editor (if started through project manager) and instances of the game started through the editor

I feel this should be default behavior, as if a user specifies a GPU to be used it should be shared from project manager to editor, and editor to debug instance. This can still be overwritten at runtime with the project setting `editor/run/main_run_args`
