### PR TITLE
Update CI to Ubuntu 22.04

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   android-template:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     name: Template (target=template_release)
 
     steps:

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   build-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false
@@ -100,6 +100,13 @@ jobs:
           echo "Disk usage before:" && df -h
           sudo rm -rf /usr/local/lib/android
           echo "Disk usage after:" && df -h
+
+      - name: Install gcc-13 and g++-13
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install gcc-13 g++-13
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 60 --slave /usr/bin/g++ g++ /usr/bin/g++-13
 
       - name: Setup Godot build cache
         uses: ./.github/actions/godot-cache

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   web-template:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     name: Template (target=template_release)
 
     steps:


### PR DESCRIPTION
This adds support for compilation with, for example, libdecor which is not available in any earlier version: https://packages.ubuntu.com/search?keywords=libdecor-0-dev.
Thus it might be helpful for #57025.