### PR TITLE
Add editor setting to enable/disable middle mouse button paste in X11

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -810,6 +810,10 @@
 			The indentation style to use (tabs or spaces).
 			[b]Note:[/b] The [url=$DOCS_URL/tutorials/scripting/gdscript/gdscript_styleguide.html]GDScript style guide[/url] recommends using tabs for indentation. It is advised to change this setting only if you need to work on a project that currently uses spaces for indentation.
 		</member>
+		<member name="text_editor/behavior/input/middle_mouse_button_paste" type="bool" setter="" getter="">
+			If [code]true[/code], enables pasting into the text editor using the middle mouse button.
+			Specific to the Linux/BSD platform.
+		</member>
 		<member name="text_editor/behavior/navigation/drag_and_drop_selection" type="bool" setter="" getter="">
 			If [code]true[/code], allows drag-and-dropping text in the script editor to move text. Disable this if you find yourself accidentally drag-and-dropping text in the script editor.
 		</member>

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1011,6 +1011,8 @@ bool CodeTextEditor::_add_font_size(int p_delta) {
 }
 
 void CodeTextEditor::update_editor_settings() {
+	print_line(vformat("update_editor_settings()"));
+
 	// Theme: Highlighting
 	completion_font_color = EDITOR_GET("text_editor/theme/highlighting/completion_font_color");
 	completion_string_color = EDITOR_GET("text_editor/theme/highlighting/string_color");
@@ -1047,6 +1049,9 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->set_smooth_scroll_enabled(EDITOR_GET("text_editor/behavior/navigation/smooth_scrolling"));
 	text_editor->set_v_scroll_speed(EDITOR_GET("text_editor/behavior/navigation/v_scroll_speed"));
 	text_editor->set_drag_and_drop_selection_enabled(EDITOR_GET("text_editor/behavior/navigation/drag_and_drop_selection"));
+
+	// Behavior: Input
+	text_editor->set_middle_mouse_paste_enabled(EDITOR_GET("text_editor/behavior/input/middle_mouse_button_paste"));
 
 	// Behavior: indent
 	text_editor->set_indent_using_spaces(EDITOR_GET("text_editor/behavior/indent/type"));

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -578,6 +578,13 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/behavior/navigation/drag_and_drop_selection", true);
 	_initial_set("text_editor/behavior/navigation/stay_in_script_editor_on_node_selected", true);
 
+	// Behavior: Input
+#ifdef LINUXBSD_ENABLED
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "text_editor/behavior/input/middle_mouse_button_paste", true, "")
+#else
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "text_editor/behavior/input/middle_mouse_button_paste", false, "")
+#endif
+
 	// Behavior: Indent
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/behavior/indent/type", 0, "Tabs,Spaces")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/behavior/indent/size", 4, "1,64,1") // size of 0 crashes.


### PR DESCRIPTION
Implements godotengine/godot-proposals#6450

![image](https://user-images.githubusercontent.com/270928/231745389-8ae86492-f84d-4820-9683-6fba95577056.png)

This adds the editor option to enable to paste when clicking the middle mouse on X11. This setting will only appear and affect Linux/BSD users on X11.

~~**By default, the setting is set to `false`, which changes the current behaviour.** So users that use purposefully that feature right now will have to activate it. This was set because I think that the majority of the users don't want that behaviour.~~

Update: I set the default to `true`, as this is expected in X11 applications.