### PR TITLE
Poll LSP/DAP clients for connection status updates

### DIFF
--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -970,6 +970,7 @@ void DebugAdapterProtocol::poll() {
 	List<Ref<DAPeer>> to_delete;
 	for (List<Ref<DAPeer>>::Element *E = clients.front(); E; E = E->next()) {
 		Ref<DAPeer> peer = E->get();
+		peer->connection->poll();
 		StreamPeerTCP::Status status = peer->connection->get_status();
 		if (status == StreamPeerTCP::STATUS_NONE || status == StreamPeerTCP::STATUS_ERROR) {
 			to_delete.push_back(peer);

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -237,6 +237,7 @@ void GDScriptLanguageProtocol::poll() {
 	HashMap<int, Ref<LSPeer>>::Iterator E = clients.begin();
 	while (E != clients.end()) {
 		Ref<LSPeer> peer = E->value;
+		peer->connection->poll();
 		StreamPeerTCP::Status status = peer->connection->get_status();
 		if (status == StreamPeerTCP::STATUS_NONE || status == StreamPeerTCP::STATUS_ERROR) {
 			on_client_disconnected(E->key);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Closes #75849

Since https://github.com/godotengine/godot/pull/59582, polls now have to be done explicitly before getting a connection's status.


