### PR TITLE
Fix blurry borders on antialiased StyleBoxFlat

### DIFF
--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -103,8 +103,9 @@
 			Antialiasing draws a small ring around the edges, which fades to transparency. As a result, edges look much smoother. This is only noticeable when using rounded corners or [member skew].
 			[b]Note:[/b] When using beveled corners with 45-degree angles ([member corner_detail] = 1), it is recommended to set [member anti_aliasing] to [code]false[/code] to ensure crisp visuals and avoid possible visual glitches.
 		</member>
-		<member name="anti_aliasing_size" type="float" setter="set_aa_size" getter="get_aa_size" default="0.625">
-			This changes the size of the faded ring. Higher values can be used to achieve a "blurry" effect.
+		<member name="anti_aliasing_size" type="float" setter="set_aa_size" getter="get_aa_size" default="1.0">
+			This changes the size of the antialiasing effect. [code]1.0[/code] is recommended for an optimal result at 100% scale, identical to how rounded rectangles are rendered in web browsers and most vector drawing software.
+			[b]Note:[/b] Higher values may produce a blur effect but can also create undesired artifacts on small boxes with large-radius corners.
 		</member>
 		<member name="bg_color" type="Color" setter="set_bg_color" getter="get_bg_color" default="Color(0.6, 0.6, 0.6, 1)">
 			The background color of the stylebox.

--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -163,7 +163,7 @@ class StyleBoxFlat : public StyleBox {
 	int corner_detail = 8;
 	int shadow_size = 0;
 	Point2 shadow_offset;
-	real_t aa_size = 0.625;
+	real_t aa_size = 1;
 
 protected:
 	virtual float get_style_margin(Side p_side) const override;


### PR DESCRIPTION
This is a fix of the antialiasing logic of StyleBoxFlat. It is now possible to have smooth rounded corners while keeping the edges sharp on the pixel, and remove the bleeding on the edges.

The problem is subtle but noticeable. In the current version, when the antialiasing is enabled on a StyleBoxFlat, the rounded corners are smoothed as expected. But, the sides also bleed a bit and lose their sharpness.

As the style boxes are mostly used to render UI components, it looks better when the sides are sharp on the pixel.

| Before | After |
|--------|--------|
| ![Capture d’écran du 2023-04-16 14-20-17](https://user-images.githubusercontent.com/26961646/232309700-33791315-c956-43f6-8f0f-c595632b39cd.png) | ![Capture d’écran du 2023-04-16 14-06-33](https://user-images.githubusercontent.com/26961646/232309710-32a7a82a-734a-4a53-bbee-44d1a049255d.png) |

Reference rendering in a vector graphics software
![Capture d’écran du 2023-04-16 14-08-25](https://user-images.githubusercontent.com/26961646/232309797-b8ed4994-9159-4cfd-88d1-d82095d3cab3.png)

Since the box is rendered using colored GL triangles, the already-implemented trick to make the edges smooth is to use extra polygons with a fade-to-transparent. I have adjusted the positioning of those polygons so that the middle of the gradient matches the "hard" border, on both the ring and the infill.

This is based on principles found here: https://blog.mapbox.com/drawing-antialiased-lines-with-opengl-8766f34192dc

As the rendering principle may not be obvious, here is a visual explanation of how it works and the changes I have done to improve the rendering:

![border_antialiasing_principle](https://user-images.githubusercontent.com/26961646/232312043-f26e0564-1629-4412-9747-e249ff37e3d2.png)

- *Bugsquad edit: This closes https://github.com/godotengine/godot/issues/75707.*
