### PR TITLE
C#: Do not use DocCache when generating glue code

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2240,7 +2240,7 @@ void EditorHelp::_gen_doc_thread(void *p_udata) {
 
 static bool doc_gen_use_threads = true;
 
-void EditorHelp::generate_doc() {
+void EditorHelp::generate_doc(bool p_use_cache) {
 	if (doc_gen_use_threads) {
 		// In case not the first attempt.
 		_wait_for_thread();
@@ -2256,7 +2256,7 @@ void EditorHelp::generate_doc() {
 		doc = memnew(DocTools);
 	}
 
-	if (first_attempt && FileAccess::exists(get_cache_full_path())) {
+	if (p_use_cache && first_attempt && FileAccess::exists(get_cache_full_path())) {
 		if (doc_gen_use_threads) {
 			thread.start(_load_doc_thread, nullptr);
 		} else {

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -204,7 +204,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	static void generate_doc();
+	static void generate_doc(bool p_use_cache = true);
 	static DocTools *get_doc_data();
 	static void cleanup_doc();
 	static String get_cache_full_path();

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -3894,7 +3894,7 @@ void BindingsGenerator::_log(const char *p_format, ...) {
 void BindingsGenerator::_initialize() {
 	initialized = false;
 
-	EditorHelp::generate_doc();
+	EditorHelp::generate_doc(false);
 
 	enum_types.clear();
 


### PR DESCRIPTION
- Fixes #76250
- See also https://github.com/godotengine/godot/pull/72855#issuecomment-1515491486

Just a workaround really, but I am not sure what the problem is and the in-editor documentation for these classes seems to work just fine.