### PR TITLE
Add signals for InputEventAction to the Input singleton

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -89,6 +89,22 @@ Input::MouseMode Input::get_mouse_mode() const {
 	return get_mouse_mode_func();
 }
 
+void Input::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_POSTINITIALIZE: {
+			if (!InputMap::get_singleton()) {
+				return;
+			}
+			for (const KeyValue<StringName, InputMap::Action> &E : InputMap::get_singleton()->get_action_map()) {
+				MethodInfo signal_pressed(Variant::NIL, vformat("%s_pressed", E.key));
+				add_user_signal(signal_pressed);
+				MethodInfo signal_released(Variant::NIL, vformat("%s_released", E.key));
+				add_user_signal(signal_released);
+			}
+		} break;
+	}
+}
+
 void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_anything_pressed"), &Input::is_anything_pressed);
 	ClassDB::bind_method(D_METHOD("is_key_pressed", "keycode"), &Input::is_key_pressed);
@@ -165,6 +181,7 @@ void Input::_bind_methods() {
 	BIND_ENUM_CONSTANT(CURSOR_HSPLIT);
 	BIND_ENUM_CONSTANT(CURSOR_HELP);
 
+	ADD_SIGNAL(MethodInfo("action_toggled", PropertyInfo(Variant::STRING, "action"), PropertyInfo(Variant::BOOL, "pressed")));
 	ADD_SIGNAL(MethodInfo("joy_connection_changed", PropertyInfo(Variant::INT, "device"), PropertyInfo(Variant::BOOL, "connected")));
 }
 
@@ -680,6 +697,14 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 				action.raw_strength = 0.0f;
 				action.exact = InputMap::get_singleton()->event_is_action(p_event, E.key, true);
 				action_state[E.key] = action;
+				// For any action
+				emit_signal("action_toggled", E.key, action.pressed);
+				// For specific actions defined in 'InputMap'
+				if (action.pressed) {
+					emit_signal(vformat("%s_pressed", E.key));
+				} else {
+					emit_signal(vformat("%s_released", E.key));
+				}
 			}
 			action_state[E.key].strength = p_event->get_action_strength(E.key);
 			action_state[E.key].raw_strength = p_event->get_action_raw_strength(E.key);

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -240,6 +240,7 @@ private:
 	EventDispatchFunc event_dispatch_function = nullptr;
 
 protected:
+	void _notification(int p_what);
 	static void _bind_methods();
 
 public:

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A singleton that deals with inputs. This includes key presses, mouse buttons and movement, joypads, and input actions. Actions and their events can be set in the [b]Input Map[/b] tab in the [b]Project &gt; Project Settings[/b], or with the [InputMap] class.
+		[b]Note:[/b] For every [InputEventAction] in the [InputMap] there exists a [code]*_pressed[/code] and [code]*_released[/code] signal that can be connected to using [method Object.connect].
 	</description>
 	<tutorials>
 		<link title="Inputs documentation index">$DOCS_URL/tutorials/inputs/index.html</link>
@@ -390,6 +391,13 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="action_toggled">
+			<param index="0" name="action" type="String" />
+			<param index="1" name="pressed" type="bool" />
+			<description>
+				Emitted when an action is pressed or released. Only works for default actions, or those added in the project settings.
+			</description>
+		</signal>
 		<signal name="joy_connection_changed">
 			<param index="0" name="device" type="int" />
 			<param index="1" name="connected" type="bool" />


### PR DESCRIPTION
each InputEventAction of the InputMap will add an `*_pressed` and `*_released` signal that can be connected to.

additionally an `action_toggled` signal was added that will fire for all actions that are triggered by an InputEvent


Implements such usability:
```
func _ready():
    Input.connect('ui_accept_pressed', func(): print('accept action pressed'))
    Input.action_toggled.connect(func(action, pressed): print('%s.pressed is %s' %[action, pressed]))
```

This PR is made to solve this proposal:
Closes https://github.com/godotengine/godot-proposals/issues/1853

This PR essentially updates the work from this closed PR to bring it into alignment with master:
https://github.com/godotengine/godot/pull/43646

That is to say that superficial changes have been made to get it working but the underlying implementation remains the same, and it is in my opinion that the solution constitutes essentially atomic work that could not be significantly changed without causing needless obfuscation.
I am of course, just one person with a biased sense of coding principles and a limited knowledge of all the methods available in the Godot source project, therefore I open this PR in the hopes that it will be merged for the greater benefit of the community, but also to further the discussion about what may need to be changed in order to satisfy the stigma that surrounds the original work.

Some conversation was already had on the dev chat:
https://chat.godotengine.org/channel/devel?msg=n2RaX48Nre7x3CpZC

The general consensus was that the original PR constituted a public distribution in good faith at the time it was authored under the MIT license, and it is thus fair to use. However the question regarding the ship of Theseus does remain unanswered.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
