### PR TITLE
Fix editor lock on SDF collision bake on error

### DIFF
--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -469,8 +469,13 @@ Ref<Image> GPUParticlesCollisionSDF3D::bake() {
 	}
 
 	//compute bvh
-
-	ERR_FAIL_COND_V_MSG(faces.size() <= 1, Ref<Image>(), "No faces detected during GPUParticlesCollisionSDF3D bake. Check whether there are visible meshes matching the bake mask within its extents.");
+	if (faces.size() <= 1) {
+		ERR_PRINT("No faces detected during GPUParticlesCollisionSDF3D bake. Check whether there are visible meshes matching the bake mask within its extents.");
+		if (bake_end_function) {
+			bake_end_function();
+		}
+		return Ref<Image>();
+	}
 
 	LocalVector<FacePos> face_pos;
 


### PR DESCRIPTION
SDF collision for particle 3D locks the editor if no faces are detected in the sdf area.
The baking progress pop-up is opened and never closed, forcing the user to kill the editor process.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
