### PR TITLE
Fix deserializing resource usage debug data

### DIFF
--- a/servers/debugger/servers_debugger.cpp
+++ b/servers/debugger/servers_debugger.cpp
@@ -56,15 +56,17 @@ Array ServersDebugger::ResourceUsage::serialize() {
 bool ServersDebugger::ResourceUsage::deserialize(const Array &p_arr) {
 	CHECK_SIZE(p_arr, 1, "ResourceUsage");
 	uint32_t size = p_arr[0];
-	CHECK_SIZE(p_arr, size, "ResourceUsage");
-	int idx = 1;
-	for (uint32_t i = 0; i < size / 4; i++) {
+	ERR_FAIL_COND_V(size % 4, false);
+	CHECK_SIZE(p_arr, 1 + size, "ResourceUsage");
+	uint32_t idx = 1;
+	while (idx < 1 + size) {
 		ResourceInfo info;
 		info.path = p_arr[idx];
 		info.format = p_arr[idx + 1];
 		info.type = p_arr[idx + 2];
 		info.vram = p_arr[idx + 3];
 		infos.push_back(info);
+		idx += 4;
 	}
 	CHECK_END(p_arr, idx, "ResourceUsage");
 	return true;


### PR DESCRIPTION
Fixes Video RAM usage listing the same (first) texture repeatedly instead of the actual data:
|Before|After|
|-|-|
|![lcvxXT5BMC](https://user-images.githubusercontent.com/9283098/230627975-ed81b18b-f6ee-4b23-81aa-219246e39c3f.png)|![godot windows editor dev x86_64_HXhF0ZzDkQ](https://user-images.githubusercontent.com/9283098/230627986-965e034b-b135-402e-b19b-e70a5fa3fb9f.png)|

_Bugsquad edit fixes: https://github.com/godotengine/godot/issues/76110_