### PR TITLE
CI: Fix checks fallback logic when changed files listing is missing

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Python style checks via black (black_format.sh)
         run: |
-          if grep -qE '*\.py|SConstruct|SCsub' changed.txt || [ ! -s changed.txt ]; then
+          if grep -qE '\.py$|SConstruct|SCsub' changed.txt || [ -z "$(cat changed.txt)" ]; then
             bash ./misc/scripts/black_format.sh
           else
             echo "Skipping Python formatting as no Python files were changed."
@@ -55,7 +55,7 @@ jobs:
 
       - name: Python scripts static analysis (mypy_check.sh)
         run: |
-          if grep -qE '*\.py|SConstruct|SCsub' changed.txt || [ ! -s changed.txt ]; then
+          if grep -qE '\.py$|SConstruct|SCsub' changed.txt || [ -z "$(cat changed.txt)" ]; then
             bash ./misc/scripts/mypy_check.sh
           else
             echo "Skipping Python static analysis as no Python files were changed."
@@ -67,7 +67,7 @@ jobs:
 
       - name: JavaScript style and documentation checks via ESLint and JSDoc
         run: |
-          if grep -q "platform/web" changed.txt || [ ! -s changed.txt ]; then
+          if grep -q "platform/web" changed.txt || [ -z "$(cat changed.txt)" ]; then
             cd platform/web
             npm ci
             npm run lint
@@ -91,7 +91,7 @@ jobs:
 
       - name: Style checks via dotnet format (dotnet_format.sh)
         run: |
-          if grep -q "modules/mono" changed.txt || [ ! -s changed.txt ]; then
+          if grep -q "modules/mono" changed.txt || [ -z "$(cat changed.txt)" ]; then
             bash ./misc/scripts/dotnet_format.sh
           else
             echo "Skipping dotnet format as no C# files were changed."


### PR DESCRIPTION
Follow-up to #76263 and #76296.

The file would be one byte (newline) so the check with '-s' failed.