### PR TITLE
Add render layers to mesh library items

### DIFF
--- a/doc/classes/MeshLibrary.xml
+++ b/doc/classes/MeshLibrary.xml
@@ -87,6 +87,13 @@
 				When running in the editor, returns a generated item preview (a 3D rendering in isometric perspective). When used in a running project, returns the manually-defined item preview which can be set using [method set_item_preview]. Returns an empty [Texture2D] if no preview was manually set in a running project.
 			</description>
 		</method>
+		<method name="get_item_render_layers" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="id" type="int" />
+			<description>
+				Returns the item's render layers bitmask.
+			</description>
+		</method>
 		<method name="get_item_shapes" qualifiers="const">
 			<return type="Array" />
 			<param index="0" name="id" type="int" />
@@ -163,6 +170,14 @@
 			<param index="1" name="texture" type="Texture2D" />
 			<description>
 				Sets a texture to use as the item's preview icon in the editor.
+			</description>
+		</method>
+		<method name="set_item_render_layers">
+			<return type="void" />
+			<param index="0" name="id" type="int" />
+			<param index="1" name="render_layers" type="int" />
+			<description>
+				Sets the item's render layers bitmask.
 			</description>
 		</method>
 		<method name="set_item_shapes">

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -113,6 +113,7 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 		}
 
 		p_library->set_item_mesh(id, mesh);
+		p_library->set_item_render_layers(id, mi->get_layer_mask());
 
 		if (p_apply_xforms) {
 			p_library->set_item_mesh_transform(id, mi->get_transform());

--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -8,7 +8,7 @@
 		GridMaps use a [MeshLibrary] which contains a list of tiles. Each tile is a mesh with materials plus optional collision and navigation shapes.
 		A GridMap contains a collection of cells. Each grid cell refers to a tile in the [MeshLibrary]. All cells in the map have the same dimensions.
 		Internally, a GridMap is split into a sparse collection of octants for efficient rendering and physics processing. Every octant has the same dimensions and can contain several cells.
-		[b]Note:[/b] GridMap doesn't extend [VisualInstance3D] and therefore can't be hidden or cull masked based on [member VisualInstance3D.layers]. If you make a light not affect the first layer, the whole GridMap won't be lit by the light in question.
+		[b]Note:[/b] GridMap doesn't extend [VisualInstance3D] and therefore can't be hidden or cull masked based on [member VisualInstance3D.layers]. Each tile will be rendered using the layers specified in the [MeshLibrary]. Baked meshes don't support render layers and will be rendered in the first layer.
 	</description>
 	<tutorials>
 		<link title="Using gridmaps">$DOCS_URL/tutorials/3d/using_gridmaps.html</link>

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -709,6 +709,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 
 			RID instance = RS::get_singleton()->instance_create();
 			RS::get_singleton()->instance_set_base(instance, mm);
+			RS::get_singleton()->instance_set_layer_mask(instance, mesh_library->get_item_render_layers(E.key));
 
 			if (is_inside_tree()) {
 				RS::get_singleton()->instance_set_scenario(instance, get_world_3d()->get_scenario());

--- a/scene/resources/mesh_library.cpp
+++ b/scene/resources/mesh_library.cpp
@@ -69,6 +69,8 @@ bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
 #endif // DISABLE_DEPRECATED
 		} else if (what == "navigation_layers") {
 			set_item_navigation_layers(idx, p_value);
+		} else if (what == "render_layers") {
+			set_item_render_layers(idx, p_value);
 		} else {
 			return false;
 		}
@@ -105,6 +107,8 @@ bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
 #endif // DISABLE_DEPRECATED
 	} else if (what == "navigation_layers") {
 		r_ret = get_item_navigation_layers(idx);
+	} else if (what == "render_layers") {
+		r_ret = get_item_render_layers(idx);
 	} else if (what == "preview") {
 		r_ret = get_item_preview(idx);
 	} else {
@@ -120,6 +124,7 @@ void MeshLibrary::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::STRING, prop_name + PNAME("name")));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("mesh"), PROPERTY_HINT_RESOURCE_TYPE, "Mesh"));
 		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, prop_name + PNAME("mesh_transform"), PROPERTY_HINT_NONE, "suffix:m"));
+		p_list->push_back(PropertyInfo(Variant::INT, prop_name + PNAME("render_layers"), PROPERTY_HINT_LAYERS_3D_RENDER));
 		p_list->push_back(PropertyInfo(Variant::ARRAY, prop_name + PNAME("shapes")));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("navigation_mesh"), PROPERTY_HINT_RESOURCE_TYPE, "NavigationMesh"));
 		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, prop_name + PNAME("navigation_mesh_transform"), PROPERTY_HINT_NONE, "suffix:m"));
@@ -190,6 +195,14 @@ void MeshLibrary::set_item_navigation_layers(int p_item, uint32_t p_navigation_l
 	emit_changed();
 }
 
+void MeshLibrary::set_item_render_layers(int p_item, uint32_t p_render_layers) {
+	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	item_map[p_item].render_layers = p_render_layers;
+	notify_property_list_changed();
+	notify_change_to_owners();
+	emit_changed();
+}
+
 void MeshLibrary::set_item_preview(int p_item, const Ref<Texture2D> &p_preview) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].preview = p_preview;
@@ -230,6 +243,11 @@ Transform3D MeshLibrary::get_item_navigation_mesh_transform(int p_item) const {
 uint32_t MeshLibrary::get_item_navigation_layers(int p_item) const {
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), 0, "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	return item_map[p_item].navigation_layers;
+}
+
+uint32_t MeshLibrary::get_item_render_layers(int p_item) const {
+	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), 0, "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	return item_map[p_item].render_layers;
 }
 
 Ref<Texture2D> MeshLibrary::get_item_preview(int p_item) const {
@@ -345,6 +363,7 @@ void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_item_navigation_mesh", "id", "navigation_mesh"), &MeshLibrary::set_item_navigation_mesh);
 	ClassDB::bind_method(D_METHOD("set_item_navigation_mesh_transform", "id", "navigation_mesh"), &MeshLibrary::set_item_navigation_mesh_transform);
 	ClassDB::bind_method(D_METHOD("set_item_navigation_layers", "id", "navigation_layers"), &MeshLibrary::set_item_navigation_layers);
+	ClassDB::bind_method(D_METHOD("set_item_render_layers", "id", "render_layers"), &MeshLibrary::set_item_render_layers);
 	ClassDB::bind_method(D_METHOD("set_item_shapes", "id", "shapes"), &MeshLibrary::_set_item_shapes);
 	ClassDB::bind_method(D_METHOD("set_item_preview", "id", "texture"), &MeshLibrary::set_item_preview);
 	ClassDB::bind_method(D_METHOD("get_item_name", "id"), &MeshLibrary::get_item_name);
@@ -353,6 +372,7 @@ void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_item_navigation_mesh", "id"), &MeshLibrary::get_item_navigation_mesh);
 	ClassDB::bind_method(D_METHOD("get_item_navigation_mesh_transform", "id"), &MeshLibrary::get_item_navigation_mesh_transform);
 	ClassDB::bind_method(D_METHOD("get_item_navigation_layers", "id"), &MeshLibrary::get_item_navigation_layers);
+	ClassDB::bind_method(D_METHOD("get_item_render_layers", "id"), &MeshLibrary::get_item_render_layers);
 	ClassDB::bind_method(D_METHOD("get_item_shapes", "id"), &MeshLibrary::_get_item_shapes);
 	ClassDB::bind_method(D_METHOD("get_item_preview", "id"), &MeshLibrary::get_item_preview);
 	ClassDB::bind_method(D_METHOD("remove_item", "id"), &MeshLibrary::remove_item);

--- a/scene/resources/mesh_library.h
+++ b/scene/resources/mesh_library.h
@@ -55,6 +55,7 @@ public:
 		Ref<NavigationMesh> navigation_mesh;
 		Transform3D navigation_mesh_transform;
 		uint32_t navigation_layers = 1;
+		uint32_t render_layers = 1;
 	};
 
 	RBMap<int, Item> item_map;
@@ -78,6 +79,7 @@ public:
 	void set_item_navigation_mesh(int p_item, const Ref<NavigationMesh> &p_navigation_mesh);
 	void set_item_navigation_mesh_transform(int p_item, const Transform3D &p_transform);
 	void set_item_navigation_layers(int p_item, uint32_t p_navigation_layers);
+	void set_item_render_layers(int p_item, uint32_t p_render_layers);
 	void set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes);
 	void set_item_preview(int p_item, const Ref<Texture2D> &p_preview);
 	String get_item_name(int p_item) const;
@@ -86,6 +88,7 @@ public:
 	Ref<NavigationMesh> get_item_navigation_mesh(int p_item) const;
 	Transform3D get_item_navigation_mesh_transform(int p_item) const;
 	uint32_t get_item_navigation_layers(int p_item) const;
+	uint32_t get_item_render_layers(int p_item) const;
 	Vector<ShapeData> get_item_shapes(int p_item) const;
 	Ref<Texture2D> get_item_preview(int p_item) const;
 


### PR DESCRIPTION
Proposed solution to these:

https://github.com/godotengine/godot/issues/40245
https://github.com/godotengine/godot-proposals/discussions/5438

Allow changing render layers on a per-item basis on a mesh_library and change grid_map to take render layers into account. Baked meshes don't support render layers.



<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
![Screenshot_20230325_181504](https://user-images.githubusercontent.com/5478365/227734469-ed98c7f2-3a8a-44c2-8667-0557558ae530.png)
