### PR TITLE
Fix for mixed tabs and spaces in gdscript

### DIFF
--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -1099,7 +1099,7 @@ void GDScriptTokenizer::check_indent() {
 			_advance();
 		}
 
-		if (mixed) {
+		if (mixed && !(line_continuation || multiline_mode)) {
 			Token error = make_error("Mixed use of tabs and spaces for indentation.");
 			error.start_line = line;
 			error.start_column = 1;


### PR DESCRIPTION
Fix for mixed tabs and spaces in multi-line situations, see https://github.com/godotengine/godot/issues/49171
Have used for a couple of weeks and have not seen any issues (other than type definitions for arrays eg. : Array[Something] failing to highlight the "Something", but I don't think that's actually due to this).

(First time I've contributed, so please tell me if I'm doing something wrong in the submission process so I can correct it)

*Bugsquad edit:*
- Fixes #49171