### PR TITLE
Fix the sliding window problem in linux occur due to reparenting of the window due to decoration. (reverted)

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -3510,6 +3510,15 @@ void DisplayServerX11::_window_changed(XEvent *event) {
 	wd.minimized = _window_minimize_check(window_id);
 	wd.maximized = _window_maximize_check(window_id, "_NET_WM_STATE");
 
+	// Readjusting the window position if the window is being reparented by the window manager for decoration
+	Window root, parent, *children;
+	unsigned int nchildren;
+	if (XQueryTree(x11_display, wd.x11_window, &root, &parent, &children, &nchildren) && wd.parent != parent) {
+		wd.parent = parent;
+		window_set_position(wd.position, window_id);
+	}
+	XFree(children);
+
 	{
 		//the position in xconfigure is not useful here, obtain it manually
 		int x = 0, y = 0;
@@ -4994,6 +5003,7 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 	{
 		wd.x11_window = XCreateWindow(x11_display, RootWindow(x11_display, visualInfo.screen), win_rect.position.x, win_rect.position.y, win_rect.size.width > 0 ? win_rect.size.width : 1, win_rect.size.height > 0 ? win_rect.size.height : 1, 0, visualInfo.depth, InputOutput, visualInfo.visual, valuemask, &windowAttributes);
 
+		wd.parent = RootWindow(x11_display, visualInfo.screen);
 		XSetWindowAttributes window_attributes_ime = {};
 		window_attributes_ime.event_mask = KeyPressMask | KeyReleaseMask | StructureNotifyMask | ExposureMask;
 

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -160,6 +160,7 @@ class DisplayServerX11 : public DisplayServer {
 	struct WindowData {
 		Window x11_window;
 		Window x11_xim_window;
+		Window parent;
 		::XIC xic;
 		bool ime_active = false;
 		bool ime_in_progress = false;


### PR DESCRIPTION
Another solution without delay was discussed in the following PR: #75709 
The caveat for this solution is that if the window manager decides to reparent the reparented window for decorations (which rarely happens in the most popular window managers), it will not work.

Fixes: #75292