### PR TITLE
Update outdated syntax in `JavaScriptBridge` doc

### DIFF
--- a/doc/classes/JavaScriptObject.xml
+++ b/doc/classes/JavaScriptObject.xml
@@ -9,7 +9,7 @@
 		[codeblock]
 		extends Node
 
-		var _my_js_callback = JavaScriptBridge.create_callback(self, "myCallback") # This reference must be kept
+		var _my_js_callback = JavaScriptBridge.create_callback(myCallback) # This reference must be kept
 		var console = JavaScriptBridge.get_interface("console")
 
 		func _init():


### PR DESCRIPTION
Fixes godotengine/godot-docs#7090.

According to `JavaScriptBridge`, this takes a Callable, not an object/string pair. This causes the example in the doc to be incorrect.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
