### PR TITLE
Write out `render_mode` even when mode is set to default in VisualShaders

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -2183,11 +2183,17 @@ void VisualShader::_update_shader() const {
 			const String temp = String(info.name);
 
 			if (!info.options.is_empty()) {
+				if (!render_mode.is_empty()) {
+					render_mode += ", ";
+				}
+				// Always write out a render_mode for the enumerated modes as having no render mode is not always
+				// the same as the default. i.e. for depth_draw_opaque, the render mode has to be declared for it
+				// to work properly, no render mode is an invalid option.
 				if (modes.has(temp) && modes[temp] < info.options.size()) {
-					if (!render_mode.is_empty()) {
-						render_mode += ", ";
-					}
 					render_mode += temp + "_" + info.options[modes[temp]];
+				} else {
+					// Use the default.
+					render_mode += temp + "_" + info.options[0];
 				}
 			} else if (flags.has(temp)) {
 				flag_names.push_back(temp);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/75380

The issue here came from the fact that we didn't write out the ``render_modes`` into the generated shader if the mode was set to the default value. Contrast that with BaseMaterial3D which writes out the render modes no matter what https://github.com/godotengine/godot/blob/ab7cb2a95d060a6533e6ff5111c11f71972ab43f/scene/resources/material.cpp#L657-L711

The issue arises because the default ``depth_draw`` mode is ``depth_draw_opaque``. Throughout the pipeline depth draw opaque is correctly used as the default, however, it order to properly function it needs a corresponding define in the shader "USE_OPAQUE_PREPASS" which only gets added if the render_mode "depth_draw_opaque" is used in the shader:
https://github.com/godotengine/godot/blob/ab7cb2a95d060a6533e6ff5111c11f71972ab43f/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp#L699

So when you have a shader without a depth_draw_mode it ends up not functioning correctly in some cases. In this case the issue only arose when no depth_draw_mode is set and ``depth_prepass_alpha`` was used. Accordingly, the object would be included in the prepass despite having alpha, but the prepass wouldn't discard any transparent pixels, leading to a big hole where the mesh should draw. 