### PR TITLE
remove to_byte_array method from PackedStringArray

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2424,7 +2424,6 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedStringArray, has, sarray("value"), varray());
 	bind_method(PackedStringArray, reverse, sarray(), varray());
 	bind_method(PackedStringArray, slice, sarray("begin", "end"), varray(INT_MAX));
-	bind_method(PackedStringArray, to_byte_array, sarray(), varray());
 	bind_method(PackedStringArray, sort, sarray(), varray());
 	bind_method(PackedStringArray, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedStringArray, duplicate, sarray(), varray());

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -181,12 +181,6 @@
 				Sorts the elements of the array in ascending order.
 			</description>
 		</method>
-		<method name="to_byte_array" qualifiers="const">
-			<return type="PackedByteArray" />
-			<description>
-				Returns a [PackedByteArray] with each string encoded as bytes.
-			</description>
-		</method>
 	</methods>
 	<operators>
 		<operator name="operator !=">


### PR DESCRIPTION
the `to_byte_array` method on PackedStringArray only introduces confusion and unexpected behaviors, while not having much of a real use (see #66526 for more details, this might need further discussion)