### PR TITLE
`CanvasItem` Fix `ENTER_CANVAS` / `VISIBILITY_CHANGED` notifications order when entering tree

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -289,11 +289,12 @@ void CanvasItem::_notification(int p_what) {
 				}
 			}
 
+			_enter_canvas();
+
 			RenderingServer::get_singleton()->canvas_item_set_visible(canvas_item, is_visible_in_tree()); // The visibility of the parent may change.
 			if (is_visible_in_tree()) {
 				notification(NOTIFICATION_VISIBILITY_CHANGED); // Considered invisible until entered.
 			}
-			_enter_canvas();
 
 			_update_texture_filter_changed(false);
 			_update_texture_repeat_changed(false);


### PR DESCRIPTION
When a visible-in-tree CanvasItem enters the tree it sends `NOTIFICATION_VISIBILITY_CHANGED`, however it was being done before handling entering the canvas by such CanvasItem. This resulted in possibly out-of-sync state during handling such `NOTIFICATION_VISIBILITY_CHANGED`, as e.g. `CanvasItem::get_canvas()` could be not yet aware the CanvasItem is in a custom canvas layer (as `CanvasItem::_enter_canvas` was not yet called), and hence it would incorrectly return the viewport's default canvas:
https://github.com/godotengine/godot/blob/0291fcd7b66bcb315a49c44de8031e5596de4216/scene/main/canvas_item.cpp#L813-L821

This PR makes the CanvasItem handle entering the canvas before sending `NOTIFICATION_VISIBILITY_CHANGED` (so the current canvas info is already properly updated when such notification is being handled).

For reference it was done like that in #63248. cc @Rindbee to confirm it wasn't anyhow intentional.

---

The mentioned issue affected e.g. CanvasModulate which were updating incorrect canvas when handling `NOTIFICATION_VISIBILITY_CHANGED`:
|Before|After|
|-|-|
|![LI9JriTeXu](https://user-images.githubusercontent.com/9283098/227006673-aa1e7234-7bb4-4bf1-91d4-a97608f2d724.gif)|![nXHPFaoyyM](https://user-images.githubusercontent.com/9283098/227006523-f680ecec-70b3-4a56-82f9-600eab39eba7.gif)|
|![Godot_v4 0 1-stable_win64_k3FpO5SrQN](https://user-images.githubusercontent.com/9283098/227008421-e1891308-632a-4b61-bc64-b169a196b8a8.png)|![godot windows editor dev x86_64_G2EHjOeONd](https://user-images.githubusercontent.com/9283098/227008448-7291fae1-e640-477c-8639-1334f6d3b36d.png)|

Fixes #63666.