### PR TITLE
Change VehicleWheel3D suspension travel to use meters internally

### DIFF
--- a/scene/3d/vehicle_body_3d.cpp
+++ b/scene/3d/vehicle_body_3d.cpp
@@ -160,11 +160,11 @@ real_t VehicleWheel3D::get_suspension_rest_length() const {
 }
 
 void VehicleWheel3D::set_suspension_travel(real_t p_length) {
-	m_maxSuspensionTravelCm = p_length / 0.01;
+	m_maxSuspensionTravel = p_length;
 }
 
 real_t VehicleWheel3D::get_suspension_travel() const {
-	return m_maxSuspensionTravelCm * 0.01;
+	return m_maxSuspensionTravel;
 }
 
 void VehicleWheel3D::set_suspension_stiffness(real_t p_value) {
@@ -429,8 +429,8 @@ real_t VehicleBody3D::_ray_cast(int p_idx, PhysicsDirectBodyState3D *s) {
 		wheel.m_raycastInfo.m_suspensionLength = hitDistance - wheel.m_wheelRadius;
 		//clamp on max suspension travel
 
-		real_t minSuspensionLength = wheel.m_suspensionRestLength - wheel.m_maxSuspensionTravelCm * real_t(0.01);
-		real_t maxSuspensionLength = wheel.m_suspensionRestLength + wheel.m_maxSuspensionTravelCm * real_t(0.01);
+		real_t minSuspensionLength = wheel.m_suspensionRestLength - wheel.m_maxSuspensionTravel;
+		real_t maxSuspensionLength = wheel.m_suspensionRestLength + wheel.m_maxSuspensionTravel;
 		if (wheel.m_raycastInfo.m_suspensionLength < minSuspensionLength) {
 			wheel.m_raycastInfo.m_suspensionLength = minSuspensionLength;
 		}

--- a/scene/3d/vehicle_body_3d.h
+++ b/scene/3d/vehicle_body_3d.h
@@ -50,7 +50,7 @@ class VehicleWheel3D : public Node3D {
 	Vector3 m_wheelAxleCS; // const or modified by steering
 
 	real_t m_suspensionRestLength = 0.15;
-	real_t m_maxSuspensionTravelCm = 20.0;
+	real_t m_maxSuspensionTravel = 0.2;
 	real_t m_wheelRadius = 0.5;
 
 	real_t m_suspensionStiffness = 5.88;


### PR DESCRIPTION
This value is exposed as meters and is used as meters, it does not make any sense to store it as centimeters...

Also, the variables in this file are not following the style guide with snake_case naming. ~~I changed only this one variable name since I was removing `Cm` anyway, the others can be renamed in another PR.~~