### PR TITLE
Enable C++ 2020 compatibility

### DIFF
--- a/core/templates/ring_buffer.h
+++ b/core/templates/ring_buffer.h
@@ -211,10 +211,9 @@ public:
 		size_mask = mask;
 	}
 
-	RingBuffer<T>(int p_power = 0) {
+	RingBuffer(int p_power = 0) {
 		resize(p_power);
 	}
-	~RingBuffer<T>() {}
 };
 
 #endif // RING_BUFFER_H

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1051,11 +1051,11 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			bool got_bracket_token = false;
 			if (builtin_types.has(token.value)) {
 				array.set_typed(builtin_types.get(token.value), StringName(), Variant());
-			} else if (token.value == "Resource" || token.value == "SubResource" || token.value == "ExtResource") {
+			} else if (token.value == Variant("Resource") || token.value == Variant("SubResource") || token.value == Variant("ExtResource")) {
 				Variant resource;
 				err = parse_value(token, resource, p_stream, line, r_err_str, p_res_parser);
 				if (err) {
-					if (token.value == "Resource" && err == ERR_PARSE_ERROR && r_err_str == "Expected '('" && token.type == TK_BRACKET_CLOSE) {
+					if (token.value == Variant("Resource") && err == ERR_PARSE_ERROR && r_err_str == "Expected '('" && token.type == TK_BRACKET_CLOSE) {
 						err = OK;
 						r_err_str = String();
 						array.set_typed(Variant::OBJECT, token.value, Variant());

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -281,12 +281,12 @@ bool ActionMapEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_d
 	}
 
 	// Don't allow moving an action in-between events.
-	if (d["input_type"] == "action" && item->has_meta("__event")) {
+	if (d["input_type"] == Variant("action") && item->has_meta("__event")) {
 		return false;
 	}
 
 	// Don't allow moving an event to a different action.
-	if (d["input_type"] == "event" && item->get_parent() != selected->get_parent()) {
+	if (d["input_type"] == Variant("event") && item->get_parent() != selected->get_parent()) {
 		return false;
 	}
 
@@ -307,13 +307,13 @@ void ActionMapEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 	}
 
 	Dictionary d = p_data;
-	if (d["input_type"] == "action") {
+	if (d["input_type"] == Variant("action")) {
 		// Change action order.
 		String relative_to = target->get_meta("__name");
 		String action_name = selected->get_meta("__name");
 		emit_signal(SNAME("action_reordered"), action_name, relative_to, drop_above);
 
-	} else if (d["input_type"] == "event") {
+	} else if (d["input_type"] == Variant("event")) {
 		// Change event order
 		int current_index = selected->get_meta("__index");
 		int target_index = target->get_meta("__index");

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2975,7 +2975,7 @@ bool AnimationTrackEdit::can_drop_data(const Point2 &p_point, const Variant &p_d
 	if (get_editor()->is_grouping_tracks()) {
 		String base_path = animation->track_get_path(track);
 		base_path = base_path.get_slice(":", 0); // Remove sub-path.
-		if (d["group"] != base_path) {
+		if (d["group"] != Variant(base_path)) {
 			return false;
 		}
 	}
@@ -3006,7 +3006,7 @@ void AnimationTrackEdit::drop_data(const Point2 &p_point, const Variant &p_data)
 	if (get_editor()->is_grouping_tracks()) {
 		String base_path = animation->track_get_path(track);
 		base_path = base_path.get_slice(":", 0); // Remove sub-path.
-		if (d["group"] != base_path) {
+		if (d["group"] != Variant(base_path)) {
 			return;
 		}
 	}
@@ -3841,13 +3841,13 @@ void AnimationTrackEditor::insert_node_value_key(Node *p_node, const String &p_p
 		} else if (animation->track_get_type(i) == Animation::TYPE_BEZIER) {
 			Variant value;
 			String track_path = animation->track_get_path(i);
-			if (track_path == np) {
+			if (track_path == String(np)) {
 				value = p_value; // All good.
 			} else {
 				int sep = track_path.rfind(":");
 				if (sep != -1) {
 					String base_path = track_path.substr(0, sep);
-					if (base_path == np) {
+					if (base_path == String(np)) {
 						String value_name = track_path.substr(sep + 1);
 						value = p_value.get(value_name);
 					} else {

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -945,7 +945,7 @@ void EditorFileDialog::update_file_list() {
 	fav_down->set_disabled(true);
 	get_ok_button()->set_disabled(_is_open_should_be_disabled());
 	for (int i = 0; i < favorites->get_item_count(); i++) {
-		if (favorites->get_item_metadata(i) == cdir || favorites->get_item_metadata(i) == cdir + "/") {
+		if (favorites->get_item_metadata(i) == Variant(cdir) || favorites->get_item_metadata(i) == Variant(cdir + "/")) {
 			favorites->select(i);
 			favorite->set_pressed(true);
 			if (i > 0) {

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2175,7 +2175,7 @@ bool EditorInspectorArray::can_drop_data_fw(const Point2 &p_point, const Variant
 	}
 	Dictionary dict = p_data;
 	int drop_position = _drop_position();
-	if (!dict.has("type") || dict["type"] != "property_array_element" || String(dict["property_array_prefix"]) != array_element_prefix || drop_position < 0) {
+	if (!dict.has("type") || dict["type"] != Variant("property_array_element") || String(dict["property_array_prefix"]) != String(array_element_prefix) || drop_position < 0) {
 		return false;
 	}
 
@@ -2216,7 +2216,7 @@ void EditorInspectorArray::_notification(int p_what) {
 
 		case NOTIFICATION_DRAG_BEGIN: {
 			Dictionary dict = get_viewport()->gui_get_drag_data();
-			if (dict.has("type") && dict["type"] == "property_array_element" && String(dict["property_array_prefix"]) == array_element_prefix) {
+			if (dict.has("type") && dict["type"] == Variant("property_array_element") && String(dict["property_array_prefix"]) == String(array_element_prefix)) {
 				dropping = true;
 				control_dropping->queue_redraw();
 			}

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3426,7 +3426,7 @@ void EditorPropertyColor::_set_read_only(bool p_read_only) {
 
 void EditorPropertyColor::_color_changed(const Color &p_color) {
 	// Cancel the color change if the current color is identical to the new one.
-	if (get_edited_object()->get(get_edited_property()) == p_color) {
+	if (get_edited_object()->get(get_edited_property()) == Variant(p_color)) {
 		return;
 	}
 
@@ -3590,7 +3590,7 @@ void EditorPropertyNodePath::drop_data_fw(const Point2 &p_point, const Variant &
 }
 
 bool EditorPropertyNodePath::is_drop_valid(const Dictionary &p_drag_data) const {
-	if (p_drag_data["type"] != "nodes") {
+	if (p_drag_data["type"] != Variant("nodes")) {
 		return false;
 	}
 	Array nodes = p_drag_data["nodes"];

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -945,7 +945,7 @@ void EditorSettings::setup_network() {
 	List<IPAddress> local_ip;
 	IP::get_singleton()->get_local_addresses(&local_ip);
 	String hint;
-	String current = has_setting("network/debug/remote_host") ? get("network/debug/remote_host") : "";
+	IPAddress current = has_setting("network/debug/remote_host") ? get("network/debug/remote_host") : "";
 	String selected = "127.0.0.1";
 
 	// Check that current remote_host is a valid interface address and populate hints.

--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -86,13 +86,13 @@ bool EditorExportPlatformPC::has_valid_export_configuration(const Ref<EditorExpo
 	bool dvalid = exists_export_template(get_template_file_name("debug", arch), &err);
 	bool rvalid = exists_export_template(get_template_file_name("release", arch), &err);
 
-	if (p_preset->get("custom_template/debug") != "") {
+	if (p_preset->get("custom_template/debug") != Variant("")) {
 		dvalid = FileAccess::exists(p_preset->get("custom_template/debug"));
 		if (!dvalid) {
 			err += TTR("Custom debug template not found.") + "\n";
 		}
 	}
-	if (p_preset->get("custom_template/release") != "") {
+	if (p_preset->get("custom_template/release") != Variant("")) {
 		rvalid = FileAccess::exists(p_preset->get("custom_template/release"));
 		if (!rvalid) {
 			err += TTR("Custom release template not found.") + "\n";

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -586,7 +586,7 @@ void FileSystemDock::_file_list_thumbnail_done(const String &p_path, const Ref<T
 		Array uarr = p_udata;
 		int idx = uarr[0];
 		String file = uarr[1];
-		if (idx < files->get_item_count() && files->get_item_text(idx) == file && files->get_item_metadata(idx) == p_path) {
+		if (idx < files->get_item_count() && files->get_item_text(idx) == file && files->get_item_metadata(idx) == Variant(p_path)) {
 			if (file_list_display_mode == FILE_LIST_DISPLAY_LIST) {
 				if (p_small_preview.is_valid()) {
 					files->set_item_icon(idx, p_small_preview);
@@ -1062,7 +1062,7 @@ void FileSystemDock::_tree_activate_file() {
 	if (selected) {
 		String file_path = selected->get_metadata(0);
 		TreeItem *parent = selected->get_parent();
-		bool is_favorite = parent != nullptr && parent->get_metadata(0) == "Favorites";
+		bool is_favorite = parent != nullptr && parent->get_metadata(0) == Variant("Favorites");
 
 		if ((!is_favorite && file_path.ends_with("/")) || file_path == "Favorites") {
 			bool collapsed = selected->is_collapsed();
@@ -1080,7 +1080,7 @@ void FileSystemDock::_file_list_activate_file(int p_idx) {
 void FileSystemDock::_preview_invalidated(const String &p_path) {
 	if (file_list_display_mode == FILE_LIST_DISPLAY_THUMBNAILS && p_path.get_base_dir() == path && searched_string.length() == 0 && file_list_vb->is_visible_in_tree()) {
 		for (int i = 0; i < files->get_item_count(); i++) {
-			if (files->get_item_metadata(i) == p_path) {
+			if (files->get_item_metadata(i) == Variant(p_path)) {
 				// Re-request preview.
 				Array udata;
 				udata.resize(2);
@@ -2577,7 +2577,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 			if (filenames.size() == 1) {
 				p_popup->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Open Scene"), FILE_OPEN);
 				p_popup->add_icon_item(get_theme_icon(SNAME("CreateNewSceneFrom"), SNAME("EditorIcons")), TTR("New Inherited Scene"), FILE_INHERIT);
-				if (GLOBAL_GET("application/run/main_scene") != filenames[0]) {
+				if (GLOBAL_GET("application/run/main_scene") != Variant(filenames[0])) {
 					p_popup->add_icon_item(get_theme_icon(SNAME("PlayScene"), SNAME("EditorIcons")), TTR("Set As Main Scene"), FILE_MAIN_SCENE);
 				}
 			} else {

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -2448,7 +2448,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 		scene->set_script(Variant(root_script));
 	}
 
-	if (p_options["nodes/root_name"] != "Scene Root") {
+	if (p_options["nodes/root_name"] != Variant("Scene Root")) {
 		scene->set_name(p_options["nodes/root_name"]);
 	} else {
 		scene->set_name(p_save_path.get_file().get_basename());

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -514,7 +514,7 @@ void ImportDock::_reimport() {
 		if (params->importer.is_valid()) {
 			String importer_name = params->importer->get_importer_name();
 
-			if (params->checking && config->get_value("remap", "importer") == params->importer->get_importer_name()) {
+			if (params->checking && config->get_value("remap", "importer") == Variant(params->importer->get_importer_name())) {
 				//update only what is edited (checkboxes) if the importer is the same
 				for (const PropertyInfo &E : params->properties) {
 					if (params->checked.has(E.name)) {

--- a/editor/multi_node_edit.cpp
+++ b/editor/multi_node_edit.cpp
@@ -53,7 +53,7 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 	}
 
 	Node *node_path_target = nullptr;
-	if (p_value.get_type() == Variant::NODE_PATH && p_value != NodePath()) {
+	if (p_value.get_type() == Variant::NODE_PATH && p_value != Variant(NodePath())) {
 		node_path_target = es->get_node(p_value);
 	}
 

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -188,7 +188,7 @@ bool EditorBitmapPreviewPlugin::handles(const String &p_type) const {
 Ref<Texture2D> EditorBitmapPreviewPlugin::generate(const Ref<Resource> &p_from, const Size2 &p_size) const {
 	Ref<BitMap> bm = p_from;
 
-	if (bm->get_size() == Size2()) {
+	if (bm->get_size() == Size2i()) {
 		return Ref<Texture2D>();
 	}
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2766,7 +2766,7 @@ void ScriptEditor::_file_removed(const String &p_removed_file) {
 		if (!se) {
 			continue;
 		}
-		if (se->get_meta("_edit_res_path") == p_removed_file) {
+		if (se->get_meta("_edit_res_path") == Variant(p_removed_file)) {
 			// The script is deleted with no undo, so just close the tab.
 			_close_tab(i, false, false);
 		}

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1390,7 +1390,7 @@ void SpriteFramesEditor::_fetch_sprite_node() {
 	AnimatedSprite2D *as2d = Object::cast_to<AnimatedSprite2D>(selected);
 	AnimatedSprite3D *as3d = Object::cast_to<AnimatedSprite3D>(selected);
 	if (as2d || as3d) {
-		if (frames != selected->call("get_sprite_frames")) {
+		if (frames != Ref<SpriteFrames>(selected->call("get_sprite_frames"))) {
 			_remove_sprite_node();
 		} else {
 			animated_sprite = selected;

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -298,7 +298,7 @@ void TileMapEditorTilesPlugin::_patterns_item_list_gui_input(const Ref<InputEven
 void TileMapEditorTilesPlugin::_pattern_preview_done(Ref<TileMapPattern> p_pattern, Ref<Texture2D> p_texture) {
 	// TODO optimize ?
 	for (int i = 0; i < patterns_item_list->get_item_count(); i++) {
-		if (patterns_item_list->get_item_metadata(i) == p_pattern) {
+		if (patterns_item_list->get_item_metadata(i) == Variant(p_pattern)) {
 			patterns_item_list->set_item_icon(i, p_texture);
 			break;
 		}

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -403,7 +403,7 @@ void TileSetEditor::_patterns_item_list_gui_input(const Ref<InputEvent> &p_event
 void TileSetEditor::_pattern_preview_done(Ref<TileMapPattern> p_pattern, Ref<Texture2D> p_texture) {
 	// TODO optimize ?
 	for (int i = 0; i < patterns_item_list->get_item_count(); i++) {
-		if (patterns_item_list->get_item_metadata(i) == p_pattern) {
+		if (patterns_item_list->get_item_metadata(i) == Variant(p_pattern)) {
 			patterns_item_list->set_item_icon(i, p_texture);
 			break;
 		}

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -1405,7 +1405,7 @@ void VisualShaderEditor::_update_custom_script(const Ref<Script> &p_script) {
 						continue;
 					}
 					Ref<VisualShaderNodeCustom> custom_node = Ref<VisualShaderNodeCustom>(vsnode.ptr());
-					if (custom_node.is_null() || custom_node->get_script() != p_script) {
+					if (custom_node.is_null() || custom_node->get_script() != Variant(p_script)) {
 						continue;
 					}
 					need_rebuild = true;
@@ -1517,7 +1517,7 @@ void VisualShaderEditor::_resources_removed() {
 								continue;
 							}
 							Ref<VisualShaderNodeCustom> custom_node = Ref<VisualShaderNodeCustom>(vsnode.ptr());
-							if (custom_node.is_null() || custom_node->get_script() != scr) {
+							if (custom_node.is_null() || custom_node->get_script() != Variant(scr)) {
 								continue;
 							}
 							visual_shader->remove_node(type, node_id);
@@ -1680,7 +1680,7 @@ void VisualShaderEditor::_update_options_menu() {
 	Color unsupported_color = get_theme_color(SNAME("error_color"), SNAME("Editor"));
 	Color supported_color = get_theme_color(SNAME("warning_color"), SNAME("Editor"));
 
-	static bool low_driver = GLOBAL_GET("rendering/renderer/rendering_method") == "gl_compatibility";
+	static bool low_driver = GLOBAL_GET("rendering/renderer/rendering_method") == Variant("gl_compatibility");
 
 	HashMap<String, TreeItem *> folders;
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1697,7 +1697,7 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 							if (!_guess_expression_type(c, dn->elements[i].key, key)) {
 								continue;
 							}
-							if (key.value == String(subscript->attribute->name)) {
+							if (key.value == Variant(String(subscript->attribute->name))) {
 								r_type.assigned_expression = dn->elements[i].value;
 								found = _guess_expression_type(c, dn->elements[i].value, r_type);
 								break;

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3596,13 +3596,13 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> p_state) {
 				width = albedo_texture->get_width();
 			}
 			orm_image->initialize_data(width, height, false, Image::FORMAT_RGBA8);
-			if (ao_image.is_valid() && ao_image->get_size() != Vector2(width, height)) {
+			if (ao_image.is_valid() && ao_image->get_size() != Vector2i(width, height)) {
 				ao_image->resize(width, height, Image::INTERPOLATE_LANCZOS);
 			}
-			if (roughness_image.is_valid() && roughness_image->get_size() != Vector2(width, height)) {
+			if (roughness_image.is_valid() && roughness_image->get_size() != Vector2i(width, height)) {
 				roughness_image->resize(width, height, Image::INTERPOLATE_LANCZOS);
 			}
-			if (metallness_image.is_valid() && metallness_image->get_size() != Vector2(width, height)) {
+			if (metallness_image.is_valid() && metallness_image->get_size() != Vector2i(width, height)) {
 				metallness_image->resize(width, height, Image::INTERPOLATE_LANCZOS);
 			}
 			for (int32_t h = 0; h < height; h++) {

--- a/modules/mono/mono_gc_handle.h
+++ b/modules/mono/mono_gc_handle.h
@@ -49,7 +49,9 @@ struct GCHandleIntPtr {
 	_FORCE_INLINE_ bool operator==(const GCHandleIntPtr &p_other) { return value == p_other.value; }
 	_FORCE_INLINE_ bool operator!=(const GCHandleIntPtr &p_other) { return value != p_other.value; }
 
+#if not defined(__cplusplus) or (__cplusplus < 202002L)
 	GCHandleIntPtr() = delete;
+#endif
 };
 }
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2645,7 +2645,7 @@ void DisplayServerX11::cursor_set_custom_image(const Ref<Resource> &p_cursor, Cu
 		HashMap<CursorShape, Vector<Variant>>::Iterator cursor_c = cursors_cache.find(p_shape);
 
 		if (cursor_c) {
-			if (cursor_c->value[0] == p_cursor && cursor_c->value[1] == p_hotspot) {
+			if (cursor_c->value[0] == Variant(p_cursor) && cursor_c->value[1] == Variant(p_hotspot)) {
 				cursor_set_shape(p_shape);
 				return;
 			}

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -359,7 +359,7 @@ Rect2 Sprite2D::get_rect() const {
 		ofs = ofs.floor();
 	}
 
-	if (s == Size2(0, 0)) {
+	if (s == Size2i(0, 0)) {
 		s = Size2(1, 1);
 	}
 

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -887,7 +887,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double
 						start_ofs += p_time - a->track_get_key_time(i, idx);
 					}
 
-					if (aa->object->call(SNAME("get_stream")) != aa->audio_stream) {
+					if (aa->object->call(SNAME("get_stream")) != Variant(aa->audio_stream)) {
 						aa->object->call(SNAME("set_stream"), aa->audio_stream);
 						aa->audio_stream_playback.unref();
 						if (!playing_audio_stream_players.has(asp)) {

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1578,7 +1578,7 @@ void AnimationTree::_process_graph(double p_delta) {
 								start_ofs += time - a->track_get_key_time(i, idx);
 							}
 
-							if (t->object->call(SNAME("get_stream")) != t->audio_stream) {
+							if (t->object->call(SNAME("get_stream")) != Variant(t->audio_stream)) {
 								t->object->call(SNAME("set_stream"), t->audio_stream);
 								t->audio_stream_playback.unref();
 								if (!playing_audio_stream_players.has(asp)) {

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -290,7 +290,7 @@ void FileDialog::_action_pressed() {
 		TreeItem *item = tree->get_selected();
 		if (item) {
 			Dictionary d = item->get_metadata(0);
-			if (d["dir"] && d["name"] != "..") {
+			if (d["dir"] && d["name"] != Variant("..")) {
 				path = path.path_join(d["name"]);
 			}
 		}

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -219,7 +219,7 @@ void ItemList::set_item_icon_region(int p_idx, const Rect2 &p_region) {
 	}
 	ERR_FAIL_INDEX(p_idx, items.size());
 
-	if (items[p_idx].icon_region == p_region) {
+	if (items[p_idx].icon_region == Rect2i(p_region)) {
 		return;
 	}
 
@@ -591,7 +591,7 @@ ItemList::IconMode ItemList::get_icon_mode() const {
 }
 
 void ItemList::set_fixed_icon_size(const Size2i &p_size) {
-	if (fixed_icon_size == p_size) {
+	if (fixed_icon_size == Size2(p_size)) {
 		return;
 	}
 

--- a/scene/gui/menu_bar.h
+++ b/scene/gui/menu_bar.h
@@ -73,7 +73,7 @@ class MenuBar : public Control {
 	int active_menu = -1;
 
 	Vector2i mouse_pos_adjusted;
-	Vector2i old_mouse_pos;
+	Vector2 old_mouse_pos;
 	ObjectID shortcut_context;
 
 	struct ThemeCache {

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -254,7 +254,7 @@ void PopupMenu::_parent_focused() {
 
 		Rect2 safe_area = DisplayServer::get_singleton()->window_get_popup_safe_rect(get_window_id());
 		Point2 pos = DisplayServer::get_singleton()->mouse_get_position() - mouse_pos_adjusted;
-		if (safe_area == Rect2i() || !safe_area.has_point(pos)) {
+		if (safe_area == Rect2() || !safe_area.has_point(pos)) {
 			Popup::_parent_focused();
 		} else {
 			grab_focus();

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -5797,7 +5797,7 @@ Ref<RichTextEffect> RichTextLabel::_get_custom_effect_by_code(String p_bbcode_id
 			continue;
 		}
 
-		if (effect->get_bbcode() == p_bbcode_identifier) {
+		if (effect->get_bbcode() == Variant(p_bbcode_identifier)) {
 			return effect;
 		}
 	}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5792,7 +5792,7 @@ void TextEdit::merge_gutters(int p_from_line, int p_to_line) {
 			text.set_line_gutter_item_color(p_to_line, i, text.get_line_gutter_item_color(p_from_line, i));
 		}
 
-		if (text.get_line_gutter_metadata(p_from_line, i) != "") {
+		if (text.get_line_gutter_metadata(p_from_line, i) != Variant("")) {
 			text.set_line_gutter_metadata(p_to_line, i, text.get_line_gutter_metadata(p_from_line, i));
 		}
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -411,7 +411,7 @@ Ref<Texture2D> TreeItem::get_icon(int p_column) const {
 void TreeItem::set_icon_region(int p_column, const Rect2 &p_icon_region) {
 	ERR_FAIL_INDEX(p_column, cells.size());
 
-	if (cells[p_column].icon_region == p_icon_region) {
+	if (cells[p_column].icon_region == Rect2i(p_icon_region)) {
 		return;
 	}
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -905,7 +905,7 @@ bool Viewport::_is_size_allocated() const {
 Rect2 Viewport::get_visible_rect() const {
 	Rect2 r;
 
-	if (size == Size2()) {
+	if (size == Size2i()) {
 		r = Rect2(Point2(), DisplayServer::get_singleton()->window_get_size());
 	} else {
 		r = Rect2(Point2(), size);

--- a/servers/xr/xr_interface.cpp
+++ b/servers/xr/xr_interface.cpp
@@ -185,7 +185,7 @@ RID XRInterface::get_vrs_texture() {
 	real_t radius = vrs_size.length() * 0.5;
 	Size2 vrs_sizei = vrs_size;
 
-	if (vrs.size != vrs_sizei) {
+	if (vrs.size != Size2i(vrs_sizei)) {
 		const uint8_t densities[] = {
 			0, // 1x1
 			1, // 1x2

--- a/servers/xr_server.cpp
+++ b/servers/xr_server.cpp
@@ -264,7 +264,7 @@ void XRServer::add_tracker(Ref<XRPositionalTracker> p_tracker) {
 
 	StringName tracker_name = p_tracker->get_tracker_name();
 	if (trackers.has(tracker_name)) {
-		if (trackers[tracker_name] != p_tracker) {
+		if (trackers[tracker_name] != Variant(p_tracker)) {
 			// We already have a tracker with this name, we're going to replace it
 			trackers[tracker_name] = p_tracker;
 			emit_signal(SNAME("tracker_updated"), tracker_name, p_tracker->get_tracker_type());


### PR DESCRIPTION
This change enables building with C++ 2020 without using any c++20 concepts and remaining compatible with C++2017. It also attempts to make the least number of changes.

_Production edit: Closes https://github.com/godotengine/godot/issues/54058_