### PR TITLE
Refresh filesystem when saving remote branch

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -41,6 +41,7 @@
 #include "editor/debugger/editor_profiler.h"
 #include "editor/debugger/editor_visual_profiler.h"
 #include "editor/editor_file_dialog.h"
+#include "editor/editor_file_system.h"
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
 #include "editor/editor_property_name_processor.h"
@@ -756,6 +757,12 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 			monitors.set(i, p_data[i]);
 		}
 		performance_profiler->update_monitors(monitors);
+
+	} else if (p_msg == "filesystem:update_file") {
+		ERR_FAIL_COND(p_data.size() < 1);
+		if (EditorFileSystem::get_singleton()) {
+			EditorFileSystem::get_singleton()->update_file(p_data[0]);
+		}
 
 	} else {
 		int colon_index = p_msg.find_char(':');

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -90,6 +90,9 @@ Error SceneDebugger::parse_message(void *p_user, const String &p_msg, const Arra
 	} else if (p_msg == "save_node") { // Save node.
 		ERR_FAIL_COND_V(p_args.size() < 2, ERR_INVALID_DATA);
 		_save_node(p_args[0], p_args[1]);
+		Array arr;
+		arr.append(p_args[1]);
+		EngineDebugger::get_singleton()->send_message("filesystem:update_file", { arr });
 
 	} else if (p_msg == "inspect_object") { // Object Inspect
 		ERR_FAIL_COND_V(p_args.size() < 1, ERR_INVALID_DATA);


### PR DESCRIPTION
Fixes #23132

This could technically be done without involving debugger, but this way it makes sure the update does not happen too early.