### PR TITLE
Bump the target SDK version to 33 (Android 13)

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -253,7 +253,7 @@ static const char *AAB_ASSETS_DIRECTORY = "res://android/build/assetPacks/instal
 
 static const int OPENGL_MIN_SDK_VERSION = 21; // Should match the value in 'platform/android/java/app/config.gradle#minSdk'
 static const int VULKAN_MIN_SDK_VERSION = 24;
-static const int DEFAULT_TARGET_SDK_VERSION = 32; // Should match the value in 'platform/android/java/app/config.gradle#targetSdk'
+static const int DEFAULT_TARGET_SDK_VERSION = 33; // Should match the value in 'platform/android/java/app/config.gradle#targetSdk'
 
 #ifndef ANDROID_ENABLED
 void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,11 +1,11 @@
 ext.versions = [
-    androidGradlePlugin: '7.2.1',
-    compileSdk         : 32,
-    // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
+    androidGradlePlugin: '7.3.0',
+    compileSdk         : 33,
+    // Also update 'platform/android/export/export_plugin.cpp#OPENGL_MIN_SDK_VERSION'
     minSdk             : 21,
     // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
-    targetSdk          : 32,
-    buildTools         : '32.0.0',
+    targetSdk          : 33,
+    buildTools         : '33.0.2',
     kotlinVersion      : '1.7.0',
     fragmentVersion    : '1.3.6',
     nexusPublishVersion: '1.1.0',

--- a/platform/android/java/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotGestureHandler.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotGestureHandler.kt
@@ -239,8 +239,8 @@ internal class GodotGestureHandler : SimpleOnGestureListener(), OnScaleGestureLi
 		return true
 	}
 
-	override fun onScale(detector: ScaleGestureDetector?): Boolean {
-		if (detector == null || !panningAndScalingEnabled || pointerCaptureInProgress) {
+	override fun onScale(detector: ScaleGestureDetector): Boolean {
+		if (!panningAndScalingEnabled || pointerCaptureInProgress) {
 			return false
 		}
 		GodotLib.magnify(
@@ -251,15 +251,15 @@ internal class GodotGestureHandler : SimpleOnGestureListener(), OnScaleGestureLi
 		return true
 	}
 
-	override fun onScaleBegin(detector: ScaleGestureDetector?): Boolean {
-		if (detector == null || !panningAndScalingEnabled || pointerCaptureInProgress) {
+	override fun onScaleBegin(detector: ScaleGestureDetector): Boolean {
+		if (!panningAndScalingEnabled || pointerCaptureInProgress) {
 			return false
 		}
 		scaleInProgress = true
 		return true
 	}
 
-	override fun onScaleEnd(detector: ScaleGestureDetector?) {
+	override fun onScaleEnd(detector: ScaleGestureDetector) {
 		scaleInProgress = false
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/74646

[3.x version](https://github.com/godotengine/godot/pull/75205)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
