### PR TITLE
C#: Do not print errors about missing references to intentionally ignored members

### DIFF
--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -523,7 +523,10 @@ void BindingsGenerator::_append_xml_method(StringBuilder &p_xml_output, const Ty
 				p_xml_output.append(target_imethod->proxy_name);
 				p_xml_output.append("\"/>");
 			} else {
-				ERR_PRINT("Cannot resolve method reference in documentation: '" + p_link_target + "'.");
+				if (!p_target_itype->is_intentionally_ignored(p_link_target)) {
+					ERR_PRINT("Cannot resolve method reference in documentation: '" + p_link_target + "'.");
+				}
+
 				_append_xml_undeclared(p_xml_output, p_link_target);
 			}
 		}
@@ -563,7 +566,10 @@ void BindingsGenerator::_append_xml_member(StringBuilder &p_xml_output, const Ty
 			p_xml_output.append(target_iprop->proxy_name);
 			p_xml_output.append("\"/>");
 		} else {
-			ERR_PRINT("Cannot resolve member reference in documentation: '" + p_link_target + "'.");
+			if (!p_target_itype->is_intentionally_ignored(p_link_target)) {
+				ERR_PRINT("Cannot resolve member reference in documentation: '" + p_link_target + "'.");
+			}
+
 			_append_xml_undeclared(p_xml_output, p_link_target);
 		}
 	}
@@ -591,7 +597,10 @@ void BindingsGenerator::_append_xml_signal(StringBuilder &p_xml_output, const Ty
 			p_xml_output.append(target_isignal->proxy_name);
 			p_xml_output.append("\"/>");
 		} else {
-			ERR_PRINT("Cannot resolve signal reference in documentation: '" + p_link_target + "'.");
+			if (!p_target_itype->is_intentionally_ignored(p_link_target)) {
+				ERR_PRINT("Cannot resolve signal reference in documentation: '" + p_link_target + "'.");
+			}
+
 			_append_xml_undeclared(p_xml_output, p_link_target);
 		}
 	}
@@ -613,7 +622,10 @@ void BindingsGenerator::_append_xml_enum(StringBuilder &p_xml_output, const Type
 		p_xml_output.append(target_enum_itype.proxy_name); // Includes nesting class if any
 		p_xml_output.append("\"/>");
 	} else {
-		ERR_PRINT("Cannot resolve enum reference in documentation: '" + p_link_target + "'.");
+		if (!p_target_itype->is_intentionally_ignored(p_link_target)) {
+			ERR_PRINT("Cannot resolve enum reference in documentation: '" + p_link_target + "'.");
+		}
+
 		_append_xml_undeclared(p_xml_output, p_link_target);
 	}
 }
@@ -673,7 +685,10 @@ void BindingsGenerator::_append_xml_constant(StringBuilder &p_xml_output, const 
 				// Also search in @GlobalScope as a last resort if no class was specified
 				_append_xml_constant_in_global_scope(p_xml_output, p_target_cname, p_link_target);
 			} else {
-				ERR_PRINT("Cannot resolve constant reference in documentation: '" + p_link_target + "'.");
+				if (!p_target_itype->is_intentionally_ignored(p_link_target)) {
+					ERR_PRINT("Cannot resolve constant reference in documentation: '" + p_link_target + "'.");
+				}
+
 				_append_xml_undeclared(p_xml_output, p_link_target);
 			}
 		}
@@ -2936,6 +2951,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 
 			if (method_has_ptr_parameter(method_info)) {
 				// Pointers are not supported.
+				itype.ignored_members.insert(method_info.name);
 				continue;
 			}
 

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -408,6 +408,7 @@ class BindingsGenerator {
 		List<PropertyInterface> properties;
 		List<MethodInterface> methods;
 		List<SignalInterface> signals_;
+		HashSet<String> ignored_members;
 
 		bool has_virtual_methods = false;
 
@@ -469,6 +470,10 @@ class BindingsGenerator {
 			}
 
 			return nullptr;
+		}
+
+		bool is_intentionally_ignored(const String &p_name) const {
+			return ignored_members.has(p_name);
 		}
 
 	private:


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/74447

~Makes that error a verbose print only, like the other cases in this method where a referenced method cannot be found.~

Added a list of members that were intentionally not emitted for some reason (currently only methods with pointer parameters/return) and then when references to these members are missing, no warning is printed.