### PR TITLE
CI: Visibly print trailing whitespace when static checks fail

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -22,7 +22,8 @@ jobs:
           sudo apt-get install -qq dos2unix clang-format-15 libxml2-utils python3-pip moreutils
           sudo update-alternatives --remove-all clang-format || true
           sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-15 100
-          sudo pip3 install black==22.3.0 pygments pytest==7.1.2 mypy==0.971
+          sudo pip3 install black==22.3.0 pytest==7.1.2 mypy==0.971
+          git config diff.wsErrorHighlight all
 
       - name: File formatting checks (file_format.sh)
         run: |

--- a/misc/scripts/black_format.sh
+++ b/misc/scripts/black_format.sh
@@ -13,13 +13,14 @@ diff=$(git diff --color)
 
 # If no diff has been generated all is OK, clean up, and exit.
 if [ -z "$diff" ] ; then
-    printf "Files in this commit comply with the black style rules.\n"
+    printf "\e[1;32m*** Files in this commit comply with the black style rules.\e[0m\n"
     exit 0
 fi
 
 # A diff has been created, notify the user, clean up, and exit.
-printf "\n*** The following differences were found between the code "
-printf "and the formatting rules:\n\n"
-echo "$diff"
-printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+printf "\n\e[1;33m*** The following changes must be made to comply with the formatting rules:\e[0m\n\n"
+# Perl commands replace trailing spaces with `·` and tabs with `<TAB>`.
+printf "$diff\n" | perl -pe 's/(.*[^ ])( +)(\e\[m)$/my $spaces="·" x length($2); sprintf("$1$spaces$3")/ge' | perl -pe 's/(.*[^\t])(\t+)(\e\[m)$/my $tabs="<TAB>" x length($2); sprintf("$1$tabs$3")/ge'
+
+printf "\n\e[1;91m*** Please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\e[0m\n"
 exit 1

--- a/misc/scripts/clang_format.sh
+++ b/misc/scripts/clang_format.sh
@@ -33,12 +33,14 @@ diff=$(git diff --color)
 
 # If no diff has been generated all is OK, clean up, and exit.
 if [ -z "$diff" ] ; then
-    printf "Files in this commit comply with the clang-format style rules.\n"
+    printf "\e[1;32m*** Files in this commit comply with the clang-format style rules.\e[0m\n"
     exit 0
 fi
 
 # A diff has been created, notify the user, clean up, and exit.
-printf "\n*** The following changes have been made to comply with the formatting rules:\n\n"
-echo "$diff"
-printf "\n*** Please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+printf "\n\e[1;33m*** The following changes must be made to comply with the formatting rules:\e[0m\n\n"
+# Perl commands replace trailing spaces with `·` and tabs with `<TAB>`.
+printf "$diff\n" | perl -pe 's/(.*[^ ])( +)(\e\[m)$/my $spaces="·" x length($2); sprintf("$1$spaces$3")/ge' | perl -pe 's/(.*[^\t])(\t+)(\e\[m)$/my $tabs="<TAB>" x length($2); sprintf("$1$tabs$3")/ge'
+
+printf "\n\e[1;91m*** Please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\e[0m\n"
 exit 1

--- a/misc/scripts/clang_tidy.sh
+++ b/misc/scripts/clang_tidy.sh
@@ -20,12 +20,14 @@ diff=$(git diff --color)
 
 # If no diff has been generated all is OK, clean up, and exit.
 if [ -z "$diff" ] ; then
-    printf "Files in this commit comply with the clang-tidy style rules.\n"
+    printf "\e[1;32m*** Files in this commit comply with the clang-tidy style rules.\e[0m\n"
     exit 0
 fi
 
 # A diff has been created, notify the user, clean up, and exit.
-printf "\n*** The following changes have been made to comply with the formatting rules:\n\n"
-echo "$diff"
-printf "\n*** Please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+printf "\n\e[1;33m*** The following changes must be made to comply with the formatting rules:\e[0m\n\n"
+# Perl commands replace trailing spaces with `·` and tabs with `<TAB>`.
+printf "$diff\n" | perl -pe 's/(.*[^ ])( +)(\e\[m)$/my $spaces="·" x length($2); sprintf("$1$spaces$3")/ge' | perl -pe 's/(.*[^\t])(\t+)(\e\[m)$/my $tabs="<TAB>" x length($2); sprintf("$1$tabs$3")/ge'
+
+printf "\n\e[1;91m*** Please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\e[0m\n"
 exit 1

--- a/misc/scripts/dotnet_format.sh
+++ b/misc/scripts/dotnet_format.sh
@@ -24,12 +24,14 @@ diff=$(git diff --color)
 
 # If no diff has been generated all is OK, clean up, and exit.
 if [ -z "$diff" ] ; then
-    printf "Files in this commit comply with the dotnet format style rules.\n"
+    printf "\e[1;32m*** Files in this commit comply with the dotnet format style rules.\e[0m\n"
     exit 0
 fi
 
 # A diff has been created, notify the user, clean up, and exit.
-printf "\n*** The following changes have been made to comply with the formatting rules:\n\n"
-echo "$diff"
-printf "\n*** Please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+printf "\n\e[1;33m*** The following changes must be made to comply with the formatting rules:\e[0m\n\n"
+# Perl commands replace trailing spaces with `·` and tabs with `<TAB>`.
+printf "$diff\n" | perl -pe 's/(.*[^ ])( +)(\e\[m)$/my $spaces="·" x length($2); sprintf("$1$spaces$3")/ge' | perl -pe 's/(.*[^\t])(\t+)(\e\[m)$/my $tabs="<TAB>" x length($2); sprintf("$1$tabs$3")/ge'
+
+printf "\n\e[1;91m*** Please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\e[0m\n"
 exit 1

--- a/misc/scripts/file_format.sh
+++ b/misc/scripts/file_format.sh
@@ -56,7 +56,7 @@ diff=$(git diff --color)
 if [ ! -s utf8-validation.txt ] && [ -z "$diff" ] ; then
     # If no UTF-8 violations were collected (the file is empty) and
     # no diff has been generated all is OK, clean up, and exit.
-    printf "Files in this commit comply with the formatting rules.\n"
+    printf "\e[1;32m*** Files in this commit comply with the file formatting rules.\e[0m\n"
     rm -f utf8-validation.txt
     exit 0
 fi
@@ -65,7 +65,7 @@ if [ -s utf8-validation.txt ]
 then
     # If the file has content and is not empty, violations
     # detected, notify the user, clean up, and exit.
-    printf "\n*** The following files contain invalid UTF-8 character sequences:\n\n"
+    printf "\n\e[1;33m*** The following files contain invalid UTF-8 character sequences:\e[0m\n\n"
     cat utf8-validation.txt
 fi
 
@@ -73,10 +73,11 @@ rm -f utf8-validation.txt
 
 if [ ! -z "$diff" ]
 then
-    printf "\n*** The following differences were found between the code "
-    printf "and the formatting rules:\n\n"
-    echo "$diff"
+    # A diff has been created, notify the user, clean up, and exit.
+    printf "\n\e[1;33m*** The following changes must be made to comply with the formatting rules:\e[0m\n\n"
+    # Perl commands replace trailing spaces with `·` and tabs with `<TAB>`.
+    printf "$diff\n" | perl -pe 's/(.*[^ ])( +)(\e\[m)$/my $spaces="·" x length($2); sprintf("$1$spaces$3")/ge' | perl -pe 's/(.*[^\t])(\t+)(\e\[m)$/my $tabs="<TAB>" x length($2); sprintf("$1$tabs$3")/ge'
 fi
 
-printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+printf "\n\e[1;91m*** Please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\e[0m\n"
 exit 1

--- a/misc/scripts/header_guards.sh
+++ b/misc/scripts/header_guards.sh
@@ -66,13 +66,14 @@ diff=$(git diff --color)
 
 # If no diff has been generated all is OK, clean up, and exit.
 if [ -z "$diff" ] ; then
-    printf "Files in this commit comply with the header guards formatting rules.\n"
+    printf "\e[1;32m*** Files in this commit comply with the header guards formatting rules.\e[0m\n"
     exit 0
 fi
 
 # A diff has been created, notify the user, clean up, and exit.
-printf "\n*** The following differences were found between the code "
-printf "and the header guards formatting rules:\n\n"
-echo "$diff"
-printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+printf "\n\e[1;33m*** The following changes must be made to comply with the formatting rules:\e[0m\n\n"
+# Perl commands replace trailing spaces with `·` and tabs with `<TAB>`.
+printf "$diff\n" | perl -pe 's/(.*[^ ])( +)(\e\[m)$/my $spaces="·" x length($2); sprintf("$1$spaces$3")/ge' | perl -pe 's/(.*[^\t])(\t+)(\e\[m)$/my $tabs="<TAB>" x length($2); sprintf("$1$tabs$3")/ge'
+
+printf "\n\e[1;91m*** Please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\e[0m\n"
 exit 1


### PR DESCRIPTION
GitHub Actions seems to be hiding colored whitespace, and after lots of attempts I couldn't find a way to work it around.

So instead I'm using a perl expression to replace trailing spaces with `·` and tabs with `<TAB>` in the ANSI colored diff output. This ensure that they're visible, and they are properly colored as expected too.

Test run: https://github.com/akien-mga/godot/actions/runs/4620688099/jobs/8171140859

![image](https://user-images.githubusercontent.com/4701338/230145483-57b2f6d7-2a1a-487e-8625-6e3e7f3f6b95.png)

All these shell scripts could use some refactoring to de-duplicate stuff, if anything by moving a few common patterns to functions in a separate script that would be sourced in each. But for now I'm keeping it simple, already spent more time on this than I was expecting, and I don't plan to work further on this right now.