### PR TITLE
Fix thread IDs.

### DIFF
--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -66,7 +66,9 @@ int RemoteDebuggerPeerTCP::get_max_message_size() const {
 
 void RemoteDebuggerPeerTCP::close() {
 	running = false;
-	thread.wait_to_finish();
+	if (thread.is_started()) {
+		thread.wait_to_finish();
+	}
 	tcp_client->disconnect_from_host();
 	out_buf.clear();
 	in_buf.clear();

--- a/core/os/thread.cpp
+++ b/core/os/thread.cpp
@@ -38,13 +38,9 @@
 
 Thread::PlatformFunctions Thread::platform_functions;
 
-uint64_t Thread::_thread_id_hash(const std::thread::id &p_t) {
-	static std::hash<std::thread::id> hasher;
-	return hasher(p_t);
-}
+SafeNumeric<uint64_t> Thread::id_counter(1); // The first value after .increment() is 2, hence by default the main thread ID should be 1.
 
-Thread::ID Thread::main_thread_id = _thread_id_hash(std::this_thread::get_id());
-thread_local Thread::ID Thread::caller_id = 0;
+thread_local Thread::ID Thread::caller_id = Thread::UNASSIGNED_ID;
 
 void Thread::_set_platform_functions(const PlatformFunctions &p_functions) {
 	platform_functions = p_functions;
@@ -71,31 +67,23 @@ void Thread::callback(ID p_caller_id, const Settings &p_settings, Callback p_cal
 }
 
 void Thread::start(Thread::Callback p_callback, void *p_user, const Settings &p_settings) {
-	if (id != _thread_id_hash(std::thread::id())) {
-#ifdef DEBUG_ENABLED
-		WARN_PRINT("A Thread object has been re-started without wait_to_finish() having been called on it. Please do so to ensure correct cleanup of the thread.");
-#endif
-		thread.detach();
-		std::thread empty_thread;
-		thread.swap(empty_thread);
-	}
-	std::thread new_thread(&Thread::callback, _thread_id_hash(thread.get_id()), p_settings, p_callback, p_user);
+	ERR_FAIL_COND_MSG(id != UNASSIGNED_ID, "A Thread object has been re-started without wait_to_finish() having been called on it.");
+	id = id_counter.increment();
+	std::thread new_thread(&Thread::callback, id, p_settings, p_callback, p_user);
 	thread.swap(new_thread);
-	id = _thread_id_hash(thread.get_id());
 }
 
 bool Thread::is_started() const {
-	return id != _thread_id_hash(std::thread::id());
+	return id != UNASSIGNED_ID;
 }
 
 void Thread::wait_to_finish() {
-	if (id != _thread_id_hash(std::thread::id())) {
-		ERR_FAIL_COND_MSG(id == get_caller_id(), "A Thread can't wait for itself to finish.");
-		thread.join();
-		std::thread empty_thread;
-		thread.swap(empty_thread);
-		id = _thread_id_hash(std::thread::id());
-	}
+	ERR_FAIL_COND_MSG(id == UNASSIGNED_ID, "Attempt of waiting to finish on a thread that was never started.");
+	ERR_FAIL_COND_MSG(id == get_caller_id(), "Threads can't wait to finish on themselves, another thread must wait.");
+	thread.join();
+	std::thread empty_thread;
+	thread.swap(empty_thread);
+	id = UNASSIGNED_ID;
 }
 
 Error Thread::set_name(const String &p_name) {
@@ -107,11 +95,10 @@ Error Thread::set_name(const String &p_name) {
 }
 
 Thread::Thread() {
-	caller_id = _thread_id_hash(std::this_thread::get_id());
 }
 
 Thread::~Thread() {
-	if (id != _thread_id_hash(std::thread::id())) {
+	if (id != UNASSIGNED_ID) {
 #ifdef DEBUG_ENABLED
 		WARN_PRINT("A Thread object has been destroyed without wait_to_finish() having been called on it. Please do so to ensure correct cleanup of the thread.");
 #endif

--- a/main/main.h
+++ b/main/main.h
@@ -60,7 +60,7 @@ public:
 
 	static int test_entrypoint(int argc, char *argv[], bool &tests_need_run);
 	static Error setup(const char *execpath, int argc, char *argv[], bool p_second_phase = true);
-	static Error setup2(Thread::ID p_main_tid_override = 0);
+	static Error setup2(); // The thread calling setup2() will effectively become the main thread.
 	static String get_rendering_driver_name();
 #ifdef TESTS_ENABLED
 	static Error test_setup();

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -3306,6 +3306,8 @@ EditorExportPlatformAndroid::EditorExportPlatformAndroid() {
 EditorExportPlatformAndroid::~EditorExportPlatformAndroid() {
 #ifndef ANDROID_ENABLED
 	quit_request.set();
-	check_for_changes_thread.wait_to_finish();
+	if (check_for_changes_thread.is_started()) {
+		check_for_changes_thread.wait_to_finish();
+	}
 #endif
 }

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -244,7 +244,7 @@ JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env,
 	if (step.get() == 0) {
 		// Since Godot is initialized on the UI thread, main_thread_id was set to that thread's id,
 		// but for Godot purposes, the main thread is the one running the game loop
-		Main::setup2(Thread::get_caller_id());
+		Main::setup2();
 		input_handler = new AndroidInputHandler();
 		step.increment();
 		return true;


### PR DESCRIPTION
On Linux, thread IDs were not properly assigned with the current approach. The line:
`std::thread new_thread(&Thread::callback, _thread_id_hash(thread.get_id()), p_settings, p_callback, p_user);` does not work because the thread ID is not assigned until the thread starts. It seems this behavior is undefined across standard libraries.

This PR changes the behavior to use manually generated thread IDs. Additionally, if a thread is (or may have been created) outside Godot, the method `Thread::get_call_id()` will assign a new ID to the thread anyway.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
