### PR TITLE
[WinTab] Use `WT_Packet` coordinates to improve precision.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4831,8 +4831,19 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				PACKET packet;
 				if (wintab_WTPacket(windows[window_id].wtctx, wParam, &packet)) {
 					POINT coords;
-					GetCursorPos(&coords);
-					ScreenToClient(windows[window_id].hWnd, &coords);
+					coords.x = packet.pkX;
+					coords.y = packet.pkY;
+					if (win81p_LogicalToPhysicalPointForPerMonitorDPI && win81p_PhysicalToLogicalPointForPerMonitorDPI) {
+						win81p_LogicalToPhysicalPointForPerMonitorDPI(0, &coords);
+						win81p_PhysicalToLogicalPointForPerMonitorDPI(windows[window_id].hWnd, &coords);
+					} else {
+						ScreenToClient(windows[window_id].hWnd, &coords);
+					}
+
+					// Event outside window area, ignore.
+					if (coords.x < 0 || coords.y < 0 || coords.x > windows[window_id].width || coords.y > windows[window_id].height) {
+						break;
+					}
 
 					windows[window_id].last_pressure_update = 0;
 
@@ -6034,8 +6045,8 @@ void DisplayServerWindows::_update_tablet_ctx(const String &p_old_driver, const 
 		if ((p_new_driver == "wintab") && wintab_available) {
 			wintab_WTInfo(WTI_DEFSYSCTX, 0, &wd.wtlc);
 			wd.wtlc.lcOptions |= CXO_MESSAGES;
-			wd.wtlc.lcPktData = PK_STATUS | PK_NORMAL_PRESSURE | PK_TANGENT_PRESSURE | PK_ORIENTATION;
-			wd.wtlc.lcMoveMask = PK_STATUS | PK_NORMAL_PRESSURE | PK_TANGENT_PRESSURE;
+			wd.wtlc.lcPktData = PK_STATUS | PK_NORMAL_PRESSURE | PK_TANGENT_PRESSURE | PK_X | PK_Y | PK_ORIENTATION;
+			wd.wtlc.lcMoveMask = PK_STATUS | PK_NORMAL_PRESSURE | PK_TANGENT_PRESSURE | PK_X | PK_Y;
 			wd.wtlc.lcPktMode = 0;
 			wd.wtlc.lcOutOrgX = 0;
 			wd.wtlc.lcOutExtX = wd.wtlc.lcInExtX;
@@ -6260,8 +6271,8 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 		if ((tablet_get_current_driver() == "wintab") && wintab_available) {
 			wintab_WTInfo(WTI_DEFSYSCTX, 0, &wd.wtlc);
 			wd.wtlc.lcOptions |= CXO_MESSAGES;
-			wd.wtlc.lcPktData = PK_STATUS | PK_NORMAL_PRESSURE | PK_TANGENT_PRESSURE | PK_ORIENTATION;
-			wd.wtlc.lcMoveMask = PK_STATUS | PK_NORMAL_PRESSURE | PK_TANGENT_PRESSURE;
+			wd.wtlc.lcPktData = PK_STATUS | PK_NORMAL_PRESSURE | PK_TANGENT_PRESSURE | PK_X | PK_Y | PK_ORIENTATION;
+			wd.wtlc.lcMoveMask = PK_STATUS | PK_NORMAL_PRESSURE | PK_TANGENT_PRESSURE | PK_X | PK_Y;
 			wd.wtlc.lcPktMode = 0;
 			wd.wtlc.lcOutOrgX = 0;
 			wd.wtlc.lcOutExtX = wd.wtlc.lcInExtX;

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -85,6 +85,8 @@
 
 #define CXO_MESSAGES 0x0004
 #define PK_STATUS 0x0002
+#define PK_X 0x0080
+#define PK_Y 0x0100
 #define PK_NORMAL_PRESSURE 0x0400
 #define PK_TANGENT_PRESSURE 0x0800
 #define PK_ORIENTATION 0x1000
@@ -143,6 +145,8 @@ typedef struct tagORIENTATION {
 
 typedef struct tagPACKET {
 	int pkStatus;
+	LONG pkX;
+	LONG pkY;
 	int pkNormalPressure;
 	int pkTangentPressure;
 	ORIENTATION pkOrientation;


### PR DESCRIPTION
Instead of using mouse coordinates, use WinTab API to get position.

Needs testing with different tablets/screen configs to ensure DPI conversion is working in all cases.

Should fix https://github.com/godotengine/godot/issues/75903