### PR TITLE
Fix libwebp Node struct shadowing Godot's Node class in MSVC debugger

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -361,6 +361,8 @@ Files extracted from upstream source:
 - `src/` and `sharpyuv/` except from: `.am`, `.rc` and `.in` files
 - `AUTHORS`, `COPYING`, `PATENTS`
 
+Patch `godot-node-debug-fix.patch` workarounds shadowing of godot's Node class in the MSVC debugger.
+
 
 ## mbedtls
 

--- a/thirdparty/libwebp/godot-node-debug-fix.patch
+++ b/thirdparty/libwebp/godot-node-debug-fix.patch
@@ -1,0 +1,16 @@
+diff --git a/thirdparty/libwebp/src/enc/quant_enc.c b/thirdparty/libwebp/src/enc/quant_enc.c
+index 6d8202d277..8f9a3c8668 100644
+--- a/src/enc/quant_enc.c
++++ b/src/enc/quant_enc.c
+@@ -556,6 +556,11 @@ static void AddScore(VP8ModeScore* WEBP_RESTRICT const dst,
+ //------------------------------------------------------------------------------
+ // Performs trellis-optimized quantization.
+ 
++// -- GODOT start --
++// Prevents Visual Studio debugger from using this Node struct in place of the Godot Node class.
++#define Node Node_libwebp_quant
++// -- GODOT end --
++
+ // Trellis node
+ typedef struct {
+   int8_t prev;            // best previous node

--- a/thirdparty/libwebp/src/enc/quant_enc.c
+++ b/thirdparty/libwebp/src/enc/quant_enc.c
@@ -556,6 +556,11 @@ static void AddScore(VP8ModeScore* WEBP_RESTRICT const dst,
 //------------------------------------------------------------------------------
 // Performs trellis-optimized quantization.
 
+// -- GODOT start --
+// Prevents Visual Studio debugger from using this Node struct in place of the Godot Node class.
+#define Node Node_libwebp_quant
+// -- GODOT end --
+
 // Trellis node
 typedef struct {
   int8_t prev;            // best previous node


### PR DESCRIPTION
I was having an issue when debugging on Visual Studio that sometimes the struct Node contents from libwebp quant_enc.c such as `int8_t prev` were showing up in the debugger instead of the godot Node class (for example, when clicking on the parent of Node3D to access the node's name in the debugger).

This renames the struct using a `#define`. it should have no effect, other than to prevent a conflicting/shadowing `struct Node` from showing up in the debug data.