### PR TITLE
Use Levenshtein Distance for InputMap action suggestions

### DIFF
--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -297,6 +297,7 @@ public:
 	bool is_quoted() const;
 	Vector<String> bigrams() const;
 	float similarity(const String &p_string) const;
+	int edit_distance(const String &p_string) const;
 	String format(const Variant &values, String placeholder = "{_}") const;
 	String replace_first(const String &p_key, const String &p_with) const;
 	String replace(const String &p_key, const String &p_with) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1653,6 +1653,7 @@ static void _register_variant_builtin_methods() {
 	bind_string_method(is_subsequence_ofn, sarray("text"), varray());
 	bind_string_method(bigrams, sarray(), varray());
 	bind_string_method(similarity, sarray("text"), varray());
+	bind_string_method(edit_distance, sarray("text"), varray());
 
 	bind_string_method(format, sarray("values", "placeholder"), varray("{_}"));
 	bind_string_methodv(replace, static_cast<String (String::*)(const String &, const String &) const>(&String::replace), sarray("what", "forwhat"), varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -168,6 +168,20 @@
 				Returns a copy of the string with indentation (leading tabs and spaces) removed. See also [method indent] to add indentation.
 			</description>
 		</method>
+		<method name="edit_distance" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="text" type="String" />
+			<description>
+				Returns the [url=https://en.wikipedia.org/wiki/Levenshtein_distance]Levenshtein Distance[/url] of this string compared to another, also known as the Edit Distance. The returned value represents the minimum number of single-character edits (insertions, deletions or substitutions) required to change this String into the other. For Strings with size less than or equal to 32, it computes the [url=https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance]Damerau-Levenshtein Distance[/url], which besides insertions, deletions and substitutions also takes into account transpositions ([code]abc[/code] becoming [code]acb[/code]).
+				[codeblock]
+				print("ABC123".edit_distance("ABC123")) # Prints 0
+				print("ABC123".edit_distance("XYZ456")) # Prints 6
+				print("ABC123".edit_distance("123ABC")) # Prints 6
+				print("ABC123".edit_distance("abc123")) # Prints 3
+				print("ABC".edit_distance("ACB")) # Prints 1
+				[/codeblock]
+			</description>
+		</method>
 		<method name="ends_with" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="text" type="String" />

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -151,6 +151,20 @@
 				Returns a copy of the string with indentation (leading tabs and spaces) removed. See also [method indent] to add indentation.
 			</description>
 		</method>
+		<method name="edit_distance" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="text" type="String" />
+			<description>
+				Returns the [url=https://en.wikipedia.org/wiki/Levenshtein_distance]Levenshtein Distance[/url] of this string compared to another, also known as the Edit Distance. The returned value represents the minimum number of single-character edits (insertions, deletions or substitutions) required to change this String into the other. For Strings with size less than or equal to 32, it computes the [url=https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance]Damerau-Levenshtein Distance[/url], which besides insertions, deletions and substitutions also takes into account transpositions ([code]abc[/code] becoming [code]acb[/code]).
+				[codeblock]
+				print("ABC123".edit_distance("ABC123")) # Prints 0
+				print("ABC123".edit_distance("XYZ456")) # Prints 6
+				print("ABC123".edit_distance("123ABC")) # Prints 6
+				print("ABC123".edit_distance("abc123")) # Prints 3
+				print("ABC".edit_distance("ACB")) # Prints 1
+				[/codeblock]
+			</description>
+		</method>
 		<method name="ends_with" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="text" type="String" />

--- a/tests/core/input/test_input_map.h
+++ b/tests/core/input/test_input_map.h
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/*  test_input_map.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_INPUT_MAP_H
+#define TEST_INPUT_MAP_H
+
+#include "tests/test_macros.h"
+
+namespace TestInputMap {
+
+TEST_CASE("[InputMap] Suggestions should return sane and expected results") {
+	HashMap<String, LocalVector<String>> test_cases;
+	test_cases.insert("ui_letf", { "ui_left" });
+	test_cases.insert("ui_eltf", { "ui_left" });
+	test_cases.insert("ui_pu", { "ui_up" });
+	test_cases.insert("ui_donw", { "ui_down" });
+	test_cases.insert("ui_do", { "ui_down", "ui_undo", "ui_redo" });
+
+	InputMap *input_map = memnew(InputMap);
+	input_map->load_default();
+	for (const KeyValue<String, LocalVector<String>> &test : test_cases) {
+		String error_message = input_map->suggest_actions(test.key);
+		for (const String &suggestion : test.value) {
+			CHECK(suggestion.is_subsequence_of(error_message));
+		}
+	}
+}
+
+} //namespace TestInputMap
+
+#endif // TEST_INPUT_MAP_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -159,6 +159,10 @@ int test_main(int argc, char *argv[]) {
 		if (arg != "--test") {
 			test_args.push_back(arg);
 		}
+
+		if (arg == "--verbose") {
+			OS::get_singleton()->_verbose_stdout = true;
+		}
 	}
 
 	if (test_args.size() > 0) {

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -33,6 +33,7 @@
 #include "tests/core/config/test_project_settings.h"
 #include "tests/core/input/test_input_event_key.h"
 #include "tests/core/input/test_input_event_mouse.h"
+#include "tests/core/input/test_input_map.h"
 #include "tests/core/input/test_shortcut.h"
 #include "tests/core/io/test_config_file.h"
 #include "tests/core/io/test_file_access.h"


### PR DESCRIPTION
This PR improves the InputMap::suggest_actions by using String::edit_distance instead of String::similarity, which often results in more accurate suggestions.
The outputted error message is also improved by including more than one suggestion (we include all with the same edit distance).
  
As a means of asserting that the method behavior didn't change a test case has been added, which works as intended.

This PR depends on: https://github.com/godotengine/godot/pull/75965