### PR TITLE
Improve consistency of ModifierKey+A editor shortcuts (Shift+A, Ctrl+A)

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -3805,6 +3805,15 @@ void VisualShaderEditor::_delete_nodes_request(const TypedArray<StringName> &p_n
 	undo_redo->commit_action();
 }
 
+void VisualShaderEditor::_select_all_nodes() {
+	for (int i = 0; i < graph->get_child_count(false); i++) {
+		GraphNode *child = Object::cast_to<GraphNode>(graph->get_child(i, false));
+		if (child) {
+			child->set_selected(true);
+		}
+	}
+}
+
 void VisualShaderEditor::_node_selected(Object *p_node) {
 	VisualShader::Type type = get_current_shader_type();
 
@@ -5058,6 +5067,24 @@ void VisualShaderEditor::_bind_methods() {
 	ClassDB::bind_method("_is_available", &VisualShaderEditor::_is_available);
 }
 
+void VisualShaderEditor::shortcut_input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_COND(p_event.is_null());
+
+	if (!p_event->is_pressed() || p_event->is_echo()) {
+		return;
+	}
+
+	const Ref<InputEventKey> k = p_event;
+
+	if (ED_IS_SHORTCUT("visual_shader_editor/select_all", p_event)) {
+		_select_all_nodes();
+		accept_event();
+	} else if (ED_IS_SHORTCUT("visual_shader_editor/add_node", p_event)) {
+		_show_members_dialog(false, VisualShaderNode::PORT_TYPE_MAX, VisualShaderNode::PORT_TYPE_MAX);
+		accept_event();
+	}
+}
+
 VisualShaderEditor::VisualShaderEditor() {
 	ShaderLanguage::get_keyword_list(&keyword_list);
 	EditorNode::get_singleton()->connect("resource_saved", callable_mp(this, &VisualShaderEditor::_resource_saved));
@@ -6106,6 +6133,11 @@ VisualShaderEditor::VisualShaderEditor() {
 	custom_node_option_idx = add_options.size();
 
 	/////////////////////////////////////////////////////////////////////
+
+	ED_SHORTCUT("visual_shader_editor/select_all", TTR("Select All"), KeyModifierMask::CMD_OR_CTRL | Key::A);
+	ED_SHORTCUT("visual_shader_editor/add_node", TTR("Add Node"), KeyModifierMask::SHIFT | Key::A);
+	set_process_shortcut_input(true);
+	set_shortcut_context(this);
 
 	_update_options_menu();
 

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -381,6 +381,8 @@ class VisualShaderEditor : public VBoxContainer {
 	void _delete_node_request(int p_type, int p_node);
 	void _delete_nodes_request(const TypedArray<StringName> &p_nodes);
 
+	void _select_all_nodes();
+
 	void _node_changed(int p_id);
 
 	void _edit_port_default_input(Object *p_button, int p_node, int p_port);
@@ -519,6 +521,8 @@ class VisualShaderEditor : public VBoxContainer {
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 public:
 	void add_plugin(const Ref<VisualShaderNodePlugin> &p_plugin);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3522,7 +3522,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	ED_SHORTCUT("scene_tree/batch_rename", TTR("Batch Rename"), KeyModifierMask::SHIFT | Key::F2);
 	ED_SHORTCUT_OVERRIDE("scene_tree/batch_rename", "macos", KeyModifierMask::SHIFT | Key::ENTER);
 
-	ED_SHORTCUT("scene_tree/add_child_node", TTR("Add Child Node"), KeyModifierMask::CMD_OR_CTRL | Key::A);
+	ED_SHORTCUT("scene_tree/add_child_node", TTR("Add Child Node"), KeyModifierMask::SHIFT | Key::A);
 	ED_SHORTCUT("scene_tree/instantiate_scene", TTR("Instantiate Child Scene"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::A);
 	ED_SHORTCUT("scene_tree/expand_collapse_all", TTR("Expand/Collapse Branch"));
 	ED_SHORTCUT("scene_tree/cut_node", TTR("Cut"), KeyModifierMask::CMD_OR_CTRL | Key::X);


### PR DESCRIPTION
To make Godot pleasant to use we should stick to the principle of least surprise, given the following reasons I think it makes sense to consider changing this behavior.
- Ctrl + A is used to "select all" in nearly every other software I know
- Ctrl + A is mapped very inconsistently within Godot, some editors use it the "standard" way, while in the scene tree it is used for a completely different function:
![Pasted image 20230403133253](https://user-images.githubusercontent.com/50084500/229863159-e8c3df09-76e5-4e02-a329-9a44fa361d8d.png)

I know, changing essential default shortcuts at this point in time isn't optimal, but I have a feeling it would be worth it. Having a shortcut map to two completely different functions across software (with Godot being exotic here) can hinder the workflow significantly.

Blender uses Shift + A, which is currently unmapped within Godot, so I went with that.

There is just one big problem here, Tree has a incremental search feature (that can not be disabled), which currently blocks all Shortcuts with the modifier keys Alt and Shift. Shift + A wouldn't be a problem since it is case insensitive, so could still select an item starting with a/A, but since A is a key with an unicode associated with it, the event gets consumed (e.g. Shift + F2 works). I am not sure if that feature is used enough to justify these restrictions. I'd suggest that we allow it to be disabled for all Controls which support incremental search via a property (enabled by default, so not compat-breaking) and/or find a way how shortcuts could take precedence over control specific input.

Because of that, Shift + A does currently not work when the SceneTreeEditor is focused. Removing `&& k->get_unicode() == 0` is quick and dirty fix for trying it out, but it hinders incremental search for nodes starting with special characters which require pressing Shift. We'd need a proper solution for that.
```
if (k->is_command_or_control_pressed() || (k->is_shift_pressed() && k->get_unicode() == 0) || k->is_meta_pressed()) {
```

Detailed changes:
- Change "Add Child Node" Shortcut from Ctrl + A to Shift + A
- Add "Add Node" Shortcut (Shift + A) to the VisualShader editor
- Add "Select All" Functionality and Shortcut (Ctrl + A) to the VisualShader editor

Please let me know what's your opinion on this and whether there are other default shortcuts bothering you.