### PR TITLE
Fix RemoteTransform2D could fail to update AnimatableBody2D's position or rotation

### DIFF
--- a/scene/2d/remote_transform_2d.cpp
+++ b/scene/2d/remote_transform_2d.cpp
@@ -60,54 +60,51 @@ void RemoteTransform2D::_update_remote() {
 		return;
 	}
 
+	if (!(update_remote_position || update_remote_rotation || update_remote_scale)) {
+		return; // The transform data of the RemoteTransform2D is not used at all.
+	}
+
 	//todo make faster
 	if (use_global_coordinates) {
 		if (update_remote_position && update_remote_rotation && update_remote_scale) {
 			n->set_global_transform(get_global_transform());
-		} else {
-			Transform2D n_trans = n->get_global_transform();
-			Transform2D our_trans = get_global_transform();
-			Vector2 n_scale = n->get_scale();
-
-			if (!update_remote_position) {
-				our_trans.set_origin(n_trans.get_origin());
-			}
-			if (!update_remote_rotation) {
-				our_trans.set_rotation(n_trans.get_rotation());
-			}
-
-			n->set_global_transform(our_trans);
-
-			if (update_remote_scale) {
-				n->set_scale(get_global_scale());
-			} else {
-				n->set_scale(n_scale);
-			}
+			return;
 		}
 
+		Transform2D n_trans = n->get_global_transform();
+		Transform2D our_trans = get_global_transform();
+
+		// There are more steps in the operation of set_rotation, so avoid calling it.
+		Transform2D trans = update_remote_rotation ? our_trans : n_trans;
+
+		if (update_remote_rotation ^ update_remote_position) {
+			trans.set_origin(update_remote_position ? our_trans.get_origin() : n_trans.get_origin());
+		}
+		if (update_remote_rotation ^ update_remote_scale) {
+			trans.set_scale(update_remote_scale ? our_trans.get_scale() : n_trans.get_scale());
+		}
+
+		n->set_global_transform(trans);
 	} else {
 		if (update_remote_position && update_remote_rotation && update_remote_scale) {
 			n->set_transform(get_transform());
-		} else {
-			Transform2D n_trans = n->get_transform();
-			Transform2D our_trans = get_transform();
-			Vector2 n_scale = n->get_scale();
-
-			if (!update_remote_position) {
-				our_trans.set_origin(n_trans.get_origin());
-			}
-			if (!update_remote_rotation) {
-				our_trans.set_rotation(n_trans.get_rotation());
-			}
-
-			n->set_transform(our_trans);
-
-			if (update_remote_scale) {
-				n->set_scale(get_scale());
-			} else {
-				n->set_scale(n_scale);
-			}
+			return;
 		}
+
+		Transform2D n_trans = n->get_transform();
+		Transform2D our_trans = get_transform();
+
+		// There are more steps in the operation of set_rotation, so avoid calling it.
+		Transform2D trans = update_remote_rotation ? our_trans : n_trans;
+
+		if (update_remote_rotation ^ update_remote_position) {
+			trans.set_origin(update_remote_position ? our_trans.get_origin() : n_trans.get_origin());
+		}
+		if (update_remote_rotation ^ update_remote_scale) {
+			trans.set_scale(update_remote_scale ? our_trans.get_scale() : n_trans.get_scale());
+		}
+
+		n->set_transform(trans);
 	}
 }
 


### PR DESCRIPTION
Configure the transform per condition, and then only set it once to prevent multiple `NOTIFICATION_LOCAL_TRANSFORM_CHANGED` notifications from being sent.

Simple fix #75486.

| Before | After |
| :-------: | :------: |
| ![0](https://user-images.githubusercontent.com/30386067/228756509-ec7b95aa-ec88-4297-b711-dc55c50b471a.gif) | ![1](https://user-images.githubusercontent.com/30386067/228756528-3219618a-2e2f-4f77-87b8-ea1ffbf115f3.gif) |



<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
