### PR TITLE
added long abs to fix build of vector2i on newlib based platforms

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -191,7 +191,8 @@ public:
 	static _ALWAYS_INLINE_ double abs(double g) { return absd(g); }
 	static _ALWAYS_INLINE_ float abs(float g) { return absf(g); }
 	static _ALWAYS_INLINE_ int abs(int g) { return g > 0 ? g : -g; }
-
+	static _ALWAYS_INLINE_ long abs(long g) { return g > 0 ? g : -g; }
+	
 	static _ALWAYS_INLINE_ double fposmod(double p_x, double p_y) {
 		double value = Math::fmod(p_x, p_y);
 		if (((value < 0) && (p_y > 0)) || ((value > 0) && (p_y < 0))) {


### PR DESCRIPTION
On newlib based platforms (like the 3ds i'm currently working on), int32_t is defined as a long by the compiler. as such NEED_LONG_INT is used to fix the build of Variant, however as vector2i uses int32_t, A long version of abs is required to build properly