### PR TITLE
gltf: Remove obsolete hack to embed gltf textures in advanced import

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -2298,11 +2298,6 @@ Node *ResourceImporterScene::pre_import(const String &p_source_file, const HashM
 	Error err = OK;
 	HashMap<StringName, Variant> options_dupe = p_options;
 
-	// By default, the GLTF importer will extract embedded images into files on disk
-	// However, we do not want the advanced settings dialog to be able to write files on disk.
-	// To avoid this and also avoid compressing to basis every time, we are using the uncompressed option.
-	options_dupe["gltf/embedded_image_handling"] = 3; // Embed as Uncompressed defined in GLTFState::GLTFHandleBinary::HANDLE_BINARY_EMBED_AS_UNCOMPRESSED
-
 	Node *scene = importer->import_scene(p_source_file, EditorSceneFormatImporter::IMPORT_ANIMATION | EditorSceneFormatImporter::IMPORT_GENERATE_TANGENT_ARRAYS, options_dupe, nullptr, &err);
 	if (!scene || err != OK) {
 		return nullptr;


### PR DESCRIPTION
Fixes godotengine/godot#75637 (this should have been a bug, not a feature proposal IMHO)

The override to force embedding of textures within the advanced importer was done as an optimization in a build before caching of extracted textures was implemented: the lack of caching led textures to be re-extracted and/or re-compressed each time. Now that the caching is fixed (for extract textures case), it may be less important.

I believe this fix is acceptable for 4.0 backport: it should have no effect on behavior for existing models or materials. My assumption was that the options passed to advanced import only affected the visual appearance of the import dialog. As it turns out, these settings also affect what is written by the GUI code using `ResourceSaver::save()` when doing material/mesh/animation extraction.

This extraction is only performed by manual user interaction and will not affect existing projects or assets, unless users delete the extracted materials and then extract them again.

"Embed as Basis Universal" may perform poorly in the advanced importer as a result of this change, because basis compression is *not* currently cached between imports, afaik. My opinion is Embed as Basis is not recommended in combination with "Extract Materials" because it will be needlessly embedded in every material.
We could address this performance hit by bringing the override back for the dialog, but we will then have to ban both mesh and material extraction if "Embed as Basis Universal" is used if we do this. I would prefer to keep poor performance and we can perhaps add caching of basis compression later?