### PR TITLE
Make navigation ProjectSettings always visible

### DIFF
--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -144,13 +144,13 @@ NavigationServer3D::NavigationServer3D() {
 	ERR_FAIL_COND(singleton != nullptr);
 	singleton = this;
 
-	GLOBAL_DEF("navigation/2d/default_cell_size", 1);
-	GLOBAL_DEF("navigation/2d/default_edge_connection_margin", 1);
-	GLOBAL_DEF("navigation/2d/default_link_connection_radius", 4);
+	GLOBAL_DEF_BASIC("navigation/2d/default_cell_size", 1);
+	GLOBAL_DEF_BASIC("navigation/2d/default_edge_connection_margin", 1);
+	GLOBAL_DEF_BASIC("navigation/2d/default_link_connection_radius", 4);
 
-	GLOBAL_DEF("navigation/3d/default_cell_size", 0.25);
-	GLOBAL_DEF("navigation/3d/default_edge_connection_margin", 0.25);
-	GLOBAL_DEF("navigation/3d/default_link_connection_radius", 1.0);
+	GLOBAL_DEF_BASIC("navigation/3d/default_cell_size", 0.25);
+	GLOBAL_DEF_BASIC("navigation/3d/default_edge_connection_margin", 0.25);
+	GLOBAL_DEF_BASIC("navigation/3d/default_link_connection_radius", 1.0);
 
 #ifdef DEBUG_ENABLED
 	debug_navigation_edge_connection_color = GLOBAL_DEF("debug/shapes/navigation/edge_connection_color", Color(1.0, 0.0, 1.0, 1.0));


### PR DESCRIPTION
Makes navigation ProjectSettings always visible instead of hiding them behind the "Advanced Settings".

These properties are project specific and need to be adjusted all the time especially for 2D games.

Also plenty of people did not find the Navigation ProjectSettings. Due to sorting and naming they ended up at the very end of the ProjectSettings scroll bar on top of being hidden by default with the "Advanced Settings" toggle.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
