### PR TITLE
Add force_draw method for viewports

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -33,6 +33,14 @@
 				Returns the first valid [World3D] for this viewport, searching the [member world_3d] property of itself and any Viewport ancestor.
 			</description>
 		</method>
+		<method name="force_draw">
+			<return type="void" />
+			<param index="0" name="swap_buffers" type="bool" default="false" />
+			<param index="1" name="frame_step" type="float" default="0.0" />
+			<description>
+				Draws this viewport and all of it's child viewports.
+			</description>
+		</method>
 		<method name="get_camera_2d" qualifiers="const">
 			<return type="Camera2D" />
 			<description>

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -8633,7 +8633,7 @@ VkSampleCountFlagBits RenderingDeviceVulkan::_ensure_supported_sample_count(Text
 	return VK_SAMPLE_COUNT_1_BIT;
 }
 
-void RenderingDeviceVulkan::swap_buffers() {
+void RenderingDeviceVulkan::swap_buffers(bool p_swap_buffers) {
 	ERR_FAIL_COND_MSG(local_device.is_valid(), "Local devices can't swap buffers.");
 	_THREAD_SAFE_METHOD_
 
@@ -8641,7 +8641,7 @@ void RenderingDeviceVulkan::swap_buffers() {
 
 	screen_prepared = false;
 	// Swap buffers.
-	context->swap_buffers();
+	context->swap_buffers(p_swap_buffers);
 
 	frame = (frame + 1) % frame_count;
 

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -1249,7 +1249,7 @@ public:
 	void initialize(VulkanContext *p_context, bool p_local_device = false);
 	void finalize();
 
-	virtual void swap_buffers(); // For main device.
+	virtual void swap_buffers(bool p_swap_buffers); // For main device.
 
 	virtual void submit(); // For local device.
 	virtual void sync(); // For local device.

--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -2250,49 +2250,50 @@ Error VulkanContext::prepare_buffers() {
 	vkWaitForFences(device, 1, &fences[frame_index], VK_TRUE, UINT64_MAX);
 	vkResetFences(device, 1, &fences[frame_index]);
 
-	for (KeyValue<int, Window> &E : windows) {
-		Window *w = &E.value;
+	if (!buffers_prepared) {
+		for (KeyValue<int, Window> &E : windows) {
+			Window *w = &E.value;
 
-		w->semaphore_acquired = false;
+			w->semaphore_acquired = false;
 
-		if (w->swapchain == VK_NULL_HANDLE) {
-			continue;
+			if (w->swapchain == VK_NULL_HANDLE) {
+				continue;
+			}
+
+			do {
+				// Get the index of the next available swapchain image.
+				err =
+						fpAcquireNextImageKHR(device, w->swapchain, UINT64_MAX,
+								w->image_acquired_semaphores[frame_index], VK_NULL_HANDLE, &w->current_buffer);
+
+				if (err == VK_ERROR_OUT_OF_DATE_KHR) {
+					// Swapchain is out of date (e.g. the window was resized) and
+					// must be recreated.
+					print_verbose("Vulkan: Early out of date swapchain, recreating.");
+					// resize_notify();
+					_update_swap_chain(w);
+				} else if (err == VK_SUBOPTIMAL_KHR) {
+					// Swapchain is not as optimal as it could be, but the platform's
+					// presentation engine will still present the image correctly.
+					print_verbose("Vulkan: Early suboptimal swapchain, recreating.");
+					Error swap_chain_err = _update_swap_chain(w);
+					if (swap_chain_err == ERR_SKIP) {
+						break;
+					}
+				} else if (err != VK_SUCCESS) {
+					ERR_BREAK_MSG(err != VK_SUCCESS, "Vulkan: Did not create swapchain successfully. Error code: " + String(string_VkResult(err)));
+				} else {
+					w->semaphore_acquired = true;
+				}
+			} while (err != VK_SUCCESS);
 		}
 
-		do {
-			// Get the index of the next available swapchain image.
-			err =
-					fpAcquireNextImageKHR(device, w->swapchain, UINT64_MAX,
-							w->image_acquired_semaphores[frame_index], VK_NULL_HANDLE, &w->current_buffer);
-
-			if (err == VK_ERROR_OUT_OF_DATE_KHR) {
-				// Swapchain is out of date (e.g. the window was resized) and
-				// must be recreated.
-				print_verbose("Vulkan: Early out of date swapchain, recreating.");
-				// resize_notify();
-				_update_swap_chain(w);
-			} else if (err == VK_SUBOPTIMAL_KHR) {
-				// Swapchain is not as optimal as it could be, but the platform's
-				// presentation engine will still present the image correctly.
-				print_verbose("Vulkan: Early suboptimal swapchain, recreating.");
-				Error swap_chain_err = _update_swap_chain(w);
-				if (swap_chain_err == ERR_SKIP) {
-					break;
-				}
-			} else if (err != VK_SUCCESS) {
-				ERR_BREAK_MSG(err != VK_SUCCESS, "Vulkan: Did not create swapchain successfully. Error code: " + String(string_VkResult(err)));
-			} else {
-				w->semaphore_acquired = true;
-			}
-		} while (err != VK_SUCCESS);
+		buffers_prepared = true;
 	}
-
-	buffers_prepared = true;
-
 	return OK;
 }
 
-Error VulkanContext::swap_buffers() {
+Error VulkanContext::swap_buffers(bool p_swap_buffers) {
 	if (!queues_initialized) {
 		return OK;
 	}
@@ -2362,18 +2363,54 @@ Error VulkanContext::swap_buffers() {
 	command_buffer_queue.write[0] = nullptr;
 	command_buffer_count = 1;
 
-	if (separate_present_queue) {
-		// If we are using separate queues, change image ownership to the
-		// present queue before presenting, waiting for the draw complete
-		// semaphore and signaling the ownership released semaphore when finished.
-		VkFence nullFence = VK_NULL_HANDLE;
-		pipe_stage_flags[0] = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-		submit_info.waitSemaphoreCount = 1;
-		submit_info.pWaitSemaphores = &draw_complete_semaphores[frame_index];
-		submit_info.commandBufferCount = 0;
+	if (p_swap_buffers) {
+		if (separate_present_queue) {
+			// If we are using separate queues, change image ownership to the
+			// present queue before presenting, waiting for the draw complete
+			// semaphore and signaling the ownership released semaphore when finished.
+			VkFence nullFence = VK_NULL_HANDLE;
+			pipe_stage_flags[0] = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+			submit_info.waitSemaphoreCount = 1;
+			submit_info.pWaitSemaphores = &draw_complete_semaphores[frame_index];
+			submit_info.commandBufferCount = 0;
 
-		VkCommandBuffer *cmdbufptr = (VkCommandBuffer *)alloca(sizeof(VkCommandBuffer *) * windows.size());
-		submit_info.pCommandBuffers = cmdbufptr;
+			VkCommandBuffer *cmdbufptr = (VkCommandBuffer *)alloca(sizeof(VkCommandBuffer *) * windows.size());
+			submit_info.pCommandBuffers = cmdbufptr;
+
+			for (KeyValue<int, Window> &E : windows) {
+				Window *w = &E.value;
+
+				if (w->swapchain == VK_NULL_HANDLE) {
+					continue;
+				}
+				cmdbufptr[submit_info.commandBufferCount] = w->swapchain_image_resources[w->current_buffer].graphics_to_present_cmd;
+				submit_info.commandBufferCount++;
+			}
+
+			submit_info.signalSemaphoreCount = 1;
+			submit_info.pSignalSemaphores = &image_ownership_semaphores[frame_index];
+			err = vkQueueSubmit(present_queue, 1, &submit_info, nullFence);
+			ERR_FAIL_COND_V_MSG(err, ERR_CANT_CREATE, "Vulkan: Cannot submit present queue. Error code: " + String(string_VkResult(err)));
+		}
+
+		// If we are using separate queues, we have to wait for image ownership,
+		// otherwise wait for draw complete.
+		VkPresentInfoKHR present = {
+			/*sType*/ VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
+			/*pNext*/ nullptr,
+			/*waitSemaphoreCount*/ 1,
+			/*pWaitSemaphores*/ (separate_present_queue) ? &image_ownership_semaphores[frame_index] : &draw_complete_semaphores[frame_index],
+			/*swapchainCount*/ 0,
+			/*pSwapchain*/ nullptr,
+			/*pImageIndices*/ nullptr,
+			/*pResults*/ nullptr,
+		};
+
+		VkSwapchainKHR *pSwapchains = (VkSwapchainKHR *)alloca(sizeof(VkSwapchainKHR *) * windows.size());
+		uint32_t *pImageIndices = (uint32_t *)alloca(sizeof(uint32_t *) * windows.size());
+
+		present.pSwapchains = pSwapchains;
+		present.pImageIndices = pImageIndices;
 
 		for (KeyValue<int, Window> &E : windows) {
 			Window *w = &E.value;
@@ -2381,133 +2418,99 @@ Error VulkanContext::swap_buffers() {
 			if (w->swapchain == VK_NULL_HANDLE) {
 				continue;
 			}
-			cmdbufptr[submit_info.commandBufferCount] = w->swapchain_image_resources[w->current_buffer].graphics_to_present_cmd;
-			submit_info.commandBufferCount++;
+			pSwapchains[present.swapchainCount] = w->swapchain;
+			pImageIndices[present.swapchainCount] = w->current_buffer;
+			present.swapchainCount++;
 		}
-
-		submit_info.signalSemaphoreCount = 1;
-		submit_info.pSignalSemaphores = &image_ownership_semaphores[frame_index];
-		err = vkQueueSubmit(present_queue, 1, &submit_info, nullFence);
-		ERR_FAIL_COND_V_MSG(err, ERR_CANT_CREATE, "Vulkan: Cannot submit present queue. Error code: " + String(string_VkResult(err)));
-	}
-
-	// If we are using separate queues, we have to wait for image ownership,
-	// otherwise wait for draw complete.
-	VkPresentInfoKHR present = {
-		/*sType*/ VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
-		/*pNext*/ nullptr,
-		/*waitSemaphoreCount*/ 1,
-		/*pWaitSemaphores*/ (separate_present_queue) ? &image_ownership_semaphores[frame_index] : &draw_complete_semaphores[frame_index],
-		/*swapchainCount*/ 0,
-		/*pSwapchain*/ nullptr,
-		/*pImageIndices*/ nullptr,
-		/*pResults*/ nullptr,
-	};
-
-	VkSwapchainKHR *pSwapchains = (VkSwapchainKHR *)alloca(sizeof(VkSwapchainKHR *) * windows.size());
-	uint32_t *pImageIndices = (uint32_t *)alloca(sizeof(uint32_t *) * windows.size());
-
-	present.pSwapchains = pSwapchains;
-	present.pImageIndices = pImageIndices;
-
-	for (KeyValue<int, Window> &E : windows) {
-		Window *w = &E.value;
-
-		if (w->swapchain == VK_NULL_HANDLE) {
-			continue;
-		}
-		pSwapchains[present.swapchainCount] = w->swapchain;
-		pImageIndices[present.swapchainCount] = w->current_buffer;
-		present.swapchainCount++;
-	}
 
 #if 0
-	if (is_device_extension_enabled(VK_KHR_incremental_present_enabled)) {
-		// If using VK_KHR_incremental_present, we provide a hint of the region
-		// that contains changed content relative to the previously-presented
-		// image.  The implementation can use this hint in order to save
-		// work/power (by only copying the region in the hint).  The
-		// implementation is free to ignore the hint though, and so we must
-		// ensure that the entire image has the correctly-drawn content.
-		uint32_t eighthOfWidth = width / 8;
-		uint32_t eighthOfHeight = height / 8;
-		VkRectLayerKHR rect = {
-			/*offset.x*/ eighthOfWidth,
-			/*offset.y*/ eighthOfHeight,
-			/*extent.width*/ eighthOfWidth * 6,
-			/*extent.height*/ eighthOfHeight * 6,
-			/*layer*/ 0,
-		};
-		VkPresentRegionKHR region = {
-			/*rectangleCount*/ 1,
-			/*pRectangles*/ &rect,
-		};
-		VkPresentRegionsKHR regions = {
-			/*sType*/ VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR,
-			/*pNext*/ present.pNext,
-			/*swapchainCount*/ present.swapchainCount,
-			/*pRegions*/ &region,
-		};
-		present.pNext = &regions;
-	}
+		if (is_device_extension_enabled(VK_KHR_incremental_present_enabled)) {
+			// If using VK_KHR_incremental_present, we provide a hint of the region
+			// that contains changed content relative to the previously-presented
+			// image.  The implementation can use this hint in order to save
+			// work/power (by only copying the region in the hint).  The
+			// implementation is free to ignore the hint though, and so we must
+			// ensure that the entire image has the correctly-drawn content.
+			uint32_t eighthOfWidth = width / 8;
+			uint32_t eighthOfHeight = height / 8;
+			VkRectLayerKHR rect = {
+				/*offset.x*/ eighthOfWidth,
+				/*offset.y*/ eighthOfHeight,
+				/*extent.width*/ eighthOfWidth * 6,
+				/*extent.height*/ eighthOfHeight * 6,
+				/*layer*/ 0,
+			};
+			VkPresentRegionKHR region = {
+				/*rectangleCount*/ 1,
+				/*pRectangles*/ &rect,
+			};
+			VkPresentRegionsKHR regions = {
+				/*sType*/ VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR,
+				/*pNext*/ present.pNext,
+				/*swapchainCount*/ present.swapchainCount,
+				/*pRegions*/ &region,
+			};
+			present.pNext = &regions;
+		}
 #endif
 
 #if 0
-	if (is_device_extension_enabled(VK_GOOGLE_DISPLAY_TIMING_EXTENSION_NAME)) {
-		VkPresentTimeGOOGLE ptime;
-		if (prev_desired_present_time == 0) {
-			// This must be the first present for this swapchain.
-			//
-			// We don't know where we are relative to the presentation engine's
-			// display's refresh cycle.  We also don't know how long rendering
-			// takes.  Let's make a grossly-simplified assumption that the
-			// desiredPresentTime should be half way between now and
-			// now+target_IPD.  We will adjust over time.
-			uint64_t curtime = getTimeInNanoseconds();
-			if (curtime == 0) {
-				// Since we didn't find out the current time, don't give a
-				// desiredPresentTime.
-				ptime.desiredPresentTime = 0;
-			} else {
-				ptime.desiredPresentTime = curtime + (target_IPD >> 1);
-			}
-		} else {
-			ptime.desiredPresentTime = (prev_desired_present_time + target_IPD);
-		}
-		ptime.presentID = next_present_id++;
-		prev_desired_present_time = ptime.desiredPresentTime;
-
-		VkPresentTimesInfoGOOGLE present_time = {
-			/*sType*/ VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE,
-			/*pNext*/ present.pNext,
-			/*swapchainCount*/ present.swapchainCount,
-			/*pTimes*/ &ptime,
-		};
 		if (is_device_extension_enabled(VK_GOOGLE_DISPLAY_TIMING_EXTENSION_NAME)) {
-			present.pNext = &present_time;
+			VkPresentTimeGOOGLE ptime;
+			if (prev_desired_present_time == 0) {
+				// This must be the first present for this swapchain.
+				//
+				// We don't know where we are relative to the presentation engine's
+				// display's refresh cycle.  We also don't know how long rendering
+				// takes.  Let's make a grossly-simplified assumption that the
+				// desiredPresentTime should be half way between now and
+				// now+target_IPD.  We will adjust over time.
+				uint64_t curtime = getTimeInNanoseconds();
+				if (curtime == 0) {
+					// Since we didn't find out the current time, don't give a
+					// desiredPresentTime.
+					ptime.desiredPresentTime = 0;
+				} else {
+					ptime.desiredPresentTime = curtime + (target_IPD >> 1);
+				}
+			} else {
+				ptime.desiredPresentTime = (prev_desired_present_time + target_IPD);
+			}
+			ptime.presentID = next_present_id++;
+			prev_desired_present_time = ptime.desiredPresentTime;
+
+			VkPresentTimesInfoGOOGLE present_time = {
+				/*sType*/ VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE,
+				/*pNext*/ present.pNext,
+				/*swapchainCount*/ present.swapchainCount,
+				/*pTimes*/ &ptime,
+			};
+			if (is_device_extension_enabled(VK_GOOGLE_DISPLAY_TIMING_EXTENSION_NAME)) {
+				present.pNext = &present_time;
+			}
 		}
-	}
 #endif
-	//	print_line("current buffer:  " + itos(current_buffer));
-	err = fpQueuePresentKHR(present_queue, &present);
+		//print_line("current buffer:  " + itos(current_buffer));
+		err = fpQueuePresentKHR(present_queue, &present);
 
-	frame_index += 1;
-	frame_index %= FRAME_LAG;
+		frame_index += 1;
+		frame_index %= FRAME_LAG;
 
-	if (err == VK_ERROR_OUT_OF_DATE_KHR) {
-		// Swapchain is out of date (e.g. the window was resized) and
-		// must be recreated.
-		print_verbose("Vulkan queue submit: Swapchain is out of date, recreating.");
-		resize_notify();
-	} else if (err == VK_SUBOPTIMAL_KHR) {
-		// Swapchain is not as optimal as it could be, but the platform's
-		// presentation engine will still present the image correctly.
-		print_verbose("Vulkan queue submit: Swapchain is suboptimal.");
-	} else {
-		ERR_FAIL_COND_V_MSG(err, ERR_CANT_CREATE, "Error code: " + String(string_VkResult(err)));
+		if (err == VK_ERROR_OUT_OF_DATE_KHR) {
+			// Swapchain is out of date (e.g. the window was resized) and
+			// must be recreated.
+			print_verbose("Vulkan queue submit: Swapchain is out of date, recreating.");
+			resize_notify();
+		} else if (err == VK_SUBOPTIMAL_KHR) {
+			// Swapchain is not as optimal as it could be, but the platform's
+			// presentation engine will still present the image correctly.
+			print_verbose("Vulkan queue submit: Swapchain is suboptimal.");
+		} else {
+			ERR_FAIL_COND_V_MSG(err, ERR_CANT_CREATE, "Error code: " + String(string_VkResult(err)));
+		}
+
+		buffers_prepared = false;
 	}
-
-	buffers_prepared = false;
 	return OK;
 }
 

--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -323,7 +323,7 @@ public:
 	void resize_notify();
 	void flush(bool p_flush_setup = false, bool p_flush_pending = false);
 	Error prepare_buffers();
-	Error swap_buffers();
+	Error swap_buffers(bool p_swap_buffers);
 	Error initialize();
 
 	void command_begin_label(VkCommandBuffer p_command_buffer, String p_label_name, const Color p_color);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -913,6 +913,10 @@ void Viewport::_process_picking() {
 	}
 }
 
+void Viewport::force_draw_viewport(bool p_swap_buffers, double frame_step) {
+	RS::get_singleton()->draw_viewport(&viewport, p_swap_buffers, frame_step);
+}
+
 RID Viewport::get_viewport_rid() const {
 	ERR_READ_THREAD_GUARD_V(RID());
 	return viewport;
@@ -4227,6 +4231,8 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_mesh_lod_threshold"), &Viewport::get_mesh_lod_threshold);
 
 	ClassDB::bind_method(D_METHOD("_process_picking"), &Viewport::_process_picking);
+
+	ClassDB::bind_method(D_METHOD("force_draw", "swap_buffers", "frame_step"), &Viewport::force_draw_viewport, DEFVAL(false), DEFVAL(0.0));
 
 #ifndef _3D_DISABLED
 	ClassDB::bind_method(D_METHOD("set_world_3d", "world_3d"), &Viewport::set_world_3d);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -633,6 +633,8 @@ public:
 	void set_default_canvas_item_texture_repeat(DefaultCanvasItemTextureRepeat p_repeat);
 	DefaultCanvasItemTextureRepeat get_default_canvas_item_texture_repeat() const;
 
+	void force_draw_viewport(bool p_swap_buffers = false, double frame_step = 0.0);
+
 	// VRS
 
 	void set_vrs_mode(VRSMode p_vrs_mode);

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -102,8 +102,7 @@ void RendererCompositorRD::begin_frame(double frame_step) {
 }
 
 void RendererCompositorRD::end_frame(bool p_swap_buffers) {
-	// TODO: Likely pass a bool to swap buffers to avoid display?
-	RD::get_singleton()->swap_buffers();
+	RD::get_singleton()->swap_buffers(p_swap_buffers);
 }
 
 void RendererCompositorRD::initialize() {
@@ -243,7 +242,7 @@ void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color
 
 	RD::get_singleton()->draw_list_end();
 
-	RD::get_singleton()->swap_buffers();
+	RD::get_singleton()->swap_buffers(true);
 
 	texture_storage->texture_free(texture);
 	RD::get_singleton()->free(sampler);

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -198,6 +198,8 @@ public:
 
 private:
 	Vector<Viewport *> _sort_active_viewports();
+	Vector<RendererViewport::Viewport *> _sort_active_viewports_of_viewport(RendererViewport::Viewport *viewport);
+	Vector<RendererViewport::Viewport *> _sort_active_viewports_of_viewports(List<RendererViewport::Viewport *> &nodes);
 	void _viewport_set_size(Viewport *p_viewport, int p_width, int p_height, uint32_t p_view_count);
 	void _configure_3d_render_buffers(Viewport *p_viewport);
 	void _draw_3d(Viewport *p_viewport);
@@ -292,7 +294,7 @@ public:
 	void handle_timestamp(String p_timestamp, uint64_t p_cpu_time, uint64_t p_gpu_time);
 
 	void set_default_clear_color(const Color &p_color);
-	void draw_viewports();
+	void draw_viewports(RID *p_viewport);
 
 	bool free(RID p_rid);
 

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1273,7 +1273,7 @@ public:
 	//methods below not exposed, used by RenderingDeviceRD
 	virtual void prepare_screen_for_drawing() = 0;
 
-	virtual void swap_buffers() = 0;
+	virtual void swap_buffers(bool p_swap_buffers) = 0;
 
 	virtual uint32_t get_frame_delay() const = 0;
 

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -69,6 +69,10 @@ void RenderingServerDefault::request_frame_drawn_callback(const Callable &p_call
 }
 
 void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
+	_draw_viewport(NULL, p_swap_buffers, frame_step);
+}
+
+void RenderingServerDefault::_draw_viewport(RID *p_viewport, bool p_swap_buffers, double frame_step) {
 	//needs to be done before changes is reset to 0, to not force the editor to redraw
 	RS::get_singleton()->emit_signal(SNAME("frame_pre_draw"));
 
@@ -88,7 +92,7 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 
 	RSG::scene->render_probes();
 
-	RSG::viewport->draw_viewports();
+	RSG::viewport->draw_viewports(p_viewport);
 	RSG::canvas_render->update();
 
 	if (OS::get_singleton()->get_current_rendering_driver_name() != "opengl3") {
@@ -353,6 +357,10 @@ void RenderingServerDefault::_thread_draw(bool p_swap_buffers, double frame_step
 	_draw(p_swap_buffers, frame_step);
 }
 
+void RenderingServerDefault::_thread_draw_viewport(RID *p_viewport, bool p_swap_buffers, double frame_step) {
+	_draw_viewport(p_viewport, p_swap_buffers, frame_step);
+}
+
 void RenderingServerDefault::_thread_flush() {
 }
 
@@ -395,6 +403,14 @@ void RenderingServerDefault::draw(bool p_swap_buffers, double frame_step) {
 		command_queue.push(this, &RenderingServerDefault::_thread_draw, p_swap_buffers, frame_step);
 	} else {
 		_draw(p_swap_buffers, frame_step);
+	}
+}
+
+void RenderingServerDefault::draw_viewport(RID *p_viewport, bool p_swap_buffers, double frame_step) {
+	if (create_thread) {
+		command_queue.push(this, &RenderingServerDefault::_thread_draw_viewport, p_viewport, p_swap_buffers, frame_step);
+	} else {
+		_draw_viewport(p_viewport, p_swap_buffers, frame_step);
 	}
 }
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -85,6 +85,7 @@ class RenderingServerDefault : public RenderingServer {
 	bool create_thread;
 
 	void _thread_draw(bool p_swap_buffers, double frame_step);
+	void _thread_draw_viewport(RID *p_viewport, bool p_swap_buffers, double frame_step);
 	void _thread_flush();
 
 	void _thread_exit();
@@ -92,6 +93,7 @@ class RenderingServerDefault : public RenderingServer {
 	Mutex alloc_mutex;
 
 	void _draw(bool p_swap_buffers, double frame_step);
+	void _draw_viewport(RID *p_viewport, bool p_swap_buffers, double frame_step);
 	void _init();
 	void _finish();
 
@@ -965,6 +967,7 @@ public:
 	virtual void request_frame_drawn_callback(const Callable &p_callable) override;
 
 	virtual void draw(bool p_swap_buffers, double frame_step) override;
+	virtual void draw_viewport(RID *p_viewport, bool p_swap_buffers, double frame_step) override;
 	virtual void sync() override;
 	virtual bool has_changed() const override;
 	virtual void init() override;

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1519,6 +1519,7 @@ public:
 	virtual void request_frame_drawn_callback(const Callable &p_callable) = 0;
 
 	virtual void draw(bool p_swap_buffers = true, double frame_step = 0.0) = 0;
+	virtual void draw_viewport(RID *p_viewport, bool p_swap_buffers = true, double frame_step = 0.0) = 0;
 	virtual void sync() = 0;
 	virtual bool has_changed() const = 0;
 	virtual void init();


### PR DESCRIPTION
Implements a `force_draw` method for viewports, which allows to update an individual viewport and it's children manually.

This method works similarly to `RenderingServer.force_draw`, but instead of drawing all active viewports it affects only a given subset.

- *Bugsquad edit: This closes godotengine/godot-proposals#1010.*