### PR TITLE
Docs: Fix SurfaceTool example caps typo

### DIFF
--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -17,7 +17,7 @@
 		var st = new SurfaceTool();
 		st.Begin(Mesh.PrimitiveType.Triangles);
 		st.SetColor(new Color(1, 0, 0));
-		st.SetUv(new Vector2(0, 0));
+		st.SetUV(new Vector2(0, 0));
 		st.AddVertex(new Vector3(0, 0, 0));
 		[/csharp]
 		[/codeblocks]


### PR DESCRIPTION
Example wasn't valid

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
