### PR TITLE
Implement zooming and panning in the profiler

### DIFF
--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -104,6 +104,11 @@ private:
 	TextureRect *graph = nullptr;
 	Ref<ImageTexture> graph_texture;
 	Vector<uint8_t> graph_image;
+
+	float graph_zoom = 0.0f;
+	float pan_accumulator = 0.0f;
+	int zoom_center = -1;
+
 	Tree *variables = nullptr;
 	HSplitContainer *h_split = nullptr;
 
@@ -155,6 +160,7 @@ private:
 	void _graph_tex_input(const Ref<InputEvent> &p_ev);
 
 	Color _get_color_from_signature(const StringName &p_signature) const;
+	int _get_zoom_left_border() const;
 
 	void _cursor_metric_changed(double);
 


### PR DESCRIPTION
As mentioned in godotengine/godot-proposals#2045 and the quite old #5682. Uses mouse wheel for zooming and middle click drag for panning. Little demonstration included below.

https://user-images.githubusercontent.com/30383615/232031698-691542cb-de74-4dbc-ba39-547ebf2beb28.mp4
