### PR TITLE
Prevent errors in the Inspector when looking for script icons

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2758,26 +2758,30 @@ void EditorInspector::update_tree() {
 			doc_name = p.name;
 
 			// Use category's owner script to update some of its information.
-			if (!EditorNode::get_editor_data().is_type_recognized(type) && p.hint_string.length() && FileAccess::exists(p.hint_string)) {
-				StringName script_name;
-
+			if (!EditorNode::get_editor_data().is_type_recognized(type) && p.hint_string.length() && ResourceLoader::exists(p.hint_string)) {
 				Ref<Script> scr = ResourceLoader::load(p.hint_string, "Script");
 				if (scr.is_valid()) {
-					script_name = EditorNode::get_editor_data().script_class_get_name(scr->get_path());
+					StringName script_name = EditorNode::get_editor_data().script_class_get_name(scr->get_path());
 
 					// Update the docs reference and the label based on the script.
 					Vector<DocData::ClassDoc> docs = scr->get_documentation();
 					if (!docs.is_empty()) {
 						doc_name = docs[0].name;
 					}
-					if (script_name != StringName() && label != script_name) {
+					if (script_name != StringName()) {
 						label = script_name;
 					}
-				}
 
-				// Find the corresponding icon.
-				category->icon = EditorNode::get_singleton()->get_class_icon(script_name, "Object");
-			} else if (!type.is_empty()) {
+					// Find the icon corresponding to the script.
+					if (script_name != StringName()) {
+						category->icon = EditorNode::get_singleton()->get_class_icon(script_name, "Object");
+					} else {
+						category->icon = EditorNode::get_singleton()->get_object_icon(scr.ptr(), "Object");
+					}
+				}
+			}
+
+			if (category->icon.is_null() && !type.is_empty()) {
 				category->icon = EditorNode::get_singleton()->get_class_icon(type, "Object");
 			}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/75764. Checking for the script itself is unlikely to provide any icons, but if we end up supporting script icons (https://github.com/godotengine/godot/pull/75656), then this should just work.