### PR TITLE
Add is_z_forward option to 3D viewport

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -62,6 +62,15 @@ class ViewportNavigationControl;
 class ViewportRotationControl : public Control {
 	GDCLASS(ViewportRotationControl, Control);
 
+	enum ViewAxis {
+		VIEW_AXIS_PLUS_X,
+		VIEW_AXIS_PLUS_Y,
+		VIEW_AXIS_PLUS_Z,
+		VIEW_AXIS_MINUS_X,
+		VIEW_AXIS_MINUS_Y,
+		VIEW_AXIS_MINUS_Z,
+	};
+
 	struct Axis2D {
 		Vector2i screen_point;
 		float z_axis = -99.0;
@@ -88,6 +97,7 @@ protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	void _draw();
 	void _draw_axis(const Axis2D &p_axis);
+	void _focus_axis();
 	void _get_sorted_axis(Vector<Axis2D> &r_axis);
 	void _update_focus();
 	void _on_mouse_exited();
@@ -110,6 +120,7 @@ class Node3DEditorViewport : public Control {
 		VIEW_RIGHT,
 		VIEW_FRONT,
 		VIEW_REAR,
+		VIEW_IS_Z_FORWARD,
 		VIEW_CENTER_TO_ORIGIN,
 		VIEW_CENTER_TO_SELECTION,
 		VIEW_ALIGN_TRANSFORM_WITH_VIEW,
@@ -218,6 +229,8 @@ private:
 
 	MenuButton *view_menu = nullptr;
 	PopupMenu *display_submenu = nullptr;
+
+	bool viewport_camera_is_z_forward = false;
 
 	Control *surface = nullptr;
 	SubViewport *viewport = nullptr;


### PR DESCRIPTION
Relates to #75875 and #72842. This PR add is_z_forward option to 3D viewport same as those.

![image](https://user-images.githubusercontent.com/61938263/231053980-b630bd0a-dad3-4601-b45b-069fbe5af1d4.png)

It provide DCC-like operation for a designer friendly viewport. Demand is already visualized in https://github.com/godotengine/godot-proposals/issues/6198#issuecomment-1419076787, https://github.com/godotengine/godot/issues/73742 and more.

But this is optional since some developers prefer to use a workflow like https://github.com/godotengine/godot/pull/72753.

Considerable matters:
- Maybe there is more suitable option name to emphasize that _it only affects the front/back/left/right View of the Viewport_
- The default is false for now, but I feel personally that default is true is more user-friendly since I am also a designer

---

This PR, #75875, #72842, and some additional documentation to be added later, we have to finish the arguments as to which is the way forward in Godot 4.x.

And let's strive to develop more consistent asset pipeline I/O so that like this arguments  does not happen in Godot 5.