### PR TITLE
Display real FPS in the 3D editor instead of estimating based on CPU/GPU time

### DIFF
--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -3748,8 +3748,8 @@ void Node3DEditorViewport::_notification(int p_what) {
 						frame_time_gradient->get_color_at_offset(
 								Math::remap(gpu_time, 0, 30, 0, 1)));
 
-				const double fps = 1000.0 / gpu_time;
-				fps_label->set_text(vformat(TTR("FPS: %d"), fps));
+				const double fps = Engine::get_singleton()->get_frames_per_second();
+				fps_label->set_text(vformat(TTR("Editor FPS: %d"), fps));
 				// Middle point is at 60 FPS.
 				fps_label->add_theme_color_override(
 						SceneStringName(font_color),

--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -3783,8 +3783,8 @@ void Node3DEditorViewport::_notification(int p_what) {
 						frame_time_gradient->get_color_at_offset(
 								Math::remap(gpu_time, 0, 30, 0, 1)));
 
-				const double fps = 1000.0 / gpu_time;
-				fps_label->set_text(vformat(TTR("FPS: %d"), fps));
+				const double fps = Engine::get_singleton()->get_frames_per_second();
+				fps_label->set_text(vformat(TTR("Editor FPS: %d"), fps));
 				// Middle point is at 60 FPS.
 				fps_label->add_theme_color_override(
 						SceneStringName(font_color),


### PR DESCRIPTION
This reverts to the 3.x method for displaying FPS in the View Frame Time panel. This has two consequences:

- The reported FPS will no longer go past V-Sync or framerate limiters.
- Unfocusing the window will display a low framerate (10 FPS by default), since the FPS is actually being limited by the engine's low-processor mode. In general, in this situation, the current FPS estimate can't be expected to be accurate as the GPU will often downclock as a result of the low GPU utilization.

Constant redrawing is still forced while the panel is visible, so there's no risk of having low-processor mode interfere.

The engine's FPS readout is updated less smoothly than the current method, but this will be improved if https://github.com/godotengine/godot/pull/63356 is merged.

On the images below, the actual FPS (and GPU power consumption) is identical, but since I use  a 120 Hz display with V-Sync enabled, the engine cannot go past 120 FPS:

Before | After
-|-
![Screenshot_20230331_003918](https://user-images.githubusercontent.com/180032/228979551-3417dfb0-b411-4033-a753-85d2f526f46a.png) | ![Screenshot_20230331_003858](https://user-images.githubusercontent.com/180032/228979552-b7654881-27d6-490c-9237-74ed3fbfbfcc.png)

- This closes https://github.com/godotengine/godot/issues/51371.
- See https://github.com/godotengine/godot/issues/69218.
