### PR TITLE
Add Levenshtein distance to ustring class and expose that to GDScript

### DIFF
--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -297,6 +297,7 @@ public:
 	bool is_quoted() const;
 	Vector<String> bigrams() const;
 	float similarity(const String &p_string) const;
+	int edit_distance(const String &p_string) const;
 	String format(const Variant &values, String placeholder = "{_}") const;
 	String replace_first(const String &p_key, const String &p_with) const;
 	String replace(const String &p_key, const String &p_with) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1653,6 +1653,7 @@ static void _register_variant_builtin_methods() {
 	bind_string_method(is_subsequence_ofn, sarray("text"), varray());
 	bind_string_method(bigrams, sarray(), varray());
 	bind_string_method(similarity, sarray("text"), varray());
+	bind_string_method(edit_distance, sarray("text"), varray());
 
 	bind_string_method(format, sarray("values", "placeholder"), varray("{_}"));
 	bind_string_methodv(replace, static_cast<String (String::*)(const String &, const String &) const>(&String::replace), sarray("what", "forwhat"), varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -168,6 +168,20 @@
 				Returns a copy of the string with indentation (leading tabs and spaces) removed. See also [method indent] to add indentation.
 			</description>
 		</method>
+		<method name="edit_distance" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="text" type="String" />
+			<description>
+				Returns the [url=https://en.wikipedia.org/wiki/Levenshtein_distance]Levenshtein Distance[/url] of this string compared to another, also known as the Edit Distance. The returned value represents the minimum number of single-character edits (insertions, deletions or substitutions) required to change this String into the other. For Strings with size less than or equal to 32, it computes the [url=https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance]Damerau-Levenshtein Distance[/url], which besides insertions, deletions and substitutions also takes into account transpositions ([code]abc[/code] becoming [code]acb[/code]).
+				[codeblock]
+				print("ABC123".edit_distance("ABC123")) # Prints 0
+				print("ABC123".edit_distance("XYZ456")) # Prints 6
+				print("ABC123".edit_distance("123ABC")) # Prints 6
+				print("ABC123".edit_distance("abc123")) # Prints 3
+				print("ABC".edit_distance("ACB")) # Prints 1
+				[/codeblock]
+			</description>
+		</method>
 		<method name="ends_with" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="text" type="String" />

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -151,6 +151,20 @@
 				Returns a copy of the string with indentation (leading tabs and spaces) removed. See also [method indent] to add indentation.
 			</description>
 		</method>
+		<method name="edit_distance" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="text" type="String" />
+			<description>
+				Returns the [url=https://en.wikipedia.org/wiki/Levenshtein_distance]Levenshtein Distance[/url] of this string compared to another, also known as the Edit Distance. The returned value represents the minimum number of single-character edits (insertions, deletions or substitutions) required to change this String into the other. For Strings with size less than or equal to 32, it computes the [url=https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance]Damerau-Levenshtein Distance[/url], which besides insertions, deletions and substitutions also takes into account transpositions ([code]abc[/code] becoming [code]acb[/code]).
+				[codeblock]
+				print("ABC123".edit_distance("ABC123")) # Prints 0
+				print("ABC123".edit_distance("XYZ456")) # Prints 6
+				print("ABC123".edit_distance("123ABC")) # Prints 6
+				print("ABC123".edit_distance("abc123")) # Prints 3
+				print("ABC".edit_distance("ACB")) # Prints 1
+				[/codeblock]
+			</description>
+		</method>
 		<method name="ends_with" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="text" type="String" />


### PR DESCRIPTION
## Description

This PR adds a fast Levenshtein Distance implementation to the String class. The implementation is exposed through the edit_distance method, which has also been made accessible to GDScript.

The Levenshtein distance is a measure of how many edits one String needs to become another. It's similar to the Sorensen-Dice coefficient ('similarity' method in the String class), in the sense that both measure how much one String is similar to another, but Levenshtein is usually more accurate when it comes to error correction (i.e., typos).

The Damerau-Levenshtein (Levenshtein, but with transposition as one of the valid transformations) distance has been implemented for Strings with size less than or equal to 32.

Unit tests have also been added, which compare this implementation against a naive one, resulting in a 100% match.

## Reason

I'm working on a Quick Open refactor, which will make use of this API to suggest better matches for searches. This could be done with the similarity method, but as stated previously, the Levenshtein distance generally works better for the type of suggestions the Quick Open have to do.


## Next step

A good next step would be improving this implementation by computing the Damerau-Levenshtein distance for all lengths.

## Sources

Sources:
  - About the "fast" claim:
    - This implementation is 1.96x faster than the naive approach when comparing 250 randomly generated strings, with a runtime of 5021 vs 9880 msec on a Ryzen 5 5600G.
  - This implementation is based off: https://github.com/ka-weihe/fastest-levenshtein
  - About the error correction claim: https://jacoby.github.io/2019/01/08/levenshtein-sorensendice-and-practical-information-theory.html
  - About the Damerau-Levenshtein Distance: https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance
- Damerau-Levenshtein distance implemented according to this paper: https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.19.7158&rep=rep1&type=pdf

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
