### PR TITLE
Rework for nested `AnimationNodeStateMachine`

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -61,6 +61,7 @@
 			<param index="0" name="time" type="float" />
 			<param index="1" name="seek" type="bool" />
 			<param index="2" name="is_external_seeking" type="bool" />
+			<param index="3" name="test_only" type="bool" />
 			<description>
 				When inheriting from [AnimationRootNode], implement this virtual method to run some code when this node is processed. The [param time] parameter is a relative delta, unless [param seek] is [code]true[/code], in which case it is absolute.
 				Here, call the [method blend_input], [method blend_node] or [method blend_animation] functions. You can also use [method get_parameter] and [method set_parameter] to modify local memory.
@@ -97,6 +98,7 @@
 			<param index="4" name="blend" type="float" />
 			<param index="5" name="filter" type="int" enum="AnimationNode.FilterAction" default="0" />
 			<param index="6" name="sync" type="bool" default="true" />
+			<param index="7" name="test_only" type="bool" default="false" />
 			<description>
 				Blend an input. This is only useful for nodes created for an [AnimationNodeBlendTree]. The [param time] parameter is a relative delta, unless [param seek] is [code]true[/code], in which case it is absolute. A filter mode may be optionally passed (see [enum FilterAction] for options).
 			</description>
@@ -111,6 +113,7 @@
 			<param index="5" name="blend" type="float" />
 			<param index="6" name="filter" type="int" enum="AnimationNode.FilterAction" default="0" />
 			<param index="7" name="sync" type="bool" default="true" />
+			<param index="8" name="test_only" type="bool" default="false" />
 			<description>
 				Blend another animation node (in case this node contains children animation nodes). This function is only useful if you inherit from [AnimationRootNode] instead, else editors will not display your node for addition.
 			</description>

--- a/doc/classes/AnimationNodeStateMachine.xml
+++ b/doc/classes/AnimationNodeStateMachine.xml
@@ -165,5 +165,23 @@
 		<member name="allow_transition_to_self" type="bool" setter="set_allow_transition_to_self" getter="is_allow_transition_to_self" default="false">
 			If [code]true[/code], allows teleport to the self state with [method AnimationNodeStateMachinePlayback.travel]. When the reset option is enabled in [method AnimationNodeStateMachinePlayback.travel], the animation is restarted. If [code]false[/code], nothing happens on the teleportation to the self state.
 		</member>
+		<member name="reset_ends" type="bool" setter="set_reset_ends" getter="are_ends_reset" default="false">
+			If [code]true[/code], treat the cross-fade to the start and end nodes as a blend with the RESET animation.
+			In most cases, when additional cross-fades are performed in the parent [AnimationNode] of the state machine, setting this property to [code]false[/code] and matching the cross-fade time of the parent [AnimationNode] and the state machine's start node and end node gives good results.
+		</member>
+		<member name="state_machine_type" type="int" setter="set_state_machine_type" getter="get_state_machine_type" enum="AnimationNodeStateMachine.StateMachineType" default="0">
+			This property can define the process of transitions for different use cases. See also [enum AnimationNodeStateMachine.StateMachineType].
+		</member>
 	</members>
+	<constants>
+		<constant name="STATE_MACHINE_TYPE_ROOT" value="0" enum="StateMachineType">
+			Seeking to the beginning is treated as playing from the start state. Transition to the end state is treated as exiting the state machine.
+		</constant>
+		<constant name="STATE_MACHINE_TYPE_NESTED" value="1" enum="StateMachineType">
+			Seeking to the beginning is treated as seeking to the beginning of the animation in the current state. Transition to the end state, or the absence of transitions in each state, is treated as exiting the state machine.
+		</constant>
+		<constant name="STATE_MACHINE_TYPE_GROUPED" value="2" enum="StateMachineType">
+			This is a grouped state machine that can be controlled from a parent state machine. It does not work on standalone. There must be a state machine with [member state_machine_type] of [constant STATE_MACHINE_TYPE_ROOT] or [constant STATE_MACHINE_TYPE_NESTED] in the parent or ancestor.
+		</constant>
+	</constants>
 </class>

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -50,6 +50,7 @@
 #include "scene/gui/tree.h"
 #include "scene/main/viewport.h"
 #include "scene/main/window.h"
+#include "scene/scene_string_names.h"
 
 bool AnimationNodeStateMachineEditor::can_edit(const Ref<AnimationNode> &p_node) {
 	Ref<AnimationNodeStateMachine> ansm = p_node;
@@ -67,7 +68,6 @@ void AnimationNodeStateMachineEditor::edit(const Ref<AnimationNode> &p_node) {
 		selected_transition_from = StringName();
 		selected_transition_to = StringName();
 		selected_transition_index = -1;
-		selected_multi_transition = TransitionLine();
 		selected_node = StringName();
 		selected_nodes.clear();
 		_update_mode();
@@ -78,14 +78,60 @@ void AnimationNodeStateMachineEditor::edit(const Ref<AnimationNode> &p_node) {
 	tool_connect->set_disabled(read_only);
 }
 
+String AnimationNodeStateMachineEditor::_get_root_playback_path(String &r_node_directory) {
+	AnimationTree *tree = AnimationTreeEditor::get_singleton()->get_animation_tree();
+	Vector<String> edited_path = AnimationTreeEditor::get_singleton()->get_edited_path();
+
+	String base_path;
+	Vector<String> node_directory_path;
+
+	bool is_playable_anodesm_found = false;
+
+	if (edited_path.size()) {
+		while (!is_playable_anodesm_found) {
+			base_path = String("/").join(edited_path);
+			Ref<AnimationNodeStateMachine> anodesm = !edited_path.size() ? tree->get_tree_root() : tree->get_tree_root()->find_node_by_path(base_path);
+			if (!anodesm.is_valid()) {
+				break;
+			} else {
+				if (anodesm->get_state_machine_type() != AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
+					is_playable_anodesm_found = true;
+				} else {
+					int idx = edited_path.size() - 1;
+					node_directory_path.push_back(edited_path[idx]);
+					edited_path.remove_at(idx);
+				}
+			}
+		}
+	}
+
+	if (is_playable_anodesm_found) {
+		// Return Root/Nested state machine playback.
+		node_directory_path.reverse();
+		r_node_directory = String("/").join(node_directory_path);
+		if (node_directory_path.size()) {
+			r_node_directory += "/";
+		}
+		base_path = !edited_path.size() ? String(SceneStringNames::get_singleton()->parameters_base_path) + "playback" : String(SceneStringNames::get_singleton()->parameters_base_path) + base_path + "/playback";
+	} else {
+		// Hmmm, we have to return Grouped state machine playback...
+		// It will give the user the error that Root/Nested state machine should be retrieved, that would be kind :-)
+		r_node_directory = String();
+		base_path = AnimationTreeEditor::get_singleton()->get_base_path() + "playback";
+	}
+
+	return base_path;
+}
+
 void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEvent> &p_event) {
 	AnimationTree *tree = AnimationTreeEditor::get_singleton()->get_animation_tree();
 	if (!tree) {
 		return;
 	}
 
-	Ref<AnimationNodeStateMachinePlayback> playback = tree->get(AnimationTreeEditor::get_singleton()->get_base_path() + "playback");
-	if (playback.is_null()) {
+	String node_directory;
+	Ref<AnimationNodeStateMachinePlayback> playback = tree->get(_get_root_playback_path(node_directory));
+	if (!playback.is_valid()) {
 		return;
 	}
 
@@ -97,16 +143,6 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			}
 			accept_event();
 		}
-	}
-
-	// Group selected nodes on a state machine
-	if (tool_select->is_pressed() && k.is_valid() && k->is_pressed() && k->is_ctrl_pressed() && !k->is_shift_pressed() && k->get_keycode() == Key::G && !k->is_echo()) {
-		_group_selected_nodes();
-	}
-
-	// Ungroup state machine
-	if (tool_select->is_pressed() && k.is_valid() && k->is_pressed() && k->is_ctrl_pressed() && k->is_shift_pressed() && k->get_keycode() == Key::G && !k->is_echo()) {
-		_ungroup_selected_nodes();
 	}
 
 	Ref<InputEventMouseButton> mb = p_event;
@@ -124,17 +160,16 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 		selected_transition_from = StringName();
 		selected_transition_to = StringName();
 		selected_transition_index = -1;
-		selected_multi_transition = TransitionLine();
 		selected_node = StringName();
 
 		for (int i = node_rects.size() - 1; i >= 0; i--) { //inverse to draw order
 			if (node_rects[i].play.has_point(mb->get_position())) { //edit name
 				if (play_mode->get_selected() == 1 || !playback->is_playing()) {
-					//start
-					playback->start(node_rects[i].node_name);
+					// Start
+					playback->start(node_directory + String(node_rects[i].node_name));
 				} else {
-					//travel
-					playback->travel(node_rects[i].node_name);
+					// Travel
+					playback->travel(node_directory + String(node_rects[i].node_name));
 				}
 				state_machine_draw->queue_redraw();
 				return;
@@ -213,26 +248,11 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			selected_transition_index = closest;
 
 			Ref<AnimationNodeStateMachineTransition> tr = state_machine->get_transition(closest);
-			EditorNode::get_singleton()->push_item(tr.ptr(), "", true);
-
-			if (!transition_lines[closest].multi_transitions.is_empty()) {
-				selected_transition_index = -1;
-				selected_multi_transition = transition_lines[closest];
-
-				Ref<EditorAnimationMultiTransitionEdit> multi;
-				multi.instantiate();
-				multi->add_transition(selected_transition_from, selected_transition_to, tr);
-
-				for (int i = 0; i < transition_lines[closest].multi_transitions.size(); i++) {
-					int index = transition_lines[closest].multi_transitions[i].transition_index;
-
-					Ref<AnimationNodeStateMachineTransition> transition = state_machine->get_transition(index);
-					StringName from = transition_lines[closest].multi_transitions[i].from_node;
-					StringName to = transition_lines[closest].multi_transitions[i].to_node;
-
-					multi->add_transition(from, to, transition);
-				}
-				EditorNode::get_singleton()->push_item(multi.ptr(), "", true);
+			if (!state_machine->is_transition_across_group(closest)) {
+				EditorNode::get_singleton()->push_item(tr.ptr(), "", true);
+			} else {
+				EditorNode::get_singleton()->push_item(tr.ptr(), "", true);
+				EditorNode::get_singleton()->push_item(nullptr, "", true);
 			}
 		}
 
@@ -296,11 +316,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 				EditorNode::get_singleton()->show_warning(TTR("Transition exists!"));
 				connecting = false;
 			} else {
-				if (anodesm.is_valid() || end_node.is_valid()) {
-					_open_connect_menu(mb->get_position());
-				} else {
-					_add_transition();
-				}
+				_add_transition();
 			}
 		} else {
 			_open_menu(mb->get_position());
@@ -481,12 +497,6 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 				String from = String(transition_lines[closest].from_node);
 				String to = String(transition_lines[closest].to_node);
 				String tooltip = from + " -> " + to;
-
-				for (int i = 0; i < transition_lines[closest].multi_transitions.size(); i++) {
-					from = String(transition_lines[closest].multi_transitions[i].from_node);
-					to = String(transition_lines[closest].multi_transitions[i].to_node);
-					tooltip += "\n" + from + " -> " + to;
-				}
 				state_machine_draw->set_tooltip_text(tooltip);
 			} else {
 				state_machine_draw->set_tooltip_text("");
@@ -520,224 +530,6 @@ Control::CursorShape AnimationNodeStateMachineEditor::get_cursor_shape(const Poi
 		}
 	}
 	return cursor_shape;
-}
-
-void AnimationNodeStateMachineEditor::_group_selected_nodes() {
-	if (!selected_nodes.is_empty()) {
-		if (selected_nodes.size() == 1 && (*selected_nodes.begin() == state_machine->start_node || *selected_nodes.begin() == state_machine->end_node))
-			return;
-
-		Ref<AnimationNodeStateMachine> group_sm = memnew(AnimationNodeStateMachine);
-		Vector2 group_position;
-
-		Vector<NodeUR> nodes_ur;
-		Vector<TransitionUR> transitions_ur;
-
-		int base = 1;
-		String base_name = group_sm->get_caption();
-		String group_name = base_name;
-
-		while (state_machine->has_node(group_name) && !selected_nodes.has(group_name)) {
-			base++;
-			group_name = base_name + " " + itos(base);
-		}
-
-		updating = true;
-		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-		undo_redo->create_action("Group");
-
-		// Move selected nodes to the new state machine
-		for (const StringName &E : selected_nodes) {
-			if (!state_machine->can_edit_node(E)) {
-				continue;
-			}
-
-			Ref<AnimationNode> node = state_machine->get_node(E);
-			Vector2 node_position = state_machine->get_node_position(E);
-			group_position += node_position;
-
-			NodeUR new_node;
-			new_node.name = E;
-			new_node.node = node;
-			new_node.position = node_position;
-
-			nodes_ur.push_back(new_node);
-		}
-
-		// Add the transitions to the new state machine
-		for (int i = 0; i < state_machine->get_transition_count(); i++) {
-			String from = state_machine->get_transition_from(i);
-			String to = state_machine->get_transition_to(i);
-
-			String local_from = from.get_slicec('/', 0);
-			String local_to = to.get_slicec('/', 0);
-
-			String old_from = from;
-			String old_to = to;
-
-			bool from_selected = false;
-			bool to_selected = false;
-
-			if (selected_nodes.has(local_from) && local_from != state_machine->start_node) {
-				from_selected = true;
-			}
-			if (selected_nodes.has(local_to) && local_to != state_machine->end_node) {
-				to_selected = true;
-			}
-			if (!from_selected && !to_selected) {
-				continue;
-			}
-
-			Ref<AnimationNodeStateMachineTransition> tr = state_machine->get_transition(i);
-
-			if (!from_selected) {
-				from = "../" + old_from;
-			}
-			if (!to_selected) {
-				to = "../" + old_to;
-			}
-
-			TransitionUR new_tr;
-			new_tr.new_from = from;
-			new_tr.new_to = to;
-			new_tr.old_from = old_from;
-			new_tr.old_to = old_to;
-			new_tr.transition = tr;
-
-			transitions_ur.push_back(new_tr);
-		}
-
-		for (int i = 0; i < nodes_ur.size(); i++) {
-			undo_redo->add_do_method(state_machine.ptr(), "remove_node", nodes_ur[i].name);
-			undo_redo->add_undo_method(group_sm.ptr(), "remove_node", nodes_ur[i].name);
-		}
-
-		undo_redo->add_do_method(state_machine.ptr(), "add_node", group_name, group_sm, group_position / nodes_ur.size());
-		undo_redo->add_undo_method(state_machine.ptr(), "remove_node", group_name);
-
-		for (int i = 0; i < nodes_ur.size(); i++) {
-			undo_redo->add_do_method(group_sm.ptr(), "add_node", nodes_ur[i].name, nodes_ur[i].node, nodes_ur[i].position);
-			undo_redo->add_undo_method(state_machine.ptr(), "add_node", nodes_ur[i].name, nodes_ur[i].node, nodes_ur[i].position);
-		}
-
-		for (int i = 0; i < transitions_ur.size(); i++) {
-			undo_redo->add_do_method(group_sm.ptr(), "add_transition", transitions_ur[i].new_from, transitions_ur[i].new_to, transitions_ur[i].transition);
-			undo_redo->add_undo_method(state_machine.ptr(), "add_transition", transitions_ur[i].old_from, transitions_ur[i].old_to, transitions_ur[i].transition);
-		}
-
-		undo_redo->add_do_method(this, "_update_graph");
-		undo_redo->add_undo_method(this, "_update_graph");
-		undo_redo->commit_action();
-		updating = false;
-
-		selected_nodes.clear();
-		selected_nodes.insert(group_name);
-		state_machine_draw->queue_redraw();
-		accept_event();
-		_update_mode();
-	}
-}
-
-void AnimationNodeStateMachineEditor::_ungroup_selected_nodes() {
-	bool find = false;
-	HashSet<StringName> new_selected_nodes;
-
-	for (const StringName &E : selected_nodes) {
-		Ref<AnimationNodeStateMachine> group_sm = state_machine->get_node(E);
-
-		if (group_sm.is_valid()) {
-			find = true;
-
-			Vector2 group_position = state_machine->get_node_position(E);
-			StringName group_name = E;
-
-			List<AnimationNode::ChildNode> nodes;
-			group_sm->get_child_nodes(&nodes);
-
-			Vector<NodeUR> nodes_ur;
-			Vector<TransitionUR> transitions_ur;
-
-			updating = true;
-			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-			undo_redo->create_action("Ungroup");
-
-			// Move all child nodes to current state machine
-			for (int i = 0; i < nodes.size(); i++) {
-				if (!group_sm->can_edit_node(nodes[i].name)) {
-					continue;
-				}
-
-				Vector2 node_position = group_sm->get_node_position(nodes[i].name);
-
-				NodeUR new_node;
-				new_node.name = nodes[i].name;
-				new_node.position = node_position;
-				new_node.node = nodes[i].node;
-
-				nodes_ur.push_back(new_node);
-			}
-
-			for (int i = 0; i < group_sm->get_transition_count(); i++) {
-				String from = group_sm->get_transition_from(i);
-				String to = group_sm->get_transition_to(i);
-				Ref<AnimationNodeStateMachineTransition> tr = group_sm->get_transition(i);
-
-				TransitionUR new_tr;
-				new_tr.new_from = from.replace_first("../", "");
-				new_tr.new_to = to.replace_first("../", "");
-				new_tr.old_from = from;
-				new_tr.old_to = to;
-				new_tr.transition = tr;
-
-				transitions_ur.push_back(new_tr);
-			}
-
-			for (int i = 0; i < nodes_ur.size(); i++) {
-				undo_redo->add_do_method(group_sm.ptr(), "remove_node", nodes_ur[i].name);
-				undo_redo->add_undo_method(state_machine.ptr(), "remove_node", nodes_ur[i].name);
-			}
-
-			undo_redo->add_do_method(state_machine.ptr(), "remove_node", group_name);
-			undo_redo->add_undo_method(state_machine.ptr(), "add_node", group_name, group_sm, group_position);
-
-			for (int i = 0; i < nodes_ur.size(); i++) {
-				new_selected_nodes.insert(nodes_ur[i].name);
-				undo_redo->add_do_method(state_machine.ptr(), "add_node", nodes_ur[i].name, nodes_ur[i].node, nodes_ur[i].position);
-				undo_redo->add_undo_method(group_sm.ptr(), "add_node", nodes_ur[i].name, nodes_ur[i].node, nodes_ur[i].position);
-			}
-
-			for (int i = 0; i < transitions_ur.size(); i++) {
-				if (transitions_ur[i].old_from != state_machine->start_node && transitions_ur[i].old_to != state_machine->end_node) {
-					undo_redo->add_do_method(state_machine.ptr(), "add_transition", transitions_ur[i].new_from, transitions_ur[i].new_to, transitions_ur[i].transition);
-				}
-
-				undo_redo->add_undo_method(group_sm.ptr(), "add_transition", transitions_ur[i].old_from, transitions_ur[i].old_to, transitions_ur[i].transition);
-			}
-
-			for (int i = 0; i < state_machine->get_transition_count(); i++) {
-				String from = state_machine->get_transition_from(i);
-				String to = state_machine->get_transition_to(i);
-				Ref<AnimationNodeStateMachineTransition> tr = state_machine->get_transition(i);
-
-				if (from == group_name || to == group_name) {
-					undo_redo->add_undo_method(state_machine.ptr(), "add_transition", from, to, tr);
-				}
-			}
-
-			undo_redo->add_do_method(this, "_update_graph");
-			undo_redo->add_undo_method(this, "_update_graph");
-			undo_redo->commit_action();
-			updating = false;
-		}
-	}
-
-	if (find) {
-		selected_nodes = new_selected_nodes;
-		selected_node = StringName();
-		state_machine_draw->queue_redraw();
-		accept_event();
-		_update_mode();
-	}
 }
 
 void AnimationNodeStateMachineEditor::_open_menu(const Vector2 &p_position) {
@@ -790,83 +582,8 @@ void AnimationNodeStateMachineEditor::_open_menu(const Vector2 &p_position) {
 	add_node_pos = p_position / EDSCALE + state_machine->get_graph_offset();
 }
 
-void AnimationNodeStateMachineEditor::_open_connect_menu(const Vector2 &p_position) {
-	ERR_FAIL_COND(connecting_to_node == StringName());
-
-	Ref<AnimationNode> node = state_machine->get_node(connecting_to_node);
-	Ref<AnimationNodeStateMachine> anodesm = node;
-	Ref<AnimationNodeEndState> end_node = node;
-	ERR_FAIL_COND(!anodesm.is_valid() && !end_node.is_valid());
-
-	connect_menu->clear();
-	state_machine_menu->clear();
-	end_menu->clear();
-	nodes_to_connect.clear();
-
-	for (int i = connect_menu->get_child_count() - 1; i >= 0; i--) {
-		Node *child = connect_menu->get_child(i);
-
-		if (child->is_class("PopupMenu")) {
-			connect_menu->remove_child(child);
-		}
-	}
-
-	connect_menu->reset_size();
-	state_machine_menu->reset_size();
-	end_menu->reset_size();
-
-	if (anodesm.is_valid()) {
-		_create_submenu(connect_menu, anodesm, connecting_to_node, connecting_to_node);
-	} else {
-		_create_submenu(connect_menu, state_machine, connecting_to_node, connecting_to_node, true);
-	}
-
-	connect_menu->add_submenu_item(TTR("To") + " Animation", connecting_to_node);
-
-	if (state_machine_menu->get_item_count() > 0 || !end_node.is_valid()) {
-		connect_menu->add_submenu_item(TTR("To") + " StateMachine", "state_machines");
-		connect_menu->add_child(state_machine_menu);
-	}
-
-	if (end_node.is_valid()) {
-		connect_menu->add_submenu_item(TTR("To") + " End", "end_nodes");
-		connect_menu->add_child(end_menu);
-	} else {
-		state_machine_menu->add_item(connecting_to_node, nodes_to_connect.size());
-	}
-
-	nodes_to_connect.push_back(connecting_to_node);
-
-	if (nodes_to_connect.size() == 1) {
-		_add_transition();
-		return;
-	}
-
-	connect_menu->set_position(state_machine_draw->get_screen_transform().xform(p_position));
-	connect_menu->popup();
-}
-
-bool AnimationNodeStateMachineEditor::_create_submenu(PopupMenu *p_menu, Ref<AnimationNodeStateMachine> p_nodesm, const StringName &p_name, const StringName &p_path, bool from_root, Vector<Ref<AnimationNodeStateMachine>> p_parents) {
+bool AnimationNodeStateMachineEditor::_create_submenu(PopupMenu *p_menu, Ref<AnimationNodeStateMachine> p_nodesm, const StringName &p_name, const StringName &p_path) {
 	String prev_path;
-	Vector<Ref<AnimationNodeStateMachine>> parents = p_parents;
-
-	if (from_root && p_nodesm->get_prev_state_machine() == nullptr) {
-		return false;
-	}
-
-	if (from_root) {
-		AnimationNodeStateMachine *prev = p_nodesm->get_prev_state_machine();
-
-		while (prev != nullptr) {
-			parents.push_back(prev);
-			p_nodesm = Ref<AnimationNodeStateMachine>(prev);
-			prev_path += "../";
-			prev = prev->get_prev_state_machine();
-		}
-		end_menu->add_item("Root", nodes_to_connect.size());
-		nodes_to_connect.push_back(prev_path + state_machine->end_node);
-		prev_path.remove_at(prev_path.size() - 1);
-	}
 
 	List<StringName> nodes;
 	p_nodesm->get_node_list(&nodes);
@@ -881,12 +598,7 @@ bool AnimationNodeStateMachineEditor::_create_submenu(PopupMenu *p_menu, Ref<Ani
 		if (p_nodesm->can_edit_node(E)) {
 			Ref<AnimationNodeStateMachine> ansm = p_nodesm->get_node(E);
 
-			String path;
-			if (from_root) {
-				path = prev_path + "/" + E;
-			} else {
-				path = String(p_path) + "/" + E;
-			}
+			String path = String(p_path) + "/" + E;
 
 			if (ansm == state_machine) {
 				end_menu->add_item(E, nodes_to_connect.size());
@@ -895,25 +607,10 @@ bool AnimationNodeStateMachineEditor::_create_submenu(PopupMenu *p_menu, Ref<Ani
 			}
 
 			if (ansm.is_valid()) {
-				bool parent_found = false;
+				state_machine_menu->add_item(E, nodes_to_connect.size());
+				nodes_to_connect.push_back(path);
 
-				for (int i = 0; i < parents.size(); i++) {
-					if (parents[i] == ansm) {
-						path = path.replace_first("/../" + E, "");
-						parent_found = true;
-						break;
-					}
-				}
-
-				if (parent_found) {
-					end_menu->add_item(E, nodes_to_connect.size());
-					nodes_to_connect.push_back(path + "/" + state_machine->end_node);
-				} else {
-					state_machine_menu->add_item(E, nodes_to_connect.size());
-					nodes_to_connect.push_back(path);
-				}
-
-				if (_create_submenu(nodes_menu, ansm, E, path, false, parents)) {
+				if (_create_submenu(nodes_menu, ansm, E, path)) {
 					nodes_menu->add_submenu_item(E, E);
 					node_added = true;
 				}
@@ -939,7 +636,6 @@ void AnimationNodeStateMachineEditor::_delete_selected() {
 	while (item) {
 		if (!updating) {
 			updating = true;
-			selected_multi_transition = TransitionLine();
 			undo_redo->create_action("Transition(s) Removed");
 		}
 
@@ -959,18 +655,10 @@ void AnimationNodeStateMachineEditor::_delete_selected() {
 }
 
 void AnimationNodeStateMachineEditor::_delete_all() {
-	Vector<TransitionLine> multi_transitions = selected_multi_transition.multi_transitions;
-	selected_multi_transition = TransitionLine();
-
 	updating = true;
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action("Transition(s) Removed");
 	_erase_selected(true);
-	for (int i = 0; i < multi_transitions.size(); i++) {
-		selected_transition_from = multi_transitions[i].from_node;
-		selected_transition_to = multi_transitions[i].to_node;
-		_erase_selected(true);
-	}
 	undo_redo->commit_action();
 	updating = false;
 
@@ -1120,14 +808,19 @@ void AnimationNodeStateMachineEditor::_add_transition(const bool p_nested_action
 		selected_transition_to = connecting_to_node;
 		selected_transition_index = transition_lines.size();
 
-		EditorNode::get_singleton()->push_item(tr.ptr(), "", true);
+		if (!state_machine->is_transition_across_group(selected_transition_index)) {
+			EditorNode::get_singleton()->push_item(tr.ptr(), "", true);
+		} else {
+			EditorNode::get_singleton()->push_item(tr.ptr(), "", true);
+			EditorNode::get_singleton()->push_item(nullptr, "", true);
+		}
 		_update_mode();
 	}
 
 	connecting = false;
 }
 
-void AnimationNodeStateMachineEditor::_connection_draw(const Vector2 &p_from, const Vector2 &p_to, AnimationNodeStateMachineTransition::SwitchMode p_mode, bool p_enabled, bool p_selected, bool p_travel, float p_fade_ratio, bool p_auto_advance, bool p_multi_transitions) {
+void AnimationNodeStateMachineEditor::_connection_draw(const Vector2 &p_from, const Vector2 &p_to, AnimationNodeStateMachineTransition::SwitchMode p_mode, bool p_enabled, bool p_selected, bool p_travel, float p_fade_ratio, bool p_auto_advance, bool p_is_across_group) {
 	Color linecolor = get_theme_color(SNAME("font_color"), SNAME("Label"));
 	Color icon_color(1, 1, 1);
 	Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
@@ -1173,11 +866,7 @@ void AnimationNodeStateMachineEditor::_connection_draw(const Vector2 &p_from, co
 	xf.columns[2] = (p_from + p_to) * 0.5 - xf.columns[1] * icon->get_height() * 0.5 - xf.columns[0] * icon->get_height() * 0.5;
 
 	state_machine_draw->draw_set_transform_matrix(xf);
-	if (p_multi_transitions) {
-		state_machine_draw->draw_texture(icons[0], Vector2(-icon->get_width(), 0), icon_color);
-		state_machine_draw->draw_texture(icons[0], Vector2(), icon_color);
-		state_machine_draw->draw_texture(icons[0], Vector2(icon->get_width(), 0), icon_color);
-	} else {
+	if (!p_is_across_group) {
 		state_machine_draw->draw_texture(icon, Vector2(), icon_color);
 	}
 	state_machine_draw->draw_set_transform_matrix(Transform2D());
@@ -1344,17 +1033,14 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 	for (int i = 0; i < state_machine->get_transition_count(); i++) {
 		TransitionLine tl;
 		tl.transition_index = i;
+
 		tl.from_node = state_machine->get_transition_from(i);
-		StringName local_from = String(tl.from_node).get_slicec('/', 0);
-		local_from = local_from == ".." ? state_machine->start_node : local_from;
-		Vector2 ofs_from = (dragging_selected && selected_nodes.has(local_from)) ? drag_ofs : Vector2();
-		tl.from = (state_machine->get_node_position(local_from) * EDSCALE) + ofs_from - state_machine->get_graph_offset() * EDSCALE;
+		Vector2 ofs_from = (dragging_selected && selected_nodes.has(tl.from_node)) ? drag_ofs : Vector2();
+		tl.from = (state_machine->get_node_position(tl.from_node) * EDSCALE) + ofs_from - state_machine->get_graph_offset() * EDSCALE;
 
 		tl.to_node = state_machine->get_transition_to(i);
-		StringName local_to = String(tl.to_node).get_slicec('/', 0);
-		local_to = local_to == ".." ? state_machine->end_node : local_to;
-		Vector2 ofs_to = (dragging_selected && selected_nodes.has(local_to)) ? drag_ofs : Vector2();
-		tl.to = (state_machine->get_node_position(local_to) * EDSCALE) + ofs_to - state_machine->get_graph_offset() * EDSCALE;
+		Vector2 ofs_to = (dragging_selected && selected_nodes.has(tl.to_node)) ? drag_ofs : Vector2();
+		tl.to = (state_machine->get_node_position(tl.to_node) * EDSCALE) + ofs_to - state_machine->get_graph_offset() * EDSCALE;
 
 		Ref<AnimationNodeStateMachineTransition> tr = state_machine->get_transition(i);
 		tl.disabled = bool(tr->get_advance_mode() == AnimationNodeStateMachineTransition::ADVANCE_MODE_DISABLED);
@@ -1366,35 +1052,36 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 		tl.travel = false;
 		tl.fade_ratio = 0.0;
 		tl.hidden = false;
+		tl.is_across_group = state_machine->is_transition_across_group(i);
 
-		if (state_machine->has_local_transition(local_to, local_from)) { //offset if same exists
+		if (state_machine->has_transition(tl.to_node, tl.from_node)) { //offset if same exists
 			Vector2 offset = -(tl.from - tl.to).normalized().orthogonal() * tr_bidi_offset;
 			tl.from += offset;
 			tl.to += offset;
 		}
 
 		for (int j = 0; j < node_rects.size(); j++) {
-			if (node_rects[j].node_name == local_from) {
+			if (node_rects[j].node_name == tl.from_node) {
 				_clip_src_line_to_rect(tl.from, tl.to, node_rects[j].node);
 			}
-			if (node_rects[j].node_name == local_to) {
+			if (node_rects[j].node_name == tl.to_node) {
 				_clip_dst_line_to_rect(tl.from, tl.to, node_rects[j].node);
 			}
 		}
 
 		tl.selected = selected_transition_from == tl.from_node && selected_transition_to == tl.to_node;
 
-		if (blend_from == local_from && current == local_to) {
+		if (blend_from == tl.from_node && current == tl.to_node) {
 			tl.travel = true;
 			tl.fade_ratio = MIN(1.0, fading_pos / fading_time);
 		}
 
 		if (travel_path.size()) {
-			if (current == local_from && travel_path[0] == local_to) {
+			if (current == tl.from_node && travel_path[0] == tl.to_node) {
 				tl.travel = true;
 			} else {
 				for (int j = 0; j < travel_path.size() - 1; j++) {
-					if (travel_path[j] == local_from && travel_path[j + 1] == local_to) {
+					if (travel_path[j] == tl.from_node && travel_path[j + 1] == tl.to_node) {
 						tl.travel = true;
 						break;
 					}
@@ -1408,17 +1095,11 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 			tl.auto_advance = true;
 		}
 
-		// check if already have this local transition
+		// check if already have this transition
 		for (int j = 0; j < transition_lines.size(); j++) {
-			StringName from = String(transition_lines[j].from_node).get_slicec('/', 0);
-			StringName to = String(transition_lines[j].to_node).get_slicec('/', 0);
-			from = from == ".." ? state_machine->start_node : from;
-			to = to == ".." ? state_machine->end_node : to;
-
-			if (from == local_from && to == local_to) {
+			if (transition_lines[j].from_node == tl.from_node && transition_lines[j].to_node == tl.to_node) {
 				tl.hidden = true;
 				transition_lines.write[j].disabled = transition_lines[j].disabled && tl.disabled;
-				transition_lines.write[j].multi_transitions.push_back(tl);
 			}
 		}
 		transition_lines.push_back(tl);
@@ -1427,7 +1108,7 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 	for (int i = 0; i < transition_lines.size(); i++) {
 		TransitionLine tl = transition_lines[i];
 		if (!tl.hidden) {
-			_connection_draw(tl.from, tl.to, tl.mode, !tl.disabled, tl.selected, tl.travel, tl.fade_ratio, tl.auto_advance, !tl.multi_transitions.is_empty());
+			_connection_draw(tl.from, tl.to, tl.mode, !tl.disabled, tl.selected, tl.travel, tl.fade_ratio, tl.auto_advance, tl.is_across_group);
 		}
 	}
 
@@ -1481,6 +1162,7 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 		state_machine_draw->draw_string(font, nr.name.position + Vector2(0, font->get_ascent(font_size)), name, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, font_color);
 		offset.x += strsize + sep;
 
+		nr.can_edit = needs_editor;
 		if (needs_editor) {
 			nr.edit.position = offset + Vector2(0, (h - edit->get_height()) / 2).floor();
 			nr.edit.size = edit->get_size();
@@ -1546,6 +1228,10 @@ void AnimationNodeStateMachineEditor::_state_machine_pos_draw_individual(String 
 
 	const NodeRect &nr = node_rects[idx];
 
+	if (nr.can_edit) {
+		return; // It is not AnimationNodeAnimation.
+	}
+
 	Vector2 from;
 	from.x = nr.play.position.x;
 	from.y = (nr.play.position.y + nr.play.size.y + nr.node.position.y + nr.node.size.y) * 0.5;
@@ -1584,14 +1270,14 @@ void AnimationNodeStateMachineEditor::_state_machine_pos_draw_all() {
 	{
 		float len = MAX(0.0001, current_length);
 		float pos = CLAMP(current_play_pos, 0, len);
-		float c = pos / len;
+		float c = current_length == HUGE_LENGTH ? 1 : (pos / len);
 		_state_machine_pos_draw_individual(playback->get_current_node(), c);
 	}
 
 	{
 		float len = MAX(0.0001, fade_from_length);
 		float pos = CLAMP(fade_from_current_play_pos, 0, len);
-		float c = pos / len;
+		float c = fade_from_length == HUGE_LENGTH ? 1 : (pos / len);
 		_state_machine_pos_draw_individual(playback->get_fading_from_node(), c);
 	}
 }
@@ -1630,8 +1316,6 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 			auto_advance->set_icon(get_theme_icon(SNAME("AutoPlay"), SNAME("EditorIcons")));
 
 			tool_erase->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
-			tool_group->set_icon(get_theme_icon(SNAME("Group"), SNAME("EditorIcons")));
-			tool_ungroup->set_icon(get_theme_icon(SNAME("Ungroup"), SNAME("EditorIcons")));
 
 			play_mode->clear();
 			play_mode->add_icon_item(get_theme_icon(SNAME("PlayTravel"), SNAME("EditorIcons")), TTR("Travel"));
@@ -1655,10 +1339,6 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 				error = TTR("AnimationTree is inactive.\nActivate to enable playback, check node warnings if activation fails.");
 			} else if (tree->is_state_invalid()) {
 				error = tree->get_invalid_state_reason();
-				/*} else if (state_machine->get_parent().is_valid() && state_machine->get_parent()->is_class("AnimationNodeStateMachine")) {
-				if (state_machine->get_start_node() == StringName() || state_machine->get_end_node() == StringName()) {
-					error = TTR("Start and end nodes are needed for a sub-transition.");
-				}*/
 			} else if (playback.is_null()) {
 				error = vformat(TTR("No playback resource set at path: %s."), AnimationTreeEditor::get_singleton()->get_base_path() + "playback");
 			}
@@ -1780,8 +1460,12 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 
 					while (anodesm.is_valid()) {
 						current_node_playback = tree->get(AnimationTreeEditor::get_singleton()->get_base_path() + next + "/playback");
-						next += "/" + current_node_playback->get_current_node();
-						anodesm = anodesm->get_node(current_node_playback->get_current_node());
+						StringName cnode = current_node_playback->get_current_node();
+						next += "/" + cnode;
+						if (!anodesm->has_node(cnode)) {
+							break;
+						}
+						anodesm = anodesm->get_node(cnode);
 					}
 
 					// when current_node is a state machine, use playback of current_node to set play_pos
@@ -1883,10 +1567,7 @@ void AnimationNodeStateMachineEditor::_erase_selected(const bool p_nested_action
 			for (int j = 0; j < state_machine->get_transition_count(); j++) {
 				String from = state_machine->get_transition_from(j);
 				String to = state_machine->get_transition_to(j);
-				String local_from = from.get_slicec('/', 0);
-				String local_to = to.get_slicec('/', 0);
-
-				if (local_from == node_rects[i].node_name || local_to == node_rects[i].node_name) {
+				if (from == node_rects[i].node_name || to == node_rects[i].node_name) {
 					undo_redo->add_undo_method(state_machine.ptr(), "add_transition", from, to, state_machine->get_transition(j));
 				}
 			}
@@ -1901,30 +1582,6 @@ void AnimationNodeStateMachineEditor::_erase_selected(const bool p_nested_action
 		}
 
 		selected_nodes.clear();
-	}
-
-	if (!selected_multi_transition.multi_transitions.is_empty()) {
-		delete_tree->clear();
-
-		TreeItem *root = delete_tree->create_item();
-
-		TreeItem *item = delete_tree->create_item(root);
-		item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
-		item->set_text(0, String(selected_transition_from) + " -> " + selected_transition_to);
-		item->set_editable(0, true);
-
-		for (int i = 0; i < selected_multi_transition.multi_transitions.size(); i++) {
-			String from = selected_multi_transition.multi_transitions[i].from_node;
-			String to = selected_multi_transition.multi_transitions[i].to_node;
-
-			item = delete_tree->create_item(root);
-			item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
-			item->set_text(0, from + " -> " + to);
-			item->set_editable(0, true);
-		}
-
-		delete_window->popup_centered(Vector2(400, 200));
-		return;
 	}
 
 	if (selected_transition_to != StringName() && selected_transition_from != StringName() && state_machine->has_transition(selected_transition_from, selected_transition_to)) {
@@ -1945,7 +1602,6 @@ void AnimationNodeStateMachineEditor::_erase_selected(const bool p_nested_action
 		selected_transition_from = StringName();
 		selected_transition_to = StringName();
 		selected_transition_index = -1;
-		selected_multi_transition = TransitionLine();
 	}
 
 	state_machine_draw->queue_redraw();
@@ -1957,24 +1613,6 @@ void AnimationNodeStateMachineEditor::_update_mode() {
 		bool nothing_selected = selected_nodes.is_empty() && selected_transition_from == StringName() && selected_transition_to == StringName();
 		bool start_end_selected = selected_nodes.size() == 1 && (*selected_nodes.begin() == state_machine->start_node || *selected_nodes.begin() == state_machine->end_node);
 		tool_erase->set_disabled(nothing_selected || start_end_selected || read_only);
-
-		if (selected_nodes.is_empty() || start_end_selected || read_only) {
-			tool_group->set_disabled(true);
-			tool_group->set_visible(true);
-			tool_ungroup->set_visible(false);
-		} else {
-			Ref<AnimationNodeStateMachine> ansm = state_machine->get_node(*selected_nodes.begin());
-
-			if (selected_nodes.size() == 1 && ansm.is_valid()) {
-				tool_group->set_disabled(true);
-				tool_group->set_visible(false);
-				tool_ungroup->set_visible(true);
-			} else {
-				tool_group->set_disabled(false);
-				tool_group->set_visible(true);
-				tool_ungroup->set_visible(false);
-			}
-		}
 	} else {
 		selection_tools_hb->hide();
 	}
@@ -2036,20 +1674,6 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	selection_tools_hb = memnew(HBoxContainer);
 	top_hb->add_child(selection_tools_hb);
 	selection_tools_hb->add_child(memnew(VSeparator));
-
-	tool_group = memnew(Button);
-	tool_group->set_flat(true);
-	tool_group->set_tooltip_text(TTR("Group Selected Node(s)") + " (Ctrl+G)");
-	tool_group->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_group_selected_nodes));
-	tool_group->set_disabled(true);
-	selection_tools_hb->add_child(tool_group);
-
-	tool_ungroup = memnew(Button);
-	tool_ungroup->set_flat(true);
-	tool_ungroup->set_tooltip_text(TTR("Ungroup Selected Node") + " (Ctrl+Shift+G)");
-	tool_ungroup->connect("pressed", callable_mp(this, &AnimationNodeStateMachineEditor::_ungroup_selected_nodes));
-	tool_ungroup->set_visible(false);
-	selection_tools_hb->add_child(tool_ungroup);
 
 	tool_erase = memnew(Button);
 	tool_erase->set_flat(true);

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -56,8 +56,6 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	LineEdit *name_edit = nullptr;
 
 	HBoxContainer *selection_tools_hb = nullptr;
-	Button *tool_group = nullptr;
-	Button *tool_ungroup = nullptr;
 	Button *tool_erase = nullptr;
 
 	HBoxContainer *transition_tools_hb = nullptr;
@@ -85,7 +83,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	static AnimationNodeStateMachineEditor *singleton;
 
 	void _state_machine_gui_input(const Ref<InputEvent> &p_event);
-	void _connection_draw(const Vector2 &p_from, const Vector2 &p_to, AnimationNodeStateMachineTransition::SwitchMode p_mode, bool p_enabled, bool p_selected, bool p_travel, float p_fade_ratio, bool p_auto_advance, bool p_multi_transitions);
+	void _connection_draw(const Vector2 &p_from, const Vector2 &p_to, AnimationNodeStateMachineTransition::SwitchMode p_mode, bool p_enabled, bool p_selected, bool p_travel, float p_fade_ratio, bool p_auto_advance, bool p_is_across_group);
 
 	void _state_machine_draw();
 
@@ -136,6 +134,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 		Rect2 play;
 		Rect2 name;
 		Rect2 edit;
+		bool can_edit;
 	};
 
 	Vector<NodeRect> node_rects;
@@ -156,7 +155,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 		float fade_ratio;
 		bool hidden;
 		int transition_index;
-		Vector<TransitionLine> multi_transitions;
+		bool is_across_group = false;
 	};
 
 	Vector<TransitionLine> transition_lines;
@@ -178,7 +177,6 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	StringName selected_transition_from;
 	StringName selected_transition_to;
 	int selected_transition_index;
-	TransitionLine selected_multi_transition;
 	void _add_transition(const bool p_nested_action = false);
 
 	StringName over_node;
@@ -190,18 +188,16 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	void _open_editor(const String &p_name);
 	void _scroll_changed(double);
 
+	String _get_root_playback_path(String &r_node_directory);
+
 	void _clip_src_line_to_rect(Vector2 &r_from, const Vector2 &p_to, const Rect2 &p_rect);
 	void _clip_dst_line_to_rect(const Vector2 &p_from, Vector2 &r_to, const Rect2 &p_rect);
 
 	void _erase_selected(const bool p_nested_action = false);
 	void _update_mode();
 	void _open_menu(const Vector2 &p_position);
-	void _open_connect_menu(const Vector2 &p_position);
-	bool _create_submenu(PopupMenu *p_menu, Ref<AnimationNodeStateMachine> p_nodesm, const StringName &p_name, const StringName &p_path, bool from_root = false, Vector<Ref<AnimationNodeStateMachine>> p_parents = Vector<Ref<AnimationNodeStateMachine>>());
+	bool _create_submenu(PopupMenu *p_menu, Ref<AnimationNodeStateMachine> p_nodesm, const StringName &p_name, const StringName &p_path);
 	void _stop_connecting();
-
-	void _group_selected_nodes();
-	void _ungroup_selected_nodes();
 
 	void _delete_selected();
 	void _delete_all();

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -66,11 +66,6 @@ void AnimationTreeEditor::edit(AnimationTree *p_tree) {
 
 	Vector<String> path;
 	if (tree) {
-		if (tree->has_meta("_tree_edit_path")) {
-			path = tree->get_meta("_tree_edit_path");
-		} else {
-			current_root = ObjectID();
-		}
 		edit_path(path);
 	}
 }

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -46,7 +46,7 @@ Variant AnimationNodeBlendSpace1D::get_parameter_default_value(const StringName 
 	}
 }
 
-Ref<AnimationNode> AnimationNodeBlendSpace1D::get_child_by_name(const StringName &p_name) {
+Ref<AnimationNode> AnimationNodeBlendSpace1D::get_child_by_name(const StringName &p_name) const {
 	return get_blend_point_node(p_name.operator String().to_int());
 }
 
@@ -272,14 +272,14 @@ void AnimationNodeBlendSpace1D::_add_blend_point(int p_index, const Ref<Animatio
 	}
 }
 
-double AnimationNodeBlendSpace1D::process(double p_time, bool p_seek, bool p_is_external_seeking) {
+double AnimationNodeBlendSpace1D::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
 	if (blend_points_used == 0) {
 		return 0.0;
 	}
 
 	if (blend_points_used == 1) {
 		// only one point available, just play that animation
-		return blend_node(blend_points[0].name, blend_points[0].node, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true);
+		return blend_node(blend_points[0].name, blend_points[0].node, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
 	}
 
 	double blend_pos = get_parameter(blend_position);
@@ -351,10 +351,10 @@ double AnimationNodeBlendSpace1D::process(double p_time, bool p_seek, bool p_is_
 
 		for (int i = 0; i < blend_points_used; i++) {
 			if (i == point_lower || i == point_higher) {
-				double remaining = blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, weights[i], FILTER_IGNORE, true);
+				double remaining = blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, weights[i], FILTER_IGNORE, true, p_test_only);
 				max_time_remaining = MAX(max_time_remaining, remaining);
 			} else if (sync) {
-				blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, 0, FILTER_IGNORE, true);
+				blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, 0, FILTER_IGNORE, true, p_test_only);
 			}
 		}
 	} else {
@@ -379,22 +379,22 @@ double AnimationNodeBlendSpace1D::process(double p_time, bool p_seek, bool p_is_
 					na_n->set_backward(na_c->is_backward());
 				}
 				//see how much animation remains
-				from = cur_length_internal - blend_node(blend_points[cur_closest].name, blend_points[cur_closest].node, p_time, false, p_is_external_seeking, 0.0, FILTER_IGNORE, true);
+				from = cur_length_internal - blend_node(blend_points[cur_closest].name, blend_points[cur_closest].node, p_time, false, p_is_external_seeking, 0.0, FILTER_IGNORE, true, p_test_only);
 			}
 
-			max_time_remaining = blend_node(blend_points[new_closest].name, blend_points[new_closest].node, from, true, p_is_external_seeking, 1.0, FILTER_IGNORE, true);
+			max_time_remaining = blend_node(blend_points[new_closest].name, blend_points[new_closest].node, from, true, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
 			cur_length_internal = from + max_time_remaining;
 
 			cur_closest = new_closest;
 
 		} else {
-			max_time_remaining = blend_node(blend_points[cur_closest].name, blend_points[cur_closest].node, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true);
+			max_time_remaining = blend_node(blend_points[cur_closest].name, blend_points[cur_closest].node, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
 		}
 
 		if (sync) {
 			for (int i = 0; i < blend_points_used; i++) {
 				if (i != cur_closest) {
-					blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, 0, FILTER_IGNORE, true);
+					blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, 0, FILTER_IGNORE, true, p_test_only);
 				}
 			}
 		}

--- a/scene/animation/animation_blend_space_1d.h
+++ b/scene/animation/animation_blend_space_1d.h
@@ -114,10 +114,10 @@ public:
 	void set_use_sync(bool p_sync);
 	bool is_using_sync() const;
 
-	double process(double p_time, bool p_seek, bool p_is_external_seeking) override;
+	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 	String get_caption() const override;
 
-	Ref<AnimationNode> get_child_by_name(const StringName &p_name) override;
+	Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;
 
 	AnimationNodeBlendSpace1D();
 	~AnimationNodeBlendSpace1D();

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -442,7 +442,7 @@ void AnimationNodeBlendSpace2D::_blend_triangle(const Vector2 &p_pos, const Vect
 	r_weights[2] = w;
 }
 
-double AnimationNodeBlendSpace2D::process(double p_time, bool p_seek, bool p_is_external_seeking) {
+double AnimationNodeBlendSpace2D::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
 	_update_triangles();
 
 	Vector2 blend_pos = get_parameter(blend_position);
@@ -512,7 +512,7 @@ double AnimationNodeBlendSpace2D::process(double p_time, bool p_seek, bool p_is_
 			for (int j = 0; j < 3; j++) {
 				if (i == triangle_points[j]) {
 					//blend with the given weight
-					double t = blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, blend_weights[j], FILTER_IGNORE, true);
+					double t = blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, blend_weights[j], FILTER_IGNORE, true, p_test_only);
 					if (first || t < mind) {
 						mind = t;
 						first = false;
@@ -523,7 +523,7 @@ double AnimationNodeBlendSpace2D::process(double p_time, bool p_seek, bool p_is_
 			}
 
 			if (sync && !found) {
-				blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, 0, FILTER_IGNORE, true);
+				blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, 0, FILTER_IGNORE, true, p_test_only);
 			}
 		}
 	} else {
@@ -548,22 +548,22 @@ double AnimationNodeBlendSpace2D::process(double p_time, bool p_seek, bool p_is_
 					na_n->set_backward(na_c->is_backward());
 				}
 				//see how much animation remains
-				from = cur_length_internal - blend_node(blend_points[cur_closest].name, blend_points[cur_closest].node, p_time, false, p_is_external_seeking, 0.0, FILTER_IGNORE, true);
+				from = cur_length_internal - blend_node(blend_points[cur_closest].name, blend_points[cur_closest].node, p_time, false, p_is_external_seeking, 0.0, FILTER_IGNORE, true, p_test_only);
 			}
 
-			mind = blend_node(blend_points[new_closest].name, blend_points[new_closest].node, from, true, p_is_external_seeking, 1.0, FILTER_IGNORE, true);
+			mind = blend_node(blend_points[new_closest].name, blend_points[new_closest].node, from, true, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
 			cur_length_internal = from + mind;
 
 			cur_closest = new_closest;
 
 		} else {
-			mind = blend_node(blend_points[cur_closest].name, blend_points[cur_closest].node, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true);
+			mind = blend_node(blend_points[cur_closest].name, blend_points[cur_closest].node, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
 		}
 
 		if (sync) {
 			for (int i = 0; i < blend_points_used; i++) {
 				if (i != cur_closest) {
-					blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, 0, FILTER_IGNORE, true);
+					blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, 0, FILTER_IGNORE, true, p_test_only);
 				}
 			}
 		}
@@ -604,7 +604,7 @@ bool AnimationNodeBlendSpace2D::get_auto_triangles() const {
 	return auto_triangles;
 }
 
-Ref<AnimationNode> AnimationNodeBlendSpace2D::get_child_by_name(const StringName &p_name) {
+Ref<AnimationNode> AnimationNodeBlendSpace2D::get_child_by_name(const StringName &p_name) const {
 	return get_blend_point_node(p_name.operator String().to_int());
 }
 

--- a/scene/animation/animation_blend_space_2d.h
+++ b/scene/animation/animation_blend_space_2d.h
@@ -129,7 +129,7 @@ public:
 	void set_y_label(const String &p_label);
 	String get_y_label() const;
 
-	virtual double process(double p_time, bool p_seek, bool p_is_external_seeking) override;
+	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 	virtual String get_caption() const override;
 
 	Vector2 get_closest_point(const Vector2 &p_point);
@@ -143,7 +143,7 @@ public:
 	void set_use_sync(bool p_sync);
 	bool is_using_sync() const;
 
-	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) override;
+	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;
 
 	AnimationNodeBlendSpace2D();
 	~AnimationNodeBlendSpace2D();

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -53,7 +53,7 @@ public:
 	static Vector<String> (*get_editable_animation_list)();
 
 	virtual String get_caption() const override;
-	virtual double process(double p_time, bool p_seek, bool p_is_external_seeking) override;
+	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	void set_animation(const StringName &p_name);
 	StringName get_animation() const;
@@ -150,7 +150,7 @@ public:
 	MixMode get_mix_mode() const;
 
 	virtual bool has_filter() const override;
-	virtual double process(double p_time, bool p_seek, bool p_is_external_seeking) override;
+	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	AnimationNodeOneShot();
 };
@@ -173,7 +173,7 @@ public:
 	virtual String get_caption() const override;
 
 	virtual bool has_filter() const override;
-	virtual double process(double p_time, bool p_seek, bool p_is_external_seeking) override;
+	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	AnimationNodeAdd2();
 };
@@ -193,7 +193,7 @@ public:
 	virtual String get_caption() const override;
 
 	virtual bool has_filter() const override;
-	virtual double process(double p_time, bool p_seek, bool p_is_external_seeking) override;
+	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	AnimationNodeAdd3();
 };
@@ -211,7 +211,7 @@ public:
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
-	virtual double process(double p_time, bool p_seek, bool p_is_external_seeking) override;
+	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	virtual bool has_filter() const override;
 	AnimationNodeBlend2();
@@ -231,7 +231,7 @@ public:
 
 	virtual String get_caption() const override;
 
-	double process(double p_time, bool p_seek, bool p_is_external_seeking) override;
+	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 	AnimationNodeBlend3();
 };
 
@@ -249,7 +249,7 @@ public:
 
 	virtual String get_caption() const override;
 
-	double process(double p_time, bool p_seek, bool p_is_external_seeking) override;
+	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	AnimationNodeTimeScale();
 };
@@ -268,7 +268,7 @@ public:
 
 	virtual String get_caption() const override;
 
-	double process(double p_time, bool p_seek, bool p_is_external_seeking) override;
+	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	AnimationNodeTimeSeek();
 };
@@ -332,7 +332,7 @@ public:
 	void set_allow_transition_to_self(bool p_enable);
 	bool is_allow_transition_to_self() const;
 
-	double process(double p_time, bool p_seek, bool p_is_external_seeking) override;
+	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	AnimationNodeTransition();
 };
@@ -342,7 +342,7 @@ class AnimationNodeOutput : public AnimationNode {
 
 public:
 	virtual String get_caption() const override;
-	virtual double process(double p_time, bool p_seek, bool p_is_external_seeking) override;
+	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 	AnimationNodeOutput();
 };
 
@@ -414,14 +414,14 @@ public:
 	void get_node_connections(List<NodeConnection> *r_connections) const;
 
 	virtual String get_caption() const override;
-	virtual double process(double p_time, bool p_seek, bool p_is_external_seeking) override;
+	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	void get_node_list(List<StringName> *r_list);
 
 	void set_graph_offset(const Vector2 &p_graph_offset);
 	Vector2 get_graph_offset() const;
 
-	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) override;
+	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;
 
 	AnimationNodeBlendTree();
 	~AnimationNodeBlendTree();

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -179,33 +179,118 @@ AnimationNodeStateMachineTransition::AnimationNodeStateMachineTransition() {
 
 ////////////////////////////////////////////////////////
 
+void AnimationNodeStateMachinePlayback::_set_current(AnimationNodeStateMachine *p_state_machine, const StringName &p_state) {
+	current = p_state;
+	if (current == StringName()) {
+		group_start_transition = Ref<AnimationNodeStateMachineTransition>();
+		group_end_transition = Ref<AnimationNodeStateMachineTransition>();
+		return;
+	}
+
+	Ref<AnimationNodeStateMachine> anodesm = p_state_machine->find_node_by_path(current);
+	if (!anodesm.is_valid()) {
+		group_start_transition = Ref<AnimationNodeStateMachineTransition>();
+		group_end_transition = Ref<AnimationNodeStateMachineTransition>();
+		return;
+	}
+
+	Vector<int> indices = p_state_machine->find_transition_to(current);
+	int group_start_size = indices.size();
+	if (group_start_size) {
+		group_start_transition = p_state_machine->get_transition(indices[0]);
+	} else {
+		group_start_transition = Ref<AnimationNodeStateMachineTransition>();
+	}
+
+	indices = p_state_machine->find_transition_from(current);
+	int group_end_size = indices.size();
+	if (group_end_size) {
+		group_end_transition = p_state_machine->get_transition(indices[0]);
+	} else {
+		group_end_transition = Ref<AnimationNodeStateMachineTransition>();
+	}
+
+	// Validation.
+	if (anodesm->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
+		indices = anodesm->find_transition_from(anodesm->start_node);
+		int anodesm_start_size = indices.size();
+		indices = anodesm->find_transition_to(anodesm->end_node);
+		int anodesm_end_size = indices.size();
+		if (group_start_size > 1) {
+			WARN_PRINT_ED("There are two or more transitions to the Grouped AnimationNodeStateMachine in AnimationNodeStateMachine: " + base_path + ", which may result in unintended transitions.");
+		}
+		if (group_end_size > 1) {
+			WARN_PRINT_ED("There are two or more transitions from the Grouped AnimationNodeStateMachine in AnimationNodeStateMachine: " + base_path + ", which may result in unintended transitions.");
+		}
+		if (anodesm_start_size > 1) {
+			WARN_PRINT_ED("There are two or more transitions from the Start of Grouped AnimationNodeStateMachine in AnimationNodeStateMachine: " + base_path + current + ", which may result in unintended transitions.");
+		}
+		if (anodesm_end_size > 1) {
+			WARN_PRINT_ED("There are two or more transitions to the End of Grouped AnimationNodeStateMachine in AnimationNodeStateMachine: " + base_path + current + ", which may result in unintended transitions.");
+		}
+		if (anodesm_start_size != group_start_size) {
+			ERR_PRINT_ED("There is a mismatch in the number of start transitions in and out of the Grouped AnimationNodeStateMachine on AnimationNodeStateMachine: " + base_path + current + ".");
+		}
+		if (anodesm_end_size != group_end_size) {
+			ERR_PRINT_ED("There is a mismatch in the number of end transitions in and out of the Grouped AnimationNodeStateMachine on AnimationNodeStateMachine: " + base_path + current + ".");
+		}
+	}
+}
+
+void AnimationNodeStateMachinePlayback::_set_grouped(bool p_is_grouped) {
+	is_grouped = p_is_grouped;
+}
+
 void AnimationNodeStateMachinePlayback::travel(const StringName &p_state, bool p_reset_on_teleport) {
+	ERR_FAIL_COND_EDMSG(is_grouped, "Grouped AnimationNodeStateMachinePlayback must be handled by parent AnimationNodeStateMachinePlayback. You need to retrieve the parent Root/Nested AnimationNodeStateMachine.");
+	ERR_FAIL_COND_EDMSG(String(p_state).contains("/Start") || String(p_state).contains("/End"), "Grouped AnimationNodeStateMachinePlayback doesn't allow to play Start/End directly. Instead, play the prev or next state of group in the parent AnimationNodeStateMachine.");
+	_travel_main(p_state, p_reset_on_teleport);
+}
+
+void AnimationNodeStateMachinePlayback::start(const StringName &p_state, bool p_reset) {
+	ERR_FAIL_COND_EDMSG(is_grouped, "Grouped AnimationNodeStateMachinePlayback must be handled by parent AnimationNodeStateMachinePlayback. You need to retrieve the parent Root/Nested AnimationNodeStateMachine.");
+	ERR_FAIL_COND_EDMSG(String(p_state).contains("/Start") || String(p_state).contains("/End"), "Grouped AnimationNodeStateMachinePlayback doesn't allow to play Start/End directly. Instead, play the prev or next state of group in the parent AnimationNodeStateMachine.");
+	_start_main(p_state, p_reset);
+}
+
+void AnimationNodeStateMachinePlayback::next() {
+	ERR_FAIL_COND_EDMSG(is_grouped, "Grouped AnimationNodeStateMachinePlayback must be handled by parent AnimationNodeStateMachinePlayback. You need to retrieve the parent Root/Nested AnimationNodeStateMachine.");
+	_next_main();
+}
+
+void AnimationNodeStateMachinePlayback::stop() {
+	ERR_FAIL_COND_EDMSG(is_grouped, "Grouped AnimationNodeStateMachinePlayback must be handled by parent AnimationNodeStateMachinePlayback. You need to retrieve the parent Root/Nested AnimationNodeStateMachine.");
+	_stop_main();
+}
+
+void AnimationNodeStateMachinePlayback::_travel_main(const StringName &p_state, bool p_reset_on_teleport) {
 	travel_request = p_state;
 	reset_request_on_teleport = p_reset_on_teleport;
 	stop_request = false;
 }
 
-void AnimationNodeStateMachinePlayback::start(const StringName &p_state, bool p_reset) {
+void AnimationNodeStateMachinePlayback::_start_main(const StringName &p_state, bool p_reset) {
 	travel_request = StringName();
+	path.clear();
 	reset_request = p_reset;
-	_start(p_state);
-}
-
-void AnimationNodeStateMachinePlayback::_start(const StringName &p_state) {
 	start_request = p_state;
 	stop_request = false;
 }
 
-void AnimationNodeStateMachinePlayback::next() {
+void AnimationNodeStateMachinePlayback::_next_main() {
 	next_request = true;
 }
 
-void AnimationNodeStateMachinePlayback::stop() {
+void AnimationNodeStateMachinePlayback::_stop_main() {
 	stop_request = true;
 }
 
 bool AnimationNodeStateMachinePlayback::is_playing() const {
 	return playing;
+}
+
+bool AnimationNodeStateMachinePlayback::is_end() const {
+	return current == "End" && fading_from == StringName();
 }
 
 StringName AnimationNodeStateMachinePlayback::get_current_node() const {
@@ -244,60 +329,234 @@ float AnimationNodeStateMachinePlayback::get_fading_pos() const {
 	return fading_pos;
 }
 
-bool AnimationNodeStateMachinePlayback::_travel(AnimationNodeStateMachine *p_state_machine, const StringName &p_travel) {
-	ERR_FAIL_COND_V(!playing, false);
-	ERR_FAIL_COND_V(!p_state_machine->states.has(p_travel), false);
-	ERR_FAIL_COND_V(!p_state_machine->states.has(current), false);
+void AnimationNodeStateMachinePlayback::_clear_path_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_test_only) {
+	List<AnimationNode::ChildNode> child_nodes;
+	p_state_machine->get_child_nodes(&child_nodes);
+	for (int i = 0; i < child_nodes.size(); i++) {
+		Ref<AnimationNodeStateMachine> anodesm = child_nodes[i].node;
+		if (anodesm.is_valid() && anodesm->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
+			Ref<AnimationNodeStateMachinePlayback> playback = p_tree->get(base_path + child_nodes[i].name + "/playback");
+			ERR_FAIL_COND(!playback.is_valid());
+			playback->_set_base_path(base_path + child_nodes[i].name + "/");
+			if (p_test_only) {
+				playback = playback->duplicate();
+			}
+			playback->path.clear();
+			playback->_clear_path_children(p_tree, anodesm.ptr(), p_test_only);
+			if (current != child_nodes[i].name) {
+				playback->_start(anodesm.ptr()); // Can restart.
+			}
+		}
+	}
+}
 
-	path.clear(); //a new one will be needed
+void AnimationNodeStateMachinePlayback::_start_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const String &p_path, bool p_test_only) {
+	if (p_state_machine->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
+		return; // This function must be fired only by the top state machine, do nothing in child state machine.
+	}
+	Vector<String> temp_path = p_path.split("/");
+	if (temp_path.size() > 1) {
+		for (int i = 1; i < temp_path.size(); i++) {
+			String concatenated;
+			for (int j = 0; j < i; j++) {
+				concatenated += temp_path[j] + (j == i - 1 ? "" : "/");
+			}
+			Ref<AnimationNodeStateMachine> anodesm = p_state_machine->find_node_by_path(concatenated);
+			if (anodesm.is_valid() && anodesm->get_state_machine_type() != AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
+				ERR_FAIL_MSG("Root/Nested AnimationNodeStateMachine can't have path from parent AnimationNodeStateMachine.");
+			}
+			Ref<AnimationNodeStateMachinePlayback> playback = p_tree->get(base_path + concatenated + "/playback");
+			ERR_FAIL_COND(!playback.is_valid());
+			playback->_set_base_path(base_path + concatenated + "/");
+			if (p_test_only) {
+				playback = playback->duplicate();
+			}
+			playback->_start_main(temp_path[i], i == temp_path.size() - 1 ? reset_request : false);
+		}
+		reset_request = false;
+	}
+}
 
-	if (current == p_travel) {
-		return !p_state_machine->is_allow_transition_to_self();
+bool AnimationNodeStateMachinePlayback::_travel_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const String &p_path, bool p_is_allow_transition_to_self, bool p_is_parent_same_state, bool p_test_only) {
+	if (p_state_machine->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
+		return false; // This function must be fired only by the top state machine, do nothing in child state machine.
+	}
+	Vector<String> temp_path = p_path.split("/");
+	Vector<ChildStateMachineInfo> children;
+
+	bool found_route = true;
+	bool is_parent_same_state = p_is_parent_same_state;
+	if (temp_path.size() > 1) {
+		for (int i = 1; i < temp_path.size(); i++) {
+			String concatenated;
+			for (int j = 0; j < i; j++) {
+				concatenated += temp_path[j] + (j == i - 1 ? "" : "/");
+			}
+
+			Ref<AnimationNodeStateMachine> anodesm = p_state_machine->find_node_by_path(concatenated);
+			if (anodesm.is_valid() && anodesm->get_state_machine_type() != AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
+				ERR_FAIL_V_MSG(false, "Root/Nested AnimationNodeStateMachine can't have path from parent AnimationNodeStateMachine.");
+			}
+			Ref<AnimationNodeStateMachinePlayback> playback = p_tree->get(base_path + concatenated + "/playback");
+			ERR_FAIL_COND_V(!playback.is_valid(), false);
+			playback->_set_base_path(base_path + concatenated + "/");
+			if (p_test_only) {
+				playback = playback->duplicate();
+			}
+			if (!playback->is_playing()) {
+				playback->_start(anodesm.ptr());
+			}
+			ChildStateMachineInfo child_info;
+			child_info.playback = playback;
+
+			// Process for the case that parent state is changed.
+			bool child_found_route = true;
+			bool is_current_same_state = temp_path[i] == playback->get_current_node();
+			if (!is_parent_same_state) {
+				// Force travel to end current child state machine.
+				String child_path = "/" + playback->get_current_node();
+				while (true) {
+					Ref<AnimationNodeStateMachine> child_anodesm = p_state_machine->find_node_by_path(concatenated + child_path);
+					if (!child_anodesm.is_valid() || child_anodesm->get_state_machine_type() != AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
+						break;
+					}
+					Ref<AnimationNodeStateMachinePlayback> child_playback = p_tree->get(base_path + concatenated + child_path + "/playback");
+					ERR_FAIL_COND_V(!child_playback.is_valid(), false);
+					child_playback->_set_base_path(base_path + concatenated + "/");
+					if (p_test_only) {
+						child_playback = child_playback->duplicate();
+					}
+					child_playback->_travel_main("End");
+					child_found_route &= child_playback->_travel(p_tree, child_anodesm.ptr(), false, p_test_only);
+					child_path += "/" + child_playback->get_current_node();
+				}
+				// Force restart target state machine.
+				playback->_start(anodesm.ptr());
+			}
+			is_parent_same_state = is_current_same_state;
+
+			bool is_deepest_state = i == temp_path.size() - 1;
+			child_info.is_reset = is_deepest_state ? reset_request_on_teleport : false;
+			playback->_travel_main(temp_path[i], child_info.is_reset);
+			if (playback->_make_travel_path(p_tree, anodesm.ptr(), is_deepest_state ? p_is_allow_transition_to_self : false, child_info.path, p_test_only)) {
+				found_route &= child_found_route;
+			} else {
+				child_info.path.push_back(temp_path[i]);
+				found_route = false;
+			}
+			children.push_back(child_info);
+		}
+		reset_request_on_teleport = false;
 	}
 
-	Vector2 current_pos = p_state_machine->states[current].position;
-	Vector2 target_pos = p_state_machine->states[p_travel].position;
+	if (found_route) {
+		for (int i = 0; i < children.size(); i++) {
+			children.write[i].playback->clear_path();
+			for (int j = 0; j < children[i].path.size(); j++) {
+				children.write[i].playback->push_path(children[i].path[j]);
+			}
+		}
+	} else {
+		for (int i = 0; i < children.size(); i++) {
+			children.write[i].playback->_travel_main(StringName(), children[i].is_reset); // Clear travel.
+			if (children[i].path.size()) {
+				children.write[i].playback->_start_main(children[i].path[children[i].path.size() - 1], children[i].is_reset);
+			}
+		}
+	}
+	return found_route;
+}
 
+void AnimationNodeStateMachinePlayback::_start(AnimationNodeStateMachine *p_state_machine) {
+	playing = true;
+	_set_current(p_state_machine, start_request != StringName() ? start_request : p_state_machine->start_node);
+	teleport_request = true;
+	stop_request = false;
+	start_request = StringName();
+}
+
+bool AnimationNodeStateMachinePlayback::_travel(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, bool p_test_only) {
+	return _make_travel_path(p_tree, p_state_machine, p_is_allow_transition_to_self, path, p_test_only);
+}
+
+String AnimationNodeStateMachinePlayback::_validate_path(AnimationNodeStateMachine *p_state_machine, const String &p_path) {
+	if (p_state_machine->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
+		return p_path; // Grouped state machine doesn't allow validat-able request.
+	}
+	String target = p_path;
+	Ref<AnimationNodeStateMachine> anodesm = p_state_machine->find_node_by_path(target);
+	while (anodesm.is_valid() && anodesm->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
+		Vector<int> indices = anodesm->find_transition_from(anodesm->start_node);
+		if (indices.size()) {
+			target = target + "/" + anodesm->get_transition_to(indices[0]); // Find next state of Start.
+		} else {
+			break; // There is no transition in Start state of grouped state machine.
+		}
+		anodesm = p_state_machine->find_node_by_path(target);
+	}
+	return target;
+}
+
+bool AnimationNodeStateMachinePlayback::_make_travel_path(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, Vector<StringName> &r_path, bool p_test_only) {
+	StringName travel = travel_request;
+	travel_request = StringName();
+
+	if (!playing) {
+		_start(p_state_machine);
+	}
+
+	ERR_FAIL_COND_V(!p_state_machine->states.has(travel), false);
+	ERR_FAIL_COND_V(!p_state_machine->states.has(current), false);
+
+	if (current == travel) {
+		return !p_is_allow_transition_to_self;
+	}
+
+	Vector<StringName> new_path;
+
+	Vector2 current_pos = p_state_machine->states[current].position;
+	Vector2 target_pos = p_state_machine->states[travel].position;
+
+	bool found_route = false;
 	HashMap<StringName, AStarCost> cost_map;
 
 	List<int> open_list;
 
-	//build open list
+	// Build open list.
 	for (int i = 0; i < p_state_machine->transitions.size(); i++) {
 		if (p_state_machine->transitions[i].transition->get_advance_mode() == AnimationNodeStateMachineTransition::ADVANCE_MODE_DISABLED) {
 			continue;
 		}
 
-		if (p_state_machine->transitions[i].local_from == current) {
+		if (p_state_machine->transitions[i].from == current) {
 			open_list.push_back(i);
-			float cost = p_state_machine->states[p_state_machine->transitions[i].local_to].position.distance_to(current_pos);
+			float cost = p_state_machine->states[p_state_machine->transitions[i].to].position.distance_to(current_pos);
 			cost *= p_state_machine->transitions[i].transition->get_priority();
 			AStarCost ap;
 			ap.prev = current;
 			ap.distance = cost;
-			cost_map[p_state_machine->transitions[i].local_to] = ap;
+			cost_map[p_state_machine->transitions[i].to] = ap;
 
-			if (p_state_machine->transitions[i].local_to == p_travel) { //prematurely found it! :D
-				path.push_back(p_travel);
-				return true;
+			if (p_state_machine->transitions[i].to == travel) { // Prematurely found it! :D
+				found_route = true;
+				break;
 			}
 		}
 	}
 
-	//begin astar
-	bool found_route = false;
+	// Begin astar.
 	while (!found_route) {
 		if (open_list.size() == 0) {
-			return false; //no path found
+			break; // No path found.
 		}
 
-		//find the last cost transition
+		// Find the last cost transition.
 		List<int>::Element *least_cost_transition = nullptr;
 		float least_cost = 1e20;
 
 		for (List<int>::Element *E = open_list.front(); E; E = E->next()) {
-			float cost = cost_map[p_state_machine->transitions[E->get()].local_to].distance;
-			cost += p_state_machine->states[p_state_machine->transitions[E->get()].local_to].position.distance_to(target_pos);
+			float cost = cost_map[p_state_machine->transitions[E->get()].to].distance;
+			cost += p_state_machine->states[p_state_machine->transitions[E->get()].to].position.distance_to(target_pos);
 
 			if (cost < least_cost) {
 				least_cost_transition = E;
@@ -305,38 +564,38 @@ bool AnimationNodeStateMachinePlayback::_travel(AnimationNodeStateMachine *p_sta
 			}
 		}
 
-		StringName transition_prev = p_state_machine->transitions[least_cost_transition->get()].local_from;
-		StringName transition = p_state_machine->transitions[least_cost_transition->get()].local_to;
+		StringName transition_prev = p_state_machine->transitions[least_cost_transition->get()].from;
+		StringName transition = p_state_machine->transitions[least_cost_transition->get()].to;
 
 		for (int i = 0; i < p_state_machine->transitions.size(); i++) {
 			if (p_state_machine->transitions[i].transition->get_advance_mode() == AnimationNodeStateMachineTransition::ADVANCE_MODE_DISABLED) {
 				continue;
 			}
 
-			if (p_state_machine->transitions[i].local_from != transition || p_state_machine->transitions[i].local_to == transition_prev) {
-				continue; //not interested on those
+			if (p_state_machine->transitions[i].from != transition || p_state_machine->transitions[i].to == transition_prev) {
+				continue; // Not interested on those.
 			}
 
-			float distance = p_state_machine->states[p_state_machine->transitions[i].local_from].position.distance_to(p_state_machine->states[p_state_machine->transitions[i].local_to].position);
+			float distance = p_state_machine->states[p_state_machine->transitions[i].from].position.distance_to(p_state_machine->states[p_state_machine->transitions[i].to].position);
 			distance *= p_state_machine->transitions[i].transition->get_priority();
-			distance += cost_map[p_state_machine->transitions[i].local_from].distance;
+			distance += cost_map[p_state_machine->transitions[i].from].distance;
 
-			if (cost_map.has(p_state_machine->transitions[i].local_to)) {
-				//oh this was visited already, can we win the cost?
-				if (distance < cost_map[p_state_machine->transitions[i].local_to].distance) {
-					cost_map[p_state_machine->transitions[i].local_to].distance = distance;
-					cost_map[p_state_machine->transitions[i].local_to].prev = p_state_machine->transitions[i].local_from;
+			if (cost_map.has(p_state_machine->transitions[i].to)) {
+				// Oh this was visited already, can we win the cost?
+				if (distance < cost_map[p_state_machine->transitions[i].to].distance) {
+					cost_map[p_state_machine->transitions[i].to].distance = distance;
+					cost_map[p_state_machine->transitions[i].to].prev = p_state_machine->transitions[i].from;
 				}
 			} else {
-				//add to open list
+				// Add to open list.
 				AStarCost ac;
-				ac.prev = p_state_machine->transitions[i].local_from;
+				ac.prev = p_state_machine->transitions[i].from;
 				ac.distance = distance;
-				cost_map[p_state_machine->transitions[i].local_to] = ac;
+				cost_map[p_state_machine->transitions[i].to] = ac;
 
 				open_list.push_back(i);
 
-				if (p_state_machine->transitions[i].local_to == p_travel) {
+				if (p_state_machine->transitions[i].to == travel) {
 					found_route = true;
 					break;
 				}
@@ -350,20 +609,60 @@ bool AnimationNodeStateMachinePlayback::_travel(AnimationNodeStateMachine *p_sta
 		open_list.erase(least_cost_transition);
 	}
 
-	//make path
-	StringName at = p_travel;
-	while (at != current) {
-		path.push_back(at);
-		at = cost_map[at].prev;
+	// Check child grouped state machine.
+	if (found_route) {
+		// Make path.
+		StringName at = travel;
+		while (at != current) {
+			new_path.push_back(at);
+			at = cost_map[at].prev;
+		}
+		new_path.reverse();
+
+		// Check internal paths of child grouped state machine.
+		// For example:
+		// [current - End] - [Start - End] - [Start - End] - [Start - target]
+		String current_path = current;
+		int len = new_path.size() + 1;
+		for (int i = 0; i < len; i++) {
+			Ref<AnimationNodeStateMachine> anodesm = p_state_machine->find_node_by_path(current_path);
+			if (anodesm.is_valid() && anodesm->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
+				Ref<AnimationNodeStateMachinePlayback> playback = p_tree->get(base_path + current_path + "/playback");
+				ERR_FAIL_COND_V(!playback.is_valid(), false);
+				playback->_set_base_path(base_path + current_path + "/");
+				if (p_test_only) {
+					playback = playback->duplicate();
+				}
+				if (i > 0) {
+					playback->_start(anodesm.ptr());
+				}
+				if (i >= new_path.size()) {
+					break; // Tracing has been finished, needs to break.
+				}
+				playback->_travel_main("End");
+				if (!playback->_travel(p_tree, anodesm.ptr(), false, p_test_only)) {
+					found_route = false;
+					break;
+				}
+			}
+			if (i >= new_path.size()) {
+				break; // Tracing has been finished, needs to break.
+			}
+			current_path = new_path[i];
+		}
 	}
 
-	path.reverse();
-
-	return true;
+	// Finally, rewrite path if route is found.
+	if (found_route) {
+		r_path = new_path;
+		return true;
+	} else {
+		return false;
+	}
 }
 
-double AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking) {
-	double rem = _process(p_state_machine, p_time, p_seek, p_is_external_seeking);
+double AnimationNodeStateMachinePlayback::process(const String &p_base_path, AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+	double rem = _process(p_base_path, p_state_machine, p_time, p_seek, p_is_external_seeking, p_test_only);
 	start_request = StringName();
 	next_request = false;
 	stop_request = false;
@@ -371,99 +670,129 @@ double AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_s
 	return rem;
 }
 
-double AnimationNodeStateMachinePlayback::_process(AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking) {
-	if (p_time == -1) {
-		Ref<AnimationNodeStateMachine> anodesm = p_state_machine->states[current].node;
-		if (anodesm.is_valid()) {
-			p_state_machine->blend_node(current, p_state_machine->states[current].node, -1, p_seek, p_is_external_seeking, 0, AnimationNode::FILTER_IGNORE, true);
-		}
-		playing = false;
-		return 0;
-	}
+double AnimationNodeStateMachinePlayback::_process(const String &p_base_path, AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+	_set_base_path(p_base_path);
 
-	//if not playing and it can restart, then restart
-	if (!playing && start_request == StringName()) {
-		if (!stop_request && p_state_machine->start_node) {
-			_start(p_state_machine->start_node);
+	AnimationTree *tree = p_state_machine->state->tree;
+
+	// Check seek to 0 (means reset) by parent AnimationNode.
+	if (p_time == 0 && p_seek && !p_is_external_seeking) {
+		if (p_state_machine->state_machine_type != AnimationNodeStateMachine::STATE_MACHINE_TYPE_NESTED || is_end() || !playing) {
+			// Restart state machine.
+			if (p_state_machine->get_state_machine_type() != AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
+				path.clear();
+				_clear_path_children(tree, p_state_machine, p_test_only);
+			}
+			reset_request = true;
+			_start(p_state_machine);
 		} else {
-			return 0;
+			// Reset current state.
+			reset_request = true;
+			teleport_request = true;
 		}
 	}
 
-	if (playing && stop_request) {
+	if (stop_request) {
+		start_request = StringName();
+		travel_request = StringName();
+		path.clear();
 		playing = false;
 		return 0;
 	}
 
-	bool play_start = false;
+	if (!playing && start_request != StringName() && travel_request != StringName()) {
+		return 0;
+	}
+
+	// Process start/travel request.
+	if (start_request != StringName() || travel_request != StringName()) {
+		if (p_state_machine->get_state_machine_type() != AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
+			_clear_path_children(tree, p_state_machine, p_test_only);
+		}
+	}
 
 	if (start_request != StringName()) {
-		// teleport to start
+		path.clear();
+		String start_target = _validate_path(p_state_machine, start_request);
+		Vector<String> start_path = String(start_target).split("/");
+		start_request = start_path[0];
+		if (start_path.size()) {
+			_start_children(tree, p_state_machine, start_target, p_test_only);
+		}
+		// Teleport to start.
 		if (p_state_machine->states.has(start_request)) {
-			path.clear();
-			current = start_request;
-			playing = true;
-			play_start = true;
+			_start(p_state_machine);
 		} else {
 			StringName node = start_request;
 			ERR_FAIL_V_MSG(0, "No such node: '" + node + "'");
 		}
-	} else if (travel_request != StringName()) {
-		if (!playing) {
-			if (!stop_request && p_state_machine->start_node) {
-				// can restart, just postpone traveling
-				path.clear();
-				current = p_state_machine->start_node;
-				playing = true;
-				play_start = true;
+	}
+
+	if (travel_request != StringName()) {
+		// Fix path.
+		String travel_target = _validate_path(p_state_machine, travel_request);
+		Vector<String> travel_path = travel_target.split("/");
+		travel_request = travel_path[0];
+		StringName temp_travel_request = travel_request; // For the case that can't travel.
+		// Process children.
+		Vector<StringName> new_path;
+		bool can_travel = _make_travel_path(tree, p_state_machine, travel_path.size() <= 1 ? p_state_machine->is_allow_transition_to_self() : false, new_path, p_test_only);
+		if (travel_path.size()) {
+			if (can_travel) {
+				can_travel = _travel_children(tree, p_state_machine, travel_target, p_state_machine->is_allow_transition_to_self(), travel_path[0] == current, p_test_only);
 			} else {
-				// stopped, invalid state
-				String node_name = travel_request;
-				travel_request = StringName();
-				ERR_FAIL_V_MSG(0, "Can't travel to '" + node_name + "' if state machine is not playing. Maybe you need to enable Autoplay on Load for one of the nodes in your state machine or call .start() first?");
+				_start_children(tree, p_state_machine, travel_target, p_test_only);
 			}
+		}
+
+		// Process to travel.
+		if (can_travel) {
+			path = new_path;
 		} else {
-			if (!_travel(p_state_machine, travel_request)) {
-				// can't travel, then teleport
-				if (p_state_machine->states.has(travel_request)) {
-					path.clear();
-					if (current != travel_request || reset_request_on_teleport) {
-						current = travel_request;
-						play_start = true;
-						reset_request = reset_request_on_teleport;
-					}
-				} else {
-					StringName node = travel_request;
-					travel_request = StringName();
-					ERR_FAIL_V_MSG(0, "No such node: '" + node + "'");
+			// Can't travel, then teleport.
+			if (p_state_machine->states.has(temp_travel_request)) {
+				path.clear();
+				if (current != temp_travel_request || reset_request_on_teleport) {
+					_set_current(p_state_machine, temp_travel_request);
+					reset_request = reset_request_on_teleport;
+					teleport_request = true;
 				}
+			} else {
+				ERR_FAIL_V_MSG(0, "No such node: '" + temp_travel_request + "'");
 			}
-			travel_request = StringName();
 		}
 	}
 
-	bool do_start = (p_seek && p_time == 0) || play_start || current == StringName();
-
-	if (do_start) {
-		if (p_state_machine->start_node != StringName() && p_seek && p_time == 0 && current == StringName()) {
-			current = p_state_machine->start_node;
-		}
-
-		if (reset_request) {
-			len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, p_is_external_seeking, 1.0, AnimationNode::FILTER_IGNORE, true);
-			pos_current = 0;
-			reset_request = false;
-		}
+	if (teleport_request) {
+		teleport_request = false;
+		// Clear fadeing on teleport.
+		fading_from = StringName();
+		fading_pos = 0;
+		// Init current length.
+		pos_current = 0; // Overwritten suddenly in main process.
+		len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, false, 0, AnimationNode::FILTER_IGNORE, true, true);
+		// Don't process first node if not necessary, insteads process next node.
+		_transition_to_next_recursive(tree, p_state_machine, p_test_only);
 	}
 
+	// Check current node existence.
 	if (!p_state_machine->states.has(current)) {
-		playing = false; //current does not exist
-		current = StringName();
+		playing = false; // Current does not exist.
+		_set_current(p_state_machine, StringName());
 		return 0;
 	}
-	float fade_blend = 1.0;
 
-	if (fading_from != StringName()) {
+	// Special case for grouped state machine Start/End to make priority with parent blend (means don't treat Start and End states as RESET animations).
+	bool is_start_of_group = false;
+	bool is_end_of_group = false;
+	if (!p_state_machine->are_ends_reset() || p_state_machine->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
+		is_start_of_group = fading_from == p_state_machine->start_node;
+		is_end_of_group = current == p_state_machine->end_node;
+	}
+
+	// Calc blend amount by cross-fade.
+	float fade_blend = 1.0;
+	if (fading_time && fading_from != StringName()) {
 		if (!p_state_machine->states.has(fading_from)) {
 			fading_from = StringName();
 		} else {
@@ -473,223 +802,283 @@ double AnimationNodeStateMachinePlayback::_process(AnimationNodeStateMachine *p_
 			fade_blend = MIN(1.0, fading_pos / fading_time);
 		}
 	}
-
 	if (current_curve.is_valid()) {
 		fade_blend = current_curve->sample(fade_blend);
 	}
+	fade_blend = Math::is_zero_approx(fade_blend) ? CMP_EPSILON : fade_blend;
+	if (is_start_of_group) {
+		fade_blend = 1.0;
+	} else if (is_end_of_group) {
+		fade_blend = 0.0;
+	}
 
-	double rem = do_start ? len_current : p_state_machine->blend_node(current, p_state_machine->states[current].node, p_time, p_seek, p_is_external_seeking, Math::is_zero_approx(fade_blend) ? CMP_EPSILON : fade_blend, AnimationNode::FILTER_IGNORE, true); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
+	// Main process.
+	double rem = 0.0;
+	if (reset_request) {
+		reset_request = false;
+		len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, p_is_external_seeking, fade_blend, AnimationNode::FILTER_IGNORE, true, p_test_only);
+		rem = len_current;
+	} else {
+		rem = p_state_machine->blend_node(current, p_state_machine->states[current].node, p_time, p_seek, p_is_external_seeking, fade_blend, AnimationNode::FILTER_IGNORE, true, p_test_only); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
+	}
 
+	// Cross-fade process.
 	if (fading_from != StringName()) {
 		double fade_blend_inv = 1.0 - fade_blend;
+		fade_blend_inv = Math::is_zero_approx(fade_blend_inv) ? CMP_EPSILON : fade_blend_inv;
+		if (is_start_of_group) {
+			fade_blend_inv = 0.0;
+		} else if (is_end_of_group) {
+			fade_blend_inv = 1.0;
+		}
+
 		float fading_from_rem = 0.0;
-		fading_from_rem = p_state_machine->blend_node(fading_from, p_state_machine->states[fading_from].node, p_time, p_seek, p_is_external_seeking, Math::is_zero_approx(fade_blend_inv) ? CMP_EPSILON : fade_blend_inv, AnimationNode::FILTER_IGNORE, true); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
-		//guess playback position
-		if (fading_from_rem > len_fade_from) { // weird but ok
+		if (_reset_request_for_fading_from) {
+			_reset_request_for_fading_from = false;
+			fading_from_rem = p_state_machine->blend_node(fading_from, p_state_machine->states[fading_from].node, 0, true, p_is_external_seeking, fade_blend_inv, AnimationNode::FILTER_IGNORE, true); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
+		} else {
+			fading_from_rem = p_state_machine->blend_node(fading_from, p_state_machine->states[fading_from].node, p_time, p_seek, p_is_external_seeking, fade_blend_inv, AnimationNode::FILTER_IGNORE, true); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
+		}
+
+		// Guess playback position.
+		if (fading_from_rem > len_fade_from) { /// Weird but ok.
 			len_fade_from = fading_from_rem;
 		}
+		pos_fade_from = len_fade_from - fading_from_rem;
 
-		{ //advance and loop check
-			float next_pos = len_fade_from - fading_from_rem;
-			pos_fade_from = next_pos; //looped
-		}
-		if (fade_blend >= 1.0) {
-			fading_from = StringName();
+		if (fading_pos >= fading_time) {
+			fading_from = StringName(); // Finish fading.
 		}
 	}
 
-	//guess playback position
-	if (rem > len_current) { // weird but ok
+	// Guess playback position.
+	if (rem > len_current) { // Weird but ok.
 		len_current = rem;
 	}
+	pos_current = len_current - rem;
 
-	{ //advance and loop check
-		double next_pos = len_current - rem;
-		end_loop = next_pos < pos_current;
-		pos_current = next_pos; //looped
+	// Find next and see when to transition.
+	_transition_to_next_recursive(tree, p_state_machine, p_test_only);
+
+	// Predict reamin time.
+	double remain = rem; // If we can't predict the end of state machine, the time remaining must be INFINITY.
+
+	if (p_state_machine->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_NESTED) {
+		// There is no next transition.
+		if (!p_state_machine->has_transition_from(current)) {
+			if (fading_from != StringName()) {
+				remain = MAX(rem, fading_time - fading_pos);
+			} else {
+				remain = rem;
+			}
+			return remain;
+		}
 	}
 
-	//find next
-	StringName next;
-	double next_xfade = 0.0;
-	AnimationNodeStateMachineTransition::SwitchMode switch_mode = AnimationNodeStateMachineTransition::SWITCH_MODE_IMMEDIATE;
+	if (current == p_state_machine->end_node) {
+		if (fading_from != StringName()) {
+			remain = MAX(0, fading_time - fading_pos);
+		} else {
+			remain = 0;
+		}
+		return remain;
+	}
 
+	if (!is_end()) {
+		return HUGE_LENGTH;
+	}
+
+	return remain;
+}
+
+bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_test_only) {
+	_reset_request_for_fading_from = false;
+
+	bool is_state_changed = false;
+
+	NextInfo next;
+	StringName transition_start = current;
+	while (true) {
+		next = _find_next(p_tree, p_state_machine);
+		if (next.node == transition_start) {
+			is_state_changed = false;
+			break; // Maybe infinity loop, do noting more.
+		}
+
+		if (!_can_transition_to_next(p_tree, p_state_machine, next, p_test_only)) {
+			break; // Finish transition.
+		}
+
+		is_state_changed = true;
+
+		// Setting for fading.
+		if (next.xfade) {
+			// Time to fade.
+			fading_from = current;
+			fading_time = next.xfade;
+			fading_pos = 0;
+		} else {
+			if (reset_request) {
+				// There is no possibility of processing doubly. Now we can apply reset actually in here.
+				p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, false, 0, AnimationNode::FILTER_IGNORE, true, p_test_only);
+			}
+			fading_from = StringName();
+			fading_time = 0;
+			fading_pos = 0;
+		}
+
+		// If it came from path, remove path.
+		if (path.size()) {
+			path.remove_at(0);
+		}
+
+		// Update current status.
+		_set_current(p_state_machine, next.node);
+		current_curve = next.curve;
+
+		_reset_request_for_fading_from = reset_request; // To avoid processing doubly, it must be reset in the fading process within _process().
+		reset_request = next.is_reset;
+
+		pos_fade_from = pos_current;
+		len_fade_from = len_current;
+
+		if (next.switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_SYNC) {
+			p_state_machine->blend_node(current, p_state_machine->states[current].node, MIN(pos_current, len_current), true, false, 0, AnimationNode::FILTER_IGNORE, true);
+		}
+
+		// Just get length to find next recursive.
+		double rem = 0.0;
+		if (next.is_reset) {
+			len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, false, 0, AnimationNode::FILTER_IGNORE, true, true); // Just retrieve remain length, don't process.
+			rem = len_current;
+		} else {
+			rem = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, false, false, 0, AnimationNode::FILTER_IGNORE, true, true); // Just retrieve remain length, don't process.
+		}
+
+		// Guess playback position.
+		if (rem > len_current) { // Weird but ok.
+			len_current = rem;
+		}
+		pos_current = len_current - rem;
+
+		// Fading must be processed.
+		if (fading_time) {
+			break;
+		}
+	}
+
+	return is_state_changed;
+}
+
+bool AnimationNodeStateMachinePlayback::_can_transition_to_next(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, NextInfo p_next, bool p_test_only) {
+	if (p_next.node == StringName()) {
+		return false;
+	}
+
+	if (next_request) {
+		// Process request only once.
+		next_request = false;
+		// Next request must be applied to only deepest state machine.
+		Ref<AnimationNodeStateMachine> anodesm = p_state_machine->find_node_by_path(current);
+		if (anodesm.is_valid() && anodesm->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
+			Ref<AnimationNodeStateMachinePlayback> playback = p_tree->get(base_path + current + "/playback");
+			ERR_FAIL_COND_V(!playback.is_valid(), false);
+			playback->_set_base_path(base_path + current + "/");
+			if (p_test_only) {
+				playback = playback->duplicate();
+			}
+			playback->_next_main();
+			// Then, fadeing should be end.
+			fading_from = StringName();
+			fading_pos = 0;
+		} else {
+			return true;
+		}
+	}
+
+	if (fading_from != StringName()) {
+		return false;
+	}
+
+	if (current != p_state_machine->start_node && p_next.switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_AT_END) {
+		return pos_current >= len_current - p_next.xfade;
+	}
+	return true;
+}
+
+Ref<AnimationNodeStateMachineTransition> AnimationNodeStateMachinePlayback::_check_group_transition(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const AnimationNodeStateMachine::Transition &p_transition, Ref<AnimationNodeStateMachine> &r_state_machine, bool &r_bypass) const {
+	Ref<AnimationNodeStateMachineTransition> temp_transition;
+	Ref<AnimationNodeStateMachinePlayback> parent_playback;
+	if (r_state_machine->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
+		if (p_transition.from == "Start") {
+			parent_playback = _get_parent_playback(p_tree);
+			if (parent_playback.is_valid()) {
+				r_bypass = true;
+				temp_transition = parent_playback->_get_group_start_transition();
+			}
+		} else if (p_transition.to == "End") {
+			parent_playback = _get_parent_playback(p_tree);
+			if (parent_playback.is_valid()) {
+				temp_transition = parent_playback->_get_group_end_transition();
+			}
+		}
+		if (temp_transition.is_valid()) {
+			r_state_machine = _get_parent_state_machine(p_tree);
+			return temp_transition;
+		}
+	}
+	return p_transition.transition;
+}
+
+AnimationNodeStateMachinePlayback::NextInfo AnimationNodeStateMachinePlayback::_find_next(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine) const {
+	NextInfo next;
 	if (path.size()) {
 		for (int i = 0; i < p_state_machine->transitions.size(); i++) {
-			if (p_state_machine->transitions[i].transition->get_advance_mode() == AnimationNodeStateMachineTransition::ADVANCE_MODE_DISABLED) {
+			Ref<AnimationNodeStateMachine> anodesm = p_state_machine;
+			bool bypass = false;
+			Ref<AnimationNodeStateMachineTransition> ref_transition = _check_group_transition(p_tree, p_state_machine, p_state_machine->transitions[i], anodesm, bypass);
+			if (ref_transition->get_advance_mode() == AnimationNodeStateMachineTransition::ADVANCE_MODE_DISABLED) {
 				continue;
 			}
-
-			if (p_state_machine->transitions[i].local_from == current && p_state_machine->transitions[i].local_to == path[0]) {
-				next_xfade = p_state_machine->transitions[i].transition->get_xfade_time();
-				current_curve = p_state_machine->transitions[i].transition->get_xfade_curve();
-				switch_mode = p_state_machine->transitions[i].transition->get_switch_mode();
-				reset_request = p_state_machine->transitions[i].transition->is_reset();
-				next = path[0];
+			if (p_state_machine->transitions[i].from == current && p_state_machine->transitions[i].to == path[0]) {
+				next.node = path[0];
+				next.xfade = ref_transition->get_xfade_time();
+				next.curve = ref_transition->get_xfade_curve();
+				next.switch_mode = ref_transition->get_switch_mode();
+				next.is_reset = ref_transition->is_reset();
 			}
 		}
 	} else {
-		float priority_best = 1e20;
 		int auto_advance_to = -1;
-
+		float priority_best = 1e20;
 		for (int i = 0; i < p_state_machine->transitions.size(); i++) {
-			if (p_state_machine->transitions[i].transition->get_advance_mode() == AnimationNodeStateMachineTransition::ADVANCE_MODE_DISABLED) {
+			Ref<AnimationNodeStateMachine> anodesm = p_state_machine;
+			bool bypass = false;
+			Ref<AnimationNodeStateMachineTransition> ref_transition = _check_group_transition(p_tree, p_state_machine, p_state_machine->transitions[i], anodesm, bypass);
+			if (ref_transition->get_advance_mode() == AnimationNodeStateMachineTransition::ADVANCE_MODE_DISABLED) {
 				continue;
 			}
-
-			// handles end_node: when end_node is reached in a sub state machine, find and activate the current_transition
-			if (force_auto_advance) {
-				if (p_state_machine->transitions[i].from == current_transition.from && p_state_machine->transitions[i].to == current_transition.to) {
-					auto_advance_to = i;
-					force_auto_advance = false;
-					break;
-				}
-			}
-
-			// handles start_node: if previous state machine is pointing to a node inside the current state machine, starts the current machine from start_node to prev_local_to
-			if (p_state_machine->start_node == current && p_state_machine->transitions[i].local_from == current) {
-				if (p_state_machine->prev_state_machine != nullptr) {
-					Ref<AnimationNodeStateMachinePlayback> prev_playback = p_state_machine->prev_state_machine->get_parameter(p_state_machine->playback);
-
-					if (prev_playback.is_valid()) {
-						StringName prev_local_to = String(prev_playback->current_transition.next).replace_first(String(p_state_machine->state_machine_name) + "/", "");
-
-						if (p_state_machine->transitions[i].to == prev_local_to) {
-							auto_advance_to = i;
-							prev_playback->current_transition.next = StringName();
-							break;
-						}
-					}
-				}
-			}
-
-			if (p_state_machine->transitions[i].from == current && _check_advance_condition(p_state_machine, p_state_machine->transitions[i].transition)) {
-				if (p_state_machine->transitions[i].transition->get_priority() <= priority_best) {
-					priority_best = p_state_machine->transitions[i].transition->get_priority();
+			if (p_state_machine->transitions[i].from == current && (_check_advance_condition(anodesm, ref_transition) || bypass)) {
+				if (ref_transition->get_priority() <= priority_best) {
+					priority_best = ref_transition->get_priority();
 					auto_advance_to = i;
 				}
 			}
 		}
 
 		if (auto_advance_to != -1) {
-			next = p_state_machine->transitions[auto_advance_to].local_to;
-			Transition tr;
-			tr.from = String(p_state_machine->state_machine_name) + "/" + String(p_state_machine->transitions[auto_advance_to].from);
-			tr.to = String(p_state_machine->transitions[auto_advance_to].to).replace_first("../", "");
-			tr.next = p_state_machine->transitions[auto_advance_to].to;
-			current_transition = tr;
-			current_curve = p_state_machine->transitions[auto_advance_to].transition->get_xfade_curve();
-			next_xfade = p_state_machine->transitions[auto_advance_to].transition->get_xfade_time();
-			switch_mode = p_state_machine->transitions[auto_advance_to].transition->get_switch_mode();
-			reset_request = p_state_machine->transitions[auto_advance_to].transition->is_reset();
+			next.node = p_state_machine->transitions[auto_advance_to].to;
+			Ref<AnimationNodeStateMachine> anodesm = p_state_machine;
+			bool bypass = false;
+			Ref<AnimationNodeStateMachineTransition> ref_transition = _check_group_transition(p_tree, p_state_machine, p_state_machine->transitions[auto_advance_to], anodesm, bypass);
+			next.xfade = ref_transition->get_xfade_time();
+			next.curve = ref_transition->get_xfade_curve();
+			next.switch_mode = ref_transition->get_switch_mode();
+			next.is_reset = ref_transition->is_reset();
 		}
 	}
 
-	if (next == p_state_machine->end_node) {
-		AnimationNodeStateMachine *prev_state_machine = p_state_machine->prev_state_machine;
-
-		if (prev_state_machine != nullptr) {
-			Ref<AnimationNodeStateMachinePlayback> prev_playback = prev_state_machine->get_parameter(p_state_machine->playback);
-
-			if (prev_playback.is_valid()) {
-				if (next_xfade) {
-					prev_playback->current_transition = current_transition;
-					prev_playback->force_auto_advance = true;
-
-					return rem;
-				}
-				float priority_best = 1e20;
-				int auto_advance_to = -1;
-
-				for (int i = 0; i < prev_state_machine->transitions.size(); i++) {
-					if (prev_state_machine->transitions[i].transition->get_advance_mode() == AnimationNodeStateMachineTransition::ADVANCE_MODE_DISABLED) {
-						continue;
-					}
-
-					if (current_transition.next == prev_state_machine->end_node && _check_advance_condition(prev_state_machine, prev_state_machine->transitions[i].transition)) {
-						if (prev_state_machine->transitions[i].transition->get_priority() <= priority_best) {
-							priority_best = prev_state_machine->transitions[i].transition->get_priority();
-							auto_advance_to = i;
-						}
-					}
-				}
-
-				if (auto_advance_to != -1) {
-					if (prev_state_machine->transitions[auto_advance_to].transition->get_xfade_time()) {
-						return rem;
-					}
-				}
-			}
-		}
-	}
-
-	//if next, see when to transition
-	if (next != StringName()) {
-		bool goto_next = false;
-
-		if (switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_AT_END) {
-			goto_next = next_xfade >= (len_current - pos_current) || end_loop;
-			if (end_loop) {
-				next_xfade = 0;
-			}
-		} else {
-			goto_next = fading_from == StringName();
-		}
-
-		if (next_request || goto_next) { //end_loop should be used because fade time may be too small or zero and animation may have looped
-			if (next_xfade) {
-				//time to fade, baby
-				fading_from = current;
-				fading_time = next_xfade;
-				fading_pos = 0;
-			} else {
-				fading_from = StringName();
-				fading_pos = 0;
-			}
-
-			if (path.size()) { //if it came from path, remove path
-				path.remove_at(0);
-			}
-
-			{ // if the current node is a state machine, update the "playing" variable to false by passing -1 in p_time
-				Ref<AnimationNodeStateMachine> anodesm = p_state_machine->states[current].node;
-				if (anodesm.is_valid()) {
-					p_state_machine->blend_node(current, p_state_machine->states[current].node, -1, p_seek, p_is_external_seeking, 0, AnimationNode::FILTER_IGNORE, true);
-				}
-			}
-
-			current = next;
-			pos_fade_from = pos_current;
-			len_fade_from = len_current;
-
-			if (reset_request) {
-				len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, p_is_external_seeking, CMP_EPSILON, AnimationNode::FILTER_IGNORE, true); // Process next node's first key in here.
-			}
-			if (switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_SYNC) {
-				pos_current = MIN(pos_current, len_current);
-				p_state_machine->blend_node(current, p_state_machine->states[current].node, pos_current, true, p_is_external_seeking, 0, AnimationNode::FILTER_IGNORE, true);
-			} else {
-				pos_current = 0;
-			}
-
-			rem = len_current; //so it does not show 0 on transition
-		}
-	}
-
-	if (current != p_state_machine->end_node) {
-		rem = 1; // the time remaining must always be 1 because there is no way to predict how long it takes for the entire state machine to complete
-	} else {
-		if (p_state_machine->prev_state_machine != nullptr) {
-			Ref<AnimationNodeStateMachinePlayback> prev_playback = p_state_machine->prev_state_machine->get_parameter(p_state_machine->playback);
-
-			if (prev_playback.is_valid()) {
-				prev_playback->current_transition = current_transition;
-				prev_playback->force_auto_advance = true;
-			}
-		}
-	}
-
-	return rem;
+	return next;
 }
 
 bool AnimationNodeStateMachinePlayback::_check_advance_condition(const Ref<AnimationNodeStateMachine> state_machine, const Ref<AnimationNodeStateMachineTransition> transition) const {
@@ -724,6 +1113,63 @@ bool AnimationNodeStateMachinePlayback::_check_advance_condition(const Ref<Anima
 	return true;
 }
 
+void AnimationNodeStateMachinePlayback::clear_path() {
+	path.clear();
+}
+
+void AnimationNodeStateMachinePlayback::push_path(const StringName &p_state) {
+	path.push_back(p_state);
+}
+
+void AnimationNodeStateMachinePlayback::_set_base_path(const String &p_base_path) {
+	base_path = p_base_path;
+}
+
+Ref<AnimationNodeStateMachinePlayback> AnimationNodeStateMachinePlayback::_get_parent_playback(AnimationTree *p_tree) const {
+	if (base_path.is_empty()) {
+		return Ref<AnimationNodeStateMachinePlayback>();
+	}
+	Vector<String> split = base_path.split("/");
+	ERR_FAIL_COND_V_MSG(split.size() < 2, Ref<AnimationNodeStateMachinePlayback>(), "Path is too short.");
+	StringName self_path = split[split.size() - 2];
+	split.remove_at(split.size() - 2);
+	String playback_path = String("/").join(split) + "playback";
+	Ref<AnimationNodeStateMachinePlayback> playback = p_tree->get(playback_path);
+	if (!playback.is_valid()) {
+		ERR_PRINT_ONCE("Can't get parent AnimationNodeStateMachinePlayback with path: " + playback_path + ". Maybe there is no Root/Nested AnimationNodeStateMachine in the parent of the Grouped AnimationNodeStateMachine.");
+		return Ref<AnimationNodeStateMachinePlayback>();
+	}
+	if (playback->get_current_node() != self_path) {
+		return Ref<AnimationNodeStateMachinePlayback>();
+	}
+	return playback;
+}
+
+Ref<AnimationNodeStateMachine> AnimationNodeStateMachinePlayback::_get_parent_state_machine(AnimationTree *p_tree) const {
+	if (base_path.is_empty()) {
+		return Ref<AnimationNodeStateMachine>();
+	}
+	Vector<String> split = base_path.split("/");
+	ERR_FAIL_COND_V_MSG(split.size() < 3, Ref<AnimationNodeStateMachine>(), "Path is too short.");
+	split = split.slice(1, split.size() - 2);
+	Ref<AnimationNode> root = p_tree->get_tree_root();
+	ERR_FAIL_COND_V_MSG(root.is_null(), Ref<AnimationNodeStateMachine>(), "There is no root AnimationNode in AnimationTree: " + String(p_tree->get_name()));
+	String anodesm_path = String("/").join(split);
+	Ref<AnimationNodeStateMachine> anodesm = !anodesm_path.size() ? root : root->find_node_by_path(anodesm_path);
+	ERR_FAIL_COND_V_MSG(anodesm.is_null(), Ref<AnimationNodeStateMachine>(), "Can't get state machine with path: " + anodesm_path);
+	return anodesm;
+}
+
+Ref<AnimationNodeStateMachineTransition> AnimationNodeStateMachinePlayback::_get_group_start_transition() const {
+	ERR_FAIL_COND_V_MSG(group_start_transition.is_null(), Ref<AnimationNodeStateMachineTransition>(), "Group start transition is null.");
+	return group_start_transition;
+}
+
+Ref<AnimationNodeStateMachineTransition> AnimationNodeStateMachinePlayback::_get_group_end_transition() const {
+	ERR_FAIL_COND_V_MSG(group_end_transition.is_null(), Ref<AnimationNodeStateMachineTransition>(), "Group end transition is null.");
+	return group_end_transition;
+}
+
 void AnimationNodeStateMachinePlayback::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("travel", "to_node", "reset_on_teleport"), &AnimationNodeStateMachinePlayback::travel, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("start", "node", "reset"), &AnimationNodeStateMachinePlayback::start, DEFVAL(true));
@@ -738,13 +1184,18 @@ void AnimationNodeStateMachinePlayback::_bind_methods() {
 }
 
 AnimationNodeStateMachinePlayback::AnimationNodeStateMachinePlayback() {
-	set_local_to_scene(true); //only one per instantiated scene
+	set_local_to_scene(true); // Only one per instantiated scene.
+	default_transition.instantiate();
+	default_transition->set_xfade_time(0);
+	default_transition->set_reset(true);
+	default_transition->set_advance_mode(AnimationNodeStateMachineTransition::ADVANCE_MODE_AUTO);
+	default_transition->set_switch_mode(AnimationNodeStateMachineTransition::SWITCH_MODE_IMMEDIATE);
 }
 
 ///////////////////////////////////////////////////////
 
 void AnimationNodeStateMachine::get_parameter_list(List<PropertyInfo> *r_list) const {
-	r_list->push_back(PropertyInfo(Variant::OBJECT, playback, PROPERTY_HINT_RESOURCE_TYPE, "AnimationNodeStateMachinePlayback", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ALWAYS_DUPLICATE));
+	r_list->push_back(PropertyInfo(Variant::OBJECT, playback, PROPERTY_HINT_RESOURCE_TYPE, "AnimationNodeStateMachinePlayback", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_ALWAYS_DUPLICATE)); // Don't store this object in .tres, it always needs to be made as unique object.
 	List<StringName> advance_conditions;
 	for (int i = 0; i < transitions.size(); i++) {
 		StringName ac = transitions[i].transition->get_advance_condition_name();
@@ -765,8 +1216,15 @@ Variant AnimationNodeStateMachine::get_parameter_default_value(const StringName 
 		p.instantiate();
 		return p;
 	} else {
-		return false; //advance condition
+		return false; // Advance condition.
 	}
+}
+
+bool AnimationNodeStateMachine::is_parameter_read_only(const StringName &p_parameter) const {
+	if (p_parameter == playback) {
+		return true;
+	}
+	return false;
 }
 
 void AnimationNodeStateMachine::add_node(const StringName &p_name, Ref<AnimationNode> p_node, const Vector2 &p_position) {
@@ -779,13 +1237,6 @@ void AnimationNodeStateMachine::add_node(const StringName &p_name, Ref<Animation
 	state_new.position = p_position;
 
 	states[p_name] = state_new;
-
-	Ref<AnimationNodeStateMachine> anodesm = p_node;
-
-	if (anodesm.is_valid()) {
-		anodesm->state_machine_name = p_name;
-		anodesm->prev_state_machine = this;
-	}
 
 	emit_changed();
 	emit_signal(SNAME("tree_changed"));
@@ -819,12 +1270,31 @@ void AnimationNodeStateMachine::replace_node(const StringName &p_name, Ref<Anima
 	p_node->connect("animation_node_removed", callable_mp(this, &AnimationNodeStateMachine::_animation_node_removed), CONNECT_REFERENCE_COUNTED);
 }
 
+void AnimationNodeStateMachine::set_state_machine_type(StateMachineType p_state_machine_type) {
+	state_machine_type = p_state_machine_type;
+	emit_changed();
+	emit_signal(SNAME("tree_changed"));
+	notify_property_list_changed();
+}
+
+AnimationNodeStateMachine::StateMachineType AnimationNodeStateMachine::get_state_machine_type() const {
+	return state_machine_type;
+}
+
 void AnimationNodeStateMachine::set_allow_transition_to_self(bool p_enable) {
 	allow_transition_to_self = p_enable;
 }
 
 bool AnimationNodeStateMachine::is_allow_transition_to_self() const {
 	return allow_transition_to_self;
+}
+
+void AnimationNodeStateMachine::set_reset_ends(bool p_enable) {
+	reset_ends = p_enable;
+}
+
+bool AnimationNodeStateMachine::are_ends_reset() const {
+	return reset_ends;
 }
 
 bool AnimationNodeStateMachine::can_edit_node(const StringName &p_name) const {
@@ -836,7 +1306,7 @@ bool AnimationNodeStateMachine::can_edit_node(const StringName &p_name) const {
 }
 
 Ref<AnimationNode> AnimationNodeStateMachine::get_node(const StringName &p_name) const {
-	ERR_FAIL_COND_V(!states.has(p_name), Ref<AnimationNode>());
+	ERR_FAIL_COND_V_EDMSG(!states.has(p_name), Ref<AnimationNode>(), String(p_name) + " is not found current state.");
 
 	return states[p_name].node;
 }
@@ -880,7 +1350,7 @@ void AnimationNodeStateMachine::remove_node(const StringName &p_name) {
 	}
 
 	for (int i = 0; i < transitions.size(); i++) {
-		if (transitions[i].local_from == p_name || transitions[i].local_to == p_name) {
+		if (transitions[i].from == p_name || transitions[i].to == p_name) {
 			remove_transition_by_index(i);
 			i--;
 		}
@@ -909,11 +1379,6 @@ void AnimationNodeStateMachine::rename_node(const StringName &p_name, const Stri
 	states[p_new_name] = states[p_name];
 	states.erase(p_name);
 
-	Ref<AnimationNodeStateMachine> anodesm = states[p_new_name].node;
-	if (anodesm.is_valid()) {
-		anodesm->state_machine_name = p_new_name;
-	}
-
 	_rename_transitions(p_name, p_new_name);
 
 	emit_signal(SNAME("animation_node_renamed"), get_instance_id(), p_name, p_new_name);
@@ -929,36 +1394,9 @@ void AnimationNodeStateMachine::_rename_transitions(const StringName &p_name, co
 	updating_transitions = true;
 	for (int i = 0; i < transitions.size(); i++) {
 		if (transitions[i].from == p_name) {
-			Vector<String> path = String(transitions[i].to).split("/");
-			if (path.size() > 1) {
-				if (path[0] == "..") {
-					prev_state_machine->_rename_transitions(String(state_machine_name) + "/" + p_name, String(state_machine_name) + "/" + p_new_name);
-				} else {
-					((Ref<AnimationNodeStateMachine>)states[transitions[i].local_to].node)->_rename_transitions("../" + p_name, "../" + p_new_name);
-				}
-			}
-
-			if (transitions[i].local_from == p_name) {
-				transitions.write[i].local_from = p_new_name;
-			}
-
 			transitions.write[i].from = p_new_name;
 		}
-
 		if (transitions[i].to == p_name) {
-			Vector<String> path = String(transitions[i].from).split("/");
-			if (path.size() > 1) {
-				if (path[0] == "..") {
-					prev_state_machine->_rename_transitions(String(state_machine_name) + "/" + p_name, String(state_machine_name) + "/" + p_new_name);
-				} else {
-					((Ref<AnimationNodeStateMachine>)states[transitions[i].local_from].node)->_rename_transitions("../" + p_name, "../" + p_new_name);
-				}
-			}
-
-			if (transitions[i].local_to == p_name) {
-				transitions.write[i].local_to = p_new_name;
-			}
-
 			transitions.write[i].to = p_new_name;
 		}
 	}
@@ -977,16 +1415,27 @@ void AnimationNodeStateMachine::get_node_list(List<StringName> *r_nodes) const {
 	}
 }
 
-AnimationNodeStateMachine *AnimationNodeStateMachine::get_prev_state_machine() const {
-	return prev_state_machine;
+bool AnimationNodeStateMachine::has_transition(const StringName &p_from, const StringName &p_to) const {
+	for (int i = 0; i < transitions.size(); i++) {
+		if (transitions[i].from == p_from && transitions[i].to == p_to) {
+			return true;
+		}
+	}
+	return false;
 }
 
-bool AnimationNodeStateMachine::has_transition(const StringName &p_from, const StringName &p_to) const {
-	StringName from = _get_shortest_path(p_from);
-	StringName to = _get_shortest_path(p_to);
-
+bool AnimationNodeStateMachine::has_transition_from(const StringName &p_from) const {
 	for (int i = 0; i < transitions.size(); i++) {
-		if (transitions[i].from == from && transitions[i].to == to) {
+		if (transitions[i].from == p_from) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool AnimationNodeStateMachine::has_transition_to(const StringName &p_to) const {
+	for (int i = 0; i < transitions.size(); i++) {
+		if (transitions[i].to == p_to) {
 			return true;
 		}
 	}
@@ -994,33 +1443,36 @@ bool AnimationNodeStateMachine::has_transition(const StringName &p_from, const S
 }
 
 int AnimationNodeStateMachine::find_transition(const StringName &p_from, const StringName &p_to) const {
-	StringName from = _get_shortest_path(p_from);
-	StringName to = _get_shortest_path(p_to);
-
 	for (int i = 0; i < transitions.size(); i++) {
-		if (transitions[i].from == from && transitions[i].to == to) {
+		if (transitions[i].from == p_from && transitions[i].to == p_to) {
 			return i;
 		}
 	}
 	return -1;
 }
 
-bool AnimationNodeStateMachine::_can_connect(const StringName &p_name, Vector<AnimationNodeStateMachine *> p_parents) {
-	if (p_parents.is_empty()) {
-		AnimationNodeStateMachine *prev = this;
-		while (prev != nullptr) {
-			p_parents.push_back(prev);
-			prev = prev->prev_state_machine;
+Vector<int> AnimationNodeStateMachine::find_transition_from(const StringName &p_from) const {
+	Vector<int> ret;
+	for (int i = 0; i < transitions.size(); i++) {
+		if (transitions[i].from == p_from) {
+			ret.push_back(i);
 		}
 	}
+	return ret;
+}
 
-	if (states.has(p_name)) {
-		Ref<AnimationNodeStateMachine> anodesm = states[p_name].node;
-
-		if (anodesm.is_valid() && p_parents.find(anodesm.ptr()) != -1) {
-			return false;
+Vector<int> AnimationNodeStateMachine::find_transition_to(const StringName &p_to) const {
+	Vector<int> ret;
+	for (int i = 0; i < transitions.size(); i++) {
+		if (transitions[i].to == p_to) {
+			ret.push_back(i);
 		}
+	}
+	return ret;
+}
 
+bool AnimationNodeStateMachine::_can_connect(const StringName &p_name) {
+	if (states.has(p_name)) {
 		return true;
 	}
 
@@ -1031,48 +1483,7 @@ bool AnimationNodeStateMachine::_can_connect(const StringName &p_name, Vector<An
 		return false;
 	}
 
-	if (path[0] == "..") {
-		if (prev_state_machine != nullptr) {
-			return prev_state_machine->_can_connect(node_name.replace_first("../", ""), p_parents);
-		}
-	} else if (states.has(path[0])) {
-		Ref<AnimationNodeStateMachine> anodesm = states[path[0]].node;
-		if (anodesm.is_valid()) {
-			return anodesm->_can_connect(node_name.replace_first(path[0] + "/", ""), p_parents);
-		}
-	}
-
 	return false;
-}
-
-StringName AnimationNodeStateMachine::_get_shortest_path(const StringName &p_path) const {
-	// If p_path is something like StateMachine/../StateMachine2/State1,
-	// the result will be StateMachine2/State1. This avoid duplicate
-	// transitions when using add_transition. eg, this two calls is the same:
-	//
-	// add_transition("State1", "StateMachine/../State2", tr)
-	// add_transition("State1", "State2", tr)
-	//
-	// but the second call must be invalid because the transition already exists
-
-	Vector<String> path = String(p_path).split("/");
-	Vector<String> new_path;
-
-	for (int i = 0; i < path.size(); i++) {
-		if (i > 0 && path[i] == ".." && new_path[i - 1] != "..") {
-			new_path.remove_at(i - 1);
-		} else {
-			new_path.push_back(path[i]);
-		}
-	}
-
-	String result;
-	for (int i = 0; i < new_path.size(); i++) {
-		result += new_path[i] + "/";
-	}
-	result.remove_at(result.length() - 1);
-
-	return result;
 }
 
 void AnimationNodeStateMachine::add_transition(const StringName &p_from, const StringName &p_to, const Ref<AnimationNodeStateMachineTransition> &p_transition) {
@@ -1080,60 +1491,26 @@ void AnimationNodeStateMachine::add_transition(const StringName &p_from, const S
 		return;
 	}
 
-	StringName from = _get_shortest_path(p_from);
-	StringName to = _get_shortest_path(p_to);
-	Vector<String> path_from = String(from).split("/");
-	Vector<String> path_to = String(to).split("/");
-
-	ERR_FAIL_COND(from == end_node || to == start_node);
-	ERR_FAIL_COND(from == to);
-	ERR_FAIL_COND(!_can_connect(from));
-	ERR_FAIL_COND(!_can_connect(to));
+	ERR_FAIL_COND(p_from == end_node || p_to == start_node);
+	ERR_FAIL_COND(p_from == p_to);
+	ERR_FAIL_COND(!_can_connect(p_from));
+	ERR_FAIL_COND(!_can_connect(p_to));
 	ERR_FAIL_COND(p_transition.is_null());
 
 	for (int i = 0; i < transitions.size(); i++) {
-		ERR_FAIL_COND(transitions[i].from == from && transitions[i].to == to);
-	}
-
-	if (path_from.size() > 1 || path_to.size() > 1) {
-		ERR_FAIL_COND(path_from[0] == path_to[0]);
+		ERR_FAIL_COND(transitions[i].from == p_from && transitions[i].to == p_to);
 	}
 
 	updating_transitions = true;
 
-	StringName local_from = String(from).get_slicec('/', 0);
-	StringName local_to = String(to).get_slicec('/', 0);
-	local_from = local_from == ".." ? "Start" : local_from;
-	local_to = local_to == ".." ? "End" : local_to;
-
 	Transition tr;
-	tr.from = from;
-	tr.to = to;
-	tr.local_from = local_from;
-	tr.local_to = local_to;
+	tr.from = p_from;
+	tr.to = p_to;
 	tr.transition = p_transition;
 
 	tr.transition->connect("advance_condition_changed", callable_mp(this, &AnimationNodeStateMachine::_tree_changed), CONNECT_REFERENCE_COUNTED);
 
 	transitions.push_back(tr);
-
-	// do recursive
-	if (path_from.size() > 1) {
-		StringName local_path = String(from).replace_first(path_from[0] + "/", "");
-		if (path_from[0] == "..") {
-			prev_state_machine->add_transition(local_path, String(state_machine_name) + "/" + to, p_transition);
-		} else {
-			((Ref<AnimationNodeStateMachine>)states[path_from[0]].node)->add_transition(local_path, "../" + to, p_transition);
-		}
-	}
-	if (path_to.size() > 1) {
-		StringName local_path = String(to).replace_first(path_to[0] + "/", "");
-		if (path_to[0] == "..") {
-			prev_state_machine->add_transition(String(state_machine_name) + "/" + from, local_path, p_transition);
-		} else {
-			((Ref<AnimationNodeStateMachine>)states[path_to[0]].node)->add_transition("../" + from, local_path, p_transition);
-		}
-	}
 
 	updating_transitions = false;
 }
@@ -1153,16 +1530,23 @@ StringName AnimationNodeStateMachine::get_transition_to(int p_transition) const 
 	return transitions[p_transition].to;
 }
 
+bool AnimationNodeStateMachine::is_transition_across_group(int p_transition) const {
+	ERR_FAIL_INDEX_V(p_transition, transitions.size(), false);
+	if (get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
+		if (transitions[p_transition].from == "Start" || transitions[p_transition].to == "End") {
+			return true;
+		}
+	}
+	return false;
+}
+
 int AnimationNodeStateMachine::get_transition_count() const {
 	return transitions.size();
 }
 
 void AnimationNodeStateMachine::remove_transition(const StringName &p_from, const StringName &p_to) {
-	StringName from = _get_shortest_path(p_from);
-	StringName to = _get_shortest_path(p_to);
-
 	for (int i = 0; i < transitions.size(); i++) {
-		if (transitions[i].from == from && transitions[i].to == to) {
+		if (transitions[i].from == p_from && transitions[i].to == p_to) {
 			remove_transition_by_index(i);
 			return;
 		}
@@ -1181,20 +1565,6 @@ void AnimationNodeStateMachine::remove_transition_by_index(const int p_transitio
 	List<Vector<String>> paths;
 	paths.push_back(path_from);
 	paths.push_back(path_to);
-
-	for (List<Vector<String>>::Element *E = paths.front(); E; E = E->next()) {
-		if (E->get()[0].size() > 1) {
-			if (E->get()[0] == "..") {
-				prev_state_machine->_remove_transition(tr.transition);
-			} else if (states.has(E->get()[0])) {
-				Ref<AnimationNodeStateMachine> anodesm = states[E->get()[0]].node;
-
-				if (anodesm.is_valid()) {
-					anodesm->_remove_transition(tr.transition);
-				}
-			}
-		}
-	}
 }
 
 void AnimationNodeStateMachine::_remove_transition(const Ref<AnimationNodeStateMachineTransition> p_transition) {
@@ -1214,30 +1584,21 @@ Vector2 AnimationNodeStateMachine::get_graph_offset() const {
 	return graph_offset;
 }
 
-double AnimationNodeStateMachine::process(double p_time, bool p_seek, bool p_is_external_seeking) {
+double AnimationNodeStateMachine::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
 	Ref<AnimationNodeStateMachinePlayback> playback_new = get_parameter(playback);
 	ERR_FAIL_COND_V(playback_new.is_null(), 0.0);
-
-	return playback_new->process(this, p_time, p_seek, p_is_external_seeking);
+	playback_new->_set_grouped(state_machine_type == STATE_MACHINE_TYPE_GROUPED);
+	if (p_test_only) {
+		playback_new = playback_new->duplicate(); // Don't process original when testing.
+	}
+	return playback_new->process(base_path, this, p_time, p_seek, p_is_external_seeking, p_test_only);
 }
 
 String AnimationNodeStateMachine::get_caption() const {
 	return "StateMachine";
 }
 
-bool AnimationNodeStateMachine::has_local_transition(const StringName &p_from, const StringName &p_to) const {
-	StringName from = _get_shortest_path(p_from);
-	StringName to = _get_shortest_path(p_to);
-
-	for (int i = 0; i < transitions.size(); i++) {
-		if (transitions[i].local_from == from && transitions[i].local_to == to) {
-			return true;
-		}
-	}
-	return false;
-}
-
-Ref<AnimationNode> AnimationNodeStateMachine::get_child_by_name(const StringName &p_name) {
+Ref<AnimationNode> AnimationNodeStateMachine::get_child_by_name(const StringName &p_name) const {
 	return get_node(p_name);
 }
 
@@ -1302,10 +1663,6 @@ bool AnimationNodeStateMachine::_get(const StringName &p_name, Variant &r_ret) c
 			String from = transitions[i].from;
 			String to = transitions[i].to;
 
-			if (from.get_slicec('/', 0) == ".." || to.get_slicec('/', 0) == "..") {
-				continue;
-			}
-
 			trans.push_back(from);
 			trans.push_back(to);
 			trans.push_back(transitions[i].transition);
@@ -1335,6 +1692,18 @@ void AnimationNodeStateMachine::_get_property_list(List<PropertyInfo> *p_list) c
 
 	p_list->push_back(PropertyInfo(Variant::ARRAY, "transitions", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
 	p_list->push_back(PropertyInfo(Variant::VECTOR2, "graph_offset", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
+
+	for (PropertyInfo &E : *p_list) {
+		_validate_property(E);
+	}
+}
+
+void AnimationNodeStateMachine::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "allow_transition_to_self" || p_property.name == "reset_ends") {
+		if (state_machine_type == STATE_MACHINE_TYPE_GROUPED) {
+			p_property.usage = PROPERTY_USAGE_NONE;
+		}
+	}
 }
 
 void AnimationNodeStateMachine::reset_state() {
@@ -1410,10 +1779,22 @@ void AnimationNodeStateMachine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_graph_offset", "offset"), &AnimationNodeStateMachine::set_graph_offset);
 	ClassDB::bind_method(D_METHOD("get_graph_offset"), &AnimationNodeStateMachine::get_graph_offset);
 
+	ClassDB::bind_method(D_METHOD("set_state_machine_type", "state_machine_type"), &AnimationNodeStateMachine::set_state_machine_type);
+	ClassDB::bind_method(D_METHOD("get_state_machine_type"), &AnimationNodeStateMachine::get_state_machine_type);
+
 	ClassDB::bind_method(D_METHOD("set_allow_transition_to_self", "enable"), &AnimationNodeStateMachine::set_allow_transition_to_self);
 	ClassDB::bind_method(D_METHOD("is_allow_transition_to_self"), &AnimationNodeStateMachine::is_allow_transition_to_self);
 
+	ClassDB::bind_method(D_METHOD("set_reset_ends", "enable"), &AnimationNodeStateMachine::set_reset_ends);
+	ClassDB::bind_method(D_METHOD("are_ends_reset"), &AnimationNodeStateMachine::are_ends_reset);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "state_machine_type", PROPERTY_HINT_ENUM, "Root,Nested,Grouped"), "set_state_machine_type", "get_state_machine_type");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_transition_to_self"), "set_allow_transition_to_self", "is_allow_transition_to_self");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "reset_ends"), "set_reset_ends", "are_ends_reset");
+
+	BIND_ENUM_CONSTANT(STATE_MACHINE_TYPE_ROOT);
+	BIND_ENUM_CONSTANT(STATE_MACHINE_TYPE_NESTED);
+	BIND_ENUM_CONSTANT(STATE_MACHINE_TYPE_GROUPED);
 }
 
 AnimationNodeStateMachine::AnimationNodeStateMachine() {

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -100,87 +100,22 @@ public:
 VARIANT_ENUM_CAST(AnimationNodeStateMachineTransition::SwitchMode)
 VARIANT_ENUM_CAST(AnimationNodeStateMachineTransition::AdvanceMode)
 
-class AnimationNodeStateMachine;
-
-class AnimationNodeStateMachinePlayback : public Resource {
-	GDCLASS(AnimationNodeStateMachinePlayback, Resource);
-
-	friend class AnimationNodeStateMachine;
-
-	struct AStarCost {
-		float distance = 0.0;
-		StringName prev;
-	};
-
-	struct Transition {
-		StringName from;
-		StringName to;
-		StringName next;
-	};
-
-	double len_fade_from = 0.0;
-	double pos_fade_from = 0.0;
-
-	double len_current = 0.0;
-	double pos_current = 0.0;
-	bool end_loop = false;
-
-	StringName current;
-	Transition current_transition;
-	Ref<Curve> current_curve;
-	bool force_auto_advance = false;
-
-	StringName fading_from;
-	float fading_time = 0.0;
-	float fading_pos = 0.0;
-
-	Vector<StringName> path;
-	bool playing = false;
-
-	StringName start_request;
-	StringName travel_request;
-	bool reset_request = false;
-	bool reset_request_on_teleport = false;
-	bool next_request = false;
-	bool stop_request = false;
-
-	bool _travel(AnimationNodeStateMachine *p_state_machine, const StringName &p_travel);
-	void _start(const StringName &p_state);
-	double _process(AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking);
-
-	double process(AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking);
-
-	bool _check_advance_condition(const Ref<AnimationNodeStateMachine> p_state_machine, const Ref<AnimationNodeStateMachineTransition> p_transition) const;
-
-protected:
-	static void _bind_methods();
-
-public:
-	void travel(const StringName &p_state, bool p_reset_on_teleport = true);
-	void start(const StringName &p_state, bool p_reset = true);
-	void next();
-	void stop();
-	bool is_playing() const;
-	StringName get_current_node() const;
-	StringName get_fading_from_node() const;
-	Vector<StringName> get_travel_path() const;
-	float get_current_play_pos() const;
-	float get_current_length() const;
-
-	float get_fade_from_play_pos() const;
-	float get_fade_from_length() const;
-
-	float get_fading_time() const;
-	float get_fading_pos() const;
-
-	AnimationNodeStateMachinePlayback();
-};
+class AnimationNodeStateMachinePlayback;
 
 class AnimationNodeStateMachine : public AnimationRootNode {
 	GDCLASS(AnimationNodeStateMachine, AnimationRootNode);
 
+public:
+	enum StateMachineType {
+		STATE_MACHINE_TYPE_ROOT,
+		STATE_MACHINE_TYPE_NESTED,
+		STATE_MACHINE_TYPE_GROUPED,
+	};
+
 private:
 	friend class AnimationNodeStateMachinePlayback;
+
+	StateMachineType state_machine_type = STATE_MACHINE_TYPE_ROOT;
 
 	struct State {
 		Ref<AnimationRootNode> node;
@@ -189,28 +124,24 @@ private:
 
 	HashMap<StringName, State> states;
 	bool allow_transition_to_self = false;
+	bool reset_ends = false;
 
 	struct Transition {
 		StringName from;
 		StringName to;
-		StringName local_from;
-		StringName local_to;
 		Ref<AnimationNodeStateMachineTransition> transition;
 	};
 
 	Vector<Transition> transitions;
 
 	StringName playback = "playback";
-	StringName state_machine_name;
-	AnimationNodeStateMachine *prev_state_machine = nullptr;
 	bool updating_transitions = false;
 
 	Vector2 graph_offset;
 
 	void _remove_transition(const Ref<AnimationNodeStateMachineTransition> p_transition);
 	void _rename_transitions(const StringName &p_name, const StringName &p_new_name);
-	bool _can_connect(const StringName &p_name, Vector<AnimationNodeStateMachine *> p_parents = Vector<AnimationNodeStateMachine *>());
-	StringName _get_shortest_path(const StringName &p_path) const;
+	bool _can_connect(const StringName &p_name);
 
 protected:
 	static void _bind_methods();
@@ -218,6 +149,8 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	void _validate_property(PropertyInfo &p_property) const;
+
 	bool _check_advance_condition(const Ref<AnimationNodeStateMachine> p_state_machine, const Ref<AnimationNodeStateMachineTransition> p_transition) const;
 
 	virtual void _tree_changed() override;
@@ -232,6 +165,7 @@ public:
 
 	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
+	virtual bool is_parameter_read_only(const StringName &p_parameter) const override;
 
 	void add_node(const StringName &p_name, Ref<AnimationNode> p_node, const Vector2 &p_position = Vector2());
 	void replace_node(const StringName &p_name, Ref<AnimationNode> p_node);
@@ -248,32 +182,164 @@ public:
 	virtual void get_child_nodes(List<ChildNode> *r_child_nodes) override;
 
 	bool has_transition(const StringName &p_from, const StringName &p_to) const;
-	bool has_local_transition(const StringName &p_from, const StringName &p_to) const;
+	bool has_transition_from(const StringName &p_from) const;
+	bool has_transition_to(const StringName &p_to) const;
 	int find_transition(const StringName &p_from, const StringName &p_to) const;
+	Vector<int> find_transition_from(const StringName &p_from) const;
+	Vector<int> find_transition_to(const StringName &p_to) const;
 	void add_transition(const StringName &p_from, const StringName &p_to, const Ref<AnimationNodeStateMachineTransition> &p_transition);
 	Ref<AnimationNodeStateMachineTransition> get_transition(int p_transition) const;
 	StringName get_transition_from(int p_transition) const;
 	StringName get_transition_to(int p_transition) const;
 	int get_transition_count() const;
+	bool is_transition_across_group(int p_transition) const;
 	void remove_transition_by_index(const int p_transition);
 	void remove_transition(const StringName &p_from, const StringName &p_to);
+
+	void set_state_machine_type(StateMachineType p_state_machine_type);
+	StateMachineType get_state_machine_type() const;
 
 	void set_allow_transition_to_self(bool p_enable);
 	bool is_allow_transition_to_self() const;
 
-	bool can_edit_node(const StringName &p_name) const;
+	void set_reset_ends(bool p_enable);
+	bool are_ends_reset() const;
 
-	AnimationNodeStateMachine *get_prev_state_machine() const;
+	bool can_edit_node(const StringName &p_name) const;
 
 	void set_graph_offset(const Vector2 &p_offset);
 	Vector2 get_graph_offset() const;
 
-	virtual double process(double p_time, bool p_seek, bool p_is_external_seeking) override;
+	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 	virtual String get_caption() const override;
 
-	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) override;
+	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;
 
 	AnimationNodeStateMachine();
+};
+
+VARIANT_ENUM_CAST(AnimationNodeStateMachine::StateMachineType);
+
+class AnimationNodeStateMachinePlayback : public Resource {
+	GDCLASS(AnimationNodeStateMachinePlayback, Resource);
+
+	friend class AnimationNodeStateMachine;
+
+	struct AStarCost {
+		float distance = 0.0;
+		StringName prev;
+	};
+
+	struct TransitionInfo {
+		StringName from;
+		StringName to;
+		StringName next;
+	};
+
+	struct NextInfo {
+		StringName node;
+		double xfade;
+		Ref<Curve> curve;
+		AnimationNodeStateMachineTransition::SwitchMode switch_mode;
+		bool is_reset;
+	};
+
+	struct ChildStateMachineInfo {
+		Ref<AnimationNodeStateMachinePlayback> playback;
+		Vector<StringName> path;
+		bool is_reset = false;
+	};
+
+	Ref<AnimationNodeStateMachineTransition> default_transition;
+	String base_path;
+
+	double len_fade_from = 0.0;
+	double pos_fade_from = 0.0;
+
+	double len_current = 0.0;
+	double pos_current = 0.0;
+
+	StringName current;
+	Ref<Curve> current_curve;
+
+	Ref<AnimationNodeStateMachineTransition> group_start_transition;
+	Ref<AnimationNodeStateMachineTransition> group_end_transition;
+
+	StringName fading_from;
+	float fading_time = 0.0;
+	float fading_pos = 0.0;
+
+	Vector<StringName> path;
+	bool playing = false;
+
+	StringName start_request;
+	StringName travel_request;
+	bool reset_request = false;
+	bool reset_request_on_teleport = false;
+	bool _reset_request_for_fading_from = false;
+	bool next_request = false;
+	bool stop_request = false;
+	bool teleport_request = false;
+
+	bool is_grouped = false;
+
+	void _travel_main(const StringName &p_state, bool p_reset_on_teleport = true);
+	void _start_main(const StringName &p_state, bool p_reset = true);
+	void _next_main();
+	void _stop_main();
+
+	bool _make_travel_path(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, Vector<StringName> &r_path, bool p_test_only);
+	String _validate_path(AnimationNodeStateMachine *p_state_machine, const String &p_path);
+	bool _travel(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, bool p_test_only);
+	void _start(AnimationNodeStateMachine *p_state_machine);
+
+	void _clear_path_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_test_only);
+	bool _travel_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const String &p_path, bool p_is_allow_transition_to_self, bool p_is_parent_same_state, bool p_test_only);
+	void _start_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const String &p_path, bool p_test_only);
+
+	double process(const String &p_base_path, AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only);
+	double _process(const String &p_base_path, AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only);
+
+	bool _check_advance_condition(const Ref<AnimationNodeStateMachine> p_state_machine, const Ref<AnimationNodeStateMachineTransition> p_transition) const;
+	bool _transition_to_next_recursive(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_test_only);
+	NextInfo _find_next(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine) const;
+	Ref<AnimationNodeStateMachineTransition> _check_group_transition(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const AnimationNodeStateMachine::Transition &p_transition, Ref<AnimationNodeStateMachine> &r_state_machine, bool &r_bypass) const;
+	bool _can_transition_to_next(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, NextInfo p_next, bool p_test_only);
+
+	void _set_current(AnimationNodeStateMachine *p_state_machine, const StringName &p_state);
+	void _set_grouped(bool p_is_grouped);
+	void _set_base_path(const String &p_base_path);
+	Ref<AnimationNodeStateMachinePlayback> _get_parent_playback(AnimationTree *p_tree) const;
+	Ref<AnimationNodeStateMachine> _get_parent_state_machine(AnimationTree *p_tree) const;
+	Ref<AnimationNodeStateMachineTransition> _get_group_start_transition() const;
+	Ref<AnimationNodeStateMachineTransition> _get_group_end_transition() const;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void travel(const StringName &p_state, bool p_reset_on_teleport = true);
+	void start(const StringName &p_state, bool p_reset = true);
+	void next();
+	void stop();
+	bool is_playing() const;
+	bool is_end() const;
+	StringName get_current_node() const;
+	StringName get_fading_from_node() const;
+	Vector<StringName> get_travel_path() const;
+	float get_current_play_pos() const;
+	float get_current_length() const;
+
+	float get_fade_from_play_pos() const;
+	float get_fade_from_length() const;
+
+	float get_fading_time() const;
+	float get_fading_pos() const;
+
+	void clear_path();
+	void push_path(const StringName &p_state);
+
+	AnimationNodeStateMachinePlayback();
 };
 
 #endif // ANIMATION_NODE_STATE_MACHINE_H


### PR DESCRIPTION
~~Prerequisite #75111.~~ Now it has been included in this.

- Fixed #71562

This PR replaces/removes the previous broken nested StateMachine behavior. Previously, StateMachine stored pointers to AnimationNode within child StateMachines. However, storing pointers to other Resources within a Resource was unsafe because it could lead to duplicated processing within the animation blending process. It was causing problems similar to #22887.

This PR does not store pointers directly, but generates paths to PlaybackObject so that the child (or parent) state machine pointers are accessed only at the moment of the blending process.

- Fixed #58822
- Fixed #73643

Also, make the PlaybackObject readonly and it is not stored in tres. This prevents the PlaybackObject from having the same reference, since the PlaybackObject is created with a unique value each time.

- Fixed #45635

## Make the StateMachine to calculate the remain time at the transition to End state

Until now, the remain time was always treated as 1 second until the End state was reached. This fix will allow the fade-out to be handled correctly when using  the StateMachine from the outside such as BlendTree.

- Fixed #73648
- Fixed #74752

---

## Implement three types of StateMachine for different use cases

### RootStateMachine

This is the default state machine. The most standard StateMachine, applicable to most use cases.

![image](https://user-images.githubusercontent.com/61938263/230419411-1162bb30-6a15-4e97-96fd-fb5ae3e175aa.png)

When a seek to the beginning is commanded, a transition is made to StartState.

https://user-images.githubusercontent.com/61938263/230428527-1adfb466-6c13-4ae5-b99a-e95926e00e42.mp4

- Fixed #57223
- Fixed #68986
- Fixed #69063

And remain time is calculated only when transitioning to End state.

### NestedStateMachine

It is useful to list several animations, such as StateMnachine with NodeTransition. You can use this like AnyState. Seeking to the beginning is treated as seeking to the beginning of the animation in the current state.

![image](https://user-images.githubusercontent.com/61938263/230419516-d0798177-e248-4244-9768-06b9a9cbbf21.png)

The remain time is calculated not only at the transition to End state, but also when the animation is stopped due to a state with no transition.

### GroupedStateMachine

This is useful for organizing the StateMachine so that it does not make it too messy.

With some restrictions, GroupedStateMachine allows direct travel between StateMachines.

https://user-images.githubusercontent.com/61938263/230428319-227de9b8-778a-43b9-a54b-0bb913eee97b.mp4

- Fixed #62576.

#### Restrictions

Users cannot directly request play/travel to a StateMachinePlayback of GroupedStateMachine, since GroupedStateMachine must be processed by the parent StateMachinePlayback.

This means that a GroupedStateMachine must have a Root/Nested StateMachine as a parent or ancestor.

For example, you can play/travel in the parent Root/Nested StateMachine as follows:

```gdscript
root_playback.travel("Combo/Combo1")
```

The Start/End transition of a GroupedStateMachine does not allow parameters to be set. This is because the transitions are referenced as shown in the following figure:

![image](https://user-images.githubusercontent.com/61938263/230419723-9cc29317-a20d-4cd1-99d6-61848bbace33.png)

Then, the number of transitions to/from the GroupedStateMachine and the number of internal Start/End transitions must be matched.

It is also recommended that no more than one transition be made to a GroupedStateMachine. This is because there is currently only one input port to the StateMachine, so if there are two or more transitions, it is not possible to specify the reference for each.

However, this problem can be solved in the future by improving the StateMachine to have more than two input ports, or by increasing the number of StartNodes, etc.

Incidentally, to ensure that the reference to transition is correct, direct transitions to the Start or End State of a GroupedStateMachine is not allowed.

```gdscript
root_playback.travel("Combo/Start") # It's not alllowed.
```

However, for convenience, if a travel is specified to a GroupedStateMachine, it is implicitly replaced by a travel to the next State after Start if a Start transition exists.

```gdscript
root_playback.travel("Combo")
root_playback.travel("Combo/Combo1") # Same result with above.
```

And, of course, if the priority depend on the ASter algorithm, the equality of travel path is not guaranteed before and after they are grouped.

## TODO in the future

- Update document
- Optimize to cache parent-child relationships for path retrieval as like #75627
- Increase the number of input ports or StartNodes for grouped state machines
- Allow grouping using the GUI but the priority of this is low because the equality of transitions before and after can't be guaranteed without doing above (increasing port) first

[state_machine_improvement_demo.zip](https://github.com/godotengine/godot/files/13993286/state_machine_improvement_demo.zip)
[state_machine_improvement_demo_2.zip](https://github.com/godotengine/godot/files/13993496/state_machine_improvement_demo_2.zip)

