### PR TITLE
[3.x] Fix UI responsiveness to touch taps

### DIFF
--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -193,12 +193,14 @@ void Tabs::_gui_input(const Ref<InputEvent> &p_event) {
 			for (int i = offset; i <= max_drawn_tab; i++) {
 				if (tabs[i].rb_rect.has_point(pos)) {
 					rb_pressing = true;
+					_update_hover();
 					update();
 					return;
 				}
 
 				if (tabs[i].cb_rect.has_point(pos) && (cb_displaypolicy == CLOSE_BUTTON_SHOW_ALWAYS || (cb_displaypolicy == CLOSE_BUTTON_SHOW_ACTIVE_ONLY && i == current))) {
 					cb_pressing = true;
+					_update_hover();
 					update();
 					return;
 				}


### PR DESCRIPTION
- Make tab's close button responsive to touch taps
- Make layer and mask properties responsive to touch taps

Fixes `Close a Scene` and `Modify a Mask property` issues in https://github.com/godotengine/godot/issues/73707

[main version](https://github.com/godotengine/godot/pull/75703)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
