### PR TITLE
Use Point2 consistently in Control methods

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -765,7 +765,7 @@ void Control::set_anchor_and_offset(Side p_side, real_t p_anchor, real_t p_pos, 
 	set_offset(p_side, p_pos);
 }
 
-void Control::set_begin(const Size2 &p_point) {
+void Control::set_begin(const Point2 &p_point) {
 	ERR_FAIL_COND(!isfinite(p_point.x) || !isfinite(p_point.y));
 	if (data.offset[0] == p_point.x && data.offset[1] == p_point.y) {
 		return;
@@ -776,11 +776,11 @@ void Control::set_begin(const Size2 &p_point) {
 	_size_changed();
 }
 
-Size2 Control::get_begin() const {
-	return Size2(data.offset[0], data.offset[1]);
+Point2 Control::get_begin() const {
+	return Point2(data.offset[0], data.offset[1]);
 }
 
-void Control::set_end(const Size2 &p_point) {
+void Control::set_end(const Point2 &p_point) {
 	if (data.offset[2] == p_point.x && data.offset[3] == p_point.y) {
 		return;
 	}
@@ -790,8 +790,8 @@ void Control::set_end(const Size2 &p_point) {
 	_size_changed();
 }
 
-Size2 Control::get_end() const {
-	return Size2(data.offset[2], data.offset[3]);
+Point2 Control::get_end() const {
+	return Point2(data.offset[2], data.offset[3]);
 }
 
 void Control::set_h_grow_direction(GrowDirection p_direction) {
@@ -1358,11 +1358,11 @@ void Control::set_grow_direction_preset(LayoutPreset p_preset) {
 
 /// Manual positioning.
 
-void Control::_set_position(const Size2 &p_point) {
+void Control::_set_position(const Point2 &p_point) {
 	set_position(p_point);
 }
 
-void Control::set_position(const Size2 &p_point, bool p_keep_offsets) {
+void Control::set_position(const Point2 &p_point, bool p_keep_offsets) {
 	if (p_keep_offsets) {
 		_compute_anchors(Rect2(p_point, data.size_cache), data.offset, data.anchor);
 	} else {


### PR DESCRIPTION
While Size2 and Point2 are just aliases, which is why this doesn't fail compilation, it's nice to have things consistent. I noticed this because my editor highlighted the methods in the header as not implemented, when they clearly were.

Not sure how to check for this throughout the codebase. Would be nice to catch this during the compilation somehow, right?