### PR TITLE
Fix `ResourceImporterLayeredTexture::import()` `high_quality` type

### DIFF
--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -286,7 +286,7 @@ void ResourceImporterLayeredTexture::_save_tex(Vector<Ref<Image>> p_images, cons
 Error ResourceImporterLayeredTexture::import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	int compress_mode = p_options["compress/mode"];
 	float lossy = p_options["compress/lossy_quality"];
-	float high_quality = p_options["compress/high_quality"];
+	bool high_quality = p_options["compress/high_quality"];
 	int hdr_compression = p_options["compress/hdr_compression"];
 	bool mipmaps = p_options["mipmaps/generate"];
 


### PR DESCRIPTION
[`high_quality` is a BOOL property, not a FLOAT property](https://github.com/godotengine/godot/blob/0291fcd7b66bcb315a49c44de8031e5596de4216/editor/import/resource_importer_layered_texture.cpp#L142). Don't think this affected anything yet, as it's only used to assign another `bool` value, but you never quite know with floating point imprecision...