### PR TITLE
Fix `blend_shape` (shapekey) empty name import.

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -2820,7 +2820,13 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 				if (j == 0) {
 					const Array &target_names = extras.has("targetNames") ? (Array)extras["targetNames"] : Array();
 					for (int k = 0; k < targets.size(); k++) {
-						import_mesh->add_blend_shape(k < target_names.size() ? (String)target_names[k] : String("morph_") + itos(k));
+						String bs_name;
+						if (k < target_names.size() && ((String)target_names[k]).size() != 0) {
+							bs_name = (String)target_names[k];
+						} else {
+							bs_name = String("morph_") + itos(k);
+						}
+						import_mesh->add_blend_shape(bs_name);
 					}
 				}
 


### PR DESCRIPTION
Corresponds to the Blender glTF-Importer PR
https://github.com/KhronosGroup/glTF-Blender-IO/pull/1902

Fixes https://github.com/godotengine/godot/issues/75969

Blender – empty shape key names + PR
![grafik](https://user-images.githubusercontent.com/4047289/231432520-9985d529-3387-49c7-999f-40f260aa3454.png)

Godot – empty shape key names
![grafik](https://user-images.githubusercontent.com/4047289/231496466-73318fd0-9311-42e9-ab69-edec4887d0df.png)

Godot with shape key names
![grafik](https://user-images.githubusercontent.com/4047289/231495980-5329ed70-dc34-4f18-ad73-5664957045cf.png)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
