### PR TITLE
Tweak environment in the Advanced Import Settings dialog

### DIFF
--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1653,6 +1653,28 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 		camera->set_attributes(camera_attributes);
 	}
 
+	// Use a grayscale gradient sky to avoid skewing the preview towards a specific color,
+	// but still allow shaded areas to be easily distinguished (using the ambient and reflected light).
+	// This also helps the user orient themselves in the preview, since the bottom of the sky is black
+	// and the top of the sky is white.
+	procedural_sky_material.instantiate();
+	procedural_sky_material->set_sky_top_color(Color(1, 1, 1));
+	procedural_sky_material->set_sky_horizon_color(Color(0.5, 0.5, 0.5));
+	procedural_sky_material->set_ground_horizon_color(Color(0.5, 0.5, 0.5));
+	procedural_sky_material->set_ground_bottom_color(Color(0, 0, 0));
+	procedural_sky_material->set_sky_curve(2.0);
+	procedural_sky_material->set_ground_curve(0.5);
+	// Hide the sun from the sky.
+	procedural_sky_material->set_sun_angle_max(0.0);
+	sky.instantiate();
+	sky->set_material(procedural_sky_material);
+	environment.instantiate();
+	environment->set_background(Environment::BG_SKY);
+	environment->set_sky(sky);
+	// A custom FOV must be specified, as an orthogonal camera is used for the preview.
+	environment->set_sky_custom_fov(50.0);
+	camera->set_environment(environment);
+
 	light = memnew(DirectionalLight3D);
 	light->set_transform(Transform3D().looking_at(Vector3(-1, -2, -0.6), Vector3(0, 1, 0)));
 	base_viewport->add_child(light);

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -47,6 +47,7 @@
 #include "scene/gui/tab_container.h"
 #include "scene/gui/tree.h"
 #include "scene/resources/3d/primitive_meshes.h"
+#include "scene/resources/3d/sky_material.h"
 
 class EditorFileDialog;
 class EditorInspector;
@@ -78,6 +79,9 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 
 	Camera3D *camera = nullptr;
 	Ref<CameraAttributesPractical> camera_attributes;
+	Ref<Environment> environment;
+	Ref<Sky> sky;
+	Ref<ProceduralSkyMaterial> procedural_sky_material;
 	bool first_aabb = false;
 	AABB contents_aabb;
 


### PR DESCRIPTION
Use a gradient sky to improve visibility in shaded areas, while also helping the user orient themselves. The bottom of the sky is black, while the top of the sky is white.

This change also makes it so that the Default Clear Color project setting no longer affects the Advanced Import Settings dialog.

If we agree upon this change, a similar change can be made to mesh and material previews in the inspector.

**Testing project:** [test_advanced_import_settings_preview.zip](https://github.com/godotengine/godot/files/11180082/test_advanced_import_settings_preview.zip)

## Preview

*Notice how you can actually distinguish shaded areas from each other now.*

Before | After
-|-
![Screenshot_20230407_180921](https://user-images.githubusercontent.com/180032/230641485-a4ec6a82-51ad-415a-b112-9360ab697efe.png) | ![Screenshot_20230407_180816](https://user-images.githubusercontent.com/180032/230641482-cbb6c8c9-c3eb-4ba7-bbe2-0095d3bf7d85.png)