### PR TITLE
Fix off-by-one issue where "Go to Line" dialog shows the incorrect line number (one less than the actual current line).

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -42,7 +42,8 @@
 void GotoLineDialog::popup_find_line(CodeEdit *p_edit) {
 	text_editor = p_edit;
 
-	line->set_text(itos(text_editor->get_caret_line()));
+	// Add 1 because text_editor->get_caret_line() starts from 0, but the editor user interface starts from 1.
+	line->set_text(itos(text_editor->get_caret_line() + 1));
 	line->select_all();
 	popup_centered(Size2(180, 80) * EDSCALE);
 	line->grab_focus();
@@ -53,12 +54,14 @@ int GotoLineDialog::get_line() const {
 }
 
 void GotoLineDialog::ok_pressed() {
-	if (get_line() < 1 || get_line() > text_editor->get_line_count()) {
+	// Subtract 1 because the editor user interface starts from 1, but text_editor->set_caret_line(n) starts from 0.
+	const int line_number = get_line() - 1;
+	if (line_number < 0 || line_number >= text_editor->get_line_count()) {
 		return;
 	}
 	text_editor->remove_secondary_carets();
-	text_editor->unfold_line(get_line() - 1);
-	text_editor->set_caret_line(get_line() - 1);
+	text_editor->unfold_line(line_number);
+	text_editor->set_caret_line(line_number);
 	hide();
 }
 
@@ -1092,13 +1095,13 @@ void CodeTextEditor::remove_find_replace_bar() {
 }
 
 void CodeTextEditor::trim_trailing_whitespace() {
-	bool trimed_whitespace = false;
+	bool trimmed_whitespace = false;
 	for (int i = 0; i < text_editor->get_line_count(); i++) {
 		String line = text_editor->get_line(i);
 		if (line.ends_with(" ") || line.ends_with("\t")) {
-			if (!trimed_whitespace) {
+			if (!trimmed_whitespace) {
 				text_editor->begin_complex_operation();
-				trimed_whitespace = true;
+				trimmed_whitespace = true;
 			}
 
 			int end = 0;
@@ -1112,7 +1115,7 @@ void CodeTextEditor::trim_trailing_whitespace() {
 		}
 	}
 
-	if (trimed_whitespace) {
+	if (trimmed_whitespace) {
 		text_editor->merge_overlapping_carets();
 		text_editor->end_complex_operation();
 		text_editor->queue_redraw();


### PR DESCRIPTION
To repro:
1. In a code editor, press CMD+L to show the Go to Line popup dialog.
2. The line number is incorrect. If you are on line 1, it shows 0. If you are on line 10, it shows 9.
3. Press Enter without typing anything else. The caret now moves up one line.
4. If you repeat steps 1 through 3, the text cursor / caret will keep moving up one line at a time.