### PR TITLE
[Audio] Fix 2D audio with SubViewports.

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -157,7 +157,6 @@ void AudioStreamPlayer2D::_update_panning() {
 	Vector2 global_pos = get_global_position();
 
 	HashSet<Viewport *> viewports = world_2d->get_viewports();
-	viewports.insert(get_viewport()); // TODO: This is a mediocre workaround for #50958. Remove when that bug is fixed!
 
 	volume_vector.resize(4);
 	volume_vector.write[0] = AudioFrame(0, 0);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -414,6 +414,8 @@ void Viewport::_notification(int p_what) {
 			RenderingServer::get_singleton()->viewport_set_canvas_transform(viewport, current_canvas, canvas_transform);
 			RenderingServer::get_singleton()->viewport_set_canvas_cull_mask(viewport, canvas_cull_mask);
 			_update_audio_listener_2d();
+			find_world_2d()->_register_viewport(this);
+
 #ifndef _3D_DISABLED
 			RenderingServer::get_singleton()->viewport_set_scenario(viewport, find_world_3d()->get_scenario());
 			_update_audio_listener_3d();
@@ -472,6 +474,7 @@ void Viewport::_notification(int p_what) {
 
 		case NOTIFICATION_EXIT_TREE: {
 			_gui_cancel_tooltip();
+			find_world_2d()->_remove_viewport(this);
 
 			RenderingServer::get_singleton()->viewport_set_scenario(viewport, RID());
 			RenderingServer::get_singleton()->viewport_remove_canvas(viewport, current_canvas);
@@ -1090,6 +1093,10 @@ void Viewport::set_world_2d(const Ref<World2D> &p_world_2d) {
 		RenderingServer::get_singleton()->viewport_remove_canvas(viewport, current_canvas);
 	}
 
+	if (world_2d.is_valid()) {
+		world_2d->_remove_viewport(this);
+	}
+
 	if (p_world_2d.is_valid()) {
 		world_2d = p_world_2d;
 	} else {
@@ -1102,6 +1109,7 @@ void Viewport::set_world_2d(const Ref<World2D> &p_world_2d) {
 	if (is_inside_tree()) {
 		current_canvas = find_world_2d()->get_canvas();
 		RenderingServer::get_singleton()->viewport_attach_canvas(viewport, current_canvas);
+		find_world_2d()->_register_viewport(this);
 	}
 }
 

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -82,6 +82,14 @@ PhysicsDirectSpaceState2D *World2D::get_direct_space_state() {
 	return PhysicsServer2D::get_singleton()->space_get_direct_state(get_space());
 }
 
+void World2D::_register_viewport(Viewport *p_viewport) {
+	viewports.insert(p_viewport);
+}
+
+void World2D::_remove_viewport(Viewport *p_viewport) {
+	viewports.erase(p_viewport);
+}
+
 World2D::World2D() {
 	canvas = RenderingServer::get_singleton()->canvas_create();
 }


### PR DESCRIPTION
World2D was no longer keeping track of viewports which caused AudioStreamPlayer2Ds to ignore AudioListener2Ds inside SubViewports sharing the same world.

Viewports now registers and removes themselves from World2Ds as they used to do, so AudioStreamPlayer2D can access AudioListener2Ds in any viewport which share the same world.

(this behavior was accidentally removed in #49632).

See [audio2d.zip](https://github.com/godotengine/godot/files/11186060/audio2d.zip) for a reproduction project (no audio without the patch).