### PR TITLE
Use `MODELVIEW_MATRIX` when on double precision

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -360,7 +360,7 @@ void vertex_shader(in uint instance_index, in bool is_multimesh, in uint multime
 		vertex = mat3(matrix) * vertex;
 		model_origin = double_add_vec3(model_origin, model_precision, matrix[3].xyz, vec3(0.0), model_precision);
 	}
-	vertex = mat3(model_matrix) * vertex;
+	vertex = mat3(inv_view_matrix * modelview) * vertex;
 	vec3 temp_precision; // Will be ignored.
 	vertex += double_add_vec3(model_origin, model_precision, scene_data.inv_view_matrix[3].xyz, view_precision, temp_precision);
 	vertex = mat3(scene_data.view_matrix) * vertex;

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -347,8 +347,6 @@ void main() {
 #CODE : VERTEX
 	}
 
-	/* output */
-
 // using local coordinates (default)
 #if !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
 
@@ -361,7 +359,7 @@ void main() {
 		vertex = mat3(matrix) * vertex;
 		model_origin = double_add_vec3(model_origin, model_precision, matrix[3].xyz, vec3(0.0), model_precision);
 	}
-	vertex = mat3(model_matrix) * vertex;
+	vertex = mat3(inv_view_matrix * modelview) * vertex;
 	vec3 temp_precision;
 	vertex += double_add_vec3(model_origin, model_precision, scene_data.inv_view_matrix[3].xyz, view_precision, temp_precision);
 	vertex = mat3(scene_data.view_matrix) * vertex;


### PR DESCRIPTION
## Description

This commit updates the double precision vertex transform code to use the MODELVIEW_MATRIX instead of the MODEL_MATRIX.

This is done by transforming the MODELVIEW_MATRIX back into model space and then using it as if it were the MODEL_MATRIX.

With this in place we now properly handle VERTEX transformations that a Material Shader might do, such as billboard-ing.
This also fixes https://github.com/godotengine/godot/issues/75433.

## Comparisons
(All done using https://github.com/godotengine/godot-demo-projects/pull/894)


With this fix + double precision
https://user-images.githubusercontent.com/37230465/228559865-947ef102-f430-45b4-b437-7b3ebc8b16a4.mp4
It does jitter quite a bit on the farthest setting, but that happens regardless of this fix, so it doesn't seem like a regression.

Without this fix + double precision
https://user-images.githubusercontent.com/37230465/228562053-12cbea3c-2387-4985-b39e-25959011434d.mp4
Same jittering, but effects like billboarding stops working.




