### PR TITLE
Remember editor window mode, screen, size and position on restart

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -698,6 +698,9 @@
 		<member name="interface/editor/project_manager_screen" type="int" setter="" getter="">
 			The preferred monitor to display the project manager.
 		</member>
+		<member name="interface/editor/remember_window_size_and_position" type="bool" setter="" getter="">
+			If [code]true[/code], the editor window will remember its size, position, and which screen it was displayed on across restarts.
+		</member>
 		<member name="interface/editor/save_each_scene_on_quit" type="bool" setter="" getter="">
 			If [code]false[/code], the editor will save all scenes when confirming the [b]Save[/b] action when quitting the editor or quitting to the project list. If [code]true[/code], the editor will ask to save each scene individually.
 		</member>

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -490,6 +490,8 @@ private:
 	SurfaceUpgradeDialog *surface_upgrade_dialog = nullptr;
 	bool run_surface_upgrade_tool = false;
 
+	bool was_window_windowed_last = false;
+
 	static EditorBuildCallback build_callbacks[MAX_BUILD_CALLBACKS];
 	static EditorPluginInitializeCallback plugin_init_callbacks[MAX_INIT_CALLBACKS];
 	static int build_callback_count;
@@ -571,6 +573,7 @@ private:
 	void _show_messages();
 	void _vp_resized();
 	void _titlebar_resized();
+	void _viewport_resized();
 
 	void _update_undo_redo_allowed();
 
@@ -640,6 +643,8 @@ private:
 
 	void _save_central_editor_layout_to_config(Ref<ConfigFile> p_config_file);
 	void _load_central_editor_layout_from_config(Ref<ConfigFile> p_config_file);
+
+	void _save_window_settings_to_config(Ref<ConfigFile> p_layout, const String &p_section);
 
 	void _save_open_scenes_to_config(Ref<ConfigFile> p_layout);
 	void _load_open_scenes_from_config(Ref<ConfigFile> p_layout);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -447,6 +447,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("interface/editor/separate_distraction_mode", false);
 	_initial_set("interface/editor/automatically_open_screenshots", true);
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/single_window_mode", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	_initial_set("interface/editor/remember_window_size_and_position", true);
 	_initial_set("interface/editor/mouse_extra_buttons_navigate_history", true);
 	_initial_set("interface/editor/save_each_scene_on_quit", true); // Regression
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/save_on_focus_loss", false, "")


### PR DESCRIPTION
Second attempt at a change to allow godot editor to remember the last size, screen, position and window mode across restarts.
When working on a godot project on a high res screen or with an external text editor, people might prefer to not have the editor maximized on screen.
The previous behaviour was for the editor window to start maximized, and when windowed it would resize to a very small size.
I made a previous attempt here: [https://github.com/godotengine/godot/pull/76076](https://github.com/godotengine/godot/pull/76076)
However, this version has some nice improvements:

- It runs earlier in the process, which means the window starts at the right size and does not change after the editor has loaded;
- Is per-project, so people can setup different work environments per project (which is also the behaviour for layouts)

The project setting defaults to false and is hidden under the advanced tab. This can be changed depending of what people decide the best "default behaviour" would be
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
*Bugsquad edit:* Closes https://github.com/godotengine/godot-proposals/issues/8358