### PR TITLE
[Image Font] Fix fractional ascent for font with odd height.

### DIFF
--- a/editor/import/resource_importer_imagefont.cpp
+++ b/editor/import/resource_importer_imagefont.cpp
@@ -151,7 +151,7 @@ Error ResourceImporterImageFont::import(const String &p_source_file, const Strin
 			int x = pos % columns;
 			int y = pos / columns;
 			font->set_glyph_advance(0, chr_height, idx, Vector2(chr_width, 0));
-			font->set_glyph_offset(0, Vector2i(chr_height, 0), idx, Vector2(0, -0.5 * chr_height));
+			font->set_glyph_offset(0, Vector2i(chr_height, 0), idx, Vector2i(0, -0.5 * chr_height));
 			font->set_glyph_size(0, Vector2i(chr_height, 0), idx, Vector2(chr_width, chr_height));
 			font->set_glyph_uv_rect(0, Vector2i(chr_height, 0), idx, Rect2(img_margin.position.x + chr_cell_width * x + char_margin.position.x, img_margin.position.y + chr_cell_height * y + char_margin.position.y, chr_width, chr_height));
 			font->set_glyph_texture_idx(0, Vector2i(chr_height, 0), idx, 0);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/76117
