### PR TITLE
Prevent double input events on gamepad when running through steam input

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -113,6 +113,7 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_joy_axis", "device", "axis"), &Input::get_joy_axis);
 	ClassDB::bind_method(D_METHOD("get_joy_name", "device"), &Input::get_joy_name);
 	ClassDB::bind_method(D_METHOD("get_joy_guid", "device"), &Input::get_joy_guid);
+	ClassDB::bind_method(D_METHOD("should_ignore_device", "vendor_id", "product_id"), &Input::should_ignore_device);
 	ClassDB::bind_method(D_METHOD("get_connected_joypads"), &Input::get_connected_joypads);
 	ClassDB::bind_method(D_METHOD("get_joy_vibration_strength", "device"), &Input::get_joy_vibration_strength);
 	ClassDB::bind_method(D_METHOD("get_joy_vibration_duration", "device"), &Input::get_joy_vibration_duration);
@@ -1498,6 +1499,11 @@ String Input::get_joy_guid(int p_device) const {
 	return joy_names[p_device].uid;
 }
 
+bool Input::should_ignore_device(int p_vendor_id, int p_product_id) const {
+	uint32_t full_id = (((uint32_t)p_vendor_id) << 16) | ((uint16_t)p_product_id);
+	return ignored_device_ids.has(full_id);
+}
+
 TypedArray<int> Input::get_connected_joypads() {
 	TypedArray<int> ret;
 	HashMap<int, Joypad>::Iterator elem = joy_names.begin();
@@ -1539,6 +1545,27 @@ Input::Input() {
 				continue;
 			}
 			parse_mapping(entries[i]);
+		}
+	}
+
+	String env_ignore_devices = OS::get_singleton()->get_environment("SDL_GAMECONTROLLER_IGNORE_DEVICES");
+	if (!env_ignore_devices.is_empty()) {
+		Vector<String> entries = env_ignore_devices.split(",");
+		for (int i = 0; i < entries.size(); i++) {
+			Vector<String> vid_pid = entries[i].split("/");
+
+			if (vid_pid.size() < 2) {
+				continue;
+			}
+
+			print_verbose(vformat("Device Ignored -- Vendor: %s Product: %s", vid_pid[0], vid_pid[1]));
+			const uint16_t vid_unswapped = vid_pid[0].hex_to_int();
+			const uint16_t pid_unswapped = vid_pid[1].hex_to_int();
+			const uint16_t vid = BSWAP16(vid_unswapped);
+			const uint16_t pid = BSWAP16(pid_unswapped);
+
+			uint32_t full_id = (((uint32_t)vid) << 16) | ((uint16_t)pid);
+			ignored_device_ids.insert(full_id);
 		}
 	}
 

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -154,6 +154,9 @@ private:
 	VelocityTrack mouse_velocity_track;
 	HashMap<int, VelocityTrack> touch_velocity_track;
 	HashMap<int, Joypad> joy_names;
+
+	HashSet<uint32_t> ignored_device_ids;
+
 	int fallback_mapping = -1;
 
 	CursorShape default_shape = CURSOR_ARROW;
@@ -328,6 +331,7 @@ public:
 
 	bool is_joy_known(int p_device);
 	String get_joy_guid(int p_device) const;
+	bool should_ignore_device(int p_vendor_id, int p_product_id) const;
 	void set_fallback_mapping(String p_guid);
 
 	void flush_buffered_events();

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -343,6 +343,15 @@
 				[b]Note:[/b] This value can be immediately overwritten by the hardware sensor value on Android and iOS.
 			</description>
 		</method>
+		<method name="should_ignore_device" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="vendor_id" type="int" />
+			<param index="1" name="product_id" type="int" />
+			<description>
+				Queries whether an input device should be ignored or not. Devices can be ignored by setting the environment variable [code]SDL_GAMECONTROLLER_IGNORE_DEVICES[/code]. Read the [url=https://wiki.libsdl.org/SDL2]SDL documentation[/url] for more information.
+				[b]Note:[/b] Some 3rd party tools can contribute to the list of ignored devices. For example, [i]SteamInput[/i] creates virtual devices from physical devices for remapping purposes. To avoid handling the same input device twice, the original device is added to the ignore list.
+			</description>
+		</method>
 		<method name="start_joy_vibration">
 			<return type="void" />
 			<param index="0" name="device" type="int" />

--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -391,6 +391,16 @@ void JoypadLinux::open_joypad(const char *p_path) {
 			return;
 		}
 
+		uint16_t vendor = BSWAP16(inpid.vendor);
+		uint16_t product = BSWAP16(inpid.product);
+		uint16_t version = BSWAP16(inpid.version);
+
+		if (input->should_ignore_device(vendor, product)) {
+			// This can be true in cases where Steam is passing information into the game to ignore
+			// original gamepads when using virtual rebindings (See SteamInput).
+			return;
+		}
+
 		MutexLock lock(joypads_mutex[joy_num]);
 		Joypad &joypad = joypads[joy_num];
 		joypad.reset();
@@ -399,10 +409,6 @@ void JoypadLinux::open_joypad(const char *p_path) {
 		setup_joypad_properties(joypad);
 		sprintf(uid, "%04x%04x", BSWAP16(inpid.bustype), 0);
 		if (inpid.vendor && inpid.product && inpid.version) {
-			uint16_t vendor = BSWAP16(inpid.vendor);
-			uint16_t product = BSWAP16(inpid.product);
-			uint16_t version = BSWAP16(inpid.version);
-
 			sprintf(uid + String(uid).length(), "%04x%04x%04x%04x%04x%04x", vendor, 0, product, 0, version, 0);
 			input->joy_connection_changed(joy_num, true, name, uid);
 		} else {


### PR DESCRIPTION
Fixes #75480 

# The Problem
During GDC2023 and when generally testing on Steam Deck units, we found that a single gamepad would often register inputs twice under certain circumstances. This was caused by SteamInput creating a new virtual device, which Godot registers as a second gamepad. This resulted in two gamepad devices reporting the same button presses, often leading to buggy input response on games with no multi-device logic or otherwise could cause Steam controller rebindings to not work as intended (for example, swapping `o` and `x` on a PlayStation pad if that feature isn't supported by the game.)

SDL2 gets around this by taking in a list of devices that are to be ignored via system environment. When valve sees a controller that wants to be routed through SteamInput, they push a new `VID/PID` entry onto the environment variable `SDL_GAMECONTROLLER_IGNORE_DEVICES` matching the source gamepad so that the SDL based games will only read inputs from the virtual device remappings.

## Proposed Solution
This PR fixes this issue by leveraging the same logic that SDL uses. As we are already using SDL gamepad related HID mappings, there shouldn't be much harm in leveraging another environment variable for usb device ignoring capabilities.

This feature is currently only being used on LinuxBSD platform, but can be applied to other platforms that need it due to the implementation in the Input class. 

## Considerations

- This environment variable parsing and `should_ignore_device` api could be moved to another class. For example, they could be stored in `JoypadLinux/JoypadOSX/JoypadXXX` if we determine that we only really need this functionality for a few select platforms.
- It's very likely that this logic will also be needed on OSX as SDL2 does so on that platform as well. I don't have a computer to test this so I left it unimplemented. In theory, JoypadOSX would also simply call `should_ignore_device` before registering controller connection to determine whether or not the device should be ignored.
- Windows *supposedly* **doesn't** need to take this into account, as Valve is doing their own thing on that platform with regards to virtual game inputs. Having said that, if it is determined that Windows does need this, it should also use a pretty similar solution to what's provided here.


## Testing Procedure

<details>
   <summary> Collapsed for ease-of-reading </summary>

### Reproduction, Verification

- Download the attached testing project
- Get vanilla Godot 4.0 template_debug export target
- Verify that only 1 `A Button` press occurs when running the testing project standalone (no steam)
- Export the testing project as a game via vanilla 4.0
- Load the game via Steam, make sure that Steam Input is enabled for your device (on Xbox/Nintendo controllers, this often needs to be done manually.)
- Observe when you press the A button (or X Button on PS layout, or the B Button on Nintendo controller layout) that there's two button presses registered on a single frame for the single gamepad.

### Testing

- Compile this branch, both editor and template_debug export target.
- Verify that only 1 button press occurs when running the testing project standalone (no steam)
- Load the testing project in the editor and export.
- Reload the game via Steam, making sure to use the same Steam Input settings as the reproduction.
- Observe when you press the A button (or X button PS layout, B button Nintendo layout) there's now only one button press registered for the single gamepad. 

- [x] Controller input should work when running Godot without steam input
- [x] Controller input should work when running Godot through steam input, with only one button press registered per button.
- [x] Controllers should be rebindable via SteamInput when the user wants to take advantage of system-level customization features (for example, swapping buttons or axis.) 
</details>

[bug75480.zip](https://github.com/godotengine/godot/files/11229184/bug75480.zip)

   