### PR TITLE
[3.x] Fix null in Android text entry system.

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotTextInputWrapper.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotTextInputWrapper.java
@@ -124,11 +124,12 @@ public class GodotTextInputWrapper implements TextWatcher, OnEditorActionListene
 	public boolean onEditorAction(final TextView pTextView, final int pActionID, final KeyEvent pKeyEvent) {
 		if (this.mEdit == pTextView && this.isFullScreenEdit() && pKeyEvent != null) {
 			final String characters = pKeyEvent.getCharacters();
-
-			for (int i = 0; i < characters.length(); i++) {
-				final int ch = characters.codePointAt(i);
-				GodotLib.key(ch, 0, ch, true);
-				GodotLib.key(ch, 0, ch, false);
+			if (characters != null) {
+				for (int i = 0; i < characters.length(); i++) {
+					final int ch = characters.codePointAt(i);
+					GodotLib.key(ch, 0, ch, true);
+					GodotLib.key(ch, 0, ch, false);
+				}
 			}
 		}
 


### PR DESCRIPTION
[master version](https://github.com/godotengine/godot/pull/75991)

Fix a potential null in the android text entry system.

Note the documentation says this value can be null:
https://developer.android.com/reference/android/view/KeyEvent#getCharacters()