### PR TITLE
Add an option for ButtonGroups to be unpressed

### DIFF
--- a/doc/classes/ButtonGroup.xml
+++ b/doc/classes/ButtonGroup.xml
@@ -24,6 +24,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="allow_unpress" type="bool" setter="set_allow_unpress" getter="is_allow_unpress" default="false">
+			If [code]true[/code], it is possible to unpress all buttons in this [ButtonGroup].
+		</member>
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="true" />
 	</members>
 	<signals>

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -40,7 +40,7 @@ void BaseButton::_unpress_group() {
 		return;
 	}
 
-	if (toggle_mode) {
+	if (toggle_mode && !button_group->is_allow_unpress()) {
 		status.pressed = true;
 	}
 
@@ -537,9 +537,20 @@ BaseButton *ButtonGroup::get_pressed_button() {
 	return nullptr;
 }
 
+void ButtonGroup::set_allow_unpress(bool p_enabled) {
+	allow_unpress = p_enabled;
+}
+bool ButtonGroup::is_allow_unpress() {
+	return allow_unpress;
+}
+
 void ButtonGroup::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_pressed_button"), &ButtonGroup::get_pressed_button);
 	ClassDB::bind_method(D_METHOD("get_buttons"), &ButtonGroup::_get_buttons);
+	ClassDB::bind_method(D_METHOD("set_allow_unpress", "enabled"), &ButtonGroup::set_allow_unpress);
+	ClassDB::bind_method(D_METHOD("is_allow_unpress"), &ButtonGroup::is_allow_unpress);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_unpress"), "set_allow_unpress", "is_allow_unpress");
 
 	ADD_SIGNAL(MethodInfo("pressed", PropertyInfo(Variant::OBJECT, "button", PROPERTY_HINT_RESOURCE_TYPE, "BaseButton")));
 }

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -152,6 +152,7 @@ class ButtonGroup : public Resource {
 	GDCLASS(ButtonGroup, Resource);
 	friend class BaseButton;
 	HashSet<BaseButton *> buttons;
+	bool allow_unpress = false;
 
 protected:
 	static void _bind_methods();
@@ -160,6 +161,8 @@ public:
 	BaseButton *get_pressed_button();
 	void get_buttons(List<BaseButton *> *r_buttons);
 	TypedArray<BaseButton> _get_buttons();
+	void set_allow_unpress(bool p_enabled);
+	bool is_allow_unpress();
 	ButtonGroup();
 };
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Closes https://github.com/godotengine/godot-proposals/issues/6722