### PR TITLE
`TextureProgressBar` Update upon texture changes

### DIFF
--- a/scene/gui/texture_progress_bar.h
+++ b/scene/gui/texture_progress_bar.h
@@ -113,6 +113,8 @@ private:
 	Color tint_progress = Color(1, 1, 1);
 	Color tint_over = Color(1, 1, 1);
 
+	void _set_texture(Ref<Texture2D> *p_destination, const Ref<Texture2D> &p_texture);
+	void _texture_changed();
 	Point2 unit_val_to_uv(float val);
 	Point2 get_relative_center();
 	void draw_nine_patch_stretched(const Ref<Texture2D> &p_texture, FillMode p_mode, double p_ratio, const Color &p_modulate);


### PR DESCRIPTION
Makes sure TextureProgressBar is updated on `changed` signal of any texture assigned to it. The same thing is already being done e.g. for TextureRect:
https://github.com/godotengine/godot/blob/caf7a72b029803041bee37708bfdc9de60170eca/scene/gui/texture_rect.cpp#L198-L215

Fixes #75531.