### PR TITLE
Fix tile resizing towards atlas boundary

### DIFF
--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -497,19 +497,16 @@ Vector2i TileAtlasView::get_atlas_tile_coords_at_pos(const Vector2 p_pos, bool p
 	Vector2i separation = tile_set_atlas_source->get_separation();
 	Vector2i texture_region_size = tile_set_atlas_source->get_texture_region_size();
 
-	// Compute index in atlas
+	// Compute index in atlas.
 	Vector2 pos = p_pos - margins;
 	Vector2i ret = (pos / (texture_region_size + separation)).floor();
 
-	// Return invalid value (without clamp).
-	Rect2i rect = Rect2(Vector2i(), tile_set_atlas_source->get_atlas_grid_size());
-	if (!p_clamp && !rect.has_point(ret)) {
-		return TileSetSource::INVALID_ATLAS_COORDS;
-	}
-
 	// Clamp.
-	ret.x = CLAMP(ret.x, 0, rect.size.x - 1);
-	ret.y = CLAMP(ret.y, 0, rect.size.y - 1);
+	if (p_clamp) {
+		Vector2i size = tile_set_atlas_source->get_atlas_grid_size();
+		ret.x = CLAMP(ret.x, 0, size.x - 1);
+		ret.y = CLAMP(ret.y, 0, size.y - 1);
+	}
 
 	return ret;
 }

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -1031,7 +1031,7 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 		if (mm.is_valid()) {
 			Vector2i start_base_tiles_coords = tile_atlas_view->get_atlas_tile_coords_at_pos(drag_start_mouse_pos, true);
 			Vector2i last_base_tiles_coords = tile_atlas_view->get_atlas_tile_coords_at_pos(drag_last_mouse_pos, true);
-			Vector2i new_base_tiles_coords = tile_atlas_view->get_atlas_tile_coords_at_pos(tile_atlas_control->get_local_mouse_position(), true);
+			Vector2i new_base_tiles_coords = tile_atlas_view->get_atlas_tile_coords_at_pos(tile_atlas_control->get_local_mouse_position());
 
 			Vector2i grid_size = tile_set_atlas_source->get_atlas_grid_size();
 


### PR DESCRIPTION
Fixes #75213

The resizing logic was fine. It was built around the assumption that it can get out-of-bound tile coordinates. But the function to get tile coordinate was probably changed later, clamping the returned coordinate inside the atlas boundary.

This PR changes the `clamp` argument of `TileAtlasView::get_atlas_tile_coords_at_pos()` from `bool` to `ClampMode`, adding a way to clamp to the `(-1, -1, width, height)` region.

https://github.com/godotengine/godot/blob/4e4ba295226030ebf3e9c26a920f0f7511fc21f7/editor/plugins/tiles/tile_atlas_view.h#L125-L129

The previous `clamp = false` can't be reused because it should error by returning the `INVALID_ATLAS_COORDS` constant when the input position is out-of-bound.