### PR TITLE
Reimplement `String.erase()` as immutable method

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -2840,6 +2840,12 @@ String String::insert(int p_at_pos, const String &p_string) const {
 	return pre + p_string + post;
 }
 
+String String::erase(int p_pos, int p_chars) const {
+	ERR_FAIL_COND_V_MSG(p_pos < 0, "", vformat("Invalid starting position for `String.erase()`: %d. Starting position must be positive or zero.", p_pos));
+	ERR_FAIL_COND_V_MSG(p_chars < 0, "", vformat("Invalid character count for `String.erase()`: %d. Character count must be positive or zero.", p_chars));
+	return left(p_pos) + substr(p_pos + p_chars);
+}
+
 String String::substr(int p_from, int p_chars) const {
 	if (p_chars == -1) {
 		p_chars = length() - p_from;

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -304,6 +304,7 @@ public:
 	String replacen(const String &p_key, const String &p_with) const;
 	String repeat(int p_count) const;
 	String insert(int p_at_pos, const String &p_string) const;
+	String erase(int p_pos, int p_chars = 1) const;
 	String pad_decimals(int p_digits) const;
 	String pad_zeros(int p_digits) const;
 	String trim_prefix(const String &p_prefix) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1659,6 +1659,7 @@ static void _register_variant_builtin_methods() {
 	bind_string_method(replacen, sarray("what", "forwhat"), varray());
 	bind_string_method(repeat, sarray("count"), varray());
 	bind_string_method(insert, sarray("position", "what"), varray());
+	bind_string_method(erase, sarray("position", "chars"), varray(1));
 	bind_string_method(capitalize, sarray(), varray());
 	bind_string_method(to_camel_case, sarray(), varray());
 	bind_string_method(to_pascal_case, sarray(), varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -175,6 +175,14 @@
 				Returns [code]true[/code] if the string ends with the given [param text]. See also [method begins_with].
 			</description>
 		</method>
+		<method name="erase" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="position" type="int" />
+			<param index="1" name="chars" type="int" default="1" />
+			<description>
+				Returns a string with [param chars] characters erased starting from [param position]. If [param chars] goes beyond the string's length given the specified [param position], fewer characters will be erased from the returned string. Returns an empty string if either [code]position[/code] or [code]chars[/code] is negative. Returns the original string unmodified if [param chars] is [code]0[/code].
+			</description>
+		</method>
 		<method name="find" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="what" type="String" />

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -158,6 +158,14 @@
 				Returns [code]true[/code] if the string ends with the given [param text]. See also [method begins_with].
 			</description>
 		</method>
+		<method name="erase" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="position" type="int" />
+			<param index="1" name="chars" type="int" default="1" />
+			<description>
+				Returns a string with [param chars] characters erased starting from [param position]. If [param chars] goes beyond the string's length given the specified [param position], fewer characters will be erased from the returned string. Returns an empty string if either [code]position[/code] or [code]chars[/code] is negative. Returns the original string unmodified if [param chars] is [code]0[/code].
+			</description>
+		</method>
 		<method name="find" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="what" type="String" />

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -395,6 +395,12 @@ TEST_CASE("[String] Insertion") {
 	CHECK(s == "Who is Frederic Chopin?");
 }
 
+TEST_CASE("[String] Erasing") {
+	String s = "Josephine is such a cute girl!";
+	s = s.erase(s.find("cute "), String("cute ").length());
+	CHECK(s == "Josephine is such a girl!");
+}
+
 TEST_CASE("[String] Number to string") {
 	CHECK(String::num(0) == "0");
 	CHECK(String::num(0.0) == "0"); // No trailing zeros.


### PR DESCRIPTION
Reimplements `String.erase()` as an immutable method that was removed in #54869 as it was mutable in 3.x

See godotengine/godot-proposals#6598 for more information.

_Production edit: closes https://github.com/godotengine/godot-proposals/issues/6598_

