### PR TITLE
Broken link removed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,8 +230,7 @@ feature, *please* edit the commit title to something meaningful. Commits named
 
 You can contribute to Godot's translation from the [Hosted
 Weblate](https://hosted.weblate.org/projects/godot-engine/godot), an open
-source and web-based translation platform. Please refer to the [translation
-readme](editor/translations/README.md) for more information.
+source and web-based translation platform.
 
 You can also help translate [Godot's
 documentation](https://hosted.weblate.org/projects/godot-engine/godot-docs/)


### PR DESCRIPTION
The translation readme in editor/translations/README.md was deleted in #70623, broken link removed

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
