### PR TITLE
un-ifdef NEED_LONG_INT

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1493,7 +1493,6 @@ Variant::operator ObjectID() const {
 	}
 }
 
-#ifdef NEED_LONG_INT
 Variant::operator signed long() const {
 	switch (type) {
 		case NIL:
@@ -1533,7 +1532,6 @@ Variant::operator unsigned long() const {
 
 	return 0;
 }
-#endif
 
 Variant::operator signed short() const {
 	switch (type) {
@@ -2428,8 +2426,6 @@ Variant::Variant(unsigned int p_int) {
 	_data._int = p_int;
 }
 
-#ifdef NEED_LONG_INT
-
 Variant::Variant(signed long p_int) {
 	type = INT;
 	_data._int = p_int;
@@ -2439,7 +2435,6 @@ Variant::Variant(unsigned long p_int) {
 	type = INT;
 	_data._int = p_int;
 }
-#endif
 
 Variant::Variant(int64_t p_int) {
 	type = INT;

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -357,13 +357,10 @@ public:
 	operator unsigned short() const;
 	operator signed char() const;
 	operator unsigned char() const;
-	//operator long unsigned int() const;
 	operator int64_t() const;
 	operator uint64_t() const;
-#ifdef NEED_LONG_INT
 	operator signed long() const;
 	operator unsigned long() const;
-#endif
 
 	operator ObjectID() const;
 

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -131,7 +131,6 @@ def configure(env: "Environment"):
             )
         )
         env.Append(ASFLAGS=["-arch", "arm64"])
-        env.Append(CPPDEFINES=["NEED_LONG_INT"])
 
     if env["ios_exceptions"]:
         env.Append(CCFLAGS=["-fexceptions"])


### PR DESCRIPTION
At least on OpenBSD the long/unsigned long version of the Variant constructor and accessors are needed.

Fixes #74669
