### PR TITLE
Expose more compression formats in Image and fix compress check

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2649,7 +2649,7 @@ Error Image::compress_from_channels(CompressMode p_mode, UsedChannels p_channels
 			_image_compress_bptc_func(this, p_channels);
 		} break;
 		case COMPRESS_ASTC: {
-			ERR_FAIL_COND_V(!_image_compress_bptc_func, ERR_UNAVAILABLE);
+			ERR_FAIL_COND_V(!_image_compress_astc_func, ERR_UNAVAILABLE);
 			_image_compress_astc_func(this, p_astc_format);
 		} break;
 		case COMPRESS_MAX: {
@@ -3535,6 +3535,8 @@ void Image::_bind_methods() {
 	BIND_ENUM_CONSTANT(COMPRESS_ETC);
 	BIND_ENUM_CONSTANT(COMPRESS_ETC2);
 	BIND_ENUM_CONSTANT(COMPRESS_BPTC);
+	BIND_ENUM_CONSTANT(COMPRESS_ASTC);
+	BIND_ENUM_CONSTANT(COMPRESS_MAX);
 
 	BIND_ENUM_CONSTANT(USED_CHANNELS_L);
 	BIND_ENUM_CONSTANT(USED_CHANNELS_LA);

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -714,6 +714,12 @@
 		<constant name="COMPRESS_BPTC" value="3" enum="CompressMode">
 			Use BPTC compression.
 		</constant>
+		<constant name="COMPRESS_ASTC" value="4" enum="CompressMode">
+			Use ASTC compression.
+		</constant>
+		<constant name="COMPRESS_MAX" value="5" enum="CompressMode">
+			Represents the size of the [enum CompressMode] enum.
+		</constant>
 		<constant name="USED_CHANNELS_L" value="0" enum="UsedChannels">
 		</constant>
 		<constant name="USED_CHANNELS_LA" value="1" enum="UsedChannels">


### PR DESCRIPTION
Check for compressing ASTC checked if the function for BPTC was present

Exposed `COMPRESS_MAX` to match `Format`

Assumed the lack of these enums was an oversight, if it was intended I will reduce this to just fixing the check

Fixes #76013
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
