### PR TITLE
Implement file-extension-aware Scanner and Replacer for the FindInFilesPanel

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1348,6 +1348,7 @@ ProjectSettings::ProjectSettings() {
 		extensions.push_back("cs");
 	}
 	extensions.push_back("gdshader");
+	extensions.push_back("tscn");
 
 	GLOBAL_DEF(PropertyInfo(Variant::PACKED_STRING_ARRAY, "editor/script/search_in_file_extensions"), extensions);
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -905,8 +905,8 @@
 			prime-run %command%
 			[/codeblock]
 		</member>
-		<member name="editor/script/search_in_file_extensions" type="PackedStringArray" setter="" getter="" default="PackedStringArray(&quot;gd&quot;, &quot;gdshader&quot;)">
-			Text-based file extensions to include in the script editor's "Find in Files" feature. You can add e.g. [code]tscn[/code] if you wish to also parse your scene files, especially if you use built-in scripts which are serialized in the scene files.
+		<member name="editor/script/search_in_file_extensions" type="PackedStringArray" setter="" getter="" default="PackedStringArray(&quot;gd&quot;, &quot;gdshader&quot;, &quot;tscn&quot;)">
+			Text-based file extensions to include in the script editor's "Find in Files" feature.
 		</member>
 		<member name="editor/script/templates_search_path" type="String" setter="" getter="" default="&quot;res://script_templates&quot;">
 			Search path for project-specific script templates. Godot will search for script templates both in the editor-specific path and in this project-specific path.

--- a/doc/classes/ScriptScanner.xml
+++ b/doc/classes/ScriptScanner.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ScriptScanner" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_get_supported_extensions" qualifiers="virtual const">
+			<return type="PackedStringArray" />
+			<description>
+			</description>
+		</method>
+		<method name="_replace" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="file" type="FileAccess" />
+			<param index="1" name="file_path" type="String" />
+			<param index="2" name="display_path" type="String" />
+			<param index="3" name="locations" type="Dictionary[]" />
+			<param index="4" name="match_case" type="bool" />
+			<param index="5" name="whole_words" type="bool" />
+			<param index="6" name="search_text" type="String" />
+			<param index="7" name="new_text" type="String" />
+			<param index="8" name="range" type="Vector2i" />
+			<description>
+			</description>
+		</method>
+		<method name="_scan" qualifiers="virtual const">
+			<return type="Dictionary[]" />
+			<param index="0" name="file" type="FileAccess" />
+			<param index="1" name="display_path" type="String" />
+			<param index="2" name="pattern" type="String" />
+			<param index="3" name="match_case" type="bool" />
+			<param index="4" name="whole_words" type="bool" />
+			<param index="5" name="range" type="Vector2i" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/ScriptSearchReplace.xml
+++ b/doc/classes/ScriptSearchReplace.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ScriptSearchReplace" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="add_scanner">
+			<return type="void" />
+			<param index="0" name="scanner" type="ScriptScanner" />
+			<param index="1" name="at_front" type="bool" default="false" />
+			<description>
+			</description>
+		</method>
+		<method name="assemble_scan_location">
+			<return type="Dictionary" />
+			<param index="0" name="line_number" type="int" />
+			<param index="1" name="begin" type="int" />
+			<param index="2" name="end" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="assemble_scan_match">
+			<return type="Dictionary" />
+			<param index="0" name="file_path" type="String" />
+			<param index="1" name="display_text" type="String" />
+			<param index="2" name="line_number" type="int" />
+			<param index="3" name="begin" type="int" />
+			<param index="4" name="end" type="int" />
+			<param index="5" name="line" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="get_singleton" qualifiers="static">
+			<return type="ScriptSearchReplace" />
+			<description>
+			</description>
+		</method>
+		<method name="get_suitable_scanner" qualifiers="const">
+			<return type="ScriptScanner" />
+			<param index="0" name="extension" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="remove_scanner">
+			<return type="void" />
+			<param index="0" name="scanner" type="ScriptScanner" />
+			<description>
+			</description>
+		</method>
+		<method name="replace" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="file_path" type="String" />
+			<param index="1" name="display_path" type="String" />
+			<param index="2" name="locations" type="Dictionary[]" />
+			<param index="3" name="match_case" type="bool" />
+			<param index="4" name="whole_words" type="bool" />
+			<param index="5" name="search_text" type="String" />
+			<param index="6" name="new_text" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="scan" qualifiers="const">
+			<return type="Dictionary[]" />
+			<param index="0" name="file_path" type="String" />
+			<param index="1" name="display_path" type="String" />
+			<param index="2" name="pattern" type="String" />
+			<param index="3" name="match_case" type="bool" />
+			<param index="4" name="whole_words" type="bool" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/editor/find_in_files.h
+++ b/editor/find_in_files.h
@@ -38,6 +38,30 @@
 class FindInFiles : public Node {
 	GDCLASS(FindInFiles, Node);
 
+private:
+	void _process();
+	void _iterate();
+	void _scan_dir(String path, PackedStringArray &out_folders);
+
+	// Config
+	String _pattern;
+	HashSet<String> _extension_filter;
+	String _root_dir;
+	bool _whole_words = true;
+	bool _match_case = true;
+
+	// State
+	bool _searching = false;
+	String _current_dir;
+	Vector<PackedStringArray> _folders_stack;
+	Vector<String> _files_to_scan;
+	int _initial_files_count = 0;
+
+protected:
+	void _notification(int p_what);
+
+	static void _bind_methods();
+
 public:
 	static const char *SIGNAL_RESULT_FOUND;
 	static const char *SIGNAL_FINISHED;
@@ -58,31 +82,6 @@ public:
 
 	bool is_searching() const { return _searching; }
 	float get_progress() const;
-
-protected:
-	void _notification(int p_what);
-
-	static void _bind_methods();
-
-private:
-	void _process();
-	void _iterate();
-	void _scan_dir(String path, PackedStringArray &out_folders);
-	void _scan_file(String fpath);
-
-	// Config
-	String _pattern;
-	HashSet<String> _extension_filter;
-	String _root_dir;
-	bool _whole_words = true;
-	bool _match_case = true;
-
-	// State
-	bool _searching = false;
-	String _current_dir;
-	Vector<PackedStringArray> _folders_stack;
-	Vector<String> _files_to_scan;
-	int _initial_files_count = 0;
 };
 
 class LineEdit;
@@ -176,7 +175,7 @@ protected:
 	void _notification(int p_what);
 
 private:
-	void _on_result_found(String fpath, int line_number, int begin, int end, String text);
+	void _on_result_found(String display_text, String relative_path, String absolute_path, int line_number, int begin, int end, String text);
 	void _on_finished();
 	void _on_refresh_button_clicked();
 	void _on_cancel_button_clicked();
@@ -192,7 +191,6 @@ private:
 		int begin_trimmed = 0;
 	};
 
-	void apply_replaces_in_file(String fpath, const Vector<Result> &locations, String new_text);
 	void update_replace_buttons();
 	String get_replace_text();
 

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -481,7 +481,7 @@ class ScriptEditor : public PanelContainer {
 
 	void _on_find_in_files_requested(String text);
 	void _on_replace_in_files_requested(String text);
-	void _on_find_in_files_result_selected(String fpath, int line_number, int begin, int end);
+	void _on_find_in_files_result_selected(String relative_path, String absolute_path, int line_number, int begin, int end);
 	void _start_find_in_files(bool with_replace);
 	void _on_find_in_files_modified_files(PackedStringArray paths);
 

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -127,6 +127,7 @@
 #include "editor/plugins/visual_shader_editor_plugin.h"
 #include "editor/plugins/voxel_gi_editor_plugin.h"
 #include "editor/register_exporters.h"
+#include "editor/script_search_replace.h"
 
 void register_editor_types() {
 	OS::get_singleton()->benchmark_begin_measure("register_editor_types");
@@ -197,6 +198,9 @@ void register_editor_types() {
 	GDREGISTER_CLASS(ResourceImporterTexture);
 	GDREGISTER_CLASS(ResourceImporterTextureAtlas);
 	GDREGISTER_CLASS(ResourceImporterWAV);
+
+	GDREGISTER_CLASS(ScriptSearchReplace);
+	GDREGISTER_CLASS(ScriptScanner);
 
 	// This list is alphabetized, and plugins that depend on Node2D are in their own section below.
 	EditorPlugins::add_by_type<AnimationTreeEditorPlugin>();

--- a/editor/script_builtin_scanner.cpp
+++ b/editor/script_builtin_scanner.cpp
@@ -1,0 +1,124 @@
+/**************************************************************************/
+/*  script_builtin_scanner.cpp                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "script_builtin_scanner.h"
+
+#include "core/core_bind.h"
+#include "editor/editor_node.h"
+#include "editor/plugins/text_editor.h"
+#include "modules/gdscript/gdscript.h"
+#include "scene/resources/packed_scene.h"
+
+TypedArray<Dictionary> ScriptBuiltinScanner::scan(Ref<FileAccess> p_file, String p_display_path, String p_pattern, bool p_match_case, bool p_whole_words, Size2i p_range) {
+	TypedArray<Dictionary> matches;
+
+	Vector<Ref<Script>> found_scripts = _parse_scene(p_file->get_path());
+	for (Ref<Script> scr : found_scripts) {
+		String source_code = scr->get_source_code();
+		String line;
+		int line_number = 1; // Line number starts at 1.
+		for (int char_idx = 0; char_idx < source_code.length(); char_idx++) {
+			line += source_code[char_idx];
+			if (source_code[char_idx] == '\n') {
+				if (!_scan_line(line, line_number, p_file->get_path(), p_display_path, p_pattern, p_match_case, p_whole_words, p_range, matches)) {
+					break;
+				}
+				line_number++;
+				line = "";
+			}
+		}
+
+		// Update the display_text and file_path to reference the actual scr itself (within the scene file).
+		for (int k = 0; k < matches.size(); k++) {
+			Dictionary match = matches[k];
+			match["display_text"] = scr->get_path();
+			match["file_path"] = scr->get_path();
+		}
+	}
+
+	return matches;
+}
+
+bool ScriptBuiltinScanner::replace(Ref<FileAccess> p_file, String p_file_path, String p_display_path, TypedArray<Dictionary> p_locations, bool p_match_case, bool p_whole_words, String p_search_text, String p_new_text, Size2i p_range) {
+	Ref<Script> scr = _parse_scene(p_file_path, p_display_path);
+	if (scr == nullptr) {
+		// Failed to parse the builtin script.
+		return false;
+	}
+
+	String result;
+	bool ok = _replace(scr->get_source_code(), p_file_path, p_display_path, p_locations, p_match_case, p_whole_words, p_search_text, p_new_text, p_range, result);
+
+	if (!ok) {
+		// Nothing to replace, sort-of a success.
+		return true;
+	}
+
+	// TODO: Reload opened builtin scripts.
+	scr->set_source_code(result);
+	ResourceSaver::save(scr, p_display_path);
+
+	return true;
+}
+
+Vector<Ref<Script>> ScriptBuiltinScanner::_parse_scene(String p_file_path) const {
+	Vector<Ref<Script>> found_scripts;
+
+	Error err;
+	Ref<PackedScene> packed_scene = ResourceLoader::load(p_file_path, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
+	ERR_FAIL_COND_V_MSG(packed_scene.is_null(), found_scripts, vformat("Failed opening PackedScene with error: %s", err));
+	Ref<SceneState> state = packed_scene->get_state();
+
+	for (int i = 0; i < state->get_node_count(); i++) {
+		for (int j = 0; j < state->get_node_property_count(i); j++) {
+			StringName property_name = state->get_node_property_name(i, j);
+			if (property_name != SNAME("script")) {
+				continue;
+			}
+			Variant scr = state->get_node_property_value(i, j);
+			Ref<Script> gdscript = Object::cast_to<Script>(scr);
+			if (gdscript != nullptr && gdscript->is_built_in()) {
+				found_scripts.append(gdscript);
+			}
+		}
+	}
+
+	return found_scripts;
+}
+
+Ref<Script> ScriptBuiltinScanner::_parse_scene(String p_file_path, String p_display_path) const {
+	for (Ref<Script> scr : _parse_scene(p_file_path)) {
+		if (scr->get_path() == p_display_path) {
+			return scr;
+		}
+	}
+
+	return nullptr;
+}

--- a/editor/script_builtin_scanner.h
+++ b/editor/script_builtin_scanner.h
@@ -1,0 +1,50 @@
+/**************************************************************************/
+/*  script_builtin_scanner.h                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef SCRIPT_BUILTIN_SCANNER_H
+#define SCRIPT_BUILTIN_SCANNER_H
+
+#include "script_search_replace.h"
+
+#include "core/variant/typed_array.h"
+#include "script_default_scanner.h"
+
+class ScriptBuiltinScanner : public ScriptDefaultScanner {
+private:
+	Vector<Ref<Script>> _parse_scene(String p_file_path) const;
+	Ref<Script> _parse_scene(String p_file_path, String p_display_path) const;
+
+public:
+	virtual PackedStringArray get_supported_extensions() const { return { "tscn" }; }
+	virtual TypedArray<Dictionary> scan(Ref<FileAccess> p_file, String p_display_path, String p_pattern, bool p_match_case, bool p_whole_words, Size2i p_range = Size2i(1, -1));
+	virtual bool replace(Ref<FileAccess> p_file, String p_file_path, String p_display_path, TypedArray<Dictionary> p_locations, bool p_match_case, bool p_whole_words, String p_search_text, String p_new_text, Size2i p_range = Size2i(1, -1));
+};
+
+#endif // SCRIPT_BUILTIN_SCANNER_H

--- a/editor/script_default_scanner.cpp
+++ b/editor/script_default_scanner.cpp
@@ -1,0 +1,168 @@
+/**************************************************************************/
+/*  script_default_scanner.cpp                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "script_default_scanner.h"
+
+TypedArray<Dictionary> ScriptDefaultScanner::scan(Ref<FileAccess> p_file, String p_display_path, String p_pattern, bool p_match_case, bool p_whole_words, Size2i p_range) {
+	TypedArray<Dictionary> matches;
+
+	// Line number starts at 1.
+	for (int line_number = 1; !p_file->eof_reached(); line_number++) {
+		String line = p_file->get_line();
+		if (!_scan_line(line, line_number, p_file->get_path(), p_display_path, p_pattern, p_match_case, p_whole_words, p_range, matches)) {
+			break;
+		}
+	}
+
+	return matches;
+}
+
+bool ScriptDefaultScanner::replace(Ref<FileAccess> p_file, String p_file_path, String p_display_path, TypedArray<Dictionary> p_locations, bool p_match_case, bool p_whole_words, String p_search_text, String p_new_text, Size2i p_range) {
+	String buffer;
+	_replace(p_file->get_as_text(), p_file_path, p_display_path, p_locations, p_match_case, p_whole_words, p_search_text, p_new_text, p_range, buffer);
+
+	// Now the modified contents are in the buffer, rewrite the file with our changes.
+	Error err = p_file->reopen(p_file->get_path(), FileAccess::WRITE);
+	ERR_FAIL_COND_V_MSG(err != OK, false, vformat("Cannot create file in path '%s'.", p_display_path));
+
+	p_file->store_string(buffer);
+	return true;
+}
+
+bool ScriptDefaultScanner::_scan_line(String p_line, int p_line_number, String p_path, String p_display_path, String p_pattern, bool p_match_case, bool p_whole_words, Size2i p_range, TypedArray<Dictionary> &p_matches) {
+	int begin = 0, end = 0;
+	if (p_line_number < p_range.x) {
+		return true;
+	} else if (p_range.y > 0 && p_line_number > p_range.y) {
+		return false;
+	}
+
+	while (_find_next(p_line, p_pattern, end, p_match_case, p_whole_words, begin, end)) {
+		ScriptSearchReplace::ScanMatch match = ScriptSearchReplace::ScanMatch{ p_path, p_display_path, p_line_number - p_range.x + 1, begin, end, p_line };
+		p_matches.append(match.to_dict());
+	}
+
+	return true;
+}
+
+bool ScriptDefaultScanner::_replace(String p_source_code, String p_file_path, String p_display_path, TypedArray<Dictionary> p_locations, bool p_match_case, bool p_whole_words, String p_search_text, String p_new_text, Size2i p_range, String &p_result) {
+	int current_line = 1;
+
+	line_buffer_idx = 0;
+	String line = _get_line(p_source_code);
+
+	int offset = 0;
+
+	for (int i = 0; i < p_locations.size(); ++i) {
+		ScriptSearchReplace::ScanLocation location = ScriptSearchReplace::ScanLocation::from_dict(p_locations[i]);
+		int repl_line_number = location.line_number + (p_range.x - 1); // "- 1" because p_range is in terms of "visual lines", which starts at 1, but here we need it to start at 0.
+
+		while (current_line < repl_line_number) {
+			p_result += line;
+			line = _get_line(p_source_code);
+			++current_line;
+			offset = 0;
+		}
+
+		int repl_begin = location.begin + offset;
+		int repl_end = location.end + offset;
+
+		int _;
+		if (!_find_next(line, p_search_text, repl_begin, p_match_case, p_whole_words, _, _)) {
+			// Make sure the replacement is still valid in case the file was tampered with.
+			print_verbose(vformat("Occurrence no longer matches, replace will be ignored in %s: line %d, col %d", p_display_path, repl_line_number, repl_begin));
+			continue;
+		}
+
+		line = line.left(repl_begin) + p_new_text + line.substr(repl_end);
+		// Keep an offset in case there are successive replaces in the same line.
+		offset += p_new_text.length() - (repl_end - repl_begin);
+	}
+
+	p_result += line;
+
+	while (line_buffer_idx < p_source_code.size() - 1) {
+		p_result += _get_line(p_source_code);
+	}
+
+	return current_line > 1 || p_result != p_source_code;
+}
+
+bool ScriptDefaultScanner::_find_next(const String &p_line, String p_pattern, int from, bool p_match_case, bool p_whole_words, int &out_begin, int &out_end) {
+	int end = from;
+
+	while (true) {
+		int begin = p_match_case ? p_line.find(p_pattern, end) : p_line.findn(p_pattern, end);
+
+		if (begin == -1) {
+			return false;
+		}
+
+		end = begin + p_pattern.length();
+		out_begin = begin;
+		out_end = end;
+
+		if (p_whole_words) {
+			if (begin > 0 && (is_ascii_identifier_char(p_line[begin - 1]))) {
+				continue;
+			}
+			if (end < p_line.size() && (is_ascii_identifier_char(p_line[end]))) {
+				continue;
+			}
+		}
+
+		return true;
+	}
+}
+
+String ScriptDefaultScanner::_get_line(String source_code) {
+	line_buffer.clear();
+	char32_t c = source_code[line_buffer_idx++];
+
+	while (line_buffer_idx < source_code.size() - 1) {
+		if (c == '\n') {
+			line_buffer.push_back(c);
+			line_buffer.push_back(0);
+			return String::utf8(line_buffer.ptr());
+
+		} else if (c == '\0') {
+			line_buffer.push_back(c);
+			return String::utf8(line_buffer.ptr());
+
+		} else if (c != '\r') {
+			line_buffer.push_back(c);
+		}
+
+		c = source_code[line_buffer_idx++];
+	}
+
+	line_buffer.push_back(0);
+	return String::utf8(line_buffer.ptr());
+}

--- a/editor/script_default_scanner.h
+++ b/editor/script_default_scanner.h
@@ -1,0 +1,55 @@
+/**************************************************************************/
+/*  script_default_scanner.h                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef SCRIPT_DEFAULT_SCANNER_H
+#define SCRIPT_DEFAULT_SCANNER_H
+
+#include "script_search_replace.h"
+
+#include "core/variant/typed_array.h"
+
+class ScriptDefaultScanner : public ScriptScanner {
+protected:
+	Vector<char> line_buffer;
+	int line_buffer_idx = 0;
+
+	// Same as get_line, but preserves line ending characters.
+	String _get_line(String p_source_code);
+	bool _find_next(const String &p_line, String p_pattern, int p_from, bool p_match_case, bool p_whole_words, int &out_begin, int &out_end);
+
+	bool _scan_line(String p_line, int p_line_number, String p_path, String p_display_path, String p_pattern, bool p_match_case, bool p_whole_words, Size2i p_range, TypedArray<Dictionary> &p_matches);
+	bool _replace(String p_source_code, String p_file_path, String p_display_path, TypedArray<Dictionary> p_locations, bool p_match_case, bool p_whole_words, String p_search_text, String p_new_text, Size2i p_range, String &result);
+
+public:
+	virtual TypedArray<Dictionary> scan(Ref<FileAccess> p_file, String p_display_path, String p_pattern, bool p_match_case, bool p_whole_words, Size2i p_range = Size2i(1, -1));
+	virtual bool replace(Ref<FileAccess> p_file, String p_file_path, String p_display_path, TypedArray<Dictionary> p_locations, bool p_match_case, bool p_whole_words, String p_search_text, String p_new_text, Size2i p_range = Size2i(1, -1));
+};
+
+#endif // SCRIPT_DEFAULT_SCANNER_H

--- a/editor/script_search_replace.cpp
+++ b/editor/script_search_replace.cpp
@@ -1,0 +1,226 @@
+/**************************************************************************/
+/*  script_search_replace.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "script_search_replace.h"
+
+#include "script_builtin_scanner.h"
+#include "script_default_scanner.h"
+
+ScriptSearchReplace *ScriptSearchReplace::singleton = nullptr;
+
+static Ref<ScriptBuiltinScanner> builtin_scanner;
+static Ref<ScriptDefaultScanner> default_scanner;
+
+ScriptSearchReplace *ScriptSearchReplace::get_singleton() {
+	if (singleton == nullptr) {
+		memnew(ScriptSearchReplace);
+	}
+	return singleton;
+}
+
+TypedArray<Dictionary> ScriptSearchReplace::scan(String p_file_path, String p_display_path, String p_pattern, bool p_match_case, bool p_whole_words) const {
+	Ref<FileAccess> file = FileAccess::open(p_file_path, FileAccess::READ);
+	ERR_FAIL_COND_V_MSG(file.is_null(), {}, "Error opening file: '" + p_file_path + "'.");
+
+	String extension = file->get_path().get_extension().to_lower();
+	Ref<ScriptScanner> scanner = get_suitable_scanner(extension);
+	if (scanner.is_valid()) {
+		return scanner->scan(file, p_display_path, p_pattern, p_match_case, p_whole_words);
+	}
+
+	return {};
+}
+
+bool ScriptSearchReplace::replace(String p_file_path, String p_display_path, TypedArray<Dictionary> p_locations, bool p_match_case, bool p_whole_words, String p_search_text, String p_new_text) const {
+	Ref<FileAccess> file = FileAccess::open(p_file_path, FileAccess::READ);
+	ERR_FAIL_COND_V_MSG(file.is_null(), false, "Error opening file: '" + p_file_path + "'.");
+
+	String extension = file->get_path().get_extension().to_lower();
+	Ref<ScriptScanner> scanner = get_suitable_scanner(extension);
+	if (scanner.is_valid()) {
+		return scanner->replace(file, p_file_path, p_display_path, p_locations, p_match_case, p_whole_words, p_search_text, p_new_text);
+	}
+
+	return false;
+}
+
+void ScriptSearchReplace::add_scanner(Ref<ScriptScanner> p_scanner, bool p_at_front) {
+	ERR_FAIL_COND(p_scanner.is_null());
+	ERR_FAIL_COND(scanners_count >= MAX_SCANNERS);
+
+	if (p_at_front) {
+		for (int i = scanners_count; i > 0; i--) {
+			scanners[i] = scanners[i - 1];
+		}
+		scanners[0] = p_scanner;
+		scanners_count++;
+	} else {
+		scanners[scanners_count++] = p_scanner;
+	}
+}
+
+void ScriptSearchReplace::remove_scanner(Ref<ScriptScanner> p_scanner) {
+	ERR_FAIL_COND(p_scanner.is_null());
+
+	// Find scanner
+	int i = 0;
+	for (; i < scanners_count; ++i) {
+		if (scanners[i] == p_scanner) {
+			break;
+		}
+	}
+
+	ERR_FAIL_COND(i >= scanners_count); // Not found
+
+	// Shift next scanners up
+	for (; i < scanners_count - 1; ++i) {
+		scanners[i] = scanners[i + 1];
+	}
+	scanners[scanners_count - 1].unref();
+	--scanners_count;
+}
+
+Ref<ScriptScanner> ScriptSearchReplace::get_suitable_scanner(String p_extension) const {
+	for (int i = 0; i < scanners_count; i++) {
+		Ref<ScriptScanner> scanner = scanners[i];
+		PackedStringArray supported_extensions = scanner->get_supported_extensions();
+		if (supported_extensions.has(p_extension)) {
+			return scanner;
+			break;
+		}
+	}
+
+	return default_scanner;
+}
+
+Dictionary ScriptSearchReplace::assemble_scan_match(String p_file_path, String p_display_path, int p_line_number, int p_begin, int p_end, String p_line) {
+	return ScanMatch{ p_file_path, p_display_path, p_line_number, p_begin, p_end, p_line }.to_dict();
+}
+
+Dictionary ScriptSearchReplace::ScanMatch::to_dict() {
+	Dictionary ret;
+	ret["file_path"] = file_path;
+	ret["display_text"] = display_text;
+	ret["line_number"] = line_number;
+	ret["begin"] = begin;
+	ret["end"] = end;
+	ret["line"] = line;
+	return ret;
+}
+
+ScriptSearchReplace::ScanMatch ScriptSearchReplace::ScanMatch::from_dict(Dictionary p_dict) {
+	return ScriptSearchReplace::ScanMatch{
+		p_dict["file_path"],
+		p_dict["display_text"],
+		p_dict["line_number"],
+		p_dict["begin"],
+		p_dict["end"],
+		p_dict["line"],
+	};
+}
+
+Dictionary ScriptSearchReplace::assemble_scan_location(int p_line_number, int p_begin, int p_end) {
+	return ScanLocation{ p_line_number, p_begin, p_end }.to_dict();
+}
+
+Dictionary ScriptSearchReplace::ScanLocation::to_dict() {
+	Dictionary ret;
+	ret["line_number"] = line_number;
+	ret["begin"] = begin;
+	ret["end"] = end;
+	return ret;
+}
+
+ScriptSearchReplace::ScanLocation ScriptSearchReplace::ScanLocation::from_dict(Dictionary p_dict) {
+	return ScriptSearchReplace::ScanLocation{
+		p_dict["line_number"],
+		p_dict["begin"],
+		p_dict["end"],
+	};
+}
+
+PackedStringArray ScriptScanner::get_supported_extensions() const {
+	PackedStringArray ret;
+	if (GDVIRTUAL_CALL(_get_supported_extensions, ret)) {
+		return ret;
+	}
+	return {};
+}
+
+TypedArray<Dictionary> ScriptScanner::scan(Ref<FileAccess> p_file, String p_display_path, String p_pattern, bool p_match_case, bool p_whole_words, Size2i p_range) {
+	TypedArray<Dictionary> ret;
+	GDVIRTUAL_CALL(_scan, p_file, p_display_path, p_pattern, p_match_case, p_whole_words, p_range, ret);
+	return ret;
+}
+
+bool ScriptScanner::replace(Ref<FileAccess> p_file, String p_file_path, String p_display_path, TypedArray<Dictionary> p_locations, bool p_match_case, bool p_whole_words, String p_search_text, String p_new_text, Size2i p_range) {
+	bool success = false;
+	GDVIRTUAL_CALL(_replace, p_file, p_file_path, p_display_path, p_locations, p_match_case, p_whole_words, p_search_text, p_new_text, p_range, success);
+	return success;
+}
+
+void ScriptScanner::_bind_methods() {
+	GDVIRTUAL_BIND(_get_supported_extensions);
+	GDVIRTUAL_BIND(_scan, "file", "display_path", "pattern", "match_case", "whole_words", "range");
+	GDVIRTUAL_BIND(_replace, "file", "file_path", "display_path", "locations", "match_case", "whole_words", "search_text", "new_text", "range");
+}
+
+void ScriptSearchReplace::_bind_methods() {
+	ClassDB::bind_static_method("ScriptSearchReplace", D_METHOD("get_singleton"), &ScriptSearchReplace::get_singleton);
+
+	ClassDB::bind_method(D_METHOD("add_scanner", "scanner", "at_front"), &ScriptSearchReplace::add_scanner, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("remove_scanner", "scanner"), &ScriptSearchReplace::remove_scanner);
+	ClassDB::bind_method(D_METHOD("get_suitable_scanner", "extension"), &ScriptSearchReplace::get_suitable_scanner);
+
+	ClassDB::bind_method(D_METHOD("assemble_scan_match", "file_path", "display_text", "line_number", "begin", "end", "line"), &ScriptSearchReplace::assemble_scan_match);
+	ClassDB::bind_method(D_METHOD("assemble_scan_location", "line_number", "begin", "end"), &ScriptSearchReplace::assemble_scan_location);
+
+	ClassDB::bind_method(D_METHOD("scan", "file_path", "display_path", "pattern", "match_case", "whole_words"), &ScriptSearchReplace::scan);
+	ClassDB::bind_method(D_METHOD("replace", "file_path", "display_path", "locations", "match_case", "whole_words", "search_text", "new_text"), &ScriptSearchReplace::replace);
+}
+
+ScriptSearchReplace::ScriptSearchReplace() {
+	singleton = this;
+
+	builtin_scanner.instantiate();
+	singleton->add_scanner(builtin_scanner);
+
+	::default_scanner.instantiate();
+	singleton->set_default_scanner(::default_scanner);
+}
+
+ScriptSearchReplace::~ScriptSearchReplace() {
+	for (int i = 0; i < singleton->scanners_count; i++) {
+		singleton->scanners[i].unref();
+	}
+	singleton->default_scanner.unref();
+
+	singleton = nullptr;
+}

--- a/editor/script_search_replace.h
+++ b/editor/script_search_replace.h
@@ -1,0 +1,117 @@
+/**************************************************************************/
+/*  script_search_replace.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef SCRIPT_SEARCH_REPLACE_H
+#define SCRIPT_SEARCH_REPLACE_H
+
+#include "core/io/file_access.h"
+#include "core/object/gdvirtual.gen.inc"
+#include "core/object/object.h"
+#include "core/object/script_language.h"
+#include "core/variant/typed_array.h"
+
+class ScriptScanner : public RefCounted {
+	GDCLASS(ScriptScanner, RefCounted);
+
+protected:
+	static void _bind_methods();
+
+	GDVIRTUAL0RC(String, _get_name);
+	GDVIRTUAL0RC(PackedStringArray, _get_supported_extensions);
+	GDVIRTUAL6RC(TypedArray<Dictionary>, _scan, Ref<FileAccess>, String, String, bool, bool, Size2i);
+	GDVIRTUAL9RC(bool, _replace, Ref<FileAccess>, String, String, TypedArray<Dictionary>, bool, bool, String, String, Size2i);
+
+public:
+	virtual PackedStringArray get_supported_extensions() const;
+	virtual TypedArray<Dictionary> scan(Ref<FileAccess> p_file, String p_display_path, String p_pattern, bool p_match_case, bool p_whole_words, Size2i p_range = Size2i(1, -1));
+	virtual bool replace(Ref<FileAccess> p_file, String p_file_path, String p_display_path, TypedArray<Dictionary> p_locations, bool p_match_case, bool p_whole_words, String p_search_text, String p_new_text, Size2i p_range = Size2i(1, -1));
+
+	virtual ~ScriptScanner() {}
+};
+
+class ScriptSearchReplace : public Object {
+	GDCLASS(ScriptSearchReplace, Object);
+
+	static ScriptSearchReplace *singleton;
+
+	enum {
+		MAX_SCANNERS = 64
+	};
+
+private:
+	Ref<ScriptScanner> default_scanner = nullptr;
+	Ref<ScriptScanner> scanners[MAX_SCANNERS];
+	int scanners_count = 0;
+
+	void set_default_scanner(Ref<ScriptScanner> p_scanner) { default_scanner = p_scanner; }
+
+protected:
+	static void _bind_methods();
+
+public:
+	struct ScanMatch {
+		String file_path; // Allows us to specify different paths for builtin scripts
+		String display_text;
+		int line_number;
+		int begin;
+		int end;
+		String line;
+
+		Dictionary to_dict();
+		static ScanMatch from_dict(Dictionary p_dict);
+	};
+	struct ScanLocation {
+		int line_number = 0;
+		int begin = 0;
+		int end = 0;
+
+		Dictionary to_dict();
+		static ScanLocation from_dict(Dictionary p_dict);
+	};
+
+	static ScriptSearchReplace *get_singleton();
+
+	void add_scanner(Ref<ScriptScanner> p_scanner, bool p_at_front = false);
+	void remove_scanner(Ref<ScriptScanner> p_scanner);
+	Ref<ScriptScanner> get_default_scanner() const { return default_scanner; }
+	Ref<ScriptScanner> get_suitable_scanner(String p_extension) const;
+
+	// Type Helpers
+	Dictionary assemble_scan_match(String p_file_path, String p_display_path, int p_line_number, int p_begin, int p_end, String p_line);
+	Dictionary assemble_scan_location(int p_line_number, int p_begin, int p_end);
+
+	TypedArray<Dictionary> scan(String p_file_path, String p_display_path, String p_pattern, bool p_match_case, bool p_whole_words) const;
+	bool replace(String p_file_path, String p_display_path, TypedArray<Dictionary> p_locations, bool p_match_case, bool p_whole_words, String p_search_text, String p_new_text) const;
+
+	ScriptSearchReplace();
+	~ScriptSearchReplace();
+};
+
+#endif // SCRIPT_SEARCH_REPLACE_H


### PR DESCRIPTION
This PR implements the new find_in_files_scanner, a extension-aware scanner and replacer for the FindInFilesPanel.
It correctly handles .tscn files, even when they have multiple builtin scripts, by essentially parsing the scene file and automatically unescaping and offsetting matches.
    
The .tscn extension has also been added to the default "editor/script/search_in_file_extensions" Project Settings property.
This allows for the builtin scripts to be searched in by default.
    
The way results are reported and shown in the FindInFilesPanel has also been improved, allowing for differenciation between "relative file path", "absolute file path" and "display text". All of which can be used to append more extensions to the scanner in the future.

Fixes: https://github.com/godotengine/godot/issues/75600
Closes https://github.com/godotengine/godot-proposals/issues/9436