### PR TITLE
Improve encrypted PCK robustness, by enforcing encrypted PCK usage and disabling certain unsafe features.

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -238,6 +238,7 @@ ec_valid = len(gdkey) == 64
 if ec_valid:
     try:
         gdkey = ", ".join([str(int(f"{a}{b}", 16)) for a, b in zip(gdkey[0::2], gdkey[1::2])])
+        env.Append(CPPDEFINES=["PCK_ENCRYPTION_ENABLED"])
     except Exception:
         ec_valid = False
 if not ec_valid:

--- a/core/config/project_settings.compat.inc
+++ b/core/config/project_settings.compat.inc
@@ -1,0 +1,41 @@
+/**************************************************************************/
+/*  project_settings.compat.inc                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+bool ProjectSettings::_load_resource_pack_bind_compat_76161(const String &p_pack, bool p_replace_files, int p_offset) {
+	return _load_resource_pack(p_pack, p_replace_files, p_offset, false, false);
+}
+
+void ProjectSettings::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset"), &ProjectSettings::_load_resource_pack_bind_compat_76161, DEFVAL(true), DEFVAL(0));
+}
+
+#endif

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "project_settings.h"
+#include "project_settings.compat.inc"
 
 #include "core/core_bind.h" // For Compression enum.
 #include "core/input/input_map.h"
@@ -472,11 +473,11 @@ void ProjectSettings::_emit_changed() {
 	emit_signal("settings_changed");
 }
 
-bool ProjectSettings::load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset) {
-	return ProjectSettings::_load_resource_pack(p_pack, p_replace_files, p_offset, false);
+bool ProjectSettings::load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset, bool p_require_encryption) {
+	return ProjectSettings::_load_resource_pack(p_pack, p_replace_files, p_offset, false, p_require_encryption);
 }
 
-bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset, bool p_main_pack) {
+bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset, bool p_main_pack, bool p_require_encryption) {
 	if (PackedData::get_singleton()->is_disabled()) {
 		return false;
 	}
@@ -495,7 +496,7 @@ bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_f
 		using_datapack = true;
 	}
 
-	bool ok = PackedData::get_singleton()->add_pack(p_pack, p_replace_files, p_offset) == OK;
+	bool ok = PackedData::get_singleton()->add_pack(p_pack, p_replace_files, p_offset, p_require_encryption) == OK;
 	if (!ok) {
 		return false;
 	}
@@ -570,10 +571,16 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 		}
 	}
 
-	// Attempt with a user-defined main pack first
+#if defined(PCK_ENCRYPTION_ENABLED) && !defined(TOOLS_ENABLED)
+	// PCK encryption is enabled, load only from encrypted pack.
+	bool require_encryption = true;
+#else
+	bool require_encryption = false;
+#endif
 
+	// Attempt with a user-defined (or Android OBB) main pack first
 	if (!p_main_pack.is_empty()) {
-		bool ok = _load_resource_pack(p_main_pack, false, 0, true);
+		bool ok = _load_resource_pack(p_main_pack, false, 0, true, require_encryption);
 		ERR_FAIL_COND_V_MSG(!ok, ERR_CANT_OPEN, vformat("Cannot open resource pack '%s'.", p_main_pack));
 
 		Error err = _load_settings_text_or_binary("res://project.godot", "res://project.binary");
@@ -592,7 +599,7 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 		// and if so, we attempt loading it at the end.
 
 		// Attempt with PCK bundled into executable.
-		bool found = _load_resource_pack(exec_path, false, 0, true);
+		bool found = _load_resource_pack(exec_path, false, 0, true, require_encryption);
 
 		// Attempt with exec_name.pck.
 		// (This is the usual case when distributing a Godot game.)
@@ -608,26 +615,26 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 #ifdef MACOS_ENABLED
 		if (!found) {
 			// Attempt to load PCK from macOS .app bundle resources.
-			found = _load_resource_pack(OS::get_singleton()->get_bundle_resource_dir().path_join(exec_basename + ".pck"), false, 0, true) || _load_resource_pack(OS::get_singleton()->get_bundle_resource_dir().path_join(exec_filename + ".pck"), false, 0, true);
+			found = _load_resource_pack(OS::get_singleton()->get_bundle_resource_dir().path_join(exec_basename + ".pck"), false, 0, true, require_encryption) || _load_resource_pack(OS::get_singleton()->get_bundle_resource_dir().path_join(exec_filename + ".pck"), false, 0, true, require_encryption);
 		}
 #endif
 
 		if (!found) {
 			// Try to load data pack at the location of the executable.
 			// As mentioned above, we have two potential names to attempt.
-			found = _load_resource_pack(exec_dir.path_join(exec_basename + ".pck"), false, 0, true) || _load_resource_pack(exec_dir.path_join(exec_filename + ".pck"), false, 0, true);
+			found = _load_resource_pack(exec_dir.path_join(exec_basename + ".pck"), false, 0, true, require_encryption) || _load_resource_pack(exec_dir.path_join(exec_filename + ".pck"), false, 0, true, require_encryption);
 		}
 
 		if (!found) {
 			// If we couldn't find them next to the executable, we attempt
 			// the current working directory. Same story, two tests.
-			found = _load_resource_pack(exec_basename + ".pck", false, 0, true) || _load_resource_pack(exec_filename + ".pck", false, 0, true);
+			found = _load_resource_pack(exec_basename + ".pck", false, 0, true, require_encryption) || _load_resource_pack(exec_filename + ".pck", false, 0, true, require_encryption);
 		}
 
 		// If we opened our package, try and load our project.
 		if (found) {
 			Error err = _load_settings_text_or_binary("res://project.godot", "res://project.binary");
-			if (err == OK && !p_ignore_override) {
+			if (!require_encryption && err == OK && !p_ignore_override) {
 				// Load overrides from the PCK and the executable location.
 				// Optional, we don't mind if either fails.
 				_load_settings_text("res://override.cfg");
@@ -638,83 +645,87 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 	}
 
 	// Try to use the filesystem for files, according to OS.
-	// (Only Android -when reading from pck- and iOS use this.)
+	// (Only Android -when reading from APK- uses this.)
 
 	if (!OS::get_singleton()->get_resource_dir().is_empty()) {
 		Error err = _load_settings_text_or_binary("res://project.godot", "res://project.binary");
-		if (err == OK && !p_ignore_override) {
+		if (!require_encryption && err == OK && !p_ignore_override) {
 			// Optional, we don't mind if it fails.
 			_load_settings_text("res://override.cfg");
 		}
 		return err;
 	}
 
+	if (require_encryption) {
+		return ERR_CANT_OPEN;
+	} else {
 #ifdef MACOS_ENABLED
-	// Attempt to load project file from macOS .app bundle resources.
-	resource_path = OS::get_singleton()->get_bundle_resource_dir();
-	if (!resource_path.is_empty()) {
-		if (resource_path[resource_path.length() - 1] == '/') {
-			resource_path = resource_path.substr(0, resource_path.length() - 1); // Chop end.
-		}
-		Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-		ERR_FAIL_COND_V_MSG(d.is_null(), ERR_CANT_CREATE, vformat("Cannot create DirAccess for path '%s'.", resource_path));
-		d->change_dir(resource_path);
+		// Attempt to load project file from macOS .app bundle resources.
+		resource_path = OS::get_singleton()->get_bundle_resource_dir();
+		if (!resource_path.is_empty()) {
+			if (resource_path[resource_path.length() - 1] == '/') {
+				resource_path = resource_path.substr(0, resource_path.length() - 1); // Chop end.
+			}
+			Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+			ERR_FAIL_COND_V_MSG(d.is_null(), ERR_CANT_CREATE, vformat("Cannot create DirAccess for path '%s'.", resource_path));
+			d->change_dir(resource_path);
 
-		Error err;
+			Error err;
 
-		err = _load_settings_text_or_binary(resource_path.path_join("project.godot"), resource_path.path_join("project.binary"));
-		if (err == OK && !p_ignore_override) {
-			// Optional, we don't mind if it fails.
-			_load_settings_text(resource_path.path_join("override.cfg"));
-			return err;
+			err = _load_settings_text_or_binary(resource_path.path_join("project.godot"), resource_path.path_join("project.binary"));
+			if (err == OK && !p_ignore_override) {
+				// Optional, we don't mind if it fails.
+				_load_settings_text(resource_path.path_join("override.cfg"));
+				return err;
+			}
 		}
-	}
 #endif
 
-	// Nothing was found, try to find a project file in provided path (`p_path`)
-	// or, if requested (`p_upwards`) in parent directories.
+		// Nothing was found, try to find a project file in provided path (`p_path`)
+		// or, if requested (`p_upwards`) in parent directories.
 
-	Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	ERR_FAIL_COND_V_MSG(d.is_null(), ERR_CANT_CREATE, vformat("Cannot create DirAccess for path '%s'.", p_path));
-	d->change_dir(p_path);
+		Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+		ERR_FAIL_COND_V_MSG(d.is_null(), ERR_CANT_CREATE, vformat("Cannot create DirAccess for path '%s'.", p_path));
+		d->change_dir(p_path);
 
-	String current_dir = d->get_current_dir();
-	bool found = false;
-	Error err;
+		String current_dir = d->get_current_dir();
+		bool found = false;
+		Error err;
 
-	while (true) {
-		// Set the resource path early so things can be resolved when loading.
-		resource_path = current_dir;
-		resource_path = resource_path.replace("\\", "/"); // Windows path to Unix path just in case.
-		err = _load_settings_text_or_binary(current_dir.path_join("project.godot"), current_dir.path_join("project.binary"));
-		if (err == OK && !p_ignore_override) {
-			// Optional, we don't mind if it fails.
-			_load_settings_text(current_dir.path_join("override.cfg"));
-			found = true;
-			break;
-		}
-
-		if (p_upwards) {
-			// Try to load settings ascending through parent directories
-			d->change_dir("..");
-			if (d->get_current_dir() == current_dir) {
-				break; // not doing anything useful
+		while (true) {
+			// Set the resource path early so things can be resolved when loading.
+			resource_path = current_dir;
+			resource_path = resource_path.replace("\\", "/"); // Windows path to Unix path just in case.
+			err = _load_settings_text_or_binary(current_dir.path_join("project.godot"), current_dir.path_join("project.binary"));
+			if (err == OK && !p_ignore_override) {
+				// Optional, we don't mind if it fails.
+				_load_settings_text(current_dir.path_join("override.cfg"));
+				found = true;
+				break;
 			}
-			current_dir = d->get_current_dir();
-		} else {
-			break;
+
+			if (p_upwards) {
+				// Try to load settings ascending through parent directories
+				d->change_dir("..");
+				if (d->get_current_dir() == current_dir) {
+					break; // not doing anything useful
+				}
+				current_dir = d->get_current_dir();
+			} else {
+				break;
+			}
 		}
-	}
 
-	if (!found) {
-		return err;
-	}
+		if (!found) {
+			return err;
+		}
 
-	if (resource_path.length() && resource_path[resource_path.length() - 1] == '/') {
-		resource_path = resource_path.substr(0, resource_path.length() - 1); // Chop end.
-	}
+		if (resource_path.length() && resource_path[resource_path.length() - 1] == '/') {
+			resource_path = resource_path.substr(0, resource_path.length() - 1); // Chop end.
+		}
 
-	return OK;
+		return OK;
+	}
 }
 
 Error ProjectSettings::setup(const String &p_path, const String &p_main_pack, bool p_upwards, bool p_ignore_override) {
@@ -1419,7 +1430,7 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("localize_path", "path"), &ProjectSettings::localize_path);
 	ClassDB::bind_method(D_METHOD("globalize_path", "path"), &ProjectSettings::globalize_path);
 	ClassDB::bind_method(D_METHOD("save"), &ProjectSettings::save);
-	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset"), &ProjectSettings::load_resource_pack, DEFVAL(true), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset", "require_encryption"), &ProjectSettings::load_resource_pack, DEFVAL(true), DEFVAL(0), DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("save_custom", "file"), &ProjectSettings::_save_custom_bnd);
 

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -134,8 +134,8 @@ protected:
 
 	void _convert_to_last_version(int p_from_version);
 
-	bool load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset);
-	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true, int p_offset = 0, bool p_main_pack = false);
+	bool load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset, bool p_require_encryption = false);
+	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true, int p_offset = 0, bool p_main_pack = false, bool p_require_encryption = false);
 
 	void _add_property_info_bind(const Dictionary &p_info);
 
@@ -145,6 +145,11 @@ protected:
 
 protected:
 	static void _bind_methods();
+
+#ifndef DISABLE_DEPRECATED
+	bool _load_resource_pack_bind_compat_76161(const String &p_pack, bool p_replace_files, int p_offset);
+	static void _bind_compatibility_methods();
+#endif
 
 public:
 	static const int CONFIG_VERSION = 5;

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -38,6 +38,8 @@
 
 // Godot's packed file magic header ("GDPC" in ASCII).
 #define PACK_HEADER_MAGIC 0x43504447
+// Godot's packed file standalone directory magic header ("GDDR" in ASCII).
+#define DIR_HEADER_MAGIC 0x52444447
 // The current packed file format version number.
 #define PACK_FORMAT_VERSION 2
 
@@ -96,6 +98,7 @@ private:
 		}
 	};
 
+	static HashSet<String> require_encryption;
 	HashMap<PathMD5, PackedFile, PathMD5> files;
 
 	Vector<PackSource *> sources;
@@ -109,6 +112,8 @@ private:
 	void _get_file_paths(PackedDir *p_dir, const String &p_parent_dir, HashSet<String> &r_paths) const;
 
 public:
+	static bool file_requires_encryption(const String &p_name);
+
 	void add_pack_source(PackSource *p_source);
 	void add_path(const String &p_pkg_path, const String &p_path, uint64_t p_ofs, uint64_t p_size, const uint8_t *p_md5, PackSource *p_src, bool p_replace_files, bool p_encrypted = false); // for PackSource
 	void remove_path(const String &p_path);
@@ -119,7 +124,7 @@ public:
 	_FORCE_INLINE_ bool is_disabled() const { return disabled; }
 
 	static PackedData *get_singleton() { return singleton; }
-	Error add_pack(const String &p_path, bool p_replace_files, uint64_t p_offset);
+	Error add_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, bool p_require_encryption = false);
 
 	void clear();
 
@@ -137,14 +142,14 @@ public:
 
 class PackSource {
 public:
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) = 0;
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, bool p_require_encryption) = 0;
 	virtual Ref<FileAccess> get_file(const String &p_path, PackedData::PackedFile *p_file) = 0;
 	virtual ~PackSource() {}
 };
 
 class PackedSourcePCK : public PackSource {
 public:
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) override;
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, bool p_require_encryption) override;
 	virtual Ref<FileAccess> get_file(const String &p_path, PackedData::PackedFile *p_file) override;
 };
 
@@ -152,7 +157,7 @@ class PackedSourceDirectory : public PackSource {
 	void add_directory(const String &p_path, bool p_replace_files);
 
 public:
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) override;
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, bool p_require_encryption) override;
 	virtual Ref<FileAccess> get_file(const String &p_path, PackedData::PackedFile *p_file) override;
 };
 

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -146,13 +146,14 @@ unzFile ZipArchive::get_file_handle(const String &p_file) const {
 	return pkg;
 }
 
-bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset = 0) {
-	// load with offset feature only supported for PCK files
-	ERR_FAIL_COND_V_MSG(p_offset != 0, false, "Invalid PCK data. Note that loading files with a non-zero offset isn't supported with ZIP archives.");
-
+bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, bool p_require_encryption) {
 	if (p_path.get_extension().nocasecmp_to("zip") != 0 && p_path.get_extension().nocasecmp_to("pcz") != 0) {
 		return false;
 	}
+
+	// Load with offset feature only supported for PCK files.
+	ERR_FAIL_COND_V_MSG(p_require_encryption, false, "Invalid PCK data. Encryption is not supported with ZIP archives.");
+	ERR_FAIL_COND_V_MSG(p_offset != 0, false, "Invalid PCK data. Note that loading files with a non-zero offset isn't supported with ZIP archives.");
 
 	zlib_filefunc_def io;
 	memset(&io, 0, sizeof(io));

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -63,7 +63,7 @@ public:
 
 	bool file_exists(const String &p_name) const;
 
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) override;
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, bool p_require_encryption) override;
 	Ref<FileAccess> get_file(const String &p_path, PackedData::PackedFile *p_file) override;
 
 	static ZipArchive *get_singleton();

--- a/doc/classes/EditorExportPreset.xml
+++ b/doc/classes/EditorExportPreset.xml
@@ -33,7 +33,7 @@
 				Returns number of files selected in the "Resources" tab of the export dialog.
 			</description>
 		</method>
-		<method name="get_encrypt_directory" qualifiers="const">
+		<method name="get_encrypt_directory" qualifiers="const" deprecated="Directory encryption is always enabled.">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code], PCK directory encryption is enabled in the export dialog.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -147,11 +147,13 @@
 			<param index="0" name="pack" type="String" />
 			<param index="1" name="replace_files" type="bool" default="true" />
 			<param index="2" name="offset" type="int" default="0" />
+			<param index="3" name="require_encryption" type="bool" default="false" />
 			<description>
 				Loads the contents of the .pck or .zip file specified by [param pack] into the resource filesystem ([code]res://[/code]). Returns [code]true[/code] on success.
 				[b]Note:[/b] If a file from [param pack] shares the same path as a file already in the resource filesystem, any attempts to load that file will use the file from [param pack] unless [param replace_files] is set to [code]false[/code].
 				[b]Note:[/b] The optional [param offset] parameter can be used to specify the offset in bytes to the start of the resource pack. This is only supported for .pck files.
 				[b]Note:[/b] [DirAccess] will not show changes made to the contents of [code]res://[/code] after calling this function.
+				[b]Note:[/b] Encryption is only supported for .pck files.
 			</description>
 		</method>
 		<method name="localize_path" qualifiers="const">

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -90,7 +90,6 @@ void EditorExport::_save() {
 		config->set_value(section, "seed", preset->get_seed());
 
 		config->set_value(section, "encrypt_pck", preset->get_enc_pck());
-		config->set_value(section, "encrypt_directory", preset->get_enc_directory());
 		config->set_value(section, "script_export_mode", preset->get_script_export_mode());
 		credentials->set_value(section, "script_encryption_key", preset->get_script_encryption_key());
 
@@ -314,9 +313,6 @@ void EditorExport::load_config() {
 		}
 		if (config->has_section_key(section, "encrypt_pck")) {
 			preset->set_enc_pck(config->get_value(section, "encrypt_pck"));
-		}
-		if (config->has_section_key(section, "encrypt_directory")) {
-			preset->set_enc_directory(config->get_value(section, "encrypt_directory"));
 		}
 		if (config->has_section_key(section, "encryption_include_filters")) {
 			preset->set_enc_in_filter(config->get_value(section, "encryption_include_filters"));

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -84,7 +84,9 @@ void EditorExportPreset::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_encryption_in_filter"), &EditorExportPreset::get_enc_in_filter);
 	ClassDB::bind_method(D_METHOD("get_encryption_ex_filter"), &EditorExportPreset::get_enc_ex_filter);
 	ClassDB::bind_method(D_METHOD("get_encrypt_pck"), &EditorExportPreset::get_enc_pck);
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("get_encrypt_directory"), &EditorExportPreset::get_enc_directory);
+#endif
 	ClassDB::bind_method(D_METHOD("get_encryption_key"), &EditorExportPreset::get_script_encryption_key);
 	ClassDB::bind_method(D_METHOD("get_script_export_mode"), &EditorExportPreset::get_script_export_mode);
 
@@ -469,14 +471,11 @@ bool EditorExportPreset::get_enc_pck() const {
 	return enc_pck;
 }
 
-void EditorExportPreset::set_enc_directory(bool p_enabled) {
-	enc_directory = p_enabled;
-	EditorExport::singleton->save_presets();
-}
-
+#ifndef DISABLE_DEPRECATED
 bool EditorExportPreset::get_enc_directory() const {
-	return enc_directory;
+	return true;
 }
+#endif
 
 void EditorExportPreset::set_script_encryption_key(const String &p_key) {
 	script_key = p_key;

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -90,7 +90,6 @@ private:
 	String enc_in_filters;
 	String enc_ex_filters;
 	bool enc_pck = false;
-	bool enc_directory = false;
 	uint64_t seed = 0;
 
 	String script_key;
@@ -171,9 +170,9 @@ public:
 	void set_enc_pck(bool p_enabled);
 	bool get_enc_pck() const;
 
-	void set_enc_directory(bool p_enabled);
+#ifndef DISABLE_DEPRECATED
 	bool get_enc_directory() const;
-
+#endif
 	void set_script_encryption_key(const String &p_key);
 	String get_script_encryption_key() const;
 

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -386,14 +386,10 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 		seed_input->set_text(itos(seed));
 	}
 
-	enc_directory->set_disabled(!enc_pck_mode);
 	enc_in_filters->set_editable(enc_pck_mode);
 	enc_ex_filters->set_editable(enc_pck_mode);
 	script_key->set_editable(enc_pck_mode);
 	seed_input->set_editable(enc_pck_mode);
-
-	bool enc_directory_mode = current->get_enc_directory();
-	enc_directory->set_pressed(enc_directory_mode);
 
 	String key = current->get_script_encryption_key();
 	if (!updating_script_key) {
@@ -588,7 +584,6 @@ void ProjectExportDialog::_enc_pck_changed(bool p_pressed) {
 	ERR_FAIL_COND(current.is_null());
 
 	current->set_enc_pck(p_pressed);
-	enc_directory->set_disabled(!p_pressed);
 	enc_in_filters->set_editable(p_pressed);
 	enc_ex_filters->set_editable(p_pressed);
 	script_key->set_editable(p_pressed);
@@ -609,19 +604,6 @@ void ProjectExportDialog::_seed_input_changed(const String &p_text) {
 	updating_seed = true;
 	_update_current_preset();
 	updating_seed = false;
-}
-
-void ProjectExportDialog::_enc_directory_changed(bool p_pressed) {
-	if (updating) {
-		return;
-	}
-
-	Ref<EditorExportPreset> current = get_current_preset();
-	ERR_FAIL_COND(current.is_null());
-
-	current->set_enc_directory(p_pressed);
-
-	_update_current_preset();
 }
 
 void ProjectExportDialog::_script_encryption_key_changed(const String &p_key) {
@@ -707,7 +689,6 @@ void ProjectExportDialog::_duplicate_preset() {
 	preset->set_enc_in_filter(current->get_enc_in_filter());
 	preset->set_enc_ex_filter(current->get_enc_ex_filter());
 	preset->set_enc_pck(current->get_enc_pck());
-	preset->set_enc_directory(current->get_enc_directory());
 	preset->set_script_encryption_key(current->get_script_encryption_key());
 	preset->set_script_export_mode(current->get_script_export_mode());
 
@@ -1626,13 +1607,8 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	enc_pck = memnew(CheckButton);
 	enc_pck->connect(SceneStringName(toggled), callable_mp(this, &ProjectExportDialog::_enc_pck_changed));
-	enc_pck->set_text(TTR("Encrypt Exported PCK"));
+	enc_pck->set_text(TTR("Encrypt Exported PCK or Android Assets"));
 	sec_vb->add_child(enc_pck);
-
-	enc_directory = memnew(CheckButton);
-	enc_directory->connect(SceneStringName(toggled), callable_mp(this, &ProjectExportDialog::_enc_directory_changed));
-	enc_directory->set_text(TTR("Encrypt Index (File Names and Info)"));
-	sec_vb->add_child(enc_directory);
 
 	enc_in_filters = memnew(LineEdit);
 	enc_in_filters->connect(SceneStringName(text_changed), callable_mp(this, &ProjectExportDialog::_enc_filters_changed));

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -168,7 +168,6 @@ class ProjectExportDialog : public ConfirmationDialog {
 	EditorFileDialog *export_project = nullptr;
 
 	CheckButton *enc_pck = nullptr;
-	CheckButton *enc_directory = nullptr;
 	LineEdit *enc_in_filters = nullptr;
 	LineEdit *enc_ex_filters = nullptr;
 	LineEdit *seed_input = nullptr;
@@ -194,7 +193,6 @@ class ProjectExportDialog : public ConfirmationDialog {
 	bool updating_enc_filters = false;
 	bool updating_seed = false;
 	void _enc_pck_changed(bool p_pressed);
-	void _enc_directory_changed(bool p_pressed);
 	void _enc_filters_changed(const String &p_text);
 	void _seed_input_changed(const String &p_text);
 	void _script_encryption_key_changed(const String &p_key);

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -24,3 +24,11 @@ Validate extension JSON: Error: Field 'classes/OpenXRAPIExtension/methods/regist
 Validate extension JSON: Error: Field 'classes/OpenXRAPIExtension/methods/unregister_projection_views_extension/arguments/0': type changed value in new API, from "OpenXRExtensionWrapperExtension" to "OpenXRExtensionWrapper".
 
 Switched from `OpenXRExtensionWrapperExtension` to parent `OpenXRExtensionWrapper`. Compatibility methods registered.
+
+
+GH-76161
+--------
+
+Validate extension JSON: Error: Field 'classes/ProjectSettings/methods/load_resource_pack/arguments': size changed value in new API, from 3 to 4.
+
+Added optional argument. Compatibility method registered.

--- a/platform/android/doc_classes/EditorExportPlatformAndroid.xml
+++ b/platform/android/doc_classes/EditorExportPlatformAndroid.xml
@@ -16,7 +16,6 @@
 		</member>
 		<member name="apk_expansion/enable" type="bool" setter="" getter="">
 			If [code]true[/code], project resources are stored in the separate APK expansion file, instead of the APK.
-			[b]Note:[/b] APK expansion should be enabled to use PCK encryption. See [url=https://developer.android.com/google/play/expansion-files]APK Expansion Files[/url]
 		</member>
 		<member name="apk_expansion/public_key" type="String" setter="" getter="">
 			Base64 encoded RSA public key for your publisher account, available from the profile page on the "Google Play Console".

--- a/platform/android/export/encryption_export_util.cpp
+++ b/platform/android/export/encryption_export_util.cpp
@@ -1,0 +1,221 @@
+/**************************************************************************/
+/*  encryption_export_util.cpp                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "encryption_export_util.h"
+
+#include "core/crypto/crypto_core.h"
+#include "core/io/file_access_encrypted.h"
+#include "core/io/file_access_memory.h"
+#include "core/io/file_access_pack.h"
+#include "core/math/random_pcg.h"
+#include "core/version.h"
+#include "editor/export/editor_export_platform.h"
+
+constexpr int64_t DIRECTORY_HEADER_SIZE = 23 * sizeof(uint64_t); // Directory header size.
+constexpr int64_t ENCRYPTION_OVERHEAD = 64; // Hash + IV + data size.
+
+String encrypt_file(Vector<uint8_t> &r_enc_data, HashSet<String> r_ids, HashMap<String, String> &r_directory, const String &p_path, const Vector<uint8_t> &p_data, const Vector<uint8_t> &p_key, uint64_t p_seed) {
+	String path = p_path;
+	if (path.begins_with("/")) {
+		path = path.substr(1, path.length());
+	} else if (path.begins_with("res://")) {
+		path = path.substr(6, path.length());
+	}
+
+	String id;
+	do {
+		// Generate random ID.
+		CharString cs = path.utf8();
+		for (int i = 0; i < 16; i++) {
+			cs += char(32 + Math::rand() % 220);
+		}
+		unsigned char hash[32];
+		CryptoCore::sha256((unsigned char *)cs.ptr(), cs.length(), hash);
+		id = String::hex_encode_buffer(hash, 32);
+	} while (r_ids.has(id));
+
+	r_ids.insert(id);
+
+	{
+		uint64_t len = p_data.size();
+		len += ENCRYPTION_OVERHEAD; // Encryption overhead (hash + iv + size).
+		if (len % 16) {
+			len += 16 - (len % 16);
+		}
+		r_enc_data.resize(len);
+	}
+
+	Vector<uint8_t> iv;
+	if (p_seed != 0) {
+		uint64_t seed = p_seed;
+
+		const uint8_t *ptr = p_data.ptr();
+		uint64_t len = p_data.size();
+		for (uint64_t i = 0; i < len; i++) {
+			seed = ((seed << 5) + seed) ^ ptr[i];
+		}
+
+		RandomPCG rng = RandomPCG(seed);
+		iv.resize(16);
+		for (int i = 0; i < 16; i++) {
+			iv.write[i] = rng.rand() % 256;
+		}
+	}
+
+	Ref<FileAccessMemory> fmem;
+	fmem.instantiate();
+	ERR_FAIL_COND_V(fmem.is_null(), String());
+	Error err = fmem->open_custom(r_enc_data.ptrw(), r_enc_data.size());
+	ERR_FAIL_COND_V(err != OK, String());
+
+	Ref<FileAccessEncrypted> fae;
+	fae.instantiate();
+	ERR_FAIL_COND_V(fae.is_null(), String());
+	err = fae->open_and_parse(fmem, p_key, FileAccessEncrypted::MODE_WRITE_AES256, false, iv);
+	ERR_FAIL_COND_V(err != OK, String());
+
+	// Store file content.
+	fae->store_buffer(p_data.ptr(), p_data.size());
+
+	fae.unref();
+	fmem.unref();
+
+	r_directory[path] = id;
+
+	return id;
+}
+
+Error encrypt_directory(const HashMap<String, String> &p_directory, const String &p_script_key, Vector<uint8_t> &r_dir_data) {
+	uint64_t len = DIRECTORY_HEADER_SIZE; // Header size.
+	for (const KeyValue<String, String> &E : p_directory) {
+		uint32_t string_len = E.key.utf8().length();
+		uint32_t pad = EditorExportPlatform::_get_pad(sizeof(uint32_t), string_len);
+		len += (sizeof(uint32_t) + string_len + pad);
+
+		string_len = E.value.utf8().length();
+		pad = EditorExportPlatform::_get_pad(sizeof(uint32_t), string_len);
+		len += (sizeof(uint32_t) + string_len + pad);
+	}
+	len += ENCRYPTION_OVERHEAD; // Encryption overhead.
+	if (len % 16) {
+		len += 16 - (len % 16); // Alignment.
+	}
+	r_dir_data.resize(len);
+	memset(r_dir_data.ptrw(), 0, len);
+
+	Ref<FileAccessMemory> fmem;
+	fmem.instantiate();
+	ERR_FAIL_COND_V(fmem.is_null(), ERR_CANT_CREATE);
+	Error err = fmem->open_custom(r_dir_data.ptrw(), r_dir_data.size());
+	ERR_FAIL_COND_V(err != OK, ERR_CANT_CREATE);
+
+	fmem->store_32(DIR_HEADER_MAGIC);
+	fmem->store_32(PACK_FORMAT_VERSION);
+	fmem->store_32(VERSION_MAJOR);
+	fmem->store_32(VERSION_MINOR);
+	fmem->store_32(VERSION_PATCH);
+	fmem->store_32(PACK_DIR_ENCRYPTED); // Flags.
+
+	for (int i = 0; i < 16; i++) {
+		// Reserved.
+		fmem->store_32(0);
+	}
+
+	fmem->store_32(p_directory.size()); // Amount of files.
+
+	Ref<FileAccessEncrypted> fae;
+	Ref<FileAccess> fhead = fmem;
+	Vector<uint8_t> key;
+	key.resize(32);
+	if (p_script_key.length() == 64) {
+		for (int i = 0; i < 32; i++) {
+			int v = 0;
+			if (i * 2 < p_script_key.length()) {
+				char32_t ct = p_script_key[i * 2];
+				if (is_digit(ct)) {
+					ct = ct - '0';
+				} else if (ct >= 'a' && ct <= 'f') {
+					ct = 10 + ct - 'a';
+				}
+				v |= ct << 4;
+			}
+
+			if (i * 2 + 1 < p_script_key.length()) {
+				char32_t ct = p_script_key[i * 2 + 1];
+				if (is_digit(ct)) {
+					ct = ct - '0';
+				} else if (ct >= 'a' && ct <= 'f') {
+					ct = 10 + ct - 'a';
+				}
+				v |= ct;
+			}
+			key.write[i] = v;
+		}
+	}
+	fae.instantiate();
+	if (fae.is_null()) {
+		return ERR_CANT_CREATE;
+	}
+
+	err = fae->open_and_parse(fmem, key, FileAccessEncrypted::MODE_WRITE_AES256, false);
+	if (err != OK) {
+		return err;
+	}
+	fhead = fae;
+
+	for (const KeyValue<String, String> &E : p_directory) {
+		uint32_t string_len = E.key.utf8().length();
+		uint32_t pad = EditorExportPlatform::_get_pad(sizeof(uint32_t), string_len);
+
+		fhead->store_32(string_len + pad);
+		fhead->store_buffer((const uint8_t *)E.key.utf8().get_data(), string_len);
+		for (uint32_t j = 0; j < pad; j++) {
+			fhead->store_8(0);
+		}
+
+		string_len = E.value.utf8().length();
+		pad = EditorExportPlatform::_get_pad(sizeof(uint32_t), string_len);
+
+		fhead->store_32(string_len + pad);
+		fhead->store_buffer((const uint8_t *)E.value.utf8().get_data(), string_len);
+		for (uint32_t j = 0; j < pad; j++) {
+			fhead->store_8(0);
+		}
+	}
+
+	if (fae.is_valid()) {
+		fhead.unref();
+		fae.unref();
+	}
+
+	fmem.unref();
+
+	return OK;
+}

--- a/platform/android/export/encryption_export_util.h
+++ b/platform/android/export/encryption_export_util.h
@@ -1,0 +1,37 @@
+/**************************************************************************/
+/*  encryption_export_util.h                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
+
+String encrypt_file(Vector<uint8_t> &r_enc_data, HashSet<String> r_ids, HashMap<String, String> &r_directory, const String &p_path, const Vector<uint8_t> &p_data, const Vector<uint8_t> &p_key, uint64_t p_seed);
+Error encrypt_directory(const HashMap<String, String> &p_directory, const String &p_script_key, Vector<uint8_t> &r_dir_data);

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -72,6 +72,9 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 	struct APKExportData {
 		zipFile apk;
+		bool enc_pack = false;
+		HashMap<String, String> directory;
+		HashSet<String> ids;
 		EditorProgress *ep = nullptr;
 	};
 

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -64,6 +64,9 @@ static const int XR_MODE_OPENXR = 1;
 struct CustomExportData {
 	String assets_directory;
 	String libs_directory;
+	bool enc_pack = false;
+	HashMap<String, String> directory;
+	HashSet<String> ids;
 	bool debug;
 	Vector<String> libs;
 };

--- a/platform/android/file_access_android.cpp
+++ b/platform/android/file_access_android.cpp
@@ -30,13 +30,100 @@
 
 #include "file_access_android.h"
 
+#include "core/object/script_language.h"
 #include "core/string/print_string.h"
+#include "core/version.h"
 #include "thread_jandroid.h"
 
 #include <android/asset_manager_jni.h>
 
 AAssetManager *FileAccessAndroid::asset_manager = nullptr;
 jobject FileAccessAndroid::j_asset_manager = nullptr;
+
+#if defined(PCK_ENCRYPTION_ENABLED)
+
+HashMap<String, String> FileAccessAndroid::directory;
+bool FileAccessAndroid::dir_loaded = false;
+
+void FileAccessAndroid::_load_encrypted_directory() {
+	if (!dir_loaded) {
+		dir_loaded = true;
+		const String &enc_path = "encrypted/directory";
+
+		Ref<FileAccessAndroid> f;
+		f.instantiate();
+		ERR_FAIL_COND_MSG(f.is_null(), "Can't open encrypted file directory.");
+
+		f->asset = AAssetManager_open(asset_manager, enc_path.utf8().get_data(), AASSET_MODE_STREAMING);
+		if (f->asset) {
+			f->path_src = enc_path;
+			f->absolute_path = enc_path;
+			f->len = AAsset_getLength(f->asset);
+			f->pos = 0;
+			f->eof = false;
+
+			uint32_t magic = f->get_32();
+			if (magic == DIR_HEADER_MAGIC) {
+				uint32_t version = f->get_32();
+				uint32_t ver_major = f->get_32();
+				uint32_t ver_minor = f->get_32();
+				f->get_32(); // Patch number, not used for validation.
+
+				ERR_FAIL_COND_MSG(version != PACK_FORMAT_VERSION, "Directory version unsupported: " + itos(version) + ".");
+				ERR_FAIL_COND_MSG(ver_major > VERSION_MAJOR || (ver_major == VERSION_MAJOR && ver_minor > VERSION_MINOR), "Directory created with a newer version of the engine: " + itos(ver_major) + "." + itos(ver_minor) + ".");
+
+				uint32_t pack_flags = f->get_32();
+
+				bool enc_directory = (pack_flags & PACK_DIR_ENCRYPTED);
+				ERR_FAIL_COND_MSG(!enc_directory, "Can't open encrypted pack directory.");
+				for (int i = 0; i < 16; i++) {
+					// Reserved.
+					f->get_32();
+				}
+
+				int file_count = f->get_32();
+
+				Ref<FileAccess> fhead = f;
+				Ref<FileAccessEncrypted> fae;
+				fae.instantiate();
+				ERR_FAIL_COND_MSG(fae.is_null(), "Can't open encrypted directory.");
+
+				Vector<uint8_t> key;
+				key.resize(32);
+				for (int i = 0; i < key.size(); i++) {
+					key.write[i] = script_encryption_key[i];
+				}
+
+				Error err = fae->open_and_parse(f, key, FileAccessEncrypted::MODE_READ, false);
+				ERR_FAIL_COND_MSG(err, "Can't open encrypted directory.");
+				fhead = fae;
+
+				for (int i = 0; i < file_count; i++) {
+					uint32_t sl = fhead->get_32();
+					CharString cs;
+					cs.resize(sl + 1);
+					fhead->get_buffer((uint8_t *)cs.ptr(), sl);
+					cs[sl] = 0;
+
+					String path;
+					path.parse_utf8(cs.ptr());
+
+					sl = fhead->get_32();
+					cs.resize(sl + 1);
+					fhead->get_buffer((uint8_t *)cs.ptr(), sl);
+					cs[sl] = 0;
+
+					String enc_path;
+					enc_path.parse_utf8(cs.ptr());
+
+					directory[path] = enc_path;
+				}
+			}
+		}
+	}
+}
+
+#endif
 
 String FileAccessAndroid::get_path() const {
 	return path_src;
@@ -59,18 +146,65 @@ Error FileAccessAndroid::open_internal(const String &p_path, int p_mode_flags) {
 	}
 
 	ERR_FAIL_COND_V(p_mode_flags & FileAccess::WRITE, ERR_UNAVAILABLE); //can't write on android..
-	asset = AAssetManager_open(asset_manager, path.utf8().get_data(), AASSET_MODE_STREAMING);
-	if (!asset) {
-		return ERR_CANT_OPEN;
+
+#if defined(PCK_ENCRYPTION_ENABLED)
+	_load_encrypted_directory();
+	if (directory.has(path)) {
+		const String &enc_path = "encrypted/" + directory[path];
+
+		Ref<FileAccessAndroid> f;
+		f.instantiate();
+		ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_OPEN, "Can't open encrypted file '" + path + "'.");
+
+		f->asset = AAssetManager_open(asset_manager, enc_path.utf8().get_data(), AASSET_MODE_STREAMING);
+		if (!f->asset) {
+			return ERR_CANT_OPEN;
+		}
+		f->path_src = enc_path;
+		f->absolute_path = enc_path;
+		f->len = AAsset_getLength(f->asset);
+		f->pos = 0;
+		f->eof = false;
+
+		fae.instantiate();
+		ERR_FAIL_COND_V_MSG(fae.is_null(), ERR_CANT_OPEN, "Can't open encrypted file '" + path + "'.");
+
+		Vector<uint8_t> key;
+		key.resize(32);
+		for (int i = 0; i < key.size(); i++) {
+			key.write[i] = script_encryption_key[i];
+		}
+
+		Error err = fae->open_and_parse(f, key, FileAccessEncrypted::MODE_READ, false);
+		if (err != OK) {
+			if (fae.is_valid()) {
+				fae.unref();
+			}
+			ERR_FAIL_V_MSG(err, "Can't open encrypted file '" + path + "'.");
+		}
+	} else {
+		ERR_FAIL_COND_V_MSG(PackedData::file_requires_encryption(path), ERR_CANT_OPEN, "Can't open encrypted pack-referenced file '" + path + "'.");
+#else
+	{
+#endif
+		asset = AAssetManager_open(asset_manager, path.utf8().get_data(), AASSET_MODE_STREAMING);
+		if (!asset) {
+			return ERR_CANT_OPEN;
+		}
+		len = AAsset_getLength(asset);
+		pos = 0;
+		eof = false;
 	}
-	len = AAsset_getLength(asset);
-	pos = 0;
-	eof = false;
 
 	return OK;
 }
 
 void FileAccessAndroid::_close() {
+#if defined(PCK_ENCRYPTION_ENABLED)
+	if (fae.is_valid()) {
+		fae.unref();
+	}
+#endif
 	if (!asset) {
 		return;
 	}
@@ -83,6 +217,13 @@ bool FileAccessAndroid::is_open() const {
 }
 
 void FileAccessAndroid::seek(uint64_t p_position) {
+#if defined(PCK_ENCRYPTION_ENABLED)
+	if (fae.is_valid()) {
+		fae->seek(p_position);
+		return;
+	}
+#endif
+
 	ERR_FAIL_NULL(asset);
 
 	AAsset_seek(asset, p_position, SEEK_SET);
@@ -96,25 +237,57 @@ void FileAccessAndroid::seek(uint64_t p_position) {
 }
 
 void FileAccessAndroid::seek_end(int64_t p_position) {
+#if defined(PCK_ENCRYPTION_ENABLED)
+	if (fae.is_valid()) {
+		fae->seek_end(p_position);
+		return;
+	}
+#endif
+
 	ERR_FAIL_NULL(asset);
+
 	AAsset_seek(asset, p_position, SEEK_END);
 	pos = len + p_position;
 }
 
 uint64_t FileAccessAndroid::get_position() const {
+#if defined(PCK_ENCRYPTION_ENABLED)
+	if (fae.is_valid()) {
+		return fae->get_position();
+	}
+#endif
+
 	return pos;
 }
 
 uint64_t FileAccessAndroid::get_length() const {
+#if defined(PCK_ENCRYPTION_ENABLED)
+	if (fae.is_valid()) {
+		return fae->get_length();
+	}
+#endif
+
 	return len;
 }
 
 bool FileAccessAndroid::eof_reached() const {
+#if defined(PCK_ENCRYPTION_ENABLED)
+	if (fae.is_valid()) {
+		return fae->eof_reached();
+	}
+#endif
+
 	return eof;
 }
 
 uint64_t FileAccessAndroid::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
+
+#if defined(PCK_ENCRYPTION_ENABLED)
+	if (fae.is_valid()) {
+		return fae->get_buffer(p_dst, p_length);
+	}
+#endif
 
 	int r = AAsset_read(asset, p_dst, p_length);
 
@@ -137,6 +310,12 @@ int64_t FileAccessAndroid::_get_size(const String &p_file) {
 }
 
 Error FileAccessAndroid::get_error() const {
+#if defined(PCK_ENCRYPTION_ENABLED)
+	if (fae.is_valid()) {
+		return fae->get_error();
+	}
+#endif
+
 	return eof ? ERR_FILE_EOF : OK; // not sure what else it may happen
 }
 
@@ -155,6 +334,13 @@ bool FileAccessAndroid::file_exists(const String &p_path) {
 	} else if (path.begins_with("res://")) {
 		path = path.substr(6);
 	}
+
+#if defined(PCK_ENCRYPTION_ENABLED)
+	_load_encrypted_directory();
+	if (directory.has(path)) {
+		path = "encrypted/" + directory[path];
+	}
+#endif
 
 	AAsset *at = AAssetManager_open(asset_manager, path.utf8().get_data(), AASSET_MODE_STREAMING);
 

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -31,6 +31,8 @@
 #pragma once
 
 #include "core/io/file_access.h"
+#include "core/io/file_access_encrypted.h"
+#include "core/io/file_access_pack.h"
 
 #include <android/asset_manager.h>
 #include <android/log.h>
@@ -47,6 +49,14 @@ class FileAccessAndroid : public FileAccess {
 	mutable bool eof = false;
 	String absolute_path;
 	String path_src;
+
+#if defined(PCK_ENCRYPTION_ENABLED)
+	static HashMap<String, String> directory;
+	static bool dir_loaded;
+	Ref<FileAccessEncrypted> fae;
+
+	static void _load_encrypted_directory();
+#endif
 
 	void _close();
 

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -416,7 +416,9 @@ String OS_Android::get_resource_dir() const {
 #ifdef TOOLS_ENABLED
 	return OS_Unix::get_resource_dir();
 #else
-	if (remote_fs_dir.is_empty()) {
+	if (use_apk_expansion) {
+		return OS_Unix::get_resource_dir();
+	} else if (remote_fs_dir.is_empty()) {
 		return "/"; // Android has its own filesystem for resources inside the APK
 	} else {
 		return remote_fs_dir;


### PR DESCRIPTION
Adds some extra restrictions to the exports with embedded encryption key (compiled with `SCRIPT_AES256_ENCRYPTION_KEY`) to make encryption bypass by overriding project settings harder:

Allows encrypting asset files in the APK/AAB using existing PCK encryption key/export config, without using APK extension.

- Always encrypt PCK file list/metadata and some core files.
- Allow only encrypted main PCK to be loaded and ignore `project.godot`/`project.binary` outside the PCK.
- Disable command line arguments for remote filesystem, and script / scene selection when encryption is used.
- Disable `override.cfg`.

Implements https://github.com/godotengine/godot-proposals/issues/6675