### PR TITLE
Fix auto-indentation in typed arrays, comments, and after colon

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1075,7 +1075,7 @@ void CodeEdit::_new_line(bool p_split_current_line, bool p_above) {
 
 			for (; line_col < cc; line_col++) {
 				char32_t c = line[line_col];
-				if (auto_indent_prefixes.has(c)) {
+				if (auto_indent_prefixes.has(c) && is_in_comment(cl, line_col) == -1) {
 					should_indent = true;
 					indent_char = c;
 					continue;

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -2300,6 +2300,17 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			SEND_GUI_ACTION("ui_text_newline_blank");
 			CHECK(code_edit->get_line(0) == "test{}");
 			CHECK(code_edit->get_line(1) == "");
+
+			/* If there is something after a colon
+			and there is a colon in the comment it
+			should not indent. */
+			code_edit->add_comment_delimiter("#", "");
+			code_edit->set_text("");
+			code_edit->insert_text_at_caret("test:test#:");
+			SEND_GUI_ACTION("ui_text_newline");
+			CHECK(code_edit->get_line(0) == "test:test#:");
+			CHECK(code_edit->get_line(1) == "");
+			code_edit->remove_comment_delimiter("#");
 		}
 	}
 


### PR DESCRIPTION
fix #75139

Sample code:

```
if 0==0:#enter
#tab

var:#enter
#nothing

var a:#enter
#nothing

var a:=0#enter
#nothing, just as before

var b:=0 #:#enter
#nothing, what we want

var c:=get_node(#enter
#tab, just as before
)

var e:=get_node(#enter #:
#tab
)
```
I hope it is correct
