### PR TITLE
Make `Gradient` resort points on `reverse`

### DIFF
--- a/scene/resources/gradient.cpp
+++ b/scene/resources/gradient.cpp
@@ -153,6 +153,7 @@ void Gradient::reverse() {
 		points.write[i].offset = 1.0 - points[i].offset;
 	}
 
+	is_sorted = false;
 	_update_sorting();
 	emit_signal(CoreStringNames::get_singleton()->changed);
 }


### PR DESCRIPTION
`Gradient::reverse()` failed to sort the points because not marking them as sorted, I'm not sure if it should call `_update_sorting` here or delay it until drawing, and if it should sort before reversing to make sure it is valid at that point, but this solves the immediate issue.

Fixes #75234
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
