### PR TITLE
Windows TTS: Use HashMap instead of RBMap for ids

### DIFF
--- a/platform/android/tts_android.h
+++ b/platform/android/tts_android.h
@@ -32,6 +32,7 @@
 #define TTS_ANDROID_H
 
 #include "core/string/ustring.h"
+#include "core/templates/hash_map.h"
 #include "core/variant/array.h"
 #include "servers/display_server.h"
 

--- a/platform/ios/tts_ios.h
+++ b/platform/ios/tts_ios.h
@@ -38,8 +38,8 @@
 #endif
 
 #include "core/string/ustring.h"
+#include "core/templates/hash_map.h"
 #include "core/templates/list.h"
-#include "core/templates/rb_map.h"
 #include "core/variant/array.h"
 #include "servers/display_server.h"
 

--- a/platform/linuxbsd/tts_linux.h
+++ b/platform/linuxbsd/tts_linux.h
@@ -34,8 +34,8 @@
 #include "core/os/thread.h"
 #include "core/os/thread_safe.h"
 #include "core/string/ustring.h"
+#include "core/templates/hash_map.h"
 #include "core/templates/list.h"
-#include "core/templates/rb_map.h"
 #include "core/variant/array.h"
 #include "servers/display_server.h"
 

--- a/platform/macos/tts_macos.h
+++ b/platform/macos/tts_macos.h
@@ -32,8 +32,8 @@
 #define TTS_MACOS_H
 
 #include "core/string/ustring.h"
+#include "core/templates/hash_map.h"
 #include "core/templates/list.h"
-#include "core/templates/rb_map.h"
 #include "core/variant/array.h"
 #include "servers/display_server.h"
 

--- a/platform/windows/tts_windows.h
+++ b/platform/windows/tts_windows.h
@@ -32,8 +32,8 @@
 #define TTS_WINDOWS_H
 
 #include "core/string/ustring.h"
+#include "core/templates/hash_map.h"
 #include "core/templates/list.h"
-#include "core/templates/rb_map.h"
 #include "core/variant/array.h"
 #include "servers/display_server.h"
 
@@ -54,7 +54,7 @@ class TTS_Windows {
 		int offset;
 		int id;
 	};
-	RBMap<ULONG, UTData> ids;
+	HashMap<uint32_t, UTData> ids;
 
 	static void __stdcall speech_event_callback(WPARAM wParam, LPARAM lParam);
 	void _update_tts();


### PR DESCRIPTION
And fixup includes in other implementations.

This is just a code quality change, shouldn't impact the feature.