### PR TITLE
Remove double thes from class documentation

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -230,7 +230,7 @@
 	</methods>
 	<members>
 		<member name="assigned_animation" type="String" setter="set_assigned_animation" getter="get_assigned_animation">
-			If playing, the the current animation's key, otherwise, the animation last played. When set, this changes the animation, but will not play it unless already playing. See also [member current_animation].
+			If playing, the current animation's key, otherwise, the animation last played. When set, this changes the animation, but will not play it unless already playing. See also [member current_animation].
 		</member>
 		<member name="audio_max_polyphony" type="int" setter="set_audio_max_polyphony" getter="get_audio_max_polyphony" default="32">
 			The number of possible simultaneous sounds for each of the assigned AudioStreamPlayers.

--- a/doc/classes/Area3D.xml
+++ b/doc/classes/Area3D.xml
@@ -128,7 +128,7 @@
 			The magnitude of area-specific wind force.
 		</member>
 		<member name="wind_source_path" type="NodePath" setter="set_wind_source_path" getter="get_wind_source_path" default="NodePath(&quot;&quot;)">
-			The [Node3D] which is used to specify the the direction and origin of an area-specific wind force. The direction is opposite to the z-axis of the [Node3D]'s local transform, and its origin is the origin of the [Node3D]'s local transform.
+			The [Node3D] which is used to specify the direction and origin of an area-specific wind force. The direction is opposite to the z-axis of the [Node3D]'s local transform, and its origin is the origin of the [Node3D]'s local transform.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -138,7 +138,7 @@
 			<param index="1" name="cubic" type="bool" default="false" />
 			<param index="2" name="apply_tilt" type="bool" default="false" />
 			<description>
-				Similar with [code]interpolate_baked()[/code]. The the return value is [code]Transform3D[/code], with [code]origin[/code] as point position, [code]basis.x[/code] as sideway vector, [code]basis.y[/code] as up vector, [code]basis.z[/code] as forward vector. When the curve length is 0, there is no reasonable way to calculate the rotation, all vectors aligned with global space axes.
+				Similar with [code]interpolate_baked()[/code]. The return value is [code]Transform3D[/code], with [code]origin[/code] as point position, [code]basis.x[/code] as sideway vector, [code]basis.y[/code] as up vector, [code]basis.z[/code] as forward vector. When the curve length is 0, there is no reasonable way to calculate the rotation, all vectors aligned with global space axes.
 			</description>
 		</method>
 		<method name="samplef" qualifiers="const">

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -662,7 +662,7 @@
 			<return type="bool" />
 			<param index="0" name="method" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the the given [param method] name exists in the object.
+				Returns [code]true[/code] if the given [param method] name exists in the object.
 				[b]Note:[/b] In C#, [param method] must be in snake_case when referring to built-in Godot methods. Prefer using the names exposed in the [code]MethodName[/code] class to avoid allocating a new [StringName] on each call.
 			</description>
 		</method>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1004,7 +1004,7 @@
 			macOS specific override for the shortcut to add a caret below every caret.
 		</member>
 		<member name="input/ui_text_caret_document_end" type="Dictionary" setter="" getter="">
-			Default [InputEventAction] to move the text cursor the the end of the text.
+			Default [InputEventAction] to move the text cursor to the end of the text.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
 		<member name="input/ui_text_caret_document_end.macos" type="Dictionary" setter="" getter="">
@@ -2384,7 +2384,7 @@
 			[b]Note:[/b] Changing this setting does [i]not[/i] impact textures that were already imported before. To make this setting apply to textures that were already imported, exit the editor, remove the [code].godot/imported/[/code] folder located inside the project folder then restart the editor (see [member application/config/use_hidden_project_data_directory]).
 		</member>
 		<member name="rendering/textures/vram_compression/import_s3tc_bptc" type="bool" setter="" getter="">
-			If [code]true[/code], the texture importer will import VRAM-compressed textures using the S3 Texture Compression algorithm (DXT1-5) for lower quality textures and the the BPTC algorithm (BC6H and BC7) for high quality textures. This algorithm is only supported on PC desktop platforms and consoles.
+			If [code]true[/code], the texture importer will import VRAM-compressed textures using the S3 Texture Compression algorithm (DXT1-5) for lower quality textures and the BPTC algorithm (BC6H and BC7) for high quality textures. This algorithm is only supported on PC desktop platforms and consoles.
 			[b]Note:[/b] Changing this setting does [i]not[/i] impact textures that were already imported before. To make this setting apply to textures that were already imported, exit the editor, remove the [code].godot/imported/[/code] folder located inside the project folder then restart the editor (see [member application/config/use_hidden_project_data_directory]).
 		</member>
 		<member name="rendering/textures/webp_compression/compression_method" type="int" setter="" getter="" default="2">

--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -212,7 +212,7 @@
 			Sets the maximum width which all tabs should be limited to. Unlimited if set to [code]0[/code].
 		</member>
 		<member name="scroll_to_selected" type="bool" setter="set_scroll_to_selected" getter="get_scroll_to_selected" default="true">
-			If [code]true[/code], the tab offset will be changed to keep the the currently selected tab visible.
+			If [code]true[/code], the tab offset will be changed to keep the currently selected tab visible.
 		</member>
 		<member name="scrolling_enabled" type="bool" setter="set_scrolling_enabled" getter="get_scrolling_enabled" default="true">
 			if [code]true[/code], the mouse's scroll wheel can be used to navigate the scroll view.

--- a/doc/classes/TextureLayered.xml
+++ b/doc/classes/TextureLayered.xml
@@ -22,7 +22,7 @@
 		<method name="_get_height" qualifiers="virtual const">
 			<return type="int" />
 			<description>
-				Called when the the [TextureLayered]'s height is queried.
+				Called when the [TextureLayered]'s height is queried.
 			</description>
 		</method>
 		<method name="_get_layer_data" qualifiers="virtual const">

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -159,7 +159,7 @@
 			<return type="Vector2i" />
 			<param index="0" name="right" type="int" />
 			<description>
-				Gets the remainder of each component of the [Vector2i] with the the given [int]. This operation uses truncated division, which is often not desired as it does not work well with negative numbers. Consider using [method @GlobalScope.posmod] instead if you want to handle negative numbers.
+				Gets the remainder of each component of the [Vector2i] with the given [int]. This operation uses truncated division, which is often not desired as it does not work well with negative numbers. Consider using [method @GlobalScope.posmod] instead if you want to handle negative numbers.
 				[codeblock]
 				print(Vector2i(10, -20) % 7) # Prints "(3, -6)"
 				[/codeblock]

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -166,7 +166,7 @@
 			<return type="Vector3i" />
 			<param index="0" name="right" type="int" />
 			<description>
-				Gets the remainder of each component of the [Vector3i] with the the given [int]. This operation uses truncated division, which is often not desired as it does not work well with negative numbers. Consider using [method @GlobalScope.posmod] instead if you want to handle negative numbers.
+				Gets the remainder of each component of the [Vector3i] with the given [int]. This operation uses truncated division, which is often not desired as it does not work well with negative numbers. Consider using [method @GlobalScope.posmod] instead if you want to handle negative numbers.
 				[codeblock]
 				print(Vector3i(10, -20, 30) % 7) # Prints "(3, -6, 2)"
 				[/codeblock]

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -258,7 +258,7 @@
 			If [code]true[/code], the GUI controls on the viewport will lay pixel perfectly.
 		</member>
 		<member name="handle_input_locally" type="bool" setter="set_handle_input_locally" getter="is_handling_input_locally" default="true">
-			If [code]true[/code], this viewport will mark incoming input events as handled by itself. If [code]false[/code], this is instead done by the the first parent viewport that is set to handle input locally.
+			If [code]true[/code], this viewport will mark incoming input events as handled by itself. If [code]false[/code], this is instead done by the first parent viewport that is set to handle input locally.
 			A [SubViewportContainer] will automatically set this property to [code]false[/code] for the [Viewport] contained inside of it.
 			See also [method set_input_as_handled] and [method is_input_handled].
 		</member>


### PR DESCRIPTION
Remove duplicated definite article from the class documentation:
**the the -> the**
