### PR TITLE
Auto translate popup menus of MenuButton and OptionButton

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -927,7 +927,7 @@
 			Anchors the top edge of the node to the origin, the center or the end of its parent control. It changes how the top offset updates when the node moves or changes size. You can use one of the [enum Anchor] constants for convenience.
 		</member>
 		<member name="auto_translate" type="bool" setter="set_auto_translate" getter="is_auto_translating" default="true">
-			Toggles if any text should automatically change to its translated version depending on the current locale. Note that this will not affect any internal nodes (e.g. the popup of a [MenuButton]).
+			Toggles if any text should automatically change to its translated version depending on the current locale.
 			Also decides if the node's strings should be parsed for POT generation.
 		</member>
 		<member name="clip_contents" type="bool" setter="set_clip_contents" getter="is_clipping_contents" default="false">

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -169,6 +169,10 @@ void MenuButton::_notification(int p_what) {
 				menu_btn_other->get_popup()->set_focused_item(-1);
 			}
 		} break;
+
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			popup->set_auto_translate(is_auto_translating());
+		} break;
 	}
 }
 

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -128,7 +128,10 @@ void OptionButton::_notification(int p_what) {
 			theme_cache.arrow_icon->draw(ci, ofs, clr);
 		} break;
 
-		case NOTIFICATION_TRANSLATION_CHANGED:
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			popup->set_auto_translate(is_auto_translating());
+			[[fallthrough]];
+		}
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
 			popup->set_layout_direction((Window::LayoutDirection)get_layout_direction());
 			[[fallthrough]];


### PR DESCRIPTION
Currently, `auto_translate` property of a `MenuButton` or `OptionButton` won't affect its popup menu. It's okay if you want to auto translate, but requires extra setup if you don't. I don't think there's a practical use case for translating popup menus while not translating the buttons.

This PR changes internal `PopupMenu`'s `auto_translate` property when the button's `auto_translate` changes.

Note: The descriptions in `Control.xml` were later summarized based on existing behavior, rather than the design at the time of initial implementation.