### PR TITLE
Fix `NodePath` subname index range documentation

### DIFF
--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -141,7 +141,7 @@
 			<return type="StringName" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Gets the resource or property name indicated by [param idx] (0 to [method get_subname_count]).
+				Gets the resource or property name indicated by [param idx] (0 to [method get_subname_count] - 1).
 				[codeblocks]
 				[gdscript]
 				var node_path = NodePath("Path2D/PathFollow2D/Sprite2D:texture:load_path")


### PR DESCRIPTION
Documentation for `get_subname` had incorrect (inclusive) index range

3.x version #75370 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
