### PR TITLE
Make `SyntaxHighlighter::get_text_edit` a const function

### DIFF
--- a/doc/classes/SyntaxHighlighter.xml
+++ b/doc/classes/SyntaxHighlighter.xml
@@ -58,7 +58,7 @@
 				This will color columns 0-4 red, and columns 5-eol in green.
 			</description>
 		</method>
-		<method name="get_text_edit">
+		<method name="get_text_edit" qualifiers="const">
 			<return type="TextEdit" />
 			<description>
 				Returns the associated [TextEdit] node.

--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -99,7 +99,7 @@ void SyntaxHighlighter::set_text_edit(TextEdit *p_text_edit) {
 	update_cache();
 }
 
-TextEdit *SyntaxHighlighter::get_text_edit() {
+TextEdit *SyntaxHighlighter::get_text_edit() const {
 	return text_edit;
 }
 

--- a/scene/resources/syntax_highlighter.h
+++ b/scene/resources/syntax_highlighter.h
@@ -64,7 +64,7 @@ public:
 	virtual void _update_cache() {}
 
 	void set_text_edit(TextEdit *p_text_edit);
-	TextEdit *get_text_edit();
+	TextEdit *get_text_edit() const;
 
 	SyntaxHighlighter() {}
 	virtual ~SyntaxHighlighter() {}


### PR DESCRIPTION
fixes #75773

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
