### PR TITLE
Fix method dialog label

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -338,11 +338,6 @@ void ConnectDialog::_update_method_tree() {
 	// If a script is attached, get methods from it.
 	ScriptInstance *si = target->get_script_instance();
 	if (si) {
-		TreeItem *si_item = method_tree->create_item(root_item);
-		si_item->set_text(0, TTR("Attached Script"));
-		si_item->set_icon(0, get_theme_icon(SNAME("Script"), SNAME("EditorIcons")));
-		si_item->set_selectable(0, false);
-
 		if (si->get_script()->is_built_in()) {
 			si->get_script()->reload();
 		}
@@ -350,9 +345,12 @@ void ConnectDialog::_update_method_tree() {
 		si->get_method_list(&methods);
 		methods = _filter_method_list(methods, signal_info, search_string);
 
-		if (methods.is_empty()) {
-			si_item->set_custom_color(0, disabled_color);
-		} else {
+		if (!methods.is_empty()) {
+			TreeItem *si_item = method_tree->create_item(root_item);
+			si_item->set_text(0, TTR("Attached Script"));
+			si_item->set_icon(0, get_theme_icon(SNAME("Script"), SNAME("EditorIcons")));
+			si_item->set_selectable(0, false);
+
 			_create_method_tree_items(methods, si_item);
 		}
 	}
@@ -687,8 +685,10 @@ ConnectDialog::ConnectDialog() {
 	method_tree->connect("item_activated", callable_mp((Window *)method_popup, &Window::hide));
 
 	empty_tree_label = memnew(Label(TTR("No method found matching given filters.")));
-	method_tree->add_child(empty_tree_label);
-	empty_tree_label->set_anchors_and_offsets_preset(Control::PRESET_CENTER);
+	method_popup->add_child(empty_tree_label);
+	empty_tree_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	empty_tree_label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
+	empty_tree_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD);
 
 	script_methods_only = memnew(CheckButton(TTR("Script Methods Only")));
 	method_vbc->add_child(script_methods_only);


### PR DESCRIPTION
In the method pick dialog, the label that appears when no methods are found could be at wrong position (probably due to being child of Tree).
![image](https://user-images.githubusercontent.com/2223172/230760713-2692de2f-f2eb-43e3-b4a4-7a77303d3da7.png)
Also if you selected an empty script, the label did not appear due to empty root item:
![image](https://user-images.githubusercontent.com/2223172/230760749-17a2499e-dbd7-4d86-88f8-07f0cf0af674.png)
With this PR the label is centered in the dialog and the "Attached Script" item only appears if there are any script methods available to pick.
![image](https://user-images.githubusercontent.com/2223172/230760758-1f2ce841-5330-4367-99da-3b6e22f2fc35.png)
