### PR TITLE
Do not clamp non-embedded window size to embedder

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1564,7 +1564,7 @@ void Window::popup(const Rect2i &p_screen_rect) {
 		ERR_PRINT(vformat("Window %d spawned at invalid position: %s.", get_window_id(), position));
 		set_position((parent_rect.size - size) / 2);
 	}
-	if (parent_rect != Rect2i() && is_clamped_to_embedder()) {
+	if (parent_rect != Rect2i() && is_clamped_to_embedder() && is_embedded()) {
 		Rect2i new_rect = fit_rect_in_parent(Rect2i(position, size), parent_rect);
 		set_position(new_rect.position);
 		set_size(new_rect.size);


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/75473

Yuri's guess does indeed fix the issue (tho I was kinda surprised at the fix not working in the editor itself, but that was just because the saved window position got updated to the desktop center before)