### PR TITLE
Optimize HashMap size

### DIFF
--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -67,9 +67,9 @@ template <class TKey, class TValue,
 		class Allocator = DefaultTypedAllocator<HashMapElement<TKey, TValue>>>
 class HashMap {
 public:
-	const uint32_t MIN_CAPACITY_INDEX = 2; // Use a prime.
-	const float MAX_OCCUPANCY = 0.75;
-	const uint32_t EMPTY_HASH = 0;
+	static constexpr uint32_t MIN_CAPACITY_INDEX = 2; // Use a prime.
+	static constexpr float MAX_OCCUPANCY = 0.75;
+	static constexpr uint32_t EMPTY_HASH = 0;
 
 private:
 	Allocator element_alloc;


### PR DESCRIPTION
This PR is less exciting than the clickbait title, looks like a few const variables were accidentally left as normal member variables instead of static variables. This PR makes them `static constexpr` (similar to HashSet). By doing that, default HashMap size goes from 56 bytes to 48 bytes. We could further reduce it to 40 bytes by making `element_alloc` and its methods static too, although that would limit the customization of the HashMap memory allocations (although I don't think that feature is used currently). Or we could maybe use `[[no_unique_address]]`, but it's a C++20 feature. Has a nice cascading effect as it also reduces the size of all other objects that have HashMaps which in turn makes more stuff fit in CPU caches which is much more limited than normal memory.