### PR TITLE
Fix compilation warnings first pass

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -754,12 +754,10 @@ static void _scale_cubic(const uint8_t *__restrict p_src, uint8_t *__restrict p_
 
 template <int CC, class T>
 static void _scale_bilinear(const uint8_t *__restrict p_src, uint8_t *__restrict p_dst, uint32_t p_src_width, uint32_t p_src_height, uint32_t p_dst_width, uint32_t p_dst_height) {
-	enum {
-		FRAC_BITS = 8,
-		FRAC_LEN = (1 << FRAC_BITS),
-		FRAC_HALF = (FRAC_LEN >> 1),
-		FRAC_MASK = FRAC_LEN - 1
-	};
+	constexpr int FRAC_BITS = 8;
+	constexpr int FRAC_LEN = (1 << FRAC_BITS);
+	constexpr int FRAC_HALF = (FRAC_LEN >> 1);
+	constexpr int FRAC_MASK = FRAC_LEN - 1;
 
 	for (uint32_t i = 0; i < p_dst_height; i++) {
 		// Add 0.5 in order to interpolate based on pixel center

--- a/core/math/audio_frame.h
+++ b/core/math/audio_frame.h
@@ -34,7 +34,7 @@
 #include "core/math/vector2.h"
 #include "core/typedefs.h"
 
-static inline float undenormalize(volatile float f) {
+static inline float undenormalize(float f) {
 	union {
 		uint32_t i;
 		float f;


### PR DESCRIPTION
Fix a few compilation warnings around float to enum comparison [deprecated] and applying volatile on a pass by value var. There are multiple other enums that are being compared to floats which has been deprecated [https://reviews.llvm.org/D71576]. While this is a unnamed enum and scoped it looks fine; but there are other that needs to be enums. One option is to static_cast<> but that will be a lot of locations. The other option is to make it no longer an enum similar to that below or make a getter from enum->value.