### PR TITLE
Make GDScript type not found errors more informative.

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4121,9 +4121,6 @@ String GDScriptParser::DataType::to_string() const {
 			}
 			return native_type.operator String();
 		case CLASS:
-			if (is_meta_type) {
-				return GDScript::get_class_static();
-			}
 			if (class_type->identifier != nullptr) {
 				return class_type->identifier->name.operator String();
 			}

--- a/modules/gdscript/tests/scripts/analyzer/errors/prints_base_type_not_found.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/prints_base_type_not_found.gd
@@ -1,0 +1,6 @@
+class InnerClass:
+	pass
+
+func test():
+	var x : InnerClass.DoesNotExist
+	print("FAIL")

--- a/modules/gdscript/tests/scripts/analyzer/errors/prints_base_type_not_found.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/prints_base_type_not_found.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Could not find type "DoesNotExist" under base "InnerClass".


### PR DESCRIPTION
This PR removes a check for whether a datatype is a meta type when generating a datatype's to_string() result. This means that error messages that fail to find the type will now print their class names, which is much more useful when trying to identify errors.

Before:

![image](https://user-images.githubusercontent.com/1133892/229381909-0f2cd3b3-af72-4a38-a508-f803e9df14a0.png)

After:

![image](https://user-images.githubusercontent.com/1133892/229381961-e6719d96-4808-40d4-b5f8-7c56eb667d4e.png)


I don't believe this will have any undesirable side-effects, and there are maybe a couple more similar lines in the changed function that might receive a similar treatment :)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
