### PR TITLE
Tree: Fix offset calculation when there are hidden items

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4594,8 +4594,8 @@ int Tree::get_item_offset(TreeItem *p_item) const {
 			return ofs;
 		}
 
-		ofs += compute_item_height(it);
-		if (it != root || !hide_root) {
+		if ((it != root || !hide_root) && it->is_visible()) {
+			ofs += compute_item_height(it);
 			ofs += theme_cache.v_separation;
 		}
 


### PR DESCRIPTION
Fixes #75929

The incorrect behavior was caused by accumulated vseparation for invisible tree items.

Moving `ofs += compute_item_height(it);` into the `if` clause is not necessary because `compute_item_height()` returns 0 for the same condition. But the code looks clearer ;)