### PR TITLE
GDScript: Add missing member type check when resolving `extends`

### DIFF
--- a/modules/gdscript/tests/scripts/analyzer/errors/extend_non_class_constant_1.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/extend_non_class_constant_1.gd
@@ -1,0 +1,9 @@
+# GH-75870
+
+const A = 1
+
+class B extends A:
+	pass
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/extend_non_class_constant_1.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/extend_non_class_constant_1.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Constant "A" is not a preloaded script or class.

--- a/modules/gdscript/tests/scripts/analyzer/errors/extend_non_class_constant_2.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/extend_non_class_constant_2.gd
@@ -1,0 +1,12 @@
+# GH-75870
+
+class A:
+	const X = 1
+
+const Y = A.X # A.X is now resolved.
+
+class B extends A.X:
+	pass
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/extend_non_class_constant_2.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/extend_non_class_constant_2.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Identifier "X" is not a preloaded script or class.

--- a/modules/gdscript/tests/scripts/analyzer/errors/extend_variable.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/extend_variable.gd
@@ -1,0 +1,9 @@
+# GH-75870
+
+var A = 1
+
+class B extends A:
+	pass
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/extend_variable.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/extend_variable.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot use variable "A" in extends chain.


### PR DESCRIPTION
Closes #75870.