### PR TITLE
Fix `get_test_texture()` returning an almost fully white texture

### DIFF
--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -140,9 +140,9 @@ RID RenderingServer::get_test_texture() {
 					c.b = y;
 				}
 
-				w[(y * TEST_TEXTURE_SIZE + x) * 3 + 0] = uint8_t(CLAMP(c.r * 255, 0, 255));
-				w[(y * TEST_TEXTURE_SIZE + x) * 3 + 1] = uint8_t(CLAMP(c.g * 255, 0, 255));
-				w[(y * TEST_TEXTURE_SIZE + x) * 3 + 2] = uint8_t(CLAMP(c.b * 255, 0, 255));
+				w[(y * TEST_TEXTURE_SIZE + x) * 3 + 0] = uint8_t(CLAMP(c.r, 0, 255));
+				w[(y * TEST_TEXTURE_SIZE + x) * 3 + 1] = uint8_t(CLAMP(c.g, 0, 255));
+				w[(y * TEST_TEXTURE_SIZE + x) * 3 + 2] = uint8_t(CLAMP(c.b, 0, 255));
 			}
 		}
 	}


### PR DESCRIPTION
The texture's appearance is now similar to the texture that was displayed on the TestCube node in Godot 2.x:

Before | After[^1] (this PR)
-|-
![Screenshot_20230404_014312](https://user-images.githubusercontent.com/180032/229655784-b8f27657-6495-4192-977f-0411759abb48.png) | ![image](https://user-images.githubusercontent.com/180032/229655774-dcc52791-6947-4b28-8e4e-ebef09c79460.png)

If you need a fully white texture, `RenderingServer.get_white_texture()` is available.

[^1]: I get *Godotstalgia* by looking at this texture. :no_mouth:
