### PR TITLE
Fix the sliding down of the window due to the reparenting caused by the window manager decorations.

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -1310,11 +1310,17 @@ void DisplayServerX11::show_window(WindowID p_id) {
 	const WindowData &wd = windows[p_id];
 	popup_open(p_id);
 
+	const Point2i bmpos = wd.position;
+
 	DEBUG_LOG_X11("show_window: %lu (%u) \n", wd.x11_window, p_id);
 
 	XMapWindow(x11_display, wd.x11_window);
 	XSync(x11_display, False);
 	_validate_mode_on_map(p_id);
+	if (!wd.borderless && !wd.fullscreen && !wd.exclusive_fullscreen) {
+		usleep(50000); // waiting for the window-manager to compelete the decoration of the window
+		window_set_position(bmpos, p_id);
+	}
 }
 
 void DisplayServerX11::delete_sub_window(WindowID p_id) {


### PR DESCRIPTION
It fixes the sliding down of the window due to the reparenting by the window manager which is done after mapping the window in X11. 
fixes #75292 and many more. It also slows down the thread as it waits for the window manager to complete the decorations. It would be optimal to start a new thread that will execute this solution and then terminate itself. I would love to have the dev's opinion on this.
Edit: It also doesn't work if the window manager takes more time in decoration than the waiting time given which can be solved by increasing the waiting time but it also slows the program even more.
Edit: It also just slows down the tiling window manager as XMoveWindow does not affect them.
Edit: Another solution as discussed in the review with no delay #76040