### PR TITLE
[TextServer] Add support for retrieving OpenType name strings.

### DIFF
--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -215,6 +215,12 @@
 				Returns a set of OpenType feature tags. More info: [url=https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags]OpenType feature tags[/url].
 			</description>
 		</method>
+		<method name="get_ot_name_strings" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Returns [Dictionary] with OpenType font name strings (localized font names, version, description, license information, sample text, etc.).
+			</description>
+		</method>
 		<method name="get_rids" qualifiers="const">
 			<return type="RID[]" />
 			<description>

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -334,6 +334,13 @@
 				Returns font OpenType feature set override.
 			</description>
 		</method>
+		<method name="font_get_ot_name_strings" qualifiers="const">
+			<return type="Dictionary" />
+			<param index="0" name="font_rid" type="RID" />
+			<description>
+				Returns [Dictionary] with OpenType font name strings (localized font names, version, description, license information, sample text, etc.).
+			</description>
+		</method>
 		<method name="font_get_oversampling" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -287,6 +287,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_font_get_ot_name_strings" qualifiers="virtual const">
+			<return type="Dictionary" />
+			<param index="0" name="font_rid" type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="_font_get_oversampling" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -714,6 +714,7 @@ public:
 
 	MODBIND2(font_set_name, const RID &, const String &);
 	MODBIND1RC(String, font_get_name, const RID &);
+	MODBIND1RC(Dictionary, font_get_ot_name_strings, const RID &);
 
 	MODBIND2(font_set_antialiasing, const RID &, TextServer::FontAntialiasing);
 	MODBIND1RC(TextServer::FontAntialiasing, font_get_antialiasing, const RID &);

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -62,6 +62,7 @@ void Font::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_font_name"), &Font::get_font_name);
 	ClassDB::bind_method(D_METHOD("get_font_style_name"), &Font::get_font_style_name);
+	ClassDB::bind_method(D_METHOD("get_ot_name_strings"), &Font::get_ot_name_strings);
 	ClassDB::bind_method(D_METHOD("get_font_style"), &Font::get_font_style);
 	ClassDB::bind_method(D_METHOD("get_font_weight"), &Font::get_font_weight);
 	ClassDB::bind_method(D_METHOD("get_font_stretch"), &Font::get_font_stretch);
@@ -241,6 +242,10 @@ real_t Font::get_underline_thickness(int p_font_size) const {
 
 String Font::get_font_name() const {
 	return TS->font_get_name(_get_rid());
+}
+
+Dictionary Font::get_ot_name_strings() const {
+	return TS->font_get_ot_name_strings(_get_rid());
 }
 
 String Font::get_font_style_name() const {

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -126,6 +126,7 @@ public:
 
 	virtual String get_font_name() const;
 	virtual String get_font_style_name() const;
+	virtual Dictionary get_ot_name_strings() const;
 	virtual BitField<TextServer::FontStyle> get_font_style() const;
 	virtual int get_font_weight() const;
 	virtual int get_font_stretch() const;

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -65,6 +65,7 @@ void TextServerExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_font_set_name, "font_rid", "name");
 	GDVIRTUAL_BIND(_font_get_name, "font_rid");
+	GDVIRTUAL_BIND(_font_get_ot_name_strings, "font_rid");
 
 	GDVIRTUAL_BIND(_font_set_style_name, "font_rid", "name_style");
 	GDVIRTUAL_BIND(_font_get_style_name, "font_rid");
@@ -473,6 +474,12 @@ void TextServerExtension::font_set_name(const RID &p_font_rid, const String &p_n
 String TextServerExtension::font_get_name(const RID &p_font_rid) const {
 	String ret;
 	GDVIRTUAL_CALL(_font_get_name, p_font_rid, ret);
+	return ret;
+}
+
+Dictionary TextServerExtension::font_get_ot_name_strings(const RID &p_font_rid) const {
+	Dictionary ret;
+	GDVIRTUAL_CALL(_font_get_ot_name_strings, p_font_rid, ret);
 	return ret;
 }
 

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -101,8 +101,10 @@ public:
 
 	virtual void font_set_name(const RID &p_font_rid, const String &p_name) override;
 	virtual String font_get_name(const RID &p_font_rid) const override;
+	virtual Dictionary font_get_ot_name_strings(const RID &p_font_rid) const override;
 	GDVIRTUAL2(_font_set_name, RID, const String &);
 	GDVIRTUAL1RC(String, _font_get_name, RID);
+	GDVIRTUAL1RC(Dictionary, _font_get_ot_name_strings, RID);
 
 	virtual void font_set_style_name(const RID &p_font_rid, const String &p_name) override;
 	virtual String font_get_style_name(const RID &p_font_rid) const override;

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -219,6 +219,7 @@ void TextServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("font_set_name", "font_rid", "name"), &TextServer::font_set_name);
 	ClassDB::bind_method(D_METHOD("font_get_name", "font_rid"), &TextServer::font_get_name);
+	ClassDB::bind_method(D_METHOD("font_get_ot_name_strings", "font_rid"), &TextServer::font_get_ot_name_strings);
 
 	ClassDB::bind_method(D_METHOD("font_set_style_name", "font_rid", "name"), &TextServer::font_set_style_name);
 	ClassDB::bind_method(D_METHOD("font_get_style_name", "font_rid"), &TextServer::font_get_style_name);

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -251,6 +251,7 @@ public:
 
 	virtual void font_set_name(const RID &p_font_rid, const String &p_name) = 0;
 	virtual String font_get_name(const RID &p_font_rid) const = 0;
+	virtual Dictionary font_get_ot_name_strings(const RID &p_font_rid) const { return Dictionary(); }
 
 	virtual void font_set_style_name(const RID &p_font_rid, const String &p_name) = 0;
 	virtual String font_get_style_name(const RID &p_font_rid) const = 0;


### PR DESCRIPTION
Add method to get OpenType name strings, which contain localized name and other font information. Was made to get sample texts for better font selection/preview, unfortunately seems like most fonts do not have samples (only 5 from 500 on my system do). But it might be useful for something else.

Example of the returned `Dictionary`:
```
{
    "en": {
        "copyright": "© 2012 DynaComware Taiwan Inc. All rights reserved.",
        "family_name": "HanziPen SC",
        "subfamily_name": "Regular",
        "unique_identifier": "HanziPen SC Regular; 14.0d1e1; 2018-06-12",
        "full_name": "HanziPen SC Regular",
        "version": "14.0d1e1",
        "postscript_name": "HanziPenSC-W3",
        "trademark": "HanziPenSC W3 is a trademark of DynaComware Taiwan Inc.",
        "designer": "DynaComware Taiwan Inc.",
        "vendor_url": "http://www.dynacw.com",
        "typographic_family_name": "HanziPen SC",
        "typographic_subfamily_name": "Regular" 
    },
    "zh-cn": {
        "family_name": "翩翩体-简",
        "subfamily_name": "常规体",
        "full_name": "翩翩体-简 常规体",
        "typographic_family_name": "翩翩体-简",
        "typographic_subfamily_name": "常规体" 
    },
    "zh-tw": {
        "family_name": "翩翩體 簡",
        "subfamily_name": "標準體",
        "full_name": "翩翩體-簡 標準體",
        "typographic_family_name": "翩翩體-簡",
        "typographic_subfamily_name": "標準體" 
    } 
}
```