### PR TITLE
Adding possible solution for the inconsistent behaviors between round…

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
@@ -503,17 +503,19 @@ namespace Godot
             return new Vector2(value.X, value.Y);
         }
 
-        /// <summary>
-        /// Converts a <see cref="Vector2"/> to a <see cref="Vector2I"/>.
-        /// </summary>
-        /// <param name="value">The vector to convert.</param>
-        public static explicit operator Vector2I(Vector2 value)
-        {
-            return new Vector2I(
-                Mathf.RoundToInt(value.X),
-                Mathf.RoundToInt(value.Y)
-            );
-        }
+      /// <summary>
+    /// Converts a <see cref="Vector2"/> to a <see cref="Vector2I"/> by truncating
+    /// components' fractional parts (rounding towards zero). This ensures consistent
+    /// rounding behavior, but note that it may result in values that are different from
+    /// the behavior of <see cref="Vector2.Round"/> or other rounding methods when
+    /// converting float values that are exactly between two integer values.
+    /// </summary>
+    /// <param name="value">The vector to convert.</param>
+    public static implicit operator Vector2i(Vector2 value)
+    {
+        return new Vector2i((int)Math.Truncate(value.x), (int)Math.Truncate(value.y));
+    }
+
 
         /// <summary>
         /// Returns <see langword="true"/> if the vector is equal

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
@@ -558,18 +558,19 @@ namespace Godot
             return new Vector3(value.X, value.Y, value.Z);
         }
 
-        /// <summary>
-        /// Converts a <see cref="Vector3"/> to a <see cref="Vector3I"/>.
-        /// </summary>
-        /// <param name="value">The vector to convert.</param>
-        public static explicit operator Vector3I(Vector3 value)
-        {
-            return new Vector3I(
-                Mathf.RoundToInt(value.X),
-                Mathf.RoundToInt(value.Y),
-                Mathf.RoundToInt(value.Z)
-            );
-        }
+    /// <summary>
+    /// Converts a <see cref="Vector3"/> to a <see cref="Vector3I"/> by truncating
+    /// components' fractional parts (rounding towards zero). This ensures consistent
+    /// rounding behavior, but note that it may result in values that are different from
+    /// the behavior of <see cref="Vector3.Round"/> or other rounding methods when
+    /// converting float values that are exactly between two integer values.
+    /// </summary>
+    /// <param name="value">The vector to convert.</param>
+    public static explicit operator Vector3I(Vector3 value)
+    {
+        return new Vector3I((int)Math.Truncate(value.X), (int)Math.Truncate(value.Y), (int)Math.Truncate(value.Z));
+    }
+
 
         /// <summary>
         /// Returns <see langword="true"/> if the vector is equal

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
@@ -579,19 +579,19 @@ namespace Godot
             return new Vector4(value.X, value.Y, value.Z, value.W);
         }
 
-        /// <summary>
-        /// Converts a <see cref="Vector4"/> to a <see cref="Vector4I"/>.
-        /// </summary>
-        /// <param name="value">The vector to convert.</param>
-        public static explicit operator Vector4I(Vector4 value)
-        {
-            return new Vector4I(
-                Mathf.RoundToInt(value.X),
-                Mathf.RoundToInt(value.Y),
-                Mathf.RoundToInt(value.Z),
-                Mathf.RoundToInt(value.W)
-            );
-        }
+    /// <summary>
+    /// Converts a <see cref="Vector4"/> to a <see cref="Vector4I"/> by truncating
+    /// components' fractional parts (rounding towards zero). This ensures consistent
+    /// rounding behavior, but note that it may result in values that are different from
+    /// the behavior of <see cref="Vector4.Round"/> or other rounding methods when
+    /// converting float values that are exactly between two integer values.
+    /// </summary>
+    /// <param name="value">The vector to convert.</param>
+    public static explicit operator Vector4I(Vector4 value)
+    {
+        return new Vector4I((int)Math.Truncate(value.X), (int)Math.Truncate(value.Y), (int)Math.Truncate(value.Z), (int)Math.Truncate(value.W));
+    }
+
 
         /// <summary>
         /// Returns <see langword="true"/> if the vector is equal


### PR DESCRIPTION
The previous implicit conversion from vector2i and other files use round instead of truncate which will causes errors such as rounding 0.51 to 1 instead of 0. #75470