### PR TITLE
Implement occlusion "soft-culling" to reduce LOD of occluded meshes rather than skipping drawing entirely

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2471,10 +2471,16 @@
 		</member>
 		<member name="rendering/limits/time/time_rollover_secs" type="float" setter="" getter="" default="3600">
 		</member>
+		<member name="rendering/mesh_lod/lod_change/shadow_lod_bias" type="float" setter="" getter="" default="0.3">
+			LOD bias multiplier for shadow passes. Allows shadows to be rendered at a lower LOD.
+		</member>
 		<member name="rendering/mesh_lod/lod_change/threshold_pixels" type="float" setter="" getter="" default="1.0">
 			The automatic LOD bias to use for meshes rendered within the [ReflectionProbe]. Higher values will use less detailed versions of meshes that have LOD variations generated. If set to [code]0.0[/code], automatic LOD is disabled. Increase [member rendering/mesh_lod/lod_change/threshold_pixels] to improve performance at the cost of geometry detail.
 			[b]Note:[/b] [member rendering/mesh_lod/lod_change/threshold_pixels] does not affect [GeometryInstance3D] visibility ranges (also known as "manual" LOD or hierarchical LOD).
 			[b]Note:[/b] This property is only read when the project starts. To adjust the automatic LOD threshold at runtime, set [member Viewport.mesh_lod_threshold] on the root [Viewport].
+		</member>
+		<member name="rendering/occlusion_culling/bounds_scale" type="float" setter="" getter="" default="1.0">
+			Scale factor for occludee bounding boxes. Allows objects to be culled before they're fully occluded. Changing this is not recommended when [member rendering/occlusion_culling/soft_cull_lod_bias] is set to [code]0.0[/code].
 		</member>
 		<member name="rendering/occlusion_culling/bvh_build_quality" type="int" setter="" getter="" default="2">
 			The [url=https://en.wikipedia.org/wiki/Bounding_volume_hierarchy]Bounding Volume Hierarchy[/url] quality to use when rendering the occlusion culling buffer. Higher values will result in more accurate occlusion culling, at the cost of higher CPU usage. See also [member rendering/occlusion_culling/occlusion_rays_per_thread].
@@ -2483,6 +2489,9 @@
 		<member name="rendering/occlusion_culling/occlusion_rays_per_thread" type="int" setter="" getter="" default="512">
 			The number of occlusion rays traced per CPU thread. Higher values will result in more accurate occlusion culling, at the cost of higher CPU usage. The occlusion culling buffer's pixel count is roughly equal to [code]occlusion_rays_per_thread * number_of_logical_cpu_cores[/code], so it will depend on the system's CPU. Therefore, CPUs with fewer cores will use a lower resolution to attempt keeping performance costs even across devices. See also [member rendering/occlusion_culling/bvh_build_quality].
 			[b]Note:[/b] This property is only read when the project starts. To adjust the number of occlusion rays traced per thread at runtime, use [method RenderingServer.viewport_set_occlusion_rays_per_thread].
+		</member>
+		<member name="rendering/occlusion_culling/soft_cull_lod_bias" type="float" setter="" getter="" default="0.0">
+			LOD bias multiplier for occluded objects. If set to a value greater than [code]0.0[/code], occluded objects will be drawn with a lower LOD rather than culled.
 		</member>
 		<member name="rendering/occlusion_culling/use_occlusion_culling" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], [OccluderInstance3D] nodes will be usable for occlusion culling in 3D in the root viewport. In custom viewports, [member Viewport.use_occlusion_culling] must be set to [code]true[/code] instead.

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1266,8 +1266,9 @@ void RasterizerSceneGLES3::_fill_render_list(RenderListType p_render_list, const
 					distance = 1.0;
 				}
 
+				float model_scale = inst->calculate_final_model_scale(p_pass_mode == PASS_MODE_SHADOW);
 				uint32_t indices = 0;
-				surf->lod_index = mesh_storage->mesh_surface_get_lod(surf->surface, inst->lod_model_scale * inst->lod_bias, distance * p_render_data->lod_distance_multiplier, p_render_data->screen_mesh_lod_threshold, indices);
+				surf->lod_index = mesh_storage->mesh_surface_get_lod(surf->surface, model_scale, distance * p_render_data->lod_distance_multiplier, p_render_data->screen_mesh_lod_threshold, indices);
 				surf->index_count = indices;
 
 				if (p_render_data->render_info) {

--- a/servers/rendering/dummy/rasterizer_scene_dummy.h
+++ b/servers/rendering/dummy/rasterizer_scene_dummy.h
@@ -50,7 +50,7 @@ public:
 		virtual void set_mesh_instance(RID p_mesh_instance) override {}
 		virtual void set_transform(const Transform3D &p_transform, const AABB &p_aabb, const AABB &p_transformed_aabb) override {}
 		virtual void set_pivot_data(float p_sorting_offset, bool p_use_aabb_center) override {}
-		virtual void set_lod_bias(float p_lod_bias) override {}
+		virtual void set_lod_bias(float p_geom_lod_bias, float p_shadow_lod_bias) override {}
 		virtual void set_layer_mask(uint32_t p_layer_mask) override {}
 		virtual void set_fade_range(bool p_enable_near, float p_near_begin, float p_near_end, bool p_enable_far, float p_far_begin, float p_far_end) override {}
 		virtual void set_parent_fade_alpha(float p_alpha) override {}

--- a/servers/rendering/renderer_geometry_instance.cpp
+++ b/servers/rendering/renderer_geometry_instance.cpp
@@ -85,8 +85,9 @@ void RenderGeometryInstanceBase::set_pivot_data(float p_sorting_offset, bool p_u
 	use_aabb_center = p_use_aabb_center;
 }
 
-void RenderGeometryInstanceBase::set_lod_bias(float p_lod_bias) {
-	lod_bias = p_lod_bias;
+void RenderGeometryInstanceBase::set_lod_bias(float p_geom_lod_bias, float p_shadow_lod_bias) {
+	geom_lod_bias = p_geom_lod_bias;
+	shadow_lod_bias = p_shadow_lod_bias;
 }
 
 void RenderGeometryInstanceBase::set_layer_mask(uint32_t p_layer_mask) {

--- a/servers/rendering/renderer_geometry_instance.h
+++ b/servers/rendering/renderer_geometry_instance.h
@@ -51,7 +51,7 @@ public:
 	virtual void set_mesh_instance(RID p_mesh_instance) = 0;
 	virtual void set_transform(const Transform3D &p_transform, const AABB &p_aabb, const AABB &p_transformed_aabb) = 0;
 	virtual void set_pivot_data(float p_sorting_offset, bool p_use_aabb_center) = 0;
-	virtual void set_lod_bias(float p_lod_bias) = 0;
+	virtual void set_lod_bias(float p_geom_lod_bias, float p_shadow_lod_bias) = 0;
 	virtual void set_layer_mask(uint32_t p_layer_mask) = 0;
 	virtual void set_fade_range(bool p_enable_near, float p_near_begin, float p_near_end, bool p_enable_far, float p_far_begin, float p_far_end) = 0;
 	virtual void set_parent_fade_alpha(float p_alpha) = 0;
@@ -91,7 +91,8 @@ public:
 	AABB transformed_aabb;
 	bool non_uniform_scale = false;
 	float lod_model_scale = 1.0;
-	float lod_bias = 0.0;
+	float geom_lod_bias = 0.0;
+	float shadow_lod_bias = 0.0;
 	float sorting_offset = 0.0;
 	bool use_aabb_center = true;
 
@@ -130,6 +131,10 @@ public:
 
 	Data *data = nullptr;
 
+	float calculate_final_model_scale(bool is_shadow) {
+		return lod_model_scale * (is_shadow ? shadow_lod_bias : geom_lod_bias);
+	}
+
 	virtual void set_skeleton(RID p_skeleton) override;
 	virtual void set_material_override(RID p_override) override;
 	virtual void set_material_overlay(RID p_overlay) override;
@@ -137,7 +142,7 @@ public:
 	virtual void set_mesh_instance(RID p_mesh_instance) override;
 	virtual void set_transform(const Transform3D &p_transform, const AABB &p_aabb, const AABB &p_transformed_aabb) override;
 	virtual void set_pivot_data(float p_sorting_offset, bool p_use_aabb_center) override;
-	virtual void set_lod_bias(float p_lod_bias) override;
+	virtual void set_lod_bias(float p_geom_lod_bias, float p_shadow_lod_bias) override;
 	virtual void set_layer_mask(uint32_t p_layer_mask) override;
 	virtual void set_fade_range(bool p_enable_near, float p_near_begin, float p_near_end, bool p_enable_far, float p_far_begin, float p_far_end) override;
 	virtual void set_parent_fade_alpha(float p_alpha) override;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -967,8 +967,9 @@ void RenderForwardClustered::_fill_render_list(RenderListType p_render_list, con
 					distance = 1.0;
 				}
 
+				float model_scale = inst->calculate_final_model_scale(p_pass_mode == PASS_MODE_SHADOW || p_pass_mode == PASS_MODE_SHADOW_DP);
 				uint32_t indices = 0;
-				surf->sort.lod_index = mesh_storage->mesh_surface_get_lod(surf->surface, inst->lod_model_scale * inst->lod_bias, distance * p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, indices);
+				surf->sort.lod_index = mesh_storage->mesh_surface_get_lod(surf->surface, model_scale, distance * p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, indices);
 				if (p_render_data->render_info) {
 					indices = _indices_to_primitives(surf->primitive, indices);
 					if (p_render_list == RENDER_LIST_OPAQUE) { //opaque

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1848,8 +1848,9 @@ void RenderForwardMobile::_fill_render_list(RenderListType p_render_list, const 
 					distance = 1.0;
 				}
 
+				float model_scale = inst->calculate_final_model_scale(p_pass_mode == PASS_MODE_SHADOW || p_pass_mode == PASS_MODE_SHADOW_DP);
 				uint32_t indices = 0;
-				surf->lod_index = mesh_storage->mesh_surface_get_lod(surf->surface, inst->lod_model_scale * inst->lod_bias, distance * p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, indices);
+				surf->lod_index = mesh_storage->mesh_surface_get_lod(surf->surface, model_scale, distance * p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, indices);
 				if (p_render_data->render_info) {
 					indices = _indices_to_primitives(surf->primitive, indices);
 					if (p_render_list == RENDER_LIST_OPAQUE) { //opaque

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -342,6 +342,9 @@ public:
 		}
 	};
 
+	float occlusion_bounds_scale;
+	float shadow_lod_bias;
+	float soft_cull_bias;
 	int indexer_update_iterations = 0;
 
 	mutable RID_Owner<Scenario, true> scenario_owner;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2961,7 +2961,11 @@ void RenderingServer::init() {
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/textures/decals/filter", PROPERTY_HINT_ENUM, "Nearest (Fast),Linear (Fast),Nearest Mipmap (Fast),Linear Mipmap (Fast),Nearest Mipmap Anisotropic (Average),Linear Mipmap Anisotropic (Average)"), DECAL_FILTER_LINEAR_MIPMAPS);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/textures/light_projectors/filter", PROPERTY_HINT_ENUM, "Nearest (Fast),Linear (Fast),Nearest Mipmap (Fast),Linear Mipmap (Fast),Nearest Mipmap Anisotropic (Average),Linear Mipmap Anisotropic (Average)"), LIGHT_PROJECTOR_FILTER_LINEAR_MIPMAPS);
 
+	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "rendering/mesh_lod/lod_change/shadow_lod_bias", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), 0.3);
+
 	GLOBAL_DEF_RST("rendering/occlusion_culling/occlusion_rays_per_thread", 512);
+	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "rendering/occlusion_culling/bounds_scale", PROPERTY_HINT_RANGE, "0.0,2.0,0.01"), 1.0);
+	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "rendering/occlusion_culling/soft_cull_lod_bias", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), 0.0);
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/environment/glow/upscale_mode", PROPERTY_HINT_ENUM, "Linear (Fast),Bicubic (Slow)"), 1);
 	GLOBAL_DEF("rendering/environment/glow/upscale_mode.mobile", 0);


### PR DESCRIPTION
Occlusion "soft-culling" has less noticeable artifacts (LOD popping) than standard "hard-culling" (disappearing/flickering meshes):

https://user-images.githubusercontent.com/103326468/233419333-795560f0-39c7-465b-9a49-86ccf17b152f.mp4

This opens the door for more aggressive occlusion settings, and allows meshes that wouldn't normally be considered candidates for acting as occluders (trees/vegetation, vents, rough/dirty windows, smoke and other particles, etc) to be made feasible for that purpose.

This puts a greater reliance on depth testing to prevent overshading (Hierarchical Z makes this very cheap for low polycounts) and HLOD/visibility ranges to reduce draw calls.

Adds three new project settings:

- `rendering/occlusion_culling/soft_cull_lod_bias`
  LOD bias multiplier for occluded objects. 0 disables soft-culling (reverts to standard hard-culling)

https://github.com/godotengine/godot/assets/103326468/84a1520a-fd69-47d8-835c-967dc9b65f45

Left: `soft_cull_lod_bias` = 0 (hard-culling)
Right: `soft_cull_lod_bias` = 0.05

- `rendering/occlusion_culling/bounds_scale`
  Scale factor for occludee bounding boxes. Allows objects to be culled before they're fully occluded. Changing this is not recommended when hard-culling is active.

https://user-images.githubusercontent.com/103326468/233420140-6d67c867-9112-4ae7-a3bd-8fd529f7a3d3.mp4

Left: `bounds_scale` = 0.6
Right: `bounds_scale` = 0.1 (extreme value for demonstration purpose)

- `rendering/mesh_lod/lod_change/shadow_lod_bias`
  LOD bias multiplier for shadow passes. This had to be separated out from the normal LOD bias to avoid shadow popping artifacts, so it was easier to just include it in this PR.

Depends on #74118, marked as draft until that one is merged 

Fixes #53288
Fixes #63771
Fixes godotengine/godot-proposals#2600