### PR TITLE
Fix AudioStreamPlayer2D crash when PhysicsServer2D runs on thread

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -68,7 +68,8 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			// Update anything related to position first, if possible of course.
-			if (setplay.get() > 0 || (active.is_set() && last_mix_count != AudioServer::get_singleton()->get_mix_count())) {
+			if (setplay.get() > 0 || (active.is_set() && last_mix_count != AudioServer::get_singleton()->get_mix_count()) || force_update_panning) {
+				force_update_panning = false;
 				_update_panning();
 			}
 
@@ -109,6 +110,7 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 	}
 }
 
+// Interacts with PhysicsServer2D, so can only be called during _physics_process
 StringName AudioStreamPlayer2D::_get_actual_bus() {
 	Vector2 global_pos = get_global_position();
 
@@ -117,6 +119,7 @@ StringName AudioStreamPlayer2D::_get_actual_bus() {
 	ERR_FAIL_COND_V(world_2d.is_null(), SNAME("Master"));
 
 	PhysicsDirectSpaceState2D *space_state = PhysicsServer2D::get_singleton()->space_get_direct_state(world_2d->get_space());
+	ERR_FAIL_COND_V(space_state == nullptr, SNAME("Master"));
 	PhysicsDirectSpaceState2D::ShapeResult sr[MAX_INTERSECT_AREAS];
 
 	PhysicsDirectSpaceState2D::PointParameters point_params;
@@ -142,6 +145,7 @@ StringName AudioStreamPlayer2D::_get_actual_bus() {
 	return default_bus;
 }
 
+// Interacts with PhysicsServer2D, so can only be called during _physics_process
 void AudioStreamPlayer2D::_update_panning() {
 	if (!active.is_set() || stream.is_null()) {
 		return;

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -61,6 +61,7 @@ private:
 	Vector<AudioFrame> volume_vector;
 
 	uint64_t last_mix_count = -1;
+	bool force_update_panning = false;
 
 	float volume_db = 0.0;
 	float pitch_scale = 1.0;
@@ -75,7 +76,7 @@ private:
 	void _update_panning();
 	void _bus_layout_changed();
 
-	static void _listener_changed_cb(void *self) { reinterpret_cast<AudioStreamPlayer2D *>(self)->_update_panning(); }
+	static void _listener_changed_cb(void *self) { reinterpret_cast<AudioStreamPlayer2D *>(self)->force_update_panning = true; }
 
 	uint32_t area_mask = 1;
 


### PR DESCRIPTION
Fixes AudioStreamPlayer2D crash when PhysicsServer2D runs on thread.

Fixes #75727.

Applies the same fix to 2D that was already done for 3D a few months back with https://github.com/godotengine/godot/pull/61417.

The issue was that when a Viewport changes it triggers AudioServer updates for listeners. In case of the AudioStreamPlayer2D this would call the panning update function immediately. This function tries to access the physicsspace outside the physics frame which returns null while the PhysicsServer2D runs on a thread causing the crash.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
