### PR TITLE
Fix Windows `StringFileInfo` structure

### DIFF
--- a/core/version.h
+++ b/core/version.h
@@ -40,13 +40,13 @@
 // Defines the main "branch" version. Patch versions in this branch should be
 // forward-compatible.
 // Example: "3.1"
-#define VERSION_BRANCH "" _MKSTR(VERSION_MAJOR) "." _MKSTR(VERSION_MINOR)
+#define VERSION_BRANCH _MKSTR(VERSION_MAJOR) "." _MKSTR(VERSION_MINOR)
 #if VERSION_PATCH
 // Example: "3.1.4"
-#define VERSION_NUMBER "" VERSION_BRANCH "." _MKSTR(VERSION_PATCH)
+#define VERSION_NUMBER VERSION_BRANCH "." _MKSTR(VERSION_PATCH)
 #else // patch is 0, we don't include it in the "pretty" version number.
 // Example: "3.1" instead of "3.1.0"
-#define VERSION_NUMBER "" VERSION_BRANCH
+#define VERSION_NUMBER VERSION_BRANCH
 #endif // VERSION_PATCH
 
 // Version number encoded as hexadecimal int with one byte for each number,
@@ -57,16 +57,16 @@
 // Describes the full configuration of that Godot version, including the version number,
 // the status (beta, stable, etc.) and potential module-specific features (e.g. mono).
 // Example: "3.1.4.stable.mono"
-#define VERSION_FULL_CONFIG "" VERSION_NUMBER "." VERSION_STATUS VERSION_MODULE_CONFIG
+#define VERSION_FULL_CONFIG VERSION_NUMBER "." VERSION_STATUS VERSION_MODULE_CONFIG
 
 // Similar to VERSION_FULL_CONFIG, but also includes the (potentially custom) VERSION_BUILD
 // description (e.g. official, custom_build, etc.).
 // Example: "3.1.4.stable.mono.official"
-#define VERSION_FULL_BUILD "" VERSION_FULL_CONFIG "." VERSION_BUILD
+#define VERSION_FULL_BUILD VERSION_FULL_CONFIG "." VERSION_BUILD
 
 // Same as above, but prepended with Godot's name and a cosmetic "v" for "version".
 // Example: "Godot v3.1.4.stable.official.mono"
-#define VERSION_FULL_NAME "" VERSION_NAME " v" VERSION_FULL_BUILD
+#define VERSION_FULL_NAME VERSION_NAME " v" VERSION_FULL_BUILD
 
 // Git commit hash, generated at build time in `core/version_hash.gen.cpp`.
 extern const char *const VERSION_HASH;


### PR DESCRIPTION
Windows editor/template have wrong StringFileInfo structure (part of resources section) which you can check by looking at properties of exe file.
Depending on the tool used to parse resources in exe file you'll see wrong values or lack of some values at all.
Master built version decompiled with Ubuntu shows info like this:
<pre>
BLOCK "StringFileInfo"
{
  BLOCK "040904b0"
  {
    VALUE "CompanyName",       "Godot Engine"
    VALUE "FileDescription",   "Godot Engine"
    <i>VALUE "FileVersion",       ".1"</i>                   <- this is wrong
    VALUE "ProductName",       "Godot Engine"
    VALUE "Licence",           "MIT"
    VALUE "LegalCopyright",    "Copyright (c) 2007-2023 Juan Linietsky, Ariel Manzur and contributors"
    VALUE "Info",              "https://godotengine.org"
    <i>VALUE "ProductVersion4.1.dev.custom_build"</i>        <- this is also wrong
  }
}
</pre>
Fixed branch results in:
```
BLOCK "StringFileInfo"
{
  BLOCK "040904b0"
  {
    VALUE "CompanyName",       "Godot Engine"
    VALUE "FileDescription",   "Godot Engine (Console)"
    VALUE "FileVersion",       "4.1"
    VALUE "ProductName",       "Godot Engine (Console)"
    VALUE "Licence",           "MIT"
    VALUE "LegalCopyright",    "Copyright (c) 2007-2023 Juan Linietsky, Ariel Manzur and contributors"
    VALUE "Info",              "https://godotengine.org"
    VALUE "ProductVersion",    "4.1.dev.custom_build"
  }
}
```