### PR TITLE
Make `EditorInterface` accessible as a singleton

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1463,6 +1463,10 @@
 		<member name="DisplayServer" type="DisplayServer" setter="" getter="">
 			The [DisplayServer] singleton.
 		</member>
+		<member name="EditorInterface" type="EditorInterface" setter="" getter="">
+			The [EditorInterface] singleton.
+			[b]Note:[/b] Only available in editor builds.
+		</member>
 		<member name="Engine" type="Engine" setter="" getter="">
 			The [Engine] singleton.
 		</member>

--- a/doc/classes/EditorCommandPalette.xml
+++ b/doc/classes/EditorCommandPalette.xml
@@ -8,13 +8,13 @@
 		Command key names use slash delimiters to distinguish sections, for example: [code]"example/command1"[/code] then [code]example[/code] will be the section name.
 		[codeblocks]
 		[gdscript]
-		var command_palette = get_editor_interface().get_command_palette()
+		var command_palette = EditorInterface.get_command_palette()
 		# external_command is a function that will be called with the command is executed.
 		var command_callable = Callable(self, "external_command").bind(arguments)
 		command_palette.add_command("command", "test/command",command_callable)
 		[/gdscript]
 		[csharp]
-		EditorCommandPalette commandPalette = GetEditorInterface().GetCommandPalette();
+		EditorCommandPalette commandPalette = EditorInterface.Singleton.GetCommandPalette();
 		// ExternalCommand is a function that will be called with the command is executed.
 		Callable commandCallable = new Callable(this, MethodName.ExternalCommand);
 		commandPalette.AddCommand("command", "test/command", commandCallable)

--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -5,7 +5,16 @@
 	</brief_description>
 	<description>
 		[EditorInterface] gives you control over Godot editor's window. It allows customizing the window, saving and (re-)loading scenes, rendering mesh previews, inspecting and editing resources and objects, and provides access to [EditorSettings], [EditorFileSystem], [EditorResourcePreview], [ScriptEditor], the editor viewport, and information about scenes.
-		[b]Note:[/b] This class shouldn't be instantiated directly. Instead, access the singleton using [method EditorPlugin.get_editor_interface].
+		[b]Note:[/b] This class shouldn't be instantiated directly. Instead, access the singleton directly by its name.
+		[codeblocks]
+		[gdscript]
+		var editor_settings = EditorInterface.get_editor_settings()
+		[/gdscript]
+		[csharp]
+		// In C# you can access it via the static Singleton property.
+		EditorSettings settings = EditorInterface.Singleton.GetEditorSettings();
+		[/csharp]
+		[/codeblocks]
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -245,7 +245,7 @@
 				    # You can use a custom icon:
 				    return preload("res://addons/my_plugin/my_plugin_icon.svg")
 				    # Or use a built-in icon:
-				    return get_editor_interface().get_base_control().get_theme_icon("Node", "EditorIcons")
+				    return EditorInterface.get_base_control().get_theme_icon("Node", "EditorIcons")
 				[/gdscript]
 				[csharp]
 				public override Texture2D _GetPluginIcon()
@@ -253,7 +253,7 @@
 				    // You can use a custom icon:
 				    return ResourceLoader.Load&lt;Texture2D&gt;("res://addons/my_plugin/my_plugin_icon.svg");
 				    // Or use a built-in icon:
-				    return GetEditorInterface().GetBaseControl().GetThemeIcon("Node", "EditorIcons");
+				    return EditorInterface.Singleton.GetBaseControl().GetThemeIcon("Node", "EditorIcons");
 				}
 				[/csharp]
 				[/codeblocks]
@@ -340,7 +340,7 @@
 
 				func _enter_tree():
 				    plugin_control = preload("my_plugin_control.tscn").instantiate()
-				    get_editor_interface().get_editor_main_screen().add_child(plugin_control)
+				    EditorInterface.get_editor_main_screen().add_child(plugin_control)
 				    plugin_control.hide()
 
 				func _has_main_screen():
@@ -353,7 +353,7 @@
 				    return "My Super Cool Plugin 3000"
 
 				func _get_plugin_icon():
-				    return get_editor_interface().get_base_control().get_theme_icon("Node", "EditorIcons")
+				    return EditorInterface.get_base_control().get_theme_icon("Node", "EditorIcons")
 				[/codeblock]
 			</description>
 		</method>
@@ -558,10 +558,11 @@
 				The callback should have 4 arguments: [Object] [code]undo_redo[/code], [Object] [code]modified_object[/code], [String] [code]property[/code] and [Variant] [code]new_value[/code]. They are, respectively, the [UndoRedo] object used by the inspector, the currently modified object, the name of the modified property and the new value the property is about to take.
 			</description>
 		</method>
-		<method name="get_editor_interface">
+		<method name="get_editor_interface" is_deprecated="true">
 			<return type="EditorInterface" />
 			<description>
-				Returns the [EditorInterface] singleton. It provides access to some parts of the editor GUI as well as various inner states and tools.
+				Returns the [EditorInterface] singleton instance.
+				[i]Deprecated.[/i] [EditorInterface] is a global singleton and can be accessed directly by its name.
 			</description>
 		</method>
 		<method name="get_export_as_menu">

--- a/doc/classes/EditorScript.xml
+++ b/doc/classes/EditorScript.xml
@@ -48,10 +48,11 @@
 				[b]Warning:[/b] The implementation of this method is currently disabled.
 			</description>
 		</method>
-		<method name="get_editor_interface" qualifiers="const">
+		<method name="get_editor_interface" qualifiers="const" is_deprecated="true">
 			<return type="EditorInterface" />
 			<description>
 				Returns the [EditorInterface] singleton instance.
+				[i]Deprecated.[/i] [EditorInterface] is a global singleton and can be accessed directly by its name.
 			</description>
 		</method>
 		<method name="get_scene" qualifiers="const">

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -9,7 +9,7 @@
 		Accessing the settings can be done using the following methods, such as:
 		[codeblocks]
 		[gdscript]
-		var settings = get_editor_interface().get_editor_settings()
+		var settings = EditorInterface.get_editor_settings()
 		# `settings.set("some/property", 10)` also works as this class overrides `_set()` internally.
 		settings.set_setting("some/property", 10)
 		# `settings.get("some/property")` also works as this class overrides `_get()` internally.
@@ -17,7 +17,7 @@
 		var list_of_settings = settings.get_property_list()
 		[/gdscript]
 		[csharp]
-		EditorSettings settings = GetEditorInterface().GetEditorSettings();
+		EditorSettings settings = EditorInterface.Singleton.GetEditorSettings();
 		// `settings.set("some/property", value)` also works as this class overrides `_set()` internally.
 		settings.SetSetting("some/property", Value);
 		// `settings.get("some/property", value)` also works as this class overrides `_get()` internally.

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -275,6 +275,7 @@ void register_editor_types() {
 	GLOBAL_DEF("editor/version_control/autoload_on_startup", false);
 
 	EditorInterface::create();
+	Engine::get_singleton()->add_singleton(Engine::Singleton("EditorInterface", EditorInterface::get_singleton()));
 
 	OS::get_singleton()->benchmark_end_measure("register_editor_types");
 }

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -23,7 +23,7 @@ namespace GodotTools.Build
             if (dotnetPath == null)
                 throw new FileNotFoundException("Cannot find the dotnet executable.");
 
-            var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
+            var editorSettings = EditorInterface.Singleton.GetEditorSettings();
 
             var startInfo = new ProcessStartInfo(dotnetPath);
 
@@ -94,7 +94,7 @@ namespace GodotTools.Build
             if (dotnetPath == null)
                 throw new FileNotFoundException("Cannot find the dotnet executable.");
 
-            var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
+            var editorSettings = EditorInterface.Singleton.GetEditorSettings();
 
             var startInfo = new ProcessStartInfo(dotnetPath);
 

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -473,10 +473,9 @@ namespace GodotTools
                 }
             }
 
-            var editorInterface = GetEditorInterface();
-            var editorBaseControl = editorInterface.GetBaseControl();
+            var editorBaseControl = EditorInterface.Singleton.GetBaseControl();
 
-            _editorSettings = editorInterface.GetEditorSettings();
+            _editorSettings = EditorInterface.Singleton.GetEditorSettings();
 
             _errorDialog = new AcceptDialog();
             editorBaseControl.AddChild(_errorDialog);

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
@@ -79,7 +79,7 @@ namespace GodotTools.Ides
 
         public async Task<EditorPick?> LaunchIdeAsync(int millisecondsTimeout = 10000)
         {
-            var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
+            var editorSettings = EditorInterface.Singleton.GetEditorSettings();
             var editorId = editorSettings.GetSetting(GodotSharpEditor.Settings.ExternalEditor).As<ExternalEditorId>();
             string editorIdentity = GetExternalEditorIdentity(editorId);
 

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
@@ -23,7 +23,7 @@ namespace GodotTools.Ides.Rider
 
         private static string GetRiderPathFromSettings()
         {
-            var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
+            var editorSettings = EditorInterface.Singleton.GetEditorSettings();
             if (editorSettings.HasSetting(EditorPathSettingName))
                 return (string)editorSettings.GetSetting(EditorPathSettingName);
             return null;
@@ -31,7 +31,7 @@ namespace GodotTools.Ides.Rider
 
         public static void Initialize()
         {
-            var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
+            var editorSettings = EditorInterface.Singleton.GetEditorSettings();
             var editor = editorSettings.GetSetting(GodotSharpEditor.Settings.ExternalEditor).As<ExternalEditorId>();
             if (editor == ExternalEditorId.Rider)
             {
@@ -92,7 +92,7 @@ namespace GodotTools.Ides.Rider
             string newPath = riderInfos.Length > 0
                 ? riderInfos[riderInfos.Length - 1].Path
                 : allInfos[allInfos.Length - 1].Path;
-            var editorSettings = GodotSharpEditor.Instance.GetEditorInterface().GetEditorSettings();
+            var editorSettings = EditorInterface.Singleton.GetEditorSettings();
             editorSettings.SetSetting(EditorPathSettingName, newPath);
             Globals.EditorDef(EditorPathSettingName, newPath);
             return newPath;

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -4014,7 +4014,7 @@ void BindingsGenerator::_initialize_blacklisted_methods() {
 }
 
 void BindingsGenerator::_initialize_compat_singletons() {
-	// No compat singletons yet.
+	compat_singletons.insert("EditorInterface");
 }
 
 void BindingsGenerator::_log(const char *p_format, ...) {

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -409,9 +409,6 @@ void validate_method(const Context &p_context, const ExposedClass &p_class, cons
 	if (p_method.return_type.name != StringName()) {
 		const ExposedClass *return_class = p_context.find_exposed_class(p_method.return_type);
 		if (return_class) {
-			TEST_COND(return_class->is_singleton,
-					"Method return type is a singleton: '", p_class.name, ".", p_method.name, "'.");
-
 			if (p_class.api_type == ClassDB::API_CORE) {
 				TEST_COND(return_class->api_type == ClassDB::API_EDITOR,
 						"Method '", p_class.name, ".", p_method.name, "' has return type '", return_class->name,


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot/pull/66109 and part of https://github.com/godotengine/godot/pull/68696. Closes https://github.com/godotengine/godot/issues/68685.

It was previously impossible to access this editor-specific singleton without first creating an instance of `EditorScript` or `EditorPlugin`. Which led to hacks, where users would create such instances ad-hoc in their tool scripts. And within the editor plugins you would need to carry a reference everywhere just to have this access. All while the `EditorInterface` object was internally a singleton, and accessible throughout the editor code directly.

So I made it a singleton officially, in the API. Naturally, like any other editor class it is only available in editor builds. So if you end up relying on it, guard your code accordingly.

![godot windows editor dev x86_64_2023-04-05_17-05-44](https://user-images.githubusercontent.com/11782833/230129822-6a89c1b8-64d8-4ca4-a131-7b2eea0a225b.png)

In the future we could probably refine the exposed API more, make use of the editor-specific singletons more too.