### PR TITLE
Emit scroll signal

### DIFF
--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -159,6 +159,8 @@ void ScrollContainer::gui_input(const Ref<InputEvent> &p_gui_input) {
 			}
 
 			if (scroll_value_modified && (v_scroll->get_value() != prev_v_scroll || h_scroll->get_value() != prev_h_scroll)) {
+				propagate_notification(NOTIFICATION_SCROLL_BEGIN);
+				emit_signal(SNAME("scroll_started"));
 				accept_event(); // Accept event if scroll changed.
 				return;
 			}
@@ -233,6 +235,8 @@ void ScrollContainer::gui_input(const Ref<InputEvent> &p_gui_input) {
 		}
 
 		if (v_scroll->get_value() != prev_v_scroll || h_scroll->get_value() != prev_h_scroll) {
+			propagate_notification(NOTIFICATION_SCROLL_BEGIN);
+			emit_signal(SNAME("scroll_started"));
 			accept_event(); // Accept event if scroll changed.
 		}
 		return;

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -471,6 +471,8 @@ void ScrollContainer::_scroll_moved(float) {
 void ScrollContainer::set_h_scroll(int p_pos) {
 	h_scroll->set_value(p_pos);
 	_cancel_drag();
+	emit_signal(SNAME("scroll_ended"));
+	propagate_notification(NOTIFICATION_SCROLL_END);
 }
 
 int ScrollContainer::get_h_scroll() const {
@@ -480,6 +482,8 @@ int ScrollContainer::get_h_scroll() const {
 void ScrollContainer::set_v_scroll(int p_pos) {
 	v_scroll->set_value(p_pos);
 	_cancel_drag();
+	emit_signal(SNAME("scroll_ended"));
+	propagate_notification(NOTIFICATION_SCROLL_END);
 }
 
 int ScrollContainer::get_v_scroll() const {

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -471,8 +471,6 @@ void ScrollContainer::_scroll_moved(float) {
 void ScrollContainer::set_h_scroll(int p_pos) {
 	h_scroll->set_value(p_pos);
 	_cancel_drag();
-	emit_signal(SNAME("scroll_ended"));
-	propagate_notification(NOTIFICATION_SCROLL_END);
 }
 
 int ScrollContainer::get_h_scroll() const {
@@ -482,8 +480,6 @@ int ScrollContainer::get_h_scroll() const {
 void ScrollContainer::set_v_scroll(int p_pos) {
 	v_scroll->set_value(p_pos);
 	_cancel_drag();
-	emit_signal(SNAME("scroll_ended"));
-	propagate_notification(NOTIFICATION_SCROLL_END);
 }
 
 int ScrollContainer::get_v_scroll() const {


### PR DESCRIPTION
PR emits scroll started signal on mouse wheel scroll and touch drag scroll in scroll container.

Possibly fixes problem of #22936 as scroll ended is emitted already upon touch drag release. But this emits scroll started every time scroll is moved, even when held down. Not sure if this is how it's intended, but it's certainly the functionality I was looking for. If this is not what was intended, and the signal is only supposed to be emitted once, at start, then perhaps I can create a new signal called is scrolling or something. But this seems better than nothing as it was before, as you could work around it, so it's your call.

