### PR TITLE
Linux: Add .desktop actions for editor and project manager

### DIFF
--- a/misc/dist/linux/org.godotengine.Godot.desktop
+++ b/misc/dist/linux/org.godotengine.Godot.desktop
@@ -16,3 +16,12 @@ Type=Application
 MimeType=application/x-godot-project;
 Categories=Development;IDE;
 StartupWMClass=Godot
+Actions=Editor;ProjectManager;
+
+[Desktop Action Editor]
+Exec=godot --editor
+Name=Editor
+
+[Desktop Action ProjectManager]
+Exec=godot --project-manager
+Name=Project Manager


### PR DESCRIPTION
This follows the [FreeDesktop.org Desktop Entry specification for extra actions](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#extra-actions). These are shown by desktop environments like GNOME, KDE, Pantheon, etc. as a menu on the dock icon and in other contexts to enable a user to open the app in a specific context, e.g. if they have a scene open and want to open a new window with the project manager.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
