### PR TITLE
Wait for navigation baking to finish before destruction

### DIFF
--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -372,6 +372,10 @@ NavigationRegion3D::NavigationRegion3D() {
 }
 
 NavigationRegion3D::~NavigationRegion3D() {
+	if (bake_thread.is_started()) {
+		bake_thread.wait_to_finish();
+	}
+
 	if (navigation_mesh.is_valid()) {
 		navigation_mesh->disconnect("changed", callable_mp(this, &NavigationRegion3D::_navigation_changed));
 	}


### PR DESCRIPTION
If `NavigationRegion3D` is destroyed while a thread is baking the mesh it could result in a crash. Wait for thread to finish in the destructor of the `NavigationRegion3D` to avoid crashing.

This crash occurs for example when:
* Closing the game
* Switching scenes
* Freeing a node