### PR TITLE
Exposes String functions for X509Certificates

### DIFF
--- a/core/crypto/crypto.cpp
+++ b/core/crypto/crypto.cpp
@@ -63,6 +63,8 @@ X509Certificate *X509Certificate::create() {
 void X509Certificate::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("save", "path"), &X509Certificate::save);
 	ClassDB::bind_method(D_METHOD("load", "path"), &X509Certificate::load);
+	ClassDB::bind_method(D_METHOD("save_to_string"), &X509Certificate::save_to_string);
+	ClassDB::bind_method(D_METHOD("load_from_string", "string"), &X509Certificate::load_from_string);
 }
 
 /// TLSOptions

--- a/core/crypto/crypto.h
+++ b/core/crypto/crypto.h
@@ -65,6 +65,8 @@ public:
 	virtual Error load(String p_path) = 0;
 	virtual Error load_from_memory(const uint8_t *p_buffer, int p_len) = 0;
 	virtual Error save(String p_path) = 0;
+	virtual String save_to_string() = 0;
+	virtual Error load_from_string(const String &string) = 0;
 };
 
 class TLSOptions : public RefCounted {

--- a/doc/classes/X509Certificate.xml
+++ b/doc/classes/X509Certificate.xml
@@ -17,11 +17,24 @@
 				Loads a certificate from [param path] ("*.crt" file).
 			</description>
 		</method>
+		<method name="load_from_string">
+			<return type="int" enum="Error" />
+			<param index="0" name="string" type="String" />
+			<description>
+				Loads a certificate from the given [param string].
+			</description>
+		</method>
 		<method name="save">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<description>
 				Saves a certificate to the given [param path] (should be a "*.crt" file).
+			</description>
+		</method>
+		<method name="save_to_string">
+			<return type="String" />
+			<description>
+				Returns a string representation of the certificate, or an empty string if the certificate is invalid.
 			</description>
 		</method>
 	</methods>

--- a/modules/mbedtls/crypto_mbedtls.h
+++ b/modules/mbedtls/crypto_mbedtls.h
@@ -85,6 +85,8 @@ public:
 	virtual Error load(String p_path);
 	virtual Error load_from_memory(const uint8_t *p_buffer, int p_len);
 	virtual Error save(String p_path);
+	virtual String save_to_string();
+	virtual Error load_from_string(const String &p_string_key);
 
 	X509CertificateMbedTLS() {
 		mbedtls_x509_crt_init(&cert);


### PR DESCRIPTION
Exposes String functions for X509Certificates via two function calls: save_to_string() and load_from_string(str).

For proposal: https://github.com/godotengine/godot-proposals/issues/4585
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
