### PR TITLE
[3.x] Fix Polygon2D skinned bounds (for culling)

### DIFF
--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -728,6 +728,14 @@
 				Modulates all colors in the given canvas.
 			</description>
 		</method>
+		<method name="debug_canvas_item_get_rect">
+			<return type="Rect2" />
+			<argument index="0" name="item" type="RID" />
+			<description>
+				Returns the bounding rectangle for a canvas item in local space, as calculated by the renderer. This bound is used internally for culling.
+				[b]Warning:[/b] This function is intended for debugging in the editor, and will pass through and return a zero [Rect2] in exported projects.
+			</description>
+		</method>
 		<method name="directional_light_create">
 			<return type="RID" />
 			<description>

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -111,6 +111,16 @@ void Polygon2D::_notification(int p_what) {
 			if (skeleton_node) {
 				VS::get_singleton()->canvas_item_attach_skeleton(get_canvas_item(), skeleton_node->get_skeleton());
 				new_skeleton_id = skeleton_node->get_instance_id();
+
+				// Sync the offset transform between the Polygon2D and the skeleton.
+				// This is needed for accurate culling in VisualServer.
+				Transform2D global_xform_skel = skeleton_node->get_global_transform();
+				Transform2D global_xform_poly = get_global_transform();
+
+				// find the difference
+				Transform2D global_xform_offset = global_xform_skel.affine_inverse() * global_xform_poly;
+				VS::get_singleton()->canvas_item_set_skeleton_relative_xform(get_canvas_item(), global_xform_offset);
+
 			} else {
 				VS::get_singleton()->canvas_item_attach_skeleton(get_canvas_item(), RID());
 			}

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -892,9 +892,23 @@ public:
 			bool antialiased;
 			bool antialiasing_use_indices;
 
+			struct SkinningData {
+				bool dirty = true;
+				LocalVector<Rect2> active_bounds;
+				LocalVector<uint16_t> active_bone_ids;
+				Rect2 untransformed_bound;
+			};
+			mutable SkinningData *skinning_data = nullptr;
+
 			CommandPolygon() {
 				type = TYPE_POLYGON;
 				count = 0;
+			}
+			virtual ~CommandPolygon() {
+				if (skinning_data) {
+					memdelete(skinning_data);
+					skinning_data = nullptr;
+				}
 			}
 		};
 
@@ -968,6 +982,12 @@ public:
 
 		Item *next;
 
+		struct SkinningData {
+			Transform2D skeleton_relative_xform;
+			Transform2D skeleton_relative_xform_inv;
+		};
+		SkinningData *skinning_data = nullptr;
+
 		struct CopyBackBuffer {
 			Rect2 rect;
 			Rect2 screen_rect;
@@ -984,6 +1004,11 @@ public:
 
 		Rect2 global_rect_cache;
 
+	private:
+		Rect2 calculate_polygon_bounds(const Item::CommandPolygon &p_polygon) const;
+		void precalculate_polygon_bone_bounds(const Item::CommandPolygon &p_polygon) const;
+
+	public:
 		const Rect2 &get_rect() const {
 			if (custom_rect) {
 				return rect;
@@ -1068,61 +1093,8 @@ public:
 					} break;
 					case Item::Command::TYPE_POLYGON: {
 						const Item::CommandPolygon *polygon = static_cast<const Item::CommandPolygon *>(c);
-						int l = polygon->points.size();
-						const Point2 *pp = &polygon->points[0];
-						r.position = pp[0];
-						for (int j = 1; j < l; j++) {
-							r.expand_to(pp[j]);
-						}
-
-						if (skeleton != RID()) {
-							// calculate bone AABBs
-							int bone_count = RasterizerStorage::base_singleton->skeleton_get_bone_count(skeleton);
-
-							Vector<Rect2> bone_aabbs;
-							bone_aabbs.resize(bone_count);
-							Rect2 *bptr = bone_aabbs.ptrw();
-
-							for (int j = 0; j < bone_count; j++) {
-								bptr[j].size = Vector2(-1, -1); //negative means unused
-							}
-							if (l && polygon->bones.size() == l * 4 && polygon->weights.size() == polygon->bones.size()) {
-								for (int j = 0; j < l; j++) {
-									Point2 p = pp[j];
-									for (int k = 0; k < 4; k++) {
-										int idx = polygon->bones[j * 4 + k];
-										float w = polygon->weights[j * 4 + k];
-										if (w == 0) {
-											continue;
-										}
-
-										if (bptr[idx].size.x < 0) {
-											//first
-											bptr[idx] = Rect2(p, Vector2(0.00001, 0.00001));
-										} else {
-											bptr[idx].expand_to(p);
-										}
-									}
-								}
-
-								Rect2 aabb;
-								bool first_bone = true;
-								for (int j = 0; j < bone_count; j++) {
-									Transform2D mtx = RasterizerStorage::base_singleton->skeleton_bone_get_transform_2d(skeleton, j);
-									Rect2 baabb = mtx.xform(bone_aabbs[j]);
-
-									if (first_bone) {
-										aabb = baabb;
-										first_bone = false;
-									} else {
-										aabb = aabb.merge(baabb);
-									}
-								}
-
-								r = r.merge(aabb);
-							}
-						}
-
+						DEV_ASSERT(polygon);
+						r = calculate_polygon_bounds(*polygon);
 					} break;
 					case Item::Command::TYPE_MESH: {
 						const Item::CommandMesh *mesh = static_cast<const Item::CommandMesh *>(c);
@@ -1188,6 +1160,11 @@ public:
 			final_clip_owner = nullptr;
 			material_owner = nullptr;
 			light_masked = false;
+
+			if (skinning_data) {
+				memdelete(skinning_data);
+				skinning_data = nullptr;
+			}
 		}
 		Item() {
 			light_mask = 1;

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -917,6 +917,38 @@ void VisualServerCanvas::canvas_item_set_z_as_relative_to_parent(RID p_item, boo
 	canvas_item->z_relative = p_enable;
 }
 
+Rect2 VisualServerCanvas::_debug_canvas_item_get_rect(RID p_item) {
+	Item *canvas_item = canvas_item_owner.getornull(p_item);
+	ERR_FAIL_COND_V(!canvas_item, Rect2());
+	return canvas_item->get_rect();
+}
+
+void VisualServerCanvas::canvas_item_set_skeleton_relative_xform(RID p_item, Transform2D p_relative_xform) {
+	Item *canvas_item = canvas_item_owner.getornull(p_item);
+	ERR_FAIL_COND(!canvas_item);
+
+	if (!canvas_item->skinning_data) {
+		canvas_item->skinning_data = memnew(Item::SkinningData);
+	}
+	canvas_item->skinning_data->skeleton_relative_xform = p_relative_xform;
+	canvas_item->skinning_data->skeleton_relative_xform_inv = p_relative_xform.affine_inverse();
+
+	// Set any Polygon2Ds pre-calced bone bounds to dirty.
+	for (int n = 0; n < canvas_item->commands.size(); n++) {
+		Item::Command *c = canvas_item->commands[n];
+		if (c->type == Item::Command::TYPE_POLYGON) {
+			Item::CommandPolygon *polygon = static_cast<Item::CommandPolygon *>(c);
+
+			// Make sure skinning data is present.
+			if (!polygon->skinning_data) {
+				polygon->skinning_data = memnew(Item::CommandPolygon::SkinningData);
+			}
+
+			polygon->skinning_data->dirty = true;
+		}
+	}
+}
+
 void VisualServerCanvas::canvas_item_attach_skeleton(RID p_item, RID p_skeleton) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);

--- a/servers/visual/visual_server_canvas.h
+++ b/servers/visual/visual_server_canvas.h
@@ -208,6 +208,8 @@ public:
 	void canvas_item_set_z_as_relative_to_parent(RID p_item, bool p_enable);
 	void canvas_item_set_copy_to_backbuffer(RID p_item, bool p_enable, const Rect2 &p_rect);
 	void canvas_item_attach_skeleton(RID p_item, RID p_skeleton);
+	void canvas_item_set_skeleton_relative_xform(RID p_item, Transform2D p_relative_xform);
+	Rect2 _debug_canvas_item_get_rect(RID p_item);
 
 	void canvas_item_clear(RID p_item);
 	void canvas_item_set_draw_index(RID p_item, int p_index);

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -718,6 +718,8 @@ public:
 	BIND2(canvas_item_set_z_as_relative_to_parent, RID, bool)
 	BIND3(canvas_item_set_copy_to_backbuffer, RID, bool, const Rect2 &)
 	BIND2(canvas_item_attach_skeleton, RID, RID)
+	BIND2(canvas_item_set_skeleton_relative_xform, RID, Transform2D)
+	BIND1R(Rect2, _debug_canvas_item_get_rect, RID)
 
 	BIND1(canvas_item_clear, RID)
 	BIND2(canvas_item_set_draw_index, RID, int)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -619,6 +619,8 @@ public:
 	FUNC2(canvas_item_set_z_as_relative_to_parent, RID, bool)
 	FUNC3(canvas_item_set_copy_to_backbuffer, RID, bool, const Rect2 &)
 	FUNC2(canvas_item_attach_skeleton, RID, RID)
+	FUNC2(canvas_item_set_skeleton_relative_xform, RID, Transform2D)
+	FUNC1R(Rect2, _debug_canvas_item_get_rect, RID)
 
 	FUNC1(canvas_item_clear, RID)
 	FUNC2(canvas_item_set_draw_index, RID, int)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2202,6 +2202,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_item_set_draw_index", "item", "index"), &VisualServer::canvas_item_set_draw_index);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_material", "item", "material"), &VisualServer::canvas_item_set_material);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_use_parent_material", "item", "enabled"), &VisualServer::canvas_item_set_use_parent_material);
+	ClassDB::bind_method(D_METHOD("debug_canvas_item_get_rect", "item"), &VisualServer::debug_canvas_item_get_rect);
 	ClassDB::bind_method(D_METHOD("canvas_light_create"), &VisualServer::canvas_light_create);
 	ClassDB::bind_method(D_METHOD("canvas_light_attach_to_canvas", "light", "canvas"), &VisualServer::canvas_light_attach_to_canvas);
 	ClassDB::bind_method(D_METHOD("canvas_light_set_enabled", "light", "enabled"), &VisualServer::canvas_light_set_enabled);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -1052,6 +1052,16 @@ public:
 	virtual void canvas_item_set_copy_to_backbuffer(RID p_item, bool p_enable, const Rect2 &p_rect) = 0;
 
 	virtual void canvas_item_attach_skeleton(RID p_item, RID p_skeleton) = 0;
+	virtual void canvas_item_set_skeleton_relative_xform(RID p_item, Transform2D p_relative_xform) = 0;
+
+	Rect2 debug_canvas_item_get_rect(RID p_item) {
+#ifdef TOOLS_ENABLED
+		return _debug_canvas_item_get_rect(p_item);
+#else
+		return Rect2();
+#endif
+	}
+	virtual Rect2 _debug_canvas_item_get_rect(RID p_item) = 0;
 
 	virtual void canvas_item_clear(RID p_item) = 0;
 	virtual void canvas_item_set_draw_index(RID p_item, int p_index) = 0;


### PR DESCRIPTION
The bound Rect2 was previously incorrect because bone transforms need to be applied to verts in bone space (or rigged space), rather than local space. This was previously resulting in skinned Polygon2Ds being incorrectly culled.

Also adds `debug_canvas_item_get_rect()` function to `VisualServer` for debugging / verification / possible unit testing.

Fixes #63047 (2nd issue reported by @hothex)

### Testing project
Contains skinned Polygon2Ds, and displays bounding boxes in green.

[Skinned_Polygon2D_CullingTest.zip](https://github.com/godotengine/godot/files/11209674/Skinned_Polygon2D_CullingTest.zip)

https://user-images.githubusercontent.com/21999379/230062627-0a2f5a60-ecaf-413d-a696-35fbb44d6afb.mp4

## Explanation
There were a number of difficulties to overcome in generating the bounding rect in local space, compared to the skinning in the renderer. In particular in the renderer it was easier to find the relative global transform between the `Polygon2D` and the `Skeleton`. In the `get_rect()` call, this information was not available.

* The _relative transform_ is important to deal with the case where there is an offset between the `Polygon2D` and the `Skeleton`. When they are exactly aligned, there is no relative transform to deal with and things are simpler - but users tend to rig with relative transforms.

The `final_transform` in the canvas item is not so useful because it is only calculated _after_ rendering, and there is a chicken and egg problem where we need to know the global transform of the `Polygon2D` _before_ rendering, because in the current paradigm the global transforms are not stored in the visual server, only calculated on the fly during rendering. Additionally the `final_transform` contained also the camera transform, and thus could not be compared with the `Skeleton` global transform.

I explored two options to finding the relative transform:
1) Send the global transform of `Polygon2D`s from scene side to `VisualServer`. This would entail keeping this updated whenever the `Polygon2D` moved, which is quite a few updates. Additionally the relative transform would need to be calculated each time.
2) By checking the numbers I noticed that the relative transform typically doesn't change once the bones are rigged to a skeleton. This means we had the opportunity to calculate the relative transform as a one off, and send it to the `VisualServer`. This is the approach I have taken in this PR.

## Notes
* The most expensive part (vertex operations) is now precalculated as a one off when the rigging is established. This means that at runtime, in most cases it transforms and merges one or two bones, which should be pretty cheap.
* This error was introduced in #40869 . The logic was copied from sections of code that were calculating the bone bounds, but this is not the same calculation needed for `Polygon2D` bounds.
* The canonical software transform for 2D skinning should now be referred to from `rasterizer_canvas_batcher`. This is the most tested path, and a number of bugs were solved there. https://github.com/godotengine/godot/blob/b0c399ec8c9f5f71c64656e8463907153f8459ff/drivers/gles_common/rasterizer_canvas_batcher.h#L1801-L1924
The approach in this PR is _adapted_ from the software skinning (with significant differences).
* The code involved is moved from the h to cpp, as it is quite involved and should be capable of being inlined anyway (just as easily as from the header) as it is called from the same translation unit.
* The old code applied an unused bone `AABB` (0, 0, -1, -1) to the final result even if it was not used. This probably caused little problems due to other oversights, but is strictly speaking incorrect I think, so I did a check for this.
* It is possible that there is a simpler way of doing this. Indeed it can be simpler when the skeleton and `Polygon2D` are guaranteed to be aligned in some ways, but through bug testing the skinning, the robust approach needed the relative transforms.

## Extra
* The same bug is likely in 4.x, as reported in #74656, this PR could be ported.
* The same bug may be present in 3D, we should double check bounds calculations are correct there also if it uses the same approach.

## Discussion
Additionally on rocketchat we discussed 2 additional / alternative methods for skeleton bounds:

1) Single uber-bound that covers the entire skeleton (probably not recalculated)
2) Calculate bounds of the bones _only_, then add a user margin 'fudge factor' to account for the size of the `Polygon2D` _around_ the bones. (This could possibly be derived from the geometry, not sure yet.)

This second approach still has a problem:
We can calculate bone origins in global space (the skeleton in `VisualServer` _does_ have global transform in the form of `skel_base_xform`).
However we need to calculate the `Polygon2D` bound in _local space_. As such we still need a relative transform to go from global to `Polygon2D` local space, probably the global transform for the `Polygon2D` to be updated, which could be expensive. Alternatively we could cull `Polygon2D` in global space directly, but this may not play well with the rest of the engine that expects `get_rect()` to work in local space.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
