### PR TITLE
Rename internal root canvas group to start with underscore

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -222,7 +222,7 @@ void CanvasItem::_enter_canvas() {
 		RenderingServer::get_singleton()->canvas_item_set_parent(canvas_item, canvas);
 		RenderingServer::get_singleton()->canvas_item_set_visibility_layer(canvas_item, visibility_layer);
 
-		canvas_group = "root_canvas" + itos(canvas.get_id());
+		canvas_group = "_root_canvas" + itos(canvas.get_id());
 
 		add_to_group(canvas_group);
 		if (canvas_layer) {


### PR DESCRIPTION
In the file <code>scene/main/canvas_item.cpp</code> renames <code>root_canvas</code> to <code>_root_canvas</code> to follow the guidelines described in the docs, ["The engine uses some group names internally (all starting with an underscore)"](https://docs.godotengine.org/en/latest/classes/class_node.html#class-node-method-get-groups).  This change is the 4.0 branch.
Closes #62558 