### PR TITLE
Remember last editor window mode, size, position and screen across re…

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -394,6 +394,8 @@ private:
 	EditorAbout *about = nullptr;
 	AcceptDialogAutoReparent *warning = nullptr;
 
+	Ref<ConfigFile> window_config;
+
 	int overridden_default_layout = -1;
 	Ref<ConfigFile> default_layout;
 	PopupMenu *editor_layouts = nullptr;
@@ -571,6 +573,9 @@ private:
 	void _fs_changed();
 	void _resources_reimported(const Vector<String> &p_resources);
 	void _sources_changed(bool p_exist);
+
+	void _load_window_config();
+	void _save_window_config();
 
 	void _node_renamed();
 	void _editor_select_next();

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1369,6 +1369,10 @@ String EditorSettings::get_editor_layouts_config() const {
 	return EditorPaths::get_singleton()->get_config_dir().path_join("editor_layouts.cfg");
 }
 
+String EditorSettings::get_window_cached_config() const {
+	return EditorPaths::get_singleton()->get_cache_dir().path_join("window.cfg");
+}
+
 float EditorSettings::get_auto_display_scale() const {
 #if defined(MACOS_ENABLED) || defined(ANDROID_ENABLED)
 	return DisplayServer::get_singleton()->screen_get_max_scale();

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -168,6 +168,7 @@ public:
 
 	Vector<String> get_script_templates(const String &p_extension, const String &p_custom_path = String());
 	String get_editor_layouts_config() const;
+	String get_window_cached_config() const;
 	float get_auto_display_scale() const;
 
 	void _add_shortcut_default(const String &p_name, const Ref<Shortcut> &p_shortcut);


### PR DESCRIPTION
Based on commit 7ea587e. Exposes a new editor setting that preserves the editor window state to be restored across restart.
This is particularly useful for people with high resolution monitors or that use external text editors on the same screen.
The previous behaviour was for the editor to always start maximized and, when manually windowed, switch to the smallest allowed window size.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
