### PR TITLE
`TileSet` Fix crash in `AtlasMergingDialog`

### DIFF
--- a/editor/plugins/tiles/atlas_merging_dialog.cpp
+++ b/editor/plugins/tiles/atlas_merging_dialog.cpp
@@ -95,7 +95,9 @@ void AtlasMergingDialog::_generate_merged(Vector<Ref<TileSetAtlasSource>> p_atla
 			}
 		}
 
+		merged->set_name(p_atlas_sources[0]->get_name());
 		merged->set_texture(ImageTexture::create_from_image(output_image));
+		merged->set_texture_region_size(new_texture_region_size);
 
 		// Copy the tiles to the merged TileSetAtlasSource.
 		for (int source_index = 0; source_index < p_atlas_sources.size(); source_index++) {
@@ -130,9 +132,6 @@ void AtlasMergingDialog::_generate_merged(Vector<Ref<TileSetAtlasSource>> p_atla
 				}
 			}
 		}
-
-		merged->set_name(p_atlas_sources[0]->get_name());
-		merged->set_texture_region_size(new_texture_region_size);
 	}
 }
 


### PR DESCRIPTION
When generating the `merged` TileSetAtlasSource the newly calculated `new_texture_region_size` was being set after creating tiles within such source. Hence during tiles creation its `texture_region_size` was the default `(16, 16)` instead of the `new_texture_region_size`. When any dimension of `new_texture_region_size` was smaller than 16 then the tile would fail to be created as it would be determined to not fit within the new texture. Hence later obtaining such tile's data would fail (as it was not created) and thus `nullptr` would be dereferenced when trying to copy the properties (which caused the crash).

This PR makes the `new_texture_region_size` be set before copying the tiles so the checks should not fail like before.

Fixes #75354.