### PR TITLE
Always cache parent visibility in `CanvasItem`

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -350,9 +350,7 @@ void CanvasItem::update_draw_order() {
 }
 
 void CanvasItem::_window_visibility_changed() {
-	if (visible) {
-		_propagate_visibility_changed(window->is_visible());
-	}
+	_propagate_visibility_changed(window->is_visible());
 }
 
 void CanvasItem::queue_redraw() {


### PR DESCRIPTION
Noticed while testing https://github.com/godotengine/godot/pull/75844. This check prevents us from storing the parent visibility state correctly when a `CanvasItem` is a child of a `Window`. Calling into the method directly has no extra side effects if the current node is hidden, we simply store the visibility state and return.