### PR TITLE
Fix the limit for interpolation of R0 with respect to metallic and the calculation of the cos theata in the Fresnel Shlick term in SSR

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
@@ -263,9 +263,8 @@ void main() {
 
 		// Schlick term.
 		float metallic = texelFetch(source_metallic, ssC << 1, 0).w;
-		float f0 = mix(0.04, 1.0, metallic); // Assume a "specular" amount of 0.5
-		normal.y = -normal.y;
-		float m = clamp(1.0 - dot(normalize(normal), -view_dir), 0.0, 1.0);
+		float f0 = mix(0.04, 0.37, metallic); // The default value of R0 is 0.04 and the maximum value is considered to be Germanium with R0 value of 0.37
+		float m = clamp(1.0 - dot(normal, -view_dir), 0.0, 1.0);
 		float m2 = m * m;
 		m = m2 * m2 * m; // pow(m,5)
 		final_color.a *= f0 + (1.0 - f0) * m; // Fresnel Schlick term.


### PR DESCRIPTION
The default of Ro is assumed to be around 1.5 after applying the formula which is ((u -1)/(u +1))^2 => ((1.5 -1)/(1.5+1))^2=>0.04. The element with the highest refractive index found in nature is considered to [be Germanium](https://en.wikipedia.org/wiki/List_of_refractive_indices). It has a range of refractive index from 4.05 to 4.1. After applying the formula to the maximum of the range ((4.1 - 1)/(4.1 +1))^2=>(Approx)0.37. So, the rational limit should be this.
Fix #75302 