### PR TITLE
Remove double vertex addition when using precision=double for multimesh rendering

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -358,7 +358,7 @@ void vertex_shader(in uint instance_index, in bool is_multimesh, in uint multime
 	vec3 model_origin = model_matrix[3].xyz;
 	if (is_multimesh) {
 		vertex = mat3(matrix) * vertex;
-		model_origin = double_add_vec3(model_origin, model_precision, matrix[3].xyz, vec3(0.0), model_precision);
+		model_origin = double_add_vec3(vec3(0.0), model_precision, matrix[3].xyz, vec3(0.0), model_precision);
 	}
 	vertex = mat3(model_matrix) * vertex;
 	vec3 temp_precision; // Will be ignored.

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -359,7 +359,7 @@ void main() {
 	vec3 model_origin = model_matrix[3].xyz;
 	if (is_multimesh) {
 		vertex = mat3(matrix) * vertex;
-		model_origin = double_add_vec3(model_origin, model_precision, matrix[3].xyz, vec3(0.0), model_precision);
+		model_origin = double_add_vec3(vec3(0.0), model_precision, matrix[3].xyz, vec3(0.0), model_precision);
 	}
 	vertex = mat3(model_matrix) * vertex;
 	vec3 temp_precision;


### PR DESCRIPTION
Fixes #75549 

When in a multimesh pass on Vulkan and precision=double, the model_origin was being added to the vertex twice. 

Applies to GPUParticles3D as well as MultiMeshInstance3D. 

(Second animation was also using the billboard fix from #75462 but is not required for this fix to work).

![anim](https://user-images.githubusercontent.com/175568/230644614-dfc17b71-c14f-424d-8d5e-be1c885cd615.gif)
![anim-2](https://user-images.githubusercontent.com/175568/230644617-47e9adc5-8a5a-48fe-9b54-4a81a6e1274f.gif)

