### PR TITLE
GDScript: Allow elements of a parent class in a typed array literal

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2373,6 +2373,10 @@ void GDScriptAnalyzer::update_array_literal_element_type(GDScriptParser::ArrayNo
 			continue;
 		}
 		if (!is_type_compatible(p_element_type, element_type, true, p_array)) {
+			if (is_type_compatible(element_type, p_element_type)) {
+				mark_node_unsafe(element_node);
+				continue;
+			}
 			push_error(vformat(R"(Cannot have an element of type "%s" in an array of type "Array[%s]".)", element_type.to_string(), p_element_type.to_string()), element_node);
 			return;
 		}

--- a/modules/gdscript/tests/scripts/analyzer/features/typed_array_usage.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/typed_array_usage.gd
@@ -116,8 +116,8 @@ func test():
 	assert(duplicated_floats.get_typed_builtin() == TYPE_FLOAT)
 
 
-	var b_objects: Array[B] = [B.new(), null]
-	assert(b_objects.size() == 2)
+	var b_objects: Array[B] = [B.new(), B.new() as A, null]
+	assert(b_objects.size() == 3)
 	assert(b_objects.get_typed_builtin() == TYPE_OBJECT)
 	assert(b_objects.get_typed_script() == B)
 

--- a/modules/gdscript/tests/scripts/runtime/errors/typed_array_assign_wrong_to_typed.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/typed_array_assign_wrong_to_typed.gd
@@ -1,0 +1,7 @@
+class Foo: pass
+class Bar extends Foo: pass
+class Baz extends Foo: pass
+
+func test():
+	var typed: Array[Bar] = [Baz.new() as Foo]
+	print('not ok')

--- a/modules/gdscript/tests/scripts/runtime/errors/typed_array_assign_wrong_to_typed.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/typed_array_assign_wrong_to_typed.out
@@ -1,0 +1,7 @@
+GDTEST_RUNTIME_ERROR
+>> ERROR
+>> on function: assign()
+>> core/variant/array.cpp
+>> 222
+>> Method/function failed.
+not ok


### PR DESCRIPTION
```gdscript
func _ready():
  var node: Node = $path
  var controls: Array[Control] = [node] # now allowed, but unsafe
```

This is about array literals. Initially when I made `update_array_literal_element_type` it was strict, but later some changes were requested to make it usable with untyped code. Currently it is allowed to have weakly typed or variants inside the literal. So just like in other places (assignments, passing to arguments and so on) it makes sense to allow super type to be present in the literal, but with unsafe mark.

Closes #75393.