### PR TITLE
Increase tooltip offset to (25,30) to avoid the mouse pointer.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -621,7 +621,7 @@
 		<member name="display/mouse_cursor/custom_image_hotspot" type="Vector2" setter="" getter="" default="Vector2(0, 0)">
 			Hotspot for the custom mouse cursor image.
 		</member>
-		<member name="display/mouse_cursor/tooltip_position_offset" type="Vector2" setter="" getter="" default="Vector2(10, 10)">
+		<member name="display/mouse_cursor/tooltip_position_offset" type="Vector2" setter="" getter="" default="Vector2(25, 30)">
 			Position offset for tooltips, relative to the mouse cursor's hotspot.
 		</member>
 		<member name="display/window/dpi/allow_hidpi" type="bool" setter="" getter="" default="true">

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2326,7 +2326,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "display/mouse_cursor/custom_image", PROPERTY_HINT_FILE, "*.png,*.webp"), String());
 	GLOBAL_DEF_BASIC("display/mouse_cursor/custom_image_hotspot", Vector2());
-	GLOBAL_DEF_BASIC("display/mouse_cursor/tooltip_position_offset", Point2(10, 10));
+	GLOBAL_DEF_BASIC("display/mouse_cursor/tooltip_position_offset", Point2(25, 30));
 
 	if (String(GLOBAL_GET("display/mouse_cursor/custom_image")) != String()) {
 		Ref<Texture2D> cursor = ResourceLoader::load(


### PR DESCRIPTION
Tested on macOS with pointers ranging from smallest (default) to largest. It looks okay from smallest to about 1/3 of the way up the size slider.

Fixes https://github.com/godotengine/godot/issues/76232

I realize 25,30 isn't a nice round number like 10,10 or 20,20 or 30,30.

However, it feels comfortable and looks nice (in my opinion), especially since my mouse pointer is taller than it is wide.