### PR TITLE
Reorganize the meaning of engine axes.

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -1016,12 +1016,15 @@ void Basis::rotate_sh(real_t *p_values) {
 	p_values[8] = d4 * s_scale_dst4;
 }
 
-Basis Basis::looking_at(const Vector3 &p_target, const Vector3 &p_up) {
+Basis Basis::looking_at(const Vector3 &p_target, const Vector3 &p_up, bool p_z_plus_as_forward) {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(p_target.is_zero_approx(), Basis(), "The target vector can't be zero.");
 	ERR_FAIL_COND_V_MSG(p_up.is_zero_approx(), Basis(), "The up vector can't be zero.");
 #endif
-	Vector3 v_z = -p_target.normalized();
+	Vector3 v_z = p_target.normalized();
+	if (!p_z_plus_as_forward) {
+		v_z = -v_z;
+	}
 	Vector3 v_x = p_up.cross(v_z);
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(v_x.is_zero_approx(), Basis(), "The target vector and up vector can't be parallel to each other.");

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -217,7 +217,7 @@ struct _NO_DISCARD_ Basis {
 
 	operator Quaternion() const { return get_quaternion(); }
 
-	static Basis looking_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0));
+	static Basis looking_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0), bool p_z_plus_as_forward = false);
 
 	Basis(const Quaternion &p_quaternion) { set_quaternion(p_quaternion); };
 	Basis(const Quaternion &p_quaternion, const Vector3 &p_scale) { set_quaternion_scale(p_quaternion, p_scale); }

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -77,20 +77,20 @@ void Transform3D::rotate_basis(const Vector3 &p_axis, real_t p_angle) {
 	basis.rotate(p_axis, p_angle);
 }
 
-Transform3D Transform3D::looking_at(const Vector3 &p_target, const Vector3 &p_up) const {
+Transform3D Transform3D::looking_at(const Vector3 &p_target, const Vector3 &p_up, bool p_z_plus_as_forward) const {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(origin.is_equal_approx(p_target), Transform3D(), "The transform's origin and target can't be equal.");
 #endif
 	Transform3D t = *this;
-	t.basis = Basis::looking_at(p_target - origin, p_up);
+	t.basis = Basis::looking_at(p_target - origin, p_up, p_z_plus_as_forward);
 	return t;
 }
 
-void Transform3D::set_look_at(const Vector3 &p_eye, const Vector3 &p_target, const Vector3 &p_up) {
+void Transform3D::set_look_at(const Vector3 &p_eye, const Vector3 &p_target, const Vector3 &p_up, bool p_z_plus_as_forward) {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_MSG(p_eye.is_equal_approx(p_target), "The eye and target vectors can't be equal.");
 #endif
-	basis = Basis::looking_at(p_target - p_eye, p_up);
+	basis = Basis::looking_at(p_target - p_eye, p_up, p_z_plus_as_forward);
 	origin = p_eye;
 }
 

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -52,8 +52,8 @@ struct _NO_DISCARD_ Transform3D {
 	void rotate(const Vector3 &p_axis, real_t p_angle);
 	void rotate_basis(const Vector3 &p_axis, real_t p_angle);
 
-	void set_look_at(const Vector3 &p_eye, const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0));
-	Transform3D looking_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0)) const;
+	void set_look_at(const Vector3 &p_eye, const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0), bool p_z_plus_as_forward = false);
+	Transform3D looking_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0), bool p_z_plus_as_forward = false) const;
 
 	void scale(const Vector3 &p_scale);
 	Transform3D scaled(const Vector3 &p_scale) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2098,7 +2098,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Basis, is_equal_approx, sarray("b"), varray());
 	bind_method(Basis, is_finite, sarray(), varray());
 	bind_method(Basis, get_rotation_quaternion, sarray(), varray());
-	bind_static_method(Basis, looking_at, sarray("target", "up"), varray(Vector3(0, 1, 0)));
+	bind_static_method(Basis, looking_at, sarray("target", "up", "z_plus_as_forward"), varray(Vector3(0, 1, 0), false));
 	bind_static_method(Basis, from_scale, sarray("scale"), varray());
 	bind_static_method(Basis, from_euler, sarray("euler", "order"), varray((int64_t)EulerOrder::YXZ));
 
@@ -2141,7 +2141,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Transform3D, scaled_local, sarray("scale"), varray());
 	bind_method(Transform3D, translated, sarray("offset"), varray());
 	bind_method(Transform3D, translated_local, sarray("offset"), varray());
-	bind_method(Transform3D, looking_at, sarray("target", "up"), varray(Vector3(0, 1, 0)));
+	bind_method(Transform3D, looking_at, sarray("target", "up", "z_plus_as_forward"), varray(Vector3(0, 1, 0), false));
 	bind_method(Transform3D, interpolate_with, sarray("xform", "weight"), varray());
 	bind_method(Transform3D, is_equal_approx, sarray("xform"), varray());
 	bind_method(Transform3D, is_finite, sarray(), varray());
@@ -2522,12 +2522,20 @@ static void _register_variant_builtin_methods() {
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "ZERO", Vector3(0, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "ONE", Vector3(1, 1, 1));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "INF", Vector3(INFINITY, INFINITY, INFINITY));
+
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "LEFT", Vector3(-1, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "RIGHT", Vector3(1, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "UP", Vector3(0, 1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "DOWN", Vector3(0, -1, 0));
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "CAMERA_FORWARD", Vector3(0, 0, -1));
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "CAMERA_BACK", Vector3(0, 0, 1));
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "FRONT", Vector3(0, 0, 1));
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "REAR", Vector3(0, 0, -1));
+
+#ifndef DISABLE_DEPRECATED
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "FORWARD", Vector3(0, 0, -1));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "BACK", Vector3(0, 0, 1));
+#endif
 
 	_VariantCall::add_constant(Variant::VECTOR4, "AXIS_X", Vector4::AXIS_X);
 	_VariantCall::add_constant(Variant::VECTOR4, "AXIS_Y", Vector4::AXIS_Y);

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -123,6 +123,7 @@
 			<return type="Basis" />
 			<param index="0" name="target" type="Vector3" />
 			<param index="1" name="up" type="Vector3" default="Vector3(0, 1, 0)" />
+			<param index="2" name="z_plus_as_forward" type="bool" default="false" />
 			<description>
 				Creates a Basis with a rotation such that the forward axis (-Z) points towards the [param target] position.
 				The up axis (+Y) points as close to the [param up] vector as possible while staying perpendicular to the forward axis. The resulting Basis is orthonormalized. The [param target] and [param up] vectors cannot be zero, and cannot be parallel to each other.

--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -20,6 +20,25 @@
 				Attach a gizmo to this [code]Node3D[/code].
 			</description>
 		</method>
+		<method name="camera_look_at">
+			<return type="void" />
+			<param index="0" name="target" type="Vector3" />
+			<param index="1" name="up" type="Vector3" default="Vector3(0, 1, 0)" />
+			<description>
+				Rotates the node so that the [constant Vector3.CAMERA_FORWARD] axis (-Z) points toward the [param target] position. Use this method when you want to point a Camera3D node towards a specific positions. For 3D models, [method model_look_at] will properly orient the front in the desired direction.
+				The local up axis (+Y) points as close to the [param up] vector as possible while staying perpendicular to the local forward axis. The resulting transform is orthogonal, and the scale is preserved. Non-uniform scaling may not work correctly.
+				The [param target] position cannot be the same as the node's position, the [param up] vector cannot be zero, and the direction from the node's position to the [param target] vector cannot be parallel to the [param up] vector.
+				Operations take place in global space, which means that the node must be in the scene tree.
+			</description>
+		</method>
+		<method name="camera_look_at_from_position">
+			<return type="void" />
+			<param index="0" name="position" type="Vector3" />
+			<param index="1" name="target" type="Vector3" />
+			<param index="2" name="up" type="Vector3" default="Vector3(0, 1, 0)" />
+			<description>
+			</description>
+		</method>
 		<method name="clear_gizmos">
 			<return type="void" />
 			<description>
@@ -108,7 +127,7 @@
 				Returns [code]true[/code] if the node is present in the [SceneTree], its [member visible] property is [code]true[/code] and all its antecedents are also visible. If any antecedent is hidden, this node will not be visible in the scene tree.
 			</description>
 		</method>
-		<method name="look_at">
+		<method name="look_at" is_deprecated="true">
 			<return type="void" />
 			<param index="0" name="target" type="Vector3" />
 			<param index="1" name="up" type="Vector3" default="Vector3(0, 1, 0)" />
@@ -117,15 +136,37 @@
 				The local up axis (+Y) points as close to the [param up] vector as possible while staying perpendicular to the local forward axis. The resulting transform is orthogonal, and the scale is preserved. Non-uniform scaling may not work correctly.
 				The [param target] position cannot be the same as the node's position, the [param up] vector cannot be zero, and the direction from the node's position to the [param target] vector cannot be parallel to the [param up] vector.
 				Operations take place in global space, which means that the node must be in the scene tree.
+				This method is deprecated, please use [method model_look_at] or [method camera_look_at] depending on your needs.
 			</description>
 		</method>
-		<method name="look_at_from_position">
+		<method name="look_at_from_position" is_deprecated="true">
 			<return type="void" />
 			<param index="0" name="position" type="Vector3" />
 			<param index="1" name="target" type="Vector3" />
 			<param index="2" name="up" type="Vector3" default="Vector3(0, 1, 0)" />
 			<description>
 				Moves the node to the specified [param position], and then rotates the node to point toward the [param target] as per [method look_at]. Operations take place in global space.
+				This method is deprecated, please use [method model_look_at_from_position] or [method camera_look_at_from_position] depending on your needs.
+			</description>
+		</method>
+		<method name="model_look_at">
+			<return type="void" />
+			<param index="0" name="target" type="Vector3" />
+			<param index="1" name="up" type="Vector3" default="Vector3(0, 1, 0)" />
+			<description>
+				Rotates the node so that the [constant Vector3.MODEL_FRONT] axis (+Z) points toward the [param target] position. Use this method when you want to point a 3D model towards a specific position. For 3D cameras ([Camera3D]) use [method camera_look_at].
+				The local up axis (+Y) points as close to the [param up] vector as possible while staying perpendicular to the local forward axis. The resulting transform is orthogonal, and the scale is preserved. Non-uniform scaling may not work correctly.
+				The [param target] position cannot be the same as the node's position, the [param up] vector cannot be zero, and the direction from the node's position to the [param target] vector cannot be parallel to the [param up] vector.
+				Operations take place in global space, which means that the node must be in the scene tree.
+			</description>
+		</method>
+		<method name="model_look_at_from_position">
+			<return type="void" />
+			<param index="0" name="position" type="Vector3" />
+			<param index="1" name="target" type="Vector3" />
+			<param index="2" name="up" type="Vector3" default="Vector3(0, 1, 0)" />
+			<description>
+				Moves the node to the specified [param position], and then rotates the node to point toward the [param target] as per [method model_look_at]. Operations take place in global space.
 			</description>
 		</method>
 		<method name="orthonormalize">

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -93,6 +93,7 @@
 			<return type="Transform3D" />
 			<param index="0" name="target" type="Vector3" />
 			<param index="1" name="up" type="Vector3" default="Vector3(0, 1, 0)" />
+			<param index="2" name="z_plus_as_forward" type="bool" default="false" />
 			<description>
 				Returns a copy of the transform rotated such that the forward axis (-Z) points towards the [param target] position.
 				The up axis (+Y) points as close to the [param up] vector as possible while staying perpendicular to the forward axis. The resulting transform is orthonormalized. The existing rotation, scale, and skew information from the original transform is discarded. The [param target] and [param up] vectors cannot be zero, cannot be parallel to each other, and are defined in global/parent space.

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -403,11 +403,23 @@
 		<constant name="DOWN" value="Vector3(0, -1, 0)">
 			Down unit vector.
 		</constant>
-		<constant name="FORWARD" value="Vector3(0, 0, -1)">
-			Forward unit vector. Represents the local direction of forward, and the global direction of north.
+		<constant name="CAMERA_FORWARD" value="Vector3(0, 0, -1)">
+			Forward unit vector from a camera view (as Godot cameras look at -Z, +Y-up).
 		</constant>
-		<constant name="BACK" value="Vector3(0, 0, 1)">
-			Back unit vector. Represents the local direction of back, and the global direction of south.
+		<constant name="CAMERA_BACK" value="Vector3(0, 0, 1)">
+			Backward unit vector from a camera view (as Godot cameras look at -Z, +Y-up).
+		</constant>
+		<constant name="FRONT" value="Vector3(0, 0, 1)">
+			Forward unit vector for models, and the global direction of south.
+		</constant>
+		<constant name="REAR" value="Vector3(0, 0, -1)">
+			Back unit vector for models, and the global direction of north.
+		</constant>
+		<constant name="FORWARD" value="Vector3(0, 0, -1)" is_deprecated="true">
+			This constant is deprecated and is no longer meaningful. Please refer to either [constant Vector3.CAMERA_FORWARD] or [constant Vector3.FRONT] depending on your needs.
+		</constant>
+		<constant name="BACK" value="Vector3(0, 0, 1)" is_deprecated="true">
+			This constant is deprecated and is no longer meaningful. Please refer to either [constant Vector3.CAMERA_BACK] or [constant Vector3.REAR] depending on your needs.
 		</constant>
 	</constants>
 	<operators>

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -809,6 +809,7 @@ void Node3D::set_identity() {
 	set_transform(Transform3D());
 }
 
+#ifndef DISABLE_DEPRECATED
 void Node3D::look_at(const Vector3 &p_target, const Vector3 &p_up) {
 	ERR_FAIL_COND_MSG(!is_inside_tree(), "Node not inside tree. Use look_at_from_position() instead.");
 	Vector3 origin = get_global_transform().origin;
@@ -821,6 +822,42 @@ void Node3D::look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target
 	ERR_FAIL_COND_MSG(p_up.cross(p_target - p_pos).is_zero_approx(), "Up vector and direction between node origin and target are aligned, look_at() failed.");
 
 	Transform3D lookat = Transform3D(Basis::looking_at(p_target - p_pos, p_up), p_pos);
+	Vector3 original_scale = get_scale();
+	set_global_transform(lookat);
+	set_scale(original_scale);
+	WARN_DEPRECATED_MSG("This function is deprecated and will eventually be removed. Please use camera_look_at() instead, or model_look_at() functions depending on the right context.");
+}
+#endif
+
+void Node3D::camera_look_at(const Vector3 &p_target, const Vector3 &p_up) {
+	ERR_FAIL_COND_MSG(!is_inside_tree(), "Node not inside tree. Use camera_look_at_from_position() instead.");
+	Vector3 origin = get_global_transform().origin;
+	look_at_from_position(origin, p_target, p_up);
+}
+
+void Node3D::camera_look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up) {
+	ERR_FAIL_COND_MSG(p_pos.is_equal_approx(p_target), "Node origin and target are in the same position, camera_look_at_from_position() failed.");
+	ERR_FAIL_COND_MSG(p_up.is_zero_approx(), "The up vector can't be zero, camera_look_at() failed.");
+	ERR_FAIL_COND_MSG(p_up.cross(p_target - p_pos).is_zero_approx(), "Up vector and direction between node origin and target are aligned, camera_look_at() failed.");
+
+	Transform3D lookat = Transform3D(Basis::looking_at(p_target - p_pos, p_up), p_pos);
+	Vector3 original_scale = get_scale();
+	set_global_transform(lookat);
+	set_scale(original_scale);
+}
+
+void Node3D::model_look_at(const Vector3 &p_target, const Vector3 &p_up) {
+	ERR_FAIL_COND_MSG(!is_inside_tree(), "Node not inside tree. Use model_look_at_from_position() instead.");
+	Vector3 origin = get_global_transform().origin;
+	model_look_at_from_position(origin, p_target, p_up);
+}
+
+void Node3D::model_look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up) {
+	ERR_FAIL_COND_MSG(p_pos.is_equal_approx(p_target), "Node origin and target are in the same position, model_look_at_from_position() failed.");
+	ERR_FAIL_COND_MSG(p_up.is_zero_approx(), "The up vector can't be zero, model_look_at() failed.");
+	ERR_FAIL_COND_MSG(p_up.cross(p_target - p_pos).is_zero_approx(), "Up vector and direction between node origin and target are aligned, model_look_at() failed.");
+
+	Transform3D lookat = Transform3D(Basis::looking_at(p_target - p_pos, p_up, true), p_pos);
 	Vector3 original_scale = get_scale();
 	set_global_transform(lookat);
 	set_scale(original_scale);
@@ -1056,8 +1093,16 @@ void Node3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("orthonormalize"), &Node3D::orthonormalize);
 	ClassDB::bind_method(D_METHOD("set_identity"), &Node3D::set_identity);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("look_at", "target", "up"), &Node3D::look_at, DEFVAL(Vector3(0, 1, 0)));
 	ClassDB::bind_method(D_METHOD("look_at_from_position", "position", "target", "up"), &Node3D::look_at_from_position, DEFVAL(Vector3(0, 1, 0)));
+#endif
+
+	ClassDB::bind_method(D_METHOD("camera_look_at", "target", "up"), &Node3D::camera_look_at, DEFVAL(Vector3(0, 1, 0)));
+	ClassDB::bind_method(D_METHOD("camera_look_at_from_position", "position", "target", "up"), &Node3D::camera_look_at_from_position, DEFVAL(Vector3(0, 1, 0)));
+
+	ClassDB::bind_method(D_METHOD("model_look_at", "target", "up"), &Node3D::model_look_at, DEFVAL(Vector3(0, 1, 0)));
+	ClassDB::bind_method(D_METHOD("model_look_at_from_position", "position", "target", "up"), &Node3D::model_look_at_from_position, DEFVAL(Vector3(0, 1, 0)));
 
 	ClassDB::bind_method(D_METHOD("to_local", "global_point"), &Node3D::to_local);
 	ClassDB::bind_method(D_METHOD("to_global", "local_point"), &Node3D::to_global);

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -242,9 +242,15 @@ public:
 	void global_rotate(const Vector3 &p_axis, real_t p_angle);
 	void global_scale(const Vector3 &p_scale);
 	void global_translate(const Vector3 &p_offset);
-
+#ifndef DISABLE_DEPRECATED
 	void look_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0));
 	void look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0));
+#endif
+	void model_look_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0));
+	void model_look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0));
+
+	void camera_look_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0));
+	void camera_look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0));
 
 	Vector3 to_local(Vector3 p_global) const;
 	Vector3 to_global(Vector3 p_local) const;


### PR DESCRIPTION
Until not too long ago, Godot did not really have any concept of *forward*, *back*, etc. As the push to make the engine easier to use grew, meanings for each axis unit vector were added to the engine.

The problem, however, is that Godot is an engine that uses the [right handed coordinate system](https://en.wikipedia.org/wiki/Right-hand_rule) with Y as "up axis". Unlike engines that use the Left Hand Rule (Unity, Unreal), this causes a conflict between what the camera considers as *forward* (Z-) and what imported 3D models end up considering as *forward* when converted to this coordinate system (Z+). As such, the use of methods such as *look_at()* or constants such as **Vector3.FORWARD** do not yield the expected results, as the meaning of foward differs depending on the context. 

![image](https://user-images.githubusercontent.com/6265307/232059168-bd9d9dcf-b06d-459c-9267-1b7ecb7d4931.png)

Again, this is not a problem in engines such as Unity due to the chosen coordinate system (which followed the Direct3D standard), where *forward* is the same for both cameras and models, but it is an explicit problem for Godot due to its chosen coordinate system (which followed the OpenGL standard).

As it is obviously more than a decade too late to change the coordinate system in Godot, this PR intends to ameliorate confusion for Godot users, by explicitly separating the concept of *camera forward* and *model front*, and deprecating unique constants that can be ambiguous but conflicting in meaning.

Additionally, this PR ensures that engine axes are renamed to things that make more sense, as now `Vector3::FORWARD` is `Vector3::CAMERA_FORWARD` (pointing to Z-, which confused many users). And a `Vector3::FRONT` is added that is Z+.

This PR also requires #76052 being merged to ensure everything is fully consistent again.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
