### PR TITLE
Ensure binds are duplicated with `Node` signals

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2722,9 +2722,15 @@ void Node::_duplicate_signals(const Node *p_original, Node *p_copy) const {
 					copytarget = p_copy->get_node(ptarget);
 				}
 
-				if (copy && copytarget) {
-					const Callable copy_callable = Callable(copytarget, E.callable.get_method());
+				if (copy && copytarget && E.callable.get_method() != StringName()) {
+					Callable copy_callable = Callable(copytarget, E.callable.get_method());
 					if (!copy->is_connected(E.signal.get_name(), copy_callable)) {
+						int arg_count = E.callable.get_bound_arguments_count();
+						if (arg_count > 0) {
+							copy_callable = copy_callable.bindv(E.callable.get_bound_arguments());
+						} else if (arg_count < 0) {
+							copy_callable = copy_callable.unbind(-arg_count);
+						}
 						copy->connect(E.signal.get_name(), copy_callable, E.flags);
 					}
 				}


### PR DESCRIPTION
Also added a check to ensure the function has a method name, doesn't fully prevent pointer binds from ending up attempting to duplicate (it would be an error to have such a signal as persists anyway), could make a more elaborate change involving adding a `rebind` function to `Callable` but think it is outside the scope of this

Fixes #75105
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
