### PR TITLE
Optimize `Object::get_class_name`

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -195,14 +195,15 @@ bool Object::_predelete() {
 	_predelete_ok = 1;
 	notification(NOTIFICATION_PREDELETE, true);
 	if (_predelete_ok) {
-		_class_ptr = nullptr; //must restore so destructors can access class ptr correctly
+		_class_name_ptr = nullptr; // Must restore, so constructors/destructors have proper class name access at each stage.
 	}
 	return _predelete_ok;
 }
 
 void Object::_postinitialize() {
-	_class_ptr = _get_class_namev();
+	_class_name_ptr = _get_class_namev(); // Set the direct pointer, which is much faster to obtain, but can only happen after postinitialize.
 	_initialize_classv();
+	_class_name_ptr = nullptr; // May have been called from a constructor.
 	notification(NOTIFICATION_POSTINITIALIZE);
 }
 

--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -201,6 +201,14 @@ StringName::StringName(const StringName &p_name) {
 	}
 }
 
+void StringName::assign_static_unique_class_name(StringName *ptr, const char *p_name) {
+	mutex.lock();
+	if (*ptr == StringName()) {
+		*ptr = StringName(p_name, true);
+	}
+	mutex.unlock();
+}
+
 StringName::StringName(const char *p_name, bool p_static) {
 	_data = nullptr;
 

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -177,6 +177,8 @@ public:
 	StringName(const String &p_name, bool p_static = false);
 	StringName(const StaticCString &p_static_string, bool p_static = false);
 	StringName() {}
+
+	static void assign_static_unique_class_name(StringName *ptr, const char *p_name);
 	_FORCE_INLINE_ ~StringName() {
 		if (likely(configured) && _data) { //only free if configured
 			unref();


### PR DESCRIPTION
* Run the static function once per class instead of one per instance.
* Saves some memory in Object derived classes.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
