### PR TITLE
[LSP] Fix GDScript inner method variable rename

### DIFF
--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -400,6 +400,20 @@ void ExtendGDScriptParser::parse_function_symbol(const GDScriptParser::FunctionN
 				}
 			} break;
 
+			case GDScriptParser::TypeNode::VARIABLE: {
+				GDScriptParser::VariableNode *variable_node = (GDScriptParser::VariableNode *)(node);
+				lsp::DocumentSymbol symbol;
+				symbol.kind = lsp::SymbolKind::Variable;
+				symbol.name = variable_node->identifier->name;
+				symbol.range.start.line = LINE_NUMBER_TO_INDEX(variable_node->start_line);
+				symbol.range.start.character = LINE_NUMBER_TO_INDEX(variable_node->start_column);
+				symbol.range.end.line = LINE_NUMBER_TO_INDEX(variable_node->end_line);
+				symbol.range.end.character = LINE_NUMBER_TO_INDEX(variable_node->end_column);
+				symbol.uri = uri;
+				symbol.script_path = path;
+				r_symbol.children.push_back(symbol);
+			} break;
+
 			default:
 				continue;
 		}

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -293,16 +293,6 @@ struct WorkspaceEdit {
 	}
 
 	_FORCE_INLINE_ void add_change(const String &uri, const int &line, const int &start_character, const int &end_character, const String &new_text) {
-		if (HashMap<String, Vector<TextEdit>>::Iterator E = changes.find(uri)) {
-			Vector<TextEdit> edit_list = E->value;
-			for (int i = 0; i < edit_list.size(); ++i) {
-				TextEdit edit = edit_list[i];
-				if (edit.range.start.character == start_character) {
-					return;
-				}
-			}
-		}
-
 		TextEdit new_edit;
 		new_edit.newText = new_text;
 		new_edit.range.start.line = line;


### PR DESCRIPTION
Fixes the GDScript inner method variable rename function in the context of the language server protocol (LSP).

Fixes #76094
#65563 isn't fixed with this PR, as there's still issues with renaming, like renaming function arguments.

Should be cherry-pickable for 4.0.x