### PR TITLE
C#: Fix memory leak when passing RefCounted objects to C#

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1541,7 +1541,8 @@ void CSharpLanguage::tie_managed_to_unmanaged_with_pre_setup(GCHandleIntPtr p_gc
 	CSharpInstance *instance = CAST_CSHARP_INSTANCE(p_unmanaged->get_script_instance());
 
 	if (!instance) {
-		// Native bindings don't need post-setup
+		// Native bindings don't need post-setup, just release the handle again to avoid leaking the managed object
+		MonoGCHandleData(p_gchandle_intptr, gdmono::GCHandleType::STRONG_HANDLE).release();
 		return;
 	}
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropUtils.cs
@@ -37,14 +37,25 @@ namespace Godot.NativeInterop
             object target = gcHandlePtr != IntPtr.Zero ? GCHandle.FromIntPtr(gcHandlePtr).Target : null;
 
             if (target != null)
+            {
+                NativeFuncs.godotsharp_internal_instance_binding_ensure_weakref(unmanaged, gcHandlePtr);
                 return (GodotObject)target;
+            }
 
             // If the native instance binding GC handle target was collected, create a new one
 
             gcHandlePtr = NativeFuncs.godotsharp_internal_unmanaged_instance_binding_create_managed(
                 unmanaged, gcHandlePtr);
 
-            return gcHandlePtr != IntPtr.Zero ? (GodotObject)GCHandle.FromIntPtr(gcHandlePtr).Target : null;
+            target = gcHandlePtr != IntPtr.Zero ? GCHandle.FromIntPtr(gcHandlePtr).Target : null;
+            if (target != null)
+            {
+                NativeFuncs.godotsharp_internal_instance_binding_ensure_weakref(unmanaged, gcHandlePtr);
+                return (GodotObject)target;
+            }
+
+            // This should be unreachable
+            throw new InvalidOperationException("Failed to get managed instance for unmanaged object.");
         }
 
         public static void TieManagedToUnmanaged(GodotObject managed, IntPtr unmanaged,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -90,6 +90,9 @@ namespace Godot.NativeInterop
         internal static partial IntPtr godotsharp_internal_unmanaged_instance_binding_create_managed(IntPtr p_unmanaged,
             IntPtr oldGCHandlePtr);
 
+        internal static partial void godotsharp_internal_instance_binding_ensure_weakref(IntPtr p_unmanaged,
+            IntPtr oldGCHandlePtr);
+
         internal static partial void godotsharp_internal_new_csharp_script(godot_ref* r_dest);
 
         internal static partial godot_bool godotsharp_internal_script_load(in godot_string p_path, godot_ref* r_dest);


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/71081

If objects are passed to C# a managed wrapper is created for them.
Previously this wrapper was tracked from native by a strong GC handle, keeping it alive but the managed instance also increments the native refcount keeping the native object alive, allowing neither to be freed unless the managed object is manually disposed.

This changes the link to a weak reference so that the managed object can be garbage collected, when no longer references. Unlike scripts, the object the wrapper can be cheaply recreated, so there is no need (or possibility) to do the whole dance of holding a strong reference only when there also is a managed reference to the object.

Also sometimes there was an additional strong handle to the managed wrapper that just got discarded without being released that kept the wrappers alive.

Initially the strong handle is necessary, as during creating there is a moment where that handle is the only reference to the newly created wrapper.

This fix is kinda hacky, but the whole binding handling is in need of a bigger cleanup anyways, so I left it at a minimal fix.

MRP for the issue is actually just calling any method that returns a new RefCounted object a bunch and not disposing the result, eg:
```cs
for (int i = 0; i < 10_000; i++)
	DirAccess.Open("res://");
```