### PR TITLE
[3.x] Additive Animation Fix (and Sub2 node feature)

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -37,6 +37,7 @@
 			<argument index="3" name="blend" type="float" />
 			<argument index="4" name="filter" type="int" enum="AnimationNode.FilterAction" default="0" />
 			<argument index="5" name="optimize" type="bool" default="true" />
+			<argument index="6" name="use_blend" type="bool" default="true" />
 			<description>
 				Blend an input. This is only useful for nodes created for an [AnimationNodeBlendTree]. The [code]time[/code] parameter is a relative delta, unless [code]seek[/code] is [code]true[/code], in which case it is absolute. A filter mode may be optionally passed (see [enum FilterAction] for options).
 			</description>
@@ -50,6 +51,7 @@
 			<argument index="4" name="blend" type="float" />
 			<argument index="5" name="filter" type="int" enum="AnimationNode.FilterAction" default="0" />
 			<argument index="6" name="optimize" type="bool" default="true" />
+			<argument index="7" name="use_blend" type="bool" default="true" />
 			<description>
 				Blend another animation node (in case this node contains children animation nodes). This function is only useful if you inherit from [AnimationRootNode] instead, else editors will not display your node for addition.
 			</description>

--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -49,9 +49,9 @@
 			<argument index="2" name="time" type="float" />
 			<argument index="3" name="seek" type="bool" />
 			<argument index="4" name="blend" type="float" />
-			<argument index="5" name="filter" type="int" enum="AnimationNode.FilterAction" />
+			<argument index="5" name="filter" type="int" enum="AnimationNode.FilterAction" default="0" />
 			<argument index="6" name="optimize" type="bool" default="true" />
-			<argument index="7" name="blend_use" type="bool" default="true" />
+			<argument index="7" name="use_blend" type="bool" default="true" />
 			<description>
 				Blend another animation node (in case this node contains children animation nodes). This function is only useful if you inherit from [AnimationRootNode] instead, else editors will not display your node for addition.
 			</description>

--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -49,9 +49,9 @@
 			<argument index="2" name="time" type="float" />
 			<argument index="3" name="seek" type="bool" />
 			<argument index="4" name="blend" type="float" />
-			<argument index="5" name="filter" type="int" enum="AnimationNode.FilterAction" default="0" />
+			<argument index="5" name="filter" type="int" enum="AnimationNode.FilterAction" />
 			<argument index="6" name="optimize" type="bool" default="true" />
-			<argument index="7" name="use_blend" type="bool" default="true" />
+			<argument index="7" name="blend_use" type="bool" default="true" />
 			<description>
 				Blend another animation node (in case this node contains children animation nodes). This function is only useful if you inherit from [AnimationRootNode] instead, else editors will not display your node for addition.
 			</description>

--- a/doc/classes/AnimationNodeAdd2.xml
+++ b/doc/classes/AnimationNodeAdd2.xml
@@ -13,7 +13,7 @@
 	</methods>
 	<members>
 		<member name="add_directly" type="bool" setter="set_add_directly" getter="get_add_directly" default="false">
-			If [code]true[/code], transform tracks will have their location and rotation applied directly. Normal behaviour, when [code]false[/false], adds transforms using blending (linear interpolation).
+			If [code]true[/code], transform tracks will have their location and rotation applied directly. Normal behaviour, when [code]false[/code], adds transforms using blending (linear interpolation).
 		</member>
 		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
 			If [code]true[/code], sets the [code]optimization[/code] to [code]false[/code] when calling [method AnimationNode.blend_input], forcing the blended animations to update every frame.

--- a/doc/classes/AnimationNodeAdd2.xml
+++ b/doc/classes/AnimationNodeAdd2.xml
@@ -12,6 +12,9 @@
 	<methods>
 	</methods>
 	<members>
+		<member name="add_directly" type="bool" setter="set_add_directly" getter="get_add_directly" default="false">
+			If [code]true[/code], transform tracks will have their location and rotation applied directly. Normal behaviour, when [code]false[/false], adds transforms using blending (linear interpolation).
+		</member>
 		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
 			If [code]true[/code], sets the [code]optimization[/code] to [code]false[/code] when calling [method AnimationNode.blend_input], forcing the blended animations to update every frame.
 		</member>

--- a/doc/classes/AnimationNodeAdd2.xml
+++ b/doc/classes/AnimationNodeAdd2.xml
@@ -13,7 +13,7 @@
 	</methods>
 	<members>
 		<member name="add_directly" type="bool" setter="set_add_directly" getter="get_add_directly" default="false">
-			If [code]true[/code], transform tracks will have their location and rotation applied directly. Normal behaviour, when [code]false[/code], adds transforms using blending (linear interpolation).
+			If [code]true[/code], transform tracks will have their location and rotation applied directly. Normal behavior, when [code]false[/code], adds transforms using blending (linear interpolation).
 		</member>
 		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
 			If [code]true[/code], sets the [code]optimization[/code] to [code]false[/code] when calling [method AnimationNode.blend_input], forcing the blended animations to update every frame.

--- a/doc/classes/AnimationNodeSub2.xml
+++ b/doc/classes/AnimationNodeSub2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AnimationNodeSub2" inherits="AnimationNode" version="3.6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Blends two animations subtractively inside of an [AnimationNodeBlendTree].
+	</brief_description>
+	<description>
+		A resource to add to an [AnimationNodeBlendTree]. Blends two animations subtractively based on an amount value in the [code][0.0, 1.0][/code] range. The direct inverse of the Add2 node.
+	</description>
+	<tutorials>
+		<link>$DOCS_URL/tutorials/animation/animation_tree.html</link>
+	</tutorials>
+	<methods>
+	</methods>
+	<members>
+		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
+			If [code]true[/code], sets the [code]optimization[/code] to [code]false[/code] when calling [method AnimationNode.blend_input], forcing the blended animations to update every frame.
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -986,6 +986,7 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 
 	add_options.push_back(AddOption("Animation", "AnimationNodeAnimation"));
 	add_options.push_back(AddOption("OneShot", "AnimationNodeOneShot", 2));
+	add_options.push_back(AddOption("Sub2", "AnimationNodeSub2", 2));
 	add_options.push_back(AddOption("Add2", "AnimationNodeAdd2", 2));
 	add_options.push_back(AddOption("Add3", "AnimationNodeAdd3", 3));
 	add_options.push_back(AddOption("Blend2", "AnimationNodeBlend2", 2));

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -189,7 +189,7 @@ float AnimationNodeOneShot::get_autorestart_random_delay() const {
 void AnimationNodeOneShot::set_mix_mode(MixMode p_mix) {
 	mix = p_mix;
 }
-AnimationNodeOneShot::MixMode AnimationNodeOneShot::get_mix_mode() const {
+AnimationNode::MixMode AnimationNodeOneShot::get_mix_mode() const {
 	return mix;
 }
 
@@ -359,6 +359,50 @@ AnimationNodeOneShot::AnimationNodeOneShot() {
 	time_to_restart = "time_to_restart";
 }
 
+
+////////////////////////////////////////////////
+
+void AnimationNodeSub2::get_parameter_list(List<PropertyInfo> *r_list) const {
+}
+
+Variant AnimationNodeSub2::get_parameter_default_value(const StringName &p_parameter) const {
+	return 0;
+}
+
+String AnimationNodeSub2::get_caption() const {
+	return "Sub2";
+}
+void AnimationNodeSub2::set_use_sync(bool p_sync) {
+	sync = p_sync;
+}
+
+bool AnimationNodeSub2::is_using_sync() const {
+	return sync;
+}
+
+bool AnimationNodeSub2::has_filter() const {
+	return true;
+}
+
+float AnimationNodeSub2::process(float p_time, bool p_seek) {
+	float rem0 = blend_input(0, p_time, p_seek, 1.0, FILTER_IGNORE, !sync, MIX_MODE_BLEND);
+	blend_input(1, p_time, p_seek, 1.0, FILTER_PASS, !sync, MIX_MODE_SUB);
+
+	return rem0;
+}
+
+void AnimationNodeSub2::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_use_sync", "enable"), &AnimationNodeSub2::set_use_sync);
+	ClassDB::bind_method(D_METHOD("is_using_sync"), &AnimationNodeSub2::is_using_sync);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sync"), "set_use_sync", "is_using_sync");
+}
+
+AnimationNodeSub2::AnimationNodeSub2() {
+	add_input("in");
+	add_input("sub");
+	sync = false;
+}
+
 ////////////////////////////////////////////////
 
 void AnimationNodeAdd2::get_parameter_list(List<PropertyInfo> *r_list) const {
@@ -379,6 +423,14 @@ bool AnimationNodeAdd2::is_using_sync() const {
 	return sync;
 }
 
+void AnimationNodeAdd2::set_add_directly(bool p_add_directly) {
+	add_directly = p_add_directly;
+}
+
+bool AnimationNodeAdd2::get_add_directly() const {
+	return add_directly;
+}
+
 bool AnimationNodeAdd2::has_filter() const {
 	return true;
 }
@@ -386,7 +438,7 @@ bool AnimationNodeAdd2::has_filter() const {
 float AnimationNodeAdd2::process(float p_time, bool p_seek) {
 	float amount = get_parameter(add_amount);
 	float rem0 = blend_input(0, p_time, p_seek, 1.0, FILTER_IGNORE, !sync);
-	blend_input(1, p_time, p_seek, amount, FILTER_PASS, !sync);
+	blend_input(1, p_time, p_seek, amount, FILTER_PASS, !sync, add_directly ? MIX_MODE_ADD_DIRECT : MIX_MODE_ADD);
 
 	return rem0;
 }
@@ -395,7 +447,11 @@ void AnimationNodeAdd2::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_sync", "enable"), &AnimationNodeAdd2::set_use_sync);
 	ClassDB::bind_method(D_METHOD("is_using_sync"), &AnimationNodeAdd2::is_using_sync);
 
+	ClassDB::bind_method(D_METHOD("set_add_directly", "enable"), &AnimationNodeAdd2::set_add_directly);
+	ClassDB::bind_method(D_METHOD("get_add_directly"), &AnimationNodeAdd2::get_add_directly);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sync"), "set_use_sync", "is_using_sync");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "add_directly"), "set_add_directly", "get_add_directly");
 }
 
 AnimationNodeAdd2::AnimationNodeAdd2() {
@@ -403,6 +459,7 @@ AnimationNodeAdd2::AnimationNodeAdd2() {
 	add_input("in");
 	add_input("add");
 	sync = false;
+	add_directly = false;
 }
 
 ////////////////////////////////////////////////

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -372,6 +372,7 @@ Variant AnimationNodeSub2::get_parameter_default_value(const StringName &p_param
 String AnimationNodeSub2::get_caption() const {
 	return "Sub2";
 }
+
 void AnimationNodeSub2::set_use_sync(bool p_sync) {
 	sync = p_sync;
 }

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -362,7 +362,7 @@ AnimationNodeOneShot::AnimationNodeOneShot() {
 ////////////////////////////////////////////////
 
 void AnimationNodeSub2::get_parameter_list(List<PropertyInfo> *r_list) const {
-	r_list->push_back(PropertyInfo(Variant::REAL, sub_amount, PROPERTY_HINT_RANGE, "0,1,0.01,or_less,or_greater"));
+	r_list->push_back(PropertyInfo(Variant::REAL, sub_amount, PROPERTY_HINT_RANGE, "0,1,0.01"));
 }
 
 Variant AnimationNodeSub2::get_parameter_default_value(const StringName &p_parameter) const {
@@ -385,11 +385,11 @@ bool AnimationNodeSub2::has_filter() const {
 }
 
 float AnimationNodeSub2::process(float p_time, bool p_seek) {
-	double amount = get_parameter(sub_amount);
 	// Out = Sub.Transform3D^(-1) * In.Transform3D
-	blend_input(1, p_time, p_seek, -amount, FILTER_PASS, sync, false);
-	return blend_input(0, p_time, p_seek, 1.0, FILTER_IGNORE, sync);
-
+	float amount = get_parameter(sub_amount);
+	float rem0 = blend_input(0, p_time, p_seek, 1.0, FILTER_IGNORE, sync, true); // in
+	blend_input(1, p_time, p_seek, -amount, FILTER_PASS, sync, false); // sub
+	return rem0;
 }
 
 void AnimationNodeSub2::_bind_methods() {
@@ -439,9 +439,8 @@ bool AnimationNodeAdd2::has_filter() const {
 
 float AnimationNodeAdd2::process(float p_time, bool p_seek) {
 	float amount = get_parameter(add_amount);
-	float rem0 = blend_input(0, p_time, p_seek, 1.0, FILTER_IGNORE, !sync);
-	blend_input(1, p_time, p_seek, amount, FILTER_PASS, !sync, !add_directly);
-
+	float rem0 = blend_input(0, p_time, p_seek, 1.0, FILTER_IGNORE, sync, true);
+	blend_input(1, p_time, p_seek, amount, FILTER_PASS, sync, add_directly ? false : true);
 	return rem0;
 }
 

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -189,7 +189,7 @@ float AnimationNodeOneShot::get_autorestart_random_delay() const {
 void AnimationNodeOneShot::set_mix_mode(MixMode p_mix) {
 	mix = p_mix;
 }
-AnimationNode::MixMode AnimationNodeOneShot::get_mix_mode() const {
+AnimationNodeOneShot::MixMode AnimationNodeOneShot::get_mix_mode() const {
 	return mix;
 }
 
@@ -362,6 +362,7 @@ AnimationNodeOneShot::AnimationNodeOneShot() {
 ////////////////////////////////////////////////
 
 void AnimationNodeSub2::get_parameter_list(List<PropertyInfo> *r_list) const {
+	r_list->push_back(PropertyInfo(Variant::REAL, sub_amount, PROPERTY_HINT_RANGE, "0,1,0.01,or_less,or_greater"));
 }
 
 Variant AnimationNodeSub2::get_parameter_default_value(const StringName &p_parameter) const {
@@ -384,10 +385,11 @@ bool AnimationNodeSub2::has_filter() const {
 }
 
 float AnimationNodeSub2::process(float p_time, bool p_seek) {
-	float rem0 = blend_input(0, p_time, p_seek, 1.0, FILTER_IGNORE, !sync, MIX_MODE_BLEND);
-	blend_input(1, p_time, p_seek, 1.0, FILTER_PASS, !sync, MIX_MODE_SUB);
+	double amount = get_parameter(sub_amount);
+	// Out = Sub.Transform3D^(-1) * In.Transform3D
+	blend_input(1, p_time, p_seek, -amount, FILTER_PASS, sync, false);
+	return blend_input(0, p_time, p_seek, 1.0, FILTER_IGNORE, sync);
 
-	return rem0;
 }
 
 void AnimationNodeSub2::_bind_methods() {
@@ -397,6 +399,7 @@ void AnimationNodeSub2::_bind_methods() {
 }
 
 AnimationNodeSub2::AnimationNodeSub2() {
+	sub_amount = PNAME("sub_amount");
 	add_input("in");
 	add_input("sub");
 	sync = false;
@@ -437,7 +440,7 @@ bool AnimationNodeAdd2::has_filter() const {
 float AnimationNodeAdd2::process(float p_time, bool p_seek) {
 	float amount = get_parameter(add_amount);
 	float rem0 = blend_input(0, p_time, p_seek, 1.0, FILTER_IGNORE, !sync);
-	blend_input(1, p_time, p_seek, amount, FILTER_PASS, !sync, add_directly ? MIX_MODE_ADD_DIRECT : MIX_MODE_ADD);
+	blend_input(1, p_time, p_seek, amount, FILTER_PASS, !sync, !add_directly);
 
 	return rem0;
 }

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -359,7 +359,6 @@ AnimationNodeOneShot::AnimationNodeOneShot() {
 	time_to_restart = "time_to_restart";
 }
 
-
 ////////////////////////////////////////////////
 
 void AnimationNodeSub2::get_parameter_list(List<PropertyInfo> *r_list) const {

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -65,10 +65,12 @@ class AnimationNodeOneShot : public AnimationNode {
 	GDCLASS(AnimationNodeOneShot, AnimationNode);
 
 public:
+	/*
 	enum MixMode {
 		MIX_MODE_BLEND,
 		MIX_MODE_ADD
 	};
+	*/
 
 private:
 	float fade_in;
@@ -77,7 +79,7 @@ private:
 	bool autorestart;
 	float autorestart_delay;
 	float autorestart_random_delay;
-	MixMode mix;
+	//MixMode mix;
 
 	bool sync;
 
@@ -127,12 +129,11 @@ public:
 	AnimationNodeOneShot();
 };
 
-VARIANT_ENUM_CAST(AnimationNodeOneShot::MixMode)
+VARIANT_ENUM_CAST(AnimationNode::MixMode)
 
-class AnimationNodeAdd2 : public AnimationNode {
-	GDCLASS(AnimationNodeAdd2, AnimationNode);
+class AnimationNodeSub2 : public AnimationNode {
+	GDCLASS(AnimationNodeSub2, AnimationNode);
 
-	StringName add_amount;
 	bool sync;
 
 protected:
@@ -146,6 +147,33 @@ public:
 
 	void set_use_sync(bool p_sync);
 	bool is_using_sync() const;
+
+	virtual bool has_filter() const;
+	virtual float process(float p_time, bool p_seek);
+
+	AnimationNodeSub2();
+};
+class AnimationNodeAdd2 : public AnimationNode {
+	GDCLASS(AnimationNodeAdd2, AnimationNode);
+
+	StringName add_amount;
+	bool sync;
+	bool add_directly;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void get_parameter_list(List<PropertyInfo> *r_list) const;
+	virtual Variant get_parameter_default_value(const StringName &p_parameter) const;
+
+	virtual String get_caption() const;
+
+	void set_use_sync(bool p_sync);
+	bool is_using_sync() const;
+
+	void set_add_directly(bool p_add_directly);
+	bool get_add_directly() const;
 
 	virtual bool has_filter() const;
 	virtual float process(float p_time, bool p_seek);

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -152,6 +152,7 @@ public:
 
 	AnimationNodeSub2();
 };
+
 class AnimationNodeAdd2 : public AnimationNode {
 	GDCLASS(AnimationNodeAdd2, AnimationNode);
 

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -133,7 +133,7 @@ class AnimationNodeSub2 : public AnimationNode {
 
 	bool sync;
 
-	StringName sub_amount = PNAME("sub_amount");
+	StringName sub_amount;
 
 protected:
 	static void _bind_methods();

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -65,12 +65,10 @@ class AnimationNodeOneShot : public AnimationNode {
 	GDCLASS(AnimationNodeOneShot, AnimationNode);
 
 public:
-	/*
 	enum MixMode {
 		MIX_MODE_BLEND,
 		MIX_MODE_ADD
 	};
-	*/
 
 private:
 	float fade_in;
@@ -79,8 +77,7 @@ private:
 	bool autorestart;
 	float autorestart_delay;
 	float autorestart_random_delay;
-	//MixMode mix;
-
+	MixMode mix;
 	bool sync;
 
 	/*	bool active;
@@ -129,12 +126,14 @@ public:
 	AnimationNodeOneShot();
 };
 
-VARIANT_ENUM_CAST(AnimationNode::MixMode)
+VARIANT_ENUM_CAST(AnimationNodeOneShot::MixMode)
 
 class AnimationNodeSub2 : public AnimationNode {
 	GDCLASS(AnimationNodeSub2, AnimationNode);
 
 	bool sync;
+
+	StringName sub_amount = PNAME("sub_amount");
 
 protected:
 	static void _bind_methods();

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -78,6 +78,7 @@ private:
 	float autorestart_delay;
 	float autorestart_random_delay;
 	MixMode mix;
+
 	bool sync;
 
 	/*	bool active;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -112,6 +112,9 @@ void AnimationNode::blend_animation(const StringName &p_animation, float p_time,
 	anim_state.time = p_time;
 	anim_state.animation = animation;
 	anim_state.seeked = p_seeked;
+	anim_state.mix = mix;
+
+	mix = MIX_MODE_BLEND; // reset?
 
 	state->animation_states.push_back(anim_state);
 }
@@ -141,7 +144,7 @@ void AnimationNode::make_invalid(const String &p_reason) {
 	state->invalid_reasons += String::utf8("• ") + p_reason;
 }
 
-float AnimationNode::blend_input(int p_input, float p_time, bool p_seek, float p_blend, FilterAction p_filter, bool p_optimize) {
+float AnimationNode::blend_input(int p_input, float p_time, bool p_seek, float p_blend, FilterAction p_filter, bool p_optimize, MixMode p_mix) {
 	ERR_FAIL_INDEX_V(p_input, inputs.size(), 0);
 	ERR_FAIL_COND_V(!state, 0);
 
@@ -154,6 +157,14 @@ float AnimationNode::blend_input(int p_input, float p_time, bool p_seek, float p
 		String name = blend_tree->get_node_name(Ref<AnimationNode>(this));
 		make_invalid(vformat(RTR("Nothing connected to input '%s' of node '%s'."), get_input_name(p_input), name));
 		return 0;
+	} else {
+		Ref<AnimationNode> node = blend_tree->get_node(node_name);
+		// this is some hacky bs to make it pass down to children
+		if (p_mix == MIX_MODE_BLEND) {
+			node->mix = mix; // use parent flag
+		} else {
+			node->mix = p_mix; // use parameter
+		}
 	}
 
 	Ref<AnimationNode> node = blend_tree->get_node(node_name);
@@ -412,7 +423,7 @@ void AnimationNode::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("blend_animation", "animation", "time", "delta", "seeked", "blend"), &AnimationNode::blend_animation);
 	ClassDB::bind_method(D_METHOD("blend_node", "name", "node", "time", "seek", "blend", "filter", "optimize"), &AnimationNode::blend_node, DEFVAL(FILTER_IGNORE), DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("blend_input", "input_index", "time", "seek", "blend", "filter", "optimize"), &AnimationNode::blend_input, DEFVAL(FILTER_IGNORE), DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("blend_input", "input_index", "time", "seek", "blend", "filter", "optimize", "mix"), &AnimationNode::blend_input, DEFVAL(FILTER_IGNORE), DEFVAL(true), DEFVAL(MIX_MODE_BLEND));
 
 	ClassDB::bind_method(D_METHOD("set_parameter", "name", "value"), &AnimationNode::set_parameter);
 	ClassDB::bind_method(D_METHOD("get_parameter", "name"), &AnimationNode::get_parameter);
@@ -446,6 +457,7 @@ AnimationNode::AnimationNode() {
 	state = nullptr;
 	parent = nullptr;
 	filter_enabled = false;
+	mix = MIX_MODE_BLEND;
 }
 
 ////////////////////
@@ -922,7 +934,42 @@ void AnimationTree::_process_graph(float p_delta) {
 							if (err != OK) {
 								continue;
 							}
+							
+							if (as.mix == AnimationNode::MIX_MODE_BLEND || as.mix == AnimationNode::MIX_MODE_ADD) {
+									t->loc = t->loc.linear_interpolate(loc, blend);
+									if (t->rot_blend_accum == 0) {
+										t->rot = rot;
+										t->rot_blend_accum = blend;
+									} else {
+										float rot_total = t->rot_blend_accum + blend;
+										t->rot = rot.slerp(t->rot, t->rot_blend_accum / rot_total).normalized();
+										t->rot_blend_accum = rot_total;
+									}
+									t->scale = t->scale.linear_interpolate(scale, blend);
+							} else if (as.mix == AnimationNode::MIX_MODE_ADD_DIRECT) {
+								//ERR_PRINT("add direct");
 
+								t->loc += loc * blend;
+								t->scale = t->scale.linear_interpolate(scale, blend);
+
+								Quat q = Quat().slerp(rot.normalized(),  blend).normalized();
+								t->rot = (t->rot * q).normalized();
+
+								//Quat q = Quat().slerp(rot.normalized(), blend).normalized();
+								//t->rot = (t->rot * q).normalized();
+							} else if (as.mix == AnimationNode::MIX_MODE_SUB) {
+								//ERR_PRINT("sub");
+
+								t->loc -= loc * blend;
+								t->scale = t->scale.linear_interpolate(scale, blend);
+
+								Quat q = Quat().slerp(rot.normalized().inverse(),  blend).normalized();
+								t->rot = (t->rot * q).normalized();
+
+								//Quat q = Quat().slerp(rot.normalized().inverse(), blend).normalized();
+								//t->rot = (t->rot * q).normalized();
+							}
+							/*
 							t->loc = t->loc.linear_interpolate(loc, blend);
 							if (t->rot_blend_accum == 0) {
 								t->rot = rot;
@@ -933,6 +980,7 @@ void AnimationTree::_process_graph(float p_delta) {
 								t->rot_blend_accum = rot_total;
 							}
 							t->scale = t->scale.linear_interpolate(scale, blend);
+							*/
 						}
 
 					} break;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -933,7 +933,7 @@ void AnimationTree::_process_graph(float p_delta) {
 								t->scale = scale;
 							}
 
-							if (err != OK) { // error happens when I animated an object transform manually?? fix
+							if (err != OK) { // Error happens when I animated an object transform manually?? fix.
 								continue;
 							}
 

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -189,8 +189,8 @@ float AnimationNode::_blend_node(const StringName &p_subpath, const Vector<Strin
 
 	// If an animation node sets use_blend to false it must remain false
 	// this is a way to make it pass down the tree. Without this
-	// the next node, which will often set use_blend to true, will 
-	// override our request for use_blend false. 
+	// the next node, which will often set use_blend to true, will
+	// override our request for use_blend false.
 	if (p_use_blend) {
 		// use self
 		p_node->use_blend = this->use_blend;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -190,13 +190,7 @@ float AnimationNode::_blend_node(const StringName &p_subpath, const Vector<Strin
 	// this is a way to make it pass down the tree. Without this
 	// the next node, which will often set use_blend to true, will
 	// override our request for use_blend false.
-	if (p_use_blend) {
-		// use self
-		p_node->use_blend = this->use_blend;
-	} else {
-		// use parameter
-		p_node->use_blend = p_use_blend;
-	}
+	p_node->use_blend = p_use_blend && use_blend;
 
 	float *blendw = p_node->blends.ptrw();
 	const float *blendr = blends.ptr();

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -114,7 +114,6 @@ void AnimationNode::blend_animation(const StringName &p_animation, float p_time,
 	anim_state.seeked = p_seeked;
 	anim_state.use_blend = use_blend;
 
-
 	state->animation_states.push_back(anim_state);
 }
 

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -949,7 +949,7 @@ void AnimationTree::_process_graph(float p_delta) {
 									t->rot_blend_accum = rot_total;
 								}
 							} else {
-								// Direct addition / subtraction
+								// Direct addition / subtraction.
 								t->loc += loc * blend;
 								Quat q = Quat();
 								q = q.slerp(rot.normalized(), blend).normalized();

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -934,7 +934,7 @@ void AnimationTree::_process_graph(float p_delta) {
 							if (err != OK) {
 								continue;
 							}
-							
+
 							if (as.mix == AnimationNode::MIX_MODE_BLEND || as.mix == AnimationNode::MIX_MODE_ADD) {
 									t->loc = t->loc.linear_interpolate(loc, blend);
 									if (t->rot_blend_accum == 0) {
@@ -947,40 +947,18 @@ void AnimationTree::_process_graph(float p_delta) {
 									}
 									t->scale = t->scale.linear_interpolate(scale, blend);
 							} else if (as.mix == AnimationNode::MIX_MODE_ADD_DIRECT) {
-								//ERR_PRINT("add direct");
-
 								t->loc += loc * blend;
 								t->scale = t->scale.linear_interpolate(scale, blend);
 
 								Quat q = Quat().slerp(rot.normalized(),  blend).normalized();
 								t->rot = (t->rot * q).normalized();
-
-								//Quat q = Quat().slerp(rot.normalized(), blend).normalized();
-								//t->rot = (t->rot * q).normalized();
 							} else if (as.mix == AnimationNode::MIX_MODE_SUB) {
-								//ERR_PRINT("sub");
-
 								t->loc -= loc * blend;
 								t->scale = t->scale.linear_interpolate(scale, blend);
 
 								Quat q = Quat().slerp(rot.normalized().inverse(),  blend).normalized();
 								t->rot = (t->rot * q).normalized();
-
-								//Quat q = Quat().slerp(rot.normalized().inverse(), blend).normalized();
-								//t->rot = (t->rot * q).normalized();
 							}
-							/*
-							t->loc = t->loc.linear_interpolate(loc, blend);
-							if (t->rot_blend_accum == 0) {
-								t->rot = rot;
-								t->rot_blend_accum = blend;
-							} else {
-								float rot_total = t->rot_blend_accum + blend;
-								t->rot = rot.slerp(t->rot, t->rot_blend_accum / rot_total).normalized();
-								t->rot_blend_accum = rot_total;
-							}
-							t->scale = t->scale.linear_interpolate(scale, blend);
-							*/
 						}
 
 					} break;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -279,7 +279,7 @@ float AnimationNode::_blend_node(const StringName &p_subpath, const Vector<Strin
 	if (r_max) {
 		*r_max = 0;
 		for (int i = 0; i < blend_count; i++) {
-			*r_max = MAX(*r_max, Math::absf(blendw[i])); // to account for negative blend weights as used by Sub2 nodes
+			*r_max = MAX(*r_max, Math::absf(blendw[i])); // To account for negative blend weights as used by Sub2 nodes.
 		}
 	}
 

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -936,27 +936,27 @@ void AnimationTree::_process_graph(float p_delta) {
 							}
 
 							if (as.mix == AnimationNode::MIX_MODE_BLEND || as.mix == AnimationNode::MIX_MODE_ADD) {
-									t->loc = t->loc.linear_interpolate(loc, blend);
-									if (t->rot_blend_accum == 0) {
-										t->rot = rot;
-										t->rot_blend_accum = blend;
-									} else {
-										float rot_total = t->rot_blend_accum + blend;
-										t->rot = rot.slerp(t->rot, t->rot_blend_accum / rot_total).normalized();
-										t->rot_blend_accum = rot_total;
-									}
-									t->scale = t->scale.linear_interpolate(scale, blend);
+								t->loc = t->loc.linear_interpolate(loc, blend);
+								if (t->rot_blend_accum == 0) {
+									t->rot = rot;
+									t->rot_blend_accum = blend;
+								} else {
+									float rot_total = t->rot_blend_accum + blend;
+									t->rot = rot.slerp(t->rot, t->rot_blend_accum / rot_total).normalized();
+									t->rot_blend_accum = rot_total;
+								}
+								t->scale = t->scale.linear_interpolate(scale, blend);
 							} else if (as.mix == AnimationNode::MIX_MODE_ADD_DIRECT) {
 								t->loc += loc * blend;
 								t->scale = t->scale.linear_interpolate(scale, blend);
 
-								Quat q = Quat().slerp(rot.normalized(),  blend).normalized();
+								Quat q = Quat().slerp(rot.normalized(), blend).normalized();
 								t->rot = (t->rot * q).normalized();
 							} else if (as.mix == AnimationNode::MIX_MODE_SUB) {
 								t->loc -= loc * blend;
 								t->scale = t->scale.linear_interpolate(scale, blend);
 
-								Quat q = Quat().slerp(rot.normalized().inverse(),  blend).normalized();
+								Quat q = Quat().slerp(rot.normalized().inverse(), blend).normalized();
 								t->rot = (t->rot * q).normalized();
 							}
 						}

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1032,6 +1032,7 @@ void AnimationTree::_process_graph(float p_delta) {
 							t->value = bezier;
 							t->process_pass = process_pass;
 						}
+
 						t->value = Math::lerp(t->value, bezier, blend);
 
 					} break;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -424,7 +424,7 @@ void AnimationNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_get_filters"), &AnimationNode::_get_filters);
 
 	ClassDB::bind_method(D_METHOD("blend_animation", "animation", "time", "delta", "seeked", "blend"), &AnimationNode::blend_animation);
-	ClassDB::bind_method(D_METHOD("blend_node", "name", "node", "time", "seek", "blend", "filter", "optimize"), &AnimationNode::blend_node, DEFVAL(FILTER_IGNORE), DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("blend_node", "name", "node", "time", "seek", "blend", "filter", "optimize", "use_blend"), &AnimationNode::blend_node, DEFVAL(FILTER_IGNORE), DEFVAL(true), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("blend_input", "input_index", "time", "seek", "blend", "filter", "optimize", "use_blend"), &AnimationNode::blend_input, DEFVAL(FILTER_IGNORE), DEFVAL(true), DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("set_parameter", "name", "value"), &AnimationNode::set_parameter);

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -51,6 +51,13 @@ public:
 		FILTER_BLEND
 	};
 
+	enum MixMode {
+		MIX_MODE_BLEND,
+		MIX_MODE_ADD,
+		MIX_MODE_ADD_DIRECT,
+		MIX_MODE_SUB
+	};
+
 	struct Input {
 		String name;
 	};
@@ -66,6 +73,7 @@ public:
 		const Vector<float> *track_blends;
 		float blend;
 		bool seeked;
+		MixMode mix;
 	};
 
 	struct State {
@@ -91,6 +99,7 @@ public:
 
 	HashMap<NodePath, bool> filter;
 	bool filter_enabled;
+	MixMode mix;
 
 	Array _get_filters() const;
 	void _set_filters(const Array &p_filters);
@@ -100,7 +109,7 @@ public:
 protected:
 	void blend_animation(const StringName &p_animation, float p_time, float p_delta, bool p_seeked, float p_blend);
 	float blend_node(const StringName &p_sub_path, Ref<AnimationNode> p_node, float p_time, bool p_seek, float p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true);
-	float blend_input(int p_input, float p_time, bool p_seek, float p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true);
+	float blend_input(int p_input, float p_time, bool p_seek, float p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true, MixMode p_mix = MIX_MODE_BLEND);
 	void make_invalid(const String &p_reason);
 
 	static void _bind_methods();

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -97,12 +97,12 @@ public:
 	Array _get_filters() const;
 	void _set_filters(const Array &p_filters);
 	friend class AnimationNodeBlendTree;
-	float _blend_node(const StringName &p_subpath, const Vector<StringName> &p_connections, AnimationNode *p_new_parent, Ref<AnimationNode> p_node, float p_time, bool p_seek, float p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true, float *r_max = nullptr);
+	float _blend_node(const StringName &p_subpath, const Vector<StringName> &p_connections, AnimationNode *p_new_parent, Ref<AnimationNode> p_node, float p_time, bool p_seek, float p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true, float *r_max = nullptr, bool p_use_blend = true);
 
 protected:
 	void blend_animation(const StringName &p_animation, float p_time, float p_delta, bool p_seeked, float p_blend);
-	float blend_node(const StringName &p_sub_path, Ref<AnimationNode> p_node, float p_time, bool p_seek, float p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true);
-	float blend_input(int p_input, float p_time, bool p_seek, float p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true, bool use_blend=true);
+	float blend_node(const StringName &p_sub_path, Ref<AnimationNode> p_node, float p_time, bool p_seek, float p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true, bool p_use_blend = true);
+	float blend_input(int p_input, float p_time, bool p_seek, float p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true, bool p_use_blend = true);
 	void make_invalid(const String &p_reason);
 
 	static void _bind_methods();

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -51,13 +51,6 @@ public:
 		FILTER_BLEND
 	};
 
-	enum MixMode {
-		MIX_MODE_BLEND,
-		MIX_MODE_ADD,
-		MIX_MODE_ADD_DIRECT,
-		MIX_MODE_SUB
-	};
-
 	struct Input {
 		String name;
 	};
@@ -73,7 +66,7 @@ public:
 		const Vector<float> *track_blends;
 		float blend;
 		bool seeked;
-		MixMode mix;
+		bool use_blend;
 	};
 
 	struct State {
@@ -99,7 +92,7 @@ public:
 
 	HashMap<NodePath, bool> filter;
 	bool filter_enabled;
-	MixMode mix;
+	bool use_blend;
 
 	Array _get_filters() const;
 	void _set_filters(const Array &p_filters);
@@ -109,7 +102,7 @@ public:
 protected:
 	void blend_animation(const StringName &p_animation, float p_time, float p_delta, bool p_seeked, float p_blend);
 	float blend_node(const StringName &p_sub_path, Ref<AnimationNode> p_node, float p_time, bool p_seek, float p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true);
-	float blend_input(int p_input, float p_time, bool p_seek, float p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true, MixMode p_mix = MIX_MODE_BLEND);
+	float blend_input(int p_input, float p_time, bool p_seek, float p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true, bool use_blend=true);
 	void make_invalid(const String &p_reason);
 
 	static void _bind_methods();

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -417,6 +417,7 @@ void register_scene_types() {
 	ClassDB::register_class<AnimationNodeOutput>();
 	ClassDB::register_class<AnimationNodeOneShot>();
 	ClassDB::register_class<AnimationNodeAnimation>();
+	ClassDB::register_class<AnimationNodeSub2>();
 	ClassDB::register_class<AnimationNodeAdd2>();
 	ClassDB::register_class<AnimationNodeAdd3>();
 	ClassDB::register_class<AnimationNodeBlend2>();


### PR DESCRIPTION
Adds the Add2 node option: Add directly.
Default behavior is current behavior to preserve backwards compatibility. 

Demonstration:


Issue premise:
Additive animation is where two animations are added together. 
Normally animations are blended together which means interpolation between poses.
Additive animation adds poses. We can control how much we add by blending the pose being added
between the identity pose and itself.
Godot has had an Add2 node in its animation tree for years however this does not add poses, it blends them.

Why this matters:
Additive animation is how your animated character plays two animations at once. 
For example: 
In every shooter your character can look up and down, the body moves its aim up and down.
How this works under the hood is that we have an aiming forward pose and we are adding the aim up/down pose.
Why not blend? Imagine the player is running, and breathing, and reloading, while looking up. To accomplish this with blends
you could filter the blends per bone but that looks rubbish. In practice these animations are added, sometimes referred to as layered.
In our example we play the running animation and blend the torso into the aiming pose, we then add the aiming pose (Unreal calls these aim offsets), then we add the reload animation if it is playing, then we add the breathing loop.
All these adds combine to a single animation that is expressive, dynamic, and natural.

About this commit:
This commit adds a new option to the Add2 node allowing users to add directly which does add poses as expected.
It also adds a new animation tree node called Sub2, for the creation of delta animations, often used in conjunction with Add2.

https://user-images.githubusercontent.com/44295008/233524603-8c40fad7-cfb2-430f-bc3c-b7426a7c2840.mp4

![additive_animation_demo_tree](https://user-images.githubusercontent.com/44295008/233525262-5b6ce66b-cf1c-4664-bc14-eb03d882fbe9.PNG)

In this commit:
- Animation states contain a mix mode parameter allowing unlimited custom mixing options
- Added the add directly mix mode
- New node Sub2 subtracts pose. (WARNING: This is a new feature and Im sure Godot managers will want to revise and discuss this new feature)

Why add a new animation node called Sub2? 
If we directly add two animations we add every pose directly. So even poses that are the same in both animations get added!
Instead we add the delta between two animations by first subtracting a mutual pose from the animation being added.
Reference:
http://guillaumeblanc.github.io/ozz-animation/samples/additive/
EDIT: The term rest pose has a meaning already and I don't want to confuse the use of Sub2. I also added a helpful reference.

Notes:
- Note: This doesn't change any existing nodes or setups.
- This is a messy commit and news some polish but is is a good first draft.
- Use blender NLA to test what additive animations should look like.
- I understand the Sub2 node is a new feature. If accepted I hope we can add it for 3.6!
- I promise Ill shine this commit up real nice

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

edit: removed 'draft'.