### PR TITLE
Update GPUParticles2D/3D speed scale on ENTER_TREE

### DIFF
--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -538,6 +538,11 @@ void GPUParticles2D::_notification(int p_what) {
 			if (sub_emitter != NodePath()) {
 				_attach_sub_emitter();
 			}
+			if (can_process()) {
+				RS::get_singleton()->particles_set_speed_scale(particles, speed_scale);
+			} else {
+				RS::get_singleton()->particles_set_speed_scale(particles, 0);
+			}
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -439,6 +439,11 @@ void GPUParticles3D::_notification(int p_what) {
 			if (sub_emitter != NodePath()) {
 				_attach_sub_emitter();
 			}
+			if (can_process()) {
+				RS::get_singleton()->particles_set_speed_scale(particles, speed_scale);
+			} else {
+				RS::get_singleton()->particles_set_speed_scale(particles, 0);
+			}
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {


### PR DESCRIPTION
Fixes #75218

Pause notifications are not sent when a node is added as a child. So GPUParticles2D/3D should also obey its can_process status on ENTER_TREE, not just PAUSED/UNPAUSED.

**Warning**: This is my first PR for Godot :) 

For GPUParticles2D:

Before:
Particles when running scene w/ disabled parent + inherit 
![anim](https://user-images.githubusercontent.com/205457/228004961-8fa9ce2d-0795-435f-9b61-01241dd687bf.gif)


After:
No particles when running scene w/ disabled parent + inherit 
<img width="981" alt="image" src="https://user-images.githubusercontent.com/205457/228003356-6b3e978a-c76d-4d94-b064-abeab7bb0f37.png">

For GPUParticles3D:
 
Before:
Running, ignoring inheritance of disabled:
![anim-before](https://user-images.githubusercontent.com/205457/228058884-200e3739-d0cd-454e-a32e-6a9116a56184.gif)


After:
Running, obeying inheritance properly:
![anim-after](https://user-images.githubusercontent.com/205457/228058899-d77ab3d8-0323-4618-82d4-f8391f645f29.gif)
