### PR TITLE
Editor: add gutter to preview and update inline colors in the script and shader editors

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -739,6 +739,9 @@
 		<member name="text_editor/appearance/gutters/line_numbers_zero_padded" type="bool" setter="" getter="">
 			If [code]true[/code], displays line numbers with zero padding (e.g. [code]007[/code] instead of [code]7[/code]).
 		</member>
+		<member name="text_editor/appearance/gutters/show_color_preview_gutter" type="bool" setter="" getter="">
+			If [code]true[/code], displays inline color preview in a gutter at the left. Only preview the first inline color. Click on the gutter to show a [ColorPicker] and change the inline color.
+		</member>
 		<member name="text_editor/appearance/gutters/show_info_gutter" type="bool" setter="" getter="">
 			If [code]true[/code], displays a gutter at the left containing icons for methods with signal connections and for overridden methods.
 		</member>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -554,6 +554,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/appearance/gutters/line_numbers_zero_padded", false);
 	_initial_set("text_editor/appearance/gutters/highlight_type_safe_lines", true);
 	_initial_set("text_editor/appearance/gutters/show_info_gutter", true);
+	_initial_set("text_editor/appearance/gutters/show_color_preview_gutter", true);
 
 	// Appearance: Minimap
 	_initial_set("text_editor/appearance/minimap/show_minimap", true);

--- a/editor/icons/ColorPreviewOpaque.svg
+++ b/editor/icons/ColorPreviewOpaque.svg
@@ -1,0 +1,1 @@
+<svg enable-background="new 0 0 64 64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg"><path d="m24 1052.4 40-40v40z" fill="#fff" transform="translate(0 -988.36)"/></svg>

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -34,6 +34,7 @@
 #include "script_editor_plugin.h"
 
 #include "editor/code_editor.h"
+#include "modules/regex/regex.h"
 #include "scene/gui/color_picker.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/tree.h"
@@ -91,6 +92,15 @@ class ScriptTextEditor : public ScriptEditorBase {
 	int connection_gutter = -1;
 	void _gutter_clicked(int p_line, int p_gutter);
 	void _update_gutter_indexes();
+
+	int color_preview_gutter = -1;
+	RegEx color_rule = RegEx("Color((?<named_color>\\.[A-Z_]+)|(?<ctor>\\(.*\\)))");
+	Ref<Texture2D> color_preview_icon;
+	Ref<Texture2D> color_preview_opaque_icon;
+	Variant _parse_color_value(const String &p_line, Ref<RegExMatch> *r_match = nullptr) const;
+	String _format_color_value(const Color &p_color) const;
+	Point2 _snap_color_panel_position(const Point2 &p_position) const;
+	void _color_preview_gutter_draw_callback(int p_line, int p_gutter, Rect2 p_region);
 
 	int line_number_gutter = -1;
 	Color default_line_number_color = Color(1, 1, 1);
@@ -165,6 +175,8 @@ protected:
 	void _update_errors();
 	void _update_bookmark_list();
 	void _bookmark_item_pressed(int p_idx);
+
+	void _update_color_previews();
 
 	static void _code_complete_scripts(void *p_ud, const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force);
 	void _code_complete_script(const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force);

--- a/editor/plugins/text_shader_editor.h
+++ b/editor/plugins/text_shader_editor.h
@@ -32,6 +32,8 @@
 #define TEXT_SHADER_EDITOR_H
 
 #include "editor/code_editor.h"
+#include "modules/regex/regex.h"
+#include "scene/gui/color_picker.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/rich_text_label.h"
@@ -150,12 +152,19 @@ class TextShaderEditor : public MarginContainer {
 	ShaderTextEditor *shader_editor = nullptr;
 	bool compilation_success = true;
 
+	PopupPanel *color_panel = nullptr;
+	ColorPicker *color_picker = nullptr;
+	Vector2 color_position;
+	String color_args;
+
 	void _menu_option(int p_option);
 	mutable Ref<Shader> shader;
 	mutable Ref<ShaderInclude> shader_inc;
 
 	void _editor_settings_changed();
 	void _project_settings_changed();
+
+	void _color_changed(const Color &p_color);
 
 	void _check_for_external_edit();
 	void _reload_shader_from_disk();
@@ -165,10 +174,22 @@ class TextShaderEditor : public MarginContainer {
 	void _warning_clicked(Variant p_line);
 	void _update_warnings(bool p_validate);
 
-	void _script_validated(bool p_valid) {
-		compilation_success = p_valid;
-		emit_signal(SNAME("validation_changed"));
-	}
+	void _script_validated(bool p_valid);
+
+	void _update_color_previews();
+
+	void _gutter_clicked(int p_line, int p_gutter);
+	void _update_gutter_indexes();
+
+	/* Color Preview Gutter */
+	int color_preview_gutter = -1;
+	RegEx source_color_rule = RegEx("vec4\\((?<channels>.*)\\)");
+	Ref<Texture2D> color_preview_icon;
+	Ref<Texture2D> color_preview_opaque_icon;
+	Variant _parse_source_color_value(const String &p_line, Ref<RegExMatch> *r_match = nullptr) const;
+	String _format_source_color_value(const Color &p_color) const;
+	Point2 _snap_color_panel_position(const Point2 &p_position);
+	void _color_preview_gutter_draw_callback(int p_line, int p_gutter, Rect2 p_region);
 
 	uint32_t dependencies_version = 0xFFFFFFFF;
 


### PR DESCRIPTION
This is an implementation of this [GIP #6653](https://github.com/godotengine/godot-proposals/issues/6653).

- parses most `Color` constructors and static methods.
- shows a `ColorPicker` when clicking on color preview's gutter. Set picker's position around color preview's gutter such as editor's content can still be visualized (may need Right-To-Left support in the future).
- updates color in line with new picked color.
- adds the editor setting `text_editor/appearance/gutters/show_color_previews`.
- adds an SVG file, optimized with *svgcleaner*.
- declares two editor icons.
- updates documentation in `doc/classes`.
- adds two unit tests (code coverage is limited).

Implementation is essentially `private`. Therefore only setter / getter to draw gutter are bound with `ClassDB`.

Not compatible with `v3.x`. I'd be willing to create another PR to support `v3.x` if this one were accepted.

*Edit:*
- An archive of a Godot project ready to test this PR: [gd_color_preview_editors.zip](https://github.com/godotengine/godot/files/11252700/gd_color_preview_editors.zip)
- Screenshots with different picker's positions: [#01](https://user-images.githubusercontent.com/950147/232582945-9c55d5bf-95ff-4af7-a3d9-40f5cb44ee99.png), [#02](https://user-images.githubusercontent.com/950147/232582953-80b16bc9-6a1a-4889-9494-17374c01ae71.png), [#03](https://user-images.githubusercontent.com/950147/232582958-ed0ad174-e7a2-4f1b-8933-791d89a2e664.png)

_Production edit: Closes https://github.com/godotengine/godot-proposals/issues/6653_