### PR TITLE
Add a project setting to enable render time measurements on root Viewport

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3377,6 +3377,11 @@
 			[b]Note:[/b] This setting will have no effect when using the Compatibility renderer, which always renders in low dynamic range for performance reasons.
 			[b]Note:[/b] This property is only read when the project starts. To toggle HDR 2D at runtime, set [member Viewport.use_hdr_2d] on the root [Viewport].
 		</member>
+		<member name="rendering/viewport/measure_render_time" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], enables CPU/GPU render time measurements on the root viewport using [method RenderingServer.viewport_get_measured_render_time_cpu] and [method RenderingServer.viewport_get_measured_render_time_gpu]. Internally, this calls [method RenderingServer.viewport_set_measure_render_time] with the root viewport's RID as an argument (obtained using [method Viewport.get_viewport_rid]).
+			[b]Note:[/b] Only enable [member rendering/viewport/measure_render_time] if you actually need to query render time, as it has a performance overhead even if the value is never queried. If you only display measurements in a debug menu, consider using [method RenderingServer.viewport_set_measure_render_time] to toggle this value at run-time on the root viewport while leaving [member rendering/viewport/measure_render_time] to [code]false[/code].
+			[b]Note:[/b] This property is only read when the project starts. To toggle render time measurements at runtime, use [method RenderingServer.viewport_set_measure_render_time] on the root [Viewport].
+		</member>
 		<member name="rendering/viewport/transparent_background" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], enables [member Viewport.transparent_bg] on the root viewport. This allows per-pixel transparency to be effective after also enabling [member display/window/size/transparent] and [member display/window/per_pixel_transparency/allowed].
 		</member>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1615,7 +1615,7 @@
 		<method name="get_frame_setup_time_cpu" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the time taken to setup rendering on the CPU in milliseconds. This value is shared across all viewports and does [i]not[/i] require [method viewport_set_measure_render_time] to be enabled on a viewport to be queried. See also [method viewport_get_measured_render_time_cpu].
+				Returns the time taken to setup rendering on the CPU in milliseconds. This value is shared across all viewports and does [i]not[/i] require [member ProjectSettings.rendering/viewport/measure_render_time] to be enabled to be queried. See also [method viewport_get_measured_render_time_cpu].
 			</description>
 		</method>
 		<method name="get_rendering_device" qualifiers="const">
@@ -3878,15 +3878,15 @@
 			<param index="0" name="viewport" type="RID" />
 			<description>
 				Returns the CPU time taken to render the last frame in milliseconds. This [i]only[/i] includes time spent in rendering-related operations; scripts' [code]_process[/code] functions and other engine subsystems are not included in this readout. To get a complete readout of CPU time spent to render the scene, sum the render times of all viewports that are drawn every frame plus [method get_frame_setup_time_cpu]. Unlike [method Engine.get_frames_per_second], this method will accurately reflect CPU utilization even if framerate is capped via V-Sync or [member Engine.max_fps]. See also [method viewport_get_measured_render_time_gpu].
-				[b]Note:[/b] Requires measurements to be enabled on the specified [param viewport] using [method viewport_set_measure_render_time]. Otherwise, this method returns [code]0.0[/code].
+				[b]Note:[/b] Requires measurements to be enabled on the specified [param viewport] using [method viewport_set_measure_render_time]. Otherwise, this method returns [code]0.0[/code]. On the root viewport, [member ProjectSettings.rendering/viewport/measure_render_time] can be enabled as an alternative to calling [method viewport_set_measure_render_time].
 			</description>
 		</method>
 		<method name="viewport_get_measured_render_time_gpu" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="viewport" type="RID" />
 			<description>
-				Returns the GPU time taken to render the last frame in milliseconds. To get a complete readout of GPU time spent to render the scene, sum the render times of all viewports that are drawn every frame. Unlike [method Engine.get_frames_per_second], this method accurately reflects GPU utilization even if framerate is capped via V-Sync or [member Engine.max_fps]. See also [method viewport_get_measured_render_time_cpu].
-				[b]Note:[/b] Requires measurements to be enabled on the specified [param viewport] using [method viewport_set_measure_render_time]. Otherwise, this method returns [code]0.0[/code].
+				Returns the GPU time taken to render the last frame in milliseconds. To get a complete readout of GPU time spent to render the scene, sum the render times of all viewports that are drawn every frame. Unlike [method Engine.get_frames_per_second], this method accurately reflects GPU utilization even if framerate is capped via V-Sync or [member Engine.max_fps]. See also [method viewport_get_measured_render_time_gpu].
+				[b]Note:[/b] Requires measurements to be enabled on the specified [param viewport] using [method viewport_set_measure_render_time]. Otherwise, this method returns [code]0.0[/code]. On the root viewport, [member ProjectSettings.rendering/viewport/measure_render_time] can be enabled as an alternative to calling [method viewport_set_measure_render_time].
 				[b]Note:[/b] When GPU utilization is low enough during a certain period of time, GPUs will decrease their power state (which in turn decreases core and memory clock speeds). This can cause the reported GPU time to increase if GPU utilization is kept low enough by a framerate cap (compared to what it would be at the GPU's highest power state). Keep this in mind when benchmarking using [method viewport_get_measured_render_time_gpu]. This behavior can be overridden in the graphics driver settings at the cost of higher power usage.
 			</description>
 		</method>
@@ -4067,7 +4067,7 @@
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="enable" type="bool" />
 			<description>
-				Sets the measurement for the given [param viewport] RID (obtained using [method Viewport.get_viewport_rid]). Once enabled, [method viewport_get_measured_render_time_cpu] and [method viewport_get_measured_render_time_gpu] will return values greater than [code]0.0[/code] when queried with the given [param viewport].
+				Sets the measurement for the given [param viewport] RID (obtained using [method Viewport.get_viewport_rid]). Once enabled, [method viewport_get_measured_render_time_cpu] and [method viewport_get_measured_render_time_gpu] will return values greater than [code]0.0[/code] when queried with the given [param viewport]. See also [member ProjectSettings.rendering/viewport/measure_render_time].
 			</description>
 		</method>
 		<method name="viewport_set_msaa_2d">

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2087,6 +2087,9 @@ SceneTree::SceneTree() {
 	bool snap_2d_vertices = GLOBAL_DEF("rendering/2d/snap/snap_2d_vertices_to_pixel", false);
 	root->set_snap_2d_vertices_to_pixel(snap_2d_vertices);
 
+	const bool measure_render_time = GLOBAL_DEF("rendering/viewport/measure_render_time", false);
+	RS::get_singleton()->viewport_set_measure_render_time(root->get_viewport_rid(), measure_render_time);
+
 	// We setup VRS for the main viewport here, in the editor this will have little effect.
 	const int vrs_mode = GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/vrs/mode", PROPERTY_HINT_ENUM, String::utf8("Disabled,Texture,XR")), 0);
 	root->set_vrs_mode(Viewport::VRSMode(vrs_mode));


### PR DESCRIPTION
When enabled, this makes `RenderingServer.viewport_get_measured_render_time_cpu()` and `RenderingServer.viewport_get_measured_render_time_gpu()` effective without having to manually call `RenderingServer.viewport_set_measure_render_time()` with the root viewport RID as a parameter.

This has a small performance overhead, so only enable render time measurements if you actually query them at runtime:

### 1152×648

Measurements disabled | Measurements enabled (slower)
-|-
![Screenshot_20230327_170859 webp](https://user-images.githubusercontent.com/180032/227987871-c561ba31-8aac-40d0-925c-4dcb5243df03.png) | ![Screenshot_20230327_170929 webp](https://user-images.githubusercontent.com/180032/227987851-88f72efb-d94b-4fa9-9e88-99dc089d0fd7.png)

### 3840×2160

Measurements disabled | Measurements enabled (slower)
-|-
![Screenshot_20230327_170914 webp](https://user-images.githubusercontent.com/180032/227987922-6ad56a70-84f7-4365-815b-65e385b89ba8.png) | ![Screenshot_20230327_170935 webp](https://user-images.githubusercontent.com/180032/227987917-b0b4112c-65dc-4664-8637-f10ccd17e2cd.png)

**Testing project:** [test_measure_render_time_2.zip](https://github.com/godotengine/godot/files/11080347/test_measure_render_time_2.zip)

- This closes https://github.com/godotengine/godot/issues/75346.