### PR TITLE
Fix `@export_category` interfering with property tooltips

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2846,7 +2846,6 @@ void EditorInspector::update_tree() {
 
 			String type = p.name;
 			String label = p.name;
-			doc_name = p.name;
 
 			// Use category's owner script to update some of its information.
 			if (!EditorNode::get_editor_data().is_type_recognized(type) && p.hint_string.length() && ResourceLoader::exists(p.hint_string)) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/64432
Don't assume the category name can be used as the doc_name. Just leave it blank so it can be properly determined later on just before looking up cached doc info.

~Fixes (not) https://github.com/godotengine/godot/issues/63997
update_tree() populates description-related caches, but nothing was ever clearing them out so they'd forever hold onto the first description seen.~