### PR TITLE
Fix mistakes in documentation and GDScript errors

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -329,7 +329,7 @@
 			[b]Note:[/b] On certain window managers on Linux, the [kbd]Alt[/kbd] key will be intercepted by the window manager when clicking a mouse button at the same time. This means Godot will not see the modifier key as being pressed.
 		</member>
 		<member name="editors/3d/navigation/warped_mouse_panning" type="bool" setter="" getter="">
-			If [code]true[/code], warps the mouse around the 3D viewport while panning in the 3D editor. This makes it possible to pan over a large area without having to exit panning then mouse the mouse back constantly.
+			If [code]true[/code], warps the mouse around the 3D viewport while panning in the 3D editor. This makes it possible to pan over a large area without having to exit panning and adjust the mouse cursor.
 		</member>
 		<member name="editors/3d/navigation/zoom_modifier" type="int" setter="" getter="">
 			The modifier key that must be held to zoom in the 3D editor.
@@ -408,7 +408,7 @@
 			Controls whether the mouse wheel scroll zooms or pans in subeditors. The list of affected subeditors is: animation blend tree editor, [Polygon2D] editor, tileset editor, texture region editor and visual shader editor. See also [member editors/panning/2d_editor_panning_scheme] and [member editors/panning/animation_editors_panning_scheme].
 		</member>
 		<member name="editors/panning/warped_mouse_panning" type="bool" setter="" getter="">
-			If [code]true[/code], warps the mouse around the 2D viewport while panning in the 2D editor. This makes it possible to pan over a large area without having to exit panning then mouse the mouse back constantly.
+			If [code]true[/code], warps the mouse around the 2D viewport while panning in the 2D editor. This makes it possible to pan over a large area without having to exit panning and adjust the mouse cursor.
 		</member>
 		<member name="editors/polygon_editor/point_grab_radius" type="int" setter="" getter="">
 			The radius in which points can be selected in the [Polygon2D] and [CollisionPolygon2D] editors (in pixels). Higher values make it easier to select points quickly, but can make it more difficult to select the expected point when several points are located close to each other.
@@ -686,7 +686,7 @@
 			If [code]true[/code], makes the caret blink according to [member text_editor/appearance/caret/caret_blink_interval]. Disabling this setting can improve battery life on laptops if you spend long amounts of time in the script editor, since it will reduce the frequency at which the editor needs to be redrawn.
 		</member>
 		<member name="text_editor/appearance/caret/caret_blink_interval" type="float" setter="" getter="">
-			The interval at which to blink the caret (in seconds). See also [member text_editor/appearance/caret/caret_blink].
+			The interval at which the caret will blink (in seconds). See also [member text_editor/appearance/caret/caret_blink].
 		</member>
 		<member name="text_editor/appearance/caret/highlight_all_occurrences" type="bool" setter="" getter="">
 			If [code]true[/code], highlights all occurrences of the currently selected text in the script editor. See also [member text_editor/theme/highlighting/word_highlighted_color].

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -187,10 +187,10 @@
 			Text alignment as defined in the [enum HorizontalAlignment] enum.
 		</member>
 		<member name="caret_blink" type="bool" setter="set_caret_blink_enabled" getter="is_caret_blink_enabled" default="false">
-			If [code]true[/code], the caret (text cursor) blinks.
+			If [code]true[/code], makes the caret blink.
 		</member>
 		<member name="caret_blink_interval" type="float" setter="set_caret_blink_interval" getter="get_caret_blink_interval" default="0.65">
-			Duration (in seconds) of a caret's blinking cycle.
+			The interval at which the caret blinks (in seconds).
 		</member>
 		<member name="caret_column" type="int" setter="set_caret_column" getter="get_caret_column" default="0">
 			The caret's column position inside the [LineEdit]. When set, the text may scroll to accommodate it.

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1088,10 +1088,10 @@
 	</methods>
 	<members>
 		<member name="caret_blink" type="bool" setter="set_caret_blink_enabled" getter="is_caret_blink_enabled" default="false">
-			Sets if the caret should blink.
+			If [code]true[/code], makes the caret blink.
 		</member>
 		<member name="caret_blink_interval" type="float" setter="set_caret_blink_interval" getter="get_caret_blink_interval" default="0.65">
-			Duration (in seconds) of a caret's blinking cycle.
+			The interval at which the caret blinks (in seconds).
 		</member>
 		<member name="caret_mid_grapheme" type="bool" setter="set_caret_mid_grapheme_enabled" getter="is_caret_mid_grapheme_enabled" default="true">
 			Allow moving caret, selecting and removing the individual composite character components.

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1343,7 +1343,7 @@ void GDScriptParser::parse_function_signature(FunctionNode *p_function, SuiteNod
 				default_used = true;
 			} else {
 				if (default_used) {
-					push_error("Cannot have a mandatory parameters after optional parameters.");
+					push_error("Cannot have mandatory parameters after optional parameters.");
 					continue;
 				}
 			}
@@ -1475,7 +1475,7 @@ GDScriptParser::AnnotationNode *GDScriptParser::parse_annotation(uint32_t p_vali
 
 void GDScriptParser::clear_unused_annotations() {
 	for (const AnnotationNode *annotation : annotation_stack) {
-		push_error(vformat(R"(Annotation "%s" does not precedes a valid target, so it will have no effect.)", annotation->name), annotation);
+		push_error(vformat(R"(Annotation "%s" does not precede a valid target, so it will have no effect.)", annotation->name), annotation);
 	}
 
 	annotation_stack.clear();
@@ -1817,7 +1817,7 @@ GDScriptParser::ForNode *GDScriptParser::parse_for() {
 	n_for->list = parse_expression(false);
 
 	if (!n_for->list) {
-		push_error(R"(Expected a list or range after "in".)");
+		push_error(R"(Expected iterable after "in".)");
 	}
 
 	consume(GDScriptTokenizer::Token::COLON, R"(Expected ":" after "for" condition.)");
@@ -3856,7 +3856,7 @@ bool GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node
 					variable->export_info.hint = PROPERTY_HINT_NODE_TYPE;
 					variable->export_info.hint_string = export_type.to_string();
 				} else {
-					push_error(R"(Export type can only be built-in, a resource, a node or an enum.)", variable);
+					push_error(R"(Export type can only be built-in, a resource, a node, or an enum.)", variable);
 					return false;
 				}
 
@@ -3901,8 +3901,7 @@ bool GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node
 				variable->export_info.hint_string = enum_hint_string;
 			} break;
 			default:
-				// TODO: Allow custom user resources.
-				push_error(R"(Export type can only be built-in, a resource, or an enum.)", variable);
+				push_error(R"(Export type can only be built-in, a resource, a node, or an enum.)", variable);
 				break;
 		}
 

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -183,7 +183,7 @@ String GDScriptWarning::get_message() const {
 			return vformat(R"*(The default value is using "%s" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.)*", symbols[0]);
 		}
 		case ONREADY_WITH_EXPORT: {
-			return R"(The "@onready" annotation will make the default value to be set after the "@export" takes effect and will override it.)";
+			return R"("@onready" will set the default value after "@export" takes effect and will override it.)";
 		}
 		case WARNING_MAX:
 			break; // Can't happen, but silences warning

--- a/modules/gdscript/tests/scripts/analyzer/warnings/onready_with_export.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/onready_with_export.out
@@ -2,5 +2,5 @@ GDTEST_OK
 >> WARNING
 >> Line: 3
 >> ONREADY_WITH_EXPORT
->> The "@onready" annotation will make the default value to be set after the "@export" takes effect and will override it.
+>> "@onready" will set the default value after "@export" takes effect and will override it.
 warn


### PR DESCRIPTION
Just a couple mistakes I noted down over the last few months of using Godot.

> Mouse the mouse

Lmao. Moreover, I think the author intended to say "wrapped" and not "warped", but it's in the variable and I'm just changing strings here.

> Blinking cycle

That infers the full cycle, both when the caret is visible and when it's not. But the property is actually the time between toggling the caret's visibility.

> A list or range

Or a string. Or a number. `in` is referred to as a "content-test operator", so I switched that to "content".

> // TODO: Allow custom user resources.

I synchronized all the errors that said `"Only X and Y and Z is allowed in @export"`. This TODO was above one of them, and I don't know the specific context, but AFAIK exporting custom user resources is fully solved now.