### PR TITLE
Take SubViewports into account when handling Node selections

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -253,6 +253,14 @@
 				[b]Note:[/b] As this method walks upwards in the scene tree, it can be slow in large, deeply nested scene trees. Whenever possible, consider using [method get_node] with unique names instead (see [member unique_name_in_owner]), or caching the node references into variable.
 			</description>
 		</method>
+		<method name="find_parent_by_class_or_null" qualifiers="const">
+			<return type="Node" />
+			<param index="0" name="class_name" type="String" />
+			<description>
+				Finds the first parent of the current node whose class matches [param class_name] as in [method Object.is_class].
+				If no match is found, null is returned.
+			</description>
+		</method>
 		<method name="get_child" qualifiers="const">
 			<return type="Node" />
 			<param index="0" name="idx" type="int" />

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5419,6 +5419,21 @@ void CanvasItemEditorPlugin::edit(Object *p_object) {
 }
 
 bool CanvasItemEditorPlugin::handles(Object *p_object) const {
+	// Let's handle the current node if it's part of a SubViewport, which in turn is the child of a CanvasItem.
+	// That way we don't keep going back to the 3D editor when the user probably wants to stay in the 2D editor.
+	Node *node = Object::cast_to<Node>(p_object);
+	if (node != nullptr && node->is_inside_tree() && node->get_tree()->get_edited_scene_root() != node) {
+		if (node->is_class("SubViewport")) {
+			// If a SubViewport is selected, let's try to keep the current editor
+			return canvas_item_editor->is_visible();
+		}
+
+		Node *parent = node->find_parent_by_class_or_null("SubViewport");
+		if (parent != nullptr) {
+			return parent->get_parent()->is_class("CanvasItem");
+		}
+	}
+
 	return p_object->is_class("CanvasItem");
 }
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -8683,6 +8683,21 @@ void Node3DEditorPlugin::edit(Object *p_object) {
 }
 
 bool Node3DEditorPlugin::handles(Object *p_object) const {
+	// Let's handle the current node if it's part of a SubViewport, which in turn is the child of a Node3D.
+	// That way we don't keep going back to the 2D editor when the user probably wants to stay in the 3D editor.
+	Node *node = Object::cast_to<Node>(p_object);
+	if (node != nullptr && node->is_inside_tree() && node->get_tree()->get_edited_scene_root() != node) {
+		if (node->is_class("SubViewport")) {
+			// If a SubViewport is selected, let's try to keep the current editor
+			return spatial_editor->is_visible();
+		}
+
+		Node *parent = node->find_parent_by_class_or_null("SubViewport");
+		if (parent != nullptr) {
+			return parent->get_parent()->is_class("Node3D");
+		}
+	}
+
 	return p_object->is_class("Node3D");
 }
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1472,6 +1472,18 @@ Node *Node::find_parent(const String &p_pattern) const {
 	return nullptr;
 }
 
+Node *Node::find_parent_by_class_or_null(const String &class_name) const {
+	Node *parent = data.parent;
+	while (parent != nullptr && parent != data.tree->get_edited_scene_root()) {
+		if (parent->is_class(class_name)) {
+			return parent;
+		}
+		parent = parent->get_parent();
+	}
+
+	return nullptr;
+}
+
 Window *Node::get_window() const {
 	Viewport *vp = get_viewport();
 	if (vp) {
@@ -2852,6 +2864,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("find_child", "pattern", "recursive", "owned"), &Node::find_child, DEFVAL(true), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("find_children", "pattern", "type", "recursive", "owned"), &Node::find_children, DEFVAL(""), DEFVAL(true), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("find_parent", "pattern"), &Node::find_parent);
+	ClassDB::bind_method(D_METHOD("find_parent_by_class_or_null", "class_name"), &Node::find_parent_by_class_or_null);
 	ClassDB::bind_method(D_METHOD("has_node_and_resource", "path"), &Node::has_node_and_resource);
 	ClassDB::bind_method(D_METHOD("get_node_and_resource", "path"), &Node::_get_node_and_resource);
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -322,6 +322,7 @@ public:
 	virtual void reparent(Node *p_parent, bool p_keep_global_transform = true);
 	Node *get_parent() const;
 	Node *find_parent(const String &p_pattern) const;
+	Node *find_parent_by_class_or_null(const String &class_name) const;
 
 	Window *get_window() const;
 


### PR DESCRIPTION
This PR changes the way the handles method is implemented for the canvas_item_editor_plugin and node_3d_editor_plugin.

With this in place, we now check whether the selected node is inside a SubViewport and, if that's the case, we try to match the SubViewport's parent class against either CanvasItem or Node3D (canvas_item_editor_plugin and node_3d_editor_plugin, respectively).

This PR also adds the find_parent_by_class_or_null method to the Node class. As the name says, it walks up the scene tree, starting for the Node itself, matching the parents against the given class. If a match is found, the matching parent is returned and if not, null is returned.

Addresses: https://github.com/godotengine/godot/issues/75511