### PR TITLE
Add missing `TabBar` signals to `TabContainer`

### DIFF
--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -184,6 +184,12 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="active_tab_rearranged">
+			<param index="0" name="idx_to" type="int" />
+			<description>
+				Emitted when the active tab is rearranged via mouse drag. See [member drag_to_rearrange_enabled].
+			</description>
+		</signal>
 		<signal name="pre_popup_pressed">
 			<description>
 				Emitted when the [TabContainer]'s [Popup] button is clicked. See [method set_popup] for details.
@@ -199,6 +205,18 @@
 			<param index="0" name="tab" type="int" />
 			<description>
 				Emitted when switching to another tab.
+			</description>
+		</signal>
+		<signal name="tab_clicked">
+			<param index="0" name="tab" type="int" />
+			<description>
+				Emitted when a tab is clicked, even if it is the current tab.
+			</description>
+		</signal>
+		<signal name="tab_hovered">
+			<param index="0" name="tab" type="int" />
+			<description>
+				Emitted when a tab is hovered by the mouse.
 			</description>
 		</signal>
 		<signal name="tab_selected">

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -453,6 +453,7 @@ void TabContainer::_drop_data_fw(const Point2 &p_point, const Variant &p_data, C
 
 			move_child(get_tab_control(tab_from_id), get_tab_control(hover_now)->get_index(false));
 			if (!is_tab_disabled(hover_now)) {
+				emit_signal(SNAME("active_tab_rearranged"), hover_now);
 				set_current_tab(hover_now);
 			}
 
@@ -495,6 +496,14 @@ void TabContainer::_drop_data_fw(const Point2 &p_point, const Variant &p_data, C
 			}
 		}
 	}
+}
+
+void TabContainer::_on_tab_clicked(int p_tab) {
+	emit_signal(SNAME("tab_clicked"), p_tab);
+}
+
+void TabContainer::_on_tab_hovered(int p_tab) {
+	emit_signal(SNAME("tab_hovered"), p_tab);
 }
 
 void TabContainer::_on_tab_changed(int p_tab) {
@@ -971,7 +980,10 @@ void TabContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_repaint"), &TabContainer::_repaint);
 	ClassDB::bind_method(D_METHOD("_on_theme_changed"), &TabContainer::_on_theme_changed);
 
+	ADD_SIGNAL(MethodInfo("active_tab_rearranged", PropertyInfo(Variant::INT, "idx_to")));
 	ADD_SIGNAL(MethodInfo("tab_changed", PropertyInfo(Variant::INT, "tab")));
+	ADD_SIGNAL(MethodInfo("tab_clicked", PropertyInfo(Variant::INT, "tab")));
+	ADD_SIGNAL(MethodInfo("tab_hovered", PropertyInfo(Variant::INT, "tab")));
 	ADD_SIGNAL(MethodInfo("tab_selected", PropertyInfo(Variant::INT, "tab")));
 	ADD_SIGNAL(MethodInfo("tab_button_pressed", PropertyInfo(Variant::INT, "tab")));
 	ADD_SIGNAL(MethodInfo("pre_popup_pressed"));
@@ -992,6 +1004,8 @@ TabContainer::TabContainer() {
 	add_child(tab_bar, false, INTERNAL_MODE_FRONT);
 	tab_bar->set_anchors_and_offsets_preset(Control::PRESET_TOP_WIDE);
 	tab_bar->connect("tab_changed", callable_mp(this, &TabContainer::_on_tab_changed));
+	tab_bar->connect("tab_clicked", callable_mp(this, &TabContainer::_on_tab_clicked));
+	tab_bar->connect("tab_hovered", callable_mp(this, &TabContainer::_on_tab_hovered));
 	tab_bar->connect("tab_selected", callable_mp(this, &TabContainer::_on_tab_selected));
 	tab_bar->connect("tab_button_pressed", callable_mp(this, &TabContainer::_on_tab_button_pressed));
 

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -90,6 +90,8 @@ class TabContainer : public Container {
 	void _update_margins();
 	void _on_mouse_exited();
 	void _on_tab_changed(int p_tab);
+	void _on_tab_clicked(int p_tab);
+	void _on_tab_hovered(int p_tab);
 	void _on_tab_selected(int p_tab);
 	void _on_tab_button_pressed(int p_tab);
 


### PR DESCRIPTION
Adds `active_tab_rearranged`, `tab_clicked` and `tab_hovered` signals to `TabContainer`, to *almost* achieve full parity with `TabBar`'s signals. If desired, I could also try to add `tab_rmb_clicked`. I don't think `tab_close_pressed` needs to be added, since we can't close tabs when using `TabContainer`.

Prior to this PR, there was no way of knowing whether a `TabContainer`'s tab has been re-arranged, since `tab_changed` no longer fires when a tab is re-arranged, like it used to in Godot 3.x. So I added `active_tab_rearranged` to `TabContainer`, to make it consistent with `TabBar`'s behavior, and I also took the opportunity to add the other two signals as well, in case anyone needs them.