### PR TITLE
Fix UI responsiveness to touch taps

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -871,56 +871,75 @@ String EditorPropertyLayersGrid::get_tooltip(const Point2 &p_pos) const {
 	return String();
 }
 
+void EditorPropertyLayersGrid::_update_hovered(const Vector2 &p_position) {
+	bool expand_was_hovered = expand_hovered;
+	expand_hovered = expand_rect.has_point(p_position);
+	if (expand_hovered != expand_was_hovered) {
+		queue_redraw();
+	}
+
+	if (!expand_hovered) {
+		for (int i = 0; i < flag_rects.size(); i++) {
+			if (flag_rects[i].has_point(p_position)) {
+				// Used to highlight the hovered flag in the layers grid.
+				hovered_index = i;
+				queue_redraw();
+				return;
+			}
+		}
+	}
+
+	// Remove highlight when no square is hovered.
+	if (hovered_index != -1) {
+		hovered_index = -1;
+		queue_redraw();
+	}
+}
+
+void EditorPropertyLayersGrid::_on_hover_exit() {
+	if (expand_hovered) {
+		expand_hovered = false;
+		queue_redraw();
+	}
+	if (hovered_index != -1) {
+		hovered_index = -1;
+		queue_redraw();
+	}
+}
+
+void EditorPropertyLayersGrid::_update_flag() {
+	if (hovered_index >= 0) {
+		// Toggle the flag.
+		// We base our choice on the hovered flag, so that it always matches the hovered flag.
+		if (value & (1 << hovered_index)) {
+			value &= ~(1 << hovered_index);
+		} else {
+			value |= (1 << hovered_index);
+		}
+
+		emit_signal(SNAME("flag_changed"), value);
+		queue_redraw();
+	} else if (expand_hovered) {
+		expanded = !expanded;
+		update_minimum_size();
+		queue_redraw();
+	}
+}
+
 void EditorPropertyLayersGrid::gui_input(const Ref<InputEvent> &p_ev) {
 	if (read_only) {
 		return;
 	}
 	const Ref<InputEventMouseMotion> mm = p_ev;
 	if (mm.is_valid()) {
-		bool expand_was_hovered = expand_hovered;
-		expand_hovered = expand_rect.has_point(mm->get_position());
-		if (expand_hovered != expand_was_hovered) {
-			queue_redraw();
-		}
-
-		if (!expand_hovered) {
-			for (int i = 0; i < flag_rects.size(); i++) {
-				if (flag_rects[i].has_point(mm->get_position())) {
-					// Used to highlight the hovered flag in the layers grid.
-					hovered_index = i;
-					queue_redraw();
-					return;
-				}
-			}
-		}
-
-		// Remove highlight when no square is hovered.
-		if (hovered_index != -1) {
-			hovered_index = -1;
-			queue_redraw();
-		}
-
+		_update_hovered(mm->get_position());
 		return;
 	}
 
 	const Ref<InputEventMouseButton> mb = p_ev;
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed()) {
-		if (hovered_index >= 0) {
-			// Toggle the flag.
-			// We base our choice on the hovered flag, so that it always matches the hovered flag.
-			if (value & (1 << hovered_index)) {
-				value &= ~(1 << hovered_index);
-			} else {
-				value |= (1 << hovered_index);
-			}
-
-			emit_signal(SNAME("flag_changed"), value);
-			queue_redraw();
-		} else if (expand_hovered) {
-			expanded = !expanded;
-			update_minimum_size();
-			queue_redraw();
-		}
+		_update_hovered(mb->get_position());
+		_update_flag();
 	}
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed()) {
 		if (hovered_index >= 0) {
@@ -1055,14 +1074,7 @@ void EditorPropertyLayersGrid::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_MOUSE_EXIT: {
-			if (expand_hovered) {
-				expand_hovered = false;
-				queue_redraw();
-			}
-			if (hovered_index != -1) {
-				hovered_index = -1;
-				queue_redraw();
-			}
+			_on_hover_exit();
 		} break;
 	}
 }

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -273,6 +273,9 @@ private:
 
 	void _rename_pressed(int p_menu);
 	void _rename_operation_confirm();
+	void _update_hovered(const Vector2 &p_position);
+	void _on_hover_exit();
+	void _update_flag();
 	Size2 get_grid_size() const;
 
 protected:

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -255,12 +255,14 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 
 				if (tabs[i].rb_rect.has_point(pos)) {
 					rb_pressing = true;
+					_update_hover();
 					queue_redraw();
 					return;
 				}
 
 				if (tabs[i].cb_rect.has_point(pos) && (cb_displaypolicy == CLOSE_BUTTON_SHOW_ALWAYS || (cb_displaypolicy == CLOSE_BUTTON_SHOW_ACTIVE_ONLY && i == current))) {
 					cb_pressing = true;
+					_update_hover();
 					queue_redraw();
 					return;
 				}


### PR DESCRIPTION
- Make tab's close button responsive to touch taps
- Make layer and mask properties responsive to touch taps

Fixes `Close a Scene` and `Modify a Mask property` issues in https://github.com/godotengine/godot/issues/73707

[3.x version](https://github.com/godotengine/godot/pull/75699)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
