### PR TITLE
Round values to 3 decimals in the ColorPicker constructor string

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -966,9 +966,9 @@ bool ColorPicker::is_deferred_mode() const {
 void ColorPicker::_update_text_value() {
 	bool text_visible = true;
 	if (text_is_constructor) {
-		String t = "Color(" + String::num(color.r) + ", " + String::num(color.g) + ", " + String::num(color.b);
+		String t = "Color(" + String::num(color.r, 3) + ", " + String::num(color.g, 3) + ", " + String::num(color.b, 3);
 		if (edit_alpha && color.a < 1) {
-			t += ", " + String::num(color.a) + ")";
+			t += ", " + String::num(color.a, 3) + ")";
 		} else {
 			t += ")";
 		}


### PR DESCRIPTION
This makes the whole string always fit within the LineEdit (at least when using the default font).
Precision is still quite good for color values – it's 4 times more precise than an hexadecimal code, since there are 1,000 possible values between `0.0` and `1.0`.

- Related to https://github.com/godotengine/godot/issues/75897.

## Preview

![image](https://user-images.githubusercontent.com/180032/230972265-88f58d49-3e88-4576-a608-0607a9a222b1.png)