### PR TITLE
Add missing `script_type` `nullptr` check

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4129,7 +4129,7 @@ String GDScriptParser::DataType::to_string() const {
 			return class_type->fqcn;
 		case SCRIPT: {
 			if (is_meta_type) {
-				return script_type->get_class_name().operator String();
+				return script_type != nullptr ? script_type->get_class_name().operator String() : "";
 			}
 			String name = script_type != nullptr ? script_type->get_name() : "";
 			if (!name.is_empty()) {


### PR DESCRIPTION
Adds a missing `script_type` `nullptr` check as suggested by @Faless on https://github.com/godotengine/godot/issues/55858#issuecomment-1438603168

Cherrypickable for 4.0