### PR TITLE
Make MarginContainer available with `disable_advanced_gui=yes`

### DIFF
--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -385,6 +385,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(FlowContainer);
 	GDREGISTER_CLASS(HFlowContainer);
 	GDREGISTER_CLASS(VFlowContainer);
+	GDREGISTER_CLASS(MarginContainer);
 
 	OS::get_singleton()->yield(); // may take time to init
 
@@ -419,7 +420,6 @@ void register_scene_types() {
 	GDREGISTER_CLASS(AcceptDialog);
 	GDREGISTER_CLASS(ConfirmationDialog);
 
-	GDREGISTER_CLASS(MarginContainer);
 	GDREGISTER_CLASS(SubViewportContainer);
 	GDREGISTER_CLASS(SplitContainer);
 	GDREGISTER_CLASS(HSplitContainer);


### PR DESCRIPTION
Comparatively more advanced GUI nodes such as FlowContainer and AspectRatioContainer are already available when building with `disable_advanced_gui=yes`.

This increases binary size by about 8 KB for binaries compiled with `disable_advanced_gui=yes` (Linux release export template with LTO enabled).

For context, I'm working on a PR to [display license notices in a GUI](https://github.com/Calinou/godot/tree/add-license-notices-gui) (similar to https://github.com/godotengine/godot/pull/51028). Having MarginContainer available in all situations would help a lot, so that the GUI can keep working in binaries compiled with `disable_advanced_gui=yes`.

```bash
# Current `master` branch when building with `disable_advanced_gui=yes`
60,355,504 godot.linuxbsd.template_release.x86_64.disable_advanced_gui_master

# MarginContainer enabled (what this PR does)
60,363,728 godot.linuxbsd.template_release.x86_64.disable_advanced_gui_pr_margincontainer_only

# MarginContainer, SplitContainer and SubViewportContainer enabled
# (not done in this PR, only included for reference)
60,421,040 godot.linuxbsd.template_release.x86_64.disable_advanced_gui_pr

# `disable_advanced_gui=no` (default)
62,809,040 godot.linuxbsd.template_release.x86_64.enable_advanced_gui
```