### PR TITLE
C#: Add option to embed dotnet build outputs into the data file

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -3,6 +3,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using GodotTools.Build;
 using GodotTools.Core;
 using GodotTools.Internals;
@@ -45,6 +47,17 @@ namespace GodotTools.Export
                         }
                     },
                     { "default_value", true }
+                },
+                new Godot.Collections.Dictionary()
+                {
+                    {
+                        "option", new Godot.Collections.Dictionary()
+                        {
+                            { "name", "dotnet/embed_build_outputs" },
+                            { "type", (int)Variant.Type.Bool }
+                        }
+                    },
+                    { "default_value", false }
                 }
             };
         }
@@ -146,6 +159,8 @@ namespace GodotTools.Export
                 }
             }
 
+            bool embedBuildResults = (bool)GetOption("dotnet/embed_build_outputs");
+
             foreach (var arch in archs)
             {
                 string ridOS = DetermineRuntimeIdentifierOS(platform);
@@ -190,15 +205,42 @@ namespace GodotTools.Export
                         "Publish succeeded but project assembly not found in the output directory");
                 }
 
-                // Add to the exported project shared object list.
+                var manifest = new StringBuilder();
 
+                // Add to the exported project shared object list or packed resources.
                 foreach (string file in Directory.GetFiles(publishOutputTempDir, "*", SearchOption.AllDirectories))
                 {
-                    AddSharedObject(file, tags: null,
-                        Path.Join(projectDataDirName,
-                            Path.GetRelativePath(publishOutputTempDir, Path.GetDirectoryName(file))));
+                    if (embedBuildResults)
+                    {
+                        var filePath = SanitizeSlashes(Path.GetRelativePath(publishOutputTempDir, file));
+                        var fileData = File.ReadAllBytes(file);
+                        var hash = Convert.ToBase64String(SHA512.HashData(fileData));
+
+                        manifest.Append($"{filePath}\t{hash}\n");
+
+                        AddFile($"res://.godot/mono/publish/{arch}/{filePath}", fileData, false);
+                    }
+                    else
+                    {
+                        AddSharedObject(file, tags: null,
+                            Path.Join(projectDataDirName,
+                                Path.GetRelativePath(publishOutputTempDir, Path.GetDirectoryName(file))));
+                    }
+                }
+
+                if (embedBuildResults)
+                {
+                    var fileData = Encoding.Default.GetBytes(manifest.ToString());
+                    AddFile($"res://.godot/mono/publish/{arch}/.dotnet-publish-manifest", fileData, false);
                 }
             }
+        }
+
+        private string SanitizeSlashes(string path)
+        {
+            if (Path.DirectorySeparatorChar == '\\')
+                return path.Replace('\\', '/');
+            return path;
         }
 
         private string DetermineRuntimeIdentifierOS(string platform)


### PR DESCRIPTION
Extracted from #73257. Somewhat related issue: https://github.com/godotengine/godot/issues/72159

This is largely equivalent to the `mono/export/export_assemblies_inside_pck` project setting from 3.x.
Adds an export option that, when enabled, embeds the C# build outputs into the pck/zip instead of having them as loose files. For execution these files have to be extracted to some temporary location to be able to load them.

Together with the embed pck option this allows for single file exports of C# project for windows and linux.

Open Question: What is the best place to put the published outputs for execution?
Currently they are extracted into `OS::get_singleton()->get_cache_path().path_join("data_" + appname_safe + "_" + arch)`, which on windows ends up in `AppData/Local` which is not a folder that can really be cleaned out as per user app installations often end up there and thus these files are likely to remain there forever.
