### PR TITLE
[3.x] Don't apply scale to autohide theme property

### DIFF
--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -898,8 +898,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("vseparation", "GridContainer", 4 * scale);
 	theme->set_constant("separation", "HSplitContainer", 12 * scale);
 	theme->set_constant("separation", "VSplitContainer", 12 * scale);
-	theme->set_constant("autohide", "HSplitContainer", 1 * scale);
-	theme->set_constant("autohide", "VSplitContainer", 1 * scale);
+	theme->set_constant("autohide", "HSplitContainer", 1);
+	theme->set_constant("autohide", "VSplitContainer", 1);
 	theme->set_constant("hseparation", "HFlowContainer", 4 * scale);
 	theme->set_constant("vseparation", "HFlowContainer", 4 * scale);
 	theme->set_constant("hseparation", "VFlowContainer", 4 * scale);


### PR DESCRIPTION
`SplitContainer` theme property `autohide` is a boolean and shouldn't be scaled

4.x version: #75993
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
