### PR TITLE
CI: Fixup failure to get changed files on merge

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -30,9 +30,9 @@ jobs:
         id: changed-files
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            files=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} 2> /dev/null)
+            files=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} 2> /dev/null || true)
           elif [ "${{ github.event_name }}" == "push" -a "${{ github.event.forced }}" == "false" -a "${{ github.event.created }}" == "false" ]; then
-            files=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.before }}..${{ github.event.after }} 2> /dev/null)
+            files=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.before }}..${{ github.event.after }} 2> /dev/null || true)
           fi
           echo "$files" >> changed.txt
           cat changed.txt


### PR DESCRIPTION
Follow-up to #76263.

The checkout might be too shallow so the before commit isn't available. The logic was already written to take this into account (it then generates an empty 'changed.txt' which falls back to testing everything), but the error code would still force terminate the job.

Hopefully we can find a way to make the logic work for merge events too in the future, but for now this is a quick fix.