### PR TITLE
[LSP] Fix typo in parse function parameters

### DIFF
--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -337,7 +337,7 @@ void ExtendGDScriptParser::parse_function_symbol(const GDScriptParser::FunctionN
 		symbol.kind = lsp::SymbolKind::Variable;
 		symbol.name = parameter->identifier->name;
 		symbol.range.start.line = LINE_NUMBER_TO_INDEX(parameter->start_line);
-		symbol.range.start.character = LINE_NUMBER_TO_INDEX(parameter->start_line);
+		symbol.range.start.character = LINE_NUMBER_TO_INDEX(parameter->start_column);
 		symbol.range.end.line = LINE_NUMBER_TO_INDEX(parameter->end_line);
 		symbol.range.end.character = LINE_NUMBER_TO_INDEX(parameter->end_column);
 		symbol.uri = uri;


### PR DESCRIPTION
This is an obvious typo. 

The code actually sets the `symbol.range.start.character` to `parameter->start_line`, but it should be `parameter->start_column`.
Right after, the code correctly sets `symbol.range.end.character` to `parameter->end_column`.
