### PR TITLE
[ci] use reusable workflows

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -1,5 +1,6 @@
 name: 🤖 Android Builds
-on: [push, pull_request]
+on:
+  workflow_call:
 
 # Global Settings
 env:

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -1,5 +1,6 @@
 name: 🍏 iOS Builds
-on: [push, pull_request]
+on:
+  workflow_call:
 
 # Global Settings
 env:

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -1,5 +1,6 @@
 name: 🐧 Linux Builds
-on: [push, pull_request]
+on:
+  workflow_call:
 
 # Global Settings
 env:

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -1,5 +1,6 @@
 name: 🍎 macOS Builds
-on: [push, pull_request]
+on:
+  workflow_call:
 
 # Global Settings
 env:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,4 +1,4 @@
-name: Pipeline
+name: GHA
 on:
   push:
   pull_request:
@@ -10,29 +10,29 @@ concurrency:
 jobs:
 
   static:
-    name: 📊 Static Checks
+    name: 📊 Static
     uses: ./.github/workflows/static_checks.yml
 
   android:
-    name: 🤖 Android Builds
+    name: 🤖 Android
     uses: ./.github/workflows/android_builds.yml
 
   ios:
-    name: 🍏 iOS Builds
+    name: 🍏 iOS
     uses: ./.github/workflows/ios_builds.yml
 
   linux:
-    name: 🐧 Linux Builds
+    name: 🐧 Linux
     uses: ./.github/workflows/linux_builds.yml
 
   macos:
-    name: 🍎 macOS Builds
+    name: 🍎 macOS
     uses: ./.github/workflows/macos_builds.yml
 
   web:
-    name: 🌐 Web Builds
+    name: 🌐 Web
     uses: ./.github/workflows/web_builds.yml
 
   windows:
-    name: 🏁 Windows Builds
+    name: 🏁 Windows
     uses: ./.github/workflows/windows_builds.yml

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,38 @@
+name: Pipeline
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-pipeline
+  cancel-in-progress: true
+
+jobs:
+
+  static:
+    name: 📊 Static Checks
+    uses: ./.github/workflows/static_checks.yml
+
+  android:
+    name: 🤖 Android Builds
+    uses: ./.github/workflows/android_builds.yml
+
+  ios:
+    name: 🍏 iOS Builds
+    uses: ./.github/workflows/ios_builds.yml
+
+  linux:
+    name: 🐧 Linux Builds
+    uses: ./.github/workflows/linux_builds.yml
+
+  macos:
+    name: 🍎 macOS Builds
+    uses: ./.github/workflows/macos_builds.yml
+
+  web:
+    name: 🌐 Web Builds
+    uses: ./.github/workflows/web_builds.yml
+
+  windows:
+    name: 🏁 Windows Builds
+    uses: ./.github/workflows/windows_builds.yml

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -1,5 +1,6 @@
 name: 📊 Static Checks
-on: [push, pull_request]
+on:
+  workflow_call:
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-static

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -1,5 +1,6 @@
 name: 🌐 Web Builds
-on: [push, pull_request]
+on:
+  workflow_call:
 
 # Global Settings
 env:

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -1,5 +1,6 @@
 name: 🏁 Windows Builds
-on: [push, pull_request]
+on:
+  workflow_call:
 
 # Global Settings
 # SCONS_CACHE for windows must be set in the build environment


### PR DESCRIPTION
There are seven GHA workflows in this repository. Each of them is described as being independent. As a result, for each push, seven different entries are generated in the Actions list. It is not intuitive to later know which of them are related.
However, the triggering conditions of all the workflows are the same. I.e., they are not independent and all the jobs could be written in a single workflow. I guess the reason to have them separated is to make maintenance easier.

Fortunately, GHA provides a solution: https://docs.github.com/en/actions/using-workflows/reusing-workflows. Reusable workflows are regular workflows with a `workflow_call` triggering condition that allows them to be called from other workflows.

This PR converts all existing workflows into reusable workflows by removing push and pull_request trigger conditions and adding workflow_call instead. Moreover, a `pipeline.yml` workflow is added, which calls all other workflows, and which is to be triggered by push and pull_request events. As a result:

- A single entry will be generated in the main Actions list for each push.
- All the jobs will be shown in the sidebar, in a tree view. See, for instance: https://github.com/umarcor/godot/actions/runs/4521888744.
- All the jobs will be shown in a single graph. See, for instance: https://github.com/umarcor/godot/actions/runs/4521888744
- All the artifacts from different jobs are shown in a list.

~Furthermore, since this PR is based on #75336, individual workflows can be manually triggered one-by-one, apart from having all triggered through the pipeline workflow.~

The list of "checks" shown at the bottom of PRs will not change, because the jobs that are executed are exactly the same. "checks" do show jobs but don't tell the hierarchy of the workflows. Well, strictly, they tell the hierarchy through "breadcrumbs" in the name of the jobs.