### PR TITLE
Expose dialog parent-and-popup logic to the API

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -205,6 +205,43 @@
 				Plays the main scene.
 			</description>
 		</method>
+		<method name="popup_dialog">
+			<return type="void" />
+			<param index="0" name="dialog" type="Window" />
+			<param index="1" name="rect" type="Rect2i" default="Rect2i(0, 0, 0, 0)" />
+			<description>
+				Pops up the [param dialog] in the editor UI with [method Window.popup_exclusive]. The dialog must have no current parent, otherwise the method fails.
+				See also [method Window.set_unparent_when_invisible].
+			</description>
+		</method>
+		<method name="popup_dialog_centered">
+			<return type="void" />
+			<param index="0" name="dialog" type="Window" />
+			<param index="1" name="minsize" type="Vector2i" default="Vector2i(0, 0)" />
+			<description>
+				Pops up the [param dialog] in the editor UI with [method Window.popup_exclusive_centered]. The dialog must have no current parent, otherwise the method fails.
+				See also [method Window.set_unparent_when_invisible].
+			</description>
+		</method>
+		<method name="popup_dialog_centered_clamped">
+			<return type="void" />
+			<param index="0" name="dialog" type="Window" />
+			<param index="1" name="minsize" type="Vector2i" default="Vector2i(0, 0)" />
+			<param index="2" name="fallback_ratio" type="float" default="0.75" />
+			<description>
+				Pops up the [param dialog] in the editor UI with [method Window.popup_exclusive_centered_clamped]. The dialog must have no current parent, otherwise the method fails.
+				See also [method Window.set_unparent_when_invisible].
+			</description>
+		</method>
+		<method name="popup_dialog_centered_ratio">
+			<return type="void" />
+			<param index="0" name="dialog" type="Window" />
+			<param index="1" name="ratio" type="float" default="0.8" />
+			<description>
+				Pops up the [param dialog] in the editor UI with [method Window.popup_exclusive_centered_ratio]. The dialog must have no current parent, otherwise the method fails.
+				See also [method Window.set_unparent_when_invisible].
+			</description>
+		</method>
 		<method name="reload_scene_from_path">
 			<return type="void" />
 			<param index="0" name="scene_filepath" type="String" />

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -328,6 +328,12 @@
 				If [param include_internal] is [code]false[/code], the index won't take internal children into account, i.e. first non-internal child will have index of 0 (see [code]internal[/code] parameter in [method add_child]).
 			</description>
 		</method>
+		<method name="get_last_exclusive_window" qualifiers="const">
+			<return type="Window" />
+			<description>
+				Returns the [Window] that contains this node, or the last exclusive child in a chain of windows starting with the one that contains this node.
+			</description>
+		</method>
 		<method name="get_multiplayer_authority" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -375,6 +375,52 @@
 				Popups the [Window] centered inside its parent [Window] and sets its size as a [param ratio] of parent's size.
 			</description>
 		</method>
+		<method name="popup_exclusive">
+			<return type="void" />
+			<param index="0" name="from_node" type="Node" />
+			<param index="1" name="rect" type="Rect2i" default="Rect2i(0, 0, 0, 0)" />
+			<description>
+				Attempts to parent this dialog to the last exclusive window relative to [param from_node], and then calls [method Window.popup] on it. The dialog must have no current parent, otherwise the method fails.
+				See also [method set_unparent_when_invisible] and [method Node.get_last_exclusive_window].
+			</description>
+		</method>
+		<method name="popup_exclusive_centered">
+			<return type="void" />
+			<param index="0" name="from_node" type="Node" />
+			<param index="1" name="minsize" type="Vector2i" default="Vector2i(0, 0)" />
+			<description>
+				Attempts to parent this dialog to the last exclusive window relative to [param from_node], and then calls [method Window.popup_centered] on it. The dialog must have no current parent, otherwise the method fails.
+				See also [method set_unparent_when_invisible] and [method Node.get_last_exclusive_window].
+			</description>
+		</method>
+		<method name="popup_exclusive_centered_clamped">
+			<return type="void" />
+			<param index="0" name="from_node" type="Node" />
+			<param index="1" name="minsize" type="Vector2i" default="Vector2i(0, 0)" />
+			<param index="2" name="fallback_ratio" type="float" default="0.75" />
+			<description>
+				Attempts to parent this dialog to the last exclusive window relative to [param from_node], and then calls [method Window.popup_centered_clamped] on it. The dialog must have no current parent, otherwise the method fails.
+				See also [method set_unparent_when_invisible] and [method Node.get_last_exclusive_window].
+			</description>
+		</method>
+		<method name="popup_exclusive_centered_ratio">
+			<return type="void" />
+			<param index="0" name="from_node" type="Node" />
+			<param index="1" name="ratio" type="float" default="0.8" />
+			<description>
+				Attempts to parent this dialog to the last exclusive window relative to [param from_node], and then calls [method Window.popup_centered_ratio] on it. The dialog must have no current parent, otherwise the method fails.
+				See also [method set_unparent_when_invisible] and [method Node.get_last_exclusive_window].
+			</description>
+		</method>
+		<method name="popup_exclusive_on_parent">
+			<return type="void" />
+			<param index="0" name="from_node" type="Node" />
+			<param index="1" name="parent_rect" type="Rect2i" />
+			<description>
+				Attempts to parent this dialog to the last exclusive window relative to [param from_node], and then calls [method Window.popup_on_parent] on it. The dialog must have no current parent, otherwise the method fails.
+				See also [method set_unparent_when_invisible] and [method Node.get_last_exclusive_window].
+			</description>
+		</method>
 		<method name="popup_on_parent">
 			<return type="void" />
 			<param index="0" name="parent_rect" type="Rect2i" />
@@ -463,6 +509,14 @@
 			<param index="0" name="direction" type="int" enum="Window.LayoutDirection" />
 			<description>
 				Sets layout direction and text writing direction. Right-to-left layouts are necessary for certain languages (e.g. Arabic and Hebrew).
+			</description>
+		</method>
+		<method name="set_unparent_when_invisible">
+			<return type="void" />
+			<param index="0" name="unparent" type="bool" />
+			<description>
+				If [param unparent] is [code]true[/code], the window is automatically unparented when going invisible.
+				[b]Note:[/b] Make sure to keep a reference to the node, otherwise it will be orphaned. You also need to manually call [method Node.queue_free] to free the window if it's not parented.
 			</description>
 		</method>
 		<method name="set_use_font_oversampling">

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -42,6 +42,7 @@
 #include "main/main.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/control.h"
+#include "scene/main/window.h"
 
 EditorInterface *EditorInterface::singleton = nullptr;
 
@@ -221,6 +222,22 @@ float EditorInterface::get_editor_scale() const {
 	return EDSCALE;
 }
 
+void EditorInterface::popup_dialog(Window *p_dialog, const Rect2i &p_screen_rect) {
+	p_dialog->popup_exclusive(EditorNode::get_singleton(), p_screen_rect);
+}
+
+void EditorInterface::popup_dialog_centered(Window *p_dialog, const Size2i &p_minsize) {
+	p_dialog->popup_exclusive_centered(EditorNode::get_singleton(), p_minsize);
+}
+
+void EditorInterface::popup_dialog_centered_ratio(Window *p_dialog, float p_ratio) {
+	p_dialog->popup_exclusive_centered_ratio(EditorNode::get_singleton(), p_ratio);
+}
+
+void EditorInterface::popup_dialog_centered_clamped(Window *p_dialog, const Size2i &p_size, float p_fallback_ratio) {
+	p_dialog->popup_exclusive_centered_clamped(EditorNode::get_singleton(), p_size, p_fallback_ratio);
+}
+
 // Editor docks.
 
 FileSystemDock *EditorInterface::get_file_system_dock() const {
@@ -379,6 +396,11 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_distraction_free_mode_enabled"), &EditorInterface::is_distraction_free_mode_enabled);
 
 	ClassDB::bind_method(D_METHOD("get_editor_scale"), &EditorInterface::get_editor_scale);
+
+	ClassDB::bind_method(D_METHOD("popup_dialog", "dialog", "rect"), &EditorInterface::popup_dialog, DEFVAL(Rect2i()));
+	ClassDB::bind_method(D_METHOD("popup_dialog_centered", "dialog", "minsize"), &EditorInterface::popup_dialog_centered, DEFVAL(Size2i()));
+	ClassDB::bind_method(D_METHOD("popup_dialog_centered_ratio", "dialog", "ratio"), &EditorInterface::popup_dialog_centered_ratio, DEFVAL(0.8));
+	ClassDB::bind_method(D_METHOD("popup_dialog_centered_clamped", "dialog", "minsize", "fallback_ratio"), &EditorInterface::popup_dialog_centered_clamped, DEFVAL(Size2i()), DEFVAL(0.75));
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "distraction_free_mode"), "set_distraction_free_mode", "is_distraction_free_mode_enabled");
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -50,6 +50,7 @@ class Node;
 class ScriptEditor;
 class Texture2D;
 class VBoxContainer;
+class Window;
 
 class EditorInterface : public Object {
 	GDCLASS(EditorInterface, Object);
@@ -93,6 +94,11 @@ public:
 	bool is_distraction_free_mode_enabled() const;
 
 	float get_editor_scale() const;
+
+	void popup_dialog(Window *p_dialog, const Rect2i &p_screen_rect = Rect2i());
+	void popup_dialog_centered(Window *p_dialog, const Size2i &p_minsize = Size2i());
+	void popup_dialog_centered_ratio(Window *p_dialog, float p_ratio = 0.8);
+	void popup_dialog_centered_clamped(Window *p_dialog, const Size2i &p_size = Size2i(), float p_fallback_ratio = 0.75);
 
 	// Editor docks.
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -41,7 +41,6 @@ typedef void (*EditorPluginInitializeCallback)();
 typedef bool (*EditorBuildCallback)();
 
 class AcceptDialog;
-class AcceptDialogAutoReparent;
 class CenterContainer;
 class CheckBox;
 class ColorPicker;
@@ -359,10 +358,10 @@ private:
 	PluginConfigDialog *plugin_config_dialog = nullptr;
 
 	RichTextLabel *load_errors = nullptr;
-	AcceptDialogAutoReparent *load_error_dialog = nullptr;
+	AcceptDialog *load_error_dialog = nullptr;
 
 	RichTextLabel *execute_outputs = nullptr;
-	AcceptDialogAutoReparent *execute_output_dialog = nullptr;
+	AcceptDialog *execute_output_dialog = nullptr;
 
 	Ref<Theme> theme;
 
@@ -377,10 +376,10 @@ private:
 	ConfirmationDialog *import_confirmation = nullptr;
 	ConfirmationDialog *pick_main_scene = nullptr;
 	Button *select_current_scene_button = nullptr;
-	AcceptDialogAutoReparent *accept = nullptr;
-	AcceptDialogAutoReparent *save_accept = nullptr;
+	AcceptDialog *accept = nullptr;
+	AcceptDialog *save_accept = nullptr;
 	EditorAbout *about = nullptr;
-	AcceptDialogAutoReparent *warning = nullptr;
+	AcceptDialog *warning = nullptr;
 
 	int overridden_default_layout = -1;
 	Ref<ConfigFile> default_layout;

--- a/editor/progress_dialog.cpp
+++ b/editor/progress_dialog.cpp
@@ -32,6 +32,7 @@
 
 #include "core/object/message_queue.h"
 #include "core/os/os.h"
+#include "editor/editor_interface.h"
 #include "editor/editor_node.h"
 #include "editor/editor_scale.h"
 #include "main/main.h"
@@ -155,17 +156,7 @@ void ProgressDialog::_popup() {
 	main->set_offset(SIDE_TOP, style->get_margin(SIDE_TOP));
 	main->set_offset(SIDE_BOTTOM, -style->get_margin(SIDE_BOTTOM));
 
-	EditorNode *ed = EditorNode::get_singleton();
-	if (ed && !is_inside_tree()) {
-		Window *w = ed->get_window();
-		while (w && w->get_exclusive_child()) {
-			w = w->get_exclusive_child();
-		}
-		if (w && w != this) {
-			w->add_child(this);
-			popup_centered(ms);
-		}
-	}
+	EditorInterface::get_singleton()->popup_dialog_centered(this, ms);
 }
 
 void ProgressDialog::add_task(const String &p_task, const String &p_label, int p_steps, bool p_can_cancel) {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1735,6 +1735,15 @@ Window *Node::get_window() const {
 	return nullptr;
 }
 
+Window *Node::get_last_exclusive_window() const {
+	Window *w = get_window();
+	while (w && w->get_exclusive_child()) {
+		w = w->get_exclusive_child();
+	}
+
+	return w;
+}
+
 bool Node::is_ancestor_of(const Node *p_node) const {
 	ERR_FAIL_NULL_V(p_node, false);
 	Node *p = p_node->data.parent;
@@ -3297,6 +3306,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_physics_processing_internal"), &Node::is_physics_processing_internal);
 
 	ClassDB::bind_method(D_METHOD("get_window"), &Node::get_window);
+	ClassDB::bind_method(D_METHOD("get_last_exclusive_window"), &Node::get_last_exclusive_window);
 	ClassDB::bind_method(D_METHOD("get_tree"), &Node::get_tree);
 	ClassDB::bind_method(D_METHOD("create_tween"), &Node::create_tween);
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -385,6 +385,7 @@ public:
 	Node *find_parent(const String &p_pattern) const;
 
 	Window *get_window() const;
+	Window *get_last_exclusive_window() const;
 
 	_FORCE_INLINE_ SceneTree *get_tree() const {
 		ERR_FAIL_COND_V(!data.tree, nullptr);

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -121,6 +121,7 @@ private:
 	bool updating_child_controls = false;
 	bool updating_embedded_window = false;
 	bool clamp_to_embedder = false;
+	bool unparent_when_invisible = false;
 
 	LayoutDirection layout_dir = LAYOUT_DIRECTION_INHERITED;
 
@@ -137,6 +138,8 @@ private:
 	void _make_window();
 	void _clear_window();
 	void _update_from_window();
+
+	bool _try_parent_dialog(Node *p_from_node);
 
 	Size2i max_size_used;
 
@@ -272,6 +275,8 @@ public:
 	void set_clamp_to_embedder(bool p_enable);
 	bool is_clamped_to_embedder() const;
 
+	void set_unparent_when_invisible(bool p_unparent);
+
 	bool is_in_edited_scene_root() const;
 
 	bool can_draw() const;
@@ -307,11 +312,18 @@ public:
 	Window *get_exclusive_child() const { return exclusive_child; };
 	Window *get_parent_visible_window() const;
 	Viewport *get_parent_viewport() const;
-	void popup(const Rect2i &p_rect = Rect2i());
+
+	void popup(const Rect2i &p_screen_rect = Rect2i());
 	void popup_on_parent(const Rect2i &p_parent_rect);
-	void popup_centered_ratio(float p_ratio = 0.8);
 	void popup_centered(const Size2i &p_minsize = Size2i());
+	void popup_centered_ratio(float p_ratio = 0.8);
 	void popup_centered_clamped(const Size2i &p_size = Size2i(), float p_fallback_ratio = 0.75);
+
+	void popup_exclusive(Node *p_from_node, const Rect2i &p_screen_rect = Rect2i());
+	void popup_exclusive_on_parent(Node *p_from_node, const Rect2i &p_parent_rect);
+	void popup_exclusive_centered(Node *p_from_node, const Size2i &p_minsize = Size2i());
+	void popup_exclusive_centered_ratio(Node *p_from_node, float p_ratio = 0.8);
+	void popup_exclusive_centered_clamped(Node *p_from_node, const Size2i &p_size = Size2i(), float p_fallback_ratio = 0.75);
 
 	Rect2i fit_rect_in_parent(Rect2i p_rect, const Rect2i &p_parent_rect) const;
 	Size2 get_contents_minimum_size() const;


### PR DESCRIPTION
This was introduced in a hacky way before to fix immediate issues with some of the editor windows (see https://github.com/godotengine/godot/pull/73365). But I think we should have this feature generally accessible, so we can address similar issues in other editor windows, and so plugin developers could use it too. In fact, this is probably useful to user projects as well, if they support multiple windows.

So this removes the old hacky class and moves the necessary functionality to other places.

- `EditorInterface` receives new `popup_dialog_*` methods to automatically reparent a window to the editor UI before popping it up.
- `Window` receives `set_unparent_when_invisible`, a new scripting-only method to enable the "unparent this window when visibility changes to not visible" logic. It's scripting-only because using it requires you to have a script, and enabling it by accident can lead to orphan nodes. `Window` also receives new `popup_exclusive_*` methods, which power `EditorInterface` methods secretly.
- `Node` receives `get_last_exclusive_window`, which tries to find the top-most exclusive child of the owner window, or returns the parent window (or nothing, if there is no window); this can be exposed as a part of `Window` as well, but being a part of `Node` makes it easier to use, as it can handle the owner window internally and return a clean result.

-----

Marking as a draft as this is based on the `EditorInterface` refactoring from https://github.com/godotengine/godot/pull/75694.