### PR TITLE
[TextServer] Improve BiDi error handling.

### DIFF
--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -515,7 +515,9 @@ class TextServerAdvanced : public TextServerExtension {
 
 		~ShapedTextDataAdvanced() {
 			for (int i = 0; i < bidi_iter.size(); i++) {
-				ubidi_close(bidi_iter[i]);
+				if (bidi_iter[i]) {
+					ubidi_close(bidi_iter[i]);
+				}
 			}
 			if (script_iter) {
 				memdelete(script_iter);


### PR DESCRIPTION
Instead of aborting shaping if BiDi failed (usually due to invalid control chars in the string), continue shaping as a single L-to-R run. Prevents excessive error spam.