### PR TITLE
Fix filesystem drag&drop move&copy for directories

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1746,10 +1746,14 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 		bool is_copied = false;
 		for (int i = 0; i < to_move.size(); i++) {
 			String old_path = to_move[i].path.ends_with("/") ? to_move[i].path.substr(0, to_move[i].path.length() - 1) : to_move[i].path;
-			const String &new_path = new_paths[i];
+			String new_path = new_paths[i];
+
+			if (!to_move[i].is_file && old_path.get_base_dir() != new_path.get_base_dir()) {
+				new_path = new_path.path_join(old_path.get_file());
+			}
 
 			if (old_path != new_path) {
-				_try_duplicate_item(to_move[i], new_paths[i]);
+				_try_duplicate_item(to_move[i], new_path);
 				is_copied = true;
 			}
 		}
@@ -1771,7 +1775,13 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 
 		for (int i = 0; i < to_move.size(); i++) {
 			String old_path = to_move[i].path.ends_with("/") ? to_move[i].path.substr(0, to_move[i].path.length() - 1) : to_move[i].path;
-			const String &new_path = new_paths[i];
+			String new_path = new_paths[i];
+
+			// This is not a rename, we are moving a directory into another directory
+			if (!to_move[i].is_file && old_path.get_base_dir() != new_path.get_base_dir()) {
+				new_path = new_path.path_join(old_path.get_file());
+			}
+
 			if (old_path != new_path) {
 				_try_move_item(to_move[i], new_path, file_renames, folder_renames);
 				is_moved = true;


### PR DESCRIPTION
Make drag and drop for directories in the filesystem panel functional.
The current behaviour results in errors displayed and no move being performed.
Changed tested with right click > move and drag & drop for both single and multiple directories and single and multiple files

Previous:
![prev_behaviour](https://user-images.githubusercontent.com/494097/233215693-acc02a16-4da1-4476-813a-2ed1e994282e.gif)
New:
![new_behaviour](https://user-images.githubusercontent.com/494097/233215738-1b8a4755-4ad6-4d46-9394-471eb115b346.gif)
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as need
ed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

*Bugsquad edit:* Fixes #77689