### PR TITLE
[3.x] Fix `NodePath` subname index range documentation

### DIFF
--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -96,7 +96,7 @@
 			<return type="String" />
 			<argument index="0" name="idx" type="int" />
 			<description>
-				Gets the resource or property name indicated by [code]idx[/code] (0 to [method get_subname_count]).
+				Gets the resource or property name indicated by [code]idx[/code] (0 to [method get_subname_count] - 1).
 				[codeblock]
 				var node_path = NodePath("Path2D/PathFollow2D/Sprite:texture:load_path")
 				print(node_path.get_subname(0)) # texture


### PR DESCRIPTION
Documentation for get_subname had incorrect (inclusive) index range

4.1 version #75350
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
