### PR TITLE
Show String properties' text in a tooltip in the inspector

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -69,6 +69,12 @@ bool EditorInspector::_property_path_matches(const String &p_property_path, cons
 	return false;
 }
 
+String EditorProperty::get_tooltip_string(const String &p_string) const {
+	// Trim to 100 characters to prevent the tooltip from being too long.
+	constexpr int TOOLTIP_MAX_LENGTH = 100;
+	return p_string.left(TOOLTIP_MAX_LENGTH).strip_edges() + String((p_string.length() > TOOLTIP_MAX_LENGTH) ? "..." : "");
+}
+
 Size2 EditorProperty::get_minimum_size() const {
 	Size2 ms;
 	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Tree"));

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -160,6 +160,8 @@ protected:
 public:
 	void emit_changed(const StringName &p_property, const Variant &p_value, const StringName &p_field = StringName(), bool p_changing = false);
 
+	String get_tooltip_string(const String &p_string) const;
+
 	virtual Size2 get_minimum_size() const override;
 
 	void set_label(const String &p_label);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -91,6 +91,10 @@ void EditorPropertyText::_text_changed(const String &p_string) {
 		return;
 	}
 
+	// Set tooltip so that the full text is displayed in a tooltip if hovered.
+	// This is useful when using a narrow inspector, as the text can be trimmed otherwise.
+	text->set_tooltip_text(get_tooltip_string(text->get_text()));
+
 	if (string_name) {
 		emit_changed(get_edited_property(), StringName(p_string));
 	} else {
@@ -104,6 +108,7 @@ void EditorPropertyText::update_property() {
 	if (text->get_text() != s) {
 		int caret = text->get_caret_column();
 		text->set_text(s);
+		text->set_tooltip_text(get_tooltip_string(s));
 		text->set_caret_column(caret);
 	}
 	text->set_editable(!is_read_only());
@@ -150,10 +155,14 @@ void EditorPropertyMultilineText::_set_read_only(bool p_read_only) {
 
 void EditorPropertyMultilineText::_big_text_changed() {
 	text->set_text(big_text->get_text());
+	// Set tooltip so that the full text is displayed in a tooltip if hovered.
+	// This is useful when using a narrow inspector, as the text can be trimmed otherwise.
+	text->set_tooltip_text(get_tooltip_string(big_text->get_text()));
 	emit_changed(get_edited_property(), big_text->get_text(), "", true);
 }
 
 void EditorPropertyMultilineText::_text_changed() {
+	text->set_tooltip_text(get_tooltip_string(text->get_text()));
 	emit_changed(get_edited_property(), text->get_text(), "", true);
 }
 
@@ -182,6 +191,7 @@ void EditorPropertyMultilineText::update_property() {
 	String t = get_edited_property_value();
 	if (text->get_text() != t) {
 		text->set_text(t);
+		text->set_tooltip_text(get_tooltip_string(t));
 		if (big_text && big_text->is_visible_in_tree()) {
 			big_text->set_text(t);
 		}


### PR DESCRIPTION
This allows previewing single-line or multipline strings that are too long too fit within the box in the inspector.

~~I wonder if it's possible to only show the tooltip if the text doesn't fully fit within the box. @bruvzg Is there a way we can detect this while taking the font size and advance into account (for both LineEdit and TextEdit)?~~

- This closes https://github.com/godotengine/godot-proposals/discussions/6638.

**Testing project:** [test_inspector_text_tooltip.zip](https://github.com/godotengine/godot/files/11266657/test_inspector_text_tooltip.zip)

## Preview

![Screenshot_20230418_234734](https://user-images.githubusercontent.com/180032/232913263-07c66efc-201d-4e53-ba89-d6e82086d3c8.png)