### PR TITLE
Add tab metadata to TabBar & TabContainer

### DIFF
--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -77,6 +77,13 @@
 				Returns tab title language code.
 			</description>
 		</method>
+		<method name="get_tab_metadata" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="tab_idx" type="int" />
+			<description>
+				Returns the metadata value set to the tab at index [param tab_idx] using [method set_tab_metadata]. If no metadata was previously set, returns [code]null[/code] by default.
+			</description>
+		</method>
 		<method name="get_tab_offset" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -179,6 +186,14 @@
 			<param index="1" name="language" type="String" />
 			<description>
 				Sets language code of tab title used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
+			</description>
+		</method>
+		<method name="set_tab_metadata">
+			<return type="void" />
+			<param index="0" name="tab_idx" type="int" />
+			<param index="1" name="metadata" type="Variant" />
+			<description>
+				Sets the metadata value for the tab at index [param tab_idx], which can be retrieved later using [method get_tab_metadata].
 			</description>
 		</method>
 		<method name="set_tab_text_direction">

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -72,6 +72,13 @@
 				Returns the index of the tab tied to the given [param control]. The control must be a child of the [TabContainer].
 			</description>
 		</method>
+		<method name="get_tab_metadata" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="tab_idx" type="int" />
+			<description>
+				Returns the metadata value set to the tab at index [param tab_idx] using [method set_tab_metadata]. If no metadata was previously set, returns [code]null[/code] by default.
+			</description>
+		</method>
 		<method name="get_tab_title" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="tab_idx" type="int" />
@@ -130,6 +137,14 @@
 			<param index="1" name="icon" type="Texture2D" />
 			<description>
 				Sets an icon for the tab at index [param tab_idx].
+			</description>
+		</method>
+		<method name="set_tab_metadata">
+			<return type="void" />
+			<param index="0" name="tab_idx" type="int" />
+			<param index="1" name="metadata" type="Variant" />
+			<description>
+				Sets the metadata value for the tab at index [param tab_idx], which can be retrieved later using [method get_tab_metadata].
 			</description>
 		</method>
 		<method name="set_tab_title">

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -791,6 +791,21 @@ bool TabBar::is_tab_hidden(int p_tab) const {
 	return tabs[p_tab].hidden;
 }
 
+void TabBar::set_tab_metadata(int p_tab, const Variant &p_metadata) {
+	ERR_FAIL_INDEX(p_tab, tabs.size());
+
+	if (tabs[p_tab].metadata == p_metadata) {
+		return;
+	}
+
+	tabs.write[p_tab].metadata = p_metadata;
+}
+
+Variant TabBar::get_tab_metadata(int p_tab) const {
+	ERR_FAIL_INDEX_V(p_tab, tabs.size(), Variant());
+	return tabs[p_tab].metadata;
+}
+
 void TabBar::set_tab_button_icon(int p_tab, const Ref<Texture2D> &p_icon) {
 	ERR_FAIL_INDEX(p_tab, tabs.size());
 
@@ -1607,6 +1622,8 @@ void TabBar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_tab_disabled", "tab_idx"), &TabBar::is_tab_disabled);
 	ClassDB::bind_method(D_METHOD("set_tab_hidden", "tab_idx", "hidden"), &TabBar::set_tab_hidden);
 	ClassDB::bind_method(D_METHOD("is_tab_hidden", "tab_idx"), &TabBar::is_tab_hidden);
+	ClassDB::bind_method(D_METHOD("set_tab_metadata", "tab_idx", "metadata"), &TabBar::set_tab_metadata);
+	ClassDB::bind_method(D_METHOD("get_tab_metadata", "tab_idx"), &TabBar::get_tab_metadata);
 	ClassDB::bind_method(D_METHOD("remove_tab", "tab_idx"), &TabBar::remove_tab);
 	ClassDB::bind_method(D_METHOD("add_tab", "title", "icon"), &TabBar::add_tab, DEFVAL(""), DEFVAL(Ref<Texture2D>()));
 	ClassDB::bind_method(D_METHOD("get_tab_idx_at_point", "point"), &TabBar::get_tab_idx_at_point);

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -66,6 +66,7 @@ private:
 
 		bool disabled = false;
 		bool hidden = false;
+		Variant metadata;
 		int ofs_cache = 0;
 		int size_cache = 0;
 		int size_text = 0;
@@ -183,6 +184,9 @@ public:
 
 	void set_tab_hidden(int p_tab, bool p_hidden);
 	bool is_tab_hidden(int p_tab) const;
+
+	void set_tab_metadata(int p_tab, const Variant &p_metadata);
+	Variant get_tab_metadata(int p_tab) const;
 
 	void set_tab_button_icon(int p_tab, const Ref<Texture2D> &p_icon);
 	Ref<Texture2D> get_tab_button_icon(int p_tab) const;

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -465,7 +465,9 @@ void TabContainer::_drop_data_fw(const Point2 &p_point, const Variant &p_data, C
 			if (from_tabc && from_tabc->get_tabs_rearrange_group() == get_tabs_rearrange_group()) {
 				// Get the tab properties before they get erased by the child removal.
 				String tab_title = from_tabc->get_tab_title(tab_from_id);
+				Ref<Texture2D> tab_icon = from_tabc->get_tab_icon(tab_from_id);
 				bool tab_disabled = from_tabc->is_tab_disabled(tab_from_id);
+				Variant tab_metadata = from_tabc->get_tab_metadata(tab_from_id);
 
 				// Drop the new tab to the left or right depending on where the target tab is being hovered.
 				if (hover_now != -1) {
@@ -482,7 +484,9 @@ void TabContainer::_drop_data_fw(const Point2 &p_point, const Variant &p_data, C
 				add_child(moving_tabc, true);
 
 				set_tab_title(get_tab_count() - 1, tab_title);
+				set_tab_icon(get_tab_count() - 1, tab_icon);
 				set_tab_disabled(get_tab_count() - 1, tab_disabled);
+				set_tab_metadata(get_tab_count() - 1, tab_metadata);
 
 				move_child(moving_tabc, get_tab_control(hover_now)->get_index(false));
 				if (!is_tab_disabled(hover_now)) {
@@ -794,6 +798,14 @@ bool TabContainer::is_tab_hidden(int p_tab) const {
 	return tab_bar->is_tab_hidden(p_tab);
 }
 
+void TabContainer::set_tab_metadata(int p_tab, const Variant &p_metadata) {
+	tab_bar->set_tab_metadata(p_tab, p_metadata);
+}
+
+Variant TabContainer::get_tab_metadata(int p_tab) const {
+	return tab_bar->get_tab_metadata(p_tab);
+}
+
 void TabContainer::set_tab_button_icon(int p_tab, const Ref<Texture2D> &p_icon) {
 	tab_bar->set_tab_button_icon(p_tab, p_icon);
 
@@ -941,6 +953,8 @@ void TabContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_tab_disabled", "tab_idx"), &TabContainer::is_tab_disabled);
 	ClassDB::bind_method(D_METHOD("set_tab_hidden", "tab_idx", "hidden"), &TabContainer::set_tab_hidden);
 	ClassDB::bind_method(D_METHOD("is_tab_hidden", "tab_idx"), &TabContainer::is_tab_hidden);
+	ClassDB::bind_method(D_METHOD("set_tab_metadata", "tab_idx", "metadata"), &TabContainer::set_tab_metadata);
+	ClassDB::bind_method(D_METHOD("get_tab_metadata", "tab_idx"), &TabContainer::get_tab_metadata);
 	ClassDB::bind_method(D_METHOD("set_tab_button_icon", "tab_idx", "icon"), &TabContainer::set_tab_button_icon);
 	ClassDB::bind_method(D_METHOD("get_tab_button_icon", "tab_idx"), &TabContainer::get_tab_button_icon);
 	ClassDB::bind_method(D_METHOD("get_tab_idx_at_point", "point"), &TabContainer::get_tab_idx_at_point);

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -135,6 +135,9 @@ public:
 	void set_tab_hidden(int p_tab, bool p_hidden);
 	bool is_tab_hidden(int p_tab) const;
 
+	void set_tab_metadata(int p_tab, const Variant &p_metadata);
+	Variant get_tab_metadata(int p_tab) const;
+
 	void set_tab_button_icon(int p_tab, const Ref<Texture2D> &p_icon);
 	Ref<Texture2D> get_tab_button_icon(int p_tab) const;
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/6664

This PR adds two new methods to TabContainer & TabBar for getting and setting metadata on individual tabs.

- For TabBar, I simply mirrored the way metadata is handled in ItemList & TreeItem, and added a `Variant metadata;` variable to the Tab struct.
- For TabContainer, it uses TabBar internally, so I just wrapped its metadata methods.

3.x Version: #75959 