### PR TITLE
Changing the curve from cosTheta^5 for the Schlick approx of Fresnel term to cosTheta^1.

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
@@ -266,9 +266,9 @@ void main() {
 		float f0 = mix(0.04, 1.0, metallic); // Assume a "specular" amount of 0.5
 		normal.y = -normal.y;
 		float m = clamp(1.0 - dot(normalize(normal), -view_dir), 0.0, 1.0);
-		float m2 = m * m;
-		m = m2 * m2 * m; // pow(m,5)
-		final_color.a *= f0 + (1.0 - f0) * m; // Fresnel Schlick term.
+
+		// Fresnel Schlick term, but cosTheta^1 instead of ^5 for less aggressive fade of the specular on non-metals.
+		final_color.a *= f0 + (1.0 - f0) * m; 
 
 		imageStore(ssr_image, ssC, final_color);
 


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/75302#issuecomment-1485556668 for details.