### PR TITLE
[ci/web] update mymindstorm/setup-emsdk to v12

### DIFF
--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Emscripten latest
-        uses: mymindstorm/setup-emsdk@v11
+        uses: mymindstorm/setup-emsdk@v12
         with:
           version: ${{env.EM_VERSION}}
           actions-cache-folder: ${{env.EM_CACHE_FOLDER}}


### PR DESCRIPTION
Fix the warning that is shown in the web workflow:

> *Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: mymindstorm/setup-emsdk@v11. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.*

Was fixed in https://github.com/mymindstorm/setup-emsdk/commit/ed0d39adca709d0c4f7253f52a73759b7694a5f8. See https://github.com/mymindstorm/setup-emsdk/issues/28.