### PR TITLE
Fix completion of `source_color` hint for texture arrays in shaders

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -10529,36 +10529,42 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 
 					r_options->push_back(option);
 				}
-			} else if ((int(completion_base) > int(TYPE_MAT4) && int(completion_base) < int(TYPE_STRUCT)) && !completion_base_array) {
+			} else if ((int(completion_base) > int(TYPE_MAT4) && int(completion_base) < int(TYPE_STRUCT))) {
 				Vector<String> options;
-				if (current_uniform_filter == FILTER_DEFAULT) {
-					options.push_back("filter_linear");
-					options.push_back("filter_linear_mipmap");
-					options.push_back("filter_linear_mipmap_anisotropic");
-					options.push_back("filter_nearest");
-					options.push_back("filter_nearest_mipmap");
-					options.push_back("filter_nearest_mipmap_anisotropic");
-				}
-				if (current_uniform_hint == ShaderNode::Uniform::HINT_NONE) {
-					options.push_back("hint_anisotropy");
-					options.push_back("hint_default_black");
-					options.push_back("hint_default_white");
-					options.push_back("hint_default_transparent");
-					options.push_back("hint_normal");
-					options.push_back("hint_roughness_a");
-					options.push_back("hint_roughness_b");
-					options.push_back("hint_roughness_g");
-					options.push_back("hint_roughness_gray");
-					options.push_back("hint_roughness_normal");
-					options.push_back("hint_roughness_r");
-					options.push_back("hint_screen_texture");
-					options.push_back("hint_normal_roughness_texture");
-					options.push_back("hint_depth_texture");
-					options.push_back("source_color");
-				}
-				if (current_uniform_repeat == REPEAT_DEFAULT) {
-					options.push_back("repeat_enable");
-					options.push_back("repeat_disable");
+				if (completion_base_array) {
+					if (current_uniform_hint == ShaderNode::Uniform::HINT_NONE) {
+						options.push_back("source_color");
+					}
+				} else {
+					if (current_uniform_filter == FILTER_DEFAULT) {
+						options.push_back("filter_linear");
+						options.push_back("filter_linear_mipmap");
+						options.push_back("filter_linear_mipmap_anisotropic");
+						options.push_back("filter_nearest");
+						options.push_back("filter_nearest_mipmap");
+						options.push_back("filter_nearest_mipmap_anisotropic");
+					}
+					if (current_uniform_hint == ShaderNode::Uniform::HINT_NONE) {
+						options.push_back("hint_anisotropy");
+						options.push_back("hint_default_black");
+						options.push_back("hint_default_white");
+						options.push_back("hint_default_transparent");
+						options.push_back("hint_normal");
+						options.push_back("hint_roughness_a");
+						options.push_back("hint_roughness_b");
+						options.push_back("hint_roughness_g");
+						options.push_back("hint_roughness_gray");
+						options.push_back("hint_roughness_normal");
+						options.push_back("hint_roughness_r");
+						options.push_back("hint_screen_texture");
+						options.push_back("hint_normal_roughness_texture");
+						options.push_back("hint_depth_texture");
+						options.push_back("source_color");
+					}
+					if (current_uniform_repeat == REPEAT_DEFAULT) {
+						options.push_back("repeat_enable");
+						options.push_back("repeat_disable");
+					}
 				}
 
 				for (int i = 0; i < options.size(); i++) {


### PR DESCRIPTION
I found that hint is currently correctly working with texture arrays, so after this fix the suggestion pop-up will also show: 

![image](https://user-images.githubusercontent.com/3036176/230734160-9a70fc94-715e-426d-9d62-cba2bdc21493.png)

