### PR TITLE
Fix some theme values affect the editor by setting a default value for them

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -861,6 +861,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("icon_pressed_color", "Button", icon_pressed_color);
 	theme->set_color("icon_disabled_color", "Button", icon_disabled_color);
 
+	theme->set_constant("h_separation", "Button", 2 * EDSCALE);
 	theme->set_constant("outline_size", "Button", 0 * EDSCALE);
 
 	const float ACTION_BUTTON_EXTRA_MARGIN = 32 * EDSCALE;
@@ -917,6 +918,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("icon_pressed_color", "MenuBar", icon_pressed_color);
 	theme->set_color("icon_disabled_color", "MenuBar", icon_disabled_color);
 
+	theme->set_constant("h_separation", "MenuBar", 4 * EDSCALE);
 	theme->set_constant("outline_size", "MenuBar", 0 * EDSCALE);
 
 	// OptionButton
@@ -1452,6 +1454,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_outline_color", "TextEdit", font_outline_color);
 	theme->set_color("caret_color", "TextEdit", font_color);
 	theme->set_color("selection_color", "TextEdit", selection_color);
+	theme->set_color("background_color", "TextEdit", Color(0, 0, 0, 0));
+
 	theme->set_constant("line_spacing", "TextEdit", 4 * EDSCALE);
 	theme->set_constant("outline_size", "TextEdit", 0 * EDSCALE);
 


### PR DESCRIPTION
Fixes parts of https://github.com/godotengine/godot/issues/60930 for 4.0.

Continuation of https://github.com/godotengine/godot/pull/71475 to fix some more theme values which affects the editor when overidden.
This PR sets a default `h_separation` for `Button` and `MenuBar` + a default `background_color` for `TextEdit`.
The default values are taken from the inspector and `default_theme.cpp`:

https://github.com/godotengine/godot/blob/21d080ead4ff09a0796574c920a76e66e8b8a3e4/scene/resources/default_theme/default_theme.cpp#L182

Note that this PR only fixes some of the more obvious theme properties, there are some more which may affect the editor.
But as mentioned here: https://github.com/godotengine/godot/pull/71475#issuecomment-1383251920, the whole problem that a custom theme can affect the editor will be eventually solved. Until then, it is a good idea to fix the most problematic properties.

The following screenshot demonstrate the problem:
- `h_separation` set to 50
- `background_color` set to red

![image](https://user-images.githubusercontent.com/66004280/229295471-aa8d1659-a2f2-4eb0-81d3-b800b5b2b319.png)
 