### PR TITLE
Fix DAP path mismatch on Windows

### DIFF
--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -341,6 +341,12 @@ Dictionary DebugAdapterParser::req_setBreakpoints(const Dictionary &p_params) co
 		return prepare_error_response(p_params, DAP::ErrorType::WRONG_PATH, variables);
 	}
 
+	// If path contains \, it's a Windows path, so we need to convert it to /, and make the drive letter uppercase
+	if (source.path.find("\\") != -1) {
+		source.path = source.path.replace("\\", "/");
+		source.path = source.path.substr(0, 1).to_upper() + source.path.substr(1);
+	}
+
 	Array breakpoints = args["breakpoints"], lines;
 	for (int i = 0; i < breakpoints.size(); i++) {
 		DAP::SourceBreakpoint breakpoint;

--- a/editor/debugger/debug_adapter/debug_adapter_parser.h
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.h
@@ -45,6 +45,12 @@ private:
 	friend DebugAdapterProtocol;
 
 	_FORCE_INLINE_ bool is_valid_path(const String &p_path) const {
+		// If path contains \, it's a Windows path, so we need to convert it to /, and check as case-insensitive.
+		if (p_path.contains("\\")) {
+			String project_path = ProjectSettings::get_singleton()->get_resource_path();
+			String path = p_path.replace("\\", "/");
+			return path.findn(project_path) != -1;
+		}
 		return p_path.begins_with(ProjectSettings::get_singleton()->get_resource_path());
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Closes #75834

Handles all cases where file paths are received from DAP clients and might be in Windows-style. Implicitly this also fixes breakpoints not being correctly set in-between.