### PR TITLE
update set_smooth_group description

### DIFF
--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -242,6 +242,7 @@
 			<param index="0" name="index" type="int" />
 			<description>
 				Specifies the smooth group to use for the [i]next[/i] vertex. If this is never called, all vertices will have the default smooth group of [code]0[/code] and will be smoothed with adjacent vertices of the same group. To produce a mesh with flat normals, set the smooth group to [code]-1[/code].
+				[b]Note:[/b] This function actually takes an [code]uint32_t[/code], so C# users should use [code]uint32.MaxValue[/code] instead of [code]-1[/code] to produce a mesh with flat normals.
 			</description>
 		</method>
 		<method name="set_tangent">


### PR DESCRIPTION
Fixes #74452

Added a note to SurfaceTool.set_smooth_group() function for C# users because passing in a -1 returns an error.

"Note:This function actually takes an uint32_t, so C# users should use uint32.MaxValue instead of -1 to produce a mesh with flat normals."