### PR TITLE
[Tilemap] Fix self_modulate 

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -3973,6 +3973,19 @@ void TileMap::set_texture_repeat(CanvasItem::TextureRepeat p_texture_repeat) {
 	}
 }
 
+void TileMap::set_self_modulate(const Color &p_self_modulate) {
+	CanvasItem::set_self_modulate(p_self_modulate);
+
+	// Update self_modulate for the whole tilemap.
+	for (unsigned int layer = 0; layer < layers.size(); layer++) {
+		for (const KeyValue<Vector2i, TileMapQuadrant> &E : layers[layer].quadrant_map) {
+			for (const RID &ci : E.value.canvas_items) {
+				RenderingServer::get_singleton()->canvas_item_set_self_modulate(ci, get_self_modulate());
+			}
+		}
+		_rendering_update_layer(layer);
+	}
+}
 TypedArray<Vector2i> TileMap::get_surrounding_cells(const Vector2i &coords) {
 	if (!tile_set.is_valid()) {
 		return TypedArray<Vector2i>();

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -393,6 +393,7 @@ public:
 	virtual void set_use_parent_material(bool p_use_parent_material) override;
 	virtual void set_texture_filter(CanvasItem::TextureFilter p_texture_filter) override;
 	virtual void set_texture_repeat(CanvasItem::TextureRepeat p_texture_repeat) override;
+	virtual void set_self_modulate(const Color &p_self_modulate) override;
 
 	// For finding tiles from collision.
 	Vector2i get_coords_for_body_rid(RID p_physics_body);

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -233,7 +233,7 @@ public:
 	Color get_modulate() const;
 	Color get_modulate_in_tree() const;
 
-	void set_self_modulate(const Color &p_self_modulate);
+	virtual void set_self_modulate(const Color &p_self_modulate);
 	Color get_self_modulate() const;
 
 	void set_visibility_layer(uint32_t p_visibility_layer);


### PR DESCRIPTION
Fixes #31413

`set_self_modulate` is now virtual in `CanvasItem` and `Tilemap` inherits it to pass the changes to quadrants.

*Note: Made an error on first PR with unwanted commit*