### PR TITLE
[PCK Encryption] Add support for APK assets encryption using PCK encryption key/export config.

### DIFF
--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -40,6 +40,8 @@
 
 // Godot's packed file magic header ("GDPC" in ASCII).
 #define PACK_HEADER_MAGIC 0x43504447
+// Godot's packed file standalone directory magic header ("GDDR" in ASCII).
+#define DIR_HEADER_MAGIC 0x52444447
 // The current packed file format version number.
 #define PACK_FORMAT_VERSION 2
 

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1251,7 +1251,7 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	enc_pck = memnew(CheckButton);
 	enc_pck->connect("toggled", callable_mp(this, &ProjectExportDialog::_enc_pck_changed));
-	enc_pck->set_text(TTR("Encrypt Exported PCK"));
+	enc_pck->set_text(TTR("Encrypt Exported PCK / APK Assets"));
 	sec_vb->add_child(enc_pck);
 
 	enc_directory = memnew(CheckButton);

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -33,8 +33,12 @@
 #include "gradle_export_util.h"
 
 #include "core/config/project_settings.h"
+#include "core/crypto/crypto_core.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
+#include "core/io/file_access_encrypted.h"
+#include "core/io/file_access_memory.h"
+#include "core/io/file_access_pack.h"
 #include "core/io/image_loader.h"
 #include "core/io/json.h"
 #include "core/io/marshalls.h"
@@ -254,6 +258,16 @@ static const char *AAB_ASSETS_DIRECTORY = "res://android/build/assetPacks/instal
 static const int OPENGL_MIN_SDK_VERSION = 21; // Should match the value in 'platform/android/java/app/config.gradle#minSdk'
 static const int VULKAN_MIN_SDK_VERSION = 24;
 static const int DEFAULT_TARGET_SDK_VERSION = 33; // Should match the value in 'platform/android/java/app/config.gradle#targetSdk'
+
+static int _get_pad(int p_alignment, int p_n) {
+	int rest = p_n % p_alignment;
+	int pad = 0;
+	if (rest > 0) {
+		pad = p_alignment - rest;
+	};
+
+	return pad;
+}
 
 #ifndef ANDROID_ENABLED
 void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
@@ -749,9 +763,75 @@ Error EditorExportPlatformAndroid::save_apk_so(void *p_userdata, const SharedObj
 
 Error EditorExportPlatformAndroid::save_apk_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key) {
 	APKExportData *ed = static_cast<APKExportData *>(p_userdata);
-	String dst_path = p_path.replace_first("res://", "assets/");
 
-	store_in_apk(ed, dst_path, p_data, _should_compress_asset(p_path, p_data) ? Z_DEFLATED : 0);
+	bool encrypt = false;
+	for (int i = 0; i < p_enc_in_filters.size(); ++i) {
+		if (p_path.matchn(p_enc_in_filters[i]) || p_path.replace("res://", "").matchn(p_enc_in_filters[i])) {
+			encrypt = true;
+			break;
+		}
+	}
+
+	for (int i = 0; i < p_enc_ex_filters.size(); ++i) {
+		if (p_path.matchn(p_enc_ex_filters[i]) || p_path.replace("res://", "").matchn(p_enc_ex_filters[i])) {
+			encrypt = false;
+			break;
+		}
+	}
+
+	if (encrypt && ed->enc_pack) {
+		String path = p_path;
+		if (path.begins_with("/")) {
+			path = path.substr(1, path.length());
+		} else if (path.begins_with("res://")) {
+			path = path.substr(6, path.length());
+		}
+
+		String id;
+		do {
+			CharString cs = path.utf8();
+			for (int i = 0; i < 16; i++) {
+				cs += char(32 + Math::rand() % 220);
+			}
+			unsigned char hash[32];
+			CryptoCore::sha256((unsigned char *)cs.ptr(), cs.length(), hash);
+			id = String::hex_encode_buffer(hash, 32);
+		} while (ed->ids.has(id));
+
+		ed->ids.insert(id);
+
+		Vector<uint8_t> enc_data;
+		uint64_t len = p_data.size();
+		if (len % 16) {
+			len += 16 - (len % 16);
+		}
+		len += 4 + 16 + 8 + 16; /* Encrypted file overhead, magic, md5, orig size, iv */
+		enc_data.resize(len);
+
+		Ref<FileAccessMemory> fmem;
+		fmem.instantiate();
+		ERR_FAIL_COND_V(fmem.is_null(), ERR_SKIP);
+		Error err = fmem->open_custom(enc_data.ptrw(), enc_data.size());
+		ERR_FAIL_COND_V(err != OK, ERR_SKIP);
+
+		Ref<FileAccessEncrypted> fae;
+		fae.instantiate();
+		ERR_FAIL_COND_V(fae.is_null(), ERR_SKIP);
+		err = fae->open_and_parse(fmem, p_key, FileAccessEncrypted::MODE_WRITE_AES256, false);
+		ERR_FAIL_COND_V(err != OK, ERR_SKIP);
+
+		// Store file content.
+		fae->store_buffer(p_data.ptr(), p_data.size());
+
+		fae.unref();
+		fmem.unref();
+
+		ed->directory[path] = id;
+		store_in_apk(ed, "assets/.encrypted/" + id, enc_data, 0);
+	} else {
+		String dst_path = p_path.replace_first("res://", "assets/");
+		store_in_apk(ed, dst_path, p_data, _should_compress_asset(p_path, p_data) ? Z_DEFLATED : 0);
+	}
 	return OK;
 }
 
@@ -3131,10 +3211,137 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 				return err;
 			}
 		} else {
+			bool enc_pck = p_preset->get_enc_pck();
+			bool enc_directory = p_preset->get_enc_directory();
+
 			APKExportData ed;
 			ed.ep = &ep;
 			ed.apk = unaligned_apk;
+			ed.enc_pack = enc_pck;
 			err = export_project_files(p_preset, p_debug, save_apk_file, &ed, save_apk_so);
+
+			if (!ed.directory.is_empty() && enc_pck) {
+				Vector<uint8_t> dir_data;
+				uint64_t len = 92; // Header size.
+				for (const KeyValue<String, String> &E : ed.directory) {
+					uint32_t string_len = E.key.utf8().length();
+					uint32_t pad = _get_pad(4, string_len);
+					len += (4 + string_len + pad);
+
+					string_len = E.value.utf8().length();
+					pad = _get_pad(4, string_len);
+					len += (4 + string_len + pad);
+				}
+				len += 16;
+				if (enc_directory) {
+					len += 44; // Encryption overhead (hash + iv + size).
+				}
+				if (len % 16) {
+					len += 16 - (len % 16);
+				}
+				dir_data.resize(len);
+				memset(dir_data.ptrw(), 0, len);
+
+				Ref<FileAccessMemory> fmem;
+				fmem.instantiate();
+				ERR_FAIL_COND_V(fmem.is_null(), ERR_CANT_CREATE);
+				err = fmem->open_custom(dir_data.ptrw(), dir_data.size());
+				ERR_FAIL_COND_V(err != OK, ERR_CANT_CREATE);
+
+				fmem->store_32(DIR_HEADER_MAGIC);
+				fmem->store_32(PACK_FORMAT_VERSION);
+				fmem->store_32(VERSION_MAJOR);
+				fmem->store_32(VERSION_MINOR);
+				fmem->store_32(VERSION_PATCH);
+
+				uint32_t pack_flags = 0;
+				if (enc_directory) {
+					pack_flags |= PACK_DIR_ENCRYPTED;
+				}
+				fmem->store_32(pack_flags); // flags
+
+				for (int i = 0; i < 16; i++) {
+					//reserved
+					fmem->store_32(0);
+				}
+
+				fmem->store_32(ed.directory.size()); //amount of files
+
+				Ref<FileAccessEncrypted> fae;
+				Ref<FileAccess> fhead = fmem;
+				if (enc_directory) {
+					String script_key = p_preset->get_script_encryption_key().to_lower();
+					Vector<uint8_t> key;
+					key.resize(32);
+					if (script_key.length() == 64) {
+						for (int i = 0; i < 32; i++) {
+							int v = 0;
+							if (i * 2 < script_key.length()) {
+								char32_t ct = script_key[i * 2];
+								if (is_digit(ct)) {
+									ct = ct - '0';
+								} else if (ct >= 'a' && ct <= 'f') {
+									ct = 10 + ct - 'a';
+								}
+								v |= ct << 4;
+							}
+
+							if (i * 2 + 1 < script_key.length()) {
+								char32_t ct = script_key[i * 2 + 1];
+								if (is_digit(ct)) {
+									ct = ct - '0';
+								} else if (ct >= 'a' && ct <= 'f') {
+									ct = 10 + ct - 'a';
+								}
+								v |= ct;
+							}
+							key.write[i] = v;
+						}
+					}
+					fae.instantiate();
+					if (fae.is_null()) {
+						add_message(EXPORT_MESSAGE_ERROR, TTR("Save APK"), TTR("Can't create encrypted file."));
+						return ERR_CANT_CREATE;
+					}
+
+					err = fae->open_and_parse(fmem, key, FileAccessEncrypted::MODE_WRITE_AES256, false);
+					if (err != OK) {
+						add_message(EXPORT_MESSAGE_ERROR, TTR("Save APK"), TTR("Can't open encrypted file to write."));
+						return ERR_CANT_CREATE;
+					}
+
+					fhead = fae;
+				}
+
+				for (const KeyValue<String, String> &E : ed.directory) {
+					uint32_t string_len = E.key.utf8().length();
+					uint32_t pad = _get_pad(4, string_len);
+
+					fhead->store_32(string_len + pad);
+					fhead->store_buffer((const uint8_t *)E.key.utf8().get_data(), string_len);
+					for (uint32_t j = 0; j < pad; j++) {
+						fhead->store_8(0);
+					}
+
+					string_len = E.value.utf8().length();
+					pad = _get_pad(4, string_len);
+
+					fhead->store_32(string_len + pad);
+					fhead->store_buffer((const uint8_t *)E.value.utf8().get_data(), string_len);
+					for (uint32_t j = 0; j < pad; j++) {
+						fhead->store_8(0);
+					}
+				}
+
+				if (fae.is_valid()) {
+					fhead.unref();
+					fae.unref();
+				}
+
+				fmem.unref();
+
+				store_in_apk(&ed, "assets/.encrypted/directory", dir_data, 0);
+			}
 		}
 	}
 

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -69,6 +69,9 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 	struct APKExportData {
 		zipFile apk;
+		bool enc_pack = false;
+		HashMap<String, String> directory;
+		HashSet<String> ids;
 		EditorProgress *ep = nullptr;
 	};
 

--- a/platform/android/file_access_android.cpp
+++ b/platform/android/file_access_android.cpp
@@ -30,9 +30,13 @@
 
 #include "file_access_android.h"
 
+#include "core/object/script_language.h"
 #include "core/string/print_string.h"
+#include "core/version.h"
 
 AAssetManager *FileAccessAndroid::asset_manager = nullptr;
+HashMap<String, String> FileAccessAndroid::directory;
+bool FileAccessAndroid::dir_loaded = false;
 
 String FileAccessAndroid::get_path() const {
 	return path_src;
@@ -40,6 +44,87 @@ String FileAccessAndroid::get_path() const {
 
 String FileAccessAndroid::get_path_absolute() const {
 	return absolute_path;
+}
+
+void FileAccessAndroid::_load_encrypted_directory() {
+	if (!dir_loaded) {
+		dir_loaded = true;
+
+		const String &enc_path = ".encrypted/directory";
+
+		Ref<FileAccessAndroid> f;
+		f.instantiate();
+		ERR_FAIL_COND_MSG(f.is_null(), "Can't open encrypted file directory.");
+
+		f->asset = AAssetManager_open(asset_manager, enc_path.utf8().get_data(), AASSET_MODE_STREAMING);
+		if (f->asset) {
+			f->path_src = enc_path;
+			f->absolute_path = enc_path;
+			f->len = AAsset_getLength(f->asset);
+			f->pos = 0;
+			f->eof = false;
+
+			uint32_t magic = f->get_32();
+			if (magic == DIR_HEADER_MAGIC) {
+				uint32_t version = f->get_32();
+				uint32_t ver_major = f->get_32();
+				uint32_t ver_minor = f->get_32();
+				f->get_32(); // patch number, not used for validation.
+
+				ERR_FAIL_COND_MSG(version != PACK_FORMAT_VERSION, "Directory version unsupported: " + itos(version) + ".");
+				ERR_FAIL_COND_MSG(ver_major > VERSION_MAJOR || (ver_major == VERSION_MAJOR && ver_minor > VERSION_MINOR), "Directory created with a newer version of the engine: " + itos(ver_major) + "." + itos(ver_minor) + ".");
+
+				uint32_t pack_flags = f->get_32();
+
+				bool enc_directory = (pack_flags & PACK_DIR_ENCRYPTED);
+
+				for (int i = 0; i < 16; i++) {
+					//reserved
+					f->get_32();
+				}
+
+				int file_count = f->get_32();
+
+				Ref<FileAccess> fhead = f;
+				if (enc_directory) {
+					Ref<FileAccessEncrypted> fae;
+					fae.instantiate();
+					ERR_FAIL_COND_MSG(fae.is_null(), "Can't open encrypted directory.");
+
+					Vector<uint8_t> key;
+					key.resize(32);
+					for (int i = 0; i < key.size(); i++) {
+						key.write[i] = script_encryption_key[i];
+					}
+
+					Error err = fae->open_and_parse(f, key, FileAccessEncrypted::MODE_READ, false);
+					ERR_FAIL_COND_MSG(err, "Can't open encrypted directory.");
+					fhead = fae;
+				}
+
+				for (int i = 0; i < file_count; i++) {
+					uint32_t sl = fhead->get_32();
+					CharString cs;
+					cs.resize(sl + 1);
+					fhead->get_buffer((uint8_t *)cs.ptr(), sl);
+					cs[sl] = 0;
+
+					String path;
+					path.parse_utf8(cs.ptr());
+
+					sl = fhead->get_32();
+					cs.resize(sl + 1);
+					fhead->get_buffer((uint8_t *)cs.ptr(), sl);
+					cs[sl] = 0;
+
+					String enc_path;
+					enc_path.parse_utf8(cs.ptr());
+
+					directory[path] = enc_path;
+				}
+			}
+		}
+	}
 }
 
 Error FileAccessAndroid::open_internal(const String &p_path, int p_mode_flags) {
@@ -55,18 +140,59 @@ Error FileAccessAndroid::open_internal(const String &p_path, int p_mode_flags) {
 	}
 
 	ERR_FAIL_COND_V(p_mode_flags & FileAccess::WRITE, ERR_UNAVAILABLE); //can't write on android..
-	asset = AAssetManager_open(asset_manager, path.utf8().get_data(), AASSET_MODE_STREAMING);
-	if (!asset) {
-		return ERR_CANT_OPEN;
+
+	_load_encrypted_directory();
+	if (directory.has(path)) {
+		const String &enc_path = ".encrypted/" + directory[path];
+
+		Ref<FileAccessAndroid> f;
+		f.instantiate();
+		ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_OPEN, "Can't open encrypted file '" + path + "'.");
+
+		f->asset = AAssetManager_open(asset_manager, enc_path.utf8().get_data(), AASSET_MODE_STREAMING);
+		if (!f->asset) {
+			return ERR_CANT_OPEN;
+		}
+		f->path_src = enc_path;
+		f->absolute_path = enc_path;
+		f->len = AAsset_getLength(f->asset);
+		f->pos = 0;
+		f->eof = false;
+
+		fae.instantiate();
+		ERR_FAIL_COND_V_MSG(fae.is_null(), ERR_CANT_OPEN, "Can't open encrypted file '" + path + "'.");
+
+		Vector<uint8_t> key;
+		key.resize(32);
+		for (int i = 0; i < key.size(); i++) {
+			key.write[i] = script_encryption_key[i];
+		}
+
+		Error err = fae->open_and_parse(f, key, FileAccessEncrypted::MODE_READ, false);
+		if (err != OK) {
+			if (fae.is_valid()) {
+				fae.unref();
+			}
+			ERR_FAIL_V_MSG(err, "Can't open encrypted file '" + path + "'.");
+		}
+	} else {
+		asset = AAssetManager_open(asset_manager, path.utf8().get_data(), AASSET_MODE_STREAMING);
+		if (!asset) {
+			return ERR_CANT_OPEN;
+		}
+		len = AAsset_getLength(asset);
+		pos = 0;
+		eof = false;
 	}
-	len = AAsset_getLength(asset);
-	pos = 0;
-	eof = false;
 
 	return OK;
 }
 
 void FileAccessAndroid::_close() {
+	if (fae.is_valid()) {
+		fae.unref();
+	}
+
 	if (!asset) {
 		return;
 	}
@@ -79,68 +205,101 @@ bool FileAccessAndroid::is_open() const {
 }
 
 void FileAccessAndroid::seek(uint64_t p_position) {
-	ERR_FAIL_NULL(asset);
-
-	AAsset_seek(asset, p_position, SEEK_SET);
-	pos = p_position;
-	if (pos > len) {
-		pos = len;
-		eof = true;
+	if (fae.is_valid()) {
+		fae->seek(p_position);
 	} else {
-		eof = false;
+		ERR_FAIL_NULL(asset);
+
+		AAsset_seek(asset, p_position, SEEK_SET);
+		pos = p_position;
+		if (pos > len) {
+			pos = len;
+			eof = true;
+		} else {
+			eof = false;
+		}
 	}
 }
 
 void FileAccessAndroid::seek_end(int64_t p_position) {
-	ERR_FAIL_NULL(asset);
-	AAsset_seek(asset, p_position, SEEK_END);
-	pos = len + p_position;
+	if (fae.is_valid()) {
+		fae->seek_end(p_position);
+	} else {
+		ERR_FAIL_NULL(asset);
+
+		AAsset_seek(asset, p_position, SEEK_END);
+		pos = len + p_position;
+	}
 }
 
 uint64_t FileAccessAndroid::get_position() const {
-	return pos;
+	if (fae.is_valid()) {
+		return fae->get_position();
+	} else {
+		return pos;
+	}
 }
 
 uint64_t FileAccessAndroid::get_length() const {
-	return len;
+	if (fae.is_valid()) {
+		return fae->get_length();
+	} else {
+		return len;
+	}
 }
 
 bool FileAccessAndroid::eof_reached() const {
-	return eof;
+	if (fae.is_valid()) {
+		return fae->eof_reached();
+	} else {
+		return eof;
+	}
 }
 
 uint8_t FileAccessAndroid::get_8() const {
-	if (pos >= len) {
-		eof = true;
-		return 0;
-	}
+	if (fae.is_valid()) {
+		return fae->get_8();
+	} else {
+		if (pos >= len) {
+			eof = true;
+			return 0;
+		}
 
-	uint8_t byte;
-	AAsset_read(asset, &byte, 1);
-	pos++;
-	return byte;
+		uint8_t byte;
+		AAsset_read(asset, &byte, 1);
+		pos++;
+		return byte;
+	}
 }
 
 uint64_t FileAccessAndroid::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 
-	int r = AAsset_read(asset, p_dst, p_length);
+	if (fae.is_valid()) {
+		return fae->get_buffer(p_dst, p_length);
+	} else {
+		int r = AAsset_read(asset, p_dst, p_length);
 
-	if (pos + p_length > len) {
-		eof = true;
-	}
-
-	if (r >= 0) {
-		pos += r;
-		if (pos > len) {
-			pos = len;
+		if (pos + p_length > len) {
+			eof = true;
 		}
+
+		if (r >= 0) {
+			pos += r;
+			if (pos > len) {
+				pos = len;
+			}
+		}
+		return r;
 	}
-	return r;
 }
 
 Error FileAccessAndroid::get_error() const {
-	return eof ? ERR_FILE_EOF : OK; // not sure what else it may happen
+	if (fae.is_valid()) {
+		return fae->get_error();
+	} else {
+		return eof ? ERR_FILE_EOF : OK; // not sure what else it may happen
+	}
 }
 
 void FileAccessAndroid::flush() {
@@ -157,6 +316,11 @@ bool FileAccessAndroid::file_exists(const String &p_path) {
 		path = path.substr(1, path.length());
 	} else if (path.begins_with("res://")) {
 		path = path.substr(6, path.length());
+	}
+
+	_load_encrypted_directory();
+	if (directory.has(path)) {
+		path = ".encrypted/" + directory[path];
 	}
 
 	AAsset *at = AAssetManager_open(asset_manager, path.utf8().get_data(), AASSET_MODE_STREAMING);

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -32,6 +32,8 @@
 #define FILE_ACCESS_ANDROID_H
 
 #include "core/io/file_access.h"
+#include "core/io/file_access_encrypted.h"
+#include "core/io/file_access_pack.h"
 #include <android/asset_manager.h>
 #include <android/log.h>
 #include <stdio.h>
@@ -44,7 +46,12 @@ class FileAccessAndroid : public FileAccess {
 	String absolute_path;
 	String path_src;
 
+	static HashMap<String, String> directory;
+	static bool dir_loaded;
+	Ref<FileAccessEncrypted> fae;
+
 	void _close();
+	static void _load_encrypted_directory();
 
 public:
 	static AAssetManager *asset_manager;


### PR DESCRIPTION
Allow encrypting asset files in the APK using existing PCK encryption key/export config, without using APK extension.

Implements https://github.com/godotengine/godot-proposals/issues/6675
