### PR TITLE
Fix global scope clamp results

### DIFF
--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -623,35 +623,51 @@ struct VariantUtilityFunctions {
 	}
 
 	static inline Variant clamp(const Variant &x, const Variant &min, const Variant &max, Callable::CallError &r_error) {
-		Variant value = x;
-
-		Variant ret;
-
-		bool valid;
-		Variant::evaluate(Variant::OP_LESS, value, min, ret, valid);
-		if (!valid) {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.expected = value.get_type();
-			r_error.argument = 1;
-			return Variant();
-		}
-		if (ret.booleanize()) {
-			value = min;
-		}
-		Variant::evaluate(Variant::OP_GREATER, value, max, ret, valid);
-		if (!valid) {
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.expected = value.get_type();
-			r_error.argument = 2;
-			return Variant();
-		}
-		if (ret.booleanize()) {
-			value = max;
-		}
-
 		r_error.error = Callable::CallError::CALL_OK;
+		if (x.get_type() != min.get_type()) {
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+			r_error.expected = x.get_type();
+			r_error.argument = 1;
+			return x;
+		}
 
-		return value;
+		if (x.get_type() != max.get_type()) {
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+			r_error.expected = x.get_type();
+			r_error.argument = 2;
+			return x;
+		}
+
+		switch (x.get_type()) {
+			case Variant::INT: {
+				return clampi(x, min, max);
+			} break;
+			case Variant::FLOAT: {
+				return clampf(x, min, max);
+			} break;
+			case Variant::VECTOR2: {
+				return VariantInternalAccessor<Vector2>::get(&x).clamp(VariantInternalAccessor<Vector2>::get(&min), VariantInternalAccessor<Vector2>::get(&max));
+			} break;
+			case Variant::VECTOR2I: {
+				return VariantInternalAccessor<Vector2i>::get(&x).clamp(VariantInternalAccessor<Vector2i>::get(&min), VariantInternalAccessor<Vector2i>::get(&max));
+			} break;
+			case Variant::VECTOR3: {
+				return VariantInternalAccessor<Vector3>::get(&x).clamp(VariantInternalAccessor<Vector3>::get(&min), VariantInternalAccessor<Vector3>::get(&max));
+			} break;
+			case Variant::VECTOR3I: {
+				return VariantInternalAccessor<Vector3i>::get(&x).clamp(VariantInternalAccessor<Vector3i>::get(&min), VariantInternalAccessor<Vector3i>::get(&max));
+			} break;
+			case Variant::VECTOR4: {
+				return VariantInternalAccessor<Vector4>::get(&x).clamp(VariantInternalAccessor<Vector4>::get(&min), VariantInternalAccessor<Vector4>::get(&max));
+			} break;
+			case Variant::VECTOR4I: {
+				return VariantInternalAccessor<Vector4i>::get(&x).clamp(VariantInternalAccessor<Vector4i>::get(&min), VariantInternalAccessor<Vector4i>::get(&max));
+			} break;
+			default: {
+				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+				return x;
+			}
+		}
 	}
 
 	static inline double clampf(double x, double min, double max) {

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -200,7 +200,7 @@
 				var f = clamp(Vector3i(-7, -8, -9), Vector3i(-1, 2, 3), Vector3i(-4, -5, -6))
 				# f is (-4, -5, -6)
 				[/codeblock]
-				[b]Note:[/b] For better type safety, use [method clampf], [method clampi], [method Vector2.clamp], [method Vector2i.clamp], [method Vector3.clamp], [method Vector3i.clamp], [method Vector4.clamp], or [method Vector4i.clamp].
+				[b]Note:[/b] For better type safety, use [method clampf], [method clampi], [method Vector2.clamp], [method Vector2i.clamp], [method Vector3.clamp], [method Vector3i.clamp], [method Vector4.clamp], or [method Vector4i.clamp]. For swapped [param min] and [param max] values result is predictable but incorrect.
 			</description>
 		</method>
 		<method name="clampf">


### PR DESCRIPTION
Global scope clamp function returns wrong results for Vector types.
Also against documentation it works for String values.
This PR aligns results from global scope function to class function results.

**Master branch:**

clamp(4, 2, 6) Global scope: 4, class method 4
clamp(4, 2, 6) Global scope: 4, class method 4
clamp((4, 4), (2, 2), (6, 6)) Global scope: (4, 4), class method (4, 4)
clamp((0, 8), (2, 2), (6, 6)) Global scope: (2, 2), class method (2, 6) **<- LOOK HERE!**
clamp((8, 8), (2, 2), (6, 6)) Global scope: (6, 6), class method (6, 6)
clamp((8, 4), (2, 2), (6, 6)) Global scope: (6, 6), class method (6, 4) **<- LOOK HERE!**
clamp((8, 0), (2, 2), (6, 6)) Global scope: (6, 6), class method (6, 2) **<- LOOK HERE!**
clamp((4, 0), (2, 2), (6, 6)) Global scope: (4, 0), class method (4, 2) **<- LOOK HERE!**
clamp((0, 0), (2, 2), (6, 6)) Global scope: (2, 2), class method (2, 2)
clamp((0, 4), (2, 2), (6, 6)) Global scope: (2, 2), class method (2, 4) **<- LOOK HERE!**
clamp((0, 8), (2, 2), (6, 6)) Global scope: (2, 2), class method (2, 6) **<- LOOK HERE!**
clamp((0, 8), (2, 2), (6, 6)) Global scope: (2, 2), class method (2, 6) **<- LOOK HERE!**
clamp((0, 8, 4), (2, 2, 2), (6, 6, 6)) Global scope: (2, 2, 2), class method (2, 6, 4) **<- LOOK HERE!**
clamp((0, 8, 4), (2, 2, 2), (6, 6, 6)) Global scope: (2, 2, 2), class method (2, 6, 4) **<- LOOK HERE!**
clamp((0, 8, 4, 4), (2, 2, 2, 2), (6, 6, 6, 6)) Global scope: (2, 2, 2, 2), class method (2, 6, 4, 4) **<- LOOK HERE!**
clamp((0, 8, 4, 4), (2, 2, 2, 2), (6, 6, 6, 6)) Global scope: (2, 2, 2, 2), class method (2, 6, 4, 4) **<- LOOK HERE!**
clamp((4, 4), (8, 8), (0, 0)) Global scope: (8, 8), class method (8, 8)

clamp(a, b, d) Global scope: b **<- LOOK HERE!**
clamp(c, b, d) Global scope: c **<- LOOK HERE!**
clamp(e, b, d) Global scope: d **<- LOOK HERE!**

clamp((Vector2i(), 1, 2)) throws Invalid type in utility function 'clamp'. Cannot convert argument 2 from int to Vector2i.
clamp(Vector2i(), Vector2i(), 2)) throws Invalid type in utility function 'clamp'. Cannot convert argument 3 from int to Vector2i.


**Fixed version:**

clamp(4, 2, 6) Global scope: 4, class method 4
clamp(4, 2, 6) Global scope: 4, class method 4
clamp((4, 4), (2, 2), (6, 6)) Global scope: (4, 4), class method (4, 4)
clamp((0, 8), (2, 2), (6, 6)) Global scope: (2, 6), class method (2, 6)
clamp((8, 8), (2, 2), (6, 6)) Global scope: (6, 6), class method (6, 6)
clamp((8, 4), (2, 2), (6, 6)) Global scope: (6, 4), class method (6, 4)
clamp((8, 0), (2, 2), (6, 6)) Global scope: (6, 2), class method (6, 2)
clamp((4, 0), (2, 2), (6, 6)) Global scope: (4, 2), class method (4, 2)
clamp((0, 0), (2, 2), (6, 6)) Global scope: (2, 2), class method (2, 2)
clamp((0, 4), (2, 2), (6, 6)) Global scope: (2, 4), class method (2, 4)
clamp((0, 8), (2, 2), (6, 6)) Global scope: (2, 6), class method (2, 6)
clamp((0, 8), (2, 2), (6, 6)) Global scope: (2, 6), class method (2, 6)
clamp((0, 8, 4), (2, 2, 2), (6, 6, 6)) Global scope: (2, 6, 4), class method (2, 6, 4)
clamp((0, 8, 4), (2, 2, 2), (6, 6, 6)) Global scope: (2, 6, 4), class method (2, 6, 4)
clamp((0, 8, 4, 4), (2, 2, 2, 2), (6, 6, 6, 6)) Global scope: (2, 6, 4, 4), class method (2, 6, 4, 4)
clamp((0, 8, 4, 4), (2, 2, 2, 2), (6, 6, 6, 6)) Global scope: (2, 6, 4, 4), class method (2, 6, 4, 4)
clamp((4, 4), (8, 8), (0, 0)) Global scope: (8, 8), class method (8, 8)

clamp(a, b, d) throws Error calling utility function 'clamp': a
clamp(c, b, d) throws Error calling utility function 'clamp': c
clamp(e, b, d) throws Error calling utility function 'clamp': e

clamp((Vector2i(), 1, 2)) throws Invalid type in utility function 'clamp'. Cannot convert argument 2 from int to Vector2i.
clamp(Vector2i(), Vector2i(), 2)) throws Invalid type in utility function 'clamp'. Cannot convert argument 3 from int to Vector2i.

[Minimum test project](https://github.com/godotengine/godot/files/11286538/clamp.zip)
