### PR TITLE
[TextEdit] Fix block caret size at the end of the line.

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1385,7 +1385,7 @@ void TextEdit::_notification(int p_what) {
 													ts_caret.l_caret.position.y += ts_caret.l_caret.size.y;
 													ts_caret.l_caret.size.y = caret_width;
 												}
-												if (ts_caret.l_caret.position.x >= TS->shaped_text_get_size(rid).x) {
+												if (Math::ceil(ts_caret.l_caret.position.x) >= TS->shaped_text_get_size(rid).x) {
 													ts_caret.l_caret.size.x = font->get_char_size('m', font_size).x;
 												} else {
 													ts_caret.l_caret.size.x = 3 * caret_width;


### PR DESCRIPTION
Fixes rounding error that was causing block caret to be min. size instead of `m` size.

| Before | After |
|---|---|
| <img width="75" alt="Screenshot 2023-04-02 at 21 00 01" src="https://user-images.githubusercontent.com/7645683/229370493-1b796564-fa8e-46ba-8511-9646c0407941.png"> | <img width="75" alt="Screenshot 2023-04-02 at 20 54 43" src="https://user-images.githubusercontent.com/7645683/229370299-88a5f0cc-a053-4b0c-b821-454f5213bbed.png"> |
