### PR TITLE
Rename `iconpath` => `icon_path` & `hasicon` => `has_icon`.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2396,7 +2396,7 @@ static MainTimerSync main_timer_sync;
 bool Main::start() {
 	ERR_FAIL_COND_V(!_start_success, false);
 
-	bool hasicon = false;
+	bool has_icon = false;
 	String positional_arg;
 	String game_path;
 	String script;
@@ -2966,28 +2966,28 @@ bool Main::start() {
 				sml->add_current_scene(scene);
 
 #ifdef MACOS_ENABLED
-				String mac_iconpath = GLOBAL_GET("application/config/macos_native_icon");
-				if (!mac_iconpath.is_empty()) {
-					DisplayServer::get_singleton()->set_native_icon(mac_iconpath);
-					hasicon = true;
+				String mac_icon_path = GLOBAL_GET("application/config/macos_native_icon");
+				if (!mac_icon_path.is_empty()) {
+					DisplayServer::get_singleton()->set_native_icon(mac_icon_path);
+					has_icon = true;
 				}
 #endif
 
 #ifdef WINDOWS_ENABLED
-				String win_iconpath = GLOBAL_GET("application/config/windows_native_icon");
-				if (!win_iconpath.is_empty()) {
-					DisplayServer::get_singleton()->set_native_icon(win_iconpath);
-					hasicon = true;
+				String win_icon_path = GLOBAL_GET("application/config/windows_native_icon");
+				if (!win_icon_path.is_empty()) {
+					DisplayServer::get_singleton()->set_native_icon(win_icon_path);
+					has_icon = true;
 				}
 #endif
 
-				String iconpath = GLOBAL_GET("application/config/icon");
-				if ((!iconpath.is_empty()) && (!hasicon)) {
+				String icon_path = GLOBAL_GET("application/config/icon");
+				if ((!icon_path.is_empty()) && (!has_icon)) {
 					Ref<Image> icon;
 					icon.instantiate();
-					if (ImageLoader::load_image(iconpath, icon) == OK) {
+					if (ImageLoader::load_image(icon_path, icon) == OK) {
 						DisplayServer::get_singleton()->set_icon(icon);
-						hasicon = true;
+						has_icon = true;
 					}
 				}
 			}
@@ -3015,7 +3015,7 @@ bool Main::start() {
 #endif
 	}
 
-	if (!hasicon && OS::get_singleton()->get_bundle_icon_path().is_empty()) {
+	if (!has_icon && OS::get_singleton()->get_bundle_icon_path().is_empty()) {
 		Ref<Image> icon = memnew(Image(app_icon_png));
 		DisplayServer::get_singleton()->set_icon(icon);
 	}

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -1368,16 +1368,16 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 
 		if (file == "Contents/Resources/icon.icns") {
 			// See if there is an icon.
-			String iconpath;
+			String icon_path;
 			if (p_preset->get("application/icon") != "") {
-				iconpath = p_preset->get("application/icon");
+				icon_path = p_preset->get("application/icon");
 			} else {
-				iconpath = GLOBAL_GET("application/config/icon");
+				icon_path = GLOBAL_GET("application/config/icon");
 			}
 
-			if (!iconpath.is_empty()) {
-				if (iconpath.get_extension() == "icns") {
-					Ref<FileAccess> icon = FileAccess::open(iconpath, FileAccess::READ);
+			if (!icon_path.is_empty()) {
+				if (icon_path.get_extension() == "icns") {
+					Ref<FileAccess> icon = FileAccess::open(icon_path, FileAccess::READ);
 					if (icon.is_valid()) {
 						data.resize(icon->get_length());
 						icon->get_buffer(&data.write[0], icon->get_length());
@@ -1385,7 +1385,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 				} else {
 					Ref<Image> icon;
 					icon.instantiate();
-					err = ImageLoader::load_image(iconpath, icon);
+					err = ImageLoader::load_image(icon_path, icon);
 					if (err == OK && !icon->is_empty()) {
 						_make_icon(p_preset, icon, data);
 					}


### PR DESCRIPTION
Godot engine uses snake_case, so we fix instances of `iconpath` and `hasicon` to be consistent with the rest of the codebase.