### PR TITLE
Port robust signal (dis)connection to `ShapeCast2D`

### DIFF
--- a/scene/2d/shape_cast_2d.cpp
+++ b/scene/2d/shape_cast_2d.cpp
@@ -151,11 +151,18 @@ bool ShapeCast2D::is_enabled() const {
 }
 
 void ShapeCast2D::set_shape(const Ref<Shape2D> &p_shape) {
+	if (p_shape == shape) {
+		return;
+	}
+	if (shape.is_valid()) {
+		shape->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &ShapeCast2D::_shape_changed));
+	}
 	shape = p_shape;
-	if (p_shape.is_valid()) {
-		shape->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &ShapeCast2D::_redraw_shape));
+	if (shape.is_valid()) {
+		shape->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &ShapeCast2D::_shape_changed));
 		shape_rid = shape->get_rid();
 	}
+
 	update_configuration_warnings();
 	queue_redraw();
 }
@@ -186,7 +193,7 @@ bool ShapeCast2D::get_exclude_parent_body() const {
 	return exclude_parent_body;
 }
 
-void ShapeCast2D::_redraw_shape() {
+void ShapeCast2D::_shape_changed() {
 	queue_redraw();
 }
 

--- a/scene/2d/shape_cast_2d.h
+++ b/scene/2d/shape_cast_2d.h
@@ -61,7 +61,7 @@ class ShapeCast2D : public Node2D {
 	real_t collision_unsafe_fraction = 1.0;
 
 	Array _get_collision_result() const;
-	void _redraw_shape();
+	void _shape_changed();
 
 protected:
 	void _notification(int p_what);

--- a/scene/3d/shape_cast_3d.cpp
+++ b/scene/3d/shape_cast_3d.cpp
@@ -331,16 +331,14 @@ void ShapeCast3D::set_shape(const Ref<Shape3D> &p_shape) {
 	if (p_shape == shape) {
 		return;
 	}
-	if (!shape.is_null()) {
+	if (shape.is_valid()) {
 		shape->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &ShapeCast3D::_shape_changed));
 		shape->unregister_owner(this);
 	}
 	shape = p_shape;
-	if (!shape.is_null()) {
+	if (shape.is_valid()) {
 		shape->register_owner(this);
 		shape->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &ShapeCast3D::_shape_changed));
-	}
-	if (p_shape.is_valid()) {
 		shape_rid = shape->get_rid();
 	}
 


### PR DESCRIPTION
Ported from `ShapeCast3D`. Fixes https://github.com/godotengine/godot/issues/75233.