### PR TITLE
Ignore Attributes for MustBeVariantAnalyzer

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MustBeVariantAnalyzer.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MustBeVariantAnalyzer.cs
@@ -26,9 +26,10 @@ namespace Godot.SourceGenerators
 
         private void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
-            // Ignore syntax inside comments
-            if (IsInsideDocumentation(context.Node))
+            if (ShouldIgnoreTypeArgumentList(context.Node))
+            {
                 return;
+            }
 
             var typeArgListSyntax = (TypeArgumentListSyntax)context.Node;
 
@@ -95,6 +96,16 @@ namespace Godot.SourceGenerators
             }
 
             return false;
+        }
+
+        private bool IsInAttribute(SyntaxNode? syntaxNode)
+        {
+            return syntaxNode?.Parent is NameSyntax && syntaxNode.Parent.Parent is AttributeSyntax;
+        }
+
+        private bool ShouldIgnoreTypeArgumentList(SyntaxNode? syntaxNode)
+        {
+            return IsInsideDocumentation(syntaxNode) || IsInAttribute(syntaxNode);
         }
 
         /// <summary>


### PR DESCRIPTION
csharp 11 introduces [generic attributes](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-11.0/generic-attributes), and I was finding a bunch of (reasonably inexplicable) errors in my project builds because of my use of [Jab](https://github.com/pakrym/jab).

Errors were:
> warning AD0001: Analyzer 'Godot.SourceGenerators.MustBeVariantAnalyzer' threw an exception of type 'System.IndexOutOfRangeException' with message 'Index was outside the bounds of the array.'.

There are probably improvements to make in the `ShouldCheckTypeArgument` method to avoid exceptions also, but simply not processing Attribute generic names seems reasonable.
