### PR TITLE
[ci] use shorter workflow and job names

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   android-template:
     runs-on: "ubuntu-20.04"
-    name: Template (target=template_release)
+    name: Template
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   ios-template:
     runs-on: "macos-latest"
-    name: Template (target=template_release)
+    name: Template
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -33,7 +33,7 @@ jobs:
             proj-conv: true
             artifact: true
 
-          - name: Editor with doubles and GCC sanitizers (tests=yes, dev_build=yes, precision=double, use_asan=yes, use_ubsan=yes, linker=gold)
+          - name: Editor with doubles and GCC sanitizers
             cache-name: linux-editor-double-sanitizers
             target: editor
             tests: true
@@ -48,7 +48,7 @@ jobs:
             # Skip 2GiB artifact speeding up action.
             artifact: false
 
-          - name: Editor with clang sanitizers (tests=yes, dev_build=yes, use_asan=yes, use_ubsan=yes, use_llvm=yes, linker=lld)
+          - name: Editor with clang sanitizers
             cache-name: linux-editor-llvm-sanitizers
             target: editor
             tests: true
@@ -66,7 +66,7 @@ jobs:
             build-mono: false
             artifact: true
 
-          - name: Minimal template (everything disabled)
+          - name: Minimal template
             cache-name: linux-template-minimal
             target: template_release
             tests: false

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -34,6 +34,7 @@ jobs:
             artifact: true
 
           - name: Editor with doubles and GCC sanitizers
+            info: 'tests=yes, dev_build=yes, precision=double, use_asan=yes, use_ubsan=yes, linker=gold'
             cache-name: linux-editor-double-sanitizers
             target: editor
             tests: true
@@ -49,6 +50,7 @@ jobs:
             artifact: false
 
           - name: Editor with clang sanitizers
+            info: 'tests=yes, dev_build=yes, use_asan=yes, use_ubsan=yes, use_llvm=yes, linker=lld'
             cache-name: linux-editor-llvm-sanitizers
             target: editor
             tests: true
@@ -67,6 +69,7 @@ jobs:
             artifact: true
 
           - name: Minimal template
+            info: 'everything disabled'
             cache-name: linux-template-minimal
             target: template_release
             tests: false
@@ -74,6 +77,7 @@ jobs:
             artifact: true
 
     steps:
+      - run: "echo 'INFO: ${{ matrix.info }}'"
       - uses: actions/checkout@v3
 
       # Need newer mesa for lavapipe to work properly.

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Editor w/ Mono (target=editor)
+          - name: Editor w/ Mono
             cache-name: linux-editor-mono
             target: editor
             tests: false # Disabled due freeze caused by mix Mono build and CI
@@ -33,7 +33,7 @@ jobs:
             proj-conv: true
             artifact: true
 
-          - name: Editor with doubles and GCC sanitizers (target=editor, tests=yes, dev_build=yes, precision=double, use_asan=yes, use_ubsan=yes, linker=gold)
+          - name: Editor with doubles and GCC sanitizers (tests=yes, dev_build=yes, precision=double, use_asan=yes, use_ubsan=yes, linker=gold)
             cache-name: linux-editor-double-sanitizers
             target: editor
             tests: true
@@ -48,7 +48,7 @@ jobs:
             # Skip 2GiB artifact speeding up action.
             artifact: false
 
-          - name: Editor with clang sanitizers (target=editor, tests=yes, dev_build=yes, use_asan=yes, use_ubsan=yes, use_llvm=yes, linker=lld)
+          - name: Editor with clang sanitizers (tests=yes, dev_build=yes, use_asan=yes, use_ubsan=yes, use_llvm=yes, linker=lld)
             cache-name: linux-editor-llvm-sanitizers
             target: editor
             tests: true
@@ -58,7 +58,7 @@ jobs:
             # Skip 2GiB artifact speeding up action.
             artifact: false
 
-          - name: Template w/ Mono (target=template_release)
+          - name: Template w/ Mono
             cache-name: linux-template-mono
             target: template_release
             tests: false
@@ -66,7 +66,7 @@ jobs:
             build-mono: false
             artifact: true
 
-          - name: Minimal template (target=template_release, everything disabled)
+          - name: Minimal template (everything disabled)
             cache-name: linux-template-minimal
             target: template_release
             tests: false

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -20,13 +20,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Editor (target=editor, tests=yes)
+          - name: Editor (tests=yes)
             cache-name: macos-editor
             target: editor
             tests: true
             bin: "./bin/godot.macos.editor.x86_64"
 
-          - name: Template (target=template_release)
+          - name: Template
             cache-name: macos-template
             target: template_release
             tests: false

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         include:
           - name: Editor
+            info: 'tests=yes'
             cache-name: macos-editor
             target: editor
             tests: true
@@ -33,6 +34,7 @@ jobs:
             sconsflags: debug_symbols=no
 
     steps:
+      - run: "echo 'INFO: ${{ matrix.info }}'"
       - uses: actions/checkout@v3
 
       - name: Setup Godot build cache

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Editor (tests=yes)
+          - name: Editor
             cache-name: macos-editor
             target: editor
             tests: true

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   static-checks:
-    name: Static Checks (clang-format, black format, file format, documentation checks)
+    name: Static Checks
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -11,6 +11,7 @@ jobs:
     name: Static Checks
     runs-on: ubuntu-20.04
     steps:
+      - run: "echo 'INFO: clang-format, black format, file format, documentation checks'"
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   web-template:
     runs-on: "ubuntu-20.04"
-    name: Template (target=template_release)
+    name: Template
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         include:
           - name: Editor
+            info: 'tests=yes'
             cache-name: windows-editor
             target: editor
             tests: true
@@ -32,12 +33,14 @@ jobs:
             bin: "./bin/godot.windows.editor.x86_64.exe"
 
           - name: Template
+            info: 'tools=no'
             cache-name: windows-template
             target: template_release
             tests: false
             sconsflags: debug_symbols=no
 
     steps:
+      - run: "echo 'INFO: ${{ matrix.info }}'"
       - uses: actions/checkout@v3
 
       - name: Setup Godot build cache

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Editor (tests=yes)
+          - name: Editor
             cache-name: windows-editor
             target: editor
             tests: true

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Editor (target=editor, tests=yes)
+          - name: Editor (tests=yes)
             cache-name: windows-editor
             target: editor
             tests: true
@@ -31,7 +31,7 @@ jobs:
             sconsflags: debug_symbols=no vsproj=yes
             bin: "./bin/godot.windows.editor.x86_64.exe"
 
-          - name: Template (target=template_release)
+          - name: Template
             cache-name: windows-template
             target: template_release
             tests: false


### PR DESCRIPTION
Current CI job titles are too long for the visualisation in GitHub, both at the bottom of PRs and in the Actions sidebar.  This PR makes the names shorter by removing the content in parens.