### PR TITLE
Add script formatter, comment parsing in parser, and editor settings

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -331,6 +331,7 @@ public:
 
 	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) { return ERR_UNAVAILABLE; }
 
+	virtual String format_code(const String &p_code) { return p_code; }
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const = 0;
 	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value) = 0;
 	virtual void add_named_global_constant(const StringName &p_name, const Variant &p_value) {}

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -757,7 +757,7 @@
 			The shape of the caret to use in the script editor. [b]Line[/b] displays a vertical line to the left of the current character, whereas [b]Block[/b] displays an outline over the current character.
 		</member>
 		<member name="text_editor/appearance/guidelines/line_length_guideline_hard_column" type="int" setter="" getter="">
-			The column at which to display a subtle line as a line length guideline for scripts. This should generally be greater than [member text_editor/appearance/guidelines/line_length_guideline_soft_column].
+			The column at which to display a subtle line as a line length guideline for scripts. This should generally be greater than [member text_editor/appearance/guidelines/line_length_guideline_soft_column]. This also sets the target line length that the code formatter tries to target.
 		</member>
 		<member name="text_editor/appearance/guidelines/line_length_guideline_soft_column" type="int" setter="" getter="">
 			The column at which to display a [i]very[/i] subtle line as a line length guideline for scripts. This should generally be lower than [member text_editor/appearance/guidelines/line_length_guideline_hard_column].
@@ -815,6 +815,15 @@
 		</member>
 		<member name="text_editor/behavior/files/trim_trailing_whitespace_on_save" type="bool" setter="" getter="">
 			If [code]true[/code], trims trailing whitespace when saving a script. Trailing whitespace refers to tab and space characters placed at the end of lines. Since these serve no practical purpose, they can and should be removed to make version control diffs less noisy.
+		</member>
+		<member name="text_editor/behavior/formatter/format_on_save" type="bool" setter="" getter="">
+			If [code]true[/code], uses the code formatter before saving a script.
+		</member>
+		<member name="text_editor/behavior/formatter/indent_in_multiline_block" type="int" setter="" getter="">
+			The number of indents for the formatter to include when wrapping single line statements into multi-line blocks.
+		</member>
+		<member name="text_editor/behavior/formatter/lines_between_functions" type="int" setter="" getter="">
+			The number of extra lines between functions the formatter inserts.
 		</member>
 		<member name="text_editor/behavior/indent/auto_indent" type="bool" setter="" getter="">
 			If [code]true[/code], automatically indents code when pressing the [kbd]Enter[/kbd] key based on blocks above the new line.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -589,6 +589,11 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/behavior/indent/size", 4, "1,64,1") // size of 0 crashes.
 	_initial_set("text_editor/behavior/indent/auto_indent", true);
 
+	// Behavior: Formatter
+	_initial_set("text_editor/behavior/formatter/indent_in_multiline_block", 2);
+	_initial_set("text_editor/behavior/formatter/lines_between_functions", 2);
+	_initial_set("text_editor/behavior/formatter/format_on_save", false);
+
 	// Behavior: Files
 	_initial_set("text_editor/behavior/files/trim_trailing_whitespace_on_save", false);
 	_initial_set("text_editor/behavior/files/autosave_interval_secs", 0);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -944,14 +944,18 @@ void ScriptEditor::_resave_scripts(const String &p_str) {
 			continue; //internal script, who cares
 		}
 
-		if (trim_trailing_whitespace_on_save) {
-			se->trim_trailing_whitespace();
-		}
+		if (!format_on_save) {
+			if (trim_trailing_whitespace_on_save) {
+				se->trim_trailing_whitespace();
+			}
 
-		se->insert_final_newline();
+			se->insert_final_newline();
 
-		if (convert_indent_on_save) {
-			se->convert_indent();
+			if (convert_indent_on_save) {
+				se->convert_indent();
+			}
+		} else {
+			se->format_code();
 		}
 
 		Ref<TextFile> text_file = scr;
@@ -1295,14 +1299,17 @@ void ScriptEditor::_menu_option(int p_option) {
 				save_current_script();
 			} break;
 			case FILE_SAVE_AS: {
-				if (trim_trailing_whitespace_on_save) {
-					current->trim_trailing_whitespace();
-				}
+				if (!format_on_save) {
+					if (trim_trailing_whitespace_on_save) {
+						current->trim_trailing_whitespace();
+					}
+					current->insert_final_newline();
 
-				current->insert_final_newline();
-
-				if (convert_indent_on_save) {
-					current->convert_indent();
+					if (convert_indent_on_save) {
+						current->convert_indent();
+					}
+				} else {
+					current->format_code();
 				}
 
 				Ref<Resource> resource = current->get_edited_resource();
@@ -2478,14 +2485,18 @@ void ScriptEditor::save_current_script() {
 		return;
 	}
 
-	if (trim_trailing_whitespace_on_save) {
-		current->trim_trailing_whitespace();
-	}
+	if (!format_on_save) {
+		if (trim_trailing_whitespace_on_save) {
+			current->trim_trailing_whitespace();
+		}
 
-	current->insert_final_newline();
+		current->insert_final_newline();
 
-	if (convert_indent_on_save) {
-		current->convert_indent();
+		if (convert_indent_on_save) {
+			current->convert_indent();
+		}
+	} else {
+		current->format_code();
 	}
 
 	Ref<Resource> resource = current->get_edited_resource();
@@ -2528,15 +2539,19 @@ void ScriptEditor::save_all_scripts() {
 			continue;
 		}
 
-		if (convert_indent_on_save) {
-			se->convert_indent();
-		}
+		if (!format_on_save) {
+			if (convert_indent_on_save) {
+				se->convert_indent();
+			}
 
-		if (trim_trailing_whitespace_on_save) {
-			se->trim_trailing_whitespace();
-		}
+			if (trim_trailing_whitespace_on_save) {
+				se->trim_trailing_whitespace();
+			}
 
-		se->insert_final_newline();
+			se->insert_final_newline();
+		} else {
+			se->format_code();
+		}
 
 		if (!se->is_unsaved()) {
 			continue;
@@ -2756,6 +2771,8 @@ void ScriptEditor::_editor_settings_changed() {
 
 	trim_trailing_whitespace_on_save = EDITOR_GET("text_editor/behavior/files/trim_trailing_whitespace_on_save");
 	convert_indent_on_save = EDITOR_GET("text_editor/behavior/files/convert_indent_on_save");
+	use_space_indentation = EDITOR_GET("text_editor/behavior/indent/type");
+	format_on_save = EDITOR_GET("text_editor/behavior/formatter/format_on_save");
 
 	members_overview_enabled = EDITOR_GET("text_editor/script_list/show_members_overview");
 	help_overview_enabled = EDITOR_GET("text_editor/help/show_help_index");
@@ -4141,6 +4158,8 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	edit_pass = 0;
 	trim_trailing_whitespace_on_save = EDITOR_GET("text_editor/behavior/files/trim_trailing_whitespace_on_save");
 	convert_indent_on_save = EDITOR_GET("text_editor/behavior/files/convert_indent_on_save");
+	use_space_indentation = EDITOR_GET("text_editor/behavior/indent/type");
+	format_on_save = EDITOR_GET("text_editor/behavior/formatter/format_on_save");
 
 	ScriptServer::edit_request_func = _open_script_request;
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1003,20 +1003,20 @@ void ScriptEditor::_scene_saved_callback(const String &p_path) {
 	}
 }
 
-void ScriptEditor::_format_code(ScriptEditorBase *se) {
+void ScriptEditor::_format_code(ScriptEditorBase *p_script_editor) {
 	if (!format_on_save) {
 		if (trim_trailing_whitespace_on_save) {
-			se->trim_trailing_whitespace();
+			p_script_editor->trim_trailing_whitespace();
 		}
 
-		se->insert_final_newline();
+		p_script_editor->insert_final_newline();
 
 		if (convert_indent_on_save) {
-			se->convert_indent();
+			p_script_editor->convert_indent();
 		}
 
 	} else {
-		se->format_code();
+		p_script_editor->format_code();
 	}
 }
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -944,19 +944,7 @@ void ScriptEditor::_resave_scripts(const String &p_str) {
 			continue; //internal script, who cares
 		}
 
-		if (!format_on_save) {
-			if (trim_trailing_whitespace_on_save) {
-				se->trim_trailing_whitespace();
-			}
-
-			se->insert_final_newline();
-
-			if (convert_indent_on_save) {
-				se->convert_indent();
-			}
-		} else {
-			se->format_code();
-		}
+		ScriptEditor::_format_code(se);
 
 		Ref<TextFile> text_file = scr;
 		if (text_file != nullptr) {
@@ -1012,6 +1000,23 @@ void ScriptEditor::_scene_saved_callback(const String &p_path) {
 		if (scr.is_valid() && scr->is_tool()) {
 			scr->reload(true);
 		}
+	}
+}
+
+void ScriptEditor::_format_code(ScriptEditorBase *se) {
+	if (!format_on_save) {
+		if (trim_trailing_whitespace_on_save) {
+			se->trim_trailing_whitespace();
+		}
+
+		se->insert_final_newline();
+
+		if (convert_indent_on_save) {
+			se->convert_indent();
+		}
+
+	} else {
+		se->format_code();
 	}
 }
 
@@ -1299,18 +1304,7 @@ void ScriptEditor::_menu_option(int p_option) {
 				save_current_script();
 			} break;
 			case FILE_SAVE_AS: {
-				if (!format_on_save) {
-					if (trim_trailing_whitespace_on_save) {
-						current->trim_trailing_whitespace();
-					}
-					current->insert_final_newline();
-
-					if (convert_indent_on_save) {
-						current->convert_indent();
-					}
-				} else {
-					current->format_code();
-				}
+				ScriptEditor::_format_code(current);
 
 				Ref<Resource> resource = current->get_edited_resource();
 				Ref<TextFile> text_file = resource;
@@ -2485,19 +2479,7 @@ void ScriptEditor::save_current_script() {
 		return;
 	}
 
-	if (!format_on_save) {
-		if (trim_trailing_whitespace_on_save) {
-			current->trim_trailing_whitespace();
-		}
-
-		current->insert_final_newline();
-
-		if (convert_indent_on_save) {
-			current->convert_indent();
-		}
-	} else {
-		current->format_code();
-	}
+	ScriptEditor::_format_code(current);
 
 	Ref<Resource> resource = current->get_edited_resource();
 	Ref<TextFile> text_file = resource;
@@ -2539,19 +2521,7 @@ void ScriptEditor::save_all_scripts() {
 			continue;
 		}
 
-		if (!format_on_save) {
-			if (convert_indent_on_save) {
-				se->convert_indent();
-			}
-
-			if (trim_trailing_whitespace_on_save) {
-				se->trim_trailing_whitespace();
-			}
-
-			se->insert_final_newline();
-		} else {
-			se->format_code();
-		}
+		ScriptEditor::_format_code(se);
 
 		if (!se->is_unsaved()) {
 			continue;

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -399,6 +399,7 @@ class ScriptEditor : public PanelContainer {
 	bool format_on_save;
 	bool use_space_indentation;
 	bool convert_indent_on_save;
+	void _format_code(ScriptEditorBase *se);
 
 	void _goto_script_line2(int p_line);
 	void _goto_script_line(Ref<RefCounted> p_script, int p_line);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -170,6 +170,7 @@ public:
 	virtual void set_executing_line(int p_line) = 0;
 	virtual void clear_executing_line() = 0;
 	virtual void trim_trailing_whitespace() = 0;
+	virtual void format_code() = 0;
 	virtual void insert_final_newline() = 0;
 	virtual void convert_indent() = 0;
 	virtual void ensure_focus() = 0;
@@ -395,6 +396,8 @@ class ScriptEditor : public PanelContainer {
 
 	bool open_textfile_after_create = true;
 	bool trim_trailing_whitespace_on_save;
+	bool format_on_save;
+	bool use_space_indentation;
 	bool convert_indent_on_save;
 
 	void _goto_script_line2(int p_line);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -399,7 +399,7 @@ class ScriptEditor : public PanelContainer {
 	bool format_on_save;
 	bool use_space_indentation;
 	bool convert_indent_on_save;
-	void _format_code(ScriptEditorBase *se);
+	void _format_code(ScriptEditorBase *p_script_editor);
 
 	void _goto_script_line2(int p_line);
 	void _goto_script_line(Ref<RefCounted> p_script, int p_line);

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -116,6 +116,7 @@ class ScriptTextEditor : public ScriptEditorBase {
 		EDIT_SELECT_ALL,
 		EDIT_COMPLETE,
 		EDIT_AUTO_INDENT,
+		EDIT_FORMAT_CODE,
 		EDIT_TRIM_TRAILING_WHITESAPCE,
 		EDIT_CONVERT_INDENT_TO_SPACES,
 		EDIT_CONVERT_INDENT_TO_TABS,
@@ -224,6 +225,7 @@ public:
 	virtual Variant get_navigation_state() override;
 	virtual void ensure_focus() override;
 	virtual void trim_trailing_whitespace() override;
+	virtual void format_code() override;
 	virtual void insert_final_newline() override;
 	virtual void convert_indent() override;
 	virtual void tag_saved_version() override;

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -284,6 +284,9 @@ void TextEditor::trim_trailing_whitespace() {
 	code_editor->trim_trailing_whitespace();
 }
 
+void TextEditor::format_code() {
+}
+
 void TextEditor::insert_final_newline() {
 	code_editor->insert_final_newline();
 }

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -132,6 +132,7 @@ public:
 	virtual void set_executing_line(int p_line) override;
 	virtual void clear_executing_line() override;
 	virtual void trim_trailing_whitespace() override;
+	virtual void format_code() override;
 	virtual void insert_final_newline() override;
 	virtual void convert_indent() override;
 	virtual void ensure_focus() override;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -512,6 +512,7 @@ public:
 	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) override;
 #endif
 	virtual String _get_indentation() const;
+	virtual String format_code(const String &p_code) override;
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const override;
 	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value) override;
 	virtual void add_named_global_constant(const StringName &p_name, const Variant &p_value) override;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -32,6 +32,7 @@
 
 #include "gdscript_analyzer.h"
 #include "gdscript_compiler.h"
+#include "gdscript_format.h"
 #include "gdscript_parser.h"
 #include "gdscript_tokenizer.h"
 #include "gdscript_utility_functions.h"
@@ -3163,6 +3164,12 @@ String GDScriptLanguage::_get_indentation() const {
 	}
 #endif
 	return "\t";
+}
+
+String GDScriptLanguage::format_code(const String &p_code) {
+	GDScriptFormat formatter;
+	String output = formatter.format(p_code);
+	return output;
 }
 
 void GDScriptLanguage::auto_indent_code(String &p_code, int p_from_line, int p_to_line) const {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3168,8 +3168,12 @@ String GDScriptLanguage::_get_indentation() const {
 
 String GDScriptLanguage::format_code(const String &p_code) {
 	GDScriptFormat formatter;
-	String output = formatter.format(p_code);
-	return output;
+	String formatted_code;
+	Error err = formatter.format(p_code, formatted_code);
+	if (err != OK) {
+		return p_code;
+	}
+	return formatted_code;
 }
 
 void GDScriptLanguage::auto_indent_code(String &p_code, int p_from_line, int p_to_line) const {

--- a/modules/gdscript/gdscript_format.cpp
+++ b/modules/gdscript/gdscript_format.cpp
@@ -97,8 +97,8 @@ String GDScriptFormat::format(const String &p_code) {
 void GDScriptFormat::find_custom_newlines(const String &p_code) {
 	new_lines.clear();
 	const Vector<String> split_code = p_code.replace("\t", "").replace(" ", "").split("\n");
-	for (int i = 0; i < split_code.size(); ++i) {
-		if (i < split_code.size() - 1 && split_code[i].is_empty()) {
+	for (int i = 0; i < split_code.size() - 1; ++i) {
+		if (split_code[i].is_empty()) {
 			new_lines.insert(i);
 		}
 	}
@@ -1040,7 +1040,11 @@ String GDScriptFormat::parse_function_signature(const GDP::FunctionNode *p_node,
 }
 
 String GDScriptFormat::parse_lambda(const GDP::LambdaNode *p_node, const int p_indent_level) {
-	return parse_function(p_node->function, p_indent_level);
+	String lambda = parse_function(p_node->function, p_indent_level);
+	if (lambda.ends_with("\n")) {
+		lambda = lambda.substr(0, lambda.length() - 1);
+	}
+	return lambda;
 }
 
 String GDScriptFormat::parse_function(const GDP::FunctionNode *p_node, const int p_indent_level) {

--- a/modules/gdscript/gdscript_format.cpp
+++ b/modules/gdscript/gdscript_format.cpp
@@ -2087,36 +2087,38 @@ String GDScriptFormat::parse_preload(const GDP::PreloadNode *p_node, const int p
 String GDScriptFormat::parse_call_arguments(const Vector<GDP::ExpressionNode *> &p_nodes, const int p_indent_level, const BreakType p_break_type) {
 	StringBuilder output;
 	for (int i = 0; i < p_nodes.size(); ++i) {
+		GDP::ExpressionNode *node = p_nodes[i];
+
 		if (p_break_type != NONE) {
-			if (p_nodes[i]->type != GDP::Node::ARRAY && p_nodes[i]->type != GDP::Node::DICTIONARY) {
+			if (node->type != GDP::Node::ARRAY && node->type != GDP::Node::DICTIONARY) {
 				output += indent(p_indent_level);
 			}
 		}
 
 		int indent_mod = 0;
-		if (p_nodes[i]->type == GDP::Node::ARRAY || p_nodes[i]->type == GDP::Node::DICTIONARY) {
+		if (node->type == GDP::Node::ARRAY || node->type == GDP::Node::DICTIONARY) {
 			indent_mod = 1;
 		}
 
 		String parameter_string;
-		if (children_have_comments(p_nodes[i])) {
-			parameter_string = parse_expression(p_nodes[i], p_indent_level - indent_mod, p_break_type);
+		if (children_have_comments(node)) {
+			parameter_string = parse_expression(node, p_indent_level - indent_mod, p_break_type);
 		} else {
-			parameter_string = parse_expression(p_nodes[i], p_indent_level);
+			parameter_string = parse_expression(node, p_indent_level);
 			if (p_break_type != NONE && parameter_string.length() > line_length_maximum) {
-				parameter_string = parse_expression(p_nodes[i], p_indent_level - indent_mod, p_break_type);
+				parameter_string = parse_expression(node, p_indent_level - indent_mod, p_break_type);
 			}
 		}
-		output += print_comment(p_nodes[i], true, p_indent_level);
+		output += print_comment(node, true, p_indent_level);
 		output += parameter_string;
 
-		if (i < p_nodes.size() - 1) {
+		if (i < p_nodes.size() - 1 || p_break_type != NONE) {
 			output += ",";
 			if (p_break_type == NONE) {
 				output += " ";
 			}
 		}
-		output += print_comment(p_nodes[i], false);
+		output += print_comment(node, false);
 	}
 
 	return output;

--- a/modules/gdscript/gdscript_format.cpp
+++ b/modules/gdscript/gdscript_format.cpp
@@ -1799,27 +1799,24 @@ String GDScriptFormat::parse_literal(const GDP::LiteralNode *p_node) {
 			default:
 				break;
 		}
-	} else if (p_node->value.get_type() == Variant::Type::STRING || p_node->value.get_type() == Variant::Type::NODE_PATH || p_node->value.get_type() == Variant::Type::STRING_NAME) {
-		const String string_contents = p_node->value;
-		if (p_node->value.get_type() == Variant::Type::NODE_PATH) {
-			value_string += "^";
-		} else if (p_node->value.get_type() == Variant::Type::STRING_NAME) {
-			value_string += "&";
+	}
+
+	switch (p_node->value.get_type()) {
+		case Variant::Type::STRING:
+		case Variant::Type::NODE_PATH:
+		case Variant::Type::STRING_NAME:
+		case Variant::Type::INT:
+		case Variant::Type::FLOAT: {
+			value_string += p_node->source;
+		} break;
+
+		case Variant::Type::NIL: {
+			value_string += "null";
+		} break;
+
+		default: {
+			value_string += String(p_node->value);
 		}
-		if (string_contents.contains("\"")) {
-			value_string += '\'' + string_contents + '\'';
-		} else {
-			value_string += '\"' + string_contents + '\"';
-		}
-	} else if (p_node->value.get_type() == Variant::Type::FLOAT) {
-		value_string += String(p_node->value);
-		if (!value_string.as_string().contains(".")) {
-			value_string += ".0";
-		}
-	} else if (p_node->value.get_type() == Variant::Type::NIL) {
-		value_string += "null";
-	} else {
-		value_string += String(p_node->value);
 	}
 
 	return value_string;

--- a/modules/gdscript/gdscript_format.cpp
+++ b/modules/gdscript/gdscript_format.cpp
@@ -947,7 +947,7 @@ String GDScriptFormat::parse_parameter(const GDP::ParameterNode *p_node, const i
 	}
 
 	if (p_node->initializer != nullptr) {
-		if (p_node->datatype_specifier != nullptr) {
+		if (p_node->datatype_specifier != nullptr || !p_node->infer_datatype) {
 			param_string += " ";
 		}
 		param_string += "= " + parse_expression(p_node->initializer, p_indent_level, p_break_type);
@@ -1554,7 +1554,7 @@ String GDScriptFormat::parse_get_node(const GDP::GetNodeNode *p_node, const int 
 	String append;
 	String full_path = p_node->full_path;
 	bool wrap = false;
-	
+
 	if (full_path.get(0) == '%') {
 		output += "%";
 		full_path = full_path.substr(1);

--- a/modules/gdscript/gdscript_format.cpp
+++ b/modules/gdscript/gdscript_format.cpp
@@ -52,12 +52,16 @@ GDScriptFormat::GDScriptFormat() :
 #endif // TOOLS_ENABLED
 }
 
-String GDScriptFormat::format(const String &p_code) {
+Error GDScriptFormat::format(const String &p_code, String &r_formatted_code) {
 	GDScriptParser parser;
-	parser.parse(p_code, "", false);
+	Error err = parser.parse(p_code, "", false);
 
-	if (!parser.get_errors().is_empty()) {
-		return p_code;
+	if (err != OK) {
+		parser_errors.clear();
+		for (GDScriptParser::ParserError err : parser.get_errors()) {
+			parser_errors.push_back({ vformat("%s", err.message), err.line, err.column });
+		}
+		return FAILED;
 	}
 
 	find_custom_newlines(p_code);
@@ -91,7 +95,10 @@ String GDScriptFormat::format(const String &p_code) {
 
 	output = make_disabled_lines_from_headers(output);
 
-	return output;
+	r_formatted_code.clear();
+	r_formatted_code += output;
+
+	return OK;
 }
 
 void GDScriptFormat::find_custom_newlines(const String &p_code) {

--- a/modules/gdscript/gdscript_format.cpp
+++ b/modules/gdscript/gdscript_format.cpp
@@ -1,0 +1,2190 @@
+/**************************************************************************/
+/*  gdscript_format.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdscript_format.h"
+#ifdef TOOLS_ENABLED
+#include "editor/editor_settings.h"
+#endif
+#include "core/string/string_builder.h"
+#include "gdscript_parser.h"
+
+GDScriptFormat::GDScriptFormat() :
+		line_length_maximum(100),
+		tab_size(4),
+		tab_type(0),
+		lines_between_functions(2),
+		indent_in_multiline_block(2) {
+#ifdef TOOLS_ENABLED
+	if (EditorSettings::get_singleton()) {
+		line_length_maximum = EditorSettings::get_singleton()->get_setting("text_editor/appearance/guidelines/line_length_guideline_hard_column");
+		lines_between_functions = EditorSettings::get_singleton()->get_setting("text_editor/behavior/formatter/lines_between_functions");
+		indent_in_multiline_block = EditorSettings::get_singleton()->get_setting("text_editor/behavior/formatter/indent_in_multiline_block");
+		tab_size = EditorSettings::get_singleton()->get_setting("text_editor/behavior/indent/size");
+		tab_type = EditorSettings::get_singleton()->get_setting("text_editor/behavior/indent/type");
+	}
+#endif // TOOLS_ENABLED
+}
+
+String GDScriptFormat::format(const String &p_code) {
+	GDScriptParser parser;
+	parser.parse(p_code, "", false);
+
+	if (!parser.get_errors().is_empty()) {
+		return p_code;
+	}
+
+	find_custom_newlines(p_code);
+
+	GDP::ClassNode *root = parser.get_tree();
+
+	StringBuilder code_block;
+	if (parser.is_tool()) {
+		if (!root->tool_header_comment.is_empty()) {
+			for (const String &i : root->tool_header_comment) {
+				code_block += "# ";
+				code_block += i;
+				code_block += "\n";
+			}
+		}
+		code_block += "@tool";
+		if (!root->tool_inline_comment.is_empty()) {
+			code_block += " # ";
+			code_block += root->tool_inline_comment;
+		}
+		code_block += "\n";
+	}
+
+	code_block += parse_class(root, 0);
+
+	String output = code_block.as_string();
+
+	while (output.ends_with("\n\n")) {
+		output = output.substr(0, output.length() - 1);
+	}
+
+	output = make_disabled_lines_from_headers(output);
+
+	return output;
+}
+
+void GDScriptFormat::find_custom_newlines(const String &p_code) {
+	new_lines.clear();
+	const Vector<String> split_code = p_code.replace("\t", "").replace(" ", "").split("\n");
+	for (int i = 0; i < split_code.size(); ++i) {
+		if (i < split_code.size() - 1 && split_code[i].is_empty()) {
+			new_lines.insert(i);
+		}
+	}
+}
+
+bool GDScriptFormat::node_has_comments(const GDP::Node *p_node) {
+	return p_node != nullptr && (!p_node->header_comment.is_empty() || !p_node->inline_comment.is_empty());
+}
+
+bool GDScriptFormat::children_have_comments(const GDP::Node *p_parent) {
+	if (p_parent == nullptr) {
+		return false;
+	}
+	switch (p_parent->type) {
+		case GDP::Node::Type::CLASS: {
+			const GDP::ClassNode *m_class = dynamic_cast<const GDP::ClassNode *>(p_parent);
+			for (const GDScriptParser::ClassNode::Member &member : m_class->members) {
+				bool children = false;
+				switch (member.type) {
+					case GDP::ClassNode::Member::Type::ENUM:
+						children = node_has_comments(member.m_enum) || children_have_comments(member.m_enum);
+						break;
+					case GDP::ClassNode::Member::Type::CONSTANT:
+						children = node_has_comments(member.constant) || children_have_comments(member.constant);
+						break;
+					case GDP::ClassNode::Member::Type::SIGNAL:
+						children = node_has_comments(member.signal) || children_have_comments(member.signal);
+						break;
+					case GDP::ClassNode::Member::Type::FUNCTION:
+						children = node_has_comments(member.function) || children_have_comments(member.function);
+						break;
+					case GDP::ClassNode::Member::Type::ENUM_VALUE:
+						children = node_has_comments(member.enum_value.parent_enum) || children_have_comments(member.enum_value.parent_enum);
+						break;
+					case GDP::ClassNode::Member::Type::VARIABLE:
+						children = node_has_comments(member.variable) || children_have_comments(member.variable);
+						break;
+					case GDP::ClassNode::Member::Type::UNDEFINED:
+						children = false;
+						break;
+					case GDP::ClassNode::Member::Type::CLASS:
+					case GDScriptParser::ClassNode::Member::GROUP:
+						break;
+				}
+				if (children) {
+					return true;
+				}
+			}
+			return false;
+		}
+		case GDP::Node::Type::ENUM: {
+			const GDP::EnumNode *m_enum = dynamic_cast<const GDP::EnumNode *>(p_parent);
+			for (const GDScriptParser::EnumNode::Value &value : m_enum->values) {
+				if (!value.identifier->inline_comment.is_empty() || !value.identifier->header_comment.is_empty()) {
+					return true;
+				}
+			}
+			return false;
+		}
+		case GDP::Node::Type::CONSTANT: {
+			const GDP::ConstantNode *constant = dynamic_cast<const GDP::ConstantNode *>(p_parent);
+			return node_has_comments(constant->initializer) || children_have_comments(constant->initializer);
+		}
+
+		case GDP::Node::Type::VARIABLE: {
+			const GDP::VariableNode *variable = dynamic_cast<const GDP::VariableNode *>(p_parent);
+			return node_has_comments(variable->initializer) || children_have_comments(variable->initializer);
+		}
+		case GDP::Node::Type::ARRAY: {
+			const GDP::ArrayNode *m_array = dynamic_cast<const GDP::ArrayNode *>(p_parent);
+			for (const GDScriptParser::ExpressionNode *element : m_array->elements) {
+				if (node_has_comments(element) || children_have_comments(element)) {
+					return true;
+				}
+			}
+			return false;
+		}
+		case GDP::Node::Type::ASSERT: {
+			const GDP::AssertNode *assert = dynamic_cast<const GDP::AssertNode *>(p_parent);
+			return node_has_comments(assert->condition) || children_have_comments(assert->condition);
+		}
+		case GDP::Node::Type::ASSIGNMENT: {
+			const GDP::AssignmentNode *assignment = dynamic_cast<const GDP::AssignmentNode *>(p_parent);
+			return node_has_comments(assignment->assigned_value) || children_have_comments(assignment->assigned_value);
+		}
+		case GDP::Node::Type::BINARY_OPERATOR: {
+			const GDP::BinaryOpNode *binary_op_node = dynamic_cast<const GDP::BinaryOpNode *>(p_parent);
+			return node_has_comments(binary_op_node->left_operand) || node_has_comments(binary_op_node->right_operand) || children_have_comments(binary_op_node->left_operand) || children_have_comments(binary_op_node->right_operand);
+		}
+		case GDP::Node::Type::CALL: {
+			const GDP::CallNode *call_node = dynamic_cast<const GDP::CallNode *>(p_parent);
+			for (const GDScriptParser::ExpressionNode *argument : call_node->arguments) {
+				if (node_has_comments(argument) || children_have_comments(argument)) {
+					return true;
+				}
+			}
+			return false;
+		}
+		case GDP::Node::Type::DICTIONARY: {
+			const GDP::DictionaryNode *dictionary_node = dynamic_cast<const GDP::DictionaryNode *>(p_parent);
+			for (const GDScriptParser::DictionaryNode::Pair element : dictionary_node->elements) {
+				if (node_has_comments(element.key) || node_has_comments(element.value) || children_have_comments(element.key) || children_have_comments(element.value)) {
+					return true;
+				}
+			}
+			return false;
+		}
+		case GDP::Node::Type::FOR: {
+			const GDP::ForNode *for_node = dynamic_cast<const GDP::ForNode *>(p_parent);
+			return node_has_comments(for_node->list) || children_have_comments(for_node->list);
+		}
+		case GDP::Node::Type::FUNCTION: {
+			const GDP::FunctionNode *function_node = dynamic_cast<const GDP::FunctionNode *>(p_parent);
+			for (const GDScriptParser::ParameterNode *parameter : function_node->parameters) {
+				if (node_has_comments(parameter) || children_have_comments(parameter)) {
+					return true;
+				}
+			}
+			return false;
+		}
+		case GDP::Node::Type::IF: {
+			const GDP::IfNode *if_node = dynamic_cast<const GDP::IfNode *>(p_parent);
+			return node_has_comments(if_node->condition) || children_have_comments(if_node->condition);
+		}
+		case GDP::Node::Type::LAMBDA: {
+			const GDP::LambdaNode *lambda_node = dynamic_cast<const GDP::LambdaNode *>(p_parent);
+			return children_have_comments(lambda_node->function);
+		}
+		case GDP::Node::Type::MATCH: {
+			const GDP::MatchNode *match_node = dynamic_cast<const GDP::MatchNode *>(p_parent);
+			return node_has_comments(match_node->test) || children_have_comments(match_node->test);
+		}
+		case GDP::Node::Type::MATCH_BRANCH: {
+			const GDP::MatchBranchNode *match_branch_node = dynamic_cast<const GDP::MatchBranchNode *>(p_parent);
+			for (const GDScriptParser::PatternNode *pattern : match_branch_node->patterns) {
+				if (node_has_comments(pattern) || children_have_comments(pattern)) {
+					return true;
+				}
+			}
+			return false;
+		}
+		case GDP::Node::Type::SUBSCRIPT: {
+			const GDP::SubscriptNode *subscript_node = dynamic_cast<const GDP::SubscriptNode *>(p_parent);
+			return node_has_comments(subscript_node->index) || children_have_comments(subscript_node->index);
+		}
+		case GDP::Node::Type::TERNARY_OPERATOR: {
+			const GDP::TernaryOpNode *ternary_op_node = dynamic_cast<const GDP::TernaryOpNode *>(p_parent);
+			return node_has_comments(ternary_op_node->condition) || node_has_comments(ternary_op_node->false_expr) || children_have_comments(ternary_op_node->condition) || children_have_comments(ternary_op_node->false_expr);
+		}
+		case GDP::Node::Type::SIGNAL: {
+			const GDP::SignalNode *signal_node = dynamic_cast<const GDP::SignalNode *>(p_parent);
+			for (const GDScriptParser::ParameterNode *parameter : signal_node->parameters) {
+				if (node_has_comments(parameter) || children_have_comments(parameter)) {
+					return true;
+				}
+			}
+			return false;
+		}
+		default:
+			break;
+	}
+
+	return false;
+}
+
+String GDScriptFormat::make_disabled_lines_from_headers(const String &p_input) const {
+	Vector<String> split_lines = p_input.split("\n");
+	for (int i = 0; i < split_lines.size(); ++i) {
+		String dedented = split_lines[i].dedent();
+		if (dedented.begins_with("# DIS#")) {
+			String line = dedented.substr(6);
+			if (line.begins_with(tab_type == 0 ? "\t" : String(" ").repeat(tab_size))) {
+				split_lines.write[i] = "#" + line;
+			}
+		}
+	}
+
+	return String("\n").join(split_lines);
+}
+
+String GDScriptFormat::print_comment(const GDP::Node *p_node, const bool p_headers, const int p_indent_level) {
+	StringBuilder output;
+	if (p_headers) {
+		for (const String &i : p_node->header_comment) {
+			output += "#";
+			if (!i.begins_with("#")) {
+				output += " ";
+			}
+			output += i;
+			output += indent(p_indent_level);
+		}
+	} else if (!p_node->inline_comment.is_empty()) {
+		output += " # ";
+		output += p_node->inline_comment;
+	}
+	return output;
+}
+
+String GDScriptFormat::parse_class_variable(const GDP::ClassNode *p_node, const int p_indent_level, const int p_member_index) {
+	StringBuilder output;
+	String variable_string;
+	bool did_break = false;
+
+	if (children_have_comments(p_node->members[p_member_index].variable) && is_nestable_statement(p_node->members[p_member_index].variable->initializer)) {
+		variable_string = parse_variable(p_node->members[p_member_index].variable, p_indent_level, WRAP);
+		did_break = get_length_without_comments(variable_string) > line_length_maximum || variable_string.contains("\n");
+	} else {
+		variable_string = parse_variable(p_node->members[p_member_index].variable, p_indent_level, NONE);
+		if (get_length_without_comments(variable_string) > line_length_maximum) {
+			did_break = true;
+			variable_string = parse_variable(p_node->members[p_member_index].variable, p_indent_level, WRAP);
+		}
+	}
+
+	output += print_comment(p_node->members[p_member_index].variable, true, p_indent_level);
+
+	if (!p_node->members[p_member_index].variable->annotations.is_empty()) {
+		String annotation_string;
+		if (!did_break) {
+			for (GDScriptParser::AnnotationNode *&annotation : p_node->members[p_member_index].variable->annotations) {
+				if (String(annotation->name).find("_") > -1) {
+					did_break = true;
+					break;
+				}
+			}
+		}
+		if (!did_break) {
+			annotation_string = parse_annotations(p_node->members[p_member_index].variable->annotations, p_indent_level);
+			if (get_length_without_comments(annotation_string) + get_length_without_comments(variable_string) > line_length_maximum) {
+				annotation_string = parse_annotations(p_node->members[p_member_index].variable->annotations, p_indent_level, SPLIT);
+			}
+		} else {
+			annotation_string = parse_annotations(p_node->members[p_member_index].variable->annotations, p_indent_level, SPLIT);
+		}
+		output += annotation_string;
+	}
+	output += variable_string;
+	output += print_comment(p_node->members[p_member_index].variable, false);
+
+	const String property_string = parse_property(p_node->members[p_member_index].variable, p_indent_level);
+	output += property_string;
+	if ((!property_string.is_empty() && p_member_index < p_node->members.size() - 1) || new_lines.has(p_node->members[p_member_index].variable->end_line)) {
+		output += "\n";
+	}
+
+	return output;
+}
+
+String GDScriptFormat::parse_class(const GDP::ClassNode *p_node, const int p_indent_level) {
+	StringBuilder output;
+
+	bool has_section = false;
+	if (!p_node->icon_path.is_empty()) {
+		if (!p_node->icon_header_comment.is_empty()) {
+			for (const String &i : p_node->icon_header_comment) {
+				output += "# ";
+				output += i;
+				output += indent(p_indent_level);
+			}
+		}
+		output += "@icon(\"";
+		output += p_node->icon_path;
+		output += "\")";
+		if (!p_node->icon_inline_comment.is_empty()) {
+			output += " # ";
+			output += p_node->icon_inline_comment;
+		}
+		output += "\n";
+		has_section = true;
+	}
+	if (p_node->identifier != nullptr) {
+		if (p_node->outer != nullptr) {
+			const String pre_comment = print_comment(p_node, true, p_indent_level);
+			const String comment = print_comment(p_node, false);
+			output += pre_comment;
+			output += "class ";
+			output += p_node->identifier->name;
+			output += ":";
+			output += comment + "\n";
+		} else {
+			output += print_comment(p_node, true, p_indent_level);
+			output += "class_name " + p_node->identifier->name;
+			output += print_comment(p_node, false);
+			output += "\n";
+			has_section = true;
+		}
+	}
+	if (p_node->extends_used) {
+		if (p_node->outer != nullptr) {
+			output += indent(p_indent_level + 1, false);
+		}
+		if (!p_node->extends_header_comment.is_empty()) {
+			for (const String &i : p_node->extends_header_comment) {
+				output += "# ";
+				output += i;
+				output += indent(p_indent_level);
+			}
+		}
+		output += "extends ";
+		if (!p_node->extends_path.is_empty()) {
+			output += "\"";
+			output += p_node->extends_path;
+			output += "\"";
+		}
+		if (!p_node->extends.is_empty()) {
+			if (!p_node->extends_path.is_empty()) {
+				output += ".";
+			}
+			for (int i = 0; i < p_node->extends.size(); ++i) {
+				output += p_node->extends[i]->name;
+				if (i < p_node->extends.size() - 1) {
+					output += ".";
+				}
+			}
+		}
+
+		if (!p_node->extends_inline_comment.is_empty()) {
+			output += " # ";
+			output += p_node->extends_inline_comment;
+		}
+
+		output += "\n";
+		has_section = true;
+	}
+
+	if (!p_node->members.is_empty()) {
+		Vector<GDP::EnumNode *> completed_values;
+
+		if (has_section) {
+			while (!output.as_string().ends_with("\n\n\n")) {
+				output += "\n";
+			}
+		}
+		int indent_mod = p_node->outer != nullptr ? 1 : 0;
+		for (int i = 0; i < p_node->members.size(); ++i) {
+			bool skip_newline = false;
+			if (p_node->outer != nullptr) {
+				output += indent(p_indent_level + 1, false);
+			}
+
+			switch (p_node->members[i].type) {
+				case GDP::ClassNode::Member::Type::VARIABLE:
+					output += parse_class_variable(p_node, p_indent_level + indent_mod, i);
+					break;
+				case GDP::ClassNode::Member::Type::CONSTANT: {
+					String constant_string;
+					if (children_have_comments(p_node->members[i].constant) && is_nestable_statement(p_node->members[i].constant->initializer)) {
+						constant_string = parse_constant(p_node->members[i].constant, p_indent_level + indent_mod, WRAP);
+					} else {
+						constant_string = parse_constant(p_node->members[i].constant, p_indent_level + indent_mod);
+						if (get_length_without_comments(constant_string) > line_length_maximum) {
+							constant_string = parse_constant(p_node->members[i].constant, p_indent_level + indent_mod, WRAP);
+						}
+					}
+					output += constant_string;
+					if ((i < p_node->members.size() - 1 && p_node->members[i + 1].type != GDP::ClassNode::Member::Type::CONSTANT && p_node->members[i + 1].type != GDP::ClassNode::Member::Type::ENUM && p_node->members[i + 1].type != GDP::ClassNode::Member::Type::ENUM_VALUE) || new_lines.has(p_node->members[i].constant->end_line)) {
+						output += "\n";
+					}
+				} break;
+				case GDP::ClassNode::Member::Type::FUNCTION:
+					if (i > 0 && p_node->members[i - 1].type != GDP::ClassNode::Member::Type::FUNCTION) {
+						while (!output.as_string().ends_with("\n\n\n")) {
+							output += "\n";
+						}
+					}
+					if (!p_node->members[i].function->annotations.is_empty()) {
+						output += parse_annotations(p_node->members[i].function->annotations, p_indent_level + indent_mod, SPLIT);
+					}
+					output += parse_function(p_node->members[i].function, p_indent_level + indent_mod);
+					if (i < p_node->members.size() - 1) {
+						while (!output.as_string().ends_with(String("\n").repeat(lines_between_functions))) {
+							output += "\n";
+						}
+					}
+					break;
+				case GDP::ClassNode::Member::Type::SIGNAL: {
+					String signal_string;
+					if (children_have_comments(p_node->members[i].signal)) {
+						signal_string = parse_signal(p_node->members[i].signal, p_indent_level + indent_mod, WRAP);
+					} else {
+						signal_string = parse_signal(p_node->members[i].signal, p_indent_level + indent_mod);
+						if (get_length_without_comments(signal_string) > line_length_maximum) {
+							signal_string = parse_signal(p_node->members[i].signal, p_indent_level + indent_mod, WRAP);
+						}
+					}
+					output += signal_string;
+					if ((i < p_node->members.size() - 1 && p_node->members[i + 1].type != GDP::ClassNode::Member::Type::SIGNAL) || new_lines.has(p_node->members[i].signal->end_line)) {
+						output += "\n";
+					}
+				} break;
+				case GDP::ClassNode::Member::Type::CLASS:
+					output += parse_class(p_node->members[i].m_class, p_indent_level + indent_mod);
+					skip_newline = p_node->members[i].m_class->outer != nullptr;
+					break;
+				case GDP::ClassNode::Member::Type::ENUM: {
+					output += parse_enum(p_node->members[i].m_enum, p_indent_level + indent_mod);
+					if ((i < p_node->members.size() - 1 && p_node->members[i + 1].type != GDP::ClassNode::Member::Type::CONSTANT && p_node->members[i + 1].type != GDP::ClassNode::Member::Type::ENUM && p_node->members[i + 1].type != GDP::ClassNode::Member::Type::ENUM_VALUE) || new_lines.has(p_node->members[i].m_enum->end_line)) {
+						output += "\n";
+					}
+				} break;
+				case GDP::ClassNode::Member::Type::ENUM_VALUE: {
+					if (completed_values.find(p_node->members[i].enum_value.parent_enum) == -1) {
+						output += parse_enum(p_node->members[i].enum_value.parent_enum, p_indent_level + indent_mod);
+						completed_values.push_back(p_node->members[i].enum_value.parent_enum);
+						if ((i < p_node->members.size() - 1 && p_node->members[i + 1].type != GDP::ClassNode::Member::Type::CONSTANT && p_node->members[i + 1].type != GDP::ClassNode::Member::Type::ENUM && p_node->members[i + 1].type != GDP::ClassNode::Member::Type::ENUM_VALUE) || new_lines.has(p_node->members[i].enum_value.parent_enum->end_line)) {
+							output += "\n";
+						}
+					} else {
+						skip_newline = true;
+					}
+				} break;
+				case GDP::ClassNode::Member::Type::UNDEFINED:
+				case GDScriptParser::ClassNode::Member::GROUP:
+					break;
+			}
+			if (!skip_newline) {
+				output += "\n";
+			}
+		}
+	} else if (p_node->outer != nullptr && !p_node->extends_used) {
+		output += indent(p_indent_level + 1, false) + "pass\n";
+	}
+
+	const int indent_mod = p_node->outer == nullptr ? 0 : 1;
+	for (int i = 0; i < p_node->footer_comment.size(); ++i) {
+		if (i == p_node->footer_comment.size() - 1 && indent_mod == 0 && !output.as_string().ends_with("\n")) {
+			output += "\n";
+		}
+		output += indent(p_indent_level + indent_mod);
+		output += "# ";
+		output += p_node->footer_comment[i];
+		if (i == p_node->footer_comment.size() - 1 && indent_mod == 0) {
+			output += "\n";
+		}
+	}
+
+	return output;
+}
+
+String GDScriptFormat::parse_enum_elements(const GDP::EnumNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+	for (int i = 0; i < p_node->values.size(); ++i) {
+		if (p_break_type != NONE) {
+			output += indent(p_indent_level);
+		}
+		output += print_comment(p_node->values[i].identifier, true, p_indent_level);
+
+		output += p_node->values[i].identifier->name;
+		if (p_node->values[i].custom_value != nullptr) {
+			output += " = ";
+			output += parse_expression(p_node->values[i].custom_value, p_indent_level);
+		}
+
+		if (p_break_type != NONE || i < p_node->values.size() - 1) {
+			output += ",";
+		}
+		if (p_break_type == NONE && i < p_node->values.size() - 1) {
+			output += " ";
+		}
+		output += print_comment(p_node->values[i].identifier, false);
+	}
+
+	return output;
+}
+
+String GDScriptFormat::parse_enum(const GDP::EnumNode *p_node, const int p_indent_level) {
+	StringBuilder output;
+	output += print_comment(p_node, true, p_indent_level);
+
+	output += "enum";
+	if (p_node->identifier != nullptr) {
+		output += " ";
+		output += p_node->identifier->name;
+	}
+	output += " {";
+	bool break_line = false;
+
+	String enum_elements_string;
+	if (children_have_comments(p_node)) {
+		enum_elements_string = parse_enum_elements(p_node, p_indent_level + 1, WRAP);
+		break_line = true;
+	} else {
+		enum_elements_string = parse_enum_elements(p_node, p_indent_level);
+		if (get_length_without_comments(enum_elements_string) > line_length_maximum) {
+			enum_elements_string = parse_enum_elements(p_node, p_indent_level + 1, WRAP);
+			break_line = true;
+		}
+	}
+
+	if (!break_line && get_length_without_comments(output) + get_length_without_comments(enum_elements_string) > line_length_maximum) {
+		output += indent(p_indent_level + 1);
+		break_line = true;
+	} else if (!break_line) {
+		output += " ";
+	}
+
+	output += enum_elements_string;
+
+	if (break_line) {
+		output += indent(p_indent_level);
+	} else {
+		output += " ";
+	}
+
+	output += "}";
+	output += print_comment(p_node, false);
+
+	return output;
+}
+
+String GDScriptFormat::parse_type(const GDP::TypeNode *p_node) {
+	StringBuilder output;
+	if (p_node->type_chain.size() > 0) {
+		for (int i = 0; i < p_node->type_chain.size(); ++i) {
+			output += p_node->type_chain[i]->name;
+			if (i < p_node->type_chain.size() - 1) {
+				output += ".";
+			}
+		}
+		if (p_node->container_type != nullptr) {
+			output += "[";
+			output += parse_type(p_node->container_type);
+			output += "]";
+		}
+		output += print_comment(p_node->type_chain[p_node->type_chain.size() - 1], false);
+	} else {
+		output += "void";
+	}
+
+	return output;
+}
+
+String GDScriptFormat::parse_var_value(const GDP::ExpressionNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	const String comment_headers = print_comment(p_node, true, p_indent_level);
+
+	StringBuilder value;
+	if (p_break_type != NONE) {
+		bool add_wrap;
+		switch (p_node->type) {
+			case GDP::Node::Type::ARRAY:
+			case GDP::Node::Type::CALL:
+			case GDP::Node::Type::PRELOAD:
+			case GDP::Node::Type::DICTIONARY:
+			case GDP::Node::Type::SUBSCRIPT:
+			case GDP::Node::Type::TERNARY_OPERATOR:
+			case GDP::Node::Type::BINARY_OPERATOR:
+			case GDP::Node::Type::LAMBDA:
+				add_wrap = false;
+				break;
+			default:
+				add_wrap = true;
+				break;
+		}
+
+		if (add_wrap) {
+			value += "(";
+			value += indent(p_indent_level + indent_in_multiline_block);
+
+			String value_string;
+			if (children_have_comments(p_node)) {
+				value_string = parse_expression(p_node, p_indent_level + indent_in_multiline_block, p_break_type);
+			} else {
+				value_string = parse_expression(p_node, p_indent_level + indent_in_multiline_block);
+				if (get_length_without_comments(value_string) > line_length_maximum) {
+					value_string = parse_expression(p_node, p_indent_level + indent_in_multiline_block, p_break_type);
+				}
+			}
+
+			value += value_string;
+			value += indent(p_indent_level) + ")";
+		} else {
+			value += parse_expression(p_node, p_indent_level, p_break_type);
+		}
+	} else {
+		if (children_have_comments(p_node)) {
+			value += parse_expression(p_node, p_indent_level, p_break_type);
+		} else {
+			value += parse_expression(p_node, p_indent_level);
+		}
+	}
+
+	const String comment = print_comment(p_node, false);
+
+	StringBuilder output;
+	output += comment_headers;
+	output += value;
+	output += comment;
+
+	return output;
+}
+
+String GDScriptFormat::parse_constant(const GDP::ConstantNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder declaration;
+	declaration += "const ";
+	declaration += p_node->identifier->name;
+
+	String value;
+	if (p_node->initializer != nullptr) {
+		if (p_node->infer_datatype) {
+			declaration += " := ";
+		} else if (p_node->datatype_specifier != nullptr) {
+			declaration += ": ";
+			declaration += parse_type(p_node->datatype_specifier);
+			declaration += " = ";
+		} else {
+			declaration += " = ";
+		}
+
+		value = parse_var_value(p_node->initializer, p_indent_level, p_break_type);
+	}
+
+	StringBuilder output;
+	output += print_comment(p_node, true, p_indent_level);
+	output += declaration;
+	output += value;
+	output += print_comment(p_node, false);
+	return output;
+}
+
+String GDScriptFormat::parse_property(const GDP::VariableNode *p_node, const int p_indent_level) {
+	StringBuilder output;
+
+	switch (p_node->property) {
+		case GDP::VariableNode::PropertyStyle::PROP_INLINE:
+			output += indent(p_indent_level + 1);
+			if (p_node->setter != nullptr) {
+				output += print_comment(p_node->setter, true, p_indent_level + 1);
+				output += "set(";
+				output += p_node->setter->parameters[0]->identifier->name;
+				output += "):";
+				output += print_comment(p_node->setter, false);
+				output += parse_suite(p_node->setter->body, p_indent_level + 2);
+				if (p_node->getter != nullptr) {
+					output += indent(p_indent_level + 1);
+				}
+			}
+			if (p_node->getter != nullptr) {
+				output += print_comment(p_node->getter, true, p_indent_level + 1);
+				output += "get:";
+				output += print_comment(p_node->getter, false);
+				output += parse_suite(p_node->getter->body, p_indent_level + 2);
+			}
+			break;
+		case GDP::VariableNode::PropertyStyle::PROP_SETGET:
+			output += " : ";
+			if (p_node->setter_pointer != nullptr) {
+				output += "set = ";
+				output += p_node->setter_pointer->name;
+			}
+			if (p_node->getter_pointer != nullptr) {
+				output += p_node->setter_pointer != nullptr ? ", get = " : "get = ";
+				output += p_node->getter_pointer->name;
+			}
+			break;
+		case GDP::VariableNode::PropertyStyle::PROP_NONE:
+			break;
+	}
+
+	return output;
+}
+
+String GDScriptFormat::parse_variable(const GDP::VariableNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder declaration;
+	declaration += "var ";
+	declaration += p_node->identifier->name;
+
+	String value = "";
+	if (p_node->initializer != nullptr) {
+		if (p_node->infer_datatype) {
+			declaration += " := ";
+		} else if (p_node->datatype_specifier != nullptr) {
+			declaration += ": ";
+			declaration += parse_type(p_node->datatype_specifier);
+			declaration += " = ";
+		} else {
+			declaration += " = ";
+		}
+
+		value = parse_var_value(p_node->initializer, p_indent_level, p_break_type);
+	} else if (p_node->datatype_specifier != nullptr) {
+		declaration += ": ";
+		declaration += parse_type(p_node->datatype_specifier);
+	}
+	const String prop_append = p_node->property == GDP::VariableNode::PROP_INLINE ? ":" : "";
+
+	StringBuilder output;
+	output += declaration;
+	output += value;
+	output += prop_append;
+
+	return output;
+}
+
+String GDScriptFormat::parse_variable_with_comments(const GDP::VariableNode *p_node, int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+	output += print_comment(p_node, true, p_indent_level);
+	output += parse_variable(p_node, p_indent_level, p_break_type);
+	output += print_comment(p_node, false);
+	return output;
+}
+
+String GDScriptFormat::parse_annotations(const List<GDP::AnnotationNode *> &p_annotations, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+	for (const GDScriptParser::AnnotationNode *p_annotation : p_annotations) {
+		output += print_comment(p_annotation, true, p_indent_level);
+		output += p_annotation->name;
+
+		if (!p_annotation->arguments.is_empty()) {
+			output += "(";
+			output += parse_call_arguments(p_annotation->arguments, p_indent_level);
+			output += ")";
+		}
+
+		output += print_comment(p_annotation, false);
+
+		if (p_break_type != NONE) {
+			output += "\n";
+		} else {
+			output += " ";
+		}
+	}
+	return output;
+}
+
+String GDScriptFormat::parse_signal(const GDP::SignalNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder signal_string;
+	signal_string += "signal ";
+	signal_string += parse_expression(p_node->identifier, p_indent_level);
+
+	if (!p_node->parameters.is_empty()) {
+		signal_string += "(";
+		if (p_break_type != NONE) {
+			signal_string += indent(p_indent_level + 1);
+		}
+		String parameters;
+		if (children_have_comments(p_node)) {
+			parameters = parse_parameters(p_node->parameters, p_indent_level, p_break_type);
+		} else {
+			parameters = parse_parameters(p_node->parameters, p_indent_level);
+			if (p_break_type != NONE && get_length_without_comments(parameters) > line_length_maximum) {
+				parameters = parse_parameters(p_node->parameters, p_indent_level, p_break_type);
+			}
+		}
+		signal_string += parameters;
+		if (p_break_type != NONE) {
+			signal_string += indent(p_indent_level);
+		}
+		signal_string += ")";
+	} else if (p_node->has_empty_parameter_list) {
+		signal_string += "()";
+	}
+
+	StringBuilder output;
+	output += print_comment(p_node, true, p_indent_level);
+	output += signal_string;
+	output += print_comment(p_node, false);
+
+	return output;
+}
+
+String GDScriptFormat::parse_cast(const GDP::CastNode *p_node, const int p_indent_level) {
+	StringBuilder output;
+	output += parse_expression(p_node->operand, p_indent_level);
+	output += " as ";
+	output += parse_type(p_node->cast_type);
+
+	return output;
+}
+
+String GDScriptFormat::parse_expression(const GDP::ExpressionNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	String output = "";
+	switch (p_node->type) {
+		case GDP::Node::Type::ASSIGNMENT:
+			output = parse_assignment(dynamic_cast<const GDP::AssignmentNode *>(p_node), p_indent_level, p_break_type);
+			break;
+		case GDP::Node::Type::AWAIT:
+			output = parse_await(dynamic_cast<const GDP::AwaitNode *>(p_node), p_indent_level);
+			break;
+		case GDP::Node::Type::ARRAY:
+			output = parse_array(dynamic_cast<const GDP::ArrayNode *>(p_node), p_indent_level, p_break_type);
+			break;
+		case GDP::Node::Type::BINARY_OPERATOR:
+			output = parse_binary_operator(dynamic_cast<const GDP::BinaryOpNode *>(p_node), p_indent_level, p_break_type);
+			break;
+		case GDP::Node::Type::LITERAL:
+			output = parse_literal(dynamic_cast<const GDP::LiteralNode *>(p_node));
+			break;
+		case GDP::Node::Type::CAST:
+			output = parse_cast(dynamic_cast<const GDP::CastNode *>(p_node), p_indent_level);
+			break;
+		case GDP::Node::Type::IDENTIFIER:
+			output = dynamic_cast<const GDP::IdentifierNode *>(p_node)->name;
+			break;
+		case GDP::Node::Type::CALL:
+			output = parse_call(dynamic_cast<const GDP::CallNode *>(p_node), p_indent_level, p_break_type);
+			break;
+		case GDP::Node::Type::DICTIONARY:
+			output = parse_dictionary(dynamic_cast<const GDP::DictionaryNode *>(p_node), p_indent_level, p_break_type);
+			break;
+		case GDP::Node::Type::GET_NODE:
+			output = parse_get_node(dynamic_cast<const GDP::GetNodeNode *>(p_node), p_indent_level);
+			break;
+		case GDP::Node::Type::PRELOAD:
+			output = parse_preload(dynamic_cast<const GDP::PreloadNode *>(p_node), p_indent_level, p_break_type);
+			break;
+		case GDP::Node::Type::SELF:
+			output = "self";
+			break;
+		case GDP::Node::Type::SUBSCRIPT:
+			output = parse_subscript(dynamic_cast<const GDP::SubscriptNode *>(p_node), p_indent_level, p_break_type);
+			break;
+		case GDP::Node::Type::TERNARY_OPERATOR:
+			output = parse_ternary_op(dynamic_cast<const GDP::TernaryOpNode *>(p_node), p_indent_level, p_break_type);
+			break;
+		case GDP::Node::Type::TYPE_TEST:
+			output = parse_type_test(dynamic_cast<const GDP::TypeTestNode *>(p_node), p_indent_level, p_break_type);
+			break;
+		case GDP::Node::Type::UNARY_OPERATOR:
+			output = parse_unary_op(dynamic_cast<const GDP::UnaryOpNode *>(p_node), p_indent_level, p_break_type);
+			break;
+		case GDP::Node::Type::LAMBDA:
+			output = parse_lambda(dynamic_cast<const GDP::LambdaNode *>(p_node), p_indent_level);
+			break;
+		default:
+			break;
+	}
+
+	return output;
+}
+
+String GDScriptFormat::parse_parameter(const GDP::ParameterNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder param_string;
+	param_string += parse_expression(p_node->identifier, p_indent_level, p_break_type);
+	if (p_node->datatype_specifier != nullptr) {
+		param_string += ": ";
+		param_string += parse_type(p_node->datatype_specifier);
+	} else if (p_node->infer_datatype) {
+		param_string += " :";
+	}
+
+	if (p_node->initializer != nullptr) {
+		if (p_node->datatype_specifier != nullptr) {
+			param_string += " ";
+		}
+		param_string += "= " + parse_expression(p_node->initializer, p_indent_level, p_break_type);
+	}
+
+	StringBuilder output;
+	output += print_comment(p_node, true, p_indent_level);
+	output += param_string;
+
+	return output;
+}
+
+String GDScriptFormat::parse_parameters(const Vector<GDP::ParameterNode *> &p_nodes, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+	for (int i = 0; i < p_nodes.size(); ++i) {
+		const GDP::ParameterNode *parameter_node = p_nodes[i];
+
+		int indent_level_mod = 0;
+		if (p_break_type != NONE && i > 0) {
+			indent_level_mod = 1;
+			output += indent(p_indent_level + 1);
+		}
+		String parameter;
+		if (children_have_comments(parameter_node)) {
+			parameter = parse_parameter(parameter_node, p_indent_level + indent_level_mod, p_break_type);
+		} else {
+			parameter = parse_parameter(parameter_node, p_indent_level + indent_level_mod);
+			if (p_break_type != NONE && get_length_without_comments(parameter) > line_length_maximum) {
+				parameter = parse_parameter(parameter_node, p_indent_level + indent_level_mod, p_break_type);
+			}
+		}
+
+		output += parameter;
+		if (i < p_nodes.size() - 1) {
+			output += ",";
+			if (p_break_type == NONE) {
+				output += " ";
+			}
+		}
+
+		output += print_comment(parameter_node, false);
+	}
+
+	return output;
+}
+
+String GDScriptFormat::parse_function_signature(const GDP::FunctionNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder signature;
+	if (p_node->is_static) {
+		signature += "static ";
+	}
+
+	signature += "func";
+
+	if (p_node->identifier != nullptr) {
+		signature += " ";
+		signature += parse_expression(p_node->identifier, p_indent_level, p_break_type);
+	}
+	signature += "(";
+
+	if (p_break_type != NONE) {
+		signature += indent(p_indent_level + 1);
+	}
+
+	String parameters;
+	if (children_have_comments(p_node)) {
+		parameters = parse_parameters(p_node->parameters, p_indent_level, p_break_type);
+	} else {
+		parameters = parse_parameters(p_node->parameters, p_indent_level);
+		if (p_break_type != NONE && get_length_without_comments(parameters) > line_length_maximum) {
+			parameters = parse_parameters(p_node->parameters, p_indent_level, p_break_type);
+		}
+	}
+
+	signature += parameters;
+
+	for (int i = 0; i < p_node->params_footer_comments.size(); ++i) {
+		signature += indent(p_indent_level + 1);
+		signature += "# ";
+		signature += p_node->params_footer_comments[i];
+		if (i == p_node->params_footer_comments.size() - 1) {
+			signature += indent(p_indent_level);
+		}
+	}
+	if (p_break_type != NONE) {
+		signature += indent(p_indent_level);
+	}
+	signature += ")";
+
+	if (p_node->return_type != nullptr) {
+		signature += " -> ";
+		signature += parse_type(p_node->return_type);
+	}
+	signature += ":";
+
+	return signature;
+}
+
+String GDScriptFormat::parse_lambda(const GDP::LambdaNode *p_node, const int p_indent_level) {
+	return parse_function(p_node->function, p_indent_level);
+}
+
+String GDScriptFormat::parse_function(const GDP::FunctionNode *p_node, const int p_indent_level) {
+	StringBuilder output;
+	String signature;
+	if (children_have_comments(p_node)) {
+		signature = parse_function_signature(p_node, p_indent_level, WRAP);
+	} else {
+		signature = parse_function_signature(p_node, p_indent_level);
+		if (get_length_without_comments(signature) > line_length_maximum) {
+			signature = parse_function_signature(p_node, p_indent_level, WRAP);
+		}
+	}
+
+	output += print_comment(p_node, true, p_indent_level);
+	output += signature;
+	output += print_comment(p_node, false);
+
+	output += parse_suite(p_node->body, p_indent_level + 1);
+
+	return output;
+}
+
+String GDScriptFormat::parse_return(const GDP::ReturnNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+	output += print_comment(p_node, true, p_indent_level);
+	output += "return";
+	if (p_node->return_value != nullptr) {
+		output += " ";
+		output += parse_expression(p_node->return_value, p_indent_level, p_break_type);
+	}
+	output += print_comment(p_node, false);
+
+	return output;
+}
+
+String GDScriptFormat::parse_assert(const GDP::AssertNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder comment;
+	comment += print_comment(p_node, false);
+	if (p_node->message != nullptr) {
+		comment += print_comment(p_node->message, false);
+	}
+
+	StringBuilder output;
+	output += print_comment(p_node, true, p_indent_level);
+	output += "assert(";
+
+	String condition_string;
+	if (children_have_comments(p_node)) {
+		condition_string = parse_expression(p_node->condition, p_indent_level, WRAP);
+	} else {
+		condition_string = parse_expression(p_node->condition, p_indent_level);
+		if (p_break_type != NONE && get_length_without_comments(condition_string) > line_length_maximum) {
+			condition_string = parse_expression(p_node->condition, p_indent_level, p_break_type);
+		}
+	}
+	output += condition_string;
+
+	if (p_node->message != nullptr) {
+		output += ", ";
+		output += parse_expression(p_node->message, p_indent_level);
+	}
+	output += ")";
+	output += comment;
+
+	return output;
+}
+
+String GDScriptFormat::parse_if(const GDP::IfNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+
+	StringBuilder true_string;
+	true_string += "if ";
+	String true_condition = parse_expression(p_node->condition, p_indent_level);
+	if (p_break_type != NONE && get_length_without_comments(true_condition) + 4 > line_length_maximum) {
+		true_string += "(";
+		true_string += indent(p_indent_level + 1);
+
+		if (get_length_without_comments(true_condition) > line_length_maximum) {
+			BreakType break_type = p_break_type;
+			if (p_node->condition->type == GDP::Node::Type::BINARY_OPERATOR) {
+				break_type = SPLIT;
+			}
+			true_condition = parse_expression(p_node->condition, p_indent_level + 1, break_type);
+		}
+
+		true_string += true_condition;
+		true_string += indent(p_indent_level);
+
+		true_string += "):";
+	} else {
+		true_string += true_condition;
+		true_string += ":";
+	}
+	output += true_string;
+	output += print_comment(p_node->condition, false);
+	output += parse_suite(p_node->true_block, p_indent_level + 1);
+
+	if (p_node->false_block != nullptr) {
+		if (p_node->false_block->statements.size() == 1 && p_node->false_block->statements[0]->type == GDP::Node::Type::IF) {
+			output += indent(p_indent_level);
+			output += print_comment(p_node->false_block->statements[0], true, p_indent_level);
+			output += "el";
+			output += parse_if(dynamic_cast<const GDP::IfNode *>(p_node->false_block->statements[0]), p_indent_level);
+		} else {
+			output += indent(p_indent_level) + print_comment(p_node->false_block, true, p_indent_level);
+			output += "else:";
+			output += print_comment(p_node->false_block, false);
+			output += parse_suite(p_node->false_block, p_indent_level + 1);
+		}
+	}
+
+	return output;
+}
+
+String GDScriptFormat::parse_match_pattern(const GDP::PatternNode *p_node, const int p_indent_level) {
+	StringBuilder output;
+	switch (p_node->pattern_type) {
+		case GDP::PatternNode::Type::PT_LITERAL:
+			output += parse_literal(p_node->literal);
+			break;
+		case GDP::PatternNode::Type::PT_WILDCARD:
+			output += "_";
+			break;
+		case GDP::PatternNode::Type::PT_EXPRESSION:
+			output += parse_expression(p_node->expression, p_indent_level);
+			break;
+		case GDP::PatternNode::Type::PT_BIND:
+			output += "var ";
+			output += parse_expression(p_node->bind, p_indent_level);
+			break;
+		case GDP::PatternNode::Type::PT_ARRAY: {
+			output += "[";
+			for (int i = 0; i < p_node->array.size(); ++i) {
+				output += parse_match_pattern(p_node->array[i], p_indent_level);
+				if (i < p_node->array.size() - 1) {
+					output += ", ";
+				}
+			}
+			output += "]";
+		} break;
+		case GDP::PatternNode::Type::PT_DICTIONARY: {
+			output += "{";
+			for (int i = 0; i < p_node->dictionary.size(); ++i) {
+				output += parse_expression(p_node->dictionary[i].key);
+				output += ": ";
+				output += parse_match_pattern(p_node->dictionary[i].value_pattern);
+				if (i < p_node->dictionary.size() - 1) {
+					output += ", ";
+				}
+			}
+			output += "}";
+		} break;
+		case GDP::PatternNode::Type::PT_REST:
+			output += "..";
+			break;
+	}
+	return output;
+}
+
+String GDScriptFormat::parse_match_branch(const GDP::MatchBranchNode *p_node, const int p_indent_level) {
+	StringBuilder output;
+	output += print_comment(p_node, true, p_indent_level);
+	for (int i = 0; i < p_node->patterns.size(); ++i) {
+		output += parse_match_pattern(p_node->patterns[i], p_indent_level);
+		if (i < p_node->patterns.size() - 1) {
+			output += ", ";
+		}
+	}
+
+	output += ":";
+	output += print_comment(p_node, false);
+
+	output += parse_suite(p_node->block, p_indent_level + 1);
+
+	return output;
+}
+
+String GDScriptFormat::parse_match(const GDP::MatchNode *p_node, const int p_indent_level, BreakType p_break_type) {
+	StringBuilder output;
+	output += print_comment(p_node, true, p_indent_level);
+	output += "match ";
+	output += parse_expression(p_node->test, p_indent_level);
+	output += ":" + print_comment(p_node->test, false);
+	output += indent(p_indent_level + 1);
+	for (int i = 0; i < p_node->branches.size(); ++i) {
+		output += parse_match_branch(p_node->branches[i], p_indent_level + 1);
+		if (i < p_node->branches.size() - 1) {
+			output += indent(p_indent_level + 1);
+		}
+	}
+
+	return output;
+}
+
+String GDScriptFormat::parse_for(const GDP::ForNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+	output += print_comment(p_node, true, p_indent_level);
+
+	output += "for ";
+	output += parse_expression(p_node->variable, p_indent_level);
+	output += " in ";
+
+	String condition = parse_expression(p_node->list, p_indent_level);
+	if (p_break_type != NONE && get_length_without_comments(output) + get_length_without_comments(condition) + 1 > line_length_maximum) {
+		condition = parse_expression(p_node->list, p_indent_level, WRAP);
+	}
+	output += condition;
+	output += ":";
+	output += print_comment(p_node, false);
+
+	output += parse_suite(p_node->loop, p_indent_level + 1);
+
+	return output;
+}
+
+String GDScriptFormat::parse_while(const GDP::WhileNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+	output += print_comment(p_node, true, p_indent_level);
+
+	output += "while ";
+
+	String condition = parse_expression(p_node->condition, p_indent_level);
+	if (p_break_type != NONE && get_length_without_comments(condition) + 6 > line_length_maximum) {
+		output += "(";
+		output += indent(p_indent_level + 1);
+
+		if (get_length_without_comments(condition) > line_length_maximum) {
+			condition = parse_expression(p_node->condition, p_indent_level + 1, p_break_type);
+		}
+		output += condition;
+		output += indent(p_indent_level);
+
+		output += "):";
+	} else {
+		output += condition;
+		output += ":";
+	}
+
+	output += print_comment(p_node, false);
+	output += parse_suite(p_node->loop, p_indent_level + 1);
+
+	return output;
+}
+
+String GDScriptFormat::parse_suite(const GDP::SuiteNode *p_node, const int p_indent_level) {
+	StringBuilder output;
+	for (GDScriptParser::Node *statement : p_node->statements) {
+		output += indent(p_indent_level);
+
+		ParserFunc parser = nullptr;
+
+		String raw_statement = "";
+
+		switch (statement->type) {
+			case GDP::Node::Type::PASS:
+				raw_statement = "pass";
+				break;
+			case GDP::Node::Type::BREAKPOINT:
+				raw_statement = "breakpoint";
+				break;
+			case GDP::Node::Type::BREAK:
+				raw_statement = "break";
+				break;
+			case GDP::Node::Type::CONTINUE:
+				raw_statement = "continue";
+				break;
+			case GDP::Node::Type::RETURN:
+				parser = reinterpret_cast<ParserFunc>(&GDScriptFormat::parse_return);
+				break;
+			case GDP::Node::Type::VARIABLE:
+				parser = reinterpret_cast<ParserFunc>(&GDScriptFormat::parse_variable_with_comments);
+				break;
+			case GDP::Node::Type::CONSTANT:
+				parser = reinterpret_cast<ParserFunc>(&GDScriptFormat::parse_constant);
+				break;
+			case GDP::Node::Type::ASSERT:
+				parser = reinterpret_cast<ParserFunc>(&GDScriptFormat::parse_assert);
+				break;
+			case GDP::Node::Type::IF:
+				parser = reinterpret_cast<ParserFunc>(&GDScriptFormat::parse_if);
+				output += print_comment(statement, true, p_indent_level);
+				break;
+			case GDP::Node::Type::WHILE:
+				parser = reinterpret_cast<ParserFunc>(&GDScriptFormat::parse_while);
+				break;
+			case GDP::Node::Type::FOR:
+				parser = reinterpret_cast<ParserFunc>(&GDScriptFormat::parse_for);
+				break;
+			case GDP::Node::Type::MATCH:
+				parser = reinterpret_cast<ParserFunc>(&GDScriptFormat::parse_match);
+				break;
+
+			case GDP::Node::Type::IDENTIFIER:
+			case GDP::Node::Type::ASSIGNMENT:
+			case GDP::Node::Type::AWAIT:
+			case GDP::Node::Type::CALL:
+			case GDP::Node::Type::BINARY_OPERATOR:
+			case GDP::Node::Type::ARRAY:
+			case GDP::Node::Type::DICTIONARY:
+			case GDP::Node::Type::GET_NODE:
+			case GDP::Node::Type::LITERAL:
+			case GDP::Node::Type::PRELOAD:
+			case GDP::Node::Type::SELF:
+			case GDP::Node::Type::SUBSCRIPT:
+			case GDP::Node::Type::TERNARY_OPERATOR:
+			case GDP::Node::Type::UNARY_OPERATOR:
+				parser = reinterpret_cast<ParserFunc>(&GDScriptFormat::parse_expression);
+				break;
+			default:
+				break;
+		}
+
+		if (parser == nullptr) {
+			if (!raw_statement.is_empty()) {
+				output += print_comment(statement, true, p_indent_level);
+				output += raw_statement;
+				output += print_comment(statement, false);
+				if (new_lines.has(statement->end_line)) {
+					output += "\n";
+				}
+			}
+			continue;
+		}
+
+		String statement_string = (this->*parser)(statement, p_indent_level, NONE);
+		if (get_length_without_comments(statement_string) > line_length_maximum) {
+			statement_string = (this->*parser)(statement, p_indent_level, WRAP);
+		}
+		output += statement_string;
+
+		if (new_lines.has(statement->end_line)) {
+			output += "\n";
+		}
+	}
+
+	for (int i = 0; i < p_node->footer_comment.size(); ++i) {
+		if (i == 0 && !output.as_string().ends_with("\n")) {
+			output += "\n";
+		}
+		output += indent(p_indent_level);
+		output += "# ";
+		output += p_node->footer_comment[i];
+	}
+
+	return output;
+}
+
+String GDScriptFormat::parse_type_test(const GDP::TypeTestNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+	output += parse_expression(p_node->operand, p_indent_level, p_break_type);
+	output += " is ";
+	output += parse_type(p_node->test_type);
+	return output;
+}
+
+String GDScriptFormat::parse_unary_op(const GDP::UnaryOpNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+	switch (p_node->operation) {
+		case GDP::UnaryOpNode::OpType::OP_NEGATIVE:
+			output += "-";
+			break;
+		case GDP::UnaryOpNode::OpType::OP_POSITIVE:
+			output += "+";
+			break;
+		case GDP::UnaryOpNode::OpType::OP_LOGIC_NOT:
+			output += "not ";
+			break;
+		case GDP::UnaryOpNode::OpType::OP_COMPLEMENT:
+			output += "~";
+			break;
+	}
+
+	output += parse_expression(p_node->operand, p_indent_level, p_break_type);
+
+	return output;
+}
+
+String GDScriptFormat::parse_ternary_op(const GDP::TernaryOpNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+	if (p_break_type != NONE) {
+		output += "(";
+	}
+
+	StringBuilder true_condition;
+	true_condition += parse_expression(p_node->true_expr, p_indent_level + 1);
+	true_condition += " if ";
+	true_condition += parse_expression(p_node->condition, p_indent_level + 1);
+	if (p_break_type != NONE) {
+		String true_condition_string = true_condition.as_string();
+		true_condition = StringBuilder();
+		true_condition += indent(p_indent_level + 1) + true_condition_string;
+		if (get_length_without_comments(true_condition) > line_length_maximum) {
+			true_condition = StringBuilder();
+			true_condition += indent(p_indent_level + 1);
+			true_condition += parse_expression(p_node->true_expr, p_indent_level + 1, p_break_type);
+			true_condition += " if ";
+			true_condition += parse_expression(p_node->condition, p_indent_level + 1, p_break_type);
+		}
+	}
+	output += true_condition;
+	output += print_comment(p_node->condition, false);
+
+	StringBuilder false_condition;
+	false_condition += "else ";
+	false_condition += parse_expression(p_node->false_expr, p_indent_level + 1);
+	if (p_break_type != NONE) {
+		String false_condition_sting = false_condition.as_string();
+		false_condition = StringBuilder();
+		false_condition += indent(p_indent_level + 1);
+		false_condition += false_condition_sting;
+		if (get_length_without_comments(false_condition) > line_length_maximum) {
+			false_condition = StringBuilder();
+			false_condition += indent(p_indent_level + 1);
+			false_condition += "else ";
+			false_condition += parse_expression(p_node->false_expr, p_indent_level + 1, p_break_type);
+		}
+
+	} else {
+		String false_condition_sting = false_condition.as_string();
+		false_condition = StringBuilder();
+		false_condition += " ";
+		false_condition += false_condition_sting;
+	}
+	output += false_condition;
+	output += print_comment(p_node->false_expr, false);
+
+	if (p_break_type != NONE) {
+		output += indent(p_indent_level) + ")";
+	}
+
+	return output;
+}
+
+String GDScriptFormat::parse_await(const GDP::AwaitNode *p_node, const int p_indent_level) {
+	StringBuilder output;
+	output += print_comment(p_node, true, p_indent_level) + print_comment(p_node->to_await, true, p_indent_level);
+	output += "await ";
+
+	StringBuilder await_string;
+	await_string += parse_expression(p_node->to_await, p_indent_level);
+	if (get_length_without_comments(await_string) > line_length_maximum) {
+		await_string = StringBuilder();
+		await_string += "(";
+		await_string += indent(p_indent_level + 1);
+		await_string += parse_expression(p_node->to_await, p_indent_level + 1, WRAP);
+		await_string += indent(p_indent_level);
+		await_string += ")";
+	}
+	output += await_string;
+	output += print_comment(p_node, false);
+	output += print_comment(p_node->to_await, false);
+
+	return output;
+}
+
+String GDScriptFormat::parse_subscript(const GDP::SubscriptNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+	if (p_node->base->type == GDP::Node::Type::CAST || p_node->base->type == GDP::Node::Type::BINARY_OPERATOR) {
+		output += "(";
+	}
+	String base = parse_expression(p_node->base, p_indent_level);
+	if (p_break_type != NONE && get_length_without_comments(base) > line_length_maximum) {
+		base = parse_expression(p_node->base, p_indent_level, p_break_type);
+	}
+	output += base;
+	if (p_node->base->type == GDP::Node::Type::CAST || p_node->base->type == GDP::Node::Type::BINARY_OPERATOR) {
+		output += ")";
+	}
+	if (p_node->is_attribute) {
+		String attribute = parse_expression(p_node->attribute, p_indent_level);
+		if (p_break_type != NONE && get_length_without_comments(attribute) + 1 > line_length_maximum) {
+			attribute = parse_expression(p_node->attribute, p_indent_level, p_break_type);
+		}
+		output += ".";
+		output += attribute;
+	} else {
+		output += "[";
+		if (p_break_type != NONE) {
+			output += indent(p_indent_level + 1);
+		}
+		String subscript_string = print_comment(p_node->index, true) + parse_expression(p_node->index, p_indent_level);
+		if (get_length_without_comments(subscript_string) > line_length_maximum) {
+			subscript_string = parse_expression(p_node->index, p_indent_level, p_break_type);
+		}
+		output += subscript_string;
+		output += print_comment(p_node->index, false);
+
+		if (p_break_type != NONE) {
+			output += indent(p_indent_level);
+		}
+		output += "]";
+	}
+
+	return output;
+}
+
+String GDScriptFormat::parse_get_node(const GDP::GetNodeNode *p_node, const int p_indent_level) {
+	StringBuilder output;
+	output += "$";
+	String append;
+	if ((p_node->full_path[0] < 65 || p_node->full_path[0] > 90) && (p_node->full_path[0] < 97 || p_node->full_path[0] > 122) && !p_node->full_path.begins_with("_")) {
+		output += "\"";
+		append = "\"";
+	}
+	output += p_node->full_path;
+	output += append;
+	return output;
+}
+
+String GDScriptFormat::parse_binary_operator_element(const GDP::ExpressionNode *p_node, int p_indent_level, const BreakType p_break_type) {
+	String element;
+	if (p_break_type == SPLIT) {
+		element = parse_expression(p_node, p_indent_level, p_break_type);
+	} else {
+		element = parse_expression(p_node, p_indent_level);
+		if (p_break_type != NONE && get_length_without_comments(element) > line_length_maximum) {
+			int indent_mod = 0;
+			if (p_break_type == WRAP) {
+				indent_mod = 1;
+			}
+			element = parse_expression(p_node, p_indent_level + indent_mod, p_break_type);
+		}
+	}
+
+	return element;
+}
+
+String GDScriptFormat::parse_binary_operator(const GDP::BinaryOpNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	String operator_string = "";
+	switch (p_node->operation) {
+		case GDP::BinaryOpNode::OpType::OP_ADDITION:
+			operator_string = "+ ";
+			break;
+		case GDP::BinaryOpNode::OpType::OP_SUBTRACTION:
+			operator_string = "- ";
+			break;
+		case GDP::BinaryOpNode::OpType::OP_MULTIPLICATION:
+			operator_string = "* ";
+			break;
+		case GDP::BinaryOpNode::OpType::OP_DIVISION:
+			operator_string = "/ ";
+			break;
+		case GDP::BinaryOpNode::OpType::OP_MODULO:
+			operator_string = "% ";
+			break;
+		case GDP::BinaryOpNode::OpType::OP_BIT_LEFT_SHIFT:
+			operator_string = "<< ";
+			break;
+		case GDP::BinaryOpNode::OpType::OP_BIT_RIGHT_SHIFT:
+			operator_string = ">> ";
+			break;
+		case GDP::BinaryOpNode::OpType::OP_BIT_AND:
+			operator_string = "& ";
+			break;
+		case GDP::BinaryOpNode::OpType::OP_BIT_OR:
+			operator_string = "| ";
+			break;
+		case GDP::BinaryOpNode::OpType::OP_BIT_XOR:
+			operator_string = "^ ";
+			break;
+		case GDP::BinaryOpNode::OpType::OP_LOGIC_AND:
+			operator_string = "and ";
+			break;
+		case GDP::BinaryOpNode::OpType::OP_LOGIC_OR:
+			operator_string = "or ";
+			break;
+		case GDP::BinaryOpNode::OpType::OP_CONTENT_TEST:
+			operator_string = "in ";
+			break;
+		case GDP::BinaryOpNode::OpType::OP_COMP_EQUAL:
+			operator_string = "== ";
+			break;
+		case GDP::BinaryOpNode::OpType::OP_COMP_NOT_EQUAL:
+			operator_string = "!= ";
+			break;
+		case GDP::BinaryOpNode::OpType::OP_COMP_LESS:
+			operator_string = "< ";
+			break;
+		case GDP::BinaryOpNode::OpType::OP_COMP_LESS_EQUAL:
+			operator_string = "<= ";
+			break;
+		case GDP::BinaryOpNode::OpType::OP_COMP_GREATER:
+			operator_string = "> ";
+			break;
+		case GDP::BinaryOpNode::OpType::OP_COMP_GREATER_EQUAL:
+			operator_string = ">= ";
+			break;
+		case GDScriptParser::BinaryOpNode::OP_POWER:
+			operator_string += "** ";
+			break;
+	}
+
+	StringBuilder output;
+
+	bool break_string = false;
+	StringBuilder left_operand, right_operand;
+	if (children_have_comments(p_node)) {
+		break_string = true;
+
+		if (p_node->left_operand->type == GDP::Node::Type::BINARY_OPERATOR) {
+			left_operand += parse_binary_operator_element(p_node->left_operand, p_indent_level + (p_indent_level == 0 ? indent_in_multiline_block : 0), FORCE_SPLIT);
+		} else {
+			left_operand += parse_binary_operator_element(p_node->left_operand, p_indent_level, WRAP);
+		}
+		String left_operand_string = left_operand.as_string();
+		left_operand = StringBuilder();
+		left_operand += print_comment(p_node->left_operand, true, p_indent_level);
+		left_operand += left_operand_string;
+		left_operand += print_comment(p_node->left_operand, false);
+
+		if (p_node->right_operand->type == GDP::Node::Type::BINARY_OPERATOR) {
+			right_operand += parse_binary_operator_element(p_node->right_operand, p_indent_level + (p_indent_level == 0 ? indent_in_multiline_block : 0), FORCE_SPLIT);
+		} else {
+			right_operand += parse_binary_operator_element(p_node->right_operand, p_indent_level, WRAP);
+		}
+		String right_operand_string = right_operand.as_string();
+		right_operand = StringBuilder();
+		right_operand += print_comment(p_node->right_operand, true, p_indent_level);
+		right_operand += right_operand_string;
+		right_operand += print_comment(p_node->right_operand, false);
+	} else {
+		left_operand += parse_binary_operator_element(p_node->left_operand, p_indent_level);
+		right_operand += parse_binary_operator_element(p_node->right_operand, p_indent_level);
+		if (p_break_type != NONE && get_length_without_comments(left_operand) + get_length_without_comments(right_operand) + get_length_without_comments(operator_string) + 1 > line_length_maximum) {
+			break_string = true;
+
+			if (p_node->left_operand->type == GDP::Node::Type::BINARY_OPERATOR) {
+				left_operand = StringBuilder();
+				left_operand += parse_expression(p_node->left_operand, p_indent_level + (p_indent_level == 0 ? indent_in_multiline_block : 0), FORCE_SPLIT);
+			} else {
+				left_operand = StringBuilder();
+				left_operand += parse_binary_operator_element(p_node->left_operand, p_indent_level, WRAP);
+			}
+			if (p_node->right_operand->type == GDP::Node::Type::BINARY_OPERATOR) {
+				right_operand = StringBuilder();
+				right_operand += parse_expression(p_node->right_operand, p_indent_level + (p_indent_level == 0 ? indent_in_multiline_block : 0), FORCE_SPLIT);
+			} else {
+				right_operand = StringBuilder();
+				right_operand += parse_binary_operator_element(p_node->right_operand, p_indent_level, WRAP);
+			}
+		} else if (p_break_type == FORCE_SPLIT) {
+			break_string = true;
+		}
+	}
+
+	if (p_break_type == WRAP) {
+		output += "(";
+		output += indent(p_indent_level + indent_in_multiline_block);
+	}
+
+	bool wrap_left = false;
+	if (p_node->left_operand->type == GDP::Node::Type::BINARY_OPERATOR) {
+		const int left_priority = get_operation_priority(dynamic_cast<GDP::BinaryOpNode *>(p_node->left_operand)->operation);
+		const int right_priority = get_operation_priority(p_node->operation);
+
+		wrap_left = left_priority > right_priority;
+	}
+
+	if (wrap_left) {
+		output += "(";
+		output += left_operand;
+		output += ")";
+	} else {
+		output += left_operand;
+	}
+
+	if (break_string) {
+		output += indent(p_indent_level + (p_break_type == WRAP ? indent_in_multiline_block : 0));
+	} else {
+		output += " ";
+	}
+
+	bool wrap_right = false;
+	if (p_node->right_operand->type == GDP::Node::Type::BINARY_OPERATOR) {
+		const int left_priority = get_operation_priority(p_node->operation);
+		const int right_priority = get_operation_priority(dynamic_cast<GDP::BinaryOpNode *>(p_node->right_operand)->operation);
+
+		wrap_right = p_node->operation == GDP::BinaryOpNode::OpType::OP_DIVISION || right_priority > left_priority;
+	}
+
+	if (wrap_right) {
+		output += operator_string;
+		output += "(";
+		output += right_operand;
+		output += ")";
+	} else {
+		output += operator_string;
+		output += right_operand;
+	}
+
+	if (p_break_type == WRAP) {
+		output += indent(p_indent_level) + ")";
+	}
+
+	return output;
+}
+
+int GDScriptFormat::get_length_without_comments(const String &p_string) {
+	Vector<String> lines = p_string.split("\n");
+	if (lines.is_empty()) {
+		return 0;
+	}
+	while (!lines.is_empty() && lines[0].dedent().begins_with("#")) {
+		lines.remove_at(0);
+	}
+	int character_count = 0;
+	for (const String &line : lines) {
+		const int inline_comment_idx = line.rfind("#");
+		int quote_string_blocks = 0;
+		int quote_single_string_blocks = 0;
+		for (int c = inline_comment_idx; c >= 0; --c) {
+			if (line[c] == '"') {
+				quote_string_blocks += 1;
+			}
+			if (line[c] == '\'') {
+				quote_single_string_blocks += 1;
+			}
+		}
+		if (quote_string_blocks > 0 && quote_string_blocks % 2) {
+			continue;
+		}
+		if (quote_single_string_blocks > 0 && quote_single_string_blocks % 2) {
+			continue;
+		}
+		if (inline_comment_idx > -1) {
+			character_count += line.substr(inline_comment_idx).length();
+		} else {
+			character_count += line.length();
+		}
+	}
+	return character_count;
+}
+
+String GDScriptFormat::parse_literal(const GDP::LiteralNode *p_node) {
+	StringBuilder value_string;
+
+	if (p_node->is_builtin_constant) {
+		switch (p_node->constant_type) {
+			case GDScriptTokenizer::Token::Type::CONST_PI:
+				value_string += "PI";
+				break;
+			case GDScriptTokenizer::Token::Type::CONST_TAU:
+				value_string += "TAU";
+				break;
+			case GDScriptTokenizer::Token::Type::CONST_INF:
+				value_string += "INF";
+				break;
+			case GDScriptTokenizer::Token::Type::CONST_NAN:
+				value_string += "NAN";
+				break;
+			default:
+				break;
+		}
+	} else if (p_node->value.get_type() == Variant::Type::STRING || p_node->value.get_type() == Variant::Type::NODE_PATH || p_node->value.get_type() == Variant::Type::STRING_NAME) {
+		const String string_contents = p_node->value;
+		if (p_node->value.get_type() == Variant::Type::NODE_PATH) {
+			value_string += "^";
+		} else if (p_node->value.get_type() == Variant::Type::STRING_NAME) {
+			value_string += "&";
+		}
+		if (string_contents.contains("\"")) {
+			value_string += '\'' + string_contents + '\'';
+		} else {
+			value_string += '\"' + string_contents + '\"';
+		}
+	} else if (p_node->value.get_type() == Variant::Type::FLOAT) {
+		value_string += String(p_node->value);
+		if (!value_string.as_string().contains(".")) {
+			value_string += ".0";
+		}
+	} else if (p_node->value.get_type() == Variant::Type::NIL) {
+		value_string += "null";
+	} else {
+		value_string += String(p_node->value);
+	}
+
+	return value_string;
+}
+
+String GDScriptFormat::parse_array_element(const GDP::ExpressionNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	return parse_expression(p_node, p_indent_level, p_break_type);
+}
+
+String GDScriptFormat::parse_array_elements(const GDP::ArrayNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+
+	for (int i = 0; i < p_node->elements.size(); ++i) {
+		if (i > 0 && p_break_type != NONE) {
+			output += indent(p_indent_level);
+		}
+
+		String element;
+		if (children_have_comments(p_node)) {
+			element = print_comment(p_node->elements[i], true, p_indent_level) + parse_array_element(p_node->elements[i], p_indent_level, p_break_type);
+		} else {
+			element = parse_array_element(p_node->elements[i], p_indent_level);
+			if (p_break_type != NONE && element.length() > line_length_maximum) {
+				element = parse_array_element(p_node->elements[i], p_indent_level, p_break_type);
+			}
+		}
+
+		output += element;
+		if (i < p_node->elements.size() - 1 || p_break_type != NONE) {
+			output += ",";
+		}
+		if (p_break_type == NONE && i < p_node->elements.size() - 1) {
+			output += " ";
+		}
+		output += print_comment(p_node->elements[i], false);
+	}
+
+	return output;
+}
+
+String GDScriptFormat::parse_array(const GDP::ArrayNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder array_string;
+	array_string += "[";
+	int indent_mod = 0;
+	if (p_break_type != NONE) {
+		indent_mod = 1;
+		array_string += indent(p_indent_level + 1);
+	}
+
+	String elements;
+	if (children_have_comments(p_node) || !p_node->footer_comments.is_empty()) {
+		if (p_break_type == NONE && !p_node->elements.is_empty()) {
+			array_string += indent(p_indent_level + 1);
+		}
+		elements = parse_array_elements(p_node, p_indent_level + 1, WRAP);
+	} else {
+		elements = parse_array_elements(p_node, p_indent_level + indent_mod);
+		if (p_break_type != NONE && elements.length() > line_length_maximum) {
+			elements = parse_array_elements(p_node, p_indent_level + indent_mod, p_break_type);
+		}
+	}
+
+	array_string += elements;
+
+	for (int i = 0; i < p_node->footer_comments.size(); ++i) {
+		array_string += indent(p_indent_level + 1);
+		array_string += "# ";
+		array_string += p_node->footer_comments[i];
+	}
+	if (p_break_type != NONE || !p_node->footer_comments.is_empty()) {
+		array_string += indent(p_indent_level);
+	}
+	array_string += "]";
+
+	StringBuilder output;
+	output += print_comment(p_node, true, p_indent_level);
+	output += array_string;
+	output += print_comment(p_node, false);
+
+	return output;
+}
+
+String GDScriptFormat::parse_dictionary_element(const GDP::ExpressionNode *p_key, const GDP::ExpressionNode *p_value, const bool p_is_lua, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+	output += print_comment(p_key, true, p_indent_level);
+	output += print_comment(p_value, true, p_indent_level);
+	output += parse_expression(p_key, p_indent_level);
+	if (p_is_lua) {
+		output += " = ";
+	} else {
+		output += ": ";
+	}
+
+	output += parse_expression(p_value, p_indent_level, p_break_type);
+
+	return output;
+}
+
+String GDScriptFormat::parse_dictionary_elements(const GDP::DictionaryNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+
+	const bool is_lua = p_node->style == GDP::DictionaryNode::Style::LUA_TABLE;
+	for (int i = 0; i < p_node->elements.size(); ++i) {
+		const GDP::ExpressionNode *key = p_node->elements[i].key;
+		const GDP::ExpressionNode *value = p_node->elements[i].value;
+
+		if (p_break_type != NONE) {
+			output += indent(p_indent_level);
+		}
+
+		String element_string;
+		if (children_have_comments(p_node)) {
+			element_string = parse_dictionary_element(key, value, is_lua, p_indent_level, p_break_type);
+		} else {
+			element_string = parse_dictionary_element(key, value, is_lua, p_indent_level);
+			if (p_break_type != NONE && element_string.length() > line_length_maximum) {
+				element_string = parse_dictionary_element(key, value, is_lua, p_indent_level, p_break_type);
+			}
+		}
+
+		if (p_break_type != NONE || i < p_node->elements.size() - 1) {
+			element_string += ",";
+		}
+		if (p_break_type == NONE && i < p_node->elements.size() - 1) {
+			element_string += " ";
+		}
+
+		output += element_string;
+		output += print_comment(value, false);
+	}
+
+	return output;
+}
+
+String GDScriptFormat::parse_dictionary(const GDP::DictionaryNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder dictionary_string;
+	dictionary_string += "{";
+
+	int indent_mod = 0;
+	if (p_break_type != NONE) {
+		indent_mod = 1;
+	}
+
+	String elements;
+	if (children_have_comments(p_node) || !p_node->footer_comments.is_empty()) {
+		elements = parse_dictionary_elements(p_node, p_indent_level + 1, WRAP);
+	} else {
+		elements = parse_dictionary_elements(p_node, p_indent_level + indent_mod);
+		if (p_break_type != NONE && get_length_without_comments(elements) > line_length_maximum) {
+			elements = parse_dictionary_elements(p_node, p_indent_level + indent_mod, p_break_type);
+		} else if (p_break_type != NONE) {
+			dictionary_string += indent(p_indent_level + indent_mod);
+		}
+	}
+	dictionary_string += elements;
+
+	for (int i = 0; i < p_node->footer_comments.size(); ++i) {
+		dictionary_string += indent(p_indent_level + 1);
+		dictionary_string += "# ";
+		dictionary_string += p_node->footer_comments[i];
+	}
+	if (p_break_type == WRAP || !p_node->footer_comments.is_empty()) {
+		dictionary_string += indent(p_indent_level);
+	}
+	dictionary_string += "}";
+
+	StringBuilder output;
+	output += print_comment(p_node, true, p_indent_level);
+	output += dictionary_string;
+	output += print_comment(p_node, false);
+
+	return output;
+}
+
+String GDScriptFormat::parse_assignment(const GDP::AssignmentNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+	output += print_comment(p_node, true, p_indent_level);
+	output += parse_expression(p_node->assignee, p_indent_level, p_break_type);
+
+	switch (p_node->operation) {
+		case GDP::AssignmentNode::Operation::OP_NONE:
+			output += " = ";
+			break;
+		case GDP::AssignmentNode::Operation::OP_ADDITION:
+			output += " += ";
+			break;
+		case GDP::AssignmentNode::Operation::OP_SUBTRACTION:
+			output += " -= ";
+			break;
+		case GDP::AssignmentNode::Operation::OP_MULTIPLICATION:
+			output += " *= ";
+			break;
+		case GDP::AssignmentNode::Operation::OP_DIVISION:
+			output += " /= ";
+			break;
+		case GDP::AssignmentNode::Operation::OP_MODULO:
+			output += " %= ";
+			break;
+		case GDP::AssignmentNode::Operation::OP_BIT_SHIFT_LEFT:
+			output += " <<= ";
+			break;
+		case GDP::AssignmentNode::Operation::OP_BIT_SHIFT_RIGHT:
+			output += " >>= ";
+			break;
+		case GDP::AssignmentNode::Operation::OP_BIT_AND:
+			output += " &= ";
+			break;
+		case GDP::AssignmentNode::Operation::OP_BIT_OR:
+			output += " |= ";
+			break;
+		case GDP::AssignmentNode::Operation::OP_BIT_XOR:
+			output += " ^= ";
+			break;
+		case GDScriptParser::AssignmentNode::OP_POWER:
+			output += " **= ";
+			break;
+	}
+	output += parse_expression(p_node->assigned_value, p_indent_level, p_break_type);
+	output += print_comment(p_node, false);
+	if (p_node->assigned_value->type == GDP::Node::Type::LITERAL || p_node->assigned_value->type == GDP::Node::Type::IDENTIFIER || p_node->assigned_value->type == GDP::Node::Type::SELF) {
+		output += print_comment(p_node->assigned_value, false);
+	}
+
+	if (p_break_type == NONE && output.as_string().length() > line_length_maximum) {
+		output = StringBuilder();
+		output += parse_assignment(p_node, p_indent_level, WRAP);
+	}
+
+	return output;
+}
+
+String GDScriptFormat::indent(const int p_count, const bool p_newline) {
+	StringBuilder output;
+	if (p_newline) {
+		output += "\n";
+	}
+	if (tab_type == 0) {
+		for (int i = 0; i < p_count; ++i) {
+			output += "\t";
+		}
+	} else {
+		for (int i = 0; i < p_count * tab_size; ++i) {
+			output += " ";
+		}
+	}
+	return output;
+}
+
+String GDScriptFormat::parse_preload(const GDP::PreloadNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+	output += "preload(";
+	const bool path_has_comment = !p_node->path->inline_comment.is_empty();
+	if (path_has_comment || p_break_type != NONE) {
+		output += indent(p_indent_level + 1);
+	}
+	output += parse_expression(p_node->path, p_indent_level, p_break_type);
+	output += print_comment(p_node->path, false);
+	if (path_has_comment || p_break_type != NONE) {
+		output += indent(p_indent_level);
+	}
+	output += ")";
+
+	output += print_comment(p_node, false);
+
+	return output;
+}
+
+String GDScriptFormat::parse_call_arguments(const Vector<GDP::ExpressionNode *> &p_nodes, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+	for (int i = 0; i < p_nodes.size(); ++i) {
+		if (p_break_type != NONE) {
+			if (p_nodes[i]->type != GDP::Node::ARRAY && p_nodes[i]->type != GDP::Node::DICTIONARY) {
+				output += indent(p_indent_level);
+			}
+		}
+
+		int indent_mod = 0;
+		if (p_nodes[i]->type == GDP::Node::ARRAY || p_nodes[i]->type == GDP::Node::DICTIONARY) {
+			indent_mod = 1;
+		}
+
+		String parameter_string;
+		if (children_have_comments(p_nodes[i])) {
+			parameter_string = parse_expression(p_nodes[i], p_indent_level - indent_mod, p_break_type);
+		} else {
+			parameter_string = parse_expression(p_nodes[i], p_indent_level);
+			if (p_break_type != NONE && parameter_string.length() > line_length_maximum) {
+				parameter_string = parse_expression(p_nodes[i], p_indent_level - indent_mod, p_break_type);
+			}
+		}
+		output += print_comment(p_nodes[i], true, p_indent_level);
+		output += parameter_string;
+
+		if (i < p_nodes.size() - 1) {
+			output += ",";
+			if (p_break_type == NONE) {
+				output += " ";
+			}
+		}
+		output += print_comment(p_nodes[i], false);
+	}
+
+	return output;
+}
+
+String GDScriptFormat::parse_call(const GDP::CallNode *p_node, const int p_indent_level, const BreakType p_break_type) {
+	StringBuilder output;
+	output += print_comment(p_node, true, p_indent_level);
+
+	if (p_node->is_super) {
+		output += "super";
+		if (p_node->get_callee_type() != GDP::Node::Type::NONE) {
+			output += ".";
+			output += parse_expression(p_node->callee, p_indent_level);
+		}
+	} else {
+		output += parse_expression(p_node->callee, p_indent_level);
+	}
+	output += "(";
+
+	bool break_string = false;
+	int indent_mod = 0;
+	if (p_break_type != NONE) {
+		indent_mod = indent_in_multiline_block;
+	}
+
+	String parameters_string;
+	if (children_have_comments(p_node) || !p_node->params_footer_comment.is_empty()) {
+		parameters_string = parse_call_arguments(p_node->arguments, p_indent_level + indent_in_multiline_block, WRAP);
+		break_string = true;
+	} else {
+		parameters_string = parse_call_arguments(p_node->arguments, p_indent_level + indent_mod);
+		if (p_break_type != NONE && parameters_string.length() > line_length_maximum) {
+			break_string = true;
+			parameters_string = parse_call_arguments(p_node->arguments, p_indent_level + indent_mod, p_break_type);
+		}
+	}
+
+	if (!break_string && p_break_type != NONE) {
+		output += indent(p_indent_level + indent_in_multiline_block);
+	}
+	output += parameters_string;
+
+	for (int i = 0; i < p_node->params_footer_comment.size(); ++i) {
+		output += indent(p_indent_level + indent_in_multiline_block);
+		output += "# ";
+		output += p_node->params_footer_comment[i];
+		if (i == p_node->params_footer_comment.size() - 1) {
+			output += indent(p_indent_level);
+		}
+	}
+
+	if (p_break_type != NONE || break_string) {
+		const String indent_checker = p_indent_level > 0 ? "\t" : "\n";
+		if (!output.as_string().ends_with(indent_checker)) {
+			bool skip_indent = false;
+			if (!p_node->arguments.is_empty()) {
+				const GDP::Node *last_argument = p_node->arguments[p_node->arguments.size() - 1];
+				if (last_argument->type == GDP::Node::ARRAY || last_argument->type == GDP::Node::DICTIONARY) {
+					skip_indent = true;
+				}
+			}
+			if (!skip_indent) {
+				output += indent(p_indent_level);
+			}
+		}
+	}
+	output += ")";
+	output += print_comment(p_node, false);
+
+	return output;
+}

--- a/modules/gdscript/gdscript_format.cpp
+++ b/modules/gdscript/gdscript_format.cpp
@@ -2117,7 +2117,7 @@ String GDScriptFormat::parse_assignment(const GDP::AssignmentNode *p_node, const
 		output += print_comment(p_node->assigned_value, false);
 	}
 
-	if (p_break_type == NONE && output.as_string().length() > line_length_maximum) {
+	if (p_break_type == NONE && get_length_without_comments(output.as_string()) > line_length_maximum) {
 		output = StringBuilder();
 		output += parse_assignment(p_node, p_indent_level, WRAP);
 	}

--- a/modules/gdscript/gdscript_format.cpp
+++ b/modules/gdscript/gdscript_format.cpp
@@ -2112,7 +2112,8 @@ String GDScriptFormat::parse_call_arguments(const Vector<GDP::ExpressionNode *> 
 		output += print_comment(node, true, p_indent_level);
 		output += parameter_string;
 
-		if (i < p_nodes.size() - 1 || p_break_type != NONE) {
+		// TODO: handle trailing comma here:
+		if (i < p_nodes.size() - 1) {
 			output += ",";
 			if (p_break_type == NONE) {
 				output += " ";

--- a/modules/gdscript/gdscript_format.cpp
+++ b/modules/gdscript/gdscript_format.cpp
@@ -310,8 +310,11 @@ String GDScriptFormat::parse_class_variable(const GDP::ClassNode *p_node, const 
 	bool did_break = false;
 
 	if (children_have_comments(p_node->members[p_member_index].variable) && is_nestable_statement(p_node->members[p_member_index].variable->initializer)) {
-		variable_string = parse_variable(p_node->members[p_member_index].variable, p_indent_level, WRAP);
-		did_break = get_length_without_comments(variable_string) > line_length_maximum || variable_string.contains("\n");
+		variable_string = parse_variable(p_node->members[p_member_index].variable, p_indent_level, NONE);
+		if (get_length_without_comments(variable_string) > line_length_maximum || variable_string.contains("\n")) {
+			variable_string = parse_variable(p_node->members[p_member_index].variable, p_indent_level, WRAP);
+			did_break = get_length_without_comments(variable_string) > line_length_maximum || variable_string.contains("\n");
+		}
 	} else {
 		variable_string = parse_variable(p_node->members[p_member_index].variable, p_indent_level, NONE);
 		if (get_length_without_comments(variable_string) > line_length_maximum) {
@@ -693,7 +696,11 @@ String GDScriptFormat::parse_var_value(const GDP::ExpressionNode *p_node, const 
 	StringBuilder output;
 	output += comment_headers;
 	output += value;
-	output += comment;
+
+	// Expressions can themselves write comments (eg. function calls comments)
+	if (!output.as_string().ends_with(comment)) {
+		output += comment;
+	}
 
 	return output;
 }

--- a/modules/gdscript/gdscript_format.cpp
+++ b/modules/gdscript/gdscript_format.cpp
@@ -433,6 +433,20 @@ String GDScriptFormat::parse_class(const GDP::ClassNode *p_node, const int p_ind
 		}
 		int indent_mod = p_node->outer != nullptr ? 1 : 0;
 		for (int i = 0; i < p_node->members.size(); ++i) {
+			// Section newlines
+			switch (p_node->members[i].type) {
+				case GDP::ClassNode::Member::Type::FUNCTION: {
+					if (i > 0 && p_node->members[i - 1].type != GDP::ClassNode::Member::Type::FUNCTION) {
+						while (!output.as_string().ends_with("\n\n\n")) {
+							output += "\n";
+						}
+					}
+				} break;
+				default: {
+					// do nothing
+				}
+			}
+
 			bool skip_newline = false;
 			if (p_node->outer != nullptr) {
 				output += indent(p_indent_level + 1, false);
@@ -458,11 +472,6 @@ String GDScriptFormat::parse_class(const GDP::ClassNode *p_node, const int p_ind
 					}
 				} break;
 				case GDP::ClassNode::Member::Type::FUNCTION:
-					if (i > 0 && p_node->members[i - 1].type != GDP::ClassNode::Member::Type::FUNCTION) {
-						while (!output.as_string().ends_with("\n\n\n")) {
-							output += "\n";
-						}
-					}
 					if (!p_node->members[i].function->annotations.is_empty()) {
 						output += parse_annotations(p_node->members[i].function->annotations, p_indent_level + indent_mod, SPLIT);
 					}
@@ -1570,7 +1579,7 @@ String GDScriptFormat::parse_get_node(const GDP::GetNodeNode *p_node, const int 
 		output += "\"";
 		append = "\"";
 	}
-	
+
 	output += full_path;
 	output += append;
 	return output;

--- a/modules/gdscript/gdscript_format.cpp
+++ b/modules/gdscript/gdscript_format.cpp
@@ -1551,13 +1551,35 @@ String GDScriptFormat::parse_subscript(const GDP::SubscriptNode *p_node, const i
 
 String GDScriptFormat::parse_get_node(const GDP::GetNodeNode *p_node, const int p_indent_level) {
 	StringBuilder output;
-	output += "$";
 	String append;
-	if ((p_node->full_path[0] < 65 || p_node->full_path[0] > 90) && (p_node->full_path[0] < 97 || p_node->full_path[0] > 122) && !p_node->full_path.begins_with("_")) {
+	String full_path = p_node->full_path;
+	bool wrap = false;
+	
+	if (full_path.get(0) == '%') {
+		output += "%";
+		full_path = full_path.substr(1);
+	} else {
+		output += "$";
+	}
+	char32_t *full_path_chars = full_path.ptrw();
+
+	if (!is_unicode_identifier_start(full_path_chars[0]) && full_path_chars[0] != '%') {
+		wrap = true;
+	}
+	if (!wrap) {
+		for (int i = 1; i < full_path.length(); i++) {
+			if (!is_unicode_identifier_continue(full_path_chars[i]) && full_path_chars[i] != '/') {
+				wrap = true;
+				break;
+			}
+		}
+	}
+	if (wrap) {
 		output += "\"";
 		append = "\"";
 	}
-	output += p_node->full_path;
+	
+	output += full_path;
 	output += append;
 	return output;
 }

--- a/modules/gdscript/gdscript_format.cpp
+++ b/modules/gdscript/gdscript_format.cpp
@@ -2055,7 +2055,7 @@ String GDScriptFormat::parse_dictionary(const GDP::DictionaryNode *p_node, const
 		dictionary_string += "# ";
 		dictionary_string += p_node->footer_comments[i];
 	}
-	if (p_break_type == WRAP || !p_node->footer_comments.is_empty()) {
+	if (children_have_comments(p_node) || !p_node->footer_comments.is_empty()) {
 		dictionary_string += indent(p_indent_level);
 	}
 	dictionary_string += "}";

--- a/modules/gdscript/gdscript_format.cpp
+++ b/modules/gdscript/gdscript_format.cpp
@@ -325,14 +325,6 @@ String GDScriptFormat::parse_class_variable(const GDP::ClassNode *p_node, const 
 	if (!p_node->members[p_member_index].variable->annotations.is_empty()) {
 		String annotation_string;
 		if (!did_break) {
-			for (GDScriptParser::AnnotationNode *&annotation : p_node->members[p_member_index].variable->annotations) {
-				if (String(annotation->name).find("_") > -1) {
-					did_break = true;
-					break;
-				}
-			}
-		}
-		if (!did_break) {
 			annotation_string = parse_annotations(p_node->members[p_member_index].variable->annotations, p_indent_level);
 			if (get_length_without_comments(annotation_string) + get_length_without_comments(variable_string) > line_length_maximum) {
 				annotation_string = parse_annotations(p_node->members[p_member_index].variable->annotations, p_indent_level, SPLIT);

--- a/modules/gdscript/gdscript_format.cpp
+++ b/modules/gdscript/gdscript_format.cpp
@@ -58,8 +58,8 @@ Error GDScriptFormat::format(const String &p_code, String &r_formatted_code) {
 
 	if (err != OK) {
 		parser_errors.clear();
-		for (GDScriptParser::ParserError err : parser.get_errors()) {
-			parser_errors.push_back({ vformat("%s", err.message), err.line, err.column });
+		for (GDScriptParser::ParserError parser_error : parser.get_errors()) {
+			parser_errors.push_back({ vformat("%s", parser_error.message), parser_error.line, parser_error.column });
 		}
 		return FAILED;
 	}

--- a/modules/gdscript/gdscript_format.cpp
+++ b/modules/gdscript/gdscript_format.cpp
@@ -436,7 +436,7 @@ String GDScriptFormat::parse_class(const GDP::ClassNode *p_node, const int p_ind
 		}
 		int indent_mod = p_node->outer != nullptr ? 1 : 0;
 		for (int i = 0; i < p_node->members.size(); ++i) {
-			// Section newlines
+			// Section newlines.
 			switch (p_node->members[i].type) {
 				case GDP::ClassNode::Member::Type::FUNCTION: {
 					if (i > 0 && p_node->members[i - 1].type != GDP::ClassNode::Member::Type::FUNCTION) {
@@ -446,7 +446,7 @@ String GDScriptFormat::parse_class(const GDP::ClassNode *p_node, const int p_ind
 					}
 				} break;
 				default: {
-					// do nothing
+					// Do nothing.
 				}
 			}
 
@@ -697,7 +697,7 @@ String GDScriptFormat::parse_var_value(const GDP::ExpressionNode *p_node, const 
 	output += comment_headers;
 	output += value;
 
-	// Expressions can themselves write comments (eg. function calls comments)
+	// Expressions can themselves write comments (eg. function calls comments).
 	if (!output.as_string().ends_with(comment)) {
 		output += comment;
 	}
@@ -1699,8 +1699,8 @@ String GDScriptFormat::parse_binary_operator(const GDP::BinaryOpNode *p_node, co
 	bool split = false;
 	StringBuilder left_operand, right_operand;
 
-	// Check if the binary operands have comments (if we need to split the expression)
-	// In the binary tree, only the rightmost node can have a comment to not split
+	// Check if the binary operands have comments (if we need to split the expression).
+	// In the binary tree, only the rightmost node can have a comment to not split.
 	if (children_have_comments(p_node)) {
 		const GDP::BinaryOpNode *right_node = p_node;
 		while (right_node) {

--- a/modules/gdscript/gdscript_format.cpp
+++ b/modules/gdscript/gdscript_format.cpp
@@ -2044,15 +2044,21 @@ String GDScriptFormat::parse_dictionary(const GDP::DictionaryNode *p_node, const
 		indent_mod = 1;
 	}
 
+	int indent_size = (p_indent_level + indent_mod) * tab_size;
+	bool wrap_content = false;
+
 	String elements;
 	if (children_have_comments(p_node) || !p_node->footer_comments.is_empty()) {
 		elements = parse_dictionary_elements(p_node, p_indent_level + 1, WRAP);
+		wrap_content = true;
 	} else {
-		elements = parse_dictionary_elements(p_node, p_indent_level + indent_mod);
-		if (p_break_type != NONE && get_length_without_comments(elements) > line_length_maximum) {
+		elements = parse_dictionary_elements(p_node, 0);
+		if (p_break_type != NONE && indent_size + get_length_without_comments(elements) > line_length_maximum) {
 			elements = parse_dictionary_elements(p_node, p_indent_level + indent_mod, p_break_type);
+			wrap_content = true;
 		} else if (p_break_type != NONE) {
 			dictionary_string += indent(p_indent_level + indent_mod);
+			wrap_content = true;
 		}
 	}
 	dictionary_string += elements;
@@ -2062,7 +2068,7 @@ String GDScriptFormat::parse_dictionary(const GDP::DictionaryNode *p_node, const
 		dictionary_string += "# ";
 		dictionary_string += p_node->footer_comments[i];
 	}
-	if (children_have_comments(p_node) || !p_node->footer_comments.is_empty()) {
+	if (wrap_content) {
 		dictionary_string += indent(p_indent_level);
 	}
 	dictionary_string += "}";

--- a/modules/gdscript/gdscript_format.cpp
+++ b/modules/gdscript/gdscript_format.cpp
@@ -1716,29 +1716,29 @@ String GDScriptFormat::parse_binary_operator(const GDP::BinaryOpNode *p_node, co
 		break_string = true;
 
 		if (p_node->left_operand->type == GDP::Node::Type::BINARY_OPERATOR) {
-			left_operand += parse_binary_operator_element(p_node->left_operand, p_indent_level + (p_indent_level == 0 ? indent_in_multiline_block : 0) + 1, FORCE_SPLIT);
+			left_operand += parse_binary_operator_element(p_node->left_operand, p_indent_level + (p_indent_level == 0 ? indent_in_multiline_block : 0), FORCE_SPLIT);
 		} else {
-			left_operand += parse_binary_operator_element(p_node->left_operand, p_indent_level + 1, WRAP);
+			left_operand += parse_binary_operator_element(p_node->left_operand, p_indent_level, WRAP);
 		}
 		String left_operand_string = left_operand.as_string();
 		left_operand = StringBuilder();
-		left_operand += print_comment(p_node->left_operand, true, p_indent_level + 1);
+		left_operand += print_comment(p_node->left_operand, true, p_indent_level);
 		left_operand += left_operand_string;
-		left_operand += print_comment(p_node->left_operand, false, p_indent_level + 1);
+		left_operand += print_comment(p_node->left_operand, false, p_indent_level);
 
 		if (p_node->right_operand->type == GDP::Node::Type::BINARY_OPERATOR) {
-			right_operand += parse_binary_operator_element(p_node->right_operand, p_indent_level + (p_indent_level == 0 ? indent_in_multiline_block : 0) + 1, FORCE_SPLIT);
+			right_operand += parse_binary_operator_element(p_node->right_operand, p_indent_level + (p_indent_level == 0 ? indent_in_multiline_block : 0), FORCE_SPLIT);
 		} else {
-			right_operand += parse_binary_operator_element(p_node->right_operand, p_indent_level + 1, WRAP);
+			right_operand += parse_binary_operator_element(p_node->right_operand, p_indent_level, WRAP);
 		}
 		String right_operand_string = right_operand.as_string();
 		right_operand = StringBuilder();
-		right_operand += print_comment(p_node->right_operand, true, p_indent_level + 1);
+		right_operand += print_comment(p_node->right_operand, true, p_indent_level);
 		right_operand += right_operand_string;
-		right_operand += print_comment(p_node->right_operand, false, p_indent_level + 1);
+		right_operand += print_comment(p_node->right_operand, false, p_indent_level);
 	} else {
-		left_operand += parse_binary_operator_element(p_node->left_operand, p_indent_level + 1);
-		right_operand += parse_binary_operator_element(p_node->right_operand, p_indent_level + 1);
+		left_operand += parse_binary_operator_element(p_node->left_operand, p_indent_level);
+		right_operand += parse_binary_operator_element(p_node->right_operand, p_indent_level);
 		if (p_break_type != NONE && get_length_without_comments(left_operand) + get_length_without_comments(right_operand) + get_length_without_comments(operator_string) + 1 > line_length_maximum) {
 			break_string = true;
 			left_operand = StringBuilder();

--- a/modules/gdscript/gdscript_format.h
+++ b/modules/gdscript/gdscript_format.h
@@ -1,0 +1,204 @@
+/**************************************************************************/
+/*  gdscript_format.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef GDSCRIPT_FORMAT_H
+#define GDSCRIPT_FORMAT_H
+
+#include "core/string/ustring.h"
+#include "gdscript_parser.h"
+
+using GDP = GDScriptParser;
+
+class GDScriptFormat {
+private:
+	enum BreakType {
+		NONE,
+		WRAP,
+		SPLIT,
+		FORCE_SPLIT,
+	};
+
+	typedef String (GDScriptFormat::*ParserFunc)(GDP::Node *, int, BreakType);
+	HashSet<int> new_lines;
+
+private:
+	static bool node_has_comments(const GDP::Node *p_node);
+	static bool children_have_comments(const GDP::Node *p_parent);
+
+	static int get_operation_priority(const GDP::BinaryOpNode::OpType p_op_type) {
+		switch (p_op_type) {
+			case GDP::BinaryOpNode::OpType::OP_MULTIPLICATION:
+			case GDP::BinaryOpNode::OpType::OP_DIVISION:
+			case GDP::BinaryOpNode::OpType::OP_MODULO:
+			case GDP::BinaryOpNode::OpType::OP_POWER:
+				return 0;
+			case GDP::BinaryOpNode::OpType::OP_ADDITION:
+			case GDP::BinaryOpNode::OpType::OP_SUBTRACTION:
+				return 1;
+			case GDP::BinaryOpNode::OpType::OP_BIT_LEFT_SHIFT:
+			case GDP::BinaryOpNode::OpType::OP_BIT_RIGHT_SHIFT:
+				return 2;
+			case GDP::BinaryOpNode::OpType::OP_COMP_LESS:
+			case GDP::BinaryOpNode::OpType::OP_COMP_LESS_EQUAL:
+			case GDP::BinaryOpNode::OpType::OP_COMP_GREATER:
+			case GDP::BinaryOpNode::OpType::OP_COMP_GREATER_EQUAL:
+				return 3;
+			case GDP::BinaryOpNode::OpType::OP_CONTENT_TEST:
+			case GDP::BinaryOpNode::OpType::OP_COMP_EQUAL:
+			case GDP::BinaryOpNode::OpType::OP_COMP_NOT_EQUAL:
+				return 4;
+			case GDP::BinaryOpNode::OpType::OP_BIT_AND:
+				return 5;
+			case GDP::BinaryOpNode::OpType::OP_BIT_XOR:
+				return 6;
+			case GDP::BinaryOpNode::OpType::OP_BIT_OR:
+				return 7;
+			case GDP::BinaryOpNode::OpType::OP_LOGIC_AND:
+				return 8;
+			case GDP::BinaryOpNode::OpType::OP_LOGIC_OR:
+				return 9;
+		}
+
+		return 10;
+	}
+
+	static bool is_nestable_statement(const GDP::Node *p_node) {
+		bool nestable_statement = true;
+		if (p_node != nullptr) {
+			switch (p_node->type) {
+				case GDP::Node::Type::TYPE:
+				case GDP::Node::Type::CAST:
+				case GDP::Node::Type::LITERAL:
+				case GDP::Node::Type::ASSIGNMENT:
+				case GDP::Node::Type::IDENTIFIER:
+				case GDP::Node::Type::GET_NODE:
+				case GDP::Node::Type::SELF:
+					nestable_statement = false;
+					break;
+				default:
+					break;
+			}
+		}
+
+		return nestable_statement;
+	}
+
+	static bool should_not_hold_comments(const GDP::Node *p_node) {
+		return p_node->type == GDP::Node::Type::BINARY_OPERATOR || p_node->type == GDP::Node::Type::TERNARY_OPERATOR || p_node->type == GDP::Node::Type::SUITE;
+	}
+
+	static bool has_special_line_wrapping(const GDP::Node *p_node) {
+		return p_node != nullptr && p_node->type == GDP::Node::Type::ASSERT;
+	}
+
+	static int get_length_without_comments(const String &p_string);
+
+	static String parse_literal(const GDP::LiteralNode *p_node);
+	static String parse_get_node(const GDP::GetNodeNode *p_node, int p_indent_level = 0);
+
+	String indent(int p_count, bool p_newline = true);
+	String print_comment(const GDP::Node *p_node, bool p_headers, int p_indent_level = 0);
+	void find_custom_newlines(const String &p_code);
+	String make_disabled_lines_from_headers(const String &p_input) const;
+
+	String parse_type(const GDP::TypeNode *p_node);
+
+	String parse_class(const GDP::ClassNode *p_node, int p_indent_level = 0);
+	String parse_class_variable(const GDP::ClassNode *p_node, int p_indent_level, int p_member_index);
+
+	String parse_expression(const GDP::ExpressionNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_suite(const GDP::SuiteNode *p_node, int p_indent_level = 0);
+
+	String parse_var_value(const GDP::ExpressionNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_constant(const GDP::ConstantNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_signal(const GDP::SignalNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+
+	String parse_annotations(const List<GDP::AnnotationNode *> &p_annotations, int p_indent_level = 0, BreakType p_break_type = NONE);
+
+	String parse_property(const GDP::VariableNode *p_node, int p_indent_level = 0);
+	String parse_variable(const GDP::VariableNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_variable_with_comments(const GDP::VariableNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+
+	String parse_binary_operator_element(const GDP::ExpressionNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_binary_operator(const GDP::BinaryOpNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+
+	String parse_array_element(const GDP::ExpressionNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_array_elements(const GDP::ArrayNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_array(const GDP::ArrayNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+
+	String parse_dictionary_element(const GDP::ExpressionNode *p_key, const GDP::ExpressionNode *p_value, bool p_is_lua, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_dictionary_elements(const GDP::DictionaryNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_dictionary(const GDP::DictionaryNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+
+	String parse_assignment(const GDP::AssignmentNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+
+	String parse_call_arguments(const Vector<GDP::ExpressionNode *> &p_nodes, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_call(const GDP::CallNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+
+	String parse_cast(const GDP::CastNode *p_node, int p_indent_level = 0);
+	String parse_await(const GDP::AwaitNode *p_node, int p_indent_level = 0);
+	String parse_subscript(const GDP::SubscriptNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_preload(const GDP::PreloadNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_ternary_op(const GDP::TernaryOpNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_type_test(const GDP::TypeTestNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_unary_op(const GDP::UnaryOpNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_lambda(const GDP::LambdaNode *p_node, int p_indent_level = 0);
+
+	String parse_assert(const GDP::AssertNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_return(const GDP::ReturnNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_if(const GDP::IfNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_while(const GDP::WhileNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_for(const GDP::ForNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+
+	String parse_enum_elements(const GDP::EnumNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_enum(const GDP::EnumNode *p_node, int p_indent_level = 0);
+
+	String parse_match_pattern(const GDP::PatternNode *p_node, int p_indent_level = 0);
+	String parse_match_branch(const GDP::MatchBranchNode *p_node, int p_indent_level = 0);
+	String parse_match(const GDP::MatchNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+
+	String parse_function(const GDP::FunctionNode *p_node, int p_indent_level = 0);
+	String parse_function_signature(const GDP::FunctionNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_parameters(const Vector<GDP::ParameterNode *> &p_nodes, int p_indent_level = 0, BreakType p_break_type = NONE);
+	String parse_parameter(const GDP::ParameterNode *p_node, int p_indent_level = 0, BreakType p_break_type = NONE);
+
+public:
+	int line_length_maximum;
+	int tab_size;
+	int tab_type;
+	int lines_between_functions;
+	int indent_in_multiline_block;
+
+	GDScriptFormat();
+
+	String format(const String &p_code);
+};
+
+#endif // GDSCRIPT_FORMAT_H

--- a/modules/gdscript/gdscript_format.h
+++ b/modules/gdscript/gdscript_format.h
@@ -51,7 +51,7 @@ private:
 
 private:
 	static bool node_has_comments(const GDP::Node *p_node);
-	static bool children_have_comments(const GDP::Node *p_parent);
+	static bool children_have_comments(const GDP::Node *p_parent, bool p_recursive = true);
 
 	static int get_operation_priority(const GDP::BinaryOpNode::OpType p_op_type) {
 		switch (p_op_type) {

--- a/modules/gdscript/gdscript_format.h
+++ b/modules/gdscript/gdscript_format.h
@@ -47,6 +47,7 @@ private:
 
 	typedef String (GDScriptFormat::*ParserFunc)(GDP::Node *, int, BreakType);
 	HashSet<int> new_lines;
+	List<GDScriptParser::ParserError> parser_errors;
 
 private:
 	static bool node_has_comments(const GDP::Node *p_node);
@@ -198,7 +199,8 @@ public:
 
 	GDScriptFormat();
 
-	String format(const String &p_code);
+	Error format(const String &p_code, String &r_formatted_code);
+	List<GDScriptParser::ParserError> get_parser_errors() { return parser_errors; };
 };
 
 #endif // GDSCRIPT_FORMAT_H

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2754,6 +2754,7 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_literal(ExpressionNode *p_
 	LiteralNode *literal = alloc_node<LiteralNode>();
 	complete_extents(literal);
 	literal->value = previous.literal;
+	literal->source = previous.source;
 	if (check(GDScriptTokenizer::Token::COMMENT)) {
 		literal->inline_comment = check_for_comment();
 	}

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2661,7 +2661,10 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_precedence(Precedence p_pr
 	advance(); // Only consume the token if there's a valid rule.
 
 	Vector<String> header_comment_block;
-	if (check(GDScriptTokenizer::Token::COMMENT) && (previous.start_line != current.start_line || previous.type == GDScriptTokenizer::Token::PARENTHESIS_OPEN)) {
+	bool check_is_comment = check(GDScriptTokenizer::Token::COMMENT);
+	bool new_line_or_previous_is_parenthesis = (previous.start_line != current.start_line || previous.type == GDScriptTokenizer::Token::PARENTHESIS_OPEN);
+	bool previous_is_not_open_bracket_brace = !(previous.type == GDScriptTokenizer::Token::BRACKET_OPEN || previous.type == GDScriptTokenizer::Token::BRACE_OPEN);
+	if (check_is_comment && new_line_or_previous_is_parenthesis && previous_is_not_open_bracket_brace) {
 		header_comment_block = check_for_comment_block();
 
 		if (current.type == GDScriptTokenizer::Token::BRACKET_CLOSE || current.type == GDScriptTokenizer::Token::PARENTHESIS_CLOSE || current.type == GDScriptTokenizer::Token::BRACE_CLOSE) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -37,7 +37,6 @@
 #endif
 
 #include "core/config/project_settings.h"
-#include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
 #include "core/math/math_defs.h"
 #include "scene/main/multiplayer_api.h"
@@ -45,6 +44,9 @@
 #ifdef DEBUG_ENABLED
 #include "core/os/os.h"
 #include "core/string/string_builder.h"
+#include "gdscript.h"
+#include "gdscript_tokenizer.h"
+#include "gdscript_warning.h"
 #include "servers/text_server.h"
 #endif
 
@@ -215,6 +217,69 @@ void GDScriptParser::push_warning(const Node *p_source, GDScriptWarning::Code p_
 }
 #endif
 
+String GDScriptParser::turn_disabled_lines_into_headers(const String &p_source) {
+	Vector<String> lines = p_source.split("\n");
+	int tab_size = 4;
+#ifdef TOOLS_ENABLED
+	if (EditorSettings::get_singleton()) {
+		tab_size = EditorSettings::get_singleton()->get_setting("text_editor/behavior/indent/size");
+	}
+#endif // TOOLS_ENABLED
+
+	String indent_char = "";
+	for (int i = 0; i < lines.size(); ++i) {
+		if (!lines[i].begins_with("#")) {
+			continue;
+		}
+		Vector<int> lines_to_edit;
+		while (lines[i].begins_with("#")) {
+			lines_to_edit.push_back(i);
+			if (i == lines.size() - 1) {
+				break;
+			}
+			i++;
+		}
+		int next_indent_count = 0;
+		if (i < lines.size()) {
+			for (int c = 0; c < lines[i].length(); ++c) {
+				if (lines[i][c] == '\t') {
+					if (indent_char.is_empty()) {
+						indent_char = "\t";
+					} else if (indent_char == " ") {
+						return p_source;
+					}
+					next_indent_count += tab_size;
+				} else if (lines[i][c] == ' ') {
+					if (indent_char.is_empty()) {
+						indent_char = " ";
+					} else if (indent_char == "\t") {
+						return p_source;
+					}
+					next_indent_count += 1;
+				} else {
+					break;
+				}
+			}
+		}
+
+		if (next_indent_count == 0) {
+			continue;
+		}
+
+		const int indent_count = next_indent_count / (indent_char == "\t" ? tab_size : 1);
+
+		for (const int l : lines_to_edit) {
+			StringBuilder builder;
+			builder += String(indent_char).repeat(indent_count);
+			builder += "#DIS";
+			builder += lines[l];
+			lines.write[l] = builder;
+		}
+	}
+
+	return String("\n").join(lines) + "\n";
+}
+
 void GDScriptParser::make_completion_context(CompletionType p_type, Node *p_node, int p_argument, bool p_force) {
 	if (!for_completion || (!p_force && completion_context.type != COMPLETION_NONE)) {
 		return;
@@ -280,6 +345,14 @@ void GDScriptParser::set_last_completion_call_arg(int p_argument) {
 }
 
 Error GDScriptParser::parse(const String &p_source_code, const String &p_script_path, bool p_for_completion) {
+	if (OS::get_singleton()->is_stdout_verbose()) {
+		if (p_script_path.is_empty()) {
+			print_line("Parsing: \"\n" + p_source_code + "\n\"");
+		} else {
+			print_line("Parsing " + p_script_path);
+		}
+	}
+
 	clear();
 
 	String source = p_source_code;
@@ -321,6 +394,8 @@ Error GDScriptParser::parse(const String &p_source_code, const String &p_script_
 		source = source.replace_first(String::chr(0xFFFF), String());
 	}
 
+	source = turn_disabled_lines_into_headers(source);
+
 	tokenizer.set_source_code(source);
 	tokenizer.set_cursor_position(cursor_line, cursor_column);
 	script_path = p_script_path;
@@ -332,6 +407,21 @@ Error GDScriptParser::parse(const String &p_source_code, const String &p_script_
 			push_error(current.literal);
 		}
 		current = tokenizer.scan();
+	}
+
+	// Check for empty files with only comments
+	if (current.type == GDScriptTokenizer::Token::COMMENT) {
+		while (current.type == GDScriptTokenizer::Token::COMMENT || current.type == GDScriptTokenizer::Token::NEWLINE) {
+			current = tokenizer.scan();
+		}
+		if (current.type != GDScriptTokenizer::Token::TK_EOF) {
+			tokenizer.set_source_code(source);
+			tokenizer.set_cursor_position(cursor_line, cursor_column);
+			current = tokenizer.scan();
+			while (current.type == GDScriptTokenizer::Token::ERROR || current.type == GDScriptTokenizer::Token::NEWLINE) {
+				current = tokenizer.scan();
+			}
+		}
 	}
 
 #ifdef DEBUG_ENABLED
@@ -502,14 +592,27 @@ void GDScriptParser::parse_program() {
 	head->fqcn = script_path;
 	current_class = head;
 	bool can_have_class_or_extends = true;
+	Vector<String> top_header_comment;
 
 	while (!check(GDScriptTokenizer::Token::TK_EOF)) {
-		if (match(GDScriptTokenizer::Token::ANNOTATION)) {
+		if (check(GDScriptTokenizer::Token::COMMENT)) {
+			top_header_comment = check_for_comment_block();
+		} else if (match(GDScriptTokenizer::Token::ANNOTATION)) {
 			AnnotationNode *annotation = parse_annotation(AnnotationInfo::SCRIPT | AnnotationInfo::STANDALONE | AnnotationInfo::CLASS_LEVEL);
 			if (annotation != nullptr) {
 				if (annotation->applies_to(AnnotationInfo::SCRIPT)) {
-					// `@icon` needs to be applied in the parser. See GH-72444.
+					// `@icon` and `@tool` need to be applied in the parser. See GH-72444.
 					if (annotation->name == SNAME("@icon")) {
+						head->icon_inline_comment = check_for_comment();
+						match(GDScriptTokenizer::Token::NEWLINE);
+						head->icon_header_comment = top_header_comment.duplicate();
+						top_header_comment.clear();
+						annotation->apply(this, head);
+					} else if (annotation->name == SNAME("@tool")) {
+						head->tool_inline_comment = check_for_comment();
+						match(GDScriptTokenizer::Token::NEWLINE);
+						head->tool_header_comment = top_header_comment.duplicate();
+						top_header_comment.clear();
 						annotation->apply(this, head);
 					} else {
 						head->annotations.push_back(annotation);
@@ -534,6 +637,10 @@ void GDScriptParser::parse_program() {
 		}
 	}
 
+	if (check(GDScriptTokenizer::Token::COMMENT)) {
+		top_header_comment = check_for_comment_block();
+	}
+
 	while (can_have_class_or_extends) {
 		// Order here doesn't matter, but there should be only one of each at most.
 		switch (current.type) {
@@ -542,6 +649,10 @@ void GDScriptParser::parse_program() {
 				if (head->identifier != nullptr) {
 					push_error(R"("class_name" can only be used once.)");
 				} else {
+					if (!top_header_comment.is_empty()) {
+						head->header_comment = top_header_comment;
+						top_header_comment.clear();
+					}
 					parse_class_name();
 				}
 				break;
@@ -550,6 +661,10 @@ void GDScriptParser::parse_program() {
 				if (head->extends_used) {
 					push_error(R"("extends" can only be used once.)");
 				} else {
+					if (!top_header_comment.is_empty()) {
+						head->extends_header_comment = top_header_comment;
+						top_header_comment.clear();
+					}
 					parse_extends();
 					end_statement("superclass");
 				}
@@ -570,9 +685,19 @@ void GDScriptParser::parse_program() {
 				break;
 		}
 
+		if (check(GDScriptTokenizer::Token::COMMENT)) {
+			top_header_comment = check_for_comment_block();
+		}
+
 		if (panic_mode) {
 			synchronize();
 		}
+	}
+
+	if (!top_header_comment.is_empty()) {
+		last_comment_block = top_header_comment;
+	} else if (check(GDScriptTokenizer::Token::COMMENT)) {
+		last_comment_block = check_for_comment_block();
 	}
 
 	parse_class_body(true);
@@ -669,7 +794,15 @@ GDScriptParser::ClassNode *GDScriptParser::parse_class(bool p_is_static) {
 
 	consume(GDScriptTokenizer::Token::COLON, R"(Expected ":" after class declaration.)");
 
+	if (check(GDScriptTokenizer::Token::COMMENT)) {
+		n_class->inline_comment = check_for_comment();
+	}
+
 	bool multiline = match(GDScriptTokenizer::Token::NEWLINE);
+
+	if (check(GDScriptTokenizer::Token::COMMENT)) {
+		last_comment_block.append_array(check_for_comment_block());
+	}
 
 	if (multiline && !consume(GDScriptTokenizer::Token::INDENT, R"(Expected indented block after class declaration.)")) {
 		current_class = previous_class;
@@ -709,6 +842,11 @@ void GDScriptParser::parse_class_name() {
 	} else {
 		end_statement("class_name statement");
 	}
+
+	if (!current_class->identifier->inline_comment.is_empty()) {
+		current_class->inline_comment = current_class->identifier->inline_comment;
+		current_class->identifier->inline_comment.clear();
+	}
 }
 
 void GDScriptParser::parse_extends() {
@@ -732,7 +870,9 @@ void GDScriptParser::parse_extends() {
 	if (!consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected superclass name after "extends".)")) {
 		return;
 	}
-	current_class->extends.push_back(parse_identifier());
+	IdentifierNode *identifier = parse_identifier();
+	current_class->extends_inline_comment = identifier->inline_comment;
+	current_class->extends.push_back(identifier);
 
 	while (match(GDScriptTokenizer::Token::PERIOD)) {
 		make_completion_context(COMPLETION_INHERIT_TYPE, current_class, chain_index++);
@@ -740,6 +880,10 @@ void GDScriptParser::parse_extends() {
 			return;
 		}
 		current_class->extends.push_back(parse_identifier());
+	}
+
+	if (check(GDScriptTokenizer::Token::COMMENT)) {
+		current_class->extends_inline_comment = check_for_comment();
 	}
 }
 
@@ -815,28 +959,58 @@ void GDScriptParser::parse_class_body(bool p_is_multiline) {
 	bool class_end = false;
 	bool next_is_static = false;
 	while (!class_end && !is_at_end()) {
+		Vector<String> member_comment_headers;
+		if (last_comment_block.is_empty()) {
+			member_comment_headers = check_for_comment_block();
+		} else {
+			member_comment_headers = last_comment_block;
+			last_comment_block.clear();
+		}
+
 		GDScriptTokenizer::Token token = current;
 		switch (token.type) {
 			case GDScriptTokenizer::Token::VAR:
 				parse_class_member(&GDScriptParser::parse_variable, AnnotationInfo::VARIABLE, "variable", next_is_static);
+				if (!current_class->members.is_empty()) {
+					current_class->members[current_class->members.size() - 1].variable->header_comment = member_comment_headers;
+				}
 				if (next_is_static) {
 					current_class->has_static_data = true;
 				}
 				break;
 			case GDScriptTokenizer::Token::CONST:
 				parse_class_member(&GDScriptParser::parse_constant, AnnotationInfo::CONSTANT, "constant");
+				if (!current_class->members.is_empty()) {
+					current_class->members[current_class->members.size() - 1].constant->header_comment = member_comment_headers;
+				}
 				break;
 			case GDScriptTokenizer::Token::SIGNAL:
 				parse_class_member(&GDScriptParser::parse_signal, AnnotationInfo::SIGNAL, "signal");
+				if (!current_class->members.is_empty()) {
+					current_class->members[current_class->members.size() - 1].signal->header_comment = member_comment_headers;
+				}
 				break;
 			case GDScriptTokenizer::Token::FUNC:
 				parse_class_member(&GDScriptParser::parse_function, AnnotationInfo::FUNCTION, "function", next_is_static);
+				if (!current_class->members.is_empty()) {
+					current_class->members[current_class->members.size() - 1].function->header_comment = member_comment_headers;
+				}
 				break;
 			case GDScriptTokenizer::Token::CLASS:
 				parse_class_member(&GDScriptParser::parse_class, AnnotationInfo::CLASS, "class");
+				if (!current_class->members.is_empty()) {
+					current_class->members[current_class->members.size() - 1].m_class->header_comment = member_comment_headers;
+				}
 				break;
 			case GDScriptTokenizer::Token::ENUM:
 				parse_class_member(&GDScriptParser::parse_enum, AnnotationInfo::NONE, "enum");
+				if (!current_class->members.is_empty()) {
+					if (current_class->members[current_class->members.size() - 1].type == ClassNode::Member::ENUM) {
+						current_class->members[current_class->members.size() - 1].m_enum->header_comment = member_comment_headers;
+					} else {
+						current_class->members[current_class->members.size() - 1].enum_value.parent_enum->header_comment = member_comment_headers;
+					}
+				}
 				break;
 			case GDScriptTokenizer::Token::STATIC: {
 				advance();
@@ -851,6 +1025,7 @@ void GDScriptParser::parse_class_body(bool p_is_multiline) {
 				// Check for standalone and class-level annotations.
 				AnnotationNode *annotation = parse_annotation(AnnotationInfo::STANDALONE | AnnotationInfo::CLASS_LEVEL);
 				if (annotation != nullptr) {
+					annotation->header_comment = member_comment_headers;
 					if (annotation->applies_to(AnnotationInfo::STANDALONE)) {
 						if (previous.type != GDScriptTokenizer::Token::NEWLINE) {
 							push_error(R"(Expected newline after a standalone annotation.)");
@@ -871,7 +1046,11 @@ void GDScriptParser::parse_class_body(bool p_is_multiline) {
 				advance();
 				end_statement(R"("pass")");
 				break;
+			case GDScriptTokenizer::Token::TK_EOF:
 			case GDScriptTokenizer::Token::DEDENT:
+				current_class->footer_comment = member_comment_headers;
+				member_comment_headers.clear();
+
 				class_end = true;
 				break;
 			case GDScriptTokenizer::Token::LITERAL:
@@ -891,9 +1070,11 @@ void GDScriptParser::parse_class_body(bool p_is_multiline) {
 				advance();
 				break;
 		}
+
 		if (token.type != GDScriptTokenizer::Token::STATIC) {
 			next_is_static = false;
 		}
+
 		if (panic_mode) {
 			synchronize();
 		}
@@ -920,6 +1101,8 @@ GDScriptParser::VariableNode *GDScriptParser::parse_variable(bool p_is_static, b
 	variable->is_static = p_is_static;
 
 	if (match(GDScriptTokenizer::Token::COLON)) {
+		variable->inline_comment = check_for_comment();
+
 		if (check(GDScriptTokenizer::Token::NEWLINE)) {
 			if (p_allow_property) {
 				advance();
@@ -958,11 +1141,15 @@ GDScriptParser::VariableNode *GDScriptParser::parse_variable(bool p_is_static, b
 	}
 
 	if (p_allow_property && match(GDScriptTokenizer::Token::COLON)) {
+		variable->inline_comment = check_for_comment();
+
 		if (match(GDScriptTokenizer::Token::NEWLINE)) {
 			return parse_property(variable, true);
 		} else {
 			return parse_property(variable, false);
 		}
+	} else {
+		variable->inline_comment = check_for_comment();
 	}
 
 	complete_extents(variable);
@@ -973,6 +1160,10 @@ GDScriptParser::VariableNode *GDScriptParser::parse_variable(bool p_is_static, b
 
 GDScriptParser::VariableNode *GDScriptParser::parse_property(VariableNode *p_variable, bool p_need_indent) {
 	if (p_need_indent) {
+		if (check(GDScriptTokenizer::Token::COMMENT)) {
+			last_comment_block = check_for_comment_block();
+		}
+
 		if (!consume(GDScriptTokenizer::Token::INDENT, R"(Expected indented block for property after ":".)")) {
 			complete_extents(p_variable);
 			return nullptr;
@@ -980,6 +1171,10 @@ GDScriptParser::VariableNode *GDScriptParser::parse_property(VariableNode *p_var
 	}
 
 	VariableNode *property = p_variable;
+
+	if (last_comment_block.is_empty()) {
+		last_comment_block = check_for_comment_block();
+	}
 
 	make_completion_context(COMPLETION_PROPERTY_DECLARATION, property);
 
@@ -1001,6 +1196,8 @@ GDScriptParser::VariableNode *GDScriptParser::parse_property(VariableNode *p_var
 
 	bool getter_used = false;
 	bool setter_used = false;
+
+	bool dedented_early = false;
 
 	// Run with a loop because order doesn't matter.
 	for (int i = 0; i < 2; i++) {
@@ -1036,6 +1233,18 @@ GDScriptParser::VariableNode *GDScriptParser::parse_property(VariableNode *p_var
 			}
 		}
 
+		if (check(GDScriptTokenizer::Token::DEDENT)) {
+			advance();
+			dedented_early = true;
+		}
+
+		if (last_comment_block.is_empty()) {
+			last_comment_block = check_for_comment_block();
+			if (dedented_early && check(GDScriptTokenizer::Token::INDENT)) {
+				advance();
+			}
+		}
+
 		if (!match(GDScriptTokenizer::Token::IDENTIFIER)) {
 			break;
 		}
@@ -1048,7 +1257,9 @@ GDScriptParser::VariableNode *GDScriptParser::parse_property(VariableNode *p_var
 	}
 
 	if (p_need_indent) {
-		consume(GDScriptTokenizer::Token::DEDENT, R"(Expected end of indented block for property.)");
+		if (!dedented_early) {
+			consume(GDScriptTokenizer::Token::DEDENT, R"(Expected end of indented block for property.)");
+		}
 	}
 	return property;
 }
@@ -1057,6 +1268,9 @@ void GDScriptParser::parse_property_setter(VariableNode *p_variable) {
 	switch (p_variable->property) {
 		case VariableNode::PROP_INLINE: {
 			FunctionNode *function = alloc_node<FunctionNode>();
+			function->header_comment = last_comment_block;
+			last_comment_block.clear();
+
 			IdentifierNode *identifier = alloc_node<IdentifierNode>();
 			complete_extents(identifier);
 			identifier->name = "@" + p_variable->identifier->name + "_setter";
@@ -1077,6 +1291,8 @@ void GDScriptParser::parse_property_setter(VariableNode *p_variable) {
 
 			consume(GDScriptTokenizer::Token::PARENTHESIS_CLOSE, R"*(Expected ")" after parameter name.)*");
 			consume(GDScriptTokenizer::Token::COLON, R"*(Expected ":" after ")".)*");
+
+			function->inline_comment = check_for_comment();
 
 			FunctionNode *previous_function = current_function;
 			current_function = function;
@@ -1106,8 +1322,12 @@ void GDScriptParser::parse_property_getter(VariableNode *p_variable) {
 	switch (p_variable->property) {
 		case VariableNode::PROP_INLINE: {
 			FunctionNode *function = alloc_node<FunctionNode>();
+			function->header_comment = last_comment_block;
+			last_comment_block.clear();
 
 			consume(GDScriptTokenizer::Token::COLON, R"(Expected ":" after "get".)");
+
+			function->inline_comment = check_for_comment();
 
 			IdentifierNode *identifier = alloc_node<IdentifierNode>();
 			complete_extents(identifier);
@@ -1172,6 +1392,8 @@ GDScriptParser::ConstantNode *GDScriptParser::parse_constant(bool p_is_static) {
 		return nullptr;
 	}
 
+	constant->inline_comment = check_for_comment();
+
 	complete_extents(constant);
 	end_statement("constant declaration");
 
@@ -1185,6 +1407,11 @@ GDScriptParser::ParameterNode *GDScriptParser::parse_parameter() {
 
 	ParameterNode *parameter = alloc_node<ParameterNode>();
 	parameter->identifier = parse_identifier();
+
+	if (!parameter->identifier->inline_comment.is_empty()) {
+		parameter->inline_comment = parameter->identifier->inline_comment;
+		parameter->identifier->inline_comment.clear();
+	}
 
 	if (match(GDScriptTokenizer::Token::COLON)) {
 		if (check((GDScriptTokenizer::Token::EQUAL))) {
@@ -1220,6 +1447,10 @@ GDScriptParser::SignalNode *GDScriptParser::parse_signal(bool p_is_static) {
 		push_multiline(true);
 		advance();
 		do {
+			if (check(GDScriptTokenizer::Token::COMMENT)) {
+				signal->parameters[signal->parameters.size() - 1]->inline_comment = check_for_comment();
+			}
+
 			if (check(GDScriptTokenizer::Token::PARENTHESIS_CLOSE)) {
 				// Allow for trailing comma.
 				break;
@@ -1243,7 +1474,13 @@ GDScriptParser::SignalNode *GDScriptParser::parse_signal(bool p_is_static) {
 
 		pop_multiline();
 		consume(GDScriptTokenizer::Token::PARENTHESIS_CLOSE, R"*(Expected closing ")" after signal parameters.)*");
+
+		if (signal->parameters.is_empty()) {
+			signal->has_empty_parameter_list = true;
+		}
 	}
+
+	signal->inline_comment = check_for_comment();
 
 	complete_extents(signal);
 	end_statement("signal declaration");
@@ -1271,7 +1508,18 @@ GDScriptParser::EnumNode *GDScriptParser::parse_enum(bool p_is_static) {
 	GDScriptLanguage::get_singleton()->get_public_functions(&gdscript_funcs);
 #endif
 
+	Vector<String> current_header_comment;
+	String current_inline_comment;
+
 	do {
+		if (check(GDScriptTokenizer::Token::COMMENT)) {
+			if (previous.start_line != current.start_line) {
+				current_header_comment = check_for_comment_block();
+			} else {
+				enum_node->values[enum_node->values.size() - 1].identifier->inline_comment = check_for_comment();
+			}
+		}
+
 		if (check(GDScriptTokenizer::Token::BRACE_CLOSE)) {
 			break; // Allow trailing comma.
 		}
@@ -1293,6 +1541,10 @@ GDScriptParser::EnumNode *GDScriptParser::parse_enum(bool p_is_static) {
 			}
 #endif
 			item.identifier = identifier;
+			item.identifier->header_comment = current_header_comment;
+			if (!current_header_comment.is_empty()) {
+				current_header_comment.clear();
+			}
 			item.parent_enum = enum_node;
 			item.line = previous.start_line;
 			item.leftmost_column = previous.leftmost_column;
@@ -1362,6 +1614,8 @@ GDScriptParser::EnumNode *GDScriptParser::parse_enum(bool p_is_static) {
 	}
 #endif // TOOLS_ENABLED
 
+	enum_node->inline_comment = check_for_comment();
+
 	complete_extents(enum_node);
 	end_statement("enum");
 
@@ -1372,13 +1626,29 @@ void GDScriptParser::parse_function_signature(FunctionNode *p_function, SuiteNod
 	if (!check(GDScriptTokenizer::Token::PARENTHESIS_CLOSE) && !is_at_end()) {
 		bool default_used = false;
 		do {
+			Vector<String> comment_header_block;
+			if (check(GDScriptTokenizer::Token::COMMENT)) {
+				if (p_function->parameters.is_empty()) {
+					comment_header_block = check_for_comment_block();
+				} else {
+					p_function->parameters[p_function->parameters.size() - 1]->inline_comment = check_for_comment();
+				}
+			}
+
 			if (check(GDScriptTokenizer::Token::PARENTHESIS_CLOSE)) {
+				if (!comment_header_block.is_empty()) {
+					p_function->params_footer_comments = comment_header_block;
+				}
 				// Allow for trailing comma.
 				break;
 			}
 			ParameterNode *parameter = parse_parameter();
 			if (parameter == nullptr) {
 				break;
+			}
+			if (!comment_header_block.is_empty()) {
+				parameter->header_comment = comment_header_block;
+				comment_header_block.clear();
 			}
 			if (parameter->initializer != nullptr) {
 				default_used = true;
@@ -1421,6 +1691,8 @@ void GDScriptParser::parse_function_signature(FunctionNode *p_function, SuiteNod
 
 	// TODO: Improve token consumption so it synchronizes to a statement boundary. This way we can get into the function body with unrecognized tokens.
 	consume(GDScriptTokenizer::Token::COLON, vformat(R"(Expected ":" after %s declaration.)", p_type));
+
+	p_function->inline_comment = check_for_comment();
 }
 
 GDScriptParser::FunctionNode *GDScriptParser::parse_function(bool p_is_static) {
@@ -1510,7 +1782,13 @@ GDScriptParser::AnnotationNode *GDScriptParser::parse_annotation(uint32_t p_vali
 	}
 	complete_extents(annotation);
 
-	match(GDScriptTokenizer::Token::NEWLINE); // Newline after annotation is optional.
+	// Need to be applied to the parser instead of the annotation.
+	if (annotation->name != SNAME("@icon") && annotation->name != SNAME("@tool")) {
+		if (check(GDScriptTokenizer::Token::COMMENT)) {
+			annotation->inline_comment = check_for_comment();
+		}
+		match(GDScriptTokenizer::Token::NEWLINE); // Newline after annotation is optional.
+	}
 
 	if (valid) {
 		valid = validate_annotation_arguments(annotation);
@@ -1560,7 +1838,21 @@ GDScriptParser::SuiteNode *GDScriptParser::parse_suite(const String &p_context, 
 		multiline = true;
 	}
 
+	Vector<String> comment_header;
+
+	bool dedented = false;
+	GDScriptTokenizer::Token dedented_token;
 	if (multiline) {
+		if (check(GDScriptTokenizer::Token::DEDENT)) {
+			dedented_token = current;
+			advance();
+			dedented = true;
+		}
+		if (check(GDScriptTokenizer::Token::COMMENT)) {
+			comment_header = check_for_comment_block();
+		} else if (dedented) {
+			current = dedented_token;
+		}
 		if (!consume(GDScriptTokenizer::Token::INDENT, vformat(R"(Expected indented block after %s.)", p_context))) {
 			current_suite = suite->parent_block;
 			complete_extents(suite);
@@ -1575,6 +1867,14 @@ GDScriptParser::SuiteNode *GDScriptParser::parse_suite(const String &p_context, 
 		if (is_at_end() || (!multiline && previous.type == GDScriptTokenizer::Token::SEMICOLON && check(GDScriptTokenizer::Token::NEWLINE))) {
 			break;
 		}
+
+		comment_header.append_array(check_for_comment_block());
+		if (current.type == GDScriptTokenizer::Token::DEDENT) {
+			suite->footer_comment = comment_header;
+			comment_header.clear();
+			break;
+		}
+
 		Node *statement = parse_statement();
 		if (statement == nullptr) {
 			if (error_count++ > 100) {
@@ -1583,6 +1883,8 @@ GDScriptParser::SuiteNode *GDScriptParser::parse_suite(const String &p_context, 
 			}
 			continue;
 		}
+		statement->header_comment = comment_header;
+		comment_header.clear();
 		suite->statements.push_back(statement);
 
 		// Register locals.
@@ -1615,14 +1917,19 @@ GDScriptParser::SuiteNode *GDScriptParser::parse_suite(const String &p_context, 
 				break;
 		}
 
+		if (current.type == GDScriptTokenizer::Token::Type::NEWLINE) {
+			advance();
+		}
+
 	} while ((multiline || previous.type == GDScriptTokenizer::Token::SEMICOLON) && !check(GDScriptTokenizer::Token::DEDENT) && !lambda_ended && !is_at_end());
 
 	complete_extents(suite);
 
 	if (multiline) {
 		if (!lambda_ended) {
-			consume(GDScriptTokenizer::Token::DEDENT, vformat(R"(Missing unindent at the end of %s.)", p_context));
-
+			if (!check(GDScriptTokenizer::Token::TK_EOF)) {
+				consume(GDScriptTokenizer::Token::DEDENT, vformat(R"(Missing unindent at the end of %s.)", p_context));
+			}
 		} else {
 			match(GDScriptTokenizer::Token::DEDENT);
 		}
@@ -1637,6 +1944,25 @@ GDScriptParser::SuiteNode *GDScriptParser::parse_suite(const String &p_context, 
 	return suite;
 }
 
+Vector<String> GDScriptParser::check_for_comment_block() {
+	Vector<String> comments;
+	while (check(GDScriptTokenizer::Token::COMMENT)) {
+		match(GDScriptTokenizer::Token::COMMENT);
+		comments.push_back(previous.comment);
+		match(GDScriptTokenizer::Token::NEWLINE);
+	}
+	return comments;
+}
+
+String GDScriptParser::check_for_comment() {
+	String comment;
+	if (check(GDScriptTokenizer::Token::COMMENT)) {
+		match(GDScriptTokenizer::Token::COMMENT);
+		comment = previous.comment;
+	}
+	return comment;
+}
+
 GDScriptParser::Node *GDScriptParser::parse_statement() {
 	Node *result = nullptr;
 #ifdef DEBUG_ENABLED
@@ -1649,6 +1975,7 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 		case GDScriptTokenizer::Token::PASS:
 			advance();
 			result = alloc_node<PassNode>();
+			result->inline_comment = check_for_comment();
 			complete_extents(result);
 			end_statement(R"("pass")");
 			break;
@@ -1687,6 +2014,9 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 		case GDScriptTokenizer::Token::RETURN: {
 			advance();
 			ReturnNode *n_return = alloc_node<ReturnNode>();
+			if (check(GDScriptTokenizer::Token::COMMENT)) {
+				n_return->inline_comment = check_for_comment();
+			}
 			if (!is_statement_end()) {
 				if (current_function && (current_function->identifier->name == GDScriptLanguage::get_singleton()->strings._init || current_function->identifier->name == GDScriptLanguage::get_singleton()->strings._static_init)) {
 					push_error(R"(Constructor cannot return a value.)");
@@ -1708,6 +2038,7 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 		case GDScriptTokenizer::Token::BREAKPOINT:
 			advance();
 			result = alloc_node<BreakpointNode>();
+			result->inline_comment = check_for_comment();
 			complete_extents(result);
 			end_statement(R"("breakpoint")");
 			break;
@@ -1829,6 +2160,10 @@ GDScriptParser::AssertNode *GDScriptParser::parse_assert() {
 	pop_multiline();
 	consume(GDScriptTokenizer::Token::PARENTHESIS_CLOSE, R"*(Expected ")" after assert expression.)*");
 
+	if (check(GDScriptTokenizer::Token::COMMENT)) {
+		assert->inline_comment = check_for_comment();
+	}
+
 	complete_extents(assert);
 	end_statement(R"("assert")");
 
@@ -1840,6 +2175,7 @@ GDScriptParser::BreakNode *GDScriptParser::parse_break() {
 		push_error(R"(Cannot use "break" outside of a loop.)");
 	}
 	BreakNode *break_node = alloc_node<BreakNode>();
+	break_node->inline_comment = check_for_comment();
 	complete_extents(break_node);
 	end_statement(R"("break")");
 	return break_node;
@@ -1851,6 +2187,7 @@ GDScriptParser::ContinueNode *GDScriptParser::parse_continue() {
 	}
 	current_suite->has_continue = true;
 	ContinueNode *cont = alloc_node<ContinueNode>();
+	cont->inline_comment = check_for_comment();
 	complete_extents(cont);
 	end_statement(R"("continue")");
 	return cont;
@@ -1883,6 +2220,8 @@ GDScriptParser::ForNode *GDScriptParser::parse_for() {
 	}
 
 	consume(GDScriptTokenizer::Token::COLON, R"(Expected ":" after "for" condition.)");
+
+	n_for->inline_comment = check_for_comment();
 
 	// Save break/continue state.
 	bool could_break = can_break;
@@ -1921,12 +2260,18 @@ GDScriptParser::IfNode *GDScriptParser::parse_if(const String &p_token) {
 
 	consume(GDScriptTokenizer::Token::COLON, vformat(R"(Expected ":" after "%s" condition.)", p_token));
 
+	if (n_if->condition != nullptr) {
+		n_if->condition->inline_comment = check_for_comment();
+	}
+
 	n_if->true_block = parse_suite(vformat(R"("%s" block)", p_token));
 	n_if->true_block->parent_if = n_if;
 
 	if (n_if->true_block->has_continue) {
 		current_suite->has_continue = true;
 	}
+
+	Vector<String> next_header_block = check_for_comment_block();
 
 	if (match(GDScriptTokenizer::Token::ELIF)) {
 		SuiteNode *else_block = alloc_node<SuiteNode>();
@@ -1937,6 +2282,8 @@ GDScriptParser::IfNode *GDScriptParser::parse_if(const String &p_token) {
 		current_suite = else_block;
 
 		IfNode *elif = parse_if("elif");
+		elif->header_comment = next_header_block;
+		next_header_block.clear();
 		else_block->statements.push_back(elif);
 		complete_extents(else_block);
 		n_if->false_block = else_block;
@@ -1944,9 +2291,19 @@ GDScriptParser::IfNode *GDScriptParser::parse_if(const String &p_token) {
 		current_suite = previous_suite;
 	} else if (match(GDScriptTokenizer::Token::ELSE)) {
 		consume(GDScriptTokenizer::Token::COLON, R"(Expected ":" after "else".)");
+		String next_inline = check_for_comment();
 		n_if->false_block = parse_suite(R"("else" block)");
+		if (n_if->false_block != nullptr) {
+			n_if->false_block->inline_comment = next_inline;
+			n_if->false_block->header_comment = next_header_block;
+			next_header_block.clear();
+		}
 	}
 	complete_extents(n_if);
+
+	if (!next_header_block.is_empty()) {
+		n_if->true_block->footer_comment = next_header_block;
+	}
 
 	if (n_if->false_block != nullptr && n_if->false_block->has_return && n_if->true_block->has_return) {
 		current_suite->has_return = true;
@@ -1967,6 +2324,7 @@ GDScriptParser::MatchNode *GDScriptParser::parse_match() {
 	}
 
 	consume(GDScriptTokenizer::Token::COLON, R"(Expected ":" after "match" expression.)");
+	match->test->inline_comment = check_for_comment();
 	consume(GDScriptTokenizer::Token::NEWLINE, R"(Expected a newline after "match" statement.)");
 
 	if (!consume(GDScriptTokenizer::Token::INDENT, R"(Expected an indented block after "match" statement.)")) {
@@ -1977,11 +2335,19 @@ GDScriptParser::MatchNode *GDScriptParser::parse_match() {
 	bool all_have_return = true;
 	bool have_wildcard = false;
 
+	Vector<String> first_header = check_for_comment_block();
+
 	while (!check(GDScriptTokenizer::Token::DEDENT) && !is_at_end()) {
 		MatchBranchNode *branch = parse_match_branch();
 		if (branch == nullptr) {
 			advance();
 			continue;
+		}
+		if (first_header.is_empty()) {
+			branch->header_comment = check_for_comment_block();
+		} else {
+			branch->header_comment = first_header;
+			first_header.clear();
 		}
 
 #ifdef DEBUG_ENABLED
@@ -2038,6 +2404,8 @@ GDScriptParser::MatchBranchNode *GDScriptParser::parse_match_branch() {
 		complete_extents(branch);
 		return nullptr;
 	}
+
+	branch->inline_comment = check_for_comment();
 
 	SuiteNode *suite = alloc_node<SuiteNode>();
 	if (branch->patterns.size() > 0) {
@@ -2207,6 +2575,8 @@ GDScriptParser::WhileNode *GDScriptParser::parse_while() {
 
 	consume(GDScriptTokenizer::Token::COLON, R"(Expected ":" after "while" condition.)");
 
+	n_while->inline_comment = check_for_comment();
+
 	// Save break/continue state.
 	bool could_break = can_break;
 	bool could_continue = can_continue;
@@ -2258,6 +2628,17 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_precedence(Precedence p_pr
 
 	advance(); // Only consume the token if there's a valid rule.
 
+	Vector<String> header_comment_block;
+	if (check(GDScriptTokenizer::Token::COMMENT) && (previous.start_line != current.start_line || previous.type == GDScriptTokenizer::Token::PARENTHESIS_OPEN)) {
+		header_comment_block = check_for_comment_block();
+
+		if (current.type == GDScriptTokenizer::Token::BRACKET_CLOSE || current.type == GDScriptTokenizer::Token::PARENTHESIS_CLOSE || current.type == GDScriptTokenizer::Token::BRACE_CLOSE) {
+			previous = token;
+			last_comment_block = header_comment_block;
+			header_comment_block.clear();
+		}
+	}
+
 	ExpressionNode *previous_operand = (this->*prefix_rule)(nullptr, p_can_assign);
 
 	while (p_precedence <= get_rule(current.type)->precedence) {
@@ -2277,6 +2658,20 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_precedence(Precedence p_pr
 		token = advance();
 		ParseFunction infix_rule = get_rule(token.type)->infix;
 		previous_operand = (this->*infix_rule)(previous_operand, p_can_assign);
+
+		if (check(GDScriptTokenizer::Token::COMMENT)) {
+			previous_operand->inline_comment = check_for_comment();
+			match(GDScriptTokenizer::Token::NEWLINE);
+		}
+	}
+
+	if (previous_operand != nullptr) {
+		if (check(GDScriptTokenizer::Token::COMMENT)) {
+			previous_operand->inline_comment = check_for_comment();
+		}
+		if (previous_operand->header_comment.is_empty()) {
+			previous_operand->header_comment = header_comment_block;
+		}
 	}
 
 	return previous_operand;
@@ -2341,6 +2736,8 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_identifier(ExpressionNode 
 		}
 	}
 
+	identifier->inline_comment = check_for_comment();
+
 	return identifier;
 }
 
@@ -2357,6 +2754,9 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_literal(ExpressionNode *p_
 	LiteralNode *literal = alloc_node<LiteralNode>();
 	complete_extents(literal);
 	literal->value = previous.literal;
+	if (check(GDScriptTokenizer::Token::COMMENT)) {
+		literal->inline_comment = check_for_comment();
+	}
 	return literal;
 }
 
@@ -2373,6 +2773,8 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_self(ExpressionNode *p_pre
 GDScriptParser::ExpressionNode *GDScriptParser::parse_builtin_constant(ExpressionNode *p_previous_operand, bool p_can_assign) {
 	GDScriptTokenizer::Token::Type op_type = previous.type;
 	LiteralNode *constant = alloc_node<LiteralNode>();
+	constant->is_builtin_constant = true;
+	constant->constant_type = op_type;
 	complete_extents(constant);
 
 	switch (op_type) {
@@ -2436,6 +2838,10 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_unary_operator(ExpressionN
 		default:
 			complete_extents(operation);
 			return nullptr; // Unreachable.
+	}
+	if (operation->operand != nullptr && !operation->operand->inline_comment.is_empty()) {
+		operation->inline_comment = operation->operand->inline_comment;
+		operation->operand->inline_comment.clear();
 	}
 	complete_extents(operation);
 
@@ -2702,6 +3108,11 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_assignment(ExpressionNode 
 	assignment->assigned_value = parse_expression(false);
 	if (assignment->assigned_value == nullptr) {
 		push_error(R"(Expected an expression after "=".)");
+	} else {
+		if (!assignment->assigned_value->inline_comment.is_empty()) {
+			assignment->inline_comment = assignment->assigned_value->inline_comment;
+			assignment->assigned_value->inline_comment.clear();
+		}
 	}
 	complete_extents(assignment);
 
@@ -2739,7 +3150,20 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_array(ExpressionNode *p_pr
 
 	if (!check(GDScriptTokenizer::Token::BRACKET_CLOSE)) {
 		do {
+			Vector<String> current_header_block;
+			if (check(GDScriptTokenizer::Token::COMMENT)) {
+				if (current.start_line != previous.end_line || array->elements.is_empty()) {
+					current_header_block = check_for_comment_block();
+				} else {
+					array->elements[array->elements.size() - 1]->inline_comment = check_for_comment();
+				}
+				match(GDScriptTokenizer::Token::NEWLINE);
+			}
+
 			if (check(GDScriptTokenizer::Token::BRACKET_CLOSE)) {
+				if (!current_header_block.is_empty()) {
+					array->footer_comments = current_header_block;
+				}
 				// Allow for trailing comma.
 				break;
 			}
@@ -2748,10 +3172,17 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_array(ExpressionNode *p_pr
 			if (element == nullptr) {
 				push_error(R"(Expected expression as array element.)");
 			} else {
+				element->header_comment = current_header_block;
 				array->elements.push_back(element);
 			}
 		} while (match(GDScriptTokenizer::Token::COMMA) && !is_at_end());
 	}
+
+	if (!last_comment_block.is_empty()) {
+		array->footer_comments = last_comment_block;
+		last_comment_block.clear();
+	}
+
 	pop_multiline();
 	consume(GDScriptTokenizer::Token::BRACKET_CLOSE, R"(Expected closing "]" after array elements.)");
 	complete_extents(array);
@@ -2765,7 +3196,20 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_dictionary(ExpressionNode 
 	bool decided_style = false;
 	if (!check(GDScriptTokenizer::Token::BRACE_CLOSE)) {
 		do {
+			Vector<String> comment_header_block;
+			if (check(GDScriptTokenizer::Token::COMMENT)) {
+				if (previous.start_line != current.start_line || dictionary->elements.is_empty()) {
+					comment_header_block = check_for_comment_block();
+				} else {
+					dictionary->elements[dictionary->elements.size() - 1].value->inline_comment = check_for_comment();
+				}
+				match(GDScriptTokenizer::Token::NEWLINE);
+			}
+
 			if (check(GDScriptTokenizer::Token::BRACE_CLOSE)) {
+				if (!comment_header_block.is_empty()) {
+					dictionary->footer_comments = comment_header_block;
+				}
 				// Allow for trailing comma.
 				break;
 			}
@@ -2775,6 +3219,8 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_dictionary(ExpressionNode 
 
 			if (key == nullptr) {
 				push_error(R"(Expected expression as dictionary key.)");
+			} else {
+				key->header_comment = comment_header_block;
 			}
 
 			if (!decided_style) {
@@ -2844,6 +3290,12 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_dictionary(ExpressionNode 
 			}
 		} while (match(GDScriptTokenizer::Token::COMMA) && !is_at_end());
 	}
+
+	if (!last_comment_block.is_empty()) {
+		dictionary->footer_comments = last_comment_block;
+		last_comment_block.clear();
+	}
+
 	pop_multiline();
 	consume(GDScriptTokenizer::Token::BRACE_CLOSE, R"(Expected closing "}" after dictionary elements.)");
 	complete_extents(dictionary);
@@ -2894,6 +3346,11 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_attribute(ExpressionNode *
 
 	attribute->is_attribute = true;
 	attribute->attribute = parse_identifier();
+
+	if (!attribute->attribute->inline_comment.is_empty()) {
+		attribute->inline_comment = attribute->attribute->inline_comment;
+		attribute->attribute->inline_comment.clear();
+	}
 
 	complete_extents(attribute);
 	return attribute;
@@ -3002,9 +3459,21 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_call(ExpressionNode *p_pre
 	}
 	push_completion_call(call);
 	int argument_index = 0;
+	Vector<String> comment_header_block;
 	do {
 		make_completion_context(ct, call, argument_index++, true);
+		if (check(GDScriptTokenizer::Token::COMMENT)) {
+			if (call->arguments.is_empty()) {
+				comment_header_block = check_for_comment_block();
+			} else {
+				call->arguments[call->arguments.size() - 1]->inline_comment = check_for_comment();
+			}
+		}
+
 		if (check(GDScriptTokenizer::Token::PARENTHESIS_CLOSE)) {
+			if (!comment_header_block.is_empty()) {
+				call->params_footer_comment = comment_header_block;
+			}
 			// Allow for trailing comma.
 			break;
 		}
@@ -3013,6 +3482,8 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_call(ExpressionNode *p_pre
 		if (argument == nullptr) {
 			push_error(R"(Expected expression as the function argument.)");
 		} else {
+			argument->header_comment = comment_header_block;
+			comment_header_block.clear();
 			call->arguments.push_back(argument);
 
 			if (argument->type == Node::IDENTIFIER && use_identifier_completion) {
@@ -3021,10 +3492,21 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_call(ExpressionNode *p_pre
 		}
 		ct = COMPLETION_CALL_ARGUMENTS;
 	} while (match(GDScriptTokenizer::Token::COMMA));
+
+	if (!last_comment_block.is_empty()) {
+		call->params_footer_comment = last_comment_block;
+		last_comment_block.clear();
+	}
+
 	pop_completion_call();
 
 	pop_multiline();
 	consume(GDScriptTokenizer::Token::PARENTHESIS_CLOSE, R"*(Expected closing ")" after call arguments.)*");
+
+	if (check(GDScriptTokenizer::Token::COMMENT)) {
+		call->inline_comment = check_for_comment();
+	}
+
 	complete_extents(call);
 
 	return call;
@@ -3154,6 +3636,9 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_preload(ExpressionNode *p_
 
 	pop_multiline();
 	consume(GDScriptTokenizer::Token::PARENTHESIS_CLOSE, R"*(Expected ")" after preload path.)*");
+
+	preload->inline_comment = check_for_comment();
+
 	complete_extents(preload);
 
 	return preload;
@@ -3653,6 +4138,7 @@ GDScriptParser::ParseRule *GDScriptParser::get_rule(GDScriptTokenizer::Token::Ty
 		{ nullptr,                                          nullptr,                                        PREC_NONE }, // ANNOTATION,
 		{ &GDScriptParser::parse_identifier,             	nullptr,                                        PREC_NONE }, // IDENTIFIER,
 		{ &GDScriptParser::parse_literal,                	nullptr,                                        PREC_NONE }, // LITERAL,
+		{ nullptr,                                          nullptr,                                        PREC_NONE }, // COMMENT,
 		// Comparison
 		{ nullptr,                                          &GDScriptParser::parse_binary_operator,      	PREC_COMPARISON }, // LESS,
 		{ nullptr,                                          &GDScriptParser::parse_binary_operator,      	PREC_COMPARISON }, // LESS_EQUAL,
@@ -5021,12 +5507,15 @@ void GDScriptParser::TreePrinter::print_if(IfNode *p_if, bool p_is_elif) {
 	print_suite(p_if->true_block);
 	decrease_indent();
 
-	// FIXME: Properly detect "elif" blocks.
 	if (p_if->false_block != nullptr) {
-		push_line("Else :");
-		increase_indent();
-		print_suite(p_if->false_block);
-		decrease_indent();
+		if (p_if->false_block->statements.size() == 1 && p_if->false_block->statements[0]->type == GDScriptParser::Node::Type::IF) {
+			print_if(static_cast<IfNode *>(p_if->false_block->statements[0]), true);
+		} else {
+			push_line("Else :");
+			increase_indent();
+			print_suite(p_if->false_block);
+			decrease_indent();
+		}
 	}
 }
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -409,7 +409,7 @@ Error GDScriptParser::parse(const String &p_source_code, const String &p_script_
 		current = tokenizer.scan();
 	}
 
-	// Check for empty files with only comments
+	// Check for empty files with only comments.
 	if (current.type == GDScriptTokenizer::Token::COMMENT) {
 		while (current.type == GDScriptTokenizer::Token::COMMENT || current.type == GDScriptTokenizer::Token::NEWLINE) {
 			current = tokenizer.scan();
@@ -1146,7 +1146,7 @@ GDScriptParser::VariableNode *GDScriptParser::parse_variable(bool p_is_static, b
 
 	variable->inline_comment = check_for_comment();
 
-	// For setter and getters properties (hence the check for ":")
+	// For setter and getters properties (hence the check for ":").
 	if (p_allow_property && match(GDScriptTokenizer::Token::COLON)) {
 		if (match(GDScriptTokenizer::Token::NEWLINE)) {
 			return parse_property(variable, true);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2617,9 +2617,9 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_precedence(Precedence p_pr
 	switch (current.type) {
 		case GDScriptTokenizer::Token::PARENTHESIS_OPEN:
 		case GDScriptTokenizer::Token::BRACE_OPEN:
-		case GDScriptTokenizer::Token::BRACKET_OPEN:
+		case GDScriptTokenizer::Token::BRACKET_OPEN: {
 			push_multiline(true);
-			break;
+		} break;
 		default:
 			break; // Nothing to do.
 	}
@@ -3324,6 +3324,7 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_grouping(ExpressionNode *p
 	if (grouped == nullptr) {
 		push_error(R"(Expected grouping expression.)");
 	} else {
+		grouped->is_grouped = true;
 		consume(GDScriptTokenizer::Token::PARENTHESIS_CLOSE, R"*(Expected closing ")" after grouping expression.)*");
 	}
 	return grouped;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3233,10 +3233,15 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_dictionary(ExpressionNode 
 			if (check(GDScriptTokenizer::Token::COMMENT)) {
 				if (previous.start_line != current.start_line || dictionary->elements.is_empty()) {
 					comment_header_block = check_for_comment_block();
+					match(GDScriptTokenizer::Token::NEWLINE);
 				} else {
 					dictionary->elements[dictionary->elements.size() - 1].value->inline_comment = check_for_comment();
+					match(GDScriptTokenizer::Token::NEWLINE);
+					if (check(GDScriptTokenizer::Token::COMMENT)) {
+						comment_header_block = check_for_comment_block();
+						match(GDScriptTokenizer::Token::NEWLINE);
+					}
 				}
-				match(GDScriptTokenizer::Token::NEWLINE);
 			}
 
 			if (check(GDScriptTokenizer::Token::BRACE_CLOSE)) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -39,11 +39,11 @@
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
 #include "core/math/math_defs.h"
+#include "core/string/string_builder.h"
 #include "scene/main/multiplayer_api.h"
 
 #ifdef DEBUG_ENABLED
 #include "core/os/os.h"
-#include "core/string/string_builder.h"
 #include "gdscript.h"
 #include "gdscript_tokenizer.h"
 #include "gdscript_warning.h"

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2356,7 +2356,9 @@ GDScriptParser::MatchNode *GDScriptParser::parse_match() {
 	}
 
 	consume(GDScriptTokenizer::Token::COLON, R"(Expected ":" after "match" expression.)");
-	match->test->inline_comment = check_for_comment();
+	if (match->test != nullptr) {
+		match->test->inline_comment = check_for_comment();
+	}
 	consume(GDScriptTokenizer::Token::NEWLINE, R"(Expected a newline after "match" statement.)");
 
 	if (!consume(GDScriptTokenizer::Token::INDENT, R"(Expected an indented block after "match" statement.)")) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2285,7 +2285,25 @@ GDScriptParser::IfNode *GDScriptParser::parse_if(const String &p_token) {
 		current_suite->has_continue = true;
 	}
 
-	Vector<String> next_header_block = check_for_comment_block();
+	bool check_comments = false;
+	if (previous.type == GDScriptTokenizer::Token::Type::DEDENT) {
+		GDScriptTokenizer::Token current_token;
+		for (int i = 1; true; i++) {
+			current_token = tokenizer.peek(i);
+			if (current_token.type == GDScriptTokenizer::Token::Type::COMMENT || current_token.type == GDScriptTokenizer::Token::Type::NEWLINE) {
+				continue;
+			} else if (current_token.type == GDScriptTokenizer::Token::Type::ELIF || current_token.type == GDScriptTokenizer::Token::Type::ELSE) {
+				check_comments = true;
+			}
+
+			break;
+		}
+	}
+
+	Vector<String> next_header_block;
+	if (check_comments) {
+		next_header_block = check_for_comment_block();
+	}
 
 	if (match(GDScriptTokenizer::Token::ELIF)) {
 		SuiteNode *else_block = alloc_node<SuiteNode>();

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1941,6 +1941,17 @@ GDScriptParser::SuiteNode *GDScriptParser::parse_suite(const String &p_context, 
 		lambda_ended = true;
 	}
 	current_suite = suite->parent_block;
+
+	if (suite->statements.size() == 0) {
+		Node *context = nullptr;
+		if (suite->parent_block) {
+			context = suite->parent_block;
+		} else if (suite->parent_function) {
+			context = suite->parent_function;
+		}
+		push_error(vformat(R"(No statements were found in %s.)", p_context), context);
+	}
+
 	return suite;
 }
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -345,6 +345,7 @@ public:
 		// Base type for all expression kinds.
 		bool reduced = false;
 		bool is_constant = false;
+		bool is_grouped = false;
 		Variant reduced_value;
 
 		virtual bool is_expression() const override { return true; }

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1454,6 +1454,7 @@ private:
 	bool check(GDScriptTokenizer::Token::Type p_token_type) const;
 	bool consume(GDScriptTokenizer::Token::Type p_token_type, const String &p_error_message);
 	bool is_at_end() const;
+	bool is_dedenting() const;
 	bool is_statement_end_token() const;
 	bool is_statement_end() const;
 	void end_statement(const String &p_context);

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -324,6 +324,8 @@ public:
 		int start_column = 0, end_column = 0;
 		int leftmost_column = 0, rightmost_column = 0;
 		Node *next = nullptr;
+		Vector<String> header_comment;
+		String inline_comment;
 		List<AnnotationNode *> annotations;
 #ifdef DEBUG_ENABLED
 		Vector<GDScriptWarning::Code> ignored_warnings;
@@ -372,6 +374,7 @@ public:
 
 	struct ArrayNode : public ExpressionNode {
 		Vector<ExpressionNode *> elements;
+		Vector<String> footer_comments;
 
 		ArrayNode() {
 			type = ARRAY;
@@ -488,6 +491,7 @@ public:
 		Vector<ExpressionNode *> arguments;
 		StringName function_name;
 		bool is_super = false;
+		Vector<String> params_footer_comment;
 
 		CallNode() {
 			type = CALL;
@@ -736,6 +740,13 @@ public:
 		bool annotated_static_unload = false;
 		String extends_path;
 		Vector<IdentifierNode *> extends; // List for indexing: extends A.B.C
+		String extends_inline_comment;
+		Vector<String> extends_header_comment;
+		String tool_inline_comment;
+		Vector<String> tool_header_comment;
+		String icon_inline_comment;
+		Vector<String> icon_header_comment;
+		Vector<String> footer_comment;
 		DataType base_type;
 		String fqcn; // Fully-qualified class name. Identifies uniquely any class in the project.
 #ifdef TOOLS_ENABLED
@@ -807,6 +818,7 @@ public:
 			ExpressionNode *value = nullptr;
 		};
 		Vector<Pair> elements;
+		Vector<String> footer_comments;
 
 		enum Style {
 			LUA_TABLE,
@@ -849,6 +861,7 @@ public:
 
 		bool resolved_signature = false;
 		bool resolved_body = false;
+		Vector<String> params_footer_comments;
 
 		FunctionNode() {
 			type = FUNCTION;
@@ -929,6 +942,8 @@ public:
 
 	struct LiteralNode : public ExpressionNode {
 		Variant value;
+		bool is_builtin_constant = false;
+		GDScriptTokenizer::Token::Type constant_type = GDScriptTokenizer::Token::EMPTY;
 
 		LiteralNode() {
 			type = LITERAL;
@@ -1033,6 +1048,7 @@ public:
 		Vector<ParameterNode *> parameters;
 		HashMap<StringName, int> parameters_indices;
 		MethodInfo method_info;
+		bool has_empty_parameter_list = false;
 #ifdef TOOLS_ENABLED
 		MemberDocData doc_data;
 #endif // TOOLS_ENABLED
@@ -1142,6 +1158,7 @@ public:
 		Local empty;
 		Vector<Local> locals;
 		HashMap<StringName, int> locals_indices;
+		Vector<String> footer_comment;
 
 		FunctionNode *parent_function = nullptr;
 		IfNode *parent_if = nullptr;
@@ -1334,6 +1351,7 @@ private:
 	CompletionContext completion_context;
 	CompletionCall completion_call;
 	List<CompletionCall> completion_call_stack;
+	Vector<String> last_comment_block;
 	bool passed_cursor = false;
 	bool in_lambda = false;
 	bool lambda_ended = false; // Marker for when a lambda ends, to apply an end of statement if needed.
@@ -1422,6 +1440,8 @@ private:
 	}
 #endif
 
+	String turn_disabled_lines_into_headers(const String &p_source);
+
 	void make_completion_context(CompletionType p_type, Node *p_node, int p_argument = -1, bool p_force = false);
 	void make_completion_context(CompletionType p_type, Variant::Type p_builtin_type, bool p_force = false);
 	void push_completion_call(Node *p_call);
@@ -1470,6 +1490,8 @@ private:
 	bool rpc_annotation(const AnnotationNode *p_annotation, Node *p_target);
 	bool static_unload_annotation(const AnnotationNode *p_annotation, Node *p_target);
 	// Statements.
+	Vector<String> check_for_comment_block();
+	String check_for_comment();
 	Node *parse_statement();
 	VariableNode *parse_variable(bool p_is_static);
 	VariableNode *parse_variable(bool p_is_static, bool p_allow_property);

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -942,6 +942,7 @@ public:
 
 	struct LiteralNode : public ExpressionNode {
 		Variant value;
+		String source;
 		bool is_builtin_constant = false;
 		GDScriptTokenizer::Token::Type constant_type = GDScriptTokenizer::Token::EMPTY;
 

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -53,6 +53,7 @@ public:
 			ANNOTATION,
 			IDENTIFIER,
 			LITERAL,
+			COMMENT,
 			// Comparison
 			LESS,
 			LESS_EQUAL,
@@ -164,6 +165,7 @@ public:
 
 		Type type = EMPTY;
 		Variant literal;
+		String comment;
 		int start_line = 0, end_line = 0, start_column = 0, end_column = 0;
 		int leftmost_column = 0, rightmost_column = 0; // Column span for multiline tokens.
 		int cursor_position = -1;

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -212,14 +212,14 @@ private:
 		int cursor_column = -1;
 		int tab_size = 4;
 
-		// Multichar tokens
+		// Multichar tokens.
 		const char32_t *_start = nullptr;
 		int start_line = 0;
 		int start_column = 0;
 		int leftmost_column = 0;
 		int rightmost_column = 0;
 
-		// Info cache
+		// Info cache.
 		bool line_continuation = false; // Whether this line is a continuation of the previous, like when using '\'.
 		bool multiline_mode = false;
 		List<Token> error_stack;

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -202,6 +202,49 @@ public:
 #endif // TOOLS_ENABLED
 
 private:
+	struct State {
+		String source;
+		const char32_t *_source = nullptr;
+		const char32_t *_current = nullptr;
+		int line = -1;
+		int column = -1;
+		int cursor_line = -1;
+		int cursor_column = -1;
+		int tab_size = 4;
+
+		// Multichar tokens
+		const char32_t *_start = nullptr;
+		int start_line = 0;
+		int start_column = 0;
+		int leftmost_column = 0;
+		int rightmost_column = 0;
+
+		// Info cache
+		bool line_continuation = false; // Whether this line is a continuation of the previous, like when using '\'.
+		bool multiline_mode = false;
+		List<Token> error_stack;
+		bool pending_newline = false;
+		Token last_newline;
+		int pending_indents = 0;
+		List<int> indent_stack;
+		List<List<int>> indent_stack_stack; // For lambdas, which require manipulating the indentation point.
+		List<char32_t> paren_stack;
+		char32_t indent_char = '\0';
+		int position = 0;
+		int length = 0;
+
+#ifdef DEBUG_ENABLED
+		Vector<String> keyword_list;
+#endif // DEBUG_ENABLED
+
+#ifdef TOOLS_ENABLED
+		HashMap<int, CommentData> comments;
+#endif // TOOLS_ENABLED
+
+		State() {}
+	};
+	List<State> states;
+
 	String source;
 	const char32_t *_source = nullptr;
 	const char32_t *_current = nullptr;
@@ -267,8 +310,12 @@ private:
 	Token string();
 	Token annotation();
 
+	void push_state();
+	void pop_state();
+
 public:
 	Token scan();
+	Token peek(int p_offset = 0);
 
 	void set_source_code(const String &p_source_code);
 

--- a/modules/gdscript/tests/scripts/parser/errors/duplicate_tool.out
+++ b/modules/gdscript/tests/scripts/parser/errors/duplicate_tool.out
@@ -1,2 +1,2 @@
-GDTEST_ANALYZER_ERROR
+GDTEST_PARSER_ERROR
 "@tool" annotation can only be used once.

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -3122,6 +3122,24 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 			CHECK_FORMAT(code, pre_formatted);
 		}
 	}
+
+	TEST_CASE("Annotations should not be split if the line is not too long") {
+		SUBCASE("Under the line limit") {
+			const String code = R"(@export_exp_easing var very_small_var: float = 0.0
+)";
+			const String pre_formatted = code;
+			CHECK_FORMAT(code, pre_formatted);
+		}
+
+		SUBCASE("Above the line limit") {
+			const String code = R"(@export_exp_easing var very_long_long_long_long_long_long_long_long_long_long_long_long_long_long_var: float = 0.0
+)";
+			const String pre_formatted = R"(@export_exp_easing
+var very_long_long_long_long_long_long_long_long_long_long_long_long_long_long_var: float = 0.0
+)";
+			CHECK_FORMAT(code, pre_formatted);
+		}
+	}
 } // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]")
 
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Misc]") {

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -4165,6 +4165,15 @@ func my_func(optional_param := ""):
 )");
 		CHECK_FORMAT(code, pre_formatted);
 	}
+
+	TEST_CASE("Comments after a bitshift should not create a multiline expression") {
+		const String code = GDSCRIPT(R"(
+var _MAX_FILE_SIZE = 1 << 20 # 1 MiB
+)");
+		const String pre_formatted = code;
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
 } // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Misc]")
 
 } //namespace GDScriptTests

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -2196,15 +2196,10 @@ func _ready() -> void:
 	match x:
 		0
 )");
-		const String pre_formatted =
-				GDSCRIPT(R"(
-func _ready() -> void:
-	var x = 0
-	match x:
-		0
-)");
-
-		CHECK_FORMAT(code, pre_formatted);
+		GDScriptFormat formatter;
+		String output;
+		Error err = formatter.format(code, output);
+		CHECK(err != OK);
 	}
 
 	TEST_CASE("Should not error out on a lambda wrapped in a multiline") {

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -2812,34 +2812,24 @@ var my_variable := [
 	TEST_CASE("Should output a variable with a comment next to an element in a double nested array") {
 		const String code =
 				GDSCRIPT(R"(
-var my_variable := [0,1,2,[0,1,[
-	0,1, # The comment can go here
-	2
-],3],4,5,6,7,8,9]
+func _ready():
+	var my_variable := [0,1,2,[0,1,[
+		0,1, # The comment can go here
+		2
+	],3],4,5,6,7,8,9]
 )");
 		const String pre_formatted =
 				GDSCRIPT(R"(
-var my_variable := [
-	0,
-	1,
-	2,
-	[
-		0,
-		1,
-		[
-			0,
-			1, # The comment can go here
-			2,
-		],
-		3,
-	],
-	4,
-	5,
-	6,
-	7,
-	8,
-	9,
-]
+func _ready():
+	var my_variable := [
+		0, 1, 2, [
+			0, 1, [
+				0,
+				1, # The comment can go here
+				2,
+			], 3
+		], 4, 5, 6, 7, 8, 9
+	]
 )");
 
 		CHECK_FORMAT(code, pre_formatted);
@@ -3977,6 +3967,49 @@ func _ready():
 		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Header comments of the first element of an array should be formatted as that") {
+		const String code = GDSCRIPT(R"(
+static func generate_guid() -> String:
+	var b = []
+	return "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x" % [
+			# low
+			b[0], b[1], b[2], b[3],
+			# mid
+			b[4], b[5],
+			# hi
+			b[6], b[7],
+			# clock
+			b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15]
+	]
+)");
+		const String pre_formatted = GDSCRIPT(R"(
+static func generate_guid() -> String:
+	var b = []
+	return (
+			"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x"
+			% [
+				b[0],
+				b[1],
+				b[2],
+				b[3],
+				b[4],
+				b[5],
+				b[6],
+				b[7],
+				b[8],
+				b[9],
+				b[10],
+				b[11],
+				b[12],
+				b[13],
+				b[14],
+				b[15],
+				b[16],
+			]
+	)
+)");
 	}
 } // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Comments]")
 

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -1,0 +1,2954 @@
+/**************************************************************************/
+/*  test_gdscript_formatter.h                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_GDSCRIPT_FORMATTER_H
+#define TEST_GDSCRIPT_FORMATTER_H
+
+#include "core/string/ustring.h"
+#include "modules/gdscript/gdscript_format.h"
+#include "tests/test_macros.h"
+
+namespace GDScriptTests {
+
+#define CHECK_FORMAT(code, pre_formatted)    \
+	GDScriptFormat formatter;                \
+	formatter.indent_in_multiline_block = 1; \
+	String output = formatter.format(code);  \
+	CHECK_EQ(output, pre_formatted)
+
+TEST_SUITE("[Modules][GDScript][GDScriptFormatter][ClassMembers]") {
+	TEST_CASE("Should output a variable with a property that has a setter and getter, inline") {
+		const String code = R"(var my_property := 0:
+	get:
+		return my_property
+	set(value):
+		my_property = value)";
+		const String pre_formatted = R"(var my_property := 0:
+	set(value):
+		my_property = value
+	get:
+		return my_property
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a property that has a setter with a spare line after the property for readability") {
+		const String code = R"(var my_property := 0:
+	set(value):
+		my_property = value
+var some_variable = 0)";
+		const String pre_formatted = R"(var my_property := 0:
+	set(value):
+		my_property = value
+
+var some_variable = 0
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable that takes a casted value") {
+		const String code = R"(var my_casted_variable := my_uncasted_variable as CastedType)";
+		const String pre_formatted = R"(var my_casted_variable := my_uncasted_variable as CastedType
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable that takes a casted value's output") {
+		const String code = R"(var my_casted_variable := (my_uncasted_variable as CastedType).result)";
+		const String pre_formatted = R"(var my_casted_variable := (my_uncasted_variable as CastedType).result
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a simple class with a variable") {
+		const String code = R"(var my_variable)";
+		const String pre_formatted = R"(var my_variable
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a datatype but no value") {
+		const String code = R"(var my_variable: MyDataType)";
+		const String pre_formatted = R"(var my_variable: MyDataType
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a simple class with a variable with self") {
+		const String code = R"(var my_variable = self)";
+		const String pre_formatted = R"(var my_variable = self
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable that has a basic export annotation") {
+		const String code = R"(@export var my_variable)";
+		const String pre_formatted = R"(@export var my_variable
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable that has multiple annotations on one line when they fit") {
+		const String code = R"(@onready @export var my_variable)";
+		const String pre_formatted = R"(@onready @export var my_variable
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable that has a export annotation with parameters") {
+		const String code = R"(@export_range(0, 20) var my_variable)";
+		const String pre_formatted = R"(@export_range(0, 20)
+var my_variable
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable that has a export annotation with parameters that causes an annotation split") {
+		const String code = R"(@export_enum("One thing leads", "to another, which causes", "a split to occur", "even if this is not", "a valid enum") var my_variable)";
+		const String pre_formatted = R"(@export_enum("One thing leads", "to another, which causes", "a split to occur", "even if this is not", "a valid enum")
+var my_variable
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with an array being accessed by index") {
+		const String code = "var my_variable := presences[0]";
+		const String pre_formatted = R"(var my_variable := presences[0]
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a dictionary being accessed by index") {
+		const String code = R"(var my_variable := presences["MatchId"])";
+		const String pre_formatted = R"(var my_variable := presences["MatchId"]
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a dictionary being accessed by attribute") {
+		const String code = R"(var my_variable := output.format)";
+		const String pre_formatted = R"(var my_variable := output.format
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a dictionary being accessed by function that wraps due to length") {
+		const String code = R"(var my_variable := output[get_formatting_index_based_on_data("localhost", 8080, "development_branch")])";
+		const String pre_formatted = R"(var my_variable := output[
+	get_formatting_index_based_on_data("localhost", 8080, "development_branch")
+]
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable that uses a simple if/else ternary") {
+		const String code = "var my_variable := 5 if true else 8";
+		const String pre_formatted = R"(var my_variable := 5 if true else 8
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable that uses a if/else ternary that wraps due to length") {
+		const String code = R"(var my_variable := "a long string goes here to force a wrap" if true else "lorem ipsum 3.145967 robot meme")";
+		const String pre_formatted = R"(var my_variable := (
+	"a long string goes here to force a wrap" if true
+	else "lorem ipsum 3.145967 robot meme"
+)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable that uses a if/else ternary that wraps due to length with a function that wraps due to length") {
+		const String code = R"(var my_variable := "a long string goes here to force a wrap" if true else some_function("lorem ipsum", 3.145967, "robot memory of some length", "formidable length of string"))";
+		const String pre_formatted = R"(var my_variable := (
+	"a long string goes here to force a wrap" if true
+	else some_function(
+		"lorem ipsum", 3.145967, "robot memory of some length", "formidable length of string"
+	)
+)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable that holds a negated integer") {
+		const String code = "var my_variable := -2";
+		const String pre_formatted = R"(var my_variable := -2
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable that holds an inverted truth") {
+		const String code = "var my_variable := not my_condition";
+		const String pre_formatted = R"(var my_variable := not my_condition
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a get node path") {
+		const String code = "var my_variable := $Node";
+		const String pre_formatted = R"(var my_variable := $Node
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a get node chain path") {
+		const String code = "var my_variable := $NodeA/NodeB/NodeC";
+		const String pre_formatted = R"(var my_variable := $NodeA/NodeB/NodeC
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a get node string") {
+		const String code = R"(var my_variable := $"../Parent/NodeB")";
+		const String pre_formatted = R"(var my_variable := $"../Parent/NodeB"
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a preload") {
+		const String code = R"(var my_variable := preload("res://Player.tscn"))";
+		const String pre_formatted = R"(var my_variable := preload("res://Player.tscn")
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a preload that wraps") {
+		const String code = R"(var my_variable := preload("res://A/Deep/Folder/Hierarchy/To/Encourage/Wrapping/PlayerSceneWithALongName.tscn"))";
+		const String pre_formatted = R"(var my_variable := preload(
+	"res://A/Deep/Folder/Hierarchy/To/Encourage/Wrapping/PlayerSceneWithALongName.tscn"
+)
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a basic operation") {
+		SUBCASE("+") {
+			String code = "var my_variable := 0+1";
+			String pre_formatted = R"(var my_variable := 0 + 1
+)";
+			CHECK_FORMAT(code, pre_formatted);
+		}
+
+		SUBCASE("-") {
+			String code = "var my_variable := 0-1";
+			String pre_formatted = R"(var my_variable := 0 - 1
+)";
+
+			CHECK_FORMAT(code, pre_formatted);
+		}
+
+		SUBCASE("*") {
+			String code = "var my_variable := 0*1";
+			String pre_formatted = R"(var my_variable := 0 * 1
+)";
+			CHECK_FORMAT(code, pre_formatted);
+		}
+
+		SUBCASE("/") {
+			String code = "var my_variable := 0/1";
+			String pre_formatted = R"(var my_variable := 0 / 1
+)";
+
+			CHECK_FORMAT(code, pre_formatted);
+		}
+
+		SUBCASE("%") {
+			String code = "var my_variable := 0%1";
+			String pre_formatted = R"(var my_variable := 0 % 1
+)";
+			CHECK_FORMAT(code, pre_formatted);
+		}
+	}
+
+	TEST_CASE("Should output nested binary operation") {
+		const String code = "var my_variable := 0+0+1";
+		const String pre_formatted = R"(var my_variable := 0 + 0 + 1
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output double nested binary operation") {
+		const String code = "var my_variable := 0+1+0+1";
+		const String pre_formatted = R"(var my_variable := 0 + 1 + 0 + 1
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a binary operation") {
+		const String code = "var my_variable := 0+1";
+		const String pre_formatted = R"(var my_variable := 0 + 1
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with string concat") {
+		const String code = R"(var my_variable := "Hello"+"World !")";
+		const String pre_formatted = R"(var my_variable := "Hello" + "World !"
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with string concat that is wrapped due to length") {
+		const String code = R"(var my_variable := "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas et neque sodales, tempor ex sit amet, venenatis elit." + "Etiam ultrices enim id venenatis tempor. Quisque dictum ligula vel felis vestibulum, eget eleifend sem suscipit.")";
+		const String pre_formatted = R"(var my_variable := (
+	"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas et neque sodales, tempor ex sit amet, venenatis elit."
+	+ "Etiam ultrices enim id venenatis tempor. Quisque dictum ligula vel felis vestibulum, eget eleifend sem suscipit."
+)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with double string concat that is wrapped due to length") {
+		const String code = R"(var my_variable := "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas et neque sodales, tempor ex sit amet, venenatis elit." + "Etiam ultrices enim id venenatis tempor. Quisque dictum ligula vel felis vestibulum, eget eleifend sem suscipit." + "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas et neque sodales, tempor ex sit amet, venenatis elit." + "Etiam ultrices enim id venenatis tempor. Quisque dictum ligula vel felis vestibulum, eget eleifend sem suscipit.")";
+		const String pre_formatted = R"(var my_variable := (
+	"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas et neque sodales, tempor ex sit amet, venenatis elit."
+	+ "Etiam ultrices enim id venenatis tempor. Quisque dictum ligula vel felis vestibulum, eget eleifend sem suscipit."
+	+ "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas et neque sodales, tempor ex sit amet, venenatis elit."
+	+ "Etiam ultrices enim id venenatis tempor. Quisque dictum ligula vel felis vestibulum, eget eleifend sem suscipit."
+)
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable that is broken due to length with double string concat that is not wrapped due to length") {
+		const String code = R"(var my_variable := "Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum ")";
+		const String pre_formatted = R"(var my_variable := (
+	"Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum "
+)
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a properly formatted binary division operation with order of operations preserved") {
+		const String code = R"(var my_variable := 4 / (1 + 1))";
+		const String pre_formatted = R"(var my_variable := 4 / (1 + 1)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a preserved formatted operation") {
+		const String code = R"(var my_variable := 4 / 1 + 1)";
+		const String pre_formatted = R"(var my_variable := 4 / 1 + 1
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a formatted operation for complex operation") {
+		const String code = R"(var my_variable := 3+(6*(11+1-4))/8*2)";
+		const String pre_formatted = R"(var my_variable := 3 + 6 * (11 + 1 - 4) / 8 * 2
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a formatted operation for multiplication") {
+		const String code = R"(var my_variable := 4 * (1 + 1))";
+		const String pre_formatted = R"(var my_variable := 4 * (1 + 1)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should be able to store a variable with array") {
+		const String code = R"(var my_variable := [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])";
+		const String pre_formatted = R"(var my_variable := [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should be able to store a variable with array that wraps due to length") {
+		const String code = R"(var my_variable := ["Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit."])";
+		const String pre_formatted = R"(var my_variable := [
+	"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+]
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should be able to store a variable with array with subarray that wraps due to length") {
+		const String code = R"(var my_variable := [["Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit."]])";
+		const String pre_formatted = R"(var my_variable := [
+	[
+		"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+		"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+		"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+		"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+		"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+	],
+]
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should be able to store a variable with array that breaks, of arrays that do not break") {
+		const String code = R"(var my_variable := [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])";
+		const String pre_formatted = R"(var my_variable := [
+	[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+	[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+	[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+]
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should maintain type information for typed arrays") {
+		const String code = R"(extends Node
+
+@onready var children: Array[Node] = get_children())";
+		const String pre_formatted = "extends Node\n\n\n@onready var children: Array[Node] = get_children()\n";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a simple one line dictionary") {
+		const String code = R"(var my_variable := {"string key":"string value"})";
+		const String pre_formatted = R"(var my_variable := {"string key": "string value"}
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a simple one line Lua dictionary") {
+		const String code = R"(var my_variable := {string_key="string value"})";
+		const String pre_formatted = R"(var my_variable := {string_key = "string value"}
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a dictionary wrapped due to length") {
+		const String code = R"(var my_variable := {"string key 1":"string value", "string key 2":"string value", "string key 3":"string value", "string key 4":"string value", "string key 5":"string value"})";
+		const String pre_formatted = R"(var my_variable := {
+	"string key 1": "string value",
+	"string key 2": "string value",
+	"string key 3": "string value",
+	"string key 4": "string value",
+	"string key 5": "string value",
+}
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a dictionary that wraps an element due to length") {
+		const String code = R"(var test := {"test":"a long concat expression"+some_function_call("with a lot of", "very long parameters", "that should be wrapped", "due to its severely extended length")})";
+		const String pre_formatted = R"(var test := {
+	"test": (
+		"a long concat expression"
+		+ some_function_call(
+			"with a lot of",
+			"very long parameters",
+			"that should be wrapped",
+			"due to its severely extended length"
+		)
+	),
+}
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with an assigned value") {
+		const String code = "var my_variable = 0";
+		const String pre_formatted = R"(var my_variable = 0
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with inferred datatype") {
+		const String code = "var my_variable := 0";
+		const String pre_formatted = R"(var my_variable := 0
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with an explicit datatype") {
+		const String code = "var my_variable: int = 0";
+		const String pre_formatted = R"(var my_variable: int = 0
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a string literal") {
+		const String code = R"(var my_variable := "Hello, my friends!")";
+		const String pre_formatted = R"(var my_variable := "Hello, my friends!"
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a string literal that contains a quotation mark") {
+		const String code = R"(var my_variable := 'Hello, my "friends"!')";
+		const String pre_formatted = R"(var my_variable := 'Hello, my "friends"!'
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a decimal") {
+		const String code = "var my_variable := 0.0";
+		const String pre_formatted = R"(var my_variable := 0.0
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a decimal value") {
+		const String code = "var my_variable := 0.25";
+		const String pre_formatted = R"(var my_variable := 0.25
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should be able to refer to another variable by identifier") {
+		const String code = R"(var other_variable_name
+var my_variable := other_variable_name)";
+		const String pre_formatted = R"(var other_variable_name
+var my_variable := other_variable_name
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should do binary operation inside a simple function call") {
+		const String code = R"(var my_variable := a_math_function(20+5))";
+		const String pre_formatted = R"(var my_variable := a_math_function(20 + 5)
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a function with multiple arguments") {
+		const String code = R"(var my_variable:=Vector2(300,47))";
+		const String pre_formatted = R"(var my_variable := Vector2(300, 47)
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable that does a function call") {
+		const String code = R"(var cell_position := world_to_map_split(300, 47))";
+		const String pre_formatted = R"(var cell_position := world_to_map_split(300, 47)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should be able to store a variable with a function call that breaks, of parameters that do not break") {
+		const String code = R"(var wrapped_text := wrap_some_text("Lorem ipsum","Lorem ipsum","Lorem ipsum","Lorem ipsum","Lorem ips"))";
+		const String pre_formatted = R"(var wrapped_text := wrap_some_text(
+	"Lorem ipsum", "Lorem ipsum", "Lorem ipsum", "Lorem ipsum", "Lorem ips"
+)
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("First function after a non-function should be separated by newlines") {
+		const String code = R"(var my_variable = 0
+func _ready():
+	pass)";
+		const String pre_formatted = "var my_variable = 0\n\n\nfunc _ready():\n\tpass\n";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a class constant") {
+		const String code = "const MY_CONST = 50";
+		const String pre_formatted = R"(const MY_CONST = 50
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should keep built-in constants as named constants") {
+		const String code = "const TAU_COPY = TAU";
+		const String pre_formatted = R"(const TAU_COPY = TAU
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Sequential constants should follow one another, then line break for the next element type") {
+		const String code = R"(const MY_CONST_A := 5
+const MY_CONST_B = 0
+var my_variable := 10)";
+		const String pre_formatted = R"(const MY_CONST_A := 5
+const MY_CONST_B = 0
+
+var my_variable := 10
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output user-inputted incidental new lines in classes") {
+		const String code = R"(const CONSTANT_A := 0
+const CONSTANT_B := 1
+
+const CONSTANT_GROUP_A := 0
+const CONSTANT_GROUP_B := 1)";
+		const String pre_formatted = R"(const CONSTANT_A := 0
+const CONSTANT_B := 1
+
+const CONSTANT_GROUP_A := 0
+const CONSTANT_GROUP_B := 1
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a get_node statement with a nodepath string") {
+		const String code = R"(@onready var node = get_node(^"Node"))";
+		const String pre_formatted = R"(@onready var node = get_node(^"Node")
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a get_node statement with a stringname string") {
+		const String code = R"(@onready var node = get_node(&"Node"))";
+		const String pre_formatted = R"(@onready var node = get_node(&"Node")
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a signal declaration") {
+		const String code = "signal signal_happened";
+		const String pre_formatted = R"(signal signal_happened
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a signal declaration with parameters") {
+		const String code = "signal signal_happened(a, b,c)";
+		const String pre_formatted = R"(signal signal_happened(a, b, c)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a signal declaration with parameters that wrap due to length") {
+		const String code = "signal signal_happened(a_long_list_of_long_parameters_a, a_long_list_of_long_parameters_b,a_long_list_of_long_parameters_c,a_long_list_of_long_parameters_d)";
+		const String pre_formatted = R"(signal signal_happened(
+	a_long_list_of_long_parameters_a,
+	a_long_list_of_long_parameters_b,
+	a_long_list_of_long_parameters_c,
+	a_long_list_of_long_parameters_d
+)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a signal declaration with explicit empty parameter list being maintained") {
+		const String code = "signal my_signal()";
+		const String pre_formatted = "signal my_signal()\n";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a simple named enum") {
+		const String code = "enum MyEnum { A, B, C }";
+		const String pre_formatted = R"(enum MyEnum { A, B, C }
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output an enum with a value") {
+		const String code = "enum MyEnum { A, B, C = 5, D }";
+		const String pre_formatted = R"(enum MyEnum { A, B, C = 5, D }
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a named enum that wraps due to length") {
+		const String code = "enum MyNamedEnumWithALongName { ENUM_A_WITH_A_NAME, ENUM_A_WITH_B_NAME, ENUM_A_WITH_C_NAME, ENUM_A_WITH_D_NAME, ENUM_A_WITH_E_NAME, ENUM_A_WITH_F_NAME }";
+		const String pre_formatted = R"(enum MyNamedEnumWithALongName {
+	ENUM_A_WITH_A_NAME,
+	ENUM_A_WITH_B_NAME,
+	ENUM_A_WITH_C_NAME,
+	ENUM_A_WITH_D_NAME,
+	ENUM_A_WITH_E_NAME,
+	ENUM_A_WITH_F_NAME,
+}
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a named enum that wraps due to length but elements do not wrap") {
+		const String code = "enum MyNamedEnumWithALongName {ENUM_A_WITH_A_NAME, ENUM_A_WITH_B_NAME,	ENUM_A_WITH_C_NAME, ENUM_A_WITH_D_NAME}";
+		const String pre_formatted = R"(enum MyNamedEnumWithALongName {
+	ENUM_A_WITH_A_NAME, ENUM_A_WITH_B_NAME, ENUM_A_WITH_C_NAME, ENUM_A_WITH_D_NAME
+}
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a simple property enum") {
+		const String code = "enum { A, B, C }";
+		const String pre_formatted = R"(enum { A, B, C }
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Sequential signals should follow one another, then line break for the next element type") {
+		const String code = R"(signal my_signal_a
+signal my_signal_b
+var my_variable = 0)";
+		const String pre_formatted = R"(signal my_signal_a
+signal my_signal_b
+
+var my_variable = 0
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should only have one extra line after an inner class") {
+		const String code = R"(class InnerClass:
+	var my_variable)";
+		const String pre_formatted = R"(class InnerClass:
+	var my_variable
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a null value correctly") {
+		const String code = "var my_value = null";
+		const String pre_formatted = "var my_value = null\n";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a typed null value correctly") {
+		const String code = "var my_value: Object = null";
+		const String pre_formatted = "var my_value: Object = null\n";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+}
+
+TEST_SUITE("[Modules][GDScript][GDScriptFormatter][ClassSignatures]") {
+	TEST_CASE("Should output a simple class") {
+		const String code = "extends Node";
+		const String pre_formatted = R"(extends Node
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a simple class with a name") {
+		const String code = "extends Sprite2D\nclass_name MySpriteExtension";
+		const String pre_formatted = R"(class_name MySpriteExtension
+extends Sprite2D
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a class that extends a subclass") {
+		const String code = "extends OuterClass.InnerClass";
+		const String pre_formatted = R"(extends OuterClass.InnerClass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a class that extends a script file") {
+		const String code = "extends \"res://script.gd\"";
+		const String pre_formatted = R"(extends "res://script.gd"
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a class that extends a script file's subclass") {
+		const String code = "extends \"res://script.gd\".SubClass";
+		const String pre_formatted = R"(extends "res://script.gd".SubClass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a class that has the tool annotation") {
+		const String code = R"(@tool
+extends Node)";
+		const String pre_formatted = R"(@tool
+extends Node
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a class with an icon set") {
+		const String code = R"(@icon("res://CustomTypes/icon.svg")
+class_name MyClass
+extends Node)";
+		const String pre_formatted = R"(@icon("res://CustomTypes/icon.svg")
+class_name MyClass
+extends Node
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+}
+
+TEST_SUITE("[Modules][GDScript][GDScriptFormatter][ClassFunctions]") {
+	TEST_CASE("Should output a simple class method") {
+		const String code = R"(func _ready():
+	pass)";
+		const String pre_formatted = R"(func _ready():
+	pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a simple class method with a parameter") {
+		const String code = R"(func _process(delta):
+	pass)";
+		const String pre_formatted = R"(func _process(delta):
+	pass
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a simple class method with multiple parameters") {
+		const String code = R"(func operate_lever(lever_id, operator_id):
+	pass)";
+		const String pre_formatted = R"(func operate_lever(lever_id, operator_id):
+	pass
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a simple class method with multiple parameters with specified types") {
+		const String code = R"(func operate_lever(lever_id:int, operator_id:int):
+	pass)";
+		const String pre_formatted = R"(func operate_lever(lever_id: int, operator_id: int):
+	pass
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a simple class method with multiple parameters with specified types and default values") {
+		const String code = R"(func operate_lever(lever_id:int=0, operator_id:int=1):
+	pass)";
+		const String pre_formatted = R"(func operate_lever(lever_id: int = 0, operator_id: int = 1):
+	pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a simple class method with multiple parameters with inferred types and default values") {
+		const String code = R"(func operate_lever(lever_id:=0, operator_id:=1):
+	pass)";
+		const String pre_formatted = R"(func operate_lever(lever_id := 0, operator_id := 1):
+	pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a simple class method with multiple parameters that wrap due to length") {
+		const String code = R"(func a_long_function_name_with_a_lot_of_params(such_as_this_one, and_this_one, and_also_this_one, not_to_mention_this_one_over_here, but_not_this_one):
+	pass)";
+		const String pre_formatted = R"(func a_long_function_name_with_a_lot_of_params(
+	such_as_this_one,
+	and_this_one,
+	and_also_this_one,
+	not_to_mention_this_one_over_here,
+	but_not_this_one
+):
+	pass
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a simple class method that wraps due to length, with multiple parameters that do not wrap") {
+		const String code = R"(func a_medium_function_name(a_middling_length_of_params, with_a_couple_identifiers, but_not_too_many):
+	pass)";
+		const String pre_formatted = R"(func a_medium_function_name(
+	a_middling_length_of_params, with_a_couple_identifiers, but_not_too_many
+):
+	pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a class method with a return type") {
+		const String code = R"(func _ready()->void:
+	pass)";
+		const String pre_formatted = R"(func _ready() -> void:
+	pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a class method with a variable being assigned") {
+		const String code = R"(func _ready()->void:
+	var my_variable := 0)";
+		const String pre_formatted = R"(func _ready() -> void:
+	var my_variable := 0
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a class method with a return statement") {
+		const String code = R"(func _ready()->void:
+	return)";
+		const String pre_formatted = R"(func _ready() -> void:
+	return
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a class method with a non-void return statement") {
+		const String code = R"(func build()->void:
+	return 5)";
+		const String pre_formatted = R"(func build() -> void:
+	return 5
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a class method with a wrapping return statement due to length") {
+		const String code = R"(func build()->void:
+	return another_function_with_a_long_name_and_thus("lots", "of", "parameters", "that", "take up", "space"))";
+		const String pre_formatted = R"(func build() -> void:
+	return another_function_with_a_long_name_and_thus(
+		"lots", "of", "parameters", "that", "take up", "space"
+	)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a class method with a breakpoint") {
+		const String code = R"(func _ready():
+	breakpoint)";
+		const String pre_formatted = R"(func _ready():
+	breakpoint
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a class method with an assignment") {
+		const String code = R"(func _ready():
+	my_var = 50)";
+		const String pre_formatted = R"(func _ready():
+	my_var = 50
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a class method with an await statement") {
+		const String code = R"(func _ready():
+	await get_tree().idle_frame)";
+		const String pre_formatted = R"(func _ready():
+	await get_tree().idle_frame
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a method with a naked type as a statement") {
+		const String code = R"(func _ready():
+	MyNakedType)";
+		const String pre_formatted = R"(func _ready():
+	MyNakedType
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a method with a naked binary op as a statement") {
+		const String code = R"(func _ready():
+	2+2)";
+		const String pre_formatted = R"(func _ready():
+	2 + 2
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a method with a naked array as a statement") {
+		const String code = R"(func _ready():
+	[0,1,2])";
+		const String pre_formatted = R"(func _ready():
+	[0, 1, 2]
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a method with a naked Dictionary as a statement") {
+		const String code = R"(func _ready():
+	{0:5})";
+		const String pre_formatted = R"(func _ready():
+	{0: 5}
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a method with a naked get node as a statement") {
+		const String code = R"(func _ready():
+	$Node)";
+		const String pre_formatted = R"(func _ready():
+	$Node
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a method with a naked literal as a statement") {
+		const String code = R"(func _ready():
+	5)";
+		const String pre_formatted = R"(func _ready():
+	5
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a method with a naked preload as a statement") {
+		const String code = R"(func _ready():
+	preload("Node.tscn"))";
+		const String pre_formatted = R"(func _ready():
+	preload("Node.tscn")
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a method with a naked self as a statement") {
+		const String code = R"(func _ready():
+	self)";
+		const String pre_formatted = R"(func _ready():
+	self
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a method with a naked subscript as a statement") {
+		const String code = R"(func _ready():
+	the_array[0])";
+		const String pre_formatted = R"(func _ready():
+	the_array[0]
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a method with a ternary block as a statement") {
+		const String code = R"(func _ready():
+	5 if true else 0)";
+		const String pre_formatted = R"(func _ready():
+	5 if true else 0
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a method with a unary block as a statement") {
+		const String code = R"(func _ready():
+	-x)";
+		const String pre_formatted = R"(func _ready():
+	-x
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a method marked as static") {
+		const String code = R"(static func build():
+	return 5)";
+		const String pre_formatted = R"(static func build():
+	return 5
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a method with an RPC annotation") {
+		const String code = R"(@rpc func build():
+	return 5)";
+		const String pre_formatted = R"(@rpc
+func build():
+	return 5
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable that does a function call from a callee") {
+		const String code = R"(func _ready():
+	the_callee.the_call())";
+		const String pre_formatted = R"(func _ready():
+	the_callee.the_call()
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable that does a function call for super") {
+		const String code = R"(func _ready():
+	super.the_call())";
+		const String pre_formatted = R"(func _ready():
+	super.the_call()
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should wrap a long function call argument array properly") {
+		const String code = R"(func _ready():
+	var arr = []
+	arr.append_array(["long string 1", "long string 2", "long string 3", "long string 4", "long string 5", "long string 6"]))";
+		const String pre_formatted = R"(func _ready():
+	var arr = []
+	arr.append_array([
+		"long string 1", "long string 2", "long string 3", "long string 4", "long string 5", "long string 6"
+	])
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a function that has an assert condition") {
+		const String code = R"(func _ready():
+	assert(some_condition(), "Should have called a condition"))";
+		const String pre_formatted = R"(func _ready():
+	assert(some_condition(), "Should have called a condition")
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a function that has an assert condition that wraps due to length with a condition that breaks due to length") {
+		const String code = R"(func _ready():
+	assert(some_condition("with", "a bunch of parameters", "to cause a wrap", "on multiple lines that wrap and go on a bit too long"),"Should have called a condition that wraps due to length, especially with a long message"))";
+		const String pre_formatted = R"(func _ready():
+	assert(some_condition(
+		"with",
+		"a bunch of parameters",
+		"to cause a wrap",
+		"on multiple lines that wrap and go on a bit too long"
+	), "Should have called a condition that wraps due to length, especially with a long message")
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Sequential functions should be separated by newlines") {
+		const String code = R"(func _ready():
+	pass
+func _process(delta):
+	pass)";
+		const String pre_formatted = "func _ready():\n\tpass\n\n\nfunc _process(delta):\n\tpass\n";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should have a call with an array as an argument keep its brackets near the parentheses") {
+		const String code = R"(func _ready():
+	var arr = []
+	arr.append_array([
+		"test with a long string 1",
+		"test with a long string 2",
+		"test with a long string 3",
+		"test with a long string 4",
+	]))";
+		const String pre_formatted = R"(func _ready():
+	var arr = []
+	arr.append_array([
+		"test with a long string 1",
+		"test with a long string 2",
+		"test with a long string 3",
+		"test with a long string 4",
+	])
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should wrap long lines but not be too aggressive about parentheses") {
+		const String code = R"(func _ready():
+	var this_is_a_very_long_boolean_for_test_purposes: bool = false
+	if this_is_a_very_long_boolean_for_test_purposes or this_is_a_very_long_boolean_for_test_purposes or this_is_a_very_long_boolean_for_test_purposes:
+		pass)";
+		const String pre_formatted = R"(func _ready():
+	var this_is_a_very_long_boolean_for_test_purposes: bool = false
+	if (
+		this_is_a_very_long_boolean_for_test_purposes
+		or this_is_a_very_long_boolean_for_test_purposes
+		or this_is_a_very_long_boolean_for_test_purposes
+	):
+		pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+}
+
+TEST_SUITE("[Modules][GDScript][GDScriptFormatter][NestedSuites]") {
+	TEST_CASE("Should output a simple if true/else statement") {
+		const String code = R"(func _ready():
+	if true:
+		pass
+	else:
+		pass)";
+		const String pre_formatted = R"(func _ready():
+	if true:
+		pass
+	else:
+		pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a simple if/elif/else statement") {
+		const String code = R"(func _ready():
+	if 0:
+		pass
+	elif 1:
+		pass
+	else:
+		pass)";
+		const String pre_formatted = R"(func _ready():
+	if 0:
+		pass
+	elif 1:
+		pass
+	else:
+		pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a if statement that wraps due to length") {
+		const String code = R"(func _ready():
+	if some_conditional_function_with_a_true_false_return_type("and a chunk", "of long", "parameters", "with strings"):
+		pass)";
+		const String pre_formatted = R"(func _ready():
+	if (
+		some_conditional_function_with_a_true_false_return_type(
+			"and a chunk", "of long", "parameters", "with strings"
+		)
+	):
+		pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Nested if blocks should not stack newlines at end of suite") {
+		const String code = "func _ready():\n\tif true:\n\t\tif true:\n\t\t\tif true:\n\t\t\t\tpass\n\tpass\n";
+		const String pre_formatted = R"(func _ready():
+	if true:
+		if true:
+			if true:
+				pass
+	pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output an infinite while loop") {
+		const String code = R"(func _ready():
+	while true:
+		pass)";
+		const String pre_formatted = R"(func _ready():
+	while true:
+		pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a while loop with a condition call") {
+		const String code = R"(func _ready():
+	while some_conditional_function_with_a_true_false_return_type("and a chunk", "of long", "parameters", "with strings"):
+		pass)";
+		const String pre_formatted = R"(func _ready():
+	while (
+		some_conditional_function_with_a_true_false_return_type(
+			"and a chunk", "of long", "parameters", "with strings"
+		)
+	):
+		pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a while loop with a break statement") {
+		const String code = R"(func _ready():
+	while true:
+		break)";
+		const String pre_formatted = R"(func _ready():
+	while true:
+		break
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a while loop with a continue statement") {
+		const String code = R"(func _ready():
+	while true:
+		continue)";
+		const String pre_formatted = R"(func _ready():
+	while true:
+		continue
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a simple match block") {
+		const String code = R"(func _ready():
+	var test := true
+	match test:
+		true:
+			pass
+		false:
+			pass
+		)";
+		const String pre_formatted = R"(func _ready():
+	var test := true
+	match test:
+		true:
+			pass
+		false:
+			pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a match block with multiple patterns") {
+		const String code = R"(func _ready():
+	var test := 50
+	match test:
+		50, 75, 100:
+			pass
+		60, 85, 105:
+			pass
+		)";
+		const String pre_formatted = R"(func _ready():
+	var test := 50
+	match test:
+		50, 75, 100:
+			pass
+		60, 85, 105:
+			pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a match block with a wildcard entry") {
+		const String code = R"(func _ready():
+	var test := 50
+	match test:
+		50:
+			print(50)
+		_:
+			print("Not 50"))";
+		const String pre_formatted = R"(func _ready():
+	var test := 50
+	match test:
+		50:
+			print(50)
+		_:
+			print("Not 50")
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a match block with a variable entry") {
+		const String code = R"(func _ready():
+	var test := 50
+	match test:
+		MY_CONST:
+			print(50)
+		MY_OTHER_CONST:
+			print("Not 50"))";
+		const String pre_formatted = R"(func _ready():
+	var test := 50
+	match test:
+		MY_CONST:
+			print(50)
+		MY_OTHER_CONST:
+			print("Not 50")
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a match block with a binding entry") {
+		const String code = R"(func _ready():
+	var test := 30
+	match test:
+		50:
+			print(50)
+		25:
+			print(25)
+		var result:
+			print("Not %s" % [result]))";
+		const String pre_formatted = R"(func _ready():
+	var test := 30
+	match test:
+		50:
+			print(50)
+		25:
+			print(25)
+		var result:
+			print("Not %s" % [result])
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a match block with a array entry") {
+		const String code = R"(func _ready():
+	var test := [0, 1, 2]
+	match test:
+		[0, 1, 2]:
+			print(50)
+		[3, 4, 5]:
+			print(25))";
+		const String pre_formatted = R"(func _ready():
+	var test := [0, 1, 2]
+	match test:
+		[0, 1, 2]:
+			print(50)
+		[3, 4, 5]:
+			print(25)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a match block with an open-ended array entry") {
+		const String code = R"(func _ready():
+	var test := [0, 1, 2]
+	match test:
+		[0, 1, ..]:
+			print(50)
+		[3, 4, 5]:
+			print(25))";
+		const String pre_formatted = R"(func _ready():
+	var test := [0, 1, 2]
+	match test:
+		[0, 1, ..]:
+			print(50)
+		[3, 4, 5]:
+			print(25)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a match block with a dictionary entry") {
+		const String code = R"(func _ready():
+	var test := {"friend": "Me", "best": true}
+	match test:
+		{"friend": "Me", "best": true}:
+			print("happy")
+		{"friend": "Me", "best": false}:
+			print("sad"))";
+		const String pre_formatted = R"(func _ready():
+	var test := {"friend": "Me", "best": true}
+	match test:
+		{"friend": "Me", "best": true}:
+			print("happy")
+		{"friend": "Me", "best": false}:
+			print("sad")
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a simple for loop") {
+		const String code = R"(func _ready():
+	for i in 10:
+		pass)";
+		const String pre_formatted = R"(func _ready():
+	for i in 10:
+		pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a for loop with a wrapped condition due to length") {
+		const String code = R"(func _ready() -> void:
+	for i in ["A long string here","A long string there","A long string, everywhere","Hither and thither","The long strings go","Forcing us to wrap conditional statements"]:
+		pass)";
+		const String pre_formatted = R"(func _ready() -> void:
+	for i in [
+		"A long string here",
+		"A long string there",
+		"A long string, everywhere",
+		"Hither and thither",
+		"The long strings go",
+		"Forcing us to wrap conditional statements",
+	]:
+		pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable that contains a lambda") {
+		const String code = R"(var my_lambda = func():
+	pass)";
+		const String pre_formatted = R"(var my_lambda = func():
+	pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should not crash with malformed match") {
+		const String code = R"(func _ready() -> void:
+	var x = 0
+	match x:
+		0)";
+		const String pre_formatted = R"(func _ready() -> void:
+	var x = 0
+	match x:
+		0)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should not error out on a lambda wrapped in a multiline") {
+		const String code = R"(func _ready():
+	var the_lambda = (
+		func():
+			return true
+	))";
+		const String pre_formatted = R"(func _ready():
+	var the_lambda = func():
+		return true
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+}
+
+TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Usability]") {
+	TEST_CASE("Should format differently based on desired wrapping length") {
+		const String code = R"(func _ready() -> void:
+	if my_condition_is_long_enough("it should wrap", "due to length", "on multiple lines"):
+		print("Told you"))";
+
+		const String pre_formatted80 = R"(func _ready() -> void:
+	if (
+		my_condition_is_long_enough(
+			"it should wrap", "due to length", "on multiple lines"
+		)
+	):
+		print("Told you")
+)";
+
+		const String pre_formatted100 = R"(func _ready() -> void:
+	if my_condition_is_long_enough("it should wrap", "due to length", "on multiple lines"):
+		print("Told you")
+)";
+
+		GDScriptFormat formatter;
+		formatter.indent_in_multiline_block = 1;
+		formatter.line_length_maximum = 80;
+		const String output80 = formatter.format(code);
+		formatter.line_length_maximum = 100;
+		const String output100 = formatter.format(code);
+
+		CHECK_EQ(output80, pre_formatted80);
+		CHECK_EQ(output100, pre_formatted100);
+	}
+
+	TEST_CASE("Should output user-inputted incidental new lines") {
+		const String code = R"(func _ready():
+	var my_variable
+
+	var my_other_variable)";
+		const String pre_formatted = R"(func _ready():
+	var my_variable
+
+	var my_other_variable
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output user-inputted incidental new lines but compress multiple lines into one") {
+		const String code = "func _ready():\n\tvar my_variable\n\n\n\n\tvar my_other_variable";
+		const String pre_formatted = R"(func _ready():
+	var my_variable
+
+	var my_other_variable
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+}
+
+TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Comments]") {
+	TEST_CASE("Should output a class header with all related comments") {
+		const String code = R"(# Tool header
+@tool # Tool inline
+# Icon header
+@icon("res://icon.png") # Icon inline
+# Class name header
+class_name MyClass # Class name inline
+# Extends header
+extends Node # Extends inline)";
+		const String pre_formatted = R"(# Tool header
+@tool # Tool inline
+# Icon header
+@icon("res://icon.png") # Icon inline
+# Class name header
+class_name MyClass # Class name inline
+# Extends header
+extends Node # Extends inline
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment above it") {
+		const String code = R"(# A Docstring for the variable
+var my_variable = 0)";
+		const String pre_formatted = R"(# A Docstring for the variable
+var my_variable = 0
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment next to it") {
+		const String code = R"(var my_variable = 0 # With an explanatory text)";
+		const String pre_formatted = R"(var my_variable = 0 # With an explanatory text
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a wrapped variable with a comment next to it") {
+		const String code = R"(var my_variable = some_conditional_value() + "A fairly long string, to cause a wrap" # With an explanatory text)";
+		const String pre_formatted = R"(var my_variable = (
+	some_conditional_value()
+	+ "A fairly long string, to cause a wrap" # With an explanatory text
+)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment above it after a variable with a comment next to it") {
+		const String code = R"(var my_variable = 0 # My first variable
+# My Second variable
+var my_other_variable = 0)";
+		const String pre_formatted = R"(var my_variable = 0 # My first variable
+# My Second variable
+var my_other_variable = 0
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a wrapped variable with a comment on a binary operator element inside of it") {
+		const String code = R"(var my_variable = (
+	0 # My first variable
+	+ 1
+))";
+		const String pre_formatted = R"(var my_variable = (
+	0 # My first variable
+	+ 1
+)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a function calculating the triangle area from 3 Vector3's") {
+		const String code = R"(func    triangle_area(p1    :Vector3  , p2:Vector3,p3   :  Vector3):
+
+	return (p2 - p1).cross( p3 - p1 ).length() / 2.0)";
+		const String pre_formatted = R"(func triangle_area(p1: Vector3, p2: Vector3, p3: Vector3):
+	return (p2 - p1).cross(p3 - p1).length() / 2.0
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a function call with a comment on one of its parameters") {
+		const String code = R"(@onready var my_variable := some_function_call(
+	0 #with that parameter
+))";
+		const String pre_formatted = R"(@onready
+var my_variable := some_function_call(
+	0 # with that parameter
+)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a function call with a comment on one of its non-literal parameters") {
+		const String code = R"(@onready var my_variable := some_function_call(
+	SOME_CONST #with that parameter
+))";
+		const String pre_formatted = R"(@onready
+var my_variable := some_function_call(
+	SOME_CONST # with that parameter
+)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a function call with a comment on a nested call's parameters") {
+		const String code = R"(@onready var my_variable := some_function_call(
+	some_nested_call(
+		0 #with that parameter
+	)
+))";
+		const String pre_formatted = R"(@onready
+var my_variable := some_function_call(
+	some_nested_call(
+		0 # with that parameter
+	)
+)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a constant with a comment above it") {
+		const String code = R"(# A Docstring for the constant
+const MY_VARIABLE := 0)";
+		const String pre_formatted = R"(# A Docstring for the constant
+const MY_VARIABLE := 0
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a constant with a comment next to it") {
+		const String code = R"(const MY_VARIABLE := 0 # A comment for the constant)";
+		const String pre_formatted = R"(const MY_VARIABLE := 0 # A comment for the constant
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a constant with a comment next to one of its binary operator elements") {
+		const String code = R"(const MY_VARIABLE := (
+	0 # A comment for the literal
+	+ 3
+))";
+		const String pre_formatted = R"(const MY_VARIABLE := (
+	0 # A comment for the literal
+	+ 3
+)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a constant with a comment next to one of its nested binary operator elements") {
+		const String code = R"(const MY_VARIABLE := (
+	0
+	+ 4 # A comment for the literal
+	+ 3
+	+ 8
+))";
+		const String pre_formatted = R"(const MY_VARIABLE := (
+	0
+	+ 4 # A comment for the literal
+	+ 3
+	+ 8
+)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment next to a function call parameter") {
+		const String code = R"(var my_variable := my_call(
+	0,
+	1 # The comment is here
+))";
+		const String pre_formatted = R"(var my_variable := my_call(
+	0,
+	1 # The comment is here
+)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment next to a nested function call parameter") {
+		const String code = R"(var my_variable := my_call(
+	0,
+	my_other_call(
+		0,
+		1 # The comment is here
+	)
+))";
+		const String pre_formatted = R"(var my_variable := my_call(
+	0,
+	my_other_call(
+		0,
+		1 # The comment is here
+	)
+)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment next to an element in an array") {
+		const String code = R"(var my_variable := [
+	0,
+	1 # The comment is here
+])";
+		const String pre_formatted = R"(var my_variable := [
+	0,
+	1, # The comment is here
+]
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment next to an element in a dictionary") {
+		const String code = R"(var my_variable := {
+	"name": "Elizabeth",
+	"job": "Investigator" # The comment is here
+})";
+		const String pre_formatted = R"(var my_variable := {
+	"name": "Elizabeth",
+	"job": "Investigator", # The comment is here
+}
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment next to an element value in a dictionary") {
+		const String code = R"(var my_variable := {
+	"name": "Elizabeth",
+	"job": (
+		"Investigator"
+	) # The comment is here
+})";
+		const String pre_formatted = R"(var my_variable := {
+	"name": "Elizabeth",
+	"job": "Investigator", # The comment is here
+}
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment above an element key in a dictionary") {
+		const String code = R"(var my_variable := {
+	"name": "Elizabeth",
+	# The comment is here
+	"job": "Investigator"
+})";
+		const String pre_formatted = R"(var my_variable := {
+	"name": "Elizabeth",
+	# The comment is here
+	"job": "Investigator",
+}
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment above an element value in a dictionary") {
+		const String code = R"(var my_variable := {
+	"name": "Elizabeth",
+	"job": (
+		# The comment is here
+		"Investigator"
+	)
+})";
+		const String pre_formatted = R"(var my_variable := {
+	"name": "Elizabeth",
+	# The comment is here
+	"job": "Investigator",
+}
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment next to an element key and value in a dictionary") {
+		const String code = R"(var my_variable := {
+	"name": "Elizabeth",
+	"job": ( # There is a comment here
+		"Investigator"
+	) # And a comment here
+})";
+		const String pre_formatted = R"(var my_variable := {
+	"name": "Elizabeth",
+	# There is a comment here
+	"job": "Investigator", # And a comment here
+}
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment next to an element in an array") {
+		const String code = R"(var my_variable := [
+	0, 1, 2, 3,
+	4, # This is the special one
+	5, 6, 7, 8
+])";
+		const String pre_formatted = R"(var my_variable := [
+	0,
+	1,
+	2,
+	3,
+	4, # This is the special one
+	5,
+	6,
+	7,
+	8,
+]
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment above an element in an array") {
+		const String code = R"(var my_variable := [
+	0, 1, 2, 3,
+	# This is the special one
+	4,
+	5, 6, 7, 8
+])";
+		const String pre_formatted = R"(var my_variable := [
+	0,
+	1,
+	2,
+	3,
+	# This is the special one
+	4,
+	5,
+	6,
+	7,
+	8,
+]
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment next to an element in a nested array") {
+		const String code = R"(var my_variable := [
+	0, 1, 2, [
+		0, 1, 2, # The comment can go here
+		3
+	], 4, 5, 6, 7, 8, 9
+])";
+		const String pre_formatted = R"(var my_variable := [
+	0,
+	1,
+	2,
+	[
+		0,
+		1,
+		2, # The comment can go here
+		3,
+	],
+	4,
+	5,
+	6,
+	7,
+	8,
+	9,
+]
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment next to an element in a double nested array") {
+		const String code = R"(var my_variable := [0,1,2,[0,1,[
+	0,1, # The comment can go here
+	2
+],3],4,5,6,7,8,9])";
+		const String pre_formatted = R"(var my_variable := [
+	0,
+	1,
+	2,
+	[
+		0,
+		1,
+		[
+			0,
+			1, # The comment can go here
+			2,
+		],
+		3,
+	],
+	4,
+	5,
+	6,
+	7,
+	8,
+	9,
+]
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment next to a cast statement") {
+		const String code = R"(@onready var my_variable := (
+	$Player as CharacterBody2D # The comment
+))";
+		const String pre_formatted = R"(@onready var my_variable := $Player as CharacterBody2D # The comment
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment next to an identifier") {
+		const String code = R"(@onready var my_variable := (
+	MY_CONST # The comment
+))";
+		const String pre_formatted = R"(@onready var my_variable := MY_CONST # The comment
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment next to a get node") {
+		const String code = R"(@onready var my_variable := (
+	$Player/Sprite2D # The comment
+))";
+		const String pre_formatted = R"(@onready var my_variable := $Player/Sprite2D # The comment
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment next to a preload value") {
+		const String code = R"(@onready var my_variable := preload(
+	"res://Player/PlayerSprite.png" # The comment
+))";
+		const String pre_formatted = R"(@onready var my_variable := preload(
+	"res://Player/PlayerSprite.png" # The comment
+)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment next to a subscript index") {
+		const String code = R"(@onready var my_variable := MY_CONST_ARRAY[
+	0 # The comment
+])";
+		const String pre_formatted = R"(@onready
+var my_variable := MY_CONST_ARRAY[
+	0 # The comment
+]
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment as part of a ternary operator") {
+		const String code = R"(@onready var my_variable := (
+	50 if SOME_DEVELOPMENT_CONST # is enabled
+	else 75
+))";
+		const String pre_formatted = R"(@onready
+var my_variable := (
+	50 if SOME_DEVELOPMENT_CONST # is enabled
+	else 75
+)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a variable with a comment as part of a ternary operator on the false") {
+		const String code = R"(@onready var my_variable := (
+	50 if SOME_DEVELOPMENT_CONST
+	else 75 # is 75
+))";
+		const String pre_formatted = R"(@onready
+var my_variable := (
+	50 if SOME_DEVELOPMENT_CONST
+	else 75 # is 75
+)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output an assignment with a comment above it") {
+		const String code = R"(func _ready() -> void:
+	# A comment!
+	some_value = 30)";
+		const String pre_formatted = R"(func _ready() -> void:
+	# A comment!
+	some_value = 30
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output an assignment with a comment next to it") {
+		const String code = R"(func _ready() -> void:
+	some_value = 30 # A comment!)";
+		const String pre_formatted = R"(func _ready() -> void:
+	some_value = 30 # A comment!
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output an assignment with a comment next to its literal value") {
+		const String code = R"(func _ready() -> void:
+	some_value = (
+		30 # A comment!
+))";
+		const String pre_formatted = R"(func _ready() -> void:
+	some_value = 30 # A comment!
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output an assignment with a comment next to its identifier value") {
+		const String code = R"(func _ready() -> void:
+	some_value = (
+		some_other # A comment!
+))";
+		const String pre_formatted = R"(func _ready() -> void:
+	some_value = some_other # A comment!
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output an await with a comment") {
+		const String code = R"(func _ready() -> void:
+	await get_tree().process_frame # A comment goes here)";
+		const String pre_formatted = R"(func _ready() -> void:
+	await get_tree().process_frame # A comment goes here
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a get node statement with a comment") {
+		const String code = R"(@onready var some_var := (
+	$Path/To/Node # Comment here
+))";
+		const String pre_formatted = R"(@onready var some_var := $Path/To/Node # Comment here
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a function with a comment above it") {
+		const String code = R"(# Comment above
+func _ready() -> void:
+	pass)";
+		const String pre_formatted = R"(# Comment above
+func _ready() -> void:
+	pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a function with two comments above it") {
+		const String code = R"(# Comment 1
+# Comment 2
+func _ready() -> void:
+	pass)";
+		const String pre_formatted = R"(# Comment 1
+# Comment 2
+func _ready() -> void:
+	pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a function with a comment next to it") {
+		const String code = R"(func _ready() -> void: # Comment next
+	pass)";
+		const String pre_formatted = R"(func _ready() -> void: # Comment next
+	pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a function with a comment next to a parameter") {
+		const String code = R"(func a_custom_function(
+	a_parameter # with a comment
+) -> void:
+	pass)";
+		const String pre_formatted = R"(func a_custom_function(
+	a_parameter # with a comment
+) -> void:
+	pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a function with a comment next to one parameter") {
+		const String code = R"(func a_custom_function(
+	a_parameter, # with a comment
+	another_parameter
+) -> void:
+	pass)";
+		const String pre_formatted = R"(func a_custom_function(
+	a_parameter, # with a comment
+	another_parameter
+) -> void:
+	pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a class with a comment above and next to it") {
+		const String code = R"(# The comment above
+class MyClass: # The comment next
+	pass)";
+		const String pre_formatted = R"(# The comment above
+class MyClass: # The comment next
+	pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a signal with a comment inside its parameters") {
+		const String code = R"(# The comment above
+signal some_signal(with,
+	some, # And a comment here
+	params
+))";
+		const String pre_formatted = R"(# The comment above
+signal some_signal(
+	with,
+	some, # And a comment here
+	params
+)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a function return with comments") {
+		const String code = R"(func _ready() -> void:
+	# return header
+	return # end early)";
+		const String pre_formatted = R"(func _ready() -> void:
+	# return header
+	return # end early
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output an assert with comments") {
+		const String code = R"(func _ready() -> void:
+	assert(some_complex_condition(
+		"that", # comment!
+		"breaks"
+	), "And a message") # And a comment)";
+		const String pre_formatted = R"(func _ready() -> void:
+	assert(some_complex_condition(
+		"that", # comment!
+		"breaks"
+	), "And a message") # And a comment
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output an unnamed enum with comments") {
+		const String code = R"(# Enum header
+enum { VALUE_1, VALUE_2 = 3, VALUE_3,
+# Value header
+VALUE_4, # value inline
+} # enum inline)";
+		const String pre_formatted = R"(# Enum header
+enum {
+	VALUE_1,
+	VALUE_2 = 3,
+	VALUE_3,
+	# Value header
+	VALUE_4, # value inline
+} # enum inline
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should out a match statement with comments") {
+		const String code = R"(func _ready():
+	# Match header
+	match some_value: # Match inline
+		# Value header
+		0: # Value inline
+			pass
+		1:
+			pass
+		2:
+			pass)";
+		const String pre_formatted = R"(func _ready():
+	# Match header
+	match some_value: # Match inline
+		# Value header
+		0: # Value inline
+			pass
+		1:
+			pass
+		2:
+			pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output if blocks with comments") {
+		const String code = R"(func _ready():
+	# If header
+	if my_condition: # if inline
+		pass
+	# elif header
+	elif my_other_condition: # elif inline
+		pass
+	# else header
+	else: # else inline
+		pass)";
+		const String pre_formatted = R"(func _ready():
+	# If header
+	if my_condition: # if inline
+		pass
+	# elif header
+	elif my_other_condition: # elif inline
+		pass
+	# else header
+	else: # else inline
+		pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a for loop with comments") {
+		const String code = R"(func _ready():
+	# For header
+	for i in my_condition: # For inline
+		pass)";
+		const String pre_formatted = R"(func _ready():
+	# For header
+	for i in my_condition: # For inline
+		pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a while loop with comments") {
+		const String code = R"(func _ready():
+	# While header
+	while my_condition: # While inline
+		pass)";
+		const String pre_formatted = R"(func _ready():
+	# While header
+	while my_condition: # While inline
+		pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a break statement with comments") {
+		const String code = R"(func _ready():
+	for i in my_condition:
+		# Break header
+		break # break inline)";
+		const String pre_formatted = R"(func _ready():
+	for i in my_condition:
+		# Break header
+		break # break inline
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a continue statement with comments") {
+		const String code = R"(func _ready():
+	for i in my_condition:
+		# Continue header
+		continue # Continue inline)";
+		const String pre_formatted = R"(func _ready():
+	for i in my_condition:
+		# Continue header
+		continue # Continue inline
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a pass statement with comments") {
+		const String code = R"(func _ready():
+	# Pass header
+	pass # Pass inline)";
+		const String pre_formatted = R"(func _ready():
+	# Pass header
+	pass # Pass inline
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a breakpoint statement with comments") {
+		const String code = R"(func _ready():
+	# Breakpoint header
+	breakpoint # Breakpoint inline)";
+		const String pre_formatted = R"(func _ready():
+	# Breakpoint header
+	breakpoint # Breakpoint inline
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a prop with comments") {
+		const String code = R"(# prop header
+var my_property: # prop inline
+	# setter header
+	set(value): # setter inline
+		my_property = value
+	# getter header
+	get: # getter inline
+		return my_property)";
+		const String pre_formatted = R"(# prop header
+var my_property: # prop inline
+	# setter header
+	set(value): # setter inline
+		my_property = value
+	# getter header
+	get: # getter inline
+		return my_property
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a function with a footer comment") {
+		const String code = R"(func _ready():
+	pass
+
+	# Comment at the bottom
+
+func _other_function():
+	pass)";
+		const String pre_formatted = "func _ready():\n\tpass\n\n\t# Comment at the bottom\n\n\nfunc _other_function():\n\tpass\n";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output a class with a footer comment") {
+		const String code = R"(extends Node
+
+class SubClass:
+	extends Resource
+
+	# Footer comment
+
+# Footer comment)";
+		const String pre_formatted = "extends Node\n\n\nclass SubClass:\n\textends Resource\n\n\t# Footer comment\n\n# Footer comment\n";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output docstrings on classes and functions") {
+		const String code = R"(## A class that has a specific documented job
+class_name MyClass
+extends RefCounted
+
+## Returns a value
+func some_public_api_func() -> int:
+	return 0)";
+		const String pre_formatted = "## A class that has a specific documented job\nclass_name MyClass\nextends RefCounted\n\n\n## Returns a value\nfunc some_public_api_func() -> int:\n\treturn 0\n";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output indexed calls with comments") {
+		const String code = R"(func _ready():
+	# Header
+	sd.call_one() # Inline)";
+		const String pre_formatted = R"(func _ready():
+	# Header
+	sd.call_one() # Inline
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should not cause errors with disabled lines") {
+		const String code = R"(func _ready() -> void:
+#	print("disabled code")
+	print("enabled code"))";
+		const String pre_formatted = R"(func _ready() -> void:
+#	print("disabled code")
+	print("enabled code")
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should not cause errors with disabled lines in class") {
+		const String code = R"(class SomeClass:
+#	var a_disabled_var
+	var an_enabled_var)";
+		const String pre_formatted = R"(class SomeClass:
+#	var a_disabled_var
+	var an_enabled_var
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should not cause errors with disabled lines in property") {
+		const String code = R"(var some_var:
+#	get: disabled line
+	get:
+		return some_var)";
+		const String pre_formatted = R"(var some_var:
+#	get: disabled line
+	get:
+		return some_var
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should not cause errors with disabled lines in both properties") {
+		const String code = R"(var some_var:
+#	get: disabled line
+	get:
+		return some_var
+#	set(v):
+	set(v):
+		some_var = v)";
+		const String pre_formatted = R"(var some_var:
+#	set(v):
+	set(v):
+		some_var = v
+#	get: disabled line
+	get:
+		return some_var
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should not crash on empty array with inline comment over no element") {
+		const String code = R"(var array = [ # Comment
+])";
+		const String pre_formatted = R"(var array = [
+	# Comment
+]
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should not crash on empty dict with inline comment over no element") {
+		const String code = R"(var dict = { # Comment
+})";
+		const String pre_formatted = R"(var dict = {
+	# Comment
+}
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should not crash on empty parameter with inline comment over no element") {
+		const String code = R"(func some_func( # Comment
+):
+	pass)";
+		const String pre_formatted = R"(func some_func(
+	# Comment
+):
+	pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should not crash on empty call with inline comment over no element") {
+		const String code = R"(func _ready():
+	some_func( # Comment
+	))";
+		const String pre_formatted = R"(func _ready():
+	some_func(
+		# Comment
+	)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should not error out on a disabled statement in a if block") {
+		const String code = R"(func _ready():
+	if true:
+#		comment
+		print("hi"))";
+		const String pre_formatted = R"(func _ready():
+	if true:
+#		comment
+		print("hi")
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should not error out on a disabled statement in a parameter block") {
+		const String code = R"(func _ready():
+	print(
+#		"50"
+		"30"
+	))";
+		const String pre_formatted = R"(func _ready():
+	print(
+#		"50"
+		"30"
+	)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should not error out on a footer in an array with only one element") {
+		const String code = R"(func _ready():
+	var array = ["string"
+		# Comment
+	])";
+		const String pre_formatted = R"(func _ready():
+	var array = [
+		"string",
+		# Comment
+	]
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should not error out on a footer in a dictionary with only one element") {
+		const String code = R"(func _ready():
+	var dictionary = {"string": "string"
+		# Comment
+	})";
+		const String pre_formatted = R"(func _ready():
+	var dictionary = {
+		"string": "string",
+		# Comment
+	}
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should not error out on a footer in a call with only one parameter") {
+		const String code = R"(func _ready():
+	call("string"
+		# Comment
+	))";
+		const String pre_formatted = R"(func _ready():
+	call(
+		"string"
+		# Comment
+	)
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should continue parsing a suite after a dedented comment") {
+		const String code = R"(func _ready():
+	if true:
+		pass
+#	comment
+	pass)";
+		const String pre_formatted = R"(func _ready():
+	if true:
+		pass
+
+#	comment
+	pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should output comments above an onready variable") {
+		const String code = R"(## I am a comment describing var hi
+@onready var hi)";
+		const String pre_formatted = R"(## I am a comment describing var hi
+@onready var hi
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("A full commented function should output correctly") {
+		// Code by clayjohn at https://github.com/godotengine/godot-docs/issues/4834
+		const String code = R"(func _ready():
+	# We will be using our own RenderingDevice to handle the compute commands
+	var rd = RenderingServer.create_local_rendering_device()
+
+	# Create shader and pipeline
+	var shader_file = load("res://compute_example.glsl")
+	var shader_bytecode = shader_file.get_bytecode()
+	var shader = rd.shader_create(shader_bytecode)
+	var pipeline = rd.compute_pipeline_create(shader)
+
+	# Data for compute shaders has to come as an array of bytes
+	var pba = PackedByteArray()
+	pba.resize(64)
+	for i in range(16):
+		pba.encode_float(i * 4, 2.0)
+
+	# Create storage buffer
+	# Data not needed, can just create with length
+	var storage_buffer = rd.storage_buffer_create(64, pba)
+
+	# Create uniform set using the storage buffer
+	var u = RDUniform.new()
+	u.uniform_type = RenderingDevice.UNIFORM_TYPE_STORAGE_BUFFER
+	u.binding = 0
+	u.add_id(storage_buffer)
+	var uniform_set = rd.uniform_set_create([u], shader, 0)
+
+	# Start compute list to start recording our compute commands
+	var compute_list = rd.compute_list_begin()
+	# Bind the pipeline, this tells the GPU what shader to use
+	rd.compute_list_bind_compute_pipeline(compute_list, pipeline)
+	# Binds the uniform set with the data we want to give our shader
+	rd.compute_list_bind_uniform_set(compute_list, uniform_set, 0)
+	# Dispatch 1x1x1 (XxYxZ) work groups
+	rd.compute_list_dispatch(compute_list, 2, 1, 1)
+	# rd.compute_list_add_barrier(compute_list)
+	# Tell the GPU we are done with this compute task
+	rd.compute_list_end()
+	# Force the GPU to start our commands
+	rd.submit()
+	# Force the CPU to wait for the GPU to finish with the recorded commands
+	rd.sync()
+
+	# Now we can grab our data from the storage buffer
+	var byte_data = rd.buffer_get_data(storage_buffer)
+	for i in range(16):
+		print(byte_data.decode_float(i * 4)))";
+		const String pre_formatted = R"(func _ready():
+	# We will be using our own RenderingDevice to handle the compute commands
+	var rd = RenderingServer.create_local_rendering_device()
+
+	# Create shader and pipeline
+	var shader_file = load("res://compute_example.glsl")
+	var shader_bytecode = shader_file.get_bytecode()
+	var shader = rd.shader_create(shader_bytecode)
+	var pipeline = rd.compute_pipeline_create(shader)
+
+	# Data for compute shaders has to come as an array of bytes
+	var pba = PackedByteArray()
+	pba.resize(64)
+	for i in range(16):
+		pba.encode_float(i * 4, 2.0)
+
+	# Create storage buffer
+	# Data not needed, can just create with length
+	var storage_buffer = rd.storage_buffer_create(64, pba)
+
+	# Create uniform set using the storage buffer
+	var u = RDUniform.new()
+	u.uniform_type = RenderingDevice.UNIFORM_TYPE_STORAGE_BUFFER
+	u.binding = 0
+	u.add_id(storage_buffer)
+	var uniform_set = rd.uniform_set_create([u], shader, 0)
+
+	# Start compute list to start recording our compute commands
+	var compute_list = rd.compute_list_begin()
+	# Bind the pipeline, this tells the GPU what shader to use
+	rd.compute_list_bind_compute_pipeline(compute_list, pipeline)
+	# Binds the uniform set with the data we want to give our shader
+	rd.compute_list_bind_uniform_set(compute_list, uniform_set, 0)
+	# Dispatch 1x1x1 (XxYxZ) work groups
+	rd.compute_list_dispatch(compute_list, 2, 1, 1)
+	# rd.compute_list_add_barrier(compute_list)
+	# Tell the GPU we are done with this compute task
+	rd.compute_list_end()
+	# Force the GPU to start our commands
+	rd.submit()
+	# Force the CPU to wait for the GPU to finish with the recorded commands
+	rd.sync()
+
+	# Now we can grab our data from the storage buffer
+	var byte_data = rd.buffer_get_data(storage_buffer)
+	for i in range(16):
+		print(byte_data.decode_float(i * 4))
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should not error out on a disabled line between an if and its else") {
+		const String code = R"(func _ready():
+	if true:
+		pass
+#		Comment
+	else:
+		pass)";
+		const String pre_formatted = R"(func _ready():
+	if true:
+		pass
+#		Comment
+	else:
+		pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should not error out on a disabled line in the middle of a suite") {
+		const String code = R"(func _ready():
+	if true:
+		pass
+#		Comment
+		pass
+	pass)";
+		const String pre_formatted = R"(func _ready():
+	if true:
+		pass
+#		Comment
+		pass
+	pass
+)";
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Should not have an extra line after an array footer with a long first member") {
+		const String code = R"(var my_array = [
+	"there is a bug with an extra newline at the end of arrays but only when the contents have long lines",
+	# Comment
+
+])";
+		const String pre_formatted = R"(var my_array = [
+	"there is a bug with an extra newline at the end of arrays but only when the contents have long lines",
+	# Comment
+]
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+}
+
+} //namespace GDScriptTests
+
+#endif // TEST_GDSCRIPT_FORMATTER_H

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -39,34 +39,35 @@
 
 namespace GDScriptTests {
 
-#define CHECK_FORMAT(code, pre_formatted)                                                    \
-	do {                                                                                     \
-		GDScriptFormat formatter;                                                            \
-		formatter.indent_in_multiline_block = 1;                                             \
-		String output;                                                                       \
-		Error err = formatter.format(code, output);                                          \
-		Vector<String> error_messages;                                                       \
-		if (err != OK) {                                                                     \
-			for (GDScriptParser::ParserError parser_error : formatter.get_parser_errors()) { \
-				error_messages.push_back(                                                    \
-					vformat(                                                                 \
-						"Parse Error: %s (%s:%s)",                                                        \
-						parser_error.message,                                                \
-						parser_error.line,                                                   \
-						parser_error.column                                                  \
-					)                                                                        \
-				);                                                                           \
-			}                                                                                \
-		}                                                                                    \
-		CHECK_MESSAGE(                                                                       \
-			err == OK,                                                                       \
-			vformat(                                                                         \
-				"The formatter returned these errors: %s",                                   \
-				String("\n").join(error_messages)                                            \
-			)                                                                                \
-		);                                                                                   \
-		CHECK_EQ(output, pre_formatted);                                                     \
-	} while (false);                                                                     
+#define CHECK_FORMAT(code, pre_formatted)                                                       \
+	do {                                                                                        \
+		GDScriptFormat formatter;                                                               \
+		formatter.indent_in_multiline_block = 1;                                                \
+		String output;                                                                          \
+		Error err = formatter.format(code, output);                                             \
+		Vector<String> error_messages;                                                          \
+		if (err != OK) {                                                                        \
+			for (GDScriptParser::ParserError parser_error : formatter.get_parser_errors()) {    \
+				error_messages.push_back(                                                       \
+					vformat(                                                                    \
+						"Parse Error: %s (%s:%s)",                                              \
+						parser_error.message,                                                   \
+						parser_error.line,                                                      \
+						parser_error.column                                                     \
+					)                                                                           \
+				);                                                                              \
+			}                                                                                   \
+		}                                                                                       \
+		CHECK_MESSAGE(                                                                          \
+			err == OK,                                                                          \
+			vformat(                                                                            \
+				"The formatter returned errors (%s): \n%s",                                     \
+				error_messages.size(),                                                          \
+				String("\n").join(error_messages)                                               \
+			)                                                                                   \
+		);                                                                                      \
+		CHECK_EQ(output, pre_formatted);                                                        \
+	} while (false);
 
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][ClassMembers]") {
 	TEST_CASE("Should output a variable with a property that has a setter and getter, inline") {
@@ -816,7 +817,7 @@ var my_variable = 0
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
-}
+} // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][ClassMembers]")
 
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][ClassSignatures]") {
 	TEST_CASE("Should output a simple class") {
@@ -879,7 +880,7 @@ extends Node
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
-}
+} // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][ClassSignatures]")
 
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][ClassFunctions]") {
 	TEST_CASE("Should output a simple class method") {
@@ -1286,7 +1287,7 @@ func _process(delta):
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
-}
+} // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][ClassFunctions]")
 
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][NestedSuites]") {
 	TEST_CASE("Should output a simple if true/else statement") {
@@ -1639,7 +1640,7 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][NestedSuites]") {
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
-}
+} // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][NestedSuites]")
 
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Usability]") {
 	TEST_CASE("Should format differently based on desired wrapping length") {
@@ -1701,7 +1702,7 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Usability]") {
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
-}
+} // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Usability]")
 
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Comments]") {
 	TEST_CASE("Should output a class header with all related comments") {
@@ -2827,51 +2828,6 @@ func some_public_api_func() -> int:
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
-	TEST_CASE("The custom newlines should be remembered") {
-		// `vformat` because "misc/scripts/header_guards.sh"
-		// don't like two consecutive new lines.
-		const String code = vformat(R"(extends Node2D
-%s
-class Light:
-	var energy
-
-var energy_slider := Range.new()
-var height_slider := Range.new()
-var light := Light.new()
-
-func _ready() -> void:
-	energy_slider.value_changed.connect(func(value):
-		light.energy = energy_slider.value)
-
-	height_slider.value_changed.connect(func(value):
-		light.height = height_slider.value)
-
-	height_slider.value_changed.connect(func(value):
-		light.height = height_slider.value))",
-				"\n");
-		const String pre_formatted = vformat(R"(extends Node2D
-%s
-class Light:
-	var energy
-
-var energy_slider := Range.new()
-var height_slider := Range.new()
-var light := Light.new()
-%s
-func _ready() -> void:
-	energy_slider.value_changed.connect(func(value):
-		light.energy = energy_slider.value)
-
-	height_slider.value_changed.connect(func(value):
-		light.height = height_slider.value)
-
-	height_slider.value_changed.connect(func(value):
-		light.height = height_slider.value)
-)",
-				"\n", "\n");
-		CHECK_FORMAT(code, pre_formatted);
-	}
-
 	TEST_CASE("A full commented function should output correctly") {
 		// Code by clayjohn at https://github.com/godotengine/godot-docs/issues/4834
 		const String code = R"(func _ready():
@@ -3028,7 +2984,7 @@ func _ready() -> void:
 	var v := Vector2()
 	var a = v[0]  # A
 
-func another():
+	func another():
 	pass
 )";
 
@@ -3041,7 +2997,64 @@ func another():
 )";
 		CHECK_FORMAT(code, pre_formatted);
 	}
-}
+} // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Comments]")
+
+TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
+	TEST_CASE("Syntactic sugar should be preserved") {
+		SUBCASE("Unique nodes (%)") {
+			const String code = R"(@onready var unique_node = %UniqueNode)";
+			const String pre_formatted = code;
+			CHECK_FORMAT(code, pre_formatted);
+		}
+	}
+} // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]")
+
+TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Misc]") {
+	TEST_CASE("The custom newlines should be remembered") {
+		// `vformat` because "misc/scripts/header_guards.sh"
+		// don't like two consecutive new lines.
+		const String code = vformat(R"(extends Node2D
+%s
+class Light:
+	var energy
+
+var energy_slider := Range.new()
+var height_slider := Range.new()
+var light := Light.new()
+
+func _ready() -> void:
+	energy_slider.value_changed.connect(func(value):
+		light.energy = energy_slider.value)
+
+	height_slider.value_changed.connect(func(value):
+		light.height = height_slider.value)
+
+	height_slider.value_changed.connect(func(value):
+		light.height = height_slider.value))",
+				"\n");
+		const String pre_formatted = vformat(R"(extends Node2D
+%s
+class Light:
+	var energy
+
+var energy_slider := Range.new()
+var height_slider := Range.new()
+var light := Light.new()
+%s
+func _ready() -> void:
+	energy_slider.value_changed.connect(func(value):
+		light.energy = energy_slider.value)
+
+	height_slider.value_changed.connect(func(value):
+		light.height = height_slider.value)
+
+	height_slider.value_changed.connect(func(value):
+		light.height = height_slider.value)
+)",
+				"\n", "\n");
+		CHECK_FORMAT(code, pre_formatted);
+	}
+} // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Misc]")
 
 } //namespace GDScriptTests
 

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -1293,6 +1293,22 @@ func _process(delta):
 	}
 } // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][ClassFunctions]")
 
+TEST_SUITE("[Modules][GDScript][GDScriptFormatter][InnerClasses]") {
+	TEST_CASE("Inner class should handle variables") {
+		const String code = R"(class MyInnerClass:
+	var hi
+
+	func my_inner_class_function() -> void:
+		pass
+
+	func another_one() -> void:
+		pass
+)";
+		const String pre_formatted = code;
+		CHECK_FORMAT(code, pre_formatted);
+	}
+} // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][InnerClasses]")
+
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][NestedSuites]") {
 	TEST_CASE("Should output a simple if true/else statement") {
 		const String code = R"(func _ready():
@@ -3001,6 +3017,45 @@ func another():
 )";
 		CHECK_FORMAT(code, pre_formatted);
 	}
+
+	TEST_CASE("Comments on top of static functions should stay") {
+		const String code = R"(## This comment should stay after format
+static func test():
+	pass
+)";
+		const String pre_formatted = code;
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Comment at the end of a return value should stay") {
+		const String code = R"(func test_func() -> bool:
+	if true:
+		return true # In this case, stop.
+	return false
+)";
+		const String pre_formatted = code;
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Comments at the end of `get_node` should not multiply") {
+		const String code = R"(@onready var a_node = $ANode
+@onready var b_node = a_node.get_node(^"BNode") # Test
+)";
+		const String pre_formatted = code;
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Comments should not be considered as dictionary keys") {
+		const String code = R"(func _ready():
+	var dict = {
+		"key1": "value1", # Comment
+		# Comment
+		"key2": "value2",
+	}
+)";
+		const String pre_formatted = code;
+		CHECK_FORMAT(code, pre_formatted);
+	}
 } // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Comments]")
 
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
@@ -3043,6 +3098,27 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 			code = R"(@onready var unique_node = %"UniqueNodeIndeedWith$"
 )";
 			pre_formatted = code;
+			CHECK_FORMAT(code, pre_formatted);
+		}
+	}
+
+	TEST_CASE("Parentheses should be kept") {
+		SUBCASE("Using format%") {
+			const String code = R"(func _ready():
+	var number = 1234.567
+	var string = "%1.1f k" % (number * 0.001)
+)";
+			const String pre_formatted = code;
+			CHECK_FORMAT(code, pre_formatted);
+		}
+	}
+
+	TEST_CASE("Literals should be kept as-is") {
+		SUBCASE("Number below the float precision") {
+			const String code = R"(func _ready():
+	var number = 0.0000000000000000000000000000000000000000000000000000000000000001
+)";
+			const String pre_formatted = code;
 			CHECK_FORMAT(code, pre_formatted);
 		}
 	}

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -3056,6 +3056,25 @@ static func test():
 		const String pre_formatted = code;
 		CHECK_FORMAT(code, pre_formatted);
 	}
+
+	TEST_CASE("Comments should not count as expressions") {
+		SUBCASE("Function body") {
+			const String code = R"(func _run() -> void:
+	# This should not count as an expression
+)");
+			const String pre_formatted = code;
+			CHECK_FORMAT(code, pre_formatted);
+		}
+
+		SUBCASE("Condition body") {
+			const String code = R"(func _run() -> void:
+	if true:
+		# This should not count as an expression
+)";
+			const String pre_formatted = code;
+			CHECK_FORMAT(code, pre_formatted);
+		}
+	}
 } // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Comments]")
 
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -1775,7 +1775,19 @@ class MyInnerClass:
 	func another_one() -> void:
 		pass
 )");
-		const String pre_formatted = code;
+		const String pre_formatted =
+				GDSCRIPT(R"(
+class MyInnerClass:
+	var hi
+
+
+	func my_inner_class_function() -> void:
+		pass
+
+
+	func another_one() -> void:
+		pass
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
@@ -3845,6 +3857,7 @@ var my_array = [
 	# Comment
 ]
 )");
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
@@ -3852,22 +3865,15 @@ var my_array = [
 		const String code =
 				GDSCRIPT(R"(
 func _ready():
-	var v := Vector2()
-	var a = v[0]  # A
+	var v = [0]
+	var a = v[0] # A
 
-	func another():
-	pass
-)");
-
-		const String pre_formatted =
-				GDSCRIPT(R"(
-func _ready():
-	var v := Vector2()
-	var a = v[0]  # A
 
 func another():
 	pass
 )");
+		const String pre_formatted = code;
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
@@ -3879,6 +3885,7 @@ static func test():
 	pass
 )");
 		const String pre_formatted = code;
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
@@ -3891,6 +3898,7 @@ func test_func() -> bool:
 	return false
 )");
 		const String pre_formatted = code;
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
@@ -3901,6 +3909,7 @@ func test_func() -> bool:
 @onready var b_node = a_node.get_node(^"BNode") # Test
 )");
 		const String pre_formatted = code;
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
@@ -3915,6 +3924,7 @@ func _ready():
 	}
 )");
 		const String pre_formatted = code;
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
@@ -3925,8 +3935,11 @@ func _ready():
 func _run() -> void:
 	# This should not count as an expression
 )");
-			const String pre_formatted = code;
-			CHECK_FORMAT(code, pre_formatted);
+			GDScriptFormat formatter;
+			formatter.indent_in_multiline_block = 1;
+			String output;
+			Error err = formatter.format(code, output);
+			CHECK(err != OK);
 		}
 
 		SUBCASE("Condition body") {
@@ -3936,8 +3949,11 @@ func _run() -> void:
 	if true:
 		# This should not count as an expression
 )");
-			const String pre_formatted = code;
-			CHECK_FORMAT(code, pre_formatted);
+			GDScriptFormat formatter;
+			formatter.indent_in_multiline_block = 1;
+			String output;
+			Error err = formatter.format(code, output);
+			CHECK(err != OK);
 		}
 	}
 } // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Comments]")
@@ -3951,6 +3967,7 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 @onready var child_node = $ChildNode
 )");
 			String pre_formatted = code;
+
 			CHECK_FORMAT(code, pre_formatted);
 
 			// Should remove useless quotes
@@ -3962,6 +3979,7 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 					GDSCRIPT(R"(
 @onready var child_node = $ChildNode
 )");
+
 			CHECK_FORMAT(code, pre_formatted);
 
 			// Should keep quotes
@@ -3970,6 +3988,7 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 @onready var sub_child_node = $"ChildNode/Node$/Path"
 )");
 			pre_formatted = code;
+
 			CHECK_FORMAT(code, pre_formatted);
 		}
 
@@ -3980,6 +3999,7 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 @onready var unique_node = %UniqueNode
 )");
 			String pre_formatted = code;
+
 			CHECK_FORMAT(code, pre_formatted);
 
 			// Should remove useless quotes
@@ -3988,6 +4008,7 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 @onready var unique_node = %UniqueNodeIndeed
 )");
 			pre_formatted = code;
+
 			CHECK_FORMAT(code, pre_formatted);
 
 			// Should keep quotes
@@ -3996,6 +4017,7 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 @onready var unique_node = %"UniqueNodeIndeedWith$"
 )");
 			pre_formatted = code;
+
 			CHECK_FORMAT(code, pre_formatted);
 		}
 	}
@@ -4009,6 +4031,7 @@ func _ready():
 	var string = "%1.1f k" % (number * 0.001)
 )");
 			const String pre_formatted = code;
+
 			CHECK_FORMAT(code, pre_formatted);
 		}
 	}
@@ -4021,6 +4044,7 @@ func _ready():
 	var number = 0.0000000000000000000000000000000000000000000000000000000000000001
 )");
 			const String pre_formatted = code;
+
 			CHECK_FORMAT(code, pre_formatted);
 		}
 	}
@@ -4032,6 +4056,7 @@ func _ready():
 @export_exp_easing var very_small_var: float = 0.0
 )");
 			const String pre_formatted = code;
+
 			CHECK_FORMAT(code, pre_formatted);
 		}
 
@@ -4045,6 +4070,7 @@ func _ready():
 @export_exp_easing
 var very_long_long_long_long_long_long_long_long_long_long_long_long_long_long_var: float = 0.0
 )");
+
 			CHECK_FORMAT(code, pre_formatted);
 		}
 	}
@@ -4054,8 +4080,10 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Misc]") {
 	TEST_CASE("The custom newlines should be remembered") {
 		// `vformat` because "misc/scripts/header_guards.sh"
 		// don't like two consecutive new lines.
-		const String code = vformat(R"(extends Node2D
-%s
+		const String code = GDSCRIPT(R"(
+extends Node2D
+<*noop*>
+<*noop*>
 class Light:
 	var energy
 
@@ -4071,17 +4099,20 @@ func _ready() -> void:
 		light.height = height_slider.value)
 
 	height_slider.value_changed.connect(func(value):
-		light.height = height_slider.value))",
-				"\n");
-		const String pre_formatted = vformat(R"(extends Node2D
-%s
+		light.height = height_slider.value)
+)");
+		const String pre_formatted = GDSCRIPT(R"(
+extends Node2D
+<*noop*>
+<*noop*>
 class Light:
 	var energy
 
 var energy_slider := Range.new()
 var height_slider := Range.new()
 var light := Light.new()
-%s
+<*noop*>
+<*noop*>
 func _ready() -> void:
 	energy_slider.value_changed.connect(func(value):
 		light.energy = energy_slider.value)
@@ -4091,8 +4122,8 @@ func _ready() -> void:
 
 	height_slider.value_changed.connect(func(value):
 		light.height = height_slider.value)
-)",
-				"\n", "\n");
+)");
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -67,8 +67,8 @@ namespace GDScriptTests {
 			)                                                                                   \
 		);                                                                                      \
 		CHECK_EQ(                                                                               \
-			vformat(CHECK_FORMAT_FORMAT, pre_formatted),                                        \
-			vformat(CHECK_FORMAT_FORMAT, output)                                                \
+			vformat(CHECK_FORMAT_FORMAT, output),                                               \
+			vformat(CHECK_FORMAT_FORMAT, pre_formatted)                                         \
 		);                                                                                      \
 	} while (false);
 #define CHECK_FORMAT_FORMAT "\n---\n%s\n---\n"
@@ -3091,6 +3091,38 @@ func _ready() -> void:
 		light.height = height_slider.value)
 )",
 				"\n", "\n");
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Function default values should have spaces") {
+		String code;
+		String pre_formatted;
+		
+		// Without typing
+		code = R"(func my_func(optional_param= null):
+	pass
+)";
+		pre_formatted = R"(func my_func(optional_param = null):
+	pass
+)";
+		CHECK_FORMAT(code, pre_formatted);
+
+		// With explicit typing
+		code = R"(func my_func(optional_param: Node =null):
+	pass
+)";
+		pre_formatted = R"(func my_func(optional_param: Node = null):
+	pass
+)";
+		CHECK_FORMAT(code, pre_formatted);
+
+		// With inferred typing
+		code = R"(func my_func(optional_param:=""):
+	pass
+)";
+		pre_formatted = R"(func my_func(optional_param := ""):
+	pass
+)";
 		CHECK_FORMAT(code, pre_formatted);
 	}
 } // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Misc]")

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -2797,6 +2797,51 @@ func some_public_api_func() -> int:
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
+	TEST_CASE("The custom newlines should be remembered") {
+		const String code = R"(extends Node2D
+
+
+class Light:
+	var energy
+
+var energy_slider := Range.new()
+var height_slider := Range.new()
+var light := Light.new()
+
+
+func _ready() -> void:
+	energy_slider.value_changed.connect(func(value):
+		light.energy = energy_slider.value)
+
+	height_slider.value_changed.connect(func(value):
+		light.height = height_slider.value)
+
+	height_slider.value_changed.connect(func(value):
+		light.height = height_slider.value))";
+		const String pre_formatted = R"(extends Node2D
+
+
+class Light:
+	var energy
+
+var energy_slider := Range.new()
+var height_slider := Range.new()
+var light := Light.new()
+
+
+func _ready() -> void:
+	energy_slider.value_changed.connect(func(value):
+		light.energy = energy_slider.value)
+
+	height_slider.value_changed.connect(func(value):
+		light.height = height_slider.value)
+
+	height_slider.value_changed.connect(func(value):
+		light.height = height_slider.value)
+)";
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
 	TEST_CASE("A full commented function should output correctly") {
 		// Code by clayjohn at https://github.com/godotengine/godot-docs/issues/4834
 		const String code = R"(func _ready():

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -3951,6 +3951,18 @@ func _run() -> void:
 			CHECK(err != OK);
 		}
 	}
+
+	TEST_CASE("Long header comments should not make a small expression split") {
+		const String code = GDSCRIPT(R"(
+func _ready():
+	var some_node
+	# This bug only happens when the comment on the previous line exceeds 80 chars.
+	some_node.visible = 5 > 3
+)");
+		const String pre_formatted = code;
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
 } // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Comments]")
 
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -66,8 +66,12 @@ namespace GDScriptTests {
 				String("\n").join(error_messages)                                               \
 			)                                                                                   \
 		);                                                                                      \
-		CHECK_EQ(output, pre_formatted);                                                        \
+		CHECK_EQ(                                                                               \
+			vformat(CHECK_FORMAT_FORMAT, pre_formatted),                                        \
+			vformat(CHECK_FORMAT_FORMAT, output)                                                \
+		);                                                                                      \
 	} while (false);
+#define CHECK_FORMAT_FORMAT "\n---\n%s\n---\n"
 
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][ClassMembers]") {
 	TEST_CASE("Should output a variable with a property that has a setter and getter, inline") {
@@ -3001,9 +3005,44 @@ func another():
 
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 	TEST_CASE("Syntactic sugar should be preserved") {
-		SUBCASE("Unique nodes (%)") {
-			const String code = R"(@onready var unique_node = %UniqueNode)";
-			const String pre_formatted = code;
+		SUBCASE("get_node ($)") {
+			// Should let as-is
+			String code = R"(@onready var child_node = $ChildNode
+)";
+			String pre_formatted = code;
+			CHECK_FORMAT(code, pre_formatted);
+
+			// Should remove useless quotes
+			code = R"(@onready var child_node = $"ChildNode"
+)";
+			pre_formatted = R"(@onready var child_node = $ChildNode
+)";
+			CHECK_FORMAT(code, pre_formatted);
+
+			// Should keep quotes
+			code = R"(@onready var sub_child_node = $"ChildNode/Node$/Path"
+)";
+			pre_formatted = code;
+			CHECK_FORMAT(code, pre_formatted);
+		}
+
+		SUBCASE("Unique names (%)") {
+			// Should let as-is
+			String code = R"(@onready var unique_node = %UniqueNode
+)";
+			String pre_formatted = code;
+			CHECK_FORMAT(code, pre_formatted);
+
+			// Should remove useless quotes
+			code = R"(@onready var unique_node = %UniqueNodeIndeed
+)";
+			pre_formatted = code;
+			CHECK_FORMAT(code, pre_formatted);
+
+			// Should keep quotes
+			code = R"(@onready var unique_node = %"UniqueNodeIndeedWith$"
+)";
+			pre_formatted = code;
 			CHECK_FORMAT(code, pre_formatted);
 		}
 	}

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -39,419 +39,617 @@
 
 namespace GDScriptTests {
 
-#define CHECK_FORMAT(code, pre_formatted)                                                       \
-	do {                                                                                        \
-		GDScriptFormat formatter;                                                               \
-		formatter.indent_in_multiline_block = 1;                                                \
-		String output;                                                                          \
-		Error err = formatter.format(code, output);                                             \
-		Vector<String> error_messages;                                                          \
-		if (err != OK) {                                                                        \
-			for (GDScriptParser::ParserError parser_error : formatter.get_parser_errors()) {    \
-				error_messages.push_back(                                                       \
-					vformat(                                                                    \
-						"Parse Error: %s (%s:%s)",                                              \
-						parser_error.message,                                                   \
-						parser_error.line,                                                      \
-						parser_error.column                                                     \
-					)                                                                           \
-				);                                                                              \
-			}                                                                                   \
-		}                                                                                       \
-		CHECK_MESSAGE(                                                                          \
-			err == OK,                                                                          \
-			vformat(                                                                            \
-				"The formatter returned errors (%s): \n%s",                                     \
-				error_messages.size(),                                                          \
-				String("\n").join(error_messages)                                               \
-			)                                                                                   \
-		);                                                                                      \
-		CHECK_EQ(                                                                               \
-			vformat(CHECK_FORMAT_FORMAT, output),                                               \
-			vformat(CHECK_FORMAT_FORMAT, pre_formatted)                                         \
-		);                                                                                      \
+#define CHECK_FORMAT(code, pre_formatted)                                                    \
+	do {                                                                                     \
+		GDScriptFormat formatter;                                                            \
+		formatter.indent_in_multiline_block = 1;                                             \
+		String output;                                                                       \
+		Error err = formatter.format(code, output);                                          \
+		Vector<String> error_messages;                                                       \
+		if (err != OK) {                                                                     \
+			for (GDScriptParser::ParserError parser_error : formatter.get_parser_errors()) { \
+				error_messages.push_back(                                                    \
+						vformat(                                                             \
+								"Parse Error: %s (%s:%s)",                                   \
+								parser_error.message,                                        \
+								parser_error.line,                                           \
+								parser_error.column));                                       \
+			}                                                                                \
+		}                                                                                    \
+		CHECK_MESSAGE(                                                                       \
+				err == OK,                                                                   \
+				vformat(                                                                     \
+						"The formatter returned errors (%s): \n%s",                          \
+						error_messages.size(),                                               \
+						String("\n").join(error_messages)));                                 \
+		CHECK_EQ(                                                                            \
+				vformat(CHECK_FORMAT_FORMAT, output),                                        \
+				vformat(CHECK_FORMAT_FORMAT, pre_formatted));                                \
 	} while (false);
 #define CHECK_FORMAT_FORMAT "\n---\n%s\n---\n"
 
+// The GDSCRIPT macro does two things:
+// 1. Removes the first \n in the string (all GDSCRIPT macro calls must begin with a \n)
+// 2. <*noop*> is there to fix issues with {root}/misc/scripts/header_guards.sh that refuses
+//      consecutive two line breaks. <*noop*> is replaced by nothing, which leaves the \n
+//      right after intact.
+#define GDSCRIPT(code) \
+	String(code)       \
+			.substr(1) \
+			.replacen("<*noop*>", "")
+
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][ClassMembers]") {
 	TEST_CASE("Should output a variable with a property that has a setter and getter, inline") {
-		const String code = R"(var my_property := 0:
+		const String code =
+				GDSCRIPT(R"(
+var my_property := 0:
 	get:
 		return my_property
 	set(value):
-		my_property = value)";
-		const String pre_formatted = R"(var my_property := 0:
+		my_property = value
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_property := 0:
 	set(value):
 		my_property = value
 	get:
 		return my_property
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a property that has a setter with a spare line after the property for readability") {
-		const String code = R"(var my_property := 0:
+		const String code =
+				GDSCRIPT(R"(
+var my_property := 0:
 	set(value):
 		my_property = value
-var some_variable = 0)";
-		const String pre_formatted = R"(var my_property := 0:
+var some_variable = 0
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_property := 0:
 	set(value):
 		my_property = value
 
 var some_variable = 0
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable that takes a casted value") {
-		const String code = R"(var my_casted_variable := my_uncasted_variable as CastedType)";
-		const String pre_formatted = R"(var my_casted_variable := my_uncasted_variable as CastedType
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_casted_variable := my_uncasted_variable as CastedType
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable that takes a casted value's output") {
-		const String code = R"(var my_casted_variable := (my_uncasted_variable as CastedType).result)";
-		const String pre_formatted = R"(var my_casted_variable := (my_uncasted_variable as CastedType).result
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_casted_variable := (my_uncasted_variable as CastedType).result
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_casted_variable := (my_uncasted_variable as CastedType).result
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a simple class with a variable") {
-		const String code = R"(var my_variable)";
-		const String pre_formatted = R"(var my_variable
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable
+)");
+		const String pre_formatted = code;
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a datatype but no value") {
-		const String code = R"(var my_variable: MyDataType)";
-		const String pre_formatted = R"(var my_variable: MyDataType
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable: MyDataType
+)");
+		const String pre_formatted = code;
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a simple class with a variable with self") {
-		const String code = R"(var my_variable = self)";
-		const String pre_formatted = R"(var my_variable = self
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable = self
+)");
+		const String pre_formatted = code;
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable that has a basic export annotation") {
-		const String code = R"(@export var my_variable)";
-		const String pre_formatted = R"(@export var my_variable
-)";
+		const String code =
+				GDSCRIPT(R"(
+@export var my_variable
+)");
+		const String pre_formatted = code;
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable that has multiple annotations on one line when they fit") {
-		const String code = R"(@onready @export var my_variable)";
-		const String pre_formatted = R"(@onready @export var my_variable
-)";
-		CHECK_FORMAT(code, pre_formatted);
+		SUBCASE("They fit") {
+			const String code =
+					GDSCRIPT(R"(
+@onready @export var my_variable
+)");
+			const String pre_formatted = code;
+
+			CHECK_FORMAT(code, pre_formatted);
+		}
+
+		SUBCASE("They don't fit") {
+			const String code =
+					GDSCRIPT(R"(
+@onready @export var my_variable_with_a_very_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name
+)");
+			const String pre_formatted =
+					GDSCRIPT(R"(
+@onready
+@export
+var my_variable_with_a_very_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_long_name
+)");
+
+			CHECK_FORMAT(code, pre_formatted);
+		}
 	}
 
 	TEST_CASE("Should output a variable that has a export annotation with parameters") {
-		const String code = R"(@export_range(0, 20) var my_variable)";
-		const String pre_formatted = R"(@export_range(0, 20)
-var my_variable
-)";
+		const String code =
+				GDSCRIPT(R"(
+@export_range(0, 20) var my_variable
+)");
+		const String pre_formatted = code;
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable that has a export annotation with parameters that causes an annotation split") {
-		const String code = R"(@export_enum("One thing leads", "to another, which causes", "a split to occur", "even if this is not", "a valid enum") var my_variable)";
-		const String pre_formatted = R"(@export_enum("One thing leads", "to another, which causes", "a split to occur", "even if this is not", "a valid enum")
+		const String code =
+				GDSCRIPT(R"(
+@export_enum("One thing leads", "to another, which causes", "a split to occur", "even if this is not", "a valid enum") var my_variable
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+@export_enum("One thing leads", "to another, which causes", "a split to occur", "even if this is not", "a valid enum")
 var my_variable
-)";
+)");
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with an array being accessed by index") {
-		const String code = "var my_variable := presences[0]";
-		const String pre_formatted = R"(var my_variable := presences[0]
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := presences[0]
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a dictionary being accessed by index") {
-		const String code = R"(var my_variable := presences["MatchId"])";
-		const String pre_formatted = R"(var my_variable := presences["MatchId"]
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := presences["MatchId"]
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a dictionary being accessed by attribute") {
-		const String code = R"(var my_variable := output.format)";
-		const String pre_formatted = R"(var my_variable := output.format
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := output.format
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a dictionary being accessed by function that wraps due to length") {
-		const String code = R"(var my_variable := output[get_formatting_index_based_on_data("localhost", 8080, "development_branch")])";
-		const String pre_formatted = R"(var my_variable := output[
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := output[get_formatting_index_based_on_data("localhost", 8080, "development_branch")]
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := output[
 	get_formatting_index_based_on_data("localhost", 8080, "development_branch")
 ]
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable that uses a simple if/else ternary") {
-		const String code = "var my_variable := 5 if true else 8";
-		const String pre_formatted = R"(var my_variable := 5 if true else 8
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := 5 if true else 8
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable that uses a if/else ternary that wraps due to length") {
-		const String code = R"(var my_variable := "a long string goes here to force a wrap" if true else "lorem ipsum 3.145967 robot meme")";
-		const String pre_formatted = R"(var my_variable := (
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := "a long string goes here to force a wrap" if true else "lorem ipsum 3.145967 robot meme"
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := (
 	"a long string goes here to force a wrap" if true
 	else "lorem ipsum 3.145967 robot meme"
 )
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable that uses a if/else ternary that wraps due to length with a function that wraps due to length") {
-		const String code = R"(var my_variable := "a long string goes here to force a wrap" if true else some_function("lorem ipsum", 3.145967, "robot memory of some length", "formidable length of string"))";
-		const String pre_formatted = R"(var my_variable := (
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := "a long string goes here to force a wrap" if true else some_function("lorem ipsum", 3.145967, "robot memory of some length", "formidable length of string")
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := (
 	"a long string goes here to force a wrap" if true
 	else some_function(
 		"lorem ipsum", 3.145967, "robot memory of some length", "formidable length of string"
 	)
 )
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable that holds a negated integer") {
-		const String code = "var my_variable := -2";
-		const String pre_formatted = R"(var my_variable := -2
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := -2
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable that holds an inverted truth") {
-		const String code = "var my_variable := not my_condition";
-		const String pre_formatted = R"(var my_variable := not my_condition
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := not my_condition
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a get node path") {
-		const String code = "var my_variable := $Node";
-		const String pre_formatted = R"(var my_variable := $Node
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := $Node
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a get node chain path") {
-		const String code = "var my_variable := $NodeA/NodeB/NodeC";
-		const String pre_formatted = R"(var my_variable := $NodeA/NodeB/NodeC
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := $NodeA/NodeB/NodeC
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a get node string") {
-		const String code = R"(var my_variable := $"../Parent/NodeB")";
-		const String pre_formatted = R"(var my_variable := $"../Parent/NodeB"
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := $"../Parent/NodeB"
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a preload") {
-		const String code = R"(var my_variable := preload("res://Player.tscn"))";
-		const String pre_formatted = R"(var my_variable := preload("res://Player.tscn")
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := preload("res://Player.tscn")
+)");
+		const String pre_formatted = code;
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a preload that wraps") {
-		const String code = R"(var my_variable := preload("res://A/Deep/Folder/Hierarchy/To/Encourage/Wrapping/PlayerSceneWithALongName.tscn"))";
-		const String pre_formatted = R"(var my_variable := preload(
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := preload("res://A/Deep/Folder/Hierarchy/To/Encourage/Wrapping/PlayerSceneWithALongName.tscn")
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := preload(
 	"res://A/Deep/Folder/Hierarchy/To/Encourage/Wrapping/PlayerSceneWithALongName.tscn"
 )
-)";
+)");
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a basic operation") {
 		SUBCASE("+") {
-			String code = "var my_variable := 0+1";
-			String pre_formatted = R"(var my_variable := 0 + 1
-)";
+			String code =
+					GDSCRIPT(R"(
+var my_variable := 0+1
+)");
+			String pre_formatted =
+					GDSCRIPT(R"(
+var my_variable := 0 + 1
+)");
+
 			CHECK_FORMAT(code, pre_formatted);
 		}
 
 		SUBCASE("-") {
-			String code = "var my_variable := 0-1";
-			String pre_formatted = R"(var my_variable := 0 - 1
-)";
+			String code =
+					GDSCRIPT(R"(
+var my_variable := 0-1
+)");
+			String pre_formatted =
+					GDSCRIPT(R"(
+var my_variable := 0 - 1
+)");
 
 			CHECK_FORMAT(code, pre_formatted);
 		}
 
 		SUBCASE("*") {
-			String code = "var my_variable := 0*1";
-			String pre_formatted = R"(var my_variable := 0 * 1
-)";
+			String code =
+					GDSCRIPT(R"(
+var my_variable := 0*1
+)");
+			String pre_formatted =
+					GDSCRIPT(R"(
+var my_variable := 0 * 1
+)");
+
 			CHECK_FORMAT(code, pre_formatted);
 		}
 
 		SUBCASE("/") {
-			String code = "var my_variable := 0/1";
-			String pre_formatted = R"(var my_variable := 0 / 1
-)";
+			String code =
+					GDSCRIPT(R"(
+var my_variable := 0/1
+)");
+			String pre_formatted =
+					GDSCRIPT(R"(
+var my_variable := 0 / 1
+)");
 
 			CHECK_FORMAT(code, pre_formatted);
 		}
 
 		SUBCASE("%") {
-			String code = "var my_variable := 0%1";
-			String pre_formatted = R"(var my_variable := 0 % 1
-)";
+			String code =
+					GDSCRIPT(R"(
+var my_variable := 0%1
+)");
+			String pre_formatted =
+					GDSCRIPT(R"(
+var my_variable := 0 % 1
+)");
 			CHECK_FORMAT(code, pre_formatted);
 		}
 	}
 
 	TEST_CASE("Should output nested binary operation") {
-		const String code = "var my_variable := 0+0+1";
-		const String pre_formatted = R"(var my_variable := 0 + 0 + 1
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := 0+0+1
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := 0 + 0 + 1
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output double nested binary operation") {
-		const String code = "var my_variable := 0+1+0+1";
-		const String pre_formatted = R"(var my_variable := 0 + 1 + 0 + 1
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := 0+1+0+1
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := 0 + 1 + 0 + 1
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a binary operation") {
-		const String code = "var my_variable := 0+1";
-		const String pre_formatted = R"(var my_variable := 0 + 1
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := 0+1
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := 0 + 1
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with string concat") {
-		const String code = R"(var my_variable := "Hello"+"World !")";
-		const String pre_formatted = R"(var my_variable := "Hello" + "World !"
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := "Hello"+"World !"
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := "Hello" + "World !"
+)");
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with string concat that is wrapped due to length") {
-		const String code = R"(var my_variable := "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas et neque sodales, tempor ex sit amet, venenatis elit." + "Etiam ultrices enim id venenatis tempor. Quisque dictum ligula vel felis vestibulum, eget eleifend sem suscipit.")";
-		const String pre_formatted = R"(var my_variable := (
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas et neque sodales, tempor ex sit amet, venenatis elit." + "Etiam ultrices enim id venenatis tempor. Quisque dictum ligula vel felis vestibulum, eget eleifend sem suscipit."
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := (
 	"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas et neque sodales, tempor ex sit amet, venenatis elit."
 	+ "Etiam ultrices enim id venenatis tempor. Quisque dictum ligula vel felis vestibulum, eget eleifend sem suscipit."
 )
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with double string concat that is wrapped due to length") {
-		const String code = R"(var my_variable := "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas et neque sodales, tempor ex sit amet, venenatis elit." + "Etiam ultrices enim id venenatis tempor. Quisque dictum ligula vel felis vestibulum, eget eleifend sem suscipit." + "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas et neque sodales, tempor ex sit amet, venenatis elit." + "Etiam ultrices enim id venenatis tempor. Quisque dictum ligula vel felis vestibulum, eget eleifend sem suscipit.")";
-		const String pre_formatted = R"(var my_variable := (
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas et neque sodales, tempor ex sit amet, venenatis elit." + "Etiam ultrices enim id venenatis tempor. Quisque dictum ligula vel felis vestibulum, eget eleifend sem suscipit." + "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas et neque sodales, tempor ex sit amet, venenatis elit." + "Etiam ultrices enim id venenatis tempor. Quisque dictum ligula vel felis vestibulum, eget eleifend sem suscipit."
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := (
 	"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas et neque sodales, tempor ex sit amet, venenatis elit."
 	+ "Etiam ultrices enim id venenatis tempor. Quisque dictum ligula vel felis vestibulum, eget eleifend sem suscipit."
 	+ "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas et neque sodales, tempor ex sit amet, venenatis elit."
 	+ "Etiam ultrices enim id venenatis tempor. Quisque dictum ligula vel felis vestibulum, eget eleifend sem suscipit."
 )
-)";
+)");
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable that is broken due to length with double string concat that is not wrapped due to length") {
-		const String code = R"(var my_variable := "Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum ")";
-		const String pre_formatted = R"(var my_variable := (
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := "Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum "
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := (
 	"Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum" + "Lorem ipsum "
 )
-)";
+)");
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a properly formatted binary division operation with order of operations preserved") {
-		const String code = R"(var my_variable := 4 / (1 + 1))";
-		const String pre_formatted = R"(var my_variable := 4 / (1 + 1)
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := 4 / (1 + 1)
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a preserved formatted operation") {
-		const String code = R"(var my_variable := 4 / 1 + 1)";
-		const String pre_formatted = R"(var my_variable := 4 / 1 + 1
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := 4 / 1 + 1
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a formatted operation for complex operation") {
-		const String code = R"(var my_variable := 3+(6*(11+1-4))/8*2)";
-		const String pre_formatted = R"(var my_variable := 3 + 6 * (11 + 1 - 4) / 8 * 2
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := 3+(6*(11+1-4))/8*2
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := 3 + 6 * (11 + 1 - 4) / 8 * 2
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a formatted operation for multiplication") {
-		const String code = R"(var my_variable := 4 * (1 + 1))";
-		const String pre_formatted = R"(var my_variable := 4 * (1 + 1)
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := 4*(1+1)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := 4 * (1 + 1)
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should be able to store a variable with array") {
-		const String code = R"(var my_variable := [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])";
-		const String pre_formatted = R"(var my_variable := [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := [0,1,2,3,4,5,6,7,8,9]
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should be able to store a variable with array that wraps due to length") {
-		const String code = R"(var my_variable := ["Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit."])";
-		const String pre_formatted = R"(var my_variable := [
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := ["Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit."]
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := [
 	"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
 	"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
 	"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
 	"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
 	"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
 ]
-)";
+)");
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should be able to store a variable with array with subarray that wraps due to length") {
-		const String code = R"(var my_variable := [["Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit."]])";
-		const String pre_formatted = R"(var my_variable := [
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := [["Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit.","Lorem ipsum dolor sit amet, consectetur adipiscing elit."]]
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := [
 	[
 		"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
 		"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
@@ -460,64 +658,99 @@ var my_variable
 		"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
 	],
 ]
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should be able to store a variable with array that breaks, of arrays that do not break") {
-		const String code = R"(var my_variable := [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])";
-		const String pre_formatted = R"(var my_variable := [
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := [
 	[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
 	[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
 	[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
 ]
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should maintain type information for typed arrays") {
-		const String code = R"(extends Node
+		const String code =
+				GDSCRIPT(R"(
+extends Node
 
-@onready var children: Array[Node] = get_children())";
-		const String pre_formatted = "extends Node\n\n\n@onready var children: Array[Node] = get_children()\n";
+@onready var children: Array[Node] = get_children()
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+extends Node
+<*noop*>
+<*noop*>
+@onready var children: Array[Node] = get_children()
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a simple one line dictionary") {
-		const String code = R"(var my_variable := {"string key":"string value"})";
-		const String pre_formatted = R"(var my_variable := {"string key": "string value"}
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := {"string key":"string value"}
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := {"string key": "string value"}
+)");
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a simple one line Lua dictionary") {
-		const String code = R"(var my_variable := {string_key="string value"})";
-		const String pre_formatted = R"(var my_variable := {string_key = "string value"}
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := {string_key="string value"}
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := {string_key = "string value"}
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a dictionary wrapped due to length") {
-		const String code = R"(var my_variable := {"string key 1":"string value", "string key 2":"string value", "string key 3":"string value", "string key 4":"string value", "string key 5":"string value"})";
-		const String pre_formatted = R"(var my_variable := {
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := {"string key 1":"string value", "string key 2":"string value", "string key 3":"string value", "string key 4":"string value", "string key 5":"string value"}
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := {
 	"string key 1": "string value",
 	"string key 2": "string value",
 	"string key 3": "string value",
 	"string key 4": "string value",
 	"string key 5": "string value",
 }
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a dictionary that wraps an element due to length") {
-		const String code = R"(var test := {"test":"a long concat expression"+some_function_call("with a lot of", "very long parameters", "that should be wrapped", "due to its severely extended length")})";
-		const String pre_formatted = R"(var test := {
+		const String code =
+				GDSCRIPT(R"(
+var test := {"test":"a long concat expression"+some_function_call("with a lot of", "very long parameters", "that should be wrapped", "due to its severely extended length")}
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var test := {
 	"test": (
 		"a long concat expression"
 		+ some_function_call(
@@ -528,233 +761,314 @@ var my_variable
 		)
 	),
 }
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with an assigned value") {
-		const String code = "var my_variable = 0";
-		const String pre_formatted = R"(var my_variable = 0
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable = 0
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with inferred datatype") {
-		const String code = "var my_variable := 0";
-		const String pre_formatted = R"(var my_variable := 0
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := 0
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with an explicit datatype") {
-		const String code = "var my_variable: int = 0";
-		const String pre_formatted = R"(var my_variable: int = 0
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable: int = 0
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a string literal") {
-		const String code = R"(var my_variable := "Hello, my friends!")";
-		const String pre_formatted = R"(var my_variable := "Hello, my friends!"
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := "Hello, my friends!"
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a string literal that contains a quotation mark") {
-		const String code = R"(var my_variable := 'Hello, my "friends"!')";
-		const String pre_formatted = R"(var my_variable := 'Hello, my "friends"!'
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := 'Hello, my "friends"!'
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a decimal") {
-		const String code = "var my_variable := 0.0";
-		const String pre_formatted = R"(var my_variable := 0.0
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := 0.0
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a decimal value") {
-		const String code = "var my_variable := 0.25";
-		const String pre_formatted = R"(var my_variable := 0.25
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := 0.25
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should be able to refer to another variable by identifier") {
-		const String code = R"(var other_variable_name
-var my_variable := other_variable_name)";
-		const String pre_formatted = R"(var other_variable_name
+		const String code =
+				GDSCRIPT(R"(
+var other_variable_name
 var my_variable := other_variable_name
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should do binary operation inside a simple function call") {
-		const String code = R"(var my_variable := a_math_function(20+5))";
-		const String pre_formatted = R"(var my_variable := a_math_function(20 + 5)
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := a_math_function(20+5)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := a_math_function(20 + 5)
+)");
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a function with multiple arguments") {
-		const String code = R"(var my_variable:=Vector2(300,47))";
-		const String pre_formatted = R"(var my_variable := Vector2(300, 47)
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable:=Vector2(300,47)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := Vector2(300, 47)
+)");
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable that does a function call") {
-		const String code = R"(var cell_position := world_to_map_split(300, 47))";
-		const String pre_formatted = R"(var cell_position := world_to_map_split(300, 47)
-)";
+		const String code = GDSCRIPT(R"(
+var cell_position := world_to_map_split(300, 47)
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should be able to store a variable with a function call that breaks, of parameters that do not break") {
-		const String code = R"(var wrapped_text := wrap_some_text("Lorem ipsum","Lorem ipsum","Lorem ipsum","Lorem ipsum","Lorem ips"))";
-		const String pre_formatted = R"(var wrapped_text := wrap_some_text(
+		const String code =
+				GDSCRIPT(R"(
+var wrapped_text := wrap_some_text("Lorem ipsum","Lorem ipsum","Lorem ipsum","Lorem ipsum","Lorem ips")
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var wrapped_text := wrap_some_text(
 	"Lorem ipsum", "Lorem ipsum", "Lorem ipsum", "Lorem ipsum", "Lorem ips"
 )
-)";
+)");
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("First function after a non-function should be separated by newlines") {
-		const String code = R"(var my_variable = 0
+		const String code =
+				GDSCRIPT(R"(
+var my_variable = 0
 func _ready():
-	pass)";
-		const String pre_formatted = "var my_variable = 0\n\n\nfunc _ready():\n\tpass\n";
+	pass
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable = 0
+<*noop*>
+<*noop*>
+func _ready():
+	pass
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a class constant") {
-		const String code = "const MY_CONST = 50";
-		const String pre_formatted = R"(const MY_CONST = 50
-)";
+		const String code =
+				GDSCRIPT(R"(
+const MY_CONST = 50
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should keep built-in constants as named constants") {
-		const String code = "const TAU_COPY = TAU";
-		const String pre_formatted = R"(const TAU_COPY = TAU
-)";
+		const String code =
+				GDSCRIPT(R"(
+const TAU_COPY = TAU
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Sequential constants should follow one another, then line break for the next element type") {
-		const String code = R"(const MY_CONST_A := 5
+		const String code =
+				GDSCRIPT(R"(
+const MY_CONST_A := 5
 const MY_CONST_B = 0
-var my_variable := 10)";
-		const String pre_formatted = R"(const MY_CONST_A := 5
+var my_variable := 10
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+const MY_CONST_A := 5
 const MY_CONST_B = 0
 
 var my_variable := 10
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output user-inputted incidental new lines in classes") {
-		const String code = R"(const CONSTANT_A := 0
-const CONSTANT_B := 1
-
-const CONSTANT_GROUP_A := 0
-const CONSTANT_GROUP_B := 1)";
-		const String pre_formatted = R"(const CONSTANT_A := 0
+		const String code = GDSCRIPT(R"(
+const CONSTANT_A := 0
 const CONSTANT_B := 1
 
 const CONSTANT_GROUP_A := 0
 const CONSTANT_GROUP_B := 1
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a get_node statement with a nodepath string") {
-		const String code = R"(@onready var node = get_node(^"Node"))";
-		const String pre_formatted = R"(@onready var node = get_node(^"Node")
-)";
+		const String code =
+				GDSCRIPT(R"(
+@onready var node = get_node(^"Node")
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+@onready var node = get_node(^"Node")
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a get_node statement with a stringname string") {
-		const String code = R"(@onready var node = get_node(&"Node"))";
-		const String pre_formatted = R"(@onready var node = get_node(&"Node")
-)";
+		const String code =
+				GDSCRIPT(R"(
+@onready var node = get_node(&"Node")
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a signal declaration") {
-		const String code = "signal signal_happened";
-		const String pre_formatted = R"(signal signal_happened
-)";
+		const String code =
+				GDSCRIPT(R"(
+signal signal_happened
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a signal declaration with parameters") {
-		const String code = "signal signal_happened(a, b,c)";
-		const String pre_formatted = R"(signal signal_happened(a, b, c)
-)";
+		const String code =
+				GDSCRIPT(R"(
+signal signal_happened(a, b,c)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+signal signal_happened(a, b, c)
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a signal declaration with parameters that wrap due to length") {
-		const String code = "signal signal_happened(a_long_list_of_long_parameters_a, a_long_list_of_long_parameters_b,a_long_list_of_long_parameters_c,a_long_list_of_long_parameters_d)";
-		const String pre_formatted = R"(signal signal_happened(
+		const String code =
+				GDSCRIPT(R"(
+signal signal_happened(a_long_list_of_long_parameters_a, a_long_list_of_long_parameters_b,a_long_list_of_long_parameters_c,a_long_list_of_long_parameters_d)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+signal signal_happened(
 	a_long_list_of_long_parameters_a,
 	a_long_list_of_long_parameters_b,
 	a_long_list_of_long_parameters_c,
 	a_long_list_of_long_parameters_d
 )
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a signal declaration with explicit empty parameter list being maintained") {
-		const String code = "signal my_signal()";
-		const String pre_formatted = "signal my_signal()\n";
+		const String code =
+				GDSCRIPT(R"(
+signal my_signal()
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+signal my_signal()
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a simple named enum") {
-		const String code = "enum MyEnum { A, B, C }";
-		const String pre_formatted = R"(enum MyEnum { A, B, C }
-)";
+		const String code =
+				GDSCRIPT(R"(
+enum MyEnum { A, B, C }
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output an enum with a value") {
-		const String code = "enum MyEnum { A, B, C = 5, D }";
-		const String pre_formatted = R"(enum MyEnum { A, B, C = 5, D }
-)";
+		const String code =
+				GDSCRIPT(R"(
+enum MyEnum { A, B, C = 5, D }
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a named enum that wraps due to length") {
-		const String code = "enum MyNamedEnumWithALongName { ENUM_A_WITH_A_NAME, ENUM_A_WITH_B_NAME, ENUM_A_WITH_C_NAME, ENUM_A_WITH_D_NAME, ENUM_A_WITH_E_NAME, ENUM_A_WITH_F_NAME }";
-		const String pre_formatted = R"(enum MyNamedEnumWithALongName {
+		const String code =
+				GDSCRIPT(R"(
+enum MyNamedEnumWithALongName { ENUM_A_WITH_A_NAME, ENUM_A_WITH_B_NAME, ENUM_A_WITH_C_NAME, ENUM_A_WITH_D_NAME, ENUM_A_WITH_E_NAME, ENUM_A_WITH_F_NAME }
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+enum MyNamedEnumWithALongName {
 	ENUM_A_WITH_A_NAME,
 	ENUM_A_WITH_B_NAME,
 	ENUM_A_WITH_C_NAME,
@@ -762,62 +1076,87 @@ const CONSTANT_GROUP_B := 1
 	ENUM_A_WITH_E_NAME,
 	ENUM_A_WITH_F_NAME,
 }
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a named enum that wraps due to length but elements do not wrap") {
-		const String code = "enum MyNamedEnumWithALongName {ENUM_A_WITH_A_NAME, ENUM_A_WITH_B_NAME,	ENUM_A_WITH_C_NAME, ENUM_A_WITH_D_NAME}";
-		const String pre_formatted = R"(enum MyNamedEnumWithALongName {
+		const String code =
+				GDSCRIPT(R"(
+enum MyNamedEnumWithALongName {ENUM_A_WITH_A_NAME, ENUM_A_WITH_B_NAME,	ENUM_A_WITH_C_NAME, ENUM_A_WITH_D_NAME}
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+enum MyNamedEnumWithALongName {
 	ENUM_A_WITH_A_NAME, ENUM_A_WITH_B_NAME, ENUM_A_WITH_C_NAME, ENUM_A_WITH_D_NAME
 }
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a simple property enum") {
-		const String code = "enum { A, B, C }";
-		const String pre_formatted = R"(enum { A, B, C }
-)";
+		const String code =
+				GDSCRIPT(R"(
+enum { A, B, C }
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Sequential signals should follow one another, then line break for the next element type") {
-		const String code = R"(signal my_signal_a
+		const String code =
+				GDSCRIPT(R"(
+signal my_signal_a
 signal my_signal_b
-var my_variable = 0)";
-		const String pre_formatted = R"(signal my_signal_a
+var my_variable = 0
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+signal my_signal_a
 signal my_signal_b
 
 var my_variable = 0
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should only have one extra line after an inner class") {
-		const String code = R"(class InnerClass:
-	var my_variable)";
-		const String pre_formatted = R"(class InnerClass:
+		const String code =
+				GDSCRIPT(R"(
+class InnerClass:
 	var my_variable
-)";
+<*noop*>
+<*noop*>
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+class InnerClass:
+	var my_variable
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a null value correctly") {
-		const String code = "var my_value = null";
-		const String pre_formatted = "var my_value = null\n";
+		const String code =
+				GDSCRIPT(R"(
+var my_value = null
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a typed null value correctly") {
-		const String code = "var my_value: Object = null";
-		const String pre_formatted = "var my_value: Object = null\n";
+		const String code =
+				GDSCRIPT(R"(
+var my_value: Object = null
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
@@ -825,62 +1164,78 @@ var my_variable = 0
 
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][ClassSignatures]") {
 	TEST_CASE("Should output a simple class") {
-		const String code = "extends Node";
-		const String pre_formatted = R"(extends Node
-)";
+		const String code =
+				GDSCRIPT(R"(
+extends Node
+)");
+		const String pre_formatted = code;
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a simple class with a name") {
-		const String code = "extends Sprite2D\nclass_name MySpriteExtension";
-		const String pre_formatted = R"(class_name MySpriteExtension
+		const String code =
+				GDSCRIPT(R"(
 extends Sprite2D
-)";
+class_name MySpriteExtension
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+class_name MySpriteExtension
+extends Sprite2D
+)");
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a class that extends a subclass") {
-		const String code = "extends OuterClass.InnerClass";
-		const String pre_formatted = R"(extends OuterClass.InnerClass
-)";
+		const String code = GDSCRIPT(R"(
+extends OuterClass.InnerClass
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a class that extends a script file") {
-		const String code = "extends \"res://script.gd\"";
-		const String pre_formatted = R"(extends "res://script.gd"
-)";
+		const String code =
+				GDSCRIPT(R"(
+extends "res://script.gd"
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a class that extends a script file's subclass") {
-		const String code = "extends \"res://script.gd\".SubClass";
-		const String pre_formatted = R"(extends "res://script.gd".SubClass
-)";
+		const String code =
+				GDSCRIPT(R"(
+extends "res://script.gd".SubClass
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a class that has the tool annotation") {
-		const String code = R"(@tool
-extends Node)";
-		const String pre_formatted = R"(@tool
+		const String code =
+				GDSCRIPT(R"(
+@tool
 extends Node
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a class with an icon set") {
-		const String code = R"(@icon("res://CustomTypes/icon.svg")
-class_name MyClass
-extends Node)";
-		const String pre_formatted = R"(@icon("res://CustomTypes/icon.svg")
+		const String code =
+				GDSCRIPT(R"(
+@icon("res://CustomTypes/icon.svg")
 class_name MyClass
 extends Node
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
@@ -888,66 +1243,92 @@ extends Node
 
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][ClassFunctions]") {
 	TEST_CASE("Should output a simple class method") {
-		const String code = R"(func _ready():
-	pass)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	pass
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a simple class method with a parameter") {
-		const String code = R"(func _process(delta):
-	pass)";
-		const String pre_formatted = R"(func _process(delta):
+		const String code =
+				GDSCRIPT(R"(
+func _process(delta):
 	pass
-)";
+)");
+		const String pre_formatted = code;
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a simple class method with multiple parameters") {
-		const String code = R"(func operate_lever(lever_id, operator_id):
-	pass)";
-		const String pre_formatted = R"(func operate_lever(lever_id, operator_id):
+		const String code =
+				GDSCRIPT(R"(
+func operate_lever(lever_id, operator_id):
 	pass
-)";
+)");
+		const String pre_formatted = code;
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a simple class method with multiple parameters with specified types") {
-		const String code = R"(func operate_lever(lever_id:int, operator_id:int):
-	pass)";
-		const String pre_formatted = R"(func operate_lever(lever_id: int, operator_id: int):
+		const String code =
+				GDSCRIPT(R"(
+func operate_lever(lever_id:int, operator_id:int):
 	pass
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func operate_lever(lever_id: int, operator_id: int):
+	pass
+)");
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a simple class method with multiple parameters with specified types and default values") {
-		const String code = R"(func operate_lever(lever_id:int=0, operator_id:int=1):
-	pass)";
-		const String pre_formatted = R"(func operate_lever(lever_id: int = 0, operator_id: int = 1):
+		const String code =
+				GDSCRIPT(R"(
+func operate_lever(lever_id:int=0, operator_id:int=1):
 	pass
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func operate_lever(lever_id: int = 0, operator_id: int = 1):
+	pass
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a simple class method with multiple parameters with inferred types and default values") {
-		const String code = R"(func operate_lever(lever_id:=0, operator_id:=1):
-	pass)";
-		const String pre_formatted = R"(func operate_lever(lever_id := 0, operator_id := 1):
+		const String code =
+				GDSCRIPT(R"(
+func operate_lever(lever_id:=0, operator_id:=1):
 	pass
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func operate_lever(lever_id := 0, operator_id := 1):
+	pass
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a simple class method with multiple parameters that wrap due to length") {
-		const String code = R"(func a_long_function_name_with_a_lot_of_params(such_as_this_one, and_this_one, and_also_this_one, not_to_mention_this_one_over_here, but_not_this_one):
-	pass)";
-		const String pre_formatted = R"(func a_long_function_name_with_a_lot_of_params(
+		const String code =
+				GDSCRIPT(R"(
+func a_long_function_name_with_a_lot_of_params(such_as_this_one, and_this_one, and_also_this_one, not_to_mention_this_one_over_here, but_not_this_one):
+	pass
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func a_long_function_name_with_a_lot_of_params(
 	such_as_this_one,
 	and_this_one,
 	and_also_this_one,
@@ -955,313 +1336,395 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][ClassFunctions]") {
 	but_not_this_one
 ):
 	pass
-)";
+)");
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a simple class method that wraps due to length, with multiple parameters that do not wrap") {
-		const String code = R"(func a_medium_function_name(a_middling_length_of_params, with_a_couple_identifiers, but_not_too_many):
-	pass)";
-		const String pre_formatted = R"(func a_medium_function_name(
+		const String code =
+				GDSCRIPT(R"(
+func a_medium_function_name(a_middling_length_of_params, with_a_couple_identifiers, but_not_too_many):
+	pass
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func a_medium_function_name(
 	a_middling_length_of_params, with_a_couple_identifiers, but_not_too_many
 ):
 	pass
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a class method with a return type") {
-		const String code = R"(func _ready()->void:
-	pass)";
-		const String pre_formatted = R"(func _ready() -> void:
+		const String code =
+				GDSCRIPT(R"(
+func _ready()->void:
 	pass
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready() -> void:
+	pass
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a class method with a variable being assigned") {
-		const String code = R"(func _ready()->void:
-	var my_variable := 0)";
-		const String pre_formatted = R"(func _ready() -> void:
+		const String code =
+				GDSCRIPT(R"(
+func _ready()->void:
 	var my_variable := 0
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready() -> void:
+	var my_variable := 0
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a class method with a return statement") {
-		const String code = R"(func _ready()->void:
-	return)";
-		const String pre_formatted = R"(func _ready() -> void:
+		const String code =
+				GDSCRIPT(R"(
+func _ready()->void:
 	return
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready() -> void:
+	return
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a class method with a non-void return statement") {
-		const String code = R"(func build()->void:
-	return 5)";
-		const String pre_formatted = R"(func build() -> void:
+		const String code =
+				GDSCRIPT(R"(
+func build()->void:
 	return 5
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func build() -> void:
+	return 5
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a class method with a wrapping return statement due to length") {
-		const String code = R"(func build()->void:
-	return another_function_with_a_long_name_and_thus("lots", "of", "parameters", "that", "take up", "space"))";
-		const String pre_formatted = R"(func build() -> void:
+		const String code =
+				GDSCRIPT(R"(
+func build()->void:
+	return another_function_with_a_long_name_and_thus("lots", "of", "parameters", "that", "take up", "space")
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func build() -> void:
 	return another_function_with_a_long_name_and_thus(
 		"lots", "of", "parameters", "that", "take up", "space"
 	)
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a class method with a breakpoint") {
-		const String code = R"(func _ready():
-	breakpoint)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	breakpoint
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a class method with an assignment") {
-		const String code = R"(func _ready():
-	my_var = 50)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	my_var = 50
-)";
+)");
+		const String pre_formatted = code;
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a class method with an await statement") {
-		const String code = R"(func _ready():
-	await get_tree().idle_frame)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	await get_tree().idle_frame
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a method with a naked type as a statement") {
-		const String code = R"(func _ready():
-	MyNakedType)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	MyNakedType
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a method with a naked binary op as a statement") {
-		const String code = R"(func _ready():
-	2+2)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
+	2+2
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	2 + 2
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a method with a naked array as a statement") {
-		const String code = R"(func _ready():
-	[0,1,2])";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
+	[0,1,2]
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	[0, 1, 2]
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a method with a naked Dictionary as a statement") {
-		const String code = R"(func _ready():
-	{0:5})";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
+	{0:5}
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	{0: 5}
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a method with a naked get node as a statement") {
-		const String code = R"(func _ready():
-	$Node)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	$Node
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a method with a naked literal as a statement") {
-		const String code = R"(func _ready():
-	5)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	5
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a method with a naked preload as a statement") {
-		const String code = R"(func _ready():
-	preload("Node.tscn"))";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	preload("Node.tscn")
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a method with a naked self as a statement") {
-		const String code = R"(func _ready():
-	self)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	self
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a method with a naked subscript as a statement") {
-		const String code = R"(func _ready():
-	the_array[0])";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	the_array[0]
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a method with a ternary block as a statement") {
-		const String code = R"(func _ready():
-	5 if true else 0)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	5 if true else 0
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a method with a unary block as a statement") {
-		const String code = R"(func _ready():
-	-x)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	-x
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a method marked as static") {
-		const String code = R"(static func build():
-	return 5)";
-		const String pre_formatted = R"(static func build():
+		const String code =
+				GDSCRIPT(R"(
+static func build():
 	return 5
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a method with an RPC annotation") {
-		const String code = R"(@rpc func build():
-	return 5)";
-		const String pre_formatted = R"(@rpc
+		const String code =
+				GDSCRIPT(R"(
+@rpc func build():
+	return 5
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+@rpc
 func build():
 	return 5
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable that does a function call from a callee") {
-		const String code = R"(func _ready():
-	the_callee.the_call())";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	the_callee.the_call()
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable that does a function call for super") {
-		const String code = R"(func _ready():
-	super.the_call())";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	super.the_call()
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should wrap a long function call argument array properly") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	var arr = []
-	arr.append_array(["long string 1", "long string 2", "long string 3", "long string 4", "long string 5", "long string 6"]))";
-		const String pre_formatted = R"(func _ready():
+	arr.append_array(["long string 1", "long string 2", "long string 3", "long string 4", "long string 5", "long string 6"])
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	var arr = []
 	arr.append_array([
 		"long string 1", "long string 2", "long string 3", "long string 4", "long string 5", "long string 6"
 	])
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a function that has an assert condition") {
-		const String code = R"(func _ready():
-	assert(some_condition(), "Should have called a condition"))";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	assert(some_condition(), "Should have called a condition")
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a function that has an assert condition that wraps due to length with a condition that breaks due to length") {
-		const String code = R"(func _ready():
-	assert(some_condition("with", "a bunch of parameters", "to cause a wrap", "on multiple lines that wrap and go on a bit too long"),"Should have called a condition that wraps due to length, especially with a long message"))";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
+	assert(some_condition("with", "a bunch of parameters", "to cause a wrap", "on multiple lines that wrap and go on a bit too long"),"Should have called a condition that wraps due to length, especially with a long message")
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	assert(some_condition(
 		"with",
 		"a bunch of parameters",
 		"to cause a wrap",
 		"on multiple lines that wrap and go on a bit too long"
 	), "Should have called a condition that wraps due to length, especially with a long message")
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Sequential functions should be separated by newlines") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	pass
 func _process(delta):
-	pass)";
-		const String pre_formatted = "func _ready():\n\tpass\n\n\nfunc _process(delta):\n\tpass\n";
+	pass
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
+	pass
+<*noop*>
+<*noop*>
+func _process(delta):
+	pass
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should have a call with an array as an argument keep its brackets near the parentheses") {
-		const String code = R"(func _ready():
-	var arr = []
-	arr.append_array([
-		"test with a long string 1",
-		"test with a long string 2",
-		"test with a long string 3",
-		"test with a long string 4",
-	]))";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	var arr = []
 	arr.append_array([
 		"test with a long string 1",
@@ -1269,17 +1732,23 @@ func _process(delta):
 		"test with a long string 3",
 		"test with a long string 4",
 	])
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should wrap long lines but not be too aggressive about parentheses") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	var this_is_a_very_long_boolean_for_test_purposes: bool = false
 	if this_is_a_very_long_boolean_for_test_purposes or this_is_a_very_long_boolean_for_test_purposes or this_is_a_very_long_boolean_for_test_purposes:
-		pass)";
-		const String pre_formatted = R"(func _ready():
+		pass
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	var this_is_a_very_long_boolean_for_test_purposes: bool = false
 	if (
 		this_is_a_very_long_boolean_for_test_purposes
@@ -1287,7 +1756,7 @@ func _process(delta):
 		or this_is_a_very_long_boolean_for_test_purposes
 	):
 		pass
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
@@ -1295,7 +1764,9 @@ func _process(delta):
 
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][InnerClasses]") {
 	TEST_CASE("Inner class should handle variables") {
-		const String code = R"(class MyInnerClass:
+		const String code =
+				GDSCRIPT(R"(
+class MyInnerClass:
 	var hi
 
 	func my_inner_class_function() -> void:
@@ -1303,223 +1774,252 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][InnerClasses]") {
 
 	func another_one() -> void:
 		pass
-)";
+)");
 		const String pre_formatted = code;
+
 		CHECK_FORMAT(code, pre_formatted);
 	}
 } // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][InnerClasses]")
 
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][NestedSuites]") {
 	TEST_CASE("Should output a simple if true/else statement") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	if true:
 		pass
 	else:
-		pass)";
-		const String pre_formatted = R"(func _ready():
-	if true:
 		pass
-	else:
-		pass
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a simple if/elif/else statement") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	if 0:
 		pass
 	elif 1:
 		pass
 	else:
-		pass)";
-		const String pre_formatted = R"(func _ready():
-	if 0:
 		pass
-	elif 1:
-		pass
-	else:
-		pass
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a if statement that wraps due to length") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	if some_conditional_function_with_a_true_false_return_type("and a chunk", "of long", "parameters", "with strings"):
-		pass)";
-		const String pre_formatted = R"(func _ready():
+		pass
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	if (
 		some_conditional_function_with_a_true_false_return_type(
 			"and a chunk", "of long", "parameters", "with strings"
 		)
 	):
 		pass
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Nested if blocks should not stack newlines at end of suite") {
-		const String code = "func _ready():\n\tif true:\n\t\tif true:\n\t\t\tif true:\n\t\t\t\tpass\n\tpass\n";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	if true:
 		if true:
 			if true:
 				pass
-	pass
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output an infinite while loop") {
-		const String code = R"(func _ready():
-	while true:
-		pass)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	while true:
 		pass
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a while loop with a condition call") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	while some_conditional_function_with_a_true_false_return_type("and a chunk", "of long", "parameters", "with strings"):
-		pass)";
-		const String pre_formatted = R"(func _ready():
+		pass
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	while (
 		some_conditional_function_with_a_true_false_return_type(
 			"and a chunk", "of long", "parameters", "with strings"
 		)
 	):
 		pass
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a while loop with a break statement") {
-		const String code = R"(func _ready():
-	while true:
-		break)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	while true:
 		break
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
+	while true:
+		break
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a while loop with a continue statement") {
-		const String code = R"(func _ready():
-	while true:
-		continue)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	while true:
 		continue
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
+	while true:
+		continue
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a simple match block") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	var test := true
 	match test:
 		true:
 			pass
 		false:
 			pass
-		)";
-		const String pre_formatted = R"(func _ready():
+		
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	var test := true
 	match test:
 		true:
 			pass
 		false:
 			pass
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a match block with multiple patterns") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	var test := 50
 	match test:
 		50, 75, 100:
 			pass
 		60, 85, 105:
 			pass
-		)";
-		const String pre_formatted = R"(func _ready():
+		
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	var test := 50
 	match test:
 		50, 75, 100:
 			pass
 		60, 85, 105:
 			pass
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a match block with a wildcard entry") {
-		const String code = R"(func _ready():
-	var test := 50
-	match test:
-		50:
-			print(50)
-		_:
-			print("Not 50"))";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	var test := 50
 	match test:
 		50:
 			print(50)
 		_:
 			print("Not 50")
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
+	var test := 50
+	match test:
+		50:
+			print(50)
+		_:
+			print("Not 50")
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a match block with a variable entry") {
-		const String code = R"(func _ready():
-	var test := 50
-	match test:
-		MY_CONST:
-			print(50)
-		MY_OTHER_CONST:
-			print("Not 50"))";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	var test := 50
 	match test:
 		MY_CONST:
 			print(50)
 		MY_OTHER_CONST:
 			print("Not 50")
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
+	var test := 50
+	match test:
+		MY_CONST:
+			print(50)
+		MY_OTHER_CONST:
+			print("Not 50")
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a match block with a binding entry") {
-		const String code = R"(func _ready():
-	var test := 30
-	match test:
-		50:
-			print(50)
-		25:
-			print(25)
-		var result:
-			print("Not %s" % [result]))";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	var test := 30
 	match test:
 		50:
@@ -1528,88 +2028,125 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][NestedSuites]") {
 			print(25)
 		var result:
 			print("Not %s" % [result])
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
+	var test := 30
+	match test:
+		50:
+			print(50)
+		25:
+			print(25)
+		var result:
+			print("Not %s" % [result])
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a match block with a array entry") {
-		const String code = R"(func _ready():
-	var test := [0, 1, 2]
-	match test:
-		[0, 1, 2]:
-			print(50)
-		[3, 4, 5]:
-			print(25))";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	var test := [0, 1, 2]
 	match test:
 		[0, 1, 2]:
 			print(50)
 		[3, 4, 5]:
 			print(25)
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
+	var test := [0, 1, 2]
+	match test:
+		[0, 1, 2]:
+			print(50)
+		[3, 4, 5]:
+			print(25)
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a match block with an open-ended array entry") {
-		const String code = R"(func _ready():
-	var test := [0, 1, 2]
-	match test:
-		[0, 1, ..]:
-			print(50)
-		[3, 4, 5]:
-			print(25))";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	var test := [0, 1, 2]
 	match test:
 		[0, 1, ..]:
 			print(50)
 		[3, 4, 5]:
 			print(25)
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
+	var test := [0, 1, 2]
+	match test:
+		[0, 1, ..]:
+			print(50)
+		[3, 4, 5]:
+			print(25)
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a match block with a dictionary entry") {
-		const String code = R"(func _ready():
-	var test := {"friend": "Me", "best": true}
-	match test:
-		{"friend": "Me", "best": true}:
-			print("happy")
-		{"friend": "Me", "best": false}:
-			print("sad"))";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	var test := {"friend": "Me", "best": true}
 	match test:
 		{"friend": "Me", "best": true}:
 			print("happy")
 		{"friend": "Me", "best": false}:
 			print("sad")
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
+	var test := {"friend": "Me", "best": true}
+	match test:
+		{"friend": "Me", "best": true}:
+			print("happy")
+		{"friend": "Me", "best": false}:
+			print("sad")
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a simple for loop") {
-		const String code = R"(func _ready():
-	for i in 10:
-		pass)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	for i in 10:
 		pass
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
+	for i in 10:
+		pass
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a for loop with a wrapped condition due to length") {
-		const String code = R"(func _ready() -> void:
+		const String code =
+				GDSCRIPT(R"(
+func _ready() -> void:
 	for i in ["A long string here","A long string there","A long string, everywhere","Hither and thither","The long strings go","Forcing us to wrap conditional statements"]:
-		pass)";
-		const String pre_formatted = R"(func _ready() -> void:
+		pass
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready() -> void:
 	for i in [
 		"A long string here",
 		"A long string there",
@@ -1619,44 +2156,60 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][NestedSuites]") {
 		"Forcing us to wrap conditional statements",
 	]:
 		pass
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable that contains a lambda") {
-		const String code = R"(var my_lambda = func():
-	pass)";
-		const String pre_formatted = R"(var my_lambda = func():
+		const String code =
+				GDSCRIPT(R"(
+var my_lambda = func():
 	pass
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_lambda = func():
+	pass
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should not crash with malformed match") {
-		const String code = R"(func _ready() -> void:
+		const String code =
+				GDSCRIPT(R"(
+func _ready() -> void:
 	var x = 0
 	match x:
-		0)";
-		const String pre_formatted = R"(func _ready() -> void:
+		0
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready() -> void:
 	var x = 0
 	match x:
-		0)";
+		0
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should not error out on a lambda wrapped in a multiline") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	var the_lambda = (
 		func():
 			return true
-	))";
-		const String pre_formatted = R"(func _ready():
+	)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	var the_lambda = func():
 		return true
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
@@ -1664,23 +2217,30 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][NestedSuites]") {
 
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Usability]") {
 	TEST_CASE("Should format differently based on desired wrapping length") {
-		const String code = R"(func _ready() -> void:
+		const String code =
+				GDSCRIPT(R"(
+func _ready() -> void:
 	if my_condition_is_long_enough("it should wrap", "due to length", "on multiple lines"):
-		print("Told you"))";
+		print("Told you")
+)");
 
-		const String pre_formatted80 = R"(func _ready() -> void:
+		const String pre_formatted80 =
+				GDSCRIPT(R"(
+func _ready() -> void:
 	if (
 		my_condition_is_long_enough(
 			"it should wrap", "due to length", "on multiple lines"
 		)
 	):
 		print("Told you")
-)";
+)");
 
-		const String pre_formatted100 = R"(func _ready() -> void:
+		const String pre_formatted100 =
+				GDSCRIPT(R"(
+func _ready() -> void:
 	if my_condition_is_long_enough("it should wrap", "due to length", "on multiple lines"):
 		print("Told you")
-)";
+)");
 
 		GDScriptFormat formatter;
 		String output80;
@@ -1699,26 +2259,33 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Usability]") {
 	}
 
 	TEST_CASE("Should output user-inputted incidental new lines") {
-		const String code = R"(func _ready():
-	var my_variable
-
-	var my_other_variable)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	var my_variable
 
 	var my_other_variable
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
+	var my_variable
+
+	var my_other_variable
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output user-inputted incidental new lines but compress multiple lines into one") {
 		const String code = "func _ready():\n\tvar my_variable\n\n\n\n\tvar my_other_variable";
-		const String pre_formatted = R"(func _ready():
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	var my_variable
 
 	var my_other_variable
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
@@ -1726,15 +2293,9 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Usability]") {
 
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Comments]") {
 	TEST_CASE("Should output a class header with all related comments") {
-		const String code = R"(# Tool header
-@tool # Tool inline
-# Icon header
-@icon("res://icon.png") # Icon inline
-# Class name header
-class_name MyClass # Class name inline
-# Extends header
-extends Node # Extends inline)";
-		const String pre_formatted = R"(# Tool header
+		const String code =
+				GDSCRIPT(R"(
+# Tool header
 @tool # Tool inline
 # Icon header
 @icon("res://icon.png") # Icon inline
@@ -1742,306 +2303,427 @@ extends Node # Extends inline)";
 class_name MyClass # Class name inline
 # Extends header
 extends Node # Extends inline
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+# Tool header
+@tool # Tool inline
+# Icon header
+@icon("res://icon.png") # Icon inline
+# Class name header
+class_name MyClass # Class name inline
+# Extends header
+extends Node # Extends inline
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment above it") {
-		const String code = R"(# A Docstring for the variable
-var my_variable = 0)";
-		const String pre_formatted = R"(# A Docstring for the variable
+		const String code =
+				GDSCRIPT(R"(
+# A Docstring for the variable
 var my_variable = 0
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+# A Docstring for the variable
+var my_variable = 0
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment next to it") {
-		const String code = R"(var my_variable = 0 # With an explanatory text)";
-		const String pre_formatted = R"(var my_variable = 0 # With an explanatory text
-)";
+		const String code =
+				GDSCRIPT(R"(
+var my_variable = 0 # With an explanatory text
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable = 0 # With an explanatory text
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a wrapped variable with a comment next to it") {
-		const String code = R"(var my_variable = some_conditional_value() + "A fairly long string, to cause a wrap" # With an explanatory text)";
-		const String pre_formatted = R"(var my_variable = (
+		const String code =
+				GDSCRIPT(R"(
+var my_variable = some_conditional_value() + "A fairly long string, to cause a wrap" # With an explanatory text
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable = (
 	some_conditional_value()
 	+ "A fairly long string, to cause a wrap" # With an explanatory text
 )
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment above it after a variable with a comment next to it") {
-		const String code = R"(var my_variable = 0 # My first variable
-# My Second variable
-var my_other_variable = 0)";
-		const String pre_formatted = R"(var my_variable = 0 # My first variable
+		const String code =
+				GDSCRIPT(R"(
+var my_variable = 0 # My first variable
 # My Second variable
 var my_other_variable = 0
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable = 0 # My first variable
+# My Second variable
+var my_other_variable = 0
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a wrapped variable with a comment on a binary operator element inside of it") {
-		const String code = R"(var my_variable = (
-	0 # My first variable
-	+ 1
-))";
-		const String pre_formatted = R"(var my_variable = (
+		const String code =
+				GDSCRIPT(R"(
+var my_variable = (
 	0 # My first variable
 	+ 1
 )
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable = (
+	0 # My first variable
+	+ 1
+)
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a function calculating the triangle area from 3 Vector3's") {
-		const String code = R"(func    triangle_area(p1    :Vector3  , p2:Vector3,p3   :  Vector3):
+		const String code =
+				GDSCRIPT(R"(
+func    triangle_area(p1    :Vector3  , p2:Vector3,p3   :  Vector3):
 
-	return (p2 - p1).cross( p3 - p1 ).length() / 2.0)";
-		const String pre_formatted = R"(func triangle_area(p1: Vector3, p2: Vector3, p3: Vector3):
+	return (p2 - p1).cross( p3 - p1 ).length() / 2.0
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func triangle_area(p1: Vector3, p2: Vector3, p3: Vector3):
 	return (p2 - p1).cross(p3 - p1).length() / 2.0
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a function call with a comment on one of its parameters") {
-		const String code = R"(@onready var my_variable := some_function_call(
+		const String code =
+				GDSCRIPT(R"(
+@onready var my_variable := some_function_call(
 	0 #with that parameter
-))";
-		const String pre_formatted = R"(@onready
+)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+@onready
 var my_variable := some_function_call(
 	0 # with that parameter
 )
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a function call with a comment on one of its non-literal parameters") {
-		const String code = R"(@onready var my_variable := some_function_call(
+		const String code =
+				GDSCRIPT(R"(
+@onready var my_variable := some_function_call(
 	SOME_CONST #with that parameter
-))";
-		const String pre_formatted = R"(@onready
+)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+@onready
 var my_variable := some_function_call(
 	SOME_CONST # with that parameter
 )
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a function call with a comment on a nested call's parameters") {
-		const String code = R"(@onready var my_variable := some_function_call(
+		const String code =
+				GDSCRIPT(R"(
+@onready var my_variable := some_function_call(
 	some_nested_call(
 		0 #with that parameter
 	)
-))";
-		const String pre_formatted = R"(@onready
+)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+@onready
 var my_variable := some_function_call(
 	some_nested_call(
 		0 # with that parameter
 	)
 )
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a constant with a comment above it") {
-		const String code = R"(# A Docstring for the constant
-const MY_VARIABLE := 0)";
-		const String pre_formatted = R"(# A Docstring for the constant
+		const String code =
+				GDSCRIPT(R"(
+# A Docstring for the constant
 const MY_VARIABLE := 0
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+# A Docstring for the constant
+const MY_VARIABLE := 0
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a constant with a comment next to it") {
-		const String code = R"(const MY_VARIABLE := 0 # A comment for the constant)";
-		const String pre_formatted = R"(const MY_VARIABLE := 0 # A comment for the constant
-)";
+		const String code =
+				GDSCRIPT(R"(
+const MY_VARIABLE := 0 # A comment for the constant
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+const MY_VARIABLE := 0 # A comment for the constant
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a constant with a comment next to one of its binary operator elements") {
-		const String code = R"(const MY_VARIABLE := (
-	0 # A comment for the literal
-	+ 3
-))";
-		const String pre_formatted = R"(const MY_VARIABLE := (
+		const String code =
+				GDSCRIPT(R"(
+const MY_VARIABLE := (
 	0 # A comment for the literal
 	+ 3
 )
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+const MY_VARIABLE := (
+	0 # A comment for the literal
+	+ 3
+)
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a constant with a comment next to one of its nested binary operator elements") {
-		const String code = R"(const MY_VARIABLE := (
-	0
-	+ 4 # A comment for the literal
-	+ 3
-	+ 8
-))";
-		const String pre_formatted = R"(const MY_VARIABLE := (
+		const String code =
+				GDSCRIPT(R"(
+const MY_VARIABLE := (
 	0
 	+ 4 # A comment for the literal
 	+ 3
 	+ 8
 )
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+const MY_VARIABLE := (
+	0
+	+ 4 # A comment for the literal
+	+ 3
+	+ 8
+)
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment next to a function call parameter") {
-		const String code = R"(var my_variable := my_call(
-	0,
-	1 # The comment is here
-))";
-		const String pre_formatted = R"(var my_variable := my_call(
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := my_call(
 	0,
 	1 # The comment is here
 )
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := my_call(
+	0,
+	1 # The comment is here
+)
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment next to a nested function call parameter") {
-		const String code = R"(var my_variable := my_call(
-	0,
-	my_other_call(
-		0,
-		1 # The comment is here
-	)
-))";
-		const String pre_formatted = R"(var my_variable := my_call(
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := my_call(
 	0,
 	my_other_call(
 		0,
 		1 # The comment is here
 	)
 )
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := my_call(
+	0,
+	my_other_call(
+		0,
+		1 # The comment is here
+	)
+)
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment next to an element in an array") {
-		const String code = R"(var my_variable := [
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := [
 	0,
 	1 # The comment is here
-])";
-		const String pre_formatted = R"(var my_variable := [
+]
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := [
 	0,
 	1, # The comment is here
 ]
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment next to an element in a dictionary") {
-		const String code = R"(var my_variable := {
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := {
 	"name": "Elizabeth",
 	"job": "Investigator" # The comment is here
-})";
-		const String pre_formatted = R"(var my_variable := {
+}
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := {
 	"name": "Elizabeth",
 	"job": "Investigator", # The comment is here
 }
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment next to an element value in a dictionary") {
-		const String code = R"(var my_variable := {
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := {
 	"name": "Elizabeth",
 	"job": (
 		"Investigator"
 	) # The comment is here
-})";
-		const String pre_formatted = R"(var my_variable := {
+}
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := {
 	"name": "Elizabeth",
 	"job": "Investigator", # The comment is here
 }
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment above an element key in a dictionary") {
-		const String code = R"(var my_variable := {
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := {
 	"name": "Elizabeth",
 	# The comment is here
 	"job": "Investigator"
-})";
-		const String pre_formatted = R"(var my_variable := {
+}
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := {
 	"name": "Elizabeth",
 	# The comment is here
 	"job": "Investigator",
 }
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment above an element value in a dictionary") {
-		const String code = R"(var my_variable := {
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := {
 	"name": "Elizabeth",
 	"job": (
 		# The comment is here
 		"Investigator"
 	)
-})";
-		const String pre_formatted = R"(var my_variable := {
+}
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := {
 	"name": "Elizabeth",
 	# The comment is here
 	"job": "Investigator",
 }
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment next to an element key and value in a dictionary") {
-		const String code = R"(var my_variable := {
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := {
 	"name": "Elizabeth",
 	"job": ( # There is a comment here
 		"Investigator"
 	) # And a comment here
-})";
-		const String pre_formatted = R"(var my_variable := {
+}
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := {
 	"name": "Elizabeth",
 	# There is a comment here
 	"job": "Investigator", # And a comment here
 }
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment next to an element in an array") {
-		const String code = R"(var my_variable := [
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := [
 	0, 1, 2, 3,
 	4, # This is the special one
 	5, 6, 7, 8
-])";
-		const String pre_formatted = R"(var my_variable := [
+]
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := [
 	0,
 	1,
 	2,
@@ -2052,19 +2734,24 @@ const MY_VARIABLE := 0
 	7,
 	8,
 ]
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment above an element in an array") {
-		const String code = R"(var my_variable := [
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := [
 	0, 1, 2, 3,
 	# This is the special one
 	4,
 	5, 6, 7, 8
-])";
-		const String pre_formatted = R"(var my_variable := [
+]
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := [
 	0,
 	1,
 	2,
@@ -2076,19 +2763,24 @@ const MY_VARIABLE := 0
 	7,
 	8,
 ]
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment next to an element in a nested array") {
-		const String code = R"(var my_variable := [
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := [
 	0, 1, 2, [
 		0, 1, 2, # The comment can go here
 		3
 	], 4, 5, 6, 7, 8, 9
-])";
-		const String pre_formatted = R"(var my_variable := [
+]
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := [
 	0,
 	1,
 	2,
@@ -2105,17 +2797,22 @@ const MY_VARIABLE := 0
 	8,
 	9,
 ]
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment next to an element in a double nested array") {
-		const String code = R"(var my_variable := [0,1,2,[0,1,[
+		const String code =
+				GDSCRIPT(R"(
+var my_variable := [0,1,2,[0,1,[
 	0,1, # The comment can go here
 	2
-],3],4,5,6,7,8,9])";
-		const String pre_formatted = R"(var my_variable := [
+],3],4,5,6,7,8,9]
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_variable := [
 	0,
 	1,
 	2,
@@ -2136,292 +2833,344 @@ const MY_VARIABLE := 0
 	8,
 	9,
 ]
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment next to a cast statement") {
-		const String code = R"(@onready var my_variable := (
+		const String code =
+				GDSCRIPT(R"(
+@onready var my_variable := (
 	$Player as CharacterBody2D # The comment
-))";
-		const String pre_formatted = R"(@onready var my_variable := $Player as CharacterBody2D # The comment
-)";
+)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+@onready var my_variable := $Player as CharacterBody2D # The comment
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment next to an identifier") {
-		const String code = R"(@onready var my_variable := (
+		const String code =
+				GDSCRIPT(R"(
+@onready var my_variable := (
 	MY_CONST # The comment
-))";
-		const String pre_formatted = R"(@onready var my_variable := MY_CONST # The comment
-)";
+)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+@onready var my_variable := MY_CONST # The comment
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment next to a get node") {
-		const String code = R"(@onready var my_variable := (
+		const String code =
+				GDSCRIPT(R"(
+@onready var my_variable := (
 	$Player/Sprite2D # The comment
-))";
-		const String pre_formatted = R"(@onready var my_variable := $Player/Sprite2D # The comment
-)";
+)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+@onready var my_variable := $Player/Sprite2D # The comment
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment next to a preload value") {
-		const String code = R"(@onready var my_variable := preload(
-	"res://Player/PlayerSprite.png" # The comment
-))";
-		const String pre_formatted = R"(@onready var my_variable := preload(
+		const String code =
+				GDSCRIPT(R"(
+@onready var my_variable := preload(
 	"res://Player/PlayerSprite.png" # The comment
 )
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment next to a subscript index") {
-		const String code = R"(@onready var my_variable := MY_CONST_ARRAY[
+		const String code =
+				GDSCRIPT(R"(
+@onready var my_variable := MY_CONST_ARRAY[
 	0 # The comment
-])";
-		const String pre_formatted = R"(@onready
+]
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+@onready
 var my_variable := MY_CONST_ARRAY[
 	0 # The comment
 ]
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment as part of a ternary operator") {
-		const String code = R"(@onready var my_variable := (
+		const String code =
+				GDSCRIPT(R"(
+@onready var my_variable := (
 	50 if SOME_DEVELOPMENT_CONST # is enabled
 	else 75
-))";
-		const String pre_formatted = R"(@onready
+)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+@onready
 var my_variable := (
 	50 if SOME_DEVELOPMENT_CONST # is enabled
 	else 75
 )
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a variable with a comment as part of a ternary operator on the false") {
-		const String code = R"(@onready var my_variable := (
+		const String code =
+				GDSCRIPT(R"(
+@onready var my_variable := (
 	50 if SOME_DEVELOPMENT_CONST
 	else 75 # is 75
-))";
-		const String pre_formatted = R"(@onready
+)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+@onready
 var my_variable := (
 	50 if SOME_DEVELOPMENT_CONST
 	else 75 # is 75
 )
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output an assignment with a comment above it") {
-		const String code = R"(func _ready() -> void:
-	# A comment!
-	some_value = 30)";
-		const String pre_formatted = R"(func _ready() -> void:
+		const String code =
+				GDSCRIPT(R"(
+func _ready() -> void:
 	# A comment!
 	some_value = 30
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output an assignment with a comment next to it") {
-		const String code = R"(func _ready() -> void:
-	some_value = 30 # A comment!)";
-		const String pre_formatted = R"(func _ready() -> void:
+		const String code =
+				GDSCRIPT(R"(
+func _ready() -> void:
 	some_value = 30 # A comment!
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output an assignment with a comment next to its literal value") {
-		const String code = R"(func _ready() -> void:
+		const String code =
+				GDSCRIPT(R"(
+func _ready() -> void:
 	some_value = (
 		30 # A comment!
-))";
-		const String pre_formatted = R"(func _ready() -> void:
+)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready() -> void:
 	some_value = 30 # A comment!
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output an assignment with a comment next to its identifier value") {
-		const String code = R"(func _ready() -> void:
+		const String code =
+				GDSCRIPT(R"(
+func _ready() -> void:
 	some_value = (
 		some_other # A comment!
-))";
-		const String pre_formatted = R"(func _ready() -> void:
+)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready() -> void:
 	some_value = some_other # A comment!
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output an await with a comment") {
-		const String code = R"(func _ready() -> void:
-	await get_tree().process_frame # A comment goes here)";
-		const String pre_formatted = R"(func _ready() -> void:
+		const String code =
+				GDSCRIPT(R"(
+func _ready() -> void:
 	await get_tree().process_frame # A comment goes here
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a get node statement with a comment") {
-		const String code = R"(@onready var some_var := (
+		const String code =
+				GDSCRIPT(R"(
+@onready var some_var := (
 	$Path/To/Node # Comment here
-))";
-		const String pre_formatted = R"(@onready var some_var := $Path/To/Node # Comment here
-)";
+)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+@onready var some_var := $Path/To/Node # Comment here
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a function with a comment above it") {
-		const String code = R"(# Comment above
-func _ready() -> void:
-	pass)";
-		const String pre_formatted = R"(# Comment above
+		const String code =
+				GDSCRIPT(R"(
+# Comment above
 func _ready() -> void:
 	pass
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a function with two comments above it") {
-		const String code = R"(# Comment 1
-# Comment 2
-func _ready() -> void:
-	pass)";
-		const String pre_formatted = R"(# Comment 1
+		const String code =
+				GDSCRIPT(R"(
+# Comment 1
 # Comment 2
 func _ready() -> void:
 	pass
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a function with a comment next to it") {
-		const String code = R"(func _ready() -> void: # Comment next
-	pass)";
-		const String pre_formatted = R"(func _ready() -> void: # Comment next
+		const String code =
+				GDSCRIPT(R"(
+func _ready() -> void: # Comment next
 	pass
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a function with a comment next to a parameter") {
-		const String code = R"(func a_custom_function(
-	a_parameter # with a comment
-) -> void:
-	pass)";
-		const String pre_formatted = R"(func a_custom_function(
+		const String code =
+				GDSCRIPT(R"(
+func a_custom_function(
 	a_parameter # with a comment
 ) -> void:
 	pass
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a function with a comment next to one parameter") {
-		const String code = R"(func a_custom_function(
-	a_parameter, # with a comment
-	another_parameter
-) -> void:
-	pass)";
-		const String pre_formatted = R"(func a_custom_function(
+		const String code =
+				GDSCRIPT(R"(
+func a_custom_function(
 	a_parameter, # with a comment
 	another_parameter
 ) -> void:
 	pass
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a class with a comment above and next to it") {
-		const String code = R"(# The comment above
-class MyClass: # The comment next
-	pass)";
-		const String pre_formatted = R"(# The comment above
+		const String code =
+				GDSCRIPT(R"(
+# The comment above
 class MyClass: # The comment next
 	pass
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a signal with a comment inside its parameters") {
-		const String code = R"(# The comment above
+		const String code =
+				GDSCRIPT(R"(
+# The comment above
 signal some_signal(with,
 	some, # And a comment here
 	params
-))";
-		const String pre_formatted = R"(# The comment above
+)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+# The comment above
 signal some_signal(
 	with,
 	some, # And a comment here
 	params
 )
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a function return with comments") {
-		const String code = R"(func _ready() -> void:
-	# return header
-	return # end early)";
-		const String pre_formatted = R"(func _ready() -> void:
+		const String code =
+				GDSCRIPT(R"(
+func _ready() -> void:
 	# return header
 	return # end early
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output an assert with comments") {
-		const String code = R"(func _ready() -> void:
-	assert(some_complex_condition(
-		"that", # comment!
-		"breaks"
-	), "And a message") # And a comment)";
-		const String pre_formatted = R"(func _ready() -> void:
+		const String code =
+				GDSCRIPT(R"(
+func _ready() -> void:
 	assert(some_complex_condition(
 		"that", # comment!
 		"breaks"
 	), "And a message") # And a comment
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output an unnamed enum with comments") {
-		const String code = R"(# Enum header
+		const String code =
+				GDSCRIPT(R"(
+# Enum header
 enum { VALUE_1, VALUE_2 = 3, VALUE_3,
 # Value header
 VALUE_4, # value inline
-} # enum inline)";
-		const String pre_formatted = R"(# Enum header
+} # enum inline
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+# Enum header
 enum {
 	VALUE_1,
 	VALUE_2 = 3,
@@ -2429,13 +3178,15 @@ enum {
 	# Value header
 	VALUE_4, # value inline
 } # enum inline
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should out a match statement with comments") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	# Match header
 	match some_value: # Match inline
 		# Value header
@@ -2444,24 +3195,17 @@ enum {
 		1:
 			pass
 		2:
-			pass)";
-		const String pre_formatted = R"(func _ready():
-	# Match header
-	match some_value: # Match inline
-		# Value header
-		0: # Value inline
 			pass
-		1:
-			pass
-		2:
-			pass
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output if blocks with comments") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	# If header
 	if my_condition: # if inline
 		pass
@@ -2470,112 +3214,93 @@ enum {
 		pass
 	# else header
 	else: # else inline
-		pass)";
-		const String pre_formatted = R"(func _ready():
-	# If header
-	if my_condition: # if inline
 		pass
-	# elif header
-	elif my_other_condition: # elif inline
-		pass
-	# else header
-	else: # else inline
-		pass
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a for loop with comments") {
-		const String code = R"(func _ready():
-	# For header
-	for i in my_condition: # For inline
-		pass)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	# For header
 	for i in my_condition: # For inline
 		pass
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a while loop with comments") {
-		const String code = R"(func _ready():
-	# While header
-	while my_condition: # While inline
-		pass)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	# While header
 	while my_condition: # While inline
 		pass
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a break statement with comments") {
-		const String code = R"(func _ready():
-	for i in my_condition:
-		# Break header
-		break # break inline)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	for i in my_condition:
 		# Break header
 		break # break inline
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a continue statement with comments") {
-		const String code = R"(func _ready():
-	for i in my_condition:
-		# Continue header
-		continue # Continue inline)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	for i in my_condition:
 		# Continue header
 		continue # Continue inline
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a pass statement with comments") {
-		const String code = R"(func _ready():
-	# Pass header
-	pass # Pass inline)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	# Pass header
 	pass # Pass inline
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a breakpoint statement with comments") {
-		const String code = R"(func _ready():
-	# Breakpoint header
-	breakpoint # Breakpoint inline)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	# Breakpoint header
 	breakpoint # Breakpoint inline
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a prop with comments") {
-		const String code = R"(# prop header
-var my_property: # prop inline
-	# setter header
-	set(value): # setter inline
-		my_property = value
-	# getter header
-	get: # getter inline
-		return my_property)";
-		const String pre_formatted = R"(# prop header
+		const String code =
+				GDSCRIPT(R"(
+# prop header
 var my_property: # prop inline
 	# setter header
 	set(value): # setter inline
@@ -2583,321 +3308,380 @@ var my_property: # prop inline
 	# getter header
 	get: # getter inline
 		return my_property
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a function with a footer comment") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	pass
 
 	# Comment at the bottom
 
 func _other_function():
-	pass)";
-		const String pre_formatted = "func _ready():\n\tpass\n\n\t# Comment at the bottom\n\n\nfunc _other_function():\n\tpass\n";
+	pass
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
+	pass
+
+	# Comment at the bottom
+<*noop*>
+<*noop*>
+func _other_function():
+	pass
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output a class with a footer comment") {
-		const String code = R"(extends Node
+		const String code =
+				GDSCRIPT(R"(
+extends Node
 
 class SubClass:
 	extends Resource
 
 	# Footer comment
 
-# Footer comment)";
-		const String pre_formatted = "extends Node\n\n\nclass SubClass:\n\textends Resource\n\n\t# Footer comment\n\n# Footer comment\n";
+# Footer comment
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+extends Node
+<*noop*>
+<*noop*>
+class SubClass:
+	extends Resource
+
+	# Footer comment
+
+# Footer comment
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output docstrings on classes and functions") {
-		const String code = R"(## A class that has a specific documented job
+		const String code =
+				GDSCRIPT(R"(
+## A class that has a specific documented job
 class_name MyClass
 extends RefCounted
 
 ## Returns a value
 func some_public_api_func() -> int:
-	return 0)";
-		const String pre_formatted = "## A class that has a specific documented job\nclass_name MyClass\nextends RefCounted\n\n\n## Returns a value\nfunc some_public_api_func() -> int:\n\treturn 0\n";
+	return 0
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+## A class that has a specific documented job
+class_name MyClass
+extends RefCounted
+<*noop*>
+<*noop*>
+## Returns a value
+func some_public_api_func() -> int:
+	return 0
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output indexed calls with comments") {
-		const String code = R"(func _ready():
-	# Header
-	sd.call_one() # Inline)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	# Header
 	sd.call_one() # Inline
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
+	# Header
+	sd.call_one() # Inline
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should not cause errors with disabled lines") {
-		const String code = R"(func _ready() -> void:
-#	print("disabled code")
-	print("enabled code"))";
-		const String pre_formatted = R"(func _ready() -> void:
+		const String code =
+				GDSCRIPT(R"(
+func _ready() -> void:
 #	print("disabled code")
 	print("enabled code")
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready() -> void:
+#	print("disabled code")
+	print("enabled code")
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should not cause errors with disabled lines in class") {
-		const String code = R"(class SomeClass:
-#	var a_disabled_var
-	var an_enabled_var)";
-		const String pre_formatted = R"(class SomeClass:
+		const String code =
+				GDSCRIPT(R"(
+class SomeClass:
 #	var a_disabled_var
 	var an_enabled_var
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+class SomeClass:
+#	var a_disabled_var
+	var an_enabled_var
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should not cause errors with disabled lines in property") {
-		const String code = R"(var some_var:
-#	get: disabled line
-	get:
-		return some_var)";
-		const String pre_formatted = R"(var some_var:
+		const String code =
+				GDSCRIPT(R"(
+var some_var:
 #	get: disabled line
 	get:
 		return some_var
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var some_var:
+#	get: disabled line
+	get:
+		return some_var
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should not cause errors with disabled lines in both properties") {
-		const String code = R"(var some_var:
+		const String code =
+				GDSCRIPT(R"(
+var some_var:
 #	get: disabled line
 	get:
 		return some_var
 #	set(v):
 	set(v):
-		some_var = v)";
-		const String pre_formatted = R"(var some_var:
+		some_var = v
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var some_var:
 #	set(v):
 	set(v):
 		some_var = v
 #	get: disabled line
 	get:
 		return some_var
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should not crash on empty array with inline comment over no element") {
-		const String code = R"(var array = [ # Comment
-])";
-		const String pre_formatted = R"(var array = [
+		const String code =
+				GDSCRIPT(R"(
+var array = [ # Comment
+]
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var array = [
 	# Comment
 ]
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should not crash on empty dict with inline comment over no element") {
-		const String code = R"(var dict = { # Comment
-})";
-		const String pre_formatted = R"(var dict = {
+		const String code =
+				GDSCRIPT(R"(
+var dict = { # Comment
+}
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var dict = {
 	# Comment
 }
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should not crash on empty parameter with inline comment over no element") {
-		const String code = R"(func some_func( # Comment
+		const String code =
+				GDSCRIPT(R"(
+func some_func( # Comment
 ):
-	pass)";
-		const String pre_formatted = R"(func some_func(
+	pass
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func some_func(
 	# Comment
 ):
 	pass
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should not crash on empty call with inline comment over no element") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	some_func( # Comment
-	))";
-		const String pre_formatted = R"(func _ready():
+	)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	some_func(
 		# Comment
 	)
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should not error out on a disabled statement in a if block") {
-		const String code = R"(func _ready():
-	if true:
-#		comment
-		print("hi"))";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	if true:
 #		comment
 		print("hi")
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should not error out on a disabled statement in a parameter block") {
-		const String code = R"(func _ready():
-	print(
-#		"50"
-		"30"
-	))";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	print(
 #		"50"
 		"30"
 	)
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should not error out on a footer in an array with only one element") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	var array = ["string"
 		# Comment
-	])";
-		const String pre_formatted = R"(func _ready():
+	]
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	var array = [
 		"string",
 		# Comment
 	]
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should not error out on a footer in a dictionary with only one element") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	var dictionary = {"string": "string"
 		# Comment
-	})";
-		const String pre_formatted = R"(func _ready():
+	}
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	var dictionary = {
 		"string": "string",
 		# Comment
 	}
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should not error out on a footer in a call with only one parameter") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	call("string"
 		# Comment
-	))";
-		const String pre_formatted = R"(func _ready():
+	)
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	call(
 		"string"
 		# Comment
 	)
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should continue parsing a suite after a dedented comment") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	if true:
 		pass
 #	comment
-	pass)";
-		const String pre_formatted = R"(func _ready():
+	pass
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	if true:
 		pass
 
 #	comment
 	pass
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should output comments above an onready variable") {
-		const String code = R"(## I am a comment describing var hi
-@onready var hi)";
-		const String pre_formatted = R"(## I am a comment describing var hi
+		const String code =
+				GDSCRIPT(R"(
+## I am a comment describing var hi
 @onready var hi
-)";
+)");
+		const String pre_formatted = code;
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("A full commented function should output correctly") {
 		// Code by clayjohn at https://github.com/godotengine/godot-docs/issues/4834
-		const String code = R"(func _ready():
-	# We will be using our own RenderingDevice to handle the compute commands
-	var rd = RenderingServer.create_local_rendering_device()
-
-	# Create shader and pipeline
-	var shader_file = load("res://compute_example.glsl")
-	var shader_bytecode = shader_file.get_bytecode()
-	var shader = rd.shader_create(shader_bytecode)
-	var pipeline = rd.compute_pipeline_create(shader)
-
-	# Data for compute shaders has to come as an array of bytes
-	var pba = PackedByteArray()
-	pba.resize(64)
-	for i in range(16):
-		pba.encode_float(i * 4, 2.0)
-
-	# Create storage buffer
-	# Data not needed, can just create with length
-	var storage_buffer = rd.storage_buffer_create(64, pba)
-
-	# Create uniform set using the storage buffer
-	var u = RDUniform.new()
-	u.uniform_type = RenderingDevice.UNIFORM_TYPE_STORAGE_BUFFER
-	u.binding = 0
-	u.add_id(storage_buffer)
-	var uniform_set = rd.uniform_set_create([u], shader, 0)
-
-	# Start compute list to start recording our compute commands
-	var compute_list = rd.compute_list_begin()
-	# Bind the pipeline, this tells the GPU what shader to use
-	rd.compute_list_bind_compute_pipeline(compute_list, pipeline)
-	# Binds the uniform set with the data we want to give our shader
-	rd.compute_list_bind_uniform_set(compute_list, uniform_set, 0)
-	# Dispatch 1x1x1 (XxYxZ) work groups
-	rd.compute_list_dispatch(compute_list, 2, 1, 1)
-	# rd.compute_list_add_barrier(compute_list)
-	# Tell the GPU we are done with this compute task
-	rd.compute_list_end()
-	# Force the GPU to start our commands
-	rd.submit()
-	# Force the CPU to wait for the GPU to finish with the recorded commands
-	rd.sync()
-
-	# Now we can grab our data from the storage buffer
-	var byte_data = rd.buffer_get_data(storage_buffer)
-	for i in range(16):
-		print(byte_data.decode_float(i * 4)))";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	# We will be using our own RenderingDevice to handle the compute commands
 	var rd = RenderingServer.create_local_rendering_device()
 
@@ -2944,122 +3728,201 @@ func some_public_api_func() -> int:
 	var byte_data = rd.buffer_get_data(storage_buffer)
 	for i in range(16):
 		print(byte_data.decode_float(i * 4))
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
+	# We will be using our own RenderingDevice to handle the compute commands
+	var rd = RenderingServer.create_local_rendering_device()
+
+	# Create shader and pipeline
+	var shader_file = load("res://compute_example.glsl")
+	var shader_bytecode = shader_file.get_bytecode()
+	var shader = rd.shader_create(shader_bytecode)
+	var pipeline = rd.compute_pipeline_create(shader)
+
+	# Data for compute shaders has to come as an array of bytes
+	var pba = PackedByteArray()
+	pba.resize(64)
+	for i in range(16):
+		pba.encode_float(i * 4, 2.0)
+
+	# Create storage buffer
+	# Data not needed, can just create with length
+	var storage_buffer = rd.storage_buffer_create(64, pba)
+
+	# Create uniform set using the storage buffer
+	var u = RDUniform.new()
+	u.uniform_type = RenderingDevice.UNIFORM_TYPE_STORAGE_BUFFER
+	u.binding = 0
+	u.add_id(storage_buffer)
+	var uniform_set = rd.uniform_set_create([u], shader, 0)
+
+	# Start compute list to start recording our compute commands
+	var compute_list = rd.compute_list_begin()
+	# Bind the pipeline, this tells the GPU what shader to use
+	rd.compute_list_bind_compute_pipeline(compute_list, pipeline)
+	# Binds the uniform set with the data we want to give our shader
+	rd.compute_list_bind_uniform_set(compute_list, uniform_set, 0)
+	# Dispatch 1x1x1 (XxYxZ) work groups
+	rd.compute_list_dispatch(compute_list, 2, 1, 1)
+	# rd.compute_list_add_barrier(compute_list)
+	# Tell the GPU we are done with this compute task
+	rd.compute_list_end()
+	# Force the GPU to start our commands
+	rd.submit()
+	# Force the CPU to wait for the GPU to finish with the recorded commands
+	rd.sync()
+
+	# Now we can grab our data from the storage buffer
+	var byte_data = rd.buffer_get_data(storage_buffer)
+	for i in range(16):
+		print(byte_data.decode_float(i * 4))
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should not error out on a disabled line between an if and its else") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	if true:
 		pass
 #		Comment
 	else:
-		pass)";
-		const String pre_formatted = R"(func _ready():
+		pass
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	if true:
 		pass
 #		Comment
 	else:
 		pass
-)";
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should not error out on a disabled line in the middle of a suite") {
-		const String code = R"(func _ready():
-	if true:
-		pass
-#		Comment
-		pass
-	pass)";
-		const String pre_formatted = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	if true:
 		pass
 #		Comment
 		pass
 	pass
-)";
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
+	if true:
+		pass
+#		Comment
+		pass
+	pass
+)");
 
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should not have an extra line after an array footer with a long first member") {
-		const String code = R"(var my_array = [
+		const String code =
+				GDSCRIPT(R"(
+var my_array = [
 	"there is a bug with an extra newline at the end of arrays but only when the contents have long lines",
 	# Comment
 
-])";
-		const String pre_formatted = R"(var my_array = [
+]
+)");
+		const String pre_formatted =
+				GDSCRIPT(R"(
+var my_array = [
 	"there is a bug with an extra newline at the end of arrays but only when the contents have long lines",
 	# Comment
 ]
-)";
+)");
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Should accept a comment in the last statement of a function when accessing an array") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	var v := Vector2()
 	var a = v[0]  # A
 
 	func another():
 	pass
-)";
+)");
 
-		const String pre_formatted = R"(func _ready():
+		const String pre_formatted =
+				GDSCRIPT(R"(
+func _ready():
 	var v := Vector2()
 	var a = v[0]  # A
 
 func another():
 	pass
-)";
+)");
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Comments on top of static functions should stay") {
-		const String code = R"(## This comment should stay after format
+		const String code =
+				GDSCRIPT(R"(
+## This comment should stay after format
 static func test():
 	pass
-)";
+)");
 		const String pre_formatted = code;
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Comment at the end of a return value should stay") {
-		const String code = R"(func test_func() -> bool:
+		const String code =
+				GDSCRIPT(R"(
+func test_func() -> bool:
 	if true:
 		return true # In this case, stop.
 	return false
-)";
+)");
 		const String pre_formatted = code;
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Comments at the end of `get_node` should not multiply") {
-		const String code = R"(@onready var a_node = $ANode
+		const String code =
+				GDSCRIPT(R"(
+@onready var a_node = $ANode
 @onready var b_node = a_node.get_node(^"BNode") # Test
-)";
+)");
 		const String pre_formatted = code;
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Comments should not be considered as dictionary keys") {
-		const String code = R"(func _ready():
+		const String code =
+				GDSCRIPT(R"(
+func _ready():
 	var dict = {
 		"key1": "value1", # Comment
 		# Comment
 		"key2": "value2",
 	}
-)";
+)");
 		const String pre_formatted = code;
 		CHECK_FORMAT(code, pre_formatted);
 	}
 
 	TEST_CASE("Comments should not count as expressions") {
 		SUBCASE("Function body") {
-			const String code = R"(func _run() -> void:
+			const String code =
+					GDSCRIPT(R"(
+func _run() -> void:
 	# This should not count as an expression
 )");
 			const String pre_formatted = code;
@@ -3067,10 +3930,12 @@ static func test():
 		}
 
 		SUBCASE("Condition body") {
-			const String code = R"(func _run() -> void:
+			const String code =
+					GDSCRIPT(R"(
+func _run() -> void:
 	if true:
 		# This should not count as an expression
-)";
+)");
 			const String pre_formatted = code;
 			CHECK_FORMAT(code, pre_formatted);
 		}
@@ -3081,41 +3946,55 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 	TEST_CASE("Syntactic sugar should be preserved") {
 		SUBCASE("get_node ($)") {
 			// Should let as-is
-			String code = R"(@onready var child_node = $ChildNode
-)";
+			String code =
+					GDSCRIPT(R"(
+@onready var child_node = $ChildNode
+)");
 			String pre_formatted = code;
 			CHECK_FORMAT(code, pre_formatted);
 
 			// Should remove useless quotes
-			code = R"(@onready var child_node = $"ChildNode"
-)";
-			pre_formatted = R"(@onready var child_node = $ChildNode
-)";
+			code =
+					GDSCRIPT(R"(
+@onready var child_node = $"ChildNode"
+)");
+			pre_formatted =
+					GDSCRIPT(R"(
+@onready var child_node = $ChildNode
+)");
 			CHECK_FORMAT(code, pre_formatted);
 
 			// Should keep quotes
-			code = R"(@onready var sub_child_node = $"ChildNode/Node$/Path"
-)";
+			code =
+					GDSCRIPT(R"(
+@onready var sub_child_node = $"ChildNode/Node$/Path"
+)");
 			pre_formatted = code;
 			CHECK_FORMAT(code, pre_formatted);
 		}
 
 		SUBCASE("Unique names (%)") {
 			// Should let as-is
-			String code = R"(@onready var unique_node = %UniqueNode
-)";
+			String code =
+					GDSCRIPT(R"(
+@onready var unique_node = %UniqueNode
+)");
 			String pre_formatted = code;
 			CHECK_FORMAT(code, pre_formatted);
 
 			// Should remove useless quotes
-			code = R"(@onready var unique_node = %UniqueNodeIndeed
-)";
+			code =
+					GDSCRIPT(R"(
+@onready var unique_node = %UniqueNodeIndeed
+)");
 			pre_formatted = code;
 			CHECK_FORMAT(code, pre_formatted);
 
 			// Should keep quotes
-			code = R"(@onready var unique_node = %"UniqueNodeIndeedWith$"
-)";
+			code =
+					GDSCRIPT(R"(
+@onready var unique_node = %"UniqueNodeIndeedWith$"
+)");
 			pre_formatted = code;
 			CHECK_FORMAT(code, pre_formatted);
 		}
@@ -3123,10 +4002,12 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 
 	TEST_CASE("Parentheses should be kept") {
 		SUBCASE("Using format%") {
-			const String code = R"(func _ready():
+			const String code =
+					GDSCRIPT(R"(
+func _ready():
 	var number = 1234.567
 	var string = "%1.1f k" % (number * 0.001)
-)";
+)");
 			const String pre_formatted = code;
 			CHECK_FORMAT(code, pre_formatted);
 		}
@@ -3134,9 +4015,11 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 
 	TEST_CASE("Literals should be kept as-is") {
 		SUBCASE("Number below the float precision") {
-			const String code = R"(func _ready():
+			const String code =
+					GDSCRIPT(R"(
+func _ready():
 	var number = 0.0000000000000000000000000000000000000000000000000000000000000001
-)";
+)");
 			const String pre_formatted = code;
 			CHECK_FORMAT(code, pre_formatted);
 		}
@@ -3144,18 +4027,24 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 
 	TEST_CASE("Annotations should not be split if the line is not too long") {
 		SUBCASE("Under the line limit") {
-			const String code = R"(@export_exp_easing var very_small_var: float = 0.0
-)";
+			const String code =
+					GDSCRIPT(R"(
+@export_exp_easing var very_small_var: float = 0.0
+)");
 			const String pre_formatted = code;
 			CHECK_FORMAT(code, pre_formatted);
 		}
 
 		SUBCASE("Above the line limit") {
-			const String code = R"(@export_exp_easing var very_long_long_long_long_long_long_long_long_long_long_long_long_long_long_var: float = 0.0
-)";
-			const String pre_formatted = R"(@export_exp_easing
+			const String code =
+					GDSCRIPT(R"(
+@export_exp_easing var very_long_long_long_long_long_long_long_long_long_long_long_long_long_long_var: float = 0.0
+)");
+			const String pre_formatted =
+					GDSCRIPT(R"(
+@export_exp_easing
 var very_long_long_long_long_long_long_long_long_long_long_long_long_long_long_var: float = 0.0
-)";
+)");
 			CHECK_FORMAT(code, pre_formatted);
 		}
 	}
@@ -3210,32 +4099,44 @@ func _ready() -> void:
 	TEST_CASE("Function default values should have spaces") {
 		String code;
 		String pre_formatted;
-		
+
 		// Without typing
-		code = R"(func my_func(optional_param= null):
+		code =
+				GDSCRIPT(R"(
+func my_func(optional_param= null):
 	pass
-)";
-		pre_formatted = R"(func my_func(optional_param = null):
+)");
+		pre_formatted =
+				GDSCRIPT(R"(
+func my_func(optional_param = null):
 	pass
-)";
+)");
 		CHECK_FORMAT(code, pre_formatted);
 
 		// With explicit typing
-		code = R"(func my_func(optional_param: Node =null):
+		code =
+				GDSCRIPT(R"(
+func my_func(optional_param: Node =null):
 	pass
-)";
-		pre_formatted = R"(func my_func(optional_param: Node = null):
+)");
+		pre_formatted =
+				GDSCRIPT(R"(
+func my_func(optional_param: Node = null):
 	pass
-)";
+)");
 		CHECK_FORMAT(code, pre_formatted);
 
 		// With inferred typing
-		code = R"(func my_func(optional_param:=""):
+		code =
+				GDSCRIPT(R"(
+func my_func(optional_param:=""):
 	pass
-)";
-		pre_formatted = R"(func my_func(optional_param := ""):
+)");
+		pre_formatted =
+				GDSCRIPT(R"(
+func my_func(optional_param := ""):
 	pass
-)";
+)");
 		CHECK_FORMAT(code, pre_formatted);
 	}
 } // TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Misc]")

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -2798,16 +2798,16 @@ func some_public_api_func() -> int:
 	}
 
 	TEST_CASE("The custom newlines should be remembered") {
-		const String code = R"(extends Node2D
-
-
+		// `vformat` because "misc/scripts/header_guards.sh"
+		// don't like two consecutive new lines.
+		const String code = vformat(R"(extends Node2D
+%s
 class Light:
 	var energy
 
 var energy_slider := Range.new()
 var height_slider := Range.new()
 var light := Light.new()
-
 
 func _ready() -> void:
 	energy_slider.value_changed.connect(func(value):
@@ -2817,18 +2817,17 @@ func _ready() -> void:
 		light.height = height_slider.value)
 
 	height_slider.value_changed.connect(func(value):
-		light.height = height_slider.value))";
-		const String pre_formatted = R"(extends Node2D
-
-
+		light.height = height_slider.value))",
+				"\n");
+		const String pre_formatted = vformat(R"(extends Node2D
+%s
 class Light:
 	var energy
 
 var energy_slider := Range.new()
 var height_slider := Range.new()
 var light := Light.new()
-
-
+%s
 func _ready() -> void:
 	energy_slider.value_changed.connect(func(value):
 		light.energy = energy_slider.value)
@@ -2838,7 +2837,8 @@ func _ready() -> void:
 
 	height_slider.value_changed.connect(func(value):
 		light.height = height_slider.value)
-)";
+)",
+				"\n", "\n");
 		CHECK_FORMAT(code, pre_formatted);
 	}
 

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -3657,6 +3657,7 @@ func _ready():
 func _ready():
 	if true:
 		pass
+
 #	comment
 	pass
 )");
@@ -3958,6 +3959,20 @@ func _ready():
 	var some_node
 	# This bug only happens when the comment on the previous line exceeds 80 chars.
 	some_node.visible = 5 > 3
+)");
+		const String pre_formatted = code;
+
+		CHECK_FORMAT(code, pre_formatted);
+	}
+
+	TEST_CASE("Comments after an indented block should not be forcefully moved over") {
+		const String code = GDSCRIPT(R"(
+func _ready():
+	if true:
+		pass
+
+	# Description of A
+	var a
 )");
 		const String pre_formatted = code;
 

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -63,8 +63,8 @@ namespace GDScriptTests {
 						error_messages.size(),                                               \
 						String("\n").join(error_messages)));                                 \
 		CHECK_EQ(                                                                            \
-				vformat(CHECK_FORMAT_FORMAT, output),                                        \
-				vformat(CHECK_FORMAT_FORMAT, pre_formatted));                                \
+				vformat(CHECK_FORMAT_FORMAT, pre_formatted),                                 \
+				vformat(CHECK_FORMAT_FORMAT, output));                                       \
 	} while (false);
 #define CHECK_FORMAT_FORMAT "\n---\n%s\n---\n"
 

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -1780,10 +1780,8 @@ class MyInnerClass:
 class MyInnerClass:
 	var hi
 
-
 	func my_inner_class_function() -> void:
 		pass
-
 
 	func another_one() -> void:
 		pass
@@ -3853,7 +3851,6 @@ var my_array = [
 func _ready():
 	var v = [0]
 	var a = v[0] # A
-
 
 func another():
 	pass

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -1662,7 +1662,12 @@ func _ready():
 func _ready():
 	var arr = []
 	arr.append_array([
-		"long string 1", "long string 2", "long string 3", "long string 4", "long string 5", "long string 6"
+		"long string 1",
+		"long string 2",
+		"long string 3",
+		"long string 4",
+		"long string 5",
+		"long string 6",
 	])
 )");
 
@@ -1779,10 +1784,12 @@ class MyInnerClass:
 				GDSCRIPT(R"(
 class MyInnerClass:
 	var hi
-
+<*noop*>
+<*noop*>
 	func my_inner_class_function() -> void:
 		pass
-
+<*noop*>
+<*noop*>
 	func another_one() -> void:
 		pass
 )");
@@ -2857,7 +2864,7 @@ func _ready():
 )");
 		const String pre_formatted =
 				GDSCRIPT(R"(
-@onready var my_variable := MY_CONST # The comment
+@onready var my_variable := (MY_CONST) # The comment
 )");
 
 		CHECK_FORMAT(code, pre_formatted);
@@ -2872,7 +2879,7 @@ func _ready():
 )");
 		const String pre_formatted =
 				GDSCRIPT(R"(
-@onready var my_variable := $Player/Sprite2D # The comment
+@onready var my_variable := ($Player/Sprite2D) # The comment
 )");
 
 		CHECK_FORMAT(code, pre_formatted);

--- a/modules/gdscript/tests/test_gdscript_formatter.h
+++ b/modules/gdscript/tests/test_gdscript_formatter.h
@@ -4016,7 +4016,7 @@ static func generate_guid() -> String:
 TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 	TEST_CASE("Syntactic sugar should be preserved") {
 		SUBCASE("get_node ($)") {
-			// Should let as-is
+			// Should let as-is.
 			String code =
 					GDSCRIPT(R"(
 @onready var child_node = $ChildNode
@@ -4025,7 +4025,7 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 
 			CHECK_FORMAT(code, pre_formatted);
 
-			// Should remove useless quotes
+			// Should remove useless quotes.
 			code =
 					GDSCRIPT(R"(
 @onready var child_node = $"ChildNode"
@@ -4037,7 +4037,7 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 
 			CHECK_FORMAT(code, pre_formatted);
 
-			// Should keep quotes
+			// Should keep quotes.
 			code =
 					GDSCRIPT(R"(
 @onready var sub_child_node = $"ChildNode/Node$/Path"
@@ -4048,7 +4048,7 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 		}
 
 		SUBCASE("Unique names (%)") {
-			// Should let as-is
+			// Should let as-is.
 			String code =
 					GDSCRIPT(R"(
 @onready var unique_node = %UniqueNode
@@ -4057,7 +4057,7 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 
 			CHECK_FORMAT(code, pre_formatted);
 
-			// Should remove useless quotes
+			// Should remove useless quotes.
 			code =
 					GDSCRIPT(R"(
 @onready var unique_node = %UniqueNodeIndeed
@@ -4066,7 +4066,7 @@ TEST_SUITE("[Modules][GDScript][GDScriptFormatter][Syntax]") {
 
 			CHECK_FORMAT(code, pre_formatted);
 
-			// Should keep quotes
+			// Should keep quotes.
 			code =
 					GDSCRIPT(R"(
 @onready var unique_node = %"UniqueNodeIndeedWith$"
@@ -4186,7 +4186,7 @@ func _ready() -> void:
 		String code;
 		String pre_formatted;
 
-		// Without typing
+		// Without typing.
 		code =
 				GDSCRIPT(R"(
 func my_func(optional_param= null):
@@ -4199,7 +4199,7 @@ func my_func(optional_param = null):
 )");
 		CHECK_FORMAT(code, pre_formatted);
 
-		// With explicit typing
+		// With explicit typing.
 		code =
 				GDSCRIPT(R"(
 func my_func(optional_param: Node =null):
@@ -4212,7 +4212,7 @@ func my_func(optional_param: Node = null):
 )");
 		CHECK_FORMAT(code, pre_formatted);
 
-		// With inferred typing
+		// With inferred typing.
 		code =
 				GDSCRIPT(R"(
 func my_func(optional_param:=""):


### PR DESCRIPTION
This PR builds upon and finalizes the work done in [godotengine/godot/pull/55835](https://github.com/godotengine/godot/pull/55835).

This PR introduces a GDScript formatter in Godot's script editor. Users can access it through Edit/Format Code, <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd>, or by enabling the new *Format On Save* editor setting while saving their work.

Integrating a formatter in Godot's script editor improves it as an IDE for GDScript. Additionally, the formatter will improve developer's adherence to the [official GDScript style guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html).

We encourage users to test the formatter on large code bases in order to detect any quirks or bugs that need to be addressed.

Additionally, this PR includes support for comments through a header and inline. During parsing, each comment of a comment block are added to a comment header vector. The next node (variable, function, annotation) has this vector set as the header comments. The following comment until a newline, if present, is set as the inline comment.

The commits have been kept separate for ease of review, but they will be squashed before merging. Lastly, there are no new dependencies included in this PR.

_Production edit: Closes https://github.com/godotengine/godot-proposals/issues/3630_