### PR TITLE
Fix typo in FinalAction `switch` statement in RenderingDevice

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -3646,7 +3646,7 @@ VkRenderPass RenderingDeviceVulkan::_render_pass_create(const Vector<AttachmentF
 					} else {
 						description.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 						description.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-						description.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED; // Don't care what is there.
+						description.finalLayout = VK_IMAGE_LAYOUT_UNDEFINED; // Don't care what is there.
 						// TODO: What does this mean about the next usage (and thus appropriate dependency masks.
 					}
 				} break;


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/75908.

I spotted this while working on RenderingDevice documentation.

I've tested this in a [few projects](https://github.com/Calinou/godot-reflection) [and it](https://github.com/godotengine/godot-demo-projects/tree/master/3d/platformer) [works fine](https://github.com/godotengine/godot-demo-projects/tree/master/2d/lights_and_shadows).