### PR TITLE
Prevent BoneAttachment3D signal connect spam on reimports

### DIFF
--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -148,7 +148,9 @@ void BoneAttachment3D::_check_bind() {
 			bone_idx = sk->find_bone(bone_name);
 		}
 		if (bone_idx != -1) {
-			sk->call_deferred(SNAME("connect"), "bone_pose_changed", callable_mp(this, &BoneAttachment3D::on_bone_pose_update));
+			if (!bound && !sk->is_connected(SNAME("bone_pose_changed"), callable_mp(this, &BoneAttachment3D::on_bone_pose_update))) {
+				sk->call_deferred(SNAME("connect"), "bone_pose_changed", callable_mp(this, &BoneAttachment3D::on_bone_pose_update));
+			}
 			bound = true;
 			call_deferred(SNAME("on_bone_pose_update"), bone_idx);
 		}
@@ -175,7 +177,7 @@ void BoneAttachment3D::_check_unbind() {
 	if (bound) {
 		Skeleton3D *sk = _get_skeleton3d();
 
-		if (sk) {
+		if (sk && sk->is_connected(SNAME("bone_pose_changed"), callable_mp(this, &BoneAttachment3D::on_bone_pose_update))) {
 			sk->disconnect(SNAME("bone_pose_changed"), callable_mp(this, &BoneAttachment3D::on_bone_pose_update));
 		}
 		bound = false;


### PR DESCRIPTION
Prevents BoneAttachment3D signal connect spam on reimports.

When a 3D asset was already used inside an open scene and had BoneAttachment3D it would spam signal connect / disconnect errors on reimports for every single BoneAttachment3D.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
