### PR TITLE
[macOS] Bump min. version to 10.13, and remove deprecated code.

### DIFF
--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -118,10 +118,10 @@ def configure(env: "Environment"):
         env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.0"])
         env.Append(LINKFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.0"])
     elif env["arch"] == "x86_64":
-        print("Building for macOS 10.12+.")
-        env.Append(ASFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.12"])
-        env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.12"])
-        env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.12"])
+        print("Building for macOS 10.13+.")
+        env.Append(ASFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
+        env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
+        env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
 
     env.Append(CCFLAGS=["-fobjc-arc"])
 

--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -115,13 +115,7 @@
 	self.layerContentsRedrawPolicy = NSViewLayerContentsRedrawDuringViewResize;
 	self.layerContentsPlacement = NSViewLayerContentsPlacementTopLeft;
 
-	if (@available(macOS 10.13, *)) {
-		[self registerForDraggedTypes:[NSArray arrayWithObject:NSPasteboardTypeFileURL]];
-#if !defined(__aarch64__) // Do not build deprectead 10.13 code on ARM.
-	} else {
-		[self registerForDraggedTypes:[NSArray arrayWithObject:NSFilenamesPboardType]];
-#endif
-	}
+	[self registerForDraggedTypes:[NSArray arrayWithObject:NSPasteboardTypeFileURL]];
 	marked_text = [[NSMutableAttributedString alloc] init];
 	return self;
 }
@@ -321,20 +315,11 @@
 		Vector<String> files;
 		NSPasteboard *pboard = [sender draggingPasteboard];
 
-		if (@available(macOS 10.13, *)) {
-			NSArray *items = pboard.pasteboardItems;
-			for (NSPasteboardItem *item in items) {
-				NSString *url = [item stringForType:NSPasteboardTypeFileURL];
-				NSString *file = [NSURL URLWithString:url].path;
-				files.push_back(String::utf8([file UTF8String]));
-			}
-#if !defined(__aarch64__) // Do not build deprectead 10.13 code on ARM.
-		} else {
-			NSArray *filenames = [pboard propertyListForType:NSFilenamesPboardType];
-			for (NSString *file in filenames) {
-				files.push_back(String::utf8([file UTF8String]));
-			}
-#endif
+		NSArray *items = pboard.pasteboardItems;
+		for (NSPasteboardItem *item in items) {
+			NSString *url = [item stringForType:NSPasteboardTypeFileURL];
+			NSString *file = [NSURL URLWithString:url].path;
+			files.push_back(String::utf8([file UTF8String]));
 		}
 
 		Variant v = files;


### PR DESCRIPTION
Fixes https://github.com/godotengine/build-containers/issues/124

Alternative to #76395.