### PR TITLE
[MP] Implement "watched" properties (reliable/on change).

### DIFF
--- a/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
+++ b/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
@@ -51,6 +51,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="delta_interval" type="float" setter="set_delta_interval" getter="get_delta_interval" default="0.0">
+			Time interval between delta synchronizations. When set to [code]0.0[/code] (the default), delta synchronizations happen every network process frame.
+		</member>
 		<member name="public_visibility" type="bool" setter="set_visibility_public" getter="is_visibility_public" default="true">
 			Whether synchronization should be visible to all peers by default. See [method set_visibility_for] and [method add_visibility_filter] for ways of configuring fine-grained visibility options.
 		</member>
@@ -58,7 +61,7 @@
 			Resource containing which properties to synchronize.
 		</member>
 		<member name="replication_interval" type="float" setter="set_replication_interval" getter="get_replication_interval" default="0.0">
-			Time interval between synchronizes. When set to [code]0.0[/code] (the default), synchronizes happen every network process frame.
+			Time interval between synchronizations. When set to [code]0.0[/code] (the default), synchronizations happen every network process frame.
 		</member>
 		<member name="root_path" type="NodePath" setter="set_root_path" getter="get_root_path" default="NodePath(&quot;..&quot;)">
 			Node path that replicated properties are relative to.
@@ -69,9 +72,14 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="delta_synchronized">
+			<description>
+				Emitted when a new delta synchronization state is received by this synchronizer after the properties have been updated.
+			</description>
+		</signal>
 		<signal name="synchronized">
 			<description>
-				Emitted when a new synchronization state is received by this synchronizer after the variables have been updated.
+				Emitted when a new synchronization state is received by this synchronizer after the properties have been updated.
 			</description>
 		</signal>
 		<signal name="visibility_changed">

--- a/modules/multiplayer/doc_classes/SceneMultiplayer.xml
+++ b/modules/multiplayer/doc_classes/SceneMultiplayer.xml
@@ -70,6 +70,12 @@
 		<member name="auth_timeout" type="float" setter="set_auth_timeout" getter="get_auth_timeout" default="3.0">
 			If set to a value greater than [code]0.0[/code], the maximum amount of time peers can stay in the authenticating state, after which the authentication will automatically fail. See the [signal peer_authenticating] and [signal peer_authentication_failed] signals.
 		</member>
+		<member name="max_delta_packet_size" type="int" setter="set_max_delta_packet_size" getter="get_max_delta_packet_size" default="65535">
+			Maximum size of each delta packet. Higher values increase the chance of receiving full updates in a single frame, but also the chance of causing networking congestion (higher latency, disconnections). See [MultiplayerSynchronizer].
+		</member>
+		<member name="max_sync_packet_size" type="int" setter="set_max_sync_packet_size" getter="get_max_sync_packet_size" default="1350">
+			Maximum size of each synchronization packet. Higher values increase the chance of receiving full updates in a single frame, but also the chance of packet loss. See [MultiplayerSynchronizer].
+		</member>
 		<member name="refuse_new_connections" type="bool" setter="set_refuse_new_connections" getter="is_refusing_new_connections" default="false">
 			If [code]true[/code], the MultiplayerAPI's [member MultiplayerAPI.multiplayer_peer] refuses new incoming connections.
 		</member>

--- a/modules/multiplayer/doc_classes/SceneReplicationConfig.xml
+++ b/modules/multiplayer/doc_classes/SceneReplicationConfig.xml
@@ -50,6 +50,13 @@
 				Returns whether the property identified by the given [param path] is configured to be synchronized on process.
 			</description>
 		</method>
+		<method name="property_get_watch">
+			<return type="bool" />
+			<param index="0" name="path" type="NodePath" />
+			<description>
+				Returns whether the property identified by the given [code]path[/code] is configured to be reliably synchronized when changes are detected on process.
+			</description>
+		</method>
 		<method name="property_set_spawn">
 			<return type="void" />
 			<param index="0" name="path" type="NodePath" />
@@ -64,6 +71,14 @@
 			<param index="1" name="enabled" type="bool" />
 			<description>
 				Sets whether the property identified by the given [param path] is configured to be synchronized on process.
+			</description>
+		</method>
+		<method name="property_set_watch">
+			<return type="void" />
+			<param index="0" name="path" type="NodePath" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+				Sets whether the property identified by the given [code]path[/code] is configured to be reliably synchronized when changes are detected on process.
 			</description>
 		</method>
 		<method name="remove_property">

--- a/modules/multiplayer/editor/replication_editor.h
+++ b/modules/multiplayer/editor/replication_editor.h
@@ -76,7 +76,7 @@ private:
 	void _update_checked(const NodePath &p_prop, int p_column, bool p_checked);
 	void _update_config();
 	void _dialog_closed(bool p_confirmed);
-	void _add_property(const NodePath &p_property, bool p_spawn = true, bool p_sync = true);
+	void _add_property(const NodePath &p_property, bool p_spawn = true, bool p_sync = true, bool p_watch = false);
 
 	void _pick_node_filter_text_changed(const String &p_newtext);
 	void _pick_node_select_recursive(TreeItem *p_item, const String &p_filter, Vector<Node *> &p_select_candidates);

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -617,6 +617,22 @@ bool SceneMultiplayer::is_server_relay_enabled() const {
 	return server_relay;
 }
 
+void SceneMultiplayer::set_max_sync_packet_size(int p_size) {
+	replicator->set_max_sync_packet_size(p_size);
+}
+
+int SceneMultiplayer::get_max_sync_packet_size() const {
+	return replicator->get_max_sync_packet_size();
+}
+
+void SceneMultiplayer::set_max_delta_packet_size(int p_size) {
+	replicator->set_max_delta_packet_size(p_size);
+}
+
+int SceneMultiplayer::get_max_delta_packet_size() const {
+	return replicator->get_max_delta_packet_size();
+}
+
 void SceneMultiplayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_root_path", "path"), &SceneMultiplayer::set_root_path);
 	ClassDB::bind_method(D_METHOD("get_root_path"), &SceneMultiplayer::get_root_path);
@@ -641,12 +657,19 @@ void SceneMultiplayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_server_relay_enabled"), &SceneMultiplayer::is_server_relay_enabled);
 	ClassDB::bind_method(D_METHOD("send_bytes", "bytes", "id", "mode", "channel"), &SceneMultiplayer::send_bytes, DEFVAL(MultiplayerPeer::TARGET_PEER_BROADCAST), DEFVAL(MultiplayerPeer::TRANSFER_MODE_RELIABLE), DEFVAL(0));
 
+	ClassDB::bind_method(D_METHOD("get_max_sync_packet_size"), &SceneMultiplayer::get_max_sync_packet_size);
+	ClassDB::bind_method(D_METHOD("set_max_sync_packet_size", "size"), &SceneMultiplayer::set_max_sync_packet_size);
+	ClassDB::bind_method(D_METHOD("get_max_delta_packet_size"), &SceneMultiplayer::get_max_delta_packet_size);
+	ClassDB::bind_method(D_METHOD("set_max_delta_packet_size", "size"), &SceneMultiplayer::set_max_delta_packet_size);
+
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "root_path"), "set_root_path", "get_root_path");
 	ADD_PROPERTY(PropertyInfo(Variant::CALLABLE, "auth_callback"), "set_auth_callback", "get_auth_callback");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "auth_timeout", PROPERTY_HINT_RANGE, "0,30,0.1,or_greater,suffix:s"), "set_auth_timeout", "get_auth_timeout");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_object_decoding"), "set_allow_object_decoding", "is_object_decoding_allowed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "refuse_new_connections"), "set_refuse_new_connections", "is_refusing_new_connections");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "server_relay"), "set_server_relay_enabled", "is_server_relay_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_sync_packet_size"), "set_max_sync_packet_size", "get_max_sync_packet_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_delta_packet_size"), "set_max_delta_packet_size", "get_max_delta_packet_size");
 
 	ADD_PROPERTY_DEFAULT("refuse_new_connections", false);
 

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -195,6 +195,12 @@ public:
 	void set_server_relay_enabled(bool p_enabled);
 	bool is_server_relay_enabled() const;
 
+	void set_max_sync_packet_size(int p_size);
+	int get_max_sync_packet_size() const;
+
+	void set_max_delta_packet_size(int p_size);
+	int get_max_delta_packet_size() const;
+
 	Ref<SceneCacheInterface> get_path_cache() { return cache; }
 	Ref<SceneReplicationInterface> get_replicator() { return replicator; }
 

--- a/modules/multiplayer/scene_replication_config.h
+++ b/modules/multiplayer/scene_replication_config.h
@@ -45,6 +45,7 @@ private:
 		NodePath name;
 		bool spawn = true;
 		bool sync = true;
+		bool watch = false;
 
 		bool operator==(const ReplicationProperty &p_to) {
 			return name == p_to.name;
@@ -60,6 +61,7 @@ private:
 	List<ReplicationProperty> properties;
 	List<NodePath> spawn_props;
 	List<NodePath> sync_props;
+	List<NodePath> watch_props;
 
 protected:
 	static void _bind_methods();
@@ -82,8 +84,12 @@ public:
 	bool property_get_sync(const NodePath &p_path);
 	void property_set_sync(const NodePath &p_path, bool p_enabled);
 
+	bool property_get_watch(const NodePath &p_path);
+	void property_set_watch(const NodePath &p_path, bool p_enabled);
+
 	const List<NodePath> &get_spawn_properties() { return spawn_props; }
 	const List<NodePath> &get_sync_properties() { return sync_props; }
+	const List<NodePath> &get_watch_properties() { return watch_props; }
 
 	SceneReplicationConfig() {}
 };

--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -138,15 +138,16 @@ void SceneReplicationInterface::on_network_process() {
 		spawn_queue.clear();
 	}
 
-	// Process timed syncs.
-	uint64_t msec = OS::get_singleton()->get_ticks_msec();
+	// Process syncs.
+	uint64_t usec = OS::get_singleton()->get_ticks_usec();
 	for (KeyValue<int, PeerInfo> &E : peers_info) {
 		const HashSet<ObjectID> to_sync = E.value.sync_nodes;
 		if (to_sync.is_empty()) {
 			continue; // Nothing to sync
 		}
 		uint16_t sync_net_time = ++E.value.last_sent_sync;
-		_send_sync(E.key, to_sync, sync_net_time, msec);
+		_send_sync(E.key, to_sync, sync_net_time, usec);
+		_send_delta(E.key, to_sync, usec, E.value.last_watch_usecs);
 	}
 }
 
@@ -280,6 +281,7 @@ Error SceneReplicationInterface::on_replication_stop(Object *p_obj, Variant p_co
 	sync_nodes.erase(sid);
 	for (KeyValue<int, PeerInfo> &E : peers_info) {
 		E.value.sync_nodes.erase(sid);
+		E.value.last_watch_usecs.erase(sid);
 		if (sync->get_net_id()) {
 			E.value.recv_sync_ids.erase(sync->get_net_id());
 		}
@@ -357,6 +359,7 @@ Error SceneReplicationInterface::_update_sync_visibility(int p_peer, Multiplayer
 				E.value.sync_nodes.insert(sid);
 			} else {
 				E.value.sync_nodes.erase(sid);
+				E.value.last_watch_usecs.erase(sid);
 			}
 		}
 		return OK;
@@ -369,6 +372,7 @@ Error SceneReplicationInterface::_update_sync_visibility(int p_peer, Multiplayer
 			peers_info[p_peer].sync_nodes.insert(sid);
 		} else {
 			peers_info[p_peer].sync_nodes.erase(sid);
+			peers_info[p_peer].last_watch_usecs.erase(sid);
 		}
 		return OK;
 	}
@@ -670,8 +674,126 @@ Error SceneReplicationInterface::on_despawn_receive(int p_from, const uint8_t *p
 	return OK;
 }
 
-void SceneReplicationInterface::_send_sync(int p_peer, const HashSet<ObjectID> p_synchronizers, uint16_t p_sync_net_time, uint64_t p_msec) {
-	MAKE_ROOM(sync_mtu);
+bool SceneReplicationInterface::_verify_synchronizer(int p_peer, MultiplayerSynchronizer *p_sync, uint32_t &r_net_id) {
+	r_net_id = p_sync->get_net_id();
+	if (r_net_id == 0 || (r_net_id & 0x80000000)) {
+		int path_id = 0;
+		bool verified = multiplayer->get_path_cache()->send_object_cache(p_sync, p_peer, path_id);
+		ERR_FAIL_COND_V_MSG(path_id < 0, false, "This should never happen!");
+		if (r_net_id == 0) {
+			// First time path based ID.
+			r_net_id = path_id | 0x80000000;
+			p_sync->set_net_id(r_net_id | 0x80000000);
+		}
+		return verified;
+	}
+	return true;
+}
+
+MultiplayerSynchronizer *SceneReplicationInterface::_find_synchronizer(int p_peer, uint32_t p_net_id) {
+	MultiplayerSynchronizer *sync = nullptr;
+	if (p_net_id & 0x80000000) {
+		sync = Object::cast_to<MultiplayerSynchronizer>(multiplayer->get_path_cache()->get_cached_object(p_peer, p_net_id & 0x7FFFFFFF));
+	} else if (peers_info[p_peer].recv_sync_ids.has(p_net_id)) {
+		const ObjectID &sid = peers_info[p_peer].recv_sync_ids[p_net_id];
+		sync = get_id_as<MultiplayerSynchronizer>(sid);
+	}
+	return sync;
+}
+
+void SceneReplicationInterface::_send_delta(int p_peer, const HashSet<ObjectID> p_synchronizers, uint64_t p_usec, const HashMap<ObjectID, uint64_t> p_last_watch_usecs) {
+	MAKE_ROOM(/* header */ 1 + /* element */ 4 + 8 + 4 + delta_mtu);
+	uint8_t *ptr = packet_cache.ptrw();
+	ptr[0] = SceneMultiplayer::NETWORK_COMMAND_SYNC | (1 << SceneMultiplayer::CMD_FLAG_0_SHIFT);
+	int ofs = 1;
+	for (const ObjectID &oid : p_synchronizers) {
+		MultiplayerSynchronizer *sync = get_id_as<MultiplayerSynchronizer>(oid);
+		ERR_CONTINUE(!sync || !sync->get_replication_config().is_valid() || !sync->is_multiplayer_authority());
+		uint32_t net_id;
+		if (!_verify_synchronizer(p_peer, sync, net_id)) {
+			continue;
+		}
+		uint64_t last_usec = p_last_watch_usecs.has(oid) ? p_last_watch_usecs[oid] : 0;
+		uint64_t indexes;
+		List<Variant> delta = sync->get_delta_state(p_usec, last_usec, indexes);
+
+		if (!delta.size()) {
+			continue; // Nothing to update.
+		}
+
+		Vector<const Variant *> varp;
+		varp.resize(delta.size());
+		const Variant **vptr = varp.ptrw();
+		int i = 0;
+		for (const Variant &v : delta) {
+			vptr[i] = &v;
+		}
+		int size;
+		Error err = MultiplayerAPI::encode_and_compress_variants(vptr, varp.size(), nullptr, size);
+		ERR_CONTINUE_MSG(err != OK, "Unable to encode delta state.");
+
+		ERR_CONTINUE_MSG(size > delta_mtu, vformat("Synchronizer delta bigger than MTU will not be sent (%d > %d): %s", size, delta_mtu, sync->get_path()));
+
+		if (ofs + 4 + 8 + 4 + size > delta_mtu) {
+			// Send what we got, and reset write.
+			_send_raw(packet_cache.ptr(), ofs, p_peer, true);
+			ofs = 1;
+		}
+		if (size) {
+			ofs += encode_uint32(sync->get_net_id(), &ptr[ofs]);
+			ofs += encode_uint64(indexes, &ptr[ofs]);
+			ofs += encode_uint32(size, &ptr[ofs]);
+			MultiplayerAPI::encode_and_compress_variants(vptr, varp.size(), &ptr[ofs], size);
+			ofs += size;
+		}
+#ifdef DEBUG_ENABLED
+		_profile_node_data("delta_out", oid, size);
+#endif
+		peers_info[p_peer].last_watch_usecs[oid] = p_usec;
+	}
+	if (ofs > 1) {
+		// Got some left over to send.
+		_send_raw(packet_cache.ptr(), ofs, p_peer, true);
+	}
+}
+
+Error SceneReplicationInterface::on_delta_receive(int p_from, const uint8_t *p_buffer, int p_buffer_len) {
+	int ofs = 1;
+	while (ofs + 4 + 8 + 4 < p_buffer_len) {
+		uint32_t net_id = decode_uint32(&p_buffer[ofs]);
+		ofs += 4;
+		uint64_t indexes = decode_uint64(&p_buffer[ofs]);
+		ofs += 8;
+		uint32_t size = decode_uint32(&p_buffer[ofs]);
+		ofs += 4;
+		ERR_FAIL_COND_V(size > uint32_t(p_buffer_len - ofs), ERR_INVALID_DATA);
+		MultiplayerSynchronizer *sync = _find_synchronizer(p_from, net_id);
+		Node *node = sync ? sync->get_root_node() : nullptr;
+		if (!sync || sync->get_multiplayer_authority() != p_from || !node) {
+			ofs += size;
+			ERR_CONTINUE_MSG(true, "Ignoring delta for non-authority or invalid synchronizer.");
+		}
+		List<NodePath> props = sync->get_delta_properties(indexes);
+		ERR_FAIL_COND_V(props.size() == 0, ERR_INVALID_DATA);
+		Vector<Variant> vars;
+		vars.resize(props.size());
+		int consumed = 0;
+		Error err = MultiplayerAPI::decode_and_decompress_variants(vars, p_buffer + ofs, size, consumed);
+		ERR_FAIL_COND_V(err != OK, err);
+		ERR_FAIL_COND_V(uint32_t(consumed) != size, ERR_INVALID_DATA);
+		err = MultiplayerSynchronizer::set_state(props, node, vars);
+		ERR_FAIL_COND_V(err != OK, err);
+		ofs += size;
+		sync->emit_signal(SNAME("delta_synchronized"));
+#ifdef DEBUG_ENABLED
+		_profile_node_data("delta_in", sync->get_instance_id(), size);
+#endif
+	}
+	return OK;
+}
+
+void SceneReplicationInterface::_send_sync(int p_peer, const HashSet<ObjectID> p_synchronizers, uint16_t p_sync_net_time, uint64_t p_usec) {
+	MAKE_ROOM(/* header */ 3 + /* element */ 4 + 4 + sync_mtu);
 	uint8_t *ptr = packet_cache.ptrw();
 	ptr[0] = SceneMultiplayer::NETWORK_COMMAND_SYNC;
 	int ofs = 1;
@@ -681,26 +803,16 @@ void SceneReplicationInterface::_send_sync(int p_peer, const HashSet<ObjectID> p
 	for (const ObjectID &oid : p_synchronizers) {
 		MultiplayerSynchronizer *sync = get_id_as<MultiplayerSynchronizer>(oid);
 		ERR_CONTINUE(!sync || !sync->get_replication_config().is_valid() || !sync->is_multiplayer_authority());
-		if (!sync->update_outbound_sync_time(p_msec)) {
+		if (!sync->update_outbound_sync_time(p_usec)) {
 			continue; // nothing to sync.
 		}
 
 		Node *node = sync->get_root_node();
 		ERR_CONTINUE(!node);
 		uint32_t net_id = sync->get_net_id();
-		if (net_id == 0 || (net_id & 0x80000000)) {
-			int path_id = 0;
-			bool verified = multiplayer->get_path_cache()->send_object_cache(sync, p_peer, path_id);
-			ERR_CONTINUE_MSG(path_id < 0, "This should never happen!");
-			if (net_id == 0) {
-				// First time path based ID.
-				net_id = path_id | 0x80000000;
-				sync->set_net_id(net_id | 0x80000000);
-			}
-			if (!verified) {
-				// The path based sync is not yet confirmed, skipping.
-				continue;
-			}
+		if (!_verify_synchronizer(p_peer, sync, net_id)) {
+			// The path based sync is not yet confirmed, skipping.
+			continue;
 		}
 		int size;
 		Vector<Variant> vars;
@@ -711,7 +823,7 @@ void SceneReplicationInterface::_send_sync(int p_peer, const HashSet<ObjectID> p
 		err = MultiplayerAPI::encode_and_compress_variants(varp.ptrw(), varp.size(), nullptr, size);
 		ERR_CONTINUE_MSG(err != OK, "Unable to encode sync state.");
 		// TODO Handle single state above MTU.
-		ERR_CONTINUE_MSG(size > 3 + 4 + 4 + sync_mtu, vformat("Node states bigger then MTU will not be sent (%d > %d): %s", size, sync_mtu, node->get_path()));
+		ERR_CONTINUE_MSG(size > sync_mtu, vformat("Node states bigger than MTU will not be sent (%d > %d): %s", size, sync_mtu, node->get_path()));
 		if (ofs + 4 + 4 + size > sync_mtu) {
 			// Send what we got, and reset write.
 			_send_raw(packet_cache.ptr(), ofs, p_peer, false);
@@ -735,6 +847,10 @@ void SceneReplicationInterface::_send_sync(int p_peer, const HashSet<ObjectID> p
 
 Error SceneReplicationInterface::on_sync_receive(int p_from, const uint8_t *p_buffer, int p_buffer_len) {
 	ERR_FAIL_COND_V_MSG(p_buffer_len < 11, ERR_INVALID_DATA, "Invalid sync packet received");
+	bool is_delta = (p_buffer[0] & (1 << SceneMultiplayer::CMD_FLAG_0_SHIFT)) != 0;
+	if (is_delta) {
+		return on_delta_receive(p_from, p_buffer, p_buffer_len);
+	}
 	uint16_t time = decode_uint16(&p_buffer[1]);
 	int ofs = 3;
 	while (ofs + 8 < p_buffer_len) {
@@ -743,13 +859,7 @@ Error SceneReplicationInterface::on_sync_receive(int p_from, const uint8_t *p_bu
 		uint32_t size = decode_uint32(&p_buffer[ofs]);
 		ofs += 4;
 		ERR_FAIL_COND_V(size > uint32_t(p_buffer_len - ofs), ERR_INVALID_DATA);
-		MultiplayerSynchronizer *sync = nullptr;
-		if (net_id & 0x80000000) {
-			sync = Object::cast_to<MultiplayerSynchronizer>(multiplayer->get_path_cache()->get_cached_object(p_from, net_id & 0x7FFFFFFF));
-		} else if (peers_info[p_from].recv_sync_ids.has(net_id)) {
-			const ObjectID &sid = peers_info[p_from].recv_sync_ids[net_id];
-			sync = get_id_as<MultiplayerSynchronizer>(sid);
-		}
+		MultiplayerSynchronizer *sync = _find_synchronizer(p_from, net_id);
 		if (!sync) {
 			// Not received yet.
 			ofs += size;
@@ -781,4 +891,22 @@ Error SceneReplicationInterface::on_sync_receive(int p_from, const uint8_t *p_bu
 #endif
 	}
 	return OK;
+}
+
+void SceneReplicationInterface::set_max_sync_packet_size(int p_size) {
+	ERR_FAIL_COND_MSG(p_size < 128, "Sync maximum packet size must be at least 128 bytes.");
+	sync_mtu = p_size;
+}
+
+int SceneReplicationInterface::get_max_sync_packet_size() const {
+	return sync_mtu;
+}
+
+void SceneReplicationInterface::set_max_delta_packet_size(int p_size) {
+	ERR_FAIL_COND_MSG(p_size < 128, "Sync maximum packet size must be at least 128 bytes.");
+	delta_mtu = p_size;
+}
+
+int SceneReplicationInterface::get_max_delta_packet_size() const {
+	return delta_mtu;
 }


### PR DESCRIPTION
Tentative implementation for godotengine/godot-proposals#4429.

How it works
---

"Watched" properties are deep duplicated and then compared (`Variant::hash_compare`) according to the `delta_interval` property of the MultiplayerSynchronizer (default = every frame). Re-duplication only happens when a change is detected, and the time of change is also stored for each property.

Clients receives progressive (delta) changes which only includes the changed properties. The transmission happens reliably, so all changes "across frames" (`delta_interval`) are guaranteed to be received by the clients.

There is a hard limit of 64 watched properties per synchronizer.
There is a (quite arbitrary) limit of 64k bytes per delta packet which probably needs adjustment.

![watch option](https://user-images.githubusercontent.com/1687918/228606325-ec23ba61-c3b7-46ff-8434-6fbea6566e06.png)

~WIP / RFC:~

- ~More testing (e.g. comparison method).~ Seems to work fine in my tests, we can always fix that in a follow up PR.
- ~More feedback (e.g. custom comparison function, comparison frequency, reliable vs unreliable + ack).~ Well, it's been a month, I think I can mark the PR as ready.
- ~Discuss replication config editor redesign (e.g. make "Initial/Sync/Delta" exclusive, or use the current one in the proposal).~ Let's do that in a separate PR/proposal.
- ~Some further cleanup / internal command ids change.~ Kinda unrelated to this PR.
- ~*Nice to have*: Implement editor profiler (needs redesign proposal due to space constraints :sweat_smile: ).~ Needs design proposal.