### PR TITLE
Validate renderer selection in project manager and change default renderer editor setting to expose an enum to users

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -756,12 +756,12 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 #if defined(WEB_ENABLED)
 	// Web platform only supports `gl_compatibility`.
-	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_NONE, "project_manager/default_renderer", "gl_compatibility", "forward_plus,mobile,gl_compatibility")
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_ENUM, "project_manager/default_renderer", "gl_compatibility", "forward_plus,mobile,gl_compatibility")
 #elif defined(ANDROID_ENABLED)
 	// Use more suitable rendering method by default.
-	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_NONE, "project_manager/default_renderer", "mobile", "forward_plus,mobile,gl_compatibility")
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_ENUM, "project_manager/default_renderer", "mobile", "forward_plus,mobile,gl_compatibility")
 #else
-	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_NONE, "project_manager/default_renderer", "forward_plus", "forward_plus,mobile,gl_compatibility")
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_ENUM, "project_manager/default_renderer", "forward_plus", "forward_plus,mobile,gl_compatibility")
 #endif
 
 	if (p_extra_config.is_valid()) {

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -387,6 +387,8 @@ void ProjectDialog::_nonempty_confirmation_ok_pressed() {
 }
 
 void ProjectDialog::_renderer_selected() {
+	ERR_FAIL_COND(!renderer_button_group->get_pressed_button());
+
 	String renderer_type = renderer_button_group->get_pressed_button()->get_meta(SNAME("rendering_method"));
 
 	if (renderer_type == "forward_plus") {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/76318

The problem comes from how we initialize the default. We do a string compare against "forward_plus", "mobile", and "gl_compatibility" and then set the button pressed for whichever matches. We don't set any of them to pressed if none match. Then, we call ``_renderer_selected()`` to prefill the information for the selected renderer. Since we pull the information from the selected button, we end up crashing with a null pointer reference. The solution is just to throw an error in this case as it should never happen. 

Secondly, I changed the editor setting to an enum instead of a raw string. Internally nothing should change as it is still a string, but now users are given a dropdown when setting it from the editor. This matches the behaviour in ProjectSettings. 