### PR TITLE
Allow entering named colors in ColorPicker's hex field

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -543,8 +543,9 @@ void ColorPicker::_html_submitted(const String &p_html) {
 		return;
 	}
 
-	Color previous_color = color;
-	color = Color::html(p_html);
+	const Color previous_color = color;
+	color = Color::from_string(p_html, previous_color);
+
 	if (!is_editing_alpha()) {
 		color.a = previous_color.a;
 	}
@@ -644,13 +645,13 @@ void ColorPicker::_text_type_toggled() {
 		text_type->set_icon(get_theme_icon(SNAME("Script"), SNAME("EditorIcons")));
 
 		c_text->set_editable(false);
-		c_text->set_h_size_flags(SIZE_EXPAND_FILL);
+		c_text->set_tooltip_text(RTR("Copy this constructor in a script."));
 	} else {
 		text_type->set_text("#");
 		text_type->set_icon(nullptr);
 
 		c_text->set_editable(true);
-		c_text->set_h_size_flags(SIZE_FILL);
+		c_text->set_tooltip_text(RTR("Enter a hex code (\"#ff0000\") or named color (\"red\")."));
 	}
 	_update_color();
 }
@@ -1793,7 +1794,10 @@ ColorPicker::ColorPicker() {
 
 	c_text = memnew(LineEdit);
 	hex_hbc->add_child(c_text);
+	c_text->set_h_size_flags(SIZE_EXPAND_FILL);
 	c_text->set_select_all_on_focus(true);
+	c_text->set_tooltip_text(RTR("Enter a hex code (\"#ff0000\") or named color (\"red\")."));
+	c_text->set_placeholder(RTR("Hex code or named color"));
 	c_text->connect("text_submitted", callable_mp(this, &ColorPicker::_html_submitted));
 	c_text->connect("text_changed", callable_mp(this, &ColorPicker::_text_changed));
 	c_text->connect("focus_exited", callable_mp(this, &ColorPicker::_html_focus_exit));


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/75904 (can be merged independently).

This also makes the hex field wider to allow displaying 9-character hex code (`#rrggbbaa`) in full, even when using a custom font.

It turns out `Color::from_string()` does all of this for us, providing this as a fallback when the entered string isn't a valid hexadecimal color :slightly_smiling_face:

`Color::named()` also features automatic normalization, which means the color names are case-insensitive and punctuation-insensitive.

- This closes https://github.com/godotengine/godot/issues/75897.

## Preview

https://user-images.githubusercontent.com/180032/230976225-7ae3feec-4f47-4e54-a2df-0986f78821a7.mp4

