### PR TITLE
Fix height of subresource button in Inspector

### DIFF
--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -35,6 +35,12 @@
 #include "editor/editor_scale.h"
 #include "editor/multi_node_edit.h"
 
+Size2 EditorPath::get_minimum_size() const {
+	Ref<Font> font = get_theme_font(SNAME("font"));
+	int font_size = get_theme_font_size(SNAME("font_size"));
+	return Button::get_minimum_size() + Size2(0, font->get_height(font_size));
+}
+
 void EditorPath::_add_children_to_popup(Object *p_obj, int p_depth) {
 	if (p_depth > 8) {
 		return;

--- a/editor/editor_path.h
+++ b/editor/editor_path.h
@@ -61,6 +61,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual Size2 get_minimum_size() const override;
+
 	void update_path();
 	void clear_path();
 	void enable_path();


### PR DESCRIPTION
The subresource button has incorrect height when the editor uses a large font size.

This is because the button itself does not have text or icon assigned (they are implemented as another layer on top of that button). Font height is not added to the button's minimum size when the text is empty.

| Before | After |
|---|---|
| ![before](https://user-images.githubusercontent.com/372476/227868062-549e0d1b-92a1-4e73-a8d3-02340d9235bf.png) | ![after](https://user-images.githubusercontent.com/372476/227868069-919165ac-4985-4810-b610-251fadaaec97.png) |
