### PR TITLE
Add profiler column title sorting

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -624,6 +624,36 @@ Vector<Vector<String>> EditorProfiler::get_data_as_csv() const {
 	return res;
 }
 
+void EditorProfiler::_sort_column(int column, int) {
+	TreeItem *root = variables->get_root();
+
+	// Sort per category
+	for (TreeItem *cat = root->get_first_child(); cat != nullptr; cat = cat->get_next()) {
+		Vector<Pair<String, TreeItem *>> vec;
+		for (TreeItem *it = cat->get_first_child(); it != nullptr; it = it->get_next()) {
+			String trimmed = it->get_text(column).trim_suffix(" ms").trim_suffix("%");
+			vec.push_back(Pair(trimmed, it));
+		}
+		if (vec.size() < 2) {
+			continue;
+		}
+		TreeItem *first = vec[0].second;
+		vec.sort_custom<ColSort>();
+
+		// Reverse order if same column is clicked twice in a row
+		if (last_sort_column == column) {
+			vec.reverse();
+		}
+
+		vec[0].second->move_before(first);
+		for (int i = 1; i < vec.size(); i++) {
+			vec[i].second->move_after(vec[i - 1].second);
+		}
+	}
+
+	last_sort_column = last_sort_column == column ? -1 : column;
+}
+
 EditorProfiler::EditorProfiler() {
 	HBoxContainer *hb = memnew(HBoxContainer);
 	add_child(hb);
@@ -713,6 +743,7 @@ EditorProfiler::EditorProfiler() {
 	variables->set_column_clip_content(2, true);
 	variables->set_column_custom_minimum_width(2, 50 * EDSCALE);
 	variables->connect("item_edited", callable_mp(this, &EditorProfiler::_item_edited));
+	variables->connect("column_title_clicked", callable_mp(this, &EditorProfiler::_sort_column));
 
 	graph = memnew(TextureRect);
 	graph->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);

--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -133,6 +133,8 @@ private:
 	Timer *frame_delay = nullptr;
 	Timer *plot_delay = nullptr;
 
+	int last_sort_column = -1;
+
 	void _update_button_text();
 	void _update_frame();
 
@@ -161,6 +163,20 @@ private:
 	void _combo_changed(int);
 
 	Metric _get_frame_metric(int index);
+
+	void _sort_column(int column, int mouse_button_index);
+
+	struct ColSort {
+		_FORCE_INLINE_ bool operator()(const Pair<String, TreeItem *> A, const Pair<String, TreeItem *> B) const {
+			if (A.first.is_valid_float() && B.first.is_valid_float()) {
+				// Since it's for the profiler, Alphabetic is regular order but time
+				// is reverse order
+				return A.first.to_float() > B.first.to_float();
+			} else {
+				return A.first < B.first;
+			}
+		}
+	};
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
Makes it so the profiler functions are sorted according to a column when you click a column title.
As in, click 'calls', and functions with the most calls will be put on top.