### PR TITLE
[3.x] Add content scale stretch modes, implement integer scaling

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -212,6 +212,13 @@
 				Marks the most recent [InputEvent] as handled.
 			</description>
 		</method>
+		<method name="set_scale_stretch">
+			<return type="void" />
+			<argument index="0" name="stretch" type="int" enum="SceneTree.ScaleStretch" default="0" />
+			<description>
+				Configures the screen's scale stretching mode according to the given [enum ScaleStretch].
+			</description>
+		</method>
 		<method name="set_screen_stretch">
 			<return type="void" />
 			<argument index="0" name="mode" type="int" enum="SceneTree.StretchMode" />
@@ -400,6 +407,12 @@
 		</constant>
 		<constant name="STRETCH_ASPECT_EXPAND" value="4" enum="StretchAspect">
 			Expand in both directions, retaining the same aspect ratio. This prevents distortion while avoiding black bars.
+		</constant>
+		<constant name="SCALE_STRETCH_FRACTIONAL" value="0" enum="ScaleStretch">
+			The content will be stretched according to a fractional factor, filling all the space available but allowing "pixel wobble" to occur.
+		</constant>
+		<constant name="SCALE_STRETCH_INTEGER" value="1" enum="ScaleStretch">
+			The content will be stretched according to an integer factor, preserving sharp pixels but leaving a black background.
 		</constant>
 	</constants>
 </class>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2018,6 +2018,15 @@ bool Main::start() {
 
 			sml->set_screen_stretch(sml_sm, sml_aspect, stretch_size, stretch_scale);
 
+			String scale_stretch = GLOBAL_DEF("display/window/stretch/stretch", "fractional");
+
+			SceneTree::ScaleStretch sml_stretch = SceneTree::SCALE_STRETCH_FRACTIONAL;
+			if (scale_stretch == "integer") {
+				sml_stretch = SceneTree::SCALE_STRETCH_INTEGER;
+			}
+
+			sml->set_scale_stretch(sml_stretch);
+
 			sml->set_auto_accept_quit(GLOBAL_DEF("application/config/auto_accept_quit", true));
 			sml->set_quit_on_go_back(GLOBAL_DEF("application/config/quit_on_go_back", true));
 			String appname = ProjectSettings::get_singleton()->get("application/config/name");
@@ -2062,6 +2071,8 @@ bool Main::start() {
 			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/aspect", PropertyInfo(Variant::STRING, "display/window/stretch/aspect", PROPERTY_HINT_ENUM, "ignore,keep,keep_width,keep_height,expand"));
 			GLOBAL_DEF("display/window/stretch/shrink", 1.0);
 			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/shrink", PropertyInfo(Variant::REAL, "display/window/stretch/shrink", PROPERTY_HINT_RANGE, "0.1,8,0.01,or_greater"));
+			GLOBAL_DEF("display/window/stretch/stretch", "fractional");
+			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/stretch", PropertyInfo(Variant::STRING, "display/window/stretch/stretch", PROPERTY_HINT_ENUM, "fractional,integer"));
 			sml->set_auto_accept_quit(GLOBAL_DEF("application/config/auto_accept_quit", true));
 			sml->set_quit_on_go_back(GLOBAL_DEF("application/config/quit_on_go_back", true));
 			GLOBAL_DEF("gui/common/snap_controls_to_pixels", true);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1384,23 +1384,34 @@ void SceneTree::_update_root_rect() {
 		}
 	}
 
-	screen_size = screen_size.floor();
-	viewport_size = viewport_size.floor();
+	if (scale_stretch == SCALE_STRETCH_INTEGER) {
+		screen_size = screen_size.floor();
+		viewport_size = viewport_size.floor();
+
+		Size2i screen_scale = (screen_size / viewport_size).floor();
+		int scale_factor = MIN(screen_scale.x, screen_scale.y);
+
+		if (scale_factor < 1) {
+			scale_factor = 1;
+		}
+
+		screen_size = viewport_size * scale_factor;
+	}
 
 	Size2 margin;
 	Size2 offset;
 	//black bars and margin
-	if (stretch_aspect != STRETCH_ASPECT_EXPAND && screen_size.x < video_mode.x) {
+	if (screen_size.x < video_mode.x) {
 		margin.x = Math::round((video_mode.x - screen_size.x) / 2.0);
-		VisualServer::get_singleton()->black_bars_set_margins(margin.x, 0, margin.x, 0);
 		offset.x = Math::round(margin.x * viewport_size.y / screen_size.y);
-	} else if (stretch_aspect != STRETCH_ASPECT_EXPAND && screen_size.y < video_mode.y) {
-		margin.y = Math::round((video_mode.y - screen_size.y) / 2.0);
-		VisualServer::get_singleton()->black_bars_set_margins(0, margin.y, 0, margin.y);
-		offset.y = Math::round(margin.y * viewport_size.x / screen_size.x);
-	} else {
-		VisualServer::get_singleton()->black_bars_set_margins(0, 0, 0, 0);
 	}
+
+	if (screen_size.y < video_mode.y) {
+		margin.y = Math::round((video_mode.y - screen_size.y) / 2.0);
+		offset.y = Math::round(margin.y * viewport_size.x / screen_size.x);
+	}
+
+	VisualServer::get_singleton()->black_bars_set_margins(margin.x, margin.y, margin.x, margin.y);
 
 	switch (stretch_mode) {
 		case STRETCH_MODE_DISABLED: {
@@ -1432,6 +1443,11 @@ void SceneTree::set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, c
 	stretch_aspect = p_aspect;
 	stretch_min = p_minsize;
 	stretch_scale = p_scale;
+	_update_root_rect();
+}
+
+void SceneTree::set_scale_stretch(ScaleStretch p_stretch) {
+	scale_stretch = p_stretch;
 	_update_root_rect();
 }
 
@@ -2063,6 +2079,7 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("quit", "exit_code"), &SceneTree::quit, DEFVAL(-1));
 
 	ClassDB::bind_method(D_METHOD("set_screen_stretch", "mode", "aspect", "minsize", "scale"), &SceneTree::set_screen_stretch, DEFVAL(1));
+	ClassDB::bind_method(D_METHOD("set_scale_stretch", "stretch"), &SceneTree::set_scale_stretch, DEFVAL(SCALE_STRETCH_FRACTIONAL));
 
 	ClassDB::bind_method(D_METHOD("set_physics_interpolation_enabled", "enabled"), &SceneTree::set_physics_interpolation_enabled);
 	ClassDB::bind_method(D_METHOD("is_physics_interpolation_enabled"), &SceneTree::is_physics_interpolation_enabled);
@@ -2174,6 +2191,9 @@ void SceneTree::_bind_methods() {
 	BIND_ENUM_CONSTANT(STRETCH_ASPECT_KEEP_WIDTH);
 	BIND_ENUM_CONSTANT(STRETCH_ASPECT_KEEP_HEIGHT);
 	BIND_ENUM_CONSTANT(STRETCH_ASPECT_EXPAND);
+
+	BIND_ENUM_CONSTANT(SCALE_STRETCH_FRACTIONAL);
+	BIND_ENUM_CONSTANT(SCALE_STRETCH_INTEGER);
 }
 
 SceneTree *SceneTree::singleton = nullptr;

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -97,6 +97,12 @@ public:
 		STRETCH_ASPECT_EXPAND,
 	};
 
+	enum ScaleStretch {
+
+		SCALE_STRETCH_FRACTIONAL,
+		SCALE_STRETCH_INTEGER,
+	};
+
 private:
 	struct Group {
 		Vector<Node *> nodes;
@@ -160,6 +166,8 @@ private:
 	StretchAspect stretch_aspect;
 	Size2i stretch_min;
 	real_t stretch_scale;
+
+	ScaleStretch scale_stretch;
 
 	void _update_font_oversampling(float p_ratio);
 	void _update_root_rect();
@@ -384,6 +392,7 @@ public:
 	bool has_group(const StringName &p_identifier) const;
 
 	void set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, const Size2 &p_minsize, real_t p_scale = 1.0);
+	void set_scale_stretch(ScaleStretch p_stretch);
 
 	void set_use_font_oversampling(bool p_oversampling);
 	bool is_using_font_oversampling() const;
@@ -443,6 +452,7 @@ public:
 
 VARIANT_ENUM_CAST(SceneTree::StretchMode);
 VARIANT_ENUM_CAST(SceneTree::StretchAspect);
+VARIANT_ENUM_CAST(SceneTree::ScaleStretch);
 VARIANT_ENUM_CAST(SceneTree::GroupCallFlags);
 
 #endif // SCENE_TREE_H


### PR DESCRIPTION
Supersedes (and based on) #63206
Improves godotengine/godot-demo-projects#898
3.x version of #75784

Implements a new `display/window/stretch/stretch` project setting and the `ScaleStretch` enum, controlling the way the game scales the content while stretching it.

This is different from the stretch mode as this defines what rules to apply when deciding _how much_ to stretch, instead of governing _how_.

Integer scaling is achieved (after aspect expansion) by "lying" to the stretching code about the window's size, telling it that it's always an integer multiple of the viewport so that it only gets stretched to an integer factor.

This approach works with all stretch and aspect modes and doesn't require handling for each, only requiring to "loosen up" some self-excluding conditions (in other words, replacing some `else if`s with just `if`s) regarding viewport offset and margin calculation (black bars).

Notes:
 - Perhaps even worse than #75784, I really don't like the name and it clashes even more with 3.x naming. I'm not sure on how to name it. Perhaps I could name the enum `StretchScale`? Again, no idea.

 - 3.x has this huge method (`set_screen_stretch`) which sets up everything else regarding screen stretching. I implemented another method (`set_scale_stretch`) to not break API compatibility.

 - This has only been _lightly_ tested on my NVIDIA/X11 desktop, as I mostly use 4.x and Wayland on my laptop, which is only supported there. That said, the code is almost identical to its 4.x counterpart and the porting job was trivial, having just to compensate for a bunch of 3.x-isms. I'm thus pretty sure that this should work as well as #75784.
