### PR TITLE
Fix reporting external resource loading progress

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -671,6 +671,9 @@ Error ResourceLoaderBinary::load() {
 		return error;
 	}
 
+	int resource_current = 0;
+	int resources_total = internal_resources.size() + (use_sub_threads ? 0 : external_resources.size());
+
 	for (int i = 0; i < external_resources.size(); i++) {
 		String path = external_resources[i].path;
 
@@ -695,6 +698,11 @@ Error ResourceLoaderBinary::load() {
 					error = ERR_FILE_MISSING_DEPENDENCIES;
 					ERR_FAIL_V_MSG(error, "Can't load dependency: " + path + ".");
 				}
+			}
+
+			resource_current++;
+			if (progress) {
+				*progress = resource_current / float(resources_total);
 			}
 
 		} else {
@@ -861,8 +869,9 @@ Error ResourceLoaderBinary::load() {
 		res->set_edited(false);
 #endif
 
+		resource_current++;
 		if (progress) {
-			*progress = (i + 1) / float(internal_resources.size());
+			*progress = resource_current / float(resources_total);
 		}
 
 		resource_cache.push_back(res);


### PR DESCRIPTION
When loading resources without using subthreads, what you usually observe is progress always reported as zero up until it is fully loaded when it is reported as 1. The reason for that is if your scene has significant amount of external resources (e.g. meshes), neither text nor binary resource format loaders report progress on external resources. If using sub threads to load resources in parallel, the overall progress is computed as average progress on all subthreads scaled to half + progress on main loading thread also scaled to half. So that means that with sub thread loading main thread should only report progress for internal resources (subresources) and not external ones. But this is not the case when loading everything in one thread: in that case progress on external resources has to be accounted and reported.

This patch fixes load progress reporting for case when not using sub threads.

Fixes #56882 
