### PR TITLE
Optimize `Color::find_named_color()`

### DIFF
--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -33,7 +33,7 @@
 #include "color_names.inc"
 #include "core/math/math_funcs.h"
 #include "core/string/ustring.h"
-#include "core/templates/rb_map.h"
+#include "core/templates/hash_map.h"
 
 #include "thirdparty/misc/ok_color.h"
 
@@ -414,7 +414,7 @@ Color Color::named(const String &p_name, const Color &p_default) {
 
 int Color::find_named_color(const String &p_name) {
 	String name = p_name;
-	// Normalize name
+	// Normalize name.
 	name = name.replace(" ", "");
 	name = name.replace("-", "");
 	name = name.replace("_", "");
@@ -422,23 +422,24 @@ int Color::find_named_color(const String &p_name) {
 	name = name.replace(".", "");
 	name = name.to_upper();
 
-	int idx = 0;
-	while (named_colors[idx].name != nullptr) {
-		if (name == String(named_colors[idx].name).replace("_", "")) {
-			return idx;
+	static HashMap<String, int> named_colors_hashmap;
+	if (unlikely(named_colors_hashmap.is_empty())) {
+		const int named_color_count = get_named_color_count();
+		for (int i = 0; i < named_color_count; i++) {
+			named_colors_hashmap[String(named_colors[i].name).replace("_", "")] = i;
 		}
-		idx++;
+	}
+
+	const HashMap<String, int>::ConstIterator E = named_colors_hashmap.find(name);
+	if (E) {
+		return E->value;
 	}
 
 	return -1;
 }
 
 int Color::get_named_color_count() {
-	int idx = 0;
-	while (named_colors[idx].name != nullptr) {
-		idx++;
-	}
-	return idx;
+	return sizeof(named_colors) / sizeof(NamedColor);
 }
 
 String Color::get_named_color_name(int p_idx) {

--- a/core/math/color_names.inc
+++ b/core/math/color_names.inc
@@ -189,5 +189,4 @@ static NamedColor named_colors[] = {
 	{ "WHITE_SMOKE", Color::hex(0xF5F5F5FF) },
 	{ "YELLOW", Color::hex(0xFFFF00FF) },
 	{ "YELLOW_GREEN", Color::hex(0x9ACD32FF) },
-	{ nullptr, Color() },
 };


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/47700418/230786003-4e0fe72b-5b7d-4141-83aa-725617f4541e.png)

Use binary search instead of linear.

Note that GDScript already caches constant values, unlike `RichTextLabel`. If we still decide to use a `HashMap`, then we need to store two names (for example, `ALICE_BLUE` and `ALICEBLUE`), since the name with underscore is needed for constant binding.