### PR TITLE
Fix editor spin slider remaining editable if set `read_only` during and edit and fix related animation player crash

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4639,6 +4639,10 @@ void AnimationTrackEditor::_update_scroll(double) {
 }
 
 void AnimationTrackEditor::_update_step(double p_new_step) {
+	if (animation.is_null()) {
+		return;
+	}
+
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Change Animation Step"));
 	float step_value = p_new_step;

--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -573,8 +573,13 @@ void EditorSpinSlider::_value_focus_exited() {
 		return;
 	}
 
+	if (is_read_only()) {
+		// Spin slider has become read only while it was being edited.
+		return;
+	}
+
 	_evaluate_input_text();
-	// focus is not on the same element after the vlalue_input was exited
+	// focus is not on the same element after the value_input was exited
 	// -> focus is on next element
 	// -> TAB was pressed
 	// -> modal_close was not called
@@ -604,6 +609,10 @@ void EditorSpinSlider::_grabber_mouse_exited() {
 
 void EditorSpinSlider::set_read_only(bool p_enable) {
 	read_only = p_enable;
+	if (read_only && value_input) {
+		value_input->release_focus();
+	}
+
 	queue_redraw();
 }
 


### PR DESCRIPTION
This fixes a crash in the animation player.
The easiest way to reproduce it is to open 2 scenes, one with an animation player and any other one.
First select and focus the line edit for the snap step, then switch to another scene.
Two issues are noticeable:

- The editor spin slider remains editable, even though the animation is no longer selected and the spin slider has been set read only;
- The animation editor crashes trying to update the value of the snap on an animation that is no longer valid;

The changes on editor_spin_slider makes it so the line edit is correctly unfocused and un-selected if it becomes read only mid-edit.
The animation_track_editor check is just a sanity check and is not strictly necessary with the editor spin slider changes

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
