### PR TITLE
Ensure that depth write state is updated before transparent pass in OpenGL3 renderer

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1948,7 +1948,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	glDepthFunc(GL_LEQUAL);
 	glDepthMask(GL_TRUE);
 	scene_state.current_depth_test = GLES3::SceneShaderData::DEPTH_TEST_ENABLED;
-	scene_state.current_depth_draw = GLES3::SceneShaderData::DEPTH_DRAW_OPAQUE;
+	scene_state.current_depth_draw = GLES3::SceneShaderData::DEPTH_DRAW_ALWAYS;
 
 	if (!fb_cleared) {
 		glClearDepth(1.0f);
@@ -1976,19 +1976,17 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 
 	_render_list_template<PASS_MODE_COLOR>(&render_list_params, &render_data, 0, render_list[RENDER_LIST_OPAQUE].elements.size());
 
+	glDepthMask(GL_FALSE);
+	scene_state.current_depth_draw = GLES3::SceneShaderData::DEPTH_DRAW_DISABLED;
+
 	if (draw_sky) {
 		RENDER_TIMESTAMP("Render Sky");
-		if (scene_state.current_depth_test != GLES3::SceneShaderData::DEPTH_TEST_ENABLED) {
-			glEnable(GL_DEPTH_TEST);
-			scene_state.current_depth_test = GLES3::SceneShaderData::DEPTH_TEST_ENABLED;
-		}
+
 		glEnable(GL_DEPTH_TEST);
-		glDepthMask(GL_FALSE);
 		glDisable(GL_BLEND);
 		glEnable(GL_CULL_FACE);
 		glCullFace(GL_BACK);
 		scene_state.current_depth_test = GLES3::SceneShaderData::DEPTH_TEST_ENABLED;
-		scene_state.current_depth_draw = GLES3::SceneShaderData::DEPTH_DRAW_DISABLED;
 		scene_state.cull_mode = GLES3::SceneShaderData::CULL_BACK;
 
 		_draw_sky(render_data.environment, render_data.cam_projection, render_data.cam_transform, sky_energy_multiplier, p_camera_data->view_count > 1, flip_y);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/75063

The core of the issue comes from here:
https://github.com/godotengine/godot/blob/ab7cb2a95d060a6533e6ff5111c11f71972ab43f/drivers/gles3/rasterizer_scene_gles3.cpp#L1949-L1951

and here:
https://github.com/godotengine/godot/blob/ab7cb2a95d060a6533e6ff5111c11f71972ab43f/drivers/gles3/rasterizer_scene_gles3.cpp#L2138-L2152

The behaviour of ``DEPTH_DRAW_OPAQUE`` changes depending on if we are in the transparent pass or in the Opaque pass. Further, the setting doesn't get updated unless another depth draw type is used. 

#75063 is fixed just by setting the default depth draw mode to ``DEPTH_DRAW_ALWAYS`` before the opaque pass. However, a similar issue would arise if there were opaque objects in the scene. Therefore, the full solution is to ensure that the depth mode defaults to ``DEPTH_DRAW_DISABLED`` before the transparent pass so the ``glMask()`` state is correctly set regardless of what states were used in the opaque pass. 

This PR also removes a check for the depth test state that was totally unnecessary as the state was set immediately after. 

