### PR TITLE
Fix `AnimatedSprite2D` autoplay warning

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -301,13 +301,13 @@ void AnimatedSprite2D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 		frames->get_animation_list(&al);
 		if (al.size() == 0) {
 			set_animation(StringName());
-			set_autoplay(String());
+			autoplay = String();
 		} else {
 			if (!frames->has_animation(animation)) {
 				set_animation(al[0]);
 			}
 			if (!frames->has_animation(autoplay)) {
-				set_autoplay(String());
+				autoplay = String();
 			}
 		}
 	}


### PR DESCRIPTION
Changing of autoplay when changing `SpriteFrames` is not done by the user and warning is unhelpful (technically the autoplay and animation should maybe be cleared if the new animation is invalid)

Fixes #75256
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
