### PR TITLE
Fix NavigationObstacles not being added to avoidance simulation

### DIFF
--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -196,11 +196,18 @@ void NavigationObstacle2D::set_agent_parent(Node *p_agent_parent) {
 		} else {
 			NavigationServer2D::get_singleton()->agent_set_map(get_rid(), parent_node2d->get_world_2d()->get_navigation_map());
 		}
+		// Need to register Callback as obstacle requires a valid Callback to be added to avoidance simulation.
+		NavigationServer2D::get_singleton()->agent_set_callback(get_rid(), callable_mp(this, &NavigationObstacle2D::_avoidance_done));
 		reevaluate_agent_radius();
 	} else {
 		parent_node2d = nullptr;
 		NavigationServer2D::get_singleton()->agent_set_map(get_rid(), RID());
+		NavigationServer2D::get_singleton()->agent_set_callback(agent, Callable());
 	}
+}
+
+void NavigationObstacle2D::_avoidance_done(Vector3 p_new_velocity) {
+	// Dummy function as obstacle requires a valid Callback to be added to avoidance simulation.
 }
 
 void NavigationObstacle2D::set_navigation_map(RID p_navigation_map) {

--- a/scene/2d/navigation_obstacle_2d.h
+++ b/scene/2d/navigation_obstacle_2d.h
@@ -75,6 +75,8 @@ public:
 
 	PackedStringArray get_configuration_warnings() const override;
 
+	void _avoidance_done(Vector3 p_new_velocity); // Dummy
+
 private:
 	void initialize_agent();
 	void reevaluate_agent_radius();

--- a/scene/3d/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation_obstacle_3d.cpp
@@ -203,11 +203,18 @@ void NavigationObstacle3D::set_agent_parent(Node *p_agent_parent) {
 		} else {
 			NavigationServer3D::get_singleton()->agent_set_map(get_rid(), parent_node3d->get_world_3d()->get_navigation_map());
 		}
+		// Need to register Callback as obstacle requires a valid Callback to be added to avoidance simulation.
+		NavigationServer3D::get_singleton()->agent_set_callback(get_rid(), callable_mp(this, &NavigationObstacle3D::_avoidance_done));
 		reevaluate_agent_radius();
 	} else {
 		parent_node3d = nullptr;
 		NavigationServer3D::get_singleton()->agent_set_map(get_rid(), RID());
+		NavigationServer3D::get_singleton()->agent_set_callback(agent, Callable());
 	}
+}
+
+void NavigationObstacle3D::_avoidance_done(Vector3 p_new_velocity) {
+	// Dummy function as obstacle requires a valid Callback to be added to avoidance simulation.
 }
 
 void NavigationObstacle3D::set_navigation_map(RID p_navigation_map) {

--- a/scene/3d/navigation_obstacle_3d.h
+++ b/scene/3d/navigation_obstacle_3d.h
@@ -74,6 +74,8 @@ public:
 
 	PackedStringArray get_configuration_warnings() const override;
 
+	void _avoidance_done(Vector3 p_new_velocity); // Dummy
+
 private:
 	void initialize_agent();
 	void reevaluate_agent_radius();


### PR DESCRIPTION
Fixes NavigationObstacles not being added to avoidance simulation.

This fixes a regression from https://github.com/godotengine/godot/pull/74893 that fixed the bug that all agents would be added to the avoidance regardless.

The obstacles actually only worked while this bug was present as they never registered themself with the avoidance. Now that only "active" agents are added to the avoidance simulation the obstacles are ignored.

This fix with a dummy function for the callback is temporary as it is the least invasive fix for Godot 4.0.2. It will be removed with the avoidance rework again cause the rework does the entire avoidance enabling differently. Copying the same fix from the rework to 4.0.2 rightnow would require so many changes that it is not worth it.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
