### PR TITLE
Add editor preview for Light3D nodes (WIP)

### DIFF
--- a/editor/plugins/camera_3d_editor_plugin.cpp
+++ b/editor/plugins/camera_3d_editor_plugin.cpp
@@ -28,6 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#include <iostream>
+#include <string>
+using namespace std;
+
+
 #include "camera_3d_editor_plugin.h"
 
 #include "editor/editor_node.h"
@@ -51,6 +56,7 @@ void Camera3DEditor::_bind_methods() {
 
 void Camera3DEditor::edit(Node *p_camera) {
 	node = p_camera;
+	std::cout << "Camera3DEditor:edit calls with camera at [" << p_camera << "]" << std::endl;
 
 	if (!node) {
 		preview->set_pressed(false);
@@ -80,7 +86,9 @@ Camera3DEditor::Camera3DEditor() {
 }
 
 void Camera3DEditorPlugin::edit(Object *p_object) {
+	std::cout << "Camera3DEditorPlugin:edit called with camera objecct [" << p_object << "]" << std::endl;
 	Node3DEditor::get_singleton()->set_can_preview(Object::cast_to<Camera3D>(p_object));
+
 	//camera_editor->edit(Object::cast_to<Node>(p_object));
 }
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -28,6 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#include <iostream>
+#include <string>
+using namespace std;
+
 #include "node_3d_editor_plugin.h"
 
 #include "core/config/project_settings.h"
@@ -2896,7 +2900,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 
 		case NOTIFICATION_THEME_CHANGED: {
 			view_menu->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
-			preview_camera->set_icon(get_theme_icon(SNAME("Camera3D"), SNAME("EditorIcons")));
+			preview_node3d_checkbox->set_icon(get_theme_icon(SNAME("Camera3D"), SNAME("EditorIcons")));
 			Control *gui_base = EditorNode::get_singleton()->get_gui_base();
 
 			view_menu->add_theme_style_override("normal", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
@@ -2905,11 +2909,11 @@ void Node3DEditorViewport::_notification(int p_what) {
 			view_menu->add_theme_style_override("focus", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
 			view_menu->add_theme_style_override("disabled", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
 
-			preview_camera->add_theme_style_override("normal", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-			preview_camera->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-			preview_camera->add_theme_style_override("pressed", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-			preview_camera->add_theme_style_override("focus", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-			preview_camera->add_theme_style_override("disabled", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+			preview_node3d_checkbox->add_theme_style_override("normal", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+			preview_node3d_checkbox->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+			preview_node3d_checkbox->add_theme_style_override("pressed", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+			preview_node3d_checkbox->add_theme_style_override("focus", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+			preview_node3d_checkbox->add_theme_style_override("disabled", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
 
 			frame_time_gradient->set_color(0, get_theme_color(SNAME("success_color"), SNAME("Editor")));
 			frame_time_gradient->set_color(1, get_theme_color(SNAME("warning_color"), SNAME("Editor")));
@@ -3327,12 +3331,14 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 			view_menu->get_popup()->set_item_checked(idx, current);
 			previewing_cinema = true;
 			_toggle_cinema_preview(current);
+			std::cout << "Node3DEditorViewport::menu_option cinematic preview" << std::endl;
+
 
 			if (current) {
-				preview_camera->hide();
+				preview_node3d_checkbox->hide();
 			} else {
 				if (previewing != nullptr) {
-					preview_camera->show();
+					preview_node3d_checkbox->show();
 				}
 			}
 		} break;
@@ -3477,10 +3483,12 @@ void Node3DEditorViewport::_set_auto_orthogonal() {
 }
 
 void Node3DEditorViewport::_preview_exited_scene() {
-	preview_camera->disconnect("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
-	preview_camera->set_pressed(false);
-	_toggle_camera_preview(false);
-	preview_camera->connect("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
+	std::cout << "Node3DEditorViewport::preview_existed_scene called" << std::endl;
+
+	preview_node3d_checkbox->disconnect("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_node3d_preview));
+	preview_node3d_checkbox->set_pressed(false);
+	_toggle_node3d_preview(false);
+	preview_node3d_checkbox->connect("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_node3d_preview));
 	view_menu->show();
 }
 
@@ -3568,10 +3576,10 @@ void Node3DEditorViewport::_finish_gizmo_instances() {
 	RS::get_singleton()->free(rotate_gizmo_instance[3]);
 }
 
-void Node3DEditorViewport::_toggle_camera_preview(bool p_activate) {
+void Node3DEditorViewport::_toggle_node3d_preview(bool p_activate) {
 	ERR_FAIL_COND(p_activate && !preview);
 	ERR_FAIL_COND(!p_activate && !previewing);
-
+	std::cout << "  Node3DEditorViewport::_toggle_node3d_preview " << std::endl;
 	previewing_camera = p_activate;
 	_update_navigation_controls_visibility();
 
@@ -3580,7 +3588,7 @@ void Node3DEditorViewport::_toggle_camera_preview(bool p_activate) {
 		previewing = nullptr;
 		RS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), camera->get_camera()); //restore
 		if (!preview) {
-			preview_camera->hide();
+			preview_node3d_checkbox->hide();
 		}
 		surface->queue_redraw();
 
@@ -3595,6 +3603,8 @@ void Node3DEditorViewport::_toggle_camera_preview(bool p_activate) {
 void Node3DEditorViewport::_toggle_cinema_preview(bool p_activate) {
 	previewing_cinema = p_activate;
 	_update_navigation_controls_visibility();
+	std::cout << "Node3DEditorViewport::_toggle_cinema_preview to " << p_activate << std::endl;
+
 
 	if (!previewing_cinema) {
 		if (previewing != nullptr) {
@@ -3603,11 +3613,11 @@ void Node3DEditorViewport::_toggle_cinema_preview(bool p_activate) {
 
 		previewing = nullptr;
 		RS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), camera->get_camera()); //restore
-		preview_camera->set_pressed(false);
+		preview_node3d_checkbox->set_pressed(false);
 		if (!preview) {
-			preview_camera->hide();
+			preview_node3d_checkbox->hide();
 		} else {
-			preview_camera->show();
+			preview_node3d_checkbox->show();
 		}
 		view_menu->show();
 		surface->queue_redraw();
@@ -3636,9 +3646,11 @@ void Node3DEditorViewport::_selection_menu_hide() {
 
 void Node3DEditorViewport::set_can_preview(Camera3D *p_preview) {
 	preview = p_preview;
+	std::cout << "  Node3DEditorViewport::set_can_previews with camera ["<< p_preview << "]" <<std::endl;;
 
-	if (!preview_camera->is_pressed() && !previewing_cinema) {
-		preview_camera->set_visible(p_preview);
+	if (!preview_node3d_checkbox->is_pressed() && !previewing_cinema) {
+		std::cout << "   toggle checkbox" << std::endl;
+		preview_node3d_checkbox->set_visible(p_preview);
 	}
 }
 
@@ -3839,21 +3851,22 @@ void Node3DEditorViewport::set_state(const Dictionary &p_state) {
 		view_menu->get_popup()->set_item_checked(idx, previewing_cinema);
 	}
 
-	if (preview_camera->is_connected("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview))) {
-		preview_camera->disconnect("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
+	if (preview_node3d_checkbox->is_connected("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_node3d_preview))) {
+		preview_node3d_checkbox->disconnect("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_node3d_preview));
 	}
 	if (p_state.has("previewing")) {
+		std::cout << "Node3DEditorViewport::set_state is previewing" << std::endl;
 		Node *pv = EditorNode::get_singleton()->get_edited_scene()->get_node(p_state["previewing"]);
 		if (Object::cast_to<Camera3D>(pv)) {
 			previewing = Object::cast_to<Camera3D>(pv);
 			previewing->connect("tree_exiting", callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
 			RS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), previewing->get_camera()); //replace
 			surface->queue_redraw();
-			preview_camera->set_pressed(true);
-			preview_camera->show();
+			preview_node3d_checkbox->set_pressed(true);
+			preview_node3d_checkbox->show();
 		}
 	}
-	preview_camera->connect("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
+	preview_node3d_checkbox->connect("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_node3d_preview));
 }
 
 Dictionary Node3DEditorViewport::get_state() const {
@@ -5074,13 +5087,15 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	ED_SHORTCUT("spatial_editor/instant_rotate", TTR("Begin Rotate Transformation"));
 	ED_SHORTCUT("spatial_editor/instant_scale", TTR("Begin Scale Transformation"));
 
-	preview_camera = memnew(CheckBox);
-	preview_camera->set_text(TTR("Preview"));
-	preview_camera->set_shortcut(ED_SHORTCUT("spatial_editor/toggle_camera_preview", TTR("Toggle Camera Preview"), KeyModifierMask::CMD_OR_CTRL | Key::P));
-	vbox->add_child(preview_camera);
-	preview_camera->set_h_size_flags(0);
-	preview_camera->hide();
-	preview_camera->connect("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
+	std::cout << "Node3DEditorViewport::__init__" << std::endl;
+
+	preview_node3d_checkbox = memnew(CheckBox);
+	preview_node3d_checkbox->set_text(TTR("Preview"));
+	preview_node3d_checkbox->set_shortcut(ED_SHORTCUT("spatial_editor/toggle_camera_preview", TTR("Toggle Camera Preview"), KeyModifierMask::CMD_OR_CTRL | Key::P));
+	vbox->add_child(preview_node3d_checkbox);
+	preview_node3d_checkbox->set_h_size_flags(0);
+	preview_node3d_checkbox->hide();
+	preview_node3d_checkbox->connect("toggled", callable_mp(this, &Node3DEditorViewport::_toggle_node3d_preview));
 	previewing = nullptr;
 	gizmo_scale = 1.0;
 

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -213,7 +213,7 @@ private:
 
 	EditorSelection *editor_selection = nullptr;
 
-	CheckBox *preview_camera = nullptr;
+	CheckBox *preview_node3d_checkbox = nullptr;
 	SubViewportContainer *subviewport_container = nullptr;
 
 	MenuButton *view_menu = nullptr;
@@ -406,7 +406,7 @@ private:
 	bool previewing_cinema;
 	bool _is_node_locked(const Node *p_node);
 	void _preview_exited_scene();
-	void _toggle_camera_preview(bool);
+	void _toggle_node3d_preview(bool);
 	void _toggle_cinema_preview(bool);
 	void _init_gizmo_instance(int p_idx);
 	void _finish_gizmo_instances();

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -68,6 +68,7 @@
 #include "editor/plugins/gradient_editor_plugin.h"
 #include "editor/plugins/gradient_texture_2d_editor_plugin.h"
 #include "editor/plugins/input_event_editor_plugin.h"
+#include "editor/plugins/light_3d_editor_plugin.h"
 #include "editor/plugins/light_occluder_2d_editor_plugin.h"
 #include "editor/plugins/lightmap_gi_editor_plugin.h"
 #include "editor/plugins/line_2d_editor_plugin.h"
@@ -171,6 +172,7 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<GradientEditorPlugin>();
 	EditorPlugins::add_by_type<GradientTexture2DEditorPlugin>();
 	EditorPlugins::add_by_type<InputEventEditorPlugin>();
+	EditorPlugins::add_by_type<Light3DEditorPlugin>();
 	EditorPlugins::add_by_type<LightmapGIEditorPlugin>();
 	EditorPlugins::add_by_type<MaterialEditorPlugin>();
 	EditorPlugins::add_by_type<MeshEditorPlugin>();


### PR DESCRIPTION
A long standing missing feature for me in Godot is the ability to preview where Light3D nodes such as Spotlight3D are aiming.

In the editor, the user can select to Preview a Camera3D and see where the Camera3D is aiming.

I want to extend that functionality to Light3D nodes (and perhaps all Node3D nodes).

[Screencast from 30-03-23 15:01:15.webm](https://user-images.githubusercontent.com/13980/228729114-f15bc06a-d905-4337-9cfe-f52ae81ffef2.webm)

This is a proof-of-concept work-in-progress PR that I'd love to get a discussion going and some suggestions.

My current approach is this:
1. Rename `preview_camera` to `preview_node3d_checkbox-` to better reflect its purpose
2. Add a Light3DEditorPlugin, enable `preview_node3d_checkbox` visibility for this plugin.
3. When the user selects a Light3D object, it creates a camera at the same location as the Light3D node and adds it to the editor viewport, and passes the camera to the Node3DEditor to use the same setup as the Camera3D editor plugin.
4. When the user toggles on preview, use existing code to switch to the camera.
5. When they deselect the Light3D switch back to the default camera and delete the Light3D camera

My questions are:
1. Is godot interested in this feature at all? I think it's valuable but I don't want to waste anyone's time!
2. I would love to connect the preview camera back to the Light3D settings, I think we can do a rough estimate of the camera fov based on the spotlight angle and distance to really give fine control over placing and aiming of spotlights
3. Connecting is really important because as a user adjusts the position of the spotlight it should be updated instantly in the preview camera but I don't know how to connect?
4. I personally can see a massive use for this being extending to all Node3Ds. Making sure characters are looking exactly where you want is so good. Should I aim for an uber-PR that works on Node3Ds in general or keep is super restricted to Light3Ds or maybe even just Spotlight3Ds?
6. Is creating a light_3d_editor_plugin the correct way to go about this?
7. What are the icebergs about creating a camera and adding to the editor viewport? (eg can there be multiple editor viewports that might blow up or rendering issues)
8. Would it be better (or even possible) to use a new temporary viewport instead of a temporary camera, as that would give us a real editor view which might be better than a camera view (or is there an editor mode for a camera?)

Thanks!