### PR TITLE
GDScript: Misc fixes and improvements for signature generation

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4546,7 +4546,7 @@ GDScriptParser::DataType GDScriptAnalyzer::type_from_property(const PropertyInfo
 			result.set_container_element_type(elem_type);
 		} else if (p_property.type == Variant::INT) {
 			// Check if it's enum.
-			if ((p_property.usage & (PROPERTY_USAGE_CLASS_IS_ENUM | PROPERTY_USAGE_CLASS_IS_BITFIELD)) && p_property.class_name != StringName()) {
+			if ((p_property.usage & PROPERTY_USAGE_CLASS_IS_ENUM) && p_property.class_name != StringName()) {
 				if (CoreConstants::is_global_enum(p_property.class_name)) {
 					result = make_global_enum_type(p_property.class_name, StringName(), false);
 					result.is_constant = false;
@@ -4558,6 +4558,7 @@ GDScriptParser::DataType GDScriptAnalyzer::type_from_property(const PropertyInfo
 					}
 				}
 			}
+			// PROPERTY_USAGE_CLASS_IS_BITFIELD: BitField[T] isn't supported (yet?), use plain int.
 		}
 	}
 	return result;


### PR DESCRIPTION
This PR fixes some type hints that are added to the function signature if the `text_editor/completion/add_type_hints` editor setting is enabled.

* Use type hints for `@GlobalScope` enums (support added in #73590).
* Use plain `int` for `BitMask<T>` as this is not currently supported in GDScript (see also #74641).
  * Also fixed a bug in the analyzer (copy from 74641).
* Fix type hints for typed arrays.
* Use `Variant` and `void` type hints.
* Discard unnecessary class prefix.

Before

https://user-images.githubusercontent.com/47700418/230122078-6d06b556-5708-434c-85d4-5af33f610190.mp4

<br>
After
<br><br>

https://user-images.githubusercontent.com/47700418/230122132-346edaa7-f71a-4918-a335-6da6f9b4c2e5.mp4

<br>
Closes #75311.<br>
Closes #74593.