### PR TITLE
Update sibling indices after a node is removed.

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1215,6 +1215,10 @@ void Node::remove_child(Node *p_child) {
 	child_count = data.children.size();
 	children = data.children.ptrw();
 
+	for (int i = idx; i < child_count; i++) {
+		children[i]->data.index = i;
+	}
+
 	notification(NOTIFICATION_CHILD_ORDER_CHANGED);
 	emit_signal(SNAME("child_order_changed"));
 


### PR DESCRIPTION
With change 104392e the code to update node indices on removal was erronously removed. The out of date indices would cause crashes while selecting nodes in a graph editor (e.g. animation tree) and selected nodes are oftern pushed to beginning or end of the child list for the parent.