### PR TITLE
Allow for others to set an output directory for the write_disabled_classes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -510,7 +510,7 @@ if selected_platform in platform_list:
         except:
             print("Error opening feature build profile: " + env["build_profile"])
             Exit(255)
-    methods.write_disabled_classes(disabled_classes)
+    methods.write_disabled_classes(disabled_classes, "core/disabled_classes.gen.h")
 
     # Platform specific flags.
     # These can sometimes override default options.

--- a/methods.py
+++ b/methods.py
@@ -298,8 +298,8 @@ def is_module(path):
     return True
 
 
-def write_disabled_classes(class_list):
-    f = open("core/disabled_classes.gen.h", "w")
+def write_disabled_classes(class_list, output_filepath):
+    f = open(output_filepath, "w")
     f.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     f.write("#ifndef DISABLED_CLASSES_GEN_H\n")
     f.write("#define DISABLED_CLASSES_GEN_H\n\n")


### PR DESCRIPTION
This change allows the disabled classes to be written to a out of tree location