### PR TITLE
Expose `determinant` in Transform2D, rename internal method

### DIFF
--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -46,7 +46,7 @@ Transform2D Transform2D::inverse() const {
 }
 
 void Transform2D::affine_invert() {
-	real_t det = basis_determinant();
+	real_t det = determinant();
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND(det == 0);
 #endif
@@ -70,12 +70,12 @@ void Transform2D::rotate(const real_t p_angle) {
 }
 
 real_t Transform2D::get_skew() const {
-	real_t det = basis_determinant();
+	real_t det = determinant();
 	return Math::acos(columns[0].normalized().dot(SIGN(det) * columns[1].normalized())) - (real_t)Math_PI * 0.5f;
 }
 
 void Transform2D::set_skew(const real_t p_angle) {
-	real_t det = basis_determinant();
+	real_t det = determinant();
 	columns[1] = SIGN(det) * columns[0].rotated(((real_t)Math_PI * 0.5f + p_angle)).normalized() * columns[1].length();
 }
 
@@ -113,7 +113,7 @@ Transform2D::Transform2D(const real_t p_rot, const Size2 &p_scale, const real_t 
 }
 
 Size2 Transform2D::get_scale() const {
-	real_t det_sign = SIGN(basis_determinant());
+	real_t det_sign = SIGN(determinant());
 	return Size2(columns[0].length(), det_sign * columns[1].length());
 }
 
@@ -259,7 +259,7 @@ Transform2D Transform2D::rotated_local(const real_t p_angle) const {
 	return (*this) * Transform2D(p_angle, Vector2()); // Could be optimized, because origin transform can be skipped.
 }
 
-real_t Transform2D::basis_determinant() const {
+real_t Transform2D::determinant() const {
 	return columns[0].x * columns[1].y - columns[0].y * columns[1].x;
 }
 

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -77,7 +77,7 @@ struct _NO_DISCARD_ Transform2D {
 	void translate_local(const real_t p_tx, const real_t p_ty);
 	void translate_local(const Vector2 &p_translation);
 
-	real_t basis_determinant() const;
+	real_t determinant() const;
 
 	Size2 get_scale() const;
 	void set_scale(const Size2 &p_scale);

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2073,6 +2073,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Transform2D, scaled_local, sarray("scale"), varray());
 	bind_method(Transform2D, translated, sarray("offset"), varray());
 	bind_method(Transform2D, translated_local, sarray("offset"), varray());
+	bind_method(Transform2D, determinant, sarray(), varray());
 	bind_method(Transform2D, basis_xform, sarray("v"), varray());
 	bind_method(Transform2D, basis_xform_inv, sarray("v"), varray());
 	bind_method(Transform2D, interpolate_with, sarray("xform", "weight"), varray());

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -78,6 +78,13 @@
 				This method does not account for translation (the origin vector).
 			</description>
 		</method>
+		<method name="determinant" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the determinant of the basis matrix. If the basis is uniformly scaled, then its determinant equals the square of the scale factor.
+				A negative determinant means the basis was flipped, so one part of the scale is negative. A zero determinant means the basis isn't invertible, and is usually considered invalid.
+			</description>
+		</method>
 		<method name="get_origin" qualifiers="const">
 			<return type="Vector2" />
 			<description>

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1519,8 +1519,8 @@ Control *Viewport::_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_
 	}
 
 	Transform2D matrix = p_xform * p_node->get_transform();
-	// matrix.basis_determinant() == 0.0f implies that node does not exist on scene
-	if (matrix.basis_determinant() == 0.0f) {
+	// matrix.determinant() == 0.0f implies that node does not exist on scene
+	if (matrix.determinant() == 0.0f) {
 		return nullptr;
 	}
 


### PR DESCRIPTION
I usually use 3D. As a math nerd I was helping out a friend with some math in a 2D game and I was shocked that the determinant was not exposed to GDScript. This PR exposes it.

Discussion: Since this is not exposed yet, we could also rename it from `basis_determinant` to just `determinant`, since there is no other possible way to interpret the word "determinant" here. If this is desired I would be happy to add it to this PR, but I don't want to cause unnecessary friction so I haven't done so yet. `basis_determinant` is still clear and correct, it's just... kinda redundant and unnecessary.

3.x version: https://github.com/godotengine/godot/pull/76323