### PR TITLE
Editor Theme: Set `selection_color` property of `RichTextLabel`

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -97,8 +97,6 @@ void EditorLog::_update_theme() {
 	log->add_theme_font_size_override("italics_font_size", font_size);
 	log->add_theme_font_size_override("mono_font_size", font_size);
 
-	log->add_theme_color_override("selection_color", get_theme_color(SNAME("accent_color"), SNAME("Editor")) * Color(1, 1, 1, 0.4));
-
 	type_filter_map[MSG_TYPE_STD]->toggle_button->set_icon(get_theme_icon(SNAME("Popup"), SNAME("EditorIcons")));
 	type_filter_map[MSG_TYPE_ERROR]->toggle_button->set_icon(get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons")));
 	type_filter_map[MSG_TYPE_WARNING]->toggle_button->set_icon(get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1597,6 +1597,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("default_color", "RichTextLabel", font_color);
 	theme->set_color("font_shadow_color", "RichTextLabel", Color(0, 0, 0, 0));
 	theme->set_color("font_outline_color", "RichTextLabel", font_outline_color);
+	theme->set_color("selection_color", "RichTextLabel", selection_color);
 	theme->set_constant("shadow_offset_x", "RichTextLabel", 1 * EDSCALE);
 	theme->set_constant("shadow_offset_y", "RichTextLabel", 1 * EDSCALE);
 	theme->set_constant("shadow_outline_size", "RichTextLabel", 1 * EDSCALE);
@@ -1618,7 +1619,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("value_color", "EditorHelp", font_color * Color(1, 1, 1, 0.6));
 	theme->set_color("qualifier_color", "EditorHelp", font_color * Color(1, 1, 1, 0.8));
 	theme->set_color("type_color", "EditorHelp", accent_color.lerp(font_color, 0.5));
-	theme->set_color("selection_color", "EditorHelp", accent_color * Color(1, 1, 1, 0.4));
+	theme->set_color("selection_color", "EditorHelp", selection_color);
 	theme->set_color("link_color", "EditorHelp", accent_color.lerp(mono_color, 0.8));
 	theme->set_color("code_color", "EditorHelp", accent_color.lerp(mono_color, 0.6));
 	theme->set_color("kbd_color", "EditorHelp", accent_color.lerp(property_color, 0.6));


### PR DESCRIPTION
Before
![](https://user-images.githubusercontent.com/47700418/231095513-c829ba5a-168b-4cc9-b1e8-9c33271fb158.png)

After
![](https://user-images.githubusercontent.com/47700418/231095545-336fa976-caa6-4699-86d0-2f4078231f3e.png)