### PR TITLE
Fix typos and inconsistencies in classref

### DIFF
--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -109,7 +109,7 @@
 	</methods>
 	<members>
 		<member name="avoidance_enabled" type="bool" setter="set_avoidance_enabled" getter="get_avoidance_enabled" default="false">
-			If [code]true[/code] the agent is registered for an RVO avoidance callback on the [NavigationServer2D]. When [method NavigationAgent2D.set_velocity] is used and the processing is completed a [code]safe_velocity[/code] Vector2 is received with a signal connection to [signal velocity_computed]. Avoidance processing with many registered agents has a significant performance cost and should only be enabled on agents that currently require it.
+			If [code]true[/code] the agent is registered for an RVO avoidance callback on the [NavigationServer2D]. When [method set_velocity] is used and the processing is completed a [code]safe_velocity[/code] Vector2 is received with a signal connection to [signal velocity_computed]. Avoidance processing with many registered agents has a significant performance cost and should only be enabled on agents that currently require it.
 		</member>
 		<member name="debug_enabled" type="bool" setter="set_debug_enabled" getter="get_debug_enabled" default="false">
 			If [code]true[/code] shows debug visuals for this agent.
@@ -193,7 +193,7 @@
 		<signal name="velocity_computed">
 			<param index="0" name="safe_velocity" type="Vector2" />
 			<description>
-				Notifies when the collision avoidance velocity is calculated. Emitted by [method set_velocity]. Only emitted when [member avoidance_enabled] is true.
+				Notifies when the collision avoidance velocity is calculated. Emitted at the end of the physics frame in which [method set_velocity] is called. Only emitted when [member avoidance_enabled] is true.
 			</description>
 		</signal>
 		<signal name="waypoint_reached">

--- a/doc/classes/NavigationAgent3D.xml
+++ b/doc/classes/NavigationAgent3D.xml
@@ -112,7 +112,7 @@
 			The NavigationAgent height offset is subtracted from the y-axis value of any vector path position for this NavigationAgent. The NavigationAgent height offset does not change or influence the navigation mesh or pathfinding query result. Additional navigation maps that use regions with navigation meshes that the developer baked with appropriate agent radius or height values are required to support different-sized agents.
 		</member>
 		<member name="avoidance_enabled" type="bool" setter="set_avoidance_enabled" getter="get_avoidance_enabled" default="false">
-			If [code]true[/code] the agent is registered for an RVO avoidance callback on the [NavigationServer3D]. When [method NavigationAgent3D.set_velocity] is used and the processing is completed a [code]safe_velocity[/code] Vector3 is received with a signal connection to [signal velocity_computed]. Avoidance processing with many registered agents has a significant performance cost and should only be enabled on agents that currently require it.
+			If [code]true[/code] the agent is registered for an RVO avoidance callback on the [NavigationServer3D]. When [method set_velocity] is used and the processing is completed a [code]safe_velocity[/code] Vector3 is received with a signal connection to [signal velocity_computed]. Avoidance processing with many registered agents has a significant performance cost and should only be enabled on agents that currently require it.
 		</member>
 		<member name="debug_enabled" type="bool" setter="set_debug_enabled" getter="get_debug_enabled" default="false">
 			If [code]true[/code] shows debug visuals for this agent.
@@ -136,7 +136,7 @@
 			The maximum speed that an agent can move.
 		</member>
 		<member name="navigation_layers" type="int" setter="set_navigation_layers" getter="get_navigation_layers" default="1">
-			A bitfield determining what navigation layers of navigation regions this NavigationAgent will use to calculate path. Changing it runtime will clear current navigation path and generate new one, according to new navigation layers.
+			A bitfield determining what navigation layers of navigation regions this agent will use to calculate path. Changing it runtime will clear current navigation path and generate new one, according to new navigation layers.
 		</member>
 		<member name="neighbor_distance" type="float" setter="set_neighbor_distance" getter="get_neighbor_distance" default="50.0">
 			The distance to search for other agents.
@@ -196,7 +196,7 @@
 		<signal name="velocity_computed">
 			<param index="0" name="safe_velocity" type="Vector3" />
 			<description>
-				Notifies when the collision avoidance velocity is calculated. Emitted by [method set_velocity]. Only emitted when [member avoidance_enabled] is true.
+				Notifies when the collision avoidance velocity is calculated. Emitted at the end of the physics frame in which [method set_velocity] is called. Only emitted when [member avoidance_enabled] is true.
 			</description>
 		</signal>
 		<signal name="waypoint_reached">

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -587,7 +587,7 @@
 		<method name="canvas_light_occluder_create">
 			<return type="RID" />
 			<description>
-				Creates a light occluder and adds it to the RenderingServer. It can be accessed with the RID that is returned. This RID will be used in all [code]canvas_light_ocluder_*[/code] RenderingServer functions.
+				Creates a light occluder and adds it to the RenderingServer. It can be accessed with the RID that is returned. This RID will be used in all [code]canvas_light_occluder_*[/code] RenderingServer functions.
 				Once finished with your RID, you will want to free the RID using the RenderingServer's [method free_rid] static method.
 			</description>
 		</method>

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -1163,7 +1163,7 @@
 			<param index="1" name="width" type="float" />
 			<param index="2" name="jst_flags" type="int" enum="TextServer.JustificationFlag" default="3" />
 			<description>
-				Adjusts text with to fit to specified width, returns new text width.
+				Adjusts text width to fit to specified width, returns new text width.
 			</description>
 		</method>
 		<method name="shaped_text_get_ascent" qualifiers="const">

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -226,7 +226,7 @@
 		<method name="is_normalized" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the vector is normalized, [code]false[/code] otherwise.
+				Returns [code]true[/code] if the vector is normalized, i.e. its length is approximately equal to 1.
 			</description>
 		</method>
 		<method name="is_zero_approx" qualifiers="const">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -194,7 +194,7 @@
 		<method name="is_normalized" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the vector is [method normalized], [code]false[/code] otherwise.
+				Returns [code]true[/code] if the vector is normalized, i.e. its length is approximately equal to 1.
 			</description>
 		</method>
 		<method name="is_zero_approx" qualifiers="const">

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -145,7 +145,7 @@
 		<method name="is_normalized" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the vector is normalized, i.e. its length is equal to 1.
+				Returns [code]true[/code] if the vector is normalized, i.e. its length is approximately equal to 1.
 			</description>
 		</method>
 		<method name="is_zero_approx" qualifiers="const">


### PR DESCRIPTION
* Typo fixes.
* Navigation agent's `velocity_computed` signal is not emitted by `set_velocity`, but at the end of that frame if `set_velocity` is called.
* Simplify link in navigation agent's `avoidance_enabled` description.
* Unify `navigation_layers` description across `NavigationAgent{2,3}D`.
* Unify `is_normalized()` description across `Vector2`, `Vector3`, and `Vector4`

