### PR TITLE
TileMap: Add method to fetch the layer for a given body

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -134,6 +134,13 @@
 				Returns the coordinates of the tile for given physics body RID. Such RID can be retrieved from [method KinematicCollision2D.get_collider_rid], when colliding with a tile.
 			</description>
 		</method>
+		<method name="get_layer_for_body_rid">
+			<return type="int" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Returns the tilemap layer of the tile for given physics body RID. Such RID can be retrieved from [method KinematicCollision2D.get_collider_rid], when colliding with a tile.
+			</description>
+		</method>
 		<method name="get_layer_modulate" qualifiers="const">
 			<return type="Color" />
 			<param index="0" name="layer" type="int" />

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1637,6 +1637,7 @@ void TileMap::_physics_update_dirty_quadrants(SelfList<TileMapQuadrant>::List &r
 						// Create the body.
 						RID body = ps->body_create();
 						bodies_coords[body] = E_cell;
+						bodies_layers[body] = q.layer;
 						ps->body_set_mode(body, collision_animatable ? PhysicsServer2D::BODY_MODE_KINEMATIC : PhysicsServer2D::BODY_MODE_STATIC);
 						ps->body_set_space(body, space);
 
@@ -1692,6 +1693,7 @@ void TileMap::_physics_cleanup_quadrant(TileMapQuadrant *p_quadrant) {
 	ERR_FAIL_NULL(PhysicsServer2D::get_singleton());
 	for (RID body : p_quadrant->bodies) {
 		bodies_coords.erase(body);
+		bodies_layers.erase(body);
 		PhysicsServer2D::get_singleton()->free(body);
 	}
 	p_quadrant->bodies.clear();
@@ -2893,6 +2895,11 @@ HashMap<Vector2i, TileMapQuadrant> *TileMap::get_quadrant_map(int p_layer) {
 Vector2i TileMap::get_coords_for_body_rid(RID p_physics_body) {
 	ERR_FAIL_COND_V_MSG(!bodies_coords.has(p_physics_body), Vector2i(), vformat("No tiles for the given body RID %d.", p_physics_body));
 	return bodies_coords[p_physics_body];
+}
+
+int TileMap::get_layer_for_body_rid(RID p_physics_body) {
+	ERR_FAIL_COND_V_MSG(!bodies_layers.has(p_physics_body), int(), vformat("No tiles for the given body RID %d.", p_physics_body));
+	return bodies_layers[p_physics_body];
 }
 
 void TileMap::fix_invalid_tiles() {
@@ -4154,6 +4161,7 @@ void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_cell_tile_data", "layer", "coords", "use_proxies"), &TileMap::get_cell_tile_data, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("get_coords_for_body_rid", "body"), &TileMap::get_coords_for_body_rid);
+	ClassDB::bind_method(D_METHOD("get_layer_for_body_rid", "body"), &TileMap::get_layer_for_body_rid);
 
 	ClassDB::bind_method(D_METHOD("get_pattern", "layer", "coords_array"), &TileMap::get_pattern);
 	ClassDB::bind_method(D_METHOD("map_pattern", "position_in_tilemap", "coords_in_pattern", "pattern"), &TileMap::map_pattern);

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -219,6 +219,8 @@ private:
 
 	// Mapping for RID to coords.
 	HashMap<RID, Vector2i> bodies_coords;
+	// Mapping for RID to tile layer.
+	HashMap<RID, int> bodies_layers;
 
 	// Quadrants and internals management.
 	Vector2i _coords_to_quadrant_coords(int p_layer, const Vector2i &p_coords) const;
@@ -396,6 +398,8 @@ public:
 
 	// For finding tiles from collision.
 	Vector2i get_coords_for_body_rid(RID p_physics_body);
+	// For getting their layers as well.
+	int get_layer_for_body_rid(RID p_physics_body);
 
 	// Fixing and clearing methods.
 	void fix_invalid_tiles();


### PR DESCRIPTION
Currently it isn't possible to find the tilemap layer of what object you're colliding with.  This adds a tilemap method, get_layer_for_body_rid(), which works just like the already-existing get_coords_for_body_rid(), except it returns the tilemap layer instead of the tilemap coordinates.

*Bugsquad edit:*
- Closes https://github.com/godotengine/godot-proposals/issues/6716