### PR TITLE
Document why Gradient.reverse() doesn't reverse constant gradients

### DIFF
--- a/doc/classes/Gradient.xml
+++ b/doc/classes/Gradient.xml
@@ -49,13 +49,14 @@
 			<return type="void" />
 			<description>
 				Reverses/mirrors the gradient.
+				[b]Note:[/b] This method mirrors all points around the middle of the gradient, which may produce unexpected results when [member interpolation_mode] is set to [constant GRADIENT_INTERPOLATE_CONSTANT].
 			</description>
 		</method>
 		<method name="sample">
 			<return type="Color" />
 			<param index="0" name="offset" type="float" />
 			<description>
-				Returns the interpolated color specified by [code]offset[/code].
+				Returns the interpolated color specified by [param offset].
 			</description>
 		</method>
 		<method name="set_color">


### PR DESCRIPTION
Edit: Closes #76169

Documents this behavior:

https://user-images.githubusercontent.com/85438892/232495416-96b97a62-d203-442b-aee4-1ff9f3f9f6f1.mp4

Or maybe we decide that this a bug that should be fixed. (Edit: I recommend that we don't decide this, see comment)