### PR TITLE
[Windows TTS] Fix queuing utterances in rapid succession.

### DIFF
--- a/platform/windows/tts_windows.cpp
+++ b/platform/windows/tts_windows.cpp
@@ -117,7 +117,7 @@ bool TTS_Windows::is_speaking() const {
 
 	SPVOICESTATUS status;
 	synth->GetStatus(&status, nullptr);
-	return (status.dwRunningState == SPRS_IS_SPEAKING);
+	return (status.dwRunningState == SPRS_IS_SPEAKING || status.dwRunningState == 0 /* Waiting To Speak */);
 }
 
 bool TTS_Windows::is_paused() const {


### PR DESCRIPTION
Sometime, only the last of the subsequent `DisplayServer.tts_speak` calls was correctly queued, since TTS status is not changing to "speaking" instantly.