### PR TITLE
Add a `sum()` method to Array

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -749,6 +749,23 @@ Variant Array::max() const {
 	return maxval;
 }
 
+Variant Array::sum() const {
+	Variant sumval;
+	for (int i = 0; i < size(); i++) {
+		if (i == 0) {
+			sumval = get(i);
+		} else {
+			bool valid;
+			Variant term = get(i);
+			Variant::evaluate(Variant::OP_ADD, sumval, term, sumval, valid);
+			if (!valid) {
+				return Variant(); //not a valid operation
+			}
+		}
+	}
+	return sumval;
+}
+
 const void *Array::id() const {
 	return _p;
 }

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -116,6 +116,7 @@ public:
 
 	Variant min() const;
 	Variant max() const;
+	Variant sum() const;
 
 	const void *id() const;
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2239,6 +2239,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Array, all, sarray("method"), varray());
 	bind_method(Array, max, sarray(), varray());
 	bind_method(Array, min, sarray(), varray());
+	bind_method(Array, sum, sarray(), varray());
 	bind_method(Array, is_typed, sarray(), varray());
 	bind_method(Array, is_same_typed, sarray("array"), varray());
 	bind_method(Array, get_typed_builtin, sarray(), varray());

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -641,6 +641,12 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="sum" qualifiers="const">
+			<return type="Variant" />
+			<description>
+				Returns the sum of all values contained in the array if all elements are of summable types. If the elements can't be summed, [code]null[/code] is returned.
+			</description>
+		</method>
 	</methods>
 	<operators>
 		<operator name="operator !=">


### PR DESCRIPTION
I think it seems reasonable to have this built-in, since it's such a common task. The implementation's similar to `min()` and `max()`, so I placed it next to those in the code.