### PR TITLE
Add a square fill mode to GradientTexture2D

### DIFF
--- a/doc/classes/GradientTexture2D.xml
+++ b/doc/classes/GradientTexture2D.xml
@@ -42,6 +42,9 @@
 		<constant name="FILL_RADIAL" value="1" enum="Fill">
 			The colors are linearly interpolated in a circular pattern.
 		</constant>
+		<constant name="FILL_SQUARE" value="2" enum="Fill">
+			The colors are linearly interpolated in a square pattern.
+		</constant>
 		<constant name="REPEAT_NONE" value="0" enum="Repeat">
 			The gradient fill is restricted to the range defined by [member fill_from] to [member fill_to] offsets.
 		</constant>

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2427,6 +2427,8 @@ float GradientTexture2D::_get_gradient_offset_at(int x, int y) const {
 		}
 	} else if (fill == Fill::FILL_RADIAL) {
 		ofs = (pos - fill_from).length() / (fill_to - fill_from).length();
+	} else if (fill == Fill::FILL_SQUARE) {
+		ofs = MAX(Math::abs(pos.x - fill_from.x), Math::abs(pos.y - fill_from.y)) / MAX(Math::abs(fill_to.x - fill_from.x), Math::abs(fill_to.y - fill_from.y));
 	}
 	if (repeat == Repeat::REPEAT_NONE) {
 		ofs = CLAMP(ofs, 0.0, 1.0);
@@ -2555,7 +2557,7 @@ void GradientTexture2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_hdr"), "set_use_hdr", "is_using_hdr");
 
 	ADD_GROUP("Fill", "fill_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "fill", PROPERTY_HINT_ENUM, "Linear,Radial"), "set_fill", "get_fill");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "fill", PROPERTY_HINT_ENUM, "Linear,Radial,Square"), "set_fill", "get_fill");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "fill_from"), "set_fill_from", "get_fill_from");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "fill_to"), "set_fill_to", "get_fill_to");
 
@@ -2564,6 +2566,7 @@ void GradientTexture2D::_bind_methods() {
 
 	BIND_ENUM_CONSTANT(FILL_LINEAR);
 	BIND_ENUM_CONSTANT(FILL_RADIAL);
+	BIND_ENUM_CONSTANT(FILL_SQUARE);
 
 	BIND_ENUM_CONSTANT(REPEAT_NONE);
 	BIND_ENUM_CONSTANT(REPEAT);

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -829,6 +829,7 @@ public:
 	enum Fill {
 		FILL_LINEAR,
 		FILL_RADIAL,
+		FILL_SQUARE,
 	};
 	enum Repeat {
 		REPEAT_NONE,


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/6712 (I moved the demonstrations and use cases there)

This is an example of ~what it does~ what it used to look like (__see comments for a more recent version__):

![image](https://user-images.githubusercontent.com/85438892/232511050-123251b1-c839-4eb9-b87b-3058061a848b.png)

Feel free to discuss about better implementations, also if you think the feature isn't needed.

_Production edit: Closes https://github.com/godotengine/godot-proposals/issues/6712_.