### PR TITLE
Optimize 2D Delaunay and make it more readable

### DIFF
--- a/core/math/delaunay_2d.h
+++ b/core/math/delaunay_2d.h
@@ -38,7 +38,8 @@ class Delaunay2D {
 public:
 	struct Triangle {
 		int points[3];
-		bool bad = false;
+		Vector2 circum_center;
+		real_t circum_radius_squared;
 		Triangle() {}
 		Triangle(int p_a, int p_b, int p_c) {
 			points[0] = p_a;
@@ -48,117 +49,109 @@ public:
 	};
 
 	struct Edge {
-		int edge[2];
+		int points[2];
 		bool bad = false;
 		Edge() {}
 		Edge(int p_a, int p_b) {
-			edge[0] = p_a;
-			edge[1] = p_b;
+			// Store indices in a sorted manner to avoid having to check both orientations later.
+			if (p_a > p_b) {
+				points[0] = p_b;
+				points[1] = p_a;
+			} else {
+				points[0] = p_a;
+				points[1] = p_b;
+			}
 		}
 	};
 
-	static bool circum_circle_contains(const Vector<Vector2> &p_vertices, const Triangle &p_triangle, int p_vertex) {
-		Vector2 p1 = p_vertices[p_triangle.points[0]];
-		Vector2 p2 = p_vertices[p_triangle.points[1]];
-		Vector2 p3 = p_vertices[p_triangle.points[2]];
+	static Triangle create_triangle(const Vector<Vector2> &p_vertices, const int &p_a, const int &p_b, const int &p_c) {
+		Triangle triangle = Triangle(p_a, p_b, p_c);
 
-		real_t ab = p1.x * p1.x + p1.y * p1.y;
-		real_t cd = p2.x * p2.x + p2.y * p2.y;
-		real_t ef = p3.x * p3.x + p3.y * p3.y;
+		// Get the values of the circumcircle and store them inside the triangle object.
+		Vector2 a = p_vertices[p_b] - p_vertices[p_a];
+		Vector2 b = p_vertices[p_c] - p_vertices[p_a];
 
-		Vector2 circum(
-				(ab * (p3.y - p2.y) + cd * (p1.y - p3.y) + ef * (p2.y - p1.y)) / (p1.x * (p3.y - p2.y) + p2.x * (p1.y - p3.y) + p3.x * (p2.y - p1.y)),
-				(ab * (p3.x - p2.x) + cd * (p1.x - p3.x) + ef * (p2.x - p1.x)) / (p1.y * (p3.x - p2.x) + p2.y * (p1.x - p3.x) + p3.y * (p2.x - p1.x)));
+		Vector2 O = (b * a.length_squared() - a * b.length_squared()).orthogonal() / (a.cross(b) * 2.0f);
 
-		circum *= 0.5;
-		float r = p1.distance_squared_to(circum);
-		float d = p_vertices[p_vertex].distance_squared_to(circum);
-		return d <= r;
-	}
+		triangle.circum_radius_squared = O.length_squared();
+		triangle.circum_center = O + p_vertices[p_a];
 
-	static bool edge_compare(const Vector<Vector2> &p_vertices, const Edge &p_a, const Edge &p_b) {
-		if (p_vertices[p_a.edge[0]].is_equal_approx(p_vertices[p_b.edge[0]]) && p_vertices[p_a.edge[1]].is_equal_approx(p_vertices[p_b.edge[1]])) {
-			return true;
-		}
-
-		if (p_vertices[p_a.edge[0]].is_equal_approx(p_vertices[p_b.edge[1]]) && p_vertices[p_a.edge[1]].is_equal_approx(p_vertices[p_b.edge[0]])) {
-			return true;
-		}
-
-		return false;
+		return triangle;
 	}
 
 	static Vector<Triangle> triangulate(const Vector<Vector2> &p_points) {
 		Vector<Vector2> points = p_points;
 		Vector<Triangle> triangles;
 
-		Rect2 rect;
-		for (int i = 0; i < p_points.size(); i++) {
-			if (i == 0) {
-				rect.position = p_points[i];
-			} else {
-				rect.expand_to(p_points[i]);
-			}
+		int point_count = p_points.size();
+		if (point_count <= 2) {
+			return triangles;
 		}
 
-		float delta_max = MAX(rect.size.width, rect.size.height);
+		// Get a bounding rectangle.
+		Rect2 rect = Rect2(p_points[0], Size2());
+		for (int i = 1; i < point_count; i++) {
+			rect.expand_to(p_points[i]);
+		}
+
+		real_t delta_max = MAX(rect.size.width, rect.size.height);
 		Vector2 center = rect.get_center();
 
-		points.push_back(Vector2(center.x - 20 * delta_max, center.y - delta_max));
-		points.push_back(Vector2(center.x, center.y + 20 * delta_max));
-		points.push_back(Vector2(center.x + 20 * delta_max, center.y - delta_max));
+		// Construct a bounding triangle around the rectangle.
+		points.push_back(Vector2(center.x - delta_max * 16, center.y - delta_max));
+		points.push_back(Vector2(center.x, center.y + delta_max * 16));
+		points.push_back(Vector2(center.x + delta_max * 16, center.y - delta_max));
 
-		triangles.push_back(Triangle(p_points.size() + 0, p_points.size() + 1, p_points.size() + 2));
+		Triangle bounding_triangle = create_triangle(points, point_count + 0, point_count + 1, point_count + 2);
+		triangles.push_back(bounding_triangle);
 
-		for (int i = 0; i < p_points.size(); i++) {
+		for (int i = 0; i < point_count; i++) {
 			Vector<Edge> polygon;
 
-			for (int j = 0; j < triangles.size(); j++) {
-				if (circum_circle_contains(points, triangles[j], i)) {
-					triangles.write[j].bad = true;
+			// Save the edges of the triangles whose circumcircles contain the i-th vertex. Delete the triangles themselves.
+			for (int j = triangles.size() - 1; j >= 0; j--) {
+				if (points[i].distance_squared_to(triangles[j].circum_center) < triangles[j].circum_radius_squared) {
 					polygon.push_back(Edge(triangles[j].points[0], triangles[j].points[1]));
 					polygon.push_back(Edge(triangles[j].points[1], triangles[j].points[2]));
 					polygon.push_back(Edge(triangles[j].points[2], triangles[j].points[0]));
-				}
-			}
 
-			for (int j = 0; j < triangles.size(); j++) {
-				if (triangles[j].bad) {
 					triangles.remove_at(j);
-					j--;
 				}
 			}
 
-			for (int j = 0; j < polygon.size(); j++) {
-				for (int k = j + 1; k < polygon.size(); k++) {
-					if (edge_compare(points, polygon[j], polygon[k])) {
-						polygon.write[j].bad = true;
-						polygon.write[k].bad = true;
-					}
-				}
-			}
-
+			// Create a triangle for every unique edge.
 			for (int j = 0; j < polygon.size(); j++) {
 				if (polygon[j].bad) {
 					continue;
 				}
-				triangles.push_back(Triangle(polygon[j].edge[0], polygon[j].edge[1], i));
+
+				for (int k = j + 1; k < polygon.size(); k++) {
+					// Compare the edges.
+					if (polygon[k].points[0] == polygon[j].points[0] && polygon[k].points[1] == polygon[j].points[1]) {
+						polygon.write[j].bad = true;
+						polygon.write[k].bad = true;
+
+						break; // Since no more than two triangles can share an edge, no more than two edges can share vertices.
+					}
+				}
+
+				// Create triangles out of good edges.
+				if (!polygon[j].bad) {
+					triangles.push_back(create_triangle(points, polygon[j].points[0], polygon[j].points[1], i));
+				}
 			}
 		}
 
-		for (int i = 0; i < triangles.size(); i++) {
-			bool invalid = false;
-			for (int j = 0; j < 3; j++) {
-				if (triangles[i].points[j] >= p_points.size()) {
-					invalid = true;
-					break;
-				}
-			}
-			if (invalid) {
-				triangles.remove_at(i);
-				i--;
+		// Filter out the triangles containing vertices of the bounding triangle.
+		int preserved_count = 0;
+		Triangle *triangles_ptrw = triangles.ptrw();
+		for (int i = 0; i < triangles.size() - 1; i++) {
+			if (!(triangles[i].points[0] >= point_count || triangles[i].points[1] >= point_count || triangles[i].points[2] >= point_count)) {
+				triangles_ptrw[preserved_count] = triangles[i];
+				preserved_count++;
 			}
 		}
+		triangles.resize(preserved_count);
 
 		return triangles;
 	}


### PR DESCRIPTION
Co-authored: Dimitri Tabatadze <tabatadzedima@protonmail.com> (Supersedes #65280)

To summarize:

Around 2.85x speedup

**Original PR:**
* Triangle now stores the circumcircle's center and circumcircle radius squared. Both are stored in `create_triangle()` and don't have to be recalculated.
* Stores edges in a sorted manner so they are easy to compare.
* Simplifies the main loop in the triangulation routine by marking polygons edges as bad instead of triangles.

The first bullet point is a major optimization, while the other two are small optimizations. Together, they add up to a 2.85x speedup.

**My additions:**
* Returns the empty triangles vector immediately if there are less than 3 points, making the routine "free". Otherwise we know there are points, which simplifies finding the bounding rect.
* Implements vector filtering when the fake triangles are being removed.

With a minimum of 6 elements to be removed from the final triangles vector, filtering is always a speedup (microbenchmarked to make sure). This optimization is usually not noticeable, but in best case scenario (where vertices are on the outline of a squircle) the performance gain I measured was about 5%. I hoped for better, but I'll take it.

-----

Also small code simplifications and improved comments in both the original and mine. Note that the optimization changed the order in which triangles are returned and their vertices are ordered (although triangles are still always oriented CCW). The order was never expected to be meaningful, so this shouldn't break any existing user code; this algorithm isn't even used in our codebase.