### PR TITLE
[3.x] Downgrade android gradle plugin to version 7.2.1.

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,5 +1,5 @@
 ext.versions = [
-    androidGradlePlugin: '7.3.0',
+    androidGradlePlugin: '7.2.1',
     compileSdk         : 33,
     minSdk             : 19, // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
     targetSdk          : 33, // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'


### PR DESCRIPTION
Version 7.3.0 changes the build layout which causes updates to the generated shared libraries to not be picked up.

[main version](https://github.com/godotengine/godot/pull/76325)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
