### PR TITLE
Fix wrong file name on function call error

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -3572,8 +3572,9 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		//error
 		// function, file, line, error, explanation
 		String err_file;
-		if (p_instance && ObjectDB::get_instance(p_instance->owner_id) != nullptr && p_instance->script->is_valid() && !p_instance->script->path.is_empty()) {
-			err_file = p_instance->script->path;
+		bool instance_valid_with_script = p_instance && ObjectDB::get_instance(p_instance->owner_id) != nullptr && p_instance->script->is_valid();
+		if (instance_valid_with_script && !get_script()->path.is_empty()) {
+			err_file = get_script()->path;
 		} else if (script) {
 			err_file = script->path;
 		}
@@ -3581,7 +3582,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			err_file = "<built-in>";
 		}
 		String err_func = name;
-		if (p_instance && ObjectDB::get_instance(p_instance->owner_id) != nullptr && p_instance->script->is_valid() && !p_instance->script->name.is_empty()) {
+		if (instance_valid_with_script && !p_instance->script->name.is_empty()) {
 			err_func = p_instance->script->name + "." + err_func;
 		}
 		int err_line = line;


### PR DESCRIPTION
Fixes #19894. The script of the instance where the error occured is being printed out and it doesn't take into account inheritence. Apparently the path of the script of the GDScriptFunction itself should be printed instead which gives the correct script path where the error is.