### PR TITLE
Update size or size cache when toggling `expand_icon` in `Button`

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -46,6 +46,9 @@ void Button::_set_internal_margin(Side p_side, float p_value) {
 	_internal_margin[p_side] = p_value;
 }
 
+void Button::_queue_update_size_cache() {
+}
+
 void Button::_update_theme_item_cache() {
 	BaseButton::_update_theme_item_cache();
 
@@ -544,6 +547,7 @@ Ref<Texture2D> Button::get_icon() const {
 void Button::set_expand_icon(bool p_enabled) {
 	if (expand_icon != p_enabled) {
 		expand_icon = p_enabled;
+		_queue_update_size_cache();
 		queue_redraw();
 		update_minimum_size();
 	}

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -100,6 +100,7 @@ private:
 protected:
 	void _set_internal_margin(Side p_side, float p_value);
 	virtual void _update_theme_item_cache() override;
+	virtual void _queue_update_size_cache();
 	void _notification(int p_what);
 	static void _bind_methods();
 

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -176,7 +176,7 @@ bool OptionButton::_set(const StringName &p_name, const Variant &p_value) {
 		}
 
 		if (property == "text" || property == "icon") {
-			_queue_refresh_cache();
+			_queue_update_size_cache();
 		}
 
 		return valid;
@@ -243,7 +243,7 @@ void OptionButton::add_icon_item(const Ref<Texture2D> &p_icon, const String &p_l
 	if (first_selectable) {
 		select(get_item_count() - 1);
 	}
-	_queue_refresh_cache();
+	_queue_update_size_cache();
 }
 
 void OptionButton::add_item(const String &p_label, int p_id) {
@@ -252,7 +252,7 @@ void OptionButton::add_item(const String &p_label, int p_id) {
 	if (first_selectable) {
 		select(get_item_count() - 1);
 	}
-	_queue_refresh_cache();
+	_queue_update_size_cache();
 }
 
 void OptionButton::set_item_text(int p_idx, const String &p_text) {
@@ -261,7 +261,7 @@ void OptionButton::set_item_text(int p_idx, const String &p_text) {
 	if (current == p_idx) {
 		set_text(p_text);
 	}
-	_queue_refresh_cache();
+	_queue_update_size_cache();
 }
 
 void OptionButton::set_item_icon(int p_idx, const Ref<Texture2D> &p_icon) {
@@ -270,7 +270,7 @@ void OptionButton::set_item_icon(int p_idx, const Ref<Texture2D> &p_icon) {
 	if (current == p_idx) {
 		set_icon(p_icon);
 	}
-	_queue_refresh_cache();
+	_queue_update_size_cache();
 }
 
 void OptionButton::set_item_id(int p_idx, int p_id) {
@@ -456,7 +456,7 @@ void OptionButton::_refresh_size_cache() {
 	update_minimum_size();
 }
 
-void OptionButton::_queue_refresh_cache() {
+void OptionButton::_queue_update_size_cache() {
 	if (cache_refresh_pending) {
 		return;
 	}
@@ -490,7 +490,7 @@ void OptionButton::remove_item(int p_idx) {
 	if (current == p_idx) {
 		_select(NONE_SELECTED);
 	}
-	_queue_refresh_cache();
+	_queue_update_size_cache();
 }
 
 PopupMenu *OptionButton::get_popup() const {

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -66,13 +66,13 @@ class OptionButton : public Button {
 	void _select(int p_which, bool p_emit = false);
 	void _select_int(int p_which);
 	void _refresh_size_cache();
-	void _queue_refresh_cache();
 
 	virtual void pressed() override;
 
 protected:
 	Size2 get_minimum_size() const override;
 	virtual void _update_theme_item_cache() override;
+	virtual void _queue_update_size_cache() override;
 	void _notification(int p_what);
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;


### PR DESCRIPTION
When the `expand_icon` is switched, the size cache can be updated to solve the issue that the cache cannot be updated when the `OptionButton` is enabled with `fit_to_longest_item`.

Fix #68930. Combining with #64351 may work even better.

| Commit | Image |
| :--------: | :---------: | 
| Before | ![0](https://user-images.githubusercontent.com/30386067/231332466-d9b7862a-d8f1-4f28-9e0a-f1254472d4ce.gif) |
| This PR | ![1](https://user-images.githubusercontent.com/30386067/231332742-da76aedc-464a-46c9-9ec6-8653772dab7a.gif) |
| This + #64351| ![2](https://user-images.githubusercontent.com/30386067/231332472-999deaa2-7572-43e8-a507-0e2132e85b40.gif) |

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
