### PR TITLE
Fix trim when importing WAV

### DIFF
--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -386,7 +386,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 
 	bool trim = p_options["edit/trim"];
 
-	if (trim && (loop_mode != AudioStreamWAV::LOOP_DISABLED) && format_channels > 0) {
+	if (trim && (loop_mode == AudioStreamWAV::LOOP_DISABLED) && format_channels > 0) {
 		int first = 0;
 		int last = (frames / format_channels) - 1;
 		bool found = false;


### PR DESCRIPTION
Regression from #59170

It seems the trim condition was changed from `!loop` to `(loop_mode != AudioStreamSample::LOOP_DISABLED)` which are opposite

This also affects 3.x due to backport, and I have a 3.x version of this fix and can open PR for it if this gets accepted and backport is wanted.

Fixes #75236

3.x version: #78048

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
