### PR TITLE
Filter and Sort the color_map during syntax_highlighting

### DIFF
--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -47,6 +47,23 @@ Dictionary SyntaxHighlighter::get_line_syntax_highlighting(int p_line) {
 		color_map = _get_line_syntax_highlighting_impl(p_line);
 	}
 
+	// This allows us to filter (only integers) and sort (ascending) the color_map
+	Dictionary sorted_color_map;
+	Vector<Variant> sorted_keys;
+	for (const Variant *key = color_map.next(nullptr); key; key = color_map.next(key)) {
+		if (key->get_type() != Variant::INT) {
+			continue;
+		}
+		sorted_keys.push_back(*key);
+	}
+	if (!sorted_keys.is_empty()) {
+		sorted_keys.sort();
+		for (int idx = 0; idx < sorted_keys.size(); ++idx) {
+			sorted_color_map[sorted_keys[idx]] = color_map[sorted_keys[idx]];
+		}
+		color_map = sorted_color_map;
+	}
+
 	highlighting_cache[p_line] = color_map;
 	return color_map;
 }


### PR DESCRIPTION
With this PR we now filter and sort the color_map Dictionary before using it. We filter any non-integer keys and sort the remaining integer keys in ascending order.

This makes the virtual "_get_line_syntax_highlighting" method behave like one would expect, ie. that the order in which the keys of the returned Dictionary are don't matter.

Fixes https://github.com/godotengine/godot/issues/75583