### PR TITLE
Fix NavigationMesh debug visuals for non-triangulated meshes

### DIFF
--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -431,9 +431,6 @@ void NavigationRegion3D::_update_debug_mesh() {
 
 	debug_mesh->clear_surfaces();
 
-	bool enabled_geometry_face_random_color = NavigationServer3D::get_singleton()->get_debug_navigation_enable_geometry_face_random_color();
-	bool enabled_edge_lines = NavigationServer3D::get_singleton()->get_debug_navigation_enable_edge_lines();
-
 	Vector<Vector3> vertices = navigation_mesh->get_vertices();
 	if (vertices.size() == 0) {
 		return;
@@ -444,54 +441,88 @@ void NavigationRegion3D::_update_debug_mesh() {
 		return;
 	}
 
+	bool enabled_geometry_face_random_color = NavigationServer3D::get_singleton()->get_debug_navigation_enable_geometry_face_random_color();
+	bool enabled_edge_lines = NavigationServer3D::get_singleton()->get_debug_navigation_enable_edge_lines();
+
+	int vertex_count = 0;
+	int line_count = 0;
+
+	for (int i = 0; i < polygon_count; i++) {
+		const Vector<int> &polygon = navigation_mesh->get_polygon(i);
+		int polygon_size = polygon.size();
+		if (polygon_size < 3) {
+			continue;
+		}
+		line_count += polygon_size * 2;
+		vertex_count += (polygon_size - 2) * 3;
+	}
+
 	Vector<Vector3> face_vertex_array;
-	face_vertex_array.resize(polygon_count * 3);
+	face_vertex_array.resize(vertex_count);
 
 	Vector<Color> face_color_array;
 	if (enabled_geometry_face_random_color) {
-		face_color_array.resize(polygon_count * 3);
+		face_color_array.resize(vertex_count);
 	}
 
 	Vector<Vector3> line_vertex_array;
 	if (enabled_edge_lines) {
-		line_vertex_array.resize(polygon_count * 6);
+		line_vertex_array.resize(line_count);
 	}
 
 	Color debug_navigation_geometry_face_color = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_color();
 
-	Ref<StandardMaterial3D> face_material = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_material();
-	Ref<StandardMaterial3D> line_material = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_material();
-
 	RandomPCG rand;
 	Color polygon_color = debug_navigation_geometry_face_color;
 
-	for (int i = 0; i < polygon_count; i++) {
+	int face_vertex_index = 0;
+	int line_vertex_index = 0;
+
+	Vector3 *face_vertex_array_ptrw = face_vertex_array.ptrw();
+	Color *face_color_array_ptrw = face_color_array.ptrw();
+	Vector3 *line_vertex_array_ptrw = line_vertex_array.ptrw();
+
+	for (int polygon_index = 0; polygon_index < polygon_count; polygon_index++) {
+		const Vector<int> &polygon_indices = navigation_mesh->get_polygon(polygon_index);
+		int polygon_indices_size = polygon_indices.size();
+		if (polygon_indices_size < 3) {
+			continue;
+		}
+
 		if (enabled_geometry_face_random_color) {
 			// Generate the polygon color, slightly randomly modified from the settings one.
 			polygon_color.set_hsv(debug_navigation_geometry_face_color.get_h() + rand.random(-1.0, 1.0) * 0.1, debug_navigation_geometry_face_color.get_s(), debug_navigation_geometry_face_color.get_v() + rand.random(-1.0, 1.0) * 0.2);
 			polygon_color.a = debug_navigation_geometry_face_color.a;
 		}
 
-		Vector<int> polygon = navigation_mesh->get_polygon(i);
-
-		face_vertex_array.push_back(vertices[polygon[0]]);
-		face_vertex_array.push_back(vertices[polygon[1]]);
-		face_vertex_array.push_back(vertices[polygon[2]]);
-		if (enabled_geometry_face_random_color) {
-			face_color_array.push_back(polygon_color);
-			face_color_array.push_back(polygon_color);
-			face_color_array.push_back(polygon_color);
+		for (int polygon_indices_index = 0; polygon_indices_index < polygon_indices_size - 2; polygon_indices_index++) {
+			face_vertex_array_ptrw[face_vertex_index] = vertices[polygon_indices[0]];
+			face_vertex_array_ptrw[face_vertex_index + 1] = vertices[polygon_indices[polygon_indices_index + 1]];
+			face_vertex_array_ptrw[face_vertex_index + 2] = vertices[polygon_indices[polygon_indices_index + 2]];
+			if (enabled_geometry_face_random_color) {
+				face_color_array_ptrw[face_vertex_index] = polygon_color;
+				face_color_array_ptrw[face_vertex_index + 1] = polygon_color;
+				face_color_array_ptrw[face_vertex_index + 2] = polygon_color;
+			}
+			face_vertex_index += 3;
 		}
 
 		if (enabled_edge_lines) {
-			line_vertex_array.push_back(vertices[polygon[0]]);
-			line_vertex_array.push_back(vertices[polygon[1]]);
-			line_vertex_array.push_back(vertices[polygon[1]]);
-			line_vertex_array.push_back(vertices[polygon[2]]);
-			line_vertex_array.push_back(vertices[polygon[2]]);
-			line_vertex_array.push_back(vertices[polygon[0]]);
+			for (int polygon_indices_index = 0; polygon_indices_index < polygon_indices_size; polygon_indices_index++) {
+				line_vertex_array_ptrw[line_vertex_index] = vertices[polygon_indices[polygon_indices_index]];
+				line_vertex_index += 1;
+				if (polygon_indices_index + 1 == polygon_indices_size) {
+					line_vertex_array_ptrw[line_vertex_index] = vertices[polygon_indices[0]];
+					line_vertex_index += 1;
+				} else {
+					line_vertex_array_ptrw[line_vertex_index] = vertices[polygon_indices[polygon_indices_index + 1]];
+					line_vertex_index += 1;
+				}
+			}
 		}
 	}
+
+	Ref<StandardMaterial3D> face_material = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_material();
 
 	Array face_mesh_array;
 	face_mesh_array.resize(Mesh::ARRAY_MAX);
@@ -503,6 +534,8 @@ void NavigationRegion3D::_update_debug_mesh() {
 	debug_mesh->surface_set_material(0, face_material);
 
 	if (enabled_edge_lines) {
+		Ref<StandardMaterial3D> line_material = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_material();
+
 		Array line_mesh_array;
 		line_mesh_array.resize(Mesh::ARRAY_MAX);
 		line_mesh_array[Mesh::ARRAY_VERTEX] = line_vertex_array;

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -226,6 +226,7 @@ Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_geometry_face_m
 	face_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
 	face_material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
 	face_material->set_albedo(get_debug_navigation_geometry_face_color());
+	face_material->set_cull_mode(StandardMaterial3D::CULL_DISABLED);
 	if (enabled_geometry_face_random_color) {
 		face_material->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
 		face_material->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);


### PR DESCRIPTION
Fixes NavigationMesh debug visuals for non-triangulated meshes.

Technically the baked 3D navigation meshes are always triangulated - enforced by ReCast - and the reason why the debug was originally also done this way.

Now, when users try to create custom 3D navigation meshes with convex polygons that have 3+ vertices they not only face the same pathfinding bugs that 2D has but they also have broken 3D navigation mesh debug visuals. This pr only fixes the visuals.

![trimeshdebug](https://user-images.githubusercontent.com/52464204/232343849-f1dda6a4-8348-4bee-962a-f9279eb8a6c1.png)

Note that this pr does not also change the Node3DGizmo debug visuals. There exists a nearly done folllowup pr that removes the duplicated debug visuals from the gizmo and instead makes the gizmo display the shared debug visuals from the region.

GDScript code for testing:

``` gdscript
extends NavigationRegion3D


func _ready() -> void:
	var navmesh = NavigationMesh.new()
	
	var _vertices = PackedVector3Array([
		Vector3(0, 0, 0),
		Vector3(0, 0, 5),
		Vector3(5, 0, 5),
		Vector3(5, 0, 0),
		Vector3(10, 0, 5),
		Vector3(10, 0, 0),
		Vector3(5, 0, -10),
		Vector3(10, 0, -10),
		Vector3(15, 0, -10)
	])
	navmesh.vertices = _vertices
	
	var _indices : PackedInt32Array = PackedInt32Array([2, 1, 0, 3])
	navmesh.add_polygon(_indices)
	var _indices2 : PackedInt32Array = PackedInt32Array([2, 4, 5])
	navmesh.add_polygon(_indices2)
	var _indices3 : PackedInt32Array = PackedInt32Array([3, 2, 5, 8, 7, 6])
	navmesh.add_polygon(_indices3)
	
	navigation_mesh = navmesh
```

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
