### PR TITLE
Remove pointless use of atomics in error macros

### DIFF
--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -32,8 +32,6 @@
 
 #include "core/typedefs.h"
 
-#include <atomic> // IWYU pragma: keep // Used in macro. We'd normally use `safe_refcount.h`, but that would cause circular includes.
-
 #ifdef _MSC_VER
 #include <intrin.h> // `__fastfail()`.
 #endif
@@ -282,7 +280,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 		((void)0)
 
 /**
- * Same as `ERR_FAIL_UNSIGNED_INDEX_V_EDMSG` but also notifies the editor.
+ * Same as `ERR_FAIL_UNSIGNED_INDEX_V_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                    \
 	if (unlikely((m_index) >= (m_size))) {                                                                                   \
@@ -672,10 +670,10 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  */
 #define ERR_PRINT_ONCE(m_msg)                                          \
 	if (true) {                                                        \
-		static bool first_print = true;                                \
-		if (first_print) {                                             \
+		static bool warning_shown = false;                             \
+		if (unlikely(!warning_shown)) {                                \
+			warning_shown = true;                                      \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg); \
-			first_print = false;                                       \
 		}                                                              \
 	} else                                                             \
 		((void)0)
@@ -685,10 +683,10 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  */
 #define ERR_PRINT_ONCE_ED(m_msg)                                             \
 	if (true) {                                                              \
-		static bool first_print = true;                                      \
-		if (first_print) {                                                   \
+		static bool warning_shown = false;                                   \
+		if (unlikely(!warning_shown)) {                                      \
+			warning_shown = true;                                            \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true); \
-			first_print = false;                                             \
 		}                                                                    \
 	} else                                                                   \
 		((void)0)
@@ -716,10 +714,10 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  */
 #define WARN_PRINT_ONCE(m_msg)                                                                     \
 	if (true) {                                                                                    \
-		static bool first_print = true;                                                            \
-		if (first_print) {                                                                         \
+		static bool warning_shown = false;                                                         \
+		if (unlikely(!warning_shown)) {                                                            \
+			warning_shown = true;                                                                  \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, false, ERR_HANDLER_WARNING); \
-			first_print = false;                                                                   \
 		}                                                                                          \
 	} else                                                                                         \
 		((void)0)
@@ -729,10 +727,10 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  */
 #define WARN_PRINT_ONCE_ED(m_msg)                                                                 \
 	if (true) {                                                                                   \
-		static bool first_print = true;                                                           \
-		if (first_print) {                                                                        \
+		static bool warning_shown = false;                                                        \
+		if (unlikely(!warning_shown)) {                                                           \
+			warning_shown = true;                                                                 \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true, ERR_HANDLER_WARNING); \
-			first_print = false;                                                                  \
 		}                                                                                         \
 	} else                                                                                        \
 		((void)0)
@@ -754,10 +752,10 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  */
 #define WARN_DEPRECATED                                                                                                                                           \
 	if (true) {                                                                                                                                                   \
-		static std::atomic<bool> warning_shown;                                                                                                                   \
-		if (!warning_shown.load()) {                                                                                                                              \
+		static bool warning_shown = false;                                                                                                                        \
+		if (unlikely(!warning_shown)) {                                                                                                                           \
+			warning_shown = true;                                                                                                                                 \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", false, ERR_HANDLER_WARNING); \
-			warning_shown.store(true);                                                                                                                            \
 		}                                                                                                                                                         \
 	} else                                                                                                                                                        \
 		((void)0)
@@ -767,10 +765,10 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  */
 #define WARN_DEPRECATED_MSG(m_msg)                                                                                                                                       \
 	if (true) {                                                                                                                                                          \
-		static std::atomic<bool> warning_shown;                                                                                                                          \
-		if (!warning_shown.load()) {                                                                                                                                     \
+		static bool warning_shown = false;                                                                                                                               \
+		if (unlikely(!warning_shown)) {                                                                                                                                  \
+			warning_shown = true;                                                                                                                                        \
 			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", m_msg, false, ERR_HANDLER_WARNING); \
-			warning_shown.store(true);                                                                                                                                   \
 		}                                                                                                                                                                \
 	} else                                                                                                                                                               \
 		((void)0)


### PR DESCRIPTION
- The existing use of atomics did not prevent multiple threads from entering the condition and printing the deprecation message, as the flag was only set after the first thread finished.
- `WARN_DEPRECATED` is unused and `WARN_DEPRECATED_MSG` is only used once, in a place that most likely isn't thread safe either: https://github.com/godotengine/godot/blob/830b54a03b480f29e60b4ebc813c1e24ac140a70/scene/resources/mesh.cpp#L901-L903
- The `*_ONCE` macros that are actually used all over the place have no such threading protection.
- The worst failure that can happen, is that the error gets printed a handful of times (once by every thread that reaches it at the same time)
- If the errors should really never under any circumstances be printed twice, I will rework this PR to correctly ensure this using atomics and exchange.
- In the mean time I reordered setting the flag to come before printing the warning, which should make it pretty much impossible to trigger duplicated messages, even in constructed scenarios
- Made the `WARN_DEPRECATED*` and `*_ONCE` macros use the same guard pattern as there was no real reason for the difference
- (Maybe) avoid including atomic in some places (SafeRefCounted includes it pretty much everywhere anyways)
- Also fix one typo while I was editing this file
- In summary: the pointless / incorrect use of atomics annoyed me, so I changed it