### PR TITLE
Fix NavigationAgent enable avoidance crash

### DIFF
--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -593,6 +593,7 @@ void NavMap::set_agent_as_controlled(NavAgent *agent) {
 	if (!exist) {
 		ERR_FAIL_COND(!has_agent(agent));
 		controlled_agents.push_back(agent);
+		agents_dirty = true;
 	}
 }
 


### PR DESCRIPTION
Fixes NavigationAgent enable avoidance crash.

Fixes https://github.com/godotengine/godot/issues/75558

The crash was caused due to a missing update of the rvo agent arrays when not the agents but only the avoidance was changed in the same frame.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
