### PR TITLE
Fixed auto-scroll in Animation window on adding new animation

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -747,6 +747,7 @@ void SpriteFramesEditor::_select_animation(const String &p_name, bool p_update_n
 	if (!selected) {
 		return;
 	};
+	animations->scroll_to_item(selected);
 
 	edited_anim = selected->get_text(0);
 


### PR DESCRIPTION
Fixed auto-scroll in Animation window
Linked issue: https://github.com/godotengine/godot/issues/74185

Just added one line in _select_animation, it's possibly the best place to add scroll to selected item
