### PR TITLE
Set font sizes for various styles in editor output panel

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -91,7 +91,12 @@ void EditorLog::_update_theme() {
 		log->add_theme_font_override("mono_font", mono_font);
 	}
 
-	log->add_theme_font_size_override("normal_font_size", get_theme_font_size(SNAME("output_source_size"), SNAME("EditorFonts")));
+	const int font_size = get_theme_font_size(SNAME("output_source_size"), SNAME("EditorFonts"));
+	log->add_theme_font_size_override("normal_font_size", font_size);
+	log->add_theme_font_size_override("bold_font_size", font_size);
+	log->add_theme_font_size_override("italics_font_size", font_size);
+	log->add_theme_font_size_override("mono_font_size", font_size);
+
 	log->add_theme_color_override("selection_color", get_theme_color(SNAME("accent_color"), SNAME("Editor")) * Color(1, 1, 1, 0.4));
 
 	type_filter_map[MSG_TYPE_STD]->toggle_button->set_icon(get_theme_icon(SNAME("Popup"), SNAME("EditorIcons")));


### PR DESCRIPTION
Font size was only set for "normal font" in the Output panel. So you can see something like this when editor's main font size is changed, the count uses bold style:

![ksnip_20230407-200101](https://user-images.githubusercontent.com/372476/230607336-0fc9a52f-0f00-492c-94d7-bdcffce4c365.png)
