### PR TITLE
[Tilemap] Fix self_modulate

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -225,6 +225,13 @@
 				Returns a rectangle enclosing the used (non-empty) tiles of the map, including all layers.
 			</description>
 		</method>
+		<method name="is_layer_collision_enabled" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="layer" type="int" />
+			<description>
+				Returns if a layer has collision enabled.
+			</description>
+		</method>
 		<method name="is_layer_enabled" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="layer" type="int" />
@@ -317,6 +324,15 @@
 				Update all the cells in the [param path] coordinates array so that they use the given [param terrain] for the given [param terrain_set]. The function will also connect two successive cell in the path with the same terrain. This function might update neighboring tiles if needed to create correct terrain transitions.
 				If [param ignore_empty_terrains] is true, empty terrains will be ignored when trying to find the best fitting tile for the given terrain constraints.
 				[b]Note:[/b] To work correctly, [code]set_cells_terrain_path[/code] requires the TileMap's TileSet to have terrains set up with all required terrain combinations. Otherwise, it may produce unexpected results.
+			</description>
+		</method>
+		<method name="set_layer_collision_enabled">
+			<return type="void" />
+			<param index="0" name="layer" type="int" />
+			<param index="1" name="collision_enabled" type="bool" />
+			<description>
+				Enables or disables collision for the layer [param layer]. A layer with disabled collision will not instanciate physic bodies.
+				If [param layer] is negative, the layers are accessed from the last one.
 			</description>
 		</method>
 		<method name="set_layer_enabled">

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -4005,6 +4005,19 @@ void TileMap::set_texture_repeat(CanvasItem::TextureRepeat p_texture_repeat) {
 	}
 }
 
+void TileMap::set_self_modulate(const Color &p_self_modulate) {
+	CanvasItem::set_self_modulate(p_self_modulate);
+
+	// Update self_modulate for the whole tilemap.
+	for (unsigned int layer = 0; layer < layers.size(); layer++) {
+		for (const KeyValue<Vector2i, TileMapQuadrant> &E : layers[layer].quadrant_map) {
+			for (const RID &ci : E.value.canvas_items) {
+				RenderingServer::get_singleton()->canvas_item_set_self_modulate(ci, get_self_modulate());
+			}
+		}
+		_rendering_update_layer(layer);
+	}
+}
 TypedArray<Vector2i> TileMap::get_surrounding_cells(const Vector2i &coords) {
 	if (!tile_set.is_valid()) {
 		return TypedArray<Vector2i>();

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -396,6 +396,7 @@ public:
 	virtual void set_use_parent_material(bool p_use_parent_material) override;
 	virtual void set_texture_filter(CanvasItem::TextureFilter p_texture_filter) override;
 	virtual void set_texture_repeat(CanvasItem::TextureRepeat p_texture_repeat) override;
+	virtual void set_self_modulate(const Color &p_self_modulate) override;
 
 	// For finding tiles from collision.
 	Vector2i get_coords_for_body_rid(RID p_physics_body);

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -203,6 +203,7 @@ private:
 	struct TileMapLayer {
 		String name;
 		bool enabled = true;
+		bool collision_enabled = true;
 		Color modulate = Color(1, 1, 1, 1);
 		bool y_sort_enabled = false;
 		int y_sort_origin = 0;
@@ -324,6 +325,8 @@ public:
 	bool is_layer_enabled(int p_layer) const;
 	void set_layer_modulate(int p_layer, Color p_modulate);
 	Color get_layer_modulate(int p_layer) const;
+	void set_layer_collision_enabled(int p_layer, bool p_collision_enabled);
+	bool is_layer_collision_enabled(int p_layer) const;
 	void set_layer_y_sort_enabled(int p_layer, bool p_enabled);
 	bool is_layer_y_sort_enabled(int p_layer) const;
 	void set_layer_y_sort_origin(int p_layer, int p_y_sort_origin);

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -233,7 +233,7 @@ public:
 	Color get_modulate() const;
 	Color get_modulate_in_tree() const;
 
-	void set_self_modulate(const Color &p_self_modulate);
+	virtual void set_self_modulate(const Color &p_self_modulate);
 	Color get_self_modulate() const;
 
 	void set_visibility_layer(uint32_t p_visibility_layer);


### PR DESCRIPTION
Fixes #31413

`set_self_modulate` is now virtual in `CanvasItem` and `Tilemap` inherits it to pass the changes to quadrants.