### PR TITLE
PhysicsDirectBodyState3D: report contact points using global coordinates

### DIFF
--- a/doc/classes/PhysicsDirectBodyState2D.xml
+++ b/doc/classes/PhysicsDirectBodyState2D.xml
@@ -127,7 +127,7 @@
 			<return type="Vector2" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
-				Returns the contact position in the collider.
+				Returns the position of the contact point on the collider in the global coordinate system.
 			</description>
 		</method>
 		<method name="get_contact_collider_shape" qualifiers="const">
@@ -169,7 +169,7 @@
 			<return type="Vector2" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
-				Returns the local position of the contact point.
+				Returns the position of the contact point on the body in the global coordinate system.
 			</description>
 		</method>
 		<method name="get_contact_local_shape" qualifiers="const">

--- a/doc/classes/PhysicsDirectBodyState3D.xml
+++ b/doc/classes/PhysicsDirectBodyState3D.xml
@@ -127,7 +127,7 @@
 			<return type="Vector3" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
-				Returns the contact position in the collider.
+				Returns the position of the contact point on the collider in the global coordinate system.
 			</description>
 		</method>
 		<method name="get_contact_collider_shape" qualifiers="const">
@@ -169,7 +169,7 @@
 			<return type="Vector3" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
-				Returns the local position of the contact point.
+				Returns the position of the contact point on the body in the global coordinate system.
 			</description>
 		</method>
 		<method name="get_contact_local_shape" qualifiers="const">

--- a/servers/physics_3d/godot_body_pair_3d.cpp
+++ b/servers/physics_3d/godot_body_pair_3d.cpp
@@ -354,6 +354,8 @@ bool GodotBodyPair3D::pre_solve(real_t p_step) {
 
 	bool do_process = false;
 
+	const Vector3 &offset_A = A->get_transform().get_origin();
+
 	const Basis &basis_A = A->get_transform().basis;
 	const Basis &basis_B = B->get_transform().basis;
 
@@ -382,7 +384,6 @@ bool GodotBodyPair3D::pre_solve(real_t p_step) {
 
 #ifdef DEBUG_ENABLED
 		if (space->is_debugging_contacts()) {
-			const Vector3 &offset_A = A->get_transform().get_origin();
 			space->add_debug_contact(global_A + offset_A);
 			space->add_debug_contact(global_B + offset_A);
 		}
@@ -410,14 +411,13 @@ bool GodotBodyPair3D::pre_solve(real_t p_step) {
 		if (A->can_report_contacts() || B->can_report_contacts()) {
 			Vector3 crB = B->get_angular_velocity().cross(c.rB) + B->get_linear_velocity();
 			Vector3 crA = A->get_angular_velocity().cross(c.rA) + A->get_linear_velocity();
-			Vector3 wlB = global_B - offset_B;
 
 			if (A->can_report_contacts()) {
-				A->add_contact(global_A, -c.normal, depth, shape_A, crA, wlB, shape_B, B->get_instance_id(), B->get_self(), crB, c.acc_impulse);
+				A->add_contact(global_A + offset_A, -c.normal, depth, shape_A, crA, global_B + offset_A, shape_B, B->get_instance_id(), B->get_self(), crB, c.acc_impulse);
 			}
 
 			if (B->can_report_contacts()) {
-				B->add_contact(wlB, c.normal, depth, shape_B, crB, global_A, shape_A, A->get_instance_id(), A->get_self(), crA, -c.acc_impulse);
+				B->add_contact(global_B + offset_A, c.normal, depth, shape_B, crB, global_A + offset_A, shape_A, A->get_instance_id(), A->get_self(), crA, -c.acc_impulse);
 			}
 		}
 


### PR DESCRIPTION
Also update the documentation to reflect this in both 2D and 3D. (It was already the case in 2D, just not documented.)

Follow-up to https://github.com/godotengine/godot/pull/58880

- Fixes https://github.com/godotengine/godot/issues/76050

This is the most pragmatic solution, keeping 2D as it has always been (since Godot was made open source), and updating 3D which was bugged for a long time, then fixed recently by https://github.com/godotengine/godot/pull/58880 to be self-consistent but inconsistent with 2D; now this PR makes it consistent with 2D.