### PR TITLE
C# Truncate instead of round in Vector2/3/4 to Vector2I/3I/4I conversion

### DIFF
--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -31,7 +31,7 @@
 			<return type="Vector2i" />
 			<param index="0" name="from" type="Vector2" />
 			<description>
-				Constructs a new [Vector2i] from [Vector2]. The floating point coordinates will be truncated.
+				Constructs a new [Vector2i] from the given [Vector2] by truncating components' fractional parts (rounding towards zero). For a different behavior consider passing the result of [method Vector2.ceil], [method Vector2.floor] or [method Vector2.round] to this constructor instead.
 			</description>
 		</constructor>
 		<constructor name="Vector2i">

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -31,7 +31,7 @@
 			<return type="Vector3i" />
 			<param index="0" name="from" type="Vector3" />
 			<description>
-				Constructs a new [Vector3i] from [Vector3]. The floating point coordinates will be truncated.
+				Constructs a new [Vector3i] from the given [Vector3] by truncating components' fractional parts (rounding towards zero). For a different behavior consider passing the result of [method Vector3.ceil], [method Vector3.floor] or [method Vector3.round] to this constructor instead.
 			</description>
 		</constructor>
 		<constructor name="Vector3i">

--- a/doc/classes/Vector4i.xml
+++ b/doc/classes/Vector4i.xml
@@ -27,7 +27,7 @@
 			<return type="Vector4i" />
 			<param index="0" name="from" type="Vector4" />
 			<description>
-				Constructs a new [Vector4i] from the given [Vector4].
+				Constructs a new [Vector4i] from the given [Vector4] by truncating components' fractional parts (rounding towards zero). For a different behavior consider passing the result of [method Vector4.ceil], [method Vector4.floor] or [method Vector4.round] to this constructor instead.
 			</description>
 		</constructor>
 		<constructor name="Vector4i">

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
@@ -504,15 +504,15 @@ namespace Godot
         }
 
         /// <summary>
-        /// Converts a <see cref="Vector2"/> to a <see cref="Vector2I"/>.
+        /// Converts a <see cref="Vector2"/> to a <see cref="Vector2I"/> by truncating
+        /// components' fractional parts (rounding towards zero). For a different
+        /// behavior consider passing the result of <see cref="Vector2.Ceil"/>,
+        /// <see cref="Vector2.Floor"/> or <see cref="Vector2.Round"/> to this conversion operator instead.
         /// </summary>
         /// <param name="value">The vector to convert.</param>
         public static explicit operator Vector2I(Vector2 value)
         {
-            return new Vector2I(
-                Mathf.RoundToInt(value.X),
-                Mathf.RoundToInt(value.Y)
-            );
+            return new Vector2I((int)value.X, (int)value.Y);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
@@ -559,16 +559,15 @@ namespace Godot
         }
 
         /// <summary>
-        /// Converts a <see cref="Vector3"/> to a <see cref="Vector3I"/>.
+        /// Converts a <see cref="Vector3"/> to a <see cref="Vector3I"/> by truncating
+        /// components' fractional parts (rounding towards zero). For a different
+        /// behavior consider passing the result of <see cref="Vector3.Ceil"/>,
+        /// <see cref="Vector3.Floor"/> or <see cref="Vector3.Round"/> to this conversion operator instead.
         /// </summary>
         /// <param name="value">The vector to convert.</param>
         public static explicit operator Vector3I(Vector3 value)
         {
-            return new Vector3I(
-                Mathf.RoundToInt(value.X),
-                Mathf.RoundToInt(value.Y),
-                Mathf.RoundToInt(value.Z)
-            );
+            return new Vector3I((int)value.X, (int)value.Y, (int)value.Z);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
@@ -580,17 +580,15 @@ namespace Godot
         }
 
         /// <summary>
-        /// Converts a <see cref="Vector4"/> to a <see cref="Vector4I"/>.
+        /// Converts a <see cref="Vector4"/> to a <see cref="Vector4I"/> by truncating
+        /// components' fractional parts (rounding towards zero). For a different
+        /// behavior consider passing the result of <see cref="Vector4.Ceil"/>,
+        /// <see cref="Vector4.Floor"/> or <see cref="Vector4.Round"/> to this conversion operator instead.
         /// </summary>
         /// <param name="value">The vector to convert.</param>
         public static explicit operator Vector4I(Vector4 value)
         {
-            return new Vector4I(
-                Mathf.RoundToInt(value.X),
-                Mathf.RoundToInt(value.Y),
-                Mathf.RoundToInt(value.Z),
-                Mathf.RoundToInt(value.W)
-            );
+            return new Vector4I((int)value.X, (int)value.Y, (int)value.Z, (int)value.W);
         }
 
         /// <summary>


### PR DESCRIPTION
Makes C# Vector2/3/4 to Vector2I/3I/4I conversions behave consistently with the core, i.e. now they are performed by truncating to ins instead of rounding to ints like before. Also improved the relevant docs.

Fixes #75470.
