### PR TITLE
Make rescaling of animated canvas item optional

### DIFF
--- a/doc/classes/CanvasItemMaterial.xml
+++ b/doc/classes/CanvasItemMaterial.xml
@@ -23,6 +23,10 @@
 			If [code]true[/code], the particles animation will loop.
 			[b]Note:[/b] This property is only used and visible in the editor if [member particles_animation] is [code]true[/code].
 		</member>
+		<member name="particles_anim_resize" type="bool" setter="set_particles_anim_resize" getter="get_particles_anim_resize">
+			If [code]true[/code], the canvas item will resize to match the size of a single frame of the animation.
+			Set to [code]false[/code] for proper stretching with [TextureRect].
+		</member>
 		<member name="particles_anim_v_frames" type="int" setter="set_particles_anim_v_frames" getter="get_particles_anim_v_frames">
 			The number of rows in the spritesheet assigned as [Texture2D] for a [GPUParticles2D] or [CPUParticles2D].
 			[b]Note:[/b] This property is only used and visible in the editor if [member particles_animation] is [code]true[/code].

--- a/scene/resources/canvas_item_material.cpp
+++ b/scene/resources/canvas_item_material.cpp
@@ -126,7 +126,9 @@ void CanvasItemMaterial::_update_shader() {
 		code += "void vertex() {\n";
 		code += "	float h_frames = float(particles_anim_h_frames);\n";
 		code += "	float v_frames = float(particles_anim_v_frames);\n";
-		code += "	VERTEX.xy /= vec2(h_frames, v_frames);\n";
+		if (particles_anim_resize) {
+			code += "	VERTEX.xy /= vec2(h_frames, v_frames);\n";
+		}
 		code += "	float particle_total_frames = float(particles_anim_h_frames * particles_anim_v_frames);\n";
 		code += "	float particle_frame = floor(INSTANCE_CUSTOM.z * float(particle_total_frames));\n";
 		code += "	if (!particles_anim_loop) {\n";
@@ -227,6 +229,14 @@ bool CanvasItemMaterial::get_particles_anim_loop() const {
 	return particles_anim_loop;
 }
 
+void CanvasItemMaterial::set_particles_anim_resize(bool p_resize) {
+	particles_anim_resize = p_resize;
+	_queue_shader_change();
+}
+bool CanvasItemMaterial::get_particles_anim_resize() const {
+	return particles_anim_resize;
+}
+
 void CanvasItemMaterial::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name.begins_with("particles_anim_") && !particles_animation) {
 		p_property.usage = PROPERTY_USAGE_NONE;
@@ -261,6 +271,9 @@ void CanvasItemMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_particles_anim_loop", "loop"), &CanvasItemMaterial::set_particles_anim_loop);
 	ClassDB::bind_method(D_METHOD("get_particles_anim_loop"), &CanvasItemMaterial::get_particles_anim_loop);
 
+	ClassDB::bind_method(D_METHOD("set_particles_anim_resize", "resize"), &CanvasItemMaterial::set_particles_anim_resize);
+	ClassDB::bind_method(D_METHOD("get_particles_anim_resize"), &CanvasItemMaterial::get_particles_anim_resize);
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "blend_mode", PROPERTY_HINT_ENUM, "Mix,Add,Subtract,Multiply,Premultiplied Alpha"), "set_blend_mode", "get_blend_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "light_mode", PROPERTY_HINT_ENUM, "Normal,Unshaded,Light Only"), "set_light_mode", "get_light_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "particles_animation"), "set_particles_animation", "get_particles_animation");
@@ -268,6 +281,7 @@ void CanvasItemMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "particles_anim_h_frames", PROPERTY_HINT_RANGE, "1,128,1"), "set_particles_anim_h_frames", "get_particles_anim_h_frames");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "particles_anim_v_frames", PROPERTY_HINT_RANGE, "1,128,1"), "set_particles_anim_v_frames", "get_particles_anim_v_frames");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "particles_anim_loop"), "set_particles_anim_loop", "get_particles_anim_loop");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "particles_anim_resize"), "set_particles_anim_resize", "get_particles_anim_resize");
 
 	BIND_ENUM_CONSTANT(BLEND_MODE_MIX);
 	BIND_ENUM_CONSTANT(BLEND_MODE_ADD);

--- a/scene/resources/canvas_item_material.h
+++ b/scene/resources/canvas_item_material.h
@@ -59,6 +59,7 @@ private:
 			uint32_t light_mode : 4;
 			uint32_t particles_animation : 1;
 			uint32_t invalid_key : 1;
+			uint32_t particles_anim_resize : 1;
 		};
 
 		uint32_t key = 0;
@@ -94,6 +95,7 @@ private:
 		mk.blend_mode = blend_mode;
 		mk.light_mode = light_mode;
 		mk.particles_animation = particles_animation;
+		mk.particles_anim_resize = particles_anim_resize;
 		return mk;
 	}
 
@@ -114,6 +116,7 @@ private:
 	int particles_anim_h_frames = 0;
 	int particles_anim_v_frames = 0;
 	bool particles_anim_loop = false;
+	bool particles_anim_resize = true;
 
 protected:
 	static void _bind_methods();
@@ -136,6 +139,8 @@ public:
 
 	void set_particles_anim_loop(bool p_loop);
 	bool get_particles_anim_loop() const;
+	void set_particles_anim_resize(bool p_resize);
+	bool get_particles_anim_resize() const;
 
 	static void init_shaders();
 	static void finish_shaders();


### PR DESCRIPTION
This PR is to make UI elements able to be animated with flipbooks and still cover the whole space they're supposed to for containers constraints. 