### PR TITLE
Allow to disable automatic property linking

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -565,6 +565,9 @@
 			If [code]true[/code], editor main menu is using embedded [MenuBar] instead of system global menu.
 			Specific to the macOS platform.
 		</member>
+		<member name="interface/inspector/enable_vector_property_linking_by_default" type="bool" setter="" getter="">
+			If [code]true[/code], properties with [constant @GlobalScope.PROPERTY_HINT_LINK] will be linked by default.
+		</member>
 		<member name="interface/inspector/max_array_dictionary_items_per_page" type="int" setter="" getter="">
 			The number of [Array] or [Dictionary] items to display on each "page" in the inspector. Higher values allow viewing more values per page, but take more time to load. This increased load time is noticeable when selecting nodes that have array or dictionary properties in the editor.
 		</member>

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1751,7 +1751,7 @@ void EditorPropertyVector2::setup(double p_min, double p_max, double p_step, boo
 	if (!p_link) {
 		linked->hide();
 	} else {
-		linked->set_pressed(true);
+		linked->set_pressed(EDITOR_GET("interface/inspector/enable_vector_property_linking_by_default"));
 	}
 }
 
@@ -2033,7 +2033,7 @@ void EditorPropertyVector3::setup(double p_min, double p_max, double p_step, boo
 	if (!p_link) {
 		linked->hide();
 	} else {
-		linked->set_pressed(true);
+		linked->set_pressed(EDITOR_GET("interface/inspector/enable_vector_property_linking_by_default"));
 	}
 }
 
@@ -2163,7 +2163,7 @@ void EditorPropertyVector2i::setup(int p_min, int p_max, bool p_link, const Stri
 	if (!p_link) {
 		linked->hide();
 	} else {
-		linked->set_pressed(true);
+		linked->set_pressed(EDITOR_GET("interface/inspector/enable_vector_property_linking_by_default"));
 	}
 }
 
@@ -2416,7 +2416,7 @@ void EditorPropertyVector3i::setup(int p_min, int p_max, bool p_link, const Stri
 	if (!p_link) {
 		linked->hide();
 	} else {
-		linked->set_pressed(true);
+		linked->set_pressed(EDITOR_GET("interface/inspector/enable_vector_property_linking_by_default"));
 	}
 }
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -447,6 +447,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Inspector
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/inspector/max_array_dictionary_items_per_page", 20, "10,100,1")
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/show_low_level_opentype_features", false, "")
+	_initial_set("interface/inspector/enable_vector_property_linking_by_default", true);
 
 	// Theme
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_ENUM, "interface/theme/preset", "Default", "Default,Breeze Dark,Godot 2,Gray,Light,Solarized (Dark),Solarized (Light),Black (OLED),Custom")


### PR DESCRIPTION
Adds a new editor setting that makes linking disabled by default.
Closes #68165 probably