### PR TITLE
Clamp normal when calculating 2D lighting to avoid artifacts

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -589,7 +589,7 @@ void main() {
 		if (bool(read_draw_data_flags & FLAGS_FLIP_V)) {
 			normal.y = -normal.y;
 		}
-		normal.z = sqrt(1.0 - dot(normal.xy, normal.xy));
+		normal.z = sqrt(max(0.0, 1.0 - dot(normal.xy, normal.xy)));
 		normal_used = true;
 	} else {
 		normal = vec3(0.0, 0.0, 1.0);

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -508,7 +508,7 @@ void main() {
 		if (bool(draw_data.flags & FLAGS_FLIP_V)) {
 			normal.y = -normal.y;
 		}
-		normal.z = sqrt(1.0 - dot(normal.xy, normal.xy));
+		normal.z = sqrt(max(0.0, 1.0 - dot(normal.xy, normal.xy)));
 		normal_used = true;
 	} else {
 		normal = vec3(0.0, 0.0, 1.0);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/76233

This is the same fix that was applied to 3.3 in https://github.com/godotengine/godot/pull/44293. The Godot 4 2D rendering must have diverged before https://github.com/godotengine/godot/pull/44293 was made.

_Before:_
![Screenshot from 2023-04-18 17-24-35](https://user-images.githubusercontent.com/16521339/232935299-7ecf72a9-c59d-44e8-92e0-059d73c7a94a.png)

_After:_
![Screenshot from 2023-04-18 17-24-16](https://user-images.githubusercontent.com/16521339/232935305-e28bdff0-3893-45cd-98da-dd564886cce5.png)

