### PR TITLE
Fix the Python type error when creating the `.sln` file

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -783,7 +783,7 @@ def generate_vs_project(env, num_jobs, project_name="godot"):
                     for plat_id in ModuleConfigs.PLATFORM_IDS
                 ]
                 self.arg_dict["cpppaths"] += ModuleConfigs.for_every_variant(env["CPPPATH"] + [includes])
-                self.arg_dict["cppdefines"] += ModuleConfigs.for_every_variant(env["CPPDEFINES"] + defines)
+                self.arg_dict["cppdefines"] += ModuleConfigs.for_every_variant(list(env["CPPDEFINES"]) + defines)
                 self.arg_dict["cmdargs"] += ModuleConfigs.for_every_variant(cli_args)
 
             def build_commandline(self, commands):


### PR DESCRIPTION
Fix: https://github.com/godotengine/godot/issues/74725

The error occurs at the statement `env["CPPDEFINES"] + defines` , where `env["CPPDEFINES"]` is of type `<class 'collections.deque'>` and `defines` is of type `<class 'list'>` . 

Since the two types cannot be added together, `list()` function is used to convert deque to list.

After the modification, it can be compiled and generate the .sln file normally.
