### PR TITLE
Make sure script cache is created after reimport

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2318,6 +2318,7 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 	ResourceUID::get_singleton()->update_cache(); // After reimporting, update the cache.
 
 	_save_filesystem_cache();
+	_update_pending_script_classes();
 	importing = false;
 	if (!is_scanning()) {
 		emit_signal(SNAME("filesystem_changed"));


### PR DESCRIPTION
Fixes #75684

For whatever reason there are 2 reimport paths. The other one is here:
https://github.com/godotengine/godot/blob/c151d3231f8e5d207f64055c60c70967dd5351b5/editor/editor_file_system.cpp#L732-L736
and it was executed too late. I did not try understand this logic...