### PR TITLE
Fix exception when using base types of extension-based types from C#

### DIFF
--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -115,6 +115,7 @@ StringBuilder &operator<<(StringBuilder &r_sb, const char *p_cstring) {
 #define C_METHOD_MANAGED_FROM_SIGNAL C_NS_MONOMARSHAL ".ConvertSignalToManaged"
 
 // Types that will be ignored by the generator and won't be available in C#.
+// This must be kept in sync with `ignored_types` in csharp_script.cpp
 const Vector<String> ignored_types = { "PhysicsServer2DExtension", "PhysicsServer3DExtension" };
 
 void BindingsGenerator::TypeInterface::postsetup_enum_type(BindingsGenerator::TypeInterface &r_enum_itype) {


### PR DESCRIPTION
Fixes #74801.

This PR allows for GDExtension-based classes to be interacted with from C# so long as it's done through one of the engine-based base classes.

For example, without this fix the following code will cause a `NullReferenceException` when using a GDExtension-based physics server, because in such cases the `state` parameter must be backed by an extension class inheriting from `PhysicsDirectBodyState3DExtension`, which causes the C# integration to look for that extension class within the `GodotSharp` assembly, which it won't find.

```cs
public partial class MyRigidBody : RigidBody3D
{
    public override void _IntegrateForces(PhysicsDirectBodyState3D state)
    {
    }
}
```

This fix solves this (somewhat crudely) by traversing the class hierarchy when looking for the appropriate `ClassInfo`, and skipping them so long as it's a GDExtension class or its name happens to be either `PhysicsServer2DExtension` or `PhysicsServer3DExtension`. The exceptions for the physics server classes have to be made due to a workaround introduced in #59286 which explicitly filters them out when generating the C# bindings.

Note that this fix doesn't do anything to solve the issue of actually exposing the GDExtension class itself to C#. If anything, this fix would probably get in the way of solving that problem, but I figured this could be a stopgap solution.

EDIT: MRP can be found [here](https://github.com/godotengine/godot/files/11725673/PR75955_MRP.zip).