### PR TITLE
Bind `WorkerThreadPool::get_thread_count`

### DIFF
--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -465,6 +465,8 @@ void WorkerThreadPool::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_group_task_completed", "group_id"), &WorkerThreadPool::is_group_task_completed);
 	ClassDB::bind_method(D_METHOD("get_group_processed_element_count", "group_id"), &WorkerThreadPool::get_group_processed_element_count);
 	ClassDB::bind_method(D_METHOD("wait_for_group_task_completion", "group_id"), &WorkerThreadPool::wait_for_group_task_completion);
+
+	ClassDB::bind_method(D_METHOD("get_thread_count"), &WorkerThreadPool::get_thread_count);
 }
 
 WorkerThreadPool::WorkerThreadPool() {

--- a/doc/classes/WorkerThreadPool.xml
+++ b/doc/classes/WorkerThreadPool.xml
@@ -31,6 +31,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_thread_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of worker threads of the pool.
+			</description>
+		</method>
 		<method name="is_group_task_completed" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="group_id" type="int" />


### PR DESCRIPTION
This PR adds a binding for the `get_thread_count` method on `WorkerThreadPool`, which is used to retrieve the number of worker threads that the thread-pool has available to it.

Currently you're forced to assume that the number of workers in `WorkerThreadPool` is equal to `OS::get_processor_count`, which is its default value, but exposing `get_thread_count` takes the assuming/guessing out of it.

~~I removed `_FORCE_INLINE_` from the declaration of `get_thread_count` in order to be able to grab its address, but I wasn't sure what the policy/convention was regarding having bound functions be defined inside the class declaration and thereby be implicitly `inline`. Let me know if I should move its definition to `worker_thread_pool.cpp` instead.~~