### PR TITLE
Implement 2D vector graphics draw command

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -733,6 +733,25 @@ Vector<int> Geometry2D::triangulate_delaunay(const Vector<Vector2> &p_points) {
 	return ::Geometry2D::triangulate_delaunay(p_points);
 }
 
+Dictionary Geometry2D::triangulate_polygons(const TypedArray<PackedVector2Array> &p_polygons, bool p_winding_even_odd) {
+	Dictionary ret;
+
+	Vector<Vector<Vector2>> polygons;
+	for (int i = 0; i < p_polygons.size(); i++) {
+		polygons.push_back(p_polygons[i]);
+	}
+
+	Vector<Vector2> vertices;
+	Vector<int> indices;
+
+	::Geometry2D::triangulate_polygons(polygons, p_winding_even_odd, vertices, indices);
+
+	ret["vertices"] = vertices;
+	ret["indices"] = indices;
+
+	return ret;
+}
+
 Vector<Point2> Geometry2D::convex_hull(const Vector<Point2> &p_points) {
 	return ::Geometry2D::convex_hull(p_points);
 }
@@ -860,6 +879,10 @@ Dictionary Geometry2D::make_atlas(const Vector<Size2> &p_rects) {
 	return ret;
 }
 
+Vector<Vector2> Geometry2D::tessellate_curve_in_rect(const Vector<Vector2> &p_points, const Vector<uint8_t> &p_types, const Transform2D &p_transform, const Rect2 &p_limit, bool use_order5) {
+	return ::Geometry2D::tessellate_curve_in_rect(p_points, p_types, p_transform, p_limit, use_order5);
+}
+
 void Geometry2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_point_in_circle", "point", "circle_position", "circle_radius"), &Geometry2D::is_point_in_circle);
 	ClassDB::bind_method(D_METHOD("segment_intersects_circle", "segment_from", "segment_to", "circle_position", "circle_radius"), &Geometry2D::segment_intersects_circle);
@@ -878,6 +901,7 @@ void Geometry2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_point_in_polygon", "point", "polygon"), &Geometry2D::is_point_in_polygon);
 	ClassDB::bind_method(D_METHOD("triangulate_polygon", "polygon"), &Geometry2D::triangulate_polygon);
 	ClassDB::bind_method(D_METHOD("triangulate_delaunay", "points"), &Geometry2D::triangulate_delaunay);
+	ClassDB::bind_method(D_METHOD("triangulate_polygons", "polygons", "winding_even_odd"), &Geometry2D::triangulate_polygons);
 	ClassDB::bind_method(D_METHOD("convex_hull", "points"), &Geometry2D::convex_hull);
 	ClassDB::bind_method(D_METHOD("decompose_polygon_in_convex", "polygon"), &Geometry2D::decompose_polygon_in_convex);
 
@@ -893,6 +917,8 @@ void Geometry2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("offset_polyline", "polyline", "delta", "join_type", "end_type"), &Geometry2D::offset_polyline, DEFVAL(JOIN_SQUARE), DEFVAL(END_SQUARE));
 
 	ClassDB::bind_method(D_METHOD("make_atlas", "sizes"), &Geometry2D::make_atlas);
+
+	ClassDB::bind_method(D_METHOD("tessellate_curve_in_rect", "points", "types", "transform", "limit", "use_order5"), &Geometry2D::tessellate_curve_in_rect, DEFVAL(false));
 
 	BIND_ENUM_CONSTANT(OPERATION_UNION);
 	BIND_ENUM_CONSTANT(OPERATION_DIFFERENCE);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -268,6 +268,7 @@ public:
 	bool is_point_in_polygon(const Point2 &p_point, const Vector<Vector2> &p_polygon);
 	Vector<int> triangulate_polygon(const Vector<Vector2> &p_polygon);
 	Vector<int> triangulate_delaunay(const Vector<Vector2> &p_points);
+	Dictionary triangulate_polygons(const TypedArray<PackedVector2Array> &p_polygons, bool p_winding_even_odd);
 	Vector<Point2> convex_hull(const Vector<Point2> &p_points);
 	TypedArray<PackedVector2Array> decompose_polygon_in_convex(const Vector<Vector2> &p_polygon);
 
@@ -304,6 +305,8 @@ public:
 	TypedArray<PackedVector2Array> offset_polyline(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type = JOIN_SQUARE, PolyEndType p_end_type = END_SQUARE);
 
 	Dictionary make_atlas(const Vector<Size2> &p_rects);
+
+	Vector<Vector2> tessellate_curve_in_rect(const Vector<Vector2> &p_points, const Vector<uint8_t> &p_types, const Transform2D &p_transform, const Rect2 &p_limit, bool use_order5 = false);
 
 	Geometry2D() { singleton = this; }
 };

--- a/core/math/bentley_ottmann.cpp
+++ b/core/math/bentley_ottmann.cpp
@@ -1,0 +1,1271 @@
+/**************************************************************************/
+/*  bentley_ottmann.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "bentley_ottmann.h"
+
+#define EXP_MIN -65536
+
+thread_local LocalVector<BentleyOttmann::TreeNode> BentleyOttmann::tree_nodes;
+thread_local LocalVector<BentleyOttmann::ListNode> BentleyOttmann::list_nodes;
+thread_local LocalVector<BentleyOttmann::Slice> BentleyOttmann::slices;
+thread_local LocalVector<BentleyOttmann::Point> BentleyOttmann::points;
+thread_local LocalVector<BentleyOttmann::Edge> BentleyOttmann::edges;
+thread_local LocalVector<BentleyOttmann::Vertical> BentleyOttmann::verticals;
+thread_local LocalVector<uint32_t> BentleyOttmann::triangles;
+
+BentleyOttmann::BentleyOttmann(Vector<Vector2> p_edges, Vector<int> p_winding, bool p_winding_even_odd) {
+	tree_nodes.clear();
+	list_nodes.clear();
+	slices.clear();
+	points.clear();
+	edges.clear();
+	verticals.clear();
+	triangles.clear();
+	// The cost of an explicit nil node is lower than having a special nil value.
+	// This also ensures that tree_nodes[0].element is 0 instead of a null pointer exception.
+	TreeNode nil_node;
+	tree_nodes.push_back(nil_node);
+	edges_tree = tree_create();
+	slices_tree = tree_create();
+	points_tree = tree_create();
+	winding_mask = p_winding_even_odd ? 1 : -1;
+
+	ERR_FAIL_COND(p_edges.size() & 1);
+	ERR_FAIL_COND((p_edges.size() >> 1) != p_winding.size());
+	if (p_edges.size() < 1) {
+		return;
+	}
+	int x_exp = EXP_MIN;
+	int y_exp = EXP_MIN;
+	for (int i = 0; i < p_edges.size(); i++) {
+		if (isnormal(p_edges[i].x)) {
+			int exp;
+			frexp(p_edges[i].x, &exp);
+			if (x_exp < exp) {
+				x_exp = exp;
+			}
+		}
+		if (isnormal(p_edges[i].y)) {
+			int exp;
+			frexp(p_edges[i].y, &exp);
+			if (y_exp < exp) {
+				y_exp = exp;
+			}
+		}
+	}
+	if (x_exp == EXP_MIN) {
+		x_exp = 0;
+	} else {
+		x_exp -= 20;
+	}
+	if (y_exp == EXP_MIN) {
+		y_exp = 0;
+	} else {
+		y_exp -= 20;
+	}
+	for (int i = 0, j = 0; i < p_winding.size(); i++, j += 2) {
+		int64_t start_x = static_cast<int64_t>(ldexp(p_edges[j].x, -x_exp));
+		int64_t start_y = static_cast<int64_t>(ldexp(p_edges[j].y, -y_exp));
+		int64_t end_x = static_cast<int64_t>(ldexp(p_edges[j + 1].x, -x_exp));
+		int64_t end_y = static_cast<int64_t>(ldexp(p_edges[j + 1].y, -y_exp));
+		if (start_x < end_x) {
+			add_edge(add_point(start_x, start_y, 1), add_point(end_x, end_y, 1), p_winding[i]);
+		} else if (start_x > end_x) {
+			add_edge(add_point(end_x, end_y, 1), add_point(start_x, start_y, 1), -p_winding[i]);
+		} else if (start_y < end_y) {
+			add_vertical_edge(add_slice(start_x), start_y, end_y);
+		} else if (start_y > end_y) {
+			add_vertical_edge(add_slice(start_x), end_y, start_y);
+		}
+	}
+
+	uint32_t slice_iter = tree_nodes[slices_tree].next;
+	uint32_t point_iter = points_tree;
+	while (true) {
+		uint32_t point_iter_next = tree_nodes[point_iter].next;
+		if (unlikely(point_iter_next == points_tree || (slice_iter != slices_tree && points[tree_nodes[point_iter_next].element].x >= slices[tree_nodes[slice_iter].element].x * points[tree_nodes[point_iter_next].element].factor))) {
+			// There's at least two points per slice, so slices are less likely than points.
+			if (unlikely(slice_iter == slices_tree)) {
+				// And the end of the shape only happens once in the loop.
+				break;
+			}
+			uint32_t slice = tree_nodes[slice_iter].element;
+			slice_iter = tree_nodes[slice_iter].next;
+			int64_t slice_x = slices[slice].x;
+
+			// Mark intersection of passthrough edges with vertical edges.
+			uint32_t vertical_iter = tree_nodes[slices[slice].vertical_tree].next;
+			while (vertical_iter != slices[slice].vertical_tree) {
+				DEV_ASSERT(verticals[tree_nodes[vertical_iter].element].is_start);
+				uint32_t treenode_edge = get_edge_before(slice_x, verticals[tree_nodes[vertical_iter].element].y);
+				vertical_iter = tree_nodes[vertical_iter].next;
+				DEV_ASSERT(vertical_iter != slices[slice].vertical_tree);
+				DEV_ASSERT(!verticals[tree_nodes[vertical_iter].element].is_start);
+				int64_t y_end = verticals[tree_nodes[vertical_iter].element].y;
+				while (tree_nodes[treenode_edge].next != edges_tree) {
+					treenode_edge = tree_nodes[treenode_edge].next;
+					const Edge &edge = edges[tree_nodes[treenode_edge].element];
+					if (y_end * edge.dir_x - slice_x * edge.dir_y <= edge.cross) {
+						break;
+					}
+					edge_intersect_x(tree_nodes[treenode_edge].element, slice_x);
+				}
+				vertical_iter = tree_nodes[vertical_iter].next;
+			}
+		} else {
+			uint32_t point = tree_nodes[point_iter = point_iter_next].element;
+			uint32_t treenode_edge_before = get_edge_before_point(point);
+
+			// Find and remove edges going through this point.
+			while (tree_nodes[treenode_edge_before].next != edges_tree) {
+				uint32_t edge = tree_nodes[tree_nodes[treenode_edge_before].next].element;
+				if (edges[edge].point_end == point) {
+					edge_set_outgoing(edge, point);
+				} else {
+					if (cmp_point_edge(point, edge) < 0) {
+						break;
+					}
+					edge_set_outgoing(edge, point);
+					// An edge merely passing through this point will be re-added below.
+					point_add_outgoing(point, edge);
+				}
+				tree_remove(tree_nodes[treenode_edge_before].next);
+			}
+
+			// Add point to surrounding edges.
+			if (treenode_edge_before != edges_tree) {
+				edge_add_point_after(tree_nodes[treenode_edge_before].element, point);
+			}
+			if (tree_nodes[treenode_edge_before].next != edges_tree) {
+				edge_add_point_before(tree_nodes[tree_nodes[treenode_edge_before].next].element, point);
+			}
+
+			// Add outgoing edges.
+			int winding = 0;
+			if (treenode_edge_before != edges_tree) {
+				winding = edges[tree_nodes[treenode_edge_before].element].winding_total;
+			}
+			uint32_t treenode_outgoing_iter = tree_nodes[points[point].outgoing_tree].next;
+			while (treenode_outgoing_iter != points[point].outgoing_tree) {
+				winding += edges[tree_nodes[treenode_outgoing_iter].element].winding;
+				edges[tree_nodes[treenode_outgoing_iter].element].winding_total = winding;
+				treenode_outgoing_iter = tree_nodes[treenode_outgoing_iter].next;
+			}
+			treenode_outgoing_iter = tree_nodes[points[point].outgoing_tree].prev;
+			while (treenode_outgoing_iter != points[point].outgoing_tree) {
+				tree_insert(edges[tree_nodes[treenode_outgoing_iter].element].treenode_edges, treenode_edge_before);
+				treenode_outgoing_iter = tree_nodes[treenode_outgoing_iter].prev;
+			}
+
+			// Check intersections.
+			if (treenode_edge_before != edges_tree && tree_nodes[treenode_edge_before].next != edges_tree) {
+				check_intersection(treenode_edge_before);
+			}
+			if (tree_nodes[points[point].outgoing_tree].prev != points[point].outgoing_tree) {
+				uint32_t check = edges[tree_nodes[tree_nodes[points[point].outgoing_tree].prev].element].treenode_edges;
+				if (tree_nodes[check].next != edges_tree) {
+					check_intersection(check);
+				}
+			}
+
+			// Cleanup.
+			tree_clear(points[point].outgoing_tree);
+		}
+	}
+
+	DEV_ASSERT(tree_nodes[edges_tree].right == 0);
+
+	// Optimize points and flush to final buffers.
+	DEV_ASSERT((triangles.size() % 3) == 0);
+	for (uint32_t i = 0; i < triangles.size();) {
+		if (triangles[i] == triangles[i + 1] || triangles[i] == triangles[i + 2] || triangles[i + 1] == triangles[i + 2]) {
+			i += 3;
+			continue;
+		}
+		for (uint32_t j = 0; j < 3; i++, j++) {
+			if (!points[triangles[i]].used) {
+				out_points.push_back(Vector2(ldexp(static_cast<real_t>(points[triangles[i]].x / points[triangles[i]].factor), x_exp), ldexp(static_cast<real_t>(points[triangles[i]].y / points[triangles[i]].factor), y_exp)));
+				points[triangles[i]].used = out_points.size();
+			}
+			out_triangles.push_back(points[triangles[i]].used - 1);
+		}
+	}
+}
+
+uint32_t BentleyOttmann::add_slice(int64_t p_x) {
+	uint32_t insert_after = slices_tree;
+	uint32_t current = tree_nodes[slices_tree].right;
+	if (current) {
+		while (true) {
+			int64_t x = p_x - slices[tree_nodes[current].element].x;
+			if (x < 0) {
+				if (tree_nodes[current].left) {
+					current = tree_nodes[current].left;
+					continue;
+				}
+				insert_after = tree_nodes[current].prev;
+				break;
+			}
+			if (x > 0) {
+				if (tree_nodes[current].right) {
+					current = tree_nodes[current].right;
+					continue;
+				}
+				insert_after = current;
+				break;
+			}
+			return tree_nodes[current].element;
+		}
+	}
+	Slice slice;
+	slice.x = p_x;
+	slice.vertical_tree = tree_create();
+	tree_insert(tree_create(slices.size()), insert_after);
+	slices.push_back(slice);
+	return slices.size() - 1;
+}
+
+uint32_t BentleyOttmann::add_point(int64_t p_x, int64_t p_y, int64_t p_factor) {
+	DEV_ASSERT(p_factor > 0 && p_factor < 0x100000000000LL);
+	if (p_factor > 1 && (p_x % p_factor) == 0 && (p_y % p_factor) == 0) {
+		// Factor 1 offers a faster path for some operations, since no-overflow is guaranteed.
+		// Try to optimize only to 1. Optimizing to 2 or more is pointless.
+		p_x /= p_factor;
+		p_y /= p_factor;
+		p_factor = 1;
+	}
+	uint32_t insert_after = points_tree;
+	uint32_t current = tree_nodes[points_tree].right;
+	if (current) {
+		while (true) {
+			int cmp = cmp_point_point(p_x, p_y, p_factor, tree_nodes[current].element);
+			if (cmp < 0) {
+				if (tree_nodes[current].left) {
+					current = tree_nodes[current].left;
+					continue;
+				}
+				insert_after = tree_nodes[current].prev;
+				break;
+			}
+			if (cmp > 0) {
+				if (tree_nodes[current].right) {
+					current = tree_nodes[current].right;
+					continue;
+				}
+				insert_after = current;
+				break;
+			}
+			return tree_nodes[current].element;
+		}
+	}
+	Point point;
+	point.x = p_x;
+	point.y = p_y;
+	point.factor = p_factor;
+	point.outgoing_tree = tree_create();
+	point.listnode_edge_prev = list_create(points.size());
+	point.listnode_edge_next = list_create(points.size());
+	tree_insert(tree_create(points.size()), insert_after);
+	points.push_back(point);
+	return points.size() - 1;
+}
+
+void BentleyOttmann::point_add_outgoing(uint32_t p_point, uint32_t p_edge) {
+retry:
+	DEV_ASSERT(tree_nodes[edges[p_edge].treenode_outgoing].parent == 0);
+	uint32_t current = tree_nodes[points[p_point].outgoing_tree].right;
+	if (!current) {
+		tree_insert(edges[p_edge].treenode_outgoing, points[p_point].outgoing_tree);
+		return;
+	}
+	while (true) {
+		uint32_t point = edges[tree_nodes[current].element].point_end;
+		int64_t cmp = points[point].x * edges[p_edge].dir_y - points[point].y * edges[p_edge].dir_x + edges[p_edge].cross;
+		if (cmp < 0) {
+			if (tree_nodes[current].left) {
+				current = tree_nodes[current].left;
+				continue;
+			}
+			tree_insert(edges[p_edge].treenode_outgoing, tree_nodes[current].prev);
+			return;
+		}
+		if (cmp > 0) {
+			if (tree_nodes[current].right) {
+				current = tree_nodes[current].right;
+				continue;
+			}
+			tree_insert(edges[p_edge].treenode_outgoing, current);
+			return;
+		}
+		uint32_t point_end = edges[p_edge].point_end;
+		if (points[point_end].x >= points[point].x) {
+			edges[tree_nodes[current].element].winding += edges[p_edge].winding;
+			if (points[point_end].x == points[point].x) {
+				DEV_ASSERT(points[point_end].y == points[point].y);
+				return;
+			}
+			p_point = point;
+			edges[p_edge].point_outgoing = p_point;
+			goto retry;
+		}
+		tree_replace(edges[p_edge].treenode_outgoing, current);
+		edges[p_edge].winding += edges[tree_nodes[current].element].winding;
+		p_edge = tree_nodes[current].element;
+		p_point = point_end;
+		edges[p_edge].point_outgoing = p_point;
+		goto retry;
+	}
+}
+
+void BentleyOttmann::add_edge(uint32_t p_point_start, uint32_t p_point_end, int p_winding) {
+	DEV_ASSERT(points[p_point_start].factor == 1 && points[p_point_end].factor == 1);
+	Edge edge;
+	edge.point_start = edge.point_outgoing = p_point_start;
+	edge.point_end = p_point_end;
+	edge.winding = p_winding;
+	edge.treenode_edges = tree_create(edges.size());
+	edge.treenode_outgoing = tree_create(edges.size());
+	edge.points_prev_list = list_create();
+	edge.points_next_list = list_create();
+	edge.dir_x = points[p_point_end].x - points[p_point_start].x;
+	edge.dir_y = points[p_point_end].y - points[p_point_start].y;
+	if (edge.dir_y >= 0) {
+		edge.min_y = points[p_point_start].y;
+		edge.max_y = points[p_point_end].y;
+	} else {
+		edge.min_y = points[p_point_end].y;
+		edge.max_y = points[p_point_start].y;
+	}
+	DEV_ASSERT(edge.dir_x > 0);
+	edge.cross = points[p_point_start].y * edge.dir_x - points[p_point_start].x * edge.dir_y;
+	edges.push_back(edge);
+	point_add_outgoing(p_point_start, edges.size() - 1);
+}
+
+void BentleyOttmann::add_vertical_edge(uint32_t p_slice, int64_t p_y_start, int64_t p_y_end) {
+	uint32_t start;
+	uint32_t current = tree_nodes[slices[p_slice].vertical_tree].right;
+	if (!current) {
+		Vertical vertical;
+		vertical.y = p_y_start;
+		vertical.is_start = true;
+		start = tree_create(verticals.size());
+		verticals.push_back(vertical);
+		tree_insert(start, slices[p_slice].vertical_tree);
+	} else {
+		while (true) {
+			int64_t y = p_y_start - verticals[tree_nodes[current].element].y;
+			if (y < 0) {
+				if (tree_nodes[current].left) {
+					current = tree_nodes[current].left;
+					continue;
+				}
+				if (verticals[tree_nodes[current].element].is_start) {
+					Vertical vertical;
+					vertical.y = p_y_start;
+					vertical.is_start = true;
+					start = tree_create(verticals.size());
+					verticals.push_back(vertical);
+					tree_insert(start, tree_nodes[current].prev);
+				} else {
+					start = tree_nodes[current].prev;
+				}
+				break;
+			}
+			if (y > 0) {
+				if (tree_nodes[current].right) {
+					current = tree_nodes[current].right;
+					continue;
+				}
+				if (!verticals[tree_nodes[current].element].is_start) {
+					Vertical vertical;
+					vertical.y = p_y_start;
+					vertical.is_start = true;
+					start = tree_create(verticals.size());
+					verticals.push_back(vertical);
+					tree_insert(start, current);
+				} else {
+					start = current;
+				}
+				break;
+			}
+			if (verticals[tree_nodes[current].element].is_start) {
+				start = current;
+			} else {
+				start = tree_nodes[current].prev;
+			}
+			break;
+		}
+	}
+	while (tree_nodes[start].next != slices[p_slice].vertical_tree) {
+		int64_t y = p_y_end - verticals[tree_nodes[tree_nodes[start].next].element].y;
+		if (y < 0 || (y == 0 && !verticals[tree_nodes[tree_nodes[start].next].element].is_start)) {
+			break;
+		}
+		tree_remove(tree_nodes[start].next);
+	}
+	if (tree_nodes[start].next == slices[p_slice].vertical_tree || verticals[tree_nodes[tree_nodes[start].next].element].is_start) {
+		Vertical vertical;
+		vertical.y = p_y_end;
+		vertical.is_start = false;
+		tree_insert(tree_create(verticals.size()), start);
+		verticals.push_back(vertical);
+	}
+}
+
+void BentleyOttmann::edge_intersect_x(uint32_t p_edge, int64_t p_x) {
+	const Edge &edge = edges[p_edge];
+	if (points[edge.point_end].x <= p_x) {
+		return;
+	}
+	int64_t total = p_x * edge.dir_y + edge.cross;
+	add_point(p_x * edge.dir_x, total, edge.dir_x);
+}
+
+void BentleyOttmann::edge_intersect_edge(uint32_t p_edge1, uint32_t p_edge2) {
+	const Edge &edge1 = edges[p_edge1];
+	const Edge &edge2 = edges[p_edge2];
+	int64_t total_x = edge2.cross * edge1.dir_x - edge1.cross * edge2.dir_x;
+	int64_t total_y = edge2.cross * edge1.dir_y - edge1.cross * edge2.dir_y;
+	int64_t factor = edge1.dir_y * edge2.dir_x - edge2.dir_y * edge1.dir_x;
+	add_point(total_x, total_y, factor);
+	DEV_ASSERT(cmp_point_edge(add_point(total_x, total_y, factor), p_edge1) == 0 && cmp_point_edge(add_point(total_x, total_y, factor), p_edge2) == 0);
+}
+
+void BentleyOttmann::edge_set_outgoing(uint32_t p_edge, uint32_t p_point) {
+	if ((edges[p_edge].winding_total - edges[p_edge].winding) & winding_mask) {
+		uint32_t next = list_nodes[edges[p_edge].points_prev_list].next;
+		if (next != edges[p_edge].points_prev_list) {
+			uint32_t next_next = list_nodes[next].next;
+			while (next_next != edges[p_edge].points_prev_list) {
+				triangles.push_back(p_point);
+				triangles.push_back(list_nodes[next_next].element);
+				triangles.push_back(list_nodes[next].element);
+				list_remove(next);
+				next = next_next;
+				next_next = list_nodes[next].next;
+			}
+			triangles.push_back(p_point);
+			triangles.push_back(edges[p_edge].point_outgoing);
+			triangles.push_back(list_nodes[next].element);
+			list_remove(next);
+		}
+	}
+	if (edges[p_edge].winding_total & winding_mask) {
+		uint32_t next = list_nodes[edges[p_edge].points_next_list].next;
+		if (next != edges[p_edge].points_next_list) {
+			uint32_t next_next = list_nodes[next].next;
+			while (next_next != edges[p_edge].points_next_list) {
+				triangles.push_back(p_point);
+				triangles.push_back(list_nodes[next].element);
+				triangles.push_back(list_nodes[next_next].element);
+				list_remove(next);
+				next = next_next;
+				next_next = list_nodes[next].next;
+			}
+			triangles.push_back(p_point);
+			triangles.push_back(list_nodes[next].element);
+			triangles.push_back(edges[p_edge].point_outgoing);
+			list_remove(next);
+		}
+	}
+	edges[p_edge].point_outgoing = p_point;
+}
+
+void BentleyOttmann::edge_add_point_before(uint32_t p_edge, uint32_t p_point) {
+	if (!((edges[p_edge].winding_total - edges[p_edge].winding) & winding_mask)) {
+		return;
+	}
+	uint32_t next = list_nodes[edges[p_edge].points_prev_list].next;
+	if (next != edges[p_edge].points_prev_list) {
+		uint32_t next_next = list_nodes[next].next;
+		while (next_next != edges[p_edge].points_prev_list) {
+			if (cmp_cross(list_nodes[next].element, list_nodes[next_next].element, p_point) <= 0) {
+				goto done;
+			}
+			triangles.push_back(p_point);
+			triangles.push_back(list_nodes[next_next].element);
+			triangles.push_back(list_nodes[next].element);
+			list_remove(next);
+			next = next_next;
+			next_next = list_nodes[next].next;
+		}
+		if (cmp_cross(list_nodes[next].element, edges[p_edge].point_outgoing, p_point) > 0) {
+			triangles.push_back(p_point);
+			triangles.push_back(edges[p_edge].point_outgoing);
+			triangles.push_back(list_nodes[next].element);
+			list_remove(next);
+		}
+	}
+done:
+	list_insert(points[p_point].listnode_edge_prev, edges[p_edge].points_prev_list);
+}
+
+void BentleyOttmann::edge_add_point_after(uint32_t p_edge, uint32_t p_point) {
+	if (!(edges[p_edge].winding_total & winding_mask)) {
+		return;
+	}
+	uint32_t next = list_nodes[edges[p_edge].points_next_list].next;
+	if (next != edges[p_edge].points_next_list) {
+		uint32_t next_next = list_nodes[next].next;
+		while (next_next != edges[p_edge].points_next_list) {
+			if (cmp_cross(list_nodes[next].element, list_nodes[next_next].element, p_point) >= 0) {
+				goto done;
+			}
+			triangles.push_back(p_point);
+			triangles.push_back(list_nodes[next].element);
+			triangles.push_back(list_nodes[next_next].element);
+			list_remove(next);
+			next = next_next;
+			next_next = list_nodes[next].next;
+		}
+		if (cmp_cross(list_nodes[next].element, edges[p_edge].point_outgoing, p_point) < 0) {
+			triangles.push_back(p_point);
+			triangles.push_back(list_nodes[next].element);
+			triangles.push_back(edges[p_edge].point_outgoing);
+			list_remove(next);
+		}
+	}
+done:
+	list_insert(points[p_point].listnode_edge_next, edges[p_edge].points_next_list);
+}
+
+uint32_t BentleyOttmann::get_edge_before(int64_t p_x, int64_t p_y) {
+	uint32_t current = tree_nodes[edges_tree].right;
+	if (!current) {
+		return edges_tree;
+	}
+	while (true) {
+		const Edge &edge = edges[tree_nodes[current].element];
+		int64_t cross = p_y * edge.dir_x - p_x * edge.dir_y - edge.cross;
+		if (cross > 0) {
+			if (tree_nodes[current].right) {
+				current = tree_nodes[current].right;
+				continue;
+			}
+			return current;
+		}
+		if (tree_nodes[current].left) {
+			current = tree_nodes[current].left;
+			continue;
+		}
+		return tree_nodes[current].prev;
+	}
+}
+
+uint32_t BentleyOttmann::get_edge_before_point(uint32_t p_point) {
+	uint32_t current = tree_nodes[edges_tree].right;
+	if (!current) {
+		return edges_tree;
+	}
+	while (true) {
+		int cmp = cmp_point_edge(p_point, tree_nodes[current].element);
+		if (cmp > 0) {
+			if (tree_nodes[current].right) {
+				current = tree_nodes[current].right;
+				continue;
+			}
+			return current;
+		}
+		if (tree_nodes[current].left) {
+			current = tree_nodes[current].left;
+			continue;
+		}
+		return tree_nodes[current].prev;
+	}
+}
+
+void BentleyOttmann::check_intersection(uint32_t p_treenode_edge) {
+	DEV_ASSERT(p_treenode_edge != edges_tree && tree_nodes[p_treenode_edge].next != edges_tree);
+	Edge &edge1 = edges[tree_nodes[p_treenode_edge].element];
+	Edge &edge2 = edges[tree_nodes[tree_nodes[p_treenode_edge].next].element];
+	if (edge1.max_y < edge2.min_y || edge1.point_start == edge2.point_start || edge1.point_end == edge2.point_end) {
+		return;
+	}
+	int64_t max;
+	if (points[edge1.point_end].x < points[edge2.point_end].x) {
+		max = points[edge1.point_end].x;
+	} else {
+		max = points[edge2.point_end].x;
+	}
+	if ((max * edge2.dir_y + edge2.cross) * edge1.dir_x >= (max * edge1.dir_y + edge1.cross) * edge2.dir_x) {
+		return;
+	}
+	edge_intersect_edge(tree_nodes[p_treenode_edge].element, tree_nodes[tree_nodes[p_treenode_edge].next].element);
+}
+
+int BentleyOttmann::cmp_point_point(int64_t p_x, int64_t p_y, int64_t p_factor, uint32_t p_point) {
+	if (p_factor == 1) {
+		int64_t cmp = p_x * points[p_point].factor - points[p_point].x;
+		if (cmp > 0) {
+			return 1;
+		}
+		if (cmp < 0) {
+			return -1;
+		}
+		cmp = p_y * points[p_point].factor - points[p_point].y;
+		if (cmp > 0) {
+			return 1;
+		}
+		if (cmp < 0) {
+			return -1;
+		}
+		return 0;
+	}
+	if (points[p_point].factor == 1) {
+		int64_t cmp = p_x - points[p_point].x * p_factor;
+		if (cmp > 0) {
+			return 1;
+		}
+		if (cmp < 0) {
+			return -1;
+		}
+		cmp = p_y - points[p_point].y * p_factor;
+		if (cmp > 0) {
+			return 1;
+		}
+		if (cmp < 0) {
+			return -1;
+		}
+		return 0;
+	}
+	int64_t factor1_lo = p_factor & 0xFFFFFF;
+	int64_t factor1_hi = p_factor >> 24;
+	int64_t factor2_lo = points[p_point].factor & 0xFFFFFF;
+	int64_t factor2_hi = points[p_point].factor >> 24;
+	int64_t v1_lo, v1_hi, v2_lo, v2_hi, m1_lo, m1_hi, m2_lo, m2_hi;
+	int64_t m1_t1, m1_t2, m1_t3, m2_t1, m2_t2, m2_t3;
+	v1_lo = p_x & 0xFFFFFFFF;
+	v1_hi = p_x >> 32;
+	v2_lo = points[p_point].x & 0xFFFFFFFF;
+	v2_hi = points[p_point].x >> 32;
+	// m1 = x1 * factor2
+	// m2 = x2 * factor1
+	m1_t1 = factor2_lo * v1_lo;
+	m2_t1 = factor1_lo * v2_lo;
+	m1_t2 = factor2_hi * v1_lo + (m1_t1 >> 24);
+	m2_t2 = factor1_hi * v2_lo + (m2_t1 >> 24);
+	m1_t3 = factor2_lo * v1_hi + (m1_t2 >> 8);
+	m2_t3 = factor1_lo * v2_hi + (m2_t2 >> 8);
+	m1_hi = factor2_hi * v1_hi + (m1_t3 >> 24);
+	m2_hi = factor1_hi * v2_hi + (m2_t3 >> 24);
+	m1_lo = (m1_t1 & 0xFFFFFF) | ((m1_t2 & 0xFF) << 24) | ((m1_t3 & 0xFFFFFF) << 32);
+	m2_lo = (m2_t1 & 0xFFFFFF) | ((m2_t2 & 0xFF) << 24) | ((m2_t3 & 0xFFFFFF) << 32);
+	// sign(m1 - m2)
+	if (m1_hi > m2_hi) {
+		return 1;
+	}
+	if (m1_hi < m2_hi) {
+		return -1;
+	}
+	if (m1_lo > m2_lo) {
+		return 1;
+	}
+	if (m1_lo < m2_lo) {
+		return -1;
+	}
+	v1_lo = p_y & 0xFFFFFFFF;
+	v1_hi = p_y >> 32;
+	v2_lo = points[p_point].y & 0xFFFFFFFF;
+	v2_hi = points[p_point].y >> 32;
+	// m1 = y1 * factor2
+	// m2 = y2 * factor1
+	m1_t1 = factor2_lo * v1_lo;
+	m2_t1 = factor1_lo * v2_lo;
+	m1_t2 = factor2_hi * v1_lo + (m1_t1 >> 24);
+	m2_t2 = factor1_hi * v2_lo + (m2_t1 >> 24);
+	m1_t3 = factor2_lo * v1_hi + (m1_t2 >> 8);
+	m2_t3 = factor1_lo * v2_hi + (m2_t2 >> 8);
+	m1_hi = factor2_hi * v1_hi + (m1_t3 >> 24);
+	m2_hi = factor1_hi * v2_hi + (m2_t3 >> 24);
+	m1_lo = (m1_t1 & 0xFFFFFF) | ((m1_t2 & 0xFF) << 24) | ((m1_t3 & 0xFFFFFF) << 32);
+	m2_lo = (m2_t1 & 0xFFFFFF) | ((m2_t2 & 0xFF) << 24) | ((m2_t3 & 0xFFFFFF) << 32);
+	// sign(m1 - m2)
+	if (m1_hi > m2_hi) {
+		return 1;
+	}
+	if (m1_hi < m2_hi) {
+		return -1;
+	}
+	if (m1_lo > m2_lo) {
+		return 1;
+	}
+	if (m1_lo < m2_lo) {
+		return -1;
+	}
+	return 0;
+}
+
+int BentleyOttmann::cmp_point_edge(uint32_t p_point, uint32_t p_edge) {
+	if (points[p_point].factor == 1) {
+		int64_t cmp = points[p_point].y * edges[p_edge].dir_x - points[p_point].x * edges[p_edge].dir_y - edges[p_edge].cross;
+		if (cmp > 0) {
+			return 1;
+		}
+		if (cmp < 0) {
+			return -1;
+		}
+		return 0;
+	}
+	int64_t m1_lo, m1_hi, m2_lo, m2_hi, m3_lo, m3_hi;
+	int64_t v_lo, v_hi;
+	int64_t v1_lo, v1_hi, v2_lo, v2_hi, t1, t2, t3;
+	v_lo = points[p_point].y & 0xFFFFFFFF;
+	v_hi = points[p_point].y >> 32;
+	v_lo *= edges[p_edge].dir_x;
+	v_hi = v_hi * edges[p_edge].dir_x + (v_lo >> 32);
+	m1_lo = (v_lo & 0xFFFFFFFF) | ((v_hi & 0xFFFFFFF) << 32);
+	m1_hi = v_hi >> 28;
+	v_lo = points[p_point].x & 0xFFFFFFFF;
+	v_hi = points[p_point].x >> 32;
+	v_lo *= edges[p_edge].dir_y;
+	v_hi = v_hi * edges[p_edge].dir_y + (v_lo >> 32);
+	m2_lo = (v_lo & 0xFFFFFFFF) | ((v_hi & 0xFFFFFFF) << 32);
+	m2_hi = v_hi >> 28;
+	v1_lo = points[p_point].factor & 0xFFFFFF;
+	v1_hi = points[p_point].factor >> 24;
+	v2_lo = edges[p_edge].cross & 0xFFFFFF;
+	v2_hi = edges[p_edge].cross >> 24;
+	t1 = v1_lo * v2_lo;
+	t2 = v1_lo * v2_hi + v1_hi * v2_lo + (t1 >> 24);
+	t3 = v1_hi * v2_hi + (t2 >> 24);
+	m3_lo = (t1 & 0xFFFFFF) | ((t2 & 0xFFFFFF) << 24) | ((t3 & 0xFFF) << 48);
+	m3_hi = t3 >> 12;
+	m2_lo += m3_lo;
+	m2_hi += m3_hi + (m2_lo >> 60);
+	m2_lo &= 0xFFFFFFFFFFFFFFF;
+	if (m1_hi > m2_hi) {
+		return 1;
+	}
+	if (m1_hi < m2_hi) {
+		return -1;
+	}
+	if (m1_lo > m2_lo) {
+		return 1;
+	}
+	if (m1_lo < m2_lo) {
+		return -1;
+	}
+	return 0;
+}
+
+int BentleyOttmann::cmp_cross(uint32_t p_point1, uint32_t p_point2, uint32_t p_point_rel) {
+	if (points[p_point1].factor == 1 && points[p_point2].factor == 1 && points[p_point_rel].factor == 1) {
+		int64_t cmp = (points[p_point1].y - points[p_point_rel].y) * (points[p_point2].x - points[p_point_rel].x) - (points[p_point1].x - points[p_point_rel].x) * (points[p_point2].y - points[p_point_rel].y);
+		if (cmp > 0) {
+			return 1;
+		}
+		if (cmp < 0) {
+			return -1;
+		}
+		return 0;
+	}
+
+	int64_t factor1_lo = points[p_point1].factor & 0xFFFFFF;
+	int64_t factor1_hi = points[p_point1].factor >> 24;
+	int64_t factor2_lo = points[p_point2].factor & 0xFFFFFF;
+	int64_t factor2_hi = points[p_point2].factor >> 24;
+	int64_t factor_rel_lo = points[p_point_rel].factor & 0xFFFFFF;
+	int64_t factor_rel_hi = points[p_point_rel].factor >> 24;
+	int64_t x1_lo = points[p_point1].x & 0xFFFFFFFF;
+	int64_t x1_hi = points[p_point1].x >> 32;
+	int64_t x2_lo = points[p_point2].x & 0xFFFFFFFF;
+	int64_t x2_hi = points[p_point2].x >> 32;
+	int64_t x_rel_lo = (-points[p_point_rel].x) & 0xFFFFFFFF;
+	int64_t x_rel_hi = (-points[p_point_rel].x) >> 32;
+	int64_t y1_lo = points[p_point1].y & 0xFFFFFFFF;
+	int64_t y1_hi = points[p_point1].y >> 32;
+	int64_t y2_lo = points[p_point2].y & 0xFFFFFFFF;
+	int64_t y2_hi = points[p_point2].y >> 32;
+	int64_t y_rel_lo = (-points[p_point_rel].y) & 0xFFFFFFFF;
+	int64_t y_rel_hi = (-points[p_point_rel].y) >> 32;
+
+	// m1 = point1 * factor_rel - point_rel * factor1
+	// m2 = point2 * factor_rel - point_rel * factor2
+	int64_t mx1_t0 = x1_lo * factor_rel_lo + x_rel_lo * factor1_lo;
+	int64_t my1_t0 = y1_lo * factor_rel_lo + y_rel_lo * factor1_lo;
+	int64_t mx2_t0 = x2_lo * factor_rel_lo + x_rel_lo * factor2_lo;
+	int64_t my2_t0 = y2_lo * factor_rel_lo + y_rel_lo * factor2_lo;
+	int64_t mx1_t1 = x1_lo * factor_rel_hi + x_rel_lo * factor1_hi + (mx1_t0 >> 24);
+	int64_t my1_t1 = y1_lo * factor_rel_hi + y_rel_lo * factor1_hi + (my1_t0 >> 24);
+	int64_t mx2_t1 = x2_lo * factor_rel_hi + x_rel_lo * factor2_hi + (mx2_t0 >> 24);
+	int64_t my2_t1 = y2_lo * factor_rel_hi + y_rel_lo * factor2_hi + (my2_t0 >> 24);
+	int64_t mx1_t2 = x1_hi * factor_rel_lo + x_rel_hi * factor1_lo + (mx1_t1 >> 8);
+	int64_t my1_t2 = y1_hi * factor_rel_lo + y_rel_hi * factor1_lo + (my1_t1 >> 8);
+	int64_t mx2_t2 = x2_hi * factor_rel_lo + x_rel_hi * factor2_lo + (mx2_t1 >> 8);
+	int64_t my2_t2 = y2_hi * factor_rel_lo + y_rel_hi * factor2_lo + (my2_t1 >> 8);
+	int64_t mx1_t3 = x1_hi * factor_rel_hi + x_rel_hi * factor1_hi + (mx1_t2 >> 24);
+	int64_t my1_t3 = y1_hi * factor_rel_hi + y_rel_hi * factor1_hi + (my1_t2 >> 24);
+	int64_t mx2_t3 = x2_hi * factor_rel_hi + x_rel_hi * factor2_hi + (mx2_t2 >> 24);
+	int64_t my2_t3 = y2_hi * factor_rel_hi + y_rel_hi * factor2_hi + (my2_t2 >> 24);
+	int64_t mx1_0 = (mx1_t0 & 0xFFFFFF) | ((mx1_t1 & 0x1F) << 24);
+	int64_t my1_0 = (my1_t0 & 0xFFFFFF) | ((my1_t1 & 0x1F) << 24);
+	int64_t mx2_0 = (mx2_t0 & 0xFFFFFF) | ((mx2_t1 & 0x1F) << 24);
+	int64_t my2_0 = (my2_t0 & 0xFFFFFF) | ((my2_t1 & 0x1F) << 24);
+	int64_t mx1_1 = ((mx1_t1 >> 5) & 0x7) | ((mx1_t2 & 0xFFFFFF) << 3) | ((mx1_t3 & 0x3) << 27);
+	int64_t my1_1 = ((my1_t1 >> 5) & 0x7) | ((my1_t2 & 0xFFFFFF) << 3) | ((my1_t3 & 0x3) << 27);
+	int64_t mx2_1 = ((mx2_t1 >> 5) & 0x7) | ((mx2_t2 & 0xFFFFFF) << 3) | ((mx2_t3 & 0x3) << 27);
+	int64_t my2_1 = ((my2_t1 >> 5) & 0x7) | ((my2_t2 & 0xFFFFFF) << 3) | ((my2_t3 & 0x3) << 27);
+	int64_t mx1_2 = (mx1_t3 >> 2) & 0x1FFFFFFF;
+	int64_t my1_2 = (my1_t3 >> 2) & 0x1FFFFFFF;
+	int64_t mx2_2 = (mx2_t3 >> 2) & 0x1FFFFFFF;
+	int64_t my2_2 = (my2_t3 >> 2) & 0x1FFFFFFF;
+	int64_t mx1_3 = mx1_t3 >> 31;
+	int64_t my1_3 = my1_t3 >> 31;
+	int64_t mx2_3 = mx2_t3 >> 31;
+	int64_t my2_3 = my2_t3 >> 31;
+
+	// a = m1.y * m2.x
+	// b = m1.x * m2.y
+	int64_t a_0 = my1_0 * mx2_0;
+	int64_t b_0 = mx1_0 * my2_0;
+	int64_t a_1 = my1_1 * mx2_0 + my1_0 * mx2_1 + (a_0 >> 29);
+	int64_t b_1 = mx1_1 * my2_0 + mx1_0 * my2_1 + (b_0 >> 29);
+	int64_t a_2 = my1_2 * mx2_0 + my1_1 * mx2_1 + my1_0 * mx2_2 + (a_1 >> 29);
+	int64_t b_2 = mx1_2 * my2_0 + mx1_1 * my2_1 + mx1_0 * my2_2 + (b_1 >> 29);
+	int64_t a_3 = my1_3 * mx2_0 + my1_2 * mx2_1 + my1_1 * mx2_2 + my1_0 * mx2_3 + (a_2 >> 29);
+	int64_t b_3 = mx1_3 * my2_0 + mx1_2 * my2_1 + mx1_1 * my2_2 + mx1_0 * my2_3 + (b_2 >> 29);
+	int64_t a_4 = my1_3 * mx2_1 + my1_2 * mx2_2 + my1_1 * mx2_3 + (a_3 >> 29);
+	int64_t b_4 = mx1_3 * my2_1 + mx1_2 * my2_2 + mx1_1 * my2_3 + (b_3 >> 29);
+	int64_t a_5 = my1_3 * mx2_2 + my1_2 * mx2_3 + (a_4 >> 29);
+	int64_t b_5 = mx1_3 * my2_2 + mx1_2 * my2_3 + (b_4 >> 29);
+	int64_t a_6 = my1_3 * mx2_3 + (a_5 >> 29);
+	int64_t b_6 = mx1_3 * my2_3 + (b_5 >> 29);
+
+	a_0 &= 0x1FFFFFFF;
+	b_0 &= 0x1FFFFFFF;
+	a_1 &= 0x1FFFFFFF;
+	b_1 &= 0x1FFFFFFF;
+	a_2 &= 0x1FFFFFFF;
+	b_2 &= 0x1FFFFFFF;
+	a_3 &= 0x1FFFFFFF;
+	b_3 &= 0x1FFFFFFF;
+	a_4 &= 0x1FFFFFFF;
+	b_4 &= 0x1FFFFFFF;
+	a_5 &= 0x1FFFFFFF;
+	b_5 &= 0x1FFFFFFF;
+
+	// sign(a - b)
+	if (a_6 > b_6) {
+		return 1;
+	}
+	if (a_6 < b_6) {
+		return -1;
+	}
+	if (a_5 > b_5) {
+		return 1;
+	}
+	if (a_5 < b_5) {
+		return -1;
+	}
+	if (a_4 > b_4) {
+		return 1;
+	}
+	if (a_4 < b_4) {
+		return -1;
+	}
+	if (a_3 > b_3) {
+		return 1;
+	}
+	if (a_3 < b_3) {
+		return -1;
+	}
+	if (a_2 > b_2) {
+		return 1;
+	}
+	if (a_2 < b_2) {
+		return -1;
+	}
+	if (a_1 > b_1) {
+		return 1;
+	}
+	if (a_1 < b_1) {
+		return -1;
+	}
+	if (a_0 > b_0) {
+		return 1;
+	}
+	if (a_0 < b_0) {
+		return -1;
+	}
+	return 0;
+}
+
+uint32_t BentleyOttmann::tree_create(uint32_t p_element) {
+	TreeNode node;
+	node.prev = node.next = tree_nodes.size();
+	node.element = p_element;
+	tree_nodes.push_back(node);
+	return node.next;
+}
+
+void BentleyOttmann::tree_clear(uint32_t p_tree) {
+	uint32_t iter = tree_nodes[p_tree].next;
+	while (iter != p_tree) {
+		uint32_t next = tree_nodes[iter].next;
+		tree_nodes[iter].left = tree_nodes[iter].right = tree_nodes[iter].parent = 0;
+		tree_nodes[iter].prev = tree_nodes[iter].next = iter;
+		tree_nodes[iter].is_heavy = false;
+		iter = next;
+	}
+	tree_nodes[p_tree].left = tree_nodes[p_tree].right = tree_nodes[p_tree].parent = 0;
+	tree_nodes[p_tree].prev = tree_nodes[p_tree].next = iter;
+	tree_nodes[p_tree].is_heavy = false;
+}
+
+void BentleyOttmann::tree_insert(uint32_t p_insert_item, uint32_t p_insert_after) {
+	DEV_ASSERT(p_insert_item != 0 && p_insert_after != 0);
+	if (tree_nodes[p_insert_after].right == 0) {
+		tree_nodes[p_insert_after].right = p_insert_item;
+		tree_nodes[p_insert_item].parent = p_insert_after;
+	} else {
+		DEV_ASSERT(tree_nodes[tree_nodes[p_insert_after].next].left == 0);
+		tree_nodes[tree_nodes[p_insert_after].next].left = p_insert_item;
+		tree_nodes[p_insert_item].parent = tree_nodes[p_insert_after].next;
+	}
+	tree_nodes[p_insert_item].prev = p_insert_after;
+	tree_nodes[p_insert_item].next = tree_nodes[p_insert_after].next;
+	tree_nodes[tree_nodes[p_insert_after].next].prev = p_insert_item;
+	tree_nodes[p_insert_after].next = p_insert_item;
+	uint32_t item = p_insert_item;
+	uint32_t parent = tree_nodes[item].parent;
+	while (tree_nodes[parent].parent) {
+		uint32_t sibling = tree_nodes[parent].left;
+		if (sibling == item) {
+			sibling = tree_nodes[parent].right;
+		}
+		if (tree_nodes[sibling].is_heavy) {
+			tree_nodes[sibling].is_heavy = false;
+			return;
+		}
+		if (!tree_nodes[item].is_heavy) {
+			tree_nodes[item].is_heavy = true;
+			item = parent;
+			parent = tree_nodes[item].parent;
+			continue;
+		}
+		uint32_t move;
+		uint32_t unmove;
+		uint32_t move_move;
+		uint32_t move_unmove;
+		if (item == tree_nodes[parent].left) {
+			move = tree_nodes[item].right;
+			unmove = tree_nodes[item].left;
+			move_move = tree_nodes[move].left;
+			move_unmove = tree_nodes[move].right;
+		} else {
+			move = tree_nodes[item].left;
+			unmove = tree_nodes[item].right;
+			move_move = tree_nodes[move].right;
+			move_unmove = tree_nodes[move].left;
+		}
+		if (!tree_nodes[move].is_heavy) {
+			tree_rotate(item);
+			tree_nodes[item].is_heavy = tree_nodes[parent].is_heavy;
+			tree_nodes[parent].is_heavy = !tree_nodes[unmove].is_heavy;
+			if (tree_nodes[unmove].is_heavy) {
+				tree_nodes[unmove].is_heavy = false;
+				return;
+			}
+			DEV_ASSERT(move != 0);
+			tree_nodes[move].is_heavy = true;
+			parent = tree_nodes[item].parent;
+			continue;
+		}
+		tree_rotate(move);
+		tree_rotate(move);
+		tree_nodes[move].is_heavy = tree_nodes[parent].is_heavy;
+		if (unmove != 0) {
+			tree_nodes[unmove].is_heavy = tree_nodes[move_unmove].is_heavy;
+		}
+		if (sibling != 0) {
+			tree_nodes[sibling].is_heavy = tree_nodes[move_move].is_heavy;
+		}
+		tree_nodes[item].is_heavy = false;
+		tree_nodes[parent].is_heavy = false;
+		tree_nodes[move_move].is_heavy = false;
+		if (move_unmove != 0) {
+			tree_nodes[move_unmove].is_heavy = false;
+		}
+		return;
+	}
+}
+
+void BentleyOttmann::tree_remove(uint32_t p_remove_item) {
+	DEV_ASSERT(tree_nodes[p_remove_item].parent != 0);
+	if (tree_nodes[p_remove_item].left != 0 && tree_nodes[p_remove_item].right != 0) {
+		uint32_t prev = tree_nodes[p_remove_item].prev;
+		DEV_ASSERT(tree_nodes[prev].parent != 0 && tree_nodes[prev].right == 0);
+		tree_swap(p_remove_item, prev);
+	}
+	DEV_ASSERT(tree_nodes[p_remove_item].left == 0 || tree_nodes[p_remove_item].right == 0);
+	uint32_t prev = tree_nodes[p_remove_item].prev;
+	uint32_t next = tree_nodes[p_remove_item].next;
+	tree_nodes[prev].next = next;
+	tree_nodes[next].prev = prev;
+	uint32_t parent = tree_nodes[p_remove_item].parent;
+	uint32_t replacement = tree_nodes[p_remove_item].left;
+	if (replacement == 0) {
+		replacement = tree_nodes[p_remove_item].right;
+	}
+	if (replacement != 0) {
+		tree_nodes[replacement].parent = parent;
+		tree_nodes[replacement].is_heavy = tree_nodes[p_remove_item].is_heavy;
+	}
+	if (tree_nodes[parent].left == p_remove_item) {
+		tree_nodes[parent].left = replacement;
+	} else {
+		tree_nodes[parent].right = replacement;
+	}
+	tree_nodes[p_remove_item].left = tree_nodes[p_remove_item].right = tree_nodes[p_remove_item].parent = 0;
+	tree_nodes[p_remove_item].prev = tree_nodes[p_remove_item].next = p_remove_item;
+	tree_nodes[p_remove_item].is_heavy = false;
+	uint32_t item = replacement;
+	if (tree_nodes[parent].left == 0 && tree_nodes[parent].right == 0) {
+		item = parent;
+		parent = tree_nodes[item].parent;
+	}
+	while (tree_nodes[parent].parent != 0) {
+		uint32_t sibling = tree_nodes[parent].left;
+		if (sibling == item) {
+			sibling = tree_nodes[parent].right;
+		}
+		DEV_ASSERT(sibling != 0);
+		if (tree_nodes[item].is_heavy) {
+			tree_nodes[item].is_heavy = false;
+			item = parent;
+			parent = tree_nodes[item].parent;
+			continue;
+		}
+		if (!tree_nodes[sibling].is_heavy) {
+			tree_nodes[sibling].is_heavy = true;
+			return;
+		}
+		uint32_t move;
+		uint32_t unmove;
+		uint32_t move_move;
+		uint32_t move_unmove;
+		if (sibling == tree_nodes[parent].left) {
+			move = tree_nodes[sibling].right;
+			unmove = tree_nodes[sibling].left;
+			move_move = tree_nodes[move].left;
+			move_unmove = tree_nodes[move].right;
+		} else {
+			move = tree_nodes[sibling].left;
+			unmove = tree_nodes[sibling].right;
+			move_move = tree_nodes[move].right;
+			move_unmove = tree_nodes[move].left;
+		}
+		if (!tree_nodes[move].is_heavy) {
+			tree_rotate(sibling);
+			tree_nodes[sibling].is_heavy = tree_nodes[parent].is_heavy;
+			tree_nodes[parent].is_heavy = !tree_nodes[unmove].is_heavy;
+			if (tree_nodes[unmove].is_heavy) {
+				tree_nodes[unmove].is_heavy = false;
+				item = sibling;
+				parent = tree_nodes[item].parent;
+				continue;
+			}
+			DEV_ASSERT(move != 0);
+			tree_nodes[move].is_heavy = true;
+			return;
+		}
+		tree_rotate(move);
+		tree_rotate(move);
+		tree_nodes[move].is_heavy = tree_nodes[parent].is_heavy;
+		if (unmove != 0) {
+			tree_nodes[unmove].is_heavy = tree_nodes[move_unmove].is_heavy;
+		}
+		if (item != 0) {
+			tree_nodes[item].is_heavy = tree_nodes[move_move].is_heavy;
+		}
+		tree_nodes[sibling].is_heavy = false;
+		tree_nodes[parent].is_heavy = false;
+		tree_nodes[move_move].is_heavy = false;
+		if (move_unmove != 0) {
+			tree_nodes[move_unmove].is_heavy = false;
+		}
+		item = move;
+		parent = tree_nodes[item].parent;
+		continue;
+	}
+}
+
+void BentleyOttmann::tree_rotate(uint32_t p_item) {
+	DEV_ASSERT(tree_nodes[tree_nodes[p_item].parent].parent != 0);
+	uint32_t parent = tree_nodes[p_item].parent;
+	if (tree_nodes[parent].left == p_item) {
+		uint32_t move = tree_nodes[p_item].right;
+		tree_nodes[parent].left = move;
+		tree_nodes[p_item].right = parent;
+		if (move) {
+			tree_nodes[move].parent = parent;
+		}
+	} else {
+		uint32_t move = tree_nodes[p_item].left;
+		tree_nodes[parent].right = move;
+		tree_nodes[p_item].left = parent;
+		if (move) {
+			tree_nodes[move].parent = parent;
+		}
+	}
+	uint32_t grandparent = tree_nodes[parent].parent;
+	tree_nodes[p_item].parent = grandparent;
+	if (tree_nodes[grandparent].left == parent) {
+		tree_nodes[grandparent].left = p_item;
+	} else {
+		tree_nodes[grandparent].right = p_item;
+	}
+	tree_nodes[parent].parent = p_item;
+}
+
+void BentleyOttmann::tree_swap(uint32_t p_item1, uint32_t p_item2) {
+	DEV_ASSERT(tree_nodes[p_item1].parent != 0 && tree_nodes[p_item2].parent != 0);
+	uint32_t parent1 = tree_nodes[p_item1].parent;
+	uint32_t left1 = tree_nodes[p_item1].left;
+	uint32_t right1 = tree_nodes[p_item1].right;
+	uint32_t prev1 = tree_nodes[p_item1].prev;
+	uint32_t next1 = tree_nodes[p_item1].next;
+	uint32_t parent2 = tree_nodes[p_item2].parent;
+	uint32_t left2 = tree_nodes[p_item2].left;
+	uint32_t right2 = tree_nodes[p_item2].right;
+	uint32_t prev2 = tree_nodes[p_item2].prev;
+	uint32_t next2 = tree_nodes[p_item2].next;
+	if (tree_nodes[parent1].left == p_item1) {
+		tree_nodes[parent1].left = p_item2;
+	} else {
+		tree_nodes[parent1].right = p_item2;
+	}
+	if (tree_nodes[parent2].left == p_item2) {
+		tree_nodes[parent2].left = p_item1;
+	} else {
+		tree_nodes[parent2].right = p_item1;
+	}
+	if (left1) {
+		tree_nodes[left1].parent = p_item2;
+	}
+	if (right1) {
+		tree_nodes[right1].parent = p_item2;
+	}
+	if (left2) {
+		tree_nodes[left2].parent = p_item1;
+	}
+	if (right2) {
+		tree_nodes[right2].parent = p_item1;
+	}
+	tree_nodes[prev1].next = p_item2;
+	tree_nodes[next1].prev = p_item2;
+	tree_nodes[prev2].next = p_item1;
+	tree_nodes[next2].prev = p_item1;
+	parent1 = tree_nodes[p_item1].parent;
+	left1 = tree_nodes[p_item1].left;
+	right1 = tree_nodes[p_item1].right;
+	prev1 = tree_nodes[p_item1].prev;
+	next1 = tree_nodes[p_item1].next;
+	parent2 = tree_nodes[p_item2].parent;
+	left2 = tree_nodes[p_item2].left;
+	right2 = tree_nodes[p_item2].right;
+	prev2 = tree_nodes[p_item2].prev;
+	next2 = tree_nodes[p_item2].next;
+	tree_nodes[p_item2].parent = parent1;
+	tree_nodes[p_item2].left = left1;
+	tree_nodes[p_item2].right = right1;
+	tree_nodes[p_item2].prev = prev1;
+	tree_nodes[p_item2].next = next1;
+	tree_nodes[p_item1].parent = parent2;
+	tree_nodes[p_item1].left = left2;
+	tree_nodes[p_item1].right = right2;
+	tree_nodes[p_item1].prev = prev2;
+	tree_nodes[p_item1].next = next2;
+	bool is_heavy = tree_nodes[p_item1].is_heavy;
+	tree_nodes[p_item1].is_heavy = tree_nodes[p_item2].is_heavy;
+	tree_nodes[p_item2].is_heavy = is_heavy;
+}
+
+void BentleyOttmann::tree_replace(uint32_t p_item1, uint32_t p_item2) {
+	DEV_ASSERT(tree_nodes[p_item1].parent == 0 && tree_nodes[p_item2].parent != 0);
+	uint32_t parent = tree_nodes[p_item2].parent;
+	uint32_t left = tree_nodes[p_item2].left;
+	uint32_t right = tree_nodes[p_item2].right;
+	uint32_t prev = tree_nodes[p_item2].prev;
+	uint32_t next = tree_nodes[p_item2].next;
+	if (tree_nodes[parent].left == p_item2) {
+		tree_nodes[parent].left = p_item1;
+	} else {
+		tree_nodes[parent].right = p_item1;
+	}
+	if (left) {
+		tree_nodes[left].parent = p_item1;
+	}
+	if (right) {
+		tree_nodes[right].parent = p_item1;
+	}
+	tree_nodes[prev].next = p_item1;
+	tree_nodes[next].prev = p_item1;
+	tree_nodes[p_item1].parent = parent;
+	tree_nodes[p_item1].left = left;
+	tree_nodes[p_item1].right = right;
+	tree_nodes[p_item1].prev = prev;
+	tree_nodes[p_item1].next = next;
+	tree_nodes[p_item1].is_heavy = tree_nodes[p_item2].is_heavy;
+	tree_nodes[p_item2].left = tree_nodes[p_item2].right = tree_nodes[p_item2].parent = 0;
+	tree_nodes[p_item2].prev = tree_nodes[p_item2].next = p_item2;
+	tree_nodes[p_item2].is_heavy = false;
+}
+
+uint32_t BentleyOttmann::list_create(uint32_t p_element) {
+	ListNode node;
+	node.anchor = node.prev = node.next = list_nodes.size();
+	node.element = p_element;
+	list_nodes.push_back(node);
+	return node.next;
+}
+
+void BentleyOttmann::list_insert(uint32_t p_insert_item, uint32_t p_list) {
+	DEV_ASSERT(p_insert_item != p_list);
+	DEV_ASSERT(list_nodes[p_list].anchor == p_list);
+	if (list_nodes[p_insert_item].anchor == p_list) {
+		return;
+	}
+	if (list_nodes[p_insert_item].anchor != p_insert_item) {
+		list_remove(p_insert_item);
+	}
+	list_nodes[p_insert_item].anchor = p_list;
+	list_nodes[p_insert_item].prev = p_list;
+	list_nodes[p_insert_item].next = list_nodes[p_list].next;
+	list_nodes[list_nodes[p_list].next].prev = p_insert_item;
+	list_nodes[p_list].next = p_insert_item;
+}
+
+void BentleyOttmann::list_remove(uint32_t p_remove_item) {
+	list_nodes[list_nodes[p_remove_item].next].prev = list_nodes[p_remove_item].prev;
+	list_nodes[list_nodes[p_remove_item].prev].next = list_nodes[p_remove_item].next;
+	list_nodes[p_remove_item].anchor = list_nodes[p_remove_item].prev = list_nodes[p_remove_item].next = p_remove_item;
+}

--- a/core/math/bentley_ottmann.h
+++ b/core/math/bentley_ottmann.h
@@ -1,0 +1,142 @@
+/**************************************************************************/
+/*  bentley_ottmann.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef BENTLEY_OTTMANN_H
+#define BENTLEY_OTTMANN_H
+
+#include "core/math/vector2.h"
+#include "core/templates/local_vector.h"
+
+class BentleyOttmann {
+public:
+	BentleyOttmann(Vector<Vector2> p_edges, Vector<int> p_winding, bool p_winding_even_odd);
+	Vector<Vector2> out_points;
+	Vector<int32_t> out_triangles;
+
+private:
+	int winding_mask;
+
+	struct TreeNode {
+		uint32_t parent = 0;
+		uint32_t left = 0;
+		uint32_t right = 0;
+		uint32_t prev = 0;
+		uint32_t next = 0;
+		bool is_heavy = false;
+		uint32_t element = 0;
+	};
+	thread_local static LocalVector<TreeNode> tree_nodes;
+
+	struct ListNode {
+		uint32_t anchor = 0;
+		uint32_t prev = 0;
+		uint32_t next = 0;
+		uint32_t element = 0;
+	};
+	thread_local static LocalVector<ListNode> list_nodes;
+
+	struct Slice {
+		int64_t x;
+		uint32_t vertical_tree;
+	};
+	thread_local static LocalVector<Slice> slices;
+	uint32_t slices_tree;
+
+	struct Point {
+		int64_t x;
+		int64_t y;
+		int64_t factor;
+		uint32_t outgoing_tree;
+		uint32_t listnode_edge_prev;
+		uint32_t listnode_edge_next;
+		uint32_t used = 0;
+	};
+	thread_local static LocalVector<Point> points;
+	uint32_t points_tree;
+
+	struct Edge {
+		uint32_t point_start;
+		uint32_t point_end;
+		uint32_t point_outgoing;
+		uint32_t treenode_edges;
+		uint32_t treenode_outgoing;
+		uint32_t points_prev_list;
+		uint32_t points_next_list;
+		int64_t dir_x;
+		int64_t dir_y;
+		int64_t cross;
+		int64_t min_y;
+		int64_t max_y;
+		int winding;
+		int winding_total = 0;
+	};
+	thread_local static LocalVector<Edge> edges;
+	uint32_t edges_tree;
+
+	struct Vertical {
+		int64_t y;
+		bool is_start;
+	};
+	thread_local static LocalVector<Vertical> verticals;
+
+	thread_local static LocalVector<uint32_t> triangles;
+
+	uint32_t add_slice(int64_t p_x);
+	uint32_t add_point(int64_t p_x, int64_t p_y, int64_t p_factor);
+	void point_add_outgoing(uint32_t p_point, uint32_t p_edge);
+	void add_edge(uint32_t p_point_start, uint32_t p_point_end, int p_winding);
+	void add_vertical_edge(uint32_t p_slice, int64_t p_y_start, int64_t p_y_end);
+	void edge_intersect_x(uint32_t p_edge, int64_t p_x);
+	void edge_intersect_edge(uint32_t p_edge1, uint32_t p_edge2);
+	void edge_set_outgoing(uint32_t p_edge, uint32_t p_point);
+	void edge_add_point_before(uint32_t p_edge, uint32_t p_point);
+	void edge_add_point_after(uint32_t p_edge, uint32_t p_point);
+	uint32_t get_edge_before(int64_t p_x, int64_t p_y);
+	uint32_t get_edge_before_point(uint32_t p_point);
+	void check_intersection(uint32_t p_treenode_edge);
+
+	int cmp_point_point(int64_t p_x, int64_t p_y, int64_t factor, uint32_t p_point);
+	int cmp_point_edge(uint32_t p_point, uint32_t p_edge);
+	int cmp_cross(uint32_t p_point1, uint32_t p_point2, uint32_t p_point_rel);
+
+	uint32_t tree_create(uint32_t p_element = 0);
+	void tree_clear(uint32_t p_tree);
+	void tree_insert(uint32_t p_insert_item, uint32_t p_insert_after);
+	void tree_remove(uint32_t p_remove_item);
+	void tree_rotate(uint32_t p_item);
+	void tree_swap(uint32_t p_item1, uint32_t p_item2);
+	void tree_replace(uint32_t p_item1, uint32_t p_item2);
+
+	uint32_t list_create(uint32_t p_element = 0);
+	void list_insert(uint32_t p_insert_item, uint32_t p_list);
+	void list_remove(uint32_t p_remove_item);
+};
+
+#endif // BENTLEY_OTTMANN_H

--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -30,12 +30,37 @@
 
 #include "geometry_2d.h"
 
+#include "core/math/bentley_ottmann.h"
+#include "core/math/transform_2d.h"
+
 #include "thirdparty/misc/clipper.hpp"
 #include "thirdparty/misc/polypartition.h"
 #define STB_RECT_PACK_IMPLEMENTATION
 #include "thirdparty/misc/stb_rect_pack.h"
 
 #define SCALE_FACTOR 100000.0 // Based on CMP_EPSILON.
+
+void Geometry2D::triangulate_polygons(const Vector<Vector<Vector2>> &p_polygons, bool p_winding_even_odd, Vector<Vector2> &r_points, Vector<int32_t> &r_triangles) {
+	Vector<Vector2> edges;
+	Vector<int> winding;
+	for (int i = 0; i < p_polygons.size(); i++) {
+		const Vector<Vector2> &polygon = p_polygons[i];
+		if (polygon.size() < 3) {
+			continue;
+		}
+		for (int j = 1; j < polygon.size(); j++) {
+			edges.push_back(polygon[j - 1]);
+			edges.push_back(polygon[j]);
+			winding.push_back(1);
+		}
+		edges.push_back(polygon[polygon.size() - 1]);
+		edges.push_back(polygon[0]);
+		winding.push_back(1);
+	}
+	BentleyOttmann triangulator(edges, winding, p_winding_even_odd);
+	r_points = triangulator.out_points;
+	r_triangles = triangulator.out_triangles;
+}
 
 Vector<Vector<Vector2>> Geometry2D::decompose_polygon_in_convex(Vector<Point2> polygon) {
 	Vector<Vector<Vector2>> decomp;
@@ -349,5 +374,496 @@ Vector<Vector3i> Geometry2D::partial_pack_rects(const Vector<Vector2i> &p_sizes,
 		ret.write[rects[i].id] = Vector3i(rects[i].x, rects[i].y, rects[i].was_packed != 0 ? 1 : 0);
 	}
 
+	return ret;
+}
+
+static void tessellate_cubic_bezier_in_rect(Vector<Vector2> &r_out, Vector2 p_start, Vector2 p_control1, Vector2 p_control2, Vector2 p_end, Vector2 p_start_transformed, Vector2 p_control1_transformed, Vector2 p_control2_transformed, Vector2 p_end_transformed, const Rect2 &p_limit) {
+	while (true) {
+		// Stop condition - Completely out of bounds
+		real_t limit;
+		limit = p_limit.position.x;
+		if (p_start_transformed.x < limit && p_control1_transformed.x < limit && p_control2_transformed.x < limit && p_end_transformed.x < limit) {
+			break;
+		}
+		limit = p_limit.position.y;
+		if (p_start_transformed.y < limit && p_control1_transformed.y < limit && p_control2_transformed.y < limit && p_end_transformed.y < limit) {
+			break;
+		}
+		limit = p_limit.position.x + p_limit.size.x;
+		if (p_start_transformed.x > limit && p_control1_transformed.x > limit && p_control2_transformed.x > limit && p_end_transformed.x > limit) {
+			break;
+		}
+		limit = p_limit.position.y + p_limit.size.y;
+		if (p_start_transformed.y > limit && p_control1_transformed.y > limit && p_control2_transformed.y > limit && p_end_transformed.y > limit) {
+			break;
+		}
+		// Stop condition - Sufficiently close to a line
+		real_t a = p_control1_transformed.distance_squared_to(p_start_transformed);
+		real_t b = p_control1_transformed.distance_squared_to(p_end_transformed);
+		real_t c = p_start_transformed.distance_squared_to(p_end_transformed);
+		real_t abc = (c - b + a);
+		if ((a + b + c < 0.25 || abc * abc - c * (4.0 * a - 1.0) >= 0.0) && c + 0.25 > a && c + 0.25 > b) {
+			a = p_control2_transformed.distance_squared_to(p_start_transformed);
+			b = p_control2_transformed.distance_squared_to(p_end_transformed);
+			abc = (c - b + a);
+			if ((a + b + c < 0.25 || abc * abc - c * (4.0 * a - 1.0) >= 0.0) && c + 0.25 > a && c + 0.25 > b) {
+				break;
+			}
+		}
+		// Subdivision
+		Vector2 start_control1 = 0.5 * (p_start + p_control1);
+		Vector2 control1_control2 = 0.5 * (p_control1 + p_control2);
+		Vector2 control2_end = 0.5 * (p_control2 + p_end);
+
+		Vector2 start_control1_control2 = 0.5 * (start_control1 + control1_control2);
+		Vector2 control1_control2_end = 0.5 * (control1_control2 + control2_end);
+
+		Vector2 start_control1_control2_end = 0.5 * (start_control1_control2 + control1_control2_end);
+
+		Vector2 start_control1_transformed = 0.5 * (p_start_transformed + p_control1_transformed);
+		Vector2 control1_control2_transformed = 0.5 * (p_control1_transformed + p_control2_transformed);
+		Vector2 control2_end_transformed = 0.5 * (p_control2_transformed + p_end_transformed);
+
+		Vector2 start_control1_control2_transformed = 0.5 * (start_control1_transformed + control1_control2_transformed);
+		Vector2 control1_control2_end_transformed = 0.5 * (control1_control2_transformed + control2_end_transformed);
+
+		Vector2 start_control1_control2_end_transformed = 0.5 * (start_control1_control2_transformed + control1_control2_end_transformed);
+
+		tessellate_cubic_bezier_in_rect(r_out, p_start, start_control1, start_control1_control2, start_control1_control2_end, p_start_transformed, start_control1_transformed, start_control1_control2_transformed, start_control1_control2_end_transformed, p_limit);
+		p_start = start_control1_control2_end;
+		p_control1 = control1_control2_end;
+		p_control2 = control2_end;
+		p_start_transformed = start_control1_control2_end_transformed;
+		p_control1_transformed = control1_control2_end_transformed;
+		p_control2_transformed = control2_end_transformed;
+	}
+	r_out.push_back(p_end);
+}
+
+static void tessellate_order5_bezier_in_rect(Vector<Vector2> &r_out, Vector2 p_start, Vector2 p_control1, Vector2 p_control2, Vector2 p_control3, Vector2 p_control4, Vector2 p_end, Vector2 p_start_transformed, Vector2 p_control1_transformed, Vector2 p_control2_transformed, Vector2 p_control3_transformed, Vector2 p_control4_transformed, Vector2 p_end_transformed, const Rect2 &p_limit) {
+	while (true) {
+		// Stop condition - Completely out of bounds
+		real_t limit;
+		limit = p_limit.position.x;
+		if (p_start_transformed.x < limit && p_control1_transformed.x < limit && p_control2_transformed.x < limit && p_control3_transformed.x < limit && p_control4_transformed.x < limit && p_end_transformed.x < limit) {
+			break;
+		}
+		limit = p_limit.position.y;
+		if (p_start_transformed.y < limit && p_control1_transformed.y < limit && p_control2_transformed.y < limit && p_control3_transformed.y < limit && p_control4_transformed.y < limit && p_end_transformed.y < limit) {
+			break;
+		}
+		limit = p_limit.position.x + p_limit.size.x;
+		if (p_start_transformed.x > limit && p_control1_transformed.x > limit && p_control2_transformed.x > limit && p_control3_transformed.x > limit && p_control4_transformed.x > limit && p_end_transformed.x > limit) {
+			break;
+		}
+		limit = p_limit.position.y + p_limit.size.y;
+		if (p_start_transformed.y > limit && p_control1_transformed.y > limit && p_control2_transformed.y > limit && p_control3_transformed.y > limit && p_control4_transformed.y > limit && p_end_transformed.y > limit) {
+			break;
+		}
+		// Stop condition - Sufficiently close to a line
+		real_t a = p_control1_transformed.distance_squared_to(p_start_transformed);
+		real_t b = p_control1_transformed.distance_squared_to(p_end_transformed);
+		real_t c = p_start_transformed.distance_squared_to(p_end_transformed);
+		real_t abc = (c - b + a);
+		if ((a + b + c < 0.25 || abc * abc - c * (4.0 * a - 1.0) >= 0.0) && c + 0.25 > a && c + 0.25 > b) {
+			a = p_control2_transformed.distance_squared_to(p_start_transformed);
+			b = p_control2_transformed.distance_squared_to(p_end_transformed);
+			abc = (c - b + a);
+			if ((a + b + c < 0.25 || abc * abc - c * (4.0 * a - 1.0) >= 0.0) && c + 0.25 > a && c + 0.25 > b) {
+				a = p_control3_transformed.distance_squared_to(p_start_transformed);
+				b = p_control3_transformed.distance_squared_to(p_end_transformed);
+				abc = (c - b + a);
+				if ((a + b + c < 0.25 || abc * abc - c * (4.0 * a - 1.0) >= 0.0) && c + 0.25 > a && c + 0.25 > b) {
+					a = p_control4_transformed.distance_squared_to(p_start_transformed);
+					b = p_control4_transformed.distance_squared_to(p_end_transformed);
+					abc = (c - b + a);
+					if ((a + b + c < 0.25 || abc * abc - c * (4.0 * a - 1.0) >= 0.0) && c + 0.25 > a && c + 0.25 > b) {
+						break;
+					}
+				}
+			}
+		}
+		// Subdivision
+		Vector2 start_control1 = 0.5 * (p_start + p_control1);
+		Vector2 control1_control2 = 0.5 * (p_control1 + p_control2);
+		Vector2 control2_control3 = 0.5 * (p_control2 + p_control3);
+		Vector2 control3_control4 = 0.5 * (p_control3 + p_control4);
+		Vector2 control4_end = 0.5 * (p_control4 + p_end);
+
+		Vector2 start_control1_control2 = 0.5 * (start_control1 + control1_control2);
+		Vector2 control1_control2_control3 = 0.5 * (control1_control2 + control2_control3);
+		Vector2 control2_control3_control4 = 0.5 * (control2_control3 + control3_control4);
+		Vector2 control3_control4_end = 0.5 * (control3_control4 + control4_end);
+
+		Vector2 start_control1_control2_control3 = 0.5 * (start_control1_control2 + control1_control2_control3);
+		Vector2 control1_control2_control3_control4 = 0.5 * (control1_control2_control3 + control2_control3_control4);
+		Vector2 control2_control3_control4_end = 0.5 * (control2_control3_control4 + control3_control4_end);
+
+		Vector2 start_control1_control2_control3_control4 = 0.5 * (start_control1_control2_control3 + control1_control2_control3_control4);
+		Vector2 control1_control2_control3_control4_end = 0.5 * (control1_control2_control3_control4 + control2_control3_control4_end);
+
+		Vector2 start_control1_control2_control3_control4_end = 0.5 * (start_control1_control2_control3_control4 + control1_control2_control3_control4_end);
+
+		Vector2 start_control1_transformed = 0.5 * (p_start_transformed + p_control1_transformed);
+		Vector2 control1_control2_transformed = 0.5 * (p_control1_transformed + p_control2_transformed);
+		Vector2 control2_control3_transformed = 0.5 * (p_control2_transformed + p_control3_transformed);
+		Vector2 control3_control4_transformed = 0.5 * (p_control3_transformed + p_control4_transformed);
+		Vector2 control4_end_transformed = 0.5 * (p_control4_transformed + p_end_transformed);
+
+		Vector2 start_control1_control2_transformed = 0.5 * (start_control1_transformed + control1_control2_transformed);
+		Vector2 control1_control2_control3_transformed = 0.5 * (control1_control2_transformed + control2_control3_transformed);
+		Vector2 control2_control3_control4_transformed = 0.5 * (control2_control3_transformed + control3_control4_transformed);
+		Vector2 control3_control4_end_transformed = 0.5 * (control3_control4_transformed + control4_end_transformed);
+
+		Vector2 start_control1_control2_control3_transformed = 0.5 * (start_control1_control2_transformed + control1_control2_control3_transformed);
+		Vector2 control1_control2_control3_control4_transformed = 0.5 * (control1_control2_control3_transformed + control2_control3_control4_transformed);
+		Vector2 control2_control3_control4_end_transformed = 0.5 * (control2_control3_control4_transformed + control3_control4_end_transformed);
+
+		Vector2 start_control1_control2_control3_control4_transformed = 0.5 * (start_control1_control2_control3_transformed + control1_control2_control3_control4_transformed);
+		Vector2 control1_control2_control3_control4_end_transformed = 0.5 * (control1_control2_control3_control4_transformed + control2_control3_control4_end_transformed);
+
+		Vector2 start_control1_control2_control3_control4_end_transformed = 0.5 * (start_control1_control2_control3_control4_transformed + control1_control2_control3_control4_end_transformed);
+
+		tessellate_order5_bezier_in_rect(r_out, p_start, start_control1, start_control1_control2, start_control1_control2_control3, start_control1_control2_control3_control4, start_control1_control2_control3_control4_end, p_start_transformed, start_control1_transformed, start_control1_control2_transformed, start_control1_control2_control3_transformed, start_control1_control2_control3_control4_transformed, start_control1_control2_control3_control4_end_transformed, p_limit);
+		p_start = start_control1_control2_control3_control4_end;
+		p_control1 = control1_control2_control3_control4_end;
+		p_control2 = control2_control3_control4_end;
+		p_control3 = control3_control4_end;
+		p_control4 = control4_end;
+		p_start_transformed = start_control1_control2_control3_control4_end_transformed;
+		p_control1_transformed = control1_control2_control3_control4_end_transformed;
+		p_control2_transformed = control2_control3_control4_end_transformed;
+		p_control3_transformed = control3_control4_end_transformed;
+		p_control4_transformed = control4_end_transformed;
+	}
+	r_out.push_back(p_end);
+}
+
+static void tessellate_arc_in_rect(Vector<Vector2> &r_out, const Transform2D &p_axis, const Transform2D &p_axis_transformed, Vector2 p_start, Vector2 p_end, const Rect2 &p_limit) {
+	while (true) {
+		// Stop condition - Completely out of bounds.
+		Rect2 rect;
+		rect.position = p_start;
+		rect.expand_to(p_end);
+		if (!p_limit.intersects_transformed(p_axis_transformed, rect)) {
+			break;
+		}
+		// Stop condition - Sufficiently close to a line.
+		Vector2 mid = (p_start + p_end).normalized();
+		if (p_axis_transformed.basis_xform(mid - 0.5 * (p_start + p_end)).length_squared() < 0.25) {
+			break;
+		}
+		// Subdivision.
+		tessellate_arc_in_rect(r_out, p_axis, p_axis_transformed, p_start, mid, p_limit);
+		p_start = mid;
+	}
+	r_out.push_back(p_axis.xform(p_end));
+}
+
+Vector<Vector2> Geometry2D::tessellate_curve_in_rect(const Vector<Vector2> &p_points, const Vector<uint8_t> &p_types, const Transform2D &p_transform, const Rect2 &p_limit, bool use_order5) {
+	Vector<Vector2> gather;
+
+	if (p_points.size() < 1) {
+		return gather;
+	}
+
+	int index = 0;
+	gather.push_back(p_points[0]);
+
+	Vector<Vector2> transformed = p_transform.xform(p_points);
+
+	for (int i = 0; i < p_types.size(); i++) {
+		for (int j = 0; j < 8; j++) {
+			if (p_types[i] & (1 << j)) {
+				if (index + 4 >= p_points.size()) {
+					goto done;
+				}
+				Vector2 r1 = p_points[index + 1] - p_points[index + 2];
+				Vector2 r2 = p_points[index + 3] - p_points[index + 2];
+				Transform2D axis(r1, r2, p_points[index + 2]);
+				if (unlikely(axis.determinant() == 0.0)) {
+					// The axes are colinear, meaning the arc is either a "line" or a "point".
+					// Just connect to the center, and then to the end point.
+					gather.push_back(p_points[index + 2]);
+					gather.push_back(p_points[index + 4]);
+					index += 4;
+					continue;
+				}
+				Transform2D axis_inverse = axis.affine_inverse();
+				Transform2D axis_transformed = p_transform * axis;
+				Vector2 rstart = axis_inverse.xform(p_points[index]).normalized();
+				Vector2 rend = axis_inverse.xform(p_points[index + 4]).normalized();
+				gather.push_back(axis.xform(rstart));
+				// Limit arc angles to the same quadrant.
+				if (rstart.x < 0) {
+					if (rstart.y < 0) {
+						if (rend.x > 0 || rend.y > 0 || rstart.cross(rend) < 0) {
+							tessellate_arc_in_rect(gather, axis, axis_transformed, rstart, Vector2(0.0, -1.0), p_limit);
+							if (rend.x < 0 || rend.y > 0) {
+								tessellate_arc_in_rect(gather, axis, axis_transformed, Vector2(0.0, -1.0), Vector2(1.0, 0.0), p_limit);
+								if (rend.x < 0) {
+									tessellate_arc_in_rect(gather, axis, axis_transformed, Vector2(1.0, 0.0), Vector2(0.0, 1.0), p_limit);
+									if (rend.y < 0) {
+										tessellate_arc_in_rect(gather, axis, axis_transformed, Vector2(0.0, 1.0), Vector2(-1.0, 0.0), p_limit);
+										rstart = Vector2(-1.0, 0.0);
+									} else {
+										rstart = Vector2(0.0, 1.0);
+									}
+								} else {
+									rstart = Vector2(1.0, 0.0);
+								}
+							} else {
+								rstart = Vector2(0.0, -1.0);
+							}
+						}
+					} else {
+						if (rend.x > 0 || rend.y < 0 || rstart.cross(rend) < 0) {
+							tessellate_arc_in_rect(gather, axis, axis_transformed, rstart, Vector2(-1.0, 0.0), p_limit);
+							if (rend.x > 0 || rend.y > 0) {
+								tessellate_arc_in_rect(gather, axis, axis_transformed, Vector2(-1.0, 0.0), Vector2(0.0, -1.0), p_limit);
+								if (rend.y > 0) {
+									tessellate_arc_in_rect(gather, axis, axis_transformed, Vector2(0.0, -1.0), Vector2(1.0, 0.0), p_limit);
+									if (rend.x < 0) {
+										tessellate_arc_in_rect(gather, axis, axis_transformed, Vector2(1.0, 0.0), Vector2(0.0, 1.0), p_limit);
+										rstart = Vector2(0.0, 1.0);
+									} else {
+										rstart = Vector2(1.0, 0.0);
+									}
+								} else {
+									rstart = Vector2(0.0, -1.0);
+								}
+							} else {
+								rstart = Vector2(-1.0, 0.0);
+							}
+						}
+					}
+				} else {
+					if (rstart.y < 0) {
+						if (rend.x < 0 || rend.y > 0 || rstart.cross(rend) < 0) {
+							tessellate_arc_in_rect(gather, axis, axis_transformed, rstart, Vector2(1.0, 0.0), p_limit);
+							if (rend.x < 0 || rend.y < 0) {
+								tessellate_arc_in_rect(gather, axis, axis_transformed, Vector2(1.0, 0.0), Vector2(0.0, 1.0), p_limit);
+								if (rend.y < 0) {
+									tessellate_arc_in_rect(gather, axis, axis_transformed, Vector2(0.0, 1.0), Vector2(-1.0, 0.0), p_limit);
+									if (rend.x > 0) {
+										tessellate_arc_in_rect(gather, axis, axis_transformed, Vector2(-1.0, 0.0), Vector2(0.0, -1.0), p_limit);
+										rstart = Vector2(0.0, -1.0);
+									} else {
+										rstart = Vector2(-1.0, 0.0);
+									}
+								} else {
+									rstart = Vector2(0.0, 1.0);
+								}
+							} else {
+								rstart = Vector2(1.0, 0.0);
+							}
+						}
+					} else {
+						if (rend.x < 0 || rend.y < 0 || rstart.cross(rend) < 0) {
+							tessellate_arc_in_rect(gather, axis, axis_transformed, rstart, Vector2(0.0, 1.0), p_limit);
+							if (rend.x > 0 || rend.y < 0) {
+								tessellate_arc_in_rect(gather, axis, axis_transformed, Vector2(0.0, 1.0), Vector2(-1.0, 0.0), p_limit);
+								if (rend.x > 0) {
+									tessellate_arc_in_rect(gather, axis, axis_transformed, Vector2(-1.0, 0.0), Vector2(0.0, -1.0), p_limit);
+									if (rend.y > 0) {
+										tessellate_arc_in_rect(gather, axis, axis_transformed, Vector2(0.0, -1.0), Vector2(1.0, 0.0), p_limit);
+										rstart = Vector2(1.0, 0.0);
+									} else {
+										rstart = Vector2(0.0, -1.0);
+									}
+								} else {
+									rstart = Vector2(-1.0, 0.0);
+								}
+							} else {
+								rstart = Vector2(0.0, 1.0);
+							}
+						}
+					}
+				}
+				tessellate_arc_in_rect(gather, axis, axis_transformed, rstart, rend, p_limit);
+				gather.push_back(p_points[index + 4]);
+				index += 4;
+			} else if (use_order5) {
+				if (index + 5 >= p_points.size()) {
+					goto done;
+				}
+				tessellate_order5_bezier_in_rect(gather, p_points[index], p_points[index + 1], p_points[index + 2], p_points[index + 3], p_points[index + 4], p_points[index + 5], transformed[index], transformed[index + 1], transformed[index + 2], transformed[index + 3], transformed[index + 4], transformed[index + 5], p_limit);
+				index += 5;
+			} else {
+				if (index + 3 >= p_points.size()) {
+					goto done;
+				}
+				tessellate_cubic_bezier_in_rect(gather, p_points[index], p_points[index + 1], p_points[index + 2], p_points[index + 3], transformed[index], transformed[index + 1], transformed[index + 2], transformed[index + 3], p_limit);
+				index += 3;
+			}
+		}
+	}
+
+	if (use_order5) {
+		for (; index + 5 < p_points.size(); index += 5) {
+			tessellate_order5_bezier_in_rect(gather, p_points[index], p_points[index + 1], p_points[index + 2], p_points[index + 3], p_points[index + 4], p_points[index + 5], transformed[index], transformed[index + 1], transformed[index + 2], transformed[index + 3], transformed[index + 4], transformed[index + 5], p_limit);
+		}
+	} else {
+		for (; index + 3 < p_points.size(); index += 3) {
+			tessellate_cubic_bezier_in_rect(gather, p_points[index], p_points[index + 1], p_points[index + 2], p_points[index + 3], transformed[index], transformed[index + 1], transformed[index + 2], transformed[index + 3], p_limit);
+		}
+	}
+
+done:
+
+	if (gather.size() < 1) {
+		return gather;
+	}
+
+	// Optimize vertices too close to each other, or outside the rectangle.
+	Vector<Vector2> gather_transformed = p_transform.xform(gather);
+
+	// First pass - Remove points that are too close to each other.
+	Vector<int> pass1;
+	pass1.push_back(0);
+	for (int i = 1; i < gather.size(); i++) {
+		if (gather_transformed[i].distance_squared_to(gather_transformed[pass1[pass1.size() - 1]]) < 0.25) {
+			continue;
+		}
+		pass1.push_back(i);
+	}
+	if (pass1.size() < 2) {
+		// The points are all so close they're basically just one point.
+		// If that point is outside the limit rect, return an empty result.
+		// Otherwise return the one point.
+		if (gather_transformed[0].x < p_limit.position.x || gather_transformed[0].y < p_limit.position.y || gather_transformed[0].x > p_limit.position.x + p_limit.size.x || gather_transformed[0].y > p_limit.position.y + p_limit.size.y) {
+			return Vector<Vector2>();
+		}
+		Vector<Vector2> ret;
+		ret.push_back(gather[0]);
+		return ret;
+	}
+
+	// Second pass - Optimize middle points.
+	Vector<int> pass2;
+	pass2.push_back(pass1[0]);
+	pass2.push_back(pass1[1]);
+	for (int i = 2; i < pass1.size(); i++) {
+		while (pass2.size() > 1) {
+			// If three consecutive transformed points are on the same side of the rect,
+			// remove the center one.
+			Vector2 test1 = gather_transformed[pass2[pass2.size() - 2]];
+			Vector2 test2 = gather_transformed[pass2[pass2.size() - 1]];
+			Vector2 test3 = gather_transformed[pass1[i]];
+			real_t limit;
+			limit = p_limit.position.x;
+			if (test1.x < limit && test2.x < limit && test3.x < limit) {
+				pass2.resize(pass2.size() - 1);
+				continue;
+			}
+			limit = p_limit.position.y;
+			if (test1.y < limit && test2.y < limit && test3.y < limit) {
+				pass2.resize(pass2.size() - 1);
+				continue;
+			}
+			limit = p_limit.position.x + p_limit.size.x;
+			if (test1.x > limit && test2.x > limit && test3.x > limit) {
+				pass2.resize(pass2.size() - 1);
+				continue;
+			}
+			limit = p_limit.position.y + p_limit.size.y;
+			if (test1.y > limit && test2.y > limit && test3.y > limit) {
+				pass2.resize(pass2.size() - 1);
+				continue;
+			}
+			break;
+		}
+		pass2.push_back(pass1[i]);
+	}
+
+	// Third pass - Optimize first and last points.
+	int first = 0;
+	int last = pass2.size() - 1;
+
+	while (last - first > 1) {
+		{
+			Vector2 test1 = gather_transformed[pass2[last]];
+			Vector2 test2 = gather_transformed[pass2[first]];
+			Vector2 test3 = gather_transformed[pass2[first + 1]];
+			real_t limit;
+			limit = p_limit.position.x;
+			if (test1.x < limit && test2.x < limit && test3.x < limit) {
+				first++;
+				continue;
+			}
+			limit = p_limit.position.y;
+			if (test1.y < limit && test2.y < limit && test3.y < limit) {
+				first++;
+				continue;
+			}
+			limit = p_limit.position.x + p_limit.size.x;
+			if (test1.x > limit && test2.x > limit && test3.x > limit) {
+				first++;
+				continue;
+			}
+			limit = p_limit.position.y + p_limit.size.y;
+			if (test1.y > limit && test2.y > limit && test3.y > limit) {
+				first++;
+				continue;
+			}
+		}
+		{
+			Vector2 test1 = gather_transformed[pass2[last - 1]];
+			Vector2 test2 = gather_transformed[pass2[last]];
+			Vector2 test3 = gather_transformed[pass2[first]];
+			real_t limit;
+			limit = p_limit.position.x;
+			if (test1.x < limit && test2.x < limit && test3.x < limit) {
+				last--;
+				continue;
+			}
+			limit = p_limit.position.y;
+			if (test1.y < limit && test2.y < limit && test3.y < limit) {
+				last--;
+				continue;
+			}
+			limit = p_limit.position.x + p_limit.size.x;
+			if (test1.x > limit && test2.x > limit && test3.x > limit) {
+				last--;
+				continue;
+			}
+			limit = p_limit.position.y + p_limit.size.y;
+			if (test1.y > limit && test2.y > limit && test3.y > limit) {
+				last--;
+				continue;
+			}
+		}
+		break;
+	}
+
+	if (last - first < 2) {
+		// Down to just two points. If both are outside, return an empty result.
+		Vector2 test1 = gather_transformed[pass2[first]];
+		Vector2 test2 = gather_transformed[pass2[last]];
+		real_t limit;
+		limit = p_limit.position.x;
+		if (test1.x < limit && test2.x < limit) {
+			return Vector<Vector2>();
+		}
+		limit = p_limit.position.y;
+		if (test1.y < limit && test2.y < limit) {
+			return Vector<Vector2>();
+		}
+		limit = p_limit.position.x + p_limit.size.x;
+		if (test1.x > limit && test2.x > limit) {
+			return Vector<Vector2>();
+		}
+		limit = p_limit.position.y + p_limit.size.y;
+		if (test1.y > limit && test2.y > limit) {
+			return Vector<Vector2>();
+		}
+	}
+
+	// Final pass - Copy the remaining points, untransformed, to the output.
+	last++;
+	Vector<Vector2> ret;
+	for (int i = first; i < last; i++) {
+		ret.push_back(gather[pass2[i]]);
+	}
 	return ret;
 }

--- a/core/math/geometry_2d.h
+++ b/core/math/geometry_2d.h
@@ -322,6 +322,8 @@ public:
 		return triangles;
 	}
 
+	static void triangulate_polygons(const Vector<Vector<Vector2>> &p_polygons, bool p_winding_even_odd, Vector<Vector2> &r_points, Vector<int32_t> &r_triangles);
+
 	static bool is_polygon_clockwise(const Vector<Vector2> &p_polygon) {
 		int c = p_polygon.size();
 		if (c < 3) {
@@ -465,6 +467,8 @@ public:
 
 	static void make_atlas(const Vector<Size2i> &p_rects, Vector<Point2i> &r_result, Size2i &r_size);
 	static Vector<Vector3i> partial_pack_rects(const Vector<Vector2i> &p_sizes, const Size2i &p_atlas_size);
+
+	static Vector<Vector2> tessellate_curve_in_rect(const Vector<Vector2> &p_points, const Vector<uint8_t> &p_types, const Transform2D &p_transform, const Rect2 &p_limit, bool use_order5 = false);
 
 private:
 	static Vector<Vector<Point2>> _polypaths_do_operation(PolyBooleanOperation p_op, const Vector<Point2> &p_polypath_a, const Vector<Point2> &p_polypath_b, bool is_a_open = false);

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -111,6 +111,23 @@
 				After submitting all animations slices via [method draw_animation_slice], this function can be used to revert drawing to its default state (all subsequent drawing commands will be visible). If you don't care about this particular use case, usage of this function after submitting the slices is not required.
 			</description>
 		</method>
+		<method name="draw_filled_curve">
+			<return type="void" />
+			<param index="0" name="points" type="PackedVector2Array[]" />
+			<param index="1" name="types" type="PackedByteArray[]" />
+			<param index="2" name="winding_even_odd" type="bool" />
+			<param index="3" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
+			<param index="4" name="texture" type="Texture2D" default="null" />
+			<param index="5" name="transform_uv" type="Transform2D" default="Transform2D(1, 0, 0, 1, 0, 0)" />
+			<param index="6" name="use_order5" type="bool" default="false" />
+			<description>
+				Draws a curve described by [param points] and [param types], filled according to [param winding_even_odd] with [param modulate] color and [param texture]. [param transform_uv] determines how points inside the curve are transformed to texture UV coordinates.
+				Each respective element of [param points] and [param types] represents a closed curve. [param points] and [param types] must contain the same number of elements. The first point in each element of [param points] is the starting point of the curve. The remaining points are interpreted according to the element of [param types] with the same index. Each element of [param types] is interpreted as a string of bits, with each byte being interpreted as eight bits from least significant to most significant. A value of [code]0[/code] indicates the next segment is a bezier segment. If [param use_order5] is [code]false[/code] then it is a cubic bezier. The next two points in the matching element of [param points] are interpreted as control points, and the third is interpreted the end point. If [param use_order5] is [code]false[/code] then it is an order 5 bezier. The next four points in the matching element of [param points] are interpreted as control points, and the fifth is interpreted the end point. Order 5 beziers can be more complex, but allow producing a continuous curvature.
+				If the next bit represented by the element of [param types] is [code]1[/code], the next four points in the matching element of [param points] are interpreted as an elliptic arc segment. The ellipse is centered along the second point, and intersects the first and third points. The angle range of the arc is determined by the fourth point and the previous point on the curve. If the points do not coincide with the ellipse, line segments connecting the points to the ellipse are added. The arc's drawing direction is determined by the first and third points. If they are clockwise relative to the second point, the arc is drawn clockwise, otherwise it is drawn counter-clockwise.
+				If an element [param types] does not contain enough bits to interpret all the points in the matching element of [param points], it is padded with [code]0[/code] bits as necessary. If it contains too many bits, it is truncated.
+				The way overlapping parts of the curve are handled is determined by [param winding_even_odd]. If [code]true[/code] every part of the countor separates a filled and unfilled area. If [code]false[/code] overlapping areas are kept if their surrounding curve sections are the same direction clockwise or counter clockwise, and subtracted if they are opposite directions.
+			</description>
+		</method>
 		<method name="draw_lcd_texture_rect_region">
 			<return type="void" />
 			<param index="0" name="texture" type="Texture2D" />

--- a/doc/classes/Geometry2D.xml
+++ b/doc/classes/Geometry2D.xml
@@ -214,6 +214,24 @@
 				Checks if the two segments ([param from_a], [param to_a]) and ([param from_b], [param to_b]) intersect. If yes, return the point of intersection as [Vector2]. If no intersection takes place, returns [code]null[/code].
 			</description>
 		</method>
+		<method name="tessellate_curve_in_rect">
+			<return type="PackedVector2Array" />
+			<param index="0" name="points" type="PackedVector2Array" />
+			<param index="1" name="types" type="PackedByteArray" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="limit" type="Rect2" />
+			<param index="4" name="use_order5" type="bool" default="false" />
+			<description>
+				Returns a polyline that approximates the curve described by [param points] and [param types]. The precision of the approximation is determined by `[param transform]` and `[param limit]`.
+				The first point in [param points] is the starting point of the curve. The remaining points are interpreted according to [param types]. [param types] is interpreted as a string of bits, with each byte being interpreted as eight bits from least significant to most significant. A value of [code]0[/code] indicates the next segment is a bezier segment. If [param use_order5] is [code]false[/code] then it is a cubic bezier. The next two points in [param points] are interpreted as control points, and the third is interpreted the end point. If [param use_order5] is [code]false[/code] then it is an order 5 bezier. The next four points in [param points] are interpreted as control points, and the fifth is interpreted the end point. Order 5 beziers can be more complex, but allow producing a continuous curvature.
+				If the next bit represented by [param types] is [code]1[/code], the next four points in [param points] are interpreted as an elliptic arc segment. The ellipse is centered along the second point, and intersects the first and third points. The angle range of the arc is determined by the fourth point and the previous point on the curve. If the points do not coincide with the ellipse, line segments connecting the points to the ellipse are added. The arc's drawing direction is determined by the first and third points. If they are clockwise relative to the second point, the arc is drawn clockwise, otherwise it is drawn counter-clockwise.
+				If [param types] does not contain enough bits to interpret all the points in [param points], it is padded with [code]0[/code] bits as necessary. If it contains too many bits, it is truncated.
+				The precision of the approximation is determined as following: For a curve [code]C[/code], let [code]T(x)[/code] be the curve that results from multiplying every point in [code]x[/code] with the transformation [param transform]. Let [code]W(x, y)[/code] be the winding number for the closed curve [code]x[/code] around the point [code]y[/code], i.e. the number of clockwise rotations the curve completes around the point, minus the number of counter-clockwise rotations. Let [code]curve[/code] be the closed curve formed by connecting the ends of the curve described by [param points] and [param types]. Let [code]P[/code] be the polygon represented by connecting the returned points in a cycle. For every point [code]x[/code] inside [param limit], there exists a point [code]y[/code] so that [code]W(T(C), x)=W(T(P), y)[/code] and the distance between [code]x[/code] and [code]y[/code] is less than [code]0.5[/code].
+				[b]Note:[/b] The transformed output polygon is [i]not[/i] clipped to [param limit]. For any point [code]x[/code] outside the bounding rectangle of [code]T(S)[/code], [code]W(T(P), x)=0[/code] For any other point [code]x[/code] outside [param limit] [code]W(T(P), x)[/code] is [i]undefined[/i], and can be [i]any[/i] value. To avoid any undefined areas, use a [param limit] that contains the entire transformed curve.
+				[b]Note:[/b] The output is [i]not[/i] transformed by [param transform]. It is only used to determine the precision.
+				This function will try to minimize the number of points returned, while maintaining the above precision conditions.
+			</description>
+		</method>
 		<method name="triangulate_delaunay">
 			<return type="PackedInt32Array" />
 			<param index="0" name="points" type="PackedVector2Array" />
@@ -226,6 +244,15 @@
 			<param index="0" name="polygon" type="PackedVector2Array" />
 			<description>
 				Triangulates the polygon specified by the points in [param polygon]. Returns a [PackedInt32Array] where each triangle consists of three consecutive point indices into [param polygon] (i.e. the returned array will have [code]n * 3[/code] elements, with [code]n[/code] being the number of found triangles). Output triangles will always be counter clockwise, and the contour will be flipped if it's clockwise. If the triangulation did not succeed, an empty [PackedInt32Array] is returned.
+			</description>
+		</method>
+		<method name="triangulate_polygons">
+			<return type="Dictionary" />
+			<param index="0" name="polygons" type="PackedVector2Array[]" />
+			<param index="1" name="winding_even_odd" type="bool" />
+			<description>
+				Triangulates the polygons specified in [param polygons]. Each [PackedVector2Array] is interpreted as a single closed polygon. Concave polygons, overlapping polygons, and self-intersections are fully supported. The returned dictionary has two keys: [code]vertices[/code] is a [PackedVector2Array] containing vertices used in the triangulation. This includes the original vertices from [param polygons], intersection points, and points added to deal with concave areas. [code]indices[/code] is a [PackedInt32Array] where each triangle consists of three consecutive point indices into [code]vertices[/code] (i.e. the returned array will have [code]n * 3[/code] elements, with [code]n[/code] being the number of found triangles). Output triangles will always be counter clockwise.
+				The way overlapping polygons are handled is determined by [param winding_even_odd]. If [code]true[/code] every edge separates a filled and unfilled area. If [code]false[/code] overlapping areas are kept if their surrounding polygons are the same direction clockwise or counter clockwise, and subtracted if they are opposite directions.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -211,6 +211,24 @@
 				If [param ignore] is [code]true[/code], ignore clipping on items drawn with this canvas item until this is called again with [param ignore] set to false.
 			</description>
 		</method>
+		<method name="canvas_item_add_filled_curve">
+			<return type="void" />
+			<param index="0" name="item" type="RID" />
+			<param index="1" name="points" type="PackedVector2Array[]" />
+			<param index="2" name="types" type="PackedByteArray[]" />
+			<param index="3" name="winding_even_odd" type="bool" />
+			<param index="4" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
+			<param index="5" name="texture" type="RID" />
+			<param index="6" name="transform_uv" type="Transform2D" default="Transform2D(1, 0, 0, 1, 0, 0)" />
+			<param index="7" name="use_order5" type="bool" default="false" />
+			<description>
+				Draws a curve described by [param points] and [param types], filled according to [param winding_even_odd] with [param modulate] color and [param texture] on the [CanvasItem] pointed to by the [param item] [RID]. [param transform_uv] determines how points inside the curve are transformed to texture UV coordinates.
+				Each respective element of [param points] and [param types] represents a closed curve. [param points] and [param types] must contain the same number of elements. The first point in each element of [param points] is the starting point of the curve. The remaining points are interpreted according to the element of [param types] with the same index. Each element of [param types] is interpreted as a string of bits, with each byte being interpreted as eight bits from least significant to most significant. A value of [code]0[/code] indicates the next segment is a bezier segment. If [param use_order5] is [code]false[/code] then it is a cubic bezier. The next two points in the matching element of [param points] are interpreted as control points, and the third is interpreted the end point. If [param use_order5] is [code]false[/code] then it is an order 5 bezier. The next four points in the matching element of [param points] are interpreted as control points, and the fifth is interpreted the end point. Order 5 beziers can be more complex, but allow producing a continuous curvature.
+				If the next bit represented by the element of [param types] is [code]1[/code], the next four points in the matching element of [param points] are interpreted as an elliptic arc segment. The ellipse is centered along the second point, and intersects the first and third points. The angle range of the arc is determined by the fourth point and the previous point on the curve. If the points do not coincide with the ellipse, line segments connecting the points to the ellipse are added. The arc's drawing direction is determined by the first and third points. If they are clockwise relative to the second point, the arc is drawn clockwise, otherwise it is drawn counter-clockwise.
+				If an element [param types] does not contain enough bits to interpret all the points in the matching element of [param points], it is padded with [code]0[/code] bits as necessary. If it contains too many bits, it is truncated.
+				The way overlapping parts of the curve are handled is determined by [param winding_even_odd]. If [code]true[/code] every part of the countor separates a filled and unfilled area. If [code]false[/code] overlapping areas are kept if their surrounding curve sections are the same direction clockwise or counter clockwise, and subtracted if they are opposite directions.
+			</description>
+		</method>
 		<method name="canvas_item_add_lcd_texture_rect_region">
 			<return type="void" />
 			<param index="0" name="item" type="RID" />

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1118,7 +1118,8 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 
 			case Item::Command::TYPE_MESH:
 			case Item::Command::TYPE_MULTIMESH:
-			case Item::Command::TYPE_PARTICLES: {
+			case Item::Command::TYPE_PARTICLES:
+			case Item::Command::TYPE_FILLED_CURVE: {
 				// Mesh's can't be batched, so always create a new batch
 				_new_batch(r_batch_broken);
 
@@ -1171,6 +1172,10 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 						particles_storage->particles_set_canvas_sdf_collision(pt->particles, false, Transform2D(), Rect2(), 0);
 					}
 					r_sdf_used |= particles_storage->particles_has_collision(particles);
+				} else if (c->type == Item::Command::TYPE_FILLED_CURVE) {
+					const Item::CommandFilledCurve *fc = static_cast<const Item::CommandFilledCurve *>(c);
+					state.canvas_instance_batches[state.current_batch_index].tex = fc->texture;
+					modulate = fc->modulate;
 				}
 
 				state.canvas_instance_batches[state.current_batch_index].command = c;
@@ -1299,7 +1304,8 @@ void RasterizerCanvasGLES3::_render_batch(Light *p_lights, uint32_t p_index) {
 
 		case Item::Command::TYPE_MESH:
 		case Item::Command::TYPE_MULTIMESH:
-		case Item::Command::TYPE_PARTICLES: {
+		case Item::Command::TYPE_PARTICLES:
+		case Item::Command::TYPE_FILLED_CURVE: {
 			GLES3::MeshStorage *mesh_storage = GLES3::MeshStorage::get_singleton();
 			GLES3::ParticlesStorage *particles_storage = GLES3::ParticlesStorage::get_singleton();
 			RID mesh;
@@ -1365,6 +1371,9 @@ void RasterizerCanvasGLES3::_render_batch(Light *p_lights, uint32_t p_index) {
 				instance_uses_color = true;
 				instance_uses_custom_data = true;
 				use_instancing = true;
+			} else if (state.canvas_instance_batches[p_index].command_type == Item::Command::TYPE_FILLED_CURVE) {
+				const Item::CommandFilledCurve *fc = static_cast<const Item::CommandFilledCurve *>(state.canvas_instance_batches[p_index].command);
+				mesh = fc->mesh_cache;
 			}
 
 			ERR_FAIL_COND(mesh.is_null());

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -868,6 +868,10 @@ void CanvasItem::draw_char_outline(const Ref<Font> &p_font, const Point2 &p_pos,
 	p_font->draw_char_outline(canvas_item, p_pos, p_char[0], p_font_size, p_size, p_modulate);
 }
 
+void CanvasItem::draw_filled_curve(const TypedArray<PackedVector2Array> &p_points, const TypedArray<PackedByteArray> &p_types, bool p_winding_even_odd, const Color &p_modulate, const Ref<Texture2D> &p_texture, const Transform2D &p_transform_uv, bool p_use_order5) {
+	RenderingServer::get_singleton()->canvas_item_add_filled_curve(canvas_item, p_points, p_types, p_winding_even_odd, p_modulate, p_texture.is_valid() ? p_texture->get_rid() : RID(), p_transform_uv, p_use_order5);
+}
+
 void CanvasItem::_notify_transform_deferred() {
 	if (is_inside_tree() && notify_transform && !xform_change.in_list()) {
 		get_tree()->xform_change_list.add(&xform_change);
@@ -1150,6 +1154,7 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("draw_set_transform_matrix", "xform"), &CanvasItem::draw_set_transform_matrix);
 	ClassDB::bind_method(D_METHOD("draw_animation_slice", "animation_length", "slice_begin", "slice_end", "offset"), &CanvasItem::draw_animation_slice, DEFVAL(0.0));
 	ClassDB::bind_method(D_METHOD("draw_end_animation"), &CanvasItem::draw_end_animation);
+	ClassDB::bind_method(D_METHOD("draw_filled_curve", "points", "types", "winding_even_odd", "modulate", "texture", "transform_uv", "use_order5"), &CanvasItem::draw_filled_curve, DEFVAL(Color(1, 1, 1, 1)), DEFVAL(Ref<Texture2D>()), DEFVAL(Transform2D()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_transform"), &CanvasItem::get_transform);
 	ClassDB::bind_method(D_METHOD("get_global_transform"), &CanvasItem::get_global_transform);
 	ClassDB::bind_method(D_METHOD("get_global_transform_with_canvas"), &CanvasItem::get_global_transform_with_canvas);

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -300,6 +300,8 @@ public:
 	void draw_animation_slice(double p_animation_length, double p_slice_begin, double p_slice_end, double p_offset = 0);
 	void draw_end_animation();
 
+	void draw_filled_curve(const TypedArray<PackedVector2Array> &p_points, const TypedArray<PackedByteArray> &p_types, bool p_winding_even_odd, const Color &p_modulate = Color(1, 1, 1), const Ref<Texture2D> &p_texture = Ref<Texture2D>(), const Transform2D &p_transform_uv = Transform2D(), bool p_use_order5 = false);
+
 	static CanvasItem *get_current_item_drawn();
 
 	/* RECT / TRANSFORM */

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -240,6 +240,7 @@ public:
 	void canvas_item_add_set_transform(RID p_item, const Transform2D &p_transform);
 	void canvas_item_add_clip_ignore(RID p_item, bool p_ignore);
 	void canvas_item_add_animation_slice(RID p_item, double p_animation_length, double p_slice_begin, double p_slice_end, double p_offset);
+	void canvas_item_add_filled_curve(RID p_item, const TypedArray<PackedVector2Array> &p_points, const TypedArray<PackedByteArray> &p_types, bool p_winding_even_odd, const Color &p_modulate = Color(1, 1, 1), RID p_texture = RID(), const Transform2D &p_transform_uv = Transform2D(), bool p_use_order5 = false);
 
 	void canvas_item_set_sort_children_by_y(RID p_item, bool p_enable);
 	void canvas_item_set_z_index(RID p_item, int p_z);

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -183,6 +183,7 @@ public:
 				TYPE_TRANSFORM,
 				TYPE_CLIP_IGNORE,
 				TYPE_ANIMATION_SLICE,
+				TYPE_FILLED_CURVE,
 			};
 
 			Command *next = nullptr;
@@ -298,6 +299,27 @@ public:
 			CommandAnimationSlice() {
 				type = TYPE_ANIMATION_SLICE;
 			}
+		};
+
+		struct CommandFilledCurve : public Command {
+			Vector<Vector<Vector2>> points;
+			Vector<Vector<uint8_t>> types;
+			bool winding_even_odd;
+			bool use_order5;
+
+			RID mesh_cache;
+			Transform2D transform_cache;
+			Rect2 rect_cache;
+			Rect2 bounds;
+
+			Color modulate;
+			RID texture;
+			Transform2D transform_uv;
+
+			CommandFilledCurve() { type = TYPE_FILLED_CURVE; }
+			~CommandFilledCurve();
+
+			void generate_mesh(Transform2D transform, Rect2 rect);
 		};
 
 		struct ViewportRender {

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -743,7 +743,8 @@ void RendererCanvasRenderRD::_render_item(RD::DrawListID p_draw_list, RID p_rend
 			} break;
 			case Item::Command::TYPE_MESH:
 			case Item::Command::TYPE_MULTIMESH:
-			case Item::Command::TYPE_PARTICLES: {
+			case Item::Command::TYPE_PARTICLES:
+			case Item::Command::TYPE_FILLED_CURVE: {
 				RID mesh;
 				RID mesh_instance;
 				RID texture;
@@ -838,6 +839,11 @@ void RendererCanvasRenderRD::_render_item(RD::DrawListID p_draw_list, RID p_rend
 
 					// Signal that SDF texture needs to be updated.
 					r_sdf_used |= particles_storage->particles_has_collision(pt->particles);
+				} else if (c->type == Item::Command::TYPE_FILLED_CURVE) {
+					const Item::CommandFilledCurve *fc = static_cast<const Item::CommandFilledCurve *>(c);
+					mesh = fc->mesh_cache;
+					texture = fc->texture;
+					modulate = fc->modulate;
 				}
 
 				if (mesh.is_null()) {

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -866,6 +866,7 @@ public:
 	FUNC2(canvas_item_add_set_transform, RID, const Transform2D &)
 	FUNC2(canvas_item_add_clip_ignore, RID, bool)
 	FUNC5(canvas_item_add_animation_slice, RID, double, double, double, double)
+	FUNC8(canvas_item_add_filled_curve, RID, const TypedArray<PackedVector2Array> &, const TypedArray<PackedByteArray> &, bool, const Color &, RID, const Transform2D &, bool)
 
 	FUNC2(canvas_item_set_sort_children_by_y, RID, bool)
 	FUNC2(canvas_item_set_z_index, RID, int)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2622,6 +2622,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_item_add_set_transform", "item", "transform"), &RenderingServer::canvas_item_add_set_transform);
 	ClassDB::bind_method(D_METHOD("canvas_item_add_clip_ignore", "item", "ignore"), &RenderingServer::canvas_item_add_clip_ignore);
 	ClassDB::bind_method(D_METHOD("canvas_item_add_animation_slice", "item", "animation_length", "slice_begin", "slice_end", "offset"), &RenderingServer::canvas_item_add_animation_slice, DEFVAL(0.0));
+	ClassDB::bind_method(D_METHOD("canvas_item_add_filled_curve", "item", "points", "types", "winding_even_odd", "modulate", "texture", "transform_uv", "use_order5"), &RenderingServer::canvas_item_add_filled_curve, DEFVAL(Color(1, 1, 1)), DEFVAL(RID()), DEFVAL(Transform2D()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("canvas_item_set_sort_children_by_y", "item", "enabled"), &RenderingServer::canvas_item_set_sort_children_by_y);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_z_index", "item", "z_index"), &RenderingServer::canvas_item_set_z_index);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_z_as_relative_to_parent", "item", "enabled"), &RenderingServer::canvas_item_set_z_as_relative_to_parent);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1363,6 +1363,7 @@ public:
 	virtual void canvas_item_add_set_transform(RID p_item, const Transform2D &p_transform) = 0;
 	virtual void canvas_item_add_clip_ignore(RID p_item, bool p_ignore) = 0;
 	virtual void canvas_item_add_animation_slice(RID p_item, double p_animation_length, double p_slice_begin, double p_slice_end, double p_offset) = 0;
+	virtual void canvas_item_add_filled_curve(RID p_item, const TypedArray<PackedVector2Array> &p_points, const TypedArray<PackedByteArray> &p_types, bool p_winding_even_odd = false, const Color &p_modulate = Color(1, 1, 1), RID p_texture = RID(), const Transform2D &p_transform_uv = Transform2D(), bool p_use_order5 = false) = 0;
 
 	virtual void canvas_item_set_sort_children_by_y(RID p_item, bool p_enable) = 0;
 	virtual void canvas_item_set_z_index(RID p_item, int p_z) = 0;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/2924

Adds a `draw_filled_curve` method to `CanvasItem`, as well as a few methods used in its implementation. Supports cubic beziers, elliptical arcs, and, optionally, order-5 beziers (for easy C2 continuity).

Maintains smoothness at any level of zoom or curvature.