### PR TITLE
Upload artifacts as assets of a tip (nightly/latest) pre-release

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -1,5 +1,6 @@
 name: 🤖 Android Builds
-on: [push, pull_request]
+on:
+  workflow_call:
 
 # Global Settings
 env:

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -1,5 +1,6 @@
 name: 🍏 iOS Builds
-on: [push, pull_request]
+on:
+  workflow_call:
 
 # Global Settings
 env:

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -1,5 +1,6 @@
 name: 🐧 Linux Builds
-on: [push, pull_request]
+on:
+  workflow_call:
 
 # Global Settings
 env:

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -1,5 +1,6 @@
 name: 🍎 macOS Builds
-on: [push, pull_request]
+on:
+  workflow_call:
 
 # Global Settings
 env:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,29 +10,41 @@ concurrency:
 jobs:
 
   static:
-    name: 📊 Static
+    name: '📊 Static'
     uses: ./.github/workflows/static_checks.yml
 
   android:
-    name: 🤖 Android
+    name: '🤖 Android'
     uses: ./.github/workflows/android_builds.yml
 
   ios:
-    name: 🍏 iOS
+    name: '🍏 iOS'
     uses: ./.github/workflows/ios_builds.yml
 
   linux:
-    name: 🐧 Linux
+    name: '🐧 Linux'
     uses: ./.github/workflows/linux_builds.yml
 
   macos:
-    name: 🍎 macOS
+    name: '🍎 macOS'
     uses: ./.github/workflows/macos_builds.yml
 
   web:
-    name: 🌐 Web
+    name: '🌐 Web'
     uses: ./.github/workflows/web_builds.yml
 
   windows:
-    name: 🏁 Windows
+    name: '🏁 Windows'
     uses: ./.github/workflows/windows_builds.yml
+
+  tip:
+    if: (github.event_name != 'pull_request') && (github.ref == 'refs/heads/master')
+    name: '🚀 Update tip'
+    needs:
+      - android
+      - ios
+      - linux
+      - macos
+      - web
+      - windows
+    uses: ./.github/workflows/tip.yml

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,4 +1,4 @@
-name: Pipeline
+name: GHA
 on:
   push:
   pull_request:
@@ -10,29 +10,29 @@ concurrency:
 jobs:
 
   static:
-    name: 📊 Static Checks
+    name: 📊 Static
     uses: ./.github/workflows/static_checks.yml
 
   android:
-    name: 🤖 Android Builds
+    name: 🤖 Android
     uses: ./.github/workflows/android_builds.yml
 
   ios:
-    name: 🍏 iOS Builds
+    name: 🍏 iOS
     uses: ./.github/workflows/ios_builds.yml
 
   linux:
-    name: 🐧 Linux Builds
+    name: 🐧 Linux
     uses: ./.github/workflows/linux_builds.yml
 
   macos:
-    name: 🍎 macOS Builds
+    name: 🍎 macOS
     uses: ./.github/workflows/macos_builds.yml
 
   web:
-    name: 🌐 Web Builds
+    name: 🌐 Web
     uses: ./.github/workflows/web_builds.yml
 
   windows:
-    name: 🏁 Windows Builds
+    name: 🏁 Windows
     uses: ./.github/workflows/windows_builds.yml

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,38 @@
+name: Pipeline
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-pipeline
+  cancel-in-progress: true
+
+jobs:
+
+  static:
+    name: 📊 Static Checks
+    uses: ./.github/workflows/static_checks.yml
+
+  android:
+    name: 🤖 Android Builds
+    uses: ./.github/workflows/android_builds.yml
+
+  ios:
+    name: 🍏 iOS Builds
+    uses: ./.github/workflows/ios_builds.yml
+
+  linux:
+    name: 🐧 Linux Builds
+    uses: ./.github/workflows/linux_builds.yml
+
+  macos:
+    name: 🍎 macOS Builds
+    uses: ./.github/workflows/macos_builds.yml
+
+  web:
+    name: 🌐 Web Builds
+    uses: ./.github/workflows/web_builds.yml
+
+  windows:
+    name: 🏁 Windows Builds
+    uses: ./.github/workflows/windows_builds.yml

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -1,5 +1,6 @@
 name: 📊 Static Checks
-on: [push, pull_request]
+on:
+  workflow_call:
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-static

--- a/.github/workflows/tip.yml
+++ b/.github/workflows/tip.yml
@@ -1,0 +1,58 @@
+name: '🚀 Update tip'
+on:
+  workflow_call:
+
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-tip
+  cancel-in-progress: true
+
+jobs:
+
+  tip:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: '📥 Download artifacts'
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
+      - name: Prepare assets
+        run: |
+          sudo apt update -qq
+          sudo apt install -y coreutils
+
+          mkdir tip
+          cd artifacts
+          tree
+
+          for pkg in \
+            android-template \
+            linux-editor-mono \
+            web-template \
+            windows-editor \
+            windows-template \
+          ; do
+            tar czvf ../tip/"$pkg".tar.gz -C "$pkg" .
+          done
+
+          cp \
+            ios-template/libgodot.ios.template_release.arm64.a \
+            linux-template-minimal/godot.linuxbsd.template_release.x86_64 \
+            linux-template-mono/godot.linuxbsd.template_release.x86_64.mono \
+            macos-editor/godot.macos.editor.x86_64 \
+            macos-template/godot.macos.template_release.x86_64 \
+            ../tip/
+
+          cd ../tip
+          sha256sum * > sha256sums.txt
+          cat sha256sums.txt
+
+      - name: Upload artifacts as assets of pre-release 'tip'
+        run: GITHUB_TOKEN='${{ github.token }}' gh release upload --clobber tip tip/*
+
+      - name: Push tag 'tip' forward
+        run: |
+          git tag tip
+          git push origin +tip

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -1,5 +1,6 @@
 name: 🌐 Web Builds
-on: [push, pull_request]
+on:
+  workflow_call:
 
 # Global Settings
 env:

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -1,5 +1,6 @@
 name: 🏁 Windows Builds
-on: [push, pull_request]
+on:
+  workflow_call:
 
 # Global Settings
 # SCONS_CACHE for windows must be set in the build environment


### PR DESCRIPTION
This PR is based on #75338, which is a duplicate of #65232. Therefore, it is to be kept as a draft until #65232 is rebased and/or merged.

Currently, users can download artifacts from workflows. However, that requires login and it cannot be easily automated because workflow run URLs are not human-readable.  Therefore, they rely on third-party solutions or on manual action to get the pre-built editor and templates with latest fixes.

This PR adds a reusable workflow named `tip.yml` to be executed after all other workflows are finished and successful, as long as the CI run was triggered by a push to branch `master`. This workflow downloads all the artifacts, packages the content, computes the sha256sums and uploads everything as assets of a pre-release named `tip`, which is linked to tag `tip`. After uploading the assets, tag `tip` is updated.

As a result, users will have fixed URLs to download the very latest editor and templates, without requiring login.

Step 'Prepare assets' in this PR is just a naive prototype. I would need advice from some maintainer to properly decide which assets to upload and how to name them.

Related:

- godotengine/godot-proposals#1412
- #42422
- godotengine/godot-proposals#1458

---

Since the tag is updated, the pre-release in https://github.com/godotengine/godot/releases will always point to the commit that last updated the assets, and the description of the pre-release will be the body of that commit. However, the date will be "wrong". It will be the day the pre-release was created (which some maintainer needs to do before merging this PR). It seems that GitHub does not support changing the date of a release; it must be deleted and created again, which is unnacceptable for tip/nightly because it creates too much noise.