### PR TITLE
Fix OBJ mesh importer smoothing handling

### DIFF
--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -245,6 +245,7 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 	String current_group;
 	uint32_t smooth_group = 0;
 	bool smoothing = true;
+	const uint32_t no_smoothing_smooth_group = (uint32_t)-1;
 
 	while (true) {
 		String l = f->get_line().strip_edges();
@@ -349,10 +350,7 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 					if (!colors.is_empty()) {
 						surf_tool->set_color(colors[vtx]);
 					}
-					if (!smoothing) {
-						smooth_group++;
-					}
-					surf_tool->set_smooth_group(smooth_group);
+					surf_tool->set_smooth_group(smoothing ? smooth_group : no_smoothing_smooth_group);
 					surf_tool->add_vertex(vertex);
 				}
 
@@ -367,8 +365,10 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 				do_smooth = true;
 			}
 			if (do_smooth != smoothing) {
-				smooth_group++;
 				smoothing = do_smooth;
+				if (smoothing) {
+					smooth_group++;
+				}
 			}
 		} else if (/*l.begins_with("g ") ||*/ l.begins_with("usemtl ") || (l.begins_with("o ") || f->eof_reached())) { //commit group to mesh
 			//groups are too annoying


### PR DESCRIPTION
Fixes #71085.

I thought it was a regression from #68034 so fixed the smoothing logic accordingly. Seems like it does fix #71085, with this PR the MRP outputs (after forcing reimport):
```
4 vertices, 6 indices
Vertices: 
(1, 0, 1)
(-1, 0, 1)
(1, 0, -1)
(-1, 0, -1)
Indices: 
0
1
2
2
1
3
```
 However, #71085 was reported before #68034 was even merged so that was not really the cause... :thinking: Not sure what was the exact cause back then but seems to work now. :upside_down_face: