### PR TITLE
Add horizontal scrolling to scene tab bar

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5608,12 +5608,12 @@ void EditorNode::_scene_tab_input(const Ref<InputEvent> &p_input) {
 			scene_tabs_context_menu->reset_size();
 			scene_tabs_context_menu->popup();
 		}
-		if (mb->get_button_index() == MouseButton::WHEEL_UP && mb->is_pressed()) {
+		if ((mb->get_button_index() == MouseButton::WHEEL_UP || mb->get_button_index() == MouseButton::WHEEL_LEFT) && mb->is_pressed()) {
 			int previous_tab = editor_data.get_edited_scene() - 1;
 			previous_tab = previous_tab >= 0 ? previous_tab : editor_data.get_edited_scene_count() - 1;
 			_scene_tab_changed(previous_tab);
 		}
-		if (mb->get_button_index() == MouseButton::WHEEL_DOWN && mb->is_pressed()) {
+		if ((mb->get_button_index() == MouseButton::WHEEL_DOWN || mb->get_button_index() == MouseButton::WHEEL_RIGHT) && mb->is_pressed()) {
 			int next_tab = editor_data.get_edited_scene() + 1;
 			next_tab %= editor_data.get_edited_scene_count();
 			_scene_tab_changed(next_tab);


### PR DESCRIPTION
Since you can already scroll on the tab bar to change scenes, I added the ability to use horizontal scrolling as well. Scrolling to the left goes to the previous tab, and scrolling to the right goes to the next tab.