### PR TITLE
C#: Fix editor integration breaking and causing error spam when reloading assemblies fails

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -818,6 +818,9 @@
 		<member name="dotnet/project/assembly_name" type="String" setter="" getter="" default="&quot;&quot;">
 			Name of the .NET assembly. This name is used as the name of the [code].csproj[/code] and [code].sln[/code] files. By default, it's set to the name of the project ([member application/config/name]) allowing to change it in the future without affecting the .NET assembly.
 		</member>
+		<member name="dotnet/project/assembly_reload_attempts" type="int" setter="" getter="" default="3">
+			Number of times to attempt assembly reloading after rebuilding .NET assembies. Effectively also the timeout in seconds to wait for unloading of script assemblies to finish.
+		</member>
 		<member name="dotnet/project/solution_directory" type="String" setter="" getter="" default="&quot;&quot;">
 			Directory that contains the [code].sln[/code] file. By default, the [code].sln[/code] files is in the root of the project directory, next to the [code]project.godot[/code] and [code].csproj[/code] files.
 			Changing this value allows setting up a multi-project scenario where there are multiple [code].csproj[/code]. Keep in mind that the Godot project is considered one of the C# projects in the workspace and it's root directory should contain the [code]project.godot[/code] and [code].csproj[/code] next to each other.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2756,6 +2756,7 @@ bool Main::start() {
 		// Default values should be synced with mono_gd/gd_mono.cpp.
 		GLOBAL_DEF("dotnet/project/assembly_name", "");
 		GLOBAL_DEF("dotnet/project/solution_directory", "");
+		GLOBAL_DEF(PropertyInfo(Variant::INT, "dotnet/project/assembly_reload_attempts", PROPERTY_HINT_RANGE, "1,16,1,or_greater"), 3);
 #endif
 
 		Error err;

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -347,7 +347,6 @@ class CSharpLanguage : public ScriptLanguage {
 	String _debug_error;
 
 	friend class GDMono;
-	void _on_scripts_domain_about_to_unload();
 
 #ifdef TOOLS_ENABLED
 	EditorPlugin *godotsharp_editor = nullptr;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/GCHandleBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/GCHandleBridge.cs
@@ -18,5 +18,26 @@ namespace Godot.Bridge
                 ExceptionUtils.LogException(e);
             }
         }
+
+        // Returns true, if releasing the provided handle is necessary for assembly unloading to succeed.
+        // This check is not perfect and only intended to prevent things in GodotTools from being reloaded.
+        [UnmanagedCallersOnly]
+        internal static godot_bool GCHandleIsTargetCollectible(IntPtr gcHandlePtr)
+        {
+            try
+            {
+                var target = GCHandle.FromIntPtr(gcHandlePtr).Target;
+
+                if (target is Delegate @delegate)
+                    return DelegateUtils.IsDelegateCollectible(@delegate).ToGodotBool();
+
+                return target.GetType().IsCollectible.ToGodotBool();
+            }
+            catch (Exception e)
+            {
+                ExceptionUtils.LogException(e);
+                return godot_bool.True;
+            }
+        }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
@@ -38,6 +38,7 @@ namespace Godot.Bridge
         public delegate* unmanaged<IntPtr, godot_dictionary*, godot_dictionary*, void> CSharpInstanceBridge_SerializeState;
         public delegate* unmanaged<IntPtr, godot_dictionary*, godot_dictionary*, void> CSharpInstanceBridge_DeserializeState;
         public delegate* unmanaged<IntPtr, void> GCHandleBridge_FreeGCHandle;
+        public delegate* unmanaged<IntPtr, godot_bool> GCHandleBridge_GCHandleIsTargetCollectible;
         public delegate* unmanaged<void*, void> DebuggingUtils_GetCurrentStackInfo;
         public delegate* unmanaged<void> DisposablesTracker_OnGodotShuttingDown;
         public delegate* unmanaged<godot_bool, void> GD_OnCoreApiAssemblyLoaded;
@@ -78,6 +79,7 @@ namespace Godot.Bridge
                 CSharpInstanceBridge_SerializeState = &CSharpInstanceBridge.SerializeState,
                 CSharpInstanceBridge_DeserializeState = &CSharpInstanceBridge.DeserializeState,
                 GCHandleBridge_FreeGCHandle = &GCHandleBridge.FreeGCHandle,
+                GCHandleBridge_GCHandleIsTargetCollectible = &GCHandleBridge.GCHandleIsTargetCollectible,
                 DebuggingUtils_GetCurrentStackInfo = &DebuggingUtils.GetCurrentStackInfo,
                 DisposablesTracker_OnGodotShuttingDown = &DisposablesTracker.OnGodotShuttingDown,
                 GD_OnCoreApiAssemblyLoaded = &GD.OnCoreApiAssemblyLoaded,

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -68,6 +68,7 @@ class GDMono {
 
 	String project_assembly_path;
 	uint64_t project_assembly_modified_time = 0;
+	int project_load_failure_count = 0;
 
 #ifdef TOOLS_ENABLED
 	bool _load_project_assembly();
@@ -144,6 +145,7 @@ public:
 #endif
 
 #ifdef GD_MONO_HOT_RELOAD
+	void reload_failure();
 	Error reload_project_assemblies();
 #endif
 

--- a/modules/mono/mono_gd/gd_mono_cache.cpp
+++ b/modules/mono/mono_gd/gd_mono_cache.cpp
@@ -79,6 +79,7 @@ void update_godot_api_cache(const ManagedCallbacks &p_managed_callbacks) {
 	CHECK_CALLBACK_NOT_NULL(CSharpInstanceBridge, SerializeState);
 	CHECK_CALLBACK_NOT_NULL(CSharpInstanceBridge, DeserializeState);
 	CHECK_CALLBACK_NOT_NULL(GCHandleBridge, FreeGCHandle);
+	CHECK_CALLBACK_NOT_NULL(GCHandleBridge, GCHandleIsTargetCollectible);
 	CHECK_CALLBACK_NOT_NULL(DebuggingUtils, GetCurrentStackInfo);
 	CHECK_CALLBACK_NOT_NULL(DisposablesTracker, OnGodotShuttingDown);
 	CHECK_CALLBACK_NOT_NULL(GD, OnCoreApiAssemblyLoaded);

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -104,6 +104,7 @@ struct ManagedCallbacks {
 	using FuncCSharpInstanceBridge_SerializeState = void(GD_CLR_STDCALL *)(GCHandleIntPtr, const Dictionary *, const Dictionary *);
 	using FuncCSharpInstanceBridge_DeserializeState = void(GD_CLR_STDCALL *)(GCHandleIntPtr, const Dictionary *, const Dictionary *);
 	using FuncGCHandleBridge_FreeGCHandle = void(GD_CLR_STDCALL *)(GCHandleIntPtr);
+	using FuncGCHandleBridge_GCHandleIsTargetCollectible = bool(GD_CLR_STDCALL *)(GCHandleIntPtr);
 	using FuncDebuggingUtils_GetCurrentStackInfo = void(GD_CLR_STDCALL *)(Vector<ScriptLanguage::StackInfo> *);
 	using FuncDisposablesTracker_OnGodotShuttingDown = void(GD_CLR_STDCALL *)();
 	using FuncGD_OnCoreApiAssemblyLoaded = void(GD_CLR_STDCALL *)(bool);
@@ -138,6 +139,7 @@ struct ManagedCallbacks {
 	FuncCSharpInstanceBridge_SerializeState CSharpInstanceBridge_SerializeState;
 	FuncCSharpInstanceBridge_DeserializeState CSharpInstanceBridge_DeserializeState;
 	FuncGCHandleBridge_FreeGCHandle GCHandleBridge_FreeGCHandle;
+	FuncGCHandleBridge_GCHandleIsTargetCollectible GCHandleBridge_GCHandleIsTargetCollectible;
 	FuncDebuggingUtils_GetCurrentStackInfo DebuggingUtils_GetCurrentStackInfo;
 	FuncDisposablesTracker_OnGodotShuttingDown DisposablesTracker_OnGodotShuttingDown;
 	FuncGD_OnCoreApiAssemblyLoaded GD_OnCoreApiAssemblyLoaded;


### PR DESCRIPTION
- Fixes the error spam of https://github.com/godotengine/godot/issues/70026

The core issue is, that reloading user assemblies also reloads GodotTools. Then when the reloading fails all the callbacks registered from GodotTools are invalid and cause the errors and menu items and buttons no longer work.

To fix the issue, this implements a TODO about not reloading scripts (and Callables) from non-collectible assemblies and loads GodotTools as non-collectible (it can never change without an editor update anyways).

This is enough to fix the signal error spam, but because the timer to reload assembly now no longer breaks when assembly loading fails, the assembly reloading will now be reattempted forever spamming the `.NET: Failed to load project assembly.` error instead. Thus this PR also limits this to at most 5 attempts to reload the same project assembly. (If we give up on loading the assembly and the user changes things and rebuild, which now actually works from the editor, we will attempt to load it 5 times as well or maybe load it successfully)

Also upgrades the `.NET: Failed to load project assembly.` error to an editor message as otherwise there is very little indication for the user that anything has failed.

Not marking this as fixing the issue, as I haven't even started to look into why unloading even fails in the first place as that issue doesn't even have an MRP. Instead I used that the editor won't load preview versions of .net atm to produce a project that cannot be loaded: [Test_70026.zip](https://github.com/godotengine/godot/files/11122085/Test_70026.zip) (This project required a .NET 8 preview installed to build, switching the target framework between net6.0 and net8.0 can be used to switch between a loadable and non-loadable project)

EDIT: ~This does actually fix the MRP from https://github.com/godotengine/godot/issues/72435, because while the first attempt at reloading fails, the editor integration no longer breaks at it does a second attempt, which then works (IMO the unloading should happen later after the script where unloaded to properly fix this, but that is for another PR)~
