### PR TITLE
Fix `Image.compress` description

### DIFF
--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -78,7 +78,7 @@
 			<param index="2" name="astc_format" type="int" enum="Image.ASTCFormat" default="0" />
 			<description>
 				Compresses the image to use less memory. Can not directly access pixel data while the image is compressed. Returns error if the chosen compression mode is not available.
-				The [param mode] parameter helps to pick the best compression method for DXT and ETC2 formats. It is ignored for ASTC compression.
+				The [param source] parameter helps to pick the best compression method for DXT and ETC2 formats. It is ignored for ASTC compression.
 				For ASTC compression, the [param astc_format] parameter must be supplied.
 			</description>
 		</method>


### PR DESCRIPTION
Description mentioned `mode` instead of `source`

Based on the code in the function it is `source` that is meant
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
