### PR TITLE
GDScript: Add `@warning_ignore_start` and `@warning_ignore_restore` annotations

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -726,7 +726,7 @@
 				[/codeblock]
 				[b]Note:[/b] Only the script can have a custom icon. Inner classes are not supported.
 				[b]Note:[/b] As annotations describe their subject, the [annotation @icon] annotation must be placed before the class definition and inheritance.
-				[b]Note:[/b] Unlike other annotations, the argument of the [annotation @icon] annotation must be a string literal (constant expressions are not supported).
+				[b]Note:[/b] Unlike most other annotations, the argument of the [annotation @icon] annotation must be a string literal (constant expressions are not supported).
 			</description>
 		</annotation>
 		<annotation name="@onready">
@@ -794,6 +794,33 @@
 				    @warning_ignore("unreachable_code")
 				    print("unreachable")
 				[/codeblock]
+				See also [annotation @warning_ignore_start] and [annotation @warning_ignore_restore].
+			</description>
+		</annotation>
+		<annotation name="@warning_ignore_restore" qualifiers="vararg">
+			<return type="void" />
+			<param index="0" name="warning" type="String" />
+			<description>
+				Stops ignoring the listed warning types after [annotation @warning_ignore_start]. Ignoring the specified warning types will be reset to Project Settings. This annotation can be omitted to ignore the warning types until the end of the file.
+				[b]Note:[/b] Unlike most other annotations, arguments of the [annotation @warning_ignore_restore] annotation must be string literals (constant expressions are not supported).
+			</description>
+		</annotation>
+		<annotation name="@warning_ignore_start" qualifiers="vararg">
+			<return type="void" />
+			<param index="0" name="warning" type="String" />
+			<description>
+				Starts ignoring the listed warning types until the end of the file or the [annotation @warning_ignore_restore] annotation with the given warning type.
+				[codeblock]
+				func test():
+				    var a = 1 # Warning (if enabled in the Project Settings).
+				    @warning_ignore_start("unused_variable")
+				    var b = 2 # No warning.
+				    var c = 3 # No warning.
+				    @warning_ignore_restore("unused_variable")
+				    var d = 4 # Warning (if enabled in the Project Settings).
+				[/codeblock]
+				[b]Note:[/b] To suppress a single warning, use [annotation @warning_ignore] instead.
+				[b]Note:[/b] Unlike most other annotations, arguments of the [annotation @warning_ignore_start] annotation must be string literals (constant expressions are not supported).
 			</description>
 		</annotation>
 	</annotations>

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -962,8 +962,11 @@ static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_a
 				}
 			} break;
 		}
-	} else if (p_annotation->name == SNAME("@warning_ignore")) {
+	} else if (p_annotation->name == SNAME("@warning_ignore") || p_annotation->name == SNAME("@warning_ignore_start") || p_annotation->name == SNAME("@warning_ignore_restore")) {
 		for (int warning_code = 0; warning_code < GDScriptWarning::WARNING_MAX; warning_code++) {
+			if (warning_code == GDScriptWarning::RENAMED_IN_GODOT_4_HINT) {
+				continue;
+			}
 			ScriptLanguage::CodeCompletionOption warning(GDScriptWarning::get_name_from_code((GDScriptWarning::Code)warning_code).to_lower(), ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
 			warning.insert_text = warning.display.quote(p_quote_style);
 			r_result.insert(warning.display, warning);

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1358,6 +1358,7 @@ private:
 	List<GDScriptWarning> warnings;
 	List<PendingWarning> pending_warnings;
 	HashSet<int> warning_ignored_lines[GDScriptWarning::WARNING_MAX];
+	int warning_ignore_start_lines[GDScriptWarning::WARNING_MAX];
 	HashSet<int> unsafe_lines;
 #endif
 
@@ -1506,6 +1507,7 @@ private:
 	void clear_unused_annotations();
 	bool tool_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool icon_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool static_unload_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
@@ -1514,9 +1516,9 @@ private:
 	bool export_tool_button_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyUsageFlags t_usage>
 	bool export_group_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
-	bool warning_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool warning_ignore_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool warning_ignore_region_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool rpc_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
-	bool static_unload_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	// Statements.
 	Node *parse_statement();
 	VariableNode *parse_variable(bool p_is_static);

--- a/modules/gdscript/tests/scripts/analyzer/features/hard_variants.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/hard_variants.gd
@@ -13,7 +13,7 @@ func param_inferred(param := variant()) -> void: print(param)
 func return_untyped(): return variant()
 func return_typed() -> Variant: return variant()
 
-@warning_ignore("unused_variable", "inference_on_variant")
+@warning_ignore_start("unused_variable", "inference_on_variant")
 func test() -> void:
 	var weak = variant()
 	var typed: Variant = variant()
@@ -32,4 +32,4 @@ func test() -> void:
 	if typed != null: pass
 	if typed is Node: pass
 
-	print('ok')
+	print("ok")

--- a/modules/gdscript/tests/scripts/analyzer/features/type_test_usage.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/type_test_usage.gd
@@ -123,4 +123,4 @@ func test():
 	Utils.check((const_null is A) == false)
 	Utils.check(is_instance_of(const_null, A) == false)
 
-	print('ok')
+	print("ok")

--- a/modules/gdscript/tests/scripts/analyzer/features/typed_array_usage.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/typed_array_usage.gd
@@ -20,9 +20,7 @@ class Members:
 		Utils.check(str(two) == '[486]')
 		return true
 
-
-@warning_ignore("unsafe_method_access")
-@warning_ignore("return_value_discarded")
+@warning_ignore_start('unsafe_method_access', 'return_value_discarded')
 func test():
 	var untyped_basic = [459]
 	Utils.check(str(untyped_basic) == '[459]')
@@ -207,7 +205,7 @@ func test():
 
 	var a := A.new()
 	var typed_natives: Array[RefCounted] = [a]
-	var typed_scripts = Array(typed_natives, TYPE_OBJECT, "RefCounted", A)
+	var typed_scripts = Array(typed_natives, TYPE_OBJECT, 'RefCounted', A)
 	Utils.check(typed_scripts[0] == a)
 
 

--- a/modules/gdscript/tests/scripts/analyzer/features/typed_dictionary_usage.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/typed_dictionary_usage.gd
@@ -21,9 +21,7 @@ class Members:
 		return true
 
 
-@warning_ignore("unsafe_method_access")
-@warning_ignore("assert_always_true")
-@warning_ignore("return_value_discarded")
+@warning_ignore_start("unsafe_method_access", "return_value_discarded")
 func test():
 	var untyped_basic = { 459: 954 }
 	Utils.check(str(untyped_basic) == '{ 459: 954 }')

--- a/modules/gdscript/tests/scripts/analyzer/features/vararg_call.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/vararg_call.gd
@@ -1,6 +1,6 @@
 signal ok()
 
-@warning_ignore("return_value_discarded")
+@warning_ignore_start("return_value_discarded")
 func test():
-	ok.connect(func(): print('ok'))
-	emit_signal(&'ok')
+	ok.connect(func(): print("ok"))
+	emit_signal(&"ok")

--- a/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_targets.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_targets.out
@@ -1,6 +1,7 @@
 GDTEST_OK
 ~~ WARNING at line 3: (CONFUSABLE_IDENTIFIER) The identifier "my_vАr" has misleading characters and might be confused with something else.
 ~~ WARNING at line 8: (NARROWING_CONVERSION) Narrowing conversion (float is converted to int and loses precision).
+~~ WARNING at line 14: (NARROWING_CONVERSION) Narrowing conversion (float is converted to int and loses precision).
 ~~ WARNING at line 19: (NARROWING_CONVERSION) Narrowing conversion (float is converted to int and loses precision).
 ~~ WARNING at line 24: (NARROWING_CONVERSION) Narrowing conversion (float is converted to int and loses precision).
 ~~ WARNING at line 27: (CONFUSABLE_IDENTIFIER) The identifier "_my_vАr" has misleading characters and might be confused with something else.

--- a/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.gd
@@ -4,11 +4,10 @@ extends ShadowingBase
 var member: int = 0
 
 var print_debug := 'print_debug'
-@warning_ignore("shadowed_global_identifier")
+@warning_ignore('shadowed_global_identifier')
 var print := 'print'
 
-@warning_ignore("unused_variable")
-@warning_ignore("unused_local_constant")
+@warning_ignore_start('unused_variable', 'unused_local_constant')
 func test():
 	var Array := 'Array'
 	var Node := 'Node'

--- a/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.out
@@ -1,13 +1,13 @@
 GDTEST_OK
 ~~ WARNING at line 6: (SHADOWED_GLOBAL_IDENTIFIER) The variable "print_debug" has the same name as a built-in function.
-~~ WARNING at line 13: (SHADOWED_GLOBAL_IDENTIFIER) The variable "Array" has the same name as a built-in type.
-~~ WARNING at line 14: (SHADOWED_GLOBAL_IDENTIFIER) The variable "Node" has the same name as a native class.
-~~ WARNING at line 15: (SHADOWED_GLOBAL_IDENTIFIER) The variable "is_same" has the same name as a built-in function.
-~~ WARNING at line 16: (SHADOWED_GLOBAL_IDENTIFIER) The variable "sqrt" has the same name as a built-in function.
-~~ WARNING at line 17: (SHADOWED_VARIABLE) The local variable "member" is shadowing an already-declared variable at line 4 in the current class.
-~~ WARNING at line 18: (SHADOWED_VARIABLE_BASE_CLASS) The local variable "reference" is shadowing an already-declared method in the base class "RefCounted".
-~~ WARNING at line 19: (SHADOWED_GLOBAL_IDENTIFIER) The variable "ShadowedClass" has the same name as a global class defined in "shadowning.gd".
-~~ WARNING at line 20: (SHADOWED_VARIABLE_BASE_CLASS) The local variable "base_variable_member" is shadowing an already-declared variable at line 4 in the base class "ShadowingBase".
-~~ WARNING at line 21: (SHADOWED_VARIABLE_BASE_CLASS) The local constant "base_function_member" is shadowing an already-declared function at line 6 in the base class "ShadowingBase".
-~~ WARNING at line 22: (SHADOWED_VARIABLE_BASE_CLASS) The local variable "base_const_member" is shadowing an already-declared constant at line 3 in the base class "ShadowingBase".
+~~ WARNING at line 12: (SHADOWED_GLOBAL_IDENTIFIER) The variable "Array" has the same name as a built-in type.
+~~ WARNING at line 13: (SHADOWED_GLOBAL_IDENTIFIER) The variable "Node" has the same name as a native class.
+~~ WARNING at line 14: (SHADOWED_GLOBAL_IDENTIFIER) The variable "is_same" has the same name as a built-in function.
+~~ WARNING at line 15: (SHADOWED_GLOBAL_IDENTIFIER) The variable "sqrt" has the same name as a built-in function.
+~~ WARNING at line 16: (SHADOWED_VARIABLE) The local variable "member" is shadowing an already-declared variable at line 4 in the current class.
+~~ WARNING at line 17: (SHADOWED_VARIABLE_BASE_CLASS) The local variable "reference" is shadowing an already-declared method in the base class "RefCounted".
+~~ WARNING at line 18: (SHADOWED_GLOBAL_IDENTIFIER) The variable "ShadowedClass" has the same name as a global class defined in "shadowning.gd".
+~~ WARNING at line 19: (SHADOWED_VARIABLE_BASE_CLASS) The local variable "base_variable_member" is shadowing an already-declared variable at line 4 in the base class "ShadowingBase".
+~~ WARNING at line 20: (SHADOWED_VARIABLE_BASE_CLASS) The local constant "base_function_member" is shadowing an already-declared function at line 6 in the base class "ShadowingBase".
+~~ WARNING at line 21: (SHADOWED_VARIABLE_BASE_CLASS) The local variable "base_const_member" is shadowing an already-declared constant at line 3 in the base class "ShadowingBase".
 warn

--- a/modules/gdscript/tests/scripts/parser/errors/warning_ignore_extra_start.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/warning_ignore_extra_start.gd
@@ -1,0 +1,5 @@
+@warning_ignore_start("unreachable_code")
+@warning_ignore_start("unreachable_code")
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/parser/errors/warning_ignore_extra_start.out
+++ b/modules/gdscript/tests/scripts/parser/errors/warning_ignore_extra_start.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Warning "UNREACHABLE_CODE" is already being ignored by "@warning_ignore_start" at line 1.

--- a/modules/gdscript/tests/scripts/parser/errors/warning_ignore_restore_without_start.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/warning_ignore_restore_without_start.gd
@@ -1,0 +1,4 @@
+@warning_ignore_restore("unreachable_code")
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/parser/errors/warning_ignore_restore_without_start.out
+++ b/modules/gdscript/tests/scripts/parser/errors/warning_ignore_restore_without_start.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Warning "UNREACHABLE_CODE" is not being ignored by "@warning_ignore_start".

--- a/modules/gdscript/tests/scripts/parser/features/arrays_dictionaries_nested_const.gd
+++ b/modules/gdscript/tests/scripts/parser/features/arrays_dictionaries_nested_const.gd
@@ -1,6 +1,6 @@
 # https://github.com/godotengine/godot/issues/50285
 
-@warning_ignore("unused_local_constant")
+@warning_ignore_start("unused_local_constant")
 func test():
 	const CONST_INNER_DICTIONARY = { "key": true }
 	const CONST_NESTED_DICTIONARY_OLD_WORKAROUND = {

--- a/modules/gdscript/tests/scripts/parser/features/signal_declaration.gd
+++ b/modules/gdscript/tests/scripts/parser/features/signal_declaration.gd
@@ -1,3 +1,5 @@
+@warning_ignore_start("unused_signal")
+
 # No parentheses.
 signal a
 
@@ -16,13 +18,6 @@ signal d(
 
 # With type hints.
 signal e(a: int, b: Variant, c: Node)
-
-func no_exec():
-	a.emit()
-	b.emit()
-	c.emit()
-	d.emit()
-	e.emit()
 
 func test():
 	print("Ok")

--- a/modules/gdscript/tests/scripts/parser/features/warning_ignore_regions.gd
+++ b/modules/gdscript/tests/scripts/parser/features/warning_ignore_regions.gd
@@ -1,0 +1,26 @@
+@warning_ignore_start("unreachable_code", "narrowing_conversion")
+
+var _a = 1
+@warning_ignore_start("unused_private_class_variable")
+var _b = 2
+var _c = 3
+@warning_ignore_restore("unused_private_class_variable")
+var _d = 4
+
+func test():
+	return
+
+	var a = 1
+	@warning_ignore_start("unused_variable")
+	var b = 2
+	var c = 3
+	@warning_ignore_restore("unused_variable")
+	var d = 4
+
+	var _x: int = 1.0
+	@warning_ignore_restore("narrowing_conversion")
+	var _y: int = 1.0
+
+func test_2():
+	return
+	print(42)

--- a/modules/gdscript/tests/scripts/parser/features/warning_ignore_regions.out
+++ b/modules/gdscript/tests/scripts/parser/features/warning_ignore_regions.out
@@ -1,0 +1,6 @@
+GDTEST_OK
+~~ WARNING at line 3: (UNUSED_PRIVATE_CLASS_VARIABLE) The class variable "_a" is declared but never used in the class.
+~~ WARNING at line 8: (UNUSED_PRIVATE_CLASS_VARIABLE) The class variable "_d" is declared but never used in the class.
+~~ WARNING at line 13: (UNUSED_VARIABLE) The local variable "a" is declared but never used in the block. If this is intended, prefix it with an underscore: "_a".
+~~ WARNING at line 18: (UNUSED_VARIABLE) The local variable "d" is declared but never used in the block. If this is intended, prefix it with an underscore: "_d".
+~~ WARNING at line 22: (NARROWING_CONVERSION) Narrowing conversion (float is converted to int and loses precision).

--- a/modules/gdscript/tests/scripts/runtime/features/assign_operator.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/assign_operator.gd
@@ -1,6 +1,6 @@
 # https://github.com/godotengine/godot/issues/75832
 
-@warning_ignore("narrowing_conversion")
+@warning_ignore_start("narrowing_conversion")
 func test():
 	var hf := 2.0
 	var sf = 2.0

--- a/modules/gdscript/tests/scripts/runtime/features/member_info.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/member_info.gd
@@ -56,6 +56,7 @@ func test_func_hard_int() -> int: return 1
 func test_func_args_1(_a: int, _b: Array[int], _c: Dictionary[int, int], _d: int = 1, _e = 2): pass
 func test_func_args_2(_a = 1, _b = _a, _c = [2], _d = 3): pass
 
+@warning_ignore_start("unused_signal")
 signal test_signal_1()
 signal test_signal_2(a: Variant, b)
 signal test_signal_3(a: int, b: Array[int], c: Dictionary[int, int])
@@ -64,16 +65,7 @@ signal test_signal_5(a: MyEnum, b: Array[MyEnum], c: Dictionary[MyEnum, MyEnum])
 signal test_signal_6(a: Resource, b: Array[Resource], c: Dictionary[Resource, Resource])
 signal test_signal_7(a: TestMemberInfo, b: Array[TestMemberInfo], c: Dictionary[TestMemberInfo, TestMemberInfo])
 signal test_signal_8(a: MyClass, b: Array[MyClass], c: Dictionary[MyClass, MyClass])
-
-func no_exec():
-	test_signal_1.emit()
-	test_signal_2.emit()
-	test_signal_3.emit()
-	test_signal_4.emit()
-	test_signal_5.emit()
-	test_signal_6.emit()
-	test_signal_7.emit()
-	test_signal_8.emit()
+@warning_ignore_restore("unused_signal")
 
 func test():
 	var script: Script = get_script()


### PR DESCRIPTION
* Closes godotengine/godot-proposals#5405.
* Closes godotengine/godot-proposals#5906.
* Resolves #93202.
* **Also removes a controversial undocumented [feature](https://github.com/godotengine/godot/pull/83037#discussion_r1477302018). Instead, you can wrap the function in the annotations.**

![](https://user-images.githubusercontent.com/47700418/231721023-b64ee58a-647c-4252-b60b-63a9edbfa810.png)
