### PR TITLE
Fix potential null in android text entry system.

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotTextInputWrapper.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotTextInputWrapper.java
@@ -124,11 +124,12 @@ public class GodotTextInputWrapper implements TextWatcher, OnEditorActionListene
 	public boolean onEditorAction(final TextView pTextView, final int pActionID, final KeyEvent pKeyEvent) {
 		if (mEdit == pTextView && isFullScreenEdit() && pKeyEvent != null) {
 			final String characters = pKeyEvent.getCharacters();
-
-			for (int i = 0; i < characters.length(); i++) {
-				final int character = characters.codePointAt(i);
-				GodotLib.key(0, character, 0, true);
-				GodotLib.key(0, character, 0, false);
+			if (characters != null) {
+				for (int i = 0; i < characters.length(); i++) {
+					final int character = characters.codePointAt(i);
+					GodotLib.key(0, character, 0, true);
+					GodotLib.key(0, character, 0, false);
+				}
 			}
 		}
 


### PR DESCRIPTION
[3.x version](https://github.com/godotengine/godot/pull/75992)

Fix a potential null in the android text entry system.

Note the documentation says this value can be null:
https://developer.android.com/reference/android/view/KeyEvent#getCharacters()