### PR TITLE
Fix GDExtension Variant type conversion

### DIFF
--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -1541,7 +1541,7 @@ struct VariantTypeConstructor {
 
 	_FORCE_INLINE_ static void type_from_variant(void *r_value, void *p_variant) {
 		// r_value is provided by caller as uninitialized memory
-		memnew_placement(r_value, T(VariantInternalAccessor<T>::get(reinterpret_cast<Variant *>(p_variant))));
+		memnew_placement(r_value, T(*reinterpret_cast<Variant *>(p_variant)));
 	}
 };
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/75757
Fixes https://github.com/godotengine/godot-cpp/issues/1132
Fixes https://github.com/godotengine/godot-cpp/issues/907
Fixes https://github.com/godotengine/godot-cpp/issues/1106

With this PR, `VariantTypeConstructor<T>::type_from_variant` now does the type conversion from `Variant` to `T`. Previously, it only `reinterpret_cast` the variant data by `VariantInternalAccessor<T>::get`.