### PR TITLE
Add Close Docs item in script editor context menu

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3122,6 +3122,7 @@ void ScriptEditor::_make_script_list_context_menu() {
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_file"), FILE_CLOSE);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_all"), CLOSE_ALL);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_other_tabs"), CLOSE_OTHER_TABS);
+	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_docs"), CLOSE_DOCS);
 	context_menu->add_separator();
 	if (se) {
 		Ref<Script> scr = se->get_edited_resource();
@@ -3144,6 +3145,7 @@ void ScriptEditor::_make_script_list_context_menu() {
 
 	context_menu->set_item_disabled(context_menu->get_item_index(CLOSE_ALL), tab_container->get_tab_count() <= 0);
 	context_menu->set_item_disabled(context_menu->get_item_index(CLOSE_OTHER_TABS), tab_container->get_tab_count() <= 1);
+	context_menu->set_item_disabled(context_menu->get_item_index(CLOSE_DOCS), !_has_docs_tab());
 	context_menu->set_item_disabled(context_menu->get_item_index(WINDOW_MOVE_UP), tab_container->get_current_tab() <= 0);
 	context_menu->set_item_disabled(context_menu->get_item_index(WINDOW_MOVE_DOWN), tab_container->get_current_tab() >= tab_container->get_tab_count() - 1);
 	context_menu->set_item_disabled(context_menu->get_item_index(WINDOW_SORT), tab_container->get_tab_count() <= 1);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/76083

Added the "Close Docs" item in the script editor context menu. 

Screenshot when there is document open:

![Screenshot_20230418_161726](https://user-images.githubusercontent.com/52410428/232814019-4cadc962-096d-453a-8d74-3c9ba568b8f9.png)

Screenshot when there is no document open:

![Screenshot_20230418_161553](https://user-images.githubusercontent.com/52410428/232814050-496256aa-cdfc-4886-9130-75c0a7f4263f.png)

The issue is reported on 3.6 branch, as per guidelines targeting this request for master branch. 

- *Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/311.*