### PR TITLE
Add `inner_item_margin_*` Theme constants to the Tree control

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -542,6 +542,18 @@
 		<theme_item name="icon_max_width" data_type="constant" type="int" default="0">
 			The maximum allowed width of the icon in item's cells. This limit is applied on top of the default size of the icon, but before the value set with [method TreeItem.set_icon_max_width]. The height is adjusted according to the icon's ratio.
 		</theme_item>
+		<theme_item name="inner_item_margin_bottom" data_type="constant" type="int" default="0">
+			The inner bottom margin of an item.
+		</theme_item>
+		<theme_item name="inner_item_margin_left" data_type="constant" type="int" default="0">
+			The inner left margin of an item.
+		</theme_item>
+		<theme_item name="inner_item_margin_right" data_type="constant" type="int" default="0">
+			The inner right margin of an item.
+		</theme_item>
+		<theme_item name="inner_item_margin_top" data_type="constant" type="int" default="0">
+			The inner top margin of an item.
+		</theme_item>
 		<theme_item name="item_margin" data_type="constant" type="int" default="16">
 			The horizontal margin at the start of an item. This is used when folding is enabled for the item.
 		</theme_item>

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1240,6 +1240,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_constant("h_separation", "Tree", 6 * EDSCALE);
 	theme->set_constant("guide_width", "Tree", border_width);
 	theme->set_constant("item_margin", "Tree", 3 * default_margin_size * EDSCALE);
+	theme->set_constant("inner_item_margin_bottom", "Tree", (default_margin_size + extra_spacing) * EDSCALE);
+	theme->set_constant("inner_item_margin_left", "Tree", (default_margin_size + extra_spacing) * EDSCALE);
+	theme->set_constant("inner_item_margin_right", "Tree", (default_margin_size + extra_spacing) * EDSCALE);
+	theme->set_constant("inner_item_margin_top", "Tree", (default_margin_size + extra_spacing) * EDSCALE);
 	theme->set_constant("button_margin", "Tree", default_margin_size * EDSCALE);
 	theme->set_constant("scroll_border", "Tree", 40 * EDSCALE);
 	theme->set_constant("scroll_speed", "Tree", 12);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1652,6 +1652,10 @@ void Tree::_update_theme_item_cache() {
 	theme_cache.drop_position_color = get_theme_color(SNAME("drop_position_color"));
 	theme_cache.h_separation = get_theme_constant(SNAME("h_separation"));
 	theme_cache.v_separation = get_theme_constant(SNAME("v_separation"));
+	theme_cache.inner_item_margin_bottom = get_theme_constant(SNAME("inner_item_margin_bottom"));
+	theme_cache.inner_item_margin_left = get_theme_constant(SNAME("inner_item_margin_left"));
+	theme_cache.inner_item_margin_right = get_theme_constant(SNAME("inner_item_margin_right"));
+	theme_cache.inner_item_margin_top = get_theme_constant(SNAME("inner_item_margin_top"));
 	theme_cache.item_margin = get_theme_constant(SNAME("item_margin"));
 	theme_cache.button_margin = get_theme_constant(SNAME("button_margin"));
 	theme_cache.icon_max_width = get_theme_constant(SNAME("icon_max_width"));
@@ -1789,13 +1793,14 @@ int Tree::get_item_height(TreeItem *p_item) const {
 void Tree::draw_item_rect(TreeItem::Cell &p_cell, const Rect2i &p_rect, const Color &p_color, const Color &p_icon_color, int p_ol_size, const Color &p_ol_color) {
 	ERR_FAIL_COND(theme_cache.font.is_null());
 
-	Rect2i rect = p_rect;
+	Rect2i rect = p_rect.grow_individual(-theme_cache.inner_item_margin_left, -theme_cache.inner_item_margin_top, -theme_cache.inner_item_margin_right, -theme_cache.inner_item_margin_bottom);
 	Size2 ts = p_cell.text_buf->get_size();
 	bool rtl = is_layout_rtl();
 
 	int w = 0;
+	Size2i bmsize;
 	if (!p_cell.icon.is_null()) {
-		Size2i bmsize = _get_cell_icon_size(p_cell);
+		bmsize = _get_cell_icon_size(p_cell);
 		w += bmsize.width + theme_cache.h_separation;
 		if (rect.size.width > 0 && (w + ts.width) > rect.size.width) {
 			ts.width = rect.size.width - w;
@@ -1834,8 +1839,6 @@ void Tree::draw_item_rect(TreeItem::Cell &p_cell, const Rect2i &p_rect, const Co
 	}
 
 	if (!p_cell.icon.is_null()) {
-		Size2i bmsize = _get_cell_icon_size(p_cell);
-
 		p_cell.draw_icon(ci, rect.position + Size2i(0, Math::floor((real_t)(rect.size.y - bmsize.y) / 2)), bmsize, p_icon_color);
 		rect.position.x += bmsize.x + theme_cache.h_separation;
 		rect.size.x -= bmsize.x + theme_cache.h_separation;

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -547,6 +547,10 @@ private:
 
 		int h_separation = 0;
 		int v_separation = 0;
+		int inner_item_margin_bottom = 0;
+		int inner_item_margin_left = 0;
+		int inner_item_margin_right = 0;
+		int inner_item_margin_top = 0;
 		int item_margin = 0;
 		int button_margin = 0;
 		int icon_max_width = 0;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -774,6 +774,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("h_separation", "Tree", 4 * scale);
 	theme->set_constant("v_separation", "Tree", 4 * scale);
 	theme->set_constant("item_margin", "Tree", 16 * scale);
+	theme->set_constant("inner_item_margin_bottom", "Tree", 0);
+	theme->set_constant("inner_item_margin_left", "Tree", 0);
+	theme->set_constant("inner_item_margin_right", "Tree", 0);
+	theme->set_constant("inner_item_margin_top", "Tree", 0);
 	theme->set_constant("button_margin", "Tree", 4 * scale);
 	theme->set_constant("draw_relationship_lines", "Tree", 0);
 	theme->set_constant("relationship_line_width", "Tree", 1);


### PR DESCRIPTION
## Description
This PR adds the "inner_item_margin" Theme constant to the Tree Control.
It behaves like a horizontal padding (in CSS), but only in the active
writing direction (So on LTR it'll apply a left padding and on RTL right
padding).

This PR also makes use of this newly added feature to adjust the Editor Theme.
Previously, icons, like the ones in the FileSystemDock or even in the SceneTree, didn't have proper spacing between borders and would therefore appear too close to them, which was specially noticeable with large Corner Radius values, such as 6.

## Comparisons

### Currently (pre-PR)
![image](https://user-images.githubusercontent.com/37230465/222823334-10a53232-a610-4a4c-b170-bdd9202e2ca9.png)
*File System Dock*

![image](https://user-images.githubusercontent.com/37230465/222824464-4f334f6b-8784-4bd0-bf8f-e8ab890359a3.png)
*File System Dock in RTL*

### With PR
![image](https://user-images.githubusercontent.com/37230465/222823632-ffea51ae-fa8c-43f4-aecb-8699bd864a90.png)
*File System Dock*


![image](https://user-images.githubusercontent.com/37230465/222824309-6ad0d32f-c290-4958-841f-efb7877943ed.png)
*File System Dock in RTL*

Note 2: This superseeds my [first PR](https://github.com/godotengine/godot/pull/74301) and also my [second PR](https://github.com/godotengine/godot/pull/74321)