### PR TITLE
Fix `compute_pieline` typo in `RenderingDevice.compute_pipeline_is_valid()`

### DIFF
--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -113,7 +113,7 @@
 		</method>
 		<method name="compute_pipeline_is_valid">
 			<return type="bool" />
-			<param index="0" name="compute_pieline" type="RID" />
+			<param index="0" name="compute_pipeline" type="RID" />
 			<description>
 			</description>
 		</method>

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -752,7 +752,7 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("render_pipeline_is_valid", "render_pipeline"), &RenderingDevice::render_pipeline_is_valid);
 
 	ClassDB::bind_method(D_METHOD("compute_pipeline_create", "shader", "specialization_constants"), &RenderingDevice::_compute_pipeline_create, DEFVAL(TypedArray<RDPipelineSpecializationConstant>()));
-	ClassDB::bind_method(D_METHOD("compute_pipeline_is_valid", "compute_pieline"), &RenderingDevice::compute_pipeline_is_valid);
+	ClassDB::bind_method(D_METHOD("compute_pipeline_is_valid", "compute_pipeline"), &RenderingDevice::compute_pipeline_is_valid);
 
 	ClassDB::bind_method(D_METHOD("screen_get_width", "screen"), &RenderingDevice::screen_get_width, DEFVAL(DisplayServer::MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("screen_get_height", "screen"), &RenderingDevice::screen_get_height, DEFVAL(DisplayServer::MAIN_WINDOW_ID));


### PR DESCRIPTION
PS: Can parameter name changes be cherry-picked to 4.0.x, or are they considered compatibility-breaking with regards to GDExtension and C#?