### PR TITLE
Fix gles texture uniform array binding

### DIFF
--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -268,10 +268,17 @@ void ShaderGLES3::_get_uniform_locations(Version::Specialization &spec, Version 
 		}
 	}
 	// textures
-	for (int i = 0; i < p_version->texture_uniforms.size(); i++) {
-		String native_uniform_name = _mkid(p_version->texture_uniforms[i]);
+	int texture_index = 0;
+	for (uint32_t i = 0; i < p_version->texture_uniforms.size(); i++) {
+		String native_uniform_name = _mkid(p_version->texture_uniforms[i].name);
 		GLint location = glGetUniformLocation(spec.id, (native_uniform_name).ascii().get_data());
-		glUniform1i(location, i + base_texture_index);
+		Vector<int32_t> texture_uniform_bindings;
+		int texture_count = p_version->texture_uniforms[i].array_size;
+		for (int j = 0; j < texture_count; j++) {
+			texture_uniform_bindings.append(texture_index + base_texture_index);
+			texture_index++;
+		}
+		glUniform1iv(location, texture_uniform_bindings.size(), texture_uniform_bindings.ptr());
 	}
 
 	glUseProgram(0);
@@ -674,7 +681,7 @@ void ShaderGLES3::_initialize_version(Version *p_version) {
 	_save_to_cache(p_version);
 }
 
-void ShaderGLES3::version_set_code(RID p_version, const HashMap<String, String> &p_code, const String &p_uniforms, const String &p_vertex_globals, const String &p_fragment_globals, const Vector<String> &p_custom_defines, const Vector<StringName> &p_texture_uniforms, bool p_initialize) {
+void ShaderGLES3::version_set_code(RID p_version, const HashMap<String, String> &p_code, const String &p_uniforms, const String &p_vertex_globals, const String &p_fragment_globals, const Vector<String> &p_custom_defines, const LocalVector<ShaderGLES3::TextureUniformData> &p_texture_uniforms, bool p_initialize) {
 	Version *version = version_owner.get_or_null(p_version);
 	ERR_FAIL_COND(!version);
 

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -54,6 +54,12 @@
 #include <stdio.h>
 
 class ShaderGLES3 {
+public:
+	struct TextureUniformData {
+		StringName name;
+		int array_size;
+	};
+
 protected:
 	struct TexUnitPair {
 		const char *name;
@@ -85,7 +91,7 @@ private:
 	// Specializations use #ifdefs to toggle behavior on and off for performance, on supporting hardware, they will compile a version with everything enabled, and then compile more copies to improve performance
 	// Use specializations to enable and disabled advanced features, use variants to toggle behavior when different data may be used (e.g. using a samplerArray vs a sampler, or doing a depth prepass vs a color pass)
 	struct Version {
-		Vector<StringName> texture_uniforms;
+		LocalVector<TextureUniformData> texture_uniforms;
 		CharString uniforms;
 		CharString vertex_globals;
 		CharString fragment_globals;
@@ -242,7 +248,7 @@ protected:
 public:
 	RID version_create();
 
-	void version_set_code(RID p_version, const HashMap<String, String> &p_code, const String &p_uniforms, const String &p_vertex_globals, const String &p_fragment_globals, const Vector<String> &p_custom_defines, const Vector<StringName> &p_texture_uniforms, bool p_initialize = false);
+	void version_set_code(RID p_version, const HashMap<String, String> &p_code, const String &p_uniforms, const String &p_vertex_globals, const String &p_fragment_globals, const Vector<String> &p_custom_defines, const LocalVector<ShaderGLES3::TextureUniformData> &p_texture_uniforms, bool p_initialize = false);
 
 	bool version_is_valid(RID p_version);
 


### PR DESCRIPTION
Fix both texture uniform binding and texture object binding in gles (compatibility ) mode for godot 4

Before this change, the engine (editor / game) crashes whenever there is an array of sampler2D in compatibility mode

The following line in any shader crashes:
`uniform sampler2D[10] textures;`

_Production edit: Fixes https://github.com/godotengine/godot/issues/76463_