### PR TITLE
[3.x] Add tab Metadata to Tabs & TabContainer

### DIFF
--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -72,6 +72,13 @@
 				Returns the index of the tab at local coordinates [code]point[/code]. Returns [code]-1[/code] if the point is outside the control boundaries or if there's no tab at the queried position.
 			</description>
 		</method>
+		<method name="get_tab_metadata" qualifiers="const">
+			<return type="Variant" />
+			<argument index="0" name="tab_idx" type="int" />
+			<description>
+				Returns the metadata value set to the tab at index [code]tab_idx[/code]. If no metadata was previously set, returns [code]null[/code] by default.
+			</description>
+		</method>
 		<method name="get_tab_title" qualifiers="const">
 			<return type="String" />
 			<argument index="0" name="tab_idx" type="int" />
@@ -114,6 +121,14 @@
 			<argument index="1" name="icon" type="Texture" />
 			<description>
 				Sets an icon for the tab at index [code]tab_idx[/code].
+			</description>
+		</method>
+		<method name="set_tab_metadata">
+			<return type="void" />
+			<argument index="0" name="tab_idx" type="int" />
+			<argument index="1" name="metadata" type="Variant" />
+			<description>
+				Sets the metadata value for the tab at index [code]tab_idx[/code].
 			</description>
 		</method>
 		<method name="set_tab_title">

--- a/doc/classes/Tabs.xml
+++ b/doc/classes/Tabs.xml
@@ -69,6 +69,13 @@
 				Returns the [Texture] for the tab at index [code]tab_idx[/code] or [code]null[/code] if the tab has no [Texture].
 			</description>
 		</method>
+		<method name="get_tab_metadata" qualifiers="const">
+			<return type="Variant" />
+			<argument index="0" name="tab_idx" type="int" />
+			<description>
+				Returns the metadata value set to the tab at index [code]tab_idx[/code]. If no metadata was previously set, returns [code]null[/code] by default.
+			</description>
+		</method>
 		<method name="get_tab_offset" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -139,6 +146,14 @@
 			<argument index="1" name="icon" type="Texture" />
 			<description>
 				Sets an [code]icon[/code] for the tab at index [code]tab_idx[/code].
+			</description>
+		</method>
+		<method name="set_tab_metadata">
+			<return type="void" />
+			<argument index="0" name="tab_idx" type="int" />
+			<argument index="1" name="metadata" type="Variant" />
+			<description>
+				Sets the metadata value for the tab at index [code]tab_idx[/code].
 			</description>
 		</method>
 		<method name="set_tab_title">

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -931,6 +931,22 @@ bool TabContainer::get_tab_hidden(int p_tab) const {
 	}
 }
 
+void TabContainer::set_tab_metadata(int p_tab, const Variant &p_metadata) {
+	Control *child = get_tab_control(p_tab);
+	ERR_FAIL_COND(!child);
+	child->set_meta("_tab_metadata", p_metadata);
+}
+
+Variant TabContainer::get_tab_metadata(int p_tab) const {
+	Control *child = get_tab_control(p_tab);
+	ERR_FAIL_COND_V(!child, Variant());
+	if (child->has_meta("_tab_metadata")) {
+		return child->get_meta("_tab_metadata");
+	} else {
+		return Variant();
+	}
+}
+
 void TabContainer::get_translatable_strings(List<String> *p_strings) const {
 	Vector<Control *> tabs = _get_tabs();
 	for (int i = 0; i < tabs.size(); i++) {
@@ -1047,6 +1063,8 @@ void TabContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tab_disabled", "tab_idx"), &TabContainer::get_tab_disabled);
 	ClassDB::bind_method(D_METHOD("set_tab_hidden", "tab_idx", "hidden"), &TabContainer::set_tab_hidden);
 	ClassDB::bind_method(D_METHOD("get_tab_hidden", "tab_idx"), &TabContainer::get_tab_hidden);
+	ClassDB::bind_method(D_METHOD("set_tab_metadata", "tab_idx", "metadata"), &TabContainer::set_tab_metadata);
+	ClassDB::bind_method(D_METHOD("get_tab_metadata", "tab_idx"), &TabContainer::get_tab_metadata);
 	ClassDB::bind_method(D_METHOD("get_tab_idx_at_point", "point"), &TabContainer::get_tab_idx_at_point);
 	ClassDB::bind_method(D_METHOD("set_popup", "popup"), &TabContainer::set_popup);
 	ClassDB::bind_method(D_METHOD("get_popup"), &TabContainer::get_popup);

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -107,6 +107,9 @@ public:
 	void set_tab_hidden(int p_tab, bool p_hidden);
 	bool get_tab_hidden(int p_tab) const;
 
+	void set_tab_metadata(int p_tab, const Variant &p_metadata);
+	Variant get_tab_metadata(int p_tab) const;
+
 	int get_tab_count() const;
 	void set_current_tab(int p_current);
 	int get_current_tab() const;

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -472,6 +472,21 @@ bool Tabs::get_tab_disabled(int p_tab) const {
 	return tabs[p_tab].disabled;
 }
 
+void Tabs::set_tab_metadata(int p_tab, const Variant &p_metadata) {
+	ERR_FAIL_INDEX(p_tab, tabs.size());
+
+	if (tabs[p_tab].metadata == p_metadata) {
+		return;
+	}
+
+	tabs.write[p_tab].metadata = p_metadata;
+}
+
+Variant Tabs::get_tab_metadata(int p_tab) const {
+	ERR_FAIL_INDEX_V(p_tab, tabs.size(), Variant());
+	return tabs[p_tab].metadata;
+}
+
 void Tabs::set_tab_right_button(int p_tab, const Ref<Texture> &p_right_button) {
 	ERR_FAIL_INDEX(p_tab, tabs.size());
 	tabs.write[p_tab].right_button = p_right_button;
@@ -961,6 +976,8 @@ void Tabs::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tab_button_icon", "tab_idx"), &Tabs::get_tab_right_button);
 	ClassDB::bind_method(D_METHOD("set_tab_disabled", "tab_idx", "disabled"), &Tabs::set_tab_disabled);
 	ClassDB::bind_method(D_METHOD("get_tab_disabled", "tab_idx"), &Tabs::get_tab_disabled);
+	ClassDB::bind_method(D_METHOD("set_tab_metadata", "tab_idx", "metadata"), &Tabs::set_tab_metadata);
+	ClassDB::bind_method(D_METHOD("get_tab_metadata", "tab_idx"), &Tabs::get_tab_metadata);
 	ClassDB::bind_method(D_METHOD("remove_tab", "tab_idx"), &Tabs::remove_tab);
 	ClassDB::bind_method(D_METHOD("add_tab", "title", "icon"), &Tabs::add_tab, DEFVAL(""), DEFVAL(Ref<Texture>()));
 	ClassDB::bind_method(D_METHOD("set_tab_align", "align"), &Tabs::set_tab_align);

--- a/scene/gui/tabs.h
+++ b/scene/gui/tabs.h
@@ -60,6 +60,7 @@ private:
 		Ref<Texture> icon;
 		int ofs_cache;
 		bool disabled;
+		Variant metadata;
 		int size_cache;
 		int size_text;
 		int x_cache;
@@ -123,6 +124,9 @@ public:
 
 	void set_tab_disabled(int p_tab, bool p_disabled);
 	bool get_tab_disabled(int p_tab) const;
+
+	void set_tab_metadata(int p_tab, const Variant &p_metadata);
+	Variant get_tab_metadata(int p_tab) const;
 
 	void set_tab_right_button(int p_tab, const Ref<Texture> &p_right_button);
 	Ref<Texture> get_tab_right_button(int p_tab) const;


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/6664

This PR adds two new methods to TabContainer & Tabs for getting and setting metadata on individual tabs.

- For Tabs, I simply mirrored the way metadata is handled in ItemList & TreeItem, and added a `Variant metadata;` variable to the Tab struct.
- For TabContainer, metadata is saved on the tab control itself as meta, which is in line with how methods such as `set_tab_title()` and `set_tab_icon()` work.