### PR TITLE
Fix typed array export

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3515,48 +3515,17 @@ void EditorPropertyNodePath::_set_read_only(bool p_read_only) {
 	clear->set_disabled(p_read_only);
 };
 
-String EditorPropertyNodePath::_get_meta_pointer_property() const {
-	ERR_FAIL_COND_V(!pointer_mode, String());
-	return SceneState::get_meta_pointer_property(get_edited_property());
-}
-
 Variant EditorPropertyNodePath::_get_cache_value(const StringName &p_prop, bool &r_valid) const {
 	if (p_prop == get_edited_property()) {
 		r_valid = true;
-		return const_cast<EditorPropertyNodePath *>(this)->get_edited_object()->get(pointer_mode ? StringName(_get_meta_pointer_property()) : get_edited_property(), &r_valid);
+		return const_cast<EditorPropertyNodePath *>(this)->get_edited_object()->get(get_edited_property(), &r_valid);
 	}
 	return Variant();
 }
 
-StringName EditorPropertyNodePath::_get_revert_property() const {
-	if (pointer_mode) {
-		return _get_meta_pointer_property();
-	} else {
-		return get_edited_property();
-	}
-}
-
 void EditorPropertyNodePath::_node_selected(const NodePath &p_path) {
 	NodePath path = p_path;
-	Node *base_node = nullptr;
-
-	if (!use_path_from_scene_root) {
-		base_node = Object::cast_to<Node>(get_edited_object());
-
-		if (!base_node) {
-			//try a base node within history
-			if (EditorNode::get_singleton()->get_editor_selection_history()->get_path_size() > 0) {
-				Object *base = ObjectDB::get_instance(EditorNode::get_singleton()->get_editor_selection_history()->get_path_object(0));
-				if (base) {
-					base_node = Object::cast_to<Node>(base);
-				}
-			}
-		}
-	}
-
-	if (!base_node && get_edited_object()->has_method("get_root_path")) {
-		base_node = Object::cast_to<Node>(get_edited_object()->call("get_root_path"));
-	}
+	Node *base_node = get_base_node();
 
 	if (!base_node && Object::cast_to<RefCounted>(get_edited_object())) {
 		Node *to_node = get_node(p_path);
@@ -3567,8 +3536,13 @@ void EditorPropertyNodePath::_node_selected(const NodePath &p_path) {
 	if (base_node) { // for AnimationTrackKeyEdit
 		path = base_node->get_path().rel_path_to(p_path);
 	}
-	if (pointer_mode && base_node) {
-		emit_changed(_get_meta_pointer_property(), path);
+
+	if (editing_node) {
+		if (!base_node) {
+			emit_changed(get_edited_property(), get_tree()->get_edited_scene_root()->get_node(path));
+		} else {
+			emit_changed(get_edited_property(), base_node->get_node(path));
+		}
 	} else {
 		emit_changed(get_edited_property(), path);
 	}
@@ -3587,11 +3561,7 @@ void EditorPropertyNodePath::_node_assign() {
 }
 
 void EditorPropertyNodePath::_node_clear() {
-	if (pointer_mode) {
-		emit_changed(_get_meta_pointer_property(), NodePath());
-	} else {
-		emit_changed(get_edited_property(), NodePath());
-	}
+	emit_changed(get_edited_property(), NodePath());
 	update_property();
 }
 
@@ -3638,9 +3608,20 @@ bool EditorPropertyNodePath::is_drop_valid(const Dictionary &p_drag_data) const 
 }
 
 void EditorPropertyNodePath::update_property() {
+	Node *base_node = get_base_node();
+
 	NodePath p;
-	if (pointer_mode) {
-		p = get_edited_object()->get(_get_meta_pointer_property());
+	Variant val = get_edited_object()->get(get_edited_property());
+	Node *n = Object::cast_to<Node>(val);
+	if (n) {
+		if (!n->is_inside_tree()) {
+			return;
+		}
+		if (base_node) {
+			p = base_node->get_path_to(n);
+		} else {
+			p = get_tree()->get_edited_scene_root()->get_path_to(n);
+		}
 	} else {
 		p = get_edited_object()->get(get_edited_property());
 	}
@@ -3653,15 +3634,6 @@ void EditorPropertyNodePath::update_property() {
 		return;
 	}
 	assign->set_flat(true);
-
-	Node *base_node = nullptr;
-	if (base_hint != NodePath()) {
-		if (get_tree()->get_root()->has_node(base_hint)) {
-			base_node = get_tree()->get_root()->get_node(base_hint);
-		}
-	} else {
-		base_node = Object::cast_to<Node>(get_edited_object());
-	}
 
 	if (!base_node || !base_node->has_node(p)) {
 		assign->set_icon(Ref<Texture2D>());
@@ -3682,10 +3654,10 @@ void EditorPropertyNodePath::update_property() {
 	assign->set_icon(EditorNode::get_singleton()->get_object_icon(target_node, "Node"));
 }
 
-void EditorPropertyNodePath::setup(const NodePath &p_base_hint, Vector<StringName> p_valid_types, bool p_use_path_from_scene_root, bool p_pointer_mode) {
-	pointer_mode = p_pointer_mode;
+void EditorPropertyNodePath::setup(const NodePath &p_base_hint, Vector<StringName> p_valid_types, bool p_use_path_from_scene_root, bool p_editing_node) {
 	base_hint = p_base_hint;
 	valid_types = p_valid_types;
+	editing_node = p_editing_node;
 	use_path_from_scene_root = p_use_path_from_scene_root;
 }
 
@@ -3700,6 +3672,35 @@ void EditorPropertyNodePath::_notification(int p_what) {
 }
 
 void EditorPropertyNodePath::_bind_methods() {
+}
+Node *EditorPropertyNodePath::get_base_node() {
+	if (!base_hint.is_empty() && get_tree()->get_root()->has_node(base_hint)) {
+		return get_tree()->get_root()->get_node(base_hint);
+	}
+
+	Node *base_node = Object::cast_to<Node>(get_edited_object());
+
+	if (!base_node) {
+		base_node = Object::cast_to<Node>(InspectorDock::get_inspector_singleton()->get_edited_object());
+	}
+	if (!base_node) {
+		// Try a base node within history.
+		if (EditorNode::get_singleton()->get_editor_selection_history()->get_path_size() > 0) {
+			Object *base = ObjectDB::get_instance(EditorNode::get_singleton()->get_editor_selection_history()->get_path_object(0));
+			if (base) {
+				base_node = Object::cast_to<Node>(base);
+			}
+		}
+	}
+	if (use_path_from_scene_root) {
+		if (get_edited_object()->has_method("get_root_path")) {
+			base_node = Object::cast_to<Node>(get_edited_object()->call("get_root_path"));
+		} else {
+			base_node = get_tree()->get_edited_scene_root();
+		}
+	}
+
+	return base_node;
 }
 
 EditorPropertyNodePath::EditorPropertyNodePath() {

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -781,20 +781,19 @@ class EditorPropertyNodePath : public EditorProperty {
 	SceneTreeDialog *scene_tree = nullptr;
 	NodePath base_hint;
 	bool use_path_from_scene_root = false;
-	bool pointer_mode = false;
+	bool editing_node = false;
 
 	Vector<StringName> valid_types;
 	void _node_selected(const NodePath &p_path);
 	void _node_assign();
 	void _node_clear();
+	Node *get_base_node();
 
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 	bool is_drop_valid(const Dictionary &p_drag_data) const;
 
-	String _get_meta_pointer_property() const;
 	virtual Variant _get_cache_value(const StringName &p_prop, bool &r_valid) const override;
-	virtual StringName _get_revert_property() const override;
 
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
@@ -803,7 +802,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(const NodePath &p_base_hint, Vector<StringName> p_valid_types, bool p_use_path_from_scene_root = true, bool p_pointer_mode = false);
+	void setup(const NodePath &p_base_hint, Vector<StringName> p_valid_types, bool p_use_path_from_scene_root = true, bool p_editing_node = false);
 	EditorPropertyNodePath();
 };
 

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -43,7 +43,7 @@
 bool EditorPropertyArrayObject::_set(const StringName &p_name, const Variant &p_value) {
 	String name = p_name;
 
-	if (!name.begins_with("indices") && !name.begins_with(PackedScene::META_POINTER_PROPERTY_BASE + "indices")) {
+	if (!name.begins_with("indices")) {
 		return false;
 	}
 
@@ -61,7 +61,7 @@ bool EditorPropertyArrayObject::_set(const StringName &p_name, const Variant &p_
 bool EditorPropertyArrayObject::_get(const StringName &p_name, Variant &r_ret) const {
 	String name = p_name;
 
-	if (!name.begins_with("indices") && !name.begins_with(PackedScene::META_POINTER_PROPERTY_BASE + "indices")) {
+	if (!name.begins_with("indices")) {
 		return false;
 	}
 
@@ -192,7 +192,7 @@ void EditorPropertyArray::initialize_array(Variant &p_array) {
 }
 
 void EditorPropertyArray::_property_changed(const String &p_property, Variant p_value, const String &p_name, bool p_changing) {
-	if (!p_property.begins_with("indices") && !p_property.begins_with(PackedScene::META_POINTER_PROPERTY_BASE + "indices")) {
+	if (!p_property.begins_with("indices")) {
 		return;
 	}
 
@@ -203,18 +203,7 @@ void EditorPropertyArray::_property_changed(const String &p_property, Variant p_
 		index = p_property.get_slice("/", 1).to_int();
 	}
 
-	Variant array;
-	const Variant &original_array = object->get_array();
-
-	if (original_array.get_type() == Variant::ARRAY) {
-		// Needed to preserve type of TypedArrays in meta pointer properties.
-		Array temp;
-		temp.assign(original_array.duplicate());
-		array = temp;
-	} else {
-		array = original_array.duplicate();
-	}
-
+	Variant array = object->get_array().duplicate();
 	array.set(index, p_value);
 	object->set_array(array);
 	emit_changed(get_edited_property(), array, "", true);

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -221,8 +221,6 @@ protected:
 	virtual void reset_state() override;
 
 public:
-	static const String META_POINTER_PROPERTY_BASE;
-
 	enum GenEditState {
 		GEN_EDIT_STATE_DISABLED,
 		GEN_EDIT_STATE_INSTANCE,


### PR DESCRIPTION
Fixes my mess from #76114
Fixes #75981 (as a side effect, if this PR is not accepted i could easily extract the fix from it)
Fixes also the bug i found and reported here : https://github.com/godotengine/godot/pull/76378#issuecomment-1519184710
Edit : those two bugs are related to the one just above and should be fixed with this PR #74141 #74050

This PR remove the hack with pointer and replace it with a proper handling from `EditorPropertyNodePath` of both `NodePath` and `Node`. Also needed to revise a bit the saving and loading of scene to handle properly the change.

PS: This is not polished and still needs testing

*Bugsquad edit:* Fixes #76642 Fixes #74141 Fixes #74050