### PR TITLE
Prevent unnecessary navigation map synchronizations

### DIFF
--- a/modules/navigation/nav_link.cpp
+++ b/modules/navigation/nav_link.cpp
@@ -33,21 +33,33 @@
 #include "nav_map.h"
 
 void NavLink::set_map(NavMap *p_map) {
+	if (map == p_map) {
+		return;
+	}
 	map = p_map;
 	link_dirty = true;
 }
 
 void NavLink::set_bidirectional(bool p_bidirectional) {
+	if (bidirectional == p_bidirectional) {
+		return;
+	}
 	bidirectional = p_bidirectional;
 	link_dirty = true;
 }
 
 void NavLink::set_start_position(const Vector3 p_position) {
+	if (start_position == p_position) {
+		return;
+	}
 	start_position = p_position;
 	link_dirty = true;
 }
 
 void NavLink::set_end_position(const Vector3 p_position) {
+	if (end_position == p_position) {
+		return;
+	}
 	end_position = p_position;
 	link_dirty = true;
 }

--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -54,21 +54,33 @@
 	}
 
 void NavMap::set_up(Vector3 p_up) {
+	if (up == p_up) {
+		return;
+	}
 	up = p_up;
 	regenerate_polygons = true;
 }
 
 void NavMap::set_cell_size(real_t p_cell_size) {
+	if (cell_size == p_cell_size) {
+		return;
+	}
 	cell_size = p_cell_size;
 	regenerate_polygons = true;
 }
 
 void NavMap::set_edge_connection_margin(real_t p_edge_connection_margin) {
+	if (edge_connection_margin == p_edge_connection_margin) {
+		return;
+	}
 	edge_connection_margin = p_edge_connection_margin;
 	regenerate_links = true;
 }
 
 void NavMap::set_link_connection_radius(real_t p_link_connection_radius) {
+	if (link_connection_radius == p_link_connection_radius) {
+		return;
+	}
 	link_connection_radius = p_link_connection_radius;
 	regenerate_links = true;
 }

--- a/modules/navigation/nav_region.cpp
+++ b/modules/navigation/nav_region.cpp
@@ -33,6 +33,9 @@
 #include "nav_map.h"
 
 void NavRegion::set_map(NavMap *p_map) {
+	if (map == p_map) {
+		return;
+	}
 	map = p_map;
 	polygons_dirty = true;
 	if (!map) {
@@ -41,6 +44,9 @@ void NavRegion::set_map(NavMap *p_map) {
 }
 
 void NavRegion::set_transform(Transform3D p_transform) {
+	if (transform == p_transform) {
+		return;
+	}
 	transform = p_transform;
 	polygons_dirty = true;
 }

--- a/scene/2d/navigation_link_2d.h
+++ b/scene/2d/navigation_link_2d.h
@@ -45,6 +45,8 @@ class NavigationLink2D : public Node2D {
 	real_t enter_cost = 0.0;
 	real_t travel_cost = 1.0;
 
+	Transform2D current_global_transform;
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -160,15 +160,12 @@ void NavigationRegion2D::_notification(int p_what) {
 					}
 				}
 			}
+			current_global_transform = get_global_transform();
+			NavigationServer2D::get_singleton()->region_set_transform(region, current_global_transform);
 		} break;
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
-			NavigationServer2D::get_singleton()->region_set_transform(region, get_global_transform());
-			for (uint32_t i = 0; i < constrain_avoidance_obstacles.size(); i++) {
-				if (constrain_avoidance_obstacles[i].is_valid()) {
-					NavigationServer2D::get_singleton()->obstacle_set_position(constrain_avoidance_obstacles[i], get_global_position());
-				}
-			}
+			set_physics_process_internal(true);
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
@@ -179,6 +176,24 @@ void NavigationRegion2D::_notification(int p_what) {
 			for (uint32_t i = 0; i < constrain_avoidance_obstacles.size(); i++) {
 				if (constrain_avoidance_obstacles[i].is_valid()) {
 					NavigationServer2D::get_singleton()->obstacle_set_map(constrain_avoidance_obstacles[i], RID());
+				}
+			}
+		} break;
+
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+			set_physics_process_internal(false);
+			if (is_inside_tree()) {
+				Transform2D new_global_transform = get_global_transform();
+				if (current_global_transform != new_global_transform) {
+					current_global_transform = new_global_transform;
+					NavigationServer2D::get_singleton()->region_set_transform(region, current_global_transform);
+					queue_redraw();
+
+					for (uint32_t i = 0; i < constrain_avoidance_obstacles.size(); i++) {
+						if (constrain_avoidance_obstacles[i].is_valid()) {
+							NavigationServer2D::get_singleton()->obstacle_set_position(constrain_avoidance_obstacles[i], get_global_position());
+						}
+					}
 				}
 			}
 		} break;

--- a/scene/2d/navigation_region_2d.h
+++ b/scene/2d/navigation_region_2d.h
@@ -47,6 +47,8 @@ class NavigationRegion2D : public Node2D {
 	LocalVector<RID> constrain_avoidance_obstacles;
 	uint32_t avoidance_layers = 1;
 
+	Transform2D current_global_transform;
+
 	void _navigation_polygon_changed();
 	void _map_changed(RID p_RID);
 

--- a/scene/3d/navigation_link_3d.cpp
+++ b/scene/3d/navigation_link_3d.cpp
@@ -141,6 +141,8 @@ void NavigationLink3D::_update_debug_mesh() {
 	} else {
 		RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, disabled_link_material->get_rid());
 	}
+
+	RS::get_singleton()->instance_set_transform(debug_instance, current_global_transform);
 }
 #endif // DEBUG_ENABLED
 
@@ -215,29 +217,37 @@ void NavigationLink3D::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			if (enabled) {
 				NavigationServer3D::get_singleton()->link_set_map(link, get_world_3d()->get_navigation_map());
-
-				// Update global positions for the link.
-				Transform3D gt = get_global_transform();
-				NavigationServer3D::get_singleton()->link_set_start_position(link, gt.xform(start_position));
-				NavigationServer3D::get_singleton()->link_set_end_position(link, gt.xform(end_position));
 			}
+			current_global_transform = get_global_transform();
+			NavigationServer3D::get_singleton()->link_set_start_position(link, current_global_transform.xform(start_position));
+			NavigationServer3D::get_singleton()->link_set_end_position(link, current_global_transform.xform(end_position));
 
 #ifdef DEBUG_ENABLED
 			_update_debug_mesh();
 #endif // DEBUG_ENABLED
 		} break;
-		case NOTIFICATION_TRANSFORM_CHANGED: {
-			// Update global positions for the link.
-			Transform3D gt = get_global_transform();
-			NavigationServer3D::get_singleton()->link_set_start_position(link, gt.xform(start_position));
-			NavigationServer3D::get_singleton()->link_set_end_position(link, gt.xform(end_position));
 
-#ifdef DEBUG_ENABLED
-			if (is_inside_tree() && debug_instance.is_valid()) {
-				RS::get_singleton()->instance_set_transform(debug_instance, get_global_transform());
-			}
-#endif // DEBUG_ENABLED
+		case NOTIFICATION_TRANSFORM_CHANGED: {
+			set_physics_process_internal(true);
 		} break;
+
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+			set_physics_process_internal(false);
+			if (is_inside_tree()) {
+				Transform3D new_global_transform = get_global_transform();
+				if (current_global_transform != new_global_transform) {
+					current_global_transform = new_global_transform;
+					NavigationServer3D::get_singleton()->link_set_start_position(link, current_global_transform.xform(start_position));
+					NavigationServer3D::get_singleton()->link_set_end_position(link, current_global_transform.xform(end_position));
+#ifdef DEBUG_ENABLED
+					if (debug_instance.is_valid()) {
+						RS::get_singleton()->instance_set_transform(debug_instance, current_global_transform);
+					}
+#endif // DEBUG_ENABLED
+				}
+			}
+		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			NavigationServer3D::get_singleton()->link_set_map(link, RID());
 
@@ -359,8 +369,7 @@ void NavigationLink3D::set_start_position(Vector3 p_position) {
 		return;
 	}
 
-	Transform3D gt = get_global_transform();
-	NavigationServer3D::get_singleton()->link_set_start_position(link, gt.xform(start_position));
+	NavigationServer3D::get_singleton()->link_set_start_position(link, current_global_transform.xform(start_position));
 
 #ifdef DEBUG_ENABLED
 	_update_debug_mesh();
@@ -381,8 +390,7 @@ void NavigationLink3D::set_end_position(Vector3 p_position) {
 		return;
 	}
 
-	Transform3D gt = get_global_transform();
-	NavigationServer3D::get_singleton()->link_set_end_position(link, gt.xform(end_position));
+	NavigationServer3D::get_singleton()->link_set_end_position(link, current_global_transform.xform(end_position));
 
 #ifdef DEBUG_ENABLED
 	_update_debug_mesh();

--- a/scene/3d/navigation_link_3d.h
+++ b/scene/3d/navigation_link_3d.h
@@ -45,6 +45,8 @@ class NavigationLink3D : public Node3D {
 	real_t enter_cost = 0.0;
 	real_t travel_cost = 1.0;
 
+	Transform3D current_global_transform;
+
 #ifdef DEBUG_ENABLED
 	RID debug_instance;
 	Ref<ArrayMesh> debug_mesh;

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -157,6 +157,8 @@ void NavigationRegion3D::_notification(int p_what) {
 			if (enabled) {
 				NavigationServer3D::get_singleton()->region_set_map(region, get_world_3d()->get_navigation_map());
 			}
+			current_global_transform = get_global_transform();
+			NavigationServer3D::get_singleton()->region_set_transform(region, current_global_transform);
 
 #ifdef DEBUG_ENABLED
 			if (NavigationServer3D::get_singleton()->get_debug_navigation_enabled()) {
@@ -167,14 +169,24 @@ void NavigationRegion3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
-			NavigationServer3D::get_singleton()->region_set_transform(region, get_global_transform());
+			set_physics_process_internal(true);
 
+		} break;
+
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+			set_physics_process_internal(false);
+			if (is_inside_tree()) {
+				Transform3D new_global_transform = get_global_transform();
+				if (current_global_transform != new_global_transform) {
+					current_global_transform = new_global_transform;
+					NavigationServer3D::get_singleton()->region_set_transform(region, current_global_transform);
 #ifdef DEBUG_ENABLED
-			if (is_inside_tree() && debug_instance.is_valid()) {
-				RS::get_singleton()->instance_set_transform(debug_instance, get_global_transform());
-			}
+					if (debug_instance.is_valid()) {
+						RS::get_singleton()->instance_set_transform(debug_instance, current_global_transform);
+					}
 #endif // DEBUG_ENABLED
-
+				}
+			}
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
@@ -552,6 +564,7 @@ void NavigationRegion3D::_update_debug_mesh() {
 	RS::get_singleton()->instance_set_base(debug_instance, debug_mesh->get_rid());
 	if (is_inside_tree()) {
 		RS::get_singleton()->instance_set_scenario(debug_instance, get_world_3d()->get_scenario());
+		RS::get_singleton()->instance_set_transform(debug_instance, current_global_transform);
 		RS::get_singleton()->instance_set_visible(debug_instance, is_visible_in_tree());
 	}
 	if (!is_enabled()) {

--- a/scene/3d/navigation_region_3d.h
+++ b/scene/3d/navigation_region_3d.h
@@ -44,6 +44,8 @@ class NavigationRegion3D : public Node3D {
 	real_t travel_cost = 1.0;
 	Ref<NavigationMesh> navigation_mesh;
 
+	Transform3D current_global_transform;
+
 	Thread bake_thread;
 
 	void _navigation_changed();


### PR DESCRIPTION
Prevents unnecessary navigation map synchronizations triggered by redundant calls to setters of e.g. region, link or map properties.

The properly biggest, common found issue and performance offender was any transform change to regions or links. Users would often have them or their parents animated with an AnimationPlayer. They would have an animation track for the position / rotation / scale of a region, link or one of the parents. E.g. for an elevator or other moving platforms. 

The problem with animation tracks is that they trigger updates every single frame regardless if it is the same keyframe value. As long as the animation was playing as a loop those animation track updates would trigger every single frame. This in turn would trigger synchronization updates for the entire navigation map every single frame (and flood the NavigationServer queue with multiple update commands). This would make every single navigation agent on that map update the navigation path every single frame. This obviously would tank the frame rate.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
