### PR TITLE
CI: Speed up static checks by checking only changed files

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -7,7 +7,7 @@ concurrency:
 
 jobs:
   static-checks:
-    name: 📊 Static
+    name: 📊 Static checks
     uses: ./.github/workflows/static_checks.yml
 
   android-build:

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -8,38 +8,58 @@ concurrency:
 
 jobs:
   static-checks:
-    name: Static Checks (clang-format, black format, file format, documentation checks)
-    runs-on: ubuntu-20.04
+    name: Code style, file formatting, and docs
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
 
-      - name: Install dependencies
+      - name: Install APT dependencies
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: dos2unix libxml2-utils moreutils
+
+      - name: Install Python dependencies and general setup
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main"
-          sudo apt-get install -qq dos2unix clang-format-15 libxml2-utils python3-pip moreutils
-          sudo update-alternatives --remove-all clang-format || true
-          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-15 100
-          sudo pip3 install black==22.3.0 pytest==7.1.2 mypy==0.971
+          pip3 install black==22.3.0 pytest==7.1.2 mypy==0.971
           git config diff.wsErrorHighlight all
+
+      - name: Get changed files
+        id: changed-files
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            files=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} 2> /dev/null)
+          elif [ "${{ github.event_name }}" == "push" -a "${{ github.event.forced }}" == "false" -a "${{ github.event.created }}" == "false" ]; then
+            files=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.before }}..${{ github.event.after }} 2> /dev/null)
+          fi
+          echo "$files" >> changed.txt
+          cat changed.txt
 
       - name: File formatting checks (file_format.sh)
         run: |
-          bash ./misc/scripts/file_format.sh
+          bash ./misc/scripts/file_format.sh changed.txt
 
       - name: Header guards formatting checks (header_guards.sh)
         run: |
-          bash ./misc/scripts/header_guards.sh
+          bash ./misc/scripts/header_guards.sh changed.txt
 
       - name: Python style checks via black (black_format.sh)
         run: |
-          bash ./misc/scripts/black_format.sh
+          if grep -qE '*\.py|SConstruct|SCsub' changed.txt || [ ! -s changed.txt ]; then
+            bash ./misc/scripts/black_format.sh
+          else
+            echo "Skipping Python formatting as no Python files were changed."
+          fi
 
       - name: Python scripts static analysis (mypy_check.sh)
         run: |
-          bash ./misc/scripts/mypy_check.sh
+          if grep -qE '*\.py|SConstruct|SCsub' changed.txt || [ ! -s changed.txt ]; then
+            bash ./misc/scripts/mypy_check.sh
+          else
+            echo "Skipping Python static analysis as no Python files were changed."
+          fi
 
       - name: Python builders checks via pytest (pytest_builders.sh)
         run: |
@@ -47,10 +67,14 @@ jobs:
 
       - name: JavaScript style and documentation checks via ESLint and JSDoc
         run: |
-          cd platform/web
-          npm ci
-          npm run lint
-          npm run docs -- -d dry-run
+          if grep -q "platform/web" changed.txt || [ ! -s changed.txt ]; then
+            cd platform/web
+            npm ci
+            npm run lint
+            npm run docs -- -d dry-run
+          else
+            echo "Skipping JavaScript formatting as no Web/JS files were changed."
+          fi
 
       - name: Class reference schema checks
         run: |
@@ -62,11 +86,16 @@ jobs:
 
       - name: Style checks via clang-format (clang_format.sh)
         run: |
-          bash ./misc/scripts/clang_format.sh
+          clang-format --version
+          bash ./misc/scripts/clang_format.sh changed.txt
 
       - name: Style checks via dotnet format (dotnet_format.sh)
         run: |
-          bash ./misc/scripts/dotnet_format.sh
+          if grep -q "modules/mono" changed.txt || [ ! -s changed.txt ]; then
+            bash ./misc/scripts/dotnet_format.sh
+          else
+            echo "Skipping dotnet format as no C# files were changed."
+          fi
 
       - name: Spell checks via codespell
         uses: codespell-project/actions-codespell@v1

--- a/misc/scripts/file_format.sh
+++ b/misc/scripts/file_format.sh
@@ -7,14 +7,20 @@
 # We need dos2unix and isutf8.
 if [ ! -x "$(command -v dos2unix)" -o ! -x "$(command -v isutf8)" ]; then
     printf "Install 'dos2unix' and 'isutf8' (moreutils package) to use this script.\n"
+    exit 1
 fi
 
 set -uo pipefail
-IFS=$'\n\t'
 
-# Loops through all text files tracked by Git.
-git grep -zIl '' |
-while IFS= read -rd '' f; do
+if [ $# -eq 0 ]; then
+    # Loop through all code files tracked by Git.
+    mapfile -d '' files < <(git grep -zIl '')
+else
+    # $1 should be a file listing file paths to process. Used in CI.
+    mapfile -d ' ' < <(cat "$1")
+fi
+
+for f in "${files[@]}"; do
     # Exclude some types of files.
     if [[ "$f" == *"csproj" ]]; then
         continue


### PR DESCRIPTION
Our static checks used to take close to 8m to run, as many of the checks run on most files in the codebase each time, and are relatively slow bash or python scripts working file by file.

This PR optimizes the workflow by changing the scripts to (optionally) operate on a list of files, and we pass in the list of files actually changed in the PR.

We disable the dotnet format check if no `modules/mono` files are changed, as it's very slow and couldn't be optimized the same way as others. And we do the same for the JS for an extra 15 s speedup.

What's left as potential to optimize would be the dependencies install. Maybe the pip stuff can be cached too (see [actions/setup-python](https://github.com/actions/setup-python#caching-packages-dependencies)).

Before:
![image](https://user-images.githubusercontent.com/4701338/233152362-c87af42b-f0e7-40c3-aae0-1d203feabfef.png)

After:
![image](https://user-images.githubusercontent.com/4701338/233154638-14a18699-ea3b-4e0a-bdf0-bb1ca8efb3a2.png)

So we go from 7m 45s to ~1m 5s~ **50s**.