### PR TITLE
Add animation playback preview to scene import settings

### DIFF
--- a/editor/import/scene_import_settings.h
+++ b/editor/import/scene_import_settings.h
@@ -35,10 +35,13 @@
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/light_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
+#include "scene/3d/skeleton_3d.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/item_list.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/option_button.h"
+#include "scene/gui/panel_container.h"
+#include "scene/gui/slider.h"
 #include "scene/gui/split_container.h"
 #include "scene/gui/subviewport_container.h"
 #include "scene/gui/tab_container.h"
@@ -84,6 +87,15 @@ class SceneImportSettings : public ConfirmationDialog {
 
 	MeshInstance3D *mesh_preview = nullptr;
 	Ref<SphereMesh> material_preview;
+
+	AnimationPlayer *animation_player = nullptr;
+	List<Skeleton3D *> skeletons;
+	PanelContainer *animation_preview = nullptr;
+	HSlider *animation_slider = nullptr;
+	Button *animation_play_button = nullptr;
+	Button *animation_stop_button = nullptr;
+	Animation::LoopMode animation_loop_mode = Animation::LOOP_NONE;
+	bool animation_pingpong = false;
 
 	Ref<StandardMaterial3D> collider_mat;
 
@@ -151,9 +163,17 @@ class SceneImportSettings : public ConfirmationDialog {
 	void _update_view_gizmos();
 	void _update_camera();
 	void _select(Tree *p_from, String p_type, String p_id);
+	void _inspector_property_edited(const String &p_name);
+	void _reset_bone_transforms();
+	void _play_animation();
+	void _stop_current_animation();
+	void _reset_animation(const String &p_animation_name = "");
+	void _animation_slider_value_changed(double p_value);
+	void _animation_finished(const StringName &p_name);
 	void _material_tree_selected();
 	void _mesh_tree_selected();
 	void _scene_tree_selected();
+	void _cleanup();
 
 	void _viewport_input(const Ref<InputEvent> &p_input);
 


### PR DESCRIPTION
This QoL enhancement will add the option to preview animations in the import settings window (to preview animations without performing extra actions such placing the models to a scene):

![import_animation](https://user-images.githubusercontent.com/3036176/233839066-90851f65-2eb8-434a-b4af-0f87ed5ac05d.gif)

Attached demo project:
[TestModel.zip](https://github.com/godotengine/godot/files/11303814/TestModel.zip)

*Bugsquad edit:*
- Closes https://github.com/godotengine/godot-proposals/issues/6718.