### PR TITLE
Fix issues with Vulkan layout transitions

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -954,6 +954,8 @@ class RenderingDeviceVulkan : public RenderingDevice {
 
 	ComputeList *compute_list = nullptr;
 
+	void _compute_list_add_barrier(BitField<BarrierMask> p_post_barrier, uint32_t p_barrier_flags, uint32_t p_access_flags);
+
 	/**************************/
 	/**** FRAME MANAGEMENT ****/
 	/**************************/


### PR DESCRIPTION
The current access patterns for different mip levels or layers of some textures happening for computation of effects can lead to situations where the layout of the owner texture Godot is aware of is out of sync because of slices have transitioned to another one. That causes mainly two kinds of barrier validation errors (which are complementary):
1. At the time of dispatch, the descriptor set specifies `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL` but the texture is still in `VK_IMAGE_LAYOUT_GENERAL`.
2. When closing the compute list, Godot wants to take a texture back to `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL`, but it was already transitioned.

My first ideas involved tracking the state of subresources so each dispatch knew exactly which levels/aspects/layers of each texture were needed to transition back and forth. However, something like that required a tremendous amount of bookkeeping. In the end, I tried this simpler approach: letting the requests for compute barriers do the state cleanup instead of all it happening by the closing of the list. That plus a condition to avoid redundant restorations of layout has done the trick.

Probably this fix isn't universal. I mean, more complex access patterns with subresources involved may need the aforementioned complex bookkeeping approach, but this seems to be enough for a project that already uses many effects (tested on https://github.com/Calinou/godot-reflection), in which all these validation errors are fixed by this PR:
```
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: -564812795 | Message Id Name: VUID-VkDescriptorImageInfo-imageLayout-00344
	Validation Error: [ VUID-VkDescriptorImageInfo-imageLayout-00344 ] Object 0: handle = 0x1c76291d230, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0xde55a405 | vkCmdDispatch: Cannot use VkImage 0x1c76020000001271[RenderBuffer rb_ssao/deinterleaved] (layer=0 mip=0) with specific layout VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL that doesn't match the previous known layout VK_IMAGE_LAYOUT_GENERAL. The Vulkan spec states: imageLayout must match the actual VkImageLayout of each subresource accessible from imageView at the time this descriptor is accessed as defined by the image layout matching rules (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-VkDescriptorImageInfo-imageLayout-00344)
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_COMMAND_BUFFER, Handle 1955863843376
	Command Buffer Labels - 2
		Label[0] - Interleave Buffers{ 1, 1, 1, 1 }
		Label[1] - Process Screen Space Ambient Occlusion{ 1, 1, 1, 1 }
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: -564812795 | Message Id Name: VUID-VkDescriptorImageInfo-imageLayout-00344
	Validation Error: [ VUID-VkDescriptorImageInfo-imageLayout-00344 ] Object 0: handle = 0x1c76291d230, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0xde55a405 | vkCmdDispatch: Cannot use VkImage 0x1c76020000001271[RenderBuffer rb_ssao/deinterleaved] (layer=1 mip=0) with specific layout VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL that doesn't match the previous known layout VK_IMAGE_LAYOUT_GENERAL. The Vulkan spec states: imageLayout must match the actual VkImageLayout of each subresource accessible from imageView at the time this descriptor is accessed as defined by the image layout matching rules (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-VkDescriptorImageInfo-imageLayout-00344)
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_COMMAND_BUFFER, Handle 1955863843376
	Command Buffer Labels - 2
		Label[0] - Interleave Buffers{ 1, 1, 1, 1 }
		Label[1] - Process Screen Space Ambient Occlusion{ 1, 1, 1, 1 }
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: -564812795 | Message Id Name: VUID-VkDescriptorImageInfo-imageLayout-00344
	Validation Error: [ VUID-VkDescriptorImageInfo-imageLayout-00344 ] Object 0: handle = 0x1c76291d230, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0xde55a405 | vkCmdDispatch: Cannot use VkImage 0x1c76020000001271[RenderBuffer rb_ssao/deinterleaved] (layer=2 mip=0) with specific layout VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL that doesn't match the previous known layout VK_IMAGE_LAYOUT_GENERAL. The Vulkan spec states: imageLayout must match the actual VkImageLayout of each subresource accessible from imageView at the time this descriptor is accessed as defined by the image layout matching rules (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-VkDescriptorImageInfo-imageLayout-00344)
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_COMMAND_BUFFER, Handle 1955863843376
	Command Buffer Labels - 2
		Label[0] - Interleave Buffers{ 1, 1, 1, 1 }
		Label[1] - Process Screen Space Ambient Occlusion{ 1, 1, 1, 1 }
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: -564812795 | Message Id Name: VUID-VkDescriptorImageInfo-imageLayout-00344
	Validation Error: [ VUID-VkDescriptorImageInfo-imageLayout-00344 ] Object 0: handle = 0x1c76291d230, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0xde55a405 | vkCmdDispatch: Cannot use VkImage 0x1c76020000001271[RenderBuffer rb_ssao/deinterleaved] (layer=3 mip=0) with specific layout VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL that doesn't match the previous known layout VK_IMAGE_LAYOUT_GENERAL. The Vulkan spec states: imageLayout must match the actual VkImageLayout of each subresource accessible from imageView at the time this descriptor is accessed as defined by the image layout matching rules (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-VkDescriptorImageInfo-imageLayout-00344)
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_COMMAND_BUFFER, Handle 1955863843376
	Command Buffer Labels - 2
		Label[0] - Interleave Buffers{ 1, 1, 1, 1 }
		Label[1] - Process Screen Space Ambient Occlusion{ 1, 1, 1, 1 }
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: -439258052 | Message Id Name: VUID-vkCmdDispatch-None-02699
	Validation Error: [ VUID-vkCmdDispatch-None-02699 ] Object 0: handle = 0xe6c0b7000000129d, name = RID:11136850198716, type = VK_OBJECT_TYPE_DESCRIPTOR_SET; | MessageID = 0xe5d1743c | Descriptor set VkDescriptorSet 0xe6c0b7000000129d[RID:11136850198716] encountered the following validation error at vkCmdDispatch time: Image layout specified at vkUpdateDescriptorSet* or vkCmdPushDescriptorSet* time doesn't match actual image layout at time descriptor is used. See previous error callback for specific details. The Vulkan spec states: Descriptors in each bound descriptor set, specified via vkCmdBindDescriptorSets, must be valid if they are statically used by the VkPipeline bound to the pipeline bind point used by this command (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdDispatch-None-02699)
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_DESCRIPTOR_SET, Handle -1819253038829792611, Name "RID:11136850198716"
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: 307231540 | Message Id Name: VUID-VkImageMemoryBarrier-oldLayout-01197
	Validation Error: [ VUID-VkImageMemoryBarrier-oldLayout-01197 ] Object 0: handle = 0x1c76291d230, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x124ffb34 | vkCmdPipelineBarrier(): .pImageMemoryBarriers[0] VkImage 0xf52cb700000012a6[RenderBuffer rb_ssil/edges] cannot transition the layout of aspect=1 level=0 layer=0 from VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL when the previous known layout is VK_IMAGE_LAYOUT_GENERAL. The Vulkan spec states: If srcQueueFamilyIndex and dstQueueFamilyIndex define a queue family ownership transfer or oldLayout and newLayout define an image layout transition, oldLayout must be VK_IMAGE_LAYOUT_UNDEFINED or the current layout of the image subresources affected by the barrier (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-VkImageMemoryBarrier-oldLayout-01197)
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_COMMAND_BUFFER, Handle 1955863843376
	Command Buffer Labels - 2
		Label[0] - Interleave Buffers{ 1, 1, 1, 1 }
		Label[1] - Process Screen Space Indirect Lighting{ 1, 1, 1, 1 }
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: 307231540 | Message Id Name: VUID-VkImageMemoryBarrier-oldLayout-01197
	Validation Error: [ VUID-VkImageMemoryBarrier-oldLayout-01197 ] Object 0: handle = 0x1c76291d230, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x124ffb34 | vkCmdPipelineBarrier(): .pImageMemoryBarriers[0] VkImage 0xf52cb700000012a6[RenderBuffer rb_ssil/edges] cannot transition the layout of aspect=1 level=0 layer=1 from VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL when the previous known layout is VK_IMAGE_LAYOUT_GENERAL. The Vulkan spec states: If srcQueueFamilyIndex and dstQueueFamilyIndex define a queue family ownership transfer or oldLayout and newLayout define an image layout transition, oldLayout must be VK_IMAGE_LAYOUT_UNDEFINED or the current layout of the image subresources affected by the barrier (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-VkImageMemoryBarrier-oldLayout-01197)
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_COMMAND_BUFFER, Handle 1955863843376
	Command Buffer Labels - 2
		Label[0] - Interleave Buffers{ 1, 1, 1, 1 }
		Label[1] - Process Screen Space Indirect Lighting{ 1, 1, 1, 1 }
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: 307231540 | Message Id Name: VUID-VkImageMemoryBarrier-oldLayout-01197
	Validation Error: [ VUID-VkImageMemoryBarrier-oldLayout-01197 ] Object 0: handle = 0x1c76291d230, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x124ffb34 | vkCmdPipelineBarrier(): .pImageMemoryBarriers[0] VkImage 0xf52cb700000012a6[RenderBuffer rb_ssil/edges] cannot transition the layout of aspect=1 level=0 layer=2 from VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL when the previous known layout is VK_IMAGE_LAYOUT_GENERAL. The Vulkan spec states: If srcQueueFamilyIndex and dstQueueFamilyIndex define a queue family ownership transfer or oldLayout and newLayout define an image layout transition, oldLayout must be VK_IMAGE_LAYOUT_UNDEFINED or the current layout of the image subresources affected by the barrier (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-VkImageMemoryBarrier-oldLayout-01197)
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_COMMAND_BUFFER, Handle 1955863843376
	Command Buffer Labels - 2
		Label[0] - Interleave Buffers{ 1, 1, 1, 1 }
		Label[1] - Process Screen Space Indirect Lighting{ 1, 1, 1, 1 }
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: 307231540 | Message Id Name: VUID-VkImageMemoryBarrier-oldLayout-01197
	Validation Error: [ VUID-VkImageMemoryBarrier-oldLayout-01197 ] Object 0: handle = 0x1c76291d230, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x124ffb34 | vkCmdPipelineBarrier(): .pImageMemoryBarriers[0] VkImage 0xf52cb700000012a6[RenderBuffer rb_ssil/edges] cannot transition the layout of aspect=1 level=0 layer=3 from VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL when the previous known layout is VK_IMAGE_LAYOUT_GENERAL. The Vulkan spec states: If srcQueueFamilyIndex and dstQueueFamilyIndex define a queue family ownership transfer or oldLayout and newLayout define an image layout transition, oldLayout must be VK_IMAGE_LAYOUT_UNDEFINED or the current layout of the image subresources affected by the barrier (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-VkImageMemoryBarrier-oldLayout-01197)
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_COMMAND_BUFFER, Handle 1955863843376
	Command Buffer Labels - 2
		Label[0] - Interleave Buffers{ 1, 1, 1, 1 }
		Label[1] - Process Screen Space Indirect Lighting{ 1, 1, 1, 1 }
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: -564812795 | Message Id Name: VUID-VkDescriptorImageInfo-imageLayout-00344
	Validation Error: [ VUID-VkDescriptorImageInfo-imageLayout-00344 ] Object 0: handle = 0x1c76291d230, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0xde55a405 | vkCmdDispatch: Cannot use VkImage 0xeb91000000012a2[RenderBuffer rb_ssil/deinterleaved] (layer=0 mip=0) with specific layout VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL that doesn't match the previous known layout VK_IMAGE_LAYOUT_GENERAL. The Vulkan spec states: imageLayout must match the actual VkImageLayout of each subresource accessible from imageView at the time this descriptor is accessed as defined by the image layout matching rules (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-VkDescriptorImageInfo-imageLayout-00344)
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_COMMAND_BUFFER, Handle 1955863843376
	Command Buffer Labels - 2
		Label[0] - Interleave Buffers{ 1, 1, 1, 1 }
		Label[1] - Process Screen Space Indirect Lighting{ 1, 1, 1, 1 }
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: -564812795 | Message Id Name: VUID-VkDescriptorImageInfo-imageLayout-00344
	Validation Error: [ VUID-VkDescriptorImageInfo-imageLayout-00344 ] Object 0: handle = 0x1c76291d230, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0xde55a405 | vkCmdDispatch: Cannot use VkImage 0xeb91000000012a2[RenderBuffer rb_ssil/deinterleaved] (layer=1 mip=0) with specific layout VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL that doesn't match the previous known layout VK_IMAGE_LAYOUT_GENERAL. The Vulkan spec states: imageLayout must match the actual VkImageLayout of each subresource accessible from imageView at the time this descriptor is accessed as defined by the image layout matching rules (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-VkDescriptorImageInfo-imageLayout-00344)
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_COMMAND_BUFFER, Handle 1955863843376
	Command Buffer Labels - 2
		Label[0] - Interleave Buffers{ 1, 1, 1, 1 }
		Label[1] - Process Screen Space Indirect Lighting{ 1, 1, 1, 1 }
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: -564812795 | Message Id Name: VUID-VkDescriptorImageInfo-imageLayout-00344
	Validation Error: [ VUID-VkDescriptorImageInfo-imageLayout-00344 ] Object 0: handle = 0x1c76291d230, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0xde55a405 | vkCmdDispatch: Cannot use VkImage 0xeb91000000012a2[RenderBuffer rb_ssil/deinterleaved] (layer=2 mip=0) with specific layout VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL that doesn't match the previous known layout VK_IMAGE_LAYOUT_GENERAL. The Vulkan spec states: imageLayout must match the actual VkImageLayout of each subresource accessible from imageView at the time this descriptor is accessed as defined by the image layout matching rules (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-VkDescriptorImageInfo-imageLayout-00344)
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_COMMAND_BUFFER, Handle 1955863843376
	Command Buffer Labels - 2
		Label[0] - Interleave Buffers{ 1, 1, 1, 1 }
		Label[1] - Process Screen Space Indirect Lighting{ 1, 1, 1, 1 }
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: -564812795 | Message Id Name: VUID-VkDescriptorImageInfo-imageLayout-00344
	Validation Error: [ VUID-VkDescriptorImageInfo-imageLayout-00344 ] Object 0: handle = 0x1c76291d230, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0xde55a405 | vkCmdDispatch: Cannot use VkImage 0xeb91000000012a2[RenderBuffer rb_ssil/deinterleaved] (layer=3 mip=0) with specific layout VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL that doesn't match the previous known layout VK_IMAGE_LAYOUT_GENERAL. The Vulkan spec states: imageLayout must match the actual VkImageLayout of each subresource accessible from imageView at the time this descriptor is accessed as defined by the image layout matching rules (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-VkDescriptorImageInfo-imageLayout-00344)
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_COMMAND_BUFFER, Handle 1955863843376
	Command Buffer Labels - 2
		Label[0] - Interleave Buffers{ 1, 1, 1, 1 }
		Label[1] - Process Screen Space Indirect Lighting{ 1, 1, 1, 1 }
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: -439258052 | Message Id Name: VUID-vkCmdDispatch-None-02699
	Validation Error: [ VUID-vkCmdDispatch-None-02699 ] Object 0: handle = 0x9ae86500000012ea, name = RID:11428907974893, type = VK_OBJECT_TYPE_DESCRIPTOR_SET; | MessageID = 0xe5d1743c | Descriptor set VkDescriptorSet 0x9ae86500000012ea[RID:11428907974893] encountered the following validation error at vkCmdDispatch time: Image layout specified at vkUpdateDescriptorSet* or vkCmdPushDescriptorSet* time doesn't match actual image layout at time descriptor is used. See previous error callback for specific details. The Vulkan spec states: Descriptors in each bound descriptor set, specified via vkCmdBindDescriptorSets, must be valid if they are statically used by the VkPipeline bound to the pipeline bind point used by this command (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdDispatch-None-02699)
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_DESCRIPTOR_SET, Handle -7284461346597367062, Name "RID:11428907974893"
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: 307231540 | Message Id Name: VUID-VkImageMemoryBarrier-oldLayout-01197
	Validation Error: [ VUID-VkImageMemoryBarrier-oldLayout-01197 ] Object 0: handle = 0x1c76291d230, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x124ffb34 | vkCmdPipelineBarrier(): .pImageMemoryBarriers[10] VkImage 0xf52cb700000012a6[RenderBuffer rb_ssil/edges] cannot transition the layout of aspect=1 level=0 layer=0 from VK_IMAGE_LAYOUT_GENERAL when the previous known layout is VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL. The Vulkan spec states: If srcQueueFamilyIndex and dstQueueFamilyIndex define a queue family ownership transfer or oldLayout and newLayout define an image layout transition, oldLayout must be VK_IMAGE_LAYOUT_UNDEFINED or the current layout of the image subresources affected by the barrier (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-VkImageMemoryBarrier-oldLayout-01197)
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_COMMAND_BUFFER, Handle 1955863843376
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: 307231540 | Message Id Name: VUID-VkImageMemoryBarrier-oldLayout-01197
	Validation Error: [ VUID-VkImageMemoryBarrier-oldLayout-01197 ] Object 0: handle = 0x1c76291d230, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x124ffb34 | vkCmdPipelineBarrier(): .pImageMemoryBarriers[10] VkImage 0xf52cb700000012a6[RenderBuffer rb_ssil/edges] cannot transition the layout of aspect=1 level=0 layer=1 from VK_IMAGE_LAYOUT_GENERAL when the previous known layout is VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL. The Vulkan spec states: If srcQueueFamilyIndex and dstQueueFamilyIndex define a queue family ownership transfer or oldLayout and newLayout define an image layout transition, oldLayout must be VK_IMAGE_LAYOUT_UNDEFINED or the current layout of the image subresources affected by the barrier (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-VkImageMemoryBarrier-oldLayout-01197)
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_COMMAND_BUFFER, Handle 1955863843376
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: 307231540 | Message Id Name: VUID-VkImageMemoryBarrier-oldLayout-01197
	Validation Error: [ VUID-VkImageMemoryBarrier-oldLayout-01197 ] Object 0: handle = 0x1c76291d230, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x124ffb34 | vkCmdPipelineBarrier(): .pImageMemoryBarriers[10] VkImage 0xf52cb700000012a6[RenderBuffer rb_ssil/edges] cannot transition the layout of aspect=1 level=0 layer=2 from VK_IMAGE_LAYOUT_GENERAL when the previous known layout is VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL. The Vulkan spec states: If srcQueueFamilyIndex and dstQueueFamilyIndex define a queue family ownership transfer or oldLayout and newLayout define an image layout transition, oldLayout must be VK_IMAGE_LAYOUT_UNDEFINED or the current layout of the image subresources affected by the barrier (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-VkImageMemoryBarrier-oldLayout-01197)
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_COMMAND_BUFFER, Handle 1955863843376
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: 307231540 | Message Id Name: VUID-VkImageMemoryBarrier-oldLayout-01197
	Validation Error: [ VUID-VkImageMemoryBarrier-oldLayout-01197 ] Object 0: handle = 0x1c76291d230, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x124ffb34 | vkCmdPipelineBarrier(): .pImageMemoryBarriers[10] VkImage 0xf52cb700000012a6[RenderBuffer rb_ssil/edges] cannot transition the layout of aspect=1 level=0 layer=3 from VK_IMAGE_LAYOUT_GENERAL when the previous known layout is VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL. The Vulkan spec states: If srcQueueFamilyIndex and dstQueueFamilyIndex define a queue family ownership transfer or oldLayout and newLayout define an image layout transition, oldLayout must be VK_IMAGE_LAYOUT_UNDEFINED or the current layout of the image subresources affected by the barrier (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-VkImageMemoryBarrier-oldLayout-01197)
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_COMMAND_BUFFER, Handle 1955863843376
```