### PR TITLE
[ci] add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -1,6 +1,7 @@
 name: 🤖 Android Builds
 on:
   workflow_call:
+  workflow_dispatch:
 
 # Global Settings
 env:

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -1,6 +1,7 @@
 name: 🍏 iOS Builds
 on:
   workflow_call:
+  workflow_dispatch:
 
 # Global Settings
 env:

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -1,6 +1,7 @@
 name: 🐧 Linux Builds
 on:
   workflow_call:
+  workflow_dispatch:
 
 # Global Settings
 env:

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -1,6 +1,7 @@
 name: 🍎 macOS Builds
 on:
   workflow_call:
+  workflow_dispatch:
 
 # Global Settings
 env:

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -1,6 +1,7 @@
 name: 📊 Static Checks
 on:
   workflow_call:
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-static

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -1,6 +1,7 @@
 name: 🌐 Web Builds
 on:
   workflow_call:
+  workflow_dispatch:
 
 # Global Settings
 env:

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -1,6 +1,7 @@
 name: 🏁 Windows Builds
 on:
   workflow_call:
+  workflow_dispatch:
 
 # Global Settings
 # SCONS_CACHE for windows must be set in the build environment


### PR DESCRIPTION
The workflow_dispatch event allows manually triggering workflows either through the web GUI, the CLI or the API. See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch and https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow.