### PR TITLE
GDScript: Fix warning ignoring for member variables

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1336,10 +1336,11 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 						push_error(vformat(R"(Getter with type "%s" cannot be used along with setter of type "%s".)", getter_function->datatype.to_string(), setter_function->parameters[0]->datatype.to_string()), member.variable);
 					}
 				}
-#ifdef DEBUG_ENABLED
-				parser->ignored_warnings = previously_ignored_warnings;
-#endif // DEBUG_ENABLED
 			}
+
+#ifdef DEBUG_ENABLED
+			parser->ignored_warnings = previously_ignored_warnings;
+#endif // DEBUG_ENABLED
 		}
 	}
 

--- a/modules/gdscript/tests/scripts/analyzer/warnings/unused_private_class_variable.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/unused_private_class_variable.gd
@@ -1,0 +1,10 @@
+# GH-72135
+
+var _a
+@warning_ignore("unused_private_class_variable")
+var _b
+@warning_ignore("unused_private_class_variable") var _c
+var _d
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/warnings/unused_private_class_variable.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/unused_private_class_variable.out
@@ -1,0 +1,9 @@
+GDTEST_OK
+>> WARNING
+>> Line: 3
+>> UNUSED_PRIVATE_CLASS_VARIABLE
+>> The class variable "_a" is declared but never used in the script.
+>> WARNING
+>> Line: 7
+>> UNUSED_PRIVATE_CLASS_VARIABLE
+>> The class variable "_d" is declared but never used in the script.


### PR DESCRIPTION
Closes #72135.
