### PR TITLE
Fix `collide_shape` return type

### DIFF
--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -21,7 +21,7 @@
 			</description>
 		</method>
 		<method name="collide_shape">
-			<return type="PackedVector2Array[]" />
+			<return type="Vector2[]" />
 			<param index="0" name="parameters" type="PhysicsShapeQueryParameters2D" />
 			<param index="1" name="max_results" type="int" default="32" />
 			<description>

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -21,7 +21,7 @@
 			</description>
 		</method>
 		<method name="collide_shape">
-			<return type="PackedVector3Array[]" />
+			<return type="Vector3[]" />
 			<param index="0" name="parameters" type="PhysicsShapeQueryParameters3D" />
 			<param index="1" name="max_results" type="int" default="32" />
 			<description>

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -409,17 +409,17 @@ Vector<real_t> PhysicsDirectSpaceState2D::_cast_motion(const Ref<PhysicsShapeQue
 	return ret;
 }
 
-TypedArray<PackedVector2Array> PhysicsDirectSpaceState2D::_collide_shape(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query, int p_max_results) {
-	ERR_FAIL_COND_V(!p_shape_query.is_valid(), Array());
+TypedArray<Vector2> PhysicsDirectSpaceState2D::_collide_shape(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query, int p_max_results) {
+	ERR_FAIL_COND_V(!p_shape_query.is_valid(), TypedArray<Vector2>());
 
 	Vector<Vector2> ret;
 	ret.resize(p_max_results * 2);
 	int rc = 0;
 	bool res = collide_shape(p_shape_query->get_parameters(), ret.ptrw(), p_max_results, rc);
 	if (!res) {
-		return TypedArray<PackedVector2Array>();
+		return TypedArray<Vector2>();
 	}
-	TypedArray<PackedVector2Array> r;
+	TypedArray<Vector2> r;
 	r.resize(rc * 2);
 	for (int i = 0; i < rc * 2; i++) {
 		r[i] = ret[i];

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -120,7 +120,7 @@ class PhysicsDirectSpaceState2D : public Object {
 	TypedArray<Dictionary> _intersect_point(const Ref<PhysicsPointQueryParameters2D> &p_point_query, int p_max_results = 32);
 	TypedArray<Dictionary> _intersect_shape(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query, int p_max_results = 32);
 	Vector<real_t> _cast_motion(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query);
-	TypedArray<PackedVector2Array> _collide_shape(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query, int p_max_results = 32);
+	TypedArray<Vector2> _collide_shape(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query, int p_max_results = 32);
 	Dictionary _get_rest_info(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query);
 
 protected:

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -429,17 +429,17 @@ Vector<real_t> PhysicsDirectSpaceState3D::_cast_motion(const Ref<PhysicsShapeQue
 	return ret;
 }
 
-TypedArray<PackedVector3Array> PhysicsDirectSpaceState3D::_collide_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results) {
-	ERR_FAIL_COND_V(!p_shape_query.is_valid(), Array());
+TypedArray<Vector3> PhysicsDirectSpaceState3D::_collide_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results) {
+	ERR_FAIL_COND_V(!p_shape_query.is_valid(), TypedArray<Vector3>());
 
 	Vector<Vector3> ret;
 	ret.resize(p_max_results * 2);
 	int rc = 0;
 	bool res = collide_shape(p_shape_query->get_parameters(), ret.ptrw(), p_max_results, rc);
 	if (!res) {
-		return TypedArray<PackedVector3Array>();
+		return TypedArray<Vector3>();
 	}
-	TypedArray<PackedVector3Array> r;
+	TypedArray<Vector3> r;
 	r.resize(rc * 2);
 	for (int i = 0; i < rc * 2; i++) {
 		r[i] = ret[i];

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -125,7 +125,7 @@ private:
 	TypedArray<Dictionary> _intersect_point(const Ref<PhysicsPointQueryParameters3D> &p_point_query, int p_max_results = 32);
 	TypedArray<Dictionary> _intersect_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results = 32);
 	Vector<real_t> _cast_motion(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query);
-	TypedArray<PackedVector3Array> _collide_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results = 32);
+	TypedArray<Vector3> _collide_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results = 32);
 	Dictionary _get_rest_info(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query);
 
 protected:


### PR DESCRIPTION
The type used to be a plain `Array` of vectors, so now it is a `TypedArray` of vectors.

For both 2D and 3D.

- Fixes https://github.com/godotengine/godot/issues/75207