### PR TITLE
Properly update nodepath with batch rename

### DIFF
--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -85,7 +85,7 @@ class SceneTreeEditor : public Control {
 	void _notification(int p_what);
 	void _selected_changed();
 	void _deselect_items();
-	void _rename_node(ObjectID p_node, const String &p_name);
+	void _rename_node(Node *p_node, const String &p_name);
 
 	void _cell_collapsed(Object *p_obj);
 

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -588,7 +588,7 @@ void RenameDialog::rename() {
 
 	if (!to_rename.is_empty()) {
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-		undo_redo->create_action(TTR("Batch Rename"));
+		undo_redo->create_action(TTR("Batch Rename"), UndoRedo::MERGE_DISABLE, root_node, true);
 
 		// Make sure to iterate reversed so that child nodes will find parents.
 		for (int i = to_rename.size() - 1; i >= 0; --i) {
@@ -600,9 +600,7 @@ void RenameDialog::rename() {
 				continue;
 			}
 
-			scene_tree_editor->emit_signal(SNAME("node_prerename"), n, new_name);
-			undo_redo->add_do_method(scene_tree_editor, "_rename_node", n->get_instance_id(), new_name);
-			undo_redo->add_undo_method(scene_tree_editor, "_rename_node", n->get_instance_id(), n->get_name());
+			scene_tree_editor->call("_rename_node", n, new_name);
 		}
 
 		undo_redo->commit_action();


### PR DESCRIPTION
Fixes #76070 
Fixes #76680 
partially fixes #76679 (gives a warning after rename with invalid character but does not print a warning on the batch rename dialog box)

This changes the way undo redo was handled so that `prerename` signal is triggered just before the actual rename and not all at once at the start. This is important as prerename needs previous rename to have done so that Nodepath are valid.

Edit : this goes a bit further than the original commit as it was lacking in some places. It places in `_rename_node` everything that was in `_renamed` and would also apply for batch rename. This includes : 

- checking for invalid character
- handling undo redo
- emiting `node_prerename`

Unfortunatly this need this other PR #76688 to be merged first (it was added as first commit here as it is needed)
