### PR TITLE
Fix Linux fullscreen mode doesn't preserve maximized state

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2249,7 +2249,7 @@ void DisplayServerX11::window_set_mode(WindowMode p_mode, WindowID p_window) {
 
 	switch (old_mode) {
 		case WINDOW_MODE_WINDOWED: {
-			//do nothing
+			was_maximized = false;
 		} break;
 		case WINDOW_MODE_MINIMIZED: {
 			_set_wm_minimized(p_window, false);
@@ -2267,12 +2267,17 @@ void DisplayServerX11::window_set_mode(WindowMode p_mode, WindowID p_window) {
 
 			window_set_position(wd.last_position_before_fs, p_window);
 
+			if (was_maximized && p_mode == WINDOW_MODE_WINDOWED) {
+				p_mode = WINDOW_MODE_MAXIMIZED;
+			}
+
 			if (on_top) {
 				_set_wm_maximized(p_window, false);
 			}
 
 		} break;
 		case WINDOW_MODE_MAXIMIZED: {
+			was_maximized = true;
 			_set_wm_maximized(p_window, false);
 		} break;
 	}

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -210,6 +210,8 @@ class DisplayServerX11 : public DisplayServer {
 	Point2i im_selection;
 	String im_text;
 
+	bool was_maximized = false;
+
 #ifdef XKB_ENABLED
 	bool xkb_loaded = false;
 	xkb_context *xkb_ctx = nullptr;


### PR DESCRIPTION
Fix #75804


Unlike what happens under Windows, the maximized state was not saved when switching to full screen.
Added  a ``was_maximized`` variable to restore previous windowed state while leaving fullscreen.