### PR TITLE
[3.x] Disable blending before blitting to framebuffer from WebXR

### DIFF
--- a/modules/webxr/native/library_godot_webxr.js
+++ b/modules/webxr/native/library_godot_webxr.js
@@ -171,6 +171,11 @@ const GodotWebXR = {
 			gl.bindTexture(gl.TEXTURE_2D, texture);
 			gl.uniform1i(GodotWebXR.programInfo.uniformLocations.uSampler, 0);
 
+			const blend_enabled = gl.getParameter(gl.BLEND);
+			if (blend_enabled) {
+				gl.disable(gl.BLEND);
+			}
+
 			gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
 
 			// Restore state.
@@ -178,6 +183,9 @@ const GodotWebXR = {
 			gl.disableVertexAttribArray(GodotWebXR.programInfo.attribLocations.vertexPosition);
 			gl.bindBuffer(gl.ARRAY_BUFFER, null);
 			gl.useProgram(orig_program);
+			if (blend_enabled) {
+				gl.enable(gl.BLEND);
+			}
 		},
 
 		// Holds the controllers list between function calls.


### PR DESCRIPTION
This fixes a rendering bug with WebXR "immersive-ar" sessions on Meta Quest 2.

This bug only affects Godot 3.x - it isn't present on Godot 4.x (XR rendering is done very differently on 4.x)

Fixes #75581